### PR TITLE
fix(storage): attach SHA-256 checksum on PutObject for Object Lock buckets

### DIFF
--- a/pkg/storage/chunk/client/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client.go
@@ -532,6 +532,15 @@ func (a *S3ObjectClient) PutObject(ctx context.Context, objectKey string, object
 			Bucket:       aws.String(a.bucketFromKey(objectKey)),
 			Key:          aws.String(a.convertObjectKey(objectKey, true)),
 			StorageClass: types.StorageClass(a.cfg.StorageClass),
+			// Buckets with Object Lock enabled reject PutObject requests
+			// that lack either Content-MD5 or one of the x-amz-checksum-*
+			// headers with `InvalidRequest: Content-MD5 OR x-amz-checksum-
+			// HTTP header is required for Put Object requests with Object
+			// Lock parameters`. Ask the SDK to compute and attach a
+			// SHA-256 trailer so compliance buckets accept uploads
+			// without forcing operators to buffer every chunk for MD5
+			// (grafana/loki#20088).
+			ChecksumAlgorithm: types.ChecksumAlgorithmSha256,
 		}
 
 		if a.sseConfig != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

(cherry picked from commit c83d748936d85bd91d3e1f45cd22891c324da2a6)

Fixes Loki refusing to write any S3 bucket that has Object Lock enabled (commonly required for compliance / audit retention).

S3 buckets with Object Lock reject `PutObject` requests that lack either a `Content-MD5` header or one of the `x-amz-checksum-*` headers:

```
api error InvalidRequest: Content-MD5 OR x-amz-checksum- HTTP header is
required for Put Object requests with Object Lock parameters
```

Between Loki 3.5.7 and 3.6.x the aws-sdk-go-v2 upgrade changed the default behaviour: uploads no longer carry a checksum unless the caller asks, so writing any compliance-configured bucket now fails. Setting `PutObjectInput.ChecksumAlgorithm = SHA256` instructs the SDK to compute the hash incrementally and stream it as an `aws-chunked` trailer (`x-amz-trailer: x-amz-checksum-sha256`) — no body buffering required.

Non-Object-Lock buckets accept the extra header as well, so the change is safe for every target.

**Which issue(s) this PR fixes**:

Fixes #20088

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes all S3 `PutObject` uploads to include a SHA-256 checksum trailer, which can affect compatibility with some S3-compatible backends or request signing/streaming behavior, but is scoped to a single request parameter.
> 
> **Overview**
> Fixes uploads to S3 buckets with **Object Lock enabled** by always requesting the AWS SDK to compute and attach a `SHA256` checksum on `PutObject` (`ChecksumAlgorithm: types.ChecksumAlgorithmSha256`). This avoids needing `Content-MD5` buffering while making Loki writes acceptable to compliance buckets (grafana/loki#20088).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e0e2e53a9973aece674894eb710906fe0998762. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->