### PR TITLE
docs: RN for 3.6.9 patch

### DIFF
--- a/docs/sources/release-notes/v3-6.md
+++ b/docs/sources/release-notes/v3-6.md
@@ -192,6 +192,10 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 ## Bug fixes
 
+### 3.6.9 (2025-04-01)
+
+* **ci** Backporting [#19989](https://github.com/grafana/loki/pull/19989) Add build tags to Promtail build commands, into 3.6 ([#21356](https://github.com/grafana/loki/issues/21356)) ([0f56890](https://github.com/grafana/loki/commit/0f56890f0536200d1ebb22bcc3488d0e79d9285b)).
+
 ### 3.6.8 (2025-03-25)
 
 * **deps:**  Upgrade `go.opentelemetry.io/otel/sdk` from v1.38.0 to v1.40.0 ([#21115](https://github.com/grafana/loki/issues/21115)) ([d1ab148](https://github.com/grafana/loki/commit/d1ab148aa279e9e5263f699fa1b1a0e1eec14f1a)).


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Release Notes for the 3.6.9 patch release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adds a new patch release entry; no runtime or build behavior is modified.
> 
> **Overview**
> Adds a new **3.6.9 (2025-04-01)** section to the `v3-6` release notes under *Bug fixes*, documenting a CI backport to add build tags to Promtail build commands (with links to the related PR/issue/commit).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f14432a7c7963e4e8c8e392eb8732deb14a449c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->