### PR TITLE
chore(ci): Remove unused step in helm test workflow

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -147,11 +147,6 @@ jobs:
         with:
           install_only: true
 
-      - name: Install Minikube CLI
-        uses: medyagh/setup-minikube@e3c7f79eb1e997eabccc536a6cf318a2b0fe19d9  # v0.0.20
-        with:
-          start: false
-
       - name: Run test
         run: |
           # Enable verbose output only if runner debug mode is enabled


### PR DESCRIPTION
**What this PR does / why we need it**:

Test plans in https://github.com/grafana/loki/tree/main/production/helm/loki/test use kind cluster
there are no refs to minikube
```
cluster:
  type: kind
```

Triggered a test run to create kind cluster and run chart-testing. It's working fine after removing minikube dependency
https://github.com/grafana/loki/actions/runs/26495557096/job/78022826927

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
