### PR TITLE
chore: Apply two aggregator optimizations

### DIFF
--- a/pkg/engine/internal/executor/aggregator.go
+++ b/pkg/engine/internal/executor/aggregator.go
@@ -22,6 +22,8 @@ type groupState struct {
 	count int64   // values counter
 }
 
+type keyedAdder func(ts time.Time, value float64) error
+
 type aggregationOperation int
 
 const (
@@ -82,9 +84,25 @@ func (a *aggregator) SetMaxSeries(maxSeries int) {
 	a.maxSeries = maxSeries
 }
 
+func (a *aggregator) WithLabelValues(labels []arrow.Field, labelValues []string) keyedAdder {
+	a.digest.Reset()
+	for i, label := range labels {
+		if i > 0 {
+			_, _ = a.digest.Write([]byte{0}) // separator
+		}
+		_, _ = a.digest.WriteString(label.Name)
+		_, _ = a.digest.Write([]byte("="))
+		_, _ = a.digest.WriteString(labelValues[i])
+	}
+	key := a.digest.Sum64()
+	return func(ts time.Time, value float64) error {
+		return a.add(ts, key, value, labels, labelValues)
+	}
+}
+
 // Add adds a new sample value to the aggregation for the given timestamp and grouping label values.
 // It expects labelValues to be in the same order as the groupBy columns.
-func (a *aggregator) Add(ts time.Time, value float64, labels []arrow.Field, labelValues []string) error {
+func (a *aggregator) add(ts time.Time, key uint64, value float64, labels []arrow.Field, labelValues []string) error {
 	if len(labels) != len(labelValues) {
 		panic("len(labels) != len(labelValues)")
 	}
@@ -93,21 +111,6 @@ func (a *aggregator) Add(ts time.Time, value float64, labels []arrow.Field, labe
 	if !ok {
 		point = make(map[uint64]*groupState)
 		a.points[ts] = point
-	}
-
-	var key uint64
-	if len(labelValues) != 0 {
-		a.digest.Reset()
-		for i, val := range labelValues {
-			if i > 0 {
-				_, _ = a.digest.Write([]byte{0}) // separator
-			}
-
-			_, _ = a.digest.WriteString(labels[i].Name)
-			_, _ = a.digest.Write([]byte("="))
-			_, _ = a.digest.WriteString(val)
-		}
-		key = a.digest.Sum64()
 	}
 
 	if state, ok := point[key]; ok {

--- a/pkg/engine/internal/executor/aggregator.go
+++ b/pkg/engine/internal/executor/aggregator.go
@@ -22,8 +22,6 @@ type groupState struct {
 	count int64   // values counter
 }
 
-type keyedAdder func(ts time.Time, value float64) error
-
 type aggregationOperation int
 
 const (
@@ -48,6 +46,11 @@ type aggregator struct {
 	// Track unique series across all timestamps to enforce maxSeries limit
 	maxSeries    int                          // maximum number of unique series allowed (0 means no limit)
 	uniqueSeries map[uint64]map[string]string // tracks unique series across all timestamps
+
+	// cached values to avoid recomputing the key and labels for each sample value in a tight loop
+	memoizedKey         uint64
+	memoizedLabels      []arrow.Field
+	memoizedLabelValues []string
 }
 
 // newAggregator creates a new aggregator with the specified grouping.
@@ -84,27 +87,50 @@ func (a *aggregator) SetMaxSeries(maxSeries int) {
 	a.maxSeries = maxSeries
 }
 
-func (a *aggregator) WithLabelValues(labels []arrow.Field, labelValues []string) keyedAdder {
+// BindLabels caches the provided labels for the next Add call.
+// If Add is called on an aggregator with Bound labels, the bound labels and values will be used instead of the provided labels and values.
+// The returned unbind function must be called to release the cached labels and values and use the allocator for a new series.
+func (a *aggregator) BindLabels(labels []arrow.Field, labelValues []string) func() {
+	a.memoizedKey = a.computeKey(labels, labelValues)
+	a.memoizedLabels = labels
+	a.memoizedLabelValues = labelValues
+
+	return a.unbindLabels
+}
+
+func (a *aggregator) unbindLabels() {
+	a.memoizedKey = 0
+	a.memoizedLabels = nil
+	a.memoizedLabelValues = nil
+}
+
+func (a *aggregator) computeKey(labels []arrow.Field, labelValues []string) uint64 {
 	a.digest.Reset()
 	for i, label := range labels {
 		if i > 0 {
 			_, _ = a.digest.Write([]byte{0}) // separator
 		}
 		_, _ = a.digest.WriteString(label.Name)
-		_, _ = a.digest.Write([]byte("="))
+		_, _ = a.digest.Write([]byte{'='})
 		_, _ = a.digest.WriteString(labelValues[i])
 	}
-	key := a.digest.Sum64()
-	return func(ts time.Time, value float64) error {
-		return a.add(ts, key, value, labels, labelValues)
-	}
+	return a.digest.Sum64()
 }
 
 // Add adds a new sample value to the aggregation for the given timestamp and grouping label values.
 // It expects labelValues to be in the same order as the groupBy columns.
-func (a *aggregator) add(ts time.Time, key uint64, value float64, labels []arrow.Field, labelValues []string) error {
+func (a *aggregator) Add(ts time.Time, value float64, labels []arrow.Field, labelValues []string) error {
 	if len(labels) != len(labelValues) {
 		panic("len(labels) != len(labelValues)")
+	}
+
+	var key uint64
+	if a.memoizedKey != 0 {
+		key = a.memoizedKey
+		labels = a.memoizedLabels
+		labelValues = a.memoizedLabelValues
+	} else {
+		key = a.computeKey(labels, labelValues)
 	}
 
 	point, ok := a.points[ts]

--- a/pkg/engine/internal/executor/aggregator.go
+++ b/pkg/engine/internal/executor/aggregator.go
@@ -188,11 +188,10 @@ func (a *aggregator) Add(ts time.Time, value float64, labels []arrow.Field, labe
 			a.uniqueSeries[key] = series
 		}
 
-		state = &groupState{
+		a.points[groupKey] = &groupState{
 			value: value,
 			count: int64(1),
 		}
-		a.points[groupKey] = state
 	}
 	return nil
 }

--- a/pkg/engine/internal/executor/aggregator.go
+++ b/pkg/engine/internal/executor/aggregator.go
@@ -22,6 +22,11 @@ type groupState struct {
 	count int64   // values counter
 }
 
+type groupKey struct {
+	timestamp time.Time
+	key       uint64
+}
+
 type aggregationOperation int
 
 const (
@@ -37,11 +42,11 @@ const (
 
 // aggregator is used to aggregate sample values by a set of grouping keys for each point in time.
 type aggregator struct {
-	points            map[time.Time]map[uint64]*groupState // holds the groupState for each point in time series
-	digest            *xxhash.Digest                       // used to compute key for each group
-	operation         aggregationOperation                 // aggregation type
-	labels            map[string]arrow.Field               // combined list of all label fields for all sample values
-	clonedLabelValues map[string]string                    // cache of cloned strings to reduce allocations for repeated values
+	points            map[groupKey]*groupState // holds the groupState for each point in time series
+	digest            *xxhash.Digest           // used to compute key for each group
+	operation         aggregationOperation     // aggregation type
+	labels            map[string]arrow.Field   // combined list of all label fields for all sample values
+	clonedLabelValues map[string]string        // cache of cloned strings to reduce allocations for repeated values
 
 	// Track unique series across all timestamps to enforce maxSeries limit
 	maxSeries    int                          // maximum number of unique series allowed (0 means no limit)
@@ -64,9 +69,9 @@ func newAggregator(pointsSizeHint int, operation aggregationOperation) *aggregat
 	}
 
 	if pointsSizeHint > 0 {
-		a.points = make(map[time.Time]map[uint64]*groupState, pointsSizeHint)
+		a.points = make(map[groupKey]*groupState, pointsSizeHint)
 	} else {
-		a.points = make(map[time.Time]map[uint64]*groupState)
+		a.points = make(map[groupKey]*groupState)
 	}
 
 	return &a
@@ -120,26 +125,25 @@ func (a *aggregator) computeKey(labels []arrow.Field, labelValues []string) uint
 // Add adds a new sample value to the aggregation for the given timestamp and grouping label values.
 // It expects labelValues to be in the same order as the groupBy columns.
 func (a *aggregator) Add(ts time.Time, value float64, labels []arrow.Field, labelValues []string) error {
-	if len(labels) != len(labelValues) {
-		panic("len(labels) != len(labelValues)")
-	}
-
 	var key uint64
-	if a.memoizedKey != 0 {
+	switch {
+	case a.memoizedLabels != nil:
 		key = a.memoizedKey
 		labels = a.memoizedLabels
 		labelValues = a.memoizedLabelValues
-	} else {
+	case len(labels) == 0:
+		// Aggregation without grouping; all samples share key 0.
+		key = 0
+	case len(labels) != len(labelValues):
+		panic("len(labels) != len(labelValues)")
+	default:
 		key = a.computeKey(labels, labelValues)
 	}
 
-	point, ok := a.points[ts]
-	if !ok {
-		point = make(map[uint64]*groupState)
-		a.points[ts] = point
-	}
+	groupKey := groupKey{timestamp: ts, key: key}
+	state, ok := a.points[groupKey]
 
-	if state, ok := point[key]; ok {
+	if ok {
 		// TODO: handle hash collisions
 
 		// accumulate value based on aggregation type
@@ -184,10 +188,11 @@ func (a *aggregator) Add(ts time.Time, value float64, labels []arrow.Field, labe
 			a.uniqueSeries[key] = series
 		}
 
-		point[key] = &groupState{
+		state = &groupState{
 			value: value,
 			count: int64(1),
 		}
+		a.points[groupKey] = state
 	}
 	return nil
 }
@@ -204,42 +209,47 @@ func (a *aggregator) BuildRecord() (arrow.RecordBatch, error) {
 	schema := arrow.NewSchema(fields, nil)
 	rb := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
 
-	// emit aggregated results in sorted order of timestamp
-	sortedTimestamps := a.getSortedTimestamps()
+	// Emit aggregated results in sorted timestamp order.
+	sortedKeys := slices.SortedFunc(maps.Keys(a.points), func(a, b groupKey) int {
+		if c := a.timestamp.Compare(b.timestamp); c != 0 {
+			return c
+		}
+		if a.key < b.key {
+			return -1
+		}
+		if a.key > b.key {
+			return 1
+		}
+		return 0
+	})
 
-	// preallocate all builders to the total amount of rows
-	total := 0
-	for _, ts := range sortedTimestamps {
-		total += len(a.points[ts])
-	}
-	rb.Reserve(total)
+	rb.Reserve(len(sortedKeys))
 
-	for _, ts := range sortedTimestamps {
-		tsValue, _ := arrow.TimestampFromTime(ts, arrow.Nanosecond)
+	for _, gk := range sortedKeys {
+		entry := a.points[gk]
+		tsValue, _ := arrow.TimestampFromTime(gk.timestamp, arrow.Nanosecond)
 
-		for key, entry := range a.points[ts] {
-			var value float64
-			switch a.operation {
-			case aggregationOperationAvg:
-				value = entry.value / float64(entry.count)
-			case aggregationOperationCount:
-				value = float64(entry.count)
-			default:
-				value = entry.value
-			}
+		var value float64
+		switch a.operation {
+		case aggregationOperationAvg:
+			value = entry.value / float64(entry.count)
+		case aggregationOperationCount:
+			value = float64(entry.count)
+		default:
+			value = entry.value
+		}
 
-			rb.Field(0).(*array.TimestampBuilder).Append(tsValue)
-			rb.Field(1).(*array.Float64Builder).Append(value)
+		rb.Field(0).(*array.TimestampBuilder).Append(tsValue)
+		rb.Field(1).(*array.Float64Builder).Append(value)
 
-			series := a.uniqueSeries[key]
-			for i := 2; i < len(fields); i++ { // offset by 2 as the first 2 fields are timestamp and value
-				builder := rb.Field(i)
+		series := a.uniqueSeries[gk.key]
+		for i := 2; i < len(fields); i++ { // offset by 2 as the first 2 fields are timestamp and value
+			builder := rb.Field(i)
 
-				if v, ok := series[fields[i].Name]; ok {
-					builder.(*array.StringBuilder).Append(v)
-				} else {
-					builder.(*array.StringBuilder).AppendNull()
-				}
+			if v, ok := series[fields[i].Name]; ok {
+				builder.(*array.StringBuilder).Append(v)
+			} else {
+				builder.(*array.StringBuilder).AppendNull()
 			}
 		}
 	}
@@ -249,18 +259,8 @@ func (a *aggregator) BuildRecord() (arrow.RecordBatch, error) {
 
 func (a *aggregator) Reset() {
 	a.digest.Reset()
-	// keep the timestamps but clear the aggregated values
-	for _, point := range a.points {
-		clear(point)
-	}
-
+	clear(a.points)
 	clear(a.uniqueSeries)
 	clear(a.clonedLabelValues)
-}
-
-// getSortedTimestamps returns all timestamps in sorted order
-func (a *aggregator) getSortedTimestamps() []time.Time {
-	return slices.SortedFunc(maps.Keys(a.points), func(a, b time.Time) int {
-		return a.Compare(b)
-	})
+	a.unbindLabels()
 }

--- a/pkg/engine/internal/executor/aggregator_test.go
+++ b/pkg/engine/internal/executor/aggregator_test.go
@@ -14,12 +14,10 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/arrowtest"
 )
 
-var (
-	groupBy = []arrow.Field{
-		semconv.FieldFromIdent(semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String), true),
-		semconv.FieldFromIdent(semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String), true),
-	}
-)
+var groupBy = []arrow.Field{
+	semconv.FieldFromIdent(semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String), true),
+	semconv.FieldFromIdent(semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String), true),
+}
 
 func TestAggregator(t *testing.T) {
 	colTs := semconv.ColumnIdentTimestamp.FQN()
@@ -36,18 +34,18 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: prod/app1 = 10, prod/app2 = 20, dev/app1 = 30
-		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 10)
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts1, 20)
+		_ = agg.WithLabelValues(groupBy, []string{"dev", "app1"})(ts1, 30)
 
 		// ts2: prod/app1 = 15, prod/app2 = 25, dev/app2 = 35
-		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts2, 15)
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts2, 25)
+		_ = agg.WithLabelValues(groupBy, []string{"dev", "app2"})(ts2, 35)
 
 		// Add more data to same groups to test aggregation
-		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be 15
-		_ = agg.Add(ts2, 10, groupBy, []string{"prod", "app1"}) // prod/app1 at ts2 should now be 25
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 5)  // prod/app1 at ts1 should now be 15
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts2, 10) // prod/app1 at ts2 should now be 25
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -77,18 +75,18 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: prod/app1 = 10, prod/app2 = 20, dev/app1 = 30
-		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 10)
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts1, 20)
+		_ = agg.WithLabelValues(groupBy, []string{"dev", "app1"})(ts1, 30)
 
 		// ts2: prod/app1 = 15, prod/app2 = 25, dev/app2 = 35
-		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts2, 15)
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts2, 25)
+		_ = agg.WithLabelValues(groupBy, []string{"dev", "app2"})(ts2, 35)
 
 		// Add more data to same groups to test aggregation
-		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be 7.5
-		_ = agg.Add(ts2, 10, groupBy, []string{"prod", "app1"}) // prod/app1 at ts2 should now be 12.5
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 5)  // prod/app1 at ts1 should now be 7.5
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts2, 10) // prod/app1 at ts2 should now be 12.5
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -119,24 +117,24 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: add one datapoint for prod/app1, prod/app2, and dev/app1
-		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 10)
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts1, 20)
+		_ = agg.WithLabelValues(groupBy, []string{"dev", "app1"})(ts1, 30)
 
 		// ts2: add another datapoint for prod/app1, prod/app2, and dev/app2
-		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts2, 15)
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts2, 25)
+		_ = agg.WithLabelValues(groupBy, []string{"dev", "app2"})(ts2, 35)
 
 		// ts3: add another datapoint for prod/app1, prod/app2, and dev/app2
-		_ = agg.Add(ts3, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts3, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts3, 35, groupBy, []string{"dev", "app2"})
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts3, 15)
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts3, 25)
+		_ = agg.WithLabelValues(groupBy, []string{"dev", "app2"})(ts3, 35)
 
 		// Add more datapoints for prod/app1 and prod/app2
-		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be count 2
-		_ = agg.Add(ts2, 10, groupBy, []string{"prod", "app2"}) // prod/app2 at ts2 should now be count 2
-		_ = agg.Add(ts1, 25, groupBy, []string{"prod", "app1"}) // prod/app1 at ts1 should now be count 3
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 5)  // prod/app1 at ts1 should now be count 2
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts2, 10) // prod/app2 at ts2 should now be count 2
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 25) // prod/app1 at ts1 should now be count 3
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -170,19 +168,19 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: add one datapoint for prod/app1, prod/app2, and dev/app1
-		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 10)
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts1, 20)
+		_ = agg.WithLabelValues(groupBy, []string{"dev", "app1"})(ts1, 30)
 
 		// ts2: add another datapoint for prod/app1, prod/app2, and dev/app2
-		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts2, 15)
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts2, 25)
+		_ = agg.WithLabelValues(groupBy, []string{"dev", "app2"})(ts2, 35)
 
 		// Add more datapoints for prod/app1 and prod/app2
-		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should still be 10
-		_ = agg.Add(ts2, 50, groupBy, []string{"prod", "app2"}) // prod/app2 at ts2 should now be 50
-		_ = agg.Add(ts1, 15, groupBy, []string{"prod", "app1"}) // prod/app1 at ts1 should now be 15
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 5)  // prod/app1 at ts1 should still be 10
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts2, 50) // prod/app2 at ts2 should now be 50
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 15) // prod/app1 at ts1 should now be 15
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -212,19 +210,20 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: add one datapoint for prod/app1, prod/app2, and dev/app1
-		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 10)
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts1, 20)
+		_ = agg.WithLabelValues(groupBy, []string{"dev", "app1"})(ts1, 30)
+		_ = agg.WithLabelValues(groupBy, []string{"dev", "app1"})(ts1, 30)
 
 		// ts2: add another datapoint for prod/app1, prod/app2, and dev/app2
-		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts2, 15)
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts2, 25)
+		_ = agg.WithLabelValues(groupBy, []string{"dev", "app2"})(ts2, 35)
 
 		// Add more datapoints for prod/app1 and prod/app2
-		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be 5
-		_ = agg.Add(ts2, 40, groupBy, []string{"prod", "app2"}) // prod/app2 at ts2 should still be 25
-		_ = agg.Add(ts1, 25, groupBy, []string{"prod", "app1"}) // prod/app1 at ts1 should still be 5
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 5)  // prod/app1 at ts1 should now be 5
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts2, 40) // prod/app2 at ts2 should still be 25
+		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 25) // prod/app1 at ts1 should still be 5
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -257,17 +256,17 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: prod/app1 = 10, prod/app2 = 20, dev/app1 = 30
-		_ = agg.Add(ts1, 10, groupBy, []string{}) // "prod", "app1"
-		_ = agg.Add(ts1, 20, groupBy, []string{}) // "prod", "app2"
-		_ = agg.Add(ts1, 30, groupBy, []string{}) // "dev", "app1"
+		_ = agg.WithLabelValues(groupBy, []string{})(ts1, 10) // "prod", "app1"
+		_ = agg.WithLabelValues(groupBy, []string{})(ts1, 20) // "prod", "app2"
+		_ = agg.WithLabelValues(groupBy, []string{})(ts1, 30) // "dev", "app1"
 
 		// ts2: prod/app1 = 15, prod/app2 = 25, dev/app2 = 35
-		_ = agg.Add(ts2, 15, groupBy, []string{}) // "prod", "app1"
-		_ = agg.Add(ts2, 25, groupBy, []string{}) // "prod", "app2"
-		_ = agg.Add(ts2, 35, groupBy, []string{}) // "dev", "app2"
+		_ = agg.WithLabelValues(groupBy, []string{})(ts2, 15) // "prod", "app1"
+		_ = agg.WithLabelValues(groupBy, []string{})(ts2, 25) // "prod", "app2"
+		_ = agg.WithLabelValues(groupBy, []string{})(ts2, 35) // "dev", "app2"
 
-		_ = agg.Add(ts1, 5, groupBy, []string{})  // "prod", "app1"
-		_ = agg.Add(ts2, 10, groupBy, []string{}) // "prod", "app1"
+		_ = agg.WithLabelValues(groupBy, []string{})(ts1, 5)  // "prod", "app1"
+		_ = agg.WithLabelValues(groupBy, []string{})(ts2, 10) // "prod", "app1"
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -302,17 +301,17 @@ func TestAggregator(t *testing.T) {
 		agg.AddLabels(buildFields("env", "service", "cluster", "method"))
 
 		// Add test data
-		_ = agg.Add(ts1, 10, buildFields("env", "service"), []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, buildFields("env", "cluster"), []string{"prod", "east-1"})
-		_ = agg.Add(ts1, 30, buildFields("method"), []string{"init"})
+		_ = agg.WithLabelValues(buildFields("env", "service"), []string{"prod", "app1"})(ts1, 10)
+		_ = agg.WithLabelValues(buildFields("env", "cluster"), []string{"prod", "east-1"})(ts1, 20)
+		_ = agg.WithLabelValues(buildFields("method"), []string{"init"})(ts1, 30)
 
-		_ = agg.Add(ts2, 15, buildFields("env", "service"), []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, buildFields("env", "cluster"), []string{"prod", "east-1"})
-		_ = agg.Add(ts2, 35, buildFields("method"), []string{"init"})
+		_ = agg.WithLabelValues(buildFields("env", "service"), []string{"prod", "app1"})(ts2, 15)
+		_ = agg.WithLabelValues(buildFields("env", "cluster"), []string{"prod", "east-1"})(ts2, 25)
+		_ = agg.WithLabelValues(buildFields("method"), []string{"init"})(ts2, 35)
 
 		// Add more data to same groups to test aggregation
-		_ = agg.Add(ts1, 5, buildFields("env", "service"), []string{"prod", "app1"})
-		_ = agg.Add(ts2, 10, buildFields("env", "cluster"), []string{"prod", "east-1"})
+		_ = agg.WithLabelValues(buildFields("env", "service"), []string{"prod", "app1"})(ts1, 5)
+		_ = agg.WithLabelValues(buildFields("env", "cluster"), []string{"prod", "east-1"})(ts2, 10)
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -345,29 +344,29 @@ func TestAggregator(t *testing.T) {
 		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
 
 		// Add first 3 series at ts1 - should succeed
-		err := agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
+		err := agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 10)
 		require.NoError(t, err)
 
-		err = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
+		err = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts1, 20)
 		require.NoError(t, err)
 
-		err = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
+		err = agg.WithLabelValues(groupBy, []string{"dev", "app1"})(ts1, 30)
 		require.NoError(t, err)
 
 		// Try to add 4th unique series should fail
-		err = agg.Add(ts2, 10, groupBy, []string{"dev", "app2"})
+		err = agg.WithLabelValues(groupBy, []string{"dev", "app2"})(ts2, 10)
 		require.Error(t, err)
 		require.True(t, errors.Is(err, ErrSeriesLimitExceeded))
 
 		// Adding same series again at different timestamp should succeed (not a new unique series)
-		err = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
+		err = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts2, 15)
 		require.NoError(t, err)
 
 		// unset the limit
 		agg.SetMaxSeries(0)
 
 		// Now adding new series should succeed
-		err = agg.Add(ts2, 10, groupBy, []string{"dev", "app2"})
+		err = agg.WithLabelValues(groupBy, []string{"dev", "app2"})(ts2, 10)
 		require.NoError(t, err)
 	})
 }
@@ -379,16 +378,31 @@ func BenchmarkAggregator(b *testing.B) {
 		semconv.FieldFromIdent(semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String), true),
 	}
 
-	agg := newAggregator(10, aggregationOperationSum)
-	agg.AddLabels(fields)
+	b.Run("case=interleaved_series", func(b *testing.B) {
+		agg := newAggregator(10, aggregationOperationSum)
+		agg.AddLabels(fields)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(i) * time.Second)
-		env := fmt.Sprintf("env-%d", i%3)
-		cluster := fmt.Sprintf("cluster-%d", i%10)
-		service := fmt.Sprintf("service-%d", i%7)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(i) * time.Second)
+			env := fmt.Sprintf("env-%d", i%3)
+			cluster := fmt.Sprintf("cluster-%d", i%10)
+			service := fmt.Sprintf("service-%d", i%7)
 
-		_ = agg.Add(ts, 10, fields, []string{env, cluster, service})
-	}
+			_ = agg.WithLabelValues(fields, []string{env, cluster, service})(ts, 10)
+		}
+	})
+
+	b.Run("case=single_series", func(b *testing.B) {
+		agg := newAggregator(10, aggregationOperationSum)
+		agg.AddLabels(fields)
+
+		b.ResetTimer()
+		adderFn := agg.WithLabelValues(fields, []string{"prod", "app1", "east-1"})
+		for i := 0; i < b.N; i++ {
+			ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(i) * time.Second)
+
+			_ = adderFn(ts, 10)
+		}
+	})
 }

--- a/pkg/engine/internal/executor/aggregator_test.go
+++ b/pkg/engine/internal/executor/aggregator_test.go
@@ -34,18 +34,18 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: prod/app1 = 10, prod/app2 = 20, dev/app1 = 30
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 10)
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts1, 20)
-		_ = agg.WithLabelValues(groupBy, []string{"dev", "app1"})(ts1, 30)
+		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
+		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
+		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
 
 		// ts2: prod/app1 = 15, prod/app2 = 25, dev/app2 = 35
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts2, 15)
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts2, 25)
-		_ = agg.WithLabelValues(groupBy, []string{"dev", "app2"})(ts2, 35)
+		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
+		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
+		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
 
 		// Add more data to same groups to test aggregation
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 5)  // prod/app1 at ts1 should now be 15
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts2, 10) // prod/app1 at ts2 should now be 25
+		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be 15
+		_ = agg.Add(ts2, 10, groupBy, []string{"prod", "app1"}) // prod/app1 at ts2 should now be 25
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -75,18 +75,18 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: prod/app1 = 10, prod/app2 = 20, dev/app1 = 30
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 10)
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts1, 20)
-		_ = agg.WithLabelValues(groupBy, []string{"dev", "app1"})(ts1, 30)
+		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
+		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
+		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
 
 		// ts2: prod/app1 = 15, prod/app2 = 25, dev/app2 = 35
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts2, 15)
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts2, 25)
-		_ = agg.WithLabelValues(groupBy, []string{"dev", "app2"})(ts2, 35)
+		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
+		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
+		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
 
 		// Add more data to same groups to test aggregation
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 5)  // prod/app1 at ts1 should now be 7.5
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts2, 10) // prod/app1 at ts2 should now be 12.5
+		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be 7.5
+		_ = agg.Add(ts2, 10, groupBy, []string{"prod", "app1"}) // prod/app1 at ts2 should now be 12.5
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -117,24 +117,24 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: add one datapoint for prod/app1, prod/app2, and dev/app1
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 10)
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts1, 20)
-		_ = agg.WithLabelValues(groupBy, []string{"dev", "app1"})(ts1, 30)
+		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
+		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
+		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
 
 		// ts2: add another datapoint for prod/app1, prod/app2, and dev/app2
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts2, 15)
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts2, 25)
-		_ = agg.WithLabelValues(groupBy, []string{"dev", "app2"})(ts2, 35)
+		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
+		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
+		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
 
 		// ts3: add another datapoint for prod/app1, prod/app2, and dev/app2
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts3, 15)
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts3, 25)
-		_ = agg.WithLabelValues(groupBy, []string{"dev", "app2"})(ts3, 35)
+		_ = agg.Add(ts3, 15, groupBy, []string{"prod", "app1"})
+		_ = agg.Add(ts3, 25, groupBy, []string{"prod", "app2"})
+		_ = agg.Add(ts3, 35, groupBy, []string{"dev", "app2"})
 
 		// Add more datapoints for prod/app1 and prod/app2
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 5)  // prod/app1 at ts1 should now be count 2
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts2, 10) // prod/app2 at ts2 should now be count 2
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 25) // prod/app1 at ts1 should now be count 3
+		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be count 2
+		_ = agg.Add(ts2, 10, groupBy, []string{"prod", "app2"}) // prod/app2 at ts2 should now be count 2
+		_ = agg.Add(ts1, 25, groupBy, []string{"prod", "app1"}) // prod/app1 at ts1 should now be count 3
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -168,19 +168,19 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: add one datapoint for prod/app1, prod/app2, and dev/app1
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 10)
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts1, 20)
-		_ = agg.WithLabelValues(groupBy, []string{"dev", "app1"})(ts1, 30)
+		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
+		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
+		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
 
 		// ts2: add another datapoint for prod/app1, prod/app2, and dev/app2
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts2, 15)
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts2, 25)
-		_ = agg.WithLabelValues(groupBy, []string{"dev", "app2"})(ts2, 35)
+		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
+		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
+		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
 
 		// Add more datapoints for prod/app1 and prod/app2
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 5)  // prod/app1 at ts1 should still be 10
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts2, 50) // prod/app2 at ts2 should now be 50
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 15) // prod/app1 at ts1 should now be 15
+		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should still be 10
+		_ = agg.Add(ts2, 50, groupBy, []string{"prod", "app2"}) // prod/app2 at ts2 should now be 50
+		_ = agg.Add(ts1, 15, groupBy, []string{"prod", "app1"}) // prod/app1 at ts1 should now be 15
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -210,20 +210,19 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: add one datapoint for prod/app1, prod/app2, and dev/app1
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 10)
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts1, 20)
-		_ = agg.WithLabelValues(groupBy, []string{"dev", "app1"})(ts1, 30)
-		_ = agg.WithLabelValues(groupBy, []string{"dev", "app1"})(ts1, 30)
+		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
+		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
+		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
 
 		// ts2: add another datapoint for prod/app1, prod/app2, and dev/app2
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts2, 15)
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts2, 25)
-		_ = agg.WithLabelValues(groupBy, []string{"dev", "app2"})(ts2, 35)
+		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
+		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
+		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
 
 		// Add more datapoints for prod/app1 and prod/app2
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 5)  // prod/app1 at ts1 should now be 5
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts2, 40) // prod/app2 at ts2 should still be 25
-		_ = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 25) // prod/app1 at ts1 should still be 5
+		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be 5
+		_ = agg.Add(ts2, 40, groupBy, []string{"prod", "app2"}) // prod/app2 at ts2 should still be 25
+		_ = agg.Add(ts1, 25, groupBy, []string{"prod", "app1"}) // prod/app1 at ts1 should still be 5
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -256,17 +255,17 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: prod/app1 = 10, prod/app2 = 20, dev/app1 = 30
-		_ = agg.WithLabelValues(groupBy, []string{})(ts1, 10) // "prod", "app1"
-		_ = agg.WithLabelValues(groupBy, []string{})(ts1, 20) // "prod", "app2"
-		_ = agg.WithLabelValues(groupBy, []string{})(ts1, 30) // "dev", "app1"
+		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"}) // "prod", "app1"
+		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"}) // "prod", "app2"
+		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})  // "dev", "app1"
 
 		// ts2: prod/app1 = 15, prod/app2 = 25, dev/app2 = 35
-		_ = agg.WithLabelValues(groupBy, []string{})(ts2, 15) // "prod", "app1"
-		_ = agg.WithLabelValues(groupBy, []string{})(ts2, 25) // "prod", "app2"
-		_ = agg.WithLabelValues(groupBy, []string{})(ts2, 35) // "dev", "app2"
+		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"}) // "prod", "app1"
+		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"}) // "prod", "app2"
+		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})  // "dev", "app2"
 
-		_ = agg.WithLabelValues(groupBy, []string{})(ts1, 5)  // "prod", "app1"
-		_ = agg.WithLabelValues(groupBy, []string{})(ts2, 10) // "prod", "app1"
+		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // "prod", "app1"
+		_ = agg.Add(ts2, 10, groupBy, []string{"prod", "app1"}) // "prod", "app1"
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -301,17 +300,17 @@ func TestAggregator(t *testing.T) {
 		agg.AddLabels(buildFields("env", "service", "cluster", "method"))
 
 		// Add test data
-		_ = agg.WithLabelValues(buildFields("env", "service"), []string{"prod", "app1"})(ts1, 10)
-		_ = agg.WithLabelValues(buildFields("env", "cluster"), []string{"prod", "east-1"})(ts1, 20)
-		_ = agg.WithLabelValues(buildFields("method"), []string{"init"})(ts1, 30)
+		_ = agg.Add(ts1, 10, buildFields("env", "service"), []string{"prod", "app1"})
+		_ = agg.Add(ts1, 20, buildFields("env", "cluster"), []string{"prod", "east-1"})
+		_ = agg.Add(ts1, 30, buildFields("method"), []string{"init"})
 
-		_ = agg.WithLabelValues(buildFields("env", "service"), []string{"prod", "app1"})(ts2, 15)
-		_ = agg.WithLabelValues(buildFields("env", "cluster"), []string{"prod", "east-1"})(ts2, 25)
-		_ = agg.WithLabelValues(buildFields("method"), []string{"init"})(ts2, 35)
+		_ = agg.Add(ts2, 15, buildFields("env", "service"), []string{"prod", "app1"})
+		_ = agg.Add(ts2, 25, buildFields("env", "cluster"), []string{"prod", "east-1"})
+		_ = agg.Add(ts2, 35, buildFields("method"), []string{"init"})
 
 		// Add more data to same groups to test aggregation
-		_ = agg.WithLabelValues(buildFields("env", "service"), []string{"prod", "app1"})(ts1, 5)
-		_ = agg.WithLabelValues(buildFields("env", "cluster"), []string{"prod", "east-1"})(ts2, 10)
+		_ = agg.Add(ts1, 5, buildFields("env", "service"), []string{"prod", "app1"})
+		_ = agg.Add(ts2, 10, buildFields("env", "cluster"), []string{"prod", "east-1"})
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -344,29 +343,29 @@ func TestAggregator(t *testing.T) {
 		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
 
 		// Add first 3 series at ts1 - should succeed
-		err := agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts1, 10)
+		err := agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
 		require.NoError(t, err)
 
-		err = agg.WithLabelValues(groupBy, []string{"prod", "app2"})(ts1, 20)
+		err = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
 		require.NoError(t, err)
 
-		err = agg.WithLabelValues(groupBy, []string{"dev", "app1"})(ts1, 30)
+		err = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
 		require.NoError(t, err)
 
 		// Try to add 4th unique series should fail
-		err = agg.WithLabelValues(groupBy, []string{"dev", "app2"})(ts2, 10)
+		err = agg.Add(ts2, 10, groupBy, []string{"dev", "app2"})
 		require.Error(t, err)
 		require.True(t, errors.Is(err, ErrSeriesLimitExceeded))
 
 		// Adding same series again at different timestamp should succeed (not a new unique series)
-		err = agg.WithLabelValues(groupBy, []string{"prod", "app1"})(ts2, 15)
+		err = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
 		require.NoError(t, err)
 
 		// unset the limit
 		agg.SetMaxSeries(0)
 
 		// Now adding new series should succeed
-		err = agg.WithLabelValues(groupBy, []string{"dev", "app2"})(ts2, 10)
+		err = agg.Add(ts2, 10, groupBy, []string{"dev", "app2"})
 		require.NoError(t, err)
 	})
 }
@@ -389,7 +388,7 @@ func BenchmarkAggregator(b *testing.B) {
 			cluster := fmt.Sprintf("cluster-%d", i%10)
 			service := fmt.Sprintf("service-%d", i%7)
 
-			_ = agg.WithLabelValues(fields, []string{env, cluster, service})(ts, 10)
+			_ = agg.Add(ts, 10, fields, []string{env, cluster, service})
 		}
 	})
 
@@ -398,11 +397,12 @@ func BenchmarkAggregator(b *testing.B) {
 		agg.AddLabels(fields)
 
 		b.ResetTimer()
-		adderFn := agg.WithLabelValues(fields, []string{"prod", "app1", "east-1"})
+		unbind := agg.BindLabels(fields, []string{"prod", "app1", "east-1"})
 		for i := 0; i < b.N; i++ {
 			ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(i) * time.Second)
 
-			_ = adderFn(ts, 10)
+			_ = agg.Add(ts, 10, fields, []string{"prod", "app1", "east-1"})
 		}
+		unbind()
 	})
 }

--- a/pkg/engine/internal/executor/aggregator_test.go
+++ b/pkg/engine/internal/executor/aggregator_test.go
@@ -255,17 +255,17 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: prod/app1 = 10, prod/app2 = 20, dev/app1 = 30
-		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"}) // "prod", "app1"
-		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"}) // "prod", "app2"
-		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})  // "dev", "app1"
+		_ = agg.Add(ts1, 10, groupBy, []string{}) // "prod", "app1"
+		_ = agg.Add(ts1, 20, groupBy, []string{}) // "prod", "app2"
+		_ = agg.Add(ts1, 30, groupBy, []string{}) // "dev", "app1"
 
 		// ts2: prod/app1 = 15, prod/app2 = 25, dev/app2 = 35
-		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"}) // "prod", "app1"
-		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"}) // "prod", "app2"
-		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})  // "dev", "app2"
+		_ = agg.Add(ts2, 15, groupBy, []string{}) // "prod", "app1"
+		_ = agg.Add(ts2, 25, groupBy, []string{}) // "prod", "app2"
+		_ = agg.Add(ts2, 35, groupBy, []string{}) // "dev", "app2"
 
-		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // "prod", "app1"
-		_ = agg.Add(ts2, 10, groupBy, []string{"prod", "app1"}) // "prod", "app1"
+		_ = agg.Add(ts1, 5, groupBy, []string{})  // "prod", "app1"
+		_ = agg.Add(ts2, 10, groupBy, []string{}) // "prod", "app1"
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -404,5 +404,24 @@ func BenchmarkAggregator(b *testing.B) {
 			_ = agg.Add(ts, 10, fields, []string{"prod", "app1", "east-1"})
 		}
 		unbind()
+	})
+
+	b.Run("case=build_record", func(b *testing.B) {
+		agg := newAggregator(10, aggregationOperationSum)
+		agg.AddLabels(fields)
+
+		for i := 0; i < 8192; i++ {
+			ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(i) * time.Second)
+			env := fmt.Sprintf("env-%d", i%3)
+			cluster := fmt.Sprintf("cluster-%d", i%10)
+			service := fmt.Sprintf("service-%d", i%7)
+
+			_ = agg.Add(ts, 10, fields, []string{env, cluster, service})
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = agg.BuildRecord()
+		}
 	})
 }

--- a/pkg/engine/internal/executor/pipeline_utils.go
+++ b/pkg/engine/internal/executor/pipeline_utils.go
@@ -37,6 +37,13 @@ func (p *BufferedPipeline) Read(_ context.Context) (arrow.RecordBatch, error) {
 	return p.records[p.current], nil
 }
 
+// Reset rewinds the pipeline so the next Read returns the first record again.
+// Records are not released; the caller must still call Close when done.
+// Primarily used for testing.
+func (p *BufferedPipeline) Reset() {
+	p.current = -1
+}
+
 // Close implements Pipeline. It releases all unreturned records.
 func (p *BufferedPipeline) Close() {
 	p.records = nil

--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -234,12 +234,13 @@ func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch,
 				labelValues := labelValuesCache.getLabelValues(arrays, row)
 				labels := fieldsCache.getFields(arrays, groupingFields, row)
 
-				aggregatorAdd := r.aggregator.WithLabelValues(labels, labelValues)
+				unbind := r.aggregator.BindLabels(labels, labelValues)
 				for _, w := range windows {
-					if err := aggregatorAdd(w.end, value); err != nil {
+					if err := r.aggregator.Add(w.end, value, labels, labelValues); err != nil {
 						return nil, err
 					}
 				}
+				unbind()
 			}
 		}
 	}

--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"sort"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -31,16 +30,14 @@ type rangeAggregationOptions struct {
 	maxQuerySeries int // maximum number of unique series allowed
 }
 
-var (
-	// rangeAggregationOperations holds the mapping of range aggregation types to operations for an aggregator.
-	rangeAggregationOperations = map[types.RangeAggregationType]aggregationOperation{
-		types.RangeAggregationTypeSum:   aggregationOperationSum,
-		types.RangeAggregationTypeCount: aggregationOperationCount,
-		types.RangeAggregationTypeMax:   aggregationOperationMax,
-		types.RangeAggregationTypeMin:   aggregationOperationMin,
-		types.RangeAggregationTypeAvg:   aggregationOperationAvg,
-	}
-)
+// rangeAggregationOperations holds the mapping of range aggregation types to operations for an aggregator.
+var rangeAggregationOperations = map[types.RangeAggregationType]aggregationOperation{
+	types.RangeAggregationTypeSum:   aggregationOperationSum,
+	types.RangeAggregationTypeCount: aggregationOperationCount,
+	types.RangeAggregationTypeMax:   aggregationOperationMax,
+	types.RangeAggregationTypeMin:   aggregationOperationMin,
+	types.RangeAggregationTypeAvg:   aggregationOperationAvg,
+}
 
 // window is a time interval where start is exclusive and end is inclusive
 // Refer to [logql.batchRangeVectorIterator].
@@ -52,6 +49,16 @@ type window struct {
 // The window start is exclusive, the window end is inclusive.
 func (w window) Contains(t time.Time) bool {
 	return t.After(w.start) && !t.After(w.end)
+}
+
+// cmpWindowStartTime compares a window's lower bound to t for [slices.BinarySearchFunc].
+func cmpWindowStartTime(w window, t time.Time) int {
+	return w.start.Compare(t)
+}
+
+// cmpWindowEndTime compares a window's upper bound to t for [slices.BinarySearchFunc].
+func cmpWindowEndTime(w window, t time.Time) int {
+	return w.end.Compare(t)
 }
 
 // timestampMatchingWindowsFunc resolves matching range interval windows for a specific timestamp.
@@ -385,28 +392,24 @@ func (f *matcherFactory) createOverlappingMatcher(windows []window) timestampMat
 		}
 
 		// Find the last window that could contain the timestamp.
-		// We need to find the last window where t > window.startTs
-		// so search for the first window where t <= window.startTs
-		firstOOBIndex := sort.Search(len(windows), func(i int) bool {
-			return t.Compare(windows[i].start) <= 0
-		})
+		// We need the last window where t > window.start, i.e. the index before
+		// the first window where t <= window.start. Use BinarySearchFunc with a
+		// package-level cmp so we do not allocate a closure per call (unlike sort.Search).
+		firstOOBIndex, _ := slices.BinarySearchFunc(windows, t, cmpWindowStartTime)
 
 		windowIndex := firstOOBIndex - 1
 		if windowIndex < 0 {
 			return nil
 		}
 
-		// Iterate backwards from last matching window to find all matches
-		var result []window
-		for _, window := range slices.Backward(windows[:windowIndex+1]) {
-			if t.Compare(window.start) > 0 && t.Compare(window.end) <= 0 {
-				result = append(result, window)
-			} else if t.Compare(window.end) > 0 {
-				// we've gone past all possible matches
-				break
-			}
+		// For every i in [0, windowIndex], t > windows[i].start (by definition of windowIndex).
+		// Containment is therefore equivalent to t <= windows[i].end. Ends are non-decreasing
+		// in i, so matching indices are always a suffix [low, windowIndex] of that prefix.
+		prefix := windows[:windowIndex+1]
+		low, _ := slices.BinarySearchFunc(prefix, t, cmpWindowEndTime)
+		if low > windowIndex {
+			return nil
 		}
-
-		return result
+		return windows[low : windowIndex+1]
 	}
 }

--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -234,8 +234,9 @@ func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch,
 				labelValues := labelValuesCache.getLabelValues(arrays, row)
 				labels := fieldsCache.getFields(arrays, groupingFields, row)
 
+				aggregatorAdd := r.aggregator.WithLabelValues(labels, labelValues)
 				for _, w := range windows {
-					if err := r.aggregator.Add(w.end, value, labels, labelValues); err != nil {
+					if err := aggregatorAdd(w.end, value); err != nil {
 						return nil, err
 					}
 				}

--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -236,7 +236,7 @@ func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch,
 
 				unbind := r.aggregator.BindLabels(labels, labelValues)
 				for _, w := range windows {
-					if err := r.aggregator.Add(w.end, value, labels, labelValues); err != nil {
+					if err := r.aggregator.Add(w.end, value, nil, nil); err != nil {
 						return nil, err
 					}
 				}

--- a/pkg/engine/internal/executor/range_aggregation_bench_test.go
+++ b/pkg/engine/internal/executor/range_aggregation_bench_test.go
@@ -1,0 +1,205 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/assertions"
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/semconv"
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+	"github.com/grafana/loki/v3/pkg/util/arrowtest"
+)
+
+// BenchmarkRangeAggregationPipeline measures pipeline.Read for each window strategy.
+// The pipeline and input batches are built once per subbenchmark; each iteration only
+// resets cursors and aggregator state so Read can run again.
+func BenchmarkRangeAggregationPipeline(b *testing.B) {
+	old := assertions.Enabled
+	assertions.Enabled = false
+	b.Cleanup(func() { assertions.Enabled = old })
+
+	groupBy := buildRangeAggregationGrouping()
+	schema, rows := buildRangeAggregationInput()
+	inputRecords := buildInputRecords(b, schema, rows)
+	b.Cleanup(func() {
+		for _, rec := range inputRecords {
+			rec.Release()
+		}
+	})
+
+	cases := []struct {
+		name string
+		opts rangeAggregationOptions
+	}{
+		{
+			name: "case=instant",
+			opts: rangeAggregationOptions{
+				grouping:      groupBy,
+				startTs:       time.Unix(1000, 0),
+				endTs:         time.Unix(1000, 0),
+				rangeInterval: 1000 * time.Second,
+				step:          0,
+				operation:     types.RangeAggregationTypeCount,
+			},
+		},
+		{
+			name: "case=aligned",
+			opts: rangeAggregationOptions{
+				grouping:      groupBy,
+				startTs:       time.Unix(10, 0),
+				endTs:         time.Unix(40, 0),
+				rangeInterval: 10 * time.Second,
+				step:          10 * time.Second,
+				operation:     types.RangeAggregationTypeCount,
+			},
+		},
+		{
+			name: "case=gapped",
+			opts: rangeAggregationOptions{
+				grouping:      groupBy,
+				startTs:       time.Unix(10, 0),
+				endTs:         time.Unix(40, 0),
+				rangeInterval: 5 * time.Second,
+				step:          10 * time.Second,
+				operation:     types.RangeAggregationTypeCount,
+			},
+		},
+		{
+			name: "case=overlapping",
+			opts: rangeAggregationOptions{
+				grouping:      groupBy,
+				startTs:       time.Unix(10, 0),
+				endTs:         time.Unix(40, 0),
+				rangeInterval: 5 * time.Minute,
+				step:          10 * time.Second,
+				operation:     types.RangeAggregationTypeCount,
+			},
+		},
+	}
+
+	ctx := context.Background()
+	evaluator := newExpressionEvaluator()
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			input := NewBufferedPipeline(inputRecords...)
+			pipeline, err := newRangeAggregationPipeline([]Pipeline{input}, evaluator, tc.opts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if err := pipeline.Open(ctx); err != nil {
+				b.Fatal(err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				// Read all the records each iteration
+				for {
+					rec, err := pipeline.Read(ctx)
+					if err != nil {
+						if errors.Is(err, EOF) {
+							resetRangeAggregationPipeline(pipeline, input)
+							break
+						}
+						b.Fatal(err)
+					}
+					if rec != nil {
+						rec.Release()
+					}
+				}
+			}
+		})
+	}
+}
+
+// resetRangeAggregationPipeline rewinds a range aggregation pipeline so Read can be
+// invoked again with the same inputs. rangeAggregationPipeline is single-shot by
+// default (inputsExhausted); this is intended for benchmarks and tests only.
+func resetRangeAggregationPipeline(p *rangeAggregationPipeline, input *BufferedPipeline) {
+	p.inputsExhausted = false
+	p.aggregator.Reset()
+	input.Reset()
+}
+
+func buildInputRecords(b *testing.B, schema *arrow.Schema, rows []arrowtest.Rows) []arrow.RecordBatch {
+	b.Helper()
+
+	records := make([]arrow.RecordBatch, len(rows))
+	for i, r := range rows {
+		records[i] = r.Record(memory.DefaultAllocator, schema)
+	}
+	return records
+}
+
+func buildRangeAggregationGrouping() physical.Grouping {
+	return physical.Grouping{
+		Columns: []physical.ColumnExpression{
+			&physical.ColumnExpr{
+				Ref: types.ColumnRef{
+					Column: "env",
+					Type:   types.ColumnTypeAmbiguous,
+				},
+			},
+			&physical.ColumnExpr{
+				Ref: types.ColumnRef{
+					Column: "service",
+					Type:   types.ColumnTypeAmbiguous,
+				},
+			},
+		},
+		Without: false,
+	}
+}
+
+// benchmarkRangeAggregationWindows builds query windows the same way as rangeAggregationPipeline.init.
+func benchmarkRangeAggregationWindows(opts rangeAggregationOptions) []window {
+	windows := []window{}
+	cur := opts.startTs
+	endUnix := opts.endTs.UnixNano()
+	for cur.UnixNano() <= endUnix {
+		windows = append(windows, window{start: cur.Add(-opts.rangeInterval), end: cur})
+		if opts.step == 0 {
+			break
+		}
+		cur = cur.Add(opts.step)
+	}
+	return windows
+}
+
+func buildRangeAggregationInput() (*arrow.Schema, []arrowtest.Rows) {
+	fields := []arrow.Field{
+		semconv.FieldFromFQN(colTs, false),
+		semconv.FieldFromFQN(colEnv, false),
+		semconv.FieldFromFQN(colSvc, false),
+	}
+	schema := arrow.NewSchema(fields, nil)
+
+	const (
+		rowsPerBatch = 1024
+		batches      = 8
+	)
+
+	rows := make([]arrowtest.Rows, batches)
+	base := time.Unix(12, 0).UTC()
+	for batch := range batches {
+		batchRows := make(arrowtest.Rows, rowsPerBatch)
+		for i := range rowsPerBatch {
+			offset := batch*rowsPerBatch + i
+			batchRows[i] = arrowtest.Row{
+				colTs:  base.Add(time.Duration(offset%28) * time.Second),
+				colEnv: []string{"prod", "dev", "staging"}[offset%3],
+				colSvc: []string{"app1", "app2", "app3", "app4"}[offset%4],
+			}
+		}
+		rows[batch] = batchRows
+	}
+
+	return schema, rows
+}

--- a/pkg/engine/internal/executor/util_test.go
+++ b/pkg/engine/internal/executor/util_test.go
@@ -129,5 +129,8 @@ func (p *ArrowtestPipeline) Read(_ context.Context) (arrow.RecordBatch, error) {
 	return rows.Record(memory.DefaultAllocator, schema), nil
 }
 
+// Reset rewinds the pipeline so the next Read emits from the first batch again.
+func (p *ArrowtestPipeline) Reset() { p.cur = 0 }
+
 // Close implements [Pipeline], immediately exhausting the pipeline.
 func (p *ArrowtestPipeline) Close() { p.cur = math.MaxInt64 }

--- a/pkg/engine/internal/executor/vector_aggregate.go
+++ b/pkg/engine/internal/executor/vector_aggregate.go
@@ -42,15 +42,13 @@ type vectorAggregationPipeline struct {
 	identCache *semconv.IdentifierCache
 }
 
-var (
-	vectorAggregationOperations = map[types.VectorAggregationType]aggregationOperation{
-		types.VectorAggregationTypeSum:   aggregationOperationSum,
-		types.VectorAggregationTypeCount: aggregationOperationCount,
-		types.VectorAggregationTypeAvg:   aggregationOperationAvg,
-		types.VectorAggregationTypeMax:   aggregationOperationMax,
-		types.VectorAggregationTypeMin:   aggregationOperationMin,
-	}
-)
+var vectorAggregationOperations = map[types.VectorAggregationType]aggregationOperation{
+	types.VectorAggregationTypeSum:   aggregationOperationSum,
+	types.VectorAggregationTypeCount: aggregationOperationCount,
+	types.VectorAggregationTypeAvg:   aggregationOperationAvg,
+	types.VectorAggregationTypeMax:   aggregationOperationMax,
+	types.VectorAggregationTypeMin:   aggregationOperationMin,
+}
 
 func newVectorAggregationPipeline(inputs []Pipeline, evaluator *expressionEvaluator, opts vectorAggregationOptions) (*vectorAggregationPipeline, error) {
 	if len(inputs) == 0 {
@@ -168,7 +166,8 @@ func (v *vectorAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch
 				labelValues := labelValuesCache.getLabelValues(arrays, row)
 				labels := fieldsCache.getFields(arrays, groupingFields, row)
 
-				if err := v.aggregator.Add(tsCol.Value(row).ToTime(arrow.Nanosecond), valueArr.Value(row), labels, labelValues); err != nil {
+				aggregatorAdd := v.aggregator.WithLabelValues(labels, labelValues)
+				if err := aggregatorAdd(tsCol.Value(row).ToTime(arrow.Nanosecond), valueArr.Value(row)); err != nil {
 					return nil, err
 				}
 			}

--- a/pkg/engine/internal/executor/vector_aggregate.go
+++ b/pkg/engine/internal/executor/vector_aggregate.go
@@ -166,8 +166,7 @@ func (v *vectorAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch
 				labelValues := labelValuesCache.getLabelValues(arrays, row)
 				labels := fieldsCache.getFields(arrays, groupingFields, row)
 
-				aggregatorAdd := v.aggregator.WithLabelValues(labels, labelValues)
-				if err := aggregatorAdd(tsCol.Value(row).ToTime(arrow.Nanosecond), valueArr.Value(row)); err != nil {
+				if err := v.aggregator.Add(tsCol.Value(row).ToTime(arrow.Nanosecond), valueArr.Value(row), labels, labelValues); err != nil {
 					return nil, err
 				}
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Improves the performance of the aggregator with two optimizations.
1. Avoids recomputing the series hash key on every call to Add. This was particularly bad from the range aggregator because it would call Add in a loop on the same labels. (-15% duration for sequential adds)
2. Replaces the multi-level map with a single-level map using a composite key. This means it only applies the hash function once and avoids multiple hops through memory on each Add. (-24% duration)

Benchstat results
```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/engine/internal/executor
cpu: Apple M3 Max
                                      │ before.txt  │            after_bind.txt             │         after_singlemap.txt         │
                                      │   sec/op    │   sec/op     vs base                  │   sec/op     vs base                │
Aggregator/case=interleaved_series-14   480.9n ± 1%   486.6n ± 2%   +1.17% (p=0.025 n=10)     405.2n ± 2%  -15.76% (p=0.000 n=10)
Aggregator/case=single_series-14        356.0n ± 1%   303.1n ± 3%  -14.86% (p=0.000 n=10)     214.8n ± 2%  -39.66% (p=0.000 n=10)
Aggregator/case=build_record-14         2.171m ± 2%                                           1.824m ± 2%  -16.00% (p=0.000 n=10)
geomean                                 7.191µ        384.0n        -7.19%                ¹   5.415µ       -24.70%
¹ benchmark set differs from baseline; geomeans may not be comparable

                                      │  before.txt  │            after_bind.txt            │         after_singlemap.txt          │
                                      │     B/op     │    B/op     vs base                  │     B/op      vs base                │
Aggregator/case=interleaved_series-14     365.5 ± 1%   366.0 ± 1%        ~ (p=0.559 n=10)       176.0 ± 3%  -51.85% (p=0.000 n=10)
Aggregator/case=single_series-14          370.0 ± 2%   331.5 ± 3%  -10.41% (p=0.000 n=10)       210.5 ± 2%  -43.11% (p=0.000 n=10)
Aggregator/case=build_record-14         1.875Mi ± 0%                                          2.245Mi ± 0%  +19.72% (p=0.000 n=10)
geomean                                 6.280Ki        348.3        -5.28%                ¹   4.331Ki       -31.04%
¹ benchmark set differs from baseline; geomeans may not be comparable

                                      │ before.txt │           after_bind.txt            │        after_singlemap.txt         │
                                      │ allocs/op  │ allocs/op   vs base                 │ allocs/op   vs base            │
Aggregator/case=interleaved_series-14   6.000 ± 0%   6.000 ± 0%       ~ (p=1.000 n=10) ¹   4.000 ± 0%  -33.33% (p=0.000 n=10)
Aggregator/case=single_series-14        3.000 ± 0%   3.000 ± 0%       ~ (p=1.000 n=10) ¹   1.000 ± 0%  -66.67% (p=0.000 n=10)
Aggregator/case=build_record-14         134.0 ± 0%                                         135.0 ± 0%   +0.75% (p=0.000 n=10)
geomean                                 13.41        4.243       +0.00%                ²   8.143       -39.28%
¹ all samples are equal
² benchmark set differs from baseline; geomeans may not be comparable
```

There are a few more ideas but these two were the most impactful without bigger changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core aggregation state storage and introduces label binding/memoization in the `aggregator` hot path, which could affect correctness (e.g., key computation/order, reuse lifecycle) despite being performance-focused.
> 
> **Overview**
> Improves aggregation performance by reworking the `aggregator` to store states in a single map keyed by a composite `groupKey` (`timestamp`+series hash) instead of a nested `timestamp -> series` map, and by sorting/iterating over these composite keys when building the output record.
> 
> Adds `BindLabels`/memoization so callers can cache the computed series hash and label/value slices across repeated `Add` calls; `range_aggregation` now binds once per input row and reuses it across the per-window `Add` loop. Benchmarks were expanded to cover interleaved series, single-series with binding, and `BuildRecord` performance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81dbb901ec11cdf72169d0f88e3a171fed1ab565. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->