### PR TITLE
fix(test): Ensure timestamp test works in all timezones

### DIFF
--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -353,7 +353,7 @@ func Test_lineFormatter_Format(t *testing.T) {
 			"timestamp",
 			newMustLineFormatter("{{ __timestamp__ | date \"2006-01-02\" }} bar {{ .bar }}"),
 			labels.FromStrings("bar", "2"),
-			1656353124120000000,
+			1656331200000000000,
 			[]byte("2022-06-27 bar 2"),
 			labels.FromStrings("bar", "2"),
 			[]byte("1"),


### PR DESCRIPTION
**What this PR does / why we need it**:

The test for `__timestamp__` evaluates the specified unix timestamp in the running users timezone. For users running tests in some timezones, this causes the date to to vary from the value specified in the test fixture.

By selecting a timestamp at Noon, most timezones will experience this on the same date.

**Which issue(s) this PR fixes**:
Fixes #9081 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
