### PR TITLE
chore(ci): Remove `marocchino/sticky-pull-request-comment` in helm ci

### DIFF
--- a/.github/workflows/helm-diff-ci.yml
+++ b/.github/workflows/helm-diff-ci.yml
@@ -143,11 +143,7 @@ jobs:
           mv formatted_diff_output.truncated.md formatted_diff_output.md
 
       - name: Post diff as PR comment
-        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2
-        with:
-          header: "Helm Diff Output - Summary"
-          skip_unchanged: true
-          hide_and_recreate: true
-          append: true
-          hide_classify: "OUTDATED"
-          path: formatted_diff_output.md
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" --body-file formatted_diff_output.md


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes a third party action with `gh pr comment`.
This is going to post a new comment for each push unlike the existing action which could hide the stale diff comment. But this isn't so bad as the diff is collapsed. (Check the comments on this pr for an example)



**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
