### PR TITLE
feat: clamp pointerscans to index start/end timeranges

### DIFF
--- a/pkg/dataobj/metastore/metastore.go
+++ b/pkg/dataobj/metastore/metastore.go
@@ -39,9 +39,16 @@ type GetIndexesRequest struct {
 	End   time.Time
 }
 
+// IndexEntry is a reference to an index object together with the time range it covers.
+type IndexEntry struct {
+	Path  string
+	Start time.Time
+	End   time.Time
+}
+
 type GetIndexesResponse struct {
 	TableOfContentsPaths []string
-	IndexesPaths         []string
+	Indexes              []IndexEntry
 }
 
 type IndexSectionsReaderRequest struct {

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -580,6 +580,19 @@ func dedupeAndSortEntries(batches [][]IndexEntry) []IndexEntry {
 	uniqueEntries := make(map[string]IndexEntry)
 	for _, batch := range batches {
 		for _, entry := range batch {
+			// This should not happen, but just in case, adjust the index time range to cover the union of the time ranges.
+			// E.g. if first entry covers [T0, T10] and second [T5, T15], the final index time range should be [T0, T15].
+			if existing, ok := uniqueEntries[entry.Path]; ok {
+				if entry.Start.Before(existing.Start) {
+					existing.Start = entry.Start
+				}
+				if entry.End.After(existing.End) {
+					existing.End = entry.End
+				}
+				uniqueEntries[entry.Path] = existing
+				continue
+			}
+
 			uniqueEntries[entry.Path] = entry
 		}
 	}

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -194,13 +194,17 @@ func (m *ObjectMetastore) streams(ctx context.Context, start, end time.Time, mat
 	}
 
 	// List objects from all stores concurrently
-	paths, err := m.listObjectsFromTables(ctx, tablePaths, start, end)
+	entries, err := m.listObjectsFromTables(ctx, tablePaths, start, end)
 	if err != nil {
 		return nil, err
 	}
 
 	// Search the stream sections of the matching objects to find matching streams
 	predicate := streamPredicateFromMatchers(start, end, matchers...)
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		paths = append(paths, entry.Path)
+	}
 	return m.listStreamsFromObjects(ctx, paths, predicate)
 }
 
@@ -218,7 +222,15 @@ func (m *ObjectMetastore) DataObjects(ctx context.Context, start, end time.Time,
 	}
 
 	// List objects from all tables concurrently
-	return m.listObjectsFromTables(ctx, tablePaths, start, end)
+	entries, err := m.listObjectsFromTables(ctx, tablePaths, start, end)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		paths = append(paths, entry.Path)
+	}
+	return paths, nil
 }
 
 func (m *ObjectMetastore) Labels(ctx context.Context, start, end time.Time, matchers ...*labels.Matcher) ([]string, error) {
@@ -326,8 +338,8 @@ func streamPredicateFromMatchers(start, end time.Time, matchers ...*labels.Match
 }
 
 // listObjectsFromTables concurrently lists objects from multiple metastore files
-func (m *ObjectMetastore) listObjectsFromTables(ctx context.Context, tablePaths []string, start, end time.Time) ([]string, error) {
-	objects := make([][]string, len(tablePaths))
+func (m *ObjectMetastore) listObjectsFromTables(ctx context.Context, tablePaths []string, start, end time.Time) ([]IndexEntry, error) {
+	objects := make([][]IndexEntry, len(tablePaths))
 	g, ctx := errgroup.WithContext(ctx)
 
 	sStart := scalar.NewTimestampScalar(arrow.Timestamp(start.UnixNano()), arrow.FixedWidthTypes.Timestamp_ns)
@@ -350,7 +362,7 @@ func (m *ObjectMetastore) listObjectsFromTables(ctx context.Context, tablePaths 
 		return nil, err
 	}
 
-	return dedupeAndSort(objects), nil
+	return dedupeAndSortEntries(objects), nil
 }
 
 func (m *ObjectMetastore) listStreamsFromObjects(ctx context.Context, paths []string, predicate streams.RowPredicate) ([]*labels.Labels, error) {
@@ -404,7 +416,7 @@ func addLabels(mtx *sync.Mutex, streams map[uint64][]*labels.Labels, newLabels *
 	streams[key] = append(streams[key], newLabels)
 }
 
-func (m *ObjectMetastore) listObjects(ctx context.Context, path string, sStart, sEnd *scalar.Timestamp) ([]string, error) {
+func (m *ObjectMetastore) listObjects(ctx context.Context, path string, sStart, sEnd *scalar.Timestamp) ([]IndexEntry, error) {
 	var buf bytes.Buffer
 	objectReader, err := m.bucket.Get(ctx, path)
 	if err != nil {
@@ -420,16 +432,20 @@ func (m *ObjectMetastore) listObjects(ctx context.Context, path string, sStart, 
 	if err != nil {
 		return nil, fmt.Errorf("getting object from reader: %w", err)
 	}
-	var objectPaths []string
+	var entries []IndexEntry
 
 	err = forEachIndexPointer(ctx, object, sStart, sEnd, func(indexPointer indexpointers.IndexPointer) {
-		objectPaths = append(objectPaths, indexPointer.Path)
+		entries = append(entries, IndexEntry{
+			Path:  indexPointer.Path,
+			Start: indexPointer.StartTs,
+			End:   indexPointer.EndTs,
+		})
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	return objectPaths, nil
+	return entries, nil
 }
 
 // forEachStreamWithColumns iterates over the streams in the object and calls the callback function for each stream that matches the matchers and includes the requested columns
@@ -559,21 +575,23 @@ func forEachStream(ctx context.Context, object *dataobj.Object, predicate stream
 	return nil
 }
 
-// dedupeAndSort takes a slice of string slices and returns a sorted slice of unique strings
-func dedupeAndSort(objects [][]string) []string {
-	uniquePaths := make(map[string]struct{})
-	for _, batch := range objects {
-		for _, path := range batch {
-			uniquePaths[path] = struct{}{}
+// dedupeAndSortEntries takes a slice of IndexEntry slices and returns a sorted slice of unique entries (by path).
+func dedupeAndSortEntries(batches [][]IndexEntry) []IndexEntry {
+	uniqueEntries := make(map[string]IndexEntry)
+	for _, batch := range batches {
+		for _, entry := range batch {
+			uniqueEntries[entry.Path] = entry
 		}
 	}
 
-	paths := make([]string, 0, len(uniquePaths))
-	for path := range uniquePaths {
-		paths = append(paths, path)
+	entries := make([]IndexEntry, 0, len(uniqueEntries))
+	for _, entry := range uniqueEntries {
+		entries = append(entries, entry)
 	}
-	sort.Strings(paths)
-	return paths
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Path < entries[j].Path
+	})
+	return entries
 }
 
 func (m *ObjectMetastore) Sections(ctx context.Context, req SectionsRequest) (SectionsResponse, error) {
@@ -594,7 +612,7 @@ func (m *ObjectMetastore) Sections(ctx context.Context, req SectionsRequest) (Se
 	}
 
 	// Return early if no index files found
-	if len(indexes.IndexesPaths) == 0 {
+	if len(indexes.Indexes) == 0 {
 		m.metrics.resolvedSectionsTotal.Observe(0)
 		level.Debug(utillog.WithContext(ctx, m.logger)).Log("msg", "no sections resolved", "reason", "no index paths")
 		return SectionsResponse{}, nil
@@ -606,10 +624,10 @@ func (m *ObjectMetastore) Sections(ctx context.Context, req SectionsRequest) (Se
 	g.SetLimit(m.parallelism)
 
 	totalSections := atomic.NewUint64(0)
-	for _, indexPath := range indexes.IndexesPaths {
+	for _, indexEntry := range indexes.Indexes {
 		g.Go(func() error {
 			readerResp, err := m.IndexSectionsReader(ctx, IndexSectionsReaderRequest{
-				IndexPath:       indexPath,
+				IndexPath:       indexEntry.Path,
 				SectionsRequest: req,
 			})
 			if err != nil {
@@ -651,7 +669,7 @@ func (m *ObjectMetastore) Sections(ctx context.Context, req SectionsRequest) (Se
 		"msg", "resolved sections",
 		"duration", duration,
 		"tables", len(indexes.TableOfContentsPaths),
-		"indexes", len(indexes.IndexesPaths),
+		"indexes", len(indexes.Indexes),
 		"sections", len(sections),
 		"ratio", ratio,
 		"matchers", matchersToString(req.Matchers),
@@ -711,15 +729,15 @@ func (m *ObjectMetastore) GetIndexes(ctx context.Context, req GetIndexesRequest)
 	}
 
 	// List index objects from all tables concurrently
-	indexPaths, err := m.listObjectsFromTables(ctx, resp.TableOfContentsPaths, req.Start, req.End)
+	indexEntries, err := m.listObjectsFromTables(ctx, resp.TableOfContentsPaths, req.Start, req.End)
 	if err != nil {
 		return resp, err
 	}
 
-	resp.IndexesPaths = indexPaths
+	resp.Indexes = indexEntries
 
-	m.metrics.indexObjectsTotal.Observe(float64(len(indexPaths)))
-	span.Record(xcap.StatMetastoreIndexObjects.Observe(int64(len(indexPaths))))
+	m.metrics.indexObjectsTotal.Observe(float64(len(indexEntries)))
+	span.Record(xcap.StatMetastoreIndexObjects.Observe(int64(len(indexEntries))))
 
 	return resp, nil
 }

--- a/pkg/engine/internal/planner/physical/metastore_planner.go
+++ b/pkg/engine/internal/planner/physical/metastore_planner.go
@@ -51,18 +51,28 @@ func (p MetastorePlanner) Plan(ctx context.Context, selector Expression, predica
 	}
 	plan.graph.Add(scanSet)
 
-	for _, indexPath := range indexesResp.IndexesPaths {
+	for _, entry := range indexesResp.Indexes {
+		// Clamp the scan Start/End to the intersection of [query_start, query_end] ∩ [index_start, index_end].
+		scanStart := entry.Start
+		if start.After(scanStart) {
+			scanStart = start
+		}
+		scanEnd := entry.End
+		if end.Before(scanEnd) {
+			scanEnd = end
+		}
+
 		scanSet.Targets = append(scanSet.Targets, &ScanTarget{
 			Type: ScanTypePointers,
 			Pointers: &PointersScan{
 				NodeID:   ulid.Make(),
-				Location: DataObjLocation(indexPath),
+				Location: DataObjLocation(entry.Path),
 
 				Selector:   selector,
 				Predicates: predicates,
 
-				Start: start,
-				End:   end,
+				Start: scanStart,
+				End:   scanEnd,
 			},
 		})
 	}

--- a/pkg/engine/internal/planner/physical/metastore_planner_test.go
+++ b/pkg/engine/internal/planner/physical/metastore_planner_test.go
@@ -13,11 +13,11 @@ import (
 
 type fakeMetastoreIndexes struct {
 	metastore.Metastore
-	indexPaths []string
+	indexes []metastore.IndexEntry
 }
 
 func (f fakeMetastoreIndexes) GetIndexes(_ context.Context, _ metastore.GetIndexesRequest) (metastore.GetIndexesResponse, error) {
-	return metastore.GetIndexesResponse{IndexesPaths: f.indexPaths}, nil
+	return metastore.GetIndexesResponse{Indexes: f.indexes}, nil
 }
 
 func TestPointersScan_Clone_AllowsNilSelector(t *testing.T) {
@@ -30,13 +30,87 @@ func TestPointersScan_Clone_AllowsNilSelector(t *testing.T) {
 	require.Nil(t, cloned.Selector)
 }
 
-func TestMetastorePlanner_Plan_UsesMergeRootAndPointersTargets(t *testing.T) {
-	ms := fakeMetastoreIndexes{
-		indexPaths: []string{"index/0", "index/1"},
+func TestMetastorePlanner_Plan_ClampsScanTimeRange(t *testing.T) {
+	// Queries typically span multiple hours while individual index objects cover
+	// shorter windows. The common case is that the index range sits fully inside
+	// the query range and the scan uses the index boundaries unchanged.
+	// Clamping only kicks in for the boundary objects whose range extends outside
+	// the query window.
+	queryStart := time.Unix(0, 0).UTC()
+	queryEnd := queryStart.Add(6 * time.Hour)
+
+	tests := []struct {
+		name          string
+		indexStart    time.Time
+		indexEnd      time.Time
+		wantScanStart time.Time
+		wantScanEnd   time.Time
+	}{
+		{
+			name:          "index within query range (common case, no clamping)",
+			indexStart:    queryStart.Add(1 * time.Hour),
+			indexEnd:      queryStart.Add(2 * time.Hour),
+			wantScanStart: queryStart.Add(1 * time.Hour),
+			wantScanEnd:   queryStart.Add(2 * time.Hour),
+		},
+		{
+			name:          "index starts before query start (start clamped to query start)",
+			indexStart:    queryStart.Add(-1 * time.Hour),
+			indexEnd:      queryStart.Add(1 * time.Hour),
+			wantScanStart: queryStart,
+			wantScanEnd:   queryStart.Add(1 * time.Hour),
+		},
+		{
+			name:          "index ends after query end (end clamped to query end)",
+			indexStart:    queryEnd.Add(-1 * time.Hour),
+			indexEnd:      queryEnd.Add(1 * time.Hour),
+			wantScanStart: queryEnd.Add(-1 * time.Hour),
+			wantScanEnd:   queryEnd,
+		},
 	}
 
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ms := fakeMetastoreIndexes{
+				indexes: []metastore.IndexEntry{
+					{Path: "index/0", Start: tc.indexStart, End: tc.indexEnd},
+				},
+			}
+
+			p := NewMetastorePlanner(ms, 100)
+			plan, err := p.Plan(context.Background(), nil, nil, queryStart, queryEnd)
+			require.NoError(t, err)
+
+			root, err := plan.Root()
+			require.NoError(t, err)
+
+			// Unwrap Batching → Merge → Parallelize → ScanSet
+			merge := plan.Children(root)
+			require.Len(t, merge, 1)
+			parallelize := plan.Children(merge[0])
+			require.Len(t, parallelize, 1)
+			scanSetNodes := plan.Children(parallelize[0])
+			require.Len(t, scanSetNodes, 1)
+			set := scanSetNodes[0].(*ScanSet)
+			require.Len(t, set.Targets, 1)
+
+			scan := set.Targets[0].Pointers
+			require.Equal(t, tc.wantScanStart, scan.Start)
+			require.Equal(t, tc.wantScanEnd, scan.End)
+		})
+	}
+}
+
+func TestMetastorePlanner_Plan_UsesMergeRootAndPointersTargets(t *testing.T) {
 	start := time.Unix(10, 0)
 	end := start.Add(time.Hour)
+
+	ms := fakeMetastoreIndexes{
+		indexes: []metastore.IndexEntry{
+			{Path: "index/0", Start: start, End: end},
+			{Path: "index/1", Start: start, End: end},
+		},
+	}
 
 	p := NewMetastorePlanner(ms, 100)
 	plan, err := p.Plan(context.Background(), nil, nil, start, end)
@@ -60,12 +134,12 @@ func TestMetastorePlanner_Plan_UsesMergeRootAndPointersTargets(t *testing.T) {
 	require.IsType(t, &ScanSet{}, parallelChildren[0])
 
 	set := parallelChildren[0].(*ScanSet)
-	require.Len(t, set.Targets, len(ms.indexPaths))
+	require.Len(t, set.Targets, len(ms.indexes))
 
 	for i, target := range set.Targets {
 		require.Equal(t, ScanTypePointers, target.Type)
 		require.NotNil(t, target.Pointers)
-		require.Equal(t, DataObjLocation(ms.indexPaths[i]), target.Pointers.Location)
+		require.Equal(t, DataObjLocation(ms.indexes[i].Path), target.Pointers.Location)
 		require.Equal(t, start, target.Pointers.Start)
 		require.Equal(t, end, target.Pointers.End)
 	}

--- a/pkg/engine/internal/workflow/metastore_workflow_planner_test.go
+++ b/pkg/engine/internal/workflow/metastore_workflow_planner_test.go
@@ -14,20 +14,24 @@ import (
 
 type fakeMetastoreIndexes struct {
 	metastore.Metastore
-	indexPaths []string
+	indexes []metastore.IndexEntry
 }
 
 func (f fakeMetastoreIndexes) GetIndexes(_ context.Context, _ metastore.GetIndexesRequest) (metastore.GetIndexesResponse, error) {
-	return metastore.GetIndexesResponse{IndexesPaths: f.indexPaths}, nil
+	return metastore.GetIndexesResponse{Indexes: f.indexes}, nil
 }
 
 func TestPlanWorkflow_MetastorePlan_UsesMergeRootAndPointersPartitions(t *testing.T) {
-	ms := fakeMetastoreIndexes{
-		indexPaths: []string{"index/0", "index/1", "index/2"},
-	}
-
 	start := time.Unix(10, 0)
 	end := start.Add(time.Hour)
+
+	ms := fakeMetastoreIndexes{
+		indexes: []metastore.IndexEntry{
+			{Path: "index/0", Start: start, End: end},
+			{Path: "index/1", Start: start, End: end},
+			{Path: "index/2", Start: start, End: end},
+		},
+	}
 
 	p := physical.NewMetastorePlanner(ms, 100)
 	plan, err := p.Plan(context.Background(), nil, nil, start, end)
@@ -49,10 +53,10 @@ func TestPlanWorkflow_MetastorePlan_UsesMergeRootAndPointersPartitions(t *testin
 	require.Len(t, mergeNode, 1)
 	require.IsType(t, &physical.Merge{}, mergeNode[0])
 
-	require.Len(t, rootTask.Sources[mergeNode[0]], len(ms.indexPaths))
+	require.Len(t, rootTask.Sources[mergeNode[0]], len(ms.indexes))
 
 	children := graph.Children(rootTask)
-	require.Len(t, children, len(ms.indexPaths))
+	require.Len(t, children, len(ms.indexes))
 
 	gotLocations := make(map[physical.DataObjLocation]struct{}, len(children))
 	for _, child := range children {
@@ -73,8 +77,8 @@ func TestPlanWorkflow_MetastorePlan_UsesMergeRootAndPointersPartitions(t *testin
 		gotLocations[batchingChildren[0].(*physical.PointersScan).Location] = struct{}{}
 	}
 
-	for _, indexPath := range ms.indexPaths {
-		_, ok := gotLocations[physical.DataObjLocation(indexPath)]
-		require.True(t, ok, "missing partition for %q", indexPath)
+	for _, entry := range ms.indexes {
+		_, ok := gotLocations[physical.DataObjLocation(entry.Path)]
+		require.True(t, ok, "missing partition for %q", entry.Path)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Before this PR, all pointerscans within a metasotre workflow contained the same start and end: the query start and end. This made the caching of metastore tasks ineffective since the query start and end would change in the bast majority of queries.

We now clamp the start/end to the index start/end. Testing this increased the hit rate in a dev cell from <1% to >95%.

Even though the workflow optimizer from https://github.com/grafana/loki/pull/21327 tried to clamp the PointersScans predicates, these predicates will not actually have the time range predicates as DataObjScans do. I decided to leave that optimization in place for the future, but I'm happy to remove it in a followup PR.

I also considered doing the clamping on the existing optimization, taking the query time range from the [Plan.CalculateMaxTimeRange](https://github.com/grafana/loki/blob/bd51fcae09d1301f3d9b58ac81dac427e88819ff/pkg/engine/internal/planner/physical/plan.go#L197), but doing it at the `MetastorePlanner.Plan` seemed simpler.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the metastore API shape and alters planner scan time ranges, which can impact query execution and caching behavior if index metadata is incorrect or missing.
> 
> **Overview**
> Improves metastore workflow caching by **clamping each `PointersScan` time range to the intersection of the query window and the underlying index object’s `[Start, End]`**.
> 
> To support this, `GetIndexesResponse` now returns `Indexes []IndexEntry` (path + covered time range) instead of plain index paths, and the object metastore propagates/dedupes these entries (unioning time ranges on duplicate paths). Tests are updated and a new planner test asserts the clamping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3687df52c385e1e997c3f4ff3631fec738c45517. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->