### PR TITLE
chore: Update Go to `1.26.4`

### DIFF
--- a/.github/workflows/build-loki-binary.yml
+++ b/.github/workflows/build-loki-binary.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
 
 jobs:
   build:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@
   "check":
     "uses": "grafana/loki-release/.github/workflows/check.yml@e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
     "with":
-      "build_image": "golang:1.26.3"
+      "build_image": "golang:1.26.4"
       "golang_ci_lint_version": "v2.10.1"
       "release_lib_ref": "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
       "skip_validation": false

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
   GOVULNCHECK_VERSION: "v1.3.0"
 
 jobs:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -2,7 +2,7 @@
   "check":
     "uses": "grafana/loki-release/.github/workflows/check.yml@e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
     "with":
-      "build_image": "golang:1.26.3"
+      "build_image": "golang:1.26.4"
       "golang_ci_lint_version": "v2.10.1"
       "release_lib_ref": "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
       "skip_validation": false
@@ -10,7 +10,7 @@
   "logql-analyzer-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.26.3"
+      "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
       "RELEASE_LIB_REF": "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
       "RELEASE_REPO": "grafana/loki"
@@ -150,7 +150,7 @@
   "loki-canary-boringcrypto-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.26.3"
+      "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
       "RELEASE_LIB_REF": "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
       "RELEASE_REPO": "grafana/loki"
@@ -290,7 +290,7 @@
   "loki-canary-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.26.3"
+      "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
       "RELEASE_LIB_REF": "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
       "RELEASE_REPO": "grafana/loki"
@@ -430,7 +430,7 @@
   "loki-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.26.3"
+      "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
       "RELEASE_LIB_REF": "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
       "RELEASE_REPO": "grafana/loki"
@@ -570,7 +570,7 @@
   "loki-query-tee-image":
     "env":
       "BUILD_TIMEOUT": 60
-      "GO_VERSION": "1.26.3"
+      "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
       "RELEASE_LIB_REF": "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
       "RELEASE_REPO": "grafana/loki"

--- a/.github/workflows/lint-jsonnet.yml
+++ b/.github/workflows/lint-jsonnet.yml
@@ -26,7 +26,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: setup jsonnet
         run: |
           go install github.com/google/go-jsonnet/cmd/jsonnet@v0.20.0

--- a/.github/workflows/logql-bench.yml
+++ b/.github/workflows/logql-bench.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
 
       # The metastore generates invalid filenames for Windows (with colons),
       # which get rejected by upload-artifact. We zip these files to avoid this
@@ -105,7 +105,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
 
       - name: Create results directory
         run: mkdir -p ./pkg/logql/bench/results

--- a/.github/workflows/logql-correctness.yml
+++ b/.github/workflows/logql-correctness.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
 
       # The metastore generates invalid filenames for Windows (with colons),
       # which get rejected by upload-artifact. We zip these files to avoid this
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
 
       - name: Create results directory
         run: mkdir -p ./pkg/logql/bench/results

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: "write"
     uses: "grafana/loki-release/.github/workflows/check.yml@e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
     with:
-      build_image: "golang:1.26.3"
+      build_image: "golang:1.26.4"
       golang_ci_lint_version: "v2.10.1"
       release_lib_ref: "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
       skip_validation: false
@@ -131,9 +131,9 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "golang:1.26.3"
+          --entrypoint /bin/sh "golang:1.26.4"
           git config --global --add safe.directory /src/loki
-          if echo "golang:1.26.3" | grep -q "golang"; then
+          if echo "golang:1.26.4" | grep -q "golang"; then
             /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
           fi
           make dist packages
@@ -154,9 +154,9 @@ jobs:
           --env IMAGE_TAG \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "golang:1.26.3"
+          --entrypoint /bin/sh "golang:1.26.4"
           git config --global --add safe.directory /src/loki
-          if echo "golang:1.26.3" | grep -q "golang"; then
+          if echo "golang:1.26.4" | grep -q "golang"; then
             /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
           fi
           make dist/loki-linux-riscv64
@@ -780,7 +780,7 @@ jobs:
         build-args: |
           IMAGE_TAG=${{ needs.version.outputs.version }}
           GOARCH=${{ steps.platform.outputs.platform_short }}
-          BUILD_IMAGE=golang:1.26.3
+          BUILD_IMAGE=golang:1.26.4
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=local,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: "write"
     uses: "grafana/loki-release/.github/workflows/check.yml@e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
     with:
-      build_image: "golang:1.26.3"
+      build_image: "golang:1.26.4"
       golang_ci_lint_version: "v2.10.1"
       release_lib_ref: "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
       skip_validation: false
@@ -131,9 +131,9 @@ jobs:
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "golang:1.26.3"
+          --entrypoint /bin/sh "golang:1.26.4"
           git config --global --add safe.directory /src/loki
-          if echo "golang:1.26.3" | grep -q "golang"; then
+          if echo "golang:1.26.4" | grep -q "golang"; then
             /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
           fi
           make dist packages
@@ -154,9 +154,9 @@ jobs:
           --env IMAGE_TAG \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "golang:1.26.3"
+          --entrypoint /bin/sh "golang:1.26.4"
           git config --global --add safe.directory /src/loki
-          if echo "golang:1.26.3" | grep -q "golang"; then
+          if echo "golang:1.26.4" | grep -q "golang"; then
             /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
           fi
           make dist/loki-linux-riscv64
@@ -780,7 +780,7 @@ jobs:
         build-args: |
           IMAGE_TAG=${{ needs.version.outputs.version }}
           GOARCH=${{ steps.platform.outputs.platform_short }}
-          BUILD_IMAGE=golang:1.26.3
+          BUILD_IMAGE=golang:1.26.4
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=local,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}"

--- a/.github/workflows/querytee-images.yml
+++ b/.github/workflows/querytee-images.yml
@@ -17,7 +17,7 @@ permissions:
 env:
   BUILD_TIMEOUT: 60
   IMAGE_PREFIX: grafana
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
 
 jobs:
   loki-query-tee-image:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ DOCKER_INTERACTIVE_FLAGS := --tty --interactive
 endif
 
 # Ensure you run `make release-workflows` after changing this
-GO_VERSION         := 1.26.3
+GO_VERSION         := 1.26.4
 # Ensure you run `make IMAGE_TAG=<updated-tag> build-image-push` after changing this
 BUILD_IMAGE_TAG    := 0.35.1
 

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,8 @@ else
 DOCKER_INTERACTIVE_FLAGS := --tty --interactive
 endif
 
-# Ensure you run `make release-workflows` after changing this
+# Ensure you run `make update-go-version` after changing this
 GO_VERSION         := 1.26.4
-# Ensure you run `make IMAGE_TAG=<updated-tag> build-image-push` after changing this
-BUILD_IMAGE_TAG    := 0.35.1
 
 IMAGE_TAG          ?= $(shell ./tools/image-tag)
 GIT_REVISION       := $(shell git rev-parse --short HEAD)
@@ -150,7 +148,7 @@ help: ## Display this help
 .PHONY: clean clean-protos
 .PHONY: dev-k3d-loki dev-k3d-enterprise-logs dev-k3d-down
 .PHONY: helm-test helm-lint
-.PHONY: goversion
+.PHONY: goversion update-go-version
 
 #############
 # Variables #
@@ -195,6 +193,9 @@ binfmt:
 
 goversion:
 	@echo $(GO_VERSION)
+
+update-go-version: goversion release-workflows
+	@tools/go-version-bump.sh $(GO_VERSION)
 
 all: logcli loki loki-canary ## build all executables (loki, logcli, loki-canary)
 

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ help: ## Display this help
 .PHONY: clean clean-protos
 .PHONY: dev-k3d-loki dev-k3d-enterprise-logs dev-k3d-down
 .PHONY: helm-test helm-lint
+.PHONY: goversion
 
 #############
 # Variables #
@@ -191,6 +192,10 @@ binfmt:
 ################
 # Main Targets #
 ################
+
+goversion:
+	@echo $(GO_VERSION)
+
 all: logcli loki loki-canary ## build all executables (loki, logcli, loki-canary)
 
 # This is really a check for the CI to make sure generated files are built and checked in manually

--- a/Makefile
+++ b/Makefile
@@ -859,10 +859,13 @@ update-loki-release-sha:
 
 .PHONY: flake-update
 flake-update:
-	@docker run -v $(CURDIR):/loki \
+	@docker run --rm --tty --interactive \
+		--volume $(shell pwd):/loki \
 		--workdir /loki \
+		--entrypoint bash \
 		nixos/nix \
-		nix \
-		--extra-experimental-features nix-command \
-		--extra-experimental-features flakes \
-		flake update
+		-c "\
+	    git config --global --add safe.directory /loki && \
+      nix --extra-experimental-features nix-command --extra-experimental-features flakes \
+			    flake update \
+		"

--- a/clients/cmd/fluent-bit/Dockerfile
+++ b/clients/cmd/fluent-bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 COPY . /src
 

--- a/cmd/chunks-inspect/go.mod
+++ b/cmd/chunks-inspect/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/loki/cmd/chunks-inspect
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/golang/snappy v1.0.0

--- a/cmd/dataobj-inspect/go.mod
+++ b/cmd/dataobj-inspect/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/loki/cmd/dataobj-inspect
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0

--- a/docs/sources/community/maintaining/release/patch-go-version.md
+++ b/docs/sources/community/maintaining/release/patch-go-version.md
@@ -1,25 +1,15 @@
 ---
 title: Patch Go version
-description: Describes the procedure how to patch the Go version in the Loki build image.
+description: Describes the procedure how to patch the Go version in Loki.
 ---
 # Patch Go version
 
 Update vulnerable Go version to non-vulnerable Go version to build Grafana Loki binaries.
 
-## Before you begin.
-
-1. Determine the [VERSION_PREFIX](../concepts/version/).
-
-1. Need to sign-in to Docker hub to be able to push Loki build image.
-
 ## Steps
 
 1. Find Go version to which you need to update. Example `1.20.5` to `1.20.6`
-
-1. Update Go version in the Grafana Loki build image (`loki-build-image/Dockerfile`) on the `main` branch.
-
-1. [Release a new Loki Build Image](../../release-loki-build-image/)
-
-1. [Backport](../backport-commits/) the Dockerfile change to `release-VERSION_PREFIX` branch.
-
-1. [Backport](../backport-commits/) the Loki Build Image version change from `main` to `release-VERSION_PREFIX` branch.
+1. Update Go version (`GO_VERSION`) in the `Makefile`.
+1. Run `make release-workflows` to update the version in generated release workflows.
+1. Run `make update-go-version` to update all relevant files.
+1. Open a pull request against the target branch (`main` or `release-MAJOR.MINOR.x`).

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779467186,
-        "narHash": "sha256-nOesoDCiXcUftqbRBMz9tt4blI5PvljMWbm3kuCA+0s=",
+        "lastModified": 1779796641,
+        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b77b3de8775677f84492abe84635f87b0e153f0f",
+        "rev": "25f538306313eae3927264466c70d7001dcea1df",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,26 +8,40 @@
   };
 
   outputs =
-    {
-      self,
-      nixpkgs,
-      nixpkgs-unstable,
-      flake-utils,
+    { self
+    , nixpkgs
+    , nixpkgs-unstable
+    , flake-utils
+    ,
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
       let
+        # The go version in nixpkgs often trails behind the latest by a few
+        # days. Overlay to pin to the exact version go.mod expects.
+        goOverlay = final: prev: {
+          go_1_26 = prev.go_1_26.overrideAttrs (old: rec {
+            version = "1.26.4";
+            src = prev.fetchurl {
+              url = "https://go.dev/dl/go${version}.src.tar.gz";
+              hash = "sha256-T2aKMvv8ETLmqIH7lowvHa2mMUkqM5IRc1+7JVpCYC0=";
+            };
+          });
+        };
+
         base = import nixpkgs {
           inherit system;
           config = {
             allowUnfree = true;
           };
+          overlays = [ goOverlay ];
         };
         unstable = import nixpkgs-unstable {
           inherit system;
           config = {
             allowUnfree = true;
           };
+          overlays = [ goOverlay ];
         };
 
         pkgs = base // {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/loki/v3
 
-go 1.26.3
+go 1.26.4
 
 ignore ./tools/dev
 

--- a/pkg/push/go.mod
+++ b/pkg/push/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/loki/pkg/push
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/production/loki-mixin-compiled-ssd/dashboards/loki-operational.json
+++ b/production/loki-mixin-compiled-ssd/dashboards/loki-operational.json
@@ -526,7 +526,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "ms"
+                  "unit": "s"
                },
                "overrides": [ ]
             },
@@ -568,17 +568,17 @@
             "steppedLine": false,
             "targets": [
                {
-                  "expr": "histogram_quantile(0.99, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.99, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"}))",
                   "legendFormat": ".99",
                   "refId": "A"
                },
                {
-                  "expr": "histogram_quantile(0.75, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.75, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"}))",
                   "legendFormat": ".9",
                   "refId": "B"
                },
                {
-                  "expr": "histogram_quantile(0.5, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.5, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"}))",
                   "legendFormat": ".5",
                   "refId": "C"
                }
@@ -633,7 +633,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "ms"
+                  "unit": "s"
                },
                "overrides": [ ]
             },
@@ -675,17 +675,17 @@
             "steppedLine": false,
             "targets": [
                {
-                  "expr": "histogram_quantile(0.99, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.99, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", cluster=~\"$cluster\"}))",
                   "legendFormat": ".99",
                   "refId": "A"
                },
                {
-                  "expr": "histogram_quantile(0.9, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.9, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", cluster=~\"$cluster\"}))",
                   "legendFormat": ".9",
                   "refId": "B"
                },
                {
-                  "expr": "histogram_quantile(0.5, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.5, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", cluster=~\"$cluster\"}))",
                   "legendFormat": ".5",
                   "refId": "C"
                }
@@ -838,7 +838,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "ms"
+                  "unit": "s"
                },
                "overrides": [ ]
             },
@@ -880,18 +880,18 @@
             "steppedLine": false,
             "targets": [
                {
-                  "expr": "histogram_quantile(0.99, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.99, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"}))",
                   "legendFormat": ".99",
                   "refId": "A"
                },
                {
-                  "expr": "histogram_quantile(0.9, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.9, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"}))",
                   "hide": false,
                   "legendFormat": ".9",
                   "refId": "B"
                },
                {
-                  "expr": "histogram_quantile(0.5, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.5, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"}))",
                   "hide": false,
                   "legendFormat": ".5",
                   "refId": "C"
@@ -1045,7 +1045,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "ms"
+                  "unit": "s"
                },
                "overrides": [ ]
             },
@@ -1154,7 +1154,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "ms"
+                  "unit": "s"
                },
                "overrides": [ ]
             },
@@ -1196,17 +1196,17 @@
             "steppedLine": false,
             "targets": [
                {
-                  "expr": "histogram_quantile(0.99, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-read\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.99, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-read\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"}))",
                   "legendFormat": ".99-{{route}}",
                   "refId": "A"
                },
                {
-                  "expr": "histogram_quantile(0.9, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-read\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.9, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-read\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"}))",
                   "legendFormat": ".9-{{route}}",
                   "refId": "B"
                },
                {
-                  "expr": "histogram_quantile(0.5, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-read\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.5, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-read\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"}))",
                   "legendFormat": ".5-{{route}}",
                   "refId": "C"
                }
@@ -1360,7 +1360,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "ms"
+                  "unit": "s"
                },
                "overrides": [ ]
             },
@@ -1402,17 +1402,17 @@
             "steppedLine": false,
             "targets": [
                {
-                  "expr": "histogram_quantile(0.99, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.99, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"}))",
                   "legendFormat": ".99-{{route}}",
                   "refId": "A"
                },
                {
-                  "expr": "histogram_quantile(0.9, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.9, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"}))",
                   "legendFormat": ".9-{{route}}",
                   "refId": "B"
                },
                {
-                  "expr": "histogram_quantile(0.5, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.5, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(loki.*|enterprise-logs)-write\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"}))",
                   "legendFormat": ".5-{{route}}",
                   "refId": "C"
                }

--- a/production/loki-mixin-compiled/dashboards/loki-operational.json
+++ b/production/loki-mixin-compiled/dashboards/loki-operational.json
@@ -623,7 +623,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "ms"
+                  "unit": "s"
                },
                "overrides": [ ]
             },
@@ -665,17 +665,17 @@
             "steppedLine": false,
             "targets": [
                {
-                  "expr": "histogram_quantile(0.99, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.99, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"}))",
                   "legendFormat": ".99",
                   "refId": "A"
                },
                {
-                  "expr": "histogram_quantile(0.75, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.75, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"}))",
                   "legendFormat": ".9",
                   "refId": "B"
                },
                {
-                  "expr": "histogram_quantile(0.5, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.5, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", route=~\"api_prom_push|loki_api_v1_push|otlp_v1_logs\", cluster=~\"$cluster\"}))",
                   "legendFormat": ".5",
                   "refId": "C"
                }
@@ -730,7 +730,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "ms"
+                  "unit": "s"
                },
                "overrides": [ ]
             },
@@ -772,17 +772,17 @@
             "steppedLine": false,
             "targets": [
                {
-                  "expr": "histogram_quantile(0.99, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.99, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"}))",
                   "legendFormat": ".99",
                   "refId": "A"
                },
                {
-                  "expr": "histogram_quantile(0.9, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.9, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"}))",
                   "legendFormat": ".9",
                   "refId": "B"
                },
                {
-                  "expr": "histogram_quantile(0.5, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.5, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"}))",
                   "legendFormat": ".5",
                   "refId": "C"
                }
@@ -935,7 +935,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "ms"
+                  "unit": "s"
                },
                "overrides": [ ]
             },
@@ -977,18 +977,18 @@
             "steppedLine": false,
             "targets": [
                {
-                  "expr": "histogram_quantile(0.99, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(ingester.*|partition-ingester.*)\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.99, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(ingester.*|partition-ingester.*)\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"}))",
                   "legendFormat": ".99",
                   "refId": "A"
                },
                {
-                  "expr": "histogram_quantile(0.9, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(ingester.*|partition-ingester.*)\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.9, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(ingester.*|partition-ingester.*)\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"}))",
                   "hide": false,
                   "legendFormat": ".9",
                   "refId": "B"
                },
                {
-                  "expr": "histogram_quantile(0.5, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(ingester.*|partition-ingester.*)\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.5, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(ingester.*|partition-ingester.*)\", route=\"/logproto.Pusher/Push\", cluster=~\"$cluster\"}))",
                   "hide": false,
                   "legendFormat": ".5",
                   "refId": "C"
@@ -1142,7 +1142,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "ms"
+                  "unit": "s"
                },
                "overrides": [ ]
             },
@@ -1251,7 +1251,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "ms"
+                  "unit": "s"
                },
                "overrides": [ ]
             },
@@ -1293,17 +1293,17 @@
             "steppedLine": false,
             "targets": [
                {
-                  "expr": "histogram_quantile(0.99, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/querier\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.99, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/querier\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"}))",
                   "legendFormat": ".99-{{route}}",
                   "refId": "A"
                },
                {
-                  "expr": "histogram_quantile(0.9, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/querier\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.9, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/querier\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"}))",
                   "legendFormat": ".9-{{route}}",
                   "refId": "B"
                },
                {
-                  "expr": "histogram_quantile(0.5, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/querier\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.5, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/querier\", route=~\"api_prom_query|api_prom_labels|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_label|loki_api_v1_label_name_values\", cluster=\"$cluster\"}))",
                   "legendFormat": ".5-{{route}}",
                   "refId": "C"
                }
@@ -1457,7 +1457,7 @@
             "fieldConfig": {
                "defaults": {
                   "custom": { },
-                  "unit": "ms"
+                  "unit": "s"
                },
                "overrides": [ ]
             },
@@ -1499,17 +1499,17 @@
             "steppedLine": false,
             "targets": [
                {
-                  "expr": "histogram_quantile(0.99, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(ingester.*|partition-ingester.*)\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.99, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(ingester.*|partition-ingester.*)\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"}))",
                   "legendFormat": ".99-{{route}}",
                   "refId": "A"
                },
                {
-                  "expr": "histogram_quantile(0.9, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(ingester.*|partition-ingester.*)\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.9, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(ingester.*|partition-ingester.*)\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"}))",
                   "legendFormat": ".9-{{route}}",
                   "refId": "B"
                },
                {
-                  "expr": "histogram_quantile(0.5, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(ingester.*|partition-ingester.*)\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"})) * 1e3",
+                  "expr": "histogram_quantile(0.5, sum by (le,route) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/(ingester.*|partition-ingester.*)\", route=~\"/logproto.Querier/Query|/logproto.Querier/Label|/logproto.Querier/Series|/logproto.Querier/QuerySample|/logproto.Querier/GetChunkIDs\", cluster=\"$cluster\"}))",
                   "legendFormat": ".5-{{route}}",
                   "refId": "C"
                }

--- a/tools/go-version-bump.sh
+++ b/tools/go-version-bump.sh
@@ -25,17 +25,17 @@ if [[ -z "${VERSION}" ]]; then
   exit 1
 fi
 
-EXCLUDE_DIRS="-name operator -prune -o -name vendor -prune -o"
+EXCLUDE_DIRS=(-name operator -prune -o -name vendor -prune -o)
 
 print_green "Updating version in go.mod '${VERSION}'"
-find $EXCLUDE_DIRS -type f -name "go.mod" -exec grep -lE "^go " {} \; |
+find "${EXCLUDE_DIRS[@]}" -type f -name "go.mod" -exec grep -lE "^go " {} \; |
   while read -r x; do
     echo " Checking ${x}"
     ${SED} -i -re "s,go [0-9\.]+,go ${VERSION},g" "${x}"
   done
 
 print_green "Updating golang base images to '${VERSION}'"
-find $EXCLUDE_DIRS -type f -name "Dockerfile*" -exec grep -lE "FROM golang:" {} \; |
+find "${EXCLUDE_DIRS[@]}" -type f -name "Dockerfile*" -exec grep -lE "FROM golang:" {} \; |
   while read -r x; do
     echo " Checking ${x}"
     ${SED} -i -re "s,golang:[0-9\.]+,golang:${VERSION},g" "${x}"

--- a/tools/go-version-bump.sh
+++ b/tools/go-version-bump.sh
@@ -27,6 +27,13 @@ fi
 
 EXCLUDE_DIRS="-name operator -prune -o -name vendor -prune -o"
 
+print_green "Updating version in go.mod '${VERSION}'"
+find $EXCLUDE_DIRS -type f -name "go.mod" -exec grep -lE "^go " {} \; |
+  while read -r x; do
+    echo " Checking ${x}"
+    ${SED} -i -re "s,go [0-9\.]+,go ${VERSION},g" "${x}"
+  done
+
 print_green "Updating golang base images to '${VERSION}'"
 find $EXCLUDE_DIRS -type f -name "Dockerfile*" -exec grep -lE "FROM golang:" {} \; |
   while read -r x; do

--- a/tools/go-version-bump.sh
+++ b/tools/go-version-bump.sh
@@ -2,6 +2,14 @@
 
 set -euo pipefail
 
+function print_green() {
+  echo -e "\033[32m$1\033[0m";
+}
+
+function print_red() {
+  echo -e "\033[31m$1\033[0m";
+}
+
 # The BSD version of the sed command in MacOS doesn't work with this script.
 # Please install gnu-sed via `brew install gnu-sed`.
 # The gsed command becomes available then.
@@ -13,14 +21,29 @@ fi
 
 VERSION="${1-}"
 if [[ -z "${VERSION}" ]]; then
-  >&2 echo "Usage: $0 <version>"
+  >&2 print_red "Usage: $0 <version>"
   exit 1
 fi
 
-echo "Updating golang base images to '${VERSION}'"
+EXCLUDE_DIRS="-name operator -prune -o -name vendor -prune -o"
 
-find cmd clients tools loki-build-image -type f -name 'Dockerfile*' -exec grep -lE "FROM golang:[0-9\.]+" {} \; |
+print_green "Updating golang base images to '${VERSION}'"
+find $EXCLUDE_DIRS -type f -name "Dockerfile*" -exec grep -lE "FROM golang:" {} \; |
   while read -r x; do
-    echo "Updating ${x}"
+    echo " Checking ${x}"
     ${SED} -i -re "s,golang:[0-9\.]+,golang:${VERSION},g" "${x}"
+  done
+
+print_green "Updating GO_VERSION env variable in workflows to '${VERSION}'"
+find .github/workflows/ -type f -name "*.yml" -exec grep -lE "GO_VERSION:" {} \; |
+  while read -r x; do
+    echo " Checking ${x}"
+    ${SED} -i -re "s,GO_VERSION: \"[0-9\.]+\",GO_VERSION: \"${VERSION}\",g" "${x}"
+  done
+
+print_green "Updating go-version in workflows to '${VERSION}'"
+find .github/workflows/ -type f -name "*.yml" -exec grep -lE "go-version:" {} \; |
+  while read -r x; do
+    echo " Checking ${x}"
+    ${SED} -i -re "s,go-version: \"[0-9\.]+\",go-version: \"${VERSION}\",g" "${x}"
   done

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -972,7 +972,7 @@ github.com/grafana/gomemcache/memcache
 ## explicit; go 1.13
 github.com/grafana/jsonparser
 # github.com/grafana/loki/pkg/push v0.0.0-20250630054201-94c0ba7b0952 => ./pkg/push
-## explicit; go 1.26.2
+## explicit; go 1.26.4
 github.com/grafana/loki/pkg/push
 # github.com/grafana/otel-profiling-go v0.5.1
 ## explicit; go 1.16


### PR DESCRIPTION
Fixes 3 vulnerabilities detected by `govulncheck` https://github.com/grafana/loki/actions/runs/26873152545/job/79253371764?pr=22165

Updated the script `./tools/go-version-bump.sh` and `Makefile` to simplify updating Go version in multiple files.

Now you can run `./tools/go-version-bump.sh $(make goversion)` after updating `GO_VERSION` in the `Makefile`.

Update:

Now you can simply run `make update-go-version`, which updates all relevant files.