### PR TITLE
chore(queries): Log User-Agent on query metrics and finished lines

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -288,6 +288,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	durFull := time.Since(startTime)
 	logValues := []any{
 		"msg", "finished executing",
+		"user_agent", httpreq.ExtractHeader(ctx, "User-Agent"),
 		"query", params.QueryString(),
 		"length", params.End().Sub(params.Start()).String(),
 		"step", params.Step().String(),

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -168,6 +168,7 @@ func RecordRangeAndInstantQueryMetrics(
 
 	logValues = append(logValues, []interface{}{
 		"latency", latencyType, // this can be used to filter log lines.
+		"user_agent", httpreq.ExtractHeader(ctx, "User-Agent"),
 		"query", query,
 		"query_hash", hashedQuery,
 		"query_type", queryType,
@@ -350,6 +351,7 @@ func RecordLabelQueryMetrics(
 	level.Info(logger).Log(
 		"latency", latencyType,
 		"query_type", queryType,
+		"user_agent", httpreq.ExtractHeader(ctx, "User-Agent"),
 		"splits", stats.Summary.Splits,
 		"start", start.Format(time.RFC3339Nano),
 		"end", end.Format(time.RFC3339Nano),
@@ -407,6 +409,7 @@ func RecordSeriesQueryMetrics(ctx context.Context, log log.Logger, start, end ti
 	logValues = append(logValues,
 		"latency", latencyType,
 		"query_type", queryType,
+		"user_agent", httpreq.ExtractHeader(ctx, "User-Agent"),
 		"splits", stats.Summary.Splits,
 		"start", start.Format(time.RFC3339Nano),
 		"end", end.Format(time.RFC3339Nano),
@@ -454,6 +457,7 @@ func RecordStatsQueryMetrics(ctx context.Context, log log.Logger, start, end tim
 	logValues = append(logValues,
 		"latency", latencyType,
 		"query_type", queryType,
+		"user_agent", httpreq.ExtractHeader(ctx, "User-Agent"),
 		"start", start.Format(time.RFC3339Nano),
 		"end", end.Format(time.RFC3339Nano),
 		"start_delta", time.Since(start),
@@ -500,6 +504,7 @@ func RecordShardsQueryMetrics(
 	logValues = append(logValues,
 		"latency", latencyType,
 		"query_type", queryType,
+		"user_agent", httpreq.ExtractHeader(ctx, "User-Agent"),
 		"start", start.Format(time.RFC3339Nano),
 		"end", end.Format(time.RFC3339Nano),
 		"start_delta", time.Since(start),
@@ -543,6 +548,7 @@ func RecordVolumeQueryMetrics(ctx context.Context, log log.Logger, start, end ti
 	level.Info(logger).Log(
 		"latency", latencyType,
 		"query_type", queryType,
+		"user_agent", httpreq.ExtractHeader(ctx, "User-Agent"),
 		"query", query,
 		"query_hash", util.HashedQuery(query),
 		"start", start.Format(time.RFC3339Nano),
@@ -584,6 +590,7 @@ func RecordDetectedFieldsQueryMetrics(ctx context.Context, log log.Logger, start
 	level.Info(logger).Log(
 		"latency", latencyType,
 		"query_type", queryType,
+		"user_agent", httpreq.ExtractHeader(ctx, "User-Agent"),
 		"query", query,
 		"query_hash", util.HashedQuery(query),
 		"start", start.Format(time.RFC3339Nano),
@@ -724,6 +731,7 @@ func RecordDetectedLabelsQueryMetrics(ctx context.Context, log log.Logger, start
 		"api", "detected_labels",
 		"latency", latencyType,
 		"query_type", queryType,
+		"user_agent", httpreq.ExtractHeader(ctx, "User-Agent"),
 		"query", query,
 		"query_hash", util.HashedQuery(query),
 		"start", start.Format(time.RFC3339Nano),

--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -82,7 +82,7 @@ func TestLogSlowQuery(t *testing.T) {
 	}, logqlmodel.Streams{logproto.Stream{Entries: make([]logproto.Entry, 10)}})
 	require.Regexp(t,
 		regexp.MustCompile(fmt.Sprintf(
-			`level=info org_id=foo traceID=%s sampled=true latency=slow query=".*" query_hash=.* query_type=filter range_type=range length=1h0m0s .*\n`,
+			`level=info org_id=foo traceID=%s sampled=true latency=slow user_agent= query=".*" query_hash=.* query_type=filter range_type=range length=1h0m0s .*\n`,
 			sp.SpanContext().TraceID(),
 		)),
 		buf.String())
@@ -117,7 +117,7 @@ func TestLogLabelsQuery(t *testing.T) {
 	})
 	require.Regexp(t,
 		fmt.Sprintf(
-			"level=info org_id=foo traceID=%s sampled=true latency=slow query_type=labels splits=0 start=.* end=.* start_delta=1h0m0.* end_delta=.* length=1h0m0s duration=25.25s status=200 label=foo query= query_hash=2166136261 total_entries=12 cache_label_results_req=2 cache_label_results_hit=1 cache_label_results_stored=1 cache_label_results_download_time=80ns cache_label_results_query_length_served=10ns\n",
+			"level=info org_id=foo traceID=%s sampled=true latency=slow query_type=labels user_agent= splits=0 start=.* end=.* start_delta=1h0m0.* end_delta=.* length=1h0m0s duration=25.25s status=200 label=foo query= query_hash=2166136261 total_entries=12 cache_label_results_req=2 cache_label_results_hit=1 cache_label_results_stored=1 cache_label_results_download_time=80ns cache_label_results_query_length_served=10ns\n",
 			sp.SpanContext().TraceID(),
 		),
 		buf.String())
@@ -152,7 +152,7 @@ func TestLogSeriesQuery(t *testing.T) {
 	})
 	require.Regexp(t,
 		fmt.Sprintf(
-			"level=info org_id=foo traceID=%s sampled=true latency=slow query_type=series splits=0 start=.* end=.* start_delta=1h0m0.* end_delta=.* length=1h0m0s duration=25.25s status=200 match=\"{container_name=.*\"}:{app=.*}\" query_hash=23523089 total_entries=10 cache_series_results_req=2 cache_series_results_hit=1 cache_series_results_stored=1 cache_series_results_download_time=80ns cache_series_results_query_length_served=10ns\n",
+			"level=info org_id=foo traceID=%s sampled=true latency=slow query_type=series user_agent= splits=0 start=.* end=.* start_delta=1h0m0.* end_delta=.* length=1h0m0s duration=25.25s status=200 match=\"{container_name=.*\"}:{app=.*}\" query_hash=23523089 total_entries=10 cache_series_results_req=2 cache_series_results_hit=1 cache_series_results_stored=1 cache_series_results_download_time=80ns cache_series_results_query_length_served=10ns\n",
 			sp.SpanContext().TraceID(),
 		),
 		buf.String())


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `user_agent` entry on query metrics log lines and on "finished executing" lines.

This can help identify the source of particular queries.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- NA Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a logging-only change, but it increases log data collected (potential PII and higher log volume/cardinality) across several query paths.
> 
> **Overview**
> Adds `user_agent` to query-related log lines by extracting the `User-Agent` header from the request context.
> 
> This is applied both to the v2 engine’s final "finished executing" log in `pkg/engine/engine.go` and to multiple LogQL query metrics logs in `pkg/logql/metrics.go`, with `pkg/logql/metrics_test.go` updated to assert the new field is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dcae6590e3ec9d97bdd8219ba4d4891532b57a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->