### PR TITLE
fix(operator): Redistribute ingester resources for 1x.extra-small and 1x.small to support 3 replicas

### DIFF
--- a/operator/internal/manifests/internal/sizes.go
+++ b/operator/internal/manifests/internal/sizes.go
@@ -143,8 +143,8 @@ var resourceRequirementsTable = map[lokiv1.LokiStackSizeType]ComponentResources{
 		Ingester: ResourceRequirements{
 			PVCSize: resource.MustParse("10Gi"),
 			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU:    resource.MustParse("1500m"),
-				corev1.ResourceMemory: resource.MustParse("6Gi"),
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("5.25Gi"),
 			},
 		},
 		Distributor: corev1.ResourceRequirements{
@@ -200,8 +200,8 @@ var resourceRequirementsTable = map[lokiv1.LokiStackSizeType]ComponentResources{
 		Ingester: ResourceRequirements{
 			PVCSize: resource.MustParse("10Gi"),
 			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU:    resource.MustParse("3"),
-				corev1.ResourceMemory: resource.MustParse("14Gi"),
+				corev1.ResourceCPU:    resource.MustParse("2500m"),
+				corev1.ResourceMemory: resource.MustParse("13Gi"),
 			},
 		},
 		Distributor: corev1.ResourceRequirements{

--- a/operator/internal/manifests/internal/sizes.go
+++ b/operator/internal/manifests/internal/sizes.go
@@ -200,8 +200,8 @@ var resourceRequirementsTable = map[lokiv1.LokiStackSizeType]ComponentResources{
 		Ingester: ResourceRequirements{
 			PVCSize: resource.MustParse("10Gi"),
 			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU:    resource.MustParse("2500m"),
-				corev1.ResourceMemory: resource.MustParse("13Gi"),
+				corev1.ResourceCPU:    resource.MustParse("2.5"),
+				corev1.ResourceMemory: resource.MustParse("13.25Gi"),
 			},
 		},
 		Distributor: corev1.ResourceRequirements{

--- a/operator/internal/manifests/internal/sizes.go
+++ b/operator/internal/manifests/internal/sizes.go
@@ -143,8 +143,8 @@ var resourceRequirementsTable = map[lokiv1.LokiStackSizeType]ComponentResources{
 		Ingester: ResourceRequirements{
 			PVCSize: resource.MustParse("10Gi"),
 			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU:    resource.MustParse("2"),
-				corev1.ResourceMemory: resource.MustParse("8Gi"),
+				corev1.ResourceCPU:    resource.MustParse("1500m"),
+				corev1.ResourceMemory: resource.MustParse("6Gi"),
 			},
 		},
 		Distributor: corev1.ResourceRequirements{
@@ -200,8 +200,8 @@ var resourceRequirementsTable = map[lokiv1.LokiStackSizeType]ComponentResources{
 		Ingester: ResourceRequirements{
 			PVCSize: resource.MustParse("10Gi"),
 			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU:    resource.MustParse("4"),
-				corev1.ResourceMemory: resource.MustParse("20Gi"),
+				corev1.ResourceCPU:    resource.MustParse("3"),
+				corev1.ResourceMemory: resource.MustParse("14Gi"),
 			},
 		},
 		Distributor: corev1.ResourceRequirements{
@@ -474,7 +474,7 @@ var StackSizeTable = map[lokiv1.LokiStackSizeType]lokiv1.LokiStackSpec{
 				Replicas: 2,
 			},
 			Ingester: &lokiv1.LokiComponentSpec{
-				Replicas: 2,
+				Replicas: 3,
 			},
 			Querier: &lokiv1.LokiComponentSpec{
 				Replicas: 2,
@@ -534,7 +534,7 @@ var StackSizeTable = map[lokiv1.LokiStackSizeType]lokiv1.LokiStackSpec{
 				Replicas: 2,
 			},
 			Ingester: &lokiv1.LokiComponentSpec{
-				Replicas: 2,
+				Replicas: 3,
 			},
 			Querier: &lokiv1.LokiComponentSpec{
 				Replicas: 2,


### PR DESCRIPTION
**What this PR does / why we need it**:
Redistributes the ingester resources within the existing resource envelope to support 3 ingester replicas for `1x.extra-small` and `1x.small`

**Which issue(s) this PR fixes**:
Fixes [LOG-9352](https://redhat.atlassian.net/browse/LOG-9352)

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default LokiStack sizing for ingesters (replica count and per-pod requests), which can impact cluster capacity and performance for new or reconciled `1x.extra-small`/`1x.small` installs.
> 
> **Overview**
> Updates operator default sizing for `1x.extra-small` and `1x.small` stacks to run **3 ingester replicas** instead of 2.
> 
> To keep within the same overall resource envelope, it **reduces per-ingester CPU/memory requests** for those sizes (extra-small: `2 CPU/8Gi` → `1 CPU/5.25Gi`; small: `4 CPU/20Gi` → `2.5 CPU/13.25Gi`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28cd491674daf9d203606dce3b32639315f7e66c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->