### PR TITLE
docs: 3.6.6 Release Notes

### DIFF
--- a/docs/sources/release-notes/v3-6.md
+++ b/docs/sources/release-notes/v3-6.md
@@ -192,6 +192,10 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 ## Bug fixes
 
+### 3.6.5 (2025-02-16)
+
+* **deps:** Update Alpine Docker tag to v3.23.3 (main) ([#20630](https://github.com/grafana/loki/issues/20630)) ([#20832](https://github.com/grafana/loki/issues/20832)) ([fb20246](https://github.com/grafana/loki/commit/fb202465c6e9fdda198e06d6588de8381ded79e7)).
+
 ### 3.6.5 (2025-02-05)
 
 * **deps:** Bump go version for 3.6.x ([#20667](https://github.com/grafana/loki/issues/20667)) ([b06b508](https://github.com/grafana/loki/commit/b06b508e821a22e7913d3caefb6a61f56ad69089))


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Release Notes for the 3.6.6 patch release.