### PR TITLE
feat(validation): Add reject_old_samples to policy overridable limits

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2516,6 +2516,105 @@ func TestRequestScopedStreamResolver(t *testing.T) {
 	require.Equal(t, "policy1", policy)
 }
 
+func TestDistributor_PushPolicyRejectOldSamplesOverride(t *testing.T) {
+	oldEntry := logproto.Entry{
+		Timestamp: time.Now().Add(-2 * time.Hour),
+		Line:      "old log line",
+	}
+
+	boolPtr := func(v bool) *bool {
+		return &v
+	}
+
+	tests := []struct {
+		name                   string
+		tenantRejectOldSamples bool
+		policy                 string
+		override               *bool
+		labels                 string
+		expectErr              bool
+	}{
+		{
+			name:                   "tenant setting applies when no policy override matches",
+			tenantRejectOldSamples: true,
+			policy:                 "finance",
+			labels:                 `{team="ops"}`,
+			expectErr:              true,
+		},
+		{
+			name:                   "matching policy override disables old sample rejection",
+			tenantRejectOldSamples: true,
+			policy:                 "finance",
+			override:               boolPtr(false),
+			labels:                 `{team="finance"}`,
+			expectErr:              false,
+		},
+		{
+			name:                   "matching policy override enables old sample rejection",
+			tenantRejectOldSamples: false,
+			policy:                 "finance",
+			override:               boolPtr(true),
+			labels:                 `{team="finance"}`,
+			expectErr:              true,
+		},
+		{
+			name:                   "matching policy nil override uses tenant setting",
+			tenantRejectOldSamples: true,
+			policy:                 "finance",
+			override:               nil,
+			labels:                 `{team="finance"}`,
+			expectErr:              true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vLimits := &validation.Limits{}
+			flagext.DefaultValues(vLimits)
+			vLimits.RejectOldSamples = tc.tenantRejectOldSamples
+			vLimits.RejectOldSamplesMaxAge = model.Duration(1 * time.Hour)
+			vLimits.CreationGracePeriod = model.Duration(1 * time.Hour)
+			vLimits.PolicyStreamMapping = validation.PolicyStreamMapping{
+				tc.policy: []*validation.PriorityStream{
+					{
+						Selector: `{team="finance"}`,
+						Priority: 1,
+					},
+				},
+			}
+			vLimits.PolicyOverrideLimits = map[string]validation.PolicyOverridableLimits{
+				tc.policy: {
+					RejectOldSamples: tc.override,
+				},
+			}
+			require.NoError(t, vLimits.Validate())
+
+			distributors, ingesters := prepare(t, 1, 3, vLimits, nil)
+			req := &logproto.PushRequest{
+				Streams: []logproto.Stream{
+					{
+						Labels:  tc.labels,
+						Entries: []logproto.Entry{oldEntry},
+					},
+				},
+			}
+
+			resp, err := distributors[0].Push(ctx, req)
+			if tc.expectErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "timestamp too old")
+				require.Nil(t, ingesters[0].Peek())
+				require.Nil(t, ingesters[1].Peek())
+				require.Nil(t, ingesters[2].Peek())
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, success, resp)
+		})
+	}
+}
+
 func TestDistributor_PushIngestLimits(t *testing.T) {
 	tests := []struct {
 		name                      string

--- a/pkg/distributor/limits.go
+++ b/pkg/distributor/limits.go
@@ -21,6 +21,7 @@ type Limits interface {
 
 	CreationGracePeriod(userID string) time.Duration
 	RejectOldSamples(userID string) bool
+	PolicyRejectOldSamples(userID string, policy string) bool
 	RejectOldSamplesMaxAge(userID string) time.Duration
 
 	IncrementDuplicateTimestamps(userID string) bool

--- a/pkg/distributor/validator.go
+++ b/pkg/distributor/validator.go
@@ -33,7 +33,6 @@ func NewValidator(l Limits, t push.UsageTracker) (*Validator, error) {
 }
 
 type validationContext struct {
-	rejectOldSample       bool
 	rejectOldSampleMaxAge int64
 	creationGracePeriod   int64
 
@@ -66,7 +65,6 @@ type validationContext struct {
 func (v Validator) getValidationContextForTime(now time.Time, userID string) validationContext {
 	return validationContext{
 		userID:                        userID,
-		rejectOldSample:               v.RejectOldSamples(userID),
 		rejectOldSampleMaxAge:         now.Add(-v.RejectOldSamplesMaxAge(userID)).UnixNano(),
 		creationGracePeriod:           now.Add(v.CreationGracePeriod(userID)).UnixNano(),
 		maxLineSize:                   v.MaxLineSize(userID),
@@ -98,7 +96,7 @@ func (v Validator) ValidateEntry(ctx context.Context, vCtx validationContext, la
 	structuredMetadataSizeBytes := util.StructuredMetadataSize(entry.StructuredMetadata)
 	entrySize := float64(len(entry.Line) + structuredMetadataSizeBytes)
 
-	if vCtx.rejectOldSample && ts < vCtx.rejectOldSampleMaxAge {
+	if v.PolicyRejectOldSamples(vCtx.userID, policy) && ts < vCtx.rejectOldSampleMaxAge {
 		// Makes time string on the error message formatted consistently.
 		formatedEntryTime := entry.Timestamp.Format(timeFormat)
 		formatedRejectMaxAgeTime := time.Unix(0, vCtx.rejectOldSampleMaxAge).Format(timeFormat)

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -799,6 +799,22 @@ func (o *Overrides) RejectOldSamples(userID string) bool {
 	return o.getOverridesForUser(userID).RejectOldSamples
 }
 
+// PolicyRejectOldSamples returns the old-sample rejection setting for a specific
+// policy. If no policy-specific override is configured, it falls back to the
+// tenant-level setting.
+func (o *Overrides) PolicyRejectOldSamples(userID, policy string) bool {
+	limits := o.getOverridesForUser(userID)
+	if policy == "" || len(limits.PolicyOverrideLimits) == 0 {
+		return limits.RejectOldSamples
+	}
+
+	if policyLimits, exists := limits.PolicyOverrideLimits[policy]; exists && policyLimits.RejectOldSamples != nil {
+		return *policyLimits.RejectOldSamples
+	}
+
+	return limits.RejectOldSamples
+}
+
 // RejectOldSamplesMaxAge returns the age at which samples should be rejected.
 func (o *Overrides) RejectOldSamplesMaxAge(userID string) time.Duration {
 	return time.Duration(o.getOverridesForUser(userID).RejectOldSamplesMaxAge)
@@ -1474,8 +1490,9 @@ type OverwriteMarshalingStringMap struct {
 
 // PolicyOverridableLimits contains limits that can be overridden on a per-policy basis.
 type PolicyOverridableLimits struct {
-	MaxLocalStreamsPerUser  int `yaml:"max_streams_per_user" json:"max_streams_per_user" doc:"max_streams_per_user for a specific policy. 0 means unlimited."`
-	MaxGlobalStreamsPerUser int `yaml:"max_global_streams_per_user" json:"max_global_streams_per_user" doc:"max_global_streams_per_user for a specific policy. 0 means unlimited."`
+	MaxLocalStreamsPerUser  int   `yaml:"max_streams_per_user" json:"max_streams_per_user" doc:"max_streams_per_user for a specific policy. 0 means unlimited."`
+	MaxGlobalStreamsPerUser int   `yaml:"max_global_streams_per_user" json:"max_global_streams_per_user" doc:"max_global_streams_per_user for a specific policy. 0 means unlimited."`
+	RejectOldSamples        *bool `yaml:"reject_old_samples,omitempty" json:"reject_old_samples,omitempty" doc:"reject_old_samples for a specific policy. When unset, the tenant-level setting is used."`
 }
 
 func NewOverwriteMarshalingStringMap(m map[string]string) OverwriteMarshalingStringMap {

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -614,15 +615,26 @@ pattern_rate_threshold: 0.0
 }
 
 func TestLimits_PolicyOverrideLimits(t *testing.T) {
+	boolPtr := func(v bool) *bool {
+		return &v
+	}
+
 	limits := &Limits{
+		RejectOldSamples: true,
 		PolicyOverrideLimits: map[string]PolicyOverridableLimits{
 			"finance": {
 				MaxLocalStreamsPerUser:  100,
 				MaxGlobalStreamsPerUser: 1000,
+				RejectOldSamples:        boolPtr(false),
 			},
 			"ops": {
 				MaxLocalStreamsPerUser:  50,
 				MaxGlobalStreamsPerUser: 500,
+				RejectOldSamples:        boolPtr(true),
+			},
+			"inherited": {
+				MaxLocalStreamsPerUser:  25,
+				MaxGlobalStreamsPerUser: 250,
 			},
 		},
 	}
@@ -637,22 +649,27 @@ func TestLimits_PolicyOverrideLimits(t *testing.T) {
 	limit, ok := overrides.PolicyMaxGlobalStreamsPerUser("tenant1", "finance")
 	require.True(t, ok)
 	require.Equal(t, 1000, limit)
+	require.False(t, overrides.PolicyRejectOldSamples("tenant1", "finance"))
 	require.Equal(t, 50, overrides.PolicyMaxLocalStreamsPerUser("tenant1", "ops"))
 	limit, ok = overrides.PolicyMaxGlobalStreamsPerUser("tenant1", "ops")
 	require.True(t, ok)
 	require.Equal(t, 500, limit)
+	require.True(t, overrides.PolicyRejectOldSamples("tenant1", "ops"))
+	require.True(t, overrides.PolicyRejectOldSamples("tenant1", "inherited"))
 
 	// Test non-existent policy returns 0, false
 	require.Equal(t, 0, overrides.PolicyMaxLocalStreamsPerUser("tenant1", "nonexistent"))
 	limit, ok = overrides.PolicyMaxGlobalStreamsPerUser("tenant1", "nonexistent")
 	require.False(t, ok)
 	require.Equal(t, 0, limit)
+	require.True(t, overrides.PolicyRejectOldSamples("tenant1", "nonexistent"))
 
 	// Test empty policy returns 0, false
 	require.Equal(t, 0, overrides.PolicyMaxLocalStreamsPerUser("tenant1", ""))
 	limit, ok = overrides.PolicyMaxGlobalStreamsPerUser("tenant1", "")
 	require.False(t, ok)
 	require.Equal(t, 0, limit)
+	require.True(t, overrides.PolicyRejectOldSamples("tenant1", ""))
 
 	// Test nil PolicyOverrideLimits returns 0, false
 	limits.PolicyOverrideLimits = nil
@@ -660,6 +677,57 @@ func TestLimits_PolicyOverrideLimits(t *testing.T) {
 	limit, ok = overrides.PolicyMaxGlobalStreamsPerUser("tenant1", "finance")
 	require.False(t, ok)
 	require.Equal(t, 0, limit)
+	require.True(t, overrides.PolicyRejectOldSamples("tenant1", "finance"))
+}
+
+func TestLimits_PolicyOverrideLimitsRejectOldSamplesRoundTrip(t *testing.T) {
+	inputYAML := `
+policy_override_limits:
+  finance:
+    max_streams_per_user: 100
+    max_global_streams_per_user: 1000
+    reject_old_samples: false
+  ops:
+    max_streams_per_user: 50
+    max_global_streams_per_user: 500
+    reject_old_samples: true
+`
+
+	var limits Limits
+	require.NoError(t, yaml.Unmarshal([]byte(inputYAML), &limits))
+	require.NotNil(t, limits.PolicyOverrideLimits["finance"].RejectOldSamples)
+	require.False(t, *limits.PolicyOverrideLimits["finance"].RejectOldSamples)
+	require.NotNil(t, limits.PolicyOverrideLimits["ops"].RejectOldSamples)
+	require.True(t, *limits.PolicyOverrideLimits["ops"].RejectOldSamples)
+
+	out, err := yaml.Marshal(limits)
+	require.NoError(t, err)
+	output := string(out)
+	require.Contains(t, output, "reject_old_samples: false")
+	require.Contains(t, output, "reject_old_samples: true")
+}
+
+func TestLimits_PolicyOverrideLimitsBackwardCompatibleMarshalUnmarshal(t *testing.T) {
+	inputYAML := `
+policy_override_limits:
+  finance:
+    max_streams_per_user: 100
+    max_global_streams_per_user: 1000
+  ops:
+    max_streams_per_user: 50
+    max_global_streams_per_user: 500
+`
+
+	var limits Limits
+	require.NoError(t, yaml.Unmarshal([]byte(inputYAML), &limits))
+	require.Nil(t, limits.PolicyOverrideLimits["finance"].RejectOldSamples)
+	require.Nil(t, limits.PolicyOverrideLimits["ops"].RejectOldSamples)
+
+	out, err := yaml.Marshal(limits)
+	require.NoError(t, err)
+	output := string(out)
+	require.NotContains(t, output, "\n    reject_old_samples:")
+	require.True(t, strings.Contains(output, "policy_override_limits:"))
 }
 
 func TestOTLPConfig(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `reject_old_samples` to `PolicyOverridableLimits` so old-sample rejection can be controlled per policy instead of only at the tenant level.

The distributor validator now checks the effective policy-level setting when validating entries. This allows tenants using stream-to-policy mapping to disable or enable old-sample rejection for specific policies while preserving the existing tenant-level fallback when no policy override is configured.

The change also includes validation and distributor tests covering:
- policy override behavior vs tenant fallback
- YAML marshal/unmarshal round trips for the new field
- backward compatibility when older configs omit `reject_old_samples`

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

This is a narrowly scoped limits/validation change. The main behavior change is that a matched policy can now override tenant-level `reject_old_samples`; unmatched policies and unset overrides still use the tenant default.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/
commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ingestion validation behavior by letting policy-specific overrides enable/disable old-sample rejection, which could alter which log entries are accepted for tenants using policy mapping.
> 
> **Overview**
> Adds `reject_old_samples` as an optional field to `PolicyOverridableLimits`, allowing per-policy overrides with a tenant-level fallback when unset.
> 
> Updates the distributor validator to use the effective policy value via `PolicyRejectOldSamples(...)` when enforcing “timestamp too old” rejection, and adds unit/integration tests covering override precedence plus YAML marshal/unmarshal round-trips and backward-compatible configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02b82c696f13b67b09e0f1d50d8b8f3fc6b10dc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->