### PR TITLE
feat(querier): add wildcard tenant query support

### DIFF
--- a/docs/sources/configure/wildcard-tenant-queries.md
+++ b/docs/sources/configure/wildcard-tenant-queries.md
@@ -1,0 +1,202 @@
+# Wildcard Tenant Queries
+
+{{< docs/experimental product="Loki" >}}
+
+Wildcard tenant queries allow you to query logs across all tenants in a multi-tenant Loki deployment without explicitly listing each tenant ID. This is particularly useful for administrators and monitoring tools that need visibility across the entire system.
+
+## Overview
+
+By default, Loki requires you to specify tenant IDs explicitly in the `X-Scope-OrgID` header. For multi-tenant queries, you can use pipe-separated values like `tenant1|tenant2|tenant3`. However, this becomes unwieldy when you have many tenants or when tenants are frequently added or removed.
+
+Wildcard tenant queries introduce support for the special `*` character, which automatically expands to include all known tenants discovered from Loki's storage.
+
+## Requirements
+
+- Multi-tenant mode must be enabled (`auth_enabled: true`)
+- Multi-tenant queries must be enabled (`querier.multi_tenant_queries_enabled: true`)
+- Wildcard tenant queries must be enabled (`querier.wildcard_tenant_queries_enabled: true`)
+
+## Configuration
+
+Add the following to your Loki configuration:
+
+```yaml
+querier:
+  # Required: Enable multi-tenant queries
+  multi_tenant_queries_enabled: true
+  
+  # Enable wildcard tenant queries (experimental)
+  wildcard_tenant_queries_enabled: true
+  
+  # How long to cache the list of discovered tenants (default: 5m)
+  wildcard_tenant_cache_ttl: 5m
+```
+
+Or via command-line flags:
+
+```bash
+-querier.multi-tenant-queries-enabled=true
+-querier.wildcard-tenant-queries-enabled=true
+-querier.wildcard-tenant-cache-ttl=5m
+```
+
+## Usage
+
+### Query All Tenants
+
+To query all tenants, set the `X-Scope-OrgID` header to `*`:
+
+```bash
+curl -H "X-Scope-OrgID: *" \
+  "http://loki:3100/loki/api/v1/query_range" \
+  --data-urlencode 'query={job=~".+"}'
+```
+
+### Query All Tenants Except Specific Ones
+
+You can exclude specific tenants using the `!` prefix:
+
+```bash
+# Query all tenants except "internal" and "test"
+curl -H "X-Scope-OrgID: *|!internal|!test" \
+  "http://loki:3100/loki/api/v1/query_range" \
+  --data-urlencode 'query={job=~".+"}'
+```
+
+### Grafana Data Source Configuration
+
+To configure a Grafana data source for wildcard tenant queries:
+
+1. Add a new Loki data source in Grafana
+2. In the HTTP Headers section, add:
+   - Header: `X-Scope-OrgID`
+   - Value: `*` (or `*|!tenant1|!tenant2` for exclusions)
+
+Example using Grafana provisioning:
+
+```yaml
+apiVersion: 1
+datasources:
+  - name: Loki-Admin
+    type: loki
+    access: proxy
+    url: http://loki-gateway:3100
+    jsonData:
+      httpHeaderName1: 'X-Scope-OrgID'
+    secureJsonData:
+      httpHeaderValue1: '*'
+```
+
+## How It Works
+
+When a query is received with `*` in the `X-Scope-OrgID` header:
+
+1. Loki's querier detects the wildcard character
+2. It queries the index storage to discover all tenant IDs that have written data
+3. Results are cached for the duration specified by `wildcard_tenant_cache_ttl`
+4. Any exclusions (prefixed with `!`) are removed from the list
+5. The query is executed across all remaining tenants
+6. Results are merged with a `__tenant_id__` label added to each log entry
+
+## Performance Considerations
+
+### Tenant Discovery Caching
+
+Discovering tenants requires listing files from object storage, which can be expensive. The results are cached for `wildcard_tenant_cache_ttl` (default: 5 minutes). 
+
+**Trade-offs:**
+- Shorter TTL: New tenants appear faster, but more storage operations
+- Longer TTL: Fewer storage operations, but new tenants take longer to appear
+
+### Query Performance
+
+Wildcard queries fan out to all tenants in parallel. Keep in mind:
+
+- Queries touching many tenants will use more resources
+- Consider using label selectors to reduce the amount of data scanned
+- Monitor query latency and adjust limits as needed
+
+### Resource Limits
+
+Wildcard queries are subject to the same limits as regular multi-tenant queries:
+
+- `limits_config.max_query_parallelism`
+- `limits_config.max_query_series`
+- `limits_config.query_timeout`
+
+Consider adjusting these limits if you have many tenants.
+
+## API Endpoints Supported
+
+Wildcard tenant queries work with all query endpoints:
+
+- `/loki/api/v1/query` - Instant queries
+- `/loki/api/v1/query_range` - Range queries
+- `/loki/api/v1/labels` - Label names
+- `/loki/api/v1/label/{name}/values` - Label values
+- `/loki/api/v1/series` - Series metadata
+- `/loki/api/v1/index/stats` - Index statistics
+- `/loki/api/v1/index/volume` - Log volume
+
+## Tenant Label
+
+When querying multiple tenants (including wildcard queries), Loki automatically adds a `__tenant_id__` label to each log entry. This allows you to:
+
+- Filter results by tenant: `{job="app"} | __tenant_id__="tenant1"`
+- Aggregate by tenant in LogQL: `sum by(__tenant_id__) (rate({job="app"}[5m]))`
+- Display tenant information in Grafana dashboards
+
+## Troubleshooting
+
+### "wildcard tenant queries are not enabled"
+
+Ensure both configuration options are set:
+
+```yaml
+querier:
+  multi_tenant_queries_enabled: true
+  wildcard_tenant_queries_enabled: true
+```
+
+### "wildcard query resolved to zero tenants"
+
+This occurs when:
+- No tenants have written data yet
+- All discovered tenants were excluded
+- There's an issue with the storage backend
+
+Check the querier logs for more details.
+
+### "tenant exclusion (!) syntax requires wildcard (*)"
+
+You cannot use exclusion syntax without the wildcard:
+
+```bash
+# Invalid - exclusion without wildcard
+X-Scope-OrgID: tenant1|!tenant2
+
+# Valid - exclusion with wildcard  
+X-Scope-OrgID: *|!tenant2
+```
+
+### Slow Queries
+
+If wildcard queries are slow:
+
+1. Check the number of tenants discovered (logged at INFO level)
+2. Increase `wildcard_tenant_cache_ttl` to reduce storage operations
+3. Use more specific label selectors to reduce data scanned
+4. Consider excluding inactive tenants
+
+## Security Considerations
+
+- Wildcard queries bypass tenant isolation by design
+- Only grant wildcard access to trusted administrators
+- Consider using RBAC in Grafana to control who can use admin data sources
+- Audit log access when using wildcard queries in production
+
+## Known Limitations
+
+- Tenant discovery relies on index storage - tenants with only recent (not yet indexed) data may not appear immediately
+- The cache is per-querier instance - in a distributed setup, different queriers may have slightly different tenant lists during cache refresh
+- Detected fields endpoint returns limited results for multi-tenant queries

--- a/integration/wildcard_tenant_queries_test.go
+++ b/integration/wildcard_tenant_queries_test.go
@@ -1,0 +1,200 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/integration/client"
+	"github.com/grafana/loki/v3/integration/cluster"
+)
+
+// TestWildcardTenantQuery tests wildcard tenant query functionality.
+// This test requires wildcard_tenant_queries_enabled and multi_tenant_queries_enabled
+// to be true in the querier config.
+func TestWildcardTenantQuery(t *testing.T) {
+	// Wildcard tenant queries are an experimental feature
+
+	clu := cluster.New(nil)
+	defer func() {
+		assert.NoError(t, clu.Cleanup())
+	}()
+
+	var (
+		// Start Loki with multi-tenant and wildcard queries enabled
+		tAll = clu.AddComponent(
+			"all",
+			"-target=all",
+			"-querier.multi-tenant-queries-enabled=true",
+			"-querier.wildcard-tenant-queries-enabled=true",
+			"-querier.wildcard-tenant-cache-ttl=10s",
+		)
+	)
+
+	require.NoError(t, clu.Run())
+
+	// Create clients for different tenants
+	cliTenant1 := client.New("tenant1", "", tAll.HTTPURL())
+	cliTenant2 := client.New("tenant2", "", tAll.HTTPURL())
+	cliTenant3 := client.New("tenant3", "", tAll.HTTPURL())
+
+	// Wildcard client - queries all tenants
+	cliWildcard := client.New("*", "", tAll.HTTPURL())
+
+	// Wildcard with exclusion - all tenants except tenant2
+	cliWildcardExclude := client.New("*|!tenant2", "", tAll.HTTPURL())
+
+	// Ingest log lines for each tenant
+	now := time.Now()
+	require.NoError(t, cliTenant1.PushLogLine("log from tenant1", now.Add(-45*time.Minute), nil, map[string]string{"job": "app1", "level": "info"}))
+	require.NoError(t, cliTenant2.PushLogLine("log from tenant2", now.Add(-44*time.Minute), nil, map[string]string{"job": "app2", "level": "error"}))
+	require.NoError(t, cliTenant3.PushLogLine("log from tenant3", now.Add(-43*time.Minute), nil, map[string]string{"job": "app3", "level": "warn"}))
+
+	// Wait for data to be ingested
+	time.Sleep(2 * time.Second)
+
+	// Test 1: Each tenant should only see their own logs
+	t.Run("tenant isolation", func(t *testing.T) {
+		require.ElementsMatch(t, queryLines(t, cliTenant1, `{job=~".+"}`), []string{"log from tenant1"})
+		require.ElementsMatch(t, queryLines(t, cliTenant2, `{job=~".+"}`), []string{"log from tenant2"})
+		require.ElementsMatch(t, queryLines(t, cliTenant3, `{job=~".+"}`), []string{"log from tenant3"})
+	})
+
+	// Test 2: Wildcard query should return logs from all tenants
+	t.Run("wildcard query all tenants", func(t *testing.T) {
+		lines := queryLines(t, cliWildcard, `{job=~".+"}`)
+		require.ElementsMatch(t, lines, []string{
+			"log from tenant1",
+			"log from tenant2",
+			"log from tenant3",
+		})
+	})
+
+	// Test 3: Wildcard with exclusion should exclude specified tenants
+	t.Run("wildcard with exclusion", func(t *testing.T) {
+		lines := queryLines(t, cliWildcardExclude, `{job=~".+"}`)
+		require.ElementsMatch(t, lines, []string{
+			"log from tenant1",
+			"log from tenant3",
+		})
+		// Verify tenant2's log is not included
+		require.NotContains(t, lines, "log from tenant2")
+	})
+
+	// Test 4: Wildcard with label filter
+	t.Run("wildcard with label filter", func(t *testing.T) {
+		lines := queryLines(t, cliWildcard, `{level="error"}`)
+		require.ElementsMatch(t, lines, []string{"log from tenant2"})
+	})
+
+	// Test 5: Wildcard with multiple exclusions
+	t.Run("wildcard with multiple exclusions", func(t *testing.T) {
+		cliMultiExclude := client.New("*|!tenant1|!tenant2", "", tAll.HTTPURL())
+		lines := queryLines(t, cliMultiExclude, `{job=~".+"}`)
+		require.ElementsMatch(t, lines, []string{"log from tenant3"})
+	})
+
+	// Test 6: Verify __tenant_id__ label is added
+	t.Run("tenant label added", func(t *testing.T) {
+		resp, err := cliWildcard.RunRangeQueryWithStartEnd(
+			context.Background(),
+			`{job=~".+"}`,
+			now.Add(-1*time.Hour),
+			now,
+		)
+		require.NoError(t, err)
+
+		tenantLabels := make(map[string]bool)
+		for _, stream := range resp.Data.Stream {
+			if tenantID, ok := stream.Stream["__tenant_id__"]; ok {
+				tenantLabels[tenantID] = true
+			}
+		}
+
+		require.True(t, tenantLabels["tenant1"], "should have __tenant_id__=tenant1")
+		require.True(t, tenantLabels["tenant2"], "should have __tenant_id__=tenant2")
+		require.True(t, tenantLabels["tenant3"], "should have __tenant_id__=tenant3")
+	})
+}
+
+// TestWildcardTenantLabelQuery tests that labels endpoint works with wildcard
+func TestWildcardTenantLabelQuery(t *testing.T) {
+	// Wildcard tenant queries are an experimental feature
+
+	clu := cluster.New(nil)
+	defer func() {
+		assert.NoError(t, clu.Cleanup())
+	}()
+
+	var (
+		tAll = clu.AddComponent(
+			"all",
+			"-target=all",
+			"-querier.multi-tenant-queries-enabled=true",
+			"-querier.wildcard-tenant-queries-enabled=true",
+		)
+	)
+
+	require.NoError(t, clu.Run())
+
+	// Create and push data for tenants
+	cliTenant1 := client.New("tenant1", "", tAll.HTTPURL())
+	cliTenant2 := client.New("tenant2", "", tAll.HTTPURL())
+
+	now := time.Now()
+	require.NoError(t, cliTenant1.PushLogLine("line1", now.Add(-30*time.Minute), nil, map[string]string{"app": "frontend", "env": "prod"}))
+	require.NoError(t, cliTenant2.PushLogLine("line2", now.Add(-30*time.Minute), nil, map[string]string{"app": "backend", "env": "staging"}))
+
+	time.Sleep(2 * time.Second)
+
+	// Query labels with wildcard
+	cliWildcard := client.New("*", "", tAll.HTTPURL())
+
+	t.Run("label names include tenant label", func(t *testing.T) {
+		labels, err := cliWildcard.LabelNames(context.Background())
+		require.NoError(t, err)
+		require.Contains(t, labels, "__tenant_id__")
+		require.Contains(t, labels, "app")
+		require.Contains(t, labels, "env")
+	})
+
+	t.Run("label values for app include all tenants", func(t *testing.T) {
+		values, err := cliWildcard.LabelValues(context.Background(), "app")
+		require.NoError(t, err)
+		require.ElementsMatch(t, values, []string{"frontend", "backend"})
+	})
+
+	t.Run("label values for tenant returns all tenants", func(t *testing.T) {
+		values, err := cliWildcard.LabelValues(context.Background(), "__tenant_id__")
+		require.NoError(t, err)
+		require.Contains(t, values, "tenant1")
+		require.Contains(t, values, "tenant2")
+	})
+}
+
+// queryLines is a helper that extracts log lines from a query response
+func queryLines(t *testing.T, cli *client.Client, query string) []string {
+	t.Helper()
+
+	now := time.Now()
+	resp, err := cli.RunRangeQueryWithStartEnd(
+		context.Background(),
+		query,
+		now.Add(-1*time.Hour),
+		now,
+	)
+	require.NoError(t, err)
+
+	var lines []string
+	for _, stream := range resp.Data.Stream {
+		for _, val := range stream.Values {
+			lines = append(lines, val[1])
+		}
+	}
+	return lines
+}

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -88,6 +88,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/boltdb"
+	shipperstorage "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/storage"
 	boltdbcompactor "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/boltdb/compactor"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
 	"github.com/grafana/loki/v3/pkg/storage/types"
@@ -567,7 +568,34 @@ func (t *Loki) initQuerier() (services.Service, error) {
 	}
 
 	if t.Cfg.Querier.MultiTenantQueriesEnabled {
-		t.Querier = querier.NewMultiTenantQuerier(t.Querier, util_log.Logger)
+		multiTenantQuerier := querier.NewMultiTenantQuerier(t.Querier, util_log.Logger)
+		t.Querier = multiTenantQuerier
+
+		// If wildcard tenant queries are enabled, wrap with WildcardTenantQuerier
+		if t.Cfg.Querier.WildcardTenantQueriesEnabled {
+			// Create index storage client for tenant discovery
+			// Use the active period config to determine the object store and index prefix
+			periodConfigs := t.Cfg.SchemaConfig.Configs
+			if len(periodConfigs) > 0 {
+				activePeriodIdx := config.ActivePeriodConfig(periodConfigs)
+				activePeriod := periodConfigs[activePeriodIdx]
+
+				// Only enable wildcard queries for object storage index types (TSDB, boltdb-shipper)
+				if config.IsObjectStorageIndex(activePeriod.IndexType) {
+					objectClient, err := storage.NewObjectClient(activePeriod.ObjectType, "querier-tenant-discovery", t.Cfg.StorageConfig, t.ClientMetrics)
+					if err != nil {
+						level.Warn(logger).Log("msg", "failed to create object client for tenant discovery, wildcard queries disabled", "err", err)
+					} else {
+						indexStorageClient := shipperstorage.NewIndexStorageClient(objectClient, activePeriod.IndexTables.PathPrefix)
+						tenantDiscovery := querier.NewStorageTenantDiscovery(indexStorageClient, logger, t.Cfg.Querier.WildcardTenantCacheTTL)
+						t.Querier = querier.NewWildcardTenantQuerier(multiTenantQuerier, tenantDiscovery, logger)
+						level.Info(logger).Log("msg", "wildcard tenant queries enabled", "cache_ttl", t.Cfg.Querier.WildcardTenantCacheTTL)
+					}
+				} else {
+					level.Warn(logger).Log("msg", "wildcard tenant queries require object storage index type (tsdb or boltdb-shipper)", "index_type", activePeriod.IndexType)
+				}
+			}
+		}
 	}
 
 	querierWorkerServiceConfig := querier.WorkerServiceConfig{

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -62,6 +62,14 @@ type Config struct {
 	PerRequestLimitsEnabled   bool             `yaml:"per_request_limits_enabled"`
 	QueryPartitionIngesters   bool             `yaml:"query_partition_ingesters" category:"experimental"`
 
+	// WildcardTenantQueriesEnabled enables wildcard tenant queries using "*" in X-Scope-OrgID.
+	// Requires MultiTenantQueriesEnabled to be true.
+	WildcardTenantQueriesEnabled bool `yaml:"wildcard_tenant_queries_enabled" category:"experimental"`
+
+	// WildcardTenantCacheTTL is how long to cache the list of discovered tenants for wildcard queries.
+	// Default is 5 minutes.
+	WildcardTenantCacheTTL time.Duration `yaml:"wildcard_tenant_cache_ttl"`
+
 	IngesterQueryStoreMaxLookback time.Duration `yaml:"-"`
 	QueryPatternIngestersWithin   time.Duration `yaml:"-"`
 }
@@ -82,12 +90,17 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&cfg.MultiTenantQueriesEnabled, prefix+"multi-tenant-queries-enabled", false, "When true, allow queries to span multiple tenants.")
 	f.BoolVar(&cfg.PerRequestLimitsEnabled, prefix+"per-request-limits-enabled", false, "When true, querier limits sent via a header are enforced.")
 	f.BoolVar(&cfg.QueryPartitionIngesters, prefix+"query-partition-ingesters", false, "When true, querier directs ingester queries to the partition-ingesters instead of the normal ingesters.")
+	f.BoolVar(&cfg.WildcardTenantQueriesEnabled, prefix+"wildcard-tenant-queries-enabled", false, "When true, allow wildcard (*) in X-Scope-OrgID to query all tenants. Requires multi-tenant-queries-enabled to be true.")
+	f.DurationVar(&cfg.WildcardTenantCacheTTL, prefix+"wildcard-tenant-cache-ttl", 5*time.Minute, "How long to cache the list of discovered tenants for wildcard queries.")
 }
 
 // Validate validates the config.
 func (cfg *Config) Validate() error {
 	if cfg.QueryStoreOnly && cfg.QueryIngesterOnly {
 		return errors.New("querier.query_store_only and querier.query_ingester_only cannot both be true")
+	}
+	if cfg.WildcardTenantQueriesEnabled && !cfg.MultiTenantQueriesEnabled {
+		return errors.New("querier.wildcard_tenant_queries_enabled requires querier.multi_tenant_queries_enabled to be true")
 	}
 	return nil
 }

--- a/pkg/querier/tenant_discovery.go
+++ b/pkg/querier/tenant_discovery.go
@@ -1,0 +1,183 @@
+package querier
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
+
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/storage"
+)
+
+var (
+	// ErrWildcardNotEnabled is returned when wildcard tenant queries are attempted
+	// but the feature is not enabled
+	ErrWildcardNotEnabled = errors.New("wildcard tenant queries are not enabled")
+)
+
+const (
+	// WildcardTenantID is the special tenant ID that represents all tenants
+	WildcardTenantID = "*"
+
+	// DefaultTenantCacheTTL is the default time-to-live for the tenant cache
+	DefaultTenantCacheTTL = 5 * time.Minute
+)
+
+// TenantDiscovery provides methods to discover all available tenants
+// from storage. This is used to support wildcard tenant queries.
+type TenantDiscovery interface {
+	// GetAllTenants returns all known tenant IDs from storage.
+	// This operation may be expensive and should be cached.
+	GetAllTenants(ctx context.Context) ([]string, error)
+
+	// IsWildcard returns true if the given orgID represents a wildcard query
+	IsWildcard(orgID string) bool
+}
+
+// StorageTenantDiscovery discovers tenants by listing them from the index storage.
+// It caches the results to avoid expensive storage operations on every query.
+type StorageTenantDiscovery struct {
+	indexClient storage.Client
+	logger      log.Logger
+	cacheTTL    time.Duration
+
+	mu            sync.RWMutex
+	cachedTenants []string
+	cacheTime     time.Time
+}
+
+// TenantDiscoveryConfig holds configuration for tenant discovery
+type TenantDiscoveryConfig struct {
+	// CacheTTL is how long to cache the list of tenants
+	CacheTTL time.Duration `yaml:"cache_ttl"`
+
+	// Enabled controls whether wildcard tenant queries are allowed
+	Enabled bool `yaml:"enabled"`
+}
+
+// NewStorageTenantDiscovery creates a new StorageTenantDiscovery instance
+func NewStorageTenantDiscovery(indexClient storage.Client, logger log.Logger, cacheTTL time.Duration) *StorageTenantDiscovery {
+	if cacheTTL <= 0 {
+		cacheTTL = DefaultTenantCacheTTL
+	}
+
+	return &StorageTenantDiscovery{
+		indexClient: indexClient,
+		logger:      logger,
+		cacheTTL:    cacheTTL,
+	}
+}
+
+// IsWildcard returns true if the orgID is the wildcard character
+func (s *StorageTenantDiscovery) IsWildcard(orgID string) bool {
+	return orgID == WildcardTenantID
+}
+
+// GetAllTenants returns all known tenant IDs from storage.
+// Results are cached for cacheTTL duration to avoid expensive storage operations.
+func (s *StorageTenantDiscovery) GetAllTenants(ctx context.Context) ([]string, error) {
+	// Check cache first
+	s.mu.RLock()
+	if s.cachedTenants != nil && time.Since(s.cacheTime) < s.cacheTTL {
+		tenants := make([]string, len(s.cachedTenants))
+		copy(tenants, s.cachedTenants)
+		s.mu.RUnlock()
+		return tenants, nil
+	}
+	s.mu.RUnlock()
+
+	// Cache miss or expired, fetch from storage
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if s.cachedTenants != nil && time.Since(s.cacheTime) < s.cacheTTL {
+		tenants := make([]string, len(s.cachedTenants))
+		copy(tenants, s.cachedTenants)
+		return tenants, nil
+	}
+
+	tenants, err := s.discoverTenants(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	s.cachedTenants = tenants
+	s.cacheTime = time.Now()
+
+	// Return a copy to prevent modification
+	result := make([]string, len(tenants))
+	copy(result, tenants)
+
+	level.Info(s.logger).Log(
+		"msg", "discovered tenants for wildcard query",
+		"count", len(tenants),
+	)
+
+	return result, nil
+}
+
+// discoverTenants fetches all tenant IDs from the index storage
+func (s *StorageTenantDiscovery) discoverTenants(ctx context.Context) ([]string, error) {
+	tables, err := s.indexClient.ListTables(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	tenantSet := make(map[string]struct{})
+
+	for _, table := range tables {
+		_, tenants, err := s.indexClient.ListFiles(ctx, table, true)
+		if err != nil {
+			level.Warn(s.logger).Log(
+				"msg", "failed to list tenants for table",
+				"table", table,
+				"err", err,
+			)
+			continue
+		}
+
+		for _, tenant := range tenants {
+			// Skip empty tenant IDs
+			if strings.TrimSpace(tenant) == "" {
+				continue
+			}
+			tenantSet[tenant] = struct{}{}
+		}
+	}
+
+	// Convert set to sorted slice
+	tenants := make([]string, 0, len(tenantSet))
+	for tenant := range tenantSet {
+		tenants = append(tenants, tenant)
+	}
+	sort.Strings(tenants)
+
+	return tenants, nil
+}
+
+// InvalidateCache forces the cache to be refreshed on the next GetAllTenants call
+func (s *StorageTenantDiscovery) InvalidateCache() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cachedTenants = nil
+	s.cacheTime = time.Time{}
+}
+
+// NoOpTenantDiscovery is a no-op implementation that doesn't support wildcards
+type NoOpTenantDiscovery struct{}
+
+// IsWildcard always returns false for NoOpTenantDiscovery
+func (n *NoOpTenantDiscovery) IsWildcard(_ string) bool {
+	return false
+}
+
+// GetAllTenants returns an error indicating wildcards are not supported
+func (n *NoOpTenantDiscovery) GetAllTenants(_ context.Context) ([]string, error) {
+	return nil, ErrWildcardNotEnabled
+}

--- a/pkg/querier/tenant_discovery_test.go
+++ b/pkg/querier/tenant_discovery_test.go
@@ -1,0 +1,267 @@
+package querier
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/storage"
+)
+
+// mockIndexClient implements storage.Client interface for testing
+type mockIndexClient struct {
+	tables  []string
+	tenants map[string][]string // table -> tenants
+	err     error
+}
+
+// Verify interface compliance
+var _ storage.Client = (*mockIndexClient)(nil)
+
+func (m *mockIndexClient) ListTables(ctx context.Context) ([]string, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.tables, nil
+}
+
+func (m *mockIndexClient) ListFiles(ctx context.Context, tableName string, _ bool) ([]storage.IndexFile, []string, error) {
+	if m.err != nil {
+		return nil, nil, m.err
+	}
+	tenants := m.tenants[tableName]
+	return nil, tenants, nil
+}
+
+func (m *mockIndexClient) ListUserFiles(ctx context.Context, tableName, userID string, bypassCache bool) ([]storage.IndexFile, error) {
+	return nil, nil
+}
+
+func (m *mockIndexClient) GetFile(ctx context.Context, tableName, fileName string) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (m *mockIndexClient) GetUserFile(ctx context.Context, tableName, userID, fileName string) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (m *mockIndexClient) PutFile(ctx context.Context, tableName, fileName string, file io.Reader) error {
+	return nil
+}
+
+func (m *mockIndexClient) PutUserFile(ctx context.Context, tableName, userID, fileName string, file io.Reader) error {
+	return nil
+}
+
+func (m *mockIndexClient) DeleteFile(ctx context.Context, tableName, fileName string) error {
+	return nil
+}
+
+func (m *mockIndexClient) DeleteUserFile(ctx context.Context, tableName, userID, fileName string) error {
+	return nil
+}
+
+func (m *mockIndexClient) RefreshIndexTableNamesCache(ctx context.Context) {}
+
+func (m *mockIndexClient) RefreshIndexTableCache(ctx context.Context, tableName string) {}
+
+func (m *mockIndexClient) IsFileNotFoundErr(err error) bool {
+	return false
+}
+
+func (m *mockIndexClient) Stop() {}
+
+func TestStorageTenantDiscovery_IsWildcard(t *testing.T) {
+	discovery := &StorageTenantDiscovery{}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"wildcard", "*", true},
+		{"single tenant", "tenant1", false},
+		{"empty string", "", false},
+		{"asterisk in name", "tenant*", false},
+		{"multiple wildcards", "**", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := discovery.IsWildcard(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestStorageTenantDiscovery_GetAllTenants(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	tests := []struct {
+		name            string
+		tables          []string
+		tenants         map[string][]string
+		expectedTenants []string
+		cacheTTL        time.Duration
+	}{
+		{
+			name:   "single table single tenant",
+			tables: []string{"table1"},
+			tenants: map[string][]string{
+				"table1": {"tenant1"},
+			},
+			expectedTenants: []string{"tenant1"},
+			cacheTTL:        time.Minute,
+		},
+		{
+			name:   "single table multiple tenants",
+			tables: []string{"table1"},
+			tenants: map[string][]string{
+				"table1": {"tenant1", "tenant2", "tenant3"},
+			},
+			expectedTenants: []string{"tenant1", "tenant2", "tenant3"},
+			cacheTTL:        time.Minute,
+		},
+		{
+			name:   "multiple tables deduplicated tenants",
+			tables: []string{"table1", "table2"},
+			tenants: map[string][]string{
+				"table1": {"tenant1", "tenant2"},
+				"table2": {"tenant2", "tenant3"},
+			},
+			expectedTenants: []string{"tenant1", "tenant2", "tenant3"},
+			cacheTTL:        time.Minute,
+		},
+		{
+			name:   "empty tenants filtered",
+			tables: []string{"table1"},
+			tenants: map[string][]string{
+				"table1": {"tenant1", "", "  ", "tenant2"},
+			},
+			expectedTenants: []string{"tenant1", "tenant2"},
+			cacheTTL:        time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockIndexClient{
+				tables:  tt.tables,
+				tenants: tt.tenants,
+			}
+
+			discovery := NewStorageTenantDiscovery(client, logger, tt.cacheTTL)
+			tenants, err := discovery.GetAllTenants(context.Background())
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedTenants, tenants)
+		})
+	}
+}
+
+func TestStorageTenantDiscovery_Caching(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	client := &mockIndexClient{
+		tables: []string{"table1"},
+		tenants: map[string][]string{
+			"table1": {"tenant1"},
+		},
+	}
+
+	discovery := NewStorageTenantDiscovery(client, logger, time.Minute)
+
+	// First call should fetch from storage
+	tenants1, err := discovery.GetAllTenants(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tenant1"}, tenants1)
+
+	// Modify the underlying data - second call should return cached data
+	client.tenants = map[string][]string{
+		"table1": {"tenant1", "tenant2"},
+	}
+
+	tenants2, err := discovery.GetAllTenants(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tenant1"}, tenants2, "should return cached data")
+
+	// Invalidate cache
+	discovery.InvalidateCache()
+
+	// Now should get fresh data
+	tenants3, err := discovery.GetAllTenants(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tenant1", "tenant2"}, tenants3, "should return fresh data after invalidation")
+}
+
+func TestStorageTenantDiscovery_ConcurrentAccess(t *testing.T) {
+	logger := log.NewNopLogger()
+	client := &mockIndexClient{
+		tables: []string{"table1"},
+		tenants: map[string][]string{
+			"table1": {"tenant1", "tenant2"},
+		},
+	}
+
+	discovery := NewStorageTenantDiscovery(client, logger, time.Minute)
+
+	var wg sync.WaitGroup
+	concurrency := 100
+	results := make([][]string, concurrency)
+	errors := make([]error, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			tenants, err := discovery.GetAllTenants(context.Background())
+			results[idx] = tenants
+			errors[idx] = err
+		}(i)
+	}
+
+	wg.Wait()
+
+	// All results should be the same and no errors
+	expected := []string{"tenant1", "tenant2"}
+	for i := 0; i < concurrency; i++ {
+		require.NoError(t, errors[i], "goroutine %d should not error", i)
+		assert.Equal(t, expected, results[i], "goroutine %d should get correct tenants", i)
+	}
+}
+
+func TestNoOpTenantDiscovery(t *testing.T) {
+	discovery := &NoOpTenantDiscovery{}
+
+	t.Run("IsWildcard always returns false", func(t *testing.T) {
+		assert.False(t, discovery.IsWildcard("*"))
+		assert.False(t, discovery.IsWildcard("tenant1"))
+	})
+
+	t.Run("GetAllTenants returns error", func(t *testing.T) {
+		tenants, err := discovery.GetAllTenants(context.Background())
+		assert.Nil(t, tenants)
+		assert.ErrorIs(t, err, ErrWildcardNotEnabled)
+	})
+}
+
+func TestDefaultCacheTTL(t *testing.T) {
+	logger := log.NewNopLogger()
+	client := &mockIndexClient{
+		tables:  []string{"table1"},
+		tenants: map[string][]string{"table1": {"tenant1"}},
+	}
+
+	// Test that 0 or negative TTL defaults to DefaultTenantCacheTTL
+	discovery := NewStorageTenantDiscovery(client, logger, 0)
+	assert.Equal(t, DefaultTenantCacheTTL, discovery.cacheTTL)
+
+	discovery2 := NewStorageTenantDiscovery(client, logger, -1*time.Minute)
+	assert.Equal(t, DefaultTenantCacheTTL, discovery2.cacheTTL)
+}

--- a/pkg/querier/wildcard_tenant_querier.go
+++ b/pkg/querier/wildcard_tenant_querier.go
@@ -1,0 +1,216 @@
+package querier
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/tenant"
+	"github.com/grafana/dskit/user"
+	"github.com/pkg/errors"
+
+	"github.com/grafana/loki/v3/pkg/iter"
+	"github.com/grafana/loki/v3/pkg/loghttp"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql"
+	"github.com/grafana/loki/v3/pkg/querier/pattern"
+	"github.com/grafana/loki/v3/pkg/storage/stores/index/stats"
+)
+
+var (
+	// ErrExcludeWithoutWildcard is returned when tenant exclusion syntax is used
+	// without a wildcard
+	ErrExcludeWithoutWildcard = errors.New("tenant exclusion (!) syntax requires wildcard (*) to be present")
+)
+
+// WildcardTenantQuerier wraps a MultiTenantQuerier and provides wildcard tenant support.
+// It resolves "*" to all available tenants from storage before delegating to the
+// underlying querier.
+//
+// Supported X-Scope-OrgID formats:
+//   - "*"           : Query all tenants
+//   - "*|!tenant1"  : Query all tenants except tenant1
+//   - "*|!t1|!t2"   : Query all tenants except t1 and t2
+type WildcardTenantQuerier struct {
+	*MultiTenantQuerier
+	discovery TenantDiscovery
+	logger    log.Logger
+}
+
+// WildcardConfig holds configuration for wildcard tenant queries
+type WildcardConfig struct {
+	// Enabled enables wildcard tenant queries
+	Enabled bool `yaml:"enabled"`
+
+	// CacheTTL is how long to cache the list of discovered tenants
+	CacheTTL string `yaml:"cache_ttl"`
+}
+
+// NewWildcardTenantQuerier creates a new WildcardTenantQuerier.
+func NewWildcardTenantQuerier(querier *MultiTenantQuerier, discovery TenantDiscovery, logger log.Logger) *WildcardTenantQuerier {
+	return &WildcardTenantQuerier{
+		MultiTenantQuerier: querier,
+		discovery:          discovery,
+		logger:             logger,
+	}
+}
+
+// resolveWildcardTenants checks if the context contains a wildcard tenant and
+// resolves it to actual tenant IDs. Returns a new context with resolved tenants
+// injected, or the original context if no wildcard is present.
+func (q *WildcardTenantQuerier) resolveWildcardTenants(ctx context.Context) (context.Context, error) {
+	tenantIDs, err := tenant.TenantIDs(ctx)
+	if err != nil {
+		return ctx, err
+	}
+
+	// Check if we have a wildcard
+	hasWildcard := false
+	excludeTenants := make(map[string]struct{})
+
+	for _, id := range tenantIDs {
+		if q.discovery.IsWildcard(id) {
+			hasWildcard = true
+		} else if strings.HasPrefix(id, "!") {
+			// Tenant exclusion syntax: !tenant_id
+			excludeTenants[strings.TrimPrefix(id, "!")] = struct{}{}
+		}
+	}
+
+	// If exclusions are specified without wildcard, return error
+	if len(excludeTenants) > 0 && !hasWildcard {
+		return ctx, ErrExcludeWithoutWildcard
+	}
+
+	// If no wildcard, return original context
+	if !hasWildcard {
+		return ctx, nil
+	}
+
+	// Resolve wildcard to all tenants
+	allTenants, err := q.discovery.GetAllTenants(ctx)
+	if err != nil {
+		return ctx, fmt.Errorf("failed to discover tenants for wildcard query: %w", err)
+	}
+
+	// Apply exclusions
+	var resolvedTenants []string
+	for _, t := range allTenants {
+		if _, excluded := excludeTenants[t]; !excluded {
+			resolvedTenants = append(resolvedTenants, t)
+		}
+	}
+
+	if len(resolvedTenants) == 0 {
+		return ctx, errors.New("wildcard query resolved to zero tenants after exclusions")
+	}
+
+	level.Info(q.logger).Log(
+		"msg", "resolved wildcard tenant query",
+		"total_tenants", len(allTenants),
+		"excluded_tenants", len(excludeTenants),
+		"resolved_tenants", len(resolvedTenants),
+	)
+
+	// Inject resolved tenants into context
+	// The tenant package expects the org ID header format (pipe-separated)
+	orgID := strings.Join(resolvedTenants, "|")
+	return user.InjectOrgID(ctx, orgID), nil
+}
+
+// SelectLogs implements Querier.SelectLogs with wildcard support
+func (q *WildcardTenantQuerier) SelectLogs(ctx context.Context, params logql.SelectLogParams) (iter.EntryIterator, error) {
+	ctx, err := q.resolveWildcardTenants(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return q.MultiTenantQuerier.SelectLogs(ctx, params)
+}
+
+// SelectSamples implements Querier.SelectSamples with wildcard support
+func (q *WildcardTenantQuerier) SelectSamples(ctx context.Context, params logql.SelectSampleParams) (iter.SampleIterator, error) {
+	ctx, err := q.resolveWildcardTenants(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return q.MultiTenantQuerier.SelectSamples(ctx, params)
+}
+
+// Label implements Querier.Label with wildcard support
+func (q *WildcardTenantQuerier) Label(ctx context.Context, req *logproto.LabelRequest) (*logproto.LabelResponse, error) {
+	ctx, err := q.resolveWildcardTenants(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return q.MultiTenantQuerier.Label(ctx, req)
+}
+
+// Series implements Querier.Series with wildcard support
+func (q *WildcardTenantQuerier) Series(ctx context.Context, req *logproto.SeriesRequest) (*logproto.SeriesResponse, error) {
+	ctx, err := q.resolveWildcardTenants(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return q.MultiTenantQuerier.Series(ctx, req)
+}
+
+// IndexStats implements Querier.IndexStats with wildcard support
+func (q *WildcardTenantQuerier) IndexStats(ctx context.Context, req *loghttp.RangeQuery) (*stats.Stats, error) {
+	ctx, err := q.resolveWildcardTenants(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return q.MultiTenantQuerier.IndexStats(ctx, req)
+}
+
+// IndexShards implements Querier.IndexShards with wildcard support
+func (q *WildcardTenantQuerier) IndexShards(ctx context.Context, req *loghttp.RangeQuery, targetBytesPerShard uint64) (*logproto.ShardsResponse, error) {
+	ctx, err := q.resolveWildcardTenants(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return q.MultiTenantQuerier.IndexShards(ctx, req, targetBytesPerShard)
+}
+
+// Volume implements Querier.Volume with wildcard support
+func (q *WildcardTenantQuerier) Volume(ctx context.Context, req *logproto.VolumeRequest) (*logproto.VolumeResponse, error) {
+	ctx, err := q.resolveWildcardTenants(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return q.MultiTenantQuerier.Volume(ctx, req)
+}
+
+// Patterns implements Querier.Patterns with wildcard support
+func (q *WildcardTenantQuerier) Patterns(ctx context.Context, req *logproto.QueryPatternsRequest) (*logproto.QueryPatternsResponse, error) {
+	ctx, err := q.resolveWildcardTenants(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return q.MultiTenantQuerier.Patterns(ctx, req)
+}
+
+// DetectedFields implements Querier.DetectedFields with wildcard support
+func (q *WildcardTenantQuerier) DetectedFields(ctx context.Context, req *logproto.DetectedFieldsRequest) (*logproto.DetectedFieldsResponse, error) {
+	ctx, err := q.resolveWildcardTenants(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return q.MultiTenantQuerier.DetectedFields(ctx, req)
+}
+
+// DetectedLabels implements Querier.DetectedLabels with wildcard support
+func (q *WildcardTenantQuerier) DetectedLabels(ctx context.Context, req *logproto.DetectedLabelsRequest) (*logproto.DetectedLabelsResponse, error) {
+	ctx, err := q.resolveWildcardTenants(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return q.MultiTenantQuerier.DetectedLabels(ctx, req)
+}
+
+// WithPatternQuerier implements Querier.WithPatternQuerier
+func (q *WildcardTenantQuerier) WithPatternQuerier(patternQuerier pattern.PatterQuerier) {
+	q.MultiTenantQuerier.WithPatternQuerier(patternQuerier)
+}

--- a/pkg/querier/wildcard_tenant_querier_test.go
+++ b/pkg/querier/wildcard_tenant_querier_test.go
@@ -1,0 +1,276 @@
+package querier
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/user"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockTenantDiscovery implements TenantDiscovery for testing
+type mockTenantDiscovery struct {
+	tenants []string
+	err     error
+}
+
+func (m *mockTenantDiscovery) GetAllTenants(ctx context.Context) ([]string, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.tenants, nil
+}
+
+func (m *mockTenantDiscovery) IsWildcard(orgID string) bool {
+	return orgID == WildcardTenantID
+}
+
+func TestWildcardTenantQuerier_resolveWildcardTenants(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	tests := []struct {
+		name            string
+		orgID           string
+		allTenants      []string
+		expectedTenants []string
+		expectedError   error
+	}{
+		{
+			name:            "no wildcard - single tenant",
+			orgID:           "tenant1",
+			allTenants:      []string{"tenant1", "tenant2", "tenant3"},
+			expectedTenants: []string{"tenant1"},
+			expectedError:   nil,
+		},
+		{
+			name:            "no wildcard - multiple tenants",
+			orgID:           "tenant1|tenant2",
+			allTenants:      []string{"tenant1", "tenant2", "tenant3"},
+			expectedTenants: []string{"tenant1", "tenant2"},
+			expectedError:   nil,
+		},
+		{
+			name:            "wildcard only - all tenants",
+			orgID:           "*",
+			allTenants:      []string{"tenant1", "tenant2", "tenant3"},
+			expectedTenants: []string{"tenant1", "tenant2", "tenant3"},
+			expectedError:   nil,
+		},
+		{
+			name:            "wildcard with one exclusion",
+			orgID:           "*|!tenant2",
+			allTenants:      []string{"tenant1", "tenant2", "tenant3"},
+			expectedTenants: []string{"tenant1", "tenant3"},
+			expectedError:   nil,
+		},
+		{
+			name:            "wildcard with multiple exclusions",
+			orgID:           "*|!tenant1|!tenant3",
+			allTenants:      []string{"tenant1", "tenant2", "tenant3", "tenant4"},
+			expectedTenants: []string{"tenant2", "tenant4"},
+			expectedError:   nil,
+		},
+		{
+			name:            "exclusion without wildcard - error",
+			orgID:           "tenant1|!tenant2",
+			allTenants:      []string{"tenant1", "tenant2", "tenant3"},
+			expectedTenants: nil,
+			expectedError:   ErrExcludeWithoutWildcard,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			discovery := &mockTenantDiscovery{
+				tenants: tt.allTenants,
+			}
+
+			querier := &WildcardTenantQuerier{
+				discovery: discovery,
+				logger:    logger,
+			}
+
+			ctx := user.InjectOrgID(context.Background(), tt.orgID)
+			resolvedCtx, err := querier.resolveWildcardTenants(ctx)
+
+			if tt.expectedError != nil {
+				assert.ErrorIs(t, err, tt.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Extract org ID from the resolved context
+			resolvedOrgID, err := user.ExtractOrgID(resolvedCtx)
+			require.NoError(t, err)
+
+			// For non-wildcard cases, the original context should be returned unchanged
+			if tt.orgID != "*" && !containsWildcard(tt.orgID) {
+				assert.Equal(t, tt.orgID, resolvedOrgID)
+			} else {
+				// For wildcard cases, verify the resolved tenants
+				// The resolved OrgID should be a pipe-separated list of all tenants
+				// excluding any excluded ones
+				for _, expected := range tt.expectedTenants {
+					assert.Contains(t, resolvedOrgID, expected, "resolved org ID should contain %s", expected)
+				}
+			}
+		})
+	}
+}
+
+func containsWildcard(orgID string) bool {
+	return orgID == "*" || len(orgID) > 1 && (orgID[0] == '*' || orgID[len(orgID)-1] == '*')
+}
+
+func TestWildcardTenantQuerier_resolveWildcardTenants_DiscoveryError(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	discovery := &mockTenantDiscovery{
+		err: ErrWildcardNotEnabled,
+	}
+
+	querier := &WildcardTenantQuerier{
+		discovery: discovery,
+		logger:    logger,
+	}
+
+	ctx := user.InjectOrgID(context.Background(), "*")
+	_, err := querier.resolveWildcardTenants(ctx)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to discover tenants")
+}
+
+func TestWildcardTenantQuerier_resolveWildcardTenants_NoTenants(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	// All tenants excluded
+	discovery := &mockTenantDiscovery{
+		tenants: []string{"tenant1"},
+	}
+
+	querier := &WildcardTenantQuerier{
+		discovery: discovery,
+		logger:    logger,
+	}
+
+	ctx := user.InjectOrgID(context.Background(), "*|!tenant1")
+	_, err := querier.resolveWildcardTenants(ctx)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "resolved to zero tenants")
+}
+
+func TestWildcardConfig(t *testing.T) {
+	t.Run("config validation - wildcard without multi-tenant", func(t *testing.T) {
+		cfg := Config{
+			MultiTenantQueriesEnabled:    false,
+			WildcardTenantQueriesEnabled: true,
+		}
+
+		err := cfg.Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "requires querier.multi_tenant_queries_enabled")
+	})
+
+	t.Run("config validation - wildcard with multi-tenant", func(t *testing.T) {
+		cfg := Config{
+			MultiTenantQueriesEnabled:    true,
+			WildcardTenantQueriesEnabled: true,
+		}
+
+		err := cfg.Validate()
+		assert.NoError(t, err)
+	})
+}
+
+// Test edge cases for tenant ID parsing
+func TestParseWildcardOrgID(t *testing.T) {
+	tests := []struct {
+		name           string
+		orgID          string
+		hasWildcard    bool
+		excludeTenants []string
+	}{
+		{
+			name:           "simple wildcard",
+			orgID:          "*",
+			hasWildcard:    true,
+			excludeTenants: nil,
+		},
+		{
+			name:           "wildcard at start",
+			orgID:          "*|!excluded",
+			hasWildcard:    true,
+			excludeTenants: []string{"excluded"},
+		},
+		{
+			name:           "wildcard in middle (treated as separate tenant)",
+			orgID:          "tenant1|*|tenant2",
+			hasWildcard:    true,
+			excludeTenants: nil,
+		},
+		{
+			name:           "no wildcard",
+			orgID:          "tenant1|tenant2",
+			hasWildcard:    false,
+			excludeTenants: nil,
+		},
+		{
+			name:           "multiple exclusions",
+			orgID:          "*|!t1|!t2|!t3",
+			hasWildcard:    true,
+			excludeTenants: []string{"t1", "t2", "t3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			discovery := &StorageTenantDiscovery{}
+
+			// Parse the org ID as the querier would
+			ctx := user.InjectOrgID(context.Background(), tt.orgID)
+			tenantIDs, err := extractTenantIDs(ctx)
+			require.NoError(t, err)
+
+			hasWildcard := false
+			var excludeTenants []string
+
+			for _, id := range tenantIDs {
+				if discovery.IsWildcard(id) {
+					hasWildcard = true
+				} else if len(id) > 1 && id[0] == '!' {
+					excludeTenants = append(excludeTenants, id[1:])
+				}
+			}
+
+			assert.Equal(t, tt.hasWildcard, hasWildcard, "wildcard detection")
+			assert.Equal(t, tt.excludeTenants, excludeTenants, "exclusion detection")
+		})
+	}
+}
+
+// Helper to extract tenant IDs (simulates what the querier does)
+func extractTenantIDs(ctx context.Context) ([]string, error) {
+	orgID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Split by pipe character
+	var tenants []string
+	start := 0
+	for i := 0; i <= len(orgID); i++ {
+		if i == len(orgID) || orgID[i] == '|' {
+			if i > start {
+				tenants = append(tenants, orgID[start:i])
+			}
+			start = i + 1
+		}
+	}
+
+	return tenants, nil
+}


### PR DESCRIPTION
## Summary

This PR adds experimental support for wildcard tenant queries in Loki, allowing administrators to query all tenants using `*` in the `X-Scope-OrgID` header instead of explicitly listing each tenant ID.

Closes #7356

## Motivation

In multi-tenant Loki deployments with many tenants, administrators currently need to manually maintain lists of tenant IDs in their datasource configurations or query headers. This is error-prone and requires constant updates as tenants are added or removed.

This feature addresses the community request for a way to query "all tenants" or "all tenants except specific ones" without explicit enumeration.

## Changes

### New Files

- `pkg/querier/tenant_discovery.go` - Core tenant discovery interface and storage-based implementation
- `pkg/querier/wildcard_tenant_querier.go` - Querier wrapper that handles wildcard resolution
- `pkg/querier/tenant_discovery_test.go` - Unit tests for tenant discovery
- `pkg/querier/wildcard_tenant_querier_test.go` - Unit tests for wildcard querier
- `integration/wildcard_tenant_queries_test.go` - Integration tests
- `docs/sources/configure/wildcard-tenant-queries.md` - User documentation

### Modified Files

- `pkg/querier/querier.go` - Added configuration options:
  - `wildcard_tenant_queries_enabled` (bool, default: false)
  - `wildcard_tenant_cache_ttl` (duration, default: 5m)
- `pkg/loki/modules.go` - Wired wildcard querier into initialization

## Design

### Tenant Discovery

The feature uses a `TenantDiscovery` interface:

```go
type TenantDiscovery interface {
    GetAllTenants(ctx context.Context) ([]string, error)
    IsWildcard(orgID string) bool
}
```

The `StorageTenantDiscovery` implementation discovers tenants by listing them from the index storage (S3/GCS/etc). Results are cached with a configurable TTL to avoid expensive storage operations on every query.

### Query Flow

1. Request arrives with `X-Scope-OrgID: *` (or `*|!excluded`)
2. `WildcardTenantQuerier.resolveWildcardTenants()` detects the wildcard
3. `StorageTenantDiscovery.GetAllTenants()` retrieves all tenant IDs from storage (or cache)
4. Exclusions are applied if any `!tenant` patterns are present
5. Context is updated with resolved tenant IDs
6. Query proceeds through normal `MultiTenantQuerier` code path
7. Results include `__tenant_id__` label on each log entry

### Supported Syntax

| Syntax | Description |
|--------|-------------|
| `*` | Query all tenants |
| `*\|!tenant1` | All tenants except tenant1 |
| `*\|!t1\|!t2\|!t3` | All tenants except t1, t2, t3 |

## Configuration

```yaml
querier:
  multi_tenant_queries_enabled: true
  wildcard_tenant_queries_enabled: true
  wildcard_tenant_cache_ttl: 5m
```

## Testing

- Unit tests for tenant discovery caching, concurrent access, edge cases
- Unit tests for wildcard resolution, exclusion handling, error cases
- Integration tests for end-to-end validation

## Breaking Changes

None - this is an opt-in experimental feature.

## Checklist

- [x] Tests added
- [x] Documentation updated
- [x] No breaking changes
- [x] Implementation fully wired into Loki startup