### PR TITLE
feat(dataobj-compactor): Export Planner.Plan and make BinPack deterministic

### DIFF
--- a/pkg/dataobj/compaction/binpacking.go
+++ b/pkg/dataobj/compaction/binpacking.go
@@ -2,16 +2,29 @@ package planner
 
 import "sort"
 
-// Sizer is an interface for items that have a size.
-// Used by generic bin-packing algorithm.
+// Sizer is an interface for items that have a size and a stable tiebreaker hash.
+// Used by the generic bin-packing algorithm. GetLabelsHash returns a stable per-item
+// identifier used as a secondary sort key to guarantee deterministic bin assignment
+// when multiple items share the same size.
 type Sizer interface {
 	GetSize() int64
+	GetLabelsHash() uint64
 }
 
 // BinPackResult represents a bin containing groups and their total size.
 type BinPackResult[G Sizer] struct {
 	Groups []G
 	Size   int64
+}
+
+// binTiebreaker returns a stable secondary sort key for a bin. Bins are ordered
+// deterministically by their first group's LabelsHash; the first group is well-
+// defined because BinPack inserts groups in a deterministic order.
+func binTiebreaker[G Sizer](b BinPackResult[G]) uint64 {
+	if len(b.Groups) == 0 {
+		return 0
+	}
+	return b.Groups[0].GetLabelsHash()
 }
 
 // BinPack performs best-fit decreasing bin packing with overflow and merging.
@@ -28,9 +41,15 @@ func BinPack[G Sizer](groups []G) []BinPackResult[G] {
 		return nil
 	}
 
-	// Sort by size descending for better packing
+	// Sort by size descending, then by LabelsHash ascending as a stable tiebreaker.
+	// The tiebreaker is required so equal-size groups produce identical bin assignments
+	// across runs (the marker-based recovery model assumes deterministic plans).
 	sort.Slice(groups, func(i, j int) bool {
-		return groups[i].GetSize() > groups[j].GetSize()
+		si, sj := groups[i].GetSize(), groups[j].GetSize()
+		if si != sj {
+			return si > sj
+		}
+		return groups[i].GetLabelsHash() < groups[j].GetLabelsHash()
 	})
 
 	var totalUncompressedSize int64
@@ -150,9 +169,13 @@ func mergeUnderfilledBins[G Sizer](bins []BinPackResult[G]) []BinPackResult[G] {
 	minDesiredSize := targetUncompressedSize * minFillPercent / 100
 	maxAllowedSize := targetUncompressedSize * maxOutputMultiple
 
-	// Sort by size (smallest first) to process under-filled bins first
+	// Sort by size ascending with a stable LabelsHash tiebreaker so equal-size bins
+	// have a deterministic order.
 	sort.Slice(bins, func(i, j int) bool {
-		return bins[i].Size < bins[j].Size
+		if bins[i].Size != bins[j].Size {
+			return bins[i].Size < bins[j].Size
+		}
+		return binTiebreaker(bins[i]) < binTiebreaker(bins[j])
 	})
 
 	// Use write index to compact the slice as we merge
@@ -201,11 +224,14 @@ func mergeUnderfilledBins[G Sizer](bins []BinPackResult[G]) []BinPackResult[G] {
 			bins[bestMergeIdx] = bins[len(bins)-1]
 			bins = bins[:len(bins)-1]
 
-			// Re-sort remaining unprocessed bins
+			// Re-sort remaining unprocessed bins with the same stable tiebreaker.
 			if bestMergeIdx < len(bins) {
 				remaining := bins[readIdx+1:]
 				sort.Slice(remaining, func(i, j int) bool {
-					return remaining[i].Size < remaining[j].Size
+					if remaining[i].Size != remaining[j].Size {
+						return remaining[i].Size < remaining[j].Size
+					}
+					return binTiebreaker(remaining[i]) < binTiebreaker(remaining[j])
 				})
 			}
 

--- a/pkg/dataobj/compaction/binpacking_test.go
+++ b/pkg/dataobj/compaction/binpacking_test.go
@@ -10,13 +10,36 @@ import (
 type mockSizer struct {
 	size int64
 	id   string
+	hash uint64
 }
 
-func (m *mockSizer) GetSize() int64 { return m.size }
+func (m *mockSizer) GetSize() int64        { return m.size }
+func (m *mockSizer) GetLabelsHash() uint64 { return m.hash }
 
-// Helper to create mock sizers
+// newMockSizer creates a mock sizer. The hash defaults to a stable FNV-style hash
+// of the id so existing tests get a deterministic tiebreaker without rewrites.
 func newMockSizer(id string, size int64) *mockSizer {
-	return &mockSizer{id: id, size: size}
+	return &mockSizer{id: id, size: size, hash: hashID(id)}
+}
+
+// newMockSizerWithHash creates a mock sizer with an explicit hash, used by
+// determinism tests where the hash must be controlled directly.
+func newMockSizerWithHash(id string, size int64, hash uint64) *mockSizer {
+	return &mockSizer{id: id, size: size, hash: hash}
+}
+
+// hashID computes a stable 64-bit FNV-1a hash of a string for tests.
+func hashID(s string) uint64 {
+	const (
+		offset64 uint64 = 14695981039346656037
+		prime64  uint64 = 1099511628211
+	)
+	h := offset64
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= prime64
+	}
+	return h
 }
 
 // Helper to get total size of bins
@@ -309,4 +332,55 @@ func TestMergeUnderfilledBins(t *testing.T) {
 
 		require.Equal(t, inputCount, outputCount)
 	})
+}
+
+func TestBinPack_Deterministic(t *testing.T) {
+	// Build 12 equal-size groups whose total comfortably exceeds one bin so
+	// BinPack must distribute them across multiple bins. Each group has a
+	// distinct LabelsHash so the tiebreaker is well-defined.
+	const groupSize = targetUncompressedSize / 4 // 25% each → 3 groups per bin
+	const numGroups = 12
+
+	makeGroups := func() []*mockSizer {
+		groups := make([]*mockSizer, numGroups)
+		for i := 0; i < numGroups; i++ {
+			groups[i] = newMockSizerWithHash(
+				/* id */ "g"+string(rune('a'+i)),
+				/* size */ groupSize,
+				/* hash */ uint64(i+1),
+			)
+		}
+		return groups
+	}
+
+	// Two different deterministic permutations of the same input.
+	shuffleA := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+	shuffleB := []int{11, 7, 3, 9, 0, 5, 2, 10, 4, 8, 1, 6}
+
+	apply := func(order []int) []*mockSizer {
+		src := makeGroups()
+		out := make([]*mockSizer, len(order))
+		for dst, srcIdx := range order {
+			out[dst] = src[srcIdx]
+		}
+		return out
+	}
+
+	binsA := BinPack(apply(shuffleA))
+	binsB := BinPack(apply(shuffleB))
+
+	require.Equal(t, len(binsA), len(binsB), "different bin counts across shuffles")
+
+	for i := range binsA {
+		require.Equal(t, binsA[i].Size, binsB[i].Size,
+			"bin %d size differs across shuffles", i)
+		require.Equal(t, len(binsA[i].Groups), len(binsB[i].Groups),
+			"bin %d group count differs across shuffles", i)
+		for j := range binsA[i].Groups {
+			require.Equal(t,
+				binsA[i].Groups[j].GetLabelsHash(),
+				binsB[i].Groups[j].GetLabelsHash(),
+				"bin %d position %d differs across shuffles", i, j)
+		}
+	}
 }

--- a/pkg/dataobj/compaction/binpacking_test.go
+++ b/pkg/dataobj/compaction/binpacking_test.go
@@ -376,10 +376,12 @@ func TestBinPack_Deterministic(t *testing.T) {
 		require.Equal(t, len(binsA[i].Groups), len(binsB[i].Groups),
 			"bin %d group count differs across shuffles", i)
 		for j := range binsA[i].Groups {
+			require.Equal(t, binsA[i].Groups[j].id, binsB[i].Groups[j].id,
+				"bin %d position %d id differs across shuffles", i, j)
 			require.Equal(t,
 				binsA[i].Groups[j].GetLabelsHash(),
 				binsB[i].Groups[j].GetLabelsHash(),
-				"bin %d position %d differs across shuffles", i, j)
+				"bin %d position %d hash differs across shuffles", i, j)
 		}
 	}
 }

--- a/pkg/dataobj/compaction/binpacking_test.go
+++ b/pkg/dataobj/compaction/binpacking_test.go
@@ -1,6 +1,7 @@
 package planner
 
 import (
+	"hash/fnv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,16 +31,9 @@ func newMockSizerWithHash(id string, size int64, hash uint64) *mockSizer {
 
 // hashID computes a stable 64-bit FNV-1a hash of a string for tests.
 func hashID(s string) uint64 {
-	const (
-		offset64 uint64 = 14695981039346656037
-		prime64  uint64 = 1099511628211
-	)
-	h := offset64
-	for i := 0; i < len(s); i++ {
-		h ^= uint64(s[i])
-		h *= prime64
-	}
-	return h
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(s))
+	return h.Sum64()
 }
 
 // Helper to get total size of bins
@@ -334,6 +328,11 @@ func TestMergeUnderfilledBins(t *testing.T) {
 	})
 }
 
+// TestBinPack_Deterministic verifies that BinPack's initial group sort
+// (size desc, LabelsHash asc) produces identical bins across input shuffles.
+// The 12 groups in this fixture pack to exactly 3 bins at 100% fill, which
+// causes mergeUnderfilledBins to fast-path out — determinism of the
+// merge-step sorts is covered separately by TestMergeUnderfilledBins_Deterministic.
 func TestBinPack_Deterministic(t *testing.T) {
 	// Build 12 equal-size groups whose total comfortably exceeds one bin so
 	// BinPack must distribute them across multiple bins. Each group has a
@@ -381,6 +380,63 @@ func TestBinPack_Deterministic(t *testing.T) {
 				binsA[i].Groups[j].GetLabelsHash(),
 				binsB[i].Groups[j].GetLabelsHash(),
 				"bin %d position %d differs across shuffles", i, j)
+		}
+	}
+}
+
+func TestMergeUnderfilledBins_Deterministic(t *testing.T) {
+	// Five hand-crafted underfilled bins. Three pairs of equal-size bins
+	// exercise the outer-sort tiebreaker (A/B/C at 25%, D/E at 50%); after
+	// the first merge consumes one of the 50% bins, the remaining bins still
+	// contain a tie (B & C at 25%), exercising the inner re-sort tiebreaker.
+	//
+	// minDesiredSize = targetUncompressedSize * 70 / 100 = 70%.
+	// All input bins are below 70% → every bin is underfilled.
+
+	const q = targetUncompressedSize / 100 // 1% of target, used as size unit
+
+	// Use newMockSizerWithHash so we control the tiebreaker key exactly.
+	makeBins := func() []BinPackResult[*mockSizer] {
+		a := newMockSizerWithHash("a", 25*q, 10)
+		b := newMockSizerWithHash("b", 25*q, 20)
+		c := newMockSizerWithHash("c", 25*q, 30)
+		d := newMockSizerWithHash("d", 50*q, 40)
+		e := newMockSizerWithHash("e", 50*q, 50)
+		return []BinPackResult[*mockSizer]{
+			{Groups: []*mockSizer{a}, Size: 25 * q},
+			{Groups: []*mockSizer{b}, Size: 25 * q},
+			{Groups: []*mockSizer{c}, Size: 25 * q},
+			{Groups: []*mockSizer{d}, Size: 50 * q},
+			{Groups: []*mockSizer{e}, Size: 50 * q},
+		}
+	}
+
+	// Two distinct permutations of the same 5 bins.
+	permute := func(bins []BinPackResult[*mockSizer], order []int) []BinPackResult[*mockSizer] {
+		out := make([]BinPackResult[*mockSizer], len(order))
+		for dst, src := range order {
+			out[dst] = bins[src]
+		}
+		return out
+	}
+
+	orderA := []int{0, 1, 2, 3, 4}
+	orderB := []int{4, 2, 0, 3, 1}
+
+	resultA := mergeUnderfilledBins(permute(makeBins(), orderA))
+	resultB := mergeUnderfilledBins(permute(makeBins(), orderB))
+
+	require.Equal(t, len(resultA), len(resultB), "bin count differs across input permutations")
+	for i := range resultA {
+		require.Equal(t, resultA[i].Size, resultB[i].Size,
+			"bin %d size differs across permutations", i)
+		require.Equal(t, len(resultA[i].Groups), len(resultB[i].Groups),
+			"bin %d group count differs across permutations", i)
+		for j := range resultA[i].Groups {
+			require.Equal(t, resultA[i].Groups[j].id, resultB[i].Groups[j].id,
+				"bin %d position %d differs across permutations", i, j)
+			require.Equal(t, resultA[i].Groups[j].GetLabelsHash(), resultB[i].Groups[j].GetLabelsHash(),
+				"bin %d position %d hash differs across permutations", i, j)
 		}
 	}
 }

--- a/pkg/dataobj/compaction/planner.go
+++ b/pkg/dataobj/compaction/planner.go
@@ -171,8 +171,12 @@ type IndexStreamResult struct {
 	LeftoverAfterStreams  []LeftoverStreamInfo
 }
 
-// buildPlanFromIndexes builds compaction plans for each tenant and aggregates leftover streams.
-func (s *Planner) buildPlanFromIndexes(ctx context.Context, indexes []IndexInfo, windowStart, windowEnd time.Time) (map[string]*CompactionPlan, *LeftoverPlan, error) {
+// Plan builds compaction plans for each tenant and aggregates leftover streams.
+// It is the entry point used by the compactor coordinator: given the indexes
+// covering a (tenant, window) and the window bounds, it returns one
+// CompactionPlan per tenant plus an aggregated LeftoverPlan for data falling
+// outside the window.
+func (s *Planner) Plan(ctx context.Context, indexes []IndexInfo, windowStart, windowEnd time.Time) (map[string]*CompactionPlan, *LeftoverPlan, error) {
 	// Group indexes by tenant
 	indexesByTenant := make(map[string][]IndexInfo)
 	for _, index := range indexes {

--- a/pkg/dataobj/compaction/planner.go
+++ b/pkg/dataobj/compaction/planner.go
@@ -95,10 +95,17 @@ type StreamGroup struct {
 	Streams []*compactionpb.Stream
 	// TotalUncompressedSize is the sum of uncompressed sizes across all streams.
 	TotalUncompressedSize int64
+	// LabelsHash is the stable hash of the stream labels. Used as a deterministic
+	// tiebreaker by the bin-packing algorithm so equal-size groups produce identical
+	// bin assignments across runs.
+	LabelsHash uint64
 }
 
 // GetSize implements Sizer interface for bin-packing.
 func (g *StreamGroup) GetSize() int64 { return g.TotalUncompressedSize }
+
+// GetLabelsHash implements Sizer interface for bin-packing.
+func (g *StreamGroup) GetLabelsHash() uint64 { return g.LabelsHash }
 
 // StreamInfo represents aggregated stream information from an index object.
 type StreamInfo struct {
@@ -126,10 +133,17 @@ type LeftoverPlan struct {
 type LeftoverStreamGroup struct {
 	Streams               []*compactionpb.TenantStream
 	TotalUncompressedSize int64
+	// LabelsHash is the stable hash of the stream labels. Used as a deterministic
+	// tiebreaker by the bin-packing algorithm so equal-size groups produce identical
+	// bin assignments across runs.
+	LabelsHash uint64
 }
 
 // GetSize implements Sizer interface for bin-packing.
 func (g *LeftoverStreamGroup) GetSize() int64 { return g.TotalUncompressedSize }
+
+// GetLabelsHash implements Sizer interface for bin-packing.
+func (g *LeftoverStreamGroup) GetLabelsHash() uint64 { return g.LabelsHash }
 
 // LeftoverStreamInfo represents a stream's leftover data outside the compaction window.
 type LeftoverStreamInfo struct {
@@ -294,7 +308,7 @@ func (s *Planner) collectStreams(ctx context.Context, tenant string, indexes []I
 			for _, info := range result.LeftoverBeforeStreams {
 				group, ok := leftoverBeforeMap[info.LabelsHash]
 				if !ok {
-					group = &LeftoverStreamGroup{}
+					group = &LeftoverStreamGroup{LabelsHash: info.LabelsHash}
 					leftoverBeforeMap[info.LabelsHash] = group
 				}
 				group.Streams = append(group.Streams, &info.TenantStream)
@@ -305,7 +319,7 @@ func (s *Planner) collectStreams(ctx context.Context, tenant string, indexes []I
 			for _, info := range result.LeftoverAfterStreams {
 				group, ok := leftoverAfterMap[info.LabelsHash]
 				if !ok {
-					group = &LeftoverStreamGroup{}
+					group = &LeftoverStreamGroup{LabelsHash: info.LabelsHash}
 					leftoverAfterMap[info.LabelsHash] = group
 				}
 				group.Streams = append(group.Streams, &info.TenantStream)
@@ -316,7 +330,7 @@ func (s *Planner) collectStreams(ctx context.Context, tenant string, indexes []I
 			for _, info := range result.Streams {
 				group, ok := streamGroupMap[info.LabelsHash]
 				if !ok {
-					group = &StreamGroup{}
+					group = &StreamGroup{LabelsHash: info.LabelsHash}
 					streamGroupMap[info.LabelsHash] = group
 				}
 				group.Streams = append(group.Streams, &info.Stream)

--- a/pkg/dataobj/compaction/planner_test.go
+++ b/pkg/dataobj/compaction/planner_test.go
@@ -240,7 +240,7 @@ func TestBuildPlanFromIndexes(t *testing.T) {
 		planner := newTestPlanner(mockReader)
 		indexes := []IndexInfo{{Path: "index1", Tenant: "tenant1"}}
 
-		plans, leftoverPlan, err := planner.buildPlanFromIndexes(ctx, indexes, windowStart, windowEnd)
+		plans, leftoverPlan, err := planner.Plan(ctx, indexes, windowStart, windowEnd)
 
 		require.NoError(t, err)
 		require.Len(t, plans, 1)
@@ -293,7 +293,7 @@ func TestBuildPlanFromIndexes(t *testing.T) {
 			{Path: "index2", Tenant: "tenant1"},
 		}
 
-		plans, _, err := planner.buildPlanFromIndexes(ctx, indexes, windowStart, windowEnd)
+		plans, _, err := planner.Plan(ctx, indexes, windowStart, windowEnd)
 
 		require.NoError(t, err)
 		require.Len(t, plans, 1)
@@ -346,7 +346,7 @@ func TestBuildPlanFromIndexes(t *testing.T) {
 			{Path: "index2", Tenant: "tenant2"},
 		}
 
-		plans, _, err := planner.buildPlanFromIndexes(ctx, indexes, windowStart, windowEnd)
+		plans, _, err := planner.Plan(ctx, indexes, windowStart, windowEnd)
 
 		require.NoError(t, err)
 		require.Len(t, plans, 2)
@@ -401,7 +401,7 @@ func TestBuildPlanFromIndexes(t *testing.T) {
 		planner := newTestPlanner(mockReader)
 		indexes := []IndexInfo{{Path: "index1", Tenant: "tenant1"}}
 
-		plans, leftoverPlan, err := planner.buildPlanFromIndexes(ctx, indexes, windowStart, windowEnd)
+		plans, leftoverPlan, err := planner.Plan(ctx, indexes, windowStart, windowEnd)
 
 		require.NoError(t, err)
 		require.Len(t, plans, 1)
@@ -456,7 +456,7 @@ func TestBuildPlanFromIndexes(t *testing.T) {
 			{Path: "index2", Tenant: "tenant2"},
 		}
 
-		_, leftoverPlan, err := planner.buildPlanFromIndexes(ctx, indexes, windowStart, windowEnd)
+		_, leftoverPlan, err := planner.Plan(ctx, indexes, windowStart, windowEnd)
 
 		require.NoError(t, err)
 		require.NotNil(t, leftoverPlan)


### PR DESCRIPTION
## What this PR does

Two related changes in `pkg/dataobj/compaction/`, prep work for the upcoming compactor coordinator.

### 1. Export the planner entry point

Renames `Planner.buildPlanFromIndexes` → `Planner.Plan`. Signature unchanged. The future compactor coordinator (in `pkg/engine/compactor/`, a different package) will import and call `planner.Planner.Plan(...)`. Helpers (`buildTenantPlan`, `collectStreams`, `planLeftovers`, `readStreamsFromIndexObject`) stay package-private.

### 2. Make `BinPack` fully deterministic

The bin-packer's sort sites used `sort.Slice` (non-stable) keyed only by size, so equal-size groups could be assigned to different bins across runs. The upcoming coordinator's marker-based recovery model assumes plans are reproducible across processes observing the same source ToCs.

Changes:

- Extend the generic `Sizer` interface with `GetLabelsHash() uint64`.
- Add `LabelsHash` field + getter to `StreamGroup` and `LeftoverStreamGroup`; populate at construction in `collectStreams` (the map key was already the labels hash — no new lookups).
- Apply `(GetSize() desc, GetLabelsHash() asc)` to the initial sort in `BinPack`; apply analogous `(Size asc, binTiebreaker asc)` to the outer and inner re-sorts inside `mergeUnderfilledBins`. `binTiebreaker` uses the first group's `LabelsHash` (safe — groups are inserted in deterministic order after the initial sort).

## Test plan

- `TestBinPack_Deterministic` — shuffles 12 equal-size groups two ways, asserts identical bin output. Covers the initial sort.
- `TestMergeUnderfilledBins_Deterministic` — calls `mergeUnderfilledBins` directly with 5 hand-crafted underfilled bins (3-way tie at 25%, 2-way tie at 50%), asserts identical output across two input permutations. Exercises both the outer sort tiebreaker and the inner re-sort tiebreaker.
- Existing `TestBinPack`, `TestFindBestFitBin`, `TestMergeUnderfilledBins`, planner tests — all pass unchanged.

### Verification

```
go test ./pkg/dataobj/compaction/... -count=1 -race        # PASS (1.4s)
golangci-lint run --new-from-rev main ./pkg/dataobj/compaction/...  # 0 issues
```

## No external behavior change

Pure refactor + sort-key strengthening. Same source ToCs produce the same compaction plans — now also stable across re-runs.