### PR TITLE
fix(columnar): Don't release Arrow records

### DIFF
--- a/pkg/dataobj/README.md
+++ b/pkg/dataobj/README.md
@@ -546,8 +546,6 @@ func main() {
             message := batch.Column(1).(*array.String).Value(i)
             println(timestamp, message)
         }
-
-        batch.Release()
     }
 }
 ```

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -587,7 +587,6 @@ func (e *Engine) collectResult(ctx context.Context, logger log.Logger, params lo
 		}
 
 		builder.CollectRecord(rec)
-		rec.Release()
 	}
 
 	duration := timer.ObserveDuration()


### PR DESCRIPTION
**What this PR does / why we need it**:

Multiple goroutines may still be accessing records, so we cannot `Release` them.

Remove from the real code and from an example.

**Which issue(s) this PR fixes**:
Relates to #8586 

Seen for real at https://github.com/grafana/loki/actions/runs/24782802749/job/72519013015

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- [ ] Tests updated*
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`

*Existing tests detect this, when run with `-race`.  But enabling that in CI will have to wait till we fix all the existing races.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Arrow record lifecycle/ownership, which can impact memory usage and concurrency safety; incorrect ownership assumptions could cause leaks or latent crashes.
> 
> **Overview**
> Prevents premature freeing of Arrow data by removing explicit `Release()` calls on Arrow records/batches in both the `pkg/dataobj` README example and the engine’s execution result collection (`Engine.collectResult`).
> 
> This aligns record lifetime with downstream consumers that may still access the data concurrently, reducing race-driven use-after-free failures at the cost of relying on higher-level cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bafd83c2348e3b64b378ec893e070f46e7a260d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->