### PR TITLE
feat: Add NoCancelProducer to kafkav2

### DIFF
--- a/pkg/kafkav2/producer.go
+++ b/pkg/kafkav2/producer.go
@@ -1,0 +1,137 @@
+package kafkav2
+
+import (
+	"context"
+	"sync/atomic" //lint:ignore faillint we use new atomic types from sync/atomic.
+
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+type Producer interface {
+	Produce(context.Context, *kgo.Record, func(*kgo.Record, error))
+	TryProduce(context.Context, *kgo.Record, func(*kgo.Record, error))
+}
+
+// A NoCancelProducer wraps a [kgo.Client] but unlike the wrapped client,
+// cancelation of a context does not risk cancelation of all buffered records
+// for the produced partitions. From the franz-go docs:
+//
+//	Once a record is buffered into a batch, it can be canceled in three ways:
+//	canceling the context, the record timing out, or hitting the maximum
+//	retries. If any of these conditions are hit and it is currently safe to
+//	fail records, all buffered records for the relevant partition are failed.
+//	Only the first record's context in a batch is considered when determining
+//	whether the batch should be canceled.
+//
+// For more information, see
+// [https://pkg.go.dev/github.com/twmb/franz-go/pkg/kgo#Client.Produce].
+type NoCancelProducer struct {
+	client Producer
+}
+
+// NewNoCancelProducer returns a new NoCancelProducer.
+func NewNoCancelProducer(client Producer) *NoCancelProducer {
+	return &NoCancelProducer{client: client}
+}
+
+// Produce sends the Kafka record to its requested topic. It calls the optional
+// promise when Kafka replies. The error is non-nil on failure. However, unlike
+// [kgo], a canceled context for one record cannot cancel all other buffered
+// records for the same partition; nor can a promise be called with a nil error
+// after the context has been canceled. For this to work, we spawn a goroutine
+// for each context canceled via [context.AfterFunc].
+func (p *NoCancelProducer) Produce(ctx context.Context, r *kgo.Record, promise func(*kgo.Record, error)) {
+	noCancelCtx := context.WithoutCancel(ctx)
+	if promise == nil {
+		p.client.Produce(noCancelCtx, r, nil)
+		return
+	}
+	// Slow path: ensure promise is called when ctx is canceled.
+	once := atomic.Int64{}
+	stop := context.AfterFunc(ctx, func() {
+		if once.CompareAndSwap(0, 1) {
+			promise(r, ctx.Err())
+		}
+	})
+	producePromise := func(r *kgo.Record, err error) {
+		if once.CompareAndSwap(0, 1) {
+			stop() // Don't spawn a G if context is canceled after [Produce] finishes.
+			promise(r, err)
+		}
+	}
+	p.client.Produce(noCancelCtx, r, producePromise)
+}
+
+// TryProduce has the same no cancel behavior as [Produce], but does not block
+// when the buffer is full. It calls the promise with a [kgo.ErrMaxBuffered]
+// error instead.
+func (p *NoCancelProducer) TryProduce(ctx context.Context, r *kgo.Record, promise func(*kgo.Record, error)) {
+	noCancelCtx := context.WithoutCancel(ctx)
+	if promise == nil {
+		p.client.TryProduce(noCancelCtx, r, nil)
+		return
+	}
+	// Slow path: ensure promise is called when ctx is canceled.
+	once := atomic.Int64{}
+	stop := context.AfterFunc(ctx, func() {
+		if once.CompareAndSwap(0, 1) {
+			promise(r, ctx.Err())
+		}
+	})
+	producePromise := func(r *kgo.Record, err error) {
+		if once.CompareAndSwap(0, 1) {
+			stop() // Don't spawn a G if context is canceled after [Produce] finishes.
+			promise(r, err)
+		}
+	}
+	p.client.TryProduce(noCancelCtx, r, producePromise)
+}
+
+// ProduceSync produces all Kafka records to their requested topics. It waits
+// for all records to finish, or the context to be canceled, whichever happens
+// first. If the context is canceled, all records are returned with an error
+// "context canceled".
+func (p *NoCancelProducer) ProduceSync(ctx context.Context, rs ...*kgo.Record) kgo.ProduceResults {
+	results := make(kgo.ProduceResults, 0, len(rs))
+	if len(rs) == 0 {
+		return results
+	}
+	noCancelCtx := context.WithoutCancel(ctx)
+	// done is closed when resultsCh is closed.
+	done := make(chan struct{})
+	// resultsCh contains a [kgo.ProduceResult] for each record in rs.
+	resultsCh := make(chan kgo.ProduceResult, len(rs))
+	// rem counts the number of promises still to be called. It ensures that
+	// resultsCh is closed once, and after all promises have been executed.
+	rem := atomic.Int64{}
+	rem.Add(int64(len(rs)))
+	for _, r := range rs {
+		p.client.Produce(noCancelCtx, r, func(r *kgo.Record, err error) {
+			resultsCh <- kgo.ProduceResult{
+				Record: r,
+				Err:    err,
+			}
+			if rem.Add(-1) == 0 {
+				// This is the last promise, so we must close resultsCh.
+				close(resultsCh)
+				close(done)
+			}
+		})
+	}
+	select {
+	case <-ctx.Done():
+		// ctx.Err() is not free on a [cancelCtx], call it once.
+		ctxErr := ctx.Err()
+		for _, r := range rs {
+			results = append(results, kgo.ProduceResult{
+				Record: r,
+				Err:    ctxErr,
+			})
+		}
+	case <-done:
+		for res := range resultsCh {
+			results = append(results, res)
+		}
+	}
+	return results
+}

--- a/pkg/kafkav2/producer_test.go
+++ b/pkg/kafkav2/producer_test.go
@@ -1,0 +1,194 @@
+package kafkav2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func TestNoCancelProducer_Produce(t *testing.T) {
+	t.Run("without promise", func(t *testing.T) {
+		testCtx := t.Context()
+
+		// recorded records all calls to [Produce]. We use it to check that records
+		// are still produced even when the context is canceled.
+		recorded := recordingProducer{}
+		producer := NewNoCancelProducer(&recorded)
+
+		// Normal behavior. We expect there to be one call and it should have rec1
+		// in its args.
+		rec1 := &kgo.Record{Topic: "test", Partition: 0, Key: []byte("key1"), Value: []byte("value1")}
+		producer.Produce(testCtx, rec1, nil)
+		require.Len(t, recorded.calls, 1)
+		args, ok := recorded.calls[0].([]any)
+		require.True(t, ok)
+		require.Equal(t, "Produce", args[0])
+		require.Equal(t, rec1, args[2])
+
+		// Canceled context. We expect there to be a second call, even if the context
+		// is canceled.
+		cancelCtx, cancel := context.WithCancel(testCtx)
+		cancel()
+		rec2 := &kgo.Record{Topic: "test", Partition: 0, Key: []byte("key2"), Value: []byte("value2")}
+		producer.Produce(cancelCtx, rec2, nil)
+		require.Len(t, recorded.calls, 2)
+		args, ok = recorded.calls[1].([]any)
+		require.True(t, ok)
+		require.Equal(t, "Produce", args[0])
+		require.Equal(t, rec2, args[2])
+	})
+
+	t.Run("with promise", func(t *testing.T) {
+		testCtx := t.Context()
+
+		// recorded records all calls to [Produce]. We use it to check that records
+		// are still produced even when the context is canceled.
+		recorded := recordingProducer{}
+		producer := NewNoCancelProducer(&recorded)
+
+		// Normal behavior. We expect there to be one call and it should have rec1
+		// in its args.
+		rec1 := &kgo.Record{Topic: "test", Partition: 0, Key: []byte("key1"), Value: []byte("value1")}
+		producer.Produce(testCtx, rec1, func(r *kgo.Record, err error) {
+			require.NotNil(t, r)
+			require.NoError(t, err)
+		})
+		require.Len(t, recorded.calls, 1)
+		args, ok := recorded.calls[0].([]any)
+		require.True(t, ok)
+		require.Equal(t, "Produce", args[0])
+		require.Equal(t, rec1, args[2])
+
+		// Canceled context. We expect there to be a second call, and it should have
+		// rec2 in its args. We use a special context value produceNoPromise
+		// which tells the recorder not to call the promise. This lets us ensure the
+		// promise is called because of the canceled ctx instead.
+		cancelCtx, cancel := context.WithCancel(context.WithValue(testCtx, produceNoPromise{}, true))
+		cancel()
+		rec2 := &kgo.Record{Topic: "test", Partition: 0, Key: []byte("key2"), Value: []byte("value2")}
+		producer.Produce(cancelCtx, rec2, func(r *kgo.Record, err error) {
+			require.NotNil(t, r)
+			require.EqualError(t, err, "context canceled")
+		})
+		require.Len(t, recorded.calls, 2)
+		args, ok = recorded.calls[1].([]any)
+		require.True(t, ok)
+		require.Equal(t, "Produce", args[0])
+		require.Equal(t, rec2, args[2])
+	})
+}
+
+func TestNoCancelProducer_TryProduce(t *testing.T) {
+	t.Run("without promise", func(t *testing.T) {
+		testCtx := t.Context()
+
+		// recorded records all calls to [Produce]. We use it to check that records
+		// are still produced even when the context is canceled.
+		recorded := recordingProducer{}
+		producer := NewNoCancelProducer(&recorded)
+
+		// Normal behavior. We expect there to be one call and it should have rec1
+		// in its args.
+		rec1 := &kgo.Record{Topic: "test", Partition: 0, Key: []byte("key1"), Value: []byte("value1")}
+		producer.TryProduce(testCtx, rec1, nil)
+		require.Len(t, recorded.calls, 1)
+		args, ok := recorded.calls[0].([]any)
+		require.True(t, ok)
+		require.Equal(t, "TryProduce", args[0])
+		require.Equal(t, rec1, args[2])
+
+		// Canceled context. We expect there to be a second call, even if the context
+		// is canceled.
+		cancelCtx, cancel := context.WithCancel(testCtx)
+		cancel()
+		rec2 := &kgo.Record{Topic: "test", Partition: 0, Key: []byte("key2"), Value: []byte("value2")}
+		producer.TryProduce(cancelCtx, rec2, nil)
+		require.Len(t, recorded.calls, 2)
+		args, ok = recorded.calls[1].([]any)
+		require.True(t, ok)
+		require.Equal(t, "TryProduce", args[0])
+		require.Equal(t, rec2, args[2])
+	})
+
+	t.Run("with promise", func(t *testing.T) {
+		testCtx := t.Context()
+
+		// recorded records all calls to [Produce]. We use it to check that records
+		// are still produced even when the context is canceled.
+		recorded := recordingProducer{}
+		producer := NewNoCancelProducer(&recorded)
+
+		// Normal behavior. We expect there to be one call and it should have rec1
+		// in its args.
+		rec1 := &kgo.Record{Topic: "test", Partition: 0, Key: []byte("key1"), Value: []byte("value1")}
+		producer.TryProduce(testCtx, rec1, func(r *kgo.Record, err error) {
+			require.NotNil(t, r)
+			require.NoError(t, err)
+		})
+		require.Len(t, recorded.calls, 1)
+		args, ok := recorded.calls[0].([]any)
+		require.True(t, ok)
+		require.Equal(t, "TryProduce", args[0])
+		require.Equal(t, rec1, args[2])
+
+		// Canceled context. We expect there to be a second call, and it should have
+		// rec2 in its args. We use a special context value produceNoPromise
+		// which tells the recorder not to call the promise. This lets us ensure the
+		// promise is called because of the canceled ctx instead.
+		cancelCtx, cancel := context.WithCancel(context.WithValue(testCtx, produceNoPromise{}, true))
+		cancel()
+		rec2 := &kgo.Record{Topic: "test", Partition: 0, Key: []byte("key2"), Value: []byte("value2")}
+		producer.TryProduce(cancelCtx, rec2, func(r *kgo.Record, err error) {
+			require.NotNil(t, r)
+			require.EqualError(t, err, "context canceled")
+		})
+		require.Len(t, recorded.calls, 2)
+		args, ok = recorded.calls[1].([]any)
+		require.True(t, ok)
+		require.Equal(t, "TryProduce", args[0])
+		require.Equal(t, rec2, args[2])
+	})
+}
+
+func TestNoCancelProducer_ProduceSync(t *testing.T) {
+	testCtx := t.Context()
+
+	// recorded records all calls to [Produce]. We use it to check that records
+	// are still produced even when the context is canceled.
+	recorded := recordingProducer{}
+	producer := NewNoCancelProducer(&recorded)
+
+	// Must be able to produce with no records.
+	results := producer.ProduceSync(testCtx)
+	require.Len(t, results, 0)
+
+	// Normal behavior. We expect there to be one call and it should have rec1
+	// in its args.
+	rec1 := &kgo.Record{Topic: "test", Partition: 0, Key: []byte("key1"), Value: []byte("value1")}
+	results = producer.ProduceSync(testCtx, rec1)
+	require.Len(t, results, 1)
+	require.Equal(t, rec1, results[0].Record)
+	require.Nil(t, results[0].Err)
+	require.Len(t, recorded.calls, 1)
+	args, ok := recorded.calls[0].([]any)
+	require.True(t, ok)
+	require.Equal(t, rec1, args[2])
+
+	// Canceled context. We expect there to be a seond call, and it should have
+	// rec2 in its args. We use a special context value produceNoPromise
+	// which tells the recorder not to call the promise. This lets us ensure the
+	// promise is called because of the canceled ctx instead.
+	cancelCtx, cancel := context.WithCancel(context.WithValue(testCtx, produceNoPromise{}, true))
+	cancel()
+	rec2 := &kgo.Record{Topic: "test", Partition: 0, Key: []byte("key2"), Value: []byte("value2")}
+	results = producer.ProduceSync(cancelCtx, rec2)
+	require.Len(t, results, 1)
+	require.Equal(t, rec2, results[0].Record)
+	require.EqualError(t, results[0].Err, "context canceled")
+	require.Len(t, recorded.calls, 2)
+	args, ok = recorded.calls[1].([]any)
+	require.True(t, ok)
+	require.Equal(t, rec2, args[2])
+}

--- a/pkg/kafkav2/util_test.go
+++ b/pkg/kafkav2/util_test.go
@@ -1,6 +1,8 @@
 package kafkav2
 
 import (
+	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -21,4 +23,34 @@ func mustKafkaClient(t *testing.T, seed string, opts ...kgo.Opt) *kgo.Client {
 	require.NoError(t, err)
 	t.Cleanup(client.Close)
 	return client
+}
+
+type produceNoPromise struct{}
+
+// A recordingProducer records the args of all calls.
+type recordingProducer struct {
+	calls []any
+	mtx   sync.Mutex
+}
+
+// While Produce is supposed to be asynchronous, here the promise is called
+// synchronously. An optional value produceNoPromise can be passed via ctx
+// which tells it to not call the promise.
+func (p *recordingProducer) Produce(ctx context.Context, r *kgo.Record, promise func(r *kgo.Record, err error)) {
+	p.mtx.Lock()
+	p.calls = append(p.calls, []any{"Produce", ctx, r, promise})
+	p.mtx.Unlock()
+	if promise != nil && ctx.Value(produceNoPromise{}) == nil {
+		promise(r, nil)
+	}
+}
+
+// TryProduce has the same behavior as Produce here.
+func (p *recordingProducer) TryProduce(ctx context.Context, r *kgo.Record, promise func(r *kgo.Record, err error)) {
+	p.mtx.Lock()
+	p.calls = append(p.calls, []any{"TryProduce", ctx, r, promise})
+	p.mtx.Unlock()
+	if promise != nil && ctx.Value(produceNoPromise{}) == nil {
+		promise(r, nil)
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds a new type, `NoCancelProducer`, which fixes some undesirable behavior in franz-go where the cancelation of a single user-request (context) can cancel all other buffered records in the same partition(s).

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Kafka produce behavior around context cancellation and introduces new async/goroutine coordination, which could affect delivery guarantees and callback timing. Test coverage reduces risk, but correctness depends on subtle concurrency and franz-go semantics.
> 
> **Overview**
> Adds `NoCancelProducer`, a small wrapper around a franz-go producer that uses `context.WithoutCancel` to prevent one request’s canceled context from canceling other buffered records in the same partition, while still ensuring the per-record promise receives `ctx.Err()` on cancellation.
> 
> Also adds `ProduceSync` to wait for a batch of records to complete (or return early on context cancellation), plus unit tests with a `recordingProducer` test double to validate behavior for `Produce`, `TryProduce`, and sync production under canceled contexts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b2fb040959634e53bf3856117a71984603ed308. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->