### PR TITLE
fix(ruler): use correct tenant ID for query evaluation in single-tenant mode

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1645,6 +1645,7 @@ func (t *Loki) initRuler() (_ services.Service, err error) {
 	}
 
 	t.Cfg.Ruler.Ring.ListenPort = t.Cfg.Server.GRPCListenPort
+	t.Cfg.Ruler.AuthEnabled = t.Cfg.AuthEnabled
 
 	t.ruler, err = ruler.NewRuler(
 		t.Cfg.Ruler,

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"github.com/prometheus/prometheus/rules"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/template"
 
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
@@ -148,21 +149,44 @@ func MultiTenantRuleManager(cfg Config, evaluator Evaluator, overrides RulesLimi
 		logger log.Logger,
 		reg prometheus.Registerer,
 	) ruler.RulesManager {
+		// In single-tenant mode (auth_enabled: false), the query evaluation tenant
+		// must be "fake" to match chunks stored by ingesters, but the original
+		// directory-derived tenant (userID) is preserved for remote-write headers
+		// so downstream systems (e.g. Mimir) receive the expected X-Scope-OrgID.
+		queryUserID := userID
+		if !cfg.AuthEnabled {
+			level.Info(logger).Log("msg", "single-tenant mode: overriding query tenant ID", "original", userID, "query_tenant", "fake")
+			queryUserID = "fake"
+		}
+
 		registry.configureTenantStorage(userID)
+		if queryUserID != userID {
+			// Also configure WAL for the query tenant so the readiness check passes.
+			// Actual remote-write appends go through tenantOverrideAppendable using userID.
+			registry.configureTenantStorage(queryUserID)
+		}
 
 		logger = log.With(logger, "user", userID)
-		queryFn := queryFunc(evaluator, registry, userID, logger)
-		memStore := NewMemStore(userID, queryFn, newMemstoreMetrics(reg), 5*time.Minute, log.With(logger, "subcomponent", "MemStore"))
+		queryFn := queryFunc(evaluator, registry, queryUserID, logger)
+		memStore := NewMemStore(queryUserID, queryFn, newMemstoreMetrics(reg), 5*time.Minute, log.With(logger, "subcomponent", "MemStore"))
 
 		// GroupLoader builds a cache of the rules as they're loaded by the
 		// manager.This is used to back the memstore
 		groupLoader := NewCachingGroupLoader(GroupLoader{})
 
+		// When in single-tenant mode, the rules manager context uses "fake" for query
+		// evaluation, but remote-write appends need the original directory-derived tenant
+		// so that downstream systems (e.g. Mimir) receive the expected X-Scope-OrgID header.
+		var appendable storage.Appendable = registry
+		if !cfg.AuthEnabled && userID != queryUserID {
+			appendable = &tenantOverrideAppendable{inner: registry, tenantID: userID}
+		}
+
 		mgr := rules.NewManager(&rules.ManagerOptions{
-			Appendable:               registry,
+			Appendable:               appendable,
 			Queryable:                memStore,
 			QueryFunc:                queryFn,
-			Context:                  user.InjectOrgID(ctx, userID),
+			Context:                  user.InjectOrgID(ctx, queryUserID),
 			ExternalURL:              cfg.ExternalURL.URL,
 			NotifyFunc:               ruler.SendAlerts(notifier, cfg.ExternalURL.URL.String(), cfg.DatasourceUID),
 			Logger:                   util_log.SlogFromGoKit(logger),
@@ -385,4 +409,17 @@ func GetRuleDetailsFromContext(ctx context.Context) (string, string) {
 	ruleName, _ := ctx.Value(ruleNameKey).(string)
 	ruleType, _ := ctx.Value(ruleTypeKey).(string)
 	return ruleName, ruleType
+}
+
+// tenantOverrideAppendable wraps a storage.Appendable and overrides the tenant ID
+// in the context before delegating to the inner Appender. This is used in single-tenant
+// mode to ensure remote-write sends the original directory-derived tenant as X-Scope-OrgID
+// while the rules manager context uses "fake" for query evaluation.
+type tenantOverrideAppendable struct {
+	inner    storage.Appendable
+	tenantID string
+}
+
+func (t *tenantOverrideAppendable) Appender(ctx context.Context) storage.Appender {
+	return t.inner.Appender(user.InjectOrgID(ctx, t.tenantID))
 }

--- a/pkg/ruler/config.go
+++ b/pkg/ruler/config.go
@@ -25,6 +25,11 @@ type Config struct {
 	RemoteWrite RemoteWriteConfig `yaml:"remote_write,omitempty" doc:"description=Remote-write configuration to send rule samples to a Prometheus remote-write endpoint."`
 
 	Evaluation EvaluationConfig `yaml:"evaluation,omitempty" doc:"description=Configuration for rule evaluation."`
+
+	// AuthEnabled is propagated from the top-level Loki config. When false (single-tenant mode),
+	// the ruler overrides tenant IDs derived from rule directory names with "fake" to match
+	// the tenant ID used by ingesters and the store for chunk storage.
+	AuthEnabled bool `yaml:"-"`
 }
 
 func (c *Config) RegisterFlags(f *flag.FlagSet) {


### PR DESCRIPTION
## What this PR does

When `auth_enabled: false` (single-tenant mode), the ruler uses rule directory names as tenant IDs for query evaluation. However, ingesters and the chunk store use `"fake"` as the tenant (injected by the fakeauth middleware). This mismatch causes intermittent **"wrong chunk metadata"** errors when the ruler queries chunks from the store.

### Root Cause

In `MultiTenantRuleManager` (`pkg/ruler/compat.go`), the `userID` parameter comes from the rules directory name (e.g. `"anonymous"`). This is used for:
1. `user.InjectOrgID(ctx, userID)` — sets the query tenant in the rules manager context
2. `queryFunc(evaluator, registry, userID, logger)` — used for rule evaluation and the `isReady` check
3. `NewMemStore(userID, ...)` — tenant-scoped in-memory store

When the ruler evaluates a rule, the query hits ingesters (which return data regardless of tenant) and the store. The store's `Decode()` → `equalByKey()` in `pkg/storage/chunk/chunk.go` validates that the chunk key's `UserID` matches the query tenant. Since chunks are stored under `"fake"` but the query uses the directory name, this validation fails with `ErrWrongMetadata`.

The failures are **intermittent** because they only occur when recently-flushed chunks appear in the index for the query window (e.g. `[1m]`). Queries that only hit ingester memory succeed because ingesters do not enforce tenant isolation on reads.

### The Fix

This PR splits the tenant handling in `MultiTenantRuleManager`:
- **Query evaluation** (`queryFunc`, `MemStore`, rules manager `Context`) uses `"fake"` to match chunks stored by ingesters and the store
- **Remote-write appends** preserve the original directory-derived tenant via a `tenantOverrideAppendable` wrapper, so downstream systems (e.g. Mimir) receive the expected `X-Scope-OrgID` header
- **WAL storage** is configured for both tenants so the readiness check passes

A new `AuthEnabled` field is added to the ruler `Config` (tagged `yaml:"-"`) and propagated from `Loki.Cfg.AuthEnabled` in `initRuler()`. The override only activates when `AuthEnabled` is false, so **multi-tenant deployments are completely unaffected**.

### Files Changed

- `pkg/ruler/config.go` — Added `AuthEnabled bool` field to ruler Config
- `pkg/ruler/compat.go` — Split tenant for query vs remote-write paths; added `tenantOverrideAppendable` wrapper
- `pkg/loki/modules.go` — Propagate `AuthEnabled` from top-level config to ruler config

### Additional Context

- Tenant isolation in Loki is not uniformly enforced: ingesters return data regardless of the querying tenant's org_id. The tenant check only happens at chunk decode time in the store. The fakeauth HTTP/gRPC middleware is the primary isolation boundary.
- The `isReady` check in `queryFunc` uses the WAL registry, so the WAL must be configured for both the query tenant and the write tenant when they differ.
- This bug affects any single-tenant deployment where the rules directory name is not `"fake"`. There is no configuration option to control the directory-derived tenant — the only prior workaround was naming the directory `"fake"`, which is undocumented and unintuitive.
- Validated end-to-end in production: ruler evaluations succeed with `org_id=fake`, remote-write sends correct `X-Scope-OrgID` to downstream Mimir.