### PR TITLE
chore(build): Tweaks to support golangci-lint 2.10.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,14 @@ linters:
       - legacy
       - std-error-handling
     rules:
+      - linters:
+          - revive
+        path: (.*)\.go$
+        text: "avoid meaningless package names"
+      - linters:
+          - revive
+        path: (.*)\.go$
+        text: "avoid package names that conflict with Go standard library"
       - path: pkg/scheduler/scheduler.go
         text: "SA1019: msg.GetHttpRequest is deprecated: Do not use"
       - linters:

--- a/pkg/logql/bench/testcase.go
+++ b/pkg/logql/bench/testcase.go
@@ -50,13 +50,13 @@ func (c TestCase) Kind() string {
 func (c TestCase) Description() string {
 	var b strings.Builder
 	if c.Source != "" {
-		b.WriteString(fmt.Sprintf("Source: %s\n", c.Source))
+		fmt.Fprintf(&b, "Source: %s\n", c.Source)
 	}
-	b.WriteString(fmt.Sprintf("Query: %s\n", c.Query))
-	b.WriteString(fmt.Sprintf("Time Range: %v to %v\n", c.Start.Format(time.RFC3339), c.End.Format(time.RFC3339)))
+	fmt.Fprintf(&b, "Query: %s\n", c.Query)
+	fmt.Fprintf(&b, "Time Range: %v to %v\n", c.Start.Format(time.RFC3339), c.End.Format(time.RFC3339))
 	if c.Step > 0 {
-		b.WriteString(fmt.Sprintf("Step: %v\n", c.Step))
+		fmt.Fprintf(&b, "Step: %v\n", c.Step)
 	}
-	b.WriteString(fmt.Sprintf("Direction: %v", c.Direction))
+	fmt.Fprintf(&b, "Direction: %v", c.Direction)
 	return b.String()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor updates needed for the upcoming golangci-lint update.

The `.golangci.yml` file was adjusted to allow package names that overlap with stdlib package names, such as `errors`.
The logql bench `testcase.go` file had a small linting optimization done.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
