### PR TITLE
chore(ci): Remove branch and pr limit on renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -252,6 +252,8 @@
     autoApprove: false,
   },
   osvVulnerabilityAlerts: true,
+  prConcurrentLimit: 0,
+  branchConcurrentLimit: 0,
   branchPrefix: 'deps-update/',
   postUpdateOptions: [
     'gomodUpdateImportPaths',


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/grafana/loki/pull/22052 enabled the default branch and pr limits by mistake.
Defaults are too low for us preventing renovate for raising new prs, reverting this setting back to old value of 0 `no limit`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
