### PR TITLE
chore: Use a CAS loop in writer_client.go

### DIFF
--- a/pkg/kafka/client/writer_client.go
+++ b/pkg/kafka/client/writer_client.go
@@ -319,8 +319,8 @@ func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.P
 	c.produceRequestsTotal.Add(float64(len(records)))
 
 	onProduceDone := func(r *kgo.Record, err error) {
-		if c.maxBufferedBytes > 0 {
-			c.bufferedBytes.Add(-int64(len(r.Value)))
+		if !errors.Is(err, kgo.ErrMaxBuffered) {
+			c.releaseBufferedBytes(len(r.Value))
 		}
 
 		resMx.Lock()
@@ -340,12 +340,12 @@ func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.P
 	}
 
 	// Check that all records can fit within the limit.
-	var totalSize int64
+	var totalSize int
 	for _, record := range records {
-		totalSize += int64(len(record.Value))
+		totalSize += len(record.Value)
 	}
 
-	if c.maxBufferedBytes > 0 && c.bufferedBytes.Add(totalSize) > c.maxBufferedBytes {
+	if !c.reserveBufferedBytes(totalSize) {
 		// The records exceed what is left of the limit, we must fail them.
 		for _, record := range records {
 			// onProduceDone will dec the counter.
@@ -373,6 +373,39 @@ func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.P
 		// Once we're done, it's guaranteed that no more results will be appended, so we can safely return it.
 		return res
 	}
+}
+
+// reserveBufferedBytes attempts to reserve size bytes of capacity in the writer.
+// It returns true on success, otherwise false. A reservation is unsuccessful
+// if size would cause the tee to exceed maxBufferedBytes. When maxBufferedBytes
+// is zero, the limit is disabled.
+//
+// All reserved sizes must be returned by calling releaseBufferedBytes with
+// the same value.
+//
+// It is safe for concurrent use.
+func (c *Producer) reserveBufferedBytes(size int) bool {
+	for {
+		oldVal := c.bufferedBytes.Load()
+		newVal := oldVal + int64(size)
+		if c.maxBufferedBytes > 0 && newVal > c.maxBufferedBytes {
+			// If the limit is non-zero, we must first check that size can be reserved.
+			return false
+		}
+		// If we won the CAS, size was reserved, and we can return true.
+		if c.bufferedBytes.CompareAndSwap(oldVal, newVal) {
+			return true
+		}
+	}
+}
+
+// releaseBufferedBytes returns size bytes of reserved capacity to the writer.
+// It must be called whenever previously reserved capacity is no longer
+// needed.
+//
+// It is safe for concurrent use.
+func (c *Producer) releaseBufferedBytes(size int) {
+	c.bufferedBytes.Add(-int64(size))
 }
 
 // produceResultsForErr returns a [kgo.ProduceResults] that contains all records and


### PR DESCRIPTION
**What this PR does / why we need it**:

In previous version of this code, checking if the limit was exceeded was two atomic operations: one `Add` and one `Sub`. This meant two things:

1. To check if the limit was exceeded, the counter would exceed the limit.
2. Under contention, small records would be rejected when a large record was checked.

This fixes both of those.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrency/backpressure logic in `Producer.ProduceSync`, which can affect write behavior under load if the reservation/release accounting is wrong. Scope is small and localized to buffered-bytes tracking.
> 
> **Overview**
> Updates `Producer.ProduceSync` buffered-bytes limiting to *reserve* total record size upfront using a CAS loop (`reserveBufferedBytes`) rather than `Add`/rollback, preventing the counter from temporarily exceeding `maxBufferedBytes` and reducing false `kgo.ErrMaxBuffered` rejections under contention.
> 
> Adds `reserveBufferedBytes`/`releaseBufferedBytes` helpers and adjusts completion handling to only release bytes for records that were actually accepted (skipping releases for `ErrMaxBuffered`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 137a08bc0d2874fd65299e5c891b9fb8dddb83db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->