### PR TITLE
fix(logql): Fix nil pointer dereference caused by data race during query blocking

### DIFF
--- a/pkg/logql/blocker.go
+++ b/pkg/logql/blocker.go
@@ -54,28 +54,33 @@ func (qb *queryBlocker) isBlocked(ctx context.Context, tenant string) bool {
 			continue
 		}
 
+		// Use local copies to avoid mutating the shared config object.
+		// This makes `isBlocked` safe to be called concurrently.
+		pattern := b.Pattern
+		isRegex := b.Regex
+
 		// if no pattern is given, assume we want to match all queries
-		if b.Pattern == "" {
-			b.Pattern = ".*"
-			b.Regex = true
+		if pattern == "" {
+			pattern = ".*"
+			isRegex = true
 		}
 
-		if strings.TrimSpace(b.Pattern) == strings.TrimSpace(query) {
+		if strings.TrimSpace(pattern) == strings.TrimSpace(query) {
 			typesMatched, tagsMatched, blocked := qb.block(ctx, b, typ, logger)
 			level.Warn(logger).Log("msg", "query blocker matched with exact match policy", "query", query, "typesMatched", typesMatched, "tagsMatched", tagsMatched, "blocked", blocked)
 			return blocked
 		}
 
-		if b.Regex {
-			r, err := regexp.Compile(b.Pattern)
+		if isRegex {
+			r, err := regexp.Compile(pattern)
 			if err != nil {
-				level.Error(logger).Log("msg", "query blocker regex does not compile", "pattern", b.Pattern, "err", err)
+				level.Error(logger).Log("msg", "query blocker regex does not compile", "pattern", pattern, "err", err)
 				continue
 			}
 
 			if r.MatchString(query) {
 				typesMatched, tagsMatched, blocked := qb.block(ctx, b, typ, logger)
-				level.Warn(logger).Log("msg", "query blocker matched with regex policy", "pattern", b.Pattern, "query", query, "typesMatched", typesMatched, "tagsMatched", tagsMatched, "blocked", blocked)
+				level.Warn(logger).Log("msg", "query blocker matched with regex policy", "pattern", pattern, "query", query, "typesMatched", typesMatched, "tagsMatched", tagsMatched, "blocked", blocked)
 				return blocked
 			}
 		}

--- a/pkg/logql/blocker_test.go
+++ b/pkg/logql/blocker_test.go
@@ -3,6 +3,7 @@ package logql
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -182,6 +183,39 @@ func TestEngine_ExecWithBlockedQueries(t *testing.T) {
 			require.Equal(t, err.Error(), test.expectedErr.Error())
 		})
 	}
+}
+
+func TestEngine_BlockedQueries_ConcurrentAccess(t *testing.T) {
+	shared := []*validation.BlockedQuery{
+		{
+			Pattern: "", // empty → triggers the in-place mutation
+			Types:   []string{QueryTypeMetric},
+		},
+	}
+
+	limits := &fakeLimits{
+		maxSeries:      10,
+		blockedQueries: shared,
+	}
+	eng := NewEngine(EngineOpts{}, getLocalQuerier(100000), limits, log.NewNopLogger())
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	queryStr := `topk(1,rate(({app=~"foo|bar"})[1m]))`
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			params, err := NewLiteralParams(queryStr, time.Unix(0, 0), time.Unix(100000, 0), 60*time.Second, 0, logproto.FORWARD, 1000, nil, nil)
+			require.NoError(t, err)
+			q := eng.Query(params)
+			ctx := user.InjectOrgID(context.Background(), "fake")
+			_, _ = q.Exec(ctx)
+		}()
+	}
+
+	wg.Wait()
 }
 
 func TestEngine_ExecWithBlockedQueries_Tags(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix a data race in `queryBlocker.isBlocked` that causes nil-pointer panics under concurrent query load
- Add a concurrent-access regression test (`TestEngine_BlockedQueries_ConcurrentAccess`)

## Problem

`isBlocked` iterates over blocked-query rules returned by `BlockedQueries()`, which returns `[]*validation.BlockedQuery` — pointers to **shared config structs**. When a rule has an empty `Pattern`, the code mutated the shared object in-place:

```go
if b.Pattern == "" {
    b.Pattern = ".*"   // writes to shared struct
    b.Regex = true     // writes to shared struct
}
```

Every incoming query calls `isBlocked` in its own goroutine. One goroutine writing `b.Pattern` while another reads it is a data race. The concurrent read can observe a torn value, which panics in `strings.TrimSpace`:

```
panic: runtime error: invalid memory address or nil pointer dereference

strings.TrimSpace({0x0?, 0x692940277590?})
    strings/strings.go:1093 +0x38
github.com/grafana/loki/v3/pkg/logql.(*queryBlocker).isBlocked(...)
    pkg/logql/blocker.go:63 +0x1cc
```

## Fix

Copy `b.Pattern` and `b.Regex` to local variables before the defaulting logic. The shared config object is never mutated, eliminating the race.

## How to verify

```bash
go test -race -run TestEngine_BlockedQueries_ConcurrentAccess -count=1 ./pkg/logql/
```

Reverting the `blocker.go` change while keeping the test will reproduce the race detector failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query-blocking logic that runs on every query and changes how empty patterns are handled internally, so any subtle behavior difference could affect blocking decisions. The change is small and covered by a new concurrency regression test.
> 
> **Overview**
> Prevents `queryBlocker.isBlocked` from mutating shared `BlockedQuery` config when defaulting an empty pattern, by using local copies of `Pattern`/`Regex` for matching and regex compilation.
> 
> Adds `TestEngine_BlockedQueries_ConcurrentAccess` to exercise blocked-query evaluation under concurrent query execution and catch future races/panics when rules are shared across goroutines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 721e5fefbbb376b462dfc97805e90a9f0e9c473e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->