### PR TITLE
chore(dataset): Add dataset/layout package

### DIFF
--- a/pkg/columnar/clone.go
+++ b/pkg/columnar/clone.go
@@ -1,0 +1,101 @@
+package columnar
+
+import (
+	"fmt"
+
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// Clone returns a deep copy of the input Datum, allocating all new memory from
+// alloc. The returned Datum does not share any memory with the input.
+//
+// Scalars are returned as-is since they do not reference allocator-managed
+// memory.
+func Clone(alloc *memory.Allocator, input Datum) (Datum, error) {
+	switch src := input.(type) {
+	case Scalar:
+		return src, nil
+
+	case *Null:
+		return cloneNull(alloc, src), nil
+	case *Bool:
+		return cloneBool(alloc, src), nil
+	case *Number[int32]:
+		return cloneNumber(alloc, src), nil
+	case *Number[int64]:
+		return cloneNumber(alloc, src), nil
+	case *Number[uint32]:
+		return cloneNumber(alloc, src), nil
+	case *Number[uint64]:
+		return cloneNumber(alloc, src), nil
+	case *UTF8:
+		return cloneUTF8(alloc, src), nil
+	case *Struct:
+		return cloneStruct(alloc, src)
+
+	default:
+		return nil, fmt.Errorf("Clone: unsupported datum type %T", input)
+	}
+}
+
+func cloneNull(alloc *memory.Allocator, src *Null) *Null {
+	validity := cloneValidity(alloc, src.Validity())
+	return NewNull(validity)
+}
+
+func cloneValidity(alloc *memory.Allocator, validity memory.Bitmap) memory.Bitmap {
+	if validity.Len() == 0 {
+		return memory.Bitmap{}
+	}
+	return *validity.Clone(alloc)
+}
+
+func cloneBool(alloc *memory.Allocator, src *Bool) *Bool {
+	validity := cloneValidity(alloc, src.Validity())
+	srcValues := src.Values()
+	values := *srcValues.Clone(alloc)
+	return NewBool(values, validity)
+}
+
+func cloneNumber[T Numeric](alloc *memory.Allocator, src *Number[T]) *Number[T] {
+	validity := cloneValidity(alloc, src.Validity())
+	values := memory.NewBuffer[T](alloc, src.Len())
+	values.Append(src.Values()...)
+	return NewNumber(values.Data(), validity)
+}
+
+func cloneStruct(alloc *memory.Allocator, src *Struct) (*Struct, error) {
+	fields := make([]Array, src.NumFields())
+	for i := range fields {
+		cloned, err := Clone(alloc, src.Field(i))
+		if err != nil {
+			return nil, fmt.Errorf("field %d: %w", i, err)
+		}
+		fields[i] = cloned.(Array)
+	}
+	validity := cloneValidity(alloc, src.Validity())
+	return NewStruct(src.Schema(), fields, src.Len(), validity), nil
+}
+
+func cloneUTF8(alloc *memory.Allocator, src *UTF8) *UTF8 {
+	// Normalize first so offsets are zero-based and data is trimmed.
+	normalized := src.Normalize(alloc)
+	if normalized != src {
+		// Normalize already produced a full copy; return directly.
+		return normalized
+	}
+
+	var (
+		srcData    = src.Data()[:src.DataLen()]
+		srcOffsets = src.Offsets()
+	)
+
+	data := memory.NewBuffer[byte](alloc, len(srcData))
+	data.Append(srcData...)
+
+	offsets := memory.NewBuffer[int32](alloc, len(srcOffsets))
+	offsets.Append(srcOffsets...)
+
+	validity := cloneValidity(alloc, src.Validity())
+	return NewUTF8(data.Data(), offsets.Data(), validity)
+}

--- a/pkg/columnar/clone_test.go
+++ b/pkg/columnar/clone_test.go
@@ -1,0 +1,177 @@
+package columnar_test
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestClone(t *testing.T) {
+	tests := []struct {
+		name   string
+		kind   types.Kind
+		values []any
+		slice  [2]int // if non-zero, slice the source before cloning
+	}{
+		// Null
+		{name: "Null/empty", kind: types.KindNull},
+		{name: "Null/single", kind: types.KindNull, values: []any{nil}},
+		{name: "Null/multiple", kind: types.KindNull, values: []any{nil, nil, nil, nil, nil}},
+
+		// Bool
+		{name: "Bool/empty", kind: types.KindBool},
+		{name: "Bool/single true", kind: types.KindBool, values: []any{true}},
+		{name: "Bool/single false", kind: types.KindBool, values: []any{false}},
+		{name: "Bool/mixed", kind: types.KindBool, values: []any{true, false, true, true, false}},
+		{name: "Bool/with nulls", kind: types.KindBool, values: []any{true, nil, false, nil, true}},
+		{name: "Bool/all nulls", kind: types.KindBool, values: []any{nil, nil, nil}},
+		{name: "Bool/slice", kind: types.KindBool, values: []any{true, false, true, true, false, nil}, slice: [2]int{1, 4}},
+
+		// Int32
+		{name: "Int32/empty", kind: types.KindInt32},
+		{name: "Int32/single", kind: types.KindInt32, values: []any{42}},
+		{name: "Int32/multiple", kind: types.KindInt32, values: []any{1, 2, 3, 4, 5}},
+		{name: "Int32/with nulls", kind: types.KindInt32, values: []any{1, nil, 3, nil, 5}},
+		{name: "Int32/slice", kind: types.KindInt32, values: []any{10, 20, 30, 40, 50}, slice: [2]int{1, 4}},
+
+		// Int64
+		{name: "Int64/empty", kind: types.KindInt64},
+		{name: "Int64/single", kind: types.KindInt64, values: []any{42}},
+		{name: "Int64/multiple", kind: types.KindInt64, values: []any{1, 2, 3, 4, 5}},
+		{name: "Int64/with nulls", kind: types.KindInt64, values: []any{1, nil, 3, nil, 5}},
+		{name: "Int64/slice", kind: types.KindInt64, values: []any{10, 20, 30, 40, 50}, slice: [2]int{1, 4}},
+
+		// Uint32
+		{name: "Uint32/empty", kind: types.KindUint32},
+		{name: "Uint32/single", kind: types.KindUint32, values: []any{42}},
+		{name: "Uint32/multiple", kind: types.KindUint32, values: []any{1, 2, 3, 4, 5}},
+		{name: "Uint32/with nulls", kind: types.KindUint32, values: []any{1, nil, 3, nil, 5}},
+		{name: "Uint32/slice", kind: types.KindUint32, values: []any{10, 20, 30, 40, 50}, slice: [2]int{1, 4}},
+
+		// Uint64
+		{name: "Uint64/empty", kind: types.KindUint64},
+		{name: "Uint64/single", kind: types.KindUint64, values: []any{42}},
+		{name: "Uint64/multiple", kind: types.KindUint64, values: []any{1, 2, 3, 4, 5}},
+		{name: "Uint64/with nulls", kind: types.KindUint64, values: []any{1, nil, 3, nil, 5}},
+		{name: "Uint64/slice", kind: types.KindUint64, values: []any{10, 20, 30, 40, 50}, slice: [2]int{1, 4}},
+
+		// UTF8
+		{name: "UTF8/empty", kind: types.KindUTF8},
+		{name: "UTF8/single", kind: types.KindUTF8, values: []any{"hello"}},
+		{name: "UTF8/multiple", kind: types.KindUTF8, values: []any{"hello", "world", "foo", "bar"}},
+		{name: "UTF8/with nulls", kind: types.KindUTF8, values: []any{"hello", nil, "world", nil}},
+		{name: "UTF8/all nulls", kind: types.KindUTF8, values: []any{nil, nil, nil}},
+		{name: "UTF8/slice", kind: types.KindUTF8, values: []any{"hello", "world", "foo", "bar", "baz"}, slice: [2]int{1, 4}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var srcAlloc, dstAlloc memory.Allocator
+
+			src := columnartest.Array(t, tt.kind, &srcAlloc, tt.values...)
+			if tt.slice != [2]int{} {
+				src = src.Slice(tt.slice[0], tt.slice[1])
+			}
+
+			result, err := columnar.Clone(&dstAlloc, src)
+			require.NoError(t, err)
+
+			actual := result.(columnar.Array)
+			columnartest.RequireArraysEqual(t, src, actual, memory.Bitmap{})
+			requireDistinctMemory(t, src, actual)
+		})
+	}
+}
+
+func TestClone_Struct(t *testing.T) {
+	var srcAlloc, dstAlloc memory.Allocator
+
+	original := columnartest.Struct(t, &srcAlloc,
+		columnartest.Field("x", types.KindInt64, int64(1), int64(2)),
+		columnartest.Field("y", types.KindUTF8, "a", "b"),
+	)
+
+	cloned, err := columnar.Clone(&dstAlloc, original)
+	require.NoError(t, err)
+
+	cs := cloned.(*columnar.Struct)
+	require.Equal(t, 2, cs.Len())
+	require.Equal(t, 2, cs.NumFields())
+	columnartest.RequireArraysEqual(t, original.Field(0), cs.Field(0), memory.Bitmap{})
+	columnartest.RequireArraysEqual(t, original.Field(1), cs.Field(1), memory.Bitmap{})
+}
+
+func TestClone_Struct_WithValidity(t *testing.T) {
+	var srcAlloc, dstAlloc memory.Allocator
+
+	schema := columnar.NewSchema([]columnar.Column{{Name: "x"}})
+	validity := memory.NewBitmap(&srcAlloc, 2)
+	validity.AppendValues(true, false)
+	original := columnar.NewStruct(schema, []columnar.Array{
+		columnartest.Array(t, types.KindInt64, &srcAlloc, int64(1), int64(0)),
+	}, 2, validity)
+
+	cloned, err := columnar.Clone(&dstAlloc, original)
+	require.NoError(t, err)
+
+	cs := cloned.(*columnar.Struct)
+	require.Equal(t, 1, cs.Nulls())
+	require.False(t, cs.IsNull(0))
+	require.True(t, cs.IsNull(1))
+}
+
+// requireDistinctMemory asserts that two arrays do not share backing memory.
+func requireDistinctMemory(t *testing.T, a, b columnar.Array) {
+	t.Helper()
+
+	if a.Len() == 0 {
+		return
+	}
+
+	switch src := a.(type) {
+	case *columnar.Null:
+		// Null arrays only have a validity bitmap; nothing else to check.
+	case *columnar.Bool:
+		dst := b.(*columnar.Bool)
+		requireDistinctBitmaps(t, src.Values(), dst.Values())
+	case *columnar.Number[int32]:
+		requireDistinctSlices(t, src.Values(), b.(*columnar.Number[int32]).Values())
+	case *columnar.Number[int64]:
+		requireDistinctSlices(t, src.Values(), b.(*columnar.Number[int64]).Values())
+	case *columnar.Number[uint32]:
+		requireDistinctSlices(t, src.Values(), b.(*columnar.Number[uint32]).Values())
+	case *columnar.Number[uint64]:
+		requireDistinctSlices(t, src.Values(), b.(*columnar.Number[uint64]).Values())
+	case *columnar.UTF8:
+		dst := b.(*columnar.UTF8)
+		requireDistinctSlices(t, src.Offsets(), dst.Offsets())
+		if len(src.Data()) > 0 {
+			requireDistinctSlices(t, src.Data(), dst.Data())
+		}
+	}
+}
+
+func requireDistinctBitmaps(t *testing.T, a, b memory.Bitmap) {
+	t.Helper()
+	aData, _ := a.Bytes()
+	bData, _ := b.Bytes()
+	requireDistinctSlices(t, aData, bData)
+}
+
+func requireDistinctSlices[T any](t *testing.T, a, b []T) {
+	t.Helper()
+	if len(a) == 0 && len(b) == 0 {
+		return
+	}
+	require.NotEqual(t,
+		uintptr(unsafe.Pointer(unsafe.SliceData(a))),
+		uintptr(unsafe.Pointer(unsafe.SliceData(b))),
+		"expected cloned slice to have distinct backing memory",
+	)
+}

--- a/pkg/columnar/datum_utf8.go
+++ b/pkg/columnar/datum_utf8.go
@@ -161,6 +161,29 @@ func (arr *UTF8) Slice(i, j int) Array {
 	return NewUTF8(data, offsets, validity)
 }
 
+// Normalize returns a UTF8 array with zero-based offsets and data trimmed to
+// only the referenced range. If the array is already normalized, it is returned
+// as-is. Otherwise, a new array is allocated from alloc.
+func (arr *UTF8) Normalize(alloc *memory.Allocator) *UTF8 {
+	if len(arr.offsets) == 0 || arr.offsets[0] == 0 {
+		return arr
+	}
+
+	dataStart := arr.offsets[0]
+	dataEnd := arr.offsets[len(arr.offsets)-1]
+
+	data := memory.NewBuffer[byte](alloc, int(dataEnd-dataStart))
+	data.Append(arr.data[dataStart:dataEnd]...)
+
+	offsets := memory.NewBuffer[int32](alloc, len(arr.offsets))
+	for _, off := range arr.offsets {
+		offsets.Push(off - dataStart)
+	}
+
+	validity := cloneValidity(alloc, arr.validity)
+	return NewUTF8(data.Data(), offsets.Data(), validity)
+}
+
 func (arr *UTF8) isDatum() {}
 func (arr *UTF8) isArray() {}
 

--- a/pkg/dataset/layout/codec.go
+++ b/pkg/dataset/layout/codec.go
@@ -1,0 +1,124 @@
+package layout
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/expr"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// A Writer accumulates data into a [Layout].
+type Writer interface {
+	// Append appends the data from arr to the Writer. Append returns an error
+	// if the data is invalid for the Writer.
+	//
+	// Implementations must not retain references to arr beyond the call to
+	// Append.
+	Append(ctx context.Context, arr columnar.Array) error
+
+	// Flush flushes buffered data and returns a new [Layout] that represents
+	// the encoded data.
+	//
+	// After Flush is called, the Writer is reset and ready to accept new data.
+	Flush(ctx context.Context) (Layout, error)
+}
+
+// NewWriter creates an [Writer] for constructing a Layout.
+//
+// The provided alloc may be used to allocate memory that is used across the
+// entire Writer's lifetime. Callers must ensure that the allocator is valid for
+// the entire lifetime of the Writer.
+//
+// NewWriter returns an error if spec is invalid, or if spec and typ are not
+// compatible.
+func NewWriter(alloc *memory.Allocator, sink buffer.Sink, spec Spec, typ types.Type) (Writer, error) {
+	switch spec.Kind() {
+	case KindArray:
+		return newArrayWriter(alloc, sink, spec, typ)
+
+	default:
+		return nil, fmt.Errorf("unsupported layout kind %q", spec.Kind())
+	}
+}
+
+// A Reader reads data from a [Layout].
+type Reader interface {
+	// Next advances the row range covered by the reader by up to batchSize
+	// rows. Next returns the number of rows in the new window.
+	//
+	// When there are no more rows to read, Next returns 0 and io.EOF.
+	//
+	// Implementations of Reader should use Next to clear cached data that is no
+	// longer reachable after a call to Next.
+	Next(ctx context.Context, batchSize int) (int, error)
+
+	// AppendBuffers appends reachable buffers in the current row range to buf.
+	// A reachable buffer is any buffer referenced by the filter or projection
+	// expression that is not completely masked out by the provided mask.
+	AppendBuffers(buf []buffer.ID, filter expr.Expression, projection expr.Expression, mask memory.Bitmap) ([]buffer.ID, error)
+
+	// Prune reads available metadata to compute a high-level mask for the
+	// current row range based on the provided expression and mask.
+	//
+	// The returned mask is intersected with the provided mask and allocated
+	// with alloc. Prune returns an error if the mask argument is non-empty and
+	// not the same length as the row range.
+	Prune(ctx context.Context, alloc *memory.Allocator, expr expr.Expression, mask memory.Bitmap) (memory.Bitmap, error)
+
+	// Filter reads rows to compute a new mask for the current row range based
+	// on the provided expression and mask.
+	//
+	// Filter will cache data for Arrays that survived the filtering so it can
+	// be reused by future calls to Filter or Project without re-decoding.
+	//
+	// The returned mask is intersected with the provided mask and allocated
+	// with alloc. Filter returns an error if the mask argument is non-empty and
+	// not the same length as the row range.
+	Filter(ctx context.Context, alloc *memory.Allocator, expr expr.Expression, mask memory.Bitmap) (memory.Bitmap, error)
+
+	// Project materializes the projection expression for the current row
+	// range. The returned array always contains exactly the number of rows
+	// in the current window, regardless of the mask.
+	//
+	// When mask is non-empty, it acts as a selection hint: unselected rows
+	// may have undefined values but the array length is unchanged.
+	// Callers that need compacted output should apply [compute.Filter] on
+	// the result.
+	//
+	// Rows not currently cached from the Filter stage are read and decoded
+	// here. The returned array is allocated with alloc.
+	Project(ctx context.Context, alloc *memory.Allocator, projection expr.Expression, mask memory.Bitmap) (columnar.Array, error)
+
+	// Reset rewinds the reader to before the first row, allowing to re-read the
+	// data. Reset is safe to call at any point, including after EOF.
+	//
+	// Implementations may preserve internal caches (e.g., decoded data) across
+	// Reset; callers should not assume Reset frees buffers.
+	Reset()
+
+	// Close releases any resources held by the Reader.
+	Close() error
+}
+
+// NewReader creates a [Reader] for a Layout. The provided source is used to
+// retrieve buffer data inside the Layout.
+//
+// The provided alloc may used to allocate memory that is used across the entire
+// Reader's lifetime. Callers must ensure that the allocator is valid for the
+// entire lifetime of the Reader.
+//
+// NewReader returns an error if Array specifies an invalid encoding and type
+// pair.
+func NewReader(alloc *memory.Allocator, layout Layout, source buffer.Source) (Reader, error) {
+	switch layout.Kind() {
+	case KindArray:
+		return newArrayReader(alloc, layout, source)
+
+	default:
+		return nil, fmt.Errorf("unsupported layout kind %q", layout.Kind())
+	}
+}

--- a/pkg/dataset/layout/codec_array.go
+++ b/pkg/dataset/layout/codec_array.go
@@ -1,0 +1,205 @@
+package layout
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/expr"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+type arrayWriter struct {
+	inner array.Writer
+	sink  buffer.Sink
+}
+
+func newArrayWriter(alloc *memory.Allocator, sink buffer.Sink, spec Spec, typ types.Type) (*arrayWriter, error) {
+	if got, want := spec.Kind(), KindArray; got != want {
+		return nil, fmt.Errorf("invalid spec kind for array writer: got %s, want %s", got, want)
+	}
+
+	arrSpec := spec.(*SpecArray)
+
+	innerWriter, err := array.NewWriter(alloc, arrSpec.Spec, typ)
+	if err != nil {
+		return nil, fmt.Errorf("creating inner writer: %w", err)
+	}
+
+	return &arrayWriter{
+		inner: innerWriter,
+		sink:  sink,
+	}, nil
+}
+
+func (w *arrayWriter) Append(_ context.Context, arr columnar.Array) error {
+	return w.inner.Append(arr)
+}
+
+func (w *arrayWriter) Flush(ctx context.Context) (Layout, error) {
+	arr, err := w.inner.Flush(ctx, w.sink)
+	if err != nil {
+		return nil, fmt.Errorf("flushing array: %w", err)
+	}
+
+	return &Array{Metadata: arr}, nil
+}
+
+type arrayReader struct {
+	layout *Array
+	source buffer.Source
+	alloc  *memory.Allocator
+
+	// Lazily loaded full array. Loaded once on first Filter/Project call.
+	data   columnar.Array
+	loaded bool
+
+	// Window managed by Next.
+	totalRows int // Total number of rows in data.
+	offset    int // Offset into data of the first row in the current window.
+	length    int // Number of rows in the current window.
+}
+
+func newArrayReader(alloc *memory.Allocator, layout Layout, source buffer.Source) (*arrayReader, error) {
+	if got, want := layout.Kind(), KindArray; got != want {
+		return nil, fmt.Errorf("invalid layout kind for array reader: got %s, want %s", got, want)
+	}
+
+	arrLayout := layout.(*Array)
+
+	return &arrayReader{
+		layout:    arrLayout,
+		source:    source,
+		alloc:     alloc,
+		totalRows: arrLayout.Metadata.RowCount,
+	}, nil
+}
+
+func (r *arrayReader) Next(_ context.Context, batchSize int) (int, error) {
+	r.offset += r.length
+
+	if r.offset >= r.totalRows {
+		r.length = 0
+		return 0, io.EOF
+	}
+
+	r.length = min(batchSize, r.totalRows-r.offset)
+	return r.length, nil
+}
+
+func (r *arrayReader) AppendBuffers(buf []buffer.ID, _ expr.Expression, _ expr.Expression, _ memory.Bitmap) ([]buffer.ID, error) {
+	return appendArrayBuffers(buf, &r.layout.Metadata), nil
+}
+
+// appendArrayBuffers recursively collects all Buffer references from an
+// array.Array metadata tree.
+func appendArrayBuffers(buf []buffer.ID, arr *array.Array) []buffer.ID {
+	buf = append(buf, arr.Buffers...)
+	for i := range arr.Children {
+		buf = appendArrayBuffers(buf, &arr.Children[i])
+	}
+	return buf
+}
+
+func (r *arrayReader) Prune(_ context.Context, _ *memory.Allocator, _ expr.Expression, mask memory.Bitmap) (memory.Bitmap, error) {
+	if mask.Len() != 0 && mask.Len() != r.length {
+		return memory.Bitmap{}, fmt.Errorf("mask length %d does not match row range %d", mask.Len(), r.length)
+	}
+	// TODO(rfratto): Use Stats for pruning (min/max when available).
+	return mask, nil
+}
+
+func (r *arrayReader) Filter(ctx context.Context, alloc *memory.Allocator, e expr.Expression, mask memory.Bitmap) (memory.Bitmap, error) {
+	if err := r.loadData(ctx); err != nil {
+		return mask, err
+	}
+
+	windowData := r.data.Slice(r.offset, r.offset+r.length)
+	result, err := expr.Evaluate(alloc, e, windowData, mask)
+	if err != nil {
+		return mask, fmt.Errorf("evaluating filter expression: %w", err)
+	}
+
+	resultMask, err := datumToMask(alloc, result, r.length)
+	if err != nil {
+		return mask, fmt.Errorf("converting filter result to mask: %w", err)
+	}
+	if mask.Len() > 0 {
+		// datumToMask returns the raw values bitmap, which has undefined
+		// bits at unselected positions. Intersect with the input mask so
+		// only selected-and-matched rows survive.
+		resultMask = intersectMasks(alloc, resultMask, mask)
+	}
+	return resultMask, nil
+}
+
+func (r *arrayReader) loadData(ctx context.Context) error {
+	if r.loaded {
+		return nil
+	}
+
+	inner, err := array.NewReader(r.alloc, r.layout.Metadata, r.source)
+	if err != nil {
+		return fmt.Errorf("creating array reader: %w", err)
+	}
+	defer inner.Close()
+
+	// We read the full array into memory here, which can be slightly wasteful,
+	// but it is generally faster as it minimizes decoder reentrance.
+	data, err := inner.Read(ctx, r.alloc, r.totalRows)
+	if err != nil && err != io.EOF {
+		return fmt.Errorf("reading array data: %w", err)
+	}
+
+	r.data = data
+	r.loaded = true
+	return nil
+}
+
+func (r *arrayReader) Project(ctx context.Context, alloc *memory.Allocator, projection expr.Expression, mask memory.Bitmap) (columnar.Array, error) {
+	if err := r.loadData(ctx); err != nil {
+		return nil, err
+	}
+
+	windowData := r.data.Slice(r.offset, r.offset+r.length)
+
+	projected, err := expr.Evaluate(alloc, projection, windowData, mask)
+	if err != nil {
+		return nil, fmt.Errorf("evaluating projection: %w", err)
+	}
+
+	// expr.Evaluate may return its input unchanged (e.g., Identity
+	// projection). If the final result still aliases r.data, clone into
+	// alloc so the caller owns the memory.
+	final := projected
+	if final == windowData {
+		var err error
+		final, err = columnar.Clone(alloc, final)
+		if err != nil {
+			return nil, fmt.Errorf("cloning result: %w", err)
+		}
+	}
+
+	result, ok := final.(columnar.Array)
+	if !ok {
+		return nil, fmt.Errorf("projection produced %T, expected Array", final)
+	}
+	return result, nil
+}
+
+func (r *arrayReader) Reset() {
+	r.offset = 0
+	r.length = 0
+}
+
+func (r *arrayReader) Close() error {
+	r.Reset()
+
+	r.loaded = false
+	r.data = nil
+	return nil
+}

--- a/pkg/dataset/layout/codec_array_test.go
+++ b/pkg/dataset/layout/codec_array_test.go
@@ -1,0 +1,300 @@
+package layout_test
+
+import (
+	"io"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/compute"
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/dataset/layout"
+	"github.com/grafana/loki/v3/pkg/expr"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestCodec_Array(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	spec := &layout.SpecArray{
+		Spec: &array.SpecBool{Validity: nil},
+	}
+
+	w, err := layout.NewWriter(&alloc, &store, spec, &types.Bool{Nullable: false})
+	require.NoError(t, err)
+
+	expect := columnartest.Array(t, types.KindBool, &alloc, true, false, true, true)
+	require.NoError(t, w.Append(t.Context(), expect))
+
+	l, err := w.Flush(t.Context())
+	require.NoError(t, err)
+
+	r, err := layout.NewReader(&alloc, l, &store)
+	require.NoError(t, err)
+
+	// Advance the reader to get everything.
+	n, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+	actual, err := r.Project(t.Context(), &alloc, &expr.Identity{}, memory.Bitmap{})
+	require.NoError(t, err)
+
+	columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
+}
+
+func TestCodec_Array_Windowing(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	spec := &layout.SpecArray{
+		Spec: &array.SpecPlain{Validity: nil},
+	}
+
+	w, err := layout.NewWriter(&alloc, &store, spec, &types.Int64{Nullable: false})
+	require.NoError(t, err)
+
+	input := columnartest.Array(t, types.KindInt64, &alloc,
+		int64(10), int64(20), int64(30), int64(40), int64(50), int64(60),
+	)
+	require.NoError(t, w.Append(t.Context(), input))
+
+	l, err := w.Flush(t.Context())
+	require.NoError(t, err)
+
+	r, err := layout.NewReader(&alloc, l, &store)
+	require.NoError(t, err)
+
+	// First window: 2 rows.
+	n, err := r.Next(t.Context(), 2)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+
+	actual, err := r.Project(t.Context(), &alloc, &expr.Identity{}, memory.Bitmap{})
+	require.NoError(t, err)
+	columnartest.RequireArraysEqual(t,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(10), int64(20)),
+		actual,
+		memory.Bitmap{},
+	)
+
+	// Second window: 2 rows.
+	n, err = r.Next(t.Context(), 2)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+
+	actual, err = r.Project(t.Context(), &alloc, &expr.Identity{}, memory.Bitmap{})
+	require.NoError(t, err)
+	columnartest.RequireArraysEqual(t,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(30), int64(40)),
+		actual,
+		memory.Bitmap{},
+	)
+
+	// Third window: 2 remaining rows.
+	n, err = r.Next(t.Context(), 2)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+
+	actual, err = r.Project(t.Context(), &alloc, &expr.Identity{}, memory.Bitmap{})
+	require.NoError(t, err)
+	columnartest.RequireArraysEqual(t,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(50), int64(60)),
+		actual,
+		memory.Bitmap{},
+	)
+
+	// Fourth call: EOF.
+	n, err = r.Next(t.Context(), 2)
+	require.ErrorIs(t, err, io.EOF)
+	require.Equal(t, 0, n)
+}
+
+func TestCodec_Array_Filter(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	spec := &layout.SpecArray{
+		Spec: &array.SpecPlain{Validity: nil},
+	}
+
+	w, err := layout.NewWriter(&alloc, &store, spec, &types.Int64{Nullable: false})
+	require.NoError(t, err)
+
+	input := columnartest.Array(t, types.KindInt64, &alloc,
+		int64(10), int64(20), int64(30), int64(40),
+	)
+	require.NoError(t, w.Append(t.Context(), input))
+
+	l, err := w.Flush(t.Context())
+	require.NoError(t, err)
+
+	r, err := layout.NewReader(&alloc, l, &store)
+	require.NoError(t, err)
+
+	n, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+
+	// Filter: Identity > 20 → keeps rows where value > 20.
+	filterExpr := &expr.Binary{
+		Left:  &expr.Identity{},
+		Op:    expr.BinaryOpGT,
+		Right: &expr.Constant{Value: &columnar.NumberScalar[int64]{Value: 20}},
+	}
+
+	mask, err := r.Filter(t.Context(), &alloc, filterExpr, memory.Bitmap{})
+	require.NoError(t, err)
+
+	// Project with the filter mask; Project returns full window, so
+	// apply compute.Filter to compact.
+	projected, err := r.Project(t.Context(), &alloc, &expr.Identity{}, mask)
+	require.NoError(t, err)
+	filtered, err := compute.Filter(&alloc, projected, mask)
+	require.NoError(t, err)
+	columnartest.RequireArraysEqual(t,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(30), int64(40)),
+		filtered.(columnar.Array),
+		memory.Bitmap{},
+	)
+}
+
+func TestCodec_Array_Filter_WithInputMask(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	spec := &layout.SpecArray{
+		Spec: &array.SpecPlain{Validity: nil},
+	}
+
+	w, err := layout.NewWriter(&alloc, &store, spec, &types.Int64{Nullable: false})
+	require.NoError(t, err)
+
+	input := columnartest.Array(t, types.KindInt64, &alloc,
+		int64(10), int64(20), int64(30), int64(40),
+	)
+	require.NoError(t, w.Append(t.Context(), input))
+
+	l, err := w.Flush(t.Context())
+	require.NoError(t, err)
+
+	r, err := layout.NewReader(&alloc, l, &store)
+	require.NoError(t, err)
+
+	n, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+
+	// Filter: Identity > 15 → would match rows 1,2,3 (values 20,30,40).
+	// But provide an input mask that only includes rows 0 and 2.
+	filterExpr := &expr.Binary{
+		Left:  &expr.Identity{},
+		Op:    expr.BinaryOpGT,
+		Right: &expr.Constant{Value: &columnar.NumberScalar[int64]{Value: 15}},
+	}
+
+	inputMask := memory.NewBitmap(&alloc, 4)
+	inputMask.AppendValues(true, false, true, false)
+
+	mask, err := r.Filter(t.Context(), &alloc, filterExpr, inputMask)
+	require.NoError(t, err)
+
+	// Project with the intersected mask → only row 2 (value 30).
+	projected, err := r.Project(t.Context(), &alloc, &expr.Identity{}, mask)
+	require.NoError(t, err)
+	filtered, err := compute.Filter(&alloc, projected, mask)
+	require.NoError(t, err)
+	columnartest.RequireArraysEqual(t,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(30)),
+		filtered.(columnar.Array),
+		memory.Bitmap{},
+	)
+}
+
+func TestCodec_Array_Filter_NullsDoNotLeak(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	spec := &layout.SpecArray{
+		Spec: &array.SpecPlain{Validity: &array.SpecBool{}},
+	}
+
+	w, err := layout.NewWriter(&alloc, &store, spec, &types.Int64{Nullable: true})
+	require.NoError(t, err)
+
+	// Rows 1 and 3 are null. NumberBuilder.AppendNull writes the zero value
+	// for the backing storage, so the predicate "Identity > -5" evaluates to
+	// true at those positions in the compute kernel's values bitmap.
+	input := columnartest.Array(t, types.KindInt64, &alloc,
+		int64(10), nil, int64(30), nil,
+	)
+	require.NoError(t, w.Append(t.Context(), input))
+
+	l, err := w.Flush(t.Context())
+	require.NoError(t, err)
+
+	r, err := layout.NewReader(&alloc, l, &store)
+	require.NoError(t, err)
+
+	n, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+
+	// Identity > -5: backing zero for nulls also satisfies this.
+	filterExpr := &expr.Binary{
+		Left:  &expr.Identity{},
+		Op:    expr.BinaryOpGT,
+		Right: &expr.Constant{Value: &columnar.NumberScalar[int64]{Value: -5}},
+	}
+
+	mask, err := r.Filter(t.Context(), &alloc, filterExpr, memory.Bitmap{})
+	require.NoError(t, err)
+
+	require.Equal(t, 4, mask.Len())
+	require.True(t, mask.Get(0), "row 0 (value 10) should pass")
+	require.False(t, mask.Get(1), "row 1 (null) must not pass")
+	require.True(t, mask.Get(2), "row 2 (value 30) should pass")
+	require.False(t, mask.Get(3), "row 3 (null) must not pass")
+}
+
+func TestCodec_Array_ProjectAllRows(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	spec := &layout.SpecArray{
+		Spec: &array.SpecPlain{Validity: nil},
+	}
+
+	w, err := layout.NewWriter(&alloc, &store, spec, &types.Int64{Nullable: false})
+	require.NoError(t, err)
+
+	input := columnartest.Array(t, types.KindInt64, &alloc,
+		int64(1), int64(2), int64(3),
+	)
+	require.NoError(t, w.Append(t.Context(), input))
+
+	l, err := w.Flush(t.Context())
+	require.NoError(t, err)
+
+	r, err := layout.NewReader(&alloc, l, &store)
+	require.NoError(t, err)
+
+	n, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+
+	// Project with an all-set mask should return everything.
+	allSet := memory.NewBitmap(&alloc, 3)
+	allSet.AppendCount(true, 3)
+
+	projected, err := r.Project(t.Context(), &alloc, &expr.Identity{}, allSet)
+	require.NoError(t, err)
+	filtered, err := compute.Filter(&alloc, projected, allSet)
+	require.NoError(t, err)
+	columnartest.RequireArraysEqual(t, input, filtered.(columnar.Array), memory.Bitmap{})
+}

--- a/pkg/dataset/layout/codec_util.go
+++ b/pkg/dataset/layout/codec_util.go
@@ -1,0 +1,51 @@
+package layout
+
+import (
+	"fmt"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/compute"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// datumToMask converts a boolean Datum (either a Bool array or a BoolScalar)
+// into a memory.Bitmap of the given length.
+//
+// For a Bool array, the values bitmap is returned, masked by validity so that
+// null rows do not pass. For a BoolScalar, the scalar value is broadcast to
+// fill the entire length.
+func datumToMask(alloc *memory.Allocator, datum columnar.Datum, length int) (memory.Bitmap, error) {
+	switch v := datum.(type) {
+	case *columnar.Bool:
+		// Compute kernels write a result bit for every row, including nulls
+		// (backed by a zero value). Intersect with validity so null rows are
+		// excluded from the mask regardless of the underlying values bit.
+		validity := v.Validity()
+		if validity.Len() == 0 {
+			return v.Values(), nil
+		}
+		return intersectMasks(alloc, v.Values(), validity), nil
+	case *columnar.BoolScalar:
+		mask := memory.NewBitmap(alloc, length)
+		mask.AppendCount(!v.Null && v.Value, length)
+		return mask, nil
+	default:
+		return memory.Bitmap{}, fmt.Errorf("expected Bool datum, got %T", datum)
+	}
+}
+
+// intersectMasks returns a new mask where only bits set in both a and b are
+// set.
+func intersectMasks(alloc *memory.Allocator, a, b memory.Bitmap) memory.Bitmap {
+	// We wrap the bitmaps as Bool arrays to delegate to compute.And, which
+	// correctly handles byte-aligned offsets from sliced bitmaps.
+	var (
+		aArr = columnar.NewBool(a, memory.Bitmap{})
+		bArr = columnar.NewBool(b, memory.Bitmap{})
+	)
+	result, err := compute.And(alloc, aArr, bArr, memory.Bitmap{})
+	if err != nil {
+		panic("intersectMasks: " + err.Error())
+	}
+	return result.(*columnar.Bool).Values()
+}

--- a/pkg/dataset/layout/kind.go
+++ b/pkg/dataset/layout/kind.go
@@ -1,0 +1,26 @@
+package layout
+
+// Kind identifies the category of a [Layout]. Each concrete Layout
+// implementation returns a fixed Kind value.
+//
+// The zero value is an invalid Kind.
+type Kind int
+
+const (
+	KindInvalid Kind = iota
+
+	KindArray // KindArray holds a single array.
+)
+
+var kindNames = [...]string{
+	KindInvalid: "invalid",
+	KindArray:   "array",
+}
+
+// String returns the string representation of k.
+func (k Kind) String() string {
+	if k < 0 || k >= Kind(len(kindNames)) {
+		return "unknown"
+	}
+	return kindNames[k]
+}

--- a/pkg/dataset/layout/layout.go
+++ b/pkg/dataset/layout/layout.go
@@ -1,0 +1,52 @@
+// Package layout defines the [Layout], which groups [array.Array]s into a
+// hierarhical structure.
+package layout
+
+import (
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+)
+
+// Layout describes a hierarchy of [array.Arrays]. Each Layout is a grouping of
+// other Layouts, with [array.Array]s being leaf nodes.
+type Layout interface {
+	isLayout() // Sealed marker method.
+
+	// Kind returns the Kind for the Layout.
+	Kind() Kind
+
+	// DataType returns the data type of the Layout.
+	DataType() types.Type
+
+	// Len returns the total number of rows in the Layout.
+	Len() int
+}
+
+// Layout definitions.
+type (
+	// Array is a leaf node holding exactly one Array.
+	Array struct {
+		Metadata array.Array
+	}
+)
+
+// Kind returns [KindArray].
+func (l *Array) Kind() Kind {
+	return KindArray
+}
+
+// DataType returns the data type of the Array.
+func (l *Array) DataType() types.Type {
+	return l.Metadata.Type
+}
+
+// Len returns the number of rows in the Array.
+func (l *Array) Len() int {
+	return l.Metadata.RowCount
+}
+
+//
+// Sealed marker implementations.
+//
+
+func (l *Array) isLayout() {}

--- a/pkg/dataset/layout/spec.go
+++ b/pkg/dataset/layout/spec.go
@@ -1,0 +1,35 @@
+package layout
+
+import "github.com/grafana/loki/v3/pkg/dataset/array"
+
+// Spec describes how to encode data for a [Layout].
+//
+// While [Kind] categorizes the spec, the invidiual Spec implementations can
+// hold additionally encoding-specific metadata that is used for encoding and
+// decoding.
+type Spec interface {
+	isSpec() // Sealed interface.
+
+	// Kind returns the encoding kind of this Spec.
+	Kind() Kind
+}
+
+// Spec definitions.
+type (
+	// SpecArray specifies how to encode an individual [array.Array].
+	SpecArray struct {
+		// Spec for encoding data in the Array.
+		Spec array.Spec
+	}
+)
+
+// Kind returns [KindArray].
+func (spec *SpecArray) Kind() Kind {
+	return KindArray
+}
+
+//
+// Sealed marker implementations.
+//
+
+func (spec *SpecArray) isSpec() {}


### PR DESCRIPTION
Introduce a layout package which encompasses groups of arrays.

Layouts
-------

There is one initial layout, Array, which encapsulates a single array.Array. In this case, Array acts most similarly to a page.

Reading
-------

Reading a Layout is more complicated than reading an Array; layout.Reader exposes methods for pruning based on metadata, filtering logs into a mask without materializing results, and projecting a mask into a set of materialized arrays.

The additional complexity here will make it easier to write an lightweight dataset.Reader while also giving callers control over how data gets read.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new reader/writer APIs and evaluation-to-mask logic that affects filtering/projection semantics and memory ownership; bugs here could surface as incorrect query results or buffer aliasing.
> 
> **Overview**
> Adds a new `pkg/dataset/layout` package that defines `Layout`/`Spec` kinds and provides `NewWriter`/`NewReader` with an initial `KindArray` implementation supporting windowed reads, buffer discovery, filtering to a bitmap mask, and projection via `expr.Evaluate`.
> 
> Introduces `datumToMask`/`intersectMasks` to safely turn boolean evaluation results into selection masks (including masking out nulls and intersecting with an input mask).
> 
> Adds `columnar.Clone` for deep-copying arrays (including nested `Struct`) and a `UTF8.Normalize` helper; `layout` projection clones results when an identity projection would otherwise alias the reader’s cached window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8673861e5a6c0723b78a68e2a81f44f87c1b9ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->