### PR TITLE
fix(helm): keep only one ingester HPA with rollout operator

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -6023,6 +6023,7 @@ null
     "enabled": false,
     "maxReplicas": 3,
     "minReplicas": 1,
+    "scaleOnlyZoneA": null,
     "targetCPUUtilizationPercentage": 60,
     "targetMemoryUtilizationPercentage": null
   },
@@ -6217,6 +6218,15 @@ false
 			<td>Minimum autoscaling replicas for the ingester</td>
 			<td><pre lang="json">
 1
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>ingester.autoscaling.scaleOnlyZoneA</td>
+			<td>string</td>
+			<td>When zone-aware replication is enabled, only scale zone-a with HPA. If null, this is enabled when rollout_operator.enabled is true.</td>
+			<td><pre lang="json">
+null
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/templates/ingester/_helpers-ingester.tpl
+++ b/production/helm/loki/templates/ingester/_helpers-ingester.tpl
@@ -80,6 +80,18 @@ expects a dict
 {{- end -}}
 
 {{/*
+Returns true if only zone-a should get an HPA when zone-aware replication is enabled.
+Defaults to rollout_operator.enabled when scaleOnlyZoneA is not explicitly set.
+*/}}
+{{- define "loki.ingester.autoscaling.scaleOnlyZoneA" -}}
+{{- if kindIs "bool" .Values.ingester.autoscaling.scaleOnlyZoneA -}}
+{{- .Values.ingester.autoscaling.scaleOnlyZoneA -}}
+{{- else -}}
+{{- .Values.rollout_operator.enabled -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return rollout-group prefix if it is set
 */}}
 {{- define "loki.prefixRolloutGroup" -}}

--- a/production/helm/loki/templates/ingester/hpa-zone-b.yaml
+++ b/production/helm/loki/templates/ingester/hpa-zone-b.yaml
@@ -1,5 +1,6 @@
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
-{{- if and $isDistributed .Values.ingester.autoscaling.enabled .Values.ingester.zoneAwareReplication.enabled }}
+{{- $scaleOnlyZoneA := eq (include "loki.ingester.autoscaling.scaleOnlyZoneA" .) "true" -}}
+{{- if and $isDistributed .Values.ingester.autoscaling.enabled .Values.ingester.zoneAwareReplication.enabled (not $scaleOnlyZoneA) }}
 {{- $apiVersion := include "loki.hpa.apiVersion" . -}}
 apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler

--- a/production/helm/loki/templates/ingester/hpa-zone-c.yaml
+++ b/production/helm/loki/templates/ingester/hpa-zone-c.yaml
@@ -1,5 +1,6 @@
 {{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
-{{- if and $isDistributed .Values.ingester.autoscaling.enabled .Values.ingester.zoneAwareReplication.enabled }}
+{{- $scaleOnlyZoneA := eq (include "loki.ingester.autoscaling.scaleOnlyZoneA" .) "true" -}}
+{{- if and $isDistributed .Values.ingester.autoscaling.enabled .Values.ingester.zoneAwareReplication.enabled (not $scaleOnlyZoneA) }}
 {{- $apiVersion := include "loki.hpa.apiVersion" . -}}
 apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -2001,6 +2001,8 @@ ingester:
   autoscaling:
     # -- Enable autoscaling for the ingester
     enabled: false
+    # -- When zone-aware replication is enabled, only scale zone-a with HPA. If null, this is enabled when rollout_operator.enabled is true.
+    scaleOnlyZoneA: null
     # -- Minimum autoscaling replicas for the ingester
     minReplicas: 1
     # -- Maximum autoscaling replicas for the ingester


### PR DESCRIPTION
**What this PR does / why we need it**:

With zone-aware ingesters and Grafana Rollout Operator enabled, ingester StatefulSets follow each other (zone-c -> zone-b -> zone-a).
Having one HPA per zone creates contention: scaling zone-b or zone-c can be reconciled back to zone-a, which may delay or stall effective scaling.

**What this PR changes**:
  - Adds a new value: ingester.autoscaling.scaleOnlyZoneA (true|false|null).
  - Adds helper logic to compute effective behavior:
      - if scaleOnlyZoneA is explicitly set, use it
      - if null, default to .Values.rollout_operator.enabled
  - Updates ingester HPA templates so zone-b and zone-c HPAs are rendered only when effective scaleOnlyZoneA=false.
  - Keeps zone-a HPA as the scaling source in zone-aware mode.
  - Updates Helm docs/reference.

**Behavior matrix**

  - rollout_operator.enabled=false, scaleOnlyZoneA=null -> HPAs for zone-a, zone-b, zone-c (existing behavior)
  - rollout_operator.enabled=true, scaleOnlyZoneA=null -> HPA only for zone-a
  - scaleOnlyZoneA=false -> always render HPAs for all zones
  - scaleOnlyZoneA=true -> always render only zone-a HPA

**Special notes for your reviewer**:

reference.md is generated and not handwritten.

Happy to put scaleOnlyZoneA default to false to not change any existing installation if required.

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
