### PR TITLE
fix(helm): Always respect configured registry in image references

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -45,6 +45,27 @@ Supported clients should check the configuration options for max send message si
 
 ## Helm Chart Upgrades
 
+### Helm Chart 6.50.0 - Always prepend configured registry in image references
+
+The dot-based heuristic introduced in Helm chart 6.50.0 to detect an embedded registry in the `repository` field has been removed. Previously, if the `repository` value contained a dot (e.g., `mirror.gcr.io/grafana/loki`), any configured `registry` (both service-level and `global.imageRegistry`) was silently ignored.
+
+The chart now always prepends the configured registry, which is consistent with the behavior before Helm chart 6.50.0 and with other Grafana Helm charts.
+
+**Action required:** If you are embedding a full registry path in the `repository` field (e.g., `loki.image.repository: private.registry.com/grafana/loki`), split it into separate `registry` and `repository` fields:
+
+```yaml
+# Before (deprecated pattern)
+loki:
+  image:
+    repository: private.registry.com/grafana/loki
+
+# After
+loki:
+  image:
+    registry: private.registry.com
+    repository: grafana/loki
+```
+
 ### Helm Chart 6.50.0 - Respect the global registry in the sidecar image
 
 If you prefixed the sidecar container with a private registry (`sidecar.image.repository`), this is no longer necessary and is deprecated as the global registry is used starting with Helm chart 6.46.1. Therefore please use `global.imageRegistry` or alternatively, `sidecar.image.registry` for more fine-grained control.

--- a/production/helm/loki/templates/_helpers.tpl
+++ b/production/helm/loki/templates/_helpers.tpl
@@ -166,8 +166,7 @@ Create the name of the service account to use
 
 {{/*
 Base template for building docker image reference
-Determines the final image name, respecting the global registry if defined, unless the local repository
-already contains a full registry (indicated by a dot '.') for backwards-compatibility.
+Always prepends the registry when one is configured (global or service-level).
 It also respects `.digest` as well as `.sha` (deprecated).
 */}}
 {{- define "loki.baseImage" }}
@@ -178,8 +177,7 @@ It also respects `.digest` as well as `.sha` (deprecated).
 {{- $ref := ternary (printf ":%s" (.service.tag | default .defaultVersion | toString)) ($digest) (empty $digest) -}}
 
 {{- $prefix := "" -}}
-{{- $firstSegment := (split "/" $repository)._0 -}}
-{{- if and $registry (not (contains "." $firstSegment)) -}}
+{{- if $registry -}}
 {{- $prefix = printf "%s/" $registry -}}
 {{- end -}}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The dot-based heuristic introduced in #19347 assumes that a repository containing a `.` already includes a registry (e.g., `private.registry.com/grafana/loki`), and skips prepending any configured registry. However, repositories with dots in their path segments are perfectly valid Docker image names (e.g., `mirror.gcr.io/grafana/loki`, `foo.com/loki-fips`).

This causes both `global.imageRegistry` and service-level `registry` to be silently ignored when the repository happens to contain a dot.

This PR removes the heuristic and restores the pre-#19347 behavior: always prepend the registry when one is configured. Default chart values produce identical image references before and after this change.

**Which issue(s) this PR fixes**:
Fixes #20663

**Special notes for your reviewer**:

- The change is a single condition removal in `loki.baseImage` (`_helpers.tpl`).
- Verified that **all default images are unchanged** by comparing `helm template` output before and after that

  ```
  docker.io/grafana/loki:3.6.3
  docker.io/grafana/loki-canary:3.6.3
  docker.io/kiwigrid/k8s-sidecar:1.30.9
  docker.io/nginxinc/nginx-unprivileged:1.29-alpine
  docker.io/grafana/loki-helm-test:latest
  memcached:1.6.39-alpine
  prom/memcached-exporter:v0.15.4
  ```
- Users who embedded a full registry in the `repository` field (e.g., `repository: private.registry.com/grafana/loki`) should now split into `registry` + `repository`. This is documented in the upgrade guide.
- `helm lint` passes.
