### PR TITLE
perf(tsdb): don't fetch labels in TSDBIndex.GetChunkRefs

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_read.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_read.go
@@ -111,6 +111,7 @@ func (h *headIndexReader) Postings(name string, fpFilter index.FingerprintFilter
 }
 
 // Series returns the series for the given reference.
+// lbls can be nil, to indicate that just the chunks are needed.
 func (h *headIndexReader) Series(ref storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]index.ChunkMeta) (uint64, error) {
 	s := h.head.series.getByID(uint64(ref))
 
@@ -118,7 +119,9 @@ func (h *headIndexReader) Series(ref storage.SeriesRef, from int64, through int6
 		h.head.metrics.seriesNotFound.Inc()
 		return 0, storage.ErrNotFound
 	}
-	lbls.CopyFrom(s.ls)
+	if lbls != nil {
+		lbls.CopyFrom(s.ls)
+	}
 
 	queryBounds := newBounds(model.Time(from), model.Time(through))
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -2135,13 +2135,11 @@ func buildChunkSamples(d encoding.Decbuf, numChunks int, info *chunkSamples) err
 	return d.Err()
 }
 
-func (dec *Decoder) prepSeries(b []byte, lbls *labels.Labels, chks *[]ChunkMeta) (*encoding.Decbuf, uint64, error) {
+// prepSeries returns series labels for a series, only returning selected `by` label names.
+// If `by` is nil, it returns all labels for the series.
+func (dec *Decoder) prepSeries(b []byte, lbls *labels.Labels, by map[string]struct{}) (*encoding.Decbuf, uint64, error) {
 	builder := labelpool.Get()
 	defer labelpool.Put(builder)
-
-	if chks != nil {
-		*chks = (*chks)[:0]
-	}
 
 	d := encoding.DecWrap(tsdb_enc.Decbuf{B: b})
 
@@ -2160,54 +2158,11 @@ func (dec *Decoder) prepSeries(b []byte, lbls *labels.Labels, chks *[]ChunkMeta)
 		if err != nil {
 			return nil, 0, errors.Wrap(err, "lookup label name")
 		}
-		lv, err := dec.LookupSymbol(lvo)
-		if err != nil {
-			return nil, 0, errors.Wrap(err, "lookup label value")
-		}
 
-		builder.Add(ln, lv)
-	}
-
-	// Commit built labels.
-	builder.Sort()
-	*lbls = builder.Labels()
-
-	return &d, fprint, nil
-}
-
-// prepSeriesBy returns series labels and chunks for a series and only returning selected `by` label names.
-// If `by` is empty, it returns all labels for the series.
-func (dec *Decoder) prepSeriesBy(b []byte, lbls *labels.Labels, chks *[]ChunkMeta, by map[string]struct{}) (*encoding.Decbuf, uint64, error) {
-	if by == nil {
-		return dec.prepSeries(b, lbls, chks)
-	}
-
-	builder := labelpool.Get()
-	defer labelpool.Put(builder)
-
-	if chks != nil {
-		*chks = (*chks)[:0]
-	}
-
-	d := encoding.DecWrap(tsdb_enc.Decbuf{B: b})
-
-	fprint := d.Be64()
-	k := d.Uvarint()
-
-	for i := 0; i < k; i++ {
-		lno := uint32(d.Uvarint())
-		lvo := uint32(d.Uvarint())
-
-		if d.Err() != nil {
-			return nil, 0, errors.Wrap(d.Err(), "read series label offsets")
-		}
-		// todo(cyriltovena): we could cache this by user requests spanning multiple prepSeries calls.
-		ln, err := dec.LookupSymbol(lno)
-		if err != nil {
-			return nil, 0, errors.Wrap(err, "lookup label name")
-		}
-		if _, ok := by[ln]; !ok {
-			continue
+		if by != nil {
+			if _, ok := by[ln]; !ok {
+				continue
+			}
 		}
 
 		lv, err := dec.LookupSymbol(lvo)
@@ -2226,7 +2181,7 @@ func (dec *Decoder) prepSeriesBy(b []byte, lbls *labels.Labels, chks *[]ChunkMet
 }
 
 func (dec *Decoder) ChunkStats(version int, b []byte, seriesRef storage.SeriesRef, from, through int64, lbls *labels.Labels, by map[string]struct{}) (uint64, ChunkStats, error) {
-	d, fp, err := dec.prepSeriesBy(b, lbls, nil, by)
+	d, fp, err := dec.prepSeries(b, lbls, by)
 	if err != nil {
 		return 0, ChunkStats{}, err
 	}
@@ -2370,11 +2325,12 @@ func (dec *Decoder) readChunkStatsPriorV3(d *encoding.Decbuf, seriesRef storage.
 
 // Series decodes a series entry from the given byte slice into lset and chks.
 func (dec *Decoder) Series(version int, b []byte, seriesRef storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]ChunkMeta) (uint64, error) {
-	d, fprint, err := dec.prepSeries(b, lbls, chks)
+	d, fprint, err := dec.prepSeries(b, lbls, nil)
 	if err != nil {
 		return 0, err
 	}
 
+	*chks = (*chks)[:0]
 	// read chunks based on fmt
 	if err := dec.readChunks(version, d, seriesRef, from, through, chks); err != nil {
 		return 0, errors.Wrapf(err, "series %s", lbls.String())

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -2176,6 +2176,24 @@ func (dec *Decoder) prepSeries(b []byte, lbls *labels.Labels, by map[string]stru
 	// Commit built labels.
 	builder.Sort()
 	*lbls = builder.Labels()
+	return &d, fprint, nil
+}
+
+// skipSeriesLabels reads past the label section in buffer b, ready to read chunks after that.
+func (dec *Decoder) skipSeriesLabels(b []byte) (*encoding.Decbuf, uint64, error) {
+	d := encoding.DecWrap(tsdb_enc.Decbuf{B: b})
+
+	fprint := d.Be64()
+	k := d.Uvarint()
+
+	for range k {
+		_ = d.Uvarint()
+		_ = d.Uvarint()
+
+		if d.Err() != nil {
+			return nil, 0, errors.Wrap(d.Err(), "read series label offsets")
+		}
+	}
 
 	return &d, fprint, nil
 }
@@ -2323,9 +2341,15 @@ func (dec *Decoder) readChunkStatsPriorV3(d *encoding.Decbuf, seriesRef storage.
 	return res, nil
 }
 
-// Series decodes a series entry from the given byte slice into lset and chks.
-func (dec *Decoder) Series(version int, b []byte, seriesRef storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]ChunkMeta) (uint64, error) {
-	d, fprint, err := dec.prepSeries(b, lbls, nil)
+// Series decodes a series entry from the given byte slice into lbls and chks.
+// lbls can be nil, indicating the caller only wants the chunks.
+func (dec *Decoder) Series(version int, b []byte, seriesRef storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]ChunkMeta) (fprint uint64, err error) {
+	var d *encoding.Decbuf
+	if lbls == nil {
+		d, fprint, err = dec.skipSeriesLabels(b)
+	} else {
+		d, fprint, err = dec.prepSeries(b, lbls, nil)
+	}
 	if err != nil {
 		return 0, err
 	}
@@ -2333,6 +2357,9 @@ func (dec *Decoder) Series(version int, b []byte, seriesRef storage.SeriesRef, f
 	*chks = (*chks)[:0]
 	// read chunks based on fmt
 	if err := dec.readChunks(version, d, seriesRef, from, through, chks); err != nil {
+		if lbls == nil {
+			return 0, errors.Wrapf(err, "series footprint %x", fprint)
+		}
 		return 0, errors.Wrapf(err, "series %s", lbls.String())
 	}
 	return fprint, nil

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
@@ -162,16 +162,19 @@ func (i *TSDBIndex) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
 // Accepts a userID argument in order to implement `Index` interface, but since this is a single tenant index,
 // it is ignored (it's enforced elsewhere in index selection)
 func (i *TSDBIndex) ForSeries(ctx context.Context, _ string, fpFilter index.FingerprintFilter, from model.Time, through model.Time, fn func(labels.Labels, model.Fingerprint, []index.ChunkMeta) (stop bool), matchers ...*labels.Matcher) error {
+	var filterer chunk.Filterer
+	if i.chunkFilter != nil {
+		filterer = i.chunkFilter.ForRequest(ctx)
+	}
+	return i.forSeriesAndLabels(ctx, fpFilter, filterer, from, through, fn, matchers...)
+}
+
+func (i *TSDBIndex) forSeriesAndLabels(ctx context.Context, fpFilter index.FingerprintFilter, filterer chunk.Filterer, from model.Time, through model.Time, fn func(labels.Labels, model.Fingerprint, []index.ChunkMeta) (stop bool), matchers ...*labels.Matcher) error {
 	// TODO(owen-d): use pool
 
 	var ls labels.Labels
 	chks := ChunkMetasPool.Get()
 	defer ChunkMetasPool.Put(chks)
-
-	var filterer chunk.Filterer
-	if i.chunkFilter != nil {
-		filterer = i.chunkFilter.ForRequest(ctx)
-	}
 
 	return i.forPostings(ctx, fpFilter, from, through, matchers, func(p index.Postings) error {
 		for p.Next() {
@@ -198,6 +201,31 @@ func (i *TSDBIndex) ForSeries(ctx context.Context, _ string, fpFilter index.Fing
 
 }
 
+// Same as ForSeries, but the callback fn does not take a Labels parameter.
+func (i *TSDBIndex) forSeriesNoLabels(ctx context.Context, fpFilter index.FingerprintFilter, from model.Time, through model.Time, fn func(model.Fingerprint, []index.ChunkMeta) (stop bool), matchers ...*labels.Matcher) error {
+	chks := ChunkMetasPool.Get()
+	defer ChunkMetasPool.Put(chks)
+
+	return i.forPostings(ctx, fpFilter, from, through, matchers, func(p index.Postings) error {
+		for p.Next() {
+			hash, err := i.reader.Series(p.At(), int64(from), int64(through), nil, &chks)
+			if err != nil {
+				return err
+			}
+
+			// skip series that belong to different shards
+			if fpFilter != nil && !fpFilter.Match(model.Fingerprint(hash)) {
+				continue
+			}
+
+			if stop := fn(model.Fingerprint(hash), chks); stop {
+				break
+			}
+		}
+		return p.Err()
+	})
+}
+
 func (i *TSDBIndex) forPostings(
 	_ context.Context,
 	fpFilter index.FingerprintFilter,
@@ -218,7 +246,7 @@ func (i *TSDBIndex) GetChunkRefs(ctx context.Context, userID string, from, throu
 	}
 	res = res[:0]
 
-	if err := i.ForSeries(ctx, "", fpFilter, from, through, func(_ labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) (stop bool) {
+	addChunksToResult := func(fp model.Fingerprint, chks []index.ChunkMeta) (stop bool) {
 		for _, chk := range chks {
 			res = append(res, logproto.ChunkRefWithSizingInfo{
 				ChunkRef: logproto.ChunkRef{
@@ -233,11 +261,22 @@ func (i *TSDBIndex) GetChunkRefs(ctx context.Context, userID string, from, throu
 			})
 		}
 		return false
-	}, matchers...); err != nil {
-		return nil, err
 	}
 
-	return res, nil
+	var filterer chunk.Filterer
+	if i.chunkFilter != nil {
+		filterer = i.chunkFilter.ForRequest(ctx)
+	}
+	var err error
+	if filterer != nil {
+		// We need to fetch labels to pass to the filterer, even though we don't look at them in the callback.
+		err = i.forSeriesAndLabels(ctx, fpFilter, filterer, from, through, func(_ labels.Labels, fp model.Fingerprint, chks []index.ChunkMeta) (stop bool) {
+			return addChunksToResult(fp, chks)
+		}, matchers...)
+	} else {
+		err = i.forSeriesNoLabels(ctx, fpFilter, from, through, addChunksToResult, matchers...)
+	}
+	return res, err
 }
 
 func (i *TSDBIndex) Series(ctx context.Context, _ string, from, through model.Time, res []Series, fpFilter index.FingerprintFilter, matchers ...*labels.Matcher) ([]Series, error) {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index_test.go
@@ -264,6 +264,7 @@ func BenchmarkTSDBIndex_GetChunkRefs(b *testing.B) {
 		chkRefs, err := tsdbIndex.GetChunkRefs(context.Background(), "fake", queryFrom, queryThrough, nil, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
 		require.NoError(b, err)
 		require.Len(b, chkRefs, numChunksToMatch*2)
+		ChunkRefsPool.Put(chkRefs)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I noticed in a profile from production that index-gateways were spending a lot of time reading labels, in a context where labels are not typically needed.

<img width="1447" height="721" alt="image" src="https://github.com/user-attachments/assets/d6887c3b-61da-4da9-925d-82092337433f" />

This PR is made up of a refactoring to simplify the change, then adding the possibility to not fetch labels, and finally changing `GetChunkRefs` to only fetch labels when it needs to.  It may need labels for series filtering, which is used by some downstream projects.

The benchmark results are not impressive, because `BenchmarkTSDBIndex_GetChunkRefs` only creates three series.
Still, a 30% drop in objects allocated shows that something was achieved.

I fixed the benchmark to return memory to the pool, otherwise that dominates.

```
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb
cpu: Intel(R) Core(TM) i7-14700K
                          │ before.txt  │             after.txt             │
                          │   sec/op    │   sec/op     vs base              │
TenantHeads/10-28           105.1µ ± 3%   106.4µ ± 2%       ~ (p=0.093 n=6)
TenantHeads/100-28          775.7µ ± 4%   717.7µ ± 5%  -7.49% (p=0.002 n=6)
TenantHeads/1000-28         7.897m ± 6%   7.650m ± 3%       ~ (p=0.132 n=6)
IndexClient_Stats-28        17.55µ ± 1%   17.67µ ± 1%       ~ (p=0.093 n=6)
TSDBIndex_GetChunkRefs-28   860.3µ ± 1%   836.5µ ± 2%  -2.77% (p=0.009 n=6)
TSDBIndex_Volume-28         280.0µ ± 1%   280.2µ ± 1%       ~ (p=0.937 n=6)
geomean                     373.7µ        366.4µ       -1.95%

                          │  before.txt  │             after.txt              │
                          │     B/op     │     B/op      vs base              │
TenantHeads/10-28           627.4Ki ± 0%   627.1Ki ± 0%       ~ (p=0.093 n=6)
TenantHeads/100-28          6.094Mi ± 0%   6.077Mi ± 0%  -0.28% (p=0.002 n=6)
TenantHeads/1000-28         63.20Mi ± 1%   63.33Mi ± 0%       ~ (p=0.818 n=6)
IndexClient_Stats-28        2.685Ki ± 2%   2.700Ki ± 2%       ~ (p=0.485 n=6)
TSDBIndex_GetChunkRefs-28   1.343Mi ± 0%   1.342Mi ± 0%  -0.07% (p=0.002 n=6)
TSDBIndex_Volume-28         67.22Ki ± 0%   67.22Ki ± 0%       ~ (p=0.061 n=6)
geomean                     630.6Ki        631.0Ki       +0.07%

                          │ before.txt  │              after.txt               │
                          │  allocs/op  │  allocs/op   vs base                 │
TenantHeads/10-28           2.135k ± 0%   2.125k ± 0%   -0.47% (p=0.002 n=6)
TenantHeads/100-28          21.34k ± 0%   21.23k ± 0%   -0.49% (p=0.002 n=6)
TenantHeads/1000-28         213.5k ± 0%   212.5k ± 0%   -0.47% (p=0.002 n=6)
IndexClient_Stats-28         55.00 ± 0%    55.00 ± 0%        ~ (p=1.000 n=6) ¹
TSDBIndex_GetChunkRefs-28    27.00 ± 0%    19.00 ± 0%  -29.63% (p=0.002 n=6)
TSDBIndex_Volume-28         3.060k ± 0%   3.060k ± 0%        ~ (p=1.000 n=6) ¹
geomean                     1.880k        1.769k        -5.91%
¹ all samples are equal
```

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- NA Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- NA If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. 