### PR TITLE
fix(goldfish): Normalize goldfish response

### DIFF
--- a/pkg/querytee/goldfish/stats_extractor.go
+++ b/pkg/querytee/goldfish/stats_extractor.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"sort"
 	"strconv"
 
 	"github.com/grafana/loki/v3/pkg/goldfish"
@@ -70,19 +71,24 @@ type hashableResponse struct {
 	} `json:"data"`
 }
 
-// generateResponseHash creates a content-sensitive hash by removing only performance statistics
+// generateResponseHash creates a content-sensitive hash by removing only performance statistics.
+// For streams results, entries within each stream are sorted by (timestamp, line)
+// before hashing so that different tie-breaking orders for same-timestamp entries
+// across engines do not produce false mismatches.
 func (e *StatsExtractor) generateResponseHash(resp loghttp.QueryResponse) string {
-	// Create a copy of the response without statistics (which contain timing info)
 	hashableResp := hashableResponse{
 		Status: resp.Status,
 	}
 	hashableResp.Data.ResultType = string(resp.Data.ResultType)
-	hashableResp.Data.Result = resp.Data.Result
 
-	// Generate hash from the response content (excluding statistics)
+	result := resp.Data.Result
+	if streams, ok := result.(loghttp.Streams); ok {
+		result = normalizeStreamsOrder(streams)
+	}
+	hashableResp.Data.Result = result
+
 	responseBytes, err := json.Marshal(hashableResp)
 	if err != nil {
-		// Fallback to empty string if marshaling fails
 		return ""
 	}
 
@@ -90,7 +96,30 @@ func (e *StatsExtractor) generateResponseHash(resp loghttp.QueryResponse) string
 	h.Write(responseBytes)
 
 	return strconv.FormatUint(uint64(h.Sum32()), 16)
+}
 
+// normalizeStreamsOrder returns a copy of the streams with entries within each
+// stream sorted by (timestamp, line). This makes the hash order-agnostic for
+// entries that share the same nanosecond timestamp, which different engines may
+// return in different but equally valid orders.
+func normalizeStreamsOrder(streams loghttp.Streams) loghttp.Streams {
+	normalized := make(loghttp.Streams, len(streams))
+	for i, s := range streams {
+		entries := make([]loghttp.Entry, len(s.Entries))
+		copy(entries, s.Entries)
+		sort.Slice(entries, func(a, b int) bool {
+			ta, tb := entries[a].Timestamp, entries[b].Timestamp
+			if ta.Equal(tb) {
+				return entries[a].Line < entries[b].Line
+			}
+			return ta.Before(tb)
+		})
+		normalized[i] = loghttp.Stream{
+			Labels:  s.Labels,
+			Entries: entries,
+		}
+	}
+	return normalized
 }
 
 // CompareStats compares two QueryStats and returns performance differences.


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify how we generate the response hash by first sorting the entries. This way, if two cells returns the same entries but in slightly different orders, we still capture the difference and end up generating the same hash.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
