### PR TITLE
chore: Release GEL Helm chart 7.1.0

### DIFF
--- a/docs/sources/setup/install/helm/reference.md
+++ b/docs/sources/setup/install/helm/reference.md
@@ -4027,7 +4027,7 @@ null
     "pullPolicy": "IfNotPresent",
     "registry": "docker.io",
     "repository": "grafana/enterprise-logs",
-    "tag": "3.6.6"
+    "tag": "3.6.8"
   },
   "license": {
     "contents": "NOTAVALIDLICENSE"
@@ -4063,7 +4063,7 @@ null
     "tolerations": []
   },
   "useExternalLicense": false,
-  "version": "3.6.6"
+  "version": "3.6.8"
 }
 </pre>
 </td>
@@ -4174,7 +4174,7 @@ null
 			<td>string</td>
 			<td>Docker image tag</td>
 			<td><pre lang="json">
-"3.6.6"
+"3.6.8"
 </pre>
 </td>
 		</tr>
@@ -7197,7 +7197,7 @@ null
 			<td>string</td>
 			<td>Overrides the image tag whose default is the chart's appVersion</td>
 			<td><pre lang="json">
-"3.6.7"
+"3.6.8"
 </pre>
 </td>
 		</tr>

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,12 +13,16 @@ Entries should include a reference to the pull request that introduced the chang
 
 ## Unreleased
 
+## 7.1.0
+
+- [CHANGE] Changed version of Grafana Enterprise Logs to 3.6.8 (updated `enterprise.version`, and `enterprise.image.tag`).
+- [CHANGE] Updated the README to indicate that this chart is the Grafana Enterprise Logs Helm chart.
 
 ## 7.0.0
 
 - [BREAKING] The chart in this repository is now maintained for Grafana Enterprise Logs (GEL) users only. As of March 16, 2026, the Grafana Loki Helm chart for OSS users has moved to [grafana-community/helm-charts](https://github.com/grafana-community/helm-charts) (forked at chart version 6.55.0). OSS users are encouraged to migrate to the community-maintained chart.  That community chart is *not* the supported installation path for GEL as the Community chart has [removed support for GEL](https://github.com/grafana-community/helm-charts/pull/184).  See [#20705](https://github.com/grafana/loki/issues/20705) for details.
 - [CHANGE] Swap bundled minio subchart images from `minio/minio` to the Pigsty (`pgsty`) community fork (`docker.io/pgsty/minio:RELEASE.2026-03-14T12-00-00Z`, `docker.io/pgsty/mc:RELEASE.2026-03-13T08-57-32Z`) to mitigate an unresolved upstream MinIO CVE.
-- [CHANGE] Changed GEL version to 3.6.6 (updated `enterprise.version`, `enterprise.image.tag`, and chart `appVersion`).
+- [CHANGE] Changed GEL version to 3.6.6 (updated `enterprise.version`, and `enterprise.image.tag`).
 - [FEATURE] Update README chart migration notice from future tense to past tense
 
 ## 6.55.0

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: loki
-description: Helm chart for Grafana Loki and Grafana Enterprise Logs supporting monolithic, simple scalable, and microservices modes.
+description: Helm chart for Grafana Enterprise Logs supporting monolithic, simple scalable, and microservices modes.
 type: application
-appVersion: 3.6.7
-version: 7.0.0
+appVersion: 3.6.8
+version: 7.1.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,8 +1,8 @@
 # loki
 
-![Version: 7.0.0](https://img.shields.io/badge/Version-7.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.7](https://img.shields.io/badge/AppVersion-3.6.7-informational?style=flat-square)
+![Version: 7.1.0](https://img.shields.io/badge/Version-7.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.8](https://img.shields.io/badge/AppVersion-3.6.8-informational?style=flat-square)
 
-Helm chart for Grafana Loki and Grafana Enterprise Logs supporting monolithic, simple scalable, and microservices modes.
+Helm chart for Grafana Enterprise Logs supporting monolithic, simple scalable, and microservices modes.
 
 ## ⚠️ Helm Chart Migration
 As of March 16, 2026, the Grafana Loki Helm chart for OSS users has moved to [grafana-community/helm-charts](https://github.com/grafana-community/helm-charts) (forked at chart version 6.55.0). OSS users are encouraged to migrate to the community-maintained chart. The chart in this repository is now maintained for Grafana Enterprise Logs (GEL) users only. See [#20705](https://github.com/grafana/loki/issues/20705) for details.

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -88,7 +88,7 @@ loki:
     # -- Docker image repository
     repository: grafana/loki
     # -- Overrides the image tag whose default is the chart's appVersion
-    tag: 3.6.7
+    tag: 3.6.8
     # -- Overrides the image tag with an image digest
     digest: null
     # -- Docker image pull policy
@@ -634,7 +634,7 @@ enterprise:
   # `enterprise.license.contents` or `enterprise.useExternalLicense`/`enterprise.externalLicenseName`.
   enabled: false
   # Default version of GEL to deploy
-  version: 3.6.6
+  version: 3.6.8
   # -- Optional name of the GEL cluster, otherwise will use .Release.Name
   # The cluster name must match what is in your GEL license
   cluster_name: null
@@ -676,7 +676,7 @@ enterprise:
     # -- Docker image repository
     repository: grafana/enterprise-logs
     # -- Docker image tag
-    tag: 3.6.6
+    tag: 3.6.8
     # -- Overrides the image tag with an image digest
     digest: null
     # -- Docker image pull policy


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Helm Charts for GEL release.

**Special notes for your reviewer**:

Manual update of Helm Charts files for GEL release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Version bumps change the default container images deployed (`loki`/`enterprise-logs` to 3.6.8), which can introduce runtime/compatibility differences during upgrades. Other changes are documentation/metadata only.
> 
> **Overview**
> Releases Helm chart `7.1.0` by updating chart metadata (`Chart.yaml`, README badges) and changelog, and clarifying that this chart targets **Grafana Enterprise Logs only**.
> 
> Updates default image versions to `3.6.8` across the chart: chart `appVersion`, `values.yaml` (`loki.image.tag`, `enterprise.version`, `enterprise.image.tag`), and the rendered Helm values reference docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 948201dba978b774540b9cfc635772621c607e7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->