### PR TITLE
fix(querytee): Fix TestProxyEndpoint_QuerySplitting clock-drift bug

### DIFF
--- a/pkg/querytee/proxy_endpoint_test.go
+++ b/pkg/querytee/proxy_endpoint_test.go
@@ -770,10 +770,13 @@ func TestProxyEndpoint_QuerySplitting(t *testing.T) {
 	receivedQueries := []string{}
 
 	step := "60s"
-	stepMs := int64(60000)
 
-	// Calculate the split boundary: step-aligned threshold + step
-	splitBoundary := stepAlignUp(threshold, stepMs).Add(time.Duration(stepMs) * time.Millisecond)
+	// The split boundary sits midway between threshold and the recent portion
+	// of the spans-threshold subtests (threshold + 1h). A generous margin keeps
+	// the boundary stable even when v2End drifts: the engine router computes
+	// v2End from time.Now() at request time, while threshold here is captured
+	// at test setup, and logs queries don't step-align v2End.
+	splitBoundary := threshold.Add(30 * time.Minute)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
@@ -784,10 +787,10 @@ func TestProxyEndpoint_QuerySplitting(t *testing.T) {
 		require.NoError(t, err)
 		endTime := rangeQuery.End
 
-		// If end time is before or at split boundary, return old response
-		// Otherwise return recent response
+		// If end time is before the split boundary, return the old response.
+		// Otherwise return the recent response.
 		w.WriteHeader(200)
-		if endTime.Before(splitBoundary) || endTime.Equal(splitBoundary) {
+		if endTime.Before(splitBoundary) {
 			_, _ = w.Write([]byte(oldResponseBody))
 		} else {
 			_, _ = w.Write([]byte(recentResponseBody))
@@ -884,17 +887,10 @@ func TestProxyEndpoint_QuerySplitting(t *testing.T) {
 
 		assert.Equal(t, 3, len(receivedQueries), "expected 3 queries, 1 for the recent portion, and 1 to both v1 and v2 for comparison, got %d", len(receivedQueries))
 
-		// Verify that old queries go to both backends
-		// Step is 60s = 60000ms from the test query
-		stepMs := int64(60000)
-
-		// Align threshold UP (as it's treated as an end boundary in alignStartEnd)
-		// This is v2End in the engine_router
-		alignedThreshold := stepAlignUp(threshold, stepMs)
-
-		// Based on observed behavior, old queries end at alignedThreshold + gap
-		oldQueryBoundary := alignedThreshold.Add(time.Duration(stepMs) * time.Millisecond)
-
+		// Classify queries by whether their end time matches the request's end:
+		// the post-v2 (recent) split runs to the request end, while the v2 (old)
+		// split ends at v2End, which is computed dynamically from time.Now() and
+		// can drift relative to `threshold` captured at test setup.
 		oldQueries := 0
 		recentQueries := 0
 		for _, q := range receivedQueries {
@@ -902,11 +898,10 @@ func TestProxyEndpoint_QuerySplitting(t *testing.T) {
 				endStr := extractQueryParam(q, "end")
 				endTime, _ := parseTimestamp(endStr)
 
-				// Queries ending at or before oldQueryBoundary are "old"
-				if endTime.Before(oldQueryBoundary) || endTime.Equal(oldQueryBoundary) {
-					oldQueries++
-				} else {
+				if endTime.Equal(end) {
 					recentQueries++
+				} else {
+					oldQueries++
 				}
 			}
 		}
@@ -962,11 +957,8 @@ func TestProxyEndpoint_QuerySplitting(t *testing.T) {
 		// - 3 queries total: 1 for recent portion (v1 only), 2 for old portion (v1 and v2 for comparison)
 		assert.Equal(t, 3, len(receivedQueries), "expected 3 queries for v2 metric query, 1 for recent portion and 2 for old portion comparison, got %d", len(receivedQueries))
 
-		// Verify that old queries go to both backends
-		stepMs := int64(60000)
-		alignedThreshold := stepAlignUp(threshold, stepMs)
-		oldQueryBoundary := alignedThreshold.Add(time.Duration(stepMs) * time.Millisecond)
-
+		// Classify queries by whether their end time matches the request's end
+		// (the recent portion) or not (the old portion sent to both backends).
 		oldQueries := 0
 		recentQueries := 0
 		for _, q := range receivedQueries {
@@ -974,10 +966,10 @@ func TestProxyEndpoint_QuerySplitting(t *testing.T) {
 				endStr := extractQueryParam(q, "end")
 				endTime, _ := parseTimestamp(endStr)
 
-				if endTime.Before(oldQueryBoundary) || endTime.Equal(oldQueryBoundary) {
-					oldQueries++
-				} else {
+				if endTime.Equal(end) {
 					recentQueries++
+				} else {
+					oldQueries++
 				}
 			}
 		}
@@ -1016,15 +1008,6 @@ func parseTimestamp(value string) (time.Time, error) {
 		return time.Unix(nanos, 0), nil
 	}
 	return time.Unix(0, nanos), nil
-}
-
-// stepAlignUp aligns a timestamp up to the nearest step boundary
-func stepAlignUp(t time.Time, stepMs int64) time.Time {
-	timestampMs := t.UnixMilli()
-	if mod := timestampMs % stepMs; mod != 0 {
-		timestampMs += stepMs - mod
-	}
-	return time.Unix(0, timestampMs*1e6)
 }
 
 // Helper function to extract query parameters from a query string


### PR DESCRIPTION
## Summary

- `TestProxyEndpoint_QuerySplitting` was flaking in CI with `0/3` instead of `2/1` for the old/recent query split classification.
- Root cause: the test captures `threshold = time.Now().Truncate(time.Minute) - 3h` once at setup, but the engine router computes `v2End = time.Now() - StorageLag` per request. For logs queries, `alignV2Range` is a no-op (step=0), so `v2End` drifts second-by-second with wall-clock. When the truncation landed late in a minute and the prior 2-second sleep pushed total drift past 60s, `v2End > threshold + 60s` and all three queries got misclassified as "recent".
- Fix is test-only: classify queries by whether their end matches the request's end (the post-v2 split runs to request end; the v2 split ends earlier) instead of an absolute boundary, and widen the mock server's split boundary from `threshold + 60s` to `threshold + 30m` so it stays stable under any plausible drift.

## Test plan

- [x] `go test -tags=assert -count=10 -run TestProxyEndpoint_QuerySplitting ./pkg/querytee/...` passes (10/10)
- [x] `go test -tags=assert ./pkg/querytee/...` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are confined to test logic and only adjust how the mock split boundary and assertions are computed to avoid time.Now() drift flakes.
> 
> **Overview**
> Fixes CI flakiness in `TestProxyEndpoint_QuerySplitting` by making the mock backend’s split boundary drift-tolerant (using `threshold + 30m` and treating equality as *recent*).
> 
> Updates assertions to classify *old vs recent* sub-queries based on whether the query `end` matches the original request `end` (instead of comparing against a step-aligned absolute boundary), and removes the now-unused `stepAlignUp` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0ddf346eb4ba50556509b115df2ab888f7dc19b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->