### PR TITLE
chore(workflows): Restrict workflow event triggers

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,11 +1,9 @@
 name: helm-release
 
 on:
-  workflow_dispatch: # for manual testing
   push:
     branches:
       - main
-      - k[0-9]+
     paths:
       - 'production/helm/loki/Chart.yaml'
 

--- a/.github/workflows/helm-tagged-release-pr.yaml
+++ b/.github/workflows/helm-tagged-release-pr.yaml
@@ -5,8 +5,6 @@ on:
     types:
       - released
 
-  workflow_dispatch: # for manual testing
-
 jobs:
   weekly-release-pr:
     runs-on: ubuntu-x64

--- a/.github/workflows/helm-weekly-release-pr.yaml
+++ b/.github/workflows/helm-weekly-release-pr.yaml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: '0 10 * * 2' # 10 UTC every Tuesday (since ks get cut on Monday)
 
-  workflow_dispatch: # for manual testing
-
 permissions:
   contents: "read"
   id-token: "write"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,8 +6,7 @@ jobs:
   triage:
     # We don't run the triaging for PRs from forks because those can't use the loki-gh-app token broker.
     # We don't use GitHub actions app (secrets.GITHUB_TOKEN) because PRs created by the bot don't trigger CI.
-    # Also only run if the PR is merged, as an extra safe-guard.
-    if: ${{ ! github.event.pull_request.head.repo.fork && github.event.pull_request.merged == true }}
+    if: ${{ ! github.event.pull_request.head.repo.fork }}
 
     runs-on: ubuntu-x64-small
     permissions:

--- a/.github/workflows/logql-analyzer.yml
+++ b/.github/workflows/logql-analyzer.yml
@@ -1,7 +1,6 @@
 name: LogQL Analyzer
 
 on:
-  workflow_dispatch:
   release:
     types:
       - released

--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - "docs/sources/**"
-  workflow_dispatch:
 jobs:
   sync:
     if: github.repository == 'grafana/loki'


### PR DESCRIPTION
**What this PR does / why we need it**:

1. `helm-release` is currently being triggered from even from `k[0-9]+` branches. Removing this as this does not seem intentional
2. Remove `workflow_dispatch` for workflows using app tokens. We can add it back with explicit permission sets if required.
3. label workflow is incorrectly set to trigger only when `github.event.pull_request.merged == true`, my understanding is that labelling is more useful for open PRs

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
