### PR TITLE
fix: Use newer Go in fluentbit and fix canary test

### DIFF
--- a/clients/cmd/fluent-bit/Dockerfile
+++ b/clients/cmd/fluent-bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-bullseye AS builder
+FROM golang:1.25-bookworm AS builder
 
 COPY . /src
 

--- a/production/helm/loki/src/helm-test/canary_test.go
+++ b/production/helm/loki/src/helm-test/canary_test.go
@@ -129,7 +129,7 @@ func testResultCanary(t *testing.T, ctx context.Context, metric string, test fun
 	body, err := io.ReadAll(rsp.Body)
 	require.NoError(t, err, "Failed to read response body")
 
-	p, err := textparse.New(body, rsp.Header.Get("Content-Type"), "", true, false, true, labels.NewSymbolTable())
+	p, err := textparse.New(body, rsp.Header.Get("Content-Type"), labels.NewSymbolTable(), textparse.ParserOptions{})
 	require.NoError(t, err, "Failed to create Prometheus parser")
 
 	for {


### PR DESCRIPTION
**What this PR does / why we need it**:
Uses newer Go in fluentbit ([to fix this](https://github.com/grafana/loki/actions/runs/23542355474/job/68536356503))
and fix one of our helm canary tests.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
