### PR TITLE
feat: more accurate counts of max_inflight_bytes

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -215,8 +215,7 @@ type Distributor struct {
 	// are consumed.
 	numMetadataPartitions int
 
-	// inflightBytes keeps track of the total number of bytes for all in-flight
-	// push requests.
+	// Track the maximum number of inflight bytes in the last 1 minute.
 	inflightBytes      *atomic.Uint64
 	inflightBytesGauge prometheus.Gauge
 
@@ -411,8 +410,8 @@ func New(
 		inflightBytes:         atomic.NewUint64(0),
 		inflightBytesGauge: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
 			Namespace: constants.Loki,
-			Name:      "distributor_inflight_bytes",
-			Help:      "The number of bytes currently inflight.",
+			Name:      "distributor_max_inflight_bytes",
+			Help:      "The maximum number of inflight bytes in the last 1 minute.",
 		}),
 	}
 
@@ -483,11 +482,38 @@ func (d *Distributor) running(ctx context.Context) error {
 			go d.pushIngesterWorker(ctx)
 		}
 	}
+	go d.collectInflightBytes(ctx)
 	select {
 	case <-ctx.Done():
 		return nil
 	case err := <-d.subservicesWatcher.Chan():
 		return errors.Wrap(err, "distributor subservice failed")
+	}
+}
+
+// collectInflightBytes updates the inflightBytesGauge with the max value
+// from the last 1 minute.
+func (d *Distributor) collectInflightBytes(ctx context.Context) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	// window contains per-second samples for the last 1 minute.
+	window := make([]uint64, 60)
+	secs := 0
+	for {
+		select {
+		case <-ticker.C:
+			window[secs] = d.inflightBytes.Load()
+			secs = (secs + 1) % 60
+			var maxVal uint64
+			for _, val := range window {
+				if val > maxVal {
+					maxVal = val
+				}
+			}
+			d.inflightBytesGauge.Set(float64(maxVal))
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 
@@ -567,11 +593,7 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRequest, streamResolver *requestScopedStreamResolver, format string) (*logproto.PushResponse, error) {
 	requestSizeBytes := uint64(req.Size())
 	d.inflightBytes.Add(requestSizeBytes)
-	d.inflightBytesGauge.Add(float64(requestSizeBytes))
-	defer func() {
-		d.inflightBytes.Sub(requestSizeBytes)
-		d.inflightBytesGauge.Sub(float64(requestSizeBytes))
-	}()
+	defer d.inflightBytes.Sub(requestSizeBytes)
 
 	tenantID, err := tenant.TenantID(ctx)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

The previous method was not accurate, and was subject to one sample every 15-30 seconds (depending on Prometheus scrape interval). This meant we would miss the largest values between scrapes. Instead, we now scrape the maximum per-second sample from the last 1 minute.

**Old version**
<img width="1420" height="243" alt="Screenshot 2026-04-18 at 10 06 59" src="https://github.com/user-attachments/assets/16d57473-d81b-411e-95b4-db934842dbd0" />

**New version**
<img width="1445" height="283" alt="Screenshot 2026-04-18 at 10 07 23" src="https://github.com/user-attachments/assets/b5c271dc-91ed-47ba-bcfa-c8cb237447d8" />

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a user-facing Prometheus metric name/semantics and adds a background sampler goroutine; risk is mainly dashboard/alert breakage and minor runtime overhead.
> 
> **Overview**
> Updates distributor inflight-bytes instrumentation to report a *rolling 1-minute maximum* based on per-second samples, instead of tracking a point-in-time inflight gauge updated on request start/end.
> 
> Renames the Prometheus gauge from `loki_distributor_inflight_bytes` to `loki_distributor_max_inflight_bytes` and starts a new `collectInflightBytes` goroutine to sample `inflightBytes` every second and publish the window max.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a7d3e9c60adc4e2abbf49db8a9996cf64a4e309. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->