### PR TITLE
fix(mixin): Fix regex pattern for compactor job matcher

### DIFF
--- a/production/loki-mixin/dashboards/loki-retention.libsonnet
+++ b/production/loki-mixin/dashboards/loki-retention.libsonnet
@@ -3,7 +3,7 @@
   then $._config.per_instance_label + '=~"(.*compactor.*|%s-backend.*|loki-single-binary)"' % $._config.ssd.pod_prefix_matcher
   else if $._config.ssd.enabled then 'container="loki", ' + $._config.per_instance_label + '=~"%s-read.*"' % $._config.ssd.pod_prefix_matcher else 'container="compactor"',
   local compactor_job_matcher = if $._config.meta_monitoring.enabled
-  then '"(.*compactor|%s-backend.*|loki-single-binary)"' % $._config.ssd.pod_prefix_matcher
+  then '(.*compactor|%s-backend.*|loki-single-binary)' % $._config.ssd.pod_prefix_matcher
   else if $._config.ssd.enabled then '%s-backend' % $._config.ssd.pod_prefix_matcher else 'compactor',
   grafanaDashboards+::
     {


### PR DESCRIPTION
**What this PR does / why we need it**:

With quotes, it results into `job=~\"($namespace)/\"(.*compactor|.*-backend.*|loki-single-binary)\"\"`, which is wrong.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
