### PR TITLE
fix: Request source key for collision-renamed labels in metric queries

### DIFF
--- a/pkg/engine/internal/executor/compat.go
+++ b/pkg/engine/internal/executor/compat.go
@@ -17,7 +17,7 @@ import (
 )
 
 func newColumnCompatibilityPipeline(compat *physical.ColumnCompat, input Pipeline) Pipeline {
-	const extracted = "_extracted"
+	const extracted = semconv.ExtractedSuffix
 
 	identCache := semconv.NewIdentifierCache()
 

--- a/pkg/engine/internal/planner/physical/rule_projection_pushdown.go
+++ b/pkg/engine/internal/planner/physical/rule_projection_pushdown.go
@@ -5,7 +5,9 @@ import (
 	"maps"
 	"slices"
 	"sort"
+	"strings"
 
+	"github.com/grafana/loki/v3/pkg/engine/internal/semconv"
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 )
 
@@ -180,6 +182,10 @@ func (r *projectionPushdown) handleParse(expr *VariadicExpr, projections []Colum
 
 	initialKeyCount := len(requestedKeys)
 
+	// Source columns of collision-renamed "_extracted" references that must be
+	// projected from the scan (in addition to parsed) so the rename can happen.
+	var collisionSources []ColumnExpression
+
 	for _, p := range ambiguousProjections {
 		colExpr, ok := p.(*ColumnExpr)
 		if !ok {
@@ -187,8 +193,23 @@ func (r *projectionPushdown) handleParse(expr *VariadicExpr, projections []Colum
 		}
 
 		// Only collect ambiguous columns to push to parse nodes
-		if !requestedKeys[colExpr.Ref.Column] {
-			requestedKeys[colExpr.Ref.Column] = true
+		requestedKeys[colExpr.Ref.Column] = true
+
+		// A parsed field colliding with a higher-priority column (a stream label or
+		// structured metadata) is referenced downstream with the ExtractedSuffix
+		// appended ("level_extracted"), but the colliding column and the parser's source
+		// key are the de-suffixed name ("level").
+		// ColumnCompat re-applies the suffix to the parsed value at runtime.
+		// To reproduce that we must
+		// (1) request the source key from the parser, else it extracts a key that doesn't exist
+		// (2) project the source column so the colliding label/metadata is actually loaded from the
+		// scan, else there is nothing to collide with and the rename never happens.
+		// Either gap makes a group-by/filter on the "_extracted" name drop to null. Mirrors v1,
+		// where parsing happens against the full label set (see JSONParser.buildJSONPathFromPrefixBuffer).
+		// Both names are kept in case a real "<x>_extracted" field exists.
+		if src, found := strings.CutSuffix(colExpr.Ref.Column, semconv.ExtractedSuffix); found && src != "" {
+			requestedKeys[src] = true
+			collisionSources = append(collisionSources, &ColumnExpr{Ref: types.ColumnRef{Column: src, Type: types.ColumnTypeAmbiguous}})
 		}
 	}
 
@@ -202,6 +223,7 @@ func (r *projectionPushdown) handleParse(expr *VariadicExpr, projections []Colum
 
 	expr.Expressions = exprs.Pack(expr.Expressions)
 	projections = append(projections, exprs.sourceColumnExpr)
+	projections = append(projections, collisionSources...)
 	return changed, projections
 }
 

--- a/pkg/engine/internal/planner/physical/rule_projection_pushdown_test.go
+++ b/pkg/engine/internal/planner/physical/rule_projection_pushdown_test.go
@@ -406,6 +406,153 @@ func TestProjectionPushdown_PushesRequestedKeysToParseOperations(t *testing.T) {
 			expectedDataObjScanProjections: []string{"code", "duration", "message", "status", "timestamp"},
 		},
 		{
+			// Regression test for the collision-renamed "_extracted" bug: a parsed
+			// field that collides with a stream label is referenced downstream
+			// as "namespace_extracted" (e.g. json "namespace" vs the "namespace" stream label).
+			// The parser only sees real json keys, so we must
+			// also request the de-suffixed source key "namespace"; otherwise nothing
+			// is extracted and group-by on the "_extracted" name silently drops to
+			// null (returning 0 in v2 while v1 returns the correct value).
+			name: "GroupBy on collision-renamed _extracted label requests the source key",
+			buildLogical: func() logical.Value {
+				// count_over_time({app="test"} | json [5m]) by (namespace_extracted)
+				builder := logical.NewBuilder(&logical.MakeTable{
+					Selector: &logical.BinOp{
+						Left:  logical.NewColumnRef("app", types.ColumnTypeLabel),
+						Right: logical.NewLiteral("test"),
+						Op:    types.BinaryOpEq,
+					},
+					Shard: logical.NewShard(0, 1),
+				})
+				builder = builder.Parse(types.VariadicOpParseJSON, false, false)
+				builder = builder.RangeAggregation(
+					logical.Grouping{
+						Columns: []logical.ColumnRef{
+							{Ref: types.ColumnRef{Column: "namespace_extracted", Type: types.ColumnTypeAmbiguous}},
+						},
+						Without: false,
+					},
+					types.RangeAggregationTypeCount,
+					time.Unix(0, 0),
+					time.Unix(3600, 0),
+					5*time.Minute,
+					5*time.Minute,
+				)
+				return builder.Value()
+			},
+			expectedParseKeysRequested: []string{"namespace", "namespace_extracted"},
+			// "namespace" is also projected so the colliding label/metadata is loaded
+			// and ColumnCompat can rename the parsed value to "namespace_extracted".
+			expectedDataObjScanProjections: []string{"message", "namespace", "namespace_extracted", "timestamp"},
+		},
+		{
+			// Same fix from the label-filter side, combined with a clean group-by
+			// column: the "_extracted" filter column also contributes its source key,
+			// while the clean group-by column is left untouched.
+			name: "Filter on _extracted label plus clean GroupBy requests both source and clean keys",
+			buildLogical: func() logical.Value {
+				// sum by (component) (count_over_time({app="test"} | json | name_extracted="x" [5m]))
+				builder := logical.NewBuilder(&logical.MakeTable{
+					Selector: &logical.BinOp{
+						Left:  logical.NewColumnRef("app", types.ColumnTypeLabel),
+						Right: logical.NewLiteral("test"),
+						Op:    types.BinaryOpEq,
+					},
+					Shard: logical.NewShard(0, 1),
+				})
+				builder = builder.Parse(types.VariadicOpParseJSON, false, false)
+				builder = builder.Select(&logical.BinOp{
+					Left:  logical.NewColumnRef("name_extracted", types.ColumnTypeAmbiguous),
+					Right: logical.NewLiteral("x"),
+					Op:    types.BinaryOpEq,
+				})
+				builder = builder.RangeAggregation(
+					logical.NoGrouping,
+					types.RangeAggregationTypeCount,
+					time.Unix(0, 0),
+					time.Unix(3600, 0),
+					5*time.Minute,
+					5*time.Minute,
+				)
+				builder = builder.VectorAggregation(
+					logical.Grouping{
+						Columns: []logical.ColumnRef{
+							{Ref: types.ColumnRef{Column: "component", Type: types.ColumnTypeAmbiguous}},
+						},
+						Without: false,
+					},
+					types.VectorAggregationTypeSum,
+				)
+				return builder.Value()
+			},
+			expectedParseKeysRequested:     []string{"component", "name", "name_extracted"},
+			expectedDataObjScanProjections: []string{"component", "message", "name", "name_extracted", "timestamp"},
+		},
+		{
+			// Edge case: a column literally named "_extracted" must not produce an
+			// empty source key (CutSuffix yields ""), which would request every key.
+			name: "GroupBy on bare _extracted does not request an empty key",
+			buildLogical: func() logical.Value {
+				builder := logical.NewBuilder(&logical.MakeTable{
+					Selector: &logical.BinOp{
+						Left:  logical.NewColumnRef("app", types.ColumnTypeLabel),
+						Right: logical.NewLiteral("test"),
+						Op:    types.BinaryOpEq,
+					},
+					Shard: logical.NewShard(0, 1),
+				})
+				builder = builder.Parse(types.VariadicOpParseJSON, false, false)
+				builder = builder.RangeAggregation(
+					logical.Grouping{
+						Columns: []logical.ColumnRef{
+							{Ref: types.ColumnRef{Column: "_extracted", Type: types.ColumnTypeAmbiguous}},
+						},
+						Without: false,
+					},
+					types.RangeAggregationTypeCount,
+					time.Unix(0, 0),
+					time.Unix(3600, 0),
+					5*time.Minute,
+					5*time.Minute,
+				)
+				return builder.Value()
+			},
+			expectedParseKeysRequested:     []string{"_extracted"},
+			expectedDataObjScanProjections: []string{"_extracted", "message", "timestamp"},
+		},
+		{
+			// Edge case: a doubly-suffixed name (nested collision) strips exactly one
+			// level, requesting "foo_extracted" as the source.
+			name: "GroupBy on double-suffixed _extracted strips only one level",
+			buildLogical: func() logical.Value {
+				builder := logical.NewBuilder(&logical.MakeTable{
+					Selector: &logical.BinOp{
+						Left:  logical.NewColumnRef("app", types.ColumnTypeLabel),
+						Right: logical.NewLiteral("test"),
+						Op:    types.BinaryOpEq,
+					},
+					Shard: logical.NewShard(0, 1),
+				})
+				builder = builder.Parse(types.VariadicOpParseJSON, false, false)
+				builder = builder.RangeAggregation(
+					logical.Grouping{
+						Columns: []logical.ColumnRef{
+							{Ref: types.ColumnRef{Column: "foo_extracted_extracted", Type: types.ColumnTypeAmbiguous}},
+						},
+						Without: false,
+					},
+					types.RangeAggregationTypeCount,
+					time.Unix(0, 0),
+					time.Unix(3600, 0),
+					5*time.Minute,
+					5*time.Minute,
+				)
+				return builder.Value()
+			},
+			expectedParseKeysRequested:     []string{"foo_extracted", "foo_extracted_extracted"},
+			expectedDataObjScanProjections: []string{"foo_extracted", "foo_extracted_extracted", "message", "timestamp"},
+		},
+		{
 			name: "log query should request all keys even with filters",
 			buildLogical: func() logical.Value {
 				// Create a logical plan that represents a log query:

--- a/pkg/engine/internal/semconv/identifier.go
+++ b/pkg/engine/internal/semconv/identifier.go
@@ -12,6 +12,11 @@ import (
 
 const (
 	invalid = "<invalid>"
+
+	// ExtractedSuffix is appended to a parsed or metadata column's short name when
+	// it collides with a higher-priority column of the same name (e.g. a json field
+	// "namespace" colliding with the stream label "namespace" becomes "namespace_extracted").
+	ExtractedSuffix = "_extracted"
 )
 
 var (

--- a/pkg/logql/bench/queries/regression/metric-queries.yaml
+++ b/pkg/logql/bench/queries/regression/metric-queries.yaml
@@ -224,3 +224,25 @@ queries:
       log_format: json
       detected_fields:
         - level
+  - description: Count grouped by a collision-renamed _extracted label
+    query: sum by (level_extracted) (count_over_time(${SELECTOR} | logfmt [${RANGE}]))
+    kind: metric
+    time_range:
+      length: 24h
+      step: 1m
+    tags:
+      - count_over_time
+      - logfmt
+      - grouping
+      - extracted-label
+    notes: >
+      Regression for the v2 projection-pushdown fix. The logfmt "level" field collides
+      with the "level" structured metadata, so the parsed value is exposed as
+      "level_extracted". Grouping by that renamed label must match the v1 engine.
+      Previously the v2 engine asked the parser for the post-rename key "level_extracted"
+      (which is never a real field), so nothing was extracted and the group-by collapsed
+      to a single empty series / zero.
+    requires:
+      log_format: logfmt
+      detected_fields:
+        - level


### PR DESCRIPTION
**What this PR does / why we need it**:

_Issue:_ A metric query that groups by or filters on a collision-renamed `_extracted` label (a parsed field whose name collides with a stream label, e.g. json `namespace` vs the `namespace` stream label) returned empty/zero results in the v2 engine, while v1 returned the correct values.

_Root cause:_ for metric queries the projection-pushdown optimization narrows the json/logfmt parser to only the keys referenced downstream. It pushed the literal post-rename name (`namespace_extracted`) as the requested key, but the real source field is `namespace` — the `_extracted` suffix is synthesized later by the ColumnCompat operator. The parser was therefore asked for a key that does not exist, the column never materialized, and any group-by/filter on the `_extracted` name silently resolved to null.

_Fix:_ in handleParse, when an ambiguous requested column carries the `_extracted` suffix, also request the de-suffixed source key so the parser extracts the real field; ColumnCompat then re-applies the suffix. Both names are kept in case a real `<x>_extracted` field exists. This mirrors the [v1 parser, which trims the suffix when resolving a requested label back to its json path](https://github.com/grafana/loki/blob/8ca834fba574362f511ccf5635e5ddcb5af81cab/pkg/logql/log/parser.go#L242-L244) (JSONParser.buildJSONPathFromPrefixBuffer).

**Checklist**
- [X] Tests updated
