### PR TITLE
chore(engine): fix streamsView.Open semantics

### DIFF
--- a/pkg/engine/internal/executor/dataobjscan.go
+++ b/pkg/engine/internal/executor/dataobjscan.go
@@ -381,7 +381,7 @@ func (s *dataobjScan) read(ctx context.Context) (arrow.RecordBatch, error) {
 		return rec, nil
 	}
 
-	return s.streamsInjector.Inject(rec)
+	return s.streamsInjector.Inject(ctx, rec)
 }
 
 // Close closes s and releases all resources.

--- a/pkg/engine/internal/executor/executor.go
+++ b/pkg/engine/internal/executor/executor.go
@@ -261,7 +261,7 @@ func (c *Context) filterStreamsByLabels(ctx context.Context, streamIDs []int64, 
 	}
 
 	for _, id := range streamIDs {
-		lbls, err := view.Labels(id)
+		lbls, err := view.Labels(ctx, id)
 		if err != nil {
 			level.Error(c.logger).Log("msg", "failed to get labels for stream, skipping", "stream_id", id, "err", err)
 			continue

--- a/pkg/engine/internal/executor/stream_injector.go
+++ b/pkg/engine/internal/executor/stream_injector.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"cmp"
+	"context"
 	"fmt"
 	"slices"
 
@@ -38,7 +39,7 @@ func newStreamInjector(view *streamsView) *streamInjector {
 //
 // Inject fails if there is no stream ID column in the input record, or if the
 // stream ID doesn't exist in the view given to [newStreamInjector].
-func (si *streamInjector) Inject(in arrow.RecordBatch) (arrow.RecordBatch, error) {
+func (si *streamInjector) Inject(ctx context.Context, in arrow.RecordBatch) (arrow.RecordBatch, error) {
 	streamIDCol, streamIDIndex, err := columnForIdent(streamInjectorColumnIdent, in)
 	if err != nil {
 		return nil, err
@@ -81,7 +82,7 @@ func (si *streamInjector) Inject(in arrow.RecordBatch) (arrow.RecordBatch, error
 		// TODO(rfratto): this flips the processing of stream IDs into row-based
 		// processing. It may be more efficient to vectorize this by building each
 		// label column all at once.
-		lbs, err := si.view.Labels(findID)
+		lbs, err := si.view.Labels(ctx, findID)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/engine/internal/executor/stream_injector_test.go
+++ b/pkg/engine/internal/executor/stream_injector_test.go
@@ -33,7 +33,7 @@ func Test_streamInjector(t *testing.T) {
 	require.NoError(t, view.Open(t.Context()))
 
 	injector := newStreamInjector(view)
-	output, err := injector.Inject(record)
+	output, err := injector.Inject(t.Context(), record)
 	require.NoError(t, err)
 
 	expect := arrowtest.Rows{

--- a/pkg/engine/internal/executor/streams_view.go
+++ b/pkg/engine/internal/executor/streams_view.go
@@ -26,7 +26,8 @@ type streamsView struct {
 	batchSize     int
 
 	initialized  bool
-	streams      arrow.Table
+	reader       *streams.Reader
+	streams      arrow.Table   // Nil if reading hasn't happened yet.
 	idRowMapping map[int64]int // Mapping of stream ID to absolute row index in the streams table.
 	streamLabels map[int64][]labels.Label
 }
@@ -91,15 +92,53 @@ var errStreamsViewNotOpen = errors.New("streams view not opened")
 
 // Open initializes streamsView resources.
 func (v *streamsView) Open(ctx context.Context) error {
-	return v.init(ctx)
+	if v.initialized {
+		return nil
+	}
+
+	ctx, region := xcap.StartRegion(ctx, "streamsView.init")
+	defer region.End()
+
+	if v.idColumn == nil { // Initialized in [newStreamsView].
+		// The streams builder always produces a section with a streams ID column.
+		// If we hit this, someone probably made a custom section and provided it
+		// to us.
+		return fmt.Errorf("section does not contain a stream ID column")
+	}
+
+	readerOptions := streams.ReaderOptions{
+		Columns:   v.searchColumns,
+		Allocator: memory.DefaultAllocator,
+	}
+
+	var scalarIDs []scalar.Scalar
+	for _, id := range v.streamIDs {
+		scalarIDs = append(scalarIDs, scalar.NewInt64Scalar(id))
+	}
+	if len(scalarIDs) > 0 {
+		readerOptions.Predicates = []streams.Predicate{
+			streams.InPredicate{Column: v.idColumn, Values: scalarIDs},
+		}
+	}
+
+	r := streams.NewReader(readerOptions)
+	if err := r.Open(ctx); err != nil {
+		return fmt.Errorf("opening streams reader: %w", err)
+	}
+
+	v.reader = r
+	v.initialized = true
+	return nil
 }
 
 // Labels returns all of the non-null labels of a stream with the given
 // id. If [streamsViewOptions] included a subset of labels, only those labels
 // are returned.
-func (v *streamsView) Labels(id int64) ([]labels.Label, error) {
+func (v *streamsView) Labels(ctx context.Context, id int64) ([]labels.Label, error) {
 	if !v.initialized {
 		return nil, errStreamsViewNotOpen
+	} else if err := v.lazyRead(ctx); err != nil {
+		return nil, err
 	}
 
 	lbs, ok := v.streamLabels[id]
@@ -153,46 +192,16 @@ func (v *streamsView) Labels(id int64) ([]labels.Label, error) {
 	return lbs, nil
 }
 
-func (v *streamsView) init(ctx context.Context) (err error) {
-	if v.initialized {
+func (v *streamsView) lazyRead(ctx context.Context) (err error) {
+	if v.streams != nil {
 		return nil
 	}
-
-	ctx, region := xcap.StartRegion(ctx, "streamsView.init")
-	defer region.End()
-
-	if v.idColumn == nil { // Initialized in [newStreamsView].
-		// The streams builder always produces a section with a streams ID column.
-		// If we hit this, someone probably made a custom section and provided it
-		// to us.
-		return fmt.Errorf("section does not contain a stream ID column")
-	}
-
-	readerOptions := streams.ReaderOptions{
-		Columns:   v.searchColumns,
-		Allocator: memory.DefaultAllocator,
-	}
-
-	var scalarIDs []scalar.Scalar
-	for _, id := range v.streamIDs {
-		scalarIDs = append(scalarIDs, scalar.NewInt64Scalar(id))
-	}
-	if len(scalarIDs) > 0 {
-		readerOptions.Predicates = []streams.Predicate{
-			streams.InPredicate{Column: v.idColumn, Values: scalarIDs},
-		}
-	}
-
-	r := streams.NewReader(readerOptions)
-	defer r.Close()
-	if err := r.Open(ctx); err != nil {
-		return fmt.Errorf("opening streams reader: %w", err)
-	}
+	defer v.reader.Close() // Reader won't be needed anymore after this exits.
 
 	var records []arrow.RecordBatch
 
 	for {
-		rec, err := r.Read(ctx, v.batchSize)
+		rec, err := v.reader.Read(ctx, v.batchSize)
 		if rec != nil && rec.NumRows() > 0 {
 			records = append(records, rec)
 		}
@@ -204,7 +213,7 @@ func (v *streamsView) init(ctx context.Context) (err error) {
 		}
 	}
 
-	table := array.NewTableFromRecords(r.Schema(), records)
+	table := array.NewTableFromRecords(v.reader.Schema(), records)
 
 	idMapping := make(map[int64]int, table.NumRows())
 	for colIndex := range int(table.NumCols()) {
@@ -233,7 +242,6 @@ func (v *streamsView) init(ctx context.Context) (err error) {
 	}
 
 	v.streams = table
-	v.initialized = true
 	v.idRowMapping = idMapping
 	return nil
 }
@@ -265,6 +273,11 @@ func columnChunkedRow(col *arrow.Column, absoluteRow int) (arr arrow.Array, rela
 func (v *streamsView) Close() {
 	if !v.initialized {
 		return
+	}
+
+	if v.reader != nil {
+		v.reader.Close()
+		v.reader = nil
 	}
 
 	v.initialized = false

--- a/pkg/engine/internal/executor/streams_view_test.go
+++ b/pkg/engine/internal/executor/streams_view_test.go
@@ -30,7 +30,7 @@ func Test_streamsView(t *testing.T) {
 		var actual []labels.Labels
 
 		for id := 1; id <= 3; id++ {
-			lbs, err := view.Labels(int64(id))
+			lbs, err := view.Labels(t.Context(), int64(id))
 			require.NoError(t, err, "failed to get labels")
 			actual = append(actual, labels.New(lbs...))
 		}
@@ -47,7 +47,7 @@ func Test_streamsView(t *testing.T) {
 
 		var actual []labels.Labels
 
-		lbs, err := view.Labels(int64(2))
+		lbs, err := view.Labels(t.Context(), int64(2))
 		require.NoError(t, err, "failed to get labels")
 		actual = append(actual, labels.New(lbs...))
 
@@ -67,7 +67,7 @@ func Test_streamsView(t *testing.T) {
 		var actual []labels.Labels
 
 		for _, id := range []int{2, 3} {
-			lbs, err := view.Labels(int64(id))
+			lbs, err := view.Labels(t.Context(), int64(id))
 			require.NoError(t, err, "failed to get labels")
 			actual = append(actual, labels.New(lbs...))
 		}
@@ -99,7 +99,7 @@ func Test_streamsView(t *testing.T) {
 		var actual []labels.Labels
 
 		for id := 1; id <= 3; id++ {
-			lbs, err := view.Labels(int64(id))
+			lbs, err := view.Labels(t.Context(), int64(id))
 			require.NoError(t, err, "failed to get labels")
 			actual = append(actual, labels.New(lbs...))
 		}
@@ -133,7 +133,7 @@ func Test_streamsView(t *testing.T) {
 		var actual []labels.Labels
 
 		for id := 1; id <= 3; id++ {
-			lbs, err := view.Labels(int64(id))
+			lbs, err := view.Labels(t.Context(), int64(id))
 			require.NoError(t, err, "failed to get labels")
 			actual = append(actual, labels.New(lbs...))
 		}
@@ -143,7 +143,7 @@ func Test_streamsView(t *testing.T) {
 
 	t.Run("labels before open returns error", func(t *testing.T) {
 		view := newStreamsView(sec, &streamsViewOptions{BatchSize: 1})
-		lbs, err := view.Labels(1)
+		lbs, err := view.Labels(t.Context(), 1)
 		require.ErrorIs(t, err, errStreamsViewNotOpen)
 		require.Nil(t, lbs)
 	})


### PR DESCRIPTION
streamsView.Open was reading the streams section, which goes against the purpose of the Open/Read separation:

* Open should only do work required to prepare for reads
* Read should do all data-related compute work