### PR TITLE
chore: Add estimated query size to goldfish data

### DIFF
--- a/pkg/goldfish/migrations/20260521000001_add_estimated_query_size.sql
+++ b/pkg/goldfish/migrations/20260521000001_add_estimated_query_size.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- Add cell_a_estimated_query_size and cell_b_estimated_query_size columns to sampled_queries table.
+-- This is the estimated size of the query as returned by query stats. Defaults to 0 if unknown.
+
+ALTER TABLE sampled_queries
+ADD COLUMN cell_a_estimated_query_size BIGINT NOT NULL DEFAULT 0
+ADD COLUMN cell_b_estimated_query_size BIGINT NOT NULL DEFAULT 0;
+
+-- +goose Down
+-- Remove the cell_a_estimated_query_size and cell_b_estimated_query_size columns
+
+ALTER TABLE sampled_queries DROP COLUMN cell_a_estimated_query_size;
+ALTER TABLE sampled_queries DROP COLUMN cell_b_estimated_query_size;

--- a/pkg/goldfish/storage_mysql.go
+++ b/pkg/goldfish/storage_mysql.go
@@ -97,11 +97,12 @@ func (s *MySQLStorage) StoreQuerySample(ctx context.Context, sample *QuerySample
 			cell_a_trace_id, cell_b_trace_id,
 			cell_a_span_id, cell_b_span_id,
 			cell_a_used_new_engine, cell_b_used_new_engine,
+			cell_a_estimated_query_size, cell_b_estimated_query_size,
 			sampled_at,
 			comparison_status,
 			match_within_tolerance,
 			mismatch_cause
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 
 	// Convert empty span IDs to NULL for database storage
@@ -185,6 +186,8 @@ func (s *MySQLStorage) StoreQuerySample(ctx context.Context, sample *QuerySample
 		cellBSpanID,
 		sample.CellAUsedNewEngine,
 		sample.CellBUsedNewEngine,
+		sample.CellAStats.EstimatedQueryBytes,
+		sample.CellBStats.EstimatedQueryBytes,
 		sample.SampledAt,
 		comparison.ComparisonStatus,
 		comparison.MatchWithinTolerance,
@@ -269,6 +272,7 @@ func (s *MySQLStorage) GetSampledQueries(ctx context.Context, page, pageSize int
 			cell_a_trace_id, cell_b_trace_id,
 			cell_a_span_id, cell_b_span_id,
 			cell_a_used_new_engine, cell_b_used_new_engine,
+			cell_a_estimated_query_size, cell_b_estimated_query_size,
 			sampled_at, created_at,
 			comparison_status, match_within_tolerance, mismatch_cause
 		FROM sampled_queries
@@ -317,6 +321,7 @@ func (s *MySQLStorage) GetSampledQueries(ctx context.Context, page, pageSize int
 			&q.CellATraceID, &q.CellBTraceID,
 			&cellASpanID, &cellBSpanID,
 			&q.CellAUsedNewEngine, &q.CellBUsedNewEngine,
+			&q.CellAStats.EstimatedQueryBytes, &q.CellBStats.EstimatedQueryBytes,
 			&q.SampledAt, &createdAt,
 			&q.ComparisonStatus, &q.MatchWithinTolerance, &mismatchCause,
 		)
@@ -396,6 +401,7 @@ func (s *MySQLStorage) GetQueryByCorrelationID(ctx context.Context, correlationI
 			cell_a_trace_id, cell_b_trace_id,
 			cell_a_span_id, cell_b_span_id,
 			cell_a_used_new_engine, cell_b_used_new_engine,
+			cell_a_estimated_query_size, cell_b_estimated_query_size,
 			sampled_at, created_at, comparison_status, match_within_tolerance, mismatch_cause
 		FROM sampled_queries
 		WHERE correlation_id = ?
@@ -424,9 +430,9 @@ func (s *MySQLStorage) GetQueryByCorrelationID(ctx context.Context, correlationI
 		&q.CellATraceID, &q.CellBTraceID,
 		&cellASpanID, &cellBSpanID,
 		&q.CellAUsedNewEngine, &q.CellBUsedNewEngine,
+		&q.CellAStats.EstimatedQueryBytes, &q.CellBStats.EstimatedQueryBytes,
 		&q.SampledAt, &createdAt, &q.ComparisonStatus, &q.MatchWithinTolerance, &mismatchCause,
 	)
-
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, fmt.Errorf("query with correlation ID %s not found", correlationID)

--- a/pkg/goldfish/types.go
+++ b/pkg/goldfish/types.go
@@ -64,6 +64,7 @@ type QueryStats struct {
 	TotalEntriesReturned int64 `json:"totalEntriesReturned"` // Number of result entries
 	Splits               int64 `json:"splits"`               // Number of splits
 	Shards               int64 `json:"shards"`               // Number of shards
+	EstimatedQueryBytes  int64 `json:"estimatedQueryBytes"`  // Estimated bytes for this query reported by index stats before chunk reads
 }
 
 // ComparisonResult represents the outcome of comparing two responses


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds estimated query size to the goldfish result row. This is populated via the stats object in classic Loki and the data originally comes from the index based on the stream selectors.

I want this data in goldfish results so it can be used to estimate "dataset size" for a query, which is likely an interesting comparison.