### PR TITLE
chore: Update go version at the left out places in release-3.6.x branch

### DIFF
--- a/clients/cmd/fluent-bit/Dockerfile
+++ b/clients/cmd/fluent-bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.26.2-bookworm AS builder
 
 COPY . /src
 

--- a/pkg/push/go.mod
+++ b/pkg/push/go.mod
@@ -1,8 +1,6 @@
 module github.com/grafana/loki/pkg/push
 
-go 1.25.0
-
-toolchain go1.25.8
+go 1.26.2
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1252,7 +1252,7 @@ github.com/grafana/gomemcache/memcache
 ## explicit; go 1.13
 github.com/grafana/jsonparser
 # github.com/grafana/loki/pkg/push v0.0.0-20250630054201-94c0ba7b0952 => ./pkg/push
-## explicit; go 1.25.0
+## explicit; go 1.26.2
 github.com/grafana/loki/pkg/push
 # github.com/grafana/otel-profiling-go v0.5.1
 ## explicit; go 1.16


### PR DESCRIPTION
**What this PR does / why we need it**:
I missed updating some places. An update to the fluentbit Dockerfile is required because the build is failing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily build/toolchain changes, but updating the Go version and removing a pinned toolchain can affect CI/build reproducibility and dependency vendoring.
> 
> **Overview**
> Aligns leftover Go version references to `1.26.2`.
> 
> The fluent-bit output plugin Docker build now uses `golang:1.26.2-bookworm`, and `pkg/push/go.mod` is updated to `go 1.26.2` while dropping the `toolchain` pin; `vendor/modules.txt` is adjusted accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8379b555922d268a34d3348e64920cbdf54d0f38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->