### PR TITLE
docs: Update RN for 3.5.12

### DIFF
--- a/docs/sources/release-notes/v3-5.md
+++ b/docs/sources/release-notes/v3-5.md
@@ -66,6 +66,10 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 ## Bug fixes
 
+### 3.5.12 (2026-03-12)
+
+* **deps:** Upgrade go to 1.25.8 ([#21116](https://github.com/grafana/loki/issues/21116)) ([3b305e3](https://github.com/grafana/loki/commit/3b305e3fe11a23c02ba34eb0382e06d5df0e3e07))
+
 ### 3.5.11 (2026-02-23)
 
 * **alloc:** Set a limit on preallocations (backport release-3.5.x) ([#20919](https://github.com/grafana/loki/issues/20919)) ([1906dc2](https://github.com/grafana/loki/commit/1906dc2b29e1f1ffc37d9a6c9375d1590d7078a7)).


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the 3.5 Release Notes for the 3.5.12 patch.