### PR TITLE
fix(operator): deny OIDC authentication in OpenShift tenant mode

### DIFF
--- a/operator/internal/handlers/lokistack_create_or_update.go
+++ b/operator/internal/handlers/lokistack_create_or_update.go
@@ -49,6 +49,10 @@ func CreateOrUpdateLokiStack(
 		return nil, kverrors.Wrap(err, "failed to lookup lokistack", "name", req.NamespacedName)
 	}
 
+	if err := validateTenantsConfiguration(&stack.Spec); err != nil {
+		return nil, err
+	}
+
 	img := os.Getenv(manifests.EnvRelatedImageLoki)
 	if img == "" {
 		img = manifests.DefaultContainerImage
@@ -259,4 +263,21 @@ func isNamespacedResource(obj client.Object) bool {
 	default:
 		return true
 	}
+}
+
+func validateTenantsConfiguration(spec *lokiv1.LokiStackSpec) error {
+	if spec.Tenants == nil {
+		return nil
+	}
+
+	mode := spec.Tenants.Mode
+	if mode == lokiv1.OpenshiftLogging || mode == lokiv1.OpenshiftNetwork {
+		for _, auth := range spec.Tenants.Authentication {
+			if auth.OIDC != nil {
+				errMsg := fmt.Sprintf("OIDC authentication is not supported in %s tenant", mode)
+				return kverrors.New(errMsg)
+			}
+		}
+	}
+	return nil
 }

--- a/operator/internal/handlers/lokistack_create_or_update_test.go
+++ b/operator/internal/handlers/lokistack_create_or_update_test.go
@@ -740,3 +740,83 @@ func TestCreateOrUpdateLokiStack_WhenInvalidQueryTimeout_SetDegraded(t *testing.
 	require.Error(t, err)
 	require.Equal(t, degradedErr, err)
 }
+
+func TestCreateOrUpdateLokiStack_WhenAuthModeIsOIDC(t *testing.T) {
+	tests := []struct {
+		name      string
+		stack     *lokiv1.LokiStack
+		wantError bool
+		errMsg    string
+	}{
+		{
+			name: "valid - static mode with OIDC",
+			stack: &lokiv1.LokiStack{
+				Spec: lokiv1.LokiStackSpec{
+					Tenants: &lokiv1.TenantsSpec{
+						Mode: lokiv1.Static,
+						Authentication: []lokiv1.AuthenticationSpec{
+							{
+								TenantName: "test",
+								TenantID:   "test",
+								OIDC: &lokiv1.OIDCSpec{
+									IssuerURL: "https://example.com",
+									Secret: &lokiv1.TenantSecretSpec{
+										Name: "test-secret",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "valid - openshift-logging without OIDC",
+			stack: &lokiv1.LokiStack{
+				Spec: lokiv1.LokiStackSpec{
+					Tenants: &lokiv1.TenantsSpec{
+						Mode: lokiv1.OpenshiftLogging,
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "invalid - openshift-logging with OIDC",
+			stack: &lokiv1.LokiStack{
+				Spec: lokiv1.LokiStackSpec{
+					Tenants: &lokiv1.TenantsSpec{
+						Mode: lokiv1.OpenshiftLogging,
+						Authentication: []lokiv1.AuthenticationSpec{
+							{
+								TenantName: "test",
+								TenantID:   "test",
+								OIDC: &lokiv1.OIDCSpec{
+									IssuerURL: "https://example.com",
+									Secret: &lokiv1.TenantSecretSpec{
+										Name: "test-secret",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantError: true,
+			errMsg:    "OIDC authentication is not supported in openshift-logging tenant",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTenantsConfiguration(&tt.stack.Spec)
+			if tt.wantError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
