### PR TITLE
docs: backport retention update 3.6

### DIFF
--- a/docs/sources/operations/storage/retention.md
+++ b/docs/sources/operations/storage/retention.md
@@ -161,7 +161,7 @@ Retention period for a given stream is decided based on the first match in this 
 2. If multiple global `retention_stream` selectors match the stream, retention period with the highest priority is picked. This value is not considered if per-tenant `retention_stream` is set.
 3. If a per-tenant `retention_period` is specified, it will be applied.
 4. The global `retention_period` will be applied if none of the above match.
-5. If no global `retention_period` is specified, the default value of `744h` (30days) retention is used.
+5. If no global `retention_period` is specified, the default value of `0s` is used, which means logs are kept indefinitely.
 
 {{< admonition type="note" >}}
 The larger the priority value, the higher the priority.


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of https://github.com/grafana/loki/pull/21338 to 3.6 branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime behavior or configuration parsing is modified.
> 
> **Overview**
> Clarifies retention precedence by updating the documented default when `limits_config.retention_period` is not set: it now states the default is `0s` (*keep logs indefinitely*) instead of `744h` (30 days).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 701574e79de9098211470be4be0833f5116b36a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->