### PR TITLE
chore: Bump to latest rollout-operator version

### DIFF
--- a/production/ksonnet/loki/rollout-operator.libsonnet
+++ b/production/ksonnet/loki/rollout-operator.libsonnet
@@ -8,7 +8,7 @@
   local serviceAccount = $.core.v1.serviceAccount,
 
   _images+:: {
-    rollout_operator: 'grafana/rollout-operator:v0.1.1',
+    rollout_operator: 'grafana/rollout-operator:v0.37.0',
   },
 
   rollout_operator_args:: {


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves the rollout-operator to the latest released  version.
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
