### PR TITLE
feat(goldfish): Add config to skip recent queries

### DIFF
--- a/pkg/querytee/goldfish/config.go
+++ b/pkg/querytee/goldfish/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/grafana/loki/v3/pkg/storage/bucket"
 )
@@ -56,6 +57,12 @@ type Config struct {
 	//
 	// When set to 0 (default), only exact response hash matches are considered matches.
 	CompareValuesTolerance float64 `yaml:"compare_values_tolerance"`
+
+	// SkipRecentSamples excludes samples whose timestamp is within this
+	// duration of the query evaluation time. This avoids false-positive
+	// mismatches caused by ingestion lag or data replication timing between
+	// cells.
+	SkipRecentSamples time.Duration `yaml:"skip_recent_samples"`
 }
 
 // SamplingConfig defines how queries are sampled
@@ -143,6 +150,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 	// Compare response values with tolerance
 	f.Float64Var(&cfg.CompareValuesTolerance, "goldfish.compare-values-tolerance", 0.0, "Tolerance for comparing sample values in metric query responses. When set to 0, we expect an exact response hash match.")
+	f.DurationVar(&cfg.SkipRecentSamples, "goldfish.skip-recent-samples", 0, "Skip comparing samples whose timestamp is within this duration of the query evaluation time. Helps avoid false mismatches from ingestion lag between cells.")
 }
 
 // Validate validates the configuration

--- a/pkg/querytee/goldfish/manager.go
+++ b/pkg/querytee/goldfish/manager.go
@@ -105,8 +105,8 @@ func NewManager(config Config, storage goldfish.Storage, resultStore ResultStore
 	// Create comparator if values should be compared with tolerance
 	if config.CompareValuesTolerance > 0 {
 		m.responseComparator = comparator.NewSamplesComparator(comparator.SampleComparisonOptions{
-			Tolerance: config.CompareValuesTolerance,
-			// zero value for SkipRecentSamples, SkipSamplesBefore ensures all samples are compared.
+			Tolerance:         config.CompareValuesTolerance,
+			SkipRecentSamples: config.SkipRecentSamples,
 		})
 	}
 

--- a/pkg/querytee/goldfish/stats_extractor.go
+++ b/pkg/querytee/goldfish/stats_extractor.go
@@ -34,6 +34,12 @@ func (e *StatsExtractor) ExtractResponseData(responseBody []byte, duration int64
 	// Extract statistics from the response
 	queryStats := e.extractQueryStats(queryResp.Data.Statistics, duration)
 
+	// Override TotalEntriesReturned with the actual count from the parsed response data.
+	// The stats-based value (stats.Summary.TotalEntriesReturned) is an internal Loki execution
+	// metric that can differ between cells due to different splits, shards, or engine versions,
+	// even when the actual query results are identical.
+	queryStats.TotalEntriesReturned = countResponseEntries(queryResp)
+
 	// Generate response hash for integrity checking (without storing sensitive data)
 	responseHash := e.generateResponseHash(queryResp)
 
@@ -58,6 +64,32 @@ func (e *StatsExtractor) extractQueryStats(statsResult stats.Result, _ int64) go
 		TotalEntriesReturned: statsResult.Summary.TotalEntriesReturned,
 		Splits:               statsResult.Summary.Splits,
 		Shards:               statsResult.Summary.Shards,
+	}
+}
+
+// countResponseEntries counts the actual number of result entries from the parsed response data.
+// This is more reliable than stats.Summary.TotalEntriesReturned, which is an internal execution
+// metric that can vary between backends for the same result set.
+func countResponseEntries(resp loghttp.QueryResponse) int64 {
+	switch result := resp.Data.Result.(type) {
+	case loghttp.Streams:
+		var count int64
+		for _, stream := range result {
+			count += int64(len(stream.Entries))
+		}
+		return count
+	case loghttp.Vector:
+		return int64(len(result))
+	case loghttp.Matrix:
+		var count int64
+		for _, series := range result {
+			count += int64(len(series.Values)) + int64(len(series.Histograms))
+		}
+		return count
+	case loghttp.Scalar:
+		return 1
+	default:
+		return 0
 	}
 }
 

--- a/pkg/querytee/goldfish/stats_extractor_test.go
+++ b/pkg/querytee/goldfish/stats_extractor_test.go
@@ -209,6 +209,182 @@ func TestStatsExtractor_NewEngineWarningDetection(t *testing.T) {
 	}
 }
 
+func TestStatsExtractor_EntriesCountedFromResponseData(t *testing.T) {
+	extractor := NewStatsExtractor()
+
+	tests := []struct {
+		name            string
+		responseBody    string
+		expectedEntries int64
+	}{
+		{
+			name: "stream entries counted from result, not stats",
+			responseBody: `{
+				"status": "success",
+				"data": {
+					"resultType": "streams",
+					"result": [
+						{
+							"stream": {"job": "test"},
+							"values": [
+								["1700000000000000000", "line 1"],
+								["1700000000001000000", "line 2"],
+								["1700000000002000000", "line 3"]
+							]
+						}
+					],
+					"stats": {
+						"summary": {
+							"totalEntriesReturned": 999
+						}
+					}
+				}
+			}`,
+			expectedEntries: 3,
+		},
+		{
+			name: "multiple streams entries summed",
+			responseBody: `{
+				"status": "success",
+				"data": {
+					"resultType": "streams",
+					"result": [
+						{
+							"stream": {"job": "a"},
+							"values": [["1700000000000000000", "line 1"], ["1700000000001000000", "line 2"]]
+						},
+						{
+							"stream": {"job": "b"},
+							"values": [["1700000000000000000", "line 3"]]
+						}
+					],
+					"stats": {
+						"summary": {
+							"totalEntriesReturned": 50
+						}
+					}
+				}
+			}`,
+			expectedEntries: 3,
+		},
+		{
+			name: "empty streams returns zero",
+			responseBody: `{
+				"status": "success",
+				"data": {
+					"resultType": "streams",
+					"result": [],
+					"stats": {
+						"summary": {
+							"totalEntriesReturned": 10
+						}
+					}
+				}
+			}`,
+			expectedEntries: 0,
+		},
+		{
+			name: "same result data with different stats produces same entry count",
+			responseBody: `{
+				"status": "success",
+				"data": {
+					"resultType": "streams",
+					"result": [
+						{
+							"stream": {"job": "test"},
+							"values": [["1700000000000000000", "line 1"], ["1700000000001000000", "line 2"]]
+						}
+					],
+					"stats": {
+						"summary": {
+							"totalEntriesReturned": 200,
+							"splits": 5,
+							"shards": 10
+						}
+					}
+				}
+			}`,
+			expectedEntries: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats, _, _, _, _, err := extractor.ExtractResponseData([]byte(tt.responseBody), 50)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedEntries, stats.TotalEntriesReturned,
+				"TotalEntriesReturned should be counted from actual response entries, not stats")
+		})
+	}
+}
+
+func TestStatsExtractor_IdenticalResultsDifferentStats(t *testing.T) {
+	extractor := NewStatsExtractor()
+
+	// Two responses with identical result data but different stats (simulating v1 vs v2 cells)
+	cellAResponse := `{
+		"status": "success",
+		"data": {
+			"resultType": "streams",
+			"result": [
+				{
+					"stream": {"job": "test", "env": "prod"},
+					"values": [
+						["1700000000000000000", "request completed"],
+						["1700000000001000000", "request started"]
+					]
+				}
+			],
+			"stats": {
+				"summary": {
+					"execTime": 0.05,
+					"totalBytesProcessed": 1000,
+					"totalEntriesReturned": 2,
+					"splits": 1,
+					"shards": 4
+				}
+			}
+		}
+	}`
+
+	cellBResponse := `{
+		"status": "success",
+		"data": {
+			"resultType": "streams",
+			"result": [
+				{
+					"stream": {"job": "test", "env": "prod"},
+					"values": [
+						["1700000000000000000", "request completed"],
+						["1700000000001000000", "request started"]
+					]
+				}
+			],
+			"stats": {
+				"summary": {
+					"execTime": 0.08,
+					"totalBytesProcessed": 2000,
+					"totalEntriesReturned": 150,
+					"splits": 3,
+					"shards": 8
+				}
+			}
+		}
+	}`
+
+	statsA, hashA, _, _, _, err := extractor.ExtractResponseData([]byte(cellAResponse), 50)
+	require.NoError(t, err)
+
+	statsB, hashB, _, _, _, err := extractor.ExtractResponseData([]byte(cellBResponse), 80)
+	require.NoError(t, err)
+
+	assert.Equal(t, hashA, hashB, "identical result data should produce the same hash")
+	assert.Equal(t, statsA.TotalEntriesReturned, statsB.TotalEntriesReturned,
+		"identical result data should produce the same entry count regardless of stats differences")
+	assert.Equal(t, int64(2), statsA.TotalEntriesReturned,
+		"entry count should reflect the 2 actual entries in the response")
+}
+
 func TestStatsExtractor_CheckForNewEngineWarning(t *testing.T) {
 	extractor := NewStatsExtractor()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a config to skip comparing recent queries and fixes the stats counting.
If we don't skip recent queries, lagging can cause recent queries to incorrectly result in a mismatch.
I'm also recalculating the stats of a given query because I noticed when we get the query from caching, the returned results might differ. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
