### PR TITLE
fix(logql): return error on way-too-long label string

### DIFF
--- a/pkg/logql/syntax/parser_test.go
+++ b/pkg/logql/syntax/parser_test.go
@@ -2,6 +2,7 @@ package syntax
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -3739,6 +3740,9 @@ func TestParseLabels(t *testing.T) {
 			require.Equal(t, tc.output, got)
 		})
 	}
+	input := strings.Repeat("a", 1<<24)
+	_, err := ParseLabels(input)
+	require.Error(t, err)
 }
 
 func TestNoOpLabelToString(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

The underlying library panics if given such a ridiculous input.

See: https://github.com/prometheus/prometheus/issues/17993

**Which issue(s) this PR fixes**:
Part of #20936 (not a complete fix)

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- NA If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. 