### PR TITLE
fix(querytee): Compare parsed labels instead of structured metadata

### DIFF
--- a/pkg/querytee/comparator/response_comparator.go
+++ b/pkg/querytee/comparator/response_comparator.go
@@ -459,7 +459,7 @@ func compareStreams(expectedRaw, actualRaw json.RawMessage, evaluationTime time.
 				return &ComparisonSummary{MismatchCause: CauseParsedLabelsCountMismatch}, fmt.Errorf("expected %d parsed label pairs for timestamp %v but got %d pairs for stream %s: %w", expectedSamplePair.Parsed.Len(),
 					expectedSamplePair.Timestamp.UnixNano(), actualSamplePair.Parsed.Len(), expectedStream.Labels, ErrComparisonMismatch)
 			}
-			if !labels.Equal(expectedSamplePair.StructuredMetadata, actualSamplePair.StructuredMetadata) {
+			if !labels.Equal(expectedSamplePair.Parsed, actualSamplePair.Parsed) {
 				return &ComparisonSummary{MismatchCause: CauseParsedLabelsMismatch}, fmt.Errorf("expected parsed labels %v for timestamp %v but got %v for stream %s: %w", expectedSamplePair.Parsed.String(),
 					expectedSamplePair.Timestamp.UnixNano(), actualSamplePair.Parsed.String(), expectedStream.Labels, ErrComparisonMismatch)
 			}

--- a/pkg/querytee/comparator/response_comparator_test.go
+++ b/pkg/querytee/comparator/response_comparator_test.go
@@ -632,6 +632,76 @@ func TestCompareStreams(t *testing.T) {
 	}
 }
 
+func TestCompareStreams_ParsedLabels(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		expected       json.RawMessage
+		actual         json.RawMessage
+		err            error
+		expectMismatch bool
+		mismatchCause  string
+	}{
+		{
+			name: "matching parsed labels",
+			expected: json.RawMessage(`[
+				{"stream":{"foo":"bar"},"values":[["1","line1",{"structuredMetadata":{"trace":"123"},"parsed":{"level":"info"}}]]}
+			]`),
+			actual: json.RawMessage(`[
+				{"stream":{"foo":"bar"},"values":[["1","line1",{"structuredMetadata":{"trace":"123"},"parsed":{"level":"info"}}]]}
+			]`),
+		},
+		{
+			name: "different parsed labels count",
+			expected: json.RawMessage(`[
+				{"stream":{"foo":"bar"},"values":[["1","line1",{"structuredMetadata":{"trace":"123"},"parsed":{"level":"info","msg":"hello"}}]]}
+			]`),
+			actual: json.RawMessage(`[
+				{"stream":{"foo":"bar"},"values":[["1","line1",{"structuredMetadata":{"trace":"123"},"parsed":{"level":"info"}}]]}
+			]`),
+			err:            errors.New("expected 2 parsed label pairs for timestamp 1 but got 1 pairs for stream"),
+			expectMismatch: true,
+			mismatchCause:  CauseParsedLabelsCountMismatch,
+		},
+		{
+			name: "different parsed labels values",
+			expected: json.RawMessage(`[
+				{"stream":{"foo":"bar"},"values":[["1","line1",{"structuredMetadata":{"trace":"123"},"parsed":{"level":"info"}}]]}
+			]`),
+			actual: json.RawMessage(`[
+				{"stream":{"foo":"bar"},"values":[["1","line1",{"structuredMetadata":{"trace":"123"},"parsed":{"level":"error"}}]]}
+			]`),
+			err:            errors.New("expected parsed labels"),
+			expectMismatch: true,
+			mismatchCause:  CauseParsedLabelsMismatch,
+		},
+		{
+			name: "same structured metadata but different parsed labels",
+			expected: json.RawMessage(`[
+				{"stream":{"foo":"bar"},"values":[["1","line1",{"structuredMetadata":{"trace":"123"},"parsed":{"level":"info"}}]]}
+			]`),
+			actual: json.RawMessage(`[
+				{"stream":{"foo":"bar"},"values":[["1","line1",{"structuredMetadata":{"trace":"123"},"parsed":{"level":"warn"}}]]}
+			]`),
+			err:            errors.New("expected parsed labels"),
+			expectMismatch: true,
+			mismatchCause:  CauseParsedLabelsMismatch,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			summary, err := compareStreams(tc.expected, tc.actual, time.Now(), SampleComparisonOptions{})
+			if tc.err == nil {
+				require.NoError(t, err)
+				return
+			}
+			assertError(t, err, tc.err, tc.expectMismatch)
+			if tc.mismatchCause != "" {
+				require.NotNil(t, summary)
+				require.Equal(t, tc.mismatchCause, summary.MismatchCause)
+			}
+		})
+	}
+}
+
 func TestCompareStreams_SamplesOutsideComparableWindow(t *testing.T) {
 	for _, tc := range []struct {
 		name              string


### PR DESCRIPTION
**What this PR does / why we need it**:
The parsed labels comparison in compareStreams is incorrectly comparing StructuredMetadata fields instead of Parsed fields, likely from a copy paste error.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
