### PR TITLE
feat: skip known streams in limits-frontend cache

### DIFF
--- a/pkg/limits/frontend/client.go
+++ b/pkg/limits/frontend/client.go
@@ -54,7 +54,7 @@ func (c *cacheLimitsClient) ExceedsLimits(ctx context.Context, req *proto.Exceed
 	// to make to limits backends.
 	c.removeKnownStreams(req)
 	if len(req.Streams) == 0 {
-		return []*proto.ExceedsLimitsResponse{}, nil
+		return nil, nil
 	}
 
 	// Need to check with the limits service.

--- a/pkg/limits/frontend/client.go
+++ b/pkg/limits/frontend/client.go
@@ -49,11 +49,14 @@ func newCacheLimitsClient(
 // ExceedsLimits implements the [limitsClient] interface.
 func (c *cacheLimitsClient) ExceedsLimits(ctx context.Context, req *proto.ExceedsLimitsRequest) ([]*proto.ExceedsLimitsResponse, error) {
 	c.expireTTL()
-	// If the exact same request has been seen before, and all streams were
-	// accepted, we can assume it will continue to be accepted.
-	if c.hasKnownStreams(req) {
+	// Remove known streams from the request. This means we just check streams
+	// we haven't seen before, which reduces the number of requests we need
+	// to make to limits backends.
+	c.removeKnownStreams(req)
+	if len(req.Streams) == 0 {
 		return []*proto.ExceedsLimitsResponse{}, nil
 	}
+
 	// Need to check with the limits service.
 	resps, err := c.onMiss.ExceedsLimits(ctx, req)
 	if err != nil {
@@ -105,20 +108,22 @@ func (c *cacheLimitsClient) expireTTL() {
 	}
 }
 
-// hasKnownStreams returns true if all streams in req are known streams.
-func (c *cacheLimitsClient) hasKnownStreams(req *proto.ExceedsLimitsRequest) bool {
+// removeKnownStreams removes known streams from the request.
+func (c *cacheLimitsClient) removeKnownStreams(req *proto.ExceedsLimitsRequest) {
 	// b is re-used. The data built from it MUST NOT escape this function.
 	b := bytes.Buffer{}
+	// See https://go.dev/wiki/SliceTricks.
+	res := req.Streams[:0]
 	c.mtx.RLock()
 	defer c.mtx.RUnlock()
 	for _, s := range req.Streams {
 		b.Reset()
 		encodeStreamToBuf(&b, req.Tenant, s)
 		if !c.knownStreams.Test(b.Bytes()) {
-			return false
+			res = append(res, s)
 		}
 	}
-	return true
+	req.Streams = res
 }
 
 // randDuration returns a random duration between [0, d].

--- a/pkg/limits/frontend/client_test.go
+++ b/pkg/limits/frontend/client_test.go
@@ -104,4 +104,40 @@ func TestCacheLimitsClient(t *testing.T) {
 			require.Equal(t, uint(0), knownStreams.BitSet().Count())
 		})
 	})
+
+	t.Run("known streams are skipped", func(t *testing.T) {
+		knownStreams := bloom.NewWithEstimates(10, 0.01)
+		onMiss := &mockLimitsClient{
+			t: t,
+			// Expect one stream 0x2 from the tenant "test" because the other stream,
+			// 0x1, is a known stream and should be skipped.
+			expectedExceedsLimitsRequest: &proto.ExceedsLimitsRequest{
+				Tenant:  "test",
+				Streams: []*proto.StreamMetadata{{StreamHash: 0x2}},
+			},
+			exceedsLimitsResponses: []*proto.ExceedsLimitsResponse{},
+		}
+		client := newCacheLimitsClient(time.Minute, 15*time.Second, knownStreams, onMiss)
+		// Create a stream and add it to the cache.
+		s1 := &proto.StreamMetadata{StreamHash: 0x1}
+		b := bytes.Buffer{}
+		encodeStreamToBuf(&b, "test", s1)
+		knownStreams.Add(b.Bytes())
+		// Create a second stream but do not add it to the cache.
+		s2 := &proto.StreamMetadata{StreamHash: 0x2}
+		// Neither s1 or s2 should be rejected.
+		resps, err := client.ExceedsLimits(t.Context(), &proto.ExceedsLimitsRequest{
+			Tenant:  "test",
+			Streams: []*proto.StreamMetadata{s1, s2},
+		})
+		require.NoError(t, err)
+		require.Len(t, resps, 0)
+		// The cache should now contain both streams.
+		b.Reset()
+		encodeStreamToBuf(&b, "test", s1)
+		require.True(t, knownStreams.Test(b.Bytes()))
+		b.Reset()
+		encodeStreamToBuf(&b, "test", s2)
+		require.True(t, knownStreams.Test(b.Bytes()))
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit offers a further optimization where we skip known streams in the frontend cache.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
