### PR TITLE
feat(dataobj-consumer): Toc aligned data objects

### DIFF
--- a/pkg/dataobj/consumer/AGENTS.md
+++ b/pkg/dataobj/consumer/AGENTS.md
@@ -1,0 +1,70 @@
+# dataobj/consumer
+
+## Flush pipeline: `processor` ↔ `flushCommitter` ↔ `flusher`
+
+The consumer pipeline turns Kafka records into data objects, emits metastore
+events for them, and commits Kafka offsets. Three layers cooperate:
+
+1. **`processor`** (`processor.go`) — owns the per-partition lifecycle. Reads
+   records from Kafka, appends them to a `builderGroup` (one `logsobj.Builder`
+   per 12h TOC window), and decides when to flush (max-age, size, idle,
+   shutdown).
+2. **`flushCommitterImpl`** (`flush_committer.go`) — given a slice of builders
+   and an offset, flushes each builder via the `flusher`, emits a metastore
+   event per produced object, and finally commits the Kafka offset.
+3. **`flusherImpl`** (`flush.go`) — turns a single `logsobj.Builder` into an
+   uploaded object: calls `builder.Flush()`, sorts, uploads to object storage,
+   returns the object path.
+
+## Failure model: crash-and-replay, not in-process retry
+
+`logsobj.Builder.Flush` is **not re-entrant**. On a successful internal flush
+it calls `b.Reset()` before returning, so the buffered records are consumed
+regardless of what the caller does with the produced object. If anything
+after `builder.Flush()` (upload, sort, event emit, commit) fails, the data
+cannot be reconstructed in-process.
+
+The pipeline therefore uses an at-least-once model backed by Kafka replay:
+
+- `flushCommitterImpl.Flush` is a plain "do the work, return wrapped errors"
+  function. It does **not** decide how to react to failures.
+- `emitEvent` and `commit` retry indefinitely with exponential backoff
+  (`MaxRetries: 0`). The only way they return an error is when `ctx` is
+  canceled, i.e. the app is shutting down. `flusher.Flush` can surface other
+  errors too (upload/sort/object-storage problems).
+- `processor.flush` is where the reaction lives:
+  - `err == nil` → reset state, return nil, continue consuming.
+  - `errors.Is(err, context.Canceled)` → return the error so the caller exits
+    cleanly. The offset is **not** committed, so Kafka will replay on next
+    startup.
+  - Anything else → **panic**. The process exits, Kafka replays from the last
+    committed offset, and the data is rebuilt from scratch. This is the only
+    safe option given the non-re-entrant builder: an orphan object may be
+    left in storage, but no committed-but-missing state is ever visible to
+    queries.
+
+## Processor state reset
+
+`processor.flush` uses a `defer` to reset `firstAppend`, `lastAppend`, the
+builder group, and the size estimate. The reset runs on every outcome:
+
+- **Success** — obvious; prepare for the next object.
+- **`context.Canceled`** — we're shutting down, the state is no longer used.
+- **Panic** — the process is about to crash, so the reset is a no-op in
+  practice; it just runs during panic unwinding.
+
+There is intentionally no "retry with preserved state" path.
+
+## Caveats
+
+- **Metastore event idempotency.** On a crash-replay, a given batch of
+  records may produce a fresh object *and* a duplicate metastore event
+  pointing at the newly-uploaded path. Downstream readers must tolerate (or
+  dedupe) multiple TOC entries for the same logical data. The previous
+  attempt's object, if it uploaded, is orphaned in storage.
+- **`flushCommitterImpl.Flush` partial progress.** Within a single call the
+  loop runs `flusher.Flush` + `emitEvent` for each window builder in order;
+  if it fails mid-loop the already-flushed builders have already been
+  uploaded and had events emitted. Because we panic on non-cancel errors,
+  the replay re-produces them as duplicates rather than skipping them — that
+  is the intended trade-off.

--- a/pkg/dataobj/consumer/builder_group.go
+++ b/pkg/dataobj/consumer/builder_group.go
@@ -1,0 +1,127 @@
+package consumer
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+type builderFactory interface {
+	NewBuilder() (*logsobj.Builder, error)
+}
+
+// TOCAlignedBuilderGroup manages a set of [logsobj.Builder] instances, one per
+// 12-hour UTC window (see [metastore.TOCWindowSize]). Each builder in the
+// group only contains entries whose timestamps fall into that window, which
+// keeps per-object time ranges aligned with the metastore TOC and bounds the
+// number of windows a single object can cover.
+//
+// The group's [IsFull] signal is driven by the *sum* of estimated sizes across
+// all window-specific builders, so the group preserves the "a partition will
+// not buffer more than TargetObjectSize" invariant that existed before the
+// per-window split.
+type TOCAlignedBuilderGroup struct {
+	builders         map[time.Time]builder
+	builderFactory   builderFactory
+	targetObjectSize int
+}
+
+// NewTOCAlignedBuilderGroup creates a new TOC aligned builder group.
+// targetObjectSize is the combined upper bound across all window builders; it
+// should match the TargetObjectSize used by the builder factory.
+func NewTOCAlignedBuilderGroup(builderFactory builderFactory, targetObjectSize int) *TOCAlignedBuilderGroup {
+	return &TOCAlignedBuilderGroup{
+		builders:         make(map[time.Time]builder),
+		builderFactory:   builderFactory,
+		targetObjectSize: targetObjectSize,
+	}
+}
+
+var _ builderGroup = (*TOCAlignedBuilderGroup)(nil)
+
+func (g *TOCAlignedBuilderGroup) Append(tenant string, stream logproto.Stream, recTime time.Time) error {
+	// [stream] might contain entries for multiple time windows => we need to split them to multiple streams, where
+	// each one only contains the entries for a single time window
+	streamsByTimeWindows := make(map[time.Time]logproto.Stream, 1)
+	for _, e := range stream.Entries {
+		w := e.Timestamp.UTC().Truncate(metastore.TOCWindowSize)
+		if _, ok := streamsByTimeWindows[w]; !ok {
+			streamsByTimeWindows[w] = logproto.Stream{
+				Labels: stream.Labels,
+			}
+		}
+		windowedStream := streamsByTimeWindows[w]
+		windowedStream.Entries = append(windowedStream.Entries, e)
+		streamsByTimeWindows[w] = windowedStream
+	}
+
+	for w, stream := range streamsByTimeWindows {
+		b, exists := g.builders[w]
+		if !exists {
+			var err error
+			b, err = g.builderFactory.NewBuilder()
+			if err != nil {
+				return fmt.Errorf("error creating logsobj builder for window %s: %w", w.Format(time.RFC3339), err)
+			}
+		}
+		if err := b.Append(tenant, stream, recTime); err != nil {
+			return fmt.Errorf("append for window %s: %w", w.Format(time.RFC3339), err)
+		}
+
+		if !exists {
+			// Only store a new builder into the map if append succeeded to avoid empty builders added to the map
+			// on Append errors.
+			g.builders[w] = b
+		}
+	}
+
+	return nil
+}
+
+// IsFull reports whether the combined buffered size across all window
+// builders has exceeded the configured target object size.
+//
+// We intentionally compare the *sum* (rather than each individual builder's
+// IsFull) so that a partition that receives records spanning many windows is
+// still bounded to roughly TargetObjectSize bytes of buffered memory, rather
+// than K*TargetObjectSize.
+func (g *TOCAlignedBuilderGroup) IsFull() bool {
+	return g.GetEstimatedSize() > g.targetObjectSize
+}
+
+func (g *TOCAlignedBuilderGroup) GetEstimatedSize() int {
+	size := 0
+	for _, b := range g.builders {
+		size += b.GetEstimatedSize()
+	}
+	return size
+}
+
+func (g *TOCAlignedBuilderGroup) Reset() {
+	clear(g.builders)
+}
+
+// GetBuilders returns all per-window builders, sorted in ascending order of
+// window start time.
+//
+// A deterministic order keeps flush-time side effects (metastore event
+// writes, offset commits, and any future per-window metrics) predictable
+// regardless of Go's map iteration randomization, which simplifies both
+// tests and operational reasoning.
+func (g *TOCAlignedBuilderGroup) GetBuilders() []builder {
+	windows := make([]time.Time, 0, len(g.builders))
+	for w := range g.builders {
+		windows = append(windows, w)
+	}
+	sort.Slice(windows, func(i, j int) bool { return windows[i].Before(windows[j]) })
+
+	result := make([]builder, 0, len(g.builders))
+	for _, w := range windows {
+		result = append(result, g.builders[w])
+	}
+	return result
+}

--- a/pkg/dataobj/consumer/builder_group.go
+++ b/pkg/dataobj/consumer/builder_group.go
@@ -1,0 +1,120 @@
+package consumer
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+type builderFactory interface {
+	NewBuilder() (*logsobj.Builder, error)
+}
+
+// TOCAlignedBuilderGroup manages a set of [logsobj.Builder] instances, one per
+// 12-hour UTC window (see [metastore.TOCWindowSize]). Each builder in the
+// group only contains entries whose timestamps fall into that window, which
+// keeps per-object time ranges aligned with the metastore TOC and bounds the
+// number of windows a single object can cover.
+//
+// The group's [IsFull] signal is driven by the *sum* of estimated sizes across
+// all window-specific builders, so the group preserves the "a partition will
+// not buffer more than TargetObjectSize" invariant that existed before the
+// per-window split.
+type TOCAlignedBuilderGroup struct {
+	builders         map[time.Time]builder
+	builderFactory   builderFactory
+	targetObjectSize int
+}
+
+// NewTOCAlignedBuilderGroup creates a new TOC aligned builder group.
+// targetObjectSize is the combined upper bound across all window builders; it
+// should match the TargetObjectSize used by the builder factory.
+func NewTOCAlignedBuilderGroup(builderFactory builderFactory, targetObjectSize int) *TOCAlignedBuilderGroup {
+	return &TOCAlignedBuilderGroup{
+		builders:         make(map[time.Time]builder),
+		builderFactory:   builderFactory,
+		targetObjectSize: targetObjectSize,
+	}
+}
+
+var _ builderGroup = (*TOCAlignedBuilderGroup)(nil)
+
+func (g *TOCAlignedBuilderGroup) Append(tenant string, stream logproto.Stream, recTime time.Time) error {
+	// [stream] might contain entries for multiple time windows => we need to split them to multiple streams, where
+	// each one only contains the entries for a single time window
+	streamsByTimeWindows := make(map[time.Time]logproto.Stream, 1)
+	for _, e := range stream.Entries {
+		w := e.Timestamp.UTC().Truncate(metastore.TOCWindowSize)
+		if _, ok := streamsByTimeWindows[w]; !ok {
+			streamsByTimeWindows[w] = logproto.Stream{
+				Labels: stream.Labels,
+			}
+		}
+		windowedStream := streamsByTimeWindows[w]
+		windowedStream.Entries = append(windowedStream.Entries, e)
+		streamsByTimeWindows[w] = windowedStream
+	}
+
+	for w, stream := range streamsByTimeWindows {
+		if _, ok := g.builders[w]; !ok {
+			b, err := g.builderFactory.NewBuilder()
+			if err != nil {
+				return fmt.Errorf("error creating logsobj builder for window %s: %w", w.Format(time.RFC3339), err)
+			}
+			g.builders[w] = b
+		}
+		if err := g.builders[w].Append(tenant, stream, recTime); err != nil {
+			return fmt.Errorf("append for window %s: %w", w.Format(time.RFC3339), err)
+		}
+	}
+
+	return nil
+}
+
+// IsFull reports whether the combined buffered size across all window
+// builders has exceeded the configured target object size.
+//
+// We intentionally compare the *sum* (rather than each individual builder's
+// IsFull) so that a partition that receives records spanning many windows is
+// still bounded to roughly TargetObjectSize bytes of buffered memory, rather
+// than K*TargetObjectSize.
+func (g *TOCAlignedBuilderGroup) IsFull() bool {
+	return g.GetEstimatedSize() > g.targetObjectSize
+}
+
+func (g *TOCAlignedBuilderGroup) GetEstimatedSize() int {
+	size := 0
+	for _, b := range g.builders {
+		size += b.GetEstimatedSize()
+	}
+	return size
+}
+
+func (g *TOCAlignedBuilderGroup) Reset() {
+	clear(g.builders)
+}
+
+// GetBuilders returns all per-window builders, sorted in ascending order of
+// window start time.
+//
+// A deterministic order keeps flush-time side effects (metastore event
+// writes, offset commits, and any future per-window metrics) predictable
+// regardless of Go's map iteration randomization, which simplifies both
+// tests and operational reasoning.
+func (g *TOCAlignedBuilderGroup) GetBuilders() []builder {
+	windows := make([]time.Time, 0, len(g.builders))
+	for w := range g.builders {
+		windows = append(windows, w)
+	}
+	sort.Slice(windows, func(i, j int) bool { return windows[i].Before(windows[j]) })
+
+	result := make([]builder, 0, len(g.builders))
+	for _, w := range windows {
+		result = append(result, g.builders[w])
+	}
+	return result
+}

--- a/pkg/dataobj/consumer/builder_group_test.go
+++ b/pkg/dataobj/consumer/builder_group_test.go
@@ -1,0 +1,269 @@
+package consumer
+
+import (
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/push"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/scratch"
+)
+
+// countingBuilderFactory wraps a [logsobj.BuilderFactory] and optionally fails
+// after a configured number of successful calls. Used to assert that
+// TOCAlignedBuilderGroup propagates factory errors.
+type countingBuilderFactory struct {
+	inner       *logsobj.BuilderFactory
+	created     int
+	failAfter   int // 0 = never fail
+	failWithErr error
+}
+
+func (f *countingBuilderFactory) NewBuilder() (*logsobj.Builder, error) {
+	if f.failAfter > 0 && f.created >= f.failAfter {
+		return nil, f.failWithErr
+	}
+	f.created++
+	return f.inner.NewBuilder()
+}
+
+func newCountingFactory(t *testing.T) *countingBuilderFactory {
+	t.Helper()
+	inner, err := logsobj.NewBuilderFactory(testBuilderCfg, scratch.NewMemory(), logsobj.NewBuilderMetrics())
+	require.NoError(t, err)
+	return &countingBuilderFactory{inner: inner}
+}
+
+// windowEntry returns a stream entry whose timestamp falls inside the
+// requested 12-hour TOC window.
+func windowEntry(window time.Time, offset time.Duration, line string) push.Entry {
+	return push.Entry{Timestamp: window.Add(offset), Line: line}
+}
+
+func TestTOCAlignedBuilderGroup_SingleWindow(t *testing.T) {
+	factory := newCountingFactory(t)
+	g := NewTOCAlignedBuilderGroup(factory, math.MaxInt)
+
+	window := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, g.Append("tenant", logproto.Stream{
+		Labels: `{app="foo"}`,
+		Entries: []push.Entry{
+			windowEntry(window, time.Minute, "a"),
+			windowEntry(window, 2*time.Minute, "b"),
+		},
+	}, window))
+
+	require.Equal(t, 1, factory.created)
+	require.Len(t, g.GetBuilders(), 1)
+	require.False(t, g.IsFull())
+}
+
+func TestTOCAlignedBuilderGroup_SplitsAcrossWindows(t *testing.T) {
+	factory := newCountingFactory(t)
+	g := NewTOCAlignedBuilderGroup(factory, math.MaxInt)
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	w2 := w1.Add(metastore.TOCWindowSize)
+
+	require.NoError(t, g.Append("tenant", logproto.Stream{
+		Labels: `{app="foo"}`,
+		Entries: []push.Entry{
+			windowEntry(w1, time.Minute, "first-window"),
+			windowEntry(w2, time.Minute, "second-window"),
+		},
+	}, w1))
+
+	require.Equal(t, 2, factory.created)
+	require.Len(t, g.GetBuilders(), 2)
+
+	for _, b := range g.GetBuilders() {
+		ranges := b.TimeRanges()
+		require.Len(t, ranges, 1, "each window builder should hold exactly one tenant time range")
+		// Verify that each builder's MinTime/MaxTime fall inside a single
+		// 12-hour window: truncating the range endpoints to the window size
+		// should yield the same window for MinTime and MaxTime.
+		require.Equal(t,
+			ranges[0].MinTime.Truncate(metastore.TOCWindowSize),
+			ranges[0].MaxTime.Truncate(metastore.TOCWindowSize),
+			"a window builder must only contain entries from a single TOC window",
+		)
+	}
+}
+
+func TestTOCAlignedBuilderGroup_FactoryFailurePropagates(t *testing.T) {
+	factory := newCountingFactory(t)
+	factory.failAfter = 1
+	factory.failWithErr = errors.New("boom")
+
+	g := NewTOCAlignedBuilderGroup(factory, math.MaxInt)
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	w2 := w1.Add(metastore.TOCWindowSize)
+
+	err := g.Append("tenant", logproto.Stream{
+		Labels: `{app="foo"}`,
+		Entries: []push.Entry{
+			windowEntry(w1, time.Minute, "ok"),
+			windowEntry(w2, time.Minute, "fails"),
+		},
+	}, w1)
+	// Exactly one of the two windows will be able to grab a builder; the
+	// other one will hit the factory error. Map iteration order decides
+	// which one it is but the error must bubble up either way.
+	require.Error(t, err)
+	require.ErrorContains(t, err, "boom")
+}
+
+func TestTOCAlignedBuilderGroup_AppendFailureDoesNotRetainEmptyBuilder(t *testing.T) {
+	factory := newCountingFactory(t)
+	g := NewTOCAlignedBuilderGroup(factory, math.MaxInt)
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+
+	// Invalid LogQL labels force Builder.Append -> parseLabels to fail before
+	// the builder records anything. We want to verify that a brand-new
+	// per-window builder created for this call does not get left behind in the
+	// group's map when Append returns an error.
+	err := g.Append("tenant", logproto.Stream{
+		Labels: "not a valid label string",
+		Entries: []push.Entry{
+			windowEntry(w1, time.Minute, "a"),
+		},
+	}, w1)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "append for window")
+
+	require.Empty(t, g.GetBuilders(),
+		"a builder that never successfully appended must not be retained in the group")
+	require.Equal(t, 0, g.GetEstimatedSize())
+	require.False(t, g.IsFull())
+
+	// A subsequent valid Append for the same window must succeed, which also
+	// sanity-checks that the group is usable after the earlier failure.
+	require.NoError(t, g.Append("tenant", logproto.Stream{
+		Labels: `{app="foo"}`,
+		Entries: []push.Entry{
+			windowEntry(w1, time.Minute, "a"),
+		},
+	}, w1))
+	require.Len(t, g.GetBuilders(), 1)
+}
+
+func TestTOCAlignedBuilderGroup_IsFullBoundsTotalMemory(t *testing.T) {
+	// target is slightly larger than the memory footprint of a single entry
+	// but small enough that two windows together exceed it: this lets us
+	// assert that IsFull reacts to the *sum* across builders.
+	factory := newCountingFactory(t)
+	g := NewTOCAlignedBuilderGroup(factory, 1<<10) // 1 KiB
+
+	require.False(t, g.IsFull(), "fresh group should not be full")
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	w2 := w1.Add(metastore.TOCWindowSize)
+
+	// Keep appending until the group reports full. We pump entries into
+	// two distinct windows so no single builder would flip IsFull on its
+	// own; only the sum does.
+	bigLine := make([]byte, 512)
+	for i := range bigLine {
+		bigLine[i] = 'x'
+	}
+	var appends int
+	for !g.IsFull() && appends < 128 {
+		require.NoError(t, g.Append("tenant", logproto.Stream{
+			Labels: `{app="foo"}`,
+			Entries: []push.Entry{
+				windowEntry(w1, time.Duration(appends)*time.Second, string(bigLine)),
+				windowEntry(w2, time.Duration(appends)*time.Second, string(bigLine)),
+			},
+		}, w1))
+		appends++
+	}
+	require.True(t, g.IsFull(), "group must eventually report full when sum exceeds the target")
+	require.GreaterOrEqual(t, g.GetEstimatedSize(), 1<<10)
+}
+
+func TestTOCAlignedBuilderGroup_ResetClearsState(t *testing.T) {
+	factory := newCountingFactory(t)
+	g := NewTOCAlignedBuilderGroup(factory, math.MaxInt)
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, g.Append("tenant", logproto.Stream{
+		Labels: `{app="foo"}`,
+		Entries: []push.Entry{
+			windowEntry(w1, time.Minute, "a"),
+		},
+	}, w1))
+
+	require.Len(t, g.GetBuilders(), 1)
+	require.Greater(t, g.GetEstimatedSize(), 0)
+
+	g.Reset()
+	require.Empty(t, g.GetBuilders())
+	require.Equal(t, 0, g.GetEstimatedSize())
+	require.False(t, g.IsFull())
+}
+
+func TestTOCAlignedBuilderGroup_GetBuildersReturnsSnapshot(t *testing.T) {
+	factory := newCountingFactory(t)
+	g := NewTOCAlignedBuilderGroup(factory, math.MaxInt)
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	w2 := w1.Add(metastore.TOCWindowSize)
+	require.NoError(t, g.Append("tenant", logproto.Stream{
+		Labels: `{app="foo"}`,
+		Entries: []push.Entry{
+			windowEntry(w1, time.Minute, "a"),
+			windowEntry(w2, time.Minute, "b"),
+		},
+	}, w1))
+
+	snapshot := g.GetBuilders()
+	require.Len(t, snapshot, 2)
+
+	// Subsequent Reset must not mutate the already-returned snapshot so
+	// flushCommitter can iterate safely after Reset runs in the defer.
+	g.Reset()
+	require.Len(t, snapshot, 2, "snapshot must be independent of the group's internal state")
+}
+
+func TestTOCAlignedBuilderGroup_GetBuildersIsSortedByWindow(t *testing.T) {
+	factory := newCountingFactory(t)
+	g := NewTOCAlignedBuilderGroup(factory, math.MaxInt)
+
+	// Append entries out of chronological order so the map would be populated
+	// in a non-monotonic order. GetBuilders() must still return them in
+	// ascending window order.
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	w2 := w1.Add(metastore.TOCWindowSize)
+	w3 := w2.Add(metastore.TOCWindowSize)
+	require.NoError(t, g.Append("tenant", logproto.Stream{
+		Labels: `{app="foo"}`,
+		Entries: []push.Entry{
+			windowEntry(w3, time.Minute, "c"),
+			windowEntry(w1, time.Minute, "a"),
+			windowEntry(w2, time.Minute, "b"),
+		},
+	}, w1))
+
+	builders := g.GetBuilders()
+	require.Len(t, builders, 3)
+
+	for i := 0; i < len(builders)-1; i++ {
+		a, b := builders[i].TimeRanges(), builders[i+1].TimeRanges()
+		require.Len(t, a, 1)
+		require.Len(t, b, 1)
+		require.True(t,
+			a[0].MinTime.Before(b[0].MinTime),
+			"builder[%d] window (%s) must come before builder[%d] window (%s)",
+			i, a[0].MinTime, i+1, b[0].MinTime,
+		)
+	}
+}

--- a/pkg/dataobj/consumer/builder_group_test.go
+++ b/pkg/dataobj/consumer/builder_group_test.go
@@ -1,0 +1,234 @@
+package consumer
+
+import (
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/push"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/scratch"
+)
+
+// countingBuilderFactory wraps a [logsobj.BuilderFactory] and optionally fails
+// after a configured number of successful calls. Used to assert that
+// TOCAlignedBuilderGroup propagates factory errors.
+type countingBuilderFactory struct {
+	inner       *logsobj.BuilderFactory
+	created     int
+	failAfter   int // 0 = never fail
+	failWithErr error
+}
+
+func (f *countingBuilderFactory) NewBuilder() (*logsobj.Builder, error) {
+	if f.failAfter > 0 && f.created >= f.failAfter {
+		return nil, f.failWithErr
+	}
+	f.created++
+	return f.inner.NewBuilder()
+}
+
+func newCountingFactory(t *testing.T) *countingBuilderFactory {
+	t.Helper()
+	inner, err := logsobj.NewBuilderFactory(testBuilderCfg, scratch.NewMemory(), logsobj.NewBuilderMetrics())
+	require.NoError(t, err)
+	return &countingBuilderFactory{inner: inner}
+}
+
+// windowEntry returns a stream entry whose timestamp falls inside the
+// requested 12-hour TOC window.
+func windowEntry(window time.Time, offset time.Duration, line string) push.Entry {
+	return push.Entry{Timestamp: window.Add(offset), Line: line}
+}
+
+func TestTOCAlignedBuilderGroup_SingleWindow(t *testing.T) {
+	factory := newCountingFactory(t)
+	g := NewTOCAlignedBuilderGroup(factory, math.MaxInt)
+
+	window := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, g.Append("tenant", logproto.Stream{
+		Labels: `{app="foo"}`,
+		Entries: []push.Entry{
+			windowEntry(window, time.Minute, "a"),
+			windowEntry(window, 2*time.Minute, "b"),
+		},
+	}, window))
+
+	require.Equal(t, 1, factory.created)
+	require.Len(t, g.GetBuilders(), 1)
+	require.False(t, g.IsFull())
+}
+
+func TestTOCAlignedBuilderGroup_SplitsAcrossWindows(t *testing.T) {
+	factory := newCountingFactory(t)
+	g := NewTOCAlignedBuilderGroup(factory, math.MaxInt)
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	w2 := w1.Add(metastore.TOCWindowSize)
+
+	require.NoError(t, g.Append("tenant", logproto.Stream{
+		Labels: `{app="foo"}`,
+		Entries: []push.Entry{
+			windowEntry(w1, time.Minute, "first-window"),
+			windowEntry(w2, time.Minute, "second-window"),
+		},
+	}, w1))
+
+	require.Equal(t, 2, factory.created)
+	require.Len(t, g.GetBuilders(), 2)
+
+	for _, b := range g.GetBuilders() {
+		ranges := b.TimeRanges()
+		require.Len(t, ranges, 1, "each window builder should hold exactly one tenant time range")
+		// Verify that each builder's MinTime/MaxTime fall inside a single
+		// 12-hour window: truncating the range endpoints to the window size
+		// should yield the same window for MinTime and MaxTime.
+		require.Equal(t,
+			ranges[0].MinTime.Truncate(metastore.TOCWindowSize),
+			ranges[0].MaxTime.Truncate(metastore.TOCWindowSize),
+			"a window builder must only contain entries from a single TOC window",
+		)
+	}
+}
+
+func TestTOCAlignedBuilderGroup_FactoryFailurePropagates(t *testing.T) {
+	factory := newCountingFactory(t)
+	factory.failAfter = 1
+	factory.failWithErr = errors.New("boom")
+
+	g := NewTOCAlignedBuilderGroup(factory, math.MaxInt)
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	w2 := w1.Add(metastore.TOCWindowSize)
+
+	err := g.Append("tenant", logproto.Stream{
+		Labels: `{app="foo"}`,
+		Entries: []push.Entry{
+			windowEntry(w1, time.Minute, "ok"),
+			windowEntry(w2, time.Minute, "fails"),
+		},
+	}, w1)
+	// Exactly one of the two windows will be able to grab a builder; the
+	// other one will hit the factory error. Map iteration order decides
+	// which one it is but the error must bubble up either way.
+	require.Error(t, err)
+	require.ErrorContains(t, err, "boom")
+}
+
+func TestTOCAlignedBuilderGroup_IsFullBoundsTotalMemory(t *testing.T) {
+	// target is slightly larger than the memory footprint of a single entry
+	// but small enough that two windows together exceed it: this lets us
+	// assert that IsFull reacts to the *sum* across builders.
+	factory := newCountingFactory(t)
+	g := NewTOCAlignedBuilderGroup(factory, 1<<10) // 1 KiB
+
+	require.False(t, g.IsFull(), "fresh group should not be full")
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	w2 := w1.Add(metastore.TOCWindowSize)
+
+	// Keep appending until the group reports full. We pump entries into
+	// two distinct windows so no single builder would flip IsFull on its
+	// own; only the sum does.
+	bigLine := make([]byte, 512)
+	for i := range bigLine {
+		bigLine[i] = 'x'
+	}
+	var appends int
+	for !g.IsFull() && appends < 128 {
+		require.NoError(t, g.Append("tenant", logproto.Stream{
+			Labels: `{app="foo"}`,
+			Entries: []push.Entry{
+				windowEntry(w1, time.Duration(appends)*time.Second, string(bigLine)),
+				windowEntry(w2, time.Duration(appends)*time.Second, string(bigLine)),
+			},
+		}, w1))
+		appends++
+	}
+	require.True(t, g.IsFull(), "group must eventually report full when sum exceeds the target")
+	require.GreaterOrEqual(t, g.GetEstimatedSize(), 1<<10)
+}
+
+func TestTOCAlignedBuilderGroup_ResetClearsState(t *testing.T) {
+	factory := newCountingFactory(t)
+	g := NewTOCAlignedBuilderGroup(factory, math.MaxInt)
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, g.Append("tenant", logproto.Stream{
+		Labels: `{app="foo"}`,
+		Entries: []push.Entry{
+			windowEntry(w1, time.Minute, "a"),
+		},
+	}, w1))
+
+	require.Len(t, g.GetBuilders(), 1)
+	require.Greater(t, g.GetEstimatedSize(), 0)
+
+	g.Reset()
+	require.Empty(t, g.GetBuilders())
+	require.Equal(t, 0, g.GetEstimatedSize())
+	require.False(t, g.IsFull())
+}
+
+func TestTOCAlignedBuilderGroup_GetBuildersReturnsSnapshot(t *testing.T) {
+	factory := newCountingFactory(t)
+	g := NewTOCAlignedBuilderGroup(factory, math.MaxInt)
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	w2 := w1.Add(metastore.TOCWindowSize)
+	require.NoError(t, g.Append("tenant", logproto.Stream{
+		Labels: `{app="foo"}`,
+		Entries: []push.Entry{
+			windowEntry(w1, time.Minute, "a"),
+			windowEntry(w2, time.Minute, "b"),
+		},
+	}, w1))
+
+	snapshot := g.GetBuilders()
+	require.Len(t, snapshot, 2)
+
+	// Subsequent Reset must not mutate the already-returned snapshot so
+	// flushCommitter can iterate safely after Reset runs in the defer.
+	g.Reset()
+	require.Len(t, snapshot, 2, "snapshot must be independent of the group's internal state")
+}
+
+func TestTOCAlignedBuilderGroup_GetBuildersIsSortedByWindow(t *testing.T) {
+	factory := newCountingFactory(t)
+	g := NewTOCAlignedBuilderGroup(factory, math.MaxInt)
+
+	// Append entries out of chronological order so the map would be populated
+	// in a non-monotonic order. GetBuilders() must still return them in
+	// ascending window order.
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	w2 := w1.Add(metastore.TOCWindowSize)
+	w3 := w2.Add(metastore.TOCWindowSize)
+	require.NoError(t, g.Append("tenant", logproto.Stream{
+		Labels: `{app="foo"}`,
+		Entries: []push.Entry{
+			windowEntry(w3, time.Minute, "c"),
+			windowEntry(w1, time.Minute, "a"),
+			windowEntry(w2, time.Minute, "b"),
+		},
+	}, w1))
+
+	builders := g.GetBuilders()
+	require.Len(t, builders, 3)
+
+	for i := 0; i < len(builders)-1; i++ {
+		a, b := builders[i].TimeRanges(), builders[i+1].TimeRanges()
+		require.Len(t, a, 1)
+		require.Len(t, b, 1)
+		require.True(t,
+			a[0].MinTime.Before(b[0].MinTime),
+			"builder[%d] window (%s) must come before builder[%d] window (%s)",
+			i, a[0].MinTime, i+1, b[0].MinTime,
+		)
+	}
+}

--- a/pkg/dataobj/consumer/flush_committer.go
+++ b/pkg/dataobj/consumer/flush_committer.go
@@ -65,18 +65,26 @@ func newFlushCommitter(
 	}
 }
 
-// Flush the data object builder and, if successful, commit the offset.
-func (c *flushCommitterImpl) Flush(ctx context.Context, builder builder, reason string, offset int64, earliestRecordTime time.Time) error {
-	objectPath, err := c.flusher.Flush(ctx, builder, reason)
-	if err != nil {
-		return fmt.Errorf("failed to flush data object: %w", err)
+// Flush multiple data object builders and, if successful, commit the offset.
+func (c *flushCommitterImpl) Flush(ctx context.Context, builders []builder, reason string, offset int64) error {
+	for _, b := range builders {
+		earliestRecordTime := b.EarliestRecordTime()
+		objectPath, err := c.flusher.Flush(ctx, b, reason)
+		if err != nil {
+			return fmt.Errorf("failed to flush data object: %w", err)
+		}
+		// Metastore events are emitted one at a time here. When we need to
+		// flush a lot of windows at once this could be batched into a single
+		// Kafka produce; for now the sequential path keeps retries / error
+		// handling simple.
+		if err := c.emitEvent(ctx, objectPath, earliestRecordTime); err != nil {
+			return fmt.Errorf("failed to emit metastore event: %w", err)
+		}
 	}
-	if err := c.emitEvent(ctx, objectPath, earliestRecordTime); err != nil {
-		return fmt.Errorf("failed to emit metastore event: %w", err)
-	}
+
 	if err := c.commit(ctx, offset); err != nil {
 		c.commitFailures.Inc()
-		return fmt.Errorf("failed to commit data object: %w", err)
+		return fmt.Errorf("failed to commit data object offset %d: %w", offset, err)
 	}
 	return nil
 }

--- a/pkg/dataobj/consumer/flush_committer.go
+++ b/pkg/dataobj/consumer/flush_committer.go
@@ -68,6 +68,7 @@ func newFlushCommitter(
 // Flush multiple data object builders and, if successful, commit the offset.
 func (c *flushCommitterImpl) Flush(ctx context.Context, builders []builder, reason string, offset int64) error {
 	for _, b := range builders {
+		earliestRecordTime := b.EarliestRecordTime()
 		objectPath, err := c.flusher.Flush(ctx, b, reason)
 		if err != nil {
 			return fmt.Errorf("failed to flush data object: %w", err)
@@ -76,7 +77,7 @@ func (c *flushCommitterImpl) Flush(ctx context.Context, builders []builder, reas
 		// flush a lot of windows at once this could be batched into a single
 		// Kafka produce; for now the sequential path keeps retries / error
 		// handling simple.
-		if err := c.emitEvent(ctx, objectPath, b.EarliestRecordTime()); err != nil {
+		if err := c.emitEvent(ctx, objectPath, earliestRecordTime); err != nil {
 			return fmt.Errorf("failed to emit metastore event: %w", err)
 		}
 	}

--- a/pkg/dataobj/consumer/flush_committer.go
+++ b/pkg/dataobj/consumer/flush_committer.go
@@ -65,15 +65,22 @@ func newFlushCommitter(
 	}
 }
 
-// Flush the data object builder and, if successful, commit the offset.
-func (c *flushCommitterImpl) Flush(ctx context.Context, builder builder, reason string, offset int64, earliestRecordTime time.Time) error {
-	objectPath, err := c.flusher.Flush(ctx, builder, reason)
-	if err != nil {
-		return fmt.Errorf("failed to flush data object: %w", err)
+// Flush multiple data object builders and, if successful, commit the offset.
+func (c *flushCommitterImpl) Flush(ctx context.Context, builders []builder, reason string, offset int64) error {
+	for _, b := range builders {
+		objectPath, err := c.flusher.Flush(ctx, b, reason)
+		if err != nil {
+			return fmt.Errorf("failed to flush data object: %w", err)
+		}
+		// Metastore events are emitted one at a time here. When we need to
+		// flush a lot of windows at once this could be batched into a single
+		// Kafka produce; for now the sequential path keeps retries / error
+		// handling simple.
+		if err := c.emitEvent(ctx, objectPath, b.EarliestRecordTime()); err != nil {
+			return fmt.Errorf("failed to emit metastore event: %w", err)
+		}
 	}
-	if err := c.emitEvent(ctx, objectPath, earliestRecordTime); err != nil {
-		return fmt.Errorf("failed to emit metastore event: %w", err)
-	}
+
 	if err := c.commit(ctx, offset); err != nil {
 		c.commitFailures.Inc()
 		return fmt.Errorf("failed to commit data object: %w", err)

--- a/pkg/dataobj/consumer/flush_committer.go
+++ b/pkg/dataobj/consumer/flush_committer.go
@@ -83,7 +83,7 @@ func (c *flushCommitterImpl) Flush(ctx context.Context, builders []builder, reas
 
 	if err := c.commit(ctx, offset); err != nil {
 		c.commitFailures.Inc()
-		return fmt.Errorf("failed to commit data object: %w", err)
+		return fmt.Errorf("failed to commit data object offset %d: %w", offset, err)
 	}
 	return nil
 }

--- a/pkg/dataobj/consumer/flush_committer_test.go
+++ b/pkg/dataobj/consumer/flush_committer_test.go
@@ -25,14 +25,14 @@ func TestFlushCommitter(t *testing.T) {
 			flushCommitter  = newFlushCommitter(flusher, metastoreEvents, committer, 0, log.NewNopLogger(), reg)
 		)
 		// Create a builder and append some logs so it can be flushed.
-		builder := newTestBuilder(t, reg)
-		require.NoError(t, builder.Append("test", logproto.Stream{
+		b := newTestBuilder(t, reg)
+		require.NoError(t, b.Append("test", logproto.Stream{
 			Labels: `{foo="bar"}`,
 			Entries: []logproto.Entry{
 				{Timestamp: now, Line: "test"},
 			},
-		}))
-		require.NoError(t, flushCommitter.Flush(t.Context(), builder, "test", 1, now))
+		}, now))
+		require.NoError(t, flushCommitter.Flush(t.Context(), []builder{b}, "test", 1))
 		// A flush should have occurred, a metastore event emitted, and the correct
 		// offset was committed.
 		require.Equal(t, 1, flusher.flushes)
@@ -61,14 +61,14 @@ func TestFlushCommitter(t *testing.T) {
 			flushCommitter  = newFlushCommitter(flusher, metastoreEvents, committer, 0, log.NewNopLogger(), reg)
 		)
 		// Create a builder and append some logs so it can be flushed.
-		builder := newTestBuilder(t, reg)
-		require.NoError(t, builder.Append("test", logproto.Stream{
+		b := newTestBuilder(t, reg)
+		require.NoError(t, b.Append("test", logproto.Stream{
 			Labels: `{foo="bar"}`,
 			Entries: []logproto.Entry{
 				{Timestamp: now, Line: "test"},
 			},
-		}))
-		flushErr := flushCommitter.Flush(t.Context(), builder, "test", 1, now)
+		}, now))
+		flushErr := flushCommitter.Flush(t.Context(), []builder{b}, "test", 1)
 		require.EqualError(t, flushErr, "failed to flush data object: mock error")
 		// Since no flush occurred, no event should be emitted and no offsets
 		// should be committed either.

--- a/pkg/dataobj/consumer/flush_test.go
+++ b/pkg/dataobj/consumer/flush_test.go
@@ -28,7 +28,7 @@ func TestFlusher_Flush(t *testing.T) {
 			now          = time.Now()
 		)
 		// Create a builder and append some logs so it can be flushed.
-		realBuilder, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory())
+		realBuilder, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory(), logsobj.NewBuilderMetrics())
 		require.NoError(t, err)
 		testBuilder = &mockBuilder{builder: realBuilder}
 		require.NoError(t, testBuilder.Append("test", logproto.Stream{
@@ -36,7 +36,7 @@ func TestFlusher_Flush(t *testing.T) {
 			Entries: []logproto.Entry{
 				{Timestamp: now, Line: "baz"},
 			},
-		}))
+		}, now))
 		f := newFlusher(testSorter, testUploader, log.NewNopLogger(), reg)
 		// Flush the builder we created earlier.
 		objectPath, err := f.Flush(testCtx, testBuilder, flushReasonBuilderFull)

--- a/pkg/dataobj/consumer/flush_test.go
+++ b/pkg/dataobj/consumer/flush_test.go
@@ -28,7 +28,7 @@ func TestFlusher_Flush(t *testing.T) {
 			now          = time.Now()
 		)
 		// Create a builder and append some logs so it can be flushed.
-		realBuilder, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory())
+		realBuilder, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory(), logsobj.NewBuilderMetrics())
 		require.NoError(t, err)
 		testBuilder = &mockBuilder{builder: realBuilder}
 		require.NoError(t, testBuilder.Append("test", logproto.Stream{
@@ -36,7 +36,7 @@ func TestFlusher_Flush(t *testing.T) {
 			Entries: []logproto.Entry{
 				{Timestamp: now, Line: "baz"},
 			},
-		}))
+		}, now))
 		f := newFlusher(testSorter, testUploader, log.NewNopLogger(), reg)
 		// Flush the builder we created earlier.
 		objectPath, err := f.Flush(testCtx, testBuilder, "test_sync")

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/facette/natsort"
 	"github.com/grafana/dskit/flagext"
@@ -25,12 +26,9 @@ import (
 	"github.com/grafana/loki/v3/pkg/scratch"
 )
 
-// ErrBuilderFull is returned by [Builder.Append] when the buffer is
-// full and needs to flush; call [Builder.Flush] to flush it.
-var (
-	ErrBuilderFull  = errors.New("builder full")
-	ErrBuilderEmpty = errors.New("builder empty")
-)
+// ErrBuilderEmpty is returned by [Builder.Flush] when the builder does not
+// contain any buffered data yet.
+var ErrBuilderEmpty = errors.New("builder empty")
 
 const (
 	// Constants for the sort order configuration
@@ -200,7 +198,7 @@ func appendStrategy(ordered bool) logs.AppendStrategy {
 // synchronization.
 type Builder struct {
 	cfg     BuilderConfig
-	metrics *builderMetrics
+	metrics *BuilderMetrics
 
 	labelCache *lru.Cache[string, labels.Labels]
 
@@ -209,6 +207,8 @@ type Builder struct {
 	builder *dataobj.Builder // Inner builder for accumulating sections.
 	streams map[string]*streams.Builder
 	logs    map[string]*logs.Builder
+
+	earliestRecordTime time.Time
 
 	state builderState
 }
@@ -225,19 +225,12 @@ const (
 
 // NewBuilder creates a new [Builder] which stores log-oriented data objects.
 //
-// NewBuilder returns an error if the provided config is invalid.
-func NewBuilder(cfg BuilderConfig, scratchStore scratch.Store) (*Builder, error) {
-	if err := cfg.Validate(); err != nil {
-		return nil, err
-	}
-
+// Config validation and metric registration are handled by [BuilderFactory].
+func NewBuilder(cfg BuilderConfig, scratchStore scratch.Store, metrics *BuilderMetrics) (*Builder, error) {
 	labelCache, err := lru.New[string, labels.Labels](5000)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create LRU cache: %w", err)
 	}
-
-	metrics := newBuilderMetrics()
-	metrics.ObserveConfig(cfg)
 
 	return &Builder{
 		cfg:        cfg,
@@ -275,26 +268,24 @@ func (b *Builder) GetEstimatedSize() int {
 	return b.currentSizeEstimate
 }
 
+func (b *Builder) IsFull() bool {
+	return b.currentSizeEstimate > int(b.cfg.TargetObjectSize)
+}
+
 // Append buffers a stream to be written to a data object. Append returns an
-// error if the stream labels cannot be parsed or [ErrBuilderFull] if the
-// builder is full.
+// error only when the stream's labels cannot be parsed; it does not refuse
+// appends when the buffer grows past [BuilderConfig.TargetObjectSize].
 //
-// Once a Builder is full, call [Builder.Flush] to flush the buffered data,
-// then call Append again with the same entry.
-func (b *Builder) Append(tenant string, stream logproto.Stream) error {
+// Callers are expected to poll [Builder.IsFull] (or the equivalent group
+// signal when multiple builders are managed together) before appending and
+// to flush the builder once it reports full. The additional entry appended
+// by the caller on the way to [Builder.IsFull] returning true is permitted;
+// it is tracked by recTime, which is used to drive [Builder.EarliestRecordTime]
+// and the resulting metastore/TOC events.
+func (b *Builder) Append(tenant string, stream logproto.Stream, recTime time.Time) error {
 	ls, err := b.parseLabels(stream.Labels)
 	if err != nil {
 		return err
-	}
-
-	// Check whether the buffer is full before a stream can be appended; this is
-	// tends to overestimate, but we may still go over our target size.
-	//
-	// Since this check only happens after the first call to Append,
-	// b.currentSizeEstimate will always be updated to reflect the size following
-	// the previous append.
-	if b.state != builderStateEmpty && b.currentSizeEstimate+labelsEstimate(ls)+streamSizeEstimate(stream) > int(b.cfg.TargetObjectSize) {
-		return ErrBuilderFull
 	}
 
 	b.initBuilder(tenant)
@@ -330,6 +321,9 @@ func (b *Builder) Append(tenant string, stream logproto.Stream) error {
 		}
 	}
 
+	if b.earliestRecordTime.IsZero() || recTime.Before(b.earliestRecordTime) {
+		b.earliestRecordTime = recTime
+	}
 	b.currentSizeEstimate = b.estimatedSize()
 	b.state = builderStateDirty
 	return nil
@@ -347,38 +341,6 @@ func (b *Builder) parseLabels(labelString string) (labels.Labels, error) {
 	}
 	b.labelCache.Add(labelString, parsed)
 	return parsed, nil
-}
-
-// labelsEstimate estimates the size of a set of labels in bytes.
-func labelsEstimate(ls labels.Labels) int {
-	var (
-		keysSize   int
-		valuesSize int
-	)
-
-	ls.Range(func(l labels.Label) {
-		keysSize += len(l.Name)
-		valuesSize += len(l.Value)
-	})
-
-	// Keys are stored as columns directly, while values get compressed. We'll
-	// underestimate a 2x compression ratio.
-	return keysSize + valuesSize/2
-}
-
-// streamSizeEstimate estimates the size of a stream in bytes.
-func streamSizeEstimate(stream logproto.Stream) int {
-	var size int
-	for _, entry := range stream.Entries {
-		// We only check the size of the line and metadata. Timestamps and IDs
-		// encode so well that they're unlikely to make a singificant impact on our
-		// size estimate.
-		size += len(entry.Line) / 2 // Line with 2x compression ratio
-		for _, md := range entry.StructuredMetadata {
-			size += len(md.Name) + len(md.Value)/2
-		}
-	}
-	return size
 }
 
 func convertMetadata(md push.LabelsAdapter) labels.Labels {
@@ -401,7 +363,6 @@ func (b *Builder) estimatedSize() int {
 		size += lb.EstimatedSize()
 	}
 	size += b.builder.Bytes()
-	b.metrics.sizeEstimate.Set(float64(size))
 	return size
 }
 
@@ -417,6 +378,10 @@ func (b *Builder) TimeRanges() []multitenancy.TimeRange {
 		})
 	}
 	return timeRanges
+}
+
+func (b *Builder) EarliestRecordTime() time.Time {
+	return b.earliestRecordTime
 }
 
 // Flush flushes all buffered data to the buffer provided. Calling Flush can result
@@ -627,7 +592,7 @@ func (b *Builder) Reset() {
 	clear(b.logs)
 	clear(b.streams)
 
-	b.metrics.sizeEstimate.Set(0)
+	b.earliestRecordTime = time.Time{}
 	b.currentSizeEstimate = 0
 	b.state = builderStateEmpty
 }
@@ -639,9 +604,4 @@ func (b *Builder) Reset() {
 // reg must contain additional labels to differentiate between them.
 func (b *Builder) RegisterMetrics(reg prometheus.Registerer) error {
 	return b.metrics.Register(reg)
-}
-
-// UnregisterMetrics unregisters metrics about builder from reg.
-func (b *Builder) UnregisterMetrics(reg prometheus.Registerer) {
-	b.metrics.Unregister(reg)
 }

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/facette/natsort"
 	"github.com/grafana/dskit/flagext"
@@ -25,12 +26,9 @@ import (
 	"github.com/grafana/loki/v3/pkg/scratch"
 )
 
-// ErrBuilderFull is returned by [Builder.Append] when the buffer is
-// full and needs to flush; call [Builder.Flush] to flush it.
-var (
-	ErrBuilderFull  = errors.New("builder full")
-	ErrBuilderEmpty = errors.New("builder empty")
-)
+// ErrBuilderEmpty is returned by [Builder.Flush] when the builder does not
+// contain any buffered data yet.
+var ErrBuilderEmpty = errors.New("builder empty")
 
 const (
 	// Constants for the sort order configuration
@@ -200,7 +198,7 @@ func appendStrategy(ordered bool) logs.AppendStrategy {
 // synchronization.
 type Builder struct {
 	cfg     BuilderConfig
-	metrics *builderMetrics
+	metrics *BuilderMetrics
 
 	labelCache *lru.Cache[string, labels.Labels]
 
@@ -209,6 +207,8 @@ type Builder struct {
 	builder *dataobj.Builder // Inner builder for accumulating sections.
 	streams map[string]*streams.Builder
 	logs    map[string]*logs.Builder
+
+	earliestRecordTime time.Time
 
 	state builderState
 }
@@ -225,19 +225,12 @@ const (
 
 // NewBuilder creates a new [Builder] which stores log-oriented data objects.
 //
-// NewBuilder returns an error if the provided config is invalid.
-func NewBuilder(cfg BuilderConfig, scratchStore scratch.Store) (*Builder, error) {
-	if err := cfg.Validate(); err != nil {
-		return nil, err
-	}
-
+// Config validation and metric registration are handled by [BuilderFactory].
+func NewBuilder(cfg BuilderConfig, scratchStore scratch.Store, metrics *BuilderMetrics) (*Builder, error) {
 	labelCache, err := lru.New[string, labels.Labels](5000)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create LRU cache: %w", err)
 	}
-
-	metrics := newBuilderMetrics()
-	metrics.ObserveConfig(cfg)
 
 	return &Builder{
 		cfg:        cfg,
@@ -275,26 +268,24 @@ func (b *Builder) GetEstimatedSize() int {
 	return b.currentSizeEstimate
 }
 
+func (b *Builder) IsFull() bool {
+	return b.currentSizeEstimate > int(b.cfg.TargetObjectSize)
+}
+
 // Append buffers a stream to be written to a data object. Append returns an
-// error if the stream labels cannot be parsed or [ErrBuilderFull] if the
-// builder is full.
+// error only when the stream's labels cannot be parsed; it does not refuse
+// appends when the buffer grows past [BuilderConfig.TargetObjectSize].
 //
-// Once a Builder is full, call [Builder.Flush] to flush the buffered data,
-// then call Append again with the same entry.
-func (b *Builder) Append(tenant string, stream logproto.Stream) error {
+// Callers are expected to poll [Builder.IsFull] (or the equivalent group
+// signal when multiple builders are managed together) before appending and
+// to flush the builder once it reports full. The additional entry appended
+// by the caller on the way to [Builder.IsFull] returning true is permitted;
+// it is tracked by recTime, which is used to drive [Builder.EarliestRecordTime]
+// and the resulting metastore/TOC events.
+func (b *Builder) Append(tenant string, stream logproto.Stream, recTime time.Time) error {
 	ls, err := b.parseLabels(stream.Labels)
 	if err != nil {
 		return err
-	}
-
-	// Check whether the buffer is full before a stream can be appended; this is
-	// tends to overestimate, but we may still go over our target size.
-	//
-	// Since this check only happens after the first call to Append,
-	// b.currentSizeEstimate will always be updated to reflect the size following
-	// the previous append.
-	if b.state != builderStateEmpty && b.currentSizeEstimate+labelsEstimate(ls)+streamSizeEstimate(stream) > int(b.cfg.TargetObjectSize) {
-		return ErrBuilderFull
 	}
 
 	b.initBuilder(tenant)
@@ -330,6 +321,9 @@ func (b *Builder) Append(tenant string, stream logproto.Stream) error {
 		}
 	}
 
+	if b.earliestRecordTime.IsZero() || recTime.Before(b.earliestRecordTime) {
+		b.earliestRecordTime = recTime
+	}
 	b.currentSizeEstimate = b.estimatedSize()
 	b.state = builderStateDirty
 	return nil
@@ -371,7 +365,7 @@ func streamSizeEstimate(stream logproto.Stream) int {
 	var size int
 	for _, entry := range stream.Entries {
 		// We only check the size of the line and metadata. Timestamps and IDs
-		// encode so well that they're unlikely to make a singificant impact on our
+		// encode so well that they're unlikely to make a significant impact on our
 		// size estimate.
 		size += len(entry.Line) / 2 // Line with 2x compression ratio
 		for _, md := range entry.StructuredMetadata {
@@ -401,7 +395,6 @@ func (b *Builder) estimatedSize() int {
 		size += lb.EstimatedSize()
 	}
 	size += b.builder.Bytes()
-	b.metrics.sizeEstimate.Set(float64(size))
 	return size
 }
 
@@ -417,6 +410,10 @@ func (b *Builder) TimeRanges() []multitenancy.TimeRange {
 		})
 	}
 	return timeRanges
+}
+
+func (b *Builder) EarliestRecordTime() time.Time {
+	return b.earliestRecordTime
 }
 
 // Flush flushes all buffered data to the buffer provided. Calling Flush can result
@@ -627,7 +624,7 @@ func (b *Builder) Reset() {
 	clear(b.logs)
 	clear(b.streams)
 
-	b.metrics.sizeEstimate.Set(0)
+	b.earliestRecordTime = time.Time{}
 	b.currentSizeEstimate = 0
 	b.state = builderStateEmpty
 }
@@ -639,9 +636,4 @@ func (b *Builder) Reset() {
 // reg must contain additional labels to differentiate between them.
 func (b *Builder) RegisterMetrics(reg prometheus.Registerer) error {
 	return b.metrics.Register(reg)
-}
-
-// UnregisterMetrics unregisters metrics about builder from reg.
-func (b *Builder) UnregisterMetrics(reg prometheus.Registerer) {
-	b.metrics.Unregister(reg)
 }

--- a/pkg/dataobj/consumer/logsobj/builder_metrics.go
+++ b/pkg/dataobj/consumer/logsobj/builder_metrics.go
@@ -10,8 +10,16 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 )
 
-// builderMetrics provides instrumnetation for a [Builder].
-type builderMetrics struct {
+// BuilderMetrics provides instrumentation for a [Builder].
+//
+// A single instance of BuilderMetrics is shared by every [Builder] created
+// through the same [BuilderFactory]. The exported counters and histograms
+// aggregate across all of those builders. Gauges that describe the current
+// buffered size of a partition intentionally live on the consumer-level
+// metrics instead of here, because a group of builders (one per TOC window)
+// may be active at the same time and a single per-builder gauge would
+// otherwise become last-write-wins across siblings.
+type BuilderMetrics struct {
 	logs    *logs.Metrics
 	streams *streams.Metrics
 	dataobj *dataobj.Metrics
@@ -24,14 +32,13 @@ type builderMetrics struct {
 	buildTime     prometheus.Histogram
 	flushFailures prometheus.Counter
 
-	sizeEstimate prometheus.Gauge
-	builtSize    prometheus.Histogram
+	builtSize prometheus.Histogram
 }
 
-// newBuilderMetrics creates a new set of [builderMetrics] for instrumenting
+// NewBuilderMetrics creates a new set of [BuilderMetrics] for instrumenting
 // logs objects.
-func newBuilderMetrics() *builderMetrics {
-	return &builderMetrics{
+func NewBuilderMetrics() *BuilderMetrics {
+	return &BuilderMetrics{
 		logs:    logs.NewMetrics(),
 		streams: streams.NewMetrics(),
 		dataobj: dataobj.NewMetrics(),
@@ -65,10 +72,6 @@ func newBuilderMetrics() *builderMetrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: 0,
 		}),
-		sizeEstimate: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loki_dataobj_size_estimate_bytes",
-			Help: "Current estimated size of the data object in bytes.",
-		}),
 		builtSize: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name: "loki_dataobj_built_size_bytes",
 			Help: "Distribution of constructed data object sizes in bytes.",
@@ -85,13 +88,13 @@ func newBuilderMetrics() *builderMetrics {
 }
 
 // ObserveConfig updates config metrics based on the provided [BuilderConfig].
-func (m *builderMetrics) ObserveConfig(cfg BuilderConfig) {
+func (m *BuilderMetrics) ObserveConfig(cfg BuilderConfig) {
 	m.targetPageSize.Set(float64(cfg.TargetPageSize))
 	m.targetObjectSize.Set(float64(cfg.TargetObjectSize))
 }
 
 // Register registers metrics to report to reg.
-func (m *builderMetrics) Register(reg prometheus.Registerer) error {
+func (m *BuilderMetrics) Register(reg prometheus.Registerer) error {
 	var errs []error
 
 	errs = append(errs, m.logs.Register(reg))
@@ -105,7 +108,6 @@ func (m *builderMetrics) Register(reg prometheus.Registerer) error {
 	errs = append(errs, reg.Register(m.appendTime))
 	errs = append(errs, reg.Register(m.buildTime))
 
-	errs = append(errs, reg.Register(m.sizeEstimate))
 	errs = append(errs, reg.Register(m.builtSize))
 	errs = append(errs, reg.Register(m.flushFailures))
 
@@ -113,7 +115,7 @@ func (m *builderMetrics) Register(reg prometheus.Registerer) error {
 }
 
 // Unregister unregisters metrics from the provided Registerer.
-func (m *builderMetrics) Unregister(reg prometheus.Registerer) {
+func (m *BuilderMetrics) Unregister(reg prometheus.Registerer) {
 	m.logs.Unregister(reg)
 	m.streams.Unregister(reg)
 	m.dataobj.Unregister(reg)
@@ -125,7 +127,6 @@ func (m *builderMetrics) Unregister(reg prometheus.Registerer) {
 	reg.Unregister(m.appendTime)
 	reg.Unregister(m.buildTime)
 
-	reg.Unregister(m.sizeEstimate)
 	reg.Unregister(m.builtSize)
 	reg.Unregister(m.flushFailures)
 }

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -2,7 +2,6 @@ package logsobj
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -76,11 +75,11 @@ func TestBuilder(t *testing.T) {
 	}
 
 	t.Run("Build", func(t *testing.T) {
-		builder, err := NewBuilder(testBuilderConfig, nil)
+		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
 		require.NoError(t, err)
 
 		for _, entry := range testStreams {
-			require.NoError(t, builder.Append("tenant", entry))
+			require.NoError(t, builder.Append("tenant", entry, time.Time{}))
 		}
 		obj, closer, err := builder.Flush()
 		require.NoError(t, err)
@@ -97,35 +96,31 @@ func TestBuilder_Append(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	builder, err := NewBuilder(testBuilderConfig, nil)
+	builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
 	require.NoError(t, err)
 
 	tenant := "test"
 
-	for {
+	for !builder.IsFull() {
 		require.NoError(t, ctx.Err())
 
-		err := builder.Append(tenant, logproto.Stream{
+		require.NoError(t, builder.Append(tenant, logproto.Stream{
 			Labels: `{cluster="test",app="foo"}`,
 			Entries: []push.Entry{{
 				Timestamp: time.Now().UTC(),
 				Line:      strings.Repeat("a", 1024),
 			}},
-		})
-		if errors.Is(err, ErrBuilderFull) {
-			break
-		}
-		require.NoError(t, err)
+		}, time.Time{}))
 	}
 
 	obj, closer, err := builder.Flush()
 	require.NoError(t, err)
 	defer closer.Close()
 
-	// When a section builder is reset, which happens on ErrBuilderFull, the
-	// tenant is reset too. We must check that the tenant is added back
-	// to the section builder otherwise tenant will be absent from successive
-	// sections.
+	// When a section builder is reset (which happens when the builder reports
+	// IsFull and we flush) the tenant is reset too. We must check that the
+	// tenant is added back to the section builder otherwise tenant will be
+	// absent from successive sections.
 	secs := obj.Sections()
 	require.Equal(t, 1, secs.Count(streams.CheckSection))
 	require.Greater(t, secs.Count(logs.CheckSection), 1)
@@ -135,7 +130,7 @@ func TestBuilder_Append(t *testing.T) {
 }
 
 func TestBuilder_CopyAndSort(t *testing.T) {
-	builder, _ := NewBuilder(testBuilderConfig, nil)
+	builder, _ := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
 
 	now := time.Date(2025, time.September, 17, 0, 0, 0, 0, time.UTC)
 	numRows := 16 // 16 rows with 1KiB each line and 8KiB section size ~> 2 logs sections per tenant
@@ -148,7 +143,7 @@ func TestBuilder_CopyAndSort(t *testing.T) {
 					Timestamp: now.Add(time.Duration(i%8) * time.Second),
 					Line:      strings.Repeat("a", 1024), // 1KiB log line
 				}},
-			})
+			}, time.Time{})
 			require.NoError(t, err)
 		}
 	}
@@ -157,7 +152,7 @@ func TestBuilder_CopyAndSort(t *testing.T) {
 	require.NoError(t, err)
 	defer closer1.Close()
 
-	newBuilder, _ := NewBuilder(testBuilderConfig, nil)
+	newBuilder, _ := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
 
 	obj2, closer2, err := newBuilder.CopyAndSort(t.Context(), obj1)
 	require.NoError(t, err)

--- a/pkg/dataobj/consumer/logsobj/factory.go
+++ b/pkg/dataobj/consumer/logsobj/factory.go
@@ -1,10 +1,6 @@
 package logsobj
 
 import (
-	"fmt"
-
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/grafana/loki/v3/pkg/scratch"
 )
 
@@ -12,26 +8,33 @@ import (
 type BuilderFactory struct {
 	cfg          BuilderConfig
 	scratchStore scratch.Store
+	metrics      *BuilderMetrics
 }
 
-func NewBuilderFactory(cfg BuilderConfig, scratchStore scratch.Store) *BuilderFactory {
+// NewBuilderFactory validates the config, reports related metrics, and returns a factory that is prepared to create new
+// builders.
+func NewBuilderFactory(cfg BuilderConfig, scratchStore scratch.Store, metrics *BuilderMetrics) (*BuilderFactory, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	metrics.ObserveConfig(cfg)
+
 	return &BuilderFactory{
 		cfg:          cfg,
 		scratchStore: scratchStore,
-	}
+		metrics:      metrics,
+	}, nil
 }
 
-// NewBuilder returns a new builder, or an error. The registerer is optional.
-// No metrics will be registered if the registerer is nil.
-func (f *BuilderFactory) NewBuilder(r prometheus.Registerer) (*Builder, error) {
-	b, err := NewBuilder(f.cfg, f.scratchStore)
-	if err != nil {
-		return nil, err
-	}
-	if r != nil {
-		if err = b.RegisterMetrics(r); err != nil {
-			return nil, fmt.Errorf("failed to register metrics: %w", err)
-		}
-	}
-	return b, nil
+// NewBuilder returns a new builder, or an error. The returned builder shares
+// the factory's [BuilderMetrics].
+func (f *BuilderFactory) NewBuilder() (*Builder, error) {
+	return NewBuilder(f.cfg, f.scratchStore, f.metrics)
+}
+
+// NewSorterBuilder returns a new builder with "fake" non-registered metrics.
+// TODO(ivkalita): This is temporary to prevent "sorting" builder metrics from messing up the real builder metrics.
+func (f *BuilderFactory) NewSorterBuilder() (*Builder, error) {
+	return NewBuilder(f.cfg, f.scratchStore, NewBuilderMetrics())
 }

--- a/pkg/dataobj/consumer/logsobj/factory.go
+++ b/pkg/dataobj/consumer/logsobj/factory.go
@@ -1,10 +1,6 @@
 package logsobj
 
 import (
-	"fmt"
-
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/grafana/loki/v3/pkg/scratch"
 )
 
@@ -12,26 +8,27 @@ import (
 type BuilderFactory struct {
 	cfg          BuilderConfig
 	scratchStore scratch.Store
+	metrics      *BuilderMetrics
 }
 
-func NewBuilderFactory(cfg BuilderConfig, scratchStore scratch.Store) *BuilderFactory {
+// NewBuilderFactory validates the config, reports related metrics, and returns a factory that is prepared to create new
+// builders.
+func NewBuilderFactory(cfg BuilderConfig, scratchStore scratch.Store, metrics *BuilderMetrics) (*BuilderFactory, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	metrics.ObserveConfig(cfg)
+
 	return &BuilderFactory{
 		cfg:          cfg,
 		scratchStore: scratchStore,
-	}
+		metrics:      metrics,
+	}, nil
 }
 
-// NewBuilder returns a new builder, or an error. The registerer is optional.
-// No metrics will be registered if the registerer is nil.
-func (f *BuilderFactory) NewBuilder(r prometheus.Registerer) (*Builder, error) {
-	b, err := NewBuilder(f.cfg, f.scratchStore)
-	if err != nil {
-		return nil, err
-	}
-	if r != nil {
-		if err = b.RegisterMetrics(r); err != nil {
-			return nil, fmt.Errorf("failed to register metrics: %w", err)
-		}
-	}
-	return b, nil
+// NewBuilder returns a new builder, or an error. The returned builder shares
+// the factory's [BuilderMetrics].
+func (f *BuilderFactory) NewBuilder() (*Builder, error) {
+	return NewBuilder(f.cfg, f.scratchStore, f.metrics)
 }

--- a/pkg/dataobj/consumer/logsobj/factory_test.go
+++ b/pkg/dataobj/consumer/logsobj/factory_test.go
@@ -11,16 +11,22 @@ import (
 )
 
 func TestBuilderFactory(t *testing.T) {
-	bf := NewBuilderFactory(testBuilderConfig, scratch.NewMemory())
-	// Can create a builder without registering metrics.
-	b, err := bf.NewBuilder(nil)
-	require.NoError(t, err)
-	require.NotNil(t, b)
-	// Can also create a builder with metrics.
 	reg := prometheus.NewRegistry()
-	b, err = bf.NewBuilder(reg)
+	metrics := NewBuilderMetrics()
+	require.NoError(t, metrics.Register(reg))
+	bf, err := NewBuilderFactory(testBuilderConfig, scratch.NewMemory(), metrics)
+	require.NoError(t, err)
+
+	// can create builder without metrics
+	b, err := bf.NewSorterBuilder()
 	require.NoError(t, err)
 	require.NotNil(t, b)
+
+	// can create builder with metrics
+	b, err = bf.NewBuilder()
+	require.NoError(t, err)
+	require.NotNil(t, b)
+
 	// Should be able to gather registered metrics.
 	n, err := testutil.GatherAndCount(reg)
 	require.NoError(t, err)

--- a/pkg/dataobj/consumer/logsobj/factory_test.go
+++ b/pkg/dataobj/consumer/logsobj/factory_test.go
@@ -11,14 +11,12 @@ import (
 )
 
 func TestBuilderFactory(t *testing.T) {
-	bf := NewBuilderFactory(testBuilderConfig, scratch.NewMemory())
-	// Can create a builder without registering metrics.
-	b, err := bf.NewBuilder(nil)
-	require.NoError(t, err)
-	require.NotNil(t, b)
-	// Can also create a builder with metrics.
 	reg := prometheus.NewRegistry()
-	b, err = bf.NewBuilder(reg)
+	metrics := NewBuilderMetrics()
+	require.NoError(t, metrics.Register(reg))
+	bf, err := NewBuilderFactory(testBuilderConfig, scratch.NewMemory(), metrics)
+	require.NoError(t, err)
+	b, err := bf.NewBuilder()
 	require.NoError(t, err)
 	require.NotNil(t, b)
 	// Should be able to gather registered metrics.

--- a/pkg/dataobj/consumer/logsobj/pool_test.go
+++ b/pkg/dataobj/consumer/logsobj/pool_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestSizedBuilderPool(t *testing.T) {
 	t.Run("Get returns the next builder, and nil when the pool is empty", func(t *testing.T) {
-		builder, err := NewBuilder(testBuilderConfig, scratch.NewMemory())
+		builder, err := NewBuilder(testBuilderConfig, scratch.NewMemory(), NewBuilderMetrics())
 		require.NoError(t, err)
 		pool := NewSizedBuilderPool([]*Builder{builder})
 		// The first call to [Get] should return the builder.
@@ -28,7 +28,7 @@ func TestSizedBuilderPool(t *testing.T) {
 	})
 
 	t.Run("Wait blocks until a builder is available", func(t *testing.T) {
-		builder, err := NewBuilder(testBuilderConfig, scratch.NewMemory())
+		builder, err := NewBuilder(testBuilderConfig, scratch.NewMemory(), NewBuilderMetrics())
 		require.NoError(t, err)
 		pool := NewSizedBuilderPool([]*Builder{builder})
 		// The first call to [Wait] should not block.

--- a/pkg/dataobj/consumer/logsobj/sorter.go
+++ b/pkg/dataobj/consumer/logsobj/sorter.go
@@ -35,7 +35,7 @@ func NewSorter(factory *BuilderFactory, r prometheus.Registerer) *Sorter {
 // Sort takes an existing data object and rewrites the logs sections so they are
 // sorted object-wide.
 func (s *Sorter) Sort(ctx context.Context, obj *dataobj.Object) (*dataobj.Object, io.Closer, error) {
-	b, err := s.factory.NewBuilder(nil)
+	b, err := s.factory.NewSorterBuilder()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create builder: %w", err)
 	}

--- a/pkg/dataobj/consumer/logsobj/sorter.go
+++ b/pkg/dataobj/consumer/logsobj/sorter.go
@@ -35,7 +35,7 @@ func NewSorter(factory *BuilderFactory, r prometheus.Registerer) *Sorter {
 // Sort takes an existing data object and rewrites the logs sections so they are
 // sorted object-wide.
 func (s *Sorter) Sort(ctx context.Context, obj *dataobj.Object) (*dataobj.Object, io.Closer, error) {
-	b, err := s.factory.NewBuilder(nil)
+	b, err := s.factory.NewBuilder()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create builder: %w", err)
 	}

--- a/pkg/dataobj/consumer/metrics.go
+++ b/pkg/dataobj/consumer/metrics.go
@@ -15,6 +15,7 @@ type metrics struct {
 	records               prometheus.Counter
 	recordFailures        prometheus.Counter
 	timePartitionEstimate prometheus.Counter
+	sizeEstimate          prometheus.Gauge
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
@@ -45,7 +46,11 @@ func newMetrics(r prometheus.Registerer) *metrics {
 		}),
 		timePartitionEstimate: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "loki_dataobj_consumer_time_partition_estimate_total",
-			Help: "The number of data objects we would build with 12 hour windows.",
+			Help: "Total number of data objects that were produced due to records being split across 12-hour windows.",
+		}),
+		sizeEstimate: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_dataobj_size_estimate_bytes",
+			Help: "Current estimated size in bytes buffered across all window-specific builders for the partition.",
 		}),
 	}
 }

--- a/pkg/dataobj/consumer/mock_test.go
+++ b/pkg/dataobj/consumer/mock_test.go
@@ -19,14 +19,15 @@ import (
 type mockBuilder struct {
 	builder *logsobj.Builder
 	nextErr error
+	full    bool
 }
 
-func (m *mockBuilder) Append(tenant string, stream logproto.Stream) error {
+func (m *mockBuilder) Append(tenant string, stream logproto.Stream, recTime time.Time) error {
 	if err := m.nextErr; err != nil {
 		m.nextErr = nil
 		return err
 	}
-	return m.builder.Append(tenant, stream)
+	return m.builder.Append(tenant, stream, recTime)
 }
 
 func (m *mockBuilder) GetEstimatedSize() int {
@@ -49,6 +50,41 @@ func (m *mockBuilder) TimeRanges() []multitenancy.TimeRange {
 	return m.builder.TimeRanges()
 }
 
+func (m *mockBuilder) EarliestRecordTime() time.Time {
+	return m.builder.EarliestRecordTime()
+}
+
+func (m *mockBuilder) IsFull() bool {
+	if m.full {
+		return true
+	}
+	return m.builder.IsFull()
+}
+
+// mockBuilderGroup wraps a single [logsobj.Builder] so tests that want to
+// exercise the processor's [builderGroup] dependency without caring about TOC
+// window splitting can just pass a single builder.
+type mockBuilderGroup struct {
+	b *logsobj.Builder
+}
+
+func newMockBuilderGroup(b *logsobj.Builder) *mockBuilderGroup {
+	return &mockBuilderGroup{b: b}
+}
+
+func (g *mockBuilderGroup) Append(tenant string, stream logproto.Stream, recTime time.Time) error {
+	return g.b.Append(tenant, stream, recTime)
+}
+func (g *mockBuilderGroup) GetEstimatedSize() int { return g.b.GetEstimatedSize() }
+func (g *mockBuilderGroup) Reset()                { g.b.Reset() }
+func (g *mockBuilderGroup) GetBuilders() []builder {
+	if g.b.GetEstimatedSize() == 0 {
+		return nil
+	}
+	return []builder{g.b}
+}
+func (g *mockBuilderGroup) IsFull() bool { return g.b.IsFull() }
+
 // A mockCommitter implements the committer interface for tests.
 type mockCommitter struct {
 	offsets []int64
@@ -69,11 +105,17 @@ func (m *mockFlusher) Flush(_ context.Context, _ builder, _ string) (string, err
 }
 
 type mockFlushCommitter struct {
-	flushes int
+	flushes          int
+	lastBuilderCount int
+	lastReason       string
+	lastOffset       int64
 }
 
-func (m *mockFlushCommitter) Flush(_ context.Context, _ builder, _ string, _ int64, _ time.Time) error {
+func (m *mockFlushCommitter) Flush(_ context.Context, builders []builder, reason string, offset int64) error {
 	m.flushes++
+	m.lastBuilderCount = len(builders)
+	m.lastReason = reason
+	m.lastOffset = offset
 	return nil
 }
 

--- a/pkg/dataobj/consumer/mock_test.go
+++ b/pkg/dataobj/consumer/mock_test.go
@@ -101,14 +101,15 @@ func (m *mockBucket) SupportedIterOptions() []objstore.IterOptionType {
 type mockBuilder struct {
 	builder *logsobj.Builder
 	nextErr error
+	full    bool
 }
 
-func (m *mockBuilder) Append(tenant string, stream logproto.Stream) error {
+func (m *mockBuilder) Append(tenant string, stream logproto.Stream, recTime time.Time) error {
 	if err := m.nextErr; err != nil {
 		m.nextErr = nil
 		return err
 	}
-	return m.builder.Append(tenant, stream)
+	return m.builder.Append(tenant, stream, recTime)
 }
 
 func (m *mockBuilder) GetEstimatedSize() int {
@@ -131,6 +132,41 @@ func (m *mockBuilder) TimeRanges() []multitenancy.TimeRange {
 	return m.builder.TimeRanges()
 }
 
+func (m *mockBuilder) EarliestRecordTime() time.Time {
+	return m.builder.EarliestRecordTime()
+}
+
+func (m *mockBuilder) IsFull() bool {
+	if m.full {
+		return true
+	}
+	return m.builder.IsFull()
+}
+
+// mockBuilderGroup wraps a single [logsobj.Builder] so tests that want to
+// exercise the processor's [builderGroup] dependency without caring about TOC
+// window splitting can just pass a single builder.
+type mockBuilderGroup struct {
+	b *logsobj.Builder
+}
+
+func newMockBuilderGroup(b *logsobj.Builder) *mockBuilderGroup {
+	return &mockBuilderGroup{b: b}
+}
+
+func (g *mockBuilderGroup) Append(tenant string, stream logproto.Stream, recTime time.Time) error {
+	return g.b.Append(tenant, stream, recTime)
+}
+func (g *mockBuilderGroup) GetEstimatedSize() int { return g.b.GetEstimatedSize() }
+func (g *mockBuilderGroup) Reset()                { g.b.Reset() }
+func (g *mockBuilderGroup) GetBuilders() []builder {
+	if g.b.GetEstimatedSize() == 0 {
+		return nil
+	}
+	return []builder{g.b}
+}
+func (g *mockBuilderGroup) IsFull() bool { return g.b.IsFull() }
+
 // A mockCommitter implements the committer interface for tests.
 type mockCommitter struct {
 	offsets []int64
@@ -151,11 +187,20 @@ func (m *mockFlusher) Flush(_ context.Context, _ builder, _ string) (string, err
 }
 
 type mockFlushCommitter struct {
-	flushes int
+	flushes          int
+	lastBuilderCount int
+	lastReason       string
+	lastOffset       int64
 }
 
-func (m *mockFlushCommitter) Flush(_ context.Context, _ builder, _ string, _ int64, _ time.Time) error {
+func (m *mockFlushCommitter) Flush(_ context.Context, builders []builder, reason string, offset int64) error {
+	if len(builders) == 0 {
+		return nil
+	}
 	m.flushes++
+	m.lastBuilderCount = len(builders)
+	m.lastReason = reason
+	m.lastOffset = offset
 	return nil
 }
 

--- a/pkg/dataobj/consumer/processor.go
+++ b/pkg/dataobj/consumer/processor.go
@@ -14,7 +14,6 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
-	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/kafka"
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -22,16 +21,26 @@ import (
 
 // A builder allows mocking of [logsobj.Builder] in tests.
 type builder interface {
-	Append(tenant string, stream logproto.Stream) error
+	Append(tenant string, stream logproto.Stream, recTime time.Time) error
 	GetEstimatedSize() int
 	Flush() (*dataobj.Object, io.Closer, error)
 	TimeRanges() []multitenancy.TimeRange
+	EarliestRecordTime() time.Time
 	CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataobj.Object, io.Closer, error)
+	IsFull() bool
+}
+
+type builderGroup interface {
+	Append(tenant string, stream logproto.Stream, recTime time.Time) error
+	GetEstimatedSize() int
+	Reset()
+	GetBuilders() []builder
+	IsFull() bool
 }
 
 // A flushCommitter allows mocking of flushes in tests.
 type flushCommitter interface {
-	Flush(ctx context.Context, builder builder, reason string, offset int64, earliestRecordTime time.Time) error
+	Flush(ctx context.Context, builders []builder, reason string, offset int64) error
 }
 
 // A processor receives records and builds data objects from them.
@@ -42,7 +51,7 @@ type flushRequest struct {
 
 type processor struct {
 	*services.BasicService
-	builder        builder
+	builder        builderGroup
 	decoder        *kafka.Decoder
 	records        chan *kgo.Record
 	flushCommitter flushCommitter
@@ -74,14 +83,6 @@ type processor struct {
 	// idle timeout. It must be reset after each flush.
 	lastAppend time.Time
 
-	// earliestRecordTime tracks the timestamp of the earliest record appended
-	// to the data object builder. It is required for the metastore index.
-	earliestRecordTime time.Time
-
-	// timePartitionedEstimates counts how many data objects we would build
-	// per flush with 12 hour windows.
-	timePartitionedEstimates map[time.Time]struct{}
-
 	// flushRequests is used to safely trigger a flush from outside the Run loop.
 	mode          IngestMode
 	flushRequests chan flushRequest
@@ -91,7 +92,7 @@ type processor struct {
 }
 
 func newProcessor(
-	builder builder,
+	builder builderGroup,
 	records chan *kgo.Record,
 	flushCommitter flushCommitter,
 	idleFlushTimeout time.Duration,
@@ -105,17 +106,16 @@ func newProcessor(
 		panic(err)
 	}
 	p := &processor{
-		builder:                  builder,
-		decoder:                  decoder,
-		records:                  records,
-		flushCommitter:           flushCommitter,
-		flushRequests:            make(chan flushRequest, 1),
-		idleFlushTimeout:         idleFlushTimeout,
-		maxBuilderAge:            maxBuilderAge,
-		metrics:                  newMetrics(reg),
-		logger:                   logger,
-		timePartitionedEstimates: make(map[time.Time]struct{}),
-		mode:                     mode,
+		builder:          builder,
+		decoder:          decoder,
+		records:          records,
+		flushCommitter:   flushCommitter,
+		flushRequests:    make(chan flushRequest, 1),
+		idleFlushTimeout: idleFlushTimeout,
+		maxBuilderAge:    maxBuilderAge,
+		metrics:          newMetrics(reg),
+		logger:           logger,
+		mode:             mode,
 	}
 	p.BasicService = services.NewBasicService(p.starting, p.running, p.stopping)
 	return p
@@ -205,10 +205,6 @@ func (p *processor) processRecord(ctx context.Context, rec *kgo.Record) error {
 	now := time.Now()
 	p.observeRecord(rec, now)
 
-	// Find the 12 hour window.
-	window := rec.Timestamp.UTC().Truncate(12 * time.Hour)
-	p.timePartitionedEstimates[window] = struct{}{}
-
 	// Try to decode the stream in the record.
 	tenant := string(rec.Key)
 	stream, err := p.decoder.DecodeWithoutLabels(rec.Value)
@@ -223,21 +219,17 @@ func (p *processor) processRecord(ctx context.Context, rec *kgo.Record) error {
 		}
 	}
 
-	if err := p.builder.Append(tenant, stream); err != nil {
-		if !errors.Is(err, logsobj.ErrBuilderFull) {
-			return fmt.Errorf("failed to append stream: %w", err)
-		}
+	if p.builder.IsFull() {
 		if err := p.flush(ctx, flushReasonBuilderFull); err != nil {
-			return fmt.Errorf("failed to flush and commit: %w", err)
-		}
-		if err := p.builder.Append(tenant, stream); err != nil {
-			return fmt.Errorf("failed to append stream after flushing: %w", err)
+			return fmt.Errorf("failed to flush: %w", err)
 		}
 	}
 
-	if p.earliestRecordTime.IsZero() || rec.Timestamp.Before(p.earliestRecordTime) {
-		p.earliestRecordTime = rec.Timestamp
+	if err := p.builder.Append(tenant, stream, rec.Timestamp); err != nil {
+		return fmt.Errorf("failed to append stream: %w", err)
 	}
+	p.metrics.sizeEstimate.Set(float64(p.builder.GetEstimatedSize()))
+
 	if p.firstAppend.IsZero() {
 		p.firstAppend = now
 	}
@@ -302,14 +294,35 @@ func (p *processor) needsIdleFlush() bool {
 
 func (p *processor) flush(ctx context.Context, reason string) error {
 	defer func() {
-		// Reset the state to prepare for building the next data object.
-		p.earliestRecordTime = time.Time{}
+		// Reset the state to prepare for building the next data object. The
+		// reset runs on every outcome: success (obvious), ctx canceled (we're
+		// shutting down — state is no longer needed), and panic (the process
+		// is about to crash and Kafka will replay from the last committed
+		// offset).
 		p.firstAppend = time.Time{}
 		p.lastAppend = time.Time{}
-		clear(p.timePartitionedEstimates)
+		p.builder.Reset()
+		p.metrics.sizeEstimate.Set(0)
 	}()
-	p.metrics.timePartitionEstimate.Add(float64(len(p.timePartitionedEstimates)))
-	return p.flushCommitter.Flush(ctx, p.builder, reason, p.lastOffset, p.earliestRecordTime)
+
+	timeWindowedBuilders := p.builder.GetBuilders()
+	p.metrics.timePartitionEstimate.Add(float64(len(timeWindowedBuilders)))
+	err := p.flushCommitter.Flush(ctx, timeWindowedBuilders, reason, p.lastOffset)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) {
+		return err
+	}
+	if ctx.Err() != nil {
+		level.Info(p.logger).Log("msg", "flush returned a non-cancellation error while the context was canceled", "reason", reason, "err", err)
+		return ctx.Err()
+	}
+	// logsobj.Builder.Flush is not re-entrant: once it consumes the buffered
+	// state, a retry cannot reproduce the object. Any flushCommitter error
+	// that isn't a graceful shutdown therefore escalates to a panic so the
+	// process restarts and Kafka replays from the last committed offset.
+	panic(err)
 }
 
 func (p *processor) observeRecord(rec *kgo.Record, now time.Time) {

--- a/pkg/dataobj/consumer/processor.go
+++ b/pkg/dataobj/consumer/processor.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -229,21 +230,32 @@ func (p *processor) needsIdleFlush() bool {
 }
 
 func (p *processor) flush(ctx context.Context, reason string) error {
+	defer func() {
+		// Reset the state to prepare for building the next data object. The
+		// reset runs on every outcome: success (obvious), ctx canceled (we're
+		// shutting down — state is no longer needed), and panic (the process
+		// is about to crash and Kafka will replay from the last committed
+		// offset).
+		p.firstAppend = time.Time{}
+		p.lastAppend = time.Time{}
+		p.builder.Reset()
+		p.metrics.sizeEstimate.Set(0)
+	}()
+
 	timeWindowedBuilders := p.builder.GetBuilders()
 	p.metrics.timePartitionEstimate.Add(float64(len(timeWindowedBuilders)))
 	err := p.flushCommitter.Flush(ctx, timeWindowedBuilders, reason, p.lastOffset)
-	if err != nil {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) {
 		return err
 	}
-
-	// Reset the state to prepare for building the next data object.
-	// we only do it on success to keep the processor's state on errors for further retries
-	p.firstAppend = time.Time{}
-	p.lastAppend = time.Time{}
-	p.builder.Reset()
-	p.metrics.sizeEstimate.Set(0)
-
-	return nil
+	// logsobj.Builder.Flush is not re-entrant: once it consumes the buffered
+	// state, a retry cannot reproduce the object. Any flushCommitter error
+	// that isn't a graceful shutdown therefore escalates to a panic so the
+	// process restarts and Kafka replays from the last committed offset.
+	panic(err)
 }
 
 func (p *processor) observeRecord(rec *kgo.Record, now time.Time) {

--- a/pkg/dataobj/consumer/processor.go
+++ b/pkg/dataobj/consumer/processor.go
@@ -2,7 +2,6 @@ package consumer
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -14,7 +13,6 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
-	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/kafka"
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -22,22 +20,32 @@ import (
 
 // A builder allows mocking of [logsobj.Builder] in tests.
 type builder interface {
-	Append(tenant string, stream logproto.Stream) error
+	Append(tenant string, stream logproto.Stream, recTime time.Time) error
 	GetEstimatedSize() int
 	Flush() (*dataobj.Object, io.Closer, error)
 	TimeRanges() []multitenancy.TimeRange
+	EarliestRecordTime() time.Time
 	CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataobj.Object, io.Closer, error)
+	IsFull() bool
+}
+
+type builderGroup interface {
+	Append(tenant string, stream logproto.Stream, recTime time.Time) error
+	GetEstimatedSize() int
+	Reset()
+	GetBuilders() []builder
+	IsFull() bool
 }
 
 // A flushCommitter allows mocking of flushes in tests.
 type flushCommitter interface {
-	Flush(ctx context.Context, builder builder, reason string, offset int64, earliestRecordTime time.Time) error
+	Flush(ctx context.Context, builders []builder, reason string, offset int64) error
 }
 
 // A processor receives records and builds data objects from them.
 type processor struct {
 	*services.BasicService
-	builder        builder
+	builder        builderGroup
 	decoder        *kafka.Decoder
 	records        chan *kgo.Record
 	flushCommitter flushCommitter
@@ -69,20 +77,12 @@ type processor struct {
 	// idle timeout. It must be reset after each flush.
 	lastAppend time.Time
 
-	// earliestRecordTime tracks the timestamp of the earliest record appended
-	// to the data object builder. It is required for the metastore index.
-	earliestRecordTime time.Time
-
-	// timePartitionedEstimates counts how many data objects we would build
-	// per flush with 12 hour windows.
-	timePartitionedEstimates map[time.Time]struct{}
-
 	metrics *metrics
 	logger  log.Logger
 }
 
 func newProcessor(
-	builder builder,
+	builder builderGroup,
 	records chan *kgo.Record,
 	flushCommitter flushCommitter,
 	idleFlushTimeout time.Duration,
@@ -95,15 +95,14 @@ func newProcessor(
 		panic(err)
 	}
 	p := &processor{
-		builder:                  builder,
-		decoder:                  decoder,
-		records:                  records,
-		flushCommitter:           flushCommitter,
-		idleFlushTimeout:         idleFlushTimeout,
-		maxBuilderAge:            maxBuilderAge,
-		metrics:                  newMetrics(reg),
-		logger:                   logger,
-		timePartitionedEstimates: make(map[time.Time]struct{}),
+		builder:          builder,
+		decoder:          decoder,
+		records:          records,
+		flushCommitter:   flushCommitter,
+		idleFlushTimeout: idleFlushTimeout,
+		maxBuilderAge:    maxBuilderAge,
+		metrics:          newMetrics(reg),
+		logger:           logger,
 	}
 	p.BasicService = services.NewBasicService(p.starting, p.running, p.stopping)
 	return p
@@ -159,10 +158,6 @@ func (p *processor) processRecord(ctx context.Context, rec *kgo.Record) error {
 	now := time.Now()
 	p.observeRecord(rec, now)
 
-	// Find the 12 hour window.
-	window := rec.Timestamp.UTC().Truncate(12 * time.Hour)
-	p.timePartitionedEstimates[window] = struct{}{}
-
 	// Try to decode the stream in the record.
 	tenant := string(rec.Key)
 	stream, err := p.decoder.DecodeWithoutLabels(rec.Value)
@@ -177,21 +172,17 @@ func (p *processor) processRecord(ctx context.Context, rec *kgo.Record) error {
 		}
 	}
 
-	if err := p.builder.Append(tenant, stream); err != nil {
-		if !errors.Is(err, logsobj.ErrBuilderFull) {
-			return fmt.Errorf("failed to append stream: %w", err)
-		}
+	if p.builder.IsFull() {
 		if err := p.flush(ctx, flushReasonBuilderFull); err != nil {
-			return fmt.Errorf("failed to flush and commit: %w", err)
-		}
-		if err := p.builder.Append(tenant, stream); err != nil {
-			return fmt.Errorf("failed to append stream after flushing: %w", err)
+			return fmt.Errorf("failed to flush: %w", err)
 		}
 	}
 
-	if p.earliestRecordTime.IsZero() || rec.Timestamp.Before(p.earliestRecordTime) {
-		p.earliestRecordTime = rec.Timestamp
+	if err := p.builder.Append(tenant, stream, rec.Timestamp); err != nil {
+		return fmt.Errorf("failed to append stream: %w", err)
 	}
+	p.metrics.sizeEstimate.Set(float64(p.builder.GetEstimatedSize()))
+
 	if p.firstAppend.IsZero() {
 		p.firstAppend = now
 	}
@@ -238,15 +229,21 @@ func (p *processor) needsIdleFlush() bool {
 }
 
 func (p *processor) flush(ctx context.Context, reason string) error {
-	defer func() {
-		// Reset the state to prepare for building the next data object.
-		p.earliestRecordTime = time.Time{}
-		p.firstAppend = time.Time{}
-		p.lastAppend = time.Time{}
-		clear(p.timePartitionedEstimates)
-	}()
-	p.metrics.timePartitionEstimate.Add(float64(len(p.timePartitionedEstimates)))
-	return p.flushCommitter.Flush(ctx, p.builder, reason, p.lastOffset, p.earliestRecordTime)
+	timeWindowedBuilders := p.builder.GetBuilders()
+	p.metrics.timePartitionEstimate.Add(float64(len(timeWindowedBuilders)))
+	err := p.flushCommitter.Flush(ctx, timeWindowedBuilders, reason, p.lastOffset)
+	if err != nil {
+		return err
+	}
+
+	// Reset the state to prepare for building the next data object.
+	// we only do it on success to keep the processor's state on errors for further retries
+	p.firstAppend = time.Time{}
+	p.lastAppend = time.Time{}
+	p.builder.Reset()
+	p.metrics.sizeEstimate.Set(0)
+
+	return nil
 }
 
 func (p *processor) observeRecord(rec *kgo.Record, now time.Time) {

--- a/pkg/dataobj/consumer/processor_drain_test.go
+++ b/pkg/dataobj/consumer/processor_drain_test.go
@@ -21,10 +21,11 @@ func TestProcessor_Stopping_Drain(t *testing.T) {
 
 		reg := prometheus.NewRegistry()
 		builder := newTestBuilder(t, reg)
+		group := newMockBuilderGroup(builder)
 		fc := &mockFlushCommitter{}
 		ch := make(chan *kgo.Record, 10)
 
-		proc := newProcessor(builder, ch, fc, time.Hour, time.Hour, IngestModeInMemory, logger, reg)
+		proc := newProcessor(group, ch, fc, time.Hour, time.Hour, IngestModeInMemory, logger, reg)
 
 		err := proc.stopping(nil)
 		require.NoError(t, err)
@@ -37,6 +38,7 @@ func TestProcessor_Stopping_Drain(t *testing.T) {
 
 		reg := prometheus.NewRegistry()
 		builder := newTestBuilder(t, reg)
+		group := newMockBuilderGroup(builder)
 		fc := &mockFlushCommitter{}
 		ch := make(chan *kgo.Record, 10)
 
@@ -46,7 +48,7 @@ func TestProcessor_Stopping_Drain(t *testing.T) {
 			ch <- newTestRecord(t, "tenant1", now.Add(time.Duration(i)*time.Second))
 		}
 
-		proc := newProcessor(builder, ch, fc, time.Hour, time.Hour, IngestModeInMemory, logger, reg)
+		proc := newProcessor(group, ch, fc, time.Hour, time.Hour, IngestModeInMemory, logger, reg)
 
 		err := proc.stopping(nil)
 		require.NoError(t, err)

--- a/pkg/dataobj/consumer/processor_test.go
+++ b/pkg/dataobj/consumer/processor_test.go
@@ -3,6 +3,8 @@ package consumer
 import (
 	"context"
 	"errors"
+	"fmt"
+	"math"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -13,6 +15,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/scratch"
 
@@ -39,8 +42,9 @@ func TestProcessor_BuilderMaxAge(t *testing.T) {
 			ctx            = t.Context()
 			reg            = prometheus.NewRegistry()
 			builder        = newTestBuilder(t, reg)
+			group          = newMockBuilderGroup(builder)
 			flushCommitter = &mockFlushCommitter{}
-			proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, IngestModeKafka, log.NewNopLogger(), reg)
+			proc           = newProcessor(group, nil, flushCommitter, 5*time.Minute, 30*time.Minute, IngestModeKafka, log.NewNopLogger(), reg)
 		)
 
 		// Since no records have been pushed, the first append time should be zero,
@@ -88,8 +92,9 @@ func TestPartitionProcessor_IdleFlush(t *testing.T) {
 			ctx            = t.Context()
 			reg            = prometheus.NewRegistry()
 			builder        = newTestBuilder(t, reg)
+			group          = newMockBuilderGroup(builder)
 			flushCommitter = &mockFlushCommitter{}
-			proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, IngestModeKafka, log.NewNopLogger(), reg)
+			proc           = newProcessor(group, nil, flushCommitter, 5*time.Minute, 30*time.Minute, IngestModeKafka, log.NewNopLogger(), reg)
 		)
 
 		// The idle flush timeout has not been exceeded, no flush should occur.
@@ -133,8 +138,28 @@ func (f *failureFlusher) Flush(_ context.Context, _ builder, _ string) (string, 
 
 type failureFlushCommitter struct{}
 
-func (m *failureFlushCommitter) Flush(_ context.Context, _ builder, _ string, _ int64, _ time.Time) error {
+func (m *failureFlushCommitter) Flush(_ context.Context, _ []builder, _ string, _ int64) error {
 	return errors.New("mock error")
+}
+
+// canceledFlushCommitter mimics what the real flushCommitter returns on
+// graceful shutdown: a wrapped context.Canceled. The processor is expected to
+// return this error rather than panic.
+type canceledFlushCommitter struct{}
+
+func (m *canceledFlushCommitter) Flush(_ context.Context, _ []builder, _ string, _ int64) error {
+	return fmt.Errorf("failed to flush data object: %w", context.Canceled)
+}
+
+// transientErrFlushCommitter returns a non-context.Canceled error. It is used
+// to simulate the case where a transient error (e.g., a Kafka network blip)
+// surfaces from the flushCommitter's retry loop on its last attempt while the
+// context was canceled during the wait, so the returned error does not wrap
+// context.Canceled.
+type transientErrFlushCommitter struct{}
+
+func (m *transientErrFlushCommitter) Flush(_ context.Context, _ []builder, _ string, _ int64) error {
+	return errors.New("transient kafka error")
 }
 
 func TestPartitionProcessor_Flush(t *testing.T) {
@@ -144,8 +169,9 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 				ctx            = t.Context()
 				reg            = prometheus.NewRegistry()
 				builder        = newTestBuilder(t, reg)
+				group          = newMockBuilderGroup(builder)
 				flushCommitter = &mockFlushCommitter{}
-				proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, IngestModeKafka, log.NewNopLogger(), reg)
+				proc           = newProcessor(group, nil, flushCommitter, 5*time.Minute, 30*time.Minute, IngestModeKafka, log.NewNopLogger(), reg)
 			)
 
 			// No flush should have occurred.
@@ -165,60 +191,156 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 
 			// The following fields should be reset at the end of every flush.
 			require.True(t, proc.firstAppend.IsZero())
-			require.True(t, proc.earliestRecordTime.IsZero())
 			require.True(t, proc.lastAppend.IsZero())
 		})
 	})
 
-	t.Run("should fail", func(t *testing.T) {
+	t.Run("should panic on non-cancel flushCommitter error", func(t *testing.T) {
+		// logsobj.Builder.Flush is not re-entrant: once it consumes the
+		// buffered state, a retry cannot reproduce the object. Any
+		// flushCommitter error that isn't a graceful shutdown therefore
+		// escalates to a panic so the process restarts and Kafka replays
+		// from the last committed offset.
 		synctest.Test(t, func(t *testing.T) {
 			var (
 				ctx            = t.Context()
 				reg            = prometheus.NewRegistry()
 				builder        = newTestBuilder(t, reg)
+				group          = newMockBuilderGroup(builder)
 				flushCommitter = &failureFlushCommitter{}
-				proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, IngestModeKafka, log.NewNopLogger(), reg)
+				proc           = newProcessor(group, nil, flushCommitter, 5*time.Minute, 30*time.Minute, IngestModeKafka, log.NewNopLogger(), reg)
 			)
 
-			// Process a record containing some log lines. No flush should occur.
 			rec := newTestRecord(t, "tenant", time.Now())
 			require.NoError(t, proc.processRecord(ctx, rec))
-			require.Equal(t, time.Now(), proc.firstAppend)
-			require.Equal(t, time.Now(), proc.lastAppend)
-			require.Equal(t, rec.Offset, proc.lastOffset)
 
-			// Advance time and force a flush. This flush should fail.
 			time.Sleep(time.Second)
-			require.EqualError(t, proc.flush(ctx, "forced"), "mock error")
-
-			// Despite the failure, the following fields should still be reset.
-			require.True(t, proc.firstAppend.IsZero())
-			require.True(t, proc.earliestRecordTime.IsZero())
-			require.True(t, proc.lastAppend.IsZero())
+			require.PanicsWithError(t, "mock error", func() {
+				_ = proc.flush(ctx, "forced")
+			})
 		})
+	})
+
+	t.Run("should return on context canceled without panic", func(t *testing.T) {
+		// On graceful shutdown the flushCommitter surfaces a wrapped
+		// context.Canceled; the processor returns the error so the caller
+		// can exit cleanly and leave the offset uncommitted for Kafka
+		// replay on restart.
+		synctest.Test(t, func(t *testing.T) {
+			var (
+				ctx            = t.Context()
+				reg            = prometheus.NewRegistry()
+				builder        = newTestBuilder(t, reg)
+				group          = newMockBuilderGroup(builder)
+				flushCommitter = &canceledFlushCommitter{}
+				proc           = newProcessor(group, nil, flushCommitter, 5*time.Minute, 30*time.Minute, IngestModeKafka, log.NewNopLogger(), reg)
+			)
+
+			rec := newTestRecord(t, "tenant", time.Now())
+			require.NoError(t, proc.processRecord(ctx, rec))
+
+			time.Sleep(time.Second)
+			require.NotPanics(t, func() {
+				err := proc.flush(ctx, "forced")
+				require.ErrorIs(t, err, context.Canceled)
+			})
+		})
+	})
+
+	t.Run("should not panic when ctx is canceled but flushCommitter error does not wrap context.Canceled", func(t *testing.T) {
+		// The emitEvent/commit backoff loops in the real flushCommitter
+		// return the last retry attempt's error when the context is
+		// canceled. If the last attempt hit a transient error (e.g., a
+		// Kafka network blip) while the context was canceled during
+		// b.Wait(), the returned error does not wrap context.Canceled.
+		// The processor must still detect the shutdown via ctx.Err() and
+		// return cleanly rather than panic.
+		synctest.Test(t, func(t *testing.T) {
+			var (
+				rootCtx        = t.Context()
+				reg            = prometheus.NewRegistry()
+				builder        = newTestBuilder(t, reg)
+				group          = newMockBuilderGroup(builder)
+				flushCommitter = &transientErrFlushCommitter{}
+				proc           = newProcessor(group, nil, flushCommitter, 5*time.Minute, 30*time.Minute, IngestModeKafka, log.NewNopLogger(), reg)
+			)
+
+			rec := newTestRecord(t, "tenant", time.Now())
+			require.NoError(t, proc.processRecord(rootCtx, rec))
+
+			// Cancel the context before the flush to simulate a graceful
+			// shutdown that races with a transient error on the last
+			// retry attempt.
+			ctx, cancel := context.WithCancel(rootCtx)
+			cancel()
+
+			time.Sleep(time.Second)
+			require.NotPanics(t, func() {
+				err := proc.flush(ctx, "forced")
+				require.ErrorIs(t, err, context.Canceled)
+			})
+		})
+	})
+}
+
+func TestPartitionProcessor_FlushSplitsAcrossWindows(t *testing.T) {
+	// A record that carries entries from two distinct 12h TOC windows must
+	// result in two per-window builders being flushed in a single
+	// flushCommitter call.
+	synctest.Test(t, func(t *testing.T) {
+		factory, err := logsobj.NewBuilderFactory(testBuilderCfg, scratch.NewMemory(), logsobj.NewBuilderMetrics())
+		require.NoError(t, err)
+
+		var (
+			ctx            = t.Context()
+			reg            = prometheus.NewRegistry()
+			group          = NewTOCAlignedBuilderGroup(factory, math.MaxInt)
+			flushCommitter = &mockFlushCommitter{}
+			proc           = newProcessor(group, nil, flushCommitter, 5*time.Minute, 30*time.Minute, IngestModeKafka, log.NewNopLogger(), reg)
+		)
+
+		w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+		w2 := w1.Add(metastore.TOCWindowSize)
+		rec := newTestRecordWithEntries(t, "tenant", w1, []push.Entry{
+			{Timestamp: w1.Add(time.Minute), Line: "window-1"},
+			{Timestamp: w2.Add(time.Minute), Line: "window-2"},
+		})
+		require.NoError(t, proc.processRecord(ctx, rec))
+		require.Len(t, group.GetBuilders(), 2, "append must create one builder per TOC window")
+
+		require.NoError(t, proc.flush(ctx, "test"))
+		require.Equal(t, 1, flushCommitter.flushes, "flushCommitter is invoked once per flush()")
+		require.Equal(t, 2, flushCommitter.lastBuilderCount, "flushCommitter must receive one builder per window")
 	})
 }
 
 // newTestBuilder returns a new logsobj.Builder with registered metrics.
 func newTestBuilder(t *testing.T, reg prometheus.Registerer) *logsobj.Builder {
-	b, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory())
+	metrics := logsobj.NewBuilderMetrics()
+	require.NoError(t, metrics.Register(reg))
+	b, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory(), metrics)
 	require.NoError(t, err)
-	require.NoError(t, b.RegisterMetrics(reg))
 	return b
 }
 
 // newTestRecord returns a new record containing the stream.
 func newTestRecord(t *testing.T, tenant string, now time.Time) *kgo.Record {
+	return newTestRecordWithEntries(t, tenant, now, []push.Entry{{
+		Timestamp: now,
+		Line:      "baz",
+	}})
+}
+
+// newTestRecordWithEntries returns a new record whose stream has the given
+// entries. The record's Kafka timestamp is set to now.
+func newTestRecordWithEntries(t *testing.T, tenant string, now time.Time, entries []push.Entry) *kgo.Record {
 	rec := kgo.Record{
 		Key:       []byte(tenant),
 		Timestamp: now,
 	}
 	stream := logproto.Stream{
-		Labels: `{foo="bar"}`,
-		Entries: []push.Entry{{
-			Timestamp: now,
-			Line:      "baz",
-		}},
+		Labels:  `{foo="bar"}`,
+		Entries: entries,
 	}
 	var err error
 	rec.Value, err = stream.Marshal()

--- a/pkg/dataobj/consumer/processor_test.go
+++ b/pkg/dataobj/consumer/processor_test.go
@@ -3,6 +3,7 @@ package consumer
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/scratch"
 
@@ -39,8 +41,9 @@ func TestProcessor_BuilderMaxAge(t *testing.T) {
 			ctx            = t.Context()
 			reg            = prometheus.NewRegistry()
 			builder        = newTestBuilder(t, reg)
+			group          = newMockBuilderGroup(builder)
 			flushCommitter = &mockFlushCommitter{}
-			proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+			proc           = newProcessor(group, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 		)
 
 		// Since no records have been pushed, the first append time should be zero,
@@ -88,8 +91,9 @@ func TestPartitionProcessor_IdleFlush(t *testing.T) {
 			ctx            = t.Context()
 			reg            = prometheus.NewRegistry()
 			builder        = newTestBuilder(t, reg)
+			group          = newMockBuilderGroup(builder)
 			flushCommitter = &mockFlushCommitter{}
-			proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+			proc           = newProcessor(group, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 		)
 
 		// The idle flush timeout has not been exceeded, no flush should occur.
@@ -133,7 +137,7 @@ func (f *failureFlusher) Flush(_ context.Context, _ builder, _ string) (string, 
 
 type failureFlushCommitter struct{}
 
-func (m *failureFlushCommitter) Flush(_ context.Context, _ builder, _ string, _ int64, _ time.Time) error {
+func (m *failureFlushCommitter) Flush(_ context.Context, _ []builder, _ string, _ int64) error {
 	return errors.New("mock error")
 }
 
@@ -144,8 +148,9 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 				ctx            = t.Context()
 				reg            = prometheus.NewRegistry()
 				builder        = newTestBuilder(t, reg)
+				group          = newMockBuilderGroup(builder)
 				flushCommitter = &mockFlushCommitter{}
-				proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+				proc           = newProcessor(group, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 			)
 
 			// No flush should have occurred.
@@ -165,7 +170,6 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 
 			// The following fields should be reset at the end of every flush.
 			require.True(t, proc.firstAppend.IsZero())
-			require.True(t, proc.earliestRecordTime.IsZero())
 			require.True(t, proc.lastAppend.IsZero())
 		})
 	})
@@ -176,8 +180,9 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 				ctx            = t.Context()
 				reg            = prometheus.NewRegistry()
 				builder        = newTestBuilder(t, reg)
+				group          = newMockBuilderGroup(builder)
 				flushCommitter = &failureFlushCommitter{}
-				proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+				proc           = newProcessor(group, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 			)
 
 			// Process a record containing some log lines. No flush should occur.
@@ -186,39 +191,80 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 			require.Equal(t, time.Now(), proc.firstAppend)
 			require.Equal(t, time.Now(), proc.lastAppend)
 			require.Equal(t, rec.Offset, proc.lastOffset)
+			wantFirstAppend := proc.firstAppend
+			wantLastAppend := proc.lastAppend
+			wantLastOffset := proc.lastOffset
 
 			// Advance time and force a flush. This flush should fail.
 			time.Sleep(time.Second)
 			require.EqualError(t, proc.flush(ctx, "forced"), "mock error")
 
-			// Despite the failure, the following fields should still be reset.
-			require.True(t, proc.firstAppend.IsZero())
-			require.True(t, proc.earliestRecordTime.IsZero())
-			require.True(t, proc.lastAppend.IsZero())
+			// Despite the failure, the following fields should remain
+			require.Equal(t, wantFirstAppend, proc.firstAppend)
+			require.Equal(t, wantLastAppend, proc.lastAppend)
+			require.Equal(t, wantLastOffset, proc.lastOffset)
 		})
+	})
+}
+
+func TestPartitionProcessor_FlushSplitsAcrossWindows(t *testing.T) {
+	// A record that carries entries from two distinct 12h TOC windows must
+	// result in two per-window builders being flushed in a single
+	// flushCommitter call.
+	synctest.Test(t, func(t *testing.T) {
+		factory, err := logsobj.NewBuilderFactory(testBuilderCfg, scratch.NewMemory(), logsobj.NewBuilderMetrics())
+		require.NoError(t, err)
+
+		var (
+			ctx            = t.Context()
+			reg            = prometheus.NewRegistry()
+			group          = NewTOCAlignedBuilderGroup(factory, math.MaxInt)
+			flushCommitter = &mockFlushCommitter{}
+			proc           = newProcessor(group, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+		)
+
+		w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+		w2 := w1.Add(metastore.TOCWindowSize)
+		rec := newTestRecordWithEntries(t, "tenant", w1, []push.Entry{
+			{Timestamp: w1.Add(time.Minute), Line: "window-1"},
+			{Timestamp: w2.Add(time.Minute), Line: "window-2"},
+		})
+		require.NoError(t, proc.processRecord(ctx, rec))
+		require.Len(t, group.GetBuilders(), 2, "append must create one builder per TOC window")
+
+		require.NoError(t, proc.flush(ctx, "test"))
+		require.Equal(t, 1, flushCommitter.flushes, "flushCommitter is invoked once per flush()")
+		require.Equal(t, 2, flushCommitter.lastBuilderCount, "flushCommitter must receive one builder per window")
 	})
 }
 
 // newTestBuilder returns a new logsobj.Builder with registered metrics.
 func newTestBuilder(t *testing.T, reg prometheus.Registerer) *logsobj.Builder {
-	b, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory())
+	metrics := logsobj.NewBuilderMetrics()
+	require.NoError(t, metrics.Register(reg))
+	b, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory(), metrics)
 	require.NoError(t, err)
-	require.NoError(t, b.RegisterMetrics(reg))
 	return b
 }
 
 // newTestRecord returns a new record containing the stream.
 func newTestRecord(t *testing.T, tenant string, now time.Time) *kgo.Record {
+	return newTestRecordWithEntries(t, tenant, now, []push.Entry{{
+		Timestamp: now,
+		Line:      "baz",
+	}})
+}
+
+// newTestRecordWithEntries returns a new record whose stream has the given
+// entries. The record's Kafka timestamp is set to now.
+func newTestRecordWithEntries(t *testing.T, tenant string, now time.Time, entries []push.Entry) *kgo.Record {
 	rec := kgo.Record{
 		Key:       []byte(tenant),
 		Timestamp: now,
 	}
 	stream := logproto.Stream{
-		Labels: `{foo="bar"}`,
-		Entries: []push.Entry{{
-			Timestamp: now,
-			Line:      "baz",
-		}},
+		Labels:  `{foo="bar"}`,
+		Entries: entries,
 	}
 	var err error
 	rec.Value, err = stream.Marshal()

--- a/pkg/dataobj/consumer/processor_test.go
+++ b/pkg/dataobj/consumer/processor_test.go
@@ -3,6 +3,7 @@ package consumer
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"testing"
 	"testing/synctest"
@@ -141,6 +142,15 @@ func (m *failureFlushCommitter) Flush(_ context.Context, _ []builder, _ string, 
 	return errors.New("mock error")
 }
 
+// canceledFlushCommitter mimics what the real flushCommitter returns on
+// graceful shutdown: a wrapped context.Canceled. The processor is expected to
+// return this error rather than panic.
+type canceledFlushCommitter struct{}
+
+func (m *canceledFlushCommitter) Flush(_ context.Context, _ []builder, _ string, _ int64) error {
+	return fmt.Errorf("failed to flush data object: %w", context.Canceled)
+}
+
 func TestPartitionProcessor_Flush(t *testing.T) {
 	t.Run("should succeed", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
@@ -174,7 +184,12 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 		})
 	})
 
-	t.Run("should fail", func(t *testing.T) {
+	t.Run("should panic on non-cancel flushCommitter error", func(t *testing.T) {
+		// logsobj.Builder.Flush is not re-entrant: once it consumes the
+		// buffered state, a retry cannot reproduce the object. Any
+		// flushCommitter error that isn't a graceful shutdown therefore
+		// escalates to a panic so the process restarts and Kafka replays
+		// from the last committed offset.
 		synctest.Test(t, func(t *testing.T) {
 			var (
 				ctx            = t.Context()
@@ -185,24 +200,39 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 				proc           = newProcessor(group, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 			)
 
-			// Process a record containing some log lines. No flush should occur.
 			rec := newTestRecord(t, "tenant", time.Now())
 			require.NoError(t, proc.processRecord(ctx, rec))
-			require.Equal(t, time.Now(), proc.firstAppend)
-			require.Equal(t, time.Now(), proc.lastAppend)
-			require.Equal(t, rec.Offset, proc.lastOffset)
-			wantFirstAppend := proc.firstAppend
-			wantLastAppend := proc.lastAppend
-			wantLastOffset := proc.lastOffset
 
-			// Advance time and force a flush. This flush should fail.
 			time.Sleep(time.Second)
-			require.EqualError(t, proc.flush(ctx, "forced"), "mock error")
+			require.PanicsWithError(t, "mock error", func() {
+				_ = proc.flush(ctx, "forced")
+			})
+		})
+	})
 
-			// Despite the failure, the following fields should remain
-			require.Equal(t, wantFirstAppend, proc.firstAppend)
-			require.Equal(t, wantLastAppend, proc.lastAppend)
-			require.Equal(t, wantLastOffset, proc.lastOffset)
+	t.Run("should return on context canceled without panic", func(t *testing.T) {
+		// On graceful shutdown the flushCommitter surfaces a wrapped
+		// context.Canceled; the processor returns the error so the caller
+		// can exit cleanly and leave the offset uncommitted for Kafka
+		// replay on restart.
+		synctest.Test(t, func(t *testing.T) {
+			var (
+				ctx            = t.Context()
+				reg            = prometheus.NewRegistry()
+				builder        = newTestBuilder(t, reg)
+				group          = newMockBuilderGroup(builder)
+				flushCommitter = &canceledFlushCommitter{}
+				proc           = newProcessor(group, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+			)
+
+			rec := newTestRecord(t, "tenant", time.Now())
+			require.NoError(t, proc.processRecord(ctx, rec))
+
+			time.Sleep(time.Second)
+			require.NotPanics(t, func() {
+				err := proc.flush(ctx, "forced")
+				require.ErrorIs(t, err, context.Canceled)
+			})
 		})
 	})
 }

--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -173,7 +173,18 @@ func NewInMemory(cfg Config, mCfg metastore.Config, bucket objstore.Bucket, scra
 	if err := uploader.RegisterMetrics(reg); err != nil {
 		level.Error(logger).Log("msg", "failed to register uploader metrics", "err", err)
 	}
-	builderFactory := logsobj.NewBuilderFactory(cfg.BuilderConfig, scratchStore)
+
+	builderMetrics := logsobj.NewBuilderMetrics()
+	wrapped := prometheus.WrapRegistererWith(prometheus.Labels{
+		"partition": strconv.Itoa(int(partitionID)),
+	}, reg)
+	if err := builderMetrics.Register(wrapped); err != nil {
+		return nil, fmt.Errorf("failed to register logsobj builder metrics: %w", err)
+	}
+	builderFactory, err := logsobj.NewBuilderFactory(cfg.BuilderConfig, scratchStore, builderMetrics)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create logsobj builder factory: %w", err)
+	}
 	sorter := logsobj.NewSorter(builderFactory, reg)
 	s.flusher = newFlusher(sorter, uploader, logger, reg)
 
@@ -214,14 +225,6 @@ func NewInMemory(cfg Config, mCfg metastore.Config, bucket objstore.Bucket, scra
 		logger:          logger,
 	}
 
-	wrapped := prometheus.WrapRegistererWith(prometheus.Labels{
-		"partition": strconv.Itoa(int(partitionID)),
-	}, reg)
-	builder, err := builderFactory.NewBuilder(wrapped)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize data object builder: %w", err)
-	}
-
 	flushCommitter := newFlushCommitter(
 		wrappedFlusher,
 		noopMetastoreEventEmitter{},
@@ -231,7 +234,7 @@ func NewInMemory(cfg Config, mCfg metastore.Config, bucket objstore.Bucket, scra
 		wrapped,
 	)
 	s.processor = newProcessor(
-		builder,
+		NewTOCAlignedBuilderGroup(builderFactory, int(cfg.BuilderConfig.TargetObjectSize)),
 		recordsChan,
 		flushCommitter,
 		cfg.IdleFlushTimeout,
@@ -360,16 +363,22 @@ func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objsto
 	if err := uploader.RegisterMetrics(reg); err != nil {
 		level.Error(logger).Log("msg", "failed to register uploader metrics", "err", err)
 	}
-	builderFactory := logsobj.NewBuilderFactory(cfg.BuilderConfig, scratchStore)
-	sorter := logsobj.NewSorter(builderFactory, reg)
-	s.flusher = newFlusher(sorter, uploader, logger, reg)
+
+	builderMetrics := logsobj.NewBuilderMetrics()
 	wrapped := prometheus.WrapRegistererWith(prometheus.Labels{
 		"partition": strconv.Itoa(int(partitionID)),
 	}, reg)
-	builder, err := builderFactory.NewBuilder(wrapped)
+	err = builderMetrics.Register(wrapped)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize data object builder: %w", err)
+		return nil, fmt.Errorf("failed to register logsobj builder metrics: %w", err)
 	}
+	builderFactory, err := logsobj.NewBuilderFactory(cfg.BuilderConfig, scratchStore, builderMetrics)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create logsobj builder factory: %w", err)
+	}
+
+	sorter := logsobj.NewSorter(builderFactory, reg)
+	s.flusher = newFlusher(sorter, uploader, logger, reg)
 	flushCommitter := newFlushCommitter(
 		s.flusher,
 		newMetastoreEvents(partitionID, int32(mCfg.PartitionRatio), metastoreEvents),
@@ -379,7 +388,7 @@ func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objsto
 		wrapped,
 	)
 	s.processor = newProcessor(
-		builder,
+		NewTOCAlignedBuilderGroup(builderFactory, int(cfg.BuilderConfig.TargetObjectSize)),
 		records,
 		flushCommitter,
 		cfg.IdleFlushTimeout,

--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -148,16 +148,22 @@ func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objsto
 	if err := uploader.RegisterMetrics(reg); err != nil {
 		level.Error(logger).Log("msg", "failed to register uploader metrics", "err", err)
 	}
-	builderFactory := logsobj.NewBuilderFactory(cfg.BuilderConfig, scratchStore)
-	sorter := logsobj.NewSorter(builderFactory, reg)
-	s.flusher = newFlusher(sorter, uploader, logger, reg)
+
+	builderMetrics := logsobj.NewBuilderMetrics()
 	wrapped := prometheus.WrapRegistererWith(prometheus.Labels{
 		"partition": strconv.Itoa(int(partitionID)),
 	}, reg)
-	builder, err := builderFactory.NewBuilder(wrapped)
+	err = builderMetrics.Register(wrapped)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize data object builder: %w", err)
+		return nil, fmt.Errorf("failed to register logsobj builder metrics: %w", err)
 	}
+	builderFactory, err := logsobj.NewBuilderFactory(cfg.BuilderConfig, scratchStore, builderMetrics)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create logsobj builder factory: %w", err)
+	}
+
+	sorter := logsobj.NewSorter(builderFactory, reg)
+	s.flusher = newFlusher(sorter, uploader, logger, reg)
 	flushCommitter := newFlushCommitter(
 		s.flusher,
 		newMetastoreEvents(partitionID, int32(mCfg.PartitionRatio), metastoreEvents),
@@ -167,7 +173,7 @@ func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objsto
 		wrapped,
 	)
 	s.processor = newProcessor(
-		builder,
+		NewTOCAlignedBuilderGroup(builderFactory, int(cfg.BuilderConfig.TargetObjectSize)),
 		records,
 		flushCommitter,
 		cfg.IdleFlushTimeout,

--- a/pkg/dataobj/index/builder_test.go
+++ b/pkg/dataobj/index/builder_test.go
@@ -451,7 +451,7 @@ func buildLogObject(t *testing.T, app string, path string, bucket objstore.Bucke
 			SectionStripeMergeLimit: 2,
 		},
 		DataobjSortOrder: "stream-asc",
-	}, nil)
+	}, nil, logsobj.NewBuilderMetrics())
 	require.NoError(t, err)
 
 	for i := 0; i < 10; i++ {
@@ -459,7 +459,7 @@ func buildLogObject(t *testing.T, app string, path string, bucket objstore.Bucke
 			Labels:  fmt.Sprintf("{app=\"%s\",stream=\"%d\"}", app, i),
 			Entries: []logproto.Entry{{Timestamp: time.Now(), Line: fmt.Sprintf("line %d", i)}},
 		}
-		err = candidate.Append("tenant", stream)
+		err = candidate.Append("tenant", stream, time.Time{})
 		require.NoError(t, err)
 	}
 

--- a/pkg/dataobj/index/calculate_bench_test.go
+++ b/pkg/dataobj/index/calculate_bench_test.go
@@ -92,7 +92,7 @@ func buildBenchDataobj(tb testing.TB, tenants, streamsPerTenant, entriesPerStrea
 			BufferSize:              4 << 20,
 			SectionStripeMergeLimit: 2,
 		},
-	}, scratch.NewMemory())
+	}, scratch.NewMemory(), logsobj.NewBuilderMetrics())
 	require.NoError(tb, err)
 
 	// Deterministic so iteration-to-iteration variance is only from scheduling.
@@ -143,7 +143,7 @@ func buildBenchDataobj(tb testing.TB, tenants, streamsPerTenant, entriesPerStrea
 				}
 			}
 
-			require.NoError(tb, builder.Append(tenantID, logproto.Stream{Labels: lbls, Entries: entries}))
+			require.NoError(tb, builder.Append(tenantID, logproto.Stream{Labels: lbls, Entries: entries}, baseTime))
 		}
 	}
 

--- a/pkg/dataobj/index/calculate_test.go
+++ b/pkg/dataobj/index/calculate_test.go
@@ -46,7 +46,7 @@ func createTestLogObject(t *testing.T, tenants int) *dataobj.Object {
 			BufferSize:              2048 * 8,
 			SectionStripeMergeLimit: 2,
 		},
-	}, nil)
+	}, nil, logsobj.NewBuilderMetrics())
 	require.NoError(t, err)
 
 	// Add test streams with structured metadata
@@ -96,7 +96,7 @@ func createTestLogObject(t *testing.T, tenants int) *dataobj.Object {
 
 	for i := range tenants {
 		for _, stream := range testStreams {
-			err := builder.Append(fmt.Sprintf("tenant-%d", i), stream)
+			err := builder.Append(fmt.Sprintf("tenant-%d", i), stream, time.Time{})
 			require.NoError(t, err)
 		}
 	}

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -39,7 +39,11 @@ import (
 )
 
 const (
-	metastoreWindowSize = 12 * time.Hour
+	// TOCWindowSize is the UTC-aligned bucket size used by the metastore's
+	// Table-of-Contents files. Every object produced by the dataobj consumer
+	// is aligned to this window so that a single TOC file only ever references
+	// objects whose time ranges fall inside the same window.
+	TOCWindowSize = 12 * time.Hour
 
 	// TocPrefix is the prefix under which ToC files are stored in the object storage.
 	TocPrefix = "tocs/"
@@ -127,14 +131,14 @@ func tableOfContentsPath(window time.Time) string {
 }
 
 func iterTableOfContentsPaths(start, end time.Time) iter.Seq2[string, multitenancy.TimeRange] {
-	minTocWindow := start.Truncate(metastoreWindowSize).UTC()
-	maxTocWindow := end.Truncate(metastoreWindowSize).UTC()
+	minTocWindow := start.Truncate(TOCWindowSize).UTC()
+	maxTocWindow := end.Truncate(TOCWindowSize).UTC()
 
 	return func(yield func(t string, timeRange multitenancy.TimeRange) bool) {
-		for tocWindow := minTocWindow; !tocWindow.After(maxTocWindow); tocWindow = tocWindow.Add(metastoreWindowSize) {
+		for tocWindow := minTocWindow; !tocWindow.After(maxTocWindow); tocWindow = tocWindow.Add(TOCWindowSize) {
 			tocTimeRange := multitenancy.TimeRange{
 				MinTime: tocWindow,
-				MaxTime: tocWindow.Add(metastoreWindowSize),
+				MaxTime: tocWindow.Add(TOCWindowSize),
 			}
 			if !yield(tableOfContentsPath(tocWindow), tocTimeRange) {
 				return

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -41,7 +41,11 @@ import (
 )
 
 const (
-	metastoreWindowSize = 12 * time.Hour
+	// TOCWindowSize is the UTC-aligned bucket size used by the metastore's
+	// Table-of-Contents files. Every object produced by the dataobj consumer
+	// is aligned to this window so that a single TOC file only ever references
+	// objects whose time ranges fall inside the same window.
+	TOCWindowSize = 12 * time.Hour
 
 	// TocPrefix is the prefix under which ToC files are stored in the object storage.
 	TocPrefix = "tocs/"
@@ -129,14 +133,14 @@ func tableOfContentsPath(window time.Time) string {
 }
 
 func iterTableOfContentsPaths(start, end time.Time) iter.Seq2[string, multitenancy.TimeRange] {
-	minTocWindow := start.Truncate(metastoreWindowSize).UTC()
-	maxTocWindow := end.Truncate(metastoreWindowSize).UTC()
+	minTocWindow := start.Truncate(TOCWindowSize).UTC()
+	maxTocWindow := end.Truncate(TOCWindowSize).UTC()
 
 	return func(yield func(t string, timeRange multitenancy.TimeRange) bool) {
-		for tocWindow := minTocWindow; !tocWindow.After(maxTocWindow); tocWindow = tocWindow.Add(metastoreWindowSize) {
+		for tocWindow := minTocWindow; !tocWindow.After(maxTocWindow); tocWindow = tocWindow.Add(TOCWindowSize) {
 			tocTimeRange := multitenancy.TimeRange{
 				MinTime: tocWindow,
-				MaxTime: tocWindow.Add(metastoreWindowSize),
+				MaxTime: tocWindow.Add(TOCWindowSize),
 			}
 			if !yield(tableOfContentsPath(tocWindow), tocTimeRange) {
 				return

--- a/pkg/dataobj/metastore/object_test.go
+++ b/pkg/dataobj/metastore/object_test.go
@@ -75,7 +75,7 @@ type testDataBuilder struct {
 }
 
 func (b *testDataBuilder) addStreamAndFlush(tenant string, stream logproto.Stream) {
-	err := b.builder.Append(tenant, stream)
+	err := b.builder.Append(tenant, stream, time.Time{})
 	require.NoError(b.t, err)
 
 	timeRanges := b.builder.TimeRanges()
@@ -804,7 +804,7 @@ func newTestDataBuilder(t testing.TB) *testDataBuilder {
 			BufferSize:              1024 * 1024,      // 1MB
 			SectionStripeMergeLimit: 2,
 		},
-	}, nil)
+	}, nil, logsobj.NewBuilderMetrics())
 	require.NoError(t, err)
 
 	logger := log.NewLogfmtLogger(os.Stdout)

--- a/pkg/engine/internal/executor/dataobjscan_test.go
+++ b/pkg/engine/internal/executor/dataobjscan_test.go
@@ -341,11 +341,11 @@ func buildDataobj(t testing.TB, streams []logproto.Stream) *dataobj.Object {
 			SectionStripeMergeLimit: 2,
 		},
 		DataobjSortOrder: "timestamp-desc",
-	}, nil)
+	}, nil, logsobj.NewBuilderMetrics())
 	require.NoError(t, err)
 
 	for _, stream := range streams {
-		require.NoError(t, builder.Append("tenant", stream))
+		require.NoError(t, builder.Append("tenant", stream, time.Time{}))
 	}
 
 	obj, closer, err := builder.Flush()

--- a/pkg/engine/internal/util/objtest/objtest.go
+++ b/pkg/engine/internal/util/objtest/objtest.go
@@ -4,13 +4,13 @@ package objtest
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
@@ -59,7 +59,7 @@ func NewBuilder(t *testing.T) *Builder {
 
 	var builderConfig logsobj.BuilderConfig
 	builderConfig.RegisterFlagsWithPrefix("", flag.NewFlagSet("", flag.PanicOnError)) // Acquire defaults
-	logsBuilder, err := logsobj.NewBuilder(builderConfig, nil)
+	logsBuilder, err := logsobj.NewBuilder(builderConfig, nil, logsobj.NewBuilderMetrics())
 	require.NoError(t, err, "expected to be able to create logs builder")
 
 	indexWriterBucket := objstore.NewPrefixedBucket(bucket, "index/v0")
@@ -83,15 +83,11 @@ func NewBuilder(t *testing.T) *Builder {
 // Append appends the given streams to the builder.
 func (b *Builder) Append(ctx context.Context, streams ...logproto.Stream) {
 	for _, stream := range streams {
-		if err := b.logsBuilder.Append(Tenant, stream); err != nil && errors.Is(err, logsobj.ErrBuilderFull) {
+		if b.logsBuilder.IsFull() {
 			require.NoError(b.t, b.flush(ctx), "failed to flush logs builder")
-
-			// Try appending again after the flush.
-			require.NoError(b.t, b.logsBuilder.Append(Tenant, stream), "failed to append stream after flush")
-		} else if err != nil {
-			require.NoError(b.t, err, "failed to append stream")
 		}
 
+		require.NoError(b.t, b.logsBuilder.Append(Tenant, stream, time.Time{}), "failed to append stream")
 		b.dirty = true
 	}
 }

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -3,11 +3,11 @@ package bench
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -81,7 +81,7 @@ func NewDataObjStore(dir, tenant string) (*DataObjStore, error) {
 			BufferSize:              16 * 1024 * 1024,  // 16MB
 			SectionStripeMergeLimit: 2,
 		},
-	}, nil)
+	}, nil, logsobj.NewBuilderMetrics())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create builder: %w", err)
 	}
@@ -110,16 +110,12 @@ func NewDataObjStore(dir, tenant string) (*DataObjStore, error) {
 // Write implements Store
 func (s *DataObjStore) Write(_ context.Context, streams []logproto.Stream) error {
 	for _, stream := range streams {
-		if err := s.builder.Append(s.tenant, stream); errors.Is(err, logsobj.ErrBuilderFull) {
-			// If the builder is full, flush it and try again
+		if s.builder.IsFull() {
 			if err := s.flush(); err != nil {
 				return fmt.Errorf("failed to flush builder: %w", err)
 			}
-			// Try appending again
-			if err := s.builder.Append(s.tenant, stream); err != nil {
-				return fmt.Errorf("failed to append stream after flush: %w", err)
-			}
-		} else if err != nil {
+		}
+		if err := s.builder.Append(s.tenant, stream, time.Time{}); err != nil {
 			return fmt.Errorf("failed to append stream: %w", err)
 		}
 	}

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -3,11 +3,11 @@ package bench
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -82,7 +82,7 @@ func NewDataObjStore(dir, tenant string) (*DataObjStore, error) {
 			BufferSize:              16 * 1024 * 1024,  // 16MB
 			SectionStripeMergeLimit: 2,
 		},
-	}, nil)
+	}, nil, logsobj.NewBuilderMetrics())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create builder: %w", err)
 	}
@@ -111,16 +111,12 @@ func NewDataObjStore(dir, tenant string) (*DataObjStore, error) {
 // Write implements Store
 func (s *DataObjStore) Write(_ context.Context, streams []logproto.Stream) error {
 	for _, stream := range streams {
-		if err := s.builder.Append(s.tenant, stream); errors.Is(err, logsobj.ErrBuilderFull) {
-			// If the builder is full, flush it and try again
+		if s.builder.IsFull() {
 			if err := s.flush(); err != nil {
 				return fmt.Errorf("failed to flush builder: %w", err)
 			}
-			// Try appending again
-			if err := s.builder.Append(s.tenant, stream); err != nil {
-				return fmt.Errorf("failed to append stream after flush: %w", err)
-			}
-		} else if err != nil {
+		}
+		if err := s.builder.Append(s.tenant, stream, time.Time{}); err != nil {
 			return fmt.Errorf("failed to append stream: %w", err)
 		}
 	}

--- a/tools/dataobj-sort/main.go
+++ b/tools/dataobj-sort/main.go
@@ -53,7 +53,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	b, err := logsobj.NewBuilder(cfg, scr)
+	b, err := logsobj.NewBuilder(cfg, scr, logsobj.NewBuilderMetrics())
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

TOC-aligned data objects                                                                                                                                                           
                                                             
**Before:** a single logsobj.Builder per partition buffered entries from any time window, flushing them into one mixed data object that often spanned multiple TOC windows.

https://github.com/user-attachments/assets/126814ea-5448-4288-ae07-4a1e359d869a
                                                                                         
**After:** TOCAlignedBuilderGroup maintains one logsobj.Builder per 12h UTC window (metastore.TOCWindowSize), created on demand when the first matching entry arrives. The processor  checks `builder.IsFull()` (sum of sizes across windows) before appending; on flush each per-window builder produces its own data object and metastore event, so every object's time range fits within a single TOC window. 

https://github.com/user-attachments/assets/ea2c8e4d-5597-4133-87a1-0b9a567e5390
                                                                  
**Why:** aligning data objects to TOC windows bounds each object's time range, simplifies metastore indexing, and caps memory at roughly TargetObjectSize per partition regardless of how many windows the incoming traffic spans. 


### Extra things to note
- I had to change the way builder metrics are instantiated / reported. Previously a builder would create an instance of its own metrics and register them. Instead, I create the metrics object once, register it once, and pass down to NewBuilder from the factory (this is done to avoid errors on re-registering the same metrics).
- Given that the builders are created dynamically I moved the config validation to the factory constructor (there're no benefits of revalidating the config on every builder instantiation)
- I do not pool builders for reuse, not sure how much overhead it's going to add.
- I replaces "try-append -> flush -> append"  logic with "is-full? -> flush -> append". The reason is that it became tricky to "try-append" given there are multiple builders to "try".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the dataobj consumer’s core buffering/flush/commit pipeline (now multi-builder per partition) and alters failure handling to panic-and-replay on non-cancel errors, which can affect ingestion reliability and duplicate/object orphan behavior.
> 
> **Overview**
> **Aligns data objects to metastore TOC windows.** The consumer now buffers records into a `TOCAlignedBuilderGroup` with one `logsobj.Builder` per 12h `metastore.TOCWindowSize`, splitting mixed-window streams on append and flushing each window builder into its own object/event while keeping the *total* buffered size bounded to the partition target.
> 
> **Reworks flush/commit semantics and error handling.** `flushCommitter.Flush` now processes a slice of builders (emit event per object, then commit a single Kafka offset), and `processor.flush` resets state via `defer` and escalates non-shutdown flush failures to a panic to rely on crash-and-replay because `Builder.Flush` is non-reentrant.
> 
> **Refactors `logsobj` builder APIs/metrics.** `Builder.Append` now takes `recTime`, removes `ErrBuilderFull` in favor of `IsFull()`, tracks `EarliestRecordTime` for metastore events, and builder metrics are created/registered once in `BuilderFactory` (with a separate sorter builder metrics instance) and wired through `service.go`; tests and tooling are updated accordingly, and `TOCWindowSize` is exported in metastore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8429940defed514ae8ce10f650c39404dc58a14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->