### PR TITLE
fix(logql): Handle `nil` entry in blocked queries slice

### DIFF
--- a/pkg/logql/blocker.go
+++ b/pkg/logql/blocker.go
@@ -43,6 +43,9 @@ func (qb *queryBlocker) isBlocked(ctx context.Context, tenant string) bool {
 	logger := log.With(qb.logger, "user", tenant, "type", typ)
 
 	for _, b := range blocks {
+		if b == nil {
+			continue
+		}
 
 		if b.Hash > 0 {
 			if b.Hash == util.HashedQuery(query) {

--- a/pkg/logql/blocker_test.go
+++ b/pkg/logql/blocker_test.go
@@ -29,6 +29,12 @@ func TestEngine_ExecWithBlockedQueries(t *testing.T) {
 		expectedErr error
 	}{
 		{
+			name:        "edge case: slice contains nil value",
+			q:           defaultQuery,
+			blocked:     []*validation.BlockedQuery{nil},
+			expectedErr: nil,
+		},
+		{
 			"exact match all types",
 			defaultQuery, []*validation.BlockedQuery{
 				{


### PR DESCRIPTION
### Summary

This PR fixes an edge case where a `nil` entry in the blocked queries slice leads to a nil-pointer dereference during execution.

When the blocked queries slice is generated through the tenant limits, this should never be the case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a defensive nil check in the blocked-query loop and a regression test; no behavior changes for valid policies.
> 
> **Overview**
> Prevents a nil-pointer panic when the `BlockedQueries` slice contains `nil` by skipping nil entries during evaluation.
> 
> Adds a unit test covering this edge case to ensure queries execute normally when a nil policy is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95c1c78c35dbeba7a9467771272aa7ca51a744b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->