### PR TITLE
fix: backoff if no records returned, instead of at least one error

### DIFF
--- a/pkg/kafkav2/consumer.go
+++ b/pkg/kafkav2/consumer.go
@@ -122,8 +122,8 @@ func (c *SinglePartitionConsumer) Run(ctx context.Context) error {
 				numRecords++
 			}
 		}
-		fetches.EachError(func(_ string, _ int32, err error) {
-			level.Error(c.logger).Log("msg", "failed to poll fetches", "err", err)
+		fetches.EachError(func(topic string, partition int32, err error) {
+			level.Error(c.logger).Log("msg", "failed to poll fetches", "topic", topic, "partition", partition, "err", err)
 			c.fetchErrors.Inc()
 		})
 		if numRecords == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adjusts the behavior of the consumer to backoff when no records were returned from PollRecords, instead of when there is at least one error. This allows us to continue to consume from all other brokers at maximum rate, instead of backing off just because one broker is returning errors.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
