### PR TITLE
chore!: Rename metric `loki_log_flushes`

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -40,6 +40,7 @@ The output is incredibly verbose as it shows the entire internal config struct u
 ### Breaking change: Rename and remove metrics
 
 - The deprecated metric `loki_log_messages_total` is removed in favor of `loki_internal_log_messages_total`.
+- The metric `loki_log_flushes` is renamed to `loki_internal_log_flushes` to be consistent with `loki_internal_log_messages_total`.
 
 ### Breaking change: Drop support for non-TSDB stores in jsonnet lib 
 

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -132,7 +132,7 @@ func newPrometheusLogger(l dslog.Level, format string, reg prometheus.Registerer
 
 	logFlushes := promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 		Namespace: constants.Loki,
-		Name:      "log_flushes",
+		Name:      "internal_log_flushes",
 		Help:      "Histogram of log flushes using the line-buffered logger.",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, int(math.Log2(float64(logEntries)))+1),
 	})


### PR DESCRIPTION
Rename metric `loki_log_flushes` to `loki_internal_log_flushes` to be consistent with `loki_internal_log_messages_total`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it’s a **breaking Prometheus metric rename** that will break existing dashboards/alerts unless updated; runtime behavior is otherwise unchanged.
> 
> **Overview**
> Renames the buffered logger flush histogram metric from `loki_log_flushes` to `loki_internal_log_flushes` in `pkg/util/log/log.go` to align with the `loki_internal_*` naming scheme.
> 
> Updates the upgrade guide to document the metric rename as a breaking change so operators can adjust dashboards/alerts accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d192758737b8f0850cc8579fabb65a888781f490. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->