### PR TITLE
docs: backport tail endpoint limitations to 3.7

### DIFF
--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -1166,6 +1166,10 @@ It accepts the following query parameters in the URL:
 
 In microservices mode, `/loki/api/v1/tail` is exposed by the querier.
 
+{{< admonition type="note" >}}
+The `tail` endpoint is designed for near real-time observation of a log stream. The initial lookback from `start` to the current time is best-effort and isn't guaranteed to return every matching log line, so this endpoint isn't suitable for retrieving complete log history. To reliably retrieve a large or complete range of logs, make repeated calls to [`/loki/api/v1/query_range`](#query-logs-within-a-range-of-time).
+{{< /admonition >}}
+
 Response format (streamed):
 
 ```json


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of #21839 to 3.7 branch.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies `GET /loki/api/v1/tail` behavior and guides users to `query_range` for complete history.
> 
> **Overview**
> Adds a **note** to the `GET /loki/api/v1/tail` docs clarifying that the initial `start`→now lookback is *best-effort* and may miss log lines, so `tail` should be used for near real-time observation rather than complete history.
> 
> Recommends using repeated calls to `GET /loki/api/v1/query_range` when users need reliable retrieval of large or complete log ranges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba0e4b83d7688c9b459794f49ff184920b94c841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->