### PR TITLE
fix: fluent bit build with go 1.25

### DIFF
--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.34.6
+ARG BUILD_IMAGE=grafana/loki-build-image:0.34.10
 ARG GOARCH=amd64
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:

--- a/clients/cmd/fluent-bit/Dockerfile
+++ b/clients/cmd/fluent-bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-bullseye AS builder
+FROM golang:1.25-bookworm AS builder
 
 COPY . /src
 


### PR DESCRIPTION
Followup to https://github.com/grafana/loki/commit/502f046fab0e83a9e70e588a9d1ac7c823e7d332
CI was still failing with
```
0.057 go: go.mod requires go >= 1.25.0 (running go 1.24.6; GOTOOLCHAIN=local)
```