### PR TITLE
ci(operator): Ensure that the origin is defined with login creds before push

### DIFF
--- a/.github/workflows/operator-reusable-hub-release.yml
+++ b/.github/workflows/operator-reusable-hub-release.yml
@@ -123,6 +123,7 @@ jobs:
           git checkout -b $branch
           git add -A
           git commit -s -m "$message"
+          git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/grafanabot/${INPUTS_REPO}.git
           git push -f --set-upstream origin $branch
           gh pr create --title "$message" \
                        --body "$body" \


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a followup PR for the operator publish workflow.

As we now use `persist-credentials: false` we must explicitly configure the origin creds with our app token.

After merging, testing will continue with this test procedure:

- [X] Create a new release operator/v0.0.0-test
- [ ] Verify that PRs are opened against the operator-hub-prod-release and operator-hub-community-release repos
- [ ] Close the PRs
- [ ] Delete the release

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the release workflow’s git push authentication, which can break automated PR creation if the remote URL/token handling is wrong. Limited scope to a single GitHub Actions workflow step.
> 
> **Overview**
> Ensures the operator hub publish workflow can still push branches after `persist-credentials: false` by explicitly resetting `origin` to an HTTPS remote that includes the GitHub App token before `git push`.
> 
> This keeps the subsequent `gh pr create` flow unchanged while fixing push failures due to missing credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c329663cf2d54e20d17e6e7d833b036ababe2f25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->