### PR TITLE
fix(helm/loki): propagate persistentVolumeClaimRetentionPolicy on singleBinary sts

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 ## Unreleased
 
+## 7.1.1
+
+- [BUGFIX] Render `persistentVolumeClaimRetentionPolicy` on the `singleBinary` StatefulSet when the value is set under `singleBinary.persistentVolumeClaimRetentionPolicy`; previously the value was accepted but silently ignored by the template.
+
 ## 7.1.0
 
 - [CHANGE] Changed version of Grafana Enterprise Logs to 3.6.8 (updated `enterprise.version`, and `enterprise.image.tag`).

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Enterprise Logs supporting monolithic, simple scalable, and microservices modes.
 type: application
 appVersion: 3.6.8
-version: 7.1.0
+version: 7.1.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/templates/single-binary/statefulset.yaml
+++ b/production/helm/loki/templates/single-binary/statefulset.yaml
@@ -26,7 +26,15 @@ spec:
       partition: 0
   serviceName: {{ include "loki.singleBinaryFullname" . }}-headless
   revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
-  {{- if and (semverCompare ">= 1.23-0" (include "loki.kubeVersion" .)) (.Values.singleBinary.persistence.enableStatefulSetAutoDeletePVC) (.Values.singleBinary.persistence.enabled) }}
+  {{- if .Values.singleBinary.persistentVolumeClaimRetentionPolicy }}
+  {{/*
+    Allow operators to override the StatefulSet PVC retention policy directly via
+    `.Values.singleBinary.persistentVolumeClaimRetentionPolicy`. This takes precedence
+    over the legacy `singleBinary.persistence.enableStatefulSetAutoDeletePVC` toggle.
+  */}}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml .Values.singleBinary.persistentVolumeClaimRetentionPolicy | nindent 4 }}
+  {{- else if and (semverCompare ">= 1.23-0" (include "loki.kubeVersion" .)) (.Values.singleBinary.persistence.enableStatefulSetAutoDeletePVC) (.Values.singleBinary.persistence.enabled) }}
   {{/*
     Data on the singleBinary nodes is easy to replace, so we want to always delete PVCs to make
     operation easier, and will rely on re-fetching data when needed.

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -1540,6 +1540,14 @@ singleBinary:
   nodeSelector: {}
   # -- Tolerations for single binary pods
   tolerations: []
+  # -- StatefulSet `persistentVolumeClaimRetentionPolicy`. When set, takes precedence
+  # over the legacy `singleBinary.persistence.enableStatefulSetAutoDeletePVC`
+  # toggle and is rendered verbatim on the StatefulSet spec. Requires k8s >= 1.23.
+  # Example:
+  #   persistentVolumeClaimRetentionPolicy:
+  #     whenDeleted: Retain
+  #     whenScaled: Retain
+  persistentVolumeClaimRetentionPolicy: {}
   persistence:
     # -- What to do with the volume when the StatefulSet is scaled down.
     whenScaled: Delete


### PR DESCRIPTION
## What this PR does

The `singleBinary` Loki chart accepts a `persistentVolumeClaimRetentionPolicy` value, but `production/helm/loki/templates/single-binary/statefulset.yaml` never renders it. The block at L29-37 of that template only honors the legacy `singleBinary.persistence.enableStatefulSetAutoDeletePVC` toggle (which derives `whenDeleted` / `whenScaled` from `.persistence.*`). As a result, users who set:

```yaml
singleBinary:
  persistentVolumeClaimRetentionPolicy:
    whenDeleted: Retain
    whenScaled: Retain
```

get their PVCs deleted on StatefulSet teardown anyway, because the value is silently dropped — there is no schema validation or render path for it.

## Fix

- Render `persistentVolumeClaimRetentionPolicy` verbatim from `.Values.singleBinary.persistentVolumeClaimRetentionPolicy` when set.
- Fall back to the existing `enableStatefulSetAutoDeletePVC` + `persistence.whenDeleted` / `persistence.whenScaled` behavior when the new value is empty, so existing users see no change.
- Document the value in `values.yaml`.
- Bump chart to `7.1.1` and add CHANGELOG entry.

The same `persistentVolumeClaimRetentionPolicy` field exists on the StatefulSet-backed components in the SSD/microservices modes (`ingester`, `compactor`, `index-gateway`, `bloom-*`, etc.); making `singleBinary` accept the value brings it in line with how operators expect this to work.

## Verification

`helm template` against `deploymentMode: SingleBinary` with the override:

```
persistentVolumeClaimRetentionPolicy:
  whenDeleted: Retain
  whenScaled: Retain
```

emits the user-supplied policy on the StatefulSet. Without the override (default values), the StatefulSet still emits the legacy `Delete/Delete` policy via the existing branch — no regression for current users.

## Checklist
- [x] CHANGELOG updated (`production/helm/loki/CHANGELOG.md`).
- [x] Chart version bumped (`7.1.0` -> `7.1.1`).
- [x] DCO sign-off on the commit.