### PR TITLE
refactor(distributor): Clean up if else and add comment

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -863,13 +863,13 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 	}
 
 	if d.cfg.KafkaEnabled {
+		subring := d.partitionRing.PartitionRing()
 		shardSize := d.validator.IngestionPartitionsTenantShardSize(tenantID)
-		var subring *ring.PartitionRing
-		if shardSize == 0 {
-			// Optimization - don't need to create shuffle shards in this case
-			subring = d.partitionRing.PartitionRing()
-		} else {
-			subring, err = d.partitionRing.PartitionRing().ShuffleShard(tenantID, shardSize)
+		// Do not shuffle shard if the shard size is 0. When the size is 0, it
+		// creates a shuffle shard which contains the complete set of partitions,
+		// which is the same as not shuffle sharding at all.
+		if shardSize > 0 {
+			subring, err = subring.ShuffleShard(tenantID, shardSize)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

Small chore, and explains the reasons behind this change.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow cleanup limited to Kafka partition-ring shuffle-sharding; behavior should be unchanged except avoiding an unnecessary `ShuffleShard(…, 0)` call.
> 
> **Overview**
> Simplifies Kafka ingest-path partition selection in `Distributor.PushWithResolver` by always starting from the full partition ring and only applying `ShuffleShard()` when the per-tenant shard size is > 0.
> 
> Adds an explicit comment clarifying that a shard size of 0 effectively yields the full set of partitions, so shuffle-sharding is skipped to avoid redundant work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29cdd1d867c9400010ada6abe3b15fbbff15f06a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->