### PR TITLE
chore: use weighted average to smooth out new buckets

### DIFF
--- a/pkg/limits/service.go
+++ b/pkg/limits/service.go
@@ -200,21 +200,14 @@ func (s *Service) UpdateRates(
 	if err != nil {
 		return nil, err
 	}
+	now := s.clock.Now()
 	resp := proto.UpdateRatesResponse{
 		Results: make([]*proto.UpdateRatesResult, len(updated)),
 	}
 	for i, stream := range updated {
-		var totalSize uint64
-		for _, bucket := range stream.rateBuckets {
-			totalSize += bucket.size
-		}
-		// The average rate is calculated over the total number of
-		// populated buckets. This allows us to calculate accurate rates
-		// without empty buckets pulling down the average.
-		averageRate := totalSize / (uint64(s.cfg.BucketSize.Seconds()) * uint64(len(stream.rateBuckets)))
 		resp.Results[i] = &proto.UpdateRatesResult{
 			StreamHash: stream.hash,
-			Rate:       averageRate,
+			Rate:       s.usage.averageRate(stream.rateBuckets, now),
 		}
 	}
 	return &resp, nil

--- a/pkg/limits/store.go
+++ b/pkg/limits/store.go
@@ -53,6 +53,37 @@ func (s *usageStore) getPolicyBucketAndStreamsLimit(tenant, policy string) (poli
 	return noPolicy, defaultMaxStreams // Use default bucket (noPolicy)
 }
 
+// averageRate returns the average rate over the buckets. It ignores buckets outside
+// the rate window, and smoothes out the latest bucket to avoid partially filled
+// buckets from skewing the average.
+func (s *usageStore) averageRate(buckets []rateBucket, now time.Time) uint64 {
+	var (
+		totalBytes   uint64
+		totalSeconds float64
+		windowStart  = now.Add(-s.rateWindow)
+	)
+	for _, bucket := range buckets {
+		bucketTime := time.Unix(0, bucket.timestamp)
+		bucketEnd := bucketTime.Add(s.bucketSize)
+		// Ignore buckets that are outside the window.
+		if bucketTime.IsZero() || bucketEnd.Before(windowStart) {
+			continue
+		}
+		totalBytes += bucket.size
+		// If this is the current bucket, count the number of seconds start
+		// the start of the bucket, otherwise count the full duration.
+		if now.Before(bucketEnd) {
+			totalSeconds += now.Sub(bucketTime).Seconds()
+		} else {
+			totalSeconds += s.bucketSize.Seconds()
+		}
+	}
+	if totalSeconds == 0 {
+		return 0
+	}
+	return uint64(float64(totalBytes) / totalSeconds)
+}
+
 // usageStore stores per-tenant stream usage data.
 type usageStore struct {
 	activeWindow  time.Duration

--- a/pkg/limits/store_test.go
+++ b/pkg/limits/store_test.go
@@ -637,6 +637,42 @@ func TestUsageStore_PolicyBasedStreamLimits(t *testing.T) {
 	})
 }
 
+func TestUsageStore_AverageRate(t *testing.T) {
+	clock := quartz.NewMock(t)
+	s, err := newUsageStore(15*time.Minute, 5*time.Minute, time.Minute, 1, &mockLimits{}, prometheus.NewRegistry())
+	s.clock = clock
+	require.NoError(t, err)
+
+	// Empty buckets should return a rate of 0.
+	buckets := make([]rateBucket, 5)
+	require.Equal(t, uint64(0), s.averageRate(buckets, clock.Now()))
+
+	// Buckets inside window, but with no rates, should return a rate of 0.
+	for i := range buckets {
+		buckets[i].timestamp = clock.Now().UnixNano()
+		clock.Advance(time.Minute)
+	}
+	require.Equal(t, uint64(0), s.averageRate(buckets, clock.Now()))
+
+	// Buckets inside window, with rates, should return average rate.
+	for i := range buckets {
+		// Bucket size is 1 minute, so if each bucket is 1800 bytes,
+		// the per second rate is 30KB/sec.
+		buckets[i].size = uint64(1800)
+	}
+	require.Equal(t, uint64(30), s.averageRate(buckets, clock.Now()))
+
+	// If the last bucket is just inside the window (because it is the start of the
+	// next minute) just the seconds inside the window should be included.
+	for i := range buckets {
+		buckets[i].timestamp = clock.Now().Add(time.Minute * time.Duration(i)).UnixNano()
+	}
+	// Advance the clock 1 second into the last bucket. It should work out as
+	// 9000 (1800 x 5) over 4 minutes and 1 second.
+	clock.Advance(4*time.Minute + time.Second)
+	require.Equal(t, uint64(37), s.averageRate(buckets, clock.Now()))
+}
+
 // mockLimitsWithPolicy extends mockLimits to support policy-specific limits
 type mockLimitsWithPolicy struct {
 	mockLimits


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes a small issue where rate calculation drops at the start of a new bucket. Here is an example of it producing a sawtooth pattern for the rate over time:

<img width="680" height="232" alt="Screenshot 2026-02-05 at 16 50 44" src="https://github.com/user-attachments/assets/f85bb79e-2b3b-4b4d-8f5e-501c4567c16f" />

Here is the same stream using the weighted average:

<img width="677" height="231" alt="Screenshot 2026-02-05 at 16 51 47" src="https://github.com/user-attachments/assets/d383dd72-0a22-4865-8e12-9f47029d50f5" />



**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
