### PR TITLE
fix(jsonnet): Grant rollout-operator the required ZoneAwarePDB RBAC

### DIFF
--- a/production/ksonnet/loki/rollout-operator.libsonnet
+++ b/production/ksonnet/loki/rollout-operator.libsonnet
@@ -51,6 +51,17 @@
       policyRule.withApiGroups('apps') +
       policyRule.withResources(['statefulsets/status']) +
       policyRule.withVerbs(['update']),
+      // rollout-operator v0.29+ watches the ZoneAwarePodDisruptionBudget
+      // custom resource it ships with. Without these permissions the
+      // controller fails to list the CR and never reaches Ready
+      // (grafana/loki#20281). Mirrors the RBAC in the upstream
+      // rollout-operator jsonnet.
+      policyRule.withApiGroups('rollout-operator.grafana.com') +
+      policyRule.withResources(['zoneawarepoddisruptionbudgets']) +
+      policyRule.withVerbs(['list', 'get', 'watch']),
+      policyRule.withApiGroups('rollout-operator.grafana.com') +
+      policyRule.withResources(['zoneawarepoddisruptionbudgets/status']) +
+      policyRule.withVerbs(['update', 'patch']),
     ]),
 
   rollout_operator_rolebinding: if !rollout_operator_enabled then null else


### PR DESCRIPTION
**What this PR does / why we need it**:

Loki's jsonnet manifests ship a custom `rollout-operator.libsonnet` that lags the upstream one at https://github.com/grafana/rollout-operator/blob/main/operations/rollout-operator/rollout-operator.libsonnet. Rollout-operator v0.29 added a ZoneAwarePodDisruptionBudget custom resource. Upgrading to v0.29+ on a Loki deployment that uses these jsonnet manifests leaves the operator pod stuck NotReady with:

```
Failed to watch rollout-operator.grafana.com/v1 Resource=zoneawarepoddisruptionbudgets:
zoneawarepoddisruptionbudgets.rollout-operator.grafana.com is forbidden:
User "system:serviceaccount:loki:rollout-operator" cannot list resource
"zoneawarepoddisruptionbudgets" in API group "rollout-operator.grafana.com"
```

Add the two missing rules (list/get/watch on the CR and update/patch on its status), mirroring the upstream `rollout-operator.libsonnet`. No behaviour change for operators who haven't upgraded past v0.28.1; required for anyone on v0.29+.

**Which issue(s) this PR fixes**:

Fixes #20281

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only expands Kubernetes RBAC for `rollout-operator` to include a new CRD and its status subresource; the main risk is overly broad permissions if the API group/resource name is wrong.
> 
> **Overview**
> Updates the Loki `rollout-operator` Jsonnet RBAC to support rollout-operator v0.29+ by granting permissions on the `rollout-operator.grafana.com` `zoneawarepoddisruptionbudgets` custom resource.
> 
> Adds rules to allow `list/get/watch` on the CR and `update/patch` on `zoneawarepoddisruptionbudgets/status`, preventing the operator from getting stuck NotReady when it tries to watch this resource.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8117fbecf8946b7c30023df1379a1d1637f263a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->