### PR TITLE
chore!: Remove deprecated `loki_log_messages_total` metric

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -37,6 +37,10 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 ## Main / Unreleased
 
+### Breaking change: Rename and remove metrics
+
+- The deprecated metric `loki_log_messages_total` is removed in favor of `loki_internal_log_messages_total`.
+
 ### Breaking change: Drop support for non-TSDB stores in jsonnet lib 
 
 With the removal of deprecated storage backends, the Loki jsonnet library is also cleaned up to reflect these changes. Affected configuration flags are:

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -62,7 +62,6 @@ func Flush() error {
 type prometheusLogger struct {
 	baseLogger          log.Logger
 	logger              log.Logger
-	logMessages         *prometheus.CounterVec
 	internalLogMessages *prometheus.CounterVec
 	logFlushes          prometheus.Histogram
 }
@@ -125,16 +124,12 @@ func newPrometheusLogger(l dslog.Level, format string, reg prometheus.Registerer
 		flushTimeout         = 100 * time.Millisecond // flush the buffer after 100ms regardless of how full it is, to prevent losing many logs in case of ungraceful termination
 	)
 
-	logMessages := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Namespace: constants.Loki,
-		Name:      "log_messages_total",
-		Help:      "DEPRECATED. Use internal_log_messages_total for the same functionality. Total number of log messages created by Loki itself.",
-	}, []string{"level"})
 	internalLogMessages := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Namespace: constants.Loki,
 		Name:      "internal_log_messages_total",
 		Help:      "Total number of log messages created by Loki itself.",
 	}, []string{"level"})
+
 	logFlushes := promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 		Namespace: constants.Loki,
 		Name:      "log_flushes",
@@ -163,7 +158,6 @@ func newPrometheusLogger(l dslog.Level, format string, reg prometheus.Registerer
 	plogger = &prometheusLogger{
 		baseLogger:          baseLogger,
 		logger:              logger,
-		logMessages:         logMessages,
 		internalLogMessages: internalLogMessages,
 		logFlushes:          logFlushes,
 	}
@@ -175,7 +169,6 @@ func newPrometheusLogger(l dslog.Level, format string, reg prometheus.Registerer
 		level.ErrorValue(),
 	}
 	for _, level := range supportedLevels {
-		plogger.logMessages.WithLabelValues(level.String())
 		plogger.internalLogMessages.WithLabelValues(level.String())
 	}
 
@@ -198,7 +191,6 @@ func (pl *prometheusLogger) Log(kv ...interface{}) error {
 			break
 		}
 	}
-	pl.logMessages.WithLabelValues(l).Inc()
 	pl.internalLogMessages.WithLabelValues(l).Inc()
 	return nil
 }


### PR DESCRIPTION
### Summary

Use the `loki_internal_messages_total` metric instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it is a breaking observability change: dashboards/alerts/scrapes referencing `loki_log_messages_total` will stop working and must switch to `loki_internal_log_messages_total`. Code changes are small and localized to logging/metrics instrumentation.
> 
> **Overview**
> Removes the deprecated Prometheus counter `loki_log_messages_total` from `pkg/util/log/log.go`, leaving `loki_internal_log_messages_total` as the single counter for Loki’s own log message volume.
> 
> Updates the upgrade guide to call out this *breaking metrics change* and direct users to migrate dashboards/alerts to `loki_internal_log_messages_total`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95153c95e529b64eb2ab78b673c0c47c019a69f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->