### PR TITLE
chore(compactor): Align log objects to TOC windows

### DIFF
--- a/pkg/dataobj/consumer/flush_committer.go
+++ b/pkg/dataobj/consumer/flush_committer.go
@@ -65,20 +65,28 @@ func newFlushCommitter(
 	}
 }
 
-// Flush the data object builder and, if successful, commit the offset.
-func (c *flushCommitterImpl) Flush(ctx context.Context, builder builder, reason string, offset int64) error {
-	// Read before flushing: flushing resets the builder, which clears the earliest record time.
-	earliestRecordTime := builder.GetEarliestRecordTime()
-	objectPath, err := c.flusher.Flush(ctx, builder, reason)
-	if err != nil {
-		return fmt.Errorf("failed to flush data object: %w", err)
+// Flush multiple data object builders and, if successful, commit the offset.
+func (c *flushCommitterImpl) Flush(ctx context.Context, builders []builder, reason string, offset int64) error {
+	for _, b := range builders {
+		// Read before flushing: flushing resets the builder, which clears the earliest record time.
+		earliestRecordTime := b.GetEarliestRecordTime()
+		objectPath, err := c.flusher.Flush(ctx, b, reason)
+		if err != nil {
+			return fmt.Errorf("failed to flush data object: %w", err)
+		}
+
+		// TODO(ivkalita): send events in batch
+		// emitEvent returns an error only if context is cancelled, otherwise
+		// it retries indefinitely.
+		if err := c.emitEvent(ctx, objectPath, earliestRecordTime); err != nil {
+			return fmt.Errorf("failed to emit metastore event: %w", err)
+		}
 	}
-	if err := c.emitEvent(ctx, objectPath, earliestRecordTime); err != nil {
-		return fmt.Errorf("failed to emit metastore event: %w", err)
-	}
+
+	// commit returns an error only if context is cancelled, otherwise it retries indefinitely
 	if err := c.commit(ctx, offset); err != nil {
 		c.commitFailures.Inc()
-		return fmt.Errorf("failed to commit data object: %w", err)
+		return fmt.Errorf("failed to commit data object offset %d: %w", offset, err)
 	}
 	return nil
 }

--- a/pkg/dataobj/consumer/flush_committer_test.go
+++ b/pkg/dataobj/consumer/flush_committer_test.go
@@ -1,6 +1,7 @@
 package consumer
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
@@ -25,18 +27,22 @@ func TestFlushCommitter(t *testing.T) {
 			flushCommitter  = newFlushCommitter(flusher, metastoreEvents, committer, 0, log.NewNopLogger(), reg)
 		)
 		// Create a builder and append some logs so it can be flushed.
-		builder := newTestBuilder(t, reg)
-		require.NoError(t, builder.Append("test", logproto.Stream{
+		b := newTestBuilder(t, reg)
+		require.NoError(t, b.Append("test", logproto.Stream{
 			Labels: `{foo="bar"}`,
 			Entries: []logproto.Entry{
 				{Timestamp: now, Line: "test"},
 			},
 		}, now))
-		require.NoError(t, flushCommitter.Flush(t.Context(), builder, "test", 1))
+		require.NoError(t, flushCommitter.Flush(t.Context(), []builder{b}, "test", 1))
 		// A flush should have occurred, a metastore event emitted, and the correct
 		// offset was committed.
 		require.Equal(t, 1, flusher.flushes)
 		require.Len(t, metastoreKafka.produced, 1)
+		// The emitted event must carry the builder's earliest record time.
+		var event metastore.ObjectWrittenEvent
+		require.NoError(t, event.Unmarshal(metastoreKafka.produced[0].Value))
+		require.Equal(t, now.Format(time.RFC3339), event.EarliestRecordTime)
 		require.Len(t, committer.offsets, 1)
 		require.Equal(t, int64(1), committer.offsets[0])
 		// Check that the metrics are correct.
@@ -61,14 +67,14 @@ func TestFlushCommitter(t *testing.T) {
 			flushCommitter  = newFlushCommitter(flusher, metastoreEvents, committer, 0, log.NewNopLogger(), reg)
 		)
 		// Create a builder and append some logs so it can be flushed.
-		builder := newTestBuilder(t, reg)
-		require.NoError(t, builder.Append("test", logproto.Stream{
+		b := newTestBuilder(t, reg)
+		require.NoError(t, b.Append("test", logproto.Stream{
 			Labels: `{foo="bar"}`,
 			Entries: []logproto.Entry{
 				{Timestamp: now, Line: "test"},
 			},
 		}, now))
-		flushErr := flushCommitter.Flush(t.Context(), builder, "test", 1)
+		flushErr := flushCommitter.Flush(t.Context(), []builder{b}, "test", 1)
 		require.EqualError(t, flushErr, "failed to flush data object: mock error")
 		// Since no flush occurred, no event should be emitted and no offsets
 		// should be committed either.
@@ -84,4 +90,81 @@ func TestFlushCommitter(t *testing.T) {
 	loki_dataobj_consumer_commit_failures_total 0
 	`), "loki_dataobj_consumer_commits_total", "loki_dataobj_consumer_commit_failures_total"))
 	})
+
+	t.Run("should flush every builder but commit a single offset", func(t *testing.T) {
+		var (
+			now             = time.Now()
+			reg             = prometheus.NewRegistry()
+			flusher         = &mockFlusher{}
+			metastoreKafka  = &mockKafka{}
+			metastoreEvents = newMetastoreEvents(1, 10, metastoreKafka)
+			committer       = &mockCommitter{}
+			flushCommitter  = newFlushCommitter(flusher, metastoreEvents, committer, 0, log.NewNopLogger(), reg)
+		)
+		// Build a slice of builders, mimicking a partition split across windows.
+		var builders []builder
+		for i := 0; i < 3; i++ {
+			b := newTestBuilder(t, prometheus.NewRegistry())
+			require.NoError(t, b.Append("test", logproto.Stream{
+				Labels:  `{foo="bar"}`,
+				Entries: []logproto.Entry{{Timestamp: now, Line: "test"}},
+			}, now))
+			builders = append(builders, b)
+		}
+
+		require.NoError(t, flushCommitter.Flush(t.Context(), builders, "test", 7))
+		// Each builder is flushed and emits its own metastore event.
+		require.Equal(t, 3, flusher.flushes)
+		require.Len(t, metastoreKafka.produced, 3)
+		// But only a single offset is committed for the whole flush.
+		require.Len(t, committer.offsets, 1)
+		require.Equal(t, int64(7), committer.offsets[0])
+	})
+
+	t.Run("should capture earliest record time before the builder is reset", func(t *testing.T) {
+		var (
+			now = time.Now()
+			reg = prometheus.NewRegistry()
+			// flushingMockFlusher actually flushes (and thereby resets) the
+			// builder, which clears its earliest record time.
+			flusher         = &flushingMockFlusher{}
+			metastoreKafka  = &mockKafka{}
+			metastoreEvents = newMetastoreEvents(1, 10, metastoreKafka)
+			committer       = &mockCommitter{}
+			flushCommitter  = newFlushCommitter(flusher, metastoreEvents, committer, 0, log.NewNopLogger(), reg)
+		)
+		b := newTestBuilder(t, reg)
+		require.NoError(t, b.Append("test", logproto.Stream{
+			Labels:  `{foo="bar"}`,
+			Entries: []logproto.Entry{{Timestamp: now, Line: "test"}},
+		}, now))
+
+		require.NoError(t, flushCommitter.Flush(t.Context(), []builder{b}, "test", 1))
+		require.Equal(t, 1, flusher.flushes)
+		require.Len(t, metastoreKafka.produced, 1)
+		// The emitted event must keep the original earliest record time, even
+		// though the builder was reset by the flush.
+		var event metastore.ObjectWrittenEvent
+		require.NoError(t, event.Unmarshal(metastoreKafka.produced[0].Value))
+		require.Equal(t, now.Format(time.RFC3339), event.EarliestRecordTime)
+	})
+}
+
+// flushingMockFlusher is a flusher that actually flushes the builder it is
+// given, resetting the builder's buffered state (including its earliest record
+// time) as a real flusher would.
+type flushingMockFlusher struct {
+	flushes int
+}
+
+func (m *flushingMockFlusher) Flush(_ context.Context, b builder, _ string) (string, error) {
+	m.flushes++
+	_, closer, err := b.Flush()
+	if err != nil {
+		return "", err
+	}
+	if closer != nil {
+		_ = closer.Close()
+	}
+	return "", nil
 }

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -388,7 +388,6 @@ func (b *Builder) estimatedSize() int {
 		size += lb.EstimatedSize()
 	}
 	size += b.builder.Bytes()
-	b.metrics.sizeEstimate.Set(float64(size))
 	return size
 }
 
@@ -622,7 +621,6 @@ func (b *Builder) Reset() {
 	clear(b.streams)
 
 	b.earliestRecordTime = time.Time{}
-	b.metrics.sizeEstimate.Set(0)
 	b.currentSizeEstimate = 0
 	b.state = builderStateEmpty
 }

--- a/pkg/dataobj/consumer/logsobj/builder_metrics.go
+++ b/pkg/dataobj/consumer/logsobj/builder_metrics.go
@@ -24,8 +24,7 @@ type BuilderMetrics struct {
 	buildTime     prometheus.Histogram
 	flushFailures prometheus.Counter
 
-	sizeEstimate prometheus.Gauge
-	builtSize    prometheus.Histogram
+	builtSize prometheus.Histogram
 }
 
 // NewBuilderMetrics creates a new set of [BuilderMetrics] for instrumenting
@@ -65,10 +64,6 @@ func NewBuilderMetrics() *BuilderMetrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: 0,
 		}),
-		sizeEstimate: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loki_dataobj_size_estimate_bytes",
-			Help: "Current estimated size of the data object in bytes.",
-		}),
 		builtSize: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name: "loki_dataobj_built_size_bytes",
 			Help: "Distribution of constructed data object sizes in bytes.",
@@ -105,7 +100,6 @@ func (m *BuilderMetrics) Register(reg prometheus.Registerer) error {
 	errs = append(errs, reg.Register(m.appendTime))
 	errs = append(errs, reg.Register(m.buildTime))
 
-	errs = append(errs, reg.Register(m.sizeEstimate))
 	errs = append(errs, reg.Register(m.builtSize))
 	errs = append(errs, reg.Register(m.flushFailures))
 
@@ -125,7 +119,6 @@ func (m *BuilderMetrics) Unregister(reg prometheus.Registerer) {
 	reg.Unregister(m.appendTime)
 	reg.Unregister(m.buildTime)
 
-	reg.Unregister(m.sizeEstimate)
 	reg.Unregister(m.builtSize)
 	reg.Unregister(m.flushFailures)
 }

--- a/pkg/dataobj/consumer/metrics.go
+++ b/pkg/dataobj/consumer/metrics.go
@@ -15,6 +15,7 @@ type metrics struct {
 	records               prometheus.Counter
 	recordFailures        prometheus.Counter
 	timePartitionEstimate prometheus.Counter
+	sizeEstimate          prometheus.Gauge
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
@@ -46,6 +47,10 @@ func newMetrics(r prometheus.Registerer) *metrics {
 		timePartitionEstimate: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "loki_dataobj_consumer_time_partition_estimate_total",
 			Help: "The number of data objects we would build with 12 hour windows.",
+		}),
+		sizeEstimate: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "loki_dataobj_size_estimate_bytes",
+			Help: "Current estimated size in bytes buffered across all window-specific builders for the partition.",
 		}),
 	}
 }

--- a/pkg/dataobj/consumer/mock_test.go
+++ b/pkg/dataobj/consumer/mock_test.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -13,6 +14,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/scratch"
 )
 
 // mockBuilder mocks a [logsobj.Builder].
@@ -81,11 +83,68 @@ func (m *mockFlusher) Flush(_ context.Context, _ builder, _ string) (string, err
 
 type mockFlushCommitter struct {
 	flushes int
+	// lastBuilderCount records the number of builders passed to the most
+	// recent Flush call, letting tests assert how a partition was split
+	// across windows.
+	lastBuilderCount int
+	lastReason       string
+	lastOffset       int64
 }
 
-func (m *mockFlushCommitter) Flush(_ context.Context, _ builder, _ string, _ int64) error {
+func (m *mockFlushCommitter) Flush(_ context.Context, builders []builder, reason string, offset int64) error {
 	m.flushes++
+	m.lastBuilderCount = len(builders)
+	m.lastReason = reason
+	m.lastOffset = offset
 	return nil
+}
+
+// testBuilderFactory creates real [logsobj.Builder] instances backed by an
+// in-memory scratch store. All builders share a single, unregistered
+// [logsobj.BuilderMetrics] instance, mirroring how the production factory
+// shares metrics across the builders it creates.
+type testBuilderFactory struct {
+	metrics *logsobj.BuilderMetrics
+	// created counts how many builders have been handed out. Tests use it to
+	// assert that builders are reused per window rather than recreated.
+	created int
+	// failAt, when non-negative, makes NewBuilder fail once created reaches
+	// this value. A value of -1 (the default) never fails.
+	failAt int
+}
+
+func newTestBuilderFactory() *testBuilderFactory {
+	return &testBuilderFactory{metrics: logsobj.NewBuilderMetrics(), failAt: -1}
+}
+
+func (f *testBuilderFactory) NewBuilder() (*logsobj.Builder, error) {
+	if f.failAt >= 0 && f.created >= f.failAt {
+		return nil, errors.New("boom")
+	}
+	f.created++
+	return logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory(), f.metrics)
+}
+
+// mockMultiBuilder wraps the production [TOCAlignedMultiBuilder] so processor
+// tests can drive real builder behaviour while still being able to force the
+// group to report itself as full.
+type mockMultiBuilder struct {
+	*TOCAlignedMultiBuilder
+	forceFull bool
+}
+
+var _ multiBuilder = (*mockMultiBuilder)(nil)
+
+func (m *mockMultiBuilder) IsFull() bool {
+	return m.forceFull || m.TOCAlignedMultiBuilder.IsFull()
+}
+
+// newTestMultiBuilder returns a multiBuilder backed by real per-window
+// builders, suitable for driving the processor in tests.
+func newTestMultiBuilder() *mockMultiBuilder {
+	return &mockMultiBuilder{
+		TOCAlignedMultiBuilder: NewTOCAlignedMultiBuilder(newTestBuilderFactory(), int(testBuilderCfg.TargetObjectSize)),
+	}
 }
 
 // mockKafka mocks a [kgo.Client]. The zero value is usable.

--- a/pkg/dataobj/consumer/multi_builder.go
+++ b/pkg/dataobj/consumer/multi_builder.go
@@ -1,0 +1,121 @@
+package consumer
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+type builderFactory interface {
+	NewBuilder() (*logsobj.Builder, error)
+}
+
+// TOCAlignedMultiBuilder manages a set of [logsobj.Builder] instances, one per
+// 12-hour UTC window (see [metastore.MetastoreWindowSize]). Each builder in the
+// group only contains entries whose timestamps fall into that window, which
+// keeps per-object time ranges aligned with the metastore TOC and bounds the
+// number of windows a single object can cover.
+type TOCAlignedMultiBuilder struct {
+	builders         map[time.Time]builder
+	builderFactory   builderFactory
+	maxBufferedBytes int
+}
+
+// NewTOCAlignedMultiBuilder creates a new TOC aligned builder group.
+// maxBufferedBytes is the combined upper bound across all window builders;
+func NewTOCAlignedMultiBuilder(builderFactory builderFactory, maxBufferedBytes int) *TOCAlignedMultiBuilder {
+	return &TOCAlignedMultiBuilder{
+		builders:         make(map[time.Time]builder),
+		builderFactory:   builderFactory,
+		maxBufferedBytes: maxBufferedBytes,
+	}
+}
+
+var _ multiBuilder = (*TOCAlignedMultiBuilder)(nil)
+
+func (m *TOCAlignedMultiBuilder) Append(tenant string, stream logproto.Stream, recTime time.Time) error {
+	// [stream] might contain entries for multiple time windows => we need to split them to multiple streams, where
+	// each one only contains the entries for a single time window
+	streamsByTimeWindows := make(map[time.Time]logproto.Stream, 1)
+	for _, e := range stream.Entries {
+		w := e.Timestamp.UTC().Truncate(metastore.MetastoreWindowSize)
+		if _, ok := streamsByTimeWindows[w]; !ok {
+			streamsByTimeWindows[w] = logproto.Stream{
+				Labels: stream.Labels,
+			}
+		}
+		windowedStream := streamsByTimeWindows[w]
+		windowedStream.Entries = append(windowedStream.Entries, e)
+		streamsByTimeWindows[w] = windowedStream
+	}
+
+	for w, stream := range streamsByTimeWindows {
+		b, exists := m.builders[w]
+		if !exists {
+			var err error
+			b, err = m.builderFactory.NewBuilder()
+			if err != nil {
+				return fmt.Errorf("error creating logsobj builder for window %s: %w", w.Format(time.RFC3339), err)
+			}
+		}
+		if err := b.Append(tenant, stream, recTime); err != nil {
+			return fmt.Errorf("append for window %s: %w", w.Format(time.RFC3339), err)
+		}
+
+		if !exists {
+			// Only store a new builder into the map if append succeeded to avoid empty builders added to the map
+			// on Append errors.
+			m.builders[w] = b
+		}
+	}
+
+	return nil
+}
+
+// IsFull reports whether the combined buffered size across all window
+// builders has exceeded the configured target object size.
+//
+// We intentionally compare the *sum* (rather than each individual builder's
+// IsFull) so that a partition that receives records spanning many windows is
+// still bounded to roughly MaxBufferedBytes of buffered memory, rather
+// than K*MaxBufferedBytes.
+func (m *TOCAlignedMultiBuilder) IsFull() bool {
+	return m.GetEstimatedSize() > m.maxBufferedBytes
+}
+
+func (m *TOCAlignedMultiBuilder) GetEstimatedSize() int {
+	size := 0
+	for _, b := range m.builders {
+		size += b.GetEstimatedSize()
+	}
+	return size
+}
+
+func (m *TOCAlignedMultiBuilder) Reset() {
+	clear(m.builders)
+}
+
+// GetBuilders returns all per-window builders, sorted in ascending order of
+// window start time.
+//
+// A deterministic order keeps flush-time side effects (metastore event
+// writes, offset commits, and any future per-window metrics) predictable
+// regardless of Go's map iteration randomization, which simplifies both
+// tests and operational reasoning.
+func (m *TOCAlignedMultiBuilder) GetBuilders() []builder {
+	windows := make([]time.Time, 0, len(m.builders))
+	for w := range m.builders {
+		windows = append(windows, w)
+	}
+	sort.Slice(windows, func(i, j int) bool { return windows[i].Before(windows[j]) })
+
+	result := make([]builder, 0, len(m.builders))
+	for _, w := range windows {
+		result = append(result, m.builders[w])
+	}
+	return result
+}

--- a/pkg/dataobj/consumer/multi_builder_test.go
+++ b/pkg/dataobj/consumer/multi_builder_test.go
@@ -1,0 +1,185 @@
+package consumer
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/logproto"
+
+	"github.com/grafana/loki/pkg/push"
+)
+
+// windowEntry returns an entry whose timestamp falls into the given window.
+func windowEntry(window time.Time, offset time.Duration, line string) push.Entry {
+	return push.Entry{Timestamp: window.Add(offset), Line: line}
+}
+
+func TestTOCAlignedMultiBuilder_AppendSplitsAcrossWindows(t *testing.T) {
+	factory := newTestBuilderFactory()
+	m := NewTOCAlignedMultiBuilder(factory, math.MaxInt)
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	w2 := w1.Add(metastore.MetastoreWindowSize)
+
+	// A single stream whose entries span two windows must be split into one
+	// builder per window.
+	require.NoError(t, m.Append("tenant", logproto.Stream{
+		Labels: `{app="foo"}`,
+		Entries: []push.Entry{
+			windowEntry(w1, time.Minute, "a"),
+			windowEntry(w2, time.Minute, "b"),
+			windowEntry(w1, 2*time.Minute, "c"),
+		},
+	}, w1))
+
+	builders := m.GetBuilders()
+	require.Len(t, builders, 2)
+	// Two windows means two builders were created.
+	require.Equal(t, 2, factory.created)
+
+	// Builders are returned sorted by ascending window start, so the first
+	// builder must hold the earlier window.
+	require.Equal(t, w1, truncatedWindow(t, builders[0]))
+	require.Equal(t, w2, truncatedWindow(t, builders[1]))
+}
+
+func TestTOCAlignedMultiBuilder_AppendReusesBuilderForSameWindow(t *testing.T) {
+	factory := newTestBuilderFactory()
+	m := NewTOCAlignedMultiBuilder(factory, math.MaxInt)
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+
+	require.NoError(t, m.Append("tenant", logproto.Stream{
+		Labels:  `{app="foo"}`,
+		Entries: []push.Entry{windowEntry(w1, time.Minute, "a")},
+	}, w1))
+	require.NoError(t, m.Append("tenant", logproto.Stream{
+		Labels:  `{app="foo"}`,
+		Entries: []push.Entry{windowEntry(w1, 2*time.Minute, "b")},
+	}, w1))
+
+	// Both appends land in the same window, so only one builder is created and
+	// reused.
+	require.Len(t, m.GetBuilders(), 1)
+	require.Equal(t, 1, factory.created)
+}
+
+func TestTOCAlignedMultiBuilder_GetBuildersSorted(t *testing.T) {
+	factory := newTestBuilderFactory()
+	m := NewTOCAlignedMultiBuilder(factory, math.MaxInt)
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	w2 := w1.Add(metastore.MetastoreWindowSize)
+	w3 := w2.Add(metastore.MetastoreWindowSize)
+
+	// Append the windows out of order; GetBuilders must still return them in
+	// ascending window order regardless of map iteration randomization.
+	require.NoError(t, m.Append("tenant", logproto.Stream{
+		Labels: `{app="foo"}`,
+		Entries: []push.Entry{
+			windowEntry(w3, time.Minute, "c"),
+			windowEntry(w1, time.Minute, "a"),
+			windowEntry(w2, time.Minute, "b"),
+		},
+	}, w1))
+
+	builders := m.GetBuilders()
+	require.Len(t, builders, 3)
+	require.Equal(t, w1, truncatedWindow(t, builders[0]))
+	require.Equal(t, w2, truncatedWindow(t, builders[1]))
+	require.Equal(t, w3, truncatedWindow(t, builders[2]))
+}
+
+func TestTOCAlignedMultiBuilder_IsFullBoundsTotalMemory(t *testing.T) {
+	factory := newTestBuilderFactory()
+	m := NewTOCAlignedMultiBuilder(factory, math.MaxInt)
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	w2 := w1.Add(metastore.MetastoreWindowSize)
+
+	// Fill a single window and record its size.
+	require.NoError(t, m.Append("tenant", logproto.Stream{
+		Labels:  `{app="foo"}`,
+		Entries: []push.Entry{windowEntry(w1, time.Minute, "some log line")},
+	}, w1))
+	single := m.GetEstimatedSize()
+	require.Positive(t, single)
+	require.False(t, m.IsFull())
+
+	// Fill a second window with comparable data; the total now exceeds a
+	// single window's footprint.
+	require.NoError(t, m.Append("tenant", logproto.Stream{
+		Labels:  `{app="foo"}`,
+		Entries: []push.Entry{windowEntry(w2, time.Minute, "some log line")},
+	}, w1))
+	total := m.GetEstimatedSize()
+	require.Greater(t, total, single)
+
+	// With a target equal to a single window's size, neither builder is full on
+	// its own, but the group reports full because fullness is driven by the
+	// *sum* across windows.
+	m.maxBufferedBytes = single
+	require.True(t, m.IsFull())
+}
+
+func TestTOCAlignedMultiBuilder_AppendDoesNotKeepEmptyBuilderOnError(t *testing.T) {
+	factory := newTestBuilderFactory()
+	m := NewTOCAlignedMultiBuilder(factory, math.MaxInt)
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	// Invalid labels make the underlying builder's Append fail.
+	err := m.Append("tenant", logproto.Stream{
+		Labels:  `{app="foo"`,
+		Entries: []push.Entry{windowEntry(w1, time.Minute, "bad-labels")},
+	}, w1)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to parse labels")
+	// A failed append must not leave an empty builder behind.
+	require.Empty(t, m.GetBuilders())
+}
+
+func TestTOCAlignedMultiBuilder_AppendPropagatesFactoryError(t *testing.T) {
+	factory := newTestBuilderFactory()
+	factory.failAt = 0 // fail to create the very first builder
+	m := NewTOCAlignedMultiBuilder(factory, math.MaxInt)
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	err := m.Append("tenant", logproto.Stream{
+		Labels:  `{app="foo"}`,
+		Entries: []push.Entry{windowEntry(w1, time.Minute, "a")},
+	}, w1)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "boom")
+	require.Empty(t, m.GetBuilders())
+}
+
+func TestTOCAlignedMultiBuilder_Reset(t *testing.T) {
+	factory := newTestBuilderFactory()
+	m := NewTOCAlignedMultiBuilder(factory, math.MaxInt)
+
+	w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, m.Append("tenant", logproto.Stream{
+		Labels:  `{app="foo"}`,
+		Entries: []push.Entry{windowEntry(w1, time.Minute, "a")},
+	}, w1))
+	require.NotEmpty(t, m.GetBuilders())
+	require.Positive(t, m.GetEstimatedSize())
+
+	m.Reset()
+	require.Empty(t, m.GetBuilders())
+	require.Equal(t, 0, m.GetEstimatedSize())
+	require.False(t, m.IsFull())
+}
+
+// truncatedWindow returns the TOC window that the builder's single tenant time
+// range belongs to.
+func truncatedWindow(t *testing.T, b builder) time.Time {
+	t.Helper()
+	ranges := b.TimeRanges()
+	require.Len(t, ranges, 1)
+	return ranges[0].MinTime.UTC().Truncate(metastore.MetastoreWindowSize)
+}

--- a/pkg/dataobj/consumer/processor.go
+++ b/pkg/dataobj/consumer/processor.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -18,6 +19,14 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
+type multiBuilder interface {
+	Append(tenant string, stream logproto.Stream, recTime time.Time) error
+	GetEstimatedSize() int
+	IsFull() bool
+	Reset()
+	GetBuilders() []builder
+}
+
 // A builder allows mocking of [logsobj.Builder] in tests.
 type builder interface {
 	Append(tenant string, stream logproto.Stream, recTime time.Time) error
@@ -31,13 +40,13 @@ type builder interface {
 
 // A flushCommitter allows mocking of flushes in tests.
 type flushCommitter interface {
-	Flush(ctx context.Context, builder builder, reason string, offset int64) error
+	Flush(ctx context.Context, builder []builder, reason string, offset int64) error
 }
 
 // A processor receives records and builds data objects from them.
 type processor struct {
 	*services.BasicService
-	builder        builder
+	builder        multiBuilder
 	decoder        *kafka.Decoder
 	records        chan *kgo.Record
 	flushCommitter flushCommitter
@@ -69,16 +78,12 @@ type processor struct {
 	// idle timeout. It must be reset after each flush.
 	lastAppend time.Time
 
-	// timePartitionedEstimates counts how many data objects we would build
-	// per flush with 12 hour windows.
-	timePartitionedEstimates map[time.Time]struct{}
-
 	metrics *metrics
 	logger  log.Logger
 }
 
 func newProcessor(
-	builder builder,
+	builder multiBuilder,
 	records chan *kgo.Record,
 	flushCommitter flushCommitter,
 	idleFlushTimeout time.Duration,
@@ -91,15 +96,14 @@ func newProcessor(
 		panic(err)
 	}
 	p := &processor{
-		builder:                  builder,
-		decoder:                  decoder,
-		records:                  records,
-		flushCommitter:           flushCommitter,
-		idleFlushTimeout:         idleFlushTimeout,
-		maxBuilderAge:            maxBuilderAge,
-		metrics:                  newMetrics(reg),
-		logger:                   logger,
-		timePartitionedEstimates: make(map[time.Time]struct{}),
+		builder:          builder,
+		decoder:          decoder,
+		records:          records,
+		flushCommitter:   flushCommitter,
+		idleFlushTimeout: idleFlushTimeout,
+		maxBuilderAge:    maxBuilderAge,
+		metrics:          newMetrics(reg),
+		logger:           logger,
 	}
 	p.BasicService = services.NewBasicService(p.starting, p.running, p.stopping)
 	return p
@@ -120,6 +124,8 @@ func (p *processor) stopping(_ error) error {
 	return nil
 }
 
+var errUnrecoverableFlush = fmt.Errorf("unrecoverable flush failure")
+
 func (p *processor) Run(ctx context.Context) error {
 	defer level.Info(p.logger).Log("msg", "stopped partition processor")
 	level.Info(p.logger).Log("msg", "started partition processor")
@@ -136,6 +142,11 @@ func (p *processor) Run(ctx context.Context) error {
 				return nil
 			}
 			if err := p.processRecord(ctx, rec); err != nil {
+				if errors.Is(err, errUnrecoverableFlush) {
+					// restarting to re-read Kafka records
+					level.Error(p.logger).Log("msg", "terminating after unrecoverable flush", "err", err)
+					return err
+				}
 				level.Error(p.logger).Log("msg", "failed to process record", "err", err)
 				p.observeRecordErr(rec)
 			}
@@ -143,6 +154,11 @@ func (p *processor) Run(ctx context.Context) error {
 			// This partition is idle, flush it.
 			p.metrics.setConsumptionLag(0)
 			if _, err := p.idleFlush(ctx); err != nil {
+				if errors.Is(err, errUnrecoverableFlush) {
+					// restarting to re-read Kafka records
+					level.Error(p.logger).Log("msg", "terminating after unrecoverable idle flush", "err", err)
+					return err
+				}
 				level.Error(p.logger).Log("msg", "failed to idle flush", "err", err)
 			}
 		}
@@ -154,10 +170,6 @@ func (p *processor) processRecord(ctx context.Context, rec *kgo.Record) error {
 	// consumption lag, the age of the data object builder, etc.
 	now := time.Now()
 	p.observeRecord(rec, now)
-
-	// Find the 12 hour window.
-	window := rec.Timestamp.UTC().Truncate(12 * time.Hour)
-	p.timePartitionedEstimates[window] = struct{}{}
 
 	// Try to decode the stream in the record.
 	tenant := string(rec.Key)
@@ -182,6 +194,7 @@ func (p *processor) processRecord(ctx context.Context, rec *kgo.Record) error {
 	if err := p.builder.Append(tenant, stream, rec.Timestamp); err != nil {
 		return fmt.Errorf("failed to append stream: %w", err)
 	}
+	p.metrics.sizeEstimate.Set(float64(p.builder.GetEstimatedSize()))
 
 	if p.firstAppend.IsZero() {
 		p.firstAppend = now
@@ -230,13 +243,26 @@ func (p *processor) needsIdleFlush() bool {
 
 func (p *processor) flush(ctx context.Context, reason string) error {
 	defer func() {
-		// Reset the state to prepare for building the next data object.
+		// Reset the state to prepare for building the next data objects
 		p.firstAppend = time.Time{}
 		p.lastAppend = time.Time{}
-		clear(p.timePartitionedEstimates)
+		p.builder.Reset()
+		p.metrics.sizeEstimate.Set(0)
 	}()
-	p.metrics.timePartitionEstimate.Add(float64(len(p.timePartitionedEstimates)))
-	return p.flushCommitter.Flush(ctx, p.builder, reason, p.lastOffset)
+
+	timeWindowedBuilders := p.builder.GetBuilders()
+	p.metrics.timePartitionEstimate.Add(float64(len(timeWindowedBuilders)))
+	err := p.flushCommitter.Flush(ctx, timeWindowedBuilders, reason, p.lastOffset)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) {
+		return err
+	}
+
+	// flush failed – in the worst case it failed after a builder was reset but before the
+	// data was uploaded to object storage.
+	return fmt.Errorf("%w: %w", errUnrecoverableFlush, err)
 }
 
 func (p *processor) observeRecord(rec *kgo.Record, now time.Time) {

--- a/pkg/dataobj/consumer/processor_test.go
+++ b/pkg/dataobj/consumer/processor_test.go
@@ -3,6 +3,7 @@ package consumer
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/scratch"
 
@@ -38,9 +40,9 @@ func TestProcessor_BuilderMaxAge(t *testing.T) {
 		var (
 			ctx            = t.Context()
 			reg            = prometheus.NewRegistry()
-			builder        = newTestBuilder(t, reg)
+			m              = newTestMultiBuilder()
 			flushCommitter = &mockFlushCommitter{}
-			proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+			proc           = newProcessor(m, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 		)
 
 		// Since no records have been pushed, the first append time should be zero,
@@ -87,9 +89,9 @@ func TestProcessor_FlushesWhenBuilderFull(t *testing.T) {
 		var (
 			ctx            = t.Context()
 			reg            = prometheus.NewRegistry()
-			builder        = &mockBuilder{builder: newTestBuilder(t, reg)}
+			m              = newTestMultiBuilder()
 			flushCommitter = &mockFlushCommitter{}
-			proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+			proc           = newProcessor(m, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 		)
 
 		// While the builder is not full, processing a record should append
@@ -100,7 +102,7 @@ func TestProcessor_FlushesWhenBuilderFull(t *testing.T) {
 
 		// Mark the builder as full. The next record should trigger a flush
 		// before it is appended, starting a new data object.
-		builder.full = true
+		m.forceFull = true
 		flushedAt := time.Now()
 		time.Sleep(time.Minute)
 		require.NoError(t, proc.processRecord(ctx, newTestRecord(t, "tenant", time.Now())))
@@ -120,9 +122,9 @@ func TestPartitionProcessor_IdleFlush(t *testing.T) {
 		var (
 			ctx            = t.Context()
 			reg            = prometheus.NewRegistry()
-			builder        = newTestBuilder(t, reg)
+			m              = newTestMultiBuilder()
 			flushCommitter = &mockFlushCommitter{}
-			proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+			proc           = newProcessor(m, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 		)
 
 		// The idle flush timeout has not been exceeded, no flush should occur.
@@ -166,8 +168,18 @@ func (f *failureFlusher) Flush(_ context.Context, _ builder, _ string) (string, 
 
 type failureFlushCommitter struct{}
 
-func (m *failureFlushCommitter) Flush(_ context.Context, _ builder, _ string, _ int64) error {
+func (m *failureFlushCommitter) Flush(_ context.Context, _ []builder, _ string, _ int64) error {
 	return errors.New("mock error")
+}
+
+// fixedErrFlushCommitter always returns the configured error. It is used to
+// verify how the processor classifies flush failures (recoverable vs. not).
+type fixedErrFlushCommitter struct {
+	err error
+}
+
+func (m *fixedErrFlushCommitter) Flush(_ context.Context, _ []builder, _ string, _ int64) error {
+	return m.err
 }
 
 func TestPartitionProcessor_Flush(t *testing.T) {
@@ -176,9 +188,9 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 			var (
 				ctx            = t.Context()
 				reg            = prometheus.NewRegistry()
-				builder        = newTestBuilder(t, reg)
+				m              = newTestMultiBuilder()
 				flushCommitter = &mockFlushCommitter{}
-				proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+				proc           = newProcessor(m, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 			)
 
 			// No flush should have occurred.
@@ -207,9 +219,9 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 			var (
 				ctx            = t.Context()
 				reg            = prometheus.NewRegistry()
-				builder        = newTestBuilder(t, reg)
+				m              = newTestMultiBuilder()
 				flushCommitter = &failureFlushCommitter{}
-				proc           = newProcessor(builder, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+				proc           = newProcessor(m, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
 			)
 
 			// Process a record containing some log lines. No flush should occur.
@@ -219,14 +231,73 @@ func TestPartitionProcessor_Flush(t *testing.T) {
 			require.Equal(t, time.Now(), proc.lastAppend)
 			require.Equal(t, rec.Offset, proc.lastOffset)
 
-			// Advance time and force a flush. This flush should fail.
+			// Advance time and force a flush. This flush should fail. Because the
+			// flusher is not re-entrant, a non-cancellation failure is escalated
+			// to an unrecoverable error so the partition processor restarts and
+			// replays from Kafka.
 			time.Sleep(time.Second)
-			require.EqualError(t, proc.flush(ctx, "forced"), "mock error")
+			err := proc.flush(ctx, "forced")
+			require.ErrorIs(t, err, errUnrecoverableFlush)
+			require.ErrorContains(t, err, "mock error")
 
 			// Despite the failure, the following fields should still be reset.
 			require.True(t, proc.firstAppend.IsZero())
 			require.True(t, proc.lastAppend.IsZero())
 		})
+	})
+
+	t.Run("should not escalate a canceled flush", func(t *testing.T) {
+		// During shutdown the flush context is canceled. A canceled flush must
+		// be surfaced as-is rather than escalated to errUnrecoverableFlush, so
+		// the processor shuts down gracefully instead of restarting.
+		synctest.Test(t, func(t *testing.T) {
+			var (
+				ctx            = t.Context()
+				reg            = prometheus.NewRegistry()
+				m              = newTestMultiBuilder()
+				flushCommitter = &fixedErrFlushCommitter{err: context.Canceled}
+				proc           = newProcessor(m, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+			)
+
+			require.NoError(t, proc.processRecord(ctx, newTestRecord(t, "tenant", time.Now())))
+
+			time.Sleep(time.Second)
+			err := proc.flush(ctx, "forced")
+			require.ErrorIs(t, err, context.Canceled)
+			require.NotErrorIs(t, err, errUnrecoverableFlush)
+		})
+	})
+}
+
+func TestPartitionProcessor_FlushSplitsAcrossWindows(t *testing.T) {
+	// A single record whose entries span multiple TOC windows must be flushed
+	// as one builder per window, while still committing a single Kafka offset.
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			ctx            = t.Context()
+			reg            = prometheus.NewRegistry()
+			m              = newTestMultiBuilder()
+			flushCommitter = &mockFlushCommitter{}
+			proc           = newProcessor(m, nil, flushCommitter, 5*time.Minute, 30*time.Minute, log.NewNopLogger(), reg)
+		)
+
+		w1 := time.Date(2026, time.April, 17, 0, 0, 0, 0, time.UTC)
+		w2 := w1.Add(metastore.MetastoreWindowSize)
+		w3 := w2.Add(metastore.MetastoreWindowSize)
+		rec := newTestMultiWindowRecord(t, "tenant", []time.Time{w1, w2, w3})
+		require.NoError(t, proc.processRecord(ctx, rec))
+
+		// Three windows means three per-window builders.
+		require.Len(t, m.GetBuilders(), 3)
+
+		require.NoError(t, proc.flush(ctx, "forced"))
+		require.Equal(t, 1, flushCommitter.flushes)
+		require.Equal(t, 3, flushCommitter.lastBuilderCount)
+		require.Equal(t, rec.Offset, flushCommitter.lastOffset)
+
+		// The multi-builder is reset after a successful flush.
+		require.Empty(t, m.GetBuilders())
+		require.Equal(t, 0, m.GetEstimatedSize())
 	})
 }
 
@@ -251,6 +322,28 @@ func newTestRecord(t *testing.T, tenant string, now time.Time) *kgo.Record {
 			Timestamp: now,
 			Line:      "baz",
 		}},
+	}
+	var err error
+	rec.Value, err = stream.Marshal()
+	require.NoError(t, err)
+	return &rec
+}
+
+// newTestMultiWindowRecord returns a record whose stream contains one entry
+// per provided timestamp. It is used to exercise records that span multiple
+// TOC windows. The record timestamp is the first window.
+func newTestMultiWindowRecord(t *testing.T, tenant string, windows []time.Time) *kgo.Record {
+	require.NotEmpty(t, windows)
+	rec := kgo.Record{
+		Key:       []byte(tenant),
+		Timestamp: windows[0],
+	}
+	stream := logproto.Stream{Labels: `{foo="bar"}`}
+	for i, w := range windows {
+		stream.Entries = append(stream.Entries, push.Entry{
+			Timestamp: w.Add(time.Minute),
+			Line:      fmt.Sprintf("line-%d", i),
+		})
 	}
 	var err error
 	rec.Value, err = stream.Marshal()

--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -163,10 +163,6 @@ func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objsto
 	}
 	sorter := logsobj.NewSorter(builderFactory, reg)
 	s.flusher = newFlusher(sorter, uploader, logger, reg)
-	builder, err := builderFactory.NewBuilder()
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize data object builder: %w", err)
-	}
 	flushCommitter := newFlushCommitter(
 		s.flusher,
 		newMetastoreEvents(partitionID, int32(mCfg.PartitionRatio), metastoreEvents),
@@ -176,7 +172,7 @@ func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objsto
 		wrapped,
 	)
 	s.processor = newProcessor(
-		builder,
+		NewTOCAlignedMultiBuilder(builderFactory, int(cfg.BuilderConfig.TargetObjectSize)),
 		records,
 		flushCommitter,
 		cfg.IdleFlushTimeout,


### PR DESCRIPTION
**What this PR does / why we need it:**

This is (a final) part 4 of splitting https://github.com/grafana/loki/pull/21573.

I'm adding `TOCAlignedMultiBuilder` that keeps multiple logsobj builders under the hood and routes the incoming records to them. Before we had a single builder that buffers the logs from all the TOC windows, now we'll have multiple builders, one per TOC window of the received records.