### PR TITLE
chore(ci): Fix Prepare Minor Release PR workflow

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "27ed4db1e9382bd115b2c57370fa459b48087d56"
+      "version": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "27ed4db1e9382bd115b2c57370fa459b48087d56",
-      "sum": "oakODnqdF4CO2dDhZbHLZnccI+0as9yOfju414WRi7M="
+      "version": "52d476dc60de14b52b6dec2b33e86abeeb497fcc",
+      "sum": "Xmuvvfw2GyoFFNYxsFUSOEEC7BvP/Ln5sfDucjQvh/Q="
     }
   ],
   "legacyImports": false

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -321,7 +321,6 @@ local runner = import 'runner.libsonnet',
       'id-token': 'write',
     })
     + job.withSteps([
-      common.cleanUpBuildCache,
       common.fetchReleaseRepo,
       common.fetchGcsCredentials,
       common.googleAuth,

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@27ed4db1e9382bd115b2c57370fa459b48087d56"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@52d476dc60de14b52b6dec2b33e86abeeb497fcc"
     "with":
       "build_image": "grafana/loki-build-image:0.35.1"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "27ed4db1e9382bd115b2c57370fa459b48087d56"
+      "release_lib_ref": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@27ed4db1e9382bd115b2c57370fa459b48087d56"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@52d476dc60de14b52b6dec2b33e86abeeb497fcc"
     "with":
       "build_image": "grafana/loki-build-image:0.35.1"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "27ed4db1e9382bd115b2c57370fa459b48087d56"
+      "release_lib_ref": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
       "skip_validation": false
       "use_github_app_token": true
   "loki-canary-boringcrypto-image":
@@ -12,7 +12,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "27ed4db1e9382bd115b2c57370fa459b48087d56"
+      "RELEASE_LIB_REF": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -136,7 +136,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "27ed4db1e9382bd115b2c57370fa459b48087d56"
+      "RELEASE_LIB_REF": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -260,7 +260,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "27ed4db1e9382bd115b2c57370fa459b48087d56"
+      "RELEASE_LIB_REF": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -384,7 +384,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "27ed4db1e9382bd115b2c57370fa459b48087d56"
+      "RELEASE_LIB_REF": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -8,7 +8,7 @@ env:
   DRY_RUN: false
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "27ed4db1e9382bd115b2c57370fa459b48087d56"
+  RELEASE_LIB_REF: "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
@@ -19,11 +19,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@27ed4db1e9382bd115b2c57370fa459b48087d56"
+    uses: "grafana/loki-release/.github/workflows/check.yml@52d476dc60de14b52b6dec2b33e86abeeb497fcc"
     with:
       build_image: "grafana/loki-build-image:0.35.1"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "27ed4db1e9382bd115b2c57370fa459b48087d56"
+      release_lib_ref: "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -131,8 +131,6 @@ jobs:
       pull-requests: "write"
     runs-on: "ubuntu-x64"
     steps:
-    - name: "clean up build tools cache"
-      run: "rm -rf /opt/hostedtoolcache"
     - name: "pull code to release"
       uses: "actions/checkout@v4"
       with:

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -8,7 +8,7 @@ env:
   DRY_RUN: false
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "27ed4db1e9382bd115b2c57370fa459b48087d56"
+  RELEASE_LIB_REF: "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
@@ -19,11 +19,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@27ed4db1e9382bd115b2c57370fa459b48087d56"
+    uses: "grafana/loki-release/.github/workflows/check.yml@52d476dc60de14b52b6dec2b33e86abeeb497fcc"
     with:
       build_image: "grafana/loki-build-image:0.35.1"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "27ed4db1e9382bd115b2c57370fa459b48087d56"
+      release_lib_ref: "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -131,8 +131,6 @@ jobs:
       pull-requests: "write"
     runs-on: "ubuntu-x64"
     steps:
-    - name: "clean up build tools cache"
-      run: "rm -rf /opt/hostedtoolcache"
     - name: "pull code to release"
       uses: "actions/checkout@v4"
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "27ed4db1e9382bd115b2c57370fa459b48087d56"
+  RELEASE_LIB_REF: "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
   RELEASE_REPO: "grafana/loki"
   USE_GITHUB_APP_TOKEN: true
 jobs:


### PR DESCRIPTION
### Summary

Update release-lib and run `make release-workflows` to remove cache cleanup step in dist job of the workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GitHub release automation workflows and the vendored shared workflow library, which could break release PR creation or artifact publishing if the updated upstream workflow behavior differs.
> 
> **Overview**
> Updates the pinned `grafana/loki-release` workflow library ref across CI/release workflows (`check`, `images`, `minor-release-pr`, `patch-release-pr`, and `release`) and refreshes the vendored `workflows` code/lockfile.
> 
> As part of the workflow refresh, removes the explicit build cache cleanup step (`rm -rf /opt/hostedtoolcache`) from the `dist` job so release PR pipelines no longer wipe the hosted tools cache before building artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4014299041597d9bb163b4cf6f621aea819ef2d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->