### PR TITLE
docs: fix link to BOS

### DIFF
--- a/docs/sources/operations/storage/_index.md
+++ b/docs/sources/operations/storage/_index.md
@@ -46,7 +46,7 @@ For more information:
 - [Google Cloud Storage (GCS)](https://cloud.google.com/storage/)
 - [Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs)
 - [IBM Cloud Object Storage (COS)](https://www.ibm.com/cloud/object-storage)
-- [Baidu Object Storage (BOS)](https://cloud.baidu.com/product/bos.html)
+- [Baidu Object Storage](https://intl.cloud.baidu.com/product/bos.html)
 - [Alibaba Object Storage Service (OSS)](https://www.alibabacloud.com/product/object-storage-service)
 
 ### ⚠️ Supported chunks stores, not typically recommended for production use


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes link to Baidu Object Storage.  Replaces #9987, where the submitter never signed the CLA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates an external URL; no runtime behavior is affected.
> 
> **Overview**
> Updates the storage documentation to fix the Baidu Object Storage (BOS) link, switching it to the correct `intl.cloud.baidu.com` URL in the list of supported chunk stores.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cf6083a2bed3fd5e5fb0d9d1610c45e5c5f1755. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->