### PR TITLE
fix: Change consumer to also retry on 429s

### DIFF
--- a/pkg/ingester/kafka_consumer.go
+++ b/pkg/ingester/kafka_consumer.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"math"
+	"net/http"
 	"sync"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/backoff"
+	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -50,6 +52,12 @@ func newConsumerMetrics(reg prometheus.Registerer) *consumerMetrics {
 	}
 }
 
+var defaultRetryBackoff = backoff.Config{
+	MinBackoff: 100 * time.Millisecond,
+	MaxBackoff: 5 * time.Second,
+	MaxRetries: 0, // Retry infinitely
+}
+
 func NewKafkaConsumerFactory(pusher logproto.PusherServer, reg prometheus.Registerer, maxConsumerWorkers int) partition.ConsumerFactory {
 	metrics := newConsumerMetrics(reg)
 	metrics.consumeWorkersCount.Set(float64(maxConsumerWorkers))
@@ -66,6 +74,7 @@ func NewKafkaConsumerFactory(pusher logproto.PusherServer, reg prometheus.Regist
 			metrics:            metrics,
 			committer:          committer,
 			maxConsumerWorkers: maxConsumerWorkers,
+			retryBackoff:       defaultRetryBackoff,
 		}, nil
 	}
 }
@@ -77,6 +86,7 @@ type kafkaConsumer struct {
 	committer          partition.Committer
 	maxConsumerWorkers int
 	metrics            *consumerMetrics
+	retryBackoff       backoff.Config
 }
 
 func (kc *kafkaConsumer) Start(ctx context.Context, recordsCh <-chan []partition.Record) func() {
@@ -154,7 +164,7 @@ func (kc *kafkaConsumer) consume(ctx context.Context, records []partition.Record
 
 				level.Debug(kc.logger).Log("msg", "pushing record", "offset", recordWithIndex.record.Offset, "length", len(recordWithIndex.record.Content))
 
-				if err := retryWithBackoff(ctx, func(attempts int) error {
+				if err := retryWithBackoff(ctx, kc.retryBackoff, func(attempts int) error {
 					pushTime := time.Now()
 					_, err := kc.pusher.Push(recordCtx, req)
 
@@ -201,10 +211,19 @@ func (kc *kafkaConsumer) consume(ctx context.Context, records []partition.Record
 }
 
 func canRetry(err error) bool {
-	return errors.Is(err, ErrReadOnly)
+	if errors.Is(err, ErrReadOnly) {
+		return true
+	}
+
+	// Retry rate-limited requests (e.g., stream limit exceeded).
+	// The classic distributor path handles these via replication across
+	// multiple ingesters, but the dataobj partition-ingester has no
+	// such fallback, so we retry with backoff instead.
+	resp, ok := httpgrpc.HTTPResponseFromError(err)
+	return ok && resp.Code == http.StatusTooManyRequests
 }
 
-func retryWithBackoff(ctx context.Context, fn func(attempts int) error) error {
+func retryWithBackoff(ctx context.Context, cfg backoff.Config, fn func(attempts int) error) error {
 	err := fn(0)
 	if err == nil {
 		return nil
@@ -212,11 +231,7 @@ func retryWithBackoff(ctx context.Context, fn func(attempts int) error) error {
 	if !canRetry(err) {
 		return err
 	}
-	backoff := backoff.New(ctx, backoff.Config{
-		MinBackoff: 100 * time.Millisecond,
-		MaxBackoff: 5 * time.Second,
-		MaxRetries: 0, // Retry infinitely
-	})
+	backoff := backoff.New(ctx, cfg)
 	backoff.Wait()
 	for backoff.Ongoing() {
 		err = fn(backoff.NumRetries())

--- a/pkg/ingester/kafka_consumer_test.go
+++ b/pkg/ingester/kafka_consumer_test.go
@@ -2,11 +2,16 @@ package ingester
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"testing"
 	"time"
 
+	"go.uber.org/atomic"
+
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/backoff"
+	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/tenant"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
@@ -131,5 +136,78 @@ func TestConsumer(t *testing.T) {
 		{
 			Streams: []logproto.Stream{streamFoo},
 		},
+	}, pusher.pushes)
+}
+
+type failThenSucceedPusher struct {
+	failCount    int
+	pushAttempts atomic.Int32
+	pushes       []*logproto.PushRequest
+	t            *testing.T
+}
+
+func (f *failThenSucceedPusher) Push(ctx context.Context, in *logproto.PushRequest) (*logproto.PushResponse, error) {
+	attempt := int(f.pushAttempts.Add(1))
+	if attempt <= f.failCount {
+		return nil, httpgrpc.Errorf(http.StatusTooManyRequests, "maximum active stream limit exceeded")
+	}
+
+	_, err := tenant.TenantID(ctx)
+	require.NoError(f.t, err)
+
+	req := &logproto.PushRequest{}
+	for _, s := range in.Streams {
+		newStream := push.Stream{
+			Labels:  s.Labels,
+			Entries: make([]push.Entry, len(s.Entries)),
+		}
+		copy(newStream.Entries, s.Entries)
+		req.Streams = append(req.Streams, newStream)
+	}
+	f.pushes = append(f.pushes, req)
+	return nil, nil
+}
+
+func TestConsumer_Retries429(t *testing.T) {
+	pusher := &failThenSucceedPusher{
+		failCount: 3,
+		t:         t,
+	}
+
+	consumer, err := NewKafkaConsumerFactory(pusher, prometheus.NewRegistry(), 1)(&noopCommitter{}, log.NewLogfmtLogger(os.Stdout))
+	require.NoError(t, err)
+
+	consumer.(*kafkaConsumer).retryBackoff = backoff.Config{
+		MinBackoff: time.Millisecond,
+		MaxBackoff: 5 * time.Millisecond,
+		MaxRetries: 0,
+	}
+
+	records, err := kafka.Encode(0, tenantID, streamBar, 10000)
+	require.NoError(t, err)
+
+	var toPush []partition.Record
+	for i, record := range records {
+		toPush = append(toPush, partition.Record{
+			Ctx:      context.Background(),
+			TenantID: tenantID,
+			Content:  record.Value,
+			Offset:   int64(i + 1),
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	recordChan := make(chan []partition.Record)
+	wait := consumer.Start(ctx, recordChan)
+
+	recordChan <- toPush
+	close(recordChan)
+	wait()
+
+	require.Equal(t, int32(4), pusher.pushAttempts.Load(), "expected 3 failed attempts + 1 successful attempt")
+	require.Len(t, pusher.pushes, 1, "expected exactly one successful push")
+	require.Equal(t, []*logproto.PushRequest{
+		{Streams: []logproto.Stream{streamBar}},
 	}, pusher.pushes)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We're correctly retrying pushes from the consumer when an ingester is shutting down but not when a 429 happens. On this PR I'm fixing the behavior by adding the retry in those cases.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
