### PR TITLE
helm: allow overriding DNS ports in egress NetworkPolicy

### DIFF
--- a/production/helm/loki/templates/networkpolicy.yaml
+++ b/production/helm/loki/templates/networkpolicy.yaml
@@ -35,10 +35,14 @@ spec:
       {{- include "loki.selectorLabels" . | nindent 6 }}
   egress:
     - ports:
+        {{- with .Values.networkPolicy.egressDNS.ports }}
+        {{- toYaml . | nindent 8 }}
+        {{- else }}
         - port: 53
           protocol: UDP
         - port: 53
           protocol: TCP
+        {{- end }}
       to:
         - namespaceSelector: {}
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -936,6 +936,15 @@ networkPolicy:
     podSelector: {}
     # -- Specifies the namespace the discovery Pods are running in
     namespaceSelector: {}
+  egressDNS:
+    # -- Override the DNS egress ports opened by the network policy.
+    # Default ([]) keeps the in-chart defaults of 53/UDP and 53/TCP.
+    # On OpenShift the cluster DNS (dns-default) is backed by pods that
+    # listen on 5353, so set this to `- port: 5353; protocol: UDP` and
+    # `- port: 5353; protocol: TCP` (or include both 53 and 5353) to
+    # allow DNS resolution when network policies are enabled
+    # (grafana/loki#20009).
+    ports: []
   egressWorld:
     # -- Enable additional cilium egress rules to external world for write, read and backend.
     enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:

The DNS egress NetworkPolicy rendered by the Loki helm chart hard-codes `53/UDP` and `53/TCP`. On OpenShift the cluster DNS (service `dns-default` in `openshift-dns`) is backed by pods that listen on `5353`, not `53`. Once `networkPolicy.enabled: true`, DNS resolution fails for every Loki component on OpenShift. Earlier chart versions used named ports and inherited whatever the backing service exposed; the switch to numeric `53` in 6.46.0 removed that flexibility.

Add `networkPolicy.egressDNS.ports` so operators can supply custom port/protocol pairs (e.g. `5353/UDP` + `5353/TCP` on OpenShift, or both `53` and `5353` during a migration). Empty list keeps the existing defaults, so there is no behaviour change for anyone who doesn't set the value.

**Which issue(s) this PR fixes**:

Fixes #20009

**Special notes for your reviewer**:

Example values for OpenShift:

```yaml
networkPolicy:
  enabled: true
  egressDNS:
    ports:
      - port: 5353
        protocol: UDP
      - port: 5353
        protocol: TCP
```

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional Helm values override for NetworkPolicy DNS egress ports, preserving the existing 53/TCP+UDP defaults when unset; misconfiguration could still break DNS egress for Loki pods.
> 
> **Overview**
> Adds a new Helm value `networkPolicy.egressDNS.ports` to override which DNS port/protocol pairs are allowed by the chart’s `*-egress-dns` Kubernetes `NetworkPolicy`.
> 
> When `egressDNS.ports` is empty, the policy continues to open the existing defaults (`53/UDP` and `53/TCP`); when set, the template renders the provided ports instead (enabling OpenShift-style DNS on `5353`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a22e5c5b7649baccdb4bcf03913bc70228b3b2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->