### PR TITLE
ci: Fix multiarch build workflow for weekly images

### DIFF
--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -178,8 +178,7 @@ local weeklyImageJobs = {
           IMAGE_DIGEST_ARM: '${{ needs.%s-image.outputs.image_digest_linux_arm }}' % name,
           OUTPUTS_IMAGE_NAME: '${{ needs.%s-image.outputs.image_name }}' % name,
           OUTPUTS_IMAGE_TAG: '${{ needs.%s-image.outputs.image_tag }}' % name,
-          IMAGE_PREFIX: weeklyImagePrefix,
-          IMAGE_NAME: name,
+          IMAGE_NAME: '%s/%s' % [weeklyImagePrefix, name],
         })
         + job.withSteps([
           step.new('Set up Docker buildx', 'docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2'),  // v3
@@ -195,8 +194,8 @@ local weeklyImageJobs = {
 
             # 'needs.%(name)s-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
             # See https://github.com/actions/runner/issues/2316
-            # Using the IMAGE_PREFIX and IMAGE_NAME env variables instead
-            IMAGE="${IMAGE_PREFIX}/${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+            # Using the IMAGE_NAME env variable instead
+            IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
 
             echo "Create multi-arch manifest for $IMAGE"
             docker buildx imagetools create -t $IMAGE \

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -173,11 +173,13 @@ local weeklyImageJobs = {
         + job.withNeeds(['%s-image' % name])
         + job.withEnv({
           BUILD_TIMEOUT: imageBuildTimeoutMin,
-          IMAGE_DIGEST_AMD64: '${{ needs.%(name)s-image.outputs.image_digest_linux_amd64 }}' % name,
-          IMAGE_DIGEST_ARM64: '${{ needs.%(name)s-image.outputs.image_digest_linux_arm64 }}' % name,
-          IMAGE_DIGEST_ARM: '${{ needs.%(name)s-image.outputs.image_digest_linux_arm }}' % name,
-          OUTPUTS_IMAGE_NAME: '${{ needs.%(name)s-image.outputs.image_name }}' % name,
-          OUTPUTS_IMAGE_TAG: '${{ needs.%(name)s-image.outputs.image_tag }}' % name,
+          IMAGE_DIGEST_AMD64: '${{ needs.%s-image.outputs.image_digest_linux_amd64 }}' % name,
+          IMAGE_DIGEST_ARM64: '${{ needs.%s-image.outputs.image_digest_linux_arm64 }}' % name,
+          IMAGE_DIGEST_ARM: '${{ needs.%s-image.outputs.image_digest_linux_arm }}' % name,
+          OUTPUTS_IMAGE_NAME: '${{ needs.%s-image.outputs.image_name }}' % name,
+          OUTPUTS_IMAGE_TAG: '${{ needs.%s-image.outputs.image_tag }}' % name,
+          IMAGE_PREFIX: weeklyImagePrefix,
+          IMAGE_NAME: name,
         })
         + job.withSteps([
           step.new('Set up Docker buildx', 'docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2'),  // v3
@@ -190,14 +192,19 @@ local weeklyImageJobs = {
             echo "linux/arm64 $IMAGE_DIGEST_ARM64"
             echo "linux/amd64 $IMAGE_DIGEST_AMD64"
             echo "linux/arm   $IMAGE_DIGEST_ARM"
-            IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+
+            # 'needs.%(name)s-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
+            # See https://github.com/actions/runner/issues/2316
+            # Using the IMAGE_PREFIX and IMAGE_NAME env variables instead
+            IMAGE="${IMAGE_PREFIX}/${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+
             echo "Create multi-arch manifest for $IMAGE"
             docker buildx imagetools create -t $IMAGE \
-              ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
-              ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
-              ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+              ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+              ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+              ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
             docker buildx imagetools inspect $IMAGE
-          ||| % { name: '%s-image' % name }),
+          ||| % { name: name }),
         ])
       for name in std.objectFields(weeklyImageJobs)
     } + {

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -111,8 +111,7 @@
       "IMAGE_DIGEST_AMD64": "${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_amd64 }}"
       "IMAGE_DIGEST_ARM": "${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm }}"
       "IMAGE_DIGEST_ARM64": "${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm64 }}"
-      "IMAGE_NAME": "loki-canary-boringcrypto"
-      "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod"
+      "IMAGE_NAME": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod/loki-canary-boringcrypto"
       "OUTPUTS_IMAGE_NAME": "${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}"
       "OUTPUTS_IMAGE_TAG": "${{ needs.loki-canary-boringcrypto-image.outputs.image_tag }}"
     "needs":
@@ -139,8 +138,8 @@
         
         # 'needs.loki-canary-boringcrypto-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
         # See https://github.com/actions/runner/issues/2316
-        # Using the IMAGE_PREFIX and IMAGE_NAME env variables instead
-        IMAGE="${IMAGE_PREFIX}/${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        # Using the IMAGE_NAME env variable instead
+        IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
         
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
@@ -252,8 +251,7 @@
       "IMAGE_DIGEST_AMD64": "${{ needs.loki-canary-image.outputs.image_digest_linux_amd64 }}"
       "IMAGE_DIGEST_ARM": "${{ needs.loki-canary-image.outputs.image_digest_linux_arm }}"
       "IMAGE_DIGEST_ARM64": "${{ needs.loki-canary-image.outputs.image_digest_linux_arm64 }}"
-      "IMAGE_NAME": "loki-canary"
-      "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod"
+      "IMAGE_NAME": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod/loki-canary"
       "OUTPUTS_IMAGE_NAME": "${{ needs.loki-canary-image.outputs.image_name }}"
       "OUTPUTS_IMAGE_TAG": "${{ needs.loki-canary-image.outputs.image_tag }}"
     "needs":
@@ -280,8 +278,8 @@
         
         # 'needs.loki-canary-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
         # See https://github.com/actions/runner/issues/2316
-        # Using the IMAGE_PREFIX and IMAGE_NAME env variables instead
-        IMAGE="${IMAGE_PREFIX}/${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        # Using the IMAGE_NAME env variable instead
+        IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
         
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
@@ -393,8 +391,7 @@
       "IMAGE_DIGEST_AMD64": "${{ needs.loki-image.outputs.image_digest_linux_amd64 }}"
       "IMAGE_DIGEST_ARM": "${{ needs.loki-image.outputs.image_digest_linux_arm }}"
       "IMAGE_DIGEST_ARM64": "${{ needs.loki-image.outputs.image_digest_linux_arm64 }}"
-      "IMAGE_NAME": "loki"
-      "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod"
+      "IMAGE_NAME": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod/loki"
       "OUTPUTS_IMAGE_NAME": "${{ needs.loki-image.outputs.image_name }}"
       "OUTPUTS_IMAGE_TAG": "${{ needs.loki-image.outputs.image_tag }}"
     "needs":
@@ -421,8 +418,8 @@
         
         # 'needs.loki-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
         # See https://github.com/actions/runner/issues/2316
-        # Using the IMAGE_PREFIX and IMAGE_NAME env variables instead
-        IMAGE="${IMAGE_PREFIX}/${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        # Using the IMAGE_NAME env variable instead
+        IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
         
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
@@ -534,8 +531,7 @@
       "IMAGE_DIGEST_AMD64": "${{ needs.querytee-image.outputs.image_digest_linux_amd64 }}"
       "IMAGE_DIGEST_ARM": "${{ needs.querytee-image.outputs.image_digest_linux_arm }}"
       "IMAGE_DIGEST_ARM64": "${{ needs.querytee-image.outputs.image_digest_linux_arm64 }}"
-      "IMAGE_NAME": "querytee"
-      "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod"
+      "IMAGE_NAME": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod/querytee"
       "OUTPUTS_IMAGE_NAME": "${{ needs.querytee-image.outputs.image_name }}"
       "OUTPUTS_IMAGE_TAG": "${{ needs.querytee-image.outputs.image_tag }}"
     "needs":
@@ -562,8 +558,8 @@
         
         # 'needs.querytee-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
         # See https://github.com/actions/runner/issues/2316
-        # Using the IMAGE_PREFIX and IMAGE_NAME env variables instead
-        IMAGE="${IMAGE_PREFIX}/${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        # Using the IMAGE_NAME env variable instead
+        IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
         
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -111,6 +111,8 @@
       "IMAGE_DIGEST_AMD64": "${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_amd64 }}"
       "IMAGE_DIGEST_ARM": "${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm }}"
       "IMAGE_DIGEST_ARM64": "${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm64 }}"
+      "IMAGE_NAME": "loki-canary-boringcrypto"
+      "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod"
       "OUTPUTS_IMAGE_NAME": "${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}"
       "OUTPUTS_IMAGE_TAG": "${{ needs.loki-canary-boringcrypto-image.outputs.image_tag }}"
     "needs":
@@ -134,12 +136,17 @@
         echo "linux/arm64 $IMAGE_DIGEST_ARM64"
         echo "linux/amd64 $IMAGE_DIGEST_AMD64"
         echo "linux/arm   $IMAGE_DIGEST_ARM"
-        IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
+        # 'needs.loki-canary-boringcrypto-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
+        # See https://github.com/actions/runner/issues/2316
+        # Using the IMAGE_PREFIX and IMAGE_NAME env variables instead
+        IMAGE="${IMAGE_PREFIX}/${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
   "loki-canary-image":
     "env":
@@ -245,6 +252,8 @@
       "IMAGE_DIGEST_AMD64": "${{ needs.loki-canary-image.outputs.image_digest_linux_amd64 }}"
       "IMAGE_DIGEST_ARM": "${{ needs.loki-canary-image.outputs.image_digest_linux_arm }}"
       "IMAGE_DIGEST_ARM64": "${{ needs.loki-canary-image.outputs.image_digest_linux_arm64 }}"
+      "IMAGE_NAME": "loki-canary"
+      "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod"
       "OUTPUTS_IMAGE_NAME": "${{ needs.loki-canary-image.outputs.image_name }}"
       "OUTPUTS_IMAGE_TAG": "${{ needs.loki-canary-image.outputs.image_tag }}"
     "needs":
@@ -268,12 +277,17 @@
         echo "linux/arm64 $IMAGE_DIGEST_ARM64"
         echo "linux/amd64 $IMAGE_DIGEST_AMD64"
         echo "linux/arm   $IMAGE_DIGEST_ARM"
-        IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
+        # 'needs.loki-canary-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
+        # See https://github.com/actions/runner/issues/2316
+        # Using the IMAGE_PREFIX and IMAGE_NAME env variables instead
+        IMAGE="${IMAGE_PREFIX}/${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
   "loki-image":
     "env":
@@ -379,6 +393,8 @@
       "IMAGE_DIGEST_AMD64": "${{ needs.loki-image.outputs.image_digest_linux_amd64 }}"
       "IMAGE_DIGEST_ARM": "${{ needs.loki-image.outputs.image_digest_linux_arm }}"
       "IMAGE_DIGEST_ARM64": "${{ needs.loki-image.outputs.image_digest_linux_arm64 }}"
+      "IMAGE_NAME": "loki"
+      "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod"
       "OUTPUTS_IMAGE_NAME": "${{ needs.loki-image.outputs.image_name }}"
       "OUTPUTS_IMAGE_TAG": "${{ needs.loki-image.outputs.image_tag }}"
     "needs":
@@ -402,12 +418,17 @@
         echo "linux/arm64 $IMAGE_DIGEST_ARM64"
         echo "linux/amd64 $IMAGE_DIGEST_AMD64"
         echo "linux/arm   $IMAGE_DIGEST_ARM"
-        IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
+        # 'needs.loki-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
+        # See https://github.com/actions/runner/issues/2316
+        # Using the IMAGE_PREFIX and IMAGE_NAME env variables instead
+        IMAGE="${IMAGE_PREFIX}/${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
   "querytee-image":
     "env":
@@ -513,6 +534,8 @@
       "IMAGE_DIGEST_AMD64": "${{ needs.querytee-image.outputs.image_digest_linux_amd64 }}"
       "IMAGE_DIGEST_ARM": "${{ needs.querytee-image.outputs.image_digest_linux_arm }}"
       "IMAGE_DIGEST_ARM64": "${{ needs.querytee-image.outputs.image_digest_linux_arm64 }}"
+      "IMAGE_NAME": "querytee"
+      "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod"
       "OUTPUTS_IMAGE_NAME": "${{ needs.querytee-image.outputs.image_name }}"
       "OUTPUTS_IMAGE_TAG": "${{ needs.querytee-image.outputs.image_tag }}"
     "needs":
@@ -536,12 +559,17 @@
         echo "linux/arm64 $IMAGE_DIGEST_ARM64"
         echo "linux/amd64 $IMAGE_DIGEST_AMD64"
         echo "linux/arm   $IMAGE_DIGEST_ARM"
-        IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
+        # 'needs.querytee-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
+        # See https://github.com/actions/runner/issues/2316
+        # Using the IMAGE_PREFIX and IMAGE_NAME env variables instead
+        IMAGE="${IMAGE_PREFIX}/${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
   "trigger-cd":
     "env":


### PR DESCRIPTION
### Summary

The manifest-{name} step relies on the output `image_name` from the {name}-image job. However, this output (containing GAR the registry name) is incorrectly detected as a secret and therefore masked and not available in another job, see https://github.com/grafana/loki/actions/runs/26562695694/job/78251467354#step:6:19

See also https://github.com/actions/runner/issues/2316

This commit changes the manifest job to rely on env variables directly provided by the workflow library.
