### PR TITLE
feat: use stream sharding within segment subrings

### DIFF
--- a/pkg/distributor/dataobj_tee.go
+++ b/pkg/distributor/dataobj_tee.go
@@ -195,7 +195,7 @@ func (t *DataObjTee) Duplicate(ctx context.Context, tenant string, streams []Key
 func (t *DataObjTee) duplicate(ctx context.Context, tenant string, stream segmentedStream, rateBytes, tenantRateBytes uint64, pushTracker *PushTracker) {
 	t.streams.Inc()
 
-	partition, err := t.resolver.Resolve(ctx, tenant, stream.SegmentationKey, rateBytes, tenantRateBytes)
+	partition, err := t.resolver.Resolve(ctx, tenant, stream.SegmentationKey, stream.HashKey, rateBytes, tenantRateBytes)
 	if err != nil {
 		level.Error(t.logger).Log("msg", "failed to resolve partition", "err", err)
 		t.streamFailures.Inc()

--- a/pkg/distributor/segment.go
+++ b/pkg/distributor/segment.go
@@ -74,7 +74,7 @@ func newSegmentationPartitionResolver(perPartitionRateBytes uint64, ringReader r
 	}
 }
 
-func (r *segmentationPartitionResolver) Resolve(ctx context.Context, tenant string, key segmentationKey, rateBytes, tenantRateBytes uint64) (int32, error) {
+func (r *segmentationPartitionResolver) Resolve(ctx context.Context, tenant string, key segmentationKey, hashKey uint32, rateBytes, tenantRateBytes uint64) (int32, error) {
 	r.total.Inc()
 	// We use a snapshot of the partition ring to ensure resolving the
 	// partition for a segmentation key is determinstic even if the ring
@@ -112,10 +112,9 @@ func (r *segmentationPartitionResolver) Resolve(ctx context.Context, tenant stri
 		r.failed.Inc()
 		return 0, fmt.Errorf("failed to get segmentation key subring: %w", err)
 	}
-	// Get a random partition from the subring.
-	activePartitionIDs := subring.ActivePartitionIDs()
-	idx := rand.Intn(len(activePartitionIDs))
-	return activePartitionIDs[idx], nil
+	// TODO(grobinson): We need to use a different method that does not depend on
+	// stream sharding, as this information comes from the ingesters.
+	return subring.ActivePartitionForKey(hashKey)
 }
 
 // getTenantRing returns a subring for the tenant based on their rate limit.

--- a/pkg/distributor/segment_test.go
+++ b/pkg/distributor/segment_test.go
@@ -90,7 +90,7 @@ func TestSegmentationPartitionResolver_Resolve(t *testing.T) {
 	t.Run("returns error if no active partitions", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
 		resolver := newSegmentationPartitionResolver(1024, emptyRing, reg, log.NewNopLogger())
-		partition, err := resolver.Resolve(t.Context(), "tenant", segmentationKey("test"), 0, 0)
+		partition, err := resolver.Resolve(t.Context(), "tenant", segmentationKey("test"), 0x1, 0, 0)
 		require.EqualError(t, err, "no active partitions")
 		require.Equal(t, int32(0), partition)
 		// Check the metrics to make sure it fell back to random shuffle and
@@ -115,7 +115,7 @@ func TestSegmentationPartitionResolver_Resolve(t *testing.T) {
 	t.Run("uses random shuffle if rate unknown", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
 		resolver := newSegmentationPartitionResolver(1024, ringWithActivePartition, reg, log.NewNopLogger())
-		partition, err := resolver.Resolve(t.Context(), "tenant", segmentationKey("test"), 0, 0)
+		partition, err := resolver.Resolve(t.Context(), "tenant", segmentationKey("test"), 0x1, 0, 0)
 		require.NoError(t, err)
 		// Should return partition 1 since that is the only active partition.
 		require.Equal(t, int32(1), partition)
@@ -140,7 +140,7 @@ func TestSegmentationPartitionResolver_Resolve(t *testing.T) {
 	t.Run("shuffle shards on segmentation key if rate is known", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
 		resolver := newSegmentationPartitionResolver(1024, ringWithActivePartition, reg, log.NewNopLogger())
-		partition, err := resolver.Resolve(t.Context(), "tenant", segmentationKey("test"), 512, 0)
+		partition, err := resolver.Resolve(t.Context(), "tenant", segmentationKey("test"), 0x1, 512, 0)
 		require.NoError(t, err)
 		require.Equal(t, int32(1), partition)
 		require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit updates the segmentation partition resolver to use stream sharding when choosing the partition for a stream, instead of random selection. This significantly reduces the number of partitions a stream appears in.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
