### PR TITLE
fix(build): Fix build-image Docker context after Dockerfile rewrite in #21790

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,12 @@
 {
-  "image": "grafana/loki-build-image:0.35.1",
+  "build": {
+    "dockerfile": "../loki-build-image/Dockerfile",
+    "context": "..",
+    "args": {
+      "GO_VERSION": "1.26.3",
+      "INSTALL_WORKFLOW_DEPS_ARGS": "dist lint loki-release loki-build-tools"
+    }
+  },
   "containerEnv": {
     "BUILD_IN_CONTAINER": "false"
   },

--- a/Makefile
+++ b/Makefile
@@ -627,13 +627,13 @@ logql-analyzer-image: ## build the logql analyzer docker image
 
 # Build image
 build-image: ## build the build docker image
-	$(OCI_BUILD) -t $(BUILD_IMAGE) ./loki-build-image
+	$(OCI_BUILD) -f loki-build-image/Dockerfile -t $(MAKEFILE_IMAGE) .
 build-image-push:
 ifneq (,$(findstring WIP,$(IMAGE_TAG)))
 	@echo "Cannot push a WIP image, commit changes first"; \
 	false;
 endif
-	DOCKER_BUILDKIT=1 docker buildx build $(OCI_PLATFORMS) $(OCI_BUILD_ARGS) $(OCI_PUSH_ARGS) -t $(BUILD_IMAGE) ./loki-build-image
+	DOCKER_BUILDKIT=1 docker buildx build $(OCI_PLATFORMS) $(OCI_BUILD_ARGS) $(OCI_PUSH_ARGS) -f loki-build-image/Dockerfile -t $(MAKEFILE_IMAGE) .
 
 # Loki Operator
 loki-operator-image: ## build the operator docker image

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ endif
 
 # Ensure you run `make release-workflows` after changing this
 GO_VERSION         := 1.26.3
-# Ensure you run `make IMAGE_TAG=<updated-tag> build-image-push` after changing this
-BUILD_IMAGE_TAG    := 0.35.1
 
 IMAGE_TAG          ?= $(shell ./tools/image-tag)
 GIT_REVISION       := $(shell git rev-parse --short HEAD)
@@ -142,7 +140,7 @@ help: ## Display this help
 .PHONY: docker-driver docker-driver-clean docker-driver-enable docker-driver-push
 .PHONY: fluent-bit-image fluent-bit-test
 .PHONY: fluentd-image fluentd-test
-.PHONY: loki-image build-image build-image-push
+.PHONY: loki-image
 .PHONY: benchmark-store check-mod
 .PHONY: migrate migrate-image lint-markdown ragel
 .PHONY: doc check-doc
@@ -625,16 +623,6 @@ migrate-image: ## build the migrate docker image
 logql-analyzer-image: ## build the logql analyzer docker image
 	$(OCI_BUILD) -t $(LOGQL_ANALYZER_IMAGE) -f cmd/logql-analyzer/Dockerfile .
 
-# Build image
-build-image: ## build the build docker image
-	$(OCI_BUILD) -f loki-build-image/Dockerfile -t $(MAKEFILE_IMAGE) .
-build-image-push:
-ifneq (,$(findstring WIP,$(IMAGE_TAG)))
-	@echo "Cannot push a WIP image, commit changes first"; \
-	false;
-endif
-	DOCKER_BUILDKIT=1 docker buildx build $(OCI_PLATFORMS) $(OCI_BUILD_ARGS) $(OCI_PUSH_ARGS) -f loki-build-image/Dockerfile -t $(MAKEFILE_IMAGE) .
-
 # Loki Operator
 loki-operator-image: ## build the operator docker image
 	$(OCI_BUILD) -t $(OPERATOR_IMAGE) -f operator/Dockerfile ./operator
@@ -812,16 +800,6 @@ dev-k3d-enterprise-logs:
 
 dev-k3d-down:
 	$(MAKE) -C $(CURDIR)/tools/dev/k3d down
-
-# Snyk is used to scan for vulnerabilities
-.PHONY: snyk
-snyk: loki-image build-image
-	snyk container test $(IMAGE_PREFIX)/loki:$(IMAGE_TAG) --file=cmd/loki/Dockerfile
-	snyk container test $(IMAGE_PREFIX)/loki-build-image:$(IMAGE_TAG) --file=loki-build-image/Dockerfile
-	snyk code test
-
-.PHONY: scan-vulnerabilities
-scan-vulnerabilities: snyk
 
 .PHONY: release-workflows
 release-workflows:

--- a/docs/sources/community/maintaining/release-loki-build-image.md
+++ b/docs/sources/community/maintaining/release-loki-build-image.md
@@ -1,24 +1,40 @@
 ---
-title: Releasing Loki Build Image
-description: Releasing Loki Build Image
+title: Loki Build Image
+description: What the Loki build image is and how to change it.
 aliases: 
 - ../../maintaining/release-loki-build-image/
 ---
-# Releasing Loki Build Image
+# Loki Build Image
 
 The [`loki-build-image`](https://github.com/grafana/loki/blob/main/loki-build-image)
-is the Docker image used to run tests and build Grafana Loki binaries in CI.
+provides the toolchain used to build, lint, test, and release Grafana Loki: a Go
+toolchain plus tools such as `golangci-lint`, `goyacc`, `goimports`, `mixtool`,
+`buf`, `helm`, and the packaging tools (`fpm`, `rpm`).
 
-The build and publish process of the image is triggered upon a merge to `main`
-if any changes were made in the folder `./loki-build-image/`.
+It is defined by
+[`loki-build-image/Dockerfile`](https://github.com/grafana/loki/blob/main/loki-build-image/Dockerfile),
+which builds on the `golang:<GO_VERSION>` base image and installs the tooling via
+`.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh`.
 
-**To build and use the `loki-build-image`:**
+## How it is used
 
-1. Create a branch with the desired changes to the `./loki-build-image/Dockerfile`.
-1. Update the `BUILD_IMAGE_VERSION` variable in the `Makefile`.
-1. Commit your changes.
-1. Run `make build-image-push` to build and publish the new version of the build image.
-1. Run `make release-workflows` to update the Github workflows.
-1. Commit your changes.
-1. Push your changes to the remote branch.
-1. Open a PR against the `main` branch.
+The image is **built locally on demand** — it is not published from this repository:
+
+- Running any `make` target with `BUILD_IN_CONTAINER=true` builds the Dockerfile and
+  runs the target inside the resulting container.
+- The
+  [dev container](https://github.com/grafana/loki/blob/main/.devcontainer/devcontainer.json)
+  builds the same Dockerfile for local development.
+
+CI builds Loki directly on the `golang:<GO_VERSION>` image and does not pull a
+pre-published build image.
+
+## Making a change
+
+- **Change the Go version:** update `GO_VERSION` in the `Makefile`. The build image
+  and the generated GitHub workflows derive their Go version from it. See
+  [Patch Go version](../release/patch-go-version/) for the full procedure.
+- **Change the toolchain:** edit `install_workflow_dependencies.sh` (and the
+  `Dockerfile` if needed). The image is rebuilt automatically the next time a
+  containerized `make` target or the dev container is built — there is nothing to
+  publish.

--- a/docs/sources/community/maintaining/release/patch-go-version.md
+++ b/docs/sources/community/maintaining/release/patch-go-version.md
@@ -10,16 +10,21 @@ Update vulnerable Go version to non-vulnerable Go version to build Grafana Loki 
 
 1. Determine the [VERSION_PREFIX](../concepts/version/).
 
-1. Need to sign-in to Docker hub to be able to push Loki build image.
-
 ## Steps
 
-1. Find Go version to which you need to update. Example `1.20.5` to `1.20.6`
+1. Find Go version to which you need to update. Example `1.20.5` to `1.20.6`.
 
-1. Update Go version in the Grafana Loki build image (`loki-build-image/Dockerfile`) on the `main` branch.
+1. On the `main` branch, update `GO_VERSION` in the `Makefile`. This is the source of
+   truth for the [Loki build image](../../release-loki-build-image/) and the generated
+   GitHub workflows.
 
-1. [Release a new Loki Build Image](../../release-loki-build-image/)
+1. Run `tools/go-version-bump.sh <version>` to update the remaining `FROM golang:<ver>`
+   Dockerfiles and the dev container.
 
-1. [Backport](../backport-commits/) the Dockerfile change to `release-VERSION_PREFIX` branch.
+1. Run `make release-workflows` to regenerate the workflow files that embed the Go
+   version.
 
-1. [Backport](../backport-commits/) the Loki Build Image version change from `main` to `release-VERSION_PREFIX` branch.
+1. Update any remaining hardcoded Go versions, for example the `GO_VERSION` entries in
+   the hand-maintained `.github/workflows/` files and the `go` directive in `go.mod`.
+
+1. [Backport](../backport-commits/) the changes to the `release-VERSION_PREFIX` branch.

--- a/tools/go-version-bump.sh
+++ b/tools/go-version-bump.sh
@@ -24,3 +24,12 @@ find cmd clients tools loki-build-image -type f -name 'Dockerfile*' -exec grep -
     echo "Updating ${x}"
     ${SED} -i -re "s,golang:[0-9\.]+,golang:${VERSION},g" "${x}"
   done
+
+# The loki-build-image Dockerfile and the dev container take the Go version via a
+# GO_VERSION build arg (sourced from the Makefile at build time) rather than a
+# literal "FROM golang:<ver>", so update the pinned arg in the dev container too.
+DEVCONTAINER=".devcontainer/devcontainer.json"
+if [[ -f "${DEVCONTAINER}" ]]; then
+  echo "Updating ${DEVCONTAINER}"
+  ${SED} -i -re "s,(\"GO_VERSION\": \")[0-9\.]+(\"),\1${VERSION}\2,g" "${DEVCONTAINER}"
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:

PR #21790 changes the way we containerise the build so that loki-build-image is no longer required.

Also removes the `synk` and `scan-vulnerabilities`  tagets
Updated the dev-container to work without pulling the remote build-imge
Updated the docs for the build-image


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
