### PR TITLE
fix(engine): Revert "chore: Enable unwrap of batching pipeline (#21795)"

### DIFF
--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -3,18 +3,13 @@ package engine
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
-	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 
-	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
-	"github.com/grafana/loki/v3/pkg/engine/internal/planner/logical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
@@ -31,26 +26,6 @@ func (l *fakeLimits) MaxScanTaskParallelism(_ string) int {
 	return l.parallelism
 }
 
-type fakeMetastore struct {
-	metastore.Metastore
-	indexes []metastore.IndexEntry
-}
-
-func (f *fakeMetastore) GetIndexes(_ context.Context, _ metastore.GetIndexesRequest) (metastore.GetIndexesResponse, error) {
-	return metastore.GetIndexesResponse{Indexes: f.indexes}, nil
-}
-
-func (f *fakeMetastore) CollectSections(_ context.Context, _ metastore.CollectSectionsRequest) (metastore.CollectSectionsResponse, error) {
-	return metastore.CollectSectionsResponse{SectionsResponse: metastore.SectionsResponse{Sections: []*metastore.DataobjSectionDescriptor{
-		{
-			SectionKey: metastore.SectionKey{
-				ObjectPath: "index/0",
-				SectionIdx: 0,
-			},
-		},
-	}}}, nil
-}
-
 func newTestEngine(t *testing.T, limits logql.Limits) *Engine {
 	t.Helper()
 
@@ -65,18 +40,6 @@ func newTestEngine(t *testing.T, limits logql.Limits) *Engine {
 		metrics:   newMetrics(prometheus.NewRegistry()),
 		limits:    limits,
 		scheduler: &Scheduler{inner: inner},
-		metastore: &fakeMetastore{indexes: []metastore.IndexEntry{
-			{
-				Path:  "index/0",
-				Start: time.Now(),
-				End:   time.Now().Add(time.Hour),
-			},
-		}},
-		cfg: Config{
-			Executor: ExecutorConfig{
-				BatchSize: 128,
-			},
-		},
 	}
 }
 
@@ -150,88 +113,4 @@ func TestEngine_IsMetricQuery(t *testing.T) {
 			require.Equal(t, tt.want, isMetricQuery(expr))
 		})
 	}
-}
-
-func TestEngine_LimitedQueryPlansContributeTimeRanges(t *testing.T) {
-	const tenant = "test-tenant"
-	const parallelism = 42
-
-	limits := &fakeLimits{
-		Limits:      logql.NoLimits,
-		parallelism: parallelism,
-	}
-
-	tests := []struct {
-		name       string
-		query      string
-		expectTopK bool
-	}{
-		{
-			name:       "log query",
-			query:      `{app="test"}`,
-			expectTopK: true,
-		},
-		{
-			name:       "metric query",
-			query:      `rate({app="test"}[5m])`,
-			expectTopK: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Build an execution plan & workflow from the input query
-			params, err := logql.NewLiteralParams(tt.query, time.Now().UTC(), time.Now().Add(time.Hour).UTC(), 0, 0, logproto.BACKWARD, 1000, nil, nil)
-			require.NoError(t, err)
-
-			logicalPlan, err := logical.BuildPlan(context.Background(), params)
-			require.NoError(t, err)
-
-			e := newTestEngine(t, limits)
-
-			physicalPlan, _, err := e.buildPhysicalPlan(context.Background(), tenant, log.NewNopLogger(), params, logicalPlan, false)
-			require.NoError(t, err)
-
-			// Verify the plan contains a TopK node
-			require.Equal(t, tt.expectTopK, containsTopK(t, physicalPlan))
-			if !tt.expectTopK {
-				return
-			}
-
-			// Build a workflow to generate the batching pipelines
-			wf, _, err := e.buildWorkflow(context.Background(), tenant, log.NewNopLogger(), physicalPlan, false, false)
-			require.NoError(t, err)
-			defer wf.Close()
-
-			for _, task := range wf.AllTasks() {
-				if len(task.Sources) != 0 {
-					continue // not a leaf task
-				}
-
-				// For each leaf task fragment, confirm it unwraps to a ContributingTimeRangeChangedNotifier
-				pipeline := executor.Run(context.Background(), executor.Config{BatchSize: 128}, task.Fragment, log.NewNopLogger())
-				defer pipeline.Close()
-
-				unwrapped := executor.Unwrap(pipeline)
-				require.NotNil(t, unwrapped)
-
-				_, isNotifier := unwrapped.(executor.ContributingTimeRangeChangedNotifier)
-				require.True(t, isNotifier, "expected a contributing time range changed notifier")
-			}
-		})
-	}
-}
-
-func containsTopK(t *testing.T, fragment *physical.Plan) bool {
-	containsTopK := false
-	for _, root := range fragment.Roots() {
-		err := fragment.DFSWalk(root, func(n physical.Node) error {
-			if n.Type() == physical.NodeTypeTopK {
-				containsTopK = true
-			}
-			return nil
-		}, dag.PreOrderWalk)
-		require.NoError(t, err)
-	}
-	return containsTopK
 }

--- a/pkg/engine/internal/executor/batching.go
+++ b/pkg/engine/internal/executor/batching.go
@@ -11,8 +11,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/xcap"
 )
 
-var _ WrappedPipeline = (*batchingPipeline)(nil)
-
 // batchingPipeline wraps a [Pipeline] and accumulates records from it into
 // larger batches of at most batchSize rows, performing schema reconciliation
 // across records with different schemas via [arrowagg.Records].
@@ -39,10 +37,6 @@ func NewBatchingPipeline(inner Pipeline, batchSize int64) Pipeline {
 		batchSize: batchSize,
 		agg:       arrowagg.NewRecords(memory.DefaultAllocator),
 	}
-}
-
-func (p *batchingPipeline) Unwrap() Pipeline {
-	return p.inner
 }
 
 // Open implements Pipeline.

--- a/pkg/engine/internal/workflow/workflow.go
+++ b/pkg/engine/internal/workflow/workflow.go
@@ -237,7 +237,7 @@ func (wf *Workflow) init(ctx context.Context) error {
 		Actor:  wf.opts.Actor,
 
 		Streams: wf.allStreams(),
-		Tasks:   wf.AllTasks(),
+		Tasks:   wf.allTasks(),
 
 		StreamEventHandler: wf.onStreamChange,
 		TaskEventHandler:   wf.onTaskChange,
@@ -415,7 +415,7 @@ func (wf *Workflow) allStreams() []*Stream {
 	return result
 }
 
-func (wf *Workflow) AllTasks() []*Task {
+func (wf *Workflow) allTasks() []*Task {
 	var tasks []*Task
 
 	for _, root := range wf.graph.Roots() {

--- a/pkg/engine/internal/workflow/workflow_test.go
+++ b/pkg/engine/internal/workflow/workflow_test.go
@@ -81,7 +81,7 @@ func Test(t *testing.T) {
 		require.NotNil(t, rs.Listener, "results stream should have a listener")
 
 		// Check to make sure all known tasks have been given to the runner.
-		for _, task := range wf.AllTasks() {
+		for _, task := range wf.allTasks() {
 			_, exist := fr.tasks[task.ULID]
 			require.True(t, exist, "workflow should give all tasks to runner (task %s is missing)", task.ULID)
 		}
@@ -330,7 +330,7 @@ func TestAdmissionControl(t *testing.T) {
 		require.Equal(t, opts.MaxRunningScanTasks+1, len(wf.taskStates), "expected all tasks up to batch to be enqueued") // 32 scan tasks + 1 other task
 
 		// Simulate scan tasks being completed
-		for _, task := range wf.AllTasks() {
+		for _, task := range wf.allTasks() {
 			if !isScanTask(task) {
 				continue
 			}
@@ -471,7 +471,9 @@ func (f *fakeRunner) Start(ctx context.Context, tasks ...*Task) error {
 
 	for _, task := range tasks {
 		f.tasksMtx.Lock()
-		rt, exist := f.tasks[task.ULID]
+		var (
+			rt, exist = f.tasks[task.ULID]
+		)
 		f.tasksMtx.Unlock()
 
 		if !exist {
@@ -494,7 +496,9 @@ func (f *fakeRunner) Cancel(ctx context.Context, tasks ...*Task) error {
 
 	for _, task := range tasks {
 		f.tasksMtx.RLock()
-		rt, exist := f.tasks[task.ULID]
+		var (
+			rt, exist = f.tasks[task.ULID]
+		)
 		f.tasksMtx.RUnlock()
 
 		if !exist {


### PR DESCRIPTION
Reverts #21795.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes `batchingPipeline`’s `WrappedPipeline`/`Unwrap` behavior and deletes tests that relied on unwrapping pipelines and contributing-time-range notifications, which could affect any code paths expecting to introspect or unwrap batching pipelines.
> 
> **Overview**
> Reverts prior support for unwrapping the executor’s `batchingPipeline` by removing its `WrappedPipeline` implementation and `Unwrap()` method.
> 
> Cleans up workflow/engine tests accordingly: deletes the engine test that built full logical/physical plans to assert unwrapped leaf pipelines implement `ContributingTimeRangeChangedNotifier`, and makes workflow task enumeration internal by renaming `AllTasks()` to `allTasks()` and updating tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bc108fe5a65bbaca9b4101f8fb435b0b63cdfd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->