### PR TITLE
feat(helm): Add support for configuring the ui target in query-frontend

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -14,6 +14,7 @@ Entries should include a reference to the pull request that introduced the chang
 ## Unreleased
 
 - [FEATURE] Update README chart migration notice from future tense to past tense
+- [ENHANCEMENT] Add support for configuring the ui target in query frontend
 
 ## 6.55.0
 
@@ -21,7 +22,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 ## 6.54.0
 
-**NOTE:** Effective [March 16, 2026](https://github.com/grafana/loki/issues/20705), the Grafana Loki Helm chart will be forked to the new repository [grafana-community/helm-charts](https://github.com/grafana-community/helm-charts). 
+**NOTE:** Effective [March 16, 2026](https://github.com/grafana/loki/issues/20705), the Grafana Loki Helm chart will be forked to the new repository [grafana-community/helm-charts](https://github.com/grafana-community/helm-charts).
 
 - [FEATURE] Add common labels to all resources [#20269](https://github.com/grafana/loki/pull/20269)
 - [FEATURE] Memcached: allow to override CPU in the auto-computed resource mode  [#20767](https://github.com/grafana/loki/pull/20767)
@@ -39,7 +40,7 @@ Entries should include a reference to the pull request that introduced the chang
 
 ## 6.52.0
 
-- [BREAKING] DEPRECATION NOTICE - The simple scalable mode (SSD) is deprecated and will be removed in a future version of the Loki Helm charts.  
+- [BREAKING] DEPRECATION NOTICE - The simple scalable mode (SSD) is deprecated and will be removed in a future version of the Loki Helm charts.
 - [BUGFIX] Updated Loki and GEL versions in values.yaml file. [#20548](https://github.com/grafana/loki/pull/20548).
 
 ## 6.51.0
@@ -55,12 +56,12 @@ Entries should include a reference to the pull request that introduced the chang
 - [ENHANCEMENT] Add configurable `startupProbe` to ingester [#20076](https://github.com/grafana/loki/pull/20076)
 - [ENHANCEMENT] Add configurable `livenessProbe` and `startupProbe` to loki-canary [#20079](https://github.com/grafana/loki/pull/20079)
 - [ENHANCEMENT] Add configurable `livenessProbe` and `startupProbe` to pattern-ingester [#20080](https://github.com/grafana/loki/pull/20080)
-- [ENHANCEMENT] Add configurable `startupProbe` to querier [#20081](https://github.com/grafana/loki/pull/20081) 
-- [ENHANCEMENT] Add configurable `livenessProbe` and `startupProbe` to query-frontend [#20082](https://github.com/grafana/loki/pull/20082) 
-- [ENHANCEMENT] Add configurable `startupProbe` to query-scheduler [#20083](https://github.com/grafana/loki/pull/20083) 
+- [ENHANCEMENT] Add configurable `startupProbe` to querier [#20081](https://github.com/grafana/loki/pull/20081)
+- [ENHANCEMENT] Add configurable `livenessProbe` and `startupProbe` to query-frontend [#20082](https://github.com/grafana/loki/pull/20082)
+- [ENHANCEMENT] Add configurable `startupProbe` to query-scheduler [#20083](https://github.com/grafana/loki/pull/20083)
 - [ENHANCEMENT] Add configurable `startupProbe` to table-manager [#20084](https://github.com/grafana/loki/pull/20084)
-- [ENHANCEMENT] Add configurable `livenessProbe` and `startupProbe` to ruler [#20085](https://github.com/grafana/loki/pull/20085) 
-- [ENHANCEMENT] Add configurable `livenessProbe` and `startupProbe` to the loki container in the write pods [#20087](https://github.com/grafana/loki/pull/20087) 
+- [ENHANCEMENT] Add configurable `livenessProbe` and `startupProbe` to ruler [#20085](https://github.com/grafana/loki/pull/20085)
+- [ENHANCEMENT] Add configurable `livenessProbe` and `startupProbe` to the loki container in the write pods [#20087](https://github.com/grafana/loki/pull/20087)
 - [BUGFIX] Fix rendering of `dnsConfig` for `backend`, `read`, `write`, `single-binary` and `table-manager`. [#20013](https://github.com/grafana/loki/pull/20013)
 - [BUGFIX] Respect global registry in sidecar image [#19347](https://github.com/grafana/loki/pull/19347).
 - [BUGFIX] Fix typos in comments in Values for health probes [#20078](https://github.com/grafana/loki/pull/20078)

--- a/production/helm/loki/templates/querier/_helpers-querier.tpl
+++ b/production/helm/loki/templates/querier/_helpers-querier.tpl
@@ -35,5 +35,5 @@ priorityClassName: {{ $pcn }}
 querier target
 */}}
 {{- define "loki.querierTarget" -}}
-querier{{- if .Values.loki.ui.enabled -}},ui{{- end -}}
+querier{{- if and .Values.loki.ui.enabled (not .Values.queryFrontend.ui.enabled) -}},ui{{- end -}}
 {{- end -}}

--- a/production/helm/loki/templates/query-frontend/_helpers-query-frontend.tpl
+++ b/production/helm/loki/templates/query-frontend/_helpers-query-frontend.tpl
@@ -30,3 +30,10 @@ query-frontend priority class name
 priorityClassName: {{ $pcn }}
 {{- end }}
 {{- end }}
+
+{{/*
+query-frontend target
+*/}}
+{{- define "loki.queryFrontendTarget" -}}
+query-frontend{{- if and .Values.loki.ui.enabled  .Values.queryFrontend.ui.enabled -}},ui{{- end -}}
+{{- end -}}

--- a/production/helm/loki/templates/query-frontend/deployment-query-frontend.yaml
+++ b/production/helm/loki/templates/query-frontend/deployment-query-frontend.yaml
@@ -76,7 +76,7 @@ spec:
           {{- end }}
           args:
             - -config.file=/etc/loki/config/config.yaml
-            - -target=query-frontend
+            - -target={{ include "loki.queryFrontendTarget" . }}
             {{- with (concat .Values.global.extraArgs .Values.queryFrontend.extraArgs) | uniq }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -2542,6 +2542,9 @@ queryFrontend:
     enabled: true
   # -- trafficDistribution for query-frontend service
   trafficDistribution: ""
+  # -- Enable UI Target for query-frontend
+  ui:
+    enabled: false
 # -- Configuration for the query-scheduler
 queryScheduler:
   # -- Number of replicas for the query-scheduler.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for configuring the ui target in query fronted, to support loki installation that don't use the nginx proxy 

**Which issue(s) this PR fixes**:
Fixes #20654

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Helm-rendered Loki `-target` args for `query-frontend` and `querier`, which can alter runtime component roles and UI routing if misconfigured. Default remains off, but enabling the new flag affects how UI APIs are served.
> 
> **Overview**
> Adds an opt-in `queryFrontend.ui.enabled` value to let the Helm chart append `,ui` to the `query-frontend` `-target` argument when `loki.ui.enabled` is on, enabling UI APIs without relying on the gateway.
> 
> Updates the `querier` target helper to **avoid also enabling** the `ui` target on queriers when `query-frontend` UI is enabled, and records the enhancement in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9ab3d2b0d9c3c6075896df48251660273e694b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->