### PR TITLE
chore(test): fix flaky kafka test

### DIFF
--- a/pkg/kafkav2/consumer_test.go
+++ b/pkg/kafkav2/consumer_test.go
@@ -46,10 +46,12 @@ func TestGroupConsumer(t *testing.T) {
 		}
 	}
 
-	// Check that the records are as expected.
+	// Check that the records are as expected. Order is not guaranteed across partitions.
 	require.Len(t, records, 2)
-	require.Equal(t, []byte("value1"), records[0].Value)
-	require.Equal(t, []byte("value2"), records[1].Value)
+	require.ElementsMatch(t,
+		[][]byte{[]byte("value1"), []byte("value2")},
+		[][]byte{records[0].Value, records[1].Value},
+	)
 
 	// cancel the context, channel should be closed.
 	cancel()


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a flaky test, as seen [here](https://github.com/grafana/loki/actions/runs/22780469064/job/66084707272?pr=21088)

The fix replaces the strict ordered equality check with a set-membership check. Since the consumer reads from 2 partitions concurrently, the arrival order of records across partitions is non-deterministic — the test was asserting that partition 0's record always arrives first, which isn't guaranteed.
```
% go test ./pkg/kafkav2/... -run TestGroupConsumer -count=10000 
ok  	github.com/grafana/loki/v3/pkg/kafkav2	149.549s

% go test ./pkg/kafkav2/... -run TestGroupConsumer -count=10000 -race
ok  	github.com/grafana/loki/v3/pkg/kafkav2	195.769s
```
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
