### PR TITLE
docs: Backport 21267 to 3.7 branch

### DIFF
--- a/docs/sources/setup/install/helm/deployment-guides/azure.md
+++ b/docs/sources/setup/install/helm/deployment-guides/azure.md
@@ -305,8 +305,6 @@ serviceAccount:
   name: loki
   annotations:
     "azure.workload.identity/client-id": "<APP-ID>" # The app ID of the Azure AD app
-  labels:
-    "azure.workload.identity/use": "true"
 
 deploymentMode: Distributed
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of #21267 to 3.7 branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk doc-only change that adjusts an example Helm `values.yaml` snippet; no runtime code is modified.
> 
> **Overview**
> Updates the Azure Helm deployment guide to stop suggesting the `azure.workload.identity/use: "true"` *service account* label, leaving only the `azure.workload.identity/client-id` annotation on the `serviceAccount` example.
> 
> This aligns the example with using pod-level labeling (via `loki.podLabels`) for Azure Workload Identity instead of an invalid/misleading `serviceAccount.labels` block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d90505bb9b901498c73d032f6f97542b52f1d3cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->