### PR TITLE
fix: Use KafkaWriter in dataobj-tee

### DIFF
--- a/pkg/distributor/dataobj_tee.go
+++ b/pkg/distributor/dataobj_tee.go
@@ -13,7 +13,6 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/loki/v3/pkg/kafka"
 )
@@ -68,7 +67,7 @@ type DataObjTee struct {
 	limitsClient *ingestLimits
 	rateBatcher  *rateBatcher // nil if batching is disabled
 	limits       Limits
-	kafkaClient  *kgo.Client
+	kafkaClient  KafkaProducer
 	resolver     *segmentationPartitionResolver
 	logger       log.Logger
 
@@ -86,7 +85,7 @@ func NewDataObjTee(
 	resolver *segmentationPartitionResolver,
 	limitsClient *ingestLimits,
 	limits Limits,
-	kafkaClient *kgo.Client,
+	kafkaClient KafkaProducer,
 	logger log.Logger,
 	r prometheus.Registerer,
 ) (*DataObjTee, error) {
@@ -221,7 +220,7 @@ func (t *DataObjTee) duplicate(ctx context.Context, tenant string, stream segmen
 		return
 	}
 
-	results := t.kafkaClient.ProduceSync(ctx, records...)
+	results := t.kafkaClient.ProduceSync(ctx, records)
 	if err := results.FirstErr(); err != nil {
 		level.Error(t.logger).Log("msg", "failed to produce records", "err", err)
 		t.streamFailures.Inc()

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -324,7 +324,7 @@ func New(
 				resolver,
 				ingestLimits,
 				overrides,
-				kafkaClient,
+				kafkaWriter,
 				logger,
 				registerer,
 			)


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit uses the KafkaWriter in the dataobj-tee so both topics use the same limits in `pkg/kafka/client/writer_client.go`.

In future, we will deprecate the limits from `writer_client.go` and use `MaxBufferedBytes` instead, since twmb/franz-go/issues/777 has been fixed.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the distributor write path to Kafka by changing the producer type and `ProduceSync` call signature; behavior should be equivalent but miswiring could break or alter tee writes under load.
> 
> **Overview**
> The data-object tee now writes via the distributor’s shared `KafkaProducer` (`kafkaWriter`) instead of using a dedicated `*kgo.Client`, so both Kafka topics follow the same writer limits/configuration.
> 
> This updates `DataObjTee`/`NewDataObjTee` to accept `KafkaProducer` and adjusts the `ProduceSync` invocation to match the producer API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dfdc5c817bea11628dae15b17773f1a9efc6127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->