### PR TITLE
fix(goldfish): Fix migration typo

### DIFF
--- a/pkg/goldfish/migrations/20260521000001_add_estimated_query_size.sql
+++ b/pkg/goldfish/migrations/20260521000001_add_estimated_query_size.sql
@@ -3,7 +3,7 @@
 -- This is the estimated size of the query as returned by query stats. Defaults to 0 if unknown.
 
 ALTER TABLE sampled_queries
-ADD COLUMN cell_a_estimated_query_size BIGINT NOT NULL DEFAULT 0
+ADD COLUMN cell_a_estimated_query_size BIGINT NOT NULL DEFAULT 0,
 ADD COLUMN cell_b_estimated_query_size BIGINT NOT NULL DEFAULT 0;
 
 -- +goose Down


### PR DESCRIPTION
**What this PR does / why we need it**:

Goldfish database migration fails due to a typo.