### PR TITLE
chore: Unlink logentry and fluentbit

### DIFF
--- a/clients/cmd/fluent-bit/config.go
+++ b/clients/cmd/fluent-bit/config.go
@@ -8,21 +8,20 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/dskit/flagext"
+	dskit_flagext "github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/log"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/loki/v3/clients/pkg/util"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
-
-	lokiflag "github.com/grafana/loki/v3/pkg/util/flagext"
+	"github.com/grafana/loki/v3/pkg/util/flagext"
 )
 
 var defaultClientCfg = util.Config{}
 
 func init() {
 	// Init everything with default values.
-	flagext.RegisterFlags(&defaultClientCfg)
+	dskit_flagext.RegisterFlags(&defaultClientCfg)
 }
 
 type ConfigGetter interface {
@@ -55,19 +54,19 @@ type config struct {
 
 // externalLabelsFromFluentBitLabelsOption parses the fluent-bit plugin Labels option
 // (LogQL stream selector) into ExternalLabels. Empty labels uses the default {job="fluent-bit"}.
-func externalLabelsFromFluentBitLabelsOption(labels string) (lokiflag.LabelSet, error) {
+func externalLabelsFromFluentBitLabelsOption(labels string) (flagext.LabelSet, error) {
 	if labels == "" {
 		labels = `{job="fluent-bit"}`
 	}
 	matchers, err := syntax.ParseMatchers(labels, true)
 	if err != nil {
-		return lokiflag.LabelSet{}, err
+		return flagext.LabelSet{}, err
 	}
 	labelSet := make(model.LabelSet)
 	for _, m := range matchers {
 		labelSet[model.LabelName(m.Name)] = model.LabelValue(m.Value)
 	}
-	return lokiflag.LabelSet{LabelSet: labelSet}, nil
+	return flagext.LabelSet{LabelSet: labelSet}, nil
 }
 
 func parseConfig(cfg ConfigGetter) (*config, error) {
@@ -77,7 +76,7 @@ func parseConfig(cfg ConfigGetter) (*config, error) {
 	res.bufferConfig = defaultBufferConfig
 
 	url := cfg.Get("URL")
-	var clientURL flagext.URLValue
+	var clientURL dskit_flagext.URLValue
 	if url == "" {
 		url = "http://localhost:3100/loki/api/v1/push"
 	}

--- a/clients/cmd/fluent-bit/config.go
+++ b/clients/cmd/fluent-bit/config.go
@@ -12,8 +12,8 @@ import (
 	"github.com/grafana/dskit/log"
 	"github.com/prometheus/common/model"
 
-	"github.com/grafana/loki/v3/clients/pkg/logentry/logql"
 	"github.com/grafana/loki/v3/clients/pkg/util"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
 
 	lokiflag "github.com/grafana/loki/v3/pkg/util/flagext"
 )
@@ -51,6 +51,23 @@ type config struct {
 	lineFormat           format
 	dropSingleKey        bool
 	labelMap             map[string]interface{}
+}
+
+// externalLabelsFromFluentBitLabelsOption parses the fluent-bit plugin Labels option
+// (LogQL stream selector) into ExternalLabels. Empty labels uses the default {job="fluent-bit"}.
+func externalLabelsFromFluentBitLabelsOption(labels string) (lokiflag.LabelSet, error) {
+	if labels == "" {
+		labels = `{job="fluent-bit"}`
+	}
+	matchers, err := syntax.ParseMatchers(labels, true)
+	if err != nil {
+		return lokiflag.LabelSet{}, err
+	}
+	labelSet := make(model.LabelSet)
+	for _, m := range matchers {
+		labelSet[model.LabelName(m.Name)] = model.LabelValue(m.Value)
+	}
+	return lokiflag.LabelSet{LabelSet: labelSet}, nil
 }
 
 func parseConfig(cfg ConfigGetter) (*config, error) {
@@ -133,19 +150,11 @@ func parseConfig(cfg ConfigGetter) (*config, error) {
 		res.clientConfig.BackoffConfig.MaxRetries = maxRetriesValue
 	}
 
-	labels := cfg.Get("Labels")
-	if labels == "" {
-		labels = `{job="fluent-bit"}`
-	}
-	matchers, err := logql.ParseMatchers(labels)
+	extLabels, err := externalLabelsFromFluentBitLabelsOption(cfg.Get("Labels"))
 	if err != nil {
 		return nil, err
 	}
-	labelSet := make(model.LabelSet)
-	for _, m := range matchers {
-		labelSet[model.LabelName(m.Name)] = model.LabelValue(m.Value)
-	}
-	res.clientConfig.ExternalLabels = lokiflag.LabelSet{LabelSet: labelSet}
+	res.clientConfig.ExternalLabels = extLabels
 
 	logLevel := cfg.Get("LogLevel")
 	if logLevel == "" {

--- a/clients/cmd/fluent-bit/config_labels_test.go
+++ b/clients/cmd/fluent-bit/config_labels_test.go
@@ -1,22 +1,20 @@
 package main
 
 import (
-	"errors"
-	"strings"
 	"testing"
 
 	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
-
-	lokiflag "github.com/grafana/loki/v3/pkg/util/flagext"
+	"github.com/grafana/loki/v3/pkg/util/flagext"
 )
 
 func Test_externalLabelsFromFluentBitLabelsOption(t *testing.T) {
 	tests := []struct {
 		name                 string
 		labels               string
-		want                 lokiflag.LabelSet
+		want                 flagext.LabelSet
 		wantErr              bool
 		errContain           string
 		wantErrParseMatchers bool
@@ -24,27 +22,27 @@ func Test_externalLabelsFromFluentBitLabelsOption(t *testing.T) {
 		{
 			name:   "empty uses default job",
 			labels: "",
-			want:   lokiflag.LabelSet{LabelSet: model.LabelSet{"job": "fluent-bit"}},
+			want:   flagext.LabelSet{LabelSet: model.LabelSet{"job": "fluent-bit"}},
 		},
 		{
 			name:   "explicit default selector",
 			labels: `{job="fluent-bit"}`,
-			want:   lokiflag.LabelSet{LabelSet: model.LabelSet{"job": "fluent-bit"}},
+			want:   flagext.LabelSet{LabelSet: model.LabelSet{"job": "fluent-bit"}},
 		},
 		{
 			name:   "multiple equality matchers",
 			labels: `{job="fluent-bit",env="prod"}`,
-			want:   lokiflag.LabelSet{LabelSet: model.LabelSet{"job": "fluent-bit", "env": "prod"}},
+			want:   flagext.LabelSet{LabelSet: model.LabelSet{"job": "fluent-bit", "env": "prod"}},
 		},
 		{
 			name:   "equality with regexp matcher",
 			labels: `{job="app",level=~"info|warn"}`,
-			want:   lokiflag.LabelSet{LabelSet: model.LabelSet{"job": "app", "level": "info|warn"}},
+			want:   flagext.LabelSet{LabelSet: model.LabelSet{"job": "app", "level": "info|warn"}},
 		},
 		{
 			name:   "mixed matchers from pkg/logql/syntax TestParseMatchers",
 			labels: `{app!="foo",cluster=~".+bar",bar!~".?boo"}`,
-			want: lokiflag.LabelSet{LabelSet: model.LabelSet{
+			want: flagext.LabelSet{LabelSet: model.LabelSet{
 				"app":     "foo",
 				"cluster": ".+bar",
 				"bar":     ".?boo",
@@ -77,23 +75,17 @@ func Test_externalLabelsFromFluentBitLabelsOption(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := externalLabelsFromFluentBitLabelsOption(tt.labels)
 			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
+				require.Error(t, err)
+				if tt.errContain != "" {
+					require.Contains(t, err.Error(), tt.errContain)
 				}
-				if tt.errContain != "" && !strings.Contains(err.Error(), tt.errContain) {
-					t.Fatalf("error %q should contain %q", err.Error(), tt.errContain)
-				}
-				if tt.wantErrParseMatchers && !errors.Is(err, logqlmodel.ErrParseMatchers) {
-					t.Fatalf("expected ErrParseMatchers, got %v", err)
+				if tt.wantErrParseMatchers {
+					require.ErrorIs(t, err, logqlmodel.ErrParseMatchers)
 				}
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if !got.LabelSet.Equal(tt.want.LabelSet) {
-				t.Errorf("LabelSet = %v, want %v", got.LabelSet, tt.want.LabelSet)
-			}
+			require.NoError(t, err)
+			require.True(t, got.Equal(tt.want.LabelSet), "LabelSet = %v, want %v", got.LabelSet, tt.want.LabelSet)
 		})
 	}
 }

--- a/clients/cmd/fluent-bit/config_labels_test.go
+++ b/clients/cmd/fluent-bit/config_labels_test.go
@@ -85,7 +85,7 @@ func Test_externalLabelsFromFluentBitLabelsOption(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.True(t, got.Equal(tt.want.LabelSet), "LabelSet = %v, want %v", got.LabelSet, tt.want.LabelSet)
+			require.Equal(t, tt.want.LabelSet, got.LabelSet)
 		})
 	}
 }

--- a/clients/cmd/fluent-bit/config_labels_test.go
+++ b/clients/cmd/fluent-bit/config_labels_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
+
+	lokiflag "github.com/grafana/loki/v3/pkg/util/flagext"
+)
+
+func Test_externalLabelsFromFluentBitLabelsOption(t *testing.T) {
+	tests := []struct {
+		name                 string
+		labels               string
+		want                 lokiflag.LabelSet
+		wantErr              bool
+		errContain           string
+		wantErrParseMatchers bool
+	}{
+		{
+			name:   "empty uses default job",
+			labels: "",
+			want:   lokiflag.LabelSet{LabelSet: model.LabelSet{"job": "fluent-bit"}},
+		},
+		{
+			name:   "explicit default selector",
+			labels: `{job="fluent-bit"}`,
+			want:   lokiflag.LabelSet{LabelSet: model.LabelSet{"job": "fluent-bit"}},
+		},
+		{
+			name:   "multiple equality matchers",
+			labels: `{job="fluent-bit",env="prod"}`,
+			want:   lokiflag.LabelSet{LabelSet: model.LabelSet{"job": "fluent-bit", "env": "prod"}},
+		},
+		{
+			name:   "equality with regexp matcher",
+			labels: `{job="app",level=~"info|warn"}`,
+			want:   lokiflag.LabelSet{LabelSet: model.LabelSet{"job": "app", "level": "info|warn"}},
+		},
+		{
+			name:   "mixed matchers from pkg/logql/syntax TestParseMatchers",
+			labels: `{app!="foo",cluster=~".+bar",bar!~".?boo"}`,
+			want: lokiflag.LabelSet{LabelSet: model.LabelSet{
+				"app":     "foo",
+				"cluster": ".+bar",
+				"bar":     ".?boo",
+			}},
+		},
+		{
+			name:    "invalid token",
+			labels:  "a",
+			wantErr: true,
+		},
+		{
+			name:    "unclosed brace",
+			labels:  `{app="foo"`,
+			wantErr: true,
+		},
+		{
+			name:                 "line filter not allowed for ParseMatchers",
+			labels:               `{app!="foo",cluster=~".+bar",bar!~".?boo"} |= "test"`,
+			wantErr:              true,
+			wantErrParseMatchers: true,
+		},
+		{
+			name:       "only empty-compatible regexp matcher rejected by validation",
+			labels:     `{foo=~".*"}`,
+			wantErr:    true,
+			errContain: "at least one regexp or equality matcher",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := externalLabelsFromFluentBitLabelsOption(tt.labels)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContain != "" && !strings.Contains(err.Error(), tt.errContain) {
+					t.Fatalf("error %q should contain %q", err.Error(), tt.errContain)
+				}
+				if tt.wantErrParseMatchers && !errors.Is(err, logqlmodel.ErrParseMatchers) {
+					t.Fatalf("expected ErrParseMatchers, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !got.LabelSet.Equal(tt.want.LabelSet) {
+				t.Errorf("LabelSet = %v, want %v", got.LabelSet, tt.want.LabelSet)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-on work based on this [comment](https://github.com/grafana/loki/pull/21249#pullrequestreview-4009853827), to reduce the usage of the `logentry` code.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how the fluent-bit `Labels` option is parsed/validated, which can alter startup behavior or rejected configurations for existing deployments.
> 
> **Overview**
> Fluent-bit’s Loki client config parsing no longer depends on `clients/pkg/logentry/logql`; the `Labels` option is now parsed via `pkg/logql/syntax.ParseMatchers` and mapped into `ExternalLabels`, with defaulting to `{job="fluent-bit"}` preserved.
> 
> Adds targeted unit tests for the new label parsing helper, covering valid selectors (including regexp/negative matchers) and expected error cases (invalid tokens, line filters, and validation failures).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38f71f38c454a478d8d09190de282031707d879a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->