### PR TITLE
refactor(metastore): Export tableOfContentsPath, iterTableOfContentsPaths, metastoreWindowSize

### DIFF
--- a/pkg/dataobj/metastore/metastore_test.go
+++ b/pkg/dataobj/metastore/metastore_test.go
@@ -175,7 +175,7 @@ func TestIterTableOfContentsPaths(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			iter := iterTableOfContentsPaths(tc.start, tc.end)
+			iter := IterTableOfContentsPaths(tc.start, tc.end)
 			actual := []string{}
 			for path := range iter {
 				actual = append(actual, path)

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -39,7 +39,11 @@ import (
 )
 
 const (
-	metastoreWindowSize = 12 * time.Hour
+	// MetastoreWindowSize is the duration covered by a single Table of
+	// Contents file in the metastore. ToC files are aligned to multiples of
+	// this duration. Exported so external packages (e.g. the dataobj
+	// compactor) can iterate over the same time windows used internally.
+	MetastoreWindowSize = 12 * time.Hour
 
 	// TocPrefix is the prefix under which ToC files are stored in the object storage.
 	TocPrefix = "tocs/"
@@ -121,22 +125,27 @@ func (d *DataobjSectionDescriptor) Merge(pointer pointers.SectionPointer, lbls [
 	d.AmbiguousPredicatesByStream[pointer.StreamIDRef] = curLbls
 }
 
-// Table of Content files are stored in well-known locations that can be computed from a known time.
-func tableOfContentsPath(window time.Time) string {
+// TableOfContentsPath returns the object-storage path of the ToC file that
+// covers the given window-aligned time. The path layout is part of the
+// metastore's on-disk contract; callers must align window to MetastoreWindowSize.
+func TableOfContentsPath(window time.Time) string {
 	return fmt.Sprintf("%s%s.toc", TocPrefix, strings.ReplaceAll(window.Format(time.RFC3339), ":", "_"))
 }
 
-func iterTableOfContentsPaths(start, end time.Time) iter.Seq2[string, multitenancy.TimeRange] {
-	minTocWindow := start.Truncate(metastoreWindowSize).UTC()
-	maxTocWindow := end.Truncate(metastoreWindowSize).UTC()
+// IterTableOfContentsPaths returns a sequence of (path, time-range) pairs
+// covering every ToC window that overlaps [start, end]. start and end may
+// be unaligned; the iterator truncates them to MetastoreWindowSize boundaries.
+func IterTableOfContentsPaths(start, end time.Time) iter.Seq2[string, multitenancy.TimeRange] {
+	minTocWindow := start.Truncate(MetastoreWindowSize).UTC()
+	maxTocWindow := end.Truncate(MetastoreWindowSize).UTC()
 
 	return func(yield func(t string, timeRange multitenancy.TimeRange) bool) {
-		for tocWindow := minTocWindow; !tocWindow.After(maxTocWindow); tocWindow = tocWindow.Add(metastoreWindowSize) {
+		for tocWindow := minTocWindow; !tocWindow.After(maxTocWindow); tocWindow = tocWindow.Add(MetastoreWindowSize) {
 			tocTimeRange := multitenancy.TimeRange{
 				MinTime: tocWindow,
-				MaxTime: tocWindow.Add(metastoreWindowSize),
+				MaxTime: tocWindow.Add(MetastoreWindowSize),
 			}
-			if !yield(tableOfContentsPath(tocWindow), tocTimeRange) {
+			if !yield(TableOfContentsPath(tocWindow), tocTimeRange) {
 				return
 			}
 		}
@@ -187,7 +196,7 @@ func (m *ObjectMetastore) streams(ctx context.Context, start, end time.Time, mat
 	var (
 		tablePaths []string
 	)
-	for path := range iterTableOfContentsPaths(start, end) {
+	for path := range IterTableOfContentsPaths(start, end) {
 		tablePaths = append(tablePaths, path)
 	}
 
@@ -215,7 +224,7 @@ func (m *ObjectMetastore) DataObjects(ctx context.Context, start, end time.Time,
 
 	// Get all metastore paths for the time range
 	var tablePaths []string
-	for path := range iterTableOfContentsPaths(start, end) {
+	for path := range IterTableOfContentsPaths(start, end) {
 		tablePaths = append(tablePaths, path)
 	}
 
@@ -642,7 +651,7 @@ func (m *ObjectMetastore) GetIndexes(ctx context.Context, req GetIndexesRequest)
 	resp := GetIndexesResponse{}
 
 	// Get all metastore paths for the time range
-	for path := range iterTableOfContentsPaths(req.Start, req.End) {
+	for path := range IterTableOfContentsPaths(req.Start, req.End) {
 		resp.TableOfContentsPaths = append(resp.TableOfContentsPaths, path)
 	}
 

--- a/pkg/dataobj/metastore/toc_writer.go
+++ b/pkg/dataobj/metastore/toc_writer.go
@@ -105,7 +105,7 @@ func (m *TableOfContentsWriter) WriteEntry(ctx context.Context, dataobjPath stri
 
 	// Work our way through the metastore objects window by window, updating & creating them as needed.
 	// Each one handles its own retries in order to keep making progress in the event of a failure.
-	for tocPath, tocTimeRange := range iterTableOfContentsPaths(globalMinTime, globalMaxTime) {
+	for tocPath, tocTimeRange := range IterTableOfContentsPaths(globalMinTime, globalMaxTime) {
 		b := backoff.New(ctx, backoff.Config{
 			MinBackoff: 50 * time.Millisecond,
 			MaxBackoff: 10 * time.Second,

--- a/pkg/dataobj/metastore/toc_writer_test.go
+++ b/pkg/dataobj/metastore/toc_writer_test.go
@@ -75,7 +75,7 @@ func TestTableOfContentsWriter(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		reader, err := bucket.Get(context.Background(), tableOfContentsPath(unixTime(0)))
+		reader, err := bucket.Get(context.Background(), TableOfContentsPath(unixTime(0)))
 		require.NoError(t, err)
 
 		object, err := io.ReadAll(reader)
@@ -112,7 +112,7 @@ func newInMemoryBucket(t *testing.T, window time.Time, obj *dataobj.Object) objs
 
 	var (
 		bucket = objstore.NewInMemBucket()
-		path   = tableOfContentsPath(window)
+		path   = TableOfContentsPath(window)
 	)
 
 	if obj != nil && obj.Size() > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

Exports three previously-unexported helpers from `pkg/dataobj/metastore` so they can be reused outside the package by an upcoming `dataobj` compactor (which needs to iterate ToC files for a lookback period using the same window alignment as the metastore itself):

| Before | After |
| --- | --- |
| `metastoreWindowSize` (const) | `MetastoreWindowSize` |
| `tableOfContentsPath` (func) | `TableOfContentsPath` |
| `iterTableOfContentsPaths` (func) | `IterTableOfContentsPaths` |

All internal callers within the metastore package were updated to the new names. Doc comments were added on the newly exported symbols to satisfy `revive` / godoc.

This is a **pure refactor** — same constant value (`12 * time.Hour`), same path-format string, same iterator semantics. The existing metastore test suite passes identically before and after.

**Which issue(s) this PR fixes**:

N/A — small standalone refactor that unblocks subsequent compactor work. (Part of an internal dataobj-compactor roadmap; PR "A6" in that sequence.)

**Special notes for your reviewer**:

- Touches only `pkg/dataobj/metastore/{object.go, toc_writer.go, toc_writer_test.go, metastore_test.go}`.
- No external callers existed for the lowercase names (they were unexported — Go enforces it). Verified with a repo-wide `rg` after the rename: zero hits for `metastoreWindowSize|tableOfContentsPath|iterTableOfContentsPaths`.
- No behavior change. The package-level tests are the regression net; they pass identically.
- `golangci-lint run pkg/dataobj/metastore/...` → 0 issues.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added — N/A, internal API rename only.
- [x] Tests updated — internal test call sites updated to the new exported names.
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md` — N/A, no user-visible change.
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory — N/A.
