### PR TITLE
perf(dataset): use faster Uvarint implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -375,7 +375,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.6.0 // indirect
-	github.com/dennwc/varint v1.0.0 // indirect
+	github.com/dennwc/varint v1.0.0
 	github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/digitalocean/godo v1.171.0 // indirect

--- a/pkg/dataobj/internal/dataset/value_encoding_delta.go
+++ b/pkg/dataobj/internal/dataset/value_encoding_delta.go
@@ -1,7 +1,6 @@
 package dataset
 
 import (
-	"encoding/binary"
 	"fmt"
 	"io"
 
@@ -127,7 +126,7 @@ func (dec *deltaDecoder) Decode(alloc *memory.Allocator, count int) (columnar.Ar
 	}
 
 	for i := range count {
-		delta, n := binary.Varint(buf[off:])
+		delta, n := varint(buf[off:])
 		if n <= 0 {
 			valuesBuf.Resize(i)
 			return columnar.NewNumber[int64](values[:i], memory.Bitmap{}), io.EOF


### PR DESCRIPTION
**What this PR does / why we need it**:

I saw `binary.Varint` was responsible for 3.5% of all CPU in a particular set of queriers at a busy time.
The version in http://github.com/dennwc/varint has the loop unrolled, so it goes faster.
If you want to read lots more details see [this blog post](https://dolthub.awsdev.ld-corp.com/blog/2021-01-08-optimizing-varint-decoding/).

It only exports an unsigned version, so we have to add our own implementation of `varint` on top.

Selected Benchmarks:
```
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/v3/pkg/dataobj/internal/dataset
cpu: Intel(R) Core(TM) i7-14700K
                                                     │   before    │                after                 │
                                                     │   sec/op    │   sec/op     vs base                 │
Reader/batch=100-28                                    161.2m ± 1%   160.5m ± 6%        ~ (p=0.818 n=6)
Reader/batch=10k-28                                    262.5m ± 5%   262.3m ± 5%        ~ (p=0.818 n=6)
PredicateExecution/selectivity=combined-28             27.75m ± 0%   26.96m ± 1%   -2.84% (p=0.002 n=6)
PredicateExecution/selectivity=high-28                 22.76m ± 1%   22.31m ± 1%   -2.00% (p=0.002 n=6)
PredicateExecution/selectivity=low-28                  32.02m ± 0%   31.85m ± 0%   -0.54% (p=0.009 n=6)
_deltaDecoder_Decode/sequential/batchSize=256-28       148.9µ ± 1%   137.8µ ± 0%   -7.43% (p=0.002 n=6)
_deltaDecoder_Decode/sequential/batchSize=1024-28      138.1µ ± 1%   126.4µ ± 1%   -8.42% (p=0.002 n=6)
_deltaDecoder_Decode/sequential/batchSize=4096-28      135.0µ ± 1%   123.6µ ± 0%   -8.47% (p=0.002 n=6)
_deltaDecoder_Decode/largest_delta/batchSize=256-28    508.2µ ± 0%   252.9µ ± 0%  -50.23% (p=0.002 n=6)
_deltaDecoder_Decode/largest_delta/batchSize=1024-28   494.0µ ± 1%   242.0µ ± 0%  -51.02% (p=0.002 n=6)
_deltaDecoder_Decode/largest_delta/batchSize=4096-28   489.3µ ± 0%   239.4µ ± 1%  -51.07% (p=0.002 n=6)
_deltaDecoder_Decode/random/batchSize=256-28           581.6µ ± 1%   359.6µ ± 1%  -38.16% (p=0.002 n=6)
_deltaDecoder_Decode/random/batchSize=1024-28          569.6µ ± 0%   348.8µ ± 0%  -38.77% (p=0.002 n=6)
_deltaDecoder_Decode/random/batchSize=4096-28          567.3µ ± 0%   344.2µ ± 1%  -39.32% (p=0.002 n=6)
_plainBytesDecoder_Decode/scenario=constant-size-28    115.2µ ± 3%   112.0µ ± 3%   -2.80% (p=0.041 n=6)
_plainBytesDecoder_Decode/scenario=variable-size-28    65.22µ ± 2%   64.28µ ± 1%   -1.43% (p=0.004 n=6)
```

**Special notes for your reviewer**:

There are many other places that call `binary.Uvarint`, but I haven't yet found one that impacts a benchmark.

I had to pin the random number seed in `BenchmarkPredicateExecution` to get comparable results before/after.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- NA Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- NA If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. 