### PR TITLE
refactor(engine): introduce Pipeline.Open method

### DIFF
--- a/pkg/engine/basic_engine.go
+++ b/pkg/engine/basic_engine.go
@@ -264,6 +264,10 @@ func IsQuerySupported(params logql.Params) bool {
 }
 
 func collectResult(ctx context.Context, pipeline executor.Pipeline, builder ResultBuilder) error {
+	if err := pipeline.Open(ctx); err != nil {
+		return err
+	}
+
 	for {
 		rec, err := pipeline.Read(ctx)
 		if err != nil {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -391,6 +391,10 @@ func (e *Engine) metastoreSectionsResolver(ctx context.Context, tenantID string)
 		reader := executor.TranslateEOF(pipeline)
 		defer reader.Close()
 
+		if err := reader.Open(ctx); err != nil {
+			return nil, fmt.Errorf("metastore: open pipeline: %w", err)
+		}
+
 		resp, err := e.metastore.CollectSections(ctx, metastore.CollectSectionsRequest{
 			// externalize EOFs returned by executor pipelines (executor.EOF -> io.EOF)
 			// because metastore is not aware about executor implementation details
@@ -466,6 +470,10 @@ func (e *Engine) collectResult(ctx context.Context, logger log.Logger, params lo
 		// This should never trigger since we already checked the expression
 		// type in the logical planner.
 		panic(fmt.Sprintf("invalid expression type %T", params.GetExpression()))
+	}
+
+	if err := pipeline.Open(ctx); err != nil {
+		return nil, time.Duration(0), err
 	}
 
 	for {

--- a/pkg/engine/internal/executor/merge.go
+++ b/pkg/engine/internal/executor/merge.go
@@ -52,6 +52,16 @@ func newMergePipeline(inputs []Pipeline, maxPrefetch int, region *xcap.Region) (
 	}, nil
 }
 
+// Open opens all children pipelines.
+func (m *Merge) Open(ctx context.Context) error {
+	for _, p := range m.inputs {
+		if err := p.Open(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (m *Merge) init(ctx context.Context) {
 	if m.initialized {
 		return

--- a/pkg/engine/internal/executor/merge_test.go
+++ b/pkg/engine/internal/executor/merge_test.go
@@ -67,9 +67,10 @@ func TestMerge(t *testing.T) {
 			defer m.Close()
 
 			ctx := t.Context()
-			var actualRows []arrowtest.Rows
+			require.NoError(t, m.Open(ctx))
 
 			// Read all records from the merge pipeline
+			var actualRows []arrowtest.Rows
 			for {
 				rec, err := m.Read(ctx)
 				if errors.Is(err, EOF) {

--- a/pkg/engine/internal/executor/metastore.go
+++ b/pkg/engine/internal/executor/metastore.go
@@ -14,6 +14,10 @@ type metastorePipeline struct {
 	region *xcap.Region
 }
 
+func (m *metastorePipeline) Open(_ context.Context) error {
+	return nil
+}
+
 func (m *metastorePipeline) Read(ctx context.Context) (arrow.RecordBatch, error) {
 	rec, err := m.reader.Read(xcap.ContextWithRegion(ctx, m.region))
 	// metastore reader returns io.EOF that we translate to executor.EOF

--- a/pkg/engine/internal/executor/pipeline_utils.go
+++ b/pkg/engine/internal/executor/pipeline_utils.go
@@ -22,6 +22,9 @@ func NewBufferedPipeline(records ...arrow.RecordBatch) *BufferedPipeline {
 	}
 }
 
+// Open implements Pipeline.
+func (p *BufferedPipeline) Open(_ context.Context) error { return nil }
+
 // Read implements Pipeline.
 // It advances to the next record and returns EOF when all records have been read.
 func (p *BufferedPipeline) Read(_ context.Context) (arrow.RecordBatch, error) {

--- a/pkg/engine/internal/executor/pipeline_utils_test.go
+++ b/pkg/engine/internal/executor/pipeline_utils_test.go
@@ -18,6 +18,9 @@ func AssertPipelinesEqual(t testing.TB, left, right Pipeline) {
 	defer left.Close()
 	defer right.Close()
 
+	require.NoError(t, left.Open(ctx))
+	require.NoError(t, right.Open(ctx))
+
 	var (
 		leftBatch, rightBatch   arrow.RecordBatch
 		leftPos, rightPos       int64

--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -114,6 +114,16 @@ func (r *rangeAggregationPipeline) init() {
 	r.aggregator.SetMaxSeries(r.opts.maxQuerySeries)
 }
 
+// Open opens all input pipelines.
+func (r *rangeAggregationPipeline) Open(ctx context.Context) error {
+	for _, input := range r.inputs {
+		if err := input.Open(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Read reads the next value into its state.
 // It returns an error if reading fails or when the pipeline is exhausted. In this case, the function returns EOF.
 // The implementation must retain the returned error in its state and return it with subsequent Value() calls.

--- a/pkg/engine/internal/executor/topk.go
+++ b/pkg/engine/internal/executor/topk.go
@@ -127,6 +127,16 @@ func guessLokiType(ref types.ColumnRef) (types.DataType, error) {
 	}
 }
 
+// Open opens all input pipelines.
+func (p *topkPipeline) Open(ctx context.Context) error {
+	for _, in := range p.inputs {
+		if err := in.Open(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Read computes the topk as the next record. Read blocks until all input
 // pipelines have been fully read and the top K rows have been computed.
 func (p *topkPipeline) Read(ctx context.Context) (arrow.RecordBatch, error) {

--- a/pkg/engine/internal/executor/translate_errors.go
+++ b/pkg/engine/internal/executor/translate_errors.go
@@ -16,6 +16,10 @@ type translateEOFPipeline struct {
 	pipeline Pipeline
 }
 
+func (p translateEOFPipeline) Open(ctx context.Context) error {
+	return p.pipeline.Open(ctx)
+}
+
 func (p translateEOFPipeline) Close() {
 	p.pipeline.Close()
 }

--- a/pkg/engine/internal/executor/vector_aggregate.go
+++ b/pkg/engine/internal/executor/vector_aggregate.go
@@ -88,6 +88,16 @@ func newVectorAggregationPipeline(inputs []Pipeline, evaluator *expressionEvalua
 	}, nil
 }
 
+// Open opens all input pipelines.
+func (v *vectorAggregationPipeline) Open(ctx context.Context) error {
+	for _, input := range v.inputs {
+		if err := input.Open(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Read reads the next value into its state.
 func (v *vectorAggregationPipeline) Read(ctx context.Context) (arrow.RecordBatch, error) {
 	if v.inputsExhausted {

--- a/pkg/engine/internal/worker/error_pipeline.go
+++ b/pkg/engine/internal/worker/error_pipeline.go
@@ -13,6 +13,8 @@ type errorPipeline []error
 
 var _ executor.Pipeline = errorPipeline(nil)
 
+func (ep errorPipeline) Open(_ context.Context) error { return nil }
+
 func (ep errorPipeline) Read(_ context.Context) (arrow.RecordBatch, error) {
 	return nil, errors.Join(ep...)
 }

--- a/pkg/engine/internal/worker/node_source.go
+++ b/pkg/engine/internal/worker/node_source.go
@@ -30,6 +30,11 @@ type nodeSource struct {
 
 var _ executor.Pipeline = (*nodeSource)(nil)
 
+func (src *nodeSource) Open(_ context.Context) error {
+	src.lazyInit()
+	return nil
+}
+
 // Read returns the next record of the node data. Blocks until results are
 // available or until the provided ctx is canceled.
 func (src *nodeSource) Read(ctx context.Context) (arrow.RecordBatch, error) {

--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -268,6 +268,10 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 func (t *thread) drainPipeline(ctx context.Context, pipeline executor.Pipeline, job *threadJob, logger log.Logger) (int, error) {
 	region := xcap.RegionFromContext(ctx)
 
+	if err := pipeline.Open(ctx); err != nil {
+		return 0, err
+	}
+
 	var totalRows int
 	for {
 		rec, err := pipeline.Read(ctx)

--- a/pkg/engine/internal/workflow/stream_pipe.go
+++ b/pkg/engine/internal/workflow/stream_pipe.go
@@ -37,6 +37,8 @@ func newStreamPipe() *streamPipe {
 	}
 }
 
+func (pipe *streamPipe) Open(_ context.Context) error { return nil }
+
 // Read returns the next record of the stream data. Blocks until results are
 // available or until the provided ctx is canceled.
 func (pipe *streamPipe) Read(ctx context.Context) (arrow.RecordBatch, error) {

--- a/pkg/engine/internal/workflow/workflow.go
+++ b/pkg/engine/internal/workflow/workflow.go
@@ -468,6 +468,10 @@ type wrappedPipeline struct {
 	onClose func()
 }
 
+func (p *wrappedPipeline) Open(ctx context.Context) error {
+	return p.inner.Open(ctx)
+}
+
 func (p *wrappedPipeline) Read(ctx context.Context) (arrow.RecordBatch, error) {
 	return p.inner.Read(ctx)
 }

--- a/pkg/engine/internal/workflow/workflow_test.go
+++ b/pkg/engine/internal/workflow/workflow_test.go
@@ -536,6 +536,8 @@ type runnerTask struct {
 
 type noopPipeline struct{}
 
+func (noopPipeline) Open(context.Context) error { return nil }
+
 func (noopPipeline) Read(ctx context.Context) (arrow.RecordBatch, error) {
 	<-ctx.Done()
 	return nil, ctx.Err()


### PR DESCRIPTION
Add Pipeline.Open to separate initialization from read execution. This prepares the engine for separate concurrency controls for I/O-heavy initialization and compute-heavy reads.

Pipeline.Open must be called before Pipeline.Read, which will now return an error if this constraint isn't met. All call sites have been updated to follow this.

Code in pkg/dataobj continues to lazily initialize on the first call to read. That read path will be updated separately, as it's going to be a similarly large change. 