### PR TITLE
fix(ci): Align querytee weekly manifest image name with build output

### DIFF
--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -38,7 +38,7 @@ local weeklyImageJobs = {
   loki: build.weeklyImage('loki', 'cmd/loki', platform=platforms.all),
   'loki-canary': build.weeklyImage('loki-canary', 'cmd/loki-canary', platform=platforms.all),
   'loki-canary-boringcrypto': build.weeklyImage('loki-canary-boringcrypto', 'cmd/loki-canary-boringcrypto', platform=platforms.all),
-  querytee: build.weeklyImage('loki-query-tee', 'cmd/querytee'),
+  'loki-query-tee': build.weeklyImage('loki-query-tee', 'cmd/querytee'),
   'logql-analyzer': build.weeklyImage('logql-analyzer', 'cmd/logql-analyzer', platform=platforms.all),
 };
 

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -567,7 +567,7 @@
           ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
           ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
-  "querytee-image":
+  "loki-query-tee-image":
     "env":
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.3"
@@ -665,17 +665,17 @@
         - "arch": "linux/arm"
           "runs_on":
           - "ubuntu-arm64"
-  "querytee-manifest":
+  "loki-query-tee-manifest":
     "env":
       "BUILD_TIMEOUT": 60
-      "IMAGE_DIGEST_AMD64": "${{ needs.querytee-image.outputs.image_digest_linux_amd64 }}"
-      "IMAGE_DIGEST_ARM": "${{ needs.querytee-image.outputs.image_digest_linux_arm }}"
-      "IMAGE_DIGEST_ARM64": "${{ needs.querytee-image.outputs.image_digest_linux_arm64 }}"
-      "IMAGE_NAME": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod/querytee"
-      "OUTPUTS_IMAGE_NAME": "${{ needs.querytee-image.outputs.image_name }}"
-      "OUTPUTS_IMAGE_TAG": "${{ needs.querytee-image.outputs.image_tag }}"
+      "IMAGE_DIGEST_AMD64": "${{ needs.loki-query-tee-image.outputs.image_digest_linux_amd64 }}"
+      "IMAGE_DIGEST_ARM": "${{ needs.loki-query-tee-image.outputs.image_digest_linux_arm }}"
+      "IMAGE_DIGEST_ARM64": "${{ needs.loki-query-tee-image.outputs.image_digest_linux_arm64 }}"
+      "IMAGE_NAME": "us-docker.pkg.dev/grafanalabs-global/docker-loki-prod/loki-query-tee"
+      "OUTPUTS_IMAGE_NAME": "${{ needs.loki-query-tee-image.outputs.image_name }}"
+      "OUTPUTS_IMAGE_TAG": "${{ needs.loki-query-tee-image.outputs.image_tag }}"
     "needs":
-    - "querytee-image"
+    - "loki-query-tee-image"
     "permissions":
       "contents": "read"
       "id-token": "write"
@@ -696,7 +696,7 @@
         echo "linux/amd64 $IMAGE_DIGEST_AMD64"
         echo "linux/arm   $IMAGE_DIGEST_ARM"
         
-        # 'needs.querytee-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
+        # 'needs.loki-query-tee-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
         # See https://github.com/actions/runner/issues/2316
         # Using the IMAGE_NAME env variable instead
         IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"


### PR DESCRIPTION
**What this PR does**: renames the `querytee` weekly image jsonnet key to `loki-query-tee` so the `IMAGE_NAME` env in the manifest job points at the same path the image jobs actually push to.

In `images.yml`, the `*-image` jobs push by digest to `${IMAGE_PREFIX}/<image-name>`, where `<image-name>` is the first argument to `build.weeklyImage(...)`. For every other entry — `loki`, `loki-canary`, `loki-canary-boringcrypto`, `logql-analyzer` — that first argument matches the jsonnet key, so the manifest workaround introduced in #22049 (which derives `IMAGE_NAME` from the key because `OUTPUTS_IMAGE_NAME` gets secret-masked, see actions/runner#2316) just happens to land on the right path.

`querytee` was the lone exception: key `querytee` but image `loki-query-tee`. The image jobs pushed digests to `…/docker-loki-prod/loki-query-tee`, but `querytee-manifest` looked them up at `…/docker-loki-prod/querytee` and failed with `not found` on the first ref ([example failure](https://github.com/grafana/loki/actions/runs/26592903983/job/78358763878)).

The fix is the smallest change that removes the implicit "key must equal image suffix" coupling: rename the jsonnet key to match. Job names in the Actions UI change from `querytee-image`/`querytee-manifest` to `loki-query-tee-image`/`loki-query-tee-manifest`. Branch protection on `main` does not reference these job names, and `trigger-cd` only depends on `loki-image`/`loki-manifest`/`loki-canary-manifest`, so nothing downstream cares.

I considered keeping the key as `querytee` and adding a name-lookup table in the jsonnet, but that just re-introduces the coupling we got bitten by — the next time someone adds a `weeklyImage` whose key doesn't match its image name, the same failure mode comes back. Renaming the key makes the mismatch impossible.