### PR TITLE
fix(thor): incorrect empty records skipping 

### DIFF
--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -178,12 +178,12 @@ func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch,
 				return nil, err
 			}
 
+			inputsExhausted = false
+
 			if record.NumRows() == 0 {
 				// Nothing to process
 				continue
 			}
-
-			inputsExhausted = false
 
 			// extract all the columns that are used for grouping
 			var arrays []*array.String

--- a/pkg/engine/internal/executor/vector_aggregate.go
+++ b/pkg/engine/internal/executor/vector_aggregate.go
@@ -132,12 +132,12 @@ func (v *vectorAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch
 				return nil, err
 			}
 
+			inputsExhausted = false
+
 			if record.NumRows() == 0 {
 				// Nothing to process
 				continue
 			}
-
-			inputsExhausted = false
 
 			// extract timestamp column
 			tsVec, err := v.tsEval(record)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a bug with skipping empty records. Currently it effectively stops processing as soon as it gets an empty record because `inputsExhausted` will remain true. I guess it does not happen often in practice because our worker thread logic skips sending empty records over the wire, but I got this error while running locally with direct execution (no scheduler), so it is still a bug.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
