### PR TITLE
ci: Move away from github-hosted runners

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
+      "version": "808a3789820ac46c7909a9a6d6f5abc4711b874f"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b",
-      "sum": "3MrIUGHApJt1yB5mGSR2QKV1D4toLlTnws6QW8TVelo="
+      "version": "808a3789820ac46c7909a9a6d6f5abc4711b874f",
+      "sum": "mqhrYQ2AuS2RjhLY+bAmuCqt9AY/Yov9tf0YWnyjtMs="
     }
   ],
   "legacyImports": false

--- a/.github/vendor/github.com/grafana/loki-release/workflows/runner.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/runner.libsonnet
@@ -1,7 +1,7 @@
 local defaultMapping = {
-  'linux/amd64': ['github-hosted-ubuntu-x64-small'],
-  'linux/arm64': ['github-hosted-ubuntu-arm64-small'],
-  'linux/arm': ['github-hosted-ubuntu-arm64-small'],  // equal to linux/arm/v7
+  'linux/amd64': ['ubuntu-x64'],
+  'linux/arm64': ['ubuntu-arm64'],
+  'linux/arm': ['ubuntu-arm64'],  // equal to linux/arm/v7
   'linux/riscv64': ['ubuntu-26.04-riscv'],  // https://github.com/apps/rise-risc-v-runners
 };
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@808a3789820ac46c7909a9a6d6f5abc4711b874f"
     "with":
       "build_image": "grafana/loki-build-image:0.35.1"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
+      "release_lib_ref": "808a3789820ac46c7909a9a6d6f5abc4711b874f"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@808a3789820ac46c7909a9a6d6f5abc4711b874f"
     "with":
       "build_image": "grafana/loki-build-image:0.35.1"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
+      "release_lib_ref": "808a3789820ac46c7909a9a6d6f5abc4711b874f"
       "skip_validation": false
       "use_github_app_token": true
   "loki-canary-boringcrypto-image":
@@ -12,7 +12,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
+      "RELEASE_LIB_REF": "808a3789820ac46c7909a9a6d6f5abc4711b874f"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -92,13 +92,13 @@
         "include":
         - "arch": "linux/amd64"
           "runs_on":
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - "arch": "linux/arm64"
           "runs_on":
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
         - "arch": "linux/arm"
           "runs_on":
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   "loki-canary-boringcrypto-manifest":
     "env":
       "BUILD_TIMEOUT": 60
@@ -136,7 +136,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
+      "RELEASE_LIB_REF": "808a3789820ac46c7909a9a6d6f5abc4711b874f"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -216,13 +216,13 @@
         "include":
         - "arch": "linux/amd64"
           "runs_on":
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - "arch": "linux/arm64"
           "runs_on":
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
         - "arch": "linux/arm"
           "runs_on":
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   "loki-canary-manifest":
     "env":
       "BUILD_TIMEOUT": 60
@@ -260,7 +260,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
+      "RELEASE_LIB_REF": "808a3789820ac46c7909a9a6d6f5abc4711b874f"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -340,13 +340,13 @@
         "include":
         - "arch": "linux/amd64"
           "runs_on":
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - "arch": "linux/arm64"
           "runs_on":
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
         - "arch": "linux/arm"
           "runs_on":
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   "loki-manifest":
     "env":
       "BUILD_TIMEOUT": 60
@@ -384,7 +384,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
+      "RELEASE_LIB_REF": "808a3789820ac46c7909a9a6d6f5abc4711b874f"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -464,13 +464,13 @@
         "include":
         - "arch": "linux/amd64"
           "runs_on":
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - "arch": "linux/arm64"
           "runs_on":
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
         - "arch": "linux/arm"
           "runs_on":
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   "querytee-manifest":
     "env":
       "BUILD_TIMEOUT": 60

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -8,7 +8,7 @@ env:
   DRY_RUN: false
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
+  RELEASE_LIB_REF: "808a3789820ac46c7909a9a6d6f5abc4711b874f"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
@@ -19,11 +19,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
+    uses: "grafana/loki-release/.github/workflows/check.yml@808a3789820ac46c7909a9a6d6f5abc4711b874f"
     with:
       build_image: "grafana/loki-build-image:0.35.1"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
+      release_lib_ref: "808a3789820ac46c7909a9a6d6f5abc4711b874f"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -289,7 +289,7 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
   fluentd:
     needs:
     - "version"
@@ -363,7 +363,7 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
   logcli:
     needs:
     - "version"
@@ -437,13 +437,13 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
         - arch: "linux/arm"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   logstash:
     needs:
     - "version"
@@ -517,7 +517,7 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
   loki:
     needs:
     - "version"
@@ -591,13 +591,13 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
         - arch: "linux/arm"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   loki-canary:
     needs:
     - "version"
@@ -671,13 +671,13 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
         - arch: "linux/arm"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   loki-canary-boringcrypto:
     needs:
     - "version"
@@ -751,13 +751,13 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
         - arch: "linux/arm"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   loki-docker-driver:
     needs:
     - "version"
@@ -848,10 +848,10 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   loki-helm-test:
     needs:
     - "version"
@@ -925,13 +925,13 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
         - arch: "linux/arm"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   querytee:
     needs:
     - "version"
@@ -1005,10 +1005,10 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   version:
     needs:
     - "check"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -8,7 +8,7 @@ env:
   DRY_RUN: false
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
+  RELEASE_LIB_REF: "808a3789820ac46c7909a9a6d6f5abc4711b874f"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
@@ -19,11 +19,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
+    uses: "grafana/loki-release/.github/workflows/check.yml@808a3789820ac46c7909a9a6d6f5abc4711b874f"
     with:
       build_image: "grafana/loki-build-image:0.35.1"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
+      release_lib_ref: "808a3789820ac46c7909a9a6d6f5abc4711b874f"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -289,7 +289,7 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
   fluentd:
     needs:
     - "version"
@@ -363,7 +363,7 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
   logcli:
     needs:
     - "version"
@@ -437,13 +437,13 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
         - arch: "linux/arm"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   logstash:
     needs:
     - "version"
@@ -517,7 +517,7 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
   loki:
     needs:
     - "version"
@@ -591,13 +591,13 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
         - arch: "linux/arm"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   loki-canary:
     needs:
     - "version"
@@ -671,13 +671,13 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
         - arch: "linux/arm"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   loki-canary-boringcrypto:
     needs:
     - "version"
@@ -751,13 +751,13 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
         - arch: "linux/arm"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   loki-docker-driver:
     needs:
     - "version"
@@ -848,10 +848,10 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   loki-helm-test:
     needs:
     - "version"
@@ -925,13 +925,13 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
         - arch: "linux/arm"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   querytee:
     needs:
     - "version"
@@ -1005,10 +1005,10 @@ jobs:
         include:
         - arch: "linux/amd64"
           runs_on:
-          - "github-hosted-ubuntu-x64-small"
+          - "ubuntu-x64"
         - arch: "linux/arm64"
           runs_on:
-          - "github-hosted-ubuntu-arm64-small"
+          - "ubuntu-arm64"
   version:
     needs:
     - "check"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "decfa8d4d77a2dbc10e71a0785591e1cbcea6b8b"
+  RELEASE_LIB_REF: "808a3789820ac46c7909a9a6d6f5abc4711b874f"
   RELEASE_REPO: "grafana/loki"
   USE_GITHUB_APP_TOKEN: true
 jobs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Vendors in https://github.com/grafana/loki-release/pull/303

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI execution environment changes across multiple GitHub Actions workflows, which can cause unexpected build/test failures if the new runner labels or capacities differ from the previous ones.
> 
> **Overview**
> Updates the vendored `grafana/loki-release` workflow library ref to `808a3789…` (including the Jsonnet lockfile), pulling in updated runner defaults.
> 
> Migrates GitHub Actions workflows (`check`, image builds, and release PR/release pipelines) from `github-hosted-ubuntu-*-small` runner labels to the new `ubuntu-x64`/`ubuntu-arm64` labels and updates all `RELEASE_LIB_REF`/`release_lib_ref` pins accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d1bc5238ee7f47a34926f9a2e4c9deb87f3b925. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->