### PR TITLE
fix: sanitize User-Agent to valid UTF-8 before using as Prometheus label value

### DIFF
--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -269,6 +269,9 @@ func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, maxDecom
 	}
 
 	userAgent := r.Header.Get("User-Agent")
+	// Sanitize the User-Agent to valid UTF-8 to prevent prometheus from panicking
+	// when it's used as a label value in WithLabelValues.
+	userAgent = strings.ToValidUTF8(userAgent, "")
 	if userAgent != "" {
 		logValues = append(logValues, "userAgent", strings.TrimSpace(userAgent))
 	}

--- a/pkg/loghttp/push/push_test.go
+++ b/pkg/loghttp/push/push_test.go
@@ -78,6 +78,7 @@ func TestParseRequest(t *testing.T) {
 		body                            string
 		contentType                     string
 		contentEncoding                 string
+		userAgent                       string
 		valid                           bool
 		enableServiceDiscovery          bool
 		expectedStructuredMetadataBytes map[string]int
@@ -339,6 +340,17 @@ func TestParseRequest(t *testing.T) {
 			expectedLabels:                  []labels.Labels{labels.FromStrings("foo", "bar2", "environment", "prod")},
 			expectedStructuredMetadataBytes: map[string]int{"prod": len("name1") + len("value1")},
 		},
+		{
+			path:                      `/loki/api/v1/push`,
+			body:                      fmt.Sprintf(`{"streams": [{"stream": {"foo": "bar2"}, "values": [["%d", "fizzbuzz"]]}]}`, time.Now().UnixNano()),
+			contentType:               `application/json`,
+			userAgent:                 "\xe5\xe5\xe5\xe5\xe5\xe5; Intel Mac OS X 10.15; rv:148.0) Gecko/20100101 Firefox/148.0",
+			valid:                     true,
+			expectedBytes:             map[string]int{"": len("fizzbuzz")},
+			expectedLines:             map[string]int{"": 1},
+			expectedBytesUsageTracker: map[string]float64{`{foo="bar2"}`: float64(len("fizzbuzz"))},
+			expectedLabels:            []labels.Labels{labels.FromStrings("foo", "bar2")},
+		},
 	} {
 		t.Run(fmt.Sprintf("test %d", index), func(t *testing.T) {
 			streamResolver := newMockStreamResolver("fake", test.fakeLimits)
@@ -356,6 +368,9 @@ func TestParseRequest(t *testing.T) {
 			}
 			if len(test.contentEncoding) > 0 {
 				request.Header.Add("Content-Encoding", test.contentEncoding)
+			}
+			if len(test.userAgent) > 0 {
+				request.Header.Set("User-Agent", test.userAgent)
 			}
 
 			tracker := NewMockTracker()


### PR DESCRIPTION
**What this PR does / why we need it**:

Sanitizes the `User-Agent` HTTP header to valid UTF-8 before passing it to `prometheus.CounterVec.WithLabelValues()` in the push path. Invalid UTF-8 bytes in the User-Agent (e.g. `\xe5\xe5\xe5...`) cause `WithLabelValues` to panic, crashing the distributor.

The fix uses `strings.ToValidUTF8(userAgent, "")` to strip invalid UTF-8 sequences before the value is used as a Prometheus label.

**Which issue(s) this PR fixes**:
Fixes distributor panic on push requests with invalid UTF-8 User-Agent headers.

**Special notes for your reviewer**:
The panic was observed in production with a User-Agent containing raw `\xe5` bytes. The regression test uses a recent timestamp to ensure the `distributorLagByUserAgent` code path is exercised.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.