### PR TITLE
perf: don't spawn a goroutine per stream

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1291,15 +1291,16 @@ func (d *Distributor) sendStreamsErr(ctx context.Context, ingester ring.Instance
 }
 
 func (d *Distributor) sendStreamsToKafka(ctx context.Context, streams []KeyedStream, tenant string, tracker *PushTracker, subring *ring.PartitionRing) {
-	for _, s := range streams {
-		go func(s KeyedStream) {
+	go func() {
+		for _, s := range streams {
 			err := d.sendStreamToKafka(ctx, s, tenant, subring)
 			if err != nil {
 				err = fmt.Errorf("failed to write stream to kafka: %w", err)
 			}
 			tracker.doneWithResult(err)
-		}(s)
-	}
+		}
+	}()
+
 }
 
 func (d *Distributor) sendStreamToKafka(ctx context.Context, stream KeyedStream, tenant string, subring *ring.PartitionRing) error {


### PR DESCRIPTION
This is targeting lowering memory usage - spinning up a goroutine per stream is likely overkill and although the overhead of a goroutine is small, it can add up at large scale.

**What this PR does / why we need it**: Don't spawn a goroutine per stream - instead spawn a goroutine per thread.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Kafka write fan-out from per-stream goroutines to a single background goroutine, which can alter write concurrency/throughput and request completion timing under load.
> 
> **Overview**
> **Kafka push concurrency is reduced.** `sendStreamsToKafka` now launches a *single* goroutine that iterates through all streams and calls `sendStreamToKafka`, instead of spawning a goroutine per stream.
> 
> This lowers goroutine/memory overhead on large pushes, but also changes the Kafka write path from parallel to sequential within that goroutine while keeping the same per-stream `PushTracker` completion/error reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42e3fb129cdf2e47380782cf8d379d2d87485bfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->