### PR TITLE
chore(dataset/array): Add Delta encoding

### DIFF
--- a/pkg/dataset/array/codec.go
+++ b/pkg/dataset/array/codec.go
@@ -51,6 +51,8 @@ func NewWriter(alloc *memory.Allocator, spec Spec, typ types.Type) (Writer, erro
 		return newZstdWriter(alloc, spec, typ)
 	case EncodingKindZigZag:
 		return newZigZagWriter(alloc, spec, typ)
+	case EncodingKindDelta:
+		return newDeltaWriter(alloc, spec, typ)
 
 	default:
 		return nil, fmt.Errorf("unsupported encoding kind %q", spec.Kind())
@@ -107,6 +109,8 @@ func NewReader(alloc *memory.Allocator, arr Array, source buffer.Source) (Reader
 		return newZstdReader(alloc, arr, source)
 	case EncodingKindZigZag:
 		return newZigZagReader(alloc, arr, source)
+	case EncodingKindDelta:
+		return newDeltaReader(alloc, arr, source)
 
 	default:
 		return nil, fmt.Errorf("unsupported encoding kind %q", arr.Encoding.Kind())

--- a/pkg/dataset/array/codec_delta.go
+++ b/pkg/dataset/array/codec_delta.go
@@ -1,0 +1,201 @@
+package array
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+type integer interface {
+	int32 | int64 | uint32 | uint64
+}
+
+type deltaWriter[T integer] struct {
+	alloc *memory.Allocator
+	typ   types.Type
+	next  Writer
+	last  T
+}
+
+func newDeltaWriter(alloc *memory.Allocator, spec Spec, typ types.Type) (Writer, error) {
+	if got, want := spec.Kind(), EncodingKindDelta; got != want {
+		return nil, fmt.Errorf("expected spec kind %s, got %s", want, got)
+	}
+
+	dSpec := spec.(*SpecDelta)
+	if dSpec.Data == nil {
+		return nil, fmt.Errorf("delta spec must have a data spec")
+	}
+
+	switch typ.(type) {
+	case *types.Int32:
+		return newDeltaWriterTyped[int32](alloc, dSpec, typ)
+	case *types.Int64:
+		return newDeltaWriterTyped[int64](alloc, dSpec, typ)
+	case *types.Uint32:
+		return newDeltaWriterTyped[uint32](alloc, dSpec, typ)
+	case *types.Uint64:
+		return newDeltaWriterTyped[uint64](alloc, dSpec, typ)
+	default:
+		return nil, fmt.Errorf("unsupported type %s for delta encoding", typ)
+	}
+}
+
+func newDeltaWriterTyped[T integer](alloc *memory.Allocator, spec *SpecDelta, typ types.Type) (*deltaWriter[T], error) {
+	next, err := NewWriter(alloc, spec.Data, typ)
+	if err != nil {
+		return nil, fmt.Errorf("creating data writer: %w", err)
+	}
+
+	return &deltaWriter[T]{
+		alloc: alloc,
+		typ:   typ,
+		next:  next,
+	}, nil
+}
+
+func (w *deltaWriter[T]) Append(arr columnar.Array) error {
+	numArr, ok := arr.(*columnar.Number[T])
+	if !ok {
+		return fmt.Errorf("expected *columnar.Number[%T], got %T", *new(T), arr)
+	}
+
+	values := numArr.Values()
+
+	shortAlloc := memory.NewAllocator(w.alloc)
+	defer shortAlloc.Free()
+
+	encoded := memory.NewBuffer[T](shortAlloc, len(values))
+	encoded.Grow(len(values))
+	for _, v := range values {
+		encoded.Append(v - w.last)
+		w.last = v
+	}
+
+	return w.next.Append(columnar.NewNumber(encoded.Data(), numArr.Validity()))
+}
+
+func (w *deltaWriter[T]) Flush(ctx context.Context, sink buffer.Sink) (Array, error) {
+	defer w.reset()
+
+	dataArray, err := w.next.Flush(ctx, sink)
+	if err != nil {
+		return Array{}, fmt.Errorf("flushing data writer: %w", err)
+	}
+
+	return Array{
+		Encoding: &EncodingDelta{},
+		Type:     w.typ,
+		RowCount: dataArray.RowCount,
+		Stats:    dataArray.Stats,
+		Children: []Array{dataArray},
+	}, nil
+}
+
+func (w *deltaWriter[T]) reset() {
+	w.last = 0
+}
+
+type deltaReader[T integer] struct {
+	alloc      *memory.Allocator
+	arr        Array
+	dataReader Reader
+	last       T
+}
+
+func newDeltaReader(alloc *memory.Allocator, arr Array, source buffer.Source) (Reader, error) {
+	if got, want := arr.Encoding.Kind(), EncodingKindDelta; got != want {
+		return nil, fmt.Errorf("expected encoding kind %s, got %s", want, got)
+	}
+
+	if len(arr.Children) != 1 {
+		return nil, fmt.Errorf("expected 1 child for delta array, got %d", len(arr.Children))
+	}
+
+	switch arr.Type.(type) {
+	case *types.Int32:
+		return newDeltaReaderTyped[int32](alloc, arr, source)
+	case *types.Int64:
+		return newDeltaReaderTyped[int64](alloc, arr, source)
+	case *types.Uint32:
+		return newDeltaReaderTyped[uint32](alloc, arr, source)
+	case *types.Uint64:
+		return newDeltaReaderTyped[uint64](alloc, arr, source)
+	default:
+		return nil, fmt.Errorf("unsupported type %s for delta encoding", arr.Type)
+	}
+}
+
+func newDeltaReaderTyped[T integer](alloc *memory.Allocator, arr Array, source buffer.Source) (*deltaReader[T], error) {
+	dataReader, err := NewReader(alloc, arr.Children[0], source)
+	if err != nil {
+		return nil, fmt.Errorf("creating data reader: %w", err)
+	}
+
+	return &deltaReader[T]{
+		alloc:      alloc,
+		arr:        arr,
+		dataReader: dataReader,
+	}, nil
+}
+
+func (r *deltaReader[T]) Read(ctx context.Context, alloc *memory.Allocator, count int) (columnar.Array, error) {
+	if count <= 0 {
+		return nil, fmt.Errorf("count must be positive, got %d", count)
+	}
+
+	// Read deltas with a short-lived allocator; the raw deltas don't survive
+	// past this call since we decode them into absolute values.
+	shortAlloc := memory.NewAllocator(alloc)
+	defer shortAlloc.Free()
+
+	dataArr, err := r.dataReader.Read(ctx, shortAlloc, count)
+	if err != nil {
+		return nil, err
+	}
+
+	deltaArr := dataArr.(*columnar.Number[T])
+	deltas := deltaArr.Values()
+
+	decoded := memory.NewBuffer[T](alloc, len(deltas))
+	data := decoded.Next(len(deltas))
+
+	last := r.last
+	{
+		// Check length for BCE.
+		if len(data) != len(deltas) {
+			panic("decoded buffer length mismatch")
+		}
+		for i, d := range deltas {
+			last += d
+			data[i] = last
+		}
+	}
+	r.last = last
+
+	// Validity must outlive this call, so clone it with the caller's allocator.
+	var validity memory.Bitmap
+	if v := deltaArr.Validity(); v.Len() > 0 {
+		validity = *v.Clone(alloc)
+	}
+	return columnar.NewNumber(decoded.Data(), validity), nil
+}
+
+func (r *deltaReader[T]) Reset() {
+	r.resetSelf()
+	r.dataReader.Reset()
+}
+
+func (r *deltaReader[T]) resetSelf() {
+	// Reset the offset but keep everything else to allow for re-reading data.
+	r.last = 0
+}
+
+func (r *deltaReader[T]) Close() error {
+	r.resetSelf()
+	return r.dataReader.Close()
+}

--- a/pkg/dataset/array/codec_delta_test.go
+++ b/pkg/dataset/array/codec_delta_test.go
@@ -1,0 +1,448 @@
+package array_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestDeltaCodec_Validation(t *testing.T) {
+	data := &array.SpecPlain{}
+
+	tt := []struct {
+		name string
+		spec array.Spec
+		typ  types.Type
+
+		expectError bool
+	}{
+		{
+			name:        "accepts non-nullable int32",
+			spec:        &array.SpecDelta{Data: data},
+			typ:         &types.Int32{Nullable: false},
+			expectError: false,
+		},
+		{
+			name:        "accepts non-nullable int64",
+			spec:        &array.SpecDelta{Data: data},
+			typ:         &types.Int64{Nullable: false},
+			expectError: false,
+		},
+		{
+			name:        "accepts non-nullable uint32",
+			spec:        &array.SpecDelta{Data: data},
+			typ:         &types.Uint32{Nullable: false},
+			expectError: false,
+		},
+		{
+			name:        "accepts non-nullable uint64",
+			spec:        &array.SpecDelta{Data: data},
+			typ:         &types.Uint64{Nullable: false},
+			expectError: false,
+		},
+		{
+			name:        "accepts nullable int64 with validity in data spec",
+			spec:        &array.SpecDelta{Data: &array.SpecPlain{Validity: &array.SpecBool{}}},
+			typ:         &types.Int64{Nullable: true},
+			expectError: false,
+		},
+		{
+			name:        "rejects bool",
+			spec:        &array.SpecDelta{Data: data},
+			typ:         &types.Bool{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects utf8",
+			spec:        &array.SpecDelta{Data: data},
+			typ:         &types.UTF8{Nullable: false},
+			expectError: true,
+		},
+		{
+			name:        "rejects nil data spec",
+			spec:        &array.SpecDelta{Data: nil},
+			typ:         &types.Int64{Nullable: false},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			var alloc memory.Allocator
+			_, err := array.NewWriter(&alloc, tc.spec, tc.typ)
+
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDeltaCodec_NonNullable(t *testing.T) {
+	t.Run("int32", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+
+		var (
+			spec = &array.SpecDelta{Data: &array.SpecPlain{}}
+			typ  = &types.Int32{Nullable: false}
+		)
+
+		w, err := array.NewWriter(&alloc, spec, typ)
+		require.NoError(t, err)
+
+		input := []columnar.Array{
+			columnartest.Array(t, types.KindInt32, &alloc, int32(10), int32(20), int32(30), int32(25), int32(15)),
+			columnartest.Array(t, types.KindInt32, &alloc, int32(15), int32(100), int32(100), int32(0)),
+		}
+		for _, arr := range input {
+			require.NoError(t, w.Append(arr))
+		}
+
+		result, err := w.Flush(t.Context(), &store)
+		require.NoError(t, err)
+		require.Equal(t, 9, result.RowCount)
+		require.Equal(t, 0, result.Stats.NullCount)
+
+		r, err := array.NewReader(&alloc, result, &store)
+		require.NoError(t, err)
+
+		expect := columnartest.Array(
+			t, types.KindInt32, &alloc,
+			int32(10), int32(20), int32(30), int32(25), int32(15),
+			int32(15), int32(100), int32(100), int32(0),
+		)
+
+		actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+		columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+
+		_, err = r.Read(t.Context(), &alloc, 1)
+		require.ErrorIs(t, err, io.EOF)
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+
+		var (
+			spec = &array.SpecDelta{Data: &array.SpecPlain{}}
+			typ  = &types.Int64{Nullable: false}
+		)
+
+		w, err := array.NewWriter(&alloc, spec, typ)
+		require.NoError(t, err)
+
+		input := []columnar.Array{
+			columnartest.Array(t, types.KindInt64, &alloc, int64(100), int64(200), int64(150), int64(300), int64(250)),
+			columnartest.Array(t, types.KindInt64, &alloc, int64(250), int64(500), int64(0), int64(-100)),
+		}
+		for _, arr := range input {
+			require.NoError(t, w.Append(arr))
+		}
+
+		result, err := w.Flush(t.Context(), &store)
+		require.NoError(t, err)
+		require.Equal(t, 9, result.RowCount)
+		require.Equal(t, 0, result.Stats.NullCount)
+
+		r, err := array.NewReader(&alloc, result, &store)
+		require.NoError(t, err)
+
+		expect := columnartest.Array(
+			t, types.KindInt64, &alloc,
+			int64(100), int64(200), int64(150), int64(300), int64(250),
+			int64(250), int64(500), int64(0), int64(-100),
+		)
+
+		actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+		columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+
+		_, err = r.Read(t.Context(), &alloc, 1)
+		require.ErrorIs(t, err, io.EOF)
+	})
+}
+
+func TestDeltaCodec_Nullable(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecDelta{Data: &array.SpecPlain{Validity: &array.SpecBool{}}}
+		typ  = &types.Int64{Nullable: true}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	input := []columnar.Array{
+		columnartest.Array(t, types.KindInt64, &alloc, int64(10), nil, int64(30), nil, int64(50)),
+		columnartest.Array(t, types.KindInt64, &alloc, int64(60), int64(70)),
+		columnartest.Array(t, types.KindInt64, &alloc, nil),
+	}
+	for _, arr := range input {
+		require.NoError(t, w.Append(arr))
+	}
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+	require.Equal(t, 8, result.RowCount)
+	require.Equal(t, 3, result.Stats.NullCount)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	expect := columnartest.Array(
+		t, types.KindInt64, &alloc,
+		int64(10), nil, int64(30), nil, int64(50),
+		int64(60), int64(70),
+		nil,
+	)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+
+	_, err = r.Read(t.Context(), &alloc, 1)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestDeltaCodec_PartialRead(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecDelta{Data: &array.SpecPlain{}}
+		typ  = &types.Int64{Nullable: false}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	input := columnartest.Array(t, types.KindInt64, &alloc,
+		int64(10), int64(20), int64(30), int64(40), int64(50),
+		int64(60), int64(70), int64(80), int64(90), int64(100),
+	)
+	require.NoError(t, w.Append(input))
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	batch1, err := r.Read(t.Context(), &alloc, 3)
+	require.NoError(t, err)
+	require.Equal(t, 3, batch1.Len())
+	columnartest.RequireArraysEqual(t,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(10), int64(20), int64(30)),
+		batch1, memory.Bitmap{},
+	)
+
+	batch2, err := r.Read(t.Context(), &alloc, 3)
+	require.NoError(t, err)
+	require.Equal(t, 3, batch2.Len())
+	columnartest.RequireArraysEqual(t,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(40), int64(50), int64(60)),
+		batch2, memory.Bitmap{},
+	)
+
+	batch3, err := r.Read(t.Context(), &alloc, 3)
+	require.NoError(t, err)
+	require.Equal(t, 3, batch3.Len())
+	columnartest.RequireArraysEqual(t,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(70), int64(80), int64(90)),
+		batch3, memory.Bitmap{},
+	)
+
+	// Last batch: only 1 remaining.
+	batch4, err := r.Read(t.Context(), &alloc, 3)
+	require.NoError(t, err)
+	require.Equal(t, 1, batch4.Len())
+	columnartest.RequireArraysEqual(t,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(100)),
+		batch4, memory.Bitmap{},
+	)
+
+	_, err = r.Read(t.Context(), &alloc, 1)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestDeltaCodec_ReuseAfterFlush(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecDelta{Data: &array.SpecPlain{}}
+		typ  = &types.Int64{Nullable: false}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	// First session: append, flush, read back.
+	first := columnartest.Array(t, types.KindInt64, &alloc,
+		int64(100), int64(200), int64(300),
+	)
+	require.NoError(t, w.Append(first))
+
+	firstResult, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+
+	firstReader, err := array.NewReader(&alloc, firstResult, &store)
+	require.NoError(t, err)
+	firstActual := readBatches(t, &alloc, firstReader, 8)
+	columnartest.RequireArraysEqual(t, first, firstActual, memory.Bitmap{})
+
+	// Second session: reuse the writer. The writer must have reset its delta
+	// state so the next array's first value isn't encoded as a delta from the
+	// previous session's last value.
+	second := columnartest.Array(t, types.KindInt64, &alloc,
+		int64(10), int64(20), int64(30),
+	)
+	require.NoError(t, w.Append(second))
+
+	secondResult, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+
+	secondReader, err := array.NewReader(&alloc, secondResult, &store)
+	require.NoError(t, err)
+	secondActual := readBatches(t, &alloc, secondReader, 8)
+	columnartest.RequireArraysEqual(t, second, secondActual, memory.Bitmap{})
+}
+
+func TestDeltaCodec_WithZigZagBitpacked(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	var (
+		spec = &array.SpecDelta{
+			Data: &array.SpecZigZag{
+				Data: &array.SpecBitpacked{BlockSize: 8, Widths: &array.SpecPlain{}},
+			},
+		}
+		typ = &types.Int64{Nullable: false}
+	)
+
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(t, err)
+
+	input := columnartest.Array(t, types.KindInt64, &alloc,
+		int64(100), int64(110), int64(105), int64(120), int64(115),
+		int64(130), int64(125), int64(140), int64(135), int64(150),
+	)
+	require.NoError(t, w.Append(input))
+
+	result, err := w.Flush(t.Context(), &store)
+	require.NoError(t, err)
+	require.Equal(t, 10, result.RowCount)
+
+	r, err := array.NewReader(&alloc, result, &store)
+	require.NoError(t, err)
+
+	actual := readBatches(t, &alloc, r, 2) // Read in a small batch size to test reading multiple times
+	columnartest.RequireArraysEqual(t, input, actual, memory.Bitmap{})
+}
+
+func BenchmarkDeltaCodec(b *testing.B) {
+	const valueCount = 1_000_000
+
+	// Generate 1M realistic logging timestamps: unix nanosecond precision,
+	// batched close together with inter-batch gaps.
+	rnd := rand.New(rand.NewSource(42))
+	timestamps := make([]int64, valueCount)
+
+	ts := int64(1_700_000_000_000_000_000) // ~2023-11-14 in nanoseconds
+	i := 0
+	for i < valueCount {
+		// Batch of 10-100 logs with small intra-batch spacing.
+		batchSize := 10 + rnd.Intn(91)
+		if i+batchSize > valueCount {
+			batchSize = valueCount - i
+		}
+		for j := range batchSize {
+			timestamps[i+j] = ts
+			ts += int64(100 + rnd.Intn(901)) // 100ns-1µs between entries
+		}
+		i += batchSize
+		ts += int64(1_000_000 + rnd.Intn(49_000_001)) // 1ms-50ms between batches
+	}
+
+	// Encode with Delta -> ZigZag -> Bitpacked.
+	var (
+		store buffer.MemoryStore
+
+		spec = &array.SpecDelta{
+			Data: &array.SpecZigZag{
+				Data: &array.SpecBitpacked{BlockSize: 128, Widths: &array.SpecPlain{}},
+			},
+		}
+		typ = &types.Int64{Nullable: false}
+	)
+
+	var alloc memory.Allocator
+	w, err := array.NewWriter(&alloc, spec, typ)
+	require.NoError(b, err)
+
+	builder := columnar.NewNumberBuilder[int64](&alloc)
+	builder.Grow(valueCount)
+	for _, ts := range timestamps {
+		builder.AppendValue(ts)
+	}
+	require.NoError(b, w.Append(builder.Build()))
+
+	encoded, err := w.Flush(b.Context(), &store)
+	require.NoError(b, err)
+
+	batchSizes := []int{256, 1024, 4096}
+
+	for _, batchSize := range batchSizes {
+		b.Run(fmt.Sprintf("batch_size=%d", batchSize), func(b *testing.B) {
+			var alloc memory.Allocator
+
+			b.ReportAllocs()
+			b.SetBytes(int64(valueCount) * 8)
+
+			for b.Loop() {
+				alloc.Reset()
+
+				r, _ := array.NewReader(&alloc, encoded, &store)
+
+				var decoded int
+				for {
+					arr, err := r.Read(b.Context(), &alloc, batchSize)
+					if arr != nil {
+						decoded += arr.Len()
+					}
+
+					if errors.Is(err, io.EOF) {
+						break
+					} else if err != nil {
+						b.Fatal(err)
+					}
+				}
+
+				if decoded != valueCount {
+					b.Fatalf("decoded %d values, expected %d", decoded, valueCount)
+				}
+			}
+
+			elapsed := b.Elapsed()
+			if elapsed > 0 {
+				totalDecoded := int64(valueCount) * int64(b.N)
+				b.ReportMetric(float64(totalDecoded)/elapsed.Seconds(), "rows/s")
+			}
+		})
+	}
+}

--- a/pkg/dataset/array/encoding.go
+++ b/pkg/dataset/array/encoding.go
@@ -66,6 +66,13 @@ type (
 	// The single child Array holds the zigzag-encoded unsigned data.
 	// Nullability is handled by the child encoding.
 	EncodingZigZag struct{}
+
+	// EncodingDelta stores differences between consecutive integer values.
+	// This encoding stores no data of its own; all data lives in child Arrays.
+	//
+	// The single child Array holds the delta-encoded data.
+	// Nullability is handled by the child encoding.
+	EncodingDelta struct{}
 )
 
 // Kind returns [EncodingKindBool].
@@ -98,6 +105,11 @@ func (enc *EncodingZigZag) Kind() EncodingKind {
 	return EncodingKindZigZag
 }
 
+// Kind returns [EncodingKindDelta].
+func (enc *EncodingDelta) Kind() EncodingKind {
+	return EncodingKindDelta
+}
+
 //
 // Sealed marker implementations.
 //
@@ -108,3 +120,4 @@ func (enc *EncodingBinary) isEncoding()    {}
 func (enc *EncodingBitpacked) isEncoding() {}
 func (enc *EncodingZstd) isEncoding()      {}
 func (enc *EncodingZigZag) isEncoding()    {}
+func (enc *EncodingDelta) isEncoding()     {}

--- a/pkg/dataset/array/encoding_kind.go
+++ b/pkg/dataset/array/encoding_kind.go
@@ -15,6 +15,7 @@ const (
 	EncodingKindBitpacked // EncodingKindBitpacked is a bitpacked encoding for unsigned integer types.
 	EncodingKindZstd      // EncodingKindZstd encodes variable-length binary data with zstd compression.
 	EncodingKindZigZag    // EncodingKindZigZag maps signed integers to unsigned integers via zigzag encoding.
+	EncodingKindDelta     // EncodingKindDelta stores differences between consecutive integer values.
 )
 
 var kindNames = [...]string{
@@ -25,6 +26,7 @@ var kindNames = [...]string{
 	EncodingKindBitpacked: "bitpacked",
 	EncodingKindZstd:      "zstd",
 	EncodingKindZigZag:    "zigzag",
+	EncodingKindDelta:     "delta",
 }
 
 // String returns the string representation of k.

--- a/pkg/dataset/array/spec.go
+++ b/pkg/dataset/array/spec.go
@@ -87,6 +87,14 @@ type (
 		// Spec for how to encode the zigzag-encoded unsigned data.
 		Data Spec
 	}
+
+	// SpecDelta encodes integer values by storing differences between
+	// consecutive values. The delta data is then encoded according to the
+	// Data spec. Nullability is passed through to the Data child.
+	SpecDelta struct {
+		// Spec for how to encode the delta-encoded data.
+		Data Spec
+	}
 )
 
 // Kind returns [EncodingKindBool].
@@ -119,6 +127,11 @@ func (spec *SpecZigZag) Kind() EncodingKind {
 	return EncodingKindZigZag
 }
 
+// Kind returns [EncodingKindDelta].
+func (spec *SpecDelta) Kind() EncodingKind {
+	return EncodingKindDelta
+}
+
 //
 // Sealed marker implementations.
 //
@@ -129,3 +142,4 @@ func (spec *SpecBinary) isSpec()    {}
 func (spec *SpecBitpacked) isSpec() {}
 func (spec *SpecZstd) isSpec()      {}
 func (spec *SpecZigZag) isSpec()    {}
+func (spec *SpecDelta) isSpec()     {}


### PR DESCRIPTION
Adds a Delta encoding to the dataset/array package, which encodes deltas between consecutive numbers.

This is the final encoder for the initial set of encodings in dataset/array.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new core array encoding/decoding path that changes how integer data can be serialized and read back; bugs here could corrupt encoded data or produce incorrect values across batch reads/resets.
> 
> **Overview**
> Introduces a new `delta` encoding for integer arrays that stores differences between consecutive values and delegates actual storage/validity handling to a single child encoding, enabling composition (e.g., `Delta -> ZigZag -> Bitpacked`).
> 
> Wires `EncodingKindDelta`/`SpecDelta`/`EncodingDelta` into the `NewWriter`/`NewReader` dispatch, and adds a full test/benchmark suite covering type validation, nullable/non-nullable behavior, partial reads, writer reuse after `Flush`, and composition with other encodings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cb03bd2b815a844cabeebaa5b1503cba22baf07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->