### PR TITLE
fix: Reject query parameter values that overflow uint32

### DIFF
--- a/pkg/loghttp/params.go
+++ b/pkg/loghttp/params.go
@@ -25,25 +25,25 @@ const (
 )
 
 func limit(r *http.Request) (uint32, error) {
-	l, err := parseInt(r.Form.Get("limit"), defaultQueryLimit)
+	l, err := parseUint32(r.Form.Get("limit"), defaultQueryLimit)
 	if err != nil {
 		return 0, err
 	}
-	if l <= 0 {
+	if l == 0 {
 		return 0, errors.New("limit must be a positive value")
 	}
-	return uint32(l), nil
+	return l, nil
 }
 
 func lineLimit(r *http.Request) (uint32, error) {
-	l, err := parseInt(r.Form.Get("line_limit"), defaultQueryLimit)
+	l, err := parseUint32(r.Form.Get("line_limit"), defaultQueryLimit)
 	if err != nil {
 		return 0, err
 	}
-	if l <= 0 {
+	if l == 0 {
 		return 0, errors.New("limit must be a positive value")
 	}
-	return uint32(l), nil
+	return l, nil
 }
 
 func detectedFieldsLimit(r *http.Request) (uint32, error) {
@@ -53,15 +53,15 @@ func detectedFieldsLimit(r *http.Request) (uint32, error) {
 		limit = r.Form.Get("field_limit")
 	}
 
-	l, err := parseInt(limit, defaultLimit)
+	l, err := parseUint32(limit, defaultLimit)
 	if err != nil {
 		return 0, err
 	}
 
-	if l <= 0 {
+	if l == 0 {
 		return 0, errors.New("limit must be a positive value")
 	}
-	return uint32(l), nil
+	return l, nil
 }
 
 func query(r *http.Request) string {
@@ -142,11 +142,7 @@ func defaultQueryRangeStep(start time.Time, end time.Time) int {
 }
 
 func tailDelay(r *http.Request) (uint32, error) {
-	l, err := parseInt(r.Form.Get("delay_for"), 0)
-	if err != nil {
-		return 0, err
-	}
-	return uint32(l), nil
+	return parseUint32(r.Form.Get("delay_for"), 0)
 }
 
 // parseInt parses an int from a string
@@ -156,6 +152,20 @@ func parseInt(value string, def int) (int, error) {
 		return def, nil
 	}
 	return strconv.Atoi(value)
+}
+
+// parseUint32 parses a uint32 from a string.
+// If the value is empty it returns a default value passed as second parameter.
+// It returns an error if the value is negative or exceeds math.MaxUint32.
+func parseUint32(value string, def uint32) (uint32, error) {
+	if value == "" {
+		return def, nil
+	}
+	v, err := strconv.ParseUint(value, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(v), nil
 }
 
 // parseTimestamp parses a ns unix timestamp from a string

--- a/pkg/loghttp/params_test.go
+++ b/pkg/loghttp/params_test.go
@@ -359,3 +359,37 @@ func Test_determineBounds(t *testing.T) {
 		})
 	}
 }
+
+func TestParseUint32(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		def     uint32
+		want    uint32
+		wantErr bool
+	}{
+		{"empty uses default", "", 42, 42, false},
+		{"valid value", "100", 0, 100, false},
+		{"zero", "0", 1, 0, false},
+		{"max uint32", "4294967295", 0, 4294967295, false},
+		{"overflow uint32", "4294967296", 0, 0, true},
+		{"large overflow", "4294967297", 0, 0, true},
+		{"negative value", "-1", 0, 0, true},
+		{"non-numeric", "abc", 0, 0, true},
+		{"float value", "1.5", 0, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseUint32(tt.value, tt.def)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/loghttp/query.go
+++ b/pkg/loghttp/query.go
@@ -721,18 +721,13 @@ func targetLabels(r *http.Request) []string {
 }
 
 func volumeLimit(r *http.Request) error {
-	l, err := parseInt(r.Form.Get("limit"), seriesvolume.DefaultLimit)
+	l, err := parseUint32(r.Form.Get("limit"), uint32(seriesvolume.DefaultLimit))
 	if err != nil {
 		return err
 	}
 
 	if l == 0 {
 		r.Form.Set("limit", fmt.Sprint(seriesvolume.DefaultLimit))
-		return nil
-	}
-
-	if l <= 0 {
-		return errors.New("limit must be a positive value")
 	}
 
 	return nil

--- a/pkg/loghttp/query_test.go
+++ b/pkg/loghttp/query_test.go
@@ -28,6 +28,8 @@ func TestParseRangeQuery(t *testing.T) {
 		{"bad end", &http.Request{URL: mustParseURL(`?query={foo="bar"}&end=t`)}, nil, true},
 		{"end before start", &http.Request{URL: mustParseURL(`?query={foo="bar"}&start=2016-06-10T21:42:24.760738998Z&end=2015-06-10T21:42:24.760738998Z`)}, nil, true},
 		{"bad limit", &http.Request{URL: mustParseURL(`?query={foo="bar"}&start=2016-06-10T21:42:24.760738998Z&end=2017-06-10T21:42:24.760738998Z&limit=h`)}, nil, true},
+		{"overflow limit", &http.Request{URL: mustParseURL(`?query={foo="bar"}&start=2016-06-10T21:42:24.760738998Z&end=2017-06-10T21:42:24.760738998Z&limit=4294967297`)}, nil, true},
+		{"negative limit", &http.Request{URL: mustParseURL(`?query={foo="bar"}&start=2016-06-10T21:42:24.760738998Z&end=2017-06-10T21:42:24.760738998Z&limit=-1`)}, nil, true},
 		{
 			"bad direction",
 			&http.Request{
@@ -98,6 +100,8 @@ func TestParseInstantQuery(t *testing.T) {
 	}{
 		{"bad time", &http.Request{URL: mustParseURL(`?query={foo="bar"}&time=t`)}, nil, true},
 		{"bad limit", &http.Request{URL: mustParseURL(`?query={foo="bar"}&time=2016-06-10T21:42:24.760738998Z&limit=h`)}, nil, true},
+		{"overflow limit", &http.Request{URL: mustParseURL(`?query={foo="bar"}&time=2016-06-10T21:42:24.760738998Z&limit=4294967297`)}, nil, true},
+		{"negative limit", &http.Request{URL: mustParseURL(`?query={foo="bar"}&time=2016-06-10T21:42:24.760738998Z&limit=-1`)}, nil, true},
 		{
 			"bad direction",
 			&http.Request{

--- a/pkg/loghttp/tail_test.go
+++ b/pkg/loghttp/tail_test.go
@@ -24,6 +24,8 @@ func TestParseTailQuery(t *testing.T) {
 	}{
 		{"bad time", &http.Request{URL: mustParseURL(`?query={foo="bar"}&start=t`)}, nil, true},
 		{"bad limit", &http.Request{URL: mustParseURL(`?query={foo="bar"}&start=2016-06-10T21:42:24.760738998Z&limit=h`)}, nil, true},
+		{"overflow limit", &http.Request{URL: mustParseURL(`?query={foo="bar"}&start=2016-06-10T21:42:24.760738998Z&limit=4294967297`)}, nil, true},
+		{"negative limit", &http.Request{URL: mustParseURL(`?query={foo="bar"}&start=2016-06-10T21:42:24.760738998Z&limit=-1`)}, nil, true},
 		{"bad delay",
 			&http.Request{
 				URL: mustParseURL(`?query={foo="bar"}&time=2016-06-10T21:42:24.760738998Z&limit=100&delay_for=fw`),


### PR DESCRIPTION
**What this PR does / why we need it**:
Query parameters in `pkg/loghttp` (e.g. `limit`, `line_limit`, `delay_for`) are
parsed via `strconv.Atoi` into a 64-bit `int`, then cast to `uint32` without
bounds checking. This causes values exceeding `math.MaxUint32` to silently wrap
around (e.g. `limit=4294967297` becomes `1`, `limit=4294967298` becomes `2`).

This PR introduces a `parseUint32` helper that uses `strconv.ParseUint(_, 10, 32)`,
which rejects out-of-range and negative values at parse time with a clear error.
All affected callers (`limit`, `lineLimit`, `detectedFieldsLimit`, `tailDelay`,
`volumeLimit`) are updated to use it.

**Which issue(s) this PR fixes**:
Fixes #20829

**Special notes for your reviewer**:
The existing `parseInt` function is kept for any callers that need a signed `int`
return. All callers that produce a `uint32` now use `parseUint32` instead.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

Fixes: #20829