### PR TITLE
feat: detect level in nested json objects encoded as strings

### DIFF
--- a/pkg/distributor/field_detection.go
+++ b/pkg/distributor/field_detection.go
@@ -2,6 +2,7 @@ package distributor
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"strconv"
 	"strings"
@@ -270,6 +271,40 @@ func getValueUsingJSONParser(line []byte, hints []string) []byte {
 	return res
 }
 
+// bytesLookLikeJSONObject returns true if the byte slice looks like a JSON object
+// (starts with '{' and ends with '}' after optional whitespace), so we can try
+// parsing string values (e.g. message payloads) as nested JSON.
+func bytesLookLikeJSONObject(data []byte) bool {
+	if len(data) == 0 {
+		return false
+	}
+	start := 0
+	for start < len(data) && (data[start] == ' ' || data[start] == '\t') {
+		start++
+	}
+	end := len(data) - 1
+	for end > start && (data[end] == ' ' || data[end] == '\t') {
+		end--
+	}
+	return start <= end && data[start] == '{' && data[end] == '}'
+}
+
+// unescapeJSONString interprets b as the content of a JSON string (without the surrounding quotes)
+// and returns the unescaped bytes. Uses json.Unmarshal; returns b unchanged if unmarshal fails.
+func unescapeJSONString(b []byte) []byte {
+	if len(b) == 0 {
+		return b
+	}
+	quoted := make([]byte, 0, len(b)+2)
+	quoted = append(append(quoted, '"'), b...)
+	quoted = append(quoted, '"')
+	var s string
+	if err := json.Unmarshal(quoted, &s); err != nil {
+		return b
+	}
+	return []byte(s)
+}
+
 func getLevelUsingJSONParser(line []byte, allowedLevelFields map[string]struct{}, maxDepth int) []byte {
 	var result []byte
 	var detectLevel func([]byte, int) error
@@ -286,6 +321,14 @@ func getLevelUsingJSONParser(line []byte, allowedLevelFields map[string]struct{}
 					result = value
 					// ErrKeyFound is used to stop parsing once we find the desired key
 					return errKeyFound
+				}
+				// String value may be JSON (e.g. message field with nested log.level).
+				// jsonparser returns string content without outer quotes; escape sequences (e.g. \") remain.
+				if bytesLookLikeJSONObject(value) {
+					nested := unescapeJSONString(value)
+					if err := detectLevel(nested, depth+1); err == errKeyFound {
+						return err
+					}
 				}
 			case jsonparser.Object:
 				if err := detectLevel(value, depth+1); err != nil {

--- a/pkg/distributor/field_detection_test.go
+++ b/pkg/distributor/field_detection_test.go
@@ -1107,6 +1107,13 @@ func TestGetLevelUsingJsonParser(t *testing.T) {
 			maxDepth:           1,
 			want:               "",
 		},
+		{
+			name:               "Parse JSON inside a string value",
+			json:               `{"time":"2026-01-22T18:27:31.91714715Z", "looksLikeJsonButItsNot": "{not_valid_json}", "message":"{\"message\":\"foo\",\"log.level\":\"INFO\"}","object":{"service":"foo"}}`,
+			allowedLevelFields: map[string]struct{}{"log.level": {}, "level": {}},
+			maxDepth:           0,
+			want:               "INFO",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:

Supports detecting the log level in nested json objects that are encoded as strings.

For example `"message":"{\"log.level\": \"INFO\"}"} ...` instead of `"message":{"log.level": "INFO"}} ...`

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
