### PR TITLE
fix: Fix MatchNotRegexp misbehaving with the new query engine

### DIFF
--- a/pkg/dataobj/metastore/iter.go
+++ b/pkg/dataobj/metastore/iter.go
@@ -282,6 +282,7 @@ func buildLabelPredicate(matcher *labels.Matcher, columns map[string]*streams.Co
 		return streams.FuncPredicate{
 			Column: col,
 			Keep: func(_ *streams.Column, value scalar.Scalar) bool {
+				// we don't need the negation here because matcher.Matches() already handles the negation correctly.
 				return matcher.Matches(string(getBytes(value)))
 			},
 		}

--- a/pkg/dataobj/metastore/iter.go
+++ b/pkg/dataobj/metastore/iter.go
@@ -273,7 +273,7 @@ func buildLabelPredicate(matcher *labels.Matcher, columns map[string]*streams.Co
 		if col == nil {
 			// Column(NULL) is treated as empty string.
 			// Return true if regex does NOT match "", false otherwise.
-			if !matcher.Matches("") {
+			if matcher.Matches("") {
 				return streams.TruePredicate{}
 			}
 			return streams.FalsePredicate{}
@@ -282,7 +282,7 @@ func buildLabelPredicate(matcher *labels.Matcher, columns map[string]*streams.Co
 		return streams.FuncPredicate{
 			Column: col,
 			Keep: func(_ *streams.Column, value scalar.Scalar) bool {
-				return !matcher.Matches(string(getBytes(value)))
+				return matcher.Matches(string(getBytes(value)))
 			},
 		}
 

--- a/pkg/dataobj/metastore/iter_test.go
+++ b/pkg/dataobj/metastore/iter_test.go
@@ -1,0 +1,194 @@
+package metastore
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/arrow/scalar"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
+)
+
+func TestBuildLabelPredicate_MatchNotRegexp(t *testing.T) {
+	// This test verifies that MatchNotRegexp correctly excludes values that match the regex
+	// and includes values that don't match the regex.
+	//
+	// For slug!~"^k6.*":
+	// - "k6testinstant1" MATCHES the regex ^k6.*, so it should be EXCLUDED (Keep returns false)
+	// - "gitsync" does NOT match the regex ^k6.*, so it should be INCLUDED (Keep returns true)
+
+	tests := []struct {
+		name        string
+		regex       string
+		labelValue  string
+		shouldMatch bool // true if the value should be KEPT (i.e., does NOT match the regex)
+	}{
+		{
+			name:        "excludes value matching regex",
+			regex:       "^k6.*",
+			labelValue:  "k6testinstant1",
+			shouldMatch: false, // k6testinstant1 matches ^k6.*, so it should be excluded
+		},
+		{
+			name:        "includes value not matching regex",
+			regex:       "^k6.*",
+			labelValue:  "gitsync",
+			shouldMatch: true, // gitsync doesn't match ^k6.*, so it should be included
+		},
+		{
+			name:        "includes value not matching regex - different pattern",
+			regex:       "^k6.*",
+			labelValue:  "dev",
+			shouldMatch: true, // dev doesn't match ^k6.*, so it should be included
+		},
+		{
+			name:        "excludes another value matching regex",
+			regex:       "^k6.*",
+			labelValue:  "k6testslow5",
+			shouldMatch: false, // k6testslow5 matches ^k6.*, so it should be excluded
+		},
+		{
+			name:        "excludes exact match",
+			regex:       "^k6$",
+			labelValue:  "k6",
+			shouldMatch: false, // k6 matches ^k6$, so it should be excluded
+		},
+		{
+			name:        "includes partial non-match",
+			regex:       "^k6$",
+			labelValue:  "k6test",
+			shouldMatch: true, // k6test doesn't match ^k6$, so it should be included
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matcher := labels.MustNewMatcher(labels.MatchNotRegexp, "slug", tc.regex)
+
+			// Create a mock column for the label
+			col := &streams.Column{}
+
+			columns := map[string]*streams.Column{
+				"slug": col,
+			}
+
+			predicate := buildLabelPredicate(matcher, columns)
+
+			// The predicate should be a FuncPredicate
+			funcPred, ok := predicate.(streams.FuncPredicate)
+			require.True(t, ok, "expected FuncPredicate, got %T", predicate)
+
+			// Create a scalar value for the label
+			value := scalar.NewStringScalar(tc.labelValue)
+
+			// Test the Keep function
+			result := funcPred.Keep(col, value)
+			require.Equal(t, tc.shouldMatch, result,
+				"for regex %q and value %q: expected Keep to return %v, got %v",
+				tc.regex, tc.labelValue, tc.shouldMatch, result)
+		})
+	}
+}
+
+func TestBuildLabelPredicate_MatchNotRegexp_NilColumn(t *testing.T) {
+	// When the column doesn't exist (nil), the value is treated as empty string.
+	// For MatchNotRegexp, if the empty string does NOT match the regex, we should return TruePredicate.
+	// If the empty string DOES match the regex, we should return FalsePredicate.
+
+	tests := []struct {
+		name           string
+		regex          string
+		expectTrue     bool // true if we expect TruePredicate (empty string doesn't match regex)
+	}{
+		{
+			name:       "nil column with regex that doesn't match empty string",
+			regex:      "^k6.*",
+			expectTrue: true, // empty string doesn't match ^k6.*, so TruePredicate
+		},
+		{
+			name:       "nil column with regex that matches empty string",
+			regex:      "^$",
+			expectTrue: false, // empty string matches ^$, so FalsePredicate
+		},
+		{
+			name:       "nil column with regex that matches any string including empty",
+			regex:      ".*",
+			expectTrue: false, // empty string matches .*, so FalsePredicate
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matcher := labels.MustNewMatcher(labels.MatchNotRegexp, "slug", tc.regex)
+
+			// No column exists for this label
+			columns := map[string]*streams.Column{}
+
+			predicate := buildLabelPredicate(matcher, columns)
+
+			if tc.expectTrue {
+				_, ok := predicate.(streams.TruePredicate)
+				require.True(t, ok, "expected TruePredicate, got %T", predicate)
+			} else {
+				_, ok := predicate.(streams.FalsePredicate)
+				require.True(t, ok, "expected FalsePredicate, got %T", predicate)
+			}
+		})
+	}
+}
+
+func TestBuildLabelPredicate_MatchRegexp(t *testing.T) {
+	// Sanity check: verify that MatchRegexp (positive regex) works correctly too
+	tests := []struct {
+		name        string
+		regex       string
+		labelValue  string
+		shouldMatch bool // true if the value should be KEPT (i.e., DOES match the regex)
+	}{
+		{
+			name:        "includes value matching regex",
+			regex:       "^k6.*",
+			labelValue:  "k6testinstant1",
+			shouldMatch: true, // k6testinstant1 matches ^k6.*, so it should be included
+		},
+		{
+			name:        "excludes value not matching regex",
+			regex:       "^k6.*",
+			labelValue:  "gitsync",
+			shouldMatch: false, // gitsync doesn't match ^k6.*, so it should be excluded
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matcher := labels.MustNewMatcher(labels.MatchRegexp, "slug", tc.regex)
+
+			col := &streams.Column{}
+			columns := map[string]*streams.Column{
+				"slug": col,
+			}
+
+			predicate := buildLabelPredicate(matcher, columns)
+
+			funcPred, ok := predicate.(streams.FuncPredicate)
+			require.True(t, ok, "expected FuncPredicate, got %T", predicate)
+
+			value := scalar.NewStringScalar(tc.labelValue)
+			result := funcPred.Keep(col, value)
+			require.Equal(t, tc.shouldMatch, result,
+				"for regex %q and value %q: expected Keep to return %v, got %v",
+				tc.regex, tc.labelValue, tc.shouldMatch, result)
+		})
+	}
+}
+
+func scalar_NewStringScalar(s string) *scalar.String {
+	return scalar.NewStringScalar(s)
+}
+
+func init() {
+	// Ensure memory allocator is available
+	_ = memory.NewGoAllocator()
+}

--- a/pkg/dataobj/metastore/iter_test.go
+++ b/pkg/dataobj/metastore/iter_test.go
@@ -3,7 +3,6 @@ package metastore
 import (
 	"testing"
 
-	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/arrow/scalar"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -98,9 +97,9 @@ func TestBuildLabelPredicate_MatchNotRegexp_NilColumn(t *testing.T) {
 	// If the empty string DOES match the regex, we should return FalsePredicate.
 
 	tests := []struct {
-		name           string
-		regex          string
-		expectTrue     bool // true if we expect TruePredicate (empty string doesn't match regex)
+		name       string
+		regex      string
+		expectTrue bool // true if we expect TruePredicate (empty string doesn't match regex)
 	}{
 		{
 			name:       "nil column with regex that doesn't match empty string",
@@ -182,13 +181,4 @@ func TestBuildLabelPredicate_MatchRegexp(t *testing.T) {
 				tc.regex, tc.labelValue, tc.shouldMatch, result)
 		})
 	}
-}
-
-func scalar_NewStringScalar(s string) *scalar.String {
-	return scalar.NewStringScalar(s)
-}
-
-func init() {
-	// Ensure memory allocator is available
-	_ = memory.NewGoAllocator()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Noticed we weren't correctly returning results for queries with MatchNotRegexp, it seems like we overlooked `Matches` will already correctly understand the negation, so we're doing the negation twice.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes predicate evaluation for `labels.MatchNotRegexp`, which directly affects query result correctness in the metastore stream reader. Risk is moderate because it alters filtering behavior but is narrowly scoped and covered by new unit tests.
> 
> **Overview**
> Fixes metastore label filtering for `labels.MatchNotRegexp` by removing an extra negation and relying on Prometheus `matcher.Matches()` to apply the NOT-regex semantics, including the nil-column/empty-string case.
> 
> Adds focused unit tests in `iter_test.go` covering `MatchNotRegexp` (value and nil-column behavior) plus a small sanity check for `MatchRegexp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04d81ad2629c859003ababdc848b341326bdc2c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->