### PR TITLE
feat(operator)!: switch default for OpenShift stream labels

### DIFF
--- a/operator/api/loki/v1/lokistack_types.go
+++ b/operator/api/loki/v1/lokistack_types.go
@@ -333,12 +333,13 @@ type OpenshiftTenantSpec struct {
 
 // OpenshiftOTLPConfig defines configuration specific to users using OTLP together with an OpenShift tenancy mode.
 type OpenshiftOTLPConfig struct {
-	// DisableRecommendedAttributes can be used to reduce the number of attributes used as stream labels.
+	// EnableConsoleLabels can be used to add a set of additional stream labels to the OTLP input. These labels are
+	// currently used by the logs console in OpenShift.
 	//
-	// Enabling this setting removes the "recommended attributes" from the stream labels. This requires an update
-	// to queries that relied on these attributes as stream labels, as they will no longer be indexed as such.
+	// This is not different from manually adding some or all of the attributes to the set of stream labels using the
+	// normal OTLP configuration.
 	//
-	// The recommended attributes are:
+	// The additional attributes which are converted to stream labels are:
 	//
 	//  - k8s.container.name
 	//  - k8s.cronjob.name
@@ -353,15 +354,12 @@ type OpenshiftOTLPConfig struct {
 	//  - kubernetes.pod_name
 	//  - service.name
 	//
-	// This option is supposed to be combined with a custom attribute configuration listing the stream labels that
-	// should continue to exist.
-	//
 	// See also: https://github.com/rhobs/observability-data-model/blob/main/cluster-logging.md#attributes
 	//
 	// +optional
 	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Disable recommended OTLP attributes"
-	DisableRecommendedAttributes bool `json:"disableRecommendedAttributes,omitempty"`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Console labels"
+	EnableConsoleLabels bool `json:"enableConsoleLabels,omitempty"`
 }
 
 // LokiComponentSpec defines the requirements to configure scheduling

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -152,7 +152,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.9.0
-    createdAt: "2026-02-25T18:26:49Z"
+    createdAt: "2026-02-27T13:31:21Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     features.operators.openshift.io/disconnected: "true"
@@ -1103,12 +1103,13 @@ spec:
         displayName: OpenTelemetry Protocol
         path: tenants.openshift.otlp
       - description: |-
-          DisableRecommendedAttributes can be used to reduce the number of attributes used as stream labels.
+          EnableConsoleLabels can be used to add a set of additional stream labels to the OTLP input. These labels are
+          currently used by the logs console in OpenShift.
 
-          Enabling this setting removes the "recommended attributes" from the stream labels. This requires an update
-          to queries that relied on these attributes as stream labels, as they will no longer be indexed as such.
+          This is not different from manually adding some or all of the attributes to the set of stream labels using the
+          normal OTLP configuration.
 
-          The recommended attributes are:
+          The additional attributes which are converted to stream labels are:
 
            - k8s.container.name
            - k8s.cronjob.name
@@ -1123,12 +1124,9 @@ spec:
            - kubernetes.pod_name
            - service.name
 
-          This option is supposed to be combined with a custom attribute configuration listing the stream labels that
-          should continue to exist.
-
           See also: https://github.com/rhobs/observability-data-model/blob/main/cluster-logging.md#attributes
-        displayName: Disable recommended OTLP attributes
-        path: tenants.openshift.otlp.disableRecommendedAttributes
+        displayName: Enable Console labels
+        path: tenants.openshift.otlp.enableConsoleLabels
       statusDescriptors:
       - description: Distributor is a map to the per pod status of the distributor
           deployment

--- a/operator/bundle/community-openshift/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/community-openshift/manifests/loki.grafana.com_lokistacks.yaml
@@ -3976,14 +3976,15 @@ spec:
                         description: OTLP contains settings for ingesting data using
                           OTLP in the OpenShift tenancy mode.
                         properties:
-                          disableRecommendedAttributes:
+                          enableConsoleLabels:
                             description: |-
-                              DisableRecommendedAttributes can be used to reduce the number of attributes used as stream labels.
+                              EnableConsoleLabels can be used to add a set of additional stream labels to the OTLP input. These labels are
+                              currently used by the logs console in OpenShift.
 
-                              Enabling this setting removes the "recommended attributes" from the stream labels. This requires an update
-                              to queries that relied on these attributes as stream labels, as they will no longer be indexed as such.
+                              This is not different from manually adding some or all of the attributes to the set of stream labels using the
+                              normal OTLP configuration.
 
-                              The recommended attributes are:
+                              The additional attributes which are converted to stream labels are:
 
                                - k8s.container.name
                                - k8s.cronjob.name
@@ -3997,9 +3998,6 @@ spec:
                                - kubernetes.host
                                - kubernetes.pod_name
                                - service.name
-
-                              This option is supposed to be combined with a custom attribute configuration listing the stream labels that
-                              should continue to exist.
 
                               See also: https://github.com/rhobs/observability-data-model/blob/main/cluster-logging.md#attributes
                             type: boolean

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -152,7 +152,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.9.0
-    createdAt: "2026-02-25T18:26:47Z"
+    createdAt: "2026-02-27T13:31:16Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown
@@ -1096,12 +1096,13 @@ spec:
         displayName: OpenTelemetry Protocol
         path: tenants.openshift.otlp
       - description: |-
-          DisableRecommendedAttributes can be used to reduce the number of attributes used as stream labels.
+          EnableConsoleLabels can be used to add a set of additional stream labels to the OTLP input. These labels are
+          currently used by the logs console in OpenShift.
 
-          Enabling this setting removes the "recommended attributes" from the stream labels. This requires an update
-          to queries that relied on these attributes as stream labels, as they will no longer be indexed as such.
+          This is not different from manually adding some or all of the attributes to the set of stream labels using the
+          normal OTLP configuration.
 
-          The recommended attributes are:
+          The additional attributes which are converted to stream labels are:
 
            - k8s.container.name
            - k8s.cronjob.name
@@ -1116,12 +1117,9 @@ spec:
            - kubernetes.pod_name
            - service.name
 
-          This option is supposed to be combined with a custom attribute configuration listing the stream labels that
-          should continue to exist.
-
           See also: https://github.com/rhobs/observability-data-model/blob/main/cluster-logging.md#attributes
-        displayName: Disable recommended OTLP attributes
-        path: tenants.openshift.otlp.disableRecommendedAttributes
+        displayName: Enable Console labels
+        path: tenants.openshift.otlp.enableConsoleLabels
       statusDescriptors:
       - description: Distributor is a map to the per pod status of the distributor
           deployment

--- a/operator/bundle/community/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/community/manifests/loki.grafana.com_lokistacks.yaml
@@ -3977,14 +3977,15 @@ spec:
                         description: OTLP contains settings for ingesting data using
                           OTLP in the OpenShift tenancy mode.
                         properties:
-                          disableRecommendedAttributes:
+                          enableConsoleLabels:
                             description: |-
-                              DisableRecommendedAttributes can be used to reduce the number of attributes used as stream labels.
+                              EnableConsoleLabels can be used to add a set of additional stream labels to the OTLP input. These labels are
+                              currently used by the logs console in OpenShift.
 
-                              Enabling this setting removes the "recommended attributes" from the stream labels. This requires an update
-                              to queries that relied on these attributes as stream labels, as they will no longer be indexed as such.
+                              This is not different from manually adding some or all of the attributes to the set of stream labels using the
+                              normal OTLP configuration.
 
-                              The recommended attributes are:
+                              The additional attributes which are converted to stream labels are:
 
                                - k8s.container.name
                                - k8s.cronjob.name
@@ -3998,9 +3999,6 @@ spec:
                                - kubernetes.host
                                - kubernetes.pod_name
                                - service.name
-
-                              This option is supposed to be combined with a custom attribute configuration listing the stream labels that
-                              should continue to exist.
 
                               See also: https://github.com/rhobs/observability-data-model/blob/main/cluster-logging.md#attributes
                             type: boolean

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -152,7 +152,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:0.1.0
-    createdAt: "2026-02-25T18:26:52Z"
+    createdAt: "2026-02-27T13:31:26Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements
@@ -1116,12 +1116,13 @@ spec:
         displayName: OpenTelemetry Protocol
         path: tenants.openshift.otlp
       - description: |-
-          DisableRecommendedAttributes can be used to reduce the number of attributes used as stream labels.
+          EnableConsoleLabels can be used to add a set of additional stream labels to the OTLP input. These labels are
+          currently used by the logs console in OpenShift.
 
-          Enabling this setting removes the "recommended attributes" from the stream labels. This requires an update
-          to queries that relied on these attributes as stream labels, as they will no longer be indexed as such.
+          This is not different from manually adding some or all of the attributes to the set of stream labels using the
+          normal OTLP configuration.
 
-          The recommended attributes are:
+          The additional attributes which are converted to stream labels are:
 
            - k8s.container.name
            - k8s.cronjob.name
@@ -1136,12 +1137,9 @@ spec:
            - kubernetes.pod_name
            - service.name
 
-          This option is supposed to be combined with a custom attribute configuration listing the stream labels that
-          should continue to exist.
-
           See also: https://github.com/rhobs/observability-data-model/blob/main/cluster-logging.md#attributes
-        displayName: Disable recommended OTLP attributes
-        path: tenants.openshift.otlp.disableRecommendedAttributes
+        displayName: Enable Console labels
+        path: tenants.openshift.otlp.enableConsoleLabels
       statusDescriptors:
       - description: Distributor is a map to the per pod status of the distributor
           deployment

--- a/operator/bundle/openshift/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/openshift/manifests/loki.grafana.com_lokistacks.yaml
@@ -3976,14 +3976,15 @@ spec:
                         description: OTLP contains settings for ingesting data using
                           OTLP in the OpenShift tenancy mode.
                         properties:
-                          disableRecommendedAttributes:
+                          enableConsoleLabels:
                             description: |-
-                              DisableRecommendedAttributes can be used to reduce the number of attributes used as stream labels.
+                              EnableConsoleLabels can be used to add a set of additional stream labels to the OTLP input. These labels are
+                              currently used by the logs console in OpenShift.
 
-                              Enabling this setting removes the "recommended attributes" from the stream labels. This requires an update
-                              to queries that relied on these attributes as stream labels, as they will no longer be indexed as such.
+                              This is not different from manually adding some or all of the attributes to the set of stream labels using the
+                              normal OTLP configuration.
 
-                              The recommended attributes are:
+                              The additional attributes which are converted to stream labels are:
 
                                - k8s.container.name
                                - k8s.cronjob.name
@@ -3997,9 +3998,6 @@ spec:
                                - kubernetes.host
                                - kubernetes.pod_name
                                - service.name
-
-                              This option is supposed to be combined with a custom attribute configuration listing the stream labels that
-                              should continue to exist.
 
                               See also: https://github.com/rhobs/observability-data-model/blob/main/cluster-logging.md#attributes
                             type: boolean

--- a/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
+++ b/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
@@ -3958,14 +3958,15 @@ spec:
                         description: OTLP contains settings for ingesting data using
                           OTLP in the OpenShift tenancy mode.
                         properties:
-                          disableRecommendedAttributes:
+                          enableConsoleLabels:
                             description: |-
-                              DisableRecommendedAttributes can be used to reduce the number of attributes used as stream labels.
+                              EnableConsoleLabels can be used to add a set of additional stream labels to the OTLP input. These labels are
+                              currently used by the logs console in OpenShift.
 
-                              Enabling this setting removes the "recommended attributes" from the stream labels. This requires an update
-                              to queries that relied on these attributes as stream labels, as they will no longer be indexed as such.
+                              This is not different from manually adding some or all of the attributes to the set of stream labels using the
+                              normal OTLP configuration.
 
-                              The recommended attributes are:
+                              The additional attributes which are converted to stream labels are:
 
                                - k8s.container.name
                                - k8s.cronjob.name
@@ -3979,9 +3980,6 @@ spec:
                                - kubernetes.host
                                - kubernetes.pod_name
                                - service.name
-
-                              This option is supposed to be combined with a custom attribute configuration listing the stream labels that
-                              should continue to exist.
 
                               See also: https://github.com/rhobs/observability-data-model/blob/main/cluster-logging.md#attributes
                             type: boolean

--- a/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
@@ -1016,12 +1016,13 @@ spec:
         displayName: OpenTelemetry Protocol
         path: tenants.openshift.otlp
       - description: |-
-          DisableRecommendedAttributes can be used to reduce the number of attributes used as stream labels.
+          EnableConsoleLabels can be used to add a set of additional stream labels to the OTLP input. These labels are
+          currently used by the logs console in OpenShift.
 
-          Enabling this setting removes the "recommended attributes" from the stream labels. This requires an update
-          to queries that relied on these attributes as stream labels, as they will no longer be indexed as such.
+          This is not different from manually adding some or all of the attributes to the set of stream labels using the
+          normal OTLP configuration.
 
-          The recommended attributes are:
+          The additional attributes which are converted to stream labels are:
 
            - k8s.container.name
            - k8s.cronjob.name
@@ -1036,12 +1037,9 @@ spec:
            - kubernetes.pod_name
            - service.name
 
-          This option is supposed to be combined with a custom attribute configuration listing the stream labels that
-          should continue to exist.
-
           See also: https://github.com/rhobs/observability-data-model/blob/main/cluster-logging.md#attributes
-        displayName: Disable recommended OTLP attributes
-        path: tenants.openshift.otlp.disableRecommendedAttributes
+        displayName: Enable Console labels
+        path: tenants.openshift.otlp.enableConsoleLabels
       statusDescriptors:
       - description: Distributor is a map to the per pod status of the distributor
           deployment

--- a/operator/config/manifests/community/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/community/bases/loki-operator.clusterserviceversion.yaml
@@ -1009,12 +1009,13 @@ spec:
         displayName: OpenTelemetry Protocol
         path: tenants.openshift.otlp
       - description: |-
-          DisableRecommendedAttributes can be used to reduce the number of attributes used as stream labels.
+          EnableConsoleLabels can be used to add a set of additional stream labels to the OTLP input. These labels are
+          currently used by the logs console in OpenShift.
 
-          Enabling this setting removes the "recommended attributes" from the stream labels. This requires an update
-          to queries that relied on these attributes as stream labels, as they will no longer be indexed as such.
+          This is not different from manually adding some or all of the attributes to the set of stream labels using the
+          normal OTLP configuration.
 
-          The recommended attributes are:
+          The additional attributes which are converted to stream labels are:
 
            - k8s.container.name
            - k8s.cronjob.name
@@ -1029,12 +1030,9 @@ spec:
            - kubernetes.pod_name
            - service.name
 
-          This option is supposed to be combined with a custom attribute configuration listing the stream labels that
-          should continue to exist.
-
           See also: https://github.com/rhobs/observability-data-model/blob/main/cluster-logging.md#attributes
-        displayName: Disable recommended OTLP attributes
-        path: tenants.openshift.otlp.disableRecommendedAttributes
+        displayName: Enable Console labels
+        path: tenants.openshift.otlp.enableConsoleLabels
       statusDescriptors:
       - description: Distributor is a map to the per pod status of the distributor
           deployment

--- a/operator/config/manifests/openshift/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/openshift/bases/loki-operator.clusterserviceversion.yaml
@@ -1028,12 +1028,13 @@ spec:
         displayName: OpenTelemetry Protocol
         path: tenants.openshift.otlp
       - description: |-
-          DisableRecommendedAttributes can be used to reduce the number of attributes used as stream labels.
+          EnableConsoleLabels can be used to add a set of additional stream labels to the OTLP input. These labels are
+          currently used by the logs console in OpenShift.
 
-          Enabling this setting removes the "recommended attributes" from the stream labels. This requires an update
-          to queries that relied on these attributes as stream labels, as they will no longer be indexed as such.
+          This is not different from manually adding some or all of the attributes to the set of stream labels using the
+          normal OTLP configuration.
 
-          The recommended attributes are:
+          The additional attributes which are converted to stream labels are:
 
            - k8s.container.name
            - k8s.cronjob.name
@@ -1048,12 +1049,9 @@ spec:
            - kubernetes.pod_name
            - service.name
 
-          This option is supposed to be combined with a custom attribute configuration listing the stream labels that
-          should continue to exist.
-
           See also: https://github.com/rhobs/observability-data-model/blob/main/cluster-logging.md#attributes
-        displayName: Disable recommended OTLP attributes
-        path: tenants.openshift.otlp.disableRecommendedAttributes
+        displayName: Enable Console labels
+        path: tenants.openshift.otlp.enableConsoleLabels
       statusDescriptors:
       - description: Distributor is a map to the per pod status of the distributor
           deployment

--- a/operator/docs/operator/api.md
+++ b/operator/docs/operator/api.md
@@ -3240,17 +3240,18 @@ It needs to be in the same namespace as the LokiStack custom resource.</p>
 <tbody>
 <tr>
 <td>
-<code>disableRecommendedAttributes</code><br/>
+<code>enableConsoleLabels</code><br/>
 <em>
 bool
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>DisableRecommendedAttributes can be used to reduce the number of attributes used as stream labels.</p>
-<p>Enabling this setting removes the &ldquo;recommended attributes&rdquo; from the stream labels. This requires an update
-to queries that relied on these attributes as stream labels, as they will no longer be indexed as such.</p>
-<p>The recommended attributes are:</p>
+<p>EnableConsoleLabels can be used to add a set of additional stream labels to the OTLP input. These labels are
+currently used by the logs console in OpenShift.</p>
+<p>This is not different from manually adding some or all of the attributes to the set of stream labels using the
+normal OTLP configuration.</p>
+<p>The additional attributes which are converted to stream labels are:</p>
 <ul>
 <li>k8s.container.name</li>
 <li>k8s.cronjob.name</li>
@@ -3265,8 +3266,6 @@ to queries that relied on these attributes as stream labels, as they will no lon
 <li>kubernetes.pod_name</li>
 <li>service.name</li>
 </ul>
-<p>This option is supposed to be combined with a custom attribute configuration listing the stream labels that
-should continue to exist.</p>
 <p>See also: <a href="https://github.com/rhobs/observability-data-model/blob/main/cluster-logging.md#attributes">https://github.com/rhobs/observability-data-model/blob/main/cluster-logging.md#attributes</a></p>
 </td>
 </tr>

--- a/operator/docs/user-guides/open-telemetry.md
+++ b/operator/docs/user-guides/open-telemetry.md
@@ -135,15 +135,15 @@ Using a regular expression makes sense when there are many attributes with simil
 
 ### Customizing OpenShift Defaults
 
-The `openshift-logging` tenancy mode contains its own set of default attributes. Some of these attributes (called "required attributes") can not be removed by applying a custom configuration, because they are needed for other OpenShift components to function properly. Other attributes (called "recommended attributes") are provided but can be disabled in case they influence performance negatively. The complete set of attributes is documented in the [data model](rhobs-data-model) repository. The default configuration only lists the stream labels of the data model, because the mapping to structured metadata is Loki's default.
-
-Because the OpenShift attribute configuration is applied based on the tenancy mode, the simplest configuration is to just set the tenancy mode and not apply any custom attributes. This will provide instant compatibility with the other OpenShift tools.
+The `openshift-logging` tenancy mode contains its own set of default attributes. Some of these attributes (called "required attributes") can not be removed by applying a custom configuration, because they are needed for the authorization to function properly. Another set of attributes ("console labels") is used by the OpenShift Console and can be enabled when that UI is used. The complete set of attributes is documented in the [data model](rhobs-data-model) repository. The default configuration only lists the stream labels of the data model, because the mapping to structured metadata is Loki's default.
 
 In case additional stream labels are needed, the normal custom attribute configuration mentioned above can be used. Attributes defined in the custom configuration will be **merged** with the default configuration. The same approach can be used to drop attributes, as long as they are not part of the set of required attributes.
 
-#### Removing Recommended Attributes
+#### Stream Labels for OpenShift Console
 
-In case of issues with the default set of attributes, there is a way to slim down the default set of attributes applied to a LokiStack operating in `openshift-logging` tenancy mode:
+The log viewer in the OpenShift Console uses a set of pre-defined stream labels for its integrated filters. Earlier versions of the operator automatically added the whole set of stream labels to the OTLP configuration, but this was found out to have negative performance implications for customers with a lot of containers in few namespaces.
+
+It is possible to return to the previous behavior by setting the `enableConsoleLabels` configuration option in the LokiStack:
 
 ```yaml
 # [...]
@@ -152,10 +152,10 @@ spec:
     mode: openshift-logging
     openshift:
       otlp:
-        disableRecommendedAttributes: true # Set this to remove recommended attributes
+        enableConsoleLabels: true
 ```
 
-Setting `disableRecommendedAttributes: true` reduces the set of default stream labels to only the "required attributes". This means the following "recommended attributes" are **not** automatically used as stream labels:
+Setting `enableConsoleLabels: true` adds the whole set of attributes to the stream labels:
 
 - `k8s.container.name`
 - `k8s.cronjob.name`
@@ -170,7 +170,9 @@ Setting `disableRecommendedAttributes: true` reduces the set of default stream l
 - `kubernetes.pod_name`
 - `service.name`
 
-Since these attributes are no longer stream labels by default, queries that previously relied on them **as stream labels** will need to be updated, and their performance might be negatively affected. It is recommended to combine this setting with a [custom attribute mapping](#custom-attribute-mapping) to selectively reintroduce any of these attributes (or other) as stream labels if they are important for your querying strategy.
+Currently the OpenShift Log Console only supports filtering on these attributes by using stream labels. This means that unless the full set of labels is added to the configuration not all filters are working properly. This situation might change in the future when the console is extended to fall back to structured metadata when a certain stream label is not available.
+
+If you know that only a subset of the filters are used, it is recommended to only add those stream labels to the configuration instead of using the full set.
 
 ## References
 

--- a/operator/internal/manifests/config_otlp.go
+++ b/operator/internal/manifests/config_otlp.go
@@ -14,9 +14,9 @@ func defaultOTLPAttributeConfig(ts *lokiv1.TenantsSpec) config.OTLPAttributeConf
 		return config.OTLPAttributeConfig{}
 	}
 
-	disableRecommended := false
+	enableConsoleLabels := false
 	if ts.Openshift != nil && ts.Openshift.OTLP != nil {
-		disableRecommended = ts.Openshift.OTLP.DisableRecommendedAttributes
+		enableConsoleLabels = ts.Openshift.OTLP.EnableConsoleLabels
 	}
 
 	return config.OTLPAttributeConfig{
@@ -25,7 +25,7 @@ func defaultOTLPAttributeConfig(ts *lokiv1.TenantsSpec) config.OTLPAttributeConf
 			ResourceAttributes: []config.OTLPAttribute{
 				{
 					Action: config.OTLPAttributeActionStreamLabel,
-					Names:  otlp.DefaultOTLPAttributes(disableRecommended),
+					Names:  otlp.DefaultOTLPAttributes(enableConsoleLabels),
 				},
 			},
 		},

--- a/operator/internal/manifests/config_otlp_test.go
+++ b/operator/internal/manifests/config_otlp_test.go
@@ -324,13 +324,13 @@ func TestOtlpAttributeConfig(t *testing.T) {
 			},
 		},
 		{
-			desc: "openshift-logging defaults without recommended",
+			desc: "openshift-logging defaults with console labels",
 			spec: lokiv1.LokiStackSpec{
 				Tenants: &lokiv1.TenantsSpec{
 					Mode: lokiv1.OpenshiftLogging,
 					Openshift: &lokiv1.OpenshiftTenantSpec{
 						OTLP: &lokiv1.OpenshiftOTLPConfig{
-							DisableRecommendedAttributes: true,
+							EnableConsoleLabels: true,
 						},
 					},
 				},
@@ -341,7 +341,27 @@ func TestOtlpAttributeConfig(t *testing.T) {
 					ResourceAttributes: []config.OTLPAttribute{
 						{
 							Action: config.OTLPAttributeActionStreamLabel,
-							Names:  otlp.DefaultOTLPAttributes(true),
+							Names: []string{
+								"k8s.container.name",
+								"k8s.cronjob.name",
+								"k8s.daemonset.name",
+								"k8s.deployment.name",
+								"k8s.job.name",
+								"k8s.namespace.name",
+								"k8s.node.name",
+								"k8s.pod.name",
+								"k8s.statefulset.name",
+								"kubernetes.container_name",
+								"kubernetes.host",
+								"kubernetes.namespace_name",
+								"kubernetes.pod_name",
+								"log_source",
+								"log_type",
+								"openshift.cluster.uid",
+								"openshift.log.source",
+								"openshift.log.type",
+								"service.name",
+							},
 						},
 					},
 				},
@@ -385,11 +405,6 @@ func TestOtlpAttributeConfig(t *testing.T) {
 				},
 				Tenants: &lokiv1.TenantsSpec{
 					Mode: lokiv1.OpenshiftLogging,
-					Openshift: &lokiv1.OpenshiftTenantSpec{
-						OTLP: &lokiv1.OpenshiftOTLPConfig{
-							DisableRecommendedAttributes: true,
-						},
-					},
 				},
 			},
 			wantConfig: config.OTLPAttributeConfig{
@@ -473,11 +488,6 @@ func TestOtlpAttributeConfig(t *testing.T) {
 				},
 				Tenants: &lokiv1.TenantsSpec{
 					Mode: lokiv1.OpenshiftLogging,
-					Openshift: &lokiv1.OpenshiftTenantSpec{
-						OTLP: &lokiv1.OpenshiftOTLPConfig{
-							DisableRecommendedAttributes: true,
-						},
-					},
 				},
 			},
 			wantConfig: config.OTLPAttributeConfig{

--- a/operator/internal/manifests/openshift/otlp/otlp.go
+++ b/operator/internal/manifests/openshift/otlp/otlp.go
@@ -15,7 +15,7 @@ var (
 		"openshift.log.type",
 	}
 
-	recommendedAttributes = []string{
+	consoleLabels = []string{
 		"k8s.container.name",
 		"k8s.cronjob.name",
 		"k8s.daemonset.name",
@@ -32,13 +32,13 @@ var (
 )
 
 // DefaultOTLPAttributes provides the required/recommended set of OTLP attributes for OpenShift Logging.
-func DefaultOTLPAttributes(disableRecommended bool) []string {
+func DefaultOTLPAttributes(enableConsoleLabels bool) []string {
 	result := append([]string{}, requiredAttributes...)
-	if disableRecommended {
+	if !enableConsoleLabels {
 		return result
 	}
 
-	result = append(result, recommendedAttributes...)
+	result = append(result, consoleLabels...)
 	slices.Sort(result)
 
 	return result

--- a/operator/internal/validation/openshift/otlp.go
+++ b/operator/internal/validation/openshift/otlp.go
@@ -13,15 +13,15 @@ func ValidateOTLPInvalidDrop(spec *lokiv1.LokiStackSpec) field.ErrorList {
 		return nil
 	}
 
-	disableRecommendedAttributes := false
+	enableConsoleLabels := false
 	if spec.Tenants != nil &&
 		spec.Tenants.Openshift != nil &&
 		spec.Tenants.Openshift.OTLP != nil {
-		disableRecommendedAttributes = spec.Tenants.Openshift.OTLP.DisableRecommendedAttributes
+		enableConsoleLabels = spec.Tenants.Openshift.OTLP.EnableConsoleLabels
 	}
 
 	requiredAttributes := map[string]bool{}
-	for _, label := range otlp.DefaultOTLPAttributes(disableRecommendedAttributes) {
+	for _, label := range otlp.DefaultOTLPAttributes(enableConsoleLabels) {
 		requiredAttributes[label] = true
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes the stream labels configured by default for the OpenShift Logging tenancy mode to not include all the labels needed for the OpenShift Logging Console. The console labels can still be enabled by setting a configuration parameter on the LokiStack resource.
We found that having all these stream labels may lead to an excessive number of streams, especially if customers only have a few namespaces but a lot of containers (or a lot of container churn).

As of now the stream labels are required by the console, so some filters stop working when the labels are not available. This might be mitigated in future versions of the console though. Because the OTLP feature will become a GA feature for Red Hat customers soon it might be hard or impossible to change the defaults again soon.

**Which issue(s) this PR fixes**:

[LOG-8319](https://issues.redhat.com/browse/LOG-8319)

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
