### PR TITLE
fix: skip benchmark queries unsupported by v2 engine for goldfish comparison

### DIFF
--- a/pkg/logql/bench/queries/exhaustive/unwrap-aggregations.yaml
+++ b/pkg/logql/bench/queries/exhaustive/unwrap-aggregations.yaml
@@ -367,7 +367,7 @@ queries:
   - description: Standard variance over time
     query: stdvar_over_time(${SELECTOR} | logfmt | duration != "" | unwrap duration(duration) [${RANGE}])
     kind: metric
-    skip: true # stdvar_over_time unsupported by v2 engine (no goldfish comparison)
+    skip: true # stdvar_over_time unsupported by v2 engine
     time_range:
       length: 24h
       step: 1m
@@ -384,7 +384,7 @@ queries:
   - description: Standard variance grouped by level
     query: avg by (level) (stdvar_over_time(${SELECTOR} | logfmt | duration != "" | unwrap duration(duration) [${RANGE}]))
     kind: metric
-    skip: true # stdvar_over_time unsupported by v2 engine (no goldfish comparison)
+    skip: true # stdvar_over_time unsupported by v2 engine
     time_range:
       length: 24h
       step: 1m
@@ -401,7 +401,7 @@ queries:
   - description: Standard deviation over time
     query: stddev_over_time(${SELECTOR} | logfmt | duration != "" | unwrap duration(duration) [${RANGE}])
     kind: metric
-    skip: true # stddev_over_time unsupported by v2 engine (no goldfish comparison)
+    skip: true # stddev_over_time unsupported by v2 engine
     time_range:
       length: 24h
       step: 1m
@@ -418,7 +418,7 @@ queries:
   - description: Standard deviation grouped by level
     query: avg by (level) (stddev_over_time(${SELECTOR} | logfmt | duration != "" | unwrap duration(duration) [${RANGE}]))
     kind: metric
-    skip: true # stddev_over_time unsupported by v2 engine (no goldfish comparison)
+    skip: true # stddev_over_time unsupported by v2 engine
     time_range:
       length: 24h
       step: 1m
@@ -435,7 +435,7 @@ queries:
   - description: Quantile over time - p50 (median)
     query: quantile_over_time(0.5, ${SELECTOR} | logfmt | duration != "" | unwrap duration(duration) [${RANGE}])
     kind: metric
-    skip: true # quantile_over_time unsupported by v2 engine (no goldfish comparison)
+    skip: true # quantile_over_time unsupported by v2 engine
     time_range:
       length: 24h
       step: 1m
@@ -453,7 +453,7 @@ queries:
   - description: Quantile over time - p90
     query: quantile_over_time(0.90, ${SELECTOR} | logfmt | duration != "" | unwrap duration(duration) [${RANGE}])
     kind: metric
-    skip: true # quantile_over_time unsupported by v2 engine (no goldfish comparison)
+    skip: true # quantile_over_time unsupported by v2 engine
     time_range:
       length: 24h
       step: 1m
@@ -470,7 +470,7 @@ queries:
   - description: Quantile over time - p95
     query: quantile_over_time(0.95, ${SELECTOR} | logfmt | duration != "" | unwrap duration(duration) [${RANGE}])
     kind: metric
-    skip: true # quantile_over_time unsupported by v2 engine (no goldfish comparison)
+    skip: true # quantile_over_time unsupported by v2 engine
     time_range:
       length: 24h
       step: 1m
@@ -487,7 +487,7 @@ queries:
   - description: Quantile over time - p99
     query: quantile_over_time(0.99, ${SELECTOR} | json | unwrap duration_ms [${RANGE}])
     kind: metric
-    skip: true # quantile_over_time unsupported by v2 engine (no goldfish comparison)
+    skip: true # quantile_over_time unsupported by v2 engine
     time_range:
       length: 24h
       step: 1m
@@ -504,7 +504,7 @@ queries:
   - description: P99 latency grouped by level
     query: avg by (level) (quantile_over_time(0.99, ${SELECTOR} | logfmt | duration != "" | unwrap duration(duration) [${RANGE}]))
     kind: metric
-    skip: true # quantile_over_time unsupported by v2 engine (no goldfish comparison)
+    skip: true # quantile_over_time unsupported by v2 engine
     time_range:
       length: 24h
       step: 1m
@@ -522,7 +522,7 @@ queries:
   - description: P99 duration with conversion
     query: quantile_over_time(0.99, ${SELECTOR} | logfmt | duration != "" | unwrap duration_seconds(duration) [${RANGE}])
     kind: metric
-    skip: true # quantile_over_time unsupported by v2 engine (no goldfish comparison)
+    skip: true # quantile_over_time unsupported by v2 engine
     time_range:
       length: 24h
       step: 1m

--- a/pkg/logql/bench/queries/fast/basic-selectors.yaml
+++ b/pkg/logql/bench/queries/fast/basic-selectors.yaml
@@ -8,7 +8,7 @@ queries:
     kind: log
     time_range:
       length: 24h
-    directions: backward # forward log queries unsupported by v2 engine (no goldfish comparison)
+    directions: backward # forward log queries unsupported by v2 engine
     tags:
       - baseline
       - selector
@@ -17,7 +17,7 @@ queries:
     query: ${SELECTOR} |= "level"
     time_range:
       length: 24h
-    directions: backward # forward log queries unsupported by v2 engine (no goldfish comparison)
+    directions: backward # forward log queries unsupported by v2 engine
     requires:
       keywords:
         - level
@@ -29,7 +29,7 @@ queries:
     query: ${SELECTOR} |~ "(?i)error"
     time_range:
       length: 24h
-    directions: backward # forward log queries unsupported by v2 engine (no goldfish comparison)
+    directions: backward # forward log queries unsupported by v2 engine
     requires:
       keywords:
         - error
@@ -42,7 +42,7 @@ queries:
     query: ${SELECTOR} !~ "(?i)debug"
     time_range:
       length: 24h
-    directions: backward # forward log queries unsupported by v2 engine (no goldfish comparison)
+    directions: backward # forward log queries unsupported by v2 engine
     requires:
       keywords:
        - debug
@@ -55,7 +55,7 @@ queries:
     query: ${SELECTOR} | ${LABEL_NAME} = "${LABEL_VALUE}"
     time_range:
       length: 24h
-    directions: backward # forward log queries unsupported by v2 engine (no goldfish comparison)
+    directions: backward # forward log queries unsupported by v2 engine
     requires:
       labels:
         - namespace

--- a/pkg/logql/bench/queries/fast/structured-metadata.yaml
+++ b/pkg/logql/bench/queries/fast/structured-metadata.yaml
@@ -6,7 +6,7 @@ queries:
     kind: log
     time_range:
       length: 24h
-    directions: backward # forward log queries unsupported by v2 engine (no goldfish comparison)
+    directions: backward # forward log queries unsupported by v2 engine
     requires:
       structured_metadata:
         - detected_level
@@ -19,7 +19,7 @@ queries:
     kind: log
     time_range:
       length: 24h
-    directions: backward # forward log queries unsupported by v2 engine (no goldfish comparison)
+    directions: backward # forward log queries unsupported by v2 engine
     requires:
       log_format: logfmt
       structured_metadata:
@@ -34,7 +34,7 @@ queries:
     kind: log
     time_range:
       length: 24h
-    directions: backward # forward log queries unsupported by v2 engine (no goldfish comparison)
+    directions: backward # forward log queries unsupported by v2 engine
     requires:
       log_format: logfmt
       structured_metadata:
@@ -49,7 +49,7 @@ queries:
     kind: log
     time_range:
       length: 24h
-    directions: backward # forward log queries unsupported by v2 engine (no goldfish comparison)
+    directions: backward # forward log queries unsupported by v2 engine
     requires:
       log_format: json
       structured_metadata:

--- a/pkg/logql/bench/queries/regression/drilldown-patterns.yaml
+++ b/pkg/logql/bench/queries/regression/drilldown-patterns.yaml
@@ -6,7 +6,7 @@ queries:
     kind: log
     time_range:
       length: 24h
-    directions: backward # forward log queries unsupported by v2 engine (no goldfish comparison)
+    directions: backward # forward log queries unsupported by v2 engine
     tags:
       - drilldown
       - parser
@@ -16,7 +16,7 @@ queries:
     query: ${SELECTOR} | json | logfmt | drop __error__, __error_details__ | level="error"
     time_range:
       length: 24h
-    directions: backward # forward log queries unsupported by v2 engine (no goldfish comparison)
+    directions: backward # forward log queries unsupported by v2 engine
     tags:
       - drilldown
       - parser
@@ -25,7 +25,7 @@ queries:
     query: ${SELECTOR} | json | logfmt | drop __error__, __error_details__ | level="error" or level="warn"
     time_range:
       length: 24h
-    directions: backward # forward log queries unsupported by v2 engine (no goldfish comparison)
+    directions: backward # forward log queries unsupported by v2 engine
     tags:
       - drilldown
       - parser

--- a/pkg/logql/bench/queries/regression/structured-metadata.yaml
+++ b/pkg/logql/bench/queries/regression/structured-metadata.yaml
@@ -6,7 +6,7 @@ queries:
     kind: log
     time_range:
       length: 24h
-    directions: backward # forward log queries unsupported by v2 engine (no goldfish comparison)
+    directions: backward # forward log queries unsupported by v2 engine
     tags:
       - structured-metadata
       - line-filter
@@ -16,7 +16,7 @@ queries:
         - detected_level
   - description: JSON parsing with duration filter and structured metadata
     query: ${SELECTOR} | json | duration_seconds > 0.1 | detected_level!="debug"
-    skip: true # numeric label filter (> 0.1) unsupported by v2 engine (no goldfish comparison)
+    skip: true # numeric label filter (> 0.1) unsupported by v2 engine
     time_range:
       length: 24h
     directions: both
@@ -33,7 +33,7 @@ queries:
     query: ${SELECTOR} | logfmt | level="error" | detected_level="error"
     time_range:
       length: 24h
-    directions: backward # forward log queries unsupported by v2 engine (no goldfish comparison)
+    directions: backward # forward log queries unsupported by v2 engine
     tags:
       - structured-metadata
       - logfmt
@@ -44,7 +44,7 @@ queries:
         - detected_level
   - description: Drilldown pattern with case-insensitive error search
     query: ${SELECTOR} |~ "(?i)error" | json | logfmt | drop __error__, __error_details__ | status_code >= 500
-    skip: true # numeric label filter (>= 500) unsupported by v2 engine (no goldfish comparison)
+    skip: true # numeric label filter (>= 500) unsupported by v2 engine
     time_range:
       length: 24h
     directions: both
@@ -58,7 +58,7 @@ queries:
     query: ${SELECTOR} | detected_level="error" |~ "(?i)failed"
     time_range:
       length: 24h
-    directions: backward # forward log queries unsupported by v2 engine (no goldfish comparison)
+    directions: backward # forward log queries unsupported by v2 engine
     tags:
       - drilldown
       - structured-metadata
@@ -72,7 +72,7 @@ queries:
     query: ${SELECTOR} | detected_level=~"error|warn" |~ "(?i)refused"
     time_range:
       length: 24h
-    directions: backward # forward log queries unsupported by v2 engine (no goldfish comparison)
+    directions: backward # forward log queries unsupported by v2 engine
     tags:
       - drilldown
       - structured-metadata


### PR DESCRIPTION
## Summary

- Skip/restrict benchmark queries that the v2 engine doesn't support, eliminating ~30 missing goldfish comparison results
- Change `directions: both` → `directions: backward` for 16 log queries across 5 files
- Add `skip: true` for 2 queries with numeric label filters and 10 unsupported range aggregations

## Background

Investigation into why 30/107 queries consistently produced no goldfish comparison result. The `X-Loki-Goldfish-Id` header was returned for all 107 queries, but only ~77 had stored comparison results within the polling window.

**Root cause:** The `EngineRouterMiddleware` validates queries via `engine.IsQuerySupported` (which calls `logical.BuildPlan`). Unsupported queries are routed entirely to v1, bypassing `FanOutHandler` and goldfish comparison. Three categories of unsupported queries were identified:

1. **FORWARD direction log queries** — `planner.go:147-148` explicitly rejects these
2. **Numeric label filters** (`duration_seconds > 0.1`, `status_code >= 500`) — `planner.go:634-635`
3. **`stdvar_over_time`, `stddev_over_time`, `quantile_over_time`** — `planner.go:363-364`

<details>
<summary>Investigation summary</summary>

### Problem

The k6 tests were consistently matching ~77/107 queries via Goldfish, with ~30 queries never producing a comparison result within the 2-minute polling window. No errors appeared in query-tee logs. The `X-Loki-Goldfish-Id` header was returned for all 107 queries (100% sampling confirmed), but only ~77 produced a stored comparison.

The **Missing queries** showed only the splitting handler warning in the query tee, with no FanOutHandler warning — meaning they never reached `FanOutHandler` and thus never triggered goldfish comparison. This means they were hitting the unsupported path.

### Which queries were missing

The ~30 missing queries fell into consistent categories:
- **Log queries** (16 total) from `basic-selectors`, `structured-metadata`, `drilldown-patterns`, and `regression/structured-metadata` — all using FORWARD direction
- **Numeric label filter queries** (2 total) from `regression/structured-metadata` — e.g. `duration_seconds > 0.1`, `status_code >= 500`
- **Unwrap aggregation queries** (10 total) from `exhaustive/unwrap-aggregations` — `stdvar_over_time`, `stddev_over_time`, `quantile_over_time`
</details>

## Changes

| File | Change | Reason |
|------|--------|--------|
| `fast/basic-selectors.yaml` | 5 queries → `backward` only | FORWARD unsupported |
| `fast/structured-metadata.yaml` | 4 queries → `backward` only | FORWARD unsupported |
| `regression/drilldown-patterns.yaml` | 3 queries → `backward` only | FORWARD unsupported |
| `regression/structured-metadata.yaml` | 4 queries → `backward` only, 2 queries `skip: true` | FORWARD unsupported + numeric filters |
| `exhaustive/unwrap-aggregations.yaml` | 10 queries `skip: true` | stdvar/stddev/quantile_over_time unsupported |