### PR TITLE
docs: Release Notes 3.5.11

### DIFF
--- a/docs/sources/release-notes/v3-5.md
+++ b/docs/sources/release-notes/v3-5.md
@@ -66,7 +66,11 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 ## Bug fixes
 
-### 3.5.10 (2026-12-11)
+### 3.5.11 (2026-02-23)
+
+* **alloc:** Set a limit on preallocations (backport release-3.5.x) ([#20919](https://github.com/grafana/loki/issues/20919)) ([1906dc2](https://github.com/grafana/loki/commit/1906dc2b29e1f1ffc37d9a6c9375d1590d7078a7)).
+
+### 3.5.10 (2026-02-11)
 
 * **deps:**  Update to go 1.25.7 ([#20694](https://github.com/grafana/loki/issues/20694)) ([#20752](https://github.com/grafana/loki/issues/20752)) ([dd71399](https://github.com/grafana/loki/commit/dd713991cb9f55d96a5ef5da33522297fc52ddbf)).
 * build UI deps ([#20762](https://github.com/grafana/loki/issues/20762)) ([6d1e9ea](https://github.com/grafana/loki/commit/6d1e9eab7720ef486973db1a20076e357c6c081f)).


### PR DESCRIPTION
**What this PR does / why we need it**:

Release Notes for 3.5.11 patch.  (Also fixed incorrect date on last set of RN)