### PR TITLE
feat(dataobj-compactor): Add compactor target skeleton, no-op coordinator stub

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1605,6 +1605,28 @@ dataobj:
     # CLI flag: -dataobj-metastore.partition-ratio
     [partition_ratio: <int> | default = 10]
 
+  compaction:
+    # Experimental: Enable the dataobj compactor target.
+    # CLI flag: -dataobj.compaction.enabled
+    [enabled: <boolean> | default = false]
+
+    # Experimental: Per-workflow cap on concurrent CompactionMerge tasks.
+    # Currently unused; reserved for the engine scheduler's compaction admission
+    # lane added in a follow-up change.
+    # CLI flag: -dataobj.compaction.max-running-compaction-tasks
+    [max_running_compaction_tasks: <int> | default = 16]
+
+    scheduler:
+      # Experimental: host:port the embedded compaction scheduler advertises to
+      # compaction workers. Empty string keeps the scheduler in-process-only.
+      # CLI flag: -dataobj.compaction.scheduler.advertise-addr
+      [advertise_addr: <string> | default = ""]
+
+      # Experimental: HTTP path the embedded compaction scheduler listens on for
+      # worker frame traffic.
+      # CLI flag: -dataobj.compaction.scheduler.endpoint
+      [endpoint: <string> | default = "/api/v2/compaction-frame"]
+
   # The prefix to use for the storage bucket.
   # CLI flag: -dataobj-storage-bucket-prefix
   [storage_bucket_prefix: <string> | default = "dataobj/"]

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1606,7 +1606,7 @@ dataobj:
     [partition_ratio: <int> | default = 10]
 
   compaction:
-    # Experimental: Enable the dataobj compactor target.
+    # Experimental: Enable the dataobj compaction planner target.
     # CLI flag: -dataobj.compaction.enabled
     [enabled: <boolean> | default = false]
 

--- a/pkg/dataobj/config/config.go
+++ b/pkg/dataobj/config/config.go
@@ -13,7 +13,7 @@ type Config struct {
 	Consumer  consumer.Config  `yaml:"consumer"`
 	Index     index.Config     `yaml:"index"`
 	Metastore metastore.Config `yaml:"metastore"`
-	// Compaction is the dataobj-compactor target's configuration.
+	// Compaction is the dataobj-compaction-planner target's configuration.
 	// Disabled by default; setting Compaction.Enabled = true in addition
 	// to the top-level Enabled flag opts the deployment in.
 	Compaction compactor.Config `yaml:"compaction"`

--- a/pkg/dataobj/config/config.go
+++ b/pkg/dataobj/config/config.go
@@ -6,12 +6,17 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer"
 	"github.com/grafana/loki/v3/pkg/dataobj/index"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/engine/compactor"
 )
 
 type Config struct {
 	Consumer  consumer.Config  `yaml:"consumer"`
 	Index     index.Config     `yaml:"index"`
 	Metastore metastore.Config `yaml:"metastore"`
+	// Compaction is the dataobj-compactor target's configuration.
+	// Disabled by default; setting Compaction.Enabled = true in addition
+	// to the top-level Enabled flag opts the deployment in.
+	Compaction compactor.Config `yaml:"compaction"`
 	// StorageBucketPrefix is the prefix to use for the storage bucket.
 	StorageBucketPrefix string `yaml:"storage_bucket_prefix"`
 	Enabled             bool   `yaml:"enabled"`
@@ -21,6 +26,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.Consumer.RegisterFlags(f)
 	cfg.Index.RegisterFlags(f)
 	cfg.Metastore.RegisterFlags(f)
+	cfg.Compaction.RegisterFlags(f)
 	f.StringVar(
 		&cfg.StorageBucketPrefix,
 		"dataobj-storage-bucket-prefix",
@@ -47,6 +53,9 @@ func (cfg *Config) Validate() error {
 		return err
 	}
 	if err := cfg.Metastore.Validate(); err != nil {
+		return err
+	}
+	if err := cfg.Compaction.Validate(); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/engine/compactor/compactor.go
+++ b/pkg/engine/compactor/compactor.go
@@ -12,12 +12,12 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine"
 )
 
-// Compactor is the dataobj-compactor target service. It hosts an embedded
-// engine.Scheduler that compaction workers connect to, and (in a
-// follow-up change) a coordinator polling loop. This scaffold ships only
-// the lifecycle plumbing: the coordinator polling loop is a no-op stub
-// that blocks until shutdown.
-type Compactor struct {
+// Planner is the dataobj-compaction-planner target service. It hosts an
+// embedded engine.Scheduler that compaction workers connect to, and (in
+// a follow-up change) a coordinator polling loop. This scaffold ships
+// only the lifecycle plumbing: the coordinator polling loop is a no-op
+// stub that blocks until shutdown.
+type Planner struct {
 	*services.BasicService
 
 	cfg       Config
@@ -25,17 +25,17 @@ type Compactor struct {
 	scheduler *engine.Scheduler
 }
 
-// New constructs a Compactor. The scaffold takes no bucket dependency;
+// New constructs a compaction Planner. The scaffold takes no bucket dependency;
 // the coordinator loop that needs object-storage access is added in a
 // follow-up change.
-func New(cfg Config, logger log.Logger) (*Compactor, error) {
+func New(cfg Config, logger log.Logger) (*Planner, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
 
 	advertiseAddr, err := resolveAdvertiseAddr(cfg.Scheduler.AdvertiseAddr)
 	if err != nil {
-		return nil, fmt.Errorf("dataobj compactor: resolve scheduler advertise address: %w", err)
+		return nil, fmt.Errorf("dataobj compaction planner: resolve scheduler advertise address: %w", err)
 	}
 
 	scheduler, err := engine.NewScheduler(engine.SchedulerParams{
@@ -44,10 +44,10 @@ func New(cfg Config, logger log.Logger) (*Compactor, error) {
 		Endpoint:      cfg.Scheduler.Endpoint,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("dataobj compactor: construct scheduler: %w", err)
+		return nil, fmt.Errorf("dataobj compaction planner: construct scheduler: %w", err)
 	}
 
-	c := &Compactor{
+	c := &Planner{
 		cfg:       cfg,
 		logger:    logger,
 		scheduler: scheduler,
@@ -60,20 +60,20 @@ func New(cfg Config, logger log.Logger) (*Compactor, error) {
 // module-init wiring to register the scheduler's HTTP handler on the
 // Loki router (when running in remote-transport mode) and to register
 // scheduler metrics.
-func (c *Compactor) Scheduler() *engine.Scheduler {
+func (c *Planner) Scheduler() *engine.Scheduler {
 	return c.scheduler
 }
 
 // starting is the BasicService starting callback. It brings the embedded
 // scheduler service up.
-func (c *Compactor) starting(ctx context.Context) error {
+func (c *Planner) starting(ctx context.Context) error {
 	level.Info(c.logger).Log(
-		"msg", "starting dataobj compactor",
+		"msg", "starting dataobj compaction planner",
 		"scheduler_endpoint", c.cfg.Scheduler.Endpoint,
 	)
 
 	if err := services.StartAndAwaitRunning(ctx, c.scheduler.Service()); err != nil {
-		return fmt.Errorf("dataobj compactor: start scheduler service: %w", err)
+		return fmt.Errorf("dataobj compaction planner: start scheduler service: %w", err)
 	}
 	return nil
 }
@@ -81,8 +81,8 @@ func (c *Compactor) starting(ctx context.Context) error {
 // running is the BasicService running callback. The coordinator polling
 // loop is a no-op stub in this scaffold; it simply blocks until shutdown
 // so the service stays healthy.
-func (c *Compactor) running(ctx context.Context) error {
-	level.Info(c.logger).Log("msg", "dataobj compactor running")
+func (c *Planner) running(ctx context.Context) error {
+	level.Info(c.logger).Log("msg", "dataobj compaction planner running")
 	<-ctx.Done()
 	return nil
 }
@@ -90,9 +90,9 @@ func (c *Compactor) running(ctx context.Context) error {
 // stopping is the BasicService stopping callback. It tears down the
 // embedded scheduler service. The error parameter is the reason the
 // service is shutting down; it is logged but does not gate cleanup.
-func (c *Compactor) stopping(runErr error) error {
+func (c *Planner) stopping(runErr error) error {
 	if runErr != nil {
-		level.Warn(c.logger).Log("msg", "dataobj compactor stopping after run error", "err", runErr)
+		level.Warn(c.logger).Log("msg", "dataobj compaction planner stopping after run error", "err", runErr)
 	}
 	// TODO: the dskit stopping() callback signature doesn't accept a
 	// context, so we use Background(). Once the coordinator polling loop
@@ -101,7 +101,7 @@ func (c *Compactor) stopping(runErr error) error {
 	// can't wedge Loki shutdown indefinitely.
 	if err := services.StopAndAwaitTerminated(context.Background(), c.scheduler.Service()); err != nil {
 		level.Warn(c.logger).Log("msg", "stop dataobj compaction scheduler", "err", err)
-		return fmt.Errorf("dataobj compactor: stop scheduler: %w", err)
+		return fmt.Errorf("dataobj compaction planner: stop scheduler: %w", err)
 	}
 	return nil
 }

--- a/pkg/engine/compactor/compactor.go
+++ b/pkg/engine/compactor/compactor.go
@@ -1,0 +1,116 @@
+package compactor
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/services"
+
+	"github.com/grafana/loki/v3/pkg/engine"
+)
+
+// Compactor is the dataobj-compactor target service. It hosts an embedded
+// engine.Scheduler that compaction workers connect to, and (in a
+// follow-up change) a coordinator polling loop. This scaffold ships only
+// the lifecycle plumbing: the coordinator polling loop is a no-op stub
+// that blocks until shutdown.
+type Compactor struct {
+	*services.BasicService
+
+	cfg       Config
+	logger    log.Logger
+	scheduler *engine.Scheduler
+}
+
+// New constructs a Compactor. The scaffold takes no bucket dependency;
+// the coordinator loop that needs object-storage access is added in a
+// follow-up change.
+func New(cfg Config, logger log.Logger) (*Compactor, error) {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+
+	advertiseAddr, err := resolveAdvertiseAddr(cfg.Scheduler.AdvertiseAddr)
+	if err != nil {
+		return nil, fmt.Errorf("dataobj compactor: resolve scheduler advertise address: %w", err)
+	}
+
+	scheduler, err := engine.NewScheduler(engine.SchedulerParams{
+		Logger:        log.With(logger, "component", "dataobj-compaction-scheduler"),
+		AdvertiseAddr: advertiseAddr,
+		Endpoint:      cfg.Scheduler.Endpoint,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("dataobj compactor: construct scheduler: %w", err)
+	}
+
+	c := &Compactor{
+		cfg:       cfg,
+		logger:    logger,
+		scheduler: scheduler,
+	}
+	c.BasicService = services.NewBasicService(c.starting, c.running, c.stopping)
+	return c, nil
+}
+
+// Scheduler returns the embedded engine.Scheduler. Used by the Loki
+// module-init wiring to register the scheduler's HTTP handler on the
+// Loki router (when running in remote-transport mode) and to register
+// scheduler metrics.
+func (c *Compactor) Scheduler() *engine.Scheduler {
+	return c.scheduler
+}
+
+// starting is the BasicService starting callback. It brings the embedded
+// scheduler service up.
+func (c *Compactor) starting(ctx context.Context) error {
+	level.Info(c.logger).Log(
+		"msg", "starting dataobj compactor",
+		"scheduler_endpoint", c.cfg.Scheduler.Endpoint,
+	)
+
+	if err := services.StartAndAwaitRunning(ctx, c.scheduler.Service()); err != nil {
+		return fmt.Errorf("dataobj compactor: start scheduler service: %w", err)
+	}
+	return nil
+}
+
+// running is the BasicService running callback. The coordinator polling
+// loop is a no-op stub in this scaffold; it simply blocks until shutdown
+// so the service stays healthy.
+func (c *Compactor) running(ctx context.Context) error {
+	level.Info(c.logger).Log("msg", "dataobj compactor running")
+	<-ctx.Done()
+	return nil
+}
+
+// stopping is the BasicService stopping callback. It tears down the
+// embedded scheduler service. The error parameter is the reason the
+// service is shutting down; it is logged but does not gate cleanup.
+func (c *Compactor) stopping(runErr error) error {
+	if runErr != nil {
+		level.Warn(c.logger).Log("msg", "dataobj compactor stopping after run error", "err", runErr)
+	}
+	if err := services.StopAndAwaitTerminated(context.Background(), c.scheduler.Service()); err != nil {
+		level.Warn(c.logger).Log("msg", "stop dataobj compaction scheduler", "err", err)
+		return fmt.Errorf("dataobj compactor: stop scheduler: %w", err)
+	}
+	return nil
+}
+
+// resolveAdvertiseAddr converts the raw config string into a *net.TCPAddr
+// suitable for engine.SchedulerParams.AdvertiseAddr. Empty string keeps
+// the scheduler in-process-only (no remote listener) by returning nil.
+func resolveAdvertiseAddr(raw string) (net.Addr, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	addr, err := net.ResolveTCPAddr("tcp", raw)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %q: %w", raw, err)
+	}
+	return addr, nil
+}

--- a/pkg/engine/compactor/compactor.go
+++ b/pkg/engine/compactor/compactor.go
@@ -94,6 +94,11 @@ func (c *Compactor) stopping(runErr error) error {
 	if runErr != nil {
 		level.Warn(c.logger).Log("msg", "dataobj compactor stopping after run error", "err", runErr)
 	}
+	// TODO: the dskit stopping() callback signature doesn't accept a
+	// context, so we use Background(). Once the coordinator polling loop
+	// is doing real work, revisit adding an upper bound (e.g., a derived
+	// context with a configurable shutdown deadline) so a stuck scheduler
+	// can't wedge Loki shutdown indefinitely.
 	if err := services.StopAndAwaitTerminated(context.Background(), c.scheduler.Service()); err != nil {
 		level.Warn(c.logger).Log("msg", "stop dataobj compaction scheduler", "err", err)
 		return fmt.Errorf("dataobj compactor: stop scheduler: %w", err)

--- a/pkg/engine/compactor/compactor_test.go
+++ b/pkg/engine/compactor/compactor_test.go
@@ -17,7 +17,7 @@ import (
 func TestCompactor_BootShutdown(t *testing.T) {
 	cfg := Config{
 		Enabled: true,
-		Scheduler: CompactorConfig{
+		Scheduler: SchedulerConfig{
 			Endpoint: defaultEndpoint,
 			// AdvertiseAddr left empty -> scheduler runs in-process only.
 		},
@@ -55,7 +55,7 @@ func TestConfig_Validate_EnabledRejectsBadValues(t *testing.T) {
 		cfg := Config{
 			Enabled:                   true,
 			MaxRunningCompactionTasks: -1,
-			Scheduler:                 CompactorConfig{Endpoint: defaultEndpoint},
+			Scheduler:                 SchedulerConfig{Endpoint: defaultEndpoint},
 		}
 		err := cfg.Validate()
 		require.Error(t, err)
@@ -65,7 +65,7 @@ func TestConfig_Validate_EnabledRejectsBadValues(t *testing.T) {
 	t.Run("empty scheduler endpoint", func(t *testing.T) {
 		cfg := Config{
 			Enabled:   true,
-			Scheduler: CompactorConfig{Endpoint: ""},
+			Scheduler: SchedulerConfig{Endpoint: ""},
 		}
 		err := cfg.Validate()
 		require.Error(t, err)
@@ -76,7 +76,7 @@ func TestConfig_Validate_EnabledRejectsBadValues(t *testing.T) {
 		cfg := Config{
 			Enabled:                   true,
 			MaxRunningCompactionTasks: 16,
-			Scheduler:                 CompactorConfig{Endpoint: defaultEndpoint},
+			Scheduler:                 SchedulerConfig{Endpoint: defaultEndpoint},
 		}
 		require.NoError(t, cfg.Validate())
 	})

--- a/pkg/engine/compactor/compactor_test.go
+++ b/pkg/engine/compactor/compactor_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCompactor_BootShutdown boots the scaffold with an in-process-only
+// TestPlanner_BootShutdown boots the scaffold with an in-process-only
 // scheduler (empty AdvertiseAddr), waits for it to reach Running, then
 // stops it. It must transition cleanly with no error.
-func TestCompactor_BootShutdown(t *testing.T) {
+func TestPlanner_BootShutdown(t *testing.T) {
 	cfg := Config{
 		Enabled: true,
 		Scheduler: SchedulerConfig{
@@ -49,7 +49,8 @@ func TestConfig_Validate_DisabledIsNoop(t *testing.T) {
 }
 
 // TestConfig_Validate_EnabledRejectsBadValues captures the validation
-// surface that gets exercised when the operator turns the compactor on.
+// surface that gets exercised when the operator turns the compaction
+// planner on.
 func TestConfig_Validate_EnabledRejectsBadValues(t *testing.T) {
 	t.Run("negative max_running_compaction_tasks", func(t *testing.T) {
 		cfg := Config{

--- a/pkg/engine/compactor/compactor_test.go
+++ b/pkg/engine/compactor/compactor_test.go
@@ -1,0 +1,83 @@
+package compactor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/services"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCompactor_BootShutdown boots the scaffold with an in-process-only
+// scheduler (empty AdvertiseAddr), waits for it to reach Running, then
+// stops it. It must transition cleanly with no error.
+func TestCompactor_BootShutdown(t *testing.T) {
+	cfg := Config{
+		Enabled: true,
+		Scheduler: CompactorConfig{
+			Endpoint: defaultEndpoint,
+			// AdvertiseAddr left empty -> scheduler runs in-process only.
+		},
+	}
+
+	c, err := New(cfg, log.NewNopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, c.Scheduler(), "scheduler must be constructed")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, c))
+	require.Equal(t, services.Running, c.State())
+
+	require.NoError(t, services.StopAndAwaitTerminated(ctx, c))
+	require.Equal(t, services.Terminated, c.State())
+}
+
+// TestConfig_Validate_DisabledIsNoop captures the default-behaviour
+// invariant: a Config with Enabled=false validates regardless of any
+// other fields (including ones that would be invalid when enabled).
+func TestConfig_Validate_DisabledIsNoop(t *testing.T) {
+	cfg := Config{
+		Enabled:                   false,
+		MaxRunningCompactionTasks: -1, // would fail when enabled
+	}
+	require.NoError(t, cfg.Validate())
+}
+
+// TestConfig_Validate_EnabledRejectsBadValues captures the validation
+// surface that gets exercised when the operator turns the compactor on.
+func TestConfig_Validate_EnabledRejectsBadValues(t *testing.T) {
+	t.Run("negative max_running_compaction_tasks", func(t *testing.T) {
+		cfg := Config{
+			Enabled:                   true,
+			MaxRunningCompactionTasks: -1,
+			Scheduler:                 CompactorConfig{Endpoint: defaultEndpoint},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.ErrorIs(t, err, errInvalidMaxRunningCompactionTasks)
+	})
+
+	t.Run("empty scheduler endpoint", func(t *testing.T) {
+		cfg := Config{
+			Enabled:   true,
+			Scheduler: CompactorConfig{Endpoint: ""},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, errEmptySchedulerEndpoint))
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		cfg := Config{
+			Enabled:                   true,
+			MaxRunningCompactionTasks: 16,
+			Scheduler:                 CompactorConfig{Endpoint: defaultEndpoint},
+		}
+		require.NoError(t, cfg.Validate())
+	})
+}

--- a/pkg/engine/compactor/compactor_test.go
+++ b/pkg/engine/compactor/compactor_test.go
@@ -81,3 +81,20 @@ func TestConfig_Validate_EnabledRejectsBadValues(t *testing.T) {
 		require.NoError(t, cfg.Validate())
 	})
 }
+
+// TestNew_InvalidAdvertiseAddr exercises the constructor error path
+// when an unparseable advertise address is supplied. Pins the error
+// wrapping in resolveAdvertiseAddr.
+func TestNew_InvalidAdvertiseAddr(t *testing.T) {
+	cfg := Config{
+		Enabled: true,
+		Scheduler: SchedulerConfig{
+			AdvertiseAddr: "not-a-valid-host:port:::",
+			Endpoint:      defaultEndpoint,
+		},
+	}
+	_, err := New(cfg, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "resolve scheduler advertise address",
+		"error must mention the resolution step for operator clarity, got: %v", err)
+}

--- a/pkg/engine/compactor/config.go
+++ b/pkg/engine/compactor/config.go
@@ -1,0 +1,102 @@
+// Package compactor contains the data-object compactor service skeleton.
+//
+// The compactor is opt-in: it runs only when started with
+// -target=dataobj-compactor AND the dataobj.enabled and
+// dataobj.compaction.enabled config flags are both true. The default
+// configuration leaves both gates off; nothing in this package runs in
+// the default Loki binary.
+//
+// This file is the scaffold for the dataobj compactor. The real coordinator
+// polling loop, marker management, planner integration, and physical-plan
+// node types are added in subsequent changes.
+package compactor
+
+import (
+	"errors"
+	"flag"
+)
+
+// Config is the top-level configuration for the dataobj compactor target.
+// A follow-up commit wires it into the dataobj config tree at
+// pkg/dataobj/config/config.go as the `compaction` field.
+type Config struct {
+	// Enabled toggles the compactor. When false, the dataobj-compactor
+	// module is a no-op even if the target is selected.
+	Enabled bool `yaml:"enabled"`
+
+	// MaxRunningCompactionTasks caps how many CompactionMerge tasks a
+	// single workflow may run concurrently within the engine scheduler's
+	// compaction admission lane. Currently unused; reserved for the engine
+	// scheduler's compaction admission lane added in a follow-up change.
+	MaxRunningCompactionTasks int `yaml:"max_running_compaction_tasks"`
+
+	// Scheduler holds the scheduler-side knobs: advertise_addr and
+	// endpoint for the embedded engine.Scheduler instance. See
+	// pkg/engine/scheduler.go for the underlying SchedulerParams.
+	Scheduler CompactorConfig `yaml:"scheduler"`
+}
+
+// CompactorConfig holds the scheduler-side parameters that get passed
+// to engine.NewScheduler when the compactor target boots.
+type CompactorConfig struct {
+	// AdvertiseAddr is the host:port the embedded scheduler advertises to
+	// remote workers. Empty string keeps the scheduler in-process-only
+	// (no HTTP listener registered).
+	AdvertiseAddr string `yaml:"advertise_addr"`
+
+	// Endpoint is the absolute path on the Loki HTTP router where the
+	// embedded scheduler listens for worker frame traffic. Defaults to
+	// "/api/v2/compaction-frame" so it never collides with the
+	// query-engine scheduler at "/api/v2/frame".
+	Endpoint string `yaml:"endpoint"`
+}
+
+// Default values intentionally chosen conservative for the scaffold; the
+// real values get tuned alongside the coordinator in a follow-up change.
+const (
+	defaultMaxRunningCompactionTasks = 16
+	defaultEndpoint                  = "/api/v2/compaction-frame"
+)
+
+// RegisterFlags registers the compaction config flags under the given
+// prefix.
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	cfg.RegisterFlagsWithPrefix("dataobj.compaction.", f)
+}
+
+// RegisterFlagsWithPrefix registers the compaction config flags using
+// prefix as the flag-name prefix.
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.BoolVar(&cfg.Enabled, prefix+"enabled", false,
+		"Experimental: Enable the dataobj compactor target.")
+	f.IntVar(&cfg.MaxRunningCompactionTasks, prefix+"max-running-compaction-tasks",
+		defaultMaxRunningCompactionTasks,
+		"Experimental: Per-workflow cap on concurrent CompactionMerge tasks. Currently unused; reserved for the engine scheduler's compaction admission lane added in a follow-up change.")
+	f.StringVar(&cfg.Scheduler.AdvertiseAddr, prefix+"scheduler.advertise-addr", "",
+		"Experimental: host:port the embedded compaction scheduler advertises to compaction workers. Empty string keeps the scheduler in-process-only.")
+	f.StringVar(&cfg.Scheduler.Endpoint, prefix+"scheduler.endpoint", defaultEndpoint,
+		"Experimental: HTTP path the embedded compaction scheduler listens on for worker frame traffic.")
+}
+
+// Validate returns nil while the compactor is disabled. When enabled it
+// performs basic shape checks; deeper validation lands alongside the real
+// coordinator in a follow-up change.
+func (cfg *Config) Validate() error {
+	if !cfg.Enabled {
+		return nil
+	}
+	if cfg.MaxRunningCompactionTasks < 0 {
+		return errInvalidMaxRunningCompactionTasks
+	}
+	if cfg.Scheduler.Endpoint == "" {
+		return errEmptySchedulerEndpoint
+	}
+	return nil
+}
+
+// Sentinel validation errors. Kept at package scope so tests can match
+// them with errors.Is.
+var (
+	errInvalidMaxRunningCompactionTasks = errors.New("dataobj.compaction.max_running_compaction_tasks must be >= 0")
+	errEmptySchedulerEndpoint           = errors.New("dataobj.compaction.scheduler.endpoint must not be empty when compaction is enabled")
+)

--- a/pkg/engine/compactor/config.go
+++ b/pkg/engine/compactor/config.go
@@ -1,12 +1,14 @@
-// Package compactor contains the data-object compactor service skeleton.
+// Package compactor contains the dataobj compaction planner service
+// skeleton. The planner is one role in the broader dataobj compaction
+// system; the worker target is added in a follow-up change.
 //
-// The compactor is opt-in: it runs only when started with
-// -target=dataobj-compactor AND the dataobj.enabled and
+// The compaction planner is opt-in: it runs only when started with
+// -target=dataobj-compaction-planner AND the dataobj.enabled and
 // dataobj.compaction.enabled config flags are both true. The default
 // configuration leaves both gates off; nothing in this package runs in
 // the default Loki binary.
 //
-// This file is the scaffold for the dataobj compactor. The real coordinator
+// This file is the scaffold for the compaction planner. The real coordinator
 // polling loop, marker management, planner integration, and physical-plan
 // node types are added in subsequent changes.
 package compactor
@@ -16,12 +18,14 @@ import (
 	"flag"
 )
 
-// Config is the top-level configuration for the dataobj compactor target.
+// Config is the top-level configuration for the dataobj compaction
+// planner target.
 // A follow-up commit wires it into the dataobj config tree at
 // pkg/dataobj/config/config.go as the `compaction` field.
 type Config struct {
-	// Enabled toggles the compactor. When false, the dataobj-compactor
-	// module is a no-op even if the target is selected.
+	// Enabled toggles the compaction planner. When false, the
+	// dataobj-compaction-planner module is a no-op even if the target is
+	// selected.
 	Enabled bool `yaml:"enabled"`
 
 	// MaxRunningCompactionTasks caps how many CompactionMerge tasks a
@@ -40,7 +44,7 @@ type Config struct {
 }
 
 // SchedulerConfig holds the scheduler-side parameters that get passed
-// to engine.NewScheduler when the compactor target boots.
+// to engine.NewScheduler when the compaction planner target boots.
 type SchedulerConfig struct {
 	// AdvertiseAddr is the host:port the embedded scheduler advertises to
 	// remote workers. Empty string keeps the scheduler in-process-only
@@ -71,7 +75,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 // prefix as the flag-name prefix.
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&cfg.Enabled, prefix+"enabled", false,
-		"Experimental: Enable the dataobj compactor target.")
+		"Experimental: Enable the dataobj compaction planner target.")
 	f.IntVar(&cfg.MaxRunningCompactionTasks, prefix+"max-running-compaction-tasks",
 		defaultMaxRunningCompactionTasks,
 		"Experimental: Per-workflow cap on concurrent CompactionMerge tasks. Currently unused; reserved for the engine scheduler's compaction admission lane added in a follow-up change.")
@@ -81,7 +85,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 		"Experimental: HTTP path the embedded compaction scheduler listens on for worker frame traffic.")
 }
 
-// Validate returns nil while the compactor is disabled. When enabled it
+// Validate returns nil while the compaction planner is disabled. When enabled it
 // performs basic shape checks; deeper validation lands alongside the real
 // coordinator in a follow-up change.
 func (cfg *Config) Validate() error {

--- a/pkg/engine/compactor/config.go
+++ b/pkg/engine/compactor/config.go
@@ -26,8 +26,11 @@ type Config struct {
 
 	// MaxRunningCompactionTasks caps how many CompactionMerge tasks a
 	// single workflow may run concurrently within the engine scheduler's
-	// compaction admission lane. Currently unused; reserved for the engine
-	// scheduler's compaction admission lane added in a follow-up change.
+	// taskTypeCompaction admission lane. Currently unused; reserved for
+	// the engine scheduler's compaction admission lane added in a
+	// follow-up change. The semantic of zero (unlimited vs. blocked) is
+	// intentionally undefined at scaffold time; the follow-up change that
+	// consumes this field will define and document it.
 	MaxRunningCompactionTasks int `yaml:"max_running_compaction_tasks"`
 
 	// Scheduler holds the scheduler-side knobs: advertise_addr and

--- a/pkg/engine/compactor/config.go
+++ b/pkg/engine/compactor/config.go
@@ -33,12 +33,12 @@ type Config struct {
 	// Scheduler holds the scheduler-side knobs: advertise_addr and
 	// endpoint for the embedded engine.Scheduler instance. See
 	// pkg/engine/scheduler.go for the underlying SchedulerParams.
-	Scheduler CompactorConfig `yaml:"scheduler"`
+	Scheduler SchedulerConfig `yaml:"scheduler"`
 }
 
-// CompactorConfig holds the scheduler-side parameters that get passed
+// SchedulerConfig holds the scheduler-side parameters that get passed
 // to engine.NewScheduler when the compactor target boots.
-type CompactorConfig struct {
+type SchedulerConfig struct {
 	// AdvertiseAddr is the host:port the embedded scheduler advertises to
 	// remote workers. Empty string keeps the scheduler in-process-only
 	// (no HTTP listener registered).

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -41,6 +41,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/distributor"
 	"github.com/grafana/loki/v3/pkg/engine"
+	enginecompactor "github.com/grafana/loki/v3/pkg/engine/compactor"
 	"github.com/grafana/loki/v3/pkg/indexgateway"
 	"github.com/grafana/loki/v3/pkg/ingester"
 	ingester_client "github.com/grafana/loki/v3/pkg/ingester/client"
@@ -446,6 +447,7 @@ type Loki struct {
 	dataObjConsumerPartitionRing        *ring.PartitionInstanceRing
 	DataObjConsumerPartitionRingWatcher *ring.PartitionRingWatcher
 	dataObjIndexBuilder                 *dataobjindex.Builder
+	dataObjCompactor                    *enginecompactor.Compactor
 	scratchStore                        scratch.Store
 	queryEngineV2                       *engine.Engine
 	queryEngineV2Scheduler              *engine.Scheduler
@@ -805,6 +807,7 @@ func (t *Loki) setupModuleManager() error {
 	mm.RegisterModule(DataObjConsumerPartitionRing, t.initDataObjConsumerPartitionRing)
 	mm.RegisterModule(DataObjConsumer, t.initDataObjConsumer)
 	mm.RegisterModule(DataObjIndexBuilder, t.initDataObjIndexBuilder)
+	mm.RegisterModule(DataObjCompactor, t.initDataObjCompactor)
 	mm.RegisterModule(ScratchStore, t.initScratchStore)
 
 	mm.RegisterModule(All, nil)
@@ -856,6 +859,7 @@ func (t *Loki) setupModuleManager() error {
 		DataObjConsumerPartitionRing: {MemberlistKV, Server, Ring},
 		DataObjConsumer:              {MemberlistKV, ScratchStore, PartitionRing, Server, UI},
 		DataObjIndexBuilder:          {ScratchStore, Server, UIRing},
+		DataObjCompactor:             {Server, UIRing},
 		ScratchStore:                 {},
 
 		Read:    {QueryFrontend, Querier},

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -447,7 +447,7 @@ type Loki struct {
 	dataObjConsumerPartitionRing        *ring.PartitionInstanceRing
 	DataObjConsumerPartitionRingWatcher *ring.PartitionRingWatcher
 	dataObjIndexBuilder                 *dataobjindex.Builder
-	dataObjCompactor                    *enginecompactor.Compactor
+	dataObjCompactionPlanner            *enginecompactor.Planner
 	scratchStore                        scratch.Store
 	queryEngineV2                       *engine.Engine
 	queryEngineV2Scheduler              *engine.Scheduler
@@ -807,7 +807,7 @@ func (t *Loki) setupModuleManager() error {
 	mm.RegisterModule(DataObjConsumerPartitionRing, t.initDataObjConsumerPartitionRing)
 	mm.RegisterModule(DataObjConsumer, t.initDataObjConsumer)
 	mm.RegisterModule(DataObjIndexBuilder, t.initDataObjIndexBuilder)
-	mm.RegisterModule(DataObjCompactor, t.initDataObjCompactor)
+	mm.RegisterModule(DataObjCompactionPlanner, t.initDataObjCompactionPlanner)
 	mm.RegisterModule(ScratchStore, t.initScratchStore)
 
 	mm.RegisterModule(All, nil)
@@ -859,7 +859,7 @@ func (t *Loki) setupModuleManager() error {
 		DataObjConsumerPartitionRing: {MemberlistKV, Server, Ring},
 		DataObjConsumer:              {MemberlistKV, ScratchStore, PartitionRing, Server, UI},
 		DataObjIndexBuilder:          {ScratchStore, Server, UIRing},
-		DataObjCompactor:             {Server, UIRing},
+		DataObjCompactionPlanner:     {Server, UIRing},
 		ScratchStore:                 {},
 
 		Read:    {QueryFrontend, Querier},

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -2488,6 +2488,15 @@ func (t *Loki) initDataObjCompactor() (services.Service, error) {
 		return nil, nil
 	}
 
+	// Defense-in-depth: the top-level Config.Validate() gate is wrapped
+	// inside an `if c.Ingester.KafkaIngestion.Enabled` check, so a
+	// compactor-only deployment (no Kafka ingestion) skips compaction
+	// config validation entirely. Validate explicitly here so invalid
+	// values are caught before service construction.
+	if err := t.Cfg.DataObj.Compaction.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid dataobj compaction config: %w", err)
+	}
+
 	logger := log.With(util_log.Logger, "component", "dataobj-compactor")
 
 	c, err := enginecompactor.New(t.Cfg.DataObj.Compaction, logger)
@@ -2513,6 +2522,12 @@ func (t *Loki) initDataObjCompactor() (services.Service, error) {
 		c.Scheduler().RegisterSchedulerServer(t.Server.HTTP)
 	}
 
+	// Return the Compactor wrapper rather than c.Scheduler().Service():
+	// the wrapper's BasicService runs the coordinator polling loop in
+	// running() (a no-op stub today; real loop arrives in a follow-up
+	// change). Mirroring initV2QueryEngineScheduler's pattern of
+	// returning the inner service directly would prevent the
+	// coordinator loop from ever running.
 	t.dataObjCompactor = c
 	return c, nil
 }

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -155,7 +155,7 @@ const (
 	DataObjConsumerRing          = "dataobj-consumer-ring"
 	DataObjConsumerPartitionRing = "dataobj-consumer-partition-ring"
 	DataObjIndexBuilder          = "dataobj-index-builder"
-	DataObjCompactor             = "dataobj-compactor"
+	DataObjCompactionPlanner     = "dataobj-compaction-planner"
 	ScratchStore                 = "scratch-store"
 	UIRing                       = "ui-ring"
 	UI                           = "ui"
@@ -2480,24 +2480,16 @@ func (t *Loki) initDataObjIndexBuilder() (services.Service, error) {
 	return t.dataObjIndexBuilder, err
 }
 
-func (t *Loki) initDataObjCompactor() (services.Service, error) {
+func (t *Loki) initDataObjCompactionPlanner() (services.Service, error) {
 	if !t.Cfg.DataObj.Enabled || !t.Cfg.DataObj.Compaction.Enabled {
-		// Default config keeps both gates off; the dataobj-compactor
-		// target is fully opt-in. Returning nil, nil makes this a no-op
-		// module - Loki initializes nothing and starts no goroutines.
 		return nil, nil
 	}
 
-	// Defense-in-depth: the top-level Config.Validate() gate is wrapped
-	// inside an `if c.Ingester.KafkaIngestion.Enabled` check, so a
-	// compactor-only deployment (no Kafka ingestion) skips compaction
-	// config validation entirely. Validate explicitly here so invalid
-	// values are caught before service construction.
 	if err := t.Cfg.DataObj.Compaction.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid dataobj compaction config: %w", err)
 	}
 
-	logger := log.With(util_log.Logger, "component", "dataobj-compactor")
+	logger := log.With(util_log.Logger, "component", "dataobj-compaction-planner")
 
 	c, err := enginecompactor.New(t.Cfg.DataObj.Compaction, logger)
 	if err != nil {
@@ -2528,7 +2520,7 @@ func (t *Loki) initDataObjCompactor() (services.Service, error) {
 	// change). Mirroring initV2QueryEngineScheduler's pattern of
 	// returning the inner service directly would prevent the
 	// coordinator loop from ever running.
-	t.dataObjCompactor = c
+	t.dataObjCompactionPlanner = c
 	return c, nil
 }
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -53,6 +53,7 @@ import (
 	dataobjindex "github.com/grafana/loki/v3/pkg/dataobj/index"
 	"github.com/grafana/loki/v3/pkg/distributor"
 	engine_v2 "github.com/grafana/loki/v3/pkg/engine"
+	enginecompactor "github.com/grafana/loki/v3/pkg/engine/compactor"
 	"github.com/grafana/loki/v3/pkg/indexgateway"
 	"github.com/grafana/loki/v3/pkg/ingester"
 	"github.com/grafana/loki/v3/pkg/limits"
@@ -154,6 +155,7 @@ const (
 	DataObjConsumerRing          = "dataobj-consumer-ring"
 	DataObjConsumerPartitionRing = "dataobj-consumer-partition-ring"
 	DataObjIndexBuilder          = "dataobj-index-builder"
+	DataObjCompactor             = "dataobj-compactor"
 	ScratchStore                 = "scratch-store"
 	UIRing                       = "ui-ring"
 	UI                           = "ui"
@@ -2476,6 +2478,43 @@ func (t *Loki) initDataObjIndexBuilder() (services.Service, error) {
 	)
 
 	return t.dataObjIndexBuilder, err
+}
+
+func (t *Loki) initDataObjCompactor() (services.Service, error) {
+	if !t.Cfg.DataObj.Enabled || !t.Cfg.DataObj.Compaction.Enabled {
+		// Default config keeps both gates off; the dataobj-compactor
+		// target is fully opt-in. Returning nil, nil makes this a no-op
+		// module - Loki initializes nothing and starts no goroutines.
+		return nil, nil
+	}
+
+	logger := log.With(util_log.Logger, "component", "dataobj-compactor")
+
+	c, err := enginecompactor.New(t.Cfg.DataObj.Compaction, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	// Register scheduler metrics; mirror the query-engine-scheduler
+	// pattern so a clean shutdown unregisters them.
+	if err := c.Scheduler().RegisterMetrics(prometheus.DefaultRegisterer); err != nil {
+		return nil, err
+	}
+	c.Scheduler().Service().AddListener(services.NewListener(
+		nil, nil, nil,
+		func(_ services.State) { c.Scheduler().UnregisterMetrics(prometheus.DefaultRegisterer) },
+		func(_ services.State, _ error) { c.Scheduler().UnregisterMetrics(prometheus.DefaultRegisterer) },
+	))
+
+	// Only register the HTTP frame handler when the user provided an
+	// advertise address (i.e., remote-worker mode). In-process-only mode
+	// does not need a router registration.
+	if t.Cfg.DataObj.Compaction.Scheduler.AdvertiseAddr != "" {
+		c.Scheduler().RegisterSchedulerServer(t.Server.HTTP)
+	}
+
+	t.dataObjCompactor = c
+	return c, nil
 }
 
 func (t *Loki) initScratchStore() (services.Service, error) {


### PR DESCRIPTION
## Summary

**Scaffold only** — adds the new `dataobj-compaction-planner` Loki target as a `services.BasicService` skeleton with an embedded `engine.Scheduler`. The coordinator polling loop is a no-op stub; real compaction logic lands in subsequent PRs.

## What this PR does

- New package `pkg/engine/compactor/` declaring `package compactor`:
  - `Config` (top-level: `Enabled`, `MaxRunningCompactionTasks`, `Scheduler SchedulerConfig`) with flag registration + validation.
  - `SchedulerConfig` (scheduler-side params: `AdvertiseAddr`, `Endpoint`).
  - `Planner` service struct embedding `engine.Scheduler` via the public `engine.NewScheduler`.
  - Lifecycle: `starting()` brings the inner scheduler up; `running()` is a no-op stub blocking on `ctx.Done()`; `stopping()` shuts the scheduler down.
- `pkg/dataobj/config/config.go` gains `Compaction compactor.Config`, threaded through `RegisterFlags` and `Validate`.
- `pkg/loki/modules.go` + `pkg/loki/loki.go`:
  - `DataObjCompactionPlsnnrt` module-name constant and `initDataObjCompactionPlsnnrt` factory.
  - Module registered with `deps[DataObjCompactionPlanner] = {Server, UIRing}`.
  - **NOT** added to `deps[All]`, `deps[Read]`, `deps[Write]`, or `deps[Backend]`. Module is opt-in via `-target=dataobj-compactor`.

## Opt-in / default-behavior story

Three independent gates must align before any compactor code runs:
1. `-target=dataobj-compaction-planner` must be passed on the command line.
2. `dataobj.enabled: true` (defaults to `false`).
3. `dataobj.compaction.enabled: true` (defaults to `false`).

Verified live:
- `loki -target=all` emits **zero** dataobj-compactor log lines (module never initialized).
- `loki -target=dataobj-compaction-planner` with both gates set emits `starting dataobj compactor` / `dataobj compactor running` then shuts down cleanly.

## Test Plan

- [x] `make test` — passes (220 packages ok, 0 FAIL).
- [x] `make lint` — `pkg/engine/compactor/...` is clean (0 issues). Repo-wide there are 50 pre-existing `goconst` warnings in 30+ unrelated files (no overlap with this PR's touched files).
- [x] New unit tests in `pkg/engine/compactor/compactor_test.go`:
  - `TestCompactor_BootShutdown` — boots and stops cleanly with in-process-only scheduler.
  - `TestConfig_Validate_DisabledIsNoop` — default-off behavior preserved.
  - `TestConfig_Validate_EnabledRejectsBadValues` — sentinel-error symmetry via `errors.Is` (3 subtests).
  - `TestNew_InvalidAdvertiseAddr` — constructor error wrapping for invalid TCP address.
- [x] Compactor package statement coverage: **74.4 %**.
- [x] Live boot smoke: `loki -target=dataobj-compactor` with gates enabled shows the expected `starting dataobj compactor` → `dataobj compactor running` → `module stopped` sequence.
- [x] Live default-target smoke: `loki -target=all` with default config emits zero compactor log lines.
- [x] Per-task two-stage review (spec compliance + code quality) plus final multi-model `/code-review` over the full diff — all findings applied.

Notable choices:
- **Import alias `enginecompactor`** in `pkg/loki/{modules.go,loki.go}` — the existing `pkg/compactor` already owns the unqualified `compactor` identifier in both files.
- **`SchedulerConfig` (not `CompactorConfig`)** — the original name triggered a `revive` lint stutter (`compactor.CompactorConfig`); the renamed type is also more accurate (the struct holds scheduler-side params).
- **Defense-in-depth config validation** in `initDataObjCompactionPlanner` — the top-level `Config.Validate()` is wrapped in `if c.Ingester.KafkaIngestion.Enabled { ... }`, so a compactor-only deployment (no Kafka ingestion) would otherwise bypass compaction config validation entirely.

