### PR TITLE
docs: Add note to monolithic topic

### DIFF
--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -20,6 +20,10 @@ As of March 16, 2026, the Loki Helm Chart is being maintained by Grafana Champio
 With the move to the Grafana-community repository, the chart numbering has changed. Major version updates signal breaking changes in the chart. For more information, refer to the [README](https://github.com/grafana-community/helm-charts/blob/main/charts/loki/README.md#upgrading).
 {{< /admonition >}}
 
+{{< admonition type="note" >}}
+As of the community Helm chart version 12.0.0, `SingleBinary` has been renamed to `Monolithic`. If you are using `SingleBinary` deployment mode, you have to explicitly set `deploymentMode: Monolithic` in your values file to avoid breaking changes.
+{{< /admonition >}}
+
 ## Prerequisites
 
 - Helm 3 or above. See [Installing Helm](https://helm.sh/docs/intro/install/).


### PR DESCRIPTION
**What this PR does / why we need it**:

The Community Maintainers have changed the `SingleBinary` deployment in the charts to `Monolithic` to match what we call this deployment mode in the documentation.  Adding a note to the topic with this information.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds upgrade guidance; no runtime or config defaults are modified in the codebase.
> 
> **Overview**
> Updates the monolithic Helm install docs to **warn about a breaking chart rename**: community Helm chart `v12.0.0` renames `SingleBinary` to `Monolithic`.
> 
> Adds a note instructing users to set `deploymentMode: Monolithic` when upgrading/using the former `SingleBinary` mode to avoid breakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 378a2fde4e82f12388e2726ef16a32a2e3aab187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->