### PR TITLE
ci: Update issue templates to remove Promtail

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,7 @@ A clear and concise description of what the bug is.
 **To Reproduce**
 Steps to reproduce the behavior:
 1. Started Loki (SHA or version)
-2. Started Promtail (SHA or version) to tail '...'
+2. Started Alloy (SHA or version) to tail '...'
 3. Query: `{} term`
 
 **Expected behavior**
@@ -25,5 +25,5 @@ A clear and concise description of what you expected to happen.
  - Infrastructure: [e.g., Kubernetes, bare-metal, laptop]
  - Deployment tool: [e.g., helm, jsonnet]
 
-**Screenshots, Promtail config, or terminal output**
+**Screenshots, Alloy config, or terminal output**
 If applicable, add any output to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/helm_issue.md
+++ b/.github/ISSUE_TEMPLATE/helm_issue.md
@@ -122,6 +122,6 @@ body:
         - Kubernetes cluster details (version, provider)
         - Storage backend being used (filesystem, S3, GCS, Azure, etc.)
         - Log volume or specific error messages
-        - Related components (Grafana, Alloy, Promtail, etc.)
+        - Related components (Grafana, Alloy, Collector, etc.)
     validations:
       required: false


### PR DESCRIPTION
**What this PR does / why we need it**:

While doing issue triage today I noticed that our issue templates still reference Promtail.  So I updated them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change limited to GitHub issue templates; no product code or runtime behavior is affected.
> 
> **Overview**
> Updates GitHub issue templates to stop asking reporters for Promtail details.
> 
> The bug report template now references `Alloy` for log tailing and requests `Alloy` config/output, and the Helm issue template’s “related components” examples replace `Promtail` with `Collector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 634d263e7f271e46a642c2cba0a1cc1d639dcdc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->