### PR TITLE
chore: Add dnsConfig support to query-frontend

### DIFF
--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting monolithic, simple scalable, and microservices modes.
 type: application
 appVersion: 3.6.7
-version: 6.55.0
+version: 6.55.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 6.55.0](https://img.shields.io/badge/Version-6.55.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.7](https://img.shields.io/badge/AppVersion-3.6.7-informational?style=flat-square)
+![Version: 6.55.1](https://img.shields.io/badge/Version-6.55.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.7](https://img.shields.io/badge/AppVersion-3.6.7-informational?style=flat-square)
 
 Helm chart for Grafana Loki and Grafana Enterprise Logs supporting monolithic, simple scalable, and microservices modes.
 
@@ -19,7 +19,7 @@ As of March 16, 2026, the Grafana Loki Helm chart for OSS users has moved to [gr
 |------------|------|---------|
 | https://charts.min.io/ | minio(minio) | 5.4.0 |
 | https://grafana.github.io/helm-charts | grafana-agent-operator(grafana-agent-operator) | 0.5.2 |
-| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.43.0 |
+| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.47.0 |
 
 Find more information in the Loki Helm Chart [documentation](https://grafana.com/docs/loki/latest/setup/install/helm/).
 

--- a/production/helm/loki/templates/query-frontend/deployment-query-frontend.yaml
+++ b/production/helm/loki/templates/query-frontend/deployment-query-frontend.yaml
@@ -141,6 +141,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.querier.dnsConfig | default .Values.loki.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: config
           {{- include "loki.configVolume" . | nindent 10 }}

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -2439,6 +2439,8 @@ querier:
 queryFrontend:
   # -- Number of replicas for the query-frontend
   replicas: 0
+  # -- DNSConfig for query-frontend
+  dnsConfig: {}
   # -- hostAliases to add
   hostAliases: []
   #  - ip: 1.2.3.4


### PR DESCRIPTION
Allows configuring dnsConfig via queryFrontend values Falls back to global loki.dnsConfig if not explicitly set

**What this PR does / why we need it**:
query-frontend pods are currently missing any dnsconfig options.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Helm template changes affect the rendered `query-frontend` Deployment spec and could alter pod DNS behavior on upgrade; there is also a risk of misconfiguration due to the new value wiring.
> 
> **Overview**
> Adds a new `queryFrontend.dnsConfig` value and renders `dnsConfig` into the `query-frontend` Deployment, with a fallback to the global `loki.dnsConfig`.
> 
> Bumps the Loki Helm chart version to `6.55.1` and updates the `rollout-operator` dependency/version references to `0.47.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce3da2e360dfd519b146df6b65b302050240eafa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->