### PR TITLE
fix(operator): Ruler doesn't evaluate rules due to use_thanos_objstore

### DIFF
--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -342,6 +342,10 @@ schema_config:
       {{- end}}
     {{- end }}
 {{ if .Ruler.Enabled }}
+ruler_storage:
+  backend: local
+  local:
+    directory: {{ .Ruler.RulesStorageDirectory }}
 ruler:
   enable_api: true
   enable_sharding: true
@@ -535,10 +539,6 @@ ruler:
     min_age: 5m
     max_age: 4h
   rule_path: {{ .StorageDirectory }}
-  storage:
-    type: local
-    local:
-      directory: {{ .Ruler.RulesStorageDirectory }}
   ring:
     kvstore:
       store: memberlist

--- a/operator/internal/manifests/internal/config/testdata/ruler-with-alert-relabel-configs/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/ruler-with-alert-relabel-configs/config.yaml
@@ -213,10 +213,6 @@ ruler:
     min_age: 5m
     max_age: 4h
   rule_path: /tmp/loki
-  storage:
-    type: local
-    local:
-      directory: /tmp/rules
   ring:
     kvstore:
       store: memberlist
@@ -232,6 +228,10 @@ server:
   http_server_read_timeout: 30s
   http_server_write_timeout: 10m0s
   log_level: info
+ruler_storage:
+  backend: local
+  local:
+    directory: /tmp/rules
 storage_config:
   use_thanos_objstore: true
   boltdb_shipper:

--- a/operator/internal/manifests/internal/config/testdata/ruler-with-alertmanager-client/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/ruler-with-alertmanager-client/config.yaml
@@ -198,10 +198,6 @@ ruler:
     min_age: 5m
     max_age: 4h
   rule_path: /tmp/loki
-  storage:
-    type: local
-    local:
-      directory: /tmp/rules
   ring:
     kvstore:
       store: memberlist
@@ -217,6 +213,10 @@ server:
   http_server_read_timeout: 30s
   http_server_write_timeout: 10m0s
   log_level: info
+ruler_storage:
+  backend: local
+  local:
+    directory: /tmp/rules
 storage_config:
   use_thanos_objstore: true
   boltdb_shipper:

--- a/operator/internal/manifests/internal/config/testdata/ruler-with-alertmanager-overrides/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/ruler-with-alertmanager-overrides/config.yaml
@@ -213,10 +213,6 @@ ruler:
     min_age: 5m
     max_age: 4h
   rule_path: /tmp/loki
-  storage:
-    type: local
-    local:
-      directory: /tmp/rules
   ring:
     kvstore:
       store: memberlist
@@ -232,6 +228,10 @@ server:
   http_server_read_timeout: 30s
   http_server_write_timeout: 10m0s
   log_level: info
+ruler_storage:
+  backend: local
+  local:
+    directory: /tmp/rules
 storage_config:
   use_thanos_objstore: true
   boltdb_shipper:

--- a/operator/internal/manifests/internal/config/testdata/ruler-with-auth-basic/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/ruler-with-auth-basic/config.yaml
@@ -187,10 +187,6 @@ ruler:
     min_age: 5m
     max_age: 4h
   rule_path: /tmp/loki
-  storage:
-    type: local
-    local:
-      directory: /tmp/rules
   ring:
     kvstore:
       store: memberlist
@@ -206,6 +202,10 @@ server:
   http_server_read_timeout: 30s
   http_server_write_timeout: 10m0s
   log_level: info
+ruler_storage:
+  backend: local
+  local:
+    directory: /tmp/rules
 storage_config:
   use_thanos_objstore: true
   boltdb_shipper:

--- a/operator/internal/manifests/internal/config/testdata/ruler-with-auth-header/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/ruler-with-auth-header/config.yaml
@@ -186,10 +186,6 @@ ruler:
     min_age: 5m
     max_age: 4h
   rule_path: /tmp/loki
-  storage:
-    type: local
-    local:
-      directory: /tmp/rules
   ring:
     kvstore:
       store: memberlist
@@ -205,6 +201,10 @@ server:
   http_server_read_timeout: 30s
   http_server_write_timeout: 10m0s
   log_level: info
+ruler_storage:
+  backend: local
+  local:
+    directory: /tmp/rules
 storage_config:
   use_thanos_objstore: true
   boltdb_shipper:

--- a/operator/internal/manifests/internal/config/testdata/ruler-with-relabel-configs/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/ruler-with-relabel-configs/config.yaml
@@ -200,10 +200,6 @@ ruler:
     min_age: 5m
     max_age: 4h
   rule_path: /tmp/loki
-  storage:
-    type: local
-    local:
-      directory: /tmp/rules
   ring:
     kvstore:
       store: memberlist
@@ -219,6 +215,10 @@ server:
   http_server_read_timeout: 30s
   http_server_write_timeout: 10m0s
   log_level: info
+ruler_storage:
+  backend: local
+  local:
+    directory: /tmp/rules
 storage_config:
   use_thanos_objstore: true
   boltdb_shipper:

--- a/operator/internal/manifests/internal/config/testdata/with-otlp-config/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/with-otlp-config/config.yaml
@@ -221,10 +221,6 @@ ruler:
     min_age: 5m
     max_age: 4h
   rule_path: /tmp/loki
-  storage:
-    type: local
-    local:
-      directory: /tmp/rules
   ring:
     kvstore:
       store: memberlist
@@ -240,6 +236,10 @@ server:
   http_server_read_timeout: 30s
   http_server_write_timeout: 10m0s
   log_level: info
+ruler_storage:
+  backend: local
+  local:
+    directory: /tmp/rules
 storage_config:
   use_thanos_objstore: true
   tsdb_shipper:


### PR DESCRIPTION
**What this PR does / why we need it**:
When `storage_config.use_thanos_objstore` is `true`, Loki ignores the legacy `ruler.storage` section in favour of the `ruler_storage` top-level config. The operator only configured the legacy section, so the ruler had no storage backend and silently skipped all rule evaluation.

**Which issue(s) this PR fixes**:
https://redhat.atlassian.net/browse/LOG-9353

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the rendered Loki configuration for the ruler, which can affect rule evaluation behavior and storage paths in running clusters. Scope is limited to config generation and golden test updates, with no code logic changes beyond the manifest template.
> 
> **Overview**
> Fixes ruler rule evaluation when `storage_config.use_thanos_objstore: true` by rendering the top-level `ruler_storage` block (local backend + rules directory) instead of relying on the legacy `ruler.storage` section.
> 
> Updates all affected operator config testdata to reflect the new `ruler_storage` output and removes the old inline `ruler.storage` stanza.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a01f61cd88ea7c0e11f60ecb43e5a3eb99fa14e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->