### PR TITLE
fix: if we don't know the rate of a segmentation key, shard the stream

### DIFF
--- a/pkg/distributor/segment.go
+++ b/pkg/distributor/segment.go
@@ -91,9 +91,9 @@ func (r *segmentationPartitionResolver) Resolve(ctx context.Context, tenant stri
 		return 0, fmt.Errorf("failed to shuffle shard tenant: %w", err)
 	}
 	// If the rate is 0, we cannot make a decision to shuffle shard the segmentation
-	// key. We fallback to choosing a partition for the segmentation key.
+	// key. We fallback to choosing a partition for the hash key.
 	if rateBytes == 0 {
-		return subring.ActivePartitionForKey(uint32(key.Sum64()))
+		return subring.ActivePartitionForKey(hashKey)
 	}
 	numShuffleShardPartitions := numPartitionsForRate(rateBytes, r.perPartitionRateBytes, subring.ActivePartitionsCount())
 	// If the segmentation key is small enough that it does not need to be sharded,


### PR DESCRIPTION
**What this PR does / why we need it**:

This prevents any individual partition from becoming a hotspot for very high volume segmentation keys when the rate is unknown.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
