### PR TITLE
fix(dataobj): Handle constant predicates in logs predicate ordering

### DIFF
--- a/pkg/dataobj/sections/logs/row_predicate_order.go
+++ b/pkg/dataobj/sections/logs/row_predicate_order.go
@@ -172,6 +172,13 @@ func getPredicateSelectivity(p dataset.Predicate) selectivityScore {
 		// For custom functions, we cannot use the stats to estimate selectivity or to prune the rows.
 		// We might want these evaluated towards the end.
 		return selectivityScore(0.7)
+
+	case dataset.FalsePredicate:
+		return noMatchSelectivity
+
+	case dataset.TruePredicate:
+		return matchAllSelectivity
+
 	default:
 		panic(fmt.Sprintf("unknown predicate type: %T", p))
 	}

--- a/pkg/dataobj/sections/logs/row_predicate_order_test.go
+++ b/pkg/dataobj/sections/logs/row_predicate_order_test.go
@@ -216,6 +216,16 @@ func TestGetPredicateSelectivity(t *testing.T) {
 			},
 			want: selectivityScore(0.15),
 		},
+		{
+			name:      "FalsePredicate has zero selectivity",
+			predicate: dataset.FalsePredicate{},
+			want:      noMatchSelectivity,
+		},
+		{
+			name:      "TruePredicate matches all rows",
+			predicate: dataset.TruePredicate{},
+			want:      matchAllSelectivity,
+		},
 	}
 
 	for _, tt := range tests {
@@ -358,6 +368,11 @@ func TestOrderPredicates(t *testing.T) {
 			name:       "Order by selectivity - equality before AND",
 			predicates: []dataset.Predicate{andPred, equalPred2},
 			want:       []dataset.Predicate{equalPred2, andPred},
+		},
+		{
+			name:       "FalsePredicate ordered before other predicates",
+			predicates: []dataset.Predicate{equalPred1, dataset.FalsePredicate{}},
+			want:       []dataset.Predicate{dataset.FalsePredicate{}, equalPred1},
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`DataObjScan `can map engine filters to `dataset.TruePredicate` and
`dataset.FalsePredicate`, but `getPredicateSelectivity` panicked when
orderPredicates scored them. Return fixed selectivity for constants so
impossible filters no longer crash queriers during reader init.
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
