### PR TITLE
chore: run lint in docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,6 +344,10 @@ LINT_FLAGS=--timeout=15m
 GOFLAGS=""
 endif
 lint: ## run linters
+ifeq ($(BUILD_IN_CONTAINER),true)
+	$(SUDO) docker pull $(BUILD_IMAGE)
+	$(SUDO) $(run_in_container) $@
+else
 	go version
 	golangci-lint version
 	golangci-lint run -v $(LINT_FLAGS)
@@ -360,6 +364,7 @@ lint: ## run linters
 	faillint -paths \
 		"github.com/opentracing/opentracing-go,github.com/opentracing/opentracing-go/log,github.com/uber/jaeger-client-go,github.com/opentracing-contrib/go-stdlib/nethttp" \
 		./...
+endif
 
 ########
 # Test #

--- a/Makefile
+++ b/Makefile
@@ -345,7 +345,6 @@ GOFLAGS=""
 endif
 lint: ## run linters
 ifeq ($(BUILD_IN_CONTAINER),true)
-	docker pull $(BUILD_IMAGE)
 	$(run_in_container)
 else
 	go version

--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ endif
 lint: ## run linters
 ifeq ($(BUILD_IN_CONTAINER),true)
 	$(SUDO) docker pull $(BUILD_IMAGE)
-	$(SUDO) $(run_in_container) $@
+	$(SUDO) $(run_in_container)
 else
 	go version
 	golangci-lint version

--- a/Makefile
+++ b/Makefile
@@ -345,8 +345,8 @@ GOFLAGS=""
 endif
 lint: ## run linters
 ifeq ($(BUILD_IN_CONTAINER),true)
-	$(SUDO) docker pull $(BUILD_IMAGE)
-	$(SUDO) $(run_in_container)
+	docker pull $(BUILD_IMAGE)
+	$(run_in_container)
 else
 	go version
 	golangci-lint version

--- a/pkg/logql/bench/k6_types.go
+++ b/pkg/logql/bench/k6_types.go
@@ -35,7 +35,7 @@ func ConvertTestCaseToK6(tc TestCase, tenantID int, length time.Duration, buffer
 	if tc.QueryDesc != "" {
 		name = fmt.Sprintf("%s - %s", tc.Source, tc.QueryDesc)
 	}
-	if kind == "log" {
+	if kind == kindLog {
 		name = fmt.Sprintf("%s [%s]", name, directionLabel(tc.Direction))
 	}
 

--- a/pkg/logql/bench/query_registry.go
+++ b/pkg/logql/bench/query_registry.go
@@ -204,12 +204,12 @@ func (r *QueryRegistry) loadFile(filePath string, suite Suite, fileName string) 
 		q.Source = fmt.Sprintf("%s/%s:%d", suite, fileName, lineNum)
 
 		// Default directions to "both" for log queries
-		if q.Directions == "" && q.Kind == "log" {
+		if q.Directions == "" && q.Kind == kindLog {
 			q.Directions = DirectionBoth
 		}
 
-		if q.Kind == "" || (q.Kind != "metric" && q.Kind != "log") {
-			q.Kind = "log"
+		if q.Kind == "" || (q.Kind != kindMetric && q.Kind != kindLog) {
+			q.Kind = kindLog
 		}
 
 		// Validate time range
@@ -325,7 +325,7 @@ func (r *QueryRegistry) ExpandQuery(def QueryDefinition, resolver VariableResolv
 	// Create test cases based on query kind and directions
 	var cases []TestCase
 
-	if def.Kind == "metric" {
+	if def.Kind == kindMetric {
 		// Metric queries only run in forward direction
 		tc := TestCase{
 			Query:     resolvedQuery,

--- a/pkg/logql/bench/testcase.go
+++ b/pkg/logql/bench/testcase.go
@@ -10,6 +10,11 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 )
 
+const (
+	kindLog    = "log"
+	kindMetric = "metric"
+)
+
 // TestCase represents a LogQL test case for benchmarking and testing
 type TestCase struct {
 	Query     string
@@ -53,9 +58,9 @@ func (c TestCase) Kind() string {
 		return "invalid"
 	}
 	if _, ok := expr.(syntax.SampleExpr); ok {
-		return "metric"
+		return kindMetric
 	}
-	return "log"
+	return kindLog
 }
 
 // Description returns a detailed description of the test case including time range


### PR DESCRIPTION
**What this PR does / why we need it**:

New linting rules in a local copy of `golangci-lint` means that a fresh checkout of loki might fail `make lint`

This PR will enable using `run_in_container` by default but can be turned off with
```
BUILD_IN_CONTAINER=false make lint
```

Also fixes some linting errors found by golangci-lint 2.10.1

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to developer tooling (`make lint`) and small refactors in LogQL bench helpers to use shared kind constants, with no runtime or API behavior changes beyond lint/benchmark metadata.
> 
> **Overview**
> `make lint` now respects `BUILD_IN_CONTAINER` and runs via `run_in_container` by default, aligning lint results across environments while still allowing opt-out.
> 
> Fixes new linter findings in LogQL benchmark code by centralizing query kind strings (`kindLog`/`kindMetric`) and replacing scattered `"log"`/`"metric"` comparisons with these constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afe63dc6ffcf9be04dd2738247b163acfb56a9ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->