### PR TITLE
docs: RN for 3.6.11

### DIFF
--- a/docs/sources/release-notes/v3-6.md
+++ b/docs/sources/release-notes/v3-6.md
@@ -192,6 +192,13 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 ## Bug fixes
 
+### 3.6.11 (2025-05-13)
+
+* CVEs in release 3.7.x ([#21771](https://github.com/grafana/loki/issues/21771)) ([bb4c5d8](https://github.com/grafana/loki/commit/bb4c5d8758b8540cb742466683143a9ea93743c8))
+* **deps:** Update module github.com/aws/aws-sdk-go-v2/service/s3 to v1.97.3 [security] (release-3.7.x) ([#21457](https://github.com/grafana/loki/issues/21457)) ([7bc9450](https://github.com/grafana/loki/commit/7bc945082fd7ef7632a9bfd18cc22f23130ea64a)).
+* **ruler:** Fix ruler panic related to unset validation scheme (backport release-3.7.x) ([#21401](https://github.com/grafana/loki/issues/21401)) ([cf65729](https://github.com/grafana/loki/commit/cf65729674b1f0be8011223c474df3e2e5253216)).
+* **storage:** Attach SHA-256 checksum on PutObject for Object Lock buckets ([#21849](https://github.com/grafana/loki/issues/21849)) ([7df13d9](https://github.com/grafana/loki/commit/7df13d9ad3993700c3aff23edf5dfa2966281416)).
+
 ### 3.6.10 (2025-04-03)
 
 * **ci** Backporting [#19989](https://github.com/grafana/loki/pull/19989) Add build tags to Promtail build commands, into 3.6 ([#21356](https://github.com/grafana/loki/issues/21356)) ([0f56890](https://github.com/grafana/loki/commit/0f56890f0536200d1ebb22bcc3488d0e79d9285b)).


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Release Notes for the 3.6.11 patch release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change updating release notes; no product code or behavior is modified.
> 
> **Overview**
> Adds a new **`3.6.11 (2025-05-13)`** section to the `v3.6` release notes, documenting the patch’s CVE-related items, an `aws-sdk-go-v2/service/s3` security dependency update, a ruler panic fix, and an S3 PutObject checksum change for Object Lock buckets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c5f609846ebdf98750eb6114a0aa22a45da32bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->