### PR TITLE
fix: align nginx log format with standard combined format

### DIFF
--- a/production/docker/config/nginx.conf
+++ b/production/docker/config/nginx.conf
@@ -8,8 +8,8 @@ events {
 
 http {
   default_type application/octet-stream;
-  log_format   main '$remote_addr - $remote_user [$time_local]  $status '
-    '"$request" $body_bytes_sent "$http_referer" '
+  log_format   main '$remote_addr - $remote_user [$time_local] "$request" '
+    '$status $body_bytes_sent "$http_referer" '
     '"$http_user_agent" "$http_x_forwarded_for"';
   access_log   /dev/stderr  main;
   sendfile     on;


### PR DESCRIPTION
## Summary
Fixes #18788 - Aligns the nginx `log_format` directive in the Loki gateway config with the standard nginx combined log format.

**Before**: `$status` came before `"$request"` with an extra space, making standard nginx log parsers fail:
```
$remote_addr - $remote_user [$time_local]  $status "$request" ...
```

**After**: Standard combined format order with correct spacing:
```
$remote_addr - $remote_user [$time_local] "$request" $status ...
```

## Changes
- `production/docker/config/nginx.conf`: Swapped `$status` and `"$request"` fields, removed double space

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes NGINX access log formatting/field order, with no impact on request routing or proxy behavior.
> 
> **Overview**
> Aligns the Loki gateway `nginx.conf` access `log_format` with the standard *combined* format by moving `$status` after `"$request"` and fixing spacing.
> 
> This should make emitted access logs compatible with standard NGINX log parsers without changing any proxying/routing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba311f7fceee8c3e49fda86af807e65c11d45de9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->