### PR TITLE
chore(deps): Update prometheus - 2026-03-20

### DIFF
--- a/cmd/dataobj-inspect/go.mod
+++ b/cmd/dataobj-inspect/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
 	github.com/grafana/loki/v3 v3.0.0-20260311215855-e22a9bed508b
-	github.com/prometheus/prometheus v0.310.1-0.20260312203008-8b25b26a7653
+	github.com/prometheus/prometheus v0.310.1-0.20260320085417-166d20151c0d
 )
 
 require (

--- a/cmd/dataobj-inspect/go.sum
+++ b/cmd/dataobj-inspect/go.sum
@@ -143,8 +143,8 @@ github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEo
 github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
-github.com/prometheus/prometheus v0.310.1-0.20260312203008-8b25b26a7653 h1:Z7afRT2yWqXrOQfz7fLyqEBRbLzuAb3WDtaY48WvUkk=
-github.com/prometheus/prometheus v0.310.1-0.20260312203008-8b25b26a7653/go.mod h1:inufIOTbzFkTjM5hLQJTih8pcstVJRNpISmqf+jTlVY=
+github.com/prometheus/prometheus v0.310.1-0.20260320085417-166d20151c0d h1:6IKqApENq2a/7Cpx3MZmjZcYKwKVClxF+oyAqoIzHO4=
+github.com/prometheus/prometheus v0.310.1-0.20260320085417-166d20151c0d/go.mod h1:inufIOTbzFkTjM5hLQJTih8pcstVJRNpISmqf+jTlVY=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sercand/kuberesolver/v6 v6.0.1 h1:XZUTA0gy/lgDYp/UhEwv7Js24F1j8NJ833QrWv0Xux4=

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5
-	github.com/prometheus/prometheus v0.310.1-0.20260312203008-8b25b26a7653
+	github.com/prometheus/prometheus v0.310.1-0.20260320085417-166d20151c0d
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/segmentio/fasthash v1.0.3
 	github.com/shurcooL/httpfs v0.0.0-20230704072500-f1e31cf0ba5c

--- a/go.sum
+++ b/go.sum
@@ -1037,8 +1037,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
-github.com/prometheus/prometheus v0.310.1-0.20260312203008-8b25b26a7653 h1:Z7afRT2yWqXrOQfz7fLyqEBRbLzuAb3WDtaY48WvUkk=
-github.com/prometheus/prometheus v0.310.1-0.20260312203008-8b25b26a7653/go.mod h1:inufIOTbzFkTjM5hLQJTih8pcstVJRNpISmqf+jTlVY=
+github.com/prometheus/prometheus v0.310.1-0.20260320085417-166d20151c0d h1:6IKqApENq2a/7Cpx3MZmjZcYKwKVClxF+oyAqoIzHO4=
+github.com/prometheus/prometheus v0.310.1-0.20260320085417-166d20151c0d/go.mod h1:inufIOTbzFkTjM5hLQJTih8pcstVJRNpISmqf+jTlVY=
 github.com/prometheus/sigv4 v0.4.1 h1:EIc3j+8NBea9u1iV6O5ZAN8uvPq2xOIUPcqCTivHuXs=
 github.com/prometheus/sigv4 v0.4.1/go.mod h1:eu+ZbRvsc5TPiHwqh77OWuCnWK73IdkETYY46P4dXOU=
 github.com/puzpuzpuz/xsync/v3 v3.5.1 h1:GJYJZwO6IdxN/IKbneznS6yPkVC+c3zyY/j19c++5Fg=

--- a/pkg/ruler/storage/wal/wal.go
+++ b/pkg/ruler/storage/wal/wal.go
@@ -423,7 +423,7 @@ func (w *Storage) Truncate(mint int64) error {
 		w.deletedMtx.Unlock()
 		return ok
 	}
-	if _, err = wlog.Checkpoint(util_log.SlogFromGoKit(w.logger), w.wal, first, last, keep, mint); err != nil {
+	if _, err = wlog.Checkpoint(util_log.SlogFromGoKit(w.logger), w.wal, first, last, keep, mint, false); err != nil {
 		return errors.Wrap(err, "create checkpoint")
 	}
 	if err := w.wal.Truncate(last + 1); err != nil {

--- a/vendor/github.com/prometheus/prometheus/discovery/azure/azure.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/azure/azure.go
@@ -298,7 +298,10 @@ func newCredential(cfg SDConfig, policyClientOptions policy.ClientOptions) (azco
 		}
 		credential = azcore.TokenCredential(workloadIdentityCredential)
 	case authMethodManagedIdentity:
-		options := &azidentity.ManagedIdentityCredentialOptions{ClientOptions: policyClientOptions, ID: azidentity.ClientID(cfg.ClientID)}
+		options := &azidentity.ManagedIdentityCredentialOptions{ClientOptions: policyClientOptions}
+		if cfg.ClientID != "" {
+			options.ID = azidentity.ClientID(cfg.ClientID)
+		}
 		managedIdentityCredential, err := azidentity.NewManagedIdentityCredential(options)
 		if err != nil {
 			return nil, err

--- a/vendor/github.com/prometheus/prometheus/scrape/manager.go
+++ b/vendor/github.com/prometheus/prometheus/scrape/manager.go
@@ -115,7 +115,25 @@ type Options struct {
 
 	// Option to enable the ingestion of the created timestamp as a synthetic zero sample.
 	// See: https://github.com/prometheus/proposals/blob/main/proposals/2023-06-13_created-timestamp.md
+	//
+	// NOTE: This option has no effect for AppenderV2 and will be removed with the AppenderV1
+	// removal.
 	EnableStartTimestampZeroIngestion bool
+
+	// ParseST controls if ST should be parsed and appended from the scrape formats.
+	// This should be by default true, but it's opt-in for OpenMetrics (OM) 1.0 reasons and might be moved
+	// to OM  1.0 only flow.
+	//
+	// Specifically for OpenMetrics 1.0 flow, it can have some additional effects that might not be desired for non-ST users:
+	//
+	// * OpenMetrics 1.0 <metric>_created series will be parsed as ST instead of normal sample. Could be breaking
+	// if downstream user depends on _created metric. TODO(bwplotka): Add "preserveOMLines" hidden option?
+	// * Add relatively small (but still) overhead.
+	// * Can yield wrong ST values in rare edge cases (unknown metadata and metric name collisions).
+	//
+	// This only applies to AppenderV2 flow (Prometheus default).
+	// TODO: Move this option to OM1 parser and use only on OM1 flow.
+	ParseST bool
 
 	// EnableTypeAndUnitLabels represents type-and-unit-labels feature flag.
 	EnableTypeAndUnitLabels bool
@@ -126,8 +144,31 @@ type Options struct {
 	// FeatureRegistry is the registry for tracking enabled/disabled features.
 	FeatureRegistry features.Collector
 
+	// ScrapeOnShutdown enables a final scrape before the manager closes. This is useful
+	// for Prometheus in agent mode or OTel's prometheusreceiver when used in serverless
+	// job scenarios, allowing an extra scrape for the short-living edge cases.
+	//
+	// NOTE: This final scrape ignores the configured scrape interval.
+	ScrapeOnShutdown bool
+
+	// InitialScrapeOffset applies an additional baseline delay before we begin
+	// scraping targets. By default, Prometheus calculates a specific offset for
+	// each target to spread the scraping load evenly across the server. Configuring
+	// this option adds a fixed duration to that target-specific offset. This allows
+	// tuning the initial startup delay without overriding the underlying target
+	// jitter, preserving proper load balancing across the scraper pools.
+	//
+	// Setting this offset (e.g., to 10s) is particularly useful in Prometheus
+	// agent mode and OTel's prometheusreceiver when used in serverless job
+	// scenarios. It helps avoid readiness races where targets might not be fully
+	// initialized immediately upon startup. It also prevents capturing
+	// intermediate state (such as applications crashing shortly after booting),
+	// and ensures backend rate limits don't drop valuable shutdown scrapes
+	// because of an early startup scrape.
+	InitialScrapeOffset time.Duration
+
 	// private option for testability.
-	skipOffsetting bool
+	skipJitterOffsetting bool
 }
 
 // Manager maintains a set of scrape pools and manages start/stop cycles
@@ -316,8 +357,16 @@ func (m *Manager) ApplyConfig(cfg *config.Config) error {
 
 	m.scrapeFailureLoggers = scrapeFailureLoggers
 
-	if err := m.setOffsetSeed(cfg.GlobalConfig.ExternalLabels); err != nil {
-		return err
+	// Skip offset seed calculation during tests.
+	// setOffsetSeed relies on osutil.GetFQDN(), which triggers a DNS lookup using
+	// a global singleflight goroutine. This cross-boundary communication breaks
+	// synctest's isolation bubble and causes a fatal panic.
+	if m.opts.skipJitterOffsetting {
+		m.offsetSeed = 0
+	} else {
+		if err := m.setOffsetSeed(cfg.GlobalConfig.ExternalLabels); err != nil {
+			return err
+		}
 	}
 
 	// Cleanup and reload pool if the configuration has changed.

--- a/vendor/github.com/prometheus/prometheus/scrape/scrape.go
+++ b/vendor/github.com/prometheus/prometheus/scrape/scrape.go
@@ -238,7 +238,6 @@ func (sp *scrapePool) SetScrapeFailureLogger(l FailureLogger) {
 func (sp *scrapePool) stop() {
 	sp.mtx.Lock()
 	defer sp.mtx.Unlock()
-	sp.cancel()
 	var wg sync.WaitGroup
 
 	sp.targetMtx.Lock()
@@ -258,6 +257,10 @@ func (sp *scrapePool) stop() {
 	sp.targetMtx.Unlock()
 
 	wg.Wait()
+	// Cancel the context after all loops have stopped. This is required for
+	// scrapeOnShutdown to work properly, as the shutdown scrape uses this
+	// context (via sl.parentCtx) and would fail if the context was cancelled early.
+	sp.cancel()
 	sp.client.CloseIdleConnections()
 
 	if sp.config != nil {
@@ -820,11 +823,17 @@ type cacheEntry struct {
 }
 
 type scrapeLoop struct {
-	// Parameters.
-	ctx         context.Context
-	cancel      func()
-	stopped     chan struct{}
-	parentCtx   context.Context
+	// ctx represents a local context that is cancellable via s.cancel.
+	// It's meant to synchronize run() with stop().
+	// It inherits parentCtx.
+	ctx     context.Context
+	cancel  func()
+	stopped chan struct{}
+	// parentCtx represents manager-level context, typically connected
+	// to process shutdown.
+	parentCtx context.Context
+	// appenderCtx is a parentCtx with some extra context for appender
+	// implementations. Potentially remove-able with removal of AppenderV1.
 	appenderCtx context.Context
 	l           *slog.Logger
 	cache       *scrapeCache
@@ -861,12 +870,14 @@ type scrapeLoop struct {
 
 	// Options from scrape.Options.
 	enableSTZeroIngestion   bool
+	parseST                 bool // Used by AppenderV2 only.
 	enableTypeAndUnitLabels bool
 	reportExtraMetrics      bool
 	appendMetadataToWAL     bool
 	passMetadataInContext   bool
-	skipOffsetting          bool // For testability.
-
+	skipJitterOffsetting    bool // For testability.
+	scrapeOnShutdown        bool
+	initialScrapeOffset     time.Duration
 	// error injection through setForcedError.
 	forcedErr    error
 	forcedErrMtx sync.Mutex
@@ -1214,11 +1225,18 @@ func newScrapeLoop(opts scrapeLoopOptions) *scrapeLoop {
 		validationScheme:              opts.sp.config.MetricNameValidationScheme,
 
 		// scrape.Options.
-		enableSTZeroIngestion:   opts.sp.options.EnableStartTimestampZeroIngestion,
+		enableSTZeroIngestion: opts.sp.options.EnableStartTimestampZeroIngestion,
+		// parseST was added recently. Before EnableStartTimestampZeroIngestion
+		// was enabling parsing ST. For non-Prometheus users of the scrape
+		// manager, we ensure appenderV2 parseST is set on EnableStartTimestampZeroIngestion
+		// This will be removed when EnableStartTimestampZeroIngestion is removed.
+		parseST:                 opts.sp.options.ParseST || opts.sp.options.EnableStartTimestampZeroIngestion,
 		enableTypeAndUnitLabels: opts.sp.options.EnableTypeAndUnitLabels,
 		appendMetadataToWAL:     opts.sp.options.AppendMetadata,
 		passMetadataInContext:   opts.sp.options.PassMetadataInContext,
-		skipOffsetting:          opts.sp.options.skipOffsetting,
+		skipJitterOffsetting:    opts.sp.options.skipJitterOffsetting,
+		scrapeOnShutdown:        opts.sp.options.ScrapeOnShutdown,
+		initialScrapeOffset:     opts.sp.options.InitialScrapeOffset,
 	}
 }
 
@@ -1231,31 +1249,52 @@ func (sl *scrapeLoop) setScrapeFailureLogger(l FailureLogger) {
 	sl.scrapeFailureLogger = l
 }
 
+func (sl *scrapeLoop) getScrapeOffset() time.Duration {
+	offset := sl.scraper.offset(sl.interval, sl.offsetSeed)
+	if sl.skipJitterOffsetting {
+		offset = time.Duration(0)
+	}
+	return sl.initialScrapeOffset + offset
+}
+
 func (sl *scrapeLoop) run(errc chan<- error) {
-	if !sl.skipOffsetting {
+	var (
+		last   time.Time
+		ticker = time.NewTicker(sl.interval)
+	)
+	defer func() {
+		if sl.scrapeOnShutdown {
+			last = sl.scrapeAndReport(last, time.Now().Round(0), errc)
+		}
+		// Let the stop() know it can continue.
+		close(sl.stopped)
+		if sl.parentCtx.Err() == nil {
+			if !sl.disabledEndOfRunStalenessMarkers.Load() {
+				sl.endOfRunStaleness(last, ticker, sl.interval)
+			}
+		}
+		ticker.Stop()
+	}()
+
+	// Initial offset and jitter offset, if any.
+	offset := sl.getScrapeOffset()
+	if offset > 0 {
 		select {
-		case <-time.After(sl.scraper.offset(sl.interval, sl.offsetSeed)):
+		case <-time.After(offset):
 			// Continue after a scraping offset.
 		case <-sl.ctx.Done():
-			close(sl.stopped)
 			return
 		}
 	}
 
-	var last time.Time
-
+	// Reset the ticker so target scrape times are aligned to the offset+intervals.
+	ticker.Reset(sl.interval)
 	alignedScrapeTime := time.Now().Round(0)
-	ticker := time.NewTicker(sl.interval)
-	defer ticker.Stop()
 
-mainLoop:
 	for {
 		select {
-		case <-sl.parentCtx.Done():
-			close(sl.stopped)
-			return
 		case <-sl.ctx.Done():
-			break mainLoop
+			return
 		default:
 		}
 
@@ -1282,19 +1321,10 @@ mainLoop:
 		last = sl.scrapeAndReport(last, scrapeTime, errc)
 
 		select {
-		case <-sl.parentCtx.Done():
-			close(sl.stopped)
-			return
 		case <-sl.ctx.Done():
-			break mainLoop
+			return
 		case <-ticker.C:
 		}
-	}
-
-	close(sl.stopped)
-
-	if !sl.disabledEndOfRunStalenessMarkers.Load() {
-		sl.endOfRunStaleness(last, ticker, sl.interval)
 	}
 }
 

--- a/vendor/github.com/prometheus/prometheus/scrape/scrape_append_v2.go
+++ b/vendor/github.com/prometheus/prometheus/scrape/scrape_append_v2.go
@@ -102,7 +102,7 @@ func (sl *scrapeLoopAppenderV2) append(b []byte, contentType string, ts time.Tim
 		IgnoreNativeHistograms:                  !sl.enableNativeHistogramScraping,
 		ConvertClassicHistogramsToNHCB:          sl.convertClassicHistToNHCB,
 		KeepClassicOnClassicAndNativeHistograms: sl.alwaysScrapeClassicHist,
-		OpenMetricsSkipSTSeries:                 sl.enableSTZeroIngestion,
+		OpenMetricsSkipSTSeries:                 sl.parseST,
 		FallbackContentType:                     sl.fallbackScrapeProtocol,
 	})
 	if p == nil {
@@ -254,7 +254,7 @@ loop:
 			}
 
 			st := int64(0)
-			if sl.enableSTZeroIngestion {
+			if sl.parseST {
 				// p.StartTimestamp() tend to be expensive (e.g. OM1). Do it only if we care.
 				st = p.StartTimestamp()
 			}

--- a/vendor/github.com/prometheus/prometheus/storage/remote/queue_manager.go
+++ b/vendor/github.com/prometheus/prometheus/storage/remote/queue_manager.go
@@ -761,11 +761,12 @@ outer:
 			default:
 			}
 			if t.shards.enqueue(s.Ref, timeSeries{
-				seriesLabels: lbls,
-				metadata:     meta,
-				timestamp:    s.T,
-				value:        s.V,
-				sType:        tSample,
+				seriesLabels:   lbls,
+				metadata:       meta,
+				startTimestamp: s.ST,
+				timestamp:      s.T,
+				value:          s.V,
+				sType:          tSample,
 			}) {
 				continue outer
 			}
@@ -883,9 +884,10 @@ outer:
 			if t.shards.enqueue(h.Ref, timeSeries{
 				seriesLabels: lbls,
 				metadata:     meta,
-				timestamp:    h.T,
-				histogram:    h.H,
-				sType:        tHistogram,
+				// TODO(bwplotka): Populate ST once histogram Ref has it.
+				timestamp: h.T,
+				histogram: h.H,
+				sType:     tHistogram,
 			}) {
 				continue outer
 			}
@@ -942,8 +944,9 @@ outer:
 			default:
 			}
 			if t.shards.enqueue(h.Ref, timeSeries{
-				seriesLabels:   lbls,
-				metadata:       meta,
+				seriesLabels: lbls,
+				metadata:     meta,
+				// TODO(bwplotka): Populate ST once histogram Ref has it.
 				timestamp:      h.T,
 				floatHistogram: h.FH,
 				sType:          tFloatHistogram,
@@ -1397,13 +1400,13 @@ type queue struct {
 }
 
 type timeSeries struct {
-	seriesLabels   labels.Labels
-	value          float64
-	histogram      *histogram.Histogram
-	floatHistogram *histogram.FloatHistogram
-	metadata       *metadata.Metadata
-	timestamp      int64
-	exemplarLabels labels.Labels
+	seriesLabels              labels.Labels
+	value                     float64
+	histogram                 *histogram.Histogram
+	floatHistogram            *histogram.FloatHistogram
+	metadata                  *metadata.Metadata
+	startTimestamp, timestamp int64
+	exemplarLabels            labels.Labels
 	// The type of series: sample, exemplar, or histogram.
 	sType seriesType
 }
@@ -1994,8 +1997,9 @@ func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries,
 		switch d.sType {
 		case tSample:
 			pendingData[nPending].Samples = append(pendingData[nPending].Samples, writev2.Sample{
-				Value:     d.value,
-				Timestamp: d.timestamp,
+				Value:          d.value,
+				Timestamp:      d.timestamp,
+				StartTimestamp: d.startTimestamp,
 			})
 			nPendingSamples++
 		case tExemplar:
@@ -2006,9 +2010,11 @@ func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries,
 			})
 			nPendingExemplars++
 		case tHistogram:
+			// TODO(bwplotka): Extend with ST once histograms populate it.
 			pendingData[nPending].Histograms = append(pendingData[nPending].Histograms, writev2.FromIntHistogram(d.timestamp, d.histogram))
 			nPendingHistograms++
 		case tFloatHistogram:
+			// TODO(bwplotka): Extend with ST once histograms populate it.
 			pendingData[nPending].Histograms = append(pendingData[nPending].Histograms, writev2.FromFloatHistogram(d.timestamp, d.floatHistogram))
 			nPendingHistograms++
 		case tMetadata:

--- a/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/bstream.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/bstream.go
@@ -215,6 +215,95 @@ func (b *bstreamReader) ReadByte() (byte, error) {
 	return byte(v), nil
 }
 
+// readXOR2Control reads the XOR2 variable-length joint control prefix
+// and returns 0-5 mapping to the six encoding cases:
+//
+//	0 → '0'     dod=0, val=0               (1 bit consumed)
+//	1 → '10'    dod=0, val≠0               (2 bits consumed)
+//	2 → '110'   dod≠0, 13-bit signed dod   (3 bits consumed)
+//	3 → '1110'  dod≠0, 20-bit signed dod   (4 bits consumed)
+//	4 → '11110' dod≠0, 64-bit escape       (5 bits consumed)
+//	5 → '11111' dod=0, stale NaN           (5 bits consumed)
+//
+// The fast path peeks at 4 bits from the internal buffer; for the '1111'
+// prefix a fifth bit is read to distinguish cases 4 and 5.
+func (b *bstreamReader) readXOR2Control() (uint8, error) {
+	if b.valid >= 4 {
+		top4 := uint8((b.buffer >> (b.valid - 4)) & 0xf)
+		if top4 < 8 { // '0xxx' → case 0.
+			b.valid--
+			return 0, nil
+		}
+		if top4 < 12 { // '10xx' → case 1.
+			b.valid -= 2
+			return 1, nil
+		}
+		if top4 < 14 { // '110x' → case 2.
+			b.valid -= 3
+			return 2, nil
+		}
+		if top4 == 14 { // '1110' → case 3.
+			b.valid -= 4
+			return 3, nil
+		}
+		// '1111': need fifth bit to distinguish cases 4 and 5.
+		if b.valid >= 5 {
+			bit4 := uint8((b.buffer >> (b.valid - 5)) & 1)
+			b.valid -= 5
+			return 4 + bit4, nil
+		}
+		// Fifth bit spans a buffer boundary; consume the four known bits
+		// and read the fifth from the stream.
+		b.valid -= 4
+		bit4, err := b.readBit()
+		if err != nil {
+			return 0, err
+		}
+		if bit4 == zero {
+			return 4, nil
+		}
+		return 5, nil
+	}
+
+	// Slow path: bits may span buffer boundaries, read one at a time.
+	bit0, err := b.readBit()
+	if err != nil {
+		return 0, err
+	}
+	if bit0 == zero {
+		return 0, nil
+	}
+	bit1, err := b.readBit()
+	if err != nil {
+		return 0, err
+	}
+	if bit1 == zero {
+		return 1, nil
+	}
+	bit2, err := b.readBit()
+	if err != nil {
+		return 0, err
+	}
+	if bit2 == zero {
+		return 2, nil
+	}
+	bit3, err := b.readBit()
+	if err != nil {
+		return 0, err
+	}
+	if bit3 == zero {
+		return 3, nil
+	}
+	bit4, err := b.readBit()
+	if err != nil {
+		return 0, err
+	}
+	if bit4 == zero {
+		return 4, nil
+	}
+	return 5, nil
+}
+
 // loadNextBuffer loads the next bytes from the stream into the internal buffer.
 // The input nbits is the minimum number of bits that must be read, but the implementation
 // can read more (if possible) to improve performances.

--- a/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/chunk.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/chunk.go
@@ -30,6 +30,7 @@ const (
 	EncXOR
 	EncHistogram
 	EncFloatHistogram
+	EncXOR2
 )
 
 func (e Encoding) String() string {
@@ -42,13 +43,15 @@ func (e Encoding) String() string {
 		return "histogram"
 	case EncFloatHistogram:
 		return "floathistogram"
+	case EncXOR2:
+		return "XOR2"
 	}
 	return "<unknown>"
 }
 
 // IsValidEncoding returns true for supported encodings.
 func IsValidEncoding(e Encoding) bool {
-	return e == EncXOR || e == EncHistogram || e == EncFloatHistogram
+	return e == EncXOR || e == EncHistogram || e == EncFloatHistogram || e == EncXOR2
 }
 
 const (
@@ -73,6 +76,8 @@ type Chunk interface {
 	Bytes() []byte
 
 	// Encoding returns the encoding type of the chunk.
+	// If the chunk is capable of storing ST (start timestamps), it should
+	// return the appropriate encoding type (e.g., EncXOR2).
 	Encoding() Encoding
 
 	// Appender returns an appender to append samples to the chunk.
@@ -186,9 +191,12 @@ func (v ValueType) String() string {
 	}
 }
 
-func (v ValueType) ChunkEncoding() Encoding {
+func (v ValueType) ChunkEncoding(useXOR2 bool) Encoding {
 	switch v {
 	case ValFloat:
+		if useXOR2 {
+			return EncXOR2
+		}
 		return EncXOR
 	case ValHistogram:
 		return EncHistogram
@@ -199,17 +207,9 @@ func (v ValueType) ChunkEncoding() Encoding {
 	}
 }
 
-func (v ValueType) NewChunk() (Chunk, error) {
-	switch v {
-	case ValFloat:
-		return NewXORChunk(), nil
-	case ValHistogram:
-		return NewHistogramChunk(), nil
-	case ValFloatHistogram:
-		return NewFloatHistogramChunk(), nil
-	default:
-		return nil, fmt.Errorf("value type %v unsupported", v)
-	}
+// NewChunk returns a new empty chunk for the given value type.
+func (v ValueType) NewChunk(useXOR2 bool) (Chunk, error) {
+	return NewEmptyChunk(v.ChunkEncoding(useXOR2))
 }
 
 // MockSeriesIterator returns an iterator for a mock series with custom
@@ -299,6 +299,7 @@ type pool struct {
 	xor            sync.Pool
 	histogram      sync.Pool
 	floatHistogram sync.Pool
+	xo2            sync.Pool
 }
 
 // NewPool returns a new pool.
@@ -319,6 +320,11 @@ func NewPool() Pool {
 				return &FloatHistogramChunk{b: bstream{}}
 			},
 		},
+		xo2: sync.Pool{
+			New: func() any {
+				return &XOR2Chunk{b: bstream{}}
+			},
+		},
 	}
 }
 
@@ -331,6 +337,8 @@ func (p *pool) Get(e Encoding, b []byte) (Chunk, error) {
 		c = p.histogram.Get().(*HistogramChunk)
 	case EncFloatHistogram:
 		c = p.floatHistogram.Get().(*FloatHistogramChunk)
+	case EncXOR2:
+		c = p.xo2.Get().(*XOR2Chunk)
 	default:
 		return nil, fmt.Errorf("invalid chunk encoding %q", e)
 	}
@@ -352,6 +360,9 @@ func (p *pool) Put(c Chunk) error {
 	case EncFloatHistogram:
 		_, ok = c.(*FloatHistogramChunk)
 		sp = &p.floatHistogram
+	case EncXOR2:
+		_, ok = c.(*XOR2Chunk)
+		sp = &p.xo2
 	default:
 		return fmt.Errorf("invalid chunk encoding %q", c.Encoding())
 	}
@@ -378,6 +389,8 @@ func FromData(e Encoding, d []byte) (Chunk, error) {
 		return &HistogramChunk{b: bstream{count: 0, stream: d}}, nil
 	case EncFloatHistogram:
 		return &FloatHistogramChunk{b: bstream{count: 0, stream: d}}, nil
+	case EncXOR2:
+		return &XOR2Chunk{b: bstream{count: 0, stream: d}}, nil
 	}
 	return nil, fmt.Errorf("invalid chunk encoding %q", e)
 }
@@ -391,6 +404,8 @@ func NewEmptyChunk(e Encoding) (Chunk, error) {
 		return NewHistogramChunk(), nil
 	case EncFloatHistogram:
 		return NewFloatHistogramChunk(), nil
+	case EncXOR2:
+		return NewXOR2Chunk(), nil
 	}
 	return nil, fmt.Errorf("invalid chunk encoding %q", e)
 }

--- a/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/xor2.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/xor2.go
@@ -1,0 +1,822 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// XOR2Chunk implements XOR encoding with joint timestamp+value control bits
+// and byte-packed dod encoding for efficient appending. It also has an extra
+// header byte after the sample count to allow for optionally encoding start
+// timestamp (ST).
+//
+// Control prefix for samples >= 2:
+//
+//	0     → dod=0 AND value unchanged              (1 bit)
+//	10    → dod=0, value changed                   (2 bits, then value encoding)
+//	110   → dod≠0, 13-bit signed [-4096, 4095]     (prefix+dod packed into 2 bytes)
+//	1110  → dod≠0, 20-bit signed [-524288, 524287] (prefix+dod packed into 3 bytes)
+//	11110 → dod≠0, 64-bit escape                   (5+64 bits, then value encoding)
+//	11111 → dod=0, stale NaN                       (5 bits, no value field)
+//
+// The dod bins are widened so that prefix+dod aligns to byte boundaries,
+// replacing writeBit calls with writeByte for common cases.
+//
+// Value encoding for the dod≠0 cases (`<varbit_xor2>`):
+//
+//	0   → value unchanged
+//	10  → reuse previous leading/trailing window
+//	110 → new leading/trailing window
+//	111 → stale NaN
+//
+// Value encoding for the dod=0, value-changed case (`<varbit_xor2_nn>`):
+//
+//	0 → reuse previous leading/trailing window
+//	1 → new leading/trailing window
+//
+// Start timestamp (ST) encoding:
+//
+// 1-byte ST header (at b[chunkHeaderSize]) layout:
+//
+//	bit 7 (0x80): firstSTKnown   — ST for the first sample is present in the stream
+//	bits 6-0:    firstSTChangeOn — sample index where the first ST change begins
+//
+// When no ST is provided (st == 0 always), the header stays 0x00 and the
+// chunk has no additional bits in it.
+//
+// When ST is present, the ST delta (prevT - st) is appended after each
+// sample's joint timestamp+value encoding using putVarbitInt.
+
+package chunkenc
+
+import (
+	"encoding/binary"
+	"math"
+	"math/bits"
+
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/value"
+)
+
+const (
+	chunkSTHeaderSize  = 1
+	maxFirstSTChangeOn = 0x7F
+)
+
+func writeHeaderFirstSTKnown(b []byte) {
+	b[0] = 0x80
+}
+
+func writeHeaderFirstSTChangeOn(b []byte, firstSTChangeOn uint16) {
+	// First bit indicates the initial ST value.
+	// Here we save the sample number from where the first change occurs in the
+	// rest of the byte (7 bits)
+
+	if firstSTChangeOn > maxFirstSTChangeOn {
+		// This should never happen, would cause corruption (ST already skipped but shouldn't).
+		return
+	}
+	b[0] |= uint8(firstSTChangeOn)
+}
+
+func readSTHeader(b []byte) (firstSTKnown bool, firstSTChangeOn uint8) {
+	if b[0] == 0x00 {
+		return false, 0
+	}
+	if b[0] == 0x80 {
+		return true, 0
+	}
+	mask := byte(0x80)
+	if b[0]&mask != 0 {
+		firstSTKnown = true
+	}
+	mask = 0x7F
+	return firstSTKnown, b[0] & mask
+}
+
+// XOR2Chunk holds XOR2 encoded samples with optional start
+// timestamp per chunk or per sample.
+type XOR2Chunk struct {
+	b bstream
+}
+
+// NewXOR2Chunk returns a new chunk with XOR2 encoding.
+func NewXOR2Chunk() *XOR2Chunk {
+	b := make([]byte, chunkHeaderSize+chunkSTHeaderSize, chunkAllocationSize)
+	return &XOR2Chunk{b: bstream{stream: b, count: 0}}
+}
+
+func (c *XOR2Chunk) Reset(stream []byte) {
+	c.b.Reset(stream)
+}
+
+// Encoding returns the encoding type.
+func (*XOR2Chunk) Encoding() Encoding {
+	return EncXOR2
+}
+
+// Bytes returns the underlying byte slice of the chunk.
+func (c *XOR2Chunk) Bytes() []byte {
+	return c.b.bytes()
+}
+
+// NumSamples returns the number of samples in the chunk.
+func (c *XOR2Chunk) NumSamples() int {
+	return int(binary.BigEndian.Uint16(c.Bytes()))
+}
+
+// Compact implements the Chunk interface.
+func (c *XOR2Chunk) Compact() {
+	if l := len(c.b.stream); cap(c.b.stream) > l+chunkCompactCapacityThreshold {
+		buf := make([]byte, l)
+		copy(buf, c.b.stream)
+		c.b.stream = buf
+	}
+}
+
+// Appender implements the Chunk interface.
+func (c *XOR2Chunk) Appender() (Appender, error) {
+	if len(c.b.stream) == chunkHeaderSize+chunkSTHeaderSize {
+		return &xor2Appender{
+			b:       &c.b,
+			t:       math.MinInt64,
+			leading: 0xff,
+		}, nil
+	}
+	it := c.iterator(nil)
+
+	for it.Next() != ValNone {
+	}
+	if err := it.Err(); err != nil {
+		return nil, err
+	}
+
+	// Set the bit position for continuing writes. The iterator's reader tracks
+	// how many bits remain unread in the last byte.
+	c.b.count = it.br.valid
+
+	a := &xor2Appender{
+		b:               &c.b,
+		st:              it.st,
+		t:               it.t,
+		v:               it.baselineV,
+		tDelta:          it.tDelta,
+		stDiff:          it.stDiff,
+		leading:         it.leading,
+		trailing:        it.trailing,
+		numTotal:        binary.BigEndian.Uint16(c.b.bytes()),
+		firstSTKnown:    it.firstSTKnown,
+		firstSTChangeOn: uint16(it.firstSTChangeOn),
+	}
+	return a, nil
+}
+
+func (c *XOR2Chunk) iterator(it Iterator) *xor2Iterator {
+	if iter, ok := it.(*xor2Iterator); ok {
+		iter.Reset(c.b.bytes())
+		return iter
+	}
+	iter := &xor2Iterator{}
+	iter.Reset(c.b.bytes())
+	return iter
+}
+
+// Iterator implements the Chunk interface.
+func (c *XOR2Chunk) Iterator(it Iterator) Iterator {
+	return c.iterator(it)
+}
+
+// xor2Appender appends samples with optional start timestamps using
+// the XOR2 joint control bit encoding for regular timestamp and value,
+// and putVarbitInt for the start timestamp delta.
+type xor2Appender struct {
+	b *bstream
+
+	st     int64
+	t      int64
+	v      float64
+	tDelta uint64
+	stDiff int64 // prevT - st for the previous sample.
+
+	leading  uint8
+	trailing uint8
+
+	numTotal        uint16
+	firstSTChangeOn uint16
+	firstSTKnown    bool
+}
+
+func (a *xor2Appender) Append(st, t int64, v float64) {
+	var (
+		tDelta uint64
+		stDiff int64
+	)
+
+	switch a.numTotal {
+	case 0:
+		buf := make([]byte, binary.MaxVarintLen64)
+		for _, b := range buf[:binary.PutVarint(buf, t)] {
+			a.b.writeByte(b)
+		}
+		a.b.writeBits(math.Float64bits(v), 64)
+
+		if st != 0 {
+			for _, b := range buf[:binary.PutVarint(buf, t-st)] {
+				a.b.writeByte(b)
+			}
+			a.firstSTKnown = true
+			writeHeaderFirstSTKnown(a.b.bytes()[chunkHeaderSize:])
+		}
+
+	case 1:
+		tDelta = uint64(t - a.t)
+
+		buf := make([]byte, binary.MaxVarintLen64)
+		for _, b := range buf[:binary.PutUvarint(buf, tDelta)] {
+			a.b.writeByte(b)
+		}
+
+		a.writeVDelta(v)
+
+		if st != a.st {
+			stDiff = a.t - st
+			a.firstSTChangeOn = 1
+			writeHeaderFirstSTChangeOn(a.b.bytes()[chunkHeaderSize:], 1)
+			putVarbitInt(a.b, stDiff)
+		}
+
+	default:
+		tDelta = uint64(t - a.t)
+		dod := int64(tDelta - a.tDelta)
+
+		// Fast path: no ST involvement at all.
+		if st == 0 && a.numTotal != maxFirstSTChangeOn && a.firstSTChangeOn == 0 && !a.firstSTKnown {
+			a.encodeJoint(dod, v)
+			a.t = t
+			if !value.IsStaleNaN(v) {
+				a.v = v
+			}
+			a.tDelta = tDelta
+			a.numTotal++
+			binary.BigEndian.PutUint16(a.b.bytes(), a.numTotal)
+			return
+		}
+
+		// Slow path: ST may be involved.
+		a.encodeJoint(dod, v)
+
+		if a.firstSTChangeOn == 0 {
+			if st != a.st || a.numTotal == maxFirstSTChangeOn {
+				// First ST change: record prevT - st.
+				stDiff = a.t - st
+				a.firstSTChangeOn = a.numTotal
+				writeHeaderFirstSTChangeOn(a.b.bytes()[chunkHeaderSize:], a.numTotal)
+				putVarbitInt(a.b, stDiff)
+			}
+		} else {
+			stDiff = a.t - st
+			putVarbitInt(a.b, stDiff-a.stDiff)
+		}
+	}
+
+	a.st = st
+	a.t = t
+	if !value.IsStaleNaN(v) {
+		a.v = v
+	}
+	a.tDelta = tDelta
+	a.stDiff = stDiff
+	a.numTotal++
+	binary.BigEndian.PutUint16(a.b.bytes(), a.numTotal)
+}
+
+// encodeJoint writes the XOR2 joint timestamp+value control sequence for
+// samples >= 2.
+func (a *xor2Appender) encodeJoint(dod int64, v float64) {
+	if dod == 0 {
+		switch {
+		case value.IsStaleNaN(v):
+			a.b.writeBits(0b11111, 5)
+		case math.Float64bits(v)^math.Float64bits(a.v) == 0:
+			a.b.writeBit(zero)
+		default:
+			a.b.writeBits(0b10, 2)
+			a.writeVDeltaKnownNonZero(v)
+		}
+		return
+	}
+
+	switch {
+	case dod >= -(1<<12) && dod <= (1<<12)-1:
+		// 13-bit dod: prefix `110` packed with top 5 bits → 2 bytes total.
+		a.b.writeByte(0b110_00000 | byte(uint64(dod)>>8)&0x1F)
+		a.b.writeByte(byte(uint64(dod)))
+	case dod >= -(1<<19) && dod <= (1<<19)-1:
+		// 20-bit dod: prefix `1110` packed with top 4 bits → 3 bytes total.
+		a.b.writeByte(0b1110_0000 | byte(uint64(dod)>>16)&0x0F)
+		a.b.writeByte(byte(uint64(dod) >> 8))
+		a.b.writeByte(byte(uint64(dod)))
+	default:
+		// 64-bit escape (rare): `11110`.
+		a.b.writeBits(0b11110, 5)
+		a.b.writeBits(uint64(dod), 64)
+	}
+	a.writeVDelta(v)
+}
+
+// writeVDelta encodes the value delta for the dod≠0 case.
+func (a *xor2Appender) writeVDelta(v float64) {
+	if value.IsStaleNaN(v) {
+		a.b.writeBits(0b111, 3)
+		return
+	}
+
+	delta := math.Float64bits(v) ^ math.Float64bits(a.v)
+
+	if delta == 0 {
+		a.b.writeBit(zero)
+		return
+	}
+
+	newLeading := uint8(bits.LeadingZeros64(delta))
+	newTrailing := uint8(bits.TrailingZeros64(delta))
+
+	if newLeading >= 32 {
+		newLeading = 31
+	}
+
+	if a.leading != 0xff && newLeading >= a.leading && newTrailing >= a.trailing {
+		a.b.writeBits(0b10, 2)
+		a.b.writeBits(delta>>a.trailing, 64-int(a.leading)-int(a.trailing))
+		return
+	}
+
+	a.leading, a.trailing = newLeading, newTrailing
+
+	a.b.writeBits(0b110, 3)
+	a.b.writeBits(uint64(newLeading), 5)
+
+	sigbits := 64 - newLeading - newTrailing
+	a.b.writeBits(uint64(sigbits), 6)
+	a.b.writeBits(delta>>newTrailing, int(sigbits))
+}
+
+// writeVDeltaKnownNonZero encodes the value delta when it is known to be
+// non-zero and non-stale (dod=0, value-changed case).
+func (a *xor2Appender) writeVDeltaKnownNonZero(v float64) {
+	delta := math.Float64bits(v) ^ math.Float64bits(a.v)
+
+	newLeading := uint8(bits.LeadingZeros64(delta))
+	newTrailing := uint8(bits.TrailingZeros64(delta))
+
+	if newLeading >= 32 {
+		newLeading = 31
+	}
+
+	if a.leading != 0xff && newLeading >= a.leading && newTrailing >= a.trailing {
+		a.b.writeBit(zero)
+		a.b.writeBits(delta>>a.trailing, 64-int(a.leading)-int(a.trailing))
+		return
+	}
+
+	a.leading, a.trailing = newLeading, newTrailing
+
+	a.b.writeBit(one)
+	a.b.writeBits(uint64(newLeading), 5)
+
+	sigbits := 64 - newLeading - newTrailing
+	a.b.writeBits(uint64(sigbits), 6)
+	a.b.writeBits(delta>>newTrailing, int(sigbits))
+}
+
+func (*xor2Appender) AppendHistogram(*HistogramAppender, int64, int64, *histogram.Histogram, bool) (Chunk, bool, Appender, error) {
+	panic("appended a histogram sample to a float chunk")
+}
+
+func (*xor2Appender) AppendFloatHistogram(*FloatHistogramAppender, int64, int64, *histogram.FloatHistogram, bool) (Chunk, bool, Appender, error) {
+	panic("appended a float histogram sample to a float chunk")
+}
+
+// xor2Iterator decodes XOR2 chunks.
+type xor2Iterator struct {
+	br       bstreamReader
+	numTotal uint16
+	numRead  uint16
+
+	firstSTKnown    bool
+	firstSTChangeOn uint8
+
+	leading  uint8
+	trailing uint8
+
+	st  int64
+	t   int64
+	val float64
+
+	tDelta uint64
+	stDiff int64 // Accumulated prevT - st.
+	err    error
+
+	baselineV float64 // Last non-stale value for XOR baseline.
+}
+
+func (it *xor2Iterator) Seek(t int64) ValueType {
+	if it.err != nil {
+		return ValNone
+	}
+
+	for t > it.t || it.numRead == 0 {
+		if it.Next() == ValNone {
+			return ValNone
+		}
+	}
+	return ValFloat
+}
+
+func (it *xor2Iterator) At() (int64, float64) {
+	return it.t, it.val
+}
+
+func (*xor2Iterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
+	panic("cannot call xor2Iterator.AtHistogram")
+}
+
+func (*xor2Iterator) AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
+	panic("cannot call xor2Iterator.AtFloatHistogram")
+}
+
+func (it *xor2Iterator) AtT() int64 {
+	return it.t
+}
+
+func (it *xor2Iterator) AtST() int64 {
+	return it.st
+}
+
+func (it *xor2Iterator) Err() error {
+	return it.err
+}
+
+func (it *xor2Iterator) Reset(b []byte) {
+	it.br = newBReader(b[chunkHeaderSize+chunkSTHeaderSize:])
+	it.numTotal = binary.BigEndian.Uint16(b)
+	it.firstSTKnown, it.firstSTChangeOn = readSTHeader(b[chunkHeaderSize:])
+
+	it.numRead = 0
+	it.st = 0
+	it.t = 0
+	it.val = 0
+	it.leading = 0
+	it.trailing = 0
+	it.tDelta = 0
+	it.stDiff = 0
+	it.baselineV = 0
+	it.err = nil
+}
+
+func (it *xor2Iterator) Next() ValueType {
+	if it.err != nil || it.numRead == it.numTotal {
+		return ValNone
+	}
+
+	if it.numRead == 0 {
+		t, err := binary.ReadVarint(&it.br)
+		if err != nil {
+			it.err = err
+			return ValNone
+		}
+		v, err := it.br.readBits(64)
+		if err != nil {
+			it.err = err
+			return ValNone
+		}
+		it.t = t
+		it.val = math.Float64frombits(v)
+		if !value.IsStaleNaN(it.val) {
+			it.baselineV = it.val
+		}
+
+		// Optional ST for sample 0.
+		if it.firstSTKnown {
+			stDiff, err := binary.ReadVarint(&it.br)
+			if err != nil {
+				it.err = err
+				return ValNone
+			}
+			it.st = t - stDiff
+		}
+
+		it.numRead++
+		return ValFloat
+	}
+
+	if it.numRead == 1 {
+		tDelta, err := binary.ReadUvarint(&it.br)
+		if err != nil {
+			it.err = err
+			return ValNone
+		}
+		prevT := it.t
+		it.tDelta = tDelta
+		it.t += int64(it.tDelta)
+
+		if err := it.decodeValue(); err != nil {
+			it.err = err
+			return ValNone
+		}
+
+		// Optional ST delta for sample 1.
+		if it.firstSTChangeOn == 1 {
+			sdod, err := readVarbitInt(&it.br)
+			if err != nil {
+				it.err = err
+				return ValNone
+			}
+			it.stDiff = sdod
+			it.st = prevT - sdod
+		}
+
+		it.numRead++
+		return ValFloat
+	}
+
+	// Sample N >= 2: read joint XOR2 control, then optional ST data.
+	prevT := it.t
+	savedNumRead := it.numRead
+
+	ctrl, err := it.br.readXOR2Control()
+	if err != nil {
+		it.err = err
+		return ValNone
+	}
+
+	switch ctrl {
+	case 0:
+		// dod=0, value unchanged.
+		it.t += int64(it.tDelta)
+		it.val = it.baselineV
+	case 1:
+		// dod=0, value changed.
+		it.t += int64(it.tDelta)
+		if err := it.decodeValueKnownNonZero(); err != nil {
+			it.err = err
+			return ValNone
+		}
+	case 2:
+		// 13-bit dod.
+		if err := it.readDod(13); err != nil {
+			it.err = err
+			return ValNone
+		}
+		if err := it.decodeValue(); err != nil {
+			it.err = err
+			return ValNone
+		}
+	case 3:
+		// 20-bit dod.
+		if err := it.readDod(20); err != nil {
+			it.err = err
+			return ValNone
+		}
+		if err := it.decodeValue(); err != nil {
+			it.err = err
+			return ValNone
+		}
+	case 4:
+		// 64-bit escape.
+		if err := it.readDod(64); err != nil {
+			it.err = err
+			return ValNone
+		}
+		if err := it.decodeValue(); err != nil {
+			it.err = err
+			return ValNone
+		}
+	default:
+		// dod=0, stale NaN.
+		it.t += int64(it.tDelta)
+		it.val = math.Float64frombits(value.StaleNaN)
+	}
+
+	// Optional ST data, appended after the joint timestamp+value encoding.
+	// The ST delta was encoded as (prevT - st), using the PREVIOUS sample's t.
+	if it.firstSTChangeOn > 0 && savedNumRead >= uint16(it.firstSTChangeOn) {
+		sdod, err := readVarbitInt(&it.br)
+		if err != nil {
+			it.err = err
+			return ValNone
+		}
+		if savedNumRead == uint16(it.firstSTChangeOn) {
+			it.stDiff = sdod
+		} else {
+			it.stDiff += sdod
+		}
+		it.st = prevT - it.stDiff
+	}
+
+	it.numRead++
+	return ValFloat
+}
+
+// readDod reads a signed dod of width w bits and updates it.tDelta and it.t.
+func (it *xor2Iterator) readDod(w uint8) error {
+	var b uint64
+	if it.br.valid >= w {
+		it.br.valid -= w
+		b = (it.br.buffer >> it.br.valid) & ((uint64(1) << w) - 1)
+	} else {
+		var err error
+		b, err = it.br.readBits(w)
+		if err != nil {
+			return err
+		}
+	}
+
+	if w < 64 && b >= (1<<(w-1)) {
+		b -= 1 << w
+	}
+
+	it.tDelta = uint64(int64(it.tDelta) + int64(b))
+	it.t += int64(it.tDelta)
+	return nil
+}
+
+// decodeValue reads the XOR2 value encoding for the dod≠0 case:
+//
+//	`0`   → value unchanged
+//	`10`  → reuse previous leading/trailing window
+//	`110` → new leading/trailing window
+//	`111` → stale NaN
+func (it *xor2Iterator) decodeValue() error {
+	var bit bit
+	if it.br.valid > 0 {
+		it.br.valid--
+		bit = (it.br.buffer & (uint64(1) << it.br.valid)) != 0
+	} else {
+		var err error
+		bit, err = it.br.readBit()
+		if err != nil {
+			return err
+		}
+	}
+
+	if bit == zero {
+		// `0` → value unchanged.
+		it.val = it.baselineV
+		return nil
+	}
+
+	if it.br.valid > 0 {
+		it.br.valid--
+		bit = (it.br.buffer & (uint64(1) << it.br.valid)) != 0
+	} else {
+		var err error
+		bit, err = it.br.readBit()
+		if err != nil {
+			return err
+		}
+	}
+
+	if bit == zero {
+		// `10` → reuse previous leading/trailing window.
+		sz := uint8(64 - int(it.leading) - int(it.trailing))
+		var valueBits uint64
+		if it.br.valid >= sz {
+			it.br.valid -= sz
+			valueBits = (it.br.buffer >> it.br.valid) & ((uint64(1) << sz) - 1)
+		} else {
+			var err error
+			valueBits, err = it.br.readBits(sz)
+			if err != nil {
+				return err
+			}
+		}
+		vbits := math.Float64bits(it.baselineV)
+		vbits ^= valueBits << it.trailing
+		it.val = math.Float64frombits(vbits)
+		it.baselineV = it.val
+		return nil
+	}
+
+	if it.br.valid > 0 {
+		it.br.valid--
+		bit = (it.br.buffer & (uint64(1) << it.br.valid)) != 0
+	} else {
+		var err error
+		bit, err = it.br.readBit()
+		if err != nil {
+			return err
+		}
+	}
+
+	if bit == zero {
+		// `110` → new leading/trailing window.
+		return it.decodeNewLeadingTrailing()
+	}
+
+	// `111` → stale NaN.
+	it.val = math.Float64frombits(value.StaleNaN)
+	return nil
+}
+
+// decodeValueKnownNonZero reads the XOR2 value encoding for the dod=0,
+// value-changed case:
+//
+//	`0` → reuse previous leading/trailing window
+//	`1` → new leading/trailing window
+func (it *xor2Iterator) decodeValueKnownNonZero() error {
+	var bit bit
+	if it.br.valid > 0 {
+		it.br.valid--
+		bit = (it.br.buffer & (uint64(1) << it.br.valid)) != 0
+	} else {
+		var err error
+		bit, err = it.br.readBit()
+		if err != nil {
+			return err
+		}
+	}
+
+	if bit == zero {
+		// `0` → reuse previous leading/trailing window.
+		sz := uint8(64 - int(it.leading) - int(it.trailing))
+		var valueBits uint64
+		if it.br.valid >= sz {
+			it.br.valid -= sz
+			valueBits = (it.br.buffer >> it.br.valid) & ((uint64(1) << sz) - 1)
+		} else {
+			var err error
+			valueBits, err = it.br.readBits(sz)
+			if err != nil {
+				return err
+			}
+		}
+		vbits := math.Float64bits(it.baselineV)
+		vbits ^= valueBits << it.trailing
+		it.val = math.Float64frombits(vbits)
+		it.baselineV = it.val
+		return nil
+	}
+
+	// `1` → new leading/trailing window.
+	return it.decodeNewLeadingTrailing()
+}
+
+// decodeNewLeadingTrailing reads a new leading/sigbits/value triple and
+// updates it.leading, it.trailing, it.val, and it.baselineV.
+func (it *xor2Iterator) decodeNewLeadingTrailing() error {
+	var newLeading uint64
+	if it.br.valid >= 5 {
+		it.br.valid -= 5
+		newLeading = (it.br.buffer >> it.br.valid) & 0x1f
+	} else {
+		var err error
+		newLeading, err = it.br.readBits(5)
+		if err != nil {
+			return err
+		}
+	}
+
+	var sigbits uint64
+	if it.br.valid >= 6 {
+		it.br.valid -= 6
+		sigbits = (it.br.buffer >> it.br.valid) & 0x3f
+	} else {
+		var err error
+		sigbits, err = it.br.readBits(6)
+		if err != nil {
+			return err
+		}
+	}
+
+	it.leading = uint8(newLeading)
+	if sigbits == 0 {
+		sigbits = 64
+	}
+	it.trailing = 64 - it.leading - uint8(sigbits)
+
+	n := uint8(sigbits)
+	var valueBits uint64
+	if it.br.valid >= n {
+		it.br.valid -= n
+		valueBits = (it.br.buffer >> it.br.valid) & ((uint64(1) << n) - 1)
+	} else {
+		var err error
+		valueBits, err = it.br.readBits(n)
+		if err != nil {
+			return err
+		}
+	}
+
+	vbits := math.Float64bits(it.baselineV)
+	vbits ^= valueBits << it.trailing
+	it.val = math.Float64frombits(vbits)
+	it.baselineV = it.val
+	return nil
+}

--- a/vendor/github.com/prometheus/prometheus/tsdb/db.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/db.go
@@ -240,6 +240,11 @@ type Options struct {
 	// is implemented.
 	EnableSTAsZeroSample bool
 
+	// EnableXOR2Encoding enables the XOR2 chunk encoding for float samples.
+	// XOR2 provides better compression than XOR, especially for stale markers.
+	// Automatically set to true when EnableSTStorage is true.
+	EnableXOR2Encoding bool
+
 	// EnableSTStorage determines whether TSDB should write a Start Timestamp (ST)
 	// per sample to WAL.
 	// TODO(bwplotka): Implement this option as per PROM-60, currently it's noop.
@@ -868,6 +873,8 @@ func Open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, st
 		opts.FeatureRegistry.Set(features.TSDB, "isolation", !opts.IsolationDisabled)
 		opts.FeatureRegistry.Set(features.TSDB, "use_uncached_io", opts.UseUncachedIO)
 		opts.FeatureRegistry.Enable(features.TSDB, "native_histograms")
+		opts.FeatureRegistry.Set(features.TSDB, "st_storage", opts.EnableSTStorage)
+		opts.FeatureRegistry.Set(features.TSDB, "xor2_encoding", opts.EnableXOR2Encoding)
 	}
 
 	return open(dir, l, r, opts, rngs, stats)
@@ -1074,6 +1081,8 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 	headOpts.OutOfOrderCapMax.Store(opts.OutOfOrderCapMax)
 	headOpts.EnableSharding = opts.EnableSharding
 	headOpts.EnableSTAsZeroSample = opts.EnableSTAsZeroSample
+	headOpts.EnableSTStorage.Store(opts.EnableSTStorage)
+	headOpts.EnableXOR2Encoding.Store(opts.EnableXOR2Encoding)
 	headOpts.EnableMetadataWALRecords = opts.EnableMetadataWALRecords
 	if opts.WALReplayConcurrency > 0 {
 		headOpts.WALReplayConcurrency = opts.WALReplayConcurrency

--- a/vendor/github.com/prometheus/prometheus/tsdb/head.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head.go
@@ -161,6 +161,15 @@ type HeadOptions struct {
 	OutOfOrderTimeWindow atomic.Int64
 	OutOfOrderCapMax     atomic.Int64
 
+	// EnableSTStorage determines whether databases (WAL/WBL, tsdb,
+	// agent) should set a Start Time value per sample.
+	// Represents 'st-storage' feature flag.
+	EnableSTStorage atomic.Bool
+
+	// EnableXOR2Encoding enables XOR2 chunk encoding for float samples.
+	// Represents 'xor2-encoding' feature flag.
+	EnableXOR2Encoding atomic.Bool
+
 	ChunkRange int64
 	// ChunkDirRoot is the parent directory of the chunks directory.
 	ChunkDirRoot         string
@@ -1382,7 +1391,7 @@ func (h *Head) truncateWAL(mint int64) error {
 	}
 
 	h.metrics.checkpointCreationTotal.Inc()
-	if _, err = wlog.Checkpoint(h.logger, h.wal, first, last, h.keepSeriesInWALCheckpointFn(mint), mint); err != nil {
+	if _, err = wlog.Checkpoint(h.logger, h.wal, first, last, h.keepSeriesInWALCheckpointFn(mint), mint, h.opts.EnableSTStorage.Load()); err != nil {
 		h.metrics.checkpointCreationFail.Inc()
 		var cerr *chunks.CorruptionErr
 		if errors.As(err, &cerr) {
@@ -1676,7 +1685,7 @@ func (h *Head) Delete(ctx context.Context, mint, maxt int64, ms ...*labels.Match
 	}
 
 	if h.wal != nil {
-		var enc record.Encoder
+		enc := record.Encoder{EnableSTStorage: h.opts.EnableSTStorage.Load()}
 		if err := h.wal.Log(enc.Tombstones(stones, nil)); err != nil {
 			return err
 		}

--- a/vendor/github.com/prometheus/prometheus/tsdb/head_append.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head_append.go
@@ -185,6 +185,8 @@ func (h *Head) appender() *headAppender {
 			typesInBatch:          h.getTypeMap(),
 			appendID:              appendID,
 			cleanupAppendIDsBelow: cleanupAppendIDsBelow,
+			storeST:               h.opts.EnableSTStorage.Load(),
+			useXOR2:               h.opts.EnableXOR2Encoding.Load(),
 		},
 	}
 }
@@ -412,6 +414,8 @@ type headAppenderBase struct {
 
 	appendID, cleanupAppendIDsBelow uint64
 	closed                          bool
+	storeST                         bool
+	useXOR2                         bool
 }
 type headAppender struct {
 	headAppenderBase
@@ -1059,7 +1063,7 @@ func (a *headAppenderBase) log() error {
 	defer func() { a.head.putBytesBuffer(buf) }()
 
 	var rec []byte
-	var enc record.Encoder
+	enc := record.Encoder{EnableSTStorage: a.storeST}
 
 	if len(a.seriesRefs) > 0 {
 		rec = enc.Series(a.seriesRefs, buf)
@@ -1168,6 +1172,7 @@ type appenderCommitContext struct {
 	histoOOBRejected    int
 	inOrderMint         int64
 	inOrderMaxt         int64
+	appendChunkOpts     chunkOpts
 	oooMinT             int64
 	oooMaxT             int64
 	wblSamples          []record.RefSample
@@ -1177,8 +1182,7 @@ type appenderCommitContext struct {
 	oooMmapMarkersCount int
 	oooRecords          [][]byte
 	oooCapMax           int64
-	appendChunkOpts     chunkOpts
-	enc                 record.Encoder
+	oooEnc              record.Encoder
 }
 
 // commitExemplars adds all exemplars from the provided batch to the head's exemplar storage.
@@ -1228,31 +1232,31 @@ func (acc *appenderCommitContext) collectOOORecords(a *headAppenderBase) {
 				})
 			}
 		}
-		r := acc.enc.MmapMarkers(markers, a.head.getBytesBuffer())
+		r := acc.oooEnc.MmapMarkers(markers, a.head.getBytesBuffer())
 		acc.oooRecords = append(acc.oooRecords, r)
 	}
 
 	if len(acc.wblSamples) > 0 {
-		r := acc.enc.Samples(acc.wblSamples, a.head.getBytesBuffer())
+		r := acc.oooEnc.Samples(acc.wblSamples, a.head.getBytesBuffer())
 		acc.oooRecords = append(acc.oooRecords, r)
 	}
 	if len(acc.wblHistograms) > 0 {
-		r, customBucketsHistograms := acc.enc.HistogramSamples(acc.wblHistograms, a.head.getBytesBuffer())
+		r, customBucketsHistograms := acc.oooEnc.HistogramSamples(acc.wblHistograms, a.head.getBytesBuffer())
 		if len(r) > 0 {
 			acc.oooRecords = append(acc.oooRecords, r)
 		}
 		if len(customBucketsHistograms) > 0 {
-			r := acc.enc.CustomBucketsHistogramSamples(customBucketsHistograms, a.head.getBytesBuffer())
+			r := acc.oooEnc.CustomBucketsHistogramSamples(customBucketsHistograms, a.head.getBytesBuffer())
 			acc.oooRecords = append(acc.oooRecords, r)
 		}
 	}
 	if len(acc.wblFloatHistograms) > 0 {
-		r, customBucketsFloatHistograms := acc.enc.FloatHistogramSamples(acc.wblFloatHistograms, a.head.getBytesBuffer())
+		r, customBucketsFloatHistograms := acc.oooEnc.FloatHistogramSamples(acc.wblFloatHistograms, a.head.getBytesBuffer())
 		if len(r) > 0 {
 			acc.oooRecords = append(acc.oooRecords, r)
 		}
 		if len(customBucketsFloatHistograms) > 0 {
-			r := acc.enc.CustomBucketsFloatHistogramSamples(customBucketsFloatHistograms, a.head.getBytesBuffer())
+			r := acc.oooEnc.CustomBucketsFloatHistogramSamples(customBucketsFloatHistograms, a.head.getBytesBuffer())
 			acc.oooRecords = append(acc.oooRecords, r)
 		}
 	}
@@ -1387,7 +1391,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 			// Sample is OOO and OOO handling is enabled
 			// and the delta is within the OOO tolerance.
 			var mmapRefs []chunks.ChunkDiskMapperRef
-			ok, chunkCreated, mmapRefs = series.insert(s.T, s.V, nil, nil, a.head.chunkDiskMapper, acc.oooCapMax, a.head.logger)
+			ok, chunkCreated, mmapRefs = series.insert(s.ST, s.T, s.V, nil, nil, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
 			if chunkCreated {
 				r, ok := acc.oooMmapMarkers[series.ref]
 				if !ok || r != nil {
@@ -1431,7 +1435,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 		default:
 			newlyStale := !value.IsStaleNaN(series.lastValue) && value.IsStaleNaN(s.V)
 			staleToNonStale := value.IsStaleNaN(series.lastValue) && !value.IsStaleNaN(s.V)
-			ok, chunkCreated = series.append(s.T, s.V, a.appendID, acc.appendChunkOpts)
+			ok, chunkCreated = series.append(s.ST, s.T, s.V, a.appendID, acc.appendChunkOpts)
 			if ok {
 				if s.T < acc.inOrderMint {
 					acc.inOrderMint = s.T
@@ -1492,7 +1496,8 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 			// Sample is OOO and OOO handling is enabled
 			// and the delta is within the OOO tolerance.
 			var mmapRefs []chunks.ChunkDiskMapperRef
-			ok, chunkCreated, mmapRefs = series.insert(s.T, 0, s.H, nil, a.head.chunkDiskMapper, acc.oooCapMax, a.head.logger)
+			// TODO(krajorama,ywwg): Pass ST when available in WAL.
+			ok, chunkCreated, mmapRefs = series.insert(0, s.T, 0, s.H, nil, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
 			if chunkCreated {
 				r, ok := acc.oooMmapMarkers[series.ref]
 				if !ok || r != nil {
@@ -1540,7 +1545,8 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 				newlyStale = newlyStale && !value.IsStaleNaN(series.lastHistogramValue.Sum)
 				staleToNonStale = value.IsStaleNaN(series.lastHistogramValue.Sum) && !value.IsStaleNaN(s.H.Sum)
 			}
-			ok, chunkCreated = series.appendHistogram(s.T, s.H, a.appendID, acc.appendChunkOpts)
+			// TODO(krajorama,ywwg): pass ST when available in WAL.
+			ok, chunkCreated = series.appendHistogram(0, s.T, s.H, a.appendID, acc.appendChunkOpts)
 			if ok {
 				if s.T < acc.inOrderMint {
 					acc.inOrderMint = s.T
@@ -1601,7 +1607,8 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 			// Sample is OOO and OOO handling is enabled
 			// and the delta is within the OOO tolerance.
 			var mmapRefs []chunks.ChunkDiskMapperRef
-			ok, chunkCreated, mmapRefs = series.insert(s.T, 0, nil, s.FH, a.head.chunkDiskMapper, acc.oooCapMax, a.head.logger)
+			// TODO(krajorama,ywwg): Pass ST when available in WAL.
+			ok, chunkCreated, mmapRefs = series.insert(0, s.T, 0, nil, s.FH, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
 			if chunkCreated {
 				r, ok := acc.oooMmapMarkers[series.ref]
 				if !ok || r != nil {
@@ -1649,7 +1656,8 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 				newlyStale = newlyStale && !value.IsStaleNaN(series.lastFloatHistogramValue.Sum)
 				staleToNonStale = value.IsStaleNaN(series.lastFloatHistogramValue.Sum) && !value.IsStaleNaN(s.FH.Sum)
 			}
-			ok, chunkCreated = series.appendFloatHistogram(s.T, s.FH, a.appendID, acc.appendChunkOpts)
+			// TODO(krajorama,ywwg): pass ST when available in WAL.
+			ok, chunkCreated = series.appendFloatHistogram(0, s.T, s.FH, a.appendID, acc.appendChunkOpts)
 			if ok {
 				if s.T < acc.inOrderMint {
 					acc.inOrderMint = s.T
@@ -1741,6 +1749,10 @@ func (a *headAppenderBase) Commit() (err error) {
 			chunkDiskMapper: h.chunkDiskMapper,
 			chunkRange:      h.chunkRange.Load(),
 			samplesPerChunk: h.opts.SamplesPerChunk,
+			useXOR2:         a.useXOR2,
+		},
+		oooEnc: record.Encoder{
+			EnableSTStorage: a.storeST,
 		},
 	}
 
@@ -1796,18 +1808,18 @@ func (a *headAppenderBase) Commit() (err error) {
 }
 
 // insert is like append, except it inserts. Used for OOO samples.
-func (s *memSeries) insert(t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, chunkDiskMapper *chunks.ChunkDiskMapper, oooCapMax int64, logger *slog.Logger) (inserted, chunkCreated bool, mmapRefs []chunks.ChunkDiskMapperRef) {
+func (s *memSeries) insert(st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, o chunkOpts, oooCapMax int64, logger *slog.Logger) (inserted, chunkCreated bool, mmapRefs []chunks.ChunkDiskMapperRef) {
 	if s.ooo == nil {
 		s.ooo = &memSeriesOOOFields{}
 	}
 	c := s.ooo.oooHeadChunk
 	if c == nil || c.chunk.NumSamples() == int(oooCapMax) {
 		// Note: If no new samples come in then we rely on compaction to clean up stale in-memory OOO chunks.
-		c, mmapRefs = s.cutNewOOOHeadChunk(t, chunkDiskMapper, logger)
+		c, mmapRefs = s.cutNewOOOHeadChunk(t, o, logger)
 		chunkCreated = true
 	}
 
-	ok := c.chunk.Insert(t, v, h, fh)
+	ok := c.chunk.Insert(st, t, v, h, fh)
 	if ok {
 		if chunkCreated || t < c.minTime {
 			c.minTime = t
@@ -1824,19 +1836,19 @@ type chunkOpts struct {
 	chunkDiskMapper *chunks.ChunkDiskMapper
 	chunkRange      int64
 	samplesPerChunk int
+	useXOR2         bool // Selects XOR2 encoding for float chunks.
 }
 
 // append adds the sample (t, v) to the series. The caller also has to provide
 // the appendID for isolation. (The appendID can be zero, which results in no
 // isolation for this append.)
 // Series lock must be held when calling.
-func (s *memSeries) append(t int64, v float64, appendID uint64, o chunkOpts) (sampleInOrder, chunkCreated bool) {
-	c, sampleInOrder, chunkCreated := s.appendPreprocessor(t, chunkenc.EncXOR, o)
+func (s *memSeries) append(st, t int64, v float64, appendID uint64, o chunkOpts) (sampleInOrder, chunkCreated bool) {
+	c, sampleInOrder, chunkCreated := s.appendPreprocessor(t, chunkenc.ValFloat.ChunkEncoding(o.useXOR2), o)
 	if !sampleInOrder {
 		return sampleInOrder, chunkCreated
 	}
-	// TODO(krajorama): pass ST.
-	s.app.Append(0, t, v)
+	s.app.Append(st, t, v)
 
 	c.maxTime = t
 
@@ -1856,14 +1868,14 @@ func (s *memSeries) append(t int64, v float64, appendID uint64, o chunkOpts) (sa
 // In case of recoding the existing chunk, a new chunk is allocated and the old chunk is dropped.
 // To keep the meaning of prometheus_tsdb_head_chunks and prometheus_tsdb_head_chunks_created_total
 // consistent, we return chunkCreated=false in this case.
-func (s *memSeries) appendHistogram(t int64, h *histogram.Histogram, appendID uint64, o chunkOpts) (sampleInOrder, chunkCreated bool) {
+func (s *memSeries) appendHistogram(st, t int64, h *histogram.Histogram, appendID uint64, o chunkOpts) (sampleInOrder, chunkCreated bool) {
 	// Head controls the execution of recoding, so that we own the proper
 	// chunk reference afterwards and mmap used up chunks.
 
 	// Ignoring ok is ok, since we don't want to compare to the wrong previous appender anyway.
 	prevApp, _ := s.app.(*chunkenc.HistogramAppender)
 
-	c, sampleInOrder, chunkCreated := s.histogramsAppendPreprocessor(t, chunkenc.EncHistogram, o)
+	c, sampleInOrder, chunkCreated := s.histogramsAppendPreprocessor(t, chunkenc.ValHistogram.ChunkEncoding(o.useXOR2), o)
 	if !sampleInOrder {
 		return sampleInOrder, chunkCreated
 	}
@@ -1878,8 +1890,7 @@ func (s *memSeries) appendHistogram(t int64, h *histogram.Histogram, appendID ui
 		prevApp = nil
 	}
 
-	// TODO(krajorama): pass ST.
-	newChunk, recoded, s.app, _ = s.app.AppendHistogram(prevApp, 0, t, h, false) // false=request a new chunk if needed
+	newChunk, recoded, s.app, _ = s.app.AppendHistogram(prevApp, st, t, h, false) // false=request a new chunk if needed
 
 	s.lastHistogramValue = h
 	s.lastFloatHistogramValue = nil
@@ -1914,14 +1925,14 @@ func (s *memSeries) appendHistogram(t int64, h *histogram.Histogram, appendID ui
 // In case of recoding the existing chunk, a new chunk is allocated and the old chunk is dropped.
 // To keep the meaning of prometheus_tsdb_head_chunks and prometheus_tsdb_head_chunks_created_total
 // consistent, we return chunkCreated=false in this case.
-func (s *memSeries) appendFloatHistogram(t int64, fh *histogram.FloatHistogram, appendID uint64, o chunkOpts) (sampleInOrder, chunkCreated bool) {
+func (s *memSeries) appendFloatHistogram(st, t int64, fh *histogram.FloatHistogram, appendID uint64, o chunkOpts) (sampleInOrder, chunkCreated bool) {
 	// Head controls the execution of recoding, so that we own the proper
 	// chunk reference afterwards and mmap used up chunks.
 
 	// Ignoring ok is ok, since we don't want to compare to the wrong previous appender anyway.
 	prevApp, _ := s.app.(*chunkenc.FloatHistogramAppender)
 
-	c, sampleInOrder, chunkCreated := s.histogramsAppendPreprocessor(t, chunkenc.EncFloatHistogram, o)
+	c, sampleInOrder, chunkCreated := s.histogramsAppendPreprocessor(t, chunkenc.ValFloatHistogram.ChunkEncoding(o.useXOR2), o)
 	if !sampleInOrder {
 		return sampleInOrder, chunkCreated
 	}
@@ -1936,8 +1947,7 @@ func (s *memSeries) appendFloatHistogram(t int64, fh *histogram.FloatHistogram, 
 		prevApp = nil
 	}
 
-	// TODO(krajorama): pass ST.
-	newChunk, recoded, s.app, _ = s.app.AppendFloatHistogram(prevApp, 0, t, fh, false) // False means request a new chunk if needed.
+	newChunk, recoded, s.app, _ = s.app.AppendFloatHistogram(prevApp, st, t, fh, false) // False means request a new chunk if needed.
 
 	s.lastHistogramValue = nil
 	s.lastFloatHistogramValue = fh
@@ -2161,8 +2171,8 @@ func (s *memSeries) cutNewHeadChunk(mint int64, e chunkenc.Encoding, chunkRange 
 
 // cutNewOOOHeadChunk cuts a new OOO chunk and m-maps the old chunk.
 // The caller must ensure that s is locked and s.ooo is not nil.
-func (s *memSeries) cutNewOOOHeadChunk(mint int64, chunkDiskMapper *chunks.ChunkDiskMapper, logger *slog.Logger) (*oooHeadChunk, []chunks.ChunkDiskMapperRef) {
-	ref := s.mmapCurrentOOOHeadChunk(chunkDiskMapper, logger)
+func (s *memSeries) cutNewOOOHeadChunk(mint int64, o chunkOpts, logger *slog.Logger) (*oooHeadChunk, []chunks.ChunkDiskMapperRef) {
+	ref := s.mmapCurrentOOOHeadChunk(o, logger)
 
 	s.ooo.oooHeadChunk = &oooHeadChunk{
 		chunk:   NewOOOChunk(),
@@ -2174,12 +2184,12 @@ func (s *memSeries) cutNewOOOHeadChunk(mint int64, chunkDiskMapper *chunks.Chunk
 }
 
 // s must be locked when calling.
-func (s *memSeries) mmapCurrentOOOHeadChunk(chunkDiskMapper *chunks.ChunkDiskMapper, logger *slog.Logger) []chunks.ChunkDiskMapperRef {
+func (s *memSeries) mmapCurrentOOOHeadChunk(o chunkOpts, logger *slog.Logger) []chunks.ChunkDiskMapperRef {
 	if s.ooo == nil || s.ooo.oooHeadChunk == nil {
 		// OOO is not enabled or there is no head chunk, so nothing to m-map here.
 		return nil
 	}
-	chks, err := s.ooo.oooHeadChunk.chunk.ToEncodedChunks(math.MinInt64, math.MaxInt64)
+	chks, err := s.ooo.oooHeadChunk.chunk.ToEncodedChunks(math.MinInt64, math.MaxInt64, o.useXOR2)
 	if err != nil {
 		handleChunkWriteError(err)
 		return nil
@@ -2190,7 +2200,7 @@ func (s *memSeries) mmapCurrentOOOHeadChunk(chunkDiskMapper *chunks.ChunkDiskMap
 			logger.Error("Too many OOO chunks, dropping data", "series", s.lset.String())
 			break
 		}
-		chunkRef := chunkDiskMapper.WriteChunk(s.ref, memchunk.minTime, memchunk.maxTime, memchunk.chunk, true, handleChunkWriteError)
+		chunkRef := o.chunkDiskMapper.WriteChunk(s.ref, memchunk.minTime, memchunk.maxTime, memchunk.chunk, true, handleChunkWriteError)
 		chunkRefs = append(chunkRefs, chunkRef)
 		s.ooo.oooMmappedChunks = append(s.ooo.oooMmappedChunks, &mmappedChunk{
 			ref:        chunkRef,

--- a/vendor/github.com/prometheus/prometheus/tsdb/head_append_v2.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head_append_v2.go
@@ -95,6 +95,8 @@ func (h *Head) appenderV2() *headAppenderV2 {
 			typesInBatch:          h.getTypeMap(),
 			appendID:              appendID,
 			cleanupAppendIDsBelow: cleanupAppendIDsBelow,
+			storeST:               h.opts.EnableSTStorage.Load(),
+			useXOR2:               h.opts.EnableXOR2Encoding.Load(),
 		},
 	}
 }
@@ -140,7 +142,6 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 		}
 	}
 
-	// TODO(bwplotka): Handle ST natively (as per PROM-60).
 	if a.head.opts.EnableSTAsZeroSample && st != 0 {
 		a.bestEffortAppendSTZeroSample(s, ls, st, t, h, fh)
 	}
@@ -177,7 +178,7 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 			// we do not need to check for the difference between "unknown
 			// series" and "known series with stNone".
 		}
-		appErr = a.appendFloat(s, t, v, opts.RejectOutOfOrder)
+		appErr = a.appendFloat(s, st, t, v, opts.RejectOutOfOrder)
 	}
 	// Handle append error, if any.
 	if appErr != nil {
@@ -218,7 +219,7 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 	return storage.SeriesRef(s.ref), partialErr
 }
 
-func (a *headAppenderV2) appendFloat(s *memSeries, t int64, v float64, fastRejectOOO bool) error {
+func (a *headAppenderV2) appendFloat(s *memSeries, st, t int64, v float64, fastRejectOOO bool) error {
 	s.Lock()
 	// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 	// to skip that sample from the WAL and write only in the WBL.
@@ -239,7 +240,7 @@ func (a *headAppenderV2) appendFloat(s *memSeries, t int64, v float64, fastRejec
 	}
 
 	b := a.getCurrentBatch(stFloat, s.ref)
-	b.floats = append(b.floats, record.RefSample{Ref: s.ref, T: t, V: v})
+	b.floats = append(b.floats, record.RefSample{Ref: s.ref, ST: st, T: t, V: v})
 	b.floatSeries = append(b.floatSeries, s)
 	return nil
 }
@@ -366,7 +367,7 @@ func (a *headAppenderV2) bestEffortAppendSTZeroSample(s *memSeries, ls labels.La
 		}
 		err = a.appendHistogram(s, st, zeroHistogram, true)
 	default:
-		err = a.appendFloat(s, st, 0, true)
+		err = a.appendFloat(s, 0, st, 0, true)
 	}
 
 	if err != nil {

--- a/vendor/github.com/prometheus/prometheus/tsdb/head_wal.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head_wal.go
@@ -169,7 +169,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 					return
 				}
 				decoded <- series
-			case record.Samples:
+			case record.Samples, record.SamplesV2:
 				samples := h.wlReplaySamplesPool.Get()[:0]
 				samples, err = dec.Samples(r.Record(), samples)
 				if err != nil {
@@ -270,7 +270,10 @@ Outer:
 				idx := uint64(mSeries.ref) % uint64(concurrency)
 				processors[idx].input <- walSubsetProcessorInputItem{walSeriesRef: walSeries.Ref, existingSeries: mSeries}
 			}
-			h.wlReplaySeriesPool.Put(v)
+			for i := range v { // Zero out to avoid retaining label data.
+				v[i].Labels = labels.EmptyLabels()
+			}
+			h.wlReplaySeriesPool.Put(v[:0])
 		case []record.RefSample:
 			samples := v
 			minValidTime := h.minValidTime.Load()
@@ -347,7 +350,8 @@ Outer:
 				}
 			}
 
-			h.wlReplaytStonesPool.Put(v)
+			clear(v) // Zero out to avoid retaining interval data.
+			h.wlReplaytStonesPool.Put(v[:0])
 		case []record.RefExemplar:
 			for _, e := range v {
 				if e.T < h.minValidTime.Load() {
@@ -360,7 +364,10 @@ Outer:
 				}
 				exemplarsInput <- e
 			}
-			h.wlReplayExemplarsPool.Put(v)
+			for i := range v { // Zero out to avoid retaining label data.
+				v[i].Labels = labels.EmptyLabels()
+			}
+			h.wlReplayExemplarsPool.Put(v[:0])
 		case []record.RefHistogramSample:
 			samples := v
 			minValidTime := h.minValidTime.Load()
@@ -395,7 +402,8 @@ Outer:
 				}
 				samples = samples[m:]
 			}
-			h.wlReplayHistogramsPool.Put(v)
+			clear(v) // Zero out to avoid retaining histogram data.
+			h.wlReplayHistogramsPool.Put(v[:0])
 		case []record.RefFloatHistogramSample:
 			samples := v
 			minValidTime := h.minValidTime.Load()
@@ -430,7 +438,8 @@ Outer:
 				}
 				samples = samples[m:]
 			}
-			h.wlReplayFloatHistogramsPool.Put(v)
+			clear(v) // Zero out to avoid retaining histogram data.
+			h.wlReplayFloatHistogramsPool.Put(v[:0])
 		case []record.RefMetadata:
 			for _, m := range v {
 				if r, ok := multiRef[m.Ref]; ok {
@@ -448,7 +457,8 @@ Outer:
 					Help: m.Help,
 				}
 			}
-			h.wlReplayMetadataPool.Put(v)
+			clear(v) // Zero out to avoid retaining metadata strings.
+			h.wlReplayMetadataPool.Put(v[:0])
 		default:
 			panic(fmt.Errorf("unexpected decoded type: %T", d))
 		}
@@ -636,6 +646,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 		chunkDiskMapper: h.chunkDiskMapper,
 		chunkRange:      h.chunkRange.Load(),
 		samplesPerChunk: h.opts.SamplesPerChunk,
+		useXOR2:         h.opts.EnableXOR2Encoding.Load(),
 	}
 
 	for in := range wp.input {
@@ -666,7 +677,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 				h.numStaleSeries.Dec()
 			}
 
-			if _, chunkCreated := ms.append(s.T, s.V, 0, appendChunkOpts); chunkCreated {
+			if _, chunkCreated := ms.append(s.ST, s.T, s.V, 0, appendChunkOpts); chunkCreated {
 				h.metrics.chunksCreated.Inc()
 				h.metrics.chunks.Inc()
 				_ = ms.mmapChunks(h.chunkDiskMapper)
@@ -703,14 +714,16 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 					newlyStale = newlyStale && !value.IsStaleNaN(ms.lastHistogramValue.Sum)
 					staleToNonStale = value.IsStaleNaN(ms.lastHistogramValue.Sum) && !value.IsStaleNaN(s.h.Sum)
 				}
-				_, chunkCreated = ms.appendHistogram(s.t, s.h, 0, appendChunkOpts)
+				// TODO(krajorama,ywwg): Pass ST when available in WBL.
+				_, chunkCreated = ms.appendHistogram(0, s.t, s.h, 0, appendChunkOpts)
 			} else {
 				newlyStale = value.IsStaleNaN(s.fh.Sum)
 				if ms.lastFloatHistogramValue != nil {
 					newlyStale = newlyStale && !value.IsStaleNaN(ms.lastFloatHistogramValue.Sum)
 					staleToNonStale = value.IsStaleNaN(ms.lastFloatHistogramValue.Sum) && !value.IsStaleNaN(s.fh.Sum)
 				}
-				_, chunkCreated = ms.appendFloatHistogram(s.t, s.fh, 0, appendChunkOpts)
+				// TODO(krajorama,ywwg): Pass ST when available in WBL.
+				_, chunkCreated = ms.appendFloatHistogram(0, s.t, s.fh, 0, appendChunkOpts)
 			}
 			if newlyStale {
 				h.numStaleSeries.Inc()
@@ -721,6 +734,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 			if chunkCreated {
 				h.metrics.chunksCreated.Inc()
 				h.metrics.chunks.Inc()
+				_ = ms.mmapChunks(h.chunkDiskMapper)
 			}
 			if s.t > maxt {
 				maxt = s.t
@@ -798,7 +812,7 @@ func (h *Head) loadWBL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 			var err error
 			rec := r.Record()
 			switch dec.Type(rec) {
-			case record.Samples:
+			case record.Samples, record.SamplesV2:
 				samples := h.wlReplaySamplesPool.Get()[:0]
 				samples, err = dec.Samples(rec, samples)
 				if err != nil {
@@ -937,7 +951,8 @@ func (h *Head) loadWBL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 				}
 				samples = samples[m:]
 			}
-			h.wlReplayHistogramsPool.Put(v)
+			clear(v) // Zero out to avoid retaining histogram data.
+			h.wlReplayHistogramsPool.Put(v[:0])
 		case []record.RefFloatHistogramSample:
 			samples := v
 			// We split up the samples into chunks of 5000 samples or less.
@@ -966,7 +981,8 @@ func (h *Head) loadWBL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 				}
 				samples = samples[m:]
 			}
-			h.wlReplayFloatHistogramsPool.Put(v)
+			clear(v) // Zero out to avoid retaining histogram data.
+			h.wlReplayFloatHistogramsPool.Put(v[:0])
 		default:
 			panic(fmt.Errorf("unexpected decodedCh type: %T", d))
 		}
@@ -1077,6 +1093,12 @@ func (wp *wblSubsetProcessor) processWBLSamples(h *Head) (map[chunks.HeadSeriesR
 	var unknownSampleRefs, unknownHistogramRefs uint64
 
 	oooCapMax := h.opts.OutOfOrderCapMax.Load()
+	appendChunkOpts := chunkOpts{
+		chunkDiskMapper: h.chunkDiskMapper,
+		chunkRange:      h.chunkRange.Load(),
+		samplesPerChunk: h.opts.SamplesPerChunk,
+		useXOR2:         h.opts.EnableXOR2Encoding.Load(),
+	}
 	// We don't check for minValidTime for ooo samples.
 	mint, maxt := int64(math.MaxInt64), int64(math.MinInt64)
 	for in := range wp.input {
@@ -1096,7 +1118,7 @@ func (wp *wblSubsetProcessor) processWBLSamples(h *Head) (map[chunks.HeadSeriesR
 				missingSeries[s.Ref] = struct{}{}
 				continue
 			}
-			ok, chunkCreated, _ := ms.insert(s.T, s.V, nil, nil, h.chunkDiskMapper, oooCapMax, h.logger)
+			ok, chunkCreated, _ := ms.insert(s.ST, s.T, s.V, nil, nil, appendChunkOpts, oooCapMax, h.logger)
 			if chunkCreated {
 				h.metrics.chunksCreated.Inc()
 				h.metrics.chunks.Inc()
@@ -1124,9 +1146,11 @@ func (wp *wblSubsetProcessor) processWBLSamples(h *Head) (map[chunks.HeadSeriesR
 			var chunkCreated bool
 			var ok bool
 			if s.h != nil {
-				ok, chunkCreated, _ = ms.insert(s.t, 0, s.h, nil, h.chunkDiskMapper, oooCapMax, h.logger)
+				// TODO(krajorama,ywwg): Pass ST when available in WBL.
+				ok, chunkCreated, _ = ms.insert(0, s.t, 0, s.h, nil, appendChunkOpts, oooCapMax, h.logger)
 			} else {
-				ok, chunkCreated, _ = ms.insert(s.t, 0, nil, s.fh, h.chunkDiskMapper, oooCapMax, h.logger)
+				// TODO(krajorama,ywwg): Pass ST when available in WBL.
+				ok, chunkCreated, _ = ms.insert(0, s.t, 0, nil, s.fh, appendChunkOpts, oooCapMax, h.logger)
 			}
 			if chunkCreated {
 				h.metrics.chunksCreated.Inc()
@@ -1240,7 +1264,7 @@ func decodeSeriesFromChunkSnapshot(d *record.Decoder, b []byte) (csr chunkSnapsh
 	csr.mc.chunk = chk
 
 	switch enc {
-	case chunkenc.EncXOR:
+	case chunkenc.EncXOR, chunkenc.EncXOR2:
 		// Backwards-compatibility for old sampleBuf which had last 4 samples.
 		for range 3 {
 			_ = dec.Be64int64()
@@ -1400,7 +1424,7 @@ func (h *Head) ChunkSnapshot() (*ChunkSnapshotStats, error) {
 	// Assuming 100 bytes (overestimate) per exemplar, that's ~1MB.
 	maxExemplarsPerRecord := 10000
 	batch := make([]record.RefExemplar, 0, maxExemplarsPerRecord)
-	enc := record.Encoder{}
+	enc := record.Encoder{EnableSTStorage: h.opts.EnableSTStorage.Load()}
 	flushExemplars := func() error {
 		if len(batch) == 0 {
 			return nil

--- a/vendor/github.com/prometheus/prometheus/tsdb/ooo_head.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/ooo_head.go
@@ -34,14 +34,13 @@ func NewOOOChunk() *OOOChunk {
 
 // Insert inserts the sample such that order is maintained.
 // Returns false if insert was not possible due to the same timestamp already existing.
-func (o *OOOChunk) Insert(t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) bool {
+func (o *OOOChunk) Insert(st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) bool {
 	// Although out-of-order samples can be out-of-order amongst themselves, we
 	// are opinionated and expect them to be usually in-order meaning we could
 	// try to append at the end first if the new timestamp is higher than the
 	// last known timestamp.
 	if len(o.samples) == 0 || t > o.samples[len(o.samples)-1].t {
-		// TODO(krajorama): pass ST.
-		o.samples = append(o.samples, sample{0, t, v, h, fh})
+		o.samples = append(o.samples, sample{st, t, v, h, fh})
 		return true
 	}
 
@@ -50,8 +49,7 @@ func (o *OOOChunk) Insert(t int64, v float64, h *histogram.Histogram, fh *histog
 
 	if i >= len(o.samples) {
 		// none found. append it at the end
-		// TODO(krajorama): pass ST.
-		o.samples = append(o.samples, sample{0, t, v, h, fh})
+		o.samples = append(o.samples, sample{st, t, v, h, fh})
 		return true
 	}
 
@@ -63,8 +61,7 @@ func (o *OOOChunk) Insert(t int64, v float64, h *histogram.Histogram, fh *histog
 	// Expand length by 1 to make room. use a zero sample, we will overwrite it anyway.
 	o.samples = append(o.samples, sample{})
 	copy(o.samples[i+1:], o.samples[i:])
-	// TODO(krajorama): pass ST.
-	o.samples[i] = sample{0, t, v, h, fh}
+	o.samples[i] = sample{st, t, v, h, fh}
 
 	return true
 }
@@ -76,7 +73,7 @@ func (o *OOOChunk) NumSamples() int {
 // ToEncodedChunks returns chunks with the samples in the OOOChunk.
 //
 //nolint:revive
-func (o *OOOChunk) ToEncodedChunks(mint, maxt int64) (chks []memChunk, err error) {
+func (o *OOOChunk) ToEncodedChunks(mint, maxt int64, useXOR2 bool) (chks []memChunk, err error) {
 	if len(o.samples) == 0 {
 		return nil, nil
 	}
@@ -96,10 +93,13 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64) (chks []memChunk, err error
 		if s.t > maxt {
 			break
 		}
-		encoding := chunkenc.EncXOR
-		if s.h != nil {
+		encoding := chunkenc.ValFloat.ChunkEncoding(useXOR2)
+		switch {
+		case s.h != nil:
+			// TODO(krajorama): use ST capable histogram chunk.
 			encoding = chunkenc.EncHistogram
-		} else if s.fh != nil {
+		case s.fh != nil:
+			// TODO(krajorama): use ST capable float histogram chunk.
 			encoding = chunkenc.EncFloatHistogram
 		}
 
@@ -111,15 +111,11 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64) (chks []memChunk, err error
 				chks = append(chks, memChunk{chunk, cmint, cmaxt, nil})
 			}
 			cmint = s.t
-			switch encoding {
-			case chunkenc.EncXOR:
-				chunk = chunkenc.NewXORChunk()
-			case chunkenc.EncHistogram:
-				chunk = chunkenc.NewHistogramChunk()
-			case chunkenc.EncFloatHistogram:
-				chunk = chunkenc.NewFloatHistogramChunk()
-			default:
-				chunk = chunkenc.NewXORChunk()
+			chunk, err = chunkenc.NewEmptyChunk(encoding)
+			if err != nil {
+				// This should never happen. No point using a default type as
+				// calling the wrong append function would panic.
+				return chks, err
 			}
 			app, err = chunk.Appender()
 			if err != nil {
@@ -127,18 +123,17 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64) (chks []memChunk, err error
 			}
 		}
 		switch encoding {
-		case chunkenc.EncXOR:
-			// TODO(krajorama): pass ST.
-			app.Append(0, s.t, s.f)
+		case chunkenc.EncXOR, chunkenc.EncXOR2:
+			app.Append(s.st, s.t, s.f)
 		case chunkenc.EncHistogram:
+			// TODO(krajorama): handle ST capable histogram chunk.
 			// Ignoring ok is ok, since we don't want to compare to the wrong previous appender anyway.
 			prevHApp, _ := prevApp.(*chunkenc.HistogramAppender)
 			var (
 				newChunk chunkenc.Chunk
 				recoded  bool
 			)
-			// TODO(krajorama): pass ST.
-			newChunk, recoded, app, _ = app.AppendHistogram(prevHApp, 0, s.t, s.h, false)
+			newChunk, recoded, app, _ = app.AppendHistogram(prevHApp, s.st, s.t, s.h, false)
 			if newChunk != nil { // A new chunk was allocated.
 				if !recoded {
 					chks = append(chks, memChunk{chunk, cmint, cmaxt, nil})
@@ -147,14 +142,14 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64) (chks []memChunk, err error
 				chunk = newChunk
 			}
 		case chunkenc.EncFloatHistogram:
+			// TODO(krajorama): handle ST capable float histogram chunk.
 			// Ignoring ok is ok, since we don't want to compare to the wrong previous appender anyway.
 			prevHApp, _ := prevApp.(*chunkenc.FloatHistogramAppender)
 			var (
 				newChunk chunkenc.Chunk
 				recoded  bool
 			)
-			// TODO(krajorama): pass ST.
-			newChunk, recoded, app, _ = app.AppendFloatHistogram(prevHApp, 0, s.t, s.fh, false)
+			newChunk, recoded, app, _ = app.AppendFloatHistogram(prevHApp, s.st, s.t, s.fh, false)
 			if newChunk != nil { // A new chunk was allocated.
 				if !recoded {
 					chks = append(chks, memChunk{chunk, cmint, cmaxt, nil})

--- a/vendor/github.com/prometheus/prometheus/tsdb/ooo_head_read.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/ooo_head_read.go
@@ -77,7 +77,7 @@ func (oh *HeadAndOOOIndexReader) Series(ref storage.SeriesRef, builder *labels.S
 	*chks = (*chks)[:0]
 
 	if s.ooo != nil {
-		return getOOOSeriesChunks(s, oh.mint, oh.maxt, oh.lastGarbageCollectedMmapRef, 0, true, oh.inoMint, chks)
+		return getOOOSeriesChunks(s, oh.head.opts.EnableXOR2Encoding.Load(), oh.mint, oh.maxt, oh.lastGarbageCollectedMmapRef, 0, true, oh.inoMint, chks)
 	}
 	*chks = appendSeriesChunks(s, oh.inoMint, oh.maxt, *chks)
 	return nil
@@ -88,7 +88,7 @@ func (oh *HeadAndOOOIndexReader) Series(ref storage.SeriesRef, builder *labels.S
 //
 // maxMmapRef tells upto what max m-map chunk that we can consider. If it is non-0, then
 // the oooHeadChunk will not be considered.
-func getOOOSeriesChunks(s *memSeries, mint, maxt int64, lastGarbageCollectedMmapRef, maxMmapRef chunks.ChunkDiskMapperRef, includeInOrder bool, inoMint int64, chks *[]chunks.Meta) error {
+func getOOOSeriesChunks(s *memSeries, useXOR2 bool, mint, maxt int64, lastGarbageCollectedMmapRef, maxMmapRef chunks.ChunkDiskMapperRef, includeInOrder bool, inoMint int64, chks *[]chunks.Meta) error {
 	tmpChks := make([]chunks.Meta, 0, len(s.ooo.oooMmappedChunks))
 
 	addChunk := func(minT, maxT int64, ref chunks.ChunkRef, chunk chunkenc.Chunk) {
@@ -106,7 +106,7 @@ func getOOOSeriesChunks(s *memSeries, mint, maxt int64, lastGarbageCollectedMmap
 		if c.OverlapsClosedInterval(mint, maxt) && maxMmapRef == 0 {
 			ref := chunks.ChunkRef(chunks.NewHeadChunkRef(s.ref, s.oooHeadChunkID(len(s.ooo.oooMmappedChunks))))
 			if len(c.chunk.samples) > 0 { // Empty samples happens in tests, at least.
-				chks, err := s.ooo.oooHeadChunk.chunk.ToEncodedChunks(c.minTime, c.maxTime)
+				chks, err := s.ooo.oooHeadChunk.chunk.ToEncodedChunks(c.minTime, c.maxTime, useXOR2)
 				if err != nil {
 					handleChunkWriteError(err)
 					return nil
@@ -347,7 +347,7 @@ func NewOOOCompactionHead(ctx context.Context, head *Head) (*OOOCompactionHead, 
 		}
 
 		var lastMmapRef chunks.ChunkDiskMapperRef
-		mmapRefs := ms.mmapCurrentOOOHeadChunk(head.chunkDiskMapper, head.logger)
+		mmapRefs := ms.mmapCurrentOOOHeadChunk(chunkOpts{chunkDiskMapper: head.chunkDiskMapper, useXOR2: head.opts.EnableXOR2Encoding.Load()}, head.logger)
 		if len(mmapRefs) == 0 && len(ms.ooo.oooMmappedChunks) > 0 {
 			// Nothing was m-mapped. So take the mmapRef from the existing slice if it exists.
 			mmapRefs = []chunks.ChunkDiskMapperRef{ms.ooo.oooMmappedChunks[len(ms.ooo.oooMmappedChunks)-1].ref}
@@ -481,7 +481,7 @@ func (ir *OOOCompactionHeadIndexReader) Series(ref storage.SeriesRef, builder *l
 		return nil
 	}
 
-	return getOOOSeriesChunks(s, ir.ch.mint, ir.ch.maxt, 0, ir.ch.lastMmapRef, false, 0, chks)
+	return getOOOSeriesChunks(s, ir.ch.head.opts.EnableXOR2Encoding.Load(), ir.ch.mint, ir.ch.maxt, 0, ir.ch.lastMmapRef, false, 0, chks)
 }
 
 func (*OOOCompactionHeadIndexReader) SortedLabelValues(_ context.Context, _ string, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, error) {

--- a/vendor/github.com/prometheus/prometheus/tsdb/wlog/checkpoint.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/wlog/checkpoint.go
@@ -102,7 +102,7 @@ func DeleteTempCheckpoints(logger *slog.Logger, dir string) error {
 // segmented format as the original WAL itself.
 // This makes it easy to read it through the WAL package and concatenate
 // it with the original WAL.
-func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.HeadSeriesRef) bool, mint int64) (*CheckpointStats, error) {
+func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.HeadSeriesRef) bool, mint int64, enableSTStorage bool) (*CheckpointStats, error) {
 	stats := &CheckpointStats{}
 	var sgmReader io.ReadCloser
 
@@ -166,7 +166,7 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 		metadata              []record.RefMetadata
 		st                    = labels.NewSymbolTable() // Needed for decoding; labels do not outlive this function.
 		dec                   = record.NewDecoder(st, logger)
-		enc                   record.Encoder
+		enc                   = record.Encoder{EnableSTStorage: enableSTStorage}
 		buf                   []byte
 		recs                  [][]byte
 
@@ -200,7 +200,7 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 			stats.TotalSeries += len(series)
 			stats.DroppedSeries += len(series) - len(repl)
 
-		case record.Samples:
+		case record.Samples, record.SamplesV2:
 			samples, err = dec.Samples(rec, samples)
 			if err != nil {
 				return nil, fmt.Errorf("decode samples: %w", err)

--- a/vendor/github.com/prometheus/prometheus/tsdb/wlog/watcher.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/wlog/watcher.go
@@ -543,7 +543,7 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 			}
 			w.writer.StoreSeries(series, segmentNum)
 
-		case record.Samples:
+		case record.Samples, record.SamplesV2:
 			// If we're not tailing a segment we can ignore any samples records we see.
 			// This speeds up replay of the WAL by > 10x.
 			if !tail {

--- a/vendor/github.com/prometheus/prometheus/util/kahansum/kahansum.go
+++ b/vendor/github.com/prometheus/prometheus/util/kahansum/kahansum.go
@@ -16,10 +16,21 @@ package kahansum
 import "math"
 
 // Inc performs addition of two floating-point numbers using the Kahan summation algorithm.
-// We get incorrect results if this function is inlined; see https://github.com/prometheus/prometheus/issues/16714.
-//
-//go:noinline
 func Inc(inc, sum, c float64) (newSum, newC float64) {
+	// We've seen Kahan summation return less accurate results when Inc function is
+	// allowed to be inlined (see https://github.com/prometheus/prometheus/pull/16895).
+	// Go permits fusing float operations (e.g. using fused multiply-add, which allows
+	// calculating a*b+c without rounding the result of a*b to precision available in float64),
+	// and Kahan sum is sensitive to float rounding behavior. Instead of forbidding inlining
+	// (which only disallows fusing operations outside of Inc with operations  happening inside)
+	// and eating the performance cost of non-inlined function calls, we forbid just the fusing
+	// across Inc call boundary. We can do that by explicitly requesting Inc arguments and results
+	// to be rounded to float64 precision, as documented in go spec (https://go.dev/ref/spec#Floating_point_operators).
+	// The following casts are not no-ops!
+	inc = float64(inc)
+	sum = float64(sum)
+	c = float64(c)
+
 	t := sum + inc
 	switch {
 	case math.IsInf(t, 0):
@@ -31,6 +42,9 @@ func Inc(inc, sum, c float64) (newSum, newC float64) {
 	default:
 		c += (inc - t) + sum
 	}
+
+	t = float64(t)
+	c = float64(c)
 	return t, c
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1863,7 +1863,7 @@ github.com/prometheus/otlptranslator
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v0.310.1-0.20260312203008-8b25b26a7653
+# github.com/prometheus/prometheus v0.310.1-0.20260320085417-166d20151c0d
 ## explicit; go 1.25.0
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery


### PR DESCRIPTION
**What this PR does / why we need it**:
[This](https://github.com/grafana/loki/pull/21171) PR is having trouble in CI, so I'm rebuilding it.   Updates Prometheus to the latest version on main.

Only Loki change is to pass a `false` for the new `Checkpoint` argument,  which keeps the existing `SamplesV1` encoding, as opposed to the new `SamplesV2` encoding.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
