### PR TITLE
feat(distributor): add produce latency histogram to dataobj-tee

### DIFF
--- a/pkg/distributor/dataobj_tee.go
+++ b/pkg/distributor/dataobj_tee.go
@@ -77,6 +77,7 @@ type DataObjTee struct {
 	streamFailures    prometheus.Counter
 	producedBytes     *prometheus.CounterVec
 	producedRecords   *prometheus.CounterVec
+	produceLatency    prometheus.Histogram
 	estimateRateBytes *prometheus.GaugeVec
 }
 
@@ -115,6 +116,14 @@ func NewDataObjTee(
 			Name: "loki_distributor_dataobj_tee_produced_records_total",
 			Help: "Total number of records produced to each partition.",
 		}, []string{"partition", "tenant", "segmentation_key"}),
+		produceLatency: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:                            "loki_distributor_dataobj_tee_produce_latency_seconds",
+			Help:                            "Latency to produce records to the data object topic.",
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
+			NativeHistogramMaxBucketNumber:  100,
+			Buckets:                         prometheus.DefBuckets,
+		}),
 		// These metrics are not emitted at all unless debug metrics are enabled.
 		estimateRateBytes: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "loki_distributor_dataobj_tee_estimate_rate_bytes",
@@ -221,6 +230,7 @@ func (t *DataObjTee) duplicate(ctx context.Context, tenant string, stream segmen
 		return
 	}
 
+	produceTimer := prometheus.NewTimer(t.produceLatency)
 	results := t.kafkaClient.ProduceSync(ctx, records)
 	if err := results.FirstErr(); err != nil {
 		if !errors.Is(err, kgo.ErrMaxBuffered) {
@@ -230,6 +240,7 @@ func (t *DataObjTee) duplicate(ctx context.Context, tenant string, stream segmen
 		pushTracker.doneWithResult(fmt.Errorf("couldn't process request internally due to tee error: %d", TeeCouldntProduceRecordsError))
 		return
 	}
+	produceTimer.ObserveDuration()
 
 	var size int64
 	for _, rec := range records {


### PR DESCRIPTION
**What this PR does**: Adds `loki_distributor_dataobj_tee_produce_latency_seconds` — a histogram around `kafkaClient.ProduceSync` in `DataObjTee.duplicate`. The main ingest path already times its produce calls via `loki_distributor_kafka_latency_seconds` (`distributor.go:1317`), but the tee shares the same kgo client and had no latency observation of its own, so produce latency for the dataobj topic was invisible.

I mirrored the main path's histogram shape — native histogram with `prometheus.DefBuckets`, observed only on successful produce — so the two can be compared side-by-side on the write-path dashboard.

Worth noting: the kprom-emitted `loki_kafka_client_produce_*` metrics get wrapped with `component="distributor"` and aggregate across both topics (no `topic` label), so without this we couldn't see dataobj-tee produce latency in isolation.