### PR TITLE
fix: Partial acceptance of records in ProduceSync

### DIFF
--- a/pkg/kafka/client/writer_client.go
+++ b/pkg/kafka/client/writer_client.go
@@ -344,8 +344,9 @@ func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.P
 	for _, record := range records {
 		totalSize += int64(len(record.Value))
 	}
-	// The records exceed what is left of the limit, we must fail them.
+
 	if c.maxBufferedBytes > 0 && c.bufferedBytes.Add(totalSize) > c.maxBufferedBytes {
+		// The records exceed what is left of the limit, we must fail them.
 		for _, record := range records {
 			// onProduceDone will dec the counter.
 			onProduceDone(record, kgo.ErrMaxBuffered)

--- a/pkg/kafka/client/writer_client.go
+++ b/pkg/kafka/client/writer_client.go
@@ -339,22 +339,29 @@ func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.P
 		}
 	}
 
+	// Check that all records can fit within the limit.
+	var totalSize int64
 	for _, record := range records {
-		// Fast fail if the Kafka client buffer is full. Buffered bytes counter is decreased onProducerDone().
-		if c.maxBufferedBytes > 0 && c.bufferedBytes.Add(int64(len(record.Value))) > c.maxBufferedBytes {
+		totalSize += int64(len(record.Value))
+	}
+	// The records exceed what is left of the limit, we must fail them.
+	if c.maxBufferedBytes > 0 && c.bufferedBytes.Add(totalSize) > c.maxBufferedBytes {
+		for _, record := range records {
+			// onProduceDone will dec the counter.
 			onProduceDone(record, kgo.ErrMaxBuffered)
-			continue
 		}
-
-		// We use a new context to avoid that other Produce() may be cancelled when this call's context is
-		// canceled. It's important to note that cancelling the context passed to Produce() doesn't actually
-		// prevent the data to be sent over the wire (because it's never removed from the buffer) but in some
-		// cases may cause all requests to fail with context cancelled.
-		//
-		// Produce() may theoretically block if the buffer is full, but we configure the Kafka client with
-		// unlimited buffer because we implement the buffer limit ourselves (see maxBufferedBytes). This means
-		// Produce() should never block for us in practice.
-		c.Produce(context.WithoutCancel(ctx), record, onProduceDone)
+	} else {
+		for _, record := range records {
+			// We use a new context to avoid that other Produce() may be cancelled when this call's context is
+			// canceled. It's important to note that cancelling the context passed to Produce() doesn't actually
+			// prevent the data to be sent over the wire (because it's never removed from the buffer) but in some
+			// cases may cause all requests to fail with context cancelled.
+			//
+			// Produce() may theoretically block if the buffer is full, but we configure the Kafka client with
+			// unlimited buffer because we implement the buffer limit ourselves (see maxBufferedBytes). This means
+			// Produce() should never block for us in practice.
+			c.Produce(context.WithoutCancel(ctx), record, onProduceDone)
+		}
 	}
 
 	// Wait for a response or until the context has done.

--- a/pkg/kafka/client/writer_client_test.go
+++ b/pkg/kafka/client/writer_client_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -104,6 +105,37 @@ func TestProducer(t *testing.T) {
 		require.EqualError(t, results[0].Err, "context canceled")
 		require.Equal(t, rec2, results[1].Record)
 		require.EqualError(t, results[1].Err, "context canceled")
+	})
+
+	t.Run("records are failed if total exceeds buffer size", func(t *testing.T) {
+		_, kafkaCfg := testkafka.CreateCluster(t, 1, "test-topic")
+		client, err := NewWriterClient("test-client", kafkaCfg, 100, log.NewNopLogger(), prometheus.NewRegistry())
+		require.NoError(t, err)
+
+		// Set a 1KB limit on buffered records.
+		producer := NewProducer("test-producer", client, 1024, prometheus.NewRegistry())
+
+		rec1 := &kgo.Record{Key: []byte("key1"), Value: []byte(strings.Repeat("a", 1024))}
+		rec2 := &kgo.Record{Key: []byte("key2"), Value: []byte("b")}
+		results := producer.ProduceSync(t.Context(), []*kgo.Record{rec1, rec2})
+		require.Len(t, results, 2)
+
+		// All records should fail.
+		require.Equal(t, rec1, results[0].Record)
+		require.EqualError(t, results[0].Err, "the maximum amount of records are buffered, cannot buffer more")
+		require.Equal(t, rec2, results[1].Record)
+		require.EqualError(t, results[1].Err, "the maximum amount of records are buffered, cannot buffer more")
+
+		// Should be able to produce either record individually.
+		results = producer.ProduceSync(t.Context(), []*kgo.Record{rec1})
+		require.Len(t, results, 1)
+		require.Equal(t, rec1, results[0].Record)
+		require.NoError(t, results[0].Err)
+
+		results = producer.ProduceSync(t.Context(), []*kgo.Record{rec2})
+		require.Len(t, results, 1)
+		require.Equal(t, rec2, results[0].Record)
+		require.NoError(t, results[0].Err)
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes situations where some records in a batch can be accepted, but not others. For example, consider a limit of 1KB, and records of size 512B, 513B and 256B. In this case, records 1 and 3 will be accepted, and 2 will be rejected. In most cases, this results in retries, and duplication of data. This change means that the entire batch is rejected if any records exceed the limit.

Same fix in Mimir: https://github.com/grafana/mimir/pull/15227

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes producer backpressure behavior by failing an entire batch when the buffered-bytes limit would be exceeded, which could affect ingestion under load. Logic is localized and covered by a new unit test, keeping overall risk moderate.
> 
> **Overview**
> `Producer.ProduceSync` now enforces the buffered-bytes limit **atomically per batch**: it sums record sizes up-front and, if the batch would exceed `maxBufferedBytes`, it fails *all* records with `kgo.ErrMaxBuffered` instead of partially accepting some.
> 
> Adds a test ensuring oversized batches are fully rejected and that the same records succeed when produced individually.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac8701b958d008aab8eaf44c6d1702d58611776f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->