### PR TITLE
chore: Pin Alloy versions in Helm tests

### DIFF
--- a/production/helm/loki/test/integration/distributed-advanced/log-generator.yaml
+++ b/production/helm/loki/test/integration/distributed-advanced/log-generator.yaml
@@ -18,6 +18,7 @@ spec:
   chart:
     spec:
       chart: alloy
+      version: 1.7.0
       sourceRef:
         kind: HelmRepository
         name: grafana

--- a/production/helm/loki/test/integration/single-binary/log-generator.yaml
+++ b/production/helm/loki/test/integration/single-binary/log-generator.yaml
@@ -18,6 +18,7 @@ spec:
   chart:
     spec:
       chart: alloy
+      version: 1.7.0
       sourceRef:
         kind: HelmRepository
         name: grafana

--- a/production/helm/loki/test/integration/ssd/log-generator.yaml
+++ b/production/helm/loki/test/integration/ssd/log-generator.yaml
@@ -18,6 +18,7 @@ spec:
   chart:
     spec:
       chart: alloy
+      version: 1.7.0
       sourceRef:
         kind: HelmRepository
         name: grafana


### PR DESCRIPTION
**What this PR does / why we need it**:
I'm trying to release the GEL Helm chart, and checks are failing.  I consulted both CoPilot and Claude, and got the same answer as to why the tests were failing.

 Root cause: The log-generator.yaml integration test files reference the alloy Helm chart 
  from https://grafana.github.io/helm-charts without pinning a version. FluxCD resolves to 
  the latest listed version (1.8.0), but the download URL                                  
  https://github.com/grafana/helm-charts/releases/download/alloy-1.8.0/alloy-1.8.0.tgz     
  returns a 404 — the chart appears in the index but the release artifact was never        
  published.

  Fix: Added version: 1.7.0 to the chart spec in all three log-generator.yaml files (ssd/, 
  distributed-advanced/, single-binary/). Version 1.7.0 is confirmed to exist in the GitHub
   releases (verified the redirect resolves correctly). 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only HelmRelease manifests now pin a specific chart version, reducing CI flakiness without changing runtime application logic.
> 
> **Overview**
> Pins the `alloy` Helm chart to `version: 1.7.0` in the Loki integration test `log-generator.yaml` HelmReleases (distributed-advanced, single-binary, and ssd) so Flux doesn’t resolve to a newer, missing release artifact during CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f466bbacc90c5cb02d05ec57efe6a7c900ea2b28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->