### PR TITLE
docs: Add link to upgrade topic

### DIFF
--- a/docs/sources/setup/install/helm/install-microservices/_index.md
+++ b/docs/sources/setup/install/helm/install-microservices/_index.md
@@ -21,6 +21,7 @@ With the move to the Grafana-community repository, the chart numbering has chang
 This Helm chart deploys Loki to run Loki in [microservice mode](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/deployment-modes/#microservices-mode) within a Kubernetes cluster. The microservices deployment is also referred to as a Distributed deployment. The microservices deployment mode runs components of Loki as distinct processes.
 
 The default Helm chart deploys the following components:
+
 - **Compactor component** (1 replica): Compacts and processes stored data.
 - **Distributor component** (3 replicas, maxUnavailable: 2): Distributes incoming requests. Up to 2 replicas can be unavailable during updates.
 - **IndexGateway component** (2 replicas, maxUnavailable: 1): Handles indexing. Up to 1 replica can be unavailable during updates.
@@ -38,17 +39,19 @@ Zone-aware replication is enabled by default for ingesters. This creates three i
 {{< /admonition >}}
 
 {{< admonition type="note" >}}
-We do not recommend running in microservices mode with `filesystem` storage. For the purpose of this guide, we will use MinIO as the object storage to provide a complete example. 
+We do not recommend running in microservices mode with `filesystem` storage. For the purpose of this guide, we will use MinIO as the object storage to provide a complete example.
 {{< /admonition >}}
-
 
 ## Prerequisites
 
 - Helm 3 or above. See [Installing Helm](https://helm.sh/docs/intro/install/).
 - A running Kubernetes cluster (must have at least 3 nodes).
 
-
 ## Deploying the Helm chart for development and testing
+
+{{< admonition type="note" >}}
+If this is the first time you have deployed the Loki Helm chart since the move to the Community managed Helm chart, note that the URL for the chart has changed. For more information see the [Upgrade documentation](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/upgrade-to-6x/).
+{{< /admonition >}}
 
 1. Add the [Grafana Community chart repository](https://github.com/grafana-community/helm-charts) to Helm:
 
@@ -140,19 +143,23 @@ We do not recommend running in microservices mode with `filesystem` storage. For
 
 1. Install or upgrade the Loki deployment.
      - To install:
+
         ```bash
        helm install --values values.yaml loki grafana-community/loki
        ```
-    - To upgrade:
+
+     - To upgrade:
+
        ```bash
        helm upgrade --values values.yaml loki grafana-community/loki
        ```
-       
 
 1. Verify that Loki is running:
+
     ```bash
     kubectl get pods -n loki
     ```
+
     The output should an output similar to the following:
 
     ```bash
@@ -191,7 +198,6 @@ After testing Loki with [MinIO](https://min.io/docs/minio/kubernetes/upstream/in
 {{< admonition type="caution" >}}
 When deploying Loki using S3 Storage **DO NOT** use the default bucket names;  `chunk`, `ruler` and `admin`. Choose a unique name for each bucket. For more information see the following [security update](https://grafana.com/blog/2024/06/27/grafana-security-update-grafana-loki-and-unintended-data-write-attempts-to-amazon-s3-buckets/). This caution does not apply when you are using MinIO. When using MinIO we recommend using the default bucket names.
 {{< /admonition >}}
-
 
 {{< collapse title="S3" >}}
 
@@ -295,6 +301,7 @@ singleBinary:
   replicas: 0
 
 ```
+
 {{< /collapse >}}
 
 {{< collapse title="Azure" >}}
@@ -383,6 +390,7 @@ singleBinary:
   replicas: 0
 
 ```
+
 {{< /collapse >}}
 
 To configure other storage providers, refer to the [Helm Chart Reference](../reference/).
@@ -431,13 +439,15 @@ For both options, if `apiVersion` is not set, the chart auto-detects the latest 
 ## Deploying the Loki Helm chart to a Production Environment
 
 {{< admonition type="note" >}}
-We are actively working on providing more guides for deploying Loki in production. 
+We are actively working on providing more guides for deploying Loki in production.
 {{< /admonition >}}
 
 We recommend running Loki at scale within a cloud environment like AWS, Azure, or GCP. The below guides will show you how to deploy a minimally viable production environment.
+
 - [Deploy Loki on AWS](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/deployment-guides/aws/)
 - [Deploy Loki on Azure](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/deployment-guides/azure/)
 
-## Next Steps 
+## Next Steps
+
 * Configure an agent to [send log data to Loki](/docs/loki/<LOKI_VERSION>/send-data/).
 * Monitor the Loki deployment using the [Meta Monitoring Helm chart](/docs/loki/<LOKI_VERSION>/setup/install/helm/monitor-and-alert/)

--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -192,6 +192,10 @@ In this configuration, we need to make sure to update the `commonConfig.replicat
 
 ## Deploying the Helm chart for development and testing
 
+{{< admonition type="note" >}}
+If this is the first time you have deployed the Loki Helm chart since the move to the Community managed Helm chart, note that the URL for the chart has changed. For more information see the [Upgrade documentation](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/upgrade-to-6x/).
+{{< /admonition >}}
+
 1. Add the [Grafana Community chart repository](https://github.com/grafana-community/helm-charts) to Helm:
 
    ```bash
@@ -425,14 +429,14 @@ To configure other storage providers, refer to the [Helm Chart Reference](https:
 ## Deploying the Loki Helm chart to a Production Environment
 
 {{< admonition type="note" >}}
-We are actively working on providing more guides for deploying Loki in production. 
+We are actively working on providing more guides for deploying Loki in production.
 {{< /admonition >}}
 
 We recommend running Loki at scale within a cloud environment like AWS, Azure, or GCP. The below guides will show you how to deploy a minimally viable production environment.
+
 - [Deploy Loki on AWS](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/deployment-guides/aws)
 
+## Next Steps
 
-## Next Steps 
 * Configure an agent to [send log data to Loki](/docs/loki/<LOKI_VERSION>/send-data/).
 * Monitor the Loki deployment using the [Meta Monitoring Helm chart](/docs/loki/<LOKI_VERSION>/setup/install/helm/monitor-and-alert/)
-

--- a/docs/sources/setup/install/helm/install-scalable/_index.md
+++ b/docs/sources/setup/install/helm/install-scalable/_index.md
@@ -47,6 +47,10 @@ We do not recommended running scalable mode with `filesystem` storage. For the p
 
 The following steps show how to deploy the Loki Helm chart in simple scalable mode using the included MinIO as the storage backend. Our recommendation is to start here for development and testing purposes. Then configure Loki with an object storage provider when moving to production.
 
+{{< admonition type="note" >}}
+If this is the first time you have deployed the Loki Helm chart since the move to the Community managed Helm chart, note that the URL for the chart has changed. For more information see the [Upgrade documentation](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/upgrade-to-6x/).
+{{< /admonition >}}
+
 1. Add the [Grafana Community chart repository](https://github.com/grafana-community/helm-charts) to Helm:
 
    ```bash

--- a/docs/sources/setup/upgrade/upgrade-to-6x/index.md
+++ b/docs/sources/setup/upgrade/upgrade-to-6x/index.md
@@ -7,7 +7,7 @@ keywords:
   - upgrade
 ---
 
-## Upgrading to v6.x
+# Upgrading to v6.x
 
 v6.x of this chart introduces distributed mode but also introduces breaking changes from v5x.
 
@@ -20,13 +20,14 @@ Simple Scalable Deployment (SSD) mode is being deprecated. The timeline for the 
 {{< /admonition >}}
 
 {{< admonition type="tip" >}}
-With the move to the [Grafana-community/helm-charts repository](https://github.com/grafana-community/helm-charts), the chart numbering has changed. Major version updates signal breaking changes in the chart. For more information, refer to the [README](https://github.com/grafana-community/helm-charts/blob/main/charts/loki/README.md#upgrading).
+With the move to the [Grafana-community/helm-charts repository](https://github.com/grafana-community/helm-charts), the chart URL and numbering has changed. Major version updates signal breaking changes in the chart. For more information, refer to the [README](https://github.com/grafana-community/helm-charts/blob/main/charts/loki/README.md#upgrading).
 {{< /admonition >}}
 
+## Changes
 
-### Changes
+The location of the Loki Helm chart has changed from https://grafana.github.io/helm-charts to https://grafana-community.github.io/helm-charts.
 
-#### BREAKING: `deploymentMode` setting
+### BREAKING: `deploymentMode` setting
 
 This only breaks you if you are running the chart in Single Binary mode, you will need to set
 
@@ -34,17 +35,17 @@ This only breaks you if you are running the chart in Single Binary mode, you wil
 deploymentMode: SingleBinary
 ```
 
-#### BREAKING: `lokiCanary` section was moved
+### BREAKING: `lokiCanary` section was moved
 
 This section was moved from within the `monitoring` section to the root level of the values file.
 
-#### BREAKING: `topologySpreadConstraints` and `podAffinity` converted to objects
+### BREAKING: `topologySpreadConstraints` and `podAffinity` converted to objects
 
 Previously they were strings which were passed through `tpl` now they are normal objects which will be added to deployments.
 
 Also we removed the soft constraint on zone.
 
-#### BREAKING: `externalConfigSecretName` was removed and replaced
+### BREAKING: `externalConfigSecretName` was removed and replaced
 
 Instead you can now provide `configObjectName` which is used by Loki components for loading the config.
 
@@ -52,7 +53,7 @@ Instead you can now provide `configObjectName` which is used by Loki components 
 
 This gives greater flexibility in using the chart to still generate a config object but allowing for another process to load and mutate this config into a new object which can be loaded by Loki and `configObjectName`
 
-#### Monitoring
+### Monitoring
 
 After some consideration of how this chart works with other charts provided by Grafana, we decided to deprecate the monitoring sections of this chart and take a new approach entirely to monitoring Loki, Mimir and Tempo with the [Meta Monitoring Chart](https://github.com/grafana/meta-monitoring-chart).
 
@@ -77,13 +78,13 @@ monitoring:
       installOperator: true
 ```
 
-#### Memcached is included and enabled by default
+### Memcached is included and enabled by default
 
 Caching is crucial to the proper operation of Loki and Memcached is now included in this chart and enabled by default for the `chunksCache` and `resultsCache`.
 
 If you are already running Memcached separately you can remove your existing installation and use the Memcached deployments built into this chart.
 
-##### Single Binary
+#### Single Binary
 
 Memcached also deploys for the Single Binary, but this may not be desired in resource constrained environments.
 
@@ -98,7 +99,7 @@ resultsCache:
 
 With these caches disabled, Loki will return to defaults which enables an in-memory results and chunks cache, so you will still get some caching.
 
-#### BREAKING: Zone-aware ingester StatefulSet serviceName fix (6.34.0+)
+### BREAKING: Zone-aware ingester StatefulSet serviceName fix (6.34.0+)
 
 **Affected users**: Only deployments using zone-aware ingester replication (`ingester.zoneAwareReplication.enabled: true`)
 
@@ -139,7 +140,7 @@ In Helm chart version 6.34.0, [PR #18558](https://github.com/grafana/loki/pull/1
 **Why this change was necessary**:
 The previous configuration caused ingester scaling operations to fail because the rollout-operator couldn't find the correct headless services for the `/ingester/prepare-downscale` endpoint.
 
-#### BREAKING: Make access modes for persistence on all PVCs and StatefulSets editable (6.38.0+)
+### BREAKING: Make access modes for persistence on all PVCs and StatefulSets editable (6.38.0+)
 
 Version 6.38.0 of the Helm charts introduced the ability to edit the access modes for persistence on all PVCs and StatefulSets. This is a breaking change because it requires users to manually orphan StatefulSets before upgrading.
 
@@ -177,6 +178,6 @@ Version 6.38.0 of the Helm charts introduced the ability to edit the access mode
    helm upgrade <RELEASE_NAME> grafana/loki --version 6.38.0
    ```
 
-#### Distributed mode
+### Distributed mode
 
 This chart introduces the ability to run Loki in distributed, or [microservices mode](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/deployment-modes/#microservices-mode). For installation instructions, refer to [Install the microservices Helm chart](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/install-microservices/).


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a link to the Helm Upgrade topic to the installation topics.
Cleans up some formatting issues (missing or extra lines).
Updated the Upgrade charts topic.