### PR TITLE
pkg/logql/log: remove vestigial sync.RWMutex from pipeline types

### DIFF
--- a/pkg/logql/log/pipeline.go
+++ b/pkg/logql/log/pipeline.go
@@ -2,11 +2,9 @@ package log
 
 import (
 	"context"
+	"unsafe"
 
 	"github.com/prometheus/prometheus/model/labels"
-
-	"sync"
-	"unsafe"
 )
 
 // NoopStage is a stage that doesn't process a log line.
@@ -51,35 +49,24 @@ func NewNoopPipeline() Pipeline {
 	}
 }
 
+// noopPipeline is not safe for concurrent use. Callers must serialize access
+// externally; see the pipelineMtx pattern in pkg/ingester/tailer.go.
 type noopPipeline struct {
 	cache       map[uint64]*noopStreamPipeline
 	baseBuilder *BaseLabelsBuilder
-	mu          sync.RWMutex
 }
 
 func (n *noopPipeline) ForStream(labels labels.Labels) StreamPipeline {
 	h := n.baseBuilder.Hash(labels)
-
-	n.mu.RLock()
 	if cached, ok := n.cache[h]; ok {
-		n.mu.RUnlock()
 		return cached
 	}
-	n.mu.RUnlock()
-
 	sp := &noopStreamPipeline{n.baseBuilder.ForLabels(labels, h)}
-
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
 	n.cache[h] = sp
 	return sp
 }
 
 func (n *noopPipeline) Reset() {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
 	for k := range n.cache {
 		delete(n.cache, k)
 	}
@@ -137,11 +124,12 @@ func (fn StageFunc) RequiredLabelNames() []string {
 
 // pipeline is a combinations of multiple stages.
 // It can also be reduced into a single stage for convenience.
+// pipeline is not safe for concurrent use. Callers must serialize access
+// externally; see the pipelineMtx pattern in pkg/ingester/tailer.go.
 type pipeline struct {
 	AnalyzablePipeline
 	stages      []Stage
 	baseBuilder *BaseLabelsBuilder
-	mu          sync.RWMutex
 
 	streamPipelines map[uint64]StreamPipeline
 }
@@ -186,27 +174,15 @@ func NewStreamPipeline(stages []Stage, labelsBuilder *LabelsBuilder) StreamPipel
 
 func (p *pipeline) ForStream(labels labels.Labels) StreamPipeline {
 	hash := p.baseBuilder.Hash(labels)
-
-	p.mu.RLock()
 	if res, ok := p.streamPipelines[hash]; ok {
-		p.mu.RUnlock()
 		return res
 	}
-	p.mu.RUnlock()
-
 	res := NewStreamPipeline(p.stages, p.baseBuilder.ForLabels(labels, hash))
-
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
 	p.streamPipelines[hash] = res
 	return res
 }
 
 func (p *pipeline) Reset() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
 	p.baseBuilder.Reset()
 	for k := range p.streamPipelines {
 		delete(p.streamPipelines, k)


### PR DESCRIPTION
## Summary

Removes the `sync.RWMutex` from `pipeline` and `noopPipeline` and documents both types as not safe for concurrent use, matching the established contract at `pkg/ingester/tailer.go:190`.

**Why the mutex is vestigial:**
- The design contract ("pipelines are not thread safe, serialize at the caller") was set in #2917 via the external `pipelineMtx` in the tailer — `pkg/logql/log/pipeline.go` was never touched.
- The mutex was added in #9949 as a side effect of introducing `Reset()` with no review discussion and no concurrent tests.
- The double-check locking pattern was incomplete (no re-check after acquiring the write lock), and `BaseLabelsBuilder` methods called within it are themselves not thread safe, so the mutex didn't actually provide the protection it implied.
- The sibling types `lineSampleExtractor` and `labelSampleExtractor` in `metrics_extraction.go` follow the identical per-stream cache pattern and have never had a mutex.
- No production caller invokes `ForStream` concurrently on a shared pipeline instance (traced in the issue).

**Change:** remove `mu sync.RWMutex` from both structs, remove all lock/unlock calls, drop the unused `sync` import, add doc comments.

Closes #21524

Signed-off-by: Ali <alliasgher123@gmail.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes internal `sync.RWMutex` locking from `pipeline`/`noopPipeline`, so any previously-unserialized concurrent use could now race; callers must rely on external serialization (as in `tailer.pipelineMtx`). Scope is small but touches caching used during ingestion/query processing.
> 
> **Overview**
> Removes the internal `sync.RWMutex` from `pipeline` and `noopPipeline` and strips the associated lock/unlock code around per-stream cache access and `Reset()`.
> 
> Adds explicit documentation that these pipeline types are **not safe for concurrent use** and must be externally serialized (referencing the existing `pipelineMtx` pattern in `pkg/ingester/tailer.go`), and drops the now-unused `sync` import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99d4426c75bbab80c74328fd35ec5991889b758d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->