### PR TITLE
ci: Vendor loki-release commit 781f67f5

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "2d519a304729edd6ae6931ccbfb40bb2168e13a6"
+      "version": "781f67f5e65569df4c97b98c1f671b27857f5684"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "2d519a304729edd6ae6931ccbfb40bb2168e13a6",
-      "sum": "SriykE12sfd8CGtGjnU681OExrNKvqX4BDX0PEhRQKo="
+      "version": "781f67f5e65569df4c97b98c1f671b27857f5684",
+      "sum": "iBQM2jT6IOheRFvwnSfyfpvYGLXJrRKRD/rVzfOQNkE="
     }
   ],
   "legacyImports": false

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -106,8 +106,8 @@ local runner = import 'runner.libsonnet',
       common.enableCorepack,
 
       step.new('Set up Docker buildx', 'docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2'),  // v3
-      step.new('Login to DockerHub (from Vault)', 'grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25'),  // main
-
+      step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136')  // v1.0.2
+      + step.with({ registry: 'us-docker.pkg.dev' }),
       releaseStep('Get weekly version')
       + step.withId('weekly-version')
       + step.withRun(|||

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@2d519a304729edd6ae6931ccbfb40bb2168e13a6"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@781f67f5e65569df4c97b98c1f671b27857f5684"
     "with":
       "build_image": "golang:1.26.2"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "2d519a304729edd6ae6931ccbfb40bb2168e13a6"
+      "release_lib_ref": "781f67f5e65569df4c97b98c1f671b27857f5684"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@2d519a304729edd6ae6931ccbfb40bb2168e13a6"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@781f67f5e65569df4c97b98c1f671b27857f5684"
     "with":
       "build_image": "golang:1.26.2"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "2d519a304729edd6ae6931ccbfb40bb2168e13a6"
+      "release_lib_ref": "781f67f5e65569df4c97b98c1f671b27857f5684"
       "skip_validation": false
       "use_github_app_token": true
   "loki-canary-boringcrypto-image":
@@ -12,7 +12,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod"
-      "RELEASE_LIB_REF": "2d519a304729edd6ae6931ccbfb40bb2168e13a6"
+      "RELEASE_LIB_REF": "781f67f5e65569df4c97b98c1f671b27857f5684"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -49,8 +49,10 @@
       "run": "corepack enable"
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
     - "id": "weekly-version"
       "name": "Get weekly version"
       "run": |
@@ -140,7 +142,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod"
-      "RELEASE_LIB_REF": "2d519a304729edd6ae6931ccbfb40bb2168e13a6"
+      "RELEASE_LIB_REF": "781f67f5e65569df4c97b98c1f671b27857f5684"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -177,8 +179,10 @@
       "run": "corepack enable"
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
     - "id": "weekly-version"
       "name": "Get weekly version"
       "run": |
@@ -268,7 +272,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod"
-      "RELEASE_LIB_REF": "2d519a304729edd6ae6931ccbfb40bb2168e13a6"
+      "RELEASE_LIB_REF": "781f67f5e65569df4c97b98c1f671b27857f5684"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -305,8 +309,10 @@
       "run": "corepack enable"
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
     - "id": "weekly-version"
       "name": "Get weekly version"
       "run": |
@@ -396,7 +402,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.2"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod"
-      "RELEASE_LIB_REF": "2d519a304729edd6ae6931ccbfb40bb2168e13a6"
+      "RELEASE_LIB_REF": "781f67f5e65569df4c97b98c1f671b27857f5684"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -433,8 +439,10 @@
       "run": "corepack enable"
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
     - "id": "weekly-version"
       "name": "Get weekly version"
       "run": |

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -8,7 +8,7 @@ env:
   DRY_RUN: false
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "2d519a304729edd6ae6931ccbfb40bb2168e13a6"
+  RELEASE_LIB_REF: "781f67f5e65569df4c97b98c1f671b27857f5684"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
@@ -19,11 +19,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@2d519a304729edd6ae6931ccbfb40bb2168e13a6"
+    uses: "grafana/loki-release/.github/workflows/check.yml@781f67f5e65569df4c97b98c1f671b27857f5684"
     with:
       build_image: "golang:1.26.2"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "2d519a304729edd6ae6931ccbfb40bb2168e13a6"
+      release_lib_ref: "781f67f5e65569df4c97b98c1f671b27857f5684"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -8,7 +8,7 @@ env:
   DRY_RUN: false
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "2d519a304729edd6ae6931ccbfb40bb2168e13a6"
+  RELEASE_LIB_REF: "781f67f5e65569df4c97b98c1f671b27857f5684"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   USE_GITHUB_APP_TOKEN: true
@@ -19,11 +19,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@2d519a304729edd6ae6931ccbfb40bb2168e13a6"
+    uses: "grafana/loki-release/.github/workflows/check.yml@781f67f5e65569df4c97b98c1f671b27857f5684"
     with:
       build_image: "golang:1.26.2"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "2d519a304729edd6ae6931ccbfb40bb2168e13a6"
+      release_lib_ref: "781f67f5e65569df4c97b98c1f671b27857f5684"
       skip_validation: false
       use_github_app_token: true
   create-release-pr:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "2d519a304729edd6ae6931ccbfb40bb2168e13a6"
+  RELEASE_LIB_REF: "781f67f5e65569df4c97b98c1f671b27857f5684"
   RELEASE_REPO: "grafana/loki"
   USE_GITHUB_APP_TOKEN: true
 jobs:


### PR DESCRIPTION
### Summary

Contains https://github.com/grafana/loki-release/pull/334