### PR TITLE
fix gateway nginx log format

### DIFF
--- a/production/docker/config/nginx.conf
+++ b/production/docker/config/nginx.conf
@@ -8,8 +8,8 @@ events {
 
 http {
   default_type application/octet-stream;
-  log_format   main '$remote_addr - $remote_user [$time_local]  $status '
-    '"$request" $body_bytes_sent "$http_referer" '
+  log_format   main '$remote_addr - $remote_user [$time_local] "$request" '
+    '$status $body_bytes_sent "$http_referer" '
     '"$http_user_agent" "$http_x_forwarded_for"';
   access_log   /dev/stderr  main;
   sendfile     on;

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1254,8 +1254,8 @@ gateway:
     enableIPv6: true
     # -- NGINX log format
     logFormat: |-
-      main '$remote_addr - $remote_user [$time_local]  $status '
-              '"$request" $body_bytes_sent "$http_referer" '
+      main '$remote_addr - $remote_user [$time_local] "$request" '
+              '$status $body_bytes_sent "$http_referer" '
               '"$http_user_agent" "$http_x_forwarded_for"';
     # -- Allows appending custom configuration to the server block
     serverSnippet: ""


### PR DESCRIPTION
## Summary
- align the loki-gateway nginx access log format with nginx combined-style field ordering
- remove the double space before the request field in both Docker and Helm defaults

Fixes #18788

## Testing
- python3 YAML parse for production/helm/loki/values.yaml
- git diff --check

Note: nginx container validation could not be run locally because the Docker daemon is not running on this machine.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes NGINX access log `log_format` string ordering/spacing in gateway defaults, affecting log parsing but not request routing or auth.
> 
> **Overview**
> Updates the Loki gateway NGINX `log_format` in both the Docker `nginx.conf` and Helm `values.yaml` defaults to match combined-style field ordering, moving `$status` after `"$request"` and removing an extra space before the request field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e27470214734d33cea98be1ba52d4bdf863c5d34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->