### PR TITLE
fix: colliding metric names preventing running dataobj components locally

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder_metrics.go
+++ b/pkg/dataobj/consumer/logsobj/builder_metrics.go
@@ -36,19 +36,19 @@ func newBuilderMetrics() *builderMetrics {
 		streams: streams.NewMetrics(),
 		dataobj: dataobj.NewMetrics(),
 		targetPageSize: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loki_dataobj_config_target_page_size_bytes",
+			Name: "dataobj_config_target_page_size_bytes",
 			Help: "Configured target page size in bytes.",
 		}),
 		targetObjectSize: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loki_dataobj_config_target_object_size_bytes",
+			Name: "dataobj_config_target_object_size_bytes",
 			Help: "Configured target object size in bytes.",
 		}),
 		appends: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "loki_dataobj_appends_total",
+			Name: "dataobj_appends_total",
 			Help: "Total number of appends.",
 		}),
 		appendTime: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name: "loki_dataobj_append_time_seconds",
+			Name: "dataobj_append_time_seconds",
 			Help: "Time taken appending a set of log lines in a stream to a data object.",
 
 			Buckets:                         prometheus.DefBuckets,
@@ -57,7 +57,7 @@ func newBuilderMetrics() *builderMetrics {
 			NativeHistogramMinResetDuration: 0,
 		}),
 		buildTime: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name: "loki_dataobj_build_time_seconds",
+			Name: "dataobj_build_time_seconds",
 			Help: "Time taken building a data object to flush.",
 
 			Buckets:                         prometheus.DefBuckets,
@@ -66,11 +66,11 @@ func newBuilderMetrics() *builderMetrics {
 			NativeHistogramMinResetDuration: 0,
 		}),
 		sizeEstimate: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loki_dataobj_size_estimate_bytes",
+			Name: "dataobj_size_estimate_bytes",
 			Help: "Current estimated size of the data object in bytes.",
 		}),
 		builtSize: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name: "loki_dataobj_built_size_bytes",
+			Name: "dataobj_built_size_bytes",
 			Help: "Distribution of constructed data object sizes in bytes.",
 
 			NativeHistogramBucketFactor:     1.1,
@@ -78,7 +78,7 @@ func newBuilderMetrics() *builderMetrics {
 			NativeHistogramMinResetDuration: 0,
 		}),
 		flushFailures: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "loki_dataobj_flush_failures_total",
+			Name: "dataobj_flush_failures_total",
 			Help: "Total number of flush failures.",
 		}),
 	}

--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -154,7 +154,9 @@ func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objsto
 	wrapped := prometheus.WrapRegistererWith(prometheus.Labels{
 		"partition": strconv.Itoa(int(partitionID)),
 	}, reg)
-	builder, err := builderFactory.NewBuilder(wrapped)
+	builder, err := builderFactory.NewBuilder(
+		prometheus.WrapRegistererWithPrefix("loki_dataobj_consumer_", wrapped),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize data object builder: %w", err)
 	}

--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -143,7 +143,8 @@ func NewIndexBuilder(
 
 	indexStorageBucket := objstore.NewPrefixedBucket(bucket, mCfg.IndexStoragePrefix)
 
-	if err := builder.RegisterMetrics(builderReg); err != nil {
+	wrappedReg := prometheus.WrapRegistererWithPrefix("loki_dataobj_index_builder_", builderReg)
+	if err := builder.RegisterMetrics(wrappedReg); err != nil {
 		return nil, fmt.Errorf("failed to register metrics for index builder: %w", err)
 	}
 

--- a/pkg/dataobj/sections/indexpointers/metrics.go
+++ b/pkg/dataobj/sections/indexpointers/metrics.go
@@ -23,13 +23,12 @@ func NewMetrics() *Metrics {
 		columnar: columnar.NewMetrics(sectionType),
 
 		encodeSeconds: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "loki",
-			Subsystem: "dataobj",
+			Namespace: "dataobj",
 			Name:      "index_pointers_encode_seconds",
 			Help:      "The number of seconds it takes to encode the index pointers section.",
 		}),
 		recordsTotal: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: "loki_dataobj",
+			Namespace: "dataobj",
 			Subsystem: "index_pointers",
 			Name:      "records_total",
 
@@ -37,7 +36,7 @@ func NewMetrics() *Metrics {
 		}),
 
 		minTimestamp: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: "loki_dataobj",
+			Namespace: "dataobj",
 			Subsystem: "index_pointers",
 			Name:      "min_timestamp",
 
@@ -45,7 +44,7 @@ func NewMetrics() *Metrics {
 		}),
 
 		maxTimestamp: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: "loki_dataobj",
+			Namespace: "dataobj",
 			Subsystem: "index_pointers",
 			Name:      "max_timestamp",
 

--- a/pkg/dataobj/sections/internal/columnar/metrics.go
+++ b/pkg/dataobj/sections/internal/columnar/metrics.go
@@ -45,98 +45,98 @@ func NewMetrics(sectionType dataobj.SectionType) *Metrics {
 
 	return &Metrics{
 		columnMetadataSize: newNativeHistogram(prometheus.HistogramOpts{
-			Name: "loki_dataobj_encoding_dataset_column_metadata_size",
+			Name: "dataobj_encoding_dataset_column_metadata_size",
 			Help: "Distribution of column metadata size per encoded dataset column.",
 
 			ConstLabels: sectionLabels,
 		}),
 
 		columnMetadataTotalSize: newNativeHistogram(prometheus.HistogramOpts{
-			Name: "loki_dataobj_encoding_dataset_column_metadata_total_size",
+			Name: "dataobj_encoding_dataset_column_metadata_total_size",
 			Help: "Distribution of metadata size across all columns per encoded section.",
 
 			ConstLabels: sectionLabels,
 		}),
 
 		columnCount: newNativeHistogram(prometheus.HistogramOpts{
-			Name: "loki_dataobj_encoding_dataset_column_count",
+			Name: "dataobj_encoding_dataset_column_count",
 			Help: "Distribution of column counts per encoded dataset section.",
 
 			ConstLabels: sectionLabels,
 		}),
 
 		columnCompressedBytes: newNativeHistogramVec(prometheus.HistogramOpts{
-			Name: "loki_dataobj_encoding_dataset_column_compressed_bytes",
+			Name: "dataobj_encoding_dataset_column_compressed_bytes",
 			Help: "Distribution of compressed bytes per encoded dataset column.",
 
 			ConstLabels: sectionLabels,
 		}, []string{"column_type"}),
 
 		columnUncompressedBytes: newNativeHistogramVec(prometheus.HistogramOpts{
-			Name: "loki_dataobj_encoding_dataset_column_uncompressed_bytes",
+			Name: "dataobj_encoding_dataset_column_uncompressed_bytes",
 			Help: "Distribution of uncompressed bytes per encoded dataset column.",
 
 			ConstLabels: sectionLabels,
 		}, []string{"column_type"}),
 
 		columnCompressionRatio: newNativeHistogramVec(prometheus.HistogramOpts{
-			Name: "loki_dataobj_encoding_dataset_column_compression_ratio",
+			Name: "dataobj_encoding_dataset_column_compression_ratio",
 			Help: "Distribution of compression ratio per encoded dataset column. Not reported when compression is disabled.",
 
 			ConstLabels: sectionLabels,
 		}, []string{"column_type", "compression_type"}),
 
 		columnRows: newNativeHistogramVec(prometheus.HistogramOpts{
-			Name: "loki_dataobj_encoding_dataset_column_rows",
+			Name: "dataobj_encoding_dataset_column_rows",
 			Help: "Distribution of row counts per encoded dataset column.",
 
 			ConstLabels: sectionLabels,
 		}, []string{"column_type"}),
 
 		columnValues: newNativeHistogramVec(prometheus.HistogramOpts{
-			Name: "loki_dataobj_encoding_dataset_column_values",
+			Name: "dataobj_encoding_dataset_column_values",
 			Help: "Distribution of value counts per encoded dataset column.",
 
 			ConstLabels: sectionLabels,
 		}, []string{"column_type"}),
 
 		pageCount: newNativeHistogramVec(prometheus.HistogramOpts{
-			Name: "loki_dataobj_encoding_dataset_page_count",
+			Name: "dataobj_encoding_dataset_page_count",
 			Help: "Distribution of page count per encoded dataset column.",
 
 			ConstLabels: sectionLabels,
 		}, []string{"column_type"}),
 
 		pageCompressedBytes: newNativeHistogramVec(prometheus.HistogramOpts{
-			Name: "loki_dataobj_encoding_dataset_page_compressed_bytes",
+			Name: "dataobj_encoding_dataset_page_compressed_bytes",
 			Help: "Distribution of compressed bytes per encoded dataset page.",
 
 			ConstLabels: sectionLabels,
 		}, []string{"column_type"}),
 
 		pageUncompressedBytes: newNativeHistogramVec(prometheus.HistogramOpts{
-			Name: "loki_dataobj_encoding_dataset_page_uncompressed_bytes",
+			Name: "dataobj_encoding_dataset_page_uncompressed_bytes",
 			Help: "Distribution of uncompressed bytes per encoded dataset page.",
 
 			ConstLabels: sectionLabels,
 		}, []string{"column_type"}),
 
 		pageCompressionRatio: newNativeHistogramVec(prometheus.HistogramOpts{
-			Name: "loki_dataobj_encoding_dataset_page_compression_ratio",
+			Name: "dataobj_encoding_dataset_page_compression_ratio",
 			Help: "Distribution of compression ratio per encoded dataset page. Not reported when compression is disabled.",
 
 			ConstLabels: sectionLabels,
 		}, []string{"column_type", "compression_type"}),
 
 		pageRows: newNativeHistogramVec(prometheus.HistogramOpts{
-			Name: "loki_dataobj_encoding_dataset_page_rows",
+			Name: "dataobj_encoding_dataset_page_rows",
 			Help: "Distribution of row counts per encoded dataset page",
 
 			ConstLabels: sectionLabels,
 		}, []string{"column_type"}),
 
 		pageValues: newNativeHistogramVec(prometheus.HistogramOpts{
-			Name: "loki_dataobj_encoding_dataset_page_values",
+			Name: "dataobj_encoding_dataset_page_values",
 			Help: "Distribution of value counts per encoded dataset page",
 
 			ConstLabels: sectionLabels,
@@ -148,7 +148,14 @@ func NewMetrics(sectionType dataobj.SectionType) *Metrics {
 func (m *Metrics) Register(reg prometheus.Registerer) error {
 	var errs []error
 	errs = append(errs, reg.Register(m.columnMetadataSize))
-	errs = append(errs, reg.Register(m.columnMetadataTotalSize))
+	fmt.Printf("Dan - Registering metric %v\n", m.columnMetadataTotalSize.Desc().String())
+	err := reg.Register(m.columnMetadataTotalSize)
+	if err != nil {
+		fmt.Printf("Dan - Failed to register metric due to %v\n", err)
+	} else {
+		fmt.Println("Dan - Successfully registered")
+	}
+	errs = append(errs, err)
 	errs = append(errs, reg.Register(m.columnCount))
 	errs = append(errs, reg.Register(m.columnCompressedBytes))
 	errs = append(errs, reg.Register(m.columnUncompressedBytes))

--- a/pkg/dataobj/sections/logs/metrics.go
+++ b/pkg/dataobj/sections/logs/metrics.go
@@ -25,7 +25,7 @@ func NewMetrics() *Metrics {
 		columnar: columnar.NewMetrics(sectionType),
 
 		encodeSeconds: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "loki_dataobj",
+			Namespace: "dataobj",
 			Subsystem: "logs",
 			Name:      "encode_seconds",
 
@@ -38,7 +38,7 @@ func NewMetrics() *Metrics {
 		}),
 
 		appendsTotal: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: "loki_dataobj",
+			Namespace: "dataobj",
 			Subsystem: "logs",
 			Name:      "appends_total",
 
@@ -46,7 +46,7 @@ func NewMetrics() *Metrics {
 		}),
 
 		recordCount: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: "loki_dataobj",
+			Namespace: "dataobj",
 			Subsystem: "logs",
 			Name:      "records_count",
 

--- a/pkg/dataobj/sections/pointers/metrics.go
+++ b/pkg/dataobj/sections/pointers/metrics.go
@@ -26,7 +26,7 @@ func NewMetrics() *Metrics {
 		columnar: columnar.NewMetrics(sectionType),
 
 		encodeSeconds: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "loki_dataobj",
+			Namespace: "dataobj",
 			Subsystem: "pointers",
 			Name:      "encode_seconds",
 
@@ -39,7 +39,7 @@ func NewMetrics() *Metrics {
 		}),
 
 		recordsTotal: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: "loki_dataobj",
+			Namespace: "dataobj",
 			Subsystem: "pointers",
 			Name:      "records_total",
 
@@ -47,7 +47,7 @@ func NewMetrics() *Metrics {
 		}),
 
 		minTimestamp: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: "loki_dataobj",
+			Namespace: "dataobj",
 			Subsystem: "pointers",
 			Name:      "min_timestamp",
 
@@ -55,7 +55,7 @@ func NewMetrics() *Metrics {
 		}),
 
 		maxTimestamp: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: "loki_dataobj",
+			Namespace: "dataobj",
 			Subsystem: "pointers",
 			Name:      "max_timestamp",
 

--- a/pkg/dataobj/sections/streams/metrics.go
+++ b/pkg/dataobj/sections/streams/metrics.go
@@ -27,7 +27,7 @@ func NewMetrics() *Metrics {
 		columnar: columnar.NewMetrics(sectionType),
 
 		encodeSeconds: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "loki_dataobj",
+			Namespace: "dataobj",
 			Subsystem: "streams",
 			Name:      "encode_seconds",
 
@@ -40,7 +40,7 @@ func NewMetrics() *Metrics {
 		}),
 
 		recordsTotal: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: "loki_dataobj",
+			Namespace: "dataobj",
 			Subsystem: "streams",
 			Name:      "records_total",
 
@@ -48,7 +48,7 @@ func NewMetrics() *Metrics {
 		}),
 
 		streamCount: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: "loki_dataobj",
+			Namespace: "dataobj",
 			Subsystem: "streams",
 			Name:      "stream_count",
 
@@ -56,7 +56,7 @@ func NewMetrics() *Metrics {
 		}),
 
 		minTimestamp: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: "loki_dataobj",
+			Namespace: "dataobj",
 			Subsystem: "streams",
 			Name:      "min_timestamp",
 
@@ -64,7 +64,7 @@ func NewMetrics() *Metrics {
 		}),
 
 		maxTimestamp: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: "loki_dataobj",
+			Namespace: "dataobj",
 			Subsystem: "streams",
 			Name:      "max_timestamp",
 


### PR DESCRIPTION
Fix colliding metric names preventing running dataobj-consumer and dataobj-index-builder together locally. 

Before this change:
```
$ ./cmd/loki/loki --config.file=tools/dev/kafka/loki-local-config.debug.yaml --target=dataobj-consumer,dataobj-index-builder,all --dataobj.enabled=true --dataobj-consumer.topic=loki.dataobjs --dataobj-consumer.lifecycler.ID=dataobj-consumer-0 --distributor.dataobj-tee.enabled=true --distributor.dataobj-tee.topic=loki.dataobjs --dataobj-consumer.target-builder-memory-limit=5MB --dataobj-consumer.target-section-size=5MB --log.level=debug --dataobj-index-builder.flush-interval=1s --dataobj-index-builder.max-idle-time=1s
...
failed to register metrics for index builder: a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_metadata_size", help: "Distribution of column metadata size per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/indexpointers",topic="loki"}, variableLabels: {}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_metadata_total_size", help: "Distribution of metadata size across all columns per encoded section.", constLabels: {component="index_builder",section="github.com/grafana/loki/indexpointers",topic="loki"}, variableLabels: {}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_count", help: "Distribution of column counts per encoded dataset section.", constLabels: {component="index_builder",section="github.com/grafana/loki/indexpointers",topic="loki"}, variableLabels: {}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_compressed_bytes", help: "Distribution of compressed bytes per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/indexpointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_uncompressed_bytes", help: "Distribution of uncompressed bytes per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/indexpointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_compression_ratio", help: "Distribution of compression ratio per encoded dataset column. Not reported when compression is disabled.", constLabels: {component="index_builder",section="github.com/grafana/loki/indexpointers",topic="loki"}, variableLabels: {column_type,compression_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_rows", help: "Distribution of row counts per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/indexpointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_values", help: "Distribution of value counts per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/indexpointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_count", help: "Distribution of page count per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/indexpointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_compressed_bytes", help: "Distribution of compressed bytes per encoded dataset page.", constLabels: {component="index_builder",section="github.com/grafana/loki/indexpointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_uncompressed_bytes", help: "Distribution of uncompressed bytes per encoded dataset page.", constLabels: {component="index_builder",section="github.com/grafana/loki/indexpointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_compression_ratio", help: "Distribution of compression ratio per encoded dataset page. Not reported when compression is disabled.", constLabels: {component="index_builder",section="github.com/grafana/loki/indexpointers",topic="loki"}, variableLabels: {column_type,compression_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_rows", help: "Distribution of row counts per encoded dataset page", constLabels: {component="index_builder",section="github.com/grafana/loki/indexpointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_values", help: "Distribution of value counts per encoded dataset page", constLabels: {component="index_builder",section="github.com/grafana/loki/indexpointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_metadata_size", help: "Distribution of column metadata size per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/pointers",topic="loki"}, variableLabels: {}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_metadata_total_size", help: "Distribution of metadata size across all columns per encoded section.", constLabels: {component="index_builder",section="github.com/grafana/loki/pointers",topic="loki"}, variableLabels: {}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_count", help: "Distribution of column counts per encoded dataset section.", constLabels: {component="index_builder",section="github.com/grafana/loki/pointers",topic="loki"}, variableLabels: {}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_compressed_bytes", help: "Distribution of compressed bytes per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/pointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_uncompressed_bytes", help: "Distribution of uncompressed bytes per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/pointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_compression_ratio", help: "Distribution of compression ratio per encoded dataset column. Not reported when compression is disabled.", constLabels: {component="index_builder",section="github.com/grafana/loki/pointers",topic="loki"}, variableLabels: {column_type,compression_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_rows", help: "Distribution of row counts per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/pointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_values", help: "Distribution of value counts per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/pointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_count", help: "Distribution of page count per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/pointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_compressed_bytes", help: "Distribution of compressed bytes per encoded dataset page.", constLabels: {component="index_builder",section="github.com/grafana/loki/pointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_uncompressed_bytes", help: "Distribution of uncompressed bytes per encoded dataset page.", constLabels: {component="index_builder",section="github.com/grafana/loki/pointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_compression_ratio", help: "Distribution of compression ratio per encoded dataset page. Not reported when compression is disabled.", constLabels: {component="index_builder",section="github.com/grafana/loki/pointers",topic="loki"}, variableLabels: {column_type,compression_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_rows", help: "Distribution of row counts per encoded dataset page", constLabels: {component="index_builder",section="github.com/grafana/loki/pointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_values", help: "Distribution of value counts per encoded dataset page", constLabels: {component="index_builder",section="github.com/grafana/loki/pointers",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_metadata_size", help: "Distribution of column metadata size per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/streams",topic="loki"}, variableLabels: {}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_metadata_total_size", help: "Distribution of metadata size across all columns per encoded section.", constLabels: {component="index_builder",section="github.com/grafana/loki/streams",topic="loki"}, variableLabels: {}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_count", help: "Distribution of column counts per encoded dataset section.", constLabels: {component="index_builder",section="github.com/grafana/loki/streams",topic="loki"}, variableLabels: {}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_compressed_bytes", help: "Distribution of compressed bytes per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/streams",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_uncompressed_bytes", help: "Distribution of uncompressed bytes per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/streams",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_compression_ratio", help: "Distribution of compression ratio per encoded dataset column. Not reported when compression is disabled.", constLabels: {component="index_builder",section="github.com/grafana/loki/streams",topic="loki"}, variableLabels: {column_type,compression_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_rows", help: "Distribution of row counts per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/streams",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_column_values", help: "Distribution of value counts per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/streams",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_count", help: "Distribution of page count per encoded dataset column.", constLabels: {component="index_builder",section="github.com/grafana/loki/streams",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_compressed_bytes", help: "Distribution of compressed bytes per encoded dataset page.", constLabels: {component="index_builder",section="github.com/grafana/loki/streams",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_uncompressed_bytes", help: "Distribution of uncompressed bytes per encoded dataset page.", constLabels: {component="index_builder",section="github.com/grafana/loki/streams",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_compression_ratio", help: "Distribution of compression ratio per encoded dataset page. Not reported when compression is disabled.", constLabels: {component="index_builder",section="github.com/grafana/loki/streams",topic="loki"}, variableLabels: {column_type,compression_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_rows", help: "Distribution of row counts per encoded dataset page", constLabels: {component="index_builder",section="github.com/grafana/loki/streams",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_dataset_page_values", help: "Distribution of value counts per encoded dataset page", constLabels: {component="index_builder",section="github.com/grafana/loki/streams",topic="loki"}, variableLabels: {column_type}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_streams_encode_seconds", help: "Time taken encoding streams section in seconds.", constLabels: {component="index_builder",topic="loki"}, variableLabels: {}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_streams_records_total", help: "The total number of stream records appended.", constLabels: {component="index_builder",topic="loki"}, variableLabels: {}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_streams_stream_count", help: "The current number of tracked streams; this resets after an encode.", constLabels: {component="index_builder",topic="loki"}, variableLabels: {}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_streams_min_timestamp", help: "The minimum timestamp (in unix seconds) across all streams; this resets after an encode.", constLabels: {component="index_builder",topic="loki"}, variableLabels: {}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_streams_max_timestamp", help: "The maximum timestamp (in unix seconds) across all streams; this resets after an encode.", constLabels: {component="index_builder",topic="loki"}, variableLabels: {}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_sections_count", help: "Distribution of sections per encoded data object.", constLabels: {component="index_builder",topic="loki"}, variableLabels: {}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_file_metadata_size", help: "Distribution of metadata size per encoded data object.", constLabels: {component="index_builder",topic="loki"}, variableLabels: {}} has different label names or a different help string
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "loki_dataobj_encoding_section_metadata_size", help: "Distribution of metadata size per encoded section.", constLabels: {component="index_builder",topic="loki"}, variableLabels: {section}} has different label names or a different help string
error initialising module: dataobj-index-builder
github.com/grafana/dskit/modules.(*Manager).initModule
	/Users/danhopper/git/loki/vendor/github.com/grafana/dskit/modules/modules.go:138
github.com/grafana/dskit/modules.(*Manager).InitModuleServices
	/Users/danhopper/git/loki/vendor/github.com/grafana/dskit/modules/modules.go:108
github.com/grafana/loki/v3/pkg/loki.(*Loki).Run
	/Users/danhopper/git/loki/pkg/loki/loki.go:565
main.main
	/Users/danhopper/git/loki/cmd/loki/main.go:149
runtime.main
	/Users/danhopper/sdk/go1.26.1/src/runtime/proc.go:290
runtime.goexit
	/Users/danhopper/sdk/go1.26.1/src/runtime/asm_arm64.s:1447
...
```

After this change, the command above no longer crashes.

**What this PR does / why we need it**: Running dataobj-consumer and dataobj-index-builder together locally should be possible. 

**Which issue(s) this PR fixes**: NA

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
