### PR TITLE
docs: Remove link to blog

### DIFF
--- a/docs/sources/operations/storage/tsdb.md
+++ b/docs/sources/operations/storage/tsdb.md
@@ -6,7 +6,7 @@ weight: 100
 ---
 # Single Store TSDB (tsdb)
 
-Starting with Loki v2.8, TSDB is the recommended Loki index. It is heavily inspired by the Prometheus's TSDB [sub-project](https://github.com/prometheus/prometheus/tree/main/tsdb). For a deeper explanation you can read Loki maintainer Owen's [blog post](https://www.pikach.us/posts/tsdb/). The short version is that this new index is more efficient, faster, and more scalable. It also resides in object storage like the boltdb-shipper index which preceded it.
+Starting with Loki v2.8, TSDB is the recommended Loki index. It is heavily inspired by the Prometheus's TSDB [sub-project](https://github.com/prometheus/prometheus/tree/main/tsdb). This new index is more efficient, faster, and more scalable. It also resides in object storage like the boltdb-shipper index which preceded it.
 
 ## Example Configuration
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Someone mentioned at the offsite that Owen had lost his domain.  When I checked, his blog is still there, but the linked blog post no longer exists. So deleting the link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes an outdated external reference with no behavior or configuration impact.
> 
> **Overview**
> Updates `docs/sources/operations/storage/tsdb.md` to drop the reference/link to an external maintainer blog post that no longer exists, leaving the TSDB introduction as a self-contained description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e6849855a617741206e3a7cdf167eb7273292af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->