### PR TITLE
perf(engine): Short-circuit DataObjScan when logs predicate is unsatisfiable

### DIFF
--- a/pkg/engine/internal/executor/dataobjscan_predicate.go
+++ b/pkg/engine/internal/executor/dataobjscan_predicate.go
@@ -450,3 +450,50 @@ func buildLogsCaseInsensitiveMatch(col *logs.Column, op types.BinaryOp, value sc
 
 	return nil, fmt.Errorf("unrecognized case-insensitive match operation %s", op)
 }
+
+// logsPredicateIsUnsatisfiable reports whether p can never match a row.
+func logsPredicateIsUnsatisfiable(p logs.Predicate) bool {
+	switch p := p.(type) {
+	case logs.FalsePredicate:
+		return true
+	case logs.TruePredicate:
+		return false
+	case logs.AndPredicate:
+		return logsPredicateIsUnsatisfiable(p.Left) || logsPredicateIsUnsatisfiable(p.Right)
+	case logs.OrPredicate:
+		return logsPredicateIsUnsatisfiable(p.Left) && logsPredicateIsUnsatisfiable(p.Right)
+	case logs.NotPredicate:
+		return logsPredicateIsSatisfiableForAllRows(p.Inner)
+	default:
+		return false
+	}
+}
+
+// logsPredicateIsSatisfiableForAllRows reports whether p matches every row.
+func logsPredicateIsSatisfiableForAllRows(p logs.Predicate) bool {
+	switch p := p.(type) {
+	case logs.TruePredicate:
+		return true
+	case logs.FalsePredicate:
+		return false
+	case logs.AndPredicate:
+		return logsPredicateIsSatisfiableForAllRows(p.Left) && logsPredicateIsSatisfiableForAllRows(p.Right)
+	case logs.OrPredicate:
+		return logsPredicateIsSatisfiableForAllRows(p.Left) || logsPredicateIsSatisfiableForAllRows(p.Right)
+	case logs.NotPredicate:
+		return logsPredicateIsUnsatisfiable(p.Inner)
+	default:
+		return false
+	}
+}
+
+// logsPredicatesAreUnsatisfiable reports whether the conjunction of predicates can
+// never match a row. Multiple predicates passed to [logs.Reader] are ANDed.
+func logsPredicatesAreUnsatisfiable(predicates []logs.Predicate) bool {
+	for _, p := range predicates {
+		if logsPredicateIsUnsatisfiable(p) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/engine/internal/executor/dataobjscan_predicate_unsatisfiable_test.go
+++ b/pkg/engine/internal/executor/dataobjscan_predicate_unsatisfiable_test.go
@@ -1,0 +1,141 @@
+package executor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/scalar"
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/user"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+func Test_logsPredicateIsUnsatisfiable(t *testing.T) {
+	timestampColumn := &logs.Column{Type: logs.ColumnTypeTimestamp}
+	columns := []*logs.Column{timestampColumn}
+
+	tests := []struct {
+		name string
+		p    logs.Predicate
+		want bool
+	}{
+		{name: "false", p: logs.FalsePredicate{}, want: true},
+		{name: "true", p: logs.TruePredicate{}, want: false},
+		{
+			name: "AND with false child",
+			p: logs.AndPredicate{
+				Left:  logs.TruePredicate{},
+				Right: logs.FalsePredicate{},
+			},
+			want: true,
+		},
+		{
+			name: "OR with one satisfiable child",
+			p: logs.OrPredicate{
+				Left:  logs.FalsePredicate{},
+				Right: logs.TruePredicate{},
+			},
+			want: false,
+		},
+		{
+			name: "OR with both unsatisfiable",
+			p: logs.OrPredicate{
+				Left:  logs.FalsePredicate{},
+				Right: logs.FalsePredicate{},
+			},
+			want: true,
+		},
+		{
+			name: "NOT false",
+			p:    logs.NotPredicate{Inner: logs.FalsePredicate{}},
+			want: false,
+		},
+		{
+			name: "NOT true",
+			p:    logs.NotPredicate{Inner: logs.TruePredicate{}},
+			want: true,
+		},
+		{
+			name: "equality can match",
+			p: logs.EqualPredicate{
+				Column: timestampColumn,
+				Value:  scalar.NewInt64Scalar(1),
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, logsPredicateIsUnsatisfiable(tt.p))
+		})
+	}
+
+	t.Run("missing column becomes false", func(t *testing.T) {
+		expr := &physical.BinaryExpr{
+			Op:    types.BinaryOpEq,
+			Left:  columnRef(types.ColumnTypeMetadata, "missing"),
+			Right: physical.NewLiteral("value"),
+		}
+		p, err := buildLogsPredicate(expr, columns)
+		require.NoError(t, err)
+		require.True(t, logsPredicateIsUnsatisfiable(p))
+	})
+}
+
+func Test_logsPredicatesAreUnsatisfiable(t *testing.T) {
+	require.False(t, logsPredicatesAreUnsatisfiable(nil))
+	require.False(t, logsPredicatesAreUnsatisfiable([]logs.Predicate{logs.TruePredicate{}}))
+	require.True(t, logsPredicatesAreUnsatisfiable([]logs.Predicate{
+		logs.TruePredicate{},
+		logs.FalsePredicate{},
+	}))
+}
+
+func Test_executeDataObjScan_unsatisfiablePredicate(t *testing.T) {
+	obj := buildDataobj(t, []logproto.Stream{
+		{
+			Labels: `{service="loki"}`,
+			Entries: []logproto.Entry{
+				{Timestamp: mustTimeUnix(5), Line: "hello"},
+			},
+		},
+	})
+
+	bucket := objstore.NewInMemBucket()
+	const objectPath = "objects/test"
+	reader, err := obj.Reader(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, bucket.Upload(context.Background(), objectPath, reader))
+	require.NoError(t, reader.Close())
+
+	ctx := user.InjectOrgID(t.Context(), "tenant")
+	c := &Context{
+		bucket:    bucket,
+		batchSize: 512,
+		logger:    log.NewNopLogger(),
+	}
+
+	pipeline := c.executeDataObjScan(ctx, &physical.DataObjScan{
+		Location:  objectPath,
+		Section:   0,
+		StreamIDs: []int64{1},
+		Predicates: []physical.Expression{
+			physical.NewLiteral(false),
+		},
+	})
+
+	_, err = pipeline.Read(ctx)
+	require.ErrorIs(t, err, EOF)
+}
+
+func mustTimeUnix(sec int64) time.Time {
+	return time.Unix(sec, 0).UTC()
+}

--- a/pkg/engine/internal/executor/executor.go
+++ b/pkg/engine/internal/executor/executor.go
@@ -266,6 +266,11 @@ func (c *Context) executeDataObjScan(ctx context.Context, node *physical.DataObj
 	}
 	span.AddEvent("constructed predicate")
 
+	if logsPredicatesAreUnsatisfiable(predicates) {
+		span.AddEvent("unsatisfiable logs predicate; skipping dataobj scan")
+		return emptyPipeline()
+	}
+
 	var pipeline Pipeline = newDataobjScanPipeline(dataobjScanOptions{
 		// TODO(rfratto): passing the streams section means that each DataObjScan
 		// will read the entire streams section (for IDs being loaded), which is


### PR DESCRIPTION
**What this PR does / why we need it**:
When the engine pushes filters into `DataObjScan`, some expressions fold to `logs.FalsePredicate` (missing column, impossible NULL comparisons, literal false, AND with a false child, etc.). Those scans cannot return rows, but we still built a full `dataobjScan` pipeline and opened the columnar `logs.Reader`.

This change detects unsatisfiable logs predicates after `buildLogsPredicate` and returns `emptyPipeline()` instead, matching “no rows” without initializing the scan reader. Section open order is unchanged (streams and logs still open in parallel); we only skip pipeline construction.

**Changes**
Add `logsPredicateIsUnsatisfiable` / `logsPredicatesAreUnsatisfiable` for constant and composite predicates (And, Or, Not).
In `executeDataObjScan`, return `emptyPipeline()` when the conjunction of pushed-down predicates is unsatisfiable.
Unit tests for predicate analysis and an integration-style test via `executeDataObjScan` with literal `false`.




**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
