### PR TITLE
feat: add a metric for estimate size of the bloom filter

### DIFF
--- a/pkg/limits/frontend/client.go
+++ b/pkg/limits/frontend/client.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/bits-and-blooms/bloom/v3"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/grafana/loki/v3/pkg/limits/proto"
 )
@@ -26,24 +28,40 @@ type limitsClient interface {
 type cacheLimitsClient struct {
 	ttl    time.Duration
 	onMiss limitsClient
+
 	// The fields below MUST NOT be used without mtx.
-	mtx          sync.RWMutex
-	knownStreams *bloom.BloomFilter
-	lastExpired  time.Time
+	mtx                  sync.RWMutex
+	acceptedStreamsCache *bloom.BloomFilter
+	lastExpired          time.Time
+
+	// Metrics.
+	acceptedStreamsCacheSize         prometheus.Gauge
+	acceptedStreamsCacheSizeEstimate prometheus.Gauge
 }
 
 // newCacheLimitsClient returns a new cache limits client.
 func newCacheLimitsClient(
 	ttl, maxJitter time.Duration,
-	knownStreams *bloom.BloomFilter,
+	acceptedStreamsCache *bloom.BloomFilter,
 	onMiss limitsClient,
+	r prometheus.Registerer,
 ) *cacheLimitsClient {
-	return &cacheLimitsClient{
-		ttl:          ttl,
-		knownStreams: knownStreams,
-		lastExpired:  time.Now().Add(randDuration(maxJitter)),
-		onMiss:       onMiss,
+	c := &cacheLimitsClient{
+		ttl:                  ttl,
+		acceptedStreamsCache: acceptedStreamsCache,
+		lastExpired:          time.Now().Add(randDuration(maxJitter)),
+		onMiss:               onMiss,
+		acceptedStreamsCacheSize: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_ingest_limits_frontend_accepted_streams_cache_size",
+			Help: "Max size of the accepted streams cache.",
+		}),
+		acceptedStreamsCacheSizeEstimate: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_ingest_limits_frontend_accepted_streams_cache_size_estimate",
+			Help: "Estimate size of the accepted streams cache.",
+		}),
 	}
+	c.acceptedStreamsCacheSize.Set(float64(acceptedStreamsCache.Cap()))
+	return c
 }
 
 // ExceedsLimits implements the [limitsClient] interface.
@@ -51,7 +69,7 @@ func (c *cacheLimitsClient) ExceedsLimits(ctx context.Context, req *proto.Exceed
 	c.expireTTL()
 	// If the exact same request has been seen before, and all streams were
 	// accepted, we can assume it will continue to be accepted.
-	if c.hasKnownStreams(req) {
+	if c.hasAcceptedStreams(req) {
 		return []*proto.ExceedsLimitsResponse{}, nil
 	}
 	// Need to check with the limits service.
@@ -74,9 +92,10 @@ func (c *cacheLimitsClient) ExceedsLimits(ctx context.Context, req *proto.Exceed
 		if _, ok := rejected[s.StreamHash]; !ok {
 			b := bytes.Buffer{}
 			encodeStreamToBuf(&b, req.Tenant, s)
-			c.knownStreams.Add(b.Bytes())
+			c.acceptedStreamsCache.Add(b.Bytes())
 		}
 	}
+	c.acceptedStreamsCacheSizeEstimate.Set(float64(c.acceptedStreamsCache.ApproximatedSize()))
 	return resps, nil
 }
 
@@ -100,13 +119,13 @@ func (c *cacheLimitsClient) expireTTL() {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 	if time.Since(c.lastExpired) > c.ttl {
-		c.knownStreams.ClearAll()
+		c.acceptedStreamsCache.ClearAll()
 		c.lastExpired = time.Now()
 	}
 }
 
-// hasKnownStreams returns true if all streams in req are known streams.
-func (c *cacheLimitsClient) hasKnownStreams(req *proto.ExceedsLimitsRequest) bool {
+// hasAcceptedStreams returns true if all streams are in the accepted streams cache.
+func (c *cacheLimitsClient) hasAcceptedStreams(req *proto.ExceedsLimitsRequest) bool {
 	// b is re-used. The data built from it MUST NOT escape this function.
 	b := bytes.Buffer{}
 	c.mtx.RLock()
@@ -114,7 +133,7 @@ func (c *cacheLimitsClient) hasKnownStreams(req *proto.ExceedsLimitsRequest) boo
 	for _, s := range req.Streams {
 		b.Reset()
 		encodeStreamToBuf(&b, req.Tenant, s)
-		if !c.knownStreams.Test(b.Bytes()) {
+		if !c.acceptedStreamsCache.Test(b.Bytes()) {
 			return false
 		}
 	}

--- a/pkg/limits/frontend/client_test.go
+++ b/pkg/limits/frontend/client_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/bits-and-blooms/bloom/v3"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/limits"
@@ -16,9 +17,9 @@ import (
 
 func TestCacheLimitsClient(t *testing.T) {
 	t.Run("streams accepted", func(t *testing.T) {
-		// When a stream is accepted, it should be inserted into known streams.
+		// When a stream is accepted, it should be inserted into the cache.
 		// We will assert this behavior later.
-		knownStreams := bloom.NewWithEstimates(10, 0.01)
+		acceptedStreamsCache := bloom.NewWithEstimates(10, 0.01)
 		onMiss := &mockLimitsClient{
 			t: t,
 			// Expect one stream 0x1 from the tenant "test".
@@ -29,7 +30,7 @@ func TestCacheLimitsClient(t *testing.T) {
 			// All streams accepted.
 			exceedsLimitsResponses: []*proto.ExceedsLimitsResponse{},
 		}
-		client := newCacheLimitsClient(time.Minute, 15*time.Second, knownStreams, onMiss)
+		client := newCacheLimitsClient(time.Minute, 15*time.Second, acceptedStreamsCache, onMiss, prometheus.NewRegistry())
 		resps, err := client.ExceedsLimits(t.Context(), &proto.ExceedsLimitsRequest{
 			Tenant:  "test",
 			Streams: []*proto.StreamMetadata{{StreamHash: 0x1}},
@@ -42,12 +43,12 @@ func TestCacheLimitsClient(t *testing.T) {
 		b := bytes.Buffer{}
 		b.Write([]byte("test"))
 		_ = binary.Write(&b, binary.LittleEndian, uint64(1))
-		require.True(t, knownStreams.Test(b.Bytes()))
+		require.True(t, acceptedStreamsCache.Test(b.Bytes()))
 	})
 
 	t.Run("streams rejected", func(t *testing.T) {
 		// When a stream is rejected, it should not be cached.
-		knownStreams := bloom.NewWithEstimates(10, 0.01)
+		acceptedStreamsCache := bloom.NewWithEstimates(10, 0.01)
 		onMiss := &mockLimitsClient{
 			t: t,
 			// Expect one stream 0x1 from the tenant "test".
@@ -63,7 +64,7 @@ func TestCacheLimitsClient(t *testing.T) {
 				}},
 			}},
 		}
-		client := newCacheLimitsClient(time.Minute, 15*time.Second, knownStreams, onMiss)
+		client := newCacheLimitsClient(time.Minute, 15*time.Second, acceptedStreamsCache, onMiss, prometheus.NewRegistry())
 		resps, err := client.ExceedsLimits(t.Context(), &proto.ExceedsLimitsRequest{
 			Tenant:  "test",
 			Streams: []*proto.StreamMetadata{{StreamHash: 0x1}},
@@ -71,20 +72,20 @@ func TestCacheLimitsClient(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, resps, 1)
 		// No bits should have been set.
-		require.Equal(t, uint(0), knownStreams.BitSet().Count())
+		require.Equal(t, uint(0), acceptedStreamsCache.BitSet().Count())
 	})
 
 	t.Run("cache is expired after TTL", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			knownStreams := bloom.NewWithEstimates(10, 0.01)
-			client := newCacheLimitsClient(time.Minute, 15*time.Second, knownStreams, &mockLimitsClient{})
+			acceptedStreamsCache := bloom.NewWithEstimates(10, 0.01)
+			client := newCacheLimitsClient(time.Minute, 15*time.Second, acceptedStreamsCache, &mockLimitsClient{}, prometheus.NewRegistry())
 			// Remove jitter for tests.
 			client.lastExpired = time.Now()
 
 			now := time.Now()
 			require.Equal(t, now, client.lastExpired)
 			// No bits should have been set.
-			require.Equal(t, uint(0), knownStreams.BitSet().Count())
+			require.Equal(t, uint(0), acceptedStreamsCache.BitSet().Count())
 
 			// Advance the clock, no reset should happen.
 			time.Sleep(time.Second)
@@ -92,8 +93,8 @@ func TestCacheLimitsClient(t *testing.T) {
 			require.Equal(t, now, client.lastExpired)
 
 			// Add some data to the cache.
-			knownStreams.Add([]byte("test"))
-			require.Greater(t, knownStreams.BitSet().Count(), uint(0))
+			acceptedStreamsCache.Add([]byte("test"))
+			require.Greater(t, acceptedStreamsCache.BitSet().Count(), uint(0))
 
 			// Advance the clock past the TTL (include the jitter).
 			time.Sleep(time.Minute + (5 * time.Second))
@@ -101,7 +102,7 @@ func TestCacheLimitsClient(t *testing.T) {
 			client.expireTTL()
 			require.Equal(t, now, client.lastExpired)
 			// The bits should have been reset.
-			require.Equal(t, uint(0), knownStreams.BitSet().Count())
+			require.Equal(t, uint(0), acceptedStreamsCache.BitSet().Count())
 		})
 	})
 }

--- a/pkg/limits/frontend/frontend.go
+++ b/pkg/limits/frontend/frontend.go
@@ -86,7 +86,7 @@ func New(cfg Config, ringName string, limitsRing ring.ReadRing, logger log.Logge
 	// Set up the limits client.
 	f.limitsClient = newRingLimitsClient(limitsRing, clientPool, cfg.NumPartitions, f.assignedPartitionsCache, logger, reg)
 	if cfg.CacheTTL > 0 {
-		f.limitsClient = newCacheLimitsClient(cfg.CacheTTL, cfg.CacheTTLJitter, bloom.NewWithEstimates(1000000, 0.01), f.limitsClient)
+		f.limitsClient = newCacheLimitsClient(cfg.CacheTTL, cfg.CacheTTLJitter, bloom.NewWithEstimates(1000000, 0.01), f.limitsClient, reg)
 	}
 	lifecycler, err := ring.NewLifecycler(cfg.LifecyclerConfig, f, RingName, RingKey, true, logger, reg)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This will help us track the size of the bloom filter and know if we need to increase it.

I also renamed the variable from `knownStreams` to `acceptedStreams` as I suspect we will have a `rejectedStreams` cache in future too.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
