### PR TITLE
chore: End index reader span on Close

### DIFF
--- a/pkg/dataobj/metastore/index_sections_reader.go
+++ b/pkg/dataobj/metastore/index_sections_reader.go
@@ -535,6 +535,10 @@ func (r *indexSectionsReader) Close() {
 	closeAll(r.streamsReaders)
 	closeAll(r.pointersReaders)
 	closeAll(r.bloomReaders)
+
+	if r.readSpan != nil {
+		r.readSpan.End()
+	}
 }
 
 func (r *indexSectionsReader) addLabelNamesForStream(streamID int64, names []string) {

--- a/pkg/dataobj/sections/indexpointers/reader.go
+++ b/pkg/dataobj/sections/indexpointers/reader.go
@@ -416,6 +416,7 @@ func (r *Reader) Reset(opts ReaderOptions) {
 	}
 	r.opts = opts
 	r.schema = columnsSchema(opts.Columns)
+	r.readSpan = nil
 
 	r.ready = false
 

--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -421,6 +421,7 @@ func (r *Reader) Reset(opts ReaderOptions) {
 	}
 	r.opts = opts
 	r.schema = columnsSchema(opts.Columns)
+	r.readSpan = nil
 
 	r.ready = false
 

--- a/pkg/dataobj/sections/pointers/reader.go
+++ b/pkg/dataobj/sections/pointers/reader.go
@@ -423,6 +423,7 @@ func (r *Reader) Reset(opts ReaderOptions) {
 	}
 	r.opts = opts
 	r.schema = columnsSchema(opts.Columns)
+	r.readSpan = nil
 
 	r.ready = false
 

--- a/pkg/dataobj/sections/streams/reader.go
+++ b/pkg/dataobj/sections/streams/reader.go
@@ -424,6 +424,7 @@ func (r *Reader) Reset(opts ReaderOptions) {
 	}
 	r.opts = opts
 	r.schema = columnsSchema(opts.Columns)
+	r.readSpan = nil
 
 	r.ready = false
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- read spans from `indexSectionsReader` are not being exported as they are never ended.
- reset `readSpan` field on all dataset readers on calling `Reset()`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
