### PR TITLE
chore(deps): Remove references to github.com/prometheus/prometheus/tsdb/errors

### DIFF
--- a/pkg/ingester/checkpoint.go
+++ b/pkg/ingester/checkpoint.go
@@ -15,7 +15,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/gogo/protobuf/proto"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/wlog"
 	"github.com/prometheus/prometheus/util/compression"
@@ -457,7 +456,7 @@ func (w *WALCheckpointWriter) deleteCheckpoints(maxIndex int) (err error) {
 		}
 	}()
 
-	errs := tsdb_errors.NewMulti()
+	var errs []error
 
 	files, err := os.ReadDir(w.segmentWAL.Dir())
 	if err != nil {
@@ -469,10 +468,10 @@ func (w *WALCheckpointWriter) deleteCheckpoints(maxIndex int) (err error) {
 			continue
 		}
 		if err := os.RemoveAll(filepath.Join(w.segmentWAL.Dir(), fi.Name())); err != nil {
-			errs.Add(err)
+			errs = append(errs, err)
 		}
 	}
-	return errs.Err()
+	return errors.Join(errs...)
 }
 
 // cleanupOldCheckpoints removes old checkpoints that have been superseded by a newer checkpoint.

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	stderrors "errors"
 	"fmt"
 	"hash"
 	"hash/crc32"
@@ -34,7 +35,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	tsdb_enc "github.com/prometheus/prometheus/tsdb/encoding"
-	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 
 	"github.com/grafana/dskit/multierror"
@@ -1261,10 +1261,10 @@ func NewFileReader(path string) (*Reader, error) {
 	}
 	r, err := newReader(RealByteSlice(f.Bytes()), f)
 	if err != nil {
-		return nil, tsdb_errors.NewMulti(
+		return nil, stderrors.Join(
 			err,
 			f.Close(),
-		).Err()
+		)
 	}
 
 	return r, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
In preparation for the next Prometheus update, this PR removes the dependency of the Prometheus `tsdb/errrors` package, instead switching to use Go standard library mechanisms instead.

The end result is that the Loki codebase should no longer import the `tsdb/errors` package, and functionality should remain the same.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
