### PR TITLE
chore: Remove unused flag in pattern tee

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1056,10 +1056,6 @@ pattern_ingester:
 
   # Configures the pattern tee which forwards requests to the pattern ingester.
   tee_config:
-    # The size of the batch of raw logs to send for template mining
-    # CLI flag: -pattern-ingester.tee.batch-size
-    [batch_size: <int> | default = 5000]
-
     # The max time between batches of raw logs to send for template mining
     # CLI flag: -pattern-ingester.tee.batch-flush-interval
     [batch_flush_interval: <duration> | default = 1s]

--- a/pkg/pattern/ingester.go
+++ b/pkg/pattern/ingester.go
@@ -131,7 +131,6 @@ func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
 }
 
 type TeeConfig struct {
-	BatchSize          int           `yaml:"batch_size"`
 	BatchFlushInterval time.Duration `yaml:"batch_flush_interval"`
 	FlushQueueSize     int           `yaml:"flush_queue_size"`
 	FlushWorkerCount   int           `yaml:"flush_worker_count"`
@@ -140,12 +139,6 @@ type TeeConfig struct {
 }
 
 func (cfg *TeeConfig) RegisterFlags(f *flag.FlagSet, prefix string) {
-	f.IntVar(
-		&cfg.BatchSize,
-		prefix+"tee.batch-size",
-		5000,
-		"The size of the batch of raw logs to send for template mining",
-	)
 	f.DurationVar(
 		&cfg.BatchFlushInterval,
 		prefix+"tee.batch-flush-interval",


### PR DESCRIPTION
**What this PR does / why we need it**:

This flag isn't used, remove it.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since it only deletes an unused configuration/flag, but it is a minor breaking change for anyone still setting `-pattern-ingester.tee.batch-size` or `tee_config.batch_size`.
> 
> **Overview**
> Removes the unused pattern-tee `batch_size` option by deleting it from `TeeConfig` and dropping the `-pattern-ingester.tee.batch-size` flag registration.
> 
> Updates the shared configuration docs to no longer advertise `tee_config.batch_size`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0130b723b2bec7b45545d298172e0b1263dbec75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->