### PR TITLE
fix(alloc): set a limit on preallocations

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -987,7 +987,8 @@ func determineType(value string) logproto.DetectedFieldType {
 }
 
 func parseDetectedFields(limit uint32, streams logqlmodel.Streams) map[string]*parsedFields {
-	detectedFields := make(map[string]*parsedFields, limit)
+	const maxDetectedFieldsPreAlloc = 1000
+	detectedFields := make(map[string]*parsedFields, min(maxDetectedFieldsPreAlloc, limit))
 	fieldCount := uint32(0)
 	emtpyparsers := []string{}
 

--- a/pkg/querier/queryrange/detected_fields.go
+++ b/pkg/querier/queryrange/detected_fields.go
@@ -280,7 +280,8 @@ func determineType(value string) logproto.DetectedFieldType {
 }
 
 func parseDetectedFields(limit uint32, streams logqlmodel.Streams) map[string]*parsedFields {
-	detectedFields := make(map[string]*parsedFields, limit)
+	const maxDetectedFieldsPreAlloc = 1000
+	detectedFields := make(map[string]*parsedFields, min(maxDetectedFieldsPreAlloc, limit))
 	fieldCount := uint32(0)
 	emtpyparsers := []string{}
 

--- a/pkg/storage/detected/fields.go
+++ b/pkg/storage/detected/fields.go
@@ -55,7 +55,8 @@ func MergeFields(
 	fields []*logproto.DetectedField,
 	limit uint32,
 ) ([]*logproto.DetectedField, error) {
-	mergedFields := make(map[string]*UnmarshaledDetectedField, limit)
+	const maxMergedFieldsPreAlloc = 1000
+	mergedFields := make(map[string]*UnmarshaledDetectedField, min(maxMergedFieldsPreAlloc, limit))
 	foundFields := uint32(0)
 
 	for _, field := range fields {
@@ -86,7 +87,7 @@ func MergeFields(
 		}
 	}
 
-	result := make([]*logproto.DetectedField, 0, limit)
+	result := make([]*logproto.DetectedField, 0, len(mergedFields))
 	for _, field := range mergedFields {
 		detectedField := &logproto.DetectedField{
 			Label:       field.Label,
@@ -105,7 +106,8 @@ func MergeValues(
 	values []string,
 	limit uint32,
 ) ([]string, error) {
-	mergedValues := make(map[string]struct{}, limit)
+	const maxMergedValuesPreAlloc = 1000
+	mergedValues := make(map[string]struct{}, min(maxMergedValuesPreAlloc, limit))
 
 	for _, value := range values {
 		if value == "" {
@@ -119,7 +121,7 @@ func MergeValues(
 		mergedValues[value] = struct{}{}
 	}
 
-	result := make([]string, 0, limit)
+	result := make([]string, 0, len(mergedValues))
 	for value := range mergedValues {
 		result = append(result, value)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Limits the preallocations of various maps and slices. 

Thanks @Proximyst for finding and fixing.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
