### PR TITLE
fix(operator): Replace local pkg/push dependency with published module

### DIFF
--- a/operator/go.mod
+++ b/operator/go.mod
@@ -223,5 +223,3 @@ replace github.com/grafana/loki/operator/api/loki => ./api/loki
 // merged upstream yet.
 // See: https://github.com/grafana/loki/blob/main/go.mod#L477-L479
 replace github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86
-
-replace github.com/grafana/loki/pkg/push => ../pkg/push

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -245,6 +245,8 @@ github.com/grafana/gomemcache v0.0.0-20251127154401-74f93547077b h1:5qp8/5YPt/Z2
 github.com/grafana/gomemcache v0.0.0-20251127154401-74f93547077b/go.mod h1:j/s0jkda4UXTemDs7Pgw/vMT06alWc42CHisvYac0qw=
 github.com/grafana/jsonparser v0.0.0-20241004153430-023329977675 h1:U94jQ2TQr1m3HNyE8efSdyaBbDrdPaWImXyenuKZ/nw=
 github.com/grafana/jsonparser v0.0.0-20241004153430-023329977675/go.mod h1:796sq+UcONnSlzA3RtlBZ+b/hrerkZXiEmO8oMjyRwY=
+github.com/grafana/loki/pkg/push v0.0.0-20250630054201-94c0ba7b0952 h1:rLzoJGDnoXsZV2j/2atL6OVk9AHluTbDOD8Ls9trtIA=
+github.com/grafana/loki/pkg/push v0.0.0-20250630054201-94c0ba7b0952/go.mod h1:ny/0bFitf8KNZkZfweaI4hmwb5XPhaFD2d0kVcyKmjo=
 github.com/grafana/loki/v3 v3.7.1 h1:Nw1TV8uHtiB6bkO9210kvHjewtgCyZtSippj7X42+O4=
 github.com/grafana/loki/v3 v3.7.1/go.mod h1:PSxKUN/jECwG9TXInjnX8Kh8wbUvM280ncwtE7ATTR4=
 github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86 h1:aTwfQuroOmOr//QEn9J1MtC4R4CPR9/IbUd8hZrbWKo=


### PR DESCRIPTION
**What this PR does / why we need it**:

Broken by https://github.com/grafana/loki/pull/21472

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency management change limited to the operator module; main risk is build/reproducibility differences from switching `pkg/push` from a local replace to a pinned published version.
> 
> **Overview**
> Stops using a local `replace` for `github.com/grafana/loki/pkg/push` in the operator and instead pulls `pkg/push` as a published Go module at a specific pseudo-version.
> 
> Updates `operator/go.sum` accordingly, making operator builds independent of a sibling checkout layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1726fbdc233cbc273cd48a05ed64c012d49f241d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->