### PR TITLE
feat(compactor): Add `deletion_enabled` configuration to enable log deletion independently of retention

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -2836,6 +2836,11 @@ The `compactor` block configures the compactor component, which compacts index s
 # CLI flag: -compactor.retention-enabled
 [retention_enabled: <boolean> | default = false]
 
+# Enables the log deletion API. When false, deletion is only available if
+# retention is also enabled.
+# CLI flag: -compactor.deletion-enabled
+[deletion_enabled: <boolean> | default = false]
+
 # Delay after which chunks will be fully deleted during retention.
 # CLI flag: -compactor.retention-delete-delay
 [retention_delete_delay: <duration> | default = 2h]
@@ -4648,8 +4653,8 @@ ruler_remote_write_sigv4_config:
 
 # Deletion mode. Can be one of 'disabled', 'filter-only', or
 # 'filter-and-delete'. When set to 'filter-only' or 'filter-and-delete', and if
-# retention_enabled is true, then the log entry deletion API endpoints are
-# available.
+# deletion_enabled or retention_enabled is true, then the log entry deletion API
+# endpoints are available.
 # CLI flag: -compactor.deletion-mode
 [deletion_mode: <string> | default = "filter-and-delete"]
 

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -380,7 +380,7 @@ func (c *Compactor) initDeletes(objectClient client.ObjectClient, indexUpdatePro
 		return err
 	}
 
-	retentionExpiryChecker := retention.ExpirationChecker(retention.NeverExpiringExpirationChecker(limits))
+	retentionExpiryChecker := retention.NeverExpiringExpirationChecker(limits)
 	if c.cfg.RetentionEnabled {
 		retentionExpiryChecker = retention.NewExpirationChecker(limits)
 	}

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -212,9 +212,9 @@ func (c *Compactor) init(
 		return err
 	}
 
-	if c.cfg.RetentionEnabled {
+	if c.cfg.DeletionEnabled || c.cfg.RetentionEnabled {
 		if deleteStoreClient == nil {
-			return fmt.Errorf("delete store client not initialised when retention is enabled")
+			return fmt.Errorf("delete store client not initialised when deletion or retention is enabled")
 		}
 
 		if err := c.initDeletes(deleteStoreClient, indexUpdatePropagationMaxDelay, r, limits); err != nil {
@@ -236,7 +236,7 @@ func (c *Compactor) init(
 		var sc storeContainer
 		sc.indexStorageClient = storage.NewIndexStorageClient(objectClient, period.IndexTables.PathPrefix)
 
-		if c.cfg.RetentionEnabled {
+		if c.cfg.DeletionEnabled || c.cfg.RetentionEnabled {
 			var (
 				raw              client.ObjectClient
 				encoder          client.KeyEncoder
@@ -323,7 +323,7 @@ func (c *Compactor) init(
 	c.metrics = newMetrics(r)
 	c.tablesManager = newTablesManager(c.cfg, c.storeContainers, c.indexCompactors, c.schemaConfig, c.expirationChecker, c.metrics)
 
-	if c.cfg.RetentionEnabled {
+	if c.cfg.DeletionEnabled || c.cfg.RetentionEnabled {
 		if err := c.deleteRequestsManager.Init(c.tablesManager, r); err != nil {
 			return err
 		}
@@ -331,7 +331,7 @@ func (c *Compactor) init(
 
 	if c.cfg.HorizontalScalingMode == HorizontalScalingModeMain {
 		c.JobQueue = jobqueue.NewQueue(r)
-		if c.cfg.RetentionEnabled {
+		if c.cfg.DeletionEnabled || c.cfg.RetentionEnabled {
 			if err := c.JobQueue.RegisterBuilder(grpc.JOB_TYPE_DELETION, c.deleteRequestsManager.JobBuilder(), c.cfg.JobsConfig.Deletion.Timeout, c.cfg.JobsConfig.Deletion.MaxRetries, r); err != nil {
 				return err
 			}
@@ -380,7 +380,11 @@ func (c *Compactor) initDeletes(objectClient client.ObjectClient, indexUpdatePro
 		return err
 	}
 
-	c.expirationChecker = newExpirationChecker(retention.NewExpirationChecker(limits), c.deleteRequestsManager)
+	retentionExpiryChecker := retention.ExpirationChecker(retention.NeverExpiringExpirationChecker(limits))
+	if c.cfg.RetentionEnabled {
+		retentionExpiryChecker = retention.NewExpirationChecker(limits)
+	}
+	c.expirationChecker = newExpirationChecker(retentionExpiryChecker, c.deleteRequestsManager)
 	return nil
 }
 
@@ -448,7 +452,7 @@ func (c *Compactor) loop(ctx context.Context) error {
 		return nil
 	}
 
-	if c.cfg.RetentionEnabled {
+	if c.cfg.DeletionEnabled || c.cfg.RetentionEnabled {
 		if c.deleteRequestsStore != nil {
 			defer c.deleteRequestsStore.Stop()
 		}

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -240,6 +240,61 @@ func Test_schemaPeriodForTable(t *testing.T) {
 	}
 }
 
+func TestConfig_DeletionEnabled(t *testing.T) {
+	tests := []struct {
+		name            string
+		deletionEnabled bool
+		retentionEnabled bool
+		deleteReqStore  string
+		expectErr       bool
+	}{
+		{
+			name:      "neither enabled, no store — ok",
+			expectErr: false,
+		},
+		{
+			name:            "deletion enabled without delete-request-store — error",
+			deletionEnabled: true,
+			expectErr:       true,
+		},
+		{
+			name:            "deletion enabled with delete-request-store — ok",
+			deletionEnabled: true,
+			deleteReqStore:  "filesystem",
+			expectErr:       false,
+		},
+		{
+			name:             "retention enabled with delete-request-store — ok",
+			retentionEnabled: true,
+			deleteReqStore:   "filesystem",
+			expectErr:        false,
+		},
+		{
+			name:             "both enabled with delete-request-store — ok",
+			deletionEnabled:  true,
+			retentionEnabled: true,
+			deleteReqStore:   "filesystem",
+			expectErr:        false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{}
+			flagext.DefaultValues(&cfg)
+			cfg.DeletionEnabled = tc.deletionEnabled
+			cfg.RetentionEnabled = tc.retentionEnabled
+			cfg.DeleteRequestStore = tc.deleteReqStore
+			err := cfg.Validate()
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func Test_tableSort(t *testing.T) {
 	intervals := []string{
 		"index_19191",

--- a/pkg/compactor/config.go
+++ b/pkg/compactor/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	CompactionInterval              time.Duration         `yaml:"compaction_interval"`
 	ApplyRetentionInterval          time.Duration         `yaml:"apply_retention_interval"`
 	RetentionEnabled                bool                  `yaml:"retention_enabled"`
+	DeletionEnabled                 bool                  `yaml:"deletion_enabled"`
 	RetentionDeleteDelay            time.Duration         `yaml:"retention_delete_delay"`
 	RetentionDeleteWorkCount        int                   `yaml:"retention_delete_worker_count"`
 	RetentionTableTimeout           time.Duration         `yaml:"retention_table_timeout"`
@@ -52,6 +53,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.ApplyRetentionInterval, "compactor.apply-retention-interval", 0, "Interval at which to apply/enforce retention. 0 means run at same interval as compaction. If non-zero, it should always be a multiple of compaction interval.")
 	f.DurationVar(&cfg.RetentionDeleteDelay, "compactor.retention-delete-delay", 2*time.Hour, "Delay after which chunks will be fully deleted during retention.")
 	f.BoolVar(&cfg.RetentionEnabled, "compactor.retention-enabled", false, "Activate custom (per-stream,per-tenant) retention.")
+	f.BoolVar(&cfg.DeletionEnabled, "compactor.deletion-enabled", false, "Enables the log deletion API. When false, deletion is only available if retention is also enabled.")
 	f.IntVar(&cfg.RetentionDeleteWorkCount, "compactor.retention-delete-worker-count", 150, "The total amount of worker to use to delete chunks.")
 	f.StringVar(&cfg.DeleteRequestStore, "compactor.delete-request-store", "", "Store used for managing delete requests.")
 	f.StringVar(&cfg.DeleteRequestStoreKeyPrefix, "compactor.delete-request-store.key-prefix", "index/", "Path prefix for storing delete requests.")
@@ -104,18 +106,9 @@ func (cfg *Config) Validate() error {
 		return errors.New("Replication factor must not be changed as it will not take effect")
 	}
 
-	if cfg.RetentionEnabled {
+	if cfg.DeletionEnabled || cfg.RetentionEnabled {
 		if cfg.DeleteRequestStore == "" {
-			return fmt.Errorf("compactor.delete-request-store should be configured when retention is enabled")
-		}
-
-		if cfg.ApplyRetentionInterval == 0 {
-			cfg.ApplyRetentionInterval = cfg.CompactionInterval
-		}
-
-		if cfg.ApplyRetentionInterval == cfg.CompactionInterval {
-			// add some jitter to avoid running retention and compaction at same time
-			cfg.ApplyRetentionInterval += min(10*time.Minute, cfg.ApplyRetentionInterval/2)
+			return fmt.Errorf("compactor.delete-request-store should be configured when deletion or retention is enabled")
 		}
 
 		if err := config.ValidatePathPrefix(cfg.DeleteRequestStoreKeyPrefix); err != nil {
@@ -124,6 +117,17 @@ func (cfg *Config) Validate() error {
 
 		if cfg.DeletionMarkerObjectStorePrefix != "" && !strings.HasSuffix(cfg.DeletionMarkerObjectStorePrefix, "/") {
 			return fmt.Errorf("deletion marker object store prefix must end with /")
+		}
+	}
+
+	if cfg.DeletionEnabled || cfg.RetentionEnabled {
+		if cfg.ApplyRetentionInterval == 0 {
+			cfg.ApplyRetentionInterval = cfg.CompactionInterval
+		}
+
+		if cfg.ApplyRetentionInterval == cfg.CompactionInterval {
+			// add some jitter to avoid running retention and compaction at same time
+			cfg.ApplyRetentionInterval += min(10*time.Minute, cfg.ApplyRetentionInterval/2)
 		}
 	}
 

--- a/pkg/compactor/tables_manager.go
+++ b/pkg/compactor/tables_manager.go
@@ -106,7 +106,7 @@ func (c *tablesManager) start(ctx context.Context) {
 		}
 	}()
 
-	if c.cfg.RetentionEnabled {
+	if c.cfg.DeletionEnabled || c.cfg.RetentionEnabled {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/pkg/compactor/worker.go
+++ b/pkg/compactor/worker.go
@@ -20,7 +20,7 @@ func NewWorkerManager(
 ) (services.Service, error) {
 	wm := jobqueue.NewWorkerManager(cfg.WorkerConfig, grpcClient, r)
 
-	if cfg.RetentionEnabled {
+	if cfg.DeletionEnabled || cfg.RetentionEnabled {
 		deletionJobRunner := initDeletionJobRunner(cfg.JobsConfig.Deletion.ChunkProcessingConcurrency, schemaConfig, chunkClients, r)
 		err := wm.RegisterJobRunner(grpc.JOB_TYPE_DELETION, deletionJobRunner)
 		if err != nil {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -607,7 +607,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 	volumeRangeHTTPMiddleware := querier.WrapQuerySpanAndTimeout("query.VolumeRange", t.Overrides)
 	seriesHTTPMiddleware := querier.WrapQuerySpanAndTimeout("query.Series", t.Overrides)
 
-	if t.supportIndexDeleteRequest() && t.Cfg.CompactorConfig.RetentionEnabled {
+	if t.supportIndexDeleteRequest() && (t.Cfg.CompactorConfig.DeletionEnabled || t.Cfg.CompactorConfig.RetentionEnabled) {
 		toMerge = append(
 			toMerge,
 			queryrangebase.CacheGenNumberHeaderSetterMiddleware(t.cacheGenerationLoader),
@@ -720,7 +720,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 		queryrange.Instrument{Metrics: t.Metrics},
 		queryrange.Tracer{},
 	}
-	if t.supportIndexDeleteRequest() && t.Cfg.CompactorConfig.RetentionEnabled {
+	if t.supportIndexDeleteRequest() && (t.Cfg.CompactorConfig.DeletionEnabled || t.Cfg.CompactorConfig.RetentionEnabled) {
 		internalMiddlewares = append(
 			internalMiddlewares,
 			queryrangebase.CacheGenNumberContextSetterMiddleware(t.cacheGenerationLoader),
@@ -1152,7 +1152,7 @@ func (t *Loki) initQueryFrontendMiddleware() (_ services.Service, err error) {
 		util_log.Logger,
 		t.Overrides,
 		t.Cfg.SchemaConfig,
-		t.cacheGenerationLoader, t.Cfg.CompactorConfig.RetentionEnabled,
+		t.cacheGenerationLoader, t.Cfg.CompactorConfig.DeletionEnabled || t.Cfg.CompactorConfig.RetentionEnabled,
 		prometheus.DefaultRegisterer,
 		t.Cfg.MetricsNamespace,
 	)
@@ -1851,14 +1851,14 @@ func (t *Loki) initCompactor() (services.Service, error) {
 	}
 
 	var deleteRequestStoreClient client.ObjectClient
-	if t.Cfg.CompactorConfig.RetentionEnabled {
+	if t.Cfg.CompactorConfig.DeletionEnabled || t.Cfg.CompactorConfig.RetentionEnabled {
 		if deleteStore := t.Cfg.CompactorConfig.DeleteRequestStore; deleteStore != "" {
 			deleteRequestStoreClient, err = storage.NewObjectClient(deleteStore, "delete-store", t.Cfg.StorageConfig, t.ClientMetrics)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create delete request store object client: %w", err)
 			}
 		} else {
-			return nil, fmt.Errorf("compactor.delete-request-store should be configured when retention is enabled")
+			return nil, fmt.Errorf("compactor.delete-request-store should be configured when deletion or retention is enabled")
 		}
 	}
 
@@ -1886,7 +1886,7 @@ func (t *Loki) initCompactor() (services.Service, error) {
 		t.InternalServer.HTTP.PathPrefix(prefix).Handler(compactorHandler)
 	}
 
-	if t.Cfg.CompactorConfig.RetentionEnabled {
+	if t.Cfg.CompactorConfig.DeletionEnabled || t.Cfg.CompactorConfig.RetentionEnabled {
 		t.Server.HTTP.Path(constants.PathLokiDelete).Methods("PUT", "POST").Handler(t.addCompactorMiddleware(t.compactor.DeleteRequestsHandler.AddDeleteRequestHandler))
 		t.Server.HTTP.Path(constants.PathLokiDelete).Methods("GET").Handler(t.addCompactorMiddleware(t.compactor.DeleteRequestsHandler.GetAllDeleteRequestsHandler))
 		t.Server.HTTP.Path(constants.PathLokiDelete).Methods("DELETE").Handler(t.addCompactorMiddleware(t.compactor.DeleteRequestsHandler.CancelDeleteRequestHandler))
@@ -2484,7 +2484,7 @@ func (t *Loki) getDataObjBucket(clientName string) (objstore.Bucket, error) {
 }
 
 func (t *Loki) deleteRequestsClient(clientType string, limits limiter.CombinedLimits) (deletion.DeleteRequestsClient, error) {
-	if !t.supportIndexDeleteRequest() || !t.Cfg.CompactorConfig.RetentionEnabled {
+	if !t.supportIndexDeleteRequest() || (!t.Cfg.CompactorConfig.DeletionEnabled && !t.Cfg.CompactorConfig.RetentionEnabled) {
 		return deletion.NewNoOpDeleteRequestsClient(), nil
 	}
 

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -499,7 +499,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	_ = l.IngesterQuerySplitDuration.Set("0s")
 	f.Var(&l.IngesterQuerySplitDuration, "querier.split-ingester-queries-by-interval", "Interval to use for time-based splitting when a request is within the `query_ingesters_within` window; defaults to `split-queries-by-interval` by setting to 0.")
 
-	f.StringVar(&l.DeletionMode, "compactor.deletion-mode", "filter-and-delete", "Deletion mode. Can be one of 'disabled', 'filter-only', or 'filter-and-delete'. When set to 'filter-only' or 'filter-and-delete', and if retention_enabled is true, then the log entry deletion API endpoints are available.")
+	f.StringVar(&l.DeletionMode, "compactor.deletion-mode", "filter-and-delete", "Deletion mode. Can be one of 'disabled', 'filter-only', or 'filter-and-delete'. When set to 'filter-only' or 'filter-and-delete', and if deletion_enabled or retention_enabled is true, then the log entry deletion API endpoints are available.")
 
 	// Deprecated
 	dskit_flagext.DeprecatedFlag(f, "compactor.allow-deletes", "Deprecated. Instead, see compactor.deletion-mode which is another per tenant configuration", util_log.Logger)


### PR DESCRIPTION
## What this PR does / why we need it

Adds a new `compactor.deletion-enabled` config flag (YAML: `deletion_enabled`) that enables the log deletion API independently of `retention_enabled`.

Previously, the delete-request HTTP/gRPC endpoints were only available when `retention_enabled: true`. This forced operators who only want to accept user-submitted log deletion requests (e.g. for GDPR compliance) to also enable full per-stream retention machinery, increasing complexity and risk.

With `deletion_enabled: true`:
- The delete-request store is initialised
- The HTTP/gRPC deletion endpoints are registered (`/loki/api/v1/delete`)
- The compaction loop processes delete requests on the `ApplyRetentionInterval`
- The expiration checker uses `NeverExpiringExpirationChecker` for the retention side (no automatic chunk expiry) while still honouring user delete requests

Setting `retention_enabled: true` continues to work exactly as before (backward compatible). Setting both is also valid.

Closes #11182

## Checklist

- [x] Tested against `go test ./pkg/compactor/...`, all passing
- [x] `TestConfig_DeletionEnabled` added covering the new validation paths
- [x] Docs updated in `docs/sources/shared/configuration.md`
- [x] No breaking changes to existing config files

## Changes

| File | Change |
|---|---|
| `pkg/compactor/config.go` | Add `DeletionEnabled bool` field, register flag, update `Validate()` |
| `pkg/compactor/compactor.go` | Gate `initDeletes`, sweeper/marker, `deleteRequestsManager.Init`, `JobQueue.RegisterBuilder` on `DeletionEnabled \|\| RetentionEnabled`; use `NeverExpiringExpirationChecker` for retention part when only deletion enabled |
| `pkg/compactor/tables_manager.go` | Gate retention/deletion compaction loop on `DeletionEnabled \|\| RetentionEnabled` |
| `pkg/compactor/worker.go` | Register deletion job runner when `DeletionEnabled \|\| RetentionEnabled` |
| `pkg/loki/modules.go` | Gate delete-store client init, HTTP endpoints, cache gen middlewares on `DeletionEnabled \|\| RetentionEnabled` |
| `pkg/compactor/compactor_test.go` | Add `TestConfig_DeletionEnabled` with 5 test cases |
| `docs/sources/shared/configuration.md` | Document new `deletion_enabled` field |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes enable deletion APIs and delete-request processing without retention, affecting compactor init/validation and Loki module wiring; misconfiguration could unintentionally expose deletion endpoints or run new background work.
> 
> **Overview**
> Adds a new `compactor.deletion_enabled` / `-compactor.deletion-enabled` switch to enable log deletion independently of `retention_enabled`, with docs and flag help updated accordingly.
> 
> Updates compactor and Loki startup to initialize the delete-request store, register HTTP/gRPC delete endpoints and cache-gen middleware, run the retention/deletion loop, and register deletion job runners/builders when **either** deletion or retention is enabled. When only deletion is enabled, retention expiry is disabled via `NeverExpiringExpirationChecker` while still honoring explicit delete requests.
> 
> Extends config validation and tests so `compactor.delete-request-store` (and related path/prefix validation) is required whenever deletion or retention is enabled, and updates `compactor.deletion-mode` help text to reflect the new gating behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e5d2bc60dcc003da9bffa26f3dbecc90ec2abf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
