### PR TITLE
chore: Remove unused/dead code

### DIFF
--- a/pkg/bloomgateway/util_test.go
+++ b/pkg/bloomgateway/util_test.go
@@ -538,24 +538,6 @@ func createQueryInputFromBlockData(t *testing.T, tenant string, data [][]v1.Seri
 	return res
 }
 
-func createBlockRefsFromBlockData(t *testing.T, tenant string, data []*bloomshipper.CloseableBlockQuerier) []bloomshipper.BlockRef {
-	t.Helper()
-	res := make([]bloomshipper.BlockRef, 0)
-	for i := range data {
-		res = append(res, bloomshipper.BlockRef{
-			Ref: bloomshipper.Ref{
-				TenantID:       tenant,
-				TableName:      "",
-				Bounds:         v1.NewBounds(data[i].Bounds.Min, data[i].Bounds.Max),
-				StartTimestamp: 0,
-				EndTimestamp:   0,
-				Checksum:       0,
-			},
-		})
-	}
-	return res
-}
-
 func TestOverlappingChunks(t *testing.T) {
 	mkRef := func(from, through model.Time) *logproto.ShortRef {
 		return &logproto.ShortRef{From: from, Through: through}

--- a/pkg/canary/comparator/comparator_test.go
+++ b/pkg/canary/comparator/comparator_test.go
@@ -492,42 +492,6 @@ func (m *mockCounter) Inc() {
 	m.count++
 }
 
-type mockCounterVec struct {
-	mockCounter
-	labels []string
-}
-
-func (m *mockCounterVec) WithLabelValues(lvs ...string) prometheus.Counter {
-	m.labels = lvs
-	return &m.mockCounter
-}
-
-func (m *mockCounterVec) Desc() *prometheus.Desc {
-	panic("implement me")
-}
-
-func (m *mockCounterVec) Write(*io_prometheus_client.Metric) error {
-	panic("implement me")
-}
-
-func (m *mockCounterVec) Describe(chan<- *prometheus.Desc) {
-	panic("implement me")
-}
-
-func (m *mockCounterVec) Collect(chan<- prometheus.Metric) {
-	panic("implement me")
-}
-
-func (m *mockCounterVec) Add(float64) {
-	panic("implement me")
-}
-
-func (m *mockCounterVec) Inc() {
-	m.cLck.Lock()
-	defer m.cLck.Unlock()
-	m.count++
-}
-
 type mockGauge struct {
 	cLck sync.Mutex
 	val  float64

--- a/pkg/canary/writer/push.go
+++ b/pkg/canary/writer/push.go
@@ -57,9 +57,6 @@ type Push struct {
 
 	// push retry and backoff
 	backoff *backoff.Config
-
-	// cfg for sending logs in batches
-	logBatchSize int
 }
 
 // `NewPush` creates an instance of `EntryWriter` which writes logs directly to the given `lokiAddr`

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -194,35 +194,6 @@ func newInstance(
 	return i, err
 }
 
-// consumeChunk manually adds a chunk that was received during ingester chunk
-// transfer.
-func (i *instance) consumeChunk(ctx context.Context, ls labels.Labels, chunk *logproto.Chunk) error {
-	fp := i.getHashForLabels(ls)
-
-	s, _, _ := i.streams.LoadOrStoreNewByFP(fp,
-		func() (*stream, error) {
-			s, err := i.createStreamByFP(ctx, ls, fp)
-			s.chunkMtx.Lock() // Lock before return, because we have defer that unlocks it.
-			if err != nil {
-				return nil, err
-			}
-			return s, nil
-		},
-		func(s *stream) error {
-			s.chunkMtx.Lock()
-			return nil
-		},
-	)
-	defer s.chunkMtx.Unlock()
-
-	err := s.consumeChunk(ctx, chunk)
-	if err == nil {
-		i.metrics.memoryChunks.Inc()
-	}
-
-	return err
-}
-
 // Push will iterate over the given streams present in the PushRequest and attempt to store them.
 //
 // Although multiple streams are part of the PushRequest, the returned error only reflects what

--- a/pkg/ingester/recalculate_owned_streams.go
+++ b/pkg/ingester/recalculate_owned_streams.go
@@ -27,7 +27,6 @@ type recalculateOwnedStreamsSvc struct {
 
 	ownershipStrategy ownershipStrategy
 	instancesSupplier func() []*instance
-	ticker            *time.Ticker
 }
 
 func newRecalculateOwnedStreamsSvc(instancesSupplier func() []*instance, ownershipStrategy ownershipStrategy, ringPollInterval time.Duration, logger log.Logger) *recalculateOwnedStreamsSvc {

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -147,23 +147,6 @@ func newStream(
 	}
 }
 
-// consumeChunk manually adds a chunk to the stream that was received during
-// ingester chunk transfer.
-// Must hold chunkMtx
-// DEPRECATED: chunk transfers are no longer suggested and remain for compatibility.
-func (s *stream) consumeChunk(_ context.Context, chunk *logproto.Chunk) error {
-	c, err := chunkenc.NewByteChunk(chunk.Data, s.cfg.BlockSize, s.cfg.TargetChunkSize)
-	if err != nil {
-		return err
-	}
-
-	s.chunks = append(s.chunks, chunkDesc{
-		chunk: c,
-	})
-	s.metrics.chunksCreatedTotal.Inc()
-	return nil
-}
-
 // setChunks is used during checkpoint recovery
 func (s *stream) setChunks(chunks []Chunk) (bytesAdded, entriesAdded int, err error) {
 	s.chunkMtx.Lock()

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -11,11 +11,6 @@ import (
 )
 
 const (
-	consumeFromLastOffset = "last-offset"
-	consumeFromStart      = "start"
-	consumeFromEnd        = "end"
-	consumeFromTimestamp  = "timestamp"
-
 	// ProducerBatchMaxBytes is the max allowed size of a batch of Kafka records.
 	ProducerBatchMaxBytes = 16_000_000
 

--- a/pkg/kafka/partition/kafkautil_test.go
+++ b/pkg/kafka/partition/kafkautil_test.go
@@ -155,10 +155,3 @@ func produceRecords(
 	require.NoError(t, produceResult.FirstErr())
 	return produceResult
 }
-
-func commitOffset(ctx context.Context, t *testing.T, kafkaClient *kgo.Client, group string, offset kadm.Offset) {
-	offsets := make(kadm.Offsets)
-	offsets.Add(offset)
-	err := kadm.NewClient(kafkaClient).CommitAllOffsets(ctx, group, offsets)
-	require.NoError(t, err)
-}

--- a/pkg/kafka/partition/reader.go
+++ b/pkg/kafka/partition/reader.go
@@ -100,7 +100,6 @@ type KafkaReader struct {
 	client                   *kgo.Client
 	topic                    string
 	partitionID              int32
-	consumerGroup            string
 	metrics                  *ReaderMetrics
 	phase                    string
 	partitionStateMu         sync.RWMutex

--- a/pkg/limits/store.go
+++ b/pkg/limits/store.go
@@ -36,9 +36,6 @@ var (
 	)
 )
 
-// iterateFunc is a closure called for each stream.
-type iterateFunc func(tenant string, partition int32, stream streamUsage)
-
 // getPolicyBucketAndLimit determines which policy bucket to use and the max streams limit
 // for a given tenant and policy. Returns the policy bucket name and the max streams limit.
 // The policy bucket will be the input policy name only if the max streams limit is overridden for the policy.

--- a/pkg/limits/store_test.go
+++ b/pkg/limits/store_test.go
@@ -686,7 +686,3 @@ func (m *mockLimitsWithPolicy) PolicyMaxGlobalStreamsPerUser(_, policy string) (
 	}
 	return 0, false // No custom limit for this policy
 }
-
-func newRateBuckets(rateWindow, bucketSize time.Duration) []rateBucket {
-	return make([]rateBucket, int(rateWindow/bucketSize))
-}

--- a/pkg/loghttp/entry_test.go
+++ b/pkg/loghttp/entry_test.go
@@ -1,7 +1,6 @@
 package loghttp
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -267,23 +266,6 @@ func TestObjectEachHandlingOfNewlines(t *testing.T) {
 
 	// Verify proper parsing of newlines
 	require.Equal(t, "a\nb\nc", parsedValue)
-}
-
-// debugUnescapeJSONString is a custom debug version of the function in the main codebase
-func debugUnescapeJSONString(b []byte) string {
-	// First log the raw bytes before doing any unescaping
-	fmt.Printf("Raw bytes before unescaping: %v\n", b)
-
-	var stackbuf [1024]byte
-	bU, err := jsonparser.Unescape(b, stackbuf[:])
-	if err != nil {
-		return ""
-	}
-
-	// Log the unescaped bytes
-	fmt.Printf("Bytes after unescaping: %v\n", bU)
-
-	return string(bU)
 }
 
 // Write a custom test showing the different ways escaping can happen

--- a/pkg/loghttp/push/otlp_test.go
+++ b/pkg/loghttp/push/otlp_test.go
@@ -765,12 +765,6 @@ func TestOTLPLogToPushEntry(t *testing.T) {
 	}
 }
 
-type fakeRetention struct{}
-
-func (f fakeRetention) RetentionPeriodFor(_ string, _ labels.Labels) time.Duration {
-	return time.Hour
-}
-
 func TestOtlpError(t *testing.T) {
 	for _, tc := range []struct {
 		name         string

--- a/pkg/loghttp/query.go
+++ b/pkg/loghttp/query.go
@@ -26,7 +26,6 @@ import (
 var (
 	errEndBeforeStart     = errors.New("end timestamp must not be before or equal to start time")
 	errZeroOrNegativeStep = errors.New("zero or negative query resolution step widths are not accepted. Try a positive integer")
-	errNegativeStep       = errors.New("negative query resolution step widths are not accepted. Try a positive integer")
 	errStepTooSmall       = errors.New("exceeded maximum resolution of 11,000 points per time series. Try increasing the value of the step parameter")
 	errNegativeInterval   = errors.New("interval must be >= 0")
 )

--- a/pkg/logql/bench/cmd/bench/views/run.go
+++ b/pkg/logql/bench/cmd/bench/views/run.go
@@ -24,14 +24,13 @@ const (
 
 // RunView represents the benchmark run view
 type RunView struct {
-	RunConfig         RunConfig
-	Running           bool
-	Output            string
-	Viewport          viewport.Model
-	DiffViewport      viewport.Model
-	showDiff          bool
-	ready             bool   // track if we've received initial window size
-	lastBenchmarkLine string // track the last benchmark line for stats formatting
+	RunConfig    RunConfig
+	Running      bool
+	Output       string
+	Viewport     viewport.Model
+	DiffViewport viewport.Model
+	showDiff     bool
+	ready        bool // track if we've received initial window size
 
 	// Window size tracking
 	width                int

--- a/pkg/logql/bench/faker.go
+++ b/pkg/logql/bench/faker.go
@@ -187,13 +187,6 @@ var (
 		"file not found",
 		"invalid request",
 	}
-	nginxErrors = []string{
-		"access forbidden by rule",
-		"client closed connection while reading request headers",
-		"upstream timed out (110: Connection timed out)",
-		"file not found",
-		"client sent invalid request",
-	}
 	kafkaTopics = []string{
 		"users",
 		"orders",

--- a/pkg/logql/bench/metadata_resolver_test.go
+++ b/pkg/logql/bench/metadata_resolver_test.go
@@ -2,26 +2,11 @@ package bench
 
 import (
 	"math/rand"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
-
-// extractServiceName is a helper to extract service_name from a query for testing
-func extractServiceName(query string) string {
-	if strings.Contains(query, `service_name="loki"`) {
-		return "loki"
-	}
-	if strings.Contains(query, `service_name="database"`) {
-		return "database"
-	}
-	if strings.Contains(query, `service_name="web-server"`) {
-		return "web-server"
-	}
-	return ""
-}
 
 func TestMetadataVariableResolver_ResolveQuery(t *testing.T) {
 	// Create test metadata with known selectors and capabilities

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -25,7 +25,6 @@ import (
 
 // DataObjStore implements Store using the dataobj format
 type DataObjStore struct {
-	path             string
 	tenant           string
 	builder          *logsobj.Builder
 	buf              *bytes.Buffer

--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -3744,13 +3744,6 @@ func incValue(val int64) generator {
 	}
 }
 
-// nolint
-func inverse(g generator) generator {
-	return func(i int64) logData {
-		return g(-i)
-	}
-}
-
 func TestJoinSampleVector_LogsDrilldownBehavior(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -1468,11 +1468,10 @@ func (ev *DefaultEvaluator) newVariantsEvaluator(
 }
 
 type bufferedVariantsIterator struct {
-	iter          iter.PeekingSampleIterator
-	buffer        map[int][]sampleWithLabelsAndStreamHash
-	current       sampleWithLabelsAndStreamHash
-	currentLabels string
-	err           error
+	iter    iter.PeekingSampleIterator
+	buffer  map[int][]sampleWithLabelsAndStreamHash
+	current sampleWithLabelsAndStreamHash
+	err     error
 }
 
 type sampleWithLabelsAndStreamHash struct {

--- a/pkg/logql/log/consolidated_variant_extractor_test.go
+++ b/pkg/logql/log/consolidated_variant_extractor_test.go
@@ -130,7 +130,6 @@ func (m *MockVariantSpecificExtractor) ForStream(lbls labels.Labels) StreamSampl
 }
 
 type mockVariantSpecificStreamExtractor struct {
-	variantIndex   int
 	valueToExtract float64
 	shouldExtract  bool
 	labels         LabelsResult

--- a/pkg/logql/log/label_filter.go
+++ b/pkg/logql/log/label_filter.go
@@ -290,7 +290,6 @@ type NumericLabelFilter struct {
 	Name  string
 	Value float64
 	Type  LabelFilterType
-	err   error
 }
 
 // NewNumericLabelFilter creates a new label filterer which parses float64 string representation (5.2)

--- a/pkg/logql/range_vector.go
+++ b/pkg/logql/range_vector.go
@@ -512,7 +512,6 @@ type streamRangeVectorIterator struct {
 	r                                    *syntax.RangeAggregationExpr
 	metrics                              map[string]labels.Labels
 	at                                   []promql.Sample
-	agg                                  BatchRangeVectorAggregator
 }
 
 func (r *streamRangeVectorIterator) Next() bool {

--- a/pkg/logql/range_vector_test.go
+++ b/pkg/logql/range_vector_test.go
@@ -62,10 +62,6 @@ func newSample(t time.Time, v float64, metric labels.Labels) promql.Sample {
 	return promql.Sample{Metric: metric, T: t.UnixMilli(), F: v}
 }
 
-func newPoint(t time.Time, v float64) promql.FPoint {
-	return promql.FPoint{T: t.UnixMilli(), F: v}
-}
-
 func Benchmark_RangeVectorIteratorCompare(b *testing.B) {
 	// no overlap test case.
 	buildStreamingIt := func() (RangeVectorIterator, error) {

--- a/pkg/logql/sketch/heap.go
+++ b/pkg/logql/sketch/heap.go
@@ -8,8 +8,7 @@ type node struct {
 	event string
 	count float64
 	// used for the container heap Fix function
-	index           uint16
-	sketchPositions []uint32
+	index uint16
 }
 
 type MinHeap []*node

--- a/pkg/logql/sketch/topk.go
+++ b/pkg/logql/sketch/topk.go
@@ -36,9 +36,6 @@ type Topk struct {
 	bf                  [][]bool
 	hll                 *hyperloglog.Sketch
 	expectedCardinality int
-
-	// save on allocs when converting from string event name to byte slice for hll insertion
-	eventBytes []byte
 }
 
 // get the correct sketch width based on the expected cardinality of the set

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -8,14 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/loki/v3/pkg/util"
-
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
-
-	"github.com/grafana/regexp/syntax"
 
 	"github.com/grafana/loki/v3/pkg/logql/log"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
@@ -1037,11 +1033,6 @@ func (j *JSONExpressionParserExpr) String() string {
 	return sb.String()
 }
 
-type internedStringSet map[string]struct {
-	s  string
-	ok bool
-}
-
 type LogfmtExpressionParserExpr struct {
 	Expressions       []log.LabelExtractionExpr
 	Strict, KeepEmpty bool
@@ -1105,30 +1096,6 @@ func mustNewMatcher(t labels.MatchType, n, v string) *labels.Matcher {
 		panic(logqlmodel.NewParseError(err.Error(), 0, 0))
 	}
 	return m
-}
-
-// simplify will return an equals matcher if there is a regex matching a literal
-func simplify(typ labels.MatchType, name string, reg *syntax.Regexp) (*labels.Matcher, bool) {
-	switch reg.Op {
-	case syntax.OpLiteral:
-		if !util.IsCaseInsensitive(reg) {
-			t := labels.MatchEqual
-			if typ == labels.MatchNotRegexp {
-				t = labels.MatchNotEqual
-			}
-			return labels.MustNewMatcher(t, name, string(reg.Rune)), true
-		}
-		return nil, false
-	}
-	return nil, false
-}
-
-func mustNewFloat(s string) float64 {
-	n, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		panic(logqlmodel.NewParseError(fmt.Sprintf("unable to parse float: %s", err.Error()), 0, 0))
-	}
-	return n
 }
 
 type UnwrapExpr struct {

--- a/pkg/logql/syntax/serialize.go
+++ b/pkg/logql/syntax/serialize.go
@@ -961,14 +961,6 @@ func decodeVector(iter *jsoniter.Iterator) (*VectorExpr, error) {
 	return expr, nil
 }
 
-func decodeMatchers(iter *jsoniter.Iterator) (LogSelectorExpr, error) {
-	return decodeLogSelector(iter)
-}
-
-func decodePipeline(iter *jsoniter.Iterator) (LogSelectorExpr, error) {
-	return decodeLogSelector(iter)
-}
-
 func decodeVariants(iter *jsoniter.Iterator) (VariantsExpr, error) {
 	var e MultiVariantExpr
 

--- a/pkg/lokifrontend/frontend/transport/handler.go
+++ b/pkg/lokifrontend/frontend/transport/handler.go
@@ -36,12 +36,6 @@ const (
 	ServiceTimingHeaderName   = "Server-Timing"
 )
 
-var (
-	errCanceled              = httpgrpc.Errorf(StatusClientClosedRequest, "%s", context.Canceled.Error())
-	errDeadlineExceeded      = httpgrpc.Errorf(http.StatusGatewayTimeout, "%s", context.DeadlineExceeded.Error())
-	errRequestEntityTooLarge = httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "http: request body too large")
-)
-
 // Config for a Handler.
 type HandlerConfig struct {
 	LogQueriesLongerThan   time.Duration          `yaml:"log_queries_longer_than"`

--- a/pkg/pattern/aggregation/metrics.go
+++ b/pkg/pattern/aggregation/metrics.go
@@ -15,8 +15,6 @@ var (
 )
 
 type Metrics struct {
-	reg prometheus.Registerer
-
 	// push operation
 	pushErrors  *prometheus.CounterVec
 	payloadSize *prometheus.HistogramVec

--- a/pkg/pattern/aggregation/push.go
+++ b/pkg/pattern/aggregation/push.go
@@ -68,9 +68,6 @@ type Push struct {
 	// auth
 	username, password string
 
-	// Will add these label to the logs pushed to loki
-	labelName, labelValue, streamName, streamValue string
-
 	// push retry and backoff
 	backoff *backoff.Config
 

--- a/pkg/pattern/drain/chunk.go
+++ b/pkg/pattern/drain/chunk.go
@@ -12,8 +12,6 @@ import (
 
 const (
 	TimeResolution = model.Time(int64(time.Second*10) / 1e6)
-
-	defaultVolumeSize = 500
 )
 
 type Chunks []Chunk

--- a/pkg/pattern/drain/drain_benchmark_test.go
+++ b/pkg/pattern/drain/drain_benchmark_test.go
@@ -4,13 +4,8 @@ import (
 	"bufio"
 	"os"
 	"testing"
-	"time"
 
-	"github.com/prometheus/prometheus/model/labels"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
 func BenchmarkDrain_TrainExtractsPatterns(b *testing.B) {
@@ -51,16 +46,4 @@ func BenchmarkDrain_TrainExtractsPatterns(b *testing.B) {
 			}
 		})
 	}
-}
-
-type mockEntryWriter struct {
-	mock.Mock
-}
-
-func (m *mockEntryWriter) WriteEntry(ts time.Time, entry string, lbls labels.Labels, structuredMetadata []logproto.LabelAdapter) {
-	_ = m.Called(ts, entry, lbls, structuredMetadata)
-}
-
-func (m *mockEntryWriter) Stop() {
-	_ = m.Called()
 }

--- a/pkg/pattern/drain/line_tokenizer.go
+++ b/pkg/pattern/drain/line_tokenizer.go
@@ -19,22 +19,6 @@ type LineTokenizer interface {
 	Clone(tokens []string, state interface{}) ([]string, interface{})
 }
 
-type spacesTokenizer struct{}
-
-func (spacesTokenizer) Tokenize(line string, _ []string, _ interface{}) ([]string, interface{}) {
-	return strings.Split(line, " "), nil
-}
-
-func (spacesTokenizer) Join(tokens []string, _ interface{}) string {
-	return strings.Join(tokens, " ")
-}
-
-func (spacesTokenizer) Clone(tokens []string, _ interface{}) ([]string, interface{}) {
-	res := make([]string, len(tokens))
-	copy(res, tokens)
-	return res, nil
-}
-
 type punctuationTokenizer struct {
 	includeDelimiters [128]rune
 	excludeDelimiters [128]rune

--- a/pkg/pattern/drain/log_cluster.go
+++ b/pkg/pattern/drain/log_cluster.go
@@ -34,11 +34,6 @@ func (c *LogCluster) append(ts model.Time, maxChunkAge time.Duration, sampleInte
 	return c.Chunks.Add(ts, maxChunkAge, sampleInterval)
 }
 
-func (c *LogCluster) merge(samples []*logproto.PatternSample) {
-	c.Size += int(sumSize(samples))
-	c.Chunks.merge(samples)
-}
-
 func (c *LogCluster) Iterator(lvl string, from, through, step, sampleInterval model.Time) iter.Iterator {
 	return c.Chunks.Iterator(c.String(), lvl, from, through, step, sampleInterval)
 }
@@ -51,12 +46,4 @@ func (c *LogCluster) Prune(olderThan time.Duration) []*logproto.PatternSample {
 	prunedSamples := c.Chunks.prune(olderThan)
 	c.Size = c.Chunks.size()
 	return prunedSamples
-}
-
-func sumSize(samples []*logproto.PatternSample) int64 {
-	var x int64
-	for i := range samples {
-		x += samples[i].Value
-	}
-	return x
 }

--- a/pkg/pattern/flush.go
+++ b/pkg/pattern/flush.go
@@ -1,10 +1,7 @@
 package pattern
 
 import (
-	"fmt"
-
 	"github.com/go-kit/log/level"
-	"github.com/prometheus/common/model"
 
 	"github.com/grafana/loki/v3/pkg/util"
 )
@@ -32,21 +29,6 @@ func (i *Ingester) flush(mayRemoveStreams bool) {
 
 	i.flushQueuesDone.Wait()
 	level.Debug(i.logger).Log("msg", "flush queues have drained")
-}
-
-type flushOp struct {
-	from      model.Time
-	userID    string
-	fp        model.Fingerprint
-	immediate bool
-}
-
-func (o *flushOp) Key() string {
-	return fmt.Sprintf("%s-%s-%v", o.userID, o.fp, o.immediate)
-}
-
-func (o *flushOp) Priority() int64 {
-	return -int64(o.from)
 }
 
 // sweepUsers periodically schedules series for flushing and garbage collects users with no series

--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prometheus/prometheus/util/pool"
 
 	"github.com/grafana/dskit/instrument"
 	"github.com/grafana/dskit/ring"
@@ -45,7 +44,6 @@ type TeeService struct {
 
 	flushQueue chan clientRequest
 
-	bufferPool   *pool.Pool
 	buffersMutex *sync.Mutex
 	buffers      map[string][]distributor.KeyedStream
 }

--- a/pkg/querytee/proxy_endpoint.go
+++ b/pkg/querytee/proxy_endpoint.go
@@ -21,14 +21,14 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/server"
 )
 
+// TODO(chaudum): This interface is likely unused
+// [ProxyEndpoint] uses [comparator.ResponsesComparator], not this interface.
 type ResponsesComparator interface {
 	Compare(expected, actual []byte, queryEvaluationTime time.Time) (*ComparisonSummary, error)
 }
 
-type ComparisonSummary struct {
-	skipped        bool
-	missingMetrics int
-}
+// TODO(chaudum): This struct is likely unused
+type ComparisonSummary struct{}
 
 type ProxyEndpoint struct {
 	backends   []*ProxyBackend

--- a/pkg/ruler/base/store_mock_test.go
+++ b/pkg/ruler/base/store_mock_test.go
@@ -129,28 +129,6 @@ var (
 			},
 		},
 	}
-
-	mockSpecialCharRules = map[string]rulespb.RuleGroupList{
-		"user1": {
-			&rulespb.RuleGroupDesc{
-				Name:      ")(_+?/|group1+/?",
-				Namespace: ")(_+?/|namespace1+/?",
-				User:      "user1",
-				Rules: []*rulespb.RuleDesc{
-					{
-						Record: "UP_RULE",
-						Expr:   "up",
-					},
-					{
-						Alert: "UP_ALERT",
-						Expr:  "up < 1",
-					},
-				},
-				Interval: interval,
-				Limit:    limit,
-			},
-		},
-	}
 )
 
 func newMockRuleStore(rules map[string]rulespb.RuleGroupList) *mockRuleStore {

--- a/pkg/ui/service.go
+++ b/pkg/ui/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/fs"
 	"net"
 	"net/http"
 	"strings"
@@ -31,7 +30,6 @@ type Service struct {
 	ring          *ring.Ring
 	localNodeName string
 	router        *mux.Router
-	uiFS          fs.FS
 
 	client    *http.Client
 	localAddr string


### PR DESCRIPTION
### Summary

This PR removes dead/unused code from multiple packages.
Detected using [staticcheck](https://staticcheck.dev).

See individual commit messages for further details.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are predominantly deletions of unused helpers, fields, and deprecated internal code paths; no behavioral changes are intended beyond reducing surface area.
> 
> **Overview**
> **Removes dead/unused code across the repo** (largely flagged by `staticcheck`) to reduce maintenance burden.
> 
> This deletes deprecated/unreferenced internal paths (eg. ingester chunk-transfer `consumeChunk` helpers), trims unused config/constants and struct fields (Kafka, LogQL bench/UI/pattern), and simplifies types by removing unused members.
> 
> Test-only cleanup removes now-unneeded mocks/helpers and debug utilities, plus minor LogQL/query HTTP error constant cleanup and placeholder notes for likely-unused `querytee` types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cee6124c6b92f6f1632d0b854bf42643d09fb77b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->