### PR TITLE
fix(storage): Keep TSDB index filenames raw for S3 delimiter 🤖🤖🤖

### DIFF
--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -447,6 +447,44 @@ func NewObjectClient(name, component string, cfg Config, clientMetrics ClientMet
 	}
 }
 
+func newIndexObjectClient(name, component string, cfg Config, clientMetrics ClientMetrics) (client.ObjectClient, error) {
+	return NewObjectClient(name, component, withoutChunkDelimiterForIndexObjectClient(name, cfg), clientMetrics)
+}
+
+func withoutChunkDelimiterForIndexObjectClient(name string, cfg Config) Config {
+	if cfg.UseThanosObjstore {
+		return cfg
+	}
+
+	storeType := name
+	if nsType, ok := cfg.NamedStores.storeType[name]; ok {
+		storeType = nsType
+	}
+
+	if storeType != types.StorageTypeAWS && storeType != types.StorageTypeS3 {
+		return cfg
+	}
+
+	if _, ok := cfg.NamedStores.storeType[name]; ok {
+		namedCfg, ok := cfg.NamedStores.AWS[name]
+		if !ok {
+			return cfg
+		}
+
+		namedAWS := make(map[string]NamedAWSStorageConfig, len(cfg.NamedStores.AWS))
+		for storeName, storeCfg := range cfg.NamedStores.AWS {
+			namedAWS[storeName] = storeCfg
+		}
+		namedCfg.ChunkDelimiter = ""
+		namedAWS[name] = namedCfg
+		cfg.NamedStores.AWS = namedAWS
+		return cfg
+	}
+
+	cfg.S3Config.ChunkDelimiter = ""
+	return cfg
+}
+
 // internalNewObjectClient makes the underlying StorageClient of the desired types.
 func internalNewObjectClient(storeName string, cfg Config, clientMetrics ClientMetrics) (client.ObjectClient, error) {
 	var (

--- a/pkg/storage/factory_test.go
+++ b/pkg/storage/factory_test.go
@@ -1,16 +1,22 @@
 package storage
 
 import (
+	"context"
 	"os"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/grafana/dskit/flagext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
+	lokiaws "github.com/grafana/loki/v3/pkg/storage/chunk/client/aws"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/local"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
@@ -152,6 +158,95 @@ func TestNamedStores_populateStoreType(t *testing.T) {
 
 		_, ok = ns.storeType["store-4"]
 		assert.False(t, ok)
+	})
+}
+
+type listObjectKeysS3Client struct {
+	*s3.Client
+	keys []string
+}
+
+func (c listObjectKeysS3Client) ListObjectsV2(context.Context, *s3.ListObjectsV2Input, ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	modifiedAt := time.Unix(0, 0)
+	contents := make([]s3types.Object, 0, len(c.keys))
+	for _, key := range c.keys {
+		contents = append(contents, s3types.Object{
+			Key:          awssdk.String(key),
+			LastModified: awssdk.Time(modifiedAt),
+		})
+	}
+
+	return &s3.ListObjectsV2Output{
+		Contents:    contents,
+		IsTruncated: awssdk.Bool(false),
+	}, nil
+}
+
+func listedS3ObjectKeys(t *testing.T, objectClient client.ObjectClient, keys ...string) []string {
+	t.Helper()
+
+	s3ObjectClient, ok := objectClient.(*lokiaws.S3ObjectClient)
+	require.True(t, ok)
+	s3ObjectClient.S3 = listObjectKeysS3Client{keys: keys}
+
+	objects, _, err := s3ObjectClient.List(context.Background(), "", "")
+	require.NoError(t, err)
+
+	listedKeys := make([]string, 0, len(objects))
+	for _, object := range objects {
+		listedKeys = append(listedKeys, object.Key)
+	}
+
+	return listedKeys
+}
+
+func testS3Config() lokiaws.S3Config {
+	var cfg lokiaws.S3Config
+	flagext.DefaultValues(&cfg)
+	cfg.BucketNames = "bucket"
+	cfg.ChunkDelimiter = "-"
+	cfg.AccessKeyID = "test-key"
+	cfg.SecretAccessKey = flagext.SecretWithValue("test-secret")
+	return cfg
+}
+
+func TestNewIndexObjectClientDoesNotApplyS3ChunkDelimiter(t *testing.T) {
+	const indexKey = "tsdb_index_20332/1779799681971192955-compactor-1779659125419-1779761781223-4eafaf2b.tsdb"
+	colonizedIndexKey := strings.ReplaceAll(indexKey, "-", ":")
+
+	t.Run("default s3 storage", func(t *testing.T) {
+		var cfg Config
+		flagext.DefaultValues(&cfg)
+		cfg.S3Config = testS3Config()
+
+		chunkObjectClient, err := NewObjectClient(types.StorageTypeS3, "chunk-store", cfg, cm)
+		require.NoError(t, err)
+		require.Equal(t, []string{colonizedIndexKey}, listedS3ObjectKeys(t, chunkObjectClient, indexKey))
+
+		indexObjectClient, err := newIndexObjectClient(types.StorageTypeS3, "index-store", cfg, cm)
+		require.NoError(t, err)
+		require.Equal(t, []string{indexKey}, listedS3ObjectKeys(t, indexObjectClient, indexKey))
+		require.Equal(t, "-", cfg.S3Config.ChunkDelimiter)
+	})
+
+	t.Run("named aws storage", func(t *testing.T) {
+		var cfg Config
+		flagext.DefaultValues(&cfg)
+		cfg.NamedStores = NamedStores{
+			AWS: map[string]NamedAWSStorageConfig{
+				"store-1": NamedAWSStorageConfig(testS3Config()),
+			},
+		}
+		require.NoError(t, cfg.NamedStores.Validate())
+
+		chunkObjectClient, err := NewObjectClient("store-1", "chunk-store", cfg, cm)
+		require.NoError(t, err)
+		require.Equal(t, []string{colonizedIndexKey}, listedS3ObjectKeys(t, chunkObjectClient, indexKey))
+
+		indexObjectClient, err := newIndexObjectClient("store-1", "index-store", cfg, cm)
+		require.NoError(t, err)
+		require.Equal(t, []string{indexKey}, listedS3ObjectKeys(t, indexObjectClient, indexKey))
+		require.Equal(t, "-", cfg.NamedStores.AWS["store-1"].ChunkDelimiter)
 	})
 }
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -251,7 +251,7 @@ func (s *LokiStore) storeForPeriod(p config.PeriodConfig, tableRange config.Tabl
 		}, nil
 	}
 
-	objectClient, err := NewObjectClient(p.ObjectType, component, s.cfg, s.clientMetrics)
+	objectClient, err := newIndexObjectClient(p.ObjectType, component, s.cfg, s.clientMetrics)
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

When `aws.chunk_delimiter` is configured, the S3 object client translates listed object keys from the configured delimiter back to `:`. That is correct for chunk keys, but the TSDB index shipper also uses an S3 object client and uses listed object names as local cache filenames.

With `chunk_delimiter: "-"`, TSDB index objects such as:

```text
1779799681971192955-compactor-1779659125419-1779761781223-4eafaf2b.tsdb
```

were listed as:

```text
1779799681971192955:compactor:1779659125419:1779761781223:4eafaf2b.tsdb
```

The backend then stored that colonized name in `tsdb-shipper-cache`, and TSDB rejected it as an invalid path.

This PR creates TSDB/index object clients with the S3 `ChunkDelimiter` cleared. Chunk clients still keep the configured delimiter translation, while TSDB index listings keep their original hyphenated filenames. The helper also handles named AWS stores without mutating the caller's config.

**Which issue(s) this PR fixes**:

Fixes #22061
Related to #19297

**Special notes for your reviewer**:

This keeps the existing chunk delimiter behavior scoped to chunk object clients and avoids changing generic S3 list semantics for other object-client users.

**Validation**:

```bash
PATH=/tmp/go1.26.3/bin:$PATH GOTOOLCHAIN=local go test -run TestNewIndexObjectClientDoesNotApplyS3ChunkDelimiter ./pkg/storage
PATH=/tmp/go1.26.3/bin:$PATH GOTOOLCHAIN=local go test ./pkg/storage
PATH=/tmp/go1.26.3/bin:$PATH GOTOOLCHAIN=local go test ./pkg/storage/stores/shipper/indexshipper/storage
PATH=/tmp/go1.26.3/bin:$PATH GOTOOLCHAIN=local go test ./pkg/storage/stores/shipper/indexshipper/downloads
PATH=/tmp/go1.26.3/bin:$PATH GOTOOLCHAIN=local go test ./pkg/storage/stores/shipper/indexshipper/tsdb -run 'Test.*Identifier|Test.*Compactor|Test.*Head'
PATH=/tmp/go1.26.3/bin:$PATH GOTOOLCHAIN=local go test ./pkg/storage/...
git diff --check
```

**Checklist**

- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.
