### PR TITLE
fix: resume canary tail from last received timestamp on reconnect

### DIFF
--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -75,6 +75,7 @@ type Reader struct {
 	done            chan struct{}
 	queryAppend     string
 	labels          string
+	lastRecvTs      time.Time
 }
 
 func NewReader(writer io.Writer,
@@ -440,6 +441,9 @@ func (r *Reader) run() {
 					fmt.Fprint(r.w, err)
 					continue
 				}
+				if ts.After(r.lastRecvTs) {
+					r.lastRecvTs = *ts
+				}
 				r.recv <- *ts
 			}
 		}
@@ -474,11 +478,15 @@ func (r *Reader) closeAndReconnect() {
 		if r.useTLS {
 			scheme = "wss"
 		}
+		q := "query=" + url.QueryEscape(fmt.Sprintf("{%v=\"%v\",%v=\"%v\"} %v", r.sName, r.sValue, r.lName, r.lVal, r.queryAppend))
+		if !r.lastRecvTs.IsZero() {
+			q += "&start=" + strconv.FormatInt(r.lastRecvTs.UnixNano()+1, 10)
+		}
 		u := url.URL{
 			Scheme:   scheme,
 			Host:     r.addr,
 			Path:     "/loki/api/v1/tail",
-			RawQuery: "query=" + url.QueryEscape(fmt.Sprintf("{%v=\"%v\",%v=\"%v\"} %v", r.sName, r.sValue, r.lName, r.lVal, r.queryAppend)),
+			RawQuery: q,
 		}
 
 		fmt.Fprintf(r.w, "Connecting to loki at %v, querying for label '%v' with value '%v'\n", u.String(), r.lName, r.lVal)


### PR DESCRIPTION
Fixes #21232

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the canary websocket tail reconnection behavior by introducing stateful resume logic; incorrect timestamp handling could cause missed or duplicated canary messages after reconnects.
> 
> **Overview**
> Ensures the canary websocket tail resumes from the *last successfully received* log timestamp after reconnects.
> 
> `Reader` now tracks `lastRecvTs` while processing tail entries and, on reconnect, adds a `start=<lastRecvTs+1ns>` parameter to the `/loki/api/v1/tail` request to avoid re-reading older entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5043cb840faa3727d96a57cdac761e76e7485e6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->