### PR TITLE
chore: Add some hooks and refactor config parsing code to make it easier to modify and extend the config parsing

### DIFF
--- a/pkg/util/cfg/dynamic.go
+++ b/pkg/util/cfg/dynamic.go
@@ -10,19 +10,33 @@ type DynamicCloneable interface {
 	ApplyDynamicConfig() Source
 }
 
+// FileLoader creates a Source that locates and decodes a config file from args.
+// args are the CLI arguments, name is the config-file flag name (e.g. "config.file"),
+// and strict controls whether unknown YAML fields are rejected.
+type FileLoader func(args []string, name string, strict bool) Source
+
 // DynamicUnmarshal handles populating a config based on the following precedence:
 // 1. Defaults provided by the `RegisterFlags` interface
 // 2. Sections populated by dynamic logic. Configs passed to this function must implement ApplyDynamicConfig()
 // 3. Any config options specified directly in the config file
 // 4. Any config options specified on the command line.
-func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet) error {
+//
+// An optional fileLoader overrides how the config file is located and decoded on both
+// passes. If omitted, ConfigFileLoader is used.
+func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet, fileLoader ...FileLoader) error {
+	loader := FileLoader(func(args []string, name string, strict bool) Source {
+		return ConfigFileLoader(args, name, strict)
+	})
+	if len(fileLoader) > 0 {
+		loader = fileLoader[0]
+	}
 	return Unmarshal(dst,
 		// First populate the config with defaults including flags from the command line
 		Defaults(fs),
 		// Next populate the config from the config file, we do this to populate the `common`
 		// section of the config file by taking advantage of the code in ConfigFileLoader which will load
 		// and process the config file.
-		ConfigFileLoader(args, "config.file", true),
+		loader(args, "config.file", true),
 		// Now load the flags again, this will supersede anything set from config file with flags from the command line.
 		Flags(args, fs),
 		// Apply any dynamic logic to set other defaults in the config. This function is called after parsing the
@@ -35,7 +49,7 @@ func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet) err
 		// using strict yaml unmarshal causes an `already set in map` error with the `Clients` config,
 		// because it's a map that already has the keys we are trying to unmarshal into it.
 		// That is why we don't use strict for the second marshaling.
-		ConfigFileLoader(args, "config.file", false),
+		loader(args, "config.file", false),
 		// Load the flags again, this will supersede anything set from config file with flags from the command line.
 		Flags(args, fs),
 	)

--- a/pkg/util/cfg/dynamic.go
+++ b/pkg/util/cfg/dynamic.go
@@ -15,21 +15,21 @@ type DynamicCloneable interface {
 // and strict controls whether unknown YAML fields are rejected.
 type FileLoader func(args []string, name string, strict bool) Source
 
-// DynamicUnmarshal handles populating a config based on the following precedence:
+// DynamicUnmarshal populates a config from defaults, config file, and CLI flags.
+// See DynamicUnmarshalWithLoader for details on precedence and behaviour.
+func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet) error {
+	return DynamicUnmarshalWithLoader(dst, args, fs, ConfigFileLoader)
+}
+
+// DynamicUnmarshalWithLoader handles populating a config and additionally accepts a custom FileLoader
+// that overrides how the config file is located and decoded when required.
+//
+// Config is populated with the following precedence:
 // 1. Defaults provided by the `RegisterFlags` interface
 // 2. Sections populated by dynamic logic. Configs passed to this function must implement ApplyDynamicConfig()
 // 3. Any config options specified directly in the config file
 // 4. Any config options specified on the command line.
-//
-// An optional fileLoader overrides how the config file is located and decoded on both
-// passes. If omitted, ConfigFileLoader is used.
-func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet, fileLoader ...FileLoader) error {
-	loader := FileLoader(func(args []string, name string, strict bool) Source {
-		return ConfigFileLoader(args, name, strict)
-	})
-	if len(fileLoader) > 0 {
-		loader = fileLoader[0]
-	}
+func DynamicUnmarshalWithLoader(dst DynamicCloneable, args []string, fs *flag.FlagSet, loader FileLoader) error {
 	return Unmarshal(dst,
 		// First populate the config with defaults including flags from the command line
 		Defaults(fs),

--- a/pkg/util/cfg/files.go
+++ b/pkg/util/cfg/files.go
@@ -38,10 +38,9 @@ func dJSON(y []byte) Source {
 }
 
 // YAML returns a Source that opens the supplied `.yaml` file and loads it.
-// When expandEnvVars is true, variables in the supplied '.yaml\ file are expanded
+// When expandEnvVars is true, variables in the supplied '.yaml' file are expanded
 // using https://pkg.go.dev/github.com/drone/envsubst?tab=overview
-// An optional transform is applied to the raw bytes after env expansion and before decoding.
-func YAML(f string, expandEnvVars bool, strict bool, transform ...func([]byte) ([]byte, error)) Source {
+func YAML(f string, expandEnvVars bool, strict bool) Source {
 	return func(dst Cloneable) error {
 		y, err := os.ReadFile(f)
 		if err != nil {
@@ -53,12 +52,6 @@ func YAML(f string, expandEnvVars bool, strict bool, transform ...func([]byte) (
 				return err
 			}
 			y = []byte(s)
-		}
-		if len(transform) > 0 && transform[0] != nil {
-			y, err = transform[0](y)
-			if err != nil {
-				return err
-			}
 		}
 		if strict {
 			err = dYAMLStrict(y)(dst)

--- a/pkg/util/cfg/files.go
+++ b/pkg/util/cfg/files.go
@@ -98,11 +98,28 @@ func FindConfigFileFromArgs(args []string, name string) (configFile string, expa
 
 	remaining := args
 	for len(remaining) > 0 {
-		// Parse as many flags as possible, then skip over the first unrecognised arg.
+		// Parse as many flags as possible. On error, fs.Args() returns the unparsed
+		// remainder starting after the unknown flag name (Go's flag package advances
+		// past the flag name before checking whether it is known). If that next element
+		// looks like a value rather than a flag (does not start with "-"), skip it too,
+		// so that a flag-value pair like "-target ingester" does not leave a bare
+		// "ingester" that stops the parser.
+		//
+		// Exception: malformed flag syntax (e.g. "---foo", "-=val") causes Go's parser
+		// to return an error WITHOUT advancing, so fs.Args() equals remaining. In that
+		// case force-advance by one to avoid an infinite loop, then apply the same
+		// value-skip in case the malformed flag also has a trailing value token.
+		before := remaining
 		if err := fs.Parse(remaining); err == nil {
 			break
 		}
-		remaining = remaining[1:]
+		remaining = fs.Args()
+		if len(remaining) == len(before) {
+			remaining = remaining[1:]
+		}
+		if len(remaining) > 0 && !strings.HasPrefix(remaining[0], "-") {
+			remaining = remaining[1:]
+		}
 	}
 	return
 }

--- a/pkg/util/cfg/files.go
+++ b/pkg/util/cfg/files.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/drone/envsubst"
@@ -40,7 +40,8 @@ func dJSON(y []byte) Source {
 // YAML returns a Source that opens the supplied `.yaml` file and loads it.
 // When expandEnvVars is true, variables in the supplied '.yaml\ file are expanded
 // using https://pkg.go.dev/github.com/drone/envsubst?tab=overview
-func YAML(f string, expandEnvVars bool, strict bool) Source {
+// An optional transform is applied to the raw bytes after env expansion and before decoding.
+func YAML(f string, expandEnvVars bool, strict bool, transform ...func([]byte) ([]byte, error)) Source {
 	return func(dst Cloneable) error {
 		y, err := os.ReadFile(f)
 		if err != nil {
@@ -52,6 +53,12 @@ func YAML(f string, expandEnvVars bool, strict bool) Source {
 				return err
 			}
 			y = []byte(s)
+		}
+		if len(transform) > 0 && transform[0] != nil {
+			y, err = transform[0](y)
+			if err != nil {
+				return err
+			}
 		}
 		if strict {
 			err = dYAMLStrict(y)(dst)
@@ -77,40 +84,38 @@ func dYAML(y []byte) Source {
 	}
 }
 
+// FindConfigFileFromArgs extracts the config file path and expand-env flag from
+// args. Only these two flags are registered, so any other flags in args are
+// intentionally skipped: the goal is solely to locate the config file before
+// full flag parsing begins, not to validate or interpret the full flag set.
+// Unknown flags are therefore not an error here; they will be caught later
+// during normal flag parsing.
+func FindConfigFileFromArgs(args []string, name string) (configFile string, expandEnv bool) {
+	fs := flag.NewFlagSet("find-config-file", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.StringVar(&configFile, name, "", "")
+	fs.BoolVar(&expandEnv, "config.expand-env", false, "")
+
+	remaining := args
+	for len(remaining) > 0 {
+		// Parse as many flags as possible, then skip over the first unrecognised arg.
+		if err := fs.Parse(remaining); err == nil {
+			break
+		}
+		remaining = remaining[1:]
+	}
+	return
+}
+
 func ConfigFileLoader(args []string, name string, strict bool) Source {
 	return func(dst Cloneable) error {
-		freshFlags := flag.NewFlagSet("config-file-loader", flag.ContinueOnError)
-
-		// Ensure we register flags on a copy of the config so as to not mutate it while
-		// parsing out the config file location.
-		dst.Clone().RegisterFlags(freshFlags)
-
-		usage := freshFlags.Usage
-		freshFlags.Usage = func() { /* don't do anything by default, we will print usage ourselves, but only when requested. */ }
-
-		err := freshFlags.Parse(args)
-		if err == flag.ErrHelp {
-			// print available parameters to stdout, so that users can grep/less it easily
-			freshFlags.SetOutput(os.Stdout)
-			usage()
-			os.Exit(2)
-		} else if err != nil {
-			fmt.Fprintln(freshFlags.Output(), "Run with -help to get list of available parameters")
-			os.Exit(2)
-		}
-
-		f := freshFlags.Lookup(name)
-		if f == nil || f.Value.String() == "" {
+		configFile, expandEnv := FindConfigFileFromArgs(args, name)
+		if configFile == "" {
 			return nil
 		}
 
-		for _, val := range strings.Split(f.Value.String(), ",") {
+		for _, val := range strings.Split(configFile, ",") {
 			val := strings.TrimSpace(val)
-			expandEnv := false
-			expandEnvFlag := freshFlags.Lookup("config.expand-env")
-			if expandEnvFlag != nil {
-				expandEnv, _ = strconv.ParseBool(expandEnvFlag.Value.String()) // Can ignore error as false returned
-			}
 			if _, err := os.Stat(val); err == nil {
 				err := YAML(val, expandEnv, strict)(dst)
 				if err != nil && !expandEnv {
@@ -119,6 +124,6 @@ func ConfigFileLoader(args []string, name string, strict bool) Source {
 				return err
 			}
 		}
-		return fmt.Errorf("%s does not exist, set %s for custom config path", f.Value.String(), name)
+		return fmt.Errorf("%s does not exist, set %s for custom config path", configFile, name)
 	}
 }

--- a/pkg/util/cfg/files_test.go
+++ b/pkg/util/cfg/files_test.go
@@ -105,4 +105,29 @@ func TestConfigFileLoader(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 2222, dst.Server.Port)
 	})
+
+	t.Run("unknown flag with value before config.file is skipped correctly", func(t *testing.T) {
+		path := writeConfigFile(t, "server:\n  port: 3333\n")
+		var dst Data
+		err := ConfigFileLoader([]string{"-target", "ingester", "-config.file", path}, "config.file", false)(&dst)
+		require.NoError(t, err)
+		assert.Equal(t, 3333, dst.Server.Port)
+	})
+
+	t.Run("unknown flag with value between config.file and config.expand-env is skipped correctly", func(t *testing.T) {
+		t.Setenv("TEST_PORT", "4444")
+		path := writeConfigFile(t, "server:\n  port: ${TEST_PORT}\n")
+		var dst Data
+		err := ConfigFileLoader([]string{"-config.file", path, "-target", "ingester", "-config.expand-env=true"}, "config.file", false)(&dst)
+		require.NoError(t, err)
+		assert.Equal(t, 4444, dst.Server.Port)
+	})
+
+	t.Run("malformed flag syntax does not cause infinite loop", func(t *testing.T) {
+		path := writeConfigFile(t, "server:\n  port: 5555\n")
+		var dst Data
+		err := ConfigFileLoader([]string{"---foo", "-config.file", path}, "config.file", false)(&dst)
+		require.NoError(t, err)
+		assert.Equal(t, 5555, dst.Server.Port)
+	})
 }

--- a/pkg/util/cfg/files_test.go
+++ b/pkg/util/cfg/files_test.go
@@ -2,9 +2,11 @@ package cfg
 
 import (
 	"flag"
+	"os"
 	"testing"
 
 	"github.com/grafana/dskit/flagext"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,4 +32,77 @@ func TestConfigFileLoaderDoesNotMutate(t *testing.T) {
 
 	cfg.RegisterFlags(nil)
 	require.Equal(t, 1, cfg.v)
+}
+
+func writeConfigFile(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "config-*.yaml")
+	require.NoError(t, err)
+	_, err = f.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
+}
+
+func TestConfigFileLoader(t *testing.T) {
+	t.Run("no config.file arg returns nil", func(t *testing.T) {
+		var dst Data
+		err := ConfigFileLoader([]string{"-server.port", "9090"}, "config.file", true)(&dst)
+		require.NoError(t, err)
+		assert.Equal(t, 0, dst.Server.Port) // untouched
+	})
+
+	t.Run("loads values from config file", func(t *testing.T) {
+		path := writeConfigFile(t, "server:\n  port: 1234\n")
+		var dst Data
+		err := ConfigFileLoader([]string{"-config.file", path}, "config.file", false)(&dst)
+		require.NoError(t, err)
+		assert.Equal(t, 1234, dst.Server.Port)
+	})
+
+	t.Run("strict mode rejects unknown fields", func(t *testing.T) {
+		path := writeConfigFile(t, "unknown_field: true\n")
+		var dst Data
+		err := ConfigFileLoader([]string{"-config.file", path}, "config.file", true)(&dst)
+		require.Error(t, err)
+	})
+
+	t.Run("non-strict mode ignores unknown fields", func(t *testing.T) {
+		path := writeConfigFile(t, "unknown_field: true\nserver:\n  port: 5678\n")
+		var dst Data
+		err := ConfigFileLoader([]string{"-config.file", path}, "config.file", false)(&dst)
+		require.NoError(t, err)
+		assert.Equal(t, 5678, dst.Server.Port)
+	})
+
+	t.Run("expands environment variables when config.expand-env is set", func(t *testing.T) {
+		t.Setenv("TEST_PORT", "4321")
+		path := writeConfigFile(t, "server:\n  port: ${TEST_PORT}\n")
+		var dst Data
+		err := ConfigFileLoader([]string{"-config.file", path, "-config.expand-env=true"}, "config.file", false)(&dst)
+		require.NoError(t, err)
+		assert.Equal(t, 4321, dst.Server.Port)
+	})
+
+	t.Run("comma-separated paths: uses first existing file", func(t *testing.T) {
+		path := writeConfigFile(t, "server:\n  port: 7777\n")
+		var dst Data
+		err := ConfigFileLoader([]string{"-config.file", "/does/not/exist," + path}, "config.file", false)(&dst)
+		require.NoError(t, err)
+		assert.Equal(t, 7777, dst.Server.Port)
+	})
+
+	t.Run("returns error when no path in the list exists", func(t *testing.T) {
+		var dst Data
+		err := ConfigFileLoader([]string{"-config.file", "/no/such/file.yaml"}, "config.file", false)(&dst)
+		require.Error(t, err)
+	})
+
+	t.Run("unknown flags alongside config.file are silently ignored", func(t *testing.T) {
+		path := writeConfigFile(t, "server:\n  port: 2222\n")
+		var dst Data
+		err := ConfigFileLoader([]string{"-config.file", path, "-enterprise.only.flag", "value"}, "config.file", false)(&dst)
+		require.NoError(t, err)
+		assert.Equal(t, 2222, dst.Server.Port)
+	})
 }

--- a/pkg/util/cfg/files_test.go
+++ b/pkg/util/cfg/files_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/grafana/dskit/flagext"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,7 +48,7 @@ func TestConfigFileLoader(t *testing.T) {
 		var dst Data
 		err := ConfigFileLoader([]string{"-server.port", "9090"}, "config.file", true)(&dst)
 		require.NoError(t, err)
-		assert.Equal(t, 0, dst.Server.Port) // untouched
+		require.Equal(t, 0, dst.Server.Port) // untouched
 	})
 
 	t.Run("loads values from config file", func(t *testing.T) {
@@ -57,7 +56,7 @@ func TestConfigFileLoader(t *testing.T) {
 		var dst Data
 		err := ConfigFileLoader([]string{"-config.file", path}, "config.file", false)(&dst)
 		require.NoError(t, err)
-		assert.Equal(t, 1234, dst.Server.Port)
+		require.Equal(t, 1234, dst.Server.Port)
 	})
 
 	t.Run("strict mode rejects unknown fields", func(t *testing.T) {
@@ -72,7 +71,7 @@ func TestConfigFileLoader(t *testing.T) {
 		var dst Data
 		err := ConfigFileLoader([]string{"-config.file", path}, "config.file", false)(&dst)
 		require.NoError(t, err)
-		assert.Equal(t, 5678, dst.Server.Port)
+		require.Equal(t, 5678, dst.Server.Port)
 	})
 
 	t.Run("expands environment variables when config.expand-env is set", func(t *testing.T) {
@@ -81,7 +80,7 @@ func TestConfigFileLoader(t *testing.T) {
 		var dst Data
 		err := ConfigFileLoader([]string{"-config.file", path, "-config.expand-env=true"}, "config.file", false)(&dst)
 		require.NoError(t, err)
-		assert.Equal(t, 4321, dst.Server.Port)
+		require.Equal(t, 4321, dst.Server.Port)
 	})
 
 	t.Run("comma-separated paths: uses first existing file", func(t *testing.T) {
@@ -89,7 +88,7 @@ func TestConfigFileLoader(t *testing.T) {
 		var dst Data
 		err := ConfigFileLoader([]string{"-config.file", "/does/not/exist," + path}, "config.file", false)(&dst)
 		require.NoError(t, err)
-		assert.Equal(t, 7777, dst.Server.Port)
+		require.Equal(t, 7777, dst.Server.Port)
 	})
 
 	t.Run("returns error when no path in the list exists", func(t *testing.T) {
@@ -103,7 +102,7 @@ func TestConfigFileLoader(t *testing.T) {
 		var dst Data
 		err := ConfigFileLoader([]string{"-config.file", path, "-enterprise.only.flag", "value"}, "config.file", false)(&dst)
 		require.NoError(t, err)
-		assert.Equal(t, 2222, dst.Server.Port)
+		require.Equal(t, 2222, dst.Server.Port)
 	})
 
 	t.Run("unknown flag with value before config.file is skipped correctly", func(t *testing.T) {
@@ -111,7 +110,7 @@ func TestConfigFileLoader(t *testing.T) {
 		var dst Data
 		err := ConfigFileLoader([]string{"-target", "ingester", "-config.file", path}, "config.file", false)(&dst)
 		require.NoError(t, err)
-		assert.Equal(t, 3333, dst.Server.Port)
+		require.Equal(t, 3333, dst.Server.Port)
 	})
 
 	t.Run("unknown flag with value between config.file and config.expand-env is skipped correctly", func(t *testing.T) {
@@ -120,7 +119,7 @@ func TestConfigFileLoader(t *testing.T) {
 		var dst Data
 		err := ConfigFileLoader([]string{"-config.file", path, "-target", "ingester", "-config.expand-env=true"}, "config.file", false)(&dst)
 		require.NoError(t, err)
-		assert.Equal(t, 4444, dst.Server.Port)
+		require.Equal(t, 4444, dst.Server.Port)
 	})
 
 	t.Run("malformed flag syntax does not cause infinite loop", func(t *testing.T) {
@@ -128,6 +127,6 @@ func TestConfigFileLoader(t *testing.T) {
 		var dst Data
 		err := ConfigFileLoader([]string{"---foo", "-config.file", path}, "config.file", false)(&dst)
 		require.NoError(t, err)
-		assert.Equal(t, 5555, dst.Server.Port)
+		require.Equal(t, 5555, dst.Server.Port)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

To be able to modify and extend the config parsing, this PR does the following changes:                                                                                                                                                                 

1. Extracts config file discovery into `FindConfigFileFromArgs`: a new exported function that locates `config.file` and `config.expand-env` in args using a minimal two-flag flagset. Only these two flags are registered; all other flags in args are intentionally skipped, since the sole purpose is to locate the config file before full flag parsing begins. Unknown flags are not an error here; they are caught later during normal flag parsing via Flags(args, fs).                                                                                                                                                                    
2. `ConfigFileLoader` is refactored to call `FindConfigFileFromArgs` internally rather than cloning the config, registering all flags, and parsing the full flag set itself. This removes the `dst.Clone().RegisterFlags()` call and the `os.Exit(2)` paths from `ConfigFileLoader`. The behavioural implication is that unrecognised flags and `-help` are no longer caught during config-file loading; they surface at the Flags(args, fs) step instead. For normal Loki usage, the outcome is identical.
3. Adds a `FileLoader` hook to `DynamicUnmarshal`: an optional variadic parameter that overrides how the config file is located and decoded on both the strict (first) and non-strict (second) passes. When omitted, `ConfigFileLoader` is used as before. This hook allows callers that perform their own file preprocessing to pass already-decoded bytes into the two-pass orchestration rather than having `DynamicUnmarshal` discover and read the file itself.

I have added enough tests to ensure there are no breaking changes.

**Checklist**
- [X] Tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core config-loading/flag-parsing paths; behavior around unknown flags, malformed args, and help handling changes and could affect startup/config precedence if edge cases are missed.
> 
> **Overview**
> Refactors config-file discovery/loading to be more extensible and less coupled to full flag registration.
> 
> `DynamicUnmarshal` now delegates to `DynamicUnmarshalWithLoader`, introducing a `FileLoader` hook so callers can override how `config.file` is located/decoded for both the strict and non-strict config-file passes.
> 
> `ConfigFileLoader` is reworked to use a new exported `FindConfigFileFromArgs` that only parses `config.file` and `config.expand-env`, intentionally skipping unknown/malformed flags instead of exiting early; tests are expanded to cover strict vs non-strict YAML behavior, env expansion, comma-separated paths, and robustness with unknown/malformed CLI args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deceb0864cdc454ef17f5a7d086b9e7732977e09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->