### PR TITLE
feat: add headless service for pattern-ingester in Helm chart

### DIFF
--- a/production/helm/loki/templates/pattern-ingester/service-pattern-ingester-headless.yaml
+++ b/production/helm/loki/templates/pattern-ingester/service-pattern-ingester-headless.yaml
@@ -1,0 +1,24 @@
+{{- $isDistributed := eq (include "loki.deployment.isDistributed" .Subcharts.loki) "true" -}}
+{{- if and $isDistributed (gt (int .Values.patternIngester.replicas) 0) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.patternIngesterFullname" .Subcharts.loki }}-headless
+  namespace: {{ include "loki.namespace" .Subcharts.loki }}
+  labels:
+    {{- include "loki.patternIngesterLabels" .Subcharts.loki | nindent 4 }}
+  {{- with .Values.loki.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 3100
+      targetPort: http-metrics
+      protocol: TCP
+  selector:
+    {{- include "loki.patternIngesterSelectorLabels" .Subcharts.loki | nindent 4 }}
+{{- end -}}


### PR DESCRIPTION
## Summary
- Adds a headless `ClusterIP` service (`clusterIP: None`) for the pattern-ingester component in the Loki Helm chart
- Enables DNS-based peer discovery for pattern-ingester pods in distributed deployment mode
- Only created when `patternIngester.replicas > 0` and the deployment is distributed, consistent with other pattern-ingester templates

## Motivation

`ServericeMonitor` discovery for metrics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm/Kubernetes change that only adds an additional headless `Service` resource when in distributed mode with `patternIngester.replicas > 0`; main impact is on service discovery/monitoring configuration.
> 
> **Overview**
> Adds a new headless `ClusterIP` (`clusterIP: None`) `Service` for the Loki `pattern-ingester` so its pods have stable DNS/service discovery and a dedicated endpoint for `http-metrics` on port `3100`.
> 
> The resource is only rendered when Loki is deployed in *distributed* mode and `patternIngester.replicas > 0`, and it inherits the component labels plus optional chart-level annotations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0c679434db38e8a149f593df2f608a82b96a918. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->