### PR TITLE
fix(loki-canary): Apply -labels and -query-append to metric and tail queries

### DIFF
--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -75,6 +75,29 @@ type Reader struct {
 	done            chan struct{}
 	queryAppend     string
 	labels          string
+	labelSelector   string
+}
+
+func buildLabelSelector(labels, sName, sValue, lName, lVal string) (string, error) {
+	if labels != "" {
+		var lbls []string
+		for _, label := range strings.Split(labels, ",") {
+			labelParts := strings.SplitN(label, "=", 2)
+			if len(labelParts) != 2 {
+				return "", fmt.Errorf("invalid label format: %s, expected key=value", label)
+			}
+			lbls = append(lbls, fmt.Sprintf("%s=\"%s\"", labelParts[0], labelParts[1]))
+		}
+		return fmt.Sprintf("{%s}", strings.Join(lbls, ",")), nil
+	}
+	return fmt.Sprintf("{%s=\"%s\",%s=\"%s\"}", sName, sValue, lName, lVal), nil
+}
+
+func (r *Reader) buildMetricQuery(queryRange string) string {
+	if r.queryAppend != "" {
+		return fmt.Sprintf("count_over_time(%s %s[%s])", r.labelSelector, r.queryAppend, queryRange)
+	}
+	return fmt.Sprintf("count_over_time(%s[%s])", r.labelSelector, queryRange)
 }
 
 func NewReader(writer io.Writer,
@@ -132,6 +155,11 @@ func NewReader(writer io.Writer,
 	}
 	bkoff := backoff.New(context.Background(), bkcfg)
 
+	labelSel, err := buildLabelSelector(labels, streamName, streamValue, labelName, labelVal)
+	if err != nil {
+		return nil, err
+	}
+
 	rd := Reader{
 		header:          h,
 		useTLS:          useTLS,
@@ -157,6 +185,7 @@ func NewReader(writer io.Writer,
 		shuttingDown:    false,
 		queryAppend:     queryAppend,
 		labels:          labels,
+		labelSelector:   labelSel,
 	}
 
 	go rd.run()
@@ -203,7 +232,7 @@ func (r *Reader) QueryCountOverTime(queryRange string, now time.Time, cache bool
 		Scheme: scheme,
 		Host:   r.addr,
 		Path:   "/loki/api/v1/query",
-		RawQuery: "query=" + url.QueryEscape(fmt.Sprintf("count_over_time({%v=\"%v\",%v=\"%v\"}[%s])", r.sName, r.sValue, r.lName, r.lVal, queryRange)) +
+		RawQuery: "query=" + url.QueryEscape(r.buildMetricQuery(queryRange)) +
 			fmt.Sprintf("&time=%d", now.UnixNano()) +
 			"&limit=1000",
 	}
@@ -293,27 +322,12 @@ func (r *Reader) Query(start time.Time, end time.Time) ([]time.Time, error) {
 	if r.useTLS {
 		scheme = "https"
 	}
-	var labels string
-	if r.labels != "" {
-		var lbls []string
-		for _, label := range strings.Split(r.labels, ",") {
-			labelParts := strings.Split(label, "=")
-			if len(labelParts) != 2 {
-				return nil, fmt.Errorf("invalid label format: %s, expected key=value", label)
-			}
-			lbls = append(lbls, fmt.Sprintf("%s=\"%s\"", labelParts[0], labelParts[1]))
-		}
-		labels = fmt.Sprintf("{%s}", strings.Join(lbls, ","))
-	} else {
-		labels = fmt.Sprintf("{%s=\"%s\",%s=\"%s\"}", r.sName, r.sValue, r.lName, r.lVal)
-	}
-
 	u := url.URL{
 		Scheme: scheme,
 		Host:   r.addr,
 		Path:   "/loki/api/v1/query_range",
 		RawQuery: fmt.Sprintf("start=%d&end=%d", start.UnixNano(), end.UnixNano()) +
-			"&query=" + url.QueryEscape(fmt.Sprintf("%s %v", labels, r.queryAppend)) +
+			"&query=" + url.QueryEscape(fmt.Sprintf("%s %v", r.labelSelector, r.queryAppend)) +
 			"&limit=1000",
 	}
 	fmt.Fprintf(r.w, "Querying loki for logs with query: %v\n", u.String())
@@ -478,10 +492,10 @@ func (r *Reader) closeAndReconnect() {
 			Scheme:   scheme,
 			Host:     r.addr,
 			Path:     "/loki/api/v1/tail",
-			RawQuery: "query=" + url.QueryEscape(fmt.Sprintf("{%v=\"%v\",%v=\"%v\"} %v", r.sName, r.sValue, r.lName, r.lVal, r.queryAppend)),
+			RawQuery: "query=" + url.QueryEscape(fmt.Sprintf("%s %v", r.labelSelector, r.queryAppend)),
 		}
 
-		fmt.Fprintf(r.w, "Connecting to loki at %v, querying for label '%v' with value '%v'\n", u.String(), r.lName, r.lVal)
+		fmt.Fprintf(r.w, "Connecting to loki at %v, using selector %s\n", u.String(), r.labelSelector)
 
 		dialer := r.webSocketDialer()
 		c, _, err := dialer.Dial(u.String(), r.header)

--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -59,10 +59,6 @@ type Reader struct {
 	tenantID        string
 	httpClient      *http.Client
 	queryTimeout    time.Duration
-	sName           string
-	sValue          string
-	lName           string
-	lVal            string
 	backoff         *backoff.Backoff
 	nextQuery       time.Time
 	backoffMtx      sync.RWMutex
@@ -74,7 +70,6 @@ type Reader struct {
 	shuttingDown    bool
 	done            chan struct{}
 	queryAppend     string
-	labels          string
 	labelSelector   string
 }
 
@@ -171,10 +166,6 @@ func NewReader(writer io.Writer,
 		tenantID:        tenantID,
 		queryTimeout:    queryTimeout,
 		httpClient:      httpClient,
-		sName:           streamName,
-		sValue:          streamValue,
-		lName:           labelName,
-		lVal:            labelVal,
 		nextQuery:       next,
 		backoff:         bkoff,
 		interval:        interval,
@@ -184,7 +175,6 @@ func NewReader(writer io.Writer,
 		done:            make(chan struct{}),
 		shuttingDown:    false,
 		queryAppend:     queryAppend,
-		labels:          labels,
 		labelSelector:   labelSel,
 	}
 

--- a/pkg/canary/reader/reader_test.go
+++ b/pkg/canary/reader/reader_test.go
@@ -1,0 +1,112 @@
+package reader
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildLabelSelector(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   string
+		sName    string
+		sValue   string
+		lName    string
+		lVal     string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "uses legacy params when labels is empty",
+			labels:   "",
+			sName:    "stream",
+			sValue:   "stdout",
+			lName:    "pod",
+			lVal:     "loki-canary-abc",
+			expected: `{stream="stdout",pod="loki-canary-abc"}`,
+		},
+		{
+			name:     "uses labels param when set",
+			labels:   "service_name=containerd,namespace=loki,container=loki-canary",
+			sName:    "stream",
+			sValue:   "stdout",
+			lName:    "pod",
+			lVal:     "loki-canary-abc",
+			expected: `{service_name="containerd",namespace="loki",container="loki-canary"}`,
+		},
+		{
+			name:     "single label",
+			labels:   "app=loki",
+			sName:    "stream",
+			sValue:   "stdout",
+			lName:    "pod",
+			lVal:     "x",
+			expected: `{app="loki"}`,
+		},
+		{
+			name:     "label value containing equals sign",
+			labels:   "env=key=value",
+			sName:    "stream",
+			sValue:   "stdout",
+			lName:    "pod",
+			lVal:     "x",
+			expected: `{env="key=value"}`,
+		},
+		{
+			name:    "invalid label format returns error",
+			labels:  "badlabel",
+			sName:   "stream",
+			sValue:  "stdout",
+			lName:   "pod",
+			lVal:    "x",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildLabelSelector(tc.labels, tc.sName, tc.sValue, tc.lName, tc.lVal)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestBuildMetricQuery(t *testing.T) {
+	r := &Reader{
+		labelSelector: `{service_name="containerd",namespace="loki"}`,
+	}
+
+	tests := []struct {
+		name        string
+		queryAppend string
+		queryRange  string
+		expected    string
+	}{
+		{
+			name:        "no query-append",
+			queryAppend: "",
+			queryRange:  "5m",
+			expected:    `count_over_time({service_name="containerd",namespace="loki"}[5m])`,
+		},
+		{
+			name:        "with query-append filter",
+			queryAppend: `| pod="loki-canary-abc"`,
+			queryRange:  "5m",
+			expected:    `count_over_time({service_name="containerd",namespace="loki"} | pod="loki-canary-abc"[5m])`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r.queryAppend = tc.queryAppend
+			got := r.buildMetricQuery(tc.queryRange)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
  While investigating issue #21669, I noticed that loki-canary was only
  respecting the -labels and -query-append flags for spot check queries.                                                               
  The metric (count_over_time) and websocket tail queries were still                                                                   
  hardcoded to use the legacy -labelname/-labelvalue/-streamname/-streamvalue                                                          
  params, which made them useless in setups like ours where pod_name is                                                                
  stored as structured metadata instead of a label.                                                                                    
                                                                                                                                       
  To fix this, I extracted the label selector building logic into a shared                                                             
  helper (buildLabelSelector) that's computed once at startup and reused
  across all three query types. I also noticed the metric query wasn't                                                                 
  handling the empty query-append case cleanly, so I pulled that into its                                                              
  own method (buildMetricQuery) to keep things tidy.                                                                                   
                                                                                                                                       
  Also fixed a pre-existing bug where label values containing "=" would                                                                
  fail to parse — switched to SplitN to handle that correctly.                                                                         
                                                                                                                                       
  Fixes #21669

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the LogQL selector and query construction used by loki-canary’s metric, range, and websocket tail requests, which could alter what streams are read or cause malformed queries in some setups.
> 
> **Overview**
> **Unifies and fixes Loki query selector construction in loki-canary.** The reader now builds a single `labelSelector` once at startup (preferring `-labels` when provided, otherwise falling back to the legacy `-stream*`/`-label*` params) and reuses it across spot-check, metric `count_over_time`, and websocket tail queries.
> 
> Metric queries now correctly handle the empty `-query-append` case via `buildMetricQuery`, and label parsing is hardened to accept values containing `=` (using `SplitN`). New unit tests cover selector parsing and metric query rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1da23b77bf816240bae881ad87b3e814ed8a11d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->