### PR TITLE
docs: backport tail endpoint limitations to 3.6

### DIFF
--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -1028,6 +1028,10 @@ It accepts the following query parameters in the URL:
 
 In microservices mode, `/loki/api/v1/tail` is exposed by the querier.
 
+{{< admonition type="note" >}}
+The `tail` endpoint is designed for near real-time observation of a log stream. The initial lookback from `start` to the current time is best-effort and isn't guaranteed to return every matching log line, so this endpoint isn't suitable for retrieving complete log history. To reliably retrieve a large or complete range of logs, make repeated calls to [`/loki/api/v1/query_range`](#query-logs-within-a-range-of-time).
+{{< /admonition >}}
+
 Response format (streamed):
 
 ```json


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of https://github.com/grafana/loki/pull/21839 to 3.6 branch.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adds guidance about `tail` limitations without affecting runtime behavior.
> 
> **Overview**
> Adds a **note** to the `/loki/api/v1/tail` docs clarifying the endpoint is intended for near real-time streaming and that the initial `start`→now lookback is *best-effort* and may miss lines.
> 
> Recommends using repeated calls to `GET /loki/api/v1/query_range` when users need reliable or complete log history retrieval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 003e03c9065106bf14fb53e43f6891ebbcac6cad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->