### PR TITLE
fix(distributor): Keep stream sharding enabled with empty overrides

### DIFF
--- a/pkg/distributor/ratestore.go
+++ b/pkg/distributor/ratestore.go
@@ -219,7 +219,7 @@ func (s *rateStore) wasUpdated(tenantID string, streamID uint64, lastUpdated map
 
 func (s *rateStore) anyShardingEnabled() bool {
 	limits := s.limits.AllByUserID()
-	if limits == nil {
+	if len(limits) == 0 {
 		// There aren't any tenant limits, check the default
 		return s.limits.ShardStreams("fake").Enabled
 	}

--- a/pkg/distributor/ratestore_test.go
+++ b/pkg/distributor/ratestore_test.go
@@ -140,6 +140,27 @@ func TestRateStore(t *testing.T) {
 		requireRatesAndPushesEqual(t, 0, 0, tc.rateStore, "tenant 1", 0)
 	})
 
+	t.Run("it uses default sharding limits when overrides are empty", func(t *testing.T) {
+		tc := setupWithOverrides(&fakeOverrides{
+			enabled:      true,
+			tenantLimits: map[string]*validation.Limits{},
+		})
+		tc.ring.replicationSet = ring.ReplicationSet{
+			Instances: []ring.InstanceDesc{
+				{Addr: "ingester0"},
+			},
+		}
+
+		tc.clientPool.clients = map[string]client.PoolClient{
+			"ingester0": newRateClient([]*logproto.StreamRate{
+				{Tenant: "tenant 1", StreamHash: 1, StreamHashNoShard: 0, Rate: 25},
+			}),
+		}
+
+		require.NoError(t, tc.rateStore.instrumentedUpdateAllRates(context.Background()))
+		requireRatesAndPushesEqual(t, 25, 0, tc.rateStore, "tenant 1", 0)
+	})
+
 	t.Run("it clears the rate after an interval", func(t *testing.T) {
 		tc := setup(true)
 		tc.ring.replicationSet = ring.ReplicationSet{
@@ -335,10 +356,15 @@ func (c *fakeStreamDataClient) GetStreamRates(_ context.Context, _ *logproto.Str
 
 type fakeOverrides struct {
 	Limits
-	enabled bool
+	enabled      bool
+	tenantLimits map[string]*validation.Limits
 }
 
 func (c *fakeOverrides) AllByUserID() map[string]*validation.Limits {
+	if c.tenantLimits != nil {
+		return c.tenantLimits
+	}
+
 	return map[string]*validation.Limits{
 		"ingester0": {
 			ShardStreams: shardstreams.Config{
@@ -361,6 +387,10 @@ type testContext struct {
 }
 
 func setup(shardingEnabled bool) *testContext {
+	return setupWithOverrides(&fakeOverrides{enabled: shardingEnabled})
+}
+
+func setupWithOverrides(overrides *fakeOverrides) *testContext {
 	ring := newFakeRing()
 	cp := newFakeClientPool()
 	cfg := RateStoreConfig{MaxParallelism: 5, IngesterReqTimeout: time.Second, StreamRateUpdateInterval: 10 * time.Millisecond}
@@ -368,6 +398,6 @@ func setup(shardingEnabled bool) *testContext {
 	return &testContext{
 		ring:       ring,
 		clientPool: cp,
-		rateStore:  NewRateStore(cfg, ring, cp, &fakeOverrides{enabled: shardingEnabled}, nil),
+		rateStore:  NewRateStore(cfg, ring, cp, overrides, nil),
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The rate store now treats empty tenant overrides the same as missing tenant overrides when deciding whether any stream sharding is enabled. This keeps default `limits_config.shard_streams` settings active when the runtime overrides file is empty.

**Which issue(s) this PR fixes**:
Fixes #17277

**Special notes for your reviewer**:
Validated with `go test ./pkg/distributor -run TestRateStore -count=1`.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the distributor `rateStore` sharding gate to treat an empty overrides map as “no tenant limits”, which can re-enable periodic rate collection and affect runtime load/behavior in sharded deployments.
> 
> **Overview**
> Fixes `rateStore.anyShardingEnabled()` to treat `AllByUserID()` returning an *empty* map the same as having no overrides, falling back to the default `ShardStreams` config instead of disabling sharding.
> 
> Adds a regression test covering the empty-overrides case and extends the test overrides helper to return a configurable tenant limits map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 410832dd7cf2c50191c2350be8d6b95059ca17e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->