### PR TITLE
chore: Add S3 bucket configuration function for querycomparator

### DIFF
--- a/tools/querycomparator/compare.go
+++ b/tools/querycomparator/compare.go
@@ -37,7 +37,6 @@ func addCompareCommand(app *kingpin.Application) {
 	cmd.Flag("host2", "Second Loki host").Default("localhost:3102").StringVar(&host2)
 
 	cmd.Action(func(_ *kingpin.ParseContext) error {
-		storageBucket = cfg.Bucket
 		orgID = cfg.OrgID
 
 		parsed, err := parseTimeConfig(&cfg)

--- a/tools/querycomparator/config.go
+++ b/tools/querycomparator/config.go
@@ -47,7 +47,6 @@ func parseTimeConfig(cfg *Config) (*ParsedConfig, error) {
 
 // Global variables for bucket and org ID (used by storage functions)
 var (
-	storageBucket      string
 	orgID              string
 	indexStoragePrefix string
 	logger             log.Logger

--- a/tools/querycomparator/main_test.go
+++ b/tools/querycomparator/main_test.go
@@ -9,22 +9,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDebugCmd(t *testing.T) {
+func TestQueryComparatorCmd(t *testing.T) {
 	t.Skip("Test for debugging purposes only")
 
-	storageBucket = ""      // TODO: set bucket name for local engine support
-	indexStoragePrefix = "" // TODO: set index storage prefix for local engine support
-	orgID = ""              // TODO: set org ID for querying remote instances
+	bucket := MustGCSDataobjBucket("")
+	orgID = "" // TODO: set org ID for querying remote instances
 
-	start := time.Date(2025, 10, 24, 0, 0, 0, 0, time.UTC)
-	end := start.Add(45 * time.Minute)
-	query := "{namespace=\"test\"}"
+	start := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(1 * time.Minute)
+	query := `{container="distributor"}`
 
 	params, err := logql.NewLiteralParams(query, start, end, 0, 0, logproto.BACKWARD, 1000, nil, nil)
 	require.NoError(t, err)
 
 	// Run subcommands as necessary
 	require.NoError(t, doComparison(params, "localhost:3101", "localhost:3102"))
-	require.NoError(t, queryMetastore(params))
-	require.NoError(t, doExecuteLocallyV2(params))
+	require.NoError(t, queryMetastore(params, bucket))
+	require.NoError(t, doExecuteLocallyV2SchedulerRemote(params, bucket))
 }

--- a/tools/querycomparator/storage.go
+++ b/tools/querycomparator/storage.go
@@ -5,15 +5,44 @@ import (
 	"log"
 
 	glog "github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/loki/v3/pkg/storage/bucket/gcs"
+	"github.com/grafana/loki/v3/pkg/storage/bucket/s3"
 	"github.com/thanos-io/objstore"
 )
 
-// MustDataobjBucket creates a GCS bucket client for dataobj storage
-func MustDataobjBucket() objstore.Bucket {
+// MustS3DataobjBucket creates a S3 bucket client for dataobj storage
+// The access key id, secret access key, and session token are required for S3 dataobj bucket and must be provided.
+// The region endpoint follows the format "s3.<aws region name>.amazonaws.com" e.g. "s3.eu-south-2.amazonaws.com".
+func MustS3DataobjBucket(bucketName string, regionEndpoint string) objstore.Bucket {
+	accessKeyID := ""
+	secretAccessKey := ""
+	sessionToken := ""
+
+	if accessKeyID == "" || secretAccessKey == "" || sessionToken == "" {
+		log.Fatal("access key id, secret access key, and session token are required for S3 dataobj bucket")
+	}
+
+	bkt, err := s3.NewBucketClient(s3.Config{
+		Endpoint:        regionEndpoint,
+		BucketName:      bucketName,
+		AccessKeyID:     accessKeyID,
+		SecretAccessKey: flagext.SecretWithValue(secretAccessKey),
+		SessionToken:    flagext.SecretWithValue(sessionToken),
+	}, "querycomparator", glog.NewNopLogger(), nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	prefixedBkt := objstore.NewPrefixedBucket(bkt, "dataobj")
+	return prefixedBkt
+}
+
+// MustGCSDataobjBucket creates a GCS bucket client for dataobj storage
+func MustGCSDataobjBucket(bucketName string) objstore.Bucket {
 	bkt, err := gcs.NewBucketClient(context.Background(), gcs.Config{
-		BucketName: storageBucket,
-	}, "testing", glog.NewNopLogger(), nil)
+		BucketName: bucketName,
+	}, "querycomparator", glog.NewNopLogger(), nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -21,11 +50,11 @@ func MustDataobjBucket() objstore.Bucket {
 	return objBucket
 }
 
-// MustRawBucket creates a GCS bucket client for raw storage
-func MustRawBucket() objstore.Bucket {
+// MustRawGCSBucket creates a GCS bucket client for raw storage
+func MustRawGCSBucket(bucketName string) objstore.Bucket {
 	bkt, err := gcs.NewBucketClient(context.Background(), gcs.Config{
-		BucketName: storageBucket,
-	}, "testing", glog.NewNopLogger(), nil)
+		BucketName: bucketName,
+	}, "querycomparator", glog.NewNopLogger(), nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds some functions to the querycomparator to setup a connection to S3.
The command line utility itself lacks a cloud-provider flag, so it just defaults to GCS for now. S3 can be setup by editing the custom test in main_test.go