### PR TITLE
loki: avoid readiness 503 while services are starting

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -686,11 +686,14 @@ func (t *Loki) readyHandler(sm *services.Manager, shutdownRequested *atomic.Bool
 			http.Error(w, "Application is stopping", http.StatusServiceUnavailable)
 			return
 		}
-		if !sm.IsHealthy() {
-			msg := bytes.Buffer{}
-			msg.WriteString("Some services are not Running:\n")
+		byState := sm.ServicesByState()
 
-			byState := sm.ServicesByState()
+		// Only fail readiness if services actually failed.
+		// Services in Starting state are normal during bootstrap.
+		if len(byState[services.Failed]) > 0 {
+			msg := bytes.Buffer{}
+			msg.WriteString("Some services failed:\n")
+
 			for st, ls := range byState {
 				fmt.Fprintf(&msg, "%v: %d\n", st, len(ls))
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

During startup in single-binary mode (`-target=all`), several internal services remain in the `Starting` state while Loki finishes bootstrapping. The `/ready` endpoint currently relies on `sm.IsHealthy()`, which requires all services to be `Running`, causing `/ready` to return **HTTP 503** during normal startup.

This results in false readiness probe failures in Kubernetes even though the process is operational.
This PR updates the readiness logic to only return `503` when services are in a Failed state, allowing services in `Starting` during bootstrap while preserving existing component-specific readiness checks (e.g., `Ingester.CheckReady`).

**Which issue(s) this PR fixes**:  
Fixes #21027

**Special notes for your reviewer**:

This change does not modify the lifecycle behavior of `services.Manager`. It only adjusts the `/ready` handler to avoid false readiness failures during normal startup.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.