### PR TITLE
chore: Update go version to 1.26.3

### DIFF
--- a/.github/workflows/build-loki-binary.yml
+++ b/.github/workflows/build-loki-binary.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26.2"
+  GO_VERSION: "1.26.3"
 
 jobs:
   build:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@
   "check":
     "uses": "grafana/loki-release/.github/workflows/check.yml@48ee065d8d1e3f1a3a28cb1e5ecf5cb85211a019"
     "with":
-      "build_image": "golang:1.26.2"
+      "build_image": "golang:1.26.3"
       "golang_ci_lint_version": "v2.10.1"
       "release_lib_ref": "48ee065d8d1e3f1a3a28cb1e5ecf5cb85211a019"
       "skip_validation": false

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -2,7 +2,7 @@
   "check":
     "uses": "grafana/loki-release/.github/workflows/check.yml@48ee065d8d1e3f1a3a28cb1e5ecf5cb85211a019"
     "with":
-      "build_image": "golang:1.26.2"
+      "build_image": "golang:1.26.3"
       "golang_ci_lint_version": "v2.10.1"
       "release_lib_ref": "48ee065d8d1e3f1a3a28cb1e5ecf5cb85211a019"
       "skip_validation": false
@@ -10,7 +10,7 @@
   "loki-canary-boringcrypto-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.26.2"
+      "GO_VERSION": "1.26.3"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "48ee065d8d1e3f1a3a28cb1e5ecf5cb85211a019"
       "RELEASE_REPO": "grafana/loki"
@@ -134,7 +134,7 @@
   "loki-canary-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.26.2"
+      "GO_VERSION": "1.26.3"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "48ee065d8d1e3f1a3a28cb1e5ecf5cb85211a019"
       "RELEASE_REPO": "grafana/loki"
@@ -258,7 +258,7 @@
   "loki-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.26.2"
+      "GO_VERSION": "1.26.3"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "48ee065d8d1e3f1a3a28cb1e5ecf5cb85211a019"
       "RELEASE_REPO": "grafana/loki"
@@ -382,7 +382,7 @@
   "querytee-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.26.2"
+      "GO_VERSION": "1.26.3"
       "IMAGE_PREFIX": "grafana"
       "RELEASE_LIB_REF": "48ee065d8d1e3f1a3a28cb1e5ecf5cb85211a019"
       "RELEASE_REPO": "grafana/loki"

--- a/.github/workflows/lint-jsonnet.yml
+++ b/.github/workflows/lint-jsonnet.yml
@@ -21,7 +21,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
       - name: setup jsonnet
         run: |
           go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0

--- a/.github/workflows/logql-bench.yml
+++ b/.github/workflows/logql-bench.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       # The metastore generates invalid filenames for Windows (with colons),
       # which get rejected by upload-artifact. We zip these files to avoid this
@@ -105,7 +105,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Create results directory
         run: mkdir -p ./pkg/logql/bench/results

--- a/.github/workflows/logql-correctness.yml
+++ b/.github/workflows/logql-correctness.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       # The metastore generates invalid filenames for Windows (with colons),
       # which get rejected by upload-artifact. We zip these files to avoid this
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Create results directory
         run: mkdir -p ./pkg/logql/bench/results

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -21,7 +21,7 @@ jobs:
       pull-requests: "write"
     uses: "grafana/loki-release/.github/workflows/check.yml@48ee065d8d1e3f1a3a28cb1e5ecf5cb85211a019"
     with:
-      build_image: "golang:1.26.2"
+      build_image: "golang:1.26.3"
       golang_ci_lint_version: "v2.10.1"
       release_lib_ref: "48ee065d8d1e3f1a3a28cb1e5ecf5cb85211a019"
       skip_validation: false
@@ -177,10 +177,10 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "golang:1.26.2"
+          --entrypoint /bin/sh "golang:1.26.3"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
-          if echo "golang:1.26.2" | grep -q "golang"; then
+          if echo "golang:1.26.3" | grep -q "golang"; then
             /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
           fi
           make dist packages
@@ -201,9 +201,9 @@ jobs:
           --env IMAGE_TAG \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "golang:1.26.2"
+          --entrypoint /bin/sh "golang:1.26.3"
           git config --global --add safe.directory /src/loki
-          if echo "golang:1.26.2" | grep -q "golang"; then
+          if echo "golang:1.26.3" | grep -q "golang"; then
             /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
           fi
           make dist/loki-linux-riscv64
@@ -819,7 +819,7 @@ jobs:
         build-args: |
           IMAGE_TAG=${{ needs.version.outputs.version }}
           GOARCH=${{ steps.platform.outputs.platform_short }}
-          BUILD_IMAGE=golang:1.26.2
+          BUILD_IMAGE=golang:1.26.3
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=local,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -21,7 +21,7 @@ jobs:
       pull-requests: "write"
     uses: "grafana/loki-release/.github/workflows/check.yml@48ee065d8d1e3f1a3a28cb1e5ecf5cb85211a019"
     with:
-      build_image: "golang:1.26.2"
+      build_image: "golang:1.26.3"
       golang_ci_lint_version: "v2.10.1"
       release_lib_ref: "48ee065d8d1e3f1a3a28cb1e5ecf5cb85211a019"
       skip_validation: false
@@ -177,10 +177,10 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "golang:1.26.2"
+          --entrypoint /bin/sh "golang:1.26.3"
           git config --global --add safe.directory /src/loki
           echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
-          if echo "golang:1.26.2" | grep -q "golang"; then
+          if echo "golang:1.26.3" | grep -q "golang"; then
             /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
           fi
           make dist packages
@@ -201,9 +201,9 @@ jobs:
           --env IMAGE_TAG \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "golang:1.26.2"
+          --entrypoint /bin/sh "golang:1.26.3"
           git config --global --add safe.directory /src/loki
-          if echo "golang:1.26.2" | grep -q "golang"; then
+          if echo "golang:1.26.3" | grep -q "golang"; then
             /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
           fi
           make dist/loki-linux-riscv64
@@ -819,7 +819,7 @@ jobs:
         build-args: |
           IMAGE_TAG=${{ needs.version.outputs.version }}
           GOARCH=${{ steps.platform.outputs.platform_short }}
-          BUILD_IMAGE=golang:1.26.2
+          BUILD_IMAGE=golang:1.26.3
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=local,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}"

--- a/.github/workflows/querytee-images.yml
+++ b/.github/workflows/querytee-images.yml
@@ -17,7 +17,7 @@ permissions:
 env:
   BUILD_TIMEOUT: 60
   IMAGE_PREFIX: grafana
-  GO_VERSION: "1.26.2"
+  GO_VERSION: "1.26.3"
 
 jobs:
   loki-query-tee-image:

--- a/.github/workflows/verify-release-workflow.yaml
+++ b/.github/workflows/verify-release-workflow.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
       - name: setup jsonnet
         run: |
           go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ DOCKER_INTERACTIVE_FLAGS := --tty --interactive
 endif
 
 # Ensure you run `make release-workflows` after changing this
-GO_VERSION         := 1.26.2
+GO_VERSION         := 1.26.3
 # Ensure you run `make IMAGE_TAG=<updated-tag> build-image-push` after changing this
 BUILD_IMAGE_TAG    := 0.35.1
 

--- a/clients/cmd/fluent-bit/Dockerfile
+++ b/clients/cmd/fluent-bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 COPY . /src
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777673416,
-        "narHash": "sha256-5c2POKPOjU40Kh0MirOdScBLG0bu9TAuPYAtPRNZMBs=",
+        "lastModified": 1778430510,
+        "narHash": "sha256-Ti+ZBvW6yrWWAg2szExVTwCd4qOJ3KlVr1tFHfyfi8Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "26ef669cffa904b6f6832ab57b77892a37c1a671",
+        "rev": "8fd9daa3db09ced9700431c5b7ad0e8ba199b575",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1777578337,
-        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,14 +17,30 @@
     flake-utils.lib.eachDefaultSystem (
       system:
       let
+        # Override go_1_26 with upstream 1.26.3 — go.mod requires >=1.26.3 but
+        # nixpkgs hasn't packaged it yet. Drop this overlay once nixpkgs catches up.
+        goOverlay = _final: prev: {
+          go_1_26 = prev.go_1_26.overrideAttrs (_: rec {
+            version = "1.26.3";
+            src = prev.fetchurl {
+              url = "https://go.dev/dl/go${version}.src.tar.gz";
+              hash = "sha256-HGRoddCqh5kTMYTtV895/yS97+jIggRwYCqdPW2Rkrg=";
+            };
+          });
+          buildGo126Module = prev.buildGo126Module.override { go = _final.go_1_26; };
+          buildGoModule = prev.buildGoModule.override { go = _final.go_1_26; };
+        };
+
         base = import nixpkgs {
           inherit system;
+          overlays = [ goOverlay ];
           config = {
             allowUnfree = true;
           };
         };
         unstable = import nixpkgs-unstable {
           inherit system;
+          overlays = [ goOverlay ];
           config = {
             allowUnfree = true;
           };

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/loki/v3
 
-go 1.26.2
+go 1.26.3
 
 ignore ./tools/dev
 

--- a/pkg/push/go.mod
+++ b/pkg/push/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/loki/pkg/push
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/tools/dev/loki-tsdb-storage-s3/dev.dockerfile
+++ b/tools/dev/loki-tsdb-storage-s3/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2
+FROM golang:1.26.3
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.24.2
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1051,7 +1051,7 @@ github.com/grafana/gomemcache/memcache
 ## explicit; go 1.13
 github.com/grafana/jsonparser
 # github.com/grafana/loki/pkg/push v0.0.0-20250630054201-94c0ba7b0952 => ./pkg/push
-## explicit; go 1.26.2
+## explicit; go 1.26.3
 github.com/grafana/loki/pkg/push
 # github.com/grafana/otel-profiling-go v0.5.1
 ## explicit; go 1.16


### PR DESCRIPTION
**What this PR does / why we need it**:
Update go version to 1.26.3

Since nixpkgs are yet to be released with Go 1.26.3, I have added a temporary flake overlay that fetches the Go 1.26.3 source tarball from go.dev and rederives buildGoModule / buildGo126Module from it. Apply to both the base and unstable to keep the existing pattern intact. Overlay can be dropped once nixpkgs packages 1.26.3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a patch-level Go version bump touching build/CI/release configuration and toolchain metadata, with no product logic changes.
> 
> **Overview**
> Updates the repository’s Go toolchain requirement to `1.26.3` (including `go.mod`, `pkg/push/go.mod`, `Makefile`, and vendored module metadata).
> 
> Propagates the new version through CI/release GitHub Actions and Docker build images (including Fluent Bit and dev Dockerfiles), and updates Nix flake inputs plus adds a temporary overlay to provide Go `1.26.3` until `nixpkgs` packages it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbf7d028ddc71b19c784bea78fca1c94f3b2c822. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->