### PR TITLE
feat(dataobj/explorer): Decode indexpointers rows in inspect endpoint

### DIFF
--- a/pkg/dataobj/explorer/inspect.go
+++ b/pkg/dataobj/explorer/inspect.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/thanos-io/objstore"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
@@ -98,7 +99,7 @@ func (s *Service) handleInspect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	metadata := inspectFile(r.Context(), s.bucket, filename)
+	metadata := inspectFile(r.Context(), s.logger, s.bucket, filename)
 	metadata.LastModified = attrs.LastModified.UTC()
 	for _, section := range metadata.Sections {
 		section.MinTimestamp = section.MinTimestamp.UTC().Truncate(time.Second)
@@ -112,7 +113,7 @@ func (s *Service) handleInspect(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func inspectFile(ctx context.Context, bucket objstore.BucketReader, path string) FileMetadata {
+func inspectFile(ctx context.Context, logger log.Logger, bucket objstore.BucketReader, path string) FileMetadata {
 	obj, err := dataobj.FromBucket(ctx, bucket, path, 0)
 	if err != nil {
 		return FileMetadata{
@@ -176,7 +177,7 @@ func inspectFile(ctx context.Context, bucket objstore.BucketReader, path string)
 					Error: fmt.Sprintf("failed to open index pointers section: %v", err),
 				}
 			}
-			meta, err := inspectIndexPointersSection(ctx, section.Type, indexPointersSection)
+			meta, err := inspectIndexPointersSection(ctx, logger, section.Type, indexPointersSection)
 			if err != nil {
 				return FileMetadata{
 					Error: fmt.Sprintf("failed to inspect index pointers section: %v", err),
@@ -189,7 +190,7 @@ func inspectFile(ctx context.Context, bucket objstore.BucketReader, path string)
 	return result
 }
 
-func inspectIndexPointersSection(ctx context.Context, ty dataobj.SectionType, sec *indexpointers.Section) (SectionMetadata, error) {
+func inspectIndexPointersSection(ctx context.Context, logger log.Logger, ty dataobj.SectionType, sec *indexpointers.Section) (SectionMetadata, error) {
 	stats, err := indexpointers.ReadStats(ctx, sec)
 	if err != nil {
 		return SectionMetadata{}, err
@@ -255,7 +256,7 @@ func inspectIndexPointersSection(ctx context.Context, ty dataobj.SectionType, se
 		})
 	}
 	if truncated {
-		log.Printf("indexpointers section truncated to %d rows during inspect", maxIndexPointerRows)
+		level.Warn(logger).Log("msg", "indexpointers section truncated", "maxRows", maxIndexPointerRows)
 	}
 
 	return meta, nil

--- a/pkg/dataobj/explorer/inspect.go
+++ b/pkg/dataobj/explorer/inspect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -61,6 +62,12 @@ type PageInfo struct {
 	ValuesCount      uint64 `json:"values_count"`
 }
 
+type IndexPointerRow struct {
+	Path    string    `json:"path"`
+	StartTs time.Time `json:"start_ts"`
+	EndTs   time.Time `json:"end_ts"`
+}
+
 type SectionMetadata struct {
 	Type                  string            `json:"type"`
 	TotalCompressedSize   uint64            `json:"totalCompressedSize"`
@@ -70,6 +77,7 @@ type SectionMetadata struct {
 	Distribution          []uint64          `json:"distribution"`
 	MinTimestamp          time.Time         `json:"minTimestamp"`
 	MaxTimestamp          time.Time         `json:"maxTimestamp"`
+	IndexPointers         []IndexPointerRow `json:"indexPointers,omitempty"`
 }
 
 func (s *Service) handleInspect(w http.ResponseWriter, r *http.Request) {
@@ -227,6 +235,27 @@ func inspectIndexPointersSection(ctx context.Context, ty dataobj.SectionType, se
 		}
 
 		meta.Columns = append(meta.Columns, colMeta)
+	}
+
+	const maxIndexPointerRows = 1000
+	truncated := false
+	for r := range indexpointers.IterSection(ctx, sec) {
+		if r.Err() != nil {
+			return SectionMetadata{}, r.Err()
+		}
+		if len(meta.IndexPointers) >= maxIndexPointerRows {
+			truncated = true
+			break
+		}
+		p := r.MustValue()
+		meta.IndexPointers = append(meta.IndexPointers, IndexPointerRow{
+			Path:    p.Path,
+			StartTs: p.StartTs.UTC(),
+			EndTs:   p.EndTs.UTC(),
+		})
+	}
+	if truncated {
+		log.Printf("indexpointers section truncated to %d rows during inspect", maxIndexPointerRows)
 	}
 
 	return meta, nil

--- a/pkg/dataobj/explorer/inspect_test.go
+++ b/pkg/dataobj/explorer/inspect_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 
@@ -50,7 +51,7 @@ func TestInspectFile_IndexPointers(t *testing.T) {
 
 	buildIndexPointersObject(ctx, t, bucket, path, "tenantID", wantPath, start, end)
 
-	md := inspectFile(ctx, bucket, path)
+	md := inspectFile(ctx, log.NewNopLogger(), bucket, path)
 	require.Empty(t, md.Error)
 
 	var found *SectionMetadata

--- a/pkg/dataobj/explorer/inspect_test.go
+++ b/pkg/dataobj/explorer/inspect_test.go
@@ -1,0 +1,72 @@
+package explorer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/indexpointers"
+)
+
+// buildIndexPointersObject builds a dataobj with one indexpointers section and
+// uploads it to bucket at path, so inspectFile can read it back via FromBucket.
+// Mirrors pkg/dataobj/index/builder_test.go:472-481.
+func buildIndexPointersObject(t *testing.T, ctx context.Context, bucket objstore.Bucket, path, tenant, ptrPath string, start, end time.Time) {
+	t.Helper()
+
+	ib := indexpointers.NewBuilder(nil, 1024, 0)
+	ib.SetTenant(tenant)
+	ib.Append(ptrPath, start, end)
+
+	b := dataobj.NewBuilder(nil)
+	require.NoError(t, b.Append(ib))
+
+	obj, closer, err := b.Flush()
+	require.NoError(t, err)
+	defer closer.Close()
+
+	reader, err := obj.Reader(ctx)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	require.NoError(t, bucket.Upload(ctx, path, reader))
+}
+
+func TestInspectFile_IndexPointers(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	path := "index/v0/tocs/2026-06-03T12_00_00Z.toc"
+
+	// Use a non-UTC location so the test proves UTC normalization happens.
+	loc, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	start := time.Date(2026, 6, 3, 12, 0, 0, 0, loc)
+	end := time.Date(2026, 6, 3, 13, 0, 0, 0, loc)
+	wantPath := "index/v0/indexes/abc123.idx"
+
+	buildIndexPointersObject(t, ctx, bucket, path, "tenantID", wantPath, start, end)
+
+	md := inspectFile(ctx, bucket, path)
+	require.Empty(t, md.Error)
+
+	var found *SectionMetadata
+	for i := range md.Sections {
+		if len(md.Sections[i].IndexPointers) > 0 {
+			found = &md.Sections[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "expected a section with decoded IndexPointers")
+	require.Len(t, found.IndexPointers, 1)
+
+	row := found.IndexPointers[0]
+	require.Equal(t, wantPath, row.Path)
+	require.Equal(t, time.UTC, row.StartTs.Location())
+	require.Equal(t, time.UTC, row.EndTs.Location())
+	require.True(t, start.Equal(row.StartTs))
+	require.True(t, end.Equal(row.EndTs))
+}

--- a/pkg/dataobj/explorer/inspect_test.go
+++ b/pkg/dataobj/explorer/inspect_test.go
@@ -15,7 +15,7 @@ import (
 // buildIndexPointersObject builds a dataobj with one indexpointers section and
 // uploads it to bucket at path, so inspectFile can read it back via FromBucket.
 // Mirrors pkg/dataobj/index/builder_test.go:472-481.
-func buildIndexPointersObject(t *testing.T, ctx context.Context, bucket objstore.Bucket, path, tenant, ptrPath string, start, end time.Time) {
+func buildIndexPointersObject(ctx context.Context, t *testing.T, bucket objstore.Bucket, path, tenant, ptrPath string, start, end time.Time) {
 	t.Helper()
 
 	ib := indexpointers.NewBuilder(nil, 1024, 0)
@@ -48,7 +48,7 @@ func TestInspectFile_IndexPointers(t *testing.T) {
 	end := time.Date(2026, 6, 3, 13, 0, 0, 0, loc)
 	wantPath := "index/v0/indexes/abc123.idx"
 
-	buildIndexPointersObject(t, ctx, bucket, path, "tenantID", wantPath, start, end)
+	buildIndexPointersObject(ctx, t, bucket, path, "tenantID", wantPath, start, end)
 
 	md := inspectFile(ctx, bucket, path)
 	require.Empty(t, md.Error)


### PR DESCRIPTION
## What this PR does

The `dataobj-explorer` inspect endpoint (`GET /dataobj/api/v1/inspect?file=<path>`) previously returned only structural metadata (column/page counts, sizes) for each section and never decoded row values. For ToC files, the relevant section is an `indexpointers` section whose rows are `IndexPointer{Path, StartTs, EndTs}` — pointers to the actual index objects.

This change decodes those rows in `inspectIndexPointersSection` using the existing `indexpointers.IterSection` iterator and surfaces them in the JSON response so the operational UI can display and link to the referenced index objects.

### JSON contract

A new field is added to `SectionMetadata`:

```go
type IndexPointerRow struct {
    Path    string    `json:"path"`
    StartTs time.Time `json:"start_ts"` // RFC3339, UTC
    EndTs   time.Time `json:"end_ts"`   // RFC3339, UTC
}
// SectionMetadata gains:
IndexPointers []IndexPointerRow `json:"indexPointers,omitempty"`
```

The field is `omitempty`, so the change is backwards-compatible: existing consumers that don't read `indexPointers` are unaffected, and sections without index pointers serialize identically to before.

### Notes

- Timestamps are normalized to UTC.
- Row decoding is capped at 1000 rows per section to bound response size; truncation is logged.
- Only `indexpointers` sections are decoded; `pointers`, `streams`, and `logs` section values are intentionally left untouched.

## Tests

Added `TestInspectFile_IndexPointers` which builds a real dataobj with an indexpointers section, uploads it to an in-memory bucket, and asserts that `inspectFile` returns the decoded rows with UTC-normalized timestamps.