### PR TITLE
chore(build): Move remaining images away from loki-build-image

### DIFF
--- a/clients/cmd/docker-driver/Dockerfile
+++ b/clients/cmd/docker-driver/Dockerfile
@@ -1,4 +1,5 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.34.6
+ARG GO_VERSION=1.26
+ARG BUILD_IMAGE=golang:${GO_VERSION}
 ARG GOARCH=amd64
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:

--- a/cmd/loki-canary/Dockerfile.cross
+++ b/cmd/loki-canary/Dockerfile.cross
@@ -1,19 +1,18 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.34.8
 ARG GO_VERSION=1.26
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
-# docker build -t grafana/promtail -f cmd/promtail/Dockerfile .
-FROM golang:${GO_VERSION} AS goenv
+# docker build -t grafana/loki-canary -f cmd/loki-canary/Dockerfile.cross .
+FROM golang:${GO_VERSION} AS build
+ARG IMAGE_TAG
 RUN go env GOARCH > /goarch && \
   go env GOARM > /goarm
 
-FROM $BUILD_IMAGE as build
-COPY --from=goenv /goarch /goarm /
 COPY . /src/loki
 WORKDIR /src/loki
-RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false loki-canary
+RUN make clean && GOARCH=$(cat /goarch) GOARM=$(cat /goarm) make BUILD_IN_CONTAINER=false IMAGE_TAG=${IMAGE_TAG} loki-canary
 
 FROM gcr.io/distroless/static:debug
+
 COPY --from=build /src/loki/cmd/loki-canary/loki-canary /usr/bin/loki-canary
 SHELL [ "/busybox/sh", "-c" ]
 RUN ln -s /busybox/sh /bin/sh

--- a/cmd/loki/Dockerfile.debug
+++ b/cmd/loki/Dockerfile.debug
@@ -1,15 +1,15 @@
-ARG BUILD_IMAGE=grafana/loki-build-image:0.34.8
 ARG GO_VERSION=1.26
+ARG BUILD_IMAGE=golang:${GO_VERSION}
 # Directories in this file are referenced from the root of the project not this folder
 # This file is intended to be called from the root like so:
 # docker build -t grafana/loki -f cmd/loki/Dockerfile.debug .
 
-FROM golang:${GO_VERSION} as goenv
+FROM golang:${GO_VERSION} AS goenv
 RUN go env GOARCH > /goarch && \
     go env GOARM > /goarm && \
     go install github.com/go-delve/delve/cmd/dlv@latest
 
-FROM $BUILD_IMAGE as build
+FROM $BUILD_IMAGE AS build
 COPY --from=goenv /goarch /goarm /
 COPY . /src/loki
 WORKDIR /src/loki


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR migrates the three remaining images that explicitly use the `loki-build-image` away from that, instead using a `golang` build image.  

This does not change the underlying build image used as part of the `Makefile`. That is a larger project that needs to be done as a followup.

This PR does ensure that images build directly via a `docker build` command do build properly.
The loki-canary cross compilation file may not be used at all, and the Loki debug dockerfile is not a production path.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Dockerfile-only changes that swap the builder base image and tweak build args; main impact is potential CI/docker-build breakage due to image/tooling differences.
> 
> **Overview**
> Migrates the remaining Dockerfiles (`docker-driver`, `loki-canary` cross build, and `loki` debug) to build from `golang:${GO_VERSION}` instead of `grafana/loki-build-image`.
> 
> Updates `cmd/loki-canary/Dockerfile.cross` to a single `golang` build stage and threads `IMAGE_TAG` into the `make loki-canary` invocation so `docker build` paths work consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c5f9207a796c915a64f0f64441b5a56fc9430f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->