### PR TITLE
docs: backport RN to 3.6

### DIFF
--- a/docs/sources/release-notes/v3-6.md
+++ b/docs/sources/release-notes/v3-6.md
@@ -10,6 +10,10 @@ Grafana Labs and the Loki team are excited to announce the release of Loki 3.6. 
 
 For a full list of all changes and fixes, refer to the [CHANGELOG](https://github.com/grafana/loki/blob/release-3.6.x/CHANGELOG.md)
 
+{{< admonition type="note" >}}
+See the [deprecations](https://grafana.com/docs/loki/latest/release-notes/v3-6/#deprecations) section for important information about the Loki Helm charts.
+{{< /admonition >}}
+
 ## Features and enhancements
 
 Key features in Loki 3.6.0 include the following:
@@ -144,7 +148,27 @@ Other improvements include the following:
 
 * **ruler:** Add rules check for namespace and group ([#20437](https://github.com/grafana/loki/issues/20437)) ([#20463](https://github.com/grafana/loki/issues/20463)) ([7733ab1](https://github.com/grafana/loki/commit/7733ab110ab9dc02704fec30f6afdeaa3b4180fb)).
 
+### 3.6.5 (2025-02-05)
+
+* Add loki health command (backport release-3.6.x) ([#20590](https://github.com/grafana/loki/issues/20590)) ([dfdbe2a](https://github.com/grafana/loki/commit/dfdbe2a351dd0a203513ee66b6dd0b6b983332b0))
+
 ## Deprecations
+
+### 3.6.5 (2025-02-05)
+
+- [Simple Scalable Deployment (SSD)](https://grafana.com/docs/loki/latest/get-started/deployment-modes/#simple-scalable) mode is being deprecated. The deprecation notice was posted in the CHANGELOG for Helm charts version 6.52.0. The timeline for the deprecation is to be determined (TBD), but will happen before Loki 4.0 is released.
+
+- Loki Helm charts deprecations: The following Community maintained Helm charts have been deprecated:
+  - [LGTM-distributed](https://github.com/grafana/helm-charts/tree/main/charts/lgtm-distributed)
+  - [loki-canary](https://github.com/grafana/helm-charts/tree/main/charts/loki-canary)
+  - [loki-distributed](https://github.com/grafana/helm-charts/tree/main/charts/loki-distributed)
+  - [loki-simple-scalable](https://github.com/grafana/helm-charts/tree/main/charts/loki-simple-scalable)
+
+   {{< admonition type="note" >}}
+   In June 2025, Grafana recruited three [Grafana Champions](https://grafana.com/community/champions/) and launched a three month pilot program to maintain the Loki Helm chart. The pilot proved successful, attracting more Grafana champions, and led to the Champions asking to take over maintenance of the chart entirely. The [grafana-community/helm-charts](https://github.com/grafana-community/helm-charts) repository launched on January 30, 2026. The [Loki Helm chart](https://github.com/grafana/loki/tree/main/production/helm/loki) will be migrating from the Loki repository to the new [grafana-community/helm-charts](https://github.com/grafana-community/helm-charts) repository in the near future. The Champions will attempt to make this transition as seamless as possible.
+   {{< /admonition >}}
+
+### 3.6.0 (2025-11-17)
 
 One of the focuses of Loki 3.0 was cleaning up unused code and old features that had been previously deprecated but not removed. Loki 3.0 removed a number of previous deprecations and introduces some new deprecations. Some of the main areas with changes include:
 
@@ -168,6 +192,11 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 ## Bug fixes
 
+### 3.6.5 (2025-02-05)
+
+* **deps:** Bump go version for 3.6.x ([#20667](https://github.com/grafana/loki/issues/20667)) ([b06b508](https://github.com/grafana/loki/commit/b06b508e821a22e7913d3caefb6a61f56ad69089))
+* **logql:** LineFilterLabelFilter.String() regexp correct delimiters (backport release-3.6.x) ([#20649](https://github.com/grafana/loki/issues/20649)) ([9d5fb5f](https://github.com/grafana/loki/commit/9d5fb5fa5eceacec96be55c36c3091d5aba552ba))
+
 ### 3.6.4 (2025-01-21)
 
 * Backport gzip fix release 3.6.x ([#20514](https://github.com/grafana/loki/issues/20514)) ([d805266](https://github.com/grafana/loki/commit/d80526692af3bf28c35622a59a3231933b193bc2)).
@@ -185,7 +214,7 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 ### 3.6.1 (2025-11-21)
 
-* **docker:** Missing permissions  to start Docker ([#19948](https://github.com/grafana/loki/issues/19948)) ([48b507f](https://github.com/grafana/loki/commit/48b507f62f4d5a92cbf2fcb5025a1f1cdc199411)).
+* **docker:** Missing permissions to start Docker ([#19948](https://github.com/grafana/loki/issues/19948)) ([48b507f](https://github.com/grafana/loki/commit/48b507f62f4d5a92cbf2fcb5025a1f1cdc199411)).
 * **docker:** Set WORKDIR to root in Loki Dockerfiles ([#19952](https://github.com/grafana/loki/issues/19952)) ([6040a09](https://github.com/grafana/loki/commit/6040a09db017fa4b66e0805b0e08092b66a93a51)).
 
 ### 3.6.0 (2025-11-17)


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of Release Notes (#20704) to 3.6.x branch.