### PR TITLE
chore(aggregation): Without grouping should be performed on shortnames and sorted columns

### DIFF
--- a/pkg/engine/internal/executor/grouping.go
+++ b/pkg/engine/internal/executor/grouping.go
@@ -134,7 +134,10 @@ func collectWithoutGroupingColumns(record arrow.RecordBatch, grouping physical.G
 func isGroupingCandidate(columnType types.ColumnType) bool {
 	return columnType == types.ColumnTypeLabel ||
 		columnType == types.ColumnTypeMetadata ||
-		columnType == types.ColumnTypeParsed
+		columnType == types.ColumnTypeParsed ||
+		// aggregation node downstream of another aggregation node may
+		// receive grouping keys with ambiguous type.
+		columnType == types.ColumnTypeAmbiguous
 }
 
 func identMatchesGrouping(grouping []physical.ColumnExpression, ident *semconv.Identifier) (bool, error) {

--- a/pkg/engine/internal/executor/grouping.go
+++ b/pkg/engine/internal/executor/grouping.go
@@ -1,0 +1,159 @@
+package executor
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/semconv"
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+)
+
+func collectGroupingColumns(record arrow.RecordBatch, grouping physical.Grouping, evaluator *expressionEvaluator, identCache *semconv.IdentifierCache) ([]*array.String, []arrow.Field, error) {
+	if grouping.Without {
+		return collectWithoutGroupingColumns(record, grouping, identCache)
+	}
+	return collectByGroupingColumns(record, grouping, evaluator)
+}
+
+func collectByGroupingColumns(record arrow.RecordBatch, grouping physical.Grouping, evaluator *expressionEvaluator) ([]*array.String, []arrow.Field, error) {
+	arrays := make([]*array.String, 0, len(grouping.Columns))
+	fields := make([]arrow.Field, 0, len(grouping.Columns))
+
+	for _, columnExpr := range grouping.Columns {
+		arr, err := evaluator.evalForGrouping(columnExpr, record)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if arr.DataType().ID() != types.Arrow.String.ID() {
+			return nil, nil, fmt.Errorf("unsupported datatype for grouping %s", arr.DataType())
+		}
+
+		arrays = append(arrays, arr.(*array.String))
+
+		colExpr, ok := columnExpr.(*physical.ColumnExpr)
+		if !ok {
+			return nil, nil, fmt.Errorf("invalid column expression type %T", columnExpr)
+		}
+		ident := semconv.NewIdentifier(colExpr.Ref.Column, colExpr.Ref.Type, types.Loki.String)
+		fields = append(fields, semconv.FieldFromIdent(ident, true))
+	}
+
+	return arrays, fields, nil
+}
+
+// collectWithoutGroupingColumns collects columns from the input record excluding
+// those that match the grouping expressions.
+//
+// The returned fields & arrays are sorted in the order of their column names.
+// Sorting is necessary to ensure that the grouping keys are in the same order
+// irrespective of the order of columns in the input record.
+//
+// And columns with the same short name are coalesced into a single array.
+// Without this, columns with same short name but different [types.ColumnType]
+// would be treated as separate grouping keys, which is not the intended behavior.
+func collectWithoutGroupingColumns(record arrow.RecordBatch, grouping physical.Grouping, identCache *semconv.IdentifierCache) ([]*array.String, []arrow.Field, error) {
+	shortNames := make([]string, 0)
+	columns := make(map[string][]*columnWithType)
+
+	for i, field := range record.Schema().Fields() {
+		ident, err := identCache.ParseFQN(field.Name)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if !isGroupingCandidate(ident.ColumnType()) {
+			continue
+		}
+
+		match, err := identMatchesGrouping(grouping.Columns, ident)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// exclude columns that match `without` grouping keys
+		if match {
+			continue
+		}
+
+		arr, ok := record.Column(i).(*array.String)
+		if !ok {
+			return nil, nil, fmt.Errorf("unsupported datatype for grouping %s", record.Column(i).DataType())
+		}
+
+		shortName := ident.ShortName()
+		if _, exists := columns[shortName]; !exists {
+			shortNames = append(shortNames, shortName)
+		}
+
+		columns[shortName] = append(columns[shortName], &columnWithType{
+			col: arr,
+			ct:  ident.ColumnType(),
+		})
+	}
+
+	// sort names to ensure deterministic order of grouping keys.
+	// input records may have columns in any order.
+	slices.Sort(shortNames)
+
+	arrays := make([]*array.String, 0, len(shortNames))
+	fields := make([]arrow.Field, 0, len(shortNames))
+	for _, shortName := range shortNames {
+		cols := columns[shortName]
+
+		var arr arrow.Array
+		if len(cols) == 1 {
+			arr = cols[0].col
+		} else {
+			arr = NewCoalesce(cols)
+		}
+
+		arrays = append(arrays, arr.(*array.String))
+
+		// always set to ambiguous type.
+		// Imagine two records with the same short name but different types.
+		// Record 1 has `utf8.label.env`
+		// Record 2 has `utf8.metadata.env`
+		//
+		// If the original type is preserved, aggregation will treat them
+		// as different groups, which is not the intended behavior.
+		//
+		// TODO: aggregator.go should be updated to use short names
+		// instead of full identifiers for grouping keys.
+		ident := semconv.NewIdentifier(shortName, types.ColumnTypeAmbiguous, types.Loki.String)
+		fields = append(fields, semconv.FieldFromIdent(ident, true))
+	}
+
+	return arrays, fields, nil
+}
+
+func isGroupingCandidate(columnType types.ColumnType) bool {
+	return columnType == types.ColumnTypeLabel ||
+		columnType == types.ColumnTypeMetadata ||
+		columnType == types.ColumnTypeParsed
+}
+
+func identMatchesGrouping(grouping []physical.ColumnExpression, ident *semconv.Identifier) (bool, error) {
+	for _, g := range grouping {
+		colExpr, ok := g.(*physical.ColumnExpr)
+		if !ok {
+			return false, fmt.Errorf("unknown column expression %v", g)
+		}
+
+		// Match ambiguous columns only by name.
+		if colExpr.Ref.Type == types.ColumnTypeAmbiguous && colExpr.Ref.Column == ident.ShortName() {
+			return true, nil
+		}
+
+		// Match all other columns by name and type.
+		if colExpr.Ref.Column == ident.ShortName() && colExpr.Ref.Type == ident.ColumnType() {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -185,70 +185,9 @@ func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch,
 
 			assertions.CheckLabelValuesDuplicates(record)
 
-			// extract all the columns that are used for grouping
-			var arrays []*array.String
-			var groupingFields []arrow.Field
-			if r.opts.grouping.Without {
-				// Grouping without a lable set. Exclude lables from that set.
-				schema := record.Schema()
-				for i, field := range schema.Fields() {
-					ident, err := r.identCache.ParseFQN(field.Name)
-					if err != nil {
-						return nil, err
-					}
-
-					if ident.ColumnType() == types.ColumnTypeLabel ||
-						ident.ColumnType() == types.ColumnTypeMetadata ||
-						ident.ColumnType() == types.ColumnTypeParsed {
-						found := false
-						for _, g := range r.opts.grouping.Columns {
-							colExpr, ok := g.(*physical.ColumnExpr)
-							if !ok {
-								return nil, fmt.Errorf("unknown column expression %v", g)
-							}
-
-							// Match ambiguous columns only by name
-							if colExpr.Ref.Type == types.ColumnTypeAmbiguous && colExpr.Ref.Column == ident.ShortName() {
-								found = true
-								break
-							}
-
-							// Match all other columns by name and type
-							if colExpr.Ref.Column == ident.ShortName() && colExpr.Ref.Type == ident.ColumnType() {
-								found = true
-								break
-							}
-						}
-						if !found {
-							arrays = append(arrays, record.Column(i).(*array.String))
-							groupingFields = append(groupingFields, field)
-						}
-					}
-				}
-			} else {
-				groupingFields = make([]arrow.Field, 0, len(r.opts.grouping.Columns))
-
-				// Gouping by a label set. Take only labels from that set.
-				for _, columnExpr := range r.opts.grouping.Columns {
-					vec, err := r.evaluator.evalForGrouping(columnExpr, record)
-					if err != nil {
-						return nil, err
-					}
-
-					if vec.DataType().ID() != types.Arrow.String.ID() {
-						return nil, fmt.Errorf("unsupported datatype for grouping %s", vec.DataType())
-					}
-
-					arr := vec.(*array.String)
-					arrays = append(arrays, arr)
-
-					colExpr, ok := columnExpr.(*physical.ColumnExpr)
-					if !ok {
-						return nil, fmt.Errorf("invalid column expression type %T", columnExpr)
-					}
-					ident := semconv.NewIdentifier(colExpr.Ref.Column, colExpr.Ref.Type, types.Loki.String)
-					groupingFields = append(groupingFields, semconv.FieldFromIdent(ident, true))
-				}
+			arrays, groupingFields, err := collectGroupingColumns(record, r.opts.grouping, r.evaluator, r.identCache)
+			if err != nil {
+				return nil, err
 			}
 
 			r.aggregator.AddLabels(groupingFields)

--- a/pkg/engine/internal/executor/range_aggregation_test.go
+++ b/pkg/engine/internal/executor/range_aggregation_test.go
@@ -784,6 +784,244 @@ func TestRangeAggregationPipeline_MissingGroupingColumn(t *testing.T) {
 	require.ElementsMatch(t, expect, result)
 }
 
+// TestRangeAggregationPipeline_WithoutGroupsByShortName verifies that "without"
+// grouping works correctly when columns across records or multiple columns within
+// a record have the same short name but different FQNs.
+//
+// Take the following records with the same short name "status" column:
+//
+//	Record 1: `utf8.label.status`
+//	Record 2: `utf8.metadata.status`
+//	Record 3: both `utf8.label.status` and `utf8.metadata.status`
+//
+// These should be considered as `utf8.ambiguous.status` when grouping.
+// For record 3, [NewCoalesce] is used to resolve precedence between the two columns.
+func TestRangeAggregationPipeline_WithoutGroupsByShortName(t *testing.T) {
+	const (
+		fqnEnv            = "utf8.label.env"
+		fqnService        = "utf8.label.service"
+		fqnLabelStatus    = "utf8.label.status"
+		fqnMetadataStatus = "utf8.metadata.status"
+	)
+
+	startTs := time.Unix(20, 0).UTC()
+	endTs := time.Unix(30, 0).UTC()
+
+	schemaA := arrow.NewSchema([]arrow.Field{
+		semconv.FieldFromFQN(colTs, false),
+		semconv.FieldFromFQN(fqnService, true),
+		semconv.FieldFromFQN(fqnLabelStatus, true),
+		semconv.FieldFromFQN(fqnEnv, true),
+	}, nil)
+
+	schemaB := arrow.NewSchema([]arrow.Field{
+		semconv.FieldFromFQN(colTs, false),
+		semconv.FieldFromFQN(fqnEnv, true),
+		semconv.FieldFromFQN(fqnService, true),
+		semconv.FieldFromFQN(fqnMetadataStatus, true),
+	}, nil)
+
+	schemaC := arrow.NewSchema([]arrow.Field{
+		semconv.FieldFromFQN(colTs, false),
+		semconv.FieldFromFQN(fqnMetadataStatus, true),
+		semconv.FieldFromFQN(fqnService, true),
+		semconv.FieldFromFQN(fqnLabelStatus, true),
+		semconv.FieldFromFQN(fqnEnv, true),
+	}, nil)
+
+	rowsA := arrowtest.Rows{
+		{colTs: time.Unix(19, 0).UTC(), fqnService: nil, fqnLabelStatus: "200", fqnEnv: "prod"},   // out ts: 20
+		{colTs: time.Unix(20, 0).UTC(), fqnService: "api", fqnLabelStatus: "500", fqnEnv: "prod"}, // out ts: 20
+		{colTs: time.Unix(29, 0).UTC(), fqnService: nil, fqnLabelStatus: "200", fqnEnv: "prod"},   // out ts: 30
+		{colTs: time.Unix(30, 0).UTC(), fqnService: "api", fqnLabelStatus: "500", fqnEnv: "prod"}, // out ts: 30
+	}
+
+	rowsB := arrowtest.Rows{
+		{colTs: time.Unix(18, 0).UTC(), fqnEnv: "prod", fqnService: nil, fqnMetadataStatus: "200"},   // out ts: 20
+		{colTs: time.Unix(20, 0).UTC(), fqnEnv: "prod", fqnService: "api", fqnMetadataStatus: "500"}, // out ts: 20
+		{colTs: time.Unix(28, 0).UTC(), fqnEnv: "prod", fqnService: nil, fqnMetadataStatus: "200"},   // out ts: 30
+		{colTs: time.Unix(30, 0).UTC(), fqnEnv: "prod", fqnService: "api", fqnMetadataStatus: "500"}, // out ts: 30
+	}
+
+	rowsC := arrowtest.Rows{
+		{colTs: time.Unix(17, 0).UTC(), fqnMetadataStatus: "200", fqnService: nil, fqnLabelStatus: nil, fqnEnv: "prod"},   // out ts: 20
+		{colTs: time.Unix(20, 0).UTC(), fqnMetadataStatus: nil, fqnService: "api", fqnLabelStatus: "500", fqnEnv: "prod"}, // out ts: 20
+		{colTs: time.Unix(27, 0).UTC(), fqnMetadataStatus: nil, fqnService: nil, fqnLabelStatus: "200", fqnEnv: "prod"},   // out ts: 30
+		{colTs: time.Unix(30, 0).UTC(), fqnMetadataStatus: "500", fqnService: "api", fqnLabelStatus: nil, fqnEnv: "prod"}, // out ts: 30
+	}
+
+	opts := rangeAggregationOptions{
+		grouping: physical.Grouping{
+			Columns: []physical.ColumnExpression{
+				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "env", Type: types.ColumnTypeAmbiguous}},
+			},
+			Without: true,
+		},
+		startTs:       startTs,
+		endTs:         endTs,
+		rangeInterval: 10 * time.Second,
+		step:          10 * time.Second,
+		operation:     types.RangeAggregationTypeCount,
+	}
+
+	inputA := NewArrowtestPipeline(schemaA, rowsA)
+	inputB := NewArrowtestPipeline(schemaB, rowsB)
+	inputC := NewArrowtestPipeline(schemaC, rowsC)
+
+	pipeline, err := newRangeAggregationPipeline([]Pipeline{inputA, inputB, inputC}, newExpressionEvaluator(), opts)
+	require.NoError(t, err)
+	defer pipeline.Close()
+
+	record, err := pipeline.Read(t.Context())
+	require.NoError(t, err)
+
+	result, err := arrowtest.RecordRows(record)
+	require.NoError(t, err)
+
+	expect := arrowtest.Rows{
+		{
+			colTs:                    startTs,
+			colVal:                   float64(3),
+			"utf8.ambiguous.service": nil,
+			"utf8.ambiguous.status":  "200",
+		},
+		{
+			colTs:                    startTs,
+			colVal:                   float64(3),
+			"utf8.ambiguous.service": "api",
+			"utf8.ambiguous.status":  "500",
+		},
+		{
+			colTs:                    endTs,
+			colVal:                   float64(3),
+			"utf8.ambiguous.service": nil,
+			"utf8.ambiguous.status":  "200",
+		},
+		{
+			colTs:                    endTs,
+			colVal:                   float64(3),
+			"utf8.ambiguous.service": "api",
+			"utf8.ambiguous.status":  "500",
+		},
+	}
+
+	require.Equal(t, len(expect), len(result))
+	require.ElementsMatch(t, expect, result)
+}
+
+// TestRangeAggregationPipeline_WithoutSortsColumns verifies that "without" grouping
+// works correctly when columns are in different order across records.
+// They should be sorted by short name before calling the aggregator.
+func TestRangeAggregationPipeline_WithoutSortsColumns(t *testing.T) {
+	const (
+		fqnEnv     = "utf8.label.env"
+		fqnService = "utf8.label.service"
+		fqnStatus  = "utf8.label.status"
+	)
+
+	startTs := time.Unix(20, 0).UTC()
+	endTs := time.Unix(30, 0).UTC()
+
+	schemaA := arrow.NewSchema([]arrow.Field{
+		semconv.FieldFromFQN(colTs, false),
+		semconv.FieldFromFQN(fqnService, true),
+		semconv.FieldFromFQN(fqnStatus, true),
+		semconv.FieldFromFQN(fqnEnv, true),
+	}, nil)
+
+	// different column order to schemaA
+	schemaB := arrow.NewSchema([]arrow.Field{
+		semconv.FieldFromFQN(colTs, false),
+		semconv.FieldFromFQN(fqnEnv, true),
+		semconv.FieldFromFQN(fqnStatus, true),
+		semconv.FieldFromFQN(fqnService, true),
+	}, nil)
+
+	// missing "service" column
+	schemaC := arrow.NewSchema([]arrow.Field{
+		semconv.FieldFromFQN(colTs, false),
+		semconv.FieldFromFQN(fqnStatus, true),
+		semconv.FieldFromFQN(fqnEnv, true),
+	}, nil)
+
+	rowsA := arrowtest.Rows{
+		{colTs: time.Unix(19, 0).UTC(), fqnService: nil, fqnStatus: "200", fqnEnv: "prod"},   // out ts: 20
+		{colTs: time.Unix(20, 0).UTC(), fqnService: "api", fqnStatus: "500", fqnEnv: "prod"}, // out ts: 20
+		{colTs: time.Unix(29, 0).UTC(), fqnService: nil, fqnStatus: "200", fqnEnv: "prod"},   // out ts: 30
+		{colTs: time.Unix(30, 0).UTC(), fqnService: "api", fqnStatus: "500", fqnEnv: "prod"}, // out ts: 30
+	}
+
+	rowsB := arrowtest.Rows{
+		{colTs: time.Unix(18, 0).UTC(), fqnEnv: "prod", fqnStatus: "200", fqnService: nil},   // out ts: 20
+		{colTs: time.Unix(20, 0).UTC(), fqnEnv: "prod", fqnStatus: "500", fqnService: "api"}, // out ts: 20
+		{colTs: time.Unix(28, 0).UTC(), fqnEnv: "prod", fqnStatus: "200", fqnService: nil},   // out ts: 30
+		{colTs: time.Unix(30, 0).UTC(), fqnEnv: "prod", fqnStatus: "500", fqnService: "api"}, // out ts: 30
+	}
+
+	rowsC := arrowtest.Rows{
+		{colTs: time.Unix(17, 0).UTC(), fqnStatus: "200", fqnEnv: "prod"}, // out ts: 20
+		{colTs: time.Unix(27, 0).UTC(), fqnStatus: "200", fqnEnv: "prod"}, // out ts: 30
+	}
+
+	opts := rangeAggregationOptions{
+		grouping: physical.Grouping{
+			Columns: []physical.ColumnExpression{
+				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "env", Type: types.ColumnTypeAmbiguous}},
+			},
+			Without: true,
+		},
+		startTs:       startTs,
+		endTs:         endTs,
+		rangeInterval: 10 * time.Second,
+		step:          10 * time.Second,
+		operation:     types.RangeAggregationTypeCount,
+	}
+
+	inputA := NewArrowtestPipeline(schemaA, rowsA)
+	inputB := NewArrowtestPipeline(schemaB, rowsB)
+	inputC := NewArrowtestPipeline(schemaC, rowsC)
+
+	pipeline, err := newRangeAggregationPipeline([]Pipeline{inputA, inputB, inputC}, newExpressionEvaluator(), opts)
+	require.NoError(t, err)
+	defer pipeline.Close()
+
+	record, err := pipeline.Read(t.Context())
+	require.NoError(t, err)
+
+	result, err := arrowtest.RecordRows(record)
+	require.NoError(t, err)
+
+	expect := arrowtest.Rows{
+		{
+			colTs:                    startTs,
+			colVal:                   float64(3),
+			"utf8.ambiguous.service": nil,
+			"utf8.ambiguous.status":  "200",
+		},
+		{
+			colTs:                    startTs,
+			colVal:                   float64(2),
+			"utf8.ambiguous.service": "api",
+			"utf8.ambiguous.status":  "500",
+		},
+		{
+			colTs:                    endTs,
+			colVal:                   float64(3),
+			"utf8.ambiguous.service": nil,
+			"utf8.ambiguous.status":  "200",
+		},
+		{
+			colTs:                    endTs,
+			colVal:                   float64(2),
+			"utf8.ambiguous.service": "api",
+			"utf8.ambiguous.status":  "500",
+		},
+	}
+
+	require.Equal(t, len(expect), len(result))
+	require.ElementsMatch(t, expect, result)
+}
+
 // requireEqualWindows asserts that two slices of window structs contain the same elements.
 func requireEqualWindows(t *testing.T, expected, actual []window) {
 	t.Helper()

--- a/pkg/engine/internal/executor/vector_aggregate.go
+++ b/pkg/engine/internal/executor/vector_aggregate.go
@@ -153,69 +153,9 @@ func (v *vectorAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch
 			}
 			valueArr := valueVec.(*array.Float64)
 
-			// extract all the columns that are used for grouping
-			var arrays []*array.String
-			var groupingFields []arrow.Field
-
-			if v.grouping.Without {
-				// Grouping without a lable set. Exclude lables from that set.
-				schema := record.Schema()
-				for i, field := range schema.Fields() {
-					ident, err := v.identCache.ParseFQN(field.Name)
-					if err != nil {
-						return nil, err
-					}
-
-					if ident.ColumnType() == types.ColumnTypeLabel ||
-						ident.ColumnType() == types.ColumnTypeMetadata ||
-						ident.ColumnType() == types.ColumnTypeParsed {
-						found := false
-						for _, g := range v.grouping.Columns {
-							colExpr, ok := g.(*physical.ColumnExpr)
-							if !ok {
-								return nil, fmt.Errorf("unknown column expression %v", g)
-							}
-
-							// Match ambiguous columns only by name
-							if colExpr.Ref.Type == types.ColumnTypeAmbiguous && colExpr.Ref.Column == ident.ShortName() {
-								found = true
-								break
-							}
-
-							// Match all other columns by name and type
-							if colExpr.Ref.Column == ident.ShortName() && colExpr.Ref.Type == ident.ColumnType() {
-								found = true
-								break
-							}
-						}
-						if !found {
-							arrays = append(arrays, record.Column(i).(*array.String))
-							groupingFields = append(groupingFields, field)
-						}
-					}
-				}
-			} else {
-				// Gouping by a label set. Take only labels from that set.
-				for _, columnExpr := range v.grouping.Columns {
-					vec, err := v.evaluator.evalForGrouping(columnExpr, record)
-					if err != nil {
-						return nil, err
-					}
-
-					if vec.DataType().ID() != types.Arrow.String.ID() {
-						return nil, fmt.Errorf("unsupported datatype for grouping %s", vec.DataType())
-					}
-
-					arr := vec.(*array.String)
-					arrays = append(arrays, arr)
-
-					colExpr, ok := columnExpr.(*physical.ColumnExpr)
-					if !ok {
-						return nil, fmt.Errorf("invalid column expression type %T", columnExpr)
-					}
-					ident := semconv.NewIdentifier(colExpr.Ref.Column, colExpr.Ref.Type, types.Loki.String)
-					groupingFields = append(groupingFields, semconv.FieldFromIdent(ident, true))
-				}
+			arrays, groupingFields, err := collectGroupingColumns(record, v.grouping, v.evaluator, v.identCache)
+			if err != nil {
+				return nil, err
 			}
 
 			v.aggregator.AddLabels(groupingFields)

--- a/pkg/engine/internal/executor/vector_aggregate_test.go
+++ b/pkg/engine/internal/executor/vector_aggregate_test.go
@@ -224,3 +224,209 @@ func TestVectorAggregationPipeline_MissingGroupingColumn(t *testing.T) {
 	require.Equal(t, len(expect), len(result), "absent grouping column must not split series into separate streams")
 	require.ElementsMatch(t, expect, result)
 }
+
+// TestVectorAggregationPipeline_WithoutGroupsByShortName verifies that "without"
+// grouping works correctly when columns across records or multiple columns within
+// a record have the same short name but different FQNs.
+//
+// Take the following records with the same short name "status" column:
+//
+//	Record 1: `utf8.label.status`
+//	Record 2: `utf8.metadata.status`
+//	Record 3: both `utf8.label.status` and `utf8.metadata.status`
+//
+// These should be considered as `utf8.ambiguous.status` when grouping.
+// For record 3, [NewCoalesce] is used to resolve precedence between the two columns.
+func TestVectorAggregationPipeline_WithoutGroupsByShortName(t *testing.T) {
+	const (
+		fqnEnv            = "utf8.label.env"
+		fqnService        = "utf8.label.service"
+		fqnLabelStatus    = "utf8.label.status"
+		fqnMetadataStatus = "utf8.metadata.status"
+	)
+
+	ts := time.Unix(20, 0).UTC()
+
+	schemaA := arrow.NewSchema([]arrow.Field{
+		semconv.FieldFromFQN(colTs, false),
+		semconv.FieldFromFQN(colVal, false),
+		semconv.FieldFromFQN(fqnService, true),
+		semconv.FieldFromFQN(fqnLabelStatus, true),
+		semconv.FieldFromFQN(fqnEnv, true),
+	}, nil)
+
+	schemaB := arrow.NewSchema([]arrow.Field{
+		semconv.FieldFromFQN(colTs, false),
+		semconv.FieldFromFQN(colVal, false),
+		semconv.FieldFromFQN(fqnEnv, true),
+		semconv.FieldFromFQN(fqnService, true),
+		semconv.FieldFromFQN(fqnMetadataStatus, true),
+	}, nil)
+
+	schemaC := arrow.NewSchema([]arrow.Field{
+		semconv.FieldFromFQN(colTs, false),
+		semconv.FieldFromFQN(colVal, false),
+		semconv.FieldFromFQN(fqnMetadataStatus, true),
+		semconv.FieldFromFQN(fqnService, true),
+		semconv.FieldFromFQN(fqnLabelStatus, true),
+		semconv.FieldFromFQN(fqnEnv, true),
+	}, nil)
+
+	rowsA := arrowtest.Rows{
+		{colTs: ts, colVal: float64(1), fqnService: nil, fqnLabelStatus: "200", fqnEnv: "prod"},
+		{colTs: ts, colVal: float64(3), fqnService: "api", fqnLabelStatus: "500", fqnEnv: "prod"},
+	}
+
+	rowsB := arrowtest.Rows{
+		{colTs: ts, colVal: float64(2), fqnEnv: "prod", fqnService: nil, fqnMetadataStatus: "200"},
+		{colTs: ts, colVal: float64(4), fqnEnv: "prod", fqnService: "api", fqnMetadataStatus: "500"},
+	}
+
+	rowsC := arrowtest.Rows{
+		{colTs: ts, colVal: float64(5), fqnMetadataStatus: "200", fqnService: nil, fqnLabelStatus: nil, fqnEnv: "prod"},
+		{colTs: ts, colVal: float64(6), fqnMetadataStatus: nil, fqnService: "api", fqnLabelStatus: "500", fqnEnv: "prod"},
+	}
+
+	opts := vectorAggregationOptions{
+		grouping: physical.Grouping{
+			Columns: []physical.ColumnExpression{
+				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "env", Type: types.ColumnTypeAmbiguous}},
+			},
+			Without: true,
+		},
+		operation:      types.VectorAggregationTypeSum,
+		maxQuerySeries: 0,
+	}
+
+	inputA := NewArrowtestPipeline(schemaA, rowsA)
+	inputB := NewArrowtestPipeline(schemaB, rowsB)
+	inputC := NewArrowtestPipeline(schemaC, rowsC)
+
+	pipeline, err := newVectorAggregationPipeline([]Pipeline{inputA, inputB, inputC}, newExpressionEvaluator(), opts)
+	require.NoError(t, err)
+	defer pipeline.Close()
+
+	record, err := pipeline.Read(t.Context())
+	require.NoError(t, err)
+
+	result, err := arrowtest.RecordRows(record)
+	require.NoError(t, err)
+
+	expect := arrowtest.Rows{
+		{
+			colTs:                    ts,
+			colVal:                   float64(8), // 1 + 2 + 5
+			"utf8.ambiguous.service": nil,
+			"utf8.ambiguous.status":  "200",
+		},
+		{
+			colTs:                    ts,
+			colVal:                   float64(13), // 3 + 4 + 6
+			"utf8.ambiguous.service": "api",
+			"utf8.ambiguous.status":  "500",
+		},
+	}
+
+	require.Equal(t, len(expect), len(result), "same logical label values must aggregate together across records and physical types in without() grouping")
+	require.ElementsMatch(t, expect, result)
+}
+
+// TestVectorAggregationPipeline_WithoutSortsColumns verifies that "without" grouping
+// works correctly when columns are in different order across records.
+// They should be sorted by short name before calling the aggregator.
+func TestVectorAggregationPipeline_WithoutSortsColumns(t *testing.T) {
+	const (
+		fqnEnv         = "utf8.label.env"
+		fqnService     = "utf8.label.service"
+		fqnLabelStatus = "utf8.label.status"
+	)
+
+	ts := time.Unix(20, 0).UTC()
+
+	schemaA := arrow.NewSchema([]arrow.Field{
+		semconv.FieldFromFQN(colTs, false),
+		semconv.FieldFromFQN(colVal, false),
+		semconv.FieldFromFQN(fqnService, true),
+		semconv.FieldFromFQN(fqnLabelStatus, true),
+		semconv.FieldFromFQN(fqnEnv, true),
+	}, nil)
+
+	schemaB := arrow.NewSchema([]arrow.Field{
+		semconv.FieldFromFQN(colTs, false),
+		semconv.FieldFromFQN(colVal, false),
+		semconv.FieldFromFQN(fqnEnv, true),
+		semconv.FieldFromFQN(fqnLabelStatus, true),
+		semconv.FieldFromFQN(fqnService, true),
+	}, nil)
+
+	schemaC := arrow.NewSchema([]arrow.Field{
+		semconv.FieldFromFQN(colTs, false),
+		semconv.FieldFromFQN(colVal, false),
+		semconv.FieldFromFQN(fqnLabelStatus, true),
+		semconv.FieldFromFQN(fqnEnv, true),
+	}, nil)
+
+	rowsA := arrowtest.Rows{
+		{colTs: ts, colVal: float64(1), fqnService: nil, fqnLabelStatus: "200", fqnEnv: "prod"},
+		{colTs: ts, colVal: float64(10), fqnService: "api", fqnLabelStatus: "500", fqnEnv: "prod"},
+	}
+
+	rowsB := arrowtest.Rows{
+		{colTs: ts, colVal: float64(2), fqnEnv: "prod", fqnLabelStatus: "200", fqnService: nil},
+		{colTs: ts, colVal: float64(20), fqnEnv: "prod", fqnLabelStatus: "500", fqnService: "api"},
+	}
+
+	rowsC := arrowtest.Rows{
+		{colTs: ts, colVal: float64(3), fqnLabelStatus: "200", fqnEnv: "prod"},
+		{colTs: ts, colVal: float64(30), fqnLabelStatus: "503", fqnEnv: "prod"},
+	}
+
+	opts := vectorAggregationOptions{
+		grouping: physical.Grouping{
+			Columns: []physical.ColumnExpression{
+				&physical.ColumnExpr{Ref: types.ColumnRef{Column: "env", Type: types.ColumnTypeAmbiguous}},
+			},
+			Without: true,
+		},
+		operation:      types.VectorAggregationTypeSum,
+		maxQuerySeries: 0,
+	}
+
+	inputA := NewArrowtestPipeline(schemaA, rowsA)
+	inputB := NewArrowtestPipeline(schemaB, rowsB)
+	inputC := NewArrowtestPipeline(schemaC, rowsC)
+
+	pipeline, err := newVectorAggregationPipeline([]Pipeline{inputA, inputB, inputC}, newExpressionEvaluator(), opts)
+	require.NoError(t, err)
+	defer pipeline.Close()
+
+	record, err := pipeline.Read(t.Context())
+	require.NoError(t, err)
+
+	result, err := arrowtest.RecordRows(record)
+	require.NoError(t, err)
+
+	expect := arrowtest.Rows{
+		{
+			colTs:                    ts,
+			colVal:                   float64(6), // 1 + 2 + 3
+			"utf8.ambiguous.service": nil,
+			"utf8.ambiguous.status":  "200",
+		},
+		{
+			colTs:                    ts,
+			colVal:                   float64(30), // 10 + 20
+			"utf8.ambiguous.service": "api",
+			"utf8.ambiguous.status":  "500",
+		},
+		{
+			colTs:                    ts,
+			colVal:                   float64(30),
+			"utf8.ambiguous.service": nil,
+			"utf8.ambiguous.status":  "503",
+		},
+	}
+
+	require.Equal(t, len(expect), len(result), "retained logical label order must be canonical and missing columns must merge with null values in without() grouping")
+	require.ElementsMatch(t, expect, result)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

`without` aggregation has two correctness issues:
1. It picks the grouping columns in the order they appear in the input record. There is no invariant to ensure that columns of an input record are always sorted. Adding the same set of columns to the aggregator in different order results in different hash. The same set of labels can get aggregated as different groups as a result.
2. FQNs are used to perform aggregation. Columns with same short name but different type end up in different aggregation groups which again is incorrect. Ideally the aggregator should only use short names for generating hash, this should be fixed in a follow-up.

Both these issues are fixed by doing the following for each record:
1. find the unique short names & sort them
2. evaluate the column expressions in the sorted column order
3. if there is more than one column with the same name in a record, use `NewCoalese` to merge them into one
4. generate field name (used for hashing) with ambiguous type


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes grouping-key construction for `without` aggregations, which can alter series bucketing and output label schemas; errors would surface as incorrect aggregation results across mixed schemas.
> 
> **Overview**
> Fixes correctness issues in `without(...)` aggregation by centralizing grouping-key extraction in new `collectGroupingColumns`.
> 
> For `without` grouping, keys are now **canonicalized by short name** (coalescing multiple FQNs with the same short name via `NewCoalesce`, and emitting fields with an *ambiguous* type) and **sorted deterministically** to avoid hash/key instability from input column order.
> 
> Both range and vector aggregation pipelines now use the shared helper, and new tests cover short-name coalescing and column-order determinism for `without` grouping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fde9bb0ba74596fd6820c937bd097d296203a0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->