### PR TITLE
fix(canary): include -query-append in count_over_time metric query

### DIFF
--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -203,7 +203,7 @@ func (r *Reader) QueryCountOverTime(queryRange string, now time.Time, cache bool
 		Scheme: scheme,
 		Host:   r.addr,
 		Path:   "/loki/api/v1/query",
-		RawQuery: "query=" + url.QueryEscape(fmt.Sprintf("count_over_time({%v=\"%v\",%v=\"%v\"}[%s])", r.sName, r.sValue, r.lName, r.lVal, queryRange)) +
+		RawQuery: "query=" + url.QueryEscape(fmt.Sprintf("count_over_time({%v=\"%v\",%v=\"%v\"}[%s] %v)", r.sName, r.sValue, r.lName, r.lVal, queryRange, r.queryAppend)) +
 			fmt.Sprintf("&time=%d", now.UnixNano()) +
 			"&limit=1000",
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/grafana/loki/pull/8871 added support for `-query-append` but didn't include it in the metrics query, this causes some errors in the canary log:
```
error running metric query test: expected only a single series result in the metric test query vector, instead received 9
```
```
error running cache query test with cache: expected only a single series result in the metric test query vector, instead received 116
```

In my case logs are being collected by Alloy (deployed using the Grafana k8s-monitoring Helm chart) and Loki (including loki-canary) is deployed using the loki Helm chart in simple-scalable deployment mode.

In a k8s-monitoring deployment of Alloy the pod label isn't indexed so I override the canary label + stream names and use query-append to filter the logs for the specific loki-canary pod.

loki-canary is running with the following args:
    - `-push=false`
    - `-addr=loki-read:3100`
    - `-tenant-id=<tenantx>`
    - `-labelname=job`
    - `-labelvalue=<ns>/loki-canary`
    - `-streamname=app_kubernetes_io_name`
    - `-streamvalue=loki`
    - ``-query-append=| pod=`$(POD_NAME)` |~ `^\d+ p+$` ``

If the metrics query doesn't include the query-append filter then it returns a series for each canary pod.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
