### PR TITLE
chore: Use a mutex, don't be clever

### DIFF
--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"strings"
 	"sync"
-	"sync/atomic" //lint:ignore faillint we use new atomic types from sync/atomic.
 	"time"
 
 	"github.com/go-kit/log"
@@ -90,7 +89,8 @@ type TeeService struct {
 
 	// bufferedBytes is a count of the total number of bytes in buf, and all
 	// client requests in the flushQueue.
-	bufferedBytes atomic.Int64
+	bufferedBytes    int64
+	bufferedBytesMtx sync.Mutex
 
 	metrics *teeMetrics
 }
@@ -495,19 +495,19 @@ func (ts *TeeService) Duplicate(_ context.Context, tenant string, streams []dist
 // It is safe for concurrent use.
 func (ts *TeeService) reserveBufferedBytes(size int) bool {
 	maxBufferedBytes := int64(ts.cfg.TeeConfig.MaxBufferedBytes)
-	for {
-		oldVal := ts.bufferedBytes.Load()
-		newVal := oldVal + int64(size)
-		// If the limit is non-zero, we must first check that size can be reserved.
-		if maxBufferedBytes > 0 && newVal > maxBufferedBytes {
-			return false
-		}
-		// If we won the CAS, size was reserved, and we can return true.
-		if ts.bufferedBytes.CompareAndSwap(oldVal, newVal) {
-			ts.metrics.bufferedBytes.Observe(float64(newVal))
-			return true
-		}
+
+	ts.bufferedBytesMtx.Lock()
+	newVal := ts.bufferedBytes + int64(size)
+	if maxBufferedBytes > 0 && newVal > maxBufferedBytes {
+		ts.bufferedBytesMtx.Unlock()
+		return false
 	}
+
+	ts.bufferedBytes = newVal
+	ts.bufferedBytesMtx.Unlock()
+
+	ts.metrics.bufferedBytes.Observe(float64(newVal))
+	return true
 }
 
 // releaseBufferedBytes returns size bytes of reserved capacity to the tee.
@@ -516,7 +516,15 @@ func (ts *TeeService) reserveBufferedBytes(size int) bool {
 //
 // It is safe for concurrent use.
 func (ts *TeeService) releaseBufferedBytes(size int) {
-	_ = ts.bufferedBytes.Add(-int64(size))
+	ts.bufferedBytesMtx.Lock()
+	newVal := ts.bufferedBytes - int64(size)
+	if newVal < 0 {
+		ts.bufferedBytesMtx.Unlock()
+		panic("bufferedBytes: released more than reserved")
+	}
+
+	ts.bufferedBytes = newVal
+	ts.bufferedBytesMtx.Unlock()
 }
 
 func (ts *TeeService) Register(_ context.Context, _ string, _ []distributor.KeyedStream, _ *distributor.PushTracker) {

--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -517,14 +517,8 @@ func (ts *TeeService) reserveBufferedBytes(size int) bool {
 // It is safe for concurrent use.
 func (ts *TeeService) releaseBufferedBytes(size int) {
 	ts.bufferedBytesMtx.Lock()
-	newVal := ts.bufferedBytes - int64(size)
-	if newVal < 0 {
-		ts.bufferedBytesMtx.Unlock()
-		panic("bufferedBytes: released more than reserved")
-	}
-
-	ts.bufferedBytes = newVal
-	ts.bufferedBytesMtx.Unlock()
+	defer ts.bufferedBytesMtx.Unlock()
+	ts.bufferedBytes -= int64(size)
 }
 
 func (ts *TeeService) Register(_ context.Context, _ string, _ []distributor.KeyedStream, _ *distributor.PushTracker) {

--- a/pkg/pattern/tee_service_test.go
+++ b/pkg/pattern/tee_service_test.go
@@ -206,12 +206,12 @@ func TestPatternTee_MaxBufferedBytes(t *testing.T) {
 
 		tee.cfg.TeeConfig.MaxBufferedBytes = 0
 		tee.Duplicate(ctx, "test", []distributor.KeyedStream{s1}, nil)
-		bufferedBytes1 := tee.bufferedBytes.Load()
+		bufferedBytes1 := tee.bufferedBytes
 		require.NotZero(t, bufferedBytes1)
 
 		tee.cfg.TeeConfig.MaxBufferedBytes = -1
 		tee.Duplicate(ctx, "test", []distributor.KeyedStream{s1}, nil)
-		bufferedBytes2 := tee.bufferedBytes.Load()
+		bufferedBytes2 := tee.bufferedBytes
 		require.Greater(t, bufferedBytes2, bufferedBytes1)
 	})
 
@@ -234,7 +234,7 @@ func TestPatternTee_MaxBufferedBytes(t *testing.T) {
 		}
 		require.LessOrEqual(t, s1.Stream.Size(), 1024)
 		tee.Duplicate(ctx, "test", []distributor.KeyedStream{s1}, nil)
-		bufferedBytes1 := tee.bufferedBytes.Load()
+		bufferedBytes1 := tee.bufferedBytes
 		require.NotZero(t, bufferedBytes1)
 		require.Len(t, tee.buf, 1)
 		tenantBuf, ok := tee.buf["test"]
@@ -254,7 +254,7 @@ func TestPatternTee_MaxBufferedBytes(t *testing.T) {
 		}
 		require.Greater(t, s2.Stream.Size(), 1024)
 		tee.Duplicate(ctx, "test", []distributor.KeyedStream{s2}, nil)
-		bufferedBytes2 := tee.bufferedBytes.Load()
+		bufferedBytes2 := tee.bufferedBytes
 		require.Equal(t, bufferedBytes2, bufferedBytes1)
 		require.Len(t, tee.buf, 1)
 		// tenantBuf should contain s1, but not s2.
@@ -274,7 +274,7 @@ func TestPatternTee_MaxBufferedBytes(t *testing.T) {
 			},
 		}
 		tee.Duplicate(ctx, "test", []distributor.KeyedStream{s3}, nil)
-		bufferedBytes3 := tee.bufferedBytes.Load()
+		bufferedBytes3 := tee.bufferedBytes
 		require.Greater(t, bufferedBytes3, bufferedBytes2)
 		require.Len(t, tee.buf, 1)
 		// tenantBuf should contain s1 and s3.
@@ -296,7 +296,7 @@ func TestPatternTee_MaxBufferedBytes(t *testing.T) {
 		}
 		tee.Duplicate(ctx, "test", []distributor.KeyedStream{s4}, nil)
 		// The total size of s4 is less than s1 and s3, but not 0.
-		bufferedBytes4 := tee.bufferedBytes.Load()
+		bufferedBytes4 := tee.bufferedBytes
 		require.Equal(t, bufferedBytes4, bufferedBytes3)
 		require.Len(t, tee.buf, 1)
 		// tenantBuf should contain s1 and s3.
@@ -315,7 +315,7 @@ func TestPatternTee_MaxBufferedBytes(t *testing.T) {
 		}
 		tee.Duplicate(ctx, "test", []distributor.KeyedStream{s4}, nil)
 		// The total size of s4 is less than s1 and s3, but not 0.
-		bufferedBytes5 := tee.bufferedBytes.Load()
+		bufferedBytes5 := tee.bufferedBytes
 		require.Less(t, bufferedBytes5, bufferedBytes4)
 		require.NotZero(t, bufferedBytes5)
 		require.Len(t, tee.buf, 1)


### PR DESCRIPTION
**What this PR does / why we need it**:

I did some more research here, and under high contention, it sounds like the CAS version is less effective then a mutex.

First, it can burn CPU under high contention as it is effectively a spin-lock; second, it requires exclusive access to the cache, which means all other cores need to reload the cache line on losing the CAS round; and third, `sync.Mutex` uses a similar `CompareAndSwap` loop, but after 4 failed attempts, parks the goroutine to allow other goroutines to run, instead of spinning and burning CPU time.

The reason for not using `golang.org/x/sync/semaphore` is you don't know the value of the semaphore, which makes it impossible to update the metric without also storing the value behind an atomic.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrency control in `TeeService`’s buffering limit enforcement; mistakes could cause incorrect limit behavior or contention-related performance regressions under load.
> 
> **Overview**
> Switches `TeeService` buffered-byte tracking from an `atomic.Int64` CAS loop to a `sync.Mutex`-guarded `int64`, adjusting `reserveBufferedBytes`/`releaseBufferedBytes` to lock around updates while preserving the max-buffered-bytes check and metric observation.
> 
> Updates `tee_service_test.go` assertions to read the new `bufferedBytes` field directly and drops the `sync/atomic` import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79e69cf548d13dfbeff6134a688e12622f95657d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->