### PR TITLE
ci: use self-hosted runners

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,7 +12,7 @@ jobs:
     # Also only run if the PR is merged, as an extra safe-guard.
     if: ${{ ! github.event.pull_request.head.repo.fork && github.event.pull_request.merged == true }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: "read"
       id-token: "write"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,7 +20,7 @@ jobs:
     if: |
       github.event.label.name == 'claude-review'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ jobs:
        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -3,7 +3,7 @@ name: enforce conventional commits
 on: [pull_request]
 jobs:
   check-title:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-small
     permissions:
       contents: "read"
       id-token: "write"

--- a/.github/workflows/dependabot_reviewer.yml
+++ b/.github/workflows/dependabot_reviewer.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dependabot-reviewer:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
 
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
 

--- a/.github/workflows/helm-diff-ci.yml
+++ b/.github/workflows/helm-diff-ci.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   helm-diff:
     name: ${{ matrix.scenario.name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: "read"
       id-token: "write"
@@ -104,7 +104,7 @@ jobs:
 
   summary-diff-outputs:
     name: Summary Diffs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: "read"
       id-token: "write"

--- a/.github/workflows/helm-tagged-release-pr.yaml
+++ b/.github/workflows/helm-tagged-release-pr.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   weekly-release-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: "read"
       id-token: "write"

--- a/.github/workflows/helm-weekly-release-pr.yaml
+++ b/.github/workflows/helm-weekly-release-pr.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   weekly-release-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: "read"
       id-token: "write"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,7 +9,7 @@ jobs:
     # Also only run if the PR is merged, as an extra safe-guard.
     if: ${{ ! github.event.pull_request.head.repo.fork && github.event.pull_request.merged == true }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-small
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/lint-jsonnet.yml
+++ b/.github/workflows/lint-jsonnet.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check-mixin:
     name: Check mixin jsonnet files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: "read"
       id-token: "write"

--- a/.github/workflows/logql-analyzer.yml
+++ b/.github/workflows/logql-analyzer.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
 
     env:
       BUILD_TIMEOUT: 60

--- a/.github/workflows/logql-bench.yml
+++ b/.github/workflows/logql-bench.yml
@@ -31,7 +31,7 @@ permissions: {}
 jobs:
   generate-testdata:
     name: Generate test data
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     steps:
       - name: Checkout code
         id: checkout
@@ -61,7 +61,7 @@ jobs:
   setup-matrix:
     name: Setup matrix
     needs: generate-testdata
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}
     steps:

--- a/.github/workflows/logql-correctness.yml
+++ b/.github/workflows/logql-correctness.yml
@@ -35,7 +35,7 @@ permissions: {}
 jobs:
   generate-testdata:
     name: Generate test data
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     timeout-minutes: 60
     outputs:
       commit: ${{ steps.checkout.outputs.commit }}

--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -13,7 +13,7 @@ on:
       - .github/workflows/nix-ci.yaml
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: "read"
       id-token: "write"
@@ -27,7 +27,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
       - run: nix run --print-build-logs .#lint
   packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: "read"
       id-token: "write"

--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/relyance.yml
+++ b/.github/workflows/relyance.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
       id-token: write
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     timeout-minutes: 15
     steps:
       - name: Checkout Code

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -2,7 +2,7 @@ name: TruffleHog Secrets Scan
 on: [pull_request]
 jobs:
   TruffleHog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: "read"
       id-token: "write"

--- a/.github/workflows/syft-sbom-ci.yml
+++ b/.github/workflows/syft-sbom-ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   syft-sbom:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: "read"
       id-token: "write"

--- a/.github/workflows/verify-release-workflow.yaml
+++ b/.github/workflows/verify-release-workflow.yaml
@@ -2,7 +2,7 @@ name: Verify release workflow updates
 on: [pull_request]
 jobs:
   check-release-changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: "read"
       id-token: "write"


### PR DESCRIPTION
**What this PR does / why we need it**:
`ubuntu-latest` are not self-hosted workers.
I switched most of the workers to the default `ubuntu-x64`, except for some misc tasks which obviously could run on small machines.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily CI configuration changes, but they can break automation if the self-hosted runner labels/capacity or environment differ from `ubuntu-latest`.
> 
> **Overview**
> Switches multiple GitHub Actions workflows from `ubuntu-latest` GitHub-hosted runners to self-hosted runner labels (`ubuntu-x64` / `ubuntu-x64-small`).
> 
> This affects automation and CI jobs such as backporting/labeling, Claude review workflows, Helm diff/release PR creation, Nix CI, docs publishing, secret scanning, SBOM generation, and release-workflow verification, without changing the job logic itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c81ce86a6a84275ec55013d535b1f1d49d6c55c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->