### PR TITLE
feat: Add a metric that reports when goldfish racing is enabled

### DIFF
--- a/pkg/querytee/proxy.go
+++ b/pkg/querytee/proxy.go
@@ -289,6 +289,7 @@ func NewProxy(
 
 	// Pre-initialize raceWins metric for all backend/route/issuer combinations
 	if cfg.Routing.Mode == RoutingModeRace {
+		p.metrics.raceModeEnabled.Set(1)
 		for _, backend := range p.backends {
 			for _, route := range p.readRoutes {
 				for _, issuer := range []string{unknownIssuer, canaryIssuer} {

--- a/pkg/querytee/proxy_metrics.go
+++ b/pkg/querytee/proxy_metrics.go
@@ -27,7 +27,8 @@ type ProxyMetrics struct {
 	samplingDecisions *prometheus.CounterVec
 
 	// Race metrics
-	raceWins *prometheus.CounterVec
+	raceWins        *prometheus.CounterVec
+	raceModeEnabled prometheus.Gauge
 }
 
 func NewProxyMetrics(registerer prometheus.Registerer) *ProxyMetrics {
@@ -77,6 +78,12 @@ func NewProxyMetrics(registerer prometheus.Registerer) *ProxyMetrics {
 			Name:      "race_wins_total",
 			Help:      "Total number of times each backend won the race (when racing is enabled).",
 		}, []string{"backend", "backend_alias", "route", "issuer"}),
+
+		raceModeEnabled: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
+			Namespace: "loki_querytee",
+			Name:      "race_mode_enabled",
+			Help:      "Set to 1 if race mode is enabled for this querytee instance, 0 otherwise.",
+		}),
 	}
 
 	return m


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `loki_querytee_race_mode_enabled` that reports when goldfish racing is enabled

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Prometheus gauge and sets it during startup when `routing.mode` is `race`, without changing request routing or comparison behavior.
> 
> **Overview**
> Adds a new Prometheus gauge metric, `loki_querytee_race_mode_enabled`, to report whether this query-tee instance is configured to run in *race* routing mode.
> 
> When `routing.mode == race`, `NewProxy` now sets this gauge to `1` while pre-initializing existing `race_wins` label combinations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e87a734c8f562d733550bc9cf6525d49e6c7d631. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->