### PR TITLE
fix(storage): Pre-compute SHA-256 to avoid aws-chunked on PutObject

### DIFF
--- a/pkg/storage/chunk/client/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client.go
@@ -2,8 +2,10 @@ package aws
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"flag"
 	"fmt"
 	"hash/fnv"
@@ -524,20 +526,33 @@ func (a *S3ObjectClient) PutObject(ctx context.Context, objectKey string, object
 		if err != nil {
 			return err
 		}
+
+		// Pre-compute SHA-256 checksum before calling the SDK so the checksum
+		// is sent as a plain request header (x-amz-checksum-sha256) rather than
+		// as an aws-chunked trailer.
+		//
+		// When ChecksumAlgorithm is set without a pre-computed value, the AWS SDK
+		// v2 switches to trailing-checksum mode which wraps the body in
+		// aws-chunked transfer encoding (Content-Encoding: aws-chunked). This
+		// encoding is an AWS-proprietary protocol that S3-compatible backends
+		// such as OpenStack Swift do not support, causing 501 NotImplemented
+		// errors (grafana/loki#21791).
+		h := sha256.New()
+		if _, err := io.Copy(h, readSeeker); err != nil {
+			return fmt.Errorf("computing sha256 checksum for PutObject: %w", err)
+		}
+		sha256Checksum := base64.StdEncoding.EncodeToString(h.Sum(nil))
+		if _, err := readSeeker.Seek(0, io.SeekStart); err != nil {
+			return fmt.Errorf("rewinding body after checksum computation: %w", err)
+		}
+
 		putObjectInput := &s3.PutObjectInput{
-			Body:         readSeeker,
-			Bucket:       aws.String(a.bucketFromKey(objectKey)),
-			Key:          aws.String(a.convertObjectKey(objectKey, true)),
-			StorageClass: types.StorageClass(a.cfg.StorageClass),
-			// Buckets with Object Lock enabled reject PutObject requests
-			// that lack either Content-MD5 or one of the x-amz-checksum-*
-			// headers with `InvalidRequest: Content-MD5 OR x-amz-checksum-
-			// HTTP header is required for Put Object requests with Object
-			// Lock parameters`. Ask the SDK to compute and attach a
-			// SHA-256 trailer so compliance buckets accept uploads
-			// without forcing operators to buffer every chunk for MD5
-			// (grafana/loki#20088).
+			Body:              readSeeker,
+			Bucket:            aws.String(a.bucketFromKey(objectKey)),
+			Key:               aws.String(a.convertObjectKey(objectKey, true)),
+			StorageClass:      types.StorageClass(a.cfg.StorageClass),
 			ChecksumAlgorithm: types.ChecksumAlgorithmSha256,
+			ChecksumSHA256:    aws.String(sha256Checksum),
 		}
 
 		if a.sseConfig != nil {

--- a/pkg/storage/chunk/client/aws/s3_storage_client_test.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client_test.go
@@ -532,3 +532,111 @@ func TestCommonPrefixes(t *testing.T) {
 	require.Equal(t, nil, err)
 	require.Equal(t, 1, len(CommonPrefixes))
 }
+
+// TestPutObject_NoAWSChunkedEncoding verifies that PutObject sends the SHA-256
+// checksum as a plain request header (x-amz-checksum-sha256) and does NOT use
+// aws-chunked transfer encoding (Content-Encoding: aws-chunked).
+func TestPutObject_NoAWSChunkedEncoding(t *testing.T) {
+	var capturedReq *http.Request
+
+	// Use an HTTPS test server because the SDK only activates trailing
+	// checksums (and therefore aws-chunked) on HTTPS connections.
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedReq = r
+		w.WriteHeader(http.StatusOK)
+		// Return minimal valid S3 PutObject XML response
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><PutObjectResponse/>`))
+	}))
+	defer ts.Close()
+
+	cfg := S3Config{
+		Endpoint:         ts.URL,
+		BucketNames:      "test-bucket",
+		S3ForcePathStyle: true,
+		AccessKeyID:      "test-key",
+		SecretAccessKey:  flagext.SecretWithValue("test-secret"),
+		// Use the TLS client from the test server (accepts self-signed cert)
+		Inject: func(_ http.RoundTripper) http.RoundTripper {
+			return ts.Client().Transport
+		},
+	}
+
+	client, err := NewS3ObjectClient(cfg, hedging.Config{})
+	require.NoError(t, err)
+
+	body := []byte("hello from loki chunk")
+	err = client.PutObject(context.Background(), "test/key", bytes.NewReader(body))
+	require.NoError(t, err)
+	require.NotNil(t, capturedReq, "server should have received a request")
+
+	// Verify: no aws-chunked encoding header
+	contentEncoding := capturedReq.Header.Get("Content-Encoding")
+	require.NotContains(t, contentEncoding, "aws-chunked",
+		"PutObject must NOT use aws-chunked encoding — breaks S3-compatible backends like OpenStack Swift (issue #21791)")
+
+	// Verify: SHA-256 checksum is present as a plain header
+	checksumHeader := capturedReq.Header.Get("x-amz-checksum-sha256")
+	require.NotEmpty(t, checksumHeader,
+		"PutObject must send x-amz-checksum-sha256 header for Object Lock compatibility (issue #20088)")
+
+	// Verify: x-amz-content-sha256 is NOT the streaming sentinel value
+	payloadHash := capturedReq.Header.Get("x-amz-content-sha256")
+	require.NotEqual(t, "STREAMING-UNSIGNED-PAYLOAD-TRAILER", payloadHash,
+		"payload hash must not be the streaming sentinel — that indicates aws-chunked mode is active")
+}
+
+// TestPutObject_SwiftRejects_AWSChunked reproduces the exact failure from
+// https://github.com/grafana/loki/issues/21791.
+//
+// It spins up a mock server that behaves like OpenStack Swift's S3-compatible
+// API: it returns 501 NotImplemented when it receives a request with
+// Content-Encoding: aws-chunked, and 200 OK for normal requests.
+//
+// With the fix in place, PutObject sends a plain request (no aws-chunked)
+// and the mock Swift server accepts it successfully.
+func TestPutObject_SwiftRejects_AWSChunked(t *testing.T) {
+	// mockSwiftHandler simulates OpenStack Swift S3-compatible API behaviour:
+	// rejects aws-chunked with 501, accepts plain requests with 200.
+	mockSwiftHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contentEncoding := r.Header.Get("Content-Encoding")
+
+		if strings.Contains(contentEncoding, "aws-chunked") {
+			// This is exactly what OpenStack Swift returns
+			w.WriteHeader(http.StatusNotImplemented)
+			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>NotImplemented</Code>
+  <Message>Transfering payloads in multiple chunks using aws-chunked is not supported</Message>
+</Error>`))
+			return
+		}
+
+		// Normal request — Swift accepts it
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><PutObjectResponse/>`))
+	})
+
+	ts := httptest.NewTLSServer(mockSwiftHandler)
+	defer ts.Close()
+
+	cfg := S3Config{
+		Endpoint:         ts.URL,
+		BucketNames:      "swift-bucket",
+		S3ForcePathStyle: true,
+		AccessKeyID:      "swift-key",
+		SecretAccessKey:  flagext.SecretWithValue("swift-secret"),
+		Inject: func(_ http.RoundTripper) http.RoundTripper {
+			return ts.Client().Transport
+		},
+	}
+
+	client, err := NewS3ObjectClient(cfg, hedging.Config{})
+	require.NoError(t, err)
+
+	body := []byte("loki log chunk data")
+
+	// With the fix: PutObject should succeed because no aws-chunked is sent
+	err = client.PutObject(context.Background(), "logs/chunk-001", bytes.NewReader(body))
+	require.NoError(t, err,
+		"PutObject must succeed against OpenStack Swift (no aws-chunked should be sent)")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
When `ChecksumAlgorithm` is set on `PutObjectInput` without a pre-computed value, the AWS SDK v2 switches to trailing-checksum mode which wraps the body in `aws-chunked` transfer encoding. OpenStack Swift and other S3-compatible backends reject this with `501 NotImplemented`.

This PR pre-computes the SHA-256 hash upfront and passes it as `ChecksumSHA256`. This causes the SDK checksum middleware to detect that the header is already present and skip the `aws-chunked` trailing-checksum path entirely. 

This cleanly satisfies Object Lock requirements (which require the checksum header) while remaining compatible with S3-compatible backends (which don't support `aws-chunked`).

**Which issue(s) this PR fixes**:
Fixes #21791

**Special notes for your reviewer**:
I've added two regression tests to `s3_storage_client_test.go`:
1. `TestPutObject_NoAWSChunkedEncoding`: Verifies that `PutObject` sends the `x-amz-checksum-sha256` as a plain header and does NOT use `Content-Encoding: aws-chunked`.
2. `TestPutObject_SwiftRejects_AWSChunked`: A mock server that behaves like OpenStack Swift (returns `501 NotImplemented` when it sees `aws-chunked`). It proves that the fix makes the request pass successfully against a Swift-like API.

Because `clientutil.ReadSeeker` already guarantees the body is fully buffered in memory (`bytes.Reader`), the SHA-256 pre-computation reads from RAM and adds zero extra I/O.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)