### PR TITLE
perf(blooms): return full slice to pool after use

### DIFF
--- a/pkg/bloomgateway/bloomgateway.go
+++ b/pkg/bloomgateway/bloomgateway.go
@@ -285,7 +285,7 @@ func (g *Gateway) FilterChunkRefs(ctx context.Context, req *logproto.FilterChunk
 	// TODO(owen-d): include capacity in constructor?
 	task.responses = responsesPool.Get(len(series.series))
 	// free up the responses
-	defer responsesPool.Put(task.responses)
+	defer func() { responsesPool.Put(task.responses) }()
 
 	g.activeUsers.UpdateUserTimestamp(tenantID, time.Now())
 

--- a/pkg/bloomgateway/querier.go
+++ b/pkg/bloomgateway/querier.go
@@ -112,7 +112,7 @@ func (bq *BloomQuerier) FilterChunkRefs(ctx context.Context, tenant string, from
 	defer logger.Finish()
 
 	grouped := groupedChunksRefPool.Get(len(chunkRefs))
-	defer groupedChunksRefPool.Put(grouped)
+	defer func() { groupedChunksRefPool.Put(grouped) }()
 	grouped = groupChunkRefs(series, chunkRefs, grouped)
 
 	preFilterChunks := len(chunkRefs)

--- a/pkg/indexgateway/gateway.go
+++ b/pkg/indexgateway/gateway.go
@@ -626,7 +626,7 @@ func accumulateChunksToShards(
 	}
 
 	collectedSeries := sharding.SizedFPs(sharding.SizedFPsPool.Get(len(filteredM)))
-	defer sharding.SizedFPsPool.Put(collectedSeries)
+	defer func() { sharding.SizedFPsPool.Put(collectedSeries) }()
 
 	for fp, chks := range filteredM {
 		x := sharding.SizedFP{Fp: fp}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the same change as https://github.com/grafana/loki/pull/20969, covering the remaining parts of Loki.

I hand-checked every line matching `defer.*Put`, and also checked using https://github.com/egonelbre/exp/tree/main/check-deferslice.