### PR TITLE
chore: try running workers with a smaller buffer

### DIFF
--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -300,8 +300,8 @@ func (w *Worker) handleConn(ctx context.Context, conn wire.Conn) {
 		Metrics: w.wireMetrics,
 		Conn:    conn,
 
-		// Allow for a backlog of 128 frames before backpressure is applied.
-		Buffer: 128,
+		// Allow for a backlog of 8 frames before backpressure is applied.
+		Buffer: 8,
 
 		Handler: func(ctx context.Context, _ *wire.Peer, msg wire.Message) error {
 			switch msg := msg.(type) {


### PR DESCRIPTION
**What this PR does / why we need it**:

We've seen some OOMs with thousands of large messages; let's try a smaller buffer.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- NA Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime buffering/backpressure behavior on worker inbound connections, which can impact throughput/latency and expose new stalls under high load, but the code change is small and localized.
> 
> **Overview**
> Worker peer connections accepted in `handleConn` now use a much smaller `wire.Peer` frame buffer (from 128 down to 8), applying backpressure earlier when many large messages are in flight.
> 
> This is a targeted memory/throughput tuning change intended to reduce per-connection buffering and lower OOM likelihood under high fan-in/out workloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ffd813fea8c259b755ad5db1dc197c5398b5014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->