### PR TITLE
feat: Add limit on max buffered bytes in pattern-tee

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1072,6 +1072,10 @@ pattern_ingester:
     # CLI flag: -pattern-ingester.tee.flush-worker-count
     [flush_worker_count: <int> | default = 100]
 
+    # The maximum number of bytes that can be buffered before dropping
+    # CLI flag: -pattern-ingester.tee.max-buffered-bytes
+    [max_buffered_bytes: <int> | default = 0]
+
     # The max time we will try to flush any remaining logs to be mined when the
     # service is stopped
     # CLI flag: -pattern-ingester.tee.stop-flush-timeout

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1072,7 +1072,8 @@ pattern_ingester:
     # CLI flag: -pattern-ingester.tee.flush-worker-count
     [flush_worker_count: <int> | default = 100]
 
-    # The maximum number of bytes that can be buffered before dropping
+    # The maximum number of bytes that can be buffered before dropping, 0 means
+    # disabled
     # CLI flag: -pattern-ingester.tee.max-buffered-bytes
     [max_buffered_bytes: <int> | default = 0]
 

--- a/pkg/pattern/ingester.go
+++ b/pkg/pattern/ingester.go
@@ -135,6 +135,7 @@ type TeeConfig struct {
 	BatchFlushInterval time.Duration `yaml:"batch_flush_interval"`
 	FlushQueueSize     int           `yaml:"flush_queue_size"`
 	FlushWorkerCount   int           `yaml:"flush_worker_count"`
+	MaxBufferedBytes   int           `yaml:"max_buffered_bytes"`
 	StopFlushTimeout   time.Duration `yaml:"stop_flush_timeout"`
 }
 
@@ -162,6 +163,12 @@ func (cfg *TeeConfig) RegisterFlags(f *flag.FlagSet, prefix string) {
 		prefix+"tee.flush-worker-count",
 		100,
 		"the number of concurrent workers sending logs to the template service",
+	)
+	f.IntVar(
+		&cfg.MaxBufferedBytes,
+		prefix+"tee.max-buffered-bytes",
+		0,
+		"The maximum number of bytes that can be buffered before dropping",
 	)
 	f.DurationVar(
 		&cfg.StopFlushTimeout,

--- a/pkg/pattern/ingester.go
+++ b/pkg/pattern/ingester.go
@@ -168,7 +168,7 @@ func (cfg *TeeConfig) RegisterFlags(f *flag.FlagSet, prefix string) {
 		&cfg.MaxBufferedBytes,
 		prefix+"tee.max-buffered-bytes",
 		0,
-		"The maximum number of bytes that can be buffered before dropping",
+		"The maximum number of bytes that can be buffered before dropping, 0 means disabled",
 	)
 	f.DurationVar(
 		&cfg.StopFlushTimeout,

--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -34,18 +34,16 @@ type TeeService struct {
 	ringClient RingClient
 	wg         *sync.WaitGroup
 
-	ingesterAppends       *prometheus.CounterVec
-	ingesterMetricAppends *prometheus.CounterVec
-
-	teedStreams  *prometheus.CounterVec
-	teedRequests *prometheus.CounterVec
-
-	sendDuration *instrument.HistogramCollector
-
 	flushQueue chan clientRequest
 
 	buffersMutex *sync.Mutex
 	buffers      map[string][]distributor.KeyedStream
+
+	ingesterAppends       *prometheus.CounterVec
+	ingesterMetricAppends *prometheus.CounterVec
+	teedStreams           *prometheus.CounterVec
+	teedRequests          *prometheus.CounterVec
+	sendDuration          *instrument.HistogramCollector
 }
 
 func NewTeeService(
@@ -60,7 +58,17 @@ func NewTeeService(
 	registerer = prometheus.WrapRegistererWithPrefix(metricsNamespace+"_", registerer)
 
 	t := &TeeService{
-		logger: log.With(logger, "component", "pattern-tee"),
+		logger:     log.With(logger, "component", "pattern-tee"),
+		cfg:        cfg,
+		limits:     limits,
+		tenantCfgs: tenantCfgs,
+		ringClient: ringClient,
+
+		wg:           &sync.WaitGroup{},
+		buffersMutex: &sync.Mutex{},
+		buffers:      make(map[string][]distributor.KeyedStream),
+		flushQueue:   make(chan clientRequest, cfg.TeeConfig.FlushQueueSize),
+
 		ingesterAppends: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Name: "pattern_ingester_appends_total",
 			Help: "The total number of batch appends sent to pattern ingesters.",
@@ -86,15 +94,6 @@ func NewTeeService(
 				}, instrument.HistogramCollectorBuckets,
 			),
 		),
-		cfg:        cfg,
-		limits:     limits,
-		tenantCfgs: tenantCfgs,
-		ringClient: ringClient,
-
-		wg:           &sync.WaitGroup{},
-		buffersMutex: &sync.Mutex{},
-		buffers:      make(map[string][]distributor.KeyedStream),
-		flushQueue:   make(chan clientRequest, cfg.TeeConfig.FlushQueueSize),
 	}
 
 	return t, nil

--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -36,8 +36,8 @@ type TeeService struct {
 
 	flushQueue chan clientRequest
 
-	buffersMutex *sync.Mutex
-	buffers      map[string][]distributor.KeyedStream
+	bufMtx *sync.Mutex
+	buf    map[string][]distributor.KeyedStream
 
 	ingesterAppends       *prometheus.CounterVec
 	ingesterMetricAppends *prometheus.CounterVec
@@ -64,10 +64,10 @@ func NewTeeService(
 		tenantCfgs: tenantCfgs,
 		ringClient: ringClient,
 
-		wg:           &sync.WaitGroup{},
-		buffersMutex: &sync.Mutex{},
-		buffers:      make(map[string][]distributor.KeyedStream),
-		flushQueue:   make(chan clientRequest, cfg.TeeConfig.FlushQueueSize),
+		wg:         &sync.WaitGroup{},
+		bufMtx:     &sync.Mutex{},
+		buf:        make(map[string][]distributor.KeyedStream),
+		flushQueue: make(chan clientRequest, cfg.TeeConfig.FlushQueueSize),
 
 		ingesterAppends: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Name: "pattern_ingester_appends_total",
@@ -166,15 +166,15 @@ func (ts *TeeService) WaitUntilDone() {
 }
 
 func (ts *TeeService) flush() {
-	ts.buffersMutex.Lock()
-	if len(ts.buffers) == 0 {
-		ts.buffersMutex.Unlock()
+	ts.bufMtx.Lock()
+	if len(ts.buf) == 0 {
+		ts.bufMtx.Unlock()
 		return
 	}
 
-	buffered := ts.buffers
-	ts.buffers = make(map[string][]distributor.KeyedStream)
-	ts.buffersMutex.Unlock()
+	buffered := ts.buf
+	ts.buf = make(map[string][]distributor.KeyedStream)
+	ts.bufMtx.Unlock()
 
 	batches := make([]map[string]map[string]*logproto.PushRequest, 0, len(buffered))
 	for tenant, streams := range buffered {
@@ -440,9 +440,9 @@ func (ts *TeeService) Duplicate(_ context.Context, tenant string, streams []dist
 			continue
 		}
 
-		ts.buffersMutex.Lock()
-		ts.buffers[tenant] = append(ts.buffers[tenant], stream)
-		ts.buffersMutex.Unlock()
+		ts.bufMtx.Lock()
+		ts.buf[tenant] = append(ts.buf[tenant], stream)
+		ts.bufMtx.Unlock()
 	}
 }
 

--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -245,10 +245,8 @@ func (ts *TeeService) batchesForTenant(
 			batches[tenant][addr] = batch
 		}
 
-		if len(stream.Stream.Entries) > 0 {
-			batch.Streams = append(batch.Streams, stream.Stream)
-			ts.teedStreams.WithLabelValues("batched").Inc()
-		}
+		batch.Streams = append(batch.Streams, stream.Stream)
+		ts.teedStreams.WithLabelValues("batched").Inc()
 	}
 
 	streamCount := uint64(len(streams))
@@ -427,11 +425,14 @@ func (ts *TeeService) Duplicate(_ context.Context, tenant string, streams []dist
 	}
 
 	for _, stream := range streams {
+		// Skip streams with no entries.
+		if len(stream.Stream.Entries) == 0 {
+			continue
+		}
+
 		lbls, err := syntax.ParseLabels(stream.Stream.Labels)
 		if err != nil {
-			level.Error(ts.logger).
-				Log("msg", "error parsing stream labels", "labels", stream.Stream.Labels, "err", err)
-
+			level.Error(ts.logger).Log("msg", "error parsing stream labels", "labels", stream.Stream.Labels, "err", err)
 			continue
 		}
 

--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -500,7 +500,7 @@ func (ts *TeeService) tryReserveBufferedBytes(size int) bool {
 			return false
 		}
 		// If we won the CAS, our new size was reserved, and we can return true.
-		// If someone else round the CAS, we must loop and make another attempt.
+		// If someone else won the CAS, we must loop and make another attempt.
 		if ts.bufferedBytes.CompareAndSwap(oldVal, newVal) {
 			ts.bufferedBytesMaxSample.Add(int64(size))
 			return true

--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -172,13 +172,13 @@ func (ts *TeeService) Start(runCtx context.Context) error {
 		}
 	}()
 
-	services.StartAndAwaitRunning(runCtx, ts.bufferedBytesMaxSample)
+	_ = services.StartAndAwaitRunning(runCtx, ts.bufferedBytesMaxSample)
 	return nil
 }
 
 func (ts *TeeService) WaitUntilDone() {
 	ts.wg.Wait()
-	services.StopAndAwaitTerminated(context.TODO(), ts.bufferedBytesMaxSample)
+	_ = services.StopAndAwaitTerminated(context.TODO(), ts.bufferedBytesMaxSample)
 }
 
 func (ts *TeeService) flush() {
@@ -493,15 +493,15 @@ func (ts *TeeService) tryReserveBufferedBytes(size int) bool {
 		return true
 	}
 	for {
-		old := ts.bufferedBytes.Load()
-		new := old + int64(size)
-		if new > maxBufferedBytes {
+		oldVal := ts.bufferedBytes.Load()
+		newVal := oldVal + int64(size)
+		if newVal > maxBufferedBytes {
 			// size exceeds the limit, so cannot be reserved.
 			return false
 		}
 		// If we won the CAS, our new size was reserved, and we can return true.
-		// Otherwise, someone else round the CAS, and we should loop again.
-		if ts.bufferedBytes.CompareAndSwap(old, new) {
+		// If someone else round the CAS, we must loop and make another attempt.
+		if ts.bufferedBytes.CompareAndSwap(oldVal, newVal) {
 			ts.bufferedBytesMaxSample.Add(int64(size))
 			return true
 		}

--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"sync/atomic" //lint:ignore faillint we use new atomic types from sync/atomic.
 	"time"
 
 	"github.com/go-kit/log"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/grafana/dskit/instrument"
 	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/user"
 
 	"github.com/grafana/loki/v3/pkg/distributor"
@@ -21,6 +23,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/runtime"
 	"github.com/grafana/loki/v3/pkg/util/constants"
+	metric_util "github.com/grafana/loki/v3/pkg/util/metric"
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 
 	ring_client "github.com/grafana/dskit/ring/client"
@@ -39,11 +42,17 @@ type TeeService struct {
 	bufMtx *sync.Mutex
 	buf    map[string][]distributor.KeyedStream
 
-	ingesterAppends       *prometheus.CounterVec
-	ingesterMetricAppends *prometheus.CounterVec
-	teedStreams           *prometheus.CounterVec
-	teedRequests          *prometheus.CounterVec
-	sendDuration          *instrument.HistogramCollector
+	// bufferedBytes is a count of the total number of bytes in buf, and all
+	// client requests in the flushQueue.
+	bufferedBytes atomic.Int64
+
+	// Metrics.
+	bufferedBytesMaxSample *metric_util.MaxSampleCollector
+	ingesterAppends        *prometheus.CounterVec
+	ingesterMetricAppends  *prometheus.CounterVec
+	teedStreams            *prometheus.CounterVec
+	teedRequests           *prometheus.CounterVec
+	sendDuration           *instrument.HistogramCollector
 }
 
 func NewTeeService(
@@ -69,6 +78,10 @@ func NewTeeService(
 		buf:        make(map[string][]distributor.KeyedStream),
 		flushQueue: make(chan clientRequest, cfg.TeeConfig.FlushQueueSize),
 
+		bufferedBytesMaxSample: metric_util.NewMaxSampleCollector(
+			"pattern_ingester_tee_buffered_bytes",
+			"The current number of bytes buffered in the tee.",
+		),
 		ingesterAppends: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Name: "pattern_ingester_appends_total",
 			Help: "The total number of batch appends sent to pattern ingesters.",
@@ -95,6 +108,7 @@ func NewTeeService(
 			),
 		),
 	}
+	registerer.MustRegister(t.bufferedBytesMaxSample)
 
 	return t, nil
 }
@@ -158,11 +172,13 @@ func (ts *TeeService) Start(runCtx context.Context) error {
 		}
 	}()
 
+	services.StartAndAwaitRunning(runCtx, ts.bufferedBytesMaxSample)
 	return nil
 }
 
 func (ts *TeeService) WaitUntilDone() {
 	ts.wg.Wait()
+	services.StopAndAwaitTerminated(context.TODO(), ts.bufferedBytesMaxSample)
 }
 
 func (ts *TeeService) flush() {
@@ -202,15 +218,24 @@ func (ts *TeeService) flush() {
 
 	for tenant, requests := range byTenantAndPatternIngester {
 		for addr, reqs := range requests {
+			// Calculate the total size of all streams.
+			var totalSize int
+			for _, req := range reqs {
+				for _, stream := range req.Streams {
+					totalSize += stream.Size()
+				}
+			}
 			select {
 			case ts.flushQueue <- clientRequest{
 				ingesterAddr: addr,
 				tenant:       tenant,
 				reqs:         reqs,
+				size:         totalSize,
 			}:
 				ts.teedRequests.WithLabelValues("queued").Inc()
 			default:
 				ts.teedRequests.WithLabelValues("dropped").Inc()
+				ts.releaseBufferedBytes(totalSize)
 			}
 		}
 	}
@@ -233,6 +258,7 @@ func (ts *TeeService) batchesForTenant(
 		replicationSet, err := ts.ringClient.Ring().
 			Get(stream.HashKey, ring.WriteNoExtend, descs[:0], nil, nil)
 		if err != nil || len(replicationSet.Instances) == 0 {
+			ts.releaseBufferedBytes(stream.Stream.Size())
 			ts.teedStreams.WithLabelValues("dropped").Inc()
 			continue
 		}
@@ -262,6 +288,8 @@ type clientRequest struct {
 	ingesterAddr string
 	tenant       string
 	reqs         []*logproto.PushRequest
+	// size is the total size of all streams in reqs.
+	size int
 }
 
 func (ts *TeeService) batchSender(ctx context.Context) {
@@ -279,6 +307,8 @@ func (ts *TeeService) batchSender(ctx context.Context) {
 }
 
 func (ts *TeeService) sendBatch(ctx context.Context, clientRequest clientRequest) {
+	defer ts.releaseBufferedBytes(clientRequest.size)
+
 	ctx, cancel := context.WithTimeout(ctx, ts.cfg.ConnectionTimeout)
 	defer cancel()
 
@@ -440,10 +470,54 @@ func (ts *TeeService) Duplicate(_ context.Context, tenant string, streams []dist
 			continue
 		}
 
+		// Check that the stream is allowed within the current limit.
+		size := stream.Stream.Size()
+		if !ts.tryReserveBufferedBytes(size) {
+			ts.teedStreams.WithLabelValues("dropped").Inc()
+			continue
+		}
+
 		ts.bufMtx.Lock()
 		ts.buf[tenant] = append(ts.buf[tenant], stream)
 		ts.bufMtx.Unlock()
 	}
+}
+
+// tryReserveBufferedBytes returns true if size can be reserved, otherwise false.
+// It always returns true when [TeeConfig.MaxBufferedBytes] is 0.
+func (ts *TeeService) tryReserveBufferedBytes(size int) bool {
+	maxBufferedBytes := int64(ts.cfg.TeeConfig.MaxBufferedBytes)
+	if maxBufferedBytes == 0 {
+		// The limit is disabled, size can be reserved.
+		ts.bufferedBytesMaxSample.Add(int64(size))
+		return true
+	}
+	for {
+		old := ts.bufferedBytes.Load()
+		new := old + int64(size)
+		if new > maxBufferedBytes {
+			// size exceeds the limit, so cannot be reserved.
+			return false
+		}
+		// If we won the CAS, our new size was reserved, and we can return true.
+		// Otherwise, someone else round the CAS, and we should loop again.
+		if ts.bufferedBytes.CompareAndSwap(old, new) {
+			ts.bufferedBytesMaxSample.Add(int64(size))
+			return true
+		}
+	}
+}
+
+// reelaseBufferedBytes releases the size from the buffered bytes counter.
+// It is a no-op when [TeeConfig.MaxBufferedBytes] is 0.
+func (ts *TeeService) releaseBufferedBytes(size int) {
+	maxBufferedBytes := uint64(ts.cfg.TeeConfig.MaxBufferedBytes)
+	if maxBufferedBytes == 0 {
+		ts.bufferedBytesMaxSample.Sub(int64(size))
+		return
+	}
+	ts.bufferedBytes.Add(-int64(size))
+	ts.bufferedBytesMaxSample.Sub(int64(size))
 }
 
 func (ts *TeeService) Register(_ context.Context, _ string, _ []distributor.KeyedStream, _ *distributor.PushTracker) {

--- a/pkg/pattern/tee_service_test.go
+++ b/pkg/pattern/tee_service_test.go
@@ -277,7 +277,7 @@ func TestPatternTee_MaxBufferedBytes(t *testing.T) {
 	}
 	tee.Duplicate(ctx, "test", []distributor.KeyedStream{s4}, nil)
 	require.Len(t, tee.buf, 1)
-	// tenantBuf should contain s1 and s3.
+	// tenantBuf should contain s4.
 	tenantBuf, ok = tee.buf["test"]
 	require.True(t, ok)
 	require.Contains(t, tenantBuf, s4)

--- a/pkg/pattern/tee_service_test.go
+++ b/pkg/pattern/tee_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -62,7 +63,7 @@ func getTestTee(t *testing.T) (*TeeService, *mockPoolClient) {
 	return logsTee, client
 }
 
-func TestPatternTeeBasic(t *testing.T) {
+func TestPatternTee_Basic(t *testing.T) {
 	tee, client := getTestTee(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -154,7 +155,7 @@ func TestPatternTeeBasic(t *testing.T) {
 	}, pingPongEntries)
 }
 
-func TestPatternTeeEmptyStream(t *testing.T) {
+func TestPatternTee_EmptyStream(t *testing.T) {
 	tee, client := getTestTee(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -185,4 +186,99 @@ func TestPatternTeeEmptyStream(t *testing.T) {
 
 	require.Nil(t, req)
 	require.Nil(t, reqCtx)
+}
+
+func TestPatternTee_MaxBufferedBytes(t *testing.T) {
+	ctx := t.Context()
+	tee, _ := getTestTee(t)
+	tee.cfg.TeeConfig.MaxBufferedBytes = 1024 // 1KB
+	require.Len(t, tee.buf, 0)
+
+	// Stream should be accepted, less than 1KB.
+	s1 := distributor.KeyedStream{
+		HashKey: 123,
+		Stream: push.Stream{
+			Labels: `{foo="bar"}`,
+			Entries: []push.Entry{{
+				Timestamp: time.Now(),
+				Line:      "abc",
+			}},
+		},
+	}
+	tee.Duplicate(ctx, "test", []distributor.KeyedStream{s1}, nil)
+	require.LessOrEqual(t, s1.Stream.Size(), 1024)
+	require.Len(t, tee.buf, 1)
+	tenantBuf, ok := tee.buf["test"]
+	require.True(t, ok)
+	require.Contains(t, tenantBuf, s1)
+
+	// Stream should be rejected, more than 1KB.
+	s2 := distributor.KeyedStream{
+		HashKey: 123,
+		Stream: push.Stream{
+			Labels: `{foo="bar"}`,
+			Entries: []push.Entry{{
+				Timestamp: time.Now(),
+				Line:      strings.Repeat("d", 1024),
+			}},
+		},
+	}
+	tee.Duplicate(ctx, "test", []distributor.KeyedStream{s2}, nil)
+	require.Greater(t, s2.Stream.Size(), 1024)
+	require.Len(t, tee.buf, 1)
+	// tenantBuf should contain s1, but not s2.
+	tenantBuf, ok = tee.buf["test"]
+	require.True(t, ok)
+	require.Contains(t, tenantBuf, s1)
+
+	// Stream should be accepted, total of s1 and s3 is less than 1KB.
+	s3 := distributor.KeyedStream{
+		HashKey: 123,
+		Stream: push.Stream{
+			Labels: `{foo="bar"}`,
+			Entries: []push.Entry{{
+				Timestamp: time.Now(),
+				Line:      strings.Repeat("d", 512),
+			}},
+		},
+	}
+	tee.Duplicate(ctx, "test", []distributor.KeyedStream{s3}, nil)
+	require.Len(t, tee.buf, 1)
+	// tenantBuf should contain s1 and s3.
+	tenantBuf, ok = tee.buf["test"]
+	require.True(t, ok)
+	require.Contains(t, tenantBuf, s1, s3)
+
+	// Stream should be rejected, total of s1, s3 and s4 is more than 1KB.
+	s4 := distributor.KeyedStream{
+		HashKey: 123,
+		Stream: push.Stream{
+			Labels: `{foo="bar"}`,
+			Entries: []push.Entry{{
+				Timestamp: time.Now(),
+				Line:      strings.Repeat("e", 512),
+			}},
+		},
+	}
+	tee.Duplicate(ctx, "test", []distributor.KeyedStream{s4}, nil)
+	require.Len(t, tee.buf, 1)
+	// tenantBuf should contain s1 and s3.
+	tenantBuf, ok = tee.buf["test"]
+	require.True(t, ok)
+	require.Contains(t, tenantBuf, s1, s3)
+
+	// Flush s1 and s3, s4 should be accepted.
+	tee.flush()
+	select {
+	case clientRequest := <-tee.flushQueue:
+		tee.sendBatch(ctx, clientRequest)
+	case <-ctx.Done():
+		t.Fatal("context canceled before we received request from tee.flushQueue")
+	}
+	tee.Duplicate(ctx, "test", []distributor.KeyedStream{s4}, nil)
+	require.Len(t, tee.buf, 1)
+	// tenantBuf should contain s1 and s3.
+	tenantBuf, ok = tee.buf["test"]
+	require.True(t, ok)
+	require.Contains(t, tenantBuf, s4)
 }

--- a/pkg/pattern/tee_service_test.go
+++ b/pkg/pattern/tee_service_test.go
@@ -247,7 +247,8 @@ func TestPatternTee_MaxBufferedBytes(t *testing.T) {
 	// tenantBuf should contain s1 and s3.
 	tenantBuf, ok = tee.buf["test"]
 	require.True(t, ok)
-	require.Contains(t, tenantBuf, s1, s3)
+	require.Contains(t, tenantBuf, s1)
+	require.Contains(t, tenantBuf, s3)
 
 	// Stream should be rejected, total of s1, s3 and s4 is more than 1KB.
 	s4 := distributor.KeyedStream{
@@ -265,7 +266,8 @@ func TestPatternTee_MaxBufferedBytes(t *testing.T) {
 	// tenantBuf should contain s1 and s3.
 	tenantBuf, ok = tee.buf["test"]
 	require.True(t, ok)
-	require.Contains(t, tenantBuf, s1, s3)
+	require.Contains(t, tenantBuf, s1)
+	require.Contains(t, tenantBuf, s3)
 
 	// Flush s1 and s3, s4 should be accepted.
 	tee.flush()


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new buffering limit that can drop streams/flushes when the tee’s in-memory/queued payloads exceed a configured size, which changes backpressure/dropping behavior under load. The logic touches concurrency and accounting across buffering, batching, and send paths, so miscounting could lead to unexpected drops or memory growth.
> 
> **Overview**
> Adds a new `tee_config.max_buffered_bytes`/`-pattern-ingester.tee.max-buffered-bytes` setting to cap how many log bytes the pattern tee can buffer (disabled by default).
> 
> `TeeService` now tracks total buffered bytes (in-memory buffer + queued flush requests) using atomic accounting; streams/flush requests are *dropped* when the cap would be exceeded, and bytes are released when requests are sent or dropped. A new max-sample metric `pattern_ingester_tee_buffered_bytes` is exported, and tests are updated/added to cover empty streams and the new limit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94cfbdd8aaca0d75948b2d111e0e08415814de89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->