### PR TITLE
fix: add uid to canary dashboard

### DIFF
--- a/production/loki-mixin/dashboards/loki-canary-dashboard.libsonnet
+++ b/production/loki-mixin/dashboards/loki-canary-dashboard.libsonnet
@@ -30,6 +30,7 @@ local grafana = import 'grafonnet/grafana.libsonnet';
         // This dashboard uses the new grid system in order to place panels (using gridPos).
         // Because of this we can't use the mixin's addRow() and addPanel().
         schemaVersion: 27,
+        uid: 'canary',
         rows: null,
         // ugly hack, copy pasta the tag/link
         // code from the loki-mixin


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding uid to canary dashboard. All other dashboards have a uid: e.g. `uid='writes-resources'` in https://github.com/grafana/loki/blob/e22a9bed508b1fdda24aa7ecb5d16e618770d97b/production/loki-mixin/dashboards/loki-writes-resources.libsonnet

If no UID is provided, one is automatically generated when the Canary dashboard is added to Grafana via IAC (Pulumi). As a result, the dashboard JSON differs from the IAC state, causing the dashboard resource to always appear as changed in resource updates.

Thank you!