### PR TITLE
chore(ksonnet)!: Remove boltdb-shipper specific flags from lib

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -37,6 +37,16 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 ## Main / Unreleased
 
+### Breaking change: Drop support for non-TSDB stores in jsonnet lib 
+
+With the removal of deprecated storage backends, the Loki jsonnet library is also cleaned up to reflect these changes. Affected configuration flags are:
+
+- `$._config.using_shipper_store` - any usages defaulted to `true`
+- `$._config.using_boltdb_shipper` - any usages defaulted to `false`
+- `$._config.using_tsdb_shipper` - any usages defaulted to `true`
+
+This change may update both command line arguments and the Loki config. If you've been using or overriding one of the three aforementioned configuration options, please remove them and replace them with the new defaults.
+
 ### Breaking change: Removal of deprecated storage backends
 
 We deprecated legacy storage backends in Loki 3.0 and now they are subsequently removed:

--- a/production/ksonnet/loki-simple-scalable/example/main.jsonnet
+++ b/production/ksonnet/loki-simple-scalable/example/main.jsonnet
@@ -8,7 +8,7 @@ local k = import 'ksonnet-util/kausal.libsonnet',
 
 loki {
   _images+:: {
-    loki: 'grafana/loki:2.9.2',
+    loki: 'grafana/loki:3.7.1',
   },
 
   _config+:: {
@@ -45,10 +45,10 @@ loki {
       },
       schema_config: {
         configs: [{
-          from: '2021-09-12',
-          store: 'boltdb-shipper',
+          from: '2026-04-01',
+          store: 'tsdb',
           object_store: 's3',
-          schema: 'v11',
+          schema: 'v13',
           index: {
             prefix: '%s_index_' % namespace,
             period: '24h',

--- a/production/ksonnet/loki/compactor.libsonnet
+++ b/production/ksonnet/loki/compactor.libsonnet
@@ -64,14 +64,12 @@
     k.util.serviceFor($.compactor_statefulset, $._config.service_ignored_labels)
   ,
 
-  local compactor_worker_enabled = $._config.enable_horizontally_scalable_compactor,
-
-  compactor_worker_args:: if compactor_worker_enabled then $._config.commonArgs {
+  compactor_worker_args:: if $._config.enable_horizontally_scalable_compactor then $._config.commonArgs {
     target: 'compactor',
     'compactor.horizontal-scaling-mode': 'worker',
   },
 
-  compactor_worker_container:: if !compactor_worker_enabled then {} else
+  compactor_worker_container:: if !$._config.enable_horizontally_scalable_compactor then {} else
     container.new('compactor-worker', $._images.compactor_worker) +
     container.withPorts($.util.defaultPorts) +
     container.withArgsMixin(k.util.mapToFlags($.compactor_worker_args)) +
@@ -84,7 +82,7 @@
     k.util.resourcesLimits('2', '1Gi') +
     container.withEnvMixin($._config.commonEnvs),
 
-  compactor_worker_deployment: if !compactor_worker_enabled then {} else
+  compactor_worker_deployment: if !$._config.enable_horizontally_scalable_compactor then {} else
     deployment.new('compactor-worker', 1, [$.compactor_worker_container]) +
     $.config_hash_mixin +
     k.util.configVolumeMount('loki', '/etc/loki/config') +

--- a/production/ksonnet/loki/compactor.libsonnet
+++ b/production/ksonnet/loki/compactor.libsonnet
@@ -1,0 +1,97 @@
+{
+  local k = import 'ksonnet-util/kausal.libsonnet',
+  local pvc = k.core.v1.persistentVolumeClaim,
+  local volumeMount = k.core.v1.volumeMount,
+  local container = k.core.v1.container,
+  local statefulSet = k.apps.v1.statefulSet,
+  local service = k.core.v1.service,
+  local containerPort = k.core.v1.containerPort,
+  local deployment = k.apps.v1.deployment,
+
+  _config+:: {
+    compactor_pvc_size: '10Gi',
+    compactor_pvc_class: 'fast',
+
+    enable_horizontally_scalable_compactor: false,
+
+    loki+: {
+      compactor+: {
+        working_directory: '/data/compactor',
+      },
+    },
+  },
+
+  // Use PVC for compactor instead of node disk.
+  compactor_data_pvc::
+    pvc.new('compactor-data') +
+    pvc.mixin.spec.resources.withRequests({ storage: $._config.compactor_pvc_size }) +
+    pvc.mixin.spec.withAccessModes(['ReadWriteOnce']) +
+    pvc.mixin.spec.withStorageClassName($._config.compactor_pvc_class)
+  ,
+
+  compactor_args:: $._config.commonArgs {
+    target: 'compactor',
+  } + if $._config.enable_horizontally_scalable_compactor then {
+    'compactor.horizontal-scaling-mode': 'main',
+  } else {},
+
+  compactor_ports:: $.util.defaultPorts,
+
+  compactor_container::
+    container.new('compactor', $._images.compactor) +
+    container.withPorts($.compactor_ports) +
+    container.withArgsMixin(k.util.mapToFlags($.compactor_args)) +
+    container.withVolumeMountsMixin([volumeMount.new('compactor-data', '/data')]) +
+    container.mixin.readinessProbe.httpGet.withPath('/ready') +
+    container.mixin.readinessProbe.httpGet.withPort($._config.http_listen_port) +
+    container.mixin.readinessProbe.withTimeoutSeconds(1) +
+    k.util.resourcesRequests('4', '2Gi') +
+    k.util.resourcesLimits(null, '4Gi') +
+    container.withEnvMixin($._config.commonEnvs)
+  ,
+
+  compactor_statefulset:
+    statefulSet.new('compactor', 1, [$.compactor_container], $.compactor_data_pvc) +
+    statefulSet.mixin.spec.withServiceName('compactor') +
+    $.config_hash_mixin +
+    k.util.configVolumeMount('loki', '/etc/loki/config') +
+    k.util.configVolumeMount('overrides', '/etc/loki/overrides') +
+    statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
+    statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(10001)  // 10001 is the group ID assigned to Loki in the Dockerfile
+  ,
+
+  compactor_service:
+    k.util.serviceFor($.compactor_statefulset, $._config.service_ignored_labels)
+  ,
+
+  local compactor_worker_enabled = $._config.enable_horizontally_scalable_compactor,
+
+  compactor_worker_args:: if compactor_worker_enabled then $._config.commonArgs {
+    target: 'compactor',
+    'compactor.horizontal-scaling-mode': 'worker',
+  },
+
+  compactor_worker_container:: if !compactor_worker_enabled then {} else
+    container.new('compactor-worker', $._images.compactor_worker) +
+    container.withPorts($.util.defaultPorts) +
+    container.withArgsMixin(k.util.mapToFlags($.compactor_worker_args)) +
+    container.mixin.readinessProbe.httpGet.withPath('/ready') +
+    container.mixin.readinessProbe.httpGet.withPort($._config.http_listen_port) +
+    container.mixin.readinessProbe.withTimeoutSeconds(1) +
+    container.withEnvMixin($._config.commonEnvs) +
+    $.jaeger_mixin +
+    k.util.resourcesRequests('1', '500Mi') +
+    k.util.resourcesLimits('2', '1Gi') +
+    container.withEnvMixin($._config.commonEnvs),
+
+  compactor_worker_deployment: if !compactor_worker_enabled then {} else
+    deployment.new('compactor-worker', 1, [$.compactor_worker_container]) +
+    $.config_hash_mixin +
+    k.util.configVolumeMount('loki', '/etc/loki/config') +
+    k.util.configVolumeMount(
+      $._config.overrides_configmap_mount_name,
+      $._config.overrides_configmap_mount_path,
+    ) +
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge('15%') +
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable('15%'),
+}

--- a/production/ksonnet/loki/index-gateway.libsonnet
+++ b/production/ksonnet/loki/index-gateway.libsonnet
@@ -6,11 +6,6 @@
 
     loki+: {
       storage_config+: if $._config.use_index_gateway then {
-        boltdb_shipper+: {
-          index_gateway_client+: {
-            server_address: 'dns+index-gateway-headless.%s.svc.cluster.local:9095' % $._config.namespace,
-          },
-        },
         tsdb_shipper+: {
           index_gateway_client+: {
             server_address: 'dns+index-gateway-headless.%s.svc.cluster.local:9095' % $._config.namespace,

--- a/production/ksonnet/loki/loki.libsonnet
+++ b/production/ksonnet/loki/loki.libsonnet
@@ -23,8 +23,10 @@
 // Index Gateway support
 (import 'index-gateway.libsonnet') +
 
-// BoltDB and TSDB Shipper support. Anything that modifies the compactor must be imported after this.
+// TSDB Shipper support.
+// Anything that modifies the compactor must be imported after this.
 (import 'shipper.libsonnet') +
+(import 'compactor.libsonnet') +
 
 // Multi-zone ingester related config
 (import 'multi-zone.libsonnet') +

--- a/production/ksonnet/loki/ruler.libsonnet
+++ b/production/ksonnet/loki/ruler.libsonnet
@@ -9,14 +9,6 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 
   ruler_args:: $._config.commonArgs {
     target: 'ruler',
-  } + if $._config.using_boltdb_shipper then {
-    // Use PVC for caching
-    'boltdb.shipper.cache-location': '/data/boltdb-cache',
-  } else {},
-
-  _config+:: {
-    // run rulers as statefulsets when using boltdb-shipper to avoid using node disk for storing the index.
-    stateful_rulers: if self.using_boltdb_shipper && !self.use_index_gateway then true else super.stateful_rulers,
   },
 
   ruler_ports:: $.util.defaultPorts,

--- a/production/ksonnet/loki/shipper.libsonnet
+++ b/production/ksonnet/loki/shipper.libsonnet
@@ -1,117 +1,15 @@
 {
-  local k = import 'ksonnet-util/kausal.libsonnet',
-  local pvc = k.core.v1.persistentVolumeClaim,
-  local volumeMount = k.core.v1.volumeMount,
-  local container = k.core.v1.container,
-  local statefulSet = k.apps.v1.statefulSet,
-  local service = k.core.v1.service,
-  local containerPort = k.core.v1.containerPort,
-  local deployment = k.apps.v1.deployment,
-
   _config+:: {
-    // flag for tuning things when boltdb-shipper is current or upcoming index type.
-    using_boltdb_shipper: true,
-    using_tsdb_shipper: false,
-    using_shipper_store: $._config.using_boltdb_shipper || $._config.using_tsdb_shipper,
+    stateful_queriers: if !self.use_index_gateway then true else super.stateful_queriers,
+    index_period_hours: 24,
 
-    stateful_queriers: if self.using_shipper_store && !self.use_index_gateway then true else super.stateful_queriers,
-    enable_horizontally_scalable_compactor: false,
-
-    compactor_pvc_size: '10Gi',
-    compactor_pvc_class: 'fast',
-    index_period_hours: if self.using_shipper_store then 24 else super.index_period_hours,
-    loki+: if self.using_shipper_store then {
+    loki+: {
       storage_config+: {
-        boltdb_shipper+: if $._config.using_boltdb_shipper then {
-          active_index_directory: '/data/index',
-          cache_location: '/data/boltdb-cache',
-        } else {},
-        tsdb_shipper+: if $._config.using_tsdb_shipper then {
+        tsdb_shipper+: {
           active_index_directory: '/data/tsdb-index',
           cache_location: '/data/tsdb-cache',
-        } else {},
+        },
       },
-      compactor+: {
-        working_directory: '/data/compactor',
-      },
-    } else {},
+    },
   },
-
-  // we don't dedupe index writes when using boltdb-shipper or tsdb-shipper so don't deploy a cache for it.
-  memcached_index_writes: if $._config.using_shipper_store then {} else
-    if 'memcached_index_writes' in super then super.memcached_index_writes else {},
-
-  // Use PVC for compactor instead of node disk.
-  compactor_data_pvc:: if $._config.using_shipper_store then
-    pvc.new('compactor-data') +
-    pvc.mixin.spec.resources.withRequests({ storage: $._config.compactor_pvc_size }) +
-    pvc.mixin.spec.withAccessModes(['ReadWriteOnce']) +
-    pvc.mixin.spec.withStorageClassName($._config.compactor_pvc_class)
-  else {},
-
-  compactor_args:: if !$._config.using_shipper_store then {} else $._config.commonArgs {
-    target: 'compactor',
-  } + if $._config.enable_horizontally_scalable_compactor then {
-    'compactor.horizontal-scaling-mode': 'main',
-  } else {},
-
-  compactor_ports:: $.util.defaultPorts,
-
-  compactor_container:: if $._config.using_shipper_store then
-    container.new('compactor', $._images.compactor) +
-    container.withPorts($.compactor_ports) +
-    container.withArgsMixin(k.util.mapToFlags($.compactor_args)) +
-    container.withVolumeMountsMixin([volumeMount.new('compactor-data', '/data')]) +
-    container.mixin.readinessProbe.httpGet.withPath('/ready') +
-    container.mixin.readinessProbe.httpGet.withPort($._config.http_listen_port) +
-    container.mixin.readinessProbe.withTimeoutSeconds(1) +
-    k.util.resourcesRequests('4', '2Gi') +
-    k.util.resourcesLimits(null, '4Gi') +
-    container.withEnvMixin($._config.commonEnvs)
-  else {},
-
-  compactor_statefulset: if $._config.using_shipper_store then
-    statefulSet.new('compactor', 1, [$.compactor_container], $.compactor_data_pvc) +
-    statefulSet.mixin.spec.withServiceName('compactor') +
-    $.config_hash_mixin +
-    k.util.configVolumeMount('loki', '/etc/loki/config') +
-    k.util.configVolumeMount('overrides', '/etc/loki/overrides') +
-    statefulSet.mixin.spec.updateStrategy.withType('RollingUpdate') +
-    statefulSet.mixin.spec.template.spec.securityContext.withFsGroup(10001)  // 10001 is the group ID assigned to Loki in the Dockerfile
-  else {},
-
-  compactor_service: if $._config.using_shipper_store then
-    k.util.serviceFor($.compactor_statefulset, $._config.service_ignored_labels)
-  else {},
-
-  local compactor_worker_enabled = $._config.using_shipper_store && $._config.enable_horizontally_scalable_compactor,
-
-  compactor_worker_args:: if compactor_worker_enabled then $._config.commonArgs {
-    target: 'compactor',
-    'compactor.horizontal-scaling-mode': 'worker',
-  },
-
-  compactor_worker_container:: if !compactor_worker_enabled then {} else
-    container.new('compactor-worker', $._images.compactor_worker) +
-    container.withPorts($.util.defaultPorts) +
-    container.withArgsMixin(k.util.mapToFlags($.compactor_worker_args)) +
-    container.mixin.readinessProbe.httpGet.withPath('/ready') +
-    container.mixin.readinessProbe.httpGet.withPort($._config.http_listen_port) +
-    container.mixin.readinessProbe.withTimeoutSeconds(1) +
-    container.withEnvMixin($._config.commonEnvs) +
-    $.jaeger_mixin +
-    k.util.resourcesRequests('1', '500Mi') +
-    k.util.resourcesLimits('2', '1Gi') +
-    container.withEnvMixin($._config.commonEnvs),
-
-  compactor_worker_deployment: if !compactor_worker_enabled then {} else
-    deployment.new('compactor-worker', 1, [$.compactor_worker_container]) +
-    $.config_hash_mixin +
-    k.util.configVolumeMount('loki', '/etc/loki/config') +
-    k.util.configVolumeMount(
-      $._config.overrides_configmap_mount_name,
-      $._config.overrides_configmap_mount_path,
-    ) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge('15%') +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable('15%'),
 }


### PR DESCRIPTION
### Summary

With the removal of deprecated storage backends, the Loki jsonnet library is also cleaned up to reflect these changes. Affected configuration flags are:

- `$._config.using_shipper_store` - any usages defaulted to `true`
- `$._config.using_boltdb_shipper` - any usages defaulted to `false`
- `$._config.using_tsdb_shipper` - any usages defaulted to `true`

This change may update both command line arguments and the Loki config. If you've been using or overriding one of the three aforementioned configuration options, please remove them and replace them with the new defaults.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking change for Jsonnet/Tanka users who relied on `using_*shipper` toggles or BoltDB-shipper-specific behavior; it alters generated Loki args/manifests (shipper, compactor, ruler, index-gateway) and may change runtime config if overrides were in use.
> 
> **Overview**
> **Drops non-TSDB store support in the ksonnet Jsonnet lib** by removing `$._config.using_shipper_store`, `using_boltdb_shipper`, and `using_tsdb_shipper` and simplifying `shipper.libsonnet` to always configure `tsdb_shipper` (and default `stateful_queriers` when no index-gateway).
> 
> **Refactors compactor deployment** out of `shipper.libsonnet` into a new `compactor.libsonnet` and wires it into `loki.libsonnet`, including optional horizontal-scaling worker support.
> 
> **Removes BoltDB-shipper wiring elsewhere**: `index-gateway.libsonnet` no longer configures `boltdb_shipper` client settings, and `ruler.libsonnet` drops BoltDB-shipper-specific cache flags/stateful defaults.
> 
> Documentation and examples are updated to reflect the breaking change and to use newer defaults (example bumps Loki image to `3.7.1` and switches schema to `tsdb`/`v13`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27f71b05a6b7a242b6dafcf82452521a0134be2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->