### PR TITLE
chore(dataset): Add dataset/array, dataset/buffer packages

### DIFF
--- a/pkg/dataset/array/array.go
+++ b/pkg/dataset/array/array.go
@@ -1,0 +1,49 @@
+// Package array defines the [Array], which is a structured set of values stored
+// in a dataset.
+package array
+
+import (
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+)
+
+// Array describes encoded data stored within a dataset. Arrays are trees
+// composed of buffers and other Arrays, where the entire tree forms a unit of
+// data that can be read.
+//
+// This hierarchy is used so Arrays map as closely as possible to in-memory
+// representation. For example, a nullable int64 array stores int64 data in its
+// Buffer, while using a child Array to store the validity of each row.
+//
+// The exact layout and meaning of buffers and children arrays is dependant on
+// the Array's [type.Type] and its [Encoding].
+type Array struct {
+	// Encoding describes how to interpret the data in Buffers.
+	Encoding Encoding
+
+	// Type holds the Array's logical type. Type must be compatible with the
+	// Array's encoding.
+	Type types.Type
+
+	// Buffers holds handles for retrieving the Array's data from a
+	// [buffer.Source].
+	Buffers []buffer.ID
+
+	// RowCount is the number of rows in the Array.
+	RowCount int
+
+	// Stats holds optional statistics for this array.
+	Stats Stats
+
+	// Children holds the child arrays. The Encoding and Type fields determine
+	// how to interpret children.
+	Children []Array
+}
+
+// Stats holds optional statistics for an [Array]. Child statistics are not
+// rolled up; read the Stats for individual children if needed.
+type Stats struct {
+	// TODO(rfratto): Other fields like MinValue, MaxValue, etc.
+
+	NullCount int // NullCount is the number of null values in the Array.
+}

--- a/pkg/dataset/array/codec.go
+++ b/pkg/dataset/array/codec.go
@@ -1,0 +1,91 @@
+package array
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// A Writer accumulates data into an [Array].
+type Writer interface {
+	// Append appends the data from arr to the Writer. Append returns an error
+	// if the data is invalid for the Writer.
+	//
+	// Implementations must not retain references to arr beyond the call to
+	// Append.
+	Append(arr columnar.Array) error
+
+	// Flush flushes buffered data and returns a new [Array] that represents the
+	// encoded data.
+	//
+	// After Flush is called, the Writer is reset and ready to accept new data.
+	Flush(ctx context.Context, sink buffer.Sink) (Array, error)
+}
+
+// NewWriter creates a [Writer] to build an Array.
+//
+// The provided alloc may used to allocate memory that is used across the entire
+// Writer's lifetime. Callers must ensure that the allocator is valid for the
+// entire lifetime of the Writer.
+//
+// NewWriter returns an error if spec is invalid, or if spec and typ are not
+// compatible.
+func NewWriter(alloc *memory.Allocator, spec Spec, typ types.Type) (Writer, error) {
+	switch spec.Kind() {
+	case EncodingKindBool:
+		return newBoolWriter(alloc, spec, typ)
+
+	default:
+		return nil, fmt.Errorf("unsupported encoding kind %q", spec.Kind())
+	}
+}
+
+// A Reader reads data for an [Array].
+type Reader interface {
+	// Read returns array data of up to the next count values. At the end of the
+	// data, Read returns nil, io.EOF.
+	//
+	// If there was an error reading the page, Read returns the error with
+	// no array.
+	//
+	// Implementations may use the provided allocator to allocate memory for the
+	// returned data, but are not required to (such as when the data is already
+	// cached in memory).
+	//
+	// Callers must assume that the returned [columnar.Array] lives for at least
+	// as long as alloc and no longer than the lifetime of the Reader.
+	Read(ctx context.Context, alloc *memory.Allocator, count int) (columnar.Array, error)
+
+	// Reset rewinds the reader to before the first row, allowing to re-read the
+	// data. Reset is safe to call at any point, including after EOF.
+	//
+	// Implementations may preserve internal caches (e.g., decoded data) across
+	// Reset; callers should not assume Reset frees buffers.
+	Reset()
+
+	// Close closes the Reader and releases any resources it holds.
+	Close() error
+}
+
+// NewReader creates a [Reader] for an Array. The provided source is used to
+// retrieve buffer data for the array.
+//
+// The provided alloc may used to allocate memory that is used across the entire
+// Reader's lifetime. Callers must ensure that the allocator is valid for the
+// entire lifetime of the Reader.
+//
+// NewReader returns an error if Array specifies an invalid encoding and type
+// pair.
+func NewReader(alloc *memory.Allocator, arr Array, source buffer.Source) (Reader, error) {
+	switch arr.Encoding.Kind() {
+	case EncodingKindBool:
+		return newBoolReader(alloc, arr, source)
+
+	default:
+		return nil, fmt.Errorf("unsupported encoding kind %q", arr.Encoding.Kind())
+	}
+}

--- a/pkg/dataset/array/codec_bool.go
+++ b/pkg/dataset/array/codec_bool.go
@@ -1,0 +1,252 @@
+package array
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+type boolWriter struct {
+	alloc *memory.Allocator
+	typ   *types.Bool
+
+	bmap     memory.Bitmap
+	validity Writer
+	nulls    int
+}
+
+func newBoolWriter(alloc *memory.Allocator, spec Spec, typ types.Type) (*boolWriter, error) {
+	if got, want := spec.Kind(), EncodingKindBool; got != want {
+		return nil, fmt.Errorf("expected spec kind %s, got %s", want, got)
+	} else if got, want := typ.Kind(), types.KindBool; got != want {
+		return nil, fmt.Errorf("expected type %s, got %s", want, got)
+	}
+
+	var (
+		boolTyp  = typ.(*types.Bool)
+		boolSpec = spec.(*SpecBool)
+	)
+
+	hasValidity := boolSpec.Validity != nil
+	if boolTyp.Nullable != hasValidity {
+		return nil, fmt.Errorf("expected %s to have validity %t, got %t", boolTyp, boolTyp.Nullable, hasValidity)
+	}
+
+	var validityWriter Writer
+	if hasValidity {
+		var err error
+		validityWriter, err = NewWriter(alloc, boolSpec.Validity, &types.Bool{Nullable: false})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &boolWriter{
+		alloc: alloc,
+		typ:   boolTyp,
+
+		bmap:     memory.NewBitmap(alloc, 0),
+		validity: validityWriter,
+	}, nil
+}
+
+func (w *boolWriter) Append(arr columnar.Array) error {
+	boolArr, ok := arr.(*columnar.Bool)
+	if !ok {
+		return fmt.Errorf("expected *columnar.Bool, got %T", arr)
+	}
+
+	values := boolArr.Values()
+
+	// Validate before any mutation so a failed Append leaves the writer's
+	// state unchanged.
+	if err := validateNulls(w.validity, boolArr, values.Len()); err != nil {
+		return err
+	}
+
+	nulls, err := appendNulls(w.alloc, w.validity, boolArr, values.Len())
+	if err != nil {
+		return err
+	}
+	w.nulls += nulls
+
+	w.bmap.AppendBitmap(values)
+	return nil
+}
+
+func (w *boolWriter) Flush(ctx context.Context, sink buffer.Sink) (Array, error) {
+	defer w.reset()
+
+	var children []Array
+	var validityArray Array
+	if validity := w.validity; validity != nil {
+		var err error
+		validityArray, err = validity.Flush(ctx, sink)
+		if err != nil {
+			return Array{}, fmt.Errorf("flushing validity writer: %w", err)
+		}
+
+		children = append(children, validityArray)
+	}
+
+	// We want to store the trimmed bytes, ignoring any padding.
+	data, _ := w.bmap.BytesTrimmed()
+	bufs, err := sink.WriteBuffers(ctx, []buffer.Data{data})
+	if err != nil {
+		return Array{}, fmt.Errorf("writing bool data to a buffer: %w", err)
+	}
+
+	return Array{
+		Encoding: &EncodingBool{},
+		Type:     w.typ,
+		Buffers:  bufs,
+		RowCount: w.bmap.Len(),
+		Stats: Stats{
+			NullCount: w.nulls,
+		},
+		Children: children,
+	}, nil
+}
+
+func (w *boolWriter) reset() {
+	w.bmap = memory.NewBitmap(w.alloc, 0)
+	w.nulls = 0
+}
+
+type boolReader struct {
+	alloc  *memory.Allocator
+	typ    *types.Bool
+	arr    Array
+	source buffer.Source
+
+	validity Reader
+
+	initialized bool
+	data        memory.Bitmap
+	off         int // Offset into data
+}
+
+func newBoolReader(alloc *memory.Allocator, arr Array, source buffer.Source) (*boolReader, error) {
+	if got, want := arr.Encoding.Kind(), EncodingKindBool; got != want {
+		return nil, fmt.Errorf("expected spec kind %s, got %s", want, got)
+	} else if got, want := arr.Type.Kind(), types.KindBool; got != want {
+		return nil, fmt.Errorf("expected type %s, got %s", want, got)
+	}
+
+	var (
+		boolTyp = arr.Type.(*types.Bool)
+	)
+
+	var validityReader Reader
+	switch {
+	case boolTyp.Nullable && len(arr.Children) == 0:
+		return nil, errors.New("nullable bool array must have a validity child array")
+	case boolTyp.Nullable && len(arr.Children) > 1:
+		return nil, fmt.Errorf("expected 1 child for nullable bool array, got %d", len(arr.Children))
+	case !boolTyp.Nullable && len(arr.Children) != 0:
+		return nil, fmt.Errorf("expected 0 children for non-nullable bool array, got %d", len(arr.Children))
+	}
+	if boolTyp.Nullable {
+		if got, want := arr.Children[0].RowCount, arr.RowCount; got != want {
+			return nil, fmt.Errorf("validity child has %d rows, expected %d to match parent", got, want)
+		}
+
+		var err error
+		validityReader, err = NewReader(alloc, arr.Children[0], source)
+		if err != nil {
+			return nil, fmt.Errorf("creating validity reader: %w", err)
+		}
+	}
+
+	if len(arr.Buffers) != 1 {
+		return nil, fmt.Errorf("expected 1 buffer, got %d", len(arr.Buffers))
+	}
+
+	return &boolReader{
+		alloc:  alloc,
+		typ:    boolTyp,
+		arr:    arr,
+		source: source,
+
+		validity: validityReader,
+	}, nil
+}
+
+func (r *boolReader) Read(ctx context.Context, alloc *memory.Allocator, count int) (columnar.Array, error) {
+	if count <= 0 {
+		return nil, fmt.Errorf("count must be positive, got %d", count)
+	}
+
+	if !r.initialized {
+		// We use the reader's allocator for initializing since the data
+		// persists across calls to Read.
+		if err := r.init(ctx, r.alloc); err != nil {
+			return nil, err
+		}
+		r.initialized = true
+	}
+
+	endOff := min(r.off+count, r.data.Len())
+	if endOff-r.off == 0 {
+		return nil, io.EOF
+	}
+	values := r.data.Slice(r.off, endOff)
+
+	// Read validity bytes now.
+	var validity memory.Bitmap
+	if r.validity != nil {
+		validityArr, err := r.validity.Read(ctx, alloc, count)
+		if err != nil {
+			return nil, fmt.Errorf("reading validity: %w", err)
+		}
+
+		validityBoolArr := validityArr.(*columnar.Bool)
+		validity = validityBoolArr.Values()
+	}
+
+	r.off += values.Len()
+	return columnar.NewBool(*values, validity), nil
+}
+
+func (r *boolReader) init(ctx context.Context, alloc *memory.Allocator) error {
+	data, err := r.source.ReadBuffers(ctx, alloc, r.arr.Buffers)
+	if err != nil {
+		return fmt.Errorf("fetching buffer data: %w", err)
+	}
+
+	// newBoolReader already checked that there's one buffer, and ReadBuffers
+	// must return the same number of buffers; data[0] is the only valid index.
+	r.data = memory.BitmapFrom(data[0], r.arr.RowCount, 0)
+	return nil
+}
+
+func (r *boolReader) Reset() {
+	r.resetSelf()
+
+	if r.validity != nil {
+		r.validity.Reset()
+	}
+}
+
+func (r *boolReader) resetSelf() {
+	// Reset the offset but keep everything else to allow for re-reading data.
+	r.off = 0
+}
+
+func (r *boolReader) Close() error {
+	r.resetSelf()
+
+	r.initialized = false
+	r.data = memory.Bitmap{}
+
+	if r.validity != nil {
+		return r.validity.Close()
+	}
+	return nil
+}

--- a/pkg/dataset/array/codec_bool_test.go
+++ b/pkg/dataset/array/codec_bool_test.go
@@ -1,0 +1,242 @@
+package array_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestBoolCodec_Validation(t *testing.T) {
+	tt := []struct {
+		name string
+		spec array.Spec
+		typ  types.Type
+
+		expectError bool
+	}{
+		{
+			name:        "accepts valid non-nullable bool",
+			spec:        &array.SpecBool{Validity: nil},
+			typ:         &types.Bool{Nullable: false},
+			expectError: false,
+		},
+		{
+			name:        "rejects non-nullable bool with validity spec",
+			spec:        &array.SpecBool{Validity: &array.SpecBool{}},
+			typ:         &types.Bool{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects nullable bool with no validity spec",
+			spec:        &array.SpecBool{Validity: nil},
+			typ:         &types.Bool{Nullable: true},
+			expectError: true,
+		},
+		{
+			name:        "accepts nullable bool with validity spec",
+			spec:        &array.SpecBool{Validity: &array.SpecBool{}},
+			typ:         &types.Bool{Nullable: true},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			var alloc memory.Allocator
+			_, err := array.NewWriter(&alloc, tc.spec, tc.typ)
+
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestBoolCodec_NonNullable(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecBool{Validity: nil}
+		typ  = &types.Bool{Nullable: false}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	input := []columnar.Array{
+		columnartest.Array(t, types.KindBool, &alloc, true, false, false, true, false),
+		columnartest.Array(t, types.KindBool, &alloc, false, true, false, false, true),
+	}
+	for _, arr := range input {
+		require.NoError(t, w.Append(arr))
+	}
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+	require.Equal(t, 10, result.RowCount)
+	require.Equal(t, 0, result.Stats.NullCount)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	expect := columnartest.Array(
+		t, types.KindBool, &alloc,
+		true, false, false, true, false,
+		false, true, false, false, true,
+	)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+
+	// Reading again should produce a EOF.
+	_, err = r.Read(t.Context(), &alloc, 1)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestBoolCodec_Nullable(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecBool{Validity: &array.SpecBool{}}
+		typ  = &types.Bool{Nullable: true}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	input := []columnar.Array{
+		columnartest.Array(t, types.KindBool, &alloc, true, nil, false, nil, false),
+		columnartest.Array(t, types.KindBool, &alloc, false, true, false, false, true),
+		columnartest.Array(t, types.KindBool, &alloc, nil),
+	}
+	for _, arr := range input {
+		require.NoError(t, w.Append(arr))
+	}
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+	require.Equal(t, 11, result.RowCount)
+	require.Equal(t, 3, result.Stats.NullCount)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	expect := columnartest.Array(
+		t, types.KindBool, &alloc,
+		true, nil, false, nil, false,
+		false, true, false, false, true,
+		nil,
+	)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+
+	// Reading again should produce a EOF.
+	_, err = r.Read(t.Context(), &alloc, 1)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func BenchmarkBoolCodec(b *testing.B) {
+	var (
+		store buffer.MemoryStore
+
+		spec = &array.SpecBool{Validity: nil}
+		typ  = &types.Bool{Nullable: false}
+	)
+
+	const values = 1 << 16
+
+	var arr array.Array
+	{
+		var alloc memory.Allocator
+
+		builder := columnar.NewBoolBuilder(&alloc)
+		builder.Grow(1_000_000)
+
+		for i := range values {
+			// Alternating bits of false/true
+			builder.AppendValue(i%2 == 0)
+		}
+
+		writer, err := array.NewWriter(&alloc, spec, typ)
+		require.NoError(b, err)
+
+		require.NoError(b, writer.Append(builder.Build()))
+		arr, err = writer.Flush(b.Context(), &store)
+		require.NoError(b, err)
+	}
+
+	batchSizes := []int{2048, 4096, 8192}
+
+	b.Run(fmt.Sprintf("rows=%d", values), func(b *testing.B) {
+		for _, batchSize := range batchSizes {
+			b.Run(fmt.Sprintf("batch_size=%d", batchSize), func(b *testing.B) {
+				var alloc memory.Allocator
+
+				var totalBytes int64
+				var totalRows int64
+
+				for b.Loop() {
+					alloc.Reset()
+
+					r, _ := array.NewReader(&alloc, arr, &store)
+					for {
+						arr, err := r.Read(b.Context(), &alloc, batchSize)
+						if arr != nil {
+							totalBytes += int64(arr.Size())
+							totalRows += int64(arr.Len())
+						}
+
+						if err != nil && errors.Is(err, io.EOF) {
+							break
+						} else if err != nil {
+							b.Fatal(err)
+						}
+					}
+				}
+
+				b.SetBytes(totalBytes / int64(b.N))
+
+				elapsed := b.Elapsed()
+				if elapsed > 0 {
+					b.ReportMetric(float64(totalRows)/elapsed.Seconds(), "rows/s")
+				}
+			})
+		}
+	})
+}
+
+func readBatches(t *testing.T, alloc *memory.Allocator, r array.Reader, batchSize int) columnar.Array {
+	t.Helper()
+
+	var all []columnar.Array
+	for {
+		arr, err := r.Read(t.Context(), alloc, batchSize)
+		if arr != nil {
+			all = append(all, arr)
+		}
+
+		if err != nil && errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+	}
+
+	res, err := columnar.Concat(alloc, all)
+	require.NoError(t, err)
+	return res
+}

--- a/pkg/dataset/array/codec_util.go
+++ b/pkg/dataset/array/codec_util.go
@@ -1,0 +1,54 @@
+package array
+
+import (
+	"fmt"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// validateNulls checks whether arr's null configuration is compatible with w,
+// without performing any mutations. It is intended to be called before
+// [appendNulls] so callers can reject invalid input before mutating their own
+// state.
+func validateNulls(w Writer, arr columnar.Array, values int) error {
+	if w == nil && arr.Nulls() > 0 {
+		return fmt.Errorf("cannot write null values to nil Writer")
+	}
+
+	validity := arr.Validity()
+	if validity.Len() != 0 && validity.Len() != values {
+		return fmt.Errorf("invalid validity bitmap length: %d (expected 0 or %d)", validity.Len(), values)
+	}
+	return nil
+}
+
+// appendNulls is a utility function that appends null values from the array to
+// a Writer. Callers must have validated the input via [validateNulls] first;
+// appendNulls assumes the null configuration is well-formed.
+//
+// Returns the number of null values appended and an error, if any.
+func appendNulls(alloc *memory.Allocator, w Writer, arr columnar.Array, values int) (int, error) {
+	nullCount := arr.Nulls()
+
+	if w == nil {
+		return 0, nil
+	}
+
+	validity := arr.Validity()
+	if validity.Len() == 0 {
+		// All values are valid. We need to make a temporary bitmap to pass to
+		// the validity writer.
+		//
+		// TODO(rfratto): Can we find a way to avoid this to avoid allocations
+		// here?
+		shortAlloc := memory.NewAllocator(alloc)
+		defer shortAlloc.Free()
+
+		validity = memory.NewBitmap(shortAlloc, values)
+		validity.AppendCount(true, values)
+	}
+
+	validityArr := columnar.NewBool(validity, memory.Bitmap{})
+	return nullCount, w.Append(validityArr)
+}

--- a/pkg/dataset/array/encoding.go
+++ b/pkg/dataset/array/encoding.go
@@ -1,0 +1,36 @@
+package array
+
+// Encoding describes how an [Array]'s data is encoded and how it should be
+// read.
+//
+// [Spec] is the counterpart to Encoding which is used for building new Arrays.
+//
+// While [EncodingKind] categorizes the encoding, the invidiual Encoding
+// implementations can hold additionally encoding-specific metadata that is
+// required for proper decoding.
+type Encoding interface {
+	isEncoding() // Sealed interface.
+
+	// Kind returns the encoding kind of this Encoding.
+	Kind() EncodingKind
+}
+
+// Encoding definitions.
+type (
+	// EncodingBool holds bit-packed boolean values.
+	//
+	// If the data type is nullable, then the first child Array holds validity
+	// data.
+	EncodingBool struct{}
+)
+
+// Kind returns [EncodingKindBool].
+func (enc *EncodingBool) Kind() EncodingKind {
+	return EncodingKindBool
+}
+
+//
+// Sealed marker implementations.
+//
+
+func (enc *EncodingBool) isEncoding() {}

--- a/pkg/dataset/array/encoding_kind.go
+++ b/pkg/dataset/array/encoding_kind.go
@@ -1,0 +1,26 @@
+package array
+
+// EncodingKind identifies the category of an [Encoding]. Each concrete Encoding
+// implementation returns a fixed EncodingKind value.
+//
+// The zero value is an invalid encoding kind.
+type EncodingKind int
+
+const (
+	EncodingKindInvalid EncodingKind = iota // EncodingKindInvalid is an invalid encoding.
+
+	EncodingKindBool // EncodingKindBool is a bit-packed encoding for boolean types.
+)
+
+var kindNames = [...]string{
+	EncodingKindInvalid: "invalid",
+	EncodingKindBool:    "bool",
+}
+
+// String returns the string representation of k.
+func (k EncodingKind) String() string {
+	if k < 0 || k >= EncodingKind(len(kindNames)) {
+		return "unknown"
+	}
+	return kindNames[k]
+}

--- a/pkg/dataset/array/spec.go
+++ b/pkg/dataset/array/spec.go
@@ -1,0 +1,37 @@
+package array
+
+// Spec describes how to encode an [Array]'s data.
+//
+// [Encoding] is the counterpart to Spec which is used for reading the
+// resulting Array.
+//
+// While [EncodingKind] categorizes the encoding, the invidiual Encoding
+// implementations can hold additionally encoding-specific metadata that is
+// used for encoding and decoding.
+type Spec interface {
+	isSpec() // Sealed interface.
+
+	// Kind returns the encoding kind of this Spec.
+	Kind() EncodingKind
+}
+
+// Spec definitions.
+type (
+	// SpecBool encodes bit-packed boolean values.
+	SpecBool struct {
+		// Spec for how to encode validity data. Must only be set for nullable
+		// data types.
+		Validity Spec
+	}
+)
+
+// Kind returns [EncodingKindBool].
+func (spec *SpecBool) Kind() EncodingKind {
+	return EncodingKindBool
+}
+
+//
+// Sealed marker implementations.
+//
+
+func (spec *SpecBool) isSpec() {}

--- a/pkg/dataset/buffer/buffer.go
+++ b/pkg/dataset/buffer/buffer.go
@@ -1,0 +1,15 @@
+// Package buffer describes contigous regions of dataset memory. Each buffer
+// holds arbitrary data, which is interpreted contextually depending on where
+// the buffer is stored.
+package buffer
+
+// Invalid refers to an invalid buffer ID.
+const Invalid ID = 0
+
+// ID is an opaque identifier for where underlying [Data] is stored. The zero
+// value is reserved for an [Invalid] ID.
+type ID uint64
+
+// Data holds the raw bytes for a [Buffer]. Data is read-only and must not be
+// modified.
+type Data []byte

--- a/pkg/dataset/buffer/store.go
+++ b/pkg/dataset/buffer/store.go
@@ -1,0 +1,47 @@
+package buffer
+
+import (
+	"context"
+
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// Sink stores buffer [Data] and returns handles to the stored buffers.
+type Sink interface {
+	// WriteBuffers stores each [Data] and returns handles to the corresponding
+	// buffers. Returned IDs must be non-zero; ID 0 is reserved for the
+	// [Invalid] buffer.
+	//
+	// Implementations must not store data beyond the call to WriteBuffers, or
+	// modify it, even temporarily.
+	WriteBuffers(ctx context.Context, data []Data) ([]ID, error)
+}
+
+// Source retrieves buffer [Data] from handles.
+type Source interface {
+	// ReadBuffers retrieves the read-only Data for the given buffer IDs. The
+	// output elements match the order of the input bufs slice and have the same
+	// length as bufs. Callers must not pass buffers with ID 0.
+	//
+	// ReadBuffers returns an error if any of the given buffers are not found.
+	//
+	// Implementations may use the provided allocator to allocate memory for
+	// returned Data, but are not required to. Returned Data must remain valid
+	// for at least the lifetime of alloc.
+	ReadBuffers(ctx context.Context, alloc *memory.Allocator, bufs []ID) ([]Data, error)
+
+	// BufferSizes returns the byte size of each requested buffer.
+	//
+	// BufferSizes returns an error if any of the given buffers are not found.
+	BufferSizes(ctx context.Context, alloc *memory.Allocator, bufs []ID) ([]int64, error)
+}
+
+// Store combines Sink and Source into a single interface for read-write
+// access to buffer data.
+type Store interface {
+	Sink
+	Source
+
+	// Delete removes the given buffers from the store.
+	Delete(ctx context.Context, bufs []ID) error
+}

--- a/pkg/dataset/buffer/store_memory.go
+++ b/pkg/dataset/buffer/store_memory.go
@@ -1,0 +1,79 @@
+package buffer
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// MemoryStore is a simple in-memory [Store] backed by a slice. Buffer IDs are
+// not reused after deletion.
+type MemoryStore struct {
+	bufs []Data
+}
+
+var _ Store = (*MemoryStore)(nil)
+
+// WriteBuffers clones each [Data] into the store and returns their IDs.
+func (s *MemoryStore) WriteBuffers(_ context.Context, data []Data) ([]ID, error) {
+	results := make([]ID, len(data))
+	for i, d := range data {
+		clone := slices.Clone(d)
+		if clone == nil {
+			clone = Data{} // Normalize nil to empty so Delete can distinguish live vs deleted.
+		}
+		s.bufs = append(s.bufs, clone)
+		results[i] = ID(len(s.bufs))
+	}
+	return results, nil
+}
+
+// ReadBuffers returns the [Data] for the requested buffer IDs.
+func (s *MemoryStore) ReadBuffers(_ context.Context, _ *memory.Allocator, bufs []ID) ([]Data, error) {
+	res := make([]Data, len(bufs))
+	for i, buf := range bufs {
+		if err := s.validate(buf); err != nil {
+			return nil, err
+		}
+		res[i] = s.bufs[buf-1]
+	}
+	return res, nil
+}
+
+func (s *MemoryStore) validate(id ID) error {
+	if id < 1 || int(id) > len(s.bufs) {
+		return fmt.Errorf("invalid buffer ID %d", id)
+	} else if s.bufs[id-1] == nil {
+		return fmt.Errorf("buffer %d has been deleted", id)
+	}
+	return nil
+}
+
+// BufferSizes returns the byte size of each requested buffer.
+func (s *MemoryStore) BufferSizes(_ context.Context, _ *memory.Allocator, bufs []ID) ([]int64, error) {
+	sizes := make([]int64, len(bufs))
+	for i, buf := range bufs {
+		if err := s.validate(buf); err != nil {
+			return nil, err
+		}
+		sizes[i] = int64(len(s.bufs[buf-1]))
+	}
+	return sizes, nil
+}
+
+// Len returns the total number of buffers that have been written, including
+// deleted ones.
+func (s *MemoryStore) Len() int { return len(s.bufs) }
+
+// Delete nils out the stored data for the given buffer IDs.
+func (s *MemoryStore) Delete(_ context.Context, bufs []ID) error {
+	for _, buf := range bufs {
+		if err := s.validate(buf); err != nil {
+			return err
+		}
+		s.bufs[buf-1] = nil
+	}
+	return nil
+}

--- a/pkg/dataset/buffer/store_memory_test.go
+++ b/pkg/dataset/buffer/store_memory_test.go
@@ -1,0 +1,127 @@
+package buffer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+)
+
+func TestMemoryStore(t *testing.T) {
+	var s buffer.MemoryStore
+
+	var (
+		inputData = []buffer.Data{buffer.Data("hello"), buffer.Data("world")}
+		expectIDs = []buffer.ID{1, 2}
+	)
+
+	ids, err := s.WriteBuffers(t.Context(), inputData)
+	require.NoError(t, err)
+	require.Equal(t, expectIDs, ids)
+
+	got, err := s.ReadBuffers(t.Context(), nil, ids)
+	require.NoError(t, err)
+	require.Equal(t, inputData, got)
+}
+
+func TestMemoryStore_WriteBuffers(t *testing.T) {
+	t.Run("WriteBuffers clones memory", func(t *testing.T) {
+		var s buffer.MemoryStore
+
+		orig := buffer.Data("abc")
+		ids, err := s.WriteBuffers(t.Context(), []buffer.Data{orig})
+		require.NoError(t, err)
+
+		// Mutate the original; the stored copy must be unaffected.
+		orig[0] = 'z'
+
+		got, err := s.ReadBuffers(t.Context(), nil, ids)
+		require.NoError(t, err)
+		require.Equal(t, buffer.Data("abc"), got[0])
+	})
+
+	t.Run("normalizes nil to empty", func(t *testing.T) {
+		var s buffer.MemoryStore
+
+		ids, err := s.WriteBuffers(t.Context(), []buffer.Data{nil})
+		require.NoError(t, err)
+
+		got, err := s.ReadBuffers(t.Context(), nil, ids)
+		require.NoError(t, err)
+		require.Equal(t, buffer.Data{}, got[0])
+	})
+}
+
+func TestMemoryStore_ReadBuffers(t *testing.T) {
+	t.Run("fails with invalid ID", func(t *testing.T) {
+		var s buffer.MemoryStore
+
+		_, err := s.ReadBuffers(t.Context(), nil, []buffer.ID{0})
+		require.Error(t, err, "ReadBuffers should fail with invalid ID")
+
+		_, err = s.ReadBuffers(t.Context(), nil, []buffer.ID{99})
+		require.Error(t, err, "ReadBuffers should fail with invalid ID")
+	})
+}
+
+func TestMemoryStore_BufferSizes(t *testing.T) {
+	t.Run("succeeds with valid buffers", func(t *testing.T) {
+		var s buffer.MemoryStore
+
+		var (
+			inputData   = []buffer.Data{[]byte("ab"), []byte("cdefg")}
+			expectSizes = []int64{2, 5}
+		)
+
+		ids, err := s.WriteBuffers(t.Context(), inputData)
+		require.NoError(t, err)
+
+		sizes, err := s.BufferSizes(t.Context(), nil, ids)
+		require.NoError(t, err)
+		require.Equal(t, expectSizes, sizes)
+	})
+
+	t.Run("fails with non-existing buffers", func(t *testing.T) {
+		ctx := context.Background()
+		var s buffer.MemoryStore
+
+		_, err := s.BufferSizes(ctx, nil, []buffer.ID{0})
+		require.Error(t, err)
+
+		_, err = s.BufferSizes(ctx, nil, []buffer.ID{99})
+		require.Error(t, err)
+	})
+}
+
+func TestMemoryStore_Delete(t *testing.T) {
+	t.Run("succeeds with existing buffers", func(t *testing.T) {
+		var s buffer.MemoryStore
+
+		ids, err := s.WriteBuffers(t.Context(), []buffer.Data{[]byte("a"), []byte("b")})
+		require.NoError(t, err)
+
+		require.NoError(t, s.Delete(t.Context(), ids[:1]), "Delete should succeed with existing buffers")
+
+		_, err = s.ReadBuffers(t.Context(), nil, ids[:1])
+		require.Error(t, err, "ReadBuffers should fail with deleted buffer")
+
+		_, err = s.BufferSizes(t.Context(), nil, ids[:1])
+		require.Error(t, err, "BufferSizes should fail with deleted buffer")
+
+		got, err := s.ReadBuffers(t.Context(), nil, ids[1:])
+		require.NoError(t, err)
+		require.Equal(t, buffer.Data("b"), got[0], "Undeleted buffers should still be readable")
+	})
+
+	t.Run("fails on deleted buffer", func(t *testing.T) {
+		var s buffer.MemoryStore
+
+		ids, err := s.WriteBuffers(t.Context(), []buffer.Data{[]byte("x")})
+		require.NoError(t, err)
+
+		require.NoError(t, s.Delete(t.Context(), ids), "Delete should succeed with existing buffers")
+		require.Error(t, s.Delete(t.Context(), ids), "Delete should fail with deleted buffer")
+	})
+}

--- a/pkg/engine/basic_engine.go
+++ b/pkg/engine/basic_engine.go
@@ -270,7 +270,7 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 		"duration_full", durFull,
 	)
 
-	metadataCtx.AddWarning("Query was executed using the new experimental query engine and dataobj storage.")
+	metadataCtx.AddWarning("Query was executed using the next-generation Loki query engine.")
 	span.SetStatus(codes.Ok, "")
 	return builder.Build(stats, metadataCtx), nil
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -334,7 +334,7 @@ func (e *Engine) buildContext(ctx context.Context) context.Context {
 	// [rangeio.ReadRanges] to make use of.
 	ctx = rangeio.WithConfig(ctx, &e.cfg.Executor.RangeConfig)
 
-	metadataContext.AddWarning("Query was executed using the new experimental query engine and dataobj storage.")
+	metadataContext.AddWarning("Query was executed using the next-generation Loki query engine.")
 	return ctx
 }
 

--- a/pkg/engine/handler.go
+++ b/pkg/engine/handler.go
@@ -575,7 +575,7 @@ func emptyResult(ctx context.Context, params logql.Params) (logqlmodel.Result, e
 	}
 
 	md := metadata.FromContext(ctx)
-	md.AddWarning("Query was executed using the new experimental query engine.")
+	md.AddWarning("Query was executed using the next-generation Loki query engine.")
 
 	return logqlmodel.Result{
 		Data:     data,

--- a/pkg/memory/bitmap.go
+++ b/pkg/memory/bitmap.go
@@ -29,6 +29,27 @@ type Bitmap struct {
 	off  int     // Offset into the first word.
 }
 
+// BitmapFrom returns a read-only Bitmap backed by the given data slice.
+//
+// BitmapFrom panics if bitmapLen or off are negative, or if off+bitmapLen bits
+// do not fit within data.
+func BitmapFrom(data []uint8, bitmapLen, off int) Bitmap {
+	if bitmapLen < 0 {
+		panic("negative length")
+	} else if off < 0 {
+		panic("negative offset")
+	} else if off+bitmapLen > 8*len(data) {
+		panic("bitmap does not fit in data")
+	}
+	return Bitmap{
+		alloc: nil,
+
+		data: data[:len(data):len(data)],
+		len:  bitmapLen,
+		off:  off,
+	}
+}
+
 // NewBitmap creates a Bitmap managed by the provided allocator. The returned
 // Bitmap will have an initial length of zero and a capacity of at least n
 // (which may be 0).
@@ -231,6 +252,12 @@ func (bmap *Bitmap) Clone(alloc *Allocator) *Bitmap {
 //
 // The first offset bits in data are undefined.
 func (bmap *Bitmap) Bytes() (data []byte, offset int) { return bmap.data, bmap.off }
+
+// BytesTrimmed returns [Bitmap.Bytes] without any padding beyond data and offset.
+func (bmap *Bitmap) BytesTrimmed() (data []byte, offset int) {
+	byteLen := (bmap.off + bmap.len + 7) / 8
+	return bmap.data[:byteLen], bmap.off
+}
 
 // Slice returns a slice of bmap from index i to j. he returned slice has both a
 // length and capacity of j-i, shares memory with bmap, and uses the same

--- a/pkg/querytee/goldfish/end_to_end_test.go
+++ b/pkg/querytee/goldfish/end_to_end_test.go
@@ -392,7 +392,7 @@ func TestGoldfishNewEngineDetection(t *testing.T) {
 			}
 		},
 		"warnings": [
-			"Query was executed using the new experimental query engine and dataobj storage."
+			"Query was executed using the next-generation Loki query engine."
 		]
 	}`)
 

--- a/pkg/querytee/goldfish/manager_test.go
+++ b/pkg/querytee/goldfish/manager_test.go
@@ -161,7 +161,7 @@ func TestManager_ProcessQueryPair(t *testing.T) {
 	cellBResp := &BackendResponse{
 		BackendName: "cell-b",
 		Status:      200,
-		Body:        []byte(`{"status":"success","data":{"resultType":"matrix","result":[],"stats":{"summary":{"execTime":0.12,"queueTime":0.06,"totalBytesProcessed":1000,"totalLinesProcessed":100,"bytesProcessedPerSecond":8333,"linesProcessedPerSecond":833,"totalEntriesReturned":5,"splits":1,"shards":2}}},"warnings":["Query was executed using the new experimental query engine and dataobj storage."]}`),
+		Body:        []byte(`{"status":"success","data":{"resultType":"matrix","result":[],"stats":{"summary":{"execTime":0.12,"queueTime":0.06,"totalBytesProcessed":1000,"totalLinesProcessed":100,"bytesProcessedPerSecond":8333,"linesProcessedPerSecond":833,"totalEntriesReturned":5,"splits":1,"shards":2}}},"warnings":["Query was executed using the next-generation Loki query engine."]}`),
 		Duration:    120 * time.Millisecond,
 		TraceID:     "",
 		SpanID:      "",

--- a/pkg/querytee/goldfish/stats_extractor.go
+++ b/pkg/querytee/goldfish/stats_extractor.go
@@ -227,7 +227,7 @@ func (e *StatsExtractor) CompareStats(cellA, cellB goldfish.QueryStats) map[stri
 
 // checkForNewEngineWarning checks if the warnings contain the new engine warning
 func (e *StatsExtractor) checkForNewEngineWarning(warnings []string) bool {
-	const newEngineWarning = "Query was executed using the new experimental query engine and dataobj storage."
+	const newEngineWarning = "Query was executed using the next-generation Loki query engine."
 
 	for _, warning := range warnings {
 		if warning == newEngineWarning {

--- a/pkg/querytee/goldfish/stats_extractor_test.go
+++ b/pkg/querytee/goldfish/stats_extractor_test.go
@@ -42,7 +42,7 @@ func TestStatsExtractor_NewEngineWarningDetection(t *testing.T) {
 					}
 				},
 				"warnings": [
-					"Query was executed using the new experimental query engine and dataobj storage."
+					"Query was executed using the next-generation Loki query engine."
 				]
 			}`,
 			expectedUsed:       true,
@@ -137,7 +137,7 @@ func TestStatsExtractor_NewEngineWarningDetection(t *testing.T) {
 				},
 				"warnings": [
 					"Query processing took longer than expected",
-					"Query was executed using the new experimental query engine and dataobj storage.",
+					"Query was executed using the next-generation Loki query engine.",
 					"Large dataset detected"
 				]
 			}`,
@@ -219,7 +219,7 @@ func TestStatsExtractor_CheckForNewEngineWarning(t *testing.T) {
 	}{
 		{
 			name:     "exact match",
-			warnings: []string{"Query was executed using the new experimental query engine and dataobj storage."},
+			warnings: []string{"Query was executed using the next-generation Loki query engine."},
 			expected: true,
 		},
 		{
@@ -240,8 +240,8 @@ func TestStatsExtractor_CheckForNewEngineWarning(t *testing.T) {
 		{
 			name: "partial match should not count",
 			warnings: []string{
-				"Query was executed using the new engine",
-				"experimental query engine and dataobj storage",
+				"Query was executed using",
+				"the next-generation Loki query engine.",
 			},
 			expected: false,
 		},
@@ -249,7 +249,7 @@ func TestStatsExtractor_CheckForNewEngineWarning(t *testing.T) {
 			name: "multiple warnings with match",
 			warnings: []string{
 				"Warning 1",
-				"Query was executed using the new experimental query engine and dataobj storage.",
+				"Query was executed using the next-generation Loki query engine.",
 				"Warning 3",
 			},
 			expected: true,
@@ -257,7 +257,7 @@ func TestStatsExtractor_CheckForNewEngineWarning(t *testing.T) {
 		{
 			name: "case sensitive check",
 			warnings: []string{
-				"query was executed using the new experimental query engine and dataobj storage.",
+				"query was executed using the next-generation loki query engine.",
 			},
 			expected: false, // Should be case sensitive
 		},


### PR DESCRIPTION
This PR starts rearchitecting the [dataset package](https://github.com/grafana/loki/tree/main/pkg/dataobj/internal/dataset) as a top-level package with two main changes:

* Both the write and read path will be column-oriented throughout 
* The Parquet-inspired encoding is replaced with a Vortex-inspired encoding so that data at rest more closely represents how that data will be loaded into memory. 

For this initial PR, two new packages are added: 

* dataset/buffer, which hold opaque handles to encoded data. All encoded aspects of a dataset, including protobuf metadata and encoded arrays, will be stored as a buffer.  
* dataset/array, which encodes and decodes a hierarchical sequence of values, stored in buffers. 

Writers accept a stream of columnar.Array and encode them into a dataset Array, while Readers accept a single dataset Array and decodes N values into the corresponding columnar.Array.

Encoding and decoding is hierarchical to allow different encoding strategies for different parts of an Array. For example, this can permit choosing between plain encoding and a RLE representation for the validity buffer, while leaving the top-level values buffer as a plain bitpacked array.

This initial commit introduces one encoding, Bool, which encodes a bitpacked sequence of boolean values. It supports nullable and non-nullable types. When a type is nullable, the final child Array is used for the validity buffer (which is also a Bool type).

Encoded data is stored in a `buffer.Store` (composed of `buffer.Source` and `buffer.Sink` interfaces), which abstracts the logic for storing and retrieving buffer data. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new foundational `dataset/buffer` and `dataset/array` encoding/decoding APIs plus new bitmap helpers; while mostly additive, these become building blocks for future storage paths and could hide subtle encoding/nullability bugs.
> 
> **Overview**
> Introduces new top-level `dataset/buffer` and `dataset/array` packages to represent encoded dataset data as buffer-backed, hierarchical `Array` trees, with generic `Writer`/`Reader` interfaces.
> 
> Implements an initial `bool` encoding (bit-packed values with optional child validity array for nulls), including null-handling utilities, in-memory `buffer.MemoryStore`, and unit/benchmark coverage.
> 
> Adds `memory.BitmapFrom` and `Bitmap.BytesTrimmed` helpers to support zero-copy decoding and trimmed serialization, and updates the V2 engine warning string (and Goldfish tests/detection) to "next-generation Loki query engine."
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b04458332724b87dff26797993d9eb3883399773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->