### PR TITLE
feat: add cluster and namespace to segmentation keys

### DIFF
--- a/pkg/distributor/segment.go
+++ b/pkg/distributor/segment.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"hash/fnv"
+	"strings"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/ring"
 	"github.com/prometheus/client_golang/prometheus"
@@ -20,10 +21,10 @@ type segmentationKey string
 
 // Sum64 returns a 64 bit, non-cryptographic hash of the key.
 func (key segmentationKey) Sum64() uint64 {
-	h := fnv.New64a()
+	h := xxhash.New()
 	// Use a reserved word here to avoid any possible hash conflicts with
 	// streams.
-	h.Write([]byte("__loki_segmentation_key__"))
+	h.Write([]byte("loki_segmentation_key"))
 	h.Write([]byte(key))
 	return h.Sum64()
 }
@@ -34,10 +35,25 @@ func getSegmentationKey(stream KeyedStream) (segmentationKey, error) {
 	if err != nil {
 		return "", err
 	}
-	if serviceName := labels.Get("service_name"); serviceName != "" {
-		return segmentationKey(serviceName), nil
+	sb := strings.Builder{}
+	if cluster := labels.Get("cluster"); cluster != "" {
+		sb.WriteString(cluster)
+	} else {
+		sb.WriteString("unknown_cluster")
 	}
-	return segmentationKey("unknown_service"), nil
+	sb.WriteByte('/')
+	if namespace := labels.Get("namespace"); namespace != "" {
+		sb.WriteString(namespace)
+	} else {
+		sb.WriteString("unknown_namespace")
+	}
+	sb.WriteByte('/')
+	if serviceName := labels.Get("service_name"); serviceName != "" {
+		sb.WriteString(serviceName)
+	} else {
+		sb.WriteString("unknown_service")
+	}
+	return segmentationKey(sb.String()), nil
 }
 
 // segmentationPartitionResolver resolves the partition for a segmentation key.


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds cluster and namespace to segmentation keys, so we can keep streams from the same cluster/namespace close together.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
