### PR TITLE
chore: clean up check for max-buffered-bytes limit

### DIFF
--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -487,19 +487,17 @@ func (ts *TeeService) Duplicate(_ context.Context, tenant string, streams []dist
 // reserveBufferedBytes attempts to reserve size bytes of capacity in the tee.
 // It returns true on success, otherwise false. A reservation is unsuccessful
 // if size would cause the tee to exceed [TeeConfig.MaxBufferedBytes]. When
-// [TeeConfig.MaxBufferedBytes] is zero, the limit is disabled.
+// [TeeConfig.MaxBufferedBytes] is zero or negative, the limit is disabled.
 //
 // All reserved sizes must be returned by calling releaseBufferedBytes with
 // the same value.
 //
 // It is safe for concurrent use.
 func (ts *TeeService) reserveBufferedBytes(size int) bool {
-	maxBufferedBytes := int64(ts.cfg.TeeConfig.MaxBufferedBytes)
 	for {
 		oldVal := ts.bufferedBytes.Load()
 		newVal := oldVal + int64(size)
-		// If the limit is non-zero, we must first check that size can be reserved.
-		if maxBufferedBytes > 0 && newVal > maxBufferedBytes {
+		if !ts.permittedMaxBufferedBytes(newVal) {
 			return false
 		}
 		// If we won the CAS, size was reserved, and we can return true.
@@ -508,6 +506,17 @@ func (ts *TeeService) reserveBufferedBytes(size int) bool {
 			return true
 		}
 	}
+}
+
+// permittedMaxBufferedBytes returns true if the new value is less than
+// [TeeConfig.maxBufferedBytes].
+func (ts *TeeService) permittedMaxBufferedBytes(newVal int64) bool {
+	maxBufferedBytes := int64(ts.cfg.TeeConfig.MaxBufferedBytes)
+	if maxBufferedBytes <= 0 {
+		// When zero or negative, the limit is disabled.
+		return true
+	}
+	return newVal <= maxBufferedBytes
 }
 
 // releaseBufferedBytes returns size bytes of reserved capacity to the tee.


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor of tee buffering limit enforcement; behavior change is limited to treating negative `MaxBufferedBytes` values as disabling the limit, which could increase buffering if misconfigured.
> 
> **Overview**
> Refactors `TeeService.reserveBufferedBytes` to centralize max-buffered-bytes enforcement in a new `permittedMaxBufferedBytes` helper.
> 
> Also changes the semantics of `TeeConfig.MaxBufferedBytes` so **zero *or negative*** values disable the buffering limit (previously only zero), updating the inline documentation accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6264ab19c62838f32d0a78ed85d892913b70358. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->