### PR TITLE
fix(helm): make ServiceMonitor job relabeling overridable

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -8345,6 +8345,7 @@ false
     "annotations": {},
     "enabled": false,
     "interval": "15s",
+    "jobRelabelings": null,
     "labels": {},
     "metricRelabelings": [],
     "metricsInstance": {
@@ -8772,6 +8773,7 @@ The same namespace as the loki chart is installed in.
   "annotations": {},
   "enabled": false,
   "interval": "15s",
+  "jobRelabelings": null,
   "labels": {},
   "metricRelabelings": [],
   "metricsInstance": {
@@ -8813,6 +8815,15 @@ false
 			<td>ServiceMonitor scrape interval Default is 15s because included recording rules use a 1m rate, and scrape interval needs to be at least 1/4 rate interval.</td>
 			<td><pre lang="json">
 "15s"
+</pre>
+</td>
+		</tr>
+		<tr>
+			<td>monitoring.serviceMonitor.jobRelabelings</td>
+			<td>string</td>
+			<td>Custom relabeling rules for the job label applied to ServiceMonitor endpoints. By default, the chart prepends the namespace to the job label (e.g. namespace/component). This can cause issues with OpenTelemetry Collector which applies its own namespace prefix, resulting in doubled namespace (e.g. namespace/namespace/component). Set to [] to disable job relabeling entirely. Set to a custom list to override the default relabeling rules. Note: some GitOps tools or values-merging pipelines may collapse [] to null. If using deep merge from multiple values files, verify [] is preserved.</td>
+			<td><pre lang="">
+Prepends namespace to job label
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/templates/monitoring/servicemonitor.yaml
+++ b/production/helm/loki/templates/monitoring/servicemonitor.yaml
@@ -38,10 +38,16 @@ spec:
       scrapeTimeout: {{ . }}
       {{- end }}
       relabelings:
+        {{- if not (kindIs "slice" .jobRelabelings) }}
         - sourceLabels: [job]
           action: replace
           replacement: "{{ include "loki.namespace" $ }}/$1"
           targetLabel: job
+        {{- else }}
+        {{- with .jobRelabelings }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
         - action: replace
           replacement: "{{ include "loki.clusterLabel" $ }}"
           targetLabel: cluster

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -4271,6 +4271,16 @@ monitoring:
     interval: 15s
     # -- ServiceMonitor scrape timeout in Go duration format (e.g. 15s)
     scrapeTimeout: null
+    # -- Custom relabeling rules for the job label applied to ServiceMonitor endpoints.
+    # By default, the chart prepends the namespace to the job label (e.g. namespace/component).
+    # This can cause issues with OpenTelemetry Collector which applies its own namespace prefix,
+    # resulting in doubled namespace (e.g. namespace/namespace/component).
+    # Set to [] to disable job relabeling entirely.
+    # Set to a custom list to override the default relabeling rules.
+    # Note: some GitOps tools or values-merging pipelines may collapse [] to null.
+    # If using deep merge from multiple values files, verify [] is preserved.
+    # @default -- Prepends namespace to job label
+    jobRelabelings: null
     # -- ServiceMonitor relabel configs to apply to samples before scraping
     # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
     relabelings: []


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes the hardcoded `job` relabeling rule in the ServiceMonitor template
overridable via the new `monitoring.serviceMonitor.jobRelabelings` value.

When Loki is scraped via OpenTelemetry Collector, the Collector's Prometheus
receiver reconstructs the `job` label as `service.namespace/service.name`.
Since the chart already prepends the namespace, this results in doubled
values like `loki/loki/write`.

The new field supports three states:
- `null` (default): existing behavior — `namespace/component`
- `[]`: disable job relabeling entirely
- `[{...}]`: custom relabeling rules

**Which issue(s) this PR fixes**:
Fixes #21110

**Special notes for your reviewer**:
- Backwards compatible: default behavior (`null`) is identical to before
- Only the main ServiceMonitor is changed; `pod-logs.yaml` has a similar
  pattern but is under the deprecated `selfMonitoring` section
- Verified with `helm template` for all three states
- No upgrade docs needed: default behavior is unchanged; the new field
  only takes effect when explicitly set

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Documentation added
- [x] Title matches the required conventional commits format

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Helm template change is backward-compatible by default and only affects ServiceMonitor relabeling when `monitoring.serviceMonitor.jobRelabelings` is explicitly set; main risk is misconfiguration producing invalid relabeling YAML.
> 
> **Overview**
> Makes the ServiceMonitor’s `job` relabeling configurable via a new `monitoring.serviceMonitor.jobRelabelings` Helm value.
> 
> Default behavior remains the same when the value is `null`, but users can now set it to `[]` to disable the chart’s namespace-prefixing `job` relabeling or provide a custom list to fully override the `job` relabeling rules. Documentation and `values.yaml` are updated to describe the new option and its merge semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0244539438465cdfba1fcac34296fb2ff8d685a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->