### PR TITLE
feat: make service_name label configurable via global config

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/util"
 	_ "github.com/grafana/loki/v3/pkg/util/build"
 	"github.com/grafana/loki/v3/pkg/util/cfg"
+	"github.com/grafana/loki/v3/pkg/util/constants"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/validation"
 )
@@ -63,6 +64,10 @@ func main() {
 
 	// Set the global OTLP config which is needed in per tenant otlp config
 	config.LimitsConfig.SetGlobalOTLPConfig(config.Distributor.OTLPConfig)
+	// Set the global service label name used for service name discovery
+	if config.ServiceLabelName != "" {
+		constants.ServiceLabelName = config.ServiceLabelName
+	}
 	// Set the default policy stream mappings which are needed in per tenant policy stream mappings
 	if err := config.LimitsConfig.SetDefaultPolicyStreamMapping(config.Distributor.DefaultPolicyStreamMappings); err != nil {
 		level.Error(util_log.Logger).Log("msg", "failed to set default policy stream mappings", "err", err.Error())

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -29,6 +29,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/util/cfg"
+	"github.com/grafana/loki/v3/pkg/util/constants"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/validation"
 )
@@ -441,6 +442,9 @@ func (c *Component) run() error {
 	}
 
 	config.LimitsConfig.SetGlobalOTLPConfig(config.Distributor.OTLPConfig)
+	if config.ServiceLabelName != "" {
+		constants.ServiceLabelName = config.ServiceLabelName
+	}
 	if err := config.LimitsConfig.SetDefaultPolicyStreamMapping(config.Distributor.DefaultPolicyStreamMappings); err != nil {
 		return err
 	}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1383,7 +1383,7 @@ func TestParseStreamLabels(t *testing.T) {
 			},
 			expectedLabels: labels.FromStrings(
 				"foo", "bar",
-				loghttp_push.LabelServiceName, loghttp_push.ServiceUnknown,
+				constants.ServiceLabelName, loghttp_push.ServiceUnknown,
 			),
 		},
 	} {

--- a/pkg/distributor/segment.go
+++ b/pkg/distributor/segment.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/util/constants"
 )
 
 // A segmentationKey is a special partition key that attempts to equally
@@ -34,7 +35,7 @@ func getSegmentationKey(stream KeyedStream) (segmentationKey, error) {
 	if err != nil {
 		return "", err
 	}
-	if serviceName := labels.Get("service_name"); serviceName != "" {
+	if serviceName := labels.Get(constants.ServiceLabelName); serviceName != "" {
 		return segmentationKey(serviceName), nil
 	}
 	return segmentationKey("unknown_service"), nil

--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -168,8 +168,8 @@ func (v Validator) ValidateLabels(vCtx validationContext, ls labels.Labels, stre
 
 	numLabelNames := ls.Len()
 	// This is a special case that's often added by the Loki infrastructure. It may result in allowing one extra label
-	// if incoming requests already have a service_name
-	if ls.Has(push.LabelServiceName) {
+	// if incoming requests already have the configured service label
+	if ls.Has(constants.ServiceLabelName) {
 		numLabelNames--
 	}
 

--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -199,7 +199,7 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 					if !hasServiceName && shouldDiscoverServiceName {
 						for _, labelName := range discoverServiceName {
 							if lbl.Name == labelName {
-								streamLabels[model.LabelName(LabelServiceName)] = model.LabelValue(lbl.Value)
+								streamLabels[model.LabelName(constants.ServiceLabelName)] = model.LabelValue(lbl.Value)
 								hasServiceName = true
 								break
 							}
@@ -217,7 +217,7 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 		}
 
 		if !hasServiceName && shouldDiscoverServiceName {
-			streamLabels[model.LabelName(LabelServiceName)] = model.LabelValue(ServiceUnknown)
+			streamLabels[model.LabelName(constants.ServiceLabelName)] = model.LabelValue(ServiceUnknown)
 		}
 
 		// this must be pushed to the end after log lines are also evaluated
@@ -234,7 +234,7 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 			level.Debug(logger).Log(
 				"msg", "OTLP push request stream before service name discovery",
 				"stream", sb.String(),
-				"service_name", streamLabels[model.LabelName(LabelServiceName)],
+				constants.ServiceLabelName, streamLabels[model.LabelName(constants.ServiceLabelName)],
 			)
 		}
 

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -76,9 +76,8 @@ var (
 )
 
 const (
-	applicationJSON  = "application/json"
-	LabelServiceName = "service_name"
-	ServiceUnknown   = "unknown_service"
+	applicationJSON = "application/json"
+	ServiceUnknown  = "unknown_service"
 
 	// maxStreamLabelsSize is the maximum allowed size of a single stream's labels string.
 	// Prometheus' label parser panics when encoding labels that exceed 16MB (2^24 bytes).
@@ -440,7 +439,7 @@ func ParseLokiRequest(userID string, r *http.Request, limits Limits, tenantConfi
 		}
 
 		serviceName := ServiceUnknown
-		if !lbs.Has(LabelServiceName) && len(discoverServiceName) > 0 && !isInternalStream {
+		if !lbs.Has(constants.ServiceLabelName) && len(discoverServiceName) > 0 && !isInternalStream {
 			for _, labelName := range discoverServiceName {
 				if labelVal := lbs.Get(labelName); labelVal != "" {
 					serviceName = labelVal
@@ -449,7 +448,7 @@ func ParseLokiRequest(userID string, r *http.Request, limits Limits, tenantConfi
 			}
 
 			lb := labels.NewBuilder(lbs)
-			lbs = lb.Set(LabelServiceName, serviceName).Labels()
+			lbs = lb.Set(constants.ServiceLabelName, serviceName).Labels()
 		}
 
 		// Update labels. They were sanitized and potentially with the added service_name label.

--- a/pkg/loghttp/push/push_test.go
+++ b/pkg/loghttp/push/push_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/runtime"
+	"github.com/grafana/loki/v3/pkg/util/constants"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
 
@@ -255,7 +256,7 @@ func TestParseRequest(t *testing.T) {
 			expectedBytes:             map[string]int{"": len("fizzbuss")},
 			expectedLines:             map[string]int{"": 1},
 			expectedBytesUsageTracker: map[string]float64{`{foo="bar2", job="stuff", service_name="stuff"}`: float64(len("fizzbuss"))},
-			expectedLabels:            []labels.Labels{labels.FromStrings("foo", "bar2", "job", "stuff", LabelServiceName, "stuff")},
+			expectedLabels:            []labels.Labels{labels.FromStrings("foo", "bar2", "job", "stuff", constants.ServiceLabelName, "stuff")},
 		},
 		{
 			path:                      `/loki/api/v1/push`,
@@ -266,7 +267,7 @@ func TestParseRequest(t *testing.T) {
 			expectedBytes:             map[string]int{"": len("fizzbuzz")},
 			expectedLines:             map[string]int{"": 1},
 			expectedBytesUsageTracker: map[string]float64{`{foo="bar2", service_name="unknown_service"}`: float64(len("fizzbuss"))},
-			expectedLabels:            []labels.Labels{labels.FromStrings("foo", "bar2", LabelServiceName, ServiceUnknown)},
+			expectedLabels:            []labels.Labels{labels.FromStrings("foo", "bar2", constants.ServiceLabelName, ServiceUnknown)},
 		},
 		{
 			path:                      `/loki/api/v1/push`,
@@ -529,7 +530,7 @@ func Test_ServiceDetection(t *testing.T) {
 		data, _, err := ParseRequest(util_log.Logger, "fake", 100<<20, 100<<20, request, limits, nil, ParseLokiRequest, tracker, streamResolver, "", "loki")
 
 		require.NoError(t, err)
-		require.Equal(t, labels.FromStrings("foo", "bar", LabelServiceName, "bar").String(), data.Streams[0].Labels)
+		require.Equal(t, labels.FromStrings("foo", "bar", constants.ServiceLabelName, "bar").String(), data.Streams[0].Labels)
 	})
 
 	t.Run("detects service from OTLP push requests using default indexing", func(t *testing.T) {
@@ -540,7 +541,7 @@ func Test_ServiceDetection(t *testing.T) {
 		streamResolver := newMockStreamResolver("fake", limits)
 		data, _, err := ParseRequest(util_log.Logger, "fake", 100<<20, 100<<20, request, limits, nil, ParseOTLPRequest, tracker, streamResolver, "", "loki")
 		require.NoError(t, err)
-		require.Equal(t, labels.FromStrings("k8s_job_name", "bar", LabelServiceName, "bar").String(), data.Streams[0].Labels)
+		require.Equal(t, labels.FromStrings("k8s_job_name", "bar", constants.ServiceLabelName, "bar").String(), data.Streams[0].Labels)
 	})
 
 	t.Run("detects service from OTLP push requests using custom indexing", func(t *testing.T) {
@@ -555,7 +556,7 @@ func Test_ServiceDetection(t *testing.T) {
 		streamResolver := newMockStreamResolver("fake", limits)
 		data, _, err := ParseRequest(util_log.Logger, "fake", 100<<20, 100<<20, request, limits, nil, ParseOTLPRequest, tracker, streamResolver, "", "loki")
 		require.NoError(t, err)
-		require.Equal(t, labels.FromStrings("special", "sauce", LabelServiceName, "sauce").String(), data.Streams[0].Labels)
+		require.Equal(t, labels.FromStrings("special", "sauce", constants.ServiceLabelName, "sauce").String(), data.Streams[0].Labels)
 	})
 
 	t.Run("only detects custom service label from indexed labels", func(t *testing.T) {
@@ -570,7 +571,7 @@ func Test_ServiceDetection(t *testing.T) {
 		streamResolver := newMockStreamResolver("fake", limits)
 		data, _, err := ParseRequest(util_log.Logger, "fake", 100<<20, 100<<20, request, limits, nil, ParseOTLPRequest, tracker, streamResolver, "", "loki")
 		require.NoError(t, err)
-		require.Equal(t, labels.FromStrings(LabelServiceName, ServiceUnknown).String(), data.Streams[0].Labels)
+		require.Equal(t, labels.FromStrings(constants.ServiceLabelName, ServiceUnknown).String(), data.Streams[0].Labels)
 	})
 }
 

--- a/pkg/logproto/extensions.go
+++ b/pkg/logproto/extensions.go
@@ -213,11 +213,11 @@ func (m *QueryPatternsRequest) GetSampleQuery() (string, error) {
 		return "", nil
 	}
 
-	// Find service_name from matchers
+	// Find service label from matchers
 	var serviceName string
 	var serviceMatcher labels.MatchType
 	for i, m := range matchers {
-		if m.Name == "service_name" {
+		if m.Name == constants.ServiceLabelName {
 			matchers = slices.Delete(matchers, i, i+1)
 			serviceName = m.Value
 			serviceMatcher = m.Type

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -82,10 +82,11 @@ import (
 
 // Config is the root config for Loki.
 type Config struct {
-	Target       flagext.StringSliceCSV `yaml:"target,omitempty"`
-	AuthEnabled  bool                   `yaml:"auth_enabled,omitempty"`
-	HTTPPrefix   string                 `yaml:"http_prefix" doc:"hidden"`
-	BallastBytes int                    `yaml:"ballast_bytes"`
+	Target           flagext.StringSliceCSV `yaml:"target,omitempty"`
+	AuthEnabled      bool                   `yaml:"auth_enabled,omitempty"`
+	ServiceLabelName string                 `yaml:"service_label_name,omitempty"`
+	HTTPPrefix       string                 `yaml:"http_prefix" doc:"hidden"`
+	BallastBytes     int                    `yaml:"ballast_bytes"`
 
 	Server              server.Config              `yaml:"server,omitempty"`
 	InternalServer      internalserver.Config      `yaml:"internal_server,omitempty" doc:"hidden"`
@@ -159,6 +160,10 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&c.AuthEnabled, "auth.enabled", true,
 		"Enables authentication through the X-Scope-OrgID header, which must be present if true. "+
 			"If false, the OrgID will always be set to 'fake'.",
+	)
+	f.StringVar(&c.ServiceLabelName, "service-label-name", "service_name",
+		"The label name used for service name discovery. "+
+			"Changing this value will affect how service names are discovered, stored, and queried.",
 	)
 	f.IntVar(&c.BallastBytes, "config.ballast-bytes", 0,
 		"The amount of virtual memory in bytes to reserve as ballast in order to optimize garbage collection. "+

--- a/pkg/pattern/instance.go
+++ b/pkg/pattern/instance.go
@@ -356,7 +356,7 @@ func (i *instance) writeAggregatedMetrics(
 	level string,
 	totalBytes, totalCount uint64,
 ) {
-	service := streamLbls.Get(push.LabelServiceName)
+	service := streamLbls.Get(constants.ServiceLabelName)
 	if service == "" {
 		service = push.ServiceUnknown
 	}

--- a/pkg/pattern/stream.go
+++ b/pkg/pattern/stream.go
@@ -230,7 +230,7 @@ func (s *stream) writePattern(
 	count int64,
 	lvl string,
 ) {
-	service := streamLbls.Get(push.LabelServiceName)
+	service := streamLbls.Get(constants.ServiceLabelName)
 	if service == "" {
 		service = push.ServiceUnknown
 	}

--- a/pkg/util/constants/service.go
+++ b/pkg/util/constants/service.go
@@ -1,0 +1,5 @@
+package constants
+
+// ServiceLabelName is the configurable label name used for service name discovery.
+// It defaults to "service_name" and can be overridden via the -service-label-name flag.
+var ServiceLabelName = "service_name"


### PR DESCRIPTION
Add a `service_label_name` config option (flag: `-service-label-name`) to allow customizing the label name used for service name discovery. Defaults to "service_name" for backward compatibility.

This follows the same pattern as `auth_enabled`, living in the root Loki config rather than limits_config. The configured value is set as a global variable in `pkg/util/constants` at startup and used across the push, OTLP, distributor, pattern, and logproto packages.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new globally-configurable `service_label_name` that changes how Loki discovers, injects, validates, and queries the service label; misconfiguration could impact stream partitioning and queries relying on the previous `service_name` label.
> 
> **Overview**
> Adds a root-level `service_label_name` config/flag (`-service-label-name`, default `service_name`) and wires it into startup so the chosen label name becomes a global `constants.ServiceLabelName`.
> 
> Updates service-name discovery and handling to use this configurable label across ingestion paths (Loki push + OTLP), distributor label validation/segmentation, pattern/aggregated metrics labeling, and LogQL matcher extraction; tests are adjusted accordingly and the old hardcoded `LabelServiceName` constant is removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f26e9c3a84d0d44cc9ceaf643a7d26475fe3b53a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->