### PR TITLE
fix: do not spawn workers if ingesters are disabled

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -476,9 +476,12 @@ func (d *Distributor) running(ctx context.Context) error {
 		cancel()
 		d.ingesterTaskWg.Wait()
 	}()
-	d.ingesterTaskWg.Add(d.cfg.PushWorkerCount)
-	for i := 0; i < d.cfg.PushWorkerCount; i++ {
-		go d.pushIngesterWorker(ctx)
+	if d.cfg.IngesterEnabled {
+		// Spawn workers if ingesters are enabled.
+		d.ingesterTaskWg.Add(d.cfg.PushWorkerCount)
+		for i := 0; i < d.cfg.PushWorkerCount; i++ {
+			go d.pushIngesterWorker(ctx)
+		}
 	}
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
**What this PR does / why we need it**:

I noticed from profiles that we have 100s of goroutines running (per pod) when ingesters are disabled/Kafka ingestion is used. This should reduce the number of goroutines that need to be managed in the runtime.

**Without the fix**

<img width="1063" height="327" alt="Screenshot 2026-04-13 at 15 27 01" src="https://github.com/user-attachments/assets/6d94b010-e1d2-4fc9-b62f-d6f8a441d601" />

**With the fix**

<img width="1410" height="419" alt="Screenshot 2026-04-13 at 16 58 55" src="https://github.com/user-attachments/assets/30306237-db88-4755-b0d9-02b92e2ae687" />


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change scoped to distributor startup behavior; it only gates goroutine/worker creation on `IngesterEnabled` and should not affect request handling when ingester writes are enabled.
> 
> **Overview**
> Prevents the distributor from spawning `pushIngesterWorker` goroutines when `distributor.ingester-writes-enabled` is `false`, avoiding hundreds of idle workers in Kafka-only deployments.
> 
> The worker waitgroup lifecycle is unchanged, but worker creation is now conditional on ingester writes being enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 261be2b676fcf952e31e55ff9c629d8eb5b21733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->