### PR TITLE
feat(dataobj): Reduce postings indexing allocations via observe/aggregate pattern

### DIFF
--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -255,11 +255,18 @@ func (c *Calculator) processLogsSection(ctx context.Context, sectionLogger log.L
 	// Track cumulative duration per calculation step across all batches + flush.
 	stepDurations := make([]time.Duration, len(calculationSteps))
 
+	// Lock the builder during Prepare because some calculations (e.g.,
+	// columnValuesCalculation) mutate shared builder state via
+	// PrepareBloomColumn. The builder is not goroutine-safe, and multiple
+	// processLogsSection goroutines may run concurrently for the same tenant.
+	c.builderMtx.Lock()
 	for _, calculation := range calculationSteps {
 		if err := calculation.Prepare(ctx, calculationContext, section, stats); err != nil {
+			c.builderMtx.Unlock()
 			return fmt.Errorf("failed to prepare calculation: %w", err)
 		}
 	}
+	c.builderMtx.Unlock()
 
 	// TODO(benclive): Switch to a columnar reader instead of row based
 	rowReader := logs.NewRowReader(logsSection)

--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -26,7 +26,7 @@ type logsIndexCalculation interface {
 	// Name returns a short identifier for this calculation step, used for metrics labels.
 	Name() string
 	// Prepare is called before the first batch of logs is processed in order to initialize any state.
-	Prepare(ctx context.Context, section *dataobj.Section, stats logs.Stats) error
+	Prepare(ctx context.Context, calcCtx *logsCalculationContext, section *dataobj.Section, stats logs.Stats) error
 	// ProcessBatch is called for each batch of logs records.
 	//
 	// If ProcessBatchNeedsBuilderLock returns true, implementations can assume
@@ -256,7 +256,7 @@ func (c *Calculator) processLogsSection(ctx context.Context, sectionLogger log.L
 	stepDurations := make([]time.Duration, len(calculationSteps))
 
 	for _, calculation := range calculationSteps {
-		if err := calculation.Prepare(ctx, section, stats); err != nil {
+		if err := calculation.Prepare(ctx, calculationContext, section, stats); err != nil {
 			return fmt.Errorf("failed to prepare calculation: %w", err)
 		}
 	}

--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -257,8 +257,10 @@ func (c *Calculator) processLogsSection(ctx context.Context, sectionLogger log.L
 
 	// Lock the builder during Prepare because some calculations (e.g.,
 	// columnValuesCalculation) mutate shared builder state via
-	// PrepareBloomColumn. The builder is not goroutine-safe, and multiple
-	// processLogsSection goroutines may run concurrently for the same tenant.
+	// PrepareBloomColumn. The Calculate method dispatches one goroutine per
+	// logs section (see g.Go in Calculate), so two processLogsSection calls
+	// for sections of the same tenant within one data object run
+	// concurrently against the same per-tenant postings builder.
 	c.builderMtx.Lock()
 	for _, calculation := range calculationSteps {
 		if err := calculation.Prepare(ctx, calculationContext, section, stats); err != nil {

--- a/pkg/dataobj/index/column_values.go
+++ b/pkg/dataobj/index/column_values.go
@@ -3,130 +3,80 @@ package index
 import (
 	"context"
 	"fmt"
-	"time"
 
-	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
-	"github.com/grafana/loki/v3/pkg/memory"
 )
 
 // created for and scoped to each logs section
 type columnValuesCalculation struct {
-	columnBloomBuilders map[string]*bloom.BloomFilter
-	columnIndexes       map[string]int64
-
-	// Per-column tracking for AppendBloomPosting.
-	columnStreamBitmaps map[string]*memory.Bitmap
-	columnMinTimestamps map[string]time.Time
-	columnMaxTimestamps map[string]time.Time
-	columnSizes         map[string]int64
-	maxStreamID         int64
+	columnIndexes map[string]int64
 }
 
 func (c *columnValuesCalculation) Name() string { return "column_values" }
 
 // ProcessBatchNeedsBuilderLock reports whether ProcessBatch mutates the shared
-// builder. Column values only mutate step-local bloom builders, bitmaps and
-// timestamp trackers during ProcessBatch; shared-builder writes happen in
-// Flush, so no lock is required for ProcessBatch.
-func (c *columnValuesCalculation) ProcessBatchNeedsBuilderLock() bool { return false }
+// builder. Column values calls builder.ObserveBloomPosting per matching metadata
+// label, which writes into per-column postings state on the shared builder, so
+// it must run under the builder lock.
+func (c *columnValuesCalculation) ProcessBatchNeedsBuilderLock() bool { return true }
 
-func (c *columnValuesCalculation) Prepare(_ context.Context, _ *dataobj.Section, stats logs.Stats) error {
-	c.columnBloomBuilders = make(map[string]*bloom.BloomFilter)
+func (c *columnValuesCalculation) Prepare(_ context.Context, calcCtx *logsCalculationContext, _ *dataobj.Section, stats logs.Stats) error {
 	c.columnIndexes = make(map[string]int64)
-	c.columnStreamBitmaps = make(map[string]*memory.Bitmap)
-	c.columnMinTimestamps = make(map[string]time.Time)
-	c.columnMaxTimestamps = make(map[string]time.Time)
-	c.columnSizes = make(map[string]int64)
-	c.maxStreamID = 0
 
 	for _, column := range stats.Columns {
 		logsType, _ := logs.ParseColumnType(column.Type)
 		if logsType != logs.ColumnTypeMetadata {
 			continue
 		}
-		c.columnBloomBuilders[column.Name] = bloom.NewWithEstimates(uint(column.Cardinality), 1.0/128.0)
 		c.columnIndexes[column.Name] = column.ColumnIndex
-		bm := memory.NewBitmap(nil, 0)
-		c.columnStreamBitmaps[column.Name] = &bm
+		calcCtx.builder.PrepareBloomColumn(
+			calcCtx.tenantID, calcCtx.objectPath, calcCtx.sectionIdx,
+			column.Name, uint(column.Cardinality),
+		)
 	}
 	return nil
 }
 
-func (c *columnValuesCalculation) ProcessBatch(_ context.Context, _ *logsCalculationContext, batch []logs.Record) error {
+func (c *columnValuesCalculation) ProcessBatch(_ context.Context, calcCtx *logsCalculationContext, batch []logs.Record) error {
+	var batchErr error
 	for _, log := range batch {
-		if log.StreamID > c.maxStreamID {
-			c.maxStreamID = log.StreamID
+		if batchErr != nil {
+			break
 		}
-
 		log.Metadata.Range(func(md labels.Label) {
-			bf, ok := c.columnBloomBuilders[md.Name]
-			if !ok {
+			if batchErr != nil {
 				return
 			}
-
-			bf.Add([]byte(md.Value))
-
-			// columnStreamBitmaps was populated with the same metadata keys as
-			// columnBloomBuilders in Prepare, so the bitmap will exist
-			bm := c.columnStreamBitmaps[md.Name]
-			if int(log.StreamID) >= bm.Len() {
-				bm.Resize(int(log.StreamID) + 1)
+			if _, ok := c.columnIndexes[md.Name]; !ok {
+				return
 			}
-			bm.Set(int(log.StreamID), true)
-
-			if ts, ok := c.columnMinTimestamps[md.Name]; !ok || log.Timestamp.Before(ts) {
-				c.columnMinTimestamps[md.Name] = log.Timestamp
-			}
-			if ts, ok := c.columnMaxTimestamps[md.Name]; !ok || log.Timestamp.After(ts) {
-				c.columnMaxTimestamps[md.Name] = log.Timestamp
-			}
-			c.columnSizes[md.Name] += int64(len(log.Line))
+			batchErr = calcCtx.builder.ObserveBloomPosting(
+				calcCtx.tenantID, calcCtx.objectPath, calcCtx.sectionIdx,
+				md.Name, md.Value, log.StreamID,
+				int64(len(log.Line)), log.Timestamp,
+			)
 		})
 	}
-	return nil
+	return batchErr
 }
 
-func (c *columnValuesCalculation) Flush(_ context.Context, context *logsCalculationContext) error {
-	for columnName, bloomFilter := range c.columnBloomBuilders {
-		bloomBytes, err := bloomFilter.MarshalBinary()
+func (c *columnValuesCalculation) Flush(_ context.Context, calcCtx *logsCalculationContext) error {
+	for columnName := range c.columnIndexes {
+		bloomBytes, err := calcCtx.builder.BloomBytes(
+			calcCtx.tenantID, calcCtx.objectPath, calcCtx.sectionIdx, columnName,
+		)
 		if err != nil {
-			return fmt.Errorf("failed to marshal bloom filter: %w", err)
+			return fmt.Errorf("failed to get bloom bytes for %s: %w", columnName, err)
 		}
-		err = context.builder.AppendColumnIndex(context.tenantID, context.objectPath, context.sectionIdx, columnName, c.columnIndexes[columnName], bloomBytes)
+		err = calcCtx.builder.AppendColumnIndex(
+			calcCtx.tenantID, calcCtx.objectPath, calcCtx.sectionIdx,
+			columnName, c.columnIndexes[columnName], bloomBytes,
+		)
 		if err != nil {
 			return fmt.Errorf("failed to append column index: %w", err)
-		}
-
-		// Append bloom posting with stream ID bitmap.
-		if bm, ok := c.columnStreamBitmaps[columnName]; ok {
-			targetSize := int(c.maxStreamID) + 1
-			if bm.Len() < targetSize {
-				bm.Resize(targetSize)
-			}
-			bitmapData, _ := bm.Bytes()
-
-			minTs := c.columnMinTimestamps[columnName]
-			maxTs := c.columnMaxTimestamps[columnName]
-			size := c.columnSizes[columnName]
-
-			err = context.builder.AppendBloomPosting(
-				context.tenantID,
-				context.objectPath,
-				context.sectionIdx,
-				columnName,
-				bloomBytes,
-				bitmapData,
-				size,
-				minTs,
-				maxTs,
-			)
-			if err != nil {
-				return fmt.Errorf("failed to append bloom posting: %w", err)
-			}
 		}
 	}
 	return nil

--- a/pkg/dataobj/index/column_values.go
+++ b/pkg/dataobj/index/column_values.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
 )
 
 // created for and scoped to each logs section
@@ -53,11 +54,15 @@ func (c *columnValuesCalculation) ProcessBatch(_ context.Context, calcCtx *logsC
 			if _, ok := c.columnIndexes[md.Name]; !ok {
 				return
 			}
-			batchErr = calcCtx.builder.ObserveBloomPosting(
-				calcCtx.tenantID, calcCtx.objectPath, calcCtx.sectionIdx,
-				md.Name, md.Value, log.StreamID,
-				int64(len(log.Line)), log.Timestamp,
-			)
+			batchErr = calcCtx.builder.ObserveBloomPosting(calcCtx.tenantID, postings.BloomObservation{
+				ObjectPath:       calcCtx.objectPath,
+				SectionIndex:     calcCtx.sectionIdx,
+				ColumnName:       md.Name,
+				Value:            md.Value,
+				StreamID:         log.StreamID,
+				Timestamp:        log.Timestamp,
+				UncompressedSize: int64(len(log.Line)),
+			})
 		})
 	}
 	return batchErr

--- a/pkg/dataobj/index/column_values_test.go
+++ b/pkg/dataobj/index/column_values_test.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -58,7 +59,7 @@ func TestColumnValuesCalculation_BloomPostingAppended(t *testing.T) {
 
 	calc := &columnValuesCalculation{}
 	stat := makeColumnValuesStats([]string{"trace_id", "span_id"})
-	require.NoError(t, calc.Prepare(context.Background(), nil, stat))
+	require.NoError(t, calc.Prepare(context.Background(), calcCtx, nil, stat))
 
 	ts1 := time.Unix(10, 0).UTC()
 	ts2 := time.Unix(20, 0).UTC()
@@ -132,7 +133,7 @@ func TestColumnValuesCalculation_TimestampsAndSizes(t *testing.T) {
 
 	calc := &columnValuesCalculation{}
 	stat := makeColumnValuesStats([]string{"trace_id"})
-	require.NoError(t, calc.Prepare(context.Background(), nil, stat))
+	require.NoError(t, calc.Prepare(context.Background(), calcCtx, nil, stat))
 
 	ts1 := time.Unix(10, 0).UTC()
 	ts2 := time.Unix(20, 0).UTC()
@@ -184,7 +185,7 @@ func TestColumnValuesCalculation_StreamIDBitmapBitsSet(t *testing.T) {
 
 	calc := &columnValuesCalculation{}
 	stat := makeColumnValuesStats([]string{"trace_id"})
-	require.NoError(t, calc.Prepare(context.Background(), nil, stat))
+	require.NoError(t, calc.Prepare(context.Background(), calcCtx, nil, stat))
 
 	// Only stream 1 has trace_id metadata; stream 2 does not.
 	batch := []logs.Record{
@@ -222,7 +223,7 @@ func TestColumnValuesCalculation_EmptyBatch(t *testing.T) {
 
 	calc := &columnValuesCalculation{}
 	stat := makeColumnValuesStats([]string{"trace_id"})
-	require.NoError(t, calc.Prepare(context.Background(), nil, stat))
+	require.NoError(t, calc.Prepare(context.Background(), calcCtx, nil, stat))
 	require.NoError(t, calc.ProcessBatch(context.Background(), calcCtx, nil))
 	require.NoError(t, calc.Flush(context.Background(), calcCtx))
 
@@ -238,9 +239,10 @@ func TestColumnValuesCalculation_EmptyBatch(t *testing.T) {
 		}
 	}
 	require.NotNil(t, tracePosting, "expected bloom posting for trace_id even with empty batch")
-	zeroTs := time.Time{}.UnixNano()
-	require.Equal(t, zeroTs, tracePosting.MinTimestamp, "no records means Go zero-value timestamp")
-	require.Equal(t, zeroTs, tracePosting.MaxTimestamp, "no records means Go zero-value timestamp")
+	// With the bloom aggregator, an unobserved but prepared column uses sentinel values:
+	// MinTimestamp = math.MaxInt64 and MaxTimestamp = math.MinInt64.
+	require.Equal(t, int64(math.MaxInt64), tracePosting.MinTimestamp, "no records means sentinel max int64 for min timestamp")
+	require.Equal(t, int64(math.MinInt64), tracePosting.MaxTimestamp, "no records means sentinel min int64 for max timestamp")
 	require.Equal(t, int64(0), tracePosting.UncompressedSize, "no records means zero size")
 }
 
@@ -256,7 +258,7 @@ func TestColumnValuesCalculation_MultipleBatches(t *testing.T) {
 
 	calc := &columnValuesCalculation{}
 	stat := makeColumnValuesStats([]string{"trace_id"})
-	require.NoError(t, calc.Prepare(context.Background(), nil, stat))
+	require.NoError(t, calc.Prepare(context.Background(), calcCtx, nil, stat))
 
 	ts1 := time.Unix(10, 0).UTC()
 	ts2 := time.Unix(30, 0).UTC()

--- a/pkg/dataobj/index/full_pipeline_bench_test.go
+++ b/pkg/dataobj/index/full_pipeline_bench_test.go
@@ -45,10 +45,7 @@ func BenchmarkFullPostingsPipeline(b *testing.B) {
 			batch := makePipelineBenchBatch(tc.records, tc.streams, metaCols, tc.metaCardinality)
 			stats := makePipelineBenchStats(metaCols, tc.metaCardinality)
 
-			b.ResetTimer()
-			b.ReportAllocs()
-
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				builder, err := indexobj.NewBuilder(testCalculatorConfig, nil)
 				if err != nil {
 					b.Fatal(err)

--- a/pkg/dataobj/index/full_pipeline_bench_test.go
+++ b/pkg/dataobj/index/full_pipeline_bench_test.go
@@ -1,0 +1,178 @@
+package index
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
+)
+
+// BenchmarkFullPostingsPipeline drives both labelPostingsCalculation and
+// columnValuesCalculation through a full Prepare → ProcessBatch → calc.Flush →
+// builder.Flush cycle against a synthetic logs section.
+//
+// The workload exercises both the label posting path (per stream label per
+// record) and the bloom posting path (per metadata column per record), which
+// together account for nearly all postings-pipeline allocations during
+// indexing.
+func BenchmarkFullPostingsPipeline(b *testing.B) {
+	cases := []struct {
+		records         int
+		streams         int
+		streamLabels    int // number of stream labels per stream
+		metaCols        int // number of metadata columns
+		metaCardinality int // distinct values per metadata column
+	}{
+		{records: 10_000, streams: 100, streamLabels: 3, metaCols: 4, metaCardinality: 10},
+		{records: 10_000, streams: 100, streamLabels: 3, metaCols: 20, metaCardinality: 100},
+		{records: 100_000, streams: 1_000, streamLabels: 4, metaCols: 10, metaCardinality: 100},
+		{records: 100_000, streams: 1_000, streamLabels: 4, metaCols: 20, metaCardinality: 1_000},
+	}
+
+	for _, tc := range cases {
+		name := fmt.Sprintf("records=%d/streams=%d/labels=%d/metaCols=%d/metaCard=%d",
+			tc.records, tc.streams, tc.streamLabels, tc.metaCols, tc.metaCardinality)
+		b.Run(name, func(b *testing.B) {
+			// Build inputs once outside the timing loop. ProcessBatch reads but
+			// does not mutate them.
+			streamLabelsMap := makePipelineBenchStreamLabels(tc.streams, tc.streamLabels)
+			metaCols := makePipelineBenchMetadataColumnNames(tc.metaCols)
+			batch := makePipelineBenchBatch(tc.records, tc.streams, metaCols, tc.metaCardinality)
+			stats := makePipelineBenchStats(metaCols, tc.metaCardinality)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				builder, err := indexobj.NewBuilder(testCalculatorConfig, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+				calcCtx := &logsCalculationContext{
+					tenantID:     "bench-tenant",
+					objectPath:   "bench/path",
+					sectionIdx:   0,
+					streamLabels: streamLabelsMap,
+					builder:      builder,
+				}
+
+				labelCalc := &labelPostingsCalculation{}
+				colCalc := &columnValuesCalculation{}
+
+				if err := labelCalc.Prepare(context.Background(), calcCtx, nil, stats); err != nil {
+					b.Fatal(err)
+				}
+				if err := colCalc.Prepare(context.Background(), calcCtx, nil, stats); err != nil {
+					b.Fatal(err)
+				}
+
+				if err := labelCalc.ProcessBatch(context.Background(), calcCtx, batch); err != nil {
+					b.Fatal(err)
+				}
+				if err := colCalc.ProcessBatch(context.Background(), calcCtx, batch); err != nil {
+					b.Fatal(err)
+				}
+
+				if err := labelCalc.Flush(context.Background(), calcCtx); err != nil {
+					b.Fatal(err)
+				}
+				if err := colCalc.Flush(context.Background(), calcCtx); err != nil {
+					b.Fatal(err)
+				}
+
+				obj, closer, err := builder.Flush()
+				if err != nil {
+					b.Fatal(err)
+				}
+				_ = obj
+				_ = closer.Close()
+			}
+		})
+	}
+}
+
+// makePipelineBenchStreamLabels builds a stream → labels map for the
+// benchmark. Labels are drawn from a fixed set so that values overlap across
+// streams (realistic) but each stream has a unique combination.
+func makePipelineBenchStreamLabels(streams, labelsPerStream int) map[int64]labels.Labels {
+	result := make(map[int64]labels.Labels, streams)
+	baseLabelKeys := []string{"service_name", "cluster", "namespace", "region"}
+	mods := []int{50, 5, 10, 3}
+	for i := 0; i < streams; i++ {
+		pairs := make([]string, 0, labelsPerStream*2)
+		for j := 0; j < labelsPerStream && j < len(baseLabelKeys); j++ {
+			pairs = append(pairs, baseLabelKeys[j], fmt.Sprintf("%s-%d", baseLabelKeys[j], i%mods[j]))
+		}
+		result[int64(i)] = labels.FromStrings(pairs...)
+	}
+	return result
+}
+
+// makePipelineBenchMetadataColumnNames returns n synthetic metadata column
+// names of the form "meta_col_<i>".
+func makePipelineBenchMetadataColumnNames(n int) []string {
+	cols := make([]string, n)
+	for i := 0; i < n; i++ {
+		cols[i] = fmt.Sprintf("meta_col_%d", i)
+	}
+	return cols
+}
+
+// makePipelineBenchBatch builds a synthetic batch of log records. Each record
+// has every metadata column present and rotates through metaCardinality
+// distinct values per column, giving columnValuesCalculation a non-trivial
+// bloom filter to populate.
+func makePipelineBenchBatch(records, streams int, metaCols []string, metaCardinality int) []logs.Record {
+	batch := make([]logs.Record, records)
+	for i := range batch {
+		metaPairs := make([]string, 0, len(metaCols)*2)
+		for j, col := range metaCols {
+			metaPairs = append(metaPairs, col, fmt.Sprintf("v-%d", (i+j)%metaCardinality))
+		}
+		batch[i] = logs.Record{
+			StreamID:  int64(i % streams),
+			Timestamp: time.Unix(int64(i), 0).UTC(),
+			Line:      []byte("log line payload for benchmarking"),
+			Metadata:  labels.FromStrings(metaPairs...),
+		}
+	}
+	return batch
+}
+
+// makePipelineBenchStats builds a logs.Stats describing the metadata columns
+// in the synthetic batch, as columnValuesCalculation.Prepare expects.
+func makePipelineBenchStats(metaCols []string, cardinality int) logs.Stats {
+	var s logs.Stats
+	s.Columns = append(s.Columns, logs.ColumnStats{
+		Name:        "stream_id",
+		Type:        "stream_id",
+		ColumnIndex: 0,
+		Cardinality: 1000,
+	})
+	s.Columns = append(s.Columns, logs.ColumnStats{
+		Name:        "timestamp",
+		Type:        "timestamp",
+		ColumnIndex: 1,
+		Cardinality: 100,
+	})
+	for i, col := range metaCols {
+		s.Columns = append(s.Columns, logs.ColumnStats{
+			Name:        col,
+			Type:        "metadata",
+			ColumnIndex: int64(2 + i),
+			Cardinality: uint64(cardinality),
+		})
+	}
+	s.Columns = append(s.Columns, logs.ColumnStats{
+		Name:        "message",
+		Type:        "message",
+		ColumnIndex: int64(2 + len(metaCols)),
+		Cardinality: 1000,
+	})
+	return s
+}

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -192,10 +192,13 @@ func (b *Builder) AppendStat(tenantID, objectPath string, sectionIdx int64,
 // (bitmap normalization, bloom filter construction). The builderFull flag
 // provides back-pressure via TargetObjectSize.
 func (b *Builder) ObserveLabelPosting(tenantID string, obs postings.LabelObservation) error {
+	// Postings are observed per (record × stream label), so this method runs in
+	// a hot loop that fires hundreds of thousands of times per logs section.
+	// Per-call prometheus.NewTimer / Histogram.Observe / sizeEstimate.Set were
+	// designed for the previous per-posting Append API and are too expensive at
+	// this granularity. We keep the cheap atomic counter and account for size
+	// growth via the aggregator delta only.
 	b.metrics.appendsTotal.Inc()
-
-	timer := prometheus.NewTimer(b.metrics.appendTime)
-	defer timer.ObserveDuration()
 
 	tenantPostings := b.getPostingsBuilderForTenant(tenantID)
 	preSize := tenantPostings.EstimatedSize()
@@ -204,8 +207,7 @@ func (b *Builder) ObserveLabelPosting(tenantID string, obs postings.LabelObserva
 
 	postSize := tenantPostings.EstimatedSize()
 	b.unflushedSizeEstimate += postSize - preSize
-
-	b.currentSizeEstimate = b.estimatedSize()
+	b.currentSizeEstimate += postSize - preSize
 	b.state = builderStateDirty
 	if b.currentSizeEstimate > int(b.cfg.TargetObjectSize) {
 		b.builderFull = true
@@ -226,10 +228,9 @@ func (b *Builder) PrepareBloomColumn(tenantID, objectPath string, sectionIdx int
 // PrepareBloomColumn. The aggregated postings are flushed when
 // [Builder.Flush] is called.
 func (b *Builder) ObserveBloomPosting(tenantID string, obs postings.BloomObservation) error {
+	// See ObserveLabelPosting for why metrics.appendTime / sizeEstimate.Set are
+	// not updated per observation.
 	b.metrics.appendsTotal.Inc()
-
-	timer := prometheus.NewTimer(b.metrics.appendTime)
-	defer timer.ObserveDuration()
 
 	tenantPostings := b.getPostingsBuilderForTenant(tenantID)
 	preSize := tenantPostings.EstimatedSize()
@@ -240,8 +241,7 @@ func (b *Builder) ObserveBloomPosting(tenantID string, obs postings.BloomObserva
 
 	postSize := tenantPostings.EstimatedSize()
 	b.unflushedSizeEstimate += postSize - preSize
-
-	b.currentSizeEstimate = b.estimatedSize()
+	b.currentSizeEstimate += postSize - preSize
 	b.state = builderStateDirty
 	if b.currentSizeEstimate > int(b.cfg.TargetObjectSize) {
 		b.builderFull = true

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -180,16 +180,18 @@ func (b *Builder) AppendStat(tenantID, objectPath string, sectionIdx int64,
 	return nil
 }
 
-// ObserveLabelPosting records a label-based posting observation for a data object column.
-// Multiple observations for the same (objectPath, sectionIdx, columnName, labelValue) are aggregated internally.
-// The aggregated postings are flushed when [Builder.Flush] is called.
+// ObserveLabelPosting records a label-based posting observation for a data
+// object column. Multiple observations sharing the same
+// (ObjectPath, SectionIndex, ColumnName, LabelValue) key in obs are
+// aggregated internally. The aggregated postings are flushed when
+// [Builder.Flush] is called.
 //
-// Unlike other section types (stats, pointers), postings are NOT flushed mid-stream
-// when they exceed TargetSectionSize. The aggregation model requires all observations
-// for a section to be present before encoding (bitmap normalization, bloom filter
-// construction). The builderFull flag provides back-pressure via TargetObjectSize.
-func (b *Builder) ObserveLabelPosting(tenantID, objectPath string, sectionIdx int64,
-	columnName, labelValue string, streamID, uncompressedSize int64, ts time.Time) error {
+// Unlike other section types (stats, pointers), postings are NOT flushed
+// mid-stream when they exceed TargetSectionSize. The aggregation model
+// requires all observations for a section to be present before encoding
+// (bitmap normalization, bloom filter construction). The builderFull flag
+// provides back-pressure via TargetObjectSize.
+func (b *Builder) ObserveLabelPosting(tenantID string, obs postings.LabelObservation) error {
 	b.metrics.appendsTotal.Inc()
 
 	timer := prometheus.NewTimer(b.metrics.appendTime)
@@ -198,7 +200,7 @@ func (b *Builder) ObserveLabelPosting(tenantID, objectPath string, sectionIdx in
 	tenantPostings := b.getPostingsBuilderForTenant(tenantID)
 	preSize := tenantPostings.EstimatedSize()
 
-	tenantPostings.ObserveLabelPosting(objectPath, sectionIdx, columnName, labelValue, streamID, ts, uncompressedSize)
+	tenantPostings.ObserveLabelPosting(obs)
 
 	postSize := tenantPostings.EstimatedSize()
 	b.unflushedSizeEstimate += postSize - preSize
@@ -219,11 +221,11 @@ func (b *Builder) PrepareBloomColumn(tenantID, objectPath string, sectionIdx int
 	tenantPostings.PrepareBloomColumn(objectPath, sectionIdx, columnName, estimatedCardinality)
 }
 
-// ObserveBloomPosting records a bloom-filter posting observation for a data object column.
-// Returns an error if the column has not been prepared via PrepareBloomColumn.
-// The aggregated postings are flushed when [Builder.Flush] is called.
-func (b *Builder) ObserveBloomPosting(tenantID, objectPath string, sectionIdx int64,
-	columnName, value string, streamID, uncompressedSize int64, ts time.Time) error {
+// ObserveBloomPosting records a bloom-filter posting observation for a data
+// object column. Returns an error if the column has not been prepared via
+// PrepareBloomColumn. The aggregated postings are flushed when
+// [Builder.Flush] is called.
+func (b *Builder) ObserveBloomPosting(tenantID string, obs postings.BloomObservation) error {
 	b.metrics.appendsTotal.Inc()
 
 	timer := prometheus.NewTimer(b.metrics.appendTime)
@@ -232,7 +234,7 @@ func (b *Builder) ObserveBloomPosting(tenantID, objectPath string, sectionIdx in
 	tenantPostings := b.getPostingsBuilderForTenant(tenantID)
 	preSize := tenantPostings.EstimatedSize()
 
-	if err := tenantPostings.ObserveBloomPosting(objectPath, sectionIdx, columnName, value, streamID, ts, uncompressedSize); err != nil {
+	if err := tenantPostings.ObserveBloomPosting(obs); err != nil {
 		return err
 	}
 

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -183,6 +183,11 @@ func (b *Builder) AppendStat(tenantID, objectPath string, sectionIdx int64,
 // ObserveLabelPosting records a label-based posting observation for a data object column.
 // Multiple observations for the same (objectPath, sectionIdx, columnName, labelValue) are aggregated internally.
 // The aggregated postings are flushed when [Builder.Flush] is called.
+//
+// Unlike other section types (stats, pointers), postings are NOT flushed mid-stream
+// when they exceed TargetSectionSize. The aggregation model requires all observations
+// for a section to be present before encoding (bitmap normalization, bloom filter
+// construction). The builderFull flag provides back-pressure via TargetObjectSize.
 func (b *Builder) ObserveLabelPosting(tenantID, objectPath string, sectionIdx int64,
 	columnName, labelValue string, streamID, uncompressedSize int64, ts time.Time) error {
 	b.metrics.appendsTotal.Inc()

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -133,7 +133,7 @@ func (b *Builder) getStatsBuilderForTenant(tenantID string) *stats.Builder {
 
 func (b *Builder) getPostingsBuilderForTenant(tenantID string) *postings.Builder {
 	if _, ok := b.postings[tenantID]; !ok {
-		pb := postings.NewBuilder(b.metrics.postings, postings.ColumnarSectionEncoder(int(b.cfg.TargetPageSize), b.cfg.MaxPageRows))
+		pb := postings.NewBuilder(b.metrics.postings, int(b.cfg.TargetPageSize), b.cfg.MaxPageRows)
 		pb.SetTenant(tenantID)
 		b.postings[tenantID] = pb
 	}
@@ -180,89 +180,73 @@ func (b *Builder) AppendStat(tenantID, objectPath string, sectionIdx int64,
 	return nil
 }
 
-// AppendLabelPosting records a label-based posting for a data object column.
-func (b *Builder) AppendLabelPosting(tenantID, objectPath string, sectionIdx int64,
-	columnName string, labelValue string, streamIDBitmap []byte,
-	uncompressedSize int64, minTs, maxTs time.Time) error {
+// ObserveLabelPosting records a label-based posting observation for a data object column.
+// Multiple observations for the same (objectPath, sectionIdx, columnName, labelValue) are aggregated internally.
+// The aggregated postings are flushed when [Builder.Flush] is called.
+func (b *Builder) ObserveLabelPosting(tenantID, objectPath string, sectionIdx int64,
+	columnName, labelValue string, streamID, uncompressedSize int64, ts time.Time) error {
 	b.metrics.appendsTotal.Inc()
 
 	timer := prometheus.NewTimer(b.metrics.appendTime)
 	defer timer.ObserveDuration()
 
 	tenantPostings := b.getPostingsBuilderForTenant(tenantID)
-	preAppendSizeEstimate := tenantPostings.EstimatedSize()
+	preSize := tenantPostings.EstimatedSize()
 
-	tenantPostings.Append(postings.Posting{
-		Kind:             postings.KindLabel,
-		ObjectPath:       objectPath,
-		SectionIndex:     sectionIdx,
-		ColumnName:       columnName,
-		LabelValue:       labelValue,
-		BloomFilter:      nil,
-		StreamIDBitmap:   streamIDBitmap,
-		UncompressedSize: uncompressedSize,
-		MinTimestamp:     minTs.UnixNano(),
-		MaxTimestamp:     maxTs.UnixNano(),
-	})
+	tenantPostings.ObserveLabelPosting(objectPath, sectionIdx, columnName, labelValue, streamID, ts, uncompressedSize)
 
-	postAppendSizeEstimate := tenantPostings.EstimatedSize()
-	b.unflushedSizeEstimate += postAppendSizeEstimate - preAppendSizeEstimate
-
-	if postAppendSizeEstimate > int(b.cfg.TargetSectionSize) {
-		if err := b.builder.Append(tenantPostings); err != nil {
-			return err
-		}
-	}
+	postSize := tenantPostings.EstimatedSize()
+	b.unflushedSizeEstimate += postSize - preSize
 
 	b.currentSizeEstimate = b.estimatedSize()
 	b.state = builderStateDirty
 	if b.currentSizeEstimate > int(b.cfg.TargetObjectSize) {
 		b.builderFull = true
 	}
-
 	return nil
 }
 
-// AppendBloomPosting records a Bloom-filter posting for a data object column.
-func (b *Builder) AppendBloomPosting(tenantID, objectPath string, sectionIdx int64,
-	columnName string, bloomFilter []byte, streamIDBitmap []byte,
-	uncompressedSize int64, minTs, maxTs time.Time) error {
+// PrepareBloomColumn initializes the bloom filter for a specific column.
+// Must be called before any ObserveBloomPosting calls for the given (objectPath, sectionIdx, columnName).
+func (b *Builder) PrepareBloomColumn(tenantID, objectPath string, sectionIdx int64,
+	columnName string, estimatedCardinality uint) {
+	tenantPostings := b.getPostingsBuilderForTenant(tenantID)
+	tenantPostings.PrepareBloomColumn(objectPath, sectionIdx, columnName, estimatedCardinality)
+}
+
+// ObserveBloomPosting records a bloom-filter posting observation for a data object column.
+// Returns an error if the column has not been prepared via PrepareBloomColumn.
+// The aggregated postings are flushed when [Builder.Flush] is called.
+func (b *Builder) ObserveBloomPosting(tenantID, objectPath string, sectionIdx int64,
+	columnName, value string, streamID, uncompressedSize int64, ts time.Time) error {
 	b.metrics.appendsTotal.Inc()
 
 	timer := prometheus.NewTimer(b.metrics.appendTime)
 	defer timer.ObserveDuration()
 
 	tenantPostings := b.getPostingsBuilderForTenant(tenantID)
-	preAppendSizeEstimate := tenantPostings.EstimatedSize()
+	preSize := tenantPostings.EstimatedSize()
 
-	tenantPostings.Append(postings.Posting{
-		Kind:             postings.KindBloom,
-		ObjectPath:       objectPath,
-		SectionIndex:     sectionIdx,
-		ColumnName:       columnName,
-		BloomFilter:      bloomFilter,
-		StreamIDBitmap:   streamIDBitmap,
-		UncompressedSize: uncompressedSize,
-		MinTimestamp:     minTs.UnixNano(),
-		MaxTimestamp:     maxTs.UnixNano(),
-	})
-
-	postAppendSizeEstimate := tenantPostings.EstimatedSize()
-	b.unflushedSizeEstimate += postAppendSizeEstimate - preAppendSizeEstimate
-
-	if postAppendSizeEstimate > int(b.cfg.TargetSectionSize) {
-		if err := b.builder.Append(tenantPostings); err != nil {
-			return err
-		}
+	if err := tenantPostings.ObserveBloomPosting(objectPath, sectionIdx, columnName, value, streamID, ts, uncompressedSize); err != nil {
+		return err
 	}
+
+	postSize := tenantPostings.EstimatedSize()
+	b.unflushedSizeEstimate += postSize - preSize
 
 	b.currentSizeEstimate = b.estimatedSize()
 	b.state = builderStateDirty
 	if b.currentSizeEstimate > int(b.cfg.TargetObjectSize) {
 		b.builderFull = true
 	}
-
 	return nil
+}
+
+// BloomBytes returns the marshaled bloom filter bytes for a specific column.
+// Returns an error if the column has not been prepared via PrepareBloomColumn.
+func (b *Builder) BloomBytes(tenantID, objectPath string, sectionIdx int64, columnName string) ([]byte, error) {
+	tenantPostings := b.getPostingsBuilderForTenant(tenantID)
+	return tenantPostings.BloomBytes(objectPath, sectionIdx, columnName)
 }
 
 func (b *Builder) AppendIndexPointer(tenantID string, path string, startTs time.Time, endTs time.Time) error {
@@ -371,12 +355,7 @@ func (b *Builder) getPointersBuilderForTenant(tenantID string) *pointers.Builder
 	return tenantPointers
 }
 
-// Append buffers a stream to be written to a data object. Append returns an
-// error if the stream labels cannot be parsed or [ErrBuilderFull] if the
-// builder is full.
-//
-// Once a Builder is full, call [Builder.Flush] to flush the buffered data,
-// then call Append again with the same entry.
+// ObserveLogLine records a log line observation for a stream in the pointers section.
 func (b *Builder) ObserveLogLine(tenantID string, path string, section int64, streamIDInObject int64, streamIDInIndex int64, ts time.Time, uncompressedSize int64) error {
 	// Check whether the buffer is full before a stream can be appended; this is
 	// tends to overestimate, but we may still go over our target size.
@@ -407,12 +386,7 @@ func (b *Builder) ObserveLogLine(tenantID string, path string, section int64, st
 	return nil
 }
 
-// Append buffers a stream to be written to a data object. Append returns an
-// error if the stream labels cannot be parsed or [ErrBuilderFull] if the
-// builder is full.
-//
-// Once a Builder is full, call [Builder.Flush] to flush the buffered data,
-// then call Append again with the same entry.
+// AppendColumnIndex records a column index entry with bloom filter data in the pointers section.
 func (b *Builder) AppendColumnIndex(tenantID string, path string, section int64, columnName string, columnIndex int64, valuesBloom []byte) error {
 	// Check whether the buffer is full before a stream can be appended; this is
 	// tends to overestimate, but we may still go over our target size.

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -52,6 +52,15 @@ type Builder struct {
 	stats         map[string]*stats.Builder         // The key is the TenantID.
 	postings      map[string]*postings.Builder      // The key is the TenantID.
 
+	// Hot-path cache for the postings builder. Postings are observed per
+	// (record × stream label), so getPostingsBuilderForTenant runs in a tight
+	// loop. The Calculate pipeline holds builderMtx for the entire ProcessBatch
+	// of a single tenant, so consecutive observations always target the same
+	// tenant; caching the resolved pointer lets the inner loop skip the map
+	// lookup. Invalidated on Reset.
+	lastPostingsTenant  string
+	lastPostingsBuilder *postings.Builder
+
 	// Optimization to avoid recalculating the size by asking all tenants for their estimated size.
 	unflushedSizeEstimate int
 
@@ -132,12 +141,18 @@ func (b *Builder) getStatsBuilderForTenant(tenantID string) *stats.Builder {
 }
 
 func (b *Builder) getPostingsBuilderForTenant(tenantID string) *postings.Builder {
-	if _, ok := b.postings[tenantID]; !ok {
-		pb := postings.NewBuilder(b.metrics.postings, int(b.cfg.TargetPageSize), b.cfg.MaxPageRows)
+	if b.lastPostingsBuilder != nil && b.lastPostingsTenant == tenantID {
+		return b.lastPostingsBuilder
+	}
+	pb, ok := b.postings[tenantID]
+	if !ok {
+		pb = postings.NewBuilder(b.metrics.postings, int(b.cfg.TargetPageSize), b.cfg.MaxPageRows)
 		pb.SetTenant(tenantID)
 		b.postings[tenantID] = pb
 	}
-	return b.postings[tenantID]
+	b.lastPostingsTenant = tenantID
+	b.lastPostingsBuilder = pb
+	return pb
 }
 
 // AppendStat records a per-sort-key aggregate for a data object section.
@@ -558,6 +573,8 @@ func (b *Builder) Reset() {
 	clear(b.indexPointers)
 	b.stats = make(map[string]*stats.Builder)
 	b.postings = make(map[string]*postings.Builder)
+	b.lastPostingsTenant = ""
+	b.lastPostingsBuilder = nil
 
 	b.metrics.sizeEstimate.Set(0)
 	b.currentSizeEstimate = 0

--- a/pkg/dataobj/index/label_postings_calculation.go
+++ b/pkg/dataobj/index/label_postings_calculation.go
@@ -1,132 +1,50 @@
 package index
 
 import (
-	"cmp"
 	"context"
-	"slices"
-	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
-	"github.com/grafana/loki/v3/pkg/memory"
 )
 
 // created for and scoped to each logs section
-type labelPostingsCalculation struct {
-	postingsByKey map[postingKey]*labelPosting
-	maxStreamID   int64
-}
-
-type postingKey struct {
-	columnName string
-	labelValue string
-}
-
-type labelPosting struct {
-	streamIDBitmap   memory.Bitmap
-	minTimestamp     time.Time
-	maxTimestamp     time.Time
-	uncompressedSize int64
-}
+type labelPostingsCalculation struct{}
 
 func (c *labelPostingsCalculation) Name() string { return "label_postings" }
 
 // ProcessBatchNeedsBuilderLock reports whether ProcessBatch mutates the shared
-// builder. Label postings only mutate step-local postings maps during
-// ProcessBatch; shared-builder writes happen in Flush, so no lock is required.
-func (c *labelPostingsCalculation) ProcessBatchNeedsBuilderLock() bool { return false }
+// builder. Label postings calls builder.ObserveLabelPosting per stream label,
+// which writes into the shared postings builder, so it must run under the
+// builder lock.
+func (c *labelPostingsCalculation) ProcessBatchNeedsBuilderLock() bool { return true }
 
-func (c *labelPostingsCalculation) Prepare(_ context.Context, _ *dataobj.Section, _ logs.Stats) error {
-	c.postingsByKey = make(map[postingKey]*labelPosting)
-	c.maxStreamID = 0
+func (c *labelPostingsCalculation) Prepare(_ context.Context, _ *logsCalculationContext, _ *dataobj.Section, _ logs.Stats) error {
 	return nil
 }
 
 func (c *labelPostingsCalculation) ProcessBatch(_ context.Context, calcCtx *logsCalculationContext, batch []logs.Record) error {
+	var batchErr error
 	for _, log := range batch {
-		streamLbls := calcCtx.streamLabels[log.StreamID]
-
-		if log.StreamID > c.maxStreamID {
-			c.maxStreamID = log.StreamID
+		if batchErr != nil {
+			break
 		}
-
-		// Create postings for every stream label key/value pair
+		streamLbls := calcCtx.streamLabels[log.StreamID]
 		streamLbls.Range(func(lbl labels.Label) {
-			pk := postingKey{columnName: lbl.Name, labelValue: lbl.Value}
-
-			posting, ok := c.postingsByKey[pk]
-			if !ok {
-				posting = &labelPosting{
-					streamIDBitmap: memory.NewBitmap(nil, 0),
-					minTimestamp:   log.Timestamp,
-					maxTimestamp:   log.Timestamp,
-				}
-				c.postingsByKey[pk] = posting
+			if batchErr != nil {
+				return
 			}
-
-			// Grow the bitmap if needed and set the bit for this stream ID.
-			if int(log.StreamID) >= posting.streamIDBitmap.Len() {
-				posting.streamIDBitmap.Resize(int(log.StreamID) + 1)
-			}
-			posting.streamIDBitmap.Set(int(log.StreamID), true)
-
-			if log.Timestamp.Before(posting.minTimestamp) {
-				posting.minTimestamp = log.Timestamp
-			}
-			if log.Timestamp.After(posting.maxTimestamp) {
-				posting.maxTimestamp = log.Timestamp
-			}
-			posting.uncompressedSize += int64(len(log.Line))
+			batchErr = calcCtx.builder.ObserveLabelPosting(
+				calcCtx.tenantID, calcCtx.objectPath, calcCtx.sectionIdx,
+				lbl.Name, lbl.Value, log.StreamID,
+				int64(len(log.Line)), log.Timestamp,
+			)
 		})
 	}
-	return nil
+	return batchErr
 }
 
-func (c *labelPostingsCalculation) Flush(_ context.Context, calcCtx *logsCalculationContext) error {
-	if len(c.postingsByKey) == 0 {
-		return nil
-	}
-
-	// Normalize all bitmaps to the same size.
-	targetSize := int(c.maxStreamID) + 1
-	for _, posting := range c.postingsByKey {
-		if posting.streamIDBitmap.Len() < targetSize {
-			posting.streamIDBitmap.Resize(targetSize)
-		}
-	}
-
-	// Sort postings by [columnName, labelValue] for deterministic output.
-	keys := make([]postingKey, 0, len(c.postingsByKey))
-	for k := range c.postingsByKey {
-		keys = append(keys, k)
-	}
-	slices.SortFunc(keys, func(a, b postingKey) int {
-		if c := cmp.Compare(a.columnName, b.columnName); c != 0 {
-			return c
-		}
-		return cmp.Compare(a.labelValue, b.labelValue)
-	})
-
-	for _, key := range keys {
-		posting := c.postingsByKey[key]
-		bitmapData, _ := posting.streamIDBitmap.Bytes()
-
-		err := calcCtx.builder.AppendLabelPosting(
-			calcCtx.tenantID,
-			calcCtx.objectPath,
-			calcCtx.sectionIdx,
-			key.columnName,
-			key.labelValue,
-			bitmapData,
-			posting.uncompressedSize,
-			posting.minTimestamp,
-			posting.maxTimestamp,
-		)
-		if err != nil {
-			return err
-		}
-	}
+func (c *labelPostingsCalculation) Flush(_ context.Context, _ *logsCalculationContext) error {
 	return nil
 }

--- a/pkg/dataobj/index/label_postings_calculation.go
+++ b/pkg/dataobj/index/label_postings_calculation.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
 )
 
 // created for and scoped to each logs section
@@ -35,11 +36,15 @@ func (c *labelPostingsCalculation) ProcessBatch(_ context.Context, calcCtx *logs
 			if batchErr != nil {
 				return
 			}
-			batchErr = calcCtx.builder.ObserveLabelPosting(
-				calcCtx.tenantID, calcCtx.objectPath, calcCtx.sectionIdx,
-				lbl.Name, lbl.Value, log.StreamID,
-				int64(len(log.Line)), log.Timestamp,
-			)
+			batchErr = calcCtx.builder.ObserveLabelPosting(calcCtx.tenantID, postings.LabelObservation{
+				ObjectPath:       calcCtx.objectPath,
+				SectionIndex:     calcCtx.sectionIdx,
+				ColumnName:       lbl.Name,
+				LabelValue:       lbl.Value,
+				StreamID:         log.StreamID,
+				Timestamp:        log.Timestamp,
+				UncompressedSize: int64(len(log.Line)),
+			})
 		})
 	}
 	return batchErr

--- a/pkg/dataobj/index/label_postings_calculation_test.go
+++ b/pkg/dataobj/index/label_postings_calculation_test.go
@@ -62,7 +62,7 @@ func TestLabelPostingsCalculation_BasicPostings(t *testing.T) {
 	calcCtx := makeTestCalcContext(builder)
 	calc := &labelPostingsCalculation{}
 
-	require.NoError(t, calc.Prepare(context.Background(), nil, logs.Stats{}))
+	require.NoError(t, calc.Prepare(context.Background(), calcCtx, nil, logs.Stats{}))
 
 	ts1 := time.Unix(100, 0).UTC()
 	ts2 := time.Unix(200, 0).UTC()
@@ -117,7 +117,7 @@ func TestLabelPostingsCalculation_BitmapsNormalized(t *testing.T) {
 	calcCtx := makeTestCalcContext(builder)
 	calc := &labelPostingsCalculation{}
 
-	require.NoError(t, calc.Prepare(context.Background(), nil, logs.Stats{}))
+	require.NoError(t, calc.Prepare(context.Background(), calcCtx, nil, logs.Stats{}))
 
 	// Stream 1 = svcA/prod, Stream 2 = svcB/dev (from makeTestStreamLabels).
 	batch := []logs.Record{
@@ -164,7 +164,7 @@ func TestLabelPostingsCalculation_TimestampsAndSizes(t *testing.T) {
 	calcCtx := makeTestCalcContext(builder)
 	calc := &labelPostingsCalculation{}
 
-	require.NoError(t, calc.Prepare(context.Background(), nil, logs.Stats{}))
+	require.NoError(t, calc.Prepare(context.Background(), calcCtx, nil, logs.Stats{}))
 
 	ts1 := time.Unix(10, 0).UTC()
 	ts2 := time.Unix(20, 0).UTC()
@@ -197,7 +197,7 @@ func TestLabelPostingsCalculation_EmptyBatch(t *testing.T) {
 	calcCtx := makeTestCalcContext(builder)
 	calc := &labelPostingsCalculation{}
 
-	require.NoError(t, calc.Prepare(context.Background(), nil, logs.Stats{}))
+	require.NoError(t, calc.Prepare(context.Background(), calcCtx, nil, logs.Stats{}))
 	require.NoError(t, calc.ProcessBatch(context.Background(), calcCtx, nil))
 	require.NoError(t, calc.Flush(context.Background(), calcCtx))
 
@@ -211,7 +211,7 @@ func TestLabelPostingsCalculation_MultipleBatches(t *testing.T) {
 	calcCtx := makeTestCalcContext(builder)
 	calc := &labelPostingsCalculation{}
 
-	require.NoError(t, calc.Prepare(context.Background(), nil, logs.Stats{}))
+	require.NoError(t, calc.Prepare(context.Background(), calcCtx, nil, logs.Stats{}))
 
 	batch1 := []logs.Record{
 		{StreamID: 1, Timestamp: time.Unix(1, 0).UTC(), Line: []byte("a")},
@@ -291,7 +291,7 @@ func BenchmarkLabelPostingsCalculation_ProcessBatch(b *testing.B) {
 				}
 				calc := &labelPostingsCalculation{}
 
-				if err := calc.Prepare(context.Background(), nil, logs.Stats{}); err != nil {
+				if err := calc.Prepare(context.Background(), calcCtx, nil, logs.Stats{}); err != nil {
 					b.Fatal(err)
 				}
 				if err := calc.ProcessBatch(context.Background(), calcCtx, batch); err != nil {

--- a/pkg/dataobj/index/stats_calculation.go
+++ b/pkg/dataobj/index/stats_calculation.go
@@ -34,7 +34,7 @@ func (c *statsCalculation) Name() string { return "stats" }
 // shared-builder writes happen in Flush, so no lock is required.
 func (c *statsCalculation) ProcessBatchNeedsBuilderLock() bool { return false }
 
-func (c *statsCalculation) Prepare(_ context.Context, _ *dataobj.Section, _ logs.Stats) error {
+func (c *statsCalculation) Prepare(_ context.Context, _ *logsCalculationContext, _ *dataobj.Section, _ logs.Stats) error {
 	c.aggregates = make(map[uint64]*statsAggregate)
 	return nil
 }

--- a/pkg/dataobj/index/stats_calculation_test.go
+++ b/pkg/dataobj/index/stats_calculation_test.go
@@ -79,7 +79,7 @@ func TestStatsCalculation_BasicAggregation(t *testing.T) {
 	ctx := makeTestCalcContext(builder)
 	calc := &statsCalculation{sortSchemaKeys: defaultSortSchemaKeys}
 
-	require.NoError(t, calc.Prepare(context.Background(), nil, logs.Stats{}))
+	require.NoError(t, calc.Prepare(context.Background(), ctx, nil, logs.Stats{}))
 
 	ts1 := time.Unix(100, 0).UTC()
 	ts2 := time.Unix(200, 0).UTC()
@@ -127,7 +127,7 @@ func TestStatsCalculation_MetadataFields(t *testing.T) {
 	ctx := makeTestCalcContext(builder)
 	calc := &statsCalculation{sortSchemaKeys: defaultSortSchemaKeys}
 
-	require.NoError(t, calc.Prepare(context.Background(), nil, logs.Stats{}))
+	require.NoError(t, calc.Prepare(context.Background(), ctx, nil, logs.Stats{}))
 
 	ts := time.Unix(500, 0).UTC()
 	batch := []logs.Record{
@@ -152,7 +152,7 @@ func TestStatsCalculation_MissingServiceName(t *testing.T) {
 	ctx := makeTestCalcContext(builder)
 	calc := &statsCalculation{sortSchemaKeys: defaultSortSchemaKeys}
 
-	require.NoError(t, calc.Prepare(context.Background(), nil, logs.Stats{}))
+	require.NoError(t, calc.Prepare(context.Background(), ctx, nil, logs.Stats{}))
 
 	batch := []logs.Record{
 		{StreamID: 3, Timestamp: time.Unix(1, 0).UTC(), Line: []byte("no svc")},
@@ -170,7 +170,7 @@ func TestStatsCalculation_MultipleBatches(t *testing.T) {
 	ctx := makeTestCalcContext(builder)
 	calc := &statsCalculation{sortSchemaKeys: defaultSortSchemaKeys}
 
-	require.NoError(t, calc.Prepare(context.Background(), nil, logs.Stats{}))
+	require.NoError(t, calc.Prepare(context.Background(), ctx, nil, logs.Stats{}))
 
 	// First batch.
 	batch1 := []logs.Record{
@@ -207,7 +207,7 @@ func TestStatsCalculation_EmptyBatch(t *testing.T) {
 	ctx := makeTestCalcContext(builder)
 	calc := &statsCalculation{sortSchemaKeys: defaultSortSchemaKeys}
 
-	require.NoError(t, calc.Prepare(context.Background(), nil, logs.Stats{}))
+	require.NoError(t, calc.Prepare(context.Background(), ctx, nil, logs.Stats{}))
 	require.NoError(t, calc.ProcessBatch(context.Background(), ctx, nil))
 	require.NoError(t, calc.Flush(context.Background(), ctx))
 

--- a/pkg/dataobj/index/stream_statistics.go
+++ b/pkg/dataobj/index/stream_statistics.go
@@ -18,7 +18,7 @@ func (c *streamStatisticsCalculation) Name() string { return "stream_statistics"
 // run under the builder lock.
 func (c *streamStatisticsCalculation) ProcessBatchNeedsBuilderLock() bool { return true }
 
-func (c *streamStatisticsCalculation) Prepare(_ context.Context, _ *dataobj.Section, _ logs.Stats) error {
+func (c *streamStatisticsCalculation) Prepare(_ context.Context, _ *logsCalculationContext, _ *dataobj.Section, _ logs.Stats) error {
 	return nil
 }
 

--- a/pkg/dataobj/sections/postings/bloom_aggregator.go
+++ b/pkg/dataobj/sections/postings/bloom_aggregator.go
@@ -1,0 +1,185 @@
+package postings
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/bits-and-blooms/bloom/v3"
+
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// bloomPostingKey is the unique key for a bloom posting aggregation entry.
+type bloomPostingKey struct {
+	objectPath   string
+	sectionIndex int64
+	columnName   string
+}
+
+// bloomPostingEntry holds the aggregated state for a single bloom posting.
+type bloomPostingEntry struct {
+	ObjectPath       string
+	SectionIndex     int64
+	ColumnName       string
+	bloomFilter      *bloom.BloomFilter
+	bitmap           memory.Bitmap
+	MinTimestamp     int64
+	MaxTimestamp     int64
+	UncompressedSize int64
+}
+
+// BloomFilter returns the bloom filter for this entry.
+func (e *bloomPostingEntry) BloomFilter() *bloom.BloomFilter {
+	return e.bloomFilter
+}
+
+// BloomBytes marshals the bloom filter to binary and returns the bytes.
+func (e *bloomPostingEntry) BloomBytes() ([]byte, error) {
+	b, err := e.bloomFilter.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("marshaling bloom filter: %w", err)
+	}
+	return b, nil
+}
+
+// BitmapBytes returns the raw bytes of the bitmap trimmed to the logical size
+// (ceil(Len()/8) bytes). Offset is always 0 for bitmaps built with Resize/Set.
+func (e *bloomPostingEntry) BitmapBytes() []byte {
+	data, _ := e.bitmap.Bytes()
+	n := (e.bitmap.Len() + 7) / 8
+	if n > len(data) {
+		n = len(data)
+	}
+	return data[:n]
+}
+
+// bloomAggregator aggregates bloom posting observations per metadata column.
+// It is NOT goroutine-safe; callers must synchronize if needed.
+type bloomAggregator struct {
+	entries       map[bloomPostingKey]*bloomPostingEntry
+	maxStreamID   int64
+	estimatedSize int
+}
+
+// newBloomAggregator creates a new bloomAggregator.
+func newBloomAggregator() *bloomAggregator {
+	return &bloomAggregator{
+		entries: make(map[bloomPostingKey]*bloomPostingEntry),
+	}
+}
+
+// PrepareColumn initializes the bloom filter for a specific column. Must be
+// called before any Observe calls for the given (objectPath, sectionIndex,
+// columnName) combination.
+func (a *bloomAggregator) PrepareColumn(objectPath string, sectionIndex int64, columnName string, estimatedCardinality uint) {
+	key := bloomPostingKey{
+		objectPath:   objectPath,
+		sectionIndex: sectionIndex,
+		columnName:   columnName,
+	}
+	if _, ok := a.entries[key]; ok {
+		// Already prepared; do not overwrite.
+		return
+	}
+
+	entry := &bloomPostingEntry{
+		ObjectPath:   objectPath,
+		SectionIndex: sectionIndex,
+		ColumnName:   columnName,
+		bloomFilter:  bloom.NewWithEstimates(estimatedCardinality, 1.0/128.0),
+		bitmap:       memory.NewBitmap(nil, 0),
+		MinTimestamp: math.MaxInt64,
+		MaxTimestamp: math.MinInt64,
+	}
+	a.entries[key] = entry
+
+	// Track size estimate for new entry: 5 int64 fields + string sizes + bloom filter capacity.
+	a.estimatedSize += 5*8 + len(objectPath) + len(columnName) + int(entry.bloomFilter.Cap()/8)
+}
+
+// Observe records a single observation for a bloom column. Returns an error if
+// the column has not been prepared via PrepareColumn.
+func (a *bloomAggregator) Observe(objectPath string, sectionIndex int64, columnName, value string, streamID int64, ts time.Time, uncompressedSize int64) error {
+	key := bloomPostingKey{
+		objectPath:   objectPath,
+		sectionIndex: sectionIndex,
+		columnName:   columnName,
+	}
+
+	entry, ok := a.entries[key]
+	if !ok {
+		return fmt.Errorf("bloom column not prepared: objectPath=%q sectionIndex=%d columnName=%q", objectPath, sectionIndex, columnName)
+	}
+
+	entry.bloomFilter.Add([]byte(value))
+
+	// Grow bitmap if needed and set the bit for this stream ID.
+	if int(streamID) >= entry.bitmap.Len() {
+		prevLen := entry.bitmap.Len()
+		entry.bitmap.Resize(int(streamID) + 1)
+		// Track bitmap growth in estimated size.
+		newBytes := (entry.bitmap.Len() + 7) / 8
+		oldBytes := (prevLen + 7) / 8
+		a.estimatedSize += newBytes - oldBytes
+	}
+	entry.bitmap.Set(int(streamID), true)
+
+	tsNano := ts.UnixNano()
+	if tsNano < entry.MinTimestamp {
+		entry.MinTimestamp = tsNano
+	}
+	if tsNano > entry.MaxTimestamp {
+		entry.MaxTimestamp = tsNano
+	}
+	entry.UncompressedSize += uncompressedSize
+
+	if streamID > a.maxStreamID {
+		a.maxStreamID = streamID
+	}
+
+	return nil
+}
+
+// Entries returns all aggregated entries. Bitmap normalization (padding to
+// equal length) is NOT done here; the caller (columnarEncode) handles it
+// across both label and bloom entries.
+func (a *bloomAggregator) Entries() []*bloomPostingEntry {
+	if len(a.entries) == 0 {
+		return nil
+	}
+
+	result := make([]*bloomPostingEntry, 0, len(a.entries))
+	for _, entry := range a.entries {
+		result = append(result, entry)
+	}
+	return result
+}
+
+// BloomBytes marshals and returns the bloom filter bytes for a specific column.
+// Returns an error if the column has not been prepared.
+func (a *bloomAggregator) BloomBytes(objectPath string, sectionIndex int64, columnName string) ([]byte, error) {
+	key := bloomPostingKey{
+		objectPath:   objectPath,
+		sectionIndex: sectionIndex,
+		columnName:   columnName,
+	}
+	entry, ok := a.entries[key]
+	if !ok {
+		return nil, fmt.Errorf("bloom column not prepared: objectPath=%q sectionIndex=%d columnName=%q", objectPath, sectionIndex, columnName)
+	}
+	return entry.BloomBytes()
+}
+
+// EstimatedSize returns an O(1) estimate of the encoded size of all
+// accumulated observations in bytes.
+func (a *bloomAggregator) EstimatedSize() int {
+	return a.estimatedSize
+}
+
+// Reset clears all accumulated state including prepared columns.
+func (a *bloomAggregator) Reset() {
+	a.entries = make(map[bloomPostingKey]*bloomPostingEntry)
+	a.maxStreamID = 0
+	a.estimatedSize = 0
+}

--- a/pkg/dataobj/sections/postings/bloom_aggregator.go
+++ b/pkg/dataobj/sections/postings/bloom_aggregator.go
@@ -3,7 +3,6 @@ package postings
 import (
 	"fmt"
 	"math"
-	"time"
 
 	"github.com/bits-and-blooms/bloom/v3"
 
@@ -99,39 +98,39 @@ func (a *bloomAggregator) PrepareColumn(objectPath string, sectionIndex int64, c
 
 // Observe records a single observation for a bloom column. Returns an error if
 // the column has not been prepared via PrepareColumn.
-func (a *bloomAggregator) Observe(objectPath string, sectionIndex int64, columnName, value string, streamID int64, ts time.Time, uncompressedSize int64) error {
+func (a *bloomAggregator) Observe(obs BloomObservation) error {
 	key := bloomPostingKey{
-		objectPath:   objectPath,
-		sectionIndex: sectionIndex,
-		columnName:   columnName,
+		objectPath:   obs.ObjectPath,
+		sectionIndex: obs.SectionIndex,
+		columnName:   obs.ColumnName,
 	}
 
 	entry, ok := a.entries[key]
 	if !ok {
-		return fmt.Errorf("bloom column not prepared: objectPath=%q sectionIndex=%d columnName=%q", objectPath, sectionIndex, columnName)
+		return fmt.Errorf("bloom column not prepared: objectPath=%q sectionIndex=%d columnName=%q", obs.ObjectPath, obs.SectionIndex, obs.ColumnName)
 	}
 
-	entry.bloomFilter.Add([]byte(value))
+	entry.bloomFilter.Add([]byte(obs.Value))
 
 	// Grow bitmap if needed and set the bit for this stream ID.
-	if int(streamID) >= entry.bitmap.Len() {
+	if int(obs.StreamID) >= entry.bitmap.Len() {
 		prevLen := entry.bitmap.Len()
-		entry.bitmap.Resize(int(streamID) + 1)
+		entry.bitmap.Resize(int(obs.StreamID) + 1)
 		// Track bitmap growth in estimated size.
 		newBytes := (entry.bitmap.Len() + 7) / 8
 		oldBytes := (prevLen + 7) / 8
 		a.estimatedSize += newBytes - oldBytes
 	}
-	entry.bitmap.Set(int(streamID), true)
+	entry.bitmap.Set(int(obs.StreamID), true)
 
-	tsNano := ts.UnixNano()
+	tsNano := obs.Timestamp.UnixNano()
 	if tsNano < entry.MinTimestamp {
 		entry.MinTimestamp = tsNano
 	}
 	if tsNano > entry.MaxTimestamp {
 		entry.MaxTimestamp = tsNano
 	}
-	entry.UncompressedSize += uncompressedSize
+	entry.UncompressedSize += obs.UncompressedSize
 
 	return nil
 }

--- a/pkg/dataobj/sections/postings/bloom_aggregator.go
+++ b/pkg/dataobj/sections/postings/bloom_aggregator.go
@@ -58,7 +58,6 @@ func (e *bloomPostingEntry) BitmapBytes() []byte {
 // It is NOT goroutine-safe; callers must synchronize if needed.
 type bloomAggregator struct {
 	entries       map[bloomPostingKey]*bloomPostingEntry
-	maxStreamID   int64
 	estimatedSize int
 }
 
@@ -134,10 +133,6 @@ func (a *bloomAggregator) Observe(objectPath string, sectionIndex int64, columnN
 	}
 	entry.UncompressedSize += uncompressedSize
 
-	if streamID > a.maxStreamID {
-		a.maxStreamID = streamID
-	}
-
 	return nil
 }
 
@@ -180,6 +175,5 @@ func (a *bloomAggregator) EstimatedSize() int {
 // Reset clears all accumulated state including prepared columns.
 func (a *bloomAggregator) Reset() {
 	a.entries = make(map[bloomPostingKey]*bloomPostingEntry)
-	a.maxStreamID = 0
 	a.estimatedSize = 0
 }

--- a/pkg/dataobj/sections/postings/builder.go
+++ b/pkg/dataobj/sections/postings/builder.go
@@ -3,7 +3,6 @@ package postings
 import (
 	"fmt"
 	"sort"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -53,17 +52,18 @@ func (b *Builder) PrepareBloomColumn(objectPath string, sectionIndex int64, colu
 	b.blooms.PrepareColumn(objectPath, sectionIndex, columnName, estimatedCardinality)
 }
 
-// ObserveLabelPosting records a label posting observation. Multiple observations
-// for the same (objectPath, sectionIndex, columnName, labelValue) key are
-// aggregated into a single posting.
-func (b *Builder) ObserveLabelPosting(objectPath string, sectionIndex int64, columnName, labelValue string, streamID int64, ts time.Time, uncompressedSize int64) {
-	b.labels.Observe(objectPath, sectionIndex, columnName, labelValue, streamID, ts, uncompressedSize)
+// ObserveLabelPosting records a label posting observation. Multiple
+// observations for the same
+// (ObjectPath, SectionIndex, ColumnName, LabelValue) key are aggregated into a
+// single posting.
+func (b *Builder) ObserveLabelPosting(obs LabelObservation) {
+	b.labels.Observe(obs)
 }
 
 // ObserveBloomPosting records a bloom posting observation. Returns an error if
 // the column has not been prepared via PrepareBloomColumn.
-func (b *Builder) ObserveBloomPosting(objectPath string, sectionIndex int64, columnName, value string, streamID int64, ts time.Time, uncompressedSize int64) error {
-	return b.blooms.Observe(objectPath, sectionIndex, columnName, value, streamID, ts, uncompressedSize)
+func (b *Builder) ObserveBloomPosting(obs BloomObservation) error {
+	return b.blooms.Observe(obs)
 }
 
 // BloomBytes returns the marshaled bloom filter bytes for a specific column.

--- a/pkg/dataobj/sections/postings/builder.go
+++ b/pkg/dataobj/sections/postings/builder.go
@@ -3,6 +3,7 @@ package postings
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -10,26 +11,29 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/internal/columnar"
 )
 
-// Builder accumulates [Posting] rows and encodes them into a section via a
-// [dataobj.SectionWriter].
-//
-// Flush writes are done via [Builder.Flush], which encodes all accumulated
-// rows and writes them to the provided [dataobj.SectionWriter].
+// Builder aggregates posting observations and builds bitmaps and bloom filters
+// incrementally. Call [Builder.Flush] to encode all accumulated data and write
+// a postings section to the provided [dataobj.SectionWriter].
 type Builder struct {
 	metrics *Metrics
 	tenant  string
-	encode  SectionEncoder
+	labels  *labelAggregator
+	blooms  *bloomAggregator
 
-	rows []Posting
+	pageSizeHint    int
+	pageMaxRowCount int
 }
 
-// NewBuilder creates a new Builder.
-// encode is the [SectionEncoder] to use for encoding rows.
+// pageSizeHint and pageMaxRowCount control page splitting of the underlying
+// column builders (0 means use defaults).
 // metrics may be nil to disable instrumentation.
-func NewBuilder(metrics *Metrics, encode SectionEncoder) *Builder {
+func NewBuilder(metrics *Metrics, pageSizeHint, pageMaxRowCount int) *Builder {
 	return &Builder{
-		metrics: metrics,
-		encode:  encode,
+		metrics:         metrics,
+		labels:          newLabelAggregator(),
+		blooms:          newBloomAggregator(),
+		pageSizeHint:    pageSizeHint,
+		pageMaxRowCount: pageMaxRowCount,
 	}
 }
 
@@ -42,53 +46,53 @@ func (b *Builder) Tenant() string { return b.tenant }
 // Type returns the [dataobj.SectionType] of the postings builder.
 func (b *Builder) Type() dataobj.SectionType { return sectionType }
 
-// Append adds a [Posting] row to the builder.
-func (b *Builder) Append(p Posting) {
-	b.rows = append(b.rows, p)
+// PrepareBloomColumn initializes the bloom filter for a specific column. Must
+// be called before any ObserveBloomPosting calls for the given
+// (objectPath, sectionIndex, columnName) combination.
+func (b *Builder) PrepareBloomColumn(objectPath string, sectionIndex int64, columnName string, estimatedCardinality uint) {
+	b.blooms.PrepareColumn(objectPath, sectionIndex, columnName, estimatedCardinality)
 }
 
-// comparePostings returns true if a should sort before b, using the sort order
-// [Kind, ColumnName, LabelValue, MinTimestamp, MaxTimestamp]. All comparisons
-// are lexicographic. Empty LabelValue (used by Bloom entries) sorts before any
-// non-empty value for the same column_name.
-func comparePostings(a, b Posting) bool {
-	if a.Kind != b.Kind {
-		return a.Kind < b.Kind
-	}
-	if a.ColumnName != b.ColumnName {
-		return a.ColumnName < b.ColumnName
-	}
-	if a.LabelValue != b.LabelValue {
-		return a.LabelValue < b.LabelValue
-	}
-	if a.MinTimestamp != b.MinTimestamp {
-		return a.MinTimestamp < b.MinTimestamp
-	}
-	return a.MaxTimestamp < b.MaxTimestamp
+// ObserveLabelPosting records a label posting observation. Multiple observations
+// for the same (objectPath, sectionIndex, columnName, labelValue) key are
+// aggregated into a single posting.
+func (b *Builder) ObserveLabelPosting(objectPath string, sectionIndex int64, columnName, labelValue string, streamID int64, ts time.Time, uncompressedSize int64) {
+	b.labels.Observe(objectPath, sectionIndex, columnName, labelValue, streamID, ts, uncompressedSize)
+}
+
+// ObserveBloomPosting records a bloom posting observation. Returns an error if
+// the column has not been prepared via PrepareBloomColumn.
+func (b *Builder) ObserveBloomPosting(objectPath string, sectionIndex int64, columnName, value string, streamID int64, ts time.Time, uncompressedSize int64) error {
+	return b.blooms.Observe(objectPath, sectionIndex, columnName, value, streamID, ts, uncompressedSize)
+}
+
+// BloomBytes returns the marshaled bloom filter bytes for a specific column.
+// Returns an error if the column has not been prepared.
+func (b *Builder) BloomBytes(objectPath string, sectionIndex int64, columnName string) ([]byte, error) {
+	return b.blooms.BloomBytes(objectPath, sectionIndex, columnName)
 }
 
 // EstimatedSize returns an estimate of the encoded size of the accumulated
-// rows in bytes.
+// data in bytes.
 func (b *Builder) EstimatedSize() int {
-	var total int
-	for _, r := range b.rows {
-		total += r.Size()
-	}
-	return total
+	return b.labels.EstimatedSize() + b.blooms.EstimatedSize()
 }
 
-// Reset clears all accumulated rows and resets the builder to a fresh state.
+// Reset clears all accumulated data and resets the builder to a fresh state.
 func (b *Builder) Reset() {
-	b.rows = b.rows[:0]
+	b.labels.Reset()
+	b.blooms.Reset()
 }
 
-// Flush sorts the accumulated rows by [Kind, ColumnName, LabelValue,
-// MinTimestamp, MaxTimestamp], encodes them into the provided
-// [dataobj.SectionWriter], and returns the number of bytes written.
+// Flush encodes all accumulated observations into the provided
+// [dataobj.SectionWriter] and returns the number of bytes written.
 //
 // After a successful flush, the builder is reset.
 func (b *Builder) Flush(w dataobj.SectionWriter) (n int64, err error) {
-	if len(b.rows) == 0 {
+	labelEntries := b.labels.Entries()
+	bloomEntries := b.blooms.Entries()
+
+	if len(labelEntries) == 0 && len(bloomEntries) == 0 {
 		return 0, nil
 	}
 
@@ -97,15 +101,37 @@ func (b *Builder) Flush(w dataobj.SectionWriter) (n int64, err error) {
 		defer timer.ObserveDuration()
 	}
 
-	// Sort rows by [Kind, ColumnName, LabelValue, MinTimestamp, MaxTimestamp] (lexicographic).
-	sort.SliceStable(b.rows, func(i, j int) bool {
-		return comparePostings(b.rows[i], b.rows[j])
+	// Sort label entries by [objectPath, sectionIndex, columnName, labelValue].
+	sort.SliceStable(labelEntries, func(i, j int) bool {
+		a, bEntry := labelEntries[i], labelEntries[j]
+		if a.ObjectPath != bEntry.ObjectPath {
+			return a.ObjectPath < bEntry.ObjectPath
+		}
+		if a.SectionIndex != bEntry.SectionIndex {
+			return a.SectionIndex < bEntry.SectionIndex
+		}
+		if a.ColumnName != bEntry.ColumnName {
+			return a.ColumnName < bEntry.ColumnName
+		}
+		return a.LabelValue < bEntry.LabelValue
+	})
+
+	// Sort bloom entries by [objectPath, sectionIndex, columnName].
+	sort.SliceStable(bloomEntries, func(i, j int) bool {
+		a, bEntry := bloomEntries[i], bloomEntries[j]
+		if a.ObjectPath != bEntry.ObjectPath {
+			return a.ObjectPath < bEntry.ObjectPath
+		}
+		if a.SectionIndex != bEntry.SectionIndex {
+			return a.SectionIndex < bEntry.SectionIndex
+		}
+		return a.ColumnName < bEntry.ColumnName
 	})
 
 	var enc columnar.Encoder
 	defer enc.Reset()
 
-	if err := b.encode(b.rows, &enc); err != nil {
+	if err := columnarEncode(bloomEntries, labelEntries, &enc, b.pageSizeHint, b.pageMaxRowCount); err != nil {
 		return 0, fmt.Errorf("encoding postings: %w", err)
 	}
 

--- a/pkg/dataobj/sections/postings/builder_test.go
+++ b/pkg/dataobj/sections/postings/builder_test.go
@@ -5,43 +5,41 @@ import (
 	"fmt"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
-	"github.com/grafana/loki/v3/pkg/memory"
 )
 
-// defaultEncoder is a SectionEncoder using default page sizes for testing.
-var defaultEncoder = ColumnarSectionEncoder(0, 0)
+// checkBit returns true if bit n is set in the LSB-encoded bitmap data.
+func checkBit(data []byte, n int) bool {
+	byteIdx := n / 8
+	bitPos := uint(n % 8)
+	if byteIdx >= len(data) {
+		return false
+	}
+	return (data[byteIdx]>>bitPos)&1 == 1
+}
 
 // TestBuilder_Empty verifies that an empty builder produces no sections.
 func TestBuilder_Empty(t *testing.T) {
-	b := NewBuilder(nil, defaultEncoder)
+	b := NewBuilder(nil, 0, 0)
 	require.Zero(t, b.EstimatedSize(), "empty builder should have zero size")
 	// An empty builder writes 0 bytes; the dataobj builder would fail to flush
 	// without any data. This verifies the postings builder is truly empty.
-	require.Empty(t, b.rows, "empty builder should have no rows")
+	require.Empty(t, b.labels.entries, "empty builder should have no label entries")
+	require.Empty(t, b.blooms.entries, "empty builder should have no bloom entries")
 }
 
 // TestBuilder_LabelPostingRoundTrip verifies a label posting round-trips correctly.
 func TestBuilder_LabelPostingRoundTrip(t *testing.T) {
-	b := NewBuilder(nil, defaultEncoder)
+	b := NewBuilder(nil, 0, 0)
 
-	bitmap := makeBitmap(t, 3, 7, 15)
-	input := Posting{
-		Kind:             KindLabel,
-		ObjectPath:       "/tenant/abc/obj1",
-		SectionIndex:     0,
-		ColumnName:       "env",
-		LabelValue:       "value1",
-		BloomFilter:      nil,
-		StreamIDBitmap:   bitmap,
-		UncompressedSize: 4096,
-		MinTimestamp:     1000,
-		MaxTimestamp:     2000,
-	}
-	b.Append(input)
+	ts := time.Unix(0, 1000)
+	b.ObserveLabelPosting("/tenant/abc/obj1", 0, "env", "value1", 3, ts, 4096)
+	b.ObserveLabelPosting("/tenant/abc/obj1", 0, "env", "value1", 7, ts, 0)
+	b.ObserveLabelPosting("/tenant/abc/obj1", 0, "env", "value1", 15, ts, 0)
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
@@ -56,30 +54,29 @@ func TestBuilder_LabelPostingRoundTrip(t *testing.T) {
 	require.Equal(t, "env", p.ColumnName)
 	require.Equal(t, "value1", p.LabelValue)
 	require.Nil(t, p.BloomFilter)
-	require.Equal(t, bitmap, p.StreamIDBitmap)
 	require.Equal(t, int64(4096), p.UncompressedSize)
 	require.Equal(t, int64(1000), p.MinTimestamp)
-	require.Equal(t, int64(2000), p.MaxTimestamp)
+	require.Equal(t, int64(1000), p.MaxTimestamp)
+
+	// Verify stream IDs 3, 7, 15 are set in the bitmap.
+	require.True(t, checkBit(p.StreamIDBitmap, 3), "bit 3 should be set")
+	require.True(t, checkBit(p.StreamIDBitmap, 7), "bit 7 should be set")
+	require.True(t, checkBit(p.StreamIDBitmap, 15), "bit 15 should be set")
+	require.False(t, checkBit(p.StreamIDBitmap, 0), "bit 0 should not be set")
 }
 
 // TestBuilder_BloomPostingRoundTrip verifies a bloom posting round-trips correctly.
 func TestBuilder_BloomPostingRoundTrip(t *testing.T) {
-	b := NewBuilder(nil, defaultEncoder)
+	b := NewBuilder(nil, 0, 0)
 
-	bitmap := makeBitmap(t, 0, 2, 8)
-	bloomFilter := []byte{0xDE, 0xAD, 0xBE, 0xEF}
-	input := Posting{
-		Kind:             KindBloom,
-		ObjectPath:       "/tenant/abc/obj2",
-		SectionIndex:     1,
-		ColumnName:       "service_name",
-		BloomFilter:      bloomFilter,
-		StreamIDBitmap:   bitmap,
-		UncompressedSize: 8192,
-		MinTimestamp:     500,
-		MaxTimestamp:     1500,
-	}
-	b.Append(input)
+	ts := time.Unix(0, 500)
+	b.PrepareBloomColumn("/tenant/abc/obj2", 1, "service_name", 100)
+	err := b.ObserveBloomPosting("/tenant/abc/obj2", 1, "service_name", "my-service", 0, ts, 8192)
+	require.NoError(t, err)
+	err = b.ObserveBloomPosting("/tenant/abc/obj2", 1, "service_name", "my-service", 2, ts, 0)
+	require.NoError(t, err)
+	err = b.ObserveBloomPosting("/tenant/abc/obj2", 1, "service_name", "my-service", 8, ts, 0)
+	require.NoError(t, err)
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
@@ -93,39 +90,30 @@ func TestBuilder_BloomPostingRoundTrip(t *testing.T) {
 	require.Equal(t, int64(1), p.SectionIndex)
 	require.Equal(t, "service_name", p.ColumnName)
 	require.Empty(t, p.LabelValue)
-	require.Equal(t, bloomFilter, p.BloomFilter)
-	require.Equal(t, bitmap, p.StreamIDBitmap)
+	require.NotNil(t, p.BloomFilter, "Bloom posting should have non-nil BloomFilter")
 	require.Equal(t, int64(8192), p.UncompressedSize)
 	require.Equal(t, int64(500), p.MinTimestamp)
-	require.Equal(t, int64(1500), p.MaxTimestamp)
+	require.Equal(t, int64(500), p.MaxTimestamp)
+
+	// Verify stream IDs 0, 2, 8 are set.
+	require.True(t, checkBit(p.StreamIDBitmap, 0), "bit 0 should be set")
+	require.True(t, checkBit(p.StreamIDBitmap, 2), "bit 2 should be set")
+	require.True(t, checkBit(p.StreamIDBitmap, 8), "bit 8 should be set")
+	require.False(t, checkBit(p.StreamIDBitmap, 1), "bit 1 should not be set")
 }
 
 // TestBuilder_MixedPostings verifies both Bloom and Label postings work together.
 func TestBuilder_MixedPostings(t *testing.T) {
-	b := NewBuilder(nil, defaultEncoder)
+	b := NewBuilder(nil, 0, 0)
 
-	bloom := Posting{
-		Kind:           KindBloom,
-		ObjectPath:     "/obj1",
-		ColumnName:     "col_a",
-		BloomFilter:    []byte{0x01, 0x02},
-		StreamIDBitmap: makeBitmap(t, 0),
-		MinTimestamp:   100,
-		MaxTimestamp:   200,
-	}
-	label := Posting{
-		Kind:           KindLabel,
-		ObjectPath:     "/obj2",
-		ColumnName:     "col_b",
-		LabelValue:     "myval",
-		BloomFilter:    nil,
-		StreamIDBitmap: makeBitmap(t, 1, 3),
-		MinTimestamp:   300,
-		MaxTimestamp:   400,
-	}
+	ts := time.Unix(0, 100)
+	b.PrepareBloomColumn("/obj1", 0, "col_a", 10)
+	err := b.ObserveBloomPosting("/obj1", 0, "col_a", "val", 0, ts, 0)
+	require.NoError(t, err)
 
-	b.Append(label) // Append out of sort order
-	b.Append(bloom)
+	ts2 := time.Unix(0, 300)
+	b.ObserveLabelPosting("/obj2", 0, "col_b", "myval", 1, ts2, 0)
+	b.ObserveLabelPosting("/obj2", 0, "col_b", "myval", 3, ts2, 0)
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
@@ -143,39 +131,37 @@ func TestBuilder_MixedPostings(t *testing.T) {
 	require.Nil(t, got[1].BloomFilter)
 }
 
-// TestBuilder_SortOrder verifies the sort order: [Kind, ColumnName, LabelValue, MinTimestamp].
+// TestBuilder_SortOrder verifies the sort order: bloom entries before label entries,
+// sorted by [objectPath, sectionIndex, columnName] for blooms and
+// [objectPath, sectionIndex, columnName, labelValue] for labels.
 func TestBuilder_SortOrder(t *testing.T) {
-	b := NewBuilder(nil, defaultEncoder)
+	b := NewBuilder(nil, 0, 0)
 
-	bitmapBytes := makeBitmap(t, 0)
+	ts := time.Unix(0, 50)
 
-	// Bloom entries (Kind=0) should come before Label entries (Kind=1) for
-	// same column. Within Bloom, sort by ColumnName then MinTimestamp.
-	// Nil LabelValue for Bloom sorts as "" (before any label value string).
-	postings := []Posting{
-		{Kind: KindLabel, ColumnName: "col_a", LabelValue: "beta", MinTimestamp: 200, StreamIDBitmap: bitmapBytes},
-		{Kind: KindLabel, ColumnName: "col_a", LabelValue: "alpha", MinTimestamp: 100, StreamIDBitmap: bitmapBytes},
-		{Kind: KindBloom, ColumnName: "col_a", BloomFilter: []byte{0x01}, MinTimestamp: 50, StreamIDBitmap: bitmapBytes},
-		{Kind: KindLabel, ColumnName: "col_a", LabelValue: "alpha", MinTimestamp: 50, StreamIDBitmap: bitmapBytes},
-		{Kind: KindBloom, ColumnName: "col_b", BloomFilter: []byte{0x02}, MinTimestamp: 10, StreamIDBitmap: bitmapBytes},
-	}
+	// Prepare and add bloom entries.
+	b.PrepareBloomColumn("", 0, "col_a", 10)
+	_ = b.ObserveBloomPosting("", 0, "col_a", "v", 0, ts, 0)
 
-	for _, p := range postings {
-		b.Append(p)
-	}
+	b.PrepareBloomColumn("", 0, "col_b", 10)
+	_ = b.ObserveBloomPosting("", 0, "col_b", "v", 0, time.Unix(0, 10), 0)
+
+	// Label entries.
+	b.ObserveLabelPosting("", 0, "col_a", "beta", 0, time.Unix(0, 200), 0)
+	b.ObserveLabelPosting("", 0, "col_a", "alpha", 0, time.Unix(0, 100), 0)
+	b.ObserveLabelPosting("", 0, "col_a", "alpha", 0, time.Unix(0, 50), 0)
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
 
 	got := readAllPostings(t, sections[0])
-	require.Len(t, got, 5)
+	require.Len(t, got, 4) // 2 bloom + 2 label (alpha aggregated into 1, beta into 1)
 
 	// Expected order:
-	// 0: KindBloom, col_a, nil, ts=50
-	// 1: KindBloom, col_b, nil, ts=10
-	// 2: KindLabel, col_a, alpha, ts=50
-	// 3: KindLabel, col_a, alpha, ts=100
-	// 4: KindLabel, col_a, beta, ts=200
+	// 0: KindBloom, col_a
+	// 1: KindBloom, col_b
+	// 2: KindLabel, col_a, alpha (aggregated)
+	// 3: KindLabel, col_a, beta (aggregated)
 	require.Equal(t, KindBloom, got[0].Kind)
 	require.Equal(t, "col_a", got[0].ColumnName)
 	require.Empty(t, got[0].LabelValue)
@@ -187,34 +173,22 @@ func TestBuilder_SortOrder(t *testing.T) {
 	require.Equal(t, KindLabel, got[2].Kind)
 	require.Equal(t, "col_a", got[2].ColumnName)
 	require.Equal(t, "alpha", got[2].LabelValue)
-	require.Equal(t, int64(50), got[2].MinTimestamp)
 
 	require.Equal(t, KindLabel, got[3].Kind)
 	require.Equal(t, "col_a", got[3].ColumnName)
-	require.Equal(t, "alpha", got[3].LabelValue)
-	require.Equal(t, int64(100), got[3].MinTimestamp)
-
-	require.Equal(t, KindLabel, got[4].Kind)
-	require.Equal(t, "col_a", got[4].ColumnName)
-	require.Equal(t, "beta", got[4].LabelValue)
+	require.Equal(t, "beta", got[3].LabelValue)
 }
 
 // TestBuilder_NullableHandling verifies nullable column correctness.
 func TestBuilder_NullableHandling(t *testing.T) {
-	b := NewBuilder(nil, defaultEncoder)
+	b := NewBuilder(nil, 0, 0)
 
-	bitmapBytes := makeBitmap(t, 0)
+	ts := time.Unix(0, 0)
 
-	b.Append(Posting{
-		Kind: KindBloom, ColumnName: "col",
-		BloomFilter:    []byte{0xAB},
-		StreamIDBitmap: bitmapBytes,
-	})
-	b.Append(Posting{
-		Kind: KindLabel, ColumnName: "col",
-		LabelValue:     "val",
-		StreamIDBitmap: bitmapBytes,
-	})
+	b.PrepareBloomColumn("", 0, "col", 10)
+	_ = b.ObserveBloomPosting("", 0, "col", "val", 0, ts, 0)
+
+	b.ObserveLabelPosting("", 0, "col", "val", 0, ts, 0)
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
@@ -237,27 +211,14 @@ func TestBuilder_NullableHandling(t *testing.T) {
 
 // TestBuilder_BitmapCorrectness verifies that stream ID bitmaps are LSB-encoded correctly.
 func TestBuilder_BitmapCorrectness(t *testing.T) {
-	b := NewBuilder(nil, defaultEncoder)
+	b := NewBuilder(nil, 0, 0)
 
-	// Build bitmap with stream IDs 0, 3, 7.
-	// Byte 0: bit 0 = 1 (stream 0), bit 3 = 1 (stream 3), bit 7 = 1 (stream 7).
-	// Expected byte 0: 0b10001001 = 0x89
-	var alloc memory.Allocator
-	bmap := memory.NewBitmap(&alloc, 8)
-	bmap.Resize(8)
-	bmap.Set(0, true)
-	bmap.Set(3, true)
-	bmap.Set(7, true)
-	bitmapData, _ := bmap.Bytes()
-	bitmapBytes := make([]byte, 1)
-	copy(bitmapBytes, bitmapData[:1])
-
-	b.Append(Posting{
-		Kind:           KindBloom,
-		ColumnName:     "col",
-		BloomFilter:    []byte{0x01},
-		StreamIDBitmap: bitmapBytes,
-	})
+	ts := time.Unix(0, 0)
+	b.PrepareBloomColumn("", 0, "col", 10)
+	// Observe stream IDs 0, 3, 7.
+	_ = b.ObserveBloomPosting("", 0, "col", "v", 0, ts, 0)
+	_ = b.ObserveBloomPosting("", 0, "col", "v", 3, ts, 0)
+	_ = b.ObserveBloomPosting("", 0, "col", "v", 7, ts, 0)
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
@@ -268,12 +229,6 @@ func TestBuilder_BitmapCorrectness(t *testing.T) {
 	// Verify LSB encoding: bit N at byte N/8, position N%8.
 	bitmap := got[0].StreamIDBitmap
 	require.NotEmpty(t, bitmap)
-
-	checkBit := func(data []byte, n int) bool {
-		byteIdx := n / 8
-		bitPos := uint(n % 8)
-		return (data[byteIdx]>>bitPos)&1 == 1
-	}
 
 	require.True(t, checkBit(bitmap, 0), "bit 0 should be set")
 	require.False(t, checkBit(bitmap, 1), "bit 1 should not be set")
@@ -288,25 +243,13 @@ func TestBuilder_BitmapCorrectness(t *testing.T) {
 // TestBuilder_BitmapNormalization verifies that bitmaps of different sizes are
 // padded to the same length.
 func TestBuilder_BitmapNormalization(t *testing.T) {
-	b := NewBuilder(nil, defaultEncoder)
+	b := NewBuilder(nil, 0, 0)
 
-	short := []byte{0x01}            // 1 byte
-	long := []byte{0x01, 0x02, 0x03} // 3 bytes
-
-	b.Append(Posting{
-		Kind:           KindLabel,
-		ColumnName:     "col",
-		LabelValue:     "a",
-		StreamIDBitmap: short,
-		MinTimestamp:   100,
-	})
-	b.Append(Posting{
-		Kind:           KindLabel,
-		ColumnName:     "col",
-		LabelValue:     "b",
-		StreamIDBitmap: long,
-		MinTimestamp:   200,
-	})
+	ts := time.Unix(0, 0)
+	// "a": stream ID 0 → 1-byte bitmap
+	b.ObserveLabelPosting("", 0, "col", "a", 0, ts, 0)
+	// "b": stream ID 23 → 3-byte bitmap
+	b.ObserveLabelPosting("", 0, "col", "b", 23, ts, 0)
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
@@ -314,35 +257,20 @@ func TestBuilder_BitmapNormalization(t *testing.T) {
 	got := readAllPostings(t, sections[0])
 	require.Len(t, got, 2)
 
-	// All bitmaps should be the same length (3 bytes, the maximum).
+	// All bitmaps should be the same length (3 bytes, the maximum for stream ID 23).
 	require.Len(t, got[0].StreamIDBitmap, 3, "short bitmap should be padded to max length")
 	require.Len(t, got[1].StreamIDBitmap, 3, "long bitmap should remain at max length")
-
-	// Short bitmap should be zero-padded.
-	require.Equal(t, byte(0x01), got[0].StreamIDBitmap[0])
-	require.Equal(t, byte(0x00), got[0].StreamIDBitmap[1])
-	require.Equal(t, byte(0x00), got[0].StreamIDBitmap[2])
-
-	// Long bitmap should be unchanged.
-	require.Equal(t, long, got[1].StreamIDBitmap)
 }
 
 // TestBuilder_SectionSplitting verifies that a small targetSectionSize causes
-// rows to be split across multiple sections.
+// rows to be split across multiple pages.
 func TestBuilder_SectionSplitting(t *testing.T) {
 	// Use a very small page size to force splitting across multiple pages.
-	smallEncoder := ColumnarSectionEncoder(100, 2)
-	b := NewBuilder(nil, smallEncoder)
+	b := NewBuilder(nil, 100, 2)
 
-	bitmapBytes := makeBitmap(t, 0)
+	ts := time.Unix(0, 0)
 	for i := range 6 {
-		b.Append(Posting{
-			Kind:           KindLabel,
-			ColumnName:     "col",
-			LabelValue:     "val",
-			StreamIDBitmap: bitmapBytes,
-			MinTimestamp:   int64(i * 100),
-		})
+		b.ObserveLabelPosting("", 0, "col", fmt.Sprintf("val%d", i), 0, ts, 0)
 	}
 
 	sections := flushAndOpenSections(t, b)
@@ -351,26 +279,17 @@ func TestBuilder_SectionSplitting(t *testing.T) {
 	// Collect all rows.
 	allPostings := readAllPostings(t, sections[0])
 	require.Len(t, allPostings, 6)
-
-	// Rows should be in sorted order.
-	for i := 1; i < len(allPostings); i++ {
-		require.LessOrEqual(t, allPostings[i-1].MinTimestamp, allPostings[i].MinTimestamp)
-	}
 }
 
 // TestBuilder_AllBloom verifies that a builder with only Bloom postings works.
 func TestBuilder_AllBloom(t *testing.T) {
-	b := NewBuilder(nil, defaultEncoder)
+	b := NewBuilder(nil, 0, 0)
 
-	bitmapBytes := makeBitmap(t, 0)
+	ts := time.Unix(0, 0)
 	for i := range 3 {
-		b.Append(Posting{
-			Kind:           KindBloom,
-			ColumnName:     "col",
-			BloomFilter:    []byte{byte(i)},
-			StreamIDBitmap: bitmapBytes,
-			MinTimestamp:   int64(i * 100),
-		})
+		colName := fmt.Sprintf("col%d", i)
+		b.PrepareBloomColumn("", 0, colName, 10)
+		_ = b.ObserveBloomPosting("", 0, colName, "val", 0, ts, 0)
 	}
 
 	sections := flushAndOpenSections(t, b)
@@ -387,18 +306,12 @@ func TestBuilder_AllBloom(t *testing.T) {
 
 // TestBuilder_AllLabel verifies that a builder with only Label postings works.
 func TestBuilder_AllLabel(t *testing.T) {
-	b := NewBuilder(nil, defaultEncoder)
+	b := NewBuilder(nil, 0, 0)
 
-	bitmapBytes := makeBitmap(t, 0)
+	ts := time.Unix(0, 0)
 	for i := range 3 {
 		lv := fmt.Sprintf("val%d", i)
-		b.Append(Posting{
-			Kind:           KindLabel,
-			ColumnName:     "col",
-			LabelValue:     lv,
-			StreamIDBitmap: bitmapBytes,
-			MinTimestamp:   int64(i * 100),
-		})
+		b.ObserveLabelPosting("", 0, "col", lv, 0, ts, 0)
 	}
 
 	sections := flushAndOpenSections(t, b)
@@ -415,21 +328,24 @@ func TestBuilder_AllLabel(t *testing.T) {
 
 // TestBuilder_FlushResetsBuilder verifies that a flush resets the builder.
 func TestBuilder_FlushResetsBuilder(t *testing.T) {
-	b := NewBuilder(nil, defaultEncoder)
-	b.Append(Posting{Kind: KindLabel, ColumnName: "col", LabelValue: "v", StreamIDBitmap: makeBitmap(t, 0)})
+	b := NewBuilder(nil, 0, 0)
+
+	ts := time.Unix(0, 0)
+	b.ObserveLabelPosting("", 0, "col", "v", 0, ts, 0)
 
 	obj, closer := flushToObject(t, b)
 	closer.Close()
 	require.Len(t, obj.Sections(), 1)
 
 	// After flush, builder should be empty (Reset was called).
-	require.Empty(t, b.rows, "builder should be empty after flush")
+	require.Empty(t, b.labels.entries, "builder should have no label entries after flush")
+	require.Empty(t, b.blooms.entries, "builder should have no bloom entries after flush")
 	require.Zero(t, b.EstimatedSize(), "builder should have zero estimated size after flush")
 }
 
 // TestBuilder_Type verifies that the section type is correct.
 func TestBuilder_Type(t *testing.T) {
-	b := NewBuilder(nil, defaultEncoder)
+	b := NewBuilder(nil, 0, 0)
 	require.Equal(t, sectionType, b.Type())
 }
 
@@ -451,18 +367,12 @@ func TestCheckSection(t *testing.T) {
 }
 
 func TestRowReader_SmallBuffer(t *testing.T) {
-	b := NewBuilder(nil, defaultEncoder)
+	b := NewBuilder(nil, 0, 0)
 
-	bitmapBytes := makeBitmap(t, 0)
-	// Append 5 rows.
+	ts := time.Unix(0, 0)
+	// Append 5 rows with distinct label values.
 	for i := range 5 {
-		b.Append(Posting{
-			Kind:           KindLabel,
-			ColumnName:     "col",
-			LabelValue:     fmt.Sprintf("val%d", i),
-			StreamIDBitmap: bitmapBytes,
-			MinTimestamp:   int64(i * 100),
-		})
+		b.ObserveLabelPosting("", 0, "col", fmt.Sprintf("val%d", i), 0, ts, 0)
 	}
 
 	sections := flushAndOpenSections(t, b)
@@ -478,6 +388,207 @@ func TestRowReader_SmallBuffer(t *testing.T) {
 	n, err := rr.Read(context.Background(), buf)
 	require.NoError(t, err)
 	require.Equal(t, 2, n, "should read exactly len(buf) rows")
+}
+
+// TestBuilder_ObserveLabelPosting verifies that multiple stream IDs for the
+// same key are aggregated into a single posting entry.
+func TestBuilder_ObserveLabelPosting(t *testing.T) {
+	b := NewBuilder(nil, 0, 0)
+
+	minTs := time.Unix(0, 100)
+	midTs := time.Unix(0, 200)
+	maxTs := time.Unix(0, 300)
+
+	b.ObserveLabelPosting("/obj", 0, "env", "prod", 1, minTs, 100)
+	b.ObserveLabelPosting("/obj", 0, "env", "prod", 5, midTs, 200)
+	b.ObserveLabelPosting("/obj", 0, "env", "prod", 10, maxTs, 300)
+
+	sections := flushAndOpenSections(t, b)
+	require.Len(t, sections, 1)
+
+	got := readAllPostings(t, sections[0])
+	require.Len(t, got, 1, "three observations for same key should aggregate to one posting")
+
+	p := got[0]
+	require.Equal(t, KindLabel, p.Kind)
+	require.Equal(t, "env", p.ColumnName)
+	require.Equal(t, "prod", p.LabelValue)
+	require.Equal(t, int64(600), p.UncompressedSize, "sizes should be summed")
+	require.Equal(t, minTs.UnixNano(), p.MinTimestamp)
+	require.Equal(t, maxTs.UnixNano(), p.MaxTimestamp)
+
+	// Verify stream IDs 1, 5, 10 are set.
+	require.True(t, checkBit(p.StreamIDBitmap, 1))
+	require.True(t, checkBit(p.StreamIDBitmap, 5))
+	require.True(t, checkBit(p.StreamIDBitmap, 10))
+	require.False(t, checkBit(p.StreamIDBitmap, 0))
+	require.False(t, checkBit(p.StreamIDBitmap, 2))
+}
+
+// TestBuilder_ObserveBloomPosting verifies bloom observation: prepare, observe, check membership and bitmap.
+func TestBuilder_ObserveBloomPosting(t *testing.T) {
+	b := NewBuilder(nil, 0, 0)
+
+	ts := time.Unix(0, 100)
+	b.PrepareBloomColumn("/obj", 0, "service_name", 100)
+
+	values := []string{"alpha", "beta", "gamma"}
+	for i, v := range values {
+		err := b.ObserveBloomPosting("/obj", 0, "service_name", v, int64(i), ts, 10)
+		require.NoError(t, err)
+	}
+
+	// Check bloom bytes contain values.
+	bloomBytes, err := b.BloomBytes("/obj", 0, "service_name")
+	require.NoError(t, err)
+	require.NotEmpty(t, bloomBytes)
+
+	// Verify bloom membership via the aggregator's bloom filter.
+	entry := b.blooms.entries[bloomPostingKey{"/obj", 0, "service_name"}]
+	require.NotNil(t, entry)
+	for _, v := range values {
+		require.True(t, entry.BloomFilter().Test([]byte(v)), "bloom filter should contain %q", v)
+	}
+	require.False(t, entry.BloomFilter().Test([]byte("delta")), "bloom filter should not contain 'delta'")
+
+	sections := flushAndOpenSections(t, b)
+	require.Len(t, sections, 1)
+
+	got := readAllPostings(t, sections[0])
+	require.Len(t, got, 1)
+
+	p := got[0]
+	require.Equal(t, KindBloom, p.Kind)
+	require.Equal(t, "service_name", p.ColumnName)
+	require.NotNil(t, p.BloomFilter)
+
+	// Verify stream IDs 0, 1, 2 are set in the bitmap.
+	require.True(t, checkBit(p.StreamIDBitmap, 0))
+	require.True(t, checkBit(p.StreamIDBitmap, 1))
+	require.True(t, checkBit(p.StreamIDBitmap, 2))
+	require.False(t, checkBit(p.StreamIDBitmap, 3))
+}
+
+// TestBuilder_MixedObservations verifies bloom and label observations produce
+// the correct sort order (bloom before label).
+func TestBuilder_MixedObservations(t *testing.T) {
+	b := NewBuilder(nil, 0, 0)
+
+	ts := time.Unix(0, 100)
+
+	// Add label first (out of order relative to expected output).
+	b.ObserveLabelPosting("/obj", 0, "col_b", "v", 0, ts, 0)
+
+	// Add bloom second.
+	b.PrepareBloomColumn("/obj", 0, "col_a", 10)
+	_ = b.ObserveBloomPosting("/obj", 0, "col_a", "v", 0, ts, 0)
+
+	sections := flushAndOpenSections(t, b)
+	require.Len(t, sections, 1)
+
+	got := readAllPostings(t, sections[0])
+	require.Len(t, got, 2)
+
+	// Bloom should be first regardless of observation order.
+	require.Equal(t, KindBloom, got[0].Kind, "bloom should sort before label")
+	require.Equal(t, KindLabel, got[1].Kind)
+}
+
+// TestBuilder_ObserveBloomUnprepared verifies that observing an unprepared bloom
+// column returns an error.
+func TestBuilder_ObserveBloomUnprepared(t *testing.T) {
+	b := NewBuilder(nil, 0, 0)
+
+	ts := time.Unix(0, 0)
+	err := b.ObserveBloomPosting("/obj", 0, "unprepared_col", "val", 0, ts, 0)
+	require.Error(t, err, "observing unprepared bloom column should return an error")
+	require.Contains(t, err.Error(), "bloom column not prepared")
+}
+
+// TestBuilder_MultipleObjectContexts verifies that observations with different
+// (objectPath, sectionIndex) for the same (columnName, labelValue) produce
+// distinct posting rows.
+func TestBuilder_MultipleObjectContexts(t *testing.T) {
+	b := NewBuilder(nil, 0, 0)
+
+	ts := time.Unix(0, 0)
+
+	// Same column/label, different object paths.
+	b.ObserveLabelPosting("/obj1", 0, "env", "prod", 0, ts, 100)
+	b.ObserveLabelPosting("/obj2", 0, "env", "prod", 1, ts, 200)
+
+	// Same column/label, same path but different section index.
+	b.ObserveLabelPosting("/obj1", 1, "env", "prod", 2, ts, 300)
+
+	sections := flushAndOpenSections(t, b)
+	require.Len(t, sections, 1)
+
+	got := readAllPostings(t, sections[0])
+	require.Len(t, got, 3, "different (objectPath, sectionIndex) should produce distinct postings")
+
+	// Collect all (objectPath, sectionIndex) pairs from results.
+	type key struct {
+		path  string
+		secID int64
+	}
+	seen := make(map[key]bool)
+	for _, p := range got {
+		k := key{p.ObjectPath, p.SectionIndex}
+		require.False(t, seen[k], "duplicate (objectPath, sectionIndex) found")
+		seen[k] = true
+	}
+
+	require.True(t, seen[key{"/obj1", 0}])
+	require.True(t, seen[key{"/obj2", 0}])
+	require.True(t, seen[key{"/obj1", 1}])
+
+	// Each posting should only have the stream IDs for that context.
+	for _, p := range got {
+		switch {
+		case p.ObjectPath == "/obj1" && p.SectionIndex == 0:
+			require.True(t, checkBit(p.StreamIDBitmap, 0), "obj1/0 should have stream 0")
+			require.Equal(t, int64(100), p.UncompressedSize)
+		case p.ObjectPath == "/obj2" && p.SectionIndex == 0:
+			require.True(t, checkBit(p.StreamIDBitmap, 1), "obj2/0 should have stream 1")
+			require.Equal(t, int64(200), p.UncompressedSize)
+		case p.ObjectPath == "/obj1" && p.SectionIndex == 1:
+			require.True(t, checkBit(p.StreamIDBitmap, 2), "obj1/1 should have stream 2")
+			require.Equal(t, int64(300), p.UncompressedSize)
+		}
+	}
+}
+
+// TestBuilder_BloomBytes verifies that BloomBytes returns valid marshaled bloom
+// data matching what was observed.
+func TestBuilder_BloomBytes(t *testing.T) {
+	b := NewBuilder(nil, 0, 0)
+
+	ts := time.Unix(0, 0)
+	b.PrepareBloomColumn("/obj", 0, "col", 50)
+
+	values := []string{"foo", "bar", "baz"}
+	for _, v := range values {
+		err := b.ObserveBloomPosting("/obj", 0, "col", v, 0, ts, 0)
+		require.NoError(t, err)
+	}
+
+	bloomBytes, err := b.BloomBytes("/obj", 0, "col")
+	require.NoError(t, err)
+	require.NotEmpty(t, bloomBytes)
+
+	// Verify the bloom bytes are valid by unmarshaling them.
+	// The values we added should be present after round-trip.
+	entry := b.blooms.entries[bloomPostingKey{"/obj", 0, "col"}]
+	require.NotNil(t, entry)
+
+	for _, v := range values {
+		require.True(t, entry.BloomFilter().Test([]byte(v)), "expected %q to be in bloom filter", v)
+	}
+	require.False(t, entry.BloomFilter().Test([]byte("unknown")), "unexpected value in bloom filter")
+
+	// Error for non-existent column.
+	_, err = b.BloomBytes("/obj", 0, "nonexistent")
+	require.Error(t, err)
 }
 
 // flushToObject flushes the builder into a dataobj.Object using dataobj.Builder.
@@ -528,33 +639,4 @@ func readAllPostings(t *testing.T, sec *Section) []Posting {
 		require.NoError(t, err)
 	}
 	return all
-}
-
-// makeBitmap creates a bitmap with the given stream IDs set, and returns its
-// raw bytes (padded to a full byte boundary).
-func makeBitmap(t *testing.T, streamIDs ...int) []byte {
-	t.Helper()
-	if len(streamIDs) == 0 {
-		return []byte{0x00}
-	}
-
-	maxID := 0
-	for _, id := range streamIDs {
-		if id > maxID {
-			maxID = id
-		}
-	}
-
-	var alloc memory.Allocator
-	bmap := memory.NewBitmap(&alloc, maxID+1)
-	bmap.Resize(maxID + 1)
-	for _, id := range streamIDs {
-		bmap.Set(id, true)
-	}
-
-	data, _ := bmap.Bytes()
-	numBytes := (maxID + 8) / 8
-	result := make([]byte, numBytes)
-	copy(result, data[:numBytes])
-	return result
 }

--- a/pkg/dataobj/sections/postings/builder_test.go
+++ b/pkg/dataobj/sections/postings/builder_test.go
@@ -37,9 +37,9 @@ func TestBuilder_LabelPostingRoundTrip(t *testing.T) {
 	b := NewBuilder(nil, 0, 0)
 
 	ts := time.Unix(0, 1000)
-	b.ObserveLabelPosting("/tenant/abc/obj1", 0, "env", "value1", 3, ts, 4096)
-	b.ObserveLabelPosting("/tenant/abc/obj1", 0, "env", "value1", 7, ts, 0)
-	b.ObserveLabelPosting("/tenant/abc/obj1", 0, "env", "value1", 15, ts, 0)
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/tenant/abc/obj1", SectionIndex: 0, ColumnName: "env", LabelValue: "value1", StreamID: 3, Timestamp: ts, UncompressedSize: 4096})
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/tenant/abc/obj1", SectionIndex: 0, ColumnName: "env", LabelValue: "value1", StreamID: 7, Timestamp: ts, UncompressedSize: 0})
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/tenant/abc/obj1", SectionIndex: 0, ColumnName: "env", LabelValue: "value1", StreamID: 15, Timestamp: ts, UncompressedSize: 0})
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
@@ -71,11 +71,11 @@ func TestBuilder_BloomPostingRoundTrip(t *testing.T) {
 
 	ts := time.Unix(0, 500)
 	b.PrepareBloomColumn("/tenant/abc/obj2", 1, "service_name", 100)
-	err := b.ObserveBloomPosting("/tenant/abc/obj2", 1, "service_name", "my-service", 0, ts, 8192)
+	err := b.ObserveBloomPosting(BloomObservation{ObjectPath: "/tenant/abc/obj2", SectionIndex: 1, ColumnName: "service_name", Value: "my-service", StreamID: 0, Timestamp: ts, UncompressedSize: 8192})
 	require.NoError(t, err)
-	err = b.ObserveBloomPosting("/tenant/abc/obj2", 1, "service_name", "my-service", 2, ts, 0)
+	err = b.ObserveBloomPosting(BloomObservation{ObjectPath: "/tenant/abc/obj2", SectionIndex: 1, ColumnName: "service_name", Value: "my-service", StreamID: 2, Timestamp: ts, UncompressedSize: 0})
 	require.NoError(t, err)
-	err = b.ObserveBloomPosting("/tenant/abc/obj2", 1, "service_name", "my-service", 8, ts, 0)
+	err = b.ObserveBloomPosting(BloomObservation{ObjectPath: "/tenant/abc/obj2", SectionIndex: 1, ColumnName: "service_name", Value: "my-service", StreamID: 8, Timestamp: ts, UncompressedSize: 0})
 	require.NoError(t, err)
 
 	sections := flushAndOpenSections(t, b)
@@ -108,12 +108,12 @@ func TestBuilder_MixedPostings(t *testing.T) {
 
 	ts := time.Unix(0, 100)
 	b.PrepareBloomColumn("/obj1", 0, "col_a", 10)
-	err := b.ObserveBloomPosting("/obj1", 0, "col_a", "val", 0, ts, 0)
+	err := b.ObserveBloomPosting(BloomObservation{ObjectPath: "/obj1", SectionIndex: 0, ColumnName: "col_a", Value: "val", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 	require.NoError(t, err)
 
 	ts2 := time.Unix(0, 300)
-	b.ObserveLabelPosting("/obj2", 0, "col_b", "myval", 1, ts2, 0)
-	b.ObserveLabelPosting("/obj2", 0, "col_b", "myval", 3, ts2, 0)
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/obj2", SectionIndex: 0, ColumnName: "col_b", LabelValue: "myval", StreamID: 1, Timestamp: ts2, UncompressedSize: 0})
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/obj2", SectionIndex: 0, ColumnName: "col_b", LabelValue: "myval", StreamID: 3, Timestamp: ts2, UncompressedSize: 0})
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
@@ -141,15 +141,15 @@ func TestBuilder_SortOrder(t *testing.T) {
 
 	// Prepare and add bloom entries.
 	b.PrepareBloomColumn("", 0, "col_a", 10)
-	_ = b.ObserveBloomPosting("", 0, "col_a", "v", 0, ts, 0)
+	_ = b.ObserveBloomPosting(BloomObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col_a", Value: "v", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 
 	b.PrepareBloomColumn("", 0, "col_b", 10)
-	_ = b.ObserveBloomPosting("", 0, "col_b", "v", 0, time.Unix(0, 10), 0)
+	_ = b.ObserveBloomPosting(BloomObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col_b", Value: "v", StreamID: 0, Timestamp: time.Unix(0, 10), UncompressedSize: 0})
 
 	// Label entries.
-	b.ObserveLabelPosting("", 0, "col_a", "beta", 0, time.Unix(0, 200), 0)
-	b.ObserveLabelPosting("", 0, "col_a", "alpha", 0, time.Unix(0, 100), 0)
-	b.ObserveLabelPosting("", 0, "col_a", "alpha", 0, time.Unix(0, 50), 0)
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col_a", LabelValue: "beta", StreamID: 0, Timestamp: time.Unix(0, 200), UncompressedSize: 0})
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col_a", LabelValue: "alpha", StreamID: 0, Timestamp: time.Unix(0, 100), UncompressedSize: 0})
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col_a", LabelValue: "alpha", StreamID: 0, Timestamp: time.Unix(0, 50), UncompressedSize: 0})
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
@@ -186,9 +186,9 @@ func TestBuilder_NullableHandling(t *testing.T) {
 	ts := time.Unix(0, 0)
 
 	b.PrepareBloomColumn("", 0, "col", 10)
-	_ = b.ObserveBloomPosting("", 0, "col", "val", 0, ts, 0)
+	_ = b.ObserveBloomPosting(BloomObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col", Value: "val", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 
-	b.ObserveLabelPosting("", 0, "col", "val", 0, ts, 0)
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col", LabelValue: "val", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
@@ -216,9 +216,9 @@ func TestBuilder_BitmapCorrectness(t *testing.T) {
 	ts := time.Unix(0, 0)
 	b.PrepareBloomColumn("", 0, "col", 10)
 	// Observe stream IDs 0, 3, 7.
-	_ = b.ObserveBloomPosting("", 0, "col", "v", 0, ts, 0)
-	_ = b.ObserveBloomPosting("", 0, "col", "v", 3, ts, 0)
-	_ = b.ObserveBloomPosting("", 0, "col", "v", 7, ts, 0)
+	_ = b.ObserveBloomPosting(BloomObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col", Value: "v", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
+	_ = b.ObserveBloomPosting(BloomObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col", Value: "v", StreamID: 3, Timestamp: ts, UncompressedSize: 0})
+	_ = b.ObserveBloomPosting(BloomObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col", Value: "v", StreamID: 7, Timestamp: ts, UncompressedSize: 0})
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
@@ -247,9 +247,9 @@ func TestBuilder_BitmapNormalization(t *testing.T) {
 
 	ts := time.Unix(0, 0)
 	// "a": stream ID 0 → 1-byte bitmap
-	b.ObserveLabelPosting("", 0, "col", "a", 0, ts, 0)
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col", LabelValue: "a", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 	// "b": stream ID 23 → 3-byte bitmap
-	b.ObserveLabelPosting("", 0, "col", "b", 23, ts, 0)
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col", LabelValue: "b", StreamID: 23, Timestamp: ts, UncompressedSize: 0})
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
@@ -270,7 +270,7 @@ func TestBuilder_SectionSplitting(t *testing.T) {
 
 	ts := time.Unix(0, 0)
 	for i := range 6 {
-		b.ObserveLabelPosting("", 0, "col", fmt.Sprintf("val%d", i), 0, ts, 0)
+		b.ObserveLabelPosting(LabelObservation{ColumnName: "col", LabelValue: fmt.Sprintf("val%d", i), Timestamp: ts})
 	}
 
 	sections := flushAndOpenSections(t, b)
@@ -289,7 +289,7 @@ func TestBuilder_AllBloom(t *testing.T) {
 	for i := range 3 {
 		colName := fmt.Sprintf("col%d", i)
 		b.PrepareBloomColumn("", 0, colName, 10)
-		_ = b.ObserveBloomPosting("", 0, colName, "val", 0, ts, 0)
+		_ = b.ObserveBloomPosting(BloomObservation{ObjectPath: "", SectionIndex: 0, ColumnName: colName, Value: "val", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 	}
 
 	sections := flushAndOpenSections(t, b)
@@ -311,7 +311,7 @@ func TestBuilder_AllLabel(t *testing.T) {
 	ts := time.Unix(0, 0)
 	for i := range 3 {
 		lv := fmt.Sprintf("val%d", i)
-		b.ObserveLabelPosting("", 0, "col", lv, 0, ts, 0)
+		b.ObserveLabelPosting(LabelObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col", LabelValue: lv, StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 	}
 
 	sections := flushAndOpenSections(t, b)
@@ -331,7 +331,7 @@ func TestBuilder_FlushResetsBuilder(t *testing.T) {
 	b := NewBuilder(nil, 0, 0)
 
 	ts := time.Unix(0, 0)
-	b.ObserveLabelPosting("", 0, "col", "v", 0, ts, 0)
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col", LabelValue: "v", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 
 	obj, closer := flushToObject(t, b)
 	closer.Close()
@@ -372,7 +372,7 @@ func TestRowReader_SmallBuffer(t *testing.T) {
 	ts := time.Unix(0, 0)
 	// Append 5 rows with distinct label values.
 	for i := range 5 {
-		b.ObserveLabelPosting("", 0, "col", fmt.Sprintf("val%d", i), 0, ts, 0)
+		b.ObserveLabelPosting(LabelObservation{ColumnName: "col", LabelValue: fmt.Sprintf("val%d", i), Timestamp: ts})
 	}
 
 	sections := flushAndOpenSections(t, b)
@@ -399,9 +399,9 @@ func TestBuilder_ObserveLabelPosting(t *testing.T) {
 	midTs := time.Unix(0, 200)
 	maxTs := time.Unix(0, 300)
 
-	b.ObserveLabelPosting("/obj", 0, "env", "prod", 1, minTs, 100)
-	b.ObserveLabelPosting("/obj", 0, "env", "prod", 5, midTs, 200)
-	b.ObserveLabelPosting("/obj", 0, "env", "prod", 10, maxTs, 300)
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/obj", SectionIndex: 0, ColumnName: "env", LabelValue: "prod", StreamID: 1, Timestamp: minTs, UncompressedSize: 100})
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/obj", SectionIndex: 0, ColumnName: "env", LabelValue: "prod", StreamID: 5, Timestamp: midTs, UncompressedSize: 200})
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/obj", SectionIndex: 0, ColumnName: "env", LabelValue: "prod", StreamID: 10, Timestamp: maxTs, UncompressedSize: 300})
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
@@ -434,7 +434,7 @@ func TestBuilder_ObserveBloomPosting(t *testing.T) {
 
 	values := []string{"alpha", "beta", "gamma"}
 	for i, v := range values {
-		err := b.ObserveBloomPosting("/obj", 0, "service_name", v, int64(i), ts, 10)
+		err := b.ObserveBloomPosting(BloomObservation{ObjectPath: "/obj", SectionIndex: 0, ColumnName: "service_name", Value: v, StreamID: int64(i), Timestamp: ts, UncompressedSize: 10})
 		require.NoError(t, err)
 	}
 
@@ -477,11 +477,11 @@ func TestBuilder_MixedObservations(t *testing.T) {
 	ts := time.Unix(0, 100)
 
 	// Add label first (out of order relative to expected output).
-	b.ObserveLabelPosting("/obj", 0, "col_b", "v", 0, ts, 0)
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/obj", SectionIndex: 0, ColumnName: "col_b", LabelValue: "v", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 
 	// Add bloom second.
 	b.PrepareBloomColumn("/obj", 0, "col_a", 10)
-	_ = b.ObserveBloomPosting("/obj", 0, "col_a", "v", 0, ts, 0)
+	_ = b.ObserveBloomPosting(BloomObservation{ObjectPath: "/obj", SectionIndex: 0, ColumnName: "col_a", Value: "v", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
@@ -500,7 +500,7 @@ func TestBuilder_ObserveBloomUnprepared(t *testing.T) {
 	b := NewBuilder(nil, 0, 0)
 
 	ts := time.Unix(0, 0)
-	err := b.ObserveBloomPosting("/obj", 0, "unprepared_col", "val", 0, ts, 0)
+	err := b.ObserveBloomPosting(BloomObservation{ObjectPath: "/obj", SectionIndex: 0, ColumnName: "unprepared_col", Value: "val", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 	require.Error(t, err, "observing unprepared bloom column should return an error")
 	require.Contains(t, err.Error(), "bloom column not prepared")
 }
@@ -514,11 +514,11 @@ func TestBuilder_MultipleObjectContexts(t *testing.T) {
 	ts := time.Unix(0, 0)
 
 	// Same column/label, different object paths.
-	b.ObserveLabelPosting("/obj1", 0, "env", "prod", 0, ts, 100)
-	b.ObserveLabelPosting("/obj2", 0, "env", "prod", 1, ts, 200)
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/obj1", SectionIndex: 0, ColumnName: "env", LabelValue: "prod", StreamID: 0, Timestamp: ts, UncompressedSize: 100})
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/obj2", SectionIndex: 0, ColumnName: "env", LabelValue: "prod", StreamID: 1, Timestamp: ts, UncompressedSize: 200})
 
 	// Same column/label, same path but different section index.
-	b.ObserveLabelPosting("/obj1", 1, "env", "prod", 2, ts, 300)
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/obj1", SectionIndex: 1, ColumnName: "env", LabelValue: "prod", StreamID: 2, Timestamp: ts, UncompressedSize: 300})
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
@@ -568,7 +568,7 @@ func TestBuilder_BloomBytes(t *testing.T) {
 
 	values := []string{"foo", "bar", "baz"}
 	for _, v := range values {
-		err := b.ObserveBloomPosting("/obj", 0, "col", v, 0, ts, 0)
+		err := b.ObserveBloomPosting(BloomObservation{ObjectPath: "/obj", SectionIndex: 0, ColumnName: "col", Value: v, StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 		require.NoError(t, err)
 	}
 

--- a/pkg/dataobj/sections/postings/encode_columnar.go
+++ b/pkg/dataobj/sections/postings/encode_columnar.go
@@ -9,19 +9,13 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/internal/columnar"
 )
 
-// ColumnarSectionEncoder returns a [SectionEncoder] that encodes [Posting] rows
-// using [dataset.ColumnBuilder]s backed by a [columnar.Encoder].
+// columnarEncode encodes bloom and label entries into the provided columnar
+// encoder. Bloom entries (Kind=0) are encoded first, followed by label entries
+// (Kind=1), using the same 10 column builders.
 //
 // pageSizeHint and pageMaxRowCount control the page splitting behaviour of the
 // underlying column builders.
-func ColumnarSectionEncoder(pageSizeHint int, pageMaxRowCount int) SectionEncoder {
-	return func(rows []Posting, enc *columnar.Encoder) error {
-		return columnarEncode(rows, enc, pageSizeHint, pageMaxRowCount)
-	}
-}
-
-// columnarEncode implements the core encoding logic.
-func columnarEncode(rows []Posting, enc *columnar.Encoder, pageSizeHint, pageMaxRowCount int) error {
+func columnarEncode(bloomEntries []*bloomPostingEntry, labelEntries []*labelPostingEntry, enc *columnar.Encoder, pageSizeHint, pageMaxRowCount int) error {
 	// Build column builders for all 10 columns.
 
 	// kind is a 2-value flag (0=bloom, 1=label). DELTA is the only encoding
@@ -96,43 +90,77 @@ func columnarEncode(rows []Posting, enc *columnar.Encoder, pageSizeHint, pageMax
 		return fmt.Errorf("creating max_timestamp column: %w", err)
 	}
 
-	// Normalize stream ID bitmaps to the same length before encoding.
-	normalizedBitmaps := columnarNormalizeBitmaps(rows)
-
-	// Populate column builders row by row.
-	for i, r := range rows {
-		_ = kindBuilder.Append(i, dataset.Int64Value(int64(r.Kind)))
-		_ = objectPathBuilder.Append(i, dataset.BinaryValue([]byte(r.ObjectPath)))
-		_ = sectionIndexBuilder.Append(i, dataset.Int64Value(r.SectionIndex))
-		_ = columnNameBuilder.Append(i, dataset.BinaryValue([]byte(r.ColumnName)))
-
-		// label_value: null (omit append) for bloom postings.
-		if r.Kind != KindBloom {
-			_ = labelValueBuilder.Append(i, dataset.BinaryValue([]byte(r.LabelValue)))
+	// Compute the max bitmap length across both bloom and label entries for normalization.
+	maxBitmapLen := 0
+	for _, e := range bloomEntries {
+		if b := e.BitmapBytes(); len(b) > maxBitmapLen {
+			maxBitmapLen = len(b)
 		}
-
-		// bloom_filter: null (omit append) for label postings.
-		if r.BloomFilter != nil {
-			_ = bloomFilterBuilder.Append(i, dataset.BinaryValue(r.BloomFilter))
+	}
+	for _, e := range labelEntries {
+		if b := e.BitmapBytes(); len(b) > maxBitmapLen {
+			maxBitmapLen = len(b)
 		}
-
-		_ = streamIDBitmapBuilder.Append(i, dataset.BinaryValue(normalizedBitmaps[i]))
-
-		_ = uncompressedSizeBuilder.Append(i, dataset.Int64Value(r.UncompressedSize))
-		_ = minTimestampBuilder.Append(i, dataset.Int64Value(r.MinTimestamp))
-		_ = maxTimestampBuilder.Append(i, dataset.Int64Value(r.MaxTimestamp))
 	}
 
-	// Set sort info: [kind(0), column_name(3), label_value(4), min_timestamp(8), max_timestamp(9)]
+	// normalizeBitmap pads a bitmap to maxBitmapLen.
+	normalizeBitmap := func(b []byte) []byte {
+		if len(b) == maxBitmapLen {
+			return b
+		}
+		padded := make([]byte, maxBitmapLen)
+		copy(padded, b)
+		return padded
+	}
+
+	// Populate column builders: bloom entries first (Kind=0), then label entries (Kind=1).
+	rowIdx := 0
+
+	for _, e := range bloomEntries {
+		bloomBytes, err := e.BloomBytes()
+		if err != nil {
+			return fmt.Errorf("marshaling bloom filter for column %q: %w", e.ColumnName, err)
+		}
+
+		_ = kindBuilder.Append(rowIdx, dataset.Int64Value(int64(KindBloom)))
+		_ = objectPathBuilder.Append(rowIdx, dataset.BinaryValue([]byte(e.ObjectPath)))
+		_ = sectionIndexBuilder.Append(rowIdx, dataset.Int64Value(e.SectionIndex))
+		_ = columnNameBuilder.Append(rowIdx, dataset.BinaryValue([]byte(e.ColumnName)))
+		_ = labelValueBuilder.Append(rowIdx, dataset.Value{}) // null for bloom
+		_ = bloomFilterBuilder.Append(rowIdx, dataset.BinaryValue(bloomBytes))
+		_ = streamIDBitmapBuilder.Append(rowIdx, dataset.BinaryValue(normalizeBitmap(e.BitmapBytes())))
+		_ = uncompressedSizeBuilder.Append(rowIdx, dataset.Int64Value(e.UncompressedSize))
+		_ = minTimestampBuilder.Append(rowIdx, dataset.Int64Value(e.MinTimestamp))
+		_ = maxTimestampBuilder.Append(rowIdx, dataset.Int64Value(e.MaxTimestamp))
+		rowIdx++
+	}
+
+	for _, e := range labelEntries {
+		_ = kindBuilder.Append(rowIdx, dataset.Int64Value(int64(KindLabel)))
+		_ = objectPathBuilder.Append(rowIdx, dataset.BinaryValue([]byte(e.ObjectPath)))
+		_ = sectionIndexBuilder.Append(rowIdx, dataset.Int64Value(e.SectionIndex))
+		_ = columnNameBuilder.Append(rowIdx, dataset.BinaryValue([]byte(e.ColumnName)))
+		_ = labelValueBuilder.Append(rowIdx, dataset.BinaryValue([]byte(e.LabelValue)))
+		_ = bloomFilterBuilder.Append(rowIdx, dataset.Value{}) // null for label
+		_ = streamIDBitmapBuilder.Append(rowIdx, dataset.BinaryValue(normalizeBitmap(e.BitmapBytes())))
+		_ = uncompressedSizeBuilder.Append(rowIdx, dataset.Int64Value(e.UncompressedSize))
+		_ = minTimestampBuilder.Append(rowIdx, dataset.Int64Value(e.MinTimestamp))
+		_ = maxTimestampBuilder.Append(rowIdx, dataset.Int64Value(e.MaxTimestamp))
+		rowIdx++
+	}
+
+	// Set sort info: [kind(0), object_path(1), section_index(2), column_name(3), label_value(4)]
 	// Column indices: kind=0, object_path=1, section_index=2, column_name=3, label_value=4,
 	// bloom_filter=5, stream_id_bitmap=6, uncompressed_size=7, min_timestamp=8, max_timestamp=9.
+	// Data is sorted by [kind, objectPath, sectionIndex, columnName, labelValue]; timestamps
+	// are not part of the sort key.
 	enc.SetSortInfo(&datasetmd.SortInfo{
 		ColumnSorts: []*datasetmd.SortInfo_ColumnSort{
 			{ColumnIndex: 0, Direction: datasetmd.SORT_DIRECTION_ASCENDING}, // kind
+			{ColumnIndex: 1, Direction: datasetmd.SORT_DIRECTION_ASCENDING}, // object_path
+			{ColumnIndex: 2, Direction: datasetmd.SORT_DIRECTION_ASCENDING}, // section_index
 			{ColumnIndex: 3, Direction: datasetmd.SORT_DIRECTION_ASCENDING}, // column_name
 			{ColumnIndex: 4, Direction: datasetmd.SORT_DIRECTION_ASCENDING}, // label_value
-			{ColumnIndex: 8, Direction: datasetmd.SORT_DIRECTION_ASCENDING}, // min_timestamp
-			{ColumnIndex: 9, Direction: datasetmd.SORT_DIRECTION_ASCENDING}, // max_timestamp
 		},
 	})
 
@@ -153,29 +181,6 @@ func columnarEncode(rows []Posting, enc *columnar.Encoder, pageSizeHint, pageMax
 		return fmt.Errorf("encoding columns: %w", err)
 	}
 	return nil
-}
-
-// columnarNormalizeBitmaps pads all stream ID bitmaps to the same length (the
-// maximum length) with zero bytes.
-func columnarNormalizeBitmaps(rows []Posting) [][]byte {
-	maxLen := 0
-	for _, r := range rows {
-		if len(r.StreamIDBitmap) > maxLen {
-			maxLen = len(r.StreamIDBitmap)
-		}
-	}
-
-	result := make([][]byte, len(rows))
-	for i, r := range rows {
-		if len(r.StreamIDBitmap) == maxLen {
-			result[i] = r.StreamIDBitmap
-		} else {
-			padded := make([]byte, maxLen)
-			copy(padded, r.StreamIDBitmap)
-			result[i] = padded
-		}
-	}
-	return result
 }
 
 // binaryColumnBuilder creates a column builder for BINARY/PLAIN/ZSTD columns.

--- a/pkg/dataobj/sections/postings/label_aggregator.go
+++ b/pkg/dataobj/sections/postings/label_aggregator.go
@@ -41,7 +41,6 @@ func (e *labelPostingEntry) BitmapBytes() []byte {
 // It is NOT goroutine-safe; callers must synchronize if needed.
 type labelAggregator struct {
 	entries       map[labelPostingKey]*labelPostingEntry
-	maxStreamID   int64
 	estimatedSize int
 }
 
@@ -98,9 +97,6 @@ func (a *labelAggregator) Observe(objectPath string, sectionIndex int64, columnN
 	}
 	entry.UncompressedSize += uncompressedSize
 
-	if streamID > a.maxStreamID {
-		a.maxStreamID = streamID
-	}
 }
 
 // Entries returns all aggregated entries. Bitmap normalization (padding to
@@ -127,6 +123,5 @@ func (a *labelAggregator) EstimatedSize() int {
 // Reset clears all accumulated state.
 func (a *labelAggregator) Reset() {
 	a.entries = make(map[labelPostingKey]*labelPostingEntry)
-	a.maxStreamID = 0
 	a.estimatedSize = 0
 }

--- a/pkg/dataobj/sections/postings/label_aggregator.go
+++ b/pkg/dataobj/sections/postings/label_aggregator.go
@@ -1,8 +1,6 @@
 package postings
 
 import (
-	"time"
-
 	"github.com/grafana/loki/v3/pkg/memory"
 )
 
@@ -52,51 +50,51 @@ func newLabelAggregator() *labelAggregator {
 }
 
 // Observe records a single observation of a label posting.
-func (a *labelAggregator) Observe(objectPath string, sectionIndex int64, columnName, labelValue string, streamID int64, ts time.Time, uncompressedSize int64) {
+func (a *labelAggregator) Observe(obs LabelObservation) {
 	key := labelPostingKey{
-		objectPath:   objectPath,
-		sectionIndex: sectionIndex,
-		columnName:   columnName,
-		labelValue:   labelValue,
+		objectPath:   obs.ObjectPath,
+		sectionIndex: obs.SectionIndex,
+		columnName:   obs.ColumnName,
+		labelValue:   obs.LabelValue,
 	}
+
+	tsNano := obs.Timestamp.UnixNano()
 
 	entry, ok := a.entries[key]
 	if !ok {
 		entry = &labelPostingEntry{
-			ObjectPath:   objectPath,
-			SectionIndex: sectionIndex,
-			ColumnName:   columnName,
-			LabelValue:   labelValue,
+			ObjectPath:   obs.ObjectPath,
+			SectionIndex: obs.SectionIndex,
+			ColumnName:   obs.ColumnName,
+			LabelValue:   obs.LabelValue,
 			bitmap:       memory.NewBitmap(nil, 0),
-			MinTimestamp: ts.UnixNano(),
-			MaxTimestamp: ts.UnixNano(),
+			MinTimestamp: tsNano,
+			MaxTimestamp: tsNano,
 		}
 		a.entries[key] = entry
 
 		// Track size for new entry: 5 int64 fields + string sizes
-		a.estimatedSize += 5*8 + len(objectPath) + len(columnName) + len(labelValue)
+		a.estimatedSize += 5*8 + len(obs.ObjectPath) + len(obs.ColumnName) + len(obs.LabelValue)
 	}
 
 	// Grow bitmap if needed and set the bit for this stream ID.
-	if int(streamID) >= entry.bitmap.Len() {
+	if int(obs.StreamID) >= entry.bitmap.Len() {
 		prevLen := entry.bitmap.Len()
-		entry.bitmap.Resize(int(streamID) + 1)
+		entry.bitmap.Resize(int(obs.StreamID) + 1)
 		// Track bitmap growth in estimated size.
 		newBytes := (entry.bitmap.Len() + 7) / 8
 		oldBytes := (prevLen + 7) / 8
 		a.estimatedSize += newBytes - oldBytes
 	}
-	entry.bitmap.Set(int(streamID), true)
+	entry.bitmap.Set(int(obs.StreamID), true)
 
-	tsNano := ts.UnixNano()
 	if tsNano < entry.MinTimestamp {
 		entry.MinTimestamp = tsNano
 	}
 	if tsNano > entry.MaxTimestamp {
 		entry.MaxTimestamp = tsNano
 	}
-	entry.UncompressedSize += uncompressedSize
-
+	entry.UncompressedSize += obs.UncompressedSize
 }
 
 // Entries returns all aggregated entries. Bitmap normalization (padding to

--- a/pkg/dataobj/sections/postings/label_aggregator.go
+++ b/pkg/dataobj/sections/postings/label_aggregator.go
@@ -1,0 +1,132 @@
+package postings
+
+import (
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// labelPostingKey is the unique key for a label posting aggregation entry.
+type labelPostingKey struct {
+	objectPath   string
+	sectionIndex int64
+	columnName   string
+	labelValue   string
+}
+
+// labelPostingEntry holds the aggregated state for a single label posting.
+type labelPostingEntry struct {
+	ObjectPath       string
+	SectionIndex     int64
+	ColumnName       string
+	LabelValue       string
+	bitmap           memory.Bitmap
+	MinTimestamp     int64
+	MaxTimestamp     int64
+	UncompressedSize int64
+}
+
+// BitmapBytes returns the raw bytes of the bitmap trimmed to the logical size
+// (ceil(Len()/8) bytes). Offset is always 0 for bitmaps built with Resize/Set.
+func (e *labelPostingEntry) BitmapBytes() []byte {
+	data, _ := e.bitmap.Bytes()
+	n := (e.bitmap.Len() + 7) / 8
+	if n > len(data) {
+		n = len(data)
+	}
+	return data[:n]
+}
+
+// labelAggregator aggregates label posting observations incrementally.
+// It is NOT goroutine-safe; callers must synchronize if needed.
+type labelAggregator struct {
+	entries       map[labelPostingKey]*labelPostingEntry
+	maxStreamID   int64
+	estimatedSize int
+}
+
+// newLabelAggregator creates a new labelAggregator.
+func newLabelAggregator() *labelAggregator {
+	return &labelAggregator{
+		entries: make(map[labelPostingKey]*labelPostingEntry),
+	}
+}
+
+// Observe records a single observation of a label posting.
+func (a *labelAggregator) Observe(objectPath string, sectionIndex int64, columnName, labelValue string, streamID int64, ts time.Time, uncompressedSize int64) {
+	key := labelPostingKey{
+		objectPath:   objectPath,
+		sectionIndex: sectionIndex,
+		columnName:   columnName,
+		labelValue:   labelValue,
+	}
+
+	entry, ok := a.entries[key]
+	if !ok {
+		entry = &labelPostingEntry{
+			ObjectPath:   objectPath,
+			SectionIndex: sectionIndex,
+			ColumnName:   columnName,
+			LabelValue:   labelValue,
+			bitmap:       memory.NewBitmap(nil, 0),
+			MinTimestamp: ts.UnixNano(),
+			MaxTimestamp: ts.UnixNano(),
+		}
+		a.entries[key] = entry
+
+		// Track size for new entry: 5 int64 fields + string sizes
+		a.estimatedSize += 5*8 + len(objectPath) + len(columnName) + len(labelValue)
+	}
+
+	// Grow bitmap if needed and set the bit for this stream ID.
+	if int(streamID) >= entry.bitmap.Len() {
+		prevLen := entry.bitmap.Len()
+		entry.bitmap.Resize(int(streamID) + 1)
+		// Track bitmap growth in estimated size.
+		newBytes := (entry.bitmap.Len() + 7) / 8
+		oldBytes := (prevLen + 7) / 8
+		a.estimatedSize += newBytes - oldBytes
+	}
+	entry.bitmap.Set(int(streamID), true)
+
+	tsNano := ts.UnixNano()
+	if tsNano < entry.MinTimestamp {
+		entry.MinTimestamp = tsNano
+	}
+	if tsNano > entry.MaxTimestamp {
+		entry.MaxTimestamp = tsNano
+	}
+	entry.UncompressedSize += uncompressedSize
+
+	if streamID > a.maxStreamID {
+		a.maxStreamID = streamID
+	}
+}
+
+// Entries returns all aggregated entries. Bitmap normalization (padding to
+// equal length) is NOT done here; the caller (columnarEncode) handles it
+// across both label and bloom entries.
+func (a *labelAggregator) Entries() []*labelPostingEntry {
+	if len(a.entries) == 0 {
+		return nil
+	}
+
+	result := make([]*labelPostingEntry, 0, len(a.entries))
+	for _, entry := range a.entries {
+		result = append(result, entry)
+	}
+	return result
+}
+
+// EstimatedSize returns an O(1) estimate of the encoded size of all
+// accumulated observations in bytes.
+func (a *labelAggregator) EstimatedSize() int {
+	return a.estimatedSize
+}
+
+// Reset clears all accumulated state.
+func (a *labelAggregator) Reset() {
+	a.entries = make(map[labelPostingKey]*labelPostingEntry)
+	a.maxStreamID = 0
+	a.estimatedSize = 0
+}

--- a/pkg/dataobj/sections/postings/observation.go
+++ b/pkg/dataobj/sections/postings/observation.go
@@ -1,0 +1,57 @@
+package postings
+
+import "time"
+
+// LabelObservation describes a single observation of a label posting (a stream
+// label value) for the postings index.
+//
+// Multiple observations sharing the same (ObjectPath, SectionIndex, ColumnName,
+// LabelValue) are aggregated into a single posting that tracks the union of
+// stream IDs, the min/max timestamps seen, and the total uncompressed size.
+type LabelObservation struct {
+	// ObjectPath is the path of the data object that originated this posting.
+	ObjectPath string
+	// SectionIndex is the index of the logs section within ObjectPath.
+	SectionIndex int64
+	// ColumnName is the name of the labels column being indexed.
+	ColumnName string
+	// LabelValue is the observed value of the label.
+	LabelValue string
+	// StreamID is the (rewritten) stream ID associated with the observation.
+	StreamID int64
+	// Timestamp is the timestamp of the log record that produced the observation.
+	Timestamp time.Time
+	// UncompressedSize is the uncompressed size in bytes of the log record that
+	// produced the observation. It is summed across all observations in the
+	// aggregated posting.
+	UncompressedSize int64
+}
+
+// BloomObservation describes a single observation of a bloom posting (a
+// metadata column value) for the postings index.
+//
+// Multiple observations sharing the same (ObjectPath, SectionIndex, ColumnName)
+// are aggregated into a single posting whose bloom filter contains every
+// observed Value, alongside the union of stream IDs, the min/max timestamps
+// seen, and the total uncompressed size.
+//
+// PrepareBloomColumn must be called for the same (ObjectPath, SectionIndex,
+// ColumnName) before any observations are recorded.
+type BloomObservation struct {
+	// ObjectPath is the path of the data object that originated this posting.
+	ObjectPath string
+	// SectionIndex is the index of the logs section within ObjectPath.
+	SectionIndex int64
+	// ColumnName is the name of the metadata column being indexed.
+	ColumnName string
+	// Value is the observed column value to add to the bloom filter.
+	Value string
+	// StreamID is the (rewritten) stream ID associated with the observation.
+	StreamID int64
+	// Timestamp is the timestamp of the log record that produced the observation.
+	Timestamp time.Time
+	// UncompressedSize is the uncompressed size in bytes of the log record that
+	// produced the observation. It is summed across all observations in the
+	// aggregated posting.
+	UncompressedSize int64
+}

--- a/pkg/dataobj/sections/postings/postings.go
+++ b/pkg/dataobj/sections/postings/postings.go
@@ -196,6 +196,3 @@ type Column struct {
 
 	inner *columnar.Column
 }
-
-// SectionEncoder encodes a batch of sorted Posting rows into a columnar encoder.
-type SectionEncoder func(rows []Posting, enc *columnar.Encoder) error


### PR DESCRIPTION
## Summary

Convert the postings indexing pipeline from a struct-append pattern to an observation/aggregation pattern. The calculators (`labelPostingsCalculation`, `columnValuesCalculation`) now stream raw observations into the postings builder instead of accumulating their own bitmaps, bloom filters, and `Posting` structs and copying them into the builder at flush time. The builder owns aggregation directly.

The result is a substantial reduction in allocation churn — and therefore GC pressure — on the indexing hot path, with a small throughput improvement as a side effect.

## Benchmark

`BenchmarkFullPostingsPipeline` (added in this PR, in `pkg/dataobj/index/full_pipeline_bench_test.go`) drives both `labelPostingsCalculation` and `columnValuesCalculation` through `Prepare → ProcessBatch → calc.Flush → builder.Flush` against a synthetic logs section, exercising both the label path (per stream label per record) and the bloom path (per metadata column per record).

Comparing this branch to its parent `gold-pond` on Apple M3 Pro, `go test -bench=BenchmarkFullPostingsPipeline -benchmem -count=10 -benchtime=3x`:

```
                                                                │ gold-pond    │           this branch              │
                                                                │    sec/op    │   sec/op     vs base               │
records=10000/streams=100/labels=3/metaCols=4/metaCard=10            5.032m ± 3%   4.716m ± 3%   -6.28% (p=0.003)
records=10000/streams=100/labels=3/metaCols=20/metaCard=100          18.77m ± 8%   15.79m ± 1%  -15.86% (p=0.000)
records=100000/streams=1000/labels=4/metaCols=10/metaCard=100        87.65m ± 4%   85.73m ± 2%   -2.19% (p=0.007)
records=100000/streams=1000/labels=4/metaCols=20/metaCard=1000       168.1m ± 2%   157.1m ± 2%   -6.51% (p=0.000)
geomean                                                              34.34m        31.65m        -7.85%

                                                                │     B/op     │      B/op     vs base              │
geomean                                                              2.654Mi       826.5Ki        -69.59%

                                                                │  allocs/op   │   allocs/op   vs base              │
geomean                                                              39.84k        11.46k         -71.23%
```

## Changes

- **New aggregator types** (`label_aggregator.go`, `bloom_aggregator.go`): aggregate posting observations into internal maps keyed by `(objectPath, sectionIndex, columnName, labelValue/columnName)`. Build stream ID bitmaps incrementally, track min/max timestamps and sizes, expose O(1) `EstimatedSize()`.
- **Postings builder API**: replace `Append(Posting)` with `ObserveLabelPosting` / `ObserveBloomPosting` / `PrepareBloomColumn` / `BloomBytes`. Observations are passed via `LabelObservation` / `BloomObservation` structs (named-field, easy to extend). Remove `SectionEncoder` abstraction; refactor `columnarEncode` to take aggregated entry types directly (no `[]Posting` materialization).
- **`indexobj.Builder`** updated to expose `ObserveLabelPosting` / `ObserveBloomPosting` / `PrepareBloomColumn` / `BloomBytes`. Caches the last-resolved per-tenant `*postings.Builder` to skip the tenant-map lookup on the per-observation hot path.
- **`labelPostingsCalculation`** simplified (127 → 44 lines): now stateless. `ProcessBatch` delegates directly to the builder; `Flush` is a no-op.
- **`columnValuesCalculation`** simplified (127 → 75 lines): drops bloom filters, per-column bitmaps, timestamps, sizes. Calls `PrepareBloomColumn` in `Prepare`, `ObserveBloomPosting` per record, and `builder.BloomBytes` in `Flush` for `AppendColumnIndex` (so `AppendColumnIndex` reuses the builder's bloom rather than the calculator marshalling its own copy).
- **`logsIndexCalculation.Prepare`** gains a `calcCtx *logsCalculationContext` parameter so `columnValuesCalculation.Prepare` can call `PrepareBloomColumn` during init.

## Design Decisions

- `objectPath` / `sectionIndex` are part of the aggregation key (not builder-global state) so a builder shared across parallel `processLogsSection` goroutines for the same tenant cannot corrupt cross-section data.
- Mid-stream `TargetSectionSize` flush intentionally removed from postings observe methods — aggregation requires all observations before encoding (bitmap normalization, bloom filter construction). Back-pressure is provided by `TargetObjectSize` / `builderFull`.
- `columnarEncode` refactored in place rather than duplicated into the builder.

## AI Spec

<details>
<summary>Postings Builder Allocation-Reduction Spec</summary>

### Problem

The postings builder uses a struct-append/accumulator pattern: the calculation pipeline (`label_postings_calculation.go`, `column_values.go`) fully constructs each `Posting` struct — including heap-allocated `[]byte` fields for bloom filters and stream ID bitmaps — and passes it to the builder via `b.Append(Posting{...})`. The builder accumulates all rows in a `[]Posting` slice until flush.

This means both the calculator and the builder allocate state for the same postings:

1. **Calculator** — holds state keyed by posting key (label value, column name, etc.) to aggregate stream IDs into bitmaps and build bloom filters
2. **Builder** — holds the fully-formed `[]Posting` slice waiting to be flushed, populated by `calc.Flush` from the calculator's state

The result is per-section churn of `Posting` structs, marshaled bloom-filter byte slices, and per-key bookkeeping maps.

### Approach: Observation/Aggregation with Direct Column Encoding

Convert the postings builder from a struct-append/accumulator pattern to an observation/aggregation pattern for both label postings and bloom postings. The builder owns all aggregation (bitmap building, bloom filter construction) and encodes directly to `dataset.ColumnBuilder`s on flush — no intermediate `[]Posting` slice, no `SectionEncoder` abstraction.

The builder delegates to two internal aggregator types:

- **`labelAggregator`** — map keyed by `(objectPath, sectionIndex, columnName, labelValue)`, each entry holds a `memory.Bitmap`, min/max timestamps, and accumulated uncompressed size.
- **`bloomAggregator`** — map keyed by `(objectPath, sectionIndex, columnName)`, each entry holds a `bloom.BloomFilter` (sized from cardinality hint via `PrepareColumn`), a `memory.Bitmap`, min/max timestamps, and accumulated uncompressed size.

**Critical design decision:** `objectPath` and `sectionIndex` are part of the aggregation key, not builder-global state. This is required because the postings builder is shared per-tenant across parallel `processLogsSection` goroutines.

### Calculator Simplification

- **`labelPostingsCalculation`** becomes stateless: `ProcessBatch` calls `builder.ObserveLabelPosting(...)` for each stream label on each log record. No internal maps, bitmaps, or sorting. `Flush` is a no-op.
- **`columnValuesCalculation`** drops all internal state except column indexes. `PrepareBloomColumn` is called in `Prepare`. In `Flush`, the calculator calls `builder.BloomBytes(columnName)` for `AppendColumnIndex`, eliminating the duplicate bloom filter.

### Benefits

- **Lower allocation churn** — replace per-batch construction of intermediate `Posting` structs and per-calculator bitmap/bloom-filter state with a single builder-owned aggregator, reducing total bytes allocated by ~70% on `BenchmarkFullPostingsPipeline`.
- **Eliminates double-storage** — calculator no longer holds postings state; the builder owns all aggregation
- **Eliminates bloom duplication** — calculator uses builder's bloom for `AppendColumnIndex`
- **O(1) size estimation** — incremental tracking replaces O(n) iteration
- **Matches established pattern** — consistent with how streams/pointers builders work
- **Simpler calculators** — `labelPostingsCalculation` becomes stateless; `columnValuesCalculation` drops nearly all state

### Trade-offs

- **Builder becomes more complex** — it takes on aggregation responsibility (bitmap building, bloom filter construction) that currently lives in the calculation pipeline
- **Tighter coupling** — the builder depends on `memory.Bitmap` and `bits-and-blooms/bloom/v3`; the calculator calls `builder.BloomBytes` for pointer section data

</details>
