### PR TITLE
chore: Migrate yaml from gopkg.in/yaml.v2 to go.yaml.in/yaml/v4

### DIFF
--- a/clients/cmd/docker-driver/config.go
+++ b/clients/cmd/docker-driver/config.go
@@ -17,7 +17,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
-	"gopkg.in/yaml.v2"
+	yaml "go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/clients/pkg/logentry/stages"
 	clients_util "github.com/grafana/loki/v3/clients/pkg/util"
@@ -318,7 +318,9 @@ func parsePipeline(logCtx logger.Info) (PipelineConfig, error) {
 		}
 	}
 	if okString {
-		if err := yaml.UnmarshalStrict([]byte(pipelineString), &pipeline.PipelineStages); err != nil {
+		dec := yaml.NewDecoder(bytes.NewReader([]byte(pipelineString)))
+		dec.KnownFields(true)
+		if err := dec.Decode(&pipeline.PipelineStages); err != nil {
 			return pipeline, err
 		}
 	}
@@ -362,7 +364,9 @@ func parseInt(key string, logCtx logger.Info, set func(i int)) error {
 
 func relabelConfig(config string, lbs model.LabelSet) (model.LabelSet, error) {
 	relabelConfig := make([]*relabel.Config, 0)
-	if err := yaml.UnmarshalStrict([]byte(config), &relabelConfig); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader([]byte(config)))
+	dec.KnownFields(true)
+	if err := dec.Decode(&relabelConfig); err != nil {
 		return nil, err
 	}
 	// Validate relabel configs to set the validation scheme properly
@@ -397,5 +401,7 @@ func loadConfig(filename string, cfg interface{}) error {
 		return errors.Wrap(err, "Error reading config file")
 	}
 
-	return yaml.UnmarshalStrict(buf, cfg)
+	dec := yaml.NewDecoder(bytes.NewReader(buf))
+	dec.KnownFields(true)
+	return dec.Decode(cfg)
 }

--- a/clients/cmd/docker-driver/config_test.go
+++ b/clients/cmd/docker-driver/config_test.go
@@ -67,13 +67,13 @@ var pipelineString = `
 `
 var pipeline = PipelineConfig{
 	PipelineStages: []interface{}{
-		map[interface{}]interface{}{
-			"regex": map[interface{}]interface{}{
+		map[string]interface{}{
+			"regex": map[string]interface{}{
 				"expression": "(level|lvl|severity)=(?P<level>\\w+)",
 			},
 		},
-		map[interface{}]interface{}{
-			"labels": map[interface{}]interface{}{
+		map[string]interface{}{
+			"labels": map[string]interface{}{
 				"level": nil,
 			},
 		},

--- a/clients/pkg/logentry/stages/json_test.go
+++ b/clients/pkg/logentry/stages/json_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
@@ -99,10 +99,10 @@ func TestYamlMapStructure(t *testing.T) {
 	t.Parallel()
 
 	// testing that we can use yaml data into mapstructure.
-	var mapstruct map[interface{}]interface{}
+	var mapstruct map[string]interface{}
 	err := yaml.Unmarshal([]byte(cfg), &mapstruct)
 	assert.NoError(t, err, "error while un-marshalling config: %s", err)
-	p, ok := mapstruct["json"].(map[interface{}]interface{})
+	p, ok := mapstruct["json"].(map[string]interface{})
 	assert.True(t, ok, "could not read parser %+v", mapstruct["json"])
 	got, err := parseJSONConfig(p)
 	assert.NoError(t, err, "could not create parser from yaml: %s", err)

--- a/clients/pkg/logentry/stages/logfmt_test.go
+++ b/clients/pkg/logentry/stages/logfmt_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
@@ -85,9 +85,9 @@ func TestLogfmtYamlMapStructure(t *testing.T) {
 	t.Parallel()
 
 	// testing that we can use yaml data into mapstructure.
-	var mapstruct map[interface{}]interface{}
+	var mapstruct map[string]interface{}
 	assert.NoError(t, yaml.Unmarshal([]byte(testLogfmtCfg), &mapstruct))
-	p, ok := mapstruct["logfmt"].(map[interface{}]interface{})
+	p, ok := mapstruct["logfmt"].(map[string]interface{})
 	assert.True(t, ok)
 	got, err := parseLogfmtConfig(p)
 	assert.NoError(t, err)

--- a/clients/pkg/logentry/stages/pipeline.go
+++ b/clients/pkg/logentry/stages/pipeline.go
@@ -16,7 +16,7 @@ import (
 type PipelineStages = []interface{}
 
 // PipelineStage contains configuration for a single pipeline stage
-type PipelineStage = map[interface{}]interface{}
+type PipelineStage = map[string]interface{}
 
 var rateLimiter *rate.Limiter
 var rateLimiterDrop bool
@@ -49,11 +49,7 @@ func NewPipeline(logger log.Logger, stgs PipelineStages, jobName *string, regist
 		if len(stage) > 1 {
 			return nil, errors.New("pipeline stage must contain only one key")
 		}
-		for key, config := range stage {
-			name, ok := key.(string)
-			if !ok {
-				return nil, errors.New("pipeline stage key must be a string")
-			}
+		for name, config := range stage {
 			newStage, err := New(logger, jobName, name, config, registerer)
 			if err != nil {
 				return nil, errors.Wrapf(err, "invalid %s stage config", name)

--- a/clients/pkg/logentry/stages/pipeline_test.go
+++ b/clients/pkg/logentry/stages/pipeline_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/clients/pkg/util"
 

--- a/clients/pkg/logentry/stages/regex_test.go
+++ b/clients/pkg/logentry/stages/regex_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
@@ -140,11 +140,11 @@ func TestRegexMapStructure(t *testing.T) {
 	t.Parallel()
 
 	// testing that we can use yaml data into mapstructure.
-	var mapstruct map[interface{}]interface{}
+	var mapstruct map[string]interface{}
 	if err := yaml.Unmarshal([]byte(regexCfg), &mapstruct); err != nil {
 		t.Fatalf("error while un-marshalling config: %s", err)
 	}
-	p, ok := mapstruct["regex"].(map[interface{}]interface{})
+	p, ok := mapstruct["regex"].(map[string]interface{})
 	if !ok {
 		t.Fatalf("could not read parser %+v", mapstruct["regex"])
 	}

--- a/clients/pkg/logentry/stages/replace_test.go
+++ b/clients/pkg/logentry/stages/replace_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
@@ -184,11 +184,11 @@ func TestReplaceMapStructure(t *testing.T) {
 	t.Parallel()
 
 	// testing that we can use yaml data into mapstructure.
-	var mapstruct map[interface{}]interface{}
+	var mapstruct map[string]interface{}
 	if err := yaml.Unmarshal([]byte(replaceCfg), &mapstruct); err != nil {
 		t.Fatalf("error while un-marshalling config: %s", err)
 	}
-	p, ok := mapstruct["replace"].(map[interface{}]interface{})
+	p, ok := mapstruct["replace"].(map[string]interface{})
 	if !ok {
 		t.Fatalf("could not read parser %+v", mapstruct["replace"])
 	}

--- a/clients/pkg/logentry/stages/stage.go
+++ b/clients/pkg/logentry/stages/stage.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/clients/pkg/util"
 )

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	google.golang.org/api v0.276.0
 	google.golang.org/grpc v1.80.0
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 )
 

--- a/go.mod
+++ b/go.mod
@@ -292,7 +292,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
-	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
+	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	modernc.org/libc v1.72.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	golang.org/x/time v0.15.0
 	google.golang.org/api v0.276.0
 	google.golang.org/grpc v1.80.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/klog/v2 v2.140.0 // indirect
 )

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -21,7 +21,7 @@ import (
 	"github.com/grafana/dskit/multierror"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/integration/util"
 

--- a/integration/cluster/schema.go
+++ b/integration/cluster/schema.go
@@ -4,7 +4,7 @@ var (
 	tsdbShipperSchemaConfigTemplate = `
 schema_config:
   configs:
-    - from: {{.curPeriodStart}}
+    - from: "{{.curPeriodStart}}"
       store: tsdb
       object_store: filesystem
       schema: {{.schemaVer}}
@@ -15,7 +15,7 @@ schema_config:
 	additionalTSDBShipperSchemaConfigTemplate = `
 schema_config:
   configs:
-    - from: {{.additionalPeriodStart}}
+    - from: "{{.additionalPeriodStart}}"
       store: tsdb
       object_store: store-1
       schema: {{.schemaVer}}

--- a/integration/util/merger.go
+++ b/integration/util/merger.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"dario.cat/mergo"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 )
 
 // YAMLMerger takes a set of given YAML fragments and merges them into a single YAML document.

--- a/integration/util/merger.go
+++ b/integration/util/merger.go
@@ -22,7 +22,7 @@ func (m *YAMLMerger) AddFragment(fragment []byte) {
 }
 
 func (m *YAMLMerger) Merge() ([]byte, error) {
-	merged := make(map[interface{}]interface{})
+	merged := make(map[string]interface{})
 	for _, fragment := range m.fragments {
 		fragmentMap, err := yamlToMap(fragment)
 		if err != nil {
@@ -43,7 +43,7 @@ func (m *YAMLMerger) Merge() ([]byte, error) {
 }
 
 func yamlToMap(fragment []byte) (interface{}, error) {
-	var fragmentMap map[interface{}]interface{}
+	var fragmentMap map[string]interface{}
 
 	err := yaml.Unmarshal(fragment, &fragmentMap)
 	if err != nil {

--- a/operator/internal/manifests/internal/rules/marshal.go
+++ b/operator/internal/manifests/internal/rules/marshal.go
@@ -2,7 +2,7 @@ package rules
 
 import (
 	"github.com/ViaQ/logerr/v2/kverrors"
-	"go.yaml.in/yaml/v4"
+	"gopkg.in/yaml.v2"
 
 	lokiv1 "github.com/grafana/loki/operator/api/loki/v1"
 )

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -14,7 +14,7 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/logcli/client"
 	"github.com/grafana/loki/v3/pkg/logcli/output"
@@ -566,7 +566,7 @@ func LoadSchemaUsingObjectClient(oc chunk.ObjectClient, name string) (*config.Sc
 	defer rdr.Close()
 
 	decoder := yaml.NewDecoder(rdr)
-	decoder.SetStrict(true)
+	decoder.KnownFields(true)
 	section := schemaConfigSection{}
 	err = decoder.Decode(&section)
 	if err != nil {

--- a/pkg/loghttp/push/otlplabels/config.go
+++ b/pkg/loghttp/push/otlplabels/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/prometheus/model/relabel"
+	yaml "go.yaml.in/yaml/v4"
 )
 
 // Action is the action to be performed on OTLP Resource Attribute.
@@ -131,9 +132,9 @@ type AttributesConfig struct {
 	Regex      relabel.Regexp `yaml:"regex" json:"regex" doc:"description=Regex to choose attributes to configure how to store them or drop them altogether"`
 }
 
-func (c *AttributesConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *AttributesConfig) UnmarshalYAML(value *yaml.Node) error {
 	type plain AttributesConfig
-	if err := unmarshal((*plain)(c)); err != nil {
+	if err := value.Decode((*plain)(c)); err != nil {
 		return err
 	}
 

--- a/pkg/loghttp/push/otlplabels/config_test.go
+++ b/pkg/loghttp/push/otlplabels/config_test.go
@@ -1,12 +1,13 @@
 package otlplabels
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	yaml "go.yaml.in/yaml/v4"
 )
 
 var defaultGlobalOTLPConfig = GlobalOTLPConfig{}
@@ -153,7 +154,9 @@ log_attributes:
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := OTLPConfig{}
-			err := yaml.UnmarshalStrict(tc.yamlConfig, &cfg)
+			dec := yaml.NewDecoder(bytes.NewReader(tc.yamlConfig))
+			dec.KnownFields(true)
+			err := dec.Decode(&cfg)
 			if tc.expectedErr != nil {
 				require.ErrorIs(t, err, tc.expectedErr)
 				return

--- a/pkg/logql/bench/query_registry.go
+++ b/pkg/logql/bench/query_registry.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 )

--- a/pkg/loki/config_handler.go
+++ b/pkg/loki/config_handler.go
@@ -7,28 +7,28 @@ import (
 	"reflect"
 
 	"github.com/grafana/dskit/tenant"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/util/build"
 	"github.com/grafana/loki/v3/pkg/validation"
 )
 
-func yamlMarshalUnmarshal(in interface{}) (map[interface{}]interface{}, error) {
+func yamlMarshalUnmarshal(in interface{}) (map[string]interface{}, error) {
 	yamlBytes, err := yaml.Marshal(in)
 	if err != nil {
 		return nil, err
 	}
 
-	object := make(map[interface{}]interface{})
-	if err := yaml.Unmarshal(yamlBytes, object); err != nil {
+	object := make(map[string]interface{})
+	if err := yaml.Unmarshal(yamlBytes, &object); err != nil {
 		return nil, err
 	}
 
 	return object, nil
 }
 
-func diffConfig(defaultConfig, actualConfig map[interface{}]interface{}) (map[interface{}]interface{}, error) {
-	output := make(map[interface{}]interface{})
+func diffConfig(defaultConfig, actualConfig map[string]interface{}) (map[string]interface{}, error) {
+	output := make(map[string]interface{})
 
 	for key, value := range actualConfig {
 
@@ -64,10 +64,11 @@ func diffConfig(defaultConfig, actualConfig map[interface{}]interface{}) (map[in
 			if !ok || !reflect.DeepEqual(defaultV, v) {
 				output[key] = v
 			}
-		case map[interface{}]interface{}:
-			defaultV, ok := defaultValue.(map[interface{}]interface{})
+		case map[string]interface{}:
+			defaultV, ok := defaultValue.(map[string]interface{})
 			if !ok {
 				output[key] = value
+				break
 			}
 			diff, err := diffConfig(defaultV, v)
 			if err != nil {

--- a/pkg/loki/config_handler_test.go
+++ b/pkg/loki/config_handler_test.go
@@ -61,9 +61,9 @@ func TestConfigDiffHandler(t *testing.T) {
 			},
 			expectedStatusCode: 200,
 			expectedBody: "my_slice:\n" +
-				"- value1\n" +
-				"- value2\n" +
-				"- value3\n",
+				"    - value1\n" +
+				"    - value2\n" +
+				"    - value3\n",
 		},
 		{
 			name: "string in nested struct changed",
@@ -74,7 +74,7 @@ func TestConfigDiffHandler(t *testing.T) {
 			},
 			expectedStatusCode: 200,
 			expectedBody: "my_nested_struct:\n" +
-				"  my_string: string2\n",
+				"    my_string: string2\n",
 		},
 		{
 			name: "bool in nested struct changed",
@@ -85,7 +85,7 @@ func TestConfigDiffHandler(t *testing.T) {
 			},
 			expectedStatusCode: 200,
 			expectedBody: "my_nested_struct:\n" +
-				"  my_bool: true\n",
+				"    my_bool: true\n",
 		},
 		{
 			name: "test invalid input",
@@ -94,8 +94,8 @@ func TestConfigDiffHandler(t *testing.T) {
 				return &c
 			},
 			expectedStatusCode: 500,
-			expectedBody: "yaml: unmarshal errors:\n" +
-				"  line 1: cannot unmarshal !!str `x` into map[interface {}]interface {}\n",
+			expectedBody: "yaml: construct errors:\n" +
+				"  line 1: cannot construct !!str `x` into map[string]interface {}\n",
 		},
 	} {
 		defaultCfg := newDefaultDiffConfigMock()

--- a/pkg/loki/runtime_config.go
+++ b/pkg/loki/runtime_config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/runtimeconfig"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/runtime"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
@@ -42,7 +42,7 @@ func loadRuntimeConfig(r io.Reader) (interface{}, error) {
 	overrides := &runtimeConfigValues{}
 
 	decoder := yaml.NewDecoder(r)
-	decoder.SetStrict(true)
+	decoder.KnownFields(true)
 	if err := decoder.Decode(&overrides); err != nil {
 		return nil, err
 	}

--- a/pkg/loki/tenant_limits_handler_test.go
+++ b/pkg/loki/tenant_limits_handler_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/loghttp/push"
 	"github.com/grafana/loki/v3/pkg/validation"

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"

--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/loghttp"
 	"github.com/grafana/loki/v3/pkg/logproto"

--- a/pkg/querytee/goldfish/result_store_test.go
+++ b/pkg/querytee/goldfish/result_store_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/storage/bucket"
 )

--- a/pkg/ruler/base/ruler_test.go
+++ b/pkg/ruler/base/ruler_test.go
@@ -39,8 +39,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
-	"google.golang.org/grpc"
 	"go.yaml.in/yaml/v4"
+	"google.golang.org/grpc"
 
 	"github.com/grafana/dskit/tenant"
 

--- a/pkg/ruler/base/ruler_test.go
+++ b/pkg/ruler/base/ruler_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/dskit/tenant"
 

--- a/pkg/ruler/config.go
+++ b/pkg/ruler/config.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	ruler "github.com/grafana/loki/v3/pkg/ruler/base"
 	"github.com/grafana/loki/v3/pkg/ruler/storage/cleaner"

--- a/pkg/ruler/registry.go
+++ b/pkg/ruler/registry.go
@@ -24,7 +24,7 @@ import (
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/sigv4"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/ruler/storage/cleaner"
 	"github.com/grafana/loki/v3/pkg/ruler/storage/instance"

--- a/pkg/ruler/storage/instance/instance.go
+++ b/pkg/ruler/storage/instance/instance.go
@@ -75,11 +75,10 @@ type Config struct {
 func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 	*c = DefaultConfig
 
-	type plain Config
-	// Use Load with WithKnownFields to propagate strict mode through this
-	// custom unmarshaler (Node.Decode does not carry KnownFields from the
-	// outer Decoder).
-	return value.Load((*plain)(c), yaml.WithKnownFields(true))
+	type raw Config
+	// We always want strict config parsing
+	// See https://github.com/yaml/go-yaml/issues/321 and https://github.com/yaml/go-yaml/pull/332
+	return value.Load((*raw)(c), yaml.WithKnownFields(true))
 }
 
 // MarshalYAML implements yaml.Marshaler.

--- a/pkg/ruler/storage/instance/instance.go
+++ b/pkg/ruler/storage/instance/instance.go
@@ -25,7 +25,7 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tsdb/wlog"
-	"gopkg.in/yaml.v2"
+	yaml "go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/ruler/storage/util"
 	"github.com/grafana/loki/v3/pkg/ruler/storage/wal"
@@ -72,11 +72,14 @@ type Config struct {
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
-func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 	*c = DefaultConfig
 
 	type plain Config
-	return unmarshal((*plain)(c))
+	// Use Load with WithKnownFields to propagate strict mode through this
+	// custom unmarshaler (Node.Decode does not carry KnownFields from the
+	// outer Decoder).
+	return value.Load((*plain)(c), yaml.WithKnownFields(true))
 }
 
 // MarshalYAML implements yaml.Marshaler.
@@ -89,13 +92,18 @@ func (c Config) MarshalYAML() (interface{}, error) {
 		return nil, err
 	}
 
-	// Use a yaml.MapSlice rather than a map[string]interface{} so
-	// order of keys is retained compared to just calling MarshalConfig.
-	var m yaml.MapSlice
-	if err := yaml.Unmarshal(bb, &m); err != nil {
+	// Use a yaml.Node to preserve key order compared to map[string]interface{}.
+	// yaml.Unmarshal into a Node produces a DocumentNode wrapper; unwrap it
+	// to return the actual mapping node so the caller's marshaler doesn't
+	// encounter a nested document-start marker.
+	var doc yaml.Node
+	if err := yaml.Unmarshal(bb, &doc); err != nil {
 		return nil, err
 	}
-	return m, nil
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		return doc.Content[0], nil
+	}
+	return &doc, nil
 }
 
 // ApplyDefaults applies default configurations to the configuration to all

--- a/pkg/ruler/storage/instance/marshal.go
+++ b/pkg/ruler/storage/instance/marshal.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"io"
 
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 )
 
 // UnmarshalConfig unmarshals an instance config from a reader based on a
@@ -15,7 +15,7 @@ import (
 func UnmarshalConfig(r io.Reader) (*Config, error) {
 	var cfg Config
 	dec := yaml.NewDecoder(r)
-	dec.SetStrict(true)
+	dec.KnownFields(true)
 	err := dec.Decode(&cfg)
 	return &cfg, err
 }

--- a/pkg/ruler/storage/instance/marshal_test.go
+++ b/pkg/ruler/storage/instance/marshal_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestUnmarshalConfig_Valid(t *testing.T) {

--- a/pkg/ruler/storage/util/compare_yaml.go
+++ b/pkg/ruler/storage/util/compare_yaml.go
@@ -6,7 +6,7 @@ package util //nolint:revive
 import (
 	"bytes"
 
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 )
 
 // CompareYAML marshals a and b to YAML and ensures that their contents are

--- a/pkg/storage/bucket/client_test.go
+++ b/pkg/storage/bucket/client_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	yaml "gopkg.in/yaml.v2"
+	yaml "go.yaml.in/yaml/v4"
 
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )

--- a/pkg/storage/bucket/http/config_test.go
+++ b/pkg/storage/bucket/http/config_test.go
@@ -69,7 +69,7 @@ max_connections_per_host: 8
 
 			err := yaml.Unmarshal([]byte(testData.config), &cfg)
 			if testData.expectedTypeErr {
-				var typeErr *yaml.TypeError
+				var typeErr *yaml.LoadErrors
 				require.ErrorAs(t, err, &typeErr)
 			} else {
 				require.NoError(t, err)

--- a/pkg/storage/bucket/http/config_test.go
+++ b/pkg/storage/bucket/http/config_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/grafana/dskit/flagext"
 	"github.com/stretchr/testify/require"
-	yaml "gopkg.in/yaml.v2"
+	yaml "go.yaml.in/yaml/v4"
 )
 
 // defaultConfig should match the default flag values defined in RegisterFlagsWithPrefix.
@@ -25,14 +25,13 @@ func TestConfig(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		config         string
-		expectedConfig Config
-		expectedErr    error
+		config          string
+		expectedConfig  Config
+		expectedTypeErr bool
 	}{
 		"default config": {
 			config:         "",
 			expectedConfig: defaultConfig,
-			expectedErr:    nil,
 		},
 		"custom config": {
 			config: `
@@ -55,12 +54,11 @@ max_connections_per_host: 8
 				MaxIdleConnsPerHost:   7,
 				MaxConnsPerHost:       8,
 			},
-			expectedErr: nil,
 		},
 		"invalid type": {
-			config:         `max_idle_connections: foo`,
-			expectedConfig: defaultConfig,
-			expectedErr:    &yaml.TypeError{Errors: []string{"line 1: cannot unmarshal !!str `foo` into int"}},
+			config:          `max_idle_connections: foo`,
+			expectedConfig:  defaultConfig,
+			expectedTypeErr: true,
 		},
 	}
 
@@ -70,7 +68,12 @@ max_connections_per_host: 8
 			flagext.DefaultValues(&cfg)
 
 			err := yaml.Unmarshal([]byte(testData.config), &cfg)
-			require.Equal(t, testData.expectedErr, err)
+			if testData.expectedTypeErr {
+				var typeErr *yaml.TypeError
+				require.ErrorAs(t, err, &typeErr)
+			} else {
+				require.NoError(t, err)
+			}
 			require.Equal(t, testData.expectedConfig, cfg)
 		})
 	}

--- a/pkg/storage/bucket/named_stores.go
+++ b/pkg/storage/bucket/named_stores.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/grafana/dskit/flagext"
+	yaml "go.yaml.in/yaml/v4"
+
 	"github.com/grafana/loki/v3/pkg/storage/bucket/azure"
 	"github.com/grafana/loki/v3/pkg/storage/bucket/filesystem"
 	"github.com/grafana/loki/v3/pkg/storage/bucket/gcs"
 	"github.com/grafana/loki/v3/pkg/storage/bucket/s3"
 	"github.com/grafana/loki/v3/pkg/storage/bucket/swift"
-
-	"github.com/grafana/dskit/flagext"
 )
 
 // NamedStores helps configure additional object stores from a given storage provider
@@ -162,9 +163,9 @@ func (ns *NamedStores) OverrideConfig(storeCfg *Config, namedStore string) error
 type NamedS3StorageConfig s3.Config
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (cfg *NamedS3StorageConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (cfg *NamedS3StorageConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*s3.Config)(cfg))
-	return unmarshal((*s3.Config)(cfg))
+	return value.Decode((*s3.Config)(cfg))
 }
 
 func (cfg *NamedS3StorageConfig) Validate() error {
@@ -174,31 +175,31 @@ func (cfg *NamedS3StorageConfig) Validate() error {
 type NamedGCSStorageConfig gcs.Config
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (cfg *NamedGCSStorageConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (cfg *NamedGCSStorageConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*gcs.Config)(cfg))
-	return unmarshal((*gcs.Config)(cfg))
+	return value.Decode((*gcs.Config)(cfg))
 }
 
 type NamedAzureStorageConfig azure.Config
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (cfg *NamedAzureStorageConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (cfg *NamedAzureStorageConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*azure.Config)(cfg))
-	return unmarshal((*azure.Config)(cfg))
+	return value.Decode((*azure.Config)(cfg))
 }
 
 type NamedSwiftStorageConfig swift.Config
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (cfg *NamedSwiftStorageConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (cfg *NamedSwiftStorageConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*swift.Config)(cfg))
-	return unmarshal((*swift.Config)(cfg))
+	return value.Decode((*swift.Config)(cfg))
 }
 
 type NamedFilesystemStorageConfig filesystem.Config
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (cfg *NamedFilesystemStorageConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (cfg *NamedFilesystemStorageConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*filesystem.Config)(cfg))
-	return unmarshal((*filesystem.Config)(cfg))
+	return value.Decode((*filesystem.Config)(cfg))
 }

--- a/pkg/storage/bucket/named_stores.go
+++ b/pkg/storage/bucket/named_stores.go
@@ -165,7 +165,9 @@ type NamedS3StorageConfig s3.Config
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (cfg *NamedS3StorageConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*s3.Config)(cfg))
-	return value.Decode((*s3.Config)(cfg))
+	// We always want strict config parsing
+	// See https://github.com/yaml/go-yaml/issues/321 and https://github.com/yaml/go-yaml/pull/332
+	return value.Load((*s3.Config)(cfg), yaml.WithKnownFields(true))
 }
 
 func (cfg *NamedS3StorageConfig) Validate() error {
@@ -177,7 +179,9 @@ type NamedGCSStorageConfig gcs.Config
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (cfg *NamedGCSStorageConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*gcs.Config)(cfg))
-	return value.Decode((*gcs.Config)(cfg))
+	// We always want strict config parsing
+	// See https://github.com/yaml/go-yaml/issues/321 and https://github.com/yaml/go-yaml/pull/332
+	return value.Load((*gcs.Config)(cfg), yaml.WithKnownFields(true))
 }
 
 type NamedAzureStorageConfig azure.Config
@@ -185,7 +189,9 @@ type NamedAzureStorageConfig azure.Config
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (cfg *NamedAzureStorageConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*azure.Config)(cfg))
-	return value.Decode((*azure.Config)(cfg))
+	// We always want strict config parsing
+	// See https://github.com/yaml/go-yaml/issues/321 and https://github.com/yaml/go-yaml/pull/332
+	return value.Load((*azure.Config)(cfg), yaml.WithKnownFields(true))
 }
 
 type NamedSwiftStorageConfig swift.Config
@@ -193,7 +199,9 @@ type NamedSwiftStorageConfig swift.Config
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (cfg *NamedSwiftStorageConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*swift.Config)(cfg))
-	return value.Decode((*swift.Config)(cfg))
+	// We always want strict config parsing
+	// See https://github.com/yaml/go-yaml/issues/321 and https://github.com/yaml/go-yaml/pull/332
+	return value.Load((*swift.Config)(cfg), yaml.WithKnownFields(true))
 }
 
 type NamedFilesystemStorageConfig filesystem.Config
@@ -201,5 +209,7 @@ type NamedFilesystemStorageConfig filesystem.Config
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (cfg *NamedFilesystemStorageConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*filesystem.Config)(cfg))
-	return value.Decode((*filesystem.Config)(cfg))
+	// We always want strict config parsing
+	// See https://github.com/yaml/go-yaml/issues/321 and https://github.com/yaml/go-yaml/pull/332
+	return value.Load((*filesystem.Config)(cfg), yaml.WithKnownFields(true))
 }

--- a/pkg/storage/chunk/client/aws/s3_storage_client_test.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/flagext"

--- a/pkg/storage/chunk/client/baidubce/bos_storage_client_test.go
+++ b/pkg/storage/chunk/client/baidubce/bos_storage_client_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/dskit/flagext"
 )

--- a/pkg/storage/config/bench_test.go
+++ b/pkg/storage/config/bench_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	yaml "gopkg.in/yaml.v2"
+	yaml "go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/config"

--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -147,8 +147,10 @@ type PeriodConfig struct {
 
 // UnmarshalYAML implements yaml.Unmarshaller.
 func (cfg *PeriodConfig) UnmarshalYAML(value *yaml.Node) error {
-	type plain PeriodConfig
-	err := value.Decode((*plain)(cfg))
+	type raw PeriodConfig
+	// We always want strict config parsing
+	// See https://github.com/yaml/go-yaml/issues/321 and https://github.com/yaml/go-yaml/pull/332
+	err := value.Load((*raw)(cfg), yaml.WithKnownFields(true))
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -15,7 +15,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/mtime"
 	"github.com/prometheus/common/model"
-	yaml "gopkg.in/yaml.v2"
+	yaml "go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/chunkenc"
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -146,9 +146,9 @@ type PeriodConfig struct {
 }
 
 // UnmarshalYAML implements yaml.Unmarshaller.
-func (cfg *PeriodConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (cfg *PeriodConfig) UnmarshalYAML(value *yaml.Node) error {
 	type plain PeriodConfig
-	err := unmarshal((*plain)(cfg))
+	err := value.Decode((*plain)(cfg))
 	if err != nil {
 		return err
 	}
@@ -192,9 +192,9 @@ func (d DayTime) MarshalYAML() (interface{}, error) {
 }
 
 // UnmarshalYAML implements yaml.Unmarshaller.
-func (d *DayTime) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (d *DayTime) UnmarshalYAML(value *yaml.Node) error {
 	var from string
-	if err := unmarshal(&from); err != nil {
+	if err := value.Decode(&from); err != nil {
 		return err
 	}
 	t, err := time.Parse("2006-01-02", from)
@@ -297,7 +297,7 @@ func (cfg *SchemaConfig) loadFromFile() error {
 	}
 
 	decoder := yaml.NewDecoder(f)
-	decoder.SetStrict(true)
+	decoder.KnownFields(true)
 	return decoder.Decode(&cfg)
 }
 
@@ -503,14 +503,14 @@ func (cfg *IndexPeriodicTableConfig) Validate() error {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (cfg *IndexPeriodicTableConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (cfg *IndexPeriodicTableConfig) UnmarshalYAML(value *yaml.Node) error {
 	g := struct {
 		PathPrefix string         `yaml:"path_prefix"`
 		Prefix     string         `yaml:"prefix"`
 		Period     model.Duration `yaml:"period"`
 		Tags       Tags           `yaml:"tags"`
 	}{}
-	if err := unmarshal(&g); err != nil {
+	if err := value.Decode(&g); err != nil {
 		return err
 	}
 
@@ -563,13 +563,13 @@ type PeriodicTableConfig struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (cfg *PeriodicTableConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (cfg *PeriodicTableConfig) UnmarshalYAML(value *yaml.Node) error {
 	g := struct {
 		Prefix string         `yaml:"prefix"`
 		Period model.Duration `yaml:"period"`
 		Tags   Tags           `yaml:"tags"`
 	}{}
-	if err := unmarshal(&g); err != nil {
+	if err := value.Decode(&g); err != nil {
 		return err
 	}
 

--- a/pkg/storage/config/schema_config_test.go
+++ b/pkg/storage/config/schema_config_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	yaml "gopkg.in/yaml.v2"
+	yaml "go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
@@ -408,7 +408,7 @@ func TestIndexPeriodicTableConfigCustomUnmarshalling(t *testing.T) {
 prefix: cortex_
 period: 1w
 tags:
-  foo: bar
+    foo: bar
 `
 
 	cfg := IndexPeriodicTableConfig{}
@@ -438,7 +438,7 @@ func TestPeriodicTableConfigCustomUnmarshalling(t *testing.T) {
 	yamlFile := `prefix: cortex_
 period: 1w
 tags:
-  foo: bar
+    foo: bar
 `
 
 	cfg := PeriodicTableConfig{}

--- a/pkg/storage/config/tags.go
+++ b/pkg/storage/config/tags.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"strings"
+
+	yaml "go.yaml.in/yaml/v4"
 )
 
 // Tags is a string-string map that implements flag.Value.
@@ -32,9 +34,9 @@ func (ts *Tags) Set(s string) error {
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
-func (ts *Tags) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (ts *Tags) UnmarshalYAML(value *yaml.Node) error {
 	var m map[string]string
-	if err := unmarshal(&m); err != nil {
+	if err := value.Decode(&m); err != nil {
 		return err
 	}
 	*ts = Tags(m)

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	yaml "go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/indexgateway"
 	"github.com/grafana/loki/v3/pkg/storage/bucket"
@@ -57,9 +58,9 @@ type StoreLimits interface {
 type NamedAWSStorageConfig aws.S3Config
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (cfg *NamedAWSStorageConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (cfg *NamedAWSStorageConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*aws.S3Config)(cfg))
-	return unmarshal((*aws.S3Config)(cfg))
+	return value.Decode((*aws.S3Config)(cfg))
 }
 
 func (cfg *NamedAWSStorageConfig) Validate() error {
@@ -69,9 +70,9 @@ func (cfg *NamedAWSStorageConfig) Validate() error {
 type NamedBlobStorageConfig azure.BlobStorageConfig
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (cfg *NamedBlobStorageConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (cfg *NamedBlobStorageConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*azure.BlobStorageConfig)(cfg))
-	return unmarshal((*azure.BlobStorageConfig)(cfg))
+	return value.Decode((*azure.BlobStorageConfig)(cfg))
 }
 
 func (cfg *NamedBlobStorageConfig) Validate() error {
@@ -81,41 +82,41 @@ func (cfg *NamedBlobStorageConfig) Validate() error {
 type NamedBOSStorageConfig baidubce.BOSStorageConfig
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (cfg *NamedBOSStorageConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (cfg *NamedBOSStorageConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*baidubce.BOSStorageConfig)(cfg))
-	return unmarshal((*baidubce.BOSStorageConfig)(cfg))
+	return value.Decode((*baidubce.BOSStorageConfig)(cfg))
 }
 
 type NamedFSConfig local.FSConfig
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (cfg *NamedFSConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (cfg *NamedFSConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*local.FSConfig)(cfg))
-	return unmarshal((*local.FSConfig)(cfg))
+	return value.Decode((*local.FSConfig)(cfg))
 }
 
 type NamedGCSConfig gcp.GCSConfig
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (cfg *NamedGCSConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (cfg *NamedGCSConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*gcp.GCSConfig)(cfg))
-	return unmarshal((*gcp.GCSConfig)(cfg))
+	return value.Decode((*gcp.GCSConfig)(cfg))
 }
 
 type NamedOssConfig alibaba.OssConfig
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (cfg *NamedOssConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (cfg *NamedOssConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*alibaba.OssConfig)(cfg))
-	return unmarshal((*alibaba.OssConfig)(cfg))
+	return value.Decode((*alibaba.OssConfig)(cfg))
 }
 
 type NamedSwiftConfig openstack.SwiftConfig
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (cfg *NamedSwiftConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (cfg *NamedSwiftConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*openstack.SwiftConfig)(cfg))
-	return unmarshal((*openstack.SwiftConfig)(cfg))
+	return value.Decode((*openstack.SwiftConfig)(cfg))
 }
 
 func (cfg *NamedSwiftConfig) Validate() error {
@@ -125,9 +126,9 @@ func (cfg *NamedSwiftConfig) Validate() error {
 type NamedCOSConfig ibmcloud.COSConfig
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (cfg *NamedCOSConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (cfg *NamedCOSConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*ibmcloud.COSConfig)(cfg))
-	return unmarshal((*ibmcloud.COSConfig)(cfg))
+	return value.Decode((*ibmcloud.COSConfig)(cfg))
 }
 
 // NamedStores helps configure additional object stores from a given storage provider

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -60,7 +60,9 @@ type NamedAWSStorageConfig aws.S3Config
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (cfg *NamedAWSStorageConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*aws.S3Config)(cfg))
-	return value.Decode((*aws.S3Config)(cfg))
+	// We always want strict config parsing
+	// See https://github.com/yaml/go-yaml/issues/321 and https://github.com/yaml/go-yaml/pull/332
+	return value.Load((*aws.S3Config)(cfg), yaml.WithKnownFields(true))
 }
 
 func (cfg *NamedAWSStorageConfig) Validate() error {
@@ -72,7 +74,9 @@ type NamedBlobStorageConfig azure.BlobStorageConfig
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (cfg *NamedBlobStorageConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*azure.BlobStorageConfig)(cfg))
-	return value.Decode((*azure.BlobStorageConfig)(cfg))
+	// We always want strict config parsing
+	// See https://github.com/yaml/go-yaml/issues/321 and https://github.com/yaml/go-yaml/pull/332
+	return value.Load((*azure.BlobStorageConfig)(cfg), yaml.WithKnownFields(true))
 }
 
 func (cfg *NamedBlobStorageConfig) Validate() error {
@@ -84,7 +88,9 @@ type NamedBOSStorageConfig baidubce.BOSStorageConfig
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (cfg *NamedBOSStorageConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*baidubce.BOSStorageConfig)(cfg))
-	return value.Decode((*baidubce.BOSStorageConfig)(cfg))
+	// We always want strict config parsing
+	// See https://github.com/yaml/go-yaml/issues/321 and https://github.com/yaml/go-yaml/pull/332
+	return value.Load((*baidubce.BOSStorageConfig)(cfg), yaml.WithKnownFields(true))
 }
 
 type NamedFSConfig local.FSConfig
@@ -92,7 +98,9 @@ type NamedFSConfig local.FSConfig
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (cfg *NamedFSConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*local.FSConfig)(cfg))
-	return value.Decode((*local.FSConfig)(cfg))
+	// We always want strict config parsing
+	// See https://github.com/yaml/go-yaml/issues/321 and https://github.com/yaml/go-yaml/pull/332
+	return value.Load((*local.FSConfig)(cfg), yaml.WithKnownFields(true))
 }
 
 type NamedGCSConfig gcp.GCSConfig
@@ -100,7 +108,9 @@ type NamedGCSConfig gcp.GCSConfig
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (cfg *NamedGCSConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*gcp.GCSConfig)(cfg))
-	return value.Decode((*gcp.GCSConfig)(cfg))
+	// We always want strict config parsing
+	// See https://github.com/yaml/go-yaml/issues/321 and https://github.com/yaml/go-yaml/pull/332
+	return value.Load((*gcp.GCSConfig)(cfg), yaml.WithKnownFields(true))
 }
 
 type NamedOssConfig alibaba.OssConfig
@@ -108,7 +118,9 @@ type NamedOssConfig alibaba.OssConfig
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (cfg *NamedOssConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*alibaba.OssConfig)(cfg))
-	return value.Decode((*alibaba.OssConfig)(cfg))
+	// We always want strict config parsing
+	// See https://github.com/yaml/go-yaml/issues/321 and https://github.com/yaml/go-yaml/pull/332
+	return value.Load((*alibaba.OssConfig)(cfg), yaml.WithKnownFields(true))
 }
 
 type NamedSwiftConfig openstack.SwiftConfig
@@ -116,7 +128,9 @@ type NamedSwiftConfig openstack.SwiftConfig
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (cfg *NamedSwiftConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*openstack.SwiftConfig)(cfg))
-	return value.Decode((*openstack.SwiftConfig)(cfg))
+	// We always want strict config parsing
+	// See https://github.com/yaml/go-yaml/issues/321 and https://github.com/yaml/go-yaml/pull/332
+	return value.Load((*openstack.SwiftConfig)(cfg), yaml.WithKnownFields(true))
 }
 
 func (cfg *NamedSwiftConfig) Validate() error {
@@ -128,7 +142,9 @@ type NamedCOSConfig ibmcloud.COSConfig
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (cfg *NamedCOSConfig) UnmarshalYAML(value *yaml.Node) error {
 	flagext.DefaultValues((*ibmcloud.COSConfig)(cfg))
-	return value.Decode((*ibmcloud.COSConfig)(cfg))
+	// We always want strict config parsing
+	// See https://github.com/yaml/go-yaml/issues/321 and https://github.com/yaml/go-yaml/pull/332
+	return value.Load((*ibmcloud.COSConfig)(cfg), yaml.WithKnownFields(true))
 }
 
 // NamedStores helps configure additional object stores from a given storage provider

--- a/pkg/util/cfg/cfg_test.go
+++ b/pkg/util/cfg/cfg_test.go
@@ -63,7 +63,7 @@ tls:
 		flagSource,
 	)
 	require.Error(t, err)
-	require.Equal(t, err.Error(), "yaml: unmarshal errors:\n  line 2: field servers not found in type cfg.Data\n  line 6: field keey not found in type cfg.TLS")
+	require.Equal(t, err.Error(), "yaml: construct errors:\n  line 2: field servers not found in type cfg.Data\n  line 6: field keey not found in type cfg.TLS")
 }
 
 func TestDefaultUnmarshal(t *testing.T) {

--- a/pkg/util/cfg/files.go
+++ b/pkg/util/cfg/files.go
@@ -8,9 +8,12 @@ import (
 	"strconv"
 	"strings"
 
+	"bytes"
+	"io"
+
 	"github.com/drone/envsubst"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	yaml "go.yaml.in/yaml/v4"
 )
 
 // JSON returns a Source that opens the supplied `.json` file and loads it.
@@ -66,7 +69,12 @@ func YAML(f string, expandEnvVars bool, strict bool) Source {
 // dYAMLStrict returns a YAML source and allows dependency injection
 func dYAMLStrict(y []byte) Source {
 	return func(dst Cloneable) error {
-		return yaml.UnmarshalStrict(y, dst)
+		dec := yaml.NewDecoder(bytes.NewReader(y))
+		dec.KnownFields(true)
+		if err := dec.Decode(dst); err != nil && err != io.EOF {
+			return err
+		}
+		return nil
 	}
 }
 

--- a/pkg/util/config.go
+++ b/pkg/util/config.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/common/version"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )

--- a/pkg/util/flagext/bytesize.go
+++ b/pkg/util/flagext/bytesize.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/c2h5oh/datasize"
+	yaml "go.yaml.in/yaml/v4"
 )
 
 // ByteSize is a flag parsing compatibility type for constructing human friendly sizes.
@@ -36,9 +37,9 @@ func (bs ByteSize) Val() int {
 }
 
 // UnmarshalYAML the Unmarshaler interface of the yaml pkg.
-func (bs *ByteSize) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (bs *ByteSize) UnmarshalYAML(value *yaml.Node) error {
 	var str string
-	err := unmarshal(&str)
+	err := value.Decode(&str)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/flagext/bytesize_test.go
+++ b/pkg/util/flagext/bytesize_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 )
 
 func Test_ByteSize(t *testing.T) {

--- a/pkg/util/flagext/csv.go
+++ b/pkg/util/flagext/csv.go
@@ -2,6 +2,8 @@ package flagext
 
 import (
 	"strings"
+
+	yaml "go.yaml.in/yaml/v4"
 )
 
 type ListValue interface {
@@ -47,9 +49,9 @@ func (v CSV[T]) Get() []T {
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
-func (v *CSV[T]) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (v *CSV[T]) UnmarshalYAML(value *yaml.Node) error {
 	var s string
-	if err := unmarshal(&s); err != nil {
+	if err := value.Decode(&s); err != nil {
 		return err
 	}
 

--- a/pkg/util/flagext/labelset.go
+++ b/pkg/util/flagext/labelset.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/common/model"
-	"gopkg.in/yaml.v2"
+	yaml "go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/util"
 )
@@ -72,9 +72,9 @@ func (v *LabelSet) Set(s string) error {
 }
 
 // UnmarshalYAML the Unmarshaler interface of the yaml pkg.
-func (v *LabelSet) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (v *LabelSet) UnmarshalYAML(value *yaml.Node) error {
 	lbSet := model.LabelSet{}
-	err := unmarshal(&lbSet)
+	err := value.Decode(&lbSet)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -20,7 +20,7 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 )
 
 const messageSizeLargerErrFmt = "%w than max (%d vs %d)"

--- a/pkg/util/http_test.go
+++ b/pkg/util/http_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/util"

--- a/pkg/util/validation/notifications_limit_flag.go
+++ b/pkg/util/validation/notifications_limit_flag.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	yaml "go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/util"
 )
@@ -31,9 +32,9 @@ func (m NotificationRateLimitMap) Set(s string) error {
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
-func (m NotificationRateLimitMap) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (m NotificationRateLimitMap) UnmarshalYAML(value *yaml.Node) error {
 	newMap := map[string]float64{}
-	return m.updateMap(unmarshal(newMap), newMap)
+	return m.updateMap(value.Decode(newMap), newMap)
 }
 
 func (m NotificationRateLimitMap) updateMap(unmarshalErr error, newMap map[string]float64) error {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -17,8 +17,8 @@ import (
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/sigv4"
-	"golang.org/x/time/rate"
 	yaml "go.yaml.in/yaml/v4"
+	"golang.org/x/time/rate"
 
 	"github.com/grafana/loki/v3/pkg/compactor/deletionmode"
 	"github.com/grafana/loki/v3/pkg/compression"

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -18,7 +18,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/sigv4"
 	"golang.org/x/time/rate"
-	"gopkg.in/yaml.v2"
+	yaml "go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/compactor/deletionmode"
 	"github.com/grafana/loki/v3/pkg/compression"
@@ -602,7 +602,7 @@ func (l *Limits) SetDefaultPolicyStreamMapping(cfg PolicyStreamMapping) error {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (l *Limits) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (l *Limits) UnmarshalYAML(value *yaml.Node) error {
 	// We want to set c to the defaults and then overwrite it with the input.
 	// To make unmarshal fill the plain data struct rather than calling UnmarshalYAML
 	// again, we have to hide it using a type indirection.  See prometheus/config.
@@ -620,7 +620,7 @@ func (l *Limits) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		// set the otlp config to nil, which would help to detect later if it was set in the tenant override
 		l.OTLPConfig = nil
 	}
-	if err := unmarshal((*plain)(l)); err != nil {
+	if err := value.Decode((*plain)(l)); err != nil {
 		return err
 	}
 
@@ -1494,10 +1494,10 @@ func (sm OverwriteMarshalingStringMap) MarshalYAML() (interface{}, error) {
 	return sm.m, nil
 }
 
-func (sm *OverwriteMarshalingStringMap) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (sm *OverwriteMarshalingStringMap) UnmarshalYAML(value *yaml.Node) error {
 	var def map[string]string
 
-	err := unmarshal(&def)
+	err := value.Decode(&def)
 	if err != nil {
 		return err
 	}

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -11,7 +12,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	yaml "go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/compactor/deletionmode"
 	"github.com/grafana/loki/v3/pkg/compression"
@@ -236,14 +237,18 @@ ruler_remote_write_headers:
 			},
 		},
 		{
-			desc: "empty map overrides defaults",
+			// In yaml.v4, null YAML values for struct-backed custom types do not
+			// invoke UnmarshalYAML; the existing value (from defaults) is preserved.
+			// Use `ruler_remote_write_headers: {}` to explicitly set an empty map.
+			desc: "null map preserves defaults (yaml.v4 behaviour)",
 			yaml: `
 ruler_remote_write_headers:
 `,
 			exp: Limits{
-				DiscoverGenericFields: FieldDetectorConfig{},
-				DiscoverServiceName:   []string{},
-				LogLevelFields:        []string{},
+				DiscoverGenericFields:   FieldDetectorConfig{},
+				DiscoverServiceName:     []string{},
+				LogLevelFields:          []string{},
+				RulerRemoteWriteHeaders: OverwriteMarshalingStringMap{m: map[string]string{"a": "b"}},
 				// Rest from new defaults
 				StreamRetention: []StreamRetention{
 					{
@@ -346,7 +351,9 @@ query_timeout: 5m
 
 		t.Run(tc.desc, func(t *testing.T) {
 			var out Limits
-			require.Nil(t, yaml.UnmarshalStrict([]byte(tc.yaml), &out))
+			dec := yaml.NewDecoder(bytes.NewReader([]byte(tc.yaml)))
+			dec.KnownFields(true)
+			require.Nil(t, dec.Decode(&out))
 			require.Equal(t, tc.exp, out)
 		})
 	}
@@ -956,7 +963,9 @@ otlp_config:
 			SetDefaultLimitsForYAMLUnmarshalling(newDefaults)
 
 			var out Limits
-			require.Nil(t, yaml.UnmarshalStrict([]byte(tc.yaml), &out))
+			dec := yaml.NewDecoder(bytes.NewReader([]byte(tc.yaml)))
+			dec.KnownFields(true)
+			require.Nil(t, dec.Decode(&out))
 			require.Equal(t, tc.exp, out)
 		})
 	}


### PR DESCRIPTION
[gopkg.in/yaml.v3](https://github.com/go-yaml/yaml/tree/v3) was the successor of gopkg.in/yaml.v2 but is also already not maintained any more.

https://pkg.go.dev/go.yaml.in/yaml/v4 is the YAML org maintained fork of the former.

Switching to an actively maintained project reduces the risk of security vulnerabilities.
 
### Summary

- Replace all `gopkg.in/yaml.v2` imports with `go.yaml.in/yaml/v4`
- Update `UnmarshalYAML` signatures from `func(interface{}) error` to `*yaml.Node`
- Replace `yaml.UnmarshalStrict` and `decoder.SetStrict` with `KnownFields(true)`
- Replace `yaml.MapSlice` with `yaml.Node` (unwrapped `DocumentNode`)
- Update `map[interface{}]interface{}` to `map[string]interface{}` (v4 decodes into `interface{}` using string-keyed maps)
- Handle `io.EOF` from `Decoder.Decode` on empty input
- Update test assertions for changed error message format and YAML indentation