### PR TITLE
fix: Incorrect bounds check in tryReserveBufferedBytes

### DIFF
--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -487,7 +487,7 @@ func (ts *TeeService) Duplicate(_ context.Context, tenant string, streams []dist
 // It always returns true when [TeeConfig.MaxBufferedBytes] is 0.
 func (ts *TeeService) tryReserveBufferedBytes(size int) bool {
 	maxBufferedBytes := int64(ts.cfg.TeeConfig.MaxBufferedBytes)
-	if maxBufferedBytes == 0 {
+	if maxBufferedBytes <= 0 {
 		// The limit is disabled, size can be reserved.
 		ts.bufferedBytesMaxSample.Add(int64(size))
 		return true
@@ -511,8 +511,8 @@ func (ts *TeeService) tryReserveBufferedBytes(size int) bool {
 // reelaseBufferedBytes releases the size from the buffered bytes counter.
 // It is a no-op when [TeeConfig.MaxBufferedBytes] is 0.
 func (ts *TeeService) releaseBufferedBytes(size int) {
-	maxBufferedBytes := uint64(ts.cfg.TeeConfig.MaxBufferedBytes)
-	if maxBufferedBytes == 0 {
+	maxBufferedBytes := ts.cfg.TeeConfig.MaxBufferedBytes
+	if maxBufferedBytes <= 0 {
 		ts.bufferedBytesMaxSample.Sub(int64(size))
 		return
 	}

--- a/pkg/pattern/tee_service_test.go
+++ b/pkg/pattern/tee_service_test.go
@@ -189,98 +189,140 @@ func TestPatternTee_EmptyStream(t *testing.T) {
 }
 
 func TestPatternTee_MaxBufferedBytes(t *testing.T) {
-	ctx := t.Context()
-	tee, _ := getTestTee(t)
-	tee.cfg.TeeConfig.MaxBufferedBytes = 1024 // 1KB
-	require.Len(t, tee.buf, 0)
+	t.Run("limit is disabled when zero or negative", func(t *testing.T) {
+		ctx := t.Context()
+		tee, _ := getTestTee(t)
 
-	// Stream should be accepted, less than 1KB.
-	s1 := distributor.KeyedStream{
-		HashKey: 123,
-		Stream: push.Stream{
-			Labels: `{foo="bar"}`,
-			Entries: []push.Entry{{
-				Timestamp: time.Now(),
-				Line:      "abc",
-			}},
-		},
-	}
-	tee.Duplicate(ctx, "test", []distributor.KeyedStream{s1}, nil)
-	require.LessOrEqual(t, s1.Stream.Size(), 1024)
-	require.Len(t, tee.buf, 1)
-	tenantBuf, ok := tee.buf["test"]
-	require.True(t, ok)
-	require.Contains(t, tenantBuf, s1)
+		s1 := distributor.KeyedStream{
+			HashKey: 123,
+			Stream: push.Stream{
+				Labels: `{foo="bar"}`,
+				Entries: []push.Entry{{
+					Timestamp: time.Now(),
+					Line:      "abc",
+				}},
+			},
+		}
 
-	// Stream should be rejected, more than 1KB.
-	s2 := distributor.KeyedStream{
-		HashKey: 123,
-		Stream: push.Stream{
-			Labels: `{foo="bar"}`,
-			Entries: []push.Entry{{
-				Timestamp: time.Now(),
-				Line:      strings.Repeat("d", 1024),
-			}},
-		},
-	}
-	tee.Duplicate(ctx, "test", []distributor.KeyedStream{s2}, nil)
-	require.Greater(t, s2.Stream.Size(), 1024)
-	require.Len(t, tee.buf, 1)
-	// tenantBuf should contain s1, but not s2.
-	tenantBuf, ok = tee.buf["test"]
-	require.True(t, ok)
-	require.Contains(t, tenantBuf, s1)
+		tee.cfg.TeeConfig.MaxBufferedBytes = 0
+		tee.Duplicate(ctx, "test", []distributor.KeyedStream{s1}, nil)
+		// The atomic counter should not be incremented when disabled.
+		require.Equal(t, int64(0), tee.bufferedBytes.Load())
 
-	// Stream should be accepted, total of s1 and s3 is less than 1KB.
-	s3 := distributor.KeyedStream{
-		HashKey: 123,
-		Stream: push.Stream{
-			Labels: `{foo="bar"}`,
-			Entries: []push.Entry{{
-				Timestamp: time.Now(),
-				Line:      strings.Repeat("d", 512),
-			}},
-		},
-	}
-	tee.Duplicate(ctx, "test", []distributor.KeyedStream{s3}, nil)
-	require.Len(t, tee.buf, 1)
-	// tenantBuf should contain s1 and s3.
-	tenantBuf, ok = tee.buf["test"]
-	require.True(t, ok)
-	require.Contains(t, tenantBuf, s1)
-	require.Contains(t, tenantBuf, s3)
+		tee.cfg.TeeConfig.MaxBufferedBytes = -1
+		tee.Duplicate(ctx, "test", []distributor.KeyedStream{s1}, nil)
+		// The atomic counter should not be incremented when disabled.
+		require.Equal(t, int64(0), tee.bufferedBytes.Load())
+	})
 
-	// Stream should be rejected, total of s1, s3 and s4 is more than 1KB.
-	s4 := distributor.KeyedStream{
-		HashKey: 123,
-		Stream: push.Stream{
-			Labels: `{foo="bar"}`,
-			Entries: []push.Entry{{
-				Timestamp: time.Now(),
-				Line:      strings.Repeat("e", 512),
-			}},
-		},
-	}
-	tee.Duplicate(ctx, "test", []distributor.KeyedStream{s4}, nil)
-	require.Len(t, tee.buf, 1)
-	// tenantBuf should contain s1 and s3.
-	tenantBuf, ok = tee.buf["test"]
-	require.True(t, ok)
-	require.Contains(t, tenantBuf, s1)
-	require.Contains(t, tenantBuf, s3)
+	t.Run("limit is enforced when positive", func(t *testing.T) {
+		ctx := t.Context()
+		tee, _ := getTestTee(t)
+		tee.cfg.TeeConfig.MaxBufferedBytes = 1024 // 1KB
+		require.Len(t, tee.buf, 0)
 
-	// Flush s1 and s3, s4 should be accepted.
-	tee.flush()
-	select {
-	case clientRequest := <-tee.flushQueue:
-		tee.sendBatch(ctx, clientRequest)
-	case <-ctx.Done():
-		t.Fatal("context canceled before we received request from tee.flushQueue")
-	}
-	tee.Duplicate(ctx, "test", []distributor.KeyedStream{s4}, nil)
-	require.Len(t, tee.buf, 1)
-	// tenantBuf should contain s4.
-	tenantBuf, ok = tee.buf["test"]
-	require.True(t, ok)
-	require.Contains(t, tenantBuf, s4)
+		// Stream should be accepted, less than 1KB.
+		s1 := distributor.KeyedStream{
+			HashKey: 123,
+			Stream: push.Stream{
+				Labels: `{foo="bar"}`,
+				Entries: []push.Entry{{
+					Timestamp: time.Now(),
+					Line:      "abc",
+				}},
+			},
+		}
+		require.LessOrEqual(t, s1.Stream.Size(), 1024)
+		tee.Duplicate(ctx, "test", []distributor.KeyedStream{s1}, nil)
+		bufferedBytes1 := tee.bufferedBytes.Load()
+		require.NotZero(t, bufferedBytes1)
+		require.Len(t, tee.buf, 1)
+		tenantBuf, ok := tee.buf["test"]
+		require.True(t, ok)
+		require.Contains(t, tenantBuf, s1)
+
+		// Stream should be rejected, more than 1KB.
+		s2 := distributor.KeyedStream{
+			HashKey: 123,
+			Stream: push.Stream{
+				Labels: `{foo="bar"}`,
+				Entries: []push.Entry{{
+					Timestamp: time.Now(),
+					Line:      strings.Repeat("d", 1024),
+				}},
+			},
+		}
+		require.Greater(t, s2.Stream.Size(), 1024)
+		tee.Duplicate(ctx, "test", []distributor.KeyedStream{s2}, nil)
+		bufferedBytes2 := tee.bufferedBytes.Load()
+		require.Equal(t, bufferedBytes2, bufferedBytes1)
+		require.Len(t, tee.buf, 1)
+		// tenantBuf should contain s1, but not s2.
+		tenantBuf, ok = tee.buf["test"]
+		require.True(t, ok)
+		require.Contains(t, tenantBuf, s1)
+
+		// Stream should be accepted, total of s1 and s3 is less than 1KB.
+		s3 := distributor.KeyedStream{
+			HashKey: 123,
+			Stream: push.Stream{
+				Labels: `{foo="bar"}`,
+				Entries: []push.Entry{{
+					Timestamp: time.Now(),
+					Line:      strings.Repeat("d", 512),
+				}},
+			},
+		}
+		tee.Duplicate(ctx, "test", []distributor.KeyedStream{s3}, nil)
+		bufferedBytes3 := tee.bufferedBytes.Load()
+		require.Greater(t, bufferedBytes3, bufferedBytes2)
+		require.Len(t, tee.buf, 1)
+		// tenantBuf should contain s1 and s3.
+		tenantBuf, ok = tee.buf["test"]
+		require.True(t, ok)
+		require.Contains(t, tenantBuf, s1)
+		require.Contains(t, tenantBuf, s3)
+
+		// Stream should be rejected, total of s1, s3 and s4 is more than 1KB.
+		s4 := distributor.KeyedStream{
+			HashKey: 123,
+			Stream: push.Stream{
+				Labels: `{foo="bar"}`,
+				Entries: []push.Entry{{
+					Timestamp: time.Now(),
+					Line:      strings.Repeat("e", 512),
+				}},
+			},
+		}
+		tee.Duplicate(ctx, "test", []distributor.KeyedStream{s4}, nil)
+		// The total size of s4 is less than s1 and s3, but not 0.
+		bufferedBytes4 := tee.bufferedBytes.Load()
+		require.Equal(t, bufferedBytes4, bufferedBytes3)
+		require.Len(t, tee.buf, 1)
+		// tenantBuf should contain s1 and s3.
+		tenantBuf, ok = tee.buf["test"]
+		require.True(t, ok)
+		require.Contains(t, tenantBuf, s1)
+		require.Contains(t, tenantBuf, s3)
+
+		// Flush s1 and s3, s4 should be accepted.
+		tee.flush()
+		select {
+		case clientRequest := <-tee.flushQueue:
+			tee.sendBatch(ctx, clientRequest)
+		case <-ctx.Done():
+			t.Fatal("context canceled before we received request from tee.flushQueue")
+		}
+		tee.Duplicate(ctx, "test", []distributor.KeyedStream{s4}, nil)
+		// The total size of s4 is less than s1 and s3, but not 0.
+		bufferedBytes5 := tee.bufferedBytes.Load()
+		require.Less(t, bufferedBytes5, bufferedBytes4)
+		require.NotZero(t, bufferedBytes5)
+		require.Len(t, tee.buf, 1)
+		// tenantBuf should contain s4.
+		tenantBuf, ok = tee.buf["test"]
+		require.True(t, ok)
+		require.Contains(t, tenantBuf, s4)
+	})
+
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches buffering/flow-control logic that can affect memory usage and drop behavior under load, but the change is small and covered by updated tests.
> 
> **Overview**
> Fixes `TeeService` buffered-bytes accounting by treating `TeeConfig.MaxBufferedBytes <= 0` as *limit disabled* (instead of only `== 0`) in both `tryReserveBufferedBytes` and `releaseBufferedBytes`.
> 
> Updates `TestPatternTee_MaxBufferedBytes` to cover the new zero/negative semantics and to assert `bufferedBytes` increases/decreases only when the limit is enabled and enforced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74b2c8c9d1ed9f766eea7207f9c748ece8235ab0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->