### PR TITLE
fix: WAL replay hang when flush doesn't progress

### DIFF
--- a/pkg/ingester/replay_controller.go
+++ b/pkg/ingester/replay_controller.go
@@ -50,7 +50,7 @@ type replayController struct {
 	currentBytes    atomic.Int64
 	totalSubtracted atomic.Int64 // monotonically increasing; used to detect flush no-progress without being affected by concurrent Add calls
 	cfg             WALConfig
-	metrics      *ingesterMetrics
+	metrics         *ingesterMetrics
 
 	flusher Flusher
 	flushSF singleflight.Group

--- a/pkg/ingester/replay_controller_test.go
+++ b/pkg/ingester/replay_controller_test.go
@@ -142,13 +142,20 @@ func TestReplayControllerPartialProgressFlush(t *testing.T) {
 
 // Test that WithBackPressure does not spuriously error when concurrent workers refill currentBytes
 // during a flush. The flush made real progress (Sub was called), so no error should be returned
-// even though currentBytes ends up higher than before due to concurrent Add calls.
+// even though currentBytes ends up higher than the pre-flush snapshot due to concurrent Add calls.
+//
+// Sequence:
+//  1. bytes=95 > ceiling=90, enter loop; old code snapshots before=95
+//  2. Flush runs: Sub(80) → bytes=15; concurrent goroutine adds 85 → bytes=100
+//  3. Old check: currentBytes(100) >= before(95) → spurious error
+//  4. New check: totalSubtracted increased → no error, loop continues and drains on next flush
 func TestReplayControllerNoSpuriousErrorOnConcurrentAdd(t *testing.T) {
 	var rc *replayController
+	var once sync.Once
 	flushed := make(chan struct{})
 	flusher := newDumbFlusher(func() {
-		rc.Sub(80) // genuine progress: drops bytes from 95 to 15
-		close(flushed)
+		rc.Sub(80)                         // genuine progress each flush
+		once.Do(func() { close(flushed) }) // signal the concurrent goroutine only on first flush
 	})
 	rc = newReplayController(nilMetrics(), WALConfig{ReplayMemoryCeiling: 100}, flusher)
 	rc.Add(95) // above 90% ceiling
@@ -157,10 +164,11 @@ func TestReplayControllerNoSpuriousErrorOnConcurrentAdd(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		// Simulate a concurrent worker adding bytes while the flush is running,
-		// pushing currentBytes back above the before snapshot.
+		// Simulate a concurrent worker adding bytes while the first flush is running,
+		// pushing currentBytes back above the pre-flush snapshot (100 > before=95).
+		// The loop will flush again and drain normally; no error should be returned.
 		<-flushed
-		rc.Add(85) // refills: 15 + 85 = 100, above the original before=95
+		rc.Add(85) // 15 + 85 = 100, above the original before=95
 	}()
 
 	err := rc.WithBackPressure(func() error { return nil })


### PR DESCRIPTION
**What this PR does / why we need it**:
During WAL replay, the ingester uses a backpressure loop to throttle recovery when in-memory bytes exceed 90% of `ReplayMemoryCeiling`. If the flush never reduces memory — because the storage backend is slow, unavailable, or chunks haven't been marked as flushed yet — the loop had no exit condition and would spin forever. This caused ingester pods to hang at startup with no error logged and no corruption detected; the only visible signal was `loki_ingester_wal_replay_active` remaining stuck at 1.

`replay_controller.go` — `WithBackPressure`

- Guard against `ReplayMemoryCeiling == 0`: previously, a zero ceiling computed a threshold of 0, causing the loop to fire immediately on any non-zero byte count. Now backpressure is skipped entirely when the ceiling is unset.
- Detect no-progress flushes: track a monotonically increasing totalSubtracted counter in Sub(). Before each flush, snapshot the counter; if it hasn't increased after the flush completes, the flusher did no work and recovery returns a descriptive error:

`WAL replay flush made no progress: 4.0 GB in use, ceiling 3.6 GB; cannot recover`

Using `totalSubtracted` rather than a before/after comparison of `currentBytes` avoids a false positive: replay runs `GOMAXPROCS` workers concurrently, and other workers can legitimately call `Add()` while a flush is in progress, pushing `currentBytes` back above the pre-flush snapshot even when the flush genuinely freed memory.

Four new test cases:

`TestReplayControllerZeroCeiling` — verifies backpressure is bypassed and the flusher is never called when ReplayMemoryCeiling is zero
`TestReplayControllerNoProgressFlush` — verifies an error is returned when the flusher is a complete no-op
`TestReplayControllerPartialProgressFlush` — verifies an error is returned when the flusher makes partial progress on the first call but stalls on subsequent calls, which is the realistic scenario when a degraded backend drains some chunks but cannot keep up
`TestReplayControllerNoSpuriousErrorOnConcurrentAdd` — verifies that a concurrent `Add()` racing with a genuine flush does not cause a false no-progress error

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
