### PR TITLE
docs: Adding one last error message

### DIFF
--- a/docs/sources/operations/troubleshooting/troubleshoot-operations.md
+++ b/docs/sources/operations/troubleshooting/troubleshoot-operations.md
@@ -2190,7 +2190,7 @@ Query parallelism has been set to zero, effectively disabling all queries. This 
 
 - **Account for the querier capacity this requires.** Each unit of parallelism consumes one querier worker slot. With the default `querier.max_concurrent` of `4`, the number of queriers needed to fully parallelize a single query is:
 
-  ```
+  ```bash
   queriers needed = tsdb_max_query_parallelism / max_concurrent
   ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Before deleting the current Troubleshooting page, I checked that I'd already documented all of the error messages, and discovered that there was one that hadn't been covered yet.  Adding that error message before publishing the new Troubleshooting landing page.