### PR TITLE
chore: replace quartz with synctest

### DIFF
--- a/pkg/limits/frontend/cache.go
+++ b/pkg/limits/frontend/cache.go
@@ -3,8 +3,6 @@ package frontend
 import (
 	"sync"
 	"time"
-
-	"github.com/coder/quartz"
 )
 
 type cache[K comparable, V any] interface {
@@ -36,16 +34,12 @@ type ttlcache[K comparable, V any] struct {
 	ttl           time.Duration
 	lastEvictedAt time.Time
 	mu            sync.RWMutex
-
-	// Used for tests.
-	clock quartz.Clock
 }
 
 func newTTLCache[K comparable, V any](ttl time.Duration) *ttlcache[K, V] {
 	return &ttlcache[K, V]{
 		items: make(map[K]item[V]),
 		ttl:   ttl,
-		clock: quartz.NewReal(),
 	}
 }
 
@@ -54,7 +48,7 @@ func (c *ttlcache[K, V]) Get(key K) (V, bool) {
 	var (
 		value  V
 		exists bool
-		now    = c.clock.Now()
+		now    = time.Now()
 	)
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -67,7 +61,7 @@ func (c *ttlcache[K, V]) Get(key K) (V, bool) {
 
 // Set implements the [cache] interface.
 func (c *ttlcache[K, V]) Set(key K, value V) {
-	now := c.clock.Now()
+	now := time.Now()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.items[key] = item[V]{

--- a/pkg/limits/frontend/cache_test.go
+++ b/pkg/limits/frontend/cache_test.go
@@ -2,70 +2,68 @@ package frontend
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
-	"github.com/coder/quartz"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTTLCache_Get(t *testing.T) {
-	c := newTTLCache[string, string](time.Minute)
-	clock := quartz.NewMock(t)
-	c.clock = clock
-	// The value should be absent.
-	value, ok := c.Get("foo")
-	require.Equal(t, "", value)
-	require.False(t, ok)
-	// Set the value and it should be present.
-	c.Set("foo", "bar")
-	value, ok = c.Get("foo")
-	require.Equal(t, "bar", value)
-	require.True(t, ok)
-	// Advance the time to be 1 second before the expiration time.
-	clock.Advance(59 * time.Second)
-	value, ok = c.Get("foo")
-	require.Equal(t, "bar", value)
-	require.True(t, ok)
-	// Advance the time to be equal to the expiration time, the value should
-	// be absent.
-	clock.Advance(time.Second)
-	value, ok = c.Get("foo")
-	require.Equal(t, "", value)
-	require.False(t, ok)
-	// Advance the time past the expiration time, the value should still be
-	// absent.
-	clock.Advance(time.Second)
-	value, ok = c.Get("foo")
-	require.Equal(t, "", value)
-	require.False(t, ok)
+	synctest.Test(t, func(t *testing.T) {
+		c := newTTLCache[string, string](time.Minute)
+		// The value should be absent.
+		value, ok := c.Get("foo")
+		require.Equal(t, "", value)
+		require.False(t, ok)
+		// Set the value and it should be present.
+		c.Set("foo", "bar")
+		value, ok = c.Get("foo")
+		require.Equal(t, "bar", value)
+		require.True(t, ok)
+		// Advance the time to be 1 second before the expiration time.
+		time.Sleep(59 * time.Second)
+		value, ok = c.Get("foo")
+		require.Equal(t, "bar", value)
+		require.True(t, ok)
+		// Advance the time to be equal to the expiration time, the value should
+		// be absent.
+		time.Sleep(time.Second)
+		value, ok = c.Get("foo")
+		require.Equal(t, "", value)
+		require.False(t, ok)
+		// Advance the time past the expiration time, the value should still be
+		// absent.
+		time.Sleep(time.Second)
+		value, ok = c.Get("foo")
+		require.Equal(t, "", value)
+		require.False(t, ok)
+	})
 }
 
 func TestTTLCache_Set(t *testing.T) {
-	c := newTTLCache[string, string](time.Minute)
-	clock := quartz.NewMock(t)
-	c.clock = clock
-	c.Set("foo", "bar")
-	item1, ok := c.items["foo"]
-	require.True(t, ok)
-	require.Equal(t, c.clock.Now().Add(time.Minute), item1.expiresAt)
-	// Set should refresh the expiration time.
-	clock.Advance(time.Second)
-	c.Set("foo", "bar")
-	item2, ok := c.items["foo"]
-	require.True(t, ok)
-	require.Greater(t, item2.expiresAt, item1.expiresAt)
-	require.Equal(t, item2.expiresAt, item1.expiresAt.Add(time.Second))
-	// Set should replace the value.
-	c.Set("foo", "baz")
-	value, ok := c.Get("foo")
-	require.True(t, ok)
-	require.Equal(t, "baz", value)
+	synctest.Test(t, func(t *testing.T) {
+		c := newTTLCache[string, string](time.Minute)
+		c.Set("foo", "bar")
+		item1, ok := c.items["foo"]
+		require.True(t, ok)
+		require.Equal(t, time.Now().Add(time.Minute), item1.expiresAt)
+		// Set should refresh the expiration time.
+		time.Sleep(time.Second)
+		c.Set("foo", "bar")
+		item2, ok := c.items["foo"]
+		require.True(t, ok)
+		require.Greater(t, item2.expiresAt, item1.expiresAt)
+		require.Equal(t, item2.expiresAt, item1.expiresAt.Add(time.Second))
+		// Set should replace the value.
+		c.Set("foo", "baz")
+		value, ok := c.Get("foo")
+		require.True(t, ok)
+		require.Equal(t, "baz", value)
+	})
 }
 
 func TestTTLCache_Delete(t *testing.T) {
 	c := newTTLCache[string, string](time.Minute)
-	clock := quartz.NewMock(t)
-	c.clock = clock
 	// Set the value and it should be present.
 	c.Set("foo", "bar")
 	value, ok := c.Get("foo")
@@ -80,8 +78,6 @@ func TestTTLCache_Delete(t *testing.T) {
 
 func TestTTLCache_Reset(t *testing.T) {
 	c := newTTLCache[string, string](time.Minute)
-	clock := quartz.NewMock(t)
-	c.clock = clock
 	// Set two values, both should be present.
 	c.Set("foo", "bar")
 	value, ok := c.Get("foo")
@@ -107,89 +103,89 @@ func TestTTLCache_Reset(t *testing.T) {
 }
 
 func TestTTLCache_EvictExpired(t *testing.T) {
-	c := newTTLCache[string, string](time.Minute)
-	clock := quartz.NewMock(t)
-	c.clock = clock
-	c.Set("foo", "bar")
-	_, ok := c.items["foo"]
-	require.True(t, ok)
-	// Advance the clock and update foo, it should not be evicted as its
-	// expiration time should be refreshed.
-	clock.Advance(time.Minute)
-	c.Set("foo", "bar")
-	_, ok = c.items["foo"]
-	require.True(t, ok)
-	eviction1 := clock.Now()
-	require.Equal(t, eviction1, c.lastEvictedAt)
-	// Advance the clock 15 seconds. Since 15 seconds is less than half
-	// the TTL (30 seconds) since the last eviction, no eviction should
-	// be run.
-	clock.Advance(15 * time.Second)
-	c.Set("bar", "baz")
-	_, ok = c.items["foo"]
-	require.True(t, ok)
-	_, ok = c.items["bar"]
-	require.True(t, ok)
-	require.Equal(t, eviction1, c.lastEvictedAt)
-	// Advance the clock 16 seconds. Since 31 seconds is more than half the TTL
-	// since the last eviction, an eviction should be run, but no items should
-	// be evicted.
-	clock.Advance(16 * time.Second)
-	c.Set("baz", "qux")
-	_, ok = c.items["foo"]
-	require.True(t, ok)
-	_, ok = c.items["bar"]
-	require.True(t, ok)
-	_, ok = c.items["baz"]
-	require.True(t, ok)
-	eviction2 := clock.Now()
-	require.Equal(t, eviction2, c.lastEvictedAt)
-	// Advance the clock another 15 seconds. Again, since 15 seconds is less
-	// than half the TTL (seconds) since the last eviction, no eviction should
-	// be run.
-	clock.Advance(15 * time.Second)
-	c.Set("qux", "corge")
-	_, ok = c.items["foo"]
-	require.True(t, ok)
-	_, ok = c.items["bar"]
-	require.True(t, ok)
-	_, ok = c.items["baz"]
-	require.True(t, ok)
-	_, ok = c.items["qux"]
-	require.True(t, ok)
-	require.Equal(t, eviction2, c.lastEvictedAt)
-	// Advance the clock another 16 seconds. Since 31 seconds is more than
-	// half the TTL since the last eviction, an eviction should be run and
-	// this time foo should be evicted as it has expired.
-	clock.Advance(16 * time.Second)
-	c.Set("corge", "jorge")
-	_, ok = c.items["foo"]
-	require.False(t, ok)
-	_, ok = c.items["bar"]
-	require.True(t, ok)
-	_, ok = c.items["baz"]
-	require.True(t, ok)
-	_, ok = c.items["qux"]
-	require.True(t, ok)
-	_, ok = c.items["corge"]
-	require.True(t, ok)
-	eviction3 := clock.Now()
-	require.Equal(t, eviction3, c.lastEvictedAt)
-	// Advance the clock one whole minute. All items should be expired.
-	clock.Advance(time.Minute)
-	c.Set("foo", "bar")
-	_, ok = c.items["foo"]
-	require.True(t, ok)
-	_, ok = c.items["bar"]
-	require.False(t, ok)
-	_, ok = c.items["baz"]
-	require.False(t, ok)
-	_, ok = c.items["qux"]
-	require.False(t, ok)
-	_, ok = c.items["qux"]
-	require.False(t, ok)
-	eviction4 := clock.Now()
-	require.Equal(t, eviction4, c.lastEvictedAt)
+	synctest.Test(t, func(t *testing.T) {
+		c := newTTLCache[string, string](time.Minute)
+		c.Set("foo", "bar")
+		_, ok := c.items["foo"]
+		require.True(t, ok)
+		// Advance the clock and update foo, it should not be evicted as its
+		// expiration time should be refreshed.
+		time.Sleep(time.Minute)
+		c.Set("foo", "bar")
+		_, ok = c.items["foo"]
+		require.True(t, ok)
+		eviction1 := time.Now()
+		require.Equal(t, eviction1, c.lastEvictedAt)
+		// Advance the clock 15 seconds. Since 15 seconds is less than half
+		// the TTL (30 seconds) since the last eviction, no eviction should
+		// be run.
+		time.Sleep(15 * time.Second)
+		c.Set("bar", "baz")
+		_, ok = c.items["foo"]
+		require.True(t, ok)
+		_, ok = c.items["bar"]
+		require.True(t, ok)
+		require.Equal(t, eviction1, c.lastEvictedAt)
+		// Advance the clock 16 seconds. Since 31 seconds is more than half the TTL
+		// since the last eviction, an eviction should be run, but no items should
+		// be evicted.
+		time.Sleep(16 * time.Second)
+		c.Set("baz", "qux")
+		_, ok = c.items["foo"]
+		require.True(t, ok)
+		_, ok = c.items["bar"]
+		require.True(t, ok)
+		_, ok = c.items["baz"]
+		require.True(t, ok)
+		eviction2 := time.Now()
+		require.Equal(t, eviction2, c.lastEvictedAt)
+		// Advance the clock another 15 seconds. Again, since 15 seconds is less
+		// than half the TTL (seconds) since the last eviction, no eviction should
+		// be run.
+		time.Sleep(15 * time.Second)
+		c.Set("qux", "corge")
+		_, ok = c.items["foo"]
+		require.True(t, ok)
+		_, ok = c.items["bar"]
+		require.True(t, ok)
+		_, ok = c.items["baz"]
+		require.True(t, ok)
+		_, ok = c.items["qux"]
+		require.True(t, ok)
+		require.Equal(t, eviction2, c.lastEvictedAt)
+		// Advance the clock another 16 seconds. Since 31 seconds is more than
+		// half the TTL since the last eviction, an eviction should be run and
+		// this time foo should be evicted as it has expired.
+		time.Sleep(16 * time.Second)
+		c.Set("corge", "jorge")
+		_, ok = c.items["foo"]
+		require.False(t, ok)
+		_, ok = c.items["bar"]
+		require.True(t, ok)
+		_, ok = c.items["baz"]
+		require.True(t, ok)
+		_, ok = c.items["qux"]
+		require.True(t, ok)
+		_, ok = c.items["corge"]
+		require.True(t, ok)
+		eviction3 := time.Now()
+		require.Equal(t, eviction3, c.lastEvictedAt)
+		// Advance the clock one whole minute. All items should be expired.
+		time.Sleep(time.Minute)
+		c.Set("foo", "bar")
+		_, ok = c.items["foo"]
+		require.True(t, ok)
+		_, ok = c.items["bar"]
+		require.False(t, ok)
+		_, ok = c.items["baz"]
+		require.False(t, ok)
+		_, ok = c.items["qux"]
+		require.False(t, ok)
+		_, ok = c.items["qux"]
+		require.False(t, ok)
+		eviction4 := time.Now()
+		require.Equal(t, eviction4, c.lastEvictedAt)
+	})
 }
 
 func TestNopCache(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

We can now replace quartz with synctest.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
