### PR TITLE
chore: Move to a golang-based build image instead of loki-build-image for operator/Dockerfile.cross

### DIFF
--- a/operator/Dockerfile.cross
+++ b/operator/Dockerfile.cross
@@ -1,11 +1,8 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.33.6
+# Build the manager binary. BUILD_IMAGE defaults to the same Go image as Dockerfile.
+ARG BUILD_IMAGE=golang:1.25.7
 
-FROM golang:1.25.7-alpine as goenv
-RUN go env GOARCH > /goarch && \
-  go env GOARM > /goarm
+FROM ${BUILD_IMAGE} AS builder
 
-FROM --platform=linux/amd64 $BUILD_IMAGE as builder
-COPY --from=goenv /goarch /goarm /
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY api/ api/
@@ -19,8 +16,8 @@ RUN go mod download
 COPY cmd/loki-operator/main.go cmd/loki-operator/main.go
 COPY internal/ internal/
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on GOARCH=$(cat /goarch) GOARM=$(cat /goarm) go build -a -o manager cmd/loki-operator/main.go
+# Build (GOARCH/GOARM follow the build platform; use docker buildx --platform for cross-compiles)
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on GOARCH=$(go env GOARCH) GOARM=$(go env GOARM) go build -mod=readonly -o manager cmd/loki-operator/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aligns the `Dockefile.cross` file with the `Dockerfile`, specifically, utilizing a `golang` image as the build image, as opposed to the `loki-build-image`.

**Which issue(s) this PR fixes**:
This removes another dependency on the `loki-build-image`, which is one less item to keep up to date for patching purposes.

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-only change: adjusts the operator cross-build container image and build flags without modifying runtime code. Main risk is potential CI/buildx behavior differences for cross-platform builds.
> 
> **Overview**
> `operator/Dockerfile.cross` now defaults to a plain `golang:1.25.7` build image (via `ARG BUILD_IMAGE`) instead of the `loki-build-image` and removes the extra stage that captured `GOARCH/GOARM`.
> 
> The build step now derives `GOARCH/GOARM` from `go env` (expecting `docker buildx --platform` for cross-compiles) and enforces module immutability via `go build -mod=readonly`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cd4b1a4b810f72ff1a0d4886cba4e45de765a1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->