### PR TITLE
fix: Revert "fix(deps): update module github.com/grafana/loki/pkg/push to v0.4.0 (main)"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -143,7 +143,7 @@
       automerge: false,
     },
     {
-      // Disable all updates for pkg/push/go.mod
+      // Disable all updates for pkg/push/go.mod (deps of the submodule).
       matchFileNames: ['pkg/push/go.mod'],
       enabled: false,
       autoApprove: false,
@@ -203,6 +203,14 @@
       digest: {
         enabled: true,
       },
+    },
+    {
+      // Last: do not bump github.com/grafana/loki/pkg/push in any go.mod (overrides broader enable rules).
+      matchManagers: ['gomod'],
+      matchPackageNames: ['github.com/grafana/loki/pkg/push'],
+      enabled: false,
+      autoApprove: false,
+      automerge: false,
     },
   ],
   digest: {

--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,7 @@ require (
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/gogo/googleapis v1.4.1
 	github.com/grafana/jsonparser v0.0.0-20241004153430-023329977675
-	github.com/grafana/loki/pkg/push v0.4.0
+	github.com/grafana/loki/pkg/push v0.0.0-20250630054201-94c0ba7b0952
 	github.com/influxdata/tdigest v0.0.2-0.20210216194612-fc98d27c9e8b
 	github.com/joshdk/go-junit v1.0.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1051,7 +1051,7 @@ github.com/grafana/gomemcache/memcache
 # github.com/grafana/jsonparser v0.0.0-20241004153430-023329977675
 ## explicit; go 1.13
 github.com/grafana/jsonparser
-# github.com/grafana/loki/pkg/push v0.4.0 => ./pkg/push
+# github.com/grafana/loki/pkg/push v0.0.0-20250630054201-94c0ba7b0952 => ./pkg/push
 ## explicit; go 1.24.0
 github.com/grafana/loki/pkg/push
 # github.com/grafana/otel-profiling-go v0.5.1


### PR DESCRIPTION
Reverts grafana/loki#21640

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mainly dependency management/config changes; the module is still replaced by the local `./pkg/push`, so runtime behavior should be unaffected aside from module/version resolution and Renovate behavior.
> 
> **Overview**
> Reverts the `github.com/grafana/loki/pkg/push` module requirement change by switching `go.mod` (and the vendored `modules.txt`) from `v0.4.0` to a pseudo-version while still replacing it with the local `./pkg/push`.
> 
> Updates Renovate config to **explicitly disable** updates to `github.com/grafana/loki/pkg/push` in any `go.mod`, overriding broader Go module enable rules, and clarifies the existing rule disabling updates for `pkg/push/go.mod`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a03ceaaf6407adbfe74d7fd22bcd1db3c96a67d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->