### PR TITLE
fix: make the chunkFilter apply to new MultiIndex/s

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
@@ -110,6 +110,8 @@ type HeadManager struct {
 	shards                 int
 	activeHeads, prevHeads *tenantHeads
 
+	chunkFilter chunk.RequestChunkFilterer
+
 	Index
 
 	wg     sync.WaitGroup
@@ -143,7 +145,11 @@ func NewHeadManager(name string, logger log.Logger, dir string, metrics *Metrics
 			indices = append(indices, m.activeHeads)
 		}
 
-		return NewMultiIndex(IndexSlice(indices)), nil
+		idx := NewMultiIndex(IndexSlice(indices))
+		if m.chunkFilter != nil {
+			idx.SetChunkFilterer(m.chunkFilter)
+		}
+		return idx, nil
 	})
 
 	return m
@@ -246,6 +252,10 @@ func (m *HeadManager) Stop() error {
 	}
 
 	return m.buildTSDBFromHead(m.activeHeads)
+}
+
+func (m *HeadManager) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+	m.chunkFilter = chunkFilter
 }
 
 func (m *HeadManager) Append(userID string, ls labels.Labels, fprint uint64, chks index.ChunkMetas) error {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
@@ -434,6 +434,42 @@ func Test_HeadManager_QueryAfterRotate(t *testing.T) {
 
 }
 
+func Test_HeadManager_ChunkFilterer(t *testing.T) {
+	now := time.Now()
+	dir := t.TempDir()
+	storeName := "store_2010-10-10"
+	mgr := NewHeadManager(storeName, log.NewNopLogger(), dir, NewMetrics(nil), newNoopTSDBManager(storeName, dir))
+	for _, d := range managerRequiredDirs(storeName, dir) {
+		require.Nil(t, util.EnsureDirectory(d))
+	}
+	require.Nil(t, mgr.Rotate(now))
+
+	user := "tenant1"
+	ls := mustParseLabels(`{foo="bar"}`)
+	chks := []index.ChunkMeta{{MinTime: 1, MaxTime: 10, Checksum: 1}}
+	require.Nil(t, mgr.Append(user, ls, labels.StableHash(ls), chks))
+
+	matchAll := labels.MustNewMatcher(labels.MatchRegexp, "foo", ".+")
+	nextPeriod := time.Now().Add(time.Duration(mgr.period))
+	mgr.tick(nextPeriod) // rotate so data moves to prevHeads, queryable via lazy index
+
+	// Confirm data is reachable via GetChunkRefs before testing Series.
+	refs, err := mgr.GetChunkRefs(context.Background(), user, 0, math.MaxInt64, nil, nil, matchAll)
+	require.Nil(t, err)
+	require.Len(t, refs, 1)
+
+	// Without a filterer, Series returns the appended series.
+	series, err := mgr.Series(context.Background(), user, 0, math.MaxInt64, nil, nil, matchAll)
+	require.Nil(t, err)
+	require.Len(t, series, 1)
+
+	// With a filterAll filterer, Series returns no results.
+	mgr.SetChunkFilterer(&filterAll{})
+	series, err = mgr.Series(context.Background(), user, 0, math.MaxInt64, nil, nil, matchAll)
+	require.Nil(t, err)
+	require.Len(t, series, 0)
+}
+
 // test mgr recover from multiple wals across multiple periods
 func Test_HeadManager_Lifecycle(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
**What this PR does / why we need it**:

Problem: After flushing, LBAC filters were no longer applied to /series queries

Root cause: When chunks are flushed to storage, IndexChunk() writes entries to the TSDB HeadManager. The HeadManager uses an embedded LazyIndex that creates a new MultiIndex on every call. When the outer MultiIndex's forMatchingIndices() called SetChunkFilterer() on the HeadManager, it went to LazyIndex.SetChunkFilterer() which created a throwaway MultiIndex, set the filterer on it, and immediately discarded it. On the subsequent Series() call, a new unfilterd MultiIndex was created, incorrectly returning unfiltered series.

Fix: Added a chunkFilter field to HeadManager, overrode SetChunkFilterer to store it, and updated the lazy function to apply the stored filterer to each newly created MultiIndex.


**Special notes for your reviewer**:
I found this issue while porting LBAC to loki. claude helped find the root cause and fix the issue.


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Do not end the title with punctuation. It will be added in the changelog.
  b. Start with an imperative verb. Example: Fix the latency between System A and System B.
  c. Use sentence case, not title case.
  d. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with main
4. If changing the Helm chart, please ensure the chart version is increased per semantic versioning (https://semver.org)
-->

**Checklist**
- [x] Documentation added
- [x] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
