### PR TITLE
chore(operator): prepare community release v0.10.1

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -21,7 +21,7 @@ LOKI_OPERATOR_NS ?= kubernetes-operators
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.10.0
+VERSION ?= 0.10.1
 CHANNELS ?= "alpha"
 DEFAULT_CHANNEL ?= "alpha"
 

--- a/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-metrics-reader_v1_serviceaccount.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-metrics-reader_v1_serviceaccount.yaml
@@ -3,9 +3,9 @@ kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: loki-operator-controller-manager-metrics-reader

--- a/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
@@ -6,11 +6,11 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: loki-operator-controller-manager-metrics-service
 spec:
   ports:

--- a/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-metrics-token_v1_secret.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-metrics-token_v1_secret.yaml
@@ -4,10 +4,10 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: loki-operator-controller-manager-metrics-reader
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: loki-operator-controller-manager-metrics-token
 type: kubernetes.io/service-account-token

--- a/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-read-metrics_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-read-metrics_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -3,11 +3,11 @@ kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: loki-operator-controller-manager-read-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operator/bundle/community-openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
@@ -61,9 +61,9 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: loki-operator-manager-config

--- a/operator/bundle/community-openshift/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -2,11 +2,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
     name: loki-operator
   name: loki-operator-metrics-monitor
 spec:

--- a/operator/bundle/community-openshift/manifests/loki-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -3,11 +3,11 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: loki-operator-metrics-reader
 rules:
 - nonResourceURLs:

--- a/operator/bundle/community-openshift/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_role.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_role.yaml
@@ -6,11 +6,11 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: loki-operator-prometheus
 rules:
 - apiGroups:

--- a/operator/bundle/community-openshift/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -6,11 +6,11 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: loki-operator-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operator/bundle/community-openshift/manifests/loki-operator-webhook-service_v1_service.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-webhook-service_v1_service.yaml
@@ -3,11 +3,11 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: loki-operator-webhook-service
 spec:
   ports:

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -151,8 +151,8 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional, Logging & Tracing, Observability
     certified: "false"
-    containerImage: docker.io/grafana/loki-operator:0.10.0
-    createdAt: "2026-03-17T17:13:04Z"
+    containerImage: docker.io/grafana/loki-operator:0.10.1
+    createdAt: "2026-04-10T16:58:37Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     features.operators.openshift.io/disconnected: "true"
@@ -169,7 +169,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
-  name: loki-operator.v0.10.0
+  name: loki-operator.v0.10.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1929,11 +1929,11 @@ spec:
         serviceAccountName: loki-operator-controller-manager
       deployments:
       - label:
-          app.kubernetes.io/instance: loki-operator-v0.10.0
+          app.kubernetes.io/instance: loki-operator-v0.10.1
           app.kubernetes.io/managed-by: operator-lifecycle-manager
           app.kubernetes.io/name: loki-operator
           app.kubernetes.io/part-of: loki-operator
-          app.kubernetes.io/version: 0.10.0
+          app.kubernetes.io/version: 0.10.1
           control-plane: controller-manager
         name: loki-operator-controller-manager
         spec:
@@ -1967,7 +1967,7 @@ spec:
                   value: quay.io/observatorium/api:latest
                 - name: RELATED_IMAGE_OPA
                   value: quay.io/observatorium/opa-openshift:latest
-                image: docker.io/grafana/loki-operator:0.10.0
+                image: docker.io/grafana/loki-operator:0.10.1
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:
@@ -2075,8 +2075,8 @@ spec:
     name: gateway
   - image: quay.io/observatorium/opa-openshift:latest
     name: opa
-  replaces: loki-operator.v0.9.0
-  version: 0.10.0
+  replaces: loki-operator.v0.10.0
+  version: 0.10.1
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/operator/bundle/community-openshift/manifests/loki.grafana.com_alertingrules.yaml
+++ b/operator/bundle/community-openshift/manifests/loki.grafana.com_alertingrules.yaml
@@ -5,11 +5,11 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.1
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: alertingrules.loki.grafana.com
 spec:
   conversion:

--- a/operator/bundle/community-openshift/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/community-openshift/manifests/loki.grafana.com_lokistacks.yaml
@@ -5,11 +5,11 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.1
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: lokistacks.loki.grafana.com
 spec:
   conversion:

--- a/operator/bundle/community-openshift/manifests/loki.grafana.com_recordingrules.yaml
+++ b/operator/bundle/community-openshift/manifests/loki.grafana.com_recordingrules.yaml
@@ -5,11 +5,11 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.1
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: recordingrules.loki.grafana.com
 spec:
   conversion:

--- a/operator/bundle/community-openshift/manifests/loki.grafana.com_rulerconfigs.yaml
+++ b/operator/bundle/community-openshift/manifests/loki.grafana.com_rulerconfigs.yaml
@@ -5,11 +5,11 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.1
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: rulerconfigs.loki.grafana.com
 spec:
   conversion:

--- a/operator/bundle/community/manifests/loki-operator-controller-manager-metrics-reader_v1_serviceaccount.yaml
+++ b/operator/bundle/community/manifests/loki-operator-controller-manager-metrics-reader_v1_serviceaccount.yaml
@@ -3,9 +3,9 @@ kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: loki-operator-controller-manager-metrics-reader

--- a/operator/bundle/community/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operator/bundle/community/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
@@ -4,11 +4,11 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: loki-operator-controller-manager-metrics-service
 spec:
   ports:

--- a/operator/bundle/community/manifests/loki-operator-controller-manager-read-metrics_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/operator/bundle/community/manifests/loki-operator-controller-manager-read-metrics_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -3,11 +3,11 @@ kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: loki-operator-controller-manager-read-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operator/bundle/community/manifests/loki-operator-manager-config_v1_configmap.yaml
+++ b/operator/bundle/community/manifests/loki-operator-manager-config_v1_configmap.yaml
@@ -28,9 +28,9 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: loki-operator-manager-config

--- a/operator/bundle/community/manifests/loki-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operator/bundle/community/manifests/loki-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -3,11 +3,11 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: loki-operator-metrics-reader
 rules:
 - nonResourceURLs:

--- a/operator/bundle/community/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_role.yaml
+++ b/operator/bundle/community/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_role.yaml
@@ -6,11 +6,11 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: loki-operator-prometheus
 rules:
 - apiGroups:

--- a/operator/bundle/community/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/operator/bundle/community/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -6,11 +6,11 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: loki-operator-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operator/bundle/community/manifests/loki-operator-webhook-service_v1_service.yaml
+++ b/operator/bundle/community/manifests/loki-operator-webhook-service_v1_service.yaml
@@ -3,11 +3,11 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: loki-operator-webhook-service
 spec:
   ports:

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -151,8 +151,8 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional, Logging & Tracing, Observability
     certified: "false"
-    containerImage: docker.io/grafana/loki-operator:0.10.0
-    createdAt: "2026-03-17T17:13:03Z"
+    containerImage: docker.io/grafana/loki-operator:0.10.1
+    createdAt: "2026-04-10T16:58:36Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown
@@ -162,7 +162,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
-  name: loki-operator.v0.10.0
+  name: loki-operator.v0.10.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1909,11 +1909,11 @@ spec:
         serviceAccountName: loki-operator-controller-manager
       deployments:
       - label:
-          app.kubernetes.io/instance: loki-operator-v0.10.0
+          app.kubernetes.io/instance: loki-operator-v0.10.1
           app.kubernetes.io/managed-by: operator-lifecycle-manager
           app.kubernetes.io/name: loki-operator
           app.kubernetes.io/part-of: loki-operator
-          app.kubernetes.io/version: 0.10.0
+          app.kubernetes.io/version: 0.10.1
           control-plane: controller-manager
         name: loki-operator-controller-manager
         spec:
@@ -1947,7 +1947,7 @@ spec:
                   value: quay.io/observatorium/api:latest
                 - name: RELATED_IMAGE_OPA
                   value: quay.io/observatorium/opa-openshift:latest
-                image: docker.io/grafana/loki-operator:0.10.0
+                image: docker.io/grafana/loki-operator:0.10.1
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:
@@ -2045,8 +2045,8 @@ spec:
     name: gateway
   - image: quay.io/observatorium/opa-openshift:latest
     name: opa
-  replaces: loki-operator.v0.9.0
-  version: 0.10.0
+  replaces: loki-operator.v0.10.0
+  version: 0.10.1
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/operator/bundle/community/manifests/loki.grafana.com_alertingrules.yaml
+++ b/operator/bundle/community/manifests/loki.grafana.com_alertingrules.yaml
@@ -6,11 +6,11 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.1
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: alertingrules.loki.grafana.com
 spec:
   conversion:

--- a/operator/bundle/community/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/community/manifests/loki.grafana.com_lokistacks.yaml
@@ -6,11 +6,11 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.1
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: lokistacks.loki.grafana.com
 spec:
   conversion:

--- a/operator/bundle/community/manifests/loki.grafana.com_recordingrules.yaml
+++ b/operator/bundle/community/manifests/loki.grafana.com_recordingrules.yaml
@@ -6,11 +6,11 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.1
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: recordingrules.loki.grafana.com
 spec:
   conversion:

--- a/operator/bundle/community/manifests/loki.grafana.com_rulerconfigs.yaml
+++ b/operator/bundle/community/manifests/loki.grafana.com_rulerconfigs.yaml
@@ -6,11 +6,11 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.1
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/version: 0.10.1
   name: rulerconfigs.loki.grafana.com
 spec:
   conversion:

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -152,7 +152,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing, Observability
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:0.1.0
-    createdAt: "2026-03-17T17:13:05Z"
+    createdAt: "2026-04-10T16:58:38Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements

--- a/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional, Logging & Tracing, Observability
     certified: "false"
-    containerImage: docker.io/grafana/loki-operator:0.10.0
+    containerImage: docker.io/grafana/loki-operator:0.10.1
     createdAt: "2022-12-22T13:28:40+00:00"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
@@ -2595,5 +2595,5 @@ spec:
   minKubeVersion: 1.21.1
   provider:
     name: Grafana Loki SIG Operator
-  replaces: loki-operator.v0.9.0
+  replaces: loki-operator.v0.10.0
   version: 0.0.0

--- a/operator/config/manifests/community/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/community/bases/loki-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional, Logging & Tracing, Observability
     certified: "false"
-    containerImage: docker.io/grafana/loki-operator:0.10.0
+    containerImage: docker.io/grafana/loki-operator:0.10.1
     createdAt: "2022-12-22T13:28:40+00:00"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
@@ -2575,5 +2575,5 @@ spec:
   minKubeVersion: 1.21.1
   provider:
     name: Grafana Loki SIG Operator
-  replaces: loki-operator.v0.9.0
+  replaces: loki-operator.v0.10.0
   version: 0.0.0

--- a/operator/config/overlays/community-openshift/kustomization.yaml
+++ b/operator/config/overlays/community-openshift/kustomization.yaml
@@ -14,8 +14,8 @@ labels:
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
 - pairs:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
+    app.kubernetes.io/version: 0.10.1
 
 configMapGenerator:
 - behavior: replace
@@ -27,7 +27,7 @@ configMapGenerator:
 images:
 - name: controller
   newName: docker.io/grafana/loki-operator
-  newTag: 0.10.0
+  newTag: 0.10.1
 
 patches:
 - path: manager_related_image_patch.yaml

--- a/operator/config/overlays/community/kustomization.yaml
+++ b/operator/config/overlays/community/kustomization.yaml
@@ -25,8 +25,8 @@ labels:
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
 - pairs:
-    app.kubernetes.io/instance: loki-operator-v0.10.0
-    app.kubernetes.io/version: 0.10.0
+    app.kubernetes.io/instance: loki-operator-v0.10.1
+    app.kubernetes.io/version: 0.10.1
 
 generatorOptions:
   disableNameSuffixHash: true
@@ -40,7 +40,7 @@ configMapGenerator:
 images:
 - name: controller
   newName: docker.io/grafana/loki-operator
-  newTag: 0.10.0
+  newTag: 0.10.1
 
 # the following config is for teaching kustomize how to do var substitution
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.


### PR DESCRIPTION
**What this PR does / why we need it**:
In draft, waiting for https://github.com/grafana/loki/pull/21504

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a version bump across generated bundle/Kustomize manifests; low functional risk but reviewers should sanity-check OLM upgrade metadata (`replaces`) and image tag changes for release correctness.
> 
> **Overview**
> Bumps the community Loki Operator release from `0.10.0` to `0.10.1`, updating the `Makefile` `VERSION`, Kustomize image tags, and all bundle manifests/labels to reference `docker.io/grafana/loki-operator:0.10.1`.
> 
> Updates OLM `ClusterServiceVersion` metadata for the new release (new CSV name/version, updated `createdAt`, and `replaces: loki-operator.v0.10.0`) for both `community` and `community-openshift` bundles, plus refreshes the OpenShift CSV `createdAt` timestamp.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 362cff13da74f38e7bed3dd4c1e706daba0ed7f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->