### PR TITLE
chore: Make MaxSampleCollector implement same interface as prometheus gauge

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -569,8 +569,8 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 // The returned error is the last one seen.
 func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRequest, streamResolver *requestScopedStreamResolver, format string) (*logproto.PushResponse, error) {
 	requestSize := int64(req.Size())
-	d.inflightBytes.Inc(requestSize)
-	defer d.inflightBytes.Inc(-requestSize)
+	d.inflightBytes.Add(requestSize)
+	defer d.inflightBytes.Sub(requestSize)
 
 	tenantID, err := tenant.TenantID(ctx)
 	if err != nil {

--- a/pkg/util/metric/max_sample_collector.go
+++ b/pkg/util/metric/max_sample_collector.go
@@ -30,9 +30,24 @@ func NewMaxSampleCollector(fqName, help string) *MaxSampleCollector {
 	return c
 }
 
-// Inc adds the delta to the current value.
-func (c *MaxSampleCollector) Inc(delta int64) {
+// Add adds the delta to the current value.
+func (c *MaxSampleCollector) Add(delta int64) {
 	c.val.Add(delta)
+}
+
+// Sub subtracts the delta to the current value.
+func (c *MaxSampleCollector) Sub(delta int64) {
+	c.val.Add(-delta)
+}
+
+// Inc increments the counter.
+func (c *MaxSampleCollector) Inc() {
+	c.val.Add(1)
+}
+
+// Dec decrements the counter.
+func (c *MaxSampleCollector) Dec() {
+	c.val.Add(-1)
 }
 
 // Describe implements [prometheus.Collector].

--- a/pkg/util/metric/max_sample_collector_test.go
+++ b/pkg/util/metric/max_sample_collector_test.go
@@ -16,7 +16,7 @@ func TestMaxSampleCollector(t *testing.T) {
 	require.Equal(t, expected, c.samples)
 	// Inc should update the current value, but not samples, since the
 	// timer hasn't fired.
-	c.Inc(1)
+	c.Add(1)
 	require.Equal(t, int64(1), c.val.Load())
 	require.Equal(t, int64(0), c.maxVal.Load())
 	require.Equal(t, expected, c.samples)
@@ -33,7 +33,7 @@ func TestMaxSampleCollector(t *testing.T) {
 	require.Equal(t, int64(1), c.val.Load())
 	require.Equal(t, int64(1), c.maxVal.Load())
 	// Inc one last time, and call the iterFunc.
-	c.Inc(2)
+	c.Add(2)
 	require.Equal(t, int64(3), c.val.Load())
 	require.Equal(t, int64(1), c.maxVal.Load())
 	require.NoError(t, c.iterFunc(t.Context()))
@@ -49,6 +49,26 @@ func TestMaxSampleCollector(t *testing.T) {
 # TYPE test gauge
 test 3
 `), "test"))
+}
+
+func TestMaxSampleCollector_Add_Sub(t *testing.T) {
+	c := NewMaxSampleCollector("test", "")
+	require.Equal(t, int64(0), c.val.Load())
+	c.Add(2)
+	require.Equal(t, int64(2), c.val.Load())
+	c.Sub(1)
+	require.Equal(t, int64(1), c.val.Load())
+}
+
+func TestMaxSampleCollector_Inc_Dec(t *testing.T) {
+	c := NewMaxSampleCollector("test", "")
+	require.Equal(t, int64(0), c.val.Load())
+	c.Inc()
+	require.Equal(t, int64(1), c.val.Load())
+	c.Inc()
+	require.Equal(t, int64(2), c.val.Load())
+	c.Dec()
+	require.Equal(t, int64(1), c.val.Load())
 }
 
 func ExampleMaxSampleCollector() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Make MaxSampleCollector implement same interface as prometheus gauge.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized metric API change plus a single call-site update; behavior remains simple atomic adds/subtracts and is covered by unit tests.
> 
> **Overview**
> Updates `MaxSampleCollector` to expose a Prometheus `Gauge`-like API by adding `Add`/`Sub` and `Inc`/`Dec` methods (replacing the old `Inc(delta)` signature).
> 
> Updates the distributor inflight-bytes tracking to use the new `Add`/`Sub` calls, and expands unit tests to cover the new methods.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a41e3bc5eb725d7e2c7fea0445deb5f2c93fa89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->