### PR TITLE
chore(engine): more descriptive span names in thread.runJob

### DIFF
--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -209,7 +209,7 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	ctx, capture := xcap.NewCapture(ctx, nil)
 	defer capture.End()
 
-	ctx, span := xcap.StartSpan(ctx, tracer, "thread.runJob",
+	ctx, span := xcap.StartSpan(ctx, tracer, runJobSpanName(job.Task.Fragment),
 		trace.WithAttributes(attribute.Stringer("task_id", job.Task.ULID)),
 	)
 	defer span.End()
@@ -303,6 +303,14 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	if err != nil {
 		level.Warn(logger).Log("msg", "failed to inform scheduler of task status", "err", err)
 	}
+}
+
+func runJobSpanName(plan *physical.Plan) string {
+	root, err := plan.Root()
+	if err != nil { // No root or multiple roots.
+		return "thread.runJob"
+	}
+	return "thread.runJob " + root.Type().String()
 }
 
 func (t *thread) drainPipeline(ctx context.Context, pipeline executor.Pipeline, sinks []recordSink, batchSizeRecords int64, logger log.Logger) (int, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Since there can be thousands of them, add the root node type name, if there is one.

Motivating example: 
<img width="157" height="221" alt="image" src="https://github.com/user-attachments/assets/cac362b1-a28b-4328-8ba0-17bc8d4a0e85" />

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- NA Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- NA If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. 