### PR TITLE
fix: allow S3 test to pass regardless of AWS config

### DIFF
--- a/pkg/storage/chunk/client/aws/s3_storage_client_test.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"syscall"
 	"testing"
@@ -29,6 +30,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
 )
+
+func TestMain(m *testing.M) {
+	// Prevent tests from loading the host's AWS config, which may have profiles
+	// that fail validation (e.g. SSO profiles missing required fields).
+	os.Setenv("AWS_CONFIG_FILE", "/dev/null")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/dev/null")
+	os.Exit(m.Run())
+}
 
 type RoundTripperFunc func(*http.Request) (*http.Response, error)
 


### PR DESCRIPTION
Users with invalid AWS config profile may be unable to run tests. This makes the tests more independent

**What this PR does / why we need it**:
The grafana tooling rewrites the AWS config file in a way which is not compatible with the loki S3 storage test.

This PR removes the external dependency making the test more pure/independent of it's environment.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that forces AWS SDK config/credentials files to `/dev/null` to avoid failures from invalid local AWS profiles.
> 
> **Overview**
> Adds a `TestMain` in `s3_storage_client_test.go` that sets `AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE` to `/dev/null` before running the suite, preventing S3 client tests from reading (and potentially failing on) the developer machine’s AWS configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73058d13e4ec7cc8fb1c6ff3536f3ed198ad9114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->