### PR TITLE
feat(fluentd): bump version

### DIFF
--- a/clients/cmd/fluentd/Makefile
+++ b/clients/cmd/fluentd/Makefile
@@ -4,7 +4,7 @@ SHELL    = /usr/bin/env bash -o pipefail
 # needs to match the name in fluent-plugin-grafana-loki.gemspec
 NAME    := fluent-plugin-grafana-loki
 # needs to match the version in fluent-plugin-grafana-loki.gemspec
-VERSION := 1.2.20
+VERSION := 1.3.0
 
 clean:
 	rm -f $(NAME)-*.gem

--- a/clients/cmd/fluentd/fluent-plugin-grafana-loki.gemspec
+++ b/clients/cmd/fluentd/fluent-plugin-grafana-loki.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 Gem::Specification.new do |spec|
   spec.name    = 'fluent-plugin-grafana-loki'
-  spec.version = '1.2.20'
+  spec.version = '1.3.0'
   spec.authors = %w[woodsaj briangann cyriltovena]
   spec.email   = ['awoods@grafana.com', 'brian@grafana.com', 'cyril.tovena@grafana.com']
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A follow-up on https://github.com/grafana/loki/pull/21296, releasing the new gem (I forgot to increase the version in the previous PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a version-only bump in build/release metadata with no runtime code changes.
> 
> **Overview**
> Bumps the `fluent-plugin-grafana-loki` gem release version from `1.2.20` to `1.3.0` in both the Fluentd plugin `Makefile` and `fluent-plugin-grafana-loki.gemspec` so the packaged gem name/version aligns for building and pushing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc34c2daacd546f8885dd4177d663b5777567145. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->