### PR TITLE
refactor: migrate bloombuild/planner and compactor/jobqueue to sync/atomic

### DIFF
--- a/pkg/bloombuild/planner/planner.go
+++ b/pkg/bloombuild/planner/planner.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -14,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/bloombuild/common"
 	"github.com/grafana/loki/v3/pkg/bloombuild/planner/queue"

--- a/pkg/bloombuild/planner/planner_test.go
+++ b/pkg/bloombuild/planner/planner_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
 	"github.com/grafana/loki/v3/pkg/bloombuild/planner/plannertest"

--- a/pkg/bloombuild/planner/task.go
+++ b/pkg/bloombuild/planner/task.go
@@ -2,9 +2,8 @@ package planner
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
-
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/bloombuild/protos"
 )

--- a/pkg/compactor/jobqueue/queue_test.go
+++ b/pkg/compactor/jobqueue/queue_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"

--- a/pkg/compactor/jobqueue/queue_test.go
+++ b/pkg/compactor/jobqueue/queue_test.go
@@ -32,9 +32,9 @@ type mockBuilder struct {
 
 func (m *mockBuilder) OnJobResponse(res *compactor_grpc.JobResult) error {
 	if res.Error != "" {
-		m.jobsFailed.Inc()
+		m.jobsFailed.Add(1)
 	} else {
-		m.jobsSucceeded.Inc()
+		m.jobsSucceeded.Add(1)
 	}
 
 	return nil
@@ -46,7 +46,7 @@ func (m *mockBuilder) BuildJobs(ctx context.Context, jobsChan chan<- *compactor_
 		case <-ctx.Done():
 			return
 		case jobsChan <- job:
-			m.jobsSentCount.Inc()
+			m.jobsSentCount.Add(1)
 		}
 	}
 

--- a/pkg/compactor/jobqueue/worker.go
+++ b/pkg/compactor/jobqueue/worker.go
@@ -5,13 +5,13 @@ import (
 	"flag"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/backoff"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/compactor/client/grpc"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"

--- a/pkg/compactor/jobqueue/worker_test.go
+++ b/pkg/compactor/jobqueue/worker_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/grafana/dskit/flagext"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
 	compactor_grpc "github.com/grafana/loki/v3/pkg/compactor/client/grpc"


### PR DESCRIPTION
This PR starts the migration from `go.uber.org/atomic` to the standard library `sync/atomic` package, as proposed in #20673.

Since Go 1.19, `sync/atomic` provides typed wrappers (`atomic.Int64`, `atomic.Bool`, `atomic.Int32`) that offer the same safety guarantees as `go.uber.org/atomic`. Moving to the standard library reduces external dependencies while keeping the same API surface.

This initial PR migrates two self-contained package groups:

- `pkg/bloombuild/planner` (task.go, planner.go, planner_test.go)
- `pkg/compactor/jobqueue` (worker.go, queue_test.go, worker_test.go)

These packages only use `atomic.Int64`, `atomic.Int32`, and `atomic.Bool` -- all available in stdlib since 1.19. No custom wrapper types are needed for these changes.

The migration is incremental: other packages using `atomic.Float64` or `atomic.Duration` will require an `atomicutil` helper package, which can be added in a follow-up PR.
