### PR TITLE
feat(query-engine): Omit labels with empty values

### DIFF
--- a/pkg/engine/compat.go
+++ b/pkg/engine/compat.go
@@ -115,7 +115,12 @@ func (b *streamsResultBuilder) CollectRecord(rec arrow.RecordBatch) {
 		case ident.ColumnType() == types.ColumnTypeLabel:
 			labelCol := col.(*array.String)
 			forEachNotNullRowColValue(numRows, labelCol, func(rowIdx int) {
-				b.rowBuilders[rowIdx].lbsBuilder.Set(shortName, labelCol.Value(rowIdx))
+				val := labelCol.Value(rowIdx)
+				if val == "" {
+					// We also drop empty labels from stream labels to match classic Loki engine behavior.
+					return
+				}
+				b.rowBuilders[rowIdx].lbsBuilder.Set(shortName, val)
 			})
 
 		// One of the metadata columns

--- a/pkg/engine/compat_test.go
+++ b/pkg/engine/compat_test.go
@@ -473,6 +473,68 @@ func TestStreamsResultBuilder(t *testing.T) {
 		}
 		require.Equal(t, expected, streams)
 	})
+	t.Run("labels with empty values are dropped from stream labels", func(t *testing.T) {
+		colTs := semconv.ColumnIdentTimestamp
+		colMsg := semconv.ColumnIdentMessage
+		colEnv := semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String)
+		colRegion := semconv.NewIdentifier("region", types.ColumnTypeLabel, types.Loki.String)
+
+		schema := arrow.NewSchema(
+			[]arrow.Field{
+				semconv.FieldFromIdent(colTs, false),
+				semconv.FieldFromIdent(colMsg, false),
+				semconv.FieldFromIdent(colEnv, true),
+				semconv.FieldFromIdent(colRegion, true),
+			},
+			nil,
+		)
+		rows := arrowtest.Rows{
+			{
+				colTs.FQN():     time.Unix(0, 1620000000000000001).UTC(),
+				colMsg.FQN():    "log line 1",
+				colEnv.FQN():    "prod",
+				colRegion.FQN(): "us-west",
+			},
+			{
+				colTs.FQN():     time.Unix(0, 1620000000000000002).UTC(),
+				colMsg.FQN():    "log line 2",
+				colEnv.FQN():    "prod",
+				colRegion.FQN(): "",
+			},
+			{
+				colTs.FQN():     time.Unix(0, 1620000000000000003).UTC(),
+				colMsg.FQN():    "log line 3",
+				colEnv.FQN():    "",
+				colRegion.FQN(): "us-east",
+			},
+		}
+
+		record := rows.Record(memory.DefaultAllocator, schema)
+
+		pipeline := executor.NewBufferedPipeline(record)
+		defer pipeline.Close()
+
+		builder := newStreamsResultBuilder(logproto.FORWARD, false)
+		err := collectResult(context.Background(), pipeline, builder)
+
+		require.NoError(t, err)
+		require.Equal(t, 3, builder.Len())
+
+		md, _ := metadata.NewContext(t.Context())
+		result := builder.Build(stats.Result{}, md)
+		streams := result.Data.(logqlmodel.Streams)
+
+		require.Equal(t, 3, len(streams), "should have 3 unique streams (empty label values dropped)")
+
+		streamLabels := make([]string, len(streams))
+		for i, s := range streams {
+			streamLabels[i] = s.Labels
+		}
+		require.Contains(t, streamLabels, labels.FromStrings("env", "prod", "region", "us-west").String())
+		require.Contains(t, streamLabels, labels.FromStrings("env", "prod").String())
+		require.Contains(t, streamLabels, labels.FromStrings("region", "us-east").String())
+	})
+
 	t.Run("categorize labels does not consider metadata or parsed keys when building output streams", func(t *testing.T) {
 		colTs := semconv.ColumnIdentTimestamp
 		colMsg := semconv.ColumnIdentMessage

--- a/pkg/engine/internal/executor/streams_view.go
+++ b/pkg/engine/internal/executor/streams_view.go
@@ -180,6 +180,11 @@ func (v *streamsView) Labels(ctx context.Context, id int64) ([]labels.Label, err
 			panic(fmt.Sprintf("unexpected column type %T for labels", colValues))
 		}
 
+		// Drop labels with empty values to match classic Loki engine behavior.
+		if label.Value == "" {
+			continue
+		}
+
 		lbs = append(lbs, label)
 	}
 

--- a/pkg/engine/internal/executor/streams_view_test.go
+++ b/pkg/engine/internal/executor/streams_view_test.go
@@ -141,6 +141,33 @@ func Test_streamsView(t *testing.T) {
 		require.Equal(t, expect, actual, "expected all streams to be returned with the proper labels")
 	})
 
+	t.Run("labels with empty values are dropped", func(t *testing.T) {
+		emptyStreams := []labels.Labels{
+			labels.FromStrings("app", "loki", "env", "prod", "region", "us-west"),
+			labels.FromStrings("app", "loki", "env", ""),
+			labels.FromStrings("app", "", "env", "prod"),
+		}
+
+		emptySec := buildStreamsSection(t, emptyStreams)
+
+		view := newStreamsView(emptySec, &streamsViewOptions{
+			BatchSize: 1,
+		})
+		require.NoError(t, view.Open(t.Context()))
+
+		lbs1, err := view.Labels(t.Context(), 1)
+		require.NoError(t, err)
+		require.Equal(t, labels.FromStrings("app", "loki", "env", "prod", "region", "us-west"), labels.New(lbs1...))
+
+		lbs2, err := view.Labels(t.Context(), 2)
+		require.NoError(t, err)
+		require.Equal(t, labels.FromStrings("app", "loki"), labels.New(lbs2...), "empty env value should be dropped")
+
+		lbs3, err := view.Labels(t.Context(), 3)
+		require.NoError(t, err)
+		require.Equal(t, labels.FromStrings("env", "prod"), labels.New(lbs3...), "empty app value should be dropped")
+	})
+
 	t.Run("labels before open returns error", func(t *testing.T) {
 		view := newStreamsView(sec, &streamsViewOptions{BatchSize: 1})
 		lbs, err := view.Labels(t.Context(), 1)


### PR DESCRIPTION
**What this PR does / why we need it**:
To match the same behavior we have for the classic query engine, I'm tweaking the new query engine to omit labels that have empty values. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
