### PR TITLE
docs: Remove BigTable from storage docs

### DIFF
--- a/docs/sources/configure/storage.md
+++ b/docs/sources/configure/storage.md
@@ -99,14 +99,6 @@ Cassandra can also be utilized for the index store and aside from the [boltdb-sh
 This storage type for indexes is deprecated and may be removed in future major versions of Loki.
 {{< /admonition >}}
 
-### BigTable (deprecated)
-
-Bigtable is a cloud database offered by Google. It is a good candidate for a managed index store if you're already using it (due to its heavy fixed costs) or wish to run in GCP.
-
-{{< admonition type="note" >}}
-This storage type for indexes is deprecated and may be removed in future major versions of Loki.
-{{< /admonition >}}
-
 ### DynamoDB (deprecated)
 
 DynamoDB is a cloud database offered by AWS. It is a good candidate for a managed index store, especially if you're already running in AWS.


### PR DESCRIPTION
This has been forgotten in #21502

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that removes an outdated storage option; no runtime or configuration logic is modified.
> 
> **Overview**
> Removes the deprecated `Bigtable` index storage option from `docs/sources/configure/storage.md`, leaving Cassandra and DynamoDB as the remaining documented legacy index-store backends in that section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f78e7053ef635aaaab557543087bba840f5b386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->