### PR TITLE
fix(ksonnet): reduce terminationGracePeriodSeconds from 4800 to 300

### DIFF
--- a/production/ksonnet/loki-simple-scalable/backend.libsonnet
+++ b/production/ksonnet/loki-simple-scalable/backend.libsonnet
@@ -44,7 +44,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     k.util.antiAffinity +
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
     statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the group ID assigned to Loki in the Dockerfile
-    statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(4800) +
+    statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(300) +
     statefulSet.mixin.spec.withPodManagementPolicy('Parallel'),
 
   backend_service:

--- a/production/ksonnet/loki-simple-scalable/read.libsonnet
+++ b/production/ksonnet/loki-simple-scalable/read.libsonnet
@@ -33,7 +33,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     k.util.configVolumeMount('loki', '/etc/loki') +
     k.util.antiAffinity +
     deployment.mixin.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the group ID assigned to Loki in the Dockerfile
-    deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(4800),
+    deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(300),
 
   read_service:
     k.util.serviceFor($.read_deployment) +

--- a/production/ksonnet/loki-simple-scalable/write.libsonnet
+++ b/production/ksonnet/loki-simple-scalable/write.libsonnet
@@ -45,7 +45,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     k.util.antiAffinity +
     statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
     statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(10001) +  // 10001 is the group ID assigned to Loki in the Dockerfile
-    statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(4800) +
+    statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(300) +
     statefulSet.mixin.spec.withPodManagementPolicy('Parallel'),
 
   write_service:

--- a/production/ksonnet/loki/ingester.libsonnet
+++ b/production/ksonnet/loki/ingester.libsonnet
@@ -24,9 +24,9 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 
   newIngesterStatefulSet(name, container, with_anti_affinity=true)::
     $.newLokiStatefulSet(name, 3, container, [self.ingester_data_pvc, self.ingester_wal_pvc]) +
-    // When the ingester needs to flush blocks to the storage, it may take quite a lot of time.
-    // For this reason, we grant an high termination period (80 minutes).
-    statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(4800) +
+    // With WAL enabled (default), ingesters persist data to disk and replay on restart,
+    // so a long termination period is no longer needed. Aligned with the Helm chart default.
+    statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(300) +
     // $.lokiVolumeMounts +
     $.util.podPriority('high') +
     (if with_anti_affinity then $.util.antiAffinity else {}),


### PR DESCRIPTION
**What this PR does / why we need it**:

Reduces `terminationGracePeriodSeconds` from 4800 (80 minutes) to 300 (5 minutes) across all ksonnet/Tanka deployment templates, aligning them with the Helm chart default.

The 4800s value was set when ingesters needed long flush windows on shutdown. Since WAL is now enabled by default (PR #10542), ingesters persist data to WAL on PVC and replay on restart — the long grace period is no longer needed.

The stale 4800s value also causes a hazard with Karpenter: when `terminationGracePeriodSeconds` exceeds the NodePool's `terminationGracePeriod`, Karpenter's `DeleteExpiringPods` force-deletes pods immediately via `kubeClient.Delete()`, completely bypassing PodDisruptionBudgets.

**Which issue(s) this PR fixes**:
Fixes #20944

**Special notes for your reviewer**:

The Helm chart already uses 300s for all components. This change brings ksonnet in line.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`