### PR TITLE
loghttp: reject out-of-range float timestamps in query params

### DIFF
--- a/pkg/loghttp/params.go
+++ b/pkg/loghttp/params.go
@@ -179,6 +179,21 @@ func parseTimestamp(value string, def time.Time) (time.Time, error) {
 
 	if strings.Contains(value, ".") {
 		if t, err := strconv.ParseFloat(value, 64); err == nil {
+			// The float branch exists to accept Prometheus-style
+			// "seconds.fraction" timestamps such as "1234567890.123".
+			// Scientific notation like "1.767610546875e+18" (a
+			// nanosecond-precision int accidentally stringified as a
+			// float) also lands here, and would be interpreted as
+			// 1.76e18 seconds -- far past year 2286 -- which causes
+			// downstream range expansion and can exhaust memory
+			// building the query plan. Reject values that are not
+			// representable as a time.Time in a sensible range.
+			// time.Time internally clamps to roughly year 2262 for
+			// nanosecond precision; 1e10 seconds is year 2286, which
+			// is well beyond any realistic Loki query horizon.
+			if math.IsNaN(t) || math.IsInf(t, 0) || t < 0 || t > 1e10 {
+				return time.Time{}, fmt.Errorf("timestamp %q is out of range", value)
+			}
 			s, ns := math.Modf(t)
 			ns = math.Round(ns*1000) / 1000
 			return time.Unix(int64(s), int64(ns*float64(time.Second))), nil

--- a/pkg/loghttp/params.go
+++ b/pkg/loghttp/params.go
@@ -186,12 +186,16 @@ func parseTimestamp(value string, def time.Time) (time.Time, error) {
 			// float) also lands here, and would be interpreted as
 			// 1.76e18 seconds -- far past year 2286 -- which causes
 			// downstream range expansion and can exhaust memory
-			// building the query plan. Reject values that are not
-			// representable as a time.Time in a sensible range.
-			// time.Time internally clamps to roughly year 2262 for
-			// nanosecond precision; 1e10 seconds is year 2286, which
-			// is well beyond any realistic Loki query horizon.
-			if math.IsNaN(t) || math.IsInf(t, 0) || t < 0 || t > 1e10 {
+			// building the query plan. Reject values outside a
+			// realistic Unix-seconds range. time.Time internally
+			// clamps to roughly year 2262 for nanosecond precision;
+			// 1e10 seconds is year 2286, which is well beyond any
+			// realistic Loki query horizon.
+			// NaN and +-Inf can't reach this branch: their string
+			// forms ("NaN", "+Inf", "-Inf") don't contain ".", and
+			// ParseFloat's overflow case returns a non-nil ErrRange,
+			// so err == nil here implies a finite value.
+			if t < 0 || t > 1e10 {
 				return time.Time{}, fmt.Errorf("timestamp %q is out of range", value)
 			}
 			s, ns := math.Modf(t)

--- a/pkg/loghttp/params_test.go
+++ b/pkg/loghttp/params_test.go
@@ -365,6 +365,12 @@ func Test_parseTimestamp(t *testing.T) {
 		{"RFC3339 format", "2002-10-02T15:00:00Z", now, time.Date(2002, 10, 02, 15, 0, 0, 0, time.UTC), false},
 		{"RFC3339nano format", "2009-11-10T23:00:00.000000001Z", now, time.Date(2009, 11, 10, 23, 0, 0, 1, time.UTC), false},
 		{"invalid", "we", now, time.Time{}, true},
+		// Scientific notation that parses as a float but lands far past
+		// year 2286 used to propagate and drive the query planner into
+		// OOM; reject it as out of range (#20293).
+		{"scientific notation out of range", "1.767610546875e+18", now, time.Time{}, true},
+		{"negative float", "-1.5", now, time.Time{}, true},
+		{"NaN", "NaN", now, time.Time{}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a DoS vector in the query parameter parser. `parseTimestamp`'s float branch accepted inputs like `end=1.767610546875e+18` (a nanosecond-precision integer stringified as a float) without bounds-checking the result. `math.Modf(1.767e18)` returned `(1.767e18, 0)`, and `time.Unix(1.767e18, 0)` produced a timestamp ~56 billion years in the future. The downstream range expansion then happily built a query plan over that horizon, which on a realistic corpus could drive the ingester/querier into OOM on a single crafted request.

The legitimate Prometheus-style float timestamp case (`1571332130.934`) is unaffected, values must be NaN, infinite, negative, or larger than `1e10` seconds (≈year 2286) to be rejected. Anything past year 2286 has no realistic use case for Loki range queries.

**Which issue(s) this PR fixes**:

Fixes #20293

**Special notes for your reviewer**:

- The 1e10 bound is conservative: `time.Time`'s nanosecond-precision range extends to roughly year 2262, so a 2286-ceiling still accepts every realistically useful timestamp.
- The fix preserves the existing int / RFC3339 / nanosecond-int paths untouched, so only the float branch sees new behaviour.

**Checklist**

- [x] `go test ./pkg/loghttp/... -count=1` passes.
- [x] Added table-driven cases for scientific notation out of range, negative float, and NaN.
- [x] `gofmt` clean.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted validation change in HTTP query parsing with added tests; risk is limited to rejecting previously-accepted malformed float timestamps.
> 
> **Overview**
> Prevents pathological future timestamps from being accepted via query params by adding a bounds check to `parseTimestamp`’s float parsing path (rejecting negative or >`1e10`-seconds values, including scientific-notation inputs).
> 
> Extends `Test_parseTimestamp` to cover previously-accepted DoS-style inputs (scientific notation far in the future, negative floats, and `NaN`) and assert they now error (#20293).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3a26106ce5aa75472acf982222e722764abed8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->