### PR TITLE
feat(helm): Allow lokiCanary to be run without user/pass/tenant automatically being injected

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -7558,6 +7558,15 @@ false
 </td>
 		</tr>
 		<tr>
+			<td>lokiCanary.autoAuth</td>
+			<td>bool</td>
+			<td>If true, auto detect authentication information based on enterprise.enabled==true, use environment variables USER/PASS of container loki.auth_enabled==true, use monitoring.selfMonitoring.tenant.name/password</td>
+			<td><pre lang="json">
+true
+</pre>
+</td>
+		</tr>
+		<tr>
 			<td>lokiCanary.dnsConfig</td>
 			<td>object</td>
 			<td>DNS config for canary pods</td>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -17,6 +17,7 @@ Entries should include a reference to the pull request that introduced the chang
 ## 6.53.0
 
 - [CHANGE] Changed version of Grafana Loki to 3.6.5
+- [ENHANCEMENT] Allow lokiCanary to be run without user/pass/tenant automatically being injected [#20723](https://github.com/grafana/loki/pull/20723).
 
 ## 6.52.0
 

--- a/production/helm/loki/templates/loki-canary/daemonset.yaml
+++ b/production/helm/loki/templates/loki-canary/daemonset.yaml
@@ -56,11 +56,11 @@ spec:
             - -addr={{- default (include "loki.host" $) .lokiurl }}
             - -labelname={{ .labelname }}
             - -labelvalue=$(POD_NAME)
-            {{- if $.Values.enterprise.enabled }}
+            {{- if and $.Values.lokiCanary.autoAuth $.Values.enterprise.enabled }}
             - -user=$(USER)
             - -tenant-id=$(USER)
             - -pass=$(PASS)
-            {{- else if $.Values.loki.auth_enabled }}
+            {{- else if and $.Values.lokiCanary.autoAuth $.Values.loki.auth_enabled }}
             - -user={{ $.Values.monitoring.selfMonitoring.tenant.name }}
             - -tenant-id={{ $.Values.monitoring.selfMonitoring.tenant.name }}
             - -pass={{ $.Values.monitoring.selfMonitoring.tenant.password }}
@@ -86,7 +86,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            {{ if $.Values.enterprise.enabled }}
+            {{ if and $.Values.lokiCanary.autoAuth $.Values.enterprise.enabled }}
             - name: USER
               valueFrom:
                 secretKeyRef:

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -786,6 +786,10 @@ lokiCanary:
   push: true
   # -- If set overwrites the default value set by loki.host helper function. Use this if gateway not enabled.
   lokiurl: null
+  # -- If true, auto detect authentication information based on
+  # enterprise.enabled==true, use environment variables USER/PASS of container
+  # loki.auth_enabled==true, use monitoring.selfMonitoring.tenant.name/password
+  autoAuth: true
   # -- The name of the label to look for at loki when doing the checks.
   labelname: pod
   # -- Additional annotations for the `loki-canary` Daemonset


### PR DESCRIPTION
**What this PR does / why we need it**:
For a multi tenant setup (auth_enabled==true), it's currently not possible to set authentication on your own as extraArgs as the current template automatically injects user/pass/tenan. We need to provide this on our own throught extraArgs as we use a custom authentication header which requires user/pass to be unset.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
