### PR TITLE
chore: refactor into generic collector

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -55,6 +55,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
+	util_metric "github.com/grafana/loki/v3/pkg/util/metric"
 	lokiring "github.com/grafana/loki/v3/pkg/util/ring"
 	"github.com/grafana/loki/v3/pkg/validation"
 )
@@ -216,8 +217,7 @@ type Distributor struct {
 	numMetadataPartitions int
 
 	// Track the maximum number of inflight bytes in the last 1 minute.
-	inflightBytes      *atomic.Uint64
-	inflightBytesGauge prometheus.Gauge
+	inflightBytes *util_metric.MaxSampleCollector
 
 	// kafka metrics
 	kafkaAppends           *prometheus.CounterVec
@@ -407,12 +407,10 @@ func New(
 		partitionRing:         partitionRing,
 		ingestLimits:          ingestLimits,
 		numMetadataPartitions: numMetadataPartitions,
-		inflightBytes:         atomic.NewUint64(0),
-		inflightBytesGauge: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
-			Namespace: constants.Loki,
-			Name:      "distributor_max_inflight_bytes",
-			Help:      "The maximum number of inflight bytes in the last 1 minute.",
-		}),
+		inflightBytes: util_metric.NewMaxSampleCollector(
+			"loki_distributor_max_inflight_bytes",
+			"The maximum number of inflight bytes in the last 1 minute.",
+		),
 	}
 
 	if overrides.IngestionRateStrategy() == validation.GlobalIngestionRateStrategy {
@@ -453,6 +451,8 @@ func New(
 	)
 	d.rateStore = rs
 
+	_ = registerer.Register(d.inflightBytes)
+	servs = append(servs, d.inflightBytes)
 	servs = append(servs, d.ingesterClients, rs)
 	d.subservices, err = services.NewManager(servs...)
 	if err != nil {
@@ -482,38 +482,11 @@ func (d *Distributor) running(ctx context.Context) error {
 			go d.pushIngesterWorker(ctx)
 		}
 	}
-	go d.collectInflightBytes(ctx)
 	select {
 	case <-ctx.Done():
 		return nil
 	case err := <-d.subservicesWatcher.Chan():
 		return errors.Wrap(err, "distributor subservice failed")
-	}
-}
-
-// collectInflightBytes updates the inflightBytesGauge with the max value
-// from the last 1 minute.
-func (d *Distributor) collectInflightBytes(ctx context.Context) {
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-	// window contains per-second samples for the last 1 minute.
-	window := make([]uint64, 60)
-	secs := 0
-	for {
-		select {
-		case <-ticker.C:
-			window[secs] = d.inflightBytes.Load()
-			secs = (secs + 1) % 60
-			var maxVal uint64
-			for _, val := range window {
-				if val > maxVal {
-					maxVal = val
-				}
-			}
-			d.inflightBytesGauge.Set(float64(maxVal))
-		case <-ctx.Done():
-			return
-		}
 	}
 }
 
@@ -591,9 +564,9 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 // Push a set of streams.
 // The returned error is the last one seen.
 func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRequest, streamResolver *requestScopedStreamResolver, format string) (*logproto.PushResponse, error) {
-	requestSizeBytes := uint64(req.Size())
-	d.inflightBytes.Add(requestSizeBytes)
-	defer d.inflightBytes.Sub(requestSizeBytes)
+	requestSize := int64(req.Size())
+	d.inflightBytes.Inc(requestSize)
+	defer d.inflightBytes.Inc(-requestSize)
 
 	tenantID, err := tenant.TenantID(ctx)
 	if err != nil {

--- a/pkg/util/metric/max_sample_collector.go
+++ b/pkg/util/metric/max_sample_collector.go
@@ -1,0 +1,64 @@
+package metric
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// MaxSampleCollector is a special kind of prometheus collector that collects
+// the max sample in the last 1 minute. The sample period is 1 second. It is
+// lock-free.
+type MaxSampleCollector struct {
+	*services.BasicService
+	// samples and secs are exclusive to [iterFunc], which is called from the
+	// timer service in a loop, so no mutex is required.
+	samples     [60]int64
+	secs        int
+	val, maxVal atomic.Int64
+	desc        *prometheus.Desc
+}
+
+// NewMaxSampleCollector returns a new MaxSampleCollector for the metric name
+// and help.
+func NewMaxSampleCollector(fqName, help string) *MaxSampleCollector {
+	c := &MaxSampleCollector{desc: prometheus.NewDesc(fqName, help, nil, nil)}
+	c.BasicService = services.NewTimerService(time.Second, nil, c.iterFunc, nil)
+	return c
+}
+
+// Inc adds the delta to the current value.
+func (c *MaxSampleCollector) Inc(delta int64) {
+	c.val.Add(delta)
+}
+
+// Describe implements [prometheus.Collector].
+func (c *MaxSampleCollector) Describe(descs chan<- *prometheus.Desc) {
+	descs <- c.desc
+}
+
+// Collect implements [prometheus.Collector].
+func (c *MaxSampleCollector) Collect(metrics chan<- prometheus.Metric) {
+	metrics <- prometheus.MustNewConstMetric(
+		c.desc,
+		prometheus.GaugeValue,
+		float64(c.maxVal.Load()),
+	)
+}
+
+// iterFunc implements [services.OneIteration].
+func (c *MaxSampleCollector) iterFunc(_ context.Context) error {
+	c.samples[c.secs] = c.val.Load()
+	c.secs = (c.secs + 1) % 60
+	var maxVal int64
+	for _, val := range c.samples {
+		if val > maxVal {
+			maxVal = val
+		}
+	}
+	c.maxVal.Store(maxVal)
+	return nil
+}

--- a/pkg/util/metric/max_sample_collector.go
+++ b/pkg/util/metric/max_sample_collector.go
@@ -2,7 +2,7 @@ package metric
 
 import (
 	"context"
-	"sync/atomic"
+	"sync/atomic" //lint:ignore faillint we use new atomic types from sync/atomic.
 	"time"
 
 	"github.com/grafana/dskit/services"

--- a/pkg/util/metric/max_sample_collector_test.go
+++ b/pkg/util/metric/max_sample_collector_test.go
@@ -1,0 +1,59 @@
+package metric
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaxSampleCollector(t *testing.T) {
+	c := NewMaxSampleCollector("test", "A test metric from the max sample collector.")
+	// The collector should have no samples.
+	expected := [60]int64{}
+	require.Equal(t, expected, c.samples)
+	// Inc should update the current value, but not samples, since the
+	// timer hasn't fired.
+	c.Inc(1)
+	require.Equal(t, int64(1), c.val.Load())
+	require.Equal(t, int64(0), c.maxVal.Load())
+	require.Equal(t, expected, c.samples)
+	// Call the iterFunc to mimic the timer.
+	require.NoError(t, c.iterFunc(t.Context()))
+	require.Equal(t, int64(1), c.val.Load())
+	require.Equal(t, int64(1), c.maxVal.Load())
+	expected[0] = 1
+	require.Equal(t, expected, c.samples)
+	// Call the iterFunc once more, the next sample should also be 1.
+	require.NoError(t, c.iterFunc(t.Context()))
+	expected[1] = 1
+	require.Equal(t, expected, c.samples)
+	require.Equal(t, int64(1), c.val.Load())
+	require.Equal(t, int64(1), c.maxVal.Load())
+	// Inc one last time, and call the iterFunc.
+	c.Inc(2)
+	require.Equal(t, int64(3), c.val.Load())
+	require.Equal(t, int64(1), c.maxVal.Load())
+	require.NoError(t, c.iterFunc(t.Context()))
+	expected[2] = 3
+	require.Equal(t, expected, c.samples)
+	require.Equal(t, int64(3), c.val.Load())
+	require.Equal(t, int64(3), c.maxVal.Load())
+	// Scrape the metric.
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(c))
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP test A test metric from the max sample collector.
+# TYPE test gauge
+test 3
+`), "test"))
+}
+
+func ExampleMaxSampleCollector() {
+	c := NewMaxSampleCollector("metric_name", "This is the metric description, or help message.")
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(c)
+	// The metric_name metric will be scraped via /metrics.
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors https://github.com/grafana/loki/pull/21611 into a generic collector.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior should be equivalent but the metric emission now depends on the collector service being started/registered correctly; impact is limited to observability (no ingestion logic changes).
> 
> **Overview**
> Refactors `distributor`’s `max_inflight_bytes` metric to use a new reusable `util/metric.MaxSampleCollector` instead of maintaining an `atomic` counter plus a custom 1-minute window goroutine.
> 
> Adds `MaxSampleCollector` (a lock-free Prometheus `Collector` implemented as a `services.TimerService`) with unit tests, registers it as a subservice, and switches inflight tracking in `PushWithResolver` to `Inc(+/-size)` on the collector’s internal value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eea65818749cf436cdd100c2def3b92e5261cfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->