### PR TITLE
refactor: migrate simple atomic types to sync/atomic

### DIFF
--- a/pkg/bloombuild/builder/builder_test.go
+++ b/pkg/bloombuild/builder/builder_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
 	"github.com/grafana/loki/v3/pkg/bloombuild/planner/plannertest"
@@ -104,7 +104,7 @@ func createTasks(n int) []*protos.ProtoTask {
 
 func Test_BuilderLoop(t *testing.T) {
 	logger := log.NewNopLogger()
-	//logger := log.NewLogfmtLogger(os.Stdout)
+	// logger := log.NewLogfmtLogger(os.Stdout)
 
 	tasks := createTasks(256)
 	server, err := newFakePlannerServer(tasks)
@@ -176,7 +176,7 @@ func Test_BuilderLoop_Timeout(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			logger := log.NewNopLogger()
-			//logger := log.NewLogfmtLogger(os.Stdout)
+			// logger := log.NewLogfmtLogger(os.Stdout)
 
 			tasks := createTasks(256)
 			server, err := newFakePlannerServer(tasks)
@@ -290,9 +290,9 @@ func (f *fakePlannerServer) BuilderLoop(srv protos.PlannerForBuilder_BuilderLoop
 			return fmt.Errorf("failed to receive task response: %w", err)
 		}
 
-		f.completedTasks.Inc()
+		f.completedTasks.Add(1)
 		if result.Result.Error != "" {
-			f.erroredTasks.Inc()
+			f.erroredTasks.Add(1)
 		}
 
 		time.Sleep(10 * time.Millisecond) // Simulate task processing time to add some latency.

--- a/pkg/dataobj/sections/streams/builder.go
+++ b/pkg/dataobj/sections/streams/builder.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"

--- a/pkg/engine/internal/scheduler/scheduler_test.go
+++ b/pkg/engine/internal/scheduler/scheduler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
@@ -1403,6 +1403,6 @@ type mockRecordWriter struct {
 }
 
 func (m *mockRecordWriter) Write(_ context.Context, _ arrow.RecordBatch) error {
-	m.writes.Inc()
+	m.writes.Add(1)
 	return nil
 }

--- a/pkg/engine/internal/scheduler/wire/peer.go
+++ b/pkg/engine/internal/scheduler/wire/peer.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 	"reflect"
 	"sync"
+	"sync/atomic"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -230,7 +230,7 @@ type request struct {
 func (p *Peer) SendMessage(ctx context.Context, message Message) error {
 	p.lazyInit()
 
-	reqID := p.requestID.Inc()
+	reqID := p.requestID.Add(1)
 	req := &request{
 		result: make(chan error, 1),
 	}
@@ -265,7 +265,7 @@ func (p *Peer) SendMessage(ctx context.Context, message Message) error {
 func (p *Peer) SendMessageAsync(ctx context.Context, message Message) error {
 	p.lazyInit()
 
-	reqID := p.requestID.Inc()
+	reqID := p.requestID.Add(1)
 	p.Metrics.incMessageSent(message.Kind().String())
 	return p.enqueueFrame(ctx, MessageFrame{ID: reqID, Message: message})
 }

--- a/pkg/engine/internal/util/ewma/ewma.go
+++ b/pkg/engine/internal/util/ewma/ewma.go
@@ -6,10 +6,10 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/atomic"
 )
 
 // Source is an interface that provides a value for an EWMA calculation.

--- a/pkg/kafka/client/writer_client.go
+++ b/pkg/kafka/client/writer_client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -18,8 +19,6 @@ import (
 	"github.com/twmb/franz-go/plugin/kprom"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/atomic"
-
 	"github.com/grafana/loki/v3/pkg/kafka"
 )
 
@@ -227,7 +226,7 @@ type Producer struct {
 
 	// Keep track of Kafka records size (bytes) currently in-flight in the Kafka client.
 	// This counter is used to implement a limit on the max buffered bytes.
-	bufferedBytes *atomic.Int64
+	bufferedBytes atomic.Int64
 
 	// The max buffered bytes allowed. Once this limit is reached, produce requests fail.
 	maxBufferedBytes int64
@@ -260,7 +259,6 @@ func NewProducer(component string, client *kgo.Client, maxBufferedBytes int64, r
 
 	producer := &Producer{
 		Client:           client,
-		bufferedBytes:    atomic.NewInt64(0),
 		maxBufferedBytes: maxBufferedBytes,
 
 		// Metrics.
@@ -310,11 +308,12 @@ func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.P
 	}
 
 	var (
-		remaining = atomic.NewInt64(int64(len(records)))
+		remaining atomic.Int64
 		done      = make(chan struct{})
 		resMx     sync.Mutex
 		res       = make(kgo.ProduceResults, 0, len(records))
 	)
+	remaining.Store(int64(len(records)))
 
 	c.produceRequestsTotal.Add(float64(len(records)))
 
@@ -334,7 +333,7 @@ func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.P
 		// In case of error we'll wait for all responses anyway before returning from produceSync().
 		// It allows us to keep code easier, given we don't expect this function to be frequently
 		// called with multiple records.
-		if remaining.Dec() == 0 {
+		if remaining.Add(-1) == 0 {
 			close(done)
 		}
 	}

--- a/pkg/kafka/partition/committer.go
+++ b/pkg/kafka/partition/committer.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/kafka/client"
 )
@@ -32,7 +32,7 @@ type partitionCommitter struct {
 	offsetManager OffsetManager
 	commitFreq    time.Duration
 
-	toCommit *atomic.Int64
+	toCommit atomic.Int64
 	wg       sync.WaitGroup
 	cancel   context.CancelFunc
 }
@@ -71,8 +71,9 @@ func newCommitter(offsetManager OffsetManager, partition int32, commitFreq time.
 			Help:        "The last consumed offset successfully committed by the partition reader. Set to -1 if not offset has been committed yet.",
 			ConstLabels: prometheus.Labels{"partition": strconv.Itoa(int(partition))},
 		}),
-		toCommit: atomic.NewInt64(-1),
 	}
+
+	c.toCommit.Store(-1)
 
 	// Initialize the last committed offset metric to -1 to signal no offset has been committed yet
 	c.lastCommittedOffset.Set(-1)

--- a/pkg/logql/bench/cache_test.go
+++ b/pkg/logql/bench/cache_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/engine"
 	"github.com/grafana/loki/v3/pkg/logql"

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	rt "runtime"
+	"sync/atomic"
 	"time"
 
 	"github.com/fatih/color"
@@ -26,7 +27,6 @@ import (
 	"github.com/grafana/dskit/signals"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/grafana/loki/v3/pkg/analytics"
@@ -573,13 +573,13 @@ func (t *Loki) Run(opts RunOpts) error {
 		return err
 	}
 
-	shutdownRequested := atomic.NewBool(false)
+	var shutdownRequested atomic.Bool
 
 	// before starting servers, register /ready handler. It should reflect entire Loki.
 	if t.Cfg.InternalServer.Enable {
-		t.InternalServer.HTTP.Path("/ready").Methods("GET").Handler(t.readyHandler(sm, shutdownRequested))
+		t.InternalServer.HTTP.Path("/ready").Methods("GET").Handler(t.readyHandler(sm, &shutdownRequested))
 	}
-	t.Server.HTTP.Path("/ready").Methods("GET").Handler(t.readyHandler(sm, shutdownRequested))
+	t.Server.HTTP.Path("/ready").Methods("GET").Handler(t.readyHandler(sm, &shutdownRequested))
 
 	t.Server.HTTP.Path("/log_level").Methods("GET", "POST").Handler(util_log.LevelHandler(&t.Cfg.Server.LogLevel))
 

--- a/pkg/lokifrontend/frontend/v1/frontend_test.go
+++ b/pkg/lokifrontend/frontend/v1/frontend_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,7 +28,6 @@ import (
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
 	"github.com/grafana/loki/v3/pkg/loghttp"
@@ -173,7 +173,7 @@ func TestFrontendCancel(t *testing.T) {
 	var tries atomic.Int32
 	handler := queryrangebase.HandlerFunc(func(ctx context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
 		<-ctx.Done()
-		tries.Inc()
+		tries.Add(1)
 		return nil, ctx.Err()
 	})
 	test := func(addr string, _ *Frontend) {

--- a/pkg/lokifrontend/frontend/v2/frontend.go
+++ b/pkg/lokifrontend/frontend/v2/frontend.go
@@ -23,7 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel"
-	"go.uber.org/atomic"
+	"sync/atomic"
 
 	"github.com/grafana/dskit/tenant"
 
@@ -230,7 +230,7 @@ func (f *Frontend) RoundTripGRPC(ctx context.Context, req *httpgrpc.HTTPRequest)
 	defer cancel()
 
 	freq := &frontendRequest{
-		queryID:      f.lastQueryID.Inc(),
+		queryID:      f.lastQueryID.Add(1),
 		request:      req,
 		tenantID:     tenantID,
 		actor:        httpreq.ExtractActorPath(ctx),
@@ -290,7 +290,7 @@ func (f *Frontend) Do(ctx context.Context, req queryrangebase.Request) (queryran
 	defer cancel()
 
 	freq := &frontendRequest{
-		queryID:      f.lastQueryID.Inc(),
+		queryID:      f.lastQueryID.Add(1),
 		tenantID:     tenantID,
 		actor:        httpreq.ExtractActorPath(ctx),
 		statsEnabled: stats.IsEnabled(ctx),

--- a/pkg/lokifrontend/frontend/v2/frontend_test.go
+++ b/pkg/lokifrontend/frontend/v2/frontend_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/user"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
+	"sync/atomic"
 	"google.golang.org/grpc"
 
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
@@ -158,7 +158,8 @@ func TestFrontendBasicWorkflowProto(t *testing.T) {
 
 func TestFrontendRetryEnqueue(t *testing.T) {
 	// Frontend uses worker concurrency to compute number of retries. We use one less failure.
-	failures := atomic.NewInt64(testFrontendWorkerConcurrency - 1)
+	var failures atomic.Int64
+	failures.Store(testFrontendWorkerConcurrency - 1)
 	const (
 		body   = "hello world"
 		userID = "test"
@@ -167,7 +168,7 @@ func TestFrontendRetryEnqueue(t *testing.T) {
 	cfg := Config{}
 	flagext.DefaultValues(&cfg)
 	f, _ := setupFrontend(t, cfg, func(f *Frontend, msg *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend {
-		fail := failures.Dec()
+		fail := failures.Add(-1)
 		if fail >= 0 {
 			return &schedulerpb.SchedulerToFrontend{Status: schedulerpb.SHUTTING_DOWN}
 		}

--- a/pkg/memory/allocator.go
+++ b/pkg/memory/allocator.go
@@ -2,9 +2,8 @@ package memory
 
 import (
 	"errors"
-	"unsafe"
-
 	"sync/atomic"
+	"unsafe"
 
 	"github.com/grafana/loki/v3/pkg/memory/internal/memalign"
 )

--- a/pkg/memory/allocator.go
+++ b/pkg/memory/allocator.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"unsafe"
 
-	"go.uber.org/atomic"
+	"sync/atomic"
 
 	"github.com/grafana/loki/v3/pkg/memory/internal/memalign"
 )

--- a/pkg/pattern/streams_map.go
+++ b/pkg/pattern/streams_map.go
@@ -2,16 +2,16 @@ package pattern
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/prometheus/common/model"
-	"go.uber.org/atomic"
 )
 
 type streamsMap struct {
 	consistencyMtx sync.RWMutex // Keep read/write consistency between other fields
 	streams        *sync.Map    // map[string]*stream
 	streamsByFP    *sync.Map    // map[model.Fingerprint]*stream
-	streamsCounter *atomic.Int64
+	streamsCounter atomic.Int64
 }
 
 func newStreamsMap() *streamsMap {
@@ -19,7 +19,6 @@ func newStreamsMap() *streamsMap {
 		consistencyMtx: sync.RWMutex{},
 		streams:        &sync.Map{},
 		streamsByFP:    &sync.Map{},
-		streamsCounter: atomic.NewInt64(0),
 	}
 }
 
@@ -48,7 +47,7 @@ func (m *streamsMap) Delete(s *stream) bool {
 	_, loaded := m.streams.LoadAndDelete(s.labelsString)
 	if loaded {
 		m.streamsByFP.Delete(s.fp)
-		m.streamsCounter.Dec()
+		m.streamsCounter.Add(-1)
 		return true
 	}
 	return false
@@ -108,7 +107,7 @@ func (m *streamsMap) store(key interface{}, s *stream) {
 		m.streams.Store(s.labelsString, s)
 	}
 	m.streamsByFP.Store(s.fp, s)
-	m.streamsCounter.Inc()
+	m.streamsCounter.Add(1)
 }
 
 // newStreamFn: Called if not loaded, with consistencyMtx locked. Must not be nil

--- a/pkg/querier/ingester_querier_test.go
+++ b/pkg/querier/ingester_querier_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/ring/client"
 	"github.com/grafana/dskit/user"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 	grpc_metadata "google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -305,7 +305,7 @@ func TestIngesterQuerierFetchesResponsesFromPartitionIngesters(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
-		cnt := atomic.NewInt32(0)
+		var cnt atomic.Int32
 
 		t.Run(testName, func(t *testing.T) {
 			cnt.Store(0)
@@ -404,7 +404,7 @@ func TestIngesterQuerier_QueriesSameIngestersWithPartitionContext(t *testing.T) 
 	}
 
 	for testName, testData := range tests {
-		cnt := atomic.NewInt32(0)
+		var cnt atomic.Int32
 		ctx := NewPartitionContext(testCtx)
 
 		t.Run(testName, func(t *testing.T) {

--- a/pkg/querier/queryrange/downstreamer_test.go
+++ b/pkg/querier/queryrange/downstreamer_test.go
@@ -11,12 +11,13 @@ import (
 	"testing"
 	"time"
 
+	"sync/atomic"
+
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
@@ -568,7 +569,7 @@ func TestCancelWhileWaitingResponse(t *testing.T) {
 
 	// Launch the For call in a goroutine because it blocks and we need to be able to cancel the context
 	// to prove it will exit when the context is canceled.
-	b := atomic.NewBool(false)
+	var b atomic.Bool
 	go func() {
 		_, _ = in.For(ctx, queries, acc, func(_ logql.DownstreamQuery) (logqlmodel.Result, error) {
 			// Intended to keep the For method from returning unless the context is canceled.
@@ -625,11 +626,11 @@ func TestCancelDoesNotLeakGoroutines(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		acc := logql.NewBufferedAccumulator(len(queries))
 
-		started := atomic.NewInt32(0)
+		var started atomic.Int32
 		done := make(chan struct{})
 		go func() {
 			_, _ = in.For(ctx, queries, acc, func(_ logql.DownstreamQuery) (logqlmodel.Result, error) {
-				started.Inc()
+				started.Add(1)
 				// Block until context is canceled.
 				<-ctx.Done()
 				return logqlmodel.Result{}, ctx.Err()

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -9,12 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"sync/atomic"
+
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -566,11 +567,11 @@ func Test_MaxQueryParallelism(t *testing.T) {
 	var count atomic.Int32
 	var maxVal atomic.Int32
 	h := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
-		cur := count.Inc()
+		cur := count.Add(1)
 		if cur > maxVal.Load() {
 			maxVal.Store(cur)
 		}
-		defer count.Dec()
+		defer count.Add(-1)
 		// simulate some work
 		time.Sleep(20 * time.Millisecond)
 		return queryrangebase.NewEmptyPrometheusResponse(model.ValMatrix), nil
@@ -1103,10 +1104,10 @@ func Test_MaxQuerySize_WithQueryLimitsContext(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			statsHits := atomic.NewInt32(0)
+			var statsHits atomic.Int32
 
 			statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
-				statsHits.Inc()
+				statsHits.Add(1)
 
 				bytes := tc.queryBytes
 				if req.GetQuery() == ctxSentinal {

--- a/pkg/querier/queryrange/queryrangebase/retry_test.go
+++ b/pkg/querier/queryrange/queryrangebase/retry_test.go
@@ -7,11 +7,12 @@ import (
 	"net/http"
 	"testing"
 
+	"sync/atomic"
+
 	"github.com/go-kit/log"
 	"github.com/gogo/status"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/loki/v3/pkg/util/constants"
@@ -30,7 +31,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "retry failures",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				if try.Inc() == 5 {
+				if try.Add(1) == 5 {
 					return &PrometheusResponse{Status: "Hello World"}, nil
 				}
 				return nil, fmt.Errorf("fail")
@@ -41,7 +42,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "don't retry 400s",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				try.Inc()
+				try.Add(1)
 				return nil, httpgrpc.Errorf(http.StatusBadRequest, "Bad Request")
 			}),
 			err:           httpgrpc.Errorf(http.StatusBadRequest, "Bad Request"),
@@ -50,7 +51,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "retry 500s",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				try.Inc()
+				try.Add(1)
 				return nil, httpgrpc.Errorf(http.StatusInternalServerError, "Internal Server Error")
 			}),
 			err:           httpgrpc.Errorf(http.StatusInternalServerError, "Internal Server Error"),
@@ -59,7 +60,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "last error",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				if try.Inc() == 5 {
+				if try.Add(1) == 5 {
 					return nil, httpgrpc.Errorf(http.StatusBadRequest, "Bad Request")
 				}
 				return nil, httpgrpc.Errorf(http.StatusInternalServerError, "Internal Server Error")
@@ -72,7 +73,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "protobuf enc don't retry 400s",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				try.Inc()
+				try.Add(1)
 				return nil, status.New(codes.Code(http.StatusBadRequest), "Bad Request").Err()
 			}),
 			err:           status.New(codes.Code(http.StatusBadRequest), "Bad Request").Err(),
@@ -81,7 +82,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "protobuf enc retry 500s",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				try.Inc()
+				try.Add(1)
 				return nil, status.New(codes.Code(http.StatusInternalServerError), "Internal Server Error").Err()
 			}),
 			err:           status.New(codes.Code(http.StatusInternalServerError), "Internal Server Error").Err(),
@@ -112,7 +113,7 @@ func Test_RetryMiddlewareCancel(t *testing.T) {
 	cancel()
 	_, err := NewRetryMiddleware(log.NewNopLogger(), 5, nil, constants.Loki).Wrap(
 		HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-			try.Inc()
+			try.Add(1)
 			return nil, ctx.Err()
 		}),
 	).Do(ctx, req)
@@ -122,7 +123,7 @@ func Test_RetryMiddlewareCancel(t *testing.T) {
 	ctx, cancel = context.WithCancel(context.Background())
 	_, err = NewRetryMiddleware(log.NewNopLogger(), 5, nil, constants.Loki).Wrap(
 		HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-			try.Inc()
+			try.Add(1)
 			cancel()
 			return nil, errors.New("failed")
 		}),

--- a/pkg/querier/tail/tail.go
+++ b/pkg/querier/tail/tail.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
-
-	"go.uber.org/atomic"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"

--- a/pkg/querier/worker/frontend_processor_test.go
+++ b/pkg/querier/worker/frontend_processor_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"sync/atomic"
+
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
@@ -36,7 +37,7 @@ func TestRecvFailDoesntCancelProcess(t *testing.T) {
 
 	cfg := Config{}
 	mgr := newFrontendProcessor(cfg, nil, log.NewNopLogger(), queryrange.DefaultCodec)
-	running := atomic.NewBool(false)
+	var running atomic.Bool
 	go func() {
 		running.Store(true)
 		defer running.Store(false)

--- a/pkg/querier/worker/processor_manager.go
+++ b/pkg/querier/worker/processor_manager.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 )
 
@@ -29,16 +29,15 @@ type processorManager struct {
 	cancelsMu sync.Mutex
 	cancels   []context.CancelFunc
 
-	currentProcessors *atomic.Int32
+	currentProcessors atomic.Int32
 }
 
 func newProcessorManager(ctx context.Context, p processor, conn *grpc.ClientConn, address string) *processorManager {
 	return &processorManager{
-		p:                 p,
-		ctx:               ctx,
-		conn:              conn,
-		address:           address,
-		currentProcessors: atomic.NewInt32(0),
+		p:       p,
+		ctx:     ctx,
+		conn:    conn,
+		address: address,
 	}
 }
 
@@ -75,8 +74,8 @@ func (pm *processorManager) concurrency(n int) {
 		go func(workerID int) {
 			defer pm.wg.Done()
 
-			pm.currentProcessors.Inc()
-			defer pm.currentProcessors.Dec()
+			pm.currentProcessors.Add(1)
+			defer pm.currentProcessors.Add(-1)
 
 			pm.p.processQueriesOnSingleStream(ctx, pm.conn, pm.address, strconv.Itoa(workerID))
 		}(workerID)

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -21,7 +22,6 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 

--- a/pkg/querier/worker/scheduler_processor_test.go
+++ b/pkg/querier/worker/scheduler_processor_test.go
@@ -4,6 +4,7 @@ package worker
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -54,10 +54,10 @@ func TestSchedulerProcessor_processQueriesOnSingleStream(t *testing.T) {
 	t.Run("should wait until inflight query execution is completed before returning when worker context is canceled", func(t *testing.T) {
 		sp, loopClient, requestHandler := prepareSchedulerProcessor()
 
-		recvCount := atomic.NewInt64(0)
+		var recvCount atomic.Int64
 
 		loopClient.On("Recv").Return(func() (*schedulerpb.SchedulerToQuerier, error) {
-			switch recvCount.Inc() {
+			switch recvCount.Add(1) {
 			case 1:
 				return &schedulerpb.SchedulerToQuerier{
 					QueryID: 1,

--- a/pkg/querier/worker/util.go
+++ b/pkg/querier/worker/util.go
@@ -5,6 +5,7 @@ package worker
 import (
 	"context"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -12,7 +13,6 @@ import (
 	"github.com/gogo/status"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/pkg/errors"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/loki/v3/pkg/querier/queryrange"
@@ -35,7 +35,7 @@ import (
 // once the inflight query terminates and the response has been sent.
 func newExecutionContext(workerCtx context.Context, logger log.Logger) (execCtx context.Context, execCancel context.CancelCauseFunc, inflightQuery *atomic.Bool) {
 	execCtx, execCancel = context.WithCancelCause(context.Background())
-	inflightQuery = atomic.NewBool(false)
+	inflightQuery = &atomic.Bool{}
 
 	go func() {
 		// Wait until it's safe to cancel the execution context, which is when one of the following conditions happen:

--- a/pkg/ruler/storage/wal/wal.go
+++ b/pkg/ruler/storage/wal/wal.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -29,7 +30,6 @@ import (
 	"github.com/prometheus/prometheus/tsdb/record"
 	"github.com/prometheus/prometheus/tsdb/wlog"
 	"github.com/prometheus/prometheus/util/compression"
-	"go.uber.org/atomic"
 
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
@@ -58,7 +58,7 @@ type Storage struct {
 	appenderPool sync.Pool
 	bufPool      sync.Pool
 
-	ref    *atomic.Uint64
+	ref    atomic.Uint64
 	series *stripeSeries
 
 	deletedMtx sync.Mutex
@@ -83,7 +83,6 @@ func NewStorage(logger log.Logger, metrics *Metrics, registerer prometheus.Regis
 		deleted: map[chunks.HeadSeriesRef]int{},
 		series:  newStripeSeries(),
 		metrics: metrics,
-		ref:     atomic.NewUint64(0),
 	}
 
 	storage.bufPool.New = func() interface{} {
@@ -651,7 +650,7 @@ func (a *appender) getOrCreate(l labels.Labels) (series *memSeries, created bool
 		return series, false
 	}
 
-	series = &memSeries{ref: chunks.HeadSeriesRef(a.w.ref.Inc()), lset: l}
+	series = &memSeries{ref: chunks.HeadSeriesRef(a.w.ref.Add(1)), lset: l}
 	a.w.series.set(labels.StableHash(l), series)
 	return series, true
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"net/textproto"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -25,7 +26,6 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
 	"github.com/grafana/loki/v3/pkg/lokifrontend/frontend/v2/frontendv2pb"

--- a/pkg/storage/bloom/v1/fuse.go
+++ b/pkg/storage/bloom/v1/fuse.go
@@ -2,13 +2,13 @@ package v1
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/efficientgo/core/errors"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
-	"go.uber.org/atomic"
 
 	iter "github.com/grafana/loki/v3/pkg/iter/v2"
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
@@ -26,17 +26,8 @@ type Request struct {
 // BloomRecorder records the results of a bloom search
 func NewBloomRecorder(ctx context.Context, id string) *BloomRecorder {
 	return &BloomRecorder{
-		ctx:            ctx,
-		id:             id,
-		seriesFound:    atomic.NewInt64(0),
-		chunksFound:    atomic.NewInt64(0),
-		seriesSkipped:  atomic.NewInt64(0),
-		chunksSkipped:  atomic.NewInt64(0),
-		seriesMissed:   atomic.NewInt64(0),
-		chunksMissed:   atomic.NewInt64(0),
-		seriesEmpty:    atomic.NewInt64(0),
-		chunksEmpty:    atomic.NewInt64(0),
-		chunksFiltered: atomic.NewInt64(0),
+		ctx: ctx,
+		id:  id,
 	}
 }
 
@@ -44,15 +35,15 @@ type BloomRecorder struct {
 	ctx context.Context
 	id  string
 	// exists in the bloom+queried
-	seriesFound, chunksFound *atomic.Int64
+	seriesFound, chunksFound atomic.Int64
 	// exists in bloom+skipped
-	seriesSkipped, chunksSkipped *atomic.Int64
+	seriesSkipped, chunksSkipped atomic.Int64
 	// not found in bloom
-	seriesMissed, chunksMissed *atomic.Int64
+	seriesMissed, chunksMissed atomic.Int64
 	// exists in block index but empty offsets
-	seriesEmpty, chunksEmpty *atomic.Int64
+	seriesEmpty, chunksEmpty atomic.Int64
 	// filtered out
-	chunksFiltered *atomic.Int64
+	chunksFiltered atomic.Int64
 }
 
 func (r *BloomRecorder) Merge(other *BloomRecorder) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Continues the migration from `go.uber.org/atomic` to `sync/atomic` (issue #20673).

This PR migrates the packages that only use direct-swap types (`Int32`, `Int64`, `Uint32`, `Uint64`, `Bool`) with no custom wrappers needed:

- `pkg/bloombuild/builder`
- `pkg/dataobj/sections/streams`
- `pkg/engine/internal/scheduler`
- `pkg/engine/internal/scheduler/wire`
- `pkg/engine/internal/util/ewma`
- `pkg/kafka/client`
- `pkg/kafka/partition`
- `pkg/logql/bench`
- `pkg/loki`
- `pkg/lokifrontend/frontend/v1`
- `pkg/lokifrontend/frontend/v2`
- `pkg/memory`
- `pkg/pattern`
- `pkg/querier`
- `pkg/querier/queryrange/queryrangebase`
- `pkg/querier/tail`
- `pkg/ruler/storage/wal`
- `pkg/scheduler`
- `pkg/storage/bloom/v1`

All stdlib equivalents have been available since Go 1.19.

**Which issue(s) this PR fixes**:
Partially addresses #20673

**Special notes for your reviewer**:
This PR covers only simple swaps. Packages using `atomic.Float64`, `atomic.Duration`, or other types without stdlib equivalents will be handled in follow-up PRs.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)