### PR TITLE
docs: Troubleshooting readiness

### DIFF
--- a/docs/sources/operations/troubleshooting/troubleshoot-operations.md
+++ b/docs/sources/operations/troubleshooting/troubleshoot-operations.md
@@ -1524,7 +1524,7 @@ After being disconnected from the memberlist cluster, the instance failed to rej
 
 ## Component readiness errors
 
-Readiness errors occur when Loki components are not ready to serve requests. These errors are returned by the `/ready` health check endpoint and prevent load balancers from routing traffic to unready instances.
+Readiness errors occur when Loki components are not ready to serve requests. These errors are returned by the [`/ready` health check endpoint](http://localhost:3100/ready) and prevent load balancers from routing traffic to unready instances.
 
 ### Error: Application is stopping
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Troubleshooting Ring content to the Troubleshooting Operations topic 
(Part 6 of 19)

Dependent on Part 5 https://github.com/grafana/loki/pull/20810   [MERGED]

**Special notes for your reviewer**:
AI generated, so watch for hallucinations.
Additional content in other PRs.  I left the headings in the PR for context and to help me keep the sections in the correct order if PRs merge out of sequence.

I plan to get all the pieces of this topic approved and stitched back together in `main` before backporting/publishing the file.