### PR TITLE
fix(gateway): fix nginx log_format field order and double space

### DIFF
--- a/production/docker/config/nginx.conf
+++ b/production/docker/config/nginx.conf
@@ -8,8 +8,8 @@ events {
 
 http {
   default_type application/octet-stream;
-  log_format   main '$remote_addr - $remote_user [$time_local]  $status '
-    '"$request" $body_bytes_sent "$http_referer" '
+  log_format   main '$remote_addr - $remote_user [$time_local] "$request" '
+    '$status $body_bytes_sent "$http_referer" '
     '"$http_user_agent" "$http_x_forwarded_for"';
   access_log   /dev/stderr  main;
   sendfile     on;

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1254,8 +1254,8 @@ gateway:
     enableIPv6: true
     # -- NGINX log format
     logFormat: |-
-      main '$remote_addr - $remote_user [$time_local]  $status '
-              '"$request" $body_bytes_sent "$http_referer" '
+      main '$remote_addr - $remote_user [$time_local] "$request" '
+              '$status $body_bytes_sent "$http_referer" '
               '"$http_user_agent" "$http_x_forwarded_for"';
     # -- Allows appending custom configuration to the server block
     serverSnippet: ""

--- a/production/ksonnet/loki/gateway.libsonnet
+++ b/production/ksonnet/loki/gateway.libsonnet
@@ -38,8 +38,8 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 
         http {
           default_type application/octet-stream;
-          log_format   main '$remote_addr - $remote_user [$time_local]  $status '
-            '"$request" $body_bytes_sent "$http_referer" '
+          log_format   main '$remote_addr - $remote_user [$time_local] "$request" '
+            '$status $body_bytes_sent "$http_referer" '
             '"$http_user_agent" "$http_x_forwarded_for"';
           access_log   /dev/stderr  main;
           sendfile     on;


### PR DESCRIPTION
Fixes #18788

The nginx `log_format` directive had two issues compared to the standard nginx combined log format:

1. A double space between `[$time_local]` and `$status`
2. `$status` appeared before `"$request"`, the reverse of the standard order

The fix is applied consistently across all three gateway config locations:
- `production/docker/config/nginx.conf`
- `production/helm/loki/values.yaml`
- `production/ksonnet/loki/gateway.libsonnet`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only reorders fields and removes an extra space in the NGINX `log_format`, affecting log line formatting but not request routing or auth behavior.
> 
> **Overview**
> Updates the Loki gateway NGINX access log format to match the standard combined format by removing a double space after `[$time_local]` and moving `$status` to come after `"$request"`.
> 
> Applies the same `log_format` change consistently across the docker gateway config, Helm `values.yaml`, and ksonnet gateway template so logs are uniform regardless of deployment method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9f8ecece11efdab9f6a917884c6ae5649e2b847. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
