### PR TITLE
docs: clarify caching section wording

### DIFF
--- a/docs/sources/operations/caching.md
+++ b/docs/sources/operations/caching.md
@@ -10,7 +10,7 @@ keywords:
 # Configure caches to speed up queries
 
 Loki supports two types of caching for query results and chunks to speed up query performance and reduce calls to the storage layer. Memcached is included in the Loki Helm chart and enabled by default for the `chunksCache` and `resultsCache`.
-This sections describes the recommended Memcached configuration to enable caching for chunks and query results.
+This section describes the recommended Memcached configuration to enable caching for chunks and query results.
 
 #### Results cache
 The results cache stores the results for index-stat, instant-metric, label and volume queries and it supports negative caching for log queries. It is sometimes called frontend cache in some configurations. For details of each supported request type, refer to the [Components section](https://grafana.com/docs/loki/<LOKI_VERSION>//get-started/components).

--- a/docs/sources/operations/loki-ui/_index.md
+++ b/docs/sources/operations/loki-ui/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Loki deployment user interface
 menuTitle: Loki UI
-description: Describes how to setup and use the Loki Deployment UI.
+description: Describes how to set up and use the Loki Deployment UI.
 draft: true
 weight: 100
 ---
@@ -30,7 +30,7 @@ Each Loki component now includes the UI service.
 
 When running Loki as a docker container, the UI service is enabled by default. No additional configuration is required. 
 
-For Loki Helm users discoverability of the UI service needs to be enabled in the Loki configuration. To enable the UI discoverability, add the following paramter to the `loki` section of the `values.yaml` file:
+For Loki Helm users, discovery of the UI service needs to be enabled in the Loki configuration. To enable UI discovery, add the following parameter to the `loki` section of the `values.yaml` file:
 
 ```yaml
 loki:

--- a/docs/sources/operations/meta-monitoring/mixins.md
+++ b/docs/sources/operations/meta-monitoring/mixins.md
@@ -13,7 +13,7 @@ To set up monitoring using the mixin, you need to:
 1. Deploy the Kubernetes Monitoring Helm chart. Follow the instructions in the [Deploy Loki Meta-monitoring](https://grafana.com/docs/loki/latest/operations/meta-monitoring/deploy) documentation.
 1. Be actively storing metrics from your Loki cluster in Grafana Cloud or a separate LGTM stack.
 
-This procedure assumes that you have set up Loki using the Helm chart.
+This procedure assumes that you have already set up Loki using the Helm chart.
 
 {{< admonition type="note" >}}
 Be sure to update the commands and configuration to match your own deployment.

--- a/docs/sources/operations/recording-rules.md
+++ b/docs/sources/operations/recording-rules.md
@@ -1,7 +1,7 @@
 ---
 title: Manage recording rules
 menuTitle: Recording rules
-description: Describes how to setup and use recording rules in Grafana Loki.
+description: Describes how to set up and use recording rules in Grafana Loki.
 weight:  
 ---
 # Manage recording rules
@@ -33,7 +33,7 @@ on disk and are loaded into memory.
 
 {{< admonition type="note" >}}
 WALs are loaded one at a time upon start-up. This is a current limitation of the Loki ruler.
-For this reason, it is adviseable that the number of rule groups serviced by a ruler be kept to a reasonable size, since
+For this reason, it is advisable that the number of rule groups serviced by a ruler be kept to a reasonable size, since
 _no rule evaluation occurs while WAL replay is in progress (this includes alerting rules)_.
 {{< /admonition >}}
 
@@ -171,4 +171,3 @@ the `loki_ruler_wal_corruptions_repair_failed_total` metric will be incremented.
 ### Found another failure mode?
 
 Open an [issue](https://github.com/grafana/loki/issues) and tell us about it!
-


### PR DESCRIPTION
Small docs-only cleanup in the caching guide. This fixes the section wording so the page reads more naturally while keeping the technical guidance unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (typos/wording and markdown formatting) with no impact on runtime behavior.
> 
> **Overview**
> Tightens wording/grammar across several operations docs (caching, Loki UI, meta-monitoring mixins, and recording rules) without changing any technical guidance.
> 
> Fixes minor markdown formatting issues (e.g., code block/admonition closing and missing trailing newlines) to render correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab4999c17cf7b260c600c3dcbad597db773985cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->