### PR TITLE
docs: clarify meta monitoring wording

### DIFF
--- a/docs/sources/operations/meta-monitoring/mixins.md
+++ b/docs/sources/operations/meta-monitoring/mixins.md
@@ -13,7 +13,7 @@ To set up monitoring using the mixin, you need to:
 1. Deploy the Kubernetes Monitoring Helm chart. Follow the instructions in the [Deploy Loki Meta-monitoring](https://grafana.com/docs/loki/latest/operations/meta-monitoring/deploy) documentation.
 1. Be actively storing metrics from your Loki cluster in Grafana Cloud or a separate LGTM stack.
 
-This procedure assumes that you have set up Loki using the Helm chart.
+This procedure assumes that you have already set up Loki using the Helm chart.
 
 {{< admonition type="note" >}}
 Be sure to update the commands and configuration to match your own deployment.


### PR DESCRIPTION
Small docs-only wording cleanup in the meta-monitoring mixins guide.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no impact on runtime behavior or configuration.
> 
> **Overview**
> Clarifies wording in the meta-monitoring mixins guide by updating the prerequisite statement to explicitly say Loki must be *already* set up via the Helm chart before following the procedure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a9575db69713d2e88c05c2791a80c6fb4518d9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->