### PR TITLE
fix(nix): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1772433332,
-        "narHash": "sha256-izhTDFKsg6KeVBxJS9EblGeQ8y+O8eCa6RcW874vxEc=",
+        "lastModified": 1774709303,
+        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cf59864ef8aa2e178cccedbe2c178185b0365705",
+        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
**What this PR does / why we need it**:

We updated go version to 1.25.8 which broke nix build process. Updating flake.lock to include latest versions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only change; primary impact is that Nix builds/devShell inputs may resolve to slightly different package versions.
> 
> **Overview**
> Updates `flake.lock` to **advance the pinned `nixpkgs-unstable` input** (new `rev`, `narHash`, and `lastModified`), refreshing the Nix package set used by the flake.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7a499071abaf51465ac651fef58226fa95b6b05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->