### PR TITLE
fix(storage): attach SHA-256 checksum on PutObject for Object Lock buckets

### DIFF
--- a/pkg/storage/chunk/client/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client.go
@@ -532,6 +532,15 @@ func (a *S3ObjectClient) PutObject(ctx context.Context, objectKey string, object
 			Bucket:       aws.String(a.bucketFromKey(objectKey)),
 			Key:          aws.String(a.convertObjectKey(objectKey, true)),
 			StorageClass: types.StorageClass(a.cfg.StorageClass),
+			// Buckets with Object Lock enabled reject PutObject requests
+			// that lack either Content-MD5 or one of the x-amz-checksum-*
+			// headers with `InvalidRequest: Content-MD5 OR x-amz-checksum-
+			// HTTP header is required for Put Object requests with Object
+			// Lock parameters`. Ask the SDK to compute and attach a
+			// SHA-256 trailer so compliance buckets accept uploads
+			// without forcing operators to buffer every chunk for MD5
+			// (grafana/loki#20088).
+			ChecksumAlgorithm: types.ChecksumAlgorithmSha256,
 		}
 
 		if a.sseConfig != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes Loki refusing to write any S3 bucket that has Object Lock enabled (commonly required for compliance / audit retention).

S3 buckets with Object Lock reject `PutObject` requests that lack either a `Content-MD5` header or one of the `x-amz-checksum-*` headers:

```
api error InvalidRequest: Content-MD5 OR x-amz-checksum- HTTP header is
required for Put Object requests with Object Lock parameters
```

Between Loki 3.5.7 and 3.6.x the aws-sdk-go-v2 upgrade changed the default behaviour: uploads no longer carry a checksum unless the caller asks, so writing any compliance-configured bucket now fails. Setting `PutObjectInput.ChecksumAlgorithm = SHA256` instructs the SDK to compute the hash incrementally and stream it as an `aws-chunked` trailer (`x-amz-trailer: x-amz-checksum-sha256`) — no body buffering required.

Non-Object-Lock buckets accept the extra header as well, so the change is safe for every target.

**Which issue(s) this PR fixes**:

Fixes #20088

**Test**:

- `go build ./pkg/storage/chunk/client/aws/...` green.
- `go test ./pkg/storage/chunk/client/aws/... -count=1` passes (24s full suite).
- `gofmt` clean.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the S3 write path by adding a checksum trailer to every `PutObject`, which could affect compatibility with some S3-compatible endpoints or add minor overhead, but is a narrowly scoped change.
> 
> **Overview**
> Fixes uploads failing to S3 buckets with **Object Lock enabled** by always setting `PutObjectInput.ChecksumAlgorithm` to `SHA256`, prompting the AWS SDK to compute and send a checksum (as a streamed trailer) without buffering the full object.
> 
> This makes Loki’s S3 `PutObject` requests satisfy S3’s requirement for `Content-MD5` or `x-amz-checksum-*` headers, while remaining compatible for non-Object-Lock buckets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cb44fbece9b9a9fd8a6e9c4589c880fe102783a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->