### PR TITLE
fix: Don't drain in Kafka mode

### DIFF
--- a/pkg/dataobj/consumer/processor.go
+++ b/pkg/dataobj/consumer/processor.go
@@ -46,8 +46,6 @@ type processor struct {
 	decoder        *kafka.Decoder
 	records        chan *kgo.Record
 	flushCommitter flushCommitter
-	// flushRequests is used to safely trigger a flush from outside the Run loop.
-	flushRequests chan flushRequest
 
 	// lastOffset contains the offset of the last record appended to the data object
 	// builder. It is used to commit the correct offset after a flush.
@@ -84,6 +82,10 @@ type processor struct {
 	// per flush with 12 hour windows.
 	timePartitionedEstimates map[time.Time]struct{}
 
+	// flushRequests is used to safely trigger a flush from outside the Run loop.
+	mode          IngestMode
+	flushRequests chan flushRequest
+
 	metrics *metrics
 	logger  log.Logger
 }
@@ -94,6 +96,7 @@ func newProcessor(
 	flushCommitter flushCommitter,
 	idleFlushTimeout time.Duration,
 	maxBuilderAge time.Duration,
+	mode IngestMode,
 	logger log.Logger,
 	reg prometheus.Registerer,
 ) *processor {
@@ -112,6 +115,7 @@ func newProcessor(
 		metrics:                  newMetrics(reg),
 		logger:                   logger,
 		timePartitionedEstimates: make(map[time.Time]struct{}),
+		mode:                     mode,
 	}
 	p.BasicService = services.NewBasicService(p.starting, p.running, p.stopping)
 	return p
@@ -137,42 +141,8 @@ func (p *processor) running(ctx context.Context) error {
 // The records channel remains open (owned by Service) and may still have
 // buffered records written by the distributor before the push timeout fired.
 func (p *processor) stopping(_ error) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	dropped := 0
-drain:
-	for {
-		select {
-		case rec, ok := <-p.records:
-			if !ok {
-				break drain
-			}
-			if err := p.processRecord(ctx, rec); err != nil {
-				level.Error(p.logger).Log("msg", "failed to process record during shutdown drain", "err", err)
-				p.observeRecordErr(rec)
-			}
-		case <-ctx.Done():
-			// Drain timed out — count remaining buffered records as dropped.
-			dropped = len(p.records)
-			break drain
-		default:
-			// Channel is empty — drain complete.
-			break drain
-		}
-	}
-
-	if dropped > 0 {
-		level.Warn(p.logger).Log("msg", "inmemory drain timed out, records dropped", "count", dropped)
-	} else {
-		level.Info(p.logger).Log("msg", "inmemory channel drained cleanly on shutdown")
-	}
-
-	// Flush whatever was accumulated during drain.
-	if !p.lastAppend.IsZero() && p.builder.GetEstimatedSize() > 0 {
-		if err := p.flush(ctx, "shutdown"); err != nil {
-			level.Error(p.logger).Log("msg", "failed to flush during shutdown drain", "err", err)
-		}
+	if p.mode == IngestModeInMemory {
+		p.drainOnShutdown()
 	}
 	return nil
 }
@@ -352,4 +322,44 @@ func (p *processor) observeRecord(rec *kgo.Record, now time.Time) {
 func (p *processor) observeRecordErr(rec *kgo.Record) {
 	p.metrics.recordFailures.Inc()
 	p.metrics.discardedBytes.Add(float64(len(rec.Value)))
+}
+
+func (p *processor) drainOnShutdown() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	dropped := 0
+drain:
+	for {
+		select {
+		case rec, ok := <-p.records:
+			if !ok {
+				break drain
+			}
+			if err := p.processRecord(ctx, rec); err != nil {
+				level.Error(p.logger).Log("msg", "failed to process record during shutdown drain", "err", err)
+				p.observeRecordErr(rec)
+			}
+		case <-ctx.Done():
+			// Drain timed out — count remaining buffered records as dropped.
+			dropped = len(p.records)
+			break drain
+		default:
+			// Channel is empty — drain complete.
+			break drain
+		}
+	}
+
+	if dropped > 0 {
+		level.Warn(p.logger).Log("msg", "inmemory drain timed out, records dropped", "count", dropped)
+	} else {
+		level.Info(p.logger).Log("msg", "inmemory channel drained cleanly on shutdown")
+	}
+
+	// Flush whatever was accumulated during drain.
+	if !p.lastAppend.IsZero() && p.builder.GetEstimatedSize() > 0 {
+		if err := p.flush(ctx, "shutdown"); err != nil {
+			level.Error(p.logger).Log("msg", "failed to flush during shutdown drain", "err", err)
+		}
+	}
 }

--- a/pkg/dataobj/consumer/processor_drain_test.go
+++ b/pkg/dataobj/consumer/processor_drain_test.go
@@ -24,7 +24,7 @@ func TestProcessor_Stopping_Drain(t *testing.T) {
 		fc := &mockFlushCommitter{}
 		ch := make(chan *kgo.Record, 10)
 
-		proc := newProcessor(builder, ch, fc, time.Hour, time.Hour, logger, reg)
+		proc := newProcessor(builder, ch, fc, time.Hour, time.Hour, IngestModeInMemory, logger, reg)
 
 		err := proc.stopping(nil)
 		require.NoError(t, err)
@@ -46,7 +46,7 @@ func TestProcessor_Stopping_Drain(t *testing.T) {
 			ch <- newTestRecord(t, "tenant1", now.Add(time.Duration(i)*time.Second))
 		}
 
-		proc := newProcessor(builder, ch, fc, time.Hour, time.Hour, logger, reg)
+		proc := newProcessor(builder, ch, fc, time.Hour, time.Hour, IngestModeInMemory, logger, reg)
 
 		err := proc.stopping(nil)
 		require.NoError(t, err)

--- a/pkg/dataobj/consumer/processor_test.go
+++ b/pkg/dataobj/consumer/processor_test.go
@@ -40,7 +40,7 @@ func TestProcessor_BuilderMaxAge(t *testing.T) {
 			reg            = prometheus.NewRegistry()
 			builder        = newTestBuilder(t, reg)
 			flushCommitter = &mockFlushCommitter{}
-			proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+			proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, IngestModeKafka, log.NewNopLogger(), reg)
 		)
 
 		// Since no records have been pushed, the first append time should be zero,
@@ -89,7 +89,7 @@ func TestPartitionProcessor_IdleFlush(t *testing.T) {
 			reg            = prometheus.NewRegistry()
 			builder        = newTestBuilder(t, reg)
 			flushCommitter = &mockFlushCommitter{}
-			proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+			proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, IngestModeKafka, log.NewNopLogger(), reg)
 		)
 
 		// The idle flush timeout has not been exceeded, no flush should occur.
@@ -145,7 +145,7 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 				reg            = prometheus.NewRegistry()
 				builder        = newTestBuilder(t, reg)
 				flushCommitter = &mockFlushCommitter{}
-				proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+				proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, IngestModeKafka, log.NewNopLogger(), reg)
 			)
 
 			// No flush should have occurred.
@@ -177,7 +177,7 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 				reg            = prometheus.NewRegistry()
 				builder        = newTestBuilder(t, reg)
 				flushCommitter = &failureFlushCommitter{}
-				proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+				proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, IngestModeKafka, log.NewNopLogger(), reg)
 			)
 
 			// Process a record containing some log lines. No flush should occur.

--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -236,6 +236,7 @@ func NewInMemory(cfg Config, mCfg metastore.Config, bucket objstore.Bucket, scra
 		flushCommitter,
 		cfg.IdleFlushTimeout,
 		cfg.MaxBuilderAge,
+		IngestModeInMemory,
 		logger,
 		wrapped,
 	)
@@ -383,6 +384,7 @@ func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objsto
 		flushCommitter,
 		cfg.IdleFlushTimeout,
 		cfg.MaxBuilderAge,
+		IngestModeKafka,
 		logger,
 		wrapped,
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoids expensive drain operation in Kafka mode which has high chance of timing out.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shutdown behavior in the data object consumer by disabling record-channel draining when running in Kafka mode, which could affect what gets flushed/committed during termination. Risk is limited to stop-path semantics and is gated by `IngestMode`.
> 
> **Overview**
> Stops performing the expensive “drain buffered records then flush” logic during `processor.stopping()` when running in *Kafka* ingest mode; draining/flush-on-shutdown now only happens for `IngestModeInMemory`.
> 
> Adds an explicit `mode IngestMode` to `processor`/`newProcessor` and wires it through `Service` constructors, with tests updated to pass the mode and to cover the inmemory shutdown drain path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22d3c62b08d5a77bb5965c12eed25b1b057adcfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->