### PR TITLE
docs: add upgrade to community topic

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -64,6 +64,10 @@ Supported clients should check the configuration options for max send message si
 With the move to the [Grafana-community/helm-charts repository](https://github.com/grafana-community/helm-charts), the chart numbering has changed. Major version updates signal breaking changes in the chart. For more information, refer to the [README](https://github.com/grafana-community/helm-charts/blob/main/charts/loki/README.md#upgrading).
 {{< /admonition >}}
 
+### Migrating from the Loki Repository Helm Chart to the Community Helm Chart
+
+If you are migrating from the Helm chart previously hosted in the Loki repository (chart version 6.x) to the Grafana Community Helm chart (chart version 12.x), refer to the dedicated migration guide: [Migrate to the Community Helm chart](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/upgrade-to-community/).
+
 ### Helm Chart 6.50.0 - Respect the global registry in the sidecar image
 
 If you prefixed the sidecar container with a private registry (`sidecar.image.repository`), this is no longer necessary and is deprecated as the global registry is used starting with Helm chart 6.46.1. Therefore please use `global.imageRegistry` or alternatively, `sidecar.image.registry` for more fine-grained control.

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -66,7 +66,7 @@ With the move to the [Grafana-community/helm-charts repository](https://github.c
 
 ### Migrating from the Loki Repository Helm Chart to the Community Helm Chart
 
-If you are migrating from the Helm chart previously hosted in the Loki repository (chart version 6.x) to the Grafana Community Helm chart (chart version 12.x), refer to the dedicated migration guide: [Migrate to the Community Helm chart](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/upgrade-to-community/).
+If you are upgrading from the Helm chart previously hosted in the Loki repository (chart version 6.x) to the Grafana Community Helm chart (chart version 13.x), refer to the dedicated migration guide: [Upgrade to the Community Helm chart](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/upgrade-to-community/).
 
 ### Helm Chart 6.50.0 - Respect the global registry in the sidecar image
 

--- a/docs/sources/setup/upgrade/upgrade-to-community/_index.md
+++ b/docs/sources/setup/upgrade/upgrade-to-community/_index.md
@@ -15,20 +15,20 @@ The Loki Helm chart has moved from the [Loki repository](https://github.com/graf
 
 This guide walks you through upgrading from 6.55.0 to 13.x, which spans seven major chart versions (7 through 13), each with breaking changes.
 
-{{< admonition type="caution" >}}
-This upgrade spans seven major versions with accumulated breaking changes. Test the upgrade in a non-production environment before applying it to production.
+{{< admonition type="warning" >}}
+Grafana Enterprise Logs (GEL) support was removed from the community chart in version 8.0.0. If you are a GEL user, **do not migrate** to the community chart. The `grafana/loki` chart remains available for GEL users.
 {{< /admonition >}}
 
-{{< admonition type="warning" >}}
-Grafana Enterprise Logs (GEL) support was removed from the community chart in version 8.0.0. If you are a GEL user, **do not migrate** to the community chart. The upstream `grafana/loki` chart remains available for GEL users.
+{{< admonition type="caution" >}}
+This upgrade spans several major versions with accumulated breaking changes. Test the upgrade in a non-production environment before applying it to production.
 {{< /admonition >}}
 
 ## Prerequisites
 
 Before you begin:
 
-- **Kubernetes 1.25 or later** is required (enforced since chart version 7.0.0).
-- **Helm 3.x** is required.
+- Kubernetes 1.25 or later is required (enforced since chart version 7.0.0).
+- Helm 3.x is required.
 - Back up your current Helm release values:
 
   ```bash
@@ -37,18 +37,18 @@ Before you begin:
 
 - Back up any persistent volumes and object store indexes.
 
-## Step 1: Update your Helm repository
+## Update your Helm repository
 
-The chart is now published to a different Helm repository and OCI registry.
+The chart is now published to a different Helm repository and Open Container Initiative (OCI) registry.  The official Helm documentation now recommends using OCI registries as they implement unified storage, distribution, and improved security.
 
-**Before** (6.x from the Loki repository):
+Old Location - 6.x from the Loki repository:
 
 ```bash
 helm repo add grafana https://grafana.github.io/helm-charts
 helm upgrade <RELEASE_NAME> grafana/loki -f values.yaml
 ```
 
-**After** (13.x from the community repository):
+New Location - 7.x and later from the community repository:
 
 ```bash
 helm repo add grafana-community https://grafana-community.github.io/helm-charts
@@ -56,13 +56,13 @@ helm repo update
 helm upgrade <RELEASE_NAME> grafana-community/loki -f values.yaml --version 13.1.2
 ```
 
-Or using OCI:
+Or using OCI for 7.x and later:
 
 ```bash
 helm upgrade <RELEASE_NAME> oci://ghcr.io/grafana-community/helm-charts/loki -f values.yaml --version 13.1.2
 ```
 
-## Step 2: Update your values file for breaking changes
+## Update your values file for breaking changes
 
 The following sections describe every breaking change between chart versions 6.55.0 and 13.x, grouped by the major version that introduced each change. Review each section and update your values file accordingly.
 
@@ -74,7 +74,7 @@ Check the Loki Helm Chart [README](https://github.com/grafana-community/helm-cha
 
 Support for deprecated Kubernetes APIs and PodSecurityPolicy has been removed. Kubernetes 1.25 or later is now required.
 
-**Remove** the following from your values file:
+Remove the following from your values file:
 
 ```yaml
 rbac:
@@ -91,14 +91,18 @@ rbac:
   namespaced: false
 ```
 
-If you have custom Ingress resources using `networking.k8s.io/v1beta1`, update them to `networking.k8s.io/v1`. If you reference PodDisruptionBudget resources with `policy/v1beta1`, update them to `policy/v1`.
+| If you have   | using   | update them to |
+| ------------- | ------------- | ------------- |
+| custom Ingress resources | `networking.k8s.io/v1beta1` | `networking.k8s.io/v1` |
+| PodDisruptionBudget resources | `policy/v1beta1` | `policy/v1` |
 
 ### 7.x to 8.0: Enterprise support removed
 
-The entire `enterprise` configuration section has been removed from the chart. If your values file includes any `enterprise.*` keys, remove them:
+Enterprise support is removed in the community Helm chart.
+
+Remove the entire `enterprise` configuration section from your chart, including any `enterprise.*` keys:
 
 ```yaml
-# Remove this entire section
 enterprise:
   enabled: false
   version: 3.6.5
@@ -109,7 +113,6 @@ enterprise:
   externalLicenseName: null
   externalConfigName: ""
   gelGateway: true
-  # ... all other enterprise.* keys
 ```
 
 {{< admonition type="note" >}}
@@ -120,10 +123,9 @@ The Helm Chart in the Loki repository is being maintained for GEL customers only
 
 The `monitoring.selfMonitoring` section and the `grafana-agent-operator` subchart dependency have been removed.
 
-**Remove** the following from your values file:
+Remove the `monitoring.selfMonitoring` section from your values file:
 
 ```yaml
-# Remove this entire section
 monitoring:
   selfMonitoring:
     enabled: false
@@ -150,7 +152,7 @@ Also remove `monitoring.serviceMonitor.metricsInstance` if present. It reference
 
 Loki canary tenant authentication has moved from `monitoring.selfMonitoring.tenant` to the top-level `lokiCanary.tenant` section. If you were using canary tenant auth, update as follows:
 
-**Before** (6.x):
+Before (6.x):
 
 ```yaml
 monitoring:
@@ -160,7 +162,7 @@ monitoring:
       password: "my-password"
 ```
 
-**After** (13.x):
+After (13.x):
 
 ```yaml
 lokiCanary:
@@ -177,7 +179,7 @@ lokiCanary:
 
 The `indexGateway.persistence.inMemory` field has been replaced with `indexGateway.persistence.dataVolumeParameters` for more consistent configuration across components.
 
-**Before** (6.x):
+Before (6.x):
 
 ```yaml
 indexGateway:
@@ -187,7 +189,7 @@ indexGateway:
     size: 10Gi
 ```
 
-**After** (13.x):
+After (13.x):
 
 ```yaml
 indexGateway:
@@ -213,7 +215,7 @@ indexGateway:
 
 The `read.legacyReadTarget` option has been removed. Simple scalable deployments now always require a dedicated backend target (read, write, and backend).
 
-**Remove** from your values file if present:
+Remove from your values file if present:
 
 ```yaml
 read:
@@ -226,21 +228,21 @@ If you had `legacyReadTarget: true` (running the 2-target read/write mode withou
 
 The default `deploymentMode` has changed from `SimpleScalable` to `Monolithic`, and `SingleBinary` has been renamed to `Monolithic`.
 
-**Before** (6.x default):
+Before (6.x default):
 
 ```yaml
 deploymentMode: SimpleScalable
 ```
 
-**After** (13.x default):
+After (13.x default):
 
 ```yaml
 deploymentMode: Monolithic
 ```
 
-**Action required based on your current mode:**
+Action required based on your current mode:
 
-If you are running **SimpleScalable** (the 6.x default), explicitly set it in your values file to preserve your current deployment:
+If you are running `SimpleScalable` (the 6.x default), explicitly set it in your values file to preserve your current deployment:
 
 ```yaml
 deploymentMode: SimpleScalable
@@ -250,7 +252,7 @@ deploymentMode: SimpleScalable
 `SimpleScalable` is deprecated and will be removed in Loki 4.0. Plan to migrate to `Monolithic` or `Distributed`.
 {{< /admonition >}}
 
-If you are running **SingleBinary**, update the value to the new name:
+If you are running `SingleBinary`, update the value to the new name:
 
 ```yaml
 # Before
@@ -260,7 +262,7 @@ deploymentMode: SingleBinary
 deploymentMode: Monolithic
 ```
 
-If you are running **Distributed**, no change is needed.
+If you are running `Distributed`, no change is needed.
 
 ### 12.x to 13.0: Ephemeral volume persistence flattened
 
@@ -272,7 +274,7 @@ If you are migrating directly from 6.55.0 and have never used the `ephemeralData
 
 If you adopted the `ephemeralDataVolume` pattern from any intermediate community chart version, update your values as follows:
 
-**Before** (12.x):
+Before (12.x):
 
 ```yaml
 <component>:
@@ -285,7 +287,7 @@ If you adopted the `ephemeralDataVolume` pattern from any intermediate community
       storageClass: null
 ```
 
-**After** (13.x):
+After (13.x):
 
 ```yaml
 <component>:
@@ -300,7 +302,7 @@ If you adopted the `ephemeralDataVolume` pattern from any intermediate community
 
 The `type` field accepts `pvc` (default for most components) or `ephemeral`. Fields that were nested under `ephemeralDataVolume` (`accessModes`, `size`, `storageClass`, `volumeAttributesClassName`, `selector`, `annotations`, `labels`) now sit directly under `persistence`.
 
-## Step 3: Review additional deprecations
+## Review additional deprecations
 
 Several per-component fields have been deprecated in favor of unified blocks. These still work but will be removed in a future release. Consider updating them now:
 
@@ -328,7 +330,7 @@ global:
   imageRegistry: null
 ```
 
-## Step 4: Perform the upgrade
+## Perform the upgrade
 
 After updating your values file, run the upgrade:
 
@@ -359,7 +361,7 @@ kubectl logs -l app.kubernetes.io/component=write --tail=50
 kubectl logs -l app.kubernetes.io/component=loki-canary --tail=20
 ```
 
-## Step 5: Post-migration cleanup
+## Post-migration cleanup
 
 After a successful upgrade:
 
@@ -372,7 +374,7 @@ After a successful upgrade:
 - Update any CI/CD pipelines to reference `grafana-community/loki` or the OCI URL `oci://ghcr.io/grafana-community/helm-charts/loki`.
 - Review monitoring dashboards for renamed metrics. Refer to the [Loki 3.x upgrade notes](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/#30) for metric namespace changes.
 
-## Troubleshooting
+## Troubleshoot
 
 ### Pods fail to start with PodSecurityPolicy errors
 

--- a/docs/sources/setup/upgrade/upgrade-to-community/_index.md
+++ b/docs/sources/setup/upgrade/upgrade-to-community/_index.md
@@ -41,14 +41,14 @@ Before you begin:
 
 The chart is now published to a different Helm repository and Open Container Initiative (OCI) registry.  The official Helm documentation now recommends using OCI registries as they implement unified storage, distribution, and improved security.
 
-Old Location - 6.x from the Loki repository:
+Old location for 6.x from the Loki repository:
 
 ```bash
 helm repo add grafana https://grafana.github.io/helm-charts
 helm upgrade <RELEASE_NAME> grafana/loki -f values.yaml
 ```
 
-New Location - 7.x and later from the community repository:
+New location for 7.x and later from the community repository:
 
 ```bash
 helm repo add grafana-community https://grafana-community.github.io/helm-charts
@@ -56,7 +56,7 @@ helm repo update
 helm upgrade <RELEASE_NAME> grafana-community/loki -f values.yaml --version 13.1.2
 ```
 
-Or using OCI for 7.x and later:
+Or if you are using OCI for 7.x and later:
 
 ```bash
 helm upgrade <RELEASE_NAME> oci://ghcr.io/grafana-community/helm-charts/loki -f values.yaml --version 13.1.2
@@ -67,7 +67,7 @@ helm upgrade <RELEASE_NAME> oci://ghcr.io/grafana-community/helm-charts/loki -f 
 The following sections describe every breaking change between chart versions 6.55.0 and 13.x, grouped by the major version that introduced each change. Review each section and update your values file accordingly.
 
 {{< admonition type="caution" >}}
-Check the Loki Helm Chart [README](https://github.com/grafana-community/helm-charts/tree/main/charts/loki#upgrading) for the latest changes and upgrade information.  The Grafana Community is constantly improving the charts.
+Check the Loki Helm Chart [README](https://github.com/grafana-community/helm-charts/tree/main/charts/loki#upgrading) for the latest changes and upgrade information. The Grafana Community is constantly improving the charts.
 {{< /admonition >}}
 
 ### 6.x to 7.0: Kubernetes API cleanup
@@ -148,7 +148,7 @@ monitoring:
       # ...
 ```
 
-Also remove `monitoring.serviceMonitor.metricsInstance` if present. It referenced a Grafana Agent CRD that no longer exists.
+Also remove `monitoring.serviceMonitor.metricsInstance`, if present. It referenced a Grafana Agent CRD that no longer exists.
 
 Loki canary tenant authentication has moved from `monitoring.selfMonitoring.tenant` to the top-level `lokiCanary.tenant` section. If you were using canary tenant auth, update as follows:
 
@@ -269,7 +269,7 @@ If you are running `Distributed`, no change is needed.
 The persistence configuration for ephemeral volumes has been flattened across all components. The nested `persistence.ephemeralDataVolume` structure has been replaced with a `persistence.type` field.
 
 {{< admonition type="note" >}}
-If you are migrating directly from 6.55.0 and have never used the `ephemeralDataVolume` configuration introduced in the community chart, this change does not require action on your existing values. However, be aware of the new `persistence.type` field when configuring persistence for components like the compactor or bloom-builder.
+If you are migrating directly from 6.55.0 and have never used the `ephemeralDataVolume` configuration introduced in the community chart, this change doesn't require action on your existing values. However, be aware of the new `persistence.type` field when configuring persistence for components like the compactor or bloom-builder.
 {{< /admonition >}}
 
 If you adopted the `ephemeralDataVolume` pattern from any intermediate community chart version, update your values as follows:

--- a/docs/sources/setup/upgrade/upgrade-to-community/_index.md
+++ b/docs/sources/setup/upgrade/upgrade-to-community/_index.md
@@ -1,27 +1,26 @@
 ---
-title: Migrate from the Loki Helm chart to the Community Helm chart
-menuTitle: Migrate to Community Helm chart
-description: Migrate from the Loki repository Helm chart (6.x) to the Grafana Community Helm chart (12.x).
+title: Upgrade from the Loki Helm chart to the Community Helm chart
+menuTitle: Upgrade to Community Helm chart
+description: Upgrade from the Loki repository Helm chart (6.x) to the Grafana Community Helm chart (13.x).
 weight: 900
 keywords:
   - upgrade
-  - migrate
   - community
   - helm
 ---
 
-# Migrate from the Loki Helm chart to the Community Helm chart
+# Upgrade from the Loki Helm chart to the Community Helm chart
 
-The Loki Helm chart has moved from the [Loki repository](https://github.com/grafana/loki) to the [Grafana Community Helm Charts repository](https://github.com/grafana-community/helm-charts). Chart version 6.55.0 (appVersion 3.6.7) was the last release from the Loki repository. Chart version 12.0.0 (appVersion 3.7.1) is the current release from the community repository.
+The Loki Helm chart has moved from the [Loki repository](https://github.com/grafana/loki) to the [Grafana Community Helm Charts repository](https://github.com/grafana-community/helm-charts). Chart version 6.55.0 (appVersion 3.6.7) was the last release from the Loki repository. Chart version 13.1.2 (appVersion 3.7.1) is the current release from the community repository at the time this topic was published.
 
-This guide walks you through migrating from 6.55.0 to 12.0.0, which spans six major chart versions (7 through 12), each with breaking changes.
+This guide walks you through upgrading from 6.55.0 to 13.x, which spans seven major chart versions (7 through 13), each with breaking changes.
 
 {{< admonition type="caution" >}}
-This migration spans six major versions with accumulated breaking changes. Test the upgrade in a non-production environment before applying it to production.
+This upgrade spans seven major versions with accumulated breaking changes. Test the upgrade in a non-production environment before applying it to production.
 {{< /admonition >}}
 
 {{< admonition type="warning" >}}
-Grafana Enterprise Logs (GEL) support was removed from the community chart in version 8.0.0. If you are a GEL user, **do not migrate** to the community chart. The upstream `grafana/loki` chart remains available for GEL users. Consult your Grafana Labs account team about your migration options. Refer to the [migration announcement](https://github.com/grafana/loki/issues/20705) for details.
+Grafana Enterprise Logs (GEL) support was removed from the community chart in version 8.0.0. If you are a GEL user, **do not migrate** to the community chart. The upstream `grafana/loki` chart remains available for GEL users.
 {{< /admonition >}}
 
 ## Prerequisites
@@ -49,23 +48,27 @@ helm repo add grafana https://grafana.github.io/helm-charts
 helm upgrade <RELEASE_NAME> grafana/loki -f values.yaml
 ```
 
-**After** (12.x from the community repository):
+**After** (13.x from the community repository):
 
 ```bash
 helm repo add grafana-community https://grafana-community.github.io/helm-charts
 helm repo update
-helm upgrade <RELEASE_NAME> grafana-community/loki -f values.yaml --version 12.0.0
+helm upgrade <RELEASE_NAME> grafana-community/loki -f values.yaml --version 13.1.2
 ```
 
 Or using OCI:
 
 ```bash
-helm upgrade <RELEASE_NAME> oci://ghcr.io/grafana-community/helm-charts/loki -f values.yaml --version 12.0.0
+helm upgrade <RELEASE_NAME> oci://ghcr.io/grafana-community/helm-charts/loki -f values.yaml --version 13.1.2
 ```
 
 ## Step 2: Update your values file for breaking changes
 
-The following sections describe every breaking change between chart versions 6.55.0 and 12.0.0, grouped by the major version that introduced each change. Review each section and update your values file accordingly.
+The following sections describe every breaking change between chart versions 6.55.0 and 13.x, grouped by the major version that introduced each change. Review each section and update your values file accordingly.
+
+{{< admonition type="caution" >}}
+Check the Loki Helm Chart [README](https://github.com/grafana-community/helm-charts/tree/main/charts/loki#upgrading) for the latest changes and upgrade information.  The Grafana Community is constantly improving the charts.
+{{< /admonition >}}
 
 ### 6.x to 7.0: Kubernetes API cleanup
 
@@ -79,7 +82,7 @@ rbac:
   pspAnnotations: {}       # remove this key
 ```
 
-The `rbac` section in 12.0.0 only contains:
+The `rbac` section in 13.x only contains:
 
 ```yaml
 rbac:
@@ -108,6 +111,10 @@ enterprise:
   gelGateway: true
   # ... all other enterprise.* keys
 ```
+
+{{< admonition type="note" >}}
+The Helm Chart in the Loki repository is being maintained for GEL customers only.
+{{< /admonition >}}
 
 ### 8.x to 9.0: Self-monitoring and Grafana Agent Operator removed
 
@@ -153,7 +160,7 @@ monitoring:
       password: "my-password"
 ```
 
-**After** (12.0.0):
+**After** (13.x):
 
 ```yaml
 lokiCanary:
@@ -180,7 +187,7 @@ indexGateway:
     size: 10Gi
 ```
 
-**After** (12.0.0):
+**After** (13.x):
 
 ```yaml
 indexGateway:
@@ -225,7 +232,7 @@ The default `deploymentMode` has changed from `SimpleScalable` to `Monolithic`, 
 deploymentMode: SimpleScalable
 ```
 
-**After** (12.0.0 default):
+**After** (13.x default):
 
 ```yaml
 deploymentMode: Monolithic
@@ -254,6 +261,44 @@ deploymentMode: Monolithic
 ```
 
 If you are running **Distributed**, no change is needed.
+
+### 12.x to 13.0: Ephemeral volume persistence flattened
+
+The persistence configuration for ephemeral volumes has been flattened across all components. The nested `persistence.ephemeralDataVolume` structure has been replaced with a `persistence.type` field.
+
+{{< admonition type="note" >}}
+If you are migrating directly from 6.55.0 and have never used the `ephemeralDataVolume` configuration introduced in the community chart, this change does not require action on your existing values. However, be aware of the new `persistence.type` field when configuring persistence for components like the compactor or bloom-builder.
+{{< /admonition >}}
+
+If you adopted the `ephemeralDataVolume` pattern from any intermediate community chart version, update your values as follows:
+
+**Before** (12.x):
+
+```yaml
+<component>:
+  persistence:
+    ephemeralDataVolume:
+      enabled: true
+      accessModes:
+        - ReadWriteOnce
+      size: 10Gi
+      storageClass: null
+```
+
+**After** (13.x):
+
+```yaml
+<component>:
+  persistence:
+    enabled: true
+    type: ephemeral
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+    storageClass: null
+```
+
+The `type` field accepts `pvc` (default for most components) or `ephemeral`. Fields that were nested under `ephemeralDataVolume` (`accessModes`, `size`, `storageClass`, `volumeAttributesClassName`, `selector`, `annotations`, `labels`) now sit directly under `persistence`.
 
 ## Step 3: Review additional deprecations
 
@@ -290,7 +335,7 @@ After updating your values file, run the upgrade:
 ```bash
 helm upgrade <RELEASE_NAME> grafana-community/loki \
   -f your-updated-values.yaml \
-  --version 12.0.0
+  --version 13.1.2
 ```
 
 Or using OCI:
@@ -298,7 +343,7 @@ Or using OCI:
 ```bash
 helm upgrade <RELEASE_NAME> oci://ghcr.io/grafana-community/helm-charts/loki \
   -f your-updated-values.yaml \
-  --version 12.0.0
+  --version 13.1.2
 ```
 
 ### Verify the upgrade
@@ -337,7 +382,7 @@ After a successful upgrade:
 
 ### Loki canary fails authentication
 
-**Cause:** Canary tenant configuration was under `monitoring.selfMonitoring.tenant` in 6.x and has moved to `lokiCanary.tenant` in 12.0.0.
+**Cause:** Canary tenant configuration was under `monitoring.selfMonitoring.tenant` in 6.x and has moved to `lokiCanary.tenant` in 13.x.
 
 **Fix:** Move `tenant.name` and `tenant.password` to the `lokiCanary.tenant` section.
 
@@ -358,6 +403,12 @@ After a successful upgrade:
 **Cause:** The `enterprise.*` section was removed in 8.0.0. Any leftover keys cause Helm to reject the values.
 
 **Fix:** Remove the entire `enterprise` section from your values file.
+
+### Unknown field `ephemeralDataVolume`
+
+**Cause:** The nested `persistence.ephemeralDataVolume` structure was flattened in 13.0.0. If you adopted this pattern from an intermediate community chart version, the old keys are no longer recognized.
+
+**Fix:** Replace `persistence.ephemeralDataVolume.enabled: true` with `persistence.enabled: true` and `persistence.type: ephemeral`, and move all nested fields directly under `persistence` as described in [12.x to 13.0](#12x-to-130-ephemeral-volume-persistence-flattened).
 
 ## Further reading
 

--- a/docs/sources/setup/upgrade/upgrade-to-community/_index.md
+++ b/docs/sources/setup/upgrade/upgrade-to-community/_index.md
@@ -1,0 +1,366 @@
+---
+title: Migrate from the Loki Helm chart to the Community Helm chart
+menuTitle: Migrate to Community Helm chart
+description: Migrate from the Loki repository Helm chart (6.x) to the Grafana Community Helm chart (12.x).
+weight: 900
+keywords:
+  - upgrade
+  - migrate
+  - community
+  - helm
+---
+
+# Migrate from the Loki Helm chart to the Community Helm chart
+
+The Loki Helm chart has moved from the [Loki repository](https://github.com/grafana/loki) to the [Grafana Community Helm Charts repository](https://github.com/grafana-community/helm-charts). Chart version 6.55.0 (appVersion 3.6.7) was the last release from the Loki repository. Chart version 12.0.0 (appVersion 3.7.1) is the current release from the community repository.
+
+This guide walks you through migrating from 6.55.0 to 12.0.0, which spans six major chart versions (7 through 12), each with breaking changes.
+
+{{< admonition type="caution" >}}
+This migration spans six major versions with accumulated breaking changes. Test the upgrade in a non-production environment before applying it to production.
+{{< /admonition >}}
+
+{{< admonition type="warning" >}}
+Grafana Enterprise Logs (GEL) support was removed from the community chart in version 8.0.0. If you are a GEL user, **do not migrate** to the community chart. The upstream `grafana/loki` chart remains available for GEL users. Consult your Grafana Labs account team about your migration options. Refer to the [migration announcement](https://github.com/grafana/loki/issues/20705) for details.
+{{< /admonition >}}
+
+## Prerequisites
+
+Before you begin:
+
+- **Kubernetes 1.25 or later** is required (enforced since chart version 7.0.0).
+- **Helm 3.x** is required.
+- Back up your current Helm release values:
+
+  ```bash
+  helm get values <RELEASE_NAME> -o yaml > backup-values.yaml
+  ```
+
+- Back up any persistent volumes and object store indexes.
+
+## Step 1: Update your Helm repository
+
+The chart is now published to a different Helm repository and OCI registry.
+
+**Before** (6.x from the Loki repository):
+
+```bash
+helm repo add grafana https://grafana.github.io/helm-charts
+helm upgrade <RELEASE_NAME> grafana/loki -f values.yaml
+```
+
+**After** (12.x from the community repository):
+
+```bash
+helm repo add grafana-community https://grafana-community.github.io/helm-charts
+helm repo update
+helm upgrade <RELEASE_NAME> grafana-community/loki -f values.yaml --version 12.0.0
+```
+
+Or using OCI:
+
+```bash
+helm upgrade <RELEASE_NAME> oci://ghcr.io/grafana-community/helm-charts/loki -f values.yaml --version 12.0.0
+```
+
+## Step 2: Update your values file for breaking changes
+
+The following sections describe every breaking change between chart versions 6.55.0 and 12.0.0, grouped by the major version that introduced each change. Review each section and update your values file accordingly.
+
+### 6.x to 7.0: Kubernetes API cleanup
+
+Support for deprecated Kubernetes APIs and PodSecurityPolicy has been removed. Kubernetes 1.25 or later is now required.
+
+**Remove** the following from your values file:
+
+```yaml
+rbac:
+  pspEnabled: false        # remove this key
+  pspAnnotations: {}       # remove this key
+```
+
+The `rbac` section in 12.0.0 only contains:
+
+```yaml
+rbac:
+  sccEnabled: false
+  sccAllowHostDirVolumePlugin: false
+  namespaced: false
+```
+
+If you have custom Ingress resources using `networking.k8s.io/v1beta1`, update them to `networking.k8s.io/v1`. If you reference PodDisruptionBudget resources with `policy/v1beta1`, update them to `policy/v1`.
+
+### 7.x to 8.0: Enterprise support removed
+
+The entire `enterprise` configuration section has been removed from the chart. If your values file includes any `enterprise.*` keys, remove them:
+
+```yaml
+# Remove this entire section
+enterprise:
+  enabled: false
+  version: 3.6.5
+  cluster_name: null
+  license:
+    contents: "NOTAVALIDLICENSE"
+  useExternalLicense: false
+  externalLicenseName: null
+  externalConfigName: ""
+  gelGateway: true
+  # ... all other enterprise.* keys
+```
+
+### 8.x to 9.0: Self-monitoring and Grafana Agent Operator removed
+
+The `monitoring.selfMonitoring` section and the `grafana-agent-operator` subchart dependency have been removed.
+
+**Remove** the following from your values file:
+
+```yaml
+# Remove this entire section
+monitoring:
+  selfMonitoring:
+    enabled: false
+    tenant:
+      name: "self-monitoring"
+      password: null
+      secretNamespace: '{{ include "loki.namespace" . }}'
+    grafanaAgent:
+      installOperator: false
+      annotations: {}
+      labels: {}
+      enableConfigReadAPI: false
+      priorityClassName: null
+      resources: {}
+      tolerations: []
+    podLogs:
+      apiVersion: monitoring.grafana.com/v1alpha1
+      # ...
+    logsInstance:
+      # ...
+```
+
+Also remove `monitoring.serviceMonitor.metricsInstance` if present. It referenced a Grafana Agent CRD that no longer exists.
+
+Loki canary tenant authentication has moved from `monitoring.selfMonitoring.tenant` to the top-level `lokiCanary.tenant` section. If you were using canary tenant auth, update as follows:
+
+**Before** (6.x):
+
+```yaml
+monitoring:
+  selfMonitoring:
+    tenant:
+      name: "self-monitoring"
+      password: "my-password"
+```
+
+**After** (12.0.0):
+
+```yaml
+lokiCanary:
+  tenant:
+    name: "self-monitoring"
+    password: "my-password"
+```
+
+{{< admonition type="tip" >}}
+[Grafana Alloy](https://grafana.com/docs/alloy/latest/) is the successor to Grafana Agent. If you relied on Agent-based self-monitoring, consider using Alloy for log collection.
+{{< /admonition >}}
+
+### 9.x to 10.0: Index gateway persistence restructured
+
+The `indexGateway.persistence.inMemory` field has been replaced with `indexGateway.persistence.dataVolumeParameters` for more consistent configuration across components.
+
+**Before** (6.x):
+
+```yaml
+indexGateway:
+  persistence:
+    enabled: false
+    inMemory: false
+    size: 10Gi
+```
+
+**After** (12.0.0):
+
+```yaml
+indexGateway:
+  persistence:
+    enabled: false
+    dataVolumeParameters:
+      emptyDir: {}
+    size: 10Gi
+```
+
+If you were using in-memory storage (`inMemory: true`), the equivalent configuration is:
+
+```yaml
+indexGateway:
+  persistence:
+    dataVolumeParameters:
+      emptyDir:
+        medium: Memory
+        sizeLimit: 10Gi
+```
+
+### 10.x to 11.0: Legacy read target removed
+
+The `read.legacyReadTarget` option has been removed. Simple scalable deployments now always require a dedicated backend target (read, write, and backend).
+
+**Remove** from your values file if present:
+
+```yaml
+read:
+  legacyReadTarget: false  # remove this key
+```
+
+If you had `legacyReadTarget: true` (running the 2-target read/write mode without a backend), you must now run the 3-target mode (read, write, backend) or switch to a different deployment mode.
+
+### 11.x to 12.0: Deployment mode renamed and default changed
+
+The default `deploymentMode` has changed from `SimpleScalable` to `Monolithic`, and `SingleBinary` has been renamed to `Monolithic`.
+
+**Before** (6.x default):
+
+```yaml
+deploymentMode: SimpleScalable
+```
+
+**After** (12.0.0 default):
+
+```yaml
+deploymentMode: Monolithic
+```
+
+**Action required based on your current mode:**
+
+If you are running **SimpleScalable** (the 6.x default), explicitly set it in your values file to preserve your current deployment:
+
+```yaml
+deploymentMode: SimpleScalable
+```
+
+{{< admonition type="note" >}}
+`SimpleScalable` is deprecated and will be removed in Loki 4.0. Plan to migrate to `Monolithic` or `Distributed`.
+{{< /admonition >}}
+
+If you are running **SingleBinary**, update the value to the new name:
+
+```yaml
+# Before
+deploymentMode: SingleBinary
+
+# After
+deploymentMode: Monolithic
+```
+
+If you are running **Distributed**, no change is needed.
+
+## Step 3: Review additional deprecations
+
+Several per-component fields have been deprecated in favor of unified blocks. These still work but will be removed in a future release. Consider updating them now:
+
+```yaml
+# Deprecated per-component service fields (applies to indexGateway, compactor, and others)
+indexGateway:
+  serviceLabels: {}        # deprecated, use indexGateway.service.labels
+  serviceAnnotations: {}   # deprecated, use indexGateway.service.annotations
+  serviceType: "ClusterIP" # deprecated, use indexGateway.service.type
+  appProtocol:             # deprecated, use indexGateway.service.appProtocol
+    grpc: ""
+  maxUnavailable: null     # deprecated, use podDisruptionBudget.maxUnavailable
+```
+
+The global image registry override has also been renamed:
+
+```yaml
+# Deprecated
+global:
+  image:
+    registry: null
+
+# Use instead
+global:
+  imageRegistry: null
+```
+
+## Step 4: Perform the upgrade
+
+After updating your values file, run the upgrade:
+
+```bash
+helm upgrade <RELEASE_NAME> grafana-community/loki \
+  -f your-updated-values.yaml \
+  --version 12.0.0
+```
+
+Or using OCI:
+
+```bash
+helm upgrade <RELEASE_NAME> oci://ghcr.io/grafana-community/helm-charts/loki \
+  -f your-updated-values.yaml \
+  --version 12.0.0
+```
+
+### Verify the upgrade
+
+```bash
+# Check all pods are running
+kubectl get pods -l app.kubernetes.io/name=loki
+
+# Verify Loki is accepting writes
+kubectl logs -l app.kubernetes.io/component=write --tail=50
+
+# Verify Loki canary is healthy (if enabled)
+kubectl logs -l app.kubernetes.io/component=loki-canary --tail=20
+```
+
+## Step 5: Post-migration cleanup
+
+After a successful upgrade:
+
+- Remove the old Helm repository if no longer needed:
+
+  ```bash
+  helm repo remove grafana
+  ```
+
+- Update any CI/CD pipelines to reference `grafana-community/loki` or the OCI URL `oci://ghcr.io/grafana-community/helm-charts/loki`.
+- Review monitoring dashboards for renamed metrics. Refer to the [Loki 3.x upgrade notes](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/#30) for metric namespace changes.
+
+## Troubleshooting
+
+### Pods fail to start with PodSecurityPolicy errors
+
+**Cause:** Leftover `rbac.pspEnabled` or `rbac.pspAnnotations` in your values file.
+
+**Fix:** Remove both keys from your values file and re-run the upgrade.
+
+### Loki canary fails authentication
+
+**Cause:** Canary tenant configuration was under `monitoring.selfMonitoring.tenant` in 6.x and has moved to `lokiCanary.tenant` in 12.0.0.
+
+**Fix:** Move `tenant.name` and `tenant.password` to the `lokiCanary.tenant` section.
+
+### Index gateway CrashLoopBackOff
+
+**Cause:** The old `indexGateway.persistence.inMemory` field is no longer recognized.
+
+**Fix:** Replace `inMemory: true` with the equivalent `dataVolumeParameters` configuration as described in [9.x to 10.0](#9x-to-100-index-gateway-persistence-restructured).
+
+### Unexpected deployment mode change
+
+**Cause:** The default `deploymentMode` changed from `SimpleScalable` to `Monolithic`. If you relied on the default without explicitly setting it, your deployment mode changed on upgrade.
+
+**Fix:** Explicitly set `deploymentMode: SimpleScalable` in your values file (or choose `Monolithic` or `Distributed`) and re-run the upgrade.
+
+### Unknown field errors from enterprise values
+
+**Cause:** The `enterprise.*` section was removed in 8.0.0. Any leftover keys cause Helm to reject the values.
+
+**Fix:** Remove the entire `enterprise` section from your values file.
+
+## Further reading
+
+- [Community chart changelog](https://grafana-community.github.io/helm-charts/changelog/?chart=loki)
+- [Community chart README - Upgrading](https://github.com/grafana-community/helm-charts/blob/main/charts/loki/README.md#upgrading)
+- [Helm chart 6.x upgrade guide](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/upgrade-to-6x/)

--- a/docs/sources/setup/upgrade/upgrade-to-community/_index.md
+++ b/docs/sources/setup/upgrade/upgrade-to-community/_index.md
@@ -304,18 +304,17 @@ The `type` field accepts `pvc` (default for most components) or `ephemeral`. Fie
 
 ## Review additional deprecations
 
-Several per-component fields have been deprecated in favor of unified blocks. These still work but will be removed in a future release. Consider updating them now:
+Several per-component fields have been deprecated in favor of unified blocks. These deprecated per-component service fields apply to indexGateway, compactor, and others.
 
-```yaml
-# Deprecated per-component service fields (applies to indexGateway, compactor, and others)
-indexGateway:
-  serviceLabels: {}        # deprecated, use indexGateway.service.labels
-  serviceAnnotations: {}   # deprecated, use indexGateway.service.annotations
-  serviceType: "ClusterIP" # deprecated, use indexGateway.service.type
-  appProtocol:             # deprecated, use indexGateway.service.appProtocol
-    grpc: ""
-  maxUnavailable: null     # deprecated, use podDisruptionBudget.maxUnavailable
-```
+These still work but will be removed in a future release. Consider updating them now:
+
+| Deprecated                      | Use                                |
+| ------------------------------- | ------------------------------- -- |
+| indexGateway.serviceLabels      | indexGateway.service.labels        |
+| indexGateway.serviceAnnotations | indexGateway.service.annotations   |
+| indexGateway.serviceType        | indexGateway.service.type          |
+| indexGateway.appProtocol        | indexGateway.service.type          |
+| indexGateway.maxUnavailable     | podDisruptionBudget.maxUnavailable |
 
 The global image registry override has also been renamed:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Users migrating from the last Loki-repo chart (6.55.0) to the community helm-charts repo (12.0.0) must traverse six major-version breaking changes and a repository migration in a single upgrade.


**Special notes for your reviewer**:
Written with AI
Validated with a different model
Reviewed by a human (myself) before submitting the PR


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that add a new upgrade guide and a link from existing upgrade notes, with no code or configuration behavior changes.
> 
> **Overview**
> Adds a dedicated docs page describing how to migrate Helm deployments from the Loki-repo `grafana/loki` chart `6.55.0` to the Grafana Community `grafana-community/loki` chart `13.x`, including repository/OCI switch, version-by-version breaking-change value migrations, and troubleshooting.
> 
> Updates the main `Upgrade Loki` page to prominently link to this new community-chart migration guide under *Helm Chart Upgrades*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b74d0e6559714e4e06894c37297953fa437c454b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->