### PR TITLE
chore(dataset/array): Add ZigZag encoding

### DIFF
--- a/pkg/dataset/array/codec.go
+++ b/pkg/dataset/array/codec.go
@@ -49,6 +49,8 @@ func NewWriter(alloc *memory.Allocator, spec Spec, typ types.Type) (Writer, erro
 		return newBitpackedWriter(alloc, spec, typ)
 	case EncodingKindZstd:
 		return newZstdWriter(alloc, spec, typ)
+	case EncodingKindZigZag:
+		return newZigZagWriter(alloc, spec, typ)
 
 	default:
 		return nil, fmt.Errorf("unsupported encoding kind %q", spec.Kind())
@@ -103,6 +105,8 @@ func NewReader(alloc *memory.Allocator, arr Array, source buffer.Source) (Reader
 		return newBitpackedReader(alloc, arr, source)
 	case EncodingKindZstd:
 		return newZstdReader(alloc, arr, source)
+	case EncodingKindZigZag:
+		return newZigZagReader(alloc, arr, source)
 
 	default:
 		return nil, fmt.Errorf("unsupported encoding kind %q", arr.Encoding.Kind())

--- a/pkg/dataset/array/codec_zigzag.go
+++ b/pkg/dataset/array/codec_zigzag.go
@@ -1,0 +1,183 @@
+package array
+
+import (
+	"context"
+	"fmt"
+	"unsafe"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+type signed interface{ int32 | int64 }
+
+type zigzagWriter[S signed, U unsigned] struct {
+	alloc      *memory.Allocator
+	typ        types.Type
+	dataWriter Writer
+}
+
+func newZigZagWriter(alloc *memory.Allocator, spec Spec, typ types.Type) (Writer, error) {
+	if got, want := spec.Kind(), EncodingKindZigZag; got != want {
+		return nil, fmt.Errorf("expected spec kind %s, got %s", want, got)
+	}
+
+	zzSpec := spec.(*SpecZigZag)
+	if zzSpec.Data == nil {
+		return nil, fmt.Errorf("zigzag spec must have a data spec")
+	}
+
+	switch typ := typ.(type) {
+	case *types.Int32:
+		return newZigZagWriterTyped[int32, uint32](alloc, zzSpec, typ, &types.Uint32{Nullable: typ.Nullable})
+	case *types.Int64:
+		return newZigZagWriterTyped[int64, uint64](alloc, zzSpec, typ, &types.Uint64{Nullable: typ.Nullable})
+	default:
+		return nil, fmt.Errorf("unsupported type %s for zigzag encoding", typ)
+	}
+}
+
+func newZigZagWriterTyped[S signed, U unsigned](alloc *memory.Allocator, spec *SpecZigZag, typ types.Type, unsignedTyp types.Type) (*zigzagWriter[S, U], error) {
+	dataWriter, err := NewWriter(alloc, spec.Data, unsignedTyp)
+	if err != nil {
+		return nil, fmt.Errorf("creating data writer: %w", err)
+	}
+
+	return &zigzagWriter[S, U]{
+		alloc:      alloc,
+		typ:        typ,
+		dataWriter: dataWriter,
+	}, nil
+}
+
+func (w *zigzagWriter[S, U]) Append(arr columnar.Array) error {
+	numArr, ok := arr.(*columnar.Number[S])
+	if !ok {
+		return fmt.Errorf("expected *columnar.Number[%T], got %T", *new(S), arr)
+	}
+
+	values := numArr.Values()
+
+	// Zigzag encode signed values into unsigned.
+	shortAlloc := memory.NewAllocator(w.alloc)
+	defer shortAlloc.Free()
+
+	encoded := memory.NewBuffer[U](shortAlloc, len(values))
+	encoded.Grow(len(values))
+	for _, v := range values {
+		encoded.Append(zigzagEncode[S, U](v))
+	}
+
+	return w.dataWriter.Append(columnar.NewNumber(encoded.Data(), numArr.Validity()))
+}
+
+func (w *zigzagWriter[S, U]) Flush(ctx context.Context, sink buffer.Sink) (Array, error) {
+	dataArray, err := w.dataWriter.Flush(ctx, sink)
+	if err != nil {
+		return Array{}, fmt.Errorf("flushing data writer: %w", err)
+	}
+
+	return Array{
+		Encoding: &EncodingZigZag{},
+		Type:     w.typ,
+		RowCount: dataArray.RowCount,
+		Stats:    dataArray.Stats,
+		Children: []Array{dataArray},
+	}, nil
+}
+
+type zigzagReader[S signed, U unsigned] struct {
+	alloc      *memory.Allocator
+	arr        Array
+	dataReader Reader
+}
+
+func newZigZagReader(alloc *memory.Allocator, arr Array, source buffer.Source) (Reader, error) {
+	if got, want := arr.Encoding.Kind(), EncodingKindZigZag; got != want {
+		return nil, fmt.Errorf("expected encoding kind %s, got %s", want, got)
+	}
+
+	if len(arr.Children) != 1 {
+		return nil, fmt.Errorf("expected 1 child for zigzag array, got %d", len(arr.Children))
+	}
+
+	switch arr.Type.(type) {
+	case *types.Int32:
+		return newZigZagReaderTyped[int32, uint32](alloc, arr, source)
+	case *types.Int64:
+		return newZigZagReaderTyped[int64, uint64](alloc, arr, source)
+	default:
+		return nil, fmt.Errorf("unsupported type %s for zigzag encoding", arr.Type)
+	}
+}
+
+func newZigZagReaderTyped[S signed, U unsigned](alloc *memory.Allocator, arr Array, source buffer.Source) (*zigzagReader[S, U], error) {
+	dataReader, err := NewReader(alloc, arr.Children[0], source)
+	if err != nil {
+		return nil, fmt.Errorf("creating data reader: %w", err)
+	}
+
+	return &zigzagReader[S, U]{
+		alloc:      alloc,
+		arr:        arr,
+		dataReader: dataReader,
+	}, nil
+}
+
+func (r *zigzagReader[S, U]) Read(ctx context.Context, alloc *memory.Allocator, count int) (columnar.Array, error) {
+	if count <= 0 {
+		return nil, fmt.Errorf("count must be positive, got %d", count)
+	}
+
+	// Read unsigned data with a short-lived allocator; the raw unsigned values
+	// don't survive past this call since we decode them into signed values.
+	shortAlloc := memory.NewAllocator(alloc)
+	defer shortAlloc.Free()
+
+	dataArr, err := r.dataReader.Read(ctx, shortAlloc, count)
+	if err != nil {
+		return nil, err
+	}
+
+	unsignedArr := dataArr.(*columnar.Number[U])
+	values := unsignedArr.Values()
+
+	// Zigzag decode unsigned values back to signed.
+	decoded := memory.NewBuffer[S](alloc, len(values))
+
+	data := decoded.Next(len(values))
+
+	// Assert length for BCE.
+	if len(data) != len(values) {
+		panic("decoded buffer length mismatch")
+	}
+	for i, v := range values {
+		data[i] = zigzagDecode[S, U](v)
+	}
+
+	// Validity must outlive this call, so clone it with the caller's allocator.
+	var validity memory.Bitmap
+	if v := unsignedArr.Validity(); v.Len() > 0 {
+		validity = *v.Clone(alloc)
+	}
+	return columnar.NewNumber(decoded.Data(), validity), nil
+}
+
+func (r *zigzagReader[S, U]) Reset() {
+	r.dataReader.Reset()
+}
+
+func (r *zigzagReader[S, U]) Close() error {
+	return r.dataReader.Close()
+}
+
+func zigzagEncode[S signed, U unsigned](v S) U {
+	shift := unsafe.Sizeof(v)*8 - 1
+	return U((v << 1) ^ (v >> shift))
+}
+
+func zigzagDecode[S signed, U unsigned](v U) S {
+	return S(v>>1) ^ -S(v&1)
+}

--- a/pkg/dataset/array/codec_zigzag_test.go
+++ b/pkg/dataset/array/codec_zigzag_test.go
@@ -1,0 +1,462 @@
+package array_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestZigZagCodec_Validation(t *testing.T) {
+	data := &array.SpecPlain{}
+
+	tt := []struct {
+		name string
+		spec array.Spec
+		typ  types.Type
+
+		expectError bool
+	}{
+		{
+			name:        "accepts non-nullable int32",
+			spec:        &array.SpecZigZag{Data: data},
+			typ:         &types.Int32{Nullable: false},
+			expectError: false,
+		},
+		{
+			name:        "accepts non-nullable int64",
+			spec:        &array.SpecZigZag{Data: data},
+			typ:         &types.Int64{Nullable: false},
+			expectError: false,
+		},
+		{
+			name:        "accepts nullable int64 with validity in data spec",
+			spec:        &array.SpecZigZag{Data: &array.SpecPlain{Validity: &array.SpecBool{}}},
+			typ:         &types.Int64{Nullable: true},
+			expectError: false,
+		},
+		{
+			name:        "rejects uint32",
+			spec:        &array.SpecZigZag{Data: data},
+			typ:         &types.Uint32{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects uint64",
+			spec:        &array.SpecZigZag{Data: data},
+			typ:         &types.Uint64{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects bool",
+			spec:        &array.SpecZigZag{Data: data},
+			typ:         &types.Bool{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects utf8",
+			spec:        &array.SpecZigZag{Data: data},
+			typ:         &types.UTF8{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects nil data spec",
+			spec:        &array.SpecZigZag{Data: nil},
+			typ:         &types.Int64{Nullable: false},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			var alloc memory.Allocator
+			_, err := array.NewWriter(&alloc, tc.spec, tc.typ)
+
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestZigZagCodec_NonNullable(t *testing.T) {
+	t.Run("int32", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+
+		var (
+			spec = &array.SpecZigZag{Data: &array.SpecPlain{}}
+			typ  = &types.Int32{Nullable: false}
+		)
+
+		w, err := array.NewWriter(&alloc, spec, typ)
+		require.NoError(t, err)
+
+		input := []columnar.Array{
+			columnartest.Array(t, types.KindInt32, &alloc, int32(-3), int32(-2), int32(-1), int32(0), int32(1)),
+			columnartest.Array(t, types.KindInt32, &alloc, int32(2), int32(3), int32(100), int32(-100)),
+		}
+		for _, arr := range input {
+			require.NoError(t, w.Append(arr))
+		}
+
+		result, err := w.Flush(t.Context(), &store)
+		require.NoError(t, err)
+		require.Equal(t, 9, result.RowCount)
+		require.Equal(t, 0, result.Stats.NullCount)
+
+		r, err := array.NewReader(&alloc, result, &store)
+		require.NoError(t, err)
+
+		expect := columnartest.Array(
+			t, types.KindInt32, &alloc,
+			int32(-3), int32(-2), int32(-1), int32(0), int32(1),
+			int32(2), int32(3), int32(100), int32(-100),
+		)
+
+		actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+		columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+
+		_, err = r.Read(t.Context(), &alloc, 1)
+		require.ErrorIs(t, err, io.EOF)
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+
+		var (
+			spec = &array.SpecZigZag{Data: &array.SpecPlain{}}
+			typ  = &types.Int64{Nullable: false}
+		)
+
+		w, err := array.NewWriter(&alloc, spec, typ)
+		require.NoError(t, err)
+
+		input := []columnar.Array{
+			columnartest.Array(t, types.KindInt64, &alloc, int64(-3), int64(-2), int64(-1), int64(0), int64(1)),
+			columnartest.Array(t, types.KindInt64, &alloc, int64(2), int64(3), int64(100), int64(-100)),
+		}
+		for _, arr := range input {
+			require.NoError(t, w.Append(arr))
+		}
+
+		result, err := w.Flush(t.Context(), &store)
+		require.NoError(t, err)
+		require.Equal(t, 9, result.RowCount)
+		require.Equal(t, 0, result.Stats.NullCount)
+
+		r, err := array.NewReader(&alloc, result, &store)
+		require.NoError(t, err)
+
+		expect := columnartest.Array(
+			t, types.KindInt64, &alloc,
+			int64(-3), int64(-2), int64(-1), int64(0), int64(1),
+			int64(2), int64(3), int64(100), int64(-100),
+		)
+
+		actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+		columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+
+		_, err = r.Read(t.Context(), &alloc, 1)
+		require.ErrorIs(t, err, io.EOF)
+	})
+}
+
+func TestZigZagCodec_Nullable(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecZigZag{Data: &array.SpecPlain{Validity: &array.SpecBool{}}}
+		typ  = &types.Int64{Nullable: true}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	input := []columnar.Array{
+		columnartest.Array(t, types.KindInt64, &alloc, int64(-1), nil, int64(1), nil, int64(0)),
+		columnartest.Array(t, types.KindInt64, &alloc, int64(42), int64(-42)),
+		columnartest.Array(t, types.KindInt64, &alloc, nil),
+	}
+	for _, arr := range input {
+		require.NoError(t, w.Append(arr))
+	}
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+	require.Equal(t, 8, result.RowCount)
+	require.Equal(t, 3, result.Stats.NullCount)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	expect := columnartest.Array(
+		t, types.KindInt64, &alloc,
+		int64(-1), nil, int64(1), nil, int64(0),
+		int64(42), int64(-42),
+		nil,
+	)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+
+	_, err = r.Read(t.Context(), &alloc, 1)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestZigZagCodec_PartialRead(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecZigZag{Data: &array.SpecPlain{}}
+		typ  = &types.Int64{Nullable: false}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	input := columnartest.Array(t, types.KindInt64, &alloc,
+		int64(-5), int64(-4), int64(-3), int64(-2), int64(-1),
+		int64(0), int64(1), int64(2), int64(3), int64(4),
+	)
+	require.NoError(t, w.Append(input))
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	batch1, err := r.Read(t.Context(), &alloc, 3)
+	require.NoError(t, err)
+	require.Equal(t, 3, batch1.Len())
+	columnartest.RequireArraysEqual(t,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(-5), int64(-4), int64(-3)),
+		batch1, memory.Bitmap{},
+	)
+
+	batch2, err := r.Read(t.Context(), &alloc, 3)
+	require.NoError(t, err)
+	require.Equal(t, 3, batch2.Len())
+	columnartest.RequireArraysEqual(t,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(-2), int64(-1), int64(0)),
+		batch2, memory.Bitmap{},
+	)
+
+	batch3, err := r.Read(t.Context(), &alloc, 3)
+	require.NoError(t, err)
+	require.Equal(t, 3, batch3.Len())
+	columnartest.RequireArraysEqual(t,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(1), int64(2), int64(3)),
+		batch3, memory.Bitmap{},
+	)
+
+	// Last batch: only 1 remaining.
+	batch4, err := r.Read(t.Context(), &alloc, 3)
+	require.NoError(t, err)
+	require.Equal(t, 1, batch4.Len())
+	columnartest.RequireArraysEqual(t,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(4)),
+		batch4, memory.Bitmap{},
+	)
+
+	_, err = r.Read(t.Context(), &alloc, 1)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestZigZagCodec_Extremes(t *testing.T) {
+	t.Run("int32", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+
+		var (
+			spec = &array.SpecZigZag{Data: &array.SpecPlain{}}
+			typ  = &types.Int32{Nullable: false}
+		)
+
+		w, err := array.NewWriter(&alloc, spec, typ)
+		require.NoError(t, err)
+
+		input := columnartest.Array(t, types.KindInt32, &alloc,
+			int32(0), int32(math.MinInt32), int32(math.MaxInt32), int32(-1), int32(1),
+		)
+		require.NoError(t, w.Append(input))
+
+		result, err := w.Flush(t.Context(), &store)
+		require.NoError(t, err)
+
+		r, err := array.NewReader(&alloc, result, &store)
+		require.NoError(t, err)
+
+		actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+		columnartest.RequireArraysEqual(t, input, actual, memory.Bitmap{})
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+
+		var (
+			spec = &array.SpecZigZag{Data: &array.SpecPlain{}}
+			typ  = &types.Int64{Nullable: false}
+		)
+
+		w, err := array.NewWriter(&alloc, spec, typ)
+		require.NoError(t, err)
+
+		input := columnartest.Array(t, types.KindInt64, &alloc,
+			int64(0), int64(math.MinInt64), int64(math.MaxInt64), int64(-1), int64(1),
+		)
+		require.NoError(t, w.Append(input))
+
+		result, err := w.Flush(t.Context(), &store)
+		require.NoError(t, err)
+
+		r, err := array.NewReader(&alloc, result, &store)
+		require.NoError(t, err)
+
+		actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+		columnartest.RequireArraysEqual(t, input, actual, memory.Bitmap{})
+	})
+}
+
+func TestZigZagCodec_WithBitpacked(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecZigZag{
+			Data: &array.SpecBitpacked{BlockSize: 8, Widths: &array.SpecPlain{}},
+		}
+		typ = &types.Int64{Nullable: false}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	input := columnartest.Array(t, types.KindInt64, &alloc,
+		int64(0), int64(-1), int64(1), int64(-2), int64(2),
+		int64(-3), int64(3), int64(-4), int64(4), int64(-5),
+	)
+	require.NoError(t, w.Append(input))
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+	require.Equal(t, 10, result.RowCount)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, input, actual, memory.Bitmap{})
+}
+
+func BenchmarkZigZagCodec(b *testing.B) {
+	var (
+		store buffer.MemoryStore
+
+		spec = &array.SpecZigZag{Data: &array.SpecPlain{}}
+		typ  = &types.Int64{Nullable: false}
+	)
+
+	const valuesPerPage = 1 << 16
+
+	type scenario struct {
+		name       string
+		valueCount int
+		encoded    array.Array
+	}
+
+	build := func(name string, valueCount int, valueAt func(i int) int64) scenario {
+		var alloc memory.Allocator
+		w, err := array.NewWriter(&alloc, spec, typ)
+		require.NoError(b, err)
+
+		builder := columnar.NewNumberBuilder[int64](&alloc)
+		builder.Grow(valueCount)
+
+		for i := range valueCount {
+			builder.AppendValue(valueAt(i))
+		}
+		require.NoError(b, w.Append(builder.Build()))
+
+		arr, err := w.Flush(b.Context(), &store)
+		require.NoError(b, err)
+		return scenario{name: name, valueCount: valueCount, encoded: arr}
+	}
+
+	scenarios := []scenario{
+		build("variance=constant", valuesPerPage, func(int) int64 { return -42 }),
+		build("variance=small_range", valuesPerPage, func(i int) int64 { return int64(i%16) - 8 }),
+		func() scenario {
+			rnd := rand.New(rand.NewSource(0))
+			return build("variance=random", valuesPerPage, func(int) int64 {
+				return rnd.Int63() - rnd.Int63()
+			})
+		}(),
+	}
+
+	batchSizes := []int{256, 1024, 4096}
+
+	for _, sc := range scenarios {
+		b.Run(sc.name, func(b *testing.B) {
+			b.Run(fmt.Sprintf("values_per_page=%d", sc.valueCount), func(b *testing.B) {
+				for _, batchSize := range batchSizes {
+					b.Run(fmt.Sprintf("batch_size=%d", batchSize), func(b *testing.B) {
+						var alloc memory.Allocator
+
+						b.ReportAllocs()
+						decodedBytesPerOp := int64(sc.valueCount) * 8
+						b.SetBytes(decodedBytesPerOp)
+
+						for b.Loop() {
+							alloc.Reset()
+
+							r, _ := array.NewReader(&alloc, sc.encoded, &store)
+
+							var decoded int
+							for {
+								arr, err := r.Read(b.Context(), &alloc, batchSize)
+								if arr != nil {
+									decoded += arr.Len()
+								}
+
+								if errors.Is(err, io.EOF) {
+									break
+								} else if err != nil {
+									b.Fatal(err)
+								}
+							}
+
+							if decoded != sc.valueCount {
+								b.Fatalf("decoded %d values, expected %d", decoded, sc.valueCount)
+							}
+						}
+
+						elapsed := b.Elapsed()
+						if elapsed > 0 {
+							totalDecoded := int64(sc.valueCount) * int64(b.N)
+							b.ReportMetric(float64(totalDecoded)/elapsed.Seconds(), "rows/s")
+						}
+					})
+				}
+			})
+		})
+	}
+}

--- a/pkg/dataset/array/encoding.go
+++ b/pkg/dataset/array/encoding.go
@@ -57,6 +57,15 @@ type (
 		// compression. The reader uses this to pre-allocate the decode buffer.
 		UncompressedSize int
 	}
+
+	// EncodingZigZag maps signed integer values to unsigned integers using
+	// zigzag encoding, where small-magnitude values (positive and negative)
+	// produce small unsigned values. This encoding stores no data of its own;
+	// all data lives in child Arrays.
+	//
+	// The single child Array holds the zigzag-encoded unsigned data.
+	// Nullability is handled by the child encoding.
+	EncodingZigZag struct{}
 )
 
 // Kind returns [EncodingKindBool].
@@ -84,6 +93,11 @@ func (enc *EncodingZstd) Kind() EncodingKind {
 	return EncodingKindZstd
 }
 
+// Kind returns [EncodingKindZigZag].
+func (enc *EncodingZigZag) Kind() EncodingKind {
+	return EncodingKindZigZag
+}
+
 //
 // Sealed marker implementations.
 //
@@ -93,3 +107,4 @@ func (enc *EncodingPlain) isEncoding()     {}
 func (enc *EncodingBinary) isEncoding()    {}
 func (enc *EncodingBitpacked) isEncoding() {}
 func (enc *EncodingZstd) isEncoding()      {}
+func (enc *EncodingZigZag) isEncoding()    {}

--- a/pkg/dataset/array/encoding_kind.go
+++ b/pkg/dataset/array/encoding_kind.go
@@ -14,6 +14,7 @@ const (
 	EncodingKindBinary    // EncodingKindBinary encodes variable-length binary data (like UTF8).
 	EncodingKindBitpacked // EncodingKindBitpacked is a bitpacked encoding for unsigned integer types.
 	EncodingKindZstd      // EncodingKindZstd encodes variable-length binary data with zstd compression.
+	EncodingKindZigZag    // EncodingKindZigZag maps signed integers to unsigned integers via zigzag encoding.
 )
 
 var kindNames = [...]string{
@@ -23,6 +24,7 @@ var kindNames = [...]string{
 	EncodingKindBinary:    "binary",
 	EncodingKindBitpacked: "bitpacked",
 	EncodingKindZstd:      "zstd",
+	EncodingKindZigZag:    "zigzag",
 }
 
 // String returns the string representation of k.

--- a/pkg/dataset/array/spec.go
+++ b/pkg/dataset/array/spec.go
@@ -78,6 +78,15 @@ type (
 		// data types.
 		Validity Spec
 	}
+
+	// SpecZigZag encodes signed integer values by mapping them to unsigned
+	// integers using zigzag encoding. The unsigned data is then encoded
+	// according to the Data spec. Nullability is passed through to the
+	// Data child.
+	SpecZigZag struct {
+		// Spec for how to encode the zigzag-encoded unsigned data.
+		Data Spec
+	}
 )
 
 // Kind returns [EncodingKindBool].
@@ -105,6 +114,11 @@ func (spec *SpecZstd) Kind() EncodingKind {
 	return EncodingKindZstd
 }
 
+// Kind returns [EncodingKindZigZag].
+func (spec *SpecZigZag) Kind() EncodingKind {
+	return EncodingKindZigZag
+}
+
 //
 // Sealed marker implementations.
 //
@@ -114,3 +128,4 @@ func (spec *SpecPlain) isSpec()     {}
 func (spec *SpecBinary) isSpec()    {}
 func (spec *SpecBitpacked) isSpec() {}
 func (spec *SpecZstd) isSpec()      {}
+func (spec *SpecZigZag) isSpec()    {}


### PR DESCRIPTION
Adds a ZigZag encoding, which compactly represents negative numbers for signed integers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `EncodingKindZigZag` with new reader/writer paths and allocator/validity handling; mistakes could surface as data corruption or subtle decoding bugs for int32/int64 arrays.
> 
> **Overview**
> Adds a new `zigzag` array encoding (`EncodingKindZigZag`, `SpecZigZag`, `EncodingZigZag`) and wires it into `NewWriter`/`NewReader` dispatch.
> 
> Implements `codec_zigzag.go` to zigzag-transform `int32`/`int64` values to unsigned (`uint32`/`uint64`) for storage via a child encoding, then decode back on read (including cloning validity for nullable arrays). Includes extensive tests/benchmarks covering type validation, nullable/non-nullable roundtrips, partial reads, extreme values, and composition with `bitpacked`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 367541b0167066c95a7ec91812f616d131487884. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->