### PR TITLE
fix: remove all unrelated AWS env vars

### DIFF
--- a/pkg/storage/chunk/client/aws/s3_storage_client_test.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client_test.go
@@ -34,10 +34,14 @@ import (
 func TestMain(m *testing.M) {
 	// Prevent tests from loading the host's AWS config, which may have profiles
 	// that fail validation (e.g. SSO profiles missing required fields).
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, "AWS_") {
+			os.Unsetenv(strings.SplitN(env, "=", 2)[0])
+		}
+	}
 	os.Setenv("AWS_CONFIG_FILE", "/dev/null")
 	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/dev/null")
-	os.Setenv("AWS_PROFILE", "")
-	os.Setenv("AWS_REGION", "")
+	os.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION

**What this PR does / why we need it**:
Follow up to https://github.com/grafana/loki/pull/21510 and https://github.com/grafana/loki/pull/21499

Unset _all_ `AWS_` env vars except:
* `AWS_CONFIG_FILE` which is explicity set to `/dev/null` to prevent default lookup behavior.
* `AWS_SHARED_CREDENTIALS_FILE` which is explicity set to `/dev/null` to prevent credentials being read.
* `AWS_EC2_METADATA_DISABLED` which is explictly set `true` to ensure we don't get instance credentials or lookup delays.

This should prevent any AWS credential providers or the S3 client from being derailed by local config and env vars


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test setup and only affect how AWS SDK configuration is isolated during tests.
> 
> **Overview**
> Improves isolation of `s3_storage_client_test.go` by **unsetting all `AWS_` environment variables** before running tests, then explicitly forcing `AWS_CONFIG_FILE`/`AWS_SHARED_CREDENTIALS_FILE` to `/dev/null` and disabling EC2 metadata lookups via `AWS_EC2_METADATA_DISABLED=true`.
> 
> This replaces the narrower approach of clearing only `AWS_PROFILE`/`AWS_REGION`, reducing flakiness from host AWS configs (e.g., invalid SSO profiles) influencing the SDK during unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c00ea6924d8733500aebff44e7176701e45f86e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->