### PR TITLE
fix(storage): Remove partial destination file when download fails

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/storage/util.go
+++ b/pkg/storage/stores/shipper/indexshipper/storage/util.go
@@ -42,7 +42,7 @@ func putGzipReader(reader io.Reader) {
 type GetFileFunc func() (io.ReadCloser, error)
 
 // DownloadFileFromStorage downloads a file from storage to given location.
-func DownloadFileFromStorage(destination string, decompressFile bool, sync bool, logger log.Logger, getFileFunc GetFileFunc) error {
+func DownloadFileFromStorage(destination string, decompressFile bool, sync bool, logger log.Logger, getFileFunc GetFileFunc) (err error) {
 	start := time.Now()
 	readCloser, err := getFileFunc()
 	if err != nil {
@@ -95,8 +95,16 @@ func DownloadFileFromStorage(destination string, decompressFile bool, sync bool,
 	}
 
 	defer func() {
-		if err := f.Close(); err != nil {
+		if closeErr := f.Close(); closeErr != nil {
 			level.Warn(logger).Log("msg", "failed to close file", "file", destination)
+		}
+		// If the download failed partway (e.g. truncated source, see #21736), remove the
+		// partial destination so a future retry starts clean and corrupt bytes are not
+		// left behind for openers to misread.
+		if err != nil {
+			if removeErr := os.Remove(destination); removeErr != nil && !os.IsNotExist(removeErr) {
+				level.Warn(logger).Log("msg", "failed to remove partial destination file", "file", destination, "err", removeErr)
+			}
 		}
 	}()
 	var objectReader io.Reader = tmpReader

--- a/pkg/storage/stores/shipper/indexshipper/storage/util_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/storage/util_test.go
@@ -57,6 +57,61 @@ func Test_GetFileFromStorage(t *testing.T) {
 	require.Equal(t, testData, b)
 }
 
+// Test_DownloadFileFromStorage_PreservesDestinationOnEarlyError verifies that if the
+// download fails before the destination file is touched (e.g. getFileFunc returns an
+// error), a pre-existing destination file is left untouched.
+func Test_DownloadFileFromStorage_PreservesDestinationOnEarlyError(t *testing.T) {
+	tempDir := t.TempDir()
+	dst := filepath.Join(tempDir, "dest")
+	original := []byte("pre-existing content")
+	require.NoError(t, os.WriteFile(dst, original, 0o666))
+
+	err := DownloadFileFromStorage(dst, false, false, util_log.Logger, func() (io.ReadCloser, error) {
+		return nil, io.ErrUnexpectedEOF
+	})
+	require.Error(t, err)
+
+	b, statErr := os.ReadFile(dst)
+	require.NoError(t, statErr, "pre-existing destination should be untouched on early error")
+	require.Equal(t, original, b)
+}
+
+// Test_DownloadFileFromStorage_TruncatedGzip verifies that when the source gzip is
+// truncated (which mimics a storage backend returning a short body, see issue #21736),
+// DownloadFileFromStorage does not leave a partial destination file on disk.
+func Test_DownloadFileFromStorage_TruncatedGzip(t *testing.T) {
+	tempDir := t.TempDir()
+	tableName := "test-table"
+	require.NoError(t, util.EnsureDirectory(filepath.Join(tempDir, tableName)))
+
+	// Write a valid source, compress it, then truncate the gzipped output to simulate
+	// a short-body response from object storage.
+	srcPath := filepath.Join(tempDir, tableName, "src")
+	require.NoError(t, os.WriteFile(srcPath, []byte("the quick brown fox jumps over the lazy dog"), 0o666))
+
+	gzPath := filepath.Join(tempDir, tableName, "src.gz")
+	compressFile(t, srcPath, gzPath, true)
+
+	info, err := os.Stat(gzPath)
+	require.NoError(t, err)
+	// Truncate the last few bytes, enough to corrupt the gzip trailer.
+	require.NoError(t, os.Truncate(gzPath, info.Size()-5))
+
+	objectClient, err := local.NewFSObjectClient(local.FSConfig{Directory: tempDir})
+	require.NoError(t, err)
+	indexStorageClient := NewIndexStorageClient(objectClient, "")
+
+	dst := filepath.Join(tempDir, "dest")
+	err = DownloadFileFromStorage(dst, true, false, util_log.Logger, func() (io.ReadCloser, error) {
+		return indexStorageClient.GetFile(context.Background(), tableName, "src.gz")
+	})
+	require.Error(t, err, "expected error for truncated gzip")
+
+	_, statErr := os.Stat(dst)
+	require.True(t, os.IsNotExist(statErr),
+		"destination file should be removed when download fails, but it exists: stat err = %v", statErr)
+}
+
 func compressFile(t *testing.T, src, dest string, sync bool) {
 	uncompressedFile, err := os.Open(src)
 	require.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

`DownloadFileFromStorage` creates the destination file with `os.Create`, then copies (and optionally decompresses) the source bytes into it. If the copy fails partway (e.g. truncated source body, decompression error), the partial destination file is left on disk. The tmp file is cleaned up by an existing defer, but the destination is not, so corrupt bytes can persist across restarts and may be silently misread on the next startup.

The fix names the return value and adds cleanup inside the existing `f.Close()` defer that runs after `os.Create(destination)`. On error, the partial destination is removed. Placing the defer after `os.Create` means a pre-existing destination is left untouched if the function fails before touching it (e.g. `getFileFunc` network error).

**Which issue(s) this PR fixes**:
Fixes #21736

**Special notes for your reviewer**:

This is a minimal fix for the "partial file on disk" piece of the issue. The larger asks in the issue (retry-with-redownload, Content-Length validation) would need a separate PR because they require storage interface changes and more design work around retry semantics.

Added two tests:
- `Test_DownloadFileFromStorage_TruncatedGzip` reproduces the bug
- `Test_DownloadFileFromStorage_PreservesDestinationOnEarlyError` verifies a
  pre-existing destination file is not removed if the function fails early

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
