### PR TITLE
docs: add back promtail topic with migration links

### DIFF
--- a/docs/sources/send-data/_index.md
+++ b/docs/sources/send-data/_index.md
@@ -21,7 +21,6 @@ The following clients are developed and supported (for those customers who have 
 - [Grafana Alloy](https://grafana.com/docs/alloy/latest/) - Grafana Alloy is a vendor-neutral distribution of the OpenTelemetry (OTel) Collector. Alloy offers native pipelines for OTel, Prometheus, Pyroscope, Loki, and many other metrics, logs, traces, and profile tools. In addition, you can use Alloy pipelines to do different tasks, such as configure alert rules in Loki and Mimir. Alloy is fully compatible with the OTel Collector and Prometheus Agent. You can use Alloy as an alternative to either of these solutions or combine it into a hybrid system of multiple collectors and agents. You can deploy Alloy anywhere within your IT infrastructure and pair it with your Grafana LGTM stack, a telemetry backend from Grafana Cloud, or any other compatible backend from any other vendor.
 - [xk6-loki extension](https://github.com/grafana/xk6-loki) - The k6-loki extension lets you perform [load testing on Loki](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/k6/).
 
-
 ## OpenTelemetry Collector
 
 Loki natively supports ingesting OpenTelemetry logs over HTTP.

--- a/docs/sources/send-data/promtail/_index.md
+++ b/docs/sources/send-data/promtail/_index.md
@@ -1,0 +1,24 @@
+---
+title: Promtail agent
+menuTitle:  Promtail
+description: How to use the Promtail agent to ship logs to Loki
+aliases: 
+- ../clients/promtail/ # /docs/loki/latest/clients/promtail/
+weight:  300
+---
+# Promtail agent
+
+{{< admonition type="warning" >}}
+Promtail is end of life (EOL) as of March 2, 2026.  Commercial support has ended. No future support or updates will be provided. All future feature development will occur in Grafana Alloy.  
+Note that the deprecation of Promtail does NOT include the lambda-promtail client.
+{{< /admonition >}}
+
+If you are currently using Promtail, you must migrate to Alloy or another supported client.
+
+The Alloy migration documentation includes a migration tool for converting your Promtail configuration to an Alloy configuration with a single command.
+
+## Resources
+
+- Links to [Migrate to Alloy documentation](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/migrate/migrate-to-alloy/).
+- [Medium post with migration instructions](https://medium.com/@syed_usman_ahmed/docker-users-who-use-grafana-loki-with-promtail-need-to-migrate-to-grafana-alloy-as-promtail-the-a20a) written by a Grafana Developer Advocate.
+- [Video for Docker users with Promtail migration guide](https://www.youtube.com/watch?v=3W99Go4S39E) filmed by a Grafana Developer Advocate.

--- a/docs/sources/setup/migrate/migrate-to-alloy/_index.md
+++ b/docs/sources/setup/migrate/migrate-to-alloy/_index.md
@@ -6,7 +6,7 @@ weight: 100
 
 # Migrate to Alloy
 
-Grafana Alloy is the new name for the Grafana Labs distribution of the OpenTelemetry collector. Grafana Agent Static, Grafana Agent Flow, and Grafana Agent Operator have been deprecated and are in Long-Term Support (LTS) through October 31, 2025. They will reach an End-of-Life (EOL) on November 1, 2025. Grafana Labs has provided tools and migration documentation to assist you in migrating to Grafana Alloy.
+Grafana Alloy is the new name for the Grafana Labs distribution of the OpenTelemetry collector. Grafana Agent Static, Grafana Agent Flow, and Grafana Agent Operator reached End-of-Life (EOL) on November 1, 2025. Grafana Labs has provided tools and migration documentation to assist you in migrating to Grafana Alloy.
 
 Read more about why we recommend migrating to [Grafana Alloy](https://grafana.com/blog/2024/04/09/grafana-alloy-opentelemetry-collector-with-prometheus-pipelines/).
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We removed the Promtail docs in https://github.com/grafana/loki/pull/21245 and https://github.com/grafana/loki/pull/21258.  I realized that we still need a Promtail page for the following:

- Link to the Migration docs.
- Link to migration article and video created by one of the Developer Advocates.
- Maintain the note that lambda-promtail is NOT deprecated.

Also - Updates the text in the Migration links page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that add/adjust navigation and migration guidance; low risk aside from potential broken links/redirects.
> 
> **Overview**
> Reintroduces a dedicated `Promtail` docs page under `send-data` that clearly states Promtail’s EOL (while explicitly excluding `lambda-promtail`) and points users to Alloy migration resources (docs, article, and video).
> 
> Updates the `Migrate to Alloy` landing page text to reflect that Grafana Agent components have already reached EOL, and cleans up a stray list item in the `Send data` index page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 628af111090914bd33835cbe86693000234c9f40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->