### PR TITLE
Fix missing folder annotation for single binary mode

### DIFF
--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -171,6 +171,10 @@ spec:
             {{- end }}
             - name: FOLDER
               value: "{{ .Values.sidecar.rules.folder }}"
+            {{- if .Values.sidecar.rules.folderAnnotation }}
+            - name: FOLDER_ANNOTATION
+              value: "{{ .Values.sidecar.rules.folderAnnotation }}"
+            {{- end }}
             - name: RESOURCE
               value: {{ quote .Values.sidecar.rules.resource }}
             {{- if .Values.sidecar.enableUniqueFilenames }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `folderAnnotation` env var to the single binary rules sidecar. It is currently missing there, which doesn't allow us to configure multi-tenant rules.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm templating change that only adds an optional env var to the single-binary rules sidecar when configured. Impact is limited to users enabling `sidecar.rules.folderAnnotation`.
> 
> **Overview**
> Fixes single-binary Helm deployments to correctly propagate `sidecar.rules.folderAnnotation` into the rules sidecar by conditionally setting the `FOLDER_ANNOTATION` environment variable.
> 
> This brings single-binary behavior in line with other deployment modes and enables folder overrides (e.g., for multi-tenant rules) when the annotation value is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60a8794d139f3c7717552e49a9f0f971a0bf6e59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->