### PR TITLE
fix: preserve parsed labels with empty values in samples query response from thor engine

### DIFF
--- a/pkg/engine/compat.go
+++ b/pkg/engine/compat.go
@@ -450,6 +450,13 @@ func collectSamplesFromRow(builder *labels.Builder, rec arrow.RecordBatch, i int
 	var sample promql.Sample
 	builder.Reset(labels.EmptyLabels())
 
+	// emptyParsedKeys collects label names whose value is the empty string (not NULL).
+	// Pipeline stages such as `| json` can produce parsed labels with empty values, and
+	// these must appear in the result to match classic Loki engine behaviour.
+	// The Prometheus labels.Builder treats Set(name, "") as a deletion, so we handle
+	// these labels separately using labels.NewScratchBuilder at the end.
+	var emptyParsedKeys []string
+
 	// TODO: we add a lot of overhead by reading row by row. Switch to vectorized conversion.
 	for colIdx := range int(rec.NumCols()) {
 		col := rec.Column(colIdx)
@@ -487,13 +494,45 @@ func collectSamplesFromRow(builder *labels.Builder, rec arrow.RecordBatch, i int
 
 		// allow any string columns
 		if ident.DataType() == types.Loki.String {
-			val := col.(*array.String).Value(i)
-			if val != "" {
-				builder.Set(shortName, val)
+			// The aggregator schema contains every label seen across all series. For a
+			// series that doesn't have a particular label, BuildRecord calls AppendNull,
+			// so IsNull(i)==true here means this label is simply absent for this series.
+			// Skip it rather than treating the empty string returned by Value(i) as a
+			// genuine empty label value.
+			if col.IsNull(i) {
+				continue
 			}
+			val := col.(*array.String).Value(i)
+			if val == "" {
+				// Stream labels and structured metadata should ideally never carry empty values:
+				// Loki removes them at ingestion time. Parsed labels (and ambiguous columns that
+				// originate from parsed labels) can legitimately be empty; we track them
+				// to add them back below after the Prometheus builder has finished.
+				if ident.ColumnType() != types.ColumnTypeLabel &&
+					ident.ColumnType() != types.ColumnTypeMetadata {
+					emptyParsedKeys = append(emptyParsedKeys, shortName)
+				}
+				continue
+			}
+			builder.Set(shortName, val)
 		}
 	}
 
-	sample.Metric = builder.Labels()
+	if len(emptyParsedKeys) > 0 {
+		// labels.Builder silently drops empty-valued labels, so we build the final
+		// label set manually when there are empty parsed labels.
+		lbs := builder.Labels()
+		scratch := labels.NewScratchBuilder(lbs.Len() + len(emptyParsedKeys))
+		lbs.Range(func(l labels.Label) {
+			scratch.Add(l.Name, l.Value)
+		})
+		for _, key := range emptyParsedKeys {
+			scratch.Add(key, "")
+		}
+		scratch.Sort()
+		sample.Metric = scratch.Labels()
+	} else {
+		sample.Metric = builder.Labels()
+	}
 	return sample, true
 }

--- a/pkg/engine/compat_test.go
+++ b/pkg/engine/compat_test.go
@@ -711,6 +711,80 @@ func TestVectorResultBuilder(t *testing.T) {
 		require.Equal(t, expected, vector)
 	})
 
+	t.Run("empty parsed label values are preserved in vector results", func(t *testing.T) {
+		colTs := semconv.ColumnIdentTimestamp
+		colVal := semconv.ColumnIdentValue
+		colEnv := semconv.NewIdentifier("env", types.ColumnTypeParsed, types.Loki.String)
+		colScheme := semconv.NewIdentifier("http_url_scheme", types.ColumnTypeParsed, types.Loki.String)
+
+		schema := arrow.NewSchema(
+			[]arrow.Field{
+				semconv.FieldFromIdent(colTs, false),
+				semconv.FieldFromIdent(colVal, false),
+				semconv.FieldFromIdent(colEnv, true),
+				semconv.FieldFromIdent(colScheme, true),
+			},
+			nil,
+		)
+		ts := time.Unix(0, 1620000000000000000).UTC()
+		rows := arrowtest.Rows{
+			// Non-empty parsed label value — no change in behaviour.
+			{colTs.FQN(): ts, colVal.FQN(): float64(1), colEnv.FQN(): "prod", colScheme.FQN(): "https"},
+			// Empty parsed label value (e.g. `| json` parsed http_url_scheme as "").
+			// Must appear in the result with value "" rather than being absent.
+			{colTs.FQN(): ts, colVal.FQN(): float64(2), colEnv.FQN(): "dev", colScheme.FQN(): ""},
+			// Absent parsed label (NULL — aggregator called AppendNull for this series).
+			// Must NOT appear in the result at all.
+			{colTs.FQN(): ts, colVal.FQN(): float64(3), colEnv.FQN(): "staging", colScheme.FQN(): nil},
+		}
+
+		record := rows.Record(memory.DefaultAllocator, schema)
+
+		pipeline := executor.NewBufferedPipeline(record)
+		defer pipeline.Close()
+
+		builder := newVectorResultBuilder()
+		err := collectResult(context.Background(), pipeline, builder)
+
+		require.NoError(t, err)
+		require.Equal(t, 3, builder.Len())
+
+		md, _ := metadata.NewContext(t.Context())
+		result := builder.Build(stats.Result{}, md)
+		vector := result.Data.(promql.Vector)
+
+		samples := make(map[string]*promql.Sample, len(vector))
+		for i := range vector {
+			env := vector[i].Metric.Get("env")
+			samples[env] = &vector[i]
+		}
+
+		// prod: non-empty value, must be present as-is.
+		require.NotNil(t, samples["prod"], "expected a sample with env=prod")
+		require.Equal(t, "https", samples["prod"].Metric.Get("http_url_scheme"))
+
+		// dev: empty string value, must be present in the label set.
+		require.NotNil(t, samples["dev"], "expected a sample with env=dev")
+		devHasScheme := false
+		samples["dev"].Metric.Range(func(l labels.Label) {
+			if l.Name == "http_url_scheme" {
+				devHasScheme = true
+				require.Equal(t, "", l.Value)
+			}
+		})
+		require.True(t, devHasScheme, "dev: http_url_scheme with empty value must be present in the label set")
+
+		// staging: absent label (NULL), must not appear at all.
+		require.NotNil(t, samples["staging"], "expected a sample with env=staging")
+		stagingHasScheme := false
+		samples["staging"].Metric.Range(func(l labels.Label) {
+			if l.Name == "http_url_scheme" {
+				stagingHasScheme = true
+			}
+		})
+		require.False(t, stagingHasScheme, "staging: absent label (NULL) must not appear in the label set")
+	})
+
 	// TODO:(ashwanth) also enforce grouping labels are all present?
 	t.Run("rows without timestamp or value are ignored", func(t *testing.T) {
 		colTs := semconv.ColumnIdentTimestamp

--- a/pkg/engine/internal/executor/range_aggregation_test.go
+++ b/pkg/engine/internal/executor/range_aggregation_test.go
@@ -98,7 +98,9 @@ func TestRangeAggregationPipeline_instant(t *testing.T) {
 		{colTs: time.Unix(20, 0).UTC(), colVal: float64(2), "utf8.ambiguous.env": "prod", "utf8.ambiguous.service": "app1"},
 		{colTs: time.Unix(20, 0).UTC(), colVal: float64(3), "utf8.ambiguous.env": "prod", "utf8.ambiguous.service": "app2"},
 		{colTs: time.Unix(20, 0).UTC(), colVal: float64(2), "utf8.ambiguous.env": "prod", "utf8.ambiguous.service": "app3"},
-		{colTs: time.Unix(20, 0).UTC(), colVal: float64(1), "utf8.ambiguous.env": "dev", "utf8.ambiguous.service": nil},
+		// Empty service label must be preserved in the aggregation result, not dropped or turned into NULL.
+		// Pipeline stages like `| json` can produce parsed labels with empty values.
+		{colTs: time.Unix(20, 0).UTC(), colVal: float64(1), "utf8.ambiguous.env": "dev", "utf8.ambiguous.service": ""},
 	}
 
 	rows, err := arrowtest.RecordRows(record)
@@ -645,6 +647,59 @@ func TestMatcher(t *testing.T) {
 			})
 		}
 	})
+}
+
+// TestRangeAggregationPipeline_EmptyLabelValues is a regression test: empty parsed label values must be
+// preserved in the aggregation output so the downstream result builder can include them in the metric
+// label set (matching classic Loki engine behaviour).
+func TestRangeAggregationPipeline_EmptyLabelValues(t *testing.T) {
+	fields := []arrow.Field{
+		semconv.FieldFromFQN(colTs, false),
+		semconv.FieldFromFQN(colEnv, false),
+		semconv.FieldFromFQN(colSvc, false),
+	}
+	schema := arrow.NewSchema(fields, nil)
+
+	rows := []arrowtest.Rows{
+		{
+			{colTs: time.Unix(20, 0).UTC(), colEnv: "prod", colSvc: "app1"},
+			{colTs: time.Unix(15, 0).UTC(), colEnv: "prod", colSvc: "app1"},
+			// svc="" — a parsed label with empty value; must be preserved, not collapsed with absent svc.
+			{colTs: time.Unix(18, 0).UTC(), colEnv: "dev", colSvc: ""},
+		},
+	}
+
+	opts := rangeAggregationOptions{
+		grouping: physical.Grouping{
+			Columns: []physical.ColumnExpression{
+				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "env", Type: types.ColumnTypeAmbiguous}},
+				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "service", Type: types.ColumnTypeAmbiguous}},
+			},
+		},
+		startTs:       time.Unix(20, 0).UTC(),
+		endTs:         time.Unix(20, 0).UTC(),
+		rangeInterval: 10 * time.Second,
+		operation:     types.RangeAggregationTypeCount,
+	}
+
+	input := NewArrowtestPipeline(schema, rows...)
+	pipeline, err := newRangeAggregationPipeline([]Pipeline{input}, newExpressionEvaluator(), opts)
+	require.NoError(t, err)
+	defer pipeline.Close()
+
+	record, err := pipeline.Read(t.Context())
+	require.NoError(t, err)
+
+	result, err := arrowtest.RecordRows(record)
+	require.NoError(t, err)
+
+	expect := arrowtest.Rows{
+		{colTs: time.Unix(20, 0).UTC(), colVal: float64(2), "utf8.ambiguous.env": "prod", "utf8.ambiguous.service": "app1"},
+		// svc="" must appear as empty string in the output row, not nil (NULL).
+		{colTs: time.Unix(20, 0).UTC(), colVal: float64(1), "utf8.ambiguous.env": "dev", "utf8.ambiguous.service": ""},
+	}
+	require.Equal(t, len(expect), len(result))
+	require.ElementsMatch(t, expect, result)
 }
 
 // requireEqualWindows asserts that two slices of window structs contain the same elements.

--- a/pkg/engine/internal/executor/util.go
+++ b/pkg/engine/internal/executor/util.go
@@ -35,7 +35,8 @@ func columnForFQN(fqn string, batch arrow.RecordBatch) (arrow.Array, int, error)
 }
 
 // labelValuesCache returns label values for a given row in range and vector aggregators, but cache them in order
-// to reduce object allocations for repeated label sets. It first scans the row for non-empty labels and computes xxhash.
+// to reduce object allocations for repeated label sets. It computes an xxhash over the non-null label values
+// to form the cache key, then returns the full slice of values.
 // In case of a cache miss it scans the row again and allocates arrays for label values.
 type labelValuesCache struct {
 	digest *xxhash.Digest
@@ -52,10 +53,9 @@ func newLabelValuesCache() *labelValuesCache {
 func (c *labelValuesCache) getLabelValues(arrays []*array.String, row int) []string {
 	c.digest.Reset()
 	for _, arr := range arrays {
-		val := arr.Value(row)
-		if val != "" {
+		if !arr.IsNull(row) {
 			_, _ = c.digest.Write(separator)
-			_, _ = c.digest.WriteString(val)
+			_, _ = c.digest.WriteString(arr.Value(row))
 		}
 	}
 	key := c.digest.Sum64()
@@ -63,11 +63,9 @@ func (c *labelValuesCache) getLabelValues(arrays []*array.String, row int) []str
 	labelValues, ok := c.cache[key]
 	if !ok {
 		labelValues = make([]string, 0, len(arrays))
-
 		for _, arr := range arrays {
-			val := arr.Value(row)
-			if val != "" {
-				labelValues = append(labelValues, val)
+			if !arr.IsNull(row) {
+				labelValues = append(labelValues, arr.Value(row))
 			}
 		}
 		c.cache[key] = labelValues
@@ -77,7 +75,7 @@ func (c *labelValuesCache) getLabelValues(arrays []*array.String, row int) []str
 }
 
 // fieldsCache returns labels for a given row in range and vector aggregators, but cache them in order
-// to reduce object allocations for repeated label sets. It first scans the row for non-empty labels and computes xxhash.
+// to reduce object allocations for repeated label sets. It first scans the row for non-null labels and computes xxhash.
 // In case of a cache miss it scans the row again and allocates arrays for label names.
 type fieldsCache struct {
 	digest *xxhash.Digest
@@ -94,8 +92,7 @@ func newFieldsCache() *fieldsCache {
 func (c *fieldsCache) getFields(arrays []*array.String, fields []arrow.Field, row int) []arrow.Field {
 	c.digest.Reset()
 	for i, arr := range arrays {
-		val := arr.Value(row)
-		if val != "" {
+		if !arr.IsNull(row) {
 			_, _ = c.digest.Write(separator)
 			_, _ = c.digest.WriteString(fields[i].Name)
 		}
@@ -106,8 +103,7 @@ func (c *fieldsCache) getFields(arrays []*array.String, fields []arrow.Field, ro
 	if !ok {
 		labels = make([]arrow.Field, 0, len(arrays))
 		for i, arr := range arrays {
-			val := arr.Value(row)
-			if val != "" {
+			if !arr.IsNull(row) {
 				labels = append(labels, fields[i])
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
When a parser generates labels with empty values, the v2 query engine drops those labels from the samples query response. However, such labels are retained by the v1 query engine and in the logs query response from the v2 query engine.

To match the behaviour of the v2 query engine to that of the v1 query engine, I have changed the v2 engine code to retain parsed labels with empty values in the samples query response.

**Checklist**
- [X] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how label sets are built for vector/matrix results and how aggregators treat empty vs NULL string values, which can affect query result grouping/series identity. Risk is moderate and mitigated by added regression tests around empty-label handling.
> 
> **Overview**
> Aligns thor/v2 samples query output with classic Loki behavior by **preserving parsed/ambiguous labels whose value is an empty string** (while still treating NULL as label absence).
> 
> Updates `collectSamplesFromRow` to skip NULL string columns, track empty parsed keys separately, and rebuild the final metric label set with `labels.NewScratchBuilder` so empty-valued parsed labels are retained.
> 
> Adjusts executor label/field caching and range aggregation expectations to key off *non-NULL* values (not non-empty strings), and adds regression tests covering empty vs absent labels in both vector results and range aggregation output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d02b37242b526008cdb5b9882b49d2fdc4528e51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->