### PR TITLE
fix: Data race in dataobj index builder tests

### DIFF
--- a/pkg/dataobj/index/builder_test.go
+++ b/pkg/dataobj/index/builder_test.go
@@ -295,7 +295,10 @@ func TestIndexBuilder_idlePartition(t *testing.T) {
 
 	// Wait for idle partition to be flushed
 	for i := 0; i < 1000; i++ {
-		if len(readAllSectionPointers(t, bucket)) == 30 && len(p.partitionStates[0].events) == 0 {
+		p.partitionsMutex.Lock()
+		numEvents := len(p.partitionStates[0].events)
+		p.partitionsMutex.Unlock()
+		if len(readAllSectionPointers(t, bucket)) == 30 && numEvents == 0 {
 			break
 		}
 		time.Sleep(time.Millisecond)
@@ -365,7 +368,10 @@ func TestIndexBuilder_oldEvents(t *testing.T) {
 
 	// Wait for data to be flushed
 	for i := 0; i < 1000; i++ {
-		if len(readAllSectionPointers(t, bucket)) == 30 && len(p.partitionStates[0].events) == 0 {
+		p.partitionsMutex.Lock()
+		numEvents := len(p.partitionStates[0].events)
+		p.partitionsMutex.Unlock()
+		if len(readAllSectionPointers(t, bucket)) == 30 && numEvents == 0 {
 			break
 		}
 		time.Sleep(time.Millisecond)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a data race in the test:

```
==================
WARNING: DATA RACE
Write at 0x00c000729340 by goroutine 426:
  github.com/grafana/loki/v3/pkg/dataobj/index.(*Builder).markEventsCompleted()
      /Users/grobinson/go/src/github.com/grafana/loki/pkg/dataobj/index/builder.go:374 +0xec
  github.com/grafana/loki/v3/pkg/dataobj/index.(*Builder).buildAndCommitIndex()
      /Users/grobinson/go/src/github.com/grafana/loki/pkg/dataobj/index/builder.go:462 +0xcdc
  github.com/grafana/loki/v3/pkg/dataobj/index.(*Builder).flushPartition.func1()
      /Users/grobinson/go/src/github.com/grafana/loki/pkg/dataobj/index/builder.go:434 +0x3c8

Previous read at 0x00c000729340 by goroutine 53:
  github.com/grafana/loki/v3/pkg/dataobj/index.TestIndexBuilder_idlePartition()
      /Users/grobinson/go/src/github.com/grafana/loki/pkg/dataobj/index/builder_test.go:298 +0xc60
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:2101 +0x34

Goroutine 426 (running) created at:
  github.com/grafana/loki/v3/pkg/dataobj/index.(*Builder).flushPartition()
      /Users/grobinson/go/src/github.com/grafana/loki/pkg/dataobj/index/builder.go:429 +0x1ac
  github.com/grafana/loki/v3/pkg/dataobj/index.(*Builder).checkAndFlushPartitions()
      /Users/grobinson/go/src/github.com/grafana/loki/pkg/dataobj/index/builder.go:418 +0x5f0
  github.com/grafana/loki/v3/pkg/dataobj/index.(*Builder).starting.func1()
      /Users/grobinson/go/src/github.com/grafana/loki/pkg/dataobj/index/builder.go:264 +0xb4
  sync.(*WaitGroup).Go.func1()
      /usr/local/go/src/sync/waitgroup.go:258 +0x54

Goroutine 53 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:2101 +0x7bc
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2585 +0x78
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:2036 +0x164
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2583 +0x7a0
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:2443 +0xb38
  main.main()
      _testmain.go:102 +0x100
==================
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test synchronization by guarding shared state reads with `partitionsMutex`, reducing flakiness without affecting production logic.
> 
> **Overview**
> Fixes a data race in `builder_test.go` by reading `partitionStates[0].events` under `p.partitionsMutex` in the polling loops for `TestIndexBuilder_idlePartition` and `TestIndexBuilder_oldEvents`.
> 
> This makes the “wait until flushed” assertions concurrency-safe while the builder goroutines concurrently truncate the events slice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e84f12d75816254a28ec09ef2ccc774d8a2d983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->