### PR TITLE
chore: rename flushManager to flushCommitter to prepare for future changes

### DIFF
--- a/pkg/dataobj/consumer/flush_committer.go
+++ b/pkg/dataobj/consumer/flush_committer.go
@@ -27,8 +27,8 @@ type flusher interface {
 	Flush(ctx context.Context, builder builder, reason string) (string, error)
 }
 
-// A flushManagerImpl manages the flushing of data objects and commits.
-type flushManagerImpl struct {
+// A flushCommitterImpl manages the flushing of data objects and commits.
+type flushCommitterImpl struct {
 	flusher         flusher
 	metastoreEvents metastoreEventEmitter
 	committer       committer
@@ -40,15 +40,15 @@ type flushManagerImpl struct {
 	commitFailures prometheus.Counter
 }
 
-func newFlushManager(
+func newFlushCommitter(
 	flusher flusher,
 	metastoreEvents metastoreEventEmitter,
 	committer committer,
 	partition int32,
 	logger log.Logger,
 	r prometheus.Registerer,
-) *flushManagerImpl {
-	return &flushManagerImpl{
+) *flushCommitterImpl {
+	return &flushCommitterImpl{
 		flusher:         flusher,
 		metastoreEvents: metastoreEvents,
 		committer:       committer,
@@ -66,16 +66,16 @@ func newFlushManager(
 }
 
 // Flush the data object builder and, if successful, commit the offset.
-func (m *flushManagerImpl) Flush(ctx context.Context, builder builder, reason string, offset int64, earliestRecordTime time.Time) error {
-	objectPath, err := m.flusher.Flush(ctx, builder, reason)
+func (c *flushCommitterImpl) Flush(ctx context.Context, builder builder, reason string, offset int64, earliestRecordTime time.Time) error {
+	objectPath, err := c.flusher.Flush(ctx, builder, reason)
 	if err != nil {
 		return fmt.Errorf("failed to flush data object: %w", err)
 	}
-	if err := m.emitEvent(ctx, objectPath, earliestRecordTime); err != nil {
+	if err := c.emitEvent(ctx, objectPath, earliestRecordTime); err != nil {
 		return fmt.Errorf("failed to emit metastore event: %w", err)
 	}
-	if err := m.commit(ctx, offset); err != nil {
-		m.commitFailures.Inc()
+	if err := c.commit(ctx, offset); err != nil {
+		c.commitFailures.Inc()
 		return fmt.Errorf("failed to commit data object: %w", err)
 	}
 	return nil
@@ -83,7 +83,7 @@ func (m *flushManagerImpl) Flush(ctx context.Context, builder builder, reason st
 
 // emitEvent emits a metastore event for the object, retries with exponential
 // backoff until successful or the context is canceled.
-func (m *flushManagerImpl) emitEvent(ctx context.Context, objectPath string, earliestRecordTime time.Time) error {
+func (c *flushCommitterImpl) emitEvent(ctx context.Context, objectPath string, earliestRecordTime time.Time) error {
 	b := backoff.New(ctx, backoff.Config{
 		MinBackoff: 100 * time.Millisecond,
 		MaxBackoff: 10 * time.Second,
@@ -91,11 +91,11 @@ func (m *flushManagerImpl) emitEvent(ctx context.Context, objectPath string, ear
 	})
 	var lastErr error
 	for b.Ongoing() {
-		lastErr = m.metastoreEvents.Emit(ctx, objectPath, earliestRecordTime)
+		lastErr = c.metastoreEvents.Emit(ctx, objectPath, earliestRecordTime)
 		if lastErr == nil {
 			break
 		}
-		level.Warn(m.logger).Log("msg", "failed to emit metastore event", "err", lastErr, "attempt", b.NumRetries())
+		level.Warn(c.logger).Log("msg", "failed to emit metastore event", "err", lastErr, "attempt", b.NumRetries())
 		b.Wait()
 	}
 	return lastErr
@@ -103,21 +103,21 @@ func (m *flushManagerImpl) emitEvent(ctx context.Context, objectPath string, ear
 
 // commits the offset, retries with exponential backoff until successful or
 // the context is canceled.
-func (m *flushManagerImpl) commit(ctx context.Context, offset int64) error {
+func (c *flushCommitterImpl) commit(ctx context.Context, offset int64) error {
 	b := backoff.New(ctx, backoff.Config{
 		MinBackoff: 100 * time.Millisecond,
 		MaxBackoff: 10 * time.Second,
 		MaxRetries: 0,
 	})
-	m.commits.Inc()
+	c.commits.Inc()
 	var lastErr error
 	for b.Ongoing() {
-		lastErr = m.committer.Commit(ctx, m.partition, offset)
+		lastErr = c.committer.Commit(ctx, c.partition, offset)
 		if lastErr == nil {
-			level.Debug(m.logger).Log("msg", "committed offset", "partition", m.partition, "offset", offset)
+			level.Debug(c.logger).Log("msg", "committed offset", "partition", c.partition, "offset", offset)
 			break
 		}
-		level.Warn(m.logger).Log("msg", "failed to commit offset", "err", lastErr, "attempt", b.NumRetries())
+		level.Warn(c.logger).Log("msg", "failed to commit offset", "err", lastErr, "attempt", b.NumRetries())
 		b.Wait()
 	}
 	return lastErr

--- a/pkg/dataobj/consumer/flush_committer_test.go
+++ b/pkg/dataobj/consumer/flush_committer_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
-func TestFlushManager(t *testing.T) {
+func TestFlushCommitter(t *testing.T) {
 	t.Run("should succeed", func(t *testing.T) {
 		var (
 			now             = time.Now()
@@ -22,7 +22,7 @@ func TestFlushManager(t *testing.T) {
 			metastoreKafka  = &mockKafka{}
 			metastoreEvents = newMetastoreEvents(1, 10, metastoreKafka)
 			committer       = &mockCommitter{}
-			flushManager    = newFlushManager(flusher, metastoreEvents, committer, 0, log.NewNopLogger(), reg)
+			flushCommitter  = newFlushCommitter(flusher, metastoreEvents, committer, 0, log.NewNopLogger(), reg)
 		)
 		// Create a builder and append some logs so it can be flushed.
 		builder := newTestBuilder(t, reg)
@@ -32,7 +32,7 @@ func TestFlushManager(t *testing.T) {
 				{Timestamp: now, Line: "test"},
 			},
 		}))
-		require.NoError(t, flushManager.Flush(t.Context(), builder, "test", 1, now))
+		require.NoError(t, flushCommitter.Flush(t.Context(), builder, "test", 1, now))
 		// A flush should have occurred, a metastore event emitted, and the correct
 		// offset was committed.
 		require.Equal(t, 1, flusher.flushes)
@@ -58,7 +58,7 @@ func TestFlushManager(t *testing.T) {
 			metastoreKafka  = &mockKafka{}
 			metastoreEvents = newMetastoreEvents(1, 10, metastoreKafka)
 			committer       = &mockCommitter{}
-			flushManager    = newFlushManager(flusher, metastoreEvents, committer, 0, log.NewNopLogger(), reg)
+			flushCommitter  = newFlushCommitter(flusher, metastoreEvents, committer, 0, log.NewNopLogger(), reg)
 		)
 		// Create a builder and append some logs so it can be flushed.
 		builder := newTestBuilder(t, reg)
@@ -68,7 +68,7 @@ func TestFlushManager(t *testing.T) {
 				{Timestamp: now, Line: "test"},
 			},
 		}))
-		flushErr := flushManager.Flush(t.Context(), builder, "test", 1, now)
+		flushErr := flushCommitter.Flush(t.Context(), builder, "test", 1, now)
 		require.EqualError(t, flushErr, "failed to flush data object: mock error")
 		// Since no flush occurred, no event should be emitted and no offsets
 		// should be committed either.

--- a/pkg/dataobj/consumer/mock_test.go
+++ b/pkg/dataobj/consumer/mock_test.go
@@ -150,11 +150,11 @@ func (m *mockFlusher) Flush(_ context.Context, _ builder, _ string) (string, err
 	return "", nil
 }
 
-type mockFlushManager struct {
+type mockFlushCommitter struct {
 	flushes int
 }
 
-func (m *mockFlushManager) Flush(_ context.Context, _ builder, _ string, _ int64, _ time.Time) error {
+func (m *mockFlushCommitter) Flush(_ context.Context, _ builder, _ string, _ int64, _ time.Time) error {
 	m.flushes++
 	return nil
 }

--- a/pkg/dataobj/consumer/processor.go
+++ b/pkg/dataobj/consumer/processor.go
@@ -29,18 +29,18 @@ type builder interface {
 	CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataobj.Object, io.Closer, error)
 }
 
-// A flushManager allows mocking of flushes in tests.
-type flushManager interface {
+// A flushCommitter allows mocking of flushes in tests.
+type flushCommitter interface {
 	Flush(ctx context.Context, builder builder, reason string, offset int64, earliestRecordTime time.Time) error
 }
 
 // A processor receives records and builds data objects from them.
 type processor struct {
 	*services.BasicService
-	builder      builder
-	decoder      *kafka.Decoder
-	records      chan *kgo.Record
-	flushManager flushManager
+	builder        builder
+	decoder        *kafka.Decoder
+	records        chan *kgo.Record
+	flushCommitter flushCommitter
 
 	// lastOffset contains the offset of the last record appended to the data object
 	// builder. It is used to commit the correct offset after a flush.
@@ -80,7 +80,7 @@ type processor struct {
 func newProcessor(
 	builder builder,
 	records chan *kgo.Record,
-	flushManager flushManager,
+	flushCommitter flushCommitter,
 	idleFlushTimeout time.Duration,
 	maxBuilderAge time.Duration,
 	logger log.Logger,
@@ -94,7 +94,7 @@ func newProcessor(
 		builder:          builder,
 		decoder:          decoder,
 		records:          records,
-		flushManager:     flushManager,
+		flushCommitter:   flushCommitter,
 		idleFlushTimeout: idleFlushTimeout,
 		maxBuilderAge:    maxBuilderAge,
 		metrics:          newMetrics(reg),
@@ -235,7 +235,7 @@ func (p *processor) flush(ctx context.Context, reason string) error {
 		p.firstAppend = time.Time{}
 		p.lastAppend = time.Time{}
 	}()
-	return p.flushManager.Flush(ctx, p.builder, reason, p.lastOffset, p.earliestRecordTime)
+	return p.flushCommitter.Flush(ctx, p.builder, reason, p.lastOffset, p.earliestRecordTime)
 }
 
 func (p *processor) observeRecord(rec *kgo.Record, now time.Time) {

--- a/pkg/dataobj/consumer/processor_test.go
+++ b/pkg/dataobj/consumer/processor_test.go
@@ -36,17 +36,17 @@ var (
 func TestProcessor_BuilderMaxAge(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		var (
-			ctx          = t.Context()
-			reg          = prometheus.NewRegistry()
-			builder      = newTestBuilder(t, reg)
-			flushManager = &mockFlushManager{}
-			proc         = newProcessor(builder, nil, flushManager, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+			ctx            = t.Context()
+			reg            = prometheus.NewRegistry()
+			builder        = newTestBuilder(t, reg)
+			flushCommitter = &mockFlushCommitter{}
+			proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 		)
 
 		// Since no records have been pushed, the first append time should be zero,
 		// and no flush should have occurred.
 		require.True(t, proc.firstAppend.IsZero())
-		require.Equal(t, 0, flushManager.flushes)
+		require.Equal(t, 0, flushCommitter.flushes)
 
 		// Process a record containing some log lines. No flush should occur because
 		// the builder has not reached the maximum age.
@@ -56,7 +56,7 @@ func TestProcessor_BuilderMaxAge(t *testing.T) {
 		// should have occurred.
 		require.Equal(t, time.Now(), proc.firstAppend)
 		require.Equal(t, time.Now(), proc.lastAppend)
-		require.Equal(t, 0, flushManager.flushes)
+		require.Equal(t, 0, flushCommitter.flushes)
 
 		// Advance time past the maximum age. A flush should occur, and the
 		// the log lines from the record should be appended to the next data
@@ -69,7 +69,7 @@ func TestProcessor_BuilderMaxAge(t *testing.T) {
 		require.Equal(t, time.Now(), proc.firstAppend)
 		require.Equal(t, time.Now(), proc.lastAppend)
 		require.NotEqual(t, proc.builder.GetEstimatedSize(), 0)
-		require.Equal(t, 1, flushManager.flushes)
+		require.Equal(t, 1, flushCommitter.flushes)
 
 		// Advance time one last time and push some more logs. No flush should
 		// occur because the next builder has not reached the maximum age.
@@ -78,25 +78,25 @@ func TestProcessor_BuilderMaxAge(t *testing.T) {
 		require.NoError(t, proc.processRecord(ctx, newTestRecord(t, "tenant1", time.Now())))
 		require.Equal(t, expectedLastFlushed, proc.firstAppend)
 		require.Equal(t, time.Now(), proc.lastAppend)
-		require.Equal(t, 1, flushManager.flushes)
+		require.Equal(t, 1, flushCommitter.flushes)
 	})
 }
 
 func TestPartitionProcessor_IdleFlush(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		var (
-			ctx          = t.Context()
-			reg          = prometheus.NewRegistry()
-			builder      = newTestBuilder(t, reg)
-			flushManager = &mockFlushManager{}
-			proc         = newProcessor(builder, nil, flushManager, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+			ctx            = t.Context()
+			reg            = prometheus.NewRegistry()
+			builder        = newTestBuilder(t, reg)
+			flushCommitter = &mockFlushCommitter{}
+			proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 		)
 
 		// The idle flush timeout has not been exceeded, no flush should occur.
 		flushed, err := proc.idleFlush(ctx)
 		require.NoError(t, err)
 		require.False(t, flushed)
-		require.Equal(t, 0, flushManager.flushes)
+		require.Equal(t, 0, flushCommitter.flushes)
 
 		// Advance time past the idle flush time. No flush should occur because
 		// the builder is empty.
@@ -104,7 +104,7 @@ func TestPartitionProcessor_IdleFlush(t *testing.T) {
 		flushed, err = proc.idleFlush(ctx)
 		require.NoError(t, err)
 		require.False(t, flushed)
-		require.Equal(t, 0, flushManager.flushes)
+		require.Equal(t, 0, flushCommitter.flushes)
 
 		// Process a record containing some log lines. No flush should occur because
 		// when log lines are appended to the builder it resets the idle timeout.
@@ -113,14 +113,14 @@ func TestPartitionProcessor_IdleFlush(t *testing.T) {
 		flushed, err = proc.idleFlush(ctx)
 		require.NoError(t, err)
 		require.False(t, flushed)
-		require.Equal(t, 0, flushManager.flushes)
+		require.Equal(t, 0, flushCommitter.flushes)
 
 		// Advance time past the idle timeout. A flush should occur.
 		time.Sleep(6 * time.Minute)
 		flushed, err = proc.idleFlush(ctx)
 		require.NoError(t, err)
 		require.True(t, flushed)
-		require.Equal(t, 1, flushManager.flushes)
+		require.Equal(t, 1, flushCommitter.flushes)
 	})
 }
 
@@ -131,9 +131,9 @@ func (f *failureFlusher) Flush(_ context.Context, _ builder, _ string) (string, 
 	return "", errors.New("mock error")
 }
 
-type failureFlushManager struct{}
+type failureFlushCommitter struct{}
 
-func (m *failureFlushManager) Flush(_ context.Context, _ builder, _ string, _ int64, _ time.Time) error {
+func (m *failureFlushCommitter) Flush(_ context.Context, _ builder, _ string, _ int64, _ time.Time) error {
 	return errors.New("mock error")
 }
 
@@ -141,15 +141,15 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 	t.Run("should succeed", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			var (
-				ctx          = t.Context()
-				reg          = prometheus.NewRegistry()
-				builder      = newTestBuilder(t, reg)
-				flushManager = &mockFlushManager{}
-				proc         = newProcessor(builder, nil, flushManager, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+				ctx            = t.Context()
+				reg            = prometheus.NewRegistry()
+				builder        = newTestBuilder(t, reg)
+				flushCommitter = &mockFlushCommitter{}
+				proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 			)
 
 			// No flush should have occurred.
-			require.Equal(t, 0, flushManager.flushes)
+			require.Equal(t, 0, flushCommitter.flushes)
 
 			// Process a record containing some log lines. No flush should occur.
 			rec1 := newTestRecord(t, "tenant", time.Now())
@@ -161,7 +161,7 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 			// Advance time and force a flush.
 			time.Sleep(time.Second)
 			require.NoError(t, proc.flush(ctx, "test"))
-			require.Equal(t, 1, flushManager.flushes)
+			require.Equal(t, 1, flushCommitter.flushes)
 
 			// The following fields should be reset at the end of every flush.
 			require.True(t, proc.firstAppend.IsZero())
@@ -173,11 +173,11 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 	t.Run("should fail", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			var (
-				ctx          = t.Context()
-				reg          = prometheus.NewRegistry()
-				builder      = newTestBuilder(t, reg)
-				flushManager = &failureFlushManager{}
-				proc         = newProcessor(builder, nil, flushManager, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+				ctx            = t.Context()
+				reg            = prometheus.NewRegistry()
+				builder        = newTestBuilder(t, reg)
+				flushCommitter = &failureFlushCommitter{}
+				proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 			)
 
 			// Process a record containing some log lines. No flush should occur.

--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -158,7 +158,7 @@ func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objsto
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize data object builder: %w", err)
 	}
-	flushManager := newFlushManager(
+	flushCommitter := newFlushCommitter(
 		s.flusher,
 		newMetastoreEvents(partitionID, int32(mCfg.PartitionRatio), metastoreEvents),
 		committer,
@@ -169,7 +169,7 @@ func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objsto
 	s.processor = newProcessor(
 		builder,
 		records,
-		flushManager,
+		flushCommitter,
 		cfg.IdleFlushTimeout,
 		cfg.MaxBuilderAge,
 		logger,


### PR DESCRIPTION
**What this PR does / why we need it**:

This name is more appropriate given the changes I am making for parallel flushing and time based objects.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
