### PR TITLE
docs: backport canary updates 3.6

### DIFF
--- a/docs/sources/operations/loki-canary/_index.md
+++ b/docs/sources/operations/loki-canary/_index.md
@@ -323,8 +323,6 @@ All options:
     	Duration between log entries (default 1s)
   -key-file string
     	Client PEM encoded X.509 key for optional use with TLS connection to Loki
-  -labels string
-        Comma-separated string of labels for the query e.g. 'service=loki,app=canary'. The parsing logic for this argument is simple, label values must not contain a comma or special characters and should not be quoted. Overwrites labelname and streamname
   -labelname string
     	The label name for this instance of loki-canary to use in the log selector (default "name")
   -labelvalue string
@@ -349,8 +347,6 @@ All options:
     	Frequency to check sent vs received logs, also the frequency which queries for missing logs will be dispatched to loki (default 1m0s)
   -push
     	Push the logs directly to given Loki address
-  -query-append string
-        LogQL filters to be appended to the Canary query e.g. '| json | line_format `{{.log}}`'  	
   -query-timeout duration
     	How long to wait for a query response from Loki (default 10s)
   -size int


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of https://github.com/grafana/loki/pull/21218 to the 3.6 branch.

**Special notes for your reviewer**:

<strike>The 3.6 branch shows a couple of additional changes (lines 326 and 352).  I checked the history and 3.6 released Nov. 17, but those two news config options were introduced in https://github.com/grafana/loki/pull/17008 on Dec 30.  Not sure if I should pull them out or not if they're not in the 3.6 branch until 3.6.4?</strike>  [REMOVED]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes, primarily clarifying deployment and scraping configuration without modifying runtime behavior.
> 
> **Overview**
> Updates the Loki Canary operations doc to reflect that the canary **writes logs to standard output** (requiring capture to a file) and replaces older Promtail/pipeline guidance with **Grafana Alloy** references (including `loki.process`).
> 
> Refreshes the Docker pull example to a newer image tag and adds a new **monolithic mode setup** walkthrough with systemd output redirection plus Alloy/Prometheus snippets for scraping logs and metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 561dcff1ddbdb58bcc78645162bf497323f73ade. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->