### PR TITLE
fix(config_wrapper): Honor grpc_listen_address for ring advertisement

### DIFF
--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -153,6 +153,13 @@ func lastTSDBConfig(configs []config.PeriodConfig) int {
 // - "instance-addr", the address advertised to be used by other components.
 // - "instance-interface-names", a list of net interfaces used when looking for addresses.
 func applyInstanceConfigs(r, defaults *ConfigWrapper) {
+	// Derive instance_addr from grpc_listen_address when not explicitly set.
+	if reflect.DeepEqual(r.Common.InstanceAddr, defaults.Common.InstanceAddr) &&
+		r.Server.GRPCListenAddress != "" &&
+		r.Server.GRPCListenAddress != defaults.Server.GRPCListenAddress {
+		r.Common.InstanceAddr = r.Server.GRPCListenAddress
+	}
+
 	if !reflect.DeepEqual(r.Common.InstanceAddr, defaults.Common.InstanceAddr) {
 		if reflect.DeepEqual(r.Common.Ring.InstanceAddr, defaults.Common.Ring.InstanceAddr) {
 			r.Common.Ring.InstanceAddr = r.Common.InstanceAddr

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -2052,6 +2052,35 @@ common:
 		assert.Equal(t, "99.99.99.99", config.IndexGateway.Ring.InstanceAddr)
 	})
 
+	t.Run("grpc_listen_address is used as instance addr when common instance addr is not set", func(t *testing.T) {
+		yamlContent := `server:
+  grpc_listen_address: 127.0.0.1`
+		config, _, err := configWrapperFromYAML(t, yamlContent, nil)
+		require.NoError(t, err)
+		require.Equal(t, "127.0.0.1", config.Common.InstanceAddr)
+		require.Equal(t, "127.0.0.1", config.Distributor.DistributorRing.InstanceAddr)
+		require.Equal(t, "127.0.0.1", config.Ingester.LifecyclerConfig.Addr)
+		require.Equal(t, "127.0.0.1", config.Ruler.Ring.InstanceAddr)
+		require.Equal(t, "127.0.0.1", config.QueryScheduler.SchedulerRing.InstanceAddr)
+		require.Equal(t, "127.0.0.1", config.Frontend.FrontendV2.Addr)
+		require.Equal(t, "127.0.0.1", config.CompactorConfig.CompactorRing.InstanceAddr)
+		require.Equal(t, "127.0.0.1", config.IndexGateway.Ring.InstanceAddr)
+		require.Equal(t, "127.0.0.1", config.MemberlistKV.AdvertiseAddr)
+	})
+
+	t.Run("common instance addr takes precedence over grpc_listen_address", func(t *testing.T) {
+		yamlContent := `server:
+  grpc_listen_address: 127.0.0.1
+common:
+  instance_addr: 99.99.99.99`
+		config, _, err := configWrapperFromYAML(t, yamlContent, nil)
+		require.NoError(t, err)
+		require.Equal(t, "99.99.99.99", config.Common.InstanceAddr)
+		require.Equal(t, "99.99.99.99", config.Distributor.DistributorRing.InstanceAddr)
+		require.Equal(t, "99.99.99.99", config.Frontend.FrontendV2.Addr)
+		require.Equal(t, "99.99.99.99", config.QueryScheduler.SchedulerRing.InstanceAddr)
+	})
+
 	t.Run("common instance addr doesn't supersede instance addr from common ring", func(t *testing.T) {
 		yamlContent := `common:
   instance_addr: 99.99.99.99


### PR DESCRIPTION
Internal ring components have no awareness of server.grpc_listen_address. When determining the address to advertise they either use common.instance_addr or auto-detect from network interfaces. This causes gRPC connection failures when gRPC is bound to a specific address like 127.0.0.1 but instance_addr is not also explicitly configured.

Bridge this gap in the config wrapper by propagating grpc_listen_address to instance_addr for ring advertisement when instance_addr is not set.

Closes #7586

**What this PR does / why we need it**:
server.grpc_listen_address isn't being honored by internal ring components when common.instance_addr is not also specified

**Which issue(s) this PR fixes**:
Fixes #7586 

**Special notes for your reviewer**:

This makes the configuration of, for example,

server:
  http_listen_address: 127.0.0.1
  grpc_listen_address: 127.0.0.1

for the use case of binding localhost only work as expected. I didn't figure it's a documentation / configuration change since it's really just making the existing config parameters work as expected...

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
