### PR TITLE
test: Fix race in bloom planner cancellation test

### DIFF
--- a/pkg/bloombuild/planner/planner_test.go
+++ b/pkg/bloombuild/planner/planner_test.go
@@ -176,9 +176,17 @@ func Test_BuilderLoop(t *testing.T) {
 			// Start planner
 			err := services.StartAndAwaitRunning(context.Background(), planner)
 			require.NoError(t, err)
+
+			builderErrCh := make(chan error, nBuilders)
+			var builderWg sync.WaitGroup
+
 			t.Cleanup(func() {
 				err := services.StopAndAwaitTerminated(context.Background(), planner)
 				require.NoError(t, err)
+				builderWg.Wait()
+				for i := 0; i < nBuilders; i++ {
+					require.ErrorIs(t, <-builderErrCh, tc.expectedBuilderLoopError)
+				}
 			})
 
 			// Enqueue tasks
@@ -195,10 +203,11 @@ func Test_BuilderLoop(t *testing.T) {
 				builder := newMockBuilder(fmt.Sprintf("builder-%d", i))
 				builders = append(builders, builder)
 
-				go func(expectedBuilderLoopError error) {
-					err := planner.BuilderLoop(builder)
-					require.ErrorIs(t, err, expectedBuilderLoopError)
-				}(tc.expectedBuilderLoopError)
+				builderWg.Add(1)
+				go func(builder *fakeBuilder) {
+					defer builderWg.Done()
+					builderErrCh <- planner.BuilderLoop(builder)
+				}(builder)
 			}
 
 			// Eventually, all tasks should be sent to builders
@@ -210,8 +219,10 @@ func Test_BuilderLoop(t *testing.T) {
 				return receivedTasks == nTasks
 			}, 5*time.Second, 10*time.Millisecond)
 
-			// Finally, the queue should be empty
-			require.Equal(t, 0, planner.tasksQueue.TotalPending())
+			// Dequeued tasks stay in pendingTasks until Release; wait for that after all sends.
+			require.Eventually(t, func() bool {
+				return planner.tasksQueue.TotalPending() == 0
+			}, 5*time.Second, 10*time.Millisecond, "pending tasks: %d", planner.tasksQueue.TotalPending())
 
 			// consume all tasks result to free up the channel for the next round of tasks
 			for i := 0; i < nTasks; i++ {


### PR DESCRIPTION
**What this PR does / why we need it**:
To address
```
--- FAIL: Test_BuilderLoop (10.22s)
    --- FAIL: Test_BuilderLoop/context_cancel (0.04s)
        planner_test.go:214: 
            	Error Trace:	/Users/progers/dev/src/github.com/grafana/loki/pkg/bloombuild/planner/planner_test.go:214
            	Error:      	Not equal: 
            	            	expected: 0
            	            	actual  : 6
            	Test:       	Test_BuilderLoop/context_cancel
        planner_test.go:200: 
            	Error Trace:	/Users/progers/dev/src/github.com/grafana/loki/pkg/bloombuild/planner/planner_test.go:200
            	            				/opt/homebrew/Cellar/go/1.26.3/libexec/src/runtime/asm_arm64.s:1447
            	Error:      	Target error should be in err chain:
            	            	expected: "context canceled"
            	            	in chain: "planner is not running"
            	Test:       	Test_BuilderLoop/context_cancel
```
**Which issue(s) this PR fixes**:
In support of: https://github.com/grafana/loki/issues/8586

**Special notes for your reviewer**:
```
 % go test -race -count=20 -timeout=300s ./pkg/bloombuild/planner -run 'Test_BuilderLoop/context_cancel'
ok  	github.com/grafana/loki/v3/pkg/bloombuild/planner	102.193s

go test -race -count=50 -timeout=300s ./pkg/bloombuild/planner -run 'Test_BuilderLoop/context_cancel'
ok  	github.com/grafana/loki/v3/pkg/bloombuild/planner	253.105s
```
**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that add synchronization and more robust eventual assertions; no production code paths are modified.
> 
> **Overview**
> Stabilizes `Test_BuilderLoop` by capturing `BuilderLoop` errors via a channel and waiting for all builder goroutines to exit during cleanup, instead of asserting inside goroutines.
> 
> Updates the empty-queue assertion to account for tasks remaining in `pendingTasks` until release by using `require.Eventually` on `tasksQueue.TotalPending()` rather than an immediate equality check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 699153936a6bfbcb4046a84294085c4f72ed74c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->