### PR TITLE
chore: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,32 @@ make format                   # format code (gofmt and goimports)
 
 ## Using Tools
 - When using the `mcp__acp__Write` tool, write to a path within the current worktree to avoid sandboxing/permissions issues. This includes when writing plan files.
+
+## Cursor Cloud specific instructions
+
+### Environment overview
+- **Go 1.25.7** (auto-downloaded via toolchain directive in `go.mod`); the Makefile references Go 1.26.0 for Docker build images, but the module's `go 1.25.7` directive is what matters locally.
+- Build with `BUILD_IN_CONTAINER=false` to avoid Docker dependency. The Makefile defaults `BUILD_IN_CONTAINER=true`; override it or build directly with `go build`.
+- `golangci-lint` (v2.10.1) and `faillint` (v1.15.0) must be on `PATH` for `make lint`. They are installed to `/usr/local/bin` and `$(go env GOPATH)/bin` respectively by the update script.
+
+### Running Loki locally
+Run Loki as a single-binary monolith with zero external dependencies:
+```bash
+go build -o ./cmd/loki/loki ./cmd/loki
+./cmd/loki/loki -config.file=./cmd/loki/loki-local-config.yaml
+```
+Loki takes ~25-30 s after startup to report `ready` (ingester + pattern-ingester warm-up). Check with `curl http://localhost:3100/ready`.
+
+### Running tests
+- `go test -tags netgo ./pkg/...` runs unit tests without Docker. Add `-count=1` to disable caching.
+- `make test` builds all binaries first, then runs tests with coverage. This is slower but comprehensive.
+- Integration tests (`make test-integration`) start Loki components in-process; no Docker needed.
+
+### Lint
+- `make lint` requires `golangci-lint` and `faillint` on PATH. It runs `golangci-lint run`, then `faillint` with multiple import-path checks.
+- To lint a specific package faster: `golangci-lint run -v --timeout=15m --build-tags=linux ./pkg/some/package/...`
+
+### Gotchas
+- The `.golangci.yml` declares `version: "2"` — this requires golangci-lint v2.x, not v1.x.
+- Vendor directory is checked in; do not run `go mod vendor` unless intentionally updating dependencies.
+- The `go.mod` has an `ignore ./tools/dev` directive; that submodule is not part of the main build.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What this PR does / why we need it**:

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with development environment setup guidance for cloud agents, including Go toolchain notes, local Loki startup instructions, testing/lint shortcuts, and known gotchas.

**Which issue(s) this PR fixes**:
N/A - Development environment setup

**Special notes for your reviewer**:
This only adds documentation to AGENTS.md. No code changes.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e62c95a6-121e-4ac0-a1b2-783ad548e8c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e62c95a6-121e-4ac0-a1b2-783ad548e8c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

