### PR TITLE
fix(logging): Stabilize storage layer log messages

### DIFF
--- a/pkg/compactor/index_set.go
+++ b/pkg/compactor/index_set.go
@@ -281,7 +281,7 @@ func (is *indexSet) upload() error {
 	}()
 
 	fileName := idx.Name()
-	level.Debug(is.logger).Log("msg", fmt.Sprintf("uploading index %s", fileName))
+	level.Debug(is.logger).Log("msg", "uploading index", "file_name", fileName)
 
 	idxPath := idx.Path()
 

--- a/pkg/compactor/tables_manager.go
+++ b/pkg/compactor/tables_manager.go
@@ -66,7 +66,7 @@ func (c *tablesManager) start(ctx context.Context) {
 	func() {
 		t := time.NewTimer(c.cfg.CompactionInterval)
 		defer t.Stop()
-		level.Info(util_log.Logger).Log("msg", fmt.Sprintf("waiting %v for ring to stay stable and previous compactions to finish before starting compactor", c.cfg.CompactionInterval))
+		level.Info(util_log.Logger).Log("msg", "waiting for ring to stay stable and previous compactions to finish before starting compactor", "duration", c.cfg.CompactionInterval)
 		select {
 		case <-ctx.Done():
 			stopped = true
@@ -254,7 +254,7 @@ func (c *tablesManager) runCompaction(ctx context.Context, applyRetention bool) 
 			}
 		}
 		if !applyRetention && runtime > c.cfg.CompactionInterval {
-			level.Warn(util_log.Logger).Log("msg", fmt.Sprintf("last compaction took %s which is longer than the compaction interval of %s, this can lead to duplicate compactors running if not running a standalone compactor instance.", runtime, c.cfg.CompactionInterval))
+			level.Warn(util_log.Logger).Log("msg", "last compaction took longer than the compaction interval, this can lead to duplicate compactors running if not running a standalone compactor instance", "duration", runtime, "interval", c.cfg.CompactionInterval)
 		}
 	}()
 

--- a/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
@@ -130,12 +130,12 @@ func (t *indexSet) Init(forQuerying bool, logger log.Logger) (err error) {
 		// if we fail to open an index file, lets skip it and let sync operation re-download the file from storage.
 		idx, err := t.openIndexFileFunc(fullPath)
 		if err != nil {
-			level.Error(logger).Log("msg", fmt.Sprintf("failed to open existing index file %s, removing the file and continuing without it to let the sync operation catch up", fullPath), "err", err)
+			level.Error(logger).Log("msg", "failed to open existing index file, removing and continuing to let the sync operation catch up", "path", fullPath, "err", err)
 			// Sometimes files get corrupted when the process gets killed in the middle of a download operation which can cause problems in reading the file.
 			// Implementation of openIndexFileFunc should take care of gracefully handling corrupted files.
 			// Let us just remove the file and let the sync operation re-download it.
 			if err := os.Remove(fullPath); err != nil {
-				level.Error(logger).Log("msg", fmt.Sprintf("failed to remove index file %s which failed to open", fullPath))
+				level.Error(logger).Log("msg", "failed to remove index file which failed to open", "path", fullPath)
 			}
 			continue
 		}
@@ -143,7 +143,7 @@ func (t *indexSet) Init(forQuerying bool, logger log.Logger) (err error) {
 		t.index[entry.Name()] = idx
 	}
 
-	level.Debug(logger).Log("msg", fmt.Sprintf("opened %d local files, now starting sync operation", len(t.index)))
+	level.Debug(logger).Log("msg", "opened local files, now starting sync operation", "count", len(t.index))
 
 	// sync the table to get new files and remove the deleted ones from storage.
 	err = t.syncWithRetry(ctx, false, forQuerying)
@@ -313,14 +313,14 @@ func (t *indexSet) syncWithRetry(ctx context.Context, lock, bypassListCache bool
 
 // sync downloads updated and new files from the storage relevant for the table and removes the deleted ones
 func (t *indexSet) sync(ctx context.Context, lock, bypassListCache bool) (err error) {
-	level.Debug(t.logger).Log("msg", fmt.Sprintf("syncing files for table %s", t.tableName))
+	level.Debug(t.logger).Log("msg", "syncing files for table", "table", t.tableName)
 
 	toDownload, toDelete, err := t.checkStorageForUpdates(ctx, lock, bypassListCache)
 	if err != nil {
 		return err
 	}
 
-	level.Debug(t.logger).Log("msg", fmt.Sprintf("updates for table %s. toDownload: %s, toDelete: %s", t.tableName, toDownload, toDelete))
+	level.Debug(t.logger).Log("msg", "computed storage updates for table", "table", t.tableName, "to_download", toDownload, "to_delete", toDelete)
 
 	downloadedFiles, err := t.doConcurrentDownload(ctx, toDownload)
 	if err != nil {
@@ -445,7 +445,7 @@ func (t *indexSet) doConcurrentDownload(ctx context.Context, files []storage.Ind
 		fileName, err := t.downloadFileFromStorage(ctx, files[idx].Name, t.cacheLocation)
 		if err != nil {
 			if t.baseIndexSet.IsFileNotFoundErr(err) {
-				level.Info(t.logger).Log("msg", fmt.Sprintf("ignoring missing file %s, possibly removed during compaction", fileName))
+				level.Info(t.logger).Log("msg", "ignoring missing file, possibly removed during compaction", "file", fileName)
 				return nil
 			}
 			return err

--- a/pkg/storage/stores/shipper/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table.go
@@ -102,7 +102,7 @@ func LoadTable(name, cacheLocation string, storageClient storage.Client, openInd
 		maxConcurrent:      maxConcurrent,
 	}
 
-	level.Debug(table.logger).Log("msg", fmt.Sprintf("opening locally present files for table %s", name), "files", fmt.Sprint(dirEntries))
+	level.Debug(table.logger).Log("msg", "opening locally present files for table", "table", name, "files", fmt.Sprint(dirEntries))
 
 	// common index files are outside the directories and user index files are in the directories
 	for _, entry := range dirEntries {
@@ -253,7 +253,7 @@ func (t *table) DropUnusedIndex(ttl time.Duration, now time.Time) (bool, error) 
 				continue
 			}
 
-			level.Info(t.logger).Log("msg", fmt.Sprintf("cleaning up expired index set %s", userID))
+			level.Info(t.logger).Log("msg", "cleaning up expired index set", "user_id", userID)
 			err := t.indexSets[userID].DropAllDBs()
 			if err != nil {
 				return false, err
@@ -270,7 +270,7 @@ func (t *table) DropUnusedIndex(ttl time.Duration, now time.Time) (bool, error) 
 
 // Sync downloads updated and new files from the storage relevant for the table and removes the deleted ones
 func (t *table) Sync(ctx context.Context) error {
-	level.Debug(t.logger).Log("msg", fmt.Sprintf("syncing files for table %s", t.name))
+	level.Debug(t.logger).Log("msg", "syncing files for table", "table", t.name)
 
 	t.indexSetsMtx.RLock()
 	users := slices.Collect(maps.Keys(t.indexSets))
@@ -367,9 +367,9 @@ func (t *table) cleanupBrokenIndexSet(ctx context.Context, id string) {
 		return
 	}
 
-	level.Error(util_log.WithContext(ctx, t.logger)).Log("msg", fmt.Sprintf("index set %s has some problem, cleaning it up", id), "err", indexSet.Err())
+	level.Error(util_log.WithContext(ctx, t.logger)).Log("msg", "index set has a problem, cleaning it up", "index_set", id, "err", indexSet.Err())
 	if err := indexSet.DropAllDBs(); err != nil {
-		level.Error(t.logger).Log("msg", fmt.Sprintf("failed to cleanup broken index set %s", id), "err", err)
+		level.Error(t.logger).Log("msg", "failed to cleanup broken index set", "index_set", id, "err", err)
 	}
 
 	delete(t.indexSets, id)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/manager.go
@@ -111,7 +111,7 @@ func (m *tsdbManager) Start() error {
 
 		bucket := f.Name()
 		if ok, err := m.tableRange.TableInRange(bucket); !ok {
-			level.Info(m.log).Log("msg", fmt.Sprintf("skip loading, table not in range: %s", f.Name()), "reason", err)
+			level.Info(m.log).Log("msg", "skip loading, table not in range", "table", f.Name(), "reason", err)
 			continue
 		}
 		buckets++

--- a/pkg/storage/stores/shipper/indexshipper/uploads/index_set.go
+++ b/pkg/storage/stores/shipper/indexshipper/uploads/index_set.go
@@ -83,7 +83,7 @@ func (t *indexSet) Upload(ctx context.Context) error {
 	t.indexMtx.RLock()
 	defer t.indexMtx.RUnlock()
 
-	level.Info(util_log.Logger).Log("msg", fmt.Sprintf("uploading table %s", t.tableName))
+	level.Info(util_log.Logger).Log("msg", "uploading table", "table", t.tableName)
 
 	for name, idx := range t.index {
 		// if the file is uploaded already do not upload it again.
@@ -104,7 +104,7 @@ func (t *indexSet) Upload(ctx context.Context) error {
 		t.indexUploadTimeMtx.Unlock()
 	}
 
-	level.Info(util_log.Logger).Log("msg", fmt.Sprintf("finished uploading table %s", t.tableName))
+	level.Info(util_log.Logger).Log("msg", "finished uploading table", "table", t.tableName)
 
 	return nil
 }
@@ -116,7 +116,7 @@ func (t *indexSet) Close() {
 
 	for name, idx := range t.index {
 		if err := idx.Close(); err != nil {
-			level.Error(t.logger).Log("msg", fmt.Sprintf("failed to close index %s", name), "err", err)
+			level.Error(t.logger).Log("msg", "failed to close index", "index", name, "err", err)
 		}
 	}
 
@@ -125,7 +125,7 @@ func (t *indexSet) Close() {
 
 func (t *indexSet) uploadIndex(ctx context.Context, idx index.Index) error {
 	fileName := idx.Name()
-	level.Debug(t.logger).Log("msg", fmt.Sprintf("uploading index %s", fileName))
+	level.Debug(t.logger).Log("msg", "uploading index", "index", fileName)
 
 	idxPath := idx.Path()
 
@@ -183,7 +183,7 @@ func (t *indexSet) uploadIndex(ctx context.Context, idx index.Index) error {
 
 // Cleanup removes indexes which are already uploaded and have been retained for period longer than indexRetainPeriod since they were uploaded.
 func (t *indexSet) Cleanup(indexRetainPeriod time.Duration) error {
-	level.Info(util_log.Logger).Log("msg", fmt.Sprintf("cleaning up unwanted indexes from table %s", t.tableName))
+	level.Info(util_log.Logger).Log("msg", "cleaning up unwanted indexes from table", "table", t.tableName)
 
 	var filesToCleanup []string
 	cutoffTime := time.Now().Add(-indexRetainPeriod)
@@ -203,7 +203,7 @@ func (t *indexSet) Cleanup(indexRetainPeriod time.Duration) error {
 	t.indexMtx.RUnlock()
 
 	for i := range filesToCleanup {
-		level.Debug(util_log.Logger).Log("msg", fmt.Sprintf("dropping uploaded index %s from table %s", filesToCleanup[i], t.tableName))
+		level.Debug(util_log.Logger).Log("msg", "dropping uploaded index from table", "index", filesToCleanup[i], "table", t.tableName)
 
 		if err := t.removeIndex(filesToCleanup[i]); err != nil {
 			return err

--- a/pkg/util/ring_watcher.go
+++ b/pkg/util/ring_watcher.go
@@ -2,7 +2,6 @@ package util //nolint:revive
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/go-kit/log"
@@ -85,12 +84,18 @@ func (w *ringWatcher) lookupAddresses() {
 	}
 
 	for _, ta := range toAdd {
-		level.Debug(w.log).Log("msg", fmt.Sprintf("adding connection to address: %s", ta))
+		level.Debug(w.log).Log(
+			"msg", "adding connection to address",
+			"address", ta,
+		)
 		w.notifications.AddressAdded(ta)
 	}
 
 	for _, tr := range toRemove {
-		level.Debug(w.log).Log("msg", fmt.Sprintf("removing connection to address: %s", tr))
+		level.Debug(w.log).Log(
+			"msg", "removing connection to address",
+			"address", tr,
+		)
 		w.notifications.AddressRemoved(tr)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes structured logging violations across the storage layer as part of the larger audit in #21800.

In multiple places, runtime values (table names, file paths, user IDs, counts) were embedded directly into the `msg` field via `fmt.Sprintf`:

Before: `Log("msg", fmt.Sprintf("syncing files for table %s", t.tableName))`
After:  `Log("msg", "syncing files for table", "table", t.tableName)`

This causes high log cardinality in Loki itself — every unique table name or file path creates a new log stream, making stable aggregation and alerting impossible on these events. All changes are purely mechanical with no logic changes.

Files changed:
- `pkg/storage/stores/shipper/indexshipper/downloads/index_set.go` — 6 fixes
- `pkg/storage/stores/shipper/indexshipper/downloads/table.go` — 5 fixes
- `pkg/storage/stores/shipper/indexshipper/uploads/index_set.go` — 6 fixes
- `pkg/storage/stores/shipper/indexshipper/tsdb/manager.go` — 1 fix
- `pkg/compactor/index_set.go` — 1 fix
- `pkg/compactor/tables_manager.go` — 2 fixes

**Which issue(s) this PR fixes**:
Part of #21800

**Special notes for your reviewer**:
This is PR 2/3 in the #21800 series:
- PR 1: #21953 — ring watcher (already open)
- PR 2: This PR — storage layer https://github.com/grafana/loki/pull/21955
- PR 3: Application layer (pending)

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.
