### PR TITLE
feat(operator): Add manifests to install operator using OLMv1

### DIFF
--- a/operator/hack/olmv1/RBAC-GUIDE.md
+++ b/operator/hack/olmv1/RBAC-GUIDE.md
@@ -1,0 +1,224 @@
+# OLM v1 RBAC Requirements Guide
+
+This guide explains the RBAC permissions required for the installer ServiceAccount and how to troubleshoot permission errors.
+
+## Why OLM v1 Requires a ServiceAccount
+
+**OLM v0** runs with cluster-admin permissions by default - insecure but simple.
+
+**OLM v1** follows a **least-privilege security model**:
+- You must provide a ServiceAccount with explicit permissions
+- OLM v1 uses this ServiceAccount to install the operator
+- If permissions are missing, installation fails with clear error messages
+
+## Required Permissions Explained
+
+The installer ServiceAccount needs permissions to install operator components:
+
+### 1. CRD Management
+```yaml
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["create", "get", "list", "update", "patch", "watch"]
+```
+
+Install LokiStack, AlertingRule, RecordingRule, RulerConfig CRDs
+
+### 2. RBAC Management
+```yaml
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+  verbs: ["create", "get", "list", "update", "patch", "escalate", "bind", "watch"]
+```
+
+Create operator's ClusterRole and bindings
+Only grant to trusted ServiceAccounts in controlled namespaces
+
+### 3. ServiceAccount Management
+```yaml
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["create", "get", "list", "update", "patch", "delete", "watch"]
+
+- apiGroups: [""]
+  resources: ["serviceaccounts/finalizers"]
+  verbs: ["update"]
+```
+
+Create operator ServiceAccount and manage owner references
+Required for proper resource lifecycle management
+
+### 4. Deployment Management
+```yaml
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["create", "get", "list", "update", "patch", "delete", "watch"]
+```
+
+Create and manage operator Deployment
+
+### 5. Service Management
+```yaml
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["create", "get", "list", "update", "patch", "watch"]
+```
+
+Create webhook Service and metrics Service
+
+### 6. ConfigMap Management
+```yaml
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create", "get", "list", "update", "patch", "watch"]
+```
+
+Create operator configuration ConfigMaps
+
+### 7. Secret Management
+```yaml
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create", "get", "list", "update", "patch", "watch"]
+```
+
+Manage operator secrets (metrics tokens, webhook certs)
+
+### 8. Webhook Configuration
+```yaml
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+  verbs: ["create", "get", "list", "update", "patch", "watch"]
+```
+
+Register validation and mutation webhooks
+
+### 9. Cert-Manager Integration (Optional)
+```yaml
+- apiGroups: ["cert-manager.io"]
+  resources: ["certificates", "issuers"]
+  verbs: ["create", "get", "list", "update", "patch"]
+```
+
+Support built-in certificate management if enabled
+
+### 10. Namespace Access
+```yaml
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list"]
+```
+
+Verify installation namespace exists
+
+### 11. Prometheus Operator Resources
+```yaml
+- apiGroups: ["monitoring.coreos.com"]
+  resources: ["servicemonitors", "prometheusrules"]
+  verbs: ["create", "get", "list", "update", "patch", "watch"]
+```
+
+Create ServiceMonitors and PrometheusRules if monitoring feature gates enabled
+
+### 12. ClusterExtension Resources
+```yaml
+- apiGroups: ["olm.operatorframework.io"]
+  resources: ["clusterextensions"]
+  verbs: ["get", "list"]
+
+- apiGroups: ["olm.operatorframework.io"]
+  resources: ["clusterextensions/finalizers"]
+  verbs: ["update"]
+```
+
+Read ClusterExtension for owner references and manage finalizers
+
+---
+
+## Troubleshooting Permission Errors
+
+**If you encounter permission errors:**
+
+1. Check the error message for the specific resource and verb
+2. Add that permission to `serviceaccount-installer.yaml`
+3. Apply the updated ServiceAccount
+4. Delete and recreate the ClusterExtension
+
+**Example:**
+```
+User "system:serviceaccount:openshift-operators-redhat:loki-operator-installer" 
+cannot get resource "secrets" in namespace "openshift-operators-redhat"
+```
+
+**Solution:**
+1. Identify missing resource (e.g., "secrets")
+2. Add permission to `serviceaccount-installer.yaml`:
+   ```yaml
+   - apiGroups: [""]  # or appropriate API group
+     resources: ["secrets"]
+     verbs: ["create", "get", "list", "update", "patch", "watch"]
+   ```
+3. Apply updated ServiceAccount:
+   ```bash
+   kubectl apply -f hack/olmv1/serviceaccount-installer.yaml
+   ```
+4. Delete and recreate ClusterExtension:
+   ```bash
+   kubectl delete clusterextension loki-operator
+   kubectl apply -f hack/olmv1/clusterextension-loki-operator.yaml
+   ```
+
+---
+
+## Testing Your ServiceAccount
+
+**Before deploying the operator, verify the ServiceAccount has required permissions:**
+
+```bash
+# Test CRD permission
+kubectl auth can-i create customresourcedefinitions \
+  --as=system:serviceaccount:openshift-operators-redhat:loki-operator-installer
+
+# Test RBAC permission
+kubectl auth can-i create clusterroles \
+  --as=system:serviceaccount:openshift-operators-redhat:loki-operator-installer
+
+# Test with escalate/bind (should be "yes")
+kubectl auth can-i escalate clusterroles \
+  --as=system:serviceaccount:openshift-operators-redhat:loki-operator-installer
+```
+
+**All should return `yes` if permissions are correct.**
+
+---
+
+## Operator Upgrades and RBAC
+
+**Critical:** If a new operator version requires additional permissions, the upgrade will fail.
+
+### Upgrade Workflow When Permissions Change
+
+1. **Check release notes** for RBAC changes
+2. **Update ServiceAccount** with new permissions:
+   ```bash
+   # Edit serviceaccount-installer.yaml to add new permissions
+   kubectl apply -f hack/olmv1/serviceaccount-installer.yaml
+   ```
+3. **Then upgrade operator**:
+   ```bash
+   kubectl patch clusterextension loki-operator --type=merge \
+     -p '{"spec":{"source":{"catalog":{"version":"X.Y.Z"}}}}'
+   ```
+
+**Without updating the ServiceAccount first, the upgrade will fail with permission errors.**
+
+---
+
+## Minimal Permission Set
+
+**The permissions in `serviceaccount-installer.yaml` are the minimum required set** discovered through testing on OCP 4.22.0-rc.5.
+
+**Do NOT remove permissions** unless you've verified they're unused through testing.
+
+**Do NOT add permissions** unless you encounter specific errors requiring them.
+

--- a/operator/hack/olmv1/README.md
+++ b/operator/hack/olmv1/README.md
@@ -1,0 +1,220 @@
+# OLM v1 Quick Start Guide
+
+This directory contains files for deploying Loki Operator using OLM v1 instead of OLM v0.
+
+## Prerequisites
+
+### Cluster Requirements
+
+✅ **OpenShift 4.22+** (webhook support GA, enabled by default)
+
+⚠️ **OpenShift 4.20-4.21** (webhook support may need manual enablement)
+
+### Verify OLM v1 Availability
+
+```bash
+# Check if OLM v1 CRDs exist
+oc get crd clusterextensions.olm.operatorframework.io
+oc get crd clustercatalogs.olm.operatorframework.io
+
+# Check for openshift-operator-controller namespace
+oc get ns openshift-operator-controller
+
+# Check webhook support (if operator-controller is running)
+oc logs -n openshift-operator-controller \
+<operator-controller-controller-manager-name> | grep "WebhookProvider"
+# --feature-gates=WebhookProviderOpenshiftServiceCA should equal to true
+
+```
+
+---
+
+## Installation
+
+### Step 1: Create Installer ServiceAccount + RBAC
+
+```bash
+kubectl apply -f serviceaccount-installer.yaml
+```
+
+This creates:
+- Namespace: `openshift-operators-redhat`
+- ServiceAccount: `loki-operator-installer`
+- ClusterRole: `loki-operator-installer` (with required permissions)
+- ClusterRoleBinding: `loki-operator-installer`
+
+**Why is this needed?** OLM v1 uses a **least-privilege security model**. Unlike OLM v0 (which runs as cluster-admin), OLM v1 requires you to provide a ServiceAccount with explicit permissions to install operator components.
+
+**Required Permissions Include:**
+- CRD management (create, update, watch)
+- RBAC management (with escalate/bind verbs)
+- Deployment, Service, ConfigMap, Secret management
+- Webhook configuration
+- Monitoring resources (ServiceMonitors, PrometheusRules)
+- Owner reference finalizers
+
+**See [RBAC-GUIDE.md](./RBAC-GUIDE.md) for:**
+- Detailed explanation of each permission
+- How to troubleshoot permission errors
+- What to do when upgrading if permissions change
+- Security considerations
+
+### Step 2: Create ClusterExtension
+
+```bash
+kubectl apply -f clusterextension-loki-operator.yaml
+```
+
+This:
+- Installs loki-operator from `openshift-redhat-operators` catalog
+- Uses the installer ServiceAccount (least-privilege security model)
+- Deploys to `openshift-operators-redhat` namespace
+
+---
+
+## Verification
+
+### Check Installation Status
+
+```bash
+# View ClusterExtension
+kubectl get clusterextension loki-operator
+
+# Should show:
+# NAME            INSTALLED BUNDLE       VERSION   INSTALLED   PROGRESSING
+# loki-operator   loki-operator.v6.5.1   6.5.1     True        ...
+```
+
+### Check Operator Pod
+
+```bash
+kubectl get pods -n openshift-operators-redhat
+
+# Should show:
+# NAME                                                READY   STATUS
+# loki-operator-controller-manager-XXXXXXXXXX-XXXXX   1/1     Running
+```
+
+### Verify CRDs Installed
+
+```bash
+kubectl get crd | grep loki.grafana.com
+
+# Should show:
+# alertingrules.loki.grafana.com
+# lokistacks.loki.grafana.com
+# recordingrules.loki.grafana.com
+# rulerconfigs.loki.grafana.com
+```
+
+### Verify Webhooks Registered
+
+```bash
+kubectl get validatingwebhookconfigurations | grep loki
+
+# Should show:
+# valertingrule.loki.grafana.com
+# vlokistack.loki.grafana.com
+# vrecordingrule.loki.grafana.com
+# vrulerconfig.loki.grafana.com
+```
+
+---
+
+## Upgrading the Operator
+
+### Option 1: Auto-update (if using version range)
+
+OLM v1 automatically updates operators when:
+  1. ClusterCatalog polls for new versions (default: every 10 minutes as configured in the openshift-redhat-operators ClusterCatalog CR)
+  2. New version matches your version range
+  3. Upgrade path exists (if using CatalogProvided policy)
+
+### Option 2: Pin to specific version
+
+Edit the ClusterExtension:
+```bash
+kubectl patch clusterextension loki-operator --type=merge -p '{
+  "spec": {
+    "source": {
+      "catalog": {
+        "version": "6.6.0"
+      }
+    }
+  }
+}'
+```
+
+### ⚠️ Important: RBAC Changes
+
+If a new operator version requires **additional permissions**, the upgrade will **fail** unless you update the installer ServiceAccount first:
+
+```bash
+# 1. Update ServiceAccount with new permissions
+kubectl apply -f serviceaccount-installer-updated.yaml
+
+# 2. Then upgrade
+kubectl patch clusterextension loki-operator --type=merge -p '...'
+```
+
+Always check release notes for RBAC changes before upgrading!
+
+---
+
+## Uninstalling
+
+
+OLM v1 deletes CRDs and all Custom Resources when you delete the ClusterExtension.
+
+All LokiStack, AlertingRule, RecordingRule, RulerConfig CRs will be deleted.
+
+```bash
+# Delete ClusterExtension (deletes operator, CRDs, and all CRs)
+kubectl delete clusterextension loki-operator
+
+# Delete installer RBAC
+kubectl delete -f serviceaccount-installer.yaml
+```
+
+### Manual Cleanup
+
+Operator `ClusterRole` and `ClusterRoleBindings` require require manual cleanup.
+
+---
+
+## Troubleshooting
+
+### Operator not visible in OpenShift Console
+
+**Expected behavior:** OLM v1 operators don't appear in the traditional "Installed Operators" page.
+
+The console UI hasn't been updated for OLM v1 yet. Use:
+- `kubectl get clusterextension`
+- Search for `ClusterExtension` in console
+- Check CRDs to verify installation
+
+### ClusterExtension stuck in Progressing
+
+Check conditions:
+```bash
+kubectl describe clusterextension loki-operator
+```
+
+Common issues:
+- **Missing permissions**: Update serviceaccount-installer.yaml
+- **Webhook feature gates disabled**: Upgrade to OCP 4.22+ or enable feature gates
+- **Catalog not available**: Check `kubectl get clustercatalog`
+
+### Permission errors during installation
+
+The installer ServiceAccount needs extensive permissions. If you see errors like:
+```
+User "system:serviceaccount:openshift-operators-redhat:loki-operator-installer" cannot get resource "X"
+```
+
+Update `serviceaccount-installer.yaml` to include the missing permission, then:
+```bash
+kubectl apply -f serviceaccount-installer.yaml
+kubectl delete clusterextension loki-operator
+kubectl apply -f clusterextension-loki-operator-production.yaml
+```

--- a/operator/hack/olmv1/clusterextension-loki-operator.yaml
+++ b/operator/hack/olmv1/clusterextension-loki-operator.yaml
@@ -1,0 +1,41 @@
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: loki-operator
+  labels:
+    app.kubernetes.io/name: loki-operator
+    app.kubernetes.io/part-of: loki
+spec:
+  namespace: openshift-operators-redhat
+  serviceAccount:
+    name: loki-operator-installer
+  source:
+    sourceType: Catalog
+    catalog:
+      packageName: loki-operator
+
+      # Version selection
+      # Option 1: Latest version
+      # Omit version field to install latest available
+
+      # Option 2: Pin to specific version
+      # version: "0.7.0"
+
+      # Option 3: Version range (auto-update within range)
+      # version: ">=0.7.0, <1.0.0"
+      # version: "0.7.x"  # Patch updates only
+      # version: "~0.7"   # Z-stream updates
+
+      # Upgrade policy
+      # - CatalogProvided: Follow catalog upgrade constraints (default, recommended)
+      # - SelfCertified: Ignore constraints, allow any upgrade/downgrade
+      upgradeConstraintPolicy: CatalogProvided
+
+      # Catalog selector
+      # Filters which ClusterCatalogs to use for package selection
+      selector:
+        matchLabels:
+          olm.operatorframework.io/metadata.name: openshift-redhat-operators
+
+      # Optional: Channel selection
+      # channels: ["stable"]

--- a/operator/hack/olmv1/serviceaccount-installer.yaml
+++ b/operator/hack/olmv1/serviceaccount-installer.yaml
@@ -1,0 +1,213 @@
+# Minimal ServiceAccount for OLM v1 loki-operator installation
+#
+# This is the ABSOLUTE MINIMUM permissions needed based on bundle contents.
+# Derived from analyzing bundle/openshift/manifests/ and testing on OCP 4.22.5.
+#
+# Bundle contains:
+# - 4 CustomResourceDefinitions
+# - 1 ClusterRole + 1 ClusterRoleBinding
+# - 1 Role + 1 RoleBinding
+# - 1 ServiceAccount
+# - 2 Services
+# - 1 ConfigMap
+# - 1 Secret
+# - 1 ServiceMonitor
+# - ValidatingWebhookConfigurations (extracted from CSV by OLM v1)
+#
+# Usage:
+#   kubectl apply -f hack/olmv1/serviceaccount-installer-minimal.yaml
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-operators-redhat
+  labels:
+    app.kubernetes.io/name: loki-operator
+    app.kubernetes.io/part-of: loki
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loki-operator-installer
+  namespace: openshift-operators-redhat
+  labels:
+    app.kubernetes.io/name: loki-operator
+    app.kubernetes.io/component: installer
+    app.kubernetes.io/part-of: loki
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: loki-operator-installer
+  labels:
+    app.kubernetes.io/name: loki-operator
+    app.kubernetes.io/component: installer
+    app.kubernetes.io/part-of: loki
+rules:
+  # Create CRDs from bundle
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - patch
+      - watch
+  # Create operator RBAC (ClusterRole, ClusterRoleBinding, Role, RoleBinding)
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - clusterrolebindings
+      - roles
+      - rolebindings
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - patch
+      - escalate  # REQUIRED to create ClusterRole with more permissions
+      - bind      # REQUIRED to bind ClusterRole to ServiceAccount
+      - watch
+  # Create operator ServiceAccount + finalizers for owner references
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - patch
+      - delete
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/finalizers
+    verbs:
+      - update
+  # Create operator Deployment
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - patch
+      - delete
+      - watch
+  # Create Services
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - patch
+      - watch
+  # Create ConfigMaps
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - patch
+      - watch
+  # Create/access Secrets (metrics token, etc.)
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - patch
+      - watch
+  # Create ValidatingWebhookConfigurations
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - patch
+      - watch
+  # Read namespaces to verify installation namespace exists
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+  # Create ServiceMonitors
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+      - prometheusrules
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - patch
+      - watch
+  # Access ClusterExtension for owner references
+  - apiGroups:
+      - olm.operatorframework.io
+    resources:
+      - clusterextensions
+    verbs:
+      - get
+      - list
+
+  - apiGroups:
+      - olm.operatorframework.io
+    resources:
+      - clusterextensions/finalizers
+    verbs:
+      - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: loki-operator-installer
+  labels:
+    app.kubernetes.io/name: loki-operator
+    app.kubernetes.io/component: installer
+    app.kubernetes.io/part-of: loki
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: loki-operator-installer
+subjects:
+  - kind: ServiceAccount
+    name: loki-operator-installer
+    namespace: openshift-operators-redhat

--- a/operator/hack/olmv1/serviceaccount-installer.yaml
+++ b/operator/hack/olmv1/serviceaccount-installer.yaml
@@ -1,7 +1,7 @@
 # Minimal ServiceAccount for OLM v1 loki-operator installation
 #
-# This is the ABSOLUTE MINIMUM permissions needed based on bundle contents.
-# Derived from analyzing bundle/openshift/manifests/ and testing on OCP 4.22.5.
+# This is the minimum permissions needed based on bundle contents.
+# Derived from analyzing bundle/openshift/manifests/ and testing on OCP 4.22.0-rc.5.
 #
 # Bundle contains:
 # - 4 CustomResourceDefinitions
@@ -12,7 +12,7 @@
 # - 1 ConfigMap
 # - 1 Secret
 # - 1 ServiceMonitor
-# - ValidatingWebhookConfigurations (extracted from CSV by OLM v1)
+# - ValidatingWebhookConfigurations
 #
 # Usage:
 #   kubectl apply -f hack/olmv1/serviceaccount-installer-minimal.yaml
@@ -73,8 +73,8 @@ rules:
       - list
       - update
       - patch
-      - escalate  # REQUIRED to create ClusterRole with more permissions
-      - bind      # REQUIRED to bind ClusterRole to ServiceAccount
+      - escalate
+      - bind
       - watch
   # Create operator ServiceAccount + finalizers for owner references
   - apiGroups:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for deploying the Loki Operator using OLM v1 with the ClusterExtension API.

**Which issue(s) this PR fixes**:
Fixes [LOG-9429](https://redhat.atlassian.net/browse/LOG-9429)

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
