### PR TITLE
chore: Improve AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,33 +1,58 @@
-# Loki Development Guide
+# AGENTS.md
 
-## Build & Test Commands
+Instructions file for coding agents.
+
+## Environment Setup
+
+- Use the minimum Go version specified in [go.mod](go.mod)
+- Warn the user about an old Go version
+- The project uses GNU make for building binaries and images. See [Makefile](Makefile)
+
+## Commands
+
+### Tests
+
+For fast feeback run tests using `go test` (or `gotest` if available).
 
 ```bash
-make all                      # build all binaries
-make loki                     # build loki only
-make logcli                   # build logcli only
-make test                     # run all unit tests
-make test-integration         # run integration tests
-go test ./...                 # run all tests with Go directly
-go test -v ./pkg/logql/...    # run tests in specific package
-go test -run TestName ./pkg/path  # run a specific test
-make lint  # run all linters (use in CI-like environment)
-make format                   # format code (gofmt and goimports)
+go test -v ./...                               # run all tests with Go directly
+go test -v ./pkg/...                           # run Loki package tests
+go test -v ./pkg/<pkg>/...                     # run tests in specific package
+go test -v -test.run TestName ./pkg/<pkg>/...  # run a specific test
 ```
 
-## Code Style Guidelines
+For full verification use dedicated `make` targets (only when requested).
+
+```
+make test                                      # run full test suite
+make test-integration                          # run integration test suite
+make test-fuzz                                 # run fuzz tests
+```
+
+## Code Style
+
 - Follow standard Go formatting (gofmt/goimports)
-- Import order: standard lib, external packages, then Loki packages
+- Follow import order:
+  1. standard lib
+  2. external packages
+  3. Loki packages (`github.com/grafana/loki/v3`)
 - Error handling: Always check errors with `if err != nil { return ... }`
-- Use structured logging with leveled logging (go-kit/log)
-- Use CamelCase for exported identifiers, camelCase for non-exported 
+- Use structured logging with leveled logging (`github.com/go-kit/log`)
 - Document all exported functions, types, and variables
+
+### Testing
+
+- Always prefer `github.com/stretchr/testify/require` over `github.com/stretchr/testify/assert`
 - Use table-driven tests when appropriate
-- Follow Conventional Commits format: `<change type>: Your change`
-- For frontend: use TypeScript, functional components, component composition
-- Frontend naming: lowercase with dashes for directories (components/auth-wizard)
+
+## Commits and Pull Requests
+
+- Always run Loki package tests `gotest -v ./pkg/...` before commiting
+- Focus on "why", rather than "what" in the commit message and PR description
+- Follow conventional commits format: `<type>(<scope>): Your change` (note the uppercase after colon)
 
 ## Documentation Standards
+
 - Follow the Grafana [Writers' Toolkit](https://grafana.com/docs/writers-toolkit/) Style Guide
 - Use CommonMark flavor of markdown for documentation
 - Create LIDs (Loki Improvement Documents) for large functionality changes
@@ -36,4 +61,5 @@ make format                   # format code (gofmt and goimports)
 - Include examples and clear descriptions for public APIs
 
 ## Using Tools
+
 - When using the `mcp__acp__Write` tool, write to a path within the current worktree to avoid sandboxing/permissions issues. This includes when writing plan files.


### PR DESCRIPTION
### Summary

Recently I saw multiple pull requests that were created with the help of AI agents and the test used both `github.com/stretchr/testify/assert` and `github.com/stretchr/testify/require` in the same file. This project tries to use `require` - although there are still old usages of `assert`.

This was the motivation behind behind updating and improving the AGENTS.md file, loosely following https://gist.github.com/0xfauzi/7c8f65572930a21efa62623557d83f6e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only updates contributor/agent documentation and does not change runtime code or build behavior.
> 
> **Overview**
> Updates `AGENTS.md` from a generic Loki dev guide into explicit instructions for coding agents, adding environment setup expectations (Go version, make usage) and reorganizing test guidance to emphasize fast `go test` workflows vs. full `make` verification.
> 
> Clarifies code style conventions (import ordering, logging package) and adds testing guidance to prefer `testify/require` over `assert`, plus lightweight commit/PR and documentation standards reminders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 743c338ae4387be052e0ea1582cb62418134cf82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->