### PR TITLE
chore: Explicit plan for no grouping columns when none are provided.

### DIFF
--- a/pkg/engine/internal/planner/logical/grouping.go
+++ b/pkg/engine/internal/planner/logical/grouping.go
@@ -6,6 +6,4 @@ type Grouping struct {
 	Without bool        // The grouping mode
 }
 
-var (
-	NoGrouping = Grouping{Without: true}
-)
+var NoGrouping = Grouping{Without: false}

--- a/pkg/engine/internal/planner/logical/planner.go
+++ b/pkg/engine/internal/planner/logical/planner.go
@@ -696,10 +696,7 @@ func convertGrouping(g *syntax.Grouping) Grouping {
 	var columns []ColumnRef
 
 	if g == nil {
-		return Grouping{
-			Columns: columns,
-			Without: true,
-		}
+		return NoGrouping
 	}
 
 	if g.Groups != nil {

--- a/pkg/engine/internal/planner/logical/planner_test.go
+++ b/pkg/engine/internal/planner/logical/planner_test.go
@@ -228,8 +228,44 @@ func TestConvertAST_MetricQuery_Success(t *testing.T) {
 %8 = LT builtin.timestamp 1970-01-01T02:00:00Z
 %9 = SELECT %7 [predicate=%8]
 %10 = SELECT %9 [predicate=%4]
-%11 = RANGE_AGGREGATION %10 [operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
+%11 = RANGE_AGGREGATION %10 [group_by=(), operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
 %12 = VECTOR_AGGREGATION %11 [operation=sum, group_by=(ambiguous.level)]
+%13 = LOGQL_COMPAT %12
+RETURN %13
+`
+
+		require.Equal(t, expected, logicalPlan.String())
+
+		var sb strings.Builder
+		PrintTree(&sb, logicalPlan.Value())
+
+		t.Logf("\n%s\n", sb.String())
+	})
+
+	t.Run("simple metric query with empty grouping", func(t *testing.T) {
+		q := &query{
+			statement: `sum (count_over_time({cluster="prod", namespace=~"loki-.*"} |= "metric.go"[5m]))`,
+			start:     3600,
+			end:       7200,
+			interval:  5 * time.Minute,
+		}
+
+		logicalPlan, err := BuildPlan(context.Background(), q)
+		require.NoError(t, err)
+		t.Logf("\n%s\n", logicalPlan.String())
+
+		expected := `%1 = EQ label.cluster "prod"
+%2 = MATCH_RE label.namespace "loki-.*"
+%3 = AND %1 %2
+%4 = MATCH_STR builtin.message "metric.go"
+%5 = MAKETABLE [selector=%3, predicates=[%4], shard=0_of_1]
+%6 = GTE builtin.timestamp 1970-01-01T00:55:00Z
+%7 = SELECT %5 [predicate=%6]
+%8 = LT builtin.timestamp 1970-01-01T02:00:00Z
+%9 = SELECT %7 [predicate=%8]
+%10 = SELECT %9 [predicate=%4]
+%11 = RANGE_AGGREGATION %10 [group_by=(), operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
+%12 = VECTOR_AGGREGATION %11 [operation=sum, group_by=()]
 %13 = LOGQL_COMPAT %12
 RETURN %13
 `
@@ -262,7 +298,7 @@ RETURN %13
 %6 = SELECT %4 [predicate=%5]
 %7 = LT builtin.timestamp 1970-01-01T02:00:00Z
 %8 = SELECT %6 [predicate=%7]
-%9 = RANGE_AGGREGATION %8 [operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
+%9 = RANGE_AGGREGATION %8 [group_by=(), operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
 %10 = DIV %9 300
 %11 = VECTOR_AGGREGATION %10 [operation=sum, group_by=(ambiguous.level)]
 %12 = LOGQL_COMPAT %11
@@ -295,7 +331,42 @@ RETURN %12
 %4 = SELECT %2 [predicate=%3]
 %5 = LT builtin.timestamp 1970-01-01T02:00:00Z
 %6 = SELECT %4 [predicate=%5]
-%7 = RANGE_AGGREGATION %6 [operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
+%7 = RANGE_AGGREGATION %6 [group_by=(), operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
+%8 = DIV %7 300
+%9 = SUB %8 100
+%10 = POW %9 2
+%11 = VECTOR_AGGREGATION %10 [operation=sum, group_by=(ambiguous.level)]
+%12 = LOGQL_COMPAT %11
+RETURN %12
+`
+
+		require.Equal(t, expected, logicalPlan.String())
+
+		var sb strings.Builder
+		PrintTree(&sb, logicalPlan.Value())
+
+		t.Logf("\n%s\n", sb.String())
+	})
+
+	t.Run(`rate metric query with nested math expression`, func(t *testing.T) {
+		q := &query{
+			statement: `sum by (level) ((rate({cluster="prod"}[5m]) - 100) ^ 2)`,
+			start:     3600,
+			end:       7200,
+			interval:  5 * time.Minute,
+		}
+
+		logicalPlan, err := BuildPlan(context.Background(), q)
+		require.NoError(t, err)
+		t.Logf("\n%s\n", logicalPlan.String())
+
+		expected := `%1 = EQ label.cluster "prod"
+%2 = MAKETABLE [selector=%1, predicates=[], shard=0_of_1]
+%3 = GTE builtin.timestamp 1970-01-01T00:55:00Z
+%4 = SELECT %2 [predicate=%3]
+%5 = LT builtin.timestamp 1970-01-01T02:00:00Z
+%6 = SELECT %4 [predicate=%5]
+%7 = RANGE_AGGREGATION %6 [group_by=(), operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
 %8 = DIV %7 300
 %9 = SUB %8 100
 %10 = POW %9 2
@@ -581,7 +652,7 @@ func TestPlannerCreatesCastOperationForUnwrap(t *testing.T) {
 %11 = EQ generated.__error_details__ ""
 %12 = AND %10 %11
 %13 = SELECT %9 [predicate=%12]
-%14 = RANGE_AGGREGATION %13 [operation=sum, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
+%14 = RANGE_AGGREGATION %13 [group_by=(), operation=sum, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
 %15 = VECTOR_AGGREGATION %14 [operation=sum, group_by=(ambiguous.status)]
 %16 = LOGQL_COMPAT %15
 RETURN %16
@@ -616,7 +687,7 @@ func TestPlannerCreatesProjectionWithParseOperation(t *testing.T) {
 %8 = PROJECT %6 [mode=*E, expr=%7]
 %9 = EQ ambiguous.level "error"
 %10 = SELECT %8 [predicate=%9]
-%11 = RANGE_AGGREGATION %10 [operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
+%11 = RANGE_AGGREGATION %10 [group_by=(), operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
 %12 = VECTOR_AGGREGATION %11 [operation=sum, group_by=(ambiguous.level)]
 %13 = LOGQL_COMPAT %12
 RETURN %13
@@ -679,7 +750,7 @@ RETURN %12
 %8 = PROJECT %6 [mode=*E, expr=%7]
 %9 = EQ ambiguous.level "error"
 %10 = SELECT %8 [predicate=%9]
-%11 = RANGE_AGGREGATION %10 [operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
+%11 = RANGE_AGGREGATION %10 [group_by=(), operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
 %12 = VECTOR_AGGREGATION %11 [operation=sum, group_by=(ambiguous.level)]
 %13 = LOGQL_COMPAT %12
 RETURN %13
@@ -742,7 +813,7 @@ RETURN %12
 %8 = PROJECT %6 [mode=*E, expr=%7]
 %9 = EQ ambiguous.foo "bar"
 %10 = SELECT %8 [predicate=%9]
-%11 = RANGE_AGGREGATION %10 [operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
+%11 = RANGE_AGGREGATION %10 [group_by=(), operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
 %12 = VECTOR_AGGREGATION %11 [operation=sum, group_by=(ambiguous.foo)]
 %13 = LOGQL_COMPAT %12
 RETURN %13
@@ -869,7 +940,7 @@ RETURN %16
 %12 = PROJECT %10 [mode=*E, expr=%11]
 %13 = EQ ambiguous.level "debug"
 %14 = SELECT %12 [predicate=%13]
-%15 = RANGE_AGGREGATION %14 [operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
+%15 = RANGE_AGGREGATION %14 [group_by=(), operation=count, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
 %16 = VECTOR_AGGREGATION %15 [operation=sum, group_by=(ambiguous.level)]
 %17 = LOGQL_COMPAT %16
 RETURN %17

--- a/pkg/engine/internal/planner/physical/rule_projection_pushdown.go
+++ b/pkg/engine/internal/planner/physical/rule_projection_pushdown.go
@@ -34,7 +34,7 @@ func (r *projectionPushdown) propagateProjections(node Node, projections []Colum
 		if node.Grouping.Without {
 			return changed
 		}
-		// [Source] RangeAggregation requires partitionBy columns & timestamp.
+		// RangeAggregation requires partitionBy columns for "by" queries.
 		projections = append(projections, node.Grouping.Columns...)
 		// Always project timestamp column. Timestamp values are required to perform range aggregation.
 		projections = append(projections, &ColumnExpr{Ref: types.ColumnRef{Column: types.ColumnNameBuiltinTimestamp, Type: types.ColumnTypeBuiltin}})


### PR DESCRIPTION
**What this PR does / why we need it**:
When planning a query like `sum(count_over_time({container="loki"}[5m]))` the range aggregation only needs timestamps as there is no By or Without clause.

The previous behaviour would default to reading all columns (e.g. `without ()`) rather than reading timestamps only. This fixes that case.

In my test query, this removed any reading of secondary bytes which was 90% of the bytes loaded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default grouping semantics for metric aggregations, which affects planning/projection pushdown and could alter which columns are scanned for some queries. Main risk is behavioral differences in edge cases around `by/without` handling, though coverage is added via updated planner tests.
> 
> **Overview**
> Fixes metric planning so *absence of a `by`/`without` clause* is represented as explicit `group_by=()` (via `NoGrouping`) instead of behaving like `without ()`, enabling projection pushdown to scan only required columns (notably timestamp-only for ungrouped range aggregations).
> 
> Updates logical-plan string expectations and adds a test for empty grouping, plus adjusts projection pushdown comments/behavior to treat `RangeAggregation` projections as only needed for `by` groupings (skipping `without`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433a7d1902403304af72c28a06357e7d6f12bb44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->