### PR TITLE
refactor(dataobj/indexobj): Split observation and merge builders into separate types

### DIFF
--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -206,7 +206,7 @@ func (b *Builder) AppendStat(tenantID, objectPath string, sectionIdx int64,
 // requires all observations for a section to be present before encoding
 // (bitmap normalization, bloom filter construction). The builderFull flag
 // provides back-pressure via TargetObjectSize.
-func (b *Builder) ObserveLabelPosting(tenantID string, obs postings.LabelObservation) error {
+func (b *Builder) ObserveLabelPosting(tenantID string, obs postings.LabelObservation) {
 	// Postings are observed per (record × stream label), so this method runs in
 	// a hot loop that fires hundreds of thousands of times per logs section.
 	// Per-call prometheus.NewTimer / Histogram.Observe / sizeEstimate.Set were
@@ -227,7 +227,6 @@ func (b *Builder) ObserveLabelPosting(tenantID string, obs postings.LabelObserva
 	if b.currentSizeEstimate > int(b.cfg.TargetObjectSize) {
 		b.builderFull = true
 	}
-	return nil
 }
 
 // PrepareBloomColumn initializes the bloom filter for a specific column.

--- a/pkg/dataobj/index/indexobj/merge_builder.go
+++ b/pkg/dataobj/index/indexobj/merge_builder.go
@@ -1,0 +1,265 @@
+package indexobj
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/stats"
+	"github.com/grafana/loki/v3/pkg/scratch"
+)
+
+// MergeBuilder accumulates aggregated posting and stat entries from
+// existing sections for merging. Unlike Builder, which aggregates per-observation,
+// MergeBuilder accepts already-aggregated entries and forwards them to
+// merge-mode sub-builders.
+//
+// Methods on MergeBuilder are not goroutine-safe; callers are responsible for
+// synchronization.
+type MergeBuilder struct {
+	cfg     logsobj.BuilderBaseConfig
+	metrics *builderMetrics
+
+	currentSizeEstimate int
+	builderFull         bool
+
+	builder  *dataobj.Builder                  // Inner builder for accumulating sections.
+	stats    map[string]*stats.Builder         // The key is the TenantID.
+	postings map[string]*postings.MergeBuilder // The key is the TenantID.
+
+	unflushedSizeEstimate int
+
+	state builderState
+}
+
+// NewMergeBuilder creates a new [MergeBuilder] for merging pre-aggregated
+// posting and stats entries.
+//
+// NewMergeBuilder returns an error if the provided config is invalid.
+func NewMergeBuilder(cfg logsobj.BuilderBaseConfig, scratchStore scratch.Store) (*MergeBuilder, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	metrics := newBuilderMetrics()
+	metrics.ObserveConfig(cfg)
+
+	return &MergeBuilder{
+		cfg:     cfg,
+		metrics: metrics,
+
+		builder:  dataobj.NewBuilder(scratchStore),
+		stats:    make(map[string]*stats.Builder),
+		postings: make(map[string]*postings.MergeBuilder),
+	}, nil
+}
+
+func (b *MergeBuilder) GetEstimatedSize() int {
+	return b.currentSizeEstimate
+}
+
+func (b *MergeBuilder) IsFull() bool {
+	return b.builderFull
+}
+
+func (b *MergeBuilder) getStatsBuilderForTenant(tenantID string) *stats.Builder {
+	if _, ok := b.stats[tenantID]; !ok {
+		sb := stats.NewBuilder(b.metrics.stats, stats.ColumnarSectionEncoder(int(b.cfg.TargetPageSize), b.cfg.MaxPageRows))
+		sb.SetTenant(tenantID)
+		b.stats[tenantID] = sb
+	}
+	return b.stats[tenantID]
+}
+
+func (b *MergeBuilder) getPostingsMergeBuilderForTenant(tenantID string) *postings.MergeBuilder {
+	if _, ok := b.postings[tenantID]; !ok {
+		pmb := postings.NewMergeBuilder(b.metrics.postings, int(b.cfg.TargetPageSize), b.cfg.MaxPageRows)
+		pmb.SetTenant(tenantID)
+		b.postings[tenantID] = pmb
+	}
+	return b.postings[tenantID]
+}
+
+// AppendStat records a per-sort-key aggregate for a data object section.
+func (b *MergeBuilder) AppendStat(tenantID string, stat stats.Stat) error {
+	b.metrics.appendsTotal.Inc()
+
+	tenantStats := b.getStatsBuilderForTenant(tenantID)
+	preAppendSizeEstimate := tenantStats.EstimatedSize()
+
+	tenantStats.Append(stat)
+
+	postAppendSizeEstimate := tenantStats.EstimatedSize()
+	b.unflushedSizeEstimate += postAppendSizeEstimate - preAppendSizeEstimate
+
+	if postAppendSizeEstimate > int(b.cfg.TargetSectionSize) {
+		if err := b.builder.Append(tenantStats); err != nil {
+			return err
+		}
+	}
+
+	b.currentSizeEstimate = b.estimatedSize()
+	b.state = builderStateDirty
+	if b.currentSizeEstimate > int(b.cfg.TargetObjectSize) {
+		b.builderFull = true
+	}
+
+	return nil
+}
+
+// AppendPostingsLabelEntry appends an aggregated label posting entry
+// directly to the builder.
+func (b *MergeBuilder) AppendPostingsLabelEntry(tenantID string, entry postings.LabelEntry) error {
+	b.metrics.appendsTotal.Inc()
+
+	tenantPostings := b.getPostingsMergeBuilderForTenant(tenantID)
+	preSize := tenantPostings.EstimatedSize()
+
+	if err := tenantPostings.AppendLabelEntry(entry); err != nil {
+		return err
+	}
+
+	postSize := tenantPostings.EstimatedSize()
+	b.unflushedSizeEstimate += postSize - preSize
+	b.currentSizeEstimate += postSize - preSize
+	b.state = builderStateDirty
+	if b.currentSizeEstimate > int(b.cfg.TargetObjectSize) {
+		b.builderFull = true
+	}
+	return nil
+}
+
+// AppendPostingsBloomEntry appends an aggregated bloom posting entry
+// directly to the builder.
+func (b *MergeBuilder) AppendPostingsBloomEntry(tenantID string, entry postings.BloomEntry) error {
+	b.metrics.appendsTotal.Inc()
+
+	tenantPostings := b.getPostingsMergeBuilderForTenant(tenantID)
+	preSize := tenantPostings.EstimatedSize()
+
+	if err := tenantPostings.AppendBloomEntry(entry); err != nil {
+		return err
+	}
+
+	postSize := tenantPostings.EstimatedSize()
+	b.unflushedSizeEstimate += postSize - preSize
+	b.currentSizeEstimate += postSize - preSize
+	b.state = builderStateDirty
+	if b.currentSizeEstimate > int(b.cfg.TargetObjectSize) {
+		b.builderFull = true
+	}
+	return nil
+}
+
+func (b *MergeBuilder) estimatedSize() int {
+	var size int
+	size += b.unflushedSizeEstimate
+	size += b.builder.Bytes()
+	b.metrics.sizeEstimate.Set(float64(size))
+	return size
+}
+
+// Flush flushes all buffered data and returns the built object.
+//
+// [MergeBuilder.Reset] is called after a successful Flush to discard any pending
+// data and allow new data to be appended.
+func (b *MergeBuilder) Flush() (*dataobj.Object, io.Closer, error) {
+	if b.state == builderStateEmpty {
+		return nil, nil, ErrBuilderEmpty
+	}
+
+	b.metrics.flushTotal.Inc()
+	timer := prometheus.NewTimer(b.metrics.buildTime)
+	defer timer.ObserveDuration()
+
+	var flushErrors []error
+
+	for _, tenantStats := range b.stats {
+		if tenantStats.EstimatedSize() > 0 {
+			flushErrors = append(flushErrors, b.builder.Append(tenantStats))
+		}
+	}
+	for _, tenantPostings := range b.postings {
+		if tenantPostings.EstimatedSize() > 0 {
+			flushErrors = append(flushErrors, b.builder.Append(tenantPostings))
+		}
+	}
+
+	if err := errors.Join(flushErrors...); err != nil {
+		b.metrics.flushFailures.Inc()
+		return nil, nil, fmt.Errorf("building object: %w", err)
+	}
+
+	obj, closer, err := b.builder.Flush()
+	if err != nil {
+		b.metrics.flushFailures.Inc()
+		return nil, nil, fmt.Errorf("flushing object: %w", err)
+	}
+
+	b.metrics.builtSize.Observe(float64(obj.Size()))
+
+	err = b.observeObject(context.Background(), obj)
+
+	b.Reset()
+	return obj, closer, err
+}
+
+func (b *MergeBuilder) observeObject(ctx context.Context, obj *dataobj.Object) error {
+	var errs []error
+
+	errs = append(errs, b.metrics.dataobj.Observe(obj))
+
+	for _, sec := range obj.Sections() {
+		switch {
+		case postings.CheckSection(sec):
+			postingSection, err := postings.Open(ctx, sec)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			errs = append(errs, b.metrics.postings.Observe(ctx, postingSection))
+		case stats.CheckSection(sec):
+			statSection, err := stats.Open(ctx, sec)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			errs = append(errs, b.metrics.stats.Observe(ctx, statSection))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// Reset discards pending data and resets the builder to an empty state.
+func (b *MergeBuilder) Reset() {
+	b.builder.Reset()
+	b.stats = make(map[string]*stats.Builder)
+	b.postings = make(map[string]*postings.MergeBuilder)
+
+	b.metrics.sizeEstimate.Set(0)
+	b.currentSizeEstimate = 0
+	b.unflushedSizeEstimate = 0
+	b.builderFull = false
+	b.state = builderStateEmpty
+}
+
+// RegisterMetrics registers metrics about builder to report to reg. All
+// metrics will have a tenant label set to the tenant ID of the Builder.
+//
+// If multiple Builders for the same tenant are running in the same process,
+// reg must contain additional labels to differentiate between them.
+func (b *MergeBuilder) RegisterMetrics(reg prometheus.Registerer) error {
+	return b.metrics.Register(reg)
+}
+
+// UnregisterMetrics unregisters metrics about builder from reg.
+func (b *MergeBuilder) UnregisterMetrics(reg prometheus.Registerer) {
+	b.metrics.Unregister(reg)
+}

--- a/pkg/dataobj/index/indexobj/merge_builder_test.go
+++ b/pkg/dataobj/index/indexobj/merge_builder_test.go
@@ -1,0 +1,467 @@
+package indexobj
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/stats"
+)
+
+// TestMergeBuilder_Empty verifies that an empty merge builder returns ErrBuilderEmpty on flush.
+func TestMergeBuilder_Empty(t *testing.T) {
+	b, err := NewMergeBuilder(logsobj.BuilderBaseConfig{
+		TargetPageSize:          2048,
+		MaxPageRows:             10000,
+		TargetObjectSize:        1 << 22, // 4 MiB
+		TargetSectionSize:       1 << 21, // 2 MiB
+		BufferSize:              2048 * 8,
+		SectionStripeMergeLimit: 2,
+	}, nil)
+	require.NoError(t, err)
+
+	_, _, err = b.Flush()
+	require.Error(t, err)
+	require.Equal(t, ErrBuilderEmpty, err)
+}
+
+// TestMergeBuilder_AppendStat verifies that AppendStat works correctly.
+func TestMergeBuilder_AppendStat(t *testing.T) {
+	b, err := NewMergeBuilder(logsobj.BuilderBaseConfig{
+		TargetPageSize:          2048,
+		MaxPageRows:             10000,
+		TargetObjectSize:        1 << 22,
+		TargetSectionSize:       1 << 21,
+		BufferSize:              2048 * 8,
+		SectionStripeMergeLimit: 2,
+	}, nil)
+	require.NoError(t, err)
+
+	ts := time.Unix(0, 0).UTC()
+
+	// Append a stat
+	stat := stats.Stat{
+		ObjectPath:       "/path/to/obj1",
+		SectionIndex:     0,
+		SortSchema:       "sort_key_1",
+		Labels:           map[string]string{"level": "info"},
+		MinTimestamp:     ts.UnixNano(),
+		MaxTimestamp:     ts.UnixNano(),
+		RowCount:         100,
+		UncompressedSize: 1024,
+	}
+	err = b.AppendStat("tenant-1", stat)
+	require.NoError(t, err)
+
+	require.Greater(t, b.GetEstimatedSize(), 0)
+	require.False(t, b.IsFull())
+
+	// Flush should succeed now
+	obj, closer, err := b.Flush()
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	defer closer.Close()
+
+	// After flush, Reset should have been called
+	require.Equal(t, 0, b.GetEstimatedSize())
+	require.False(t, b.IsFull())
+
+	// Assert the object contains the expected stats section with the appended row.
+	require.Len(t, obj.Sections(), 1)
+	sec := obj.Sections()[0]
+	require.Equal(t, "tenant-1", sec.Tenant)
+	require.True(t, stats.CheckSection(sec))
+
+	ctx := context.Background()
+	statSection, err := stats.Open(ctx, sec)
+	require.NoError(t, err)
+
+	decodedRows := readAllStatsRows(ctx, t, statSection)
+	require.Len(t, decodedRows, 1)
+
+	row := decodedRows[0]
+	require.Equal(t, stat.ObjectPath, row.ObjectPath)
+	require.Equal(t, stat.SectionIndex, row.SectionIndex)
+	require.Equal(t, stat.RowCount, row.RowCount)
+	require.Equal(t, stat.UncompressedSize, row.UncompressedSize)
+}
+
+// TestMergeBuilder_AppendPostingsLabelEntry verifies that AppendPostingsLabelEntry works.
+func TestMergeBuilder_AppendPostingsLabelEntry(t *testing.T) {
+	b, err := NewMergeBuilder(logsobj.BuilderBaseConfig{
+		TargetPageSize:          2048,
+		MaxPageRows:             10000,
+		TargetObjectSize:        1 << 22,
+		TargetSectionSize:       1 << 21,
+		BufferSize:              2048 * 8,
+		SectionStripeMergeLimit: 2,
+	}, nil)
+	require.NoError(t, err)
+
+	ts := int64(1000) // unix nanoseconds
+
+	// Create a valid label entry
+	bitmapBytes := []byte{0x01, 0x00}
+	entry := postings.LabelEntry{
+		ObjectPath:       "/obj1",
+		SectionIndex:     0,
+		ColumnName:       "env",
+		LabelValue:       "prod",
+		StreamIDBitmap:   bitmapBytes,
+		MinTimestamp:     ts,
+		MaxTimestamp:     ts,
+		UncompressedSize: 4096,
+	}
+
+	err = b.AppendPostingsLabelEntry("tenant-1", entry)
+	require.NoError(t, err)
+
+	require.Greater(t, b.GetEstimatedSize(), 0)
+
+	// Flush should succeed
+	obj, closer, err := b.Flush()
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	defer closer.Close()
+
+	// Assert the object contains the expected postings section with the appended row.
+	require.Len(t, obj.Sections(), 1)
+	sec := obj.Sections()[0]
+	require.Equal(t, "tenant-1", sec.Tenant)
+	require.True(t, postings.CheckSection(sec))
+
+	ctx := context.Background()
+	postingsSection, err := postings.Open(ctx, sec)
+	require.NoError(t, err)
+
+	decodedRows := readAllPostingsRows(ctx, t, postingsSection)
+	require.Len(t, decodedRows, 1)
+
+	row := decodedRows[0]
+	require.Equal(t, postings.KindLabel, row.Kind)
+	require.Equal(t, entry.ObjectPath, row.ObjectPath)
+	require.Equal(t, entry.SectionIndex, row.SectionIndex)
+	require.Equal(t, entry.ColumnName, row.ColumnName)
+	require.Equal(t, entry.LabelValue, row.LabelValue)
+	require.Equal(t, entry.StreamIDBitmap, row.StreamIDBitmap)
+}
+
+// TestMergeBuilder_AppendPostingsBloomEntry verifies that AppendPostingsBloomEntry works.
+func TestMergeBuilder_AppendPostingsBloomEntry(t *testing.T) {
+	b, err := NewMergeBuilder(logsobj.BuilderBaseConfig{
+		TargetPageSize:          2048,
+		MaxPageRows:             10000,
+		TargetObjectSize:        1 << 22,
+		TargetSectionSize:       1 << 21,
+		BufferSize:              2048 * 8,
+		SectionStripeMergeLimit: 2,
+	}, nil)
+	require.NoError(t, err)
+
+	timeVal := time.Unix(0, 500).UTC()
+
+	// Create valid bloom bytes using an observation builder
+	tempBuilder := postings.NewBuilder(nil, 0, 0)
+	tempBuilder.PrepareBloomColumn("/obj2", 1, "service_name", 100)
+	err = tempBuilder.ObserveBloomPosting(postings.BloomObservation{
+		ObjectPath:       "/obj2",
+		SectionIndex:     1,
+		ColumnName:       "service_name",
+		Value:            "my-service",
+		StreamID:         0,
+		Timestamp:        timeVal,
+		UncompressedSize: 0,
+	})
+	require.NoError(t, err)
+
+	bloomBytes, err := tempBuilder.BloomBytes("/obj2", 1, "service_name")
+	require.NoError(t, err)
+
+	// Now create the entry
+	ts := int64(500) // unix nanoseconds
+	bitmapBytes := []byte{0x01, 0x00}
+	entry := postings.BloomEntry{
+		ObjectPath:       "/obj2",
+		SectionIndex:     1,
+		ColumnName:       "service_name",
+		BloomFilter:      bloomBytes,
+		StreamIDBitmap:   bitmapBytes,
+		MinTimestamp:     ts,
+		MaxTimestamp:     ts,
+		UncompressedSize: 8192,
+	}
+
+	err = b.AppendPostingsBloomEntry("tenant-1", entry)
+	require.NoError(t, err)
+
+	require.Greater(t, b.GetEstimatedSize(), 0)
+
+	// Flush should succeed
+	obj, closer, err := b.Flush()
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	defer closer.Close()
+
+	// Assert the object contains the expected postings section with the appended row.
+	require.Len(t, obj.Sections(), 1)
+	sec := obj.Sections()[0]
+	require.Equal(t, "tenant-1", sec.Tenant)
+	require.True(t, postings.CheckSection(sec))
+
+	ctx := context.Background()
+	postingsSection, err := postings.Open(ctx, sec)
+	require.NoError(t, err)
+
+	decodedRows := readAllPostingsRows(ctx, t, postingsSection)
+	require.Len(t, decodedRows, 1)
+
+	row := decodedRows[0]
+	require.Equal(t, postings.KindBloom, row.Kind)
+	require.Equal(t, entry.ObjectPath, row.ObjectPath)
+	require.Equal(t, entry.SectionIndex, row.SectionIndex)
+	require.Equal(t, entry.ColumnName, row.ColumnName)
+	require.Equal(t, entry.BloomFilter, row.BloomFilter)
+	require.Equal(t, entry.StreamIDBitmap, row.StreamIDBitmap)
+}
+
+// TestMergeBuilder_MultiTenant verifies that the merge builder handles multiple tenants.
+func TestMergeBuilder_MultiTenant(t *testing.T) {
+	b, err := NewMergeBuilder(logsobj.BuilderBaseConfig{
+		TargetPageSize:          2048,
+		MaxPageRows:             10000,
+		TargetObjectSize:        1 << 22,
+		TargetSectionSize:       1 << 21,
+		BufferSize:              2048 * 8,
+		SectionStripeMergeLimit: 2,
+	}, nil)
+	require.NoError(t, err)
+
+	ts := time.Unix(0, 0).UTC()
+
+	// Append stats for different tenants
+	stat1 := stats.Stat{
+		ObjectPath:       "/path/obj1",
+		SectionIndex:     0,
+		SortSchema:       "sort_key_1",
+		Labels:           map[string]string{},
+		MinTimestamp:     ts.UnixNano(),
+		MaxTimestamp:     ts.UnixNano(),
+		RowCount:         100,
+		UncompressedSize: 1024,
+	}
+	err = b.AppendStat("tenant-1", stat1)
+	require.NoError(t, err)
+
+	stat2 := stats.Stat{
+		ObjectPath:       "/path/obj2",
+		SectionIndex:     0,
+		SortSchema:       "sort_key_1",
+		Labels:           map[string]string{},
+		MinTimestamp:     ts.UnixNano(),
+		MaxTimestamp:     ts.UnixNano(),
+		RowCount:         200,
+		UncompressedSize: 2048,
+	}
+	err = b.AppendStat("tenant-2", stat2)
+	require.NoError(t, err)
+
+	// Flush should include both tenants' data
+	obj, closer, err := b.Flush()
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	defer closer.Close()
+
+	// Assert we have sections for both tenants (one stats section per tenant).
+	require.Len(t, obj.Sections(), 2)
+
+	// Collect sections by tenant.
+	sectionsByTenant := make(map[string]*dataobj.Section)
+	for _, sec := range obj.Sections() {
+		sectionsByTenant[sec.Tenant] = sec
+	}
+	require.Len(t, sectionsByTenant, 2)
+
+	// Verify tenant-1 section contains stat1.
+	sec1 := sectionsByTenant["tenant-1"]
+	require.NotNil(t, sec1)
+	require.True(t, stats.CheckSection(sec1))
+
+	ctx := context.Background()
+	statSec1, err := stats.Open(ctx, sec1)
+	require.NoError(t, err)
+	rows1 := readAllStatsRows(ctx, t, statSec1)
+	require.Len(t, rows1, 1)
+	require.Equal(t, stat1.ObjectPath, rows1[0].ObjectPath)
+	require.Equal(t, stat1.RowCount, rows1[0].RowCount)
+
+	// Verify tenant-2 section contains stat2.
+	sec2 := sectionsByTenant["tenant-2"]
+	require.NotNil(t, sec2)
+	require.True(t, stats.CheckSection(sec2))
+
+	statSec2, err := stats.Open(ctx, sec2)
+	require.NoError(t, err)
+	rows2 := readAllStatsRows(ctx, t, statSec2)
+	require.Len(t, rows2, 1)
+	require.Equal(t, stat2.ObjectPath, rows2[0].ObjectPath)
+	require.Equal(t, stat2.RowCount, rows2[0].RowCount)
+}
+
+// readAllPostingsRows opens a postings section and returns all decoded rows.
+// It drains the reader in batches and decodes each row from the Arrow record batches.
+func readAllPostingsRows(ctx context.Context, t *testing.T, sec *postings.Section) []postings.Row {
+	t.Helper()
+
+	r := postings.NewReader(postings.ReaderOptions{
+		Columns:   sec.Columns(),
+		Allocator: memory.DefaultAllocator,
+	})
+	require.NoError(t, r.Open(ctx))
+	t.Cleanup(func() { _ = r.Close() })
+
+	var (
+		rows    []postings.Row
+		columns postings.ColumnIndex
+	)
+	for {
+		batch, err := r.Read(ctx, 128)
+		if err != nil && !errors.Is(err, io.EOF) {
+			require.NoError(t, err)
+		}
+
+		if batch == nil || batch.NumRows() == 0 {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			continue
+		}
+
+		// Build column index on first batch.
+		if columns == nil {
+			columns = postings.BuildColumnIndex(batch.Schema())
+		}
+
+		// Decode each row in the batch.
+		for rowIdx := 0; rowIdx < int(batch.NumRows()); rowIdx++ {
+			rows = append(rows, postings.DecodeRow(batch, columns, rowIdx))
+		}
+
+		if errors.Is(err, io.EOF) {
+			break
+		}
+	}
+
+	return rows
+}
+
+// readAllStatsRows opens a stats section and returns all decoded rows.
+// It drains the reader in batches and decodes each row from the Arrow record batches.
+func readAllStatsRows(ctx context.Context, t *testing.T, sec *stats.Section) []stats.Stat {
+	t.Helper()
+
+	r := stats.NewReader(stats.ReaderOptions{
+		Columns:   sec.Columns(),
+		Allocator: memory.DefaultAllocator,
+	})
+	require.NoError(t, r.Open(ctx))
+	t.Cleanup(func() { _ = r.Close() })
+
+	var (
+		rows    []stats.Stat
+		columns stats.ColumnIndex
+	)
+	for {
+		batch, err := r.Read(ctx, 128)
+		if err != nil && !errors.Is(err, io.EOF) {
+			require.NoError(t, err)
+		}
+
+		if batch == nil || batch.NumRows() == 0 {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			continue
+		}
+
+		// Build column index on first batch.
+		if columns == nil {
+			columns = stats.BuildColumnIndex(batch.Schema())
+		}
+
+		// Decode each row in the batch.
+		for rowIdx := 0; rowIdx < int(batch.NumRows()); rowIdx++ {
+			rows = append(rows, stats.DecodeRow(batch, columns, rowIdx))
+		}
+
+		if errors.Is(err, io.EOF) {
+			break
+		}
+	}
+
+	return rows
+}
+
+// TestMergeBuilder_Reset verifies that Reset clears all state.
+func TestMergeBuilder_Reset(t *testing.T) {
+	b, err := NewMergeBuilder(logsobj.BuilderBaseConfig{
+		TargetPageSize:          2048,
+		MaxPageRows:             10000,
+		TargetObjectSize:        1 << 22,
+		TargetSectionSize:       1 << 21,
+		BufferSize:              2048 * 8,
+		SectionStripeMergeLimit: 2,
+	}, nil)
+	require.NoError(t, err)
+
+	ts := time.Unix(0, 0).UTC()
+
+	// Add some data
+	stat := stats.Stat{
+		ObjectPath:       "/path/obj1",
+		SectionIndex:     0,
+		SortSchema:       "sort_key_1",
+		Labels:           map[string]string{},
+		MinTimestamp:     ts.UnixNano(),
+		MaxTimestamp:     ts.UnixNano(),
+		RowCount:         100,
+		UncompressedSize: 1024,
+	}
+	err = b.AppendStat("tenant-1", stat)
+	require.NoError(t, err)
+
+	require.Greater(t, b.GetEstimatedSize(), 0)
+
+	// Reset
+	b.Reset()
+
+	require.Equal(t, 0, b.GetEstimatedSize())
+	require.False(t, b.IsFull())
+	require.Equal(t, builderStateEmpty, b.state)
+
+	// After reset, should be able to add data again and flush
+	stat2 := stats.Stat{
+		ObjectPath:       "/path/obj1",
+		SectionIndex:     0,
+		SortSchema:       "sort_key_1",
+		Labels:           map[string]string{},
+		MinTimestamp:     ts.UnixNano(),
+		MaxTimestamp:     ts.UnixNano(),
+		RowCount:         100,
+		UncompressedSize: 1024,
+	}
+	err = b.AppendStat("tenant-1", stat2)
+	require.NoError(t, err)
+
+	obj, closer, err := b.Flush()
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	closer.Close()
+}

--- a/pkg/dataobj/index/label_postings_calculation.go
+++ b/pkg/dataobj/index/label_postings_calculation.go
@@ -36,7 +36,7 @@ func (c *labelPostingsCalculation) ProcessBatch(_ context.Context, calcCtx *logs
 			if batchErr != nil {
 				return
 			}
-			batchErr = calcCtx.builder.ObserveLabelPosting(calcCtx.tenantID, postings.LabelObservation{
+			calcCtx.builder.ObserveLabelPosting(calcCtx.tenantID, postings.LabelObservation{
 				ObjectPath:       calcCtx.objectPath,
 				SectionIndex:     calcCtx.sectionIdx,
 				ColumnName:       lbl.Name,


### PR DESCRIPTION
## What this does

Part 2 of 6 splitting up #21972 (IndexMerge executor) into reviewable PRs.

> **Stacked on #22229** (postings/stats primitives). Review/merge that first

The IndexMerge compaction executor must write index rows it has already merged from multiple source sections, **without** re-feeding them through the observation aggregator (which re-derives `UncompressedSize` per observation and would double-count on pre-merged input). Rather than overload `Builder` with a merge mode, this splits the merge path into its own concrete type.

- **`Builder` stays observation-only**  and the matching callsite in `label_postings_calculation.go` is simplified.
- **`MergeBuilder`** is the new merge-side top-level builder. It carries only the section types the merger writes (stats + postings via `postings.MergeBuilder` from #22229) — no streams, pointers, or indexPointers maps. `Flush` emits the same metrics.

The indexer pipelines (`Builder`) and the compactor (`MergeBuilder`) run in separate processes and never share a builder, which is the motivation for the type-level split.