### PR TITLE
docs: clarify storage guide wording

### DIFF
--- a/docs/sources/configure/storage.md
+++ b/docs/sources/configure/storage.md
@@ -331,7 +331,7 @@ The role should have a policy with the following permissions attached.
 }
 ```
 
-**To setup an S3 bucket and an IAM role and policy:**
+**To set up an S3 bucket and an IAM role and policy:**
 
 This guide assumes a provisioned EKS cluster.
 


### PR DESCRIPTION
Small docs-only cleanup to make the storage guide wording read more naturally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only wording change with no impact on runtime behavior or configuration semantics.
> 
> **Overview**
> Updates `docs/sources/configure/storage.md` to fix a minor grammar issue in the AWS S3 setup instructions ("setup"  "set up").
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18e2fa5a34fa25953c5920e6da6b4ad1511b1e44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->