### PR TITLE
chore(columnar): check both validity and offsets capacity in UTF8Builder.needGrow

### DIFF
--- a/pkg/columnar/datum_utf8.go
+++ b/pkg/columnar/datum_utf8.go
@@ -199,7 +199,7 @@ func (b *UTF8Builder) Grow(n int) {
 }
 
 func (b *UTF8Builder) needGrow(n int) bool {
-	return b.offsets.Len()+n > b.offsets.Cap()
+	return b.validity.Len()+n > b.validity.Cap() || b.offsets.Len()+n > b.offsets.Cap()
 }
 
 // GrowData increases b's bytes capacity, if necessary, to guarantee space

--- a/pkg/columnar/datum_utf8_test.go
+++ b/pkg/columnar/datum_utf8_test.go
@@ -1,0 +1,30 @@
+package columnar_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestUTF8Builder_AppendManyValues(t *testing.T) {
+	// Regression test: UTF8Builder.needGrow only checked offsets capacity, not
+	// the validity bitmap. Because offsets (4 bytes each) and the bitmap (1 bit
+	// each) grow at different rates, the bitmap could fill up first, causing a
+	// panic in AppendUnsafe.
+	alloc := memory.NewAllocator(nil)
+	defer alloc.Free()
+
+	b := columnar.NewUTF8Builder(alloc)
+	require.NotPanics(t, func() {
+		for i := range 1000 {
+			b.AppendValue([]byte("x"))
+			_ = i
+		}
+	})
+
+	arr := b.Build()
+	require.Equal(t, 1000, arr.Len())
+}


### PR DESCRIPTION
UTF8Builder.needGrow only checked offsets capacity, but AppendValue calls validity.AppendUnsafe which assumes the bitmap has room. Due to 64-byte memory alignment, offsets can get far more headroom than the validity bitmap (e.g., 16 int32 slots from a single 64-byte allocation vs 8 bits from 1 byte), so offsets-based needGrow returns false while the bitmap is already full.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized capacity-check fix in `UTF8Builder` plus a regression test; main impact is preventing a panic during large appends.
> 
> **Overview**
> Fixes `UTF8Builder.needGrow` to consider **both** the validity bitmap and offsets buffer capacity, preventing `AppendValue`/`AppendNull` from calling `validity.AppendUnsafe` when the bitmap has run out of space.
> 
> Adds a regression test (`TestUTF8Builder_AppendManyValues`) that appends many small strings and asserts the builder does not panic and produces the expected length.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1906127b8860b5fb820c5f1c88814ee42f33e685. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->