### PR TITLE
chore(operator): introduced dynamic VERSION to olm commands

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -259,15 +259,12 @@ OLM_VERSION ?= $(DEV_VERSION)
 # Build and push the bundle image to a container registry.
 .PHONY: olm-deploy-bundle
 olm-deploy-bundle:
-	$(MAKE) bundle VERSION=$(OLM_VERSION)
-	$(MAKE) bundle-build VERSION=$(OLM_VERSION)
-	$(MAKE) oci-push IMG=$(OLM_BUNDLE_IMG)
+	$(MAKE) bundle bundle-build oci-push VERSION=$(OLM_VERSION) IMG=$(OLM_BUNDLE_IMG)
 
 # Build and push the operator image to a container registry.
 .PHONY: olm-deploy-operator
 olm-deploy-operator:
-	$(MAKE) oci-build IMG=$(OLM_IMG)
-	$(MAKE) oci-push IMG=$(OLM_IMG)
+	$(MAKE) oci-build oci-push IMG=$(OLM_IMG)
 
 .PHONY: olm-deploy
 ifeq ($(or $(findstring openshift-logging,$(OLM_IMG)),$(findstring openshift-logging,$(OLM_BUNDLE_IMG))),openshift-logging)


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes it so during development we don't have to specify a VERSION in `make olm-+*` commands

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
