### PR TITLE
fix: clarify retention cutoff timestamp in compactor log

### DIFF
--- a/pkg/compactor/retention/expiration.go
+++ b/pkg/compactor/retention/expiration.go
@@ -79,8 +79,15 @@ func (e *expirationChecker) DropFromIndex(userID []byte, _ Chunk, labels labels.
 
 func (e *expirationChecker) MarkPhaseStarted() {
 	e.latestRetentionStartTime = findLatestRetentionStartTime(model.Now(), e.tenantsRetention.limits)
-	level.Info(util_log.Logger).Log("msg", fmt.Sprintf("overall smallest retention period %v, default smallest retention period %v",
-		e.latestRetentionStartTime.overall, e.latestRetentionStartTime.defaults))
+
+	level.Info(util_log.Logger).Log(
+		"msg",
+		fmt.Sprintf(
+			"overall smallest retention cutoff timestamp %v, default smallest retention cutoff timestamp %v",
+			e.latestRetentionStartTime.overall,
+			e.latestRetentionStartTime.defaults,
+		),
+	)
 }
 
 func (e *expirationChecker) MarkPhaseFailed()   {}


### PR DESCRIPTION
**What this PR does / why we need it**:

Clarifies the compactor log message in `expiration.go`.  
The previous message referred to a "retention period" but printed a Unix timestamp, which can be confusing.  
This change updates the log to clearly indicate that the value is a retention cutoff timestamp.

**Which issue(s) this PR fixes**:
Fixes #20941

**Special notes for your reviewer**:
Small log message clarification only. No behavior changes.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml`