### PR TITLE
chore(tsdb): prune dead code

### DIFF
--- a/tools/tsdb/helpers/util.go
+++ b/tools/tsdb/helpers/util.go
@@ -10,15 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus/common/model"
-
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/types"
-)
-
-const (
-	daySeconds = int64(24 * time.Hour / time.Second)
 )
 
 // regexp for finding the trailing index bucket number at the end of table name
@@ -39,13 +33,6 @@ func extractTableNumberFromName(tableName string) (int64, error) {
 	}
 
 	return tableNumber, nil
-}
-func getActiveTableNumber() int64 {
-	return getTableNumberForTime(model.Now())
-}
-
-func getTableNumberForTime(t model.Time) int64 {
-	return t.Unix() / daySeconds
 }
 
 func GetPeriodConfigForTableNumber(table string, periodicConfigs []config.PeriodConfig) (config.PeriodConfig, config.TableRange, string, error) {


### PR DESCRIPTION
This removes two unused functions, a constant, and an import from `tools/tsdb/helpers`.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that only removes unused helpers and an unused dependency, with no behavior changes to live code paths.
> 
> **Overview**
> Removes unused time-to-table-number helpers (`daySeconds`, `getActiveTableNumber`, `getTableNumberForTime`) from `tools/tsdb/helpers/util.go` and drops the now-unneeded Prometheus `model` import.
> 
> No functional changes to the remaining TSDB helper routines; this is strictly dead-code pruning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d867b1dc7716febcae33eb6a676b375af1f0945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->