### PR TITLE
chore: use kafkav2 package in index builders

### DIFF
--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/kafka"
 	"github.com/grafana/loki/v3/pkg/kafka/client"
+	"github.com/grafana/loki/v3/pkg/kafkav2"
 	"github.com/grafana/loki/v3/pkg/scratch"
 )
 
@@ -89,8 +90,10 @@ type Builder struct {
 	mCfg metastore.Config
 
 	// Kafka client and topic/partition info
-	client kafkaClient
-	topic  string
+	client   kafkaClient
+	records  chan *kgo.Record
+	consumer *kafkav2.GroupConsumer
+	topic    string
 
 	// Indexer handles all index building
 	indexer indexer
@@ -154,6 +157,7 @@ func NewIndexBuilder(
 		metrics:            builderMetrics,
 		partitionStates:    make(map[int32]*partitionState),
 		activeCalculations: make(map[int32]context.CancelCauseFunc),
+		records:            make(chan *kgo.Record),
 	}
 
 	// Create self-contained indexer
@@ -178,7 +182,6 @@ func NewIndexBuilder(
 		kafkaCfg,
 		logger,
 		reg,
-		kgo.ConsumeTopics(kafkaCfg.Topic),
 		kgo.InstanceID(instanceID),
 		kgo.SessionTimeout(3*time.Minute),
 		kgo.ConsumerGroup(consumerGroup),
@@ -193,6 +196,14 @@ func NewIndexBuilder(
 		return nil, fmt.Errorf("failed to create kafka consumer client: %w", err)
 	}
 	s.client = eventConsumerClient
+
+	s.consumer = kafkav2.NewGroupConsumer(
+		eventConsumerClient,
+		kafkaCfg.Topic,
+		s.records,
+		logger,
+		prometheus.WrapRegistererWithPrefix("loki_index_builder_", reg),
+	)
 
 	s.Service = services.NewBasicService(s.starting, s.running, s.stopping)
 
@@ -240,11 +251,12 @@ func (p *Builder) handlePartitionsLost(ctx context.Context, client *kgo.Client, 
 }
 
 func (p *Builder) starting(ctx context.Context) error {
-	// Start indexer service first
-	if err := services.StartAndAwaitRunning(ctx, p.indexer); err != nil {
-		return fmt.Errorf("failed to start indexer service: %w", err)
+	if err := services.StartAndAwaitRunning(ctx, p.consumer); err != nil {
+		return fmt.Errorf("failed to start consumer: %w", err)
 	}
-
+	if err := services.StartAndAwaitRunning(ctx, p.indexer); err != nil {
+		return fmt.Errorf("failed to start indexer: %w", err)
+	}
 	// Start flush worker if configured
 	if p.cfg.FlushInterval > 0 {
 		p.flushTicker = time.NewTicker(p.cfg.FlushInterval)
@@ -267,42 +279,20 @@ func (p *Builder) starting(ctx context.Context) error {
 }
 
 func (p *Builder) running(ctx context.Context) error {
-	// Main Kafka processing loop
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		fetches := p.client.PollRecords(ctx, -1)
-		if err := fetches.Err0(); err != nil {
-			if errors.Is(err, kgo.ErrClientClosed) || errors.Is(err, context.Canceled) {
-				return err
-			}
-			// Some other error occurred. We will check it in
-			// [processFetchTopicPartition] instead.
-		}
-		if fetches.Empty() {
-			continue
-		}
-		fetches.EachPartition(func(fetch kgo.FetchTopicPartition) {
-			if err := fetch.Err; err != nil {
-				level.Error(p.logger).Log("msg", "failed to fetch records for topic partition", "topic", fetch.Topic, "partition", fetch.Partition, "err", err.Error())
-				return
-			}
-			for _, record := range fetch.Records {
-				p.processRecord(ctx, record)
-			}
-		})
+	for rec := range p.records {
+		p.processRecord(ctx, rec)
 	}
+	return nil
 }
 
 func (p *Builder) stopping(failureCase error) error {
 	// Stop indexer service first - this handles calculation cleanup via context cancelation.
 	ctx := context.TODO()
+	if err := services.StopAndAwaitTerminated(ctx, p.consumer); err != nil {
+		return fmt.Errorf("failed to stop consumer: %w", err)
+	}
 	if err := services.StopAndAwaitTerminated(ctx, p.indexer); err != nil {
-		level.Error(p.logger).Log("msg", "failed to stop indexer", "err", err)
+		return fmt.Errorf("failed to stop indexer: %w", err)
 	}
 
 	// Stop other components


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit uses the `kafkav2` package in index builders to re-use shared logic around error handling and fetches.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
