### PR TITLE
fix(storage) ensure endpoints use correct scheme based on insecure flag

### DIFF
--- a/pkg/storage/chunk/client/aws/config_test.go
+++ b/pkg/storage/chunk/client/aws/config_test.go
@@ -76,7 +76,7 @@ func urlValue(s string) flagext.URLValue {
 
 func TestS3ClientOptions(t *testing.T) {
 
-	t.Run("s3 schema with region as hostname", func(t *testing.T) {
+	t.Run("s3 scheme with region as hostname", func(t *testing.T) {
 		cfg := S3Config{
 			S3: urlValue("s3://us-east-0/bucket"),
 		}
@@ -88,7 +88,7 @@ func TestS3ClientOptions(t *testing.T) {
 		require.Nil(t, opts.BaseEndpoint)
 	})
 
-	t.Run("https schema with region as hostname", func(t *testing.T) {
+	t.Run("https scheme with region as hostname", func(t *testing.T) {
 		cfg := S3Config{
 			S3: urlValue("https://us-east-0/bucket"),
 		}
@@ -100,9 +100,10 @@ func TestS3ClientOptions(t *testing.T) {
 		require.Nil(t, opts.BaseEndpoint)
 	})
 
-	t.Run("s3 schema with endpoint hostname", func(t *testing.T) {
+	t.Run("s3 scheme with endpoint hostname insecure", func(t *testing.T) {
 		cfg := S3Config{
-			S3: urlValue("s3://s3.us-east-0.amazonaws.com/bucket"),
+			Insecure: true,
+			S3:       urlValue("s3://s3.us-east-0.amazonaws.com/bucket"),
 		}
 		fn, _ := s3ClientConfigFunc(cfg, hedging.Config{}, false)
 		opts := s3.Options{}
@@ -112,7 +113,19 @@ func TestS3ClientOptions(t *testing.T) {
 		require.Equal(t, "http://s3.us-east-0.amazonaws.com", *opts.BaseEndpoint)
 	})
 
-	t.Run("https schema with endpoint hostname", func(t *testing.T) {
+	t.Run("s3 scheme with endpoint hostname secure", func(t *testing.T) {
+		cfg := S3Config{
+			S3: urlValue("s3://s3.us-east-0.amazonaws.com/bucket"),
+		}
+		fn, _ := s3ClientConfigFunc(cfg, hedging.Config{}, false)
+		opts := s3.Options{}
+		fn(&opts)
+
+		require.Equal(t, InvalidAWSRegion, opts.Region) // it is still required to set region explicitly
+		require.Equal(t, "https://s3.us-east-0.amazonaws.com", *opts.BaseEndpoint)
+	})
+
+	t.Run("https scheme with endpoint hostname", func(t *testing.T) {
 		cfg := S3Config{
 			S3: urlValue("https://s3.us-east-0.amazonaws.com/bucket"),
 		}

--- a/pkg/storage/chunk/client/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client.go
@@ -307,9 +307,11 @@ func s3ClientConfigFunc(cfg S3Config, hedgingCfg hedging.Config, hedging bool) (
 					endpoint = fmt.Sprintf("%s://%s", awsURL.Scheme, awsURL.Host)
 				case "s3":
 					// s3://<key>:<secret>@s3.us-east-0.amazonaws.com/<bucketname>
-					// In case of an s3:// URL, we want to be backwards compatible and always assume insecure http,
-					// even though it would probably more correct to check cfg.Insecure.
-					endpoint = fmt.Sprintf("http://%s", awsURL.Host)
+					if cfg.Insecure {
+						endpoint = fmt.Sprintf("http://%s", awsURL.Host)
+					} else {
+						endpoint = fmt.Sprintf("https://%s", awsURL.Host)
+					}
 				}
 				opts.BaseEndpoint = aws.String(endpoint)
 			} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
When using s3 storage backend and config specifies S3 URL then Loki will always attempt to connect with http scheme and ignore insecure flag. This behavior is inconsistent with the case when endpoint without scheme is specified. Ex:

s3: `s3://access_key:secret_key@endpoint:port/bucket` and `insecure: false` -> (INCORRECT) endpoint: `http://access_key:secret_key@endpoint:port/bucket`

s3: `s3://access_key:secret_key@endpoint:port/bucket` and `insecure: true` -> endpoint: `http://access_key:secret_key@endpoint:port/bucket`

But...

endpoint: `access_key:secret_key@endpoint:port/bucket` and `insecure: false` -> (CORRECT) endpoint: `https://endpoint:port/bucket`

endpoint: `access_key:secret_key@endpoint:port/bucket` and `insecure: true` -> endpoint: `http://endpoint:port/bucket`

The current workaround is to specify endpoint with `https://` scheme

The fix merely imitates the logic that is already applied to endpoint handling `s3_storage_client.go:329-336`
```
endpoint := cfg.Endpoint
if !strings.Contains(cfg.Endpoint, "://") {
    if cfg.Insecure {
        endpoint = fmt.Sprintf("http://%s", cfg.Endpoint)
    } else {
        endpoint = fmt.Sprintf("https://%s", cfg.Endpoint)
    }
}
```

There is a comment in the code `s3_storage_client.go:310-311`
```
// In case of an s3:// URL, we want to be backwards compatible and always assume insecure http,
// even though it would probably more correct to check cfg.Insecure.
```

The AWS SDK uses equivalent `DisableHTTPS` s3.Options setting but it defaults to secure connection. It would be nice to have consistency even though it is not backwards compatible.


**Which issue(s) this PR fixes**:
Fixes #7290 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `s3://` URLs are translated into S3 base endpoints, which can flip connections from HTTP to HTTPS (or vice versa) for some deployments and may impact connectivity/cert expectations. Coverage is improved with targeted tests, but behavior is not fully backwards compatible for `s3://` endpoint hosts.
> 
> **Overview**
> Aligns `s3://` URL handling with `endpoint` handling by setting `opts.BaseEndpoint` to `https://...` by default and only using `http://...` when `S3Config.Insecure` is true.
> 
> Updates `TestS3ClientOptions` to cover both secure and insecure `s3://` endpoint-host cases and clarifies test names ("schema" -> "scheme").
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45d5d19697a626874effe272513f6252a9ee1c5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->