### PR TITLE
docs: Backport 21705 to 3.7

### DIFF
--- a/docs/sources/send-data/docker-driver/_index.md
+++ b/docs/sources/send-data/docker-driver/_index.md
@@ -27,7 +27,7 @@ The Docker plugin must be installed on each Docker host that will be running con
 Run the following command to install the plugin, updating the release version, or changing the architecture (`arm64` and `amd64` are currently supported), if needed:
 
 ```bash
-docker plugin install grafana/loki-docker-driver:3.7.0-arm64 --alias loki --grant-all-permissions
+docker plugin install grafana/loki-docker-driver:3.7.0-amd64 --alias loki --grant-all-permissions
 ```
 
 {{< admonition type="note" >}}


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of #21705 to 3.7 branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the example Docker plugin install command; no runtime or API behavior is affected.
> 
> **Overview**
> Updates the Docker driver client install instructions to use the `3.7.0-amd64` plugin tag in the example command (with the existing note to add `-arm64` for ARM hosts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e0caca36867e0797351ce76b195c82e7bef4b90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->