### PR TITLE
fix(query-engine): Fix different error messages ending up in different streams

### DIFF
--- a/pkg/engine/compat.go
+++ b/pkg/engine/compat.go
@@ -60,6 +60,10 @@ type rowBuilder struct {
 	metadataBuilder *labels.Builder
 	parsedBuilder   *labels.Builder
 	parsedEmptyKeys []string
+	// errorLabelKeys tracks error label names (__error__, __error_details__) that were added
+	// to lbsBuilder. These are excluded from the stream grouping key but included in stream
+	// labels for display, matching classic Loki engine behavior.
+	errorLabelKeys []string
 }
 
 func (b *streamsResultBuilder) CollectRecord(rec arrow.RecordBatch) {
@@ -149,10 +153,13 @@ func (b *streamsResultBuilder) CollectRecord(rec arrow.RecordBatch) {
 				}
 
 				b.rowBuilders[rowIdx].parsedBuilder.Set(shortName, parsedVal)
-				// Error labels should never be included in stream labels to match classic Loki engine behavior.
-				// They are only included in the parsed labels of each entry.
-				if !b.categorizeLabels && !isErrorColumn {
+				if !b.categorizeLabels {
 					b.rowBuilders[rowIdx].lbsBuilder.Set(shortName, parsedVal)
+					// Track error labels separately - they're included in stream labels for display
+					// but excluded from stream grouping key to match classic Loki behavior.
+					if isErrorColumn {
+						b.rowBuilders[rowIdx].errorLabelKeys = append(b.rowBuilders[rowIdx].errorLabelKeys, shortName)
+					}
 				}
 				if b.rowBuilders[rowIdx].metadataBuilder.Get(shortName) != "" {
 					b.rowBuilders[rowIdx].metadataBuilder.Del(shortName)
@@ -199,6 +206,28 @@ func (b *streamsResultBuilder) CollectRecord(rec arrow.RecordBatch) {
 			lbsString = lbs.String()
 		}
 
+		// Compute stream grouping key by excluding error labels.
+		// Error labels are included in stream labels for display but excluded from grouping
+		// so that entries with different error details stay in the same stream.
+		streamKey := lbsString
+		if len(b.rowBuilders[rowIdx].errorLabelKeys) > 0 {
+			keyBuilder := labels.NewScratchBuilder(lbs.Len())
+			lbs.Range(func(label labels.Label) {
+				for _, errKey := range b.rowBuilders[rowIdx].errorLabelKeys {
+					if label.Name == errKey {
+						return // skip error labels in grouping key
+					}
+				}
+				keyBuilder.Add(label.Name, label.Value)
+			})
+			// Also add empty parsed keys (excluding error labels)
+			for _, key := range b.rowBuilders[rowIdx].parsedEmptyKeys {
+				keyBuilder.Add(key, "")
+			}
+			keyBuilder.Sort()
+			streamKey = keyBuilder.Labels().String()
+		}
+
 		entry := logproto.Entry{
 			Timestamp:          ts,
 			Line:               line,
@@ -208,12 +237,11 @@ func (b *streamsResultBuilder) CollectRecord(rec arrow.RecordBatch) {
 		b.resetRowBuilder(rowIdx)
 
 		// Add entry to appropriate stream
-		key := lbsString
-		idx, ok := b.streams[key]
+		idx, ok := b.streams[streamKey]
 		if !ok {
 			idx = len(b.data)
-			b.streams[key] = idx
-			b.data = append(b.data, push.Stream{Labels: key})
+			b.streams[streamKey] = idx
+			b.data = append(b.data, push.Stream{Labels: lbsString})
 		}
 		b.data[idx].Entries = append(b.data[idx].Entries, entry)
 		b.count++
@@ -243,6 +271,7 @@ func (b *streamsResultBuilder) ensureRowBuilders(newLen int) {
 			metadataBuilder: labels.NewBuilder(labels.EmptyLabels()),
 			parsedBuilder:   labels.NewBuilder(labels.EmptyLabels()),
 			parsedEmptyKeys: make([]string, 0),
+			errorLabelKeys:  make([]string, 0),
 		}
 	}
 }
@@ -254,6 +283,7 @@ func (b *streamsResultBuilder) resetRowBuilder(i int) {
 	b.rowBuilders[i].metadataBuilder.Reset(labels.EmptyLabels())
 	b.rowBuilders[i].parsedBuilder.Reset(labels.EmptyLabels())
 	b.rowBuilders[i].parsedEmptyKeys = b.rowBuilders[i].parsedEmptyKeys[:0]
+	b.rowBuilders[i].errorLabelKeys = b.rowBuilders[i].errorLabelKeys[:0]
 }
 
 func forEachNotNullRowColValue(numRows int, col arrow.Array, f func(rowIdx int)) {

--- a/pkg/engine/compat.go
+++ b/pkg/engine/compat.go
@@ -149,7 +149,9 @@ func (b *streamsResultBuilder) CollectRecord(rec arrow.RecordBatch) {
 				}
 
 				b.rowBuilders[rowIdx].parsedBuilder.Set(shortName, parsedVal)
-				if !b.categorizeLabels {
+				// Error labels should never be included in stream labels to match classic Loki engine behavior.
+				// They are only included in the parsed labels of each entry.
+				if !b.categorizeLabels && !isErrorColumn {
 					b.rowBuilders[rowIdx].lbsBuilder.Set(shortName, parsedVal)
 				}
 				if b.rowBuilders[rowIdx].metadataBuilder.Get(shortName) != "" {

--- a/pkg/engine/compat.go
+++ b/pkg/engine/compat.go
@@ -136,11 +136,11 @@ func (b *streamsResultBuilder) CollectRecord(rec arrow.RecordBatch) {
 
 		// One of the parsed columns
 		case ident.ColumnType() == types.ColumnTypeParsed || (ident.ColumnType() == types.ColumnTypeGenerated &&
-			shortName == types.ColumnNameError || shortName == types.ColumnNameErrorDetails):
+			(shortName == types.ColumnNameError || shortName == types.ColumnNameErrorDetails)):
 			parsedCol := col.(*array.String)
 
 			isErrorColumn := ident.ColumnType() == types.ColumnTypeGenerated &&
-				shortName == types.ColumnNameError || shortName == types.ColumnNameErrorDetails
+				(shortName == types.ColumnNameError || shortName == types.ColumnNameErrorDetails)
 
 			forEachNotNullRowColValue(numRows, parsedCol, func(rowIdx int) {
 				parsedVal := parsedCol.Value(rowIdx)

--- a/pkg/engine/compat_test.go
+++ b/pkg/engine/compat_test.go
@@ -639,6 +639,121 @@ func TestStreamsResultBuilder(t *testing.T) {
 		}
 		require.Equal(t, expected, streams)
 	})
+
+	// Regression test: entries with different __error__ values must NOT be split into separate streams.
+	//
+	// BUG: When categorizeLabels=false, the new engine was incorrectly adding __error__ and
+	// __error_details__ to stream labels (via lbsBuilder). This caused entries with different
+	// error messages to be placed in separate streams.
+	//
+	// Example: A query like `{app="foo"} | logfmt` parsing logs with invalid logfmt syntax
+	// would produce errors like "logfmt syntax error at pos 74" and "logfmt syntax error at pos 75".
+	// The old engine correctly keeps all entries in one stream {app="foo"}, but the buggy new
+	// engine would create separate streams:
+	//   - {app="foo", __error__="LogfmtParserErr", __error_details__="...pos 74"}
+	//   - {app="foo", __error__="LogfmtParserErr", __error_details__="...pos 75"}
+	//
+	// The fix ensures error labels are only added to parsed labels (per-entry), never to stream labels.
+	t.Run("regression: error labels must not cause stream splitting", func(t *testing.T) {
+		colTs := semconv.ColumnIdentTimestamp
+		colMsg := semconv.ColumnIdentMessage
+		colEnv := semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String)
+		colError := semconv.NewIdentifier(types.ColumnNameError, types.ColumnTypeGenerated, types.Loki.String)
+		colErrorDetails := semconv.NewIdentifier(types.ColumnNameErrorDetails, types.ColumnTypeGenerated, types.Loki.String)
+
+		schema := arrow.NewSchema(
+			[]arrow.Field{
+				semconv.FieldFromIdent(colTs, false),
+				semconv.FieldFromIdent(colMsg, false),
+				semconv.FieldFromIdent(colEnv, false),
+				semconv.FieldFromIdent(colError, true),
+				semconv.FieldFromIdent(colErrorDetails, true),
+			},
+			nil,
+		)
+
+		rows := arrowtest.Rows{
+			// Entry 1: no error (successfully parsed)
+			{
+				colTs.FQN():           time.Unix(0, 1620000000000000001).UTC(),
+				colMsg.FQN():          "level=info msg=success",
+				colEnv.FQN():          "prod",
+				colError.FQN():        nil,
+				colErrorDetails.FQN(): nil,
+			},
+			// Entry 2: logfmt parse error at position 74
+			{
+				colTs.FQN():           time.Unix(0, 1620000000000000002).UTC(),
+				colMsg.FQN():          "invalid {json broken at pos 74",
+				colEnv.FQN():          "prod",
+				colError.FQN():        "LogfmtParserErr",
+				colErrorDetails.FQN(): "logfmt syntax error at pos 74",
+			},
+			// Entry 3: logfmt parse error at position 75 (DIFFERENT error details)
+			// BUG: This entry was incorrectly placed in a separate stream due to different __error_details__
+			{
+				colTs.FQN():           time.Unix(0, 1620000000000000003).UTC(),
+				colMsg.FQN():          "invalid {json broken at pos 75",
+				colEnv.FQN():          "prod",
+				colError.FQN():        "LogfmtParserErr",
+				colErrorDetails.FQN(): "logfmt syntax error at pos 75",
+			},
+		}
+
+		record := rows.Record(memory.DefaultAllocator, schema)
+		defer record.Release()
+
+		// categorizeLabels=false is the default API behavior where parsed labels
+		// are merged into stream labels. Error labels must be excluded from this.
+		builder := newStreamsResultBuilder(logproto.FORWARD, false)
+		builder.CollectRecord(record)
+
+		require.Equal(t, 3, builder.Len(), "should have 3 entries")
+
+		md, _ := metadata.NewContext(t.Context())
+		result := builder.Build(stats.Result{}, md)
+		streams := result.Data.(logqlmodel.Streams)
+
+		// CRITICAL ASSERTION: All 3 entries must be in ONE stream.
+		// Before the fix, this would fail with len(streams) == 3 (each entry in its own stream).
+		require.Equal(t, 1, len(streams), "BUG: error labels caused stream splitting - expected 1 stream, got %d", len(streams))
+		require.Equal(t, 3, len(streams[0].Entries), "all 3 entries should be in the same stream")
+
+		// Verify stream labels do NOT contain error labels
+		streamLabels := streams[0].Labels
+		require.NotContains(t, streamLabels, types.ColumnNameError,
+			"stream labels must not contain __error__")
+		require.NotContains(t, streamLabels, types.ColumnNameErrorDetails,
+			"stream labels must not contain __error_details__")
+
+		// Verify error labels ARE present in the parsed labels of entries that have errors
+		entry2 := streams[0].Entries[1] // Second entry has error at pos 74
+		entry3 := streams[0].Entries[2] // Third entry has error at pos 75
+
+		// Helper to find a label in parsed labels
+		findParsedLabel := func(entry logproto.Entry, name string) (string, bool) {
+			for _, l := range entry.Parsed {
+				if l.Name == name {
+					return l.Value, true
+				}
+			}
+			return "", false
+		}
+
+		// Entry 2 should have error at pos 74
+		errVal, found := findParsedLabel(entry2, types.ColumnNameError)
+		require.True(t, found, "entry 2 should have __error__ in parsed labels")
+		require.Equal(t, "LogfmtParserErr", errVal)
+
+		errDetails, found := findParsedLabel(entry2, types.ColumnNameErrorDetails)
+		require.True(t, found, "entry 2 should have __error_details__ in parsed labels")
+		require.Equal(t, "logfmt syntax error at pos 74", errDetails)
+
+		// Entry 3 should have error at pos 75 (different from entry 2)
+		errDetails3, found := findParsedLabel(entry3, types.ColumnNameErrorDetails)
+		require.True(t, found, "entry 3 should have __error_details__ in parsed labels")
+		require.Equal(t, "logfmt syntax error at pos 75", errDetails3)
+	})
 }
 
 func TestVectorResultBuilder(t *testing.T) {

--- a/pkg/engine/compat_test.go
+++ b/pkg/engine/compat_test.go
@@ -642,18 +642,18 @@ func TestStreamsResultBuilder(t *testing.T) {
 
 	// Regression test: entries with different __error__ values must NOT be split into separate streams.
 	//
-	// BUG: When categorizeLabels=false, the new engine was incorrectly adding __error__ and
-	// __error_details__ to stream labels (via lbsBuilder). This caused entries with different
-	// error messages to be placed in separate streams.
+	// BUG: When categorizeLabels=false, the new engine was incorrectly using __error__ and
+	// __error_details__ for stream GROUPING. This caused entries with different error messages
+	// to be placed in separate streams.
 	//
 	// Example: A query like `{app="foo"} | logfmt` parsing logs with invalid logfmt syntax
 	// would produce errors like "logfmt syntax error at pos 74" and "logfmt syntax error at pos 75".
-	// The old engine correctly keeps all entries in one stream {app="foo"}, but the buggy new
-	// engine would create separate streams:
-	//   - {app="foo", __error__="LogfmtParserErr", __error_details__="...pos 74"}
-	//   - {app="foo", __error__="LogfmtParserErr", __error_details__="...pos 75"}
+	// The old engine correctly keeps all entries in one stream, but the buggy new engine would
+	// create separate streams based on the different error details.
 	//
-	// The fix ensures error labels are only added to parsed labels (per-entry), never to stream labels.
+	// The fix ensures error labels are excluded from the stream grouping key, matching classic
+	// Loki engine behavior. Error labels are still included in stream labels (when the first
+	// entry has errors) and in parsed labels (for all entries with errors).
 	t.Run("regression: error labels must not cause stream splitting", func(t *testing.T) {
 		colTs := semconv.ColumnIdentTimestamp
 		colMsg := semconv.ColumnIdentMessage
@@ -673,30 +673,30 @@ func TestStreamsResultBuilder(t *testing.T) {
 		)
 
 		rows := arrowtest.Rows{
-			// Entry 1: no error (successfully parsed)
+			// Entry 1: logfmt parse error at position 74 (first entry, sets stream labels)
 			{
 				colTs.FQN():           time.Unix(0, 1620000000000000001).UTC(),
-				colMsg.FQN():          "level=info msg=success",
-				colEnv.FQN():          "prod",
-				colError.FQN():        nil,
-				colErrorDetails.FQN(): nil,
-			},
-			// Entry 2: logfmt parse error at position 74
-			{
-				colTs.FQN():           time.Unix(0, 1620000000000000002).UTC(),
 				colMsg.FQN():          "invalid {json broken at pos 74",
 				colEnv.FQN():          "prod",
 				colError.FQN():        "LogfmtParserErr",
 				colErrorDetails.FQN(): "logfmt syntax error at pos 74",
 			},
-			// Entry 3: logfmt parse error at position 75 (DIFFERENT error details)
+			// Entry 2: logfmt parse error at position 75 (DIFFERENT error details)
 			// BUG: This entry was incorrectly placed in a separate stream due to different __error_details__
 			{
-				colTs.FQN():           time.Unix(0, 1620000000000000003).UTC(),
+				colTs.FQN():           time.Unix(0, 1620000000000000002).UTC(),
 				colMsg.FQN():          "invalid {json broken at pos 75",
 				colEnv.FQN():          "prod",
 				colError.FQN():        "LogfmtParserErr",
 				colErrorDetails.FQN(): "logfmt syntax error at pos 75",
+			},
+			// Entry 3: logfmt parse error at position 76 (yet another DIFFERENT error details)
+			{
+				colTs.FQN():           time.Unix(0, 1620000000000000003).UTC(),
+				colMsg.FQN():          "invalid {json broken at pos 76",
+				colEnv.FQN():          "prod",
+				colError.FQN():        "LogfmtParserErr",
+				colErrorDetails.FQN(): "logfmt syntax error at pos 76",
 			},
 		}
 
@@ -704,7 +704,7 @@ func TestStreamsResultBuilder(t *testing.T) {
 		defer record.Release()
 
 		// categorizeLabels=false is the default API behavior where parsed labels
-		// are merged into stream labels. Error labels must be excluded from this.
+		// are merged into stream labels.
 		builder := newStreamsResultBuilder(logproto.FORWARD, false)
 		builder.CollectRecord(record)
 
@@ -714,22 +714,18 @@ func TestStreamsResultBuilder(t *testing.T) {
 		result := builder.Build(stats.Result{}, md)
 		streams := result.Data.(logqlmodel.Streams)
 
-		// CRITICAL ASSERTION: All 3 entries must be in ONE stream.
-		// Before the fix, this would fail with len(streams) == 3 (each entry in its own stream).
+		// CRITICAL ASSERTION: All 3 entries with different error details must be in ONE stream.
+		// Before the fix, this would fail with len(streams) == 3 (each entry in its own stream
+		// due to different __error_details__ values being used for grouping).
 		require.Equal(t, 1, len(streams), "BUG: error labels caused stream splitting - expected 1 stream, got %d", len(streams))
 		require.Equal(t, 3, len(streams[0].Entries), "all 3 entries should be in the same stream")
 
-		// Verify stream labels do NOT contain error labels
+		// Verify error labels ARE present in stream labels (set by the first entry)
 		streamLabels := streams[0].Labels
-		require.NotContains(t, streamLabels, types.ColumnNameError,
-			"stream labels must not contain __error__")
-		require.NotContains(t, streamLabels, types.ColumnNameErrorDetails,
-			"stream labels must not contain __error_details__")
+		require.Contains(t, streamLabels, types.ColumnNameError,
+			"stream labels should contain __error__ (from first entry)")
 
-		// Verify error labels ARE present in the parsed labels of entries that have errors
-		entry2 := streams[0].Entries[1] // Second entry has error at pos 74
-		entry3 := streams[0].Entries[2] // Third entry has error at pos 75
-
+		// Verify error labels ARE present in the parsed labels of each entry
 		// Helper to find a label in parsed labels
 		findParsedLabel := func(entry logproto.Entry, name string) (string, bool) {
 			for _, l := range entry.Parsed {
@@ -740,19 +736,16 @@ func TestStreamsResultBuilder(t *testing.T) {
 			return "", false
 		}
 
-		// Entry 2 should have error at pos 74
-		errVal, found := findParsedLabel(entry2, types.ColumnNameError)
-		require.True(t, found, "entry 2 should have __error__ in parsed labels")
-		require.Equal(t, "LogfmtParserErr", errVal)
+		// All entries should have __error__ in parsed labels
+		for i, entry := range streams[0].Entries {
+			errVal, found := findParsedLabel(entry, types.ColumnNameError)
+			require.True(t, found, "entry %d should have __error__ in parsed labels", i)
+			require.Equal(t, "LogfmtParserErr", errVal)
 
-		errDetails, found := findParsedLabel(entry2, types.ColumnNameErrorDetails)
-		require.True(t, found, "entry 2 should have __error_details__ in parsed labels")
-		require.Equal(t, "logfmt syntax error at pos 74", errDetails)
-
-		// Entry 3 should have error at pos 75 (different from entry 2)
-		errDetails3, found := findParsedLabel(entry3, types.ColumnNameErrorDetails)
-		require.True(t, found, "entry 3 should have __error_details__ in parsed labels")
-		require.Equal(t, "logfmt syntax error at pos 75", errDetails3)
+			// Each entry should have its own __error_details__ value
+			_, found = findParsedLabel(entry, types.ColumnNameErrorDetails)
+			require.True(t, found, "entry %d should have __error_details__ in parsed labels", i)
+		}
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The new query engine is misbehaving in the following situation: different entries for the same stream, when erroring, are ending up in different streams in case the error message is different. This PR fixes this by making them be in the same stream. The regression test correctly reproduces the situation.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stream grouping behavior in the query engine result builder by excluding `__error__`/`__error_details__` from the grouping key; this can affect how results are partitioned and displayed. Scope is limited and covered by a targeted regression test.
> 
> **Overview**
> Fixes a regression in `streamsResultBuilder` where generated error labels (`__error__`, `__error_details__`) were being used to *group* streams when `categorizeLabels=false`, causing identical streams with different parse error messages to be split.
> 
> The builder now tracks which error labels were added and computes a separate stream grouping key that omits them, while still keeping error labels in the stream’s displayed `Labels` string and in each entry’s parsed labels. Adds a regression test asserting multiple entries with differing `__error_details__` remain in a single stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af19c82542c10b5af96442477503a80453115846. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->