### PR TITLE
fix(logging): Stabilize ring watcher log messages

### DIFF
--- a/pkg/util/ring_watcher.go
+++ b/pkg/util/ring_watcher.go
@@ -2,7 +2,6 @@ package util //nolint:revive
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/go-kit/log"
@@ -85,12 +84,18 @@ func (w *ringWatcher) lookupAddresses() {
 	}
 
 	for _, ta := range toAdd {
-		level.Debug(w.log).Log("msg", fmt.Sprintf("adding connection to address: %s", ta))
+		level.Debug(w.log).Log(
+			"msg", "adding connection to address",
+			"address", ta,
+		)
 		w.notifications.AddressAdded(ta)
 	}
 
 	for _, tr := range toRemove {
-		level.Debug(w.log).Log("msg", fmt.Sprintf("removing connection to address: %s", tr))
+		level.Debug(w.log).Log(
+			"msg", "removing connection to address",
+			"address", tr,
+		)
 		w.notifications.AddressRemoved(tr)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces dynamically formatted log messages in `pkg/util/ring_watcher.go`
with stable structured logging fields.

Previously, runtime-specific address values were embedded directly into the
`msg` field using `fmt.Sprintf`, which can increase log cardinality and make
aggregation/querying less effective in observability systems.

This change keeps the log message stable and moves runtime values into a
dedicated structured field.

**Which issue(s) this PR fixes**:

Fixes part of #21800

**Special notes for your reviewer**:

This PR intentionally scopes the fix to `pkg/util/ring_watcher.go` as a focused
subset of the larger logging audit issue.

**Checklist**

* [x] Reviewed the [`[CONTRIBUTING.md](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md)`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
* [x] Documentation added
* [ ] Tests updated
* [x] Title matches the required conventional commits format, see [[here](https://www.conventionalcommits.org/en/v1.0.0/)](https://www.conventionalcommits.org/en/v1.0.0/)
* [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
* [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.