### PR TITLE
feat(WIP): add optimizers for clamping time ranges in workflow

### DIFF
--- a/pkg/engine/internal/planner/physical/optimizer.go
+++ b/pkg/engine/internal/planner/physical/optimizer.go
@@ -319,9 +319,15 @@ func clampExpression(e Expression, tr TimeRange) (Expression, bool) {
 			if t2.Before(tr.Start) {
 				ts = types.Timestamp(tr.Start.UnixNano())
 			}
-		case types.BinaryOpLt, types.BinaryOpLte:
+		case types.BinaryOpLte:
 			if t2.After(tr.End) {
 				ts = types.Timestamp(tr.End.UnixNano())
+			}
+		case types.BinaryOpLt:
+			// We treat the end time as exclusive, so when clamping "time < max" we add 1 ns to the time range.
+			// Start time is inclusive so we don't need to do the same thing there.
+			if t2.After(tr.End) {
+				ts = types.Timestamp(tr.End.UnixNano() + 1)
 			}
 		}
 		if ts == orig {

--- a/pkg/engine/internal/planner/physical/optimizer.go
+++ b/pkg/engine/internal/planner/physical/optimizer.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"slices"
 	"sort"
+	"time"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
@@ -157,6 +158,185 @@ func (r *limitPushdown) applyToTargets(node Node, limit uint32) bool {
 		}
 	}
 	return changed
+}
+
+var _ rule = (*scanTimeRangePushup)(nil)
+
+// scanTimeRangePushup is a rule that moves the max time range from scan nodes up to RangeAggregations.
+type scanTimeRangePushup struct {
+	plan *Plan
+}
+
+// apply implements rule.
+func (r *scanTimeRangePushup) apply(root Node) bool {
+	// collect scan nodes.
+	nodes := findMatchingNodes(r.plan, root, func(node Node) bool {
+		switch node.Type() {
+		case NodeTypeDataObjScan:
+			return true
+		case NodeTypePointersScan:
+			return true
+		}
+		return false
+	})
+
+	// propagate time range to target parent nodes.
+	changed := false
+	for _, n := range nodes {
+		dataObjScan, ok := n.(*DataObjScan)
+		if ok {
+			applied := r.applyToTargets(dataObjScan, dataObjScan.MaxTimeRange)
+			if applied {
+				changed = true
+			}
+		} else {
+			pointersScan, ok := n.(*PointersScan)
+			if ok {
+				applied := r.applyToTargets(pointersScan, pointersScan.MaxTimeRange())
+				if applied {
+					changed = true
+				}
+			}
+		}
+	}
+	return changed
+}
+
+// applyToTargets applies max time range on target nodes.
+func (r *scanTimeRangePushup) applyToTargets(node Node, timeRange TimeRange) bool {
+	var changed bool
+	switch node := node.(type) {
+	case *RangeAggregation:
+		if node.Step == 0 {
+			if node.Start.Compare(timeRange.Start) < 0 {
+				node.Start = timeRange.Start
+				changed = true
+			}
+			if node.End.Compare(timeRange.End) > 0 {
+				node.End = timeRange.End
+				changed = true
+			}
+		} else {
+			trSteppedStart := time.UnixMilli((timeRange.Start.UnixMilli() / node.Step.Milliseconds()) * node.Step.Milliseconds()).UTC()
+			for trSteppedStart.Compare(timeRange.Start) < 0 { // should only happen at most once, but just in case
+				trSteppedStart = trSteppedStart.Add(node.Step)
+			}
+			trSteppedEnd := time.UnixMilli((timeRange.End.UnixMilli() / node.Step.Milliseconds()) * node.Step.Milliseconds()).UTC()
+			for trSteppedEnd.Compare(timeRange.End) > 0 {
+				trSteppedEnd = trSteppedEnd.Add(-node.Step)
+			}
+			if node.Start.Compare(trSteppedStart) < 0 {
+				node.Start = trSteppedStart
+				changed = true
+			}
+			if node.End.Compare(trSteppedEnd) > 0 {
+				node.End = trSteppedEnd
+				changed = true
+			}
+		}
+	}
+
+	// Continue to parents
+	for _, parent := range r.plan.Parent(node) {
+		if r.applyToTargets(parent, timeRange) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+var _ rule = (*clampPredicates)(nil)
+
+// clampPredicates is a rule that applies the time predicates from scan nodes.
+type clampPredicates struct {
+	plan *Plan
+}
+
+// apply implements rule.
+func (r *clampPredicates) apply(root Node) bool {
+	// collect scan nodes.
+	nodes := findMatchingNodes(r.plan, root, func(node Node) bool {
+		switch node.Type() {
+		case NodeTypeDataObjScan:
+			return true
+		case NodeTypePointersScan:
+			return true
+		}
+		return false
+	})
+	changed := false
+	for _, n := range nodes {
+		switch n := n.(type) {
+		case *DataObjScan:
+			predicates := make([]Expression, len(n.Predicates))
+			for i, p := range n.Predicates {
+				clamped := false
+				predicates[i], clamped = clampExpression(p, n.MaxTimeRange)
+				if clamped {
+					changed = true
+				}
+			}
+			n.Predicates = predicates
+		case *PointersScan:
+			predicates := make([]Expression, len(n.Predicates))
+			for i, p := range n.Predicates {
+				clamped := false
+				predicates[i], clamped = clampExpression(p, n.MaxTimeRange())
+				if clamped {
+					changed = true
+				}
+			}
+			n.Predicates = predicates
+		}
+	}
+	return changed
+}
+
+// Only modifies BinaryExpressions that take the form ">= timestamp" or "<= timestamp".
+// Returns true if the expression has been modified or false if it has not.
+func clampExpression(e Expression, tr TimeRange) (Expression, bool) {
+	switch e := e.(type) {
+	case *BinaryExpr:
+		if tr.IsZero() {
+			return e, false
+		}
+		col, ok := e.Left.(*ColumnExpr)
+		if !ok || col.Ref.Column != types.ColumnNameBuiltinTimestamp || col.Ref.Type != types.ColumnTypeBuiltin {
+			return e, false
+		}
+		lit, ok := e.Right.(*LiteralExpr)
+		if !ok || lit.ValueType() != types.Loki.Timestamp {
+			return e, false
+		}
+		ts, ok := lit.Value().(types.Timestamp)
+		if !ok {
+			return e, false
+		}
+		t2 := time.Unix(0, int64(ts))
+		orig := ts
+		switch e.Op {
+		case types.BinaryOpGte, types.BinaryOpGt:
+			if t2.Before(tr.Start) {
+				ts = types.Timestamp(tr.Start.UnixNano())
+			}
+		case types.BinaryOpLt, types.BinaryOpLte:
+			if t2.After(tr.End) {
+				ts = types.Timestamp(tr.End.UnixNano())
+			}
+		}
+		if ts == orig {
+			return e, false
+		}
+		return &BinaryExpr{
+			Left:  e.Left,
+			Right: NewLiteral(ts),
+			Op:    e.Op,
+		}, true
+
+	default:
+		return e, false
+	}
+
 }
 
 var _ rule = (*groupByPushdown)(nil)
@@ -699,6 +879,17 @@ func canShardAggregation(vec *VectorAggregation, rng *RangeAggregation) bool {
 	return false
 }
 
+func WorkflowOptimizations(plan *Plan) []*optimization {
+	return []*optimization{
+		newOptimization("ClampPredicates", plan).withRules(
+			&clampPredicates{plan: plan}),
+		// needs to happen after ClampPredicates
+		newOptimization("ScanTimeRangePushup", plan).withRules(
+			&scanTimeRangePushup{plan: plan}),
+	}
+
+}
+
 // optimization represents a single optimization pass and can hold multiple rules.
 type optimization struct {
 	plan  *Plan
@@ -749,11 +940,11 @@ type optimizer struct {
 	optimisations []*optimization
 }
 
-func newOptimizer(plan *Plan, passes []*optimization) *optimizer {
+func NewOptimizer(plan *Plan, passes []*optimization) *optimizer {
 	return &optimizer{plan: plan, optimisations: passes}
 }
 
-func (o *optimizer) optimize(node Node) {
+func (o *optimizer) Optimize(node Node) {
 	for _, optimisation := range o.optimisations {
 		optimisation.optimize(node)
 	}

--- a/pkg/engine/internal/planner/physical/optimizer.go
+++ b/pkg/engine/internal/planner/physical/optimizer.go
@@ -885,8 +885,8 @@ func canShardAggregation(vec *VectorAggregation, rng *RangeAggregation) bool {
 	return false
 }
 
-func WorkflowOptimizations(plan *Plan) []*optimization {
-	return []*optimization{
+func WorkflowOptimizations(plan *Plan) []*Optimization {
+	return []*Optimization{
 		newOptimization("ClampPredicates", plan).withRules(
 			&clampPredicates{plan: plan}),
 		// needs to happen after ClampPredicates
@@ -896,26 +896,26 @@ func WorkflowOptimizations(plan *Plan) []*optimization {
 
 }
 
-// optimization represents a single optimization pass and can hold multiple rules.
-type optimization struct {
+// Optimization represents a single Optimization pass and can hold multiple rules.
+type Optimization struct {
 	plan  *Plan
 	name  string
 	rules []rule
 }
 
-func newOptimization(name string, plan *Plan) *optimization {
-	return &optimization{
+func newOptimization(name string, plan *Plan) *Optimization {
+	return &Optimization{
 		name: name,
 		plan: plan,
 	}
 }
 
-func (o *optimization) withRules(rules ...rule) *optimization {
+func (o *Optimization) withRules(rules ...rule) *Optimization {
 	o.rules = append(o.rules, rules...)
 	return o
 }
 
-func (o *optimization) optimize(node Node) {
+func (o *Optimization) optimize(node Node) {
 	iterations, maxIterations := 0, 10
 
 	for iterations < maxIterations {
@@ -928,7 +928,7 @@ func (o *optimization) optimize(node Node) {
 	}
 }
 
-func (o *optimization) applyRules(node Node) bool {
+func (o *Optimization) applyRules(node Node) bool {
 	anyChanged := false
 
 	for _, rule := range o.rules {
@@ -940,17 +940,17 @@ func (o *optimization) applyRules(node Node) bool {
 	return anyChanged
 }
 
-// The optimizer can optimize physical plans using the provided optimization passes.
-type optimizer struct {
+// The Optimizer can optimize physical plans using the provided optimization passes.
+type Optimizer struct {
 	plan          *Plan
-	optimisations []*optimization
+	optimisations []*Optimization
 }
 
-func NewOptimizer(plan *Plan, passes []*optimization) *optimizer {
-	return &optimizer{plan: plan, optimisations: passes}
+func NewOptimizer(plan *Plan, passes []*Optimization) *Optimizer {
+	return &Optimizer{plan: plan, optimisations: passes}
 }
 
-func (o *optimizer) Optimize(node Node) {
+func (o *Optimizer) Optimize(node Node) {
 	for _, optimisation := range o.optimisations {
 		optimisation.optimize(node)
 	}

--- a/pkg/engine/internal/planner/physical/optimizer_test.go
+++ b/pkg/engine/internal/planner/physical/optimizer_test.go
@@ -109,7 +109,7 @@ func dummyPlan() *Plan {
 
 func TestPredicatePushdown(t *testing.T) {
 	plan := dummyPlan()
-	optimizations := []*optimization{
+	optimizations := []*Optimization{
 		newOptimization("predicate pushdown", plan).withRules(
 			&predicatePushdown{plan},
 		),
@@ -172,7 +172,7 @@ func TestLimitPushdown(t *testing.T) {
 		}
 
 		// apply optimisations
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("limit pushdown", plan).withRules(
 				&limitPushdown{plan: plan},
 			),
@@ -235,7 +235,7 @@ func TestLimitPushdown(t *testing.T) {
 		orig := PrintAsTree(plan)
 
 		// apply optimisations
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("limit pushdown", plan).withRules(
 				&limitPushdown{plan: plan},
 			),
@@ -262,7 +262,7 @@ func TestScanTimeRangePushup(t *testing.T) {
 		}
 
 		// apply optimisations
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("scan time range pushup", plan).withRules(
 				&scanTimeRangePushup{plan: plan},
 			),
@@ -298,7 +298,7 @@ func TestScanTimeRangePushup(t *testing.T) {
 		}
 
 		// apply optimisations
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("scan time range pushup", plan).withRules(
 				&scanTimeRangePushup{plan: plan},
 			),
@@ -334,7 +334,7 @@ func TestScanTimeRangePushup(t *testing.T) {
 		}
 
 		// apply optimisations
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("scan time range pushup", plan).withRules(
 				&scanTimeRangePushup{plan: plan},
 			),
@@ -459,7 +459,7 @@ func TestGroupByPushdown(t *testing.T) {
 		}
 
 		// apply optimisation
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("groupBy pushdown", plan).withRules(
 				&groupByPushdown{plan: plan},
 			),
@@ -527,7 +527,7 @@ func TestGroupByPushdown(t *testing.T) {
 		orig := PrintAsTree(plan)
 
 		// apply optimisation
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("projection pushdown", plan).withRules(
 				&groupByPushdown{plan: plan},
 			),
@@ -567,7 +567,7 @@ func TestProjectionPushdown(t *testing.T) {
 		}
 
 		// apply optimisations
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("projection pushdown", plan).withRules(
 				&projectionPushdown{plan: plan},
 			),
@@ -636,7 +636,7 @@ func TestProjectionPushdown(t *testing.T) {
 		}
 
 		// apply optimisations
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("projection pushdown", plan).withRules(
 				&projectionPushdown{plan: plan},
 			),
@@ -707,7 +707,7 @@ func TestProjectionPushdown(t *testing.T) {
 		}
 
 		// apply optimisations
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("projection pushdown", plan).withRules(
 				&projectionPushdown{plan: plan},
 			),
@@ -1055,7 +1055,7 @@ func TestProjectionPushdown_PushesRequestedKeysToParseOperations(t *testing.T) {
 
 func TestRemoveNoopFilter(t *testing.T) {
 	plan := dummyPlan()
-	optimizations := []*optimization{
+	optimizations := []*Optimization{
 		newOptimization("noop filter", plan).withRules(
 			&removeNoopFilter{plan},
 		),
@@ -1161,7 +1161,7 @@ func Test_parallelPushdown(t *testing.T) {
 			require.NoError(t, plan.graph.AddEdge(dag.Edge[Node]{Parent: parallelize, Child: scan}))
 		}
 
-		opt := NewOptimizer(&plan, []*optimization{
+		opt := NewOptimizer(&plan, []*Optimization{
 			newOptimization("ParallelPushdown", &plan).withRules(&parallelPushdown{plan: &plan}),
 		})
 		root, _ := plan.graph.Root()
@@ -1198,7 +1198,7 @@ func Test_parallelPushdown(t *testing.T) {
 			require.NoError(t, plan.graph.AddEdge(dag.Edge[Node]{Parent: parallelize, Child: scan}))
 		}
 
-		opt := NewOptimizer(&plan, []*optimization{
+		opt := NewOptimizer(&plan, []*Optimization{
 			newOptimization("ParallelPushdown", &plan).withRules(&parallelPushdown{plan: &plan}),
 		})
 		root, _ := plan.graph.Root()
@@ -1249,7 +1249,7 @@ func Test_parallelPushdown(t *testing.T) {
 			require.NoError(t, plan.graph.AddEdge(dag.Edge[Node]{Parent: parallelize, Child: scan}))
 		}
 
-		opt := NewOptimizer(&plan, []*optimization{
+		opt := NewOptimizer(&plan, []*Optimization{
 			newOptimization("ParallelPushdown", &plan).withRules(&parallelPushdown{plan: &plan}),
 		})
 		root, _ := plan.graph.Root()

--- a/pkg/engine/internal/planner/physical/optimizer_test.go
+++ b/pkg/engine/internal/planner/physical/optimizer_test.go
@@ -1,6 +1,7 @@
 package physical
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/logical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+	"github.com/grafana/loki/v3/pkg/engine/internal/util"
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
 )
 
@@ -113,8 +115,8 @@ func TestPredicatePushdown(t *testing.T) {
 		),
 	}
 
-	o := newOptimizer(plan, optimizations)
-	o.optimize(plan.Roots()[0])
+	o := NewOptimizer(plan, optimizations)
+	o.Optimize(plan.Roots()[0])
 	actual := PrintAsTree(plan)
 
 	optimized := &Plan{}
@@ -175,8 +177,8 @@ func TestLimitPushdown(t *testing.T) {
 				&limitPushdown{plan: plan},
 			),
 		}
-		o := newOptimizer(plan, optimizations)
-		o.optimize(plan.Roots()[0])
+		o := NewOptimizer(plan, optimizations)
+		o.Optimize(plan.Roots()[0])
 
 		expectedPlan := &Plan{}
 		{
@@ -238,12 +240,189 @@ func TestLimitPushdown(t *testing.T) {
 				&limitPushdown{plan: plan},
 			),
 		}
-		o := newOptimizer(plan, optimizations)
-		o.optimize(plan.Roots()[0])
+		o := NewOptimizer(plan, optimizations)
+		o.Optimize(plan.Roots()[0])
 
 		actual := PrintAsTree(plan)
 		require.Equal(t, orig, actual)
 	})
+}
+
+func TestScanTimeRangePushup(t *testing.T) {
+	t.Run("pushup time range to RangeAggregation with zero step", func(t *testing.T) {
+		plan := &Plan{}
+		{
+			dataObjScan := plan.graph.Add(&DataObjScan{MaxTimeRange: TimeRange{Start: time.Date(2026, 3, 14, 16, 45, 29, 0, time.UTC),
+				End: time.Date(2026, 3, 14, 16, 46, 31, 0, time.UTC)}})
+			rangeAgg := plan.graph.Add(&RangeAggregation{
+				Start: time.Date(2026, 3, 14, 16, 43, 30, 0, time.UTC),
+				End:   time.Date(2026, 3, 14, 16, 53, 30, 0, time.UTC),
+				Step:  0, Range: time.Minute})
+			_ = plan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: dataObjScan})
+		}
+
+		// apply optimisations
+		optimizations := []*optimization{
+			newOptimization("scan time range pushup", plan).withRules(
+				&scanTimeRangePushup{plan: plan},
+			),
+		}
+		o := NewOptimizer(plan, optimizations)
+		o.Optimize(plan.Roots()[0])
+
+		expectedPlan := &Plan{}
+		{
+			dataObjScan := expectedPlan.graph.Add(&DataObjScan{MaxTimeRange: TimeRange{Start: time.Date(2026, 3, 14, 16, 45, 29, 0, time.UTC),
+				End: time.Date(2026, 3, 14, 16, 46, 31, 0, time.UTC)}})
+			rangeAgg := expectedPlan.graph.Add(&RangeAggregation{
+				Start: time.Date(2026, 3, 14, 16, 45, 29, 0, time.UTC),
+				End:   time.Date(2026, 3, 14, 16, 46, 31, 0, time.UTC),
+				Step:  0, Range: time.Minute})
+			_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: dataObjScan})
+		}
+
+		actual := PrintAsTree(plan)
+		expected := PrintAsTree(expectedPlan)
+		require.Equal(t, expected, actual)
+	})
+	t.Run("non-zero step rounds scan time range in RangeAggregation", func(t *testing.T) {
+		plan := &Plan{}
+		{
+			dataObjScan := plan.graph.Add(&DataObjScan{MaxTimeRange: TimeRange{Start: time.Date(2026, 3, 14, 16, 44, 29, 0, time.UTC),
+				End: time.Date(2026, 3, 14, 16, 46, 31, 0, time.UTC)}})
+			rangeAgg := plan.graph.Add(&RangeAggregation{
+				Start: time.Date(2026, 3, 14, 16, 43, 30, 0, time.UTC),
+				End:   time.Date(2026, 3, 14, 16, 53, 30, 0, time.UTC),
+				Step:  time.Minute, Range: time.Minute})
+			_ = plan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: dataObjScan})
+		}
+
+		// apply optimisations
+		optimizations := []*optimization{
+			newOptimization("scan time range pushup", plan).withRules(
+				&scanTimeRangePushup{plan: plan},
+			),
+		}
+		o := NewOptimizer(plan, optimizations)
+		o.Optimize(plan.Roots()[0])
+
+		expectedPlan := &Plan{}
+		{
+			dataObjScan := expectedPlan.graph.Add(&DataObjScan{MaxTimeRange: TimeRange{Start: time.Date(2026, 3, 14, 16, 44, 29, 0, time.UTC),
+				End: time.Date(2026, 3, 14, 16, 46, 31, 0, time.UTC)}})
+			rangeAgg := expectedPlan.graph.Add(&RangeAggregation{
+				Start: time.Date(2026, 3, 14, 16, 45, 0, 0, time.UTC),
+				End:   time.Date(2026, 3, 14, 16, 46, 0, 0, time.UTC),
+				Step:  time.Minute, Range: time.Minute})
+			_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: dataObjScan})
+		}
+
+		actual := PrintAsTree(plan)
+		expected := PrintAsTree(expectedPlan)
+		require.Equal(t, expected, actual)
+	})
+	t.Run("unusual step still rounds scan time range in RangeAggregation", func(t *testing.T) {
+		plan := &Plan{}
+		{
+			dataObjScan := plan.graph.Add(&DataObjScan{MaxTimeRange: TimeRange{Start: time.Date(2026, 3, 20, 17, 53, 41, 0, time.UTC),
+				End: time.Date(2026, 3, 20, 17, 54, 49, 0, time.UTC)}})
+			rangeAgg := plan.graph.Add(&RangeAggregation{
+				Start: time.Date(2026, 3, 20, 16, 43, 30, 0, time.UTC),
+				End:   time.Date(2026, 3, 20, 18, 53, 30, 0, time.UTC),
+				Step:  63 * time.Second, Range: time.Minute})
+			_ = plan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: dataObjScan})
+		}
+
+		// apply optimisations
+		optimizations := []*optimization{
+			newOptimization("scan time range pushup", plan).withRules(
+				&scanTimeRangePushup{plan: plan},
+			),
+		}
+		o := NewOptimizer(plan, optimizations)
+		o.Optimize(plan.Roots()[0])
+
+		expectedPlan := &Plan{}
+		{
+			dataObjScan := expectedPlan.graph.Add(&DataObjScan{MaxTimeRange: TimeRange{Start: time.Date(2026, 3, 20, 17, 53, 41, 0, time.UTC),
+				End: time.Date(2026, 3, 20, 17, 54, 49, 0, time.UTC)}})
+			rangeAgg := expectedPlan.graph.Add(&RangeAggregation{
+				Start: time.Date(2026, 3, 20, 17, 53, 42, 0, time.UTC),
+				End:   time.Date(2026, 3, 20, 17, 54, 45, 0, time.UTC),
+				Step:  63 * time.Second, Range: time.Minute})
+			_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: dataObjScan})
+		}
+
+		actual := PrintAsTree(plan)
+		expected := PrintAsTree(expectedPlan)
+		require.Equal(t, expected, actual)
+	})
+}
+
+func TestClampExpression(t *testing.T) {
+	col := newColumnExpr(types.ColumnNameBuiltinTimestamp, types.ColumnTypeBuiltin)
+	early := types.Timestamp(time.Date(2026, 3, 11, 12, 41, 44, 719000000, time.UTC).UnixNano())
+	late := types.Timestamp(time.Date(2026, 3, 18, 9, 41, 44, 976217699, time.UTC).UnixNano())
+	tests := []struct {
+		desc    string
+		e       Expression
+		tr      TimeRange
+		clamped bool
+		want    string
+	}{
+		{
+			desc: "GTE before range clamps to start",
+			e:    &BinaryExpr{Left: col, Right: NewLiteral(early), Op: types.BinaryOpGte},
+			tr: TimeRange{
+				Start: time.Date(2026, 3, 14, 16, 43, 30, 0, time.UTC),
+				End:   time.Date(2026, 3, 14, 16, 48, 0, 0, time.UTC),
+			},
+			clamped: true,
+			want:    fmt.Sprintf("GTE(%s, %s)", col, util.FormatTimeRFC3339Nano(time.Date(2026, 3, 14, 16, 43, 30, 0, time.UTC))),
+		},
+		{
+			desc: "LT after range clamps to end",
+			e:    &BinaryExpr{Left: col, Right: NewLiteral(late), Op: types.BinaryOpLt},
+			tr: TimeRange{
+				Start: time.Date(2026, 3, 14, 16, 43, 30, 0, time.UTC),
+				End:   time.Date(2026, 3, 14, 16, 48, 0, 0, time.UTC),
+			},
+			clamped: true,
+			want:    fmt.Sprintf("LT(%s, %s)", col, util.FormatTimeRFC3339Nano(time.Date(2026, 3, 14, 16, 48, 0, 0, time.UTC))),
+		},
+		{
+			desc:    "zero TimeRange leaves expression unchanged",
+			e:       &BinaryExpr{Left: col, Right: NewLiteral(early), Op: types.BinaryOpGte},
+			tr:      TimeRange{},
+			clamped: false,
+			want:    (&BinaryExpr{Left: col, Right: NewLiteral(early), Op: types.BinaryOpGte}).String(),
+		},
+		{
+			desc: "non-timestamp binary expr unchange",
+			e: &BinaryExpr{
+				Left:  newColumnExpr("level", types.ColumnTypeLabel),
+				Right: NewLiteral("info"),
+				Op:    types.BinaryOpEq,
+			},
+			tr: TimeRange{
+				Start: time.Date(2026, 3, 14, 16, 43, 30, 0, time.UTC),
+				End:   time.Date(2026, 3, 14, 16, 48, 0, 0, time.UTC),
+			},
+			clamped: false,
+			want: (&BinaryExpr{
+				Left:  newColumnExpr("level", types.ColumnTypeLabel),
+				Right: NewLiteral("info"),
+				Op:    types.BinaryOpEq,
+			}).String(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, clamped := clampExpression(tt.e, tt.tr)
+			require.Equal(t, tt.clamped, clamped)
+			require.Equal(t, tt.want, got.String())
+		})
+	}
 }
 
 func TestGroupByPushdown(t *testing.T) {
@@ -285,8 +464,8 @@ func TestGroupByPushdown(t *testing.T) {
 				&groupByPushdown{plan: plan},
 			),
 		}
-		o := newOptimizer(plan, optimizations)
-		o.optimize(plan.Roots()[0])
+		o := NewOptimizer(plan, optimizations)
+		o.Optimize(plan.Roots()[0])
 
 		expectedPlan := &Plan{}
 		{
@@ -353,8 +532,8 @@ func TestGroupByPushdown(t *testing.T) {
 				&groupByPushdown{plan: plan},
 			),
 		}
-		o := newOptimizer(plan, optimizations)
-		o.optimize(plan.Roots()[0])
+		o := NewOptimizer(plan, optimizations)
+		o.Optimize(plan.Roots()[0])
 
 		actual := PrintAsTree(plan)
 		require.Equal(t, orig, actual)
@@ -393,8 +572,8 @@ func TestProjectionPushdown(t *testing.T) {
 				&projectionPushdown{plan: plan},
 			),
 		}
-		o := newOptimizer(plan, optimizations)
-		o.optimize(plan.Roots()[0])
+		o := NewOptimizer(plan, optimizations)
+		o.Optimize(plan.Roots()[0])
 
 		expectedPlan := &Plan{}
 		{
@@ -462,8 +641,8 @@ func TestProjectionPushdown(t *testing.T) {
 				&projectionPushdown{plan: plan},
 			),
 		}
-		o := newOptimizer(plan, optimizations)
-		o.optimize(plan.Roots()[0])
+		o := NewOptimizer(plan, optimizations)
+		o.Optimize(plan.Roots()[0])
 
 		expectedPlan := &Plan{}
 		{
@@ -533,8 +712,8 @@ func TestProjectionPushdown(t *testing.T) {
 				&projectionPushdown{plan: plan},
 			),
 		}
-		o := newOptimizer(plan, optimizations)
-		o.optimize(plan.Roots()[0])
+		o := NewOptimizer(plan, optimizations)
+		o.Optimize(plan.Roots()[0])
 
 		expectedPlan := &Plan{}
 		{
@@ -882,8 +1061,8 @@ func TestRemoveNoopFilter(t *testing.T) {
 		),
 	}
 
-	o := newOptimizer(plan, optimizations)
-	o.optimize(plan.Roots()[0])
+	o := NewOptimizer(plan, optimizations)
+	o.Optimize(plan.Roots()[0])
 	actual := PrintAsTree(plan)
 
 	optimized := &Plan{}
@@ -982,11 +1161,11 @@ func Test_parallelPushdown(t *testing.T) {
 			require.NoError(t, plan.graph.AddEdge(dag.Edge[Node]{Parent: parallelize, Child: scan}))
 		}
 
-		opt := newOptimizer(&plan, []*optimization{
+		opt := NewOptimizer(&plan, []*optimization{
 			newOptimization("ParallelPushdown", &plan).withRules(&parallelPushdown{plan: &plan}),
 		})
 		root, _ := plan.graph.Root()
-		opt.optimize(root)
+		opt.Optimize(root)
 
 		var expectedPlan Plan
 		{
@@ -1019,7 +1198,7 @@ func Test_parallelPushdown(t *testing.T) {
 			require.NoError(t, plan.graph.AddEdge(dag.Edge[Node]{Parent: parallelize, Child: scan}))
 		}
 
-		opt := newOptimizer(&plan, []*optimization{
+		opt := NewOptimizer(&plan, []*optimization{
 			newOptimization("ParallelPushdown", &plan).withRules(&parallelPushdown{plan: &plan}),
 		})
 		root, _ := plan.graph.Root()
@@ -1035,7 +1214,7 @@ func Test_parallelPushdown(t *testing.T) {
 		//         TopK # Shard from second iteration
 		//           TopK # Shard from third iteration
 		//             DataObjScan
-		opt.optimize(root)
+		opt.Optimize(root)
 
 		var expectedPlan Plan
 		{
@@ -1070,11 +1249,11 @@ func Test_parallelPushdown(t *testing.T) {
 			require.NoError(t, plan.graph.AddEdge(dag.Edge[Node]{Parent: parallelize, Child: scan}))
 		}
 
-		opt := newOptimizer(&plan, []*optimization{
+		opt := NewOptimizer(&plan, []*optimization{
 			newOptimization("ParallelPushdown", &plan).withRules(&parallelPushdown{plan: &plan}),
 		})
 		root, _ := plan.graph.Root()
-		opt.optimize(root)
+		opt.Optimize(root)
 
 		var expectedPlan Plan
 		{

--- a/pkg/engine/internal/planner/physical/optimizer_test.go
+++ b/pkg/engine/internal/planner/physical/optimizer_test.go
@@ -388,7 +388,7 @@ func TestClampExpression(t *testing.T) {
 				End:   time.Date(2026, 3, 14, 16, 48, 0, 0, time.UTC),
 			},
 			clamped: true,
-			want:    fmt.Sprintf("LT(%s, %s)", col, util.FormatTimeRFC3339Nano(time.Date(2026, 3, 14, 16, 48, 0, 0, time.UTC))),
+			want:    fmt.Sprintf("LT(%s, %s)", col, util.FormatTimeRFC3339Nano(time.Date(2026, 3, 14, 16, 48, 0, 1, time.UTC))),
 		},
 		{
 			desc:    "zero TimeRange leaves expression unchanged",

--- a/pkg/engine/internal/planner/physical/planner.go
+++ b/pkg/engine/internal/planner/physical/planner.go
@@ -751,7 +751,7 @@ func disambiguateExpression(expr Expression, conflictingLabels []string) (Expres
 // if any optimizations can be applied.
 func (p *Planner) Optimize(plan *Plan) (*Plan, error) {
 	for i, root := range plan.Roots() {
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("PredicatePushdown", plan).withRules(
 				&predicatePushdown{plan: plan},
 			),

--- a/pkg/engine/internal/planner/physical/planner.go
+++ b/pkg/engine/internal/planner/physical/planner.go
@@ -773,8 +773,8 @@ func (p *Planner) Optimize(plan *Plan) (*Plan, error) {
 				&removeNoopFilter{plan: plan},
 			),
 		}
-		optimizer := newOptimizer(plan, optimizations)
-		optimizer.optimize(root)
+		optimizer := NewOptimizer(plan, optimizations)
+		optimizer.Optimize(root)
 		if i == 1 {
 			return nil, errors.New("physical plan must only have exactly one root node")
 		}

--- a/pkg/engine/internal/util/dag/dag.go
+++ b/pkg/engine/internal/util/dag/dag.go
@@ -254,10 +254,14 @@ func (g *Graph[NodeType]) Clone() *Graph[NodeType] {
 	for node, children := range g.children {
 		newChildren[node] = slices.Clone(children)
 	}
+	newParents := make(map[NodeType][]NodeType, len(g.parents))
+	for node, parents := range g.parents {
+		newParents[node] = slices.Clone(parents)
+	}
 
 	return &Graph[NodeType]{
 		nodes:    maps.Clone(g.nodes),
-		parents:  maps.Clone(g.parents),
+		parents:  newParents,
 		children: newChildren,
 	}
 }

--- a/pkg/engine/internal/worker/worker_test.go
+++ b/pkg/engine/internal/worker/worker_test.go
@@ -58,7 +58,7 @@ func Test(t *testing.T) {
 			Line:      "Hello, world!",
 		}, {
 			Timestamp: time.Date(2025, time.January, 1, 0, 0, 1, 0, time.UTC),
-			Line:      "Goodbye, world!",
+			Line:      "Goodbye, world!", // missing from output
 		}},
 	})
 	builder.Close()

--- a/pkg/engine/internal/workflow/workflow_planner.go
+++ b/pkg/engine/internal/workflow/workflow_planner.go
@@ -61,6 +61,13 @@ func planWorkflow(tenantID string, plan *physical.Plan, cache cacheParams) (dag.
 		return dag.Graph[*Task]{}, err
 	}
 
+	for _, root := range planner.graph.Roots() {
+		planner.graph.Walk(root, func(t *Task) error {
+			optimize(t)
+			return nil
+		}, dag.PostOrderWalk)
+	}
+
 	if cache.enabled {
 		if err := injectTaskCaching(tenantID, planner.graph, cache.maxSizeBytes); err != nil {
 			return dag.Graph[*Task]{}, err
@@ -68,6 +75,13 @@ func planWorkflow(tenantID string, plan *physical.Plan, cache cacheParams) (dag.
 	}
 
 	return planner.graph, nil
+}
+
+func optimize(t *Task) {
+	for _, root := range t.Fragment.Roots() {
+		optimizer := physical.NewOptimizer(t.Fragment, physical.WorkflowOptimizations(t.Fragment))
+		optimizer.Optimize(root)
+	}
 }
 
 // injectTaskCaching wraps each cacheable task fragment with a Cache node.
@@ -383,6 +397,7 @@ func (p *planner) processParallelizeNode(node *physical.Parallelize) ([]*Task, e
 		shardedPlan := templateTask.Fragment.Graph().Clone()
 		shardedPlan.Inject(shardableNode, shard)
 		shardedPlan.Eliminate(shardableNode)
+		cloneAllParents(shard, shardedPlan, templateTask, map[physical.Node]bool{})
 
 		// The sources of the template task need to be replaced with new unique
 		// streams.
@@ -445,6 +460,32 @@ func (p *planner) processParallelizeNode(node *physical.Parallelize) ([]*Task, e
 
 	p.graph.Eliminate(templateTask)
 	return partitions, nil
+}
+
+// takes a starting node and a graph and recursively replaces
+// all parents of that node in the graph with clones.
+func cloneAllParents(node physical.Node, graph *dag.Graph[physical.Node], task *Task, visited map[physical.Node]bool) {
+	visited[node] = true
+	parents := graph.Parents(node)
+	for _, parent := range parents {
+		if visited[parent] {
+			continue
+		}
+		clone := parent.Clone()
+		_, ok := task.Sources[parent]
+		if ok {
+			tmp := task.Sources[parent]
+			task.Sources[clone] = tmp
+			delete(task.Sources, parent)
+		}
+		graph.Inject(parent, clone)
+		graph.Eliminate(parent)
+		visited[clone] = true
+		cloneParents := graph.Parents(clone)
+		for _, p := range cloneParents {
+			cloneAllParents(p, graph, task, visited)
+		}
+	}
 }
 
 // findShardableNode finds the first node in the graph that can be split into

--- a/pkg/engine/internal/workflow/workflow_planner.go
+++ b/pkg/engine/internal/workflow/workflow_planner.go
@@ -62,10 +62,12 @@ func planWorkflow(tenantID string, plan *physical.Plan, cache cacheParams) (dag.
 	}
 
 	for _, root := range planner.graph.Roots() {
-		planner.graph.Walk(root, func(t *Task) error {
+		if err := planner.graph.Walk(root, func(t *Task) error {
 			optimize(t)
 			return nil
-		}, dag.PostOrderWalk)
+		}, dag.PostOrderWalk); err != nil {
+			return dag.Graph[*Task]{}, err
+		}
 	}
 
 	if cache.enabled {

--- a/pkg/engine/internal/workflow/workflow_planner_test.go
+++ b/pkg/engine/internal/workflow/workflow_planner_test.go
@@ -429,7 +429,7 @@ func Test_planWorkflow(t *testing.T) {
 │
 │ Batching batch_size=500
 │ │   └── @sink stream=00000000000000000000000004
-│ └── RangeAggregation operation=count start=1970-01-01T00:00:05Z end=1970-01-01T00:00:45Z step=0s range=0s group_by=()
+│ └── RangeAggregation operation=count start=1970-01-01T00:00:10Z end=1970-01-01T00:00:45Z step=0s range=0s group_by=()
 │     └── DataObjScan location=a streams=0 section_id=0 projections=()
 │             └── @max_time_range start=1970-01-01T00:00:10Z end=1970-01-01T00:00:50Z
 └
@@ -438,7 +438,7 @@ func Test_planWorkflow(t *testing.T) {
 │
 │ Batching batch_size=500
 │ │   └── @sink stream=00000000000000000000000005
-│ └── RangeAggregation operation=count start=1970-01-01T00:00:05Z end=1970-01-01T00:00:45Z step=0s range=0s group_by=()
+│ └── RangeAggregation operation=count start=1970-01-01T00:00:20Z end=1970-01-01T00:00:45Z step=0s range=0s group_by=()
 │     └── DataObjScan location=b streams=0 section_id=0 projections=()
 │             └── @max_time_range start=1970-01-01T00:00:20Z end=1970-01-01T00:01:00Z
 └
@@ -468,20 +468,20 @@ func Test_planWorkflow(t *testing.T) {
 ┌ Task 00000000000000000000000002
 │ @max_time_range start=1970-01-01T00:00:05Z end=1970-01-01T00:00:45Z
 │
-│ Cache max_cacheable_size=1.0 MiB hashed_key=502e8c56ecf762f4 key= |>>| Batching |>>| RangeAggregation{operation=count,start=1970-01-01T00:00:05Z,end=1970-01-01T00:00:45Z,step=0s,range=0s,grouping=by=[],max_series=0} |>>| DataObjScan{location=a,section=0,stream_ids=[],projections=[],predicates=[],max_time_range_start=1970-01-01T00:00:10Z,max_time_range_end=1970-01-01T00:00:50Z}
+│ Cache max_cacheable_size=1.0 MiB hashed_key=0b7ae7b5f552e5b6 key= |>>| Batching |>>| RangeAggregation{operation=count,start=1970-01-01T00:00:10Z,end=1970-01-01T00:00:45Z,step=0s,range=0s,grouping=by=[],max_series=0} |>>| DataObjScan{location=a,section=0,stream_ids=[],projections=[],predicates=[],max_time_range_start=1970-01-01T00:00:10Z,max_time_range_end=1970-01-01T00:00:50Z}
 │ │   └── @sink stream=00000000000000000000000004
 │ └── Batching batch_size=500
-│     └── RangeAggregation operation=count start=1970-01-01T00:00:05Z end=1970-01-01T00:00:45Z step=0s range=0s group_by=()
+│     └── RangeAggregation operation=count start=1970-01-01T00:00:10Z end=1970-01-01T00:00:45Z step=0s range=0s group_by=()
 │         └── DataObjScan location=a streams=0 section_id=0 projections=()
 │                 └── @max_time_range start=1970-01-01T00:00:10Z end=1970-01-01T00:00:50Z
 └
 ┌ Task 00000000000000000000000003
 │ @max_time_range start=1970-01-01T00:00:05Z end=1970-01-01T00:00:45Z
 │
-│ Cache max_cacheable_size=1.0 MiB hashed_key=9888d9ec9f19e11e key= |>>| Batching |>>| RangeAggregation{operation=count,start=1970-01-01T00:00:05Z,end=1970-01-01T00:00:45Z,step=0s,range=0s,grouping=by=[],max_series=0} |>>| DataObjScan{location=b,section=0,stream_ids=[],projections=[],predicates=[],max_time_range_start=1970-01-01T00:00:20Z,max_time_range_end=1970-01-01T00:01:00Z}
+│ Cache max_cacheable_size=1.0 MiB hashed_key=73d7a06ab8903dbb key= |>>| Batching |>>| RangeAggregation{operation=count,start=1970-01-01T00:00:20Z,end=1970-01-01T00:00:45Z,step=0s,range=0s,grouping=by=[],max_series=0} |>>| DataObjScan{location=b,section=0,stream_ids=[],projections=[],predicates=[],max_time_range_start=1970-01-01T00:00:20Z,max_time_range_end=1970-01-01T00:01:00Z}
 │ │   └── @sink stream=00000000000000000000000005
 │ └── Batching batch_size=500
-│     └── RangeAggregation operation=count start=1970-01-01T00:00:05Z end=1970-01-01T00:00:45Z step=0s range=0s group_by=()
+│     └── RangeAggregation operation=count start=1970-01-01T00:00:20Z end=1970-01-01T00:00:45Z step=0s range=0s group_by=()
 │         └── DataObjScan location=b streams=0 section_id=0 projections=()
 │                 └── @max_time_range start=1970-01-01T00:00:20Z end=1970-01-01T00:01:00Z
 └


### PR DESCRIPTION
Two new optimizers: The first one, scanTimeRangePushup, propagates the MaxTimeRange from DataObjScan and PointersScan nodes to RangeAggregation nodes. The second, clampPredicates, clamps the time range on DataObjScan and PointersScan nodes based on any BinaryExpr predicates that limit the time range.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
