### PR TITLE
feat: add builder pool to logsobj package

### DIFF
--- a/pkg/dataobj/consumer/logsobj/pool.go
+++ b/pkg/dataobj/consumer/logsobj/pool.go
@@ -1,0 +1,47 @@
+package logsobj
+
+import (
+	"context"
+)
+
+// A SizedBuilderPool implements a fixed-size pool of builders.
+type SizedBuilderPool struct {
+	builders chan *Builder
+}
+
+// NewSizedBuilderPool returns a new SizedBuilderPool.
+func NewSizedBuilderPool(builders []*Builder) *SizedBuilderPool {
+	p := &SizedBuilderPool{builders: make(chan *Builder, len(builders))}
+	for _, b := range builders {
+		p.builders <- b
+	}
+	return p
+}
+
+// Get returns the next builder in the pool. If there are no builders available,
+// because the pool is currently empty, it returns nil instead.
+func (p *SizedBuilderPool) Get() *Builder {
+	select {
+	case res := <-p.builders:
+		return res
+	default:
+		return nil
+	}
+}
+
+// Wait returns the next builder in the pool. If there are no builders available,
+// because the pool is currently empty, it blocks until either a builder becomes
+// available or the context is canceled.
+func (p *SizedBuilderPool) Wait(ctx context.Context) (*Builder, error) {
+	select {
+	case res := <-p.builders:
+		return res, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// Put returns the builder to the pool.
+func (p *SizedBuilderPool) Put(b *Builder) {
+	p.builders <- b
+}

--- a/pkg/dataobj/consumer/logsobj/pool_test.go
+++ b/pkg/dataobj/consumer/logsobj/pool_test.go
@@ -1,0 +1,52 @@
+package logsobj
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/scratch"
+)
+
+func TestSizedBuilderPool(t *testing.T) {
+	t.Run("Get returns the next builder, and nil when the pool is empty", func(t *testing.T) {
+		builder, err := NewBuilder(testBuilderConfig, scratch.NewMemory())
+		require.NoError(t, err)
+		pool := NewSizedBuilderPool([]*Builder{builder})
+		// The first call to [Get] should return the builder.
+		require.NotNil(t, pool.Get())
+		// The second call to [Get] should return nil as the pool has a fixed size
+		// of 1.
+		require.Nil(t, pool.Get())
+		// If we put the builder back in the pool, we should be able to fetch it
+		// once more.
+		pool.Put(builder)
+		require.NotNil(t, pool.Get())
+		require.Nil(t, pool.Get())
+	})
+
+	t.Run("Wait blocks until a builder is available", func(t *testing.T) {
+		builder, err := NewBuilder(testBuilderConfig, scratch.NewMemory())
+		require.NoError(t, err)
+		pool := NewSizedBuilderPool([]*Builder{builder})
+		// The first call to [Wait] should not block.
+		timedCtx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+		b, err := pool.Wait(timedCtx)
+		require.NoError(t, err)
+		require.NotNil(t, b)
+		// The second call to [Wait] should timeout.
+		b, err = pool.Wait(timedCtx)
+		require.EqualError(t, err, "context deadline exceeded")
+		require.Nil(t, b)
+		// Put the builder back in the pool.
+		pool.Put(builder)
+		timedCtx, cancel = context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+		b, err = pool.Wait(timedCtx)
+		require.NoError(t, err)
+		require.NotNil(t, b)
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds a builder pool to the `logsobj` package. This pool will be used for both parallel flushes and the testing time-based builders.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
