### PR TITLE
chore(dataset/array): Add Zstd encoding

### DIFF
--- a/pkg/dataset/array/codec.go
+++ b/pkg/dataset/array/codec.go
@@ -47,6 +47,8 @@ func NewWriter(alloc *memory.Allocator, spec Spec, typ types.Type) (Writer, erro
 		return newBinaryWriter(alloc, spec, typ)
 	case EncodingKindBitpacked:
 		return newBitpackedWriter(alloc, spec, typ)
+	case EncodingKindZstd:
+		return newZstdWriter(alloc, spec, typ)
 
 	default:
 		return nil, fmt.Errorf("unsupported encoding kind %q", spec.Kind())
@@ -99,6 +101,8 @@ func NewReader(alloc *memory.Allocator, arr Array, source buffer.Source) (Reader
 		return newBinaryReader(alloc, arr, source)
 	case EncodingKindBitpacked:
 		return newBitpackedReader(alloc, arr, source)
+	case EncodingKindZstd:
+		return newZstdReader(alloc, arr, source)
 
 	default:
 		return nil, fmt.Errorf("unsupported encoding kind %q", arr.Encoding.Kind())

--- a/pkg/dataset/array/codec_zstd.go
+++ b/pkg/dataset/array/codec_zstd.go
@@ -1,0 +1,383 @@
+package array
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"sync"
+
+	"github.com/klauspost/compress/zstd"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// Shared zstd decoder. GOMAXPROCS concurrency, checksum disabled (the dataset
+// layer computes CRC32 on each page).
+var zstdDecoder = sync.OnceValues(func() (*zstd.Decoder, error) {
+	return zstd.NewReader(nil,
+		zstd.WithDecoderConcurrency(0),
+		zstd.IgnoreChecksum(true),
+	)
+})
+
+// Shared zstd encoder. SpeedDefault, CRC disabled.
+var zstdEncoder = sync.OnceValues(func() (*zstd.Encoder, error) {
+	return zstd.NewWriter(nil,
+		zstd.WithEncoderLevel(zstd.SpeedDefault),
+		zstd.WithEncoderCRC(false),
+	)
+})
+
+type zstdWriter struct {
+	alloc *memory.Allocator
+	typ   *types.UTF8
+
+	offsetWriter Writer
+	validity     Writer
+
+	initialized bool
+	data        memory.Buffer[byte]
+	nulls       int
+	rows        int
+}
+
+func newZstdWriter(alloc *memory.Allocator, spec Spec, typ types.Type) (Writer, error) {
+	if got, want := spec.Kind(), EncodingKindZstd; got != want {
+		return nil, fmt.Errorf("expected spec kind %s, got %s", want, got)
+	} else if got, want := typ.Kind(), types.KindUTF8; got != want {
+		return nil, fmt.Errorf("expected type %s, got %s", want, got)
+	}
+
+	var (
+		zstdSpec = spec.(*SpecZstd)
+		utf8Typ  = typ.(*types.UTF8)
+	)
+
+	if zstdSpec.Offsets == nil {
+		return nil, errors.New("zstd spec requires an offsets spec")
+	}
+
+	hasValidity := zstdSpec.Validity != nil
+	if utf8Typ.Nullable != hasValidity {
+		return nil, fmt.Errorf("expected %s to have validity %t, got %t", utf8Typ, utf8Typ.Nullable, hasValidity)
+	}
+
+	offsetWriter, err := NewWriter(alloc, zstdSpec.Offsets, &types.Int32{Nullable: false})
+	if err != nil {
+		return nil, fmt.Errorf("creating offset writer: %w", err)
+	}
+
+	var validityWriter Writer
+	if hasValidity {
+		validityWriter, err = NewWriter(alloc, zstdSpec.Validity, &types.Bool{Nullable: false})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &zstdWriter{
+		alloc: alloc,
+		typ:   utf8Typ,
+
+		data:         memory.NewBuffer[byte](alloc, 0),
+		offsetWriter: offsetWriter,
+		validity:     validityWriter,
+	}, nil
+}
+
+func (w *zstdWriter) Append(arr columnar.Array) error {
+	utf8Arr, ok := arr.(*columnar.UTF8)
+	if !ok {
+		return fmt.Errorf("expected *columnar.UTF8, got %T", arr)
+	}
+
+	if !w.initialized {
+		w.init()
+		w.initialized = true
+	}
+
+	// Validate before any mutation so a failed Append leaves the writer's
+	// state unchanged.
+	if err := validateNulls(w.validity, utf8Arr, utf8Arr.Len()); err != nil {
+		return err
+	}
+
+	// Fall through to the utility method to handle nulls (including whether our
+	// type is not nullable).
+	nulls, err := appendNulls(w.alloc, w.validity, utf8Arr, utf8Arr.Len())
+	if err != nil {
+		return err
+	}
+	w.nulls += nulls
+
+	var (
+		baseOffset = int32(w.data.Len())
+
+		srcData    = utf8Arr.Data()
+		srcOffsets = utf8Arr.Offsets()
+		dataStart  = srcOffsets[0]
+		dataEnd    = srcOffsets[len(srcOffsets)-1]
+	)
+
+	// Append only the referenced data range. Sliced UTF8 arrays share the
+	// full parent data buffer, so srcData may contain bytes outside the
+	// offset range.
+	w.data.Grow(int(dataEnd - dataStart))
+	w.data.Append(srcData[dataStart:dataEnd]...)
+
+	// Build rebased offsets and write through the child offset writer (skip
+	// first since the leading zero was written by init).
+	{
+		alloc := memory.NewAllocator(w.alloc)
+		defer alloc.Free()
+
+		rebasedBuilder := columnar.NewNumberBuilder[int32](alloc)
+		rebasedBuilder.Grow(utf8Arr.Len())
+
+		for i := range utf8Arr.Len() {
+			rebasedBuilder.AppendValue(srcOffsets[i+1] - dataStart + baseOffset)
+		}
+
+		rebased := rebasedBuilder.Build()
+		if err := w.offsetWriter.Append(rebased); err != nil {
+			return fmt.Errorf("appending offsets: %w", err)
+		}
+		w.rows += utf8Arr.Len()
+	}
+
+	return nil
+}
+
+func (w *zstdWriter) init() {
+	// Write the leading zero offset, since the offset array has N+1 values.
+	leading := columnar.NewNumber([]int32{0}, memory.Bitmap{})
+
+	// offsetWriter.Append cannot fail for a single zero value written to a
+	// fresh writer, so we intentionally ignore the error.
+	_ = w.offsetWriter.Append(leading)
+}
+
+func (w *zstdWriter) Flush(ctx context.Context, sink buffer.Sink) (Array, error) {
+	defer w.reset()
+
+	enc, err := zstdEncoder()
+	if err != nil {
+		return Array{}, fmt.Errorf("getting zstd encoder: %w", err)
+	}
+
+	// Compress the accumulated data buffer into a pre-allocated buffer and
+	// write it to the sink.
+	raw := w.data.Serialize()
+	encBuf := memory.NewBuffer[byte](w.alloc, len(raw))
+	compressed := enc.EncodeAll(raw, encBuf.Data())
+
+	bufs, err := sink.WriteBuffers(ctx, []buffer.Data{compressed})
+	if err != nil {
+		return Array{}, fmt.Errorf("writing zstd data to a buffer: %w", err)
+	}
+
+	// Flush children (offsets, validity).
+	var children []Array
+
+	offsetArray, err := w.offsetWriter.Flush(ctx, sink)
+	if err != nil {
+		return Array{}, fmt.Errorf("flushing offset writer: %w", err)
+	}
+	children = append(children, offsetArray)
+
+	if w.validity != nil {
+		validityArray, err := w.validity.Flush(ctx, sink)
+		if err != nil {
+			return Array{}, fmt.Errorf("flushing validity writer: %w", err)
+		}
+		children = append(children, validityArray)
+	}
+
+	return Array{
+		Encoding: &EncodingZstd{UncompressedSize: len(raw)},
+		Type:     w.typ,
+		Buffers:  bufs,
+		RowCount: w.rows,
+		Stats: Stats{
+			NullCount: w.nulls,
+		},
+		Children: children,
+	}, nil
+}
+
+func (w *zstdWriter) reset() {
+	w.initialized = false
+	w.data = memory.NewBuffer[byte](w.alloc, 0)
+	w.nulls = 0
+	w.rows = 0
+}
+
+type zstdReader struct {
+	alloc  *memory.Allocator
+	arr    Array
+	source buffer.Source
+
+	offsets  Reader
+	validity Reader
+
+	initialized      bool
+	data             []byte
+	offsetData       []int32
+	off              int // Row offset into data
+	uncompressedSize int
+}
+
+func newZstdReader(alloc *memory.Allocator, arr Array, source buffer.Source) (*zstdReader, error) {
+	if got, want := arr.Encoding.Kind(), EncodingKindZstd; got != want {
+		return nil, fmt.Errorf("expected encoding kind %s, got %s", want, got)
+	} else if got, want := arr.Type.Kind(), types.KindUTF8; got != want {
+		return nil, fmt.Errorf("expected type %s, got %s", want, got)
+	}
+
+	var (
+		utf8Typ = arr.Type.(*types.UTF8)
+		enc     = arr.Encoding.(*EncodingZstd)
+	)
+
+	switch {
+	case !utf8Typ.Nullable && len(arr.Children) != 1:
+		return nil, fmt.Errorf("expected 1 child for non-nullable zstd array, got %d", len(arr.Children))
+	case utf8Typ.Nullable && len(arr.Children) != 2:
+		return nil, fmt.Errorf("expected 2 children for nullable zstd array, got %d", len(arr.Children))
+	}
+
+	offsetReader, err := NewReader(alloc, arr.Children[0], source)
+	if err != nil {
+		return nil, fmt.Errorf("creating offset reader: %w", err)
+	}
+
+	var validityReader Reader
+	if utf8Typ.Nullable {
+		validityReader, err = NewReader(alloc, arr.Children[1], source)
+		if err != nil {
+			return nil, fmt.Errorf("creating validity reader: %w", err)
+		}
+	}
+
+	return &zstdReader{
+		alloc:  alloc,
+		arr:    arr,
+		source: source,
+
+		offsets:          offsetReader,
+		validity:         validityReader,
+		uncompressedSize: enc.UncompressedSize,
+	}, nil
+}
+
+func (r *zstdReader) Read(ctx context.Context, alloc *memory.Allocator, count int) (columnar.Array, error) {
+	if count <= 0 {
+		return nil, fmt.Errorf("count must be positive, got %d", count)
+	}
+
+	if !r.initialized {
+		// We use the reader's allocator for initializing since the data
+		// persists across calls to Read.
+		if err := r.init(ctx, r.alloc); err != nil {
+			return nil, err
+		}
+		r.initialized = true
+	}
+
+	endOff := min(r.off+count, r.arr.RowCount)
+	n := endOff - r.off
+	if n == 0 {
+		return nil, io.EOF
+	}
+
+	// Slice offsets for this batch. The offset array has N+1 values, so we
+	// take elements [off, off+n] inclusive to get n+1 offsets for n elements.
+	slicedOffsets := r.offsetData[r.off : r.off+n+1]
+
+	// Read validity bytes now.
+	var validity memory.Bitmap
+	if r.validity != nil {
+		validityArr, err := r.validity.Read(ctx, alloc, count)
+		if err != nil {
+			return nil, fmt.Errorf("reading validity: %w", err)
+		}
+
+		validityBoolArr := validityArr.(*columnar.Bool)
+		validity = validityBoolArr.Values()
+	}
+
+	r.off += n
+
+	// The sliced offsets reference positions within r.data, so we return the
+	// entire r.data slice for each call. If we sliced r.data, then we would
+	// need to normalize slicedOffsets to be positionally correct.
+	return columnar.NewUTF8(r.data, slicedOffsets, validity), nil
+}
+
+func (r *zstdReader) init(ctx context.Context, alloc *memory.Allocator) error {
+	data, err := r.source.ReadBuffers(ctx, alloc, r.arr.Buffers)
+	if err != nil {
+		return fmt.Errorf("fetching buffer data: %w", err)
+	} else if len(data) != 1 {
+		return fmt.Errorf("expected 1 buffer, got %d", len(data))
+	}
+
+	// Decompress the data buffer into a pre-allocated, allocator-managed buffer.
+	dec, err := zstdDecoder()
+	if err != nil {
+		return fmt.Errorf("getting zstd decoder: %w", err)
+	}
+
+	decBuf := memory.NewBuffer[byte](alloc, r.uncompressedSize)
+	decompressed, err := dec.DecodeAll(data[0], decBuf.Data())
+	if err != nil {
+		return fmt.Errorf("decompressing zstd data: %w", err)
+	}
+
+	// Read all offsets.
+	arr, err := r.offsets.Read(ctx, alloc, math.MaxInt)
+	if err != nil {
+		return fmt.Errorf("reading offsets: %w", err)
+	}
+	offsets := arr.(*columnar.Number[int32]).Values()
+
+	r.data = decompressed
+	r.offsetData = offsets
+	return nil
+}
+
+func (r *zstdReader) Reset() {
+	r.resetSelf()
+
+	if r.validity != nil {
+		r.validity.Reset()
+	}
+	if r.offsets != nil {
+		r.offsets.Reset()
+	}
+}
+
+func (r *zstdReader) resetSelf() {
+	// Reset the offset but keep everything else to allow for re-reading data.
+	r.off = 0
+}
+
+func (r *zstdReader) Close() error {
+	r.resetSelf()
+
+	r.initialized = false
+	r.data = nil
+	r.offsetData = nil
+
+	if r.validity != nil {
+		offsetErr := r.offsets.Close()
+		validityErr := r.validity.Close()
+		return errors.Join(offsetErr, validityErr)
+	}
+	return r.offsets.Close()
+}

--- a/pkg/dataset/array/codec_zstd_test.go
+++ b/pkg/dataset/array/codec_zstd_test.go
@@ -1,0 +1,301 @@
+package array_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestZstdCodec_Validation(t *testing.T) {
+	tt := []struct {
+		name string
+		spec array.Spec
+		typ  types.Type
+
+		expectError bool
+	}{
+		{
+			name:        "accepts valid non-nullable utf8",
+			spec:        &array.SpecZstd{Offsets: &array.SpecPlain{}},
+			typ:         &types.UTF8{Nullable: false},
+			expectError: false,
+		},
+		{
+			name:        "rejects missing offsets spec",
+			spec:        &array.SpecZstd{Offsets: nil},
+			typ:         &types.UTF8{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects non-nullable utf8 with validity spec",
+			spec:        &array.SpecZstd{Offsets: &array.SpecPlain{}, Validity: &array.SpecBool{}},
+			typ:         &types.UTF8{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects nullable utf8 with no validity spec",
+			spec:        &array.SpecZstd{Offsets: &array.SpecPlain{}},
+			typ:         &types.UTF8{Nullable: true},
+			expectError: true,
+		},
+		{
+			name:        "accepts nullable utf8 with validity spec",
+			spec:        &array.SpecZstd{Offsets: &array.SpecPlain{}, Validity: &array.SpecBool{}},
+			typ:         &types.UTF8{Nullable: true},
+			expectError: false,
+		},
+		{
+			name:        "rejects unsupported type bool",
+			spec:        &array.SpecZstd{Offsets: &array.SpecPlain{}},
+			typ:         &types.Bool{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects unsupported type int64",
+			spec:        &array.SpecZstd{Offsets: &array.SpecPlain{}},
+			typ:         &types.Int64{Nullable: false},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			var alloc memory.Allocator
+			_, err := array.NewWriter(&alloc, tc.spec, tc.typ)
+
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestZstdCodec_NonNullable(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecZstd{Offsets: &array.SpecPlain{}}
+		typ  = &types.UTF8{Nullable: false}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	input := []columnar.Array{
+		columnartest.Array(t, types.KindUTF8, &alloc, "hello", "world", "", "foo", "bar"),
+		columnartest.Array(t, types.KindUTF8, &alloc, "baz", "qux", "quux", "corge", "grault"),
+	}
+	for _, arr := range input {
+		require.NoError(t, w.Append(arr))
+	}
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+	require.Equal(t, 10, result.RowCount)
+	require.Equal(t, 0, result.Stats.NullCount)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	expect := columnartest.Array(
+		t, types.KindUTF8, &alloc,
+		"hello", "world", "", "foo", "bar",
+		"baz", "qux", "quux", "corge", "grault",
+	)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+
+	// Reading again should produce a EOF.
+	_, err = r.Read(t.Context(), &alloc, 1)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestZstdCodec_Nullable(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecZstd{Offsets: &array.SpecPlain{}, Validity: &array.SpecBool{}}
+		typ  = &types.UTF8{Nullable: true}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	input := []columnar.Array{
+		columnartest.Array(t, types.KindUTF8, &alloc, "hello", nil, "world", nil, "foo"),
+		columnartest.Array(t, types.KindUTF8, &alloc, "bar", "baz", "qux", "quux", "corge"),
+		columnartest.Array(t, types.KindUTF8, &alloc, nil),
+	}
+	for _, arr := range input {
+		require.NoError(t, w.Append(arr))
+	}
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+	require.Equal(t, 11, result.RowCount)
+	require.Equal(t, 3, result.Stats.NullCount)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	expect := columnartest.Array(
+		t, types.KindUTF8, &alloc,
+		"hello", nil, "world", nil, "foo",
+		"bar", "baz", "qux", "quux", "corge",
+		nil,
+	)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+
+	// Reading again should produce a EOF.
+	_, err = r.Read(t.Context(), &alloc, 1)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestZstdCodec_SlicedInput(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecZstd{Offsets: &array.SpecPlain{}}
+		typ  = &types.UTF8{Nullable: false}
+	)
+
+	// Build a full array then slice out a middle section, so the input has
+	// non-zero-based offsets and a shared data buffer.
+	full := columnartest.Array(t, types.KindUTF8, &alloc,
+		"alpha", "bravo", "charlie", "delta", "echo",
+	)
+	sliced := full.Slice(1, 4) // ["bravo", "charlie", "delta"]
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+	require.NoError(t, w.Append(sliced))
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+	require.Equal(t, 3, result.RowCount)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	expect := columnartest.Array(t, types.KindUTF8, &alloc,
+		"bravo", "charlie", "delta",
+	)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+}
+
+func BenchmarkZstdCodec(b *testing.B) {
+	var (
+		store buffer.MemoryStore
+
+		spec = &array.SpecZstd{Offsets: &array.SpecPlain{}}
+		typ  = &types.UTF8{Nullable: false}
+	)
+
+	const valuesPerPage = 1 << 16
+
+	type scenario struct {
+		name       string
+		valueCount int
+		encoded    array.Array
+	}
+
+	build := func(name string, valueCount int, valueAt func(i int) []byte) scenario {
+		var alloc memory.Allocator
+		w, err := array.NewWriter(&alloc, spec, typ)
+		require.NoError(b, err)
+
+		builder := columnar.NewUTF8Builder(&alloc)
+		builder.Grow(valueCount)
+
+		for i := range valueCount {
+			builder.AppendValue(valueAt(i))
+		}
+		require.NoError(b, w.Append(builder.Build()))
+
+		arr, err := w.Flush(b.Context(), &store)
+		require.NoError(b, err)
+		return scenario{name: name, valueCount: valueCount, encoded: arr}
+	}
+
+	scenarios := []scenario{
+		build("variance=constant", valuesPerPage, func(int) []byte { return []byte("hello") }),
+		func() scenario {
+			rnd := rand.New(rand.NewSource(0))
+			return build("variance=random", valuesPerPage, func(int) []byte {
+				buf := make([]byte, 5+rnd.Intn(20))
+				rnd.Read(buf)
+				return buf
+			})
+		}(),
+	}
+
+	batchSizes := []int{256, 1024, 4096}
+
+	for _, sc := range scenarios {
+		b.Run(sc.name, func(b *testing.B) {
+			b.Run(fmt.Sprintf("values_per_page=%d", sc.valueCount), func(b *testing.B) {
+				for _, batchSize := range batchSizes {
+					b.Run(fmt.Sprintf("batch_size=%d", batchSize), func(b *testing.B) {
+						var alloc memory.Allocator
+
+						b.ReportAllocs()
+						// Approximate bytes: data + offsets
+						decodedBytesPerOp := int64(sc.encoded.RowCount) * 15 // ~15 bytes avg string
+						b.SetBytes(decodedBytesPerOp)
+
+						for b.Loop() {
+							alloc.Reset()
+
+							r, _ := array.NewReader(&alloc, sc.encoded, &store)
+
+							var decoded int
+							for {
+								arr, err := r.Read(b.Context(), &alloc, batchSize)
+								if arr != nil {
+									decoded += arr.Len()
+								}
+
+								if errors.Is(err, io.EOF) {
+									break
+								} else if err != nil {
+									b.Fatal(err)
+								}
+							}
+
+							if decoded != sc.valueCount {
+								b.Fatalf("decoded %d values, expected %d", decoded, sc.valueCount)
+							}
+						}
+
+						elapsed := b.Elapsed()
+						if elapsed > 0 {
+							totalDecoded := int64(sc.valueCount) * int64(b.N)
+							b.ReportMetric(float64(totalDecoded)/elapsed.Seconds(), "rows/s")
+						}
+					})
+				}
+			})
+		})
+	}
+}

--- a/pkg/dataset/array/encoding.go
+++ b/pkg/dataset/array/encoding.go
@@ -47,6 +47,16 @@ type (
 	EncodingBitpacked struct {
 		BlockSize int // Number of rows per block. The last block may have fewer rows.
 	}
+
+	// EncodingZstd holds zstd-compressed binary data. The structure mirrors
+	// [EncodingBinary]: the first child Array holds N+1 offsets, and if
+	// nullable, the last child Array holds validity data. The data buffer is
+	// zstd-compressed.
+	EncodingZstd struct {
+		// UncompressedSize is the byte length of the data buffer before
+		// compression. The reader uses this to pre-allocate the decode buffer.
+		UncompressedSize int
+	}
 )
 
 // Kind returns [EncodingKindBool].
@@ -69,6 +79,11 @@ func (enc *EncodingBitpacked) Kind() EncodingKind {
 	return EncodingKindBitpacked
 }
 
+// Kind returns [EncodingKindZstd].
+func (enc *EncodingZstd) Kind() EncodingKind {
+	return EncodingKindZstd
+}
+
 //
 // Sealed marker implementations.
 //
@@ -77,3 +92,4 @@ func (enc *EncodingBool) isEncoding()      {}
 func (enc *EncodingPlain) isEncoding()     {}
 func (enc *EncodingBinary) isEncoding()    {}
 func (enc *EncodingBitpacked) isEncoding() {}
+func (enc *EncodingZstd) isEncoding()      {}

--- a/pkg/dataset/array/encoding_kind.go
+++ b/pkg/dataset/array/encoding_kind.go
@@ -13,6 +13,7 @@ const (
 	EncodingKindPlain     // EncodingKindPlain is plain encoding for fixed-width types (int32, etc).
 	EncodingKindBinary    // EncodingKindBinary encodes variable-length binary data (like UTF8).
 	EncodingKindBitpacked // EncodingKindBitpacked is a bitpacked encoding for unsigned integer types.
+	EncodingKindZstd      // EncodingKindZstd encodes variable-length binary data with zstd compression.
 )
 
 var kindNames = [...]string{
@@ -21,6 +22,7 @@ var kindNames = [...]string{
 	EncodingKindPlain:     "plain",
 	EncodingKindBinary:    "binary",
 	EncodingKindBitpacked: "bitpacked",
+	EncodingKindZstd:      "zstd",
 }
 
 // String returns the string representation of k.

--- a/pkg/dataset/array/spec.go
+++ b/pkg/dataset/array/spec.go
@@ -65,6 +65,19 @@ type (
 		// data types.
 		Validity Spec
 	}
+
+	// SpecZstd encodes variable-length data with zstd compression on the
+	// data buffer. Structure mirrors [SpecBinary].
+	SpecZstd struct {
+		// Spec for how to encode offset information, where the half-open range
+		// (offsets[i], offsets[i+1]] specifies where the offsets where element
+		// i.
+		Offsets Spec
+
+		// Spec for how to encode validity data. Must only be set for nullable
+		// data types.
+		Validity Spec
+	}
 )
 
 // Kind returns [EncodingKindBool].
@@ -87,6 +100,11 @@ func (spec *SpecBitpacked) Kind() EncodingKind {
 	return EncodingKindBitpacked
 }
 
+// Kind returns [EncodingKindZstd].
+func (spec *SpecZstd) Kind() EncodingKind {
+	return EncodingKindZstd
+}
+
 //
 // Sealed marker implementations.
 //
@@ -95,3 +113,4 @@ func (spec *SpecBool) isSpec()      {}
 func (spec *SpecPlain) isSpec()     {}
 func (spec *SpecBinary) isSpec()    {}
 func (spec *SpecBitpacked) isSpec() {}
+func (spec *SpecZstd) isSpec()      {}


### PR DESCRIPTION
Adds a Zstd encoding to the dataset/array package, which comrpesses binary data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `EncodingKindZstd` with custom reader/writer logic and compressed buffer handling, which can affect correctness/performance of dataset serialization and memory usage. Scope is isolated to the `dataset/array` encoding layer and is covered by new unit tests and a benchmark.
> 
> **Overview**
> Adds a new `EncodingKindZstd`/`SpecZstd`/`EncodingZstd` to support zstd-compressed UTF8 (variable-length) array pages, wiring it into `NewWriter`/`NewReader` dispatch.
> 
> Introduces `codec_zstd.go` implementing a zstd-backed writer/reader that compresses the UTF8 data buffer on flush and preallocates using `UncompressedSize` on read, while keeping offsets (and optional validity) as child arrays.
> 
> Adds tests for validation, nullable/non-nullable roundtrips, sliced-input handling, plus a benchmark for decode throughput under different batch sizes and data variance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7948208939238ba434ef06a5805499ae51d44354. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->