### PR TITLE
ci: move to latest loki-release, move off of ubuntu-latest runners

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
+      "version": "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "52d476dc60de14b52b6dec2b33e86abeeb497fcc",
-      "sum": "Xmuvvfw2GyoFFNYxsFUSOEEC7BvP/Ln5sfDucjQvh/Q="
+      "version": "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b",
+      "sum": "3MrIUGHApJt1yB5mGSR2QKV1D4toLlTnws6QW8TVelo="
     }
   ],
   "legacyImports": false

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -315,7 +315,7 @@ local runner = import 'runner.libsonnet',
       pr_created: '${{ steps.version.outputs.pr_created }}',
     }),
 
-  dist: function(buildImage, skipArm=true, useGCR=false, makeTargets=['dist', 'packages'], optionalTargets=[], runsOn='ubuntu-latest')
+  dist: function(buildImage, skipArm=true, useGCR=false, makeTargets=['dist', 'packages'], optionalTargets=[], runsOn='ubuntu-x64')
     job.new(runsOn)
     + job.withPermissions({
       'id-token': 'write',

--- a/.github/vendor/github.com/grafana/loki-release/workflows/common.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/common.libsonnet
@@ -34,7 +34,7 @@
     },
   },
   job: {
-    new: function(runsOn='ubuntu-latest') {
+    new: function(runsOn='ubuntu-x64') {
       'runs-on': runsOn,
     },
     with: function(with) {

--- a/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
@@ -15,7 +15,7 @@
     checkTemplate='./.github/workflows/check.yml',
     distMakeTargets=['dist', 'packages'],
     distOptionalTargets=[],
-    distRunsOn='ubuntu-latest',
+    distRunsOn='ubuntu-x64',
     dryRun=false,
     dockerUsername='grafana',
     golangCiLintVersion='v2.3.0',

--- a/.github/vendor/github.com/grafana/loki-release/workflows/runner.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/runner.libsonnet
@@ -28,6 +28,6 @@ local defaultMapping = {
     }
     else {
       arch: arch,
-      runs_on: ['ubuntu-latest'],
+      runs_on: ['ubuntu-x64'],
     },
 }

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@52d476dc60de14b52b6dec2b33e86abeeb497fcc"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
     "with":
       "build_image": "grafana/loki-build-image:0.35.1"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
+      "release_lib_ref": "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@52d476dc60de14b52b6dec2b33e86abeeb497fcc"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
     "with":
       "build_image": "grafana/loki-build-image:0.35.1"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
+      "release_lib_ref": "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
       "skip_validation": false
       "use_github_app_token": true
   "loki-canary-boringcrypto-image":
@@ -12,7 +12,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
+      "RELEASE_LIB_REF": "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -112,7 +112,7 @@
     "permissions":
       "contents": "read"
       "id-token": "write"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
@@ -136,7 +136,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
+      "RELEASE_LIB_REF": "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -236,7 +236,7 @@
     "permissions":
       "contents": "read"
       "id-token": "write"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
@@ -260,7 +260,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
+      "RELEASE_LIB_REF": "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -360,7 +360,7 @@
     "permissions":
       "contents": "read"
       "id-token": "write"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
@@ -384,7 +384,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
+      "RELEASE_LIB_REF": "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -484,7 +484,7 @@
     "permissions":
       "contents": "read"
       "id-token": "write"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
@@ -514,7 +514,7 @@
     "permissions":
       "contents": "read"
       "id-token": "write"
-    "runs-on": "ubuntu-latest"
+    "runs-on": "ubuntu-x64"
     "steps":
     - "name": "Trigger CD workflow"
       "uses": "grafana/shared-workflows/actions/trigger-argo-workflow@8b88213bca76e86f9f59b43038cc5d7545452436"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -8,7 +8,7 @@ env:
   DRY_RUN: false
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
+  RELEASE_LIB_REF: "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
@@ -19,11 +19,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@52d476dc60de14b52b6dec2b33e86abeeb497fcc"
+    uses: "grafana/loki-release/.github/workflows/check.yml@decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
     with:
       build_image: "grafana/loki-build-image:0.35.1"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
+      release_lib_ref: "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -43,7 +43,7 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
       uses: "actions/checkout@v4"
@@ -1019,7 +1019,7 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -8,7 +8,7 @@ env:
   DRY_RUN: false
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
+  RELEASE_LIB_REF: "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
@@ -19,11 +19,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@52d476dc60de14b52b6dec2b33e86abeeb497fcc"
+    uses: "grafana/loki-release/.github/workflows/check.yml@decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
     with:
       build_image: "grafana/loki-build-image:0.35.1"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
+      release_lib_ref: "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -43,7 +43,7 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
       uses: "actions/checkout@v4"
@@ -1019,7 +1019,7 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
+  RELEASE_LIB_REF: "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
   RELEASE_REPO: "grafana/loki"
   USE_GITHUB_APP_TOKEN: true
 jobs:
@@ -25,7 +25,7 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
       uses: "actions/checkout@v4"
@@ -151,7 +151,7 @@ jobs:
     permissions:
       contents: "write"
       id-token: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
       uses: "actions/checkout@v4"
@@ -248,7 +248,7 @@ jobs:
     - "createRelease"
     permissions:
       id-token: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -302,7 +302,7 @@ jobs:
     - "createRelease"
     permissions:
       id-token: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull release library code"
       uses: "actions/checkout@v4"
@@ -352,7 +352,7 @@ jobs:
     permissions:
       contents: "write"
       id-token: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
       uses: "actions/checkout@v4"
@@ -407,7 +407,7 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
       uses: "actions/checkout@v4"


### PR DESCRIPTION
**What this PR does / why we need it**:
Pulls in https://github.com/grafana/loki-release/pull/302 , and reframes our workflows to use `ubuntu-x64` instead of `ubuntu-latest`, so that we use self-hosted runners.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI/release workflows are updated to a new shared `loki-release` revision and to different runner labels, which could break builds or releases if runner availability/labels differ or the upstream workflow behavior changed.
> 
> **Overview**
> Updates the vendored `grafana/loki-release` workflow library to `decfa8d4d…` (including `jsonnetfile`/lock sum updates) and points all reusable-workflow invocations (`check.yml`, release PR workflows) at the same new ref.
> 
> Migrates workflow execution off `ubuntu-latest` by changing default Jsonnet workflow runner settings and multiple GitHub Actions jobs (including image manifest publishing and release/release-PR jobs) to run on `ubuntu-x64` instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 591bc299db7e002a1771464d4db08fc7c5b1ab95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->