### PR TITLE
ci: Publish weekly images to GAR

### DIFF
--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -9,6 +9,7 @@ local buildImage = 'golang:%s' % goVersion;
 local golangCiLintVersion = 'v2.10.1';
 local imageBuildTimeoutMin = 60;
 local imagePrefix = 'grafana';
+local weeklyImagePrefix = 'us-docker.pkg.dev/grafanalabs-global/docker-loki-prod';
 local dockerPluginDir = 'clients/cmd/docker-driver';
 local runner = import 'workflows/runner.libsonnet',
       r = runner.withDefaultMapping();  // Do we need a different mapping?
@@ -86,7 +87,7 @@ local weeklyImageJobs = {
     lokiRelease.releaseWorkflow(
       branches=['release-[0-9]+.[0-9]+.x', 'k[0-9]+', 'main'],
       getDockerCredsFromVault=true,
-      imagePrefix='grafana',
+      imagePrefix=imagePrefix,
       releaseLibRef=releaseLibRef,
       pluginBuildDir=dockerPluginDir,
       releaseBranchTemplate='release-\\${major}.\\${minor}.x',
@@ -157,7 +158,7 @@ local weeklyImageJobs = {
           BUILD_TIMEOUT: imageBuildTimeoutMin,
           RELEASE_REPO: 'grafana/loki',
           RELEASE_LIB_REF: releaseLibRef,
-          IMAGE_PREFIX: imagePrefix,
+          IMAGE_PREFIX: weeklyImagePrefix,
           GO_VERSION: goVersion,
         })
       for name in std.objectFields(weeklyImageJobs)
@@ -179,7 +180,7 @@ local weeklyImageJobs = {
         })
         + job.withSteps([
           step.new('Set up Docker buildx', 'docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2'),  // v3
-          step.new('Login to DockerHub (from Vault)', 'grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746'),  // main
+          step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136'),  // v1.0.2
           step.new('Publish multi-arch manifest')
           + step.withRun(|||
             # Unfortunately there is no better way atm than having a separate named output for each digest

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -9,7 +9,8 @@ local buildImage = 'golang:%s' % goVersion;
 local golangCiLintVersion = 'v2.10.1';
 local imageBuildTimeoutMin = 60;
 local imagePrefix = 'grafana';
-local weeklyImagePrefix = 'us-docker.pkg.dev/grafanalabs-global/docker-loki-prod';
+local weeklyImageRegistry = 'us-docker.pkg.dev';
+local weeklyImagePrefix = '%s/grafanalabs-global/docker-loki-prod' % weeklyImageRegistry;
 local dockerPluginDir = 'clients/cmd/docker-driver';
 local runner = import 'workflows/runner.libsonnet',
       r = runner.withDefaultMapping();  // Do we need a different mapping?
@@ -180,7 +181,12 @@ local weeklyImageJobs = {
         })
         + job.withSteps([
           step.new('Set up Docker buildx', 'docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2'),  // v3
-          step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136'),  // v1.0.2
+          step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136')  // v1.0.2
+          + {
+            with: {
+              registry: weeklyImageRegistry,
+            },
+          },
           step.new('Publish multi-arch manifest')
           + step.withRun(|||
             # Unfortunately there is no better way atm than having a separate named output for each digest

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -120,6 +120,8 @@
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - "name": "Login to GAR"
       "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
@@ -246,6 +248,8 @@
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - "name": "Login to GAR"
       "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
@@ -372,6 +376,8 @@
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - "name": "Login to GAR"
       "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
@@ -498,6 +504,8 @@
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - "name": "Login to GAR"
       "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -11,7 +11,7 @@
     "env":
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
-      "IMAGE_PREFIX": "grafana"
+      "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod"
       "RELEASE_LIB_REF": "2d519a304729edd6ae6931ccbfb40bb2168e13a6"
       "RELEASE_REPO": "grafana/loki"
     "needs":
@@ -118,8 +118,8 @@
     "steps":
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
@@ -137,7 +137,7 @@
     "env":
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
-      "IMAGE_PREFIX": "grafana"
+      "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod"
       "RELEASE_LIB_REF": "2d519a304729edd6ae6931ccbfb40bb2168e13a6"
       "RELEASE_REPO": "grafana/loki"
     "needs":
@@ -244,8 +244,8 @@
     "steps":
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
@@ -263,7 +263,7 @@
     "env":
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
-      "IMAGE_PREFIX": "grafana"
+      "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod"
       "RELEASE_LIB_REF": "2d519a304729edd6ae6931ccbfb40bb2168e13a6"
       "RELEASE_REPO": "grafana/loki"
     "needs":
@@ -370,8 +370,8 @@
     "steps":
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
@@ -389,7 +389,7 @@
     "env":
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
-      "IMAGE_PREFIX": "grafana"
+      "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod"
       "RELEASE_LIB_REF": "2d519a304729edd6ae6931ccbfb40bb2168e13a6"
       "RELEASE_REPO": "grafana/loki"
     "needs":
@@ -496,8 +496,8 @@
     "steps":
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest


### PR DESCRIPTION
### Summary

Obtain short-lived credential via OIDC and login to Google Container Registry (GAR). Publish weekly k-release images to GAR.