### PR TITLE
chore(engine): don't observe task execution time if there's no assign time

### DIFF
--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -285,9 +285,14 @@ func (s *Scheduler) handleTaskStatus(ctx context.Context, worker *workerConn, ms
 			owner.Unassign(task)
 		}
 
-		if task.status.State == workflow.TaskStateCompleted {
+		if task.status.State == workflow.TaskStateCompleted && !task.assignTime.IsZero() {
 			// The execution time of the task is the duration from when it was
 			// first assigned to when we received the completion status.
+			//
+			// We skip the observation when assignTime is zero, which can happen
+			// when a task completes before we can process the assignment. If we
+			// didn't skip these, we'd record an observation of the maximum
+			// time.Duration value (290 years).
 			s.metrics.taskExecSeconds.Observe(time.Since(task.assignTime).Seconds())
 		}
 


### PR DESCRIPTION
If a task completes faster than the scheduler is able to process the assignment, we end up recording an observation of the max time.Duration value, approximately 290 years.

This is purely a metrics bug. Processing assignments is handled asynchronously, and assignment time is the only state that is used outside of that call, and is only ever used for reporting metrics. 