### PR TITLE
fix(distributor): Make max_line_size_truncate truncation observable

### DIFF
--- a/docs/sources/operations/request-validation-rate-limits.md
+++ b/docs/sources/operations/request-validation-rate-limits.md
@@ -91,11 +91,13 @@ This error occurs when a log line exceeds the maximum allowable length in bytes.
 
 This value can be modified globally in the [`limits_config`](/docs/loki/<LOKI_VERSION>/configuration/#limits_config) block, or on a per-tenant basis in the [runtime overrides](/docs/loki/<LOKI_VERSION>/configuration/#runtime-configuration-file) file. To increase the maximum line size, adjust `max_line_size`.  We recommend that you do not increase this value above 256kb for performance reasons. Alternatively, Loki can be configured to ingest truncated versions of log lines over the length limit by using the `max_line_size_truncate` option.
 
+When `max_line_size_truncate` is enabled, lines exceeding `max_line_size` are truncated and ingested rather than discarded, so they do **not** appear in the `loki_discarded_samples_total` / `loki_discarded_bytes_total` metrics. Truncation events can instead be observed with the `loki_mutated_samples_total` and `loki_mutated_bytes_total` metrics, both labelled with `reason="line_too_long"` and the `tenant` they belong to. The `distributor` also emits a debug-level log line (`msg="truncated log lines exceeding max_line_size"`) reporting the affected stream, the number of truncated lines, and the number of truncated bytes.
+
 | Property                | Value            |
 |-------------------------|------------------|
 | Enforced by             | `distributor`    |
 | Retryable               | **No**           |
-| Sample discarded        | **Yes**          |
+| Sample discarded        | **Yes** (truncated when `max_line_size_truncate` is enabled) |
 | Configurable per tenant | Yes              |
 
 ### `invalid_labels`

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -56,6 +56,7 @@ When set to `filter-only` or `filter-and-delete`, and `retention_enabled` is set
 
 - The deprecated metric `loki_log_messages_total` is removed in favor of `loki_internal_log_messages_total`.
 - The metric `loki_log_flushes` is renamed to `loki_internal_log_flushes` to be consistent with `loki_internal_log_messages_total`.
+- The second label of the `loki_mutated_samples_total` and `loki_mutated_bytes_total` metrics is renamed from `truncated` to `tenant`. The label always held the tenant ID (not a boolean), so the new name reflects its actual value and is consistent with the `tenant` label on the `loki_discarded_samples_total` / `loki_discarded_bytes_total` metrics. If you have dashboards or alerts that aggregate these metrics by the `truncated` label, update them to use `tenant`.
 
 ### Breaking change: Drop support for non-TSDB stores in jsonnet lib 
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1211,8 +1211,22 @@ func (d *Distributor) truncateLines(vContext validationContext, stream *logproto
 		}
 	}
 
-	validation.MutatedSamples.WithLabelValues(validation.LineTooLong, vContext.userID).Add(float64(truncatedSamples))
-	validation.MutatedBytes.WithLabelValues(validation.LineTooLong, vContext.userID).Add(float64(truncatedBytes))
+	if truncatedSamples > 0 {
+		validation.MutatedSamples.WithLabelValues(validation.LineTooLong, vContext.userID).Add(float64(truncatedSamples))
+		validation.MutatedBytes.WithLabelValues(validation.LineTooLong, vContext.userID).Add(float64(truncatedBytes))
+
+		// Emit a log line so operators can confirm which streams are being
+		// truncated when max_line_size_truncate is enabled, complementing the
+		// mutated_samples_total / mutated_bytes_total metrics.
+		level.Debug(d.logger).Log(
+			"msg", "truncated log lines exceeding max_line_size",
+			"tenant", vContext.userID,
+			"stream", stream.Labels,
+			"max_line_size", vContext.maxLineSize,
+			"truncated_lines", truncatedSamples,
+			"truncated_bytes", truncatedBytes,
+		)
+	}
 }
 
 type pushIngesterTask struct {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -786,10 +786,19 @@ func Test_TruncateLogLines(t *testing.T) {
 		limits, ingester := setup()
 		distributors, _ := prepare(t, 1, 5, limits, func(_ string) (ring_client.PoolClient, error) { return ingester, nil })
 
+		// reset metrics in case they were set from a previous test.
+		validation.MutatedSamples.Reset()
+		validation.MutatedBytes.Reset()
+
 		_, err := distributors[0].Push(ctx, makeWriteRequest(1, 10))
 		require.NoError(t, err)
 		topVal := ingester.Peek()
 		require.Len(t, topVal.Streams[0].Entries[0].Line, 5)
+
+		// Truncation must be observable via the mutated_* metrics: 1 line of 10
+		// bytes truncated to 5 bytes => 1 sample, 5 bytes mutated.
+		assert.Equal(t, float64(1), testutil.ToFloat64(validation.MutatedSamples.WithLabelValues(validation.LineTooLong, "test")))
+		assert.Equal(t, float64(5), testutil.ToFloat64(validation.MutatedBytes.WithLabelValues(validation.LineTooLong, "test")))
 	})
 
 	t.Run("it truncates lines and adds suffix if configured", func(t *testing.T) {

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -89,24 +89,24 @@ func (e *ErrStreamRateLimit) Error() string {
 		e.Bytes.String())
 }
 
-// MutatedSamples is a metric of the total number of lines mutated, by reason.
+// MutatedSamples is a metric of the total number of lines mutated, by reason and tenant.
 var MutatedSamples = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: constants.Loki,
 		Name:      "mutated_samples_total",
 		Help:      "The total number of samples that have been mutated.",
 	},
-	[]string{ReasonLabel, "truncated"},
+	[]string{ReasonLabel, "tenant"},
 )
 
-// MutatedBytes is a metric of the total mutated bytes, by reason.
+// MutatedBytes is a metric of the total mutated bytes, by reason and tenant.
 var MutatedBytes = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: constants.Loki,
 		Name:      "mutated_bytes_total",
 		Help:      "The total number of bytes that have been mutated.",
 	},
-	[]string{ReasonLabel, "truncated"},
+	[]string{ReasonLabel, "tenant"},
 )
 
 // DiscardedBytes is a metric of the total discarded bytes, by reason.


### PR DESCRIPTION
**What this PR does / why we need it**:

When max_line_size_truncate is enabled, oversized log lines are truncated and ingested rather than discarded, so they never show up in the loki_discarded_* metrics. Operators had no clear way to confirm which data was being truncated.

This makes truncation observable in two ways:

- Emit a debug-level distributor log line reporting the affected stream, tenant, configured max_line_size, and the number of truncated lines and bytes whenever a stream is truncated.
- Rename the misleading second label of loki_mutated_samples_total and loki_mutated_bytes_total from "truncated" to "tenant". The label always held the tenant ID, never a boolean, so the new name reflects its real value and matches the "tenant" label on the discarded_* metrics.

Docs for the line_too_long validation reason and the upgrade guide are updated, and the truncation test now asserts the mutated_* metrics.

**Which issue(s) this PR fixes**:
Fixes #22065

**Special notes for your reviewer**:

The mutated_* metrics already existed but were undocumented and their second label was named "truncated" while it actually held the tenant ID, so truncation was effectively unobservable in practice. This PR documents them, fixes the label name, and adds an explicit log line.

This is my first contribution to Loki, so I'm happy to adjust based on your feedback. In particular, the metric label rename (truncated → tenant) is technically a breaking change for any dashboard/alert that aggregates by the old label (noted in the upgrade guide); if you'd prefer to preserve backwards compatibility, I can instead add a new "tenant" label alongside the existing one, or scope this PR down to the docs + log line only.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
