### PR TITLE
chore: Remove noisy log line in dataobj_tee.go

### DIFF
--- a/pkg/distributor/dataobj_tee.go
+++ b/pkg/distributor/dataobj_tee.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/loki/v3/pkg/kafka"
 )
@@ -222,7 +223,9 @@ func (t *DataObjTee) duplicate(ctx context.Context, tenant string, stream segmen
 
 	results := t.kafkaClient.ProduceSync(ctx, records)
 	if err := results.FirstErr(); err != nil {
-		level.Error(t.logger).Log("msg", "failed to produce records", "err", err)
+		if !errors.Is(err, kgo.ErrMaxBuffered) {
+			level.Error(t.logger).Log("msg", "failed to produce records", "err", err)
+		}
 		t.streamFailures.Inc()
 		pushTracker.doneWithResult(fmt.Errorf("couldn't process request internally due to tee error: %d", TeeCouldntProduceRecordsError))
 		return


### PR DESCRIPTION
**What this PR does / why we need it**:

With the max-buffered-bytes limit enforced for Kafka, this log lines become very noisy. If we need need to know the reason we can find a way to sample it or export it as a metric.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes logging behavior by silencing `kgo.ErrMaxBuffered` errors; write/metrics/error handling behavior is otherwise unchanged.
> 
> **Overview**
> Reduces log noise in `DataObjTee` by **skipping error logs** when Kafka production fails specifically with `kgo.ErrMaxBuffered` (buffer full), while still counting the failure and returning the same tee error code.
> 
> Adds the `franz-go` `kgo` import to detect this condition explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a282f896709368f9bccce25c1e6485aa21b74ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->