### PR TITLE
docs: backport storage typo fix 3.6

### DIFF
--- a/docs/sources/operations/storage/_index.md
+++ b/docs/sources/operations/storage/_index.md
@@ -148,7 +148,7 @@ See the [IBM Cloud Object Storage section](https://grafana.com/docs/loki/<LOKI_V
 +--------------------+----------------------------+
 | block 1 (n bytes)  | checksum (uint32, 4 bytes) |
 +--------------------+----------------------------+
-| block 1 (n bytes)  | checksum (uint32, 4 bytes) |
+| block 2 (n bytes)  | checksum (uint32, 4 bytes) |
 +--------------------+----------------------------+
 | ...                                             |
 +--------------------+----------------------------+


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of https://github.com/grafana/loki/pull/20996 to the 3.6 branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that corrects an ASCII diagram; no runtime behavior is affected.
> 
> **Overview**
> Fixes a typo in `docs/sources/operations/storage/_index.md` where the chunk format **Blocks** ASCII diagram had a duplicated/misaligned `block 1` row, updating it to correctly show `block 1`, `block 2`, ..., `block N` each followed by a checksum.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 905e07db7d1449575e4d8dad0ce1fd9d0f8916d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->