### PR TITLE
chore: Ignore errgroup context in decoder

### DIFF
--- a/pkg/dataobj/decoder.go
+++ b/pkg/dataobj/decoder.go
@@ -25,7 +25,7 @@ func (d *decoder) Metadata(ctx context.Context) (*filemd.Metadata, error) {
 	buf := bufpool.Get(int(optimisticReadBytes))
 	defer bufpool.Put(buf)
 
-	g, ctx := errgroup.WithContext(ctx)
+	g, _ := errgroup.WithContext(ctx)
 
 	// We launch a separate goroutine to cache the object size in the background
 	// as we read the header.


### PR DESCRIPTION
**What this PR does / why we need it**:
Don't use the errgroups context since it gets cancelled after Wait() is called, or first err.