### PR TITLE
test: Reset AWS_* env variables in S3 storage client test

### DIFF
--- a/pkg/storage/chunk/client/aws/s3_storage_client_test.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client_test.go
@@ -36,6 +36,8 @@ func TestMain(m *testing.M) {
 	// that fail validation (e.g. SSO profiles missing required fields).
 	os.Setenv("AWS_CONFIG_FILE", "/dev/null")
 	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/dev/null")
+	os.Setenv("AWS_PROFILE", "")
+	os.Setenv("AWS_REGION", "")
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
Follow up on https://github.com/grafana/loki/pull/21499

The test suite would fail in case the AWS_PROFILE environment variable is set on the host that references a profile, which cannot be present, because of AWS_CONFIG_FILE being empty.

Additionally, resetting AWS_REGION is more a safety measure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that isolates the S3 storage client tests from host AWS configuration, reducing CI flakiness without affecting runtime behavior.
> 
> **Overview**
> Makes `pkg/storage/chunk/client/aws/s3_storage_client_test.go` more hermetic by clearing `AWS_PROFILE` and `AWS_REGION` in `TestMain`, in addition to pointing `AWS_CONFIG_FILE`/`AWS_SHARED_CREDENTIALS_FILE` at `/dev/null`.
> 
> This prevents failures when a developer/CI environment has an `AWS_PROFILE` set that depends on config/credentials files that the test suite intentionally disables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bb600e7aa37446d48b661d658bedad86dc2712d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->