### PR TITLE
chore: Separate seriesvolume code

### DIFF
--- a/pkg/loghttp/query.go
+++ b/pkg/loghttp/query.go
@@ -19,7 +19,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
-	"github.com/grafana/loki/v3/pkg/storage/stores/index/seriesvolume"
 	"github.com/grafana/loki/v3/pkg/util"
 )
 
@@ -40,6 +39,17 @@ const (
 	// How much stack space to allocate for unescaping JSON strings; if a string longer
 	// than this needs to be escaped, it will result in a heap allocation
 	unescapeStackBufSize = 64
+)
+
+// Volume HTTP defaults and validation duplicated here so pkg/loghttp stays free of
+// pkg/storage/stores/index/seriesvolume (AGPL). Keep in sync with that package's
+// DefaultLimit, DefaultAggregateBy, and ValidateAggregateBy.
+const (
+	defaultVolumeLimit       = 100
+	defaultVolumeAggregateBy = "series"
+
+	volumeAggregateByLabels = "labels"
+	volumeAggregateBySeries = "series"
 )
 
 // QueryResponse represents the http json response to a Loki range and instant query
@@ -567,10 +577,10 @@ func NewVolumeRangeQueryWithDefaults(matchers string) *logproto.VolumeRequest {
 		From:         from,
 		Through:      through,
 		Matchers:     matchers,
-		Limit:        seriesvolume.DefaultLimit,
+		Limit:        defaultVolumeLimit,
 		Step:         step,
 		TargetLabels: nil,
-		AggregateBy:  seriesvolume.DefaultAggregateBy,
+		AggregateBy:  defaultVolumeAggregateBy,
 	}
 }
 
@@ -720,13 +730,13 @@ func targetLabels(r *http.Request) []string {
 }
 
 func volumeLimit(r *http.Request) error {
-	l, err := parseInt(r.Form.Get("limit"), seriesvolume.DefaultLimit)
+	l, err := parseInt(r.Form.Get("limit"), defaultVolumeLimit)
 	if err != nil {
 		return err
 	}
 
 	if l == 0 {
-		r.Form.Set("limit", fmt.Sprint(seriesvolume.DefaultLimit))
+		r.Form.Set("limit", fmt.Sprint(defaultVolumeLimit))
 		return nil
 	}
 
@@ -737,13 +747,22 @@ func volumeLimit(r *http.Request) error {
 	return nil
 }
 
+func validateVolumeAggregateBy(aggregateBy string) bool {
+	switch aggregateBy {
+	case volumeAggregateByLabels, volumeAggregateBySeries:
+		return true
+	default:
+		return false
+	}
+}
+
 func volumeAggregateBy(r *http.Request) (string, error) {
 	l := r.Form.Get("aggregateBy")
 	if l == "" {
-		return seriesvolume.DefaultAggregateBy, nil
+		return defaultVolumeAggregateBy, nil
 	}
 
-	if seriesvolume.ValidateAggregateBy(l) {
+	if validateVolumeAggregateBy(l) {
 		return l, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Small PR to fix Apache-licensed code to not depend on AGPL-licensed code.

While this does involve code duplication, it is minimal, and almost boilerplate.

Which issue(s) this PR fixes:
PR 2 of many in support of https://github.com/grafana/loki/issues/13019

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to `pkg/loghttp` volume-query request defaulting/validation, but it introduces duplicated constants that must stay in sync with `seriesvolume` to avoid behavior drift.
> 
> **Overview**
> Removes the `pkg/loghttp` dependency on `pkg/storage/stores/index/seriesvolume` by duplicating the volume HTTP defaults (`limit`, `aggregateBy`) and aggregation validation directly in `query.go`.
> 
> Updates volume request construction and request parsing (`NewVolumeRangeQueryWithDefaults`, `volumeLimit`, `volumeAggregateBy`) to use the new local defaults and `validateVolumeAggregateBy` instead of `seriesvolume` symbols.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d43d3de27c2b106f965d2b1a1d66e4993a9ebaea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->