### PR TITLE
chore: Add better error message on predicate panic

### DIFF
--- a/pkg/dataobj/sections/logs/row_predicate_order.go
+++ b/pkg/dataobj/sections/logs/row_predicate_order.go
@@ -1,6 +1,7 @@
 package logs
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
@@ -172,7 +173,7 @@ func getPredicateSelectivity(p dataset.Predicate) selectivityScore {
 		// We might want these evaluated towards the end.
 		return selectivityScore(0.7)
 	default:
-		panic("unknown predicate type")
+		panic(fmt.Sprintf("unknown predicate type: %T", p))
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Includes unexpected type in panic message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes a panic message to include the unexpected predicate type, with no impact on predicate ordering logic unless a panic occurs.
> 
> **Overview**
> Improves debugging for unexpected `dataset.Predicate` implementations in `getPredicateSelectivity` by including the concrete type (`%T`) in the panic message, and adds the required `fmt` import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59744c4d1cee0d1ec53c402abed1db38e957e5c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->