### PR TITLE
feat: handle context cancelation in memcached batching

### DIFF
--- a/pkg/storage/chunk/cache/memcached.go
+++ b/pkg/storage/chunk/cache/memcached.go
@@ -202,6 +202,7 @@ func (c *Memcached) fetchKeysBatched(ctx context.Context, keys []string) (found 
 			abort = true
 		case <-ctx.Done():
 			abort = true
+			err = ctx.Err()
 		default:
 			c.inputCh <- &work{
 				keys:     keys[i:min(i+batchSize, len(keys))],
@@ -232,6 +233,9 @@ func (c *Memcached) fetchKeysBatched(ctx context.Context, keys []string) (found 
 		bufs = append(bufs, r.bufs...)
 		missed = append(missed, r.missed...)
 		if r.err != nil {
+			// NOTE: this will overwrite the error from the context if any.
+			// I considered using a multierror, but if there are many batches,
+			// this may result in too many errors for the likely same reason
 			err = r.err
 		}
 	}

--- a/pkg/storage/chunk/cache/memcached.go
+++ b/pkg/storage/chunk/cache/memcached.go
@@ -22,6 +22,10 @@ import (
 type MemcachedConfig struct {
 	Expiration time.Duration `yaml:"expiration"`
 
+	// BatchSize is the number of keys fetched per worker request. When
+	// non-zero, Fetch splits keys into batches of this size and processes them
+	// in parallel. If the context is cancelled mid-flight, already-completed
+	// batches are returned as partial results and the rest are reported missed.
 	BatchSize   int `yaml:"batch_size"`
 	Parallelism int `yaml:"parallelism"`
 }
@@ -45,8 +49,9 @@ type Memcached struct {
 	wg      sync.WaitGroup
 	inputCh chan *work
 
-	// `closed` tracks if `inputCh` is closed.
-	// So that any writer goroutine wouldn't write to it after closing `intputCh`
+	// `closed` is closed by Stop() to signal that the cache is stopping.
+	// It is closed before inputCh so that senders can safely check it before
+	// attempting a send and avoid a "send on closed channel" panic.
 	closed chan struct{}
 
 	logger log.Logger
@@ -131,7 +136,13 @@ func memcacheStatusCode(err error) string {
 	}
 }
 
-// Fetch gets keys from the cache. The keys that are found must be in the order of the keys requested.
+// Fetch gets keys from the cache. The keys that are found must be in the order
+// of the keys requested.
+//
+// When BatchSize is non-zero, Fetch submits keys in batches to a worker pool.
+// If the context is cancelled before all batches complete, Fetch returns
+// whatever results have been collected so far together with ctx.Err(). Keys
+// whose batch did not complete in time are reported as missed.
 func (c *Memcached) Fetch(ctx context.Context, keys []string) (found []string, bufs [][]byte, missed []string, err error) {
 	if c.cfg.BatchSize == 0 {
 		found, bufs, missed, err = c.fetch(ctx, keys)
@@ -168,57 +179,66 @@ func (c *Memcached) fetch(ctx context.Context, keys []string) (found []string, b
 }
 
 func (c *Memcached) fetchKeysBatched(ctx context.Context, keys []string) (found []string, bufs [][]byte, missed []string, err error) {
-	resultsCh := make(chan *result)
 	batchSize := c.cfg.BatchSize
+	numBatches := (len(keys) + batchSize - 1) / batchSize
 
-	go func() {
-		for i, j := 0, 0; i < len(keys); i += batchSize {
-			batchKeys := keys[i:min(i+batchSize, len(keys))]
-			select {
-			case <-c.closed:
-				return
-			default:
-				c.inputCh <- &work{
-					keys:     batchKeys,
-					ctx:      ctx,
-					resultCh: resultsCh,
-					batchID:  j,
-				}
-				j++
-			}
-		}
-	}()
+	// resultsCh is buffered to numBatches so workers can always deliver without
+	// blocking, even when we stop collecting early due to cancellation or Stop.
+	// This lets us submit batches synchronously: if inputCh is full we block
+	// until a worker picks up a batch (it can always send its result to the
+	// buffered resultsCh first), so there is no deadlock risk.
+	resultsCh := make(chan *result, numBatches)
 
-	// Read all values from this channel to avoid blocking upstream.
-	numResults := len(keys) / batchSize
-	if len(keys)%batchSize != 0 {
-		numResults++
-	}
-
-	// We need to order found by the input keys order.
-	results := make([]*result, numResults)
-	for i := 0; i < numResults; i++ {
-		// NOTE: Without this check, <-resultCh may wait forever as work is
-		// interrupted (by other goroutine by calling `Stop()`) and there may not be `numResults`
-		// values to read from `resultsCh` in that case.
-		// Also we do close(resultsCh) in the same goroutine so <-resultCh may never return.
+	var (
+		sent  int
+		abort bool
+	)
+	for i := 0; i < len(keys) && !abort; i += batchSize {
+		// Stop() closes c.closed before c.inputCh, so c.closed is always ready
+		// by the time inputCh is closed. The default branch (and its send to
+		// inputCh) is therefore never reached when inputCh is unsafe to use.
 		select {
 		case <-c.closed:
-			return
+			abort = true
+		case <-ctx.Done():
+			abort = true
 		default:
-			result := <-resultsCh
-			results[result.batchID] = result
+			c.inputCh <- &work{
+				keys:     keys[i:min(i+batchSize, len(keys))],
+				ctx:      ctx,
+				resultCh: resultsCh,
+				batchID:  sent,
+			}
+			sent++
 		}
 	}
-	close(resultsCh)
 
-	for _, result := range results {
-		found = append(found, result.found...)
-		bufs = append(bufs, result.bufs...)
-		missed = append(missed, result.missed...)
-		if result.err != nil {
-			err = result.err
+	// If Stop() was called, workers may not complete — return nothing.
+	select {
+	case <-c.closed:
+		return
+	default:
+	}
+
+	// Collect exactly as many results as were submitted,
+	// then aggregate in batch order to preserve input key ordering.
+	results := make([]*result, sent)
+	for i := 0; i < sent; i++ {
+		r := <-resultsCh
+		results[r.batchID] = r
+	}
+	for _, r := range results {
+		found = append(found, r.found...)
+		bufs = append(bufs, r.bufs...)
+		missed = append(missed, r.missed...)
+		if r.err != nil {
+			err = r.err
 		}
+	}
+
+	if sent < numBatches {
+		// Keys in batches that were never submitted are all missed.
+		missed = append(missed, keys[sent*batchSize:]...)
 	}
 
 	return
@@ -248,8 +268,8 @@ func (c *Memcached) Stop() {
 		return
 	}
 
-	close(c.inputCh)
-	close(c.closed)
+	close(c.closed)  // signal senders to stop before closing inputCh
+	close(c.inputCh) // stop workers
 	c.wg.Wait()
 }
 

--- a/pkg/storage/chunk/cache/memcached_client_test.go
+++ b/pkg/storage/chunk/cache/memcached_client_test.go
@@ -3,6 +3,7 @@ package cache_test
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/grafana/gomemcache/memcache"
 )
@@ -37,4 +38,21 @@ func (m *mockMemcache) Set(item *memcache.Item) error {
 	defer m.Unlock()
 	m.contents[item.Key] = item.Value
 	return nil
+}
+
+// delayedMockMemcache introduces a fixed delay before each GetMulti call,
+// simulating a slow memcached server. If the context is cancelled during the
+// delay it returns immediately with ctx.Err().
+type delayedMockMemcache struct {
+	mockMemcache
+	delay time.Duration
+}
+
+func (m *delayedMockMemcache) GetMulti(ctx context.Context, keys []string, opts ...memcache.Option) (map[string]*memcache.Item, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(m.delay):
+		return m.mockMemcache.GetMulti(ctx, keys)
+	}
 }

--- a/pkg/storage/chunk/cache/memcached_client_test.go
+++ b/pkg/storage/chunk/cache/memcached_client_test.go
@@ -48,7 +48,7 @@ type delayedMockMemcache struct {
 	delay time.Duration
 }
 
-func (m *delayedMockMemcache) GetMulti(ctx context.Context, keys []string, opts ...memcache.Option) (map[string]*memcache.Item, error) {
+func (m *delayedMockMemcache) GetMulti(ctx context.Context, keys []string, _ ...memcache.Option) (map[string]*memcache.Item, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/pkg/storage/chunk/cache/memcached_test.go
+++ b/pkg/storage/chunk/cache/memcached_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/go-kit/log"
@@ -118,26 +119,28 @@ func TestMemcached_fetchKeysBatched_contextCancellation(t *testing.T) {
 	// With Parallelism=1, batches run sequentially. Each GetMulti call takes
 	// 10ms (simulated delay). A 25ms timeout allows the first two batches to
 	// complete (~20ms total) but cuts off the third (~30ms).
-	keys := []string{"k1", "k2", "k3", "k4", "k5", "k6"}
-	client := &delayedMockMemcache{mockMemcache: *newMockMemcache(), delay: 10 * time.Millisecond}
-	for _, k := range keys {
-		require.NoError(t, client.Set(&memcache.Item{Key: k, Value: []byte(k)}))
-	}
-	mc := cache.NewMemcached(cache.MemcachedConfig{
-		BatchSize:   2,
-		Parallelism: 1,
-	}, client, "test", nil, log.NewNopLogger(), "test")
-	defer mc.Stop()
+	synctest.Test(t, func(t *testing.T) {
+		keys := []string{"k1", "k2", "k3", "k4", "k5", "k6"}
+		client := &delayedMockMemcache{mockMemcache: *newMockMemcache(), delay: 10 * time.Millisecond}
+		for _, k := range keys {
+			require.NoError(t, client.Set(&memcache.Item{Key: k, Value: []byte(k)}))
+		}
+		mc := cache.NewMemcached(cache.MemcachedConfig{
+			BatchSize:   2,
+			Parallelism: 1,
+		}, client, "test", nil, log.NewNopLogger(), "test")
+		defer mc.Stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
+		defer cancel()
 
-	found, bufs, missed, err := mc.Fetch(ctx, keys)
+		found, bufs, missed, err := mc.Fetch(ctx, keys)
 
-	require.ErrorIs(t, err, context.DeadlineExceeded)
-	require.Len(t, bufs, len(found))
-	require.ElementsMatch(t, []string{"k1", "k2", "k3", "k4"}, found)
-	require.ElementsMatch(t, []string{"k5", "k6"}, missed)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Len(t, bufs, len(found))
+		require.ElementsMatch(t, []string{"k1", "k2", "k3", "k4"}, found)
+		require.ElementsMatch(t, []string{"k5", "k6"}, missed)
+	})
 }
 
 // mockMemcache whose calls fail 1/3rd of the time.

--- a/pkg/storage/chunk/cache/memcached_test.go
+++ b/pkg/storage/chunk/cache/memcached_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/gomemcache/memcache"
@@ -111,6 +112,32 @@ func testMemcache(t *testing.T, memcache *cache.Memcached) {
 		found = found[1:]
 		bufs = bufs[1:]
 	}
+}
+
+func TestMemcached_fetchKeysBatched_contextCancellation(t *testing.T) {
+	// With Parallelism=1, batches run sequentially. Each GetMulti call takes
+	// 10ms (simulated delay). A 25ms timeout allows the first two batches to
+	// complete (~20ms total) but cuts off the third (~30ms).
+	keys := []string{"k1", "k2", "k3", "k4", "k5", "k6"}
+	client := &delayedMockMemcache{mockMemcache: *newMockMemcache(), delay: 10 * time.Millisecond}
+	for _, k := range keys {
+		require.NoError(t, client.Set(&memcache.Item{Key: k, Value: []byte(k)}))
+	}
+	mc := cache.NewMemcached(cache.MemcachedConfig{
+		BatchSize:   2,
+		Parallelism: 1,
+	}, client, "test", nil, log.NewNopLogger(), "test")
+	defer mc.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	found, bufs, missed, err := mc.Fetch(ctx, keys)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Len(t, bufs, len(found))
+	require.ElementsMatch(t, []string{"k1", "k2", "k3", "k4"}, found)
+	require.ElementsMatch(t, []string{"k5", "k6"}, missed)
 }
 
 // mockMemcache whose calls fail 1/3rd of the time.


### PR DESCRIPTION
**What this PR does / why we need it**:

Check context on memcached batching implementation so we can return early when the context is done.
Now when the context is done, Fetch returns `ctx.Err` and the fetched keys so far. Any remaining key not fetched is reported as missing.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency/cancellation behavior in the hot-path cache fetch logic; mistakes could cause missed cache hits, ordering issues, or goroutine/channel deadlocks under load.
> 
> **Overview**
> `Memcached.Fetch` batching now checks `ctx.Done()` and stops submitting further batches, returning **partial results** plus `ctx.Err()` and marking unsubmitted keys as missed.
> 
> The batching implementation was reworked to use a `numBatches`-buffered results channel and to collect only the results for batches actually submitted (preserving key order), and `Stop()` now closes `closed` before `inputCh` to avoid send-on-closed-channel races.
> 
> Tests add a delayed memcache client and a deterministic timeout case to verify cancellation returns the first completed batches and reports the remainder as missed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46828f9578605922cc80cf54aefbbacba5cd7e3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->