### PR TITLE
docs: backport storage typo fix 3.7

### DIFF
--- a/docs/sources/operations/storage/_index.md
+++ b/docs/sources/operations/storage/_index.md
@@ -148,7 +148,7 @@ See the [IBM Cloud Object Storage section](https://grafana.com/docs/loki/<LOKI_V
 +--------------------+----------------------------+
 | block 1 (n bytes)  | checksum (uint32, 4 bytes) |
 +--------------------+----------------------------+
-| block 1 (n bytes)  | checksum (uint32, 4 bytes) |
+| block 2 (n bytes)  | checksum (uint32, 4 bytes) |
 +--------------------+----------------------------+
 | ...                                             |
 +--------------------+----------------------------+


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of #20996 to the 3.7 branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change correcting the chunk format diagram; no runtime or behavior impact.
> 
> **Overview**
> Fixes a typo in `docs/sources/operations/storage/_index.md` where the chunk format *Blocks* ASCII diagram incorrectly duplicated a line; it now correctly shows sequential `block 1`, `block 2`, … `block N` entries with their checksums.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b62f5434b279074304b3834e57c3e413c9c0f401. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->