### PR TITLE
chore(engine): Add stats for measuring data locality

### DIFF
--- a/pkg/dataobj/internal/dataset/row_reader.go
+++ b/pkg/dataobj/internal/dataset/row_reader.go
@@ -225,6 +225,7 @@ func (r *RowReader) readAndFilterPrimaryColumns(ctx context.Context, readSize in
 		passCount          int // number of rows that passed the predicate
 		primaryColumnBytes int64
 		filledColumns      = make(map[Column]struct{}, len(r.primaryColumnIndexes))
+		region             = xcap.RegionFromContext(ctx)
 	)
 
 	// sequentially apply the predicates.
@@ -275,6 +276,13 @@ func (r *RowReader) readAndFilterPrimaryColumns(ctx context.Context, readSize in
 			passCount++
 		}
 
+		// Track rows that are relevant to the stream matchers.
+		// This is updated only if the first predicate is streamID
+		// any other applied predicates measure query selectivity.
+		if i == 0 && isStreamIDPredicate(p) {
+			region.Record(dataobj.StatStreamRelevantRows.Observe(int64(passCount)))
+		}
+
 		if passCount == 0 {
 			// No rows passed the predicate, so we can stop early.
 			break
@@ -287,7 +295,6 @@ func (r *RowReader) readAndFilterPrimaryColumns(ctx context.Context, readSize in
 		readSize = passCount
 	}
 
-	region := xcap.RegionFromContext(ctx)
 	region.Record(xcap.StatDatasetPrimaryRowsRead.Observe(int64(rowsRead)))
 	region.Record(xcap.StatDatasetPrimaryRowBytes.Observe(primaryColumnBytes))
 
@@ -825,11 +832,13 @@ func (r *RowReader) buildColumnPredicateRanges(ctx context.Context, c Column, p 
 
 	region := xcap.RegionFromContext(ctx)
 
-	var ranges rangeset.Set
-
 	var (
+		ranges       rangeset.Set
 		pageStart    int
 		lastPageSize int
+
+		isStreamCol      = isStreamIDColumn(c)
+		prevPageIncluded bool // used for tracking avg run length
 	)
 
 	for result := range c.ListPages(ctx) {
@@ -847,12 +856,28 @@ func (r *RowReader) buildColumnPredicateRanges(ctx context.Context, c Column, p 
 			End:   uint64(pageStart + pageInfo.RowCount),
 		}
 
+		if isStreamCol {
+			region.Record(dataobj.StatStreamPagesTotal.Observe(1))
+		}
+
 		minValue, maxValue, err := readMinMax(pageInfo.Stats)
 		if err != nil {
 			return rangeset.Set{}, fmt.Errorf("failed to read page stats: %w", err)
 		} else if minValue.IsNil() || maxValue.IsNil() {
 			// No stats, so we add the whole range.
 			ranges.Add(pageRange)
+
+			if isStreamCol {
+				region.Record(dataobj.StatStreamRelevantPages.Observe(1))
+
+				// record start of a new run
+				if !prevPageIncluded {
+					region.Record(dataobj.StatStreamPageRuns.Observe(1))
+				}
+
+			}
+
+			prevPageIncluded = true
 			continue
 		}
 
@@ -880,6 +905,15 @@ func (r *RowReader) buildColumnPredicateRanges(ctx context.Context, c Column, p 
 
 		if include {
 			ranges.Add(pageRange)
+
+			if isStreamCol {
+				region.Record(dataobj.StatStreamRelevantPages.Observe(1))
+
+				// track start of a new run
+				if !prevPageIncluded {
+					region.Record(dataobj.StatStreamPageRuns.Observe(1))
+				}
+			}
 		} else {
 			// Page-level stats were present and the predicate ruled out the page,
 			// so the page will not be downloaded for this predicate. Pages without
@@ -887,6 +921,8 @@ func (r *RowReader) buildColumnPredicateRanges(ctx context.Context, c Column, p 
 			// counted here.
 			region.Record(dataobj.StatDatasetPagesPruned.Observe(1))
 		}
+
+		prevPageIncluded = include
 	}
 
 	return ranges, nil
@@ -953,4 +989,17 @@ func (r *RowReader) predicateColumns(p Predicate, keep func(c Column) bool) ([]C
 	}
 
 	return ret, idxs, nil
+}
+
+func isStreamIDPredicate(p Predicate) bool {
+	in, ok := p.(InPredicate)
+	if !ok {
+		return false
+	}
+
+	return isStreamIDColumn(in.Column)
+}
+
+func isStreamIDColumn(col Column) bool {
+	return col.ColumnDesc().Type.Logical == "stream_id"
 }

--- a/pkg/dataobj/metastore/index_sections_reader.go
+++ b/pkg/dataobj/metastore/index_sections_reader.go
@@ -64,7 +64,8 @@ type indexSectionsReader struct {
 	pointersReaderIdx int
 
 	// Stats
-	bloomRowsRead uint64
+	bloomRowsRead            uint64
+	pointerSectionProductive []bool
 
 	// readSpan for recording observations, it is created once during init.
 	readSpan *xcap.Span
@@ -119,6 +120,7 @@ func (r *indexSectionsReader) Open(ctx context.Context) error {
 		return err
 	}
 
+	r.pointerSectionProductive = make([]bool, len(r.pointersReaders))
 	r.initialized = true
 	return nil
 }
@@ -127,6 +129,9 @@ func (r *indexSectionsReader) init(ctx context.Context) error {
 	if len(r.matchers) == 0 {
 		return nil
 	}
+
+	ctx, sp := xcap.StartSpan(ctx, tracer, "metastore.indexSectionsReader.Open")
+	defer sp.End()
 
 	targetTenant, err := user.ExtractOrgID(ctx)
 	if err != nil {
@@ -197,6 +202,7 @@ func (r *indexSectionsReader) init(ctx context.Context) error {
 				}
 
 				r.pointersReaders[i] = pointersReader
+				sp.Record(StatMetastorePointerSectionsOpened.Observe(1))
 				return nil
 			})
 
@@ -599,6 +605,10 @@ func (r *indexSectionsReader) readPointers(ctx context.Context) (arrow.RecordBat
 				return nil, err
 			}
 			if matchedRows > 0 {
+				if !r.pointerSectionProductive[r.pointersReaderIdx] {
+					r.pointerSectionProductive[r.pointersReaderIdx] = true
+					r.readSpan.Record(StatMetastorePointerSectionsProductive.Observe(1))
+				}
 				r.readSpan.Record(xcap.StatMetastoreSectionPointersRead.Observe(int64(matchedRows)))
 				r.bloomRowsRead += uint64(matchedRows)
 				return filteredRec, nil

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -654,6 +654,7 @@ func (m *ObjectMetastore) GetIndexes(ctx context.Context, req GetIndexesRequest)
 	for path := range IterTableOfContentsPaths(req.Start, req.End) {
 		resp.TableOfContentsPaths = append(resp.TableOfContentsPaths, path)
 	}
+	span.Record(StatMetastoreTocTables.Observe(int64(len(resp.TableOfContentsPaths))))
 
 	// Return early if no toc files are found
 	if len(resp.TableOfContentsPaths) == 0 {
@@ -714,9 +715,6 @@ func (m *ObjectMetastore) CollectSections(ctx context.Context, req CollectSectio
 	for _, s := range objectSectionDescriptors {
 		sections = append(sections, s)
 	}
-
-	region := xcap.RegionFromContext(ctx)
-	region.Record(xcap.StatMetastoreSectionsResolved.Observe(int64(len(sections))))
 
 	return CollectSectionsResponse{
 		SectionsResponse: SectionsResponse{

--- a/pkg/dataobj/metastore/stats.go
+++ b/pkg/dataobj/metastore/stats.go
@@ -1,0 +1,16 @@
+package metastore
+
+import "github.com/grafana/loki/v3/pkg/xcap"
+
+// Metastore statistics.
+var (
+	// StatMetastoreTocTables is the number of TOC tables read.
+	StatMetastoreTocTables = xcap.NewStatisticInt64("metastore.toc.tables", xcap.AggregationTypeSum)
+
+	// StatMetastorePointerSectionsOpened is the number of pointer section opened.
+	StatMetastorePointerSectionsOpened = xcap.NewStatisticInt64("metastore.sections.opened", xcap.AggregationTypeSum)
+
+	// StatMetastorePointerSectionsProductive counts the number of pointer sections that yielded
+	// atleast one pointer.
+	StatMetastorePointerSectionsProductive = xcap.NewStatisticInt64("metastore.sections.productive", xcap.AggregationTypeSum)
+)

--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -23,6 +23,8 @@ import (
 
 var tracer = otel.Tracer("pkg/dataobj/sections/logs")
 
+var RegionPrefix string = "logs.Reader."
+
 // ReaderOptions customizes the behavior of a [Reader].
 type ReaderOptions struct {
 	// Columns to read. Each column must belong to the same [Section].
@@ -188,7 +190,7 @@ func (r *Reader) Read(ctx context.Context, batchSize int) (arrow.RecordBatch, er
 	}
 
 	if r.readSpan == nil {
-		ctx, r.readSpan = xcap.StartSpan(ctx, tracer, "logs.Reader.Read")
+		ctx, r.readSpan = xcap.StartSpan(ctx, tracer, RegionPrefix+"Read")
 	} else {
 		// inject span into context for inner readers to record observations.
 		ctx = xcap.ContextWithSpan(ctx, r.readSpan)
@@ -222,7 +224,7 @@ func (r *Reader) init(ctx context.Context) error {
 		r.opts.Allocator = memory.DefaultAllocator
 	}
 
-	ctx, span := xcap.StartSpan(ctx, tracer, "logs.Reader.Open")
+	ctx, span := xcap.StartSpan(ctx, tracer, RegionPrefix+"Open")
 	defer span.End()
 
 	// Compose dataset using projected columns and any additional columns
@@ -261,7 +263,7 @@ func (r *Reader) init(ctx context.Context) error {
 	innerOptions := dataset.RowReaderOptions{
 		Dataset:    dset,
 		Columns:    dset.Columns(),
-		Predicates: orderPredicates(preds),
+		Predicates: preds,
 		Prefetch:   true,
 	}
 	if r.inner == nil {

--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -22,8 +22,7 @@ import (
 )
 
 var tracer = otel.Tracer("pkg/dataobj/sections/logs")
-
-var RegionPrefix string = "logs.Reader."
+var RegionPrefix = "logs.Reader."
 
 // ReaderOptions customizes the behavior of a [Reader].
 type ReaderOptions struct {

--- a/pkg/dataobj/sections/logs/row_reader.go
+++ b/pkg/dataobj/sections/logs/row_reader.go
@@ -161,7 +161,7 @@ func (r *RowReader) initReader(ctx context.Context) error {
 	readerOpts := dataset.RowReaderOptions{
 		Dataset:    dset,
 		Columns:    columns,
-		Predicates: orderPredicates(predicates),
+		Predicates: predicates,
 		Prefetch:   true,
 	}
 

--- a/pkg/dataobj/stat.go
+++ b/pkg/dataobj/stat.go
@@ -32,4 +32,27 @@ var (
 	// storage. Bytes served from the metadata prefetch buffer are not counted
 	// again, so this is a true "transferred from storage" figure.
 	StatObjectBytesDownloaded = xcap.NewStatisticInt64("dataobj.object.bytes.downloaded", xcap.AggregationTypeSum)
+
+	// -- Following stats are added to understand how data locality affects a query --
+	//
+	// A row is considered relevant to the query if it matches the stream selector.
+	// A page is considered relevant to the query if it contains a matching stream.
+	//
+	// Good locality would result in most sections being highly relevant.
+
+	// StatStreamPagesTotal is the total number of pages in the stream-ID column.
+	StatStreamPagesTotal = xcap.NewStatisticInt64("dataobj.stream.pages.total", xcap.AggregationTypeSum)
+
+	// StatStreamRelevantPages is the number of stream-ID column pages whose
+	// min/max range overlaps the queried stream IDs.
+	StatStreamRelevantPages = xcap.NewStatisticInt64("dataobj.stream.pages.relevant", xcap.AggregationTypeSum)
+
+	// StatStreamRelevantRows is the number of rows that passed the stream-ID
+	// predicate before other query predicates narrowed the result further.
+	StatStreamRelevantRows = xcap.NewStatisticInt64("dataobj.stream.rows.relevant", xcap.AggregationTypeSum)
+
+	// StatStreamPageRuns is the number of contiguous runs of relevant
+	// stream-ID pages. A single run means all relevant pages are back-to-back;
+	// a count equal to relevant pages means every relevant page is isolated.
+	StatStreamPageRuns = xcap.NewStatisticInt64("dataobj.stream.pages.runs", xcap.AggregationTypeSum)
 )

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -19,7 +19,9 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/engine/internal/deletion"
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/logical"
@@ -476,8 +478,6 @@ func printPhysicalPlanSummary(q *query, plan *physical.Plan, duration time.Durat
 	level.Info(q.Logger()).Log(
 		"msg", "physical-plan-summary",
 
-		"plan", physical.PrintAsTree(plan),
-
 		// Plan stats.
 		"duration_ms", duration.Milliseconds(),
 		"plan_node_count", plan.Len(),
@@ -494,6 +494,10 @@ func printPhysicalPlanSummary(q *query, plan *physical.Plan, duration time.Durat
 		}),
 
 		// TODO(rfratto): include stats on which optimization passes applied/didn't apply
+
+		// Large plans result in log line truncation, retain the other
+		// kvs by moving this to the end.
+		"plan", physical.PrintAsTree(plan),
 	)
 }
 
@@ -578,8 +582,26 @@ func (e *Engine) metastoreSectionsResolver(ctx context.Context, parent *query, l
 			printExecutionSummary(q, executionDuration)
 		}
 
+		sectionsResolved := len(resp.SectionsResponse.Sections)
+		printMetastoreLocalitySummary(q, sectionsResolved)
+
+		if parent != nil {
+			parent.rootRegion.Record(xcap.StatMetastoreSectionsResolved.Observe(int64(sectionsResolved)))
+		}
+
 		return resp.SectionsResponse.Sections, nil
 	}
+}
+
+func printMetastoreLocalitySummary(q *query, sectionsResolved int) {
+	level.Info(q.Logger()).Log(
+		"msg", "metastore-locality-summary",
+		"toc_tables", xcap.Value[int64](q.capture, metastore.StatMetastoreTocTables),
+		"index_objects", xcap.Value[int64](q.capture, xcap.StatMetastoreIndexObjects),
+		"index_sections_opened", xcap.Value[int64](q.capture, metastore.StatMetastorePointerSectionsOpened),
+		"index_sections_productive", xcap.Value[int64](q.capture, metastore.StatMetastorePointerSectionsProductive),
+		"logs_sections_resolved", sectionsResolved,
+	)
 }
 
 // execute reads from the pipeline and produces a result.
@@ -643,6 +665,7 @@ func (e *Engine) execute(ctx context.Context, q *query, params logql.Params, pip
 	span.Record(statProcessBatchDuration.Observe(int64(totalProcessBatchTime)))
 
 	printExecutionSummary(q, duration)
+	printLogLocalitySummary(q)
 
 	span.SetStatus(codes.Ok, "")
 	return builder, nil
@@ -657,6 +680,8 @@ func printExecutionSummary(q *query, duration time.Duration) {
 		readBatchDuration, _    = q.capture.Value(statReadBatchDuration).Int64()
 		processBatchDuration, _ = q.capture.Value(statProcessBatchDuration).Int64()
 		otherDuration           = calculateResidual(duration, readBatchDuration, processBatchDuration)
+
+		logSections = xcap.Value[int64](q.capture, xcap.StatMetastoreSectionsResolved)
 
 		tasksPruned           = xcap.Value[int64](q.capture, workflow.StatPrunedTasks)
 		tasksPlanned          = xcap.Value[int64](q.capture, scheduler.StatPlannedTasks)
@@ -698,6 +723,8 @@ func printExecutionSummary(q *query, duration time.Duration) {
 		"task_neg_result_cache_hits", xcap.Value[int64](q.capture, workflow.StatNegativeCacheHits),
 		"task_pos_result_cache_hits", xcap.Value[int64](q.capture, workflow.StatPositiveCacheHits),
 
+		"log_sections_resolved", logSections,
+
 		// Task fan-out
 		"tasks_total", tasksTotal,
 		"tasks_pruned", tasksPruned,
@@ -710,5 +737,22 @@ func printExecutionSummary(q *query, duration time.Duration) {
 		"tasks_canceled_queued", tasksCanceledQueued,
 		"tasks_canceled_assigned", tasksCanceledAssigned,
 		"tasks_unknown_status", tasksUnkownStatus,
+	)
+}
+
+func printLogLocalitySummary(q *query) {
+	var (
+		rowsTotal           = xcap.ValueFromRegion[int64](q.capture, logs.RegionPrefix, xcap.StatDatasetMaxRows)
+		relevantRows        = xcap.ValueFromRegion[int64](q.capture, logs.RegionPrefix, dataobj.StatStreamRelevantRows)
+		streamPagesTotal    = xcap.ValueFromRegion[int64](q.capture, logs.RegionPrefix, dataobj.StatStreamPagesTotal)
+		streamRelevantPages = xcap.ValueFromRegion[int64](q.capture, logs.RegionPrefix, dataobj.StatStreamRelevantPages)
+	)
+
+	level.Info(q.Logger()).Log(
+		"msg", "logs-locality-summary",
+		"dataset_rows_total", rowsTotal,
+		"stream_relevant_rows", relevantRows,
+		"stream_pages_total", streamPagesTotal,
+		"stream_relevant_pages", streamRelevantPages,
 	)
 }

--- a/pkg/engine/internal/workflow/task_summary.go
+++ b/pkg/engine/internal/workflow/task_summary.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-kit/log/level"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/schedulerstat"
 	"github.com/grafana/loki/v3/pkg/engine/internal/worker/workerstat"
@@ -86,6 +87,52 @@ func (wf *Workflow) printTaskSummary(task *Task, oldState TaskState, newStatus T
 		// Task result cache.
 		"cache_check", taskResultCacheOutcome(capture),
 	)
+
+	if isScanTask(task) {
+		// print log section data locality as a separate log line.
+		wf.printTaskLogLocalitySummary(task, capture)
+	}
+}
+
+func (wf *Workflow) printTaskLogLocalitySummary(task *Task, capture *xcap.Capture) {
+	rowsTotal := xcap.ValueFromRegion[int64](capture, logs.RegionPrefix, xcap.StatDatasetMaxRows)
+	relevantRows := xcap.ValueFromRegion[int64](capture, logs.RegionPrefix, dataobj.StatStreamRelevantRows)
+	streamPagesTotal := xcap.ValueFromRegion[int64](capture, logs.RegionPrefix, dataobj.StatStreamPagesTotal)
+	streamRelevantPages := xcap.ValueFromRegion[int64](capture, logs.RegionPrefix, dataobj.StatStreamRelevantPages)
+	streamPageRuns := xcap.ValueFromRegion[int64](capture, logs.RegionPrefix, dataobj.StatStreamPageRuns)
+
+	level.Info(wf.logger).Log(
+		"msg", "task-log-locality-summary",
+		// Identity
+		"task_id", task.ULID,
+		"query_id", wf.opts.ID,
+		"parent_task_id", wf.parentTaskID(task),
+
+		// Locality
+		"dataset_rows_total", rowsTotal,
+		"stream_relevant_rows", relevantRows,
+		"stream_pages_total", streamPagesTotal,
+		"stream_relevant_pages", streamRelevantPages,
+		"stream_page_runs", streamPageRuns,
+		"stream_row_relevance", ratio(relevantRows, rowsTotal),
+		"stream_page_relevance", ratio(streamRelevantPages, streamPagesTotal),
+		"stream_avg_page_run_len", avgRunLength(streamRelevantPages, streamPageRuns),
+	)
+}
+
+func ratio(part, total int64) float64 {
+	if total <= 0 {
+		return 0
+	}
+
+	return float64(part) / float64(total)
+}
+
+func avgRunLength(relevantPages, pageRuns int64) float64 {
+	if pageRuns <= 0 {
+		return 0
+	}
+	return float64(relevantPages) / float64(pageRuns)
 }
 
 // parentTaskID returns the task's parent ULID, or the zero ULID if the task

--- a/pkg/engine/internal/workflow/task_summary.go
+++ b/pkg/engine/internal/workflow/task_summary.go
@@ -116,7 +116,7 @@ func (wf *Workflow) printTaskLogLocalitySummary(task *Task, capture *xcap.Captur
 		"stream_page_runs", streamPageRuns,
 		"stream_row_relevance", ratio(relevantRows, rowsTotal),
 		"stream_page_relevance", ratio(streamRelevantPages, streamPagesTotal),
-		"stream_avg_page_run_len", avgRunLength(streamRelevantPages, streamPageRuns),
+		"stream_page_fragmentation", ratio(streamPageRuns, streamRelevantPages),
 	)
 }
 
@@ -126,13 +126,6 @@ func ratio(part, total int64) float64 {
 	}
 
 	return float64(part) / float64(total)
-}
-
-func avgRunLength(relevantPages, pageRuns int64) float64 {
-	if pageRuns <= 0 {
-		return 0
-	}
-	return float64(relevantPages) / float64(pageRuns)
 }
 
 // parentTaskID returns the task's parent ULID, or the zero ULID if the task

--- a/pkg/xcap/capture.go
+++ b/pkg/xcap/capture.go
@@ -56,6 +56,7 @@ package xcap
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/gogo/protobuf/proto"
@@ -257,6 +258,42 @@ func (c *Capture) Value(stat Statistic) *AggregatedObservation {
 	return rolled
 }
 
+// ValueFromRegion computes the value of a statistic from regions with
+// names that start with prefix. If the statistic is not present in any matching
+// region, ValueFromRegion returns nil.
+func (c *Capture) ValueFromRegion(prefix string, stat Statistic) *AggregatedObservation {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	key := stat.Key()
+	var rolled *AggregatedObservation
+
+	for _, region := range c.regions {
+		if !strings.HasPrefix(region.name, prefix) {
+			continue
+		}
+
+		region.mu.RLock()
+		obs, ok := region.observations[key]
+		if !ok {
+			region.mu.RUnlock()
+			continue
+		}
+		if rolled == nil {
+			rolled = &AggregatedObservation{
+				Statistic: obs.Statistic,
+				Value:     obs.Value,
+				Count:     obs.Count,
+			}
+		} else {
+			rolled.Merge(obs)
+		}
+		region.mu.RUnlock()
+	}
+
+	return rolled
+}
+
 // Value gets a typed value from a capture. If the statistic it not present in
 // any region from the capture, or the statistic is not of type T, Value returns
 // the zero value for T.
@@ -266,6 +303,25 @@ func (c *Capture) Value(stat Statistic) *AggregatedObservation {
 func Value[T any](c *Capture, stat Statistic) T {
 	v, _ := TryValue[T](c, stat)
 	return v
+}
+
+// ValueFromRegion gets a typed value from a capture, aggregating only
+// regions with names that start with prefix. If the statistic is not present in
+// any matching region, or the statistic is not of type T, ValueFromRegion
+// returns the zero value for T.
+func ValueFromRegion[T any](c *Capture, prefix string, stat Statistic) T {
+	rolled := c.ValueFromRegion(prefix, stat)
+	if rolled == nil {
+		var zero T
+		return zero
+	}
+
+	val, ok := rolled.Value.(T)
+	if !ok {
+		var zero T
+		return zero
+	}
+	return val
 }
 
 // TryValue gets a typed value from a capture, returning both the value and a

--- a/pkg/xcap/capture_test.go
+++ b/pkg/xcap/capture_test.go
@@ -365,6 +365,33 @@ func TestCapture_Value(t *testing.T) {
 	}
 }
 
+func TestCapture_ValueFromRegion(t *testing.T) {
+	ctx, capture := NewCapture(context.Background(), nil)
+	stat := NewStatisticInt64("rows.scanned", AggregationTypeSum)
+
+	_, logsOpen := StartRegion(ctx, "logs.Reader.Open")
+	logsOpen.Record(stat.Observe(100))
+	logsOpen.End()
+
+	_, logsRead := StartRegion(ctx, "logs.Reader.Read")
+	logsRead.Record(stat.Observe(50))
+	logsRead.End()
+
+	_, streamsOpen := StartRegion(ctx, "streams.Reader.Open")
+	streamsOpen.Record(stat.Observe(1000))
+	streamsOpen.End()
+
+	got := capture.ValueFromRegion("logs.Reader.", stat)
+	require.NotNil(t, got)
+	require.Equal(t, int64(150), got.Value)
+	require.Equal(t, 2, got.Count)
+	require.Equal(t, stat.Key(), got.Statistic.Key())
+
+	require.Equal(t, int64(150), ValueFromRegion[int64](capture, "logs.Reader", stat))
+	require.Zero(t, ValueFromRegion[int64](capture, "missing.Reader", stat))
+	require.Zero(t, ValueFromRegion[float64](capture, "logs.Reader", stat))
+}
+
 func TestCapture_GetAllStatistics(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/xcap/stats_definitions.go
+++ b/pkg/xcap/stats_definitions.go
@@ -65,10 +65,12 @@ var (
 
 // Metastore statistics.
 var (
-	StatMetastoreIndexObjects            = NewStatisticInt64("metastore.index.objects", AggregationTypeSum)
-	StatMetastoreSectionsResolved        = NewStatisticInt64("metastore.sections.resolved", AggregationTypeSum)
-	StatMetastoreStreamsRead             = NewStatisticInt64("metastore.sections.streams.read", AggregationTypeSum)
-	StatMetastoreStreamsReadTime         = NewStatisticFloat64("metastore.sections.streams.read.duration", AggregationTypeSum)
+	StatMetastoreIndexObjects     = NewStatisticInt64("metastore.index.objects", AggregationTypeSum)
+	StatMetastoreSectionsResolved = NewStatisticInt64("metastore.sections.resolved", AggregationTypeSum)
+
+	StatMetastoreStreamsRead     = NewStatisticInt64("metastore.sections.streams.read", AggregationTypeSum)
+	StatMetastoreStreamsReadTime = NewStatisticFloat64("metastore.sections.streams.read.duration", AggregationTypeSum)
+
 	StatMetastoreSectionPointersRead     = NewStatisticInt64("metastore.sections.pointers.read", AggregationTypeSum)
 	StatMetastoreSectionPointersReadTime = NewStatisticFloat64("metastore.sections.pointers.read.duration", AggregationTypeSum)
 )

--- a/pkg/xcap/summary.go
+++ b/pkg/xcap/summary.go
@@ -395,17 +395,9 @@ func summarizeObservations(capture *Capture) *observations {
 
 	// metastore streams and pointers scan stats
 	result.merge(
-		collect.fromRegions("metastore.indexSectionsReader.Open", false).
-			filter(
-				StatMetastoreStreamsRead.Key(),
-			).
-			normalizeKeys(),
-	)
-
-	// metastore streams and pointers scan stats
-	result.merge(
 		collect.fromRegions("metastore.indexSectionsReader.Read", false).
 			filter(
+				StatMetastoreStreamsRead.Key(),
 				StatMetastoreSectionPointersRead.Key(),
 			).
 			normalizeKeys(),


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds per-task and overall query level data locality summaries.

For a log section, locality is measured using row relevance. A row is considered relevant to the query if it passes the stream_id predicate. Other predicates are not considered as they are more about query selectivity than locality.

1. `msg="task-log-locality-summary"` reports log locality summary for each task. It reports row relevance, page relevance along with number of distinct page runs within a dataset to measure how fragmented the data is.
2. `msg="logs-locality-summary"` reports the aggregated log locality summary for the entire query with similar information.

For pointer sections, locality is measured by how many sections yielded results.

1. `msg="metastore-locality-summary"` log line reports how many pointer sections were scanned and how many returned pointers.

Follow-up work: With the new pointer section format, we can also measure section relevance by checking how many rows contain a label from the query matchers. With compaction, we expect to see more pointer sections to be highly relevant.

❗  **Breaking change**: Locality tracking expects stream id column to be the first column. This change removes the call to `orderPredicates` which orders the predicates by selectivity. I am removing it since we never really measured how effective predicate ordering is.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
