### PR TITLE
fix(operator): Use thanos objstore CA flags for S3 and Swift storage

### DIFF
--- a/operator/internal/manifests/storage/configure.go
+++ b/operator/internal/manifests/storage/configure.go
@@ -303,11 +303,11 @@ func ensureCAForObjectStorage(p *corev1.PodSpec, tls *TLSConfig, secretType loki
 	switch secretType {
 	case lokiv1.ObjectStorageSecretS3:
 		container.Args = append(container.Args,
-			fmt.Sprintf("-s3.http.ca-file=%s", path.Join(caDirectory, tls.Key)),
+			fmt.Sprintf("-common.storage.object-store.s3.http.tls-ca-path=%s", path.Join(caDirectory, tls.Key)),
 		)
 	case lokiv1.ObjectStorageSecretSwift:
 		container.Args = append(container.Args,
-			fmt.Sprintf("-swift.http.tls-ca-path=%s", path.Join(caDirectory, tls.Key)),
+			fmt.Sprintf("-common.storage.object-store.swift.http.tls-ca-path=%s", path.Join(caDirectory, tls.Key)),
 		)
 	}
 

--- a/operator/internal/manifests/storage/configure_test.go
+++ b/operator/internal/manifests/storage/configure_test.go
@@ -2562,7 +2562,7 @@ func TestConfigureDeploymentForStorageCA(t *testing.T) {
 										},
 									},
 									Args: []string{
-										"-s3.http.ca-file=/etc/storage/ca/service-ca.crt",
+										"-common.storage.object-store.s3.http.tls-ca-path=/etc/storage/ca/service-ca.crt",
 									},
 									Env: []corev1.EnvVar{
 										{
@@ -2658,7 +2658,7 @@ func TestConfigureDeploymentForStorageCA(t *testing.T) {
 										},
 									},
 									Args: []string{
-										"-swift.http.tls-ca-path=/etc/storage/ca/service-ca.crt",
+										"-common.storage.object-store.swift.http.tls-ca-path=/etc/storage/ca/service-ca.crt",
 									},
 									Env: []corev1.EnvVar{
 										{
@@ -2852,7 +2852,7 @@ func TestConfigureStatefulSetForStorageCA(t *testing.T) {
 										},
 									},
 									Args: []string{
-										"-s3.http.ca-file=/etc/storage/ca/service-ca.crt",
+										"-common.storage.object-store.s3.http.tls-ca-path=/etc/storage/ca/service-ca.crt",
 									},
 									Env: []corev1.EnvVar{
 										{
@@ -2948,7 +2948,7 @@ func TestConfigureStatefulSetForStorageCA(t *testing.T) {
 										},
 									},
 									Args: []string{
-										"-swift.http.tls-ca-path=/etc/storage/ca/service-ca.crt",
+										"-common.storage.object-store.swift.http.tls-ca-path=/etc/storage/ca/service-ca.crt",
 									},
 									Env: []corev1.EnvVar{
 										{


### PR DESCRIPTION
**What this PR does / why we need it**:

The operator mounts a user-supplied CA ConfigMap for S3 and Swift object storage and passes its path to Loki via a CLI flag. Since the migration to the thanos objstore backend (#20475), storage operations go through the thanos bucket client, but the operator was still emitting the legacy client flags:

- `-s3.http.ca-file`
- `-swift.http.tls-ca-path`

The thanos client never reads those, so the CA was ignored and the client fell back to the system root CAs. With an internal CA this fails with `tls: failed to verify certificate: x509: certificate signed by unknown authority`, and the compactor (and other storage-touching pods) crashloop. This is a regression: it worked in operator 0.9.0 and broke in 0.10.x.

The fix emits the flags the thanos client actually reads:

- `-common.storage.object-store.s3.http.tls-ca-path`
- `-common.storage.object-store.swift.http.tls-ca-path`

**Which issue(s) this PR fixes**:
Fixes #21739

**Special notes for your reviewer**:

The issue only reports S3, but Swift has the identical bug (legacy flag emitted, thanos client reads the prefixed one), so both are fixed here. GCS and Azure are not affected: the operator never mounts a CA for them, and their thanos configs
don't expose a CA path.

Verified by updating the existing CA test expectations to the thanos flags first (they failed against the old code, confirming the bug), then applying the fix.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)

