### PR TITLE
fix: include labels in size for limits service

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1431,15 +1431,6 @@ func calculateShards(rate int64, pushSize, desiredRate int) int {
 	return int(math.Ceil(shards))
 }
 
-func calculateStreamSizes(stream logproto.Stream) (uint64, uint64) {
-	var entriesSize, structuredMetadataSize uint64
-	for _, entry := range stream.Entries {
-		entriesSize += uint64(len(entry.Line))
-		structuredMetadataSize += uint64(util.StructuredMetadataSize(entry.StructuredMetadata))
-	}
-	return entriesSize, structuredMetadataSize
-}
-
 // newRingAndLifecycler creates a new distributor ring and lifecycler with all required lifecycler delegates
 func newRingAndLifecycler(cfg RingConfig, instanceCount *atomic.Uint32, logger log.Logger, reg prometheus.Registerer, metricsNamespace string) (*ring.Ring, *ring.BasicLifecycler, error) {
 	kvStore, err := kv.NewClient(cfg.KVStore, ring.GetCodec(), kv.RegistererWithKVName(reg, "distributor-lifecycler"), logger)

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2496,7 +2496,7 @@ func TestDistributor_PushIngestLimits(t *testing.T) {
 			Tenant: "test",
 			Streams: []*limitsproto.StreamMetadata{{
 				StreamHash: 0x90eb45def17f924,
-				TotalSize:  0x3,
+				TotalSize:  0x47,
 			}},
 		},
 		limitsResponse: &limitsproto.ExceedsLimitsResponse{
@@ -2529,10 +2529,10 @@ func TestDistributor_PushIngestLimits(t *testing.T) {
 			Tenant: "test",
 			Streams: []*limitsproto.StreamMetadata{{
 				StreamHash: 0x90eb45def17f924,
-				TotalSize:  0x3,
+				TotalSize:  0x47,
 			}, {
 				StreamHash: 0x11561609feba8cf6,
-				TotalSize:  0x3,
+				TotalSize:  0x47,
 			}},
 		},
 		limitsResponse: &limitsproto.ExceedsLimitsResponse{
@@ -2571,10 +2571,10 @@ func TestDistributor_PushIngestLimits(t *testing.T) {
 			Tenant: "test",
 			Streams: []*limitsproto.StreamMetadata{{
 				StreamHash: 0x90eb45def17f924,
-				TotalSize:  0x3,
+				TotalSize:  0x47,
 			}, {
 				StreamHash: 0x11561609feba8cf6,
-				TotalSize:  0x3,
+				TotalSize:  0x47,
 			}},
 		},
 		limitsResponse: &limitsproto.ExceedsLimitsResponse{
@@ -2609,7 +2609,7 @@ func TestDistributor_PushIngestLimits(t *testing.T) {
 			Tenant: "test",
 			Streams: []*limitsproto.StreamMetadata{{
 				StreamHash: 0x90eb45def17f924,
-				TotalSize:  0x3,
+				TotalSize:  0x47,
 			}},
 		},
 		limitsResponse: &limitsproto.ExceedsLimitsResponse{
@@ -2639,7 +2639,7 @@ func TestDistributor_PushIngestLimits(t *testing.T) {
 			Tenant: "test",
 			Streams: []*limitsproto.StreamMetadata{{
 				StreamHash: 0x90eb45def17f924,
-				TotalSize:  0x3,
+				TotalSize:  0x47,
 			}},
 		},
 		limitsResponseErr:        errors.New("failed to check limits"),

--- a/pkg/distributor/ingest_limits.go
+++ b/pkg/distributor/ingest_limits.go
@@ -185,10 +185,9 @@ func newExceedsLimitsRequest(tenant string, streams []KeyedStream) (*proto.Excee
 	// from the request caused it to exceed its limits.
 	streamMetadata := make([]*proto.StreamMetadata, 0, len(streams))
 	for _, stream := range streams {
-		entriesSize, structuredMetadataSize := calculateStreamSizes(stream.Stream)
 		streamMetadata = append(streamMetadata, &proto.StreamMetadata{
 			StreamHash:      stream.HashKeyNoShard,
-			TotalSize:       entriesSize + structuredMetadataSize,
+			TotalSize:       uint64(stream.Stream.Size()),
 			IngestionPolicy: stream.Policy,
 		})
 	}
@@ -231,10 +230,9 @@ func newUpdateRatesRequest(tenant string, streams []segmentedStream) (*proto.Upd
 	// from the request caused it to exceed its limits.
 	streamMetadata := make([]*proto.StreamMetadata, 0, len(streams))
 	for _, stream := range streams {
-		entriesSize, structuredMetadataSize := calculateStreamSizes(stream.Stream)
 		streamMetadata = append(streamMetadata, &proto.StreamMetadata{
 			StreamHash:      stream.SegmentationKeyHash,
-			TotalSize:       entriesSize + structuredMetadataSize,
+			TotalSize:       uint64(stream.Stream.Size()),
 			IngestionPolicy: stream.Policy,
 		})
 	}

--- a/pkg/distributor/ingest_limits_test.go
+++ b/pkg/distributor/ingest_limits_test.go
@@ -102,10 +102,10 @@ func TestIngestLimits_EnforceLimits(t *testing.T) {
 			Tenant: "test",
 			Streams: []*proto.StreamMetadata{{
 				StreamHash: 1,
-				TotalSize:  9,
+				TotalSize:  0x20,
 			}, {
 				StreamHash: 2,
-				TotalSize:  11,
+				TotalSize:  0x22,
 			}},
 		},
 		responseErr: errors.New("failed to check limits"),


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes a mistake where we didn't include labels in the size of a stream. As a result, we under-estimated what we ingested as much as 50% for some streams. We now use the Size() method on the logproto stream instead.

Here is an example of such a case:

<img width="668" height="180" alt="Screenshot 2026-02-05 at 15 19 04" src="https://github.com/user-attachments/assets/b4505824-4a58-4b5f-a73b-481cc02fc47f" />

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
