### PR TITLE
docs(retention): fix default retention_period value (0s, not 744h)

### DIFF
--- a/docs/sources/operations/storage/retention.md
+++ b/docs/sources/operations/storage/retention.md
@@ -161,7 +161,7 @@ Retention period for a given stream is decided based on the first match in this 
 2. If multiple global `retention_stream` selectors match the stream, retention period with the highest priority is picked. This value is not considered if per-tenant `retention_stream` is set.
 3. If a per-tenant `retention_period` is specified, it will be applied.
 4. The global `retention_period` will be applied if none of the above match.
-5. If no global `retention_period` is specified, the default value of `744h` (30days) retention is used.
+5. If no global `retention_period` is specified, the default value of `0s` is used, which means logs are kept indefinitely.
 
 {{< admonition type="note" >}}
 The larger the priority value, the higher the priority.


### PR DESCRIPTION
## What this PR does / why we need it

Fixes a documentation error in the retention guide. Since v2.8.0 ([PR #8753](https://github.com/grafana/loki/pull/8753)), the default value of `retention_period` is `0s`, which keeps logs indefinitely. The docs still stated the old default of `744h` (30 days).

## Which issue(s) this PR fixes

Fixes #21336

## Checklist

- [x] Documentation updated
- [ ] Tests added / updated (n/a — docs-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change correcting the stated default `retention_period` value; no runtime or configuration parsing behavior is modified.
> 
> **Overview**
> Updates the retention documentation to state that when no global `retention_period` is configured, the default is `0s` (keep logs indefinitely) rather than `744h` (30 days).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 439d25965400000cb0c96ae545217c43dc6f68db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->