### PR TITLE
fix(engine/workflow): Surface failed-task errors before results EOF

### DIFF
--- a/pkg/engine/internal/workflow/workflow.go
+++ b/pkg/engine/internal/workflow/workflow.go
@@ -446,14 +446,43 @@ func (wf *Workflow) onStreamChange(_ context.Context, stream *Stream, newState S
 	}
 
 	wf.streamsMut.Lock()
-	defer wf.streamsMut.Unlock()
-
 	wf.streamStates[stream] = newState
+	shouldCloseResults := newState == StreamStateClosed && stream.ULID == wf.resultsStream.ULID
+	wf.streamsMut.Unlock()
 
-	if newState == StreamStateClosed && stream.ULID == wf.resultsStream.ULID {
-		// Close the results pipeline once the results stream has closed.
-		wf.resultsPipeline.Close()
+	if shouldCloseResults {
+		wf.maybeCloseResults()
 	}
+}
+
+// resultsStreamClosed reports whether the results stream has reached
+// StreamStateClosed. Callers must hold streamsMut.
+func (wf *Workflow) resultsStreamClosed() bool {
+	return wf.streamStates[wf.resultsStream] == StreamStateClosed
+}
+
+// maybeCloseResults closes the results pipeline (signaling EOF) only once the
+// results stream has closed AND every task is terminal, so any failed task's
+// SetError happens-before the EOF. Idempotent; safe to call from any handler.
+func (wf *Workflow) maybeCloseResults() {
+	wf.streamsMut.RLock()
+	streamClosed := wf.resultsStreamClosed()
+	wf.streamsMut.RUnlock()
+
+	if !streamClosed {
+		return
+	}
+
+	wf.tasksMut.RLock()
+	for _, state := range wf.taskStates {
+		if !state.Terminal() {
+			wf.tasksMut.RUnlock()
+			return
+		}
+	}
+	wf.tasksMut.RUnlock()
+
+	wf.resultsPipeline.Close()
 }
 
 func (wf *Workflow) onTaskChange(ctx context.Context, task *Task, newStatus TaskStatus) {
@@ -530,6 +559,9 @@ func (wf *Workflow) handleTerminalStateChange(ctx context.Context, task *Task, o
 	wf.tasksMut.RUnlock()
 
 	wf.cancelTasks(ctx, tasksToCancel)
+
+	// Close the results pipeline if it was waiting on this task to finish.
+	wf.maybeCloseResults()
 
 	// Print the summary at the very end to track full end-to-end task time.
 	wf.printTaskSummary(task, oldState, newStatus)

--- a/pkg/engine/internal/workflow/workflow_test.go
+++ b/pkg/engine/internal/workflow/workflow_test.go
@@ -158,6 +158,83 @@ func TestCancellation(t *testing.T) {
 	}
 }
 
+// TestFailedTaskSurfacesErrorBeforeEOF reproduces a race where a failed task's
+// error is lost because the worker closes the results-stream sink (signaling
+// EOF) before the workflow learns the task failed and calls
+// resultsPipeline.SetError. A sink-only task (the root task emits no records
+// and is its own root) maximizes the window: the worker closes the results
+// sink immediately, then reports TaskStateFailed.
+//
+// The consumer (e.g. the dataobj compactor's runPlan) reads the results
+// pipeline to io.EOF and treats EOF as success. If the error is lost, a failed
+// compaction task looks successful and the coordinator swaps the ToC to point
+// at index objects that were never written.
+//
+// This drives the handlers in the order a real worker produces them:
+//  1. results stream -> StreamStateClosed   (worker closes all sinks on failure)
+//  2. root task      -> TaskStateFailed      (worker reports terminal status)
+//
+// and asserts the consumer pipeline surfaces the failure rather than EOF.
+func TestFailedTaskSurfacesErrorBeforeEOF(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var physicalGraph dag.Graph[physical.Node]
+		_ = physicalGraph.Add(&physical.DataObjScan{})
+		physicalPlan := physical.FromGraph(physicalGraph)
+
+		fr := newFakeRunner()
+		wf, err := New(t.Context(), Options{}, log.NewNopLogger(), fr, physicalPlan)
+		require.NoError(t, err, "workflow should construct properly")
+
+		p, err := wf.Run(t.Context())
+		require.NoError(t, err, "workflow should start properly")
+		defer p.Close()
+
+		synctest.Wait()
+
+		rootTask, err := wf.graph.Root()
+		require.NoError(t, err, "should be able to retrieve singular root task")
+		rt, ok := fr.tasks[rootTask.ULID]
+		require.True(t, ok, "root task should be registered with runner")
+
+		wantErr := errors.New("index merge failed: object not found")
+
+		// The consumer drains the results pipeline in a goroutine, blocked on
+		// Read, exactly as runPlan does.
+		require.NoError(t, p.Open(t.Context()))
+		type readResult struct {
+			err error
+		}
+		done := make(chan readResult, 1)
+		go func() {
+			_, readErr := p.Read(t.Context())
+			done <- readResult{err: readErr}
+		}()
+
+		// Let the consumer goroutine block in Read.
+		synctest.Wait()
+
+		// 1. Worker closes the results-stream sink first (the EOF signal), before
+		//    the workflow has learned the task failed, so errCond is not closed.
+		rs, ok := fr.streams[wf.resultsStream.ULID]
+		require.True(t, ok, "results stream should be registered with runner")
+		rs.Handler(t.Context(), wf.resultsStream, StreamStateClosed)
+
+		// Let the consumer goroutine react to the stream close.
+		synctest.Wait()
+
+		// 2. Worker then reports the task failure.
+		rt.handler(t.Context(), rootTask, TaskStatus{State: TaskStateFailed, Error: wantErr})
+
+		synctest.Wait()
+
+		// The consumer must observe the failure, not a clean EOF. A lost error
+		// makes a failed task look successful.
+		res := <-done
+		require.ErrorIs(t, res.err, wantErr,
+			"consumer must surface the task failure instead of EOF")
+	})
+}
+
 // TestShortCircuiting tests that a running task updating its contributing time range cancels irrelevant
 // downstream tasks.
 func TestShortCircuiting(t *testing.T) {


### PR DESCRIPTION
## What this does

Part 4 of 6 splitting up #21972 (IndexMerge executor) into reviewable PRs. **Independent bug fix — based on `main`, can review/merge in any order.**

A workflow task closes its sinks (signaling results-stream EOF to the consumer) before reporting its terminal status, which is what triggers the workflow's `resultsPipeline.SetError`. When a task fails, the EOF can therefore reach the consumer **before** `SetError` lands, so the consumer observes a clean EOF and treats a **failed** workflow as **successful**.

For the dataobj compaction coordinator this is corrupting since IndexMerge tasks are sink only (no rows). A failed `IndexMerge` task looks successful, so the coordinator would swap the table-of-contents to point at merged-index objects that were never written.

### Fix
Defer closing the results pipeline until **both** the results stream has closed **AND** every task has reached a terminal state, guaranteeing any `SetError` happens-before the EOF. Adds a regression test driving the losing interleaving (stream close, then task failure).