### PR TITLE
docs(operator): Ingest storage arch support enhancement

### DIFF
--- a/operator/docs/enhancements/enhancement_process.md
+++ b/operator/docs/enhancements/enhancement_process.md
@@ -1,0 +1,67 @@
+---
+title: Enhancement Process
+authors:
+  - @JoaoBraveCoding
+creation-date: 2026-07-21
+last-updated: 2026-07-21
+state: published
+---
+
+## Summary
+
+Enhancement proposals describe significant changes to the Loki Operator — new features, API extensions, architectural decisions, and process changes. Each proposal tracks its lifecycle through a `state` field in its frontmatter, making it clear where an idea stands and whether it is ready to merge, implement, or abandon.
+
+## Metadata
+
+Every enhancement document must include a `state` field in its YAML frontmatter:
+
+```yaml
+---
+title: my-enhancement
+state: draft  # One of: draft, discussion, published, committed, abandoned
+authors:
+  - @author
+...
+---
+```
+
+## States
+
+An enhancement can be in one of the following five states:
+
+### draft
+
+Work in progress; not yet ready for formal review. The author is still iterating on the idea, gathering context, or filling in design details. This covers both early ideation and active authoring.
+
+### discussion
+
+Open for review, typically via a pull request. The proposal is sufficiently formed for feedback from reviewers and the broader team. Discussion happens on the PR and design meetings; the author incorporates feedback as appropriate.
+
+### published
+
+Reviewed and merged into the repository. The proposal represents an agreed-upon direction but has not yet been fully implemented. Published enhancements can still be updated through follow-up pull requests.
+
+### committed
+
+Fully implemented. The design described in the enhancement has been delivered in the operator. Changes to committed enhancements should be infrequent; significant divergences may warrant a new enhancement proposal.
+
+### abandoned
+
+Deliberately not implemented, or superseded by another proposal. Abandoned enhancements remain in the repository as a record of what was considered and why it was not pursued.
+
+## Lifecycle
+
+The typical flow between states:
+
+```
+draft → discussion → published → committed
+                  ↘ abandoned
+```
+
+- A new enhancement starts in **draft**.
+- When ready for review, move to **discussion** and open a pull request.
+- When the PR is approved and merged, move to **published**.
+- Once the feature is fully implemented, move to **committed**.
+- At any point before implementation, an enhancement can move to **abandoned** if the idea is rejected or superseded.
+
+When changing the state of an enhancement, update the `state` field in the frontmatter and the `last-updated` date.

--- a/operator/docs/enhancements/enhancement_template.md
+++ b/operator/docs/enhancements/enhancement_template.md
@@ -1,5 +1,6 @@
 ---
 title: neat-enhancement-idea
+state: draft  # One of: draft, discussion, published, committed, abandoned
 authors:
   - TBD
 reviewers: # Include a comment about what domain expertise a reviewer is expected to bring and what area of the enhancement you expect them to focus on. For example: - "@networkguru, for networking aspects, please look at IP bootstrapping aspect"

--- a/operator/docs/enhancements/ingest_storage_arch_support.md
+++ b/operator/docs/enhancements/ingest_storage_arch_support.md
@@ -1,0 +1,148 @@
+---
+title: Support Kafka-based Ingest Storage Architecture
+authors:
+  - @JoaoBraveCoding
+reviewers: 
+  - @xperimental
+  - @btaani
+creation-date: 2026-04-06
+last-updated: 2026-04-06
+tracking-link: 
+  - https://redhat.atlassian.net/browse/LOG-7377
+see-also:
+  - Initial working LokiStack + Kafka PoC:  https://github.com/grafana/loki/compare/main...JoaoBraveCoding:loki:LOG-7377-poc
+replaces:
+  - 
+superseded-by:
+  - 
+---
+
+## Summary
+
+Since the beginning of 2025, the Loki team has been working to align Loki with the new Mimir architecture around [Kafka/Warpstream](https://grafana.com/docs/mimir/latest/get-started/about-grafana-mimir-architecture/about-ingest-storage-architecture/).
+The new architecture is an improvement over the current model as it:
+
+- Increases reliability and resilience in the event of sudden spikes in query traffic or ingest volume
+- Decouples read and write paths to prevent performance interference
+
+The goal of this enhancement is to help the team define a path for the operator to migrate from the classical architecture to the new ingest storage architecture.
+
+## Motivation
+
+We should migrate to the new ingest storage architecture as this will not only bring to our users the improvements mentioned before, but it will also ensure the operator continues on the supported path. The Grafana Loki team has not officially commented on the deprecation of the classical architecture but we suspect this will come once Loki moves to release 4.0. There is a chance the classical architecture might continue to exist but it will mainly be maintained by members of the Loki community.
+
+### Goals
+
+Introduce API extensions that allow users to:
+
+- Remain on the classical architecture
+- Adopt the new ingest storage architecture
+
+### Non-Goals
+
+- Bundle a Kafka deployment into the operator.
+- Adopt the new `DataObj` format. The `DataObj` format requires the ingest storage architecture but is not a prerequisite for adopting it. Because of this, `DataObj` adoption should happen in a separate enhancement proposal to reduce the complexity of this one.
+
+## Proposal
+
+### Context
+
+#### Kafka taxonomy
+
+Apache Kafka is a distributed event streaming platform. At its core, it is a durable, ordered, append-only log. Producers write records to the end of the log, and consumers read from it at their own pace. Records are not deleted after consumption, they are retained for a configurable period, which means multiple consumers can read the same data independently.
+
+In Loki's context, Kafka acts as a buffer and durable write-ahead log between the distributor and the ingester. This decouples the write acknowledgment from ingester availability.
+
+Some important Kafka concepts to better understand this enhancement are:
+
+- Broker: A Kafka server process. A Kafka cluster consists of one or more brokers. Each broker stores a subset of the data and serves client requests. In production, you typically run 3+ brokers for fault tolerance.
+
+- Topic: A named category or feed to which records are published. A topic is a logical grouping, the actual data is split across partitions.
+
+- Partition: Partitions are ordered, immutable sequences of records. Partitions are the unit of parallelism: each partition can be consumed by exactly one consumer in a consumer group. More partitions = more parallelism.
+
+- Record: A single unit of data written to a partition. It consists of a key, a value (the payload), a timestamp, and optional headers.
+
+- Offset: A sequential ID assigned to each record within a partition. Consumers track their position using offsets. Offsets are committed to Kafka by consumers. This is how Kafka enables replay.
+
+- Producer: A client that writes records to a partition on a topic.
+
+- Consumer / Consumer Group: A client that reads records from partitions. A consumer group is a set of consumers that coordinate to divide partitions among themselves -- each partition is consumed by exactly one member of the group.
+
+#### Classical Architecture VS Ingest Storage Architecture
+
+In this section we will briefly compare the two architectures to better understand the differences both in the write path and in the read path.
+
+##### Write Path
+
+In the classical architecture, a distributor would write to a set of ingesters organized in a hash ring. A distributor determined the ingesters it should write to by hashing the stream labels in a log stream and then consulting the ingester ring. Once a quorum of ingesters confirms the write, the distributor moves on. Ingesters then collect log entries and eventually flush them to object storage as chunks with TSDB index entries. If an ingester dies, the ingester ring detects it via heartbeat timeout and the remaining ingesters take over its token ranges. If not enough ingesters remain to form a quorum, ingestion will stop. Distributors are independent from each other but have to sync with ingesters. Ingesters are independent of each other.
+The classical architecture ensured no data was lost via replication, a distributor would write to multiple ingesters.
+
+On the ingest storage architecture, each ingester joins both the classical ingester ring (for liveness and query routing) and a new partition ring (for Kafka partition assignment).
+The new partition ring tracks Kafka partitions and which ingester owns each one. Distributors hash stream labels and use the partition ring to find the active partition for that hash.
+So in the new architecture, the distributors (Kafka producers) write records (one or more serialized log streams) to Kafka partitions.
+Once Kafka confirms persistence of the record, the distributor acknowledges the write back to the client.
+Ingesters (Kafka consumers) read records from partitions and periodically commit their offset back to Kafka, allowing them to resume from where they left off after restarts or replacements.
+Ingesters collect log entries and eventually flush them to object storage as chunks with TSDB index entries.
+In the ingest storage architecture, replication is ensured through Kafka, when a write happens, Kafka replicates it to the other brokers. The compactor remains a necessary component for index compaction and retention.
+
+Partition Ring: The partition ring wraps the ingester ring for heartbeat/liveness checks. Each ingester maintains dual ring membership. The partition ring also supports shuffle sharding for tenant isolation -- instead of spreading a tenant's data across all partitions, each tenant can be assigned a small subset of partitions.
+
+Kafka Topic Partition Count: Loki can set partition count automatically, but Kafka 4.x no longer allows the number of partitions to be changed dynamically. This means the Kafka administrator must either pre-create the topic with the desired partition count or configure them afterwards before Loki starts. The partition count determines the maximum ingestion parallelism -- it should be at least equal to the number of ingesters, this is a prerequisite that in principle the operator will not be able to automate and should be documented.
+
+Summary Table:
+
+| Aspect | Classic Architecture | Ingest Storage Architecture |
+| ------ | -------------------- | --------------------------- |
+| **Write acknowledgment** | After quorum of ingesters confirm | After Kafka brokers confirm persistence |
+| **Write replication** | Loki replicates to N ingesters (default 3) | Kafka replicates internally |
+| **Ingester failure impact** | Write availability at risk | No write disruption |
+| **Deduplication** | Required (compactor deduplicates replicated blocks) | Not needed (single consumer per partition) |
+| **Scaling ingesters** | Complex (state transfer / hand-off) | Simple (reassign Kafka partitions) |
+| **Additional infrastructure** | None beyond Loki + object storage | Kafka cluster required |
+| **Read consistency** | Eventual (best-effort) | Configurable strong consistency via offset tracking |
+| **Rollout risk** | High (ingester restarts can break quorum, causing write failures) | Low (resume from Kafka offset) |
+
+##### Read Path
+
+Unlike the write path, the read path remains largely unchanged. The biggest difference is how the querier discovers ingesters.
+
+In the classic architecture, the querier discovers ingesters via the ingester ring. It then queries ingesters in the replication set and waits for a quorum of responses. It has to query multiple ingesters per hash range because with a replication factor higher than one, the same data exists on multiple ingesters. The querier waits for a quorum to ensure it possesses at least one copy of every stream even if some ingesters are slow or down.
+
+In the ingest storage architecture, the querier asks the partition ring instead. Via the partition ring it gets the relevant partitions for the tenant, which returns a replication set per partition (typically one ingester per partition in a single-zone setup). Since each partition is owned by exactly one ingester, the querier knows precisely which ingester has which data. This results in fewer requests, no duplicate data to merge, and no wasted work querying ingesters that don't hold relevant data.
+
+The Query Frontend and Index Gateway are completely unchanged.
+
+Summary Table:
+
+| Aspect | Classic Architecture | Ingest Storage Architecture |
+| ------ | -------------------- | --------------------------- |
+| **Ingester discovery** | Via ingester ring (all ingesters) | Via partition ring (only relevant ingesters) |
+| **Query fan-out** | Query all ingesters, wait for quorum | Query one ingester per partition, no quorum needed |
+| **Result deduplication** | Required (same data on multiple ingesters) | Not needed (single owner per partition) |
+| **Query Frontend** | Unchanged | Unchanged |
+| **Index Gateway** | Unchanged | Unchanged |
+
+### API Extensions
+
+
+### Implementation Details/Notes/Constraints [optional]
+
+
+
+### Risks and Mitigations
+
+
+## Design Details
+
+### Open Questions [optional]
+
+- If we have a running Loki cluster what is the recommendation for migrating it to the Ingest Storage Architecture? Shall we use dual-write capabilities or simply flip the switch?
+
+## Implementation History
+
+
+## Drawbacks
+
+
+## Alternatives

--- a/operator/docs/enhancements/ingest_storage_arch_support.md
+++ b/operator/docs/enhancements/ingest_storage_arch_support.md
@@ -84,7 +84,7 @@ When distributors (producers) want to write they hash the stream-labels and use 
 
 The partition ring also supports shuffle sharding for tenant isolation -- instead of spreading a tenant's data across all partitions, each tenant can be assigned a small subset of partitions.
 
-Kafka Topic Partition Count: Loki can set partition count automatically, but Kafka 4.x no longer allows the number of partitions to be changed dynamically. This means the Kafka administrator must either pre-create the topic with the desired partition count or configure them afterwards before Loki starts. The partition count determines the maximum number of ingesters, this is a prerequisite that in principle the operator will not be able to automate and should be documented.
+Kafka Topic Partition Count: Loki can set partition count automatically, but Kafka 4.x no longer allows the number of partitions to be changed dynamically. This means the Kafka administrator must either pre-create the topic with the desired partition count or configure them afterwards before Loki starts. The partition count determines the maximum number of ingesters, this is a prerequisite that in principle the operator will not be able to automate and should be documented. Note that Loki has no mechanism to handle Kafka reducing the number of partitions — if a partition that Loki is actively using is removed, writes and consumption for that partition will fail.
 
 ##### Write Path
 

--- a/operator/docs/enhancements/ingest_storage_arch_support.md
+++ b/operator/docs/enhancements/ingest_storage_arch_support.md
@@ -89,6 +89,7 @@ Kafka Topic Partition Count: Loki can set partition count automatically, but Kaf
 ##### Write Path
 
 In the classical architecture, a distributor would write to a set of ingesters organized in a hash ring. A distributor determined the ingesters it should write to by hashing the stream-labels in a log stream and then consulting the ingester ring. Once a quorum of ingesters confirms the write, the distributor moves on. Ingesters then collect log entries and eventually flush them to object storage as chunks with TSDB index entries. If an ingester dies, the ingester ring detects it via heartbeat timeout and the remaining ingesters take over its token ranges. If not enough ingesters remain to form a quorum, ingestion will stop. Distributors are independent from each other but have to sync with ingesters. Ingesters are independent of each other.
+Ingesters are able to enforce per-tenant limits since they receive streams directly from distributors.
 The classical architecture ensured no data was lost via replication, a distributor would write to multiple ingesters.
 
 On the ingest storage architecture, each ingester joins both the classical ingester ring (for liveness and query routing) and the new partition ring (for Kafka partition assignment).
@@ -96,6 +97,7 @@ So in the new architecture, the distributors (producers) write records (one or m
 Once Kafka confirms persistence of the record, the distributor acknowledges the write back to the client.
 Ingesters (consumers) read records from their partition and periodically commit their offset back to Kafka under their own consumer group. On startup, an ingester fetches the last committed offset for its consumer group and resumes consumption from that point, allowing seamless recovery after restarts or replacements.
 Ingesters collect log entries and eventually flush them to object storage as chunks with TSDB index entries. The TSDB index format remains the same as in the classical architecture.
+In the new architecture Ingesters are no longer in the write path. To enforce per-tenant ingestion limits, Loki introduces an optional `ingest-limits` component that the distributor queries before accepting writes. Without it, limits like maximum active streams per tenant are not enforced at ingestion time.
 In the ingest storage architecture, replication is ensured through Kafka. When a write happens, Kafka replicates it to the other brokers. Ingesters will always start reading from the last committed offset. The compactor remains a necessary component for index compaction and retention.
 
 Summary Table:
@@ -103,6 +105,7 @@ Summary Table:
 | Aspect | Classic Architecture | Ingest Storage Architecture |
 | ------ | -------------------- | --------------------------- |
 | **Write acknowledgment** | After quorum of ingesters confirm | After Kafka brokers confirm persistence |
+| **Per-tenant limits enforcement** | Ingesters enforce limits | Requires optional `ingest-limits` component |
 | **Write replication** | Loki replicates to replication-factor ingesters | Kafka replicates internally |
 | **Ingester failure impact** | Write availability at risk | No write disruption |
 | **Scaling ingesters** | Complex (state transfer / hand-off) | Simple (assign some traffic to the new Kafka partitions) |

--- a/operator/docs/enhancements/ingest_storage_arch_support.md
+++ b/operator/docs/enhancements/ingest_storage_arch_support.md
@@ -223,13 +223,132 @@ The Kafka partition 3 still exists but no ingester consumes from it. Any unconsu
 
 ### API Extensions
 
+The new API extensions are:
+
+- The addition of the IngestLimits component to `LokiTemplateSpec`.
+- The new `IngestStorage` struct, to hold all the configuration concerning the new architecture.
+
+#### New Component: `IngestLimits`
+
+```go
+type LokiTemplateSpec struct {
+	IngestLimits *LokiComponentSpec `json:"ingestLimits,omitempty"`
+}
+```
+
+#### New Field on `LokiStackSpec`
+
+```go
+type LokiStackSpec struct {
+	// IngestStorage defines the ingest storage architecture configuration.
+	// When not set, the classical architecture is used.
+	// When set, distributors write to Kafka and ingesters consume from it.
+	IngestStorage *IngestStorageSpec `json:"ingestStorage,omitempty"`
+}
+```
+
+#### `IngestStorageSpec`
+
+Currently only Kafka configuration, but this level of nesting allows future extensions (e.g., DataObj configuration) to be added as siblings without restructuring the API.
+
+```go
+type IngestStorageSpec struct {
+	// Kafka defines the connection configuration for a Kafka-compatible ingest storage backend
+	Kafka KafkaSpec `json:"kafka"`
+}
+```
+
+#### `KafkaSpec`
+
+```go
+type KafkaSpec struct {
+	// Topic is the Kafka topic name used for log ingestion.
+	// Defaults to "loki".
+	Topic string `json:"topic,omitempty"`
+
+	// Secret for Kafka connection and authentication.
+	// Name of a secret in the same namespace as the LokiStack custom resource.
+	Secret KafkaSecretSpec `json:"secret"`
+
+	// TLS configuration for the Kafka connection.
+	TLS *TLSSpec `json:"tls,omitempty"`
+}
+```
+
+The `TLS` field reuses the existing `TLSSpec` type which provides:
+
+- `CA *ValueReference` — CA certificate to verify the broker
+- `Certificate *ValueReference` — client certificate for mTLS authentication
+- `PrivateKey *SecretReference` — client private key for mTLS authentication
+
+#### `KafkaSecretSpec`
+
+```go
+type KafkaSecretSpec struct {
+	// Name of a secret in the same namespace as the LokiStack custom resource.
+	Name string `json:"name"`
+}
+```
+
+The referenced secret can contain the following keys:
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `readerAddress` | Always | Broker addresses for consumers (host:port, comma-separated) |
+| `writerAddress` | Always | Broker addresses for producers (host:port, comma-separated) |
+| `saslMechanism` | For SASL | One of `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512` |
+| `username` | For SASL | SASL username |
+| `password` | For SASL | SASL password |
+
+Authentication mode is inferred from the secret contents and TLS spec:
+
+- **No auth**: Secret contains only `readerAddress` and `writerAddress`
+- **SASL**: Secret additionally contains `saslMechanism`, `username`, and `password`
+- **mTLS**: Secret contains only addresses; `tls.certificate` and `tls.privateKey` are set in the spec
+
+#### Example CR
+
+```yaml
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: lokistack-dev
+spec:
+  size: 1x.demo
+  storage:
+    schemas:
+    - version: v13
+      effectiveDate: 2023-10-15
+    secret:
+      name: storage-secret
+      type: s3
+  ingestStorage:
+    kafka:
+      topic: loki-logs
+      secret:
+        name: kafka-credentials
+      tls:
+        ca:
+          key: ca.crt
+          secretName: my-cluster-cluster-ca-cert
+---
+# Kafka credentials secret
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kafka-credentials
+type: Opaque
+stringData:
+  readerAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
+  writerAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
+  saslMechanism: SCRAM-SHA-512
+  username: loki-user
+  password: secret-password
+```
 
 ### Implementation Details/Notes/Constraints [optional]
 
-
-
 ### Risks and Mitigations
-
 
 ## Design Details
 
@@ -239,8 +358,6 @@ The Kafka partition 3 still exists but no ingester consumes from it. Any unconsu
 
 ## Implementation History
 
-
 ## Drawbacks
-
 
 ## Alternatives

--- a/operator/docs/enhancements/ingest_storage_arch_support.md
+++ b/operator/docs/enhancements/ingest_storage_arch_support.md
@@ -11,6 +11,7 @@ tracking-link:
   - https://redhat.atlassian.net/browse/LOG-7377
 see-also:
   - Initial working LokiStack + Kafka PoC:  https://github.com/grafana/loki/compare/main...JoaoBraveCoding:loki:LOG-7377-poc
+  - API Implementation + Strimzi resources: https://github.com/grafana/loki/compare/main...JoaoBraveCoding:loki:LOG-7377-api
 replaces:
   - 
 superseded-by:
@@ -71,7 +72,7 @@ Some important Kafka concepts to better understand this enhancement are:
 
 #### Classical Architecture VS Ingest Storage Architecture
 
-In this section we will briefly compare the two architectures to better understand the differences both in the write path and in the read path. However first we will introduce the partition ring concept which is essential to understand the new architecture.
+In this section we will briefly compare the two architectures to better understand the differences both in the write path and in the read path. However, first we will introduce the partition ring concept which is essential to understand the new architecture.
 
 ##### Partition Ring
 
@@ -80,7 +81,7 @@ In the new ingest storage architecture there is a new membership ring called par
 - On a single zone deployment: each ingester maps to a single partition using their hostname. E.g `ingester-0 --> partition 0`
 - On multi zone deployments: ingesters in different zones map to the same partition, using their hostname. E.g `ingester-zone-a-0, ingester-zone-b-0, ingester-zone-c-0 --> partition 0`. All zone ingesters for the same partition consume from it independently, each using their own Kafka consumer group, and each committing offsets at their own pace.
 
-When distributors (producers) want to write they hash the stream-labels and use the partition ring to find the active partition for that hash. Once they know which partition they should write to distributors set the `Partition` field in the record and send the record to Kafka. Note that by setting the `Partition` field Loki is actively controlling how information is distributed instead of relying on Kafka.
+When distributors (producers) want to write they hash the stream-labels and use the partition ring to find the active partition for that hash. Once they know which partition they should write to, distributors set the `Partition` field in the record and send the record to Kafka. Note that by setting the `Partition` field Loki is actively controlling how information is distributed instead of relying on Kafka.
 
 The partition ring also supports shuffle sharding for tenant isolation -- instead of spreading a tenant's data across all partitions, each tenant can be assigned a small subset of partitions.
 
@@ -97,7 +98,7 @@ So in the new architecture, the distributors (producers) write records (one or m
 Once Kafka confirms persistence of the record, the distributor acknowledges the write back to the client.
 Ingesters (consumers) read records from their partition and periodically commit their offset back to Kafka under their own consumer group. On startup, an ingester fetches the last committed offset for its consumer group and resumes consumption from that point, allowing seamless recovery after restarts or replacements.
 Ingesters collect log entries and eventually flush them to object storage as chunks with TSDB index entries. The TSDB index format remains the same as in the classical architecture.
-In the new architecture Ingesters are no longer in the write path. To enforce per-tenant ingestion limits, Loki introduces an optional `ingest-limits` component that the distributor queries before accepting writes. Without it, limits like maximum active streams per tenant are not enforced at ingestion time.
+In the new architecture, ingesters are no longer in the write path. To enforce per-tenant ingestion limits, Loki introduces an optional `ingest-limits` component that the distributor queries before accepting writes. Without it, limits like maximum active streams per tenant are not enforced at ingestion time.
 In the ingest storage architecture, replication is ensured through Kafka. When a write happens, Kafka replicates it to the other brokers. Ingesters will always start reading from the last committed offset. The compactor remains a necessary component for index compaction and retention.
 
 Summary Table:
@@ -125,6 +126,9 @@ In the ingest storage architecture, each Kafka record represents one or more log
 The distributor determines the target partition by hashing the stream-labels. It then sets the partition number directly on the Kafka record, so Kafka honors the explicit partition and ignores the key. The tenant ID is set as the key purely as metadata.
 
 If a single stream exceeds the maximum record size (`producer_max_record_size_bytes`, ~15MB by default), it is automatically split into multiple records, each containing a subset of entries but sharing the same labels and hash.
+
+Records are sent to Kafka uncompressed. Loki does not configure producer-side compression, although the client it uses supports it.
+Kafka-side compression can be used independently to mitigate this.
 
 ##### Read Path
 
@@ -348,7 +352,29 @@ stringData:
 
 ### Implementation Details/Notes/Constraints [optional]
 
+#### Upstream Loki Kafka Client Limitations
+
+We identified two significant limitations in upstream Loki's Kafka client:
+
+1. **No TLS support**: The Kafka client does not call `kgo.DialTLSConfig()`, meaning it cannot connect to TLS-enabled Kafka listeners. All connections are plaintext. This prevents the operator from using Strimzi/AMQ Streams TLS listeners or mTLS authentication.
+
+2. **SASL/PLAIN only**: The client hardcodes `plain.Plain(...)` for SASL authentication. It does not support SCRAM-SHA-256, SCRAM-SHA-512, or OAUTHBEARER. Since Strimzi/AMQ Streams does not offer SASL/PLAIN as a listener authentication type we can only connect to Strimzi using no authentication. Upstream issue: [grafana/loki#21712](https://github.com/grafana/loki/issues/21712).
+
+#### Observability and Dashboards
+
+The operator deploys Prometheus recording rules and alerting rules for Loki components. The ingest storage architecture changes the write path and the read path, which may affect existing dashboard panels and alerts. Specifically:
+
+Investigation needs to be done to fully understand how to observe the new system and how the operator can customize the dashboards deployed depending on the architecture mode selected.
+
 ### Risks and Mitigations
+
+- Increase in resource requirements with the addition of Kafka
+  - A Strimzi cluster with 3 replicas with 1x.Demo was consuming 0.1 CPU and 1.8Gi. Further benchmarking needs to happen to better determine the impact
+- No backpressure from ingester consumption lag
+  - In the ingest storage architecture, the distributor writes to Kafka and has no awareness of whether ingesters are keeping up with consumption. If ingesters fall behind, records accumulate in Kafka - there is no mechanism to reject or throttle writes based on consumer lag.
+- Misconfiguration of the Kafka cluster
+  - We should write extensive documentation to support proper configuration
+  - If Kafka is temporarily unavailable, each distributor can buffer up to `producer_max_buffered_bytes` (default: 1GB) of unacknowledged records before it starts rejecting new writes.
 
 ## Design Details
 
@@ -357,6 +383,9 @@ stringData:
 - If we have a running Loki cluster what is the recommendation for migrating it to the Ingest Storage Architecture? Shall we use dual-write capabilities or simply flip the switch?
 
 ## Implementation History
+
+- Initial working LokiStack + Kafka PoC:  https://github.com/grafana/loki/compare/main...JoaoBraveCoding:loki:LOG-7377-poc
+- API Implementation + Strimzi resources: https://github.com/grafana/loki/compare/main...JoaoBraveCoding:loki:LOG-7377-api
 
 ## Drawbacks
 

--- a/operator/docs/enhancements/ingest_storage_arch_support.md
+++ b/operator/docs/enhancements/ingest_storage_arch_support.md
@@ -47,7 +47,7 @@ Introduce API extensions that allow users to:
 
 ### Context
 
-#### Kafka taxonomy
+#### Kafka Taxonomy
 
 Apache Kafka is a distributed event streaming platform. At its core, it is a durable, ordered, append-only log. Producers write records to the end of the log, and consumers read from it at their own pace. Records are not deleted after consumption, they are retained for a configurable period, which means multiple consumers can read the same data independently.
 
@@ -65,43 +65,63 @@ Some important Kafka concepts to better understand this enhancement are:
 
 - Offset: A sequential ID assigned to each record within a partition. Consumers track their position using offsets. Offsets are committed to Kafka by consumers. This is how Kafka enables replay.
 
-- Producer: A client that writes records to a partition on a topic.
+- Producer: A client that writes records to a partition on a topic. In Loki, each distributor is a producer.
 
-- Consumer / Consumer Group: A client that reads records from partitions. A consumer group is a set of consumers that coordinate to divide partitions among themselves -- each partition is consumed by exactly one member of the group.
+- Consumer / Consumer Group: A client that reads records from partitions. A consumer group is a set of consumers that coordinate to divide partitions among themselves -- each partition is consumed by exactly one member of the group. In Loki, each ingester is a consumer that uses its own consumer group (by default, the ingester's instance ID, e.g. `ingester-zone-a-0`). This means each ingester tracks its own offset independently — in a multi-zone deployment, all zone ingesters consume the same partition in parallel, each at their own pace, because they belong to different consumer groups.
 
 #### Classical Architecture VS Ingest Storage Architecture
 
-In this section we will briefly compare the two architectures to better understand the differences both in the write path and in the read path.
+In this section we will briefly compare the two architectures to better understand the differences both in the write path and in the read path. However first we will introduce the partition ring concept which is essential to understand the new architecture.
+
+##### Partition Ring
+
+In the new ingest storage architecture there is a new membership ring called partition ring. The partition ring wraps the ingester ring for heartbeat/liveness checks and each ingester maintains dual ring membership. The new partition ring tracks Kafka partitions and which ingester owns each one.
+
+- On a single zone deployment: each ingester maps to a single partition using their hostname. E.g `ingester-0 --> partition 0`
+- On multi zone deployments: ingesters in different zones map to the same partition, using their hostname. E.g `ingester-zone-a-0, ingester-zone-b-0, ingester-zone-c-0 --> partition 0`. All zone ingesters for the same partition consume from it independently, each using their own Kafka consumer group, and each committing offsets at their own pace.
+
+When distributors (producers) want to write they hash the stream-labels and use the partition ring to find the active partition for that hash. Once they know which partition they should write to distributors set the `Partition` field in the record and send the record to Kafka. Note that by setting the `Partition` field Loki is actively controlling how information is distributed instead of relying on Kafka.
+
+The partition ring also supports shuffle sharding for tenant isolation -- instead of spreading a tenant's data across all partitions, each tenant can be assigned a small subset of partitions.
+
+Kafka Topic Partition Count: Loki can set partition count automatically, but Kafka 4.x no longer allows the number of partitions to be changed dynamically. This means the Kafka administrator must either pre-create the topic with the desired partition count or configure them afterwards before Loki starts. The partition count determines the maximum number of ingesters, this is a prerequisite that in principle the operator will not be able to automate and should be documented.
 
 ##### Write Path
 
-In the classical architecture, a distributor would write to a set of ingesters organized in a hash ring. A distributor determined the ingesters it should write to by hashing the stream labels in a log stream and then consulting the ingester ring. Once a quorum of ingesters confirms the write, the distributor moves on. Ingesters then collect log entries and eventually flush them to object storage as chunks with TSDB index entries. If an ingester dies, the ingester ring detects it via heartbeat timeout and the remaining ingesters take over its token ranges. If not enough ingesters remain to form a quorum, ingestion will stop. Distributors are independent from each other but have to sync with ingesters. Ingesters are independent of each other.
+In the classical architecture, a distributor would write to a set of ingesters organized in a hash ring. A distributor determined the ingesters it should write to by hashing the stream-labels in a log stream and then consulting the ingester ring. Once a quorum of ingesters confirms the write, the distributor moves on. Ingesters then collect log entries and eventually flush them to object storage as chunks with TSDB index entries. If an ingester dies, the ingester ring detects it via heartbeat timeout and the remaining ingesters take over its token ranges. If not enough ingesters remain to form a quorum, ingestion will stop. Distributors are independent from each other but have to sync with ingesters. Ingesters are independent of each other.
 The classical architecture ensured no data was lost via replication, a distributor would write to multiple ingesters.
 
-On the ingest storage architecture, each ingester joins both the classical ingester ring (for liveness and query routing) and a new partition ring (for Kafka partition assignment).
-The new partition ring tracks Kafka partitions and which ingester owns each one. Distributors hash stream labels and use the partition ring to find the active partition for that hash.
-So in the new architecture, the distributors (Kafka producers) write records (one or more serialized log streams) to Kafka partitions.
+On the ingest storage architecture, each ingester joins both the classical ingester ring (for liveness and query routing) and the new partition ring (for Kafka partition assignment).
+So in the new architecture, the distributors (producers) write records (one or more serialized log streams) to Kafka partitions.
 Once Kafka confirms persistence of the record, the distributor acknowledges the write back to the client.
-Ingesters (Kafka consumers) read records from partitions and periodically commit their offset back to Kafka, allowing them to resume from where they left off after restarts or replacements.
-Ingesters collect log entries and eventually flush them to object storage as chunks with TSDB index entries.
-In the ingest storage architecture, replication is ensured through Kafka, when a write happens, Kafka replicates it to the other brokers. The compactor remains a necessary component for index compaction and retention.
-
-Partition Ring: The partition ring wraps the ingester ring for heartbeat/liveness checks. Each ingester maintains dual ring membership. The partition ring also supports shuffle sharding for tenant isolation -- instead of spreading a tenant's data across all partitions, each tenant can be assigned a small subset of partitions.
-
-Kafka Topic Partition Count: Loki can set partition count automatically, but Kafka 4.x no longer allows the number of partitions to be changed dynamically. This means the Kafka administrator must either pre-create the topic with the desired partition count or configure them afterwards before Loki starts. The partition count determines the maximum ingestion parallelism -- it should be at least equal to the number of ingesters, this is a prerequisite that in principle the operator will not be able to automate and should be documented.
+Ingesters (consumers) read records from their partition and periodically commit their offset back to Kafka under their own consumer group. On startup, an ingester fetches the last committed offset for its consumer group and resumes consumption from that point, allowing seamless recovery after restarts or replacements.
+Ingesters collect log entries and eventually flush them to object storage as chunks with TSDB index entries. The TSDB index format remains the same as in the classical architecture.
+In the ingest storage architecture, replication is ensured through Kafka. When a write happens, Kafka replicates it to the other brokers. Ingesters will always start reading from the last committed offset. The compactor remains a necessary component for index compaction and retention.
 
 Summary Table:
 
 | Aspect | Classic Architecture | Ingest Storage Architecture |
 | ------ | -------------------- | --------------------------- |
 | **Write acknowledgment** | After quorum of ingesters confirm | After Kafka brokers confirm persistence |
-| **Write replication** | Loki replicates to N ingesters (default 3) | Kafka replicates internally |
+| **Write replication** | Loki replicates to replication-factor ingesters | Kafka replicates internally |
 | **Ingester failure impact** | Write availability at risk | No write disruption |
-| **Deduplication** | Required (compactor deduplicates replicated blocks) | Not needed (single consumer per partition) |
-| **Scaling ingesters** | Complex (state transfer / hand-off) | Simple (reassign Kafka partitions) |
+| **Scaling ingesters** | Complex (state transfer / hand-off) | Simple (assign some traffic to the new Kafka partitions) |
 | **Additional infrastructure** | None beyond Loki + object storage | Kafka cluster required |
-| **Read consistency** | Eventual (best-effort) | Configurable strong consistency via offset tracking |
 | **Rollout risk** | High (ingester restarts can break quorum, causing write failures) | Low (resume from Kafka offset) |
+
+###### Record Structure
+
+In the ingest storage architecture, each Kafka record represents one or more log streams for a single tenant. The record structure is:
+
+| Field | Value |
+| ----- | ----- |
+| **Key** | Tenant ID (used for identification, not for partitioning) |
+| **Value** | Protobuf-serialized `logproto.Stream` containing: stream-labels (string), log entries (timestamp + line + structured metadata), and a stream hash |
+| **Partition** | Explicitly set by Loki via the partition ring |
+
+The distributor determines the target partition by hashing the stream-labels. It then sets the partition number directly on the Kafka record, so Kafka honors the explicit partition and ignores the key. The tenant ID is set as the key purely as metadata.
+
+If a single stream exceeds the maximum record size (`producer_max_record_size_bytes`, ~15MB by default), it is automatically split into multiple records, each containing a subset of entries but sharing the same labels and hash.
 
 ##### Read Path
 
@@ -109,7 +129,7 @@ Unlike the write path, the read path remains largely unchanged. The biggest diff
 
 In the classic architecture, the querier discovers ingesters via the ingester ring. It then queries ingesters in the replication set and waits for a quorum of responses. It has to query multiple ingesters per hash range because with a replication factor higher than one, the same data exists on multiple ingesters. The querier waits for a quorum to ensure it possesses at least one copy of every stream even if some ingesters are slow or down.
 
-In the ingest storage architecture, the querier asks the partition ring instead. Via the partition ring it gets the relevant partitions for the tenant, which returns a replication set per partition (typically one ingester per partition in a single-zone setup). Since each partition is owned by exactly one ingester, the querier knows precisely which ingester has which data. This results in fewer requests, no duplicate data to merge, and no wasted work querying ingesters that don't hold relevant data.
+In the ingest storage architecture, the querier asks the partition ring instead. Via the partition ring it gets the relevant partitions for the tenant, which returns a replication set per partition. In a single-zone setup this is one ingester per partition; in a multi-zone setup it includes one ingester per zone per partition, but the querier only needs one successful response (the data is identical across zones). Since partition ownership is deterministic, the querier knows precisely which ingester(s) hold which data. This results in fewer requests, no duplicate data to merge, and no wasted work querying ingesters that don't hold relevant data.
 
 The Query Frontend and Index Gateway are completely unchanged.
 
@@ -117,11 +137,86 @@ Summary Table:
 
 | Aspect | Classic Architecture | Ingest Storage Architecture |
 | ------ | -------------------- | --------------------------- |
-| **Ingester discovery** | Via ingester ring (all ingesters) | Via partition ring (only relevant ingesters) |
-| **Query fan-out** | Query all ingesters, wait for quorum | Query one ingester per partition, no quorum needed |
-| **Result deduplication** | Required (same data on multiple ingesters) | Not needed (single owner per partition) |
-| **Query Frontend** | Unchanged | Unchanged |
-| **Index Gateway** | Unchanged | Unchanged |
+| **Ingester discovery** | Via ingester ring (all ingesters) | Via partition ring (only partition owners, one per zone) |
+| **Query fan-out** | Query all ingesters, wait for quorum | Query partition owners, need only one successful response per partition |
+| **Result deduplication** | Required (multiple ingesters write the same data with different chunk boundaries, querier must merge and deduplicate) | Not needed (consumers of the same partition produce byte-identical, content-addressed chunks; querier needs only one successful response per partition) |
+| **Read consistency** | Eventual (best-effort) | Eventual (best-effort) |
+
+##### Scaling Ingesters
+
+###### Scaling Up
+
+Partition assignment is static and hostname-based: `ingester-N` owns Kafka partition N. Each ingester owns exactly one partition. The Kafka topic may have many more partitions than ingesters, but only N partitions are ACTIVE at any time (one per ingester).
+
+Two flags control when a PENDING partition transitions to ACTIVE:
+
+- `max_consumer_lag_at_startup` (default: 15s): When an ingester starts, it replays records from Kafka starting at its last committed offset. The ingester repeatedly reads until the gap between the latest produced offset and the last processed offset represents less than this threshold of time. Only then does the ingester pass its readiness check. This ensures the ingester has caught up with the Kafka partition before serving queries.
+
+- `min_partition_owners_count` (default: 1): The minimum number of owners that must be registered in the partition ring before the partition transitions from PENDING to ACTIVE. Each owner must have been registered for at least `min_partition_owners_duration` (default: 10s). In a multi-zone deployment, this should be increased to match (or approximate) the number of zones to ensure read redundancy is established before the partition starts receiving writes.
+
+Consider a cluster with 3 ingesters:
+
+```
+Before (3 active partitions out of many in Kafka):
+  ingester-0 → partition 0 (ACTIVE)
+  ingester-1 → partition 1 (ACTIVE)
+  ingester-2 → partition 2 (ACTIVE)
+```
+
+When `ingester-3` joins:
+
+1. `ingester-3` registers in both the ingester ring (liveness) and the partition ring, claiming partition 3
+2. Partition 3 starts in PENDING state
+3. `ingester-3` begins consuming from Kafka partition 3, replaying from the last committed offset to catch up
+4. Once the consumer lag is within the configured threshold (`max_consumer_lag_at_startup`, default 15s) and the minimum ownership duration has elapsed (`min_partition_owners_duration`, default 10s), partition 3 transitions to ACTIVE
+
+```
+After (4 active partitions):
+  ingester-0 → partition 0 (ACTIVE)
+  ingester-1 → partition 1 (ACTIVE)
+  ingester-2 → partition 2 (ACTIVE)
+  ingester-3 → partition 3 (ACTIVE)
+```
+
+**Write path impact**: While partition 3 is PENDING, `ActivePartitionForKey()` skips it and distributors continue routing to partitions 0, 1, 2. Once partition 3 becomes ACTIVE, distributors see the updated ring and some streams begin routing to partition 3. No writes are lost during the transition because Kafka decouples writes from consumption.
+
+**Read path impact**: When partition 3's tokens enter the ring, some streams that previously hashed to partitions 0, 1, or 2 now hash to partition 3. However, `ingester-3` has no historical data for those streams — it only sees new writes going forward. The historical data is still in the memory of the ingesters that owned the old partitions. Since all old partitions (0, 1, 2) remain ACTIVE, queriers continue querying them alongside partition 3 via the lookback window (`ShuffleShardWithLookback`, controlled by `query_ingesters_within`, default: 3h), which ensures that partitions whose state recently changed remain included in the query set. This prevents gaps during the transition. Once the old ingesters have flushed their in-memory data to object storage, queriers serve historical data from there.
+
+###### Scaling Down
+
+Consider a cluster with 4 ingesters:
+
+```
+Before (4 active partitions):
+  ingester-0 → partition 0 (ACTIVE)
+  ingester-1 → partition 1 (ACTIVE)
+  ingester-2 → partition 2 (ACTIVE)
+  ingester-3 → partition 3 (ACTIVE)
+```
+
+**Graceful shutdown** of `ingester-3`:
+
+1. `ingester-3` receives a shutdown signal and calls its `prepare-downscale` endpoint
+2. Partition 3 transitions to INACTIVE in the partition ring
+3. `ActivePartitionForKey()` skips INACTIVE partitions, so distributors reroute streams that would have gone to partition 3 to one of the remaining ACTIVE partitions (0, 1, or 2)
+4. `ingester-3` stops consuming from Kafka, then flushes its in-memory chunks to object storage as part of the lifecycler shutdown, and exits
+5. The INACTIVE partition entry remains in the ring for a grace period (default 13h) and is eventually removed
+
+```
+After (3 active partitions):
+  ingester-0 → partition 0 (ACTIVE)
+  ingester-1 → partition 1 (ACTIVE)
+  ingester-2 → partition 2 (ACTIVE)
+  partition 3: INACTIVE, no consumer
+```
+
+The Kafka partition 3 still exists but no ingester consumes from it. Any unconsumed records in partition 3 remain in Kafka until Kafka's retention period expires. Streams that previously hashed to partition 3 are rerouted to whichever ACTIVE partition is next in the ring for their hash key.
+
+**Write path impact**: Writes are immediately rerouted away from partition 3. Since no ingester will consume from it, any writes that were not processed will be lost when Kafka's retention expires unless the partition is claimed again (e.g., by scaling back up).
+
+**Read path impact**: Before shutting down, `ingester-3` flushes its in-memory data to object storage. After the flush, queriers serve all historical data from object storage.
+
+**Crash scenario**: If `ingester-3` crashes instead of shutting down gracefully, partition 3 remains ACTIVE in the partition ring — no component changes its state since the lifecycler runs on the ingester itself. Distributors continue writing to Kafka partition 3 as normal, which is safe because writes go to Kafka, not to the ingester directly. Records simply accumulate in the Kafka partition until `ingester-3` comes back. When `ingester-3` restarts, it resumes consuming from the last committed Kafka offset, replaying all records that accumulated during the downtime. Data consumed before the crash but not yet flushed to object storage is recovered from the WAL if persistent volumes are used.
 
 ### API Extensions
 

--- a/operator/docs/enhancements/ingest_storage_arch_support.md
+++ b/operator/docs/enhancements/ingest_storage_arch_support.md
@@ -12,6 +12,7 @@ tracking-link:
 see-also:
   - Initial working LokiStack + Kafka PoC:  https://github.com/grafana/loki/compare/main...JoaoBraveCoding:loki:LOG-7377-poc
   - API Implementation + Strimzi resources: https://github.com/grafana/loki/compare/main...JoaoBraveCoding:loki:LOG-7377-api
+  - ADR 004 Tempo and Loki architecture change with Kafka: https://docs.google.com/document/d/1JP6DZW8qfaJkxw5SMmhmmQ69DdDYF4n8Tmo9kSBZJPM
 replaces:
   - 
 superseded-by:
@@ -30,7 +31,7 @@ The goal of this enhancement is to help the team define a path for the operator 
 
 ## Motivation
 
-We should migrate to the new ingest storage architecture as this will not only bring to our users the improvements mentioned before, but it will also ensure the operator continues on the supported path. The Grafana Loki team has not officially commented on the deprecation of the classical architecture but we suspect this will come once Loki moves to release 4.0. There is a chance the classical architecture might continue to exist but it will mainly be maintained by members of the Loki community.
+We should migrate to the new ingest storage architecture as this will not only bring to our users the improvements mentioned before, but it will also ensure the operator continues on the supported path. The Grafana Loki team has not officially commited to a deprecation date/target of the classical architecture but we suspect this will come once Loki moves to release 5.0. There is a chance the classical architecture might continue to exist but it will mainly be maintained by members of the Loki community.
 
 ### Goals
 
@@ -123,12 +124,27 @@ In the ingest storage architecture, each Kafka record represents one or more log
 | **Value** | Protobuf-serialized `logproto.Stream` containing: stream-labels (string), log entries (timestamp + line + structured metadata), and a stream hash |
 | **Partition** | Explicitly set by Loki via the partition ring |
 
-The distributor determines the target partition by hashing the stream-labels. It then sets the partition number directly on the Kafka record, so Kafka honors the explicit partition and ignores the key. The tenant ID is set as the key purely as metadata.
-
 If a single stream exceeds the maximum record size (`producer_max_record_size_bytes`, ~15MB by default), it is automatically split into multiple records, each containing a subset of entries but sharing the same labels and hash.
 
 Records are sent to Kafka uncompressed. Loki does not configure producer-side compression, although the client it uses supports it.
 Kafka-side compression can be used independently to mitigate this.
+
+###### Ingest Limits
+
+In the classical architecture, ingesters sit in the write path and enforce limits like max active streams per tenant locally. With ingest storage, distributors write to Kafka and ingesters consume asynchronously, so ingesters are no longer a reliable place to reject writes at ingestion time. Ingest-limits fills that gap: distributors call it before writing to Kafka.
+
+The component has two parts:
+
+- **ingest-limits-frontend**: Stateless router/aggregator; fans out requests to backend instances.
+- **ingest-limits**: Stateful backend; tracks active streams per tenant in memory.
+
+On each push, the distributor sends stream metadata (hash, size, ingestion policy) to the frontend, which routes each stream to the backend instance that owns its metadata partition (`streamHash % num_partitions`). The backend accepts or rejects streams against the tenant's max active stream limit. A stream is considered active if it was seen within the active window (default: 2h). The global limit (`max_global_streams_per_user`) is sharded across partitions, so each backend enforces `limit / num_partitions` for its share.
+
+The backend builds and replicates state via a dedicated Kafka metadata topic (separate from the log ingest topic). Unlike ingesters, which use static hostname-based partition assignment, ingest-limits uses Kafka consumer-group rebalancing to distribute metadata partitions across instances. The user would need to provision this additional topic.
+
+At the time of this writing, ingest-limits enforces max active streams per tenant only. Distributors continue to apply local byte-rate limiting (`ingestion_rate_mb`).
+
+The system is designed to fail open. If ingest-limits is unavailable, or individual streams cannot be checked, distributors accept those streams rather than blocking ingestion.
 
 ##### Read Path
 
@@ -203,11 +219,12 @@ Before (4 active partitions):
 
 **Graceful shutdown** of `ingester-3`:
 
-1. `ingester-3` receives a shutdown signal and calls its `prepare-downscale` endpoint
+1. Call the endpoint `prepare_partition_downscale` on `ingester-3`
 2. Partition 3 transitions to INACTIVE in the partition ring
 3. `ActivePartitionForKey()` skips INACTIVE partitions, so distributors reroute streams that would have gone to partition 3 to one of the remaining ACTIVE partitions (0, 1, or 2)
-4. `ingester-3` stops consuming from Kafka, then flushes its in-memory chunks to object storage as part of the lifecycler shutdown, and exits
-5. The INACTIVE partition entry remains in the ring for a grace period (default 13h) and is eventually removed
+4. `ingester-3` continues consuming from Kafka
+5. `ingester-3` receives the shutdown signal and flushes its in-memory chunks to object storage as part of the lifecycler shutdown, and exits
+6. The INACTIVE partition entry remains in the ring for a grace period (default 13h) and is eventually removed
 
 ```
 After (3 active partitions):
@@ -217,9 +234,7 @@ After (3 active partitions):
   partition 3: INACTIVE, no consumer
 ```
 
-The Kafka partition 3 still exists but no ingester consumes from it. Any unconsumed records in partition 3 remain in Kafka until Kafka's retention period expires. Streams that previously hashed to partition 3 are rerouted to whichever ACTIVE partition is next in the ring for their hash key.
-
-**Write path impact**: Writes are immediately rerouted away from partition 3. Since no ingester will consume from it, any writes that were not processed will be lost when Kafka's retention expires unless the partition is claimed again (e.g., by scaling back up).
+**Write path impact**: New writes are immediately rerouted away from partition 3 and consumed by the remaining ingesters. ingester-3 continues consuming only the backlog already present in Kafka partition 3 until shutdown. If it shuts down before that backlog is fully consumed and committed, those records are orphaned and will be lost when Kafka retention expires.
 
 **Read path impact**: Before shutting down, `ingester-3` flushes its in-memory data to object storage. After the flush, queriers serve all historical data from object storage.
 
@@ -229,14 +244,24 @@ The Kafka partition 3 still exists but no ingester consumes from it. Any unconsu
 
 The new API extensions are:
 
-- The addition of the IngestLimits component to `LokiTemplateSpec`.
+- The addition of the `IngestLimits` component to `LokiTemplateSpec`.
 - The new `IngestStorage` struct, to hold all the configuration concerning the new architecture.
 
-#### New Component: `IngestLimits`
+Note some of the details regarding `IngestStorage` have been agreen in the context of [ADR 004 Tempo and Loki architecture change with Kafka](https://docs.google.com/document/d/1JP6DZW8qfaJkxw5SMmhmmQ69DdDYF4n8Tmo9kSBZJPM) to align both Loki Operator and Tempo Operator in terms of API when interacting with Kafka.
+
+#### New Components: `IngestLimits` and `IngestLimitsFrontend`
+
+The ingest-limits system consists of two separate workloads with different characteristics:
+
+- **ingest-limits** (backend): Stateful; tracks active streams per tenant in memory using a dedicated Kafka metadata topic.
+- **ingest-limits-frontend**: Stateless router/aggregator; fans out requests from distributors to the correct backend instances.
+
+Because they scale independently and have different resource profiles, each gets its own field in `LokiTemplateSpec`:
 
 ```go
 type LokiTemplateSpec struct {
-	IngestLimits *LokiComponentSpec `json:"ingestLimits,omitempty"`
+	IngestLimits         *LokiComponentSpec `json:"ingestLimits,omitempty"`
+	IngestLimitsFrontend *LokiComponentSpec `json:"ingestLimitsFrontend,omitempty"`
 }
 ```
 
@@ -270,9 +295,20 @@ type KafkaSpec struct {
 	// Defaults to "loki".
 	Topic string `json:"topic,omitempty"`
 
-	// Secret for Kafka connection and authentication.
-	// Name of a secret in the same namespace as the LokiStack custom resource.
-	Secret KafkaSecretSpec `json:"secret"`
+	// MetadataTopic is the Kafka topic name used by the ingest-limits component
+	// to track stream metadata. If not set, defaults to "{Topic}-metadata".
+	MetadataTopic string `json:"metadataTopic,omitempty"`
+
+	// ReaderAddress defines the broker addresses for consumers (host:port, comma-separated).
+	ReaderAddress string `json:"readerAddress"`
+
+	// WriterAddress defines the broker addresses for producers (host:port, comma-separated).
+	WriterAddress string `json:"writerAddress"`
+
+	// Authentication for Kafka SASL authentication.
+	// For mTLS authentication, configure the certificate and privateKey
+	// fields in the TLS spec instead.
+	Authentication *KafkaAuthenticationSpec `json:"authentication,omitempty"`
 
 	// TLS configuration for the Kafka connection.
 	TLS *TLSSpec `json:"tls,omitempty"`
@@ -285,30 +321,40 @@ The `TLS` field reuses the existing `TLSSpec` type which provides:
 - `Certificate *ValueReference` — client certificate for mTLS authentication
 - `PrivateKey *SecretReference` — client private key for mTLS authentication
 
-#### `KafkaSecretSpec`
+#### `KafkaSASLMechanism`
 
 ```go
-type KafkaSecretSpec struct {
-	// Name of a secret in the same namespace as the LokiStack custom resource.
-	Name string `json:"name"`
+type KafkaSASLMechanism string
+
+const (
+	KafkaSASLMechanismPlain       KafkaSASLMechanism = "PLAIN"
+	KafkaSASLMechanismSCRAMSHA256 KafkaSASLMechanism = "SCRAM-SHA-256"
+	KafkaSASLMechanismSCRAMSHA512 KafkaSASLMechanism = "SCRAM-SHA-512"
+)
+```
+
+#### `KafkaAuthenticationSpec`
+
+```go
+type KafkaAuthenticationSpec struct {
+	// SASLMechanism defines the SASL mechanism to use for authentication.
+	SASLMechanism KafkaSASLMechanism `json:"saslMechanism"`
+
+	// Username is a reference to the key in a Secret containing the SASL username.
+	Username *SecretReference `json:"username"`
+
+	// Password is a reference to the key in a Secret containing the SASL password.
+	Password *SecretReference `json:"password"`
 }
 ```
 
-The referenced secret can contain the following keys:
+Each `SecretReference` points to a specific key in a specific Secret, allowing the username and password to live in separate secrets or share one.
 
-| Key | Required | Description |
-|-----|----------|-------------|
-| `readerAddress` | Always | Broker addresses for consumers (host:port, comma-separated) |
-| `writerAddress` | Always | Broker addresses for producers (host:port, comma-separated) |
-| `saslMechanism` | For SASL | One of `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512` |
-| `username` | For SASL | SASL username |
-| `password` | For SASL | SASL password |
+Authentication mode is inferred from the spec:
 
-Authentication mode is inferred from the secret contents and TLS spec:
-
-- **No auth**: Secret contains only `readerAddress` and `writerAddress`
-- **SASL**: Secret additionally contains `saslMechanism`, `username`, and `password`
-- **mTLS**: Secret contains only addresses; `tls.certificate` and `tls.privateKey` are set in the spec
+- **No auth**: `authentication` is not set, no TLS client certificate
+- **SASL**: `authentication` is set with `saslMechanism`, `username`, and `password`
+- **mTLS**: `authentication` is not set; `tls.certificate` and `tls.privateKey` are configured in the spec
 
 #### Example CR
 
@@ -329,8 +375,16 @@ spec:
   ingestStorage:
     kafka:
       topic: loki-logs
-      secret:
-        name: kafka-credentials
+      readerAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
+      writerAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
+      authentication:
+        saslMechanism: SCRAM-SHA-512
+        username:
+          key: username
+          secretName: kafka-credentials
+        password:
+          key: password
+          secretName: kafka-credentials
       tls:
         ca:
           key: ca.crt
@@ -343,9 +397,6 @@ metadata:
   name: kafka-credentials
 type: Opaque
 stringData:
-  readerAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
-  writerAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
-  saslMechanism: SCRAM-SHA-512
   username: loki-user
   password: secret-password
 ```
@@ -375,6 +426,9 @@ Investigation needs to be done to fully understand how to observe the new system
 - Misconfiguration of the Kafka cluster
   - We should write extensive documentation to support proper configuration
   - If Kafka is temporarily unavailable, each distributor can buffer up to `producer_max_buffered_bytes` (default: 1GB) of unacknowledged records before it starts rejecting new writes.
+- Grafana is experimenting with their own Kafka client optimized for warpstream. 
+  - We should monitor this to make sure they wouldn't swap the client upstream and break OSS
+  - Ref https://github.com/grafana/warpstream-go   
 
 ## Design Details
 

--- a/operator/docs/enhancements/ingest_storage_arch_support.md
+++ b/operator/docs/enhancements/ingest_storage_arch_support.md
@@ -1,5 +1,6 @@
 ---
 title: Support Kafka-based Ingest Storage Architecture
+state: published
 authors:
   - @JoaoBraveCoding
 reviewers: 
@@ -299,11 +300,14 @@ type KafkaSpec struct {
 	// to track stream metadata. If not set, defaults to "{Topic}-metadata".
 	MetadataTopic string `json:"metadataTopic,omitempty"`
 
-	// ReaderAddress defines the broker addresses for consumers (host:port, comma-separated).
-	ReaderAddress string `json:"readerAddress"`
+	// Address defines the broker addresses for producers (host:port, comma-separated).
+	Address string `json:"address"`
 
-	// WriterAddress defines the broker addresses for producers (host:port, comma-separated).
-	WriterAddress string `json:"writerAddress"`
+	// ReaderAddress defines the broker addresses for consumers (host:port, comma-separated).
+	// If not set, defaults to Address.
+	//
+	// +optional
+	ReaderAddress string `json:"readerAddress,omitempty"`
 
 	// Authentication for Kafka SASL authentication.
 	// For mTLS authentication, configure the certificate and privateKey
@@ -375,8 +379,7 @@ spec:
   ingestStorage:
     kafka:
       topic: loki-logs
-      readerAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
-      writerAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
+      address: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
       authentication:
         saslMechanism: SCRAM-SHA-512
         username:

--- a/operator/docs/enhancements/retention_support.md
+++ b/operator/docs/enhancements/retention_support.md
@@ -1,5 +1,6 @@
 ---
 title: Stream-based Retention Support
+state: committed
 authors:
   - "@shwetaap"
 reviewers:

--- a/operator/docs/enhancements/ruler_support.md
+++ b/operator/docs/enhancements/ruler_support.md
@@ -1,5 +1,6 @@
 ---
 title: Ruler Support
+state: committed
 description: Support for Loki Ruler and alerting/recording rules
 authors:
   - "@periklis"

--- a/operator/docs/enhancements/short_lived_tokens_authentication.md
+++ b/operator/docs/enhancements/short_lived_tokens_authentication.md
@@ -1,5 +1,6 @@
 ---
 title: Short-Lived Token Authentication
+state: committed
 authors:
   - "@periklis"
 reviewers:

--- a/operator/docs/enhancements/zone_aware_replication.md
+++ b/operator/docs/enhancements/zone_aware_replication.md
@@ -1,5 +1,6 @@
 ---
 title: Zone-Aware Replication Support
+state: committed
 authors:
   - "@shwetaap"
   - "@btaani"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a new enhancement proposal to draft the path the loki-operator will take if we adopt the new Loki Ingest Storage Architecture that uses Kafka as a log buffer.

**Which issue(s) this PR fixes**:

https://redhat.atlassian.net/browse/LOG-7377

**Special notes for your reviewer**:

There is a small working PoC in https://github.com/grafana/loki/compare/main...JoaoBraveCoding:loki:LOG-7377-poc simply 

```sh
oc apply -f hack/kafka-broker.yaml
oc apply -f hack/lokistack_gateway_ocp.yaml
```

**Questions from reviews**

Some questions where asked do not necessarily belong on the enhancement so I'm leaving them here.

Questions from review meeting on the 24/04/2026:

> 1. At some point the concept of reading ingesters was mentioned, does that still exist in the code-base or no?

No, they don't exist in the codebase. There is no separate "read ingester" or "write ingester" role.

> 2. Does the compactor only do Index compacting or does it also do data compaction? Do ingesters have a way to tell if a file already exists in object storage?

The compactor does both index compaction and deletion of expired chunks, nothing else. No ingesters don't have a mechanism to tell if a different ingester already wrote to S3 a chunk containing the same that it's trying to write. De-duplication always happens at query time in queriers.
