### PR TITLE
ci(operator): Publish loki-operator image to GAR instead of DockerHub

### DIFF
--- a/.github/workflows/operator-images.yaml
+++ b/.github/workflows/operator-images.yaml
@@ -16,8 +16,8 @@ jobs:
     uses: ./.github/workflows/operator-reusable-image-build.yml
     with:
       dockerfile: "operator/Dockerfile"
-      registry: "docker.io"
-      organization: "grafana"
+      registry: "us-docker.pkg.dev"
+      organization: "grafanalabs-global/dockerhub-loki-prod-mirror"
       image_name: "loki-operator"
       tag: "latest"
 

--- a/.github/workflows/operator-reusable-image-build.yml
+++ b/.github/workflows/operator-reusable-image-build.yml
@@ -36,10 +36,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: "Login to DockerHub (from vault)"
-        if: ${{ inputs.registry == 'docker.io' }}
-        uses: "grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746"
-
       - name: "Login to GAR"
         if: ${{ inputs.registry == 'us-docker.pkg.dev' }}
         uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"

--- a/.github/workflows/operator-reusable-image-build.yml
+++ b/.github/workflows/operator-reusable-image-build.yml
@@ -40,8 +40,14 @@ jobs:
         if: ${{ inputs.registry == 'docker.io' }}
         uses: "grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746"
 
+      - name: "Login to GAR"
+        if: ${{ inputs.registry == 'us-docker.pkg.dev' }}
+        uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+        with:
+          registry: "us-docker.pkg.dev"
+
       - name: "fetch openshift credentials from vault"
-        if: ${{ inputs.registry != 'docker.io' }}
+        if: ${{ inputs.registry == 'quay.io' }}
         uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
         with:
           repo_secrets: |
@@ -49,7 +55,7 @@ jobs:
             OPENSHIFT_PASS=openshift-credentials:password
 
       - name: Login to Quay.io
-        if: ${{ inputs.registry != 'docker.io' }}
+        if: ${{ inputs.registry == 'quay.io' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: quay.io


### PR DESCRIPTION
**What this PR does / why we need it**:

The `publish-grafana-operator` job in the `operator images` workflow currently pushes `loki-operator` to `docker.io/grafana/loki-operator:latest`. Pushing to DockerHub is now prohibited.

This change points the job at the same Google Artifact Registry path the rest of Loki uses:

```
us-docker.pkg.dev/grafanalabs-global/docker-loki-prod/loki-operator:latest
```

- **`operator-images.yaml`**: `publish-grafana-operator` now sets `registry: us-docker.pkg.dev` and `organization: grafanalabs-global/docker-loki-prod`.
- **`operator-reusable-image-build.yml`**: added a `Login to GAR` step (the `login-to-gar` shared action, pinned to the same SHA used by `images.yml`), gated on `registry == 'us-docker.pkg.dev'`. It uses the job's existing `id-token: write` OIDC permission, so no new secrets are required.
- The two OpenShift/Quay login steps were changed from `registry != 'docker.io'` to `registry == 'quay.io'` so the new GAR registry does not accidentally trigger the OpenShift vault/Quay login path.

The `build-push` step needs no change — its tag template `${registry}/${organization}/${image_name}:${tag}` produces the correct GAR path. The four `quay.io` OpenShift jobs are untouched.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

This assumes the GAR OIDC identity used by `images.yml` is permitted to push the `loki-operator` repo under `docker-loki-prod`, alongside the existing `loki`, `loki-canary`, etc. images.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.