### PR TITLE
refactor: extract otlplabels package for reusable OTLP label conversion

### DIFF
--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -3,7 +3,6 @@ package push
 import (
 	"compress/gzip"
 	"context"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,12 +16,11 @@ import (
 	"github.com/pierrec/lz4/v4"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/otlptranslator"
 	"github.com/prometheus/prometheus/model/labels"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 
+	"github.com/grafana/loki/v3/pkg/loghttp/push/otlplabels"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 
 	"github.com/grafana/loki/pkg/push"
@@ -165,70 +163,30 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 		res := rls.At(i).Resource()
 		resAttrs := res.Attributes()
 
-		resourceAttributesAsStructuredMetadata := make(push.LabelsAdapter, 0, resAttrs.Len())
-		streamLabels := make(model.LabelSet, 30) // we have a default labels limit of 30 so just initialize the map of same size
+		resResult, err := otlplabels.ResourceAttrsToStreamLabels(resAttrs, otlpConfig, discoverServiceName)
+		if err != nil {
+			return nil, err
+		}
+
+		resourceAttributesAsStructuredMetadata := resResult.StructuredMetadata
+		streamLabels := resResult.StreamLabels
+
 		var pushedLabels model.LabelSet
 		if logServiceNameDiscovery {
-			pushedLabels = make(model.LabelSet, 30)
-		}
-
-		shouldDiscoverServiceName := len(discoverServiceName) > 0
-		hasServiceName := false
-		if v, ok := resAttrs.Get(attrServiceName); ok && v.AsString() != "" {
-			hasServiceName = true
-		}
-		var rangeErr error
-		resAttrs.Range(func(k string, v pcommon.Value) bool {
-			action := otlpConfig.ActionForResourceAttribute(k)
-			if action == Drop {
-				return true
+			pushedLabels = make(model.LabelSet, len(streamLabels))
+			for k, v := range streamLabels {
+				pushedLabels[k] = v
 			}
-
-			attributeAsLabels, err := attributeToLabels(k, v, "")
-			if err != nil {
-				rangeErr = err
-				return false
-			}
-			if action == IndexLabel {
-				for _, lbl := range attributeAsLabels {
-					streamLabels[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
-					if logServiceNameDiscovery && pushedLabels != nil {
-						pushedLabels[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
-					}
-
-					if !hasServiceName && shouldDiscoverServiceName {
-						for _, labelName := range discoverServiceName {
-							if lbl.Name == labelName {
-								streamLabels[model.LabelName(LabelServiceName)] = model.LabelValue(lbl.Value)
-								hasServiceName = true
-								break
-							}
-						}
-					}
-				}
-			} else if action == StructuredMetadata {
-				resourceAttributesAsStructuredMetadata = append(resourceAttributesAsStructuredMetadata, attributeAsLabels...)
-			}
-
-			return true
-		})
-		if rangeErr != nil {
-			return nil, rangeErr
 		}
 
-		if !hasServiceName && shouldDiscoverServiceName {
-			streamLabels[model.LabelName(LabelServiceName)] = model.LabelValue(ServiceUnknown)
-		}
-
-		// this must be pushed to the end after log lines are also evaluated
 		if logServiceNameDiscovery {
 			var sb strings.Builder
 			sb.WriteString("{")
-			labels := make([]string, 0, len(pushedLabels))
+			lblStrs := make([]string, 0, len(pushedLabels))
 			for name, value := range pushedLabels {
-				labels = append(labels, fmt.Sprintf(`%s="%s"`, name, value))
+				lblStrs = append(lblStrs, fmt.Sprintf(`%s="%s"`, name, value))
 			}
-			sb.WriteString(strings.Join(labels, ", "))
+			sb.WriteString(strings.Join(lblStrs, ", "))
 			sb.WriteString("}")
 
 			level.Debug(logger).Log(
@@ -285,9 +243,7 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 		stats.ResourceAndSourceMetadataLabels[policy][retentionPeriodForUser] = append(stats.ResourceAndSourceMetadataLabels[policy][retentionPeriodForUser], resourceAttributesAsStructuredMetadata...)
 
 		for j := 0; j < sls.Len(); j++ {
-			scope := sls.At(j).Scope()
 			logs := sls.At(j).LogRecords()
-			scopeAttrs := scope.Attributes()
 
 			// it would be rare to have multiple scopes so if the entries slice is empty, pre-allocate it for the number of log entries
 			if cap(pushRequestsByStream[labelsStr].Entries) == 0 {
@@ -296,48 +252,11 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 				pushRequestsByStream[labelsStr] = stream
 			}
 
-			// use fields and attributes from scope as structured metadata
-			scopeAttributesAsStructuredMetadata := make(push.LabelsAdapter, 0, scopeAttrs.Len()+3)
-			var rangeErr error
-			scopeAttrs.Range(func(k string, v pcommon.Value) bool {
-				action := otlpConfig.ActionForScopeAttribute(k)
-				if action == Drop {
-					return true
-				}
-
-				attributeAsLabels, err := attributeToLabels(k, v, "")
-				if err != nil {
-					rangeErr = err
-					return false
-				}
-				if action == StructuredMetadata {
-					scopeAttributesAsStructuredMetadata = append(scopeAttributesAsStructuredMetadata, attributeAsLabels...)
-				}
-
-				return true
-			})
-			if rangeErr != nil {
-				return nil, rangeErr
+			scopeResult, err := otlplabels.ScopeAttrsToStructuredMetadata(sls, j, otlpConfig)
+			if err != nil {
+				return nil, err
 			}
-
-			if scopeName := scope.Name(); scopeName != "" {
-				scopeAttributesAsStructuredMetadata = append(scopeAttributesAsStructuredMetadata, push.LabelAdapter{
-					Name:  "scope_name",
-					Value: scopeName,
-				})
-			}
-			if scopeVersion := scope.Version(); scopeVersion != "" {
-				scopeAttributesAsStructuredMetadata = append(scopeAttributesAsStructuredMetadata, push.LabelAdapter{
-					Name:  "scope_version",
-					Value: scopeVersion,
-				})
-			}
-			if scopeDroppedAttributesCount := scope.DroppedAttributesCount(); scopeDroppedAttributesCount != 0 {
-				scopeAttributesAsStructuredMetadata = append(scopeAttributesAsStructuredMetadata, push.LabelAdapter{
-					Name:  "scope_dropped_attributes_count",
-					Value: fmt.Sprintf("%d", scopeDroppedAttributesCount),
-				})
-			}
+			scopeAttributesAsStructuredMetadata := scopeResult.StructuredMetadata
 
 			scopeAttributesAsStructuredMetadataSize := loki_util.StructuredMetadataSize(scopeAttributesAsStructuredMetadata)
 			stats.StructuredMetadataBytes[policy][retentionPeriodForUser] += int64(scopeAttributesAsStructuredMetadataSize)
@@ -481,176 +400,22 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 
 // otlpLogToPushEntry converts an OTLP log record to a Loki push.Entry.
 func otlpLogToPushEntry(log plog.LogRecord, otlpConfig OTLPConfig, logServiceNameDiscovery bool, pushedLabels model.LabelSet) (model.LabelSet, push.Entry, error) {
-	// copy log attributes and all the fields from log(except log.Body) to structured metadata
-	logAttrs := log.Attributes()
-	structuredMetadata := make(push.LabelsAdapter, 0, logAttrs.Len()+8)
-	logLabels := make(model.LabelSet)
+	logResult, err := otlplabels.LogAttrsToLabels(log, otlpConfig)
+	if err != nil {
+		return nil, push.Entry{}, err
+	}
 
-	var rangeErr error
-	logAttrs.Range(func(k string, v pcommon.Value) bool {
-		action := otlpConfig.ActionForLogAttribute(k)
-		if action == Drop {
-			return true
+	if logServiceNameDiscovery && pushedLabels != nil {
+		for k, v := range logResult.IndexLabels {
+			pushedLabels[k] = v
 		}
-
-		// If the dedicated OTLP EventName field is set, skip any log attribute
-		// also named event_name to avoid duplicate entries. The first-class field
-		// takes precedence over the attribute.
-		if k == OTLPEventName && log.EventName() != "" {
-			return true
-		}
-
-		attributeAsLabels, err := attributeToLabels(k, v, "")
-		if err != nil {
-			rangeErr = err
-			return false
-		}
-		if action == StructuredMetadata {
-			structuredMetadata = append(structuredMetadata, attributeAsLabels...)
-		}
-
-		if action == IndexLabel {
-			for _, lbl := range attributeAsLabels {
-				logLabels[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
-				if logServiceNameDiscovery && pushedLabels != nil {
-					pushedLabels[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
-				}
-			}
-		}
-
-		return true
-	})
-	if rangeErr != nil {
-		return nil, push.Entry{}, rangeErr
 	}
 
-	// if log.Timestamp() is 0, we would have already stored log.ObservedTimestamp as log timestamp so no need to store again in structured metadata
-	if log.Timestamp() != 0 && log.ObservedTimestamp() != 0 {
-		structuredMetadata = append(structuredMetadata, push.LabelAdapter{
-			Name:  "observed_timestamp",
-			Value: fmt.Sprintf("%d", log.ObservedTimestamp().AsTime().UnixNano()),
-		})
-	}
-
-	if severityNum := log.SeverityNumber(); severityNum != plog.SeverityNumberUnspecified {
-		structuredMetadata = append(structuredMetadata, push.LabelAdapter{
-			Name:  OTLPSeverityNumber,
-			Value: fmt.Sprintf("%d", severityNum),
-		})
-	}
-	if severityText := log.SeverityText(); severityText != "" {
-		// Add severity_text as an index label if configured
-		if otlpConfig.SeverityTextAsLabel {
-			logLabels[model.LabelName(OTLPSeverityText)] = model.LabelValue(severityText)
-			if logServiceNameDiscovery && pushedLabels != nil {
-				pushedLabels[model.LabelName(OTLPSeverityText)] = model.LabelValue(severityText)
-			}
-		}
-
-		// Always add severity_text as structured metadata
-		structuredMetadata = append(structuredMetadata, push.LabelAdapter{
-			Name:  OTLPSeverityText,
-			Value: severityText,
-		})
-	}
-
-	if droppedAttributesCount := log.DroppedAttributesCount(); droppedAttributesCount != 0 {
-		structuredMetadata = append(structuredMetadata, push.LabelAdapter{
-			Name:  "dropped_attributes_count",
-			Value: fmt.Sprintf("%d", droppedAttributesCount),
-		})
-	}
-	if logRecordFlags := log.Flags(); logRecordFlags != 0 {
-		structuredMetadata = append(structuredMetadata, push.LabelAdapter{
-			Name:  "flags",
-			Value: fmt.Sprintf("%d", logRecordFlags),
-		})
-	}
-
-	if traceID := log.TraceID(); !traceID.IsEmpty() {
-		structuredMetadata = append(structuredMetadata, push.LabelAdapter{
-			Name:  "trace_id",
-			Value: hex.EncodeToString(traceID[:]),
-		})
-	}
-	if spanID := log.SpanID(); !spanID.IsEmpty() {
-		structuredMetadata = append(structuredMetadata, push.LabelAdapter{
-			Name:  "span_id",
-			Value: hex.EncodeToString(spanID[:]),
-		})
-	}
-	if eventName := log.EventName(); eventName != "" {
-		structuredMetadata = append(structuredMetadata, push.LabelAdapter{
-			Name:  OTLPEventName,
-			Value: eventName,
-		})
-	}
-
-	return logLabels, push.Entry{
+	return logResult.IndexLabels, push.Entry{
 		Timestamp:          timestampFromLogRecord(log),
 		Line:               log.Body().AsString(),
-		StructuredMetadata: structuredMetadata,
+		StructuredMetadata: logResult.StructuredMetadata,
 	}, nil
-}
-
-func attributesToLabels(attrs pcommon.Map, prefix string) (push.LabelsAdapter, error) {
-	labelsAdapter := make(push.LabelsAdapter, 0, attrs.Len())
-	if attrs.Len() == 0 {
-		return labelsAdapter, nil
-	}
-
-	var rangeErr error
-	attrs.Range(func(k string, v pcommon.Value) bool {
-		lbls, err := attributeToLabels(k, v, prefix)
-		if err != nil {
-			rangeErr = err
-			return false
-		}
-		labelsAdapter = append(labelsAdapter, lbls...)
-		return true
-	})
-
-	return labelsAdapter, rangeErr
-}
-
-func attributeToLabels(k string, v pcommon.Value, prefix string) (push.LabelsAdapter, error) {
-	var labelsAdapter push.LabelsAdapter
-
-	keyWithPrefix := k
-	if prefix != "" {
-		keyWithPrefix = prefix + "_" + k
-	}
-
-	labelNamer := otlptranslator.LabelNamer{}
-	keyWithPrefix, err := labelNamer.Build(keyWithPrefix)
-	if err != nil {
-		return nil, fmt.Errorf("symbolizer lookup: %w", err)
-	}
-
-	typ := v.Type()
-	if typ == pcommon.ValueTypeMap {
-		mv := v.Map()
-		labelsAdapter = make(push.LabelsAdapter, 0, mv.Len())
-		var rangeErr error
-		mv.Range(func(k string, v pcommon.Value) bool {
-			lbls, err := attributeToLabels(k, v, keyWithPrefix)
-			if err != nil {
-				rangeErr = fmt.Errorf("symbolizer lookup: %w", err)
-				return false
-			}
-			labelsAdapter = append(labelsAdapter, lbls...)
-			return true
-		})
-		if rangeErr != nil {
-			return nil, rangeErr
-		}
-	} else {
-		labelsAdapter = push.LabelsAdapter{
-			push.LabelAdapter{Name: keyWithPrefix, Value: v.AsString()},
-		}
-	}
-
-	return labelsAdapter, nil
 }
 
 func timestampFromLogRecord(lr plog.LogRecord) time.Time {

--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -34,8 +34,7 @@ const (
 	pbContentType       = "application/x-protobuf"
 	gzipContentEncoding = "gzip"
 	zstdContentEncoding = "zstd"
-	lz4ContentEncoding  = "lz4"
-	attrServiceName     = "service.name"
+	lz4ContentEncoding = "lz4"
 
 	OTLPSeverityNumber = "severity_number"
 	OTLPSeverityText   = "severity_text"

--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -34,11 +34,11 @@ const (
 	pbContentType       = "application/x-protobuf"
 	gzipContentEncoding = "gzip"
 	zstdContentEncoding = "zstd"
-	lz4ContentEncoding = "lz4"
+	lz4ContentEncoding  = "lz4"
 
-	OTLPSeverityNumber = "severity_number"
-	OTLPSeverityText   = "severity_text"
-	OTLPEventName      = "event_name"
+	OTLPSeverityNumber = otlplabels.OTLPSeverityNumber
+	OTLPSeverityText   = otlplabels.OTLPSeverityText
+	OTLPEventName      = otlplabels.OTLPEventName
 
 	messageSizeLargerErrFmt = "%w than max (%d vs %d)"
 )
@@ -178,14 +178,15 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 			}
 		}
 
+		// this must be pushed to the end after log lines are also evaluated
 		if logServiceNameDiscovery {
 			var sb strings.Builder
 			sb.WriteString("{")
-			lblStrs := make([]string, 0, len(pushedLabels))
+			labels := make([]string, 0, len(pushedLabels))
 			for name, value := range pushedLabels {
-				lblStrs = append(lblStrs, fmt.Sprintf(`%s="%s"`, name, value))
+				labels = append(labels, fmt.Sprintf(`%s="%s"`, name, value))
 			}
-			sb.WriteString(strings.Join(lblStrs, ", "))
+			sb.WriteString(strings.Join(labels, ", "))
 			sb.WriteString("}")
 
 			level.Debug(logger).Log(

--- a/pkg/loghttp/push/otlp_config_compat.go
+++ b/pkg/loghttp/push/otlp_config_compat.go
@@ -1,0 +1,22 @@
+package push
+
+import (
+	"github.com/grafana/loki/v3/pkg/loghttp/push/otlplabels"
+)
+
+// Type aliases for backward compatibility. All definitions live in otlplabels.
+type Action = otlplabels.Action
+type OTLPConfig = otlplabels.OTLPConfig
+type GlobalOTLPConfig = otlplabels.GlobalOTLPConfig
+type AttributesConfig = otlplabels.AttributesConfig
+type ResourceAttributesConfig = otlplabels.ResourceAttributesConfig
+
+const (
+	IndexLabel         = otlplabels.IndexLabel
+	StructuredMetadata = otlplabels.StructuredMetadata
+	Drop               = otlplabels.Drop
+)
+
+func DefaultOTLPConfig(cfg GlobalOTLPConfig) OTLPConfig {
+	return otlplabels.DefaultOTLPConfig(cfg)
+}

--- a/pkg/loghttp/push/otlp_test.go
+++ b/pkg/loghttp/push/otlp_test.go
@@ -3,7 +3,6 @@ package push
 import (
 	"compress/gzip"
 	"context"
-	"encoding/base64"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -21,7 +20,6 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/grafana/loki/v3/pkg/loghttp/push/otlplabels"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 
 	"github.com/grafana/loki/pkg/push"
@@ -763,130 +761,6 @@ func TestOTLPLogToPushEntry(t *testing.T) {
 			_, res, err := otlpLogToPushEntry(tc.buildLogRecord(), DefaultOTLPConfig(defaultGlobalOTLPConfig), false, nil)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedResp, res)
-		})
-	}
-}
-
-func TestAttributesToLabels(t *testing.T) {
-	for _, tc := range []struct {
-		name         string
-		buildAttrs   func() pcommon.Map
-		expectedResp push.LabelsAdapter
-	}{
-		{
-			name: "no attributes",
-			buildAttrs: func() pcommon.Map {
-				return pcommon.NewMap()
-			},
-			expectedResp: push.LabelsAdapter{},
-		},
-		{
-			name: "with attributes",
-			buildAttrs: func() pcommon.Map {
-				attrs := pcommon.NewMap()
-				attrs.PutEmpty("empty")
-				attrs.PutStr("str", "val")
-				attrs.PutInt("int", 1)
-				attrs.PutDouble("double", 3.14)
-				attrs.PutBool("bool", true)
-				attrs.PutEmptyBytes("bytes").Append(1, 2, 3)
-
-				slice := attrs.PutEmptySlice("slice")
-				slice.AppendEmpty().SetInt(1)
-				slice.AppendEmpty().SetEmptySlice().AppendEmpty().SetStr("foo")
-				slice.AppendEmpty().SetEmptyMap().PutStr("fizz", "buzz")
-
-				m := attrs.PutEmptyMap("nested")
-				m.PutStr("foo", "bar")
-				m.PutEmptyMap("more").PutStr("key", "val")
-
-				return attrs
-			},
-			expectedResp: push.LabelsAdapter{
-				{
-					Name: "empty",
-				},
-				{
-					Name:  "str",
-					Value: "val",
-				},
-				{
-					Name:  "int",
-					Value: "1",
-				},
-				{
-					Name:  "double",
-					Value: "3.14",
-				},
-				{
-					Name:  "bool",
-					Value: "true",
-				},
-				{
-					Name:  "bytes",
-					Value: base64.StdEncoding.EncodeToString([]byte{1, 2, 3}),
-				},
-				{
-					Name:  "slice",
-					Value: `[1,["foo"],{"fizz":"buzz"}]`,
-				},
-				{
-					Name:  "nested_foo",
-					Value: "bar",
-				},
-				{
-					Name:  "nested_more_key",
-					Value: "val",
-				},
-			},
-		},
-		{
-			name: "attributes with special chars",
-			buildAttrs: func() pcommon.Map {
-				attrs := pcommon.NewMap()
-				attrs.PutStr("st.r", "val")
-
-				m := attrs.PutEmptyMap("nest*ed")
-				m.PutStr("fo@o", "bar")
-				m.PutEmptyMap("m$ore").PutStr("k_ey", "val")
-
-				return attrs
-			},
-			expectedResp: push.LabelsAdapter{
-				{
-					Name:  "st_r",
-					Value: "val",
-				},
-				{
-					Name:  "nest_ed_fo_o",
-					Value: "bar",
-				},
-				{
-					Name:  "nest_ed_m_ore_k_ey",
-					Value: "val",
-				},
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			attrs := tc.buildAttrs()
-			var result push.LabelsAdapter
-			if attrs.Len() == 0 {
-				result = push.LabelsAdapter{}
-			} else {
-				var rangeErr error
-				attrs.Range(func(k string, v pcommon.Value) bool {
-					ol, err := otlplabels.AttributeToLabels(k, v, "")
-					if err != nil {
-						rangeErr = err
-						return false
-					}
-					result = append(result, ol...)
-					return true
-				})
-				require.NoError(t, rangeErr)
-			}
-			require.Equal(t, tc.expectedResp, result)
 		})
 	}
 }

--- a/pkg/loghttp/push/otlp_test.go
+++ b/pkg/loghttp/push/otlp_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/require"
@@ -20,6 +21,7 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/grafana/loki/v3/pkg/loghttp/push/otlplabels"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 
 	"github.com/grafana/loki/pkg/push"
@@ -32,6 +34,12 @@ import (
 	"github.com/pierrec/lz4/v4"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 )
+
+var defaultGlobalOTLPConfig = GlobalOTLPConfig{}
+
+func init() {
+	flagext.DefaultValues(&defaultGlobalOTLPConfig)
+}
 
 func TestOTLPToLokiPushRequest(t *testing.T) {
 	now := time.Unix(0, time.Now().UnixNano())
@@ -861,9 +869,24 @@ func TestAttributesToLabels(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			lbls, err := attributesToLabels(tc.buildAttrs(), "")
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedResp, lbls)
+			attrs := tc.buildAttrs()
+			var result push.LabelsAdapter
+			if attrs.Len() == 0 {
+				result = push.LabelsAdapter{}
+			} else {
+				var rangeErr error
+				attrs.Range(func(k string, v pcommon.Value) bool {
+					ol, err := otlplabels.AttributeToLabels(k, v, "")
+					if err != nil {
+						rangeErr = err
+						return false
+					}
+					result = append(result, ol...)
+					return true
+				})
+				require.NoError(t, rangeErr)
+			}
+			require.Equal(t, tc.expectedResp, result)
 		})
 	}
 }

--- a/pkg/loghttp/push/otlplabels/config.go
+++ b/pkg/loghttp/push/otlplabels/config.go
@@ -1,4 +1,4 @@
-package push
+package otlplabels
 
 import (
 	"encoding/json"
@@ -22,9 +22,9 @@ const (
 )
 
 var (
-	errUnsupportedAction         = fmt.Errorf("unsupported action, it must be one of: %s, %s, %s", Drop, IndexLabel, StructuredMetadata)
-	errAttributesAndRegexNotSet  = fmt.Errorf("attributes or regex must be set")
-	errAttributesAndRegexBothSet = fmt.Errorf("only one of attributes or regex must be set")
+	ErrUnsupportedAction         = fmt.Errorf("unsupported action, it must be one of: %s, %s, %s", Drop, IndexLabel, StructuredMetadata)
+	ErrAttributesAndRegexNotSet  = fmt.Errorf("attributes or regex must be set")
+	ErrAttributesAndRegexBothSet = fmt.Errorf("only one of attributes or regex must be set")
 )
 
 func DefaultOTLPConfig(cfg GlobalOTLPConfig) OTLPConfig {
@@ -142,15 +142,15 @@ func (c *AttributesConfig) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	}
 
 	if c.Action != IndexLabel && c.Action != StructuredMetadata && c.Action != Drop {
-		return errUnsupportedAction
+		return ErrUnsupportedAction
 	}
 
 	if len(c.Attributes) == 0 && c.Regex.Regexp == nil {
-		return errAttributesAndRegexNotSet
+		return ErrAttributesAndRegexNotSet
 	}
 
 	if len(c.Attributes) != 0 && c.Regex.Regexp != nil {
-		return errAttributesAndRegexBothSet
+		return ErrAttributesAndRegexBothSet
 	}
 
 	return nil

--- a/pkg/loghttp/push/otlplabels/config_test.go
+++ b/pkg/loghttp/push/otlplabels/config_test.go
@@ -361,19 +361,3 @@ func TestOTLPConfig(t *testing.T) {
 		})
 	}
 }
-
-func TestValidate(t *testing.T) {
-	t.Run("scope with index_label returns error", func(t *testing.T) {
-		cfg := OTLPConfig{
-			ScopeAttributes: []AttributesConfig{
-				{Action: IndexLabel, Attributes: []string{"foo"}},
-			},
-		}
-		require.Error(t, cfg.Validate())
-	})
-
-	t.Run("valid config returns nil", func(t *testing.T) {
-		cfg := DefaultOTLPConfig(defaultGlobalOTLPConfig)
-		require.NoError(t, cfg.Validate())
-	})
-}

--- a/pkg/loghttp/push/otlplabels/config_test.go
+++ b/pkg/loghttp/push/otlplabels/config_test.go
@@ -1,4 +1,4 @@
-package push
+package otlplabels
 
 import (
 	"testing"
@@ -131,14 +131,14 @@ log_attributes:
   - action: keep
     attributes:
       - fizz`),
-			expectedErr: errUnsupportedAction,
+			expectedErr: ErrUnsupportedAction,
 		},
 		{
 			name: "attributes and regex both not set should error",
 			yamlConfig: []byte(`
 log_attributes:
   - action: drop`),
-			expectedErr: errAttributesAndRegexNotSet,
+			expectedErr: ErrAttributesAndRegexNotSet,
 		},
 		{
 			name: "attributes and regex both being set should error",
@@ -148,7 +148,7 @@ log_attributes:
     regex: foo
     attributes:
       - fizz`),
-			expectedErr: errAttributesAndRegexBothSet,
+			expectedErr: ErrAttributesAndRegexBothSet,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -182,7 +182,7 @@ func TestOTLPConfig(t *testing.T) {
 			otlpConfig: DefaultOTLPConfig(defaultGlobalOTLPConfig),
 			resAttrs: []attrAndExpAction{
 				{
-					attr:           attrServiceName,
+					attr:           AttrServiceName,
 					expectedAction: IndexLabel,
 				},
 				{
@@ -210,7 +210,7 @@ func TestOTLPConfig(t *testing.T) {
 					AttributesConfig: []AttributesConfig{
 						{
 							Action:     IndexLabel,
-							Attributes: []string{attrServiceName},
+							Attributes: []string{AttrServiceName},
 						},
 						{
 							Action: StructuredMetadata,
@@ -245,7 +245,7 @@ func TestOTLPConfig(t *testing.T) {
 			},
 			resAttrs: []attrAndExpAction{
 				{
-					attr:           attrServiceName,
+					attr:           AttrServiceName,
 					expectedAction: IndexLabel,
 				},
 				{
@@ -285,7 +285,7 @@ func TestOTLPConfig(t *testing.T) {
 					AttributesConfig: []AttributesConfig{
 						{
 							Action:     Drop,
-							Attributes: []string{attrServiceName},
+							Attributes: []string{AttrServiceName},
 						},
 						{
 							Action: IndexLabel,
@@ -316,7 +316,7 @@ func TestOTLPConfig(t *testing.T) {
 			},
 			resAttrs: []attrAndExpAction{
 				{
-					attr:           attrServiceName,
+					attr:           AttrServiceName,
 					expectedAction: Drop,
 				},
 				{
@@ -360,4 +360,20 @@ func TestOTLPConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("scope with index_label returns error", func(t *testing.T) {
+		cfg := OTLPConfig{
+			ScopeAttributes: []AttributesConfig{
+				{Action: IndexLabel, Attributes: []string{"foo"}},
+			},
+		}
+		require.Error(t, cfg.Validate())
+	})
+
+	t.Run("valid config returns nil", func(t *testing.T) {
+		cfg := DefaultOTLPConfig(defaultGlobalOTLPConfig)
+		require.NoError(t, cfg.Validate())
+	})
 }

--- a/pkg/loghttp/push/otlplabels/labels.go
+++ b/pkg/loghttp/push/otlplabels/labels.go
@@ -1,0 +1,317 @@
+package otlplabels
+
+import (
+	"encoding/hex"
+	"fmt"
+	"slices"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/otlptranslator"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/grafana/loki/pkg/push"
+)
+
+const (
+	AttrServiceName  = "service.name"
+	LabelServiceName = "service_name"
+	ServiceUnknown   = "unknown_service"
+
+	OTLPSeverityNumber = "severity_number"
+	OTLPSeverityText   = "severity_text"
+	OTLPEventName      = "event_name"
+)
+
+// AttributeToLabels converts a single OTLP attribute key/value into one or
+// more LabelAdapters. Map-valued attributes are expanded recursively with the
+// parent key as prefix. The key is normalized via otlptranslator.LabelNamer.
+func AttributeToLabels(k string, v pcommon.Value, prefix string) (push.LabelsAdapter, error) {
+	keyWithPrefix := k
+	if prefix != "" {
+		keyWithPrefix = prefix + "_" + k
+	}
+
+	namer := otlptranslator.LabelNamer{}
+	normalized, err := namer.Build(keyWithPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("symbolizer lookup: %w", err)
+	}
+
+	if v.Type() == pcommon.ValueTypeMap {
+		mv := v.Map()
+		result := make(push.LabelsAdapter, 0, mv.Len())
+		var rangeErr error
+		mv.Range(func(mk string, mv pcommon.Value) bool {
+			sub, err := AttributeToLabels(mk, mv, normalized)
+			if err != nil {
+				rangeErr = fmt.Errorf("symbolizer lookup: %w", err)
+				return false
+			}
+			result = append(result, sub...)
+			return true
+		})
+		if rangeErr != nil {
+			return nil, rangeErr
+		}
+		return result, nil
+	}
+
+	return push.LabelsAdapter{{Name: normalized, Value: v.AsString()}}, nil
+}
+
+// attributesToLabels converts all attributes in a pcommon.Map to LabelsAdapter.
+func attributesToLabels(attrs pcommon.Map, prefix string) (push.LabelsAdapter, error) {
+	result := make(push.LabelsAdapter, 0, attrs.Len())
+	if attrs.Len() == 0 {
+		return result, nil
+	}
+
+	var rangeErr error
+	attrs.Range(func(k string, v pcommon.Value) bool {
+		lbls, err := AttributeToLabels(k, v, prefix)
+		if err != nil {
+			rangeErr = err
+			return false
+		}
+		result = append(result, lbls...)
+		return true
+	})
+
+	return result, rangeErr
+}
+
+// ResourceAttrsResult holds the output of ResourceAttrsToStreamLabels.
+type ResourceAttrsResult struct {
+	// StreamLabels are attributes configured as IndexLabel.
+	StreamLabels model.LabelSet
+	// StructuredMetadata are attributes configured as StructuredMetadata.
+	StructuredMetadata push.LabelsAdapter
+}
+
+// ResourceAttrsToStreamLabels converts OTLP resource attributes into stream
+// labels and structured metadata according to the OTLPConfig.
+//
+// When discoverServiceName is non-empty and no explicit service.name attribute
+// is present, the first indexed label whose name appears in discoverServiceName
+// is promoted to service_name. If no candidate is found, service_name defaults
+// to "unknown_service".
+func ResourceAttrsToStreamLabels(attrs pcommon.Map, otlpConfig OTLPConfig, discoverServiceName []string) (*ResourceAttrsResult, error) {
+	result := &ResourceAttrsResult{
+		StreamLabels:       make(model.LabelSet, 30),
+		StructuredMetadata: make(push.LabelsAdapter, 0, attrs.Len()),
+	}
+
+	shouldDiscover := len(discoverServiceName) > 0
+	hasServiceName := false
+	if v, ok := attrs.Get(AttrServiceName); ok && v.AsString() != "" {
+		hasServiceName = true
+	}
+
+	var rangeErr error
+	attrs.Range(func(k string, v pcommon.Value) bool {
+		action := otlpConfig.ActionForResourceAttribute(k)
+		if action == Drop {
+			return true
+		}
+
+		attrLabels, err := AttributeToLabels(k, v, "")
+		if err != nil {
+			rangeErr = err
+			return false
+		}
+
+		if action == IndexLabel {
+			for _, lbl := range attrLabels {
+				result.StreamLabels[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
+
+				if !hasServiceName && shouldDiscover {
+					if slices.Contains(discoverServiceName, lbl.Name) {
+						result.StreamLabels[model.LabelName(LabelServiceName)] = model.LabelValue(lbl.Value)
+						hasServiceName = true
+					}
+				}
+			}
+		} else if action == StructuredMetadata {
+			result.StructuredMetadata = append(result.StructuredMetadata, attrLabels...)
+		}
+
+		return true
+	})
+	if rangeErr != nil {
+		return nil, rangeErr
+	}
+
+	if !hasServiceName && shouldDiscover {
+		result.StreamLabels[model.LabelName(LabelServiceName)] = model.LabelValue(ServiceUnknown)
+	}
+
+	return result, nil
+}
+
+// ScopeAttrsResult holds the output of ScopeAttrsToStructuredMetadata.
+type ScopeAttrsResult struct {
+	StructuredMetadata push.LabelsAdapter
+}
+
+// ScopeAttrsToStructuredMetadata converts OTLP scope attributes plus scope
+// name, version, and dropped attributes count into structured metadata labels.
+func ScopeAttrsToStructuredMetadata(scope plog.ScopeLogsSlice, idx int, otlpConfig OTLPConfig) (*ScopeAttrsResult, error) {
+	s := scope.At(idx).Scope()
+	scopeAttrs := s.Attributes()
+	result := &ScopeAttrsResult{
+		StructuredMetadata: make(push.LabelsAdapter, 0, scopeAttrs.Len()+3),
+	}
+
+	var rangeErr error
+	scopeAttrs.Range(func(k string, v pcommon.Value) bool {
+		action := otlpConfig.ActionForScopeAttribute(k)
+		if action == Drop {
+			return true
+		}
+
+		attrLabels, err := AttributeToLabels(k, v, "")
+		if err != nil {
+			rangeErr = err
+			return false
+		}
+		if action == StructuredMetadata {
+			result.StructuredMetadata = append(result.StructuredMetadata, attrLabels...)
+		}
+		return true
+	})
+	if rangeErr != nil {
+		return nil, rangeErr
+	}
+
+	if name := s.Name(); name != "" {
+		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
+			Name:  "scope_name",
+			Value: name,
+		})
+	}
+	if version := s.Version(); version != "" {
+		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
+			Name:  "scope_version",
+			Value: version,
+		})
+	}
+	if dropped := s.DroppedAttributesCount(); dropped != 0 {
+		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
+			Name:  "scope_dropped_attributes_count",
+			Value: fmt.Sprintf("%d", dropped),
+		})
+	}
+
+	return result, nil
+}
+
+// LogAttrsResult holds the output of LogAttrsToLabels.
+type LogAttrsResult struct {
+	// IndexLabels are log attributes configured as IndexLabel.
+	IndexLabels model.LabelSet
+	// StructuredMetadata are log attributes plus log record fields
+	// (severity, trace_id, span_id, etc.) stored as structured metadata.
+	StructuredMetadata push.LabelsAdapter
+}
+
+// LogAttrsToLabels converts OTLP log record attributes and built-in fields
+// (severity, trace/span IDs, event name, flags, dropped attributes count,
+// observed timestamp) into index labels and structured metadata.
+func LogAttrsToLabels(log plog.LogRecord, otlpConfig OTLPConfig) (*LogAttrsResult, error) {
+	logAttrs := log.Attributes()
+	result := &LogAttrsResult{
+		IndexLabels:        make(model.LabelSet),
+		StructuredMetadata: make(push.LabelsAdapter, 0, logAttrs.Len()+8),
+	}
+
+	var rangeErr error
+	logAttrs.Range(func(k string, v pcommon.Value) bool {
+		action := otlpConfig.ActionForLogAttribute(k)
+		if action == Drop {
+			return true
+		}
+
+		// When the dedicated OTLP EventName field is set, skip any log
+		// attribute also named event_name to avoid duplicates. The
+		// first-class field takes precedence.
+		if k == OTLPEventName && log.EventName() != "" {
+			return true
+		}
+
+		attrLabels, err := AttributeToLabels(k, v, "")
+		if err != nil {
+			rangeErr = err
+			return false
+		}
+		if action == StructuredMetadata {
+			result.StructuredMetadata = append(result.StructuredMetadata, attrLabels...)
+		}
+		if action == IndexLabel {
+			for _, lbl := range attrLabels {
+				result.IndexLabels[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
+			}
+		}
+		return true
+	})
+	if rangeErr != nil {
+		return nil, rangeErr
+	}
+
+	if log.Timestamp() != 0 && log.ObservedTimestamp() != 0 {
+		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
+			Name:  "observed_timestamp",
+			Value: fmt.Sprintf("%d", log.ObservedTimestamp().AsTime().UnixNano()),
+		})
+	}
+
+	if severityNum := log.SeverityNumber(); severityNum != plog.SeverityNumberUnspecified {
+		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
+			Name:  OTLPSeverityNumber,
+			Value: fmt.Sprintf("%d", severityNum),
+		})
+	}
+	if severityText := log.SeverityText(); severityText != "" {
+		if otlpConfig.SeverityTextAsLabel {
+			result.IndexLabels[model.LabelName(OTLPSeverityText)] = model.LabelValue(severityText)
+		}
+		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
+			Name:  OTLPSeverityText,
+			Value: severityText,
+		})
+	}
+
+	if dropped := log.DroppedAttributesCount(); dropped != 0 {
+		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
+			Name:  "dropped_attributes_count",
+			Value: fmt.Sprintf("%d", dropped),
+		})
+	}
+	if flags := log.Flags(); flags != 0 {
+		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
+			Name:  "flags",
+			Value: fmt.Sprintf("%d", flags),
+		})
+	}
+
+	if traceID := log.TraceID(); !traceID.IsEmpty() {
+		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
+			Name:  "trace_id",
+			Value: hex.EncodeToString(traceID[:]),
+		})
+	}
+	if spanID := log.SpanID(); !spanID.IsEmpty() {
+		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
+			Name:  "span_id",
+			Value: hex.EncodeToString(spanID[:]),
+		})
+	}
+	if eventName := log.EventName(); eventName != "" {
+		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
+			Name:  OTLPEventName,
+			Value: eventName,
+		})
+	}
+
+	return result, nil
+}

--- a/pkg/loghttp/push/otlplabels/labels.go
+++ b/pkg/loghttp/push/otlplabels/labels.go
@@ -65,7 +65,6 @@ func AttributeToLabels(k string, v pcommon.Value, prefix string) (push.LabelsAda
 	return labelsAdapter, nil
 }
 
-// attributesToLabels converts all attributes in a pcommon.Map to LabelsAdapter.
 func attributesToLabels(attrs pcommon.Map, prefix string) (push.LabelsAdapter, error) {
 	labelsAdapter := make(push.LabelsAdapter, 0, attrs.Len())
 	if attrs.Len() == 0 {

--- a/pkg/loghttp/push/otlplabels/labels.go
+++ b/pkg/loghttp/push/otlplabels/labels.go
@@ -3,7 +3,6 @@ package otlplabels
 import (
 	"encoding/hex"
 	"fmt"
-	"slices"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/otlptranslator"
@@ -27,44 +26,50 @@ const (
 // more LabelAdapters. Map-valued attributes are expanded recursively with the
 // parent key as prefix. The key is normalized via otlptranslator.LabelNamer.
 func AttributeToLabels(k string, v pcommon.Value, prefix string) (push.LabelsAdapter, error) {
+	var labelsAdapter push.LabelsAdapter
+
 	keyWithPrefix := k
 	if prefix != "" {
 		keyWithPrefix = prefix + "_" + k
 	}
 
-	namer := otlptranslator.LabelNamer{}
-	normalized, err := namer.Build(keyWithPrefix)
+	labelNamer := otlptranslator.LabelNamer{}
+	keyWithPrefix, err := labelNamer.Build(keyWithPrefix)
 	if err != nil {
 		return nil, fmt.Errorf("symbolizer lookup: %w", err)
 	}
 
-	if v.Type() == pcommon.ValueTypeMap {
+	typ := v.Type()
+	if typ == pcommon.ValueTypeMap {
 		mv := v.Map()
-		result := make(push.LabelsAdapter, 0, mv.Len())
+		labelsAdapter = make(push.LabelsAdapter, 0, mv.Len())
 		var rangeErr error
-		mv.Range(func(mk string, mv pcommon.Value) bool {
-			sub, err := AttributeToLabels(mk, mv, normalized)
+		mv.Range(func(k string, v pcommon.Value) bool {
+			lbls, err := AttributeToLabels(k, v, keyWithPrefix)
 			if err != nil {
 				rangeErr = fmt.Errorf("symbolizer lookup: %w", err)
 				return false
 			}
-			result = append(result, sub...)
+			labelsAdapter = append(labelsAdapter, lbls...)
 			return true
 		})
 		if rangeErr != nil {
 			return nil, rangeErr
 		}
-		return result, nil
+	} else {
+		labelsAdapter = push.LabelsAdapter{
+			push.LabelAdapter{Name: keyWithPrefix, Value: v.AsString()},
+		}
 	}
 
-	return push.LabelsAdapter{{Name: normalized, Value: v.AsString()}}, nil
+	return labelsAdapter, nil
 }
 
 // attributesToLabels converts all attributes in a pcommon.Map to LabelsAdapter.
 func attributesToLabels(attrs pcommon.Map, prefix string) (push.LabelsAdapter, error) {
-	result := make(push.LabelsAdapter, 0, attrs.Len())
+	labelsAdapter := make(push.LabelsAdapter, 0, attrs.Len())
 	if attrs.Len() == 0 {
-		return result, nil
+		return labelsAdapter, nil
 	}
 
 	var rangeErr error
@@ -74,11 +79,11 @@ func attributesToLabels(attrs pcommon.Map, prefix string) (push.LabelsAdapter, e
 			rangeErr = err
 			return false
 		}
-		result = append(result, lbls...)
+		labelsAdapter = append(labelsAdapter, lbls...)
 		return true
 	})
 
-	return result, rangeErr
+	return labelsAdapter, rangeErr
 }
 
 // ResourceAttrsResult holds the output of ResourceAttrsToStreamLabels.
@@ -102,7 +107,7 @@ func ResourceAttrsToStreamLabels(attrs pcommon.Map, otlpConfig OTLPConfig, disco
 		StructuredMetadata: make(push.LabelsAdapter, 0, attrs.Len()),
 	}
 
-	shouldDiscover := len(discoverServiceName) > 0
+	shouldDiscoverServiceName := len(discoverServiceName) > 0
 	hasServiceName := false
 	if v, ok := attrs.Get(AttrServiceName); ok && v.AsString() != "" {
 		hasServiceName = true
@@ -115,25 +120,28 @@ func ResourceAttrsToStreamLabels(attrs pcommon.Map, otlpConfig OTLPConfig, disco
 			return true
 		}
 
-		attrLabels, err := AttributeToLabels(k, v, "")
+		attributeAsLabels, err := AttributeToLabels(k, v, "")
 		if err != nil {
 			rangeErr = err
 			return false
 		}
 
 		if action == IndexLabel {
-			for _, lbl := range attrLabels {
+			for _, lbl := range attributeAsLabels {
 				result.StreamLabels[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
 
-				if !hasServiceName && shouldDiscover {
-					if slices.Contains(discoverServiceName, lbl.Name) {
-						result.StreamLabels[model.LabelName(LabelServiceName)] = model.LabelValue(lbl.Value)
-						hasServiceName = true
+				if !hasServiceName && shouldDiscoverServiceName {
+					for _, labelName := range discoverServiceName {
+						if lbl.Name == labelName {
+							result.StreamLabels[model.LabelName(LabelServiceName)] = model.LabelValue(lbl.Value)
+							hasServiceName = true
+							break
+						}
 					}
 				}
 			}
 		} else if action == StructuredMetadata {
-			result.StructuredMetadata = append(result.StructuredMetadata, attrLabels...)
+			result.StructuredMetadata = append(result.StructuredMetadata, attributeAsLabels...)
 		}
 
 		return true
@@ -142,7 +150,7 @@ func ResourceAttrsToStreamLabels(attrs pcommon.Map, otlpConfig OTLPConfig, disco
 		return nil, rangeErr
 	}
 
-	if !hasServiceName && shouldDiscover {
+	if !hasServiceName && shouldDiscoverServiceName {
 		result.StreamLabels[model.LabelName(LabelServiceName)] = model.LabelValue(ServiceUnknown)
 	}
 
@@ -156,9 +164,9 @@ type ScopeAttrsResult struct {
 
 // ScopeAttrsToStructuredMetadata converts OTLP scope attributes plus scope
 // name, version, and dropped attributes count into structured metadata labels.
-func ScopeAttrsToStructuredMetadata(scope plog.ScopeLogsSlice, idx int, otlpConfig OTLPConfig) (*ScopeAttrsResult, error) {
-	s := scope.At(idx).Scope()
-	scopeAttrs := s.Attributes()
+func ScopeAttrsToStructuredMetadata(sls plog.ScopeLogsSlice, idx int, otlpConfig OTLPConfig) (*ScopeAttrsResult, error) {
+	scope := sls.At(idx).Scope()
+	scopeAttrs := scope.Attributes()
 	result := &ScopeAttrsResult{
 		StructuredMetadata: make(push.LabelsAdapter, 0, scopeAttrs.Len()+3),
 	}
@@ -170,36 +178,37 @@ func ScopeAttrsToStructuredMetadata(scope plog.ScopeLogsSlice, idx int, otlpConf
 			return true
 		}
 
-		attrLabels, err := AttributeToLabels(k, v, "")
+		attributeAsLabels, err := AttributeToLabels(k, v, "")
 		if err != nil {
 			rangeErr = err
 			return false
 		}
 		if action == StructuredMetadata {
-			result.StructuredMetadata = append(result.StructuredMetadata, attrLabels...)
+			result.StructuredMetadata = append(result.StructuredMetadata, attributeAsLabels...)
 		}
+
 		return true
 	})
 	if rangeErr != nil {
 		return nil, rangeErr
 	}
 
-	if name := s.Name(); name != "" {
+	if scopeName := scope.Name(); scopeName != "" {
 		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
 			Name:  "scope_name",
-			Value: name,
+			Value: scopeName,
 		})
 	}
-	if version := s.Version(); version != "" {
+	if scopeVersion := scope.Version(); scopeVersion != "" {
 		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
 			Name:  "scope_version",
-			Value: version,
+			Value: scopeVersion,
 		})
 	}
-	if dropped := s.DroppedAttributesCount(); dropped != 0 {
+	if scopeDroppedAttributesCount := scope.DroppedAttributesCount(); scopeDroppedAttributesCount != 0 {
 		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
 			Name:  "scope_dropped_attributes_count",
-			Value: fmt.Sprintf("%d", dropped),
+			Value: fmt.Sprintf("%d", scopeDroppedAttributesCount),
 		})
 	}
 
@@ -232,32 +241,35 @@ func LogAttrsToLabels(log plog.LogRecord, otlpConfig OTLPConfig) (*LogAttrsResul
 			return true
 		}
 
-		// When the dedicated OTLP EventName field is set, skip any log
-		// attribute also named event_name to avoid duplicates. The
-		// first-class field takes precedence.
+		// If the dedicated OTLP EventName field is set, skip any log attribute
+		// also named event_name to avoid duplicate entries. The first-class field
+		// takes precedence over the attribute.
 		if k == OTLPEventName && log.EventName() != "" {
 			return true
 		}
 
-		attrLabels, err := AttributeToLabels(k, v, "")
+		attributeAsLabels, err := AttributeToLabels(k, v, "")
 		if err != nil {
 			rangeErr = err
 			return false
 		}
 		if action == StructuredMetadata {
-			result.StructuredMetadata = append(result.StructuredMetadata, attrLabels...)
+			result.StructuredMetadata = append(result.StructuredMetadata, attributeAsLabels...)
 		}
+
 		if action == IndexLabel {
-			for _, lbl := range attrLabels {
+			for _, lbl := range attributeAsLabels {
 				result.IndexLabels[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
 			}
 		}
+
 		return true
 	})
 	if rangeErr != nil {
 		return nil, rangeErr
 	}
 
+	// if log.Timestamp() is 0, we would have already stored log.ObservedTimestamp as log timestamp so no need to store again in structured metadata
 	if log.Timestamp() != 0 && log.ObservedTimestamp() != 0 {
 		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
 			Name:  "observed_timestamp",
@@ -272,25 +284,28 @@ func LogAttrsToLabels(log plog.LogRecord, otlpConfig OTLPConfig) (*LogAttrsResul
 		})
 	}
 	if severityText := log.SeverityText(); severityText != "" {
+		// Add severity_text as an index label if configured
 		if otlpConfig.SeverityTextAsLabel {
 			result.IndexLabels[model.LabelName(OTLPSeverityText)] = model.LabelValue(severityText)
 		}
+
+		// Always add severity_text as structured metadata
 		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
 			Name:  OTLPSeverityText,
 			Value: severityText,
 		})
 	}
 
-	if dropped := log.DroppedAttributesCount(); dropped != 0 {
+	if droppedAttributesCount := log.DroppedAttributesCount(); droppedAttributesCount != 0 {
 		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
 			Name:  "dropped_attributes_count",
-			Value: fmt.Sprintf("%d", dropped),
+			Value: fmt.Sprintf("%d", droppedAttributesCount),
 		})
 	}
-	if flags := log.Flags(); flags != 0 {
+	if logRecordFlags := log.Flags(); logRecordFlags != 0 {
 		result.StructuredMetadata = append(result.StructuredMetadata, push.LabelAdapter{
 			Name:  "flags",
-			Value: fmt.Sprintf("%d", flags),
+			Value: fmt.Sprintf("%d", logRecordFlags),
 		})
 	}
 

--- a/pkg/loghttp/push/otlplabels/labels_test.go
+++ b/pkg/loghttp/push/otlplabels/labels_test.go
@@ -1,0 +1,497 @@
+package otlplabels
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/grafana/loki/pkg/push"
+)
+
+func labelAdapterGet(ls push.LabelsAdapter, name string) string {
+	for _, l := range ls {
+		if l.Name == name {
+			return l.Value
+		}
+	}
+	return ""
+}
+
+func labelSetGet(ls model.LabelSet, name string) string {
+	return string(ls[model.LabelName(name)])
+}
+
+// ---------- AttributeToLabels tests ----------
+
+func TestAttributeToLabels_Simple(t *testing.T) {
+	v := pcommon.NewValueStr("hello")
+	got, err := AttributeToLabels("my.key", v, "")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(got))
+	assert.Equal(t, "hello", labelAdapterGet(got, "my_key"))
+}
+
+func TestAttributeToLabels_WithPrefix(t *testing.T) {
+	v := pcommon.NewValueStr("val")
+	got, err := AttributeToLabels("child", v, "parent")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(got))
+	assert.Equal(t, "val", labelAdapterGet(got, "parent_child"))
+}
+
+func TestAttributeToLabels_MapValue(t *testing.T) {
+	v := pcommon.NewValueMap()
+	m := v.Map()
+	m.PutStr("inner.a", "v1")
+	m.PutStr("inner.b", "v2")
+
+	got, err := AttributeToLabels("outer", v, "")
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(got))
+	assert.Equal(t, "v1", labelAdapterGet(got, "outer_inner_a"))
+	assert.Equal(t, "v2", labelAdapterGet(got, "outer_inner_b"))
+}
+
+func TestAttributeToLabels_NestedMap(t *testing.T) {
+	v := pcommon.NewValueMap()
+	inner := v.Map().PutEmptyMap("level1")
+	inner.PutStr("level2", "deep")
+
+	got, err := AttributeToLabels("root", v, "")
+	require.NoError(t, err)
+	assert.Equal(t, "deep", labelAdapterGet(got, "root_level1_level2"))
+}
+
+func TestAttributeToLabels_LeadingDigit(t *testing.T) {
+	v := pcommon.NewValueStr("val")
+	got, err := AttributeToLabels("123abc", v, "")
+	require.NoError(t, err)
+	assert.Equal(t, "val", labelAdapterGet(got, "key_123abc"))
+}
+
+func TestAttributeToLabels_DotsToUnderscores(t *testing.T) {
+	v := pcommon.NewValueStr("val")
+	got, err := AttributeToLabels("a.b.c", v, "")
+	require.NoError(t, err)
+	assert.Equal(t, "val", labelAdapterGet(got, "a_b_c"))
+}
+
+func TestAttributeToLabels_ReservedLabel(t *testing.T) {
+	v := pcommon.NewValueStr("val")
+	got, err := AttributeToLabels("__reserved__", v, "")
+	require.NoError(t, err)
+	assert.Equal(t, "val", labelAdapterGet(got, "__reserved__"))
+}
+
+func TestAttributeToLabels_IntValue(t *testing.T) {
+	v := pcommon.NewValueInt(42)
+	got, err := AttributeToLabels("count", v, "")
+	require.NoError(t, err)
+	assert.Equal(t, "42", labelAdapterGet(got, "count"))
+}
+
+func TestAttributeToLabels_BoolValue(t *testing.T) {
+	v := pcommon.NewValueBool(true)
+	got, err := AttributeToLabels("flag", v, "")
+	require.NoError(t, err)
+	assert.Equal(t, "true", labelAdapterGet(got, "flag"))
+}
+
+func TestAttributesToLabels(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		buildAttrs   func() pcommon.Map
+		expectedResp push.LabelsAdapter
+	}{
+		{
+			name: "no attributes",
+			buildAttrs: func() pcommon.Map {
+				return pcommon.NewMap()
+			},
+			expectedResp: push.LabelsAdapter{},
+		},
+		{
+			name: "with attributes",
+			buildAttrs: func() pcommon.Map {
+				attrs := pcommon.NewMap()
+				attrs.PutEmpty("empty")
+				attrs.PutStr("str", "val")
+				attrs.PutInt("int", 1)
+				attrs.PutDouble("double", 3.14)
+				attrs.PutBool("bool", true)
+				attrs.PutEmptyBytes("bytes").Append(1, 2, 3)
+
+				slice := attrs.PutEmptySlice("slice")
+				slice.AppendEmpty().SetInt(1)
+				slice.AppendEmpty().SetEmptySlice().AppendEmpty().SetStr("foo")
+				slice.AppendEmpty().SetEmptyMap().PutStr("fizz", "buzz")
+
+				m := attrs.PutEmptyMap("nested")
+				m.PutStr("foo", "bar")
+				m.PutEmptyMap("more").PutStr("key", "val")
+
+				return attrs
+			},
+			expectedResp: push.LabelsAdapter{
+				{Name: "empty"},
+				{Name: "str", Value: "val"},
+				{Name: "int", Value: "1"},
+				{Name: "double", Value: "3.14"},
+				{Name: "bool", Value: "true"},
+				{Name: "bytes", Value: base64.StdEncoding.EncodeToString([]byte{1, 2, 3})},
+				{Name: "slice", Value: `[1,["foo"],{"fizz":"buzz"}]`},
+				{Name: "nested_foo", Value: "bar"},
+				{Name: "nested_more_key", Value: "val"},
+			},
+		},
+		{
+			name: "attributes with special chars",
+			buildAttrs: func() pcommon.Map {
+				attrs := pcommon.NewMap()
+				attrs.PutStr("st.r", "val")
+
+				m := attrs.PutEmptyMap("nest*ed")
+				m.PutStr("fo@o", "bar")
+				m.PutEmptyMap("m$ore").PutStr("k_ey", "val")
+
+				return attrs
+			},
+			expectedResp: push.LabelsAdapter{
+				{Name: "st_r", Value: "val"},
+				{Name: "nest_ed_fo_o", Value: "bar"},
+				{Name: "nest_ed_m_ore_k_ey", Value: "val"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lbls, err := attributesToLabels(tc.buildAttrs(), "")
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedResp, lbls)
+		})
+	}
+}
+
+// ---------- ResourceAttrsToStreamLabels tests ----------
+
+func makeOTLPConfig(indexed []string) OTLPConfig {
+	return OTLPConfig{
+		ResourceAttributes: ResourceAttributesConfig{
+			AttributesConfig: []AttributesConfig{
+				{
+					Action:     IndexLabel,
+					Attributes: indexed,
+				},
+			},
+		},
+	}
+}
+
+func makeAttrs(kvs map[string]string) pcommon.Map {
+	m := pcommon.NewMap()
+	for k, v := range kvs {
+		m.PutStr(k, v)
+	}
+	return m
+}
+
+func TestResourceAttrsToStreamLabels_DefaultIndexed(t *testing.T) {
+	cfg := makeOTLPConfig([]string{"service.name", "deployment.environment"})
+	attrs := pcommon.NewMap()
+	attrs.PutStr("service.name", "my-service")
+	attrs.PutStr("deployment.environment", "production")
+	attrs.PutStr("host.name", "node-1")
+
+	got, err := ResourceAttrsToStreamLabels(attrs, cfg, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "production", labelSetGet(got.StreamLabels, "deployment_environment"))
+	assert.Equal(t, "my-service", labelSetGet(got.StreamLabels, "service_name"))
+	assert.Equal(t, "", labelSetGet(got.StreamLabels, "host_name"), "non-indexed attribute should be excluded from stream labels")
+	assert.Equal(t, "node-1", labelAdapterGet(got.StructuredMetadata, "host_name"), "non-indexed attribute should be structured metadata")
+}
+
+func TestResourceAttrsToStreamLabels_NonIndexedAsStructuredMetadata(t *testing.T) {
+	cfg := makeOTLPConfig([]string{"service.name"})
+	attrs := makeAttrs(map[string]string{
+		"service.name": "svc",
+		"host.name":    "node-1",
+		"host.arch":    "amd64",
+	})
+
+	got, err := ResourceAttrsToStreamLabels(attrs, cfg, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(got.StreamLabels))
+	assert.Equal(t, "svc", labelSetGet(got.StreamLabels, "service_name"))
+	assert.Equal(t, 2, len(got.StructuredMetadata))
+}
+
+func TestResourceAttrsToStreamLabels_DroppedExcluded(t *testing.T) {
+	cfg := OTLPConfig{
+		ResourceAttributes: ResourceAttributesConfig{
+			AttributesConfig: []AttributesConfig{
+				{Action: IndexLabel, Attributes: []string{"service.name"}},
+				{Action: Drop, Attributes: []string{"telemetry.sdk.name"}},
+			},
+		},
+	}
+	attrs := makeAttrs(map[string]string{
+		"service.name":       "svc",
+		"telemetry.sdk.name": "opentelemetry",
+	})
+
+	got, err := ResourceAttrsToStreamLabels(attrs, cfg, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(got.StreamLabels))
+	assert.Equal(t, "svc", labelSetGet(got.StreamLabels, "service_name"))
+	assert.Equal(t, 0, len(got.StructuredMetadata), "dropped attrs should not appear in structured metadata")
+}
+
+func TestResourceAttrsToStreamLabels_ServiceNameDiscovery(t *testing.T) {
+	cfg := makeOTLPConfig([]string{"k8s.namespace.name"})
+	attrs := makeAttrs(map[string]string{
+		"k8s.namespace.name": "my-namespace",
+	})
+
+	got, err := ResourceAttrsToStreamLabels(attrs, cfg, []string{"k8s_namespace_name"})
+	require.NoError(t, err)
+	assert.Equal(t, "my-namespace", labelSetGet(got.StreamLabels, LabelServiceName))
+	assert.Equal(t, "my-namespace", labelSetGet(got.StreamLabels, "k8s_namespace_name"))
+}
+
+func TestResourceAttrsToStreamLabels_ServiceNameDiscoverySkippedWhenPresent(t *testing.T) {
+	cfg := makeOTLPConfig([]string{"service.name", "k8s.namespace.name"})
+	attrs := pcommon.NewMap()
+	attrs.PutStr("service.name", "explicit-svc")
+	attrs.PutStr("k8s.namespace.name", "my-ns")
+
+	got, err := ResourceAttrsToStreamLabels(attrs, cfg, []string{"k8s_namespace_name"})
+	require.NoError(t, err)
+	assert.Equal(t, "explicit-svc", labelSetGet(got.StreamLabels, "service_name"),
+		"service_name should come from the explicit service.name attribute, not discovery")
+	assert.Equal(t, "my-ns", labelSetGet(got.StreamLabels, "k8s_namespace_name"))
+}
+
+func TestResourceAttrsToStreamLabels_ServiceNameDefaultsToUnknown(t *testing.T) {
+	cfg := makeOTLPConfig([]string{"host.name"})
+	attrs := makeAttrs(map[string]string{
+		"host.name": "node-1",
+	})
+
+	got, err := ResourceAttrsToStreamLabels(attrs, cfg, []string{"k8s_namespace_name"})
+	require.NoError(t, err)
+	assert.Equal(t, ServiceUnknown, labelSetGet(got.StreamLabels, LabelServiceName))
+}
+
+func TestResourceAttrsToStreamLabels_NoDiscoveryWhenListEmpty(t *testing.T) {
+	cfg := makeOTLPConfig([]string{"host.name"})
+	attrs := makeAttrs(map[string]string{
+		"host.name": "node-1",
+	})
+
+	got, err := ResourceAttrsToStreamLabels(attrs, cfg, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "", labelSetGet(got.StreamLabels, LabelServiceName), "no discovery when discoverServiceName is nil")
+}
+
+func TestResourceAttrsToStreamLabels_EmptyAttrs(t *testing.T) {
+	cfg := makeOTLPConfig([]string{"service.name"})
+	attrs := pcommon.NewMap()
+
+	got, err := ResourceAttrsToStreamLabels(attrs, cfg, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(got.StreamLabels))
+}
+
+// ---------- ScopeAttrsToStructuredMetadata tests ----------
+
+func TestScopeAttrsToStructuredMetadata(t *testing.T) {
+	t.Run("attributes and scope fields", func(t *testing.T) {
+		cfg := DefaultOTLPConfig(defaultGlobalOTLPConfig)
+		ld := plog.NewLogs()
+		rl := ld.ResourceLogs().AppendEmpty()
+		sl := rl.ScopeLogs().AppendEmpty()
+		scope := sl.Scope()
+		scope.SetName("my-scope")
+		scope.SetVersion("1.2.3")
+		scope.Attributes().PutStr("op", "buzz")
+		scope.SetDroppedAttributesCount(5)
+
+		got, err := ScopeAttrsToStructuredMetadata(rl.ScopeLogs(), 0, cfg)
+		require.NoError(t, err)
+
+		assert.Equal(t, "buzz", labelAdapterGet(got.StructuredMetadata, "op"))
+		assert.Equal(t, "my-scope", labelAdapterGet(got.StructuredMetadata, "scope_name"))
+		assert.Equal(t, "1.2.3", labelAdapterGet(got.StructuredMetadata, "scope_version"))
+		assert.Equal(t, "5", labelAdapterGet(got.StructuredMetadata, "scope_dropped_attributes_count"))
+	})
+
+	t.Run("dropped scope attributes excluded", func(t *testing.T) {
+		cfg := OTLPConfig{
+			ScopeAttributes: []AttributesConfig{
+				{Action: Drop, Attributes: []string{"drop.me"}},
+			},
+		}
+		ld := plog.NewLogs()
+		rl := ld.ResourceLogs().AppendEmpty()
+		sl := rl.ScopeLogs().AppendEmpty()
+		scope := sl.Scope()
+		scope.Attributes().PutStr("drop.me", "gone")
+		scope.Attributes().PutStr("keep.me", "here")
+
+		got, err := ScopeAttrsToStructuredMetadata(rl.ScopeLogs(), 0, cfg)
+		require.NoError(t, err)
+
+		assert.Equal(t, "", labelAdapterGet(got.StructuredMetadata, "drop_me"))
+		assert.Equal(t, "here", labelAdapterGet(got.StructuredMetadata, "keep_me"))
+	})
+
+	t.Run("empty scope fields omitted", func(t *testing.T) {
+		cfg := DefaultOTLPConfig(defaultGlobalOTLPConfig)
+		ld := plog.NewLogs()
+		rl := ld.ResourceLogs().AppendEmpty()
+		rl.ScopeLogs().AppendEmpty()
+
+		got, err := ScopeAttrsToStructuredMetadata(rl.ScopeLogs(), 0, cfg)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(got.StructuredMetadata))
+	})
+}
+
+// ---------- LogAttrsToLabels tests ----------
+
+func TestLogAttrsToLabels_OnlyBody(t *testing.T) {
+	log := plog.NewLogRecord()
+	log.Body().SetStr("log body")
+	log.SetTimestamp(pcommon.Timestamp(1000000000))
+
+	got, err := LogAttrsToLabels(log, DefaultOTLPConfig(defaultGlobalOTLPConfig))
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(got.IndexLabels))
+	assert.Equal(t, 0, len(got.StructuredMetadata))
+}
+
+func TestLogAttrsToLabels_AllFields(t *testing.T) {
+	log := plog.NewLogRecord()
+	log.Body().SetStr("log body")
+	log.SetTimestamp(pcommon.Timestamp(1000000000))
+	log.SetObservedTimestamp(pcommon.Timestamp(1000000001))
+	log.SetSeverityNumber(plog.SeverityNumberDebug)
+	log.SetSeverityText("debug")
+	log.SetDroppedAttributesCount(1)
+	log.SetFlags(plog.DefaultLogRecordFlags.WithIsSampled(true))
+	log.SetTraceID([16]byte{0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78})
+	log.SetSpanID([8]byte{0x12, 0x23, 0xAD, 0x12, 0x23, 0xAD, 0x12, 0x23})
+	log.SetEventName("my.event")
+	log.Attributes().PutStr("foo", "bar")
+
+	got, err := LogAttrsToLabels(log, DefaultOTLPConfig(defaultGlobalOTLPConfig))
+	require.NoError(t, err)
+
+	assert.Equal(t, "bar", labelAdapterGet(got.StructuredMetadata, "foo"))
+	assert.NotEmpty(t, labelAdapterGet(got.StructuredMetadata, "observed_timestamp"))
+	assert.Equal(t, "5", labelAdapterGet(got.StructuredMetadata, OTLPSeverityNumber))
+	assert.Equal(t, "debug", labelAdapterGet(got.StructuredMetadata, OTLPSeverityText))
+	assert.Equal(t, "1", labelAdapterGet(got.StructuredMetadata, "dropped_attributes_count"))
+	assert.Equal(t, fmt.Sprintf("%d", plog.DefaultLogRecordFlags.WithIsSampled(true)), labelAdapterGet(got.StructuredMetadata, "flags"))
+	assert.Equal(t, "12345678123456781234567812345678", labelAdapterGet(got.StructuredMetadata, "trace_id"))
+	assert.Equal(t, "1223ad1223ad1223", labelAdapterGet(got.StructuredMetadata, "span_id"))
+	assert.Equal(t, "my.event", labelAdapterGet(got.StructuredMetadata, OTLPEventName))
+}
+
+func TestLogAttrsToLabels_EventNameFieldWins(t *testing.T) {
+	log := plog.NewLogRecord()
+	log.Body().SetStr("log body")
+	log.SetTimestamp(pcommon.Timestamp(1000000000))
+	log.SetEventName("otlp.field")
+	log.Attributes().PutStr(OTLPEventName, "attribute.value")
+
+	got, err := LogAttrsToLabels(log, DefaultOTLPConfig(defaultGlobalOTLPConfig))
+	require.NoError(t, err)
+	assert.Equal(t, "otlp.field", labelAdapterGet(got.StructuredMetadata, OTLPEventName))
+}
+
+func TestLogAttrsToLabels_EventNameOnly(t *testing.T) {
+	log := plog.NewLogRecord()
+	log.Body().SetStr("log body")
+	log.SetTimestamp(pcommon.Timestamp(1000000000))
+	log.SetEventName("session.start")
+
+	got, err := LogAttrsToLabels(log, DefaultOTLPConfig(defaultGlobalOTLPConfig))
+	require.NoError(t, err)
+	assert.Equal(t, "session.start", labelAdapterGet(got.StructuredMetadata, OTLPEventName))
+}
+
+func TestLogAttrsToLabels_SeverityTextAsIndexLabel(t *testing.T) {
+	cfg := DefaultOTLPConfig(defaultGlobalOTLPConfig)
+	cfg.SeverityTextAsLabel = true
+
+	log := plog.NewLogRecord()
+	log.Body().SetStr("log body")
+	log.SetTimestamp(pcommon.Timestamp(1000000000))
+	log.SetSeverityText("ERROR")
+
+	got, err := LogAttrsToLabels(log, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "ERROR", labelSetGet(got.IndexLabels, OTLPSeverityText))
+	assert.Equal(t, "ERROR", labelAdapterGet(got.StructuredMetadata, OTLPSeverityText))
+}
+
+func TestLogAttrsToLabels_IndexedLogAttributes(t *testing.T) {
+	cfg := OTLPConfig{
+		LogAttributes: []AttributesConfig{
+			{Action: IndexLabel, Attributes: []string{"detected_level"}},
+			{Action: StructuredMetadata, Attributes: []string{"trace_id"}},
+			{Action: Drop, Regex: relabel.MustNewRegexp(".*")},
+		},
+	}
+
+	log := plog.NewLogRecord()
+	log.Body().SetStr("test")
+	log.SetTimestamp(pcommon.Timestamp(1000000000))
+	log.Attributes().PutStr("detected_level", "info")
+	log.Attributes().PutStr("trace_id", "abc123")
+	log.Attributes().PutStr("dropped", "gone")
+
+	got, err := LogAttrsToLabels(log, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "info", labelSetGet(got.IndexLabels, "detected_level"))
+	assert.Equal(t, "abc123", labelAdapterGet(got.StructuredMetadata, "trace_id"))
+	assert.Equal(t, "", labelAdapterGet(got.StructuredMetadata, "dropped"))
+	assert.Equal(t, "", labelSetGet(got.IndexLabels, "dropped"))
+}
+
+func TestLogAttrsToLabels_DroppedAttrsExcluded(t *testing.T) {
+	cfg := OTLPConfig{
+		LogAttributes: []AttributesConfig{
+			{Action: Drop, Attributes: []string{"secret"}},
+		},
+	}
+
+	log := plog.NewLogRecord()
+	log.Body().SetStr("test")
+	log.SetTimestamp(pcommon.Timestamp(1000000000))
+	log.Attributes().PutStr("secret", "hidden")
+	log.Attributes().PutStr("visible", "here")
+
+	got, err := LogAttrsToLabels(log, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "", labelAdapterGet(got.StructuredMetadata, "secret"))
+	assert.Equal(t, "here", labelAdapterGet(got.StructuredMetadata, "visible"))
+}
+
+func TestLogAttrsToLabels_ObservedTimestampOmittedWhenZero(t *testing.T) {
+	log := plog.NewLogRecord()
+	log.Body().SetStr("test")
+	log.SetTimestamp(pcommon.Timestamp(1000000000))
+
+	got, err := LogAttrsToLabels(log, DefaultOTLPConfig(defaultGlobalOTLPConfig))
+	require.NoError(t, err)
+	assert.Equal(t, "", labelAdapterGet(got.StructuredMetadata, "observed_timestamp"))
+}

--- a/pkg/loghttp/push/otlplabels/labels_test.go
+++ b/pkg/loghttp/push/otlplabels/labels_test.go
@@ -2,107 +2,13 @@ package otlplabels
 
 import (
 	"encoding/base64"
-	"fmt"
 	"testing"
 
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/relabel"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/grafana/loki/pkg/push"
 )
-
-func labelAdapterGet(ls push.LabelsAdapter, name string) string {
-	for _, l := range ls {
-		if l.Name == name {
-			return l.Value
-		}
-	}
-	return ""
-}
-
-func labelSetGet(ls model.LabelSet, name string) string {
-	return string(ls[model.LabelName(name)])
-}
-
-// ---------- AttributeToLabels tests ----------
-
-func TestAttributeToLabels_Simple(t *testing.T) {
-	v := pcommon.NewValueStr("hello")
-	got, err := AttributeToLabels("my.key", v, "")
-	require.NoError(t, err)
-	require.Equal(t, 1, len(got))
-	assert.Equal(t, "hello", labelAdapterGet(got, "my_key"))
-}
-
-func TestAttributeToLabels_WithPrefix(t *testing.T) {
-	v := pcommon.NewValueStr("val")
-	got, err := AttributeToLabels("child", v, "parent")
-	require.NoError(t, err)
-	require.Equal(t, 1, len(got))
-	assert.Equal(t, "val", labelAdapterGet(got, "parent_child"))
-}
-
-func TestAttributeToLabels_MapValue(t *testing.T) {
-	v := pcommon.NewValueMap()
-	m := v.Map()
-	m.PutStr("inner.a", "v1")
-	m.PutStr("inner.b", "v2")
-
-	got, err := AttributeToLabels("outer", v, "")
-	require.NoError(t, err)
-	assert.Equal(t, 2, len(got))
-	assert.Equal(t, "v1", labelAdapterGet(got, "outer_inner_a"))
-	assert.Equal(t, "v2", labelAdapterGet(got, "outer_inner_b"))
-}
-
-func TestAttributeToLabels_NestedMap(t *testing.T) {
-	v := pcommon.NewValueMap()
-	inner := v.Map().PutEmptyMap("level1")
-	inner.PutStr("level2", "deep")
-
-	got, err := AttributeToLabels("root", v, "")
-	require.NoError(t, err)
-	assert.Equal(t, "deep", labelAdapterGet(got, "root_level1_level2"))
-}
-
-func TestAttributeToLabels_LeadingDigit(t *testing.T) {
-	v := pcommon.NewValueStr("val")
-	got, err := AttributeToLabels("123abc", v, "")
-	require.NoError(t, err)
-	assert.Equal(t, "val", labelAdapterGet(got, "key_123abc"))
-}
-
-func TestAttributeToLabels_DotsToUnderscores(t *testing.T) {
-	v := pcommon.NewValueStr("val")
-	got, err := AttributeToLabels("a.b.c", v, "")
-	require.NoError(t, err)
-	assert.Equal(t, "val", labelAdapterGet(got, "a_b_c"))
-}
-
-func TestAttributeToLabels_ReservedLabel(t *testing.T) {
-	v := pcommon.NewValueStr("val")
-	got, err := AttributeToLabels("__reserved__", v, "")
-	require.NoError(t, err)
-	assert.Equal(t, "val", labelAdapterGet(got, "__reserved__"))
-}
-
-func TestAttributeToLabels_IntValue(t *testing.T) {
-	v := pcommon.NewValueInt(42)
-	got, err := AttributeToLabels("count", v, "")
-	require.NoError(t, err)
-	assert.Equal(t, "42", labelAdapterGet(got, "count"))
-}
-
-func TestAttributeToLabels_BoolValue(t *testing.T) {
-	v := pcommon.NewValueBool(true)
-	got, err := AttributeToLabels("flag", v, "")
-	require.NoError(t, err)
-	assert.Equal(t, "true", labelAdapterGet(got, "flag"))
-}
 
 func TestAttributesToLabels(t *testing.T) {
 	for _, tc := range []struct {
@@ -140,15 +46,41 @@ func TestAttributesToLabels(t *testing.T) {
 				return attrs
 			},
 			expectedResp: push.LabelsAdapter{
-				{Name: "empty"},
-				{Name: "str", Value: "val"},
-				{Name: "int", Value: "1"},
-				{Name: "double", Value: "3.14"},
-				{Name: "bool", Value: "true"},
-				{Name: "bytes", Value: base64.StdEncoding.EncodeToString([]byte{1, 2, 3})},
-				{Name: "slice", Value: `[1,["foo"],{"fizz":"buzz"}]`},
-				{Name: "nested_foo", Value: "bar"},
-				{Name: "nested_more_key", Value: "val"},
+				{
+					Name: "empty",
+				},
+				{
+					Name:  "str",
+					Value: "val",
+				},
+				{
+					Name:  "int",
+					Value: "1",
+				},
+				{
+					Name:  "double",
+					Value: "3.14",
+				},
+				{
+					Name:  "bool",
+					Value: "true",
+				},
+				{
+					Name:  "bytes",
+					Value: base64.StdEncoding.EncodeToString([]byte{1, 2, 3}),
+				},
+				{
+					Name:  "slice",
+					Value: `[1,["foo"],{"fizz":"buzz"}]`,
+				},
+				{
+					Name:  "nested_foo",
+					Value: "bar",
+				},
+				{
+					Name:  "nested_more_key",
+					Value: "val",
+				},
 			},
 		},
 		{
@@ -164,9 +96,18 @@ func TestAttributesToLabels(t *testing.T) {
 				return attrs
 			},
 			expectedResp: push.LabelsAdapter{
-				{Name: "st_r", Value: "val"},
-				{Name: "nest_ed_fo_o", Value: "bar"},
-				{Name: "nest_ed_m_ore_k_ey", Value: "val"},
+				{
+					Name:  "st_r",
+					Value: "val",
+				},
+				{
+					Name:  "nest_ed_fo_o",
+					Value: "bar",
+				},
+				{
+					Name:  "nest_ed_m_ore_k_ey",
+					Value: "val",
+				},
 			},
 		},
 	} {
@@ -176,322 +117,4 @@ func TestAttributesToLabels(t *testing.T) {
 			require.Equal(t, tc.expectedResp, lbls)
 		})
 	}
-}
-
-// ---------- ResourceAttrsToStreamLabels tests ----------
-
-func makeOTLPConfig(indexed []string) OTLPConfig {
-	return OTLPConfig{
-		ResourceAttributes: ResourceAttributesConfig{
-			AttributesConfig: []AttributesConfig{
-				{
-					Action:     IndexLabel,
-					Attributes: indexed,
-				},
-			},
-		},
-	}
-}
-
-func makeAttrs(kvs map[string]string) pcommon.Map {
-	m := pcommon.NewMap()
-	for k, v := range kvs {
-		m.PutStr(k, v)
-	}
-	return m
-}
-
-func TestResourceAttrsToStreamLabels_DefaultIndexed(t *testing.T) {
-	cfg := makeOTLPConfig([]string{"service.name", "deployment.environment"})
-	attrs := pcommon.NewMap()
-	attrs.PutStr("service.name", "my-service")
-	attrs.PutStr("deployment.environment", "production")
-	attrs.PutStr("host.name", "node-1")
-
-	got, err := ResourceAttrsToStreamLabels(attrs, cfg, nil)
-	require.NoError(t, err)
-
-	assert.Equal(t, "production", labelSetGet(got.StreamLabels, "deployment_environment"))
-	assert.Equal(t, "my-service", labelSetGet(got.StreamLabels, "service_name"))
-	assert.Equal(t, "", labelSetGet(got.StreamLabels, "host_name"), "non-indexed attribute should be excluded from stream labels")
-	assert.Equal(t, "node-1", labelAdapterGet(got.StructuredMetadata, "host_name"), "non-indexed attribute should be structured metadata")
-}
-
-func TestResourceAttrsToStreamLabels_NonIndexedAsStructuredMetadata(t *testing.T) {
-	cfg := makeOTLPConfig([]string{"service.name"})
-	attrs := makeAttrs(map[string]string{
-		"service.name": "svc",
-		"host.name":    "node-1",
-		"host.arch":    "amd64",
-	})
-
-	got, err := ResourceAttrsToStreamLabels(attrs, cfg, nil)
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(got.StreamLabels))
-	assert.Equal(t, "svc", labelSetGet(got.StreamLabels, "service_name"))
-	assert.Equal(t, 2, len(got.StructuredMetadata))
-}
-
-func TestResourceAttrsToStreamLabels_DroppedExcluded(t *testing.T) {
-	cfg := OTLPConfig{
-		ResourceAttributes: ResourceAttributesConfig{
-			AttributesConfig: []AttributesConfig{
-				{Action: IndexLabel, Attributes: []string{"service.name"}},
-				{Action: Drop, Attributes: []string{"telemetry.sdk.name"}},
-			},
-		},
-	}
-	attrs := makeAttrs(map[string]string{
-		"service.name":       "svc",
-		"telemetry.sdk.name": "opentelemetry",
-	})
-
-	got, err := ResourceAttrsToStreamLabels(attrs, cfg, nil)
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(got.StreamLabels))
-	assert.Equal(t, "svc", labelSetGet(got.StreamLabels, "service_name"))
-	assert.Equal(t, 0, len(got.StructuredMetadata), "dropped attrs should not appear in structured metadata")
-}
-
-func TestResourceAttrsToStreamLabels_ServiceNameDiscovery(t *testing.T) {
-	cfg := makeOTLPConfig([]string{"k8s.namespace.name"})
-	attrs := makeAttrs(map[string]string{
-		"k8s.namespace.name": "my-namespace",
-	})
-
-	got, err := ResourceAttrsToStreamLabels(attrs, cfg, []string{"k8s_namespace_name"})
-	require.NoError(t, err)
-	assert.Equal(t, "my-namespace", labelSetGet(got.StreamLabels, LabelServiceName))
-	assert.Equal(t, "my-namespace", labelSetGet(got.StreamLabels, "k8s_namespace_name"))
-}
-
-func TestResourceAttrsToStreamLabels_ServiceNameDiscoverySkippedWhenPresent(t *testing.T) {
-	cfg := makeOTLPConfig([]string{"service.name", "k8s.namespace.name"})
-	attrs := pcommon.NewMap()
-	attrs.PutStr("service.name", "explicit-svc")
-	attrs.PutStr("k8s.namespace.name", "my-ns")
-
-	got, err := ResourceAttrsToStreamLabels(attrs, cfg, []string{"k8s_namespace_name"})
-	require.NoError(t, err)
-	assert.Equal(t, "explicit-svc", labelSetGet(got.StreamLabels, "service_name"),
-		"service_name should come from the explicit service.name attribute, not discovery")
-	assert.Equal(t, "my-ns", labelSetGet(got.StreamLabels, "k8s_namespace_name"))
-}
-
-func TestResourceAttrsToStreamLabels_ServiceNameDefaultsToUnknown(t *testing.T) {
-	cfg := makeOTLPConfig([]string{"host.name"})
-	attrs := makeAttrs(map[string]string{
-		"host.name": "node-1",
-	})
-
-	got, err := ResourceAttrsToStreamLabels(attrs, cfg, []string{"k8s_namespace_name"})
-	require.NoError(t, err)
-	assert.Equal(t, ServiceUnknown, labelSetGet(got.StreamLabels, LabelServiceName))
-}
-
-func TestResourceAttrsToStreamLabels_NoDiscoveryWhenListEmpty(t *testing.T) {
-	cfg := makeOTLPConfig([]string{"host.name"})
-	attrs := makeAttrs(map[string]string{
-		"host.name": "node-1",
-	})
-
-	got, err := ResourceAttrsToStreamLabels(attrs, cfg, nil)
-	require.NoError(t, err)
-	assert.Equal(t, "", labelSetGet(got.StreamLabels, LabelServiceName), "no discovery when discoverServiceName is nil")
-}
-
-func TestResourceAttrsToStreamLabels_EmptyAttrs(t *testing.T) {
-	cfg := makeOTLPConfig([]string{"service.name"})
-	attrs := pcommon.NewMap()
-
-	got, err := ResourceAttrsToStreamLabels(attrs, cfg, nil)
-	require.NoError(t, err)
-	assert.Equal(t, 0, len(got.StreamLabels))
-}
-
-// ---------- ScopeAttrsToStructuredMetadata tests ----------
-
-func TestScopeAttrsToStructuredMetadata(t *testing.T) {
-	t.Run("attributes and scope fields", func(t *testing.T) {
-		cfg := DefaultOTLPConfig(defaultGlobalOTLPConfig)
-		ld := plog.NewLogs()
-		rl := ld.ResourceLogs().AppendEmpty()
-		sl := rl.ScopeLogs().AppendEmpty()
-		scope := sl.Scope()
-		scope.SetName("my-scope")
-		scope.SetVersion("1.2.3")
-		scope.Attributes().PutStr("op", "buzz")
-		scope.SetDroppedAttributesCount(5)
-
-		got, err := ScopeAttrsToStructuredMetadata(rl.ScopeLogs(), 0, cfg)
-		require.NoError(t, err)
-
-		assert.Equal(t, "buzz", labelAdapterGet(got.StructuredMetadata, "op"))
-		assert.Equal(t, "my-scope", labelAdapterGet(got.StructuredMetadata, "scope_name"))
-		assert.Equal(t, "1.2.3", labelAdapterGet(got.StructuredMetadata, "scope_version"))
-		assert.Equal(t, "5", labelAdapterGet(got.StructuredMetadata, "scope_dropped_attributes_count"))
-	})
-
-	t.Run("dropped scope attributes excluded", func(t *testing.T) {
-		cfg := OTLPConfig{
-			ScopeAttributes: []AttributesConfig{
-				{Action: Drop, Attributes: []string{"drop.me"}},
-			},
-		}
-		ld := plog.NewLogs()
-		rl := ld.ResourceLogs().AppendEmpty()
-		sl := rl.ScopeLogs().AppendEmpty()
-		scope := sl.Scope()
-		scope.Attributes().PutStr("drop.me", "gone")
-		scope.Attributes().PutStr("keep.me", "here")
-
-		got, err := ScopeAttrsToStructuredMetadata(rl.ScopeLogs(), 0, cfg)
-		require.NoError(t, err)
-
-		assert.Equal(t, "", labelAdapterGet(got.StructuredMetadata, "drop_me"))
-		assert.Equal(t, "here", labelAdapterGet(got.StructuredMetadata, "keep_me"))
-	})
-
-	t.Run("empty scope fields omitted", func(t *testing.T) {
-		cfg := DefaultOTLPConfig(defaultGlobalOTLPConfig)
-		ld := plog.NewLogs()
-		rl := ld.ResourceLogs().AppendEmpty()
-		rl.ScopeLogs().AppendEmpty()
-
-		got, err := ScopeAttrsToStructuredMetadata(rl.ScopeLogs(), 0, cfg)
-		require.NoError(t, err)
-		assert.Equal(t, 0, len(got.StructuredMetadata))
-	})
-}
-
-// ---------- LogAttrsToLabels tests ----------
-
-func TestLogAttrsToLabels_OnlyBody(t *testing.T) {
-	log := plog.NewLogRecord()
-	log.Body().SetStr("log body")
-	log.SetTimestamp(pcommon.Timestamp(1000000000))
-
-	got, err := LogAttrsToLabels(log, DefaultOTLPConfig(defaultGlobalOTLPConfig))
-	require.NoError(t, err)
-	assert.Equal(t, 0, len(got.IndexLabels))
-	assert.Equal(t, 0, len(got.StructuredMetadata))
-}
-
-func TestLogAttrsToLabels_AllFields(t *testing.T) {
-	log := plog.NewLogRecord()
-	log.Body().SetStr("log body")
-	log.SetTimestamp(pcommon.Timestamp(1000000000))
-	log.SetObservedTimestamp(pcommon.Timestamp(1000000001))
-	log.SetSeverityNumber(plog.SeverityNumberDebug)
-	log.SetSeverityText("debug")
-	log.SetDroppedAttributesCount(1)
-	log.SetFlags(plog.DefaultLogRecordFlags.WithIsSampled(true))
-	log.SetTraceID([16]byte{0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78})
-	log.SetSpanID([8]byte{0x12, 0x23, 0xAD, 0x12, 0x23, 0xAD, 0x12, 0x23})
-	log.SetEventName("my.event")
-	log.Attributes().PutStr("foo", "bar")
-
-	got, err := LogAttrsToLabels(log, DefaultOTLPConfig(defaultGlobalOTLPConfig))
-	require.NoError(t, err)
-
-	assert.Equal(t, "bar", labelAdapterGet(got.StructuredMetadata, "foo"))
-	assert.NotEmpty(t, labelAdapterGet(got.StructuredMetadata, "observed_timestamp"))
-	assert.Equal(t, "5", labelAdapterGet(got.StructuredMetadata, OTLPSeverityNumber))
-	assert.Equal(t, "debug", labelAdapterGet(got.StructuredMetadata, OTLPSeverityText))
-	assert.Equal(t, "1", labelAdapterGet(got.StructuredMetadata, "dropped_attributes_count"))
-	assert.Equal(t, fmt.Sprintf("%d", plog.DefaultLogRecordFlags.WithIsSampled(true)), labelAdapterGet(got.StructuredMetadata, "flags"))
-	assert.Equal(t, "12345678123456781234567812345678", labelAdapterGet(got.StructuredMetadata, "trace_id"))
-	assert.Equal(t, "1223ad1223ad1223", labelAdapterGet(got.StructuredMetadata, "span_id"))
-	assert.Equal(t, "my.event", labelAdapterGet(got.StructuredMetadata, OTLPEventName))
-}
-
-func TestLogAttrsToLabels_EventNameFieldWins(t *testing.T) {
-	log := plog.NewLogRecord()
-	log.Body().SetStr("log body")
-	log.SetTimestamp(pcommon.Timestamp(1000000000))
-	log.SetEventName("otlp.field")
-	log.Attributes().PutStr(OTLPEventName, "attribute.value")
-
-	got, err := LogAttrsToLabels(log, DefaultOTLPConfig(defaultGlobalOTLPConfig))
-	require.NoError(t, err)
-	assert.Equal(t, "otlp.field", labelAdapterGet(got.StructuredMetadata, OTLPEventName))
-}
-
-func TestLogAttrsToLabels_EventNameOnly(t *testing.T) {
-	log := plog.NewLogRecord()
-	log.Body().SetStr("log body")
-	log.SetTimestamp(pcommon.Timestamp(1000000000))
-	log.SetEventName("session.start")
-
-	got, err := LogAttrsToLabels(log, DefaultOTLPConfig(defaultGlobalOTLPConfig))
-	require.NoError(t, err)
-	assert.Equal(t, "session.start", labelAdapterGet(got.StructuredMetadata, OTLPEventName))
-}
-
-func TestLogAttrsToLabels_SeverityTextAsIndexLabel(t *testing.T) {
-	cfg := DefaultOTLPConfig(defaultGlobalOTLPConfig)
-	cfg.SeverityTextAsLabel = true
-
-	log := plog.NewLogRecord()
-	log.Body().SetStr("log body")
-	log.SetTimestamp(pcommon.Timestamp(1000000000))
-	log.SetSeverityText("ERROR")
-
-	got, err := LogAttrsToLabels(log, cfg)
-	require.NoError(t, err)
-	assert.Equal(t, "ERROR", labelSetGet(got.IndexLabels, OTLPSeverityText))
-	assert.Equal(t, "ERROR", labelAdapterGet(got.StructuredMetadata, OTLPSeverityText))
-}
-
-func TestLogAttrsToLabels_IndexedLogAttributes(t *testing.T) {
-	cfg := OTLPConfig{
-		LogAttributes: []AttributesConfig{
-			{Action: IndexLabel, Attributes: []string{"detected_level"}},
-			{Action: StructuredMetadata, Attributes: []string{"trace_id"}},
-			{Action: Drop, Regex: relabel.MustNewRegexp(".*")},
-		},
-	}
-
-	log := plog.NewLogRecord()
-	log.Body().SetStr("test")
-	log.SetTimestamp(pcommon.Timestamp(1000000000))
-	log.Attributes().PutStr("detected_level", "info")
-	log.Attributes().PutStr("trace_id", "abc123")
-	log.Attributes().PutStr("dropped", "gone")
-
-	got, err := LogAttrsToLabels(log, cfg)
-	require.NoError(t, err)
-	assert.Equal(t, "info", labelSetGet(got.IndexLabels, "detected_level"))
-	assert.Equal(t, "abc123", labelAdapterGet(got.StructuredMetadata, "trace_id"))
-	assert.Equal(t, "", labelAdapterGet(got.StructuredMetadata, "dropped"))
-	assert.Equal(t, "", labelSetGet(got.IndexLabels, "dropped"))
-}
-
-func TestLogAttrsToLabels_DroppedAttrsExcluded(t *testing.T) {
-	cfg := OTLPConfig{
-		LogAttributes: []AttributesConfig{
-			{Action: Drop, Attributes: []string{"secret"}},
-		},
-	}
-
-	log := plog.NewLogRecord()
-	log.Body().SetStr("test")
-	log.SetTimestamp(pcommon.Timestamp(1000000000))
-	log.Attributes().PutStr("secret", "hidden")
-	log.Attributes().PutStr("visible", "here")
-
-	got, err := LogAttrsToLabels(log, cfg)
-	require.NoError(t, err)
-	assert.Equal(t, "", labelAdapterGet(got.StructuredMetadata, "secret"))
-	assert.Equal(t, "here", labelAdapterGet(got.StructuredMetadata, "visible"))
-}
-
-func TestLogAttrsToLabels_ObservedTimestampOmittedWhenZero(t *testing.T) {
-	log := plog.NewLogRecord()
-	log.Body().SetStr("test")
-	log.SetTimestamp(pcommon.Timestamp(1000000000))
-
-	got, err := LogAttrsToLabels(log, DefaultOTLPConfig(defaultGlobalOTLPConfig))
-	require.NoError(t, err)
-	assert.Equal(t, "", labelAdapterGet(got.StructuredMetadata, "observed_timestamp"))
 }


### PR DESCRIPTION
## Summary

- Introduces a new `pkg/loghttp/push/otlplabels` package that contains all OTLP attribute-to-label conversion logic: config types (`OTLPConfig`, `GlobalOTLPConfig`, `AttributesConfig`, etc.), attribute mapping (`AttributeToLabels`), and higher-level converters (`ResourceAttrsToStreamLabels`, `ScopeAttrsToStructuredMetadata`, `LogAttrsToLabels`).
- Refactors `pkg/loghttp/push/otlp.go` and `otlp_config.go` to delegate to the new package, keeping type aliases and re-exports in place for full backward compatibility.
- Moves and expands unit tests into `otlplabels/` to cover the extracted functions directly.

## Motivation

External projects that need to convert OTLP attributes to Loki-style labels and structured metadata currently have to depend on the entire `push` package, which brings in HTTP handler code, compression utilities, and other unrelated concerns. Extracting the label-conversion logic into its own focused package (`otlplabels`) makes it safe and lightweight to import from outside the Loki codebase.

## Test plan

- [x] Existing `otlp_test.go` tests continue to pass (they exercise the unchanged public interface in `push`).
- [x] New `otlplabels/config_test.go` and `otlplabels/labels_test.go` directly cover the extracted types and functions.
- [x] `go build ./...` confirms no import cycles or compilation errors.