### PR TITLE
fix(docker): Use NGINX `combined` log format in loki-gateway template

### DIFF
--- a/production/docker/config/nginx.conf
+++ b/production/docker/config/nginx.conf
@@ -8,8 +8,13 @@ events {
 
 http {
   default_type application/octet-stream;
-  log_format   main '$remote_addr - $remote_user [$time_local]  $status '
-    '"$request" $body_bytes_sent "$http_referer" '
+  # Match nginx's standard "combined" format (RFC-style Common Log
+  # Format + referer + user-agent + forwarded-for) so downstream log
+  # shippers parse loki-gateway access logs with their default regex.
+  # The previous template had two spaces between [$time_local] and
+  # $status and reversed the $request / $status order (#18788).
+  log_format   main '$remote_addr - $remote_user [$time_local] "$request" '
+    '$status $body_bytes_sent "$http_referer" '
     '"$http_user_agent" "$http_x_forwarded_for"';
   access_log   /dev/stderr  main;
   sendfile     on;


### PR DESCRIPTION
**What this PR does / why we need it**:

The loki-gateway nginx template emitted a non-standard access-log line: two spaces between `[$time_local]` and `$status`, and `$status` before `$request`. Downstream shippers (Alloy, Fluentd, Promtail) using the default nginx combined-format regex had to be reconfigured with a custom parser before they could extract status / path.

Reorder the fields to match nginx's stock combined format, `$remote_addr ... [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"`, so default parsers work out of the box.

**Which issue(s) this PR fixes**:

Fixes #18788

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the `log_format` template used for access logging; behavior and routing are unaffected aside from log line structure.
> 
> **Overview**
> Updates the loki-gateway `nginx.conf` access log `log_format main` to match nginx’s standard *combined* format by reordering fields (placing `"$request"` before `$status`) and removing the extra spacing.
> 
> Adds inline comments explaining the rationale so default regex parsers in downstream log shippers can parse these access logs without custom configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6dae729bc8aec6463eee02529a508dd965d2173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->