### PR TITLE
fix: update Go version to 1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/loki/v3
 
-go 1.25.5
+go 1.25.7
 
 ignore ./tools/dev
 


### PR DESCRIPTION
Fixes CVE-2025-68121 (CRITICAL) and other Go stdlib vulnerabilities. Trivy found 3 CRITICAL in loki:3.0.0.