### PR TITLE
fix(goldfish): Use queryUsedV2Engine stat instead of warning message

### DIFF
--- a/pkg/querytee/goldfish/end_to_end_test.go
+++ b/pkg/querytee/goldfish/end_to_end_test.go
@@ -152,8 +152,8 @@ func TestGoldfishEndToEnd(t *testing.T) {
 	assert.NotEmpty(t, sample.CellAResponseHash)
 	assert.NotEmpty(t, sample.CellBResponseHash)
 	// Verify engine tracking fields are populated
-	assert.False(t, sample.CellAUsedNewEngine) // No new engine warning in response
-	assert.False(t, sample.CellBUsedNewEngine) // No new engine warning in response
+	assert.False(t, sample.CellAUsedNewEngine) // No v2 engine flag in stats
+	assert.False(t, sample.CellBUsedNewEngine) // No v2 engine flag in stats
 
 	// Check the comparison result
 	result := storage.results[0]
@@ -368,7 +368,7 @@ func TestGoldfishNewEngineDetection(t *testing.T) {
 	req := httptest.NewRequest("GET", constants.PathLokiQueryRange+"?query={job=\"test\"}", nil)
 	req.Header.Set("X-Scope-OrgID", "tenant1")
 
-	// Cell A response with new engine warning
+	// Cell A response with the v2 engine flag in query stats
 	responseBodyA := []byte(`{
 		"status": "success",
 		"data": {
@@ -388,15 +388,17 @@ func TestGoldfishNewEngineDetection(t *testing.T) {
 					"totalEntriesReturned": 1,
 					"splits": 1,
 					"shards": 1
+				},
+				"querier": {
+					"store": {
+						"queryUsedV2Engine": true
+					}
 				}
 			}
-		},
-		"warnings": [
-			"Query was executed using the next-generation Loki query engine."
-		]
+		}
 	}`)
 
-	// Cell B response without new engine warning
+	// Cell B response without the v2 engine flag
 	responseBodyB := []byte(`{
 		"status": "success",
 		"data": {

--- a/pkg/querytee/goldfish/manager_test.go
+++ b/pkg/querytee/goldfish/manager_test.go
@@ -161,7 +161,7 @@ func TestManager_ProcessQueryPair(t *testing.T) {
 	cellBResp := &BackendResponse{
 		BackendName: "cell-b",
 		Status:      200,
-		Body:        []byte(`{"status":"success","data":{"resultType":"matrix","result":[],"stats":{"summary":{"execTime":0.12,"queueTime":0.06,"totalBytesProcessed":1000,"totalLinesProcessed":100,"bytesProcessedPerSecond":8333,"linesProcessedPerSecond":833,"totalEntriesReturned":5,"splits":1,"shards":2}}},"warnings":["Query was executed using the next-generation Loki query engine."]}`),
+		Body:        []byte(`{"status":"success","data":{"resultType":"matrix","result":[],"stats":{"summary":{"execTime":0.12,"queueTime":0.06,"totalBytesProcessed":1000,"totalLinesProcessed":100,"bytesProcessedPerSecond":8333,"linesProcessedPerSecond":833,"totalEntriesReturned":5,"splits":1,"shards":2},"querier":{"store":{"queryUsedV2Engine":true}}}}}`),
 		Duration:    120 * time.Millisecond,
 		TraceID:     "",
 		SpanID:      "",

--- a/pkg/querytee/goldfish/stats_extractor.go
+++ b/pkg/querytee/goldfish/stats_extractor.go
@@ -41,8 +41,7 @@ func (e *StatsExtractor) ExtractResponseData(responseBody []byte, duration int64
 	// Calculate response size
 	responseSize := int64(len(responseBody))
 
-	// Check if new engine was used by looking for the specific warning
-	usedNewEngine := e.checkForNewEngineWarning(queryResp.Warnings)
+	usedNewEngine := queryResp.Data.Statistics.QueryUsedV2Engine()
 
 	return queryStats, responseHash, responseSize, usedNewEngine, queryResp.Data.ResultType, nil
 }
@@ -223,16 +222,4 @@ func (e *StatsExtractor) CompareStats(cellA, cellB goldfish.QueryStats) map[stri
 	}
 
 	return differences
-}
-
-// checkForNewEngineWarning checks if the warnings contain the new engine warning
-func (e *StatsExtractor) checkForNewEngineWarning(warnings []string) bool {
-	const newEngineWarning = "Query was executed using the next-generation Loki query engine."
-
-	for _, warning := range warnings {
-		if warning == newEngineWarning {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/querytee/goldfish/stats_extractor_test.go
+++ b/pkg/querytee/goldfish/stats_extractor_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStatsExtractor_NewEngineWarningDetection(t *testing.T) {
+func TestStatsExtractor_NewEngineDetection(t *testing.T) {
 	extractor := NewStatsExtractor()
 
 	tests := []struct {
@@ -18,7 +18,7 @@ func TestStatsExtractor_NewEngineWarningDetection(t *testing.T) {
 		expectedError      bool
 	}{
 		{
-			name: "response with new engine warning",
+			name: "response with v2 engine flag in stats",
 			responseBody: `{
 				"status": "success",
 				"data": {
@@ -38,6 +38,44 @@ func TestStatsExtractor_NewEngineWarningDetection(t *testing.T) {
 							"totalEntriesReturned": 1,
 							"splits": 1,
 							"shards": 1
+						},
+						"querier": {
+							"store": {
+								"queryUsedV2Engine": true
+							}
+						}
+					}
+				}
+			}`,
+			expectedUsed:       true,
+			expectedResultType: "streams",
+		},
+		{
+			name: "warning text is ignored",
+			responseBody: `{
+				"status": "success",
+				"data": {
+					"resultType": "streams",
+					"result": [{
+						"stream": {"job": "test"},
+						"values": [["1700000000000000000", "log line"]]
+					}],
+					"stats": {
+						"summary": {
+							"execTime": 0.05,
+							"queueTime": 0.01,
+							"totalBytesProcessed": 1000,
+							"totalLinesProcessed": 10,
+							"bytesProcessedPerSecond": 20000,
+							"linesProcessedPerSecond": 200,
+							"totalEntriesReturned": 1,
+							"splits": 1,
+							"shards": 1
+						},
+						"querier": {
+							"store": {
+								"queryUsedV2Engine": false
+							}
 						}
 					}
 				},
@@ -45,12 +83,11 @@ func TestStatsExtractor_NewEngineWarningDetection(t *testing.T) {
 					"Query was executed using the next-generation Loki query engine."
 				]
 			}`,
-			expectedUsed:       true,
+			expectedUsed:       false,
 			expectedResultType: "streams",
-			expectedError:      false,
 		},
 		{
-			name: "response without warnings",
+			name: "missing engine flag defaults to false",
 			responseBody: `{
 				"status": "success",
 				"data": {
@@ -76,109 +113,10 @@ func TestStatsExtractor_NewEngineWarningDetection(t *testing.T) {
 			}`,
 			expectedUsed:       false,
 			expectedResultType: "streams",
-			expectedError:      false,
-		},
-		{
-			name: "response with different warning",
-			responseBody: `{
-				"status": "success",
-				"data": {
-					"resultType": "streams",
-					"result": [{
-						"stream": {"job": "test"},
-						"values": [["1700000000000000000", "log line"]]
-					}],
-					"stats": {
-						"summary": {
-							"execTime": 0.05,
-							"queueTime": 0.01,
-							"totalBytesProcessed": 1000,
-							"totalLinesProcessed": 10,
-							"bytesProcessedPerSecond": 20000,
-							"linesProcessedPerSecond": 200,
-							"totalEntriesReturned": 1,
-							"splits": 1,
-							"shards": 1
-						}
-					}
-				},
-				"warnings": [
-					"Some other warning message",
-					"Query processing took longer than expected"
-				]
-			}`,
-			expectedUsed:       false,
-			expectedResultType: "streams",
-			expectedError:      false,
-		},
-		{
-			name: "response with new engine warning among others",
-			responseBody: `{
-				"status": "success",
-				"data": {
-					"resultType": "streams",
-					"result": [{
-						"stream": {"job": "test"},
-						"values": [["1700000000000000000", "log line"]]
-					}],
-					"stats": {
-						"summary": {
-							"execTime": 0.05,
-							"queueTime": 0.01,
-							"totalBytesProcessed": 1000,
-							"totalLinesProcessed": 10,
-							"bytesProcessedPerSecond": 20000,
-							"linesProcessedPerSecond": 200,
-							"totalEntriesReturned": 1,
-							"splits": 1,
-							"shards": 1
-						}
-					}
-				},
-				"warnings": [
-					"Query processing took longer than expected",
-					"Query was executed using the next-generation Loki query engine.",
-					"Large dataset detected"
-				]
-			}`,
-			expectedUsed:       true,
-			expectedResultType: "streams",
-			expectedError:      false,
-		},
-		{
-			name: "empty warnings array",
-			responseBody: `{
-				"status": "success",
-				"data": {
-					"resultType": "streams",
-					"result": [{
-						"stream": {"job": "test"},
-						"values": [["1700000000000000000", "log line"]]
-					}],
-					"stats": {
-						"summary": {
-							"execTime": 0.05,
-							"queueTime": 0.01,
-							"totalBytesProcessed": 1000,
-							"totalLinesProcessed": 10,
-							"bytesProcessedPerSecond": 20000,
-							"linesProcessedPerSecond": 200,
-							"totalEntriesReturned": 1,
-							"splits": 1,
-							"shards": 1
-						}
-					}
-				},
-				"warnings": []
-			}`,
-			expectedUsed:       false,
-			expectedResultType: "streams",
-			expectedError:      false,
 		},
 		{
 			name:               "invalid JSON",
 			responseBody:       `{invalid json}`,
-			expectedUsed:       false,
 			expectedResultType: "",
 			expectedError:      true,
 		},
@@ -190,83 +128,18 @@ func TestStatsExtractor_NewEngineWarningDetection(t *testing.T) {
 
 			if tt.expectedError {
 				assert.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.expectedUsed, usedNewEngine, "usedNewEngine mismatch")
-				assert.Equal(t, tt.expectedResultType, string(resultType), "resultType mismatch")
-
-				// Verify other fields are still extracted correctly
-				if stats.ExecTimeMs > 0 {
-					assert.Equal(t, int64(50), stats.ExecTimeMs) // Should use duration-based time
-					assert.Equal(t, int64(10), stats.QueueTimeMs)
-					assert.Equal(t, int64(1000), stats.BytesProcessed)
-					assert.Equal(t, int64(10), stats.LinesProcessed)
-				}
-				assert.NotEmpty(t, hash)
-				assert.Greater(t, size, int64(0))
+				return
 			}
-		})
-	}
-}
 
-func TestStatsExtractor_CheckForNewEngineWarning(t *testing.T) {
-	extractor := NewStatsExtractor()
-
-	tests := []struct {
-		name     string
-		warnings []string
-		expected bool
-	}{
-		{
-			name:     "exact match",
-			warnings: []string{"Query was executed using the next-generation Loki query engine."},
-			expected: true,
-		},
-		{
-			name:     "no match",
-			warnings: []string{"Some other warning"},
-			expected: false,
-		},
-		{
-			name:     "empty warnings",
-			warnings: []string{},
-			expected: false,
-		},
-		{
-			name:     "nil warnings",
-			warnings: nil,
-			expected: false,
-		},
-		{
-			name: "partial match should not count",
-			warnings: []string{
-				"Query was executed using",
-				"the next-generation Loki query engine.",
-			},
-			expected: false,
-		},
-		{
-			name: "multiple warnings with match",
-			warnings: []string{
-				"Warning 1",
-				"Query was executed using the next-generation Loki query engine.",
-				"Warning 3",
-			},
-			expected: true,
-		},
-		{
-			name: "case sensitive check",
-			warnings: []string{
-				"query was executed using the next-generation loki query engine.",
-			},
-			expected: false, // Should be case sensitive
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := extractor.checkForNewEngineWarning(tt.warnings)
-			assert.Equal(t, tt.expected, result)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedUsed, usedNewEngine, "usedNewEngine mismatch")
+			assert.Equal(t, tt.expectedResultType, string(resultType), "resultType mismatch")
+			assert.Equal(t, int64(50), stats.ExecTimeMs)
+			assert.Equal(t, int64(10), stats.QueueTimeMs)
+			assert.Equal(t, int64(1000), stats.BytesProcessed)
+			assert.Equal(t, int64(10), stats.LinesProcessed)
+			assert.NotEmpty(t, hash)
+			assert.Greater(t, size, int64(0))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

v2 engine detection is flaky as it relies on matching against warning message. If the message changes, detection can fail if goldfish and query workloads follow different release cadence.

Instead switch to using `queryUsedV2Engine` flag from query statistics

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to how Goldfish infers “new engine” usage from query responses, plus corresponding test updates; no auth, storage, or API behavior changes beyond this boolean.
> 
> **Overview**
> Goldfish now detects “new engine” usage via the structured `stats.querier.store.queryUsedV2Engine` flag (`QueryUsedV2Engine()`), replacing the previous string-match on a warning message.
> 
> Tests are updated accordingly: warning-based fixtures/assertions are removed, JSON responses now include (or omit) the v2 engine stats flag, and coverage ensures warning text no longer affects detection while missing flags default to `false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52c93427d14a4d0e5aeeb084c6e3d8e2f0370ee1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->