### PR TITLE
docs: Backport 21267 to 3.6 branch

### DIFF
--- a/docs/sources/setup/install/helm/deployment-guides/azure.md
+++ b/docs/sources/setup/install/helm/deployment-guides/azure.md
@@ -305,8 +305,6 @@ serviceAccount:
   name: loki
   annotations:
     "azure.workload.identity/client-id": "<APP-ID>" # The app ID of the Azure AD app
-  labels:
-    "azure.workload.identity/use": "true"
 
 deploymentMode: Distributed
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of https://github.com/grafana/loki/pull/21267 to 3.6 branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adjusts the Helm `values.yaml` snippet; no runtime code is modified.
> 
> **Overview**
> Updates the Azure Helm deployment guide to stop setting `azure.workload.identity/use: "true"` under `serviceAccount.labels`, leaving workload identity enablement to the `loki.podLabels` example and only keeping the `azure.workload.identity/client-id` annotation on the service account.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eff2ba6ca3679b28a842c6215cb648ea7ba8ea82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->