### PR TITLE
fix(storage): Use correct protocol and suffix from Azure connection string for SAS URLs

### DIFF
--- a/pkg/storage/chunk/client/azure/blob_storage_client.go
+++ b/pkg/storage/chunk/client/azure/blob_storage_client.go
@@ -704,17 +704,6 @@ func parseConnectionString(connectionString string) (ParsedConnectionString, err
 		return ParsedConnectionString{}, errors.New("connection string missing AccountName")
 	}
 
-	accountKey, ok := connStrMap["AccountKey"]
-	if !ok {
-		sharedAccessSignature, ok := connStrMap["SharedAccessSignature"]
-		if !ok {
-			return ParsedConnectionString{}, errors.New("connection string missing AccountKey and SharedAccessSignature")
-		}
-		return ParsedConnectionString{
-			ServiceURL: fmt.Sprintf("%v://%v.blob.%v/?%v", defaultScheme, accountName, defaultSuffix, sharedAccessSignature),
-		}, nil
-	}
-
 	protocol, ok := connStrMap["DefaultEndpointsProtocol"]
 	if !ok {
 		protocol = defaultScheme
@@ -723,6 +712,19 @@ func parseConnectionString(connectionString string) (ParsedConnectionString, err
 	suffix, ok := connStrMap["EndpointSuffix"]
 	if !ok {
 		suffix = defaultSuffix
+	}
+
+	accountKey, ok := connStrMap["AccountKey"]
+	if !ok {
+		sharedAccessSignature, ok := connStrMap["SharedAccessSignature"]
+		if !ok {
+			return ParsedConnectionString{}, errors.New("connection string missing AccountKey and SharedAccessSignature")
+		}
+		// Use protocol and suffix from the connection string (not hardcoded defaults)
+		// so that sovereign cloud / custom endpoint configurations are respected.
+		return ParsedConnectionString{
+			ServiceURL: fmt.Sprintf("%v://%v.blob.%v/?%v", protocol, accountName, suffix, sharedAccessSignature),
+		}, nil
 	}
 
 	if blobEndpoint, ok := connStrMap["BlobEndpoint"]; ok {


### PR DESCRIPTION
Fixes #20275. `parseConnectionString` hardcoded `https` and `core.windows.net` in the SAS path — ignoring `DefaultEndpointsProtocol` and `EndpointSuffix` from the same connection string. Move the extraction before the AccountKey check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Azure connection-string parsing for SAS-based auth; mistakes could break blob storage connectivity in non-default/sovereign clouds. Scope is small but impacts a critical storage configuration path.
> 
> **Overview**
> Fixes `parseConnectionString` so **SAS-based** Azure Blob Storage URLs are built using `DefaultEndpointsProtocol` and `EndpointSuffix` from the provided connection string, rather than always using `https` and `core.windows.net`.
> 
> This ensures sovereign cloud / custom endpoint configurations work correctly when `AccountKey` is absent and `SharedAccessSignature` is used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e27764edb08acce8452575f210260a7c8345354. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->