### PR TITLE
distributor: Allow fault tolerance of 1 on replication factor 2

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -893,10 +893,22 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 					return err
 				}
 
+				maxErrors := replicationSet.MaxErrors
+				// With RF=2 the quorum is calculated as floor(RF/2)+1 = 2, which requires
+				// all replicas, giving zero fault tolerance. A single slow or failing ingester
+				// then blocks every push indefinitely or completely fails request. All requests
+				// would need to succeed all the time.
+				//
+				// Mirror Thanos quorum https://github.com/thanos-io/thanos/blob/v0.41.0/pkg/receive/handler.go#L1058
+				// Allow one failure so RF=2 matches the fault tolerance of RF≥3 and return as soon as one ingester
+				// succeeds and let the second write complete in the background.
+				if len(replicationSet.Instances) == 2 && maxErrors == 0 {
+					maxErrors = 1
+				}
 				streamTrackers[i] = streamTracker{
 					KeyedStream: stream,
-					minSuccess:  len(replicationSet.Instances) - replicationSet.MaxErrors,
-					maxFailures: replicationSet.MaxErrors,
+					minSuccess:  len(replicationSet.Instances) - maxErrors,
+					maxFailures: maxErrors,
 				}
 				for _, ingester := range replicationSet.Instances {
 					streamsByIngester[ingester.Addr] = append(streamsByIngester[ingester.Addr], &streamTrackers[i])

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -902,7 +902,7 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 				// Mirror Thanos quorum https://github.com/thanos-io/thanos/blob/v0.41.0/pkg/receive/handler.go#L1058
 				// Allow one failure so RF=2 matches the fault tolerance of RF≥3 and return as soon as one ingester
 				// succeeds and let the second write complete in the background.
-				if len(replicationSet.Instances) == 2 && maxErrors == 0 {
+				if d.ingestersRing.ReplicationFactor() == 2 && maxErrors == 0 {
 					maxErrors = 1
 				}
 				streamTrackers[i] = streamTracker{

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -615,6 +615,67 @@ func TestDistributorPushErrors(t *testing.T) {
 	})
 }
 
+// Test RF=2 behaviour with one failure allowed.
+func TestDistributorPushErrorsRF2(t *testing.T) {
+	limits := &validation.Limits{}
+	flagext.DefaultValues(limits)
+
+	t.Run("with RF=2 a single ingester failure still succeeds", func(t *testing.T) {
+		distributors, ingesters := prepareWithRF(t, 1, 2, 2, limits, nil)
+		ingesters[0].failAfter = 5 * time.Millisecond
+		ingesters[1].succeedAfter = 10 * time.Millisecond
+
+		request := makeWriteRequest(10, 64)
+		_, err := distributors[0].Push(ctx, request)
+		require.NoError(t, err)
+
+		// The successful ingester must have received the data.
+		require.Eventually(t, func() bool {
+			return len(ingesters[1].pushed) == 1
+		}, time.Second, 10*time.Millisecond)
+
+		// The failing ingester must not have written anything.
+		require.Equal(t, 0, len(ingesters[0].pushed))
+	})
+
+	t.Run("with RF=2 both ingester failures result in error", func(t *testing.T) {
+		distributors, ingesters := prepareWithRF(t, 1, 2, 2, limits, nil)
+		ingesters[0].failAfter = 5 * time.Millisecond
+		ingesters[1].failAfter = 10 * time.Millisecond
+
+		request := makeWriteRequest(10, 64)
+		_, err := distributors[0].Push(ctx, request)
+		require.Error(t, err)
+
+		require.Equal(t, 0, len(ingesters[0].pushed))
+		require.Equal(t, 0, len(ingesters[1].pushed))
+	})
+
+	t.Run("with RF=2 push returns after first ingester succeeds without waiting for second", func(t *testing.T) {
+		distributors, ingesters := prepareWithRF(t, 1, 2, 2, limits, nil)
+		// First ingester responds quickly, second is very slow.
+		ingesters[0].succeedAfter = 5 * time.Millisecond
+		ingesters[1].succeedAfter = 500 * time.Millisecond
+
+		request := makeWriteRequest(10, 64)
+		start := time.Now()
+		_, err := distributors[0].Push(ctx, request)
+		elapsed := time.Since(start)
+
+		require.NoError(t, err)
+		// Should return well before the slow ingester finishes.
+		require.Less(t, elapsed, 200*time.Millisecond)
+
+		// First ingester succeeded immediately.
+		require.Equal(t, 1, len(ingesters[0].pushed))
+
+		// Second ingester eventually gets the write via background context.
+		require.Eventually(t, func() bool {
+			return len(ingesters[1].pushed) == 1
+		}, 2*time.Second, 10*time.Millisecond)
+	})
+}
+
 func TestDistributorPushToKafka(t *testing.T) {
 	limits := &validation.Limits{}
 	flagext.DefaultValues(limits)
@@ -1898,6 +1959,10 @@ func TestDistributor_PushIngestionBlockedByPolicy(t *testing.T) {
 }
 
 func prepare(t *testing.T, numDistributors, numIngesters int, limits *validation.Limits, factory func(addr string) (ring_client.PoolClient, error)) ([]*Distributor, []mockIngester) {
+	return prepareWithRF(t, numDistributors, numIngesters, 3, limits, factory)
+}
+
+func prepareWithRF(t *testing.T, numDistributors, numIngesters, replicationFactor int, limits *validation.Limits, factory func(addr string) (ring_client.PoolClient, error)) ([]*Distributor, []mockIngester) {
 	t.Helper()
 
 	ingesters := make([]mockIngester, numIngesters)
@@ -1936,7 +2001,7 @@ func prepare(t *testing.T, numDistributors, numIngesters int, limits *validation
 			Mock: kvStore,
 		},
 		HeartbeatTimeout:  60 * time.Minute,
-		ReplicationFactor: 3,
+		ReplicationFactor: replicationFactor,
 	}, ingester.RingKey, ingester.RingKey, nil, nil)
 
 	require.NoError(t, err)

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -613,12 +613,6 @@ func TestDistributorPushErrors(t *testing.T) {
 		require.Equal(t, 0, len(ingesters[0].pushed))
 		require.Equal(t, 0, len(ingesters[2].pushed))
 	})
-}
-
-// Test RF=2 behaviour with one failure allowed.
-func TestDistributorPushErrorsRF2(t *testing.T) {
-	limits := &validation.Limits{}
-	flagext.DefaultValues(limits)
 
 	t.Run("with RF=2 a single ingester failure still succeeds", func(t *testing.T) {
 		distributors, ingesters := prepareWithRF(t, 1, 2, 2, limits, nil)
@@ -673,6 +667,19 @@ func TestDistributorPushErrorsRF2(t *testing.T) {
 		require.Eventually(t, func() bool {
 			return len(ingesters[1].pushed) == 1
 		}, 2*time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("with RF=3 degraded to 2 instances a single failure still errors", func(t *testing.T) {
+		distributors, ingesters := prepareWithRF(t, 1, 2, 3, limits, nil)
+		ingesters[0].failAfter = 5 * time.Millisecond
+		ingesters[1].succeedAfter = 10 * time.Millisecond
+
+		request := makeWriteRequest(10, 64)
+		_, err := distributors[0].Push(ctx, request)
+
+		// minSuccess=2 with only 2 instances means one failure is fatal.
+		require.Error(t, err)
+		require.Equal(t, 0, len(ingesters[0].pushed))
 	})
 }
 


### PR DESCRIPTION
This commit adds a check and override for replication factor 2, to override the fault tolerance set by dskit.

In RF 2 case, based on quorum floor(rf/2) + 1=2, there would be no fault tolerance on incoming push request replications. Both replications would have to succeed all of the time for 2xx. Any slow ingester can block push requests indefinitely until removed from hashring.

This commit sets maxErrors to 1, to allow for similar to RF>=3 fault tolerance on RF=2.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributor write-quorum semantics for ingester pushes when `ReplicationFactor=2`, which can affect perceived write success and durability/latency characteristics under partial failure.
> 
> **Overview**
> For ingester writes with `ReplicationFactor=2`, the distributor now overrides `replicationSet.MaxErrors` to allow **one replica failure** (and return once the first ingester succeeds), mirroring Thanos’ quorum behavior and preventing pushes from being indefinitely blocked by a single slow/failing ingester.
> 
> Adds targeted tests covering RF=2 success with one failure, failure when both ingesters fail, early-return behavior when the second ingester is slow, and a guard asserting RF=3 (degraded to 2 instances) still errors on a single failure. Test scaffolding is updated with `prepareWithRF` to vary replication factor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc7f42f6453350fe707e2804dd7eae66d28b35f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->