### PR TITLE
fix: remove noop wal break

### DIFF
--- a/clients/pkg/promtail/wal/writer.go
+++ b/clients/pkg/promtail/wal/writer.go
@@ -135,7 +135,6 @@ func (wrt *Writer) start(maxSegmentAge time.Duration) {
 				if err := wrt.cleanSegments(maxSegmentAge); err != nil {
 					level.Error(wrt.log).Log("msg", "Error cleaning old segments", "err", err)
 				}
-				break
 			case <-wrt.closeCleaner:
 				trigger.Stop()
 				return


### PR DESCRIPTION
This removes a `break` that does nothing.

I attempted to correct this by labeling the `for` loop so that the `break` would actually do something, and this immediately broke the tests. If the current behavior is to be maintained this `break` is a no-op and should be removed.