### PR TITLE
fix(memory): fix off-by-one in Bitmap.Slice for byte-aligned ends

### DIFF
--- a/pkg/memory/bitmap.go
+++ b/pkg/memory/bitmap.go
@@ -244,7 +244,7 @@ func (bmap *Bitmap) Slice(i, j int) *Bitmap {
 
 	var (
 		startWord = (bmap.off + i) / 8
-		endWord   = ((bmap.off + j) / 8) + 1
+		endWord   = ((bmap.off + j) + 7) / 8
 
 		off    = (bmap.off + i) % 8
 		newLen = j - i

--- a/pkg/memory/bitmap_test.go
+++ b/pkg/memory/bitmap_test.go
@@ -290,6 +290,28 @@ func TestBitmap_Slice(t *testing.T) {
 		require.False(t, slice2.Get(15-totalOff))
 	})
 
+	t.Run("ByteAligned", func(t *testing.T) {
+		// Regression test: Slice where the end is exactly byte-aligned should
+		// not panic. The old formula (off+j)/8+1 would overshoot by 1 byte
+		// when (off+j) is a multiple of 8, causing an out-of-bounds slice.
+		var bmap memory.Bitmap
+		n := 65536 // exactly 8192 bytes
+		bmap.AppendCount(true, n)
+
+		require.NotPanics(t, func() {
+			slice := bmap.Slice(0, n)
+			require.Equal(t, n, slice.Len())
+		})
+
+		// Also test a smaller byte-aligned boundary with an offset.
+		bmap2 := memory.Bitmap{}
+		bmap2.AppendCount(false, 24) // 3 bytes
+		require.NotPanics(t, func() {
+			slice := bmap2.Slice(0, 16) // end at byte 2, exactly aligned
+			require.Equal(t, 16, slice.Len())
+		})
+	})
+
 	t.Run("Clone", func(t *testing.T) {
 		var bmap memory.Bitmap
 		bmap.AppendValues(false, false, false, true, true, false, true, true, false, false, true, true, false, false, false, false)


### PR DESCRIPTION
The endWord calculation used (off+j)/8+1 which overshoots by 1 byte when (off+j) is exactly divisible by 8, causing an out-of-bounds panic. Use ceiling division ((off+j)+7)/8 instead.

Also adds BitmapFrom constructor for wrapping existing data slices.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to bitmap slicing math with added regression coverage; main risk is unintended behavior change in edge-case slicing boundaries.
> 
> **Overview**
> Fixes an off-by-one in `Bitmap.Slice` when the slice end is exactly byte-aligned by changing the `endWord` calculation to use ceiling division, preventing an out-of-bounds panic.
> 
> Adds a regression test (`ByteAligned`) to ensure slicing at large and small byte-aligned boundaries (including with offsets) does not panic and returns the expected length.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f6b406646dc782489f275708a37bb1fc312aef2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->