### PR TITLE
feat(query engine): Add workflow optimizer to push up time ranges from scan nodes to RangeAggregations.

### DIFF
--- a/pkg/engine/internal/planner/physical/optimizer.go
+++ b/pkg/engine/internal/planner/physical/optimizer.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"slices"
 	"sort"
+	"time"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
@@ -153,6 +154,91 @@ func (r *limitPushdown) applyToTargets(node Node, limit uint32) bool {
 	// Continue to children
 	for _, child := range r.plan.Children(node) {
 		if r.applyToTargets(child, limit) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+var _ rule = (*scanTimeRangePushup)(nil)
+
+// scanTimeRangePushup is a rule that moves the max time range from scan nodes up to RangeAggregations.
+type scanTimeRangePushup struct {
+	plan *Plan
+}
+
+// apply implements rule.
+func (r *scanTimeRangePushup) apply(root Node) bool {
+	// collect scan nodes.
+	nodes := findMatchingNodes(r.plan, root, func(node Node) bool {
+		switch node.Type() {
+		case NodeTypeDataObjScan:
+			return true
+		case NodeTypePointersScan:
+			return true
+		}
+		return false
+	})
+
+	// propagate time range to target parent nodes.
+	changed := false
+	for _, n := range nodes {
+		dataObjScan, ok := n.(*DataObjScan)
+		if ok {
+			applied := r.applyToTargets(dataObjScan, dataObjScan.MaxTimeRange)
+			if applied {
+				changed = true
+			}
+		} else {
+			pointersScan, ok := n.(*PointersScan)
+			if ok {
+				applied := r.applyToTargets(pointersScan, pointersScan.MaxTimeRange())
+				if applied {
+					changed = true
+				}
+			}
+		}
+	}
+	return changed
+}
+
+// applyToTargets applies max time range on target nodes.
+func (r *scanTimeRangePushup) applyToTargets(node Node, timeRange TimeRange) bool {
+	var changed bool
+	switch node := node.(type) {
+	case *RangeAggregation:
+		if node.Step == 0 {
+			if node.Start.Compare(timeRange.Start) < 0 {
+				node.Start = timeRange.Start
+				changed = true
+			}
+			if node.End.Compare(timeRange.End) > 0 {
+				node.End = timeRange.End
+				changed = true
+			}
+		} else {
+			trSteppedStart := time.UnixMilli((timeRange.Start.UnixMilli() / node.Step.Milliseconds()) * node.Step.Milliseconds()).UTC()
+			for trSteppedStart.Compare(timeRange.Start) < 0 { // should only happen at most once, but just in case
+				trSteppedStart = trSteppedStart.Add(node.Step)
+			}
+			trSteppedEnd := time.UnixMilli((timeRange.End.UnixMilli() / node.Step.Milliseconds()) * node.Step.Milliseconds()).UTC()
+			for trSteppedEnd.Compare(timeRange.End) > 0 {
+				trSteppedEnd = trSteppedEnd.Add(-node.Step)
+			}
+			if node.Start.Compare(trSteppedStart) < 0 {
+				node.Start = trSteppedStart
+				changed = true
+			}
+			if node.End.Compare(trSteppedEnd) > 0 {
+				node.End = trSteppedEnd
+				changed = true
+			}
+		}
+	}
+
+	// Continue to parents
+	for _, parent := range r.plan.Parent(node) {
+		if r.applyToTargets(parent, timeRange) {
 			changed = true
 		}
 	}
@@ -699,26 +785,34 @@ func canShardAggregation(vec *VectorAggregation, rng *RangeAggregation) bool {
 	return false
 }
 
-// optimization represents a single optimization pass and can hold multiple rules.
-type optimization struct {
+func WorkflowOptimizations(plan *Plan) []*Optimization {
+	return []*Optimization{
+		newOptimization("ScanTimeRangePushup", plan).withRules(
+			&scanTimeRangePushup{plan: plan}),
+	}
+
+}
+
+// Optimization represents a single Optimization pass and can hold multiple rules.
+type Optimization struct {
 	plan  *Plan
 	name  string
 	rules []rule
 }
 
-func newOptimization(name string, plan *Plan) *optimization {
-	return &optimization{
+func newOptimization(name string, plan *Plan) *Optimization {
+	return &Optimization{
 		name: name,
 		plan: plan,
 	}
 }
 
-func (o *optimization) withRules(rules ...rule) *optimization {
+func (o *Optimization) withRules(rules ...rule) *Optimization {
 	o.rules = append(o.rules, rules...)
 	return o
 }
 
-func (o *optimization) optimize(node Node) {
+func (o *Optimization) optimize(node Node) {
 	iterations, maxIterations := 0, 10
 
 	for iterations < maxIterations {
@@ -731,7 +825,7 @@ func (o *optimization) optimize(node Node) {
 	}
 }
 
-func (o *optimization) applyRules(node Node) bool {
+func (o *Optimization) applyRules(node Node) bool {
 	anyChanged := false
 
 	for _, rule := range o.rules {
@@ -746,10 +840,10 @@ func (o *optimization) applyRules(node Node) bool {
 // The optimizer can optimize physical plans using the provided optimization passes.
 type optimizer struct {
 	plan          *Plan
-	optimisations []*optimization
+	optimisations []*Optimization
 }
 
-func newOptimizer(plan *Plan, passes []*optimization) *optimizer {
+func NewOptimizer(plan *Plan, passes []*Optimization) *optimizer {
 	return &optimizer{plan: plan, optimisations: passes}
 }
 

--- a/pkg/engine/internal/planner/physical/optimizer_test.go
+++ b/pkg/engine/internal/planner/physical/optimizer_test.go
@@ -107,13 +107,13 @@ func dummyPlan() *Plan {
 
 func TestPredicatePushdown(t *testing.T) {
 	plan := dummyPlan()
-	optimizations := []*optimization{
+	optimizations := []*Optimization{
 		newOptimization("predicate pushdown", plan).withRules(
 			&predicatePushdown{plan},
 		),
 	}
 
-	o := newOptimizer(plan, optimizations)
+	o := NewOptimizer(plan, optimizations)
 	o.optimize(plan.Roots()[0])
 	actual := PrintAsTree(plan)
 
@@ -170,12 +170,12 @@ func TestLimitPushdown(t *testing.T) {
 		}
 
 		// apply optimisations
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("limit pushdown", plan).withRules(
 				&limitPushdown{plan: plan},
 			),
 		}
-		o := newOptimizer(plan, optimizations)
+		o := NewOptimizer(plan, optimizations)
 		o.optimize(plan.Roots()[0])
 
 		expectedPlan := &Plan{}
@@ -233,16 +233,127 @@ func TestLimitPushdown(t *testing.T) {
 		orig := PrintAsTree(plan)
 
 		// apply optimisations
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("limit pushdown", plan).withRules(
 				&limitPushdown{plan: plan},
 			),
 		}
-		o := newOptimizer(plan, optimizations)
+		o := NewOptimizer(plan, optimizations)
 		o.optimize(plan.Roots()[0])
 
 		actual := PrintAsTree(plan)
 		require.Equal(t, orig, actual)
+	})
+}
+
+func TestScanTimeRangePushup(t *testing.T) {
+	t.Run("pushup time range to RangeAggregation with zero step", func(t *testing.T) {
+		plan := &Plan{}
+		{
+			dataObjScan := plan.graph.Add(&DataObjScan{MaxTimeRange: TimeRange{Start: time.Date(2026, 3, 14, 16, 45, 29, 0, time.UTC),
+				End: time.Date(2026, 3, 14, 16, 46, 31, 0, time.UTC)}})
+			rangeAgg := plan.graph.Add(&RangeAggregation{
+				Start: time.Date(2026, 3, 14, 16, 43, 30, 0, time.UTC),
+				End:   time.Date(2026, 3, 14, 16, 53, 30, 0, time.UTC),
+				Step:  0, Range: time.Minute})
+			_ = plan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: dataObjScan})
+		}
+
+		// apply optimisations
+		optimizations := []*Optimization{
+			newOptimization("scan time range pushup", plan).withRules(
+				&scanTimeRangePushup{plan: plan},
+			),
+		}
+		o := NewOptimizer(plan, optimizations)
+		o.Optimize(plan.Roots()[0])
+
+		expectedPlan := &Plan{}
+		{
+			dataObjScan := expectedPlan.graph.Add(&DataObjScan{MaxTimeRange: TimeRange{Start: time.Date(2026, 3, 14, 16, 45, 29, 0, time.UTC),
+				End: time.Date(2026, 3, 14, 16, 46, 31, 0, time.UTC)}})
+			rangeAgg := expectedPlan.graph.Add(&RangeAggregation{
+				Start: time.Date(2026, 3, 14, 16, 45, 29, 0, time.UTC),
+				End:   time.Date(2026, 3, 14, 16, 46, 31, 0, time.UTC),
+				Step:  0, Range: time.Minute})
+			_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: dataObjScan})
+		}
+
+		actual := PrintAsTree(plan)
+		expected := PrintAsTree(expectedPlan)
+		require.Equal(t, expected, actual)
+	})
+	t.Run("non-zero step rounds scan time range in RangeAggregation", func(t *testing.T) {
+		plan := &Plan{}
+		{
+			dataObjScan := plan.graph.Add(&DataObjScan{MaxTimeRange: TimeRange{Start: time.Date(2026, 3, 14, 16, 44, 29, 0, time.UTC),
+				End: time.Date(2026, 3, 14, 16, 46, 31, 0, time.UTC)}})
+			rangeAgg := plan.graph.Add(&RangeAggregation{
+				Start: time.Date(2026, 3, 14, 16, 43, 30, 0, time.UTC),
+				End:   time.Date(2026, 3, 14, 16, 53, 30, 0, time.UTC),
+				Step:  time.Minute, Range: time.Minute})
+			_ = plan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: dataObjScan})
+		}
+
+		// apply optimisations
+		optimizations := []*Optimization{
+			newOptimization("scan time range pushup", plan).withRules(
+				&scanTimeRangePushup{plan: plan},
+			),
+		}
+		o := NewOptimizer(plan, optimizations)
+		o.Optimize(plan.Roots()[0])
+
+		expectedPlan := &Plan{}
+		{
+			dataObjScan := expectedPlan.graph.Add(&DataObjScan{MaxTimeRange: TimeRange{Start: time.Date(2026, 3, 14, 16, 44, 29, 0, time.UTC),
+				End: time.Date(2026, 3, 14, 16, 46, 31, 0, time.UTC)}})
+			rangeAgg := expectedPlan.graph.Add(&RangeAggregation{
+				Start: time.Date(2026, 3, 14, 16, 45, 0, 0, time.UTC),
+				End:   time.Date(2026, 3, 14, 16, 46, 0, 0, time.UTC),
+				Step:  time.Minute, Range: time.Minute})
+			_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: dataObjScan})
+		}
+
+		actual := PrintAsTree(plan)
+		expected := PrintAsTree(expectedPlan)
+		require.Equal(t, expected, actual)
+	})
+	t.Run("unusual step still rounds scan time range in RangeAggregation", func(t *testing.T) {
+		plan := &Plan{}
+		{
+			dataObjScan := plan.graph.Add(&DataObjScan{MaxTimeRange: TimeRange{Start: time.Date(2026, 3, 20, 17, 53, 41, 0, time.UTC),
+				End: time.Date(2026, 3, 20, 17, 54, 49, 0, time.UTC)}})
+			rangeAgg := plan.graph.Add(&RangeAggregation{
+				Start: time.Date(2026, 3, 20, 16, 43, 30, 0, time.UTC),
+				End:   time.Date(2026, 3, 20, 18, 53, 30, 0, time.UTC),
+				Step:  63 * time.Second, Range: time.Minute})
+			_ = plan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: dataObjScan})
+		}
+
+		// apply optimisations
+		optimizations := []*Optimization{
+			newOptimization("scan time range pushup", plan).withRules(
+				&scanTimeRangePushup{plan: plan},
+			),
+		}
+		o := NewOptimizer(plan, optimizations)
+		o.Optimize(plan.Roots()[0])
+
+		expectedPlan := &Plan{}
+		{
+			dataObjScan := expectedPlan.graph.Add(&DataObjScan{MaxTimeRange: TimeRange{Start: time.Date(2026, 3, 20, 17, 53, 41, 0, time.UTC),
+				End: time.Date(2026, 3, 20, 17, 54, 49, 0, time.UTC)}})
+			rangeAgg := expectedPlan.graph.Add(&RangeAggregation{
+				Start: time.Date(2026, 3, 20, 17, 53, 42, 0, time.UTC),
+				End:   time.Date(2026, 3, 20, 17, 54, 45, 0, time.UTC),
+				Step:  63 * time.Second, Range: time.Minute})
+			_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: dataObjScan})
+		}
+
+		actual := PrintAsTree(plan)
+		expected := PrintAsTree(expectedPlan)
+		require.Equal(t, expected, actual)
 	})
 }
 
@@ -280,12 +391,12 @@ func TestGroupByPushdown(t *testing.T) {
 		}
 
 		// apply optimisation
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("groupBy pushdown", plan).withRules(
 				&groupByPushdown{plan: plan},
 			),
 		}
-		o := newOptimizer(plan, optimizations)
+		o := NewOptimizer(plan, optimizations)
 		o.optimize(plan.Roots()[0])
 
 		expectedPlan := &Plan{}
@@ -348,12 +459,12 @@ func TestGroupByPushdown(t *testing.T) {
 		orig := PrintAsTree(plan)
 
 		// apply optimisation
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("projection pushdown", plan).withRules(
 				&groupByPushdown{plan: plan},
 			),
 		}
-		o := newOptimizer(plan, optimizations)
+		o := NewOptimizer(plan, optimizations)
 		o.optimize(plan.Roots()[0])
 
 		actual := PrintAsTree(plan)
@@ -388,12 +499,12 @@ func TestProjectionPushdown(t *testing.T) {
 		}
 
 		// apply optimisations
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("projection pushdown", plan).withRules(
 				&projectionPushdown{plan: plan},
 			),
 		}
-		o := newOptimizer(plan, optimizations)
+		o := NewOptimizer(plan, optimizations)
 		o.optimize(plan.Roots()[0])
 
 		expectedPlan := &Plan{}
@@ -457,12 +568,12 @@ func TestProjectionPushdown(t *testing.T) {
 		}
 
 		// apply optimisations
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("projection pushdown", plan).withRules(
 				&projectionPushdown{plan: plan},
 			),
 		}
-		o := newOptimizer(plan, optimizations)
+		o := NewOptimizer(plan, optimizations)
 		o.optimize(plan.Roots()[0])
 
 		expectedPlan := &Plan{}
@@ -528,12 +639,12 @@ func TestProjectionPushdown(t *testing.T) {
 		}
 
 		// apply optimisations
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("projection pushdown", plan).withRules(
 				&projectionPushdown{plan: plan},
 			),
 		}
-		o := newOptimizer(plan, optimizations)
+		o := NewOptimizer(plan, optimizations)
 		o.optimize(plan.Roots()[0])
 
 		expectedPlan := &Plan{}
@@ -876,13 +987,13 @@ func TestProjectionPushdown_PushesRequestedKeysToParseOperations(t *testing.T) {
 
 func TestRemoveNoopFilter(t *testing.T) {
 	plan := dummyPlan()
-	optimizations := []*optimization{
+	optimizations := []*Optimization{
 		newOptimization("noop filter", plan).withRules(
 			&removeNoopFilter{plan},
 		),
 	}
 
-	o := newOptimizer(plan, optimizations)
+	o := NewOptimizer(plan, optimizations)
 	o.optimize(plan.Roots()[0])
 	actual := PrintAsTree(plan)
 
@@ -982,7 +1093,7 @@ func Test_parallelPushdown(t *testing.T) {
 			require.NoError(t, plan.graph.AddEdge(dag.Edge[Node]{Parent: parallelize, Child: scan}))
 		}
 
-		opt := newOptimizer(&plan, []*optimization{
+		opt := NewOptimizer(&plan, []*Optimization{
 			newOptimization("ParallelPushdown", &plan).withRules(&parallelPushdown{plan: &plan}),
 		})
 		root, _ := plan.graph.Root()
@@ -1019,7 +1130,7 @@ func Test_parallelPushdown(t *testing.T) {
 			require.NoError(t, plan.graph.AddEdge(dag.Edge[Node]{Parent: parallelize, Child: scan}))
 		}
 
-		opt := newOptimizer(&plan, []*optimization{
+		opt := NewOptimizer(&plan, []*Optimization{
 			newOptimization("ParallelPushdown", &plan).withRules(&parallelPushdown{plan: &plan}),
 		})
 		root, _ := plan.graph.Root()
@@ -1070,7 +1181,7 @@ func Test_parallelPushdown(t *testing.T) {
 			require.NoError(t, plan.graph.AddEdge(dag.Edge[Node]{Parent: parallelize, Child: scan}))
 		}
 
-		opt := newOptimizer(&plan, []*optimization{
+		opt := NewOptimizer(&plan, []*Optimization{
 			newOptimization("ParallelPushdown", &plan).withRules(&parallelPushdown{plan: &plan}),
 		})
 		root, _ := plan.graph.Root()

--- a/pkg/engine/internal/planner/physical/planner.go
+++ b/pkg/engine/internal/planner/physical/planner.go
@@ -751,7 +751,7 @@ func disambiguateExpression(expr Expression, conflictingLabels []string) (Expres
 // if any optimizations can be applied.
 func (p *Planner) Optimize(plan *Plan) (*Plan, error) {
 	for i, root := range plan.Roots() {
-		optimizations := []*optimization{
+		optimizations := []*Optimization{
 			newOptimization("PredicatePushdown", plan).withRules(
 				&predicatePushdown{plan: plan},
 			),
@@ -773,7 +773,7 @@ func (p *Planner) Optimize(plan *Plan) (*Plan, error) {
 				&removeNoopFilter{plan: plan},
 			),
 		}
-		optimizer := newOptimizer(plan, optimizations)
+		optimizer := NewOptimizer(plan, optimizations)
 		optimizer.optimize(root)
 		if i == 1 {
 			return nil, errors.New("physical plan must only have exactly one root node")

--- a/pkg/engine/internal/util/dag/dag.go
+++ b/pkg/engine/internal/util/dag/dag.go
@@ -254,10 +254,14 @@ func (g *Graph[NodeType]) Clone() *Graph[NodeType] {
 	for node, children := range g.children {
 		newChildren[node] = slices.Clone(children)
 	}
+	newParents := make(map[NodeType][]NodeType, len(g.parents))
+	for node, parents := range g.parents {
+		newParents[node] = slices.Clone(parents)
+	}
 
 	return &Graph[NodeType]{
 		nodes:    maps.Clone(g.nodes),
-		parents:  maps.Clone(g.parents),
+		parents:  newParents,
 		children: newChildren,
 	}
 }

--- a/pkg/engine/internal/workflow/workflow_planner.go
+++ b/pkg/engine/internal/workflow/workflow_planner.go
@@ -383,6 +383,14 @@ func (p *planner) processParallelizeNode(node *physical.Parallelize) ([]*Task, e
 		shardedPlan := templateTask.Fragment.Graph().Clone()
 		shardedPlan.Inject(shardableNode, shard)
 		shardedPlan.Eliminate(shardableNode)
+		// Without this next step, nodes other than the shardable node are reused between tasks.
+		// This causes an issue with time range clamping, where the clamped time range could
+		// accidentally be copied between tasks.
+		// For example, if we have a RangeAggregation with a Parallelize child, and the Parallelize
+		// has a child ScanSet with multiple ScanTargets, we will end up with one task per ScanTarget.
+		// If the ScanTarget includes a predicate that clamps the time range, we need to make sure
+		// only the RangeAggregation for that specific ScanTarget is also clamped.
+		cloneAllParents(shard, shardedPlan, templateTask, map[physical.Node]bool{})
 
 		// The sources of the template task need to be replaced with new unique
 		// streams.
@@ -445,6 +453,32 @@ func (p *planner) processParallelizeNode(node *physical.Parallelize) ([]*Task, e
 
 	p.graph.Eliminate(templateTask)
 	return partitions, nil
+}
+
+// takes a starting node and a graph and recursively replaces
+// all parents of that node in the graph with clones.
+func cloneAllParents(node physical.Node, graph *dag.Graph[physical.Node], task *Task, visited map[physical.Node]bool) {
+	visited[node] = true
+	parents := graph.Parents(node)
+	for _, parent := range parents {
+		if visited[parent] {
+			continue
+		}
+		clone := parent.Clone()
+		_, ok := task.Sources[parent]
+		if ok {
+			tmp := task.Sources[parent]
+			task.Sources[clone] = tmp
+			delete(task.Sources, parent)
+		}
+		graph.Inject(parent, clone)
+		graph.Eliminate(parent)
+		visited[clone] = true
+		cloneParents := graph.Parents(clone)
+		for _, p := range cloneParents {
+			cloneAllParents(p, graph, task, visited)
+		}
+	}
 }
 
 // findShardableNode finds the first node in the graph that can be split into


### PR DESCRIPTION
The new optimizer, scanTimeRangePushup, propagates the MaxTimeRange from DataObjScan and PointersScan nodes to RangeAggregation nodes.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
