### PR TITLE
chore(ci): Enable digest updates for docker & gh actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -58,15 +58,13 @@
       enabled: false,
     },
     {
-      // Disable Go and loki-build-image updates for Dockerfiles
       matchManagers: [
         'dockerfile',
       ],
-      matchPackageNames: [
-        'golang',
-        'grafana/loki-build-image',
-      ],
-      enabled: false,
+      // enable digest updates
+      digest: {
+        enabled: true,
+      },
     },
     {
       // Disable updates driven by Kustomize, used by the operator
@@ -125,6 +123,10 @@
         'minor',
         'patch',
       ],
+      // enable digest updates
+      digest: {
+        enabled: true,
+      },
       autoApprove: false,
       automerge: false,
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/grafana/loki/pull/22052 enables digest pinning for github actions and docker files.
Renovate hasn't created PRs for these since the merge because the config [disables digest updates globally](https://github.com/grafana/loki/blob/d29cb6f9e10d13dee2d1e15740b6d9b8e1bddca8/.github/renovate.json5#L242-L244)

This pr selectively enables digest updates for gh actions and docker files. 
It's also enabling updates to go version in docker files

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
