### PR TITLE
chore!: Remove deprecated `allow_deletes` configuration option

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -37,6 +37,12 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 ## Main / Unreleased
 
+### Breaking change: Configure deletes on compactor
+
+The configuration option `-compactor.allow-deletes` has been removed. Instead, use the the per-tenant `deletion_mode` option instead.
+This is configured in the `limits_config` and can be one of `disabled`, `filter-only`, or `filter-and-delete`.
+When set to `filter-only` or `filter-and-delete`, and `retention_enabled` is set to true, then the log entry deletion API endpoints are available.
+
 ### Breaking change: Rename and remove metrics
 
 - The deprecated metric `loki_log_messages_total` is removed in favor of `loki_internal_log_messages_total`.

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -4735,9 +4735,6 @@ ruler_remote_write_sigv4_config:
 # CLI flag: -limits.per-user-override-period
 [per_tenant_override_period: <duration> | default = 10s]
 
-# Deprecated: Use deletion_mode per tenant configuration instead.
-[allow_deletes: <boolean>]
-
 # Define streams sharding behavior.
 shard_streams:
   # Automatically shard streams to keep them under the per-stream rate limit.

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -219,9 +219,6 @@ type Limits struct {
 	PerTenantOverrideConfig string         `yaml:"per_tenant_override_config" json:"per_tenant_override_config"`
 	PerTenantOverridePeriod model.Duration `yaml:"per_tenant_override_period" json:"per_tenant_override_period"`
 
-	// Deprecated
-	CompactorDeletionEnabled bool `yaml:"allow_deletes" json:"allow_deletes" doc:"deprecated|description=Use deletion_mode per tenant configuration instead."`
-
 	ShardStreams shardstreams.Config `yaml:"shard_streams" json:"shard_streams" doc:"description=Define streams sharding behavior."`
 
 	BlockedQueries []*validation.BlockedQuery `yaml:"blocked_queries,omitempty" json:"blocked_queries,omitempty"`
@@ -670,10 +667,6 @@ func (l *Limits) Validate() error {
 
 	if _, err := deletionmode.ParseMode(l.DeletionMode); err != nil {
 		return err
-	}
-
-	if l.CompactorDeletionEnabled {
-		level.Warn(util_log.Logger).Log("msg", "The compactor.allow-deletes configuration option has been deprecated and will be ignored. Instead, use deletion_mode in the limits_configs to adjust deletion functionality")
 	}
 
 	if l.MaxQueryCapacity < 0 {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -498,9 +498,6 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.StringVar(&l.DeletionMode, "compactor.deletion-mode", "filter-and-delete", "Deletion mode. Can be one of 'disabled', 'filter-only', or 'filter-and-delete'. When set to 'filter-only' or 'filter-and-delete', and if retention_enabled is true, then the log entry deletion API endpoints are available.")
 
-	// Deprecated
-	dskit_flagext.DeprecatedFlag(f, "compactor.allow-deletes", "Deprecated. Instead, see compactor.deletion-mode which is another per tenant configuration", util_log.Logger)
-
 	f.IntVar(&l.IndexGatewayShardSize, "index-gateway.shard-size", 0, "The shard size defines how many index gateways should be used by a tenant for querying. If the global shard factor is 0, the global shard factor is set to the deprecated -replication-factor for backwards compatibility reasons.")
 	f.Float64Var(&l.IndexGatewayMaxCapacity, "index-gateway.max-capacity", 1.0, "Experimental. Defines a fraction (between 0.0 and 1.0) of the total index gateways available for a each tenant. A value of 0.0 has the same effect as 1.0, meaning all available index gateways. This setting only applies to simple mode.")
 

--- a/tools/deprecated-config-checker/checker/checker_test.go
+++ b/tools/deprecated-config-checker/checker/checker_test.go
@@ -36,6 +36,7 @@ var (
 		"compactor.shared_store_key_prefix",
 		"limits_config.enforce_metric_name",
 		"limits_config.ruler_evaluation_delay_duration",
+		"limits_config.allow_deletes",
 		"storage_config.bigtable",
 		"storage_config.cassandra",
 		"storage_config.boltdb",
@@ -80,7 +81,6 @@ var (
 		"limits_config.ruler_remote_write_sigv4_config",
 		"limits_config.per_tenant_override_config",
 		"limits_config.per_tenant_override_period",
-		"limits_config.allow_deletes",
 	}
 
 	expectedRuntimeConfigDeletes = []string{
@@ -107,7 +107,6 @@ var (
 		"overrides.foo.ruler_remote_write_sigv4_config",
 		"overrides.foo.per_tenant_override_config",
 		"overrides.foo.per_tenant_override_period",
-		"overrides.foo.allow_deletes",
 		"overrides.bar.unordered_writes",
 		"overrides.bar.ruler_remote_write_url",
 		"overrides.bar.ruler_remote_write_timeout",
@@ -124,7 +123,6 @@ var (
 		"overrides.bar.ruler_remote_write_sigv4_config",
 		"overrides.bar.per_tenant_override_config",
 		"overrides.bar.per_tenant_override_period",
-		"overrides.bar.allow_deletes",
 	}
 )
 

--- a/tools/deprecated-config-checker/checker/checker_test.go
+++ b/tools/deprecated-config-checker/checker/checker_test.go
@@ -86,8 +86,10 @@ var (
 	expectedRuntimeConfigDeletes = []string{
 		"overrides.foo.ruler_evaluation_delay_duration",
 		"overrides.foo.enforce_metric_name",
+		"overrides.foo.allow_deletes",
 		"overrides.bar.ruler_evaluation_delay_duration",
 		"overrides.bar.enforce_metric_name",
+		"overrides.bar.allow_deletes",
 	}
 
 	expectedRuntimeConfigDeprecates = []string{

--- a/tools/deprecated-config-checker/deleted-config.yaml
+++ b/tools/deprecated-config-checker/deleted-config.yaml
@@ -86,3 +86,4 @@ chunk_store_config:
 limits_config:
   ruler_evaluation_delay_duration: "This setting is removed."
   enforce_metric_name: "This setting is removed."
+  allow_deletes: "Use deletion_mode per tenant configuration instead."

--- a/tools/deprecated-config-checker/deleted-config.yaml
+++ b/tools/deprecated-config-checker/deleted-config.yaml
@@ -86,4 +86,3 @@ chunk_store_config:
 limits_config:
   ruler_evaluation_delay_duration: "This setting is removed."
   enforce_metric_name: "This setting is removed."
-  allow_deletes: "Use deletion_mode per tenant configuration instead."

--- a/tools/deprecated-config-checker/deleted-config.yaml
+++ b/tools/deprecated-config-checker/deleted-config.yaml
@@ -86,3 +86,4 @@ chunk_store_config:
 limits_config:
   ruler_evaluation_delay_duration: "This setting is removed."
   enforce_metric_name: "This setting is removed."
+  allow_deletes: "This setting is removed."

--- a/tools/deprecated-config-checker/deprecated-config.yaml
+++ b/tools/deprecated-config-checker/deprecated-config.yaml
@@ -48,7 +48,6 @@ limits_config:
   ruler_remote_write_sigv4_config: "Use ruler_remote_write_config instead."
   per_tenant_override_config: "Feature renamed to 'runtime configuration', flag deprecated in favor of runtime_config.file"
   per_tenant_override_period: "Feature renamed to 'runtime configuration', flag deprecated in favor of runtime_config.period"
-  allow_deletes: "Use deletion_mode per tenant configuration instead."
 
 server:
   grpc_server_stats_tracking_enabled: "Deprecated, currently doesn't do anything, will be removed in a future version."

--- a/tools/deprecated-config-checker/test-fixtures/config.yaml
+++ b/tools/deprecated-config-checker/test-fixtures/config.yaml
@@ -65,7 +65,7 @@ storage_config:
   bigtable: # DEPRECATED
     project: "my-project"
   cassandra: # DEPRECATED
-    addresses: 'a.b.c.d:9042'
+    addresses: "a.b.c.d:9042"
   boltdb: # DEPRECATED
     directory: /tmp/loki/boltdb
   grpc_store: # DEPRECATED
@@ -136,4 +136,3 @@ limits_config:
     region: "wherever"
   per_tenant_override_config: ./overrides.yaml # DEPRECATED
   per_tenant_override_period: 5s # DEPRECATED
-  allow_deletes: true # DEPRECATED

--- a/tools/deprecated-config-checker/test-fixtures/config.yaml
+++ b/tools/deprecated-config-checker/test-fixtures/config.yaml
@@ -136,3 +136,4 @@ limits_config:
     region: "wherever"
   per_tenant_override_config: ./overrides.yaml # DEPRECATED
   per_tenant_override_period: 5s # DEPRECATED
+  allow_deletes: true # DELETED

--- a/tools/deprecated-config-checker/test-fixtures/runtime-config.yaml
+++ b/tools/deprecated-config-checker/test-fixtures/runtime-config.yaml
@@ -20,6 +20,7 @@ overrides:
       region: "wherever"
     per_tenant_override_config: ./overrides.yaml # DEPRECATED
     per_tenant_override_period: 5s # DEPRECATED
+    allow_deletes: true # REMOVED
   "bar": *tenant_overrides
 
 multi_kv_config:

--- a/tools/deprecated-config-checker/test-fixtures/runtime-config.yaml
+++ b/tools/deprecated-config-checker/test-fixtures/runtime-config.yaml
@@ -20,7 +20,7 @@ overrides:
       region: "wherever"
     per_tenant_override_config: ./overrides.yaml # DEPRECATED
     per_tenant_override_period: 5s # DEPRECATED
-    allow_deletes: true # DEPRECATED
+    allow_deletes: true # DELETED
   "bar": *tenant_overrides
 
 multi_kv_config:

--- a/tools/deprecated-config-checker/test-fixtures/runtime-config.yaml
+++ b/tools/deprecated-config-checker/test-fixtures/runtime-config.yaml
@@ -6,7 +6,7 @@ overrides:
     ruler_evaluation_delay_duration: 1m # DELETED
     ruler_remote_write_url: "push.123abc.net" # DEPRECATED
     ruler_remote_write_timeout: 1m # DEPRECATED
-    ruler_remote_write_headers: [ "foo", "bar" ] # DEPRECATED
+    ruler_remote_write_headers: ["foo", "bar"] # DEPRECATED
     ruler_remote_write_relabel_configs: "foo" # DEPRECATED
     ruler_remote_write_queue_capacity: 10 # DEPRECATED
     ruler_remote_write_queue_min_shards: 10 # DEPRECATED
@@ -20,7 +20,6 @@ overrides:
       region: "wherever"
     per_tenant_override_config: ./overrides.yaml # DEPRECATED
     per_tenant_override_period: 5s # DEPRECATED
-    allow_deletes: true # DELETED
   "bar": *tenant_overrides
 
 multi_kv_config:


### PR DESCRIPTION
### Summary

The `-compactor.allow-deletes` was already deprecated and unused and only logged a warning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes a previously accepted config field/flag (`allow_deletes`), which can cause startup/config-validation failures for deployments still setting it, but the runtime behavior was already controlled by `deletion_mode`.
> 
> **Overview**
> **Removes the deprecated `allow_deletes` delete toggle** by deleting the `limits_config.allow_deletes` YAML field and the `-compactor.allow-deletes` CLI flag (and associated warning/validation code), leaving `limits_config.deletion_mode` as the supported control.
> 
> Updates upgrade docs to call out the breaking change, and adjusts the deprecated-config checker to treat `allow_deletes` as *deleted/invalid* (including test fixtures and delete lists).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32d64516cc95710d1d0b89b379160fa43235897f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->