### PR TITLE
chore(compactor): EarliestRecordTime per logsobj builder

### DIFF
--- a/pkg/dataobj/consumer/flush_committer.go
+++ b/pkg/dataobj/consumer/flush_committer.go
@@ -66,7 +66,9 @@ func newFlushCommitter(
 }
 
 // Flush the data object builder and, if successful, commit the offset.
-func (c *flushCommitterImpl) Flush(ctx context.Context, builder builder, reason string, offset int64, earliestRecordTime time.Time) error {
+func (c *flushCommitterImpl) Flush(ctx context.Context, builder builder, reason string, offset int64) error {
+	// Read before flushing: flushing resets the builder, which clears the earliest record time.
+	earliestRecordTime := builder.GetEarliestRecordTime()
 	objectPath, err := c.flusher.Flush(ctx, builder, reason)
 	if err != nil {
 		return fmt.Errorf("failed to flush data object: %w", err)

--- a/pkg/dataobj/consumer/flush_committer_test.go
+++ b/pkg/dataobj/consumer/flush_committer_test.go
@@ -31,8 +31,8 @@ func TestFlushCommitter(t *testing.T) {
 			Entries: []logproto.Entry{
 				{Timestamp: now, Line: "test"},
 			},
-		}))
-		require.NoError(t, flushCommitter.Flush(t.Context(), builder, "test", 1, now))
+		}, now))
+		require.NoError(t, flushCommitter.Flush(t.Context(), builder, "test", 1))
 		// A flush should have occurred, a metastore event emitted, and the correct
 		// offset was committed.
 		require.Equal(t, 1, flusher.flushes)
@@ -67,8 +67,8 @@ func TestFlushCommitter(t *testing.T) {
 			Entries: []logproto.Entry{
 				{Timestamp: now, Line: "test"},
 			},
-		}))
-		flushErr := flushCommitter.Flush(t.Context(), builder, "test", 1, now)
+		}, now))
+		flushErr := flushCommitter.Flush(t.Context(), builder, "test", 1)
 		require.EqualError(t, flushErr, "failed to flush data object: mock error")
 		// Since no flush occurred, no event should be emitted and no offsets
 		// should be committed either.

--- a/pkg/dataobj/consumer/flush_test.go
+++ b/pkg/dataobj/consumer/flush_test.go
@@ -36,7 +36,7 @@ func TestFlusher_Flush(t *testing.T) {
 			Entries: []logproto.Entry{
 				{Timestamp: now, Line: "baz"},
 			},
-		}))
+		}, now))
 		f := newFlusher(testSorter, testUploader, log.NewNopLogger(), reg)
 		// Flush the builder we created earlier.
 		objectPath, err := f.Flush(testCtx, testBuilder, flushReasonBuilderFull)

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/facette/natsort"
 	"github.com/go-kit/log"
@@ -222,6 +223,10 @@ type Builder struct {
 	streams map[string]*streams.Builder
 	logs    map[string]*logs.Builder
 
+	// earliestRecordTime tracks the timestamp of the earliest record appended
+	// to the builder. It is required for the metastore index.
+	earliestRecordTime time.Time
+
 	state builderState
 }
 
@@ -287,6 +292,10 @@ func (b *Builder) initBuilder(tenant string) {
 	}
 }
 
+func (b *Builder) GetEarliestRecordTime() time.Time {
+	return b.earliestRecordTime
+}
+
 func (b *Builder) GetEstimatedSize() int {
 	return b.currentSizeEstimate
 }
@@ -297,7 +306,7 @@ func (b *Builder) GetEstimatedSize() int {
 //
 // Once a Builder is full, call [Builder.Flush] to flush the buffered data,
 // then call Append again with the same entry.
-func (b *Builder) Append(tenant string, stream logproto.Stream) error {
+func (b *Builder) Append(tenant string, stream logproto.Stream, recTime time.Time) error {
 	ls, err := b.parseLabels(stream.Labels)
 	if err != nil {
 		return err
@@ -346,6 +355,9 @@ func (b *Builder) Append(tenant string, stream logproto.Stream) error {
 		}
 	}
 
+	if b.earliestRecordTime.IsZero() || recTime.Before(b.earliestRecordTime) {
+		b.earliestRecordTime = recTime
+	}
 	b.currentSizeEstimate = b.estimatedSize()
 	b.state = builderStateDirty
 	return nil
@@ -650,6 +662,7 @@ func (b *Builder) Reset() {
 	clear(b.logs)
 	clear(b.streams)
 
+	b.earliestRecordTime = time.Time{}
 	b.metrics.sizeEstimate.Set(0)
 	b.currentSizeEstimate = 0
 	b.state = builderStateEmpty

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -80,7 +80,7 @@ func TestBuilder(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, entry := range testStreams {
-			require.NoError(t, builder.Append("tenant", entry))
+			require.NoError(t, builder.Append("tenant", entry, time.Now()))
 		}
 		obj, closer, err := builder.Flush()
 		require.NoError(t, err)
@@ -111,7 +111,7 @@ func TestBuilder_Append(t *testing.T) {
 				Timestamp: time.Now().UTC(),
 				Line:      strings.Repeat("a", 1024),
 			}},
-		})
+		}, time.Now())
 		if errors.Is(err, ErrBuilderFull) {
 			break
 		}
@@ -134,6 +134,65 @@ func TestBuilder_Append(t *testing.T) {
 	}
 }
 
+// TestBuilder_EarliestRecordTime ensures the builder tracks the earliest
+// record time seen across appends and resets it when the builder is reset.
+func TestBuilder_EarliestRecordTime(t *testing.T) {
+	newStream := func() logproto.Stream {
+		return logproto.Stream{
+			Labels:  `{cluster="test",app="foo"}`,
+			Entries: []push.Entry{{Timestamp: time.Unix(0, 0).UTC(), Line: "hello"}},
+		}
+	}
+
+	t.Run("zero on an empty builder", func(t *testing.T) {
+		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
+		require.NoError(t, err)
+		require.True(t, builder.GetEarliestRecordTime().IsZero())
+	})
+
+	t.Run("set on first append", func(t *testing.T) {
+		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
+		require.NoError(t, err)
+
+		recTime := time.Unix(100, 0).UTC()
+		require.NoError(t, builder.Append("tenant", newStream(), recTime))
+		require.Equal(t, recTime, builder.GetEarliestRecordTime())
+	})
+
+	t.Run("tracks the minimum across appends", func(t *testing.T) {
+		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
+		require.NoError(t, err)
+
+		require.NoError(t, builder.Append("tenant", newStream(), time.Unix(100, 0).UTC()))
+		// A later record must not move the earliest time forward.
+		require.NoError(t, builder.Append("tenant", newStream(), time.Unix(200, 0).UTC()))
+		require.Equal(t, time.Unix(100, 0).UTC(), builder.GetEarliestRecordTime())
+		// An earlier record must move the earliest time backward.
+		require.NoError(t, builder.Append("tenant", newStream(), time.Unix(50, 0).UTC()))
+		require.Equal(t, time.Unix(50, 0).UTC(), builder.GetEarliestRecordTime())
+	})
+
+	t.Run("reset on Reset", func(t *testing.T) {
+		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
+		require.NoError(t, err)
+
+		require.NoError(t, builder.Append("tenant", newStream(), time.Unix(100, 0).UTC()))
+		builder.Reset()
+		require.True(t, builder.GetEarliestRecordTime().IsZero())
+	})
+
+	t.Run("reset on Flush", func(t *testing.T) {
+		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
+		require.NoError(t, err)
+
+		require.NoError(t, builder.Append("tenant", newStream(), time.Unix(100, 0).UTC()))
+		_, closer, err := builder.Flush()
+		require.NoError(t, err)
+		defer closer.Close()
+		require.True(t, builder.GetEarliestRecordTime().IsZero())
+	})
+}
+
 func TestBuilder_CopyAndSort(t *testing.T) {
 	builder, _ := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
 
@@ -148,7 +207,7 @@ func TestBuilder_CopyAndSort(t *testing.T) {
 					Timestamp: now.Add(time.Duration(i%8) * time.Second),
 					Line:      strings.Repeat("a", 1024), // 1KiB log line
 				}},
-			})
+			}, now.Add(time.Duration(i%8)*time.Second))
 			require.NoError(t, err)
 		}
 	}
@@ -237,7 +296,7 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 						Timestamp: now.Add(time.Duration(i) * time.Second),
 						Line:      fmt.Sprintf("%s-%d", app, i),
 					}},
-				}))
+				}, now.Add(time.Duration(i)*time.Second)))
 			}
 		}
 		obj, closer, err := b.Flush()
@@ -334,11 +393,11 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 				require.NoError(t, b.Append("schema-tenant", logproto.Stream{
 					Labels:  fmt.Sprintf(`{app=%q}`, app),
 					Entries: []push.Entry{{Timestamp: now.Add(time.Duration(i) * time.Second), Line: app}},
-				}))
+				}, now.Add(time.Duration(i)*time.Second)))
 				require.NoError(t, b.Append("plain-tenant", logproto.Stream{
 					Labels:  fmt.Sprintf(`{app=%q}`, app),
 					Entries: []push.Entry{{Timestamp: now.Add(time.Duration(i) * time.Second), Line: app}},
-				}))
+				}, now.Add(time.Duration(i)*time.Second)))
 			}
 		}
 		obj1, closer1, err := b.Flush()
@@ -410,7 +469,7 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 			require.NoError(t, b.Append("t1", logproto.Stream{
 				Labels:  fmt.Sprintf(`{namespace=%q,app=%q}`, e.ns, e.app),
 				Entries: []push.Entry{{Timestamp: now, Line: e.ns + "/" + e.app}},
-			}))
+			}, now))
 		}
 		obj1, closer1, err := b.Flush()
 		require.NoError(t, err)

--- a/pkg/dataobj/consumer/mock_test.go
+++ b/pkg/dataobj/consumer/mock_test.go
@@ -21,12 +21,16 @@ type mockBuilder struct {
 	nextErr error
 }
 
-func (m *mockBuilder) Append(tenant string, stream logproto.Stream) error {
+func (m *mockBuilder) Append(tenant string, stream logproto.Stream, recTime time.Time) error {
 	if err := m.nextErr; err != nil {
 		m.nextErr = nil
 		return err
 	}
-	return m.builder.Append(tenant, stream)
+	return m.builder.Append(tenant, stream, recTime)
+}
+
+func (m *mockBuilder) GetEarliestRecordTime() time.Time {
+	return m.builder.GetEarliestRecordTime()
 }
 
 func (m *mockBuilder) GetEstimatedSize() int {
@@ -72,7 +76,7 @@ type mockFlushCommitter struct {
 	flushes int
 }
 
-func (m *mockFlushCommitter) Flush(_ context.Context, _ builder, _ string, _ int64, _ time.Time) error {
+func (m *mockFlushCommitter) Flush(_ context.Context, _ builder, _ string, _ int64) error {
 	m.flushes++
 	return nil
 }

--- a/pkg/dataobj/consumer/processor.go
+++ b/pkg/dataobj/consumer/processor.go
@@ -22,16 +22,17 @@ import (
 
 // A builder allows mocking of [logsobj.Builder] in tests.
 type builder interface {
-	Append(tenant string, stream logproto.Stream) error
+	Append(tenant string, stream logproto.Stream, recTime time.Time) error
 	GetEstimatedSize() int
 	Flush() (*dataobj.Object, io.Closer, error)
 	TimeRanges() []multitenancy.TimeRange
+	GetEarliestRecordTime() time.Time
 	CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataobj.Object, io.Closer, error)
 }
 
 // A flushCommitter allows mocking of flushes in tests.
 type flushCommitter interface {
-	Flush(ctx context.Context, builder builder, reason string, offset int64, earliestRecordTime time.Time) error
+	Flush(ctx context.Context, builder builder, reason string, offset int64) error
 }
 
 // A processor receives records and builds data objects from them.
@@ -68,10 +69,6 @@ type processor struct {
 	// object builder. It is used to know if the builder has exceeded the
 	// idle timeout. It must be reset after each flush.
 	lastAppend time.Time
-
-	// earliestRecordTime tracks the timestamp of the earliest record appended
-	// to the data object builder. It is required for the metastore index.
-	earliestRecordTime time.Time
 
 	// timePartitionedEstimates counts how many data objects we would build
 	// per flush with 12 hour windows.
@@ -177,21 +174,18 @@ func (p *processor) processRecord(ctx context.Context, rec *kgo.Record) error {
 		}
 	}
 
-	if err := p.builder.Append(tenant, stream); err != nil {
+	if err := p.builder.Append(tenant, stream, rec.Timestamp); err != nil {
 		if !errors.Is(err, logsobj.ErrBuilderFull) {
 			return fmt.Errorf("failed to append stream: %w", err)
 		}
 		if err := p.flush(ctx, flushReasonBuilderFull); err != nil {
 			return fmt.Errorf("failed to flush and commit: %w", err)
 		}
-		if err := p.builder.Append(tenant, stream); err != nil {
+		if err := p.builder.Append(tenant, stream, rec.Timestamp); err != nil {
 			return fmt.Errorf("failed to append stream after flushing: %w", err)
 		}
 	}
 
-	if p.earliestRecordTime.IsZero() || rec.Timestamp.Before(p.earliestRecordTime) {
-		p.earliestRecordTime = rec.Timestamp
-	}
 	if p.firstAppend.IsZero() {
 		p.firstAppend = now
 	}
@@ -240,13 +234,12 @@ func (p *processor) needsIdleFlush() bool {
 func (p *processor) flush(ctx context.Context, reason string) error {
 	defer func() {
 		// Reset the state to prepare for building the next data object.
-		p.earliestRecordTime = time.Time{}
 		p.firstAppend = time.Time{}
 		p.lastAppend = time.Time{}
 		clear(p.timePartitionedEstimates)
 	}()
 	p.metrics.timePartitionEstimate.Add(float64(len(p.timePartitionedEstimates)))
-	return p.flushCommitter.Flush(ctx, p.builder, reason, p.lastOffset, p.earliestRecordTime)
+	return p.flushCommitter.Flush(ctx, p.builder, reason, p.lastOffset)
 }
 
 func (p *processor) observeRecord(rec *kgo.Record, now time.Time) {

--- a/pkg/dataobj/consumer/processor_test.go
+++ b/pkg/dataobj/consumer/processor_test.go
@@ -133,7 +133,7 @@ func (f *failureFlusher) Flush(_ context.Context, _ builder, _ string) (string, 
 
 type failureFlushCommitter struct{}
 
-func (m *failureFlushCommitter) Flush(_ context.Context, _ builder, _ string, _ int64, _ time.Time) error {
+func (m *failureFlushCommitter) Flush(_ context.Context, _ builder, _ string, _ int64) error {
 	return errors.New("mock error")
 }
 
@@ -165,7 +165,6 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 
 			// The following fields should be reset at the end of every flush.
 			require.True(t, proc.firstAppend.IsZero())
-			require.True(t, proc.earliestRecordTime.IsZero())
 			require.True(t, proc.lastAppend.IsZero())
 		})
 	})
@@ -193,7 +192,6 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 
 			// Despite the failure, the following fields should still be reset.
 			require.True(t, proc.firstAppend.IsZero())
-			require.True(t, proc.earliestRecordTime.IsZero())
 			require.True(t, proc.lastAppend.IsZero())
 		})
 	})

--- a/pkg/dataobj/index/builder_test.go
+++ b/pkg/dataobj/index/builder_test.go
@@ -465,7 +465,7 @@ func buildLogObject(t *testing.T, app string, path string, bucket objstore.Bucke
 			Labels:  fmt.Sprintf("{app=\"%s\",stream=\"%d\"}", app, i),
 			Entries: []logproto.Entry{{Timestamp: time.Now(), Line: fmt.Sprintf("line %d", i)}},
 		}
-		err = candidate.Append("tenant", stream)
+		err = candidate.Append("tenant", stream, time.Now())
 		require.NoError(t, err)
 	}
 

--- a/pkg/dataobj/index/calculate_bench_test.go
+++ b/pkg/dataobj/index/calculate_bench_test.go
@@ -143,7 +143,7 @@ func buildBenchDataobj(tb testing.TB, tenants, streamsPerTenant, entriesPerStrea
 				}
 			}
 
-			require.NoError(tb, builder.Append(tenantID, logproto.Stream{Labels: lbls, Entries: entries}))
+			require.NoError(tb, builder.Append(tenantID, logproto.Stream{Labels: lbls, Entries: entries}, entries[0].Timestamp))
 		}
 	}
 

--- a/pkg/dataobj/index/calculate_test.go
+++ b/pkg/dataobj/index/calculate_test.go
@@ -96,7 +96,7 @@ func createTestLogObject(t *testing.T, tenants int) *dataobj.Object {
 
 	for i := range tenants {
 		for _, stream := range testStreams {
-			err := builder.Append(fmt.Sprintf("tenant-%d", i), stream)
+			err := builder.Append(fmt.Sprintf("tenant-%d", i), stream, stream.Entries[0].Timestamp)
 			require.NoError(t, err)
 		}
 	}

--- a/pkg/dataobj/metastore/object_test.go
+++ b/pkg/dataobj/metastore/object_test.go
@@ -75,7 +75,7 @@ type testDataBuilder struct {
 }
 
 func (b *testDataBuilder) addStreamAndFlush(tenant string, stream logproto.Stream) {
-	err := b.builder.Append(tenant, stream)
+	err := b.builder.Append(tenant, stream, now)
 	require.NoError(b.t, err)
 
 	timeRanges := b.builder.TimeRanges()

--- a/pkg/dataobj/sortmerge/sortmerge_test.go
+++ b/pkg/dataobj/sortmerge/sortmerge_test.go
@@ -46,7 +46,7 @@ func buildObject(t *testing.T, labels string, base time.Time, lineCount int) (*d
 	require.NoError(t, b.Append(testTenant, logproto.Stream{
 		Labels:  labels,
 		Entries: entries,
-	}))
+	}, base))
 
 	obj, closer, err := b.Flush()
 	require.NoError(t, err)

--- a/pkg/engine/internal/executor/dataobjscan_test.go
+++ b/pkg/engine/internal/executor/dataobjscan_test.go
@@ -345,7 +345,7 @@ func buildDataobj(t testing.TB, streams []logproto.Stream) *dataobj.Object {
 	require.NoError(t, err)
 
 	for _, stream := range streams {
-		require.NoError(t, builder.Append("tenant", stream))
+		require.NoError(t, builder.Append("tenant", stream, time.Now()))
 	}
 
 	obj, closer, err := builder.Flush()

--- a/pkg/engine/internal/util/objtest/objtest.go
+++ b/pkg/engine/internal/util/objtest/objtest.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
@@ -83,11 +84,11 @@ func NewBuilder(t *testing.T) *Builder {
 // Append appends the given streams to the builder.
 func (b *Builder) Append(ctx context.Context, streams ...logproto.Stream) {
 	for _, stream := range streams {
-		if err := b.logsBuilder.Append(Tenant, stream); err != nil && errors.Is(err, logsobj.ErrBuilderFull) {
+		if err := b.logsBuilder.Append(Tenant, stream, time.Now()); err != nil && errors.Is(err, logsobj.ErrBuilderFull) {
 			require.NoError(b.t, b.flush(ctx), "failed to flush logs builder")
 
 			// Try appending again after the flush.
-			require.NoError(b.t, b.logsBuilder.Append(Tenant, stream), "failed to append stream after flush")
+			require.NoError(b.t, b.logsBuilder.Append(Tenant, stream, time.Now()), "failed to append stream after flush")
 		} else if err != nil {
 			require.NoError(b.t, err, "failed to append stream")
 		}

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -110,13 +111,13 @@ func NewDataObjStore(dir, tenant string) (*DataObjStore, error) {
 // Write implements Store
 func (s *DataObjStore) Write(_ context.Context, streams []logproto.Stream) error {
 	for _, stream := range streams {
-		if err := s.builder.Append(s.tenant, stream); errors.Is(err, logsobj.ErrBuilderFull) {
+		if err := s.builder.Append(s.tenant, stream, time.Now()); errors.Is(err, logsobj.ErrBuilderFull) {
 			// If the builder is full, flush it and try again
 			if err := s.flush(); err != nil {
 				return fmt.Errorf("failed to flush builder: %w", err)
 			}
 			// Try appending again
-			if err := s.builder.Append(s.tenant, stream); err != nil {
+			if err := s.builder.Append(s.tenant, stream, time.Now()); err != nil {
 				return fmt.Errorf("failed to append stream after flush: %w", err)
 			}
 		} else if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This is part 2 of splitting https://github.com/grafana/loki/pull/21573.
**TODO:** change target branch to `main` once https://github.com/grafana/loki/pull/22138 is merged.

I'm changing processor / builder such a way that EarliestRecordTime is set per-builder not per processor. This timestamp is used later by dataobj-index-builder to track the e2e indexing latency. The reason to make it per-builder is that when we introduce builders builder-per-time-window approach we'll need to keep separate EarliestRecordTimes for these builders (one per builder).

The change is intended to be a no-op (no behavioral changes).