### PR TITLE
chore: fix non-deterministic aggregator function

### DIFF
--- a/pkg/engine/internal/executor/aggregator.go
+++ b/pkg/engine/internal/executor/aggregator.go
@@ -169,8 +169,8 @@ func (a *aggregator) BuildRecord() (arrow.RecordBatch, error) {
 		semconv.FieldFromIdent(semconv.ColumnIdentTimestamp, false),
 		semconv.FieldFromIdent(semconv.ColumnIdentValue, false),
 	)
-	for _, label := range a.labels {
-		fields = append(fields, label)
+	for _, name := range slices.Sorted(maps.Keys(a.labels)) {
+		fields = append(fields, a.labels[name])
 	}
 	schema := arrow.NewSchema(fields, nil)
 	rb := array.NewRecordBuilder(memory.NewGoAllocator(), schema)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes up a non-deterministic map iteration, which leads to flaky tests such as [this](https://github.com/grafana/loki/actions/runs/22778100736/job/66076675362?pr=21087).

`a.labels` is a `map[string]arrow.Field`, so iteration is non-deterministic.  This fix sorts label names before building the schema, and ensures output columns are the same every run.

```
% go test -run TestVectorAggregationPipeline -count=10000 -race ./pkg/engine/internal/executor/

ok  	github.com/grafana/loki/v3/pkg/engine/internal/executor	8.732s
% go test -run TestVectorAggregationPipeline -count=10000  ./pkg/engine/internal/executor/ 

ok  	github.com/grafana/loki/v3/pkg/engine/internal/executor	1.714s
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
