### PR TITLE
docs: Switch from png to mermaid markdown and switch to alloy

### DIFF
--- a/docs/sources/operations/loki-canary/_index.md
+++ b/docs/sources/operations/loki-canary/_index.md
@@ -17,7 +17,15 @@ artificial log lines,
 such that Loki Canary forms information about the performance of the Loki cluster.
 The information is available as Prometheus time series metrics.
 
-{{< figure max-width="75%" src="./loki-canary-block.png" alt="Loki canary">}}
+```mermaid
+graph LR
+    subgraph nodes["x Node"]
+        lc["loki-canary"] --> lf["log file"] --> al["Alloy"]
+    end
+
+    al -->|push| loki
+    lc -->|websocket| loki
+```
 
 Loki Canary writes a log to standard output and stores the timestamp in an internal
 array. The contents look something like this:


### PR DESCRIPTION
I remove the use of PNG and change the name of Promtail (end of life) to Alloy

**What this PR does / why we need it**:
It removes the dependancy of .png file and update the diagram from Promtail to Alloy

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
