### PR TITLE
chore: Deprecate configuration of TSDB sharding strategy

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -4452,10 +4452,10 @@ discover_generic_fields:
 # CLI flag: -querier.tsdb-max-bytes-per-shard
 [tsdb_max_bytes_per_shard: <int> | default = 600MB]
 
-# sharding strategy to use in query planning. Suggested to use bounded once all
-# nodes can recognize it.
+# DEPRECATED: Defines the sharding strategy to use in query planning. Use
+# 'bounded' only.
 # CLI flag: -limits.tsdb-sharding-strategy
-[tsdb_sharding_strategy: <string> | default = "power_of_two"]
+[tsdb_sharding_strategy: <string> | default = "bounded"]
 
 # Precompute chunks for TSDB queries. This can improve query performance at the
 # cost of increased memory usage by computing chunks once during planning,

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -434,9 +434,9 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(
 		&l.TSDBShardingStrategy,
 		"limits.tsdb-sharding-strategy",
-		logql.PowerOfTwoVersion.String(),
+		logql.BoundedVersion.String(),
 		fmt.Sprintf(
-			"sharding strategy to use in query planning. Suggested to use %s once all nodes can recognize it.",
+			"DEPRECATED: Defines the sharding strategy to use in query planning. Use '%s' only.",
 			logql.BoundedVersion.String(),
 		),
 	)
@@ -682,8 +682,8 @@ func (l *Limits) Validate() error {
 		}
 	}
 
-	if _, err := logql.ParseShardVersion(l.TSDBShardingStrategy); err != nil {
-		return errors.Wrap(err, "invalid tsdb sharding strategy")
+	if l.TSDBShardingStrategy != logql.BoundedVersion.String() {
+		return fmt.Errorf("invalid tsdb sharding strategy, only %s is supported", logql.BoundedVersion.String())
 	}
 
 	if _, err := compression.ParseCodec(l.BloomBlockEncoding); err != nil {

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -395,7 +395,7 @@ func TestLimitsValidation(t *testing.T) {
 	} {
 		desc := fmt.Sprintf("%s/%s", tc.limits.DeletionMode, tc.limits.BloomBlockEncoding)
 		t.Run(desc, func(t *testing.T) {
-			tc.limits.TSDBShardingStrategy = logql.PowerOfTwoVersion.String() // hacky but needed for test
+			tc.limits.TSDBShardingStrategy = logql.BoundedVersion.String()
 			tc.limits.TSDBMaxBytesPerShard = DefaultTSDBMaxBytesPerShard
 			if tc.limits.EngineResultsCacheTimeBucketInterval == 0 {
 				_ = tc.limits.EngineResultsCacheTimeBucketInterval.Set("24h")

--- a/tools/deprecated-config-checker/checker/checker_test.go
+++ b/tools/deprecated-config-checker/checker/checker_test.go
@@ -83,6 +83,7 @@ var (
 		"limits_config.ruler_remote_write_sigv4_config",
 		"limits_config.per_tenant_override_config",
 		"limits_config.per_tenant_override_period",
+		"limits_config.tsdb_sharding_strategy",
 	}
 
 	expectedRuntimeConfigDeletes = []string{

--- a/tools/deprecated-config-checker/deprecated-config.yaml
+++ b/tools/deprecated-config-checker/deprecated-config.yaml
@@ -44,6 +44,7 @@ limits_config:
   ruler_remote_write_sigv4_config: "Use ruler_remote_write_config instead."
   per_tenant_override_config: "Feature renamed to 'runtime configuration', flag deprecated in favor of runtime_config.file"
   per_tenant_override_period: "Feature renamed to 'runtime configuration', flag deprecated in favor of runtime_config.period"
+  tsdb_sharding_strategy: "Settting is removed in favor of the best default value"
 
 server:
   grpc_server_stats_tracking_enabled: "Deprecated, currently doesn't do anything, will be removed in a future version."

--- a/tools/deprecated-config-checker/test-fixtures/config.yaml
+++ b/tools/deprecated-config-checker/test-fixtures/config.yaml
@@ -140,3 +140,4 @@ limits_config:
   per_tenant_override_config: ./overrides.yaml # DEPRECATED
   per_tenant_override_period: 5s # DEPRECATED
   allow_deletes: true # DELETED
+  tsdb_sharding_strategy: bounded # DEPRECATED


### PR DESCRIPTION
### Summary

This PR deprecates the `tsdb_sharding_strategy` per-tenant setting (`-limits.tsdb-sharding-strategy`) and changes its default to `bounded` (from `power_of_two`).

This sharding strategy produces more accurate and consistent shard sizes across large and small streams and has been used in production for large scale tenants for a long time already.
