### PR TITLE
fix: Quick fix for various errors return 5xx

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -948,7 +948,7 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 // should be retryable in the OTEL spec.
 func trackerErrToStatusErr(err error) error {
 	if errors.Is(err, kgo.ErrMaxBuffered) {
-		return httpgrpc.Error(503, "service unavailable")
+		return httpgrpc.Error(http.StatusServiceUnavailable, "service unavailable")
 	}
 	return err
 }

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -935,12 +935,22 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 
 	select {
 	case err := <-tracker.err:
-		return nil, err
+		return nil, trackerErrToStatusErr(err)
 	case <-tracker.done:
 		return &logproto.PushResponse{}, validationErr
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
+}
+
+// TODO(grobinson): Figure out how to clean this up, this is a quick fix to ensure
+// we return the correct status codes for various errors. All status codes returned
+// should be retryable in the OTEL spec.
+func trackerErrToStatusErr(err error) error {
+	if errors.Is(err, kgo.ErrMaxBuffered) {
+		return httpgrpc.Error(503, "service unavailable")
+	}
+	return err
 }
 
 // missingEnforcedLabels returns true if the stream is missing any of the required labels.


### PR DESCRIPTION
**What this PR does / why we need it**:

This should return an appropriate status code instead of 500.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error-to-status mapping on the ingestion hot path; while small and targeted, it can alter client retry behavior and observed failure codes under Kafka backpressure.
> 
> **Overview**
> Ensures `Distributor.PushWithResolver()` returns an appropriate *retryable* HTTP status when a push fails due to Kafka producer backpressure.
> 
> Specifically, errors sent via `PushTracker` are now passed through `trackerErrToStatusErr()`, which maps `kgo.ErrMaxBuffered` to `503 Service Unavailable` (via `httpgrpc.Error`) instead of returning the raw error (often surfacing as a generic 500).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 132eda51515b5fc967e2f74d8da15b5ba2b0a7ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->