### PR TITLE
test: fixup related to entry iterator

### DIFF
--- a/pkg/chunkenc/unordered_test.go
+++ b/pkg/chunkenc/unordered_test.go
@@ -148,7 +148,7 @@ func Test_Unordered_InsertRetrieval(t *testing.T) {
 				{0, "a", labels.EmptyLabels()}, {1, "b", labels.EmptyLabels()}, {0, "a", labels.FromStrings("a", "b")},
 			},
 			exp: []entry{
-				{1, "b", labels.EmptyLabels()}, {0, "a", labels.EmptyLabels()}, {0, "a", labels.FromStrings("a", "b")},
+				{1, "b", labels.EmptyLabels()}, {0, "a", labels.FromStrings("a", "b")}, {0, "a", labels.EmptyLabels()},
 			},
 			dir:       logproto.BACKWARD,
 			forFormat: UnorderedWithStructuredMetadataHeadBlockFmt,
@@ -186,6 +186,8 @@ func Test_Unordered_InsertRetrieval(t *testing.T) {
 			},
 		},
 		{
+			// For UnorderedHeadBlockFmt, structured metadata is stripped so both ts=0 entries share
+			// the same stream and are returned in reverse insertion order.
 			desc: "ts collision backward",
 			input: []entry{
 				{0, "a", labels.FromStrings("a", "b")}, {0, "b", labels.EmptyLabels()}, {1, "c", labels.EmptyLabels()},
@@ -193,7 +195,22 @@ func Test_Unordered_InsertRetrieval(t *testing.T) {
 			exp: []entry{
 				{1, "c", labels.EmptyLabels()}, {0, "b", labels.EmptyLabels()}, {0, "a", labels.FromStrings("a", "b")},
 			},
-			dir: logproto.BACKWARD,
+			dir:       logproto.BACKWARD,
+			forFormat: UnorderedHeadBlockFmt,
+		},
+		{
+			// For UnorderedWithStructuredMetadataHeadBlockFmt, the two ts=0 entries have different
+			// structured metadata so they end up in different streams. Tie-breaking by label string
+			// puts {a="b"} before {} (since 'a' < '}' in ASCII).
+			desc: "ts collision backward",
+			input: []entry{
+				{0, "a", labels.FromStrings("a", "b")}, {0, "b", labels.EmptyLabels()}, {1, "c", labels.EmptyLabels()},
+			},
+			exp: []entry{
+				{1, "c", labels.EmptyLabels()}, {0, "a", labels.FromStrings("a", "b")}, {0, "b", labels.EmptyLabels()},
+			},
+			dir:       logproto.BACKWARD,
+			forFormat: UnorderedWithStructuredMetadataHeadBlockFmt,
 		},
 		{
 			desc: "ts remove exact dupe forward",

--- a/pkg/iter/entry_iterator.go
+++ b/pkg/iter/entry_iterator.go
@@ -271,7 +271,9 @@ func lessAscending(e1, e2 sortFields) bool {
 		// The underlying stream hash may not be available, such as when merging LokiResponses in the
 		// frontend which were sharded. Prefer to use the underlying stream hash when available,
 		// which is needed in deduping code, but defer to label sorting when it's not present.
-		if e1.streamHash == 0 {
+		// Also defer to label sorting when both hashes are equal (e.g. entries from the same base
+		// stream but with different structured metadata share the same base hash).
+		if e1.streamHash == 0 || e1.streamHash == e2.streamHash {
 			return e1.labels < e2.labels
 		}
 		return e1.streamHash < e2.streamHash
@@ -281,7 +283,7 @@ func lessAscending(e1, e2 sortFields) bool {
 
 func lessDescending(e1, e2 sortFields) bool {
 	if e1.timeNanos == e2.timeNanos {
-		if e1.streamHash == 0 {
+		if e1.streamHash == 0 || e1.streamHash == e2.streamHash {
 			return e1.labels < e2.labels
 		}
 		return e1.streamHash < e2.streamHash


### PR DESCRIPTION
**What this PR does / why we need it**:

When the sort iterator compared two entries with equal timestamps from different streams, lessAscending/lessDescending checked `e1.streamHash == 0` to decide whether to fall back to label sorting. But since the baseHash is non-zero, it fell through to `e1.streamHash < e2.streamHash` — which compared equal values, returning false for both orderings. This resulted in non-deterministic map iteration order.


This PR adds a guard condition of `|| e1.streamHash == e2.streamHash` to fall back to deterministic label sorting.

As a result, with a deterministic change, we need to adjust a couple of test cases.  This will also remove the flaky test case seen below.
Additionally, `ts_collision_backward` doesn't set `forFormat`, so it runs for both formats. For `UnorderedHeadBlockFmt`, metadata is stripped → entries share one stream → insertion order is preserved (correct). For `UnorderedWithStructuredMetadataHeadBlockFmt`, the entries have different metadata ({a=b} vs empty) → different streams → this fix makes label ordering apply, which gives a different result than what the test expects.  The test result can not be the same for both formats, so it was split into two.


**Which issue(s) this PR fixes**:
Fixes flaky test as seen [here](https://github.com/grafana/loki/actions/runs/22732450221/job/65925074258?pr=20994)

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
