### PR TITLE
chore(ci): Fix PR/commit title for Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,18 +31,18 @@
       enabled: false,
     },
     {
-    // Disable ALL updates (including security) 
-    // for dependencies found in the 'operator/**' path, but ONLY on 
-    // the specified release branches. This explicitly overrides the 
-    // global 'vulnerabilityAlerts' for this scope.
-    matchBaseBranches: [
-      'release-2.9.x', 
-      'release-3.6.x', 
-      'release-3.7.x'
-    ],
-    matchFileNames: ['operator/**'],
-    enabled: false
-  },
+      // Disable ALL updates (including security) 
+      // for dependencies found in the 'operator/**' path, but ONLY on 
+      // the specified release branches. This explicitly overrides the 
+      // global 'vulnerabilityAlerts' for this scope.
+      matchBaseBranches: [
+        'release-2.9.x', 
+        'release-3.6.x', 
+        'release-3.7.x'
+      ],
+      matchFileNames: ['operator/**'],
+      enabled: false
+    },
     {
       // Disable Go version updates
       matchManagers: [
@@ -232,7 +232,9 @@
   postUpdateOptions: [
     'gomodTidy',
   ],
+  semanticCommits: 'enabled',
   semanticCommitType: 'fix',
   semanticCommitScope: 'deps',
-  commitMessageAction: 'Update', // default is lower case
+  commitMessageLowerCase: 'never', // to leave the titles untouched, allowing uppercase characters in semantic commit titles
+  commitMessageAction: 'Update',
 }


### PR DESCRIPTION
### Summary

> With semanticCommits pr- and commit-titles will by default ("auto") be converted to all-lowercase. Set this to "never" to leave the titles untouched, allowing uppercase characters in semantic commit titles.

https://docs.renovatebot.com/configuration-options/#commitmessagelowercase

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renovate-only configuration changes affecting PR/commit naming; no production runtime impact, with minimal risk aside from altering how dependency update PRs are titled.
> 
> **Overview**
> Renovate is now configured to create semantic commits (type `fix`, scope `deps`) while **preserving original title casing** by setting `commitMessageLowerCase: 'never'` and keeping `commitMessageAction: 'Update'`.
> 
> Also refactors the `operator/**` release-branch package rule block without changing its behavior (still disables all updates, including security, for those paths on the specified release branches).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7598fc7552c0dd9fecf1bffa61bb201de29798ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->