### PR TITLE
fix(compactor): Skip retention scans for zero retention

### DIFF
--- a/pkg/compactor/retention/expiration.go
+++ b/pkg/compactor/retention/expiration.go
@@ -260,7 +260,10 @@ func findLatestRetentionStartTime(now model.Time, limits Limits) latestRetention
 	defaultLimits := limits.DefaultLimits()
 	smallestDefaultRetentionPeriod := defaultLimits.RetentionPeriod
 	for _, streamRetention := range defaultLimits.StreamRetention {
-		if streamRetention.Period < smallestDefaultRetentionPeriod {
+		if streamRetention.Period <= 0 {
+			continue
+		}
+		if smallestDefaultRetentionPeriod <= 0 || streamRetention.Period < smallestDefaultRetentionPeriod {
 			smallestDefaultRetentionPeriod = streamRetention.Period
 		}
 	}
@@ -273,21 +276,37 @@ func findLatestRetentionStartTime(now model.Time, limits Limits) latestRetention
 	for userID, limit := range limitsByUserID {
 		smallestRetentionPeriodForUser := limit.RetentionPeriod
 		for _, streamRetention := range limit.StreamRetention {
-			if streamRetention.Period < smallestRetentionPeriodForUser {
+			if streamRetention.Period <= 0 {
+				continue
+			}
+			if smallestRetentionPeriodForUser <= 0 || streamRetention.Period < smallestRetentionPeriodForUser {
 				smallestRetentionPeriodForUser = streamRetention.Period
 			}
 		}
 
-		// update the overallSmallestRetentionPeriod if this user has smaller value
+		if smallestRetentionPeriodForUser <= 0 {
+			smallestRetentionPeriodByUser[userID] = 0
+			continue
+		}
+
+		// update the overallSmallestRetentionPeriod if this user has a smaller positive value
 		smallestRetentionPeriodByUser[userID] = now.Add(time.Duration(-smallestRetentionPeriodForUser))
-		if smallestRetentionPeriodForUser < overallSmallestRetentionPeriod {
+		if overallSmallestRetentionPeriod <= 0 || smallestRetentionPeriodForUser < overallSmallestRetentionPeriod {
 			overallSmallestRetentionPeriod = smallestRetentionPeriodForUser
 		}
 	}
 
+	var defaults, overall model.Time
+	if smallestDefaultRetentionPeriod > 0 {
+		defaults = now.Add(time.Duration(-smallestDefaultRetentionPeriod))
+	}
+	if overallSmallestRetentionPeriod > 0 {
+		overall = now.Add(time.Duration(-overallSmallestRetentionPeriod))
+	}
+
 	return latestRetentionStartTime{
-		defaults: now.Add(time.Duration(-smallestDefaultRetentionPeriod)),
-		overall:  now.Add(time.Duration(-overallSmallestRetentionPeriod)),
+		defaults: defaults,
+		overall:  overall,
 		byUser:   smallestRetentionPeriodByUser,
 	}
 }

--- a/pkg/compactor/retention/expiration_test.go
+++ b/pkg/compactor/retention/expiration_test.go
@@ -530,6 +530,107 @@ func TestFindLatestRetentionStartTime(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "default retention period zero disables retention entirely",
+			limit: fakeLimits{
+				defaultLimit: retentionLimit{
+					retentionPeriod: 0,
+				},
+			},
+			expectedLatestRetentionStartTime: latestRetentionStartTime{
+				overall:  0,
+				defaults: 0,
+				byUser:   map[string]model.Time{},
+			},
+		},
+		{
+			name: "default retention zero with all stream retentions zero does not scan any tables",
+			limit: fakeLimits{
+				defaultLimit: retentionLimit{
+					retentionPeriod: 0,
+					streamRetention: []validation.StreamRetention{
+						{Period: model.Duration(0)},
+					},
+				},
+			},
+			expectedLatestRetentionStartTime: latestRetentionStartTime{
+				overall:  0,
+				defaults: 0,
+				byUser:   map[string]model.Time{},
+			},
+		},
+		{
+			name: "default retention zero with positive stream retention uses stream period",
+			limit: fakeLimits{
+				defaultLimit: retentionLimit{
+					retentionPeriod: 0,
+					streamRetention: []validation.StreamRetention{
+						{Period: model.Duration(7 * dayDuration)},
+					},
+				},
+			},
+			expectedLatestRetentionStartTime: latestRetentionStartTime{
+				overall:  now.Add(-7 * dayDuration),
+				defaults: now.Add(-7 * dayDuration),
+				byUser:   map[string]model.Time{},
+			},
+		},
+		{
+			name: "stream retention zero does not override positive default",
+			limit: fakeLimits{
+				defaultLimit: retentionLimit{
+					retentionPeriod: 30 * dayDuration,
+					streamRetention: []validation.StreamRetention{
+						{Period: model.Duration(0)},
+					},
+				},
+			},
+			expectedLatestRetentionStartTime: latestRetentionStartTime{
+				overall:  now.Add(-30 * dayDuration),
+				defaults: now.Add(-30 * dayDuration),
+				byUser:   map[string]model.Time{},
+			},
+		},
+		{
+			name: "per-user retention zero disables retention for user and does not override overall",
+			limit: fakeLimits{
+				defaultLimit: retentionLimit{
+					retentionPeriod: 30 * dayDuration,
+				},
+				perTenant: map[string]retentionLimit{
+					"0": {retentionPeriod: 0},
+					"1": {retentionPeriod: 7 * dayDuration},
+				},
+			},
+			expectedLatestRetentionStartTime: latestRetentionStartTime{
+				overall:  now.Add(-7 * dayDuration),
+				defaults: now.Add(-30 * dayDuration),
+				byUser: map[string]model.Time{
+					"0": 0,
+					"1": now.Add(-7 * dayDuration),
+				},
+			},
+		},
+		{
+			name: "default zero with some users having positive retention",
+			limit: fakeLimits{
+				defaultLimit: retentionLimit{
+					retentionPeriod: 0,
+				},
+				perTenant: map[string]retentionLimit{
+					"0": {retentionPeriod: 30 * dayDuration},
+					"1": {retentionPeriod: 7 * dayDuration},
+				},
+			},
+			expectedLatestRetentionStartTime: latestRetentionStartTime{
+				overall:  now.Add(-7 * dayDuration),
+				defaults: 0,
+				byUser: map[string]model.Time{
+					"0": now.Add(-30 * dayDuration),
+					"1": now.Add(-7 * dayDuration),
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			latestRetentionStartTime := findLatestRetentionStartTime(now, tc.limit)
@@ -547,6 +648,7 @@ func TestExpirationChecker_IntervalMayHaveExpiredChunks(t *testing.T) {
 			byUser: map[string]model.Time{
 				"user0": now.Add(-72 * time.Hour),
 				"user1": now.Add(-24 * time.Hour),
+				"user2": 0,
 			},
 		},
 	}
@@ -608,6 +710,16 @@ func TestExpirationChecker_IntervalMayHaveExpiredChunks(t *testing.T) {
 				End:   now.Add(-73 * time.Hour),
 			},
 			hasExpiredChunks: true,
+		},
+
+		// user2 has custom retention disabled, so it must not fall back to defaults
+		{
+			name:   "user2 index - disabled retention",
+			userID: "user2",
+			interval: model.Interval{
+				Start: now.Add(-49 * time.Hour),
+				End:   now.Add(-47 * time.Hour),
+			},
 		},
 
 		// user3 not having custom retention so using defaultLatestRetentionStartTime


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes retention scan planning so a retention period of `0` is treated as disabled when computing
the latest retention start time.


**Which issue(s) this PR fixes**:
Fixes #21755 

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retention cutoff computation used to plan compactor scans; incorrect handling could cause missed expirations or unnecessary scans, but behavior is well-covered by new edge-case tests.
> 
> **Overview**
> Fixes retention scan planning so a retention period of `0` is treated as *disabled* when computing the latest retention cutoff.
> 
> `findLatestRetentionStartTime` now ignores non-positive stream retentions, avoids generating cutoff timestamps when default/overall retention is non-positive, and records per-tenant `0` cutoffs to prevent falling back to default retention. Tests are expanded to cover zero-retention combinations (default, stream, and per-tenant) and to ensure `IntervalMayHaveExpiredChunks` does not scan tables for tenants with disabled retention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08ba1b3eca33ac1892365f8314631744a85b3760. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->