### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/sources/operations/troubleshooting/_index.md
+++ b/docs/sources/operations/troubleshooting/_index.md
@@ -10,7 +10,7 @@ aliases:
 
 The section provides information to help you troubleshoot issues with Grafana Loki.
 
-* [Troubleshoot operations](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/troubleshooting/troubleshooting-operations/)
+* [Troubleshoot operations](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/troubleshooting/troubleshoot-operations/)
 * [Troubleshoot ingestion (write)](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/troubleshooting/troubleshoot-ingest/)
 * [Troubleshoot Logs Drilldown](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/troubleshooting/troubleshoot-drilldown/)
 * [Troubleshoot querying (read)](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/troubleshooting/troubleshoot-query/)


### PR DESCRIPTION
**What this PR does / why we need it**:

Along with backporting the file rename (https://github.com/grafana/loki/pull/21127 and https://github.com/grafana/loki/pull/21128), will fix two broken links on the Troubleshooting landing page.  The two backports should be merged before this PR.