### PR TITLE
chore: Update go version in go.mod files in chunks/dataobj inspect tools and pkg/push

### DIFF
--- a/cmd/chunks-inspect/go.mod
+++ b/cmd/chunks-inspect/go.mod
@@ -1,8 +1,6 @@
 module github.com/grafana/loki/cmd/chunks-inspect
 
-go 1.24
-
-toolchain go1.24.0
+go 1.26.2
 
 require (
 	github.com/golang/snappy v1.0.0

--- a/cmd/dataobj-inspect/go.mod
+++ b/cmd/dataobj-inspect/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/loki/cmd/dataobj-inspect
 
-go 1.25.7
+go 1.26.2
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0

--- a/pkg/push/go.mod
+++ b/pkg/push/go.mod
@@ -1,8 +1,6 @@
 module github.com/grafana/loki/pkg/push
 
-go 1.24.0
-
-toolchain go1.24.3
+go 1.26.2
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1050,7 +1050,7 @@ github.com/grafana/gomemcache/memcache
 ## explicit; go 1.13
 github.com/grafana/jsonparser
 # github.com/grafana/loki/pkg/push v0.0.0-20250630054201-94c0ba7b0952 => ./pkg/push
-## explicit; go 1.24.0
+## explicit; go 1.26.2
 github.com/grafana/loki/pkg/push
 # github.com/grafana/otel-profiling-go v0.5.1
 ## explicit; go 1.16


### PR DESCRIPTION
**What this PR does / why we need it**:
Updating the go version in go.mod files in chunks/dataobj, inspect tools, and pkg/push to address some CVEs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low functional risk (no code changes), but upgrading the declared Go version/toolchain can affect build reproducibility, CI, and vendoring across these submodules.
> 
> **Overview**
> **Bumps the declared Go version to `1.26.2`** in the `chunks-inspect`, `dataobj-inspect`, and `pkg/push` submodules, removing older `toolchain` directives where present.
> 
> Updates `vendor/modules.txt` metadata to reflect the new Go version for the vendored `pkg/push` module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fffd210a9b638a4e060a4737a6a8956eeda19ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->