### PR TITLE
Replace go.uber.org/atomic with sync/atomic

### DIFF
--- a/clients/pkg/promtail/client/client_writeto_test.go
+++ b/clients/pkg/promtail/client/client_writeto_test.go
@@ -5,10 +5,9 @@ import (
 	"math/rand"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
-
-	"go.uber.org/atomic"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -167,7 +166,7 @@ func bench(numWriters, totalLines int, b *testing.B) {
 		defer readerWG.Done()
 		// discard received entries
 		for range ch {
-			totalReceived.Inc()
+			totalReceived.Add(1)
 		}
 	}()
 

--- a/clients/pkg/promtail/targets/cloudflare/target.go
+++ b/clients/pkg/promtail/targets/cloudflare/target.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -16,7 +17,6 @@ import (
 	"github.com/grafana/dskit/multierror"
 	"github.com/grafana/jsonparser"
 	"github.com/prometheus/common/model"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/clients/pkg/promtail/api"
 	"github.com/grafana/loki/v3/clients/pkg/promtail/positions"
@@ -91,7 +91,7 @@ func NewTarget(
 		cancel:  cancel,
 		client:  client,
 		to:      to,
-		running: atomic.NewBool(false),
+		running: (&atomic.Bool{}),
 	}
 	t.start()
 	return t, nil

--- a/clients/pkg/promtail/targets/docker/target.go
+++ b/clients/pkg/promtail/targets/docker/target.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
@@ -15,7 +16,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/clients/pkg/promtail/api"
 	"github.com/grafana/loki/v3/clients/pkg/promtail/positions"
@@ -76,7 +76,7 @@ func NewTarget(
 		maxLineSize:   maxLineSize,
 
 		client:  client,
-		running: atomic.NewBool(false),
+		running: (&atomic.Bool{}),
 	}
 	t.startIfNotRunning()
 	return t, nil

--- a/clients/pkg/promtail/targets/file/decompresser.go
+++ b/clients/pkg/promtail/targets/file/decompresser.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -18,7 +19,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
-	"go.uber.org/atomic"
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/ianaindex"
 	"golang.org/x/text/transform"
@@ -88,7 +88,7 @@ func newDecompressor(metrics *Metrics, logger log.Logger, handler api.EntryHandl
 		handler:   api.AddLabelsMiddleware(model.LabelSet{FilenameLabel: model.LabelValue(path)}).Wrap(handler),
 		positions: positions,
 		path:      path,
-		running:   atomic.NewBool(false),
+		running:   (&atomic.Bool{}),
 		posquit:   make(chan struct{}),
 		posdone:   make(chan struct{}),
 		done:      make(chan struct{}),

--- a/clients/pkg/promtail/targets/file/decompresser_test.go
+++ b/clients/pkg/promtail/targets/file/decompresser_test.go
@@ -3,13 +3,13 @@ package file
 import (
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/clients/pkg/promtail/api"
 	"github.com/grafana/loki/v3/clients/pkg/promtail/client/fake"
@@ -63,7 +63,7 @@ func BenchmarkReadlines(b *testing.B) {
 		b.Run(tc.name, func(b *testing.B) {
 			decBase := &decompressor{
 				logger:  log.NewNopLogger(),
-				running: atomic.NewBool(false),
+				running: (&atomic.Bool{}),
 				handler: entryHandler,
 				path:    tc.file,
 				cfg:     &scrapeconfig.DecompressionConfig{InitialDelay: 0, Format: "gz"},
@@ -86,7 +86,7 @@ func TestGigantiqueGunzipFile(t *testing.T) {
 
 	d := &decompressor{
 		logger:  log.NewNopLogger(),
-		running: atomic.NewBool(false),
+		running: (&atomic.Bool{}),
 		handler: handler,
 		path:    file,
 		done:    make(chan struct{}),
@@ -115,7 +115,7 @@ func TestOnelineFiles(t *testing.T) {
 
 		d := &decompressor{
 			logger:  log.NewNopLogger(),
-			running: atomic.NewBool(false),
+			running: (&atomic.Bool{}),
 			handler: handler,
 			path:    file,
 			done:    make(chan struct{}),
@@ -139,7 +139,7 @@ func TestOnelineFiles(t *testing.T) {
 
 		d := &decompressor{
 			logger:  log.NewNopLogger(),
-			running: atomic.NewBool(false),
+			running: (&atomic.Bool{}),
 			handler: handler,
 			path:    file,
 			done:    make(chan struct{}),
@@ -163,7 +163,7 @@ func TestOnelineFiles(t *testing.T) {
 
 		d := &decompressor{
 			logger:  log.NewNopLogger(),
-			running: atomic.NewBool(false),
+			running: (&atomic.Bool{}),
 			handler: handler,
 			path:    file,
 			done:    make(chan struct{}),

--- a/clients/pkg/promtail/targets/file/filetarget_test.go
+++ b/clients/pkg/promtail/targets/file/filetarget_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/clients/pkg/promtail/client/fake"
 	"github.com/grafana/loki/v3/clients/pkg/promtail/positions"
@@ -51,8 +51,8 @@ func TestFileTargetSync(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	fakeHandler := make(chan fileTargetEvent)
-	receivedStartWatch := atomic.NewInt32(0)
-	receivedStopWatch := atomic.NewInt32(0)
+	receivedStartWatch := (&atomic.Int32{})
+	receivedStopWatch := (&atomic.Int32{})
 	go func() {
 		for {
 			select {
@@ -368,8 +368,8 @@ func TestFileTargetPathExclusion(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	fakeHandler := make(chan fileTargetEvent)
-	receivedStartWatch := atomic.NewInt32(0)
-	receivedStopWatch := atomic.NewInt32(0)
+	receivedStartWatch := (&atomic.Int32{})
+	receivedStopWatch := (&atomic.Int32{})
 	go func() {
 		for {
 			select {

--- a/clients/pkg/promtail/targets/file/tailer.go
+++ b/clients/pkg/promtail/targets/file/tailer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -12,7 +13,6 @@ import (
 	"github.com/grafana/tail/watch"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
-	"go.uber.org/atomic"
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/ianaindex"
 	"golang.org/x/text/transform"
@@ -84,7 +84,7 @@ func newTailer(metrics *Metrics, logger log.Logger, handler api.EntryHandler, po
 		positions: positions,
 		path:      path,
 		tail:      tail,
-		running:   atomic.NewBool(false),
+		running:   (&atomic.Bool{}),
 		posquit:   make(chan struct{}),
 		posdone:   make(chan struct{}),
 		done:      make(chan struct{}),

--- a/clients/pkg/promtail/targets/kafka/target_test.go
+++ b/clients/pkg/promtail/targets/kafka/target_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/clients/pkg/promtail/targets/testutils"
 
@@ -45,18 +45,18 @@ func (c *testConsumerGroupHandler) Consume(ctx context.Context, topics []string,
 	return nil
 }
 
-func (c testConsumerGroupHandler) Errors() <-chan error {
+func (c *testConsumerGroupHandler) Errors() <-chan error {
 	return nil
 }
 
-func (c testConsumerGroupHandler) Close() error {
+func (c *testConsumerGroupHandler) Close() error {
 	return nil
 }
 
-func (c testConsumerGroupHandler) Pause(_ map[string][]int32)  {}
-func (c testConsumerGroupHandler) Resume(_ map[string][]int32) {}
-func (c testConsumerGroupHandler) PauseAll()                   {}
-func (c testConsumerGroupHandler) ResumeAll()                  {}
+func (c *testConsumerGroupHandler) Pause(_ map[string][]int32)  {}
+func (c *testConsumerGroupHandler) Resume(_ map[string][]int32) {}
+func (c *testConsumerGroupHandler) PauseAll()                   {}
+func (c *testConsumerGroupHandler) ResumeAll()                  {}
 
 type testSession struct {
 	markedMessage []*sarama.ConsumerMessage

--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/xdg-go/scram v1.2.0
 	go.etcd.io/bbolt v1.4.3
-	go.uber.org/atomic v1.11.0
+	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.48.0
 	golang.org/x/net v0.51.0

--- a/pkg/analytics/stats.go
+++ b/pkg/analytics/stats.go
@@ -12,14 +12,15 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
-
-	"github.com/grafana/loki/v3/pkg/util/build"
 
 	"github.com/cespare/xxhash/v2"
 	jsoniter "github.com/json-iterator/go"
 	prom "github.com/prometheus/prometheus/web/api/v1"
-	"go.uber.org/atomic"
+
+	"github.com/grafana/loki/v3/pkg/util/atomicutil"
+	"github.com/grafana/loki/v3/pkg/util/build"
 )
 
 var (
@@ -255,15 +256,15 @@ func Edition(edition string) {
 }
 
 type Statistics struct {
-	min   *atomic.Float64
-	max   *atomic.Float64
+	min   *atomicutil.Float64
+	max   *atomicutil.Float64
 	count *atomic.Int64
 
-	avg *atomic.Float64
+	avg *atomicutil.Float64
 
 	// require for stddev and stdvar
-	mean  *atomic.Float64
-	value *atomic.Float64
+	mean  *atomicutil.Float64
+	value *atomicutil.Float64
 }
 
 // NewStatistics returns a new Statistics object.
@@ -291,12 +292,12 @@ func NewStatistics(name string) *Statistics {
 		},
 		func() *Statistics { // create
 			s := &Statistics{
-				min:   atomic.NewFloat64(math.Inf(0)),
-				max:   atomic.NewFloat64(math.Inf(-1)),
-				count: atomic.NewInt64(0),
-				avg:   atomic.NewFloat64(0),
-				mean:  atomic.NewFloat64(0),
-				value: atomic.NewFloat64(0),
+				min:   atomicutil.NewFloat64(math.Inf(0)),
+				max:   atomicutil.NewFloat64(math.Inf(-1)),
+				count: (&atomic.Int64{}),
+				avg:   atomicutil.NewFloat64(0),
+				mean:  atomicutil.NewFloat64(0),
+				value: atomicutil.NewFloat64(0),
 			}
 			expvar.Publish(statsPrefix+name, s)
 			return s
@@ -371,7 +372,7 @@ func (s *Statistics) Record(v float64) {
 
 type Counter struct {
 	total *atomic.Int64
-	rate  *atomic.Float64
+	rate  *atomicutil.Float64
 
 	resetTime time.Time
 }
@@ -392,8 +393,8 @@ func NewCounter(name string) *Counter {
 		},
 		func() *Counter { // create
 			c := &Counter{
-				total:     atomic.NewInt64(0),
-				rate:      atomic.NewFloat64(0),
+				total:     (&atomic.Int64{}),
+				rate:      atomicutil.NewFloat64(0),
 				resetTime: time.Now(),
 			}
 			expvar.Publish(statsPrefix+name, c)
@@ -451,7 +452,7 @@ func NewWordCounter(name string) *WordCounter {
 		},
 		func() *WordCounter { // create
 			c := &WordCounter{
-				count: atomic.NewInt64(0),
+				count: (&atomic.Int64{}),
 				words: sync.Map{},
 			}
 			expvar.Publish(statsPrefix+name, c)

--- a/pkg/bloombuild/builder/builder_test.go
+++ b/pkg/bloombuild/builder/builder_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
 	"github.com/grafana/loki/v3/pkg/bloombuild/planner/plannertest"
@@ -290,9 +290,9 @@ func (f *fakePlannerServer) BuilderLoop(srv protos.PlannerForBuilder_BuilderLoop
 			return fmt.Errorf("failed to receive task response: %w", err)
 		}
 
-		f.completedTasks.Inc()
+		f.completedTasks.Add(1)
 		if result.Result.Error != "" {
-			f.erroredTasks.Inc()
+			f.erroredTasks.Add(1)
 		}
 
 		time.Sleep(10 * time.Millisecond) // Simulate task processing time to add some latency.

--- a/pkg/bloombuild/planner/planner.go
+++ b/pkg/bloombuild/planner/planner.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -14,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/bloombuild/common"
 	"github.com/grafana/loki/v3/pkg/bloombuild/planner/queue"

--- a/pkg/bloombuild/planner/planner_test.go
+++ b/pkg/bloombuild/planner/planner_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
 	"github.com/grafana/loki/v3/pkg/bloombuild/planner/plannertest"

--- a/pkg/bloombuild/planner/task.go
+++ b/pkg/bloombuild/planner/task.go
@@ -2,9 +2,9 @@ package planner
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/bloombuild/protos"
 )

--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -20,7 +21,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.uber.org/atomic"
 
 	iter "github.com/grafana/loki/v3/pkg/iter/v2"
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -302,7 +302,7 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 	task.enqueueTime = time.Now()
 	if err := g.queue.Enqueue(tenantID, nil, task, func() {
 		// When enqueuing, we also add the task to the pending tasks
-		_ = g.pendingTasks.Inc()
+		_ = g.pendingTasks.Add(1)
 	}); err != nil {
 		stats.Status = labelFailure
 		return nil, errors.Wrap(err, "failed to enqueue task")

--- a/pkg/bloomgateway/client.go
+++ b/pkg/bloomgateway/client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"slices"
 	"sort"
+	"sync/atomic"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -15,7 +16,6 @@ import (
 	ringclient "github.com/grafana/dskit/ring/client"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
@@ -237,7 +237,7 @@ func (c *GatewayClient) FilterChunks(ctx context.Context, _ string, interval blo
 	}
 
 	results := make([][]*logproto.GroupedChunkRefs, len(servers))
-	count := atomic.NewInt64(0)
+	count := (&atomic.Int64{})
 	err := concurrency.ForEachJob(ctx, len(servers), len(servers), func(ctx context.Context, i int) error {
 		rs := servers[i]
 

--- a/pkg/bloomgateway/processor_test.go
+++ b/pkg/bloomgateway/processor_test.go
@@ -3,6 +3,7 @@ package bloomgateway
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	v1 "github.com/grafana/loki/v3/pkg/storage/bloom/v1"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
@@ -150,14 +150,14 @@ func TestProcessor(t *testing.T) {
 		task := newTask(ctx, "fake", swb, matchers, nil)
 		tasks := []Task{task}
 
-		results := atomic.NewInt64(0)
+		results := (&atomic.Int64{})
 		var wg sync.WaitGroup
 		for i := range tasks {
 			wg.Add(1)
 			go func(ta Task) {
 				defer wg.Done()
 				for range ta.resCh {
-					results.Inc()
+					results.Add(1)
 				}
 				t.Log("done", results.Load())
 			}(tasks[i])
@@ -200,14 +200,14 @@ func TestProcessor(t *testing.T) {
 		task := newTask(ctx, "fake", swb, matchers, blocks)
 		tasks := []Task{task}
 
-		results := atomic.NewInt64(0)
+		results := (&atomic.Int64{})
 		var wg sync.WaitGroup
 		for i := range tasks {
 			wg.Add(1)
 			go func(ta Task) {
 				defer wg.Done()
 				for range ta.resCh {
-					results.Inc()
+					results.Add(1)
 				}
 				t.Log("done", results.Load())
 			}(tasks[i])
@@ -247,14 +247,14 @@ func TestProcessor(t *testing.T) {
 		task := newTask(ctx, "fake", swb, matchers, nil)
 		tasks := []Task{task}
 
-		results := atomic.NewInt64(0)
+		results := (&atomic.Int64{})
 		var wg sync.WaitGroup
 		for i := range tasks {
 			wg.Add(1)
 			go func(ta Task) {
 				defer wg.Done()
 				for range ta.resCh {
-					results.Inc()
+					results.Add(1)
 				}
 				t.Log("done", results.Load())
 			}(tasks[i])

--- a/pkg/bloomgateway/stats.go
+++ b/pkg/bloomgateway/stats.go
@@ -2,9 +2,10 @@ package bloomgateway
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
-	"go.uber.org/atomic"
+	"github.com/grafana/loki/v3/pkg/util/atomicutil"
 )
 
 type Stats struct {
@@ -12,10 +13,10 @@ type Stats struct {
 	NumTasks, NumMatchers               int
 	ChunksRequested, ChunksFiltered     int
 	SeriesRequested, SeriesFiltered     int
-	QueueTime                           *atomic.Duration
-	BlocksFetchTime                     *atomic.Duration
-	ProcessingTime, TotalProcessingTime *atomic.Duration
-	PostProcessingTime                  *atomic.Duration
+	QueueTime                           *atomicutil.Duration
+	BlocksFetchTime                     *atomicutil.Duration
+	ProcessingTime, TotalProcessingTime *atomicutil.Duration
+	PostProcessingTime                  *atomicutil.Duration
 	SkippedBlocks                       *atomic.Int32 // blocks skipped because they were not available (yet)
 	ProcessedBlocks                     *atomic.Int32 // blocks processed for this specific request
 	ProcessedBlocksTotal                *atomic.Int32 // blocks processed for multiplexed request
@@ -29,14 +30,14 @@ var ctxKey = statsKey(0)
 func ContextWithEmptyStats(ctx context.Context) (*Stats, context.Context) {
 	stats := &Stats{
 		Status:               "unknown",
-		SkippedBlocks:        atomic.NewInt32(0),
-		ProcessedBlocks:      atomic.NewInt32(0),
-		ProcessedBlocksTotal: atomic.NewInt32(0),
-		QueueTime:            atomic.NewDuration(0),
-		BlocksFetchTime:      atomic.NewDuration(0),
-		ProcessingTime:       atomic.NewDuration(0),
-		TotalProcessingTime:  atomic.NewDuration(0),
-		PostProcessingTime:   atomic.NewDuration(0),
+		SkippedBlocks:        &atomic.Int32{},
+		ProcessedBlocks:      &atomic.Int32{},
+		ProcessedBlocksTotal: &atomic.Int32{},
+		QueueTime:            atomicutil.NewDuration(0),
+		BlocksFetchTime:      atomicutil.NewDuration(0),
+		ProcessingTime:       atomicutil.NewDuration(0),
+		TotalProcessingTime:  atomicutil.NewDuration(0),
+		PostProcessingTime:   atomicutil.NewDuration(0),
 	}
 	ctx = context.WithValue(ctx, ctxKey, stats)
 	return stats, ctx
@@ -129,14 +130,14 @@ func (s *Stats) IncSkippedBlocks() {
 	if s == nil {
 		return
 	}
-	s.SkippedBlocks.Inc()
+	s.SkippedBlocks.Add(1)
 }
 
 func (s *Stats) IncProcessedBlocks() {
 	if s == nil {
 		return
 	}
-	s.ProcessedBlocks.Inc()
+	s.ProcessedBlocks.Add(1)
 }
 
 func (s *Stats) AddProcessedBlocksTotal(delta int) {

--- a/pkg/bloomgateway/worker.go
+++ b/pkg/bloomgateway/worker.go
@@ -2,13 +2,13 @@ package bloomgateway
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/services"
 	"github.com/pkg/errors"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/queue"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper"
@@ -97,7 +97,7 @@ func (w *worker) running(_ context.Context) error {
 				w.queue.ReleaseRequests(items)
 				return errors.Errorf("failed to cast dequeued item to Task: %v", item)
 			}
-			_ = w.pending.Dec()
+			_ = w.pending.Add(-1)
 			w.metrics.queueDuration.WithLabelValues(w.id).Observe(time.Since(task.enqueueTime).Seconds())
 			FromContext(task.ctx).AddQueueTime(time.Since(task.enqueueTime))
 			tasks = append(tasks, task)

--- a/pkg/compactor/deletion/delete_request.go
+++ b/pkg/compactor/deletion/delete_request.go
@@ -2,6 +2,7 @@ package deletion
 
 import (
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log/level"
@@ -9,7 +10,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/compactor/deletion/deletionproto"
 	"github.com/grafana/loki/v3/pkg/compactor/retention"
@@ -29,13 +29,14 @@ type deleteRequest struct {
 	timeInterval    *timeInterval          `json:"-"`
 
 	TotalLinesDeletedMetric *prometheus.CounterVec `json:"-"`
-	DeletedLines            atomic.Int32           `json:"-"`
+	DeletedLines            *atomic.Int32          `json:"-"`
 }
 
 func newDeleteRequest(protoReq deletionproto.DeleteRequest, totalLinesDeletedMetric *prometheus.CounterVec) (*deleteRequest, error) {
 	d := deleteRequest{
 		DeleteRequest:           protoReq,
 		TotalLinesDeletedMetric: totalLinesDeletedMetric,
+		DeletedLines:            &atomic.Int32{},
 	}
 
 	if err := d.SetQuery(d.Query); err != nil {

--- a/pkg/compactor/deletion/job_builder.go
+++ b/pkg/compactor/deletion/job_builder.go
@@ -8,13 +8,13 @@ import (
 	"path"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log/level"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/compactor/client/grpc"
 	"github.com/grafana/loki/v3/pkg/compactor/deletion/deletionproto"
@@ -397,7 +397,7 @@ func (b *JobBuilder) OnJobResponse(response *grpc.JobResult) error {
 
 	b.currSegmentStorageUpdates.addUpdates(jobDetails.labels, updates)
 	delete(b.currentManifest.jobsInProgress, response.JobId)
-	b.currSegmentNumJobsToProcess.Dec()
+	b.currSegmentNumJobsToProcess.Add(-1)
 
 	return nil
 }

--- a/pkg/compactor/jobqueue/queue_test.go
+++ b/pkg/compactor/jobqueue/queue_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
@@ -32,9 +32,9 @@ type mockBuilder struct {
 
 func (m *mockBuilder) OnJobResponse(res *compactor_grpc.JobResult) error {
 	if res.Error != "" {
-		m.jobsFailed.Inc()
+		m.jobsFailed.Add(1)
 	} else {
-		m.jobsSucceeded.Inc()
+		m.jobsSucceeded.Add(1)
 	}
 
 	return nil
@@ -46,7 +46,7 @@ func (m *mockBuilder) BuildJobs(ctx context.Context, jobsChan chan<- *compactor_
 		case <-ctx.Done():
 			return
 		case jobsChan <- job:
-			m.jobsSentCount.Inc()
+			m.jobsSentCount.Add(1)
 		}
 	}
 

--- a/pkg/compactor/jobqueue/worker.go
+++ b/pkg/compactor/jobqueue/worker.go
@@ -5,13 +5,13 @@ import (
 	"flag"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/backoff"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/compactor/client/grpc"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"

--- a/pkg/compactor/jobqueue/worker_test.go
+++ b/pkg/compactor/jobqueue/worker_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/grafana/dskit/flagext"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
 	compactor_grpc "github.com/grafana/loki/v3/pkg/compactor/client/grpc"

--- a/pkg/compactor/retention/marker.go
+++ b/pkg/compactor/retention/marker.go
@@ -11,11 +11,11 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log/level"
 	"go.etcd.io/bbolt"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
 	shipper_util "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/util"
@@ -257,7 +257,7 @@ func (r *markerProcessor) processFile(name string, deleteFunc func(ctx context.C
 	var (
 		wg               sync.WaitGroup
 		queue            = make(chan *keyPair)
-		allChunksDeleted = atomic.NewBool(true)
+		allChunksDeleted = func() *atomic.Bool { v := &atomic.Bool{}; v.Store(true); return v }()
 	)
 
 	tempFile, err := os.CreateTemp("", name)

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -26,7 +27,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/thanos-io/objstore"
 	"go.opentelemetry.io/otel"
-	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/loki/v3/pkg/storage/bucket"
@@ -606,7 +606,7 @@ func (m *ObjectMetastore) Sections(ctx context.Context, req SectionsRequest) (Se
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(m.parallelism)
 
-	totalSections := atomic.NewUint64(0)
+	totalSections := (&atomic.Uint64{})
 	for _, indexPath := range indexes.IndexesPaths {
 		g.Go(func() error {
 			readerResp, err := m.IndexSectionsReader(ctx, IndexSectionsReaderRequest{

--- a/pkg/dataobj/sections/streams/builder.go
+++ b/pkg/dataobj/sections/streams/builder.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -35,7 +36,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/analytics"
 	"github.com/grafana/loki/v3/pkg/compactor/retention"
@@ -346,7 +346,7 @@ func New(
 		ingesterClients:       clientpool.NewPool("ingester", clientCfg.PoolConfig, ingestersRing, ingesterClientFactory, logger, metricsNamespace),
 		labelCache:            labelCache,
 		shardTracker:          NewShardTracker(),
-		healthyInstancesCount: atomic.NewUint32(0),
+		healthyInstancesCount: (&atomic.Uint32{}),
 		rateLimitStrat:        rateLimitStrat,
 		tee:                   tee,
 		usageTracker:          usageTracker,
@@ -406,7 +406,7 @@ func New(
 		partitionRing:         partitionRing,
 		ingestLimits:          ingestLimits,
 		numMetadataPartitions: numMetadataPartitions,
-		inflightBytes:         atomic.NewUint64(0),
+		inflightBytes:         (&atomic.Uint64{}),
 		inflightBytesGauge: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
 			Namespace: constants.Loki,
 			Name:      "distributor_inflight_bytes",
@@ -522,11 +522,11 @@ type PushTracker struct {
 // If err is not nil, the stream push is considered failed.
 func (p *PushTracker) doneWithResult(err error) {
 	if err == nil {
-		if p.streamsPending.Dec() == 0 {
+		if p.streamsPending.Add(-1) == 0 {
 			p.done <- struct{}{}
 		}
 	} else {
-		if p.streamsFailed.Inc() == 1 {
+		if p.streamsFailed.Add(1) == 1 {
 			p.err <- err
 		}
 	}
@@ -564,7 +564,7 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 	d.inflightBytes.Add(requestSizeBytes)
 	d.inflightBytesGauge.Add(float64(requestSizeBytes))
 	defer func() {
-		d.inflightBytes.Sub(requestSizeBytes)
+		d.inflightBytes.Add(^(requestSizeBytes - 1))
 		d.inflightBytesGauge.Sub(float64(requestSizeBytes))
 	}()
 
@@ -1241,12 +1241,12 @@ func (d *Distributor) sendStreams(task pushIngesterTask) {
 	// goroutine will write to either channel.
 	for i := range task.streamTracker {
 		if err != nil {
-			if task.streamTracker[i].failed.Inc() <= int32(task.streamTracker[i].maxFailures) {
+			if task.streamTracker[i].failed.Add(1) <= int32(task.streamTracker[i].maxFailures) {
 				continue
 			}
 			task.pushTracker.doneWithResult(err)
 		} else {
-			if task.streamTracker[i].succeeded.Inc() != int32(task.streamTracker[i].minSuccess) {
+			if task.streamTracker[i].succeeded.Add(1) != int32(task.streamTracker[i].minSuccess) {
 				continue
 			}
 			task.pushTracker.doneWithResult(nil)

--- a/pkg/distributor/ingest_limits_test.go
+++ b/pkg/distributor/ingest_limits_test.go
@@ -3,13 +3,13 @@ package distributor
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/coder/quartz"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/limits"
 	"github.com/grafana/loki/v3/pkg/limits/proto"

--- a/pkg/distributor/instance_count.go
+++ b/pkg/distributor/instance_count.go
@@ -1,10 +1,10 @@
 package distributor
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/grafana/dskit/ring"
-	"go.uber.org/atomic"
 )
 
 // healthyInstanceDelegate counts the number of healthy instances that are part of the ring

--- a/pkg/distributor/instance_count_test.go
+++ b/pkg/distributor/instance_count_test.go
@@ -1,19 +1,19 @@
 package distributor
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/ring"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
 
 func TestInstanceCountDelegateCounting(t *testing.T) {
-	counter := atomic.NewUint32(0)
+	counter := (&atomic.Uint32{})
 
 	var delegate ring.BasicLifecyclerDelegate
 	delegate = ring.NewInstanceRegisterDelegate(ring.ACTIVE, 1 /* tokenCount */)
@@ -90,7 +90,7 @@ func (s *sentryDelegate) OnRingInstanceStopping(lifecycler *ring.BasicLifecycler
 }
 
 func TestInstanceCountDelegate_CorrectlyInvokesOtherDelegates(t *testing.T) {
-	counter := atomic.NewUint32(0)
+	counter := (&atomic.Uint32{})
 
 	sentry1 := map[string]int{}
 	sentry2 := map[string]int{}

--- a/pkg/engine/internal/scheduler/scheduler_test.go
+++ b/pkg/engine/internal/scheduler/scheduler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
@@ -1403,6 +1403,6 @@ type mockRecordWriter struct {
 }
 
 func (m *mockRecordWriter) Write(_ context.Context, _ arrow.RecordBatch) error {
-	m.writes.Inc()
+	m.writes.Add(1)
 	return nil
 }

--- a/pkg/engine/internal/scheduler/wire/peer.go
+++ b/pkg/engine/internal/scheduler/wire/peer.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 	"reflect"
 	"sync"
+	"sync/atomic"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -234,7 +234,7 @@ type request struct {
 func (p *Peer) SendMessage(ctx context.Context, message Message) error {
 	p.lazyInit()
 
-	reqID := p.requestID.Inc()
+	reqID := p.requestID.Add(1)
 	req := &request{
 		result: make(chan error, 1),
 	}
@@ -269,7 +269,7 @@ func (p *Peer) SendMessage(ctx context.Context, message Message) error {
 func (p *Peer) SendMessageAsync(ctx context.Context, message Message) error {
 	p.lazyInit()
 
-	reqID := p.requestID.Inc()
+	reqID := p.requestID.Add(1)
 	p.Metrics.incMessageSent()
 	return p.enqueueFrame(ctx, MessageFrame{ID: reqID, Message: message})
 }

--- a/pkg/engine/internal/util/ewma/ewma.go
+++ b/pkg/engine/internal/util/ewma/ewma.go
@@ -6,10 +6,10 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/atomic"
 )
 
 // Source is an interface that provides a value for an EWMA calculation.

--- a/pkg/engine/internal/worker/node_source.go
+++ b/pkg/engine/internal/worker/node_source.go
@@ -3,10 +3,10 @@ package worker
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
 	"github.com/grafana/loki/v3/pkg/xcap"

--- a/pkg/engine/internal/worker/scheduler_lookup_test.go
+++ b/pkg/engine/internal/worker/scheduler_lookup_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 )
 
 func Test_schedulerLookup(t *testing.T) {
@@ -45,8 +45,8 @@ func Test_schedulerLookup(t *testing.T) {
 
 		wg.Go(func() {
 			_ = disc.Run(lookupContext, func(ctx context.Context, _ net.Addr) {
-				context.AfterFunc(ctx, func() { handlers.Dec() })
-				handlers.Inc()
+				context.AfterFunc(ctx, func() { handlers.Add(-1) })
+				handlers.Add(1)
 			})
 		})
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -9,10 +9,9 @@ import (
 	"net/http/httptest"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
-
-	"go.uber.org/atomic"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -1683,11 +1682,13 @@ func (r *readRingMock) GetWithOptions(_ uint32, _ ring.Operation, _ ...ring.Opti
 }
 
 func (r *readRingMock) ShuffleShard(_ string, size int) ring.ReadRing {
-	// pass by value to copy
-	return func(r readRingMock) *readRingMock {
-		r.replicationSet.Instances = r.replicationSet.Instances[:size]
-		return &r
-	}(*r)
+	return &readRingMock{
+		replicationSet: ring.ReplicationSet{
+			Instances: r.replicationSet.Instances[:size],
+			MaxErrors: r.replicationSet.MaxErrors,
+		},
+		tokenRangesByIngester: r.tokenRangesByIngester,
+	}
 }
 
 func (r *readRingMock) BatchGet(_ []uint32, _ ring.Operation) ([]ring.ReplicationSet, error) {

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -23,7 +24,6 @@ import (
 	tsdb_record "github.com/prometheus/prometheus/tsdb/record"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/analytics"
 	"github.com/grafana/loki/v3/pkg/chunkenc"

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -3,13 +3,13 @@ package ingester
 import (
 	"fmt"
 	"math"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/grafana/dskit/ring"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"golang.org/x/time/rate"
 
 	"github.com/grafana/loki/v3/pkg/validation"
@@ -128,9 +128,13 @@ func TestStreamCountLimiter_AssertNewStreamAllowed(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
+			fixedLimitVal := &atomic.Int32{}
+			fixedLimitVal.Store(testData.fixedLimit)
+			ownedStreamCountVal := &atomic.Int64{}
+			ownedStreamCountVal.Store(int64(testData.ownedStreamCount))
 			ownedStreamSvc := &ownedStreamService{
-				fixedLimit:       atomic.NewInt32(testData.fixedLimit),
-				ownedStreamCount: atomic.NewInt64(int64(testData.ownedStreamCount)),
+				fixedLimit:       fixedLimitVal,
+				ownedStreamCount: ownedStreamCountVal,
 			}
 			strategy := &fixedStrategy{localLimit: testData.calculatedLocalLimit}
 			limiter := NewLimiter(limits, NilMetrics, strategy, &TenantBasedStrategy{limits: limits})

--- a/pkg/ingester/mapper.go
+++ b/pkg/ingester/mapper.go
@@ -5,11 +5,11 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
-	"go.uber.org/atomic"
 
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
@@ -128,7 +128,7 @@ func (m *FpMapper) maybeAddMapping(fp model.Fingerprint, collidingMetric labels.
 }
 
 func (m *FpMapper) nextMappedFP() model.Fingerprint {
-	mappedFP := model.Fingerprint(m.highestMappedFP.Inc())
+	mappedFP := model.Fingerprint(m.highestMappedFP.Add(1))
 	if mappedFP > maxMappedFP {
 		panic(fmt.Errorf("more than %v fingerprints mapped in collision detection", maxMappedFP))
 	}

--- a/pkg/ingester/owned_streams.go
+++ b/pkg/ingester/owned_streams.go
@@ -2,11 +2,11 @@ package ingester
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/util/constants"
 )
@@ -39,8 +39,8 @@ func newOwnedStreamService(tenantID string, limiter *Limiter) *ownedStreamServic
 	svc := &ownedStreamService{
 		tenantID:           tenantID,
 		limiter:            limiter,
-		fixedLimit:         atomic.NewInt32(0),
-		ownedStreamCount:   atomic.NewInt64(0),
+		fixedLimit:         (&atomic.Int32{}),
+		ownedStreamCount:   (&atomic.Int64{}),
 		notOwnedStreams:    make(map[model.Fingerprint]any),
 		policyStreamCounts: make(map[string]*atomic.Int64),
 	}
@@ -86,15 +86,15 @@ func (s *ownedStreamService) getFixedLimit() int {
 func (s *ownedStreamService) trackStreamOwnership(fp model.Fingerprint, owned bool, policy string) {
 	// only need to inc the owned count; can use sync atomics.
 	if owned {
-		s.ownedStreamCount.Inc()
+		s.ownedStreamCount.Add(1)
 
 		// Track policy-specific stream count if policy is specified
 		if policy != noPolicy {
 			s.policyLock.Lock()
 			if s.policyStreamCounts[policy] == nil {
-				s.policyStreamCounts[policy] = atomic.NewInt64(0)
+				s.policyStreamCounts[policy] = (&atomic.Int64{})
 			}
-			s.policyStreamCounts[policy].Inc()
+			s.policyStreamCounts[policy].Add(1)
 			s.policyLock.Unlock()
 		}
 		return
@@ -116,13 +116,13 @@ func (s *ownedStreamService) trackRemovedStream(fp model.Fingerprint, policy str
 		delete(s.notOwnedStreams, fp)
 		return
 	}
-	s.ownedStreamCount.Dec()
+	s.ownedStreamCount.Add(-1)
 
 	// Decrement policy-specific stream count if policy is specified
 	if policy != noPolicy {
 		s.policyLock.Lock()
 		if policyCount, exists := s.policyStreamCounts[policy]; exists {
-			policyCount.Dec()
+			policyCount.Add(-1)
 			// Clean up policy if count reaches zero to prevent unbounded map growth
 			if policyCount.Load() == 0 {
 				delete(s.policyStreamCounts, policy)

--- a/pkg/ingester/replay_controller.go
+++ b/pkg/ingester/replay_controller.go
@@ -2,10 +2,10 @@ package ingester
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	"github.com/dustin/go-humanize"
 	"github.com/go-kit/log/level"
-	"go.uber.org/atomic"
 	"golang.org/x/sync/singleflight"
 
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
@@ -72,7 +72,7 @@ func (c *replayController) Add(x int64) {
 
 func (c *replayController) Sub(x int64) {
 	c.totalSubtracted.Add(x)
-	c.metrics.setRecoveryBytesInUse(c.currentBytes.Sub(x))
+	c.metrics.setRecoveryBytesInUse(c.currentBytes.Add(-x))
 }
 
 func (c *replayController) Cur() int {

--- a/pkg/ingester/replay_controller_test.go
+++ b/pkg/ingester/replay_controller_test.go
@@ -2,11 +2,11 @@ package ingester
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/util/constants"
 )

--- a/pkg/ingester/streams_map.go
+++ b/pkg/ingester/streams_map.go
@@ -2,9 +2,9 @@ package ingester
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/prometheus/common/model"
-	"go.uber.org/atomic"
 )
 
 type streamsMap struct {
@@ -19,7 +19,7 @@ func newStreamsMap() *streamsMap {
 		consistencyMtx: sync.RWMutex{},
 		streams:        &sync.Map{},
 		streamsByFP:    &sync.Map{},
-		streamsCounter: atomic.NewInt64(0),
+		streamsCounter: (&atomic.Int64{}),
 	}
 }
 
@@ -48,7 +48,7 @@ func (m *streamsMap) Delete(s *stream) bool {
 	_, loaded := m.streams.LoadAndDelete(s.labelsString)
 	if loaded {
 		m.streamsByFP.Delete(s.fp)
-		m.streamsCounter.Dec()
+		m.streamsCounter.Add(-1)
 		return true
 	}
 	return false
@@ -108,7 +108,7 @@ func (m *streamsMap) store(key interface{}, s *stream) {
 		m.streams.Store(s.labelsString, s)
 	}
 	m.streamsByFP.Store(s.fp, s)
-	m.streamsCounter.Inc()
+	m.streamsCounter.Add(1)
 }
 
 // newStreamFn: Called if not loaded, with consistencyMtx locked. Must not be nil

--- a/pkg/ingester/tailer.go
+++ b/pkg/ingester/tailer.go
@@ -4,13 +4,13 @@ import (
 	"encoding/binary"
 	"hash/fnv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"context"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/prometheus/model/labels"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql/log"

--- a/pkg/ingester/wal.go
+++ b/pkg/ingester/wal.go
@@ -4,9 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
-	"go.uber.org/atomic"
 
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"

--- a/pkg/ingester/wal_disk_throttle_test.go
+++ b/pkg/ingester/wal_disk_throttle_test.go
@@ -2,10 +2,10 @@ package ingester
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
-	"go.uber.org/atomic"
 
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/user"

--- a/pkg/iter/entry_iterator_test.go
+++ b/pkg/iter/entry_iterator_test.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"hash/fnv"
 	"math/rand"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"

--- a/pkg/iter/sample_iterator_test.go
+++ b/pkg/iter/sample_iterator_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/util"

--- a/pkg/kafka/client/writer_client.go
+++ b/pkg/kafka/client/writer_client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -18,7 +19,6 @@ import (
 	"github.com/twmb/franz-go/plugin/kprom"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/kafka"
 )
@@ -260,7 +260,7 @@ func NewProducer(component string, client *kgo.Client, maxBufferedBytes int64, r
 
 	producer := &Producer{
 		Client:           client,
-		bufferedBytes:    atomic.NewInt64(0),
+		bufferedBytes:    (&atomic.Int64{}),
 		maxBufferedBytes: maxBufferedBytes,
 
 		// Metrics.
@@ -315,7 +315,7 @@ func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.P
 	}
 
 	var (
-		remaining = atomic.NewInt64(int64(len(records)))
+		remaining = func() *atomic.Int64 { v := &atomic.Int64{}; v.Store(int64(len(records))); return v }()
 		done      = make(chan struct{})
 		resMx     sync.Mutex
 		res       = make(kgo.ProduceResults, 0, len(records))
@@ -339,7 +339,7 @@ func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.P
 		// In case of error we'll wait for all responses anyway before returning from produceSync().
 		// It allows us to keep code easier, given we don't expect this function to be frequently
 		// called with multiple records.
-		if remaining.Dec() == 0 {
+		if remaining.Add(-1) == 0 {
 			close(done)
 		}
 	}

--- a/pkg/kafka/partition/committer.go
+++ b/pkg/kafka/partition/committer.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/kafka/client"
 )
@@ -71,7 +71,7 @@ func newCommitter(offsetManager OffsetManager, partition int32, commitFreq time.
 			Help:        "The last consumed offset successfully committed by the partition reader. Set to -1 if not offset has been committed yet.",
 			ConstLabels: prometheus.Labels{"partition": strconv.Itoa(int(partition))},
 		}),
-		toCommit: atomic.NewInt64(-1),
+		toCommit: func() *atomic.Int64 { v := &atomic.Int64{}; v.Store(-1); return v }(),
 	}
 
 	// Initialize the last committed offset metric to -1 to signal no offset has been committed yet

--- a/pkg/logproto/extensions.go
+++ b/pkg/logproto/extensions.go
@@ -5,7 +5,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
-	"sync/atomic" //lint:ignore faillint we can't use go.uber.org/atomic with a protobuf struct without wrapping it.
+	"sync/atomic"
 	"time"
 
 	"github.com/cespare/xxhash/v2"

--- a/pkg/logqlmodel/stats/context.go
+++ b/pkg/logqlmodel/stats/context.go
@@ -22,7 +22,7 @@ package stats
 import (
 	"context"
 	"sync"
-	"sync/atomic" //lint:ignore faillint we can't use go.uber.org/atomic with a protobuf struct without wrapping it.
+	"sync/atomic"
 	"time"
 
 	"github.com/dustin/go-humanize"

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	rt "runtime"
+	"sync/atomic"
 	"time"
 
 	"github.com/fatih/color"
@@ -26,7 +27,6 @@ import (
 	"github.com/grafana/dskit/signals"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/grafana/loki/v3/pkg/analytics"
@@ -581,7 +581,7 @@ func (t *Loki) Run(opts RunOpts) error {
 		return err
 	}
 
-	shutdownRequested := atomic.NewBool(false)
+	shutdownRequested := (&atomic.Bool{})
 
 	// before starting servers, register /ready handler. It should reflect entire Loki.
 	if t.Cfg.InternalServer.Enable {

--- a/pkg/lokifrontend/frontend/v1/frontend_test.go
+++ b/pkg/lokifrontend/frontend/v1/frontend_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,7 +28,6 @@ import (
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
 	"github.com/grafana/loki/v3/pkg/loghttp"
@@ -173,7 +173,7 @@ func TestFrontendCancel(t *testing.T) {
 	var tries atomic.Int32
 	handler := queryrangebase.HandlerFunc(func(ctx context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
 		<-ctx.Done()
-		tries.Inc()
+		tries.Add(1)
 		return nil, ctx.Err()
 	})
 	test := func(addr string, _ *Frontend) {

--- a/pkg/lokifrontend/frontend/v2/frontend.go
+++ b/pkg/lokifrontend/frontend/v2/frontend.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -23,7 +24,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/dskit/tenant"
 
@@ -230,7 +230,7 @@ func (f *Frontend) RoundTripGRPC(ctx context.Context, req *httpgrpc.HTTPRequest)
 	defer cancel()
 
 	freq := &frontendRequest{
-		queryID:      f.lastQueryID.Inc(),
+		queryID:      f.lastQueryID.Add(1),
 		request:      req,
 		tenantID:     tenantID,
 		actor:        httpreq.ExtractActorPath(ctx),
@@ -290,7 +290,7 @@ func (f *Frontend) Do(ctx context.Context, req queryrangebase.Request) (queryran
 	defer cancel()
 
 	freq := &frontendRequest{
-		queryID:      f.lastQueryID.Inc(),
+		queryID:      f.lastQueryID.Add(1),
 		tenantID:     tenantID,
 		actor:        httpreq.ExtractActorPath(ctx),
 		statsEnabled: stats.IsEnabled(ctx),

--- a/pkg/lokifrontend/frontend/v2/frontend_test.go
+++ b/pkg/lokifrontend/frontend/v2/frontend_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,7 +17,6 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/user"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
@@ -158,7 +158,8 @@ func TestFrontendBasicWorkflowProto(t *testing.T) {
 
 func TestFrontendRetryEnqueue(t *testing.T) {
 	// Frontend uses worker concurrency to compute number of retries. We use one less failure.
-	failures := atomic.NewInt64(testFrontendWorkerConcurrency - 1)
+	failures := &atomic.Int64{}
+	failures.Store(testFrontendWorkerConcurrency - 1)
 	const (
 		body   = "hello world"
 		userID = "test"
@@ -167,7 +168,7 @@ func TestFrontendRetryEnqueue(t *testing.T) {
 	cfg := Config{}
 	flagext.DefaultValues(&cfg)
 	f, _ := setupFrontend(t, cfg, func(f *Frontend, msg *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend {
-		fail := failures.Dec()
+		fail := failures.Add(-1)
 		if fail >= 0 {
 			return &schedulerpb.SchedulerToFrontend{Status: schedulerpb.SHUTTING_DOWN}
 		}

--- a/pkg/memory/allocator.go
+++ b/pkg/memory/allocator.go
@@ -2,9 +2,9 @@ package memory
 
 import (
 	"errors"
+	"sync/atomic"
 	"unsafe"
 
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/memory/internal/memalign"
 )

--- a/pkg/pattern/streams_map.go
+++ b/pkg/pattern/streams_map.go
@@ -2,9 +2,9 @@ package pattern
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/prometheus/common/model"
-	"go.uber.org/atomic"
 )
 
 type streamsMap struct {
@@ -19,7 +19,7 @@ func newStreamsMap() *streamsMap {
 		consistencyMtx: sync.RWMutex{},
 		streams:        &sync.Map{},
 		streamsByFP:    &sync.Map{},
-		streamsCounter: atomic.NewInt64(0),
+		streamsCounter: (&atomic.Int64{}),
 	}
 }
 
@@ -48,7 +48,7 @@ func (m *streamsMap) Delete(s *stream) bool {
 	_, loaded := m.streams.LoadAndDelete(s.labelsString)
 	if loaded {
 		m.streamsByFP.Delete(s.fp)
-		m.streamsCounter.Dec()
+		m.streamsCounter.Add(-1)
 		return true
 	}
 	return false
@@ -108,7 +108,7 @@ func (m *streamsMap) store(key interface{}, s *stream) {
 		m.streams.Store(s.labelsString, s)
 	}
 	m.streamsByFP.Store(s.fp, s)
-	m.streamsCounter.Inc()
+	m.streamsCounter.Add(1)
 }
 
 // newStreamFn: Called if not loaded, with consistencyMtx locked. Must not be nil

--- a/pkg/querier/ingester_querier_test.go
+++ b/pkg/querier/ingester_querier_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/ring/client"
 	"github.com/grafana/dskit/user"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 	grpc_metadata "google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -305,7 +305,7 @@ func TestIngesterQuerierFetchesResponsesFromPartitionIngesters(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
-		cnt := atomic.NewInt32(0)
+		cnt := (&atomic.Int32{})
 
 		t.Run(testName, func(t *testing.T) {
 			cnt.Store(0)
@@ -404,7 +404,7 @@ func TestIngesterQuerier_QueriesSameIngestersWithPartitionContext(t *testing.T) 
 	}
 
 	for testName, testData := range tests {
-		cnt := atomic.NewInt32(0)
+		cnt := (&atomic.Int32{})
 		ctx := NewPartitionContext(testCtx)
 
 		t.Run(testName, func(t *testing.T) {

--- a/pkg/querier/queryrange/downstreamer_test.go
+++ b/pkg/querier/queryrange/downstreamer_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,7 +17,6 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
@@ -568,7 +568,7 @@ func TestCancelWhileWaitingResponse(t *testing.T) {
 
 	// Launch the For call in a goroutine because it blocks and we need to be able to cancel the context
 	// to prove it will exit when the context is canceled.
-	b := atomic.NewBool(false)
+	b := (&atomic.Bool{})
 	go func() {
 		_, _ = in.For(ctx, queries, acc, func(_ logql.DownstreamQuery) (logqlmodel.Result, error) {
 			// Intended to keep the For method from returning unless the context is canceled.

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"regexp"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"gopkg.in/yaml.v2"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -566,11 +566,11 @@ func Test_MaxQueryParallelism(t *testing.T) {
 	var count atomic.Int32
 	var maxVal atomic.Int32
 	h := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
-		cur := count.Inc()
+		cur := count.Add(1)
 		if cur > maxVal.Load() {
 			maxVal.Store(cur)
 		}
-		defer count.Dec()
+		defer count.Add(-1)
 		// simulate some work
 		time.Sleep(20 * time.Millisecond)
 		return queryrangebase.NewEmptyPrometheusResponse(model.ValMatrix), nil
@@ -1126,10 +1126,10 @@ func Test_MaxQuerySize_WithQueryLimitsContext(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			statsHits := atomic.NewInt32(0)
+			statsHits := (&atomic.Int32{})
 
 			statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
-				statsHits.Inc()
+				statsHits.Add(1)
 
 				bytes := tc.queryBytes
 				if req.GetQuery() == ctxSentinal {

--- a/pkg/querier/queryrange/queryrangebase/retry_test.go
+++ b/pkg/querier/queryrange/queryrangebase/retry_test.go
@@ -5,13 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-kit/log"
 	"github.com/gogo/status"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/loki/v3/pkg/util/constants"
@@ -30,7 +30,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "retry failures",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				if try.Inc() == 5 {
+				if try.Add(1) == 5 {
 					return &PrometheusResponse{Status: "Hello World"}, nil
 				}
 				return nil, fmt.Errorf("fail")
@@ -41,7 +41,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "don't retry 400s",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				try.Inc()
+				try.Add(1)
 				return nil, httpgrpc.Errorf(http.StatusBadRequest, "Bad Request")
 			}),
 			err:           httpgrpc.Errorf(http.StatusBadRequest, "Bad Request"),
@@ -50,7 +50,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "retry 500s",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				try.Inc()
+				try.Add(1)
 				return nil, httpgrpc.Errorf(http.StatusInternalServerError, "Internal Server Error")
 			}),
 			err:           httpgrpc.Errorf(http.StatusInternalServerError, "Internal Server Error"),
@@ -59,7 +59,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "last error",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				if try.Inc() == 5 {
+				if try.Add(1) == 5 {
 					return nil, httpgrpc.Errorf(http.StatusBadRequest, "Bad Request")
 				}
 				return nil, httpgrpc.Errorf(http.StatusInternalServerError, "Internal Server Error")
@@ -72,7 +72,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "protobuf enc don't retry 400s",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				try.Inc()
+				try.Add(1)
 				return nil, status.New(codes.Code(http.StatusBadRequest), "Bad Request").Err()
 			}),
 			err:           status.New(codes.Code(http.StatusBadRequest), "Bad Request").Err(),
@@ -81,7 +81,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "protobuf enc retry 500s",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				try.Inc()
+				try.Add(1)
 				return nil, status.New(codes.Code(http.StatusInternalServerError), "Internal Server Error").Err()
 			}),
 			err:           status.New(codes.Code(http.StatusInternalServerError), "Internal Server Error").Err(),
@@ -112,7 +112,7 @@ func Test_RetryMiddlewareCancel(t *testing.T) {
 	cancel()
 	_, err := NewRetryMiddleware(log.NewNopLogger(), 5, nil, constants.Loki).Wrap(
 		HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-			try.Inc()
+			try.Add(1)
 			return nil, ctx.Err()
 		}),
 	).Do(ctx, req)
@@ -122,7 +122,7 @@ func Test_RetryMiddlewareCancel(t *testing.T) {
 	ctx, cancel = context.WithCancel(context.Background())
 	_, err = NewRetryMiddleware(log.NewNopLogger(), 5, nil, constants.Loki).Wrap(
 		HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-			try.Inc()
+			try.Add(1)
 			cancel()
 			return nil, errors.New("failed")
 		}),

--- a/pkg/querier/stats/stats.go
+++ b/pkg/querier/stats/stats.go
@@ -2,7 +2,7 @@ package stats
 
 import (
 	"context"
-	"sync/atomic" //lint:ignore faillint we can't use go.uber.org/atomic with a protobuf struct without wrapping it.
+	"sync/atomic"
 	"time"
 
 	"github.com/gogo/googleapis/google/rpc"

--- a/pkg/querier/tail/tail.go
+++ b/pkg/querier/tail/tail.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
-	"go.uber.org/atomic"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"

--- a/pkg/querier/worker/frontend_processor_test.go
+++ b/pkg/querier/worker/frontend_processor_test.go
@@ -3,13 +3,13 @@ package worker
 import (
 	"context"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
@@ -36,7 +36,7 @@ func TestRecvFailDoesntCancelProcess(t *testing.T) {
 
 	cfg := Config{}
 	mgr := newFrontendProcessor(cfg, nil, log.NewNopLogger(), queryrange.DefaultCodec)
-	running := atomic.NewBool(false)
+	running := (&atomic.Bool{})
 	go func() {
 		running.Store(true)
 		defer running.Store(false)

--- a/pkg/querier/worker/processor_manager.go
+++ b/pkg/querier/worker/processor_manager.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 )
 
@@ -38,7 +38,7 @@ func newProcessorManager(ctx context.Context, p processor, conn *grpc.ClientConn
 		ctx:               ctx,
 		conn:              conn,
 		address:           address,
-		currentProcessors: atomic.NewInt32(0),
+		currentProcessors: (&atomic.Int32{}),
 	}
 }
 
@@ -75,8 +75,8 @@ func (pm *processorManager) concurrency(n int) {
 		go func(workerID int) {
 			defer pm.wg.Done()
 
-			pm.currentProcessors.Inc()
-			defer pm.currentProcessors.Dec()
+			pm.currentProcessors.Add(1)
+			defer pm.currentProcessors.Add(-1)
 
 			pm.p.processQueriesOnSingleStream(ctx, pm.conn, pm.address, strconv.Itoa(workerID))
 		}(workerID)

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -21,7 +22,6 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 

--- a/pkg/querier/worker/scheduler_processor_test.go
+++ b/pkg/querier/worker/scheduler_processor_test.go
@@ -4,6 +4,7 @@ package worker
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -54,10 +54,10 @@ func TestSchedulerProcessor_processQueriesOnSingleStream(t *testing.T) {
 	t.Run("should wait until inflight query execution is completed before returning when worker context is canceled", func(t *testing.T) {
 		sp, loopClient, requestHandler := prepareSchedulerProcessor()
 
-		recvCount := atomic.NewInt64(0)
+		recvCount := (&atomic.Int64{})
 
 		loopClient.On("Recv").Return(func() (*schedulerpb.SchedulerToQuerier, error) {
-			switch recvCount.Inc() {
+			switch recvCount.Add(1) {
 			case 1:
 				return &schedulerpb.SchedulerToQuerier{
 					QueryID: 1,

--- a/pkg/querier/worker/util.go
+++ b/pkg/querier/worker/util.go
@@ -5,6 +5,7 @@ package worker
 import (
 	"context"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -12,7 +13,6 @@ import (
 	"github.com/gogo/status"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/pkg/errors"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/loki/v3/pkg/querier/queryrange"
@@ -35,7 +35,7 @@ import (
 // once the inflight query terminates and the response has been sent.
 func newExecutionContext(workerCtx context.Context, logger log.Logger) (execCtx context.Context, execCancel context.CancelCauseFunc, inflightQuery *atomic.Bool) {
 	execCtx, execCancel = context.WithCancelCause(context.Background())
-	inflightQuery = atomic.NewBool(false)
+	inflightQuery = (&atomic.Bool{})
 
 	go func() {
 		// Wait until it's safe to cancel the execution context, which is when one of the following conditions happen:

--- a/pkg/querytee/proxy_endpoint_test.go
+++ b/pkg/querytee/proxy_endpoint_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -22,7 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/goldfish"
 	"github.com/grafana/loki/v3/pkg/loghttp"

--- a/pkg/queue/dequeue_qos_test.go
+++ b/pkg/queue/dequeue_qos_test.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/util/constants"
 )

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/grafana/dskit/services"
 	"github.com/pkg/errors"
-	"go.uber.org/atomic"
 )
 
 const (
@@ -72,7 +72,7 @@ type RequestQueue struct {
 func NewRequestQueue(maxOutstandingPerTenant int, forgetDelay time.Duration, limits Limits, metrics *Metrics) *RequestQueue {
 	q := &RequestQueue{
 		queues:             newTenantQueues(maxOutstandingPerTenant, forgetDelay, limits),
-		connectedConsumers: atomic.NewInt32(0),
+		connectedConsumers: (&atomic.Int32{}),
 		metrics:            metrics,
 		pool:               NewSlicePool[Request](1<<6, 1<<10, 2), // Buckets are [64, 128, 256, 512, 1024].
 	}
@@ -274,7 +274,7 @@ func (q *RequestQueue) stopping(_ error) error {
 }
 
 func (q *RequestQueue) RegisterConsumerConnection(querier string) {
-	q.connectedConsumers.Inc()
+	q.connectedConsumers.Add(1)
 
 	q.mtx.Lock()
 	defer q.mtx.Unlock()
@@ -282,7 +282,7 @@ func (q *RequestQueue) RegisterConsumerConnection(querier string) {
 }
 
 func (q *RequestQueue) UnregisterConsumerConnection(querier string) {
-	q.connectedConsumers.Dec()
+	q.connectedConsumers.Add(-1)
 
 	q.mtx.Lock()
 	defer q.mtx.Unlock()

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/grafana/dskit/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/loki/v3/pkg/util/constants"
@@ -461,7 +461,7 @@ func Test_Queue_DequeueMany(t *testing.T) {
 
 			mtx := &sync.Mutex{}
 			receivedTasksPerTenant := make(map[string]int, tt.tenantsCount)
-			receivedTasksCount := atomic.NewInt32(0)
+			receivedTasksCount := (&atomic.Int32{})
 			for i := 0; i < tt.consumersCount; i++ {
 				consumer := createConsumerName(i)
 				wg.Go(func() error {

--- a/pkg/ruler/base/manager_test.go
+++ b/pkg/ruler/base/manager_test.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/prometheus/prometheus/notifier"
 	promRules "github.com/prometheus/prometheus/rules"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/ruler/rulespb"
 	"github.com/grafana/loki/v3/pkg/util/constants"

--- a/pkg/ruler/base/ruler_test.go
+++ b/pkg/ruler/base/ruler_test.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 	"unsafe"
@@ -38,7 +39,6 @@ import (
 	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v2"
 
@@ -180,7 +180,7 @@ type mockRulerClient struct {
 }
 
 func (c *mockRulerClient) Rules(ctx context.Context, in *RulesRequest, _ ...grpc.CallOption) (*RulesResponse, error) {
-	c.numberOfCalls.Inc()
+	c.numberOfCalls.Add(1)
 	return c.ruler.Rules(ctx, in)
 }
 

--- a/pkg/ruler/storage/wal/wal.go
+++ b/pkg/ruler/storage/wal/wal.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -29,7 +30,6 @@ import (
 	"github.com/prometheus/prometheus/tsdb/record"
 	"github.com/prometheus/prometheus/tsdb/wlog"
 	"github.com/prometheus/prometheus/util/compression"
-	"go.uber.org/atomic"
 
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
@@ -83,7 +83,7 @@ func NewStorage(logger log.Logger, metrics *Metrics, registerer prometheus.Regis
 		deleted: map[chunks.HeadSeriesRef]int{},
 		series:  newStripeSeries(),
 		metrics: metrics,
-		ref:     atomic.NewUint64(0),
+		ref:     (&atomic.Uint64{}),
 	}
 
 	storage.bufPool.New = func() interface{} {
@@ -651,7 +651,7 @@ func (a *appender) getOrCreate(l labels.Labels) (series *memSeries, created bool
 		return series, false
 	}
 
-	series = &memSeries{ref: chunks.HeadSeriesRef(a.w.ref.Inc()), lset: l}
+	series = &memSeries{ref: chunks.HeadSeriesRef(a.w.ref.Add(1)), lset: l}
 	a.w.series.set(labels.StableHash(l), series)
 	return series, true
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"net/textproto"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -25,7 +26,6 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
 	"github.com/grafana/loki/v3/pkg/lokifrontend/frontend/v2/frontendv2pb"

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -2,13 +2,13 @@ package v1
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/efficientgo/core/errors"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
-	"go.uber.org/atomic"
 
 	iter "github.com/grafana/loki/v3/pkg/iter/v2"
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
@@ -28,15 +28,15 @@ func NewBloomRecorder(ctx context.Context, id string) *BloomRecorder {
 	return &BloomRecorder{
 		ctx:            ctx,
 		id:             id,
-		seriesFound:    atomic.NewInt64(0),
-		chunksFound:    atomic.NewInt64(0),
-		seriesSkipped:  atomic.NewInt64(0),
-		chunksSkipped:  atomic.NewInt64(0),
-		seriesMissed:   atomic.NewInt64(0),
-		chunksMissed:   atomic.NewInt64(0),
-		seriesEmpty:    atomic.NewInt64(0),
-		chunksEmpty:    atomic.NewInt64(0),
-		chunksFiltered: atomic.NewInt64(0),
+		seriesFound:    (&atomic.Int64{}),
+		chunksFound:    (&atomic.Int64{}),
+		seriesSkipped:  (&atomic.Int64{}),
+		chunksSkipped:  (&atomic.Int64{}),
+		seriesMissed:   (&atomic.Int64{}),
+		chunksMissed:   (&atomic.Int64{}),
+		seriesEmpty:    (&atomic.Int64{}),
+		chunksEmpty:    (&atomic.Int64{}),
+		chunksFiltered: (&atomic.Int64{}),
 	}
 }
 

--- a/pkg/storage/chunk/cache/background.go
+++ b/pkg/storage/chunk/cache/background.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"flag"
 	"sync"
+	"sync/atomic"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	attribute "go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/util/constants"
 	"github.com/grafana/loki/v3/pkg/util/flagext"
@@ -152,7 +152,7 @@ func (c *backgroundCache) Store(ctx context.Context, keys []string, bufs [][]byt
 		newSize := c.size.Add(int64(size))
 		if newSize > int64(c.sizeLimit) {
 			// subtract it since we've exceeded the limit
-			c.size.Sub(int64(size))
+			c.size.Add(-int64(size))
 			c.failStore(ctx, size, num, "queue at byte size limit")
 			return nil
 		}
@@ -192,7 +192,7 @@ func (c *backgroundCache) writeBackLoop() {
 			if !ok {
 				return
 			}
-			c.size.Sub(int64(bgWrite.size()))
+			c.size.Add(-int64(bgWrite.size()))
 
 			c.queueLength.Sub(float64(len(bgWrite.keys)))
 			c.queueBytes.Set(float64(c.size.Load()))

--- a/pkg/storage/chunk/cache/embeddedcache_test.go
+++ b/pkg/storage/chunk/cache/embeddedcache_test.go
@@ -3,10 +3,10 @@ package cache
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
-	"go.uber.org/atomic"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -47,9 +47,9 @@ func TestEmbeddedCacheEviction(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		removedEntriesCount := atomic.NewInt64(0)
+		removedEntriesCount := (&atomic.Int64{})
 		onEntryRemoved := func(_ string, _ []byte) {
-			removedEntriesCount.Inc()
+			removedEntriesCount.Add(1)
 		}
 		c := NewTypedEmbeddedCache[string, []byte](test.name, test.cfg, nil, log.NewNopLogger(), "test", sizeOf, onEntryRemoved)
 		ctx := context.Background()
@@ -186,9 +186,9 @@ func TestEmbeddedCacheExpiry(t *testing.T) {
 		PurgeInterval: 50 * time.Millisecond,
 	}
 
-	removedEntriesCount := atomic.NewInt64(0)
+	removedEntriesCount := (&atomic.Int64{})
 	onEntryRemoved := func(_ string, _ []byte) {
-		removedEntriesCount.Inc()
+		removedEntriesCount.Add(1)
 	}
 	c := NewTypedEmbeddedCache[string, []byte]("cache_exprity_test", cfg, nil, log.NewNopLogger(), "test", sizeOf, onEntryRemoved)
 	ctx := context.Background()

--- a/pkg/storage/chunk/cache/memcached_test.go
+++ b/pkg/storage/chunk/cache/memcached_test.go
@@ -5,13 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/gomemcache/memcache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
 )
@@ -126,7 +126,7 @@ func newMockMemcacheFailing() *mockMemcacheFailing {
 }
 
 func (c *mockMemcacheFailing) GetMulti(ctx context.Context, keys []string, _ ...memcache.Option) (map[string]*memcache.Item, error) {
-	calls := c.calls.Inc()
+	calls := c.calls.Add(1)
 	if calls%3 == 0 {
 		return nil, errors.New("fail")
 	}

--- a/pkg/storage/chunk/client/aws/s3_storage_client_test.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -20,7 +21,6 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging"
 
@@ -273,7 +273,7 @@ func Test_Hedging(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			count := atomic.NewInt32(0)
+			count := (&atomic.Int32{})
 
 			c, err := NewS3ObjectClient(S3Config{
 				AccessKeyID:     "foo",
@@ -282,7 +282,7 @@ func Test_Hedging(t *testing.T) {
 				BucketNames:     "foo",
 				Inject: func(_ http.RoundTripper) http.RoundTripper {
 					return RoundTripperFunc(func(_ *http.Request) (*http.Response, error) {
-						count.Inc()
+						count.Add(1)
 						time.Sleep(200 * time.Millisecond)
 						return nil, errors.New("foo")
 					})
@@ -395,11 +395,11 @@ func Test_RetryLogic(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			callCount := atomic.NewInt32(0)
+			callCount := (&atomic.Int32{})
 
 			mockS3 := &MockS3Client{
 				HeadObjectFunc: func(_ context.Context, _ *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
-					callNum := callCount.Inc()
+					callNum := callCount.Add(1)
 					if !tc.exists {
 						rfIn := &types.NotFound{}
 						return nil, rfIn
@@ -424,7 +424,7 @@ func Test_RetryLogic(t *testing.T) {
 				Inject: func(_ http.RoundTripper) http.RoundTripper {
 					return RoundTripperFunc(func(_ *http.Request) (*http.Response, error) {
 						// Increment the call counter
-						callNum := callCount.Inc()
+						callNum := callCount.Add(1)
 
 						// Fail the first set of calls
 						if int(callNum) <= tc.maxRetries-1 {

--- a/pkg/storage/chunk/client/azure/blob_storage_client_test.go
+++ b/pkg/storage/chunk/client/azure/blob_storage_client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging"
 )
@@ -143,14 +143,14 @@ func Test_Hedging(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			count := atomic.NewInt32(0)
+			count := (&atomic.Int32{})
 			// hijack the client to count the number of calls
 			defaultClientFactory = func() *http.Client {
 				return &http.Client{
 					Transport: RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 						// blocklist is a call that can be fired by the SDK after PUT but is not guaranteed.
 						if !strings.Contains(req.URL.String(), "blocklist") {
-							count.Inc()
+							count.Add(1)
 							time.Sleep(50 * time.Millisecond)
 						}
 						return nil, http.ErrNotSupported

--- a/pkg/storage/chunk/client/congestion/controller_test.go
+++ b/pkg/storage/chunk/client/congestion/controller_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
@@ -253,7 +253,7 @@ func (m *mockObjectClient) PutObject(context.Context, string, io.Reader) error {
 
 func (m *mockObjectClient) GetObject(context.Context, string) (io.ReadCloser, int64, error) {
 	time.Sleep(time.Millisecond * 10)
-	if m.strategy.fail(m.reqCounter.Inc()) {
+	if m.strategy.fail(m.reqCounter.Add(1)) {
 		return nil, 0, errFakeFailure
 	}
 

--- a/pkg/storage/chunk/client/gcp/gcs_object_client_test.go
+++ b/pkg/storage/chunk/client/gcp/gcs_object_client_test.go
@@ -6,12 +6,12 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/api/option"
 
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging"
@@ -56,7 +56,7 @@ func Test_Hedging(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			count := atomic.NewInt32(0)
+			count := (&atomic.Int32{})
 			server := fakeServer(t, 200*time.Millisecond, count)
 			ctx := context.Background()
 			c, err := newGCSObjectClient(ctx, GCSConfig{
@@ -80,7 +80,7 @@ func Test_Hedging(t *testing.T) {
 
 func fakeServer(t *testing.T, returnIn time.Duration, counter *atomic.Int32) *httptest.Server {
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		counter.Inc()
+		counter.Add(1)
 		time.Sleep(returnIn)
 		_, _ = w.Write([]byte(`{}`))
 	}))

--- a/pkg/storage/chunk/client/hedging/hedging_test.go
+++ b/pkg/storage/chunk/client/hedging/hedging_test.go
@@ -3,13 +3,13 @@ package hedging
 import (
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 )
 
 type RoundTripperFunc func(*http.Request) (*http.Response, error)
@@ -34,10 +34,10 @@ func TestHedging(t *testing.T) {
 		UpTo:         3,
 		MaxPerSecond: 1000,
 	}
-	count := atomic.NewInt32(0)
+	count := (&atomic.Int32{})
 	client, err := cfg.ClientWithRegisterer(&http.Client{
 		Transport: RoundTripperFunc(func(_ *http.Request) (*http.Response, error) {
-			count.Inc()
+			count.Add(1)
 			time.Sleep(200 * time.Millisecond)
 			return &http.Response{
 				StatusCode: http.StatusOK,
@@ -69,10 +69,10 @@ func TestHedgingRateLimit(t *testing.T) {
 		UpTo:         20,
 		MaxPerSecond: 1,
 	}
-	count := atomic.NewInt32(0)
+	count := (&atomic.Int32{})
 	client, err := cfg.ClientWithRegisterer(&http.Client{
 		Transport: RoundTripperFunc(func(_ *http.Request) (*http.Response, error) {
-			count.Inc()
+			count.Add(1)
 			time.Sleep(200 * time.Millisecond)
 			return &http.Response{
 				StatusCode: http.StatusOK,

--- a/pkg/storage/chunk/client/openstack/swift_object_client_test.go
+++ b/pkg/storage/chunk/client/openstack/swift_object_client_test.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"context"
 	"net/http"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/dskit/flagext"
 
@@ -60,7 +60,7 @@ func Test_Hedging(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			count := atomic.NewInt32(0)
+			count := (&atomic.Int32{})
 			// hijack the transport to count the number of calls
 			transportCounter := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				// fake auth
@@ -81,7 +81,7 @@ func Test_Hedging(t *testing.T) {
 						Body:       http.NoBody,
 					}, nil
 				}
-				count.Inc()
+				count.Add(1)
 				time.Sleep(200 * time.Millisecond)
 				return &http.Response{
 					StatusCode: http.StatusOK,

--- a/pkg/storage/stores/shipper/bloomshipper/blockscache.go
+++ b/pkg/storage/stores/shipper/bloomshipper/blockscache.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -13,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/bloomshipper/config"
 	"github.com/grafana/loki/v3/pkg/util"
@@ -87,8 +87,8 @@ func newBlocksCacheMetrics(reg prometheus.Registerer, namespace, subsystem strin
 			Help:      "The current size of entries managed by the cache in bytes",
 		}),
 
-		hits:   atomic.NewInt64(0),
-		misses: atomic.NewInt64(0),
+		hits:   (&atomic.Int64{}),
+		misses: (&atomic.Int64{}),
 	}
 }
 
@@ -180,7 +180,7 @@ func (c *BlocksCache) PutInc(ctx context.Context, key string, value BlockDirecto
 		return err
 	}
 
-	entry.refCount.Inc()
+	entry.refCount.Add(1)
 	return nil
 }
 
@@ -213,7 +213,7 @@ func (c *BlocksCache) put(key string, value BlockDirectory) (*Entry, error) {
 		Key:      key,
 		Value:    value,
 		created:  time.Now(),
-		refCount: atomic.NewInt32(0),
+		refCount: (&atomic.Int32{}),
 	}
 	size := entry.Value.Size()
 
@@ -330,18 +330,18 @@ func (c *BlocksCache) get(key string, opt *cacheGetOptions) *Entry {
 	element, exists := c.entries[key]
 	if !exists {
 		if opt.ReportHitMiss {
-			c.metrics.misses.Inc()
+			c.metrics.misses.Add(1)
 		}
 		return nil
 	}
 
 	entry := element.Value.(*Entry)
-	entry.refCount.Inc()
+	entry.refCount.Add(1)
 
 	c.lru.MoveToFront(element)
 
 	if opt.ReportHitMiss {
-		c.metrics.hits.Inc()
+		c.metrics.hits.Add(1)
 	}
 
 	return entry
@@ -364,7 +364,7 @@ func (c *BlocksCache) Release(ctx context.Context, key string) error {
 	}
 
 	entry := element.Value.(*Entry)
-	entry.refCount.Dec()
+	entry.refCount.Add(-1)
 	return nil
 }
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head.go
@@ -14,13 +14,13 @@ package tsdb
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 )
@@ -169,7 +169,7 @@ func (h *Head) Append(ls labels.Labels, fprint uint64, chks index.ChunkMetas) (c
 	from, through := chks.Bounds()
 	var id uint64
 	created, refID = h.series.Append(ls, chks, func() *memSeries {
-		id = h.lastSeriesID.Inc()
+		id = h.lastSeriesID.Add(1)
 		return newMemSeries(id, ls, fprint)
 	})
 	updateMintMaxt(int64(from), int64(through), &h.minTime, &h.maxTime)
@@ -178,7 +178,7 @@ func (h *Head) Append(ls labels.Labels, fprint uint64, chks index.ChunkMetas) (c
 		return
 	}
 	h.postings.Add(storage.SeriesRef(id), ls)
-	h.numSeries.Inc()
+	h.numSeries.Add(1)
 	return
 }
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cespare/xxhash/v2"
@@ -22,7 +23,6 @@ import (
 	"github.com/prometheus/prometheus/tsdb/record"
 	"github.com/prometheus/prometheus/tsdb/wlog"
 	"github.com/prometheus/prometheus/util/compression"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"

--- a/pkg/tool/audit/audit.go
+++ b/pkg/tool/audit/audit.go
@@ -6,12 +6,12 @@ import (
 	"io"
 	"path"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	progressbar "github.com/schollz/progressbar/v3"
-	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/loki/v3/pkg/compactor"

--- a/pkg/util/active_user.go
+++ b/pkg/util/active_user.go
@@ -3,10 +3,10 @@ package util //nolint:revive
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/grafana/dskit/services"
-	"go.uber.org/atomic"
 )
 
 // ActiveUsers keeps track of latest user's activity timestamp,
@@ -33,7 +33,8 @@ func (m *ActiveUsers) UpdateUserTimestamp(userID string, ts int64) {
 	}
 
 	// Pre-allocate new atomic to avoid doing allocation with lock held.
-	newAtomic := atomic.NewInt64(ts)
+	newAtomic := &atomic.Int64{}
+	newAtomic.Store(ts)
 
 	// We need RW lock to create new entry.
 	m.mu.Lock()

--- a/pkg/util/active_user_test.go
+++ b/pkg/util/active_user_test.go
@@ -5,11 +5,11 @@ import (
 	"runtime"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 )
 
 func TestActiveUser(t *testing.T) {
@@ -34,9 +34,9 @@ func TestActiveUserConcurrentUpdateAndPurge(t *testing.T) {
 	as := NewActiveUsers()
 
 	done := sync.WaitGroup{}
-	stop := atomic.NewBool(false)
+	stop := (&atomic.Bool{})
 
-	latestTS := atomic.NewInt64(0)
+	latestTS := (&atomic.Int64{})
 
 	for j := 0; j < count; j++ {
 		done.Add(1)
@@ -45,7 +45,7 @@ func TestActiveUserConcurrentUpdateAndPurge(t *testing.T) {
 			defer done.Done()
 
 			for !stop.Load() {
-				ts := latestTS.Inc()
+				ts := latestTS.Add(1)
 
 				// In each cycle, we update different user.
 				as.UpdateUserTimestamp(fmt.Sprintf("%d", ts), ts)
@@ -110,7 +110,7 @@ func BenchmarkActiveUsers_Purge(b *testing.B) {
 
 func startGoroutinesDoingUpdates(b *testing.B, count int, as *ActiveUsers) {
 	done := sync.WaitGroup{}
-	stop := atomic.NewBool(false)
+	stop := (&atomic.Bool{})
 
 	started := sync.WaitGroup{}
 	for j := 0; j < count; j++ {

--- a/pkg/util/atomicutil/atomic.go
+++ b/pkg/util/atomicutil/atomic.go
@@ -1,0 +1,113 @@
+// Package atomicutil provides atomic types that are not available in the
+// standard library's sync/atomic package, such as Float64 and Duration.
+// It also provides helper constructors for stdlib atomic types that need
+// non-zero initialization.
+package atomicutil
+
+import (
+	"math"
+	"sync/atomic"
+	"time"
+)
+
+// NewBool creates a new atomic.Bool with the given initial value.
+func NewBool(val bool) *atomic.Bool {
+	b := &atomic.Bool{}
+	b.Store(val)
+	return b
+}
+
+// NewInt32 creates a new atomic.Int32 with the given initial value.
+func NewInt32(val int32) *atomic.Int32 {
+	i := &atomic.Int32{}
+	i.Store(val)
+	return i
+}
+
+// NewInt64 creates a new atomic.Int64 with the given initial value.
+func NewInt64(val int64) *atomic.Int64 {
+	i := &atomic.Int64{}
+	i.Store(val)
+	return i
+}
+
+// NewUint32 creates a new atomic.Uint32 with the given initial value.
+func NewUint32(val uint32) *atomic.Uint32 {
+	u := &atomic.Uint32{}
+	u.Store(val)
+	return u
+}
+
+// NewUint64 creates a new atomic.Uint64 with the given initial value.
+func NewUint64(val uint64) *atomic.Uint64 {
+	u := &atomic.Uint64{}
+	u.Store(val)
+	return u
+}
+
+// Float64 is an atomic float64 value.
+// The zero value is 0.0.
+type Float64 struct {
+	v atomic.Uint64
+}
+
+// NewFloat64 creates a new Float64 with the given initial value.
+func NewFloat64(val float64) *Float64 {
+	f := &Float64{}
+	f.Store(val)
+	return f
+}
+
+// Load atomically loads and returns the stored float64 value.
+func (f *Float64) Load() float64 {
+	return math.Float64frombits(f.v.Load())
+}
+
+// Store atomically stores val.
+func (f *Float64) Store(val float64) {
+	f.v.Store(math.Float64bits(val))
+}
+
+// CompareAndSwap executes the compare-and-swap operation for the float64 value.
+func (f *Float64) CompareAndSwap(old, new float64) bool {
+	return f.v.CompareAndSwap(math.Float64bits(old), math.Float64bits(new))
+}
+
+// Add atomically adds delta to the stored float64 value and returns the new value.
+func (f *Float64) Add(delta float64) float64 {
+	for {
+		old := f.Load()
+		new := old + delta
+		if f.CompareAndSwap(old, new) {
+			return new
+		}
+	}
+}
+
+// Duration is an atomic time.Duration value.
+// The zero value is 0.
+type Duration struct {
+	v atomic.Int64
+}
+
+// NewDuration creates a new Duration with the given initial value.
+func NewDuration(val time.Duration) *Duration {
+	d := &Duration{}
+	d.Store(val)
+	return d
+}
+
+// Load atomically loads and returns the stored duration value.
+func (d *Duration) Load() time.Duration {
+	return time.Duration(d.v.Load())
+}
+
+// Store atomically stores val.
+func (d *Duration) Store(val time.Duration) {
+	d.v.Store(int64(val))
+}
+
+// Add atomically adds delta to the stored duration value and returns the new value.
+func (d *Duration) Add(delta time.Duration) time.Duration {
+	return time.Duration(d.v.Add(int64(delta)))
+}

--- a/pkg/util/atomicutil/atomic_test.go
+++ b/pkg/util/atomicutil/atomic_test.go
@@ -1,0 +1,63 @@
+package atomicutil
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestFloat64(t *testing.T) {
+	f := NewFloat64(0)
+	if got := f.Load(); got != 0 {
+		t.Errorf("expected 0, got %f", got)
+	}
+
+	f.Store(3.0)
+	if got := f.Load(); got != 3.0 {
+		t.Errorf("expected 3.0, got %f", got)
+	}
+
+	f.Add(1.0)
+	if got := f.Load(); got != 4.0 {
+		t.Errorf("expected 4.0, got %f", got)
+	}
+
+	if !f.CompareAndSwap(4.0, 5.0) {
+		t.Error("CompareAndSwap should have succeeded")
+	}
+	if got := f.Load(); got != 5.0 {
+		t.Errorf("expected 5.0, got %f", got)
+	}
+
+	if f.CompareAndSwap(4.0, 6.0) {
+		t.Error("CompareAndSwap should have failed")
+	}
+
+	// Test with special values
+	inf := NewFloat64(math.Inf(1))
+	if got := inf.Load(); !math.IsInf(got, 1) {
+		t.Errorf("expected +Inf, got %f", got)
+	}
+
+	negInf := NewFloat64(math.Inf(-1))
+	if got := negInf.Load(); !math.IsInf(got, -1) {
+		t.Errorf("expected -Inf, got %f", got)
+	}
+}
+
+func TestDuration(t *testing.T) {
+	d := NewDuration(0)
+	if got := d.Load(); got != 0 {
+		t.Errorf("expected 0, got %v", got)
+	}
+
+	d.Store(time.Second)
+	if got := d.Load(); got != time.Second {
+		t.Errorf("expected 1s, got %v", got)
+	}
+
+	d.Add(500 * time.Millisecond)
+	if got := d.Load(); got != 1500*time.Millisecond {
+		t.Errorf("expected 1.5s, got %v", got)
+	}
+}

--- a/pkg/util/events.go
+++ b/pkg/util/events.go
@@ -2,9 +2,9 @@ package util //nolint:revive
 
 import (
 	"os"
+	"sync/atomic"
 
 	"github.com/go-kit/log"
-	"go.uber.org/atomic"
 )
 
 // Provide an "event" interface for observability
@@ -47,7 +47,7 @@ type samplingFilter struct {
 }
 
 func (e *samplingFilter) Log(keyvals ...interface{}) error {
-	count := e.count.Inc()
+	count := e.count.Add(1)
 	if count%int64(e.freq) == 0 {
 		return e.next.Log(keyvals...)
 	}

--- a/pkg/util/limiter/query_limiter.go
+++ b/pkg/util/limiter/query_limiter.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/prometheus/common/model"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/ingester/client"
 	"github.com/grafana/loki/v3/pkg/logproto"

--- a/pkg/util/rangeio/rangeio.go
+++ b/pkg/util/rangeio/rangeio.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -20,7 +21,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/loki/v3/pkg/xcap"


### PR DESCRIPTION
## Summary

Migrate all direct usage of `go.uber.org/atomic` to the standard library `sync/atomic` package, which has included typed wrappers (`atomic.Bool`, `atomic.Int32`, `atomic.Int64`, etc.) since Go 1.19. This removes a redundant external dependency.

Added `pkg/util/atomicutil` package providing `Float64` and `Duration` atomic types that have no stdlib equivalent. Marked `go.uber.org/atomic` as indirect in `go.mod` (still needed by vendored deps like dskit and prometheus).

### Key changes across 99 files:
- Replace `go.uber.org/atomic` imports with `sync/atomic`
- Replace uber constructors (`NewXxx(0)`) with stdlib zero-value (`&atomic.Xxx{}`)
- Replace `Inc()`/`Dec()` with `Add(1)`/`Add(-1)`
- Replace `Sub()` with `Add(-val)`
- Fix `noCopy` issues where `sync/atomic` is stricter about value semantics
- Remove outdated `lint:ignore faillint` comments

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go vet ./pkg/...` and `go vet ./clients/...` pass
- [x] Unit tests for new `atomicutil` package pass
- [x] Existing tests in affected packages pass

Closes #20673