### PR TITLE
feat(canary): add -disable-tail flag to skip websocket tailing

### DIFF
--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -47,6 +47,7 @@ func main() {
 	addr := flag.String("addr", "", "The Loki server URL:Port, e.g. loki:3100")
 	push := flag.Bool("push", false, "Push the logs directly to given Loki address")
 	useTLS := flag.Bool("tls", false, "Does the loki connection use TLS?")
+	disableTail := flag.Bool("disable-tail", false, "Disable the websocket-based tail for reading log entries from Loki. Verification falls back to query_range polling only.")
 	certFile := flag.String("cert-file", "", "Client PEM encoded X.509 certificate for optional use with TLS connection to Loki")
 	keyFile := flag.String("key-file", "", "Client PEM encoded X.509 key for optional use with TLS connection to Loki")
 	caFile := flag.String("ca-file", "", "Client certificate authority for optional use with TLS connection to Loki")
@@ -215,7 +216,7 @@ func main() {
 
 		c.writer = writer.NewWriter(entryWriter, sentChan, *interval, *outOfOrderMin, *outOfOrderMax, *outOfOrderPercentage, *size, logger)
 		var err error
-		c.reader, err = reader.NewReader(os.Stderr, receivedChan, *useTLS, tlsConfig, *caFile, *certFile, *keyFile, *addr, *user, *pass, *tenantID, *queryTimeout, *lName, *lVal, *sName, *sValue, *interval, *queryAppend, *labels)
+		c.reader, err = reader.NewReader(os.Stderr, receivedChan, *useTLS, tlsConfig, *caFile, *certFile, *keyFile, *addr, *user, *pass, *tenantID, *queryTimeout, *lName, *lVal, *sName, *sValue, *interval, *queryAppend, *labels, *disableTail)
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Unable to create reader for Loki querier, check config: %s", err)
 			os.Exit(1)

--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -71,6 +71,7 @@ type Reader struct {
 	done            chan struct{}
 	queryAppend     string
 	labelSelector   string
+	disableTail     bool
 }
 
 func buildLabelSelector(labels, sName, sValue, lName, lVal string) (string, error) {
@@ -112,6 +113,7 @@ func NewReader(writer io.Writer,
 	interval time.Duration,
 	queryAppend string,
 	labels string,
+	disableTail bool,
 ) (*Reader, error) {
 	h := http.Header{}
 
@@ -176,18 +178,26 @@ func NewReader(writer io.Writer,
 		shuttingDown:    false,
 		queryAppend:     queryAppend,
 		labelSelector:   labelSel,
+		disableTail:     disableTail,
 	}
 
-	go rd.run()
+	if disableTail {
+		go func() {
+			<-rd.quit
+			close(rd.done)
+		}()
+	} else {
+		go rd.run()
 
-	go func() {
-		<-rd.quit
-		if rd.conn != nil {
-			fmt.Fprintf(rd.w, "shutting down reader\n")
-			rd.shuttingDown = true
-			_ = rd.conn.Close()
-		}
-	}()
+		go func() {
+			<-rd.quit
+			if rd.conn != nil {
+				fmt.Fprintf(rd.w, "shutting down reader\n")
+				rd.shuttingDown = true
+				_ = rd.conn.Close()
+			}
+		}()
+	}
 
 	return &rd, nil
 }

--- a/pkg/canary/reader/reader_test.go
+++ b/pkg/canary/reader/reader_test.go
@@ -1,7 +1,9 @@
 package reader
 
 import (
+	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -74,6 +76,37 @@ func TestBuildLabelSelector(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, got)
 		})
+	}
+}
+
+func TestNewReaderDisableTail(t *testing.T) {
+	recv := make(chan time.Time, 1)
+	r, err := NewReader(
+		io.Discard,
+		recv,
+		false, nil,
+		"", "", "",
+		"localhost:3100",
+		"", "", "",
+		5*time.Second,
+		"name", "loki-canary",
+		"stream", "stdout",
+		time.Second,
+		"", "",
+		true,
+	)
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		r.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Stop() did not complete within timeout")
 	}
 }
 


### PR DESCRIPTION
Adds a `-disable-tail` flag to `loki-canary`. When set, the reader skips the WebSocket goroutine entirely; verification continues through the comparator's existing `query_range` polling path.

This is useful in environments where WebSocket connections are blocked or rate-limited at the network boundary.

## Changes

- `cmd/loki-canary/main.go`: new `-disable-tail` bool flag (default `false`)
- `pkg/canary/reader/reader.go`: `disableTail bool` field + `NewReader` param; conditional goroutine launch
- `pkg/canary/reader/reader_test.go`: unit test for the disabled-tail path, verifies `Stop()` completes cleanly without a live Loki server

## Notes

- Fully backward compatible: flag defaults to `false`, existing behaviour unchanged
- `-wait`/`-max-wait` have no effect when `-disable-tail` is set (they guard the websocket receive window). I can document this in the flag descriptions or handle it as a follow-up

Closes #11662

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an opt-in flag that bypasses the websocket tail path; main behavioral change is conditional goroutine/cleanup logic in `Reader`, which could affect shutdown if misused.
> 
> **Overview**
> Adds a new `-disable-tail` flag to `loki-canary` to **skip websocket tailing** and rely solely on the existing `query_range` polling for verification.
> 
> `reader.NewReader` now accepts/stores `disableTail` and conditionally avoids starting the websocket `run()` loop; shutdown logic is adjusted so `Stop()` still unblocks cleanly in this mode. A unit test covers the disabled-tail path by asserting `Stop()` completes without needing a live Loki server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba4db07b8f79e93201cfa818cbb172d121bb58e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->