### PR TITLE
feat: support parallel flushes

### DIFF
--- a/pkg/dataobj/consumer/flush.go
+++ b/pkg/dataobj/consumer/flush.go
@@ -18,6 +18,11 @@ const (
 	flushReasonIdle        = "idle"
 )
 
+// A builder allows mocking of [logsobj.Builder] in tests.
+type builder interface {
+	Flush() (*dataobj.Object, io.Closer, error)
+}
+
 // A sorter allows mocking of [logsobj.Sorter] in tests.
 type sorter interface {
 	Sort(ctx context.Context, obj *dataobj.Object) (*dataobj.Object, io.Closer, error)

--- a/pkg/dataobj/consumer/flush_committer.go
+++ b/pkg/dataobj/consumer/flush_committer.go
@@ -27,7 +27,8 @@ type flusher interface {
 	Flush(ctx context.Context, builder builder, reason string) (string, error)
 }
 
-// A flushCommitterImpl manages the flushing of data objects and commits.
+// A flushCommitterImpl flushes data objects. It produces a metastore event and
+// commits the Kafka offsets on success, and returns an error on failure.
 type flushCommitterImpl struct {
 	flusher         flusher
 	metastoreEvents metastoreEventEmitter

--- a/pkg/dataobj/consumer/flush_test.go
+++ b/pkg/dataobj/consumer/flush_test.go
@@ -22,15 +22,13 @@ func TestFlusher_Flush(t *testing.T) {
 		var (
 			reg          = prometheus.NewRegistry()
 			testCtx      = t.Context()
-			testBuilder  *mockBuilder
 			testSorter   = &mockSorter{}
 			testUploader = &mockUploader{}
 			now          = time.Now()
 		)
 		// Create a builder and append some logs so it can be flushed.
-		realBuilder, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory())
+		testBuilder, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory())
 		require.NoError(t, err)
-		testBuilder = &mockBuilder{builder: realBuilder}
 		require.NoError(t, testBuilder.Append("test", logproto.Stream{
 			Labels: `{foo="bar"}`,
 			Entries: []logproto.Entry{
@@ -56,9 +54,8 @@ func TestFlusher_Flush(t *testing.T) {
 
 	t.Run("should fail", func(t *testing.T) {
 		var (
-			reg         = prometheus.NewRegistry()
-			testCtx     = t.Context()
-			testBuilder *mockBuilder
+			reg     = prometheus.NewRegistry()
+			testCtx = t.Context()
 		)
 		f := newFlusher(nil, nil, log.NewNopLogger(), reg)
 		// Override the flush func to force a failure.
@@ -66,7 +63,7 @@ func TestFlusher_Flush(t *testing.T) {
 			return "", errors.New("mock error")
 		}
 		// Flush the builder we created earlier.
-		objectPath, err := f.Flush(testCtx, testBuilder, "test_sync")
+		objectPath, err := f.Flush(testCtx, &logsobj.Builder{}, "test_sync")
 		require.EqualError(t, err, "mock error")
 		require.Equal(t, "", objectPath)
 		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
@@ -92,7 +89,7 @@ func TestFlusher_FlushAsync(t *testing.T) {
 			// Mock success so promise is invoked.
 			return "", nil
 		}
-		f.FlushAsync(testCtx, &mockBuilder{}, "flush_async", func(res flushJobResult) {
+		f.FlushAsync(testCtx, &logsobj.Builder{}, "flush_async", func(res flushJobResult) {
 			require.NoError(t, res.err)
 			invoked = true
 			close(done)
@@ -115,7 +112,7 @@ func TestFlusher_FlushAsync(t *testing.T) {
 		f.flushFunc = func(_ context.Context, _ flushJob) (string, error) {
 			return "", errors.New("mock error")
 		}
-		f.FlushAsync(testCtx, &mockBuilder{}, "flush_async", func(res flushJobResult) {
+		f.FlushAsync(testCtx, &logsobj.Builder{}, "flush_async", func(res flushJobResult) {
 			require.EqualError(t, res.err, "mock error")
 			invoked = true
 			close(done)
@@ -142,7 +139,7 @@ func TestFlusher_FlushAsync(t *testing.T) {
 		}
 		// Cancel the context so FlushAsync calls the promise.
 		cancel()
-		f.FlushAsync(cancelCtx, &mockBuilder{}, "flush_async", func(res flushJobResult) {
+		f.FlushAsync(cancelCtx, &logsobj.Builder{}, "flush_async", func(res flushJobResult) {
 			require.EqualError(t, res.err, "context canceled")
 			invoked = true
 			close(done)

--- a/pkg/dataobj/consumer/mock_test.go
+++ b/pkg/dataobj/consumer/mock_test.go
@@ -13,10 +13,8 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
-	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
-	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
 // A mockBucket mocks an [objstore.Bucket].
@@ -95,40 +93,6 @@ func (m *mockBucket) Provider() objstore.ObjProvider {
 
 func (m *mockBucket) SupportedIterOptions() []objstore.IterOptionType {
 	return nil
-}
-
-// mockBuilder mocks a [logsobj.Builder].
-type mockBuilder struct {
-	builder *logsobj.Builder
-	nextErr error
-}
-
-func (m *mockBuilder) Append(tenant string, stream logproto.Stream) error {
-	if err := m.nextErr; err != nil {
-		m.nextErr = nil
-		return err
-	}
-	return m.builder.Append(tenant, stream)
-}
-
-func (m *mockBuilder) GetEstimatedSize() int {
-	return m.builder.GetEstimatedSize()
-}
-
-func (m *mockBuilder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataobj.Object, io.Closer, error) {
-	return m.builder.CopyAndSort(ctx, obj)
-}
-
-func (m *mockBuilder) Flush() (*dataobj.Object, io.Closer, error) {
-	if err := m.nextErr; err != nil {
-		m.nextErr = nil
-		return nil, nil, err
-	}
-	return m.builder.Flush()
-}
-
-func (m *mockBuilder) TimeRanges() []multitenancy.TimeRange {
-	return m.builder.TimeRanges()
 }
 
 // A mockCommitter implements the committer interface for tests.

--- a/pkg/dataobj/consumer/processor.go
+++ b/pkg/dataobj/consumer/processor.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
+	"sync"
 	"time"
 
 	"github.com/go-kit/log"
@@ -13,34 +13,55 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/twmb/franz-go/pkg/kgo"
 
-	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
-	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/kafka"
-	"github.com/grafana/loki/v3/pkg/logproto"
 )
-
-// A builder allows mocking of [logsobj.Builder] in tests.
-type builder interface {
-	Append(tenant string, stream logproto.Stream) error
-	GetEstimatedSize() int
-	Flush() (*dataobj.Object, io.Closer, error)
-	TimeRanges() []multitenancy.TimeRange
-	CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataobj.Object, io.Closer, error)
-}
 
 // A flushCommitter allows mocking of flushes in tests.
 type flushCommitter interface {
 	Flush(ctx context.Context, builder builder, reason string, offset int64, earliestRecordTime time.Time) error
 }
 
+// A flushLocker is used to hold a lock for the duration of a flush.
+type flushLocker struct {
+	lock chan struct{}
+}
+
+// newFlushLocker returns a new flushLocker.
+func newFlushLocker() *flushLocker {
+	return &flushLocker{
+		lock: make(chan struct{}, 1),
+	}
+}
+
+// Lock acquires the lock. It blocks until the lock is available or the context is canceled.
+func (l *flushLocker) Lock(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case l.lock <- struct{}{}:
+		return nil
+	}
+}
+
+// Unlock releases the lock.
+func (l *flushLocker) Unlock() {
+	<-l.lock
+}
+
 // A processor receives records and builds data objects from them.
 type processor struct {
 	*services.BasicService
-	builder        builder
+	currentBuilder *logsobj.Builder
+	builderPool    *logsobj.SizedBuilderPool
 	decoder        *kafka.Decoder
 	records        chan *kgo.Record
 	flushCommitter flushCommitter
+	flushLocker    *flushLocker
+
+	// lastFlushError contains the error of the last failed flush.
+	lastFlushErr    error
+	lastFlushErrMtx sync.Mutex
 
 	// lastOffset contains the offset of the last record appended to the data object
 	// builder. It is used to commit the correct offset after a flush.
@@ -78,7 +99,7 @@ type processor struct {
 }
 
 func newProcessor(
-	builder builder,
+	builderPool *logsobj.SizedBuilderPool,
 	records chan *kgo.Record,
 	flushCommitter flushCommitter,
 	idleFlushTimeout time.Duration,
@@ -91,10 +112,11 @@ func newProcessor(
 		panic(err)
 	}
 	p := &processor{
-		builder:          builder,
+		builderPool:      builderPool,
 		decoder:          decoder,
 		records:          records,
 		flushCommitter:   flushCommitter,
+		flushLocker:      newFlushLocker(),
 		idleFlushTimeout: idleFlushTimeout,
 		maxBuilderAge:    maxBuilderAge,
 		metrics:          newMetrics(reg),
@@ -162,20 +184,32 @@ func (p *processor) processRecord(ctx context.Context, rec *kgo.Record) error {
 		return fmt.Errorf("failed to decode stream: %w", err)
 	}
 
+	// Check if we have an active builder, and if not, wait for the next builder
+	// to be available.
+	if err := p.waitForBuilder(ctx); err != nil {
+		return fmt.Errorf("failed to wait for builder: %w", err)
+	}
+
 	if p.shouldFlushDueToMaxAge() {
 		if err := p.flush(ctx, flushReasonMaxAge); err != nil {
 			return fmt.Errorf("failed to flush: %w", err)
 		}
+		if err := p.waitForBuilder(ctx); err != nil {
+			return fmt.Errorf("failed to wait for builder: %w", err)
+		}
 	}
 
-	if err := p.builder.Append(tenant, stream); err != nil {
+	if err := p.currentBuilder.Append(tenant, stream); err != nil {
 		if !errors.Is(err, logsobj.ErrBuilderFull) {
 			return fmt.Errorf("failed to append stream: %w", err)
 		}
 		if err := p.flush(ctx, flushReasonBuilderFull); err != nil {
 			return fmt.Errorf("failed to flush and commit: %w", err)
 		}
-		if err := p.builder.Append(tenant, stream); err != nil {
+		if err := p.waitForBuilder(ctx); err != nil {
+			return fmt.Errorf("failed to wait for builder: %w", err)
+		}
+		if err := p.currentBuilder.Append(tenant, stream); err != nil {
 			return fmt.Errorf("failed to append stream after flushing: %w", err)
 		}
 	}
@@ -194,7 +228,8 @@ func (p *processor) processRecord(ctx context.Context, rec *kgo.Record) error {
 
 func (p *processor) shouldFlushDueToMaxAge() bool {
 	return p.maxBuilderAge > 0 &&
-		p.builder.GetEstimatedSize() > 0 &&
+		p.currentBuilder != nil &&
+		p.currentBuilder.GetEstimatedSize() > 0 &&
 		!p.firstAppend.IsZero() &&
 		time.Since(p.firstAppend) > p.maxBuilderAge
 }
@@ -222,22 +257,42 @@ func (p *processor) needsIdleFlush() bool {
 	// This is a safety check to make sure we never flush empty data objects.
 	// It should never happen that lastAppend is non-zero while the builder
 	// is empty.
-	if p.builder.GetEstimatedSize() == 0 {
+	if p.currentBuilder == nil || p.currentBuilder.GetEstimatedSize() == 0 {
 		return false
 	}
 	return time.Since(p.lastAppend) > p.idleFlushTimeout
 }
 
 func (p *processor) flush(ctx context.Context, reason string) error {
-	defer func() {
-		// Reset the state to prepare for building the next data object.
-		p.earliestRecordTime = time.Time{}
-		p.firstAppend = time.Time{}
-		p.lastAppend = time.Time{}
-	}()
-	return p.flushCommitter.Flush(ctx, p.builder, reason, p.lastOffset, p.earliestRecordTime)
+	if err := p.flushLocker.Lock(ctx); err != nil {
+		return err
+	}
+	go p.doFlush(ctx, p.currentBuilder, reason, p.lastOffset, p.earliestRecordTime)
+	// Reset the state to prepare for building the next data object.
+	p.earliestRecordTime = time.Time{}
+	p.firstAppend = time.Time{}
+	p.lastAppend = time.Time{}
+	p.currentBuilder = nil
+	return nil
 }
 
+func (p *processor) doFlush(ctx context.Context, builder *logsobj.Builder, reason string, offset int64, earliestRecordTime time.Time) {
+	defer func() {
+		// When the flush is complete, we must return the builder to the pool
+		// and also release the lock so the next flush can occur.
+		p.builderPool.Put(builder)
+		p.flushLocker.Unlock()
+	}()
+	err := p.flushCommitter.Flush(ctx, builder, reason, offset, earliestRecordTime)
+	if err != nil {
+		level.Error(p.logger).Log("msg", "failed to flush data object", "error", err)
+		p.lastFlushErrMtx.Lock()
+		p.lastFlushErr = err
+		p.lastFlushErrMtx.Unlock()
+	}
+}
+
+// observeRecord updates the metrics each time a record is fetched.
 func (p *processor) observeRecord(rec *kgo.Record, now time.Time) {
 	p.metrics.records.Inc()
 	p.metrics.receivedBytes.Add(float64(len(rec.Value)))
@@ -245,7 +300,32 @@ func (p *processor) observeRecord(rec *kgo.Record, now time.Time) {
 	p.metrics.setConsumptionLag(now.Sub(rec.Timestamp))
 }
 
+// observeRecordErr updates metrics when a record could not be processed and
+// must be discarded.
 func (p *processor) observeRecordErr(rec *kgo.Record) {
 	p.metrics.recordFailures.Inc()
 	p.metrics.discardedBytes.Add(float64(len(rec.Value)))
+}
+
+// waitForBuilder checks if we have a current builder, and if not, waits for one
+// to be available, or for the context to be canceled, whichever happens first.
+func (p *processor) waitForBuilder(ctx context.Context) error {
+	if p.currentBuilder == nil {
+		var err error
+		p.currentBuilder, err = p.builderPool.Wait(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Used in tests. If there is a flush in-progress, it waits until it completes,
+// or the context is canceled, whichever happens first.
+func (p *processor) waitForFlush(ctx context.Context) error {
+	if err := p.flushLocker.Lock(ctx); err != nil {
+		return err
+	}
+	p.flushLocker.Unlock()
+	return nil
 }

--- a/pkg/dataobj/consumer/processor_test.go
+++ b/pkg/dataobj/consumer/processor_test.go
@@ -39,8 +39,9 @@ func TestProcessor_BuilderMaxAge(t *testing.T) {
 			ctx            = t.Context()
 			reg            = prometheus.NewRegistry()
 			builder        = newTestBuilder(t, reg)
+			builderPool    = logsobj.NewSizedBuilderPool([]*logsobj.Builder{builder})
 			flushCommitter = &mockFlushCommitter{}
-			proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+			proc           = newProcessor(builderPool, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 		)
 
 		// Since no records have been pushed, the first append time should be zero,
@@ -51,7 +52,7 @@ func TestProcessor_BuilderMaxAge(t *testing.T) {
 		// Process a record containing some log lines. No flush should occur because
 		// the builder has not reached the maximum age.
 		require.NoError(t, proc.processRecord(ctx, newTestRecord(t, "tenant1", time.Now())))
-
+		require.NoError(t, proc.waitForFlush(ctx))
 		// The first append time should be set to the current time, but no flush
 		// should have occurred.
 		require.Equal(t, time.Now(), proc.firstAppend)
@@ -63,12 +64,13 @@ func TestProcessor_BuilderMaxAge(t *testing.T) {
 		// object, not the one that was just flushed.
 		time.Sleep(31 * time.Minute)
 		require.NoError(t, proc.processRecord(ctx, newTestRecord(t, "tenant1", time.Now())))
+		require.NoError(t, proc.waitForFlush(ctx))
 
 		// The last flushed time should be updated to the current time, and so should
 		// the first append time to reflect the start of the new data object.
 		require.Equal(t, time.Now(), proc.firstAppend)
 		require.Equal(t, time.Now(), proc.lastAppend)
-		require.NotEqual(t, proc.builder.GetEstimatedSize(), 0)
+		require.NotEqual(t, builder.GetEstimatedSize(), 0)
 		require.Equal(t, 1, flushCommitter.flushes)
 
 		// Advance time one last time and push some more logs. No flush should
@@ -76,8 +78,10 @@ func TestProcessor_BuilderMaxAge(t *testing.T) {
 		expectedLastFlushed := time.Now()
 		time.Sleep(time.Minute)
 		require.NoError(t, proc.processRecord(ctx, newTestRecord(t, "tenant1", time.Now())))
+		require.NoError(t, proc.waitForFlush(ctx))
 		require.Equal(t, expectedLastFlushed, proc.firstAppend)
 		require.Equal(t, time.Now(), proc.lastAppend)
+		require.NoError(t, proc.waitForFlush(ctx))
 		require.Equal(t, 1, flushCommitter.flushes)
 	})
 }
@@ -88,14 +92,16 @@ func TestPartitionProcessor_IdleFlush(t *testing.T) {
 			ctx            = t.Context()
 			reg            = prometheus.NewRegistry()
 			builder        = newTestBuilder(t, reg)
+			builderPool    = logsobj.NewSizedBuilderPool([]*logsobj.Builder{builder})
 			flushCommitter = &mockFlushCommitter{}
-			proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+			proc           = newProcessor(builderPool, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 		)
 
 		// The idle flush timeout has not been exceeded, no flush should occur.
 		flushed, err := proc.idleFlush(ctx)
 		require.NoError(t, err)
 		require.False(t, flushed)
+		require.NoError(t, proc.waitForFlush(ctx))
 		require.Equal(t, 0, flushCommitter.flushes)
 
 		// Advance time past the idle flush time. No flush should occur because
@@ -104,6 +110,7 @@ func TestPartitionProcessor_IdleFlush(t *testing.T) {
 		flushed, err = proc.idleFlush(ctx)
 		require.NoError(t, err)
 		require.False(t, flushed)
+		require.NoError(t, proc.waitForFlush(ctx))
 		require.Equal(t, 0, flushCommitter.flushes)
 
 		// Process a record containing some log lines. No flush should occur because
@@ -113,6 +120,7 @@ func TestPartitionProcessor_IdleFlush(t *testing.T) {
 		flushed, err = proc.idleFlush(ctx)
 		require.NoError(t, err)
 		require.False(t, flushed)
+		require.NoError(t, proc.waitForFlush(ctx))
 		require.Equal(t, 0, flushCommitter.flushes)
 
 		// Advance time past the idle timeout. A flush should occur.
@@ -120,6 +128,7 @@ func TestPartitionProcessor_IdleFlush(t *testing.T) {
 		flushed, err = proc.idleFlush(ctx)
 		require.NoError(t, err)
 		require.True(t, flushed)
+		require.NoError(t, proc.waitForFlush(ctx))
 		require.Equal(t, 1, flushCommitter.flushes)
 	})
 }
@@ -144,8 +153,9 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 				ctx            = t.Context()
 				reg            = prometheus.NewRegistry()
 				builder        = newTestBuilder(t, reg)
+				builderPool    = logsobj.NewSizedBuilderPool([]*logsobj.Builder{builder})
 				flushCommitter = &mockFlushCommitter{}
-				proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+				proc           = newProcessor(builderPool, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 			)
 
 			// No flush should have occurred.
@@ -161,6 +171,7 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 			// Advance time and force a flush.
 			time.Sleep(time.Second)
 			require.NoError(t, proc.flush(ctx, "test"))
+			require.NoError(t, proc.waitForFlush(ctx))
 			require.Equal(t, 1, flushCommitter.flushes)
 
 			// The following fields should be reset at the end of every flush.
@@ -176,8 +187,9 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 				ctx            = t.Context()
 				reg            = prometheus.NewRegistry()
 				builder        = newTestBuilder(t, reg)
+				builderPool    = logsobj.NewSizedBuilderPool([]*logsobj.Builder{builder})
 				flushCommitter = &failureFlushCommitter{}
-				proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+				proc           = newProcessor(builderPool, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 			)
 
 			// Process a record containing some log lines. No flush should occur.
@@ -189,7 +201,9 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 
 			// Advance time and force a flush. This flush should fail.
 			time.Sleep(time.Second)
-			require.EqualError(t, proc.flush(ctx, "forced"), "mock error")
+			require.NoError(t, proc.flush(ctx, "forced"))
+			require.NoError(t, proc.waitForFlush(ctx))
+			require.EqualError(t, proc.lastFlushErr, "mock error")
 
 			// Despite the failure, the following fields should still be reset.
 			require.True(t, proc.firstAppend.IsZero())

--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -154,10 +154,17 @@ func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objsto
 	wrapped := prometheus.WrapRegistererWith(prometheus.Labels{
 		"partition": strconv.Itoa(int(partitionID)),
 	}, reg)
-	builder, err := builderFactory.NewBuilder(wrapped)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize data object builder: %w", err)
+	builders := make([]*logsobj.Builder, 0)
+	for i := 0; i < 2; i++ {
+		builder, err := builderFactory.NewBuilder(prometheus.WrapRegistererWith(prometheus.Labels{
+			"builder": strconv.Itoa(i),
+		}, wrapped))
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize data object builder: %w", err)
+		}
+		builders = append(builders, builder)
 	}
+	builderPool := logsobj.NewSizedBuilderPool(builders)
 	flushCommitter := newFlushCommitter(
 		s.flusher,
 		newMetastoreEvents(partitionID, int32(mCfg.PartitionRatio), metastoreEvents),
@@ -167,7 +174,7 @@ func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objsto
 		wrapped,
 	)
 	s.processor = newProcessor(
-		builder,
+		builderPool,
 		records,
 		flushCommitter,
 		cfg.IdleFlushTimeout,


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds support for flushing in parallel (in the background), while we build another data object in the main thread. This prevents pipeline stalls and lets us run fewer consumers reducing TCO.

I have been very careful here to ensure we don't commit the wrong offsets, and avoid data loss.

1. I allow only one flush to run at a time, and as a result of this, I also guarantee that they run in order too.
2. If the first batch fails, and exceeds all its retries, I intentionally crash the process and let K8s restart it. This prevents data loss where the first batch fails, the second batch succeeds, and then we accidentally commit the offsets for the first batch.

Why crash? Well, stopping the pipeline and resetting the Kafka consumer is much more complex and error-prone. I want to keep it simple to start with and then add complexity if needed later on.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
