### PR TITLE
fix: Wire up default gRPC client config to ruler's query-frontend clients

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3688,6 +3688,7 @@ The `grpc_client` block configures the gRPC client used to communicate between a
 - `querier.scheduler-grpc-client`
 - `query-scheduler.grpc-client-config`
 - `ruler.client`
+- `ruler.evaluation.query-frontend`
 - `tsdb.shipper.index-gateway-client.grpc`
 
 &nbsp;
@@ -6084,14 +6085,11 @@ evaluation:
     # CLI flag: -ruler.evaluation.query-frontend.address
     [address: <string> | default = ""]
 
-    # Set to true if query-frontend connection requires TLS.
-    # CLI flag: -ruler.evaluation.query-frontend.tls-enabled
-    [tls_enabled: <boolean> | default = false]
-
-    # The TLS configuration.
+    # The grpc_client block configures the gRPC client used to communicate
+    # between a client and server component in Loki.
     # The CLI flags prefix for this block configuration is:
     # ruler.evaluation.query-frontend
-    [<tls_config>]
+    [<grpc_client>]
 ```
 
 ### runtime_config

--- a/pkg/ruler/evaluator_remote.go
+++ b/pkg/ruler/evaluator_remote.go
@@ -54,9 +54,7 @@ const (
 	EvalModeRemote = "remote"
 )
 
-var (
-	userAgent = fmt.Sprintf("loki-ruler/%s", build.Version)
-)
+var userAgent = fmt.Sprintf("loki-ruler/%s", build.Version)
 
 type metrics struct {
 	reqDurationSecs     *prometheus.HistogramVec
@@ -192,6 +190,7 @@ func DialQueryFrontend(cfg *QueryFrontendConfig) (httpgrpc.HTTPClient, error) {
 			),
 			grpc.WithDefaultServiceConfig(serviceConfig),
 			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(100 << 20)),
 		},
 		tlsDialOptions...,
 	)

--- a/pkg/ruler/evaluator_remote.go
+++ b/pkg/ruler/evaluator_remote.go
@@ -172,8 +172,7 @@ func (r *RemoteEvaluator) Eval(ctx context.Context, qs string, now time.Time) (*
 
 // DialQueryFrontend creates and initializes a new httpgrpc.HTTPClient taking a QueryFrontendConfig configuration.
 func DialQueryFrontend(cfg *QueryFrontendConfig) (httpgrpc.HTTPClient, error) {
-	unaryInterceptors, streamInterceptors := cfg.ClientConfig.Middleware, cfg.ClientConfig.StreamMiddleware
-	dialOptions, err := cfg.ClientConfig.DialOption(unaryInterceptors, streamInterceptors, middleware.NoOpInvalidClusterValidationReporter)
+	dialOptions, err := cfg.ClientConfig.DialOption(nil, nil, middleware.NoOpInvalidClusterValidationReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ruler/evaluator_remote.go
+++ b/pkg/ruler/evaluator_remote.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/grafana/dskit/crypto/tls"
+	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/instrument"
 	"github.com/grafana/dskit/middleware"
@@ -172,11 +172,12 @@ func (r *RemoteEvaluator) Eval(ctx context.Context, qs string, now time.Time) (*
 
 // DialQueryFrontend creates and initializes a new httpgrpc.HTTPClient taking a QueryFrontendConfig configuration.
 func DialQueryFrontend(cfg *QueryFrontendConfig) (httpgrpc.HTTPClient, error) {
-	tlsDialOptions, err := cfg.TLS.GetGRPCDialOptions(cfg.TLSEnabled)
+	unaryInterceptors, streamInterceptors := cfg.ClientConfig.Middleware, cfg.ClientConfig.StreamMiddleware
+	dialOptions, err := cfg.ClientConfig.DialOption(unaryInterceptors, streamInterceptors, middleware.NoOpInvalidClusterValidationReporter)
 	if err != nil {
 		return nil, err
 	}
-	dialOptions := append(
+	dialOptions = append(dialOptions,
 		[]grpc.DialOption{
 			grpc.WithKeepaliveParams(
 				keepalive.ClientParameters{
@@ -190,9 +191,7 @@ func DialQueryFrontend(cfg *QueryFrontendConfig) (httpgrpc.HTTPClient, error) {
 			),
 			grpc.WithDefaultServiceConfig(serviceConfig),
 			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
-			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(100 << 20)),
-		},
-		tlsDialOptions...,
+		}...,
 	)
 
 	// nolint:staticcheck // grpc.Dial() has been deprecated; we'll address it before upgrading to gRPC 2.
@@ -359,16 +358,12 @@ type QueryFrontendConfig struct {
 	// The address of the remote querier to connect to.
 	Address string `yaml:"address"`
 
-	// TLSEnabled tells whether TLS should be used to establish remote connection.
-	TLSEnabled bool `yaml:"tls_enabled"`
-
-	// TLS is the config for client TLS.
-	TLS tls.ClientConfig `yaml:",inline"`
+	// ClientConfig allows configuring the gRPC client used to connect to the query-frontend.
+	ClientConfig grpcclient.Config `yaml:",inline"`
 }
 
 func (c *QueryFrontendConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&c.Address, "ruler.evaluation.query-frontend.address", "", "GRPC listen address of the query-frontend(s). Must be a DNS address (prefixed with dns:///) to enable client side load balancing.")
-	f.BoolVar(&c.TLSEnabled, "ruler.evaluation.query-frontend.tls-enabled", false, "Set to true if query-frontend connection requires TLS.")
 
-	c.TLS.RegisterFlagsWithPrefix("ruler.evaluation.query-frontend", f)
+	c.ClientConfig.RegisterFlagsWithPrefix("ruler.evaluation.query-frontend", f)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR wires up dskit's default gRPC client config into the ruler's query-frontend

This is to inherit dskit's default gRPC max-recv-msg-size parameter, which is set to 100MB over the grpc default of 4MB. This was needed for the ruler to correctly execute rules queries that return more then 4MB of data and also allows the queries to grow significantly.

I removed a couple of config options for TLS, but they are defined & inlined from the new ClientConfig so there shouldn't be any difference in flags / args.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the ruler dials query-frontend by switching from bespoke TLS flags to shared `grpcclient.Config`, which may affect connection/TLS behavior and flag compatibility in deployments. The change is localized but impacts remote rule evaluation connectivity and message sizing defaults.
> 
> **Overview**
> Wires the ruler’s remote evaluation query-frontend client to use dskit’s `grpcclient.Config` for dial options (instead of the previous `tls_enabled`/`tls_config` fields), inheriting dskit defaults like the larger gRPC max receive message size.
> 
> Updates the remote evaluator dial path to build its `grpc.DialOption`s from `ClientConfig` and refreshes documentation to reflect the new `grpc_client` block under `ruler.evaluation.query-frontend`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a038fdd75aa4252ba823a1b08c31f7bb6bd155b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->