### PR TITLE
fix(logql): Decode unpadded base64 template values

### DIFF
--- a/docs/sources/query/template_functions.md
+++ b/docs/sources/query/template_functions.md
@@ -272,7 +272,7 @@ Examples:
 
 ### b64dec
 
-Base64 decode a string.
+Base64 decode a string. Inputs that omit trailing `=` padding are padded before decoding.
 
 Signature: `b64dec(string) string`
 

--- a/pkg/logql/log/fmt.go
+++ b/pkg/logql/log/fmt.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -70,12 +71,12 @@ var (
 		"unixToTime":       unixToTime,
 		"alignLeft":        alignLeft,
 		"alignRight":       alignRight,
+		"b64dec":           base64Decode,
 	}
 
 	// sprig template functions
 	templateFunctions = []string{
 		"b64enc",
-		"b64dec",
 		"lower",
 		"upper",
 		"title",
@@ -177,6 +178,19 @@ func toDateInZone(fmt, zone, str string) time.Time {
 	}
 	t, _ := time.ParseInLocation(fmt, str, loc)
 	return t
+}
+
+func base64Decode(v string) string {
+	if remainder := len(v) % 4; remainder != 0 && remainder != 1 {
+		v += strings.Repeat("=", 4-remainder)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(v)
+	if err != nil {
+		return err.Error()
+	}
+
+	return string(data)
 }
 
 func init() {

--- a/pkg/logql/log/fmt_test.go
+++ b/pkg/logql/log/fmt_test.go
@@ -462,6 +462,15 @@ func Test_lineFormatter_Format(t *testing.T) {
 			[]byte("1"),
 		},
 		{
+			"base64decode missing padding",
+			newMustLineFormatter("{{ .foo | b64dec }} {{ .bar | b64dec }}"),
+			labels.FromStrings("foo", "Zm9vYmE", "bar", "Zm9vYg"),
+			1656353124120000000,
+			[]byte("fooba foob"),
+			labels.FromStrings("foo", "Zm9vYmE", "bar", "Zm9vYg"),
+			[]byte("1"),
+		},
+		{
 			"alignLeft",
 			newMustLineFormatter("{{ alignLeft 4 .foo }}"),
 			labels.FromStrings("foo", "hello"),
@@ -706,6 +715,14 @@ func Test_labelsFormatter_Format(t *testing.T) {
 			labels.FromStrings("foo", "aSdtIGEgc3RyaW5nLCBlbmNvZGUgbWUh", "bar", "blop"),
 			labels.FromStrings("foo", "aSdtIGEgc3RyaW5nLCBlbmNvZGUgbWUh",
 				"bar", "i'm a string, encode me!",
+			),
+		},
+		{
+			"base64decode missing padding",
+			mustNewLabelsFormatter([]LabelFmt{NewTemplateLabelFmt("bar", "{{ .foo | b64dec }}")}),
+			labels.FromStrings("foo", "Zm9vYmE", "bar", "blop"),
+			labels.FromStrings("foo", "Zm9vYmE",
+				"bar", "fooba",
 			),
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
`b64dec` now pads standard base64 template inputs that omit trailing `=` characters before decoding. This keeps existing decode behavior for valid padded input and returns decode errors for invalid input.

**Which issue(s) this PR fixes**:
Fixes #15547

**Special notes for your reviewer**:
Validated with `go test ./pkg/logql/log -run "Test_lineFormatter_Format|Test_labelsFormatter_Format" -count=1` and `go test ./pkg/logql/log -count=1`.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LogQL template `b64dec` behavior by adding implicit padding and a custom decoder implementation, which could affect query output/error strings for malformed base64 inputs.
> 
> **Overview**
> `b64dec` in LogQL templates is no longer sourced from sprig; it is replaced with a custom `base64Decode` helper that pads inputs missing trailing `=` characters before decoding.
> 
> Adds coverage for unpadded decode cases in both `line_format` and `label_format` tests, and updates the template function documentation to reflect the new padding behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f050c40b1fc530f668da2ec9ac0aa951a3e5c87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->