### PR TITLE
ci(operator): Grant id-token write permission for GAR login

### DIFF
--- a/.github/workflows/operator-images.yaml
+++ b/.github/workflows/operator-images.yaml
@@ -10,10 +10,12 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   publish-grafana-operator:
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/operator-reusable-image-build.yml
     with:
       dockerfile: "operator/Dockerfile"
@@ -23,6 +25,9 @@ jobs:
       tag: "latest"
 
   publish-openshift-operator:
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/operator-reusable-image-build.yml
     with:
       dockerfile: "operator/Dockerfile"
@@ -32,6 +37,9 @@ jobs:
       tag: "latest"
 
   publish-openshift-bundle:
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/operator-reusable-image-build.yml
     with:
       dockerfile: "operator/bundle/openshift/bundle.Dockerfile"
@@ -41,6 +49,9 @@ jobs:
       tag: "latest"
 
   publish-openshift-size-calculator:
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/operator-reusable-image-build.yml
     with:
       dockerfile: "operator/calculator.Dockerfile"
@@ -50,6 +61,9 @@ jobs:
       tag: "latest"
 
   publish-openshift-passthrough-gateway:
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/operator-reusable-image-build.yml
     with:
       dockerfile: "operator/passthrough-gateway.Dockerfile"

--- a/.github/workflows/operator-images.yaml
+++ b/.github/workflows/operator-images.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish-grafana-operator:


### PR DESCRIPTION
## What

Add `id-token: write` to the top-level permissions of the `operator images` workflow (`.github/workflows/operator-images.yaml`).

## Why

The reusable `operator-reusable-image-build.yml` workflow's `build` job requests `id-token: write` for the GAR OIDC login (`login-to-gar`). The calling `operator-images` workflow only granted `contents: read`, leaving `id-token` at `none`. A reusable workflow can never exceed the caller's permissions, so the run failed validation:

```
The nested job 'build' is requesting 'id-token: write', but is only allowed 'id-token: none'.
```

https://github.com/grafana/loki/actions/runs/26791012402

Granting `id-token: write` on the caller allows the OIDC token to flow through to the GAR login. This is a follow-up to #22063-era GAR publishing change (commit 91f88e8377).