### PR TITLE
perf(tsdb): Reduce memory allocations in chunk overlap checking 

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/bounds.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/bounds.go
@@ -1,8 +1,6 @@
 package tsdb
 
 import (
-	"math"
-
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 	"github.com/prometheus/common/model"
 )
@@ -10,22 +8,6 @@ import (
 // TODO(chaudum): Replace with new v1.Interval struct
 type Bounded interface {
 	Bounds() (model.Time, model.Time)
-}
-
-// InclusiveBounds will ensure the underlying Bounded implementation
-// is turned into [lower,upper] inclusivity.
-// Generally, we consider bounds to be `[lower,upper)` inclusive
-// This helper will account for integer overflow.
-// Because model.Time is millisecond-precise, but Loki uses nanosecond precision,
-// be careful usage can handle an extra millisecond being added.
-func inclusiveBounds(b Bounded) (model.Time, model.Time) {
-	lower, upper := b.Bounds()
-
-	if int64(upper) < math.MaxInt64 {
-		upper++
-	}
-
-	return lower, upper
 }
 
 type bounds struct {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/bounds.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/bounds.go
@@ -1,8 +1,9 @@
 package tsdb
 
 import (
-	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 )
 
 // TODO(chaudum): Replace with new v1.Interval struct

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/bounds.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/bounds.go
@@ -3,6 +3,7 @@ package tsdb
 import (
 	"math"
 
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 	"github.com/prometheus/common/model"
 )
 
@@ -35,11 +36,21 @@ func newBounds(mint, maxt model.Time) bounds { return bounds{mint: mint, maxt: m
 
 func (b bounds) Bounds() (model.Time, model.Time) { return b.mint, b.maxt }
 
-// Overlap checks whether the given chunk or index bounds
+// overlapIndex checks whether the given index bounds
 // overlap with the bounds of a query range.
 // chunk/index bounds are defined as [from, through]
 // query bounds are defined as [from, through)
-func Overlap(chk, qry Bounded) bool {
+func overlapIndex(index Index, qry Bounded) bool {
+	idxFrom, idxThrough := index.Bounds()
+	qryFrom, qryThrough := qry.Bounds()
+
+	return idxFrom < qryThrough && idxThrough >= qryFrom
+}
+
+// Same as overlapIndex but for ChunkMeta. The code is repeated for performance:
+// attempting to share the implementation via the Bounded interface results in a lot of
+// small memory allocations because ChunkMeta is passed by value and interfaces require a pointer.
+func overlapChunk(chk index.ChunkMeta, qry bounds) bool {
 	chkFrom, chkThrough := chk.Bounds()
 	qryFrom, qryThrough := qry.Bounds()
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/bounds_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/bounds_test.go
@@ -2,7 +2,6 @@ package tsdb
 
 import (
 	"fmt"
-	"math"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -51,30 +50,6 @@ func TestOverlap(t *testing.T) {
 	} {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			require.Equal(t, tc.overlap, overlapIndex(tc.a, tc.b))
-		})
-	}
-}
-
-func TestInclusiveBounds(t *testing.T) {
-	for i, tc := range []struct {
-		input        Bounded
-		lower, upper int64
-	}{
-		{
-			input: newBounds(0, 4),
-			lower: 0,
-			upper: 5, // increment upper by 1
-		},
-		{
-			input: newBounds(0, math.MaxInt64),
-			lower: 0,
-			upper: math.MaxInt64, // do nothing since we're already at the maximum value.
-		},
-	} {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			a, b := inclusiveBounds(tc.input)
-			require.Equal(t, model.Time(tc.lower), a)
-			require.Equal(t, model.Time(tc.upper), b)
 		})
 	}
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/bounds_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/bounds_test.go
@@ -9,36 +9,48 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type fakeIndex struct {
+	bounds
+	Index
+}
+
+func (b fakeIndex) Bounds() (model.Time, model.Time) { return b.mint, b.maxt }
+
+func newFakeIndex(mint, maxt model.Time) Index {
+	return fakeIndex{bounds: bounds{mint: mint, maxt: maxt}}
+}
+
 func TestOverlap(t *testing.T) {
 	for i, tc := range []struct {
-		a, b    Bounded
+		a       Index
+		b       bounds
 		overlap bool
 	}{
 		{
-			a:       newBounds(1, 5),
+			a:       newFakeIndex(1, 5),
 			b:       newBounds(2, 6),
 			overlap: true,
 		},
 		{
-			a:       newBounds(1, 5),
+			a:       newFakeIndex(1, 5),
 			b:       newBounds(6, 7),
 			overlap: false,
 		},
 		{
 			// ensure [start,end) inclusivity works as expected
-			a:       newBounds(1, 5),
+			a:       newFakeIndex(1, 5),
 			b:       newBounds(5, 6),
 			overlap: true,
 		},
 		{
 			// ensure [start,end) inclusivity works as expected
-			a:       newBounds(5, 6),
+			a:       newFakeIndex(5, 6),
 			b:       newBounds(1, 5),
 			overlap: false,
 		},
 	} {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			require.Equal(t, tc.overlap, Overlap(tc.a, tc.b))
+			require.Equal(t, tc.overlap, overlapIndex(tc.a, tc.b))
 		})
 	}
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
@@ -794,6 +794,8 @@ func BenchmarkTenantHeads(b *testing.B) {
 					{},
 				})
 			}
+			matcher := labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")
+			b.ResetTimer()
 
 			for n := 0; n < b.N; n++ {
 				var wg sync.WaitGroup
@@ -811,7 +813,7 @@ func BenchmarkTenantHeads(b *testing.B) {
 							0, math.MaxInt64,
 							res,
 							nil,
-							labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"),
+							matcher,
 						)
 					}(r)
 				}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_read.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_read.go
@@ -128,7 +128,7 @@ func (h *headIndexReader) Series(ref storage.SeriesRef, from int64, through int6
 	*chks = (*chks)[:0]
 	s.Lock()
 	for _, chk := range s.chks {
-		if !Overlap(chk, queryBounds) {
+		if !overlapChunk(chk, queryBounds) {
 			continue
 		}
 		*chks = append(*chks, chk)
@@ -167,7 +167,7 @@ func (h *headIndexReader) ChunkStats(ref storage.SeriesRef, from, through int64,
 	var res index.ChunkStats
 	s.Lock()
 	for _, chk := range s.chks {
-		if !Overlap(chk, queryBounds) {
+		if !overlapChunk(chk, queryBounds) {
 			continue
 		}
 		res.AddChunk(&chk, from, through)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index.go
@@ -116,7 +116,7 @@ func (i *MultiIndex) forMatchingIndices(ctx context.Context, from, through model
 	queryBounds := newBounds(from, through)
 
 	return i.iter.For(ctx, i.maxParallel, func(ctx context.Context, idx Index) error {
-		if Overlap(idx, queryBounds) {
+		if overlapIndex(idx, queryBounds) {
 
 			if i.filterer != nil {
 				// TODO(owen-d): Find a nicer way

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index_test.go
@@ -237,7 +237,7 @@ func BenchmarkTSDBIndex_GetChunkRefs(b *testing.B) {
 			Entries:  1,
 		}
 		chunkMetas = append(chunkMetas, chunkMeta)
-		if Overlap(chunkMeta, queryBounds) {
+		if overlapChunk(chunkMeta, queryBounds) {
 			numChunksToMatch++
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Split `Overlap` into two functions taking concrete types, to avoid a lot of small memory allocations because both `bounds` and `ChunkMeta` are passed by value and interfaces require a pointer.

Move the creation of matchers out of the benchmark loop so we are properly measuring it.

Also chore(tsdb): remove unused function `inclusiveBounds`, not used outside of a test.

Benchmark results:

```
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb
cpu: Intel(R) Core(TM) i7-14700K
                          │    before    │               after                │
                          │    sec/op    │   sec/op     vs base               │
TenantHeads/10-28           104.45µ ± 2%   92.21µ ± 2%  -11.72% (p=0.002 n=6)
TenantHeads/100-28           729.2µ ± 5%   582.1µ ± 5%  -20.18% (p=0.002 n=6)
TenantHeads/1000-28          7.582m ± 5%   6.996m ± 2%   -7.73% (p=0.002 n=6)
IndexClient_Stats-28         17.60µ ± 2%   17.70µ ± 1%        ~ (p=0.485 n=6)
TSDBIndex_GetChunkRefs-28    897.0µ ± 6%   868.8µ ± 2%        ~ (p=0.065 n=6)
TSDBIndex_Volume-28          281.9µ ± 0%   280.5µ ± 1%        ~ (p=0.065 n=6)
geomean                      370.1µ        342.7µ        -7.41%

                          │    before    │                after                │
                          │     B/op     │     B/op      vs base               │
TenantHeads/10-28           626.5Ki ± 0%   578.8Ki ± 0%   -7.62% (p=0.002 n=6)
TenantHeads/100-28          6.076Mi ± 0%   5.599Mi ± 0%   -7.87% (p=0.002 n=6)
TenantHeads/1000-28         63.26Mi ± 0%   56.36Mi ± 0%  -10.90% (p=0.002 n=6)
IndexClient_Stats-28        2.659Ki ± 3%   2.671Ki ± 3%        ~ (p=0.974 n=6)
TSDBIndex_GetChunkRefs-28   1.342Mi ± 0%   1.342Mi ± 0%        ~ (p=0.937 n=6)
TSDBIndex_Volume-28         67.22Ki ± 0%   67.22Ki ± 0%        ~ (p=0.470 n=6)
geomean                     629.2Ki        601.3Ki        -4.44%

                          │    before    │                after                 │
                          │  allocs/op   │  allocs/op   vs base                 │
TenantHeads/10-28            2113.0 ± 0%    113.0 ± 0%  -94.65% (p=0.002 n=6)
TenantHeads/100-28          21.122k ± 0%   1.115k ± 0%  -94.72% (p=0.002 n=6)
TenantHeads/1000-28         211.40k ± 0%   11.33k ± 0%  -94.64% (p=0.002 n=6)
IndexClient_Stats-28          55.00 ± 0%    55.00 ± 0%        ~ (p=1.000 n=6) ¹
TSDBIndex_GetChunkRefs-28     19.00 ± 0%    19.00 ± 0%        ~ (p=1.000 n=6) ¹
TSDBIndex_Volume-28          3.060k ± 0%   3.060k ± 0%        ~ (p=1.000 n=6) ¹
geomean                      1.764k         407.3       -76.92%
¹ all samples are equal
```

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- NA If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance refactor: overlap logic is split into concrete-type helpers and call sites updated, which could subtly affect boundary/inclusivity behavior if incorrect, but tests cover key cases.
> 
> **Overview**
> **Reduces allocations in TSDB time-range overlap checks.** The generic `Overlap` helper is replaced with two concrete functions: `overlapIndex` for `Index` bounds and `overlapChunk` for `index.ChunkMeta`, avoiding interface/pointer conversions on hot paths.
> 
> Call sites in `head_read.go`, `multi_file_index.go`, and benchmarks/tests are updated to use the new helpers, the unused `inclusiveBounds` helper (and its test) is removed, and the `BenchmarkTenantHeads` matcher creation is moved out of the inner loop to measure read performance more accurately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f63603cd350c03afeb1716be56a8ec05476ed1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->