### PR TITLE
chore: Reduce allocs in range agg node

### DIFF
--- a/pkg/engine/internal/executor/pipeline_utils.go
+++ b/pkg/engine/internal/executor/pipeline_utils.go
@@ -37,6 +37,13 @@ func (p *BufferedPipeline) Read(_ context.Context) (arrow.RecordBatch, error) {
 	return p.records[p.current], nil
 }
 
+// Reset rewinds the pipeline so the next Read returns the first record again.
+// Records are not released; the caller must still call Close when done.
+// Primarily used for testing.
+func (p *BufferedPipeline) Reset() {
+	p.current = -1
+}
+
 // Close implements Pipeline. It releases all unreturned records.
 func (p *BufferedPipeline) Close() {
 	p.records = nil

--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"sort"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -31,16 +30,14 @@ type rangeAggregationOptions struct {
 	maxQuerySeries int // maximum number of unique series allowed
 }
 
-var (
-	// rangeAggregationOperations holds the mapping of range aggregation types to operations for an aggregator.
-	rangeAggregationOperations = map[types.RangeAggregationType]aggregationOperation{
-		types.RangeAggregationTypeSum:   aggregationOperationSum,
-		types.RangeAggregationTypeCount: aggregationOperationCount,
-		types.RangeAggregationTypeMax:   aggregationOperationMax,
-		types.RangeAggregationTypeMin:   aggregationOperationMin,
-		types.RangeAggregationTypeAvg:   aggregationOperationAvg,
-	}
-)
+// rangeAggregationOperations holds the mapping of range aggregation types to operations for an aggregator.
+var rangeAggregationOperations = map[types.RangeAggregationType]aggregationOperation{
+	types.RangeAggregationTypeSum:   aggregationOperationSum,
+	types.RangeAggregationTypeCount: aggregationOperationCount,
+	types.RangeAggregationTypeMax:   aggregationOperationMax,
+	types.RangeAggregationTypeMin:   aggregationOperationMin,
+	types.RangeAggregationTypeAvg:   aggregationOperationAvg,
+}
 
 // window is a time interval where start is exclusive and end is inclusive
 // Refer to [logql.batchRangeVectorIterator].
@@ -52,6 +49,16 @@ type window struct {
 // The window start is exclusive, the window end is inclusive.
 func (w window) Contains(t time.Time) bool {
 	return t.After(w.start) && !t.After(w.end)
+}
+
+// cmpWindowStartTime compares a window's lower bound to t for [slices.BinarySearchFunc].
+func cmpWindowStartTime(w window, t time.Time) int {
+	return w.start.Compare(t)
+}
+
+// cmpWindowEndTime compares a window's upper bound to t for [slices.BinarySearchFunc].
+func cmpWindowEndTime(w window, t time.Time) int {
+	return w.end.Compare(t)
 }
 
 // timestampMatchingWindowsFunc resolves matching range interval windows for a specific timestamp.
@@ -385,28 +392,24 @@ func (f *matcherFactory) createOverlappingMatcher(windows []window) timestampMat
 		}
 
 		// Find the last window that could contain the timestamp.
-		// We need to find the last window where t > window.startTs
-		// so search for the first window where t <= window.startTs
-		firstOOBIndex := sort.Search(len(windows), func(i int) bool {
-			return t.Compare(windows[i].start) <= 0
-		})
+		// We need the last window where t > window.start, i.e. the index before
+		// the first window where t <= window.start. Use BinarySearchFunc with a
+		// package-level cmp so we do not allocate a closure per call (unlike sort.Search).
+		firstOOBIndex, _ := slices.BinarySearchFunc(windows, t, cmpWindowStartTime)
 
 		windowIndex := firstOOBIndex - 1
 		if windowIndex < 0 {
 			return nil
 		}
 
-		// Iterate backwards from last matching window to find all matches
-		var result []window
-		for _, window := range slices.Backward(windows[:windowIndex+1]) {
-			if t.Compare(window.start) > 0 && t.Compare(window.end) <= 0 {
-				result = append(result, window)
-			} else if t.Compare(window.end) > 0 {
-				// we've gone past all possible matches
-				break
-			}
+		// For every i in [0, windowIndex], t > windows[i].start (by definition of windowIndex).
+		// Containment is therefore equivalent to t <= windows[i].end. Ends are non-decreasing
+		// in i, so matching indices are always a suffix [low, windowIndex] of that prefix.
+		prefix := windows[:windowIndex+1]
+		low, _ := slices.BinarySearchFunc(prefix, t, cmpWindowEndTime)
+		if low > windowIndex {
+			return nil
 		}
-
-		return result
+		return windows[low : windowIndex+1]
 	}
 }

--- a/pkg/engine/internal/executor/range_aggregation_bench_test.go
+++ b/pkg/engine/internal/executor/range_aggregation_bench_test.go
@@ -158,21 +158,6 @@ func buildRangeAggregationGrouping() physical.Grouping {
 	}
 }
 
-// benchmarkRangeAggregationWindows builds query windows the same way as rangeAggregationPipeline.init.
-func benchmarkRangeAggregationWindows(opts rangeAggregationOptions) []window {
-	windows := []window{}
-	cur := opts.startTs
-	endUnix := opts.endTs.UnixNano()
-	for cur.UnixNano() <= endUnix {
-		windows = append(windows, window{start: cur.Add(-opts.rangeInterval), end: cur})
-		if opts.step == 0 {
-			break
-		}
-		cur = cur.Add(opts.step)
-	}
-	return windows
-}
-
 func buildRangeAggregationInput() (*arrow.Schema, []arrowtest.Rows) {
 	fields := []arrow.Field{
 		semconv.FieldFromFQN(colTs, false),
@@ -193,7 +178,7 @@ func buildRangeAggregationInput() (*arrow.Schema, []arrowtest.Rows) {
 		for i := range rowsPerBatch {
 			offset := batch*rowsPerBatch + i
 			batchRows[i] = arrowtest.Row{
-				colTs:  base.Add(time.Duration(offset%28) * time.Second),
+				colTs:  base.Add(time.Duration(offset) * time.Second),
 				colEnv: []string{"prod", "dev", "staging"}[offset%3],
 				colSvc: []string{"app1", "app2", "app3", "app4"}[offset%4],
 			}

--- a/pkg/engine/internal/executor/range_aggregation_bench_test.go
+++ b/pkg/engine/internal/executor/range_aggregation_bench_test.go
@@ -1,0 +1,205 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/assertions"
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/semconv"
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+	"github.com/grafana/loki/v3/pkg/util/arrowtest"
+)
+
+// BenchmarkRangeAggregationPipeline measures pipeline.Read for each window strategy.
+// The pipeline and input batches are built once per subbenchmark; each iteration only
+// resets cursors and aggregator state so Read can run again.
+func BenchmarkRangeAggregationPipeline(b *testing.B) {
+	old := assertions.Enabled
+	assertions.Enabled = false
+	b.Cleanup(func() { assertions.Enabled = old })
+
+	groupBy := buildRangeAggregationGrouping()
+	schema, rows := buildRangeAggregationInput()
+	inputRecords := buildInputRecords(b, schema, rows)
+	b.Cleanup(func() {
+		for _, rec := range inputRecords {
+			rec.Release()
+		}
+	})
+
+	cases := []struct {
+		name string
+		opts rangeAggregationOptions
+	}{
+		{
+			name: "case=instant",
+			opts: rangeAggregationOptions{
+				grouping:      groupBy,
+				startTs:       time.Unix(1000, 0),
+				endTs:         time.Unix(1000, 0),
+				rangeInterval: 1000 * time.Second,
+				step:          0,
+				operation:     types.RangeAggregationTypeCount,
+			},
+		},
+		{
+			name: "case=aligned",
+			opts: rangeAggregationOptions{
+				grouping:      groupBy,
+				startTs:       time.Unix(10, 0),
+				endTs:         time.Unix(40, 0),
+				rangeInterval: 10 * time.Second,
+				step:          10 * time.Second,
+				operation:     types.RangeAggregationTypeCount,
+			},
+		},
+		{
+			name: "case=gapped",
+			opts: rangeAggregationOptions{
+				grouping:      groupBy,
+				startTs:       time.Unix(10, 0),
+				endTs:         time.Unix(40, 0),
+				rangeInterval: 5 * time.Second,
+				step:          10 * time.Second,
+				operation:     types.RangeAggregationTypeCount,
+			},
+		},
+		{
+			name: "case=overlapping",
+			opts: rangeAggregationOptions{
+				grouping:      groupBy,
+				startTs:       time.Unix(10, 0),
+				endTs:         time.Unix(40, 0),
+				rangeInterval: 5 * time.Minute,
+				step:          10 * time.Second,
+				operation:     types.RangeAggregationTypeCount,
+			},
+		},
+	}
+
+	ctx := context.Background()
+	evaluator := newExpressionEvaluator()
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			input := NewBufferedPipeline(inputRecords...)
+			pipeline, err := newRangeAggregationPipeline([]Pipeline{input}, evaluator, tc.opts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if err := pipeline.Open(ctx); err != nil {
+				b.Fatal(err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				// Read all the records each iteration
+				for {
+					rec, err := pipeline.Read(ctx)
+					if err != nil {
+						if errors.Is(err, EOF) {
+							resetRangeAggregationPipeline(pipeline, input)
+							break
+						}
+						b.Fatal(err)
+					}
+					if rec != nil {
+						rec.Release()
+					}
+				}
+			}
+		})
+	}
+}
+
+// resetRangeAggregationPipeline rewinds a range aggregation pipeline so Read can be
+// invoked again with the same inputs. rangeAggregationPipeline is single-shot by
+// default (inputsExhausted); this is intended for benchmarks and tests only.
+func resetRangeAggregationPipeline(p *rangeAggregationPipeline, input *BufferedPipeline) {
+	p.inputsExhausted = false
+	p.aggregator.Reset()
+	input.Reset()
+}
+
+func buildInputRecords(b *testing.B, schema *arrow.Schema, rows []arrowtest.Rows) []arrow.RecordBatch {
+	b.Helper()
+
+	records := make([]arrow.RecordBatch, len(rows))
+	for i, r := range rows {
+		records[i] = r.Record(memory.DefaultAllocator, schema)
+	}
+	return records
+}
+
+func buildRangeAggregationGrouping() physical.Grouping {
+	return physical.Grouping{
+		Columns: []physical.ColumnExpression{
+			&physical.ColumnExpr{
+				Ref: types.ColumnRef{
+					Column: "env",
+					Type:   types.ColumnTypeAmbiguous,
+				},
+			},
+			&physical.ColumnExpr{
+				Ref: types.ColumnRef{
+					Column: "service",
+					Type:   types.ColumnTypeAmbiguous,
+				},
+			},
+		},
+		Without: false,
+	}
+}
+
+// benchmarkRangeAggregationWindows builds query windows the same way as rangeAggregationPipeline.init.
+func benchmarkRangeAggregationWindows(opts rangeAggregationOptions) []window {
+	windows := []window{}
+	cur := opts.startTs
+	endUnix := opts.endTs.UnixNano()
+	for cur.UnixNano() <= endUnix {
+		windows = append(windows, window{start: cur.Add(-opts.rangeInterval), end: cur})
+		if opts.step == 0 {
+			break
+		}
+		cur = cur.Add(opts.step)
+	}
+	return windows
+}
+
+func buildRangeAggregationInput() (*arrow.Schema, []arrowtest.Rows) {
+	fields := []arrow.Field{
+		semconv.FieldFromFQN(colTs, false),
+		semconv.FieldFromFQN(colEnv, false),
+		semconv.FieldFromFQN(colSvc, false),
+	}
+	schema := arrow.NewSchema(fields, nil)
+
+	const (
+		rowsPerBatch = 1024
+		batches      = 8
+	)
+
+	rows := make([]arrowtest.Rows, batches)
+	base := time.Unix(12, 0).UTC()
+	for batch := range batches {
+		batchRows := make(arrowtest.Rows, rowsPerBatch)
+		for i := range rowsPerBatch {
+			offset := batch*rowsPerBatch + i
+			batchRows[i] = arrowtest.Row{
+				colTs:  base.Add(time.Duration(offset%28) * time.Second),
+				colEnv: []string{"prod", "dev", "staging"}[offset%3],
+				colSvc: []string{"app1", "app2", "app3", "app4"}[offset%4],
+			}
+		}
+		rows[batch] = batchRows
+	}
+
+	return schema, rows
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve performance of range aggregation under the "overlapping" window scenario (step < range) by reducing allocs and slicing into the windows instead.
As far as I understand, slicing a range from the windows is valid and there is never a case where there is a gap in the windows.

Includes a new benchmark that fully reads 8192 records

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/engine/internal/executor
cpu: Apple M3 Max
                                             │ before.txt  │       after_overlappingfix.txt       │
                                             │   sec/op    │    sec/op     vs base                │
RangeAggregationPipeline/case=instant-14       997.8µ ± 3%   1003.4µ ± 1%        ~ (p=0.052 n=10)
RangeAggregationPipeline/case=aligned-14       1.022m ± 2%    1.020m ± 1%        ~ (p=0.684 n=10)
RangeAggregationPipeline/case=gapped-14        608.3µ ± 1%    605.1µ ± 0%   -0.54% (p=0.029 n=10)
RangeAggregationPipeline/case=overlapping-14   2.969m ± 1%    1.800m ± 0%  -39.37% (p=0.000 n=10)
geomean                                        1.165m         1.028m       -11.78%

                                             │   before.txt   │       after_overlappingfix.txt       │
                                             │      B/op      │     B/op      vs base                │
RangeAggregationPipeline/case=instant-14         21.92Ki ± 0%   21.92Ki ± 0%        ~ (p=0.802 n=10)
RangeAggregationPipeline/case=aligned-14         24.31Ki ± 0%   24.31Ki ± 0%        ~ (p=0.450 n=10)
RangeAggregationPipeline/case=gapped-14          24.30Ki ± 0%   24.30Ki ± 0%        ~ (p=0.656 n=10)
RangeAggregationPipeline/case=overlapping-14   2449.25Ki ± 0%   24.31Ki ± 0%  -99.01% (p=0.000 n=10)
geomean                                          75.04Ki        23.69Ki       -68.44%

                                             │  before.txt  │       after_overlappingfix.txt       │
                                             │  allocs/op   │ allocs/op   vs base                  │
RangeAggregationPipeline/case=instant-14         274.0 ± 0%   274.0 ± 0%        ~ (p=1.000 n=10) ¹
RangeAggregationPipeline/case=aligned-14         304.0 ± 0%   304.0 ± 0%        ~ (p=1.000 n=10) ¹
RangeAggregationPipeline/case=gapped-14          304.0 ± 0%   304.0 ± 0%        ~ (p=1.000 n=10) ¹
RangeAggregationPipeline/case=overlapping-14   49468.0 ± 0%   304.0 ± 0%  -99.39% (p=0.000 n=10)
geomean                                         1.058k        296.2       -72.00%
¹ all samples are equal
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches range-aggregation window matching logic for the overlapping (step < range) case; while intended to be equivalent, any off-by-one or ordering assumption could change which windows receive samples. Other changes are test/benchmark utilities.
> 
> **Overview**
> Reduces allocations in the range-aggregation *overlapping window* matcher by replacing per-call backward scanning/append with two `slices.BinarySearchFunc` lookups and returning a slice of the existing `windows` array.
> 
> Adds `BufferedPipeline.Reset()` and a new benchmark (`range_aggregation_bench_test.go`) that repeatedly reads the range aggregation pipeline across instant/aligned/gapped/overlapping scenarios by resetting pipeline/input state between iterations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a644145689f2b1ce382349677b59f4ac5622cd76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->