### PR TITLE
docs: Document tail endpoint limitations

### DIFF
--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -1166,6 +1166,10 @@ It accepts the following query parameters in the URL:
 
 In microservices mode, `/loki/api/v1/tail` is exposed by the querier.
 
+{{< admonition type="note" >}}
+The `tail` endpoint is designed for near real-time observation of a log stream. The initial lookback from `start` to the current time is best-effort and isn't guaranteed to return every matching log line, so this endpoint isn't suitable for retrieving complete log history. To reliably retrieve a large or complete range of logs, make repeated calls to [`/loki/api/v1/query_range`](#query-logs-within-a-range-of-time).
+{{< /admonition >}}
+
 Response format (streamed):
 
 ```json


### PR DESCRIPTION
**What this PR does / why we need it**:
Documents a limitation of the `/loki/api/v1/tail` endpoint that isn't currently called out in the HTTP API reference (I just ran into this and stumbled upon the open issue 😅)

**Which issue(s) this PR fixes**:
Fixes #14117

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that clarifies expected behavior of `/loki/api/v1/tail` without impacting runtime code.
> 
> **Overview**
> Adds a **note** to the `/loki/api/v1/tail` HTTP API reference clarifying that the initial `start`-to-now lookback is *best-effort* and may miss log lines, so `tail` should not be used for complete history.
> 
> Directs users to use repeated calls to `
> `/loki/api/v1/query_range`
> ` for reliably retrieving large or complete log ranges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a83ba61831a9ce67a56bb6152fcd243b054ca7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->