### PR TITLE
fix(tsdb): Do not try to ship TSDBs that cannot be opened upon start

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/manager.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/multierror"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -77,16 +78,18 @@ func NewTSDBManager(
 	}
 }
 
-func (m *tsdbManager) Start() (err error) {
+func (m *tsdbManager) Start() error {
 	var (
 		buckets, indices, loadingErrors int
 	)
 
+	var multiErr multierror.MultiError
+
 	defer func() {
 		level.Info(m.log).Log(
 			"msg", "loaded leftover local indices",
-			"err", err,
-			"successful", err == nil,
+			"err", multiErr.Err(),
+			"successful", multiErr.Err() == nil,
 			"buckets", buckets,
 			"indices", indices,
 			"failures", loadingErrors,
@@ -97,7 +100,8 @@ func (m *tsdbManager) Start() (err error) {
 	mulitenantDir := managerMultitenantDir(m.dir)
 	files, err := os.ReadDir(mulitenantDir)
 	if err != nil {
-		return err
+		multiErr.Add(err)
+		return multiErr.Err()
 	}
 
 	for _, f := range files {
@@ -134,22 +138,24 @@ func (m *tsdbManager) Start() (err error) {
 
 			if err != nil {
 				level.Warn(m.log).Log(
-					"msg", "",
+					"msg", "failed to load shippable TSDB file",
 					"tsdbPath", prefixed.Path(),
 					"err", err.Error(),
 				)
+				multiErr.Add(err)
 				loadingErrors++
+				continue
 			}
 
 			if err := m.shipper.AddIndex(bucket, "", loaded); err != nil {
+				multiErr.Add(err)
 				loadingErrors++
-				return err
+				continue
 			}
 		}
-
 	}
 
-	return nil
+	return multiErr.Err()
 }
 
 type chunkInfo struct {


### PR DESCRIPTION
### Summary

On TSDB shipper start the manager tries to load all local TSDB files and hand them to the shipper, which eventually uploads them to object storage.

This change fixes a bug that causes a nil pointer dereference when a TSDB file fails to open but is nevertheless added to the shipper.

**What this PR does / why we need it**:
Closes https://github.com/grafana/loki/pull/9297

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TSDB shipper startup behavior to continue on per-file failures and return an aggregated error, which could alter failure visibility and startup success conditions.
> 
> **Overview**
> On `tsdbManager.Start`, failures to open local TSDB files no longer cause partially-initialized indices to be handed to the shipper; broken TSDBs are skipped and a clearer warning is logged.
> 
> Startup now accumulates load/add errors via `multierror` and continues scanning remaining TSDBs, returning the aggregated error at the end (and reporting it in the final "loaded leftover local indices" log).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59f718cb7d1f759997154071dbc60581c307eb68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->