### PR TITLE
fix(lokitool): correct rule-files help text for rules lint

### DIFF
--- a/pkg/tool/commands/rules.go
+++ b/pkg/tool/commands/rules.go
@@ -217,8 +217,8 @@ func (r *RuleCommand) Register(app *kingpin.Application) {
 	prepareCmd.Flag("label-excluded-rule-groups", "Comma separated list of rule group names to exclude when including the configured label to aggregations.").StringVar(&r.AggregationLabelExcludedRuleGroups)
 
 	// Lint Command
-	lintCmd.Arg("rule-files", "The rule files to check.").ExistingFilesVar(&r.RuleFilesList)
-	lintCmd.Flag("rule-files", "The rule files to check. Flag can be reused to load multiple files.").StringVar(&r.RuleFiles)
+	lintCmd.Arg("rule-files", "The rule files to format.").ExistingFilesVar(&r.RuleFilesList)
+	lintCmd.Flag("rule-files", "The rule files to format. Flag can be reused to load multiple files.").StringVar(&r.RuleFiles)
 	lintCmd.Flag(
 		"rule-dirs",
 		"Comma separated list of paths to directories containing rules yaml files. Each file in a directory with a .yml or .yaml suffix will be parsed.",


### PR DESCRIPTION
**What this PR does / why we need it**:

The \`rules lint\` subcommand of \`lokitool\` formats rule files, but its \`--rule-files\` argument and flag help text described them as "The rule files to check" — the wording used by the \`check\` subcommand. This PR updates both strings to "The rule files to format" so the help output matches the command's behavior.

Before:
\`\`\`
Args:
  [<rule-files>]  The rule files to check.
\`\`\`

After:
\`\`\`
Args:
  [<rule-files>]  The rule files to format.
\`\`\`

**Which issue(s) this PR fixes**:
Fixes #20288

**Special notes for your reviewer**:

Scope is intentionally narrow: only the two \`lintCmd\` help strings in \`pkg/tool/commands/rules.go\`. The \`check\` subcommand's help text already matches its behavior and is left untouched. No behavior changes — help text only.

**Checklist**
- [x] Reviewed the [\`CONTRIBUTING.md\`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in \`docs/sources/setup/upgrade/_index.md\`
- [ ] If the change is deprecating or removing a configuration option, update the \`deprecated-config.yaml\` and \`deleted-config.yaml\` files respectively in the \`tools/deprecated-config-checker\` directory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help-text-only change to CLI output; no behavioral or data-path modifications.
> 
> **Overview**
> Updates `lokitool rules lint` CLI help text so its `rule-files` arg/flag descriptions say "format" (matching the command’s behavior) instead of "check".
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49a29795c36a50b6618bd180f9288896b7f615d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->