### PR TITLE
chore(ci): Remove coveralls reporting in operator workflow

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -112,14 +112,7 @@ jobs:
         cache-dependency-path: ./operator/go.sum
     - name: Run tests
       working-directory: ./operator
-      run: go test -coverprofile=profile.cov ./...
+      run: go test ./...
     - name: Run prometheus rule tests
       working-directory: ./operator
       run: make test-unit-prometheus
-    - name: Send coverage
-      uses: shogo82148/actions-goveralls@9606dbc5ac5cf888a0e9ef901515c3cd516a2790 # v1.11.0
-      with:
-        working-directory: ./operator
-        path-to-profile: profile.cov
-        flag-name: Go-1.25
-        shallow: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Removing as this report is not being used by the maintainers. It also helps remove the use of a third party action `shogo82148/actions-goveralls`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
