### PR TITLE
chore: disable the accepted stream cache while we continue to validate its effectivenss

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1873,7 +1873,7 @@ ingest_limits_frontend:
   # CLI flag: -ingest-limits-frontend.assigned-partitions-cache-ttl
   [assigned_partitions_cache_ttl: <duration> | default = 1m]
 
-  # Enable the accepted streams cache.
+  # [Experimental]: Enable the accepted streams cache.
   # CLI flag: -ingest-limits-frontend.accepted-streams-cache-enabled
   [accepted_streams_cache_enabled: <boolean> | default = false]
 

--- a/pkg/limits/frontend/config.go
+++ b/pkg/limits/frontend/config.go
@@ -50,7 +50,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 		&cfg.AcceptedStreamsCacheEnabled,
 		"ingest-limits-frontend.accepted-streams-cache-enabled",
 		false,
-		"Enable the accepted streams cache.",
+		"[Experimental]: Enable the accepted streams cache.",
 	)
 	f.DurationVar(
 		&cfg.AcceptedStreamsCacheTTL,


### PR DESCRIPTION
**What this PR does / why we need it**:

Disables the accepted stream cache while we continue to validate its effectiveness. It is a probabilistic data structure and want more time to validate it before enabling it by default.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
