### PR TITLE
docs: clarify recording rules wording

### DIFF
--- a/docs/sources/operations/meta-monitoring/mixins.md
+++ b/docs/sources/operations/meta-monitoring/mixins.md
@@ -13,7 +13,7 @@ To set up monitoring using the mixin, you need to:
 1. Deploy the Kubernetes Monitoring Helm chart. Follow the instructions in the [Deploy Loki Meta-monitoring](https://grafana.com/docs/loki/latest/operations/meta-monitoring/deploy) documentation.
 1. Be actively storing metrics from your Loki cluster in Grafana Cloud or a separate LGTM stack.
 
-This procedure assumes that you have set up Loki using the Helm chart.
+This procedure assumes that you have already set up Loki using the Helm chart.
 
 {{< admonition type="note" >}}
 Be sure to update the commands and configuration to match your own deployment.

--- a/docs/sources/operations/recording-rules.md
+++ b/docs/sources/operations/recording-rules.md
@@ -1,7 +1,7 @@
 ---
 title: Manage recording rules
 menuTitle: Recording rules
-description: Describes how to setup and use recording rules in Grafana Loki.
+description: Describes how to set up and use recording rules in Grafana Loki.
 weight:  
 ---
 # Manage recording rules
@@ -33,7 +33,7 @@ on disk and are loaded into memory.
 
 {{< admonition type="note" >}}
 WALs are loaded one at a time upon start-up. This is a current limitation of the Loki ruler.
-For this reason, it is adviseable that the number of rule groups serviced by a ruler be kept to a reasonable size, since
+For this reason, it is advisable that the number of rule groups serviced by a ruler be kept to a reasonable size, since
 _no rule evaluation occurs while WAL replay is in progress (this includes alerting rules)_.
 {{< /admonition >}}
 
@@ -171,4 +171,3 @@ the `loki_ruler_wal_corruptions_repair_failed_total` metric will be incremented.
 ### Found another failure mode?
 
 Open an [issue](https://github.com/grafana/loki/issues) and tell us about it!
-


### PR DESCRIPTION
Small docs-only wording cleanup in the recording rules guide. This fixes the description wording and a typo in the start-up guidance without changing any technical behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only copy edits with no code or behavioral changes.
> 
> **Overview**
> Clarifies wording in the meta-monitoring mixin setup guide by making the Helm-chart prerequisite explicit.
> 
> Cleans up the recording rules documentation by fixing the front-matter description grammar, correcting a typo in the WAL start-up note ("adviseable" → "advisable"), and removing a stray trailing blank line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce916a869f090fdeaa2d0b1dfe469de8b210e8e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->