### PR TITLE
chore(dataset/array): Add Plain encoding

### DIFF
--- a/pkg/dataset/array/codec.go
+++ b/pkg/dataset/array/codec.go
@@ -38,6 +38,8 @@ func NewWriter(alloc *memory.Allocator, spec Spec, typ types.Type) (Writer, erro
 	switch spec.Kind() {
 	case EncodingKindBool:
 		return newBoolWriter(alloc, spec, typ)
+	case EncodingKindPlain:
+		return newPlainWriter(alloc, spec, typ)
 
 	default:
 		return nil, fmt.Errorf("unsupported encoding kind %q", spec.Kind())
@@ -84,6 +86,8 @@ func NewReader(alloc *memory.Allocator, arr Array, source buffer.Source) (Reader
 	switch arr.Encoding.Kind() {
 	case EncodingKindBool:
 		return newBoolReader(alloc, arr, source)
+	case EncodingKindPlain:
+		return newPlainReader(alloc, arr, source)
 
 	default:
 		return nil, fmt.Errorf("unsupported encoding kind %q", arr.Encoding.Kind())

--- a/pkg/dataset/array/codec_plain.go
+++ b/pkg/dataset/array/codec_plain.go
@@ -1,0 +1,283 @@
+package array
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"unsafe"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+type plainWriter[T columnar.Numeric] struct {
+	alloc *memory.Allocator
+	typ   types.Type
+
+	values   memory.Buffer[T]
+	validity Writer
+	nulls    int
+}
+
+func newPlainWriter(alloc *memory.Allocator, spec Spec, typ types.Type) (Writer, error) {
+	if got, want := spec.Kind(), EncodingKindPlain; got != want {
+		return nil, fmt.Errorf("expected spec kind %s, got %s", want, got)
+	}
+
+	plainSpec := spec.(*SpecPlain)
+
+	switch typ := typ.(type) {
+	case *types.Int32:
+		return newPlainWriterTyped[int32](alloc, plainSpec, typ, typ.Nullable)
+	case *types.Int64:
+		return newPlainWriterTyped[int64](alloc, plainSpec, typ, typ.Nullable)
+	case *types.Uint32:
+		return newPlainWriterTyped[uint32](alloc, plainSpec, typ, typ.Nullable)
+	case *types.Uint64:
+		return newPlainWriterTyped[uint64](alloc, plainSpec, typ, typ.Nullable)
+	default:
+		return nil, fmt.Errorf("unsupported type %s for plain encoding", typ)
+	}
+}
+
+func newPlainWriterTyped[T columnar.Numeric](alloc *memory.Allocator, spec *SpecPlain, typ types.Type, nullable bool) (*plainWriter[T], error) {
+	hasValidity := spec.Validity != nil
+	if nullable != hasValidity {
+		return nil, fmt.Errorf("expected %s to have validity %t, got %t", typ, nullable, hasValidity)
+	}
+
+	var validityWriter Writer
+	if hasValidity {
+		var err error
+		validityWriter, err = NewWriter(alloc, spec.Validity, &types.Bool{Nullable: false})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &plainWriter[T]{
+		alloc: alloc,
+		typ:   typ,
+
+		values:   memory.NewBuffer[T](alloc, 0),
+		validity: validityWriter,
+	}, nil
+}
+
+func (w *plainWriter[T]) Append(arr columnar.Array) error {
+	numArr, ok := arr.(*columnar.Number[T])
+	if !ok {
+		return fmt.Errorf("expected *columnar.Number[%T], got %T", *new(T), arr)
+	}
+
+	values := numArr.Values()
+
+	// Validate before any mutation so a failed Append leaves the writer's
+	// state unchanged.
+	if err := validateNulls(w.validity, numArr, len(values)); err != nil {
+		return err
+	}
+
+	nulls, err := appendNulls(w.alloc, w.validity, numArr, len(values))
+	if err != nil {
+		return err
+	}
+	w.nulls += nulls
+
+	w.values.Grow(len(values))
+	w.values.Append(values...)
+	return nil
+}
+
+func (w *plainWriter[T]) Flush(ctx context.Context, sink buffer.Sink) (Array, error) {
+	defer w.reset()
+
+	var children []Array
+	var validityArray Array
+	if validity := w.validity; validity != nil {
+		var err error
+		validityArray, err = validity.Flush(ctx, sink)
+		if err != nil {
+			return Array{}, fmt.Errorf("flushing validity writer: %w", err)
+		}
+
+		children = append(children, validityArray)
+	}
+
+	data := w.values.BytesTrimmed()
+	bufs, err := sink.WriteBuffers(ctx, []buffer.Data{data})
+	if err != nil {
+		return Array{}, fmt.Errorf("writing plain data to a buffer: %w", err)
+	}
+
+	return Array{
+		Encoding: &EncodingPlain{},
+		Type:     w.typ,
+		Buffers:  bufs,
+		RowCount: w.values.Len(),
+		Stats: Stats{
+			NullCount: w.nulls,
+		},
+		Children: children,
+	}, nil
+}
+
+func (w *plainWriter[T]) reset() {
+	w.values = memory.NewBuffer[T](w.alloc, 0)
+	w.nulls = 0
+}
+
+type plainReader[T columnar.Numeric] struct {
+	alloc  *memory.Allocator
+	arr    Array
+	source buffer.Source
+
+	validity Reader
+
+	initialized bool
+	values      []T
+	off         int // Offset into values
+}
+
+func newPlainReader(alloc *memory.Allocator, arr Array, source buffer.Source) (Reader, error) {
+	if got, want := arr.Encoding.Kind(), EncodingKindPlain; got != want {
+		return nil, fmt.Errorf("expected spec kind %s, got %s", want, got)
+	}
+
+	switch typ := arr.Type.(type) {
+	case *types.Int32:
+		return newPlainReaderTyped[int32](alloc, arr, source, typ.Nullable)
+	case *types.Int64:
+		return newPlainReaderTyped[int64](alloc, arr, source, typ.Nullable)
+	case *types.Uint32:
+		return newPlainReaderTyped[uint32](alloc, arr, source, typ.Nullable)
+	case *types.Uint64:
+		return newPlainReaderTyped[uint64](alloc, arr, source, typ.Nullable)
+	default:
+		return nil, fmt.Errorf("unsupported type %s for plain encoding", arr.Type)
+	}
+}
+
+func newPlainReaderTyped[T columnar.Numeric](alloc *memory.Allocator, arr Array, source buffer.Source, nullable bool) (*plainReader[T], error) {
+	var validityReader Reader
+	switch {
+	case nullable && len(arr.Children) == 0:
+		return nil, errors.New("nullable plain array must have a validity child array")
+	case nullable && len(arr.Children) > 1:
+		return nil, fmt.Errorf("expected 1 child for nullable plain array, got %d", len(arr.Children))
+	case !nullable && len(arr.Children) != 0:
+		return nil, fmt.Errorf("expected 0 children for non-nullable plain array, got %d", len(arr.Children))
+	}
+	if nullable {
+		if got, want := arr.Children[0].RowCount, arr.RowCount; got != want {
+			return nil, fmt.Errorf("validity child has %d rows, expected %d to match parent", got, want)
+		}
+
+		var err error
+		validityReader, err = NewReader(alloc, arr.Children[0], source)
+		if err != nil {
+			return nil, fmt.Errorf("creating validity reader: %w", err)
+		}
+	}
+
+	if len(arr.Buffers) != 1 {
+		return nil, fmt.Errorf("expected 1 buffer, got %d", len(arr.Buffers))
+	}
+
+	return &plainReader[T]{
+		alloc:  alloc,
+		arr:    arr,
+		source: source,
+
+		validity: validityReader,
+	}, nil
+}
+
+func (r *plainReader[T]) Read(ctx context.Context, alloc *memory.Allocator, count int) (columnar.Array, error) {
+	if count <= 0 {
+		return nil, fmt.Errorf("count must be positive, got %d", count)
+	}
+
+	if !r.initialized {
+		// We use the reader's allocator for initializing since the data
+		// persists across calls to Read.
+		if err := r.init(ctx, r.alloc); err != nil {
+			return nil, err
+		}
+		r.initialized = true
+	}
+
+	endOff := min(r.off+count, len(r.values))
+	if endOff-r.off == 0 {
+		return nil, io.EOF
+	}
+	values := r.values[r.off:endOff:endOff]
+
+	// Read validity bytes now.
+	var validity memory.Bitmap
+	if r.validity != nil {
+		validityArr, err := r.validity.Read(ctx, alloc, count)
+		if err != nil {
+			return nil, fmt.Errorf("reading validity: %w", err)
+		}
+
+		validityBoolArr := validityArr.(*columnar.Bool)
+		validity = validityBoolArr.Values()
+	}
+
+	r.off += len(values)
+	return columnar.NewNumber(values, validity), nil
+}
+
+func (r *plainReader[T]) init(ctx context.Context, alloc *memory.Allocator) error {
+	data, err := r.source.ReadBuffers(ctx, alloc, r.arr.Buffers)
+	if err != nil {
+		return fmt.Errorf("fetching buffer data: %w", err)
+	}
+
+	// newPlainReaderTyped already checked that there's one buffer, and
+	// ReadBuffers must return the same number of buffers; data[0] is the only
+	// valid index.
+	var zero T
+	wantBytes := r.arr.RowCount * int(unsafe.Sizeof(zero))
+	if got := len(data[0]); got < wantBytes {
+		return fmt.Errorf("buffer too small: %d bytes, expected at least %d for %d elements", got, wantBytes, r.arr.RowCount)
+	}
+
+	if r.arr.RowCount > 0 {
+		// TODO(rfratto): Make this more safe; have some kind of
+		// memory.BufferFromBytes[T]([]byte) function. This would require
+		// supporting having a Buffer with no allocator, similar to
+		// memory.Bitmap.
+		r.values = unsafe.Slice((*T)(unsafe.Pointer(unsafe.SliceData(data[0]))), r.arr.RowCount)
+	}
+	return nil
+}
+
+func (r *plainReader[T]) Reset() {
+	r.resetSelf()
+
+	if r.validity != nil {
+		r.validity.Reset()
+	}
+}
+
+func (r *plainReader[T]) resetSelf() {
+	// Reset the offset but keep everything else to allow for re-reading data.
+	r.off = 0
+}
+
+func (r *plainReader[T]) Close() error {
+	r.resetSelf()
+
+	r.initialized = false
+	r.values = nil
+
+	if r.validity != nil {
+		return r.validity.Close()
+	}
+	return nil
+}

--- a/pkg/dataset/array/codec_plain_test.go
+++ b/pkg/dataset/array/codec_plain_test.go
@@ -1,0 +1,302 @@
+package array_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestPlainCodec_Validation(t *testing.T) {
+	tt := []struct {
+		name string
+		spec array.Spec
+		typ  types.Type
+
+		expectError bool
+	}{
+		{
+			name:        "accepts valid non-nullable int32",
+			spec:        &array.SpecPlain{Validity: nil},
+			typ:         &types.Int32{Nullable: false},
+			expectError: false,
+		},
+		{
+			name:        "accepts valid non-nullable int64",
+			spec:        &array.SpecPlain{Validity: nil},
+			typ:         &types.Int64{Nullable: false},
+			expectError: false,
+		},
+		{
+			name:        "accepts valid non-nullable uint32",
+			spec:        &array.SpecPlain{Validity: nil},
+			typ:         &types.Uint32{Nullable: false},
+			expectError: false,
+		},
+		{
+			name:        "accepts valid non-nullable uint64",
+			spec:        &array.SpecPlain{Validity: nil},
+			typ:         &types.Uint64{Nullable: false},
+			expectError: false,
+		},
+		{
+			name:        "rejects non-nullable int64 with validity spec",
+			spec:        &array.SpecPlain{Validity: &array.SpecBool{}},
+			typ:         &types.Int64{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects nullable int64 with no validity spec",
+			spec:        &array.SpecPlain{Validity: nil},
+			typ:         &types.Int64{Nullable: true},
+			expectError: true,
+		},
+		{
+			name:        "accepts nullable int64 with validity spec",
+			spec:        &array.SpecPlain{Validity: &array.SpecBool{}},
+			typ:         &types.Int64{Nullable: true},
+			expectError: false,
+		},
+		{
+			name:        "rejects unsupported type bool",
+			spec:        &array.SpecPlain{Validity: nil},
+			typ:         &types.Bool{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects unsupported type utf8",
+			spec:        &array.SpecPlain{Validity: nil},
+			typ:         &types.UTF8{Nullable: false},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			var alloc memory.Allocator
+			_, err := array.NewWriter(&alloc, tc.spec, tc.typ)
+
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// plainNumericTypes lists every numeric type supported by the plain encoding,
+// used to drive the shared round-trip tests.
+var plainNumericTypes = []struct {
+	name  string
+	build func(nullable bool) types.Type
+}{
+	{"int32", func(n bool) types.Type { return &types.Int32{Nullable: n} }},
+	{"int64", func(n bool) types.Type { return &types.Int64{Nullable: n} }},
+	{"uint32", func(n bool) types.Type { return &types.Uint32{Nullable: n} }},
+	{"uint64", func(n bool) types.Type { return &types.Uint64{Nullable: n} }},
+}
+
+func TestPlainCodec_NonNullable(t *testing.T) {
+	batches := [][]any{
+		{10, 20, 30, 40, 50},
+		{60, 70, 80, 90, 100},
+	}
+	expected := []any{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}
+
+	for _, nt := range plainNumericTypes {
+		t.Run(nt.name, func(t *testing.T) {
+			runPlainRoundtrip(t, &array.SpecPlain{Validity: nil}, nt.build(false), batches, expected, 0)
+		})
+	}
+}
+
+func TestPlainCodec_Nullable(t *testing.T) {
+	batches := [][]any{
+		{10, nil, 30, nil, 50},
+		{60, 70, 80, 90, 100},
+		{nil},
+	}
+	expected := []any{10, nil, 30, nil, 50, 60, 70, 80, 90, 100, nil}
+
+	for _, nt := range plainNumericTypes {
+		t.Run(nt.name, func(t *testing.T) {
+			runPlainRoundtrip(t, &array.SpecPlain{Validity: &array.SpecBool{}}, nt.build(true), batches, expected, 3)
+		})
+	}
+}
+
+// runPlainRoundtrip writes each batch to a plain [array.Writer] constructed
+// from spec and typ, then reads the result back and asserts the decoded values
+// match expected.
+func runPlainRoundtrip(t *testing.T, spec array.Spec, typ types.Type, batches [][]any, expected []any, expectedNulls int) {
+	t.Helper()
+
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	kind := typ.Kind()
+
+	var totalRows int
+	for _, batch := range batches {
+		require.NoError(t, w.Append(columnartest.Array(t, kind, &alloc, batch...)))
+		totalRows += len(batch)
+	}
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+	require.Equal(t, totalRows, result.RowCount)
+	require.Equal(t, expectedNulls, result.Stats.NullCount)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	expect := columnartest.Array(t, kind, &alloc, expected...)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+
+	// Reading again should produce an EOF.
+	_, err = r.Read(t.Context(), &alloc, 1)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestPlainCodec_Reader(t *testing.T) {
+	t.Run("Reject undersized buffer", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+
+		var (
+			spec = &array.SpecPlain{Validity: nil}
+			typ  = &types.Int64{Nullable: false}
+		)
+
+		w, err := array.NewWriter(&alloc, spec, typ)
+		require.NoError(t, err)
+
+		input := columnartest.Array(t, types.KindInt64, &alloc, int64(10), int64(20), int64(30))
+		require.NoError(t, w.Append(input))
+
+		result, err := w.Flush(t.Context(), &store)
+		require.NoError(t, err)
+
+		// Corrupt RowCount so that it no longer fits in the underlying buffer.
+		// Reading must fail cleanly rather than slicing past the end of the data.
+		result.RowCount = 1_000_000
+
+		r, err := array.NewReader(&alloc, result, &store)
+		require.NoError(t, err)
+
+		_, err = r.Read(t.Context(), &alloc, 1)
+		require.Error(t, err)
+	})
+
+	t.Run("reject mismatching row count", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+
+		var (
+			spec = &array.SpecPlain{Validity: &array.SpecBool{}}
+			typ  = &types.Int64{Nullable: true}
+		)
+
+		w, err := array.NewWriter(&alloc, spec, typ)
+		require.NoError(t, err)
+
+		input := columnartest.Array(t, types.KindInt64, &alloc, int64(10), int64(20), int64(30))
+		require.NoError(t, w.Append(input))
+
+		result, err := w.Flush(t.Context(), &store)
+		require.NoError(t, err)
+
+		// Corrupt the Array so the validity child disagrees with the parent's row
+		// count. NewReader must reject this upfront rather than letting it propagate
+		// into Read (where it would panic inside columnar.NewNumber on length
+		// mismatch).
+		result.Children[0].RowCount = result.RowCount + 1
+
+		_, err = array.NewReader(&alloc, result, &store)
+		require.Error(t, err)
+	})
+}
+
+func BenchmarkPlainCodec(b *testing.B) {
+	var (
+		store buffer.MemoryStore
+
+		spec = &array.SpecPlain{Validity: nil}
+		typ  = &types.Int64{Nullable: false}
+	)
+
+	const values = 1 << 16
+
+	var arr array.Array
+	{
+		var alloc memory.Allocator
+
+		builder := columnar.NewNumberBuilder[int64](&alloc)
+		builder.Grow(values)
+
+		for i := range values {
+			builder.AppendValue(int64(i))
+		}
+
+		writer, err := array.NewWriter(&alloc, spec, typ)
+		require.NoError(b, err)
+
+		require.NoError(b, writer.Append(builder.Build()))
+		arr, err = writer.Flush(b.Context(), &store)
+		require.NoError(b, err)
+	}
+
+	batchSizes := []int{2048, 4096, 8192}
+
+	b.Run(fmt.Sprintf("rows=%d", values), func(b *testing.B) {
+		for _, batchSize := range batchSizes {
+			b.Run(fmt.Sprintf("batch_size=%d", batchSize), func(b *testing.B) {
+				var alloc memory.Allocator
+
+				var totalBytes int64
+				var totalRows int64
+
+				for b.Loop() {
+					alloc.Reset()
+
+					r, _ := array.NewReader(&alloc, arr, &store)
+					for {
+						arr, err := r.Read(b.Context(), &alloc, batchSize)
+						if arr != nil {
+							totalBytes += int64(arr.Size())
+							totalRows += int64(arr.Len())
+						}
+
+						if err != nil && errors.Is(err, io.EOF) {
+							break
+						} else if err != nil {
+							b.Fatal(err)
+						}
+					}
+				}
+
+				b.SetBytes(totalBytes / int64(b.N))
+
+				elapsed := b.Elapsed()
+				if elapsed > 0 {
+					b.ReportMetric(float64(totalRows)/elapsed.Seconds(), "rows/s")
+				}
+			})
+		}
+	})
+}

--- a/pkg/dataset/array/encoding.go
+++ b/pkg/dataset/array/encoding.go
@@ -22,6 +22,12 @@ type (
 	// If the data type is nullable, then the first child Array holds validity
 	// data.
 	EncodingBool struct{}
+
+	// EncodingPlain holds fixed-width values without any compression.
+	//
+	// If the data type is nullable, then the first child Array holds validity
+	// data.
+	EncodingPlain struct{}
 )
 
 // Kind returns [EncodingKindBool].
@@ -29,8 +35,14 @@ func (enc *EncodingBool) Kind() EncodingKind {
 	return EncodingKindBool
 }
 
+// Kind returns [EncodingKindPlain].
+func (enc *EncodingPlain) Kind() EncodingKind {
+	return EncodingKindPlain
+}
+
 //
 // Sealed marker implementations.
 //
 
-func (enc *EncodingBool) isEncoding() {}
+func (enc *EncodingBool) isEncoding()  {}
+func (enc *EncodingPlain) isEncoding() {}

--- a/pkg/dataset/array/encoding_kind.go
+++ b/pkg/dataset/array/encoding_kind.go
@@ -9,12 +9,14 @@ type EncodingKind int
 const (
 	EncodingKindInvalid EncodingKind = iota // EncodingKindInvalid is an invalid encoding.
 
-	EncodingKindBool // EncodingKindBool is a bit-packed encoding for boolean types.
+	EncodingKindBool  // EncodingKindBool is a bit-packed encoding for boolean types.
+	EncodingKindPlain // EncodingKindPlain is plain encoding for fixed-width types (int32, etc).
 )
 
 var kindNames = [...]string{
 	EncodingKindInvalid: "invalid",
 	EncodingKindBool:    "bool",
+	EncodingKindPlain:   "plain",
 }
 
 // String returns the string representation of k.

--- a/pkg/dataset/array/spec.go
+++ b/pkg/dataset/array/spec.go
@@ -23,6 +23,13 @@ type (
 		// data types.
 		Validity Spec
 	}
+
+	// SpecPlain encodes fixed-width values without any compression.
+	SpecPlain struct {
+		// Spec for how to encode validity data. Must only be set for nullable
+		// data types.
+		Validity Spec
+	}
 )
 
 // Kind returns [EncodingKindBool].
@@ -30,8 +37,14 @@ func (spec *SpecBool) Kind() EncodingKind {
 	return EncodingKindBool
 }
 
+// Kind returns [EncodingKindPlain].
+func (spec *SpecPlain) Kind() EncodingKind {
+	return EncodingKindPlain
+}
+
 //
 // Sealed marker implementations.
 //
 
-func (spec *SpecBool) isSpec() {}
+func (spec *SpecBool) isSpec()  {}
+func (spec *SpecPlain) isSpec() {}

--- a/pkg/memory/buffer.go
+++ b/pkg/memory/buffer.go
@@ -125,6 +125,18 @@ func (buf *Buffer[T]) Clear() {
 	clear(buf.data)
 }
 
+// BytesTrimmed returns the bytes backing buf without any padding beyond the
+// buffer's length. The returned slice has length len(buf.Data()) *
+// unsafe.Sizeof(T).
+//
+// The returned memory is shared with buf, not a copy.
+func (buf *Buffer[T]) BytesTrimmed() []byte {
+	if buf.data == nil {
+		return nil
+	}
+	return unsafecast.Slice[T, byte](buf.data)
+}
+
 // Serialize returns the serializable form of the underlying byte array
 // representing buf, padded to 64-bytes. Padded bytes will be set to zero.
 //

--- a/pkg/memory/buffer_test.go
+++ b/pkg/memory/buffer_test.go
@@ -116,6 +116,24 @@ func TestBuffer_Grow(t *testing.T) {
 	require.Equal(t, 0, alloc.FreeBytes(), "expected unused memory to be released")
 }
 
+func TestBuffer_BytesTrimmed(t *testing.T) {
+	t.Run("nil buffer", func(t *testing.T) {
+		var buf memory.Buffer[int32]
+		require.Nil(t, buf.BytesTrimmed())
+	})
+
+	t.Run("returns exactly len*sizeof bytes, no padding", func(t *testing.T) {
+		var alloc memory.Allocator
+		defer alloc.Reset()
+
+		buf := memory.NewBuffer[int32](&alloc, 10)
+		buf.Append(1, 2, 3)
+
+		got := buf.BytesTrimmed()
+		require.Len(t, got, 3*4, "BytesTrimmed must not include padding")
+	})
+}
+
 func TestBuffer_Slice(t *testing.T) {
 	var alloc memory.Allocator
 	defer alloc.Reset()


### PR DESCRIPTION
Adds a Plain encoding to dataset/array, which encodes fixed-width primitive types.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new array encoding/codec path and uses `unsafe` slice casting when decoding, which could lead to panics or subtle corruption if buffer sizing/row counts are wrong (guarded by new validation/tests).
> 
> **Overview**
> Adds a new **`plain` encoding** to `dataset/array` for fixed-width numeric primitives (`int32`, `int64`, `uint32`, `uint64`), wiring it into `NewWriter`/`NewReader` via new `EncodingKindPlain`, `EncodingPlain`, and `SpecPlain`.
> 
> Implements a plain codec that writes raw value bytes (plus optional validity child array for nullable types), reads them back in batches, and validates child/row-count/buffer sizing to fail cleanly instead of panicking.
> 
> Extends `memory.Buffer` with `BytesTrimmed()` (no 64B padding) to support writing exact-length plain buffers, and adds comprehensive round-trip tests plus a benchmark for the new codec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07312adb61a476dd1f318ff141ee26395281b7eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->