### PR TITLE
fix(logging): stabilize application layer log messages

### DIFF
--- a/clients/cmd/fluent-bit/dque.go
+++ b/clients/cmd/fluent-bit/dque.go
@@ -146,7 +146,7 @@ func (c *dqueClient) enqueuer() {
 	defer c.wg.Done()
 	for e := range c.entries {
 		if err := c.queue.Enqueue(&dqueEntry{e.Labels, e.Timestamp, e.Line}); err != nil {
-			level.Warn(c.logger).Log("msg", fmt.Sprintf("cannot enqueue record %s:", e.Line), "err", err)
+			level.Warn(c.logger).Log("msg", "cannot enqueue record", "line", e.Line, "err", err)
 		}
 	}
 }

--- a/pkg/engine/internal/scheduler/wire/wire_http2.go
+++ b/pkg/engine/internal/scheduler/wire/wire_http2.go
@@ -123,7 +123,7 @@ func (l *HTTP2Listener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "listener closed", http.StatusServiceUnavailable)
 
 	case <-r.Context().Done():
-		level.Debug(l.logger).Log("msg", "request context cancelled", err, r.Context().Err())
+		level.Debug(l.logger).Log("msg", "request context cancelled", "err", r.Context().Err())
 		return
 
 	case l.incoming <- conn:

--- a/pkg/indexgateway/client.go
+++ b/pkg/indexgateway/client.go
@@ -440,7 +440,7 @@ func (s *GatewayClient) clientDoQueries(ctx context.Context, gatewayQueries []*l
 		}
 		query, ok := queryKeyQueryMap[resp.QueryKey]
 		if !ok {
-			level.Error(s.logger).Log("msg", fmt.Sprintf("unexpected %s QueryKey received, expected queries %s", resp.QueryKey, fmt.Sprint(queryKeyQueryMap)))
+			level.Error(s.logger).Log("msg", "unexpected QueryKey received", "query_key", resp.QueryKey, "expected_queries", fmt.Sprint(queryKeyQueryMap))
 			return fmt.Errorf("unexpected %s QueryKey received", resp.QueryKey)
 		}
 		if !callback(query, &readBatch{resp}) {
@@ -473,7 +473,7 @@ func (s *GatewayClient) poolDoWithStrategy(
 	}
 
 	if len(addrs) == 0 {
-		level.Error(s.logger).Log("msg", fmt.Sprintf("no index gateway instances found for tenant %s", userID))
+		level.Error(s.logger).Log("msg", "no index gateway instances found for tenant", "tenant", userID)
 		return fmt.Errorf("no index gateway instances found for tenant %s", userID)
 	}
 
@@ -496,14 +496,14 @@ func (s *GatewayClient) poolDoWithStrategy(
 
 		genericClient, err := s.pool.GetClientFor(addr)
 		if err != nil {
-			level.Error(s.logger).Log("msg", fmt.Sprintf("failed to get client for instance %s", addr), "err", err)
+			level.Error(s.logger).Log("msg", "failed to get client for instance", "addr", addr, "err", err)
 			continue
 		}
 
 		client := (genericClient.(logproto.IndexGatewayClient))
 		if err := callback(client); err != nil {
 			lastErr = err
-			level.Error(s.logger).Log("msg", fmt.Sprintf("client do failed for instance %s", addr), "err", err)
+			level.Error(s.logger).Log("msg", "client request failed for instance", "addr", addr, "err", err)
 
 			if !shouldRetry(err) {
 				return err

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -466,11 +466,11 @@ func (i *Ingester) setupAutoForget() {
 		ctx := context.Background()
 		err := i.AwaitRunning(ctx)
 		if err != nil {
-			level.Error(i.logger).Log("msg", fmt.Sprintf("autoforget received error %s, autoforget is disabled", err.Error()))
+			level.Error(i.logger).Log("msg", "autoforget received error, autoforget is disabled", "err", err)
 			return
 		}
 
-		level.Info(i.logger).Log("msg", fmt.Sprintf("autoforget is enabled and will remove unhealthy instances from the ring after %v with no heartbeat", i.cfg.LifecyclerConfig.RingConfig.HeartbeatTimeout))
+		level.Info(i.logger).Log("msg", "autoforget is enabled and will remove unhealthy instances from the ring with no heartbeat", "timeout", i.cfg.LifecyclerConfig.RingConfig.HeartbeatTimeout)
 
 		ticker := time.NewTicker(i.cfg.LifecyclerConfig.HeartbeatPeriod)
 		defer ticker.Stop()
@@ -485,14 +485,14 @@ func (i *Ingester) setupAutoForget() {
 
 				ringDesc, ok := in.(*ring.Desc)
 				if !ok {
-					level.Warn(i.logger).Log("msg", fmt.Sprintf("autoforget saw a KV store value that was not `ring.Desc`, got `%T`", in))
+					level.Warn(i.logger).Log("msg", "autoforget saw a KV store value that was not ring.Desc", "type", fmt.Sprintf("%T", in))
 					return nil, false, nil
 				}
 
 				for id, ingester := range ringDesc.Ingesters {
 					if !ingester.IsHealthy(ring.Reporting, i.cfg.LifecyclerConfig.RingConfig.HeartbeatTimeout, time.Now()) {
 						if i.lifecycler.ID == id {
-							level.Warn(i.logger).Log("msg", fmt.Sprintf("autoforget has seen our ID `%s` as unhealthy in the ring, network may be partitioned, skip forgeting ingesters this round", id))
+							level.Warn(i.logger).Log("msg", "autoforget has seen our own ID as unhealthy in the ring, network may be partitioned, skipping this round", "id", id)
 							return nil, false, nil
 						}
 						forgetList = append(forgetList, id)
@@ -500,7 +500,7 @@ func (i *Ingester) setupAutoForget() {
 				}
 
 				if len(forgetList) == len(ringDesc.Ingesters)-1 {
-					level.Warn(i.logger).Log("msg", fmt.Sprintf("autoforget have seen %d unhealthy ingesters out of %d, network may be partioned, skip forgeting ingesters this round", len(forgetList), len(ringDesc.Ingesters)))
+					level.Warn(i.logger).Log("msg", "autoforget seen too many unhealthy ingesters, network may be partitioned, skipping this round", "unhealthy", len(forgetList), "total", len(ringDesc.Ingesters))
 					forgetList = forgetList[:0]
 					return nil, false, nil
 				}
@@ -514,12 +514,12 @@ func (i *Ingester) setupAutoForget() {
 				return nil, false, nil
 			})
 			if err != nil {
-				level.Warn(i.logger).Log("msg", err)
+				level.Warn(i.logger).Log("msg", "autoforget KV store CAS operation failed", "err", err)
 				continue
 			}
 
 			for _, id := range forgetList {
-				level.Info(i.logger).Log("msg", fmt.Sprintf("autoforget removed ingester %v from the ring because it was not healthy after %v", id, i.cfg.LifecyclerConfig.RingConfig.HeartbeatTimeout))
+				level.Info(i.logger).Log("msg", "autoforget removed ingester from the ring due to missing heartbeat", "ingester_id", id, "timeout", i.cfg.LifecyclerConfig.RingConfig.HeartbeatTimeout)
 			}
 			i.metrics.autoForgetUnhealthyIngestersTotal.Add(float64(len(forgetList)))
 		}

--- a/pkg/limits/frontend/ring.go
+++ b/pkg/limits/frontend/ring.go
@@ -146,7 +146,7 @@ func (r *ringLimitsClient) newExceedsLimitsRPCsFunc(resp *proto.ExceedsLimitsRes
 					Streams: streams,
 				})
 				if err != nil {
-					level.Error(r.logger).Log("failed check execeed limits for instance", "instance", addr, "err", err.Error())
+					level.Error(r.logger).Log("msg", "failed to check exceed limits for instance", "instance", addr, "err", err.Error())
 					return nil
 				}
 				responseCh <- resp
@@ -196,7 +196,7 @@ func (r *ringLimitsClient) newUpdateRatesRPCsFunc(resp *proto.UpdateRatesRespons
 					Streams: streams,
 				})
 				if err != nil {
-					level.Error(r.logger).Log("failed check execeed limits for instance", "instance", addr, "err", err.Error())
+					level.Error(r.logger).Log("msg", "failed to check exceed limits for instance", "instance", addr, "err", err.Error())
 					return nil
 				}
 				responseCh <- resp
@@ -382,12 +382,12 @@ func (r *ringLimitsClient) getPartitionConsumers(ctx context.Context, instances 
 			}
 			client, err := r.pool.GetClientFor(instance.Addr)
 			if err != nil {
-				level.Error(r.logger).Log("failed to get client for instance", "instance", instance.Addr, "err", err.Error())
+				level.Error(r.logger).Log("msg", "failed to get client for instance", "instance", instance.Addr, "err", err.Error())
 				return nil
 			}
 			resp, err := client.(proto.IngestLimitsClient).GetAssignedPartitions(ctx, &proto.GetAssignedPartitionsRequest{})
 			if err != nil {
-				level.Error(r.logger).Log("failed to get assigned partitions for instance", "instance", instance.Addr, "err", err.Error())
+				level.Error(r.logger).Log("msg", "failed to get assigned partitions for instance", "instance", instance.Addr, "err", err.Error())
 				return nil
 			}
 			r.assignedPartitionsCache.Set(instance.Addr, resp)

--- a/pkg/querytee/comparator/response_comparator.go
+++ b/pkg/querytee/comparator/response_comparator.go
@@ -200,7 +200,9 @@ func compareMatrixSamples(expected, actual *model.SampleStream, opts SampleCompa
 	if expectedEntriesCount != actualEntriesCount {
 		err := fmt.Errorf("expected %d samples for metric %s but got %d: %w", expectedEntriesCount, expected.Metric, actualEntriesCount, ErrComparisonMismatch)
 		if actualEntriesCount > 0 && expectedEntriesCount > 0 {
-			level.Error(util_log.Logger).Log("msg", err.Error(),
+			level.Error(util_log.Logger).Log(
+				"msg", "sample count mismatch",
+				"err", err,
 				"oldest-expected-ts", expected.Values[0].Timestamp,
 				"newest-expected-ts", expected.Values[expectedEntriesCount-1].Timestamp,
 				"oldest-actual-ts", actual.Values[0].Timestamp,
@@ -469,7 +471,10 @@ func compareStreamEntries(streamLabels loghttp.LabelSet, expected, actual []logh
 			streamLabels, actualValuesLen, ErrComparisonMismatch)
 		if expectedValuesLen > 0 && actualValuesLen > 0 {
 			// assuming BACKWARD search since that is the default ordering
-			level.Error(util_log.Logger).Log("msg", err.Error(), "newest-expected-ts", expected[0].Timestamp.UnixNano(),
+			level.Error(util_log.Logger).Log(
+				"msg", "stream entry count mismatch",
+				"err", err,
+				"newest-expected-ts", expected[0].Timestamp.UnixNano(),
 				"oldest-expected-ts", expected[expectedValuesLen-1].Timestamp.UnixNano(),
 				"newest-actual-ts", actual[0].Timestamp.UnixNano(), "oldest-actual-ts", actual[actualValuesLen-1].Timestamp.UnixNano())
 		}

--- a/pkg/util/ring_watcher.go
+++ b/pkg/util/ring_watcher.go
@@ -2,7 +2,6 @@ package util //nolint:revive
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/go-kit/log"
@@ -85,12 +84,18 @@ func (w *ringWatcher) lookupAddresses() {
 	}
 
 	for _, ta := range toAdd {
-		level.Debug(w.log).Log("msg", fmt.Sprintf("adding connection to address: %s", ta))
+		level.Debug(w.log).Log(
+			"msg", "adding connection to address",
+			"address", ta,
+		)
 		w.notifications.AddressAdded(ta)
 	}
 
 	for _, tr := range toRemove {
-		level.Debug(w.log).Log("msg", fmt.Sprintf("removing connection to address: %s", tr))
+		level.Debug(w.log).Log(
+			"msg", "removing connection to address",
+			"address", tr,
+		)
 		w.notifications.AddressRemoved(tr)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes structured logging violations across the application layer as part of the larger audit in #21800.

Three categories of violations fixed:

**1. Dynamic message names via `fmt.Sprintf`:**
Before: `Log("msg", fmt.Sprintf("autoforget removed ingester %v ...", id, timeout))`
After:  `Log("msg", "autoforget removed ingester from the ring", "ingester_id", id, "timeout", timeout)`

**2. Go variable used as field key instead of string literal:**
Before: `Log("msg", "request context cancelled", err, r.Context().Err())`
After:  `Log("msg", "request context cancelled", "err", r.Context().Err())`

**3. Missing `msg` key (first arg treated as a key instead of a message):**
Before: `Log("failed to get client for instance", "instance", addr, "err", err)`
After:  `Log("msg", "failed to get client for instance", "instance", addr, "err", err)`

All three patterns produce high-cardinality or malformed log output in observability systems.

Files changed:
- `pkg/ingester/ingester.go` — 7 fixes
- `pkg/indexgateway/client.go` — 4 fixes
- `pkg/limits/frontend/ring.go` — 4 fixes
- `pkg/querytee/comparator/response_comparator.go` — 2 fixes
- `pkg/engine/internal/scheduler/wire/wire_http2.go` — 1 fix
- `clients/cmd/fluent-bit/dque.go` — 1 fix

**Which issue(s) this PR fixes**:
Part of #21800

**Special notes for your reviewer**:
This is PR 3/3 in the #21800 series:
- PR 1: #21953 — ring watcher (already open)
- PR 2: Storage layer (pending)
- PR 3: This PR — application layer

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.
