### PR TITLE
chore: Update marshal.go to use appropriate Apache code

### DIFF
--- a/pkg/util/marshal/marshal.go
+++ b/pkg/util/marshal/marshal.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
-	indexStats "github.com/grafana/loki/v3/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
 	marshal_legacy "github.com/grafana/loki/v3/pkg/util/marshal/legacy"
 )
@@ -40,7 +39,7 @@ func WriteResponseJSON(r *http.Request, v any, w http.ResponseWriter) error {
 		return marshal_legacy.WriteLabelResponseJSON(*result, w)
 	case *logproto.SeriesResponse:
 		return WriteSeriesResponseJSON(result.GetSeries(), w)
-	case *indexStats.Stats:
+	case *logproto.IndexStatsResponse:
 		return WriteIndexStatsResponseJSON(result, w)
 	case *logproto.VolumeResponse:
 		return WriteVolumeResponseJSON(result, w)
@@ -148,9 +147,9 @@ type seriesResponseAdapter struct {
 	Data   []map[string]string `json:"data"`
 }
 
-// WriteIndexStatsResponseJSON marshals a gatewaypb.Stats to JSON and then
+// WriteIndexStatsResponseJSON marshals an IndexStatsResponse to JSON and then
 // writes it to the provided io.Writer.
-func WriteIndexStatsResponseJSON(r *indexStats.Stats, w io.Writer) error {
+func WriteIndexStatsResponseJSON(r *logproto.IndexStatsResponse, w io.Writer) error {
 	s := jsoniter.ConfigFastest.BorrowStream(w)
 	defer jsoniter.ConfigFastest.ReturnStream(s)
 	s.WriteVal(r)


### PR DESCRIPTION
**What this PR does / why we need it**:
Small PR to fix Apache-licensed code to not depend on AGPL-licensed code.

**Which issue(s) this PR fixes**:
PR 1 of many in support of https://github.com/grafana/loki/issues/13019

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a narrow type/import swap in response marshalling, with behavior unchanged aside from expecting `*logproto.IndexStatsResponse` instead of the previous stats struct.
> 
> **Overview**
> Updates `pkg/util/marshal/marshal.go` to stop depending on the `pkg/storage/stores/index/stats` type and instead handle `*logproto.IndexStatsResponse` in `WriteResponseJSON`.
> 
> `WriteIndexStatsResponseJSON` is updated accordingly (signature/comment), preserving the same JSON streaming behavior while moving the dependency to the protobuf-defined response type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a7be08bf6566681872da4410fabca26c72ba198. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->