### PR TITLE
feat(distributor): introduce distributor_bytes_accepted_total

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -220,6 +220,13 @@ type Distributor struct {
 	inflightBytes      *atomic.Uint64
 	inflightBytesGauge prometheus.Gauge
 
+	// bytesAcceptedTotal counts uncompressed bytes that survived all
+	// distributor-level rejections (validation, ingestion rate limit, ingest
+	// limits). Pairs naturally with discarded_bytes_total because both are
+	// derived from util.EntryTotalSize, which is not true of
+	// distributor_bytes_received_total.
+	bytesAcceptedTotal *prometheus.CounterVec
+
 	// kafka metrics
 	kafkaAppends           *prometheus.CounterVec
 	kafkaWriteBytesTotal   prometheus.Counter
@@ -414,6 +421,11 @@ func New(
 			Name:      "distributor_inflight_bytes",
 			Help:      "The number of bytes currently inflight.",
 		}),
+		bytesAcceptedTotal: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "distributor_bytes_accepted_total",
+			Help:      "Uncompressed bytes (sum of util.EntryTotalSize) that survived all distributor-level rejections (validation, ingestion rate limit, ingest limits) and are about to be sent to ingesters/kafka. Pairs with distributor_discarded_bytes_total.",
+		}, []string{"tenant"}),
 	}
 
 	if overrides.IngestionRateStrategy() == validation.GlobalIngestionRateStrategy {
@@ -828,6 +840,17 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 			}
 			streams = accepted
 		}
+	}
+
+	// Record bytes that survived all distributor-level rejections. Recompute
+	// from the post-filter streams rather than reusing totalEntriesSize so
+	// any streams dropped by ingest limits are excluded.
+	acceptedBytes := 0
+	for _, s := range streams {
+		acceptedBytes += util.EntriesTotalSize(s.Stream.Entries)
+	}
+	if acceptedBytes > 0 {
+		d.bytesAcceptedTotal.WithLabelValues(tenantID).Add(float64(acceptedBytes))
 	}
 
 	tracker := PushTracker{

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -831,6 +831,26 @@ func Test_DiscardEmptyStreamsAfterValidation(t *testing.T) {
 	})
 }
 
+func TestDistributor_BytesAcceptedTotal(t *testing.T) {
+	limits := &validation.Limits{}
+	flagext.DefaultValues(limits)
+	// Generous limits so the request is not rate-limited.
+	limits.IngestionRateMB = 100
+	limits.IngestionBurstSizeMB = 100
+
+	ingester := &mockIngester{}
+	distributors, _ := prepare(t, 1, 5, limits, func(_ string) (ring_client.PoolClient, error) { return ingester, nil })
+
+	const lines, lineSize = 5, 10
+	_, err := distributors[0].Push(ctx, makeWriteRequest(lines, lineSize))
+	require.NoError(t, err)
+
+	// makeWriteRequest produces `lines` entries of `lineSize` bytes each,
+	// no structured metadata, so accepted bytes == lines * lineSize.
+	got := testutil.ToFloat64(distributors[0].bytesAcceptedTotal.WithLabelValues("test"))
+	require.Equal(t, float64(lines*lineSize), got)
+}
+
 func TestStreamShard(t *testing.T) {
 	// setup base stream.
 	baseStream := logproto.Stream{}


### PR DESCRIPTION
## Summary

`distributor_bytes_received_total` and `distributor_discarded_bytes_total` are not derived from the same byte definition (one counts request body sizes, the other counts entry sizes via `util.EntryTotalSize`), so subtracting them in PromQL to estimate "accepted bytes" produces misleading results — discarded can even exceed received in some cases.

This PR adds `distributor_bytes_accepted_total`, sourced from `util.EntryTotalSize` exactly like `discarded_bytes_total`. It is recorded after both the ingestion rate-limit check and the ingest-limits filter, so it represents the bytes the distributor actually passed downstream to ingesters/kafka. Pairs algebraically with `discarded_bytes_total`.

The metric is labeled by `tenant` only, matching the granularity of `discarded_bytes_total`'s tenant dimension.

Closes #21501

## Test plan

- [x] `go test ./pkg/distributor/`
- [x] `gofmt` clean
- [x] New `TestDistributor_BytesAcceptedTotal` pushes 5 entries × 10 bytes each and asserts the counter reads `50`.

Signed-off-by: Ali <alliasgher123@gmail.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `Push` hot path by recomputing per-request entry sizes and updating a new counter, which could impact ingestion performance or metric cardinality if misused. Functionality is otherwise additive and covered by a unit test.
> 
> **Overview**
> Adds a new Prometheus counter, `distributor_bytes_accepted_total{tenant=...}`, to track *uncompressed* bytes (via `util.EntriesTotalSize`) that survive distributor-level rejections and are about to be forwarded to ingesters/Kafka.
> 
> The counter is incremented in `PushWithResolver` after the ingestion rate limit check and after any ingest-limits filtering (recomputing bytes from the post-filter stream set), and a new unit test (`TestDistributor_BytesAcceptedTotal`) validates the counter value for a successful push.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57942d29d0fa66e7319d9d397cef2b10fa9a5fc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->