### PR TITLE
docs: Loki 3.6.8 Release Notes

### DIFF
--- a/docs/sources/release-notes/v3-6.md
+++ b/docs/sources/release-notes/v3-6.md
@@ -192,6 +192,16 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 ## Bug fixes
 
+### 3.6.8 (2025-03-25)
+
+* **deps:**  Upgrade `go.opentelemetry.io/otel/sdk` from v1.38.0 to v1.40.0 ([#21115](https://github.com/grafana/loki/issues/21115)) ([d1ab148](https://github.com/grafana/loki/commit/d1ab148aa279e9e5263f699fa1b1a0e1eec14f1a)).
+* **deps:**  Upgrade Go to 1.25.8 (release-3.6.x) ([#21240](https://github.com/grafana/loki/issues/21240)) ([10d2666](https://github.com/grafana/loki/commit/10d266699420c158410e5af2521fff6ac4440d61)).
+* **deps:**  Upgrade Go used by querytee/promtail to 3.6 ([#21244](https://github.com/grafana/loki/issues/21244)) ([41a4e0c](https://github.com/grafana/loki/commit/41a4e0c702d35c52181ffb32d34bf8ad98cd7717)).
+* **deps:**  Use different debian version for fluent-bit ([#21247](https://github.com/grafana/loki/issues/21247)) ([138c391](https://github.com/grafana/loki/commit/138c391fd0237b8bf1eb9ecf9eb14d8ce04727c5)).
+* **deps:** Update module github.com/buger/jsonparser to v1.1.2 [security] (release-3.6.x) ([#21201](https://github.com/grafana/loki/issues/21201)) ([3185466](https://github.com/grafana/loki/commit/318546620179a198d9af21baab9c601f5cc367c1)).
+* **deps:** Update module go.opentelemetry.io/otel/sdk to v1.40.0 [security] (release-3.6.x) ([#20887](https://github.com/grafana/loki/issues/20887)) ([d267ad3](https://github.com/grafana/loki/commit/d267ad368873ab3886519b975c86d76ded05741b)).
+* **deps:** Update module google.golang.org/grpc to v1.79.3 [security] (release-3.6.x) ([#21193](https://github.com/grafana/loki/issues/21193)) ([87dff41](https://github.com/grafana/loki/commit/87dff4138d72c6616c47bcd2d46f04692af8d01f)).
+
 ### 3.6.7 (2025-02-23)
 
 * **alloc:** Set a limit on preallocations (backport release-3.6.x) ([#20920](https://github.com/grafana/loki/issues/20920)) ([7e1daf3](https://github.com/grafana/loki/commit/7e1daf3a36f68639a5d06c1ac057a2fcbf0dce40)).


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Release Notes for the 3.6.8 patch.