### PR TITLE
fix: prevent goroutine leak in downstreamer on context cancellation

### DIFF
--- a/pkg/querier/queryrange/downstreamer.go
+++ b/pkg/querier/queryrange/downstreamer.go
@@ -195,9 +195,16 @@ func (in instance) For(
 			return nil
 		})
 		if err != nil {
-			ch <- logql.Resp{
+			// Send the error unless the context has been canceled and the
+			// reader has already exited. Without this select, a canceled
+			// context causes this goroutine to block on the channel send
+			// forever, leaking the goroutine.
+			select {
+			case ch <- logql.Resp{
 				I:   -1,
 				Err: err,
+			}:
+			case <-ctx.Done():
 			}
 		}
 		close(ch)

--- a/pkg/querier/queryrange/downstreamer_test.go
+++ b/pkg/querier/queryrange/downstreamer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -585,6 +586,74 @@ func TestCancelWhileWaitingResponse(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond,
 		"The parent context calling the Downstreamer For method was canceled "+
 			"but the For method did not return as expected.")
+}
+
+func TestCancelDoesNotLeakGoroutines(t *testing.T) {
+	mkIn := func() *instance {
+		return DownstreamHandler{
+			limits: fakeLimits{},
+			next:   nil,
+		}.Downstreamer(context.Background()).(*instance)
+	}
+	in := mkIn()
+
+	params, err := logql.NewLiteralParams(
+		`{app="foo"}`,
+		time.Now(),
+		time.Now(),
+		0,
+		0,
+		logproto.BACKWARD,
+		1000,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	queries := make([]logql.DownstreamQuery, in.parallelism+1)
+	for i := range queries {
+		queries[i] = logql.DownstreamQuery{Params: params}
+	}
+
+	// Record baseline goroutine count.
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	// Run multiple iterations of canceled queries to amplify any leak.
+	for i := 0; i < 100; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		acc := logql.NewBufferedAccumulator(len(queries))
+
+		started := atomic.NewInt32(0)
+		done := make(chan struct{})
+		go func() {
+			_, _ = in.For(ctx, queries, acc, func(_ logql.DownstreamQuery) (logqlmodel.Result, error) {
+				started.Inc()
+				// Block until context is canceled.
+				<-ctx.Done()
+				return logqlmodel.Result{}, ctx.Err()
+			})
+			close(done)
+		}()
+
+		// Wait for at least one job to start, then cancel.
+		require.Eventually(t, func() bool {
+			return started.Load() > 0
+		}, 5*time.Second, time.Millisecond)
+
+		cancel()
+		<-done
+	}
+
+	// Allow goroutines to settle.
+	runtime.GC()
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine() <= baseline+10
+	}, 10*time.Second, 100*time.Millisecond,
+		"goroutine count did not return to baseline; likely leak in For on context cancellation (baseline=%d, current=%d)",
+		baseline, runtime.NumGoroutine(),
+	)
 }
 
 func TestDownstreamerUsesCorrectParallelism(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Guards the error channel send in `instance.For` (`pkg/querier/queryrange/downstreamer.go`) with a `select` on `ctx.Done()` so the goroutine exits cleanly when the reader has already returned due to context cancellation.

Without this fix, when the parent context is canceled the main `for` loop in `For` returns early, but the background goroutine running `ForEachJob` attempts an unconditional send on the unbuffered results channel. With no reader, that send blocks forever — permanently leaking the goroutine. Every canceled sharded query leaks one goroutine, and under sustained cancellation pressure (e.g. node upgrades, rolling drains) this snowballs into hundreds of thousands of leaked goroutines, degrading memory and latency on the affected query-frontend pod.

**Which issue(s) this PR fixes**:
Fixes #21042

**Special notes for your reviewer**:
The fix is a single `select` wrapping the existing channel send (lines 197–205 of `downstreamer.go`). The new test `TestCancelDoesNotLeakGoroutines` runs 100 iterations of cancel-during-query and asserts the goroutine count returns to baseline.

I used Claude Code with Opus 4.6.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
