### PR TITLE
fix: correct Makefile issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,19 +122,19 @@ endef
 help: ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-45s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-.PHONY: all images check-generated-files logcli loki loki-debug loki-canary loki-canary-boringcrypto lint test clean yacc protos touch-protobuf-sources
+.PHONY: all images check-generated-files logcli loki loki-debug loki-canary loki-canary-boringcrypto lint test clean yacc protos
 .PHONY: format check-format
 .PHONY: docker-driver docker-driver-clean docker-driver-enable docker-driver-push
-.PHONY: fluent-bit-image, fluent-bit-test
-.PHONY: fluentd-image, fluentd-test
+.PHONY: fluent-bit-image fluent-bit-test
+.PHONY: fluentd-image fluentd-test
 .PHONY: loki-image build-image build-image-push
-.PHONY: bigtable-backup, push-bigtable-backup
-.PHONY: benchmark-store, check-mod
+.PHONY: bigtable-backup push-bigtable-backup
+.PHONY: benchmark-store check-mod
 .PHONY: migrate migrate-image lint-markdown ragel
 .PHONY: doc check-doc
 .PHONY: validate-example-configs generate-example-config-doc check-example-config-doc
 .PHONY: clean clean-protos
-.PHONY: k3d-loki k3d-enterprise-logs k3d-down
+.PHONY: dev-k3d-loki dev-k3d-enterprise-logs dev-k3d-down
 .PHONY: helm-test helm-lint
 
 #############
@@ -152,11 +152,11 @@ PROTO_DEFS := $(shell find . $(DONT_FIND) -type f -name '*.proto' -print)
 PROTO_GOS := $(patsubst %.proto,%.pb.go,$(PROTO_DEFS))
 
 # Yacc Files
-YACC_DEFS := $(shell find . $(DONT_FIND) -type f -name *.y -print)
+YACC_DEFS := $(shell find . $(DONT_FIND) -type f -name '*.y' -print)
 YACC_GOS := $(patsubst %.y,%.y.go,$(YACC_DEFS))
 
 # Ragel Files
-RAGEL_DEFS := $(shell find . $(DONT_FIND) -type f -name *.rl -print)
+RAGEL_DEFS := $(shell find . $(DONT_FIND) -type f -name '*.rl' -print)
 RAGEL_GOS := $(patsubst %.rl,%.rl.go,$(RAGEL_DEFS))
 
 # Documentation source path
@@ -593,7 +593,7 @@ loki-canary-boringcrypto-image:
 
 # Helm test image
 helm-test-image: ## build the helm test docker image
-	$(OCI_BUIILD) -t $(IMAGE_PREFIX)/loki-helm-test:$(IMAGE_TAG) -f production/helm/loki/src/helm-test/Dockerfile .
+	$(OCI_BUILD) -t $(IMAGE_PREFIX)/loki-helm-test:$(IMAGE_TAG) -f production/helm/loki/src/helm-test/Dockerfile .
 helm-test-push: helm-test-image
 	$(OCI_PUSH) $(IMAGE_PREFIX)/loki-helm-test:$(IMAGE_TAG)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
My `make` auto-complete was failing because of some PHONY issues.

Also fixed a few other errors:
- Remove trailing commas from `.PHONY` entries (fluent-bit, fluentd, bigtable-backup, benchmark-store)
- Fix typo `$(OCI_BUIILD)` -> `$(OCI_BUILD)` in `helm-test-image` target
- Correct `.PHONY: k3d-*` names to match actual `dev-k3d-*` target names
- Remove orphaned `touch-protobuf-sources` from `.PHONY`
- Quote globs in `find` calls for `*.y` and `*.rl` files


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Makefile-only changes that adjust target metadata and fix a typo; impact is limited to local/CI build and developer tooling behavior.
> 
> **Overview**
> Fixes Makefile hygiene issues that were breaking `make` autocomplete and some targets.
> 
> This removes invalid `.PHONY` entries/commas, renames `.PHONY` `k3d-*` declarations to match the actual `dev-k3d-*` targets, quotes `find` globs for `*.y`/`*.rl`, and fixes a typo in `helm-test-image` (`$(OCI_BUIILD)` -> `$(OCI_BUILD)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33516fec17c8bf7dc8a869518ef952deee4fe694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->