### PR TITLE
feat(dataobj-compactor): Add workflow marker management library

### DIFF
--- a/pkg/engine/compactor/markers.go
+++ b/pkg/engine/compactor/markers.go
@@ -1,0 +1,46 @@
+// Package compactor contains the dataobj compactor coordinator and
+// supporting libraries. This file provides workflow-marker primitives used
+// by the coordinator to track in-flight compaction workflows in object
+// storage for cross-restart recovery and cross-coordinator deduplication.
+//
+// See the dataobj-compactor design spec § "Workflow markers and recovery"
+// for the full lifecycle and race semantics.
+package compactor
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"time"
+)
+
+// DefaultInFlightPrefix is the bucket prefix under which workflow markers
+// are written. The coordinator LISTs this prefix during recovery to
+// enumerate in-flight workflows.
+const DefaultInFlightPrefix = "dataobj/compaction/in-flight/"
+
+// Marker is the persisted content of a workflow marker file. It records the
+// identity of an in-flight compaction workflow so that coordinator restarts
+// can recover (via state-poll) and so that other coordinator replicas can
+// detect duplicate work.
+//
+// The encoded form is approximately 200 bytes.
+type Marker struct {
+	WorkflowID          string    `json:"workflow_id"`
+	Tenant              string    `json:"tenant"`
+	Window              time.Time `json:"window"`
+	PlanVersion         int       `json:"plan_version"`
+	StartedAt           time.Time `json:"started_at"`
+	ExpectedLogObjects  int       `json:"expected_log_objects"`
+	ExpectedIndexObject string    `json:"expected_index_object"`
+}
+
+// MarkerPath returns the deterministic object-storage path for the marker
+// identifying the workflow that compacts (tenant, window, planVersion). The
+// path is prefix + sha256(tenant + window.UTC().RFC3339 + planVersion) +
+// ".json". Two coordinators that build the same plan will compute the same
+// path; this is the basis of cross-coordinator deduplication.
+func MarkerPath(prefix, tenant string, window time.Time, planVersion int) string {
+	h := sha256.Sum256([]byte(tenant + window.UTC().Format(time.RFC3339) + strconv.Itoa(planVersion)))
+	return prefix + hex.EncodeToString(h[:]) + ".json"
+}

--- a/pkg/engine/compactor/markers.go
+++ b/pkg/engine/compactor/markers.go
@@ -148,6 +148,18 @@ func ListMarkers(ctx context.Context, bucket objstore.Bucket, prefix string) ([]
 	return markers, nil
 }
 
+// DeleteMarker removes the marker at path. NotFound is treated as success
+// (idempotent): it is normal for two coordinator replicas to both attempt
+// deletion at the end of a workflow, and idempotent delete is also part of
+// the force-cleanup path for stale markers.
+func DeleteMarker(ctx context.Context, bucket objstore.Bucket, path string) error {
+	err := bucket.Delete(ctx, path)
+	if err == nil || bucket.IsObjNotFoundErr(err) {
+		return nil
+	}
+	return fmt.Errorf("delete marker %q: %w", path, err)
+}
+
 // parseMarker decodes a marker file's bytes. Missing fields decode to zero
 // values; callers that care about completeness (e.g., empty WorkflowID)
 // should validate after parsing.

--- a/pkg/engine/compactor/markers.go
+++ b/pkg/engine/compactor/markers.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -101,4 +102,59 @@ func WriteMarker(ctx context.Context, bucket objstore.Bucket, path string, conte
 		return false, fmt.Errorf("write marker %q: %w", path, err)
 	}
 	return created, nil
+}
+
+// ListMarkers enumerates all parseable Marker objects under prefix using
+// bucket.Iter, fetching and JSON-decoding each entry. Use
+// DefaultInFlightPrefix for the standard coordinator path.
+//
+// Entries that fail to parse (corrupt JSON, manually-placed garbage) are
+// silently skipped — the coordinator's recovery loop must remain robust to
+// stray files, and a single bad object should not block recovery for all
+// other in-flight workflows. The caller observing a missing workflow is
+// expected to fall back to state-poll; an unparseable marker is
+// operationally equivalent to a missing marker.
+//
+// Entries deleted between LIST and GET (a normal race against
+// DeleteMarker) are likewise skipped.
+//
+// Order is unspecified.
+func ListMarkers(ctx context.Context, bucket objstore.Bucket, prefix string) ([]Marker, error) {
+	var markers []Marker
+	err := bucket.Iter(ctx, prefix, func(name string) error {
+		rc, getErr := bucket.Get(ctx, name)
+		if getErr != nil {
+			if bucket.IsObjNotFoundErr(getErr) {
+				return nil
+			}
+			return fmt.Errorf("get %q: %w", name, getErr)
+		}
+		defer rc.Close()
+		body, readErr := io.ReadAll(rc)
+		if readErr != nil {
+			return fmt.Errorf("read %q: %w", name, readErr)
+		}
+		m, parseErr := parseMarker(body)
+		if parseErr != nil {
+			// Skip unparseable entries: see function doc.
+			return nil
+		}
+		markers = append(markers, m)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list markers under %q: %w", prefix, err)
+	}
+	return markers, nil
+}
+
+// parseMarker decodes a marker file's bytes. Missing fields decode to zero
+// values; callers that care about completeness (e.g., empty WorkflowID)
+// should validate after parsing.
+func parseMarker(body []byte) (Marker, error) {
+	var m Marker
+	if err := json.Unmarshal(body, &m); err != nil {
+		return Marker{}, err
+	}
+	return m, nil
 }

--- a/pkg/engine/compactor/markers.go
+++ b/pkg/engine/compactor/markers.go
@@ -8,10 +8,16 @@
 package compactor
 
 import (
+	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
+	"io"
 	"strconv"
 	"time"
+
+	"github.com/thanos-io/objstore"
 )
 
 // DefaultInFlightPrefix is the bucket prefix under which workflow markers
@@ -43,4 +49,56 @@ type Marker struct {
 func MarkerPath(prefix, tenant string, window time.Time, planVersion int) string {
 	h := sha256.Sum256([]byte(tenant + window.UTC().Format(time.RFC3339) + strconv.Itoa(planVersion)))
 	return prefix + hex.EncodeToString(h[:]) + ".json"
+}
+
+// WriteMarker creates a workflow marker at path using bucket.GetAndReplace.
+//
+// Race semantics:
+//
+//   - On GCS / filesystem (atomic conditional-PUT backends), exactly one
+//     concurrent caller wins and observes created=true; losers either observe
+//     created=false (when their GetAndReplace's initial Get sees the
+//     winner's content) or surface a precondition error from GetAndReplace
+//     (the rarer case where two callers both saw nil at Get time and one's
+//     conditional PUT on a non-existent object fails). Both outcomes are
+//     acceptable; the caller treats both as "another coordinator is handling
+//     this workflow".
+//   - On S3 (current thanos-io/objstore provider), the conditional
+//     precondition is not enforced for new objects (see spec § "No
+//     coordinator leader election"). Two concurrent callers may both observe
+//     created=true. The overall design (deterministic output paths,
+//     idempotent ToC swap) tolerates this; this function does not attempt to
+//     compensate for it.
+//
+// Soft idempotency: when the existing object's content equals the proposed
+// content, WriteMarker returns (false, nil) — we did not create it, but no
+// error: an exact byte-for-byte duplicate is the same workflow being
+// (re)written. This is informational; callers may ignore the bool.
+//
+// The callback returns the existing bytes unchanged on race-loss so that
+// backends performing an unconditional PUT inside GetAndReplace (in-mem,
+// filesystem) write a no-op identical body, and so backends with optimistic
+// concurrency (GCS) match against the existing generation rather than
+// against "must not exist".
+func WriteMarker(ctx context.Context, bucket objstore.Bucket, path string, content []byte) (created bool, err error) {
+	err = bucket.GetAndReplace(ctx, path, func(existing io.ReadCloser) (io.ReadCloser, error) {
+		if existing == nil {
+			created = true
+			return io.NopCloser(bytes.NewReader(content)), nil
+		}
+		defer existing.Close()
+		existingBytes, readErr := io.ReadAll(existing)
+		if readErr != nil {
+			return nil, fmt.Errorf("read existing marker: %w", readErr)
+		}
+		// Race-loss (or soft idempotency): another writer beat us, or wrote
+		// the same content. Either way, created stays false. Return the
+		// existing bytes unchanged so the surrounding GetAndReplace performs
+		// no logical mutation.
+		return io.NopCloser(bytes.NewReader(existingBytes)), nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("write marker %q: %w", path, err)
+	}
+	return created, nil
 }

--- a/pkg/engine/compactor/markers_test.go
+++ b/pkg/engine/compactor/markers_test.go
@@ -73,6 +73,112 @@ func TestWriteMarker_SoftIdempotency_IdenticalContent(t *testing.T) {
 	}
 }
 
+func TestListMarkers_Empty(t *testing.T) {
+	bkt := objstore.NewInMemBucket()
+	got, err := ListMarkers(context.Background(), bkt, DefaultInFlightPrefix)
+	if err != nil {
+		t.Fatalf("ListMarkers: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 markers in empty bucket, got %d", len(got))
+	}
+}
+
+func TestListMarkers_RoundTrip(t *testing.T) {
+	bkt := objstore.NewInMemBucket()
+	window := time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)
+
+	want := []Marker{
+		{
+			WorkflowID:          "wf-29-v1",
+			Tenant:              "29",
+			Window:              window,
+			PlanVersion:         1,
+			StartedAt:           time.Date(2026, 5, 8, 10, 0, 0, 0, time.UTC),
+			ExpectedLogObjects:  10,
+			ExpectedIndexObject: "tenants/29/objects/a.dataobj",
+		},
+		{
+			WorkflowID:          "wf-30-v1",
+			Tenant:              "30",
+			Window:              window,
+			PlanVersion:         1,
+			StartedAt:           time.Date(2026, 5, 8, 10, 5, 0, 0, time.UTC),
+			ExpectedLogObjects:  20,
+			ExpectedIndexObject: "tenants/30/objects/b.dataobj",
+		},
+	}
+	for _, m := range want {
+		b, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		path := MarkerPath(DefaultInFlightPrefix, m.Tenant, m.Window, m.PlanVersion)
+		if _, err := WriteMarker(context.Background(), bkt, path, b); err != nil {
+			t.Fatalf("WriteMarker: %v", err)
+		}
+	}
+
+	got, err := ListMarkers(context.Background(), bkt, DefaultInFlightPrefix)
+	if err != nil {
+		t.Fatalf("ListMarkers: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len mismatch: got %d want %d (%+v)", len(got), len(want), got)
+	}
+
+	byID := map[string]Marker{}
+	for _, m := range got {
+		byID[m.WorkflowID] = m
+	}
+	for _, w := range want {
+		g, ok := byID[w.WorkflowID]
+		if !ok {
+			t.Fatalf("missing workflow %q", w.WorkflowID)
+		}
+		if g.Tenant != w.Tenant ||
+			!g.Window.Equal(w.Window) ||
+			g.PlanVersion != w.PlanVersion ||
+			!g.StartedAt.Equal(w.StartedAt) ||
+			g.ExpectedLogObjects != w.ExpectedLogObjects ||
+			g.ExpectedIndexObject != w.ExpectedIndexObject {
+			t.Fatalf("marker round-trip mismatch:\n got=%+v\nwant=%+v", g, w)
+		}
+	}
+}
+
+func TestListMarkers_SkipsMalformed(t *testing.T) {
+	bkt := objstore.NewInMemBucket()
+
+	good := Marker{
+		WorkflowID:          "wf-good",
+		Tenant:              "29",
+		Window:              time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC),
+		PlanVersion:         1,
+		StartedAt:           time.Date(2026, 5, 8, 10, 0, 0, 0, time.UTC),
+		ExpectedLogObjects:  1,
+		ExpectedIndexObject: "tenants/29/objects/g.dataobj",
+	}
+	gb, err := json.Marshal(good)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := bkt.Upload(context.Background(), DefaultInFlightPrefix+"good.json", bytes.NewReader(gb)); err != nil {
+		t.Fatalf("upload good: %v", err)
+	}
+	if err := bkt.Upload(context.Background(), DefaultInFlightPrefix+"bad.json", bytes.NewReader([]byte("not-json"))); err != nil {
+		t.Fatalf("upload bad: %v", err)
+	}
+
+	got, err := ListMarkers(context.Background(), bkt, DefaultInFlightPrefix)
+	if err != nil {
+		t.Fatalf("ListMarkers should not fail when one entry is malformed: %v", err)
+	}
+	if len(got) != 1 || got[0].WorkflowID != "wf-good" {
+		t.Fatalf("expected exactly one good marker, got %+v", got)
+	}
+}
+
 func TestWriteMarker_RaceLoss_DifferentContent(t *testing.T) {
 	bkt := objstore.NewInMemBucket()
 	_, contentA := sampleMarker(t)

--- a/pkg/engine/compactor/markers_test.go
+++ b/pkg/engine/compactor/markers_test.go
@@ -179,6 +179,60 @@ func TestListMarkers_SkipsMalformed(t *testing.T) {
 	}
 }
 
+func TestDeleteMarker_RemovesExisting(t *testing.T) {
+	bkt := objstore.NewInMemBucket()
+	_, content := sampleMarker(t)
+	path := MarkerPath(DefaultInFlightPrefix, "29", time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC), 1)
+
+	if _, err := WriteMarker(context.Background(), bkt, path, content); err != nil {
+		t.Fatalf("WriteMarker: %v", err)
+	}
+	if err := DeleteMarker(context.Background(), bkt, path); err != nil {
+		t.Fatalf("DeleteMarker: %v", err)
+	}
+
+	if _, err := bkt.Get(context.Background(), path); err == nil {
+		t.Fatalf("expected NotFound after delete; marker still present")
+	} else if !bkt.IsObjNotFoundErr(err) {
+		t.Fatalf("expected NotFound, got %v", err)
+	}
+}
+
+func TestDeleteMarker_IdempotentOnMissing(t *testing.T) {
+	bkt := objstore.NewInMemBucket()
+	path := MarkerPath(DefaultInFlightPrefix, "29", time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC), 1)
+	if err := DeleteMarker(context.Background(), bkt, path); err != nil {
+		t.Fatalf("DeleteMarker on missing path should be nil, got %v", err)
+	}
+}
+
+func TestDeleteMarker_RoundTrip_RemovesFromList(t *testing.T) {
+	bkt := objstore.NewInMemBucket()
+	_, content := sampleMarker(t)
+	path := MarkerPath(DefaultInFlightPrefix, "29", time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC), 1)
+
+	if _, err := WriteMarker(context.Background(), bkt, path, content); err != nil {
+		t.Fatalf("WriteMarker: %v", err)
+	}
+	got, err := ListMarkers(context.Background(), bkt, DefaultInFlightPrefix)
+	if err != nil {
+		t.Fatalf("ListMarkers: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 marker, got %d", len(got))
+	}
+	if err := DeleteMarker(context.Background(), bkt, path); err != nil {
+		t.Fatalf("DeleteMarker: %v", err)
+	}
+	got, err = ListMarkers(context.Background(), bkt, DefaultInFlightPrefix)
+	if err != nil {
+		t.Fatalf("ListMarkers post-delete: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 markers post-delete, got %d", len(got))
+	}
+}
+
 func TestWriteMarker_RaceLoss_DifferentContent(t *testing.T) {
 	bkt := objstore.NewInMemBucket()
 	_, contentA := sampleMarker(t)

--- a/pkg/engine/compactor/markers_test.go
+++ b/pkg/engine/compactor/markers_test.go
@@ -1,0 +1,57 @@
+package compactor
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMarkerPath_Deterministic(t *testing.T) {
+	window := time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)
+	got1 := MarkerPath(DefaultInFlightPrefix, "29", window, 1)
+	got2 := MarkerPath(DefaultInFlightPrefix, "29", window, 1)
+	if got1 != got2 {
+		t.Fatalf("MarkerPath not deterministic: %q vs %q", got1, got2)
+	}
+}
+
+func TestMarkerPath_StructureAndPrefix(t *testing.T) {
+	window := time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)
+	p := MarkerPath("dataobj/compaction/in-flight/", "29", window, 1)
+	const wantPrefix = "dataobj/compaction/in-flight/"
+	if p[:len(wantPrefix)] != wantPrefix {
+		t.Fatalf("path missing prefix: %q", p)
+	}
+	if got := len(p) - len(wantPrefix) - len(".json"); got != 64 {
+		t.Fatalf("hex sha256 expected 64 chars, got %d in %q", got, p)
+	}
+	if p[len(p)-5:] != ".json" {
+		t.Fatalf("path missing .json suffix: %q", p)
+	}
+}
+
+func TestMarkerPath_DiffersOnInputs(t *testing.T) {
+	window := time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)
+	base := MarkerPath(DefaultInFlightPrefix, "29", window, 1)
+	cases := map[string]string{
+		"different tenant":      MarkerPath(DefaultInFlightPrefix, "30", window, 1),
+		"different window":      MarkerPath(DefaultInFlightPrefix, "29", window.Add(time.Hour), 1),
+		"different planVersion": MarkerPath(DefaultInFlightPrefix, "29", window, 2),
+	}
+	for name, other := range cases {
+		if other == base {
+			t.Errorf("%s: expected different path, got identical %q", name, base)
+		}
+	}
+}
+
+func TestMarkerPath_TimezoneNormalized(t *testing.T) {
+	utc := time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)
+	tz, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pacific := utc.In(tz) // same instant, different zone
+	if MarkerPath(DefaultInFlightPrefix, "29", utc, 1) != MarkerPath(DefaultInFlightPrefix, "29", pacific, 1) {
+		t.Fatalf("MarkerPath should normalize to UTC")
+	}
+}

--- a/pkg/engine/compactor/markers_test.go
+++ b/pkg/engine/compactor/markers_test.go
@@ -1,9 +1,113 @@
 package compactor
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
 	"testing"
 	"time"
+
+	"github.com/thanos-io/objstore"
 )
+
+func sampleMarker(t *testing.T) (Marker, []byte) {
+	t.Helper()
+	m := Marker{
+		WorkflowID:          "wf-abc",
+		Tenant:              "29",
+		Window:              time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC),
+		PlanVersion:         1,
+		StartedAt:           time.Date(2026, 5, 8, 15, 23, 14, 0, time.UTC),
+		ExpectedLogObjects:  2667,
+		ExpectedIndexObject: "tenants/29/objects/abc.dataobj",
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return m, b
+}
+
+func TestWriteMarker_CreatesNew(t *testing.T) {
+	bkt := objstore.NewInMemBucket()
+	_, content := sampleMarker(t)
+	path := MarkerPath(DefaultInFlightPrefix, "29", time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC), 1)
+
+	created, err := WriteMarker(context.Background(), bkt, path, content)
+	if err != nil {
+		t.Fatalf("WriteMarker: %v", err)
+	}
+	if !created {
+		t.Fatalf("expected created=true on first write")
+	}
+
+	rc, err := bkt.Get(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer rc.Close()
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("stored content mismatch:\n got=%s\nwant=%s", got, content)
+	}
+}
+
+func TestWriteMarker_SoftIdempotency_IdenticalContent(t *testing.T) {
+	bkt := objstore.NewInMemBucket()
+	_, content := sampleMarker(t)
+	path := MarkerPath(DefaultInFlightPrefix, "29", time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC), 1)
+
+	if _, err := WriteMarker(context.Background(), bkt, path, content); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	created, err := WriteMarker(context.Background(), bkt, path, content)
+	if err != nil {
+		t.Fatalf("second write returned error: %v", err)
+	}
+	if created {
+		t.Fatalf("expected created=false on identical second write")
+	}
+}
+
+func TestWriteMarker_RaceLoss_DifferentContent(t *testing.T) {
+	bkt := objstore.NewInMemBucket()
+	_, contentA := sampleMarker(t)
+	mB, _ := sampleMarker(t)
+	mB.WorkflowID = "wf-different"
+	contentB, err := json.Marshal(mB)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	path := MarkerPath(DefaultInFlightPrefix, "29", time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC), 1)
+
+	if _, err := WriteMarker(context.Background(), bkt, path, contentA); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	created, err := WriteMarker(context.Background(), bkt, path, contentB)
+	if err != nil {
+		t.Fatalf("second write returned error: %v", err)
+	}
+	if created {
+		t.Fatalf("expected created=false when an existing marker is present")
+	}
+
+	rc, err := bkt.Get(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer rc.Close()
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, contentA) {
+		t.Fatalf("existing marker was overwritten\n got=%s\nwant=%s", got, contentA)
+	}
+}
 
 func TestMarkerPath_Deterministic(t *testing.T) {
 	window := time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## What this PR does

Part of the compactor roadmap.

Adds the workflow-marker library at `pkg/engine/compactor/markers.go`. The library is what the future coordinator will call to track in-flight compaction workflows in object storage, enabling cross-restart recovery and cross-coordinator deduplication. This is a simpler MVP compared to persisting an entire plan, with the thought that we can always move do that heavier option later.

This PR is **library-only**: nothing calls these primitives yet. Default behavior is unchanged.

## Primitives

| Symbol | Purpose |
| --- | --- |
| `Marker` struct | JSON-encoded marker content matching the design-spec schema (`workflow_id`, `tenant`, `window`, `plan_version`, `started_at`, `expected_log_objects`, `expected_index_object`). |
| `DefaultInFlightPrefix` | `"dataobj/compaction/in-flight/"` — the canonical LIST prefix. |
| `MarkerPath(prefix, tenant, window, planVersion)` | Deterministic path: `prefix + sha256(tenant + window.UTC().RFC3339 + planVersion) + ".json"`. |
| `WriteMarker(ctx, bucket, path, content) (created bool, err error)` | Best-effort exclusive create via `bucket.GetAndReplace`. |
| `ListMarkers(ctx, bucket, prefix) ([]Marker, error)` | LIST + Get + JSON-parse; skips unparseable entries and objects deleted between LIST and GET. |
| `DeleteMarker(ctx, bucket, path) error` | Idempotent delete — NotFound is not an error. |

## Race semantics (per spec)

- **GCS / filesystem (atomic conditional-PUT):** exactly one concurrent caller observes `created=true`; losers observe `created=false` (their initial Get saw the winner's content) or surface a precondition error in the rare both-saw-nil case.
- **S3 (current thanos-io/objstore provider):** the conditional precondition is not enforced for new objects, so both callers may observe `created=true`. v1 accepts this per design spec § *No coordinator leader election* — deterministic output paths and idempotent ToC swap converge to a correct end state regardless. **The code does not attempt to work around this gap.**
- **Soft idempotency:** a `WriteMarker` whose `content` is byte-equal to the existing object returns `(false, nil)` — same workflow being (re)written.
- The race-loss callback returns existing bytes unchanged so backends performing an unconditional PUT inside `GetAndReplace` (in-mem, filesystem) emit a no-op identical body, and so GCS matches against the existing generation rather than against "must not exist".

## Tests (13, all passing under `-race`)

`pkg/engine/compactor/markers_test.go`:

- `TestMarkerPath_Deterministic` / `_StructureAndPrefix` / `_DiffersOnInputs` / `_TimezoneNormalized`
- `TestWriteMarker_CreatesNew` — first write returns `created=true`, content stored
- `TestWriteMarker_SoftIdempotency_IdenticalContent` — second write of identical content returns `created=false`, no error
- `TestWriteMarker_RaceLoss_DifferentContent` — second write of different content returns `created=false`, existing object untouched
- `TestListMarkers_Empty` / `_RoundTrip` (two markers) / `_SkipsMalformed` (one good + one corrupt-JSON; only the good one is returned, no error)
- `TestDeleteMarker_RemovesExisting` / `_IdempotentOnMissing` / `_RoundTrip_RemovesFromList`

```
$ go test ./pkg/engine/compactor/... -race -v
PASS (13/13)
$ golangci-lint run ./pkg/engine/compactor/...
0 issues.
```

`make lint` repo-wide: the 50 pre-existing `goconst` warnings are baseline and unrelated to this PR (zero matches under `pkg/engine/compactor/`).

## Scope notes

- This PR creates the `pkg/engine/compactor/` package directory. A1 (coordinator skeleton) is a separate Wave 1 PR; if A1 lands first the package directory already exists and `markers.go` simply joins the existing files — no merge conflict expected (different files).
- Uses **only** `objstore.Bucket` interface methods (`GetAndReplace`, `Iter`, `Get`, `Delete`, `IsObjNotFoundErr`); no backend-specific code.
- No retry/backoff inside `WriteMarker` — A11 owns the retry policy.
- No metrics — A11 owns the `workflow_marker_writes_total` counter (it can derive `result` labels from the `(created, err)` return tuple).

## References

- Design spec: `docs/superpowers/specs/2026-05-06-dataobj-compactor-design.md` § *Workflow markers and recovery* and § *No coordinator leader election*.
- Roadmap: `docs/superpowers/plans/2026-05-08-dataobj-compactor-pr-roadmap.md` § *A8: dataobj-compactor/marker-management*.
- Detailed task plan: `docs/superpowers/plans/2026-05-08-A8-marker-management-detailed-plan.md` (symlink into the repo).

## Checklist

- [x] Tests added (round-trip create/list/delete, soft idempotency, race-loss, malformed-skip, idempotent-delete, determinism).
- [x] `golangci-lint` clean on the new package.
- [x] No new lint regressions repo-wide.
- [x] `go build ./...` clean.
- [x] Default behavior unchanged (library-only; no callers yet).
- [ ] CI green.
- [ ] Code review approval.
