### PR TITLE
fix(dataobj-inspect): Enhance dump and list-streams commands

### DIFF
--- a/cmd/dataobj-inspect/go.mod
+++ b/cmd/dataobj-inspect/go.mod
@@ -1,4 +1,4 @@
-module github.com/grafana/loki/cmd/index
+module github.com/grafana/loki/cmd/dataobj-inspect
 
 go 1.25.5
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I tried to use the tool to investigate some data, and found some enhancements made it more useful.

In `list-streams`, store the tenant and print it along with the ID and min/max times of the stream.  
(the "fix" part is that previously IDs were collected from all tenants and it was unspecified which one was shown)
Format labels more neatly. Allow the user to list streams for just one tenant.

Example:

    tenant: 29, id: 1, from: 2026-02-04 18:18:20, to: 2026-02-04 18:34:09, labels: {job="kube-system/calico-typha", k8s_app="calico-typha", stream="stdout"}

In `dump`, allow the user to narrow the dump to a specific tenant and/or stream ID.

Also fixed the module name in `go.mod` to match the name of the utility.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- NA Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- NA If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
