### PR TITLE
chore: use package private names for these types and funcs

### DIFF
--- a/pkg/distributor/dataobj_tee.go
+++ b/pkg/distributor/dataobj_tee.go
@@ -69,7 +69,7 @@ type DataObjTee struct {
 	rateBatcher  *rateBatcher // nil if batching is disabled
 	limits       Limits
 	kafkaClient  *kgo.Client
-	resolver     *SegmentationPartitionResolver
+	resolver     *segmentationPartitionResolver
 	logger       log.Logger
 
 	// Metrics.
@@ -82,7 +82,7 @@ type DataObjTee struct {
 // NewDataObjTee returns a new DataObjTee.
 func NewDataObjTee(
 	cfg *DataObjTeeConfig,
-	resolver *SegmentationPartitionResolver,
+	resolver *segmentationPartitionResolver,
 	limitsClient *ingestLimits,
 	limits Limits,
 	kafkaClient *kgo.Client,
@@ -131,10 +131,10 @@ func NewDataObjTee(
 	return t, nil
 }
 
-// A SegmentedStream is a KeyedStream with a segmentation key.
-type SegmentedStream struct {
+// A segmentedStream is a KeyedStream with a segmentation key.
+type segmentedStream struct {
 	KeyedStream
-	SegmentationKey     SegmentationKey
+	SegmentationKey     segmentationKey
 	SegmentationKeyHash uint64
 }
 
@@ -145,15 +145,15 @@ func (t *DataObjTee) Register(_ context.Context, _ string, streams []KeyedStream
 
 // Duplicate implements the [Tee] interface.
 func (t *DataObjTee) Duplicate(ctx context.Context, tenant string, streams []KeyedStream, pushTracker *PushTracker) {
-	segmentationKeyStreams := make([]SegmentedStream, 0, len(streams))
+	segmentationKeyStreams := make([]segmentedStream, 0, len(streams))
 	for _, stream := range streams {
-		segmentationKey, err := GetSegmentationKey(stream)
+		segmentationKey, err := getSegmentationKey(stream)
 		if err != nil {
 			level.Error(t.logger).Log("msg", "failed to get segmentation key", "err", err)
 			t.streamFailures.Inc()
 			return
 		}
-		segmentationKeyStreams = append(segmentationKeyStreams, SegmentedStream{
+		segmentationKeyStreams = append(segmentationKeyStreams, segmentedStream{
 			KeyedStream:         stream,
 			SegmentationKey:     segmentationKey,
 			SegmentationKeyHash: segmentationKey.Sum64(),
@@ -186,13 +186,13 @@ func (t *DataObjTee) Duplicate(ctx context.Context, tenant string, streams []Key
 	tenantRateBytesLimit := uint64(max(t.limits.IngestionRateBytes(tenant), 0))
 
 	for _, s := range segmentationKeyStreams {
-		go func(stream SegmentedStream) {
+		go func(stream segmentedStream) {
 			t.duplicate(ctx, tenant, stream, fastRates[stream.SegmentationKeyHash], tenantRateBytesLimit, pushTracker)
 		}(s)
 	}
 }
 
-func (t *DataObjTee) duplicate(ctx context.Context, tenant string, stream SegmentedStream, rateBytes, tenantRateBytes uint64, pushTracker *PushTracker) {
+func (t *DataObjTee) duplicate(ctx context.Context, tenant string, stream segmentedStream, rateBytes, tenantRateBytes uint64, pushTracker *PushTracker) {
 	t.streams.Inc()
 
 	partition, err := t.resolver.Resolve(ctx, tenant, stream.SegmentationKey, rateBytes, tenantRateBytes)

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -308,7 +308,7 @@ func New(
 		)
 
 		if cfg.DataObjTeeConfig.Enabled {
-			resolver := NewSegmentationPartitionResolver(
+			resolver := newSegmentationPartitionResolver(
 				uint64(cfg.DataObjTeeConfig.PerPartitionRateBytes),
 				dataObjConsumerPartitionRing,
 				registerer,

--- a/pkg/distributor/ingest_limits.go
+++ b/pkg/distributor/ingest_limits.go
@@ -201,7 +201,7 @@ func newExceedsLimitsRequest(tenant string, streams []KeyedStream) (*proto.Excee
 // UpdateRates updates the rates for the streams and returns a slice of the
 // updated rates for all streams. Any streams that could not have rates updated
 // have a rate of zero.
-func (l *ingestLimits) UpdateRates(ctx context.Context, tenant string, streams []SegmentedStream) ([]*proto.UpdateRatesResult, error) {
+func (l *ingestLimits) UpdateRates(ctx context.Context, tenant string, streams []segmentedStream) ([]*proto.UpdateRatesResult, error) {
 	req, err := newUpdateRatesRequest(tenant, streams)
 	if err != nil {
 		// We update `UpdateRates` here because we have clients directly calling `UpdateRatesRaw`.
@@ -224,7 +224,7 @@ func (l *ingestLimits) UpdateRatesRaw(ctx context.Context, req *proto.UpdateRate
 	return resp.Results, nil
 }
 
-func newUpdateRatesRequest(tenant string, streams []SegmentedStream) (*proto.UpdateRatesRequest, error) {
+func newUpdateRatesRequest(tenant string, streams []segmentedStream) (*proto.UpdateRatesRequest, error) {
 	// The distributor sends the hashes of all streams in the request to the
 	// limits-frontend. The limits-frontend is responsible for deciding if
 	// the request would exceed the tenants limits, and if so, which streams

--- a/pkg/distributor/ingest_limits_test.go
+++ b/pkg/distributor/ingest_limits_test.go
@@ -344,7 +344,7 @@ func TestIngestLimits_UpdateRates(t *testing.T) {
 	tests := []struct {
 		name            string
 		tenant          string
-		streams         []SegmentedStream
+		streams         []segmentedStream
 		expectedRequest *proto.UpdateRatesRequest
 		response        *proto.UpdateRatesResponse
 		responseErr     error
@@ -353,16 +353,16 @@ func TestIngestLimits_UpdateRates(t *testing.T) {
 	}{{
 		name:   "error should be returned if rates cannot be updated",
 		tenant: "test",
-		streams: []SegmentedStream{{
-			SegmentationKey: "test",
+		streams: []segmentedStream{{
+			SegmentationKey: segmentationKey("test"),
 		}},
 		responseErr: errors.New("failed to update rates"),
 		expectedErr: "failed to update rates",
 	}, {
 		name:   "updates rates",
 		tenant: "test",
-		streams: []SegmentedStream{{
-			SegmentationKey:     "test",
+		streams: []segmentedStream{{
+			SegmentationKey:     segmentationKey("test"),
 			SegmentationKeyHash: 13113208752873574959,
 		}},
 		expectedRequest: &proto.UpdateRatesRequest{

--- a/pkg/distributor/rate_batcher.go
+++ b/pkg/distributor/rate_batcher.go
@@ -107,7 +107,7 @@ func (b *rateBatcher) running(ctx context.Context) error {
 
 // Add adds streams to the pending batch and returns the last known rates for them.
 // This is a non-blocking operation. Streams with unknown rates will have rate=0.
-func (b *rateBatcher) Add(tenant string, streams []SegmentedStream) map[uint64]uint64 {
+func (b *rateBatcher) Add(tenant string, streams []segmentedStream) map[uint64]uint64 {
 	if len(streams) == 0 {
 		return nil
 	}

--- a/pkg/distributor/rate_batcher_test.go
+++ b/pkg/distributor/rate_batcher_test.go
@@ -56,7 +56,7 @@ func TestRateBatcher_Add_AccumulatesStreams(t *testing.T) {
 	)
 
 	// Add some streams.
-	streams := []SegmentedStream{
+	streams := []segmentedStream{
 		{
 			KeyedStream: KeyedStream{
 				Stream: logproto.Stream{
@@ -107,7 +107,7 @@ func TestRateBatcher_AccumulatesSize(t *testing.T) {
 	)
 
 	// Add stream with some entries.
-	stream1 := []SegmentedStream{
+	stream1 := []segmentedStream{
 		{
 			KeyedStream: KeyedStream{
 				Stream: logproto.Stream{
@@ -120,7 +120,7 @@ func TestRateBatcher_AccumulatesSize(t *testing.T) {
 	}
 
 	// Add stream again with more entries.
-	stream2 := []SegmentedStream{
+	stream2 := []segmentedStream{
 		{
 			KeyedStream: KeyedStream{
 				Stream: logproto.Stream{
@@ -159,8 +159,8 @@ func TestRateBatcher_MultipleTenants(t *testing.T) {
 	)
 
 	// Add streams for multiple tenants.
-	batcher.Add("tenant1", []SegmentedStream{{SegmentationKeyHash: 123}})
-	batcher.Add("tenant2", []SegmentedStream{{SegmentationKeyHash: 456}})
+	batcher.Add("tenant1", []segmentedStream{{SegmentationKeyHash: 123}})
+	batcher.Add("tenant2", []segmentedStream{{SegmentationKeyHash: 456}})
 
 	batcher.flush(context.Background())
 
@@ -213,7 +213,7 @@ func TestRateBatcher_ServiceLifecycle(t *testing.T) {
 	require.NoError(t, services.StartAndAwaitRunning(ctx, batcher))
 
 	// Add some streams.
-	batcher.Add("tenant1", []SegmentedStream{{SegmentationKeyHash: 123}})
+	batcher.Add("tenant1", []segmentedStream{{SegmentationKeyHash: 123}})
 
 	// Wait for automatic flush.
 	time.Sleep(100 * time.Millisecond)
@@ -244,8 +244,8 @@ func TestRateBatcher_StoresRatesFromFlush(t *testing.T) {
 	require.Equal(t, uint64(0), rate)
 
 	// Add streams and flush.
-	batcher.Add("tenant1", []SegmentedStream{{SegmentationKeyHash: 123}})
-	batcher.Add("tenant1", []SegmentedStream{{SegmentationKeyHash: 456}})
+	batcher.Add("tenant1", []segmentedStream{{SegmentationKeyHash: 123}})
+	batcher.Add("tenant1", []segmentedStream{{SegmentationKeyHash: 456}})
 	batcher.flush(context.Background())
 
 	// After flush, rates should be stored (mock returns 1000 for all).
@@ -276,7 +276,7 @@ func TestRateBatcher_AddReturnsRates(t *testing.T) {
 	)
 
 	// First Add returns 0 for all (no prior flush).
-	rates := batcher.Add("tenant1", []SegmentedStream{
+	rates := batcher.Add("tenant1", []segmentedStream{
 		{SegmentationKeyHash: 123},
 		{SegmentationKeyHash: 456},
 	})
@@ -287,7 +287,7 @@ func TestRateBatcher_AddReturnsRates(t *testing.T) {
 	batcher.flush(context.Background())
 
 	// Second Add returns last known rates.
-	rates = batcher.Add("tenant1", []SegmentedStream{
+	rates = batcher.Add("tenant1", []segmentedStream{
 		{SegmentationKeyHash: 123},
 		{SegmentationKeyHash: 456},
 		{SegmentationKeyHash: 789}, // New stream, unknown rate.
@@ -310,7 +310,7 @@ func TestRateBatcher_RatesUpdatedOnSubsequentFlush(t *testing.T) {
 	)
 
 	// First flush.
-	batcher.Add("tenant1", []SegmentedStream{{SegmentationKeyHash: 123}})
+	batcher.Add("tenant1", []segmentedStream{{SegmentationKeyHash: 123}})
 	batcher.flush(context.Background())
 	require.Equal(t, uint64(1000), batcher.GetRate("tenant1", 123))
 
@@ -320,7 +320,7 @@ func TestRateBatcher_RatesUpdatedOnSubsequentFlush(t *testing.T) {
 	client.mu.Unlock()
 
 	// Second flush updates the rate.
-	batcher.Add("tenant1", []SegmentedStream{{SegmentationKeyHash: 123}})
+	batcher.Add("tenant1", []segmentedStream{{SegmentationKeyHash: 123}})
 	batcher.flush(context.Background())
 	require.Equal(t, uint64(5000), batcher.GetRate("tenant1", 123))
 }
@@ -337,7 +337,7 @@ func TestRateBatcher_RatesClearedForInactiveStreams(t *testing.T) {
 	)
 
 	// First flush with streams 123 and 456.
-	batcher.Add("tenant1", []SegmentedStream{
+	batcher.Add("tenant1", []segmentedStream{
 		{SegmentationKeyHash: 123},
 		{SegmentationKeyHash: 456},
 	})
@@ -346,7 +346,7 @@ func TestRateBatcher_RatesClearedForInactiveStreams(t *testing.T) {
 	require.Equal(t, uint64(1000), batcher.GetRate("tenant1", 456))
 
 	// Second flush with only stream 123 (456 became inactive).
-	batcher.Add("tenant1", []SegmentedStream{{SegmentationKeyHash: 123}})
+	batcher.Add("tenant1", []segmentedStream{{SegmentationKeyHash: 123}})
 	batcher.flush(context.Background())
 
 	// Stream 123 still has a rate.

--- a/pkg/distributor/segment.go
+++ b/pkg/distributor/segment.go
@@ -15,12 +15,12 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 )
 
-// A SegmentationKey is a special partition key that attempts to equally
+// A segmentationKey is a special partition key that attempts to equally
 // distribute load while preserving stream locality for tenants.
-type SegmentationKey string
+type segmentationKey string
 
 // Sum64 returns a 64 bit, non-cryptographic hash of the key.
-func (key SegmentationKey) Sum64() uint64 {
+func (key segmentationKey) Sum64() uint64 {
 	h := fnv.New64a()
 	// Use a reserved word here to avoid any possible hash conflicts with
 	// streams.
@@ -29,20 +29,20 @@ func (key SegmentationKey) Sum64() uint64 {
 	return h.Sum64()
 }
 
-// GetSegmentationKey returns the segmentation key for the stream or an error.
-func GetSegmentationKey(stream KeyedStream) (SegmentationKey, error) {
+// getSegmentationKey returns the segmentation key for the stream or an error.
+func getSegmentationKey(stream KeyedStream) (segmentationKey, error) {
 	labels, err := syntax.ParseLabels(stream.Stream.Labels)
 	if err != nil {
 		return "", err
 	}
 	if serviceName := labels.Get("service_name"); serviceName != "" {
-		return SegmentationKey(serviceName), nil
+		return segmentationKey(serviceName), nil
 	}
-	return SegmentationKey("unknown_service"), nil
+	return segmentationKey("unknown_service"), nil
 }
 
-// SegmentationPartitionResolver resolves the partition for a segmentation key.
-type SegmentationPartitionResolver struct {
+// segmentationPartitionResolver resolves the partition for a segmentation key.
+type segmentationPartitionResolver struct {
 	perPartitionRateBytes uint64
 	ringReader            ring.PartitionRingReader
 	logger                log.Logger
@@ -53,9 +53,9 @@ type SegmentationPartitionResolver struct {
 	total           prometheus.Counter
 }
 
-// NewSegmentationPartitionResolver returns a new SegmentationPartitionResolver.
-func NewSegmentationPartitionResolver(perPartitionRateBytes uint64, ringReader ring.PartitionRingReader, reg prometheus.Registerer, logger log.Logger) *SegmentationPartitionResolver {
-	return &SegmentationPartitionResolver{
+// newSegmentationPartitionResolver returns a new segmentationPartitionResolver.
+func newSegmentationPartitionResolver(perPartitionRateBytes uint64, ringReader ring.PartitionRingReader, reg prometheus.Registerer, logger log.Logger) *segmentationPartitionResolver {
+	return &segmentationPartitionResolver{
 		perPartitionRateBytes: perPartitionRateBytes,
 		ringReader:            ringReader,
 		failed: promauto.With(reg).NewCounter(prometheus.CounterOpts{
@@ -74,7 +74,7 @@ func NewSegmentationPartitionResolver(perPartitionRateBytes uint64, ringReader r
 	}
 }
 
-func (r *SegmentationPartitionResolver) Resolve(ctx context.Context, tenant string, key SegmentationKey, rateBytes, tenantRateBytes uint64) (int32, error) {
+func (r *segmentationPartitionResolver) Resolve(ctx context.Context, tenant string, key segmentationKey, rateBytes, tenantRateBytes uint64) (int32, error) {
 	r.total.Inc()
 	// We use a snapshot of the partition ring to ensure resolving the
 	// partition for a segmentation key is determinstic even if the ring
@@ -119,7 +119,7 @@ func (r *SegmentationPartitionResolver) Resolve(ctx context.Context, tenant stri
 }
 
 // getTenantRing returns a subring for the tenant based on their rate limit.
-func (r *SegmentationPartitionResolver) getTenantSubring(_ context.Context, ring *ring.PartitionRing, tenant string, tenantRateBytes uint64) (*ring.PartitionRing, error) {
+func (r *segmentationPartitionResolver) getTenantSubring(_ context.Context, ring *ring.PartitionRing, tenant string, tenantRateBytes uint64) (*ring.PartitionRing, error) {
 	if tenantRateBytes == 0 {
 		// If the tenant has no limit, return the full ring.
 		return ring, nil
@@ -134,7 +134,7 @@ func (r *SegmentationPartitionResolver) getTenantSubring(_ context.Context, ring
 	return ring.ShuffleShard(tenant, int(partitions))
 }
 
-func (r *SegmentationPartitionResolver) getSegmentationKeySubring(_ context.Context, ring *ring.PartitionRing, key SegmentationKey, rateBytes uint64) (*ring.PartitionRing, error) {
+func (r *segmentationPartitionResolver) getSegmentationKeySubring(_ context.Context, ring *ring.PartitionRing, key segmentationKey, rateBytes uint64) (*ring.PartitionRing, error) {
 	if rateBytes == 0 {
 		// If the rate is 0, return the full ring.
 		return ring, nil

--- a/pkg/distributor/segment_test.go
+++ b/pkg/distributor/segment_test.go
@@ -16,49 +16,49 @@ import (
 
 func TestGetSegmentationKey(t *testing.T) {
 	t.Run("stream without labels", func(t *testing.T) {
-		key, err := GetSegmentationKey(KeyedStream{})
+		key, err := getSegmentationKey(KeyedStream{})
 		require.NoError(t, err)
-		require.Equal(t, SegmentationKey("unknown_service"), key)
+		require.Equal(t, segmentationKey("unknown_service"), key)
 	})
 
 	t.Run("stream with invalid labels", func(t *testing.T) {
-		key, err := GetSegmentationKey(KeyedStream{
+		key, err := getSegmentationKey(KeyedStream{
 			Stream: logproto.Stream{
 				Labels: "{",
 			},
 		})
 		require.EqualError(t, err, "1:2: parse error: unexpected end of input inside braces")
-		require.Equal(t, SegmentationKey(""), key)
+		require.Equal(t, segmentationKey(""), key)
 	})
 
 	t.Run("stream with service_name", func(t *testing.T) {
-		key, err := GetSegmentationKey(KeyedStream{
+		key, err := getSegmentationKey(KeyedStream{
 			Stream: logproto.Stream{
 				Labels: "{service_name=\"foo\"}",
 			},
 		})
 		require.NoError(t, err)
-		require.Equal(t, SegmentationKey("foo"), key)
+		require.Equal(t, segmentationKey("foo"), key)
 	})
 
 	t.Run("stream without service_name", func(t *testing.T) {
-		key, err := GetSegmentationKey(KeyedStream{
+		key, err := getSegmentationKey(KeyedStream{
 			Stream: logproto.Stream{
 				Labels: "{bar=\"baz\"}",
 			},
 		})
 		require.NoError(t, err)
-		require.Equal(t, SegmentationKey("unknown_service"), key)
+		require.Equal(t, segmentationKey("unknown_service"), key)
 	})
 }
 
 func TestSegmentationKey_Sum64(t *testing.T) {
-	k1 := SegmentationKey("")
+	k1 := segmentationKey("")
 	require.Equal(t, uint64(6134230144364956955), k1.Sum64())
-	k2 := SegmentationKey("abc")
+	k2 := segmentationKey("abc")
 	require.Equal(t, uint64(5348611747852513221), k2.Sum64())
 	// The same key always produces the same 64 bit sum.
-	k3 := SegmentationKey("abc")
+	k3 := segmentationKey("abc")
 	require.Equal(t, k2.Sum64(), k3.Sum64())
 }
 
@@ -89,8 +89,8 @@ func TestSegmentationPartitionResolver_Resolve(t *testing.T) {
 
 	t.Run("returns error if no active partitions", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		resolver := NewSegmentationPartitionResolver(1024, emptyRing, reg, log.NewNopLogger())
-		partition, err := resolver.Resolve(t.Context(), "tenant", SegmentationKey("test"), 0, 0)
+		resolver := newSegmentationPartitionResolver(1024, emptyRing, reg, log.NewNopLogger())
+		partition, err := resolver.Resolve(t.Context(), "tenant", segmentationKey("test"), 0, 0)
 		require.EqualError(t, err, "no active partitions")
 		require.Equal(t, int32(0), partition)
 		// Check the metrics to make sure it fell back to random shuffle and
@@ -114,8 +114,8 @@ func TestSegmentationPartitionResolver_Resolve(t *testing.T) {
 
 	t.Run("uses random shuffle if rate unknown", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		resolver := NewSegmentationPartitionResolver(1024, ringWithActivePartition, reg, log.NewNopLogger())
-		partition, err := resolver.Resolve(t.Context(), "tenant", SegmentationKey("test"), 0, 0)
+		resolver := newSegmentationPartitionResolver(1024, ringWithActivePartition, reg, log.NewNopLogger())
+		partition, err := resolver.Resolve(t.Context(), "tenant", segmentationKey("test"), 0, 0)
 		require.NoError(t, err)
 		// Should return partition 1 since that is the only active partition.
 		require.Equal(t, int32(1), partition)
@@ -139,8 +139,8 @@ func TestSegmentationPartitionResolver_Resolve(t *testing.T) {
 
 	t.Run("shuffle shards on segmentation key if rate is known", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		resolver := NewSegmentationPartitionResolver(1024, ringWithActivePartition, reg, log.NewNopLogger())
-		partition, err := resolver.Resolve(t.Context(), "tenant", SegmentationKey("test"), 512, 0)
+		resolver := newSegmentationPartitionResolver(1024, ringWithActivePartition, reg, log.NewNopLogger())
+		partition, err := resolver.Resolve(t.Context(), "tenant", segmentationKey("test"), 512, 0)
 		require.NoError(t, err)
 		require.Equal(t, int32(1), partition)
 		require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
@@ -197,7 +197,7 @@ func TestSegmentationPartitionResolver_GetTenantSubring(t *testing.T) {
 
 	t.Run("no rate returns full ring", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		resolver := NewSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
+		resolver := newSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
 		ring := ringWithActivePartitions.PartitionRing()
 		subring, err := resolver.getTenantSubring(t.Context(), ring, "tenant", 0)
 		require.NoError(t, err)
@@ -206,7 +206,7 @@ func TestSegmentationPartitionResolver_GetTenantSubring(t *testing.T) {
 
 	t.Run("rate equals partition rate returns subring with one partition", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		resolver := NewSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
+		resolver := newSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
 		ring := ringWithActivePartitions.PartitionRing()
 		subring, err := resolver.getTenantSubring(t.Context(), ring, "tenant", 1024)
 		require.NoError(t, err)
@@ -215,7 +215,7 @@ func TestSegmentationPartitionResolver_GetTenantSubring(t *testing.T) {
 
 	t.Run("rate exceeds partition rate returns subring with all partitions", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		resolver := NewSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
+		resolver := newSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
 		ring := ringWithActivePartitions.PartitionRing()
 		subring, err := resolver.getTenantSubring(t.Context(), ring, "tenant", 2048)
 		require.NoError(t, err)
@@ -259,27 +259,27 @@ func TestSegmentationPartitionResolver_GetSegmentationKeySubring(t *testing.T) {
 
 	t.Run("no rate returns full ring", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		resolver := NewSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
+		resolver := newSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
 		ring := ringWithActivePartitions.PartitionRing()
-		subring, err := resolver.getSegmentationKeySubring(t.Context(), ring, SegmentationKey("test"), 0)
+		subring, err := resolver.getSegmentationKeySubring(t.Context(), ring, segmentationKey("test"), 0)
 		require.NoError(t, err)
 		require.Equal(t, ring, subring)
 	})
 
 	t.Run("rate equals partition rate returns subring with one partition", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		resolver := NewSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
+		resolver := newSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
 		ring := ringWithActivePartitions.PartitionRing()
-		subring, err := resolver.getSegmentationKeySubring(t.Context(), ring, SegmentationKey("test"), 1024)
+		subring, err := resolver.getSegmentationKeySubring(t.Context(), ring, segmentationKey("test"), 1024)
 		require.NoError(t, err)
 		require.Equal(t, 1, subring.ActivePartitionsCount())
 	})
 
 	t.Run("rate exceeds partition rate returns subring with all partitions", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
-		resolver := NewSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
+		resolver := newSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
 		ring := ringWithActivePartitions.PartitionRing()
-		subring, err := resolver.getSegmentationKeySubring(t.Context(), ring, SegmentationKey("test"), 2048)
+		subring, err := resolver.getSegmentationKeySubring(t.Context(), ring, segmentationKey("test"), 2048)
 		require.NoError(t, err)
 		require.Equal(t, 2, subring.ActivePartitionsCount())
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

We should have used package private level funcs for this code all along.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
