### PR TITLE
chore(engine v2): Return cause of context cancelation

### DIFF
--- a/pkg/engine/internal/executor/pipeline.go
+++ b/pkg/engine/internal/executor/pipeline.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/assertions"
+	"github.com/grafana/loki/v3/pkg/engine/internal/util"
 	"github.com/grafana/loki/v3/pkg/xcap"
 )
 
@@ -197,7 +198,7 @@ func (p prefetchWrapper) prefetch(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return util.CauseError(ctx)
 		default:
 			var s state
 			s.batch, s.err = p.Pipeline.Read(ctx)
@@ -210,7 +211,7 @@ func (p prefetchWrapper) prefetch(ctx context.Context) error {
 			// If the context is cancelled while waiting to send, we return.
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				return util.CauseError(ctx)
 			case p.ch <- s:
 			}
 		}

--- a/pkg/engine/internal/scheduler/wire/peer.go
+++ b/pkg/engine/internal/scheduler/wire/peer.go
@@ -10,9 +10,10 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/grafana/loki/v3/pkg/engine/internal/util"
 	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/util"
 )
 
 // Peer wraps a [Conn] into a synchronous API that acts as both a

--- a/pkg/engine/internal/scheduler/wire/peer.go
+++ b/pkg/engine/internal/scheduler/wire/peer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/loki/v3/pkg/engine/internal/util"
 	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 )
@@ -248,7 +249,7 @@ func (p *Peer) SendMessage(ctx context.Context, message Message) error {
 	select {
 	case <-ctx.Done():
 		// TODO(rfratto): queue a DiscardFrame
-		return ctx.Err()
+		return util.CauseError(ctx)
 	case <-p.done:
 		return ErrConnClosed
 	case err := <-req.result:
@@ -274,7 +275,7 @@ func (p *Peer) SendMessageAsync(ctx context.Context, message Message) error {
 func (p *Peer) enqueueFrame(ctx context.Context, frame Frame) error {
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return util.CauseError(ctx)
 	case <-p.done:
 		return ErrConnClosed
 	case p.outgoing <- frame:

--- a/pkg/engine/internal/scheduler/wire/wire_http2.go
+++ b/pkg/engine/internal/scheduler/wire/wire_http2.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/loki/v3/pkg/engine/internal/util"
 	"golang.org/x/net/http2"
 )
 
@@ -142,7 +143,7 @@ func (l *HTTP2Listener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (l *HTTP2Listener) Accept(ctx context.Context) (Conn, error) {
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, util.CauseError(ctx)
 	case <-l.closed:
 		return nil, net.ErrClosed
 	case conn := <-l.incoming:
@@ -237,7 +238,7 @@ func (c *http2Conn) Send(ctx context.Context, frame Frame) error {
 	case <-c.ctx.Done():
 		return ErrConnClosed
 	case <-ctx.Done():
-		return ctx.Err()
+		return util.CauseError(ctx)
 	case <-c.closed:
 		return ErrConnClosed
 	default:
@@ -269,7 +270,7 @@ func (c *http2Conn) Recv(ctx context.Context) (Frame, error) {
 	case <-c.ctx.Done():
 		return nil, ErrConnClosed
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, util.CauseError(ctx)
 	case <-c.closed:
 		return nil, ErrConnClosed
 	case f := <-c.incomingCh:

--- a/pkg/engine/internal/scheduler/wire/wire_http2.go
+++ b/pkg/engine/internal/scheduler/wire/wire_http2.go
@@ -13,8 +13,9 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/grafana/loki/v3/pkg/engine/internal/util"
 	"golang.org/x/net/http2"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/util"
 )
 
 // peerAddressHeader is the header used to advertise the address to connect back

--- a/pkg/engine/internal/scheduler/wire/wire_local.go
+++ b/pkg/engine/internal/scheduler/wire/wire_local.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"sync"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/util"
 )
 
 var (
@@ -80,7 +82,7 @@ func (l *Local) DialFrom(ctx context.Context, from net.Addr) (Conn, error) {
 
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, util.CauseError(ctx)
 	case <-alive.Done():
 		return nil, net.ErrClosed
 	case l.incoming <- remoteStream:
@@ -103,7 +105,7 @@ func (l *Local) Accept(ctx context.Context) (Conn, error) {
 	case <-l.alive.Done():
 		return nil, net.ErrClosed
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, util.CauseError(ctx)
 	case conn := <-l.incoming:
 		return conn, nil
 	}
@@ -139,7 +141,7 @@ var _ Conn = (*localConn)(nil)
 func (c *localConn) Send(ctx context.Context, frame Frame) error {
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return util.CauseError(ctx)
 	case <-c.alive.Done(): // Conn closed
 		return ErrConnClosed
 	case c.write <- frame:
@@ -150,7 +152,7 @@ func (c *localConn) Send(ctx context.Context, frame Frame) error {
 func (c *localConn) Recv(ctx context.Context) (Frame, error) {
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, util.CauseError(ctx)
 	case <-c.alive.Done(): // Conn closed
 		return nil, ErrConnClosed
 	case frame, ok := <-c.read:

--- a/pkg/engine/internal/util/wrapcause.go
+++ b/pkg/engine/internal/util/wrapcause.go
@@ -1,0 +1,31 @@
+package util
+
+// Wrapper for the error from a canceled context, to provide better information
+// in logs than "context canceled".
+
+import (
+	"context"
+	"fmt"
+)
+
+type causeError struct {
+	err   error
+	cause error
+}
+
+func CauseError(ctx context.Context) error {
+	cause := context.Cause(ctx)
+	if cause == ctx.Err() {
+		return ctx.Err() // Context has no distinct cause; just return the error.
+	}
+	return &causeError{err: ctx.Err(), cause: cause}
+}
+
+func (err *causeError) Error() string {
+	return fmt.Sprintf("%s: %s", err.err.Error(), err.cause.Error())
+}
+
+// Unwrap returns both, so that usages like `errors.Is(err, context.Canceled)` work.
+func (err *causeError) Unwrap() []error {
+	return []error{err.err, err.cause}
+}

--- a/pkg/engine/internal/worker/job_manager.go
+++ b/pkg/engine/internal/worker/job_manager.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
+	"github.com/grafana/loki/v3/pkg/engine/internal/util"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
 )
 
@@ -83,7 +84,7 @@ func (jm *jobManager) Recv(ctx context.Context) (*threadJob, error) {
 		// they would be blocked forever.
 		jm.cancelWaiting()
 
-		return nil, ctx.Err()
+		return nil, util.CauseError(ctx)
 	case job := <-jm.jobCh:
 		return job, nil
 	}
@@ -151,7 +152,7 @@ func (jm *jobManager) Send(ctx context.Context, job *threadJob) error {
 		jm.waiting--
 		return nil
 	case !sent && ctx.Err() != nil:
-		return ctx.Err()
+		return util.CauseError(ctx)
 	default:
 		return errNoReadyThreads
 	}
@@ -183,5 +184,5 @@ func (jm *jobManager) WaitReady(ctx context.Context) error {
 		jm.mut.RLock()
 	}
 
-	return ctx.Err()
+	return util.CauseError(ctx)
 }

--- a/pkg/engine/internal/worker/node_source.go
+++ b/pkg/engine/internal/worker/node_source.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
+	"github.com/grafana/loki/v3/pkg/engine/internal/util"
 	"github.com/grafana/loki/v3/pkg/engine/internal/worker/workerstat"
 	"github.com/grafana/loki/v3/pkg/xcap"
 )
@@ -55,7 +56,7 @@ func (src *nodeSource) Read(ctx context.Context) (arrow.RecordBatch, error) {
 
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, util.CauseError(ctx)
 	case <-src.closed:
 		if ep := src.failErr.Load(); ep != nil {
 			return nil, *ep
@@ -80,7 +81,7 @@ func (src *nodeSource) Write(ctx context.Context, rec arrow.RecordBatch) error {
 
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return util.CauseError(ctx)
 	case <-src.closed:
 		return executor.EOF
 	case src.records <- rec:

--- a/pkg/engine/internal/worker/stream_sink.go
+++ b/pkg/engine/internal/worker/stream_sink.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/dskit/backoff"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
+	"github.com/grafana/loki/v3/pkg/engine/internal/util"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
 )
 
@@ -137,7 +138,7 @@ func (sink *streamSink) getPeer(ctx context.Context) (*wire.Peer, error) {
 	// Wait for destination.
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, util.CauseError(ctx)
 	case <-sink.ctx.Done():
 		return nil, wire.ErrConnClosed
 	case <-sink.bound:

--- a/pkg/engine/internal/worker/stream_source.go
+++ b/pkg/engine/internal/worker/stream_source.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
+	"github.com/grafana/loki/v3/pkg/engine/internal/util"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
 	"github.com/grafana/loki/v3/pkg/xcap"
 )
@@ -38,7 +39,7 @@ func (src *streamSource) Write(ctx context.Context, rec arrow.RecordBatch) error
 
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return util.CauseError(ctx)
 	case <-src.closed:
 		return wire.ErrConnClosed
 	case <-src.bound:

--- a/pkg/engine/internal/worker/thread_test.go
+++ b/pkg/engine/internal/worker/thread_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"testing/synctest"
@@ -16,10 +17,22 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
+	"github.com/grafana/loki/v3/pkg/engine/internal/util"
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
 	"github.com/grafana/loki/v3/pkg/util/arrowtest"
 )
+
+// blockingPipeline blocks in Read until the context is canceled, simulating an
+// operation that never completes.
+type blockingPipeline struct{}
+
+func (blockingPipeline) Open(_ context.Context) error { return nil }
+func (blockingPipeline) Read(ctx context.Context) (arrow.RecordBatch, error) {
+	<-ctx.Done()
+	return nil, util.CauseError(ctx)
+}
+func (blockingPipeline) Close() {}
 
 // mockRecordSink records each Send call and total rows for testing.
 // RecordedFieldNames is the list of field names (in order) for each received record.
@@ -82,6 +95,32 @@ func TestThread_drainPipeline(t *testing.T) {
 	defer sink.mu.Unlock()
 	require.Equal(t, 3, sink.SendCount, "one send per record")
 	require.Equal(t, int64(3), sink.TotalRows)
+}
+
+func TestThread_drainPipeline_Timeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	sink := &mockRecordSink{}
+	th := &thread{Logger: log.NewNopLogger(), Metrics: newMetrics()}
+	totalRows, err := th.drainPipeline(ctx, blockingPipeline{}, []recordSink{sink}, log.NewNopLogger())
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, 0, totalRows)
+}
+
+func TestThread_drainPipeline_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(t.Context())
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel(fmt.Errorf("Test cancel: %w", context.Canceled))
+	}()
+
+	sink := &mockRecordSink{}
+	th := &thread{Logger: log.NewNopLogger(), Metrics: newMetrics()}
+	totalRows, err := th.drainPipeline(ctx, blockingPipeline{}, []recordSink{sink}, log.NewNopLogger())
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 0, totalRows)
 }
 
 func TestThread_runJob_IgnoresClosedSourceBindErrors(t *testing.T) {

--- a/pkg/engine/internal/workflow/stream_pipe.go
+++ b/pkg/engine/internal/workflow/stream_pipe.go
@@ -7,6 +7,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
+	"github.com/grafana/loki/v3/pkg/engine/internal/util"
 )
 
 // A streamPipe connects data for a stream to a local listener (via
@@ -56,7 +57,7 @@ func (pipe *streamPipe) Open(_ context.Context) error { return nil }
 func (pipe *streamPipe) Read(ctx context.Context) (arrow.RecordBatch, error) {
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, util.CauseError(ctx)
 	case <-pipe.errCond:
 		return nil, pipe.err
 	case <-pipe.closed:
@@ -84,7 +85,7 @@ func (pipe *streamPipe) checkError(err error) error {
 func (pipe *streamPipe) Write(ctx context.Context, rec arrow.RecordBatch) error {
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return util.CauseError(ctx)
 	case <-pipe.closed:
 		return executor.EOF
 	case pipe.results <- rec:


### PR DESCRIPTION
**What this PR does / why we need it**:

To allow better diagnostics than the bare "context canceled" error.

Uses a wrapper struct so that usages like `errors.Is(err, context.Canceled)` still work.
Also add some tests of cancel and timeout.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only wrap `context` cancellation errors to improve diagnostics while preserving `errors.Is` behavior; primary impact is different error strings and slightly different wrapped error types.
> 
> **Overview**
> Improves cancellation diagnostics across the engine by introducing `util.CauseError(ctx)` (wraps `ctx.Err()` with `context.Cause(ctx)` when distinct) so logs show *why* a context was canceled, while still supporting `errors.Is(..., context.Canceled)`.
> 
> Replaces many `return ctx.Err()` sites in pipeline prefetching, worker stream plumbing, and scheduler `wire` transports (local + HTTP/2 + peer messaging) with `util.CauseError(ctx)`.
> 
> Adds thread tests covering `drainPipeline` timeout and cancel-cause propagation using a `blockingPipeline`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b8f0a01ed8c6ddbb05ebf458e2cf5aa32c041b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->