### PR TITLE
ci: expose suite option, use exhaustive for cron

### DIFF
--- a/.github/workflows/logql-correctness.yml
+++ b/.github/workflows/logql-correctness.yml
@@ -22,6 +22,15 @@ on:
         required: false
         default: true
         type: "boolean"
+      suite:
+        description: "Test suite to run (each option includes its predecessors)"
+        required: false
+        default: "regression"
+        type: "choice"
+        options:
+          - fast
+          - regression
+          - exhaustive
 permissions: {}
 jobs:
   generate-testdata:
@@ -95,11 +104,16 @@ jobs:
       - name: Run tests
         shell: bash # Use bash shell to propagate pipe failures
         run: |
+          case "${{ inputs.suite || (github.event_name == 'schedule' && 'exhaustive') || 'regression' }}" in
+            exhaustive) SUITE="fast|regression|exhaustive" ;;
+            regression) SUITE="fast|regression" ;;
+            *)          SUITE="fast" ;;
+          esac
           go test \
             -o results/bench.test \
             -v -slow-tests -remote-transport=${{ matrix.remote_transport }} -timeout=60m \
             -cpuprofile=results/cpu.pprof -memprofile=results/mem.pprof \
-            -run='TestStorageEquality/(fast|regression)/.*/kind=.+/store=${{ matrix.store }}$' \
+            -run="TestStorageEquality/(${SUITE})/.*/kind=.+/store=${{ matrix.store }}$" \
             ${{ matrix.range_type == 'instant' && '-range-type=instant' || '' }} \
             ${{ inputs.failfast == true && '-failfast' || '' }} \
           | tee results/results.txt


### PR DESCRIPTION
**What this PR does / why we need it**:

* Exposes a suite option to manual dispatches of the LogQL Correctness job
* Makes the cron job use the exhaustive suite

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
