### PR TITLE
chore(dataobj): Improve aggregator performance

### DIFF
--- a/pkg/engine/internal/executor/aggregator.go
+++ b/pkg/engine/internal/executor/aggregator.go
@@ -2,7 +2,6 @@ package executor
 
 import (
 	"errors"
-	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -39,11 +38,13 @@ const (
 
 // aggregator is used to aggregate sample values by a set of grouping keys for each point in time.
 type aggregator struct {
-	points            map[time.Time]map[uint64]*groupState // holds the groupState for each point in time series
-	digest            *xxhash.Digest                       // used to compute key for each group
-	operation         aggregationOperation                 // aggregation type
-	labels            []arrow.Field                        // combined list of all label fields for all sample values
-	clonedLabelValues map[string]string                    // cache of cloned strings to reduce allocations for repeated values
+	points       map[int64]map[uint64]*groupState // holds the groupState for each point in time series
+	uniquePoints []int64
+
+	digest            *xxhash.Digest       // used to compute key for each group
+	operation         aggregationOperation // aggregation type
+	labels            []arrow.Field        // combined list of all label fields for all sample values
+	clonedLabelValues map[string]string    // cache of cloned strings to reduce allocations for repeated values
 
 	// Track unique series across all timestamps to enforce maxSeries limit
 	maxSeries    int                 // maximum number of unique series allowed (0 means no limit)
@@ -60,9 +61,10 @@ func newAggregator(pointsSizeHint int, operation aggregationOperation) *aggregat
 	}
 
 	if pointsSizeHint > 0 {
-		a.points = make(map[time.Time]map[uint64]*groupState, pointsSizeHint)
+		a.points = make(map[int64]map[uint64]*groupState, pointsSizeHint)
+		a.uniquePoints = make([]int64, 0, pointsSizeHint)
 	} else {
-		a.points = make(map[time.Time]map[uint64]*groupState)
+		a.points = make(map[int64]map[uint64]*groupState)
 	}
 
 	return &a
@@ -92,10 +94,11 @@ func (a *aggregator) Add(ts time.Time, value float64, labels []arrow.Field, labe
 		panic("len(labels) != len(labelValues)")
 	}
 
-	point, ok := a.points[ts]
+	point, ok := a.points[ts.UnixNano()]
 	if !ok {
 		point = make(map[uint64]*groupState)
-		a.points[ts] = point
+		a.points[ts.UnixNano()] = point
+		a.uniquePoints = append(a.uniquePoints, ts.UnixNano())
 	}
 
 	var key uint64
@@ -191,7 +194,8 @@ func (a *aggregator) BuildRecord() (arrow.RecordBatch, error) {
 	rb := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
 
 	// emit aggregated results in sorted order of timestamp
-	sortedTimestamps := a.getSortedTimestamps()
+	slices.Sort(a.uniquePoints)
+	sortedTimestamps := a.uniquePoints
 
 	// preallocate all builders to the total amount of rows
 	total := 0
@@ -201,7 +205,7 @@ func (a *aggregator) BuildRecord() (arrow.RecordBatch, error) {
 	rb.Reserve(total)
 
 	for _, ts := range sortedTimestamps {
-		tsValue, _ := arrow.TimestampFromTime(ts, arrow.Nanosecond)
+		tsValue := arrow.Timestamp(ts)
 
 		for _, entry := range a.points[ts] {
 			var value float64
@@ -248,11 +252,4 @@ func (a *aggregator) Reset() {
 	}
 
 	clear(a.uniqueSeries)
-}
-
-// getSortedTimestamps returns all timestamps in sorted order
-func (a *aggregator) getSortedTimestamps() []time.Time {
-	return slices.SortedFunc(maps.Keys(a.points), func(a, b time.Time) int {
-		return a.Compare(b)
-	})
 }

--- a/pkg/engine/internal/executor/aggregator_test.go
+++ b/pkg/engine/internal/executor/aggregator_test.go
@@ -14,12 +14,10 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/arrowtest"
 )
 
-var (
-	groupBy = []arrow.Field{
-		semconv.FieldFromIdent(semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String), true),
-		semconv.FieldFromIdent(semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String), true),
-	}
-)
+var groupBy = []arrow.Field{
+	semconv.FieldFromIdent(semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String), true),
+	semconv.FieldFromIdent(semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String), true),
+}
 
 func TestAggregator(t *testing.T) {
 	colTs := semconv.ColumnIdentTimestamp.FQN()
@@ -372,23 +370,27 @@ func TestAggregator(t *testing.T) {
 	})
 }
 
-func BenchmarkAggregator(b *testing.B) {
+func BenchmarkBuildRecord(b *testing.B) {
 	fields := []arrow.Field{
 		semconv.FieldFromIdent(semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String), true),
 		semconv.FieldFromIdent(semconv.NewIdentifier("cluster", types.ColumnTypeLabel, types.Loki.String), true),
 		semconv.FieldFromIdent(semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String), true),
 	}
 
-	agg := newAggregator(10, aggregationOperationSum)
+	agg := newAggregator(10000, aggregationOperationSum)
 	agg.AddLabels(fields)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := 0; i < 10000; i++ {
 		ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(i) * time.Second)
 		env := fmt.Sprintf("env-%d", i%3)
 		cluster := fmt.Sprintf("cluster-%d", i%10)
 		service := fmt.Sprintf("service-%d", i%7)
 
-		_ = agg.Add(ts, 10, fields, []string{env, cluster, service})
+		_ = agg.Add(ts, float64(i), fields, []string{env, cluster, service})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		agg.BuildRecord()
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
BuildRecord perf improvements for the aggregator. Traces show that RangeAggregation spends a lot of time in BuildRecord, so I benchmarked it and found a small improvement.

I think there's some more things that could be done here, but this one was relatively simple and improved the performance of the BuildRecord function by ~2x. I think other changes require a bit of a large refactor.

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/engine/internal/executor
cpu: Apple M3 Max
               │ before.txt  │              after.txt              │
               │   sec/op    │   sec/op     vs base                │
BuildRecord-14   2.531m ± 2%   1.311m ± 2%  -48.21% (p=0.000 n=10)

               │  before.txt  │              after.txt               │
               │     B/op     │     B/op      vs base                │
BuildRecord-14   2.125Mi ± 0%   1.193Mi ± 0%  -43.84% (p=0.000 n=10)

               │ before.txt │             after.txt              │
               │ allocs/op  │ allocs/op   vs base                │
BuildRecord-14   132.0 ± 0%   111.0 ± 0%  -15.91% (p=0.000 n=10)
```