### PR TITLE
chore: Initialize metrics with known labels to zero

### DIFF
--- a/pkg/dataobj/consumer/flush.go
+++ b/pkg/dataobj/consumer/flush.go
@@ -80,11 +80,11 @@ func newFlusher(sorter sorter, uploader uploader, logger log.Logger, r prometheu
 			NativeHistogramMinResetDuration: 0,
 		}),
 	}
-	// Initialize each counter to 0, otherwise neither the rate nor increase
-	// PromQL functions detect increases from 0 to 1.
-	f.flushes.WithLabelValues(flushReasonBuilderFull).Add(0)
-	f.flushes.WithLabelValues(flushReasonIdle).Add(0)
-	f.flushes.WithLabelValues(flushReasonMaxAge).Add(0)
+	// Initialize counters to 0, as rate and increase PromQL functions do not detect
+	// increase from absent to 1.
+	f.flushes.WithLabelValues(flushReasonBuilderFull)
+	f.flushes.WithLabelValues(flushReasonIdle)
+	f.flushes.WithLabelValues(flushReasonMaxAge)
 	f.flushFunc = f.flush
 	return f
 }

--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -29,6 +29,13 @@ import (
 	ring_client "github.com/grafana/dskit/ring/client"
 )
 
+const (
+	teedRequestsStatusDropped = "dropped"
+	teedRequestsStatusQueued  = "queued"
+	teedStreamsStatusBatched  = "batched"
+	teedStreamsStatusDropped  = "dropped"
+)
+
 // teeMetrics contains the metrics for [TeeService].
 type teeMetrics struct {
 	bufferedBytes         *metric_util.MaxSampleCollector
@@ -72,6 +79,13 @@ func newTeeMetrics(reg prometheus.Registerer) *teeMetrics {
 			),
 		),
 	}
+	// Initialize counters to 0, as rate and increase PromQL functions do not detect
+	// increase from absent to 1.
+	m.teedRequests.WithLabelValues(teedRequestsStatusDropped)
+	m.teedRequests.WithLabelValues(teedRequestsStatusQueued)
+	m.teedStreams.WithLabelValues(teedStreamsStatusBatched)
+	m.teedStreams.WithLabelValues(teedStreamsStatusDropped)
+
 	reg.MustRegister(m.bufferedBytes)
 	return &m
 }
@@ -240,9 +254,9 @@ func (ts *TeeService) flush() {
 				reqs:         reqs,
 				size:         totalSize,
 			}:
-				ts.metrics.teedRequests.WithLabelValues("queued").Inc()
+				ts.metrics.teedRequests.WithLabelValues(teedRequestsStatusQueued).Inc()
 			default:
-				ts.metrics.teedRequests.WithLabelValues("dropped").Inc()
+				ts.metrics.teedRequests.WithLabelValues(teedRequestsStatusDropped).Inc()
 				ts.releaseBufferedBytes(totalSize)
 			}
 		}
@@ -267,7 +281,7 @@ func (ts *TeeService) batchesForTenant(
 			Get(stream.HashKey, ring.WriteNoExtend, descs[:0], nil, nil)
 		if err != nil || len(replicationSet.Instances) == 0 {
 			ts.releaseBufferedBytes(stream.Stream.Size())
-			ts.metrics.teedStreams.WithLabelValues("dropped").Inc()
+			ts.metrics.teedStreams.WithLabelValues(teedStreamsStatusDropped).Inc()
 			continue
 		}
 
@@ -279,7 +293,7 @@ func (ts *TeeService) batchesForTenant(
 		}
 
 		batch.Streams = append(batch.Streams, stream.Stream)
-		ts.metrics.teedStreams.WithLabelValues("batched").Inc()
+		ts.metrics.teedStreams.WithLabelValues(teedStreamsStatusBatched).Inc()
 	}
 
 	streamCount := uint64(len(streams))
@@ -477,7 +491,7 @@ func (ts *TeeService) Duplicate(_ context.Context, tenant string, streams []dist
 		// Check that the stream is allowed within the current limit.
 		size := stream.Stream.Size()
 		if !ts.tryReserveBufferedBytes(size) {
-			ts.metrics.teedStreams.WithLabelValues("dropped").Inc()
+			ts.metrics.teedStreams.WithLabelValues(teedStreamsStatusDropped).Inc()
 			continue
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

https://promlabs.com/blog/2023/09/13/dealing-with-missing-time-series-in-prometheus/#when-feasible-pre-initialize-series

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: metrics-only changes that pre-create known label series; no functional changes to flush/tee behavior beyond metric label usage.
> 
> **Overview**
> Ensures Prometheus counters expose *known label series from startup* by pre-initializing `CounterVec` label values for dataobj consumer flush reasons and pattern tee request/stream statuses, improving `rate()`/`increase()` behavior when the first event occurs.
> 
> In `TeeService`, replaces ad-hoc status strings with shared constants (`queued`/`dropped`/`batched`) to keep label usage consistent while retaining the same metric semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8f18dbbc76674ebccca455cefd10ce405868c75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->