### PR TITLE
fix: add stream size in update rates

### DIFF
--- a/pkg/distributor/ingest_limits.go
+++ b/pkg/distributor/ingest_limits.go
@@ -231,10 +231,9 @@ func newUpdateRatesRequest(tenant string, streams []segmentedStream) (*proto.Upd
 	// from the request caused it to exceed its limits.
 	streamMetadata := make([]*proto.StreamMetadata, 0, len(streams))
 	for _, stream := range streams {
-		entriesSize, structuredMetadataSize := calculateStreamSizes(stream.Stream)
 		streamMetadata = append(streamMetadata, &proto.StreamMetadata{
 			StreamHash:      stream.SegmentationKeyHash,
-			TotalSize:       entriesSize + structuredMetadataSize,
+			TotalSize:       uint64(stream.Stream.Size()),
 			IngestionPolicy: stream.Policy,
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request changes `newUpdateRatesRequest` to use `stream.Size()` so labels and timestamps are taken into account when measuring the rate of a stream. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
