### PR TITLE
feat(enginev2): Top level columnar reader

### DIFF
--- a/pkg/dataobj/internal/dataset/page_reader.go
+++ b/pkg/dataobj/internal/dataset/page_reader.go
@@ -81,7 +81,7 @@ func (pr *pageReader) skipUnwantedRows(alloc *memory.Allocator) error {
 	defer tempAlloc.Free()
 
 	readCount := int(pr.nextRow - pr.pageRow)
-	_, err := pr.readColumnar(alloc, readCount, true)
+	_, err := pr.readColumnar(tempAlloc, readCount, true)
 	return err
 }
 

--- a/pkg/dataobj/internal/dataset/reader.go
+++ b/pkg/dataobj/internal/dataset/reader.go
@@ -71,7 +71,7 @@ func (r *Reader) Reset(opts ReaderOptions) {
 }
 
 // Open initializes the Reader so it is ready to be used. Open must be called before Read.
-func (r *Reader) Open(ctx context.Context) error {
+func (r *Reader) Open(_ context.Context) error {
 	if r.ready {
 		return nil
 	}
@@ -124,7 +124,7 @@ func (r *Reader) Read(ctx context.Context, alloc *memory.Allocator, count int) (
 		// Drain the pending buffer to the output until it's empty.
 		// We read pending until it is completely empty, which may result in a small read at the end of the batch.
 		output := r.pending.Slice(int(r.row-r.pendingRow), int(r.row-r.pendingRow+int64(readCount)))
-		r.row += int64(output.NumRows())
+		r.row += output.NumRows()
 		return output, nil
 	}
 
@@ -133,7 +133,7 @@ func (r *Reader) Read(ctx context.Context, alloc *memory.Allocator, count int) (
 	r.pendingAllocator.Reclaim()
 
 	// We also create a temporary allocator for this Read which we can use to allocate any intermediate arrays.
-	tempAlloc := memory.NewAllocator(r.pendingAllocator)
+	tempAlloc := memory.NewAllocator(alloc)
 	defer tempAlloc.Free()
 
 	// Check the first column to see how many rows are remaining. They should all be the same so this is OK.
@@ -173,9 +173,9 @@ func (r *Reader) Read(ctx context.Context, alloc *memory.Allocator, count int) (
 	r.pending = columnar.NewRecordBatch(r.schema, int64(arrs.Get(0).Len()), arrs.Data())
 
 	readCount := min(arrs.Get(0).Len(), count)
-	output := r.pending.Slice(0, int(readCount))
+	output := r.pending.Slice(0, readCount)
 
-	r.row += int64(output.NumRows())
+	r.row += output.NumRows()
 	return output, nil
 }
 

--- a/pkg/dataobj/internal/dataset/reader.go
+++ b/pkg/dataobj/internal/dataset/reader.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/memory"
 )
 
-// RowReaderOptions configures how a [RowReader] will read [Row]s.
+// ReaderOptions configures how a [Reader] will read data.
 type ReaderOptions struct {
 	// Columns to read from the Dataset. It is invalid to provide a Column that
 	// is not in Dataset.
@@ -26,11 +26,12 @@ type ReaderOptions struct {
 	// Holds a list of predicates that can be sequentially applied to the dataset.
 	Predicates []Predicate
 
-	// BatchSize is the number of rows to read in a single batch.
-	// A higher batch size will reduce the number of calls to the decoders, but will also increase the memory usage.
+	// BatchSize is the number of rows to buffer in memory for future calls to Read.
+	// A higher batch size will improve performance by reducing the number of calls to the decoders, but will also increase the memory usage.
 	BatchSize int
 
-	// Allocator to use for the lifetime of the reader, until reset. If nil, a new allocator will be created.
+	// Allocator is used to allocate memory for the Reader, retained between Read calls.
+	// A reader must not be used after it's allocator is freed or reclaimed until Reset is called.
 	Allocator *memory.Allocator
 }
 
@@ -48,18 +49,14 @@ type Reader struct {
 	schema        *columnar.Schema
 }
 
-/*
-dataset.Reader maintains two buffers, both sized to the configured batch_size :
-As before, dataset.Reader wraps around column readers for each column referenced in
-the output schema or by predicates. These column readers may have their own buffers
-not described above.
-*/
+// NewReader creates a new dataset Reader with the given options.
 func NewReader(opts ReaderOptions) *Reader {
 	r := Reader{opts: opts}
 	r.Reset(opts)
 	return &r
 }
 
+// Reset resets the Reader with the given options so it is ready to be re-used.
 func (r *Reader) Reset(opts ReaderOptions) {
 	r.opts = opts
 	r.columnReaders = sliceclear.Clear(r.columnReaders)
@@ -70,6 +67,7 @@ func (r *Reader) Reset(opts ReaderOptions) {
 	r.ready = false
 }
 
+// Open initializes the Reader so it is ready to be used. Open must be called before Read.
 func (r *Reader) Open(ctx context.Context) error {
 	if r.ready {
 		return nil
@@ -111,6 +109,8 @@ func validateOpts(opts ReaderOptions) error {
 	return nil
 }
 
+// Read reads up to count rows from the dataset.
+// Read may buffer up to opts.BatchSize rows in memory for future calls to Read.
 func (r *Reader) Read(ctx context.Context, alloc *memory.Allocator, count int) (*columnar.RecordBatch, error) {
 	if !r.ready {
 		return nil, errors.New("reader not initialized")
@@ -144,14 +144,13 @@ func (r *Reader) Read(ctx context.Context, alloc *memory.Allocator, count int) (
 	selectionVector := memory.NewBitmap(tempAlloc, int(readSize))
 	selectionVector.AppendCount(true, int(readSize))
 
-	// TODO: Apply selection vector
+	// TODO: Implement selection vectors
 	_ = applySelectionVector(tempAlloc, selectionVector)
 
-	// Read rows into pending buffer
-	r.pendingRow = r.row
-
-	// We use the semi-permanent allocator here because the pending buffer is retained beyond the lifetime of the read. It is tied to the lifetime of the Reader so it is used after Reset.
+	// The pending allocator is used here because the pending buffer is retained beyond the lifetime of the read.
+	// Instead, it is tied to the lifetime of the Reader.
 	arrs := memory.NewBuffer[columnar.Array](r.pendingAllocator, len(r.columnReaders))
+	r.pendingRow = r.row
 	for _, column := range r.columnReaders {
 		arr, err := column.Read(ctx, r.pendingAllocator, count)
 		if err != nil && !errors.Is(err, io.EOF) {

--- a/pkg/dataobj/internal/dataset/reader.go
+++ b/pkg/dataobj/internal/dataset/reader.go
@@ -1,0 +1,182 @@
+package dataset
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/sliceclear"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// RowReaderOptions configures how a [RowReader] will read [Row]s.
+type ReaderOptions struct {
+	// Columns to read from the Dataset. It is invalid to provide a Column that
+	// is not in Dataset.
+	//
+	// The set of Columns can include columns not used in Predicate; such columns
+	// are considered non-predicate columns.
+	Columns []Column
+
+	// Predicates filter the data returned by a RowReader. Predicates are
+	// optional; if nil, all rows from Columns are returned.
+	//
+	// Expressions in Predicate may only reference columns in Columns.
+	// Holds a list of predicates that can be sequentially applied to the dataset.
+	Predicates []Predicate
+
+	// BatchSize is the number of rows to read in a single batch.
+	// A higher batch size will reduce the number of calls to the decoders, but will also increase the memory usage.
+	BatchSize int
+
+	// Allocator to use for the lifetime of the reader, until reset. If nil, a new allocator will be created.
+	Allocator *memory.Allocator
+}
+
+type Reader struct {
+	opts  ReaderOptions
+	ready bool
+
+	pending          *columnar.RecordBatch
+	pendingRow       int64
+	pendingAllocator *memory.Allocator
+
+	row int64
+
+	columnReaders []*columnReader
+	schema        *columnar.Schema
+}
+
+/*
+dataset.Reader maintains two buffers, both sized to the configured batch_size :
+As before, dataset.Reader wraps around column readers for each column referenced in
+the output schema or by predicates. These column readers may have their own buffers
+not described above.
+*/
+func NewReader(opts ReaderOptions) *Reader {
+	r := Reader{opts: opts}
+	r.Reset(opts)
+	return &r
+}
+
+func (r *Reader) Reset(opts ReaderOptions) {
+	r.opts = opts
+	r.columnReaders = sliceclear.Clear(r.columnReaders)
+	r.pending = nil
+	r.pendingAllocator = memory.NewAllocator(r.opts.Allocator)
+	r.row = 0
+
+	r.ready = false
+}
+
+func (r *Reader) Open(ctx context.Context) error {
+	if r.ready {
+		return nil
+	}
+
+	err := validateOpts(r.opts)
+	if err != nil {
+		return err
+	}
+
+	for _, column := range r.opts.Columns {
+		r.columnReaders = append(r.columnReaders, newColumnReader(column))
+	}
+
+	// TODO: Split this into an output & predicate schema.
+	columns := make([]columnar.Column, len(r.opts.Columns))
+	for i, column := range r.opts.Columns {
+		columns[i] = columnar.Column{
+			Name: column.ColumnDesc().Type.Logical + "/" + column.ColumnDesc().Tag,
+		}
+	}
+	r.schema = columnar.NewSchema(columns)
+
+	r.ready = true
+	return nil
+}
+
+func validateOpts(opts ReaderOptions) error {
+	if opts.Allocator == nil {
+		return errors.New("allocator is required")
+	}
+	if opts.BatchSize <= 0 {
+		return errors.New("batch size must be greater than 0")
+	}
+	if len(opts.Columns) == 0 {
+		return errors.New("at least one column is required")
+	}
+
+	return nil
+}
+
+func (r *Reader) Read(ctx context.Context, alloc *memory.Allocator, count int) (*columnar.RecordBatch, error) {
+	if !r.ready {
+		return nil, errors.New("reader not initialized")
+	}
+
+	if r.pending != nil && r.pendingRow+r.pending.NumRows() >= r.row+int64(count) {
+		readCount := min(count, int(r.pending.NumRows()))
+		// Drain the pending buffer to the output until it's empty.
+		// We read pending until it is completely empty, which may result in a small read at the end of the batch.
+		output := r.pending.Slice(int(r.row-r.pendingRow), int(r.row-r.pendingRow+int64(readCount)))
+		r.row += int64(output.NumRows())
+		return output, nil
+	}
+
+	// Pending buffer is now empty, refill it up to the batch size.
+	// We can reclaim any previously used memory now that we've finished with our previous pending buffer.
+	r.pendingAllocator.Reclaim()
+
+	// We also create a temporary allocator for this Read which we can use to allocate any intermediate arrays.
+	tempAlloc := memory.NewAllocator(r.pendingAllocator)
+	defer tempAlloc.Free()
+
+	// Check the first column to see how many rows are remaining. They should all be the same so this is OK.
+	rowsRemaining := int64(r.columnReaders[0].column.ColumnDesc().RowsCount) - r.columnReaders[0].nextRow
+	if rowsRemaining <= 0 {
+		return nil, io.EOF
+	}
+
+	// Init selection vector to true (all rows selected)
+	readSize := min(int64(r.opts.BatchSize), rowsRemaining)
+	selectionVector := memory.NewBitmap(tempAlloc, int(readSize))
+	selectionVector.AppendCount(true, int(readSize))
+
+	// TODO: Apply selection vector
+	_ = applySelectionVector(tempAlloc, selectionVector)
+
+	// Read rows into pending buffer
+	r.pendingRow = r.row
+
+	// We use the semi-permanent allocator here because the pending buffer is retained beyond the lifetime of the read. It is tied to the lifetime of the Reader so it is used after Reset.
+	arrs := memory.NewBuffer[columnar.Array](r.pendingAllocator, len(r.columnReaders))
+	for _, column := range r.columnReaders {
+		arr, err := column.Read(ctx, r.pendingAllocator, count)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return nil, err
+		}
+		arrs.Append(arr)
+	}
+
+	if arrs.Len() == 0 {
+		return nil, io.EOF
+	}
+
+	if arrs.Get(0).Len() == 0 {
+		return nil, io.EOF
+	}
+
+	r.pending = columnar.NewRecordBatch(r.schema, int64(arrs.Get(0).Len()), arrs.Data())
+
+	readCount := min(arrs.Get(0).Len(), count)
+	output := r.pending.Slice(0, int(readCount))
+
+	r.row += int64(output.NumRows())
+	return output, nil
+}
+
+func applySelectionVector(_ *memory.Allocator, selection memory.Bitmap) memory.Bitmap {
+	return selection
+}

--- a/pkg/dataobj/internal/dataset/reader.go
+++ b/pkg/dataobj/internal/dataset/reader.go
@@ -59,6 +59,9 @@ func NewReader(opts ReaderOptions) *Reader {
 // Reset resets the Reader with the given options so it is ready to be re-used.
 func (r *Reader) Reset(opts ReaderOptions) {
 	r.opts = opts
+	for _, columnReader := range r.columnReaders {
+		_ = columnReader.Close()
+	}
 	r.columnReaders = sliceclear.Clear(r.columnReaders)
 	r.pending = nil
 	r.pendingAllocator = memory.NewAllocator(r.opts.Allocator)

--- a/pkg/dataobj/internal/dataset/reader_test.go
+++ b/pkg/dataobj/internal/dataset/reader_test.go
@@ -35,7 +35,7 @@ func buildReaderTestColumn(t testing.TB, name string, values []string) *MemColum
 	t.Helper()
 
 	builder, err := NewColumnBuilder("", BuilderOptions{
-		PageSizeHint: 2 * 1024 * 1024,
+		PageSizeHint: 1024 * 1024,
 		Type:         ColumnType{Physical: datasetmd.PHYSICAL_TYPE_BINARY, Logical: name},
 		Compression:  datasetmd.COMPRESSION_TYPE_ZSTD,
 		Encoding:     datasetmd.ENCODING_TYPE_PLAIN,

--- a/pkg/dataobj/internal/dataset/reader_test.go
+++ b/pkg/dataobj/internal/dataset/reader_test.go
@@ -35,7 +35,7 @@ func buildReaderTestColumn(t testing.TB, name string, values []string) *MemColum
 	t.Helper()
 
 	builder, err := NewColumnBuilder("", BuilderOptions{
-		PageSizeHint: 128,
+		PageSizeHint: 2 * 1024 * 1024,
 		Type:         ColumnType{Physical: datasetmd.PHYSICAL_TYPE_BINARY, Logical: name},
 		Compression:  datasetmd.COMPRESSION_TYPE_ZSTD,
 		Encoding:     datasetmd.ENCODING_TYPE_PLAIN,
@@ -249,7 +249,7 @@ func TestReader_ReadEOFOnEmpty(t *testing.T) {
 }
 
 func BenchmarkReader_Read(b *testing.B) {
-	totalValues := 16 * 1024
+	totalValues := 64 * 1024
 	values := make([]string, totalValues)
 	for i := range values {
 		values[i] = fmt.Sprintf("value %d [%s]", i, strings.Repeat("A", 100))
@@ -273,12 +273,13 @@ func BenchmarkReader_Read(b *testing.B) {
 		})
 		r.Open(context.Background())
 		for {
-			_, err := r.Read(context.Background(), readerAlloc, 256)
+			_, err := r.Read(context.Background(), readerAlloc, 8192)
 			if err == io.EOF {
 				break
 			}
 			readerAlloc.Reclaim()
 		}
+		alloc.Reclaim()
 	}
 	b.SetBytes(int64(col.Desc.UncompressedSize))
 	b.ReportMetric(float64(totalValues*b.N)/b.Elapsed().Seconds(), "values/s")

--- a/pkg/dataobj/internal/dataset/reader_test.go
+++ b/pkg/dataobj/internal/dataset/reader_test.go
@@ -1,0 +1,286 @@
+package dataset
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+var readerTestStrings = []string{
+	"reader string 1",
+	"reader string 2",
+	"",
+	"reader string 4",
+	"reader string 5",
+	"reader string 1",
+	"reader string 2",
+	"",
+	"reader string 4",
+	"reader string 5",
+	"reader string 1",
+	"reader string 2",
+	"",
+	"reader string 4",
+	"reader string 5",
+}
+
+func buildReaderTestColumn(t testing.TB, name string, values []string) *MemColumn {
+	t.Helper()
+
+	builder, err := NewColumnBuilder("", BuilderOptions{
+		PageSizeHint: 128,
+		Type:         ColumnType{Physical: datasetmd.PHYSICAL_TYPE_BINARY, Logical: name},
+		Compression:  datasetmd.COMPRESSION_TYPE_ZSTD,
+		Encoding:     datasetmd.ENCODING_TYPE_PLAIN,
+	})
+	require.NoError(t, err)
+
+	for i, v := range values {
+		require.NoError(t, builder.Append(i, BinaryValue([]byte(v))))
+	}
+
+	col, err := builder.Flush()
+	require.NoError(t, err)
+	return col
+}
+
+func TestReader_ReadNotInitialized(t *testing.T) {
+	alloc := memory.NewAllocator(nil)
+	col := buildReaderTestColumn(t, "data", readerTestStrings)
+
+	r := NewReader(ReaderOptions{
+		Columns:   []Column{col},
+		BatchSize: 4,
+		Allocator: alloc,
+	})
+
+	_, err := r.Read(context.Background(), alloc, 4)
+	require.Error(t, err, "Read on unopened reader should fail")
+}
+
+func TestReader_OpenIdempotent(t *testing.T) {
+	alloc := memory.NewAllocator(nil)
+	col := buildReaderTestColumn(t, "data", readerTestStrings)
+
+	r := NewReader(ReaderOptions{
+		Columns:   []Column{col},
+		BatchSize: 4,
+		Allocator: alloc,
+	})
+
+	require.NoError(t, r.Open(context.Background()))
+	require.NoError(t, r.Open(context.Background()), "second Open should be a no-op")
+}
+
+func TestReader_ReadSingleBatch(t *testing.T) {
+	alloc := memory.NewAllocator(nil)
+	col := buildReaderTestColumn(t, "data", readerTestStrings)
+
+	r := NewReader(ReaderOptions{
+		Columns:   []Column{col},
+		BatchSize: len(readerTestStrings),
+		Allocator: alloc,
+	})
+	require.NoError(t, r.Open(context.Background()))
+
+	batch, err := r.Read(context.Background(), alloc, len(readerTestStrings))
+	require.NoError(t, err)
+	require.NotNil(t, batch)
+	require.Equal(t, int64(1), batch.NumCols())
+	require.Greater(t, batch.NumRows(), int64(0))
+}
+
+func TestReader_ReadMultipleBatches(t *testing.T) {
+	alloc := memory.NewAllocator(nil)
+	col := buildReaderTestColumn(t, "data", readerTestStrings)
+
+	batchSize := 4
+	r := NewReader(ReaderOptions{
+		Columns:   []Column{col},
+		BatchSize: batchSize,
+		Allocator: alloc,
+	})
+	require.NoError(t, r.Open(context.Background()))
+
+	var totalRows int64
+	for {
+		batch, err := r.Read(context.Background(), alloc, batchSize)
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		require.NotNil(t, batch)
+		totalRows += batch.NumRows()
+	}
+	require.Equal(t, int64(len(readerTestStrings)), totalRows)
+}
+
+func TestReader_ReadMultipleColumns(t *testing.T) {
+	alloc := memory.NewAllocator(nil)
+
+	col1 := buildReaderTestColumn(t, "data1", readerTestStrings)
+	col2 := buildReaderTestColumn(t, "data2", readerTestStrings)
+
+	r := NewReader(ReaderOptions{
+		Columns:   []Column{col1, col2},
+		BatchSize: len(readerTestStrings),
+		Allocator: alloc,
+	})
+	require.NoError(t, r.Open(context.Background()))
+
+	batch, err := r.Read(context.Background(), alloc, len(readerTestStrings))
+	require.NoError(t, err)
+	require.NotNil(t, batch)
+	require.Equal(t, int64(2), batch.NumCols())
+}
+
+func TestReader_ReadCountSmallerThanBatch(t *testing.T) {
+	alloc := memory.NewAllocator(nil)
+	col := buildReaderTestColumn(t, "data", readerTestStrings)
+
+	r := NewReader(ReaderOptions{
+		Columns:   []Column{col},
+		BatchSize: len(readerTestStrings),
+		Allocator: alloc,
+	})
+	require.NoError(t, r.Open(context.Background()))
+
+	batch, err := r.Read(context.Background(), alloc, 2)
+	require.NoError(t, err)
+	require.NotNil(t, batch)
+	require.LessOrEqual(t, batch.NumRows(), int64(2))
+}
+
+func TestReader_Reset(t *testing.T) {
+	alloc := memory.NewAllocator(nil)
+	col := buildReaderTestColumn(t, "data", readerTestStrings)
+
+	r := NewReader(ReaderOptions{
+		Columns:   []Column{col},
+		BatchSize: 4,
+		Allocator: alloc,
+	})
+	require.NoError(t, r.Open(context.Background()))
+
+	newCol := buildReaderTestColumn(t, "data", readerTestStrings[:5])
+	r.Reset(ReaderOptions{
+		Columns:   []Column{newCol},
+		BatchSize: 8,
+		Allocator: alloc,
+	})
+
+	_, err := r.Read(context.Background(), alloc, 4)
+	require.Error(t, err, "Read after Reset without Open should fail")
+
+	require.NoError(t, r.Open(context.Background()))
+
+	batch, err := r.Read(context.Background(), alloc, 8)
+	require.NoError(t, err)
+	require.NotNil(t, batch)
+}
+
+func TestReader_SchemaMatchesColumns(t *testing.T) {
+	alloc := memory.NewAllocator(nil)
+	col1 := buildReaderTestColumn(t, "data1", readerTestStrings)
+
+	builder2, err := NewColumnBuilder("tag2", BuilderOptions{
+		PageSizeHint: 128,
+		Type:         ColumnType{Physical: datasetmd.PHYSICAL_TYPE_BINARY, Logical: "label"},
+		Compression:  datasetmd.COMPRESSION_TYPE_SNAPPY,
+		Encoding:     datasetmd.ENCODING_TYPE_PLAIN,
+	})
+	require.NoError(t, err)
+	for i, v := range readerTestStrings {
+		require.NoError(t, builder2.Append(i, BinaryValue([]byte(v))))
+	}
+	col2, err := builder2.Flush()
+	require.NoError(t, err)
+
+	r := NewReader(ReaderOptions{
+		Columns:   []Column{col1, col2},
+		BatchSize: len(readerTestStrings),
+		Allocator: alloc,
+	})
+	require.NoError(t, r.Open(context.Background()))
+
+	schema := r.schema
+	require.Equal(t, 2, schema.NumColumns())
+	require.Equal(t, "data1/", schema.Column(0).Name)
+	require.Equal(t, "label/tag2", schema.Column(1).Name)
+}
+
+func TestReader_ReadEOFOnEmpty(t *testing.T) {
+	alloc := memory.NewAllocator(nil)
+
+	builder, err := NewColumnBuilder("", BuilderOptions{
+		PageSizeHint: 128,
+		Type:         ColumnType{Physical: datasetmd.PHYSICAL_TYPE_BINARY, Logical: "data"},
+		Compression:  datasetmd.COMPRESSION_TYPE_SNAPPY,
+		Encoding:     datasetmd.ENCODING_TYPE_PLAIN,
+	})
+	require.NoError(t, err)
+
+	// Append a single value so we have a valid column, then read past it.
+	require.NoError(t, builder.Append(0, BinaryValue([]byte("only"))))
+	col, err := builder.Flush()
+	require.NoError(t, err)
+
+	r := NewReader(ReaderOptions{
+		Columns:   []Column{col},
+		BatchSize: 10,
+		Allocator: alloc,
+	})
+	require.NoError(t, r.Open(context.Background()))
+
+	// First read should succeed.
+	_, err = r.Read(context.Background(), alloc, 10)
+	require.NoError(t, err)
+
+	// Second read should EOF.
+	_, err = r.Read(context.Background(), alloc, 10)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func BenchmarkReader_Read(b *testing.B) {
+	totalValues := 16 * 1024
+	values := make([]string, totalValues)
+	for i := range values {
+		values[i] = fmt.Sprintf("value %d [%s]", i, strings.Repeat("A", 100))
+	}
+
+	col := buildReaderTestColumn(b, "data", values)
+
+	alloc := memory.NewAllocator(nil)
+	r := NewReader(ReaderOptions{
+		Columns:   []Column{col},
+		BatchSize: totalValues / 2,
+		Allocator: alloc,
+	})
+
+	readerAlloc := memory.NewAllocator(alloc)
+	for b.Loop() {
+		alloc.Reclaim()
+		r.Reset(ReaderOptions{
+			Columns:   []Column{col},
+			BatchSize: totalValues / 2,
+			Allocator: alloc,
+		})
+		r.Open(context.Background())
+		for {
+			_, err := r.Read(context.Background(), readerAlloc, 256)
+			if err == io.EOF {
+				break
+			}
+			readerAlloc.Reclaim()
+		}
+	}
+	b.SetBytes(int64(col.Desc.UncompressedSize))
+	b.ReportMetric(float64(totalValues*b.N)/b.Elapsed().Seconds(), "values/s")
+}

--- a/pkg/dataobj/internal/dataset/reader_test.go
+++ b/pkg/dataobj/internal/dataset/reader_test.go
@@ -266,7 +266,6 @@ func BenchmarkReader_Read(b *testing.B) {
 
 	readerAlloc := memory.NewAllocator(alloc)
 	for b.Loop() {
-		alloc.Reclaim()
 		r.Reset(ReaderOptions{
 			Columns:   []Column{col},
 			BatchSize: totalValues / 2,

--- a/pkg/dataobj/internal/dataset/reader_test.go
+++ b/pkg/dataobj/internal/dataset/reader_test.go
@@ -271,7 +271,7 @@ func BenchmarkReader_Read(b *testing.B) {
 			BatchSize: totalValues / 2,
 			Allocator: alloc,
 		})
-		r.Open(context.Background())
+		_ = r.Open(context.Background())
 		for {
 			_, err := r.Read(context.Background(), readerAlloc, 8192)
 			if err == io.EOF {

--- a/pkg/dataobj/internal/dataset/row_reader_test.go
+++ b/pkg/dataobj/internal/dataset/row_reader_test.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"slices"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/dustin/go-humanize"
@@ -968,4 +969,33 @@ func Test_Reader_Stats(t *testing.T) {
 	require.Equal(t, int64(3), obsMap[xcap.StatDatasetRowsAfterPruning.Name()])
 	require.Equal(t, int64(3), obsMap[xcap.StatDatasetPrimaryRowsRead.Name()])
 	require.Equal(t, int64(1), obsMap[xcap.StatDatasetSecondaryRowsRead.Name()])
+}
+
+func BenchmarkRowReader_Read(b *testing.B) {
+	totalValues := 64 * 1024
+	values := make([]string, totalValues)
+	for i := range values {
+		values[i] = fmt.Sprintf("value %d [%s]", i, strings.Repeat("A", 100))
+	}
+
+	col := buildReaderTestColumn(b, "data", values)
+
+	r := NewRowReader(RowReaderOptions{
+		Columns: []Column{col},
+	})
+	batch := make([]Row, 8192)
+	for b.Loop() {
+		r.Reset(RowReaderOptions{
+			Columns: []Column{col},
+		})
+		_ = r.Open(context.Background())
+		for {
+			_, err := r.Read(context.Background(), batch)
+			if err == io.EOF {
+				break
+			}
+		}
+	}
+	b.SetBytes(int64(col.Desc.UncompressedSize))
+	b.ReportMetric(float64(totalValues*b.N)/b.Elapsed().Seconds(), "values/s")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Implemented the top-level dataset.Reader using columnar data & the allocators.

**update**
Fixed a bug in the page sizes. New benchmarks & profile. Most of the CPU time is now in zstd, which is expected and great to see.
```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/dataobj/internal/dataset
cpu: Apple M3 Max
BenchmarkReader_Read-14              555           2095966 ns/op        3590.49 MB/s      31267689 values/s      2129805 B/op        208 allocs/op
BenchmarkReader_Read-14              550           2158510 ns/op        3486.46 MB/s      30361688 values/s      2125020 B/op        207 allocs/op
BenchmarkReader_Read-14              535           2144248 ns/op        3509.65 MB/s      30563628 values/s      2125354 B/op        207 allocs/op
BenchmarkReader_Read-14              562           2114297 ns/op        3559.36 MB/s      30996587 values/s      2124562 B/op        207 allocs/op
BenchmarkReader_Read-14              570           2092588 ns/op        3596.29 MB/s      31318153 values/s      2124387 B/op        207 allocs/op
BenchmarkReader_Read-14              554           2106450 ns/op        3572.62 MB/s      31112060 values/s      2124782 B/op        207 allocs/op
BenchmarkReader_Read-14              567           2071707 ns/op        3632.54 MB/s      31633817 values/s      2124497 B/op        207 allocs/op
BenchmarkReader_Read-14              564           2094066 ns/op        3593.75 MB/s      31296058 values/s      2124468 B/op        207 allocs/op
BenchmarkReader_Read-14              567           2076901 ns/op        3623.45 MB/s      31554708 values/s      2124473 B/op        207 allocs/op
BenchmarkReader_Read-14              570           2085939 ns/op        3607.75 MB/s      31417984 values/s      2124398 B/op        207 allocs/op
PASS
ok      github.com/grafana/loki/v3/pkg/dataobj/internal/dataset 12.218s
```

<img width="1413" height="558" alt="image" src="https://github.com/user-attachments/assets/1242af3b-46e6-4629-92a9-fb636c09678d" />

