### PR TITLE
fix: duplicate lines with different structured metadata (#21039)

### DIFF
--- a/pkg/chunkenc/symbols.go
+++ b/pkg/chunkenc/symbols.go
@@ -27,6 +27,18 @@ type symbol struct {
 
 type symbols []symbol
 
+func (s symbols) Equal(other symbols) bool {
+	if len(s) != len(other) {
+		return false
+	}
+	for i := range s {
+		if s[i] != other[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // symbolizer holds a collection of label names and values and assign symbols to them.
 // symbols are actually index numbers assigned based on when the entry is seen for the first time.
 type symbolizer struct {

--- a/pkg/chunkenc/unordered.go
+++ b/pkg/chunkenc/unordered.go
@@ -132,18 +132,19 @@ func (hb *unorderedHeadBlock) Append(ts int64, line string, structuredMetadata l
 	}
 	displaced := hb.rt.Add(e)
 	if displaced[0] != nil {
+		symbols, err := hb.symbolizer.Add(structuredMetadata)
+		if err != nil {
+			return false, err
+		}
+
 		// While we support multiple entries at the same timestamp, we _do_ de-duplicate
 		// entries at the same time with the same content, iterate through any existing
 		// entries and ignore the line if we already have an entry with the same content
 		for _, et := range displaced[0].(*nsEntries).entries {
-			if et.line == line {
+			if et.line == line && et.structuredMetadataSymbols.Equal(symbols) {
 				e.entries = displaced[0].(*nsEntries).entries
 				return true, nil
 			}
-		}
-		symbols, err := hb.symbolizer.Add(structuredMetadata)
-		if err != nil {
-			return false, err
 		}
 
 		e.entries = append(displaced[0].(*nsEntries).entries, nsEntry{line, symbols})

--- a/pkg/chunkenc/unordered_test.go
+++ b/pkg/chunkenc/unordered_test.go
@@ -92,6 +92,7 @@ func Test_Unordered_InsertRetrieval(t *testing.T) {
 		input, exp []entry
 		dir        logproto.Direction
 		hasDup     bool
+		forFormat  HeadBlockFmt
 	}{
 		{
 			desc: "simple forward",
@@ -132,6 +133,50 @@ func Test_Unordered_InsertRetrieval(t *testing.T) {
 			dir: logproto.BACKWARD,
 		},
 		{
+			desc: "different structured metadata forward",
+			input: []entry{
+				{0, "a", labels.EmptyLabels()}, {1, "b", labels.EmptyLabels()}, {0, "a", labels.FromStrings("a", "b")},
+			},
+			exp: []entry{
+				{0, "a", labels.FromStrings("a", "b")}, {0, "a", labels.EmptyLabels()}, {1, "b", labels.EmptyLabels()},
+			},
+			forFormat: UnorderedWithStructuredMetadataHeadBlockFmt,
+		},
+		{
+			desc: "different structured metadata backward",
+			input: []entry{
+				{0, "a", labels.EmptyLabels()}, {1, "b", labels.EmptyLabels()}, {0, "a", labels.FromStrings("a", "b")},
+			},
+			exp: []entry{
+				{1, "b", labels.EmptyLabels()}, {0, "a", labels.EmptyLabels()}, {0, "a", labels.FromStrings("a", "b")},
+			},
+			dir:       logproto.BACKWARD,
+			forFormat: UnorderedWithStructuredMetadataHeadBlockFmt,
+		},
+		{
+			desc: "different structured metadata forward",
+			input: []entry{
+				{0, "a", labels.EmptyLabels()}, {1, "b", labels.EmptyLabels()}, {0, "a", labels.FromStrings("a", "b")},
+			},
+			exp: []entry{
+				{0, "a", labels.EmptyLabels()}, {1, "b", labels.EmptyLabels()},
+			},
+			hasDup:    true,
+			forFormat: UnorderedHeadBlockFmt,
+		},
+		{
+			desc: "different structured metadata backward",
+			input: []entry{
+				{0, "a", labels.EmptyLabels()}, {1, "b", labels.EmptyLabels()}, {0, "a", labels.FromStrings("a", "b")},
+			},
+			exp: []entry{
+				{1, "b", labels.EmptyLabels()}, {0, "a", labels.EmptyLabels()},
+			},
+			dir:       logproto.BACKWARD,
+			hasDup:    true,
+			forFormat: UnorderedHeadBlockFmt,
+		},
+		{
 			desc: "ts collision forward",
 			input: []entry{
 				{0, "a", labels.FromStrings("a", "b")}, {0, "b", labels.FromStrings("a", "b")}, {1, "c", labels.EmptyLabels()},
@@ -153,7 +198,7 @@ func Test_Unordered_InsertRetrieval(t *testing.T) {
 		{
 			desc: "ts remove exact dupe forward",
 			input: []entry{
-				{0, "a", labels.EmptyLabels()}, {0, "b", labels.EmptyLabels()}, {1, "c", labels.EmptyLabels()}, {0, "b", labels.FromStrings("a", "b")},
+				{0, "a", labels.EmptyLabels()}, {0, "b", labels.EmptyLabels()}, {1, "c", labels.EmptyLabels()}, {0, "b", labels.EmptyLabels()},
 			},
 			exp: []entry{
 				{0, "a", labels.EmptyLabels()}, {0, "b", labels.EmptyLabels()}, {1, "c", labels.EmptyLabels()},
@@ -164,7 +209,7 @@ func Test_Unordered_InsertRetrieval(t *testing.T) {
 		{
 			desc: "ts remove exact dupe backward",
 			input: []entry{
-				{0, "a", labels.EmptyLabels()}, {0, "b", labels.EmptyLabels()}, {1, "c", labels.EmptyLabels()}, {0, "b", labels.FromStrings("a", "b")},
+				{0, "a", labels.EmptyLabels()}, {0, "b", labels.EmptyLabels()}, {1, "c", labels.EmptyLabels()}, {0, "b", labels.EmptyLabels()},
 			},
 			exp: []entry{
 				{1, "c", labels.EmptyLabels()}, {0, "b", labels.EmptyLabels()}, {0, "a", labels.EmptyLabels()},
@@ -178,38 +223,40 @@ func Test_Unordered_InsertRetrieval(t *testing.T) {
 				UnorderedHeadBlockFmt,
 				UnorderedWithStructuredMetadataHeadBlockFmt,
 			} {
-				t.Run(format.String(), func(t *testing.T) {
-					hb := newUnorderedHeadBlock(format, newSymbolizer())
-					dup := false
-					for _, e := range tc.input {
-						tmpdup, err := hb.Append(e.t, e.s, e.structuredMetadata)
-						if !dup { // only set dup if it's not already true
-							if tmpdup { // can't examine duplicates until we start getting all the data
-								dup = true
+				if tc.forFormat == 0 || tc.forFormat == format {
+					t.Run(format.String(), func(t *testing.T) {
+						hb := newUnorderedHeadBlock(format, newSymbolizer())
+						dup := false
+						for _, e := range tc.input {
+							tmpdup, err := hb.Append(e.t, e.s, e.structuredMetadata)
+							if !dup { // only set dup if it's not already true
+								if tmpdup { // can't examine duplicates until we start getting all the data
+									dup = true
+								}
+							}
+							require.Nil(t, err)
+						}
+						require.Equal(t, tc.hasDup, dup)
+
+						itr := hb.Iterator(
+							context.Background(),
+							tc.dir,
+							0,
+							math.MaxInt64,
+							noopStreamPipeline,
+						)
+
+						expected := make([]entry, len(tc.exp))
+						copy(expected, tc.exp)
+						if format < UnorderedWithStructuredMetadataHeadBlockFmt {
+							for i := range expected {
+								expected[i].structuredMetadata = labels.EmptyLabels()
 							}
 						}
-						require.Nil(t, err)
-					}
-					require.Equal(t, tc.hasDup, dup)
 
-					itr := hb.Iterator(
-						context.Background(),
-						tc.dir,
-						0,
-						math.MaxInt64,
-						noopStreamPipeline,
-					)
-
-					expected := make([]entry, len(tc.exp))
-					copy(expected, tc.exp)
-					if format < UnorderedWithStructuredMetadataHeadBlockFmt {
-						for i := range expected {
-							expected[i].structuredMetadata = labels.EmptyLabels()
-						}
-					}
-
-					iterEq(t, expected, itr)
-				})
+						iterEq(t, expected, itr)
+					})
+				}
 			}
 		})
 	}

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	pushtypes "github.com/grafana/loki/pkg/push"
 	"github.com/grafana/loki/v3/pkg/chunkenc"
 	"github.com/grafana/loki/v3/pkg/distributor/writefailures"
 	"github.com/grafana/loki/v3/pkg/ingester/wal"
@@ -34,8 +35,9 @@ import (
 var ErrEntriesExist = errors.New("duplicate push - entries already exist")
 
 type line struct {
-	ts      time.Time
-	content string
+	ts                 time.Time
+	content            string
+	structuredMetadata pushtypes.LabelsAdapter
 }
 
 type stream struct {
@@ -369,6 +371,7 @@ func (s *stream) storeEntries(ctx context.Context, entries []logproto.Entry, usa
 		s.entryCt++
 		s.lastLine.ts = entries[i].Timestamp
 		s.lastLine.content = entries[i].Line
+		s.lastLine.structuredMetadata = entries[i].StructuredMetadata
 		if s.highestTs.Before(entries[i].Timestamp) {
 			s.highestTs = entries[i].Timestamp
 		}
@@ -417,7 +420,9 @@ func (s *stream) validateEntries(ctx context.Context, entries []logproto.Entry, 
 		//
 		// NOTE: it's still possible for duplicates to be appended if a stream is
 		// deleted from inactivity.
-		if entries[i].Timestamp.Equal(lastLine.ts) && entries[i].Line == lastLine.content {
+		if entries[i].Timestamp.Equal(lastLine.ts) &&
+			entries[i].Line == lastLine.content &&
+			labelsEqual(entries[i].StructuredMetadata, lastLine.structuredMetadata) {
 			continue
 		}
 
@@ -447,6 +452,7 @@ func (s *stream) validateEntries(ctx context.Context, entries []logproto.Entry, 
 
 		lastLine.ts = entries[i].Timestamp
 		lastLine.content = entries[i].Line
+		lastLine.structuredMetadata = entries[i].StructuredMetadata
 		if highestTs.Before(entries[i].Timestamp) {
 			highestTs = entries[i].Timestamp
 		}
@@ -668,4 +674,18 @@ func headBlockType(chunkfmt byte, unorderedWrites bool) chunkenc.HeadBlockFmt {
 		}
 	}
 	return chunkenc.OrderedHeadBlockFmt
+}
+
+func labelsEqual(a, b pushtypes.LabelsAdapter) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i].Name != b[i].Name || a[i].Value != b[i].Value {
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/iter/entry_iterator.go
+++ b/pkg/iter/entry_iterator.go
@@ -121,7 +121,7 @@ func (i *mergeEntryIterator) fillBuffer() {
 
 	// We support multiple entries with the same timestamp, and we want to
 	// preserve their original order.
-	// Entries with identical timestamp and line are removed as duplicates.
+	// Entries with identical timestamp, line, and metadata are removed as duplicates.
 	for {
 		next := i.tree.Winner()
 		entry := next.At()
@@ -139,7 +139,7 @@ func (i *mergeEntryIterator) fillBuffer() {
 
 		var dupe bool
 		for _, t := range previous {
-			if t.Line == entry.Line {
+			if t.Equal(entry) {
 				i.stats.AddDuplicates(1)
 				dupe = true
 				break

--- a/pkg/iter/entry_iterator_test.go
+++ b/pkg/iter/entry_iterator_test.go
@@ -922,3 +922,41 @@ func TestDedupeMergeEntryIterator(t *testing.T) {
 		require.Equal(t, []string{"0", "2", "1", "3"}, lines)
 	}
 }
+
+func TestMergeIteratorNoDedupDifferentStructuredMetadata(t *testing.T) {
+	// Entries with the same timestamp and line but different structured metadata
+	// must NOT be deduplicated — they are distinct entries.
+	const labels = `{app="foo"}`
+	ts := time.Unix(1, 0)
+	line := "same message"
+
+	entry1 := logproto.Entry{
+		Timestamp:          ts,
+		Line:               line,
+		StructuredMetadata: []logproto.LabelAdapter{{Name: "trace_id", Value: "aaa"}},
+	}
+	entry2 := logproto.Entry{
+		Timestamp:          ts,
+		Line:               line,
+		StructuredMetadata: []logproto.LabelAdapter{{Name: "trace_id", Value: "bbb"}},
+	}
+
+	it := NewMergeEntryIterator(context.Background(),
+		[]EntryIterator{
+			NewStreamIterator(logproto.Stream{Labels: labels, Hash: hashLabels(labels), Entries: []logproto.Entry{entry1}}),
+			NewStreamIterator(logproto.Stream{Labels: labels, Hash: hashLabels(labels), Entries: []logproto.Entry{entry2}}),
+		}, logproto.FORWARD)
+
+	var got []logproto.Entry
+	for it.Next() {
+		got = append(got, it.At())
+	}
+	require.NoError(t, it.Err())
+
+	require.Len(t, got, 2, "entries with different structured metadata must not be deduplicated")
+	require.Equal(t, ts, got[0].Timestamp)
+	require.Equal(t, line, got[0].Line)
+	require.Equal(t, ts, got[1].Timestamp)
+	require.Equal(t, line, got[1].Line)
+	require.NotEqual(t, got[0].StructuredMetadata, got[1].StructuredMetadata)
+}

--- a/tools/dev/loki-tsdb-storage-s3/config/loki.yaml
+++ b/tools/dev/loki-tsdb-storage-s3/config/loki.yaml
@@ -1,4 +1,4 @@
-auth_enabled: true 
+auth_enabled: true
 common:
     compactor_address: http://compactor:8006
 chunk_store_config:


### PR DESCRIPTION
**What this PR does / why we need it**:
Ports https://github.com/grafana/loki/commit/60a15670dd7017ee8c25208ca43f41ae72564509 back into k296.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
