### PR TITLE
fix(operator): Fix RemoteWriteAuthType CEL validation in RulerConfig

### DIFF
--- a/operator/api/loki/v1/rulerconfig_types.go
+++ b/operator/api/loki/v1/rulerconfig_types.go
@@ -232,7 +232,7 @@ type AlertManagerClientTLSConfig struct {
 
 // RemoteWriteAuthType defines the type of authorization to use to access the remote write endpoint.
 //
-// +kubebuilder:validation:Enum=basic;header
+// +kubebuilder:validation:Enum=basic;bearer
 type RemoteWriteAuthType string
 
 const (
@@ -270,7 +270,7 @@ type RemoteWriteClientSpec struct {
 	//
 	// +required
 	// +kubebuilder:validation:Required
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:basic","urn:alm:descriptor:com.tectonic.ui:select:header"},displayName="Authorization Type"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:basic","urn:alm:descriptor:com.tectonic.ui:select:bearer"},displayName="Authorization Type"
 	AuthorizationType RemoteWriteAuthType `json:"authorization"`
 
 	// Name of a secret in the namespace configured for authorization secrets.

--- a/operator/api/loki/v1beta1/rulerconfig_types.go
+++ b/operator/api/loki/v1beta1/rulerconfig_types.go
@@ -227,7 +227,7 @@ type AlertManagerClientTLSConfig struct {
 
 // RemoteWriteAuthType defines the type of authorization to use to access the remote write endpoint.
 //
-// +kubebuilder:validation:Enum=basic;header
+// +kubebuilder:validation:Enum=basic;bearer
 type RemoteWriteAuthType string
 
 const (
@@ -265,7 +265,7 @@ type RemoteWriteClientSpec struct {
 	//
 	// +required
 	// +kubebuilder:validation:Required
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:basic","urn:alm:descriptor:com.tectonic.ui:select:header"},displayName="Authorization Type"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:basic","urn:alm:descriptor:com.tectonic.ui:select:bearer"},displayName="Authorization Type"
 	AuthorizationType RemoteWriteAuthType `json:"authorization"`
 
 	// Name of a secret in the namespace configured for authorization secrets.

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -152,7 +152,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing, Observability
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.10.1
-    createdAt: "2026-04-10T16:58:37Z"
+    createdAt: "2026-04-23T11:43:22Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     features.operators.openshift.io/disconnected: "true"
@@ -1565,7 +1565,7 @@ spec:
         path: remoteWrite.client.authorization
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:basic
-        - urn:alm:descriptor:com.tectonic.ui:select:header
+        - urn:alm:descriptor:com.tectonic.ui:select:bearer
       - description: Name of a secret in the namespace configured for authorization
           secrets.
         displayName: Authorization Secret Name

--- a/operator/bundle/community-openshift/manifests/loki.grafana.com_rulerconfigs.yaml
+++ b/operator/bundle/community-openshift/manifests/loki.grafana.com_rulerconfigs.yaml
@@ -486,7 +486,7 @@ spec:
                           write endpoint
                         enum:
                         - basic
-                        - header
+                        - bearer
                         type: string
                       authorizationSecretName:
                         description: Name of a secret in the namespace configured
@@ -1143,7 +1143,7 @@ spec:
                           write endpoint
                         enum:
                         - basic
-                        - header
+                        - bearer
                         type: string
                       authorizationSecretName:
                         description: Name of a secret in the namespace configured

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -152,7 +152,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing, Observability
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.10.1
-    createdAt: "2026-04-10T16:58:36Z"
+    createdAt: "2026-04-23T11:43:19Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown
@@ -1558,7 +1558,7 @@ spec:
         path: remoteWrite.client.authorization
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:basic
-        - urn:alm:descriptor:com.tectonic.ui:select:header
+        - urn:alm:descriptor:com.tectonic.ui:select:bearer
       - description: Name of a secret in the namespace configured for authorization
           secrets.
         displayName: Authorization Secret Name

--- a/operator/bundle/community/manifests/loki.grafana.com_rulerconfigs.yaml
+++ b/operator/bundle/community/manifests/loki.grafana.com_rulerconfigs.yaml
@@ -487,7 +487,7 @@ spec:
                           write endpoint
                         enum:
                         - basic
-                        - header
+                        - bearer
                         type: string
                       authorizationSecretName:
                         description: Name of a secret in the namespace configured
@@ -1144,7 +1144,7 @@ spec:
                           write endpoint
                         enum:
                         - basic
-                        - header
+                        - bearer
                         type: string
                       authorizationSecretName:
                         description: Name of a secret in the namespace configured

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -152,7 +152,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing, Observability
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:0.1.0
-    createdAt: "2026-04-10T16:58:38Z"
+    createdAt: "2026-04-23T11:43:25Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements
@@ -1578,7 +1578,7 @@ spec:
         path: remoteWrite.client.authorization
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:basic
-        - urn:alm:descriptor:com.tectonic.ui:select:header
+        - urn:alm:descriptor:com.tectonic.ui:select:bearer
       - description: Name of a secret in the namespace configured for authorization
           secrets.
         displayName: Authorization Secret Name

--- a/operator/bundle/openshift/manifests/loki.grafana.com_rulerconfigs.yaml
+++ b/operator/bundle/openshift/manifests/loki.grafana.com_rulerconfigs.yaml
@@ -486,7 +486,7 @@ spec:
                           write endpoint
                         enum:
                         - basic
-                        - header
+                        - bearer
                         type: string
                       authorizationSecretName:
                         description: Name of a secret in the namespace configured
@@ -1143,7 +1143,7 @@ spec:
                           write endpoint
                         enum:
                         - basic
-                        - header
+                        - bearer
                         type: string
                       authorizationSecretName:
                         description: Name of a secret in the namespace configured

--- a/operator/config/crd/bases/loki.grafana.com_rulerconfigs.yaml
+++ b/operator/config/crd/bases/loki.grafana.com_rulerconfigs.yaml
@@ -468,7 +468,7 @@ spec:
                           write endpoint
                         enum:
                         - basic
-                        - header
+                        - bearer
                         type: string
                       authorizationSecretName:
                         description: Name of a secret in the namespace configured
@@ -1125,7 +1125,7 @@ spec:
                           write endpoint
                         enum:
                         - basic
-                        - header
+                        - bearer
                         type: string
                       authorizationSecretName:
                         description: Name of a secret in the namespace configured

--- a/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
@@ -1968,7 +1968,7 @@ spec:
         path: remoteWrite.client.authorization
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:basic
-        - urn:alm:descriptor:com.tectonic.ui:select:header
+        - urn:alm:descriptor:com.tectonic.ui:select:bearer
       - description: Name of a secret in the namespace configured for authorization
           secrets.
         displayName: Authorization Secret Name
@@ -2412,7 +2412,7 @@ spec:
         path: remoteWrite.client.authorization
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:basic
-        - urn:alm:descriptor:com.tectonic.ui:select:header
+        - urn:alm:descriptor:com.tectonic.ui:select:bearer
       - description: Name of a secret in the namespace configured for authorization
           secrets.
         displayName: Authorization Secret Name

--- a/operator/config/manifests/community/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/community/bases/loki-operator.clusterserviceversion.yaml
@@ -1961,7 +1961,7 @@ spec:
         path: remoteWrite.client.authorization
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:basic
-        - urn:alm:descriptor:com.tectonic.ui:select:header
+        - urn:alm:descriptor:com.tectonic.ui:select:bearer
       - description: Name of a secret in the namespace configured for authorization
           secrets.
         displayName: Authorization Secret Name
@@ -2405,7 +2405,7 @@ spec:
         path: remoteWrite.client.authorization
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:basic
-        - urn:alm:descriptor:com.tectonic.ui:select:header
+        - urn:alm:descriptor:com.tectonic.ui:select:bearer
       - description: Name of a secret in the namespace configured for authorization
           secrets.
         displayName: Authorization Secret Name

--- a/operator/config/manifests/openshift/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/openshift/bases/loki-operator.clusterserviceversion.yaml
@@ -1980,7 +1980,7 @@ spec:
         path: remoteWrite.client.authorization
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:basic
-        - urn:alm:descriptor:com.tectonic.ui:select:header
+        - urn:alm:descriptor:com.tectonic.ui:select:bearer
       - description: Name of a secret in the namespace configured for authorization
           secrets.
         displayName: Authorization Secret Name
@@ -2424,7 +2424,7 @@ spec:
         path: remoteWrite.client.authorization
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:basic
-        - urn:alm:descriptor:com.tectonic.ui:select:header
+        - urn:alm:descriptor:com.tectonic.ui:select:bearer
       - description: Name of a secret in the namespace configured for authorization
           secrets.
         displayName: Authorization Secret Name


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix all references of both kubebuilder validation enum and the +operator-sdk:csv:customresourcedefinitions xDescriptors annotation for RemoteWriteAuthType to use "bearer" instead of "header"

**Which issue(s) this PR fixes**:
Fixes [LOG-9002](https://redhat.atlassian.net/browse/LOG-9002)

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CRD validation/CSV descriptors to replace the `header` auth option with `bearer`, which may cause existing `RulerConfig` resources using `header` to fail validation after upgrade. Scope is limited to API schema and generated bundle/CRD manifests (no runtime logic changes).
> 
> **Overview**
> Fixes the `RemoteWriteAuthType` schema for `RulerConfig` remote-write by replacing the invalid `header` enum/console descriptor with `bearer` in both `v1` and `v1beta1` API types.
> 
> Regenerates CRD and Operator Lifecycle Manager bundle manifests so the published CRD schema (`rulerconfigs`) and CSV UI descriptors now advertise/validate `basic` or `bearer` (and updates bundle `createdAt` timestamps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 265602cb40e2edd74902866a6e3808867282bc8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->