### PR TITLE
fix: Incorrect impl of ProduceSync

### DIFF
--- a/pkg/kafka/client/writer_client.go
+++ b/pkg/kafka/client/writer_client.go
@@ -305,12 +305,7 @@ func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.P
 	// Call interceptor with all records if configured
 	if c.recordsInterceptor != nil {
 		if err := c.recordsInterceptor(ctx, records); err != nil {
-			// If interceptor fails, return error for all records
-			results := make(kgo.ProduceResults, len(records))
-			for i, record := range records {
-				results[i] = kgo.ProduceResult{Record: record, Err: err}
-			}
-			return results
+			return produceResultsForErr(records, err)
 		}
 	}
 
@@ -365,11 +360,24 @@ func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.P
 	// Wait for a response or until the context has done.
 	select {
 	case <-ctx.Done():
-		return kgo.ProduceResults{{Err: context.Cause(ctx)}}
+		return produceResultsForErr(records, context.Cause(ctx))
 	case <-done:
 		// Once we're done, it's guaranteed that no more results will be appended, so we can safely return it.
 		return res
 	}
+}
+
+// produceResultsForErr returns a [kgo.ProduceResults] that contains all records and
+// the error.
+func produceResultsForErr(records []*kgo.Record, err error) kgo.ProduceResults {
+	results := make(kgo.ProduceResults, 0, len(records))
+	for _, record := range records {
+		results = append(results, kgo.ProduceResult{
+			Record: record,
+			Err:    err,
+		})
+	}
+	return results
 }
 
 func produceErrReason(err error) string {

--- a/pkg/kafka/client/writer_client_test.go
+++ b/pkg/kafka/client/writer_client_test.go
@@ -83,6 +83,30 @@ func TestNewWriterClient(t *testing.T) {
 	}
 }
 
+func TestProducer(t *testing.T) {
+	t.Run("on context canceled", func(t *testing.T) {
+		_, kafkaCfg := testkafka.CreateCluster(t, 1, "test-topic")
+		client, err := NewWriterClient("test-client", kafkaCfg, 100, log.NewNopLogger(), prometheus.NewRegistry())
+		require.NoError(t, err)
+
+		producer := NewProducer("test-producer", client, 1024*1024, prometheus.NewRegistry())
+
+		// Force a canceled context.
+		cancelCtx, cancel := context.WithCancel(t.Context())
+		cancel()
+		rec1 := &kgo.Record{Key: []byte("key1"), Value: []byte("value1")}
+		rec2 := &kgo.Record{Key: []byte("key2"), Value: []byte("value2")}
+		results := producer.ProduceSync(cancelCtx, []*kgo.Record{rec1, rec2})
+		require.Len(t, results, 2)
+
+		// Each result should contain a "context canceled" error.
+		require.Equal(t, rec1, results[0].Record)
+		require.EqualError(t, results[0].Err, "context canceled")
+		require.Equal(t, rec2, results[1].Record)
+		require.EqualError(t, results[1].Err, "context canceled")
+	})
+}
+
 func TestProducerWithInterceptor(t *testing.T) {
 	_, kafkaCfg := testkafka.CreateCluster(t, 1, "test-topic")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes an incorrect implementation of `[ProduceSync]` where, on context cancelation, it would return a single `[kgo.ProduceResult]` with a nil record, instead of a result per record with a non-nil error. This commit fixes the implementation to adhere to that of franz-go.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, targeted change to Kafka producer error reporting plus a new unit test; behavior change is limited to how results are shaped on early failure paths.
> 
> **Overview**
> Fixes `Producer.ProduceSync` so that *early failure paths* (context cancellation or records-interceptor error) return a `kgo.ProduceResult` **for each input record** (with the `Record` populated) rather than a single error result.
> 
> Adds a small helper (`produceResultsForErr`) to build consistent per-record results, and introduces a unit test to assert correct behavior when the context is canceled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89f9f17afbcfcc41947beb32a5dfb92cb429e531. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->