### PR TITLE
chore!: Remove index read cache and index cache validity settings

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -89,7 +89,6 @@ func main() {
 	sourceConfig.StorageConfig.TSDBShipperConfig.Mode = indexshipper.ModeReadOnly
 
 	// Shorten these timers up so we resync a little faster and clear index files a little quicker
-	destConfig.StorageConfig.IndexCacheValidity = 1 * time.Minute
 	destConfig.StorageConfig.TSDBShipperConfig.ResyncInterval = 1 * time.Minute
 
 	// Don't want to use the index gateway for this, this makes sure the index files are properly uploaded when the store is stopped.

--- a/docs/sources/operations/troubleshooting/troubleshoot-operations.md
+++ b/docs/sources/operations/troubleshooting/troubleshoot-operations.md
@@ -325,37 +325,6 @@ The compactor requires a working directory for index compaction, but none is con
 - HTTP status: N/A (startup failure)
 - Configurable per tenant: No
 
-### Error: Index cache validity conflict
-
-**Error message:**
-
-```text
-CONFIG ERROR: the active index is <type> which is configured to use an `index_cache_validity` (TTL) of <duration>, however the chunk_retain_period is <duration> which is LESS than the `index_cache_validity`. This can lead to query gaps, please configure the `chunk_retain_period` to be greater than the `index_cache_validity`
-```
-
-**Cause:**
-
-The chunk retain period is shorter than the index cache validity (TTL), which can cause query gaps where data exists in the index cache but the chunks have already been flushed and removed from ingesters.
-
-**Resolution:**
-
-- **Increase the chunk retain period** to be greater than the index cache validity:
-
-  ```yaml
-  ingester:
-    chunk_retain_period: 15m  # Must be > index_cache_validity
-  
-  storage_config:
-    index_cache_validity: 5m
-  ```
-
-**Properties:**
-
-- Enforced by: Configuration validation
-- Retryable: No (configuration must be fixed)
-- HTTP status: N/A (startup failure)
-- Configurable per tenant: No
-
 ### Error: Invalid target with legacy read mode
 
 **Error message:**

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -41,6 +41,7 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 - The deprecated per-tenant setting `unordered_writes` has been removed. Loki now always allows unordered writes.
 - The deprecated setting `-store.index-cache-write` (`chunk_store_config.write_dedupe_cache_config` block in the yaml file) has been removed as it was only used for legacy storage backends that have been removed as well.
+- The setting `-store.index-cache-read` (`storage_config.index_queries_cache_config` block in the yaml file) has been removed as it was only used for legacy storage backends (`boltdb-shipper`) that have been removed as well.
 
 Use the `deprecated-config-checker` tool to validate your `config.yaml`.
 

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -42,6 +42,7 @@ The output is incredibly verbose as it shows the entire internal config struct u
 - The deprecated per-tenant setting `unordered_writes` has been removed. Loki now always allows unordered writes.
 - The deprecated setting `-store.index-cache-write` (`chunk_store_config.write_dedupe_cache_config` block in the yaml file) has been removed as it was only used for legacy storage backends that have been removed as well.
 - The setting `-store.index-cache-read` (`storage_config.index_queries_cache_config` block in the yaml file) has been removed as it was only used for legacy storage backends (`boltdb-shipper`) that have been removed as well.
+- The setting `-store.index-cache-validity` (`storage_config.index_cache_validity` block in the yaml file) has been removed as it was only used in combination with the removed `-store.index-cache-read` setting.
 
 Use the `deprecated-config-checker` tool to validate your `config.yaml`.
 

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -2427,7 +2427,6 @@ The `cache_config` block configures the cache backend for a specific Loki compon
 - `query-engine.task-results-cache`
 - `store.chunks-cache`
 - `store.chunks-cache-l2`
-- `store.index-cache-read`
 
 &nbsp;
 
@@ -2519,7 +2518,7 @@ memcached_client:
 
   # The TLS configuration.
   # The CLI flags prefix for this block configuration is:
-  # store.index-cache-read.memcached
+  # store.chunks-cache-l2.memcached
   [<tls_config>]
 
 redis:
@@ -6643,11 +6642,6 @@ congestion_control:
 # CLI flag: -store.object-prefix
 [object_prefix: <string> | default = ""]
 
-# The cache_config block configures the cache backend for a specific Loki
-# component.
-# The CLI flags prefix for this block configuration is: store.index-cache-read
-[index_queries_cache_config: <cache_config>]
-
 # Disable broad index queries which results in reduced cache usage and faster
 # query performance at the expense of somewhat higher QPS on the index store.
 # CLI flag: -store.disable-broad-index-queries
@@ -7384,7 +7378,6 @@ The TLS configuration. The supported CLI flags `<prefix>` used to reference this
 - `ruler.ring.etcd`
 - `store.chunks-cache-l2.memcached`
 - `store.chunks-cache.memcached`
-- `store.index-cache-read.memcached`
 - `tsdb.shipper.index-gateway-client.grpc`
 - `ui.ring.etcd`
 

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -6583,11 +6583,6 @@ hedging:
 # Storage (COS) backend.
 [cos: <cos_storage_config>]
 
-# Cache validity for active index entries. Should be no higher than
-# -ingester.max-chunk-idle.
-# CLI flag: -store.index-cache-validity
-[index_cache_validity: <duration> | default = 5m]
-
 congestion_control:
   # Use storage congestion control (default: disabled).
   # CLI flag: -store.congestion-control.enabled

--- a/integration/loki_micro_services_test.go
+++ b/integration/loki_micro_services_test.go
@@ -905,7 +905,6 @@ func TestCategorizedLabels(t *testing.T) {
 		tIndexGateway = clu.AddComponent(
 			"index-gateway",
 			"-target=index-gateway",
-			"-store.index-cache-read.embedded-cache.enabled=true",
 		)
 	)
 	require.NoError(t, clu.Run())

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -1165,56 +1165,6 @@ chunk_store_config:
 		})
 	})
 
-	t.Run("for the index queries cache config", func(t *testing.T) {
-		t.Run("no embedded cache enabled by default if Redis is set", func(t *testing.T) {
-			configFileString := `---
-schema_config:
-  configs:
-    - from: 2020-10-24
-      store: boltdb-shipper
-      object_store: filesystem
-      schema: v12
-      index:
-        prefix: index_
-        period: 24h
-storage_config:
-  index_queries_cache_config:
-    redis:
-      endpoint: endpoint.redis.org`
-
-			config, _, _ := configWrapperFromYAML(t, configFileString, nil)
-			assert.EqualValues(t, "endpoint.redis.org", config.StorageConfig.IndexQueriesCacheConfig.Redis.Endpoint)
-			assert.False(t, config.StorageConfig.IndexQueriesCacheConfig.EmbeddedCache.Enabled)
-		})
-
-		t.Run("no embedded cache enabled by default if Memcache is set", func(t *testing.T) {
-			configFileString := `---
-schema_config:
-  configs:
-    - from: 2020-10-24
-      store: boltdb-shipper
-      object_store: filesystem
-      schema: v12
-      index:
-        prefix: index_
-        period: 24h
-storage_config:
-  index_queries_cache_config:
-    memcached_client:
-      host: host.memcached.org`
-
-			config, _, _ := configWrapperFromYAML(t, configFileString, nil)
-
-			assert.EqualValues(t, "host.memcached.org", config.StorageConfig.IndexQueriesCacheConfig.MemcacheClient.Host)
-			assert.False(t, config.StorageConfig.IndexQueriesCacheConfig.EmbeddedCache.Enabled)
-		})
-
-		t.Run("no embedded cache is enabled by default even if no other cache is set", func(t *testing.T) {
-			config, _, _ := configWrapperFromYAML(t, minimalConfig, nil)
-			assert.False(t, config.StorageConfig.IndexQueriesCacheConfig.EmbeddedCache.Enabled)
-		})
-	})
-
 	t.Run("for the query range results cache config", func(t *testing.T) {
 		t.Run("no embedded cache enabled by default if Redis is set", func(t *testing.T) {
 			configFileString := `---
@@ -1991,14 +1941,6 @@ schema_config:
         period: 24h
 storage_config:
   index_cache_validity: 10m
-  index_queries_cache_config:
-    memcached:
-      batch_size: 256
-      parallelism: 10
-    memcached_client:
-      consistent_hash: true
-      host: memcached-index-queries.loki.svc.cluster.local
-      service: memcached-client
 `
 		config, _, err := configWrapperFromYAML(t, yamlContent, nil)
 		assert.NoError(t, err)

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -1939,8 +1939,6 @@ schema_config:
       index:
         prefix: index_
         period: 24h
-storage_config:
-  index_cache_validity: 10m
 `
 		config, _, err := configWrapperFromYAML(t, yamlContent, nil)
 		assert.NoError(t, err)

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -974,7 +974,7 @@ func (t *Loki) updateConfigForShipperStore() {
 	case t.Cfg.isTarget(Ingester), t.Cfg.isTarget(Write):
 		// We do not want ingester to unnecessarily keep downloading files
 		t.Cfg.StorageConfig.TSDBShipperConfig.Mode = indexshipper.ModeWriteOnly
-		t.Cfg.StorageConfig.TSDBShipperConfig.IngesterDBRetainPeriod = shipperQuerierIndexUpdateDelay(t.Cfg.StorageConfig.IndexCacheValidity, t.Cfg.StorageConfig.TSDBShipperConfig.ResyncInterval)
+		t.Cfg.StorageConfig.TSDBShipperConfig.IngesterDBRetainPeriod = shipperQuerierIndexUpdateDelay(t.Cfg.StorageConfig.TSDBShipperConfig.ResyncInterval)
 
 	case t.Cfg.isTarget(Querier), t.Cfg.isTarget(Ruler), t.Cfg.isTarget(Read), t.Cfg.isTarget(Backend), t.isModuleActive(IndexGateway), t.Cfg.isTarget(BloomPlanner), t.Cfg.isTarget(BloomBuilder):
 		// We do not want query to do any updates to index
@@ -983,7 +983,7 @@ func (t *Loki) updateConfigForShipperStore() {
 	default:
 		// All other targets use the shipper store in RW mode
 		t.Cfg.StorageConfig.TSDBShipperConfig.Mode = indexshipper.ModeReadWrite
-		t.Cfg.StorageConfig.TSDBShipperConfig.IngesterDBRetainPeriod = shipperQuerierIndexUpdateDelay(t.Cfg.StorageConfig.IndexCacheValidity, t.Cfg.StorageConfig.TSDBShipperConfig.ResyncInterval)
+		t.Cfg.StorageConfig.TSDBShipperConfig.IngesterDBRetainPeriod = shipperQuerierIndexUpdateDelay(t.Cfg.StorageConfig.TSDBShipperConfig.ResyncInterval)
 	}
 }
 
@@ -998,10 +998,7 @@ func (t *Loki) setupAsyncStore() error {
 
 	minIngesterQueryStoreDuration := shipperMinIngesterQueryStoreDuration(
 		t.Cfg.Ingester.MaxChunkAge,
-		shipperQuerierIndexUpdateDelay(
-			t.Cfg.StorageConfig.IndexCacheValidity,
-			shipperResyncInterval(t.Cfg.StorageConfig, t.Cfg.SchemaConfig.Configs),
-		),
+		shipperQuerierIndexUpdateDelay(t.Cfg.StorageConfig.TSDBShipperConfig.ResyncInterval),
 	)
 
 	switch true {
@@ -1834,7 +1831,7 @@ func (t *Loki) initCompactor() (services.Service, error) {
 		}
 	}
 
-	indexUpdatePropagationMaxDelay := shipperQuerierIndexUpdateDelay(t.Cfg.StorageConfig.IndexCacheValidity, shipperResyncInterval(t.Cfg.StorageConfig, t.Cfg.SchemaConfig.Configs))
+	indexUpdatePropagationMaxDelay := shipperQuerierIndexUpdateDelay(t.Cfg.StorageConfig.TSDBShipperConfig.ResyncInterval)
 	t.compactor, err = compactor.NewCompactor(
 		t.Cfg.CompactorConfig,
 		objectClients,
@@ -2591,10 +2588,8 @@ func calculateAsyncStoreQueryIngestersWithin(queryIngestersWithinConfig, minDura
 // shipperQuerierIndexUpdateDelay returns duration it could take for queriers to serve the index since it was uploaded.
 // It considers upto 3 sync attempts for the indexgateway/queries to be successful in syncing the files to factor in worst case scenarios like
 // failures in sync, low download throughput, various kinds of caches in between etc. which can delay the sync operation from getting all the updates from the storage.
-// It also considers index cache validity because a querier could have cached index just before it was going to resync which means
-// it would keep serving index until the cache entries expire.
-func shipperQuerierIndexUpdateDelay(cacheValidity, resyncInterval time.Duration) time.Duration {
-	return cacheValidity + resyncInterval*3
+func shipperQuerierIndexUpdateDelay(resyncInterval time.Duration) time.Duration {
+	return resyncInterval * 3
 }
 
 // shipperIngesterIndexUploadDelay returns duration it could take for an index file containing id of a chunk to be uploaded to the shared store since it got flushed.
@@ -2607,23 +2602,6 @@ func shipperIngesterIndexUploadDelay() time.Duration {
 // avoid missing any logs or chunk ids due to async nature of shipper.
 func shipperMinIngesterQueryStoreDuration(maxChunkAge, querierUpdateDelay time.Duration) time.Duration {
 	return maxChunkAge + shipperIngesterIndexUploadDelay() + querierUpdateDelay + 5*time.Minute
-}
-
-// shipperResyncInterval returns the resync interval for the active shipper index type (always tsdb)
-func shipperResyncInterval(storageConfig storage.Config, schemaConfigs []config.PeriodConfig) time.Duration {
-	shipperConfigIdx := config.ActivePeriodConfig(schemaConfigs)
-	iTy := schemaConfigs[shipperConfigIdx].IndexType
-	if iTy != types.IndexTypeTSDB {
-		shipperConfigIdx++
-	}
-
-	var resyncInterval time.Duration
-	switch schemaConfigs[shipperConfigIdx].IndexType {
-	case types.IndexTypeTSDB:
-		resyncInterval = storageConfig.TSDBShipperConfig.ResyncInterval
-	}
-
-	return resyncInterval
 }
 
 // NewServerService constructs service from Server component.

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -972,20 +972,6 @@ func (t *Loki) updateConfigForShipperStore() {
 
 	switch true {
 	case t.Cfg.isTarget(Ingester), t.Cfg.isTarget(Write):
-		// Use embedded cache for caching index in memory, this also significantly helps performance.
-		t.Cfg.StorageConfig.IndexQueriesCacheConfig = cache.Config{
-			EmbeddedCache: cache.EmbeddedCacheConfig{
-				Enabled:   true,
-				MaxSizeMB: 200,
-				// This is a small hack to save some CPU cycles.
-				// We check if the object is still valid after pulling it from cache using the IndexCacheValidity value
-				// however it has to be deserialized to do so, setting the cache validity to some arbitrary amount less than the
-				// IndexCacheValidity guarantees the Embedded cache will expire the object first which can be done without
-				// having to deserialize the object.
-				TTL: t.Cfg.StorageConfig.IndexCacheValidity - 1*time.Minute,
-			},
-		}
-
 		// We do not want ingester to unnecessarily keep downloading files
 		t.Cfg.StorageConfig.TSDBShipperConfig.Mode = indexshipper.ModeWriteOnly
 		t.Cfg.StorageConfig.TSDBShipperConfig.IngesterDBRetainPeriod = shipperQuerierIndexUpdateDelay(t.Cfg.StorageConfig.IndexCacheValidity, t.Cfg.StorageConfig.TSDBShipperConfig.ResyncInterval)

--- a/pkg/loki/validation.go
+++ b/pkg/loki/validation.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/grafana/loki/v3/pkg/storage/bucket"
-	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util"
@@ -25,16 +24,6 @@ func validateBackendAndLegacyReadMode(c *Config) []error {
 func validateSchemaRequirements(c *Config) []error {
 	var errs []error
 	p := config.ActivePeriodConfig(c.SchemaConfig.Configs)
-
-	// If the active index type is not TSDB (which does not use an index cache)
-	// and the index queries cache is configured
-	// and the chunk retain period is less than the validity period of the index cache
-	// throw an error.
-	if c.SchemaConfig.Configs[p].IndexType != types.IndexTypeTSDB &&
-		cache.IsCacheConfigured(c.StorageConfig.IndexQueriesCacheConfig) &&
-		c.Ingester.RetainPeriod < c.StorageConfig.IndexCacheValidity {
-		errs = append(errs, fmt.Errorf("CONFIG ERROR: the active index is %s which is configured to use an `index_cache_validity` (TTL) of %s, however the chunk_retain_period is %s which is LESS than the `index_cache_validity`. This can lead to query gaps, please configure the `chunk_retain_period` to be greater than the `index_cache_validity`", c.SchemaConfig.Configs[p].IndexType, c.StorageConfig.IndexCacheValidity, c.Ingester.RetainPeriod))
-	}
 
 	// Schema version 13 is required to use structured metadata
 	version, err := c.SchemaConfig.Configs[p].VersionAsInt()

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/indexgateway"
 	"github.com/grafana/loki/v3/pkg/storage/bucket"
-	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/alibaba"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/aws"
@@ -255,9 +254,8 @@ type Config struct {
 	CongestionControl    congestion.Config         `yaml:"congestion_control,omitempty"`
 	ObjectPrefix         string                    `yaml:"object_prefix" doc:"description=Experimental. Sets a constant prefix for all keys inserted into object storage. Example: loki/"`
 
-	IndexQueriesCacheConfig  cache.Config `yaml:"index_queries_cache_config"`
-	DisableBroadIndexQueries bool         `yaml:"disable_broad_index_queries"`
-	MaxParallelGetChunk      int          `yaml:"max_parallel_get_chunk"`
+	DisableBroadIndexQueries bool `yaml:"disable_broad_index_queries"`
+	MaxParallelGetChunk      int  `yaml:"max_parallel_get_chunk"`
 
 	UseThanosObjstore bool                         `yaml:"use_thanos_objstore"`
 	ObjectStore       bucket.ConfigWithNamedStores `yaml:"object_store"`
@@ -293,7 +291,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.UseThanosObjstore, "use-thanos-objstore", false, "Enables the use of thanos-io/objstore clients for connecting to object storage. When set to true, the configuration inside `storage_config.object_store` or `common.storage.object_store` block takes effect.")
 	cfg.ObjectStore.RegisterFlagsWithPrefix("object-store.", f)
 
-	cfg.IndexQueriesCacheConfig.RegisterFlagsWithPrefix("store.index-cache-read.", "", f)
 	f.DurationVar(&cfg.IndexCacheValidity, "store.index-cache-validity", 5*time.Minute, "Cache validity for active index entries. Should be no higher than -ingester.max-chunk-idle.")
 	f.StringVar(&cfg.ObjectPrefix, "store.object-prefix", "", "The prefix to all keys inserted in object storage. Example: loki-instances/west/")
 	f.BoolVar(&cfg.DisableBroadIndexQueries, "store.disable-broad-index-queries", false, "Disable broad index queries which results in reduced cache usage and faster query performance at the expense of somewhat higher QPS on the index store.")

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/flagext"
@@ -250,7 +249,6 @@ type Config struct {
 	Hedging              hedging.Config            `yaml:"hedging"`
 	NamedStores          NamedStores               `yaml:"named_stores"`
 	COSConfig            ibmcloud.COSConfig        `yaml:"cos"`
-	IndexCacheValidity   time.Duration             `yaml:"index_cache_validity"`
 	CongestionControl    congestion.Config         `yaml:"congestion_control,omitempty"`
 	ObjectPrefix         string                    `yaml:"object_prefix" doc:"description=Experimental. Sets a constant prefix for all keys inserted into object storage. Example: loki/"`
 
@@ -291,7 +289,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.UseThanosObjstore, "use-thanos-objstore", false, "Enables the use of thanos-io/objstore clients for connecting to object storage. When set to true, the configuration inside `storage_config.object_store` or `common.storage.object_store` block takes effect.")
 	cfg.ObjectStore.RegisterFlagsWithPrefix("object-store.", f)
 
-	f.DurationVar(&cfg.IndexCacheValidity, "store.index-cache-validity", 5*time.Minute, "Cache validity for active index entries. Should be no higher than -ingester.max-chunk-idle.")
 	f.StringVar(&cfg.ObjectPrefix, "store.object-prefix", "", "The prefix to all keys inserted in object storage. Example: loki-instances/west/")
 	f.BoolVar(&cfg.DisableBroadIndexQueries, "store.disable-broad-index-queries", false, "Disable broad index queries which results in reduced cache usage and faster query performance at the expense of somewhat higher QPS on the index store.")
 	f.IntVar(&cfg.MaxParallelGetChunk, "store.max-parallel-get-chunk", 150, "Maximum number of parallel chunk reads.")

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/tenant"
-	"github.com/grafana/loki/v3/pkg/util/httpreq"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -38,6 +37,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/deletion"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
 )
 
 var tracer = otel.Tracer("pkg/storage")

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -7,25 +7,21 @@ import (
 	"slices"
 	"time"
 
-	"go.opentelemetry.io/otel"
-
-	"github.com/grafana/loki/v3/pkg/util/httpreq"
-
-	lokilog "github.com/grafana/loki/v3/pkg/logql/log"
-
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/tenant"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
-
-	"github.com/grafana/dskit/tenant"
+	"go.opentelemetry.io/otel"
 
 	"github.com/grafana/loki/v3/pkg/analytics"
 	"github.com/grafana/loki/v3/pkg/indexgateway"
 	"github.com/grafana/loki/v3/pkg/iter"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
+	lokilog "github.com/grafana/loki/v3/pkg/logql/log"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/querier/astmapper"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
@@ -89,9 +85,8 @@ type LokiStore struct {
 	clientMetrics      ClientMetrics
 	registerer         prometheus.Registerer
 
-	indexReadCache cache.Cache
-	chunksCache    cache.Cache
-	chunksCacheL2  cache.Cache
+	chunksCache   cache.Cache
+	chunksCacheL2 cache.Cache
 
 	limits StoreLimits
 	logger log.Logger
@@ -117,11 +112,6 @@ func NewStore(cfg Config, storeCfg config.ChunkStoreConfig, schemaCfg config.Sch
 		}
 	}
 
-	indexReadCache, err := cache.New(cfg.IndexQueriesCacheConfig, registerer, logger, stats.IndexCache, metricsNamespace)
-	if err != nil {
-		return nil, err
-	}
-
 	chunkCacheCfg := storeCfg.ChunkCacheConfig
 	chunkCacheCfg.Prefix = "chunks"
 	chunksCache, err := cache.New(chunkCacheCfg, registerer, logger, stats.ChunkCache, metricsNamespace)
@@ -139,14 +129,8 @@ func NewStore(cfg Config, storeCfg config.ChunkStoreConfig, schemaCfg config.Sch
 
 	// Cache is shared by multiple stores, which means they will try and Stop
 	// it more than once.  Wrap in a StopOnce to prevent this.
-	indexReadCache = cache.StopOnce(indexReadCache)
 	chunksCache = cache.StopOnce(chunksCache)
 	chunksCacheL2 = cache.StopOnce(chunksCacheL2)
-
-	// Lets wrap all caches except chunksCache with CacheGenMiddleware to facilitate cache invalidation using cache generation numbers.
-	// chunksCache is not wrapped because chunks content can't be anyways modified without changing its ID so there is no use of
-	// invalidating chunks cache. Also chunks can be fetched only by their ID found in index and we are anyways removing the index and invalidating index cache here.
-	indexReadCache = cache.NewCacheGenNumMiddleware(indexReadCache)
 
 	err = schemaCfg.Load()
 	if err != nil {
@@ -167,9 +151,8 @@ func NewStore(cfg Config, storeCfg config.ChunkStoreConfig, schemaCfg config.Sch
 		chunkMetrics:       NewChunkMetrics(registerer, cfg.MaxChunkBatchSize),
 		registerer:         registerer,
 
-		indexReadCache: indexReadCache,
-		chunksCache:    chunksCache,
-		chunksCacheL2:  chunksCacheL2,
+		chunksCache:   chunksCache,
+		chunksCacheL2: chunksCacheL2,
 
 		logger: logger,
 		limits: limits,

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -70,8 +70,7 @@ func getLocalStore(path string, cm ClientMetrics) Store {
 			IngesterName:           "ingester-1",
 			Mode:                   indexshipper.ModeReadWrite,
 		},
-		MaxChunkBatchSize:  10,
-		IndexCacheValidity: 1 * time.Minute,
+		MaxChunkBatchSize: 10,
 	}
 
 	schemaConfig := config.SchemaConfig{

--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -306,19 +306,7 @@
       },
 
       storage_config:
-        {
-          index_queries_cache_config: {
-            memcached: {
-              batch_size: 100,
-              parallelism: 100,
-            },
-            memcached_client: {
-              host: 'memcached-index-queries.%s.svc.cluster.local' % $._config.namespace,
-              service: 'memcached-client',
-              consistent_hash: true,
-            },
-          },
-        } + $._config.object_store_config +
+        $._config.object_store_config +
         (
           if $._config.use_thanos_objstore then {
             use_thanos_objstore: true,

--- a/tools/deprecated-config-checker/checker/checker_test.go
+++ b/tools/deprecated-config-checker/checker/checker_test.go
@@ -44,6 +44,7 @@ var (
 		"storage_config.boltdb",
 		"storage_config.grpc_store",
 		"storage_config.aws.dynamodb",
+		"storage_config.index_queries_cache_config",
 		"schema_config.configs.[1].store",
 		"schema_config.configs.[1].object_store",
 		"schema_config.configs.[2].store",

--- a/tools/deprecated-config-checker/checker/checker_test.go
+++ b/tools/deprecated-config-checker/checker/checker_test.go
@@ -45,6 +45,7 @@ var (
 		"storage_config.grpc_store",
 		"storage_config.aws.dynamodb",
 		"storage_config.index_queries_cache_config",
+		"storage_config.index_cache_validity",
 		"schema_config.configs.[1].store",
 		"schema_config.configs.[1].object_store",
 		"schema_config.configs.[2].store",

--- a/tools/deprecated-config-checker/deleted-config.yaml
+++ b/tools/deprecated-config-checker/deleted-config.yaml
@@ -62,6 +62,7 @@ storage_config:
   cassandra: "Support for Cassandra is removed."
   boltdb: "Support for BoltDB is removed."
   grpc_store: "Support for gRPC store is removed."
+  index_queries_cache_config: "Index read cache configuration is removed."
   boltdb_shipper:
     shared_store: "object_store setting in the period_config will be used to configure the store for the index."
     shared_store_key_prefix: "Path prefix for storing the index can now be configured by setting path_prefix under index key in period_config."

--- a/tools/deprecated-config-checker/deleted-config.yaml
+++ b/tools/deprecated-config-checker/deleted-config.yaml
@@ -63,6 +63,7 @@ storage_config:
   boltdb: "Support for BoltDB is removed."
   grpc_store: "Support for gRPC store is removed."
   index_queries_cache_config: "Index read cache configuration is removed."
+  index_cache_validity: "Index cache validity is removed."
   boltdb_shipper:
     shared_store: "object_store setting in the period_config will be used to configure the store for the index."
     shared_store_key_prefix: "Path prefix for storing the index can now be configured by setting path_prefix under index key in period_config."

--- a/tools/deprecated-config-checker/test-fixtures/config.yaml
+++ b/tools/deprecated-config-checker/test-fixtures/config.yaml
@@ -86,6 +86,7 @@ storage_config:
   s3: *s3_cfg
   index_queries_cache_config: # REMOVED
     memcached: {}
+  index_cache_validity: 1m # REMOVED
 
 schema_config:
   configs:

--- a/tools/deprecated-config-checker/test-fixtures/config.yaml
+++ b/tools/deprecated-config-checker/test-fixtures/config.yaml
@@ -84,6 +84,8 @@ storage_config:
     dynamodb: # DEPRECATED
       dynamodb_url: "dynamodb.123abc.net"
   s3: *s3_cfg
+  index_queries_cache_config: # REMOVED
+    memcached: {}
 
 schema_config:
   configs:

--- a/tools/dev/loki-tsdb-storage-s3/config/loki.yaml
+++ b/tools/dev/loki-tsdb-storage-s3/config/loki.yaml
@@ -126,12 +126,6 @@ storage_config:
     s3forcepathstyle: true
     insecure: true
     endpoint: minio:9000
-  index_queries_cache_config:
-    memcached:
-      batch_size: 256
-      parallelism: 10
-    memcached_client:
-      addresses: memcached:11211
   tsdb_shipper:
     active_index_directory: /data/tsdb-index
     cache_location: /data/tsdb-cache


### PR DESCRIPTION
### Summary

`boltdb-shipper`, the only index backend that used the index read cache (`-store.index-cache-read`) and index cache validity (`-store.index-cache-validity`), was previously removed. The corresponding cache infrastructure and configuration remained in place but was no longer exercised by any active code path (TSDB is the only supported index type).

Caching documentation has already been updated with #21651 