### PR TITLE
perf(logql): use simpler function to drop empty labels

### DIFF
--- a/pkg/logql/syntax/parser.go
+++ b/pkg/logql/syntax/parser.go
@@ -279,7 +279,6 @@ func ParseLabels(lbs string) (labels.Labels, error) {
 		return labels.EmptyLabels(), err
 	}
 
-	// Use the label builder to trim empty label values.
 	// Empty label values are equivalent to absent labels
 	// in Prometheus, but they unfortunately alter the
 	// Hash values created. This can cause problems in Loki
@@ -288,5 +287,5 @@ func ParseLabels(lbs string) (labels.Labels, error) {
 	// Therefore we must normalize early in the write path.
 	// See https://github.com/grafana/loki/pull/7355
 	// for more information
-	return labels.NewBuilder(ls).Labels(), nil
+	return ls.WithoutEmpty(), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The purpose-built function `WithoutEmpty` is easier to read and requires less explanation.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- NA Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- NA If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. 