### PR TITLE
chore(expr): generalize Evaluate to operate on datums

### DIFF
--- a/pkg/expr/evaluate.go
+++ b/pkg/expr/evaluate.go
@@ -8,32 +8,41 @@ import (
 	"github.com/grafana/loki/v3/pkg/memory"
 )
 
-// Evaluate processes expr against the provided batch, producing a datum as a
-// result using alloc.
+// Evaluate processes expr against the provided input datum, producing a datum
+// as a result using alloc.
+//
+// The input datum determines how expressions resolve:
+//
+//   - [Identity] resolves to the input datum directly.
+//   - [Column] requires the input to be a [*columnar.Struct] and looks up
+//     the field by name.
+//
+// When selection is non-empty, only selected rows (where the bit is set) are
+// guaranteed to have meaningful results in compute operations. Unselected rows
+// have undefined values. Use [compute.Filter] on the return datum to
+// materialize a selection. A zero-value [memory.Bitmap] selects all rows.
 //
 // The return type of Evaluate depends on the expression provided. See the
 // documentation for implementations of Expression for what they produce when
 // evaluated.
-func Evaluate(alloc *memory.Allocator, expr Expression, batch *columnar.RecordBatch) (columnar.Datum, error) {
-	// Selection defines which rows are evaluated. Selected rows have a true value
-	// in the selection vector. When selection has Len() == 0, all rows are selected.
-	// When selection has Len() > 0, only rows with a true bit are selected. Rows that
-	// are not selected are treated as null in array results.
-	//
-	// We hide selection vector from the caller because we don't support selection on expressions that are columns.
-	// E.g., evaluateWithSelection(alloc, &expr.Column{...}, batch, onlyFirstAndThirdRows) will return all the rows.
-	// This is not a problem though as selection vector can be not "allSelected" only when the expression contains a
-	// BinOp that can be short-circuited.
-	allSelected := memory.Bitmap{}
-
-	return evaluateWithSelection(alloc, expr, batch, allSelected)
+func Evaluate(alloc *memory.Allocator, expr Expression, input columnar.Datum, selection memory.Bitmap) (columnar.Datum, error) {
+	return evaluateWithSelection(alloc, expr, input, selection)
 }
 
-func evaluateWithSelection(alloc *memory.Allocator, expr Expression, batch *columnar.RecordBatch, selection memory.Bitmap) (columnar.Datum, error) {
-	nrows := 0
-	if batch != nil {
-		nrows = int(batch.NumRows())
+// inputNumRows returns the number of rows for the given input datum.
+func inputNumRows(input columnar.Datum) int {
+	switch v := input.(type) {
+	case columnar.Array:
+		return v.Len()
+	case columnar.Scalar:
+		return 1
+	default:
+		return 0
 	}
+}
+
+func evaluateWithSelection(alloc *memory.Allocator, expr Expression, input columnar.Datum, selection memory.Bitmap) (columnar.Datum, error) {
+	nrows := inputNumRows(input)
 	if selection.Len() > 0 && selection.Len() != nrows {
 		return nil, fmt.Errorf("selection length mismatch: %d != %d", selection.Len(), nrows)
 	}
@@ -42,25 +51,33 @@ func evaluateWithSelection(alloc *memory.Allocator, expr Expression, batch *colu
 	case *Constant:
 		return expr.Value, nil
 
+	case *Identity:
+		return input, nil
+
 	case *Column:
+		s, ok := input.(*columnar.Struct)
+		if !ok {
+			return nil, fmt.Errorf("Column expression requires Struct input, got %T", input)
+		}
+
 		columnIndex := -1
-		if schema := batch.Schema(); schema != nil {
+		if schema := s.Schema(); schema != nil {
 			_, columnIndex = schema.ColumnIndex(expr.Name)
 		}
 
 		if columnIndex == -1 {
-			validity := memory.NewBitmap(alloc, int(batch.NumRows()))
-			validity.AppendCount(false, int(batch.NumRows()))
+			validity := memory.NewBitmap(alloc, s.Len())
+			validity.AppendCount(false, s.Len())
 			return columnar.NewNull(validity), nil
 		}
 
-		return batch.Column(int64(columnIndex)), nil
+		return s.Field(columnIndex), nil
 
 	case *Unary:
-		return evaluateUnary(alloc, expr, batch, selection)
+		return evaluateUnary(alloc, expr, input, selection)
 
 	case *Binary:
-		return evaluateBinary(alloc, expr, batch, selection)
+		return evaluateBinary(alloc, expr, input, selection)
 
 	case *Regexp:
 		return nil, fmt.Errorf("regexp can only be evaluated as the right-hand side of regex match operations")
@@ -70,10 +87,135 @@ func evaluateWithSelection(alloc *memory.Allocator, expr Expression, batch *colu
 	}
 }
 
-func evaluateUnary(alloc *memory.Allocator, expr *Unary, batch *columnar.RecordBatch, selection memory.Bitmap) (columnar.Datum, error) {
+func evaluateExtract(alloc *memory.Allocator, expr *Extract, input columnar.Datum, selection memory.Bitmap) (columnar.Datum, error) {
+	value, err := evaluateWithSelection(alloc, expr.Value, input, selection)
+	if err != nil {
+		return nil, err
+	}
+
+	s, ok := value.(*columnar.Struct)
+	if !ok {
+		return nil, fmt.Errorf("Extract expression requires Struct input, got %T", value)
+	}
+
+	columnIndex := -1
+	if schema := s.Schema(); schema != nil {
+		_, columnIndex = schema.ColumnIndex(expr.Name)
+	}
+
+	if columnIndex == -1 {
+		validity := memory.NewBitmap(alloc, s.Len())
+		validity.AppendCount(false, s.Len())
+		return columnar.NewNull(validity), nil
+	}
+
+	return s.Field(columnIndex), nil
+}
+
+func evaluateInclude(alloc *memory.Allocator, expr *Include, input columnar.Datum, selection memory.Bitmap) (columnar.Datum, error) {
+	value, err := evaluateWithSelection(alloc, expr.Value, input, selection)
+	if err != nil {
+		return nil, err
+	}
+
+	s, ok := value.(*columnar.Struct)
+	if !ok {
+		return nil, fmt.Errorf("Include expression requires Struct input, got %T", value)
+	}
+
+	var (
+		columns []columnar.Column
+		fields  []columnar.Array
+	)
+	for _, name := range expr.Names {
+		_, idx := s.Schema().ColumnIndex(name)
+		if idx == -1 {
+			continue
+		}
+		columns = append(columns, columnar.Column{Name: name})
+		fields = append(fields, s.Field(idx))
+	}
+
+	schema := columnar.NewSchema(columns)
+	return columnar.NewStruct(schema, fields, s.Len(), s.Validity()), nil
+}
+
+func evaluateMakeStruct(alloc *memory.Allocator, expr *MakeStruct, input columnar.Datum, selection memory.Bitmap) (columnar.Datum, error) {
+	if len(expr.Names) != len(expr.Values) {
+		return nil, fmt.Errorf("MakeStruct: names and values count mismatch: %d != %d", len(expr.Names), len(expr.Values))
+	}
+
+	seen := make(map[string]struct{}, len(expr.Names))
+	for _, name := range expr.Names {
+		if _, ok := seen[name]; ok {
+			return nil, fmt.Errorf("MakeStruct: duplicate field name %q", name)
+		}
+		seen[name] = struct{}{}
+	}
+
+	var (
+		columns = make([]columnar.Column, len(expr.Names))
+		fields  = make([]columnar.Array, len(expr.Values))
+	)
+	for i, name := range expr.Names {
+		val, err := evaluateWithSelection(alloc, expr.Values[i], input, selection)
+		if err != nil {
+			return nil, err
+		}
+		arr, ok := val.(columnar.Array)
+		if !ok {
+			return nil, fmt.Errorf("MakeStruct: value %d (%q) must be an array, got %T", i, name, val)
+		}
+		columns[i] = columnar.Column{Name: name}
+		fields[i] = arr
+	}
+
+	length := inputNumRows(input)
+	if len(fields) > 0 {
+		length = fields[0].Len()
+	}
+
+	schema := columnar.NewSchema(columns)
+	return columnar.NewStruct(schema, fields, length, memory.Bitmap{}), nil
+}
+
+func evaluateExclude(alloc *memory.Allocator, expr *Exclude, input columnar.Datum, selection memory.Bitmap) (columnar.Datum, error) {
+	value, err := evaluateWithSelection(alloc, expr.Value, input, selection)
+	if err != nil {
+		return nil, err
+	}
+
+	s, ok := value.(*columnar.Struct)
+	if !ok {
+		return nil, fmt.Errorf("Exclude expression requires Struct input, got %T", value)
+	}
+
+	excludeSet := make(map[string]struct{}, len(expr.Names))
+	for _, name := range expr.Names {
+		excludeSet[name] = struct{}{}
+	}
+
+	var (
+		columns []columnar.Column
+		fields  []columnar.Array
+	)
+	for i := range s.NumFields() {
+		col := s.Schema().Column(i)
+		if _, excluded := excludeSet[col.Name]; excluded {
+			continue
+		}
+		columns = append(columns, col)
+		fields = append(fields, s.Field(i))
+	}
+
+	schema := columnar.NewSchema(columns)
+	return columnar.NewStruct(schema, fields, s.Len(), s.Validity()), nil
+}
+
+func evaluateUnary(alloc *memory.Allocator, expr *Unary, input columnar.Datum, selection memory.Bitmap) (columnar.Datum, error) {
 	switch expr.Op {
 	case UnaryOpNOT:
-		value, err := evaluateWithSelection(alloc, expr.Value, batch, selection)
+		value, err := evaluateWithSelection(alloc, expr.Value, input, selection)
 		if err != nil {
 			return nil, err
 		}
@@ -83,21 +225,21 @@ func evaluateUnary(alloc *memory.Allocator, expr *Unary, batch *columnar.RecordB
 	}
 }
 
-func evaluateBinary(alloc *memory.Allocator, expr *Binary, batch *columnar.RecordBatch, selection memory.Bitmap) (columnar.Datum, error) {
+func evaluateBinary(alloc *memory.Allocator, expr *Binary, input columnar.Datum, selection memory.Bitmap) (columnar.Datum, error) {
 	// Check for special operators that need different handling of their arguments.
 	switch expr.Op {
 	case BinaryOpMatchRegex, BinaryOpIn:
-		return evaluateSpecialBinary(alloc, expr, batch, selection)
+		return evaluateSpecialBinary(alloc, expr, input, selection)
 	}
 
 	// TODO(rfratto): If expr.Op is [BinaryOpAND] or [BinaryOpOR], we can
 	// propagate selection vectors to avoid unnecessary evaluations.
-	left, err := evaluateWithSelection(alloc, expr.Left, batch, selection)
+	left, err := evaluateWithSelection(alloc, expr.Left, input, selection)
 	if err != nil {
 		return nil, err
 	}
 
-	right, err := evaluateWithSelection(alloc, expr.Right, batch, selection)
+	right, err := evaluateWithSelection(alloc, expr.Right, input, selection)
 	if err != nil {
 		return nil, err
 	}
@@ -130,10 +272,10 @@ func evaluateBinary(alloc *memory.Allocator, expr *Binary, batch *columnar.Recor
 
 // evaluateSpecialBinary evaluates binary expressions for which one of the
 // arguments does not evaluate into an expression of its own.
-func evaluateSpecialBinary(alloc *memory.Allocator, expr *Binary, batch *columnar.RecordBatch, selection memory.Bitmap) (columnar.Datum, error) {
+func evaluateSpecialBinary(alloc *memory.Allocator, expr *Binary, input columnar.Datum, selection memory.Bitmap) (columnar.Datum, error) {
 	switch expr.Op {
 	case BinaryOpMatchRegex:
-		left, err := evaluateWithSelection(alloc, expr.Left, batch, selection)
+		left, err := evaluateWithSelection(alloc, expr.Left, input, selection)
 		if err != nil {
 			return nil, err
 		}
@@ -145,7 +287,7 @@ func evaluateSpecialBinary(alloc *memory.Allocator, expr *Binary, batch *columna
 
 		return compute.RegexpMatch(alloc, left, right.Expression, selection)
 	case BinaryOpIn:
-		left, err := evaluateWithSelection(alloc, expr.Left, batch, selection)
+		left, err := evaluateWithSelection(alloc, expr.Left, input, selection)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/expr/evaluate.go
+++ b/pkg/expr/evaluate.go
@@ -57,7 +57,7 @@ func evaluateWithSelection(alloc *memory.Allocator, expr Expression, input colum
 	case *Column:
 		s, ok := input.(*columnar.Struct)
 		if !ok {
-			return nil, fmt.Errorf("Column expression requires Struct input, got %T", input)
+			return nil, fmt.Errorf("expected Struct input, got %T", input)
 		}
 
 		columnIndex := -1
@@ -72,6 +72,18 @@ func evaluateWithSelection(alloc *memory.Allocator, expr Expression, input colum
 		}
 
 		return s.Field(columnIndex), nil
+
+	case *Extract:
+		return evaluateExtract(alloc, expr, input, selection)
+
+	case *Include:
+		return evaluateInclude(alloc, expr, input, selection)
+
+	case *Exclude:
+		return evaluateExclude(alloc, expr, input, selection)
+
+	case *MakeStruct:
+		return evaluateMakeStruct(alloc, expr, input, selection)
 
 	case *Unary:
 		return evaluateUnary(alloc, expr, input, selection)
@@ -95,14 +107,10 @@ func evaluateExtract(alloc *memory.Allocator, expr *Extract, input columnar.Datu
 
 	s, ok := value.(*columnar.Struct)
 	if !ok {
-		return nil, fmt.Errorf("Extract expression requires Struct input, got %T", value)
+		return nil, fmt.Errorf("expected Struct input, got %T", value)
 	}
 
-	columnIndex := -1
-	if schema := s.Schema(); schema != nil {
-		_, columnIndex = schema.ColumnIndex(expr.Name)
-	}
-
+	_, columnIndex := s.Schema().ColumnIndex(expr.Name)
 	if columnIndex == -1 {
 		validity := memory.NewBitmap(alloc, s.Len())
 		validity.AppendCount(false, s.Len())
@@ -118,9 +126,17 @@ func evaluateInclude(alloc *memory.Allocator, expr *Include, input columnar.Datu
 		return nil, err
 	}
 
+	seen := make(map[string]struct{}, len(expr.Names))
+	for _, name := range expr.Names {
+		if _, ok := seen[name]; ok {
+			return nil, fmt.Errorf("duplicate field name %q", name)
+		}
+		seen[name] = struct{}{}
+	}
+
 	s, ok := value.(*columnar.Struct)
 	if !ok {
-		return nil, fmt.Errorf("Include expression requires Struct input, got %T", value)
+		return nil, fmt.Errorf("expected Struct input, got %T", value)
 	}
 
 	var (
@@ -142,18 +158,20 @@ func evaluateInclude(alloc *memory.Allocator, expr *Include, input columnar.Datu
 
 func evaluateMakeStruct(alloc *memory.Allocator, expr *MakeStruct, input columnar.Datum, selection memory.Bitmap) (columnar.Datum, error) {
 	if len(expr.Names) != len(expr.Values) {
-		return nil, fmt.Errorf("MakeStruct: names and values count mismatch: %d != %d", len(expr.Names), len(expr.Values))
+		return nil, fmt.Errorf("names and values count mismatch: %d != %d", len(expr.Names), len(expr.Values))
 	}
 
 	seen := make(map[string]struct{}, len(expr.Names))
 	for _, name := range expr.Names {
 		if _, ok := seen[name]; ok {
-			return nil, fmt.Errorf("MakeStruct: duplicate field name %q", name)
+			return nil, fmt.Errorf("duplicate field name %q", name)
 		}
 		seen[name] = struct{}{}
 	}
 
 	var (
+		length = inputNumRows(input)
+
 		columns = make([]columnar.Column, len(expr.Names))
 		fields  = make([]columnar.Array, len(expr.Values))
 	)
@@ -164,15 +182,14 @@ func evaluateMakeStruct(alloc *memory.Allocator, expr *MakeStruct, input columna
 		}
 		arr, ok := val.(columnar.Array)
 		if !ok {
-			return nil, fmt.Errorf("MakeStruct: value %d (%q) must be an array, got %T", i, name, val)
+			return nil, fmt.Errorf("value %d (%q) must be an array, got %T", i, name, val)
 		}
 		columns[i] = columnar.Column{Name: name}
 		fields[i] = arr
-	}
 
-	length := inputNumRows(input)
-	if len(fields) > 0 {
-		length = fields[0].Len()
+		if arr.Len() != length {
+			return nil, fmt.Errorf("value %d (%q) must have length %d, got %d", i, name, length, arr.Len())
+		}
 	}
 
 	schema := columnar.NewSchema(columns)
@@ -187,7 +204,7 @@ func evaluateExclude(alloc *memory.Allocator, expr *Exclude, input columnar.Datu
 
 	s, ok := value.(*columnar.Struct)
 	if !ok {
-		return nil, fmt.Errorf("Exclude expression requires Struct input, got %T", value)
+		return nil, fmt.Errorf("expected Struct input, got %T", value)
 	}
 
 	excludeSet := make(map[string]struct{}, len(expr.Names))

--- a/pkg/expr/evaluate_test.go
+++ b/pkg/expr/evaluate_test.go
@@ -16,16 +16,9 @@ import (
 func TestEvaluate(t *testing.T) {
 	var alloc memory.Allocator
 
-	record := columnar.NewRecordBatch(
-		columnar.NewSchema([]columnar.Column{
-			{Name: "name"},
-			{Name: "age"},
-		}),
-		3, // row count
-		[]columnar.Array{
-			columnartest.Array(t, columnar.KindUTF8, &alloc, "Peter", "Paul", "Mary"),
-			columnartest.Array(t, columnar.KindUint64, &alloc, 30, 25, 43),
-		},
+	record := columnartest.Struct(t, &alloc,
+		columnartest.Field("name", columnar.KindUTF8, "Peter", "Paul", "Mary"),
+		columnartest.Field("age", columnar.KindUint64, 30, 25, 43),
 	)
 
 	// (name != "Paul" AND age > 25)
@@ -45,7 +38,7 @@ func TestEvaluate(t *testing.T) {
 
 	expect := columnartest.Array(t, columnar.KindBool, &alloc, true, false, true)
 
-	result, err := expr.Evaluate(&alloc, e, record)
+	result, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
 	require.NoError(t, err)
 	columnartest.RequireDatumsEqual(t, expect, result, memory.Bitmap{})
 }
@@ -57,7 +50,7 @@ func TestEvaluate_Constant(t *testing.T) {
 
 	expect := columnartest.Scalar(t, columnar.KindUint64, 42)
 
-	result, err := expr.Evaluate(&alloc, e, nil)
+	result, err := expr.Evaluate(&alloc, e, nil, memory.Bitmap{})
 	require.NoError(t, err)
 	columnartest.RequireDatumsEqual(t, expect, result, memory.Bitmap{})
 }
@@ -65,18 +58,10 @@ func TestEvaluate_Constant(t *testing.T) {
 func TestEvaluate_Column(t *testing.T) {
 	var alloc memory.Allocator
 
-	record := columnar.NewRecordBatch(
-		columnar.NewSchema([]columnar.Column{
-			{Name: "name"},
-			{Name: "age"},
-			{Name: "city"},
-		}),
-		3, // row count
-		[]columnar.Array{
-			columnartest.Array(t, columnar.KindUTF8, &alloc, "Alice", "Bob", "Charlie"),
-			columnartest.Array(t, columnar.KindUint64, &alloc, 30, 25, 35),
-			columnartest.Array(t, columnar.KindUTF8, &alloc, "NYC", "LA", "SF"),
-		},
+	record := columnartest.Struct(t, &alloc,
+		columnartest.Field("name", columnar.KindUTF8, "Alice", "Bob", "Charlie"),
+		columnartest.Field("age", columnar.KindUint64, 30, 25, 35),
+		columnartest.Field("city", columnar.KindUTF8, "NYC", "LA", "SF"),
 	)
 
 	t.Run("existing column", func(t *testing.T) {
@@ -84,7 +69,7 @@ func TestEvaluate_Column(t *testing.T) {
 
 		expect := columnartest.Array(t, columnar.KindUint64, &alloc, 30, 25, 35)
 
-		result, err := expr.Evaluate(&alloc, e, record)
+		result, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
 		require.NoError(t, err)
 		columnartest.RequireDatumsEqual(t, expect, result, memory.Bitmap{})
 	})
@@ -94,23 +79,239 @@ func TestEvaluate_Column(t *testing.T) {
 
 		expect := columnartest.Array(t, columnar.KindNull, &alloc, nil, nil, nil)
 
-		result, err := expr.Evaluate(&alloc, e, record)
+		result, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
 		require.NoError(t, err)
 		columnartest.RequireDatumsEqual(t, expect, result, memory.Bitmap{})
+	})
+}
+
+func TestEvaluate_Column_Struct(t *testing.T) {
+	var alloc memory.Allocator
+
+	schema := columnar.NewSchema([]columnar.Column{{Name: "x"}, {Name: "y"}})
+	input := columnar.NewStruct(schema, []columnar.Array{
+		columnartest.Array(t, columnar.KindInt64, &alloc, int64(10), int64(20)),
+		columnartest.Array(t, columnar.KindUTF8, &alloc, "a", "b"),
+	}, 2, memory.Bitmap{})
+
+	// Resolve column "x".
+	result, err := expr.Evaluate(&alloc, &expr.Column{Name: "x"}, input, memory.Bitmap{})
+	require.NoError(t, err)
+	columnartest.RequireArraysEqual(t,
+		columnartest.Array(t, columnar.KindInt64, &alloc, int64(10), int64(20)),
+		result.(columnar.Array),
+		memory.Bitmap{},
+	)
+
+	// Unknown column resolves to null.
+	result, err = expr.Evaluate(&alloc, &expr.Column{Name: "missing"}, input, memory.Bitmap{})
+	require.NoError(t, err)
+	require.Equal(t, columnar.KindNull, result.Kind())
+	require.Equal(t, 2, result.(*columnar.Null).Len())
+}
+
+func TestEvaluate_Extract(t *testing.T) {
+	var alloc memory.Allocator
+
+	record := columnartest.Struct(t, &alloc,
+		columnartest.Field("name", columnar.KindUTF8, "Alice", "Bob", "Charlie"),
+		columnartest.Field("age", columnar.KindUint64, 30, 25, 35),
+	)
+
+	t.Run("existing field", func(t *testing.T) {
+		e := &expr.Extract{Name: "age", Value: &expr.Identity{}}
+
+		expect := columnartest.Array(t, columnar.KindUint64, &alloc, 30, 25, 35)
+
+		result, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
+		require.NoError(t, err)
+		columnartest.RequireDatumsEqual(t, expect, result, memory.Bitmap{})
+	})
+
+	t.Run("missing field", func(t *testing.T) {
+		e := &expr.Extract{Name: "missing", Value: &expr.Identity{}}
+
+		expect := columnartest.Array(t, columnar.KindNull, &alloc, nil, nil, nil)
+
+		result, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
+		require.NoError(t, err)
+		columnartest.RequireDatumsEqual(t, expect, result, memory.Bitmap{})
+	})
+
+	t.Run("non-struct value", func(t *testing.T) {
+		e := &expr.Extract{
+			Name:  "x",
+			Value: &expr.Constant{Value: columnartest.Scalar(t, columnar.KindUTF8, "hello")},
+		}
+
+		_, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
+		require.Error(t, err)
+	})
+}
+
+func TestEvaluate_Include(t *testing.T) {
+	var alloc memory.Allocator
+
+	record := columnartest.Struct(t, &alloc,
+		columnartest.Field("name", columnar.KindUTF8, "Alice", "Bob", "Charlie"),
+		columnartest.Field("age", columnar.KindUint64, 30, 25, 35),
+		columnartest.Field("city", columnar.KindUTF8, "NYC", "LA", "SF"),
+	)
+
+	t.Run("subset of fields", func(t *testing.T) {
+		e := &expr.Include{Names: []string{"name", "city"}, Value: &expr.Identity{}}
+
+		expect := columnartest.Struct(t, &alloc,
+			columnartest.Field("name", columnar.KindUTF8, "Alice", "Bob", "Charlie"),
+			columnartest.Field("city", columnar.KindUTF8, "NYC", "LA", "SF"),
+		)
+
+		result, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
+		require.NoError(t, err)
+		columnartest.RequireDatumsEqual(t, expect, result, memory.Bitmap{})
+	})
+
+	t.Run("missing names skipped", func(t *testing.T) {
+		e := &expr.Include{Names: []string{"name", "missing"}, Value: &expr.Identity{}}
+
+		expect := columnartest.Struct(t, &alloc,
+			columnartest.Field("name", columnar.KindUTF8, "Alice", "Bob", "Charlie"),
+		)
+
+		result, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
+		require.NoError(t, err)
+		columnartest.RequireDatumsEqual(t, expect, result, memory.Bitmap{})
+	})
+
+	t.Run("non-struct value", func(t *testing.T) {
+		e := &expr.Include{
+			Names: []string{"x"},
+			Value: &expr.Constant{Value: columnartest.Scalar(t, columnar.KindUTF8, "hello")},
+		}
+
+		_, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
+		require.Error(t, err)
+	})
+}
+
+func TestEvaluate_Exclude(t *testing.T) {
+	var alloc memory.Allocator
+
+	record := columnartest.Struct(t, &alloc,
+		columnartest.Field("name", columnar.KindUTF8, "Alice", "Bob", "Charlie"),
+		columnartest.Field("age", columnar.KindUint64, 30, 25, 35),
+		columnartest.Field("city", columnar.KindUTF8, "NYC", "LA", "SF"),
+	)
+
+	t.Run("exclude some fields", func(t *testing.T) {
+		e := &expr.Exclude{Names: []string{"age"}, Value: &expr.Identity{}}
+
+		expect := columnartest.Struct(t, &alloc,
+			columnartest.Field("name", columnar.KindUTF8, "Alice", "Bob", "Charlie"),
+			columnartest.Field("city", columnar.KindUTF8, "NYC", "LA", "SF"),
+		)
+
+		result, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
+		require.NoError(t, err)
+		columnartest.RequireDatumsEqual(t, expect, result, memory.Bitmap{})
+	})
+
+	t.Run("exclude non-existing names", func(t *testing.T) {
+		e := &expr.Exclude{Names: []string{"missing"}, Value: &expr.Identity{}}
+
+		expect := columnartest.Struct(t, &alloc,
+			columnartest.Field("name", columnar.KindUTF8, "Alice", "Bob", "Charlie"),
+			columnartest.Field("age", columnar.KindUint64, 30, 25, 35),
+			columnartest.Field("city", columnar.KindUTF8, "NYC", "LA", "SF"),
+		)
+
+		result, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
+		require.NoError(t, err)
+		columnartest.RequireDatumsEqual(t, expect, result, memory.Bitmap{})
+	})
+
+	t.Run("exclude all fields", func(t *testing.T) {
+		e := &expr.Exclude{Names: []string{"name", "age", "city"}, Value: &expr.Identity{}}
+
+		result, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
+		require.NoError(t, err)
+
+		s := result.(*columnar.Struct)
+		require.Equal(t, 0, s.NumFields())
+		require.Equal(t, 3, s.Len())
+	})
+
+	t.Run("non-struct value", func(t *testing.T) {
+		e := &expr.Exclude{
+			Names: []string{"x"},
+			Value: &expr.Constant{Value: columnartest.Scalar(t, columnar.KindUTF8, "hello")},
+		}
+
+		_, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
+		require.Error(t, err)
+	})
+}
+
+func TestEvaluate_MakeStruct(t *testing.T) {
+	var alloc memory.Allocator
+
+	record := columnartest.Struct(t, &alloc,
+		columnartest.Field("name", columnar.KindUTF8, "Alice", "Bob", "Charlie"),
+		columnartest.Field("age", columnar.KindUint64, 30, 25, 35),
+	)
+
+	t.Run("construct from columns", func(t *testing.T) {
+		e := &expr.MakeStruct{
+			Names:  []string{"who", "years"},
+			Values: []expr.Expression{&expr.Column{Name: "name"}, &expr.Column{Name: "age"}},
+		}
+
+		expect := columnartest.Struct(t, &alloc,
+			columnartest.Field("who", columnar.KindUTF8, "Alice", "Bob", "Charlie"),
+			columnartest.Field("years", columnar.KindUint64, 30, 25, 35),
+		)
+
+		result, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
+		require.NoError(t, err)
+		columnartest.RequireDatumsEqual(t, expect, result, memory.Bitmap{})
+	})
+
+	t.Run("mismatched names and values", func(t *testing.T) {
+		e := &expr.MakeStruct{
+			Names:  []string{"a", "b"},
+			Values: []expr.Expression{&expr.Column{Name: "name"}},
+		}
+
+		_, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
+		require.Error(t, err)
+	})
+
+	t.Run("duplicate names rejected", func(t *testing.T) {
+		e := &expr.MakeStruct{
+			Names:  []string{"x", "x"},
+			Values: []expr.Expression{&expr.Column{Name: "name"}, &expr.Column{Name: "age"}},
+		}
+
+		_, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
+		require.Error(t, err)
+	})
+
+	t.Run("scalar value rejected", func(t *testing.T) {
+		e := &expr.MakeStruct{
+			Names:  []string{"x"},
+			Values: []expr.Expression{&expr.Constant{Value: columnartest.Scalar(t, columnar.KindUTF8, "hello")}},
+		}
+
+		_, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
+		require.Error(t, err)
 	})
 }
 
 func TestEvaluate_Unary(t *testing.T) {
 	var alloc memory.Allocator
 
-	record := columnar.NewRecordBatch(
-		columnar.NewSchema([]columnar.Column{
-			{Name: "active"},
-		}),
-		3, // row count
-		[]columnar.Array{
-			columnartest.Array(t, columnar.KindBool, &alloc, true, false, true),
-		},
+	record := columnartest.Struct(t, &alloc,
+		columnartest.Field("active", columnar.KindBool, true, false, true),
 	)
 
 	e := &expr.Unary{
@@ -120,7 +321,7 @@ func TestEvaluate_Unary(t *testing.T) {
 
 	expect := columnartest.Array(t, columnar.KindBool, &alloc, false, true, false)
 
-	result, err := expr.Evaluate(&alloc, e, record)
+	result, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
 	require.NoError(t, err)
 	columnartest.RequireDatumsEqual(t, expect, result, memory.Bitmap{})
 }
@@ -128,18 +329,10 @@ func TestEvaluate_Unary(t *testing.T) {
 func TestEvaluate_Binary(t *testing.T) {
 	var alloc memory.Allocator
 
-	record := columnar.NewRecordBatch(
-		columnar.NewSchema([]columnar.Column{
-			{Name: "name"},
-			{Name: "age"},
-			{Name: "active"},
-		}),
-		3, // row count
-		[]columnar.Array{
-			columnartest.Array(t, columnar.KindUTF8, &alloc, "Alice", "Bob", "Charlie"),
-			columnartest.Array(t, columnar.KindUint64, &alloc, 30, 25, 35),
-			columnartest.Array(t, columnar.KindBool, &alloc, true, false, true),
-		},
+	record := columnartest.Struct(t, &alloc,
+		columnartest.Field("name", columnar.KindUTF8, "Alice", "Bob", "Charlie"),
+		columnartest.Field("age", columnar.KindUint64, 30, 25, 35),
+		columnartest.Field("active", columnar.KindBool, true, false, true),
 	)
 
 	tests := []struct {
@@ -224,7 +417,7 @@ func TestEvaluate_Binary(t *testing.T) {
 				Right: tt.right,
 			}
 
-			result, err := expr.Evaluate(&alloc, e, record)
+			result, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
 			require.NoError(t, err)
 			columnartest.RequireDatumsEqual(t, tt.expect, result, memory.Bitmap{})
 		})

--- a/pkg/expr/expr.go
+++ b/pkg/expr/expr.go
@@ -101,14 +101,14 @@ type (
 	}
 )
 
-func (*Constant) isExpr() {}
-func (*Column) isExpr()   {}
-func (*Unary) isExpr()    {}
-func (*Binary) isExpr()   {}
-func (*Regexp) isExpr()   {}
-func (*ValueSet) isExpr() {}
-func (*Identity) isExpr() {}
-func (*Extract) isExpr()  {}
-func (*Include) isExpr()  {}
+func (*Constant) isExpr()   {}
+func (*Column) isExpr()     {}
+func (*Unary) isExpr()      {}
+func (*Binary) isExpr()     {}
+func (*Regexp) isExpr()     {}
+func (*ValueSet) isExpr()   {}
+func (*Identity) isExpr()   {}
+func (*Extract) isExpr()    {}
+func (*Include) isExpr()    {}
 func (*Exclude) isExpr()    {}
 func (*MakeStruct) isExpr() {}

--- a/pkg/expr/expr.go
+++ b/pkg/expr/expr.go
@@ -1,5 +1,5 @@
-// Package expr provides utilities for evaluating expressions against a
-// [columnar.RecordBatch] with a selection vector.
+// Package expr provides utilities for evaluating expressions against
+// [columnar.Datum] values with a selection vector.
 //
 // Package expr is EXPERIMENTAL and currently only intended to be used by
 // [github.com/grafana/loki/v3/pkg/dataobj].
@@ -57,6 +57,48 @@ type (
 	//
 	// ValueSet cannot be evaluated directly into a datum.
 	ValueSet struct{ Values *columnar.Set }
+
+	// Identity is an Expression that resolves to the input datum passed to
+	// [Evaluate]. It represents "the current data in scope" and is used by
+	// leaf-level layout readers where column references have been rewritten
+	// to Identity by parent readers.
+	Identity struct{}
+
+	// Extract is an [Expression] that evaluates Value and extracts the field
+	// with the given Name from the resulting [*columnar.Struct].
+	//
+	// If the field doesn't exist, a Null column is produced.
+	Extract struct {
+		Name  string
+		Value Expression
+	}
+
+	// Include is an [Expression] that evaluates Value and returns a new
+	// [*columnar.Struct] containing only the fields with the given Names.
+	//
+	// Names that don't exist in the source struct are silently skipped.
+	Include struct {
+		Names []string
+		Value Expression
+	}
+
+	// Exclude is an [Expression] that evaluates Value and returns a new
+	// [*columnar.Struct] with the fields matching Names removed.
+	//
+	// Names that don't exist in the source struct are silently ignored.
+	Exclude struct {
+		Names []string
+		Value Expression
+	}
+
+	// MakeStruct is an [Expression] that evaluates each of the Values
+	// expressions and constructs a new [*columnar.Struct] with the given
+	// Names. Each value must evaluate to a [columnar.Array], and all arrays
+	// must have the same length.
+	MakeStruct struct {
+		Names  []string
+		Values []Expression
+	}
 )
 
 func (*Constant) isExpr() {}
@@ -65,3 +107,8 @@ func (*Unary) isExpr()    {}
 func (*Binary) isExpr()   {}
 func (*Regexp) isExpr()   {}
 func (*ValueSet) isExpr() {}
+func (*Identity) isExpr() {}
+func (*Extract) isExpr()  {}
+func (*Include) isExpr()  {}
+func (*Exclude) isExpr()    {}
+func (*MakeStruct) isExpr() {}


### PR DESCRIPTION
This PR updates expr.Evaluate to operate on datums rather than explicitly record batches. This permits evaluating a chain of expressions against any array, including primitive arrays like booleans. 

To support this change, five new expression types are added:

* `Identity`: returns the input datum. (For operations like `Identity < 5`). 
* `Extract`: Extracts a field from a struct. 
* `Include`: Performs a projection on a struct, returning a new struct with only the specified column names.
* `Exclude`: Performs a projection on a struct, returning a new struct without the specified column names. 
* `MakeStruct`: Returns a new struct with the given names and values.  

This new functionality and the new expressions will be used as part of the upcoming dataset package to perform both filtering and projections. 

Evaluate is also updated to allow passing in selection vectors (masks). 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core `expr.Evaluate` API (signature/semantics) and adds new struct/projection expressions, which can affect all callers and row-selection handling. Risk is mitigated by expanded unit test coverage for the new behaviors and error cases.
> 
> **Overview**
> Refactors `expr.Evaluate` to operate on a generic `columnar.Datum` (with an explicit `memory.Bitmap` selection mask) instead of a `RecordBatch`, and updates evaluation to derive row count from the input datum.
> 
> Adds new expressions for working with structured data and scoping: `Identity` (returns the input), `Extract` (field access), `Include`/`Exclude` (struct projection), and `MakeStruct` (construct a new struct from arrays), including validation for duplicate names, type/length mismatches, and missing fields.
> 
> Updates tests to use struct-based inputs and adds coverage for the new expressions and error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a662cf84a2dff171da1513d2e6b26258b06194dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->