### PR TITLE
chore(operator): For release PRs adhere to new convention for commits

### DIFF
--- a/.github/workflows/operator-check-prepare-release-commit.yml
+++ b/.github/workflows/operator-check-prepare-release-commit.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: "write"
     if: |
       github.event.pull_request.head.ref == 'release-please--branches--main--components--operator' &&
-      contains(github.event.pull_request.title, 'chore( operator): community release')
+      contains(github.event.pull_request.title, 'chore( operator): Community release')
     steps:
 
       - name: Retrieve GitHub App Credentials from Vault
@@ -40,7 +40,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          SEMVER=$(echo "$PR_TITLE" | sed -n 's/^chore( operator): community release \([0-9]\+\.[0-9]\+\.[0-9]\+\)$/\1/p')
+          SEMVER=$(echo "$PR_TITLE" | sed -n 's/^chore( operator): Community release \([0-9]\+\.[0-9]\+\.[0-9]\+\)$/\1/p')
           echo "semver=$SEMVER" >> $GITHUB_OUTPUT
 
       - name: Checkout code
@@ -57,7 +57,7 @@ jobs:
           OUTPUTS_SEMVER: ${{ steps.pr_semver.outputs.semver }}
         working-directory: "release"
         run: |
-          COMMIT=$(gh search commits "chore(operator): prepare community release v${OUTPUTS_SEMVER}")
+          COMMIT=$(gh search commits "chore(operator): Prepare community release v${OUTPUTS_SEMVER}")
           if [ -n "$COMMIT" ]; then
             echo "Prepare release commit found."
           else

--- a/operator/docs/operator/release.md
+++ b/operator/docs/operator/release.md
@@ -60,7 +60,7 @@ Since the operator shares the same repo with Loki, we want to make sure that, wh
 
 #### Preventing merging the release-please PR without updating the manifests
 
-Since step 1. is currently not automated and disconnected from release-please we have put in place a workflow in `.github/workflows/operator-check-prepare-release-commit.yml` that runs on release-please PRs. This workflow is responsible for making sure that in master exists a commit with the message `chore(operator): prepare community release v$VERSION`. Once we automate step 1. we should be able to remove this workflow.
+Since step 1. is currently not automated and disconnected from release-please we have put in place a workflow in `.github/workflows/operator-check-prepare-release-commit.yml` that runs on release-please PRs. This workflow is responsible for making sure that in master exists a commit with the message `chore(operator): Prepare community release v$VERSION`. Once we automate step 1. we should be able to remove this workflow.
 
 ### Publish release to operatorhubs
 

--- a/operator/release-please-config.json
+++ b/operator/release-please-config.json
@@ -8,7 +8,7 @@
         "operator": {
             "component": "operator",
             "release-type": "go",
-            "pull-request-title-pattern": "chore(${component}): community release ${version}",
+            "pull-request-title-pattern": "chore(${component}): Community release ${version}",
             "changelog-path": "CHANGELOG.md"
         }
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: string/casing changes to release automation checks and documentation only, with no runtime product impact.
> 
> **Overview**
> Updates the operator release automation to match a new conventional casing for community releases.
> 
> Specifically, `release-please` now generates PR titles with **"Community release"** (capital C), and the `operator-check-prepare-release-commit` workflow’s title parsing and commit lookup are updated accordingly (including checking for `chore(operator): Prepare community release v$VERSION`). The operator release docs are updated to reflect the new required commit message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eae2905044d8f13d4974d95d0277d9296c0ba86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->