### PR TITLE
chore: Upload release artifacts to generic GAR

### DIFF
--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -110,7 +110,7 @@ jobs:
           --target-branch "$(echo $OUTPUTS_BRANCH | tr -d '"')" \
           --token "$(echo $OUTPUTS_TOKEN | tr -d '"')" \
           --dry-run ${{ fromJSON(env.DRY_RUN) }}
-        
+
       working-directory: "lib"
   dist:
     needs:
@@ -231,7 +231,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -309,7 +309,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -387,7 +387,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -472,7 +472,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -550,7 +550,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -634,7 +634,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -718,7 +718,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -803,7 +803,7 @@ jobs:
       run: |
         mkdir -p images
         mkdir -p plugins
-        
+
         platform="$(echo "${{ matrix.arch}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -900,7 +900,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -984,7 +984,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -1090,7 +1090,7 @@ jobs:
       name: "get release version"
       run: |
         yarn install
-        
+
         if [[ -z "${{ env.RELEASE_AS }}" ]]; then
           yarn exec -- release-please release-pr \
             --consider-all-branches \
@@ -1120,16 +1120,16 @@ jobs:
             --token "$OUTPUTS_TOKEN" \
             --release-as "${{ env.RELEASE_AS }}"
         fi
-        
+
         cat release.json
-        
-        if [[ `jq length release.json` -gt 1 ]]; then 
+
+        if [[ `jq length release.json` -gt 1 ]]; then
           echo 'release-please would create more than 1 PR, so cannot determine correct version'
           echo "pr_created=false" >> $GITHUB_OUTPUT
           exit 1
         fi
-        
-        if [[ `jq length release.json` -eq 0 ]]; then 
+
+        if [[ `jq length release.json` -eq 0 ]]; then
           echo "pr_created=false" >> $GITHUB_OUTPUT
         else
           version="$(yarn run --silent get-version)"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -182,7 +182,7 @@ jobs:
       working-directory: "release"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -194,7 +194,7 @@ jobs:
           --repository="generic-loki-dev" \
           --location="us" \
           --source-directory=${{env.path}} \
-          --package=${{ github.sha }} \
+          --package=binaries \
           --version=${{ github.sha }}
       env:
         path: "release/dist"
@@ -251,7 +251,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/fluent-bit-plugin-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -263,7 +263,7 @@ jobs:
           --repository="generic-loki-dev" \
           --location="us" \
           --source=${{env.path}} \
-          --package=${{ github.sha }} \
+          --package=images \
           --version=${{ github.sha }}
       env:
         path: "release/images/fluent-bit-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -329,7 +329,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/fluent-plugin-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -341,7 +341,7 @@ jobs:
           --repository="generic-loki-dev" \
           --location="us" \
           --source=${{env.path}} \
-          --package=${{ github.sha }} \
+          --package=images \
           --version=${{ github.sha }}
       env:
         path: "release/images/fluent-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -407,7 +407,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/logcli:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -419,7 +419,7 @@ jobs:
           --repository="generic-loki-dev" \
           --location="us" \
           --source=${{env.path}} \
-          --package=${{ github.sha }} \
+          --package=images \
           --version=${{ github.sha }}
       env:
         path: "release/images/logcli-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -492,7 +492,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/logstash-output-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -504,7 +504,7 @@ jobs:
           --repository="generic-loki-dev" \
           --location="us" \
           --source=${{env.path}} \
-          --package=${{ github.sha }} \
+          --package=images \
           --version=${{ github.sha }}
       env:
         path: "release/images/logstash-output-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -570,7 +570,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -582,7 +582,7 @@ jobs:
           --repository="generic-loki-dev" \
           --location="us" \
           --source=${{env.path}} \
-          --package=${{ github.sha }} \
+          --package=images \
           --version=${{ github.sha }}
       env:
          path: "release/images/loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -654,7 +654,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/loki-canary:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -666,7 +666,7 @@ jobs:
           --repository="generic-loki-dev" \
           --location="us" \
           --source=${{env.path}} \
-          --package=${{ github.sha }} \
+          --package=images \
           --version=${{ github.sha }}
       env:
         path: "release/images/loki-canary-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -738,7 +738,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -750,7 +750,7 @@ jobs:
           --repository="generic-loki-dev" \
           --location="us" \
           --source=${{env.path}} \
-          --package=${{ github.sha }} \
+          --package=images \
           --version=${{ github.sha }}
       env:
        path: "release/images/loki-canary-boringcrypto-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -839,7 +839,7 @@ jobs:
         .
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -851,7 +851,7 @@ jobs:
           --repository="generic-loki-dev" \
           --location="us" \
           --source=${{env.path}} \
-          --package=${{ github.sha }} \
+          --package=plugins \
           --version=${{ github.sha }}
       env:
         path: "release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -920,7 +920,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/loki-helm-test:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -932,7 +932,7 @@ jobs:
           --repository="generic-loki-dev" \
           --location="us" \
           --source=${{env.path}} \
-          --package=${{ github.sha }} \
+          --package=images \
           --version=${{ github.sha }}
       env:
         path: "release/images/loki-helm-test-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
@@ -1004,7 +1004,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/loki-query-tee:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -1016,7 +1016,7 @@ jobs:
           --repository="generic-loki-dev" \
           --location="us" \
           --source=${{env.path}} \
-          --package=${{ github.sha }} \
+          --package=images \
           --version=${{ github.sha }}
       env:
         path: "release/images/loki-query-tee-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -129,15 +129,6 @@ jobs:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Cloud SDK"
       uses: "google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a"
       with:
@@ -190,12 +181,23 @@ jobs:
         EOF
       working-directory: "release"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}"
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source-directory=${{env.path}} \
+          --package=${{ github.sha }} \
+          --version=${{ github.sha }}
+      env:
         path: "release/dist"
-        process_gcloudignore: false
   fluent-bit:
     needs:
     - "version"
@@ -223,17 +225,6 @@ jobs:
       with:
         node-version: 24
         package-manager-cache: false
-    - name: "enable corepack"
-      run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -259,12 +250,23 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/fluent-bit-plugin-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=${{ github.sha }} \
+          --version=${{ github.sha }}
+      env:
         path: "release/images/fluent-bit-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
     strategy:
       fail-fast: true
       matrix:
@@ -301,15 +303,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -335,12 +328,23 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/fluent-plugin-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=${{ github.sha }} \
+          --version=${{ github.sha }}
+      env:
         path: "release/images/fluent-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
     strategy:
       fail-fast: true
       matrix:
@@ -377,15 +381,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -411,12 +406,24 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/logcli:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=${{ github.sha }} \
+          --version=${{ github.sha }}
+      env:
         path: "release/images/logcli-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+
     strategy:
       fail-fast: true
       matrix:
@@ -459,15 +466,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -493,12 +491,23 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/logstash-output-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=${{ github.sha }} \
+          --version=${{ github.sha }}
+      env:
         path: "release/images/logstash-output-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
     strategy:
       fail-fast: true
       matrix:
@@ -535,15 +544,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -569,12 +569,23 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=${{ github.sha }} \
+          --version=${{ github.sha }}
+      env:
+         path: "release/images/loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
     strategy:
       fail-fast: true
       matrix:
@@ -617,15 +628,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -651,12 +653,23 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-canary:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=${{ github.sha }} \
+          --version=${{ github.sha }}
+      env:
         path: "release/images/loki-canary-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
     strategy:
       fail-fast: true
       matrix:
@@ -699,15 +712,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -733,12 +737,23 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/loki-canary-boringcrypto-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=${{ github.sha }} \
+          --version=${{ github.sha }}
+      env:
+       path: "release/images/loki-canary-boringcrypto-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
     strategy:
       fail-fast: true
       matrix:
@@ -779,15 +794,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392"
     - name: "set up docker buildx"
@@ -832,12 +838,23 @@ jobs:
         -C release/plugins/loki-docker-driver-${OUTPUTS_VERSION}-${OUTPUTS_PLATFORM} \
         .
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/plugins"
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=${{ github.sha }} \
+          --version=${{ github.sha }}
+      env:
         path: "release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
     strategy:
       fail-fast: true
       matrix:
@@ -877,15 +894,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -911,12 +919,23 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-helm-test:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=${{ github.sha }} \
+          --version=${{ github.sha }}
+      env:
         path: "release/images/loki-helm-test-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
     strategy:
       fail-fast: true
       matrix:
@@ -959,15 +978,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -993,12 +1003,23 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-query-tee:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=${{ github.sha }} \
+          --version=${{ github.sha }}
+      env:
         path: "release/images/loki-query-tee-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -178,7 +178,7 @@ jobs:
       working-directory: "release"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -249,7 +249,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/fluent-bit-plugin-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -327,7 +327,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/fluent-plugin-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -405,7 +405,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/logcli:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -489,7 +489,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/logstash-output-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -567,7 +567,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -651,7 +651,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/loki-canary:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -735,7 +735,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -836,7 +836,7 @@ jobs:
         .
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -917,7 +917,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/loki-helm-test:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -1001,7 +1001,7 @@ jobs:
         tags: "${{ env.IMAGE_PREFIX }}/loki-query-tee:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -129,19 +129,6 @@ jobs:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up Cloud SDK"
-      uses: "google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a"
-      with:
-        version: ">= 452.0.0"
     - env:
         BUILD_IN_CONTAINER: false
         DRONE_TAG: "${{ needs.version.outputs.version }}"
@@ -190,12 +177,23 @@ jobs:
         EOF
       working-directory: "release"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}"
-        path: "release/dist"
-        process_gcloudignore: false
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source-directory=${{env.path}} \
+          --package=binaries \
+          --version=${{ github.sha }}
+      env:        
+       path: "release/dist"
   fluent-bit:
     needs:
     - "version"
@@ -225,15 +223,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -259,12 +248,23 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/fluent-bit-plugin-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=images \
+          --version=${{ github.sha }}
+      env:
         path: "release/images/fluent-bit-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
     strategy:
       fail-fast: true
       matrix:
@@ -301,15 +301,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -335,12 +326,23 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/fluent-plugin-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/fluent-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=images \
+          --version=${{ github.sha }}
+      env:
+         path: "release/images/fluent-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
     strategy:
       fail-fast: true
       matrix:
@@ -377,15 +379,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -411,12 +404,23 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/logcli:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=images \
+          --version=${{ github.sha }}
+      env:
         path: "release/images/logcli-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
     strategy:
       fail-fast: true
       matrix:
@@ -459,15 +463,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -493,12 +488,23 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/logstash-output-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=images \
+          --version=${{ github.sha }}
+      env:
         path: "release/images/logstash-output-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
     strategy:
       fail-fast: true
       matrix:
@@ -535,15 +541,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -569,12 +566,23 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=images \
+          --version=${{ github.sha }}
+      env:
         path: "release/images/loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
     strategy:
       fail-fast: true
       matrix:
@@ -617,15 +625,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -651,12 +650,23 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-canary:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=images \
+          --version=${{ github.sha }}
+      env:
         path: "release/images/loki-canary-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
     strategy:
       fail-fast: true
       matrix:
@@ -699,15 +709,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -733,12 +734,23 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=images \
+          --version=${{ github.sha }}
+      env:
         path: "release/images/loki-canary-boringcrypto-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
     strategy:
       fail-fast: true
       matrix:
@@ -779,15 +791,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392"
     - name: "set up docker buildx"
@@ -832,12 +835,23 @@ jobs:
         -C release/plugins/loki-docker-driver-${OUTPUTS_VERSION}-${OUTPUTS_PLATFORM} \
         .
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/plugins"
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=plugins \
+          --version=${{ github.sha }}
+      env:
         path: "release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
     strategy:
       fail-fast: true
       matrix:
@@ -877,15 +891,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -911,12 +916,23 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-helm-test:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/loki-helm-test-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=images \
+          --version=${{ github.sha }}
+      env:
+         path: "release/images/loki-helm-test-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
     strategy:
       fail-fast: true
       matrix:
@@ -959,15 +975,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -993,12 +1000,23 @@ jobs:
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-query-tee:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
     - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=images \
+          --version=${{ github.sha }}
+      env:
         path: "release/images/loki-query-tee-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -110,7 +110,7 @@ jobs:
           --target-branch "$(echo $OUTPUTS_BRANCH | tr -d '"')" \
           --token "$(echo $OUTPUTS_TOKEN | tr -d '"')" \
           --dry-run ${{ fromJSON(env.DRY_RUN) }}
-        
+
       working-directory: "lib"
   dist:
     needs:
@@ -192,7 +192,7 @@ jobs:
           --source-directory=${{env.path}} \
           --package=binaries \
           --version=${{ github.sha }}
-      env:        
+      env:
        path: "release/dist"
   fluent-bit:
     needs:
@@ -229,7 +229,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -307,7 +307,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -385,7 +385,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -469,7 +469,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -547,7 +547,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -631,7 +631,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -715,7 +715,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -800,7 +800,7 @@ jobs:
       run: |
         mkdir -p images
         mkdir -p plugins
-        
+
         platform="$(echo "${{ matrix.arch}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -897,7 +897,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -981,7 +981,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-        
+
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -1087,7 +1087,7 @@ jobs:
       name: "get release version"
       run: |
         yarn install
-        
+
         if [[ -z "${{ env.RELEASE_AS }}" ]]; then
           yarn exec -- release-please release-pr \
             --consider-all-branches \
@@ -1117,16 +1117,16 @@ jobs:
             --token "$OUTPUTS_TOKEN" \
             --release-as "${{ env.RELEASE_AS }}"
         fi
-        
+
         cat release.json
-        
-        if [[ `jq length release.json` -gt 1 ]]; then 
+
+        if [[ `jq length release.json` -gt 1 ]]; then
           echo 'release-please would create more than 1 PR, so cannot determine correct version'
           echo "pr_created=false" >> $GITHUB_OUTPUT
           exit 1
         fi
-        
-        if [[ `jq length release.json` -eq 0 ]]; then 
+
+        if [[ `jq length release.json` -eq 0 ]]; then
           echo "pr_created=false" >> $GITHUB_OUTPUT
         else
           version="$(yarn run --silent get-version)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           echo "token=${{ secrets.GH_TOKEN }}" >> $GITHUB_OUTPUT
         fi
     - name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -126,7 +126,7 @@ jobs:
       working-directory: "release"
     - if: "${{ fromJSON(env.PUBLISH_TO_GCS) }}"
       name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -260,7 +260,7 @@ jobs:
     - name: "Login to DockerHub (from vault)"
       uses: "grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25"
     - name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
@@ -306,7 +306,7 @@ jobs:
     - name: "Login to DockerHub (from vault)"
       uses: "grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25"
     - name: "Setup Google Auth"
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         project_id: grafanalabs-workload-identity
         workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,19 +47,6 @@ jobs:
         package-manager-cache: false
     - name: "enable corepack"
       run: "corepack enable"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up Cloud SDK"
-      uses: "google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a"
-      with:
-        version: ">= 452.0.0"
     - id: "get_github_app_token"
       if: "${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}"
       name: "get github app token"
@@ -76,10 +63,21 @@ jobs:
         else
           echo "token=${{ secrets.GH_TOKEN }}" >> $GITHUB_OUTPUT
         fi
+    - name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
+      with:
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
     - name: "download binaries"
       run: |
         echo "downloading binaries to $(pwd)/dist"
-        gsutil cp -r gs://${BUILD_ARTIFACTS_BUCKET}/$(echo ${SHA} | tr -d '"')/dist .
+        gcloud artifacts generic download \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --package=binaries \
+          --version=${{ github.sha }} \
+          --destintion=dist/
       working-directory: "release"
     - env:
         GH_TOKEN: "${{ steps.github_app_token.outputs.token }}"
@@ -127,13 +125,23 @@ jobs:
         gh release upload --clobber $(echo $OUTPUTS_NAME | tr -d '"') dist/*
       working-directory: "release"
     - if: "${{ fromJSON(env.PUBLISH_TO_GCS) }}"
-      name: "release artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
+      name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
       with:
-        destination: "${{ env.PUBLISH_BUCKET }}"
-        parent: false
-        path: "release/dist"
-        process_gcloudignore: false
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+    - if: "${{ fromJSON(env.PUBLISH_TO_GCS) }}"
+      name: "Upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-global" \
+          --repository="generic-loki-prod" \
+          --location="us" \
+          --source-directory=${{env.path}} \
+          --package=binaries \
+          --version=${{ github.sha }}
+      env:
+       path: "release/dist"
   createReleaseBranch:
     needs:
     - "publishRelease"
@@ -245,31 +253,29 @@ jobs:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up Cloud SDK"
-      uses: "google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a"
-      with:
-        version: ">= 452.0.0"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392"
     - name: "set up docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - name: "Login to DockerHub (from vault)"
       uses: "grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25"
+    - name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
+      with:
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
     - env:
         SHA: "${{ needs.createRelease.outputs.sha }}"
       name: "download and prepare plugins"
       run: |
         echo "downloading images to $(pwd)/plugins"
-        gsutil cp -r gs://${BUILD_ARTIFACTS_BUCKET}/$(echo ${SHA} | tr -d '"')/plugins .
+        gcloud artifacts generic download \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --package=plugins \
+          --version=${{ github.sha }} \
+          --destintion=plugins/ 
         mkdir -p "release/clients/cmd/docker-driver"
     - name: "publish docker driver"
       uses: "./lib/actions/push-images"
@@ -293,31 +299,29 @@ jobs:
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up Cloud SDK"
-      uses: "google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a"
-      with:
-        version: ">= 452.0.0"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392"
     - name: "set up docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - name: "Login to DockerHub (from vault)"
       uses: "grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25"
+    - name: "Setup Google Auth"
+      uses: google-github-actions/auth@v2
+      with:
+        project_id: grafanalabs-workload-identity
+        workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
     - env:
         SHA: "${{ needs.createRelease.outputs.sha }}"
       name: "download images"
       run: |
         echo "downloading images to $(pwd)/images"
-        gsutil cp -r gs://${BUILD_ARTIFACTS_BUCKET}/$(echo ${SHA} | tr -d '"')/images .
+        gcloud artifacts generic download \
+          --project="grafanalabs-dev" \
+          --repository="generic-loki-dev" \
+          --location="us" \
+          --package=images \
+          --version=${{ github.sha }} \
+          --destintion=images/ 
     - name: "publish docker images"
       uses: "./lib/actions/push-images"
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
         else
           echo "exists=true" >> $GITHUB_OUTPUT
         fi
-        
+
         if [[ "$isDraft" == "true" ]]; then
           echo "draft=true" >> $GITHUB_OUTPUT
         fi
@@ -191,27 +191,27 @@ jobs:
       run: |
         # Debug and clean the version variable
         echo "Original VERSION: $VERSION"
-        
+
         # Remove all quotes (both single and double)
         VERSION=$(echo $VERSION | tr -d '"' | tr -d "'")
         echo "After removing quotes: $VERSION"
-        
+
         # Extract version without the 'v' prefix if it exists
         VERSION="${VERSION#v}"
         echo "After removing v prefix: $VERSION"
-        
+
         # Extract major and minor versions
         MAJOR=$(echo $VERSION | cut -d. -f1)
         MINOR=$(echo $VERSION | cut -d. -f2)
         echo "MAJOR: $MAJOR, MINOR: $MINOR"
-        
+
         # Create branch name from template
         BRANCH_TEMPLATE="release-\${major}.\${minor}.x"
         BRANCH_NAME=${BRANCH_TEMPLATE//\$\{major\}/$MAJOR}
         BRANCH_NAME=${BRANCH_NAME//\$\{minor\}/$MINOR}
-        
+
         echo "Checking if branch already exists: $BRANCH_NAME"
-        
+
         # Check if branch exists
         if git ls-remote --heads origin $BRANCH_NAME | grep -q $BRANCH_NAME; then
           echo "Branch $BRANCH_NAME already exists, skipping creation"
@@ -219,16 +219,16 @@ jobs:
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
         else
           echo "Creating branch: $BRANCH_NAME from tag: $(echo $OUTPUTS_NAME | tr -d '"')"
-          
+
           # Create branch from the tag
           git fetch --tags
           git checkout "$(echo $OUTPUTS_BRANCH | tr -d '"')"
           git checkout -b $BRANCH_NAME
-        
+
           # explicity set the github app token to override the release branch protection
           git remote set-url origin "https://x-access-token:$(echo ${OUTPUTS_TOKEN} | tr -d '"')@github.com/${{ env.RELEASE_REPO }}"
           git push -u origin $BRANCH_NAME
-          
+
           echo "branch_exists=false" >> $GITHUB_OUTPUT
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
         fi
@@ -275,7 +275,7 @@ jobs:
           --location="us" \
           --package=plugins \
           --version=${{ github.sha }} \
-          --destintion=plugins/ 
+          --destintion=plugins/
         mkdir -p "release/clients/cmd/docker-driver"
     - name: "publish docker driver"
       uses: "./lib/actions/push-images"
@@ -321,7 +321,7 @@ jobs:
           --location="us" \
           --package=images \
           --version=${{ github.sha }} \
-          --destintion=images/ 
+          --destintion=images/
     - name: "publish docker images"
       uses: "./lib/actions/push-images"
       with:


### PR DESCRIPTION
**What this PR does / why we need it**:
Use generic GAR to publish release artifacts instead of Cloud Storage (loki binaries and docker tarballs)
Update release to read from GAR instead of GCS
Remove the use of hard-coded credential files for Google Cloud operations in these files.
