### PR TITLE
fix(query-scheduler): Only do alignment for metric queries

### DIFF
--- a/pkg/engine/handler.go
+++ b/pkg/engine/handler.go
@@ -57,10 +57,34 @@ func executorHandler(cfg Config, logger log.Logger, exec queryExecutor, limits L
 	}
 
 	if cfg.AlignQueriesWithStep {
-		h = queryrangebase.StepAlignMiddleware.Wrap(h)
+		h = newMetricStepAlignMiddleware().Wrap(h)
 	}
 
 	return queryrange.NewSerializeHTTPHandler(h, queryrange.DefaultCodec)
+}
+
+// newMetricStepAlignMiddleware returns a middleware that applies step alignment
+// only to metric queries (SampleExpr). Log queries are passed through without
+// modification, preserving sub-second timestamp precision.
+func newMetricStepAlignMiddleware() queryrangebase.Middleware {
+	return queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
+		aligned := queryrangebase.StepAlignMiddleware.Wrap(next)
+		return metricStepAlign{next: next, aligned: aligned}
+	})
+}
+
+type metricStepAlign struct {
+	next    queryrangebase.Handler
+	aligned queryrangebase.Handler
+}
+
+func (m metricStepAlign) Do(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
+	if req, ok := r.(*queryrange.LokiRequest); ok && req.Plan != nil {
+		if _, isSample := req.Plan.AST.(syntax.SampleExpr); isSample {
+			return m.aligned.Do(ctx, r)
+		}
+	}
+	return m.next.Do(ctx, r)
 }
 
 type queryHandler struct {

--- a/pkg/engine/handler_test.go
+++ b/pkg/engine/handler_test.go
@@ -63,6 +63,79 @@ func TestHandler(t *testing.T) {
 	require.NotNil(t, handler)
 }
 
+func TestMetricStepAlignMiddleware(t *testing.T) {
+	base := time.Date(2026, 3, 2, 6, 43, 7, 0, time.UTC)
+	startWithSubSecond := base.Add(123 * time.Millisecond)
+	endWithSubSecond := base.Add(456 * time.Millisecond)
+
+	step := int64(1000) // 1s step in milliseconds
+
+	tests := []struct {
+		name          string
+		query         string
+		startTs       time.Time
+		endTs         time.Time
+		step          int64
+		expectAligned bool
+	}{
+		{
+			name:          "log query preserves sub-second timestamps",
+			query:         `{app="test"}`,
+			startTs:       startWithSubSecond,
+			endTs:         endWithSubSecond,
+			step:          step,
+			expectAligned: false,
+		},
+		{
+			name:          "metric query gets step-aligned",
+			query:         `rate({app="test"}[5m])`,
+			startTs:       startWithSubSecond,
+			endTs:         endWithSubSecond,
+			step:          step,
+			expectAligned: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedStart, capturedEnd time.Time
+
+			inner := queryrangebase.HandlerFunc(func(_ context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
+				capturedStart = r.GetStart()
+				capturedEnd = r.GetEnd()
+				return &queryrange.LokiResponse{}, nil
+			})
+
+			middleware := newMetricStepAlignMiddleware()
+			handler := middleware.Wrap(inner)
+
+			expr, err := syntax.ParseExpr(tt.query)
+			require.NoError(t, err)
+
+			req := &queryrange.LokiRequest{
+				Query:   tt.query,
+				StartTs: tt.startTs,
+				EndTs:   tt.endTs,
+				Step:    tt.step,
+				Plan:    &plan.QueryPlan{AST: expr},
+			}
+
+			_, err = handler.Do(context.Background(), req)
+			require.NoError(t, err)
+
+			if tt.expectAligned {
+				alignedStart := time.UnixMilli((tt.startTs.UnixMilli() / tt.step) * tt.step)
+				alignedEnd := time.UnixMilli((tt.endTs.UnixMilli() / tt.step) * tt.step)
+				require.Equal(t, alignedStart, capturedStart, "metric query start should be step-aligned")
+				require.Equal(t, alignedEnd, capturedEnd, "metric query end should be step-aligned")
+			} else {
+				require.Equal(t, tt.startTs, capturedStart, "log query start should preserve original timestamp")
+				require.Equal(t, tt.endTs, capturedEnd, "log query end should preserve original timestamp")
+			}
+		})
+	}
+}
+
 func TestQueryHandler_Do_LokiRequest(t *testing.T) {
 	now := time.Now()
 	startTime := now.Add(-1 * time.Hour)


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow-up of https://github.com/grafana/loki/pull/20967. It always do the step alignment even for log queries, which is unwanted. This PR fixes it by checking the type of the given query and only do the alignment for metric queries.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
