### PR TITLE
feat(otlp): add event_name to OTLP log structured metadata

### DIFF
--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -493,6 +493,13 @@ func otlpLogToPushEntry(log plog.LogRecord, otlpConfig OTLPConfig, logServiceNam
 			return true
 		}
 
+		// If the dedicated OTLP EventName field is set, skip any log attribute
+		// also named event_name to avoid duplicate entries. The first-class field
+		// takes precedence over the attribute.
+		if k == OTLPEventName && log.EventName() != "" {
+			return true
+		}
+
 		attributeAsLabels, err := attributeToLabels(k, v, "")
 		if err != nil {
 			rangeErr = err

--- a/pkg/loghttp/push/otlp_test.go
+++ b/pkg/loghttp/push/otlp_test.go
@@ -708,6 +708,28 @@ func TestOTLPLogToPushEntry(t *testing.T) {
 			},
 		},
 		{
+			name: "event_name attribute conflicts with EventName field — OTLP field wins",
+			buildLogRecord: func() plog.LogRecord {
+				log := plog.NewLogRecord()
+				log.Body().SetStr("log body")
+				log.SetTimestamp(pcommon.Timestamp(now.UnixNano()))
+				log.SetEventName("otlp.field")
+				log.Attributes().PutStr(OTLPEventName, "attribute.value")
+
+				return log
+			},
+			expectedResp: push.Entry{
+				Timestamp: now,
+				Line:      "log body",
+				StructuredMetadata: push.LabelsAdapter{
+					{
+						Name:  "event_name",
+						Value: "otlp.field",
+					},
+				},
+			},
+		},
+		{
 			name: "event_name only",
 			buildLogRecord: func() plog.LogRecord {
 				log := plog.NewLogRecord()


### PR DESCRIPTION
**What this PR does / why we need it**:

The [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.54.0/specification/logs/data-model.md#events) defines *events* as log records with an `event_name` field. This field is a first-class part of the OTel log data model and is particularly important in mobile, browser, and RUM use cases.

Loki was not capturing `event_name` when ingesting OTLP logs. This PR adds `event_name` to structured metadata when it is present on a log record, consistent with how all other log record fields (`trace_id`, `span_id`, `severity_number`, `severity_text`, `flags`, etc.) are already handled.

**Which issue(s) this PR fixes**:
Fixes #21172

**Special notes for your reviewer**:

The change is minimal and follows the exact same pattern as the existing `span_id`/`trace_id`/`severity_*` fields — a nil-guard check followed by an append to `structuredMetadata`. The `OTLPEventName` constant is exported for consistency with `OTLPSeverityNumber` and `OTLPSeverityText`.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)