### PR TITLE
chore: remove deprecated metrics

### DIFF
--- a/pkg/dataobj/consumer/metrics.go
+++ b/pkg/dataobj/consumer/metrics.go
@@ -14,12 +14,6 @@ type metrics struct {
 	discardedBytes prometheus.Counter
 	records        prometheus.Counter
 	recordFailures prometheus.Counter
-
-	// Deprecated, will be removed in two weeklies.
-	latestDelay      prometheus.Gauge
-	currentOffset    prometheus.Gauge
-	processedBytes   prometheus.Counter
-	processedRecords prometheus.Counter
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
@@ -48,33 +42,14 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			Name: "loki_dataobj_consumer_record_failures_total",
 			Help: "Total number of records that failed to be processed.",
 		}),
-		// TODO(grobinson): Remove after two minor releases.
-		latestDelay: promauto.With(r).NewGauge(prometheus.GaugeOpts{
-			Name: "loki_dataobj_consumer_latest_processing_delay_seconds",
-			Help: "Latest time difference bweteen record timestamp and processing time in seconds",
-		}),
-		currentOffset: promauto.With(r).NewGauge(prometheus.GaugeOpts{
-			Name: "loki_dataobj_consumer_current_offset",
-			Help: "The last consumed offset.",
-		}),
-		processedBytes: promauto.With(r).NewCounter(prometheus.CounterOpts{
-			Name: "loki_dataobj_consumer_processed_bytes_total",
-			Help: "The sum of bytes in all Kafka records.",
-		}),
-		processedRecords: promauto.With(r).NewCounter(prometheus.CounterOpts{
-			Name: "loki_dataobj_consumer_processed_records_total",
-			Help: "The total number of Kafka records.",
-		}),
 	}
 }
 
 func (m *metrics) setLastOffset(offset int64) {
 	m.lastOffset.Set(float64(offset))
-	m.currentOffset.Set(float64(offset))
 }
 
 func (m *metrics) setConsumptionLag(d time.Duration) {
 	secs := float64(d.Seconds())
 	m.consumptionLag.Set(secs)
-	m.latestDelay.Set(secs)
 }

--- a/pkg/dataobj/consumer/processor.go
+++ b/pkg/dataobj/consumer/processor.go
@@ -243,9 +243,6 @@ func (p *processor) observeRecord(rec *kgo.Record, now time.Time) {
 	p.metrics.receivedBytes.Add(float64(len(rec.Value)))
 	p.metrics.setLastOffset(rec.Offset)
 	p.metrics.setConsumptionLag(now.Sub(rec.Timestamp))
-	// Deprecated metrics.
-	p.metrics.processedBytes.Add(float64(len(rec.Value)))
-	p.metrics.processedRecords.Inc()
 }
 
 func (p *processor) observeRecordErr(rec *kgo.Record) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the deprecated metrics.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
