### PR TITLE
fix: Flush reason counter not initialized to 0, breaks PromQL functions

### DIFF
--- a/pkg/dataobj/consumer/flush.go
+++ b/pkg/dataobj/consumer/flush.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	flushReasonMaxAge      = "max_age"
 	flushReasonBuilderFull = "builder_full"
 	flushReasonIdle        = "idle"
+	flushReasonMaxAge      = "max_age"
 )
 
 // A sorter allows mocking of [logsobj.Sorter] in tests.
@@ -80,6 +80,11 @@ func newFlusher(sorter sorter, uploader uploader, logger log.Logger, r prometheu
 			NativeHistogramMinResetDuration: 0,
 		}),
 	}
+	// Initialize each counter to 0, otherwise neither the rate nor increase
+	// PromQL functions detect increases from 0 to 1.
+	f.flushes.WithLabelValues(flushReasonBuilderFull).Add(0)
+	f.flushes.WithLabelValues(flushReasonIdle).Add(0)
+	f.flushes.WithLabelValues(flushReasonMaxAge).Add(0)
 	f.flushFunc = f.flush
 	return f
 }

--- a/pkg/dataobj/consumer/flush_test.go
+++ b/pkg/dataobj/consumer/flush_test.go
@@ -39,7 +39,7 @@ func TestFlusher_Flush(t *testing.T) {
 		}))
 		f := newFlusher(testSorter, testUploader, log.NewNopLogger(), reg)
 		// Flush the builder we created earlier.
-		objectPath, err := f.Flush(testCtx, testBuilder, "test_sync")
+		objectPath, err := f.Flush(testCtx, testBuilder, flushReasonBuilderFull)
 		require.NoError(t, err)
 		require.Equal(t, "object_001", objectPath)
 		// Check that the dataobj was flushed and uploaded.
@@ -47,7 +47,9 @@ func TestFlusher_Flush(t *testing.T) {
 		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 	# HELP loki_dataobj_consumer_flushes_total Total number of flushes.
 	# TYPE loki_dataobj_consumer_flushes_total counter
-	loki_dataobj_consumer_flushes_total{reason="test_sync"} 1
+	loki_dataobj_consumer_flushes_total{reason="builder_full"} 1
+	loki_dataobj_consumer_flushes_total{reason="idle"} 0
+	loki_dataobj_consumer_flushes_total{reason="max_age"} 0
 	# HELP loki_dataobj_consumer_flush_failures_total Total number of failed flushes.
 	# TYPE loki_dataobj_consumer_flush_failures_total counter
 	loki_dataobj_consumer_flush_failures_total 0
@@ -66,13 +68,15 @@ func TestFlusher_Flush(t *testing.T) {
 			return "", errors.New("mock error")
 		}
 		// Flush the builder we created earlier.
-		objectPath, err := f.Flush(testCtx, testBuilder, "test_sync")
+		objectPath, err := f.Flush(testCtx, testBuilder, flushReasonBuilderFull)
 		require.EqualError(t, err, "mock error")
 		require.Equal(t, "", objectPath)
 		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP loki_dataobj_consumer_flushes_total Total number of flushes.
 		# TYPE loki_dataobj_consumer_flushes_total counter
-		loki_dataobj_consumer_flushes_total{reason="test_sync"} 1
+		loki_dataobj_consumer_flushes_total{reason="builder_full"} 1
+		loki_dataobj_consumer_flushes_total{reason="idle"} 0
+		loki_dataobj_consumer_flushes_total{reason="max_age"} 0
 		# HELP loki_dataobj_consumer_flush_failures_total Total number of failed flushes.
 		# TYPE loki_dataobj_consumer_flush_failures_total counter
 		loki_dataobj_consumer_flush_failures_total 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes `sum(rate` and `sum(increase` PromQL queries not counting increases from 0 to 1.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: metric initialization only, with tests updated to assert zero-valued series for all known `reason` labels.
> 
> **Overview**
> Fixes flusher Prometheus metrics so `loki_dataobj_consumer_flushes_total` exposes **pre-initialized time series** for the known flush reasons (`builder_full`, `idle`, `max_age`) by explicitly adding `0` for each label at flusher construction.
> 
> Updates `flush_test.go` to use the standard `flushReasonBuilderFull` label and to assert that the other reason series exist at `0`, ensuring `rate()`/`increase()` queries observe the first increment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b6f9c2ba4f2ccf0c5f8a9c8304589b0d647e1a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->