### PR TITLE
fix(v2 engine): sort fields alphabetically in arrowagg.Records.Aggregate() for deterministic schema ordering

### DIFF
--- a/pkg/engine/internal/arrowagg/records.go
+++ b/pkg/engine/internal/arrowagg/records.go
@@ -3,6 +3,8 @@ package arrowagg
 import (
 	"fmt"
 	"hash/maphash"
+	"slices"
+	"strings"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -13,9 +15,11 @@ import (
 // single, combined record with a combined schema.
 //
 // The returned record will have a schema composed of the union of all fields
-// from the input records. Fields will be placed in the order in which they are
-// first seen. When aggregating records, fields that do not exist in the source
-// record will be filled with null values in the output record.
+// from the input records. Fields are sorted alphabetically by name in the
+// output schema so that the ordering is deterministic regardless of the order
+// in which individual records are appended. When aggregating records, fields
+// that do not exist in the source record will be filled with null values in
+// the output record.
 type Records struct {
 	mem memory.Allocator
 
@@ -110,8 +114,7 @@ func (r *Records) AppendSlice(rec arrow.RecordBatch, i, j int64) {
 // If no records have been appended, Aggregate returns an error.
 //
 // The returned record will have a schema composed of the union of all fields
-// from the input records, sorted by the order in which each field was first
-// seen.
+// from the input records, sorted alphabetically by field name.
 //
 // Fields that do not exist in source records will be filled with null values
 // in the output record.
@@ -123,6 +126,12 @@ func (r *Records) Aggregate() (arrow.RecordBatch, error) {
 		return nil, fmt.Errorf("no records to flush")
 	}
 	defer r.Reset()
+
+	// Sort fields alphabetically so the output schema has a deterministic column
+	// ordering regardless of the order in which individual records were appended.
+	slices.SortFunc(r.fields, func(a, b arrow.Field) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 
 	mapper := NewMapper(r.fields)
 	defer mapper.Reset() // Allow immediately freeing memory used by the mapper.


### PR DESCRIPTION
**Problem:**
The v2 engine was producing more series than the classic engine for metric queries using `avg_over_time` without grouping (e.g. `avg_over_time(... [5m])`). The discrepancy was caused by phantom duplicate series — the same logical label set being hashed to different keys depending on which Arrow batch it arrived in.                                                                                                  

**Root cause:**
[arrowagg.Records](https://github.com/grafana/loki/blob/614ba969e7f7b26dd547010acd70d8dbca204a9d/pkg/engine/internal/arrowagg/records.go#L23) builds a combined schema by [accumulating fields in first-seen order across appended records](https://github.com/grafana/loki/blob/3868af26763bd6a836b9163dfd302d46ac72acb8/pkg/engine/internal/arrowagg/records.go#L16-L17). The [batchingPipeline](https://github.com/grafana/loki/blob/a4de7ad732b5ad8313959a4182592213b4a7bf67/pkg/engine/internal/executor/batching.go) uses arrowagg.Records to merge records from multiple DataObjScan sections into larger batches. Different DataObjScan sections can have different schemas — for example, some sections may have a \_\_stream_shard__ label column and others may not.

This leads to two kinds of combined batches with different column orderings for the same label:             
                                                                                                                                                                                                                     
  - A batch formed only from sections where every record has \_\_stream_shard__ — it is the first field seen, so it lands at position [0] in the combined schema.                                                      
  - A batch formed from a mix of sections — records from sections without \_\_stream_shard__ are appended first, filling positions [0]–[N]; when records with \_\_stream_shard__ are appended later, it is a new field
  and gets placed at position [N+1].                                                                                                                                                                                 

The range/vector aggregation pipelines iterate [schema.Fields()](https://github.com/grafana/loki/blob/e74e2a20c5604b1f8bbee02149f9ec2d05c0ecd0/pkg/engine/internal/executor/range_aggregation.go#L194) in order to build the grouping key for each row. With without grouping, the same logical label set would produce field lists in different column orders across these two batch types, causing aggregator.Add() to compute different hashes → phantom duplicate series in the output.                                                                                          

**Affected queries:**
Only `avg_over_time` is currently affected. All other supported range aggregations (`count_over_time`, `sum_over_time`, `max_over_time`, `min_over_time`, `rate`) are split by the aggregationSplit planner rule, which pushes an inner RangeAggregation into the worker task. On the worker, that inner aggregation runs directly on top of Merge → DataObjScan, before the Batching node — so it sees individual DataObjScan records whose schemas are already consistently sorted. Only `avg_over_time` cannot be split (it is not an associative operation), so its RangeAggregation stays on the query engine and receives the already-batched worker output, which is where the schema ordering inconsistency is introduced.

**Fix**                                                                                                                                                                                                              
Sort r.fields alphabetically by name at the start of Records.Aggregate() before building the output schema. This gives the combined record a deterministic column ordering regardless of which records were appended and in what order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the output column ordering of aggregated Arrow batches, which can affect any downstream logic that implicitly relied on first-seen field order; intended to fix incorrect series deduplication/hashing behavior.
> 
> **Overview**
> `arrowagg.Records.Aggregate()` now **sorts combined schema fields alphabetically by field name** before building the output record, making column ordering deterministic regardless of the order or schema differences of appended batches.
> 
> Updates the `Records` documentation accordingly and adds the required imports (`slices`, `strings`) to support the new sort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 614ba969e7f7b26dd547010acd70d8dbca204a9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->