### PR TITLE
feat: Write all Kafka records at once

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -847,7 +847,7 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 	if d.cfg.KafkaEnabled {
 		// When Kafka is enabled, we track just one stream, instead of len(streams),
 		// as all streams are written to Kafka at once.
-		streamsToWrite += 1
+		streamsToWrite++
 	}
 
 	// We must correctly set streamsPending before beginning any writes to ensure we don't have a race between finishing all of one path before starting the other.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -845,7 +845,9 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 		streamsToWrite += len(streams)
 	}
 	if d.cfg.KafkaEnabled {
-		streamsToWrite += len(streams)
+		// When Kafka is enabled, we track just one stream, instead of len(streams),
+		// as all streams are written to Kafka at once.
+		streamsToWrite += 1
 	}
 
 	// We must correctly set streamsPending before beginning any writes to ensure we don't have a race between finishing all of one path before starting the other.
@@ -874,7 +876,7 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 			}
 		}
 		// We don't need to create a new context like the ingester writes, because we don't return unless all writes have succeeded.
-		d.sendStreamsToKafka(ctx, streams, tenantID, &tracker, subring)
+		d.sendStreamsToKafka(ctx, tenantID, streams, &tracker, subring)
 	}
 
 	if d.cfg.IngesterEnabled {
@@ -1292,66 +1294,71 @@ func (d *Distributor) sendStreamsErr(ctx context.Context, ingester ring.Instance
 	return err
 }
 
-func (d *Distributor) sendStreamsToKafka(ctx context.Context, streams []KeyedStream, tenant string, tracker *PushTracker, subring *ring.PartitionRing) {
-	for _, s := range streams {
-		go func(s KeyedStream) {
-			err := d.sendStreamToKafka(ctx, s, tenant, subring)
-			if err != nil {
-				err = fmt.Errorf("failed to write stream to kafka: %w", err)
-			}
-			tracker.doneWithResult(err)
-		}(s)
-	}
-}
-
-func (d *Distributor) sendStreamToKafka(ctx context.Context, stream KeyedStream, tenant string, subring *ring.PartitionRing) error {
-	if len(stream.Stream.Entries) == 0 {
-		return nil
-	}
-
-	// The distributor writes stream records to one of the active partitions
-	// in the partition ring. The number of active partitions is equal to the
-	// number of ingesters.
-	streamPartitionID, err := subring.ActivePartitionForKey(stream.HashKey)
+// sendStreamsToKafka sends all streams to Kafka or returns an error.
+func (d *Distributor) sendStreamsToKafka(ctx context.Context, tenant string, streams []KeyedStream, tracker *PushTracker, subring *ring.PartitionRing) {
+	records, err := d.recordsForStreams(tenant, streams, subring)
 	if err != nil {
-		d.kafkaAppends.WithLabelValues("kafka", "fail").Inc()
-		return fmt.Errorf("failed to find active partition for stream: %w", err)
+		// We need to add len(streams) to the counter as we later count successes and
+		// failures per stream too.
+		d.kafkaAppends.WithLabelValues("kafka", "fail").Add(float64(len(streams)))
+		tracker.doneWithResult(err)
+		return
 	}
-	startTime := time.Now()
-	records, err := kafka.Encode(
-		streamPartitionID,
-		tenant,
-		stream.Stream,
-		d.cfg.KafkaConfig.ProducerMaxRecordSizeBytes,
-	)
-	if err != nil {
-		d.kafkaAppends.WithLabelValues(
-			fmt.Sprintf("partition_%d", streamPartitionID),
-			"fail",
-		).Inc()
-		return fmt.Errorf("failed to marshal write request to records: %w", err)
+	// TODO(grobinson): Check if this is needed, as I would have expected
+	// streams without entries to have been removed when the request was
+	// validated.
+	if len(records) == 0 {
+		tracker.doneWithResult(nil)
+		return
 	}
-
 	d.kafkaRecordsPerRequest.Observe(float64(len(records)))
-
-	produceResults := d.kafkaWriter.ProduceSync(ctx, records)
-
-	if count, sizeBytes := successfulProduceRecordsStats(produceResults); count > 0 {
-		d.kafkaWriteLatency.Observe(time.Since(startTime).Seconds())
+	// Produce the records to Kafka.
+	writeLatency := prometheus.NewTimer(d.kafkaWriteLatency)
+	results := d.kafkaWriter.ProduceSync(ctx, records)
+	if count, sizeBytes := successfulProduceRecordsStats(results); count > 0 {
+		// TODO(grobinson): We should emit the write latency even when we failed.
+		// This has been kept as-is for now to preserve behavior.
+		writeLatency.ObserveDuration()
 		d.kafkaWriteBytesTotal.Add(float64(sizeBytes))
 	}
-
 	var finalErr error
-	for _, result := range produceResults {
+	for _, result := range results {
 		if result.Err != nil {
-			d.kafkaAppends.WithLabelValues(fmt.Sprintf("partition_%d", streamPartitionID), "fail").Inc()
+			d.kafkaAppends.WithLabelValues(fmt.Sprintf("partition_%d", result.Record.Partition), "fail").Inc()
 			finalErr = result.Err
 		} else {
-			d.kafkaAppends.WithLabelValues(fmt.Sprintf("partition_%d", streamPartitionID), "success").Inc()
+			d.kafkaAppends.WithLabelValues(fmt.Sprintf("partition_%d", result.Record.Partition), "success").Inc()
 		}
 	}
+	tracker.doneWithResult(finalErr)
+}
 
-	return finalErr
+// recordsForStreams returns the Kafka records for the tenant's streams.
+// It splits large streams into multiple Kafka records where a stream would
+// exceed the maximum record size.
+func (d *Distributor) recordsForStreams(
+	tenant string,
+	streams []KeyedStream,
+	subring *ring.PartitionRing,
+) ([]*kgo.Record, error) {
+	records := make([]*kgo.Record, 0, len(streams))
+	for _, stream := range streams {
+		// TODO(grobinson): Check if this is still needed, I would have expected
+		// streams with no entries to have be removed when the request was validated.
+		if len(stream.Stream.Entries) == 0 {
+			continue
+		}
+		partition, err := subring.ActivePartitionForKey(stream.HashKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find partition for stream: %w", err)
+		}
+		streamRecords, err := kafka.Encode(partition, tenant, stream.Stream, d.cfg.KafkaConfig.ProducerMaxRecordSizeBytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal streams to records: %w", err)
+		}
+		records = append(records, streamRecords...)
+	}
+	return records, nil
 }
 
 func successfulProduceRecordsStats(results kgo.ProduceResults) (count, sizeBytes int) {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -876,7 +876,7 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 			}
 		}
 		// We don't need to create a new context like the ingester writes, because we don't return unless all writes have succeeded.
-		d.sendStreamsToKafka(ctx, tenantID, streams, &tracker, subring)
+		go d.sendStreamsToKafka(ctx, tenantID, streams, &tracker, subring)
 	}
 
 	if d.cfg.IngesterEnabled {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2102,18 +2102,30 @@ type mockKafkaProducer struct {
 func (m *mockKafkaProducer) ProduceSync(_ context.Context, records []*kgo.Record) kgo.ProduceResults {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	results := make(kgo.ProduceResults, 0, len(records))
 	if m.failOnWrite {
-		return kgo.ProduceResults{{Err: kgo.ErrRecordTimeout}}
+		// We must append a result for each record that has both the record and the
+		// error, as this is how it works in [kgo].
+		for _, record := range records {
+			results = append(results, kgo.ProduceResult{
+				Record: record,
+				Err:    kgo.ErrRecordTimeout,
+			})
+		}
+	} else {
+		m.pushes++
+		m.records = append(m.records, records...)
+		if m.recordsPerTopic == nil {
+			m.recordsPerTopic = make(map[string][]*kgo.Record)
+		}
+		for _, record := range records {
+			m.recordsPerTopic[record.Topic] = append(m.recordsPerTopic[record.Topic], record)
+			results = append(results, kgo.ProduceResult{
+				Record: record,
+			})
+		}
 	}
-	m.pushes++
-	m.records = append(m.records, records...)
-	if m.recordsPerTopic == nil {
-		m.recordsPerTopic = make(map[string][]*kgo.Record)
-	}
-	for _, r := range records {
-		m.recordsPerTopic[r.Topic] = append(m.recordsPerTopic[r.Topic], r)
-	}
-	return kgo.ProduceResults{{Err: nil}}
+	return results
 }
 
 func (m *mockKafkaProducer) Close() {}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the distributor write/ack tracking and Kafka error/metrics handling; incorrect pending counts or result interpretation could cause pushes to hang or misreport failures.
> 
> **Overview**
> **Kafka pushes are now written as a single batch.** Instead of spawning per-stream goroutines that each produced to Kafka, the distributor builds all Kafka records up-front and calls `ProduceSync` once, then reports a single completion to the push tracker.
> 
> This adjusts push completion accounting (Kafka counts as *one* pending write), adds `recordsForStreams` to split/encode streams into records before producing, and updates Kafka metrics to record per-record partition success/failure and handle encode failures by incrementing failure counts for all streams.
> 
> Tests update the `mockKafkaProducer` to return one `ProduceResult` per record (matching `kgo` behavior), ensuring per-record errors propagate correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eafde1865fdf5dbfe1208f1e117d0e2af4650ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->