### PR TITLE
feat: allow ring kvstore backend override in Tanka Loki

### DIFF
--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -10,6 +10,18 @@
     replication_factor: 3,
     memcached_replicas: 3,
 
+    // KV store backend used for ring state when memberlist_ring_enabled is false.
+    // Supported values: 'consul' (default), 'etcd'.
+    ring_kvstore_store: 'consul',
+
+    // When ring_kvstore_store == 'etcd', this object is rendered under the
+    // kvstore.etcd key of every ring config (ingester, distributor, ruler,
+    // pattern_ingester). Provide endpoints and any TLS/auth options required
+    // by your etcd cluster. Any field supported by Loki's etcd kvstore config
+    // (endpoints, dial_timeout, tls_enabled, tls_cert_path, tls_key_path,
+    // tls_ca_path, username, password, ...) can be set here.
+    ring_kvstore_etcd: {},
+
     grpc_server_max_msg_size: 100 << 20,  // 100MB
 
     query_scheduler_enabled: false,
@@ -254,7 +266,11 @@
           ring: {
             heartbeat_timeout: '1m',
             replication_factor: $._config.replication_factor,
-            kvstore: if $._config.memberlist_ring_enabled then {} else {
+            kvstore: if $._config.memberlist_ring_enabled then {}
+            else if $._config.ring_kvstore_store == 'etcd' then {
+              store: 'etcd',
+              etcd: $._config.ring_kvstore_etcd,
+            } else {
               store: 'consul',
               consul: {
                 host: 'consul.%s.svc.cluster.local:8500' % $._config.namespace,
@@ -276,7 +292,11 @@
           ring: {
             heartbeat_timeout: '1m',
             replication_factor: 1,
-            kvstore: if $._config.memberlist_ring_enabled then {} else {
+            kvstore: if $._config.memberlist_ring_enabled then {}
+            else if $._config.ring_kvstore_store == 'etcd' then {
+              store: 'etcd',
+              etcd: $._config.ring_kvstore_etcd,
+            } else {
               store: 'consul',
               consul: {
                 host: 'consul.%s.svc.cluster.local:8500' % $._config.namespace,
@@ -357,7 +377,11 @@
       distributor: {
         // Creates a ring between distributors, required by the ingestion rate global limit.
         ring: {
-          kvstore: if $._config.memberlist_ring_enabled then {} else {
+          kvstore: if $._config.memberlist_ring_enabled then {}
+          else if $._config.ring_kvstore_store == 'etcd' then {
+            store: 'etcd',
+            etcd: $._config.ring_kvstore_etcd,
+          } else {
             store: 'consul',
             consul: {
               host: 'consul.%s.svc.cluster.local:8500' % $._config.namespace,
@@ -377,7 +401,11 @@
         enable_sharding: true,
         enable_alertmanager_v2: true,
         ring: {
-          kvstore: if $._config.memberlist_ring_enabled then {} else {
+          kvstore: if $._config.memberlist_ring_enabled then {}
+          else if $._config.ring_kvstore_store == 'etcd' then {
+            store: 'etcd',
+            etcd: $._config.ring_kvstore_etcd,
+          } else {
             store: 'consul',
             consul: {
               host: 'consul.%s.svc.cluster.local:8500' % $._config.namespace,

--- a/production/ksonnet/loki/memberlist.libsonnet
+++ b/production/ksonnet/loki/memberlist.libsonnet
@@ -156,9 +156,16 @@
         ports,
       ) + service.mixin.spec.withClusterIp('None'),  // headless service
 
-  // Disable the consul deployment if not migrating and using memberlist
-  consul_deployment: if $._config.memberlist_ring_enabled && !$._config.multikv_migration_enabled && !$._config.multikv_migration_teardown then {} else super.consul_deployment,
-  consul_service: if $._config.memberlist_ring_enabled && !$._config.multikv_migration_enabled && !$._config.multikv_migration_teardown then {} else super.consul_service,
-  consul_config_map: if $._config.memberlist_ring_enabled && !$._config.multikv_migration_enabled && !$._config.multikv_migration_teardown then {} else super.consul_config_map,
-  consul_sidekick_rbac: if $._config.memberlist_ring_enabled && !$._config.multikv_migration_enabled && !$._config.multikv_migration_teardown then {} else super.consul_sidekick_rbac,
+  // Disable the consul deployment if not migrating and either using memberlist or an explicitly supported non-consul kv store.
+  // The discriminator mirrors config.libsonnet (positive match on 'etcd') so an unsupported/typo value cannot suppress
+  // the consul resources while config.libsonnet's else-branch still renders consul config.
+  local disableConsulResources =
+    ($._config.memberlist_ring_enabled || $._config.ring_kvstore_store == 'etcd')
+    && !$._config.multikv_migration_enabled
+    && !$._config.multikv_migration_teardown,
+
+  consul_deployment: if disableConsulResources then {} else super.consul_deployment,
+  consul_service: if disableConsulResources then {} else super.consul_service,
+  consul_config_map: if disableConsulResources then {} else super.consul_config_map,
+  consul_sidekick_rbac: if disableConsulResources then {} else super.consul_sidekick_rbac,
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Exposes the ring KV store backend as a configurable `_config` option in the Tanka Loki library. Previously `config.libsonnet` hardcoded `store: 'consul'` in every ring (ingester, pattern_ingester, distributor, ruler), forcing Tanka users to run an in-cluster Consul even when they already operate an etcd cluster.

**Which issue(s) this PR fixes**:
Fixes #4198

**Special notes for your reviewer**:
- Two new `_config` fields, both opt-in:
  - `ring_kvstore_store` (default `'consul'`) — backend selector, currently `'consul'` or `'etcd'`
  - `ring_kvstore_etcd` (default `{}`) — rendered under `kvstore.etcd` when the selector is `'etcd'`. Accepts any field from Loki's etcd kvstore config (`endpoints`, `tls_*`, `username`, `password`, ...)
- All four ring kvstore blocks now branch `memberlist → etcd → consul`. The existing consul block (with per-ring specifics like the distributor's `watch_rate_limit` / `watch_burst_size`) is preserved unchanged on the default path, so existing deployments render byte-identical config
- `memberlist.libsonnet` also suppresses the bundled consul deployment/service/configmap/rbac when `ring_kvstore_store != 'consul'`, so pointing at external etcd doesn't leave an unused Consul pod. Multi-KV migration guards are preserved
- Verified by rendering `_config.loki` via `jsonnet` in three modes (default consul / etcd / memberlist) — all four rings render as expected and bundled Consul resources evaluate to `{}` when etcd is selected. `jsonnetfmt` diff check passes

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added _(inline jsonnet comments on the two new fields)_
- [ ] Tests updated _(no jsonnet render harness in this repo; verified manually)_
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md` _(N/A — opt-in, default unchanged)_
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory _(N/A)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Loki ring KV configuration and whether Consul resources are rendered, which can break cluster coordination if misconfigured; defaults remain unchanged (Consul) so risk is mostly for opt-in etcd users.
> 
> **Overview**
> Adds opt-in support to select the Loki ring KV store backend via `_config.ring_kvstore_store` (default `consul`) and to pass etcd connection/TLS/auth settings via `_config.ring_kvstore_etcd`.
> 
> Updates all ring `kvstore` blocks (ingester, pattern ingester, distributor, ruler) to branch `memberlist` → `etcd` → `consul`, and suppresses bundled Consul k8s resources in `memberlist.libsonnet` when memberlist is enabled or `etcd` is selected (while preserving multi-KV migration guards).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 896d9cdf8719ead4eb27e01f8f0d24776c6be8a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->