### PR TITLE
fix: handle lost partitions in index builders

### DIFF
--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -185,8 +185,9 @@ func NewIndexBuilder(
 		kgo.Balancers(kgo.RoundRobinBalancer()),
 		kgo.RebalanceTimeout(5*time.Minute),
 		kgo.DisableAutoCommit(),
-		kgo.OnPartitionsRevoked(s.handlePartitionsRevoked),
 		kgo.OnPartitionsAssigned(s.handlePartitionsAssigned),
+		kgo.OnPartitionsRevoked(s.handlePartitionsRevoked),
+		kgo.OnPartitionsLost(s.handlePartitionsLost),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kafka consumer client: %w", err)
@@ -229,6 +230,10 @@ func (p *Builder) handlePartitionsRevoked(_ context.Context, _ *kgo.Client, topi
 			}
 		}
 	}
+}
+
+func (p *Builder) handlePartitionsLost(ctx context.Context, client *kgo.Client, topics map[string][]int32) {
+	p.handlePartitionsRevoked(ctx, client, topics)
 }
 
 func (p *Builder) starting(ctx context.Context) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

Partitions can be lost, not just revoked. This happens when there is an error in the Kafka broker, or a timeout in the client that causes the consumer to become disconnected, such that all of its partitions are lost. When this happens, the lost callback is called, not the revoked callback. I think we should implement both callbacks.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
