### PR TITLE
docs: Small Helm Charts updates

### DIFF
--- a/docs/sources/release-notes/v3-7.md
+++ b/docs/sources/release-notes/v3-7.md
@@ -18,7 +18,7 @@ See the [deprecations](https://grafana.com/docs/loki/latest/release-notes/v3-7/#
 
 Key features in Loki 3.7.0 include the following:
 
-* **Helm charts:** - Effective March 16, 2026, the Grafana Loki Helm chart has been be forked to the new repository [grafana-community/helm-charts](https://github.com/grafana-community/helm-charts). The motivation behind this change is to accelerate development and enable direct community maintenance, as outlined in [grafana/helm-charts#3955](https://github.com/grafana/helm-charts/issues/3955). The Grafana Community now owns maintenance of the Loki Helm Chart, while Grafana Labs continues to maintain the Helm Chart for Grafana Enterprise Logs (GEL).
+* **Helm charts:** - Effective March 16, 2026, the Grafana Loki Helm chart has been be forked to the new repository [grafana-community/helm-charts](https://github.com/grafana-community/helm-charts). The motivation behind this change is to accelerate development and enable direct community maintenance, as outlined in [grafana/helm-charts#3955](https://github.com/grafana/helm-charts/issues/3955). The Grafana Community now owns maintenance of the Loki Helm Chart, while Grafana Labs continues to maintain the Helm Chart for Grafana Enterprise Logs (GEL). The Loki Helm Charts documentation has been updated to point to the new [Grafana-Community repo](https://github.com/grafana/loki/pull/21330).
 
 * **Docs:** The documentation now includes a new, comprehensive [Troubleshooting](https://grafana.com/docs/loki/latest/operations/troubleshooting/) section, documenting the Loki and Logs Drilldown error messages.
 

--- a/docs/sources/setup/install/helm/_index.md
+++ b/docs/sources/setup/install/helm/_index.md
@@ -46,4 +46,4 @@ The following guides provide step-by-step instructions for deploying Loki on clo
 
 ## Reference
 
-[Values reference](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/reference/)
+You can find reference documentation for the Loki Helm chart in the [values.yaml file](https://github.com/grafana-community/helm-charts/blob/main/charts/loki/values.yaml).

--- a/docs/sources/setup/install/helm/install-microservices/_index.md
+++ b/docs/sources/setup/install/helm/install-microservices/_index.md
@@ -10,6 +10,10 @@ keywords:
 
 This Helm Chart deploys Grafana Loki on Kubernetes.
 
+{{< admonition type="note" >}}
+As of March 16, 2026, the Loki Helm Chart is being maintained by Grafana Champions andthe Grafana Community in the [Grafana-community/helm-charts repository](https://github.com/grafana-community/helm-charts). Please open issues and pull requests for the chart against the Grafana-commmunity repo.
+{{< /admonition >}}
+
 This Helm chart deploys Loki to run Loki in [microservice mode](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/deployment-modes/#microservices-mode) within a Kubernetes cluster. The microservices deployment is also referred to as a Distributed deployment. The microservices deployment mode runs components of Loki as distinct processes.
 
 The default Helm chart deploys the following components:

--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -12,6 +12,10 @@ weight: 100
 
 This Helm Chart installation deploys Grafana Loki in [monolithic mode](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/deployment-modes/#monolithic-mode) within a Kubernetes cluster.
 
+{{< admonition type="note" >}}
+As of March 16, 2026, the Loki Helm Chart is being maintained by Grafana Champions andthe Grafana Community in the [Grafana-community/helm-charts repository](https://github.com/grafana-community/helm-charts). Please open issues and pull requests for the chart against the Grafana-commmunity repo.
+{{< /admonition >}}
+
 ## Prerequisites
 
 - Helm 3 or above. See [Installing Helm](https://helm.sh/docs/intro/install/).

--- a/docs/sources/setup/install/helm/install-scalable/_index.md
+++ b/docs/sources/setup/install/helm/install-scalable/_index.md
@@ -11,11 +11,11 @@ keywords:
 
 # Install the simple scalable Helm chart
 
-{{< admonition type="note" >}}
-Simple Scalable Deployment (SSD) mode is being deprecated. The timeline for the deprecation is to be determined (TBD), but will happen before Loki 4.0 is released.
-{{< /admonition >}}
-
 This Helm Chart deploys Grafana Loki in [simple scalable mode](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/deployment-modes/#simple-scalable) within a Kubernetes cluster.
+
+{{< admonition type="note" >}}
+As of March 16, 2026, the Loki Helm Chart is being maintained by Grafana Champions andthe Grafana Community in the [Grafana-community/helm-charts repository](https://github.com/grafana-community/helm-charts). Please open issues and pull requests for the chart against the Grafana-commmunity repo. Simple Scalable Deployment (SSD) mode is being deprecated. The timeline for the deprecation is to be determined (TBD), but will happen before Loki 4.0 is released.
+{{< /admonition >}}
 
 This chart configures Loki to run `read`, `write`, and `backend` targets in a [scalable mode](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/deployment-modes/#simple-scalable). Loki’s simple scalable deployment mode separates execution paths into read, write, and backend targets.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Release Notes
Updates the Helm install landing page to point to values.yaml file, since we removed the Reference topic
Adds a note to the Helm installation topics to direct users to the Community repo for issues/PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only edits that primarily change external links and add informational notes, with no product/runtime behavior changes.
> 
> **Overview**
> **Helm chart docs are updated to reflect the March 16, 2026 fork/maintenance change to `grafana-community/helm-charts`.** The v3.7 release notes now explicitly call out that the Helm docs have been updated to point to the new community repo.
> 
> The Helm install landing page replaces the removed in-docs “Values reference” link with a direct link to the chart’s `values.yaml` in the community repository, and the monolithic/microservices/scalable Helm install pages add a note directing users to file chart issues/PRs in the community repo (with the scalable page also repositioning the SSD deprecation messaging).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 875c6bb285250df466065d31c4e2b703f4b6747a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->