### PR TITLE
docs: Backport 21705 to 3.6

### DIFF
--- a/docs/sources/send-data/docker-driver/_index.md
+++ b/docs/sources/send-data/docker-driver/_index.md
@@ -27,7 +27,7 @@ The Docker plugin must be installed on each Docker host that will be running con
 Run the following command to install the plugin, updating the release version, or changing the architecture (`arm64` and `amd64` are currently supported), if needed:
 
 ```bash
-docker plugin install grafana/loki-docker-driver:3.6.0-arm64 --alias loki --grant-all-permissions
+docker plugin install grafana/loki-docker-driver:3.6.0-amd64 --alias loki --grant-all-permissions
 ```
 
 {{< admonition type="note" >}}


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of https://github.com/grafana/loki/pull/21705 to 3.6 branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates the example install command; no runtime or config behavior is affected.
> 
> **Overview**
> Updates the Docker driver client installation docs to use the `3.6.0-amd64` plugin tag in the primary `docker plugin install` example, keeping ARM64 as a note rather than the default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60746af5b5438ab902a15f17d5371fdc37352d4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->