### PR TITLE
chore(operator): Build operator with 1.26.3

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25.9 as builder
+FROM golang:1.26.3 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/operator/calculator.Dockerfile
+++ b/operator/calculator.Dockerfile
@@ -1,5 +1,5 @@
 # Build the calculator binary
-FROM golang:1.25.9 as builder
+FROM golang:1.26.3 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -2,7 +2,7 @@ module github.com/grafana/loki/operator
 
 go 1.25.7
 
-toolchain go1.25.9
+toolchain go1.26.3
 
 require (
 	dario.cat/mergo v1.0.2

--- a/operator/netlify.toml
+++ b/operator/netlify.toml
@@ -6,7 +6,7 @@
   # HUGO_VERSION = "..." is set by bingo which allows reproducible local environment.
   NODE_VERSION = "22.10.0"
   NPM_VERSION = "10.9.0"
-  GO_VERSION = "1.25.9"
+  GO_VERSION = "1.26.3"
 
 [context.production]
   command = "(env && mkdir /tmp/gobin && make web GOBIN=/tmp/gobin) || (sleep 30; false)"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates the Go toolchain/base images used to build the operator and website, with no functional code changes, but it could surface new compiler/lint or dependency compatibility issues.
> 
> **Overview**
> Updates the operator’s build environment to Go `1.26.3` by switching the builder images in `operator/Dockerfile` and `operator/calculator.Dockerfile` and bumping the `toolchain` in `operator/go.mod`.
> 
> Aligns website/Netlify builds by updating `GO_VERSION` to `1.26.3` in `operator/netlify.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45e0ab3e3de0666fa73c4cbd18bb632238661f92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->