### PR TITLE
chore: Add middleware hook for query frontend client used in remote rule evaluation

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/grpcutil"
+	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/kv/memberlist"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/modules"
@@ -461,6 +462,9 @@ type Loki struct {
 	Metrics *server.Metrics
 
 	UsageTracker push.UsageTracker
+
+	// RuleEvaluatorClientMiddleware optionally wraps the httpgrpc.HTTPClient used for remote rule evaluation.
+	RuleEvaluatorClientMiddleware func(httpgrpc.HTTPClient) httpgrpc.HTTPClient
 
 	metastoreMetrics *metastore.ObjectMetastoreMetrics
 }

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1710,6 +1710,9 @@ func (t *Loki) initRuleEvaluator() (services.Service, error) {
 		if e != nil {
 			return nil, fmt.Errorf("failed to dial query frontend for remote rule evaluation: %w", err)
 		}
+		if t.RuleEvaluatorClientMiddleware != nil {
+			qfClient = t.RuleEvaluatorClientMiddleware(qfClient)
+		}
 
 		evaluator, err = ruler.NewRemoteEvaluator(qfClient, t.Overrides, logger, prometheus.DefaultRegisterer)
 	default:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a RuleEvaluatorClientMiddleware field to the Loki struct that, when set, wraps the httpgrpc.HTTPClient used to communicate with the query frontend during remote rule evaluation.                             

`RuleEvaluatorClientMiddleware func(httpgrpc.HTTPClient) httpgrpc.HTTPClient`

When non-nil, the middleware is applied to the QF client after it is dialled and before it is passed to `ruler.NewRemoteEvaluator`. When nil (the default), behaviour is unchanged. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional wrapper around the remote rule-evaluation query-frontend client and is a no-op by default, with limited impact unless downstream code sets the hook.
> 
> **Overview**
> Adds an optional `RuleEvaluatorClientMiddleware` hook on the `Loki` struct to wrap the `httpgrpc.HTTPClient` used for *remote* rule evaluation.
> 
> When `ruler.evaluation.mode=remote`, the middleware (if set) is applied after `ruler.DialQueryFrontend` and before creating the remote evaluator; default behavior is unchanged when unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b7993d5641cb798909399134966f63b53baf4a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->