### PR TITLE
chore: fix panic on read err in batchDecoratorReader

### DIFF
--- a/pkg/dataobj/sections/pointers/reader.go
+++ b/pkg/dataobj/sections/pointers/reader.go
@@ -528,7 +528,7 @@ func (d *recordBatchLabelDecorator) read(ctx context.Context, alloc *memoryv2.Al
 	// Any error, err, is returned to the caller to handle.
 	// The decorator must always decorate rb, so it must not short circuit.
 
-	if d.streamIDColumnIndex == -1 {
+	if d.streamIDColumnIndex == -1 || rb == nil {
 		// We aren't reading any stream IDs this time
 		return rb, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This should fix a panic that can occur on a non-EOF error. The decorator expects the schema to match the outer reader's schema, and the only case where that doesn't happen is if there is a valid record batch that still can be processed, but there is an error which halts further reading.

I wasn't able to write a test for this because everything is encapsulated, but I'm fairly certain this is what causes the panics that have been observed.

Drive by: Made all the methods for the decorator reader private since the reader itself is private.