### PR TITLE
docs: Add SSD Deprecation notices

### DIFF
--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -23,7 +23,7 @@ To collect logs and view your log data generally involves the following steps:
 
 ![Loki implementation steps](loki-install.png)
 
-1. Install Loki on Kubernetes in simple scalable mode, using the recommended [Helm chart](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/install-scalable/).
+1. Install Loki on Kubernetes in monolithic (single-binary) mode, using the recommended [Helm chart](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/install-monolithic/).
    Supply the Helm chart with your object storage authentication details.
    - [Storage options](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/)
    - [Configuration reference](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/)

--- a/docs/sources/get-started/deployment-modes.md
+++ b/docs/sources/get-started/deployment-modes.md
@@ -30,6 +30,10 @@ Query parallelization is limited by the number of instances and the setting `max
 
 ## Simple Scalable
 
+{{< admonition type="note" >}}
+Simple Scalable Deployment (SSD) mode is being deprecated. The timeline for the deprecation is to be determined (TBD), but will happen before Loki 4.0 is released.
+{{< /admonition >}}
+
 The simple scalable deployment is the default configuration installed by the [Loki Helm Chart](../../setup/install/helm/). This deployment mode is the easiest way to deploy Loki at scale. It strikes a balance between deploying in [monolithic mode](#monolithic-mode) or deploying each component as a [separate microservice](#microservices-mode). Simple scalable deployment is also referred to as SSD.
 
 {{< admonition type="note" >}}

--- a/docs/sources/setup/install/helm/_index.md
+++ b/docs/sources/setup/install/helm/_index.md
@@ -29,7 +29,7 @@ Loki is designed to be run in two states:
 * [Microservices](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/deployment-modes/#microservices-mode): For workloads that require high availability and scalability. Loki is deployed in this mode internally at Grafana Labs.
 
 {{< admonition type="tip" >}}
-Loki can also be deployed in [Simple Scalable mode](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/deployment-modes/#simple-scalable). For the best possible experience in production, we recommend deploying Loki in *microservices* mode.
+Loki can also be deployed in [Simple Scalable mode](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/deployment-modes/#simple-scalable). But Simple Scalable Deployment (SSD) mode is being deprecated. For the best possible experience in production, we recommend deploying Loki in *microservices* mode.
 {{< /admonition >}}
 
 ## Cloud Deployment Guides

--- a/docs/sources/setup/install/helm/concepts.md
+++ b/docs/sources/setup/install/helm/concepts.md
@@ -22,7 +22,11 @@ The Loki chart supports three methods of deployment:
 - [Simple Scalable](../install-scalable/)
 - [Microservice](../install-microservices/)
 
-By default, the chart installs in [Simple Scalable](../install-scalable/) mode. This is the recommended method for most users. To understand the differences between deployment methods, see the [Loki deployment modes](../../../../get-started/deployment-modes/) documentation.
+By default, the chart installs in [Simple Scalable](../install-scalable/) mode. For the best possible experience in production, we now recommend deploying Loki in *microservices* mode. To understand the differences between deployment methods, see the [Loki deployment modes](../../../../get-started/deployment-modes/) documentation.
+
+{{< admonition type="note" >}}
+Simple Scalable Deployment (SSD) mode is being deprecated. The timeline for the deprecation is to be determined (TBD), but will happen before Loki 4.0 is released.
+{{< /admonition >}}
 
 ## Monitoring Loki
 

--- a/docs/sources/setup/install/helm/install-scalable/_index.md
+++ b/docs/sources/setup/install/helm/install-scalable/_index.md
@@ -11,11 +11,16 @@ keywords:
 
 # Install the simple scalable Helm chart
 
+{{< admonition type="note" >}}
+Simple Scalable Deployment (SSD) mode is being deprecated. The timeline for the deprecation is to be determined (TBD), but will happen before Loki 4.0 is released.
+{{< /admonition >}}
+
 This Helm Chart deploys Grafana Loki in [simple scalable mode](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/deployment-modes/#simple-scalable) within a Kubernetes cluster.
 
-This chart configures Loki to run `read`, `write`, and `backend` targets in a [scalable mode](../../../../get-started/deployment-modes/#simple-scalable). Loki’s simple scalable deployment mode separates execution paths into read, write, and backend targets.
+This chart configures Loki to run `read`, `write`, and `backend` targets in a [scalable mode](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/deployment-modes/#simple-scalable). Loki’s simple scalable deployment mode separates execution paths into read, write, and backend targets.
 
 The default Helm chart deploys the following components:
+
 - Read component (3 replicas)
 - Write component (3 replicas)
 - Backend component (3 replicas)
@@ -25,7 +30,7 @@ The default Helm chart deploys the following components:
 - Index and Chunk cache (1 replica)
 
 {{< admonition type="note" >}}
-We do not recommended running scalable mode with `filesystem` storage. For the purpose of this guide, we will use MinIO as the object storage to provide a complete example. 
+We do not recommended running scalable mode with `filesystem` storage. For the purpose of this guide, we will use MinIO as the object storage to provide a complete example.
 {{< /admonition >}}
 
 ## Prerequisites
@@ -37,20 +42,19 @@ We do not recommended running scalable mode with `filesystem` storage. For the p
 
 The following steps show how to deploy the Loki Helm chart in simple scalable mode using the included MinIO as the storage backend. Our recommendation is to start here for development and testing purposes. Then configure Loki with an object storage provider when moving to production.
 
-
 1. Add [Grafana's chart repository](https://github.com/grafana/helm-charts) to Helm:
 
    ```bash
    helm repo add grafana https://grafana.github.io/helm-charts
    ```
 
-2. Update the chart repository:
+1. Update the chart repository:
 
    ```bash
    helm repo update
    ```
 
-3. Create the configuration file `values.yaml`. The example below illustrates how to deploy Loki in test mode using MinIO as storage:
+1. Create the configuration file `values.yaml`. The example below illustrates how to deploy Loki in test mode using MinIO as storage:
 
     ```yaml
       loki:
@@ -94,14 +98,17 @@ The following steps show how to deploy the Loki Helm chart in simple scalable mo
 
 1. Install or upgrade the Loki deployment.
 
-     - To install:
-        ```bash
-       helm install --values values.yaml loki grafana/loki
-       ```
-    - To upgrade:
-       ```bash
-       helm upgrade --values values.yaml loki grafana/loki
-       ```
+ - To install:
+
+   ```bash
+   helm install --values values.yaml loki grafana/loki
+   ```
+
+ - To upgrade:
+
+   ```bash
+   helm upgrade --values values.yaml loki grafana/loki
+   ```
 
 ## Object Storage Configuration
 
@@ -238,12 +245,13 @@ write:
 minio:
   enabled: false
 
+```
 
-``` 
 {{< /collapse >}}
 
-To configure other storage providers, refer to the [Helm Chart Reference](../reference/).
+To configure other storage providers, refer to the [Helm Chart Reference](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/reference/).
 
-## Next Steps 
-* Configure an agent to [send log data to Loki](/docs/loki/<LOKI_VERSION>/send-data/).
-* Monitor the Loki deployment using the [Meta Monitoring Helm chart](/docs/loki/<LOKI_VERSION>/setup/install/helm/monitor-and-alert/)
+## Next Steps
+
+* Configure an agent to [send log data to Loki](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/).
+* Monitor the Loki deployment using the [Meta Monitoring Helm chart](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/monitor-and-alert/)

--- a/docs/sources/setup/upgrade/upgrade-to-6x/index.md
+++ b/docs/sources/setup/upgrade/upgrade-to-6x/index.md
@@ -15,6 +15,11 @@ v6.x of this chart introduces distributed mode but also introduces breaking chan
 If you have not yet [migrated to TSDB](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/migrate/migrate-to-tsdb/), perform that migration before you upgrade your Loki Helm chart to v6.x.
 {{< /admonition >}}
 
+{{< admonition type="note" >}}
+Simple Scalable Deployment (SSD) mode is being deprecated. The timeline for the deprecation is to be determined (TBD), but will happen before Loki 4.0 is released. When you upgrade to Loki 3.x, you should choose either monolithic (single-binary) or microservices (distributed) as your [deployment mode](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/deployment-modes/).
+{{< /admonition >}}
+
+
 ### Changes
 
 #### BREAKING: `deploymentMode` setting


### PR DESCRIPTION
**What this PR does / why we need it**:
We've already announced that simple scalable deployment (SSD) mode is deprecated in the Helm Charts [CHANGELOG](https://grafana.com/docs/loki/latest/get-started/deployment-modes/) and in the [Loki Release Notes](https://grafana.com/docs/loki/latest/release-notes/v3-6/#deprecations).  

This PR adds notes where appropriate in the documentation but does NOT remove documentation for SSD.