### PR TITLE
fix(ruler): Fix data race on lastUpdateTime in WAL registry appender

### DIFF
--- a/pkg/ruler/registry.go
+++ b/pkg/ruler/registry.go
@@ -35,8 +35,11 @@ type walRegistry struct {
 	logger  log.Logger
 	manager instance.Manager
 
-	metrics     *storageRegistryMetrics
-	overridesMu sync.Mutex
+	metrics *storageRegistryMetrics
+
+	// mu guards config, overrides, and lastUpdateTime.
+	// Don't hold across configureTenantStorage — it re-enters via getTenantConfig.
+	mu sync.Mutex
 
 	config         Config
 	overrides      RulesLimits
@@ -131,10 +134,10 @@ func (r *walRegistry) get(tenant string) storage.Storage {
 
 func (r *walRegistry) Appender(ctx context.Context) storage.Appender {
 	// concurrency-safe retrieval of remote-write config for this tenant, using the global remote-write for defaults
-	r.overridesMu.Lock()
+	r.mu.Lock()
 	tenant, _ := user.ExtractOrgID(ctx)
 	rwCfg, err := r.getTenantRemoteWriteConfig(tenant, r.config.RemoteWrite)
-	r.overridesMu.Unlock()
+	r.mu.Unlock()
 
 	if err != nil {
 		level.Error(r.logger).Log("msg", "error retrieving remote-write config; discarding samples", "user", tenant, "err", err)
@@ -154,12 +157,12 @@ func (r *walRegistry) Appender(ctx context.Context) storage.Appender {
 	// we should reconfigure the storage whenever this appender is requested, but since
 	// this can request an appender very often, we hide this behind a gate
 	now := time.Now()
-	r.overridesMu.Lock()
+	r.mu.Lock()
 	shouldUpdate := r.lastUpdateTime.Before(now.Add(-r.config.RemoteWrite.ConfigRefreshPeriod))
 	if shouldUpdate {
 		r.lastUpdateTime = now
 	}
-	r.overridesMu.Unlock()
+	r.mu.Unlock()
 
 	if shouldUpdate {
 		level.Debug(r.logger).Log("user", tenant, "msg", "refreshing remote-write configuration")
@@ -190,8 +193,8 @@ func (r *walRegistry) stop() {
 }
 
 func (r *walRegistry) getTenantConfig(tenant string) (instance.Config, error) {
-	r.overridesMu.Lock()
-	defer r.overridesMu.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	conf, err := r.config.WAL.Clone()
 	if err != nil {

--- a/pkg/ruler/registry.go
+++ b/pkg/ruler/registry.go
@@ -154,9 +154,14 @@ func (r *walRegistry) Appender(ctx context.Context) storage.Appender {
 	// we should reconfigure the storage whenever this appender is requested, but since
 	// this can request an appender very often, we hide this behind a gate
 	now := time.Now()
-	if r.lastUpdateTime.Before(now.Add(-r.config.RemoteWrite.ConfigRefreshPeriod)) {
+	r.overridesMu.Lock()
+	shouldUpdate := r.lastUpdateTime.Before(now.Add(-r.config.RemoteWrite.ConfigRefreshPeriod))
+	if shouldUpdate {
 		r.lastUpdateTime = now
+	}
+	r.overridesMu.Unlock()
 
+	if shouldUpdate {
 		level.Debug(r.logger).Log("user", tenant, "msg", "refreshing remote-write configuration")
 		r.configureTenantStorage(tenant)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a data race on `walRegistry.lastUpdateTime` in `pkg/ruler/registry.go`.
The time-gate controlling remote-write config refresh reads and writes
`lastUpdateTime` without holding `overridesMu`. Under concurrent `Appender()`
calls, multiple goroutines can pass the staleness check simultaneously,
causing redundant `configureTenantStorage` calls.

The fix protects the check-and-set under the existing mutex while keeping
`configureTenantStorage` outside the lock to avoid deadlock with
`getTenantConfig`.

**Special notes for your reviewer**:
- `r.config.RemoteWrite.ConfigRefreshPeriod` is also read outside the lock,
  but `r.config` is set once at construction and never mutated, so this is safe
- All `pkg/ruler/...` tests pass with `-race`
- Single file, 6 lines added, 1 removed

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide
- [x] Title matches the required conventional commits format

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized locking change that only affects how often remote-write configuration is refreshed under concurrent `Appender()` calls.
> 
> **Overview**
> Prevents concurrent `Appender()` calls from racing on `walRegistry.lastUpdateTime` by moving the staleness check and timestamp update under `overridesMu` and computing a `shouldUpdate` flag.
> 
> Keeps `configureTenantStorage()` execution outside the lock while still ensuring only one refresh is triggered per `ConfigRefreshPeriod` window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a3832bdbd46fa822396af09c7f4bb79efa33188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->