### PR TITLE
docs: backport typo to 3.5

### DIFF
--- a/docs/sources/get-started/labels/modify-default-labels.md
+++ b/docs/sources/get-started/labels/modify-default-labels.md
@@ -120,7 +120,7 @@ If you are using the [Kubernetes Monitoring Helm chart](https://grafana.com/docs
 podLogs:
   enabled: true
   collector: alloy-singleton
-  #List of attributes to use as index labels in oki
+  #List of attributes to use as index labels in loki
   labelsToKeep:
     - app
     - app_kubernetes_io_name


### PR DESCRIPTION
Manual backport of https://github.com/grafana/loki/pull/21051 to 3.6 branch