### PR TITLE
chore: backport 20823 to k294

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1869,6 +1869,14 @@ ingest_limits_frontend:
   # CLI flag: -ingest-limits-frontend.assigned-partitions-cache-ttl
   [assigned_partitions_cache_ttl: <duration> | default = 1m]
 
+  # The TTL for the cache. 0 disables the cache.
+  # CLI flag: -ingest-limits-frontend.cache-ttl
+  [cache_ttl: <duration> | default = 1m]
+
+  # The jitter to add to the cache.
+  # CLI flag: -ingest-limits-frontend.cache-ttl-jitter
+  [cache_ttl_jitter: <duration> | default = 15s]
+
 ingest_limits_frontend_client:
   # Configures client gRPC connections to limits service.
   # The CLI flags prefix for this block configuration is:

--- a/pkg/limits/frontend/client.go
+++ b/pkg/limits/frontend/client.go
@@ -1,7 +1,14 @@
 package frontend
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/bits-and-blooms/bloom/v3"
 
 	"github.com/grafana/loki/v3/pkg/limits/proto"
 )
@@ -10,5 +17,118 @@ type limitsClient interface {
 	// ExceedsLimits checks if the streams in the request have exceeded their
 	// per-partition limits.
 	ExceedsLimits(context.Context, *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error)
+
+	// UpdateRates updates the per-second rates for the streams.
 	UpdateRates(context.Context, *proto.UpdateRatesRequest) ([]*proto.UpdateRatesResponse, error)
+}
+
+// A cacheLimitsClient uses a cache to reduce the load on limits backends.
+type cacheLimitsClient struct {
+	ttl    time.Duration
+	onMiss limitsClient
+	// The fields below MUST NOT be used without mtx.
+	mtx          sync.RWMutex
+	knownStreams *bloom.BloomFilter
+	lastExpired  time.Time
+}
+
+// newCacheLimitsClient returns a new cache limits client.
+func newCacheLimitsClient(
+	ttl, maxJitter time.Duration,
+	knownStreams *bloom.BloomFilter,
+	onMiss limitsClient,
+) *cacheLimitsClient {
+	return &cacheLimitsClient{
+		ttl:          ttl,
+		knownStreams: knownStreams,
+		lastExpired:  time.Now().Add(randDuration(maxJitter)),
+		onMiss:       onMiss,
+	}
+}
+
+// ExceedsLimits implements the [limitsClient] interface.
+func (c *cacheLimitsClient) ExceedsLimits(ctx context.Context, req *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error) {
+	c.expireTTL()
+	// If the exact same request has been seen before, and all streams were
+	// accepted, we can assume it will continue to be accepted.
+	if c.hasKnownStreams(req) {
+		return []*proto.ExceedsLimitsResponse{}, nil
+	}
+	// Need to check with the limits service.
+	resps, err := c.onMiss.ExceedsLimits(ctx, req)
+	if err != nil {
+		return resps, err
+	}
+	// We do not cache rejected streams at this time, so rejections must be
+	// filtered out before updating the cache.
+	rejected := make(map[uint64]struct{})
+	for _, resp := range resps {
+		for _, res := range resp.Results {
+			rejected[res.StreamHash] = struct{}{}
+		}
+	}
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	for _, s := range req.Streams {
+		// If the stream was not rejected, add it to the cache.
+		if _, ok := rejected[s.StreamHash]; !ok {
+			b := bytes.Buffer{}
+			encodeStreamToBuf(&b, req.Tenant, s)
+			c.knownStreams.Add(b.Bytes())
+		}
+	}
+	return resps, nil
+}
+
+// UpdateRates implements the [limitsClient] interface.
+func (c *cacheLimitsClient) UpdateRates(ctx context.Context, req *proto.UpdateRatesRequest) ([]*proto.UpdateRatesResponse, error) {
+	return c.onMiss.UpdateRates(ctx, req)
+}
+
+// expireTTL expires the caches if the TTL has been exceeded.
+func (c *cacheLimitsClient) expireTTL() {
+	// Fast path, first check the TTL with a read lock.
+	c.mtx.RLock()
+	lastExpired := c.lastExpired
+	c.mtx.RUnlock()
+	if time.Since(lastExpired) <= c.ttl {
+		return
+	}
+	// If we have reached here we need to reset the cache. However, before
+	// we can do that we need to check the TTL a second time with an exclusive
+	// lock as we could be in a data race.
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	if time.Since(c.lastExpired) > c.ttl {
+		c.knownStreams.ClearAll()
+		c.lastExpired = time.Now()
+	}
+}
+
+// hasKnownStreams returns true if all streams in req are known streams.
+func (c *cacheLimitsClient) hasKnownStreams(req *proto.ExceedsLimitsRequest) bool {
+	// b is re-used. The data built from it MUST NOT escape this function.
+	b := bytes.Buffer{}
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	for _, s := range req.Streams {
+		b.Reset()
+		encodeStreamToBuf(&b, req.Tenant, s)
+		if !c.knownStreams.Test(b.Bytes()) {
+			return false
+		}
+	}
+	return true
+}
+
+// randDuration returns a random duration between [0, d].
+func randDuration(d time.Duration) time.Duration {
+	return time.Duration(rand.Int63n(d.Nanoseconds()))
+}
+
+// encodeStreamToBuf encodes the stream to the buffer.
+func encodeStreamToBuf(b *bytes.Buffer, tenant string, s *proto.StreamMetadata) {
+	b.Write([]byte(tenant))
+	// [bytes.Buffer] never return an error, it will panic instead.
+	_ = binary.Write(b, binary.LittleEndian, s.StreamHash)
 }

--- a/pkg/limits/frontend/client_test.go
+++ b/pkg/limits/frontend/client_test.go
@@ -1,0 +1,107 @@
+package frontend
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/bits-and-blooms/bloom/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/limits"
+	"github.com/grafana/loki/v3/pkg/limits/proto"
+)
+
+func TestCacheLimitsClient(t *testing.T) {
+	t.Run("streams accepted", func(t *testing.T) {
+		// When a stream is accepted, it should be inserted into known streams.
+		// We will assert this behavior later.
+		knownStreams := bloom.NewWithEstimates(10, 0.01)
+		onMiss := &mockLimitsClient{
+			t: t,
+			// Expect one stream 0x1 from the tenant "test".
+			expectedExceedsLimitsRequest: &proto.ExceedsLimitsRequest{
+				Tenant:  "test",
+				Streams: []*proto.StreamMetadata{{StreamHash: 0x1}},
+			},
+			// All streams accepted.
+			exceedsLimitsResponses: []*proto.ExceedsLimitsResponse{},
+		}
+		client := newCacheLimitsClient(time.Minute, 15*time.Second, knownStreams, onMiss)
+		resps, err := client.ExceedsLimits(t.Context(), &proto.ExceedsLimitsRequest{
+			Tenant:  "test",
+			Streams: []*proto.StreamMetadata{{StreamHash: 0x1}},
+		})
+		// No streams should be rejected.
+		require.NoError(t, err)
+		require.Len(t, resps, 0)
+		// The cache should contain the stream 0x1 for the tenant "test".
+		// We don't use [encodeStreamToBuf] so we can test it.
+		b := bytes.Buffer{}
+		b.Write([]byte("test"))
+		_ = binary.Write(&b, binary.LittleEndian, uint64(1))
+		require.True(t, knownStreams.Test(b.Bytes()))
+	})
+
+	t.Run("streams rejected", func(t *testing.T) {
+		// When a stream is rejected, it should not be cached.
+		knownStreams := bloom.NewWithEstimates(10, 0.01)
+		onMiss := &mockLimitsClient{
+			t: t,
+			// Expect one stream 0x1 from the tenant "test".
+			expectedExceedsLimitsRequest: &proto.ExceedsLimitsRequest{
+				Tenant:  "test",
+				Streams: []*proto.StreamMetadata{{StreamHash: 0x1}},
+			},
+			// The stream should be rejected.
+			exceedsLimitsResponses: []*proto.ExceedsLimitsResponse{{
+				Results: []*proto.ExceedsLimitsResult{{
+					StreamHash: 0x1,
+					Reason:     uint32(limits.ReasonMaxStreams),
+				}},
+			}},
+		}
+		client := newCacheLimitsClient(time.Minute, 15*time.Second, knownStreams, onMiss)
+		resps, err := client.ExceedsLimits(t.Context(), &proto.ExceedsLimitsRequest{
+			Tenant:  "test",
+			Streams: []*proto.StreamMetadata{{StreamHash: 0x1}},
+		})
+		require.NoError(t, err)
+		require.Len(t, resps, 1)
+		// No bits should have been set.
+		require.Equal(t, uint(0), knownStreams.BitSet().Count())
+	})
+
+	t.Run("cache is expired after TTL", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			knownStreams := bloom.NewWithEstimates(10, 0.01)
+			client := newCacheLimitsClient(time.Minute, 15*time.Second, knownStreams, &mockLimitsClient{})
+			// Remove jitter for tests.
+			client.lastExpired = time.Now()
+
+			now := time.Now()
+			require.Equal(t, now, client.lastExpired)
+			// No bits should have been set.
+			require.Equal(t, uint(0), knownStreams.BitSet().Count())
+
+			// Advance the clock, no reset should happen.
+			time.Sleep(time.Second)
+			client.expireTTL()
+			require.Equal(t, now, client.lastExpired)
+
+			// Add some data to the cache.
+			knownStreams.Add([]byte("test"))
+			require.Greater(t, knownStreams.BitSet().Count(), uint(0))
+
+			// Advance the clock past the TTL (include the jitter).
+			time.Sleep(time.Minute + (5 * time.Second))
+			now = time.Now()
+			client.expireTTL()
+			require.Equal(t, now, client.lastExpired)
+			// The bits should have been reset.
+			require.Equal(t, uint(0), knownStreams.BitSet().Count())
+		})
+	})
+}

--- a/pkg/limits/frontend/config.go
+++ b/pkg/limits/frontend/config.go
@@ -17,13 +17,37 @@ type Config struct {
 	LifecyclerConfig           ring.LifecyclerConfig `yaml:"lifecycler,omitempty"`
 	NumPartitions              int                   `yaml:"num_partitions"`
 	AssignedPartitionsCacheTTL time.Duration         `yaml:"assigned_partitions_cache_ttl"`
+	CacheTTL                   time.Duration         `yaml:"cache_ttl"`
+	CacheTTLJitter             time.Duration         `yaml:"cache_ttl_jitter"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.ClientConfig.RegisterFlagsWithPrefix("ingest-limits-frontend", f)
 	cfg.LifecyclerConfig.RegisterFlagsWithPrefix("ingest-limits-frontend.", f, util_log.Logger)
-	f.IntVar(&cfg.NumPartitions, "ingest-limits-frontend.num-partitions", 64, "The number of partitions to use for the ring.")
-	f.DurationVar(&cfg.AssignedPartitionsCacheTTL, "ingest-limits-frontend.assigned-partitions-cache-ttl", 1*time.Minute, "The TTL for the assigned partitions cache. 0 disables the cache.")
+	f.IntVar(
+		&cfg.NumPartitions,
+		"ingest-limits-frontend.num-partitions",
+		64,
+		"The number of partitions to use for the ring.",
+	)
+	f.DurationVar(
+		&cfg.AssignedPartitionsCacheTTL,
+		"ingest-limits-frontend.assigned-partitions-cache-ttl",
+		time.Minute,
+		"The TTL for the assigned partitions cache. 0 disables the cache.",
+	)
+	f.DurationVar(
+		&cfg.CacheTTL,
+		"ingest-limits-frontend.cache-ttl",
+		time.Minute,
+		"The TTL for the cache. 0 disables the cache.",
+	)
+	f.DurationVar(
+		&cfg.CacheTTLJitter,
+		"ingest-limits-frontend.cache-ttl-jitter",
+		15*time.Second,
+		"The jitter to add to the cache.",
+	)
 }
 
 func (cfg *Config) Validate() error {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request backports #20823 to k294.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
