### PR TITLE
chore: Don't buffer streams with no entries in the first place

### DIFF
--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -245,10 +245,8 @@ func (ts *TeeService) batchesForTenant(
 			batches[tenant][addr] = batch
 		}
 
-		if len(stream.Stream.Entries) > 0 {
-			batch.Streams = append(batch.Streams, stream.Stream)
-			ts.teedStreams.WithLabelValues("batched").Inc()
-		}
+		batch.Streams = append(batch.Streams, stream.Stream)
+		ts.teedStreams.WithLabelValues("batched").Inc()
 	}
 
 	streamCount := uint64(len(streams))
@@ -427,11 +425,14 @@ func (ts *TeeService) Duplicate(_ context.Context, tenant string, streams []dist
 	}
 
 	for _, stream := range streams {
+		// Skip streams with no entries.
+		if len(stream.Stream.Entries) == 0 {
+			continue
+		}
+
 		lbls, err := syntax.ParseLabels(stream.Stream.Labels)
 		if err != nil {
-			level.Error(ts.logger).
-				Log("msg", "error parsing stream labels", "labels", stream.Stream.Labels, "err", err)
-
+			level.Error(ts.logger).Log("msg", "error parsing stream labels", "labels", stream.Stream.Labels, "err", err)
 			continue
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This moves the check for streams with no entries out of `batchesForTenant` and into `Duplicate`. This means we no longer buffer streams, nor perform lookups in the ring, for streams that we are just going to discard anyway.

I am making this fix as we are going to put a limit on the max number of bytes that can be buffered in the tee at a time.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small control-flow change that only affects handling of streams with zero entries, reducing buffering and ring lookups without altering non-empty stream behavior.
> 
> **Overview**
> Avoids teeing empty log streams by filtering them in `TeeService.Duplicate` before buffering.
> 
> As a result, `batchesForTenant` now always appends buffered streams (since they’re guaranteed non-empty), and the error logging for label parsing is slightly simplified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a22713f47e1d4eddcc6ba0f06bd29fbb17b70ed7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->