### PR TITLE
feat: refactor frontend cache, add metrics, filter out cached streams

### DIFF
--- a/pkg/limits/frontend/client_test.go
+++ b/pkg/limits/frontend/client_test.go
@@ -2,12 +2,11 @@ package frontend
 
 import (
 	"bytes"
-	"encoding/binary"
 	"testing"
 	"testing/synctest"
 	"time"
 
-	"github.com/bits-and-blooms/bloom/v3"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/limits"
@@ -15,47 +14,18 @@ import (
 )
 
 func TestCacheLimitsClient(t *testing.T) {
-	t.Run("streams accepted", func(t *testing.T) {
-		// When a stream is accepted, it should be inserted into known streams.
+	t.Run("accepted streams cached, rejected streams returned", func(t *testing.T) {
+		// When a stream is accepted, it should be inserted into the cache.
 		// We will assert this behavior later.
-		knownStreams := bloom.NewWithEstimates(10, 0.01)
+		cache := newAcceptedStreamsCache(time.Minute, 15*time.Second, 10, prometheus.NewRegistry())
 		onMiss := &mockLimitsClient{
 			t: t,
-			// Expect one stream 0x1 from the tenant "test".
+			// Expect two stream 0x1 and 0x2 from the tenant "test".
 			expectedExceedsLimitsRequest: &proto.ExceedsLimitsRequest{
 				Tenant:  "test",
-				Streams: []*proto.StreamMetadata{{StreamHash: 0x1}},
+				Streams: []*proto.StreamMetadata{{StreamHash: 0x1}, {StreamHash: 0x2}},
 			},
-			// All streams accepted.
-			exceedsLimitsResponses: []*proto.ExceedsLimitsResponse{},
-		}
-		client := newCacheLimitsClient(time.Minute, 15*time.Second, knownStreams, onMiss)
-		resps, err := client.ExceedsLimits(t.Context(), &proto.ExceedsLimitsRequest{
-			Tenant:  "test",
-			Streams: []*proto.StreamMetadata{{StreamHash: 0x1}},
-		})
-		// No streams should be rejected.
-		require.NoError(t, err)
-		require.Len(t, resps, 0)
-		// The cache should contain the stream 0x1 for the tenant "test".
-		// We don't use [encodeStreamToBuf] so we can test it.
-		b := bytes.Buffer{}
-		b.Write([]byte("test"))
-		_ = binary.Write(&b, binary.LittleEndian, uint64(1))
-		require.True(t, knownStreams.Test(b.Bytes()))
-	})
-
-	t.Run("streams rejected", func(t *testing.T) {
-		// When a stream is rejected, it should not be cached.
-		knownStreams := bloom.NewWithEstimates(10, 0.01)
-		onMiss := &mockLimitsClient{
-			t: t,
-			// Expect one stream 0x1 from the tenant "test".
-			expectedExceedsLimitsRequest: &proto.ExceedsLimitsRequest{
-				Tenant:  "test",
-				Streams: []*proto.StreamMetadata{{StreamHash: 0x1}},
-			},
-			// The stream should be rejected.
+			// Reject stream 0x1.
 			exceedsLimitsResponses: []*proto.ExceedsLimitsResponse{{
 				Results: []*proto.ExceedsLimitsResult{{
 					StreamHash: 0x1,
@@ -63,45 +33,118 @@ func TestCacheLimitsClient(t *testing.T) {
 				}},
 			}},
 		}
-		client := newCacheLimitsClient(time.Minute, 15*time.Second, knownStreams, onMiss)
+		client := newCacheLimitsClient(cache, onMiss)
 		resps, err := client.ExceedsLimits(t.Context(), &proto.ExceedsLimitsRequest{
 			Tenant:  "test",
-			Streams: []*proto.StreamMetadata{{StreamHash: 0x1}},
+			Streams: []*proto.StreamMetadata{{StreamHash: 0x1}, {StreamHash: 0x2}},
 		})
+		// The stream 0x1 should have been rejected, and should be absent
+		// from the cache.
 		require.NoError(t, err)
 		require.Len(t, resps, 1)
-		// No bits should have been set.
-		require.Equal(t, uint(0), knownStreams.BitSet().Count())
+		require.Len(t, resps[0].Results, 1)
+		require.Equal(t, uint64(0x1), resps[0].Results[0].StreamHash)
+		b := bytes.Buffer{}
+		encodeStreamToBuf(&b, "test", &proto.StreamMetadata{StreamHash: 0x1})
+		require.False(t, cache.bf.Test(b.Bytes()))
+		// The cache should contain the stream 0x2 for the tenant "test".
+		b.Reset()
+		encodeStreamToBuf(&b, "test", &proto.StreamMetadata{StreamHash: 0x2})
+		require.True(t, cache.bf.Test(b.Bytes()))
 	})
 
-	t.Run("cache is expired after TTL", func(t *testing.T) {
+	t.Run("cached streams are returned", func(t *testing.T) {
+		cache := newAcceptedStreamsCache(time.Minute, 15*time.Second, 10, prometheus.NewRegistry())
+		cache.Update("test", []*proto.StreamMetadata{{StreamHash: 0x1}})
+		onMiss := &mockLimitsClient{
+			t: t,
+			// Expect one stream 0x2 because 0x1 is cached.
+			expectedExceedsLimitsRequest: &proto.ExceedsLimitsRequest{
+				Tenant:  "test",
+				Streams: []*proto.StreamMetadata{{StreamHash: 0x2}},
+			},
+			exceedsLimitsResponses: []*proto.ExceedsLimitsResponse{},
+		}
+		client := newCacheLimitsClient(cache, onMiss)
+		resps, err := client.ExceedsLimits(t.Context(), &proto.ExceedsLimitsRequest{
+			Tenant:  "test",
+			Streams: []*proto.StreamMetadata{{StreamHash: 0x1}, {StreamHash: 0x2}},
+		})
+		require.NoError(t, err)
+		require.Len(t, resps, 0)
+	})
+}
+
+func TestAcceptedStreamsCache(t *testing.T) {
+	t.Run("cache is cleared after TTL elapsed", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			knownStreams := bloom.NewWithEstimates(10, 0.01)
-			client := newCacheLimitsClient(time.Minute, 15*time.Second, knownStreams, &mockLimitsClient{})
+			c := newAcceptedStreamsCache(time.Minute, 15*time.Second, 10, prometheus.NewRegistry())
 			// Remove jitter for tests.
-			client.lastExpired = time.Now()
+			c.lastExpired = time.Now()
 
 			now := time.Now()
-			require.Equal(t, now, client.lastExpired)
+			require.Equal(t, now, c.lastExpired)
 			// No bits should have been set.
-			require.Equal(t, uint(0), knownStreams.BitSet().Count())
+			require.Equal(t, uint(0), c.bf.BitSet().Count())
 
 			// Advance the clock, no reset should happen.
 			time.Sleep(time.Second)
-			client.expireTTL()
-			require.Equal(t, now, client.lastExpired)
+			c.ExpireTTL()
+			require.Equal(t, now, c.lastExpired)
 
 			// Add some data to the cache.
-			knownStreams.Add([]byte("test"))
-			require.Greater(t, knownStreams.BitSet().Count(), uint(0))
+			c.bf.Add([]byte("test"))
+			require.Greater(t, c.bf.BitSet().Count(), uint(0))
 
 			// Advance the clock past the TTL (include the jitter).
 			time.Sleep(time.Minute + (5 * time.Second))
 			now = time.Now()
-			client.expireTTL()
-			require.Equal(t, now, client.lastExpired)
+			c.ExpireTTL()
+			require.Equal(t, now, c.lastExpired)
 			// The bits should have been reset.
-			require.Equal(t, uint(0), knownStreams.BitSet().Count())
+			require.Equal(t, uint(0), c.bf.BitSet().Count())
 		})
+	})
+
+	t.Run("request is filtered in place, accepted streams are removed", func(t *testing.T) {
+		c := newAcceptedStreamsCache(time.Minute, 15*time.Second, 10, prometheus.NewRegistry())
+		// Create a stream and add it to the cache.
+		s1 := &proto.StreamMetadata{StreamHash: 0x1}
+		c.Update("test", []*proto.StreamMetadata{s1})
+		// Create a second stream but do not add it to the cache.
+		s2 := &proto.StreamMetadata{StreamHash: 0x2}
+		req := &proto.ExceedsLimitsRequest{
+			Tenant:  "test",
+			Streams: []*proto.StreamMetadata{s1, s2},
+		}
+		c.FilterInPlace(req)
+		require.Len(t, req.Streams, 1)
+		require.Equal(t, uint64(0x2), req.Streams[0].StreamHash)
+	})
+
+	t.Run("cache contains streams", func(t *testing.T) {
+		c := newAcceptedStreamsCache(time.Minute, 15*time.Second, 10, prometheus.NewRegistry())
+		// Create a stream, add it to the cache, and then check that it is
+		// present.
+		s1 := &proto.StreamMetadata{StreamHash: 0x1}
+		c.Update("test", []*proto.StreamMetadata{s1})
+		b := bytes.Buffer{}
+		encodeStreamToBuf(&b, "test", s1)
+		require.True(t, c.bf.Test(b.Bytes()))
+		// Create a second stream without adding it to the cache, and then
+		// check that it is absent.
+		s2 := &proto.StreamMetadata{StreamHash: 0x2}
+		b.Reset()
+		encodeStreamToBuf(&b, "test", s2)
+		require.False(t, c.bf.Test(b.Bytes()))
+		// Add the second stream to the cache, and then check both streams
+		// are present.
+		c.Update("test", []*proto.StreamMetadata{s2})
+		b.Reset()
+		encodeStreamToBuf(&b, "test", s1)
+		require.True(t, c.bf.Test(b.Bytes()))
+		b.Reset()
+		encodeStreamToBuf(&b, "test", s2)
+		require.True(t, c.bf.Test(b.Bytes()))
 	})
 }

--- a/pkg/limits/frontend/frontend.go
+++ b/pkg/limits/frontend/frontend.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/ring"
@@ -86,7 +85,7 @@ func New(cfg Config, ringName string, limitsRing ring.ReadRing, logger log.Logge
 	// Set up the limits client.
 	f.limitsClient = newRingLimitsClient(limitsRing, clientPool, cfg.NumPartitions, f.assignedPartitionsCache, logger, reg)
 	if cfg.CacheTTL > 0 {
-		f.limitsClient = newCacheLimitsClient(cfg.CacheTTL, cfg.CacheTTLJitter, bloom.NewWithEstimates(1000000, 0.01), f.limitsClient)
+		f.limitsClient = newCacheLimitsClient(newAcceptedStreamsCache(cfg.CacheTTL, cfg.CacheTTLJitter, 1000000, reg), f.limitsClient)
 	}
 	lifecycler, err := ring.NewLifecycler(cfg.LifecyclerConfig, f, RingName, RingKey, true, logger, reg)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit refactors the frontend cache into a separate struct called the acceptedStreamsCache. This will allow us to add other caches in future without confusion over which variables (i.e. multiple TTLs) are for which caches.

It also add two metrics to the cache to track the maximum size of the bloom filter, and the current estimated size, so operators know if the bloom filter needs to be resized to reduce false positives.

Last, it provides a further optimization where we removed cached streams from the request. This helps for requests that contain a mix of cached and uncached streams.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
