### PR TITLE
fix: allow blocking multiple query hashes

### DIFF
--- a/pkg/logql/blocker.go
+++ b/pkg/logql/blocker.go
@@ -51,7 +51,7 @@ func (qb *queryBlocker) isBlocked(ctx context.Context, tenant string) bool {
 				return blocked
 			}
 
-			return false
+			continue
 		}
 
 		// if no pattern is given, assume we want to match all queries

--- a/pkg/logql/blocker_test.go
+++ b/pkg/logql/blocker_test.go
@@ -139,6 +139,28 @@ func TestEngine_ExecWithBlockedQueries(t *testing.T) {
 			}, nil,
 		},
 		{
+			"non-matching hash does not prevent subsequent pattern from matching",
+			defaultQuery, []*validation.BlockedQuery{
+				{
+					Hash: util.HashedQuery(defaultQuery) + 1, // does not match
+				},
+				{
+					Pattern: defaultQuery, // should still be evaluated
+				},
+			}, logqlmodel.ErrBlocked,
+		},
+		{
+			"second hash in list matches when first does not",
+			defaultQuery, []*validation.BlockedQuery{
+				{
+					Hash: util.HashedQuery(defaultQuery) + 1, // does not match
+				},
+				{
+					Hash: util.HashedQuery(defaultQuery), // matches
+				},
+			}, logqlmodel.ErrBlocked,
+		},
+		{
 			"no blocked queries",
 			defaultQuery, []*validation.BlockedQuery{}, nil,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
The current code returns from the logic early if there are multiple hashes specified for queries to be blocked.  This is incorrect, and all hashes need to be evaluated.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
