### PR TITLE
chore(engine): Improve log events to observe query lifecycles

### DIFF
--- a/pkg/dataobj/internal/dataset/row_reader.go
+++ b/pkg/dataobj/internal/dataset/row_reader.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"iter"
 
+	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/bitmask"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/rangeset"
@@ -576,13 +577,16 @@ func (r *RowReader) initDownloader(ctx context.Context) error {
 		primary := mask.Test(i)
 		r.dl.AddColumn(column, primary)
 
+		pageCount := int64(column.ColumnDesc().PagesCount)
+		region.Record(dataobj.StatDatasetPagesTotal.Observe(pageCount))
+
 		if primary {
 			r.primaryColumnIndexes = append(r.primaryColumnIndexes, i)
 			region.Record(xcap.StatDatasetPrimaryColumns.Observe(1))
-			region.Record(xcap.StatDatasetPrimaryColumnPages.Observe(int64(column.ColumnDesc().PagesCount)))
+			region.Record(xcap.StatDatasetPrimaryColumnPages.Observe(pageCount))
 		} else {
 			region.Record(xcap.StatDatasetSecondaryColumns.Observe(1))
-			region.Record(xcap.StatDatasetSecondaryColumnPages.Observe(int64(column.ColumnDesc().PagesCount)))
+			region.Record(xcap.StatDatasetSecondaryColumnPages.Observe(pageCount))
 		}
 	}
 
@@ -819,6 +823,8 @@ func (r *RowReader) buildColumnPredicateRanges(ctx context.Context, c Column, p 
 		return rangeset.Set{}, fmt.Errorf("column %v not found in RowReader columns", c)
 	}
 
+	region := xcap.RegionFromContext(ctx)
+
 	var ranges rangeset.Set
 
 	var (
@@ -874,6 +880,12 @@ func (r *RowReader) buildColumnPredicateRanges(ctx context.Context, c Column, p 
 
 		if include {
 			ranges.Add(pageRange)
+		} else {
+			// Page-level stats were present and the predicate ruled out the page,
+			// so the page will not be downloaded for this predicate. Pages without
+			// stats short-circuit above (they are always included) and are not
+			// counted here.
+			region.Record(dataobj.StatDatasetPagesPruned.Observe(1))
 		}
 	}
 

--- a/pkg/dataobj/range_reader.go
+++ b/pkg/dataobj/range_reader.go
@@ -7,6 +7,8 @@ import (
 	"math"
 
 	"github.com/thanos-io/objstore"
+
+	"github.com/grafana/loki/v3/pkg/xcap"
 )
 
 // rangeReader is an interface that can read a range of bytes from an object.
@@ -37,11 +39,52 @@ func (rr *bucketRangeReader) Size(ctx context.Context) (int64, error) {
 }
 
 func (rr *bucketRangeReader) Read(ctx context.Context) (io.ReadCloser, error) {
-	return rr.bucket.Get(ctx, rr.path)
+	rc, err := rr.bucket.Get(ctx, rr.path)
+	if err != nil {
+		return nil, err
+	}
+	return newDownloadCountingReadCloser(ctx, rc), nil
 }
 
 func (rr *bucketRangeReader) ReadRange(ctx context.Context, offset int64, length int64) (io.ReadCloser, error) {
-	return rr.bucket.GetRange(ctx, rr.path, offset, length)
+	rc, err := rr.bucket.GetRange(ctx, rr.path, offset, length)
+	if err != nil {
+		return nil, err
+	}
+	return newDownloadCountingReadCloser(ctx, rc), nil
+}
+
+// downloadCountingReadCloser wraps an [io.ReadCloser] returned by an
+// object-store request and accumulates the number of bytes read from it.
+// The accumulated total is recorded against [StatObjectBytesDownloaded] on
+// [xcap.Region] in the context (if any) when the reader is closed, so the
+// total reflects bytes actually transferred from storage rather than the
+// requested range size.
+type downloadCountingReadCloser struct {
+	inner  io.ReadCloser
+	region *xcap.Region
+	n      int64
+}
+
+func newDownloadCountingReadCloser(ctx context.Context, rc io.ReadCloser) *downloadCountingReadCloser {
+	return &downloadCountingReadCloser{
+		inner:  rc,
+		region: xcap.RegionFromContext(ctx),
+	}
+}
+
+func (rc *downloadCountingReadCloser) Read(p []byte) (int, error) {
+	n, err := rc.inner.Read(p)
+	rc.n += int64(n)
+	return n, err
+}
+
+func (rc *downloadCountingReadCloser) Close() error {
+	if rc.n > 0 {
+		rc.region.Record(StatObjectBytesDownloaded.Observe(rc.n))
+		rc.n = 0
+	}
+	return rc.inner.Close()
 }
 
 type readerAtRangeReader struct {

--- a/pkg/dataobj/stat.go
+++ b/pkg/dataobj/stat.go
@@ -1,0 +1,35 @@
+package dataobj
+
+import "github.com/grafana/loki/v3/pkg/xcap"
+
+// These stats are defined alongside the dataobj package so that
+// [pkg/dataobj/internal/dataset] can record them without forcing
+// [pkg/xcap] to learn about dataobj-internal counters.
+
+var (
+	// StatDatasetPagesTotal is the total number of pages contained in the
+	// dataset sections opened by a task's [dataset.RowReader], summed across
+	// every read column. This is the pre-pruning page count: it is recorded
+	// before metadata predicates have a chance to eliminate pages from the read
+	// set.
+	StatDatasetPagesTotal = xcap.NewStatisticInt64("dataobj.dataset.pages.total", xcap.AggregationTypeSum)
+
+	// StatDatasetPagesPruned counts pages that a task's [dataset.RowReader]
+	// eliminated using page-level metadata statistics (min/max) before any page
+	// data was downloaded.
+	//
+	// The counter is incremented per (page, leaf-predicate) rejection, so a
+	// page that is rejected by multiple predicates contributes more than once.
+	// This matches "work avoided by metadata pruning" rather than "distinct
+	// pages skipped".
+	StatDatasetPagesPruned = xcap.NewStatisticInt64("dataobj.dataset.pages.pruned", xcap.AggregationTypeSum)
+
+	// StatObjectBytesDownloaded is the total number of bytes a task pulled from
+	// the backing object store via the [rangeReader] interface across every
+	// request (metadata reads, page downloads, ad-hoc reads, etc.).
+	//
+	// It is recorded at the lowest rangeReader layer that actually hits remote
+	// storage. Bytes served from the metadata prefetch buffer are not counted
+	// again, so this is a true "transferred from storage" figure.
+	StatObjectBytesDownloaded = xcap.NewStatisticInt64("dataobj.object.bytes.downloaded", xcap.AggregationTypeSum)
+)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -24,7 +24,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/logical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
-	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
@@ -220,7 +219,11 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	}
 	defer q.Close()
 
+	// We save the pre-query logger so we can pass it to buildPhysicalPlan,
+	// which creates a subquery.
+	engineLogger := logger
 	logger = q.Logger()
+
 	level.Info(logger).Log("msg", "starting query", "query", params.QueryString(), "shard", strings.Join(params.Shards(), ","))
 
 	ctx, task := gotrace.NewTask(ctx, "Engine.Execute")
@@ -248,7 +251,8 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	}
 	gotrace.Log(ctx, "logical_planning", "done")
 
-	physicalPlan, durPhysicalPlanning, err := e.buildPhysicalPlan(ctx, q, params, logicalPlan, cacheEnabled)
+	catalog := physical.NewMetastoreCatalog(e.metastoreSectionsResolver(ctx, q, engineLogger, cacheEnabled))
+	physicalPlan, durPhysicalPlanning, err := e.buildPhysicalPlan(ctx, q, params, catalog, logicalPlan)
 	if err != nil {
 		e.metrics.subqueries.WithLabelValues(statusFailure).Inc()
 		q.RecordError(ctx, errors.New("failed to create physical plan"))
@@ -408,11 +412,9 @@ func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Pa
 }
 
 // buildPhysicalPlan builds a physical plan from the given logical plan.
-func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.Params, logicalPlan *logical.Plan, taskCacheEnabled bool) (*physical.Plan, time.Duration, error) {
+func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.Params, catalog *physical.MetastoreCatalog, logicalPlan *logical.Plan) (*physical.Plan, time.Duration, error) {
 	span := trace.SpanFromContext(ctx)
 	timer := prometheus.NewTimer(e.metrics.physicalPlanning)
-
-	catalog := physical.NewMetastoreCatalog(e.metastoreSectionsResolver(ctx, q.TenantID(), q.Logger(), taskCacheEnabled))
 
 	// TODO(rfratto): It feels strange that we need to past the start/end time
 	// to the physical planner. Isn't it already represented by the logical
@@ -457,36 +459,43 @@ func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.P
 	return physicalPlan, duration, nil
 }
 
-func (e *Engine) metastoreSectionsResolver(ctx context.Context, tenantID string, logger log.Logger, cacheEnabled bool) physical.MetastoreSectionsResolver {
+func (e *Engine) metastoreSectionsResolver(ctx context.Context, parent *query, logger log.Logger, cacheEnabled bool) physical.MetastoreSectionsResolver {
 	planner := physical.NewMetastorePlanner(e.metastore, e.cfg.Executor.BatchSize)
 	logger = log.With(logger, "subcomponent", "metastore")
+
+	if parent != nil {
+		logger = log.With(logger, "parent_query_id", parent.ID())
+	}
+
 	return func(selector physical.Expression, predicates []physical.Expression, start time.Time, end time.Time) ([]*metastore.DataobjSectionDescriptor, error) {
-		ctx, span := xcap.StartSpan(ctx, tracer, "engine.metastoreResolver")
-		defer span.End()
+		q, ctx, err := e.newQuery(ctx, logger, "index", cacheEnabled)
+		if err != nil {
+			return nil, fmt.Errorf("creating index query: %w", err)
+		}
+		defer q.Close()
 
 		plan, err := planner.Plan(ctx, selector, predicates, start, end)
 		if err != nil {
-			return nil, fmt.Errorf("metastore: build plan: %w", err)
+			return nil, fmt.Errorf("index query: build plan: %w", err)
 		}
 
 		// Disable admission lanes for metastore queries
 		useAdmissionLanes := false
-
-		wf, _, err := e.buildWorkflow(ctx, tenantID, logger, plan, useAdmissionLanes, cacheEnabled)
+		wf, err := q.Prepare(ctx, plan, useAdmissionLanes)
 		if err != nil {
-			return nil, fmt.Errorf("metastore: build workflow: %w", err)
+			return nil, fmt.Errorf("index query: build workflow: %w", err)
 		}
 		defer wf.Close()
 
 		pipeline, err := wf.Run(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("metastore: run workflow: %w", err)
+			return nil, fmt.Errorf("index query: run workflow: %w", err)
 		}
 		reader := executor.TranslateEOF(pipeline)
 		defer reader.Close()
 
 		if err := reader.Open(ctx); err != nil {
-			return nil, fmt.Errorf("metastore: open pipeline: %w", err)
+			return nil, fmt.Errorf("index query: open pipeline: %w", err)
 		}
 
 		resp, err := e.metastore.CollectSections(ctx, metastore.CollectSectionsRequest{
@@ -495,68 +504,11 @@ func (e *Engine) metastoreSectionsResolver(ctx context.Context, tenantID string,
 			Reader: reader,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("metastore: collect sections: %w", err)
+			return nil, fmt.Errorf("index query: collect sections: %w", err)
 		}
 
-		// close to report the stats
-		reader.Close()
 		return resp.SectionsResponse.Sections, nil
 	}
-}
-
-// buildWorkflow builds a workflow from the given physical plan.
-func (e *Engine) buildWorkflow(ctx context.Context, tenantID string, logger log.Logger, physicalPlan *physical.Plan, useAdmissionLanes bool, cacheEnabled bool) (*workflow.Workflow, time.Duration, error) {
-	span := trace.SpanFromContext(ctx)
-	timer := prometheus.NewTimer(e.metrics.workflowPlanning)
-
-	maxRunningScanTasks := 0
-	// Set max running tasks limits on when admission lanes are enabled
-	if useAdmissionLanes {
-		maxRunningScanTasks = e.limits.MaxScanTaskParallelism(tenantID)
-	}
-
-	opts := workflow.Options{
-		Tenant: tenantID,
-		Actor:  httpreq.ExtractActorPath(ctx),
-
-		MaxRunningScanTasks:  maxRunningScanTasks,
-		MaxRunningOtherTasks: 0,
-
-		CacheEnabled:                 cacheEnabled,
-		MaxTaskCacheSize:             uint64(e.cfg.Executor.TaskResultsCache.TaskResultMaxCacheableSize),
-		MaxDataObjScanCacheSize:      uint64(e.cfg.Executor.TaskResultsCache.DataObjScanResultMaxCacheableSize),
-		CacheCompression:             e.cfg.Executor.TaskResultsCache.Compression,
-		PruneEmptyCachedTasks:        e.cfg.Executor.TaskResultsCache.PruneEmptyCachedTasks,
-		NonEmptyCachedTasksMaxSize:   uint64(e.cfg.Executor.TaskResultsCache.PruneCachedTasksMaxSize),
-		PruneCachedTasksFetchTimeout: e.cfg.Executor.TaskResultsCache.PruneCachedTasksFetchTimeout,
-		TaskCacheRegistry:            e.taskCaches,
-
-		DebugTasks:   e.limits.DebugEngineTasks(tenantID),
-		DebugStreams: e.limits.DebugEngineStreams(tenantID),
-	}
-	wf, err := workflow.New(opts, logger, e.scheduler.inner, physicalPlan)
-	if err != nil {
-		level.Warn(logger).Log("msg", "failed to create workflow", "err", err)
-		span.RecordError(err)
-		return nil, 0, ErrNotSupported
-	}
-
-	duration := timer.ObserveDuration()
-
-	// The execution plan can be way more verbose than the physical plan, so we
-	// only log it at debug level.
-	level.Debug(logger).Log(
-		"msg", "generated execution plan",
-		"plan", workflow.Sprint(wf),
-	)
-	level.Info(logger).Log(
-		"msg", "finished execution planning",
-		"duration", duration.String(),
-		"tasks", wf.Len(),
-	)
-
-	span.AddEvent("finished execution planning", trace.WithAttributes(attribute.Stringer("duration", duration)))
-	return wf, duration, nil
 }
 
 // collectResult processes the results of the execution plan.

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"net/http"
 	gotrace "runtime/trace"
 	"strings"
 	"time"
@@ -14,8 +13,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
-	"github.com/grafana/dskit/httpgrpc"
-	"github.com/grafana/dskit/tenant"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -210,21 +207,24 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	// This pain point will eventually go away as remaining usages of
 	// [logql.Engine] disappear.
 
-	// Starts the execution capture for the query.
-	// All recorded observations will be captured to it.
-	ctx, capture := xcap.NewCapture(ctx, nil)
-	defer capture.End()
-	startTime := time.Now()
+	cacheEnabled := cache.IsCacheConfigured(e.cfg.Executor.TaskResultsCache.CacheConfig) && !params.CachingOptions().Disabled
+
+	ctx = e.buildContext(ctx)
+	logger := util_log.WithContext(ctx, e.logger)
+	logger = log.With(logger, "engine", "v2")
+	logger = injectQueryTags(ctx, logger)
+
+	q, ctx, err := e.newQuery(ctx, logger, logqlQueryType(params.GetExpression()), cacheEnabled)
+	if err != nil {
+		return logqlmodel.Result{}, err
+	}
+	defer q.Close()
+
+	logger = q.Logger()
+	level.Info(logger).Log("msg", "starting query", "query", params.QueryString(), "shard", strings.Join(params.Shards(), ","))
 
 	ctx, task := gotrace.NewTask(ctx, "Engine.Execute")
 	defer task.End()
-
-	tenantID, err := tenant.TenantID(ctx)
-	if err != nil {
-		return logqlmodel.Result{}, httpgrpc.Error(http.StatusBadRequest, err.Error())
-	}
-
-	cacheEnabled := cache.IsCacheConfigured(e.cfg.Executor.TaskResultsCache.CacheConfig) && !params.CachingOptions().Disabled
 
 	ctx, span := xcap.StartSpan(ctx, tracer, "Engine.Execute",
 		trace.WithAttributes(
@@ -240,25 +240,18 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	)
 	defer span.End()
 
-	ctx = e.buildContext(ctx)
-	logger := util_log.WithContext(ctx, e.logger)
-	logger = log.With(logger, "engine", "v2")
-	logger = injectQueryTags(ctx, logger)
-
-	level.Info(logger).Log("msg", "starting query", "query", params.QueryString(), "shard", strings.Join(params.Shards(), ","))
-
-	logicalPlan, durLogicalPlanning, err := e.buildLogicalPlan(ctx, logger, params)
+	logicalPlan, durLogicalPlanning, err := e.buildLogicalPlan(ctx, q, params)
 	if err != nil {
 		e.metrics.subqueries.WithLabelValues(statusNotImplemented).Inc()
-		span.SetStatus(codes.Error, "failed to create logical plan")
+		q.RecordError(ctx, errors.New("failed to create logical plan"))
 		return logqlmodel.Result{}, ErrNotSupported
 	}
 	gotrace.Log(ctx, "logical_planning", "done")
 
-	physicalPlan, durPhysicalPlanning, err := e.buildPhysicalPlan(ctx, tenantID, logger, params, logicalPlan, cacheEnabled)
+	physicalPlan, durPhysicalPlanning, err := e.buildPhysicalPlan(ctx, q, params, logicalPlan, cacheEnabled)
 	if err != nil {
 		e.metrics.subqueries.WithLabelValues(statusFailure).Inc()
-		span.SetStatus(codes.Error, "failed to create physical plan")
+		q.RecordError(ctx, errors.New("failed to create physical plan"))
 		return logqlmodel.Result{}, ErrPlanningFailed
 	}
 	gotrace.Log(ctx, "physical_planning", "done")
@@ -266,10 +259,12 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	// Enable admission lanes only for log queries
 	useAdmissionLanes := !isMetricQuery(params.GetExpression())
 
-	wf, durWorkflowPlanning, err := e.buildWorkflow(ctx, tenantID, logger, physicalPlan, useAdmissionLanes, cacheEnabled)
+	start := time.Now()
+	wf, err := q.Prepare(ctx, physicalPlan, useAdmissionLanes)
+	durWorkflowPlanning := time.Since(start)
 	if err != nil {
 		e.metrics.subqueries.WithLabelValues(statusFailure).Inc()
-		span.SetStatus(codes.Error, "failed to create execution plan")
+		q.RecordError(ctx, errors.New("failed to create execution plan"))
 		return logqlmodel.Result{}, ErrPlanningFailed
 	}
 	defer wf.Close()
@@ -280,7 +275,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 		level.Error(logger).Log("msg", "failed to execute query", "err", err)
 
 		e.metrics.subqueries.WithLabelValues(statusFailure).Inc()
-		span.SetStatus(codes.Error, "failed to execute query")
+		q.RecordError(ctx, errors.New("failed to execute query"))
 		return logqlmodel.Result{}, ErrSchedulingFailed
 	}
 	defer pipeline.Close()
@@ -289,11 +284,11 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	builder, durExecution, err := e.collectResult(ctx, logger, params, pipeline)
 	if err != nil {
 		e.metrics.subqueries.WithLabelValues(statusFailure).Inc()
-		span.SetStatus(codes.Error, "error during query execution")
+		q.RecordError(ctx, errors.New("error during query execution"))
 		return logqlmodel.Result{}, err
 	}
 
-	durFull := time.Since(startTime)
+	durFull := time.Since(q.startTime)
 	logValues := []any{
 		"msg", "finished executing",
 		"user_agent", httpreq.ExtractHeader(ctx, "User-Agent"),
@@ -311,25 +306,32 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 
 	// Close the pipeline to calculate the stats.
 	pipeline.Close()
-
 	span.SetStatus(codes.Ok, "")
 
 	// explicitly call End() before exporting even though we have a defer above.
 	// It is safe to call End() multiple times.
 	span.End()
-	capture.End()
+	q.capture.End()
 
-	logValues = append(logValues, xcap.SummaryLogValues(capture)...)
+	logValues = append(logValues, xcap.SummaryLogValues(q.capture)...)
 	level.Info(logger).Log(
 		logValues...,
 	)
 
 	// TODO: capture and report queue time
 	md := metadata.FromContext(ctx)
-	stats := capture.ToStatsSummary(durFull, 0, builder.Len())
+	stats := q.capture.ToStatsSummary(durFull, 0, builder.Len())
 	result := builder.Build(stats, md)
 
 	return result, nil
+}
+
+func logqlQueryType(expr syntax.Expr) string {
+	_, ok := expr.(syntax.SampleExpr)
+	if ok {
+		return "metrics"
+	}
+	return "logs"
 }
 
 // buildContext initializes a request-scoped context prior to execution.
@@ -363,7 +365,7 @@ func isMetricQuery(expr syntax.Expr) bool {
 }
 
 // buildLogicalPlan builds a logical plan from the given params.
-func (e *Engine) buildLogicalPlan(ctx context.Context, logger log.Logger, params logql.Params) (*logical.Plan, time.Duration, error) {
+func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Params) (*logical.Plan, time.Duration, error) {
 	span := trace.SpanFromContext(ctx)
 	timer := prometheus.NewTimer(e.metrics.logicalPlanning)
 
@@ -378,19 +380,19 @@ func (e *Engine) buildLogicalPlan(ctx context.Context, logger log.Logger, params
 
 	logicalPlan, err := logical.BuildPlanWithDeletes(ctx, params, deleteReqs)
 	if err != nil {
-		level.Warn(logger).Log("msg", "failed to create logical plan", "err", err)
-		span.RecordError(err)
+		level.Warn(q.Logger()).Log("msg", "failed to create logical plan", "err", err)
+		q.RecordError(ctx, err)
 		return nil, 0, ErrNotSupported
 	}
 
 	if err := logical.Optimize(logicalPlan); err != nil {
-		level.Warn(logger).Log("msg", "failed to optimize logical plan", "err", err)
-		span.RecordError(err)
+		level.Warn(q.Logger()).Log("msg", "failed to optimize logical plan", "err", err)
+		q.RecordError(ctx, err)
 		return nil, 0, ErrNotSupported
 	}
 
 	duration := timer.ObserveDuration()
-	level.Info(logger).Log(
+	level.Info(q.Logger()).Log(
 		"msg", "finished logical planning",
 		"plan", logicalPlan.String(),
 		"duration", duration.String(),
@@ -406,11 +408,11 @@ func (e *Engine) buildLogicalPlan(ctx context.Context, logger log.Logger, params
 }
 
 // buildPhysicalPlan builds a physical plan from the given logical plan.
-func (e *Engine) buildPhysicalPlan(ctx context.Context, tenantID string, logger log.Logger, params logql.Params, logicalPlan *logical.Plan, taskCacheEnabled bool) (*physical.Plan, time.Duration, error) {
+func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.Params, logicalPlan *logical.Plan, taskCacheEnabled bool) (*physical.Plan, time.Duration, error) {
 	span := trace.SpanFromContext(ctx)
 	timer := prometheus.NewTimer(e.metrics.physicalPlanning)
 
-	catalog := physical.NewMetastoreCatalog(e.metastoreSectionsResolver(ctx, tenantID, logger, taskCacheEnabled))
+	catalog := physical.NewMetastoreCatalog(e.metastoreSectionsResolver(ctx, q.TenantID(), q.Logger(), taskCacheEnabled))
 
 	// TODO(rfratto): It feels strange that we need to past the start/end time
 	// to the physical planner. Isn't it already represented by the logical
@@ -419,33 +421,33 @@ func (e *Engine) buildPhysicalPlan(ctx context.Context, tenantID string, logger 
 
 	// Get the tenant's MaxQuerySeries limit and pass it to the planner context if enforcement is enabled
 	if e.cfg.EnforceQuerySeriesLimit {
-		plannerCtx = plannerCtx.WithMaxQuerySeries(e.limits.MaxQuerySeries(ctx, tenantID))
+		plannerCtx = plannerCtx.WithMaxQuerySeries(e.limits.MaxQuerySeries(ctx, q.TenantID()))
 	}
 
 	planner := physical.NewPlanner(plannerCtx, catalog)
 	physicalPlan, err := planner.Build(logicalPlan)
 	if err != nil {
-		level.Warn(logger).Log("msg", "failed to create physical plan", "err", err)
-		span.RecordError(err)
+		level.Warn(q.Logger()).Log("msg", "failed to create physical plan", "err", err)
+		q.RecordError(ctx, err)
 		return nil, 0, ErrNotSupported
 	}
 
 	physicalPlan, err = planner.Optimize(physicalPlan)
 	if err != nil {
-		level.Warn(logger).Log("msg", "failed to optimize physical plan", "err", err)
-		span.RecordError(err)
+		level.Warn(q.Logger()).Log("msg", "failed to optimize physical plan", "err", err)
+		q.RecordError(ctx, err)
 		return nil, 0, ErrNotSupported
 	}
 
 	physicalPlan, err = physical.WrapWithBatching(physicalPlan, e.cfg.Executor.BatchSize)
 	if err != nil {
-		level.Warn(logger).Log("msg", "failed to wrap physical plan with batching", "err", err)
-		span.RecordError(err)
+		level.Warn(q.Logger()).Log("msg", "failed to wrap physical plan with batching", "err", err)
+		q.RecordError(ctx, err)
 		return nil, 0, ErrNotSupported
 	}
 
 	duration := timer.ObserveDuration()
-	level.Info(logger).Log(
+	level.Info(q.Logger()).Log(
 		"msg", "finished physical planning",
 		"plan", physical.PrintAsTree(physicalPlan),
 		"duration", duration.String(),

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -243,7 +243,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	)
 	defer span.End()
 
-	logicalPlan, durLogicalPlanning, err := e.buildLogicalPlan(ctx, q, params)
+	logicalPlan, err := e.buildLogicalPlan(ctx, q, params)
 	if err != nil {
 		e.metrics.subqueries.WithLabelValues(statusNotImplemented).Inc()
 		q.RecordError(ctx, errors.New("failed to create logical plan"))
@@ -252,7 +252,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	gotrace.Log(ctx, "logical_planning", "done")
 
 	catalog := physical.NewMetastoreCatalog(e.metastoreSectionsResolver(ctx, q, engineLogger, cacheEnabled))
-	physicalPlan, durPhysicalPlanning, err := e.buildPhysicalPlan(ctx, q, params, catalog, logicalPlan)
+	physicalPlan, err := e.buildPhysicalPlan(ctx, q, params, catalog, logicalPlan)
 	if err != nil {
 		e.metrics.subqueries.WithLabelValues(statusFailure).Inc()
 		q.RecordError(ctx, errors.New("failed to create physical plan"))
@@ -263,9 +263,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	// Enable admission lanes only for log queries
 	useAdmissionLanes := !isMetricQuery(params.GetExpression())
 
-	start := time.Now()
 	wf, err := q.Prepare(ctx, physicalPlan, useAdmissionLanes)
-	durWorkflowPlanning := time.Since(start)
 	if err != nil {
 		e.metrics.subqueries.WithLabelValues(statusFailure).Inc()
 		q.RecordError(ctx, errors.New("failed to create execution plan"))
@@ -285,27 +283,12 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	defer pipeline.Close()
 
 	gotrace.Log(ctx, "collect_result", "start")
-	builder, durExecution, err := e.collectResult(ctx, logger, params, pipeline)
+	builder, err := e.execute(ctx, q, params, pipeline)
 	if err != nil {
 		e.metrics.subqueries.WithLabelValues(statusFailure).Inc()
 		q.RecordError(ctx, errors.New("error during query execution"))
 		return logqlmodel.Result{}, err
 	}
-
-	durFull := time.Since(q.startTime)
-	logValues := []any{
-		"msg", "finished executing",
-		"user_agent", httpreq.ExtractHeader(ctx, "User-Agent"),
-		"query", params.QueryString(),
-		"length", params.End().Sub(params.Start()).String(),
-		"step", params.Step().String(),
-		"duration_logical_planning", durLogicalPlanning,
-		"duration_physical_planning", durPhysicalPlanning,
-		"duration_workflow_planning", durWorkflowPlanning,
-		"duration_execution", durExecution,
-		"duration_full", durFull,
-	}
-
 	gotrace.Log(ctx, "collect_result", "done")
 
 	// Close the pipeline to calculate the stats.
@@ -315,18 +298,11 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	// explicitly call End() before exporting even though we have a defer above.
 	// It is safe to call End() multiple times.
 	span.End()
-	q.capture.End()
+	q.Close()
 
-	logValues = append(logValues, xcap.SummaryLogValues(q.capture)...)
-	level.Info(logger).Log(
-		logValues...,
-	)
-
-	// TODO: capture and report queue time
-	md := metadata.FromContext(ctx)
-	stats := q.capture.ToStatsSummary(durFull, 0, builder.Len())
-	result := builder.Build(stats, md)
-
+	// TODO(rfratto): capture and report queue time
+	stats := q.capture.ToStatsSummary(q.Duration(), 0, builder.Len())
+	result := builder.Build(stats, metadata.FromContext(ctx))
 	return result, nil
 }
 
@@ -369,8 +345,10 @@ func isMetricQuery(expr syntax.Expr) bool {
 }
 
 // buildLogicalPlan builds a logical plan from the given params.
-func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Params) (*logical.Plan, time.Duration, error) {
-	span := trace.SpanFromContext(ctx)
+func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Params) (*logical.Plan, error) {
+	ctx, span := xcap.StartSpan(ctx, tracer, "Engine.buildLogicalPlan")
+	defer span.End()
+
 	timer := prometheus.NewTimer(e.metrics.logicalPlanning)
 
 	var deleteReqs []*deletion.Request
@@ -378,7 +356,8 @@ func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Pa
 		var err error
 		deleteReqs, err = deletion.DeletesForUser(ctx, params.Start(), params.End(), e.deleteGetter)
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to get delete requests: %w", err)
+			q.RecordError(ctx, err)
+			return nil, fmt.Errorf("failed to get delete requests: %w", err)
 		}
 	}
 
@@ -386,34 +365,37 @@ func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Pa
 	if err != nil {
 		level.Warn(q.Logger()).Log("msg", "failed to create logical plan", "err", err)
 		q.RecordError(ctx, err)
-		return nil, 0, ErrNotSupported
+		return nil, ErrNotSupported
 	}
 
 	if err := logical.Optimize(logicalPlan); err != nil {
 		level.Warn(q.Logger()).Log("msg", "failed to optimize logical plan", "err", err)
 		q.RecordError(ctx, err)
-		return nil, 0, ErrNotSupported
+		return nil, ErrNotSupported
 	}
 
 	duration := timer.ObserveDuration()
-	level.Info(q.Logger()).Log(
-		"msg", "finished logical planning",
+	span.Record(statLogicalPlanDuration.Observe(int64(duration)))
+
+	level.Info(q.logger).Log(
+		"msg", "logical-plan-summary",
+
 		"plan", logicalPlan.String(),
-		"duration", duration.String(),
+		"duration_ms", duration.Milliseconds(),
+	)
+	span.SetAttributes(
+		attribute.Stringer("plan", logicalPlan),
 	)
 
-	span.AddEvent("finished logical planning",
-		trace.WithAttributes(
-			attribute.Stringer("plan", logicalPlan),
-			attribute.Stringer("duration", duration),
-		),
-	)
-	return logicalPlan, duration, nil
+	span.SetStatus(codes.Ok, "")
+	return logicalPlan, nil
 }
 
 // buildPhysicalPlan builds a physical plan from the given logical plan.
-func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.Params, catalog *physical.MetastoreCatalog, logicalPlan *logical.Plan) (*physical.Plan, time.Duration, error) {
-	span := trace.SpanFromContext(ctx)
+func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.Params, catalog *physical.MetastoreCatalog, logicalPlan *logical.Plan) (*physical.Plan, error) {
+	ctx, span := xcap.StartSpan(ctx, tracer, "Engine.buildPhysicalPlan")
+	defer span.End()
+
 	timer := prometheus.NewTimer(e.metrics.physicalPlanning)
 
 	// TODO(rfratto): It feels strange that we need to past the start/end time
@@ -431,32 +413,76 @@ func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.P
 	if err != nil {
 		level.Warn(q.Logger()).Log("msg", "failed to create physical plan", "err", err)
 		q.RecordError(ctx, err)
-		return nil, 0, ErrNotSupported
+		return nil, ErrNotSupported
 	}
 
-	physicalPlan, err = planner.Optimize(physicalPlan)
-	if err != nil {
-		level.Warn(q.Logger()).Log("msg", "failed to optimize physical plan", "err", err)
-		q.RecordError(ctx, err)
-		return nil, 0, ErrNotSupported
+	{
+		optimizeStart := time.Now()
+
+		physicalPlan, err = planner.Optimize(physicalPlan)
+		if err != nil {
+			level.Warn(q.Logger()).Log("msg", "failed to optimize physical plan", "err", err)
+			q.RecordError(ctx, err)
+			return nil, ErrNotSupported
+		}
+
+		optimizeDuration := time.Since(optimizeStart)
+		span.Record(statPhysicalOptimizeDuration.Observe(int64(optimizeDuration)))
 	}
 
 	physicalPlan, err = physical.WrapWithBatching(physicalPlan, e.cfg.Executor.BatchSize)
 	if err != nil {
 		level.Warn(q.Logger()).Log("msg", "failed to wrap physical plan with batching", "err", err)
 		q.RecordError(ctx, err)
-		return nil, 0, ErrNotSupported
+		return nil, ErrNotSupported
 	}
 
 	duration := timer.ObserveDuration()
-	level.Info(q.Logger()).Log(
-		"msg", "finished physical planning",
-		"plan", physical.PrintAsTree(physicalPlan),
-		"duration", duration.String(),
+	span.Record(statPhysicalPlanDuration.Observe(int64(duration)))
+
+	printPhysicalPlanSummary(q, physicalPlan, duration)
+	span.SetAttributes(
+		attribute.String("plan", physical.PrintAsTree(physicalPlan)),
 	)
 
-	span.AddEvent("finished physical planning", trace.WithAttributes(attribute.Stringer("duration", duration)))
-	return physicalPlan, duration, nil
+	span.SetStatus(codes.Ok, "")
+	return physicalPlan, nil
+}
+
+// printExecutionSummary prints a general summary of the execution, including
+// timing and cache information.
+//
+// Stats that are not reported in the capture are left empty.
+func printPhysicalPlanSummary(q *query, plan *physical.Plan, duration time.Duration) {
+	var (
+		indexQueryDuration, _ = q.capture.Value(statPhysicalIndexQueryDuration).Int64()
+		optimizeDuration, _   = q.capture.Value(statPhysicalOptimizeDuration).Int64()
+
+		otherDuration = calculateResidual(duration, indexQueryDuration, optimizeDuration)
+	)
+
+	level.Info(q.Logger()).Log(
+		"msg", "physical-plan-summary",
+
+		"plan", physical.PrintAsTree(plan),
+
+		// Plan stats.
+		"duration_ms", duration.Milliseconds(),
+		"plan_node_count", plan.Len(),
+
+		// Timing info
+		"duration_index_query_ms", time.Duration(indexQueryDuration).Milliseconds(),
+		"duration_optimize_ms", time.Duration(optimizeDuration).Milliseconds(),
+		"duration_other_ms", otherDuration.Milliseconds(),
+
+		"dominant_phase", calculateDominantPhase(map[string]time.Duration{
+			"index_query": time.Duration(indexQueryDuration),
+			"optimize":    time.Duration(optimizeDuration),
+			"other":       otherDuration,
+		}),
+
+		// TODO(rfratto): include stats on which optimization passes applied/didn't apply
+	)
 }
 
 func (e *Engine) metastoreSectionsResolver(ctx context.Context, parent *query, logger log.Logger, cacheEnabled bool) physical.MetastoreSectionsResolver {
@@ -472,54 +498,89 @@ func (e *Engine) metastoreSectionsResolver(ctx context.Context, parent *query, l
 		if err != nil {
 			return nil, fmt.Errorf("creating index query: %w", err)
 		}
-		defer q.Close()
+		defer func() {
+			q.Close()
 
-		plan, err := planner.Plan(ctx, selector, predicates, start, end)
-		if err != nil {
-			return nil, fmt.Errorf("index query: build plan: %w", err)
+			// Record how long this query took to execute on the parent query.
+			if parent != nil {
+				queryTime := q.Duration()
+				parent.rootRegion.Record(statPhysicalIndexQueryDuration.Observe(int64(queryTime)))
+			}
+		}()
+
+		var plan *physical.Plan
+		{
+			timer := prometheus.NewTimer(e.metrics.physicalPlanning)
+
+			plan, err = planner.Plan(ctx, selector, predicates, start, end)
+			if err != nil {
+				q.RecordError(ctx, err)
+				return nil, fmt.Errorf("index query: build plan: %w", err)
+			}
+
+			duration := timer.ObserveDuration()
+			q.rootRegion.Record(statPhysicalPlanDuration.Observe(int64(duration)))
+
+			printPhysicalPlanSummary(q, plan, duration)
 		}
 
 		// Disable admission lanes for metastore queries
 		useAdmissionLanes := false
 		wf, err := q.Prepare(ctx, plan, useAdmissionLanes)
 		if err != nil {
+			q.RecordError(ctx, err)
 			return nil, fmt.Errorf("index query: build workflow: %w", err)
 		}
 		defer wf.Close()
 
 		pipeline, err := wf.Run(ctx)
 		if err != nil {
+			q.RecordError(ctx, err)
 			return nil, fmt.Errorf("index query: run workflow: %w", err)
 		}
 		reader := executor.TranslateEOF(pipeline)
 		defer reader.Close()
 
 		if err := reader.Open(ctx); err != nil {
+			q.RecordError(ctx, err)
 			return nil, fmt.Errorf("index query: open pipeline: %w", err)
 		}
 
-		resp, err := e.metastore.CollectSections(ctx, metastore.CollectSectionsRequest{
-			// externalize EOFs returned by executor pipelines (executor.EOF -> io.EOF)
-			// because metastore is not aware about executor implementation details
-			Reader: reader,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("index query: collect sections: %w", err)
+		var resp metastore.CollectSectionsResponse
+		{
+			timer := prometheus.NewTimer(e.metrics.execution)
+
+			resp, err = e.metastore.CollectSections(ctx, metastore.CollectSectionsRequest{
+				// externalize EOFs returned by executor pipelines (executor.EOF -> io.EOF)
+				// because metastore is not aware about executor implementation details
+				Reader: reader,
+			})
+			if err != nil {
+				q.RecordError(ctx, err)
+				return nil, fmt.Errorf("index query: collect sections: %w", err)
+			}
+
+			executionDuration := timer.ObserveDuration()
+			q.rootRegion.Record(statExecutionDuration.Observe(int64(executionDuration)))
+
+			printExecutionSummary(q, executionDuration)
 		}
 
 		return resp.SectionsResponse.Sections, nil
 	}
 }
 
-// collectResult processes the results of the execution plan.
-func (e *Engine) collectResult(ctx context.Context, logger log.Logger, params logql.Params, pipeline executor.Pipeline) (ResultBuilder, time.Duration, error) {
-	span := trace.SpanFromContext(ctx)
+// execute reads from the pipeline and produces a result.
+func (e *Engine) execute(ctx context.Context, q *query, params logql.Params, pipeline executor.Pipeline) (ResultBuilder, error) {
+	ctx, span := xcap.StartSpan(ctx, tracer, "Engine.execute")
+	defer span.End()
+
 	timer := prometheus.NewTimer(e.metrics.execution)
-	encodingFlags := httpreq.ExtractEncodingFlagsFromCtx(ctx)
 
 	var builder ResultBuilder
 	switch params.GetExpression().(type) {
 	case syntax.LogSelectorExpr:
+		encodingFlags := httpreq.ExtractEncodingFlagsFromCtx(ctx)
 		builder = newStreamsResultBuilder(params.Direction(), encodingFlags.Has(httpreq.FlagCategorizeLabels))
 	case syntax.SampleExpr:
 		if params.Step() > 0 {
@@ -534,32 +595,73 @@ func (e *Engine) collectResult(ctx context.Context, logger log.Logger, params lo
 	}
 
 	if err := pipeline.Open(ctx); err != nil {
-		return nil, time.Duration(0), err
+		return nil, err
 	}
 
+	var (
+		totalReadBatchTime    time.Duration
+		totalProcessBatchTime time.Duration
+	)
+
 	for {
+		startTime := time.Now()
+
 		rec, err := pipeline.Read(ctx)
+		totalReadBatchTime += time.Since(startTime)
 		if err != nil {
 			if errors.Is(err, executor.EOF) {
 				break
 			}
 
-			level.Warn(logger).Log(
+			level.Warn(q.Logger()).Log(
 				"msg", "error during execution",
 				"err", err,
 			)
-			return builder, time.Duration(0), err
+			return builder, err
 		}
 
+		startTime = time.Now()
 		builder.CollectRecord(rec)
+		totalProcessBatchTime += time.Since(startTime)
 	}
 
 	duration := timer.ObserveDuration()
+	span.Record(statExecutionDuration.Observe(int64(duration)))
+	span.Record(statReadBatchDuration.Observe(int64(totalReadBatchTime)))
+	span.Record(statProcessBatchDuration.Observe(int64(totalProcessBatchTime)))
 
-	// We don't log an event here because a final event will be logged by the
-	// caller noting that execution completed.
-	span.AddEvent("finished execution",
-		trace.WithAttributes(attribute.Stringer("duration", duration)),
+	printExecutionSummary(q, duration)
+
+	span.SetStatus(codes.Ok, "")
+	return builder, nil
+}
+
+// printExecutionSummary prints a general summary of the execution, including
+// timing and cache information.
+//
+// Stats that are not reported in the capture are left empty.
+func printExecutionSummary(q *query, duration time.Duration) {
+	var (
+		readBatchDuration, _    = q.capture.Value(statReadBatchDuration).Int64()
+		processBatchDuration, _ = q.capture.Value(statProcessBatchDuration).Int64()
+		otherDuration           = calculateResidual(duration, readBatchDuration, processBatchDuration)
 	)
-	return builder, duration, nil
+
+	level.Info(q.Logger()).Log(
+		"msg", "execution-summary",
+
+		// Stats
+		"duration_ms", duration.Milliseconds(),
+
+		// Timing info
+		"duration_read_batch_ms", time.Duration(readBatchDuration).Milliseconds(),
+		"duration_process_batch_ms", time.Duration(processBatchDuration).Milliseconds(),
+		"duration_other_ms", otherDuration.Milliseconds(),
+
+		"dominant_phase", calculateDominantPhase(map[string]time.Duration{
+			"read_batch":    time.Duration(readBatchDuration),
+			"process_batch": time.Duration(processBatchDuration),
+			"other":         otherDuration,
+		}),
+	)
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -227,7 +227,18 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	engineLogger := logger
 	logger = q.Logger()
 
-	level.Info(logger).Log("msg", "starting query", "query", params.QueryString(), "shard", strings.Join(params.Shards(), ","))
+	level.Info(logger).Log(
+		"msg", "logql-query-start",
+
+		"type", string(logql.GetRangeType(params)),
+		"query", params.QueryString(),
+		"start", params.Start().Format(time.RFC3339Nano),
+		"end", params.End().Format(time.RFC3339Nano),
+		"step_ms", params.Step().Milliseconds(),
+		"length_ms", params.End().Sub(params.Start()).Milliseconds(),
+		"shards", strings.Join(params.Shards(), ","),
+		"cache_enabled", cacheEnabled,
+	)
 
 	ctx, task := gotrace.NewTask(ctx, "Engine.Execute")
 	defer task.End()
@@ -454,8 +465,6 @@ func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.P
 
 // printExecutionSummary prints a general summary of the execution, including
 // timing and cache information.
-//
-// Stats that are not reported in the capture are left empty.
 func printPhysicalPlanSummary(q *query, plan *physical.Plan, duration time.Duration) {
 	var (
 		indexQueryDuration, _ = q.capture.Value(statPhysicalIndexQueryDuration).Int64()

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -24,6 +24,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/logical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler"
+	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
@@ -645,6 +647,24 @@ func printExecutionSummary(q *query, duration time.Duration) {
 		readBatchDuration, _    = q.capture.Value(statReadBatchDuration).Int64()
 		processBatchDuration, _ = q.capture.Value(statProcessBatchDuration).Int64()
 		otherDuration           = calculateResidual(duration, readBatchDuration, processBatchDuration)
+
+		tasksPruned           = xcap.Value[int64](q.capture, workflow.StatPrunedTasks)
+		tasksPlanned          = xcap.Value[int64](q.capture, scheduler.StatPlannedTasks)
+		tasksQueued           = xcap.Value[int64](q.capture, scheduler.StatQueuedTasks)
+		tasksAssigned         = xcap.Value[int64](q.capture, scheduler.StatAssignedTasks)
+		tasksExecuted         = xcap.Value[int64](q.capture, scheduler.StatExecutedTasks)
+		tasksFailed           = xcap.Value[int64](q.capture, scheduler.StatFailedTasks)
+		tasksCanceledPending  = xcap.Value[int64](q.capture, scheduler.StatCanceledPendingTasks)
+		tasksCanceledQueued   = xcap.Value[int64](q.capture, scheduler.StatCanceledQueuedTasks)
+		tasksCanceledAssigned = xcap.Value[int64](q.capture, scheduler.StatCanceledAssignedTasks)
+		tasksTotal            = tasksPruned + tasksPlanned
+		totalTasksCanceled    = tasksCanceledPending + tasksCanceledQueued + tasksCanceledAssigned
+
+		// tasksExecuted, tasksFailed, and totalTasksCanceled tracks the number
+		// of tasks that reached a terminal state. The remainder from
+		// tasksPlanned determines the number of tasks where information got
+		// lost.
+		tasksUnkownStatus = (tasksPlanned - tasksExecuted - tasksFailed - totalTasksCanceled)
 	)
 
 	level.Info(q.Logger()).Log(
@@ -663,5 +683,22 @@ func printExecutionSummary(q *query, duration time.Duration) {
 			"process_batch": time.Duration(processBatchDuration),
 			"other":         otherDuration,
 		}),
+
+		// Cache information
+		"task_neg_result_cache_hits", xcap.Value[int64](q.capture, workflow.StatNegativeCacheHits),
+		"task_pos_result_cache_hits", xcap.Value[int64](q.capture, workflow.StatPositiveCacheHits),
+
+		// Task fan-out
+		"tasks_total", tasksTotal,
+		"tasks_pruned", tasksPruned,
+		"tasks_planned", tasksPlanned,
+		"tasks_queued", tasksQueued,
+		"tasks_assigned", tasksAssigned,
+		"tasks_executed", tasksExecuted,
+		"tasks_failed", tasksFailed,
+		"tasks_canceled_pending", tasksCanceledPending,
+		"tasks_canceled_queued", tasksCanceledQueued,
+		"tasks_canceled_assigned", tasksCanceledAssigned,
+		"tasks_unknown_status", tasksUnkownStatus,
 	)
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/logical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler"
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/schedulerstat"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
@@ -302,8 +303,8 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	span.End()
 	q.Close()
 
-	// TODO(rfratto): capture and report queue time
-	stats := q.capture.ToStatsSummary(q.Duration(), 0, builder.Len())
+	totalQueueTime := xcap.Value[int64](q.capture, schedulerstat.TaskQueueDuration)
+	stats := q.capture.ToStatsSummary(q.Duration(), time.Duration(totalQueueTime), builder.Len())
 	result := builder.Build(stats, metadata.FromContext(ctx))
 	return result, nil
 }

--- a/pkg/engine/engine_query.go
+++ b/pkg/engine/engine_query.go
@@ -133,7 +133,7 @@ func (q *query) Prepare(ctx context.Context, plan *physical.Plan, useAdmissionLa
 		DebugTasks:   q.engine.limits.DebugEngineTasks(q.tenantID),
 		DebugStreams: q.engine.limits.DebugEngineStreams(q.tenantID),
 	}
-	wf, err := workflow.New(opts, q.logger, q.engine.scheduler.inner, plan)
+	wf, err := workflow.New(ctx, opts, q.logger, q.engine.scheduler.inner, plan)
 	if err != nil {
 		level.Warn(q.logger).Log("msg", "failed to create workflow", "err", err)
 		q.RecordError(ctx, err)

--- a/pkg/engine/engine_query.go
+++ b/pkg/engine/engine_query.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/grafana/dskit/tenant"
 	"github.com/oklog/ulid/v2"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
@@ -28,12 +28,18 @@ type query struct {
 	queryType string
 	useCache  bool
 
-	tenantID string
+	tenantID  string
+	userAgent string
+	actorPath string
 
-	startTime time.Time
+	startTime  time.Time
+	finishTime time.Time
 
 	capture    *xcap.Capture
 	rootRegion *xcap.Region
+
+	failed      bool
+	failureType string
 }
 
 func (e *Engine) newQuery(ctx context.Context, logger log.Logger, queryType string, useCache bool) (*query, context.Context, error) {
@@ -49,6 +55,9 @@ func (e *Engine) newQuery(ctx context.Context, logger log.Logger, queryType stri
 		logger:    log.With(logger, "query_id", id),
 		queryType: queryType,
 		useCache:  useCache,
+
+		userAgent: httpreq.ExtractHeader(ctx, "User-Agent"),
+		actorPath: httpreq.ExtractHeader(ctx, httpreq.LokiActorPathHeader),
 
 		startTime: startTime,
 
@@ -83,10 +92,20 @@ func (q *query) TenantID() string { return q.tenantID }
 // ID returns the unique identifier of the query.
 func (q *query) ID() ulid.ULID { return q.id }
 
+// Duration returns the current duration of the query.
+func (q *query) Duration() time.Duration {
+	if q.finishTime.IsZero() {
+		return time.Since(q.startTime)
+	}
+	return q.finishTime.Sub(q.startTime)
+}
+
 // Prepare constucts a workflow from the given physical plan. The returned
 // workflow must be closed to release resources.
 func (q *query) Prepare(ctx context.Context, plan *physical.Plan, useAdmissionLanes bool) (*workflow.Workflow, error) {
-	span := trace.SpanFromContext(ctx)
+	ctx, span := xcap.StartSpan(ctx, tracer, "query.Prepare")
+	defer span.End()
+
 	timer := prometheus.NewTimer(q.engine.metrics.workflowPlanning)
 
 	var maxRunningScanTasks int
@@ -122,20 +141,21 @@ func (q *query) Prepare(ctx context.Context, plan *physical.Plan, useAdmissionLa
 	}
 
 	duration := timer.ObserveDuration()
+	span.Record(statPrepareDuration.Observe(int64(duration)))
 
 	// The execution plan can be way more verbose than the physical plan, so we
 	// only log it at debug level.
 	level.Debug(q.logger).Log(
-		"msg", "generated execution plan",
+		"msg", "execution-plan-detail",
 		"plan", workflow.Sprint(wf),
 	)
 	level.Info(q.logger).Log(
-		"msg", "finished execution planning",
-		"duration", duration.String(),
+		"msg", "execution-plan-summary",
+		"duration_ms", duration.Milliseconds(),
 		"tasks", wf.Len(),
 	)
 
-	span.AddEvent("finished execution planning", trace.WithAttributes(attribute.Stringer("duration", duration)))
+	span.SetStatus(codes.Ok, "")
 	return wf, nil
 }
 
@@ -145,14 +165,99 @@ func (q *query) RecordError(ctx context.Context, err error) {
 	span.RecordError(err)
 	span.SetStatus(codes.Error, err.Error())
 
-	// TODO(rfratto): save somewhere else?
+	switch {
+	case errors.Is(err, context.Canceled):
+		q.failureType = "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		q.failureType = "timeout"
+	default:
+		q.failureType = "fail"
+	}
+	q.failed = true
 }
 
 // Close finalizes the query and logs a summary line about the query's
 // execution.
 func (q *query) Close() {
-	// TODO(rfratto): emit summary. This depends on having stats for known major
-	// phases about queries that we reference here.
+	if !q.finishTime.IsZero() {
+		// Already closed.
+		return
+	}
+
+	q.finishTime = time.Now()
 	q.rootRegion.End()
 	q.capture.End()
+
+	status := "success"
+	if q.failed {
+		status = q.failureType
+	}
+
+	var (
+		logicalPlanDuration, _  = q.capture.Value(statLogicalPlanDuration).Int64()
+		physicalPlanDuration, _ = q.capture.Value(statPhysicalPlanDuration).Int64()
+		prepareDuration, _      = q.capture.Value(statPrepareDuration).Int64()
+		executeDuration, _      = q.capture.Value(statExecutionDuration).Int64()
+
+		otherDuration = calculateResidual(q.finishTime.Sub(q.startTime), logicalPlanDuration, physicalPlanDuration, prepareDuration, executeDuration)
+	)
+
+	q.logger.Log(
+		"msg", "query-summary",
+
+		"user_agent", q.userAgent,
+		"actor_path", q.actorPath,
+		"query_type", q.queryType,
+
+		"submitted_at", q.startTime.Format(time.RFC3339Nano),
+		"completed_at", q.finishTime.Format(time.RFC3339Nano),
+		"duration_ms", q.finishTime.Sub(q.startTime).Milliseconds(),
+
+		"status", status,
+
+		// "duration_cache_check_ms", "", // See comment on query_result_cache_hit for why this is disabled.
+		"duration_logical_plan_ms", time.Duration(logicalPlanDuration).Milliseconds(),
+		"duration_physical_plan_ms", time.Duration(physicalPlanDuration).Milliseconds(),
+		"duration_prepare_ms", time.Duration(prepareDuration).Milliseconds(),
+		"duration_execute_ms", time.Duration(executeDuration).Milliseconds(),
+		"duration_other_ms", otherDuration.Milliseconds(),
+
+		"dominant_phase", calculateDominantPhase(map[string]time.Duration{
+			"logical":  time.Duration(logicalPlanDuration),
+			"physical": time.Duration(physicalPlanDuration),
+			"prepare":  time.Duration(prepareDuration),
+			"execute":  time.Duration(executeDuration),
+			"other":    otherDuration,
+		}),
+
+		// TODO(rfratto): Move caching logic into the engine so we can track
+		// cache hits/misses/latency.
+		"query_result_cache_hit", "false",
+	)
+}
+
+// calculateResidual finds the amount of time in dur that is not accounted for
+// in the given stats.
+//
+// Each stat must be an int64 value.
+func calculateResidual(dur time.Duration, stats ...int64) time.Duration {
+	var total time.Duration
+	for _, s := range stats {
+		total += time.Duration(s)
+	}
+	return dur - total
+}
+
+func calculateDominantPhase(phases map[string]time.Duration) string {
+	var (
+		maxPhase    string
+		maxDuration time.Duration
+	)
+	for phase, duration := range phases {
+		if duration > maxDuration {
+			maxPhase = phase
+			maxDuration = duration
+		}
+	}
+	return maxPhase
 }

--- a/pkg/engine/engine_query.go
+++ b/pkg/engine/engine_query.go
@@ -1,0 +1,158 @@
+package engine
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/httpgrpc"
+	"github.com/grafana/dskit/tenant"
+	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
+	"github.com/grafana/loki/v3/pkg/xcap"
+)
+
+type query struct {
+	id        ulid.ULID
+	engine    *Engine
+	logger    log.Logger
+	queryType string
+	useCache  bool
+
+	tenantID string
+
+	startTime time.Time
+
+	capture    *xcap.Capture
+	rootRegion *xcap.Region
+}
+
+func (e *Engine) newQuery(ctx context.Context, logger log.Logger, queryType string, useCache bool) (*query, context.Context, error) {
+	startTime := time.Now()
+
+	ctx, capture := xcap.NewCapture(ctx, nil)
+	ctx, region := xcap.StartRegion(ctx, "Query")
+
+	id := ulid.Make()
+	q := &query{
+		id:        id,
+		engine:    e,
+		logger:    log.With(logger, "query_id", id),
+		queryType: queryType,
+		useCache:  useCache,
+
+		startTime: startTime,
+
+		capture:    capture,
+		rootRegion: region,
+	}
+	if err := q.init(ctx); err != nil {
+		// The query failed to initialize, close it and return the error.
+		q.Close()
+		return nil, ctx, err
+	}
+	return q, ctx, nil
+}
+
+func (q *query) init(ctx context.Context) error {
+	tenantID, err := tenant.TenantID(ctx)
+	if err != nil {
+		q.RecordError(ctx, err)
+		return httpgrpc.Error(http.StatusBadRequest, err.Error())
+	}
+	q.tenantID = tenantID
+	return nil
+}
+
+// Logger returns the logger associated with the query. It has fields attached
+// for query identification.
+func (q *query) Logger() log.Logger { return q.logger }
+
+// TenantID returns the tenant ID associated with the query.
+func (q *query) TenantID() string { return q.tenantID }
+
+// ID returns the unique identifier of the query.
+func (q *query) ID() ulid.ULID { return q.id }
+
+// Prepare constucts a workflow from the given physical plan. The returned
+// workflow must be closed to release resources.
+func (q *query) Prepare(ctx context.Context, plan *physical.Plan, useAdmissionLanes bool) (*workflow.Workflow, error) {
+	span := trace.SpanFromContext(ctx)
+	timer := prometheus.NewTimer(q.engine.metrics.workflowPlanning)
+
+	var maxRunningScanTasks int
+	if useAdmissionLanes {
+		maxRunningScanTasks = q.engine.limits.MaxScanTaskParallelism(q.tenantID)
+	}
+
+	opts := workflow.Options{
+		ID:     q.id,
+		Tenant: q.tenantID,
+		Actor:  httpreq.ExtractActorPath(ctx),
+
+		MaxRunningScanTasks:  maxRunningScanTasks,
+		MaxRunningOtherTasks: 0,
+
+		CacheEnabled:                 q.useCache,
+		MaxTaskCacheSize:             uint64(q.engine.cfg.Executor.TaskResultsCache.TaskResultMaxCacheableSize),
+		MaxDataObjScanCacheSize:      uint64(q.engine.cfg.Executor.TaskResultsCache.DataObjScanResultMaxCacheableSize),
+		CacheCompression:             q.engine.cfg.Executor.TaskResultsCache.Compression,
+		PruneEmptyCachedTasks:        q.engine.cfg.Executor.TaskResultsCache.PruneEmptyCachedTasks,
+		NonEmptyCachedTasksMaxSize:   uint64(q.engine.cfg.Executor.TaskResultsCache.PruneCachedTasksMaxSize),
+		PruneCachedTasksFetchTimeout: q.engine.cfg.Executor.TaskResultsCache.PruneCachedTasksFetchTimeout,
+		TaskCacheRegistry:            q.engine.taskCaches,
+
+		DebugTasks:   q.engine.limits.DebugEngineTasks(q.tenantID),
+		DebugStreams: q.engine.limits.DebugEngineStreams(q.tenantID),
+	}
+	wf, err := workflow.New(opts, q.logger, q.engine.scheduler.inner, plan)
+	if err != nil {
+		level.Warn(q.logger).Log("msg", "failed to create workflow", "err", err)
+		q.RecordError(ctx, err)
+		return nil, ErrNotSupported
+	}
+
+	duration := timer.ObserveDuration()
+
+	// The execution plan can be way more verbose than the physical plan, so we
+	// only log it at debug level.
+	level.Debug(q.logger).Log(
+		"msg", "generated execution plan",
+		"plan", workflow.Sprint(wf),
+	)
+	level.Info(q.logger).Log(
+		"msg", "finished execution planning",
+		"duration", duration.String(),
+		"tasks", wf.Len(),
+	)
+
+	span.AddEvent("finished execution planning", trace.WithAttributes(attribute.Stringer("duration", duration)))
+	return wf, nil
+}
+
+// RecordError records the query as having failed with the given error.
+func (q *query) RecordError(ctx context.Context, err error) {
+	span := trace.SpanFromContext(ctx)
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+
+	// TODO(rfratto): save somewhere else?
+}
+
+// Close finalizes the query and logs a summary line about the query's
+// execution.
+func (q *query) Close() {
+	// TODO(rfratto): emit summary. This depends on having stats for known major
+	// phases about queries that we reference here.
+	q.rootRegion.End()
+	q.capture.End()
+}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1,20 +1,19 @@
 package engine
 
 import (
-	"context"
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/loki/v3/pkg/logql/syntax"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
 	"github.com/grafana/loki/v3/pkg/logql"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
 )
 
 type fakeLimits struct {
@@ -50,7 +49,7 @@ func minimalPlan() *physical.Plan {
 }
 
 func TestEngine_AdmissionLanes(t *testing.T) {
-	const tenant = "test-tenant"
+	const tenantID = "test-tenant"
 	const parallelism = 42
 
 	limits := &fakeLimits{
@@ -78,7 +77,13 @@ func TestEngine_AdmissionLanes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := newTestEngine(t, limits)
-			wf, _, err := e.buildWorkflow(context.Background(), tenant, log.NewNopLogger(), minimalPlan(), tt.useAdmissionLanes, false)
+
+			ctx := user.InjectOrgID(t.Context(), tenantID)
+			q, ctx, err := e.newQuery(ctx, log.NewNopLogger(), "test", false)
+			require.NoError(t, err)
+			defer q.Close()
+
+			wf, err := q.Prepare(ctx, minimalPlan(), tt.useAdmissionLanes)
 			require.NoError(t, err)
 			defer wf.Close()
 

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -309,11 +309,20 @@ func (s *Scheduler) handleTaskStatus(ctx context.Context, worker *workerConn, ms
 			task.wfRegion.Record(StatFailedTasks.Observe(1))
 		}
 
+		// Terminal states may include a capture from the worker; if so, we want
+		// to roll these up into our own per-task capture to give the event
+		// handler full visibility into the task's execution.
+		notifyStatus := msg.Status
+		if notifyStatus.State.Terminal() {
+			task.capture.Merge(nil, notifyStatus.Capture)
+			notifyStatus.Capture = task.capture
+		}
+
 		// Notify the handler about the change.
 		n.AddTaskEvent(taskNotification{
 			Handler:   task.handler,
 			Task:      task.inner,
-			NewStatus: msg.Status,
+			NewStatus: notifyStatus,
 		})
 	}
 	return nil
@@ -390,20 +399,20 @@ func (s *Scheduler) removeWorker(ctx context.Context, worker *workerConn, reason
 		wasInterrupted := task.interrupted
 		worker.Unassign(task)
 
-		var newStatus workflow.TaskStatus
+		// Even though the worker disconnected we still have some stats about
+		// the task that the handler may be interested in.
+		newStatus := workflow.TaskStatus{Capture: task.capture}
 		switch {
 		case wasInterrupted:
-			// Cancellation had already been requested for this task. Honor
-			// that intent regardless of whether the worker disconnected
-			// cleanly or with an error.
-			newStatus = workflow.TaskStatus{State: workflow.TaskStateCancelled}
+			// Cancellation had already been requested for this task. Honor that
+			// intent regardless of whether the worker disconnected cleanly or
+			// with an error.
+			newStatus.State = workflow.TaskStateCancelled
 		case reason != nil:
-			newStatus = workflow.TaskStatus{
-				State: workflow.TaskStateFailed,
-				Error: reason,
-			}
+			newStatus.State = workflow.TaskStateFailed
+			newStatus.Error = reason
 		default:
-			newStatus = workflow.TaskStatus{State: workflow.TaskStateCancelled}
+			newStatus.State = workflow.TaskStateCancelled
 		}
 
 		if changed, _ := task.setState(s.metrics, newStatus); !changed {
@@ -834,11 +843,17 @@ NextTask:
 			}
 		}
 
+		// We create a fresh [xcap.Capture] for each task to generate per-task
+		// observations. This will be merged with a capture received by the
+		// worker upon receiving a terminal state.
+		_, taskCapture := xcap.NewCapture(ctx, nil)
+
 		manifestTasks[taskToAdd.ULID] = &task{
 			createTime: time.Now(),
 			scope:      scope,
 			inner:      taskToAdd,
 			handler:    manifest.TaskEventHandler,
+			capture:    taskCapture,
 		}
 	}
 
@@ -1222,11 +1237,15 @@ func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 				region.Record(obsCanceledQueued)
 			}
 
-			// Inform the owner about the change.
+			// Inform the owner about the change. Attach the per-task capture so
+			// the workflow consumer can read scheduler-side observations even for
+			// tasks that never reached a worker.
+			notifyStatus := registered.status
+			notifyStatus.Capture = registered.capture
 			n.AddTaskEvent(taskNotification{
 				Handler:   registered.handler,
 				Task:      taskToCancel,
-				NewStatus: registered.status,
+				NewStatus: notifyStatus,
 			})
 		}
 

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -287,15 +287,22 @@ func (s *Scheduler) handleTaskStatus(ctx context.Context, worker *workerConn, ms
 			owner.Unassign(task)
 		}
 
-		if task.status.State == workflow.TaskStateCompleted && !task.assignTime.IsZero() {
-			// The execution time of the task is the duration from when it was
-			// first assigned to when we received the completion status.
-			//
-			// We skip the observation when assignTime is zero, which can happen
-			// when a task completes before we can process the assignment. If we
-			// didn't skip these, we'd record an observation of the maximum
-			// time.Duration value (290 years).
-			s.metrics.taskExecSeconds.Observe(time.Since(task.assignTime).Seconds())
+		switch task.status.State {
+		case workflow.TaskStateCompleted:
+			task.wfRegion.Record(StatExecutedTasks.Observe(1))
+
+			if !task.assignTime.IsZero() {
+				// The execution time of the task is the duration from when it
+				// was first assigned to when we received the completion status.
+				//
+				// We skip the observation when assignTime is zero, which can
+				// happen when a task completes before we can process the
+				// assignment. If we didn't skip these, we'd record an
+				// observation of the maximum time.Duration value (290 years).
+				s.metrics.taskExecSeconds.Observe(time.Since(task.assignTime).Seconds())
+			}
+		case workflow.TaskStateFailed:
+			task.wfRegion.Record(StatFailedTasks.Observe(1))
 		}
 
 		// Notify the handler about the change.
@@ -385,6 +392,10 @@ func (s *Scheduler) removeWorker(ctx context.Context, worker *workerConn, reason
 
 		if changed, _ := task.setState(s.metrics, newStatus); !changed {
 			continue
+		}
+
+		if newStatus.State == workflow.TaskStateFailed {
+			task.wfRegion.Record(StatFailedTasks.Observe(1))
 		}
 
 		// We only need to inform the handler about the change. There's nothing
@@ -605,6 +616,7 @@ func (s *Scheduler) finalizeAssignment(ctx context.Context, t *task, worker *wor
 		s.metrics.taskQueueSeconds.Observe(queueDuration)
 
 		if t.wfRegion != nil {
+			t.wfRegion.Record(StatAssignedTasks.Observe(1))
 			t.wfRegion.Record(xcap.StatTaskMaxQueueDuration.Observe(queueDuration))
 
 			// Record time from task creation until this task assignment.
@@ -722,7 +734,7 @@ func (s *Scheduler) DialFrom(ctx context.Context, from net.Addr) (wire.Conn, err
 
 // RegisterManifest registers a manifest to use with the scheduler, recording
 // all streams and task inside of it for use.
-func (s *Scheduler) RegisterManifest(_ context.Context, manifest *workflow.Manifest) error {
+func (s *Scheduler) RegisterManifest(ctx context.Context, manifest *workflow.Manifest) error {
 	scope, err := s.registerManifestScope(manifest)
 	if err != nil {
 		return err
@@ -824,6 +836,8 @@ NextTask:
 	// atomically update our internal state.
 	maps.Copy(s.streams, manifestStreams)
 	maps.Copy(s.tasks, manifestTasks)
+
+	xcap.RegionFromContext(ctx).Record(StatPlannedTasks.Observe(int64(len(manifestTasks))))
 	return nil
 }
 
@@ -1023,6 +1037,7 @@ func (s *Scheduler) Start(ctx context.Context, tasks ...*workflow.Task) error {
 	tc.Inject(ctx, propagation.HeaderCarrier(metadata))
 
 	wfRegion := xcap.RegionFromContext(ctx)
+	wfRegion.Record(StatQueuedTasks.Observe(int64(len(tasks))))
 
 	for _, t := range trackedTasks {
 		if t.metadata == nil {
@@ -1125,12 +1140,20 @@ func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 
 	var errs []error
 
+	var (
+		obsCanceledPending  = StatCanceledPendingTasks.Observe(1)
+		obsCanceledQueued   = StatCanceledQueuedTasks.Observe(1)
+		obsCanceledAssigned = StatCanceledAssignedTasks.Observe(1)
+	)
+
 	for _, taskToCancel := range tasks {
 		registered, exist := s.tasks[taskToCancel.ULID]
 		if !exist {
 			errs = append(errs, fmt.Errorf("task %s not found", taskToCancel.ULID))
 			continue
 		}
+		region := registered.wfRegion
+		prevState := registered.status.State
 
 		if changed, _ := registered.setState(s.metrics, workflow.TaskStatus{State: workflow.TaskStateCancelled}); changed {
 			// If the task has an owner, we'll inform it that the task has been
@@ -1140,6 +1163,24 @@ func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 			if owner := registered.owner; owner != nil {
 				owner.Unassign(registered)
 				_ = owner.SendMessageAsync(ctx, wire.TaskCancelMessage{ID: registered.inner.ULID})
+			}
+
+			// Record the cancellation against the state the task was in at the
+			// time it was canceled.
+			//
+			// TaskStateCreated maps to the "pending" stat: from the scheduler's
+			// perspective, a task that has been registered via RegisterManifest
+			// but not yet handed off to the queue via Start is pending
+			// execution. The workflow.TaskStatePending value is a stronger
+			// condition (the task is enqueued and waiting for a worker), which
+			// is what we report as "queued".
+			switch prevState {
+			case workflow.TaskStateCreated:
+				region.Record(obsCanceledPending)
+			case workflow.TaskStatePending:
+				region.Record(obsCanceledQueued)
+			case workflow.TaskStateRunning:
+				region.Record(obsCanceledAssigned)
 			}
 
 			// Inform the owner about the change.

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/schedulerstat"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/queue/fair"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
@@ -315,6 +316,7 @@ func (s *Scheduler) handleTaskStatus(ctx context.Context, worker *workerConn, ms
 		// handler full visibility into the task's execution.
 		notifyStatus := msg.Status
 		if newState.Terminal() {
+			task.RecordTerminalObservations(time.Now())
 			task.capture.Merge(nil, notifyStatus.Capture)
 			notifyStatus.Capture = task.capture
 		}
@@ -435,6 +437,8 @@ func (s *Scheduler) removeWorker(ctx context.Context, worker *workerConn, reason
 		case workflow.TaskStateFailed:
 			task.wfRegion.Record(StatFailedTasks.Observe(1))
 		}
+
+		task.RecordTerminalObservations(time.Now())
 
 		// We only need to inform the handler about the change. There's nothing
 		// to send to the owner of the task since worker has disconnected.
@@ -662,12 +666,13 @@ func (s *Scheduler) finalizeAssignment(ctx context.Context, t *task, worker *wor
 
 		worker.Assign(t)
 		assignTime := t.AssignTime() // Set by [task.TryAssign] by the previous caller before this runs.
-		queueDuration := assignTime.Sub(t.QueueTime()).Seconds()
-		s.metrics.taskQueueSeconds.Observe(queueDuration)
+		queueDuration := assignTime.Sub(t.QueueTime())
+		s.metrics.taskQueueSeconds.Observe(queueDuration.Seconds())
+		t.region.Record(schedulerstat.TaskQueueDuration.Observe(queueDuration.Nanoseconds()))
 
 		if t.wfRegion != nil {
 			t.wfRegion.Record(StatAssignedTasks.Observe(1))
-			t.wfRegion.Record(xcap.StatTaskMaxQueueDuration.Observe(queueDuration))
+			t.wfRegion.Record(xcap.StatTaskMaxQueueDuration.Observe(queueDuration.Seconds()))
 
 			// Record time from task creation until this task assignment.
 			assignmentTailDuration := assignTime.Sub(t.createTime).Seconds()
@@ -858,7 +863,12 @@ NextTask:
 		// We create a fresh [xcap.Capture] for each task to generate per-task
 		// observations. This will be merged with a capture received by the
 		// worker upon receiving a terminal state.
-		_, taskCapture := xcap.NewCapture(ctx, nil)
+		//
+		// The scheduler region holds scheduler-side observations about this
+		// specific task; worker-supplied regions are merged into the capture
+		// alongside it.
+		captureCtx, taskCapture := xcap.NewCapture(ctx, nil)
+		_, taskRegion := xcap.StartRegion(captureCtx, "scheduler")
 
 		manifestTasks[taskToAdd.ULID] = &task{
 			createTime: time.Now(),
@@ -866,6 +876,7 @@ NextTask:
 			inner:      taskToAdd,
 			handler:    manifest.TaskEventHandler,
 			capture:    taskCapture,
+			region:     taskRegion,
 		}
 	}
 
@@ -979,11 +990,18 @@ func (s *Scheduler) UnregisterManifest(ctx context.Context, manifest *workflow.M
 			_ = owner.SendMessageAsync(ctx, wire.TaskCancelMessage{ID: registered.inner.ULID})
 		}
 
-		// Inform the owner about the change.
+		registered.RecordTerminalObservations(time.Now())
+
+		// Inform the owner about the change. Attach the per-task capture so
+		// the workflow consumer can read scheduler-side observations; once we
+		// flip the state here, any later status message from a still-running
+		// worker would be ignored as a no-op transition.
+		notifyStatus := registered.Status()
+		notifyStatus.Capture = registered.capture
 		n.AddTaskEvent(taskNotification{
 			Handler:   registered.handler,
 			Task:      taskToRemove,
-			NewStatus: registered.Status(),
+			NewStatus: notifyStatus,
 		})
 	}
 
@@ -1151,6 +1169,7 @@ func (s *Scheduler) enqueueTasks(tasks []*task) {
 		}
 
 		task.MarkQueued()
+		task.region.Record(schedulerstat.TaskStagingDuration.Observe(task.QueueTime().Sub(task.createTime).Nanoseconds()))
 		if err := s.taskQueue.Push(task.scope, task); err != nil {
 			level.Error(s.logger).Log("msg", "failed to enqueue task; task will not be executed", "id", task.inner.ULID, "err", err)
 		}
@@ -1249,6 +1268,8 @@ func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 			case workflow.TaskStatePending:
 				region.Record(obsCanceledQueued)
 			}
+
+			registered.RecordTerminalObservations(time.Now())
 
 			// Inform the owner about the change. Attach the per-task capture so
 			// the workflow consumer can read scheduler-side observations even for

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -301,6 +301,10 @@ func (s *Scheduler) handleTaskStatus(ctx context.Context, worker *workerConn, ms
 				// observation of the maximum time.Duration value (290 years).
 				s.metrics.taskExecSeconds.Observe(time.Since(task.assignTime).Seconds())
 			}
+		case workflow.TaskStateCancelled:
+			// The worker has confirmed cancellation of a previously assigned
+			// task from [Scheduler.Cancel].
+			task.wfRegion.Record(StatCanceledAssignedTasks.Observe(1))
 		case workflow.TaskStateFailed:
 			task.wfRegion.Record(StatFailedTasks.Observe(1))
 		}
@@ -367,8 +371,11 @@ func (s *Scheduler) changeStreamState(ctx context.Context, n *notifier, target *
 // - Aborts all tasks assigned to the given worker.
 // - Removes the worker from the ready list.
 //
-// If the reason argument is nil, the tasks are cancelled. Otherwise, they are
+// If reason is non-nil, tasks that were running normally on the worker are
 // marked as failed with the provided reason.
+//
+// If reason is nil, all tasks are marked as cancelled. Tasks which were pending
+// cancellation will be marked as Canceled regardless of reason.
 func (s *Scheduler) removeWorker(ctx context.Context, worker *workerConn, reason error) {
 	var n notifier
 	defer n.Notify(ctx)
@@ -379,22 +386,43 @@ func (s *Scheduler) removeWorker(ctx context.Context, worker *workerConn, reason
 	s.assignMut.Lock()
 	defer s.assignMut.Unlock()
 
-	newStatus := workflow.TaskStatus{State: workflow.TaskStateCancelled}
-	if reason != nil {
-		newStatus = workflow.TaskStatus{
-			State: workflow.TaskStateFailed,
-			Error: reason,
-		}
-	}
-
 	for _, task := range worker.Assigned() {
+		wasInterrupted := task.interrupted
 		worker.Unassign(task)
+
+		var newStatus workflow.TaskStatus
+		switch {
+		case wasInterrupted:
+			// Cancellation had already been requested for this task. Honor
+			// that intent regardless of whether the worker disconnected
+			// cleanly or with an error.
+			newStatus = workflow.TaskStatus{State: workflow.TaskStateCancelled}
+		case reason != nil:
+			newStatus = workflow.TaskStatus{
+				State: workflow.TaskStateFailed,
+				Error: reason,
+			}
+		default:
+			newStatus = workflow.TaskStatus{State: workflow.TaskStateCancelled}
+		}
 
 		if changed, _ := task.setState(s.metrics, newStatus); !changed {
 			continue
 		}
 
-		if newStatus.State == workflow.TaskStateFailed {
+		switch newStatus.State {
+		case workflow.TaskStateCancelled:
+			if wasInterrupted {
+				// The worker disconnected before confirming a cancellation we
+				// had requested. Record it against the assigned-cancellation
+				// stat to match the disposition that [Scheduler.Cancel] would
+				// have produced had the worker survived long enough to confirm.
+				task.wfRegion.Record(StatCanceledAssignedTasks.Observe(1))
+			}
+			// Otherwise the worker disconnected cleanly with no pending
+			// cancellation request; we have no specific stat for that category
+			// today.
+		case workflow.TaskStateFailed:
 			task.wfRegion.Record(StatFailedTasks.Observe(1))
 		}
 
@@ -603,9 +631,10 @@ func (s *Scheduler) finalizeAssignment(ctx context.Context, t *task, worker *wor
 		s.resourcesMut.Lock()
 		defer s.resourcesMut.Unlock()
 
-		if t.status.State.Terminal() {
-			// Worker received the assignment but task was cancelled in the meantime.
-			// Notify the worker about the cancellation.
+		if t.status.State.Terminal() || t.interrupted {
+			// Either the task already reached a terminal state or a
+			// cancellation is pending via [Scheduler.Cancel]. In both cases,
+			// the worker should be told not to bother starting it.
 			pendingMsgs = append(pendingMsgs, pendingMessage{peer: worker, msg: wire.TaskCancelMessage{ID: t.inner.ULID}})
 			return
 		}
@@ -1131,6 +1160,10 @@ func (s *Scheduler) markPending(ctx context.Context, tasks []*task) {
 
 // Cancel requests cancellation of the specified tasks. Cancel returns an error
 // if any of the tasks were not found.
+//
+// For tasks which are currently running on a worker, Cancel send a best-effort
+// cancellation message to the worker. Cancel does not wait for these tasks to
+// transition to a terminal state.
 func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 	var n notifier
 	defer n.Notify(ctx)
@@ -1141,9 +1174,8 @@ func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 	var errs []error
 
 	var (
-		obsCanceledPending  = StatCanceledPendingTasks.Observe(1)
-		obsCanceledQueued   = StatCanceledQueuedTasks.Observe(1)
-		obsCanceledAssigned = StatCanceledAssignedTasks.Observe(1)
+		obsCanceledPending = StatCanceledPendingTasks.Observe(1)
+		obsCanceledQueued  = StatCanceledQueuedTasks.Observe(1)
 	)
 
 	for _, taskToCancel := range tasks {
@@ -1152,21 +1184,30 @@ func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 			errs = append(errs, fmt.Errorf("task %s not found", taskToCancel.ULID))
 			continue
 		}
+
+		// Already in a terminal state — nothing to do for the task itself, but
+		// fall through to the sink-stream cleanup below so a redundant Cancel
+		// still closes any associated streams.
+		if registered.status.State.Terminal() {
+			s.closeTaskSinks(ctx, &n, registered)
+			continue
+		}
+
 		region := registered.wfRegion
 		prevState := registered.status.State
 
-		if changed, _ := registered.setState(s.metrics, workflow.TaskStatus{State: workflow.TaskStateCancelled}); changed {
-			// If the task has an owner, we'll inform it that the task has been
-			// canceled and it can stop processing it.
+		if owner := registered.owner; owner != nil && !registered.interrupted {
+			// The task is currently running on a worker. We don't want to
+			// transition the task's state here so we can let the worker send
+			// final stats before acknowledging cancellation.
 			//
-			// This is a best-effort message, so we don't wait for acknowledgement.
-			if owner := registered.owner; owner != nil {
-				owner.Unassign(registered)
-				_ = owner.SendMessageAsync(ctx, wire.TaskCancelMessage{ID: registered.inner.ULID})
-			}
-
-			// Record the cancellation against the state the task was in at the
-			// time it was canceled.
+			// The confirmation of cancellation will come in via
+			// handleTaskStatus.
+			registered.interrupted = true
+			_ = owner.SendMessageAsync(ctx, wire.TaskCancelMessage{ID: registered.inner.ULID})
+		} else if changed, _ := registered.setState(s.metrics, workflow.TaskStatus{State: workflow.TaskStateCancelled}); changed {
+			// No worker is executing this task, so we transition the state
+			// directly as the scheduler is the source of truth.
 			//
 			// TaskStateCreated maps to the "pending" stat: from the scheduler's
 			// perspective, a task that has been registered via RegisterManifest
@@ -1179,8 +1220,6 @@ func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 				region.Record(obsCanceledPending)
 			case workflow.TaskStatePending:
 				region.Record(obsCanceledQueued)
-			case workflow.TaskStateRunning:
-				region.Record(obsCanceledAssigned)
 			}
 
 			// Inform the owner about the change.
@@ -1191,23 +1230,30 @@ func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 			})
 		}
 
-		// Close all associated sink streams (if they are not already closed).
-		for _, sinks := range registered.inner.Sinks {
-			for _, rawSink := range sinks {
-				sink, ok := s.streams[rawSink.ULID]
-				if !ok {
-					continue
-				}
-
-				_ = s.changeStreamState(ctx, &n, sink, workflow.StreamStateClosed)
-			}
-		}
+		s.closeTaskSinks(ctx, &n, registered)
 	}
 
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
 	return nil
+}
+
+// closeTaskSinks closes all sink streams associated with t (if not already
+// closed) and queues stream-state notifications onto n.
+//
+// closeTaskSinks must be called while resourcesMut is held.
+func (s *Scheduler) closeTaskSinks(ctx context.Context, n *notifier, t *task) {
+	for _, sinks := range t.inner.Sinks {
+		for _, rawSink := range sinks {
+			sink, ok := s.streams[rawSink.ULID]
+			if !ok {
+				continue
+			}
+
+			_ = s.changeStreamState(ctx, n, sink, workflow.StreamStateClosed)
+		}
+	}
 }
 
 // RegisterMetrics registers metrics about s to report to reg.

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -279,19 +279,20 @@ func (s *Scheduler) handleTaskStatus(ctx context.Context, worker *workerConn, ms
 		return fmt.Errorf("task %s not found", msg.ID)
 	}
 
-	changed, err := task.setState(s.metrics, msg.Status)
+	changed, err := task.SetState(s.metrics, msg.Status)
 	if err != nil {
 		return err
 	} else if changed {
-		if owner := task.owner; owner != nil && task.status.State.Terminal() {
+		newState := msg.Status.State
+		if owner := task.owner; owner != nil && newState.Terminal() {
 			owner.Unassign(task)
 		}
 
-		switch task.status.State {
+		switch newState {
 		case workflow.TaskStateCompleted:
 			task.wfRegion.Record(StatExecutedTasks.Observe(1))
 
-			if !task.assignTime.IsZero() {
+			if assignTime := task.AssignTime(); !assignTime.IsZero() {
 				// The execution time of the task is the duration from when it
 				// was first assigned to when we received the completion status.
 				//
@@ -299,7 +300,7 @@ func (s *Scheduler) handleTaskStatus(ctx context.Context, worker *workerConn, ms
 				// happen when a task completes before we can process the
 				// assignment. If we didn't skip these, we'd record an
 				// observation of the maximum time.Duration value (290 years).
-				s.metrics.taskExecSeconds.Observe(time.Since(task.assignTime).Seconds())
+				s.metrics.taskExecSeconds.Observe(time.Since(assignTime).Seconds())
 			}
 		case workflow.TaskStateCancelled:
 			// The worker has confirmed cancellation of a previously assigned
@@ -313,7 +314,7 @@ func (s *Scheduler) handleTaskStatus(ctx context.Context, worker *workerConn, ms
 		// to roll these up into our own per-task capture to give the event
 		// handler full visibility into the task's execution.
 		notifyStatus := msg.Status
-		if notifyStatus.State.Terminal() {
+		if newState.Terminal() {
 			task.capture.Merge(nil, notifyStatus.Capture)
 			notifyStatus.Capture = task.capture
 		}
@@ -396,7 +397,7 @@ func (s *Scheduler) removeWorker(ctx context.Context, worker *workerConn, reason
 	defer s.assignMut.Unlock()
 
 	for _, task := range worker.Assigned() {
-		wasInterrupted := task.interrupted
+		wasInterrupted := task.Interrupted()
 		worker.Unassign(task)
 
 		// Even though the worker disconnected we still have some stats about
@@ -415,7 +416,7 @@ func (s *Scheduler) removeWorker(ctx context.Context, worker *workerConn, reason
 			newStatus.State = workflow.TaskStateCancelled
 		}
 
-		if changed, _ := task.setState(s.metrics, newStatus); !changed {
+		if changed, _ := task.SetState(s.metrics, newStatus); !changed {
 			continue
 		}
 
@@ -500,12 +501,24 @@ func (s *Scheduler) workerLoop(ctx context.Context, worker *workerConn) {
 
 		level.Debug(s.logger).Log("msg", "assigning task", "id", assignment.msg.Task.ULID, "conn", worker.RemoteAddr())
 
-		// TODO(rfratto): allow assignment timeout to be configurable.
-		sendCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		err := worker.SendMessage(sendCtx, assignment.msg)
-		cancel()
+		// TryAssign holds the task's mut for the duration of the send so a
+		// fast-responding worker can't race with the post-assignment
+		// bookkeeping in finalizeAssignment. On success it also records the
+		// assignment timestamp on the task before releasing mut.
+		err := assignment.t.TryAssign(func() error {
+			// TODO(rfratto): allow assignment timeout to be configurable.
+			sendCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
 
-		if err != nil {
+			return worker.SendMessage(sendCtx, assignment.msg)
+		})
+
+		if err != nil && errors.Is(err, errUnassignable) {
+			// Task is already in a terminal state or has been interrupted,
+			// so we can skip the send and move on to the next task.
+			continue
+		} else if err != nil {
+			// Generic error.
 			s.requeueTask(assignment.t, assignment.pos)
 
 			// if its 429, remove from ready workers and fire subscribe request.
@@ -529,7 +542,6 @@ func (s *Scheduler) workerLoop(ctx context.Context, worker *workerConn) {
 		gotrace.Log(assignment.t.runtimeTraceCtx, "task_assigned", assignment.t.inner.ULID.String()+" -> "+worker.RemoteAddr().String())
 
 		s.finalizeAssignment(ctx, assignment.t, worker, assignment.msg.StreamStates)
-
 	}
 }
 
@@ -605,7 +617,7 @@ func (s *Scheduler) requeueTask(t *task, pos fair.Position) {
 	s.assignMut.Lock()
 	defer s.assignMut.Unlock()
 
-	if t.status.State.Terminal() {
+	if t.State().Terminal() {
 		return
 	}
 
@@ -640,17 +652,17 @@ func (s *Scheduler) finalizeAssignment(ctx context.Context, t *task, worker *wor
 		s.resourcesMut.Lock()
 		defer s.resourcesMut.Unlock()
 
-		if t.status.State.Terminal() || t.interrupted {
-			// Either the task already reached a terminal state or a
-			// cancellation is pending via [Scheduler.Cancel]. In both cases,
-			// the worker should be told not to bother starting it.
+		if t.State().Terminal() {
+			// The task reached a terminal state between TryAssign and now. The
+			// worker may still have the assignment, so we tell it to not
+			// bother.
 			pendingMsgs = append(pendingMsgs, pendingMessage{peer: worker, msg: wire.TaskCancelMessage{ID: t.inner.ULID}})
 			return
 		}
 
 		worker.Assign(t)
-		t.assignTime = time.Now()
-		queueDuration := t.assignTime.Sub(t.queueTime).Seconds()
+		assignTime := t.AssignTime() // Set by [task.TryAssign] by the previous caller before this runs.
+		queueDuration := assignTime.Sub(t.QueueTime()).Seconds()
 		s.metrics.taskQueueSeconds.Observe(queueDuration)
 
 		if t.wfRegion != nil {
@@ -658,7 +670,7 @@ func (s *Scheduler) finalizeAssignment(ctx context.Context, t *task, worker *wor
 			t.wfRegion.Record(xcap.StatTaskMaxQueueDuration.Observe(queueDuration))
 
 			// Record time from task creation until this task assignment.
-			assignmentTailDuration := t.assignTime.Sub(t.createTime).Seconds()
+			assignmentTailDuration := assignTime.Sub(t.createTime).Seconds()
 			t.wfRegion.Record(xcap.StatTaskAssignmentTailDuration.Observe(assignmentTailDuration))
 		}
 
@@ -953,7 +965,7 @@ func (s *Scheduler) UnregisterManifest(ctx context.Context, manifest *workflow.M
 		// Immediately clean up our own resources.
 		s.deleteTask(registered)
 
-		if changed, _ := registered.setState(s.metrics, workflow.TaskStatus{State: workflow.TaskStateCancelled}); !changed {
+		if changed, _ := registered.SetState(s.metrics, workflow.TaskStatus{State: workflow.TaskStateCancelled}); !changed {
 			// Ignore if the task couldn't move into the canceled state, which
 			// indicates it's already in a terminal state.
 			continue
@@ -971,7 +983,7 @@ func (s *Scheduler) UnregisterManifest(ctx context.Context, manifest *workflow.M
 		n.AddTaskEvent(taskNotification{
 			Handler:   registered.handler,
 			Task:      taskToRemove,
-			NewStatus: registered.status,
+			NewStatus: registered.Status(),
 		})
 	}
 
@@ -1134,11 +1146,11 @@ func (s *Scheduler) enqueueTasks(tasks []*task) {
 		// Ignore tasks that aren't in the initial state (created). This
 		// prevents us from rejecting tasks which were preemptively canceled by
 		// callers.
-		if got, want := task.status.State, workflow.TaskStateCreated; got != want {
+		if task.State() != workflow.TaskStateCreated {
 			continue
 		}
 
-		task.queueTime = time.Now()
+		task.MarkQueued()
 		if err := s.taskQueue.Push(task.scope, task); err != nil {
 			level.Error(s.logger).Log("msg", "failed to enqueue task; task will not be executed", "id", task.inner.ULID, "err", err)
 		}
@@ -1157,7 +1169,7 @@ func (s *Scheduler) markPending(ctx context.Context, tasks []*task) {
 	defer s.resourcesMut.Unlock()
 
 	for _, task := range tasks {
-		if changed, _ := task.setState(s.metrics, workflow.TaskStatus{State: workflow.TaskStatePending}); !changed {
+		if changed, _ := task.SetState(s.metrics, workflow.TaskStatus{State: workflow.TaskStatePending}); !changed {
 			// If the state change failed, the task either got canceled or
 			// picked up by a worker in between enqueueing it and calling this
 			// method.
@@ -1168,7 +1180,7 @@ func (s *Scheduler) markPending(ctx context.Context, tasks []*task) {
 		n.AddTaskEvent(taskNotification{
 			Handler:   task.handler,
 			Task:      task.inner,
-			NewStatus: task.status,
+			NewStatus: task.Status(),
 		})
 	}
 }
@@ -1203,24 +1215,25 @@ func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 		// Already in a terminal state — nothing to do for the task itself, but
 		// fall through to the sink-stream cleanup below so a redundant Cancel
 		// still closes any associated streams.
-		if registered.status.State.Terminal() {
+		prevState := registered.State()
+		if prevState.Terminal() {
 			s.closeTaskSinks(ctx, &n, registered)
 			continue
 		}
 
 		region := registered.wfRegion
-		prevState := registered.status.State
 
-		if owner := registered.owner; owner != nil && !registered.interrupted {
+		if owner := registered.owner; owner != nil && registered.MarkInterrupted() {
 			// The task is currently running on a worker. We don't want to
 			// transition the task's state here so we can let the worker send
 			// final stats before acknowledging cancellation.
 			//
 			// The confirmation of cancellation will come in via
-			// handleTaskStatus.
-			registered.interrupted = true
+			// handleTaskStatus. MarkInterrupted makes the cancel message
+			// at most once: a redundant Cancel for an already-interrupted task
+			// is a no-op.
 			_ = owner.SendMessageAsync(ctx, wire.TaskCancelMessage{ID: registered.inner.ULID})
-		} else if changed, _ := registered.setState(s.metrics, workflow.TaskStatus{State: workflow.TaskStateCancelled}); changed {
+		} else if changed, _ := registered.SetState(s.metrics, workflow.TaskStatus{State: workflow.TaskStateCancelled}); changed {
 			// No worker is executing this task, so we transition the state
 			// directly as the scheduler is the source of truth.
 			//
@@ -1240,7 +1253,7 @@ func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 			// Inform the owner about the change. Attach the per-task capture so
 			// the workflow consumer can read scheduler-side observations even for
 			// tasks that never reached a worker.
-			notifyStatus := registered.status
+			notifyStatus := registered.Status()
 			notifyStatus.Capture = registered.capture
 			n.AddTaskEvent(taskNotification{
 				Handler:   registered.handler,

--- a/pkg/engine/internal/scheduler/schedulerstat/schedulerstat.go
+++ b/pkg/engine/internal/scheduler/schedulerstat/schedulerstat.go
@@ -1,0 +1,36 @@
+// Package schedulerstat declares scheduler-recorded per-task observation
+// statistics.
+package schedulerstat
+
+import "github.com/grafana/loki/v3/pkg/xcap"
+
+// These stats live in their own package rather than in
+// [pkg/engine/internal/scheduler] to avoid a cyclic dependency between workflow
+// and the scheduler.
+
+var (
+	// TaskStagingDuration is the time (in nanoseconds) a task spent staged
+	// between scheduler registration and being enqueued for assignment. Not
+	// recorded for tasks that never reached the queue.
+	TaskStagingDuration = xcap.NewStatisticInt64("scheduler.task.staging.duration", xcap.AggregationTypeSum)
+
+	// TaskQueueDuration is the time (in nanoseconds) a task spent enqueued before
+	// either being assigned to a worker or reaching a terminal state without
+	// ever being assigned.
+	TaskQueueDuration = xcap.NewStatisticInt64("scheduler.task.queue.duration", xcap.AggregationTypeSum)
+
+	// TaskExecutionDuration is the time (in nanoseconds) a task spent assigned to
+	// a worker before reaching a terminal state. Not recorded for tasks that
+	// never reached a worker.
+	TaskExecutionDuration = xcap.NewStatisticInt64("scheduler.task.execution.duration", xcap.AggregationTypeSum)
+
+	// TaskTotalDuration is the total time (in nanoseconds) from scheduler
+	// registration to terminal state, regardless of which phases the task
+	// passed through.
+	//
+	// The other scheduler.task.*.duration stats partition this duration into
+	// individual phases; the difference between TaskTotalDuration and the
+	// sum of the partitions is a residual that indicates an unaccounted-for
+	// phase.
+	TaskTotalDuration = xcap.NewStatisticInt64("scheduler.task.duration", xcap.AggregationTypeSum)
+)

--- a/pkg/engine/internal/scheduler/stats.go
+++ b/pkg/engine/internal/scheduler/stats.go
@@ -1,0 +1,34 @@
+package scheduler
+
+import "github.com/grafana/loki/v3/pkg/xcap"
+
+var (
+	// StatPlannedTasks records the number of tasks that were planned for
+	// execution.
+	StatPlannedTasks = xcap.NewStatisticInt64("scheduler.tasks.planned", xcap.AggregationTypeSum)
+
+	// StatQueuedTasks records the number of tasks that were queued for
+	// execution.
+	StatQueuedTasks = xcap.NewStatisticInt64("scheduler.tasks.queued", xcap.AggregationTypeSum)
+
+	// StatAssignedTasks records the number of tasks that were assigned to lanes.
+	StatAssignedTasks = xcap.NewStatisticInt64("scheduler.tasks.assigned", xcap.AggregationTypeSum)
+
+	// StatExecutedTasks records the number of tasks that were executed.
+	StatExecutedTasks = xcap.NewStatisticInt64("scheduler.tasks.executed", xcap.AggregationTypeSum)
+
+	// StatCanceledTasks records the number of pending (not yet queued) tasks
+	// that were canceled.
+	StatCanceledPendingTasks = xcap.NewStatisticInt64("scheduler.tasks.canceled.pending", xcap.AggregationTypeSum)
+
+	// StatCanceledQueuedTasks records the number of queued tasks that were
+	// canceled.
+	StatCanceledQueuedTasks = xcap.NewStatisticInt64("scheduler.tasks.canceled.queued", xcap.AggregationTypeSum)
+
+	// StatCanceledAssignedTasks records the number of assigned (in-progress)
+	// tasks that were canceled.
+	StatCanceledAssignedTasks = xcap.NewStatisticInt64("scheduler.tasks.canceled.assigned", xcap.AggregationTypeSum)
+
+	// StatFailedTasks records the number of tasks that failed during execution.
+	StatFailedTasks = xcap.NewStatisticInt64("scheduler.tasks.failed", xcap.AggregationTypeSum)
+)

--- a/pkg/engine/internal/scheduler/task.go
+++ b/pkg/engine/internal/scheduler/task.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/queue/fair"
@@ -12,31 +13,20 @@ import (
 	"github.com/grafana/loki/v3/pkg/xcap"
 )
 
-// task wraps a [workflow.Task] with its handler.
+var errUnassignable = fmt.Errorf("task is in a terminal state or has been interrupted")
+
+// task wraps a [workflow.Task] with its handler and scheduler-side state.
 type task struct {
 	createTime time.Time // Time when task was created.
-	assignTime time.Time // Time when task was assigned to a worker.
-	queueTime  time.Time // Time when task was enqueued.
+	inner      *workflow.Task
+	handler    workflow.TaskEventHandler
+	scope      fair.Scope // Queue scope this task belongs to.
 
-	inner   *workflow.Task
-	handler workflow.TaskEventHandler
-	scope   fair.Scope // Queue scope this task belongs to.
-
-	// metadata holds additional metadata associated with the task.
-	// This can be used to stortracing and other information that
-	// should be propagated to workers.
-	metadata http.Header
-
-	owner  *workerConn
-	status workflow.TaskStatus
-
-	// interrupted reports whether cancellation has been requested for this
-	// task but the worker has not yet confirmed (i.e., the task has not yet
-	// reached a terminal state).
-	//
-	// Set by [Scheduler.Cancel] when requesting cancellation for an assigned
-	// non-terminal task.
-	interrupted bool
+	mut         sync.RWMutex
+	status      workflow.TaskStatus
+	queueTime   time.Time // Time when task was enqueued.
+	assignTime  time.Time // Time when task was assigned to a worker.
+	interrupted bool      // Cancellation requested but not yet confirmed.
 
 	// capture holds individual task information from any source:
 	//
@@ -51,9 +41,13 @@ type task struct {
 	// container for per-task data.
 	capture *xcap.Capture
 
-	// wfRegion is the region associated with the parent workflow of this task.
+	// Set once by [Scheduler.Start] and read thereafter.
+	metadata        http.Header
 	wfRegion        *xcap.Region
 	runtimeTraceCtx context.Context
+
+	// Protected by [Scheduler.resourcesMut].
+	owner *workerConn
 }
 
 var validTaskTransitions = map[workflow.TaskState][]workflow.TaskState{
@@ -66,12 +60,60 @@ var validTaskTransitions = map[workflow.TaskState][]workflow.TaskState{
 	workflow.TaskStateFailed:    {}, // Terminal state, can't transition
 }
 
-// setState updates the state of the task. setState returns an error if the
+// State returns the task's current [workflow.TaskState].
+func (t *task) State() workflow.TaskState {
+	t.mut.RLock()
+	defer t.mut.RUnlock()
+	return t.status.State
+}
+
+// Status returns a snapshot of the task's current [workflow.TaskStatus].
+// The returned status's Capture field is shared by reference; callers should
+// not mutate it.
+func (t *task) Status() workflow.TaskStatus {
+	t.mut.RLock()
+	defer t.mut.RUnlock()
+	return t.status
+}
+
+// Interrupted reports whether [Scheduler.Cancel] has requested cancellation
+// of this task while it was assigned to a worker. See [task.MarkInterrupted].
+func (t *task) Interrupted() bool {
+	t.mut.RLock()
+	defer t.mut.RUnlock()
+	return t.interrupted
+}
+
+// AssignTime returns the time at which [task.TryAssign] successfully sent
+// the task's assignment to a worker, or the zero time if no successful send
+// has occurred.
+func (t *task) AssignTime() time.Time {
+	t.mut.RLock()
+	defer t.mut.RUnlock()
+	return t.assignTime
+}
+
+// QueueTime returns the time at which [task.MarkQueued] was called, or the
+// zero time if the task was never queued.
+func (t *task) QueueTime() time.Time {
+	t.mut.RLock()
+	defer t.mut.RUnlock()
+	return t.queueTime
+}
+
+// SetState updates the state of the task. SetState returns an error if the
 // transition is invalid.
 //
 // Returns true if the state was updated, false otherwise (such as if the task
 // is already in the desired state).
-func (t *task) setState(m *metrics, newStatus workflow.TaskStatus) (bool, error) {
+func (t *task) SetState(m *metrics, newStatus workflow.TaskStatus) (bool, error) {
+	t.mut.Lock()
+	defer t.mut.Unlock()
+	return t.setStateLocked(m, newStatus)
+}
+
+// setStateLocked implements the logic of [SetState]. Callers must hold t.mut.
+func (t *task) setStateLocked(m *metrics, newStatus workflow.TaskStatus) (bool, error) {
 	oldState, newState := t.status.State, newStatus.State
 
 	switch {
@@ -95,5 +137,49 @@ func (t *task) setState(m *metrics, newStatus workflow.TaskStatus) (bool, error)
 		m.tasksTotal.WithLabelValues(newState.String()).Inc()
 		return true, nil
 	}
+}
 
+// MarkQueued records that the task has been enqueued for assignment by
+// setting queueTime to the current time.
+func (t *task) MarkQueued() {
+	t.mut.Lock()
+	defer t.mut.Unlock()
+	t.queueTime = time.Now()
+}
+
+// MarkInterrupted records that cancellation has been requested for this task.
+func (t *task) MarkInterrupted() bool {
+	t.mut.Lock()
+	defer t.mut.Unlock()
+
+	if t.interrupted {
+		return false
+	}
+	t.interrupted = true
+	return true
+}
+
+// TryAssign calls doAssign, holding a mutex on the task to prevent concurrent
+// modification to t's state.
+//
+// If doAssign returns nil, the assign time is recorded and TryAssign returns
+// nil. Otherwise, TryAssign returns the error from doAssign without making any
+// changes.
+//
+// If the task is in a terminal state or has been interrupted, TryAssign
+// returns [errUnassignable] without calling doAssign.
+func (t *task) TryAssign(doAssign func() error) error {
+	t.mut.Lock()
+	defer t.mut.Unlock()
+
+	if t.status.State.Terminal() || t.interrupted {
+		return errUnassignable
+	}
+
+	if err := doAssign(); err != nil {
+		return err
+	}
+
+	t.assignTime = time.Now()
+	return nil
 }

--- a/pkg/engine/internal/scheduler/task.go
+++ b/pkg/engine/internal/scheduler/task.go
@@ -38,6 +38,19 @@ type task struct {
 	// non-terminal task.
 	interrupted bool
 
+	// capture holds individual task information from any source:
+	//
+	//   - The scheduler records its own per-task observations (e.g., timing
+	//     between state transitions) into capture.
+	//   - Worker-supplied captures are merged into this capture when their
+	//     TaskStatusMessages arrive, so workflow consumers see a single
+	//     unified capture per task.
+	//
+	// capture is distinct from wfRegion: wfRegion is used for workflow-level
+	// aggregate counters (e.g., StatPlannedTasks), while capture is the
+	// container for per-task data.
+	capture *xcap.Capture
+
 	// wfRegion is the region associated with the parent workflow of this task.
 	wfRegion        *xcap.Region
 	runtimeTraceCtx context.Context

--- a/pkg/engine/internal/scheduler/task.go
+++ b/pkg/engine/internal/scheduler/task.go
@@ -30,6 +30,14 @@ type task struct {
 	owner  *workerConn
 	status workflow.TaskStatus
 
+	// interrupted reports whether cancellation has been requested for this
+	// task but the worker has not yet confirmed (i.e., the task has not yet
+	// reached a terminal state).
+	//
+	// Set by [Scheduler.Cancel] when requesting cancellation for an assigned
+	// non-terminal task.
+	interrupted bool
+
 	// wfRegion is the region associated with the parent workflow of this task.
 	wfRegion        *xcap.Region
 	runtimeTraceCtx context.Context

--- a/pkg/engine/internal/scheduler/task.go
+++ b/pkg/engine/internal/scheduler/task.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/schedulerstat"
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/queue/fair"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
 	"github.com/grafana/loki/v3/pkg/xcap"
@@ -31,7 +32,7 @@ type task struct {
 	// capture holds individual task information from any source:
 	//
 	//   - The scheduler records its own per-task observations (e.g., timing
-	//     between state transitions) into capture.
+	//     between state transitions) into capture via region.
 	//   - Worker-supplied captures are merged into this capture when their
 	//     TaskStatusMessages arrive, so workflow consumers see a single
 	//     unified capture per task.
@@ -40,6 +41,11 @@ type task struct {
 	// aggregate counters (e.g., StatPlannedTasks), while capture is the
 	// container for per-task data.
 	capture *xcap.Capture
+
+	// region is the scheduler-owned region within capture. All scheduler-side
+	// per-task observations are recorded against this region. Worker-supplied
+	// regions are merged into capture but kept distinct from this one.
+	region *xcap.Region
 
 	// Set once by [Scheduler.Start] and read thereafter.
 	metadata        http.Header
@@ -182,4 +188,35 @@ func (t *task) TryAssign(doAssign func() error) error {
 
 	t.assignTime = time.Now()
 	return nil
+}
+
+// RecordTerminalObservations records the scheduler-side per-task duration
+// observations for a task that has just reached a terminal state and ends
+// the scheduler region within the task's capture.
+//
+// The recorded durations partition the task's total lifetime:
+//
+//   - [schedulerstat.TaskQueueDuration] is recorded if the task was enqueued
+//     but never assigned to a worker (covering pre-assignment cancellations
+//     of queued tasks). Tasks that were assigned have their queue duration
+//     recorded earlier, at assignment time.
+//   - [schedulerstat.TaskExecutionDuration] is recorded for any task that
+//     was assigned to a worker.
+//   - [schedulerstat.TaskTotalDuration] is always recorded.
+//
+// RecordTerminalObservations must only be called once per task and only when
+// the task has reached a terminal state.
+func (t *task) RecordTerminalObservations(now time.Time) {
+	t.mut.RLock()
+	queueTime, assignTime := t.queueTime, t.assignTime
+	t.mut.RUnlock()
+
+	if !queueTime.IsZero() && assignTime.IsZero() {
+		t.region.Record(schedulerstat.TaskQueueDuration.Observe(now.Sub(queueTime).Nanoseconds()))
+	}
+	if !assignTime.IsZero() {
+		t.region.Record(schedulerstat.TaskExecutionDuration.Observe(now.Sub(assignTime).Nanoseconds()))
+	}
+	t.region.Record(schedulerstat.TaskTotalDuration.Observe(now.Sub(t.createTime).Nanoseconds()))
+	t.region.End()
 }

--- a/pkg/engine/internal/worker/job_manager.go
+++ b/pkg/engine/internal/worker/job_manager.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/oklog/ulid/v2"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
@@ -19,6 +20,15 @@ var errNoReadyThreads = errors.New("no ready threads")
 type threadJob struct {
 	Context context.Context
 	Cancel  context.CancelFunc
+
+	// interrupted reports whether the scheduler has explicitly requested
+	// cancellation of this job via a TaskCancelMessage. It is used by the
+	// running thread to distinguish a scheduler-requested cancellation from
+	// an ambient context cancellation (e.g., worker shutdown).
+	//
+	// Only interrupted jobs should be reported as canceled; any other context
+	// cancellation should be treated as a failure.
+	interrupted atomic.Bool
 
 	Scheduler *wire.Peer     // Scheduler which owns the task.
 	Task      *workflow.Task // Task to execute.

--- a/pkg/engine/internal/worker/node_source.go
+++ b/pkg/engine/internal/worker/node_source.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
+	"github.com/grafana/loki/v3/pkg/engine/internal/worker/workerstat"
 	"github.com/grafana/loki/v3/pkg/xcap"
 )
 
@@ -45,7 +46,9 @@ func (src *nodeSource) Read(ctx context.Context) (arrow.RecordBatch, error) {
 	region := xcap.RegionFromContext(ctx)
 	startRecv := time.Now()
 	defer func() {
-		region.Record(xcap.TaskRecvDuration.Observe(time.Since(startRecv).Seconds()))
+		recvDuration := time.Since(startRecv)
+		region.Record(xcap.TaskRecvDuration.Observe(recvDuration.Seconds()))
+		region.Record(workerstat.TaskExecutionReadRecvDuration.Observe(recvDuration.Nanoseconds()))
 	}()
 
 	src.lazyInit()

--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
+	"github.com/grafana/loki/v3/pkg/engine/internal/worker/workerstat"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
 	"github.com/grafana/loki/v3/pkg/storage/bucket"
 	utillog "github.com/grafana/loki/v3/pkg/util/log"
@@ -414,6 +415,12 @@ func (t *thread) drainPipeline(ctx context.Context, pipeline executor.Pipeline, 
 	t.Metrics.taskReadSeconds.Observe(readDuration.Seconds())
 	t.Metrics.taskComputeSeconds.Observe(totalComputeTime.Seconds())
 	t.Metrics.taskWriteSeconds.Observe(totalWriteTime.Seconds())
+
+	// Record execution sub-phase durations on the task region so the workflow
+	// can include them in the per-task summary log.
+	region.Record(workerstat.TaskExecutionOpenDuration.Observe(readDuration.Nanoseconds()))
+	region.Record(workerstat.TaskExecutionReadDuration.Observe(totalComputeTime.Nanoseconds()))
+	region.Record(workerstat.TaskExecutionSendDuration.Observe(totalWriteTime.Nanoseconds()))
 
 	return totalRows, nil
 }

--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -284,25 +284,26 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	}
 
 	gotrace.Log(ctx, "drain_pipeline", "start")
-	_, err = t.drainPipeline(ctx, pipeline, sinksForJob(job), logger)
-	if err != nil {
-		level.Warn(logger).Log("msg", "task failed", "err", err)
-		_ = job.Scheduler.SendMessageAsync(ctx, wire.TaskStatusMessage{
-			ID: job.Task.ULID,
-			Status: workflow.TaskStatus{
-				State: workflow.TaskStateFailed,
-				Error: err,
-			},
-		})
+	_, drainErr := t.drainPipeline(ctx, pipeline, sinksForJob(job), logger)
+	gotrace.Log(ctx, "drain_pipeline", "done")
 
-		pipeline.Close()
-		return
+	var terminalStatus workflow.TaskStatus
+	switch {
+	case drainErr == nil:
+		terminalStatus = workflow.TaskStatus{State: workflow.TaskStateCompleted}
+	case errors.Is(drainErr, context.Canceled) && job.interrupted.Load():
+		// Context cancellation only counts as a task cancellation if the scheduler
+		// specifically requested it. In all other cases we treat it as a failure.
+		terminalStatus = workflow.TaskStatus{State: workflow.TaskStateCancelled}
+		level.Info(logger).Log("msg", "task cancelled", "err", drainErr)
+	default:
+		terminalStatus = workflow.TaskStatus{State: workflow.TaskStateFailed, Error: drainErr}
+		level.Warn(logger).Log("msg", "task failed", "err", drainErr)
 	}
 
-	// Finally, close all sinks.
+	// Close all sinks regardless of outcome so downstream tasks unblock.
 	for _, sink := range job.Sinks {
-		err := sink.Close(ctx)
-		if err != nil {
+		if err := sink.Close(ctx); err != nil {
 			level.Warn(logger).Log("msg", "failed to close sink", "err", err)
 		}
 	}
@@ -313,27 +314,31 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	// to finalize the capture before it's included in the TaskStatusMessage.
 	span.End()
 	capture.End()
+	terminalStatus.Capture = capture
 
-	gotrace.Log(ctx, "drain_pipeline", "done")
 	duration := time.Since(startTime)
 
 	logValues := []any{
 		"msg", "task completed",
 		"duration", duration,
+		"status", terminalStatus.State,
 	}
 	logValues = append(logValues, xcap.SummaryLogValues(capture)...)
 
 	level.Info(logger).Log(logValues...)
 	t.Metrics.taskExecSeconds.Observe(duration.Seconds())
 
-	// Wait for the scheduler to confirm the task has completed before
-	// requesting a new one. This allows the scheduler to update its bookkeeping
-	// for how many threads have capacity for requesting tasks.
-	err = job.Scheduler.SendMessage(ctx, wire.TaskStatusMessage{
+	// Send the terminal status synchronously so the scheduler can update its
+	// thread-capacity bookkeeping and merge the Capture before the worker
+	// thread requests its next job.
+	//
+	// We use a detached context so a cancelled job context does not prevent us
+	// from delivering the final status (and in particular, the Capture).
+	sendCtx := context.WithoutCancel(ctx)
+	if err := job.Scheduler.SendMessage(sendCtx, wire.TaskStatusMessage{
 		ID:     job.Task.ULID,
-		Status: workflow.TaskStatus{State: workflow.TaskStateCompleted, Capture: capture},
-	})
-	if err != nil {
+		Status: terminalStatus,
+	}); err != nil {
 		level.Warn(logger).Log("msg", "failed to inform scheduler of task status", "err", err)
 	}
 }

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -577,6 +577,10 @@ func (w *Worker) handleCancelMessage(msg wire.TaskCancelMessage) error {
 		return fmt.Errorf("task %s not found", msg.ID)
 	}
 
+	// Mark the job as interrupted before cancelling the context so we can
+	// differentiate between an expected cancellation an unexpected context
+	// cancellation (which results in a task failure).
+	job.interrupted.Store(true)
 	job.Cancel()
 	return nil
 }

--- a/pkg/engine/internal/worker/worker_test.go
+++ b/pkg/engine/internal/worker/worker_test.go
@@ -398,7 +398,7 @@ func buildWorkflow(ctx context.Context, t *testing.T, logger log.Logger, loc obj
 		MaxRunningScanTasks:  32,
 		MaxRunningOtherTasks: 0, // unlimited
 	}
-	wf, err := workflow.New(opts, logger, sched, plan)
+	wf, err := workflow.New(ctx, opts, logger, sched, plan)
 	require.NoError(t, err)
 
 	if testing.Verbose() {

--- a/pkg/engine/internal/worker/workerstat/workerstat.go
+++ b/pkg/engine/internal/worker/workerstat/workerstat.go
@@ -1,0 +1,33 @@
+// Package workerstat declares worker-recorded per-task observation
+// statistics.
+package workerstat
+
+import "github.com/grafana/loki/v3/pkg/xcap"
+
+// These stats live in their own package rather than in
+// [pkg/engine/internal/worker] to avoid a cyclic dependency between workflow
+// and the worker.
+
+var (
+	// TaskExecutionOpenDuration is the time (in nanoseconds) spent opening the
+	// root pipeline before the worker began draining record batches from it.
+	TaskExecutionOpenDuration = xcap.NewStatisticInt64("worker.task.execution.open.duration", xcap.AggregationTypeSum)
+
+	// TaskExecutionReadDuration is the total time (in nanoseconds) the worker
+	// spent in calls to Pipeline.Read while draining the root pipeline.
+	TaskExecutionReadDuration = xcap.NewStatisticInt64("worker.task.execution.read.duration", xcap.AggregationTypeSum)
+
+	// TaskExecutionSendDuration is the total time (in nanoseconds) the worker
+	// spent forwarding record batches to external sinks while draining the root
+	// pipeline.
+	TaskExecutionSendDuration = xcap.NewStatisticInt64("worker.task.execution.send.duration", xcap.AggregationTypeSum)
+
+	// TaskExecutionReadRecvDuration is the total time (in nanoseconds) spent
+	// inside the per-node receive path that feeds downstream input batches into
+	// non-leaf tasks. It is a sub-phase of [TaskExecutionReadDuration].
+	//
+	// This duplicates [xcap.TaskRecvDuration] (which is a float64 measured in
+	// seconds) at int64-nanosecond resolution so the task summary can render
+	// the value as milliseconds without losing precision.
+	TaskExecutionReadRecvDuration = xcap.NewStatisticInt64("worker.task.execution.read.recv.duration", xcap.AggregationTypeSum)
+)

--- a/pkg/engine/internal/workflow/metastore_workflow_planner_test.go
+++ b/pkg/engine/internal/workflow/metastore_workflow_planner_test.go
@@ -37,7 +37,7 @@ func TestPlanWorkflow_MetastorePlan_UsesMergeRootAndPointersPartitions(t *testin
 	plan, err := p.Plan(context.Background(), nil, nil, start, end)
 	require.NoError(t, err)
 
-	graph, err := planWorkflow("tenant", plan, cacheParams{enabled: true, taskCacheMaxSizeBytes: 1 * 1024 * 1024}, log.NewNopLogger())
+	graph, err := planWorkflow(t.Context(), "tenant", plan, cacheParams{enabled: true, taskCacheMaxSizeBytes: 1 * 1024 * 1024}, log.NewNopLogger())
 	require.NoError(t, err)
 
 	rootTask, err := graph.Root()

--- a/pkg/engine/internal/workflow/stats.go
+++ b/pkg/engine/internal/workflow/stats.go
@@ -1,0 +1,17 @@
+package workflow
+
+import "github.com/grafana/loki/v3/pkg/xcap"
+
+var (
+	// StatPrunedTasks records the number of tasks that were pruned from the
+	// workflow.
+	StatPrunedTasks = xcap.NewStatisticInt64("workflow.tasks.pruned", xcap.AggregationTypeSum)
+
+	// StatPositiveCacheHits records the number of cache hit for tasks that
+	// resulted in at least one value.
+	StatPositiveCacheHits = xcap.NewStatisticInt64("workflow.tasks.positive.cache.hits", xcap.AggregationTypeSum)
+
+	// StatNegativeCacheHits records the number of cache hits for tasks that
+	// resulted in no value (such as filtering out all rows in the section).
+	StatNegativeCacheHits = xcap.NewStatisticInt64("workflow.tasks.negative.cache.hits", xcap.AggregationTypeSum)
+)

--- a/pkg/engine/internal/workflow/task_summary.go
+++ b/pkg/engine/internal/workflow/task_summary.go
@@ -1,0 +1,222 @@
+package workflow
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/go-kit/log/level"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/schedulerstat"
+	"github.com/grafana/loki/v3/pkg/engine/internal/worker/workerstat"
+	"github.com/grafana/loki/v3/pkg/xcap"
+)
+
+func (wf *Workflow) printTaskSummary(task *Task, oldState TaskState, newStatus TaskStatus) {
+	capture := newStatus.Capture
+	if capture == nil {
+		// Every terminal notification carries the per-task capture. Skip
+		// rather than emit a log line that's all nils.
+		return
+	}
+
+	var (
+		durTotal     = xcap.Value[int64](capture, schedulerstat.TaskTotalDuration)
+		durStaging   = xcap.Value[int64](capture, schedulerstat.TaskStagingDuration)
+		durQueue     = xcap.Value[int64](capture, schedulerstat.TaskQueueDuration)
+		durExecution = xcap.Value[int64](capture, schedulerstat.TaskExecutionDuration)
+		durOther     = durTotal - durStaging - durQueue - durExecution
+
+		durExecutionOpen     = xcap.Value[int64](capture, workerstat.TaskExecutionOpenDuration)
+		durExecutionRead     = xcap.Value[int64](capture, workerstat.TaskExecutionReadDuration)
+		durExecutionReadRecv = xcap.Value[int64](capture, workerstat.TaskExecutionReadRecvDuration)
+		durExecutionSend     = xcap.Value[int64](capture, workerstat.TaskExecutionSendDuration)
+		durExecutionOther    = durExecution - durExecutionOpen - durExecutionRead - durExecutionSend
+
+		pagesDownloaded = xcap.Value[int64](capture, xcap.StatDatasetPrimaryPagesDownloaded) + xcap.Value[int64](capture, xcap.StatDatasetSecondaryPagesDownloaded)
+		bytesDownloaded = xcap.Value[int64](capture, xcap.StatDatasetPrimaryColumnBytes) + xcap.Value[int64](capture, xcap.StatDatasetSecondaryColumnBytes)
+		bytesProcessed  = xcap.Value[int64](capture, xcap.StatDatasetPrimaryRowBytes) + xcap.Value[int64](capture, xcap.StatDatasetSecondaryRowBytes)
+		linesProcessed  = xcap.Value[int64](capture, xcap.StatDatasetPrimaryRowsRead) + xcap.Value[int64](capture, xcap.StatDatasetSecondaryRowsRead)
+	)
+
+	level.Info(wf.logger).Log(
+		"msg", "task-summary",
+
+		// Identity
+		"task_id", task.ULID,
+		"query_id", wf.opts.ID,
+		"parent_task_id", wf.parentTaskID(task),
+		"task_type", taskTypeName(task),
+		"operator_type", taskOperatorType(task),
+
+		// Outcome
+		"status", taskStatusName(newStatus.State),
+		"cancellation_phase", cancellationPhaseName(oldState, newStatus.State),
+		"error", newStatus.Error,
+
+		// Timings
+		"duration_ms", time.Duration(durTotal).Milliseconds(),
+		"duration_staging_ms", time.Duration(durStaging).Milliseconds(),
+		"duration_queue_ms", time.Duration(durQueue).Milliseconds(),
+		"duration_execution_ms", time.Duration(durExecution).Milliseconds(),
+		"duration_other_ms", time.Duration(durOther).Milliseconds(),
+
+		// Breakdown timings
+		"duration_execution_open_ms", time.Duration(durExecutionOpen).Milliseconds(),
+		"duration_execution_read_ms", time.Duration(durExecutionRead).Milliseconds(),
+		"duration_execution_read_recv_ms", time.Duration(durExecutionReadRecv).Milliseconds(),
+		"duration_execution_send_ms", time.Duration(durExecutionSend).Milliseconds(),
+		"duration_execution_other_ms", time.Duration(durExecutionOther).Milliseconds(),
+
+		// Stage 9 (leaf) counters.
+		"pages_total", xcap.Value[int64](capture, dataobj.StatDatasetPagesTotal),
+		"pages_pruned", xcap.Value[int64](capture, dataobj.StatDatasetPagesPruned),
+		"pages_downloaded", pagesDownloaded, // Pages downloaded by readerDownloader
+		"pages_bytes_downloaded", bytesDownloaded, // Bytes downloaded for pages by readerDownloader
+		"total_bytes_downloaded", xcap.Value[int64](capture, dataobj.StatObjectBytesDownloaded),
+
+		// Stage 10 counters.
+		"batches_emitted", xcap.Value[int64](capture, xcap.TaskRecordsSent),
+		"batches_consumed", xcap.Value[int64](capture, xcap.TaskDrainRecordsReceived),
+		"bytes_processed", bytesProcessed, // TODO(rfratto): missing semantics for non-leaf nodes
+		"lines_processed", linesProcessed, // TODO(rfratto): missing semantics for non-leaf nodes
+		"lines_emitted", xcap.Value[int64](capture, xcap.TaskRowsSent),
+
+		// Task result cache.
+		"cache_check", taskResultCacheOutcome(capture),
+	)
+}
+
+// parentTaskID returns the task's parent ULID, or the zero ULID if the task
+// is a root (one-parent assumption per the workflow planner).
+func (wf *Workflow) parentTaskID(task *Task) any {
+	wf.tasksMut.RLock()
+	parents := wf.graph.Parents(task)
+	wf.tasksMut.RUnlock()
+
+	if len(parents) == 0 {
+		return nil
+	}
+	// One-parent assumption per the workflow planner. If multi-parent task
+	// graphs are ever introduced, this and the per-task log schema will need
+	// to be revisited.
+	return parents[0].ULID
+}
+
+// taskTypeName returns "leaf" if the task has no external sources (i.e., it
+// reads directly from storage rather than from another task), otherwise
+// "non-leaf".
+func taskTypeName(task *Task) string {
+	if len(task.Sources) == 0 {
+		return "leaf"
+	}
+	return "non-leaf"
+}
+
+// taskOperatorType returns the type name of the task's root operator, or
+// the empty string if the fragment has no usable root.
+func taskOperatorType(task *Task) string {
+	if task.Fragment == nil {
+		return ""
+	}
+
+	root, err := task.Fragment.Root()
+	if err != nil {
+		return "none"
+	}
+	root, err = unwrapPhysicalNode(task.Fragment, root)
+	if err != nil {
+		return "none"
+	}
+	return root.Type().String()
+}
+
+// unwrapPhysicalNode unwraps "helper" physical nodes to reveal the actual root
+// node.
+func unwrapPhysicalNode(plan *physical.Plan, root physical.Node) (physical.Node, error) {
+	// TODO(rfratto): this should really be behaviour defined in the physical
+	// package.
+
+	switch root := root.(type) {
+	case *physical.Cache:
+		next, err := getRootChild("caching", plan.Children(root))
+		if err != nil {
+			return nil, err
+		}
+		return unwrapPhysicalNode(plan, next)
+	case *physical.Batching:
+		next, err := getRootChild("batching", plan.Children(root))
+		if err != nil {
+			return nil, err
+		}
+		return unwrapPhysicalNode(plan, next)
+	}
+
+	return root, nil
+}
+
+func getRootChild(parent string, children []physical.Node) (physical.Node, error) {
+	switch len(children) {
+	case 0:
+		return nil, fmt.Errorf("%s node has no children", parent)
+	case 1:
+		return children[0], nil
+	default:
+		return nil, fmt.Errorf("%s node has multiple children", parent)
+	}
+}
+
+// taskStatusName maps a terminal [TaskState] to the spec's status enum.
+func taskStatusName(state TaskState) string {
+	switch state {
+	case TaskStateCompleted:
+		return "success"
+	case TaskStateFailed:
+		return "fail"
+	case TaskStateCancelled:
+		return "cancel"
+	default:
+		return state.String()
+	}
+}
+
+// cancellationPhaseName returns the cancellation phase when newState is
+// [TaskStateCancelled], or nil otherwise (so the log field is omitted for
+// non-cancellation outcomes).
+//
+//   - "pre_assignment" — cancellation happened before the task was assigned
+//     to a worker (oldState was Created or Pending).
+//   - "during_execution" — cancellation happened while a worker was running
+//     the task (oldState was Running).
+func cancellationPhaseName(oldState, newState TaskState) any {
+	if newState != TaskStateCancelled {
+		return nil
+	}
+	switch oldState {
+	case TaskStateCreated, TaskStatePending:
+		return "pre_assignment"
+	case TaskStateRunning:
+		return "during_execution"
+	default:
+		return nil
+	}
+}
+
+// taskResultCacheOutcome derives the task result cache outcome for the task
+// from its capture, returning "hit", "miss", or "n/a".
+func taskResultCacheOutcome(capture *xcap.Capture) string {
+	var (
+		hits, _   = xcap.TryValue[int64](capture, xcap.TaskCacheHits)
+		misses, _ = xcap.TryValue[int64](capture, xcap.TaskCacheMisses)
+	)
+
+	switch {
+	case hits > 0:
+		return "hit"
+	case misses > 0:
+		return "miss"
+	default:
+		return "n/a"
+	}
+}

--- a/pkg/engine/internal/workflow/workflow.go
+++ b/pkg/engine/internal/workflow/workflow.go
@@ -582,18 +582,7 @@ func (wf *Workflow) mergeCapture(capture *xcap.Capture) {
 	wf.captureMut.Lock()
 	defer wf.captureMut.Unlock()
 
-	if wf.capture == nil || capture == nil {
-		return
-	}
-
-	if wf.parentRegion != nil {
-		capture.LinkParent(wf.parentRegion)
-	}
-
-	// Merge all regions from the task's capture into the workflow's capture.
-	for _, region := range capture.Regions() {
-		wf.capture.AddRegion(region)
-	}
+	wf.capture.Merge(wf.parentRegion, capture)
 }
 
 func (wf *Workflow) mergeResults(results stats.Result) {

--- a/pkg/engine/internal/workflow/workflow.go
+++ b/pkg/engine/internal/workflow/workflow.go
@@ -17,7 +17,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
@@ -136,7 +135,7 @@ type Workflow struct {
 	capture      *xcap.Capture
 	parentRegion *xcap.Region
 
-	span trace.Span
+	span *xcap.Span
 
 	tasksMut   sync.RWMutex
 	taskStates map[*Task]TaskState
@@ -152,8 +151,8 @@ type Workflow struct {
 // cannot be partitioned into a Workflow.
 //
 // The provided Runner will be used for Workflow execution.
-func New(opts Options, logger log.Logger, runner Runner, plan *physical.Plan) (*Workflow, error) {
-	graph, err := planWorkflow(opts.Tenant, plan, cacheParams{
+func New(ctx context.Context, opts Options, logger log.Logger, runner Runner, plan *physical.Plan) (*Workflow, error) {
+	graph, err := planWorkflow(ctx, opts.Tenant, plan, cacheParams{
 		enabled:                     opts.CacheEnabled,
 		taskCacheMaxSizeBytes:       opts.MaxTaskCacheSize,
 		dataObjScanMaxSizeBytes:     opts.MaxDataObjScanCacheSize,
@@ -197,7 +196,10 @@ func New(opts Options, logger log.Logger, runner Runner, plan *physical.Plan) (*
 		taskStates:   make(map[*Task]TaskState),
 		streamStates: make(map[*Stream]StreamState),
 	}
-	if err := wf.init(context.Background()); err != nil {
+	// Detach cancellation from the caller's ctx so a cancellation of the
+	// planning context does not abort the manifest registration, but keep
+	// the xcap region attached for observation recording.
+	if err := wf.init(context.WithoutCancel(ctx)); err != nil {
 		wf.Close()
 		return nil, err
 	}
@@ -379,7 +381,8 @@ func (wf *Workflow) dispatchTasks(ctx context.Context, tasks []*Task) error {
 
 			region.Record(xcap.StatTaskAdmissionWaitDuration.Observe(time.Since(start).Seconds()))
 
-			if err := wf.runner.Start(ctx, tasks[offset:offset+batchSize]...); err != nil {
+			batch := tasks[offset : offset+batchSize]
+			if err := wf.runner.Start(ctx, batch...); err != nil {
 				return fmt.Errorf("failed to start tasks: %w", err)
 			}
 		}

--- a/pkg/engine/internal/workflow/workflow.go
+++ b/pkg/engine/internal/workflow/workflow.go
@@ -47,8 +47,9 @@ var (
 
 // Options configures a [Workflow].
 type Options struct {
-	Tenant string   // Tenant ID associated with the workflow.
-	Actor  []string // Optional path to the actor that is generating the workflow.
+	ID     ulid.ULID // Optional ID for the workflow. One will be generated if not provided.
+	Tenant string    // Tenant ID associated with the workflow.
+	Actor  []string  // Optional path to the actor that is generating the workflow.
 
 	// MaxRunningScanTasks specifies the maximum number of scan tasks that may
 	// run concurrently within a single workflow. 0 means no limit.
@@ -231,8 +232,13 @@ func injectResultsStream(tenantID string, graph *dag.Graph[*Task]) (*Stream, err
 
 // init initializes the workflow.
 func (wf *Workflow) init(ctx context.Context) error {
+	id := wf.opts.ID
+	if id.IsZero() {
+		id = ulid.Make()
+	}
+
 	wf.manifest = &Manifest{
-		ID:     ulid.Make(),
+		ID:     id,
 		Tenant: wf.opts.Tenant,
 		Actor:  wf.opts.Actor,
 

--- a/pkg/engine/internal/workflow/workflow.go
+++ b/pkg/engine/internal/workflow/workflow.go
@@ -530,6 +530,9 @@ func (wf *Workflow) handleTerminalStateChange(ctx context.Context, task *Task, o
 	wf.tasksMut.RUnlock()
 
 	wf.cancelTasks(ctx, tasksToCancel)
+
+	// Print the summary at the very end to track full end-to-end task time.
+	wf.printTaskSummary(task, oldState, newStatus)
 }
 
 func (wf *Workflow) handleNonTerminalStateChange(ctx context.Context, task *Task, newStatus TaskStatus) {

--- a/pkg/engine/internal/workflow/workflow_planner.go
+++ b/pkg/engine/internal/workflow/workflow_planner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
+	"github.com/grafana/loki/v3/pkg/xcap"
 )
 
 // planner is responsible for constructing the Task graph held by a [Workflow].
@@ -44,7 +45,11 @@ type cacheParams struct {
 //
 // planWorkflow returns an error if the provided physical plan does not
 // have exactly one root node, or if the physical plan cannot be partitioned.
-func planWorkflow(tenantID string, plan *physical.Plan, cacheOpts cacheParams, logger log.Logger) (dag.Graph[*Task], error) {
+//
+// The provided context is used only for recording planning-time observations
+// into the xcap region (if any) carried by ctx. Cancellation of ctx does not
+// abort planning.
+func planWorkflow(ctx context.Context, tenantID string, plan *physical.Plan, cacheOpts cacheParams, logger log.Logger) (dag.Graph[*Task], error) {
 	root, err := plan.Root()
 	if err != nil {
 		return dag.Graph[*Task]{}, err
@@ -89,7 +94,7 @@ func planWorkflow(tenantID string, plan *physical.Plan, cacheOpts cacheParams, l
 		if err := injectDataObjScanCaching(tenantID, planner.graph, cacheOpts.dataObjScanMaxSizeBytes, cacheOpts.compression); err != nil {
 			return dag.Graph[*Task]{}, fmt.Errorf("injecting DataObjScan caching: %w", err)
 		}
-		if err := pruneCachedTasks(planner, cacheOpts, logger); err != nil {
+		if err := pruneCachedTasks(ctx, planner, cacheOpts, logger); err != nil {
 			return dag.Graph[*Task]{}, fmt.Errorf("pruning cached tasks: %w", err)
 		}
 	}
@@ -132,10 +137,12 @@ func optimize(t *Task) {
 // also being eliminated, preventing orphaned tasks with dangling Sink streams.
 //
 // Cache fetch errors are non-fatal: the batch is skipped and an error is logged.
-func pruneCachedTasks(p *planner, cacheOpts cacheParams, logger log.Logger) error {
+func pruneCachedTasks(ctx context.Context, p *planner, cacheOpts cacheParams, logger log.Logger) error {
 	if !cacheOpts.pruneEmptyCachedTasks && cacheOpts.nonEmptyCachedTasksMaxBytes == 0 {
 		return nil
 	}
+
+	region := xcap.RegionFromContext(ctx)
 
 	start := time.Now()
 
@@ -150,6 +157,12 @@ func pruneCachedTasks(p *planner, cacheOpts cacheParams, logger log.Logger) erro
 	}
 	emptyResults, nonEmptyResults := classifyTasksByCacheHit(fetchCtx, keyToTask, backends, logger)
 	fetchDuration := time.Since(fetchStart)
+
+	// Cache-hit counts are recorded regardless of whether the corresponding
+	// tasks end up pruned: they describe the cache lookup result, not the
+	// eventual workflow shape.
+	region.Record(StatNegativeCacheHits.Observe(int64(len(emptyResults))))
+	region.Record(StatPositiveCacheHits.Observe(int64(len(nonEmptyResults))))
 
 	// NOTE: tasks cannot be eliminated inside the walk or fetch loops since
 	// dag.Graph.Eliminate uses slices.DeleteFunc which zeroes the tail of the
@@ -207,6 +220,8 @@ func pruneCachedTasks(p *planner, cacheOpts cacheParams, logger log.Logger) erro
 		tasksRemoved += removed
 	}
 	pruningDuration := time.Since(pruningStart)
+
+	region.Record(StatPrunedTasks.Observe(int64(tasksRemoved)))
 
 	// Log the number of tasks removed. Note that if removed_tasks is bigger than to_eliminate
 	// then, (removed_tasks-to_eliminate) parents were removed because all their children were removed.

--- a/pkg/engine/internal/workflow/workflow_planner_test.go
+++ b/pkg/engine/internal/workflow/workflow_planner_test.go
@@ -40,7 +40,7 @@ func Test_planWorkflow(t *testing.T) {
 
 		physicalPlan := physical.FromGraph(physicalGraph)
 
-		graph, err := planWorkflow("", physicalPlan, cacheParams{}, log.NewNopLogger())
+		graph, err := planWorkflow(t.Context(), "", physicalPlan, cacheParams{}, log.NewNopLogger())
 		require.NoError(t, err)
 		require.Equal(t, 1, graph.Len())
 		requireUniqueStreams(t, graph)
@@ -78,7 +78,7 @@ func Test_planWorkflow(t *testing.T) {
 
 		physicalPlan := physical.FromGraph(physicalGraph)
 
-		graph, err := planWorkflow("", physicalPlan, cacheParams{}, log.NewNopLogger())
+		graph, err := planWorkflow(t.Context(), "", physicalPlan, cacheParams{}, log.NewNopLogger())
 		require.NoError(t, err)
 		require.Equal(t, 1, graph.Len())
 		requireUniqueStreams(t, graph)
@@ -121,7 +121,7 @@ func Test_planWorkflow(t *testing.T) {
 		physicalPlan, err := physical.WrapWithBatching(physicalPlan, 500)
 		require.NoError(t, err)
 
-		graph, err := planWorkflow("", physicalPlan, cacheParams{}, log.NewNopLogger())
+		graph, err := planWorkflow(t.Context(), "", physicalPlan, cacheParams{}, log.NewNopLogger())
 		require.NoError(t, err)
 		require.Equal(t, 2, graph.Len())
 		requireUniqueStreams(t, graph)
@@ -152,7 +152,7 @@ func Test_planWorkflow(t *testing.T) {
 		t.Run("with caching", func(t *testing.T) {
 			ulidGen := ulidGenerator{}
 
-			graph, err := planWorkflow("", physicalPlan, cacheParams{
+			graph, err := planWorkflow(t.Context(), "", physicalPlan, cacheParams{
 				enabled:                 true,
 				taskCacheMaxSizeBytes:   1 * 1024 * 1024,
 				dataObjScanMaxSizeBytes: 0,
@@ -253,7 +253,7 @@ func Test_planWorkflow(t *testing.T) {
 		physicalPlan, err := physical.WrapWithBatching(physicalPlan, 500)
 		require.NoError(t, err)
 
-		graph, err := planWorkflow("", physicalPlan, cacheParams{}, log.NewNopLogger())
+		graph, err := planWorkflow(t.Context(), "", physicalPlan, cacheParams{}, log.NewNopLogger())
 		require.NoError(t, err)
 		require.Equal(t, 5, graph.Len())
 		requireUniqueStreams(t, graph)
@@ -315,7 +315,7 @@ func Test_planWorkflow(t *testing.T) {
 		t.Run("with caching", func(t *testing.T) {
 			ulidGen := ulidGenerator{}
 
-			graph, err := planWorkflow("", physicalPlan, cacheParams{
+			graph, err := planWorkflow(t.Context(), "", physicalPlan, cacheParams{
 				enabled:                 true,
 				taskCacheMaxSizeBytes:   1 * 1024 * 1024,
 				dataObjScanMaxSizeBytes: 0,
@@ -422,7 +422,7 @@ func Test_planWorkflow(t *testing.T) {
 		physicalPlan, err := physical.WrapWithBatching(physicalPlan, 500)
 		require.NoError(t, err)
 
-		graph, err := planWorkflow("", physicalPlan, cacheParams{}, log.NewNopLogger())
+		graph, err := planWorkflow(t.Context(), "", physicalPlan, cacheParams{}, log.NewNopLogger())
 		require.NoError(t, err)
 		require.Equal(t, 3, graph.Len()) // 1 global + 2 local (one per scan target)
 		requireUniqueStreams(t, graph)
@@ -468,7 +468,7 @@ func Test_planWorkflow(t *testing.T) {
 		t.Run("with caching", func(t *testing.T) {
 			ulidGen := ulidGenerator{}
 
-			graph, err := planWorkflow("", physicalPlan, cacheParams{
+			graph, err := planWorkflow(t.Context(), "", physicalPlan, cacheParams{
 				enabled:                 true,
 				taskCacheMaxSizeBytes:   1 * 1024 * 1024,
 				dataObjScanMaxSizeBytes: 0,
@@ -556,7 +556,7 @@ func Test_planWorkflow(t *testing.T) {
 
 		physicalPlan := physical.FromGraph(physicalGraph)
 
-		graph, err := planWorkflow("", physicalPlan, cacheParams{}, log.NewNopLogger())
+		graph, err := planWorkflow(t.Context(), "", physicalPlan, cacheParams{}, log.NewNopLogger())
 		require.NoError(t, err)
 		require.Equal(t, 2, graph.Len())
 		requireUniqueStreams(t, graph)
@@ -635,7 +635,7 @@ func Test_planWorkflow(t *testing.T) {
 		physicalPlan, err := physical.WrapWithBatching(physicalPlan, 500)
 		require.NoError(t, err)
 
-		graph, err := planWorkflow("", physicalPlan, cacheParams{}, log.NewNopLogger())
+		graph, err := planWorkflow(t.Context(), "", physicalPlan, cacheParams{}, log.NewNopLogger())
 		require.NoError(t, err)
 		require.Equal(t, 4, graph.Len())
 		requireUniqueStreams(t, graph)
@@ -686,7 +686,7 @@ func Test_planWorkflow(t *testing.T) {
 		t.Run("with caching", func(t *testing.T) {
 			ulidGen := ulidGenerator{}
 
-			graph, err := planWorkflow("", physicalPlan, cacheParams{enabled: true, taskCacheMaxSizeBytes: 1 * 1024 * 1024, dataObjScanMaxSizeBytes: 1 * 1024 * 1024}, log.NewNopLogger())
+			graph, err := planWorkflow(t.Context(), "", physicalPlan, cacheParams{enabled: true, taskCacheMaxSizeBytes: 1 * 1024 * 1024, dataObjScanMaxSizeBytes: 1 * 1024 * 1024}, log.NewNopLogger())
 			require.NoError(t, err)
 			require.Equal(t, 4, graph.Len())
 			requireUniqueStreams(t, graph)
@@ -870,7 +870,7 @@ func Test_pruneCachedTasks(t *testing.T) {
 	// Extract raw cache keys for every task in graph traversal order.
 	// tasks[0] = root (VecAgg, no graph parents), tasks[1] = leaf "a", tasks[2] = leaf "b".
 	// Each entry maps cache-type name → raw key for that task.
-	baseGraph, err := planWorkflow("", physicalPlan, cacheP, log.NewNopLogger())
+	baseGraph, err := planWorkflow(t.Context(), "", physicalPlan, cacheP, log.NewNopLogger())
 	require.NoError(t, err)
 	require.Equal(t, 3, baseGraph.Len())
 
@@ -1116,7 +1116,7 @@ func Test_pruneCachedTasks(t *testing.T) {
 				})
 			}
 
-			g, err := planWorkflow("", physicalPlan, p, log.NewNopLogger())
+			g, err := planWorkflow(t.Context(), "", physicalPlan, p, log.NewNopLogger())
 			require.NoError(t, err)
 			requireUniqueStreams(t, g)
 			generateConsistentULIDs(&ulidGen, g)
@@ -1214,7 +1214,7 @@ func Test_pruneCachedTasks_cascadeProtection(t *testing.T) {
 		}),
 	}
 
-	require.NoError(t, pruneCachedTasks(p, cacheOpts, log.NewNopLogger()))
+	require.NoError(t, pruneCachedTasks(t.Context(), p, cacheOpts, log.NewNopLogger()))
 
 	// Root and intermediate are the only tasks that should remain.
 	// leaf_a and leaf_b are eliminated (empty hits); intermediate is also

--- a/pkg/engine/internal/workflow/workflow_test.go
+++ b/pkg/engine/internal/workflow/workflow_test.go
@@ -45,7 +45,7 @@ func Test(t *testing.T) {
 
 		fr := newFakeRunner()
 
-		wf, err := New(Options{}, log.NewNopLogger(), fr, physicalPlan)
+		wf, err := New(t.Context(), Options{}, log.NewNopLogger(), fr, physicalPlan)
 		require.NoError(t, err, "workflow should construct properly")
 		require.NotNil(t, wf.resultsStream, "workflow should have created results stream")
 
@@ -111,7 +111,7 @@ func TestCancellation(t *testing.T) {
 		t.Run(state.String(), func(t *testing.T) {
 			synctest.Test(t, func(t *testing.T) {
 				fr := newFakeRunner()
-				wf, err := New(Options{}, log.NewNopLogger(), fr, physicalPlan)
+				wf, err := New(t.Context(), Options{}, log.NewNopLogger(), fr, physicalPlan)
 				require.NoError(t, err, "workflow should construct properly")
 				require.NotNil(t, wf.resultsStream, "workflow should have created results stream")
 
@@ -211,7 +211,7 @@ func TestShortCircuiting(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		fr := newFakeRunner()
-		wf, err := New(Options{}, log.NewNopLogger(), fr, physicalPlan)
+		wf, err := New(t.Context(), Options{}, log.NewNopLogger(), fr, physicalPlan)
 		require.NoError(t, err, "workflow should construct properly")
 		require.NotNil(t, wf.resultsStream, "workflow should have created results stream")
 
@@ -303,7 +303,7 @@ func TestAdmissionControl(t *testing.T) {
 			MaxRunningOtherTasks:      0,  // unlimited
 			MaxRunningCompactionTasks: 0,  // unlimited; lane is dormant
 		}
-		wf, err := New(opts, log.NewNopLogger(), fr, physicalPlan)
+		wf, err := New(t.Context(), opts, log.NewNopLogger(), fr, physicalPlan)
 		require.NoError(t, err, "workflow should construct properly")
 		require.NotNil(t, wf.resultsStream, "workflow should have created results stream")
 

--- a/pkg/engine/stats.go
+++ b/pkg/engine/stats.go
@@ -1,0 +1,22 @@
+package engine
+
+import "github.com/grafana/loki/v3/pkg/xcap"
+
+var (
+	// Top-level phase durations
+
+	statLogicalPlanDuration  = xcap.NewStatisticInt64("plan.logical.duration", xcap.AggregationTypeSum)
+	statPhysicalPlanDuration = xcap.NewStatisticInt64("plan.physical.duration", xcap.AggregationTypeSum)
+	statPrepareDuration      = xcap.NewStatisticInt64("prepare.duration", xcap.AggregationTypeSum)
+	statExecutionDuration    = xcap.NewStatisticInt64("execution.duration", xcap.AggregationTypeSum)
+
+	// Physical plan subphases
+
+	statPhysicalIndexQueryDuration = xcap.NewStatisticInt64("plan.physical.index_query.duration", xcap.AggregationTypeSum)
+	statPhysicalOptimizeDuration   = xcap.NewStatisticInt64("plan.physical.optimize.duration", xcap.AggregationTypeSum)
+
+	// Execution subphases
+
+	statReadBatchDuration    = xcap.NewStatisticInt64("execute.read_batch.duration", xcap.AggregationTypeSum)
+	statProcessBatchDuration = xcap.NewStatisticInt64("execute.process_batch.duration", xcap.AggregationTypeSum)
+)

--- a/pkg/xcap/aggregation.go
+++ b/pkg/xcap/aggregation.go
@@ -70,7 +70,9 @@ func (a *AggregatedObservation) aggregate(aggType AggregationType, val any) {
 }
 
 func (a *AggregatedObservation) Int64() (int64, bool) {
-	if a.Statistic.DataType() != DataTypeInt64 {
+	if a == nil {
+		return 0, false
+	} else if a.Statistic.DataType() != DataTypeInt64 {
 		return 0, false
 	}
 
@@ -78,7 +80,9 @@ func (a *AggregatedObservation) Int64() (int64, bool) {
 }
 
 func (a *AggregatedObservation) Float64() (float64, bool) {
-	if a.Statistic.DataType() != DataTypeFloat64 {
+	if a == nil {
+		return 0, false
+	} else if a.Statistic.DataType() != DataTypeFloat64 {
 		return 0, false
 	}
 
@@ -86,7 +90,9 @@ func (a *AggregatedObservation) Float64() (float64, bool) {
 }
 
 func (a *AggregatedObservation) Bool() bool {
-	if a.Statistic.DataType() != DataTypeBool {
+	if a == nil {
+		return false
+	} else if a.Statistic.DataType() != DataTypeBool {
 		return false
 	}
 

--- a/pkg/xcap/capture.go
+++ b/pkg/xcap/capture.go
@@ -203,3 +203,34 @@ func (c *Capture) UnmarshalBinary(data []byte) error {
 
 	return nil
 }
+
+// Value computes the value of a statistic from the capture, rolling up from all
+// regions. If the statistic is not present in any region, Value returns nil.
+func (c *Capture) Value(stat Statistic) *AggregatedObservation {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	key := stat.Key()
+	var rolled *AggregatedObservation
+
+	for _, region := range c.regions {
+		region.mu.RLock()
+		obs, ok := region.observations[key]
+		if !ok {
+			region.mu.RUnlock()
+			continue
+		}
+		if rolled == nil {
+			rolled = &AggregatedObservation{
+				Statistic: obs.Statistic,
+				Value:     obs.Value,
+				Count:     obs.Count,
+			}
+		} else {
+			rolled.Merge(obs)
+		}
+		region.mu.RUnlock()
+	}
+
+	return rolled
+}

--- a/pkg/xcap/capture.go
+++ b/pkg/xcap/capture.go
@@ -234,3 +234,28 @@ func (c *Capture) Value(stat Statistic) *AggregatedObservation {
 
 	return rolled
 }
+
+// Value gets a typed value from a capture. If the statistic it not present in
+// any region from the capture, or the statistic is not of type T, Value returns
+// the zero value for T.
+//
+// Use [TryValue] if you need to distinguish between a missing statistic and a
+// zero value.
+func Value[T any](c *Capture, stat Statistic) T {
+	v, _ := TryValue[T](c, stat)
+	return v
+}
+
+// TryValue gets a typed value from a capture, returning both the value and a
+// boolean indicating whether the statistic was present in the capture and
+// matching type T.
+func TryValue[T any](c *Capture, stat Statistic) (T, bool) {
+	rolled := c.Value(stat)
+	if rolled == nil {
+		var zero T
+		return zero, false
+	}
+
+	val, ok := rolled.Value.(T)
+	return val, ok
+}

--- a/pkg/xcap/capture.go
+++ b/pkg/xcap/capture.go
@@ -140,6 +140,28 @@ func (c *Capture) LinkParent(parent *Region) {
 	}
 }
 
+// Merge incorporates all regions from src into c. If parent is non-nil, the
+// root regions of src are re-parented onto it before being added to c,
+// preserving the parent/child relationships when src's data is presented as
+// part of c's hierarchy.
+//
+// Regions are shared by reference between c and src after Merge returns.
+//
+// Merge is a no-op if c or src is nil, or if c has already been ended.
+func (c *Capture) Merge(parent *Region, src *Capture) {
+	if c == nil || src == nil {
+		return
+	}
+
+	if parent != nil {
+		src.LinkParent(parent)
+	}
+
+	for _, region := range src.Regions() {
+		c.AddRegion(region)
+	}
+}
+
 // getAllStatistics returns statistics used across all regions
 // in this capture.
 func (c *Capture) getAllStatistics() map[StatisticKey]Statistic {

--- a/pkg/xcap/capture_test.go
+++ b/pkg/xcap/capture_test.go
@@ -119,6 +119,157 @@ func TestCapture_AddRegion(t *testing.T) {
 	}
 }
 
+func TestCapture_Value(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func() (*Capture, Statistic)
+		wantNil   bool
+		wantValue any
+		wantCount int
+	}{
+		{
+			name: "statistic not present returns nil",
+			setup: func() (*Capture, Statistic) {
+				ctx, capture := NewCapture(context.Background(), nil)
+				_, region := StartRegion(ctx, "region1")
+				region.Record(NewStatisticInt64("other", AggregationTypeSum).Observe(1))
+				region.End()
+				return capture, NewStatisticInt64("missing", AggregationTypeSum)
+			},
+			wantNil: true,
+		},
+		{
+			name: "empty capture returns nil",
+			setup: func() (*Capture, Statistic) {
+				_, capture := NewCapture(context.Background(), nil)
+				return capture, NewStatisticInt64("missing", AggregationTypeSum)
+			},
+			wantNil: true,
+		},
+		{
+			name: "single region with sum aggregation",
+			setup: func() (*Capture, Statistic) {
+				ctx, capture := NewCapture(context.Background(), nil)
+				stat := NewStatisticInt64("bytes.read", AggregationTypeSum)
+				_, region := StartRegion(ctx, "region1")
+				region.Record(stat.Observe(100))
+				region.Record(stat.Observe(50))
+				region.End()
+				return capture, stat
+			},
+			wantValue: int64(150),
+			wantCount: 2,
+		},
+		{
+			name: "multiple regions sum across regions",
+			setup: func() (*Capture, Statistic) {
+				ctx, capture := NewCapture(context.Background(), nil)
+				stat := NewStatisticInt64("bytes.read", AggregationTypeSum)
+				_, region1 := StartRegion(ctx, "region1")
+				region1.Record(stat.Observe(100))
+				region1.End()
+				_, region2 := StartRegion(ctx, "region2")
+				region2.Record(stat.Observe(200))
+				region2.Record(stat.Observe(50))
+				region2.End()
+				return capture, stat
+			},
+			wantValue: int64(350),
+			wantCount: 3,
+		},
+		{
+			name: "multiple regions min across regions",
+			setup: func() (*Capture, Statistic) {
+				ctx, capture := NewCapture(context.Background(), nil)
+				stat := NewStatisticFloat64("latency.ms", AggregationTypeMin)
+				_, region1 := StartRegion(ctx, "region1")
+				region1.Record(stat.Observe(10.0))
+				region1.End()
+				_, region2 := StartRegion(ctx, "region2")
+				region2.Record(stat.Observe(5.0))
+				region2.End()
+				_, region3 := StartRegion(ctx, "region3")
+				region3.Record(stat.Observe(20.0))
+				region3.End()
+				return capture, stat
+			},
+			wantValue: float64(5.0),
+			wantCount: 3,
+		},
+		{
+			name: "multiple regions max across regions",
+			setup: func() (*Capture, Statistic) {
+				ctx, capture := NewCapture(context.Background(), nil)
+				stat := NewStatisticInt64("rows.scanned", AggregationTypeMax)
+				_, region1 := StartRegion(ctx, "region1")
+				region1.Record(stat.Observe(10))
+				region1.End()
+				_, region2 := StartRegion(ctx, "region2")
+				region2.Record(stat.Observe(50))
+				region2.End()
+				_, region3 := StartRegion(ctx, "region3")
+				region3.Record(stat.Observe(20))
+				region3.End()
+				return capture, stat
+			},
+			wantValue: int64(50),
+			wantCount: 3,
+		},
+		{
+			name: "flag aggregates as max (any true wins)",
+			setup: func() (*Capture, Statistic) {
+				ctx, capture := NewCapture(context.Background(), nil)
+				stat := NewStatisticFlag("cache.hit")
+				_, region1 := StartRegion(ctx, "region1")
+				region1.Record(stat.Observe(false))
+				region1.End()
+				_, region2 := StartRegion(ctx, "region2")
+				region2.Record(stat.Observe(true))
+				region2.End()
+				return capture, stat
+			},
+			wantValue: true,
+			wantCount: 2,
+		},
+		{
+			name: "same name different aggregation does not collide",
+			setup: func() (*Capture, Statistic) {
+				ctx, capture := NewCapture(context.Background(), nil)
+				statSum := NewStatisticInt64("value", AggregationTypeSum)
+				statMax := NewStatisticInt64("value", AggregationTypeMax)
+				_, region1 := StartRegion(ctx, "region1")
+				region1.Record(statSum.Observe(10))
+				region1.Record(statMax.Observe(100))
+				region1.End()
+				_, region2 := StartRegion(ctx, "region2")
+				region2.Record(statSum.Observe(20))
+				region2.Record(statMax.Observe(50))
+				region2.End()
+				return capture, statMax
+			},
+			wantValue: int64(100),
+			wantCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capture, stat := tt.setup()
+			got := capture.Value(stat)
+
+			if tt.wantNil {
+				require.Nil(t, got)
+				return
+			}
+
+			require.NotNil(t, got)
+			require.Equal(t, tt.wantValue, got.Value)
+			require.Equal(t, tt.wantCount, got.Count)
+			require.Equal(t, stat.Key(), got.Statistic.Key())
+		})
+	}
+}
+
 func TestCapture_GetAllStatistics(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/xcap/capture_test.go
+++ b/pkg/xcap/capture_test.go
@@ -119,6 +119,101 @@ func TestCapture_AddRegion(t *testing.T) {
 	}
 }
 
+func TestCapture_Merge(t *testing.T) {
+	t.Run("merges all regions from src into dst", func(t *testing.T) {
+		ctxDst, dst := NewCapture(context.Background(), nil)
+		ctxSrc, src := NewCapture(context.Background(), nil)
+
+		_, _ = StartRegion(ctxDst, "dst-region")
+		_, _ = StartRegion(ctxSrc, "src-region-1")
+		_, _ = StartRegion(ctxSrc, "src-region-2")
+
+		dst.Merge(nil, src)
+
+		regions := dst.Regions()
+		got := make([]string, 0, len(regions))
+		for _, r := range regions {
+			got = append(got, r.name)
+		}
+		require.ElementsMatch(t, []string{"dst-region", "src-region-1", "src-region-2"}, got)
+	})
+
+	t.Run("re-parents src root regions when parent is provided", func(t *testing.T) {
+		ctxDst, dst := NewCapture(context.Background(), nil)
+		_, dstParent := StartRegion(ctxDst, "dst-parent")
+
+		ctxSrc, src := NewCapture(context.Background(), nil)
+		_, srcRoot := StartRegion(ctxSrc, "src-root")
+
+		require.True(t, srcRoot.parentID.IsZero(), "src root should have no parent before merge")
+
+		dst.Merge(dstParent, src)
+
+		require.Equal(t, dstParent.id, srcRoot.parentID, "src root should be re-parented onto dstParent")
+	})
+
+	t.Run("does not change parent for src non-root regions", func(t *testing.T) {
+		ctxDst, dst := NewCapture(context.Background(), nil)
+		_, dstParent := StartRegion(ctxDst, "dst-parent")
+
+		ctxSrc, src := NewCapture(context.Background(), nil)
+		ctxSrcRoot, srcRoot := StartRegion(ctxSrc, "src-root")
+		_, srcChild := StartRegion(ctxSrcRoot, "src-child")
+
+		require.Equal(t, srcRoot.id, srcChild.parentID, "src-child should be parented to src-root before merge")
+
+		dst.Merge(dstParent, src)
+
+		require.Equal(t, dstParent.id, srcRoot.parentID, "src-root should be re-parented onto dstParent")
+		require.Equal(t, srcRoot.id, srcChild.parentID, "src-child should keep its original parent (src-root)")
+	})
+
+	t.Run("observations roll up across merged regions", func(t *testing.T) {
+		stat := NewStatisticInt64("merged.value", AggregationTypeSum)
+
+		ctxDst, dst := NewCapture(context.Background(), nil)
+		_, dstRegion := StartRegion(ctxDst, "dst-region")
+		dstRegion.Record(stat.Observe(10))
+		dstRegion.End()
+
+		ctxSrc, src := NewCapture(context.Background(), nil)
+		_, srcRegion := StartRegion(ctxSrc, "src-region")
+		srcRegion.Record(stat.Observe(7))
+		srcRegion.End()
+
+		dst.Merge(nil, src)
+
+		value, ok := TryValue[int64](dst, stat)
+		require.True(t, ok)
+		require.Equal(t, int64(17), value, "dst should observe sum of both captures' regions after merge")
+	})
+
+	t.Run("nil src is a no-op", func(t *testing.T) {
+		ctxDst, dst := NewCapture(context.Background(), nil)
+		_, _ = StartRegion(ctxDst, "dst-region")
+
+		require.NotPanics(t, func() { dst.Merge(nil, nil) })
+		require.Len(t, dst.Regions(), 1)
+	})
+
+	t.Run("nil receiver is a no-op", func(t *testing.T) {
+		_, src := NewCapture(context.Background(), nil)
+		var dst *Capture
+		require.NotPanics(t, func() { dst.Merge(nil, src) })
+	})
+
+	t.Run("merge into ended capture does not add regions", func(t *testing.T) {
+		_, dst := NewCapture(context.Background(), nil)
+		dst.End()
+
+		ctxSrc, src := NewCapture(context.Background(), nil)
+		_, _ = StartRegion(ctxSrc, "src-region")
+
+		dst.Merge(nil, src)
+		require.Empty(t, dst.Regions(), "ended dst should not absorb new regions")
+	})
+}
+
 func TestCapture_Value(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
> [!NOTE]
> This is split into isolated reviewable commits.  
>
> Most of the commits are about capturing these bespoke stats. However, there is one change to the scheduler to add per-task mutexes; this is used to fix the bug where the assignment time was not known for really fast tasks. 

This PR adds a series of log lines to observe the lifecycle of a query:

* `msg=query-summary` summarizes the major phases of query execution and their timings 
* `msg=execution-summary` breaks down query execution 
* `msg=physical-plan-summary` breaks down physical planning 
* `msg=logical-plan-summary` breaks down logical planning 
* `msg=task-summary` breaks down the execution of an individual task 

Each log line is curated from a selection of xcap stats, rather than dumping all xcap stats into a single log line. 

A query ID (previously workflow ID) is used to associate the "query" that each of these corresponds to. In this context, a query is any operation being performed on the query engine. Metastore operations are now semantically considered "index queries," and receive their own query ID. Log lines for index queries reference the `parent_query_id` of the query that generated them. 

The old "finished executing" log lines are removed in favour of the new ones.

**BREAKING CHANGE:** Index queries now have their own xcap, meaning that the old xcap log lines no longer roll up metastore stats into the overall execution stats.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core query execution/scheduling paths to add per-query/per-task captures and new cancellation/assignment bookkeeping; main risk is regressions in task state transitions, cancellation semantics, or performance from extra locking/logging.
> 
> **Overview**
> Adds a new per-`query` lifecycle wrapper around engine execution (including metastore “index” subqueries) that assigns a `query_id`, captures xcap observations, and emits curated summary logs (`logql-query-start`, `logical-plan-summary`, `physical-plan-summary`, `execution-summary`, `query-summary`).
> 
> Introduces per-task capture/regions in the scheduler/worker so terminal task notifications carry merged scheduler+worker observations, enabling a new `task-summary` log with timing breakdowns, cache/pruning counters, and dataobj I/O stats; this includes new xcap statistics for scheduler/worker phases, workflow cache-pruning counts, dataset page pruning/total pages, and object bytes downloaded.
> 
> Refactors scheduler task bookkeeping with per-task mutexes and assignment/interrupt tracking (fixing fast-task assignment-time races), adjusts cancellation handling to distinguish pre-assignment vs in-progress cancellations, and updates workflow planning/execution APIs to accept context for observation recording (tests updated accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8173bd63b525aa0deea97258b3e74a1752edf940. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->