### PR TITLE
chore(dataobj): rename dataset.ReaderOptions to dataset.RowReaderOptions

### DIFF
--- a/pkg/dataobj/consumer/logsobj/sort.go
+++ b/pkg/dataobj/consumer/logsobj/sort.go
@@ -32,7 +32,7 @@ func sortMergeIterator(ctx context.Context, sections []*dataobj.Section, sort lo
 			return nil, err
 		}
 
-		r := dataset.NewRowReader(dataset.ReaderOptions{
+		r := dataset.NewRowReader(dataset.RowReaderOptions{
 			Dataset:  ds,
 			Columns:  columns,
 			Prefetch: true,

--- a/pkg/dataobj/internal/dataset/row_reader.go
+++ b/pkg/dataobj/internal/dataset/row_reader.go
@@ -14,8 +14,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/xcap"
 )
 
-// ReaderOptions configures how a [RowReader] will read [Row]s.
-type ReaderOptions struct {
+// RowReaderOptions configures how a [RowReader] will read [Row]s.
+type RowReaderOptions struct {
 	Dataset Dataset // Dataset to read from.
 
 	// Columns to read from the Dataset. It is invalid to provide a Column that
@@ -40,7 +40,7 @@ type ReaderOptions struct {
 
 // A RowReader reads [Row]s from a [Dataset].
 type RowReader struct {
-	opts  ReaderOptions
+	opts  RowReaderOptions
 	ready bool // ready is true if the RowReader has been initialized.
 
 	origColumnLookup     map[Column]int // Find the index of a column in opts.Columns.
@@ -55,7 +55,7 @@ type RowReader struct {
 }
 
 // NewRowReader creates a new RowReader from the provided options.
-func NewRowReader(opts ReaderOptions) *RowReader {
+func NewRowReader(opts RowReaderOptions) *RowReader {
 	var r RowReader
 	r.Reset(opts)
 	return &r
@@ -407,7 +407,7 @@ func (r *RowReader) Close() error {
 
 // Reset discards any state and resets the RowReader with a new set of options.
 // This permits reusing a RowReader rather than allocating a new one.
-func (r *RowReader) Reset(opts ReaderOptions) {
+func (r *RowReader) Reset(opts RowReaderOptions) {
 	r.opts = opts
 
 	// There's not much work Reset can do without a context, since it needs to
@@ -487,7 +487,7 @@ func (r *RowReader) secondaryColumns() []Column {
 }
 
 // validatePredicate ensures that all columns used in a predicate have been
-// provided in [ReaderOptions].
+// provided in [RowReaderOptions].
 func (r *RowReader) validatePredicate() error {
 	process := func(c Column) error {
 		_, ok := r.origColumnLookup[c]

--- a/pkg/dataobj/internal/dataset/row_reader_downloader.go
+++ b/pkg/dataobj/internal/dataset/row_reader_downloader.go
@@ -134,7 +134,7 @@ func newRowReaderDownloader(dset Dataset) *rowReaderDownloader {
 // before the downloader is used.
 //
 // AddColumn must be called matching the order of columns in
-// [ReaderOptions.Columns].
+// [RowReaderOptions.Columns].
 func (dl *rowReaderDownloader) AddColumn(col Column, primary bool) {
 	wrappedCol := newReaderColumn(dl, col, primary)
 

--- a/pkg/dataobj/internal/dataset/row_reader_test.go
+++ b/pkg/dataobj/internal/dataset/row_reader_test.go
@@ -22,7 +22,7 @@ import (
 
 func Test_Reader_ReadAll(t *testing.T) {
 	dset, columns := buildTestDataset(t)
-	r := NewRowReader(ReaderOptions{Dataset: dset, Columns: columns})
+	r := NewRowReader(RowReaderOptions{Dataset: dset, Columns: columns})
 	defer r.Close()
 
 	actualRows, err := readDataset(r, 3)
@@ -34,7 +34,7 @@ func Test_Reader_ReadWithPredicate(t *testing.T) {
 	dset, columns := buildTestDataset(t)
 
 	// Create a predicate that only returns people born after 1985
-	r := NewRowReader(ReaderOptions{
+	r := NewRowReader(RowReaderOptions{
 		Dataset: dset,
 		Columns: columns,
 		Predicates: []Predicate{
@@ -64,7 +64,7 @@ func Test_Reader_ReadWithPredicate(t *testing.T) {
 func TestRowReader_ReadWithPageFiltering(t *testing.T) {
 	dset, columns := buildTestDataset(t)
 
-	r := NewRowReader(ReaderOptions{
+	r := NewRowReader(RowReaderOptions{
 		Dataset: dset,
 		Columns: columns,
 
@@ -119,7 +119,7 @@ func TestRowReader_ReadWithPageFilteringOnEmptyPredicate(t *testing.T) {
 	cols, err := result.Collect(dset.ListColumns(context.Background()))
 	require.NoError(t, err)
 
-	r := NewRowReader(ReaderOptions{
+	r := NewRowReader(RowReaderOptions{
 		Dataset: dset,
 		Columns: cols,
 
@@ -161,7 +161,7 @@ func Test_Reader_ReadWithPredicate_NoSecondary(t *testing.T) {
 	dset, columns := buildTestDataset(t)
 
 	// Create a predicate that only returns people born after 1985
-	r := NewRowReader(ReaderOptions{
+	r := NewRowReader(RowReaderOptions{
 		Dataset: dset,
 		Columns: []Column{columns[3]},
 		Predicates: []Predicate{
@@ -193,7 +193,7 @@ func Test_Reader_ReadWithPredicate_NoSecondary(t *testing.T) {
 
 func Test_Reader_Reset(t *testing.T) {
 	dset, columns := buildTestDataset(t)
-	r := NewRowReader(ReaderOptions{Dataset: dset, Columns: columns})
+	r := NewRowReader(RowReaderOptions{Dataset: dset, Columns: columns})
 	defer r.Close()
 
 	// First read everything
@@ -201,7 +201,7 @@ func Test_Reader_Reset(t *testing.T) {
 	require.NoError(t, err)
 
 	// Reset and read again
-	r.Reset(ReaderOptions{Dataset: dset, Columns: columns})
+	r.Reset(RowReaderOptions{Dataset: dset, Columns: columns})
 
 	actualRows, err := readDataset(r, 3)
 	require.NoError(t, err)
@@ -394,7 +394,7 @@ func Test_BuildPredicateRanges(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			r := NewRowReader(ReaderOptions{
+			r := NewRowReader(RowReaderOptions{
 				Dataset:    ds,
 				Columns:    cols,
 				Predicates: []Predicate{tc.predicate},
@@ -543,7 +543,7 @@ func BenchmarkReader(b *testing.B) {
 
 	// Generate dataset once per case
 	ds, cols := generator.Build(b, rand.Int63())
-	opts := ReaderOptions{
+	opts := RowReaderOptions{
 		Dataset: ds,
 		Columns: cols,
 	}
@@ -609,7 +609,7 @@ func BenchmarkPredicateExecution(b *testing.B) {
 	currentPos := 0
 	batch := make([]Row, 1000)
 	// read the dataset once to pick a random row for predicate generation
-	reader := NewRowReader(ReaderOptions{
+	reader := NewRowReader(RowReaderOptions{
 		Dataset: ds,
 		Columns: cols,
 	})
@@ -688,7 +688,7 @@ func BenchmarkPredicateExecution(b *testing.B) {
 			b.ReportAllocs()
 
 			for b.Loop() {
-				reader := NewRowReader(ReaderOptions{
+				reader := NewRowReader(RowReaderOptions{
 					Dataset:    ds,
 					Columns:    cols,
 					Predicates: pp.predicates,
@@ -892,7 +892,7 @@ func Test_DatasetGenerator(t *testing.T) {
 func Test_Reader_Stats(t *testing.T) {
 	dset, columns := buildTestDataset(t)
 
-	r := NewRowReader(ReaderOptions{
+	r := NewRowReader(RowReaderOptions{
 		Dataset: dset,
 		Columns: columns,
 		Predicates: []Predicate{

--- a/pkg/dataobj/sections/indexpointers/iter.go
+++ b/pkg/dataobj/sections/indexpointers/iter.go
@@ -50,7 +50,7 @@ func IterSection(ctx context.Context, section *Section) result.Seq[IndexPointer]
 			return err
 		}
 
-		r := dataset.NewRowReader(dataset.ReaderOptions{
+		r := dataset.NewRowReader(dataset.RowReaderOptions{
 			Dataset:  dset,
 			Columns:  columns,
 			Prefetch: true,

--- a/pkg/dataobj/sections/indexpointers/reader.go
+++ b/pkg/dataobj/sections/indexpointers/reader.go
@@ -215,7 +215,7 @@ func (r *Reader) init() error {
 		return fmt.Errorf("mapping predicates: %w", err)
 	}
 
-	innerOptions := dataset.ReaderOptions{
+	innerOptions := dataset.RowReaderOptions{
 		Dataset:    dset,
 		Columns:    dset.Columns(),
 		Predicates: preds,

--- a/pkg/dataobj/sections/indexpointers/row_reader.go
+++ b/pkg/dataobj/sections/indexpointers/row_reader.go
@@ -96,7 +96,7 @@ func (r *RowReader) initReader() error {
 		predicates = append(predicates, p)
 	}
 
-	readerOpts := dataset.ReaderOptions{
+	readerOpts := dataset.RowReaderOptions{
 		Dataset:    dset,
 		Columns:    columns,
 		Predicates: predicates,

--- a/pkg/dataobj/sections/internal/columnar/columnar_test.go
+++ b/pkg/dataobj/sections/internal/columnar/columnar_test.go
@@ -96,7 +96,7 @@ func readDataset(t *testing.T, obj *dataobj.Object) []dataset.Row {
 	dset, err := columnar.MakeDataset(sec, sec.Columns())
 	require.NoError(t, err)
 
-	reader := dataset.NewRowReader(dataset.ReaderOptions{
+	reader := dataset.NewRowReader(dataset.RowReaderOptions{
 		Dataset: dset,
 		Columns: dset.Columns(),
 	})

--- a/pkg/dataobj/sections/internal/columnar/reader_adapter.go
+++ b/pkg/dataobj/sections/internal/columnar/reader_adapter.go
@@ -22,14 +22,14 @@ type ReaderAdapter struct {
 }
 
 // NewReaderAdapter creates a ReaderAdapter with the provided dataset reader options.
-func NewReaderAdapter(innerOpts dataset.ReaderOptions) *ReaderAdapter {
+func NewReaderAdapter(innerOpts dataset.RowReaderOptions) *ReaderAdapter {
 	r := &ReaderAdapter{inner: dataset.NewRowReader(innerOpts)}
 	r.Reset(innerOpts)
 	return r
 }
 
 // Reset reinitializes the adapter with new reader options.
-func (r *ReaderAdapter) Reset(opts dataset.ReaderOptions) {
+func (r *ReaderAdapter) Reset(opts dataset.RowReaderOptions) {
 	r.inner.Reset(opts)
 
 	slicegrow.GrowToCap(r.colTypes, len(opts.Columns))

--- a/pkg/dataobj/sections/internal/columnar/reader_adapter_test.go
+++ b/pkg/dataobj/sections/internal/columnar/reader_adapter_test.go
@@ -30,7 +30,7 @@ func TestReaderAdapter_ReadPreservesUTF8Nulls(t *testing.T) {
 	require.NoError(t, err)
 
 	dset := dataset.FromMemory([]*dataset.MemColumn{col})
-	reader := NewReaderAdapter(dataset.ReaderOptions{
+	reader := NewReaderAdapter(dataset.RowReaderOptions{
 		Dataset: dset,
 		Columns: []dataset.Column{col},
 	})

--- a/pkg/dataobj/sections/logs/iter.go
+++ b/pkg/dataobj/sections/logs/iter.go
@@ -51,7 +51,7 @@ func IterSection(ctx context.Context, section *Section) result.Seq[Record] {
 			return err
 		}
 
-		r := dataset.NewRowReader(dataset.ReaderOptions{
+		r := dataset.NewRowReader(dataset.RowReaderOptions{
 			Dataset:  dset,
 			Columns:  columns,
 			Prefetch: true,

--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -221,7 +221,7 @@ func (r *Reader) init(_ context.Context) error {
 		return fmt.Errorf("mapping predicates: %w", err)
 	}
 
-	innerOptions := dataset.ReaderOptions{
+	innerOptions := dataset.RowReaderOptions{
 		Dataset:    dset,
 		Columns:    dset.Columns(),
 		Predicates: orderPredicates(preds),

--- a/pkg/dataobj/sections/logs/row_reader.go
+++ b/pkg/dataobj/sections/logs/row_reader.go
@@ -141,7 +141,7 @@ func (r *RowReader) initReader() error {
 		}
 	}
 
-	readerOpts := dataset.ReaderOptions{
+	readerOpts := dataset.RowReaderOptions{
 		Dataset:    dset,
 		Columns:    columns,
 		Predicates: orderPredicates(predicates),

--- a/pkg/dataobj/sections/logs/table_merge.go
+++ b/pkg/dataobj/sections/logs/table_merge.go
@@ -69,7 +69,7 @@ func mergeTables(buf *tableBuffer, pageSize, pageRowCount int, compressionOpts *
 			return nil, err
 		}
 
-		r := dataset.NewRowReader(dataset.ReaderOptions{
+		r := dataset.NewRowReader(dataset.RowReaderOptions{
 			Dataset: t,
 			Columns: dsetColumns,
 

--- a/pkg/dataobj/sections/logs/table_test.go
+++ b/pkg/dataobj/sections/logs/table_test.go
@@ -109,7 +109,7 @@ func Test_mergeTables(t *testing.T) {
 
 			var actual []string
 
-			r := dataset.NewRowReader(dataset.ReaderOptions{
+			r := dataset.NewRowReader(dataset.RowReaderOptions{
 				Dataset: mergedTable,
 				Columns: mergedColumns,
 			})
@@ -155,7 +155,7 @@ func Test_table_backfillMetadata(t *testing.T) {
 	columns, err := result.Collect(table.ListColumns(context.Background()))
 	require.NoError(t, err)
 
-	r := dataset.NewRowReader(dataset.ReaderOptions{
+	r := dataset.NewRowReader(dataset.RowReaderOptions{
 		Dataset: table,
 		Columns: columns,
 	})

--- a/pkg/dataobj/sections/pointers/iter.go
+++ b/pkg/dataobj/sections/pointers/iter.go
@@ -51,7 +51,7 @@ func IterSection(ctx context.Context, section *Section) result.Seq[SectionPointe
 			return err
 		}
 
-		r := dataset.NewRowReader(dataset.ReaderOptions{
+		r := dataset.NewRowReader(dataset.RowReaderOptions{
 			Dataset:  dset,
 			Columns:  columns,
 			Prefetch: true,

--- a/pkg/dataobj/sections/pointers/reader.go
+++ b/pkg/dataobj/sections/pointers/reader.go
@@ -222,7 +222,7 @@ func (r *Reader) init() error {
 		return fmt.Errorf("mapping predicates: %w", err)
 	}
 
-	innerOptions := dataset.ReaderOptions{
+	innerOptions := dataset.RowReaderOptions{
 		Dataset:    dset,
 		Columns:    dset.Columns(),
 		Predicates: preds,
@@ -474,7 +474,7 @@ type recordBatchLabelDecorator struct {
 	streamIDColumnIndex  int
 }
 
-func newRecordBatchLabelDecorator(inner *columnar.ReaderAdapter, innerOpts dataset.ReaderOptions, opts ReaderOptions) *recordBatchLabelDecorator {
+func newRecordBatchLabelDecorator(inner *columnar.ReaderAdapter, innerOpts dataset.RowReaderOptions, opts ReaderOptions) *recordBatchLabelDecorator {
 	d := &recordBatchLabelDecorator{inner: inner}
 	d.Reset(innerOpts, opts)
 	return d
@@ -484,7 +484,7 @@ func (d *recordBatchLabelDecorator) Close() error {
 	return d.inner.Close()
 }
 
-func (d *recordBatchLabelDecorator) Reset(innerOpts dataset.ReaderOptions, opts ReaderOptions) {
+func (d *recordBatchLabelDecorator) Reset(innerOpts dataset.RowReaderOptions, opts ReaderOptions) {
 	d.inner.Reset(innerOpts)
 
 	d.streamIDColumnIndex = -1

--- a/pkg/dataobj/sections/pointers/row_reader.go
+++ b/pkg/dataobj/sections/pointers/row_reader.go
@@ -129,7 +129,7 @@ func (r *RowReader) initReader() error {
 		predicates = append(predicates, p)
 	}
 
-	readerOpts := dataset.ReaderOptions{
+	readerOpts := dataset.RowReaderOptions{
 		Dataset:    dset,
 		Columns:    columns,
 		Predicates: predicates,

--- a/pkg/dataobj/sections/streams/iter.go
+++ b/pkg/dataobj/sections/streams/iter.go
@@ -92,7 +92,7 @@ func iterSection(ctx context.Context, section *Section, cfg iterConfig) result.S
 			return err
 		}
 
-		r := dataset.NewRowReader(dataset.ReaderOptions{
+		r := dataset.NewRowReader(dataset.RowReaderOptions{
 			Dataset:  dset,
 			Columns:  columns,
 			Prefetch: true,

--- a/pkg/dataobj/sections/streams/reader.go
+++ b/pkg/dataobj/sections/streams/reader.go
@@ -221,7 +221,7 @@ func (r *Reader) init() error {
 		return fmt.Errorf("mapping predicates: %w", err)
 	}
 
-	innerOptions := dataset.ReaderOptions{
+	innerOptions := dataset.RowReaderOptions{
 		Dataset:    dset,
 		Columns:    dset.Columns(),
 		Predicates: preds,

--- a/pkg/dataobj/sections/streams/row_reader.go
+++ b/pkg/dataobj/sections/streams/row_reader.go
@@ -99,7 +99,7 @@ func (r *RowReader) initReader() error {
 		predicates = append(predicates, p)
 	}
 
-	readerOpts := dataset.ReaderOptions{
+	readerOpts := dataset.RowReaderOptions{
 		Dataset:    dset,
 		Columns:    columns,
 		Predicates: predicates,


### PR DESCRIPTION
grafana/loki#20629 renamed dataset.Reader to dataset.RowReader to make room for the new columnar dataset.Reader implementation, but it didn't rename dataset.ReaderOptions.

This commit completes the rename by changing dataset.ReaderOptions to dataset.RowReaderOptions.