### PR TITLE
fix: Misnamed metric produce_requests_total

### DIFF
--- a/pkg/kafka/client/writer_client.go
+++ b/pkg/kafka/client/writer_client.go
@@ -238,7 +238,7 @@ type Producer struct {
 
 	// Custom metrics.
 	bufferedProduceBytesLimit prometheus.Gauge
-	produceRequestsTotal      prometheus.Counter
+	produceRecordsTotal       prometheus.Counter
 	produceFailuresTotal      *prometheus.CounterVec
 }
 
@@ -270,15 +270,15 @@ func NewProducer(component string, client *kgo.Client, maxBufferedBytes int64, r
 				Name:      "buffered_produce_bytes_limit",
 				Help:      "The bytes limit on buffered produce records. Produce requests fail once this limit is reached.",
 			}),
-		produceRequestsTotal: promauto.With(wrappedRegisterer).NewCounter(prometheus.CounterOpts{
+		produceRecordsTotal: promauto.With(wrappedRegisterer).NewCounter(prometheus.CounterOpts{
 			Namespace: "kafka_client",
-			Name:      "produce_requests_total",
-			Help:      "Total number of produce requests issued to Kafka.",
+			Name:      "produce_records_total",
+			Help:      "Total number of records produced.",
 		}),
 		produceFailuresTotal: promauto.With(wrappedRegisterer).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "kafka_client",
 			Name:      "produce_failures_total",
-			Help:      "Total number of failed produce requests issued to Kafka.",
+			Help:      "Total number of records that failed to be produced.",
 		}, []string{"reason"}),
 	}
 
@@ -302,7 +302,7 @@ func (c *Producer) Close() {
 // This function honors the configure max buffered bytes and refuse to produce a record, returnin kgo.ErrMaxBuffered,
 // if the configured limit is reached.
 func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.ProduceResults {
-	c.produceRequestsTotal.Add(float64(len(records)))
+	c.produceRecordsTotal.Add(float64(len(records)))
 
 	// Call interceptor with all records if configured.
 	if c.recordsInterceptor != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes a misnamed metric `produce_requests_total` which does not track produce requests (i.e. to the broker), but instead tracks the number of records passed to Produce methods.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renames a Prometheus counter and adjusts its help text, which can break existing dashboards/alerts relying on `kafka_client_produce_requests_total` even though runtime behavior is unchanged.
> 
> **Overview**
> Fixes a misnamed producer Prometheus metric by renaming `kafka_client_produce_requests_total` to `kafka_client_produce_records_total` and updating help text to reflect that it counts *records* passed to `ProduceSync`, not broker-level produce requests.
> 
> Updates the corresponding counter field (`produceRequestsTotal` 1 `produceRecordsTotal`) and increments it consistently, and clarifies `produce_failures_total` as counting failed records.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76f59e4612798f8f6d810ee30953e67b4e5476bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->