### PR TITLE
fix(otlp): Skip empty values when discovering service_name from resource attributes

### DIFF
--- a/pkg/loghttp/push/otlp_test.go
+++ b/pkg/loghttp/push/otlp_test.go
@@ -62,6 +62,7 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 		expectedPushRequest logproto.PushRequest
 		expectedStats       Stats
 		otlpConfig          OTLPConfig
+		discoverServiceName []string
 	}{
 		{
 			name: "no logs",
@@ -225,6 +226,58 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 					},
 				},
 				StreamLabelsSize:                  47,
+				MostRecentEntryTimestamp:          now,
+				StreamSizeBytes:                   map[string]int64{},
+				MostRecentEntryTimestampPerStream: map[string]time.Time{},
+			},
+		},
+		{
+			name:       "service.name not defined and discovery candidate is empty",
+			otlpConfig: DefaultOTLPConfig(defaultGlobalOTLPConfig),
+			discoverServiceName: []string{
+				"container_name",
+			},
+			generateLogs: func() plog.Logs {
+				ld := plog.NewLogs()
+				ld.ResourceLogs().AppendEmpty().Resource().Attributes().PutStr("container.name", "")
+				ld.ResourceLogs().At(0).ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("test body")
+				ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).SetTimestamp(pcommon.Timestamp(now.UnixNano()))
+				return ld
+			},
+			expectedPushRequest: logproto.PushRequest{
+				Streams: []logproto.Stream{
+					{
+						Labels: `{container_name="", service_name="unknown_service"}`,
+						Entries: []logproto.Entry{
+							{
+								Timestamp:          now,
+								Line:               "test body",
+								StructuredMetadata: push.LabelsAdapter{},
+							},
+						},
+					},
+				},
+			},
+			expectedStats: Stats{
+				PolicyNumLines: map[string]int64{
+					"others": 1,
+				},
+				LogLinesBytes: PolicyWithRetentionWithBytes{
+					"others": {
+						time.Hour: 9,
+					},
+				},
+				StructuredMetadataBytes: PolicyWithRetentionWithBytes{
+					"others": {
+						time.Hour: 0,
+					},
+				},
+				ResourceAndSourceMetadataLabels: map[string]map[time.Duration]push.LabelsAdapter{
+					"others": {
+						time.Hour: nil,
+					},
+				},
+				StreamLabelsSize:                  41,
 				MostRecentEntryTimestamp:          now,
 				StreamSizeBytes:                   map[string]int64{},
 				MostRecentEntryTimestampPerStream: map[string]time.Time{},
@@ -587,6 +640,11 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			discoverServiceName := defaultServiceDetection
+			if tc.discoverServiceName != nil {
+				discoverServiceName = tc.discoverServiceName
+			}
+
 			stats := NewPushStats()
 			tracker := NewMockTracker()
 			streamResolver := newMockStreamResolver("fake", &fakeLimits{})
@@ -603,7 +661,7 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 				"foo",
 				tc.otlpConfig,
 				nil,
-				defaultServiceDetection,
+				discoverServiceName,
 				tracker,
 				stats,
 				log.NewNopLogger(),

--- a/pkg/loghttp/push/otlplabels/labels.go
+++ b/pkg/loghttp/push/otlplabels/labels.go
@@ -128,16 +128,6 @@ func ResourceAttrsToStreamLabels(attrs pcommon.Map, otlpConfig OTLPConfig, disco
 		if action == IndexLabel {
 			for _, lbl := range attributeAsLabels {
 				result.StreamLabels[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
-
-				if !hasServiceName && shouldDiscoverServiceName {
-					for _, labelName := range discoverServiceName {
-						if lbl.Name == labelName {
-							result.StreamLabels[model.LabelName(LabelServiceName)] = model.LabelValue(lbl.Value)
-							hasServiceName = true
-							break
-						}
-					}
-				}
 			}
 		} else if action == StructuredMetadata {
 			result.StructuredMetadata = append(result.StructuredMetadata, attributeAsLabels...)
@@ -147,6 +137,16 @@ func ResourceAttrsToStreamLabels(attrs pcommon.Map, otlpConfig OTLPConfig, disco
 	})
 	if rangeErr != nil {
 		return nil, rangeErr
+	}
+
+	if !hasServiceName && shouldDiscoverServiceName {
+		for _, labelName := range discoverServiceName {
+			if v, ok := result.StreamLabels[model.LabelName(labelName)]; ok && v != "" {
+				result.StreamLabels[model.LabelName(LabelServiceName)] = v
+				hasServiceName = true
+				break
+			}
+		}
 	}
 
 	if !hasServiceName && shouldDiscoverServiceName {

--- a/pkg/loghttp/push/otlplabels/labels_test.go
+++ b/pkg/loghttp/push/otlplabels/labels_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"testing"
 
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
@@ -115,6 +116,122 @@ func TestAttributesToLabels(t *testing.T) {
 			lbls, err := attributesToLabels(tc.buildAttrs(), "")
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedResp, lbls)
+		})
+	}
+}
+
+func TestResourceAttrsToStreamLabels_ServiceNameDiscovery(t *testing.T) {
+	type resourceAttribute struct {
+		key   string
+		value string
+	}
+
+	buildAttrs := func(attributes ...resourceAttribute) pcommon.Map {
+		attrs := pcommon.NewMap()
+		for _, attribute := range attributes {
+			attrs.PutStr(attribute.key, attribute.value)
+		}
+
+		return attrs
+	}
+
+	otlpConfig := OTLPConfig{
+		ResourceAttributes: ResourceAttributesConfig{
+			IgnoreDefaults: true,
+			AttributesConfig: []AttributesConfig{
+				{
+					Action: IndexLabel,
+					Attributes: []string{
+						AttrServiceName,
+						"container.name",
+						"k8s.pod.name",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range []struct {
+		name                string
+		discoverServiceName []string
+		buildAttrs          func(iteration int) pcommon.Map
+		expectedServiceName string
+		iterations          int
+	}{
+		{
+			name:                "service.name absent and only discovery candidate is empty",
+			discoverServiceName: []string{"container_name"},
+			buildAttrs: func(_ int) pcommon.Map {
+				return buildAttrs(resourceAttribute{key: "container.name", value: ""})
+			},
+			expectedServiceName: ServiceUnknown,
+		},
+		{
+			name:                "service.name absent and second discovery candidate is non-empty",
+			discoverServiceName: []string{"container_name", "k8s_pod_name"},
+			buildAttrs: func(_ int) pcommon.Map {
+				return buildAttrs(
+					resourceAttribute{key: "container.name", value: ""},
+					resourceAttribute{key: "k8s.pod.name", value: "api-7d"},
+				)
+			},
+			expectedServiceName: "api-7d",
+		},
+		{
+			name:                "service.name empty and discovery candidates empty",
+			discoverServiceName: []string{"container_name", "k8s_pod_name"},
+			buildAttrs: func(_ int) pcommon.Map {
+				return buildAttrs(
+					resourceAttribute{key: AttrServiceName, value: ""},
+					resourceAttribute{key: "container.name", value: ""},
+					resourceAttribute{key: "k8s.pod.name", value: ""},
+				)
+			},
+			expectedServiceName: ServiceUnknown,
+		},
+		{
+			name:                "first configured discovery candidate wins regardless of attribute insertion order",
+			discoverServiceName: []string{"container_name", "k8s_pod_name"},
+			buildAttrs: func(iteration int) pcommon.Map {
+				if iteration%2 == 0 {
+					return buildAttrs(
+						resourceAttribute{key: "container.name", value: "container-win"},
+						resourceAttribute{key: "k8s.pod.name", value: "pod-second"},
+					)
+				}
+
+				return buildAttrs(
+					resourceAttribute{key: "k8s.pod.name", value: "pod-first"},
+					resourceAttribute{key: "container.name", value: "container-win"},
+				)
+			},
+			expectedServiceName: "container-win",
+			iterations:          50,
+		},
+		{
+			name:                "explicit service.name overrides discovery candidates",
+			discoverServiceName: []string{"container_name", "k8s_pod_name"},
+			buildAttrs: func(_ int) pcommon.Map {
+				return buildAttrs(
+					resourceAttribute{key: AttrServiceName, value: "svc"},
+					resourceAttribute{key: "container.name", value: "container"},
+					resourceAttribute{key: "k8s.pod.name", value: "pod"},
+				)
+			},
+			expectedServiceName: "svc",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			iterations := tc.iterations
+			if iterations == 0 {
+				iterations = 1
+			}
+
+			for i := 0; i < iterations; i++ {
+				result, err := ResourceAttrsToStreamLabels(tc.buildAttrs(i), otlpConfig, tc.discoverServiceName)
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedServiceName, string(result.StreamLabels[model.LabelName(LabelServiceName)]))
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`ResourceAttrsToStreamLabels` in `pkg/loghttp/push/otlplabels/labels.go` halts the `discoverServiceName` cascade as soon as an indexed resource attribute matches a configured name, even when its value is the empty string. Combined with `pcommon.Map.Range`'s unspecified iteration order, this produces two bugs:

- `service_name` is silently set to `""`, bypassing the `unknown_service` fallback and any later non-empty candidate.
- Which empty/non-empty candidate "wins" is nondeterministic across requests with identical attributes.

The explicit `service.name` branch in the same function already treats `""` as missing, and the non-OTLP path in `pkg/loghttp/push/push.go:443-451` already iterates `discoverServiceName` in config order while skipping empty values. This PR brings the OTLP path in line with that contract.

**Changes**

- Move the `discoverServiceName` cascade out of the `attrs.Range` loop in `ResourceAttrsToStreamLabels` and run it after all resource attributes have been collected into `result.StreamLabels`.
- Walk `discoverServiceName` in declared order and pick the first candidate whose stream-label value is non-empty.
- Preserve existing behavior: explicit `service.name=""` is still treated as missing, and `unknown_service` is still used when no candidate matches.
- Add unit tests in `pkg/loghttp/push/otlplabels/labels_test.go` covering: empty-only candidate, second-candidate-wins, all-empty cascade, configured priority over attribute insertion order (looped to defeat map iteration nondeterminism), and explicit `service.name` precedence.
- Add an end-to-end case in `pkg/loghttp/push/otlp_test.go` asserting that an empty discovery candidate falls through to `service_name=\"unknown_service\"` via `otlpToLokiPushRequest`.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

No config, API, or metric surface changes. `StructuredMetadata`, `Drop`, and error paths are untouched. The fix is intentionally narrow and mirrors the existing non-OTLP discovery logic.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `service_name` is derived for OTLP resource attributes, which can alter stream labels/policy routing and affect stream cardinality for some tenants. Logic is small and covered by new unit/integration tests, but impacts label generation on ingestion paths.
> 
> **Overview**
> Fixes OTLP resource `service_name` discovery so it **no longer stops on an empty candidate value** and instead selects the first *non-empty* discovery candidate in declared `discoverServiceName` order after all resource labels are collected, falling back to `unknown_service` when none match.
> 
> Adds targeted test coverage: a new end-to-end `otlpToLokiPushRequest` case for empty discovery candidates, and unit tests ensuring deterministic candidate priority (independent of attribute iteration order) plus `service.name` precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f53ab6a5dfe78f8c9cc48402223dff9f6a21c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->