### PR TITLE
fix(ruler): Fix broken structured logging for insight logs

### DIFF
--- a/pkg/ruler/evaluator_remote.go
+++ b/pkg/ruler/evaluator_remote.go
@@ -83,7 +83,7 @@ func NewRemoteEvaluator(client httpgrpc.HTTPClient, overrides RulesLimits, logge
 		client:         client,
 		overrides:      overrides,
 		logger:         logger,
-		insightsLogger: log.With(util_log.Logger, "msg", "request timings", "insight", "true", "source", "loki_ruler", "rule_name"),
+		insightsLogger: log.With(util_log.Logger, "msg", "request timings", "insight", "true", "source", "loki_ruler"),
 		metrics:        newMetrics(registerer),
 	}, nil
 }
@@ -288,7 +288,7 @@ func (r *RemoteEvaluator) query(ctx context.Context, orgID, query string, ts tim
 	if err != nil {
 		return nil, err
 	}
-	level.Info(r.insightsLogger).Log(ruleName, "rule_type", ruleType, "total", dr.Statistics.Summary.ExecTime, "total_bytes", dr.Statistics.Summary.TotalBytesProcessed, "query_hash", util.HashedQuery(query))
+	level.Info(r.insightsLogger).Log("rule_name", ruleName, "rule_type", ruleType, "total", dr.Statistics.Summary.ExecTime, "total_bytes", dr.Statistics.Summary.TotalBytesProcessed, "query_hash", util.HashedQuery(query))
 	return dr, err
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
With() and Log() must both use key-value pairs.

**Which issue(s) this PR fixes**:
Currently we get logs like
```
level=info ts=2026-04-29T07:03:09.496995304Z caller=evaluator_remote.go:294 msg="request timings" insight=true source=loki_ruler rule_name=(MISSING) MyAlertName=rule_type alerting=total 1.89186312=total_bytes 1433348385=query_hash 842741851=(MISSING)
```
There is a skew between the keys and values due to the wrong usage of `With()`.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d7bd0be64ca422e0910af60775c6696d1da4e695. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->