### PR TITLE
docs: Rename task results cache config

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -344,31 +344,31 @@ query_engine:
     # CLI flag: -query-engine.range-reads.min-range-size
     [min_range_size: <int> | default = 1048576]
 
-  tasks_result_cache:
+  task_results_cache:
     # The cache_config block configures the cache backend for a specific Loki
     # component.
     # The CLI flags prefix for this block configuration is:
-    # query-engine.tasks-result-cache
+    # query-engine.task-results-cache
     [cache: <cache_config>]
 
     # Use compression in cache. The default is an empty value '', which disables
     # compression. Supported values are: 'snappy' and ''.
-    # CLI flag: -query-engine.tasks-result-cache.compression
+    # CLI flag: -query-engine.task-results-cache.compression
     [compression: <string> | default = ""]
 
     # Experimental: Maximum size for a task result to be cacheable. 0 means only
     # empty responses are cached.
-    # CLI flag: -query-engine.tasks-result-cache.task-result-max-cacheable-size
+    # CLI flag: -query-engine.task-results-cache.task-result-max-cacheable-size
     [task_result_max_cacheable_size: <int> | default = 0B]
 
     # Experimental: Maximum size for a DataObjScan result to be cacheable. 0
     # means only empty responses are cached.
-    # CLI flag: -query-engine.tasks-result-cache.dataobjscan-result-max-cacheable-size
+    # CLI flag: -query-engine.task-results-cache.dataobjscan-result-max-cacheable-size
     [dataobjscan_result_max_cacheable_size: <int> | default = 0B]
 
     # Experimental: When enabled, the scheduler checks cached results at plan
     # time and prunes tasks whose cached result is known to be empty.
-    # CLI flag: -query-engine.tasks-result-cache.prune-empty-cached-tasks
+    # CLI flag: -query-engine.task-results-cache.prune-empty-cached-tasks
     [prune_empty_cached_tasks: <boolean> | default = false]
 
   # Experimental: Number of worker threads to spawn. Each worker thread runs one
@@ -2457,7 +2457,7 @@ The `cache_config` block configures the cache backend for a specific Loki compon
 - `frontend.series-results-cache`
 - `frontend.volume-results-cache`
 - `query-engine.results-cache`
-- `query-engine.tasks-result-cache`
+- `query-engine.task-results-cache`
 - `store.chunks-cache`
 - `store.chunks-cache-l2`
 - `store.index-cache-read`
@@ -7981,7 +7981,7 @@ The TLS configuration. The supported CLI flags `<prefix>` used to reference this
 - `querier.frontend-grpc-client`
 - `querier.scheduler-grpc-client`
 - `query-engine.results-cache.memcached`
-- `query-engine.tasks-result-cache.memcached`
+- `query-engine.task-results-cache.memcached`
 - `query-scheduler.grpc-client-config`
 - `query-scheduler.ring.etcd`
 - `reporting.tls-config`

--- a/pkg/engine/basic_engine.go
+++ b/pkg/engine/basic_engine.go
@@ -43,7 +43,7 @@ func NewBasic(cfg ExecutorConfig, ms metastore.Metastore, bucket objstore.Bucket
 		cfg.RangeConfig = rangeio.DefaultConfig
 	}
 
-	taskCaches, err := executor.NewTaskCacheRegistry(cfg.TasksResultCache.Config, reg, logger)
+	taskCaches, err := executor.NewTaskCacheRegistry(cfg.TaskResultsCache.Config, reg, logger)
 	if err != nil {
 		panic(fmt.Sprintf("creating task results cache: %v", err))
 	}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -80,8 +80,8 @@ type ExecutorConfig struct {
 	// When set, streams are filtered before scanning.
 	StreamFilterer executor.RequestStreamFilterer `yaml:"-"`
 
-	// TasksResultCache configures the backing cache for task results.
-	TasksResultCache TaskCacheConfig `yaml:"tasks_result_cache" category:"experimental"`
+	// TaskResultsCache configures the backing cache for task results.
+	TaskResultsCache TaskCacheConfig `yaml:"task_results_cache" category:"experimental"`
 }
 
 func (cfg *ExecutorConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
@@ -91,7 +91,7 @@ func (cfg *ExecutorConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSe
 	f.Var(&cfg.PrefetchBytes, prefix+"prefetch-bytes", "Experimental: Number of bytes to prefetch when opening a data object for decoding metadata and overlapping section reads. Clamps to at least 16KiB.")
 	f.IntVar(&cfg.MergePrefetchCount, prefix+"merge-prefetch-count", 0, "Experimental: The number of inputs that are prefetched simultaneously by any Merge node. A value of 0 means that only the currently processed input is prefetched, 1 means that only the next input is prefetched, and so on. A negative value means that all inputs are be prefetched in parallel.")
 	cfg.RangeConfig.RegisterFlags(prefix+"range-reads.", f)
-	cfg.TasksResultCache.RegisterFlagsWithPrefix(prefix+"tasks-result-cache.", f)
+	cfg.TaskResultsCache.RegisterFlagsWithPrefix(prefix+"task-results-cache.", f)
 }
 
 // TaskCacheConfig extends resultscache.Config with additional task-cache-specific settings.
@@ -167,9 +167,9 @@ func New(params Params) (*Engine, error) {
 	}
 
 	var taskCaches executor.TaskCacheRegistry
-	if params.Config.Executor.TasksResultCache.PruneEmptyCachedTasks {
+	if params.Config.Executor.TaskResultsCache.PruneEmptyCachedTasks {
 		var err error
-		taskCaches, err = executor.NewTaskCacheRegistry(params.Config.Executor.TasksResultCache.Config, params.Registerer, params.Logger)
+		taskCaches, err = executor.NewTaskCacheRegistry(params.Config.Executor.TaskResultsCache.Config, params.Registerer, params.Logger)
 		if err != nil {
 			return nil, fmt.Errorf("creating task cache registry: %w", err)
 		}
@@ -216,7 +216,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 		return logqlmodel.Result{}, httpgrpc.Error(http.StatusBadRequest, err.Error())
 	}
 
-	cacheEnabled := cache.IsCacheConfigured(e.cfg.Executor.TasksResultCache.CacheConfig) && !params.CachingOptions().Disabled
+	cacheEnabled := cache.IsCacheConfigured(e.cfg.Executor.TaskResultsCache.CacheConfig) && !params.CachingOptions().Disabled
 
 	ctx, span := xcap.StartSpan(ctx, tracer, "Engine.Execute",
 		trace.WithAttributes(
@@ -511,10 +511,10 @@ func (e *Engine) buildWorkflow(ctx context.Context, tenantID string, logger log.
 		MaxRunningOtherTasks: 0,
 
 		CacheEnabled:            cacheEnabled,
-		MaxTaskCacheSize:        uint64(e.cfg.Executor.TasksResultCache.TaskResultMaxCacheableSize),
-		MaxDataObjScanCacheSize: uint64(e.cfg.Executor.TasksResultCache.DataObjScanResultMaxCacheableSize),
-		CacheCompression:        e.cfg.Executor.TasksResultCache.Compression,
-		PruneEmptyCachedTasks:   e.cfg.Executor.TasksResultCache.PruneEmptyCachedTasks,
+		MaxTaskCacheSize:        uint64(e.cfg.Executor.TaskResultsCache.TaskResultMaxCacheableSize),
+		MaxDataObjScanCacheSize: uint64(e.cfg.Executor.TaskResultsCache.DataObjScanResultMaxCacheableSize),
+		CacheCompression:        e.cfg.Executor.TaskResultsCache.Compression,
+		PruneEmptyCachedTasks:   e.cfg.Executor.TaskResultsCache.PruneEmptyCachedTasks,
 		TaskCacheRegistry:       e.taskCaches,
 
 		DebugTasks:   e.limits.DebugEngineTasks(tenantID),

--- a/pkg/engine/worker.go
+++ b/pkg/engine/worker.go
@@ -124,7 +124,7 @@ func NewWorker(params WorkerParams, reg prometheus.Registerer) (*Worker, error) 
 		return nil, errors.New("either an advertise address or a local scheduler listener must be provided")
 	}
 
-	taskCaches, err := executor.NewTaskCacheRegistry(params.Executor.TasksResultCache.Config, reg, params.Logger)
+	taskCaches, err := executor.NewTaskCacheRegistry(params.Executor.TaskResultsCache.Config, reg, params.Logger)
 	if err != nil {
 		return nil, fmt.Errorf("creating task results cache: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Just fixing a typo :)

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renames a configuration block and its CLI flag prefix for the query engine task results cache, which can break existing deployments relying on the old names.
> 
> **Overview**
> Renames the query engine task results cache configuration from `tasks_result_cache`/`query-engine.tasks-result-cache` to `task_results_cache`/`query-engine.task-results-cache` across docs and engine initialization/flag registration (`ExecutorConfig`, `NewBasic`, and worker setup).
> 
> All internal references are updated to the new field name so task result caching behavior is unchanged aside from the external config/flag identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9be307490b96e4d6b3ee04167fbe63f38516f50a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->