### PR TITLE
chore: Update loki release workflows on release-3.7.x branch

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
+      "version": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc",
-      "sum": "LfNl0q+23sWMu/zwsqHfbUuEfYZMNN2xpZBRizUUHHY="
+      "version": "52d476dc60de14b52b6dec2b33e86abeeb497fcc",
+      "sum": "Xmuvvfw2GyoFFNYxsFUSOEEC7BvP/Ln5sfDucjQvh/Q="
     }
   ],
   "legacyImports": false

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -315,13 +315,12 @@ local runner = import 'runner.libsonnet',
       pr_created: '${{ steps.version.outputs.pr_created }}',
     }),
 
-  dist: function(buildImage, skipArm=true, useGCR=false, makeTargets=['dist', 'packages'], runsOn='ubuntu-latest')
+  dist: function(buildImage, skipArm=true, useGCR=false, makeTargets=['dist', 'packages'], optionalTargets=[], runsOn='ubuntu-latest')
     job.new(runsOn)
     + job.withPermissions({
       'id-token': 'write',
     })
     + job.withSteps([
-      common.cleanUpBuildCache,
       common.fetchReleaseRepo,
       common.fetchGcsCredentials,
       common.googleAuth,
@@ -373,6 +372,45 @@ local runner = import 'runner.libsonnet',
             make %s
           EOF
         ||| % [buildImage, buildImage, std.join(' ', makeTargets)]
+      ),
+
+      releaseStep('build optional artifacts')
+      + step.withContinueOnError()
+      + step.withIf('${{ fromJSON(needs.version.outputs.pr_created) }}')
+      + step.withEnv({
+        BUILD_IN_CONTAINER: false,
+        DRONE_TAG: '${{ needs.version.outputs.version }}',
+        IMAGE_TAG: '${{ needs.version.outputs.version }}',
+      })
+      + if std.length(optionalTargets) > 0 then step.withRun(
+        (
+          if useGCR then |||
+            gcloud auth configure-docker
+          ||| else ''
+        ) +
+        |||
+          cat <<EOF | docker run \
+            --interactive \
+            --env BUILD_IN_CONTAINER \
+            --env DRONE_TAG \
+            --env IMAGE_TAG \
+            --volume .:/src/loki \
+            --workdir /src/loki \
+            --entrypoint /bin/sh "%(image)s"
+            git config --global --add safe.directory /src/loki
+            if echo "%(image)s" | grep -q "golang"; then
+              /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
+            fi
+            make %(targets)s
+          EOF
+        ||| % {
+          image: buildImage,
+          targets: std.join(' ', optionalTargets),
+        }
+      ) else step.withRun(
+        |||
+          echo "Nothing to do"
+        |||
       ),
 
       step.new('upload artifacts', 'google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0')  // v2

--- a/.github/vendor/github.com/grafana/loki-release/workflows/common.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/common.libsonnet
@@ -29,6 +29,9 @@
     withTimeoutMinutes: function(timeout) {
       'timeout-minutes': timeout,
     },
+    withContinueOnError: function() {
+      'continue-on-error': true,
+    },
   },
   job: {
     new: function(runsOn='ubuntu-latest') {

--- a/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
@@ -14,6 +14,7 @@
     changelogPath='CHANGELOG.md',
     checkTemplate='./.github/workflows/check.yml',
     distMakeTargets=['dist', 'packages'],
+    distOptionalTargets=[],
     distRunsOn='ubuntu-latest',
     dryRun=false,
     dockerUsername='grafana',
@@ -81,7 +82,7 @@
                GCS_SERVICE_ACCOUNT_KEY: '${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}',
              }) else {},
       version: $.build.version + $.common.job.withNeeds(validationSteps),
-      dist: $.build.dist(buildImage, skipArm, useGCR, distMakeTargets, distRunsOn)
+      dist: $.build.dist(buildImage, skipArm, useGCR, distMakeTargets, distOptionalTargets, distRunsOn)
             + $.common.job.withNeeds(['version'])
             + $.common.job.withPermissions({
               contents: 'write',

--- a/.github/vendor/github.com/grafana/loki-release/workflows/runner.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/runner.libsonnet
@@ -2,6 +2,7 @@ local defaultMapping = {
   'linux/amd64': ['github-hosted-ubuntu-x64-small'],
   'linux/arm64': ['github-hosted-ubuntu-arm64-small'],
   'linux/arm': ['github-hosted-ubuntu-arm64-small'],  // equal to linux/arm/v7
+  'linux/riscv64': ['ubuntu-26.04-riscv'],  // https://github.com/apps/rise-risc-v-runners
 };
 
 {

--- a/.github/vendor/github.com/grafana/loki-release/workflows/workflows.jsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/workflows.jsonnet
@@ -18,6 +18,8 @@ local dockerPluginDir = 'clients/cmd/docker-driver';
       imagePrefix='trevorwhitney075',
       releaseLibRef='main',
       releaseRepo='grafana/loki-release',
+      distRunsOn='ubuntu-26.04',
+      distOptionalTargets=['dist/loki-linux-riscv64'],
       skipValidation=false,
       versioningStrategy='always-bump-patch',
     ) + {

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@52d476dc60de14b52b6dec2b33e86abeeb497fcc"
     "with":
       "build_image": "grafana/loki-build-image:0.35.1"
       "golang_ci_lint_version": "v2.11.4"
-      "release_lib_ref": "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
+      "release_lib_ref": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@52d476dc60de14b52b6dec2b33e86abeeb497fcc"
     "with":
       "build_image": "grafana/loki-build-image:0.35.1"
       "golang_ci_lint_version": "v2.11.4"
-      "release_lib_ref": "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
+      "release_lib_ref": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
       "skip_validation": false
       "use_github_app_token": true
   "loki-canary-boringcrypto-image":
@@ -12,7 +12,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.1"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
+      "RELEASE_LIB_REF": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -136,7 +136,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.1"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
+      "RELEASE_LIB_REF": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -260,7 +260,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.1"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
+      "RELEASE_LIB_REF": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -384,7 +384,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.1"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
+      "RELEASE_LIB_REF": "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -8,7 +8,7 @@ env:
   DRY_RUN: false
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
+  RELEASE_LIB_REF: "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
@@ -19,11 +19,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
+    uses: "grafana/loki-release/.github/workflows/check.yml@52d476dc60de14b52b6dec2b33e86abeeb497fcc"
     with:
       build_image: "grafana/loki-build-image:0.35.1"
       golang_ci_lint_version: "v2.11.4"
-      release_lib_ref: "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
+      release_lib_ref: "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -131,8 +131,6 @@ jobs:
       pull-requests: "write"
     runs-on: "ubuntu-x64"
     steps:
-    - name: "clean up build tools cache"
-      run: "rm -rf /opt/hostedtoolcache"
     - name: "pull code to release"
       uses: "actions/checkout@v4"
       with:
@@ -187,6 +185,16 @@ jobs:
           fi
           make dist packages
         EOF
+      working-directory: "release"
+    - continue-on-error: true
+      env:
+        BUILD_IN_CONTAINER: false
+        DRONE_TAG: "${{ needs.version.outputs.version }}"
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "build optional artifacts"
+      run: |
+        echo "Nothing to do"
       working-directory: "release"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "upload artifacts"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -8,7 +8,7 @@ env:
   DRY_RUN: false
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
+  RELEASE_LIB_REF: "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
@@ -19,11 +19,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
+    uses: "grafana/loki-release/.github/workflows/check.yml@52d476dc60de14b52b6dec2b33e86abeeb497fcc"
     with:
       build_image: "grafana/loki-build-image:0.35.1"
       golang_ci_lint_version: "v2.11.4"
-      release_lib_ref: "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
+      release_lib_ref: "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -131,8 +131,6 @@ jobs:
       pull-requests: "write"
     runs-on: "ubuntu-x64"
     steps:
-    - name: "clean up build tools cache"
-      run: "rm -rf /opt/hostedtoolcache"
     - name: "pull code to release"
       uses: "actions/checkout@v4"
       with:
@@ -187,6 +185,16 @@ jobs:
           fi
           make dist packages
         EOF
+      working-directory: "release"
+    - continue-on-error: true
+      env:
+        BUILD_IN_CONTAINER: false
+        DRONE_TAG: "${{ needs.version.outputs.version }}"
+        IMAGE_TAG: "${{ needs.version.outputs.version }}"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "build optional artifacts"
+      run: |
+        echo "Nothing to do"
       working-directory: "release"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "upload artifacts"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "fb3b12ec3e6411bcb951a5ea08cc983c2f2735fc"
+  RELEASE_LIB_REF: "52d476dc60de14b52b6dec2b33e86abeeb497fcc"
   RELEASE_REPO: "grafana/loki"
   USE_GITHUB_APP_TOKEN: true
 jobs:


### PR DESCRIPTION
**What this PR does / why we need it**:
The cleanup build cache step has been failing due to a permission issue.
Removing the steps with the same changes as PR https://github.com/grafana/loki/pull/21623.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates shared release workflow dependencies and modifies release PR build jobs; mistakes could break artifact publishing or release automation despite being limited to CI configuration.
> 
> **Overview**
> Bumps the vendored `grafana/loki-release` workflow library ref (and updates all workflow `uses`/`RELEASE_LIB_REF` pins) to a newer commit.
> 
> Adjusts the release PR `dist` job to **stop cleaning the hosted tool cache**, and introduces an *optional artifacts* build step that runs `make` for extra targets with `continue-on-error` (wired through new `distOptionalTargets`).
> 
> Extends runner mapping to include `linux/riscv64`, and configures the generated release PR workflow to run `dist` on `ubuntu-26.04` and attempt building `dist/loki-linux-riscv64`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 314ffa143211f8419209608abb541410f05df342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->