### PR TITLE
feat: add configurable PVC support for bloom-builder

### DIFF
--- a/production/helm/loki/templates/bloom-builder/_helpers-bloom-builder.tpl
+++ b/production/helm/loki/templates/bloom-builder/_helpers-bloom-builder.tpl
@@ -30,3 +30,14 @@ bloom-builder priority class name
 priorityClassName: {{ $pcn }}
 {{- end }}
 {{- end }}
+
+{{/*
+bloom-builder pvc name
+*/}}
+{{- define "loki.bloomBuilderPVCName" -}}
+{{- if .Values.bloomBuilder.persistence.existingClaim -}}
+{{ .Values.bloomBuilder.persistence.existingClaim }}
+{{- else -}}
+{{ include "loki.bloomBuilderFullname" . }}
+{{- end -}}
+{{- end }}

--- a/production/helm/loki/templates/bloom-builder/deployment-bloom-builder.yaml
+++ b/production/helm/loki/templates/bloom-builder/deployment-bloom-builder.yaml
@@ -161,7 +161,12 @@ spec:
         - name: temp
           emptyDir: {}
         - name: data
-          emptyDir: {}
+          {{- if .Values.bloomBuilder.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "loki.bloomBuilderPVCName" . }}
+          {{- else }}
+          {{- toYaml .Values.bloomBuilder.persistence.dataVolumeParameters | nindent 10 }}
+          {{- end }}
         {{- with (concat .Values.global.extraVolumes .Values.bloomBuilder.extraVolumes) | uniq }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/production/helm/loki/templates/bloom-builder/pvc-bloom-builder.yaml
+++ b/production/helm/loki/templates/bloom-builder/pvc-bloom-builder.yaml
@@ -1,0 +1,33 @@
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .) "true" -}}
+{{- if and $isDistributed (gt (int .Values.bloomPlanner.replicas) 0) .Values.bloomBuilder.persistence.enabled (not .Values.bloomBuilder.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "loki.bloomBuilderPVCName" . }}
+  namespace: {{ include "loki.namespace" . }}
+  labels:
+    {{- include "loki.bloomBuilderLabels" . | nindent 4 }}
+    {{- with .Values.bloomBuilder.persistence.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.bloomBuilder.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.bloomBuilder.persistence.accessModes | nindent 4 }}
+  {{- with .Values.bloomBuilder.persistence.storageClass }}
+  storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
+  {{- end }}
+  {{- with .Values.bloomBuilder.persistence.volumeAttributesClassName }}
+  volumeAttributesClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.bloomBuilder.persistence.size | quote }}
+  {{- with .Values.bloomBuilder.persistence.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -3150,6 +3150,35 @@ bloomBuilder:
   extraVolumeMounts: []
   # -- Volumes to add to the bloom-builder pods
   extraVolumes: []
+  persistence:
+    # -- Enable persistent storage for the bloom-builder `data` volume.
+    enabled: false
+    # -- Name of an existing PersistentVolumeClaim to mount when persistence is enabled.
+    # If empty, the chart creates a PVC for the bloom-builder.
+    existingClaim: null
+    # -- Set access modes on the PersistentVolumeClaim.
+    accessModes:
+      - ReadWriteOnce
+    # -- Size of persistent disk.
+    size: 10Gi
+    # -- Storage class to be used.
+    # If defined, storageClassName: <storageClass>.
+    # If set to "-", storageClassName: "", which disables dynamic provisioning.
+    # If empty or set to null, no storageClassName spec is set, choosing the default provisioner.
+    storageClass: null
+    # -- Volume attributes class name to be used.
+    # If empty or set to null, no volumeAttributesClassName spec is set.
+    # Requires Kubernetes 1.31
+    volumeAttributesClassName: null
+    # -- Selector for persistent disk.
+    selector: null
+    # -- Annotations for the generated PVC.
+    annotations: {}
+    # -- Labels for the generated PVC.
+    labels: {}
+    # -- Parameters used for the `data` volume when persistence is disabled.
+    dataVolumeParameters:
+      emptyDir: {}
   # -- Resource requests and limits for the bloom-builder
   resources: {}
   # -- Init containers to add to the bloom-builder pods


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds configurable persistent storage support for the `bloom-builder` Helm deployment.

Today, the bloom-builder `data` volume is hardcoded to `emptyDir`, which stores data on the Kubernetes node filesystem. In production this can consume a large amount of node-local disk and makes storage placement difficult to control.

This change keeps the current behavior as the default, but adds a configurable `bloomBuilder.persistence` block that allows:
- continuing to use `emptyDir`
- creating a PVC from the chart
- attaching an existing PVC via `existingClaim`

This makes bloom-builder storage configurable and allows operators to move its data off node-local ephemeral storage and onto persistent volumes.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

- Backward compatibility is preserved because the default behavior remains `emptyDir`.
- The chart now creates a PVC for bloom-builder when `bloomBuilder.persistence.enabled=true` and `existingClaim` is not set.
- If `existingClaim` is set, the generated PVC is skipped and the deployment mounts the provided claim instead.
- bloom-builder is still a `Deployment`, so using one PVC with multiple replicas depends on the storage backend and access mode. For common `ReadWriteOnce` storage, this is expected to be used with a single replica.
- Validated with `helm template` in default mode, chart-managed PVC mode, and `existingClaim` mode, and with `helm lint` in both default and PVC-enabled configurations.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)