### PR TITLE
chore: move partitions calc to numPartitionsForRate

### DIFF
--- a/pkg/distributor/segment.go
+++ b/pkg/distributor/segment.go
@@ -123,14 +123,8 @@ func (r *segmentationPartitionResolver) getTenantSubring(_ context.Context, ring
 		// If the tenant has no limit, return the full ring.
 		return ring, nil
 	}
-	// The size of the subring is calculated as the tenant's ingestion rate
-	// limit divided by the expected per-tenant rate per partition.
-	partitions := tenantRateBytes / r.perPartitionRateBytes
-	// Must be at least 1 partition.
-	partitions = max(partitions, 1)
-	// Must not exceed the number of active partitions.
-	partitions = min(partitions, uint64(ring.ActivePartitionsCount()))
-	return ring.ShuffleShard(tenant, int(partitions))
+	numShuffleShardPartitions := numPartitionsForRate(tenantRateBytes, r.perPartitionRateBytes, ring.ActivePartitionsCount())
+	return ring.ShuffleShard(tenant, numShuffleShardPartitions)
 }
 
 func (r *segmentationPartitionResolver) getSegmentationKeySubring(_ context.Context, ring *ring.PartitionRing, key segmentationKey, rateBytes uint64) (*ring.PartitionRing, error) {
@@ -138,14 +132,19 @@ func (r *segmentationPartitionResolver) getSegmentationKeySubring(_ context.Cont
 		// If the rate is 0, return the full ring.
 		return ring, nil
 	}
-	// Use the rate of the segmentation key to shuffle shard the active
-	// partitions. The number of partitions in the shuffle is calculated as
-	// current rate divided by the expected per-tenant rate per partition.
-	partitions := rateBytes / r.perPartitionRateBytes
+	numShuffleShardPartitions := numPartitionsForRate(rateBytes, r.perPartitionRateBytes, ring.ActivePartitionsCount())
+	return ring.ShuffleShard(string(key), numShuffleShardPartitions)
+}
+
+// numPartitionsForRate returns the number of partitions needed to keep within
+// perPartitionRateBytes. It cannot exceed the total number of partitions.
+func numPartitionsForRate(rateBytes, perPartitionRateBytes uint64, numPartitions int) int {
+	partitions := rateBytes / perPartitionRateBytes
 	// Must be at least 1 partition.
 	partitions = max(partitions, 1)
-	// Must not exceed the number of active partitions.
-	partitions = min(partitions, uint64(ring.ActivePartitionsCount()))
-	// Shuffle shard.
-	return ring.ShuffleShard(string(key), int(partitions))
+	// Must not exceed the total number of partitions.
+	partitions = min(partitions, uint64(numPartitions))
+	// We can convert back to int here because partitions is guaranteed to be less
+	// than or equal to the number of partitions, which is an int.
+	return int(partitions)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request moves the calculation to a new function, as we will use it next to reduce the number of shuffle shards we need to call.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
