### PR TITLE
ci: Regenerate images.yml for logql-analyzer manifest

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -10,9 +10,9 @@
   "logql-analyzer-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.26.2"
+      "GO_VERSION": "1.26.3"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod"
-      "RELEASE_LIB_REF": "781f67f5e65569df4c97b98c1f671b27857f5684"
+      "RELEASE_LIB_REF": "ad39d2f109c6608c419d7abc42d5550d741870a7"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -49,6 +49,8 @@
       "run": "corepack enable"
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
+    - "name": "Login to DockerHub"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7"
     - "name": "Login to GAR"
       "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
       "with":
@@ -109,6 +111,7 @@
       "IMAGE_DIGEST_AMD64": "${{ needs.logql-analyzer-image.outputs.image_digest_linux_amd64 }}"
       "IMAGE_DIGEST_ARM": "${{ needs.logql-analyzer-image.outputs.image_digest_linux_arm }}"
       "IMAGE_DIGEST_ARM64": "${{ needs.logql-analyzer-image.outputs.image_digest_linux_arm64 }}"
+      "IMAGE_NAME": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod/logql-analyzer"
       "OUTPUTS_IMAGE_NAME": "${{ needs.logql-analyzer-image.outputs.image_name }}"
       "OUTPUTS_IMAGE_TAG": "${{ needs.logql-analyzer-image.outputs.image_tag }}"
     "needs":
@@ -120,6 +123,8 @@
     "steps":
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
+    - "name": "Login to DockerHub"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7"
     - "name": "Login to GAR"
       "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
       "with":
@@ -130,12 +135,17 @@
         echo "linux/arm64 $IMAGE_DIGEST_ARM64"
         echo "linux/amd64 $IMAGE_DIGEST_AMD64"
         echo "linux/arm   $IMAGE_DIGEST_ARM"
-        IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
+        # 'needs.logql-analyzer-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
+        # See https://github.com/actions/runner/issues/2316
+        # Using the IMAGE_NAME env variable instead
+        IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
   "loki-canary-boringcrypto-image":
     "env":


### PR DESCRIPTION
**What this PR does**: regenerates `.github/workflows/images.yml` so the `logql-analyzer-manifest` job picks up the secret-masking workaround from #22049 (`IMAGE_NAME` env var instead of `OUTPUTS_IMAGE_NAME`).

#22026 added the `logql-analyzer` weekly image and #22049 changed the manifest template, but #22026 was generated against the old template, so `logql-analyzer-manifest` shipped to `main` with the broken pattern. Without this fix, every weekly run would fail at `docker buildx imagetools create -t :tag ...` because `${{ needs.logql-analyzer-image.outputs.image_name }}` gets masked as a secret and renders empty.

No source jsonnet changes — pure regeneration. Also picks up the GO_VERSION bump to 1.26.3 and the new `Login to DockerHub` step that landed in the meantime.