### PR TITLE
backport(k300): fix(index-builder): don't repeatedly build indexes for stale partitions (#21213)

### DIFF
--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -440,6 +440,11 @@ func (p *Builder) flushPartition(ctx context.Context, partition int32) {
 			}
 			level.Error(p.logger).Log("msg", "failed to commit flush records", "partition", partition, "err", err)
 		}
+
+		// Reset metrics for stale partition so we don't leave it high indefinitely if the partition stays inactive
+		p.metrics.setProcessingDelay(partition, time.Now())
+
+		p.markEventsCompleted(partition, len(records))
 	}()
 }
 

--- a/pkg/dataobj/index/builder_test.go
+++ b/pkg/dataobj/index/builder_test.go
@@ -231,6 +231,75 @@ func TestIndexBuilder(t *testing.T) {
 	require.Equal(t, 30, len(indexes))
 }
 
+func TestIndexBuilder_stalePartition(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	// Setup test dependencies
+	bucket := objstore.NewInMemBucket()
+
+	cluster, configString := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, 1, "loki.metastore-events")
+	defer cluster.Close()
+
+	client, err := kgo.NewClient(kgo.ConsumerGroup("test-consumer-group"), kgo.ConsumeTopics("loki.metastore-events"), kgo.SeedBrokers(configString))
+	require.NoError(t, err)
+
+	p, err := NewIndexBuilder(
+		Config{
+			BuilderBaseConfig: testBuilderConfig,
+			EventsPerIndex:    16,
+			FlushInterval:     time.Millisecond, // Flush stale partitions very often
+			MaxIdleTime:       0,                // Consider all partitions stale
+		},
+		metastore.Config{},
+		kafka.Config{},
+		log.NewNopLogger(),
+		"instance-id",
+		bucket,
+		nil,
+		prometheus.NewRegistry(),
+	)
+	require.NoError(t, err)
+	p.client.Close()
+	p.client = client
+	require.NoError(t, p.StartAsync(ctx))
+	require.NoError(t, p.AwaitRunning(ctx))
+
+	// Assign some partitions to the builder.
+	p.handlePartitionsAssigned(ctx, nil, map[string][]int32{
+		"loki.metastore-events": {0},
+	})
+
+	buildLogObject(t, "loki", "test-path-0", bucket)
+	buildLogObject(t, "testing", "test-path-1", bucket)
+	buildLogObject(t, "three", "test-path-2", bucket)
+
+	for i := 0; i < 3; i++ {
+		event := metastore.ObjectWrittenEvent{
+			ObjectPath: fmt.Sprintf("test-path-%d", i),
+			WriteTime:  time.Now().Format(time.RFC3339),
+		}
+		eventBytes, err := event.Marshal()
+		require.NoError(t, err)
+
+		p.processRecord(context.Background(), &kgo.Record{
+			Value:     eventBytes,
+			Partition: int32(0),
+		})
+	}
+
+	// Wait for stale partition to be flushed
+	for i := 0; i < 100; i++ {
+		if len(readAllSectionPointers(t, bucket)) == 30 && len(p.partitionStates[0].events) == 0 {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	require.Equal(t, 30, len(readAllSectionPointers(t, bucket)))
+	require.Equal(t, 0, len(p.partitionStates[0].events)) // Events should be gone now they've been processed
+}
+
 func readAllSectionPointers(t *testing.T, bucket objstore.Bucket) []pointers.SectionPointer {
 	var out []pointers.SectionPointer
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR backports https://github.com/grafana/loki/pull/21213 into `k300`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior change is limited to resetting a partition processing-delay metric after a stale-partition flush, plus a new test to cover stale flushing behavior.
> 
> **Overview**
> Prevents the `index-builder` from leaving the per-partition processing delay metric artificially high after flushing an idle/stale partition by resetting `processingDelay` to `time.Now()` after a successful flush commit.
> 
> Adds `TestIndexBuilder_stalePartition` to ensure stale-partition flushing processes buffered events and clears the partition’s event queue even when `EventsPerIndex` isn’t reached.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d41ad68d765c569f6de6107bf98359bb686d9944. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->