### PR TITLE
chore: use map instead of bloom filter as cache

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1885,11 +1885,6 @@ ingest_limits_frontend:
   # CLI flag: -ingest-limits-frontend.accepted-streams-cache-ttl-jitter
   [accepted_streams_cache_ttl_jitter: <duration> | default = 15s]
 
-  # The maximum number of streams that can be stored in the cache without false
-  # positives.
-  # CLI flag: -ingest-limits-frontend.accepted-streams-cache-size
-  [accepted_streams_cache_size: <int> | default = 1000000]
-
 ingest_limits_frontend_client:
   # Configures client gRPC connections to limits service.
   # The CLI flags prefix for this block configuration is:

--- a/pkg/limits/frontend/config.go
+++ b/pkg/limits/frontend/config.go
@@ -22,7 +22,6 @@ type Config struct {
 	AcceptedStreamsCacheEnabled    bool                  `yaml:"accepted_streams_cache_enabled"`
 	AcceptedStreamsCacheTTL        time.Duration         `yaml:"accepted_streams_cache_ttl"`
 	AcceptedStreamsCacheTTLJitter  time.Duration         `yaml:"accepted_streams_cache_ttl_jitter"`
-	AcceptedStreamsCacheSize       int                   `yaml:"accepted_streams_cache_size"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
@@ -64,12 +63,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 		15*time.Second,
 		"The jitter to add to the accepted streams cache.",
 	)
-	f.IntVar(
-		&cfg.AcceptedStreamsCacheSize,
-		"ingest-limits-frontend.accepted-streams-cache-size",
-		1000000,
-		"The maximum number of streams that can be stored in the cache without false positives.",
-	)
 }
 
 func (cfg *Config) Validate() error {
@@ -87,9 +80,6 @@ func (cfg *Config) Validate() error {
 		}
 		if cfg.AcceptedStreamsCacheTTLJitter <= 0 {
 			return errors.New("accepted streams cache TTL jitter must be a positive number, or the cache must be disabled")
-		}
-		if cfg.AcceptedStreamsCacheSize <= 0 {
-			return errors.New("accepted streams cache size must be a positive number, or the cache must be disabled")
 		}
 	}
 	return nil

--- a/pkg/limits/frontend/frontend.go
+++ b/pkg/limits/frontend/frontend.go
@@ -88,7 +88,6 @@ func New(cfg Config, ringName string, limitsRing ring.ReadRing, logger log.Logge
 			newAcceptedStreamsCache(
 				cfg.AcceptedStreamsCacheTTL,
 				cfg.AcceptedStreamsCacheTTLJitter,
-				cfg.AcceptedStreamsCacheSize,
 				reg,
 			),
 			f.limitsClient,


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit uses a map instead of a bloom filter as the cache in the ingest-limits-frontend. The reason for the swap is that a map has lower operational overhead (no need to choose the size ahead of time), while still being fast enough and memory efficient enough for our current use case.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
