### PR TITLE
fix: Use consistent time units on operational dashboard

### DIFF
--- a/production/loki-mixin/dashboards/dashboard-loki-operational.json
+++ b/production/loki-mixin/dashboards/dashboard-loki-operational.json
@@ -621,7 +621,7 @@
        "fieldConfig": {
          "defaults": {
            "custom": {},
-           "unit": "ms"
+           "unit": "s"
          },
          "overrides": []
        },
@@ -662,17 +662,17 @@
        "steppedLine": false,
        "targets": [
          {
-           "expr": "histogram_quantile(0.99, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"$namespace/cortex-gw(-internal)?\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"})) * 1e3",
+           "expr": "histogram_quantile(0.99, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"$namespace/cortex-gw(-internal)?\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"}))",
            "legendFormat": ".99",
            "refId": "A"
          },
          {
-           "expr": "histogram_quantile(0.75, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"$namespace/cortex-gw(-internal)?\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"})) * 1e3",
+           "expr": "histogram_quantile(0.75, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"$namespace/cortex-gw(-internal)?\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"}))",
            "legendFormat": ".9",
            "refId": "B"
          },
          {
-           "expr": "histogram_quantile(0.5, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"$namespace/cortex-gw(-internal)?\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"})) * 1e3",
+           "expr": "histogram_quantile(0.5, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"$namespace/cortex-gw(-internal)?\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"}))",
            "legendFormat": ".5",
            "refId": "C"
          }
@@ -727,7 +727,7 @@
        "fieldConfig": {
          "defaults": {
            "custom": {},
-           "unit": "ms"
+           "unit": "s"
          },
          "overrides": []
        },
@@ -768,17 +768,17 @@
        "steppedLine": false,
        "targets": [
          {
-           "expr": "histogram_quantile(0.99, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"})) * 1e3",
+           "expr": "histogram_quantile(0.99, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"}))",
            "legendFormat": ".99",
            "refId": "A"
          },
          {
-           "expr": "histogram_quantile(0.9, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"})) * 1e3",
+           "expr": "histogram_quantile(0.9, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"}))",
            "legendFormat": ".9",
            "refId": "B"
          },
          {
-           "expr": "histogram_quantile(0.5, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"})) * 1e3",
+           "expr": "histogram_quantile(0.5, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"}))",
            "legendFormat": ".5",
            "refId": "C"
          }
@@ -930,7 +930,7 @@
        "fieldConfig": {
          "defaults": {
            "custom": {},
-           "unit": "ms"
+           "unit": "s"
          },
          "overrides": []
        },
@@ -971,18 +971,18 @@
        "steppedLine": false,
        "targets": [
          {
-           "expr": "histogram_quantile(0.99, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/ingester\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"})) * 1e3",
+           "expr": "histogram_quantile(0.99, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/ingester\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"}))",
            "legendFormat": ".99",
            "refId": "A"
          },
          {
-           "expr": "histogram_quantile(0.9, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/ingester\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"})) * 1e3",
+           "expr": "histogram_quantile(0.9, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/ingester\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"}))",
            "hide": false,
            "legendFormat": ".9",
            "refId": "B"
          },
          {
-           "expr": "histogram_quantile(0.5, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/ingester\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"})) * 1e3",
+           "expr": "histogram_quantile(0.5, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/ingester\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"}))",
            "hide": false,
            "legendFormat": ".5",
            "refId": "C"
@@ -1135,7 +1135,7 @@
        "fieldConfig": {
          "defaults": {
            "custom": {},
-           "unit": "ms"
+           "unit": "s"
          },
          "overrides": []
        },
@@ -1243,7 +1243,7 @@
        "fieldConfig": {
          "defaults": {
            "custom": {},
-           "unit": "ms"
+           "unit": "s"
          },
          "overrides": []
        },
@@ -1284,17 +1284,17 @@
        "steppedLine": false,
        "targets": [
          {
-           "expr": "histogram_quantile(0.99, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=\"$namespace/querier\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"})) * 1e3",
+           "expr": "histogram_quantile(0.99, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=\"$namespace/querier\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"}))",
            "legendFormat": ".99-{{route}}",
            "refId": "A"
          },
          {
-           "expr": "histogram_quantile(0.9, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=\"$namespace/querier\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"})) * 1e3",
+           "expr": "histogram_quantile(0.9, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=\"$namespace/querier\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"}))",
            "legendFormat": ".9-{{route}}",
            "refId": "B"
          },
          {
-           "expr": "histogram_quantile(0.5, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=\"$namespace/querier\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"})) * 1e3",
+           "expr": "histogram_quantile(0.5, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=\"$namespace/querier\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"}))",
            "legendFormat": ".5-{{route}}",
            "refId": "C"
          }
@@ -1447,7 +1447,7 @@
        "fieldConfig": {
          "defaults": {
            "custom": {},
-           "unit": "ms"
+           "unit": "s"
          },
          "overrides": []
        },
@@ -1488,17 +1488,17 @@
        "steppedLine": false,
        "targets": [
          {
-           "expr": "histogram_quantile(0.99, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=\"$namespace/ingester\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"})) * 1e3",
+           "expr": "histogram_quantile(0.99, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=\"$namespace/ingester\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"}))",
            "legendFormat": ".99-{{route}}",
            "refId": "A"
          },
          {
-           "expr": "histogram_quantile(0.9, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=\"$namespace/ingester\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"})) * 1e3",
+           "expr": "histogram_quantile(0.9, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=\"$namespace/ingester\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"}))",
            "legendFormat": ".9-{{route}}",
            "refId": "B"
          },
          {
-           "expr": "histogram_quantile(0.5, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=\"$namespace/ingester\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"})) * 1e3",
+           "expr": "histogram_quantile(0.5, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=\"$namespace/ingester\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"}))",
            "legendFormat": ".5-{{route}}",
            "refId": "C"
          }


### PR DESCRIPTION
**What this PR does / why we need it**:
Aligns all the latency panels on the Loki Operational dashboard to return their data in seconds and set the panel's unit to seconds to match.
Previously most panels were returning data in `ms`, with unit also set to milli-seconds except the Query Latency dashboard which was returning data in seconds and displaying it in milliseconds.


Example: The Query Latency and Querier Latency panels show the same shape of data but on two different scales so they don't agree with each other.
<img width="1382" height="385" alt="image" src="https://github.com/user-attachments/assets/d735df5e-5ce3-4f4a-a9c5-aa010ef6b328" />
