### PR TITLE
fix(columnar): Copy label values to avoid retaining memory

### DIFF
--- a/pkg/engine/internal/executor/util.go
+++ b/pkg/engine/internal/executor/util.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -35,9 +36,7 @@ func columnForFQN(fqn string, batch arrow.RecordBatch) (arrow.Array, int, error)
 }
 
 // labelValuesCache returns label values for a given row in range and vector aggregators, but cache them in order
-// to reduce object allocations for repeated label sets. It computes an xxhash over the non-null label values
-// to form the cache key, then returns the full slice of values.
-// In case of a cache miss it scans the row again and allocates arrays for label values.
+// to reduce object allocations for repeated label sets. Strings are copied to avoid referencing the Arrow data buffer.
 type labelValuesCache struct {
 	digest *xxhash.Digest
 	cache  map[uint64][]string
@@ -51,6 +50,7 @@ func newLabelValuesCache() *labelValuesCache {
 }
 
 func (c *labelValuesCache) getLabelValues(arrays []*array.String, row int) []string {
+	// Compute an xxhash over the non-null label values to form the cache key.
 	c.digest.Reset()
 	for _, arr := range arrays {
 		if !arr.IsNull(row) {
@@ -61,11 +61,12 @@ func (c *labelValuesCache) getLabelValues(arrays []*array.String, row int) []str
 	key := c.digest.Sum64()
 
 	labelValues, ok := c.cache[key]
+	// In case of a cache miss, scan the row again and copy the label values.
 	if !ok {
 		labelValues = make([]string, 0, len(arrays))
 		for _, arr := range arrays {
 			if !arr.IsNull(row) {
-				labelValues = append(labelValues, arr.Value(row))
+				labelValues = append(labelValues, strings.Clone(arr.Value(row)))
 			}
 		}
 		c.cache[key] = labelValues


### PR DESCRIPTION
**What this PR does / why we need it**:

Change `labelValuesCache` to copy string values, so that they no longer point into the Arrow data buffer. 
Otherwise this memory can be kept alive by the garbage-collector.

**Special notes for your reviewer**:

I also moved some comments around to keep internal details with the implementation.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- NA Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path aggregation code by changing how label strings are cached; correctness should improve (no buffer retention) but it may impact memory/CPU due to additional string copies.
> 
> **Overview**
> Prevents `labelValuesCache` from retaining Arrow data buffers by cloning string label values on cache misses (using `strings.Clone`) instead of storing `arr.Value(row)` directly.
> 
> Refactors the in-function comments to clarify the two-pass behavior: first hashing non-null label values for the cache key, then rescanning to populate (now copied) cached values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68b5b59d285cd2fa5380c9e1d3cd335dc5ad2dcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->