### PR TITLE
fix: broken get and replace for s3 client

### DIFF
--- a/pkg/storage/bucket/client.go
+++ b/pkg/storage/bucket/client.go
@@ -1,10 +1,12 @@
 package bucket
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -236,6 +238,8 @@ func NewClient(ctx context.Context, backend string, cfg Config, name string, log
 		client = NewPrefixedBucketClient(client, cfg.StoragePrefix)
 	}
 
+	client = newSizedGetAndReplaceBucket(client)
+
 	instrumentedClient := objstoretracing.WrapWithTraces(objstore.WrapWith(client, metrics))
 
 	// Wrap the client with any provided middleware
@@ -273,4 +277,44 @@ func (i *instrumentedRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	bucketRequestsDuration.WithLabelValues(statusCode, req.Method).Observe(time.Since(start).Seconds())
 
 	return resp, nil
+}
+
+// sizedGetAndReplaceBucket wraps a Bucket and guarantees that the io.ReadCloser
+// returned by GetAndReplace callbacks always has a size known to
+// objstore.TryToGetSize. Without this, callers that return opaque ReadClosers
+// (such as io.NopCloser-wrapped readers) cause the S3 backend to fall into the
+// putObjectMultipartStreamNoLength code path in minio-go, which reconstructs
+// PutObjectOptions before CompleteMultipartUpload and silently drops
+// customHeaders — including the If-Match conditional write header set by
+// GetAndReplace. The result is that stale writes are accepted by S3 even when
+// the object's ETag has already changed, breaking the optimistic-concurrency
+// guarantee that GetAndReplace is supposed to provide.
+//
+// The fix buffers the reader when its size cannot be determined upfront.
+// GetAndReplace is only used for small metadata objects (e.g. ToC files), so
+// the buffering cost is negligible.
+type sizedGetAndReplaceBucket struct {
+	objstore.Bucket
+}
+
+func newSizedGetAndReplaceBucket(bkt objstore.Bucket) objstore.Bucket {
+	return &sizedGetAndReplaceBucket{Bucket: bkt}
+}
+
+func (b *sizedGetAndReplaceBucket) GetAndReplace(ctx context.Context, name string, fn func(io.ReadCloser) (io.ReadCloser, error)) error {
+	return b.Bucket.GetAndReplace(ctx, name, func(existing io.ReadCloser) (io.ReadCloser, error) {
+		rc, err := fn(existing)
+		if err != nil || rc == nil {
+			return rc, err
+		}
+		if _, sizeErr := objstore.TryToGetSize(rc); sizeErr == nil {
+			return rc, nil
+		}
+		data, readErr := io.ReadAll(rc)
+		_ = rc.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+		return objstore.NopCloserWithSize(bytes.NewReader(data)), nil
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When GetAndReplace callbacks return opaque io.ReadCloser wrappers (such as io.NopCloser), [objstore.TryToGetSize](https://github.com/thanos-io/objstore/blob/4e5fd4289b5052ec0fed3a27dc025c364a0e354e/objstore.go#L304-L325) cannot determine the content size, [causing minio-go to use a multipart upload path](https://github.com/minio/minio-go/blob/c44cb2ab494db3a58ca2a07b47f674421c6d9350/api-put-object.go#L366-L374) that [silently reconstructs PutObjectOptions before CompleteMultipartUpload, dropping customHeaders](https://github.com/minio/minio-go/blob/c44cb2ab494db3a58ca2a07b47f674421c6d9350/api-put-object.go#L511-L514) and, therefore, the If-Match conditional write header. S3 then accepts the upload unconditionally, allowing a stale-ETag write to overwrite a newer version of the object.

To fix it, I have added sizedGetAndReplaceBucket, which wraps the caller's callback inside GetAndReplace and buffers the returned reader when its size is unknown, replacing it with an objstore.NopCloserWithSize-wrapped bytes.Reader. This gives minio-go a known content length, forcing the single-part PUT path where If-Match is preserved end-to-end.

GetAndReplace is only used to update TOC files, which are not that large, so switching them to a single-part upload should not cause any issues. We can try to fix the issue upstream or change the reader interface to match what objstore.TryToGetSize handles.
