### PR TITLE
feat(bench): add simulated object storage latency to LogQL benchmarks

### DIFF
--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -308,6 +308,10 @@ type Config struct {
 	// It is required for getting chunk ids of recently flushed chunks from the ingesters.
 	EnableAsyncStore bool          `yaml:"-"`
 	AsyncStoreConfig AsyncStoreCfg `yaml:"-"`
+
+	// ObjectClientDecorator, if set, wraps every ObjectClient after creation.
+	// This is intended for testing (e.g. injecting latency simulation).
+	ObjectClientDecorator func(client.ObjectClient) client.ObjectClient `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to configure this flag set.
@@ -664,6 +668,10 @@ func NewObjectClient(name, component string, cfg Config, clientMetrics ClientMet
 	actual, err := internalNewObjectClient(name, cfg, clientMetrics)
 	if err != nil {
 		return nil, err
+	}
+
+	if cfg.ObjectClientDecorator != nil {
+		actual = cfg.ObjectClientDecorator(actual)
 	}
 
 	if cfg.ObjectPrefix == "" {


### PR DESCRIPTION
## What this PR does

Adds a `-storage-latency` flag to the LogQL benchmark suite that injects per-request delays into both storage backends (dataobj-engine and chunk store), simulating real-world object storage latency (e.g. S3, GCS).

Running benchmarks against local filesystem gives an incomplete picture because it hides I/O round-trip costs that dominate in production. This flag enables measuring how sensitive each engine is to storage latency.

### Changes

- **`pkg/logql/bench/store_dataobj_v2_engine.go`**: Wraps the `objstore.Bucket` with a `latencyBucket` that sleeps before every read operation (`Get`, `GetRange`, `Iter`, `Exists`, `Attributes`).
- **`pkg/logql/bench/store_chunk.go`**: Uses the new `ObjectClientDecorator` to wrap the chunk store's `ObjectClient` with a `latencyObjectClient` applying the same per-request delay.
- **`pkg/storage/factory.go`**: Adds an `ObjectClientDecorator` field to `storage.Config` (`yaml:"-"`) that, if set, wraps every `ObjectClient` after creation. This is a minimal, test-only hook with zero impact on production code paths.

### Usage

```bash
# Simulate 10ms per-request latency (typical S3 same-region)
go test -bench=BenchmarkLogQL -benchmem -storage-latency=10ms -timeout=30m ./pkg/logql/bench/

# Simulate cross-region latency
go test -bench=BenchmarkLogQL -benchmem -storage-latency=50ms -timeout=30m ./pkg/logql/bench/
```

## Checklist

- [x] Tests and lints pass (`go test ./pkg/storage/... ./pkg/logql/bench/...`)
- [x] No production behavior change (`ObjectClientDecorator` defaults to `nil`, `yaml:"-"`)
- [x] Both storage backends covered (dataobj-engine via `objstore.Bucket`, chunk store via `ObjectClient`)
- [x] Verified no storage reads bypass the latency wrappers