### PR TITLE
chore(dataset/array): Add Binary encoding

### DIFF
--- a/pkg/dataset/array/codec.go
+++ b/pkg/dataset/array/codec.go
@@ -17,6 +17,9 @@ type Writer interface {
 	//
 	// Implementations must not retain references to arr beyond the call to
 	// Append.
+	//
+	// Writers are not guaranteed to be in a stable state if Append returns an
+	// error.
 	Append(arr columnar.Array) error
 
 	// Flush flushes buffered data and returns a new [Array] that represents the
@@ -40,6 +43,8 @@ func NewWriter(alloc *memory.Allocator, spec Spec, typ types.Type) (Writer, erro
 		return newBoolWriter(alloc, spec, typ)
 	case EncodingKindPlain:
 		return newPlainWriter(alloc, spec, typ)
+	case EncodingKindBinary:
+		return newBinaryWriter(alloc, spec, typ)
 
 	default:
 		return nil, fmt.Errorf("unsupported encoding kind %q", spec.Kind())
@@ -88,6 +93,8 @@ func NewReader(alloc *memory.Allocator, arr Array, source buffer.Source) (Reader
 		return newBoolReader(alloc, arr, source)
 	case EncodingKindPlain:
 		return newPlainReader(alloc, arr, source)
+	case EncodingKindBinary:
+		return newBinaryReader(alloc, arr, source)
 
 	default:
 		return nil, fmt.Errorf("unsupported encoding kind %q", arr.Encoding.Kind())

--- a/pkg/dataset/array/codec_binary.go
+++ b/pkg/dataset/array/codec_binary.go
@@ -1,0 +1,341 @@
+package array
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+type binaryWriter struct {
+	alloc *memory.Allocator
+	typ   *types.UTF8
+
+	offsetWriter Writer
+	validity     Writer
+
+	initialized bool
+	data        memory.Buffer[byte]
+	nulls       int
+	rows        int
+}
+
+func newBinaryWriter(alloc *memory.Allocator, spec Spec, typ types.Type) (Writer, error) {
+	if got, want := spec.Kind(), EncodingKindBinary; got != want {
+		return nil, fmt.Errorf("expected spec kind %s, got %s", want, got)
+	} else if got, want := typ.Kind(), types.KindUTF8; got != want {
+		return nil, fmt.Errorf("expected type %s, got %s", want, got)
+	}
+
+	var (
+		binarySpec = spec.(*SpecBinary)
+		utf8Typ    = typ.(*types.UTF8)
+	)
+
+	if binarySpec.Offsets == nil {
+		return nil, errors.New("binary spec requires an offsets spec")
+	}
+
+	hasValidity := binarySpec.Validity != nil
+	if utf8Typ.Nullable != hasValidity {
+		return nil, fmt.Errorf("expected %s to have validity %t, got %t", utf8Typ, utf8Typ.Nullable, hasValidity)
+	}
+
+	offsetWriter, err := NewWriter(alloc, binarySpec.Offsets, &types.Int32{Nullable: false})
+	if err != nil {
+		return nil, fmt.Errorf("creating offset writer: %w", err)
+	}
+
+	var validityWriter Writer
+	if hasValidity {
+		validityWriter, err = NewWriter(alloc, binarySpec.Validity, &types.Bool{Nullable: false})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &binaryWriter{
+		alloc: alloc,
+		typ:   utf8Typ,
+
+		data:         memory.NewBuffer[byte](alloc, 0),
+		offsetWriter: offsetWriter,
+		validity:     validityWriter,
+	}, nil
+}
+
+func (w *binaryWriter) Append(arr columnar.Array) error {
+	utf8Arr, ok := arr.(*columnar.UTF8)
+	if !ok {
+		return fmt.Errorf("expected *columnar.UTF8, got %T", arr)
+	}
+
+	if !w.initialized {
+		w.init()
+		w.initialized = true
+	}
+
+	var (
+		baseOffset = int32(w.data.Len())
+
+		srcData    = utf8Arr.Data()
+		srcOffsets = utf8Arr.Offsets()
+		dataStart  = srcOffsets[0]
+		dataEnd    = srcOffsets[len(srcOffsets)-1]
+	)
+
+	// Validate before any mutation so a failed Append leaves the writer's
+	// state unchanged.
+	if err := validateNulls(w.validity, utf8Arr, utf8Arr.Len()); err != nil {
+		return err
+	}
+
+	// Fall through to the utility method to handle nulls (including whether our
+	// type is not nullable).
+	nulls, err := appendNulls(w.alloc, w.validity, utf8Arr, utf8Arr.Len())
+	if err != nil {
+		return err
+	}
+	w.nulls += nulls
+
+	// Append only the referenced data range. Sliced UTF8 arrays share the
+	// full parent data buffer, so srcData may contain bytes outside the
+	// offset range.
+	w.data.Grow(int(dataEnd - dataStart))
+	w.data.Append(srcData[dataStart:dataEnd]...)
+
+	// Build rebased offsets and write through the child offset writer (skip
+	// first since the leading zero was written by init).
+	{
+		alloc := memory.NewAllocator(w.alloc)
+		defer alloc.Free()
+
+		rebasedBuilder := columnar.NewNumberBuilder[int32](alloc)
+		rebasedBuilder.Grow(utf8Arr.Len())
+
+		for i := range utf8Arr.Len() {
+			rebasedBuilder.AppendValue(srcOffsets[i+1] - dataStart + baseOffset)
+		}
+
+		rebased := rebasedBuilder.Build()
+		if err := w.offsetWriter.Append(rebased); err != nil {
+			return fmt.Errorf("appending offsets: %w", err)
+		}
+		w.rows += utf8Arr.Len()
+	}
+	return nil
+}
+
+func (w *binaryWriter) init() {
+	// Write the leading zero offset, since the offset array has N+1 values.
+	leading := columnar.NewNumber([]int32{0}, memory.Bitmap{})
+
+	// offsetWriter.Append cannot fail for a single zero value written to a
+	// fresh writer, so we intentionally ignore the error.
+	_ = w.offsetWriter.Append(leading)
+}
+
+func (w *binaryWriter) Flush(ctx context.Context, sink buffer.Sink) (Array, error) {
+	defer w.reset()
+
+	// Write data buffer.
+	data := w.data.Serialize()
+	bufs, err := sink.WriteBuffers(ctx, []buffer.Data{data})
+	if err != nil {
+		return Array{}, fmt.Errorf("writing binary data to a buffer: %w", err)
+	}
+
+	var children []Array
+	var offsetArray Array
+	offsetArray, err = w.offsetWriter.Flush(ctx, sink)
+	if err != nil {
+		return Array{}, fmt.Errorf("flushing offset writer: %w", err)
+	}
+	children = append(children, offsetArray)
+
+	var validityArray Array
+	if validity := w.validity; validity != nil {
+		var err error
+		validityArray, err = validity.Flush(ctx, sink)
+		if err != nil {
+			return Array{}, fmt.Errorf("flushing validity writer: %w", err)
+		}
+
+		children = append(children, validityArray)
+	}
+
+	return Array{
+		Encoding: &EncodingBinary{},
+		Type:     w.typ,
+		Buffers:  bufs,
+		RowCount: w.rows,
+		Stats: Stats{
+			NullCount: w.nulls,
+		},
+		Children: children,
+	}, nil
+}
+
+func (w *binaryWriter) reset() {
+	w.initialized = false
+	w.data = memory.NewBuffer[byte](w.alloc, 0)
+	w.nulls = 0
+	w.rows = 0
+}
+
+type binaryReader struct {
+	alloc  *memory.Allocator
+	arr    Array
+	source buffer.Source
+
+	offsets  Reader
+	validity Reader
+
+	initialized bool
+	data        []byte
+	offsetData  []int32
+	off         int // Row offset into data
+}
+
+func newBinaryReader(alloc *memory.Allocator, arr Array, source buffer.Source) (*binaryReader, error) {
+	if got, want := arr.Encoding.Kind(), EncodingKindBinary; got != want {
+		return nil, fmt.Errorf("expected spec kind %s, got %s", want, got)
+	} else if got, want := arr.Type.Kind(), types.KindUTF8; got != want {
+		return nil, fmt.Errorf("expected type %s, got %s", want, got)
+	}
+
+	var (
+		utf8Typ = arr.Type.(*types.UTF8)
+	)
+
+	switch {
+	case !utf8Typ.Nullable && len(arr.Children) != 1:
+		return nil, fmt.Errorf("expected 1 child for non-nullable binary array, got %d", len(arr.Children))
+	case utf8Typ.Nullable && len(arr.Children) != 2:
+		return nil, fmt.Errorf("expected 2 children for nullable binary array, got %d", len(arr.Children))
+	}
+
+	offsetReader, err := NewReader(alloc, arr.Children[0], source)
+	if err != nil {
+		return nil, fmt.Errorf("creating offset reader: %w", err)
+	}
+
+	var validityReader Reader
+	if utf8Typ.Nullable {
+		validityReader, err = NewReader(alloc, arr.Children[1], source)
+		if err != nil {
+			return nil, fmt.Errorf("creating validity reader: %w", err)
+		}
+	}
+
+	return &binaryReader{
+		alloc:  alloc,
+		arr:    arr,
+		source: source,
+
+		offsets:  offsetReader,
+		validity: validityReader,
+	}, nil
+}
+
+func (r *binaryReader) Read(ctx context.Context, alloc *memory.Allocator, count int) (columnar.Array, error) {
+	if count <= 0 {
+		return nil, fmt.Errorf("count must be positive, got %d", count)
+	}
+
+	if !r.initialized {
+		// We use the reader's allocator for initializing since the data
+		// persists across calls to Read.
+		if err := r.init(ctx, r.alloc); err != nil {
+			return nil, err
+		}
+		r.initialized = true
+	}
+
+	endOff := min(r.off+count, r.arr.RowCount)
+	n := endOff - r.off
+	if n == 0 {
+		return nil, io.EOF
+	}
+
+	// Slice offsets for this batch. The offset array has N+1 values, so we
+	// take elements [off, off+n] inclusive to get n+1 offsets for n elements.
+	slicedOffsets := r.offsetData[r.off : r.off+n+1]
+
+	// Read validity bytes now.
+	var validity memory.Bitmap
+	if r.validity != nil {
+		validityArr, err := r.validity.Read(ctx, alloc, count)
+		if err != nil {
+			return nil, fmt.Errorf("reading validity: %w", err)
+		}
+
+		validityBoolArr := validityArr.(*columnar.Bool)
+		validity = validityBoolArr.Values()
+	}
+
+	r.off += n
+
+	// The sliced offsets reference positions within r.data, so we return the
+	// entire r.data slice for each call. If we sliced r.data, then we would
+	// need to normalize slicedOffsets to be positionally correct.
+	return columnar.NewUTF8(r.data, slicedOffsets, validity), nil
+}
+
+func (r *binaryReader) init(ctx context.Context, alloc *memory.Allocator) error {
+	data, err := r.source.ReadBuffers(ctx, alloc, r.arr.Buffers)
+	if err != nil {
+		return fmt.Errorf("fetching buffer data: %w", err)
+	} else if len(data) != 1 {
+		return fmt.Errorf("expected 1 buffer, got %d", len(data))
+	}
+
+	// We'll also read all the offsets immediately.
+	arr, err := r.offsets.Read(ctx, alloc, math.MaxInt)
+	if err != nil {
+		return fmt.Errorf("reading offsets: %w", err)
+	}
+	offsets := arr.(*columnar.Number[int32]).Values()
+
+	r.data = data[0]
+	r.offsetData = offsets
+	return nil
+}
+
+func (r *binaryReader) Reset() {
+	r.resetSelf()
+
+	if r.validity != nil {
+		r.validity.Reset()
+	}
+	if r.offsets != nil {
+		r.offsets.Reset()
+	}
+}
+
+func (r *binaryReader) resetSelf() {
+	// Reset the offset but keep everything else to allow for re-reading data.
+	r.off = 0
+}
+
+func (r *binaryReader) Close() error {
+	r.resetSelf()
+
+	// Clear state.
+	r.initialized = false
+	r.data = nil
+	r.offsetData = nil
+
+	if r.validity != nil {
+		offsetErr := r.offsets.Close()
+		validityErr := r.validity.Close()
+		return errors.Join(offsetErr, validityErr)
+	}
+	return r.offsets.Close()
+}

--- a/pkg/dataset/array/codec_binary_test.go
+++ b/pkg/dataset/array/codec_binary_test.go
@@ -1,0 +1,340 @@
+package array_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestBinaryCodec_Validation(t *testing.T) {
+	tt := []struct {
+		name string
+		spec array.Spec
+		typ  types.Type
+
+		expectError bool
+	}{
+		{
+			name:        "accepts valid non-nullable utf8",
+			spec:        &array.SpecBinary{Offsets: &array.SpecPlain{}},
+			typ:         &types.UTF8{Nullable: false},
+			expectError: false,
+		},
+		{
+			name:        "rejects missing offsets spec",
+			spec:        &array.SpecBinary{Offsets: nil},
+			typ:         &types.UTF8{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects non-nullable utf8 with validity spec",
+			spec:        &array.SpecBinary{Offsets: &array.SpecPlain{}, Validity: &array.SpecBool{}},
+			typ:         &types.UTF8{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects nullable utf8 with no validity spec",
+			spec:        &array.SpecBinary{Offsets: &array.SpecPlain{}},
+			typ:         &types.UTF8{Nullable: true},
+			expectError: true,
+		},
+		{
+			name:        "accepts nullable utf8 with validity spec",
+			spec:        &array.SpecBinary{Offsets: &array.SpecPlain{}, Validity: &array.SpecBool{}},
+			typ:         &types.UTF8{Nullable: true},
+			expectError: false,
+		},
+		{
+			name:        "rejects unsupported type bool",
+			spec:        &array.SpecBinary{Offsets: &array.SpecPlain{}},
+			typ:         &types.Bool{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects unsupported type int64",
+			spec:        &array.SpecBinary{Offsets: &array.SpecPlain{}},
+			typ:         &types.Int64{Nullable: false},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			var alloc memory.Allocator
+			_, err := array.NewWriter(&alloc, tc.spec, tc.typ)
+
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestBinaryCodec_NonNullable(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecBinary{Offsets: &array.SpecPlain{}}
+		typ  = &types.UTF8{Nullable: false}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	input := []columnar.Array{
+		columnartest.Array(t, types.KindUTF8, &alloc, "hello", "world", "", "foo", "bar"),
+		columnartest.Array(t, types.KindUTF8, &alloc, "baz", "qux", "quux", "corge", "grault"),
+	}
+	for _, arr := range input {
+		require.NoError(t, w.Append(arr))
+	}
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+	require.Equal(t, 10, result.RowCount)
+	require.Equal(t, 0, result.Stats.NullCount)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	expect := columnartest.Array(
+		t, types.KindUTF8, &alloc,
+		"hello", "world", "", "foo", "bar",
+		"baz", "qux", "quux", "corge", "grault",
+	)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+
+	// Reading again should produce a EOF.
+	_, err = r.Read(t.Context(), &alloc, 1)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestBinaryCodec_Nullable(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecBinary{Offsets: &array.SpecPlain{}, Validity: &array.SpecBool{}}
+		typ  = &types.UTF8{Nullable: true}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	input := []columnar.Array{
+		columnartest.Array(t, types.KindUTF8, &alloc, "hello", nil, "world", nil, "foo"),
+		columnartest.Array(t, types.KindUTF8, &alloc, "bar", "baz", "qux", "quux", "corge"),
+		columnartest.Array(t, types.KindUTF8, &alloc, nil),
+	}
+	for _, arr := range input {
+		require.NoError(t, w.Append(arr))
+	}
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+	require.Equal(t, 11, result.RowCount)
+	require.Equal(t, 3, result.Stats.NullCount)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	expect := columnartest.Array(
+		t, types.KindUTF8, &alloc,
+		"hello", nil, "world", nil, "foo",
+		"bar", "baz", "qux", "quux", "corge",
+		nil,
+	)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+
+	// Reading again should produce a EOF.
+	_, err = r.Read(t.Context(), &alloc, 1)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestBinaryCodec_EmptyFlush(t *testing.T) {
+	tt := []struct {
+		name string
+		spec array.Spec
+		typ  types.Type
+	}{
+		{
+			name: "non-nullable",
+			spec: &array.SpecBinary{Offsets: &array.SpecPlain{}},
+			typ:  &types.UTF8{Nullable: false},
+		},
+		{
+			name: "nullable",
+			spec: &array.SpecBinary{Offsets: &array.SpecPlain{}, Validity: &array.SpecBool{}},
+			typ:  &types.UTF8{Nullable: true},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			var alloc memory.Allocator
+			var store buffer.MemoryStore
+
+			w, err := array.NewWriter(&alloc, tc.spec, tc.typ)
+			require.NoError(t, err)
+
+			result, err := w.Flush(t.Context(), &store)
+			require.NoError(t, err)
+			require.Equal(t, 0, result.RowCount)
+
+			r, err := array.NewReader(&alloc, result, &store)
+			require.NoError(t, err)
+
+			_, err = r.Read(t.Context(), &alloc, 1)
+			require.ErrorIs(t, err, io.EOF)
+		})
+	}
+}
+
+func TestBinaryCodec_SlicedInput(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecBinary{Offsets: &array.SpecPlain{}}
+		typ  = &types.UTF8{Nullable: false}
+	)
+
+	// Build a full array then slice out a middle section, so the input has
+	// non-zero-based offsets and a shared data buffer.
+	full := columnartest.Array(t, types.KindUTF8, &alloc,
+		"alpha", "bravo", "charlie", "delta", "echo",
+	)
+	sliced := full.Slice(1, 4) // ["bravo", "charlie", "delta"]
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+	require.NoError(t, w.Append(sliced))
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+	require.Equal(t, 3, result.RowCount)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	expect := columnartest.Array(t, types.KindUTF8, &alloc,
+		"bravo", "charlie", "delta",
+	)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+}
+
+func BenchmarkBinaryCodec(b *testing.B) {
+	var (
+		store buffer.MemoryStore
+
+		spec = &array.SpecBinary{Offsets: &array.SpecPlain{}}
+		typ  = &types.UTF8{Nullable: false}
+	)
+
+	const valuesPerPage = 1 << 16
+
+	type scenario struct {
+		name       string
+		valueCount int
+		encoded    array.Array
+	}
+
+	build := func(name string, valueCount int, valueAt func(i int) []byte) scenario {
+		var alloc memory.Allocator
+		w, err := array.NewWriter(&alloc, spec, typ)
+		require.NoError(b, err)
+
+		builder := columnar.NewUTF8Builder(&alloc)
+		builder.Grow(valueCount)
+
+		for i := range valueCount {
+			builder.AppendValue(valueAt(i))
+		}
+		require.NoError(b, w.Append(builder.Build()))
+
+		arr, err := w.Flush(b.Context(), &store)
+		require.NoError(b, err)
+		return scenario{name: name, valueCount: valueCount, encoded: arr}
+	}
+
+	scenarios := []scenario{
+		build("variance=constant", valuesPerPage, func(int) []byte { return []byte("hello") }),
+		func() scenario {
+			rnd := rand.New(rand.NewSource(0))
+			return build("variance=random", valuesPerPage, func(int) []byte {
+				buf := make([]byte, 5+rnd.Intn(20))
+				rnd.Read(buf)
+				return buf
+			})
+		}(),
+	}
+
+	batchSizes := []int{256, 1024, 4096}
+
+	for _, sc := range scenarios {
+		b.Run(sc.name, func(b *testing.B) {
+			b.Run(fmt.Sprintf("values_per_page=%d", sc.valueCount), func(b *testing.B) {
+				for _, batchSize := range batchSizes {
+					b.Run(fmt.Sprintf("batch_size=%d", batchSize), func(b *testing.B) {
+						var alloc memory.Allocator
+
+						b.ReportAllocs()
+						// Approximate bytes: data + offsets
+						decodedBytesPerOp := int64(sc.encoded.RowCount) * 15 // ~15 bytes avg string
+						b.SetBytes(decodedBytesPerOp)
+
+						for b.Loop() {
+							alloc.Reset()
+
+							r, _ := array.NewReader(&alloc, sc.encoded, &store)
+
+							var decoded int
+							for {
+								arr, err := r.Read(b.Context(), &alloc, batchSize)
+								if arr != nil {
+									decoded += arr.Len()
+								}
+
+								if errors.Is(err, io.EOF) {
+									break
+								} else if err != nil {
+									b.Fatal(err)
+								}
+							}
+
+							if decoded != sc.valueCount {
+								b.Fatalf("decoded %d values, expected %d", decoded, sc.valueCount)
+							}
+						}
+
+						elapsed := b.Elapsed()
+						if elapsed > 0 {
+							totalDecoded := int64(sc.valueCount) * int64(b.N)
+							b.ReportMetric(float64(totalDecoded)/elapsed.Seconds(), "rows/s")
+						}
+					})
+				}
+			})
+		})
+	}
+}

--- a/pkg/dataset/array/encoding.go
+++ b/pkg/dataset/array/encoding.go
@@ -28,6 +28,15 @@ type (
 	// If the data type is nullable, then the first child Array holds validity
 	// data.
 	EncodingPlain struct{}
+
+	// EncodingBinary holds raw binary data without any compression. The first
+	// child Array holds N+1 offsets into the binary data, where N is the number
+	// of elements. The half-open range (offsets[i], offsets[i+1]] specifies the
+	// data for element i.
+	//
+	// If the data type is nullable, then the last child Array holds validity
+	// data.
+	EncodingBinary struct{}
 )
 
 // Kind returns [EncodingKindBool].
@@ -40,9 +49,15 @@ func (enc *EncodingPlain) Kind() EncodingKind {
 	return EncodingKindPlain
 }
 
+// Kind returns [EncodingKindBinary].
+func (enc *EncodingBinary) Kind() EncodingKind {
+	return EncodingKindBinary
+}
+
 //
 // Sealed marker implementations.
 //
 
-func (enc *EncodingBool) isEncoding()  {}
-func (enc *EncodingPlain) isEncoding() {}
+func (enc *EncodingBool) isEncoding()   {}
+func (enc *EncodingPlain) isEncoding()  {}
+func (enc *EncodingBinary) isEncoding() {}

--- a/pkg/dataset/array/encoding_kind.go
+++ b/pkg/dataset/array/encoding_kind.go
@@ -9,14 +9,16 @@ type EncodingKind int
 const (
 	EncodingKindInvalid EncodingKind = iota // EncodingKindInvalid is an invalid encoding.
 
-	EncodingKindBool  // EncodingKindBool is a bit-packed encoding for boolean types.
-	EncodingKindPlain // EncodingKindPlain is plain encoding for fixed-width types (int32, etc).
+	EncodingKindBool   // EncodingKindBool is a bit-packed encoding for boolean types.
+	EncodingKindPlain  // EncodingKindPlain is plain encoding for fixed-width types (int32, etc).
+	EncodingKindBinary // EncodingKindBinary encodes variable-length binary data (like UTF8).
 )
 
 var kindNames = [...]string{
 	EncodingKindInvalid: "invalid",
 	EncodingKindBool:    "bool",
 	EncodingKindPlain:   "plain",
+	EncodingKindBinary:  "binary",
 }
 
 // String returns the string representation of k.

--- a/pkg/dataset/array/spec.go
+++ b/pkg/dataset/array/spec.go
@@ -30,6 +30,25 @@ type (
 		// data types.
 		Validity Spec
 	}
+
+	// SpecBinary holds raw binary data without any compression.
+	//
+	// The first child Spec determines how to encode offset information, where
+	// the half-open range (offsets[i], offsets[i+1]] specifies where the
+	// offsets where element i.
+	//
+	// If the data type is nullable, then the last child Spec describes how to
+	// encode validity data.
+	SpecBinary struct {
+		// Spec for how to encode offset information, where the half-open range
+		// (offsets[i], offsets[i+1]] specifies where the offsets where element
+		// i.
+		Offsets Spec
+
+		// Spec for how to encode validity data. Must only be set for nullable
+		// data types.
+		Validity Spec
+	}
 )
 
 // Kind returns [EncodingKindBool].
@@ -42,9 +61,15 @@ func (spec *SpecPlain) Kind() EncodingKind {
 	return EncodingKindPlain
 }
 
+// Kind returns [EncodingKindBinary].
+func (spec *SpecBinary) Kind() EncodingKind {
+	return EncodingKindBinary
+}
+
 //
 // Sealed marker implementations.
 //
 
-func (spec *SpecBool) isSpec()  {}
-func (spec *SpecPlain) isSpec() {}
+func (spec *SpecBool) isSpec()   {}
+func (spec *SpecPlain) isSpec()  {}
+func (spec *SpecBinary) isSpec() {}


### PR DESCRIPTION
Adds a Binary encoding to dataset/array, which encodes variable-width UTF8 values.

UTF8 offsets are stored in a child encoding, such as Plain. If the UTF8 array is nullable, the final child encoding will be the encoding for the validity values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `EncodingKindBinary` with new read/write paths for UTF8 data, which affects persistence/decoding correctness and can introduce subtle offset/null-handling bugs. The change is well-covered by new unit tests and a benchmark, but still touches core serialization code.
> 
> **Overview**
> Adds a new **Binary** encoding (`EncodingKindBinary`) to `dataset/array` to support variable-length UTF8 values stored as a raw byte buffer plus a child offsets array (and an optional child validity array for nullable types).
> 
> Updates `NewWriter`/`NewReader` to route to the new codec, introduces `SpecBinary`/`EncodingBinary`, and includes comprehensive tests (validation, nullable/non-nullable roundtrips, sliced-input handling, empty flush) plus a benchmark for decode throughput.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4670117a660805492835c6a32452fb1aa49eb15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->