### PR TITLE
feat(compactor): Reuse logsobj builder metrics

### DIFF
--- a/pkg/dataobj/consumer/flush_test.go
+++ b/pkg/dataobj/consumer/flush_test.go
@@ -28,7 +28,7 @@ func TestFlusher_Flush(t *testing.T) {
 			now          = time.Now()
 		)
 		// Create a builder and append some logs so it can be flushed.
-		realBuilder, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory())
+		realBuilder, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory(), logsobj.NewBuilderMetrics())
 		require.NoError(t, err)
 		testBuilder = &mockBuilder{builder: realBuilder}
 		require.NoError(t, testBuilder.Append("test", logproto.Stream{

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -210,7 +210,7 @@ type TenantOverrides interface {
 // synchronization.
 type Builder struct {
 	cfg       BuilderConfig
-	metrics   *builderMetrics
+	metrics   *BuilderMetrics
 	overrides TenantOverrides
 	logger    log.Logger
 
@@ -238,18 +238,11 @@ const (
 // NewBuilder creates a new [Builder] which stores log-oriented data objects.
 //
 // NewBuilder returns an error if the provided config is invalid.
-func NewBuilder(cfg BuilderConfig, scratchStore scratch.Store) (*Builder, error) {
-	if err := cfg.Validate(); err != nil {
-		return nil, err
-	}
-
+func NewBuilder(cfg BuilderConfig, scratchStore scratch.Store, metrics *BuilderMetrics) (*Builder, error) {
 	labelCache, err := lru.New[string, labels.Labels](5000)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create LRU cache: %w", err)
 	}
-
-	metrics := newBuilderMetrics()
-	metrics.ObserveConfig(cfg)
 
 	return &Builder{
 		cfg:        cfg,
@@ -660,20 +653,6 @@ func (b *Builder) Reset() {
 	b.metrics.sizeEstimate.Set(0)
 	b.currentSizeEstimate = 0
 	b.state = builderStateEmpty
-}
-
-// RegisterMetrics registers metrics about builder to report to reg. All
-// metrics will have a tenant label set to the tenant ID of the Builder.
-//
-// If multiple Builders for the same tenant are running in the same process,
-// reg must contain additional labels to differentiate between them.
-func (b *Builder) RegisterMetrics(reg prometheus.Registerer) error {
-	return b.metrics.Register(reg)
-}
-
-// UnregisterMetrics unregisters metrics about builder from reg.
-func (b *Builder) UnregisterMetrics(reg prometheus.Registerer) {
-	b.metrics.Unregister(reg)
 }
 
 // drainLogsIter consumes iter, appending each record to lb and flushing

--- a/pkg/dataobj/consumer/logsobj/builder_metrics.go
+++ b/pkg/dataobj/consumer/logsobj/builder_metrics.go
@@ -10,8 +10,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 )
 
-// builderMetrics provides instrumnetation for a [Builder].
-type builderMetrics struct {
+// BuilderMetrics provides instrumentation for a [Builder].
+type BuilderMetrics struct {
 	logs    *logs.Metrics
 	streams *streams.Metrics
 	dataobj *dataobj.Metrics
@@ -28,10 +28,10 @@ type builderMetrics struct {
 	builtSize    prometheus.Histogram
 }
 
-// newBuilderMetrics creates a new set of [builderMetrics] for instrumenting
+// NewBuilderMetrics creates a new set of [BuilderMetrics] for instrumenting
 // logs objects.
-func newBuilderMetrics() *builderMetrics {
-	return &builderMetrics{
+func NewBuilderMetrics() *BuilderMetrics {
+	return &BuilderMetrics{
 		logs:    logs.NewMetrics(),
 		streams: streams.NewMetrics(),
 		dataobj: dataobj.NewMetrics(),
@@ -85,13 +85,13 @@ func newBuilderMetrics() *builderMetrics {
 }
 
 // ObserveConfig updates config metrics based on the provided [BuilderConfig].
-func (m *builderMetrics) ObserveConfig(cfg BuilderConfig) {
+func (m *BuilderMetrics) ObserveConfig(cfg BuilderConfig) {
 	m.targetPageSize.Set(float64(cfg.TargetPageSize))
 	m.targetObjectSize.Set(float64(cfg.TargetObjectSize))
 }
 
 // Register registers metrics to report to reg.
-func (m *builderMetrics) Register(reg prometheus.Registerer) error {
+func (m *BuilderMetrics) Register(reg prometheus.Registerer) error {
 	var errs []error
 
 	errs = append(errs, m.logs.Register(reg))
@@ -113,7 +113,7 @@ func (m *builderMetrics) Register(reg prometheus.Registerer) error {
 }
 
 // Unregister unregisters metrics from the provided Registerer.
-func (m *builderMetrics) Unregister(reg prometheus.Registerer) {
+func (m *BuilderMetrics) Unregister(reg prometheus.Registerer) {
 	m.logs.Unregister(reg)
 	m.streams.Unregister(reg)
 	m.dataobj.Unregister(reg)

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -76,7 +76,7 @@ func TestBuilder(t *testing.T) {
 	}
 
 	t.Run("Build", func(t *testing.T) {
-		builder, err := NewBuilder(testBuilderConfig, nil)
+		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
 		require.NoError(t, err)
 
 		for _, entry := range testStreams {
@@ -97,7 +97,7 @@ func TestBuilder_Append(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	builder, err := NewBuilder(testBuilderConfig, nil)
+	builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
 	require.NoError(t, err)
 
 	tenant := "test"
@@ -135,7 +135,7 @@ func TestBuilder_Append(t *testing.T) {
 }
 
 func TestBuilder_CopyAndSort(t *testing.T) {
-	builder, _ := NewBuilder(testBuilderConfig, nil)
+	builder, _ := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
 
 	now := time.Date(2025, time.September, 17, 0, 0, 0, 0, time.UTC)
 	numRows := 16 // 16 rows with 1KiB each line and 8KiB section size ~> 2 logs sections per tenant
@@ -157,7 +157,7 @@ func TestBuilder_CopyAndSort(t *testing.T) {
 	require.NoError(t, err)
 	defer closer1.Close()
 
-	newBuilder, _ := NewBuilder(testBuilderConfig, nil)
+	newBuilder, _ := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
 
 	obj2, closer2, err := newBuilder.CopyAndSort(t.Context(), obj1)
 	require.NoError(t, err)
@@ -224,7 +224,7 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 
 	buildObj := func(t *testing.T, cfg BuilderConfig, tenant string, appVals []string, overrides TenantOverrides) *dataobj.Object {
 		t.Helper()
-		b, err := NewBuilder(cfg, nil)
+		b, err := NewBuilder(cfg, nil, NewBuilderMetrics())
 		require.NoError(t, err)
 		if overrides != nil {
 			b.SetOverrides(overrides)
@@ -248,7 +248,7 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 
 	copyAndSort := func(t *testing.T, cfg BuilderConfig, src *dataobj.Object, overrides TenantOverrides) *dataobj.Object {
 		t.Helper()
-		b, err := NewBuilder(cfg, nil)
+		b, err := NewBuilder(cfg, nil, NewBuilderMetrics())
 		require.NoError(t, err)
 		if overrides != nil {
 			b.SetOverrides(overrides)
@@ -326,7 +326,7 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 		cfg := makeCfg(true)
 		overrides := tenantOverrides{"schema-tenant": {"label:app"}}
 
-		b, err := NewBuilder(cfg, nil)
+		b, err := NewBuilder(cfg, nil, NewBuilderMetrics())
 		require.NoError(t, err)
 		b.SetOverrides(overrides)
 		for _, app := range []string{"zoo", "alpha", "middle"} {
@@ -401,7 +401,7 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 	t.Run("multi-label compound key", func(t *testing.T) {
 		cfg := makeCfg(true)
 		overrides := tenantOverrides{"t1": {"label:namespace", "label:app"}}
-		b, err := NewBuilder(cfg, nil)
+		b, err := NewBuilder(cfg, nil, NewBuilderMetrics())
 		require.NoError(t, err)
 		b.SetOverrides(overrides)
 

--- a/pkg/dataobj/consumer/logsobj/factory.go
+++ b/pkg/dataobj/consumer/logsobj/factory.go
@@ -1,10 +1,8 @@
 package logsobj
 
 import (
-	"fmt"
-
 	"github.com/go-kit/log"
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/go-kit/log/level"
 
 	"github.com/grafana/loki/v3/pkg/scratch"
 )
@@ -15,26 +13,52 @@ type BuilderFactory struct {
 	scratchStore scratch.Store
 	overrides    TenantOverrides
 	logger       log.Logger
+	metrics      *BuilderMetrics
 }
 
-// SetOverrides configures per-tenant overrides propagated to every builder
-// created by this factory.
-func (f *BuilderFactory) SetOverrides(overrides TenantOverrides) {
-	f.overrides = overrides
-}
+// NewBuilderFactory validates the config, reports related metrics, and returns a factory that is prepared to create new
+// builders.
+func NewBuilderFactory(
+	cfg BuilderConfig,
+	scratchStore scratch.Store,
+	metrics *BuilderMetrics,
+	logger log.Logger,
+	overrides TenantOverrides,
+) (*BuilderFactory, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	metrics.ObserveConfig(cfg)
 
-func NewBuilderFactory(cfg BuilderConfig, scratchStore scratch.Store, logger log.Logger) *BuilderFactory {
+	if overrides != nil {
+		level.Info(logger).Log("msg", "sort schema overrides wired to builder factory at construction")
+	} else {
+		level.Warn(logger).Log("msg", "sort schema overrides not provided at construction; schema sort will not apply to the initial builder")
+	}
+
 	return &BuilderFactory{
 		cfg:          cfg,
 		scratchStore: scratchStore,
+		metrics:      metrics,
 		logger:       logger,
-	}
+		overrides:    overrides,
+	}, nil
 }
 
-// NewBuilder returns a new builder, or an error. The registerer is optional.
-// No metrics will be registered if the registerer is nil.
-func (f *BuilderFactory) NewBuilder(r prometheus.Registerer) (*Builder, error) {
-	b, err := NewBuilder(f.cfg, f.scratchStore)
+// NewBuilder returns a new builder, or an error. The returned builder shares
+// the factory's [BuilderMetrics].
+func (f *BuilderFactory) NewBuilder() (*Builder, error) {
+	return f.newBuilderWithMetrics(f.metrics)
+}
+
+// NewSorterBuilder returns a new builder with "fake" non-registered metrics.
+// TODO(ivkalita): This is temporary to prevent "sorting" builder metrics from messing up the real builder metrics.
+func (f *BuilderFactory) NewSorterBuilder() (*Builder, error) {
+	return f.newBuilderWithMetrics(NewBuilderMetrics())
+}
+
+func (f *BuilderFactory) newBuilderWithMetrics(metrics *BuilderMetrics) (*Builder, error) {
+	b, err := NewBuilder(f.cfg, f.scratchStore, metrics)
 	if err != nil {
 		return nil, err
 	}
@@ -42,10 +66,5 @@ func (f *BuilderFactory) NewBuilder(r prometheus.Registerer) (*Builder, error) {
 		b.SetOverrides(f.overrides)
 	}
 	b.SetLogger(f.logger)
-	if r != nil {
-		if err = b.RegisterMetrics(r); err != nil {
-			return nil, fmt.Errorf("failed to register metrics: %w", err)
-		}
-	}
 	return b, nil
 }

--- a/pkg/dataobj/consumer/logsobj/factory_test.go
+++ b/pkg/dataobj/consumer/logsobj/factory_test.go
@@ -11,19 +11,50 @@ import (
 	"github.com/grafana/loki/v3/pkg/scratch"
 )
 
-func TestBuilderFactory(t *testing.T) {
-	bf := NewBuilderFactory(testBuilderConfig, scratch.NewMemory(), log.NewNopLogger())
-	// Can create a builder without registering metrics.
-	b, err := bf.NewBuilder(nil)
+func newTestBuilderFactory(t *testing.T, reg prometheus.Registerer, overrides TenantOverrides) *BuilderFactory {
+	t.Helper()
+	metrics := NewBuilderMetrics()
+	require.NoError(t, metrics.Register(reg))
+	bf, err := NewBuilderFactory(testBuilderConfig, scratch.NewMemory(), metrics, log.NewNopLogger(), overrides)
+	require.NoError(t, err)
+	return bf
+}
+
+func TestBuilderFactory_NewSorterBuilder(t *testing.T) {
+	bf := newTestBuilderFactory(t, prometheus.NewRegistry(), nil)
+
+	b, err := bf.NewSorterBuilder()
 	require.NoError(t, err)
 	require.NotNil(t, b)
-	// Can also create a builder with metrics.
+}
+
+func TestBuilderFactory_NewBuilder(t *testing.T) {
+	bf := newTestBuilderFactory(t, prometheus.NewRegistry(), nil)
+
+	b, err := bf.NewBuilder()
+	require.NoError(t, err)
+	require.NotNil(t, b)
+}
+
+func TestBuilderFactory_RegistersMetrics(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	b, err = bf.NewBuilder(reg)
-	require.NoError(t, err)
-	require.NotNil(t, b)
+	newTestBuilderFactory(t, reg, nil)
+
 	// Should be able to gather registered metrics.
 	n, err := testutil.GatherAndCount(reg)
 	require.NoError(t, err)
 	require.Greater(t, n, 0)
+}
+
+func TestBuilderFactory_SetsOverridesOnBuilders(t *testing.T) {
+	overrides := tenantOverrides{"tenant": {"label"}}
+	bf := newTestBuilderFactory(t, prometheus.NewRegistry(), overrides)
+
+	b, err := bf.NewBuilder()
+	require.NoError(t, err)
+	require.Equal(t, overrides, b.overrides)
+
+	b, err = bf.NewSorterBuilder()
+	require.NoError(t, err)
+	require.Equal(t, overrides, b.overrides)
 }

--- a/pkg/dataobj/consumer/logsobj/pool_test.go
+++ b/pkg/dataobj/consumer/logsobj/pool_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestSizedBuilderPool(t *testing.T) {
 	t.Run("Get returns the next builder, and nil when the pool is empty", func(t *testing.T) {
-		builder, err := NewBuilder(testBuilderConfig, scratch.NewMemory())
+		builder, err := NewBuilder(testBuilderConfig, scratch.NewMemory(), NewBuilderMetrics())
 		require.NoError(t, err)
 		pool := NewSizedBuilderPool([]*Builder{builder})
 		// The first call to [Get] should return the builder.
@@ -28,7 +28,7 @@ func TestSizedBuilderPool(t *testing.T) {
 	})
 
 	t.Run("Wait blocks until a builder is available", func(t *testing.T) {
-		builder, err := NewBuilder(testBuilderConfig, scratch.NewMemory())
+		builder, err := NewBuilder(testBuilderConfig, scratch.NewMemory(), NewBuilderMetrics())
 		require.NoError(t, err)
 		pool := NewSizedBuilderPool([]*Builder{builder})
 		// The first call to [Wait] should not block.

--- a/pkg/dataobj/consumer/logsobj/sorter.go
+++ b/pkg/dataobj/consumer/logsobj/sorter.go
@@ -35,7 +35,7 @@ func NewSorter(factory *BuilderFactory, r prometheus.Registerer) *Sorter {
 // Sort takes an existing data object and rewrites the logs sections so they are
 // sorted object-wide.
 func (s *Sorter) Sort(ctx context.Context, obj *dataobj.Object) (*dataobj.Object, io.Closer, error) {
-	b, err := s.factory.NewBuilder(nil)
+	b, err := s.factory.NewSorterBuilder()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create builder: %w", err)
 	}

--- a/pkg/dataobj/consumer/processor_test.go
+++ b/pkg/dataobj/consumer/processor_test.go
@@ -201,9 +201,10 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 
 // newTestBuilder returns a new logsobj.Builder with registered metrics.
 func newTestBuilder(t *testing.T, reg prometheus.Registerer) *logsobj.Builder {
-	b, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory())
+	m := logsobj.NewBuilderMetrics()
+	require.NoError(t, m.Register(reg))
+	b, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory(), m)
 	require.NoError(t, err)
-	require.NoError(t, b.RegisterMetrics(reg))
 	return b
 }
 

--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -49,7 +49,6 @@ type Service struct {
 	watcher                     *services.FailureWatcher
 	logger                      log.Logger
 	reg                         prometheus.Registerer
-	builderFactory              *logsobj.BuilderFactory
 }
 
 func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objstore.Bucket, scratchStore scratch.Store, _ string, _ ring.PartitionRingReader, reg prometheus.Registerer, logger log.Logger, overrides logsobj.TenantOverrides) (*Service, error) {
@@ -149,19 +148,22 @@ func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objsto
 	if err := uploader.RegisterMetrics(reg); err != nil {
 		level.Error(logger).Log("msg", "failed to register uploader metrics", "err", err)
 	}
-	s.builderFactory = logsobj.NewBuilderFactory(cfg.BuilderConfig, scratchStore, logger)
-	if overrides != nil {
-		s.builderFactory.SetOverrides(overrides)
-		level.Info(logger).Log("msg", "sort schema overrides wired to builder factory at construction")
-	} else {
-		level.Warn(logger).Log("msg", "sort schema overrides not provided at construction; schema sort will not apply to the initial builder")
-	}
-	sorter := logsobj.NewSorter(s.builderFactory, reg)
-	s.flusher = newFlusher(sorter, uploader, logger, reg)
+
+	builderMetrics := logsobj.NewBuilderMetrics()
 	wrapped := prometheus.WrapRegistererWith(prometheus.Labels{
 		"partition": strconv.Itoa(int(partitionID)),
 	}, reg)
-	builder, err := s.builderFactory.NewBuilder(wrapped)
+	err = builderMetrics.Register(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register logsobj builder metrics: %w", err)
+	}
+	builderFactory, err := logsobj.NewBuilderFactory(cfg.BuilderConfig, scratchStore, builderMetrics, logger, overrides)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create logsobj builder factory: %w", err)
+	}
+	sorter := logsobj.NewSorter(builderFactory, reg)
+	s.flusher = newFlusher(sorter, uploader, logger, reg)
+	builder, err := builderFactory.NewBuilder()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize data object builder: %w", err)
 	}

--- a/pkg/dataobj/index/builder_test.go
+++ b/pkg/dataobj/index/builder_test.go
@@ -457,7 +457,7 @@ func buildLogObject(t *testing.T, app string, path string, bucket objstore.Bucke
 			SectionStripeMergeLimit: 2,
 		},
 		DataobjSortOrder: "stream-asc",
-	}, nil)
+	}, nil, logsobj.NewBuilderMetrics())
 	require.NoError(t, err)
 
 	for i := 0; i < 10; i++ {

--- a/pkg/dataobj/index/calculate_bench_test.go
+++ b/pkg/dataobj/index/calculate_bench_test.go
@@ -92,7 +92,7 @@ func buildBenchDataobj(tb testing.TB, tenants, streamsPerTenant, entriesPerStrea
 			BufferSize:              4 << 20,
 			SectionStripeMergeLimit: 2,
 		},
-	}, scratch.NewMemory())
+	}, scratch.NewMemory(), logsobj.NewBuilderMetrics())
 	require.NoError(tb, err)
 
 	// Deterministic so iteration-to-iteration variance is only from scheduling.

--- a/pkg/dataobj/index/calculate_test.go
+++ b/pkg/dataobj/index/calculate_test.go
@@ -46,7 +46,7 @@ func createTestLogObject(t *testing.T, tenants int) *dataobj.Object {
 			BufferSize:              2048 * 8,
 			SectionStripeMergeLimit: 2,
 		},
-	}, nil)
+	}, nil, logsobj.NewBuilderMetrics())
 	require.NoError(t, err)
 
 	// Add test streams with structured metadata

--- a/pkg/dataobj/metastore/object_test.go
+++ b/pkg/dataobj/metastore/object_test.go
@@ -804,7 +804,7 @@ func newTestDataBuilder(t testing.TB) *testDataBuilder {
 			BufferSize:              1024 * 1024,      // 1MB
 			SectionStripeMergeLimit: 2,
 		},
-	}, nil)
+	}, nil, logsobj.NewBuilderMetrics())
 	require.NoError(t, err)
 
 	logger := log.NewLogfmtLogger(os.Stdout)

--- a/pkg/dataobj/sortmerge/sortmerge_test.go
+++ b/pkg/dataobj/sortmerge/sortmerge_test.go
@@ -33,7 +33,7 @@ const testTenant = "test"
 func buildObject(t *testing.T, labels string, base time.Time, lineCount int) (*dataobj.Object, func()) {
 	t.Helper()
 
-	b, err := logsobj.NewBuilder(testBuilderConfig, nil)
+	b, err := logsobj.NewBuilder(testBuilderConfig, nil, logsobj.NewBuilderMetrics())
 	require.NoError(t, err)
 
 	entries := make([]push.Entry, 0, lineCount)

--- a/pkg/engine/internal/executor/dataobjscan_test.go
+++ b/pkg/engine/internal/executor/dataobjscan_test.go
@@ -341,7 +341,7 @@ func buildDataobj(t testing.TB, streams []logproto.Stream) *dataobj.Object {
 			SectionStripeMergeLimit: 2,
 		},
 		DataobjSortOrder: "timestamp-desc",
-	}, nil)
+	}, nil, logsobj.NewBuilderMetrics())
 	require.NoError(t, err)
 
 	for _, stream := range streams {

--- a/pkg/engine/internal/util/objtest/objtest.go
+++ b/pkg/engine/internal/util/objtest/objtest.go
@@ -59,7 +59,7 @@ func NewBuilder(t *testing.T) *Builder {
 
 	var builderConfig logsobj.BuilderConfig
 	builderConfig.RegisterFlagsWithPrefix("", flag.NewFlagSet("", flag.PanicOnError)) // Acquire defaults
-	logsBuilder, err := logsobj.NewBuilder(builderConfig, nil)
+	logsBuilder, err := logsobj.NewBuilder(builderConfig, nil, logsobj.NewBuilderMetrics())
 	require.NoError(t, err, "expected to be able to create logs builder")
 
 	indexWriterBucket := objstore.NewPrefixedBucket(bucket, "index/v0")

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -81,7 +81,7 @@ func NewDataObjStore(dir, tenant string) (*DataObjStore, error) {
 			BufferSize:              16 * 1024 * 1024,  // 16MB
 			SectionStripeMergeLimit: 2,
 		},
-	}, nil)
+	}, nil, logsobj.NewBuilderMetrics())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create builder: %w", err)
 	}

--- a/tools/dataobj-sort/main.go
+++ b/tools/dataobj-sort/main.go
@@ -53,7 +53,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	b, err := logsobj.NewBuilder(cfg, scr)
+	b, err := logsobj.NewBuilder(cfg, scr, nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is part 1 of splitting https://github.com/grafana/loki/pull/21573.

I'm updating logsobj consumer BuilderMetrics so they are registered outside of the builder and passed down to builders through the factory. The reason is – we are going to create builders dynamically in the future (see https://github.com/grafana/loki/pull/21573) and the current approach where builder metrics are registered every time a builder is created is not going to work (the same metrics will be registered multiple times).

The change is intended to be a no-op (no behavioral changes), just shuffled metrics registration around.
