### PR TITLE
fix(operator): properly handle the deprecation of replicationFactor

### DIFF
--- a/operator/internal/handlers/lokistack_create_or_update.go
+++ b/operator/internal/handlers/lokistack_create_or_update.go
@@ -118,16 +118,6 @@ func CreateOrUpdateLokiStack(
 
 	ll.Info("begin building manifests")
 
-	// nolint:staticcheck
-	// Handle the deprecated field opt.Stack.ReplicationFactor.
-	if (opts.Stack.Replication == nil || opts.Stack.Replication.Factor == 0) && opts.Stack.ReplicationFactor > 0 {
-		if opts.Stack.Replication == nil {
-			opts.Stack.Replication = &lokiv1.ReplicationSpec{}
-		}
-
-		opts.Stack.Replication.Factor = opts.Stack.ReplicationFactor
-	}
-
 	if optErr := manifests.ApplyDefaultSettings(&opts); optErr != nil {
 		ll.Error(optErr, "failed to conform options to build settings")
 		return nil, optErr

--- a/operator/internal/handlers/lokistack_create_or_update.go
+++ b/operator/internal/handlers/lokistack_create_or_update.go
@@ -118,6 +118,16 @@ func CreateOrUpdateLokiStack(
 
 	ll.Info("begin building manifests")
 
+	// nolint:staticcheck
+	// Handle the deprecated field opt.Stack.ReplicationFactor.
+	if (opts.Stack.Replication == nil || opts.Stack.Replication.Factor == 0) && opts.Stack.ReplicationFactor > 0 {
+		if opts.Stack.Replication == nil {
+			opts.Stack.Replication = &lokiv1.ReplicationSpec{}
+		}
+
+		opts.Stack.Replication.Factor = opts.Stack.ReplicationFactor
+	}
+
 	if optErr := manifests.ApplyDefaultSettings(&opts); optErr != nil {
 		ll.Error(optErr, "failed to conform options to build settings")
 		return nil, optErr

--- a/operator/internal/manifests/build.go
+++ b/operator/internal/manifests/build.go
@@ -121,6 +121,14 @@ func DefaultLokiStackSpec(size lokiv1.LokiStackSizeType) *lokiv1.LokiStackSpec {
 // ApplyDefaultSettings manipulates the options to conform to
 // build specifications
 func ApplyDefaultSettings(opts *Options) error {
+	// Handle the deprecated field opt.Stack.ReplicationFactor.
+	if (opts.Stack.Replication == nil || opts.Stack.Replication.Factor == 0) && opts.Stack.ReplicationFactor > 0 { // nolint:staticcheck
+		if opts.Stack.Replication == nil {
+			opts.Stack.Replication = &lokiv1.ReplicationSpec{}
+		}
+		opts.Stack.Replication.Factor = opts.Stack.ReplicationFactor // nolint:staticcheck
+	}
+
 	spec := DefaultLokiStackSpec(opts.Stack.Size)
 
 	if err := mergo.Merge(spec, opts.Stack, mergo.WithOverride); err != nil {

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -107,16 +107,6 @@ func ConfigOptions(opt Options) config.Options {
 		protocol = "https"
 	}
 
-	// nolint:staticcheck
-	// Handle the deprecated field opt.Stack.ReplicationFactor.
-	if (opt.Stack.Replication == nil || opt.Stack.Replication.Factor == 0) && opt.Stack.ReplicationFactor > 0 {
-		if opt.Stack.Replication == nil {
-			opt.Stack.Replication = &lokiv1.ReplicationSpec{}
-		}
-
-		opt.Stack.Replication.Factor = opt.Stack.ReplicationFactor
-	}
-
 	// Build a slice of with the shippers that are being used in the config
 	// booleans used to prevent duplicates
 	shippers := []string{}

--- a/operator/internal/manifests/config_test.go
+++ b/operator/internal/manifests/config_test.go
@@ -1299,6 +1299,8 @@ func TestConfigOptions_Replication(t *testing.T) {
 				Stack:    tc.spec,
 				Timeouts: testTimeoutConfig(),
 			}
+			err := ApplyDefaultSettings(&inOpt)
+			require.NoError(t, err)
 			options := ConfigOptions(inOpt)
 			require.Equal(t, tc.wantOptions, *options.Stack.Replication)
 		})

--- a/operator/internal/status/lokistack.go
+++ b/operator/internal/status/lokistack.go
@@ -204,9 +204,8 @@ func generateWarnings(stack *lokiv1.LokiStack) []metav1.Condition {
 	rf := manifests.DefaultLokiStackSpec(stack.Spec.Size).Replication.Factor
 	if stack.Spec.Replication != nil && stack.Spec.Replication.Factor > 0 {
 		rf = stack.Spec.Replication.Factor
-		// nolint:staticcheck
-	} else if stack.Spec.ReplicationFactor > 0 {
-		rf = stack.Spec.ReplicationFactor
+	} else if stack.Spec.ReplicationFactor > 0 { // nolint:staticcheck
+		rf = stack.Spec.ReplicationFactor // nolint:staticcheck
 	}
 	replicas := manifests.DefaultLokiStackSpec(stack.Spec.Size).Template.Ingester.Replicas
 	if stack.Spec.Template != nil && stack.Spec.Template.Ingester != nil && stack.Spec.Template.Ingester.Replicas > 0 {

--- a/operator/internal/status/lokistack.go
+++ b/operator/internal/status/lokistack.go
@@ -204,6 +204,9 @@ func generateWarnings(stack *lokiv1.LokiStack) []metav1.Condition {
 	rf := manifests.DefaultLokiStackSpec(stack.Spec.Size).Replication.Factor
 	if stack.Spec.Replication != nil && stack.Spec.Replication.Factor > 0 {
 		rf = stack.Spec.Replication.Factor
+		// nolint:staticcheck
+	} else if stack.Spec.ReplicationFactor > 0 {
+		rf = stack.Spec.ReplicationFactor
 	}
 	replicas := manifests.DefaultLokiStackSpec(stack.Spec.Size).Template.Ingester.Replicas
 	if stack.Spec.Template != nil && stack.Spec.Template.Ingester != nil && stack.Spec.Template.Ingester.Replicas > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
The deprecated field, `replicationFactor`, was handled in the wrong part of the code, which makes it ignored when set in the LokiStack CR and not applying to `replication.Factor`. This PR moves this handling to where it should be.


**Which issue(s) this PR fixes**:
Fixes [LOG-8795](https://issues.redhat.com/browse/LOG-8795)

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
