### PR TITLE
chore(test): Address deadlock in mempool test

### DIFF
--- a/pkg/util/mempool/pool_test.go
+++ b/pkg/util/mempool/pool_test.go
@@ -109,7 +109,7 @@ func TestMemPool(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				for i := 0; i < n; i++ {
-					s := 2 << rand.Intn(5)
+					s := (2 << rand.Intn(5)) << 10 // 2KB, 4KB, 8KB, 16KB, or 32KB
 					buf1, err1 := pool.Get(s)
 					buf2, err2 := pool.Get(s)
 					if err2 == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Deadlock seen in a mempool test, for example this [failing](https://github.com/grafana/loki/actions/runs/22365981248/job/64732008470?pr=20905) run.

```
 s := 2 << rand.Intn(5)  // produces 2, 4, 8, 16, or 32 (bytes)                                                                                                        
  buf1, err1 := pool.Get(s)
  buf2, err2 := pool.Get(s)  // holds buf1 while blocking here
```
  The pool's slabs have capacities 2<<10=2048, 4096, 8192, etc. Since s is at most 32 bytes — far below 2048 — all 256 goroutines compete for the first slab only.

  The first slab has exactly Size: numWorkers = 256 buffers. The deadlock sequence:

  1. All 256 goroutines get buf1 — the first slab is now empty
  2. All 256 goroutines then block on buf2 := pool.Get(s) (line 51 in pool.go: buf := <-s.buffer)
  3. No goroutine ever reaches pool.Put(buf1) — deadlock
  
  ---
  This changes s from {2, 4, 8, 16, 32} bytes to {2048, 4096, 8192, 16384, 32768} bytes, matching the actual slab capacities so requests spread across all 5 slabs.
  
-----

```
% go test -race -count 1000 -test.fullpath=true -timeout 120s -tags requires_docker -run ^TestMemPool$/^concurrent_access$ github.com/grafana/loki/v3/pkg/util/mempool
ok  	github.com/grafana/loki/v3/pkg/util/mempool	75.709s
```
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
