### PR TITLE
feat(tracing): honor the service name env vars

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -112,7 +112,10 @@ func main() {
 
 	if config.Tracing.Enabled {
 		// Setting the environment variable JAEGER_AGENT_HOST enables tracing
-		trace, err := tracing.NewOTelOrJaegerFromEnv(fmt.Sprintf("loki-%s", config.Target), util_log.Logger)
+		trace, err := tracing.NewOTelOrJaegerFromEnv(
+			util.GetServiceNameFromEnv(fmt.Sprintf("loki-%s", config.Target), "JAEGER_SERVICE_NAME", "OTEL_SERVICE_NAME"),
+			util_log.Logger,
+		)
 		if err != nil {
 			level.Error(util_log.Logger).Log("msg", "error in initializing tracing. tracing will not be enabled", "err", err)
 		}

--- a/cmd/querytee/main.go
+++ b/cmd/querytee/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/querytee"
 	"github.com/grafana/loki/v3/pkg/querytee/comparator"
 	loki_tracing "github.com/grafana/loki/v3/pkg/tracing"
+	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
@@ -41,7 +42,10 @@ func main() {
 
 	// Initialize tracing
 	if cfg.Tracing.Enabled {
-		trace, err := tracing.NewOTelOrJaegerFromEnv("loki-querytee", util_log.Logger)
+		trace, err := tracing.NewOTelOrJaegerFromEnv(
+			util.GetServiceNameFromEnv("loki-querytee", "JAEGER_SERVICE_NAME", "OTEL_SERVICE_NAME"),
+			util_log.Logger,
+		)
 		if err != nil {
 			level.Error(util_log.Logger).Log("msg", "error in initializing tracing. tracing will not be enabled", "err", err)
 			exit(1)

--- a/pkg/util/tracing.go
+++ b/pkg/util/tracing.go
@@ -1,0 +1,15 @@
+package util //nolint:revive
+
+import "os"
+
+// GetServiceNameFromEnv returns the first configured service name from the provided
+// environment variables, or the supplied default when none are set.
+func GetServiceNameFromEnv(defaultName string, envVars ...string) string {
+	for _, envVar := range envVars {
+		if value := os.Getenv(envVar); value != "" {
+			return value
+		}
+	}
+
+	return defaultName
+}

--- a/pkg/util/tracing_test.go
+++ b/pkg/util/tracing_test.go
@@ -1,0 +1,53 @@
+package util
+
+import "testing"
+
+func TestGetServiceNameFromEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		defaultName string
+		envOrder    []string
+		env         map[string]string
+		want        string
+	}{
+		{
+			name:        "default used when no env vars set",
+			defaultName: "fallback",
+			envOrder:    []string{"JAEGER_SERVICE_NAME", "OTEL_SERVICE_NAME"},
+			env:         map[string]string{},
+			want:        "fallback",
+		},
+		{
+			name:        "first env var wins",
+			defaultName: "fallback",
+			envOrder:    []string{"JAEGER_SERVICE_NAME", "OTEL_SERVICE_NAME"},
+			env: map[string]string{
+				"JAEGER_SERVICE_NAME": "jaeger-service",
+				"OTEL_SERVICE_NAME":   "otel-service",
+			},
+			want: "jaeger-service",
+		},
+		{
+			name:        "second env var used when first empty",
+			defaultName: "fallback",
+			envOrder:    []string{"JAEGER_SERVICE_NAME", "OTEL_SERVICE_NAME"},
+			env: map[string]string{
+				"OTEL_SERVICE_NAME": "otel-service",
+			},
+			want: "otel-service",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, envVar := range tc.envOrder {
+				t.Setenv(envVar, "")
+			}
+			for key, value := range tc.env {
+				t.Setenv(key, value)
+			}
+
+			if got := GetServiceNameFromEnv(tc.defaultName, tc.envOrder...); got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
For now, the service name of traces is hard coded as `loki-<target>`, and it has higher priority than the otel env vars such as `OTEL_SERVICE_NAME`. Hence we can't change the service name via the env vars.

This PR implement honoring of the tracing service name env vars inside both loki and querytee binaries, ensuring grpc exporters pick up the configured service name instead of the hard code ones.

**Which issue(s) this PR fixes**:
NA

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
