### PR TITLE
feat: don't shuffle shard if shard factor is 1

### DIFF
--- a/pkg/distributor/segment.go
+++ b/pkg/distributor/segment.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
-	"math/rand"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/ring"
@@ -48,9 +47,8 @@ type segmentationPartitionResolver struct {
 	logger                log.Logger
 
 	// Metrics.
-	failed          prometheus.Counter
-	randomlySharded prometheus.Counter
-	total           prometheus.Counter
+	resolveFailed prometheus.Counter
+	resolveTotal  prometheus.Counter
 }
 
 // newSegmentationPartitionResolver returns a new segmentationPartitionResolver.
@@ -58,15 +56,11 @@ func newSegmentationPartitionResolver(perPartitionRateBytes uint64, ringReader r
 	return &segmentationPartitionResolver{
 		perPartitionRateBytes: perPartitionRateBytes,
 		ringReader:            ringReader,
-		failed: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		resolveFailed: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "loki_distributor_segmentation_partition_resolver_keys_failed_total",
 			Help: "Total number of segmentation keys that could not be resolved.",
 		}),
-		randomlySharded: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "loki_distributor_segmentation_partition_resolver_keys_randomly_sharded_total",
-			Help: "Total number of segmentation keys that fell back to a randomly choosing an active partition due to absent rate.",
-		}),
-		total: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		resolveTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "loki_distributor_segmentation_partition_resolver_keys_total",
 			Help: "Total number of segmentation keys passed to the resolver.",
 		}),
@@ -75,7 +69,7 @@ func newSegmentationPartitionResolver(perPartitionRateBytes uint64, ringReader r
 }
 
 func (r *segmentationPartitionResolver) Resolve(ctx context.Context, tenant string, key segmentationKey, hashKey uint32, rateBytes, tenantRateBytes uint64) (int32, error) {
-	r.total.Inc()
+	r.resolveTotal.Inc()
 	// We use a snapshot of the partition ring to ensure resolving the
 	// partition for a segmentation key is determinstic even if the ring
 	// changes.
@@ -84,32 +78,32 @@ func (r *segmentationPartitionResolver) Resolve(ctx context.Context, tenant stri
 		// If there are no active partitions then we cannot write to any
 		// partition as we do not know if the partition we chose will have a
 		// consumer.
-		r.failed.Inc()
+		r.resolveFailed.Inc()
 		return 0, errors.New("no active partitions")
 	}
 	// Get a subring for the tenant based on their ingestion rate limit.
 	// This ensures that streams are not only co-located within the same
 	// segmentation key, but also segmentation keys for a tenant are as
 	// co-located as possible.
-	subring, err := r.getTenantSubring(ctx, ring, tenant, tenantRateBytes)
+	subring, err := r.tenantShuffleShard(ctx, ring, tenant, tenantRateBytes)
 	if err != nil {
-		r.failed.Inc()
-		return 0, fmt.Errorf("failed to get tenant subring: %w", err)
+		r.resolveFailed.Inc()
+		return 0, fmt.Errorf("failed to shuffle shard tenant: %w", err)
 	}
-	// If rate bytes is 0, then we were unable to determine the rate (bytes/sec)
-	// for the segmentation key. When this happens we fallback to randomly
-	// selecting an active partition and incrementing the fallback metric.
+	// If the rate is 0, we cannot make a decision to shuffle shard the segmentation
+	// key. We fallback to choosing a partition for the segmentation key.
 	if rateBytes == 0 {
-		r.randomlySharded.Inc()
-		activePartitionIDs := subring.ActivePartitionIDs()
-		rand.Shuffle(len(activePartitionIDs), func(i, j int) {
-			activePartitionIDs[i], activePartitionIDs[j] = activePartitionIDs[j], activePartitionIDs[i]
-		})
-		return activePartitionIDs[0], nil
+		return subring.ActivePartitionForKey(uint32(key.Sum64()))
 	}
-	subring, err = r.getSegmentationKeySubring(ctx, subring, key, rateBytes)
+	numShuffleShardPartitions := numPartitionsForRate(rateBytes, r.perPartitionRateBytes, subring.ActivePartitionsCount())
+	// If the segmentation key is small enough that it does not need to be sharded,
+	// we can avoid doing an expensive shuffle shard.
+	if numShuffleShardPartitions == 1 {
+		return subring.ActivePartitionForKey(uint32(key.Sum64()))
+	}
+	subring, err = subring.ShuffleShard(string(key), numShuffleShardPartitions)
 	if err != nil {
-		r.failed.Inc()
+		r.resolveFailed.Inc()
 		return 0, fmt.Errorf("failed to get segmentation key subring: %w", err)
 	}
 	// TODO(grobinson): We need to use a different method that does not depend on
@@ -117,23 +111,14 @@ func (r *segmentationPartitionResolver) Resolve(ctx context.Context, tenant stri
 	return subring.ActivePartitionForKey(hashKey)
 }
 
-// getTenantRing returns a subring for the tenant based on their rate limit.
-func (r *segmentationPartitionResolver) getTenantSubring(_ context.Context, ring *ring.PartitionRing, tenant string, tenantRateBytes uint64) (*ring.PartitionRing, error) {
+// tenantShuffleShard returns a subring for the tenant based on their rate limit.
+func (r *segmentationPartitionResolver) tenantShuffleShard(_ context.Context, ring *ring.PartitionRing, tenant string, tenantRateBytes uint64) (*ring.PartitionRing, error) {
+	// If the tenant has no limit, return the full ring.
 	if tenantRateBytes == 0 {
-		// If the tenant has no limit, return the full ring.
 		return ring, nil
 	}
 	numShuffleShardPartitions := numPartitionsForRate(tenantRateBytes, r.perPartitionRateBytes, ring.ActivePartitionsCount())
 	return ring.ShuffleShard(tenant, numShuffleShardPartitions)
-}
-
-func (r *segmentationPartitionResolver) getSegmentationKeySubring(_ context.Context, ring *ring.PartitionRing, key segmentationKey, rateBytes uint64) (*ring.PartitionRing, error) {
-	if rateBytes == 0 {
-		// If the rate is 0, return the full ring.
-		return ring, nil
-	}
-	numShuffleShardPartitions := numPartitionsForRate(rateBytes, r.perPartitionRateBytes, ring.ActivePartitionsCount())
-	return ring.ShuffleShard(string(key), numShuffleShardPartitions)
 }
 
 // numPartitionsForRate returns the number of partitions needed to keep within

--- a/pkg/distributor/segment_test.go
+++ b/pkg/distributor/segment_test.go
@@ -161,7 +161,7 @@ func TestSegmentationPartitionResolver_Resolve(t *testing.T) {
 	})
 }
 
-func TestSegmentationPartitionResolver_GetTenantSubring(t *testing.T) {
+func TestSegmentationPartitionResolver_TenantShuffleShard(t *testing.T) {
 	// Set up a fake partition ring with two active partitions.
 	ringWithActivePartitions := mockPartitionRingReader{}
 	ring, err := ring.NewPartitionRing(ring.PartitionRingDesc{
@@ -199,7 +199,7 @@ func TestSegmentationPartitionResolver_GetTenantSubring(t *testing.T) {
 		reg := prometheus.NewRegistry()
 		resolver := newSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
 		ring := ringWithActivePartitions.PartitionRing()
-		subring, err := resolver.getTenantSubring(t.Context(), ring, "tenant", 0)
+		subring, err := resolver.tenantShuffleShard(t.Context(), ring, "tenant", 0)
 		require.NoError(t, err)
 		require.Equal(t, ring, subring)
 	})
@@ -208,7 +208,7 @@ func TestSegmentationPartitionResolver_GetTenantSubring(t *testing.T) {
 		reg := prometheus.NewRegistry()
 		resolver := newSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
 		ring := ringWithActivePartitions.PartitionRing()
-		subring, err := resolver.getTenantSubring(t.Context(), ring, "tenant", 1024)
+		subring, err := resolver.tenantShuffleShard(t.Context(), ring, "tenant", 1024)
 		require.NoError(t, err)
 		require.Equal(t, 1, subring.ActivePartitionsCount())
 	})
@@ -217,69 +217,7 @@ func TestSegmentationPartitionResolver_GetTenantSubring(t *testing.T) {
 		reg := prometheus.NewRegistry()
 		resolver := newSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
 		ring := ringWithActivePartitions.PartitionRing()
-		subring, err := resolver.getTenantSubring(t.Context(), ring, "tenant", 2048)
-		require.NoError(t, err)
-		require.Equal(t, 2, subring.ActivePartitionsCount())
-	})
-}
-
-func TestSegmentationPartitionResolver_GetSegmentationKeySubring(t *testing.T) {
-	// Set up a fake partition ring with two active partitions.
-	ringWithActivePartitions := mockPartitionRingReader{}
-	ring, err := ring.NewPartitionRing(ring.PartitionRingDesc{
-		Partitions: map[int32]ring.PartitionDesc{
-			1: {
-				Id:             1,
-				Tokens:         []uint32{1},
-				State:          ring.PartitionActive,
-				StateTimestamp: time.Now().Unix(),
-			},
-			2: {
-				Id:             2,
-				Tokens:         []uint32{2},
-				State:          ring.PartitionActive,
-				StateTimestamp: time.Now().Unix(),
-			},
-		},
-		Owners: map[string]ring.OwnerDesc{
-			"owner1": {
-				OwnedPartition:   1,
-				State:            ring.OwnerActive,
-				UpdatedTimestamp: time.Now().Unix(),
-			},
-			"owner2": {
-				OwnedPartition:   2,
-				State:            ring.OwnerActive,
-				UpdatedTimestamp: time.Now().Unix(),
-			},
-		},
-	})
-	require.NoError(t, err)
-	ringWithActivePartitions.ring = ring
-
-	t.Run("no rate returns full ring", func(t *testing.T) {
-		reg := prometheus.NewRegistry()
-		resolver := newSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
-		ring := ringWithActivePartitions.PartitionRing()
-		subring, err := resolver.getSegmentationKeySubring(t.Context(), ring, segmentationKey("test"), 0)
-		require.NoError(t, err)
-		require.Equal(t, ring, subring)
-	})
-
-	t.Run("rate equals partition rate returns subring with one partition", func(t *testing.T) {
-		reg := prometheus.NewRegistry()
-		resolver := newSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
-		ring := ringWithActivePartitions.PartitionRing()
-		subring, err := resolver.getSegmentationKeySubring(t.Context(), ring, segmentationKey("test"), 1024)
-		require.NoError(t, err)
-		require.Equal(t, 1, subring.ActivePartitionsCount())
-	})
-
-	t.Run("rate exceeds partition rate returns subring with all partitions", func(t *testing.T) {
-		reg := prometheus.NewRegistry()
-		resolver := newSegmentationPartitionResolver(1024, ringWithActivePartitions, reg, log.NewNopLogger())
-		ring := ringWithActivePartitions.PartitionRing()
-		subring, err := resolver.getSegmentationKeySubring(t.Context(), ring, segmentationKey("test"), 2048)
+		subring, err := resolver.tenantShuffleShard(t.Context(), ring, "tenant", 2048)
 		require.NoError(t, err)
 		require.Equal(t, 2, subring.ActivePartitionsCount())
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

This reduces both CPU and memory usage on the distributors. We were experiencing issues with lots of memory being used by all the various shuffle shards we cached for segmentation keys. This seems to have reduced the amount of memory used for segmentation keys by 50%.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
