### PR TITLE
chore(deps): Scope renovate prometheus updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -191,7 +191,13 @@
     },
     {
       // Track prometheus via pseudo-versions only (closest to main); do not switch to a tagged release and stick to that major.
+      // Scoped to main branch only and excludes operator files to avoid overriding their disabled update rules.
       matchPackageNames: ['github.com/prometheus/prometheus'],
+      matchBaseBranches: ['main'],
+      matchFileNames: [
+        '!operator/go.mod',
+        '!operator/api/loki/go.mod',
+      ],
       allowedVersions: '/^v[0-9]+\\.[0-9]+\\.[0-9]+-0\\.\\d{14}-[a-f0-9]+$/',
       enabled: true,
       digest: {


### PR DESCRIPTION
**What this PR does / why we need it**:
This scopes Prometheus updates to the `main` branch, and excludes the operator from being touched.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
