### PR TITLE
fix(querier): Add HTTP headers to volume response

### DIFF
--- a/pkg/querier/queryrange/volume.go
+++ b/pkg/querier/queryrange/volume.go
@@ -113,7 +113,7 @@ func ToPrometheusResponse(respsCh chan *bucketedVolumeResponse, aggregateBySerie
 		bucket, resp := bucketedVolumeResponse.bucket, bucketedVolumeResponse.response
 
 		if headers == nil {
-			headers := make([]*definitions.PrometheusResponseHeader, len(resp.Headers))
+			headers = make([]*definitions.PrometheusResponseHeader, len(resp.Headers))
 			for i, header := range resp.Headers {
 				h := header
 				headers[i] = &h


### PR DESCRIPTION
**What this PR does / why we need it**:

The `:=` meant the outer `headers` variable never changed.

It would be nice to have a test that checked this, but I don't know much about what the code is doing; I just noticed the linter warning in passing.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-line change that only affects whether `resp.Headers` are propagated into the aggregated volume response.
> 
> **Overview**
> Fixes `ToPrometheusResponse` so the first sub-response’s `Headers` are assigned to the outer `headers` slice (removing a `:=` shadow), ensuring volume query results return the expected Prometheus response headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb8d5407414635b84bc5911731a7fb72b4da1ca1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->