### PR TITLE
perf(tsdb): return full slice to pool after use

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -2255,7 +2255,7 @@ func (dec *Decoder) readChunkStatsV3(d *encoding.Decbuf, from, through int64) (r
 	nMarkers := d.Uvarint()
 
 	relevantPages := chunkPageMarkersPool.Get(nMarkers)
-	defer chunkPageMarkersPool.Put(relevantPages)
+	defer func() { chunkPageMarkersPool.Put(relevantPages) }()
 	for i := 0; i < nMarkers; i++ {
 		var marker chunkPageMarker
 		marker.decode(d)
@@ -2351,7 +2351,7 @@ func (dec *Decoder) accumulateChunkStats(d *encoding.Decbuf, nChunks int, from, 
 func (dec *Decoder) readChunkStatsPriorV3(d *encoding.Decbuf, seriesRef storage.SeriesRef, from, through int64) (res ChunkStats, err error) {
 	// prior to v3, chunks needed iteration for stats aggregation
 	chks := ChunkMetasPool.Get()
-	defer ChunkMetasPool.Put(chks)
+	defer func() { ChunkMetasPool.Put(chks) }()
 	err = dec.readChunks(FormatV2, d, seriesRef, from, through, &chks)
 	if err != nil {
 		return ChunkStats{}, err

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index_client.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index_client.go
@@ -309,7 +309,7 @@ func (c *IndexClient) GetShards(ctx context.Context, userID string, from, throug
 	resp := &logproto.ShardsResponse{}
 
 	series := sharding.SizedFPs(sharding.SizedFPsPool.Get(len(m)))
-	defer sharding.SizedFPsPool.Put(series)
+	defer func() { sharding.SizedFPsPool.Put(series) }()
 
 	for fp, chks := range m {
 		x := sharding.SizedFP{Fp: fp}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
@@ -166,7 +166,7 @@ func (i *TSDBIndex) ForSeries(ctx context.Context, _ string, fpFilter index.Fing
 
 	var ls labels.Labels
 	chks := ChunkMetasPool.Get()
-	defer ChunkMetasPool.Put(chks)
+	defer func() { ChunkMetasPool.Put(chks) }()
 
 	var filterer chunk.Filterer
 	if i.chunkFilter != nil {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index_test.go
@@ -264,6 +264,7 @@ func BenchmarkTSDBIndex_GetChunkRefs(b *testing.B) {
 		chkRefs, err := tsdbIndex.GetChunkRefs(context.Background(), "fake", queryFrom, queryThrough, nil, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
 		require.NoError(b, err)
 		require.Len(b, chkRefs, numChunksToMatch*2)
+		ChunkRefsPool.Put(chkRefs)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a somewhat subtle bug, the effect of which is to make pools of slices ineffective.

As the slice is added to, it expands and its value changes. We need that final value to put back in the pool, not the value seen by `defer` at the beginning, so add a little function to achieve that.

There are many such cases, but in this PR I am only touching those in the `pkg/storage/stores/shipper/indexshipper/tsdb` directory.

I also fixed a benchmark where it was not returning memory to the pool.  These results are after fixing that:

Benchmarks:
```
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb
cpu: Intel(R) Core(TM) i7-14700K
                          │ before.txt  │              after.txt              │
                          │   sec/op    │    sec/op     vs base               │
TenantHeads/10-28           105.1µ ± 3%   107.5µ ±  3%        ~ (p=0.093 n=6)
TenantHeads/100-28          775.7µ ± 4%   756.3µ ±  4%   -2.51% (p=0.015 n=6)
TenantHeads/1000-28         7.897m ± 6%   7.851m ±  2%        ~ (p=0.937 n=6)
IndexClient_Stats-28        17.55µ ± 1%   17.71µ ±  2%   +0.90% (p=0.026 n=6)
TSDBIndex_GetChunkRefs-28   860.3µ ± 1%   693.8µ ± 12%  -19.35% (p=0.002 n=6)
TSDBIndex_Volume-28         280.0µ ± 1%   275.6µ ±  1%   -1.56% (p=0.002 n=6)
geomean                     373.7µ        359.6µ         -3.76%

                          │   before.txt    │              after.txt              │
                          │      B/op       │     B/op      vs base               │
TenantHeads/10-28              627.4Ki ± 0%   627.3Ki ± 0%        ~ (p=0.485 n=6)
TenantHeads/100-28             6.094Mi ± 0%   6.081Mi ± 0%   -0.22% (p=0.024 n=6)
TenantHeads/1000-28            63.20Mi ± 1%   63.49Mi ± 0%        ~ (p=0.093 n=6)
IndexClient_Stats-28           2.685Ki ± 2%   2.690Ki ± 2%        ~ (p=0.485 n=6)
TSDBIndex_GetChunkRefs-28   1374.742Ki ± 0%   5.133Ki ± 9%  -99.63% (p=0.002 n=6)
TSDBIndex_Volume-28            67.22Ki ± 0%   67.22Ki ± 0%        ~ (p=1.000 n=6)
geomean                        630.6Ki        248.6Ki       -60.58%

                          │ before.txt  │              after.txt               │
                          │  allocs/op  │  allocs/op   vs base                 │
TenantHeads/10-28           2.135k ± 0%   2.135k ± 0%        ~ (p=1.000 n=6) ¹
TenantHeads/100-28          21.34k ± 0%   21.33k ± 0%        ~ (p=0.061 n=6)
TenantHeads/1000-28         213.5k ± 0%   213.5k ± 0%        ~ (p=0.128 n=6)
IndexClient_Stats-28         55.00 ± 0%    55.00 ± 0%        ~ (p=1.000 n=6) ¹
TSDBIndex_GetChunkRefs-28    27.00 ± 0%    18.00 ± 0%  -33.33% (p=0.002 n=6)
TSDBIndex_Volume-28         3.060k ± 0%   3.060k ± 0%        ~ (p=1.000 n=6) ¹
geomean                     1.880k        1.757k        -6.54%
¹ all samples are equal
```


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- NA If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. 