### PR TITLE
chore: Lower loglevel for transport is closing #7649

### DIFF
--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -23,13 +23,13 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/grafana/loki/v3/pkg/lokifrontend/frontend/v2/frontendv2pb"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange"
 	querier_stats "github.com/grafana/loki/v3/pkg/querier/stats"
 	"github.com/grafana/loki/v3/pkg/scheduler/schedulerpb"
+	"github.com/grafana/loki/v3/pkg/util"
 	httpgrpcutil "github.com/grafana/loki/v3/pkg/util/httpgrpc"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
@@ -170,7 +170,7 @@ func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_Quer
 			sp.metrics.inflightRequests.Dec()
 			// Report back to scheduler that processing of the query has finished.
 			if err := c.Send(&schedulerpb.QuerierToScheduler{}); err != nil {
-				if status.Code(err) == codes.Canceled {
+				if util.IsConnCanceled(err) {
 					level.Debug(logger).Log("msg", "error notifying scheduler about finished query", "err", err, "addr", address)
 				} else {
 					level.Error(logger).Log("msg", "error notifying scheduler about finished query", "err", err, "addr", address)
@@ -253,7 +253,7 @@ func (sp *schedulerProcessor) reply(ctx context.Context, logger log.Logger, fron
 			// Response is empty and uninteresting.
 			_, err := c.(frontendv2pb.FrontendForQuerierClient).QueryResult(ctx, result)
 			if err != nil {
-				if status.Code(err) == codes.Canceled {
+				if util.IsConnCanceled(err) {
 					level.Debug(logger).Log("msg", "error notifying frontend about finished query", "err", err)
 				} else {
 					level.Error(logger).Log("msg", "error notifying frontend about finished query", "err", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
@bboreham suggested to [use IsConnCanceled](https://github.com/grafana/loki/pull/20801#discussion_r2803883310) instead. This catches transport is closing too.

**Which issue(s) this PR fixes**:
Addresses #7649 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
Not required (very minor change)
- [x] Tests updated
Not required (very minor change)
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
