### PR TITLE
docs: Update Helm charts docs

### DIFF
--- a/docs/sources/setup/install/helm/_index.md
+++ b/docs/sources/setup/install/helm/_index.md
@@ -16,7 +16,7 @@ keywords:
 
 The [Helm](https://helm.sh/) chart lets you configure, install, and upgrade Grafana Loki within a Kubernetes cluster.
 
-This guide references the Loki Helm chart version 6.0 or greater and contains the following sections:
+This guide references the Loki community Helm chart and contains the following sections:
 
 {{< section menuTitle="true" >}}
 

--- a/docs/sources/setup/install/helm/install-microservices/_index.md
+++ b/docs/sources/setup/install/helm/install-microservices/_index.md
@@ -387,6 +387,47 @@ singleBinary:
 
 To configure other storage providers, refer to the [Helm Chart Reference](../reference/).
 
+## Gateway API
+
+As an alternative to traditional Kubernetes Ingress, the Loki Helm chart supports [Gateway API](https://gateway-api.sigs.k8s.io/) routes. There are two independent options depending on whether you want to keep the nginx gateway or bypass it entirely.
+
+### Option 1: Expose the nginx gateway via Gateway API
+
+Use `gateway.route` to replace `gateway.ingress` with a Gateway API route that points to the nginx gateway. This keeps nginx as the proxy but exposes it through a Gateway API resource instead of a traditional Ingress.
+
+```yaml
+gateway:
+  ingress:
+    enabled: false  # disable traditional Ingress
+  route:
+    main:
+      enabled: true
+      kind: HTTPRoute
+      parentRefs:
+        - name: my-gateway
+          namespace: gateway-namespace
+      hostnames:
+        - loki.example.com
+```
+
+### Option 2: Bypass nginx and route directly to Loki services
+
+Use the top-level `route:` key (mutually exclusive with the top-level `ingress:`) to route Gateway API traffic directly to Loki services, bypassing nginx. The chart auto-generates path-based rules that route requests to the correct microservice components (distributor, query-frontend, ruler, compactor) when `deploymentMode: Distributed` is set.
+
+```yaml
+route:
+  main:
+    enabled: true
+    kind: HTTPRoute
+    parentRefs:
+      - name: my-gateway
+        namespace: gateway-namespace
+    hostnames:
+      - loki.example.com
+```
+
+For both options, if `apiVersion` is not set, the chart auto-detects the latest available Gateway API version installed in the cluster. Supported route kinds include `HTTPRoute`, `GRPCRoute`, `TCPRoute`, `TLSRoute`, and `UDPRoute`.
+
 ## Deploying the Loki Helm chart to a Production Environment
 
 {{< admonition type="note" >}}

--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -77,7 +77,7 @@ loki:
 minio:
   enabled: true
       
-deploymentMode: SingleBinary
+deploymentMode: Monolithic
 
 singleBinary:
   replicas: 1
@@ -154,7 +154,7 @@ loki:
 minio:
   enabled: true
       
-deploymentMode: SingleBinary
+deploymentMode: Monolithic
 
 singleBinary:
   replicas: 3
@@ -289,7 +289,7 @@ loki:
 minio:
   enabled: false
 
-deploymentMode: SingleBinary
+deploymentMode: Monolithic
 
 singleBinary:
   replicas: 3
@@ -375,7 +375,7 @@ loki:
 minio:
   enabled: false
 
-deploymentMode: SingleBinary
+deploymentMode: Monolithic
 
 singleBinary:
   replicas: 3

--- a/docs/sources/setup/install/helm/install-scalable/_index.md
+++ b/docs/sources/setup/install/helm/install-scalable/_index.md
@@ -256,6 +256,47 @@ minio:
 
 To configure other storage providers, refer to the [Helm Chart Reference](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/reference/).
 
+## Gateway API
+
+As an alternative to traditional Kubernetes Ingress, the Loki Helm chart supports [Gateway API](https://gateway-api.sigs.k8s.io/) routes. There are two independent options depending on whether you want to keep the nginx gateway or bypass it entirely.
+
+### Option 1: Expose the nginx gateway via Gateway API
+
+Use `gateway.route` to replace `gateway.ingress` with a Gateway API route that points to the nginx gateway. This keeps nginx as the proxy but exposes it through a Gateway API resource instead of a traditional Ingress.
+
+```yaml
+gateway:
+  ingress:
+    enabled: false  # disable traditional Ingress
+  route:
+    main:
+      enabled: true
+      kind: HTTPRoute
+      parentRefs:
+        - name: my-gateway
+          namespace: gateway-namespace
+      hostnames:
+        - loki.example.com
+```
+
+### Option 2: Bypass nginx and route directly to Loki services
+
+Use the top-level `route:` key (mutually exclusive with the top-level `ingress:`) to route Gateway API traffic directly to Loki services, bypassing nginx. The chart auto-generates path-based rules that route write traffic to the write component and read traffic to the read component.
+
+```yaml
+route:
+  main:
+    enabled: true
+    kind: HTTPRoute
+    parentRefs:
+      - name: my-gateway
+        namespace: gateway-namespace
+    hostnames:
+      - loki.example.com
+```
+
+For both options, if `apiVersion` is not set, the chart auto-detects the latest available Gateway API version installed in the cluster. Supported route kinds include `HTTPRoute`, `GRPCRoute`, `TCPRoute`, `TLSRoute`, and `UDPRoute`.
+
 ## Next Steps
 
 * Configure an agent to [send log data to Loki](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/).


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Helm Charts documentation to match the past two weeks effort by the Community.

**Special notes for your reviewer**:

Written with AI
Validated both the plan and the implementation with different models
Reviewed by a human (me) before submitting the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that don’t change runtime behavior, but could impact users if configuration guidance is misunderstood.
> 
> **Overview**
> Updates the Helm install landing page to reference the *community-maintained* Loki chart (Grafana-community repo) rather than a specific chart version.
> 
> Aligns monolithic install examples with the chart rename from `deploymentMode: SingleBinary` to `deploymentMode: Monolithic`.
> 
> Adds a new **Gateway API** section to the microservices and simple-scalable install guides, documenting both exposing the nginx gateway via `gateway.route` and bypassing nginx with top-level `route:` (auto-generated path routing), including supported route kinds and API version auto-detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba2d39aae801c9aa2ea3d20bb9daaff0be582f78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->