### PR TITLE
chore(packaging): Remove RPM/DEB signing from local packaging scripts

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "eb4e89778be445f9e79533b704cbdee404592eb4"
+      "version": "65e24dba101c1535cf29bab695e1b12855803e4a"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "eb4e89778be445f9e79533b704cbdee404592eb4",
-      "sum": "F1Sz4AL7p6uDMdFsQCXWM3v5DpaWrjbODRSXn2gKBIU="
+      "version": "65e24dba101c1535cf29bab695e1b12855803e4a",
+      "sum": "GW4ryUe0e2ItKeepfxZnD6NrH64ffAagokjtq/qKm3M="
     }
   ],
   "legacyImports": false

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -325,22 +325,12 @@ local runner = import 'runner.libsonnet',
       common.googleAuth,
       common.setupGoogleCloudSdk,
 
-      step.new('get nfpm signing keys', 'grafana/shared-workflows/actions/get-vault-secrets@fa48192dac470ae356b3f7007229f3ac28c48a25')  // main
-      + step.withId('get-secrets')
-      + step.with({
-        common_secrets: |||
-          NFPM_SIGNING_KEY=packages-gpg:private-key
-          NFPM_PASSPHRASE=packages-gpg:passphrase
-        |||,
-      }),
-
       releaseStep('build artifacts')
       + step.withIf('${{ fromJSON(needs.version.outputs.pr_created) }}')
       + step.withEnv({
         BUILD_IN_CONTAINER: false,
         DRONE_TAG: '${{ needs.version.outputs.version }}',
         IMAGE_TAG: '${{ needs.version.outputs.version }}',
-        NFPM_SIGNING_KEY_FILE: 'nfpm-private-key.key',
         SKIP_ARM: skipArm,
       })
       //TODO: the workdir here is loki specific
@@ -356,15 +346,11 @@ local runner = import 'runner.libsonnet',
             --env BUILD_IN_CONTAINER \
             --env DRONE_TAG \
             --env IMAGE_TAG \
-            --env NFPM_PASSPHRASE \
-            --env NFPM_SIGNING_KEY \
-            --env NFPM_SIGNING_KEY_FILE \
             --env SKIP_ARM \
             --volume .:/src/loki \
             --workdir /src/loki \
             --entrypoint /bin/sh "%s"
             git config --global --add safe.directory /src/loki
-            echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
             if echo "%s" | grep -q "golang"; then
               /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
             fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@eb4e89778be445f9e79533b704cbdee404592eb4"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@65e24dba101c1535cf29bab695e1b12855803e4a"
     "with":
       "build_image": "golang:1.26.2"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "eb4e89778be445f9e79533b704cbdee404592eb4"
+      "release_lib_ref": "65e24dba101c1535cf29bab695e1b12855803e4a"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@eb4e89778be445f9e79533b704cbdee404592eb4"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@65e24dba101c1535cf29bab695e1b12855803e4a"
     "with":
       "build_image": "golang:1.26.2"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "eb4e89778be445f9e79533b704cbdee404592eb4"
+      "release_lib_ref": "65e24dba101c1535cf29bab695e1b12855803e4a"
       "skip_validation": false
       "use_github_app_token": true
   "loki-canary-boringcrypto-image":
@@ -12,7 +12,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "eb4e89778be445f9e79533b704cbdee404592eb4"
+      "RELEASE_LIB_REF": "65e24dba101c1535cf29bab695e1b12855803e4a"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -136,7 +136,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "eb4e89778be445f9e79533b704cbdee404592eb4"
+      "RELEASE_LIB_REF": "65e24dba101c1535cf29bab695e1b12855803e4a"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -260,7 +260,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "eb4e89778be445f9e79533b704cbdee404592eb4"
+      "RELEASE_LIB_REF": "65e24dba101c1535cf29bab695e1b12855803e4a"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -384,7 +384,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "eb4e89778be445f9e79533b704cbdee404592eb4"
+      "RELEASE_LIB_REF": "65e24dba101c1535cf29bab695e1b12855803e4a"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -8,7 +8,7 @@ env:
   DRY_RUN: false
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "eb4e89778be445f9e79533b704cbdee404592eb4"
+  RELEASE_LIB_REF: "65e24dba101c1535cf29bab695e1b12855803e4a"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
@@ -19,11 +19,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@eb4e89778be445f9e79533b704cbdee404592eb4"
+    uses: "grafana/loki-release/.github/workflows/check.yml@65e24dba101c1535cf29bab695e1b12855803e4a"
     with:
       build_image: "golang:1.26.2"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "eb4e89778be445f9e79533b704cbdee404592eb4"
+      release_lib_ref: "65e24dba101c1535cf29bab695e1b12855803e4a"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -140,18 +140,10 @@ jobs:
       uses: "google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a"
       with:
         version: ">= 452.0.0"
-    - id: "get-secrets"
-      name: "get nfpm signing keys"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@fa48192dac470ae356b3f7007229f3ac28c48a25"
-      with:
-        common_secrets: |
-          NFPM_SIGNING_KEY=packages-gpg:private-key
-          NFPM_PASSPHRASE=packages-gpg:passphrase
     - env:
         BUILD_IN_CONTAINER: false
         DRONE_TAG: "${{ needs.version.outputs.version }}"
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
-        NFPM_SIGNING_KEY_FILE: "nfpm-private-key.key"
         SKIP_ARM: false
       if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "build artifacts"
@@ -161,15 +153,11 @@ jobs:
           --env BUILD_IN_CONTAINER \
           --env DRONE_TAG \
           --env IMAGE_TAG \
-          --env NFPM_PASSPHRASE \
-          --env NFPM_SIGNING_KEY \
-          --env NFPM_SIGNING_KEY_FILE \
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
           --entrypoint /bin/sh "golang:1.26.2"
           git config --global --add safe.directory /src/loki
-          echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           if echo "golang:1.26.2" | grep -q "golang"; then
             /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
           fi

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -8,7 +8,7 @@ env:
   DRY_RUN: false
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "eb4e89778be445f9e79533b704cbdee404592eb4"
+  RELEASE_LIB_REF: "65e24dba101c1535cf29bab695e1b12855803e4a"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
@@ -19,11 +19,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@eb4e89778be445f9e79533b704cbdee404592eb4"
+    uses: "grafana/loki-release/.github/workflows/check.yml@65e24dba101c1535cf29bab695e1b12855803e4a"
     with:
       build_image: "golang:1.26.2"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "eb4e89778be445f9e79533b704cbdee404592eb4"
+      release_lib_ref: "65e24dba101c1535cf29bab695e1b12855803e4a"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:
@@ -140,18 +140,10 @@ jobs:
       uses: "google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a"
       with:
         version: ">= 452.0.0"
-    - id: "get-secrets"
-      name: "get nfpm signing keys"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@fa48192dac470ae356b3f7007229f3ac28c48a25"
-      with:
-        common_secrets: |
-          NFPM_SIGNING_KEY=packages-gpg:private-key
-          NFPM_PASSPHRASE=packages-gpg:passphrase
     - env:
         BUILD_IN_CONTAINER: false
         DRONE_TAG: "${{ needs.version.outputs.version }}"
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
-        NFPM_SIGNING_KEY_FILE: "nfpm-private-key.key"
         SKIP_ARM: false
       if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "build artifacts"
@@ -161,15 +153,11 @@ jobs:
           --env BUILD_IN_CONTAINER \
           --env DRONE_TAG \
           --env IMAGE_TAG \
-          --env NFPM_PASSPHRASE \
-          --env NFPM_SIGNING_KEY \
-          --env NFPM_SIGNING_KEY_FILE \
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
           --entrypoint /bin/sh "golang:1.26.2"
           git config --global --add safe.directory /src/loki
-          echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
           if echo "golang:1.26.2" | grep -q "golang"; then
             /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "eb4e89778be445f9e79533b704cbdee404592eb4"
+  RELEASE_LIB_REF: "65e24dba101c1535cf29bab695e1b12855803e4a"
   RELEASE_REPO: "grafana/loki"
   USE_GITHUB_APP_TOKEN: true
 jobs:

--- a/tools/packaging/nfpm.sh
+++ b/tools/packaging/nfpm.sh
@@ -1,14 +1,5 @@
 #!/usr/bin/env bash
 
-if [[ -z "${NFPM_SIGNING_KEY_FILE}" ]]; then
-    echo "NFPM_SIGNING_KEY_FILE is not set"
-    exit 1
-fi
-if [[ -z "${NFPM_PASSPHRASE}" ]]; then
-    echo "NFPM_PASSPHRASE is not set"
-    exit 1
-fi
-
 rm -rf dist/tmp && mkdir -p dist/tmp/packages
 unzip dist/\*.zip -d dist/tmp/packages
 

--- a/tools/packaging/verify-rpm-install.sh
+++ b/tools/packaging/verify-rpm-install.sh
@@ -11,9 +11,6 @@ fi
 echo "Running on directory: ${dir}"
 
 cat <<EOF | docker exec --interactive "${image}" sh
-    # Import the Grafana GPG key
-    rpm --import https://packages.grafana.com/gpg.key
-
     # Install loki and check it's running
     rpm -i ${dir}/dist/loki-*.x86_64.rpm
     [ "\$(systemctl is-active loki)" = "active" ] || (echo "loki is inactive" && exit 1)


### PR DESCRIPTION
**What this PR does / why we need it**:

Since https://github.com/grafana/loki/pull/19700 the loki does not sign packages.

The responsibility for signing is now managed by deployment-tools.

To prevent further confusion and enable the old signing key to be deleted, this PR removes the unused boilerplate from CI.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
