### PR TITLE
chore(dataset/array): Add Bitpacked encoding

### DIFF
--- a/pkg/dataset/array/codec.go
+++ b/pkg/dataset/array/codec.go
@@ -45,6 +45,8 @@ func NewWriter(alloc *memory.Allocator, spec Spec, typ types.Type) (Writer, erro
 		return newPlainWriter(alloc, spec, typ)
 	case EncodingKindBinary:
 		return newBinaryWriter(alloc, spec, typ)
+	case EncodingKindBitpacked:
+		return newBitpackedWriter(alloc, spec, typ)
 
 	default:
 		return nil, fmt.Errorf("unsupported encoding kind %q", spec.Kind())
@@ -95,6 +97,8 @@ func NewReader(alloc *memory.Allocator, arr Array, source buffer.Source) (Reader
 		return newPlainReader(alloc, arr, source)
 	case EncodingKindBinary:
 		return newBinaryReader(alloc, arr, source)
+	case EncodingKindBitpacked:
+		return newBitpackedReader(alloc, arr, source)
 
 	default:
 		return nil, fmt.Errorf("unsupported encoding kind %q", arr.Encoding.Kind())

--- a/pkg/dataset/array/codec_bitpacked.go
+++ b/pkg/dataset/array/codec_bitpacked.go
@@ -1,0 +1,478 @@
+package array
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math/bits"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+type unsigned interface{ uint32 | uint64 }
+
+type bitpackedWriter[T unsigned] struct {
+	alloc     *memory.Allocator
+	typ       types.Type
+	blockSize int
+
+	// pending holds values for the current incomplete block. Once it reaches
+	// blockSize, the block is bitpacked immediately and appended to packed.
+	pending     memory.Buffer[T]
+	packed      memory.Buffer[byte] // Concatenated bitpacked blocks.
+	widths      []uint32            // Per-block bit widths, written to widthWriter at Flush.
+	widthWriter Writer
+	validity    Writer
+	nulls       int
+	rows        int
+}
+
+func newBitpackedWriter(alloc *memory.Allocator, spec Spec, typ types.Type) (Writer, error) {
+	if got, want := spec.Kind(), EncodingKindBitpacked; got != want {
+		return nil, fmt.Errorf("expected spec kind %s, got %s", want, got)
+	}
+
+	bpSpec := spec.(*SpecBitpacked)
+
+	if bpSpec.BlockSize <= 0 {
+		return nil, fmt.Errorf("bitpacked block size must be positive, got %d", bpSpec.BlockSize)
+	}
+	if bpSpec.BlockSize%8 != 0 {
+		return nil, fmt.Errorf("bitpacked block size must be a multiple of 8, got %d", bpSpec.BlockSize)
+	}
+	if bpSpec.Widths == nil {
+		return nil, errors.New("bitpacked spec must have a widths spec")
+	}
+
+	switch typ := typ.(type) {
+	case *types.Uint32:
+		return newBitpackedWriterTyped[uint32](alloc, bpSpec, typ, typ.Nullable)
+	case *types.Uint64:
+		return newBitpackedWriterTyped[uint64](alloc, bpSpec, typ, typ.Nullable)
+	default:
+		return nil, fmt.Errorf("unsupported type %s for bitpacked encoding", typ)
+	}
+}
+
+func newBitpackedWriterTyped[T unsigned](alloc *memory.Allocator, spec *SpecBitpacked, typ types.Type, nullable bool) (*bitpackedWriter[T], error) {
+	hasValidity := spec.Validity != nil
+	if nullable != hasValidity {
+		return nil, fmt.Errorf("expected %s to have validity %t, got %t", typ, nullable, hasValidity)
+	}
+
+	// TODO(rfratto): We only need uint8 for widths, but there's no support for
+	// uint8 in columnar yet.
+	widthWriter, err := NewWriter(alloc, spec.Widths, &types.Uint32{Nullable: false})
+	if err != nil {
+		return nil, fmt.Errorf("creating widths writer: %w", err)
+	}
+
+	var validityWriter Writer
+	if hasValidity {
+		validityWriter, err = NewWriter(alloc, spec.Validity, &types.Bool{Nullable: false})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &bitpackedWriter[T]{
+		alloc:     alloc,
+		typ:       typ,
+		blockSize: spec.BlockSize,
+
+		pending:     memory.NewBuffer[T](alloc, spec.BlockSize),
+		packed:      memory.NewBuffer[byte](alloc, 0),
+		widthWriter: widthWriter,
+		validity:    validityWriter,
+	}, nil
+}
+
+func (w *bitpackedWriter[T]) Append(arr columnar.Array) error {
+	numArr, ok := arr.(*columnar.Number[T])
+	if !ok {
+		return fmt.Errorf("expected *columnar.Number[%T], got %T", *new(T), arr)
+	}
+
+	values := numArr.Values()
+
+	if err := validateNulls(w.validity, numArr, len(values)); err != nil {
+		return err
+	}
+	nulls, err := appendNulls(w.alloc, w.validity, numArr, len(values))
+	if err != nil {
+		return err
+	}
+	w.nulls += nulls
+
+	// Feed values into pending, flushing complete blocks as we go.
+	for len(values) > 0 {
+		space := w.blockSize - w.pending.Len()
+		n := min(space, len(values))
+
+		copy(w.pending.Next(n), values[:n])
+		values = values[n:]
+		w.rows += n
+
+		if w.pending.Len() == w.blockSize {
+			w.flushBlock()
+		}
+	}
+
+	return nil
+}
+
+// flushBlock bitpacks the current pending block and appends it to packed.
+func (w *bitpackedWriter[T]) flushBlock() {
+	block := w.pending.Data()
+
+	var maxVal uint64
+	for _, v := range block {
+		if uint64(v) > maxVal {
+			maxVal = uint64(v)
+		}
+	}
+	width := bits.Len64(maxVal)
+
+	bitpackInto(block, width, &w.packed)
+	w.widths = append(w.widths, uint32(width))
+
+	w.pending.Resize(0)
+}
+
+func (w *bitpackedWriter[T]) Flush(ctx context.Context, sink buffer.Sink) (Array, error) {
+	defer w.reset()
+
+	// Flush any remaining partial block.
+	if w.pending.Len() > 0 {
+		w.flushBlock()
+	}
+
+	// Write all block widths to the widths writer in one batch.
+	if err := w.widthWriter.Append(columnar.NewNumber(w.widths, memory.Bitmap{})); err != nil {
+		return Array{}, fmt.Errorf("appending block widths: %w", err)
+	}
+
+	// Flush children: widths first, then validity.
+	var children []Array
+
+	widthsArray, err := w.widthWriter.Flush(ctx, sink)
+	if err != nil {
+		return Array{}, fmt.Errorf("flushing widths writer: %w", err)
+	}
+	children = append(children, widthsArray)
+
+	if validity := w.validity; validity != nil {
+		validityArray, err := validity.Flush(ctx, sink)
+		if err != nil {
+			return Array{}, fmt.Errorf("flushing validity writer: %w", err)
+		}
+		children = append(children, validityArray)
+	}
+
+	// Write packed data buffer.
+	packedData := w.packed.Serialize()
+	bufs, err := sink.WriteBuffers(ctx, []buffer.Data{packedData})
+	if err != nil {
+		return Array{}, fmt.Errorf("writing bitpacked data to a buffer: %w", err)
+	}
+
+	return Array{
+		Encoding: &EncodingBitpacked{BlockSize: w.blockSize},
+		Type:     w.typ,
+		Buffers:  bufs,
+		RowCount: w.rows,
+		Stats: Stats{
+			NullCount: w.nulls,
+		},
+		Children: children,
+	}, nil
+}
+
+func (w *bitpackedWriter[T]) reset() {
+	w.pending.Resize(0)
+	w.packed.Resize(0)
+	w.widths = nil
+	w.nulls = 0
+	w.rows = 0
+}
+
+// bitpackInto packs values into dst using the given bit width. Values are
+// packed sequentially, LSB-first within bytes.
+func bitpackInto[T unsigned](values []T, width int, dst *memory.Buffer[byte]) {
+	if width == 0 || len(values) == 0 {
+		return
+	}
+
+	numBytes := (len(values)*width + 7) / 8
+	buf := dst.Next(numBytes)
+	clear(buf)
+
+	for i, v := range values {
+		startBit := i * width
+		for b := 0; b < width; b++ {
+			if uint64(v)&(1<<b) != 0 {
+				bitPos := startBit + b
+				buf[bitPos/8] |= 1 << (bitPos % 8)
+			}
+		}
+	}
+}
+
+type bitpackedReader[T unsigned] struct {
+	alloc  *memory.Allocator
+	arr    Array
+	source buffer.Source
+
+	validity Reader
+
+	initialized bool
+	widths      []uint32    // Per-block bit widths.
+	packedData  buffer.Data // Raw packed bytes for all blocks.
+	blockIndex  int         // Next block to unpack.
+	byteOff     int         // Byte offset into packedData for the next block.
+	rowOff      int         // Total rows already consumed across all blocks.
+
+	// Current unpacked block and read position within it. blockBuf is reused
+	// across calls to nextBlock to avoid repeated allocations.
+	blockBuf memory.Buffer[T]
+	block    []T
+	blockOff int
+}
+
+func newBitpackedReader(alloc *memory.Allocator, arr Array, source buffer.Source) (Reader, error) {
+	if got, want := arr.Encoding.Kind(), EncodingKindBitpacked; got != want {
+		return nil, fmt.Errorf("expected encoding kind %s, got %s", want, got)
+	}
+
+	switch typ := arr.Type.(type) {
+	case *types.Uint32:
+		return newBitpackedReaderTyped[uint32](alloc, arr, source, typ.Nullable)
+	case *types.Uint64:
+		return newBitpackedReaderTyped[uint64](alloc, arr, source, typ.Nullable)
+	default:
+		return nil, fmt.Errorf("unsupported type %s for bitpacked encoding", arr.Type)
+	}
+}
+
+func newBitpackedReaderTyped[T unsigned](alloc *memory.Allocator, arr Array, source buffer.Source, nullable bool) (*bitpackedReader[T], error) {
+	enc := arr.Encoding.(*EncodingBitpacked)
+
+	// Determine expected children: widths + optional validity.
+	expectChildren := 1
+	if nullable {
+		expectChildren = 2
+	}
+
+	if len(arr.Children) != expectChildren {
+		return nil, fmt.Errorf("expected %d children for bitpacked array (nullable=%t), got %d", expectChildren, nullable, len(arr.Children))
+	}
+
+	if enc.BlockSize <= 0 {
+		return nil, fmt.Errorf("bitpacked block size must be positive, got %d", enc.BlockSize)
+	}
+
+	var validityReader Reader
+	if nullable {
+		var err error
+		validityReader, err = NewReader(alloc, arr.Children[1], source)
+		if err != nil {
+			return nil, fmt.Errorf("creating validity reader: %w", err)
+		}
+	}
+
+	return &bitpackedReader[T]{
+		alloc:  alloc,
+		arr:    arr,
+		source: source,
+
+		validity: validityReader,
+		blockBuf: memory.NewBuffer[T](alloc, enc.BlockSize),
+	}, nil
+}
+
+func (r *bitpackedReader[T]) Read(ctx context.Context, alloc *memory.Allocator, count int) (columnar.Array, error) {
+	if count <= 0 {
+		return nil, fmt.Errorf("count must be positive, got %d", count)
+	}
+
+	if !r.initialized {
+		if err := r.init(ctx, r.alloc); err != nil {
+			return nil, err
+		}
+		r.initialized = true
+	}
+
+	// Collect values across block boundaries to satisfy count.
+	result := memory.NewBuffer[T](alloc, count)
+
+	for result.Len() < count {
+		// If the current block is exhausted, unpack the next one.
+		if r.blockOff >= len(r.block) {
+			if err := r.nextBlock(); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				return nil, err
+			}
+		}
+
+		n := min(count-result.Len(), len(r.block)-r.blockOff)
+		result.Append(r.block[r.blockOff : r.blockOff+n]...)
+		r.blockOff += n
+	}
+
+	if result.Len() == 0 {
+		return nil, io.EOF
+	}
+
+	var validity memory.Bitmap
+	if r.validity != nil {
+		validityArr, err := r.validity.Read(ctx, alloc, result.Len())
+		if err != nil {
+			return nil, fmt.Errorf("reading validity: %w", err)
+		}
+
+		validityBoolArr := validityArr.(*columnar.Bool)
+		validity = validityBoolArr.Values()
+	}
+
+	return columnar.NewNumber(result.Data(), validity), nil
+}
+
+func (r *bitpackedReader[T]) init(ctx context.Context, alloc *memory.Allocator) error {
+	// Read widths child array.
+	widthsReader, err := NewReader(alloc, r.arr.Children[0], r.source)
+	if err != nil {
+		return fmt.Errorf("creating widths reader: %w", err)
+	}
+	defer widthsReader.Close()
+
+	widthsArr, err := widthsReader.Read(ctx, alloc, r.arr.Children[0].RowCount)
+	if err != nil {
+		return fmt.Errorf("reading widths: %w", err)
+	}
+	r.widths = widthsArr.(*columnar.Number[uint32]).Values()
+
+	// Read packed data buffer.
+	data, err := r.source.ReadBuffers(ctx, alloc, r.arr.Buffers)
+	if err != nil {
+		return fmt.Errorf("fetching buffer data: %w", err)
+	} else if len(data) != 1 {
+		return fmt.Errorf("expected 1 buffer, got %d", len(data))
+	}
+	r.packedData = data[0]
+
+	return nil
+}
+
+// nextBlock unpacks the next block into r.block. Returns io.EOF when all
+// blocks have been consumed.
+func (r *bitpackedReader[T]) nextBlock() error {
+	if r.blockIndex >= len(r.widths) {
+		return io.EOF
+	}
+
+	enc := r.arr.Encoding.(*EncodingBitpacked)
+	width := int(r.widths[r.blockIndex])
+	blockRows := min(enc.BlockSize, r.arr.RowCount-r.rowOff)
+
+	r.blockBuf.Grow(blockRows)
+	r.blockBuf.Resize(blockRows)
+	r.blockBuf.Clear()
+
+	// We only need to unpack if width is non-zero; if the width is zero (all
+	// zero values in the block), blockBuf is already "unpacked" via the call to
+	// Clear above.
+	if width != 0 {
+		blockBytes := (blockRows*width + 7) / 8
+		if r.byteOff+blockBytes > len(r.packedData) {
+			return fmt.Errorf("packed data too short: need %d bytes, have %d", r.byteOff+blockBytes, len(r.packedData))
+		}
+
+		bitunpackInto(r.packedData[r.byteOff:r.byteOff+blockBytes], r.blockBuf.Data(), width)
+		r.byteOff += blockBytes
+	}
+	r.block = r.blockBuf.Data()
+
+	r.blockOff = 0
+	r.blockIndex++
+	r.rowOff += blockRows
+	return nil
+}
+
+// bitunpackInto unpacks values from packed data into dst using the given bit
+// width. dst must be pre-sized and zeroed.
+func bitunpackInto[T unsigned](data []byte, dst []T, width int) {
+	if width == 0 {
+		return
+	}
+
+	var mask uint64
+	if width < 64 {
+		mask = (1 << width) - 1
+	} else {
+		mask = ^uint64(0)
+	}
+
+	for i := range dst {
+		startBit := i * width
+		byteOff := startBit >> 3
+		bitOff := uint(startBit & 7)
+
+		// Fast path: read a uint64 covering the packed value.
+		if byteOff+8 <= len(data) {
+			raw := binary.LittleEndian.Uint64(data[byteOff:])
+			v := raw >> bitOff
+
+			// Handle values spanning more than 8 bytes (width+bitOff > 64).
+			if remaining := 64 - bitOff; remaining < uint(width) && byteOff+8 < len(data) {
+				v |= uint64(data[byteOff+8]) << remaining
+			}
+
+			dst[i] = T(v & mask)
+			continue
+		}
+
+		// Slow path: near the end of data, read remaining bytes.
+		var raw uint64
+		for j := byteOff; j < len(data); j++ {
+			raw |= uint64(data[j]) << uint((j-byteOff)*8)
+		}
+		dst[i] = T((raw >> bitOff) & mask)
+	}
+}
+
+func (r *bitpackedReader[T]) Reset() {
+	r.resetSelf()
+
+	if r.validity != nil {
+		r.validity.Reset()
+	}
+}
+
+func (r *bitpackedReader[T]) resetSelf() {
+	// Reset the offset but keep everything else to allow for re-reading data.
+	r.blockIndex = 0
+	r.byteOff = 0
+	r.rowOff = 0
+	r.block = nil
+	r.blockOff = 0
+}
+
+func (r *bitpackedReader[T]) Close() error {
+	r.resetSelf()
+
+	r.initialized = false
+	r.packedData = nil
+	r.widths = nil
+
+	if r.validity != nil {
+		return r.validity.Close()
+	}
+	return nil
+}

--- a/pkg/dataset/array/codec_bitpacked_test.go
+++ b/pkg/dataset/array/codec_bitpacked_test.go
@@ -1,0 +1,459 @@
+package array_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestBitpackedCodec_Validation(t *testing.T) {
+	widths := &array.SpecPlain{Validity: nil}
+
+	tt := []struct {
+		name string
+		spec array.Spec
+		typ  types.Type
+
+		expectError bool
+	}{
+		{
+			name:        "accepts valid non-nullable uint32",
+			spec:        &array.SpecBitpacked{BlockSize: 128, Widths: widths},
+			typ:         &types.Uint32{Nullable: false},
+			expectError: false,
+		},
+		{
+			name:        "accepts valid non-nullable uint64",
+			spec:        &array.SpecBitpacked{BlockSize: 128, Widths: widths},
+			typ:         &types.Uint64{Nullable: false},
+			expectError: false,
+		},
+		{
+			name:        "accepts nullable uint64 with validity spec",
+			spec:        &array.SpecBitpacked{BlockSize: 128, Widths: widths, Validity: &array.SpecBool{}},
+			typ:         &types.Uint64{Nullable: true},
+			expectError: false,
+		},
+		{
+			name:        "rejects nullable uint64 with no validity spec",
+			spec:        &array.SpecBitpacked{BlockSize: 128, Widths: widths},
+			typ:         &types.Uint64{Nullable: true},
+			expectError: true,
+		},
+		{
+			name:        "rejects non-nullable uint64 with validity spec",
+			spec:        &array.SpecBitpacked{BlockSize: 128, Widths: widths, Validity: &array.SpecBool{}},
+			typ:         &types.Uint64{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects int32",
+			spec:        &array.SpecBitpacked{BlockSize: 128, Widths: widths},
+			typ:         &types.Int32{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects int64",
+			spec:        &array.SpecBitpacked{BlockSize: 128, Widths: widths},
+			typ:         &types.Int64{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects bool",
+			spec:        &array.SpecBitpacked{BlockSize: 128, Widths: widths},
+			typ:         &types.Bool{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects utf8",
+			spec:        &array.SpecBitpacked{BlockSize: 128, Widths: widths},
+			typ:         &types.UTF8{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects zero block size",
+			spec:        &array.SpecBitpacked{BlockSize: 0, Widths: widths},
+			typ:         &types.Uint64{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects negative block size",
+			spec:        &array.SpecBitpacked{BlockSize: -1, Widths: widths},
+			typ:         &types.Uint64{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects non-multiple-of-8 block size",
+			spec:        &array.SpecBitpacked{BlockSize: 7, Widths: widths},
+			typ:         &types.Uint64{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects nil widths spec",
+			spec:        &array.SpecBitpacked{BlockSize: 128, Widths: nil},
+			typ:         &types.Uint64{Nullable: false},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			var alloc memory.Allocator
+			_, err := array.NewWriter(&alloc, tc.spec, tc.typ)
+
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestBitpackedCodec_NonNullable(t *testing.T) {
+	t.Run("uint32", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+
+		var (
+			spec = &array.SpecBitpacked{BlockSize: 8, Widths: &array.SpecPlain{}}
+			typ  = &types.Uint32{Nullable: false}
+		)
+
+		w, err := array.NewWriter(&alloc, spec, typ)
+		require.NoError(t, err)
+
+		input := []columnar.Array{
+			columnartest.Array(t, types.KindUint32, &alloc, uint32(10), uint32(20), uint32(30), uint32(40), uint32(50)),
+			columnartest.Array(t, types.KindUint32, &alloc, uint32(60), uint32(70), uint32(80), uint32(90), uint32(100)),
+		}
+		for _, arr := range input {
+			require.NoError(t, w.Append(arr))
+		}
+
+		result, err := w.Flush(t.Context(), &store)
+		require.NoError(t, err)
+		require.Equal(t, 10, result.RowCount)
+		require.Equal(t, 0, result.Stats.NullCount)
+
+		r, err := array.NewReader(&alloc, result, &store)
+		require.NoError(t, err)
+
+		expect := columnartest.Array(
+			t, types.KindUint32, &alloc,
+			uint32(10), uint32(20), uint32(30), uint32(40), uint32(50),
+			uint32(60), uint32(70), uint32(80), uint32(90), uint32(100),
+		)
+
+		actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+		columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+
+		_, err = r.Read(t.Context(), &alloc, 1)
+		require.ErrorIs(t, err, io.EOF)
+	})
+
+	t.Run("uint64", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+
+		var (
+			spec = &array.SpecBitpacked{BlockSize: 8, Widths: &array.SpecPlain{}}
+			typ  = &types.Uint64{Nullable: false}
+		)
+
+		w, err := array.NewWriter(&alloc, spec, typ)
+		require.NoError(t, err)
+
+		input := []columnar.Array{
+			columnartest.Array(t, types.KindUint64, &alloc, uint64(10), uint64(20), uint64(30), uint64(40), uint64(50)),
+			columnartest.Array(t, types.KindUint64, &alloc, uint64(60), uint64(70), uint64(80), uint64(90), uint64(100)),
+		}
+		for _, arr := range input {
+			require.NoError(t, w.Append(arr))
+		}
+
+		result, err := w.Flush(t.Context(), &store)
+		require.NoError(t, err)
+		require.Equal(t, 10, result.RowCount)
+		require.Equal(t, 0, result.Stats.NullCount)
+
+		r, err := array.NewReader(&alloc, result, &store)
+		require.NoError(t, err)
+
+		expect := columnartest.Array(
+			t, types.KindUint64, &alloc,
+			uint64(10), uint64(20), uint64(30), uint64(40), uint64(50),
+			uint64(60), uint64(70), uint64(80), uint64(90), uint64(100),
+		)
+
+		actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+		columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+
+		_, err = r.Read(t.Context(), &alloc, 1)
+		require.ErrorIs(t, err, io.EOF)
+	})
+}
+
+func TestBitpackedCodec_Nullable(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecBitpacked{BlockSize: 8, Widths: &array.SpecPlain{}, Validity: &array.SpecBool{}}
+		typ  = &types.Uint64{Nullable: true}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	input := []columnar.Array{
+		columnartest.Array(t, types.KindUint64, &alloc, uint64(10), nil, uint64(30), nil, uint64(50)),
+		columnartest.Array(t, types.KindUint64, &alloc, uint64(60), uint64(70), uint64(80), uint64(90), uint64(100)),
+		columnartest.Array(t, types.KindUint64, &alloc, nil),
+	}
+	for _, arr := range input {
+		require.NoError(t, w.Append(arr))
+	}
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+	require.Equal(t, 11, result.RowCount)
+	require.Equal(t, 3, result.Stats.NullCount)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	expect := columnartest.Array(
+		t, types.KindUint64, &alloc,
+		uint64(10), nil, uint64(30), nil, uint64(50),
+		uint64(60), uint64(70), uint64(80), uint64(90), uint64(100),
+		nil,
+	)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+
+	_, err = r.Read(t.Context(), &alloc, 1)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestBitpackedCodec_AllZeros(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecBitpacked{BlockSize: 8, Widths: &array.SpecPlain{}}
+		typ  = &types.Uint64{Nullable: false}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	input := columnartest.Array(t, types.KindUint64, &alloc,
+		uint64(0), uint64(0), uint64(0), uint64(0), uint64(0),
+	)
+	require.NoError(t, w.Append(input))
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+	require.Equal(t, 5, result.RowCount)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, input, actual, memory.Bitmap{})
+}
+
+func TestBitpackedCodec_MaxWidth(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecBitpacked{BlockSize: 128, Widths: &array.SpecPlain{}}
+		typ  = &types.Uint64{Nullable: false}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	input := columnartest.Array(t, types.KindUint64, &alloc,
+		uint64(0), uint64(math.MaxUint64), uint64(42),
+	)
+	require.NoError(t, w.Append(input))
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, input, actual, memory.Bitmap{})
+}
+
+func TestBitpackedCodec_SingleBitValues(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecBitpacked{BlockSize: 128, Widths: &array.SpecPlain{}}
+		typ  = &types.Uint32{Nullable: false}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	input := columnartest.Array(t, types.KindUint32, &alloc,
+		uint32(0), uint32(1), uint32(1), uint32(0), uint32(1),
+		uint32(0), uint32(0), uint32(1), uint32(1), uint32(1),
+	)
+	require.NoError(t, w.Append(input))
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, input, actual, memory.Bitmap{})
+}
+
+func TestBitpackedCodec_MixedWidthBlocks(t *testing.T) {
+	// Block 1 (small values, ~3 bits) and Block 2 (large values, ~7 bits)
+	// demonstrate per-block width adaptation.
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecBitpacked{BlockSize: 8, Widths: &array.SpecPlain{}}
+		typ  = &types.Uint64{Nullable: false}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	input := columnartest.Array(t, types.KindUint64, &alloc,
+		// Block 1: max=7 → width=3
+		uint64(1), uint64(3), uint64(7), uint64(5), uint64(2), uint64(0), uint64(6), uint64(1),
+		// Block 2: max=100 → width=7
+		uint64(100), uint64(50), uint64(99), uint64(1),
+	)
+	require.NoError(t, w.Append(input))
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, input, actual, memory.Bitmap{})
+}
+
+func BenchmarkBitpackedCodec(b *testing.B) {
+	var (
+		store buffer.MemoryStore
+
+		spec = &array.SpecBitpacked{BlockSize: 128, Widths: &array.SpecPlain{}}
+		typ  = &types.Uint64{Nullable: false}
+	)
+
+	const valuesPerPage = 1 << 16
+
+	type scenario struct {
+		name       string
+		valueCount int
+		encoded    array.Array
+	}
+
+	build := func(name string, valueCount int, valueAt func(i int) uint64) scenario {
+		var alloc memory.Allocator
+		w, err := array.NewWriter(&alloc, spec, typ)
+		require.NoError(b, err)
+
+		builder := columnar.NewNumberBuilder[uint64](&alloc)
+		builder.Grow(valueCount)
+
+		for i := range valueCount {
+			builder.AppendValue(valueAt(i))
+		}
+		require.NoError(b, w.Append(builder.Build()))
+
+		arr, err := w.Flush(b.Context(), &store)
+		require.NoError(b, err)
+		return scenario{name: name, valueCount: valueCount, encoded: arr}
+	}
+
+	scenarios := []scenario{
+		build("variance=constant", valuesPerPage, func(int) uint64 { return 42 }),
+		build("variance=small_range", valuesPerPage, func(i int) uint64 { return uint64(i % 16) }),
+		func() scenario {
+			rnd := rand.New(rand.NewSource(0))
+			return build("variance=random", valuesPerPage, func(int) uint64 {
+				return rnd.Uint64()
+			})
+		}(),
+	}
+
+	batchSizes := []int{256, 1024, 4096}
+
+	for _, sc := range scenarios {
+		b.Run(sc.name, func(b *testing.B) {
+			b.Run(fmt.Sprintf("values_per_page=%d", sc.valueCount), func(b *testing.B) {
+				for _, batchSize := range batchSizes {
+					b.Run(fmt.Sprintf("batch_size=%d", batchSize), func(b *testing.B) {
+						var alloc memory.Allocator
+
+						b.ReportAllocs()
+						decodedBytesPerOp := int64(sc.valueCount) * 8
+						b.SetBytes(decodedBytesPerOp)
+
+						for b.Loop() {
+							alloc.Reset()
+
+							r, _ := array.NewReader(&alloc, sc.encoded, &store)
+
+							var decoded int
+							for {
+								arr, err := r.Read(b.Context(), &alloc, batchSize)
+								if arr != nil {
+									decoded += arr.Len()
+								}
+
+								if errors.Is(err, io.EOF) {
+									break
+								} else if err != nil {
+									b.Fatal(err)
+								}
+							}
+
+							if decoded != sc.valueCount {
+								b.Fatalf("decoded %d values, expected %d", decoded, sc.valueCount)
+							}
+						}
+
+						elapsed := b.Elapsed()
+						if elapsed > 0 {
+							totalDecoded := int64(sc.valueCount) * int64(b.N)
+							b.ReportMetric(float64(totalDecoded)/elapsed.Seconds(), "rows/s")
+						}
+					})
+				}
+			})
+		})
+	}
+}

--- a/pkg/dataset/array/encoding.go
+++ b/pkg/dataset/array/encoding.go
@@ -37,6 +37,16 @@ type (
 	// If the data type is nullable, then the last child Array holds validity
 	// data.
 	EncodingBinary struct{}
+
+	// EncodingBitpacked holds bitpacked unsigned integer values split into
+	// fixed-size blocks. Each block is independently packed using the minimum
+	// number of bits needed for the largest value in that block.
+	//
+	// The first child Array holds per-block bit widths. If the data type is
+	// nullable, then the last child Array holds validity data.
+	EncodingBitpacked struct {
+		BlockSize int // Number of rows per block. The last block may have fewer rows.
+	}
 )
 
 // Kind returns [EncodingKindBool].
@@ -54,10 +64,16 @@ func (enc *EncodingBinary) Kind() EncodingKind {
 	return EncodingKindBinary
 }
 
+// Kind returns [EncodingKindBitpacked].
+func (enc *EncodingBitpacked) Kind() EncodingKind {
+	return EncodingKindBitpacked
+}
+
 //
 // Sealed marker implementations.
 //
 
-func (enc *EncodingBool) isEncoding()   {}
-func (enc *EncodingPlain) isEncoding()  {}
-func (enc *EncodingBinary) isEncoding() {}
+func (enc *EncodingBool) isEncoding()      {}
+func (enc *EncodingPlain) isEncoding()     {}
+func (enc *EncodingBinary) isEncoding()    {}
+func (enc *EncodingBitpacked) isEncoding() {}

--- a/pkg/dataset/array/encoding_kind.go
+++ b/pkg/dataset/array/encoding_kind.go
@@ -9,16 +9,18 @@ type EncodingKind int
 const (
 	EncodingKindInvalid EncodingKind = iota // EncodingKindInvalid is an invalid encoding.
 
-	EncodingKindBool   // EncodingKindBool is a bit-packed encoding for boolean types.
-	EncodingKindPlain  // EncodingKindPlain is plain encoding for fixed-width types (int32, etc).
-	EncodingKindBinary // EncodingKindBinary encodes variable-length binary data (like UTF8).
+	EncodingKindBool      // EncodingKindBool is a bit-packed encoding for boolean types.
+	EncodingKindPlain     // EncodingKindPlain is plain encoding for fixed-width types (int32, etc).
+	EncodingKindBinary    // EncodingKindBinary encodes variable-length binary data (like UTF8).
+	EncodingKindBitpacked // EncodingKindBitpacked is a bitpacked encoding for unsigned integer types.
 )
 
 var kindNames = [...]string{
-	EncodingKindInvalid: "invalid",
-	EncodingKindBool:    "bool",
-	EncodingKindPlain:   "plain",
-	EncodingKindBinary:  "binary",
+	EncodingKindInvalid:   "invalid",
+	EncodingKindBool:      "bool",
+	EncodingKindPlain:     "plain",
+	EncodingKindBinary:    "binary",
+	EncodingKindBitpacked: "bitpacked",
 }
 
 // String returns the string representation of k.

--- a/pkg/dataset/array/spec.go
+++ b/pkg/dataset/array/spec.go
@@ -49,6 +49,22 @@ type (
 		// data types.
 		Validity Spec
 	}
+
+	// SpecBitpacked encodes unsigned integer values using block-based
+	// bitpacking. Values are grouped into blocks of BlockSize rows, and each
+	// block is packed using the minimum bit width needed for its largest
+	// value.
+	SpecBitpacked struct {
+		// Number of rows per block.
+		BlockSize int
+
+		// Spec for encoding per-block bit widths (child array).
+		Widths Spec
+
+		// Spec for how to encode validity data. Must only be set for nullable
+		// data types.
+		Validity Spec
+	}
 )
 
 // Kind returns [EncodingKindBool].
@@ -66,10 +82,16 @@ func (spec *SpecBinary) Kind() EncodingKind {
 	return EncodingKindBinary
 }
 
+// Kind returns [EncodingKindBitpacked].
+func (spec *SpecBitpacked) Kind() EncodingKind {
+	return EncodingKindBitpacked
+}
+
 //
 // Sealed marker implementations.
 //
 
-func (spec *SpecBool) isSpec()   {}
-func (spec *SpecPlain) isSpec()  {}
-func (spec *SpecBinary) isSpec() {}
+func (spec *SpecBool) isSpec()      {}
+func (spec *SpecPlain) isSpec()     {}
+func (spec *SpecBinary) isSpec()    {}
+func (spec *SpecBitpacked) isSpec() {}

--- a/pkg/memory/buffer.go
+++ b/pkg/memory/buffer.go
@@ -88,6 +88,16 @@ func (buf *Buffer[T]) AppendCount(value T, n int) {
 	}
 }
 
+// Next adds space for n elements to buf and returns the slice for those
+// elements. The buf will be grown if its capacity is not sufficient.
+func (buf *Buffer[T]) Next(n int) []T {
+	buf.Grow(n)
+
+	from := len(buf.data)
+	buf.data = buf.data[:from+n]
+	return buf.data[from : from+n : from+n]
+}
+
 // Set sets the value at index i to value. Set panics if i is out of bounds.
 func (buf *Buffer[T]) Set(i int, value T) { buf.data[i] = value }
 


### PR DESCRIPTION
Adds a Bitpacked encoding to dataset/array, which encodes a batch of numbers into the smallest possible set of bits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new block-based integer encoding/decoding path with custom bit packing/unpacking logic and new child-array metadata, which could impact correctness/performance for encoded datasets despite good test coverage.
> 
> **Overview**
> Adds a new `bitpacked` array encoding for `uint32`/`uint64` that stores values in fixed-size blocks using the minimum bit-width per block, plus a widths child array (and optional validity child array for nullable types).
> 
> `NewWriter`/`NewReader` now route `EncodingKindBitpacked` to new bitpacking codec implementations, and the `memory.Buffer` API gains `Next(n)` to support efficient incremental writes. Includes extensive unit tests and a benchmark covering nullable/non-nullable cases and edge conditions (all zeros, max width, mixed-width blocks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5ae3465cd7f37dd6807c586d70fbd2cdd0b0049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->