### PR TITLE
chore: Batch aggregator & range aggregation pipeline

### DIFF
--- a/pkg/engine/internal/executor/aggregator.go
+++ b/pkg/engine/internal/executor/aggregator.go
@@ -188,6 +188,60 @@ func (a *aggregator) ensureSeries(key uint64, labels []arrow.Field, labelValues 
 	return nil
 }
 
+// ensureSeriesFromColumns registers a new unique series for key using label values read
+// from Arrow columns at row. Null columns are skipped.
+func (a *aggregator) ensureSeriesFromColumns(key uint64, labelCols []*array.String, labelFields []arrow.Field, row int) error {
+	if _, exists := a.uniqueSeries[key]; exists {
+		return nil
+	}
+
+	if a.maxSeries > 0 && len(a.uniqueSeries) >= a.maxSeries {
+		return ErrSeriesLimitExceeded
+	}
+
+	var series map[string]string
+	if len(labelFields) > 0 {
+		series = make(map[string]string)
+		for i, col := range labelCols {
+			if col.IsNull(row) {
+				continue
+			}
+
+			v := col.Value(row)
+			cloned, ok := a.clonedLabelValues[v]
+			if !ok {
+				cloned = strings.Clone(v)
+				a.clonedLabelValues[v] = cloned
+			}
+			series[labelFields[i].Name] = cloned
+		}
+	}
+
+	a.uniqueSeries[key] = series
+	return nil
+}
+
+// addSampleFromColumns accumulates value at ts, grouping by the non-null label columns at row.
+func (a *aggregator) addSampleFromColumns(ts time.Time, value float64, labelCols []*array.String, labelFields []arrow.Field, row int) error {
+	key := a.computeGroupKeyFromColumns(labelCols, labelFields, row)
+	point := a.pointForTimestamp(ts)
+
+	if state, ok := point[key]; ok {
+		a.accumulate(state, value)
+		return nil
+	}
+
+	if err := a.ensureSeriesFromColumns(key, labelCols, labelFields, row); err != nil {
+		return err
+	}
+
+	point[key] = &groupState{
+		value: value,
+		count: 1,
+	}
+	return nil
+}
+
 // accumulate updates an existing groupState for the configured aggregation operation.
 func (a *aggregator) accumulate(state *groupState, value float64) {
 	// TODO: handle hash collisions

--- a/pkg/engine/internal/executor/aggregator.go
+++ b/pkg/engine/internal/executor/aggregator.go
@@ -46,6 +46,10 @@ type aggregator struct {
 	// Track unique series across all timestamps to enforce maxSeries limit
 	maxSeries    int                          // maximum number of unique series allowed (0 means no limit)
 	uniqueSeries map[uint64]map[string]string // tracks unique series across all timestamps
+
+	// batchRowKeys caches grouping keys by source row index during addSamplesFromColumns.
+	batchRowKeys         []uint64
+	batchRowKeysComputed []bool
 }
 
 // newAggregator creates a new aggregator with the specified grouping.
@@ -221,9 +225,102 @@ func (a *aggregator) ensureSeriesFromColumns(key uint64, labelCols []*array.Stri
 	return nil
 }
 
-// addSampleFromColumns accumulates value at ts, grouping by the non-null label columns at row.
-func (a *aggregator) addSampleFromColumns(ts time.Time, value float64, labelCols []*array.String, labelFields []arrow.Field, row int) error {
+// AddSample accumulates value at ts, grouping by the non-null label columns at row.
+func (a *aggregator) AddSample(ts time.Time, value float64, labelCols []*array.String, labelFields []arrow.Field, row int) error {
 	key := a.computeGroupKeyFromColumns(labelCols, labelFields, row)
+	return a.addSampleWithKey(ts, key, value, labelCols, labelFields, row)
+}
+
+// BatchAddSample ingests samples from columnar arrays.
+// Sample i aggregates at outputTs[i] with value values[i]. When sourceRows is nil,
+// sample i uses label row i; otherwise label row sourceRows[i].
+// values may be nil for count aggregations.
+func (a *aggregator) BatchAddSample(
+	outputTs *array.Timestamp,
+	values *array.Float64,
+	sourceRows *array.Int32,
+	labelCols []*array.String,
+	labelFields []arrow.Field,
+) error {
+	n := outputTs.Len()
+	if values != nil && values.Len() != n {
+		panic("BatchAddSample: outputTs and values length mismatch")
+	}
+	if sourceRows != nil && sourceRows.Len() != n {
+		panic("BatchAddSample: outputTs and sourceRows length mismatch")
+	}
+	if n == 0 {
+		return nil
+	}
+
+	a.prepareBatchRowKeys(a.maxSourceRow(sourceRows, labelCols, n) + 1)
+
+	for i := range n {
+		row := i
+		if sourceRows != nil {
+			if sourceRows.IsNull(i) {
+				continue
+			}
+			row = int(sourceRows.Value(i))
+		}
+
+		if !a.batchRowKeysComputed[row] {
+			a.batchRowKeys[row] = a.computeGroupKeyFromColumns(labelCols, labelFields, row)
+			a.batchRowKeysComputed[row] = true
+		}
+
+		var value float64
+		if values != nil {
+			if values.IsNull(i) {
+				continue
+			}
+			value = values.Value(i)
+		}
+
+		ts := outputTs.Value(i).ToTime(arrow.Nanosecond)
+		if err := a.addSampleWithKey(ts, a.batchRowKeys[row], value, labelCols, labelFields, row); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (a *aggregator) maxSourceRow(sourceRows *array.Int32, labelCols []*array.String, n int) int {
+	if sourceRows != nil {
+		maxRow := 0
+		for i := range n {
+			if sourceRows.IsNull(i) {
+				continue
+			}
+			row := int(sourceRows.Value(i))
+			if row > maxRow {
+				maxRow = row
+			}
+		}
+		return maxRow
+	}
+
+	if len(labelCols) > 0 {
+		return labelCols[0].Len() - 1
+	}
+
+	return n - 1
+}
+
+func (a *aggregator) prepareBatchRowKeys(n int) {
+	if cap(a.batchRowKeys) < n {
+		a.batchRowKeys = make([]uint64, n)
+		a.batchRowKeysComputed = make([]bool, n)
+		return
+	}
+
+	a.batchRowKeys = a.batchRowKeys[:n]
+	a.batchRowKeysComputed = a.batchRowKeysComputed[:n]
+	clear(a.batchRowKeysComputed)
+}
+
+func (a *aggregator) addSampleWithKey(ts time.Time, key uint64, value float64, labelCols []*array.String, labelFields []arrow.Field, row int) error {
 	point := a.pointForTimestamp(ts)
 
 	if state, ok := point[key]; ok {

--- a/pkg/engine/internal/executor/aggregator.go
+++ b/pkg/engine/internal/executor/aggregator.go
@@ -89,78 +89,125 @@ func (a *aggregator) Add(ts time.Time, value float64, labels []arrow.Field, labe
 		panic("len(labels) != len(labelValues)")
 	}
 
+	key := a.computeGroupKey(labels, labelValues)
+	point := a.pointForTimestamp(ts)
+
+	if state, ok := point[key]; ok {
+		a.accumulate(state, value)
+		return nil
+	}
+
+	if err := a.ensureSeries(key, labels, labelValues); err != nil {
+		return err
+	}
+
+	point[key] = &groupState{
+		value: value,
+		count: 1,
+	}
+	return nil
+}
+
+func (a *aggregator) pointForTimestamp(ts time.Time) map[uint64]*groupState {
 	point, ok := a.points[ts]
 	if !ok {
 		point = make(map[uint64]*groupState)
 		a.points[ts] = point
 	}
+	return point
+}
 
-	var key uint64
-	if len(labelValues) != 0 {
-		a.digest.Reset()
-		for i, val := range labelValues {
-			if i > 0 {
-				_, _ = a.digest.Write([]byte{0}) // separator
-			}
-
-			_, _ = a.digest.WriteString(labels[i].Name)
-			_, _ = a.digest.Write([]byte("="))
-			_, _ = a.digest.WriteString(val)
-		}
-		key = a.digest.Sum64()
+func (a *aggregator) computeGroupKey(labels []arrow.Field, labelValues []string) uint64 {
+	if len(labelValues) == 0 {
+		return 0
 	}
 
-	if state, ok := point[key]; ok {
-		// TODO: handle hash collisions
-
-		// accumulate value based on aggregation type
-		switch a.operation {
-		case aggregationOperationSum:
-			state.value += value
-		case aggregationOperationMax:
-			if value > state.value {
-				state.value = value
-			}
-		case aggregationOperationMin:
-			if value < state.value {
-				state.value = value
-			}
-		case aggregationOperationAvg:
-			state.value += value
+	a.digest.Reset()
+	for i, val := range labelValues {
+		if i > 0 {
+			_, _ = a.digest.Write([]byte{0}) // separator
 		}
 
-		state.count++
-	} else {
-		if series, exists := a.uniqueSeries[key]; !exists {
-			// Check series limit before adding a new series
-			if a.maxSeries > 0 && len(a.uniqueSeries) >= a.maxSeries {
-				return ErrSeriesLimitExceeded
-			}
+		_, _ = a.digest.WriteString(labels[i].Name)
+		_, _ = a.digest.Write([]byte("="))
+		_, _ = a.digest.WriteString(val)
+	}
+	return a.digest.Sum64()
+}
 
-			if len(labels) > 0 {
-				series = make(map[string]string)
-				for i, v := range labelValues {
-					// copy the value as this is backed by the arrow array data buffer.
-					// We could retain the record to avoid this copy, but that would hold
-					// all other columns in memory for as long as the query is evaluated.
-					cloned, ok := a.clonedLabelValues[v]
-					if !ok {
-						cloned = strings.Clone(v)
-						a.clonedLabelValues[v] = cloned
-					}
-					series[labels[i].Name] = cloned
-				}
-			}
-
-			a.uniqueSeries[key] = series
+// computeGroupKeyFromColumns computes the same grouping key as computeGroupKey for the
+// non-null label columns at row. Null columns are skipped, matching the sparse grouping
+// semantics used by range and vector aggregators.
+func (a *aggregator) computeGroupKeyFromColumns(labelCols []*array.String, labelFields []arrow.Field, row int) uint64 {
+	a.digest.Reset()
+	first := true
+	for i, col := range labelCols {
+		if col.IsNull(row) {
+			continue
 		}
 
-		point[key] = &groupState{
-			value: value,
-			count: int64(1),
+		if !first {
+			_, _ = a.digest.Write([]byte{0}) // separator
+		}
+		first = false
+
+		_, _ = a.digest.WriteString(labelFields[i].Name)
+		_, _ = a.digest.Write([]byte("="))
+		_, _ = a.digest.WriteString(col.Value(row))
+	}
+	return a.digest.Sum64()
+}
+
+// ensureSeries registers a new unique series for key if it does not already exist.
+func (a *aggregator) ensureSeries(key uint64, labels []arrow.Field, labelValues []string) error {
+	if _, exists := a.uniqueSeries[key]; exists {
+		return nil
+	}
+
+	if a.maxSeries > 0 && len(a.uniqueSeries) >= a.maxSeries {
+		return ErrSeriesLimitExceeded
+	}
+
+	var series map[string]string
+	if len(labels) > 0 {
+		series = make(map[string]string)
+		for i, v := range labelValues {
+			// copy the value as this is backed by the arrow array data buffer.
+			// We could retain the record to avoid this copy, but that would hold
+			// all other columns in memory for as long as the query is evaluated.
+			cloned, ok := a.clonedLabelValues[v]
+			if !ok {
+				cloned = strings.Clone(v)
+				a.clonedLabelValues[v] = cloned
+			}
+			series[labels[i].Name] = cloned
 		}
 	}
+
+	a.uniqueSeries[key] = series
 	return nil
+}
+
+// accumulate updates an existing groupState for the configured aggregation operation.
+func (a *aggregator) accumulate(state *groupState, value float64) {
+	// TODO: handle hash collisions
+
+	switch a.operation {
+	case aggregationOperationSum:
+		state.value += value
+	case aggregationOperationMax:
+		if value > state.value {
+			state.value = value
+		}
+	case aggregationOperationMin:
+		if value < state.value {
+			state.value = value
+		}
+	case aggregationOperationAvg:
+		state.value += value
+	}
+
+	state.count++
 }
 
 func (a *aggregator) BuildRecord() (arrow.RecordBatch, error) {

--- a/pkg/engine/internal/executor/aggregator.go
+++ b/pkg/engine/internal/executor/aggregator.go
@@ -47,7 +47,7 @@ type aggregator struct {
 	maxSeries    int                          // maximum number of unique series allowed (0 means no limit)
 	uniqueSeries map[uint64]map[string]string // tracks unique series across all timestamps
 
-	// batchRowKeys caches grouping keys by source row index during addSamplesFromColumns.
+	// batchRowKeys caches grouping keys by source row index during BatchAddSample.
 	batchRowKeys         []uint64
 	batchRowKeysComputed []bool
 }
@@ -86,32 +86,6 @@ func (a *aggregator) SetMaxSeries(maxSeries int) {
 	a.maxSeries = maxSeries
 }
 
-// Add adds a new sample value to the aggregation for the given timestamp and grouping label values.
-// It expects labelValues to be in the same order as the groupBy columns.
-func (a *aggregator) Add(ts time.Time, value float64, labels []arrow.Field, labelValues []string) error {
-	if len(labels) != len(labelValues) {
-		panic("len(labels) != len(labelValues)")
-	}
-
-	key := a.computeGroupKey(labels, labelValues)
-	point := a.pointForTimestamp(ts)
-
-	if state, ok := point[key]; ok {
-		a.accumulate(state, value)
-		return nil
-	}
-
-	if err := a.ensureSeries(key, labels, labelValues); err != nil {
-		return err
-	}
-
-	point[key] = &groupState{
-		value: value,
-		count: 1,
-	}
-	return nil
-}
-
 func (a *aggregator) pointForTimestamp(ts time.Time) map[uint64]*groupState {
 	point, ok := a.points[ts]
 	if !ok {
@@ -121,27 +95,8 @@ func (a *aggregator) pointForTimestamp(ts time.Time) map[uint64]*groupState {
 	return point
 }
 
-func (a *aggregator) computeGroupKey(labels []arrow.Field, labelValues []string) uint64 {
-	if len(labelValues) == 0 {
-		return 0
-	}
-
-	a.digest.Reset()
-	for i, val := range labelValues {
-		if i > 0 {
-			_, _ = a.digest.Write([]byte{0}) // separator
-		}
-
-		_, _ = a.digest.WriteString(labels[i].Name)
-		_, _ = a.digest.Write([]byte("="))
-		_, _ = a.digest.WriteString(val)
-	}
-	return a.digest.Sum64()
-}
-
-// computeGroupKeyFromColumns computes the same grouping key as computeGroupKey for the
-// non-null label columns at row. Null columns are skipped, matching the sparse grouping
-// semantics used by range and vector aggregators.
+// computeGroupKeyFromColumns computes a grouping key from the non-null label columns at row.
+// Null columns are skipped, matching the sparse grouping semantics used by range and vector aggregators.
 func (a *aggregator) computeGroupKeyFromColumns(labelCols []*array.String, labelFields []arrow.Field, row int) uint64 {
 	a.digest.Reset()
 	first := true
@@ -160,36 +115,6 @@ func (a *aggregator) computeGroupKeyFromColumns(labelCols []*array.String, label
 		_, _ = a.digest.WriteString(col.Value(row))
 	}
 	return a.digest.Sum64()
-}
-
-// ensureSeries registers a new unique series for key if it does not already exist.
-func (a *aggregator) ensureSeries(key uint64, labels []arrow.Field, labelValues []string) error {
-	if _, exists := a.uniqueSeries[key]; exists {
-		return nil
-	}
-
-	if a.maxSeries > 0 && len(a.uniqueSeries) >= a.maxSeries {
-		return ErrSeriesLimitExceeded
-	}
-
-	var series map[string]string
-	if len(labels) > 0 {
-		series = make(map[string]string)
-		for i, v := range labelValues {
-			// copy the value as this is backed by the arrow array data buffer.
-			// We could retain the record to avoid this copy, but that would hold
-			// all other columns in memory for as long as the query is evaluated.
-			cloned, ok := a.clonedLabelValues[v]
-			if !ok {
-				cloned = strings.Clone(v)
-				a.clonedLabelValues[v] = cloned
-			}
-			series[labels[i].Name] = cloned
-		}
-	}
-
-	a.uniqueSeries[key] = series
-	return nil
 }
 
 // ensureSeriesFromColumns registers a new unique series for key using label values read

--- a/pkg/engine/internal/executor/aggregator_test.go
+++ b/pkg/engine/internal/executor/aggregator_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/stretchr/testify/require"
 
@@ -315,6 +316,71 @@ func TestAggregator(t *testing.T) {
 			require.NoError(t, addSamples(agg, groupBy, nil, finalInput))
 		})
 	})
+}
+
+func TestAggregator_computeGroupKeyFromColumns(t *testing.T) {
+	colEnv := semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String).FQN()
+	colSvc := semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String).FQN()
+	colCluster := semconv.NewIdentifier("cluster", types.ColumnTypeLabel, types.Loki.String).FQN()
+
+	fields := []arrow.Field{
+		semconv.FieldFromIdent(semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String), true),
+		semconv.FieldFromIdent(semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String), true),
+		semconv.FieldFromIdent(semconv.NewIdentifier("cluster", types.ColumnTypeLabel, types.Loki.String), true),
+	}
+
+	cases := []struct {
+		name      string
+		rows      arrowtest.Rows
+		row       int
+		labels    []arrow.Field
+		values    []string
+		colFields []arrow.Field
+		colIdx    []int
+	}{
+		{
+			name: "by grouping",
+			rows: arrowtest.Rows{
+				{colEnv: "prod", colSvc: "app1", colCluster: "east-1"},
+			},
+			row:       0,
+			labels:    fields[:2],
+			values:    []string{"prod", "app1"},
+			colFields: fields[:2],
+			colIdx:    []int{0, 1},
+		},
+		{
+			name: "sparse without grouping",
+			rows: arrowtest.Rows{
+				{colEnv: "prod", colSvc: nil, colCluster: "east-1"},
+			},
+			row:       0,
+			labels:    []arrow.Field{fields[0], fields[2]},
+			values:    []string{"prod", "east-1"},
+			colFields: fields,
+			colIdx:    []int{0, 2},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			record := tc.rows.Record(memory.NewGoAllocator(), arrow.NewSchema(fields, nil))
+			t.Cleanup(func() { record.Release() })
+
+			labelCols := make([]*array.String, len(tc.colIdx))
+			labelFields := make([]arrow.Field, len(tc.colIdx))
+			for i, idx := range tc.colIdx {
+				labelCols[i] = record.Column(idx).(*array.String)
+				labelFields[i] = tc.colFields[idx]
+			}
+
+			agg := newAggregator(0, aggregationOperationSum)
+			require.Equal(t,
+				agg.computeGroupKey(tc.labels, tc.values),
+				agg.computeGroupKeyFromColumns(labelCols, labelFields, tc.row),
+			)
+		})
+	}
 }
 
 var benchGroupingFields = []arrow.Field{

--- a/pkg/engine/internal/executor/aggregator_test.go
+++ b/pkg/engine/internal/executor/aggregator_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/semconv"
@@ -14,12 +15,68 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/arrowtest"
 )
 
-var (
-	groupBy = []arrow.Field{
-		semconv.FieldFromIdent(semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String), true),
-		semconv.FieldFromIdent(semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String), true),
+var groupBy = []arrow.Field{
+	semconv.FieldFromIdent(semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String), true),
+	semconv.FieldFromIdent(semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String), true),
+}
+
+// runAggregator runs fn against map and array aggregator storage.
+func runAggregator(t *testing.T, op aggregationOperation, fn func(t *testing.T, agg *aggregator)) {
+	t.Helper()
+
+	fn(t, newAggregator(0, op))
+}
+
+var samplesMem = memory.NewGoAllocator()
+
+func samplesSchema(labelFields []arrow.Field) *arrow.Schema {
+	return arrow.NewSchema(append([]arrow.Field{
+		semconv.FieldFromIdent(semconv.ColumnIdentTimestamp, false),
+		semconv.FieldFromIdent(semconv.ColumnIdentValue, false),
+	}, labelFields...), nil)
+}
+
+// addSamples ingests rows through AddBatch. schema may be nil to infer from labelFields or rows.
+func addSamples(agg *aggregator, labelFields []arrow.Field, schema *arrow.Schema, rows arrowtest.Rows) error {
+	labelValuesForRow := make([]string, len(labelFields))
+	labelFieldsForRow := make([]arrow.Field, len(labelFields))
+
+	for i := 0; i < len(rows); i++ {
+		row := rows[i]
+		ts := row[colTs].(time.Time)
+		val := row[colVal].(float64)
+		next := 0
+		for _, field := range labelFields {
+			if row[field.Name] != nil {
+				labelValuesForRow[next] = row[field.Name].(string)
+				labelFieldsForRow[next] = field
+				next++
+				continue
+			}
+		}
+		if err := agg.Add(ts, val, labelFieldsForRow[:next], labelValuesForRow[:next]); err != nil {
+			return err
+		}
 	}
-)
+	return nil
+}
+
+func mustAddSamples(t *testing.T, agg *aggregator, labelFields []arrow.Field, schema *arrow.Schema, rows arrowtest.Rows) {
+	t.Helper()
+	require.NoError(t, addSamples(agg, labelFields, schema, rows))
+}
+
+func requireAggregatedRows(t *testing.T, agg *aggregator, expect arrowtest.Rows) {
+	t.Helper()
+
+	record, err := agg.BuildRecord()
+	require.NoError(t, err)
+
+	rows, err := arrowtest.RecordRows(record)
+	require.NoError(t, err, "should be able to convert record back to rows")
+	require.Equal(t, len(expect), len(rows), "number of rows should match")
+	require.ElementsMatch(t, expect, rows)
+}
 
 func TestAggregator(t *testing.T) {
 	colTs := semconv.ColumnIdentTimestamp.FQN()
@@ -27,368 +84,331 @@ func TestAggregator(t *testing.T) {
 	colEnv := semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String).FQN()
 	colSvc := semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String).FQN()
 
+	ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+	ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
+	ts3 := time.Date(2024, 1, 1, 10, 2, 0, 0, time.UTC)
+
+	basicInput := arrowtest.Rows{
+		{colTs: ts1, colVal: 10.0, colEnv: "prod", colSvc: "app1"},
+		{colTs: ts1, colVal: 20.0, colEnv: "prod", colSvc: "app2"},
+		{colTs: ts1, colVal: 30.0, colEnv: "dev", colSvc: "app1"},
+		{colTs: ts2, colVal: 15.0, colEnv: "prod", colSvc: "app1"},
+		{colTs: ts2, colVal: 25.0, colEnv: "prod", colSvc: "app2"},
+		{colTs: ts2, colVal: 35.0, colEnv: "dev", colSvc: "app2"},
+		{colTs: ts1, colVal: 5.0, colEnv: "prod", colSvc: "app1"},
+		{colTs: ts2, colVal: 10.0, colEnv: "prod", colSvc: "app1"},
+	}
+
 	t.Run("basic SUM aggregation with record building", func(t *testing.T) {
-		agg := newAggregator(10, aggregationOperationSum)
-		agg.AddLabels(groupBy)
+		runAggregator(t, aggregationOperationSum, func(t *testing.T, agg *aggregator) {
+			agg.AddLabels(groupBy)
+			mustAddSamples(t, agg, groupBy, nil, basicInput)
 
-		ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
-		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
+			requireAggregatedRows(t, agg, arrowtest.Rows{
+				{colTs: ts1, colVal: float64(15), colEnv: "prod", colSvc: "app1"},
+				{colTs: ts1, colVal: float64(20), colEnv: "prod", colSvc: "app2"},
+				{colTs: ts1, colVal: float64(30), colEnv: "dev", colSvc: "app1"},
 
-		// Add test data
-		// ts1: prod/app1 = 10, prod/app2 = 20, dev/app1 = 30
-		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
-
-		// ts2: prod/app1 = 15, prod/app2 = 25, dev/app2 = 35
-		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
-
-		// Add more data to same groups to test aggregation
-		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be 15
-		_ = agg.Add(ts2, 10, groupBy, []string{"prod", "app1"}) // prod/app1 at ts2 should now be 25
-
-		record, err := agg.BuildRecord()
-		require.NoError(t, err)
-
-		expect := arrowtest.Rows{
-			{colTs: ts1, colVal: float64(15), colEnv: "prod", colSvc: "app1"},
-			{colTs: ts1, colVal: float64(20), colEnv: "prod", colSvc: "app2"},
-			{colTs: ts1, colVal: float64(30), colEnv: "dev", colSvc: "app1"},
-
-			{colTs: ts2, colVal: float64(25), colEnv: "prod", colSvc: "app1"},
-			{colTs: ts2, colVal: float64(25), colEnv: "prod", colSvc: "app2"},
-			{colTs: ts2, colVal: float64(35), colEnv: "dev", colSvc: "app2"},
-		}
-
-		rows, err := arrowtest.RecordRows(record)
-		require.NoError(t, err, "should be able to convert record back to rows")
-		require.Equal(t, len(expect), len(rows), "number of rows should match")
-		require.ElementsMatch(t, expect, rows)
+				{colTs: ts2, colVal: float64(25), colEnv: "prod", colSvc: "app1"},
+				{colTs: ts2, colVal: float64(25), colEnv: "prod", colSvc: "app2"},
+				{colTs: ts2, colVal: float64(35), colEnv: "dev", colSvc: "app2"},
+			})
+		})
 	})
 
 	t.Run("basic AVG aggregation with record building", func(t *testing.T) {
-		agg := newAggregator(10, aggregationOperationAvg)
-		agg.AddLabels(groupBy)
+		runAggregator(t, aggregationOperationAvg, func(t *testing.T, agg *aggregator) {
+			agg.AddLabels(groupBy)
+			mustAddSamples(t, agg, groupBy, nil, basicInput)
 
-		ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
-		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
+			requireAggregatedRows(t, agg, arrowtest.Rows{
+				{colTs: ts1, colVal: float64(7.5), colEnv: "prod", colSvc: "app1"},
+				{colTs: ts1, colVal: float64(20), colEnv: "prod", colSvc: "app2"},
+				{colTs: ts1, colVal: float64(30), colEnv: "dev", colSvc: "app1"},
 
-		// Add test data
-		// ts1: prod/app1 = 10, prod/app2 = 20, dev/app1 = 30
-		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
-
-		// ts2: prod/app1 = 15, prod/app2 = 25, dev/app2 = 35
-		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
-
-		// Add more data to same groups to test aggregation
-		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be 7.5
-		_ = agg.Add(ts2, 10, groupBy, []string{"prod", "app1"}) // prod/app1 at ts2 should now be 12.5
-
-		record, err := agg.BuildRecord()
-		require.NoError(t, err)
-
-		expect := arrowtest.Rows{
-			{colTs: ts1, colVal: float64(7.5), colEnv: "prod", colSvc: "app1"},
-			{colTs: ts1, colVal: float64(20), colEnv: "prod", colSvc: "app2"},
-			{colTs: ts1, colVal: float64(30), colEnv: "dev", colSvc: "app1"},
-
-			{colTs: ts2, colVal: float64(12.5), colEnv: "prod", colSvc: "app1"},
-			{colTs: ts2, colVal: float64(25), colEnv: "prod", colSvc: "app2"},
-			{colTs: ts2, colVal: float64(35), colEnv: "dev", colSvc: "app2"},
-		}
-
-		rows, err := arrowtest.RecordRows(record)
-		require.NoError(t, err, "should be able to convert record back to rows")
-		require.Equal(t, len(expect), len(rows), "number of rows should match")
-		require.ElementsMatch(t, expect, rows)
+				{colTs: ts2, colVal: float64(12.5), colEnv: "prod", colSvc: "app1"},
+				{colTs: ts2, colVal: float64(25), colEnv: "prod", colSvc: "app2"},
+				{colTs: ts2, colVal: float64(35), colEnv: "dev", colSvc: "app2"},
+			})
+		})
 	})
 
 	t.Run("basic COUNT aggregation with record building", func(t *testing.T) {
-		agg := newAggregator(10, aggregationOperationCount)
-		agg.AddLabels(groupBy)
+		runAggregator(t, aggregationOperationCount, func(t *testing.T, agg *aggregator) {
+			agg.AddLabels(groupBy)
+			mustAddSamples(t, agg, groupBy, nil, arrowtest.Rows{
+				{colTs: ts1, colVal: 10.0, colEnv: "prod", colSvc: "app1"},
+				{colTs: ts1, colVal: 20.0, colEnv: "prod", colSvc: "app2"},
+				{colTs: ts1, colVal: 30.0, colEnv: "dev", colSvc: "app1"},
+				{colTs: ts2, colVal: 15.0, colEnv: "prod", colSvc: "app1"},
+				{colTs: ts2, colVal: 25.0, colEnv: "prod", colSvc: "app2"},
+				{colTs: ts2, colVal: 35.0, colEnv: "dev", colSvc: "app2"},
+				{colTs: ts3, colVal: 15.0, colEnv: "prod", colSvc: "app1"},
+				{colTs: ts3, colVal: 25.0, colEnv: "prod", colSvc: "app2"},
+				{colTs: ts3, colVal: 35.0, colEnv: "dev", colSvc: "app2"},
+				{colTs: ts1, colVal: 5.0, colEnv: "prod", colSvc: "app1"},
+				{colTs: ts2, colVal: 10.0, colEnv: "prod", colSvc: "app2"},
+				{colTs: ts1, colVal: 25.0, colEnv: "prod", colSvc: "app1"},
+			})
 
-		ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
-		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
-		ts3 := time.Date(2024, 1, 1, 10, 2, 0, 0, time.UTC)
+			requireAggregatedRows(t, agg, arrowtest.Rows{
+				{colTs: ts1, colVal: float64(3), colEnv: "prod", colSvc: "app1"},
+				{colTs: ts1, colVal: float64(1), colEnv: "prod", colSvc: "app2"},
+				{colTs: ts1, colVal: float64(1), colEnv: "dev", colSvc: "app1"},
 
-		// Add test data
-		// ts1: add one datapoint for prod/app1, prod/app2, and dev/app1
-		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
+				{colTs: ts2, colVal: float64(1), colEnv: "prod", colSvc: "app1"},
+				{colTs: ts2, colVal: float64(2), colEnv: "prod", colSvc: "app2"},
+				{colTs: ts2, colVal: float64(1), colEnv: "dev", colSvc: "app2"},
 
-		// ts2: add another datapoint for prod/app1, prod/app2, and dev/app2
-		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
-
-		// ts3: add another datapoint for prod/app1, prod/app2, and dev/app2
-		_ = agg.Add(ts3, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts3, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts3, 35, groupBy, []string{"dev", "app2"})
-
-		// Add more datapoints for prod/app1 and prod/app2
-		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be count 2
-		_ = agg.Add(ts2, 10, groupBy, []string{"prod", "app2"}) // prod/app2 at ts2 should now be count 2
-		_ = agg.Add(ts1, 25, groupBy, []string{"prod", "app1"}) // prod/app1 at ts1 should now be count 3
-
-		record, err := agg.BuildRecord()
-		require.NoError(t, err)
-
-		expect := arrowtest.Rows{
-			{colTs: ts1, colVal: float64(3), colEnv: "prod", colSvc: "app1"},
-			{colTs: ts1, colVal: float64(1), colEnv: "prod", colSvc: "app2"},
-			{colTs: ts1, colVal: float64(1), colEnv: "dev", colSvc: "app1"},
-
-			{colTs: ts2, colVal: float64(1), colEnv: "prod", colSvc: "app1"},
-			{colTs: ts2, colVal: float64(2), colEnv: "prod", colSvc: "app2"},
-			{colTs: ts2, colVal: float64(1), colEnv: "dev", colSvc: "app2"},
-
-			{colTs: ts3, colVal: float64(1), colEnv: "prod", colSvc: "app1"},
-			{colTs: ts3, colVal: float64(1), colEnv: "prod", colSvc: "app2"},
-			{colTs: ts3, colVal: float64(1), colEnv: "dev", colSvc: "app2"},
-		}
-
-		rows, err := arrowtest.RecordRows(record)
-		require.NoError(t, err, "should be able to convert record back to rows")
-		require.Equal(t, len(expect), len(rows), "number of rows should match")
-		require.ElementsMatch(t, expect, rows)
+				{colTs: ts3, colVal: float64(1), colEnv: "prod", colSvc: "app1"},
+				{colTs: ts3, colVal: float64(1), colEnv: "prod", colSvc: "app2"},
+				{colTs: ts3, colVal: float64(1), colEnv: "dev", colSvc: "app2"},
+			})
+		})
 	})
 
 	t.Run("basic MAX aggregation with record building", func(t *testing.T) {
-		agg := newAggregator(10, aggregationOperationMax)
-		agg.AddLabels(groupBy)
+		runAggregator(t, aggregationOperationMax, func(t *testing.T, agg *aggregator) {
+			agg.AddLabels(groupBy)
+			mustAddSamples(t, agg, groupBy, nil, arrowtest.Rows{
+				{colTs: ts1, colVal: 10.0, colEnv: "prod", colSvc: "app1"},
+				{colTs: ts1, colVal: 20.0, colEnv: "prod", colSvc: "app2"},
+				{colTs: ts1, colVal: 30.0, colEnv: "dev", colSvc: "app1"},
+				{colTs: ts2, colVal: 15.0, colEnv: "prod", colSvc: "app1"},
+				{colTs: ts2, colVal: 25.0, colEnv: "prod", colSvc: "app2"},
+				{colTs: ts2, colVal: 35.0, colEnv: "dev", colSvc: "app2"},
+				{colTs: ts1, colVal: 5.0, colEnv: "prod", colSvc: "app1"},
+				{colTs: ts2, colVal: 50.0, colEnv: "prod", colSvc: "app2"},
+				{colTs: ts1, colVal: 15.0, colEnv: "prod", colSvc: "app1"},
+			})
 
-		ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
-		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
+			requireAggregatedRows(t, agg, arrowtest.Rows{
+				{colTs: ts1, colVal: float64(15), colEnv: "prod", colSvc: "app1"},
+				{colTs: ts1, colVal: float64(20), colEnv: "prod", colSvc: "app2"},
+				{colTs: ts1, colVal: float64(30), colEnv: "dev", colSvc: "app1"},
 
-		// Add test data
-		// ts1: add one datapoint for prod/app1, prod/app2, and dev/app1
-		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
-
-		// ts2: add another datapoint for prod/app1, prod/app2, and dev/app2
-		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
-
-		// Add more datapoints for prod/app1 and prod/app2
-		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should still be 10
-		_ = agg.Add(ts2, 50, groupBy, []string{"prod", "app2"}) // prod/app2 at ts2 should now be 50
-		_ = agg.Add(ts1, 15, groupBy, []string{"prod", "app1"}) // prod/app1 at ts1 should now be 15
-
-		record, err := agg.BuildRecord()
-		require.NoError(t, err)
-
-		expect := arrowtest.Rows{
-			{colTs: ts1, colVal: float64(15), colEnv: "prod", colSvc: "app1"},
-			{colTs: ts1, colVal: float64(20), colEnv: "prod", colSvc: "app2"},
-			{colTs: ts1, colVal: float64(30), colEnv: "dev", colSvc: "app1"},
-
-			{colTs: ts2, colVal: float64(15), colEnv: "prod", colSvc: "app1"},
-			{colTs: ts2, colVal: float64(50), colEnv: "prod", colSvc: "app2"},
-			{colTs: ts2, colVal: float64(35), colEnv: "dev", colSvc: "app2"},
-		}
-
-		rows, err := arrowtest.RecordRows(record)
-		require.NoError(t, err, "should be able to convert record back to rows")
-		require.Equal(t, len(expect), len(rows), "number of rows should match")
-		require.ElementsMatch(t, expect, rows)
+				{colTs: ts2, colVal: float64(15), colEnv: "prod", colSvc: "app1"},
+				{colTs: ts2, colVal: float64(50), colEnv: "prod", colSvc: "app2"},
+				{colTs: ts2, colVal: float64(35), colEnv: "dev", colSvc: "app2"},
+			})
+		})
 	})
 
 	t.Run("basic MIN aggregation with record building", func(t *testing.T) {
-		agg := newAggregator(10, aggregationOperationMin)
-		agg.AddLabels(groupBy)
+		runAggregator(t, aggregationOperationMin, func(t *testing.T, agg *aggregator) {
+			agg.AddLabels(groupBy)
+			mustAddSamples(t, agg, groupBy, nil, arrowtest.Rows{
+				{colTs: ts1, colVal: 10.0, colEnv: "prod", colSvc: "app1"},
+				{colTs: ts1, colVal: 20.0, colEnv: "prod", colSvc: "app2"},
+				{colTs: ts1, colVal: 30.0, colEnv: "dev", colSvc: "app1"},
+				{colTs: ts2, colVal: 15.0, colEnv: "prod", colSvc: "app1"},
+				{colTs: ts2, colVal: 25.0, colEnv: "prod", colSvc: "app2"},
+				{colTs: ts2, colVal: 35.0, colEnv: "dev", colSvc: "app2"},
+				{colTs: ts1, colVal: 5.0, colEnv: "prod", colSvc: "app1"},
+				{colTs: ts2, colVal: 40.0, colEnv: "prod", colSvc: "app2"},
+				{colTs: ts1, colVal: 25.0, colEnv: "prod", colSvc: "app1"},
+			})
 
-		ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
-		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
+			requireAggregatedRows(t, agg, arrowtest.Rows{
+				{colTs: ts1, colVal: float64(5), colEnv: "prod", colSvc: "app1"},
+				{colTs: ts1, colVal: float64(20), colEnv: "prod", colSvc: "app2"},
+				{colTs: ts1, colVal: float64(30), colEnv: "dev", colSvc: "app1"},
 
-		// Add test data
-		// ts1: add one datapoint for prod/app1, prod/app2, and dev/app1
-		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
-
-		// ts2: add another datapoint for prod/app1, prod/app2, and dev/app2
-		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
-
-		// Add more datapoints for prod/app1 and prod/app2
-		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be 5
-		_ = agg.Add(ts2, 40, groupBy, []string{"prod", "app2"}) // prod/app2 at ts2 should still be 25
-		_ = agg.Add(ts1, 25, groupBy, []string{"prod", "app1"}) // prod/app1 at ts1 should still be 5
-
-		record, err := agg.BuildRecord()
-		require.NoError(t, err)
-
-		expect := arrowtest.Rows{
-			{colTs: ts1, colVal: float64(5), colEnv: "prod", colSvc: "app1"},
-			{colTs: ts1, colVal: float64(20), colEnv: "prod", colSvc: "app2"},
-			{colTs: ts1, colVal: float64(30), colEnv: "dev", colSvc: "app1"},
-
-			{colTs: ts2, colVal: float64(15), colEnv: "prod", colSvc: "app1"},
-			{colTs: ts2, colVal: float64(25), colEnv: "prod", colSvc: "app2"},
-			{colTs: ts2, colVal: float64(35), colEnv: "dev", colSvc: "app2"},
-		}
-
-		rows, err := arrowtest.RecordRows(record)
-		require.NoError(t, err, "should be able to convert record back to rows")
-		require.Equal(t, len(expect), len(rows), "number of rows should match")
-		require.ElementsMatch(t, expect, rows)
+				{colTs: ts2, colVal: float64(15), colEnv: "prod", colSvc: "app1"},
+				{colTs: ts2, colVal: float64(25), colEnv: "prod", colSvc: "app2"},
+				{colTs: ts2, colVal: float64(35), colEnv: "dev", colSvc: "app2"},
+			})
+		})
 	})
 
 	t.Run("SUM aggregation with empty groupBy", func(t *testing.T) {
-		// Empty groupBy represents sum by () or sum(...) - all values aggregated into single group
-		groupBy := []arrow.Field{}
-
-		agg := newAggregator(1, aggregationOperationSum)
-		agg.AddLabels(groupBy)
-
-		ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
-		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
-
-		// Add test data
-		// ts1: prod/app1 = 10, prod/app2 = 20, dev/app1 = 30
-		_ = agg.Add(ts1, 10, groupBy, []string{}) // "prod", "app1"
-		_ = agg.Add(ts1, 20, groupBy, []string{}) // "prod", "app2"
-		_ = agg.Add(ts1, 30, groupBy, []string{}) // "dev", "app1"
-
-		// ts2: prod/app1 = 15, prod/app2 = 25, dev/app2 = 35
-		_ = agg.Add(ts2, 15, groupBy, []string{}) // "prod", "app1"
-		_ = agg.Add(ts2, 25, groupBy, []string{}) // "prod", "app2"
-		_ = agg.Add(ts2, 35, groupBy, []string{}) // "dev", "app2"
-
-		_ = agg.Add(ts1, 5, groupBy, []string{})  // "prod", "app1"
-		_ = agg.Add(ts2, 10, groupBy, []string{}) // "prod", "app1"
-
-		record, err := agg.BuildRecord()
-		require.NoError(t, err)
-
-		expect := arrowtest.Rows{
-			// ts1: all series aggregated into single value = 65
-			{colTs: ts1, colVal: float64(65)},
-			// ts2: all series aggregated into single value = 85
-			{colTs: ts2, colVal: float64(85)},
+		emptyGroupBy := []arrow.Field{}
+		emptyInput := arrowtest.Rows{
+			{colTs: ts1, colVal: 10.0},
+			{colTs: ts1, colVal: 20.0},
+			{colTs: ts1, colVal: 30.0},
+			{colTs: ts2, colVal: 15.0},
+			{colTs: ts2, colVal: 25.0},
+			{colTs: ts2, colVal: 35.0},
+			{colTs: ts1, colVal: 5.0},
+			{colTs: ts2, colVal: 10.0},
 		}
 
-		rows, err := arrowtest.RecordRows(record)
-		require.NoError(t, err, "should be able to convert record back to rows")
-		require.Equal(t, len(expect), len(rows), "number of rows should match")
-		require.ElementsMatch(t, expect, rows)
+		runAggregator(t, aggregationOperationSum, func(t *testing.T, agg *aggregator) {
+			agg.AddLabels(emptyGroupBy)
+			mustAddSamples(t, agg, emptyGroupBy, nil, emptyInput)
+
+			requireAggregatedRows(t, agg, arrowtest.Rows{
+				{colTs: ts1, colVal: float64(65)},
+				{colTs: ts2, colVal: float64(85)},
+			})
+		})
 	})
 
 	t.Run("basic SUM aggregation with without() grouping", func(t *testing.T) {
-		agg := newAggregator(10, aggregationOperationSum)
-
-		ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
-		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
-
-		buildFields := func(names ...string) []arrow.Field {
-			result := make([]arrow.Field, len(names))
-			for i, name := range names {
-				result[i] = semconv.FieldFromIdent(semconv.NewIdentifier(name, types.ColumnTypeLabel, types.Loki.String), true)
-			}
-			return result
-		}
-
-		agg.AddLabels(buildFields("env", "service", "cluster", "method"))
-
-		// Add test data
-		_ = agg.Add(ts1, 10, buildFields("env", "service"), []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, buildFields("env", "cluster"), []string{"prod", "east-1"})
-		_ = agg.Add(ts1, 30, buildFields("method"), []string{"init"})
-
-		_ = agg.Add(ts2, 15, buildFields("env", "service"), []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, buildFields("env", "cluster"), []string{"prod", "east-1"})
-		_ = agg.Add(ts2, 35, buildFields("method"), []string{"init"})
-
-		// Add more data to same groups to test aggregation
-		_ = agg.Add(ts1, 5, buildFields("env", "service"), []string{"prod", "app1"})
-		_ = agg.Add(ts2, 10, buildFields("env", "cluster"), []string{"prod", "east-1"})
-
-		record, err := agg.BuildRecord()
-		require.NoError(t, err)
-
 		colCluster := semconv.NewIdentifier("cluster", types.ColumnTypeLabel, types.Loki.String).FQN()
 		colMethod := semconv.NewIdentifier("method", types.ColumnTypeLabel, types.Loki.String).FQN()
 
-		expect := arrowtest.Rows{
-			{colTs: ts1, colVal: float64(15), colEnv: "prod", colSvc: "app1", colMethod: nil, colCluster: nil},
-			{colTs: ts1, colVal: float64(20), colEnv: "prod", colCluster: "east-1", colSvc: nil, colMethod: nil},
-			{colTs: ts1, colVal: float64(30), colMethod: "init", colEnv: nil, colSvc: nil, colCluster: nil},
-
-			{colTs: ts2, colVal: float64(15), colEnv: "prod", colSvc: "app1", colMethod: nil, colCluster: nil},
-			{colTs: ts2, colVal: float64(35), colEnv: "prod", colCluster: "east-1", colSvc: nil, colMethod: nil},
-			{colTs: ts2, colVal: float64(35), colMethod: "init", colEnv: nil, colSvc: nil, colCluster: nil},
+		allLabelFields := []arrow.Field{
+			semconv.FieldFromIdent(semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String), true),
+			semconv.FieldFromIdent(semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String), true),
+			semconv.FieldFromIdent(semconv.NewIdentifier("cluster", types.ColumnTypeLabel, types.Loki.String), true),
+			semconv.FieldFromIdent(semconv.NewIdentifier("method", types.ColumnTypeLabel, types.Loki.String), true),
 		}
 
-		rows, err := arrowtest.RecordRows(record)
-		require.NoError(t, err, "should be able to convert record back to rows")
-		require.Equal(t, len(expect), len(rows), "number of rows should match")
-		require.ElementsMatch(t, expect, rows)
+		withoutInput := arrowtest.Rows{
+			{colTs: ts1, colVal: 10.0, colEnv: "prod", colSvc: "app1", colCluster: nil, colMethod: nil},
+			{colTs: ts1, colVal: 20.0, colEnv: "prod", colCluster: "east-1", colSvc: nil, colMethod: nil},
+			{colTs: ts1, colVal: 30.0, colMethod: "init", colEnv: nil, colSvc: nil, colCluster: nil},
+			{colTs: ts2, colVal: 15.0, colEnv: "prod", colSvc: "app1", colCluster: nil, colMethod: nil},
+			{colTs: ts2, colVal: 25.0, colEnv: "prod", colCluster: "east-1", colSvc: nil, colMethod: nil},
+			{colTs: ts2, colVal: 35.0, colMethod: "init", colEnv: nil, colSvc: nil, colCluster: nil},
+			{colTs: ts1, colVal: 5.0, colEnv: "prod", colSvc: "app1", colCluster: nil, colMethod: nil},
+			{colTs: ts2, colVal: 10.0, colEnv: "prod", colCluster: "east-1", colSvc: nil, colMethod: nil},
+		}
+
+		runAggregator(t, aggregationOperationSum, func(t *testing.T, agg *aggregator) {
+			agg.AddLabels(allLabelFields)
+			mustAddSamples(t, agg, allLabelFields, samplesSchema(allLabelFields), withoutInput)
+
+			requireAggregatedRows(t, agg, arrowtest.Rows{
+				{colTs: ts1, colVal: float64(15), colEnv: "prod", colSvc: "app1", colMethod: nil, colCluster: nil},
+				{colTs: ts1, colVal: float64(20), colEnv: "prod", colCluster: "east-1", colSvc: nil, colMethod: nil},
+				{colTs: ts1, colVal: float64(30), colMethod: "init", colEnv: nil, colSvc: nil, colCluster: nil},
+
+				{colTs: ts2, colVal: float64(15), colEnv: "prod", colSvc: "app1", colMethod: nil, colCluster: nil},
+				{colTs: ts2, colVal: float64(35), colEnv: "prod", colCluster: "east-1", colSvc: nil, colMethod: nil},
+				{colTs: ts2, colVal: float64(35), colMethod: "init", colEnv: nil, colSvc: nil, colCluster: nil},
+			})
+		})
 	})
 
 	t.Run("series limit enforcement", func(t *testing.T) {
-		agg := newAggregator(10, aggregationOperationSum)
-		agg.AddLabels(groupBy)
-		agg.SetMaxSeries(3) // Limit to 3 series
+		initialInput := arrowtest.Rows{
+			{colTs: ts1, colVal: 10.0, colEnv: "prod", colSvc: "app1"},
+			{colTs: ts1, colVal: 20.0, colEnv: "prod", colSvc: "app2"},
+			{colTs: ts1, colVal: 30.0, colEnv: "dev", colSvc: "app1"},
+		}
+		overflowInput := arrowtest.Rows{
+			{colTs: ts2, colVal: 10.0, colEnv: "dev", colSvc: "app2"},
+		}
+		afterLimitInput := arrowtest.Rows{
+			{colTs: ts2, colVal: 15.0, colEnv: "prod", colSvc: "app1"},
+		}
+		finalInput := arrowtest.Rows{
+			{colTs: ts2, colVal: 10.0, colEnv: "dev", colSvc: "app2"},
+		}
 
-		ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
-		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
+		runAggregator(t, aggregationOperationSum, func(t *testing.T, agg *aggregator) {
+			agg.AddLabels(groupBy)
+			agg.SetMaxSeries(3)
 
-		// Add first 3 series at ts1 - should succeed
-		err := agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
-		require.NoError(t, err)
+			require.NoError(t, addSamples(agg, groupBy, nil, initialInput))
 
-		err = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
-		require.NoError(t, err)
+			err := addSamples(agg, groupBy, nil, overflowInput)
+			require.Error(t, err)
+			require.True(t, errors.Is(err, ErrSeriesLimitExceeded))
 
-		err = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
-		require.NoError(t, err)
+			require.NoError(t, addSamples(agg, groupBy, nil, afterLimitInput))
 
-		// Try to add 4th unique series should fail
-		err = agg.Add(ts2, 10, groupBy, []string{"dev", "app2"})
-		require.Error(t, err)
-		require.True(t, errors.Is(err, ErrSeriesLimitExceeded))
-
-		// Adding same series again at different timestamp should succeed (not a new unique series)
-		err = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
-		require.NoError(t, err)
-
-		// unset the limit
-		agg.SetMaxSeries(0)
-
-		// Now adding new series should succeed
-		err = agg.Add(ts2, 10, groupBy, []string{"dev", "app2"})
-		require.NoError(t, err)
+			agg.SetMaxSeries(0)
+			require.NoError(t, addSamples(agg, groupBy, nil, finalInput))
+		})
 	})
 }
 
-func BenchmarkAggregator(b *testing.B) {
-	fields := []arrow.Field{
-		semconv.FieldFromIdent(semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String), true),
-		semconv.FieldFromIdent(semconv.NewIdentifier("cluster", types.ColumnTypeLabel, types.Loki.String), true),
-		semconv.FieldFromIdent(semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String), true),
-	}
+var benchGroupingFields = []arrow.Field{
+	semconv.FieldFromIdent(semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String), true),
+	semconv.FieldFromIdent(semconv.NewIdentifier("cluster", types.ColumnTypeLabel, types.Loki.String), true),
+	semconv.FieldFromIdent(semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String), true),
+}
 
-	agg := newAggregator(10, aggregationOperationSum)
+// benchRows builds n samples. interleaved rotates label values; otherwise uses one series.
+func benchRows(interleaved bool, fields []arrow.Field, startTs time.Time, step time.Duration, numPoints, n int) arrowtest.Rows {
+	colTs := semconv.ColumnIdentTimestamp.FQN()
+	colVal := semconv.ColumnIdentValue.FQN()
+
+	rows := make(arrowtest.Rows, n)
+	for i := range n {
+		ts := startTs.Add(step * time.Duration(i%numPoints))
+		row := arrowtest.Row{colTs: ts, colVal: 10.0}
+		if interleaved {
+			row[fields[0].Name] = fmt.Sprintf("env-%d", i%3)
+			row[fields[1].Name] = fmt.Sprintf("cluster-%d", i%10)
+			row[fields[2].Name] = fmt.Sprintf("service-%d", i%7)
+		} else {
+			row[fields[0].Name] = "prod"
+			row[fields[1].Name] = "app1"
+			row[fields[2].Name] = "east-1"
+		}
+		rows[i] = row
+	}
+	return rows
+}
+
+func BenchmarkAggregatorAdd(b *testing.B) {
+	const (
+		numPoints = 10_000
+		batchSize = 1024
+	)
+	startTs := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	step := time.Second
+
+	fields := benchGroupingFields
+	schema := samplesSchema(fields)
+
+	for _, tc := range []struct {
+		name        string
+		interleaved bool
+	}{
+		{"interleaved", true},
+		{"single_series", false},
+	} {
+		batch := benchRows(tc.interleaved, fields, startTs, step, numPoints, batchSize)
+
+		b.Run("case="+tc.name, func(b *testing.B) {
+			var agg *aggregator
+			agg = newAggregator(0, aggregationOperationSum)
+			agg.AddLabels(fields)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := addSamples(agg, fields, schema, batch); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkAggregatorBuildRecord(b *testing.B) {
+	const (
+		numPoints = 8192
+		batchSize = 1024
+	)
+	startTs := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	step := time.Second
+
+	fields := benchGroupingFields
+	schema := samplesSchema(fields)
+
+	agg := newAggregator(0, aggregationOperationSum)
 	agg.AddLabels(fields)
+
+	for offset := 0; offset < numPoints; offset += batchSize {
+		n := batchSize
+		if offset+n > numPoints {
+			n = numPoints - offset
+		}
+		batch := benchRows(true, fields, startTs.Add(step*time.Duration(offset)), step, numPoints, n)
+		if err := addSamples(agg, fields, schema, batch); err != nil {
+			b.Fatal(err)
+		}
+	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(i) * time.Second)
-		env := fmt.Sprintf("env-%d", i%3)
-		cluster := fmt.Sprintf("cluster-%d", i%10)
-		service := fmt.Sprintf("service-%d", i%7)
-
-		_ = agg.Add(ts, 10, fields, []string{env, cluster, service})
+		_, _ = agg.BuildRecord()
 	}
 }

--- a/pkg/engine/internal/executor/aggregator_test.go
+++ b/pkg/engine/internal/executor/aggregator_test.go
@@ -37,7 +37,7 @@ func samplesSchema(labelFields []arrow.Field) *arrow.Schema {
 	}, labelFields...), nil)
 }
 
-// addSamples ingests rows through AddBatch. schema may be nil to infer from labelFields or rows.
+// addSamples ingests rows through Add for tests that need sparse per-row grouping.
 func addSamples(agg *aggregator, labelFields []arrow.Field, schema *arrow.Schema, rows arrowtest.Rows) error {
 	labelValuesForRow := make([]string, len(labelFields))
 	labelFieldsForRow := make([]arrow.Field, len(labelFields))
@@ -60,6 +60,21 @@ func addSamples(agg *aggregator, labelFields []arrow.Field, schema *arrow.Schema
 		}
 	}
 	return nil
+}
+
+func batchAddRecord(agg *aggregator, labelFields []arrow.Field, record arrow.RecordBatch) error {
+	if record.NumRows() == 0 {
+		return nil
+	}
+
+	tsCol := record.Column(0).(*array.Timestamp)
+	valCol := record.Column(1).(*array.Float64)
+	labelCols := make([]*array.String, len(labelFields))
+	for i := range labelFields {
+		labelCols[i] = record.Column(2 + i).(*array.String)
+	}
+
+	return agg.BatchAddSample(tsCol, valCol, nil, labelCols, labelFields)
 }
 
 func mustAddSamples(t *testing.T, agg *aggregator, labelFields []arrow.Field, schema *arrow.Schema, rows arrowtest.Rows) {
@@ -383,6 +398,97 @@ func TestAggregator_computeGroupKeyFromColumns(t *testing.T) {
 	}
 }
 
+func TestAggregator_addSamplesFromColumns(t *testing.T) {
+	colTs := semconv.ColumnIdentTimestamp.FQN()
+	colVal := semconv.ColumnIdentValue.FQN()
+	colEnv := semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String).FQN()
+	colSvc := semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String).FQN()
+
+	fields := []arrow.Field{
+		semconv.FieldFromIdent(semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String), true),
+		semconv.FieldFromIdent(semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String), true),
+	}
+
+	ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+	ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
+
+	rows := arrowtest.Rows{
+		{colTs: ts1, colVal: 10.0, colEnv: "prod", colSvc: "app1"},
+		{colTs: ts1, colVal: 20.0, colEnv: "prod", colSvc: "app2"},
+	}
+	record := rows.Record(memory.NewGoAllocator(), arrow.NewSchema(fields, nil))
+	t.Cleanup(func() { record.Release() })
+
+	labelCols := []*array.String{
+		record.Column(0).(*array.String),
+		record.Column(1).(*array.String),
+	}
+
+	// Simulate overlapping fan-out: each row contributes to two windows.
+	outputTs := []time.Time{ts1, ts2, ts1, ts2}
+	values := []float64{10, 10, 20, 20}
+	sourceRows := []int{0, 0, 1, 1}
+
+	expect := arrowtest.Rows{
+		{colTs: ts1, colVal: float64(10), colEnv: "prod", colSvc: "app1"},
+		{colTs: ts1, colVal: float64(20), colEnv: "prod", colSvc: "app2"},
+		{colTs: ts2, colVal: float64(10), colEnv: "prod", colSvc: "app1"},
+		{colTs: ts2, colVal: float64(20), colEnv: "prod", colSvc: "app2"},
+	}
+
+	single := newAggregator(0, aggregationOperationSum)
+	single.AddLabels(fields)
+	for i := range outputTs {
+		require.NoError(t, single.AddSample(outputTs[i], values[i], labelCols, fields, sourceRows[i]))
+	}
+
+	batch := newAggregator(0, aggregationOperationSum)
+	batch.AddLabels(fields)
+	outputTsArr, valuesArr, sourceRowsArr := batchSampleArrays(t, outputTs, values, sourceRows)
+	t.Cleanup(func() {
+		outputTsArr.Release()
+		valuesArr.Release()
+		sourceRowsArr.Release()
+	})
+	require.NoError(t, batch.BatchAddSample(outputTsArr, valuesArr, sourceRowsArr, labelCols, fields))
+
+	requireAggregatedRows(t, single, expect)
+	requireAggregatedRows(t, batch, expect)
+
+	// Repeated source rows in one batch should accumulate without re-hashing labels.
+	repeated := newAggregator(0, aggregationOperationSum)
+	repeated.AddLabels(fields)
+	repeatedTs, repeatedVals, repeatedRows := batchSampleArrays(t, []time.Time{ts1, ts1}, []float64{10, 10}, []int{0, 0})
+	t.Cleanup(func() {
+		repeatedTs.Release()
+		repeatedVals.Release()
+		repeatedRows.Release()
+	})
+	require.NoError(t, repeated.BatchAddSample(repeatedTs, repeatedVals, repeatedRows, labelCols, fields))
+	requireAggregatedRows(t, repeated, arrowtest.Rows{
+		{colTs: ts1, colVal: float64(20), colEnv: "prod", colSvc: "app1"},
+	})
+}
+
+func batchSampleArrays(t *testing.T, outputTs []time.Time, values []float64, sourceRows []int) (*array.Timestamp, *array.Float64, *array.Int32) {
+	t.Helper()
+
+	mem := memory.NewGoAllocator()
+	tsBuilder := array.NewTimestampBuilder(mem, &arrow.TimestampType{Unit: arrow.Nanosecond})
+	valBuilder := array.NewFloat64Builder(mem)
+	rowBuilder := array.NewInt32Builder(mem)
+
+	for i := range outputTs {
+		tsValue, err := arrow.TimestampFromTime(outputTs[i], arrow.Nanosecond)
+		require.NoError(t, err)
+		tsBuilder.Append(tsValue)
+		valBuilder.Append(values[i])
+		rowBuilder.Append(int32(sourceRows[i]))
+	}
+
+	return tsBuilder.NewArray().(*array.Timestamp), valBuilder.NewArray().(*array.Float64), rowBuilder.NewArray().(*array.Int32)
+}
+
 var benchGroupingFields = []arrow.Field{
 	semconv.FieldFromIdent(semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String), true),
 	semconv.FieldFromIdent(semconv.NewIdentifier("cluster", types.ColumnTypeLabel, types.Loki.String), true),
@@ -430,17 +536,26 @@ func BenchmarkAggregatorAdd(b *testing.B) {
 		{"interleaved", true},
 		{"single_series", false},
 	} {
-		batch := benchRows(tc.interleaved, fields, startTs, step, numPoints, batchSize)
+		rows := benchRows(tc.interleaved, fields, startTs, step, numPoints, batchSize)
+		record := rows.Record(memory.NewGoAllocator(), schema)
+		b.Cleanup(func() { record.Release() })
+
+		labelCols := make([]*array.String, len(fields))
+		for i := range fields {
+			labelCols[i] = record.Column(2 + i).(*array.String)
+		}
 
 		b.Run("case="+tc.name, func(b *testing.B) {
-			var agg *aggregator
-			agg = newAggregator(0, aggregationOperationSum)
+			agg := newAggregator(0, aggregationOperationSum)
 			agg.AddLabels(fields)
+
+			tsCol := record.Column(0).(*array.Timestamp)
+			valCol := record.Column(1).(*array.Float64)
 
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if err := addSamples(agg, fields, schema, batch); err != nil {
+				if err := agg.BatchAddSample(tsCol, valCol, nil, labelCols, fields); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -468,9 +583,12 @@ func BenchmarkAggregatorBuildRecord(b *testing.B) {
 			n = numPoints - offset
 		}
 		batch := benchRows(true, fields, startTs.Add(step*time.Duration(offset)), step, numPoints, n)
-		if err := addSamples(agg, fields, schema, batch); err != nil {
+		record := batch.Record(memory.NewGoAllocator(), schema)
+		if err := batchAddRecord(agg, fields, record); err != nil {
+			record.Release()
 			b.Fatal(err)
 		}
+		record.Release()
 	}
 
 	b.ResetTimer()

--- a/pkg/engine/internal/executor/aggregator_test.go
+++ b/pkg/engine/internal/executor/aggregator_test.go
@@ -37,29 +37,19 @@ func samplesSchema(labelFields []arrow.Field) *arrow.Schema {
 	}, labelFields...), nil)
 }
 
-// addSamples ingests rows through Add for tests that need sparse per-row grouping.
+// addSamples ingests rows through BatchAddSample for tests.
 func addSamples(agg *aggregator, labelFields []arrow.Field, schema *arrow.Schema, rows arrowtest.Rows) error {
-	labelValuesForRow := make([]string, len(labelFields))
-	labelFieldsForRow := make([]arrow.Field, len(labelFields))
-
-	for i := 0; i < len(rows); i++ {
-		row := rows[i]
-		ts := row[colTs].(time.Time)
-		val := row[colVal].(float64)
-		next := 0
-		for _, field := range labelFields {
-			if row[field.Name] != nil {
-				labelValuesForRow[next] = row[field.Name].(string)
-				labelFieldsForRow[next] = field
-				next++
-				continue
-			}
-		}
-		if err := agg.Add(ts, val, labelFieldsForRow[:next], labelValuesForRow[:next]); err != nil {
-			return err
-		}
+	if len(rows) == 0 {
+		return nil
 	}
-	return nil
+	if schema == nil {
+		schema = samplesSchema(labelFields)
+	}
+
+	record := rows.Record(samplesMem, schema)
+	defer record.Release()
+
+	return batchAddRecord(agg, labelFields, record)
 }
 
 func batchAddRecord(agg *aggregator, labelFields []arrow.Field, record arrow.RecordBatch) error {
@@ -331,71 +321,6 @@ func TestAggregator(t *testing.T) {
 			require.NoError(t, addSamples(agg, groupBy, nil, finalInput))
 		})
 	})
-}
-
-func TestAggregator_computeGroupKeyFromColumns(t *testing.T) {
-	colEnv := semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String).FQN()
-	colSvc := semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String).FQN()
-	colCluster := semconv.NewIdentifier("cluster", types.ColumnTypeLabel, types.Loki.String).FQN()
-
-	fields := []arrow.Field{
-		semconv.FieldFromIdent(semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String), true),
-		semconv.FieldFromIdent(semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String), true),
-		semconv.FieldFromIdent(semconv.NewIdentifier("cluster", types.ColumnTypeLabel, types.Loki.String), true),
-	}
-
-	cases := []struct {
-		name      string
-		rows      arrowtest.Rows
-		row       int
-		labels    []arrow.Field
-		values    []string
-		colFields []arrow.Field
-		colIdx    []int
-	}{
-		{
-			name: "by grouping",
-			rows: arrowtest.Rows{
-				{colEnv: "prod", colSvc: "app1", colCluster: "east-1"},
-			},
-			row:       0,
-			labels:    fields[:2],
-			values:    []string{"prod", "app1"},
-			colFields: fields[:2],
-			colIdx:    []int{0, 1},
-		},
-		{
-			name: "sparse without grouping",
-			rows: arrowtest.Rows{
-				{colEnv: "prod", colSvc: nil, colCluster: "east-1"},
-			},
-			row:       0,
-			labels:    []arrow.Field{fields[0], fields[2]},
-			values:    []string{"prod", "east-1"},
-			colFields: fields,
-			colIdx:    []int{0, 2},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			record := tc.rows.Record(memory.NewGoAllocator(), arrow.NewSchema(fields, nil))
-			t.Cleanup(func() { record.Release() })
-
-			labelCols := make([]*array.String, len(tc.colIdx))
-			labelFields := make([]arrow.Field, len(tc.colIdx))
-			for i, idx := range tc.colIdx {
-				labelCols[i] = record.Column(idx).(*array.String)
-				labelFields[i] = tc.colFields[idx]
-			}
-
-			agg := newAggregator(0, aggregationOperationSum)
-			require.Equal(t,
-				agg.computeGroupKey(tc.labels, tc.values),
-				agg.computeGroupKeyFromColumns(labelCols, labelFields, tc.row),
-			)
-		})
-	}
 }
 
 func TestAggregator_addSamplesFromColumns(t *testing.T) {

--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -65,6 +65,15 @@ func cmpWindowEndTime(w window, t time.Time) int {
 // The list can be empty if the timestamp is out of bounds or does not match any of the range windows.
 type timestampMatchingWindowsFunc func(time.Time) []window
 
+type columnarMatcherKind int
+
+const (
+	columnarMatcherNone columnarMatcherKind = iota
+	columnarMatcherInstant
+	columnarMatcherAligned
+	columnarMatcherGapped
+)
+
 // rangeAggregationPipeline is a pipeline that performs aggregations over a time window.
 //
 // 1. It reads from the input pipelines
@@ -77,6 +86,9 @@ type rangeAggregationPipeline struct {
 	inputsExhausted bool // indicates if all inputs are exhausted
 
 	aggregator          *aggregator
+	windows             []window
+	matcher             *matcherFactory
+	columnarMatcher     columnarMatcherKind
 	windowsForTimestamp timestampMatchingWindowsFunc // function to find matching time windows for a given timestamp
 	evaluator           *expressionEvaluator         // used to evaluate column expressions
 	opts                rangeAggregationOptions
@@ -109,6 +121,9 @@ func (r *rangeAggregationPipeline) init() {
 	}
 
 	f := newMatcherFactoryFromOpts(r.opts)
+	r.matcher = f
+	r.windows = windows
+	r.columnarMatcher = r.detectColumnarMatcher()
 	r.windowsForTimestamp = f.createMatcher(windows)
 
 	op, ok := rangeAggregationOperations[r.opts.operation]
@@ -142,7 +157,7 @@ func (r *rangeAggregationPipeline) Read(ctx context.Context) (arrow.RecordBatch,
 }
 
 // TODOs:
-// - Use columnar access pattern. Current approach is row-based which does not benefit from the storage format.
+// - Add columnar ingest for overlapping windows and without() grouping.
 // - Add toggle to return partial results on Read() call instead of returning only after exhausting all inputs.
 func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch, error) {
 	var (
@@ -164,8 +179,15 @@ func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch,
 		inputReadTime time.Duration
 	)
 
-	labelValuesCache := newLabelValuesCache()
-	fieldsCache := newFieldsCache()
+	useColumnarAddRecord := r.columnarMatcher != columnarMatcherNone
+	var (
+		labelValuesCache *labelValuesCache
+		fieldsCache      *fieldsCache
+	)
+	if !useColumnarAddRecord {
+		labelValuesCache = newLabelValuesCache()
+		fieldsCache = newFieldsCache()
+	}
 
 	r.aggregator.Reset() // reset before reading new inputs
 	inputsExhausted := false
@@ -216,6 +238,13 @@ func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch,
 				valArr = valVec.(*array.Float64)
 			}
 
+			if useColumnarAddRecord {
+				if err := r.addRecordColumnar(tsCol, valArr, arrays, groupingFields); err != nil {
+					return nil, err
+				}
+				continue
+			}
+
 			for row := range int(record.NumRows()) {
 				windows := r.windowsForTimestamp(tsCol.Value(row).ToTime(arrow.Nanosecond))
 				if len(windows) == 0 {
@@ -253,6 +282,95 @@ func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch,
 	}
 
 	return rec, err
+}
+
+func (r *rangeAggregationPipeline) detectColumnarMatcher() columnarMatcherKind {
+	if r.opts.grouping.Without {
+		return columnarMatcherNone
+	}
+
+	switch {
+	case r.opts.step == 0:
+		return columnarMatcherInstant
+	case r.opts.step == r.opts.rangeInterval:
+		return columnarMatcherAligned
+	case r.opts.step > r.opts.rangeInterval:
+		return columnarMatcherGapped
+	default:
+		return columnarMatcherNone
+	}
+}
+
+// windowEndForTimestamp maps an input sample timestamp to the end of its matching
+// evaluation window for columnar ingest. Each sample maps to at most one window.
+func (r *rangeAggregationPipeline) windowEndForTimestamp(ts time.Time) (time.Time, bool) {
+	if !r.matcher.bounds.Contains(ts) {
+		return time.Time{}, false
+	}
+
+	switch r.columnarMatcher {
+	case columnarMatcherInstant:
+		if len(r.windows) == 0 {
+			return time.Time{}, false
+		}
+		return r.windows[0].end, true
+	case columnarMatcherAligned:
+		startNs := r.matcher.start.UnixNano()
+		stepNs := r.matcher.step.Nanoseconds()
+		windowIndex := (ts.UnixNano() - startNs + stepNs - 1) / stepNs
+		if windowIndex < 0 || windowIndex >= int64(len(r.windows)) {
+			return time.Time{}, false
+		}
+		return r.windows[windowIndex].end, true
+	case columnarMatcherGapped:
+		startNs := r.matcher.start.UnixNano()
+		stepNs := r.matcher.step.Nanoseconds()
+		tNs := ts.UnixNano()
+		windowIndex := (tNs - startNs + stepNs - 1) / stepNs
+		if windowIndex >= int64(len(r.windows)) {
+			return time.Time{}, false
+		}
+		if tNs > r.windows[windowIndex].start.UnixNano() {
+			return r.windows[windowIndex].end, true
+		}
+		return time.Time{}, false
+	default:
+		return time.Time{}, false
+	}
+}
+
+// addRecordColumnar ingests an input batch using a columnar loop for by() grouping when
+// each row maps to at most one output window (instant, aligned, or gapped matchers).
+func (r *rangeAggregationPipeline) addRecordColumnar(
+	tsCol *array.Timestamp,
+	valCol *array.Float64,
+	labelCols []*array.String,
+	labelFields []arrow.Field,
+) error {
+	countOp := r.opts.operation == types.RangeAggregationTypeCount
+
+	for row := range int(tsCol.Len()) {
+		ts := tsCol.Value(row).ToTime(arrow.Nanosecond)
+		outTs, ok := r.windowEndForTimestamp(ts)
+		if !ok {
+			continue
+		}
+
+		if !countOp && valCol.IsNull(row) {
+			continue
+		}
+
+		var value float64
+		if !countOp {
+			value = valCol.Value(row)
+		}
+
+		if err := r.aggregator.addSampleFromColumns(outTs, value, labelCols, labelFields, row); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Close closes the resources of the pipeline.

--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -40,31 +41,11 @@ var rangeAggregationOperations = map[types.RangeAggregationType]aggregationOpera
 	types.RangeAggregationTypeAvg:   aggregationOperationAvg,
 }
 
-// window is a time interval where start is exclusive and end is inclusive
-// Refer to [logql.batchRangeVectorIterator].
+// window is a time interval where start is exclusive and end is inclusive.
+// Refer to [logql.batchRangeVectorIterator]. Timestamps in int64 helpers are Unix nanoseconds.
 type window struct {
 	start, end time.Time
 }
-
-// Contains returns if the timestamp t is within the bounds of the window.
-// The window start is exclusive, the window end is inclusive.
-func (w window) Contains(t time.Time) bool {
-	return t.After(w.start) && !t.After(w.end)
-}
-
-// cmpWindowStartTime compares a window's lower bound to t for [slices.BinarySearchFunc].
-func cmpWindowStartTime(w window, t time.Time) int {
-	return w.start.Compare(t)
-}
-
-// cmpWindowEndTime compares a window's upper bound to t for [slices.BinarySearchFunc].
-func cmpWindowEndTime(w window, t time.Time) int {
-	return w.end.Compare(t)
-}
-
-// timestampMatchingWindowsFunc resolves matching range interval windows for a specific timestamp.
-// The list can be empty if the timestamp is out of bounds or does not match any of the range windows.
-type timestampMatchingWindowsFunc func(time.Time) []window
 
 type columnarMatcherKind int
 
@@ -86,53 +67,62 @@ type rangeAggregationPipeline struct {
 	inputs          []Pipeline
 	inputsExhausted bool // indicates if all inputs are exhausted
 
-	aggregator          *aggregator
-	windows             []window
-	matcher             *matcherFactory
-	columnarMatcher     columnarMatcherKind
-	expandScratch       rangeAggExpandScratch
-	windowsForTimestamp timestampMatchingWindowsFunc // function to find matching time windows for a given timestamp
-	evaluator           *expressionEvaluator         // used to evaluate column expressions
-	opts                rangeAggregationOptions
-	identCache          *semconv.IdentifierCache
+	aggregator      *aggregator
+	windowStarts    []int64
+	windowEnds      []int64
+	matcher         *matcherFactory
+	columnarMatcher columnarMatcherKind
+	expandScratch   rangeAggExpandScratch
+	evaluator       *expressionEvaluator // used to evaluate column expressions
+	opts            rangeAggregationOptions
+	identCache      *semconv.IdentifierCache
 }
 
 type rangeAggExpandScratch struct {
 	mem        memory.Allocator
-	outputTs   []time.Time
-	values     []float64
-	sourceRows []int
+	tsBuilder  *array.TimestampBuilder
+	valBuilder *array.Float64Builder
+	rowBuilder *array.Int32Builder
 }
 
-func (s *rangeAggExpandScratch) reset() {
-	s.outputTs = s.outputTs[:0]
-	s.values = s.values[:0]
-	s.sourceRows = s.sourceRows[:0]
-}
-
-func (s *rangeAggExpandScratch) append(outTs time.Time, value float64, row int) {
-	s.outputTs = append(s.outputTs, outTs)
-	s.values = append(s.values, value)
-	s.sourceRows = append(s.sourceRows, row)
-}
-
-func (s *rangeAggExpandScratch) finish() (*array.Timestamp, *array.Float64, *array.Int32) {
+func (s *rangeAggExpandScratch) ensureBuilders() {
 	if s.mem == nil {
 		s.mem = memory.NewGoAllocator()
 	}
+	if s.tsBuilder == nil {
+		s.tsBuilder = array.NewTimestampBuilder(s.mem, &arrow.TimestampType{Unit: arrow.Nanosecond})
+		s.valBuilder = array.NewFloat64Builder(s.mem)
+		s.rowBuilder = array.NewInt32Builder(s.mem)
+	}
+}
 
-	tsBuilder := array.NewTimestampBuilder(s.mem, &arrow.TimestampType{Unit: arrow.Nanosecond})
-	valBuilder := array.NewFloat64Builder(s.mem)
-	rowBuilder := array.NewInt32Builder(s.mem)
+func (s *rangeAggExpandScratch) reset() {
+	s.ensureBuilders()
+	s.tsBuilder.Resize(0)
+	s.valBuilder.Resize(0)
+	s.rowBuilder.Resize(0)
+}
 
-	for i := range s.outputTs {
-		tsValue, _ := arrow.TimestampFromTime(s.outputTs[i], arrow.Nanosecond)
-		tsBuilder.Append(tsValue)
-		valBuilder.Append(s.values[i])
-		rowBuilder.Append(int32(s.sourceRows[i]))
+func (s *rangeAggExpandScratch) append(outTs int64, value float64, row int, includeValue bool) {
+	s.tsBuilder.Append(arrow.Timestamp(outTs))
+	if includeValue {
+		s.valBuilder.Append(value)
+	}
+	s.rowBuilder.Append(int32(row))
+}
+
+func (s *rangeAggExpandScratch) finish(includeValues bool) (*array.Timestamp, *array.Float64, *array.Int32) {
+	if s.tsBuilder == nil || s.tsBuilder.Len() == 0 {
+		return nil, nil, nil
 	}
 
-	return tsBuilder.NewArray().(*array.Timestamp), valBuilder.NewArray().(*array.Float64), rowBuilder.NewArray().(*array.Int32)
+	ts := s.tsBuilder.NewTimestampArray()
+	rows := s.rowBuilder.NewInt32Array()
+	if !includeValues {
+		return ts, nil, rows
+	}
+
+	return ts, s.valBuilder.NewFloat64Array(), rows
 }
 
 func newRangeAggregationPipeline(inputs []Pipeline, evaluator *expressionEvaluator, opts rangeAggregationOptions) (*rangeAggregationPipeline, error) {
@@ -162,9 +152,13 @@ func (r *rangeAggregationPipeline) init() {
 
 	f := newMatcherFactoryFromOpts(r.opts)
 	r.matcher = f
-	r.windows = windows
 	r.columnarMatcher = r.detectColumnarMatcher()
-	r.windowsForTimestamp = f.createMatcher(windows)
+	r.windowStarts = make([]int64, len(windows))
+	r.windowEnds = make([]int64, len(windows))
+	for i, w := range windows {
+		r.windowStarts[i] = w.start.UnixNano()
+		r.windowEnds[i] = w.end.UnixNano()
+	}
 
 	op, ok := rangeAggregationOperations[r.opts.operation]
 	if !ok {
@@ -300,40 +294,40 @@ func (r *rangeAggregationPipeline) detectColumnarMatcher() columnarMatcherKind {
 
 // windowEndForTimestamp maps an input sample timestamp to the end of its matching
 // evaluation window for columnar ingest. Each sample maps to at most one window.
-func (r *rangeAggregationPipeline) windowEndForTimestamp(ts time.Time) (time.Time, bool) {
-	if !r.matcher.bounds.Contains(ts) {
+func (r *rangeAggregationPipeline) windowEndForTimestamp(t int64) (time.Time, bool) {
+	m := r.matcher
+	if !boundsContains(m.boundsStart, m.boundsEnd, t) {
 		return time.Time{}, false
 	}
 
 	switch r.columnarMatcher {
 	case columnarMatcherInstant:
-		if len(r.windows) == 0 {
+		if len(r.windowEnds) == 0 {
 			return time.Time{}, false
 		}
-		return r.windows[0].end, true
+		return time.Unix(0, r.windowEnds[0]), true
 	case columnarMatcherAligned:
-		startNs := r.matcher.start.UnixNano()
-		stepNs := r.matcher.step.Nanoseconds()
-		windowIndex := (ts.UnixNano() - startNs + stepNs - 1) / stepNs
-		if windowIndex < 0 || windowIndex >= int64(len(r.windows)) {
+		windowIndex := (t - m.queryStart + m.step - 1) / m.step
+		if windowIndex < 0 || windowIndex >= int64(len(r.windowEnds)) {
 			return time.Time{}, false
 		}
-		return r.windows[windowIndex].end, true
+		return time.Unix(0, r.windowEnds[windowIndex]), true
 	case columnarMatcherGapped:
-		startNs := r.matcher.start.UnixNano()
-		stepNs := r.matcher.step.Nanoseconds()
-		tNs := ts.UnixNano()
-		windowIndex := (tNs - startNs + stepNs - 1) / stepNs
-		if windowIndex >= int64(len(r.windows)) {
+		windowIndex := (t - m.queryStart + m.step - 1) / m.step
+		if windowIndex >= int64(len(r.windowEnds)) {
 			return time.Time{}, false
 		}
-		if tNs > r.windows[windowIndex].start.UnixNano() {
-			return r.windows[windowIndex].end, true
+		if t > r.windowStarts[windowIndex] {
+			return time.Unix(0, r.windowEnds[windowIndex]), true
 		}
 		return time.Time{}, false
 	default:
 		return time.Time{}, false
 	}
+}
+
+func boundsContains(start, end, t int64) bool {
+	return t > start && t <= end
 }
 
 // addRecordColumnar ingests an input batch using a columnar loop for by() grouping.
@@ -347,11 +341,20 @@ func (r *rangeAggregationPipeline) addRecordColumnar(
 		return r.addRecordOverlapping(tsCol, valCol, labelCols, labelFields)
 	}
 
+	return r.addRecordOneToOne(tsCol, valCol, labelCols, labelFields)
+}
+
+// addRecordOneToOne ingests an input batch when each row maps to at most one output window.
+func (r *rangeAggregationPipeline) addRecordOneToOne(
+	tsCol *array.Timestamp,
+	valCol *array.Float64,
+	labelCols []*array.String,
+	labelFields []arrow.Field,
+) error {
 	countOp := r.opts.operation == types.RangeAggregationTypeCount
 
 	for row := range int(tsCol.Len()) {
-		ts := tsCol.Value(row).ToTime(arrow.Nanosecond)
-		outTs, ok := r.windowEndForTimestamp(ts)
+		outTs, ok := r.windowEndForTimestamp(int64(tsCol.Value(row)))
 		if !ok {
 			continue
 		}
@@ -373,6 +376,20 @@ func (r *rangeAggregationPipeline) addRecordColumnar(
 	return nil
 }
 
+func (r *rangeAggregationPipeline) batchAddScratch(countOp bool, labelCols []*array.String, labelFields []arrow.Field) error {
+	outputTs, values, sourceRows := r.expandScratch.finish(!countOp)
+	if outputTs == nil {
+		return nil
+	}
+	defer outputTs.Release()
+	defer sourceRows.Release()
+	if values != nil {
+		defer values.Release()
+	}
+
+	return r.aggregator.BatchAddSample(outputTs, values, sourceRows, labelCols, labelFields)
+}
+
 // addRecordOverlapping ingests an input batch for overlapping range queries with by() grouping.
 // Each row may contribute to multiple evaluation windows.
 func (r *rangeAggregationPipeline) addRecordOverlapping(
@@ -385,9 +402,9 @@ func (r *rangeAggregationPipeline) addRecordOverlapping(
 	r.expandScratch.reset()
 
 	for row := range int(tsCol.Len()) {
-		ts := tsCol.Value(row).ToTime(arrow.Nanosecond)
-		matching := overlappingWindowsForTimestamp(r.windows, r.matcher.bounds, ts)
-		if len(matching) == 0 {
+		t := int64(tsCol.Value(row))
+		low, high, ok := overlappingWindowRangeForTimestamp(r.windowStarts, r.windowEnds, r.matcher.boundsStart, r.matcher.boundsEnd, t)
+		if !ok {
 			continue
 		}
 
@@ -400,46 +417,44 @@ func (r *rangeAggregationPipeline) addRecordOverlapping(
 			value = valCol.Value(row)
 		}
 
-		for _, w := range matching {
-			r.expandScratch.append(w.end, value, row)
+		for i := low; i <= high; i++ {
+			r.expandScratch.append(r.windowEnds[i], value, row, !countOp)
 		}
 	}
 
-	outputTs, values, sourceRows := r.expandScratch.finish()
-	defer outputTs.Release()
-	defer values.Release()
-	defer sourceRows.Release()
-
-	return r.aggregator.BatchAddSample(outputTs, values, sourceRows, labelCols, labelFields)
+	return r.batchAddScratch(countOp, labelCols, labelFields)
 }
 
-// overlappingWindowsForTimestamp returns all evaluation windows that contain t.
-func overlappingWindowsForTimestamp(windows []window, bounds window, t time.Time) []window {
-	if !bounds.Contains(t) {
-		return nil
+// overlappingWindowRangeForTimestamp returns the inclusive index range of evaluation
+// windows that contain t. ok is false when t is out of bounds or matches no window.
+func overlappingWindowRangeForTimestamp(windowStarts, windowEnds []int64, boundsStart, boundsEnd, t int64) (low, high int, ok bool) {
+	if !boundsContains(boundsStart, boundsEnd, t) {
+		return 0, 0, false
 	}
 
-	// Find the last window that could contain the timestamp.
-	// We need the last window where t > window.start, i.e. the index before
-	// the first window where t <= window.start. Use BinarySearchFunc with a
-	// package-level cmp so we do not allocate a closure per call (unlike sort.Search).
-	firstOOBIndex, _ := slices.BinarySearchFunc(windows, t, cmpWindowStartTime)
+	// Find the last window where t > window.start, i.e. the index before the first
+	// window where start >= t.
+	firstOOBIndex, _ := slices.BinarySearchFunc(windowStarts, t, cmp.Compare)
 
 	windowIndex := firstOOBIndex - 1
 	if windowIndex < 0 {
-		return nil
+		return 0, 0, false
 	}
 
-	// For every i in [0, windowIndex], t > windows[i].start (by definition of windowIndex).
-	// Containment is therefore equivalent to t <= windows[i].end. Ends are non-decreasing
-	// in i, so matching indices are always a suffix [low, windowIndex] of that prefix.
-	prefix := windows[:windowIndex+1]
-	low, _ := slices.BinarySearchFunc(prefix, t, cmpWindowEndTime)
+	// For every i in [0, windowIndex], t > windows[i].start. Containment is therefore
+	// equivalent to t <= windows[i].end. Ends are non-decreasing in i, so matching
+	// indices are always a suffix [low, windowIndex].
+	low, _ = slices.BinarySearchFunc(windowEnds[:windowIndex+1], t, cmp.Compare)
 	if low > windowIndex {
-		return nil
+		return 0, 0, false
 	}
-	return windows[low : windowIndex+1]
+
+	return low, windowIndex, true
 }
+
+// timestampMatchingWindowsFunc resolves matching range interval windows for a specific timestamp.
+// The list can be empty if the timestamp is out of bounds or does not match any of the range windows.
+type timestampMatchingWindowsFunc func(time.Time) []window
 
 // Close closes the resources of the pipeline.
 // The implementation must close all the of the pipeline's inputs.
@@ -451,42 +466,28 @@ func (r *rangeAggregationPipeline) Close() {
 }
 
 func newMatcherFactoryFromOpts(opts rangeAggregationOptions) *matcherFactory {
+	bounds := window{
+		start: opts.startTs.Add(-opts.rangeInterval),
+		end:   opts.endTs,
+	}
+
 	return &matcherFactory{
-		start:    opts.startTs,
-		step:     opts.step,
-		interval: opts.rangeInterval,
-		bounds: window{
-			start: opts.startTs.Add(-opts.rangeInterval),
-			end:   opts.endTs,
-		},
+		start:       opts.startTs,
+		bounds:      bounds,
+		boundsStart: bounds.start.UnixNano(),
+		boundsEnd:   bounds.end.UnixNano(),
+		queryStart:  opts.startTs.UnixNano(),
+		step:        opts.step.Nanoseconds(),
 	}
 }
 
 type matcherFactory struct {
-	start    time.Time
-	step     time.Duration
-	interval time.Duration
-	bounds   window
-}
-
-func (f *matcherFactory) createMatcher(windows []window) timestampMatchingWindowsFunc {
-	switch {
-	case f.step == 0:
-		// For instant queries, step == 0, meaning that all samples fall into the one and same step.
-		// A sample timestamp will always match the only time window available, unless the timestamp it out of range.
-		return f.createExactMatcher(windows)
-	case f.step == f.interval:
-		// If the step is equal to the range interval (e.g. when used $__auto in Grafana), then a sample timestamp matches exactly one time window.
-		return f.createAlignedMatcher(windows)
-	case f.step > f.interval:
-		// If the step is greater than the range interval, then a sample timestamp matches either one time window or no time window (and will be discarded).
-		return f.createGappedMatcher(windows)
-	case f.step < f.interval:
-		// If the step is smaller than the range interval, then a sample timestamp matches either one or multiple time windows.
-		return f.createOverlappingMatcher(windows)
-	default:
-		panic("invalid step and range interval")
-	}
+	start       time.Time // retained for tests
+	bounds      window    // retained for tests
+	boundsStart int64
+	boundsEnd   int64
+	queryStart  int64
+	step        int64
 }
 
 // createExactMatcher is used for instant queries.
@@ -497,7 +498,7 @@ func (f *matcherFactory) createMatcher(windows []window) timestampMatchingWindow
 //	interval      |---------x-------|
 func (f *matcherFactory) createExactMatcher(windows []window) timestampMatchingWindowsFunc {
 	return func(t time.Time) []window {
-		if !f.bounds.Contains(t) {
+		if !boundsContains(f.boundsStart, f.boundsEnd, t.UnixNano()) {
 			return nil // out of range
 		}
 		if len(windows) == 0 {
@@ -515,17 +516,14 @@ func (f *matcherFactory) createExactMatcher(windows []window) timestampMatchingW
 //	interval            |---x-|
 //	interval      |-----|
 func (f *matcherFactory) createAlignedMatcher(windows []window) timestampMatchingWindowsFunc {
-	startNs := f.start.UnixNano()
-	stepNs := f.step.Nanoseconds()
-
 	return func(t time.Time) []window {
-		if !f.bounds.Contains(t) {
+		ts := t.UnixNano()
+		if !boundsContains(f.boundsStart, f.boundsEnd, ts) {
 			return nil // out of range
 		}
 
-		tNs := t.UnixNano()
-		// valid timestamps for window i: t > startNs + (i-1) * intervalNs && t <= startNs + i * intervalNs
-		windowIndex := (tNs - startNs + stepNs - 1) / stepNs // subtract 1ns because we are calculating 0-based indexes
+		// valid timestamps for window i: t > start + (i-1) * interval && t <= start + i * interval
+		windowIndex := (ts - f.queryStart + f.step - 1) / f.step // subtract 1ns because we are calculating 0-based indexes
 		return windows[windowIndex : windowIndex+1]
 	}
 }
@@ -539,24 +537,26 @@ func (f *matcherFactory) createAlignedMatcher(windows []window) timestampMatchin
 //	interval               |x-|
 //	interval         |--|
 func (f *matcherFactory) createGappedMatcher(windows []window) timestampMatchingWindowsFunc {
-	startNs := f.start.UnixNano()
-	stepNs := f.step.Nanoseconds()
+	windowStarts := make([]int64, len(windows))
+	for i, w := range windows {
+		windowStarts[i] = w.start.UnixNano()
+	}
 
 	return func(t time.Time) []window {
-		if !f.bounds.Contains(t) {
+		ts := t.UnixNano()
+		if !boundsContains(f.boundsStart, f.boundsEnd, ts) {
 			return nil // out of range
 		}
 
-		tNs := t.UnixNano()
 		// For gapped windows, window i covers: (start + i*step - interval, start + i*step]
-		windowIndex := (tNs - startNs + stepNs - 1) / stepNs // subtract 1ns because we are calculating 0-based indexes
+		windowIndex := (ts - f.queryStart + f.step - 1) / f.step // subtract 1ns because we are calculating 0-based indexes
 
 		if windowIndex >= int64(len(windows)) {
 			return nil // out of range when bounds do not fit exact number of steps
 		}
 
 		// Verify the timestamp is within the window (not in a gap)
-		if tNs > windows[windowIndex].start.UnixNano() {
+		if ts > windowStarts[windowIndex] {
 			return windows[windowIndex : windowIndex+1]
 		}
 
@@ -572,7 +572,18 @@ func (f *matcherFactory) createGappedMatcher(windows []window) timestampMatching
 //	interval         |------x-|
 //	interval   |--------|
 func (f *matcherFactory) createOverlappingMatcher(windows []window) timestampMatchingWindowsFunc {
+	windowStarts := make([]int64, len(windows))
+	windowEnds := make([]int64, len(windows))
+	for i, w := range windows {
+		windowStarts[i] = w.start.UnixNano()
+		windowEnds[i] = w.end.UnixNano()
+	}
+
 	return func(t time.Time) []window {
-		return overlappingWindowsForTimestamp(windows, f.bounds, t)
+		low, high, ok := overlappingWindowRangeForTimestamp(windowStarts, windowEnds, f.boundsStart, f.boundsEnd, t.UnixNano())
+		if !ok {
+			return nil
+		}
+		return windows[low : high+1]
 	}
 }

--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -69,8 +69,7 @@ type timestampMatchingWindowsFunc func(time.Time) []window
 type columnarMatcherKind int
 
 const (
-	columnarMatcherNone columnarMatcherKind = iota
-	columnarMatcherInstant
+	columnarMatcherInstant columnarMatcherKind = iota
 	columnarMatcherAligned
 	columnarMatcherGapped
 	columnarMatcherOverlapping
@@ -198,7 +197,6 @@ func (r *rangeAggregationPipeline) Read(ctx context.Context) (arrow.RecordBatch,
 }
 
 // TODOs:
-// - Add columnar ingest for without() grouping.
 // - Add toggle to return partial results on Read() call instead of returning only after exhausting all inputs.
 func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch, error) {
 	var (
@@ -219,16 +217,6 @@ func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch,
 		startedAt     = time.Now()
 		inputReadTime time.Duration
 	)
-
-	useColumnarAddRecord := r.columnarMatcher != columnarMatcherNone
-	var (
-		labelValuesCache *labelValuesCache
-		fieldsCache      *fieldsCache
-	)
-	if !useColumnarAddRecord {
-		labelValuesCache = newLabelValuesCache()
-		fieldsCache = newFieldsCache()
-	}
 
 	r.aggregator.Reset() // reset before reading new inputs
 	inputsExhausted := false
@@ -279,36 +267,8 @@ func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch,
 				valArr = valVec.(*array.Float64)
 			}
 
-			if useColumnarAddRecord {
-				if err := r.addRecordColumnar(tsCol, valArr, arrays, groupingFields); err != nil {
-					return nil, err
-				}
-				continue
-			}
-
-			for row := range int(record.NumRows()) {
-				windows := r.windowsForTimestamp(tsCol.Value(row).ToTime(arrow.Nanosecond))
-				if len(windows) == 0 {
-					continue // out of range, skip this row
-				}
-
-				var value float64
-				if r.opts.operation != types.RangeAggregationTypeCount {
-					if valArr.IsNull(row) {
-						continue
-					}
-
-					value = valArr.Value(row)
-				}
-
-				labelValues := labelValuesCache.getLabelValues(arrays, row)
-				labels := fieldsCache.getFields(arrays, groupingFields, row)
-
-				for _, w := range windows {
-					if err := r.aggregator.Add(w.end, value, labels, labelValues); err != nil {
-						return nil, err
-					}
-				}
+			if err := r.addRecordColumnar(tsCol, valArr, arrays, groupingFields); err != nil {
+				return nil, err
 			}
 		}
 	}
@@ -326,10 +286,6 @@ func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch,
 }
 
 func (r *rangeAggregationPipeline) detectColumnarMatcher() columnarMatcherKind {
-	if r.opts.grouping.Without {
-		return columnarMatcherNone
-	}
-
 	switch {
 	case r.opts.step == 0:
 		return columnarMatcherInstant

--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -62,7 +62,7 @@ const (
 // 2. Groups the data by the specified columns
 // 3. Applies the aggregation function on each group
 //
-// Current version only supports counting for instant queries.
+// It supports instant and range queries with by()/without() grouping.
 type rangeAggregationPipeline struct {
 	inputs          []Pipeline
 	inputsExhausted bool // indicates if all inputs are exhausted

--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/assertions"
 	"github.com/grafana/loki/v3/pkg/engine/internal/semconv"
@@ -72,6 +73,7 @@ const (
 	columnarMatcherInstant
 	columnarMatcherAligned
 	columnarMatcherGapped
+	columnarMatcherOverlapping
 )
 
 // rangeAggregationPipeline is a pipeline that performs aggregations over a time window.
@@ -89,10 +91,49 @@ type rangeAggregationPipeline struct {
 	windows             []window
 	matcher             *matcherFactory
 	columnarMatcher     columnarMatcherKind
+	expandScratch       rangeAggExpandScratch
 	windowsForTimestamp timestampMatchingWindowsFunc // function to find matching time windows for a given timestamp
 	evaluator           *expressionEvaluator         // used to evaluate column expressions
 	opts                rangeAggregationOptions
 	identCache          *semconv.IdentifierCache
+}
+
+type rangeAggExpandScratch struct {
+	mem        memory.Allocator
+	outputTs   []time.Time
+	values     []float64
+	sourceRows []int
+}
+
+func (s *rangeAggExpandScratch) reset() {
+	s.outputTs = s.outputTs[:0]
+	s.values = s.values[:0]
+	s.sourceRows = s.sourceRows[:0]
+}
+
+func (s *rangeAggExpandScratch) append(outTs time.Time, value float64, row int) {
+	s.outputTs = append(s.outputTs, outTs)
+	s.values = append(s.values, value)
+	s.sourceRows = append(s.sourceRows, row)
+}
+
+func (s *rangeAggExpandScratch) finish() (*array.Timestamp, *array.Float64, *array.Int32) {
+	if s.mem == nil {
+		s.mem = memory.NewGoAllocator()
+	}
+
+	tsBuilder := array.NewTimestampBuilder(s.mem, &arrow.TimestampType{Unit: arrow.Nanosecond})
+	valBuilder := array.NewFloat64Builder(s.mem)
+	rowBuilder := array.NewInt32Builder(s.mem)
+
+	for i := range s.outputTs {
+		tsValue, _ := arrow.TimestampFromTime(s.outputTs[i], arrow.Nanosecond)
+		tsBuilder.Append(tsValue)
+		valBuilder.Append(s.values[i])
+		rowBuilder.Append(int32(s.sourceRows[i]))
+	}
+
+	return tsBuilder.NewArray().(*array.Timestamp), valBuilder.NewArray().(*array.Float64), rowBuilder.NewArray().(*array.Int32)
 }
 
 func newRangeAggregationPipeline(inputs []Pipeline, evaluator *expressionEvaluator, opts rangeAggregationOptions) (*rangeAggregationPipeline, error) {
@@ -157,7 +198,7 @@ func (r *rangeAggregationPipeline) Read(ctx context.Context) (arrow.RecordBatch,
 }
 
 // TODOs:
-// - Add columnar ingest for overlapping windows and without() grouping.
+// - Add columnar ingest for without() grouping.
 // - Add toggle to return partial results on Read() call instead of returning only after exhausting all inputs.
 func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch, error) {
 	var (
@@ -297,7 +338,7 @@ func (r *rangeAggregationPipeline) detectColumnarMatcher() columnarMatcherKind {
 	case r.opts.step > r.opts.rangeInterval:
 		return columnarMatcherGapped
 	default:
-		return columnarMatcherNone
+		return columnarMatcherOverlapping
 	}
 }
 
@@ -339,14 +380,17 @@ func (r *rangeAggregationPipeline) windowEndForTimestamp(ts time.Time) (time.Tim
 	}
 }
 
-// addRecordColumnar ingests an input batch using a columnar loop for by() grouping when
-// each row maps to at most one output window (instant, aligned, or gapped matchers).
+// addRecordColumnar ingests an input batch using a columnar loop for by() grouping.
 func (r *rangeAggregationPipeline) addRecordColumnar(
 	tsCol *array.Timestamp,
 	valCol *array.Float64,
 	labelCols []*array.String,
 	labelFields []arrow.Field,
 ) error {
+	if r.columnarMatcher == columnarMatcherOverlapping {
+		return r.addRecordOverlapping(tsCol, valCol, labelCols, labelFields)
+	}
+
 	countOp := r.opts.operation == types.RangeAggregationTypeCount
 
 	for row := range int(tsCol.Len()) {
@@ -365,12 +409,80 @@ func (r *rangeAggregationPipeline) addRecordColumnar(
 			value = valCol.Value(row)
 		}
 
-		if err := r.aggregator.addSampleFromColumns(outTs, value, labelCols, labelFields, row); err != nil {
+		if err := r.aggregator.AddSample(outTs, value, labelCols, labelFields, row); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// addRecordOverlapping ingests an input batch for overlapping range queries with by() grouping.
+// Each row may contribute to multiple evaluation windows.
+func (r *rangeAggregationPipeline) addRecordOverlapping(
+	tsCol *array.Timestamp,
+	valCol *array.Float64,
+	labelCols []*array.String,
+	labelFields []arrow.Field,
+) error {
+	countOp := r.opts.operation == types.RangeAggregationTypeCount
+	r.expandScratch.reset()
+
+	for row := range int(tsCol.Len()) {
+		ts := tsCol.Value(row).ToTime(arrow.Nanosecond)
+		matching := overlappingWindowsForTimestamp(r.windows, r.matcher.bounds, ts)
+		if len(matching) == 0 {
+			continue
+		}
+
+		if !countOp && valCol.IsNull(row) {
+			continue
+		}
+
+		var value float64
+		if !countOp {
+			value = valCol.Value(row)
+		}
+
+		for _, w := range matching {
+			r.expandScratch.append(w.end, value, row)
+		}
+	}
+
+	outputTs, values, sourceRows := r.expandScratch.finish()
+	defer outputTs.Release()
+	defer values.Release()
+	defer sourceRows.Release()
+
+	return r.aggregator.BatchAddSample(outputTs, values, sourceRows, labelCols, labelFields)
+}
+
+// overlappingWindowsForTimestamp returns all evaluation windows that contain t.
+func overlappingWindowsForTimestamp(windows []window, bounds window, t time.Time) []window {
+	if !bounds.Contains(t) {
+		return nil
+	}
+
+	// Find the last window that could contain the timestamp.
+	// We need the last window where t > window.start, i.e. the index before
+	// the first window where t <= window.start. Use BinarySearchFunc with a
+	// package-level cmp so we do not allocate a closure per call (unlike sort.Search).
+	firstOOBIndex, _ := slices.BinarySearchFunc(windows, t, cmpWindowStartTime)
+
+	windowIndex := firstOOBIndex - 1
+	if windowIndex < 0 {
+		return nil
+	}
+
+	// For every i in [0, windowIndex], t > windows[i].start (by definition of windowIndex).
+	// Containment is therefore equivalent to t <= windows[i].end. Ends are non-decreasing
+	// in i, so matching indices are always a suffix [low, windowIndex] of that prefix.
+	prefix := windows[:windowIndex+1]
+	low, _ := slices.BinarySearchFunc(prefix, t, cmpWindowEndTime)
+	if low > windowIndex {
+		return nil
+	}
+	return windows[low : windowIndex+1]
 }
 
 // Close closes the resources of the pipeline.
@@ -505,29 +617,6 @@ func (f *matcherFactory) createGappedMatcher(windows []window) timestampMatching
 //	interval   |--------|
 func (f *matcherFactory) createOverlappingMatcher(windows []window) timestampMatchingWindowsFunc {
 	return func(t time.Time) []window {
-		if !f.bounds.Contains(t) {
-			return nil // out of range
-		}
-
-		// Find the last window that could contain the timestamp.
-		// We need the last window where t > window.start, i.e. the index before
-		// the first window where t <= window.start. Use BinarySearchFunc with a
-		// package-level cmp so we do not allocate a closure per call (unlike sort.Search).
-		firstOOBIndex, _ := slices.BinarySearchFunc(windows, t, cmpWindowStartTime)
-
-		windowIndex := firstOOBIndex - 1
-		if windowIndex < 0 {
-			return nil
-		}
-
-		// For every i in [0, windowIndex], t > windows[i].start (by definition of windowIndex).
-		// Containment is therefore equivalent to t <= windows[i].end. Ends are non-decreasing
-		// in i, so matching indices are always a suffix [low, windowIndex] of that prefix.
-		prefix := windows[:windowIndex+1]
-		low, _ := slices.BinarySearchFunc(prefix, t, cmpWindowEndTime)
-		if low > windowIndex {
-			return nil
-		}
-		return windows[low : windowIndex+1]
+		return overlappingWindowsForTimestamp(windows, f.bounds, t)
 	}
 }

--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -80,49 +80,54 @@ type rangeAggregationPipeline struct {
 
 type rangeAggExpandScratch struct {
 	mem        memory.Allocator
-	tsBuilder  *array.TimestampBuilder
-	valBuilder *array.Float64Builder
-	rowBuilder *array.Int32Builder
-}
-
-func (s *rangeAggExpandScratch) ensureBuilders() {
-	if s.mem == nil {
-		s.mem = memory.NewGoAllocator()
-	}
-	if s.tsBuilder == nil {
-		s.tsBuilder = array.NewTimestampBuilder(s.mem, &arrow.TimestampType{Unit: arrow.Nanosecond})
-		s.valBuilder = array.NewFloat64Builder(s.mem)
-		s.rowBuilder = array.NewInt32Builder(s.mem)
-	}
+	outputTs   []int64
+	values     []float64
+	sourceRows []int
 }
 
 func (s *rangeAggExpandScratch) reset() {
-	s.ensureBuilders()
-	s.tsBuilder.Resize(0)
-	s.valBuilder.Resize(0)
-	s.rowBuilder.Resize(0)
+	s.outputTs = s.outputTs[:0]
+	s.values = s.values[:0]
+	s.sourceRows = s.sourceRows[:0]
 }
 
 func (s *rangeAggExpandScratch) append(outTs int64, value float64, row int, includeValue bool) {
-	s.tsBuilder.Append(arrow.Timestamp(outTs))
+	s.outputTs = append(s.outputTs, outTs)
 	if includeValue {
-		s.valBuilder.Append(value)
+		s.values = append(s.values, value)
 	}
-	s.rowBuilder.Append(int32(row))
+	s.sourceRows = append(s.sourceRows, row)
 }
 
 func (s *rangeAggExpandScratch) finish(includeValues bool) (*array.Timestamp, *array.Float64, *array.Int32) {
-	if s.tsBuilder == nil || s.tsBuilder.Len() == 0 {
+	if len(s.outputTs) == 0 {
 		return nil, nil, nil
 	}
 
-	ts := s.tsBuilder.NewTimestampArray()
-	rows := s.rowBuilder.NewInt32Array()
+	if s.mem == nil {
+		s.mem = memory.NewGoAllocator()
+	}
+
+	tsBuilder := array.NewTimestampBuilder(s.mem, &arrow.TimestampType{Unit: arrow.Nanosecond})
+	rowBuilder := array.NewInt32Builder(s.mem)
+
+	for i, ts := range s.outputTs {
+		tsBuilder.Append(arrow.Timestamp(ts))
+		rowBuilder.Append(int32(s.sourceRows[i]))
+	}
+
+	ts := tsBuilder.NewTimestampArray()
+	rows := rowBuilder.NewInt32Array()
 	if !includeValues {
 		return ts, nil, rows
 	}
 
-	return ts, s.valBuilder.NewFloat64Array(), rows
+	valBuilder := array.NewFloat64Builder(s.mem)
+	for _, value := range s.values {
+		valBuilder.Append(value)
+	}
+
+	return ts, valBuilder.NewFloat64Array(), rows
 }
 
 func newRangeAggregationPipeline(inputs []Pipeline, evaluator *expressionEvaluator, opts rangeAggregationOptions) (*rangeAggregationPipeline, error) {
@@ -341,11 +346,11 @@ func (r *rangeAggregationPipeline) addRecordColumnar(
 		return r.addRecordOverlapping(tsCol, valCol, labelCols, labelFields)
 	}
 
-	return r.addRecordOneToOne(tsCol, valCol, labelCols, labelFields)
+	return r.addRecordSingle(tsCol, valCol, labelCols, labelFields)
 }
 
-// addRecordOneToOne ingests an input batch when each row maps to at most one output window.
-func (r *rangeAggregationPipeline) addRecordOneToOne(
+// addRecordSingle ingests an input batch when each row maps to at most one output window.
+func (r *rangeAggregationPipeline) addRecordSingle(
 	tsCol *array.Timestamp,
 	valCol *array.Float64,
 	labelCols []*array.String,

--- a/pkg/engine/internal/executor/util.go
+++ b/pkg/engine/internal/executor/util.go
@@ -2,17 +2,10 @@ package executor
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/apache/arrow-go/v18/arrow"
-	"github.com/apache/arrow-go/v18/arrow/array"
-	"github.com/cespare/xxhash/v2"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/semconv"
-)
-
-var (
-	separator = []byte{0}
 )
 
 // columnForIdent returns the column ([arrow.Array]) and its column index in the schema of the given input batch ([arrow.RecordBatch]).
@@ -33,83 +26,4 @@ func columnForFQN(fqn string, batch arrow.RecordBatch) (arrow.Array, int, error)
 	}
 
 	return batch.Column(indices[0]), indices[0], nil
-}
-
-// labelValuesCache returns label values for a given row in range and vector aggregators, but cache them in order
-// to reduce object allocations for repeated label sets. Strings are copied to avoid referencing the Arrow data buffer.
-type labelValuesCache struct {
-	digest *xxhash.Digest
-	cache  map[uint64][]string
-}
-
-func newLabelValuesCache() *labelValuesCache {
-	return &labelValuesCache{
-		digest: xxhash.New(),
-		cache:  make(map[uint64][]string),
-	}
-}
-
-func (c *labelValuesCache) getLabelValues(arrays []*array.String, row int) []string {
-	// Compute an xxhash over the non-null label values to form the cache key.
-	c.digest.Reset()
-	for _, arr := range arrays {
-		if !arr.IsNull(row) {
-			_, _ = c.digest.Write(separator)
-			_, _ = c.digest.WriteString(arr.Value(row))
-		}
-	}
-	key := c.digest.Sum64()
-
-	labelValues, ok := c.cache[key]
-	// In case of a cache miss, scan the row again and copy the label values.
-	if !ok {
-		labelValues = make([]string, 0, len(arrays))
-		for _, arr := range arrays {
-			if !arr.IsNull(row) {
-				labelValues = append(labelValues, strings.Clone(arr.Value(row)))
-			}
-		}
-		c.cache[key] = labelValues
-	}
-
-	return labelValues
-}
-
-// fieldsCache returns labels for a given row in range and vector aggregators, but cache them in order
-// to reduce object allocations for repeated label sets. It first scans the row for non-null labels and computes xxhash.
-// In case of a cache miss it scans the row again and allocates arrays for label names.
-type fieldsCache struct {
-	digest *xxhash.Digest
-	cache  map[uint64][]arrow.Field
-}
-
-func newFieldsCache() *fieldsCache {
-	return &fieldsCache{
-		digest: xxhash.New(),
-		cache:  make(map[uint64][]arrow.Field),
-	}
-}
-
-func (c *fieldsCache) getFields(arrays []*array.String, fields []arrow.Field, row int) []arrow.Field {
-	c.digest.Reset()
-	for i, arr := range arrays {
-		if !arr.IsNull(row) {
-			_, _ = c.digest.Write(separator)
-			_, _ = c.digest.WriteString(fields[i].Name)
-		}
-	}
-	key := c.digest.Sum64()
-
-	labels, ok := c.cache[key]
-	if !ok {
-		labels = make([]arrow.Field, 0, len(arrays))
-		for i, arr := range arrays {
-			if !arr.IsNull(row) {
-				labels = append(labels, fields[i])
-			}
-		}
-		c.cache[key] = labels
-	}
-
-	return labels
 }

--- a/pkg/engine/internal/executor/vector_aggregate.go
+++ b/pkg/engine/internal/executor/vector_aggregate.go
@@ -109,9 +109,6 @@ func (v *vectorAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch
 	var (
 		inputReadTime time.Duration
 		startedAt     = time.Now()
-
-		labelValuesCache = newLabelValuesCache()
-		fieldsCache      = newFieldsCache()
 	)
 
 	v.aggregator.Reset() // reset before reading new inputs
@@ -160,17 +157,8 @@ func (v *vectorAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch
 
 			v.aggregator.AddLabels(groupingFields)
 
-			for row := range int(record.NumRows()) {
-				if valueArr.IsNull(row) {
-					continue
-				}
-
-				labelValues := labelValuesCache.getLabelValues(arrays, row)
-				labels := fieldsCache.getFields(arrays, groupingFields, row)
-
-				if err := v.aggregator.Add(tsCol.Value(row).ToTime(arrow.Nanosecond), valueArr.Value(row), labels, labelValues); err != nil {
-					return nil, err
-				}
+			if err := v.aggregator.BatchAddSample(tsCol, valueArr, nil, arrays, groupingFields); err != nil {
+				return nil, err
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Switches the aggregator to operate on batches in order to be more performant. 

I achieved a 2-3x improvement to range aggregation using this approach (+ operating on UnixNano instead of time.Time was significant)

RangeAggregation:
```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/engine/internal/executor
cpu: Apple M3 Max
                                             │ range_agg_before.txt │        range_agg_after.txt         │
                                             │        sec/op        │   sec/op     vs base               │
RangeAggregationPipeline/case=instant-14               189.17µ ± 1%   84.50µ ± 2%  -55.33% (p=0.002 n=6)
RangeAggregationPipeline/case=aligned-14                82.36µ ± 6%   34.54µ ± 3%  -58.06% (p=0.002 n=6)
RangeAggregationPipeline/case=gapped-14                 80.97µ ± 2%   30.97µ ± 1%  -61.75% (p=0.002 n=6)
RangeAggregationPipeline/case=overlapping-14            86.98µ ± 3%   38.96µ ± 2%  -55.21% (p=0.002 n=6)
geomean                                                 102.3µ        43.32µ       -57.68%

                                             │ range_agg_before.txt │        range_agg_after.txt         │
                                             │         B/op         │     B/op      vs base              │
RangeAggregationPipeline/case=instant-14               21.92Ki ± 0%   20.64Ki ± 0%  -5.81% (p=0.002 n=6)
RangeAggregationPipeline/case=aligned-14               23.14Ki ± 0%   21.86Ki ± 0%  -5.51% (p=0.002 n=6)
RangeAggregationPipeline/case=gapped-14                21.18Ki ± 0%   20.03Ki ± 0%  -5.43% (p=0.002 n=6)
RangeAggregationPipeline/case=overlapping-14           24.26Ki ± 0%   25.38Ki ± 0%  +4.61% (p=0.002 n=6)
geomean                                                22.59Ki        21.89Ki       -3.13%

                                             │ range_agg_before.txt │        range_agg_after.txt        │
                                             │      allocs/op       │ allocs/op   vs base               │
RangeAggregationPipeline/case=instant-14                 274.0 ± 0%   234.0 ± 0%  -14.60% (p=0.002 n=6)
RangeAggregationPipeline/case=aligned-14                 296.0 ± 0%   256.0 ± 0%  -13.51% (p=0.002 n=6)
RangeAggregationPipeline/case=gapped-14                  265.0 ± 0%   234.0 ± 0%  -11.70% (p=0.002 n=6)
RangeAggregationPipeline/case=overlapping-14             301.0 ± 0%   278.0 ± 0%   -7.64% (p=0.002 n=6)
geomean                                                  283.6        249.8       -11.90%
```

Aggregator itself:
```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/engine/internal/executor
cpu: Apple M3 Max
                                    │ agg_before.txt │           agg_after.txt            │
                                    │     sec/op     │   sec/op     vs base               │
AggregatorAdd/case=interleaved-14       119.57µ ± 1%   69.39µ ± 1%  -41.97% (p=0.002 n=6)
AggregatorAdd/case=single_series-14     118.47µ ± 1%   69.01µ ± 2%  -41.75% (p=0.002 n=6)
geomean                                  119.0µ        69.20µ       -41.86%

                                    │ agg_before.txt │           agg_after.txt           │
                                    │      B/op      │    B/op     vs base               │
AggregatorAdd/case=interleaved-14        382.00 ± 1%   26.00 ± 0%  -93.19% (p=0.002 n=6)
AggregatorAdd/case=single_series-14      373.00 ± 0%   21.50 ± 2%  -94.24% (p=0.002 n=6)
geomean                                   377.5        23.64       -93.74%

                                    │ agg_before.txt │             agg_after.txt              │
                                    │   allocs/op    │ allocs/op   vs base                    │
AggregatorAdd/case=interleaved-14         2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
AggregatorAdd/case=single_series-14       2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
geomean                                   2.000                    ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```

Note: I used AI to make most of the changes and committed after checking each major change.

Best commits to review: 
[Support without](https://github.com/grafana/loki/commit/8b54e3a1fdcbbb85887219bd14a97d9c51d03b10)
[Use unixnano everywhere instead of time.Time](https://github.com/grafana/loki/commit/683451fe1ea0967d73970ac425911ab990a566e5)
and the final [Clean up](https://github.com/grafana/loki/commit/c36cd949a6be845ed69fc7a9bdd9c5e5f64e2a0b)