### PR TITLE
chore(compactor): Allow overflowed logsobj builders

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -31,10 +31,9 @@ import (
 	"github.com/grafana/loki/v3/pkg/scratch"
 )
 
-// ErrBuilderFull is returned by [Builder.Append] when the buffer is
-// full and needs to flush; call [Builder.Flush] to flush it.
+// ErrBuilderEmpty is returned by [Builder.Flush] when there is no buffered
+// data to flush.
 var (
-	ErrBuilderFull  = errors.New("builder full")
 	ErrBuilderEmpty = errors.New("builder empty")
 )
 
@@ -300,26 +299,18 @@ func (b *Builder) GetEstimatedSize() int {
 	return b.currentSizeEstimate
 }
 
-// Append buffers a stream to be written to a data object. Append returns an
-// error if the stream labels cannot be parsed or [ErrBuilderFull] if the
-// builder is full.
-//
-// Once a Builder is full, call [Builder.Flush] to flush the buffered data,
-// then call Append again with the same entry.
+func (b *Builder) IsFull() bool {
+	return b.currentSizeEstimate > int(b.cfg.TargetObjectSize)
+}
+
+// Append buffers a stream to be written to a data object.
+// Callers are expected to poll [Builder.IsFull] before appending and
+// to flush the builder once it reports full. Appending entries to a full
+// builder is permitted.
 func (b *Builder) Append(tenant string, stream logproto.Stream, recTime time.Time) error {
 	ls, err := b.parseLabels(stream.Labels)
 	if err != nil {
 		return err
-	}
-
-	// Check whether the buffer is full before a stream can be appended; this is
-	// tends to overestimate, but we may still go over our target size.
-	//
-	// Since this check only happens after the first call to Append,
-	// b.currentSizeEstimate will always be updated to reflect the size following
-	// the previous append.
-	if b.state != builderStateEmpty && b.currentSizeEstimate+labelsEstimate(ls)+streamSizeEstimate(stream) > int(b.cfg.TargetObjectSize) {
-		return ErrBuilderFull
 	}
 
 	b.initBuilder(tenant)
@@ -375,38 +366,6 @@ func (b *Builder) parseLabels(labelString string) (labels.Labels, error) {
 	}
 	b.labelCache.Add(labelString, parsed)
 	return parsed, nil
-}
-
-// labelsEstimate estimates the size of a set of labels in bytes.
-func labelsEstimate(ls labels.Labels) int {
-	var (
-		keysSize   int
-		valuesSize int
-	)
-
-	ls.Range(func(l labels.Label) {
-		keysSize += len(l.Name)
-		valuesSize += len(l.Value)
-	})
-
-	// Keys are stored as columns directly, while values get compressed. We'll
-	// underestimate a 2x compression ratio.
-	return keysSize + valuesSize/2
-}
-
-// streamSizeEstimate estimates the size of a stream in bytes.
-func streamSizeEstimate(stream logproto.Stream) int {
-	var size int
-	for _, entry := range stream.Entries {
-		// We only check the size of the line and metadata. Timestamps and IDs
-		// encode so well that they're unlikely to make a singificant impact on our
-		// size estimate.
-		size += len(entry.Line) / 2 // Line with 2x compression ratio
-		for _, md := range entry.StructuredMetadata {
-			size += len(md.Name) + len(md.Value)/2
-		}
-	}
-	return size
 }
 
 func convertMetadata(md push.LabelsAdapter) labels.Labels {

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -2,7 +2,6 @@ package logsobj
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -105,24 +104,25 @@ func TestBuilder_Append(t *testing.T) {
 	for {
 		require.NoError(t, ctx.Err())
 
-		err := builder.Append(tenant, logproto.Stream{
+		// Append until the builder reports that it is full.
+		if builder.IsFull() {
+			break
+		}
+
+		require.NoError(t, builder.Append(tenant, logproto.Stream{
 			Labels: `{cluster="test",app="foo"}`,
 			Entries: []push.Entry{{
 				Timestamp: time.Now().UTC(),
 				Line:      strings.Repeat("a", 1024),
 			}},
-		}, time.Now())
-		if errors.Is(err, ErrBuilderFull) {
-			break
-		}
-		require.NoError(t, err)
+		}, time.Now()))
 	}
 
 	obj, closer, err := builder.Flush()
 	require.NoError(t, err)
 	defer closer.Close()
 
-	// When a section builder is reset, which happens on ErrBuilderFull, the
+	// When a section builder is reset, which happens on flush, the
 	// tenant is reset too. We must check that the tenant is added back
 	// to the section builder otherwise tenant will be absent from successive
 	// sections.

--- a/pkg/dataobj/consumer/mock_test.go
+++ b/pkg/dataobj/consumer/mock_test.go
@@ -19,6 +19,9 @@ import (
 type mockBuilder struct {
 	builder *logsobj.Builder
 	nextErr error
+	// full, when true, forces IsFull to report the builder as full regardless
+	// of the underlying builder's estimated size.
+	full bool
 }
 
 func (m *mockBuilder) Append(tenant string, stream logproto.Stream, recTime time.Time) error {
@@ -35,6 +38,10 @@ func (m *mockBuilder) GetEarliestRecordTime() time.Time {
 
 func (m *mockBuilder) GetEstimatedSize() int {
 	return m.builder.GetEstimatedSize()
+}
+
+func (m *mockBuilder) IsFull() bool {
+	return m.full || m.builder.IsFull()
 }
 
 func (m *mockBuilder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataobj.Object, io.Closer, error) {

--- a/pkg/dataobj/consumer/processor.go
+++ b/pkg/dataobj/consumer/processor.go
@@ -2,7 +2,6 @@ package consumer
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -14,7 +13,6 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
-	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/kafka"
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -24,6 +22,7 @@ import (
 type builder interface {
 	Append(tenant string, stream logproto.Stream, recTime time.Time) error
 	GetEstimatedSize() int
+	IsFull() bool
 	Flush() (*dataobj.Object, io.Closer, error)
 	TimeRanges() []multitenancy.TimeRange
 	GetEarliestRecordTime() time.Time
@@ -174,16 +173,14 @@ func (p *processor) processRecord(ctx context.Context, rec *kgo.Record) error {
 		}
 	}
 
-	if err := p.builder.Append(tenant, stream, rec.Timestamp); err != nil {
-		if !errors.Is(err, logsobj.ErrBuilderFull) {
-			return fmt.Errorf("failed to append stream: %w", err)
-		}
+	if p.builder.IsFull() {
 		if err := p.flush(ctx, flushReasonBuilderFull); err != nil {
-			return fmt.Errorf("failed to flush and commit: %w", err)
+			return fmt.Errorf("failed to flush: %w", err)
 		}
-		if err := p.builder.Append(tenant, stream, rec.Timestamp); err != nil {
-			return fmt.Errorf("failed to append stream after flushing: %w", err)
-		}
+	}
+
+	if err := p.builder.Append(tenant, stream, rec.Timestamp); err != nil {
+		return fmt.Errorf("failed to append stream: %w", err)
 	}
 
 	if p.firstAppend.IsZero() {

--- a/pkg/dataobj/consumer/processor_test.go
+++ b/pkg/dataobj/consumer/processor_test.go
@@ -82,6 +82,39 @@ func TestProcessor_BuilderMaxAge(t *testing.T) {
 	})
 }
 
+func TestProcessor_FlushesWhenBuilderFull(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			ctx            = t.Context()
+			reg            = prometheus.NewRegistry()
+			builder        = &mockBuilder{builder: newTestBuilder(t, reg)}
+			flushCommitter = &mockFlushCommitter{}
+			proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+		)
+
+		// While the builder is not full, processing a record should append
+		// without flushing.
+		require.NoError(t, proc.processRecord(ctx, newTestRecord(t, "tenant", time.Now())))
+		require.Equal(t, 0, flushCommitter.flushes)
+		require.Equal(t, time.Now(), proc.firstAppend)
+
+		// Mark the builder as full. The next record should trigger a flush
+		// before it is appended, starting a new data object.
+		builder.full = true
+		flushedAt := time.Now()
+		time.Sleep(time.Minute)
+		require.NoError(t, proc.processRecord(ctx, newTestRecord(t, "tenant", time.Now())))
+
+		// Exactly one flush should have occurred, and the record should still
+		// have been appended afterwards, resetting firstAppend to the current
+		// time rather than the time of the first append.
+		require.Equal(t, 1, flushCommitter.flushes)
+		require.NotEqual(t, flushedAt, proc.firstAppend)
+		require.Equal(t, time.Now(), proc.firstAppend)
+		require.Equal(t, time.Now(), proc.lastAppend)
+	})
+}
+
 func TestPartitionProcessor_IdleFlush(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		var (

--- a/pkg/engine/internal/util/objtest/objtest.go
+++ b/pkg/engine/internal/util/objtest/objtest.go
@@ -4,7 +4,6 @@ package objtest
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -84,14 +83,11 @@ func NewBuilder(t *testing.T) *Builder {
 // Append appends the given streams to the builder.
 func (b *Builder) Append(ctx context.Context, streams ...logproto.Stream) {
 	for _, stream := range streams {
-		if err := b.logsBuilder.Append(Tenant, stream, time.Now()); err != nil && errors.Is(err, logsobj.ErrBuilderFull) {
+		if b.logsBuilder.IsFull() {
 			require.NoError(b.t, b.flush(ctx), "failed to flush logs builder")
-
-			// Try appending again after the flush.
-			require.NoError(b.t, b.logsBuilder.Append(Tenant, stream, time.Now()), "failed to append stream after flush")
-		} else if err != nil {
-			require.NoError(b.t, err, "failed to append stream")
 		}
+
+		require.NoError(b.t, b.logsBuilder.Append(Tenant, stream, time.Now()), "failed to append stream")
 
 		b.dirty = true
 	}

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -3,7 +3,6 @@ package bench
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -111,16 +110,12 @@ func NewDataObjStore(dir, tenant string) (*DataObjStore, error) {
 // Write implements Store
 func (s *DataObjStore) Write(_ context.Context, streams []logproto.Stream) error {
 	for _, stream := range streams {
-		if err := s.builder.Append(s.tenant, stream, time.Now()); errors.Is(err, logsobj.ErrBuilderFull) {
-			// If the builder is full, flush it and try again
+		if s.builder.IsFull() {
 			if err := s.flush(); err != nil {
 				return fmt.Errorf("failed to flush builder: %w", err)
 			}
-			// Try appending again
-			if err := s.builder.Append(s.tenant, stream, time.Now()); err != nil {
-				return fmt.Errorf("failed to append stream after flush: %w", err)
-			}
-		} else if err != nil {
+		}
+		if err := s.builder.Append(s.tenant, stream, time.Now()); err != nil {
 			return fmt.Errorf("failed to append stream: %w", err)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it:**

This is part 3 of splitting https://github.com/grafana/loki/pull/21573.

I'm changing the behavior of logsobj builders to allow appends to overflowed builders.

**Before this PR**
- (1) Processor tries to append a record to a builder
- (2) If a builder is full it doesn't append and returns an error `ErrBuilderFull`
- (3) Processor checks the error and flushes the builder
- (4) Processor tries to append the same record as in the step (1) to the now empty builder

**The issue**
This approach works fine but becomes problematic once we introduce multiple TOC windows builders. The issue is that with a single builder we have atomic "try append - flush if error"  behavior guarantee. With multiple builders this becomes a problem as a **single kafka record** might contain entries that belong to different builders. Example:
- we have a record R that has a log entry L0 for TOC window W0 AND a log entry L1 for TOC window W1
- we attempt to append L0 to the first builder B0 (for TOC W0) -> success
- we attempt to append L1 to the second builder B1 (for TOC W1) -> not appended, err builder full
- we flush all the builders (have to flush all of them because otherwise we can lose data as Kafka offset is committed after flushing)
- we attempt to append R again -> builder B0 will receive a duplicate of log L0

**Solution**
To simplify the processing we can **allow appends to full builders** ("one last time"). For the example above we'd allow the append of L1 to B1 even though B1 is already full. This way the dataobjects might become slightly bigger than the target size but this could already be the case given that the existing size estimates are estimates.