### PR TITLE
docs: RN for 3.7.2

### DIFF
--- a/docs/sources/release-notes/v3-7.md
+++ b/docs/sources/release-notes/v3-7.md
@@ -78,6 +78,13 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 ## Bug fixes
 
+### 3.7.2 (2026-05-13)
+
+* CVEs in release 3.7.x ([#21771](https://github.com/grafana/loki/issues/21771)) ([bb4c5d8](https://github.com/grafana/loki/commit/bb4c5d8758b8540cb742466683143a9ea93743c8)).
+* **deps:** Update module github.com/aws/aws-sdk-go-v2/service/s3 to v1.97.3 [security] (release-3.7.x) ([#21457](https://github.com/grafana/loki/issues/21457)) ([7bc9450](https://github.com/grafana/loki/commit/7bc945082fd7ef7632a9bfd18cc22f23130ea64a)).
+* **ruler:** Fix ruler panic related to unset validation scheme (backport release-3.7.x) ([#21401](https://github.com/grafana/loki/issues/21401)) ([cf65729](https://github.com/grafana/loki/commit/cf65729674b1f0be8011223c474df3e2e5253216)).
+* **storage:** Attach SHA-256 checksum on PutObject for Object Lock buckets ([#21849](https://github.com/grafana/loki/issues/21849)) ([7df13d9](https://github.com/grafana/loki/commit/7df13d9ad3993700c3aff23edf5dfa2966281416)).
+
 ### 3.7.1 (2026-03-27)
 
 * **deps:** Upgrade Go and gRPC versions on 3.7.x ([#21282](https://github.com/grafana/loki/issues/21282)) ([2c8fff2](https://github.com/grafana/loki/commit/2c8fff222bab6813374b973ae0eb49043d3ed14e)).


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Release Notes for the 3.7.2 patch release.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change updating release notes; no runtime or behavioral impact.
> 
> **Overview**
> Adds a new **3.7.2 (2026-05-13)** section to the `v3-7` release notes, documenting CVE coverage plus a security-related `aws-sdk-go-v2/service/s3` update, a `ruler` panic fix, and an S3 Object Lock checksum change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38df3ede24e844fcc30682b023806c8ffbcb2f1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->