### PR TITLE
ci: Updates to the grafana-github-actions workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,13 +21,21 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@v4
         with:
-          repository: "grafana/grafana-github-actions"
+          repository: grafana/grafana-github-actions
           persist-credentials: false
           path: ./actions
-          ref: 066cbcd084b61558d99d13c76f835c49e31b4670
+          ref: 3c62d35c5a66e730186a338e45aeb8fa784e2d56
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
 
       - name: Install Actions
-        run: npm install --production --prefix ./actions
+        working-directory: ./actions
+        run: |
+          corepack enable
+          yarn install --immutable
 
       - name: Generate GitHub App Token
         id: app-token

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   triage:
-    # We don't run the triaging for PRs from forks because those can't access "loki-github-bot" secrets in vault.
+    # We don't run the triaging for PRs from forks because those can't use the loki-gh-app token broker.
     # We don't use GitHub actions app (secrets.GITHUB_TOKEN) because PRs created by the bot don't trigger CI.
     # Also only run if the PR is merged, as an extra safe-guard.
     if: ${{ ! github.event.pull_request.head.repo.fork && github.event.pull_request.merged == true }}
@@ -15,17 +15,6 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-    - name: Checkout Actions
-      uses: actions/checkout@v4
-      with:
-        repository: "grafana/grafana-github-actions"
-        persist-credentials: false
-        path: ./actions
-        ref: 066cbcd084b61558d99d13c76f835c49e31b4670
-
-    - name: Install Actions
-      run: npm install --production --prefix ./actions
-
     - name: Generate GitHub App Token
       id: app-token
       uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the backport action to use the latest version of the `grafana-github-actions` and walks away from `npm`, instead utilizing `yarn`.

Updates the labeler action to not bother installing anything with `npm`, as it is not needed, and likely a cut/paste.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
