### PR TITLE
feat(dataobj/postings,stats): Add merge builders and row decoders

### DIFF
--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -206,7 +206,7 @@ func (b *Builder) AppendStat(tenantID, objectPath string, sectionIdx int64,
 // requires all observations for a section to be present before encoding
 // (bitmap normalization, bloom filter construction). The builderFull flag
 // provides back-pressure via TargetObjectSize.
-func (b *Builder) ObserveLabelPosting(tenantID string, obs postings.LabelObservation) error {
+func (b *Builder) ObserveLabelPosting(tenantID string, obs postings.LabelObservation) {
 	// Postings are observed per (record × stream label), so this method runs in
 	// a hot loop that fires hundreds of thousands of times per logs section.
 	// Per-call prometheus.NewTimer / Histogram.Observe / sizeEstimate.Set were
@@ -227,7 +227,6 @@ func (b *Builder) ObserveLabelPosting(tenantID string, obs postings.LabelObserva
 	if b.currentSizeEstimate > int(b.cfg.TargetObjectSize) {
 		b.builderFull = true
 	}
-	return nil
 }
 
 // PrepareBloomColumn initializes the bloom filter for a specific column.

--- a/pkg/dataobj/index/indexobj/merge_builder.go
+++ b/pkg/dataobj/index/indexobj/merge_builder.go
@@ -1,0 +1,265 @@
+package indexobj
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/stats"
+	"github.com/grafana/loki/v3/pkg/scratch"
+)
+
+// MergeBuilder accumulates aggregated posting and stat entries from
+// existing sections for merging. Unlike Builder, which aggregates per-observation,
+// MergeBuilder accepts already-aggregated entries and forwards them to
+// merge-mode sub-builders.
+//
+// Methods on MergeBuilder are not goroutine-safe; callers are responsible for
+// synchronization.
+type MergeBuilder struct {
+	cfg     logsobj.BuilderBaseConfig
+	metrics *builderMetrics
+
+	currentSizeEstimate int
+	builderFull         bool
+
+	builder  *dataobj.Builder                  // Inner builder for accumulating sections.
+	stats    map[string]*stats.Builder         // The key is the TenantID.
+	postings map[string]*postings.MergeBuilder // The key is the TenantID.
+
+	unflushedSizeEstimate int
+
+	state builderState
+}
+
+// NewMergeBuilder creates a new [MergeBuilder] for merging pre-aggregated
+// posting and stats entries.
+//
+// NewMergeBuilder returns an error if the provided config is invalid.
+func NewMergeBuilder(cfg logsobj.BuilderBaseConfig, scratchStore scratch.Store) (*MergeBuilder, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	metrics := newBuilderMetrics()
+	metrics.ObserveConfig(cfg)
+
+	return &MergeBuilder{
+		cfg:     cfg,
+		metrics: metrics,
+
+		builder:  dataobj.NewBuilder(scratchStore),
+		stats:    make(map[string]*stats.Builder),
+		postings: make(map[string]*postings.MergeBuilder),
+	}, nil
+}
+
+func (b *MergeBuilder) GetEstimatedSize() int {
+	return b.currentSizeEstimate
+}
+
+func (b *MergeBuilder) IsFull() bool {
+	return b.builderFull
+}
+
+func (b *MergeBuilder) getStatsBuilderForTenant(tenantID string) *stats.Builder {
+	if _, ok := b.stats[tenantID]; !ok {
+		sb := stats.NewBuilder(b.metrics.stats, stats.ColumnarSectionEncoder(int(b.cfg.TargetPageSize), b.cfg.MaxPageRows))
+		sb.SetTenant(tenantID)
+		b.stats[tenantID] = sb
+	}
+	return b.stats[tenantID]
+}
+
+func (b *MergeBuilder) getPostingsMergeBuilderForTenant(tenantID string) *postings.MergeBuilder {
+	if _, ok := b.postings[tenantID]; !ok {
+		pmb := postings.NewMergeBuilder(b.metrics.postings, int(b.cfg.TargetPageSize), b.cfg.MaxPageRows)
+		pmb.SetTenant(tenantID)
+		b.postings[tenantID] = pmb
+	}
+	return b.postings[tenantID]
+}
+
+// AppendStat records a per-sort-key aggregate for a data object section.
+func (b *MergeBuilder) AppendStat(tenantID string, stat stats.Stat) error {
+	b.metrics.appendsTotal.Inc()
+
+	tenantStats := b.getStatsBuilderForTenant(tenantID)
+	preAppendSizeEstimate := tenantStats.EstimatedSize()
+
+	tenantStats.Append(stat)
+
+	postAppendSizeEstimate := tenantStats.EstimatedSize()
+	b.unflushedSizeEstimate += postAppendSizeEstimate - preAppendSizeEstimate
+
+	if postAppendSizeEstimate > int(b.cfg.TargetSectionSize) {
+		if err := b.builder.Append(tenantStats); err != nil {
+			return err
+		}
+	}
+
+	b.currentSizeEstimate = b.estimatedSize()
+	b.state = builderStateDirty
+	if b.currentSizeEstimate > int(b.cfg.TargetObjectSize) {
+		b.builderFull = true
+	}
+
+	return nil
+}
+
+// AppendPostingsLabelEntry appends an aggregated label posting entry
+// directly to the builder.
+func (b *MergeBuilder) AppendPostingsLabelEntry(tenantID string, entry postings.LabelEntry) error {
+	b.metrics.appendsTotal.Inc()
+
+	tenantPostings := b.getPostingsMergeBuilderForTenant(tenantID)
+	preSize := tenantPostings.EstimatedSize()
+
+	if err := tenantPostings.AppendLabelEntry(entry); err != nil {
+		return err
+	}
+
+	postSize := tenantPostings.EstimatedSize()
+	b.unflushedSizeEstimate += postSize - preSize
+	b.currentSizeEstimate += postSize - preSize
+	b.state = builderStateDirty
+	if b.currentSizeEstimate > int(b.cfg.TargetObjectSize) {
+		b.builderFull = true
+	}
+	return nil
+}
+
+// AppendPostingsBloomEntry appends an aggregated bloom posting entry
+// directly to the builder.
+func (b *MergeBuilder) AppendPostingsBloomEntry(tenantID string, entry postings.BloomEntry) error {
+	b.metrics.appendsTotal.Inc()
+
+	tenantPostings := b.getPostingsMergeBuilderForTenant(tenantID)
+	preSize := tenantPostings.EstimatedSize()
+
+	if err := tenantPostings.AppendBloomEntry(entry); err != nil {
+		return err
+	}
+
+	postSize := tenantPostings.EstimatedSize()
+	b.unflushedSizeEstimate += postSize - preSize
+	b.currentSizeEstimate += postSize - preSize
+	b.state = builderStateDirty
+	if b.currentSizeEstimate > int(b.cfg.TargetObjectSize) {
+		b.builderFull = true
+	}
+	return nil
+}
+
+func (b *MergeBuilder) estimatedSize() int {
+	var size int
+	size += b.unflushedSizeEstimate
+	size += b.builder.Bytes()
+	b.metrics.sizeEstimate.Set(float64(size))
+	return size
+}
+
+// Flush flushes all buffered data and returns the built object.
+//
+// [MergeBuilder.Reset] is called after a successful Flush to discard any pending
+// data and allow new data to be appended.
+func (b *MergeBuilder) Flush() (*dataobj.Object, io.Closer, error) {
+	if b.state == builderStateEmpty {
+		return nil, nil, ErrBuilderEmpty
+	}
+
+	b.metrics.flushTotal.Inc()
+	timer := prometheus.NewTimer(b.metrics.buildTime)
+	defer timer.ObserveDuration()
+
+	var flushErrors []error
+
+	for _, tenantStats := range b.stats {
+		if tenantStats.EstimatedSize() > 0 {
+			flushErrors = append(flushErrors, b.builder.Append(tenantStats))
+		}
+	}
+	for _, tenantPostings := range b.postings {
+		if tenantPostings.EstimatedSize() > 0 {
+			flushErrors = append(flushErrors, b.builder.Append(tenantPostings))
+		}
+	}
+
+	if err := errors.Join(flushErrors...); err != nil {
+		b.metrics.flushFailures.Inc()
+		return nil, nil, fmt.Errorf("building object: %w", err)
+	}
+
+	obj, closer, err := b.builder.Flush()
+	if err != nil {
+		b.metrics.flushFailures.Inc()
+		return nil, nil, fmt.Errorf("flushing object: %w", err)
+	}
+
+	b.metrics.builtSize.Observe(float64(obj.Size()))
+
+	err = b.observeObject(context.Background(), obj)
+
+	b.Reset()
+	return obj, closer, err
+}
+
+func (b *MergeBuilder) observeObject(ctx context.Context, obj *dataobj.Object) error {
+	var errs []error
+
+	errs = append(errs, b.metrics.dataobj.Observe(obj))
+
+	for _, sec := range obj.Sections() {
+		switch {
+		case postings.CheckSection(sec):
+			postingSection, err := postings.Open(ctx, sec)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			errs = append(errs, b.metrics.postings.Observe(ctx, postingSection))
+		case stats.CheckSection(sec):
+			statSection, err := stats.Open(ctx, sec)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			errs = append(errs, b.metrics.stats.Observe(ctx, statSection))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// Reset discards pending data and resets the builder to an empty state.
+func (b *MergeBuilder) Reset() {
+	b.builder.Reset()
+	b.stats = make(map[string]*stats.Builder)
+	b.postings = make(map[string]*postings.MergeBuilder)
+
+	b.metrics.sizeEstimate.Set(0)
+	b.currentSizeEstimate = 0
+	b.unflushedSizeEstimate = 0
+	b.builderFull = false
+	b.state = builderStateEmpty
+}
+
+// RegisterMetrics registers metrics about builder to report to reg. All
+// metrics will have a tenant label set to the tenant ID of the Builder.
+//
+// If multiple Builders for the same tenant are running in the same process,
+// reg must contain additional labels to differentiate between them.
+func (b *MergeBuilder) RegisterMetrics(reg prometheus.Registerer) error {
+	return b.metrics.Register(reg)
+}
+
+// UnregisterMetrics unregisters metrics about builder from reg.
+func (b *MergeBuilder) UnregisterMetrics(reg prometheus.Registerer) {
+	b.metrics.Unregister(reg)
+}

--- a/pkg/dataobj/index/indexobj/merge_builder_test.go
+++ b/pkg/dataobj/index/indexobj/merge_builder_test.go
@@ -1,0 +1,467 @@
+package indexobj
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/stats"
+)
+
+// TestMergeBuilder_Empty verifies that an empty merge builder returns ErrBuilderEmpty on flush.
+func TestMergeBuilder_Empty(t *testing.T) {
+	b, err := NewMergeBuilder(logsobj.BuilderBaseConfig{
+		TargetPageSize:          2048,
+		MaxPageRows:             10000,
+		TargetObjectSize:        1 << 22, // 4 MiB
+		TargetSectionSize:       1 << 21, // 2 MiB
+		BufferSize:              2048 * 8,
+		SectionStripeMergeLimit: 2,
+	}, nil)
+	require.NoError(t, err)
+
+	_, _, err = b.Flush()
+	require.Error(t, err)
+	require.Equal(t, ErrBuilderEmpty, err)
+}
+
+// TestMergeBuilder_AppendStat verifies that AppendStat works correctly.
+func TestMergeBuilder_AppendStat(t *testing.T) {
+	b, err := NewMergeBuilder(logsobj.BuilderBaseConfig{
+		TargetPageSize:          2048,
+		MaxPageRows:             10000,
+		TargetObjectSize:        1 << 22,
+		TargetSectionSize:       1 << 21,
+		BufferSize:              2048 * 8,
+		SectionStripeMergeLimit: 2,
+	}, nil)
+	require.NoError(t, err)
+
+	ts := time.Unix(0, 0).UTC()
+
+	// Append a stat
+	stat := stats.Stat{
+		ObjectPath:       "/path/to/obj1",
+		SectionIndex:     0,
+		SortSchema:       "sort_key_1",
+		Labels:           map[string]string{"level": "info"},
+		MinTimestamp:     ts.UnixNano(),
+		MaxTimestamp:     ts.UnixNano(),
+		RowCount:         100,
+		UncompressedSize: 1024,
+	}
+	err = b.AppendStat("tenant-1", stat)
+	require.NoError(t, err)
+
+	require.Greater(t, b.GetEstimatedSize(), 0)
+	require.False(t, b.IsFull())
+
+	// Flush should succeed now
+	obj, closer, err := b.Flush()
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	defer closer.Close()
+
+	// After flush, Reset should have been called
+	require.Equal(t, 0, b.GetEstimatedSize())
+	require.False(t, b.IsFull())
+
+	// Assert the object contains the expected stats section with the appended row.
+	require.Len(t, obj.Sections(), 1)
+	sec := obj.Sections()[0]
+	require.Equal(t, "tenant-1", sec.Tenant)
+	require.True(t, stats.CheckSection(sec))
+
+	ctx := context.Background()
+	statSection, err := stats.Open(ctx, sec)
+	require.NoError(t, err)
+
+	decodedRows := readAllStatsRows(ctx, t, statSection)
+	require.Len(t, decodedRows, 1)
+
+	row := decodedRows[0]
+	require.Equal(t, stat.ObjectPath, row.ObjectPath)
+	require.Equal(t, stat.SectionIndex, row.SectionIndex)
+	require.Equal(t, stat.RowCount, row.RowCount)
+	require.Equal(t, stat.UncompressedSize, row.UncompressedSize)
+}
+
+// TestMergeBuilder_AppendPostingsLabelEntry verifies that AppendPostingsLabelEntry works.
+func TestMergeBuilder_AppendPostingsLabelEntry(t *testing.T) {
+	b, err := NewMergeBuilder(logsobj.BuilderBaseConfig{
+		TargetPageSize:          2048,
+		MaxPageRows:             10000,
+		TargetObjectSize:        1 << 22,
+		TargetSectionSize:       1 << 21,
+		BufferSize:              2048 * 8,
+		SectionStripeMergeLimit: 2,
+	}, nil)
+	require.NoError(t, err)
+
+	ts := int64(1000) // unix nanoseconds
+
+	// Create a valid label entry
+	bitmapBytes := []byte{0x01, 0x00}
+	entry := postings.LabelEntry{
+		ObjectPath:       "/obj1",
+		SectionIndex:     0,
+		ColumnName:       "env",
+		LabelValue:       "prod",
+		StreamIDBitmap:   bitmapBytes,
+		MinTimestamp:     ts,
+		MaxTimestamp:     ts,
+		UncompressedSize: 4096,
+	}
+
+	err = b.AppendPostingsLabelEntry("tenant-1", entry)
+	require.NoError(t, err)
+
+	require.Greater(t, b.GetEstimatedSize(), 0)
+
+	// Flush should succeed
+	obj, closer, err := b.Flush()
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	defer closer.Close()
+
+	// Assert the object contains the expected postings section with the appended row.
+	require.Len(t, obj.Sections(), 1)
+	sec := obj.Sections()[0]
+	require.Equal(t, "tenant-1", sec.Tenant)
+	require.True(t, postings.CheckSection(sec))
+
+	ctx := context.Background()
+	postingsSection, err := postings.Open(ctx, sec)
+	require.NoError(t, err)
+
+	decodedRows := readAllPostingsRows(ctx, t, postingsSection)
+	require.Len(t, decodedRows, 1)
+
+	row := decodedRows[0]
+	require.Equal(t, postings.KindLabel, row.Kind)
+	require.Equal(t, entry.ObjectPath, row.ObjectPath)
+	require.Equal(t, entry.SectionIndex, row.SectionIndex)
+	require.Equal(t, entry.ColumnName, row.ColumnName)
+	require.Equal(t, entry.LabelValue, row.LabelValue)
+	require.Equal(t, entry.StreamIDBitmap, row.StreamIDBitmap)
+}
+
+// TestMergeBuilder_AppendPostingsBloomEntry verifies that AppendPostingsBloomEntry works.
+func TestMergeBuilder_AppendPostingsBloomEntry(t *testing.T) {
+	b, err := NewMergeBuilder(logsobj.BuilderBaseConfig{
+		TargetPageSize:          2048,
+		MaxPageRows:             10000,
+		TargetObjectSize:        1 << 22,
+		TargetSectionSize:       1 << 21,
+		BufferSize:              2048 * 8,
+		SectionStripeMergeLimit: 2,
+	}, nil)
+	require.NoError(t, err)
+
+	timeVal := time.Unix(0, 500).UTC()
+
+	// Create valid bloom bytes using an observation builder
+	tempBuilder := postings.NewBuilder(nil, 0, 0)
+	tempBuilder.PrepareBloomColumn("/obj2", 1, "service_name", 100)
+	err = tempBuilder.ObserveBloomPosting(postings.BloomObservation{
+		ObjectPath:       "/obj2",
+		SectionIndex:     1,
+		ColumnName:       "service_name",
+		Value:            "my-service",
+		StreamID:         0,
+		Timestamp:        timeVal,
+		UncompressedSize: 0,
+	})
+	require.NoError(t, err)
+
+	bloomBytes, err := tempBuilder.BloomBytes("/obj2", 1, "service_name")
+	require.NoError(t, err)
+
+	// Now create the entry
+	ts := int64(500) // unix nanoseconds
+	bitmapBytes := []byte{0x01, 0x00}
+	entry := postings.BloomEntry{
+		ObjectPath:       "/obj2",
+		SectionIndex:     1,
+		ColumnName:       "service_name",
+		BloomFilter:      bloomBytes,
+		StreamIDBitmap:   bitmapBytes,
+		MinTimestamp:     ts,
+		MaxTimestamp:     ts,
+		UncompressedSize: 8192,
+	}
+
+	err = b.AppendPostingsBloomEntry("tenant-1", entry)
+	require.NoError(t, err)
+
+	require.Greater(t, b.GetEstimatedSize(), 0)
+
+	// Flush should succeed
+	obj, closer, err := b.Flush()
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	defer closer.Close()
+
+	// Assert the object contains the expected postings section with the appended row.
+	require.Len(t, obj.Sections(), 1)
+	sec := obj.Sections()[0]
+	require.Equal(t, "tenant-1", sec.Tenant)
+	require.True(t, postings.CheckSection(sec))
+
+	ctx := context.Background()
+	postingsSection, err := postings.Open(ctx, sec)
+	require.NoError(t, err)
+
+	decodedRows := readAllPostingsRows(ctx, t, postingsSection)
+	require.Len(t, decodedRows, 1)
+
+	row := decodedRows[0]
+	require.Equal(t, postings.KindBloom, row.Kind)
+	require.Equal(t, entry.ObjectPath, row.ObjectPath)
+	require.Equal(t, entry.SectionIndex, row.SectionIndex)
+	require.Equal(t, entry.ColumnName, row.ColumnName)
+	require.Equal(t, entry.BloomFilter, row.BloomFilter)
+	require.Equal(t, entry.StreamIDBitmap, row.StreamIDBitmap)
+}
+
+// TestMergeBuilder_MultiTenant verifies that the merge builder handles multiple tenants.
+func TestMergeBuilder_MultiTenant(t *testing.T) {
+	b, err := NewMergeBuilder(logsobj.BuilderBaseConfig{
+		TargetPageSize:          2048,
+		MaxPageRows:             10000,
+		TargetObjectSize:        1 << 22,
+		TargetSectionSize:       1 << 21,
+		BufferSize:              2048 * 8,
+		SectionStripeMergeLimit: 2,
+	}, nil)
+	require.NoError(t, err)
+
+	ts := time.Unix(0, 0).UTC()
+
+	// Append stats for different tenants
+	stat1 := stats.Stat{
+		ObjectPath:       "/path/obj1",
+		SectionIndex:     0,
+		SortSchema:       "sort_key_1",
+		Labels:           map[string]string{},
+		MinTimestamp:     ts.UnixNano(),
+		MaxTimestamp:     ts.UnixNano(),
+		RowCount:         100,
+		UncompressedSize: 1024,
+	}
+	err = b.AppendStat("tenant-1", stat1)
+	require.NoError(t, err)
+
+	stat2 := stats.Stat{
+		ObjectPath:       "/path/obj2",
+		SectionIndex:     0,
+		SortSchema:       "sort_key_1",
+		Labels:           map[string]string{},
+		MinTimestamp:     ts.UnixNano(),
+		MaxTimestamp:     ts.UnixNano(),
+		RowCount:         200,
+		UncompressedSize: 2048,
+	}
+	err = b.AppendStat("tenant-2", stat2)
+	require.NoError(t, err)
+
+	// Flush should include both tenants' data
+	obj, closer, err := b.Flush()
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	defer closer.Close()
+
+	// Assert we have sections for both tenants (one stats section per tenant).
+	require.Len(t, obj.Sections(), 2)
+
+	// Collect sections by tenant.
+	sectionsByTenant := make(map[string]*dataobj.Section)
+	for _, sec := range obj.Sections() {
+		sectionsByTenant[sec.Tenant] = sec
+	}
+	require.Len(t, sectionsByTenant, 2)
+
+	// Verify tenant-1 section contains stat1.
+	sec1 := sectionsByTenant["tenant-1"]
+	require.NotNil(t, sec1)
+	require.True(t, stats.CheckSection(sec1))
+
+	ctx := context.Background()
+	statSec1, err := stats.Open(ctx, sec1)
+	require.NoError(t, err)
+	rows1 := readAllStatsRows(ctx, t, statSec1)
+	require.Len(t, rows1, 1)
+	require.Equal(t, stat1.ObjectPath, rows1[0].ObjectPath)
+	require.Equal(t, stat1.RowCount, rows1[0].RowCount)
+
+	// Verify tenant-2 section contains stat2.
+	sec2 := sectionsByTenant["tenant-2"]
+	require.NotNil(t, sec2)
+	require.True(t, stats.CheckSection(sec2))
+
+	statSec2, err := stats.Open(ctx, sec2)
+	require.NoError(t, err)
+	rows2 := readAllStatsRows(ctx, t, statSec2)
+	require.Len(t, rows2, 1)
+	require.Equal(t, stat2.ObjectPath, rows2[0].ObjectPath)
+	require.Equal(t, stat2.RowCount, rows2[0].RowCount)
+}
+
+// readAllPostingsRows opens a postings section and returns all decoded rows.
+// It drains the reader in batches and decodes each row from the Arrow record batches.
+func readAllPostingsRows(ctx context.Context, t *testing.T, sec *postings.Section) []postings.Row {
+	t.Helper()
+
+	r := postings.NewReader(postings.ReaderOptions{
+		Columns:   sec.Columns(),
+		Allocator: memory.DefaultAllocator,
+	})
+	require.NoError(t, r.Open(ctx))
+	t.Cleanup(func() { _ = r.Close() })
+
+	var (
+		rows    []postings.Row
+		columns postings.ColumnIndex
+	)
+	for {
+		batch, err := r.Read(ctx, 128)
+		if err != nil && !errors.Is(err, io.EOF) {
+			require.NoError(t, err)
+		}
+
+		if batch == nil || batch.NumRows() == 0 {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			continue
+		}
+
+		// Build column index on first batch.
+		if columns == nil {
+			columns = postings.BuildColumnIndex(batch.Schema())
+		}
+
+		// Decode each row in the batch.
+		for rowIdx := 0; rowIdx < int(batch.NumRows()); rowIdx++ {
+			rows = append(rows, postings.DecodeRow(batch, columns, rowIdx))
+		}
+
+		if errors.Is(err, io.EOF) {
+			break
+		}
+	}
+
+	return rows
+}
+
+// readAllStatsRows opens a stats section and returns all decoded rows.
+// It drains the reader in batches and decodes each row from the Arrow record batches.
+func readAllStatsRows(ctx context.Context, t *testing.T, sec *stats.Section) []stats.Stat {
+	t.Helper()
+
+	r := stats.NewReader(stats.ReaderOptions{
+		Columns:   sec.Columns(),
+		Allocator: memory.DefaultAllocator,
+	})
+	require.NoError(t, r.Open(ctx))
+	t.Cleanup(func() { _ = r.Close() })
+
+	var (
+		rows    []stats.Stat
+		columns stats.ColumnIndex
+	)
+	for {
+		batch, err := r.Read(ctx, 128)
+		if err != nil && !errors.Is(err, io.EOF) {
+			require.NoError(t, err)
+		}
+
+		if batch == nil || batch.NumRows() == 0 {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			continue
+		}
+
+		// Build column index on first batch.
+		if columns == nil {
+			columns = stats.BuildColumnIndex(batch.Schema())
+		}
+
+		// Decode each row in the batch.
+		for rowIdx := 0; rowIdx < int(batch.NumRows()); rowIdx++ {
+			rows = append(rows, stats.DecodeRow(batch, columns, rowIdx))
+		}
+
+		if errors.Is(err, io.EOF) {
+			break
+		}
+	}
+
+	return rows
+}
+
+// TestMergeBuilder_Reset verifies that Reset clears all state.
+func TestMergeBuilder_Reset(t *testing.T) {
+	b, err := NewMergeBuilder(logsobj.BuilderBaseConfig{
+		TargetPageSize:          2048,
+		MaxPageRows:             10000,
+		TargetObjectSize:        1 << 22,
+		TargetSectionSize:       1 << 21,
+		BufferSize:              2048 * 8,
+		SectionStripeMergeLimit: 2,
+	}, nil)
+	require.NoError(t, err)
+
+	ts := time.Unix(0, 0).UTC()
+
+	// Add some data
+	stat := stats.Stat{
+		ObjectPath:       "/path/obj1",
+		SectionIndex:     0,
+		SortSchema:       "sort_key_1",
+		Labels:           map[string]string{},
+		MinTimestamp:     ts.UnixNano(),
+		MaxTimestamp:     ts.UnixNano(),
+		RowCount:         100,
+		UncompressedSize: 1024,
+	}
+	err = b.AppendStat("tenant-1", stat)
+	require.NoError(t, err)
+
+	require.Greater(t, b.GetEstimatedSize(), 0)
+
+	// Reset
+	b.Reset()
+
+	require.Equal(t, 0, b.GetEstimatedSize())
+	require.False(t, b.IsFull())
+	require.Equal(t, builderStateEmpty, b.state)
+
+	// After reset, should be able to add data again and flush
+	stat2 := stats.Stat{
+		ObjectPath:       "/path/obj1",
+		SectionIndex:     0,
+		SortSchema:       "sort_key_1",
+		Labels:           map[string]string{},
+		MinTimestamp:     ts.UnixNano(),
+		MaxTimestamp:     ts.UnixNano(),
+		RowCount:         100,
+		UncompressedSize: 1024,
+	}
+	err = b.AppendStat("tenant-1", stat2)
+	require.NoError(t, err)
+
+	obj, closer, err := b.Flush()
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	closer.Close()
+}

--- a/pkg/dataobj/index/label_postings_calculation.go
+++ b/pkg/dataobj/index/label_postings_calculation.go
@@ -36,7 +36,7 @@ func (c *labelPostingsCalculation) ProcessBatch(_ context.Context, calcCtx *logs
 			if batchErr != nil {
 				return
 			}
-			batchErr = calcCtx.builder.ObserveLabelPosting(calcCtx.tenantID, postings.LabelObservation{
+			calcCtx.builder.ObserveLabelPosting(calcCtx.tenantID, postings.LabelObservation{
 				ObjectPath:       calcCtx.objectPath,
 				SectionIndex:     calcCtx.sectionIdx,
 				ColumnName:       lbl.Name,

--- a/pkg/dataobj/sections/postings/bloom_aggregator.go
+++ b/pkg/dataobj/sections/postings/bloom_aggregator.go
@@ -135,19 +135,33 @@ func (a *bloomAggregator) Observe(obs BloomObservation) error {
 	return nil
 }
 
-// Entries returns all aggregated entries. Bitmap normalization (padding to
-// equal length) is NOT done here; the caller (columnarEncode) handles it
-// across both label and bloom entries.
-func (a *bloomAggregator) Entries() []*bloomPostingEntry {
+// Entries returns all aggregated entries converted to public type. Bitmap
+// normalization (padding to equal length) is NOT done here. Returns an error if
+// any bloom filter fails to marshal.
+func (a *bloomAggregator) Entries() ([]BloomEntry, error) {
 	if len(a.entries) == 0 {
-		return nil
+		return nil, nil
 	}
 
-	result := make([]*bloomPostingEntry, 0, len(a.entries))
+	result := make([]BloomEntry, 0, len(a.entries))
 	for _, entry := range a.entries {
-		result = append(result, entry)
+		bloomBytes, err := entry.BloomBytes()
+		if err != nil {
+			return nil, fmt.Errorf("marshaling bloom filter for %q section %d column %q: %w",
+				entry.ObjectPath, entry.SectionIndex, entry.ColumnName, err)
+		}
+		result = append(result, BloomEntry{
+			ObjectPath:       entry.ObjectPath,
+			SectionIndex:     entry.SectionIndex,
+			ColumnName:       entry.ColumnName,
+			BloomFilter:      bloomBytes,
+			StreamIDBitmap:   entry.BitmapBytes(),
+			MinTimestamp:     entry.MinTimestamp,
+			MaxTimestamp:     entry.MaxTimestamp,
+			UncompressedSize: entry.UncompressedSize,
+		})
 	}
-	return result
+	return result, nil
 }
 
 // BloomBytes marshals and returns the bloom filter bytes for a specific column.

--- a/pkg/dataobj/sections/postings/builder.go
+++ b/pkg/dataobj/sections/postings/builder.go
@@ -2,7 +2,6 @@ package postings
 
 import (
 	"fmt"
-	"sort"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -53,9 +52,8 @@ func (b *Builder) PrepareBloomColumn(objectPath string, sectionIndex int64, colu
 }
 
 // ObserveLabelPosting records a label posting observation. Multiple
-// observations for the same
-// (ObjectPath, SectionIndex, ColumnName, LabelValue) key are aggregated into a
-// single posting.
+// observations for the same (ObjectPath, SectionIndex, ColumnName, LabelValue)
+// key are aggregated into a single posting.
 func (b *Builder) ObserveLabelPosting(obs LabelObservation) {
 	b.labels.Observe(obs)
 }
@@ -90,7 +88,10 @@ func (b *Builder) Reset() {
 // After a successful flush, the builder is reset.
 func (b *Builder) Flush(w dataobj.SectionWriter) (n int64, err error) {
 	labelEntries := b.labels.Entries()
-	bloomEntries := b.blooms.Entries()
+	bloomEntries, err := b.blooms.Entries()
+	if err != nil {
+		return 0, fmt.Errorf("converting bloom entries: %w", err)
+	}
 
 	if len(labelEntries) == 0 && len(bloomEntries) == 0 {
 		return 0, nil
@@ -101,32 +102,8 @@ func (b *Builder) Flush(w dataobj.SectionWriter) (n int64, err error) {
 		defer timer.ObserveDuration()
 	}
 
-	// Sort label entries by [objectPath, sectionIndex, columnName, labelValue].
-	sort.SliceStable(labelEntries, func(i, j int) bool {
-		a, bEntry := labelEntries[i], labelEntries[j]
-		if a.ObjectPath != bEntry.ObjectPath {
-			return a.ObjectPath < bEntry.ObjectPath
-		}
-		if a.SectionIndex != bEntry.SectionIndex {
-			return a.SectionIndex < bEntry.SectionIndex
-		}
-		if a.ColumnName != bEntry.ColumnName {
-			return a.ColumnName < bEntry.ColumnName
-		}
-		return a.LabelValue < bEntry.LabelValue
-	})
-
-	// Sort bloom entries by [objectPath, sectionIndex, columnName].
-	sort.SliceStable(bloomEntries, func(i, j int) bool {
-		a, bEntry := bloomEntries[i], bloomEntries[j]
-		if a.ObjectPath != bEntry.ObjectPath {
-			return a.ObjectPath < bEntry.ObjectPath
-		}
-		if a.SectionIndex != bEntry.SectionIndex {
-			return a.SectionIndex < bEntry.SectionIndex
-		}
-		return a.ColumnName < bEntry.ColumnName
-	})
+	sortLabelEntries(labelEntries)
+	sortBloomEntries(bloomEntries)
 
 	var enc columnar.Encoder
 	defer enc.Reset()

--- a/pkg/dataobj/sections/postings/builder_test.go
+++ b/pkg/dataobj/sections/postings/builder_test.go
@@ -648,6 +648,28 @@ func TestBuilder_BloomBytes(t *testing.T) {
 	require.Error(t, err)
 }
 
+// mustBuildBloomBytes constructs a bloom filter section, observes one value,
+// and returns the marshaled filter bytes. Used by tests that need realistic
+// bloom-filter bytes to feed into AppendBloomEntry.
+func mustBuildBloomBytes(t *testing.T, objectPath string, sectionIndex int64, columnName, value string, ts time.Time) []byte {
+	t.Helper()
+	tempBuilder := NewBuilder(nil, 0, 0)
+	tempBuilder.PrepareBloomColumn(objectPath, sectionIndex, columnName, 100)
+	err := tempBuilder.ObserveBloomPosting(BloomObservation{
+		ObjectPath:       objectPath,
+		SectionIndex:     sectionIndex,
+		ColumnName:       columnName,
+		Value:            value,
+		StreamID:         0,
+		Timestamp:        ts,
+		UncompressedSize: 0,
+	})
+	require.NoError(t, err)
+	bytes, err := tempBuilder.BloomBytes(objectPath, sectionIndex, columnName)
+	require.NoError(t, err)
+	return bytes
+}
+
 // flushToObject flushes the builder into a dataobj.Object using dataobj.Builder.
 func flushToObject(t *testing.T, b *Builder) (*dataobj.Object, io.Closer) {
 	t.Helper()

--- a/pkg/dataobj/sections/postings/encode_columnar.go
+++ b/pkg/dataobj/sections/postings/encode_columnar.go
@@ -15,7 +15,7 @@ import (
 //
 // pageSizeHint and pageMaxRowCount control the page splitting behaviour of the
 // underlying column builders.
-func columnarEncode(bloomEntries []*bloomPostingEntry, labelEntries []*labelPostingEntry, enc *columnar.Encoder, pageSizeHint, pageMaxRowCount int) error {
+func columnarEncode(bloomEntries []BloomEntry, labelEntries []LabelEntry, enc *columnar.Encoder, pageSizeHint, pageMaxRowCount int) error {
 	// Build column builders for all 10 columns.
 
 	// kind is a 2-value flag (0=bloom, 1=label). DELTA is the only encoding
@@ -93,13 +93,13 @@ func columnarEncode(bloomEntries []*bloomPostingEntry, labelEntries []*labelPost
 	// Compute the max bitmap length across both bloom and label entries for normalization.
 	maxBitmapLen := 0
 	for _, e := range bloomEntries {
-		if b := e.BitmapBytes(); len(b) > maxBitmapLen {
-			maxBitmapLen = len(b)
+		if len(e.StreamIDBitmap) > maxBitmapLen {
+			maxBitmapLen = len(e.StreamIDBitmap)
 		}
 	}
 	for _, e := range labelEntries {
-		if b := e.BitmapBytes(); len(b) > maxBitmapLen {
-			maxBitmapLen = len(b)
+		if len(e.StreamIDBitmap) > maxBitmapLen {
+			maxBitmapLen = len(e.StreamIDBitmap)
 		}
 	}
 
@@ -117,18 +117,13 @@ func columnarEncode(bloomEntries []*bloomPostingEntry, labelEntries []*labelPost
 	rowIdx := 0
 
 	for _, e := range bloomEntries {
-		bloomBytes, err := e.BloomBytes()
-		if err != nil {
-			return fmt.Errorf("marshaling bloom filter for column %q: %w", e.ColumnName, err)
-		}
-
 		_ = kindBuilder.Append(rowIdx, dataset.Int64Value(int64(KindBloom)))
 		_ = objectPathBuilder.Append(rowIdx, dataset.BinaryValue([]byte(e.ObjectPath)))
 		_ = sectionIndexBuilder.Append(rowIdx, dataset.Int64Value(e.SectionIndex))
 		_ = columnNameBuilder.Append(rowIdx, dataset.BinaryValue([]byte(e.ColumnName)))
 		_ = labelValueBuilder.Append(rowIdx, dataset.Value{}) // null for bloom
-		_ = bloomFilterBuilder.Append(rowIdx, dataset.BinaryValue(bloomBytes))
-		_ = streamIDBitmapBuilder.Append(rowIdx, dataset.BinaryValue(normalizeBitmap(e.BitmapBytes())))
+		_ = bloomFilterBuilder.Append(rowIdx, dataset.BinaryValue(e.BloomFilter))
+		_ = streamIDBitmapBuilder.Append(rowIdx, dataset.BinaryValue(normalizeBitmap(e.StreamIDBitmap)))
 		_ = uncompressedSizeBuilder.Append(rowIdx, dataset.Int64Value(e.UncompressedSize))
 		_ = minTimestampBuilder.Append(rowIdx, dataset.Int64Value(e.MinTimestamp))
 		_ = maxTimestampBuilder.Append(rowIdx, dataset.Int64Value(e.MaxTimestamp))
@@ -142,7 +137,7 @@ func columnarEncode(bloomEntries []*bloomPostingEntry, labelEntries []*labelPost
 		_ = columnNameBuilder.Append(rowIdx, dataset.BinaryValue([]byte(e.ColumnName)))
 		_ = labelValueBuilder.Append(rowIdx, dataset.BinaryValue([]byte(e.LabelValue)))
 		_ = bloomFilterBuilder.Append(rowIdx, dataset.Value{}) // null for label
-		_ = streamIDBitmapBuilder.Append(rowIdx, dataset.BinaryValue(normalizeBitmap(e.BitmapBytes())))
+		_ = streamIDBitmapBuilder.Append(rowIdx, dataset.BinaryValue(normalizeBitmap(e.StreamIDBitmap)))
 		_ = uncompressedSizeBuilder.Append(rowIdx, dataset.Int64Value(e.UncompressedSize))
 		_ = minTimestampBuilder.Append(rowIdx, dataset.Int64Value(e.MinTimestamp))
 		_ = maxTimestampBuilder.Append(rowIdx, dataset.Int64Value(e.MaxTimestamp))

--- a/pkg/dataobj/sections/postings/label_aggregator.go
+++ b/pkg/dataobj/sections/postings/label_aggregator.go
@@ -97,17 +97,25 @@ func (a *labelAggregator) Observe(obs LabelObservation) {
 	entry.UncompressedSize += obs.UncompressedSize
 }
 
-// Entries returns all aggregated entries. Bitmap normalization (padding to
-// equal length) is NOT done here; the caller (columnarEncode) handles it
-// across both label and bloom entries.
-func (a *labelAggregator) Entries() []*labelPostingEntry {
+// Entries returns all aggregated entries converted to public type. Bitmap
+// normalization (padding to equal length) is NOT done here.
+func (a *labelAggregator) Entries() []LabelEntry {
 	if len(a.entries) == 0 {
 		return nil
 	}
 
-	result := make([]*labelPostingEntry, 0, len(a.entries))
+	result := make([]LabelEntry, 0, len(a.entries))
 	for _, entry := range a.entries {
-		result = append(result, entry)
+		result = append(result, LabelEntry{
+			ObjectPath:       entry.ObjectPath,
+			SectionIndex:     entry.SectionIndex,
+			ColumnName:       entry.ColumnName,
+			LabelValue:       entry.LabelValue,
+			StreamIDBitmap:   entry.BitmapBytes(),
+			MinTimestamp:     entry.MinTimestamp,
+			MaxTimestamp:     entry.MaxTimestamp,
+			UncompressedSize: entry.UncompressedSize,
+		})
 	}
 	return result
 }

--- a/pkg/dataobj/sections/postings/merge_builder.go
+++ b/pkg/dataobj/sections/postings/merge_builder.go
@@ -17,8 +17,8 @@ import (
 type MergeBuilder struct {
 	metrics *Metrics
 	tenant  string
-	labels  map[labelPostingKey]*LabelEntry
-	blooms  map[bloomPostingKey]*BloomEntry
+	labels  map[labelPostingKey]LabelEntry
+	blooms  map[bloomPostingKey]BloomEntry
 
 	pageSizeHint    int
 	pageMaxRowCount int
@@ -34,8 +34,8 @@ type MergeBuilder struct {
 func NewMergeBuilder(metrics *Metrics, pageSizeHint, pageMaxRowCount int) *MergeBuilder {
 	return &MergeBuilder{
 		metrics:         metrics,
-		labels:          make(map[labelPostingKey]*LabelEntry),
-		blooms:          make(map[bloomPostingKey]*BloomEntry),
+		labels:          make(map[labelPostingKey]LabelEntry),
+		blooms:          make(map[bloomPostingKey]BloomEntry),
 		pageSizeHint:    pageSizeHint,
 		pageMaxRowCount: pageMaxRowCount,
 	}
@@ -65,7 +65,7 @@ func (b *MergeBuilder) AppendLabelEntry(entry LabelEntry) error {
 		return fmt.Errorf("label posting entry with key (%q, %d, %q, %q) already exists", entry.ObjectPath, entry.SectionIndex, entry.ColumnName, entry.LabelValue)
 	}
 
-	b.labels[key] = &entry
+	b.labels[key] = entry
 
 	// Track size: 5 int64 fields + string sizes + bitmap bytes.
 	b.estimatedSize += 5*8 + len(entry.ObjectPath) + len(entry.ColumnName) + len(entry.LabelValue) + len(entry.StreamIDBitmap)
@@ -87,7 +87,7 @@ func (b *MergeBuilder) AppendBloomEntry(entry BloomEntry) error {
 		return fmt.Errorf("bloom posting entry with key (%q, %d, %q) already exists", entry.ObjectPath, entry.SectionIndex, entry.ColumnName)
 	}
 
-	b.blooms[key] = &entry
+	b.blooms[key] = entry
 
 	// Track size: 5 int64 fields + string sizes + bloom bytes + bitmap bytes.
 	b.estimatedSize += 5*8 + len(entry.ObjectPath) + len(entry.ColumnName) + len(entry.BloomFilter) + len(entry.StreamIDBitmap)
@@ -103,8 +103,8 @@ func (b *MergeBuilder) EstimatedSize() int {
 
 // Reset clears all accumulated data and resets the builder to a fresh state.
 func (b *MergeBuilder) Reset() {
-	b.labels = make(map[labelPostingKey]*LabelEntry)
-	b.blooms = make(map[bloomPostingKey]*BloomEntry)
+	b.labels = make(map[labelPostingKey]LabelEntry)
+	b.blooms = make(map[bloomPostingKey]BloomEntry)
 	b.estimatedSize = 0
 }
 
@@ -116,12 +116,12 @@ func (b *MergeBuilder) Flush(w dataobj.SectionWriter) (n int64, err error) {
 	// Convert maps to slices.
 	labelEntries := make([]LabelEntry, 0, len(b.labels))
 	for _, entry := range b.labels {
-		labelEntries = append(labelEntries, *entry)
+		labelEntries = append(labelEntries, entry)
 	}
 
 	bloomEntries := make([]BloomEntry, 0, len(b.blooms))
 	for _, entry := range b.blooms {
-		bloomEntries = append(bloomEntries, *entry)
+		bloomEntries = append(bloomEntries, entry)
 	}
 
 	if len(labelEntries) == 0 && len(bloomEntries) == 0 {

--- a/pkg/dataobj/sections/postings/merge_builder.go
+++ b/pkg/dataobj/sections/postings/merge_builder.go
@@ -1,0 +1,152 @@
+package postings
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/internal/columnar"
+)
+
+// MergeBuilder accumulates posting entries from pre-aggregated rows (e.g., from
+// existing postings sections) and merges them. Unlike Builder, which aggregates
+// per-observation, MergeBuilder accepts already-aggregated entries.
+// Call [MergeBuilder.Flush] to encode all accumulated data and write a postings
+// section to the provided [dataobj.SectionWriter].
+type MergeBuilder struct {
+	metrics *Metrics
+	tenant  string
+	labels  map[labelPostingKey]*LabelEntry
+	blooms  map[bloomPostingKey]*BloomEntry
+
+	pageSizeHint    int
+	pageMaxRowCount int
+	estimatedSize   int
+}
+
+// NewMergeBuilder creates a new [MergeBuilder] for accumulating pre-aggregated
+// posting entries.
+//
+// pageSizeHint and pageMaxRowCount control page splitting of the underlying
+// column builders (0 means use defaults).
+// metrics may be nil to disable instrumentation.
+func NewMergeBuilder(metrics *Metrics, pageSizeHint, pageMaxRowCount int) *MergeBuilder {
+	return &MergeBuilder{
+		metrics:         metrics,
+		labels:          make(map[labelPostingKey]*LabelEntry),
+		blooms:          make(map[bloomPostingKey]*BloomEntry),
+		pageSizeHint:    pageSizeHint,
+		pageMaxRowCount: pageMaxRowCount,
+	}
+}
+
+// SetTenant sets the tenant for this builder.
+func (b *MergeBuilder) SetTenant(tenant string) { b.tenant = tenant }
+
+// Tenant returns the tenant for this builder.
+func (b *MergeBuilder) Tenant() string { return b.tenant }
+
+// Type returns the [dataobj.SectionType] of the postings builder.
+func (b *MergeBuilder) Type() dataobj.SectionType { return sectionType }
+
+// AppendLabelEntry appends a label posting entry directly to the builder.
+// Returns an error if an entry with the same (ObjectPath, SectionIndex,
+// ColumnName, LabelValue) key already exists.
+func (b *MergeBuilder) AppendLabelEntry(entry LabelEntry) error {
+	key := labelPostingKey{
+		objectPath:   entry.ObjectPath,
+		sectionIndex: entry.SectionIndex,
+		columnName:   entry.ColumnName,
+		labelValue:   entry.LabelValue,
+	}
+
+	if _, ok := b.labels[key]; ok {
+		return fmt.Errorf("label posting entry with key (%q, %d, %q, %q) already exists", entry.ObjectPath, entry.SectionIndex, entry.ColumnName, entry.LabelValue)
+	}
+
+	b.labels[key] = &entry
+
+	// Track size: 5 int64 fields + string sizes + bitmap bytes.
+	b.estimatedSize += 5*8 + len(entry.ObjectPath) + len(entry.ColumnName) + len(entry.LabelValue) + len(entry.StreamIDBitmap)
+
+	return nil
+}
+
+// AppendBloomEntry appends a bloom posting entry directly to the builder.
+// Returns an error if an entry with the same (ObjectPath, SectionIndex,
+// ColumnName) key already exists.
+func (b *MergeBuilder) AppendBloomEntry(entry BloomEntry) error {
+	key := bloomPostingKey{
+		objectPath:   entry.ObjectPath,
+		sectionIndex: entry.SectionIndex,
+		columnName:   entry.ColumnName,
+	}
+
+	if _, ok := b.blooms[key]; ok {
+		return fmt.Errorf("bloom posting entry with key (%q, %d, %q) already exists", entry.ObjectPath, entry.SectionIndex, entry.ColumnName)
+	}
+
+	b.blooms[key] = &entry
+
+	// Track size: 5 int64 fields + string sizes + bloom bytes + bitmap bytes.
+	b.estimatedSize += 5*8 + len(entry.ObjectPath) + len(entry.ColumnName) + len(entry.BloomFilter) + len(entry.StreamIDBitmap)
+
+	return nil
+}
+
+// EstimatedSize returns an estimate of the encoded size of the accumulated
+// data in bytes.
+func (b *MergeBuilder) EstimatedSize() int {
+	return b.estimatedSize
+}
+
+// Reset clears all accumulated data and resets the builder to a fresh state.
+func (b *MergeBuilder) Reset() {
+	b.labels = make(map[labelPostingKey]*LabelEntry)
+	b.blooms = make(map[bloomPostingKey]*BloomEntry)
+	b.estimatedSize = 0
+}
+
+// Flush encodes all accumulated entries into the provided
+// [dataobj.SectionWriter] and returns the number of bytes written.
+//
+// After a successful flush, the builder is reset.
+func (b *MergeBuilder) Flush(w dataobj.SectionWriter) (n int64, err error) {
+	// Convert maps to slices.
+	labelEntries := make([]LabelEntry, 0, len(b.labels))
+	for _, entry := range b.labels {
+		labelEntries = append(labelEntries, *entry)
+	}
+
+	bloomEntries := make([]BloomEntry, 0, len(b.blooms))
+	for _, entry := range b.blooms {
+		bloomEntries = append(bloomEntries, *entry)
+	}
+
+	if len(labelEntries) == 0 && len(bloomEntries) == 0 {
+		return 0, nil
+	}
+
+	if b.metrics != nil {
+		timer := prometheus.NewTimer(b.metrics.encodeSeconds)
+		defer timer.ObserveDuration()
+	}
+
+	sortLabelEntries(labelEntries)
+	sortBloomEntries(bloomEntries)
+
+	var enc columnar.Encoder
+	defer enc.Reset()
+
+	if err := columnarEncode(bloomEntries, labelEntries, &enc, b.pageSizeHint, b.pageMaxRowCount); err != nil {
+		return 0, fmt.Errorf("encoding postings: %w", err)
+	}
+
+	enc.SetTenant(b.tenant)
+	n, err = enc.Flush(w)
+	if err == nil {
+		b.Reset()
+	}
+	return n, err
+}

--- a/pkg/dataobj/sections/postings/merge_builder_test.go
+++ b/pkg/dataobj/sections/postings/merge_builder_test.go
@@ -1,0 +1,233 @@
+package postings
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/util/arrowtest"
+)
+
+// TestMergeBuilder_AppendLabelEntry_RoundTrip verifies that appended label
+// entries round-trip correctly without aggregation.
+func TestMergeBuilder_AppendLabelEntry_RoundTrip(t *testing.T) {
+	b := NewMergeBuilder(nil, 0, 0)
+	b.SetTenant("test-tenant")
+
+	ts := int64(1000) // unix nanoseconds
+	timeVal := time.Unix(0, ts).UTC()
+
+	// Create a bitmap with bits 3, 7, 15 set
+	bitmapBytes := make([]byte, 2)
+	bitmapBytes[0] = 0b10001000 // bits 3, 7
+	bitmapBytes[1] = 0b10000000 // bit 15
+
+	entry := LabelEntry{
+		ObjectPath:       "/tenant/abc/obj1",
+		SectionIndex:     0,
+		ColumnName:       "env",
+		LabelValue:       "value1",
+		StreamIDBitmap:   bitmapBytes,
+		MinTimestamp:     ts,
+		MaxTimestamp:     ts,
+		UncompressedSize: 4096,
+	}
+
+	err := b.AppendLabelEntry(entry)
+	require.NoError(t, err)
+
+	sections := flushMergeBuilderAndOpenSections(t, b)
+	require.Len(t, sections, 1)
+
+	rows, tbl := readAllRows(t, sections[0])
+	require.Len(t, rows, 1)
+
+	bitmaps := extractBinaryColumn(t, tbl, "stream_id_bitmap.binary")
+
+	expected := arrowtest.Rows{
+		{
+			"kind.int64":              int64(KindLabel),
+			"object_path.utf8":        "/tenant/abc/obj1",
+			"section_index.int64":     int64(0),
+			"column_name.utf8":        "env",
+			"label_value.utf8":        "value1",
+			"bloom_filter.binary":     nil,
+			"uncompressed_size.int64": int64(4096),
+			"min_timestamp.timestamp": timeVal,
+			"max_timestamp.timestamp": timeVal,
+		},
+	}
+
+	strictRows := stripOpaqueBinaryColumns(rows, "stream_id_bitmap.binary")
+	strictExpected := stripOpaqueBinaryColumns(expected, "stream_id_bitmap.binary")
+	require.Equal(t, strictExpected, strictRows)
+
+	// Verify the bitmap bytes match exactly (modulo padding)
+	// Since we set bits 3, 7, 15, we need at least 2 bytes
+	require.NotEmpty(t, bitmaps[0])
+	require.True(t, checkBit(bitmaps[0], 3), "bit 3 should be set")
+	require.True(t, checkBit(bitmaps[0], 7), "bit 7 should be set")
+	require.True(t, checkBit(bitmaps[0], 15), "bit 15 should be set")
+	require.False(t, checkBit(bitmaps[0], 0), "bit 0 should not be set")
+}
+
+// TestMergeBuilder_AppendBloomEntry_RoundTrip verifies that appended bloom
+// entries round-trip correctly without aggregation.
+func TestMergeBuilder_AppendBloomEntry_RoundTrip(t *testing.T) {
+	b := NewMergeBuilder(nil, 0, 0)
+	b.SetTenant("test-tenant")
+
+	ts := int64(500) // unix nanoseconds
+	timeVal := time.Unix(0, ts).UTC()
+
+	bloomBytes := mustBuildBloomBytes(t, "/tenant/abc/obj2", 1, "service_name", "my-service", timeVal)
+
+	// Create bitmap with bits 0, 2, 8 set
+	bitmapBytes := make([]byte, 2)
+	bitmapBytes[0] = 0b00000101 // bits 0, 2
+	bitmapBytes[1] = 0b00000001 // bit 8
+
+	entry := BloomEntry{
+		ObjectPath:       "/tenant/abc/obj2",
+		SectionIndex:     1,
+		ColumnName:       "service_name",
+		BloomFilter:      bloomBytes,
+		StreamIDBitmap:   bitmapBytes,
+		MinTimestamp:     ts,
+		MaxTimestamp:     ts,
+		UncompressedSize: 8192,
+	}
+
+	err := b.AppendBloomEntry(entry)
+	require.NoError(t, err)
+
+	sections := flushMergeBuilderAndOpenSections(t, b)
+	require.Len(t, sections, 1)
+
+	rows, tbl := readAllRows(t, sections[0])
+	require.Len(t, rows, 1)
+
+	bitmaps := extractBinaryColumn(t, tbl, "stream_id_bitmap.binary")
+	bloomFilters := extractBinaryColumn(t, tbl, "bloom_filter.binary")
+
+	expected := arrowtest.Rows{
+		{
+			"kind.int64":              int64(KindBloom),
+			"object_path.utf8":        "/tenant/abc/obj2",
+			"section_index.int64":     int64(1),
+			"column_name.utf8":        "service_name",
+			"label_value.utf8":        nil,
+			"bloom_filter.binary":     bloomFilters[0],
+			"uncompressed_size.int64": int64(8192),
+			"min_timestamp.timestamp": timeVal,
+			"max_timestamp.timestamp": timeVal,
+		},
+	}
+
+	strictRows := stripOpaqueBinaryColumns(rows, "stream_id_bitmap.binary", "bloom_filter.binary")
+	strictExpected := stripOpaqueBinaryColumns(expected, "stream_id_bitmap.binary", "bloom_filter.binary")
+	require.Equal(t, strictExpected, strictRows)
+
+	// Verify bloom filter bytes round-trip exactly
+	require.Equal(t, bloomBytes, bloomFilters[0], "bloom filter bytes must round-trip")
+
+	// Verify stream IDs 0, 2, 8 are set
+	require.True(t, checkBit(bitmaps[0], 0), "bit 0 should be set")
+	require.True(t, checkBit(bitmaps[0], 2), "bit 2 should be set")
+	require.True(t, checkBit(bitmaps[0], 8), "bit 8 should be set")
+	require.False(t, checkBit(bitmaps[0], 1), "bit 1 should not be set")
+}
+
+// TestMergeBuilder_AppendLabelEntry_DuplicateKey_Errors verifies that
+// appending two label entries with the same key returns an error on the
+// second append.
+func TestMergeBuilder_AppendLabelEntry_DuplicateKey_Errors(t *testing.T) {
+	b := NewMergeBuilder(nil, 0, 0)
+	b.SetTenant("test-tenant")
+
+	ts := int64(0) // unix nanoseconds
+
+	bitmapBytes := []byte{0x01}
+	entry := LabelEntry{
+		ObjectPath:       "/obj",
+		SectionIndex:     0,
+		ColumnName:       "env",
+		LabelValue:       "prod",
+		StreamIDBitmap:   bitmapBytes,
+		MinTimestamp:     ts,
+		MaxTimestamp:     ts,
+		UncompressedSize: 100,
+	}
+
+	// First append should succeed
+	err := b.AppendLabelEntry(entry)
+	require.NoError(t, err)
+
+	// Second append with same key should fail
+	err = b.AppendLabelEntry(entry)
+	require.Error(t, err, "appending duplicate key should return an error")
+	require.Contains(t, err.Error(), "already exists")
+}
+
+// TestMergeBuilder_AppendBloomEntry_DuplicateKey_Errors verifies that
+// appending two bloom entries with the same key returns an error on the
+// second append.
+func TestMergeBuilder_AppendBloomEntry_DuplicateKey_Errors(t *testing.T) {
+	timeVal := time.Unix(0, 0).UTC()
+
+	// Generate valid bloom bytes using the helper
+	bloomBytes := mustBuildBloomBytes(t, "/obj", 0, "col", "val", timeVal)
+
+	// Now use a fresh builder for the duplicate append test
+	b := NewMergeBuilder(nil, 0, 0)
+	b.SetTenant("test-tenant")
+
+	ts := int64(0) // unix nanoseconds
+	bitmapBytes := []byte{0x01}
+	entry := BloomEntry{
+		ObjectPath:       "/obj",
+		SectionIndex:     0,
+		ColumnName:       "col",
+		BloomFilter:      bloomBytes,
+		StreamIDBitmap:   bitmapBytes,
+		MinTimestamp:     ts,
+		MaxTimestamp:     ts,
+		UncompressedSize: 200,
+	}
+
+	// First append should succeed
+	err := b.AppendBloomEntry(entry)
+	require.NoError(t, err)
+
+	// Second append with same key should fail
+	err = b.AppendBloomEntry(entry)
+	require.Error(t, err, "appending duplicate key should return an error")
+	require.Contains(t, err.Error(), "already exists")
+}
+
+// flushMergeBuilderAndOpenSections flushes the merge builder and opens all
+// resulting postings sections.
+func flushMergeBuilderAndOpenSections(t *testing.T, b *MergeBuilder) []*Section {
+	t.Helper()
+	// Use a dataobj.Builder to flush the merge builder
+	dob := dataobj.NewBuilder(nil)
+	err := dob.Append(b)
+	require.NoError(t, err)
+	obj, closer, err := dob.Flush()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = closer.Close() })
+
+	var sections []*Section
+	for _, s := range obj.Sections() {
+		if !CheckSection(s) {
+			continue
+		}
+		sec, err := Open(context.Background(), s)
+		require.NoError(t, err)
+		sections = append(sections, sec)
+	}
+	return sections
+}

--- a/pkg/dataobj/sections/postings/postings.go
+++ b/pkg/dataobj/sections/postings/postings.go
@@ -104,6 +104,50 @@ const (
 	KindLabel PostingKind = 1
 )
 
+// LabelEntry represents an aggregated label posting entry that can be
+// appended directly to a Builder without going through the per-observation
+// aggregation path.
+type LabelEntry struct {
+	// ObjectPath is the path of the data object that originated this posting.
+	ObjectPath string
+	// SectionIndex is the index of the logs section within ObjectPath.
+	SectionIndex int64
+	// ColumnName is the name of the labels column being indexed.
+	ColumnName string
+	// LabelValue is the value of the label.
+	LabelValue string
+	// StreamIDBitmap is the raw bytes of the stream ID bitmap (LSB-encoded).
+	StreamIDBitmap []byte
+	// MinTimestamp is the minimum timestamp of the records in this posting (unix nanoseconds since epoch).
+	MinTimestamp int64
+	// MaxTimestamp is the maximum timestamp of the records in this posting (unix nanoseconds since epoch).
+	MaxTimestamp int64
+	// UncompressedSize is the total uncompressed size in bytes.
+	UncompressedSize int64
+}
+
+// BloomEntry represents an aggregated bloom posting entry that can be
+// appended directly to a Builder without going through the per-observation
+// aggregation path.
+type BloomEntry struct {
+	// ObjectPath is the path of the data object that originated this posting.
+	ObjectPath string
+	// SectionIndex is the index of the logs section within ObjectPath.
+	SectionIndex int64
+	// ColumnName is the name of the metadata column being indexed.
+	ColumnName string
+	// BloomFilter is the marshaled bloom filter bytes.
+	BloomFilter []byte
+	// StreamIDBitmap is the raw bytes of the stream ID bitmap (LSB-encoded).
+	StreamIDBitmap []byte
+	// MinTimestamp is the minimum timestamp of the records in this posting (unix nanoseconds since epoch).
+	MinTimestamp int64
+	// MaxTimestamp is the maximum timestamp of the records in this posting (unix nanoseconds since epoch).
+	MaxTimestamp int64
+	// UncompressedSize is the total uncompressed size in bytes.
+	UncompressedSize int64
+}
+
 // Section represents an opened postings section.
 type Section struct {
 	inner   *columnar.Section

--- a/pkg/dataobj/sections/postings/row.go
+++ b/pkg/dataobj/sections/postings/row.go
@@ -1,0 +1,127 @@
+package postings
+
+import (
+	"bytes"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+)
+
+// Row is the decoded per-row representation of a postings section,
+// covering both Label and Bloom kinds.
+type Row struct {
+	Kind             PostingKind // KindLabel or KindBloom
+	ObjectPath       string
+	SectionIndex     int64
+	ColumnName       string
+	LabelValue       string // empty for KindBloom rows
+	StreamIDBitmap   []byte
+	BloomFilter      []byte // nil for KindLabel rows
+	UncompressedSize int64
+	MinTimestamp     int64 // unix nanos
+	MaxTimestamp     int64 // unix nanos
+}
+
+// LabelEntry converts the Row to a [LabelEntry]. The caller should only call
+// this when Row.Kind == KindLabel.
+func (r Row) LabelEntry() LabelEntry {
+	return LabelEntry{
+		ObjectPath:       r.ObjectPath,
+		SectionIndex:     r.SectionIndex,
+		ColumnName:       r.ColumnName,
+		LabelValue:       r.LabelValue,
+		StreamIDBitmap:   r.StreamIDBitmap,
+		MinTimestamp:     r.MinTimestamp,
+		MaxTimestamp:     r.MaxTimestamp,
+		UncompressedSize: r.UncompressedSize,
+	}
+}
+
+// BloomEntry converts the Row to a [BloomEntry]. The caller should only call
+// this when Row.Kind == KindBloom.
+func (r Row) BloomEntry() BloomEntry {
+	return BloomEntry{
+		ObjectPath:       r.ObjectPath,
+		SectionIndex:     r.SectionIndex,
+		ColumnName:       r.ColumnName,
+		BloomFilter:      r.BloomFilter,
+		StreamIDBitmap:   r.StreamIDBitmap,
+		MinTimestamp:     r.MinTimestamp,
+		MaxTimestamp:     r.MaxTimestamp,
+		UncompressedSize: r.UncompressedSize,
+	}
+}
+
+// ColumnIndex maps Arrow field names to column indices within a
+// [arrow.RecordBatch]. Build one with [BuildColumnIndex] and reuse it across
+// rows decoded from the same schema.
+type ColumnIndex map[string]int
+
+// BuildColumnIndex constructs a [ColumnIndex] from an Arrow schema. The
+// returned index can be passed to [DecodeRow] for efficient per-row decoding.
+func BuildColumnIndex(schema *arrow.Schema) ColumnIndex {
+	idx := make(ColumnIndex, len(schema.Fields()))
+	for i, field := range schema.Fields() {
+		idx[field.Name] = i
+	}
+	return idx
+}
+
+// DecodeRow decodes a single row at rowIndex from an Arrow [arrow.RecordBatch]
+// into a [Row]. Binary column values (StreamIDBitmap, BloomFilter) are copied
+// so the returned Row does not retain references to the batch's memory.
+//
+// Columns are looked up by field name via the provided [ColumnIndex]; missing
+// or null values are left at their zero value.
+func DecodeRow(batch arrow.RecordBatch, columns ColumnIndex, rowIndex int) Row {
+	var result Row
+
+	getColumn := func(name string) arrow.Array {
+		if idx, ok := columns[name]; ok {
+			return batch.Column(idx)
+		}
+		return nil
+	}
+
+	if col := getColumn("kind.int64"); col != nil && !col.IsNull(rowIndex) {
+		result.Kind = PostingKind(col.(*array.Int64).Value(rowIndex))
+	}
+
+	if col := getColumn("object_path.utf8"); col != nil && !col.IsNull(rowIndex) {
+		result.ObjectPath = col.(*array.String).Value(rowIndex)
+	}
+
+	if col := getColumn("section_index.int64"); col != nil && !col.IsNull(rowIndex) {
+		result.SectionIndex = col.(*array.Int64).Value(rowIndex)
+	}
+
+	if col := getColumn("column_name.utf8"); col != nil && !col.IsNull(rowIndex) {
+		result.ColumnName = col.(*array.String).Value(rowIndex)
+	}
+
+	if col := getColumn("label_value.utf8"); col != nil && !col.IsNull(rowIndex) {
+		result.LabelValue = col.(*array.String).Value(rowIndex)
+	}
+
+	if col := getColumn("stream_id_bitmap.binary"); col != nil && !col.IsNull(rowIndex) {
+		result.StreamIDBitmap = bytes.Clone(col.(*array.Binary).Value(rowIndex))
+	}
+
+	if col := getColumn("bloom_filter.binary"); col != nil && !col.IsNull(rowIndex) {
+		result.BloomFilter = bytes.Clone(col.(*array.Binary).Value(rowIndex))
+	}
+
+	if col := getColumn("uncompressed_size.int64"); col != nil && !col.IsNull(rowIndex) {
+		result.UncompressedSize = col.(*array.Int64).Value(rowIndex)
+	}
+
+	if col := getColumn("min_timestamp.timestamp"); col != nil && !col.IsNull(rowIndex) {
+		result.MinTimestamp = int64(col.(*array.Timestamp).Value(rowIndex))
+	}
+
+	if col := getColumn("max_timestamp.timestamp"); col != nil && !col.IsNull(rowIndex) {
+		result.MaxTimestamp = int64(col.(*array.Timestamp).Value(rowIndex))
+	}
+
+	return result
+}

--- a/pkg/dataobj/sections/postings/sort.go
+++ b/pkg/dataobj/sections/postings/sort.go
@@ -1,0 +1,38 @@
+package postings
+
+import "sort"
+
+// sortLabelEntries sorts label entries by
+// [objectPath, sectionIndex, columnName, labelValue]. The sort is stable so
+// callers that rely on insertion order for equal keys keep that order.
+func sortLabelEntries(entries []LabelEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		a, b := entries[i], entries[j]
+		if a.ObjectPath != b.ObjectPath {
+			return a.ObjectPath < b.ObjectPath
+		}
+		if a.SectionIndex != b.SectionIndex {
+			return a.SectionIndex < b.SectionIndex
+		}
+		if a.ColumnName != b.ColumnName {
+			return a.ColumnName < b.ColumnName
+		}
+		return a.LabelValue < b.LabelValue
+	})
+}
+
+// sortBloomEntries sorts bloom entries by
+// [objectPath, sectionIndex, columnName]. The sort is stable so callers that
+// rely on insertion order for equal keys keep that order.
+func sortBloomEntries(entries []BloomEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		a, b := entries[i], entries[j]
+		if a.ObjectPath != b.ObjectPath {
+			return a.ObjectPath < b.ObjectPath
+		}
+		if a.SectionIndex != b.SectionIndex {
+			return a.SectionIndex < b.SectionIndex
+		}
+		return a.ColumnName < b.ColumnName
+	})
+}

--- a/pkg/dataobj/sections/stats/row.go
+++ b/pkg/dataobj/sections/stats/row.go
@@ -1,0 +1,85 @@
+package stats
+
+import (
+	"strings"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+)
+
+// ColumnIndex maps Arrow field names to column indices within an
+// [arrow.RecordBatch]. Build one with [BuildColumnIndex] and reuse it across
+// rows decoded from the same schema.
+type ColumnIndex map[string]int
+
+// BuildColumnIndex constructs a [ColumnIndex] from an Arrow schema. The
+// returned index can be passed to [DecodeRow] for efficient per-row decoding.
+func BuildColumnIndex(schema *arrow.Schema) ColumnIndex {
+	idx := make(ColumnIndex, len(schema.Fields()))
+	for i, field := range schema.Fields() {
+		idx[field.Name] = i
+	}
+	return idx
+}
+
+// DecodeRow decodes a single row at rowIndex from an Arrow [arrow.RecordBatch]
+// into a [Stat]. Dynamic label columns (fields with a ".label.utf8" suffix)
+// are decoded into the Labels map.
+//
+// Columns are looked up by field name via the provided [ColumnIndex]; missing
+// or null values are left at their zero value.
+func DecodeRow(batch arrow.RecordBatch, columns ColumnIndex, rowIndex int) Stat {
+	result := Stat{
+		Labels: make(map[string]string),
+	}
+
+	getColumn := func(name string) arrow.Array {
+		if idx, ok := columns[name]; ok {
+			return batch.Column(idx)
+		}
+		return nil
+	}
+
+	if col := getColumn("object_path.utf8"); col != nil && !col.IsNull(rowIndex) {
+		result.ObjectPath = col.(*array.String).Value(rowIndex)
+	}
+
+	if col := getColumn("section_index.int64"); col != nil && !col.IsNull(rowIndex) {
+		result.SectionIndex = col.(*array.Int64).Value(rowIndex)
+	}
+
+	if col := getColumn("sort_schema.utf8"); col != nil && !col.IsNull(rowIndex) {
+		result.SortSchema = col.(*array.String).Value(rowIndex)
+	}
+
+	if col := getColumn("min_timestamp.timestamp"); col != nil && !col.IsNull(rowIndex) {
+		result.MinTimestamp = int64(col.(*array.Timestamp).Value(rowIndex))
+	}
+
+	if col := getColumn("max_timestamp.timestamp"); col != nil && !col.IsNull(rowIndex) {
+		result.MaxTimestamp = int64(col.(*array.Timestamp).Value(rowIndex))
+	}
+
+	if col := getColumn("row_count.int64"); col != nil && !col.IsNull(rowIndex) {
+		result.RowCount = col.(*array.Int64).Value(rowIndex)
+	}
+
+	if col := getColumn("uncompressed_size.int64"); col != nil && !col.IsNull(rowIndex) {
+		result.UncompressedSize = col.(*array.Int64).Value(rowIndex)
+	}
+
+	// Decode all label columns (format: "<label>.label.utf8").
+	// Use suffix trimming rather than Split to handle label names that contain dots.
+	for fieldName, colIdx := range columns {
+		if !strings.HasSuffix(fieldName, ".label.utf8") {
+			continue
+		}
+		labelName := strings.TrimSuffix(fieldName, ".label.utf8")
+		col := batch.Column(colIdx)
+		if !col.IsNull(rowIndex) {
+			result.Labels[labelName] = col.(*array.String).Value(rowIndex)
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
## What this does

Part 1 of 6 splitting up #21972 (IndexMerge executor) into reviewable PRs.

Introduces the row-level primitives the IndexMerge compaction executor needs to merge index sections, kept entirely within the `postings` and `stats` section packages so they have **no dependency on the engine/executor**.

### postings
- **`MergeBuilder`**: a row-only sibling of `Builder` that stores already-aggregated label/bloom rows directly, bypassing the per-observation aggregator. Both builders produce identical sections.
- **`Row` / `DecodeRow` / `BuildColumnIndex`**: canonical Arrow `RecordBatch` decoders, plus `LabelEntry()`/`BloomEntry()` conversions, so the executor and tests decode rows through one shared path.
- `LabelEntry`/`BloomEntry` now carry `int64` timestamps directly (matching the on-disk encoding); `columnarEncode` consumes the public types, dropping a round-trip and a bloom unmarshal on the merge path with no change to the observation hot path.
- **`sortLabelEntries`/`sortBloomEntries`**: shared sort helpers so `Builder` and `MergeBuilder` flush agree by construction.

## Stacked PR series (split of #21972)

1. **this PR** — postings/stats primitives
2. indexobj MergeBuilder (stacks on this) - #22230 
3. physicalpb IndexMerge marshalling (independent) - #22231 
4. workflow failed-task EOF fix (independent) - #22232 
5. executor core (stacks on 2) - #22233
6. config/wiring (stacks on 5) - #22234