### PR TITLE
feat(operator): Set __replica__ external label on ruler config for remote write

### DIFF
--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -311,10 +311,9 @@ func remoteWriteConfig(s *lokiv1.RemoteWriteSpec, rs *RulerSecret) *config.Remot
 		RefreshPeriod: string(s.RefreshPeriod),
 		RelabelConfigs: []config.RelabelConfig{
 			{
-				SourceLabels: []string{"__name__"}, // Use a dummy source label
-				TargetLabel:  "__replica__",
-				Replacement:  "${" + podNameEnvVarName + "}",
-				Action:       "replace",
+				TargetLabel: "__replica__",
+				Replacement: "${" + podNameEnvVarName + "}",
+				Action:      "replace",
 			},
 		},
 	}

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -309,6 +309,14 @@ func remoteWriteConfig(s *lokiv1.RemoteWriteSpec, rs *RulerSecret) *config.Remot
 	c := &config.RemoteWriteConfig{
 		Enabled:       s.Enabled,
 		RefreshPeriod: string(s.RefreshPeriod),
+		RelabelConfigs: []config.RelabelConfig{
+			{
+				SourceLabels: []string{"__name__"}, // Use a dummy source label
+				TargetLabel:  "__replica__",
+				Replacement:  "${" + podNameEnvVarName + "}",
+				Action:       "replace",
+			},
+		},
 	}
 
 	if cls := s.ClientSpec; cls != nil {

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -309,13 +309,6 @@ func remoteWriteConfig(s *lokiv1.RemoteWriteSpec, rs *RulerSecret) *config.Remot
 	c := &config.RemoteWriteConfig{
 		Enabled:       s.Enabled,
 		RefreshPeriod: string(s.RefreshPeriod),
-		RelabelConfigs: []config.RelabelConfig{
-			{
-				TargetLabel: "__replica__",
-				Replacement: "${" + podNameEnvVarName + "}",
-				Action:      "replace",
-			},
-		},
 	}
 
 	if cls := s.ClientSpec; cls != nil {
@@ -348,6 +341,12 @@ func remoteWriteConfig(s *lokiv1.RemoteWriteSpec, rs *RulerSecret) *config.Remot
 			})
 		}
 	}
+
+	c.RelabelConfigs = append(c.RelabelConfigs, config.RelabelConfig{
+		TargetLabel: "__replica__",
+		Replacement: "${" + podNameEnvVarName + "}",
+		Action:      "replace",
+	})
 
 	if q := s.QueueSpec; q != nil {
 		c.Queue = &config.RemoteWriteQueueConfig{

--- a/operator/internal/manifests/config_test.go
+++ b/operator/internal/manifests/config_test.go
@@ -1408,3 +1408,56 @@ func TestConfigOptions_Shipper(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigOptions_RemoteWrite_RendersReplicaLabelInYAML(t *testing.T) {
+	opts := randomConfigOptions()
+	opts.Stack.Rules = &lokiv1.RulesSpec{
+		Enabled: true,
+	}
+
+	opts.Ruler = Ruler{
+		Spec: &lokiv1.RulerConfigSpec{
+			RemoteWriteSpec: &lokiv1.RemoteWriteSpec{
+				Enabled:       true,
+				RefreshPeriod: "1m",
+				ClientSpec: &lokiv1.RemoteWriteClientSpec{
+					Name:                    "test-remote-write",
+					URL:                     "http://prometheus:9090/api/v1/write",
+					AuthorizationType:       lokiv1.BasicAuthorization,
+					AuthorizationSecretName: "test-secret",
+					RelabelConfigs: []lokiv1.RelabelConfig{
+						{
+							SourceLabels: []string{"user_label"},
+							Action:       "keep",
+							Regex:        ".*",
+						},
+					},
+				},
+			},
+		},
+		Secret: &RulerSecret{
+			Username: "user",
+			Password: "pass",
+		},
+	}
+
+	cfgOpts := ConfigOptions(opts)
+
+	// Render to YAML
+	cfg, _, err := config.Build(cfgOpts)
+	require.NoError(t, err)
+
+	expRelabelConfigs := `write_relabel_configs:
+        -
+          source_labels: ["user_label"]
+          regex: .*
+          action: keep
+          separator: ""
+        -
+          action: replace
+          separator: ""
+          replacement: ${POD_NAME}
+          target_label: __replica__`
+
+	require.Contains(t, string(cfg), expRelabelConfigs)
+}

--- a/operator/internal/manifests/ruler.go
+++ b/operator/internal/manifests/ruler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 
+	"dario.cat/mergo"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -23,6 +24,10 @@ import (
 // BuildRuler returns a list of k8s objects for Loki Stack Ruler
 func BuildRuler(opts Options) ([]client.Object, error) {
 	statefulSet := NewRulerStatefulSet(opts)
+	if err := configureRemoteWriteEnvVars(&statefulSet.Spec.Template.Spec, opts); err != nil {
+		return nil, err
+	}
+
 	if opts.Gates.HTTPEncryption {
 		if err := configureRulerHTTPServicePKI(statefulSet, opts); err != nil {
 			return nil, err
@@ -402,4 +407,32 @@ func NewRulerPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 			MinAvailable: &ma,
 		},
 	}
+}
+
+func configureRemoteWriteEnvVars(ps *corev1.PodSpec, opts Options) error {
+	if opts.Ruler.Spec == nil || opts.Ruler.Spec.RemoteWriteSpec == nil || !opts.Ruler.Spec.RemoteWriteSpec.Enabled {
+		return nil
+	}
+
+	temp := corev1.Container{
+		Env: []corev1.EnvVar{
+			{
+				Name: podNameEnvVarName,
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						APIVersion: "v1",
+						FieldPath:  "metadata.name",
+					},
+				},
+			},
+		},
+	}
+
+	for i, target := range ps.Containers {
+		if err := mergo.Merge(&target, temp, mergo.WithAppendSlice); err != nil {
+			return err
+		}
+		ps.Containers[i] = target
+	}
+	return nil
 }

--- a/operator/internal/manifests/ruler_test.go
+++ b/operator/internal/manifests/ruler_test.go
@@ -274,3 +274,73 @@ func TestNewRulerStatefulSet_TopologySpreadConstraints(t *testing.T) {
 		},
 	}, ss.Spec.Template.Spec.TopologySpreadConstraints)
 }
+
+func TestNewRulerStatefulSet_WithRemoteWrite_WithPodNameEnvVar(t *testing.T) {
+	obj, err := BuildRuler(Options{
+		Name:      "abcd",
+		Namespace: "efgh",
+		Stack: lokiv1.LokiStackSpec{
+			Template: &lokiv1.LokiTemplateSpec{
+				Ruler: &lokiv1.LokiComponentSpec{
+					Replicas: 1,
+				},
+			},
+			Rules: &lokiv1.RulesSpec{
+				Enabled: true,
+			},
+		},
+		Ruler: Ruler{
+			Spec: &lokiv1.RulerConfigSpec{
+				RemoteWriteSpec: &lokiv1.RemoteWriteSpec{
+					Enabled: true,
+				},
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, obj)
+
+	ss := obj[0].(*appsv1.StatefulSet)
+	require.Len(t, ss.Spec.Template.Spec.Containers, 1)
+
+	envVarFound := false
+	for _, env := range ss.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == podNameEnvVarName {
+			envVarFound = true
+			require.NotNil(t, env.ValueFrom)
+			require.NotNil(t, env.ValueFrom.FieldRef)
+			require.Equal(t, "v1", env.ValueFrom.FieldRef.APIVersion)
+			require.Equal(t, "metadata.name", env.ValueFrom.FieldRef.FieldPath)
+			break
+		}
+	}
+	require.True(t, envVarFound)
+}
+
+func TestNewRulerStatefulSet_WithoutRemoteWrite_WithoutPodNameEnvVar(t *testing.T) {
+	obj, err := BuildRuler(Options{
+		Name:      "abcd",
+		Namespace: "efgh",
+		Stack: lokiv1.LokiStackSpec{
+			Template: &lokiv1.LokiTemplateSpec{
+				Ruler: &lokiv1.LokiComponentSpec{
+					Replicas: 1,
+				},
+			},
+			Rules: &lokiv1.RulesSpec{
+				Enabled: true,
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, obj)
+
+	ss := obj[0].(*appsv1.StatefulSet)
+	require.Len(t, ss.Spec.Template.Spec.Containers, 1)
+
+	for _, env := range ss.Spec.Template.Spec.Containers[0].Env {
+		require.NotEqual(t, podNameEnvVarName, env.Name)
+	}
+}

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -55,6 +55,8 @@ const (
 
 	rulerContainerName = "loki-ruler"
 
+	podNameEnvVarName = "POD_NAME"
+
 	// EnvRelatedImageLoki is the environment variable to fetch the Loki image pullspec.
 	EnvRelatedImageLoki = "RELATED_IMAGE_LOKI"
 	// EnvRelatedImageGateway is the environment variable to fetch the Gateway image pullspec.

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -55,6 +55,7 @@ const (
 
 	rulerContainerName = "loki-ruler"
 
+	// podNameEnvVarName is the environment variable used in loki-config.yaml to expand into the pod name
 	podNameEnvVarName = "POD_NAME"
 
 	// EnvRelatedImageLoki is the environment variable to fetch the Loki image pullspec.


### PR DESCRIPTION
**What this PR does / why we need it**:
When multiple Loki Ruler instances send metrics via remote write, they can produce duplicate data points for the same series without a unique identifier per ruler instance.
To properly deduplicate metrics, this PR automaticaly injects `__replica__` label with the pod name for all remote write metrics when RemoteWrite is enabled.

**Which issue(s) this PR fixes**:
Fixes [LOG-9220](https://redhat.atlassian.net/browse/LOG-9220)

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes generated Loki Ruler config and StatefulSet pod env when RemoteWrite is enabled, which can affect metric label sets and remote-write behavior. Scope is limited and covered by new unit tests.
> 
> **Overview**
> When Ruler `RemoteWrite` is enabled, the operator now appends a `write_relabel_configs` rule that sets `__replica__` to `${POD_NAME}` so metrics from multiple rulers can be deduplicated.
> 
> To support env expansion, the Ruler StatefulSet is updated to inject a `POD_NAME` env var (from `metadata.name`) into the container only when RemoteWrite is enabled, and new tests validate both the rendered YAML and the pod spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 975b7090f3611ca8f172a67f7c1ebf059f9a01d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->