### PR TITLE
chore(engine): Expand observability for the v2 query engine

### DIFF
--- a/pkg/engine/basic_engine.go
+++ b/pkg/engine/basic_engine.go
@@ -117,15 +117,17 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 	// [rangeio.ReadRanges] to make use of.
 	ctx = rangeio.WithConfig(ctx, &e.cfg.RangeConfig)
 
+	queryType := logqlQueryType(params.GetExpression())
+
 	logicalPlan, err := func() (*logical.Plan, error) {
 		_, span := tracer.Start(ctx, "QueryEngine.Execute.logicalPlan")
 		defer span.End()
 
-		timer := prometheus.NewTimer(e.metrics.logicalPlanning)
+		timer := prometheus.NewTimer(e.metrics.planning.logical.WithLabelValues(queryType))
 		logicalPlan, err := logical.BuildPlan(ctx, params)
 		if err != nil {
 			level.Warn(logger).Log("msg", "failed to create logical plan", "err", err)
-			e.metrics.subqueries.WithLabelValues(statusNotImplemented).Inc()
+			e.metrics.query.subqueries.WithLabelValues(statusNotImplemented, queryType).Inc()
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "failed to create logical plan")
 			return nil, ErrNotSupported
@@ -150,7 +152,7 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 		ctx, span := tracer.Start(ctx, "QueryEngine.Execute.physicalPlan")
 		defer span.End()
 
-		timer := prometheus.NewTimer(e.metrics.physicalPlanning)
+		timer := prometheus.NewTimer(e.metrics.planning.physical.WithLabelValues(queryType))
 
 		catalog := physical.NewMetastoreCatalog(func(selectors physical.Expression, predicates []physical.Expression, start time.Time, end time.Time) ([]*metastore.DataobjSectionDescriptor, error) {
 			req, err := physical.CatalogRequestToMetastoreSectionsRequest(selectors, predicates, start, end)
@@ -164,7 +166,7 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 		plan, err := planner.Build(logicalPlan)
 		if err != nil {
 			level.Warn(logger).Log("msg", "failed to create physical plan", "err", err)
-			e.metrics.subqueries.WithLabelValues(statusFailure).Inc()
+			e.metrics.query.subqueries.WithLabelValues(statusFailure, queryType).Inc()
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "failed to create physical plan")
 			return nil, ErrNotSupported
@@ -173,7 +175,7 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 		plan, err = planner.Optimize(plan)
 		if err != nil {
 			level.Warn(logger).Log("msg", "failed to optimize physical plan", "err", err)
-			e.metrics.subqueries.WithLabelValues(statusFailure).Inc()
+			e.metrics.query.subqueries.WithLabelValues(statusFailure, queryType).Inc()
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "failed to optimize physical plan")
 			return nil, ErrNotSupported
@@ -182,7 +184,7 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 		plan, err = physical.WrapWithBatching(plan, e.cfg.BatchSize)
 		if err != nil {
 			level.Warn(logger).Log("msg", "failed to wrap physical plan with batching", "err", err)
-			e.metrics.subqueries.WithLabelValues(statusFailure).Inc()
+			e.metrics.query.subqueries.WithLabelValues(statusFailure, queryType).Inc()
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "failed to wrap physical plan with batching")
 			return nil, ErrNotSupported
@@ -210,7 +212,7 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 
 		level.Info(logger).Log("msg", "start executing query with new engine")
 
-		timer := prometheus.NewTimer(e.metrics.execution)
+		timer := prometheus.NewTimer(e.metrics.execution.duration.WithLabelValues(queryType))
 
 		cfg := executor.Config{
 			BatchSize:          int64(e.cfg.BatchSize),
@@ -240,14 +242,14 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 		}
 
 		if err := collectResult(ctx, pipeline, builder); err != nil {
-			e.metrics.subqueries.WithLabelValues(statusFailure).Inc()
+			e.metrics.query.subqueries.WithLabelValues(statusFailure, queryType).Inc()
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "failed to build results")
 			return nil, err
 		}
 
 		durExecution = timer.ObserveDuration()
-		e.metrics.subqueries.WithLabelValues(statusSuccess).Inc()
+		e.metrics.query.subqueries.WithLabelValues(statusSuccess, queryType).Inc()
 		span.SetStatus(codes.Ok, "")
 		return builder, nil
 	}()

--- a/pkg/engine/basic_engine.go
+++ b/pkg/engine/basic_engine.go
@@ -130,6 +130,7 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 		if err != nil {
 			level.Warn(logger).Log("msg", "failed to create logical plan", "err", err)
 			e.metrics.query.subqueries.WithLabelValues(statusNotImplemented, queryType).Inc()
+			e.metrics.query.stageFailures.WithLabelValues(stageLogicalPlanning, statusNotImplemented, queryType).Inc()
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "failed to create logical plan")
 			return nil, ErrNotSupported
@@ -169,6 +170,7 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 		if err != nil {
 			level.Warn(logger).Log("msg", "failed to create physical plan", "err", err)
 			e.metrics.query.subqueries.WithLabelValues(statusFailure, queryType).Inc()
+			e.metrics.query.stageFailures.WithLabelValues(stagePhysicalPlanning, statusFailure, queryType).Inc()
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "failed to create physical plan")
 			return nil, ErrNotSupported
@@ -178,6 +180,7 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 		if err != nil {
 			level.Warn(logger).Log("msg", "failed to optimize physical plan", "err", err)
 			e.metrics.query.subqueries.WithLabelValues(statusFailure, queryType).Inc()
+			e.metrics.query.stageFailures.WithLabelValues(stagePhysicalPlanning, statusFailure, queryType).Inc()
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "failed to optimize physical plan")
 			return nil, ErrNotSupported
@@ -188,6 +191,7 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 		if err != nil {
 			level.Warn(logger).Log("msg", "failed to wrap physical plan with batching", "err", err)
 			e.metrics.query.subqueries.WithLabelValues(statusFailure, queryType).Inc()
+			e.metrics.query.stageFailures.WithLabelValues(stagePhysicalPlanning, statusFailure, queryType).Inc()
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "failed to wrap physical plan with batching")
 			return nil, ErrNotSupported
@@ -248,6 +252,7 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 
 		if err := collectResult(ctx, pipeline, builder); err != nil {
 			e.metrics.query.subqueries.WithLabelValues(statusFailure, queryType).Inc()
+			e.metrics.query.stageFailures.WithLabelValues(stageExecution, statusFailure, queryType).Inc()
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "failed to build results")
 			return nil, err

--- a/pkg/engine/basic_engine.go
+++ b/pkg/engine/basic_engine.go
@@ -119,6 +119,8 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 
 	queryType := logqlQueryType(params.GetExpression())
 
+	e.metrics.observeLogQLShape(queryType, logqlShapeOf(params.QueryString(), params.GetExpression()))
+
 	logicalPlan, err := func() (*logical.Plan, error) {
 		_, span := tracer.Start(ctx, "QueryEngine.Execute.logicalPlan")
 		defer span.End()
@@ -180,6 +182,7 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 			span.SetStatus(codes.Error, "failed to optimize physical plan")
 			return nil, ErrNotSupported
 		}
+		e.metrics.recordPhysicalRules(planner.FiredRules())
 
 		plan, err = physical.WrapWithBatching(plan, e.cfg.BatchSize)
 		if err != nil {
@@ -189,6 +192,8 @@ func (e *Basic) Execute(ctx context.Context, params logql.Params) (logqlmodel.Re
 			span.SetStatus(codes.Error, "failed to wrap physical plan with batching")
 			return nil, ErrNotSupported
 		}
+
+		e.metrics.observePhysicalShape(physicalPlanShapeOf(plan))
 
 		durPhysicalPlanning = timer.ObserveDuration()
 		level.Info(logger).Log(

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -264,6 +264,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	logicalPlan, err := e.buildLogicalPlan(ctx, q, params)
 	if err != nil {
 		e.metrics.query.subqueries.WithLabelValues(statusNotImplemented, q.queryType).Inc()
+		e.metrics.query.stageFailures.WithLabelValues(stageLogicalPlanning, statusNotImplemented, q.queryType).Inc()
 		q.RecordError(ctx, errors.New("failed to create logical plan"))
 		return logqlmodel.Result{}, ErrNotSupported
 	}
@@ -273,6 +274,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	physicalPlan, err := e.buildPhysicalPlan(ctx, q, params, catalog, logicalPlan)
 	if err != nil {
 		e.metrics.query.subqueries.WithLabelValues(statusFailure, q.queryType).Inc()
+		e.metrics.query.stageFailures.WithLabelValues(stagePhysicalPlanning, statusFailure, q.queryType).Inc()
 		q.RecordError(ctx, errors.New("failed to create physical plan"))
 		return logqlmodel.Result{}, ErrPlanningFailed
 	}
@@ -284,6 +286,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	wf, err := q.Prepare(ctx, physicalPlan, useAdmissionLanes)
 	if err != nil {
 		e.metrics.query.subqueries.WithLabelValues(statusFailure, q.queryType).Inc()
+		e.metrics.query.stageFailures.WithLabelValues(stagePrepare, statusFailure, q.queryType).Inc()
 		q.RecordError(ctx, errors.New("failed to create execution plan"))
 		return logqlmodel.Result{}, ErrPlanningFailed
 	}
@@ -295,6 +298,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 		level.Error(logger).Log("msg", "failed to execute query", "err", err)
 
 		e.metrics.query.subqueries.WithLabelValues(statusFailure, q.queryType).Inc()
+		e.metrics.query.stageFailures.WithLabelValues(stageExecution, statusFailure, q.queryType).Inc()
 		q.RecordError(ctx, errors.New("failed to execute query"))
 		return logqlmodel.Result{}, ErrSchedulingFailed
 	}
@@ -304,6 +308,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	builder, err := e.execute(ctx, q, params, pipeline)
 	if err != nil {
 		e.metrics.query.subqueries.WithLabelValues(statusFailure, q.queryType).Inc()
+		e.metrics.query.stageFailures.WithLabelValues(stageExecution, statusFailure, q.queryType).Inc()
 		q.RecordError(ctx, errors.New("error during query execution"))
 		return logqlmodel.Result{}, err
 	}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -261,7 +261,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 
 	logicalPlan, err := e.buildLogicalPlan(ctx, q, params)
 	if err != nil {
-		e.metrics.subqueries.WithLabelValues(statusNotImplemented).Inc()
+		e.metrics.query.subqueries.WithLabelValues(statusNotImplemented, q.queryType).Inc()
 		q.RecordError(ctx, errors.New("failed to create logical plan"))
 		return logqlmodel.Result{}, ErrNotSupported
 	}
@@ -270,7 +270,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	catalog := physical.NewMetastoreCatalog(e.metastoreSectionsResolver(ctx, q, engineLogger, cacheEnabled))
 	physicalPlan, err := e.buildPhysicalPlan(ctx, q, params, catalog, logicalPlan)
 	if err != nil {
-		e.metrics.subqueries.WithLabelValues(statusFailure).Inc()
+		e.metrics.query.subqueries.WithLabelValues(statusFailure, q.queryType).Inc()
 		q.RecordError(ctx, errors.New("failed to create physical plan"))
 		return logqlmodel.Result{}, ErrPlanningFailed
 	}
@@ -281,7 +281,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 
 	wf, err := q.Prepare(ctx, physicalPlan, useAdmissionLanes)
 	if err != nil {
-		e.metrics.subqueries.WithLabelValues(statusFailure).Inc()
+		e.metrics.query.subqueries.WithLabelValues(statusFailure, q.queryType).Inc()
 		q.RecordError(ctx, errors.New("failed to create execution plan"))
 		return logqlmodel.Result{}, ErrPlanningFailed
 	}
@@ -292,7 +292,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to execute query", "err", err)
 
-		e.metrics.subqueries.WithLabelValues(statusFailure).Inc()
+		e.metrics.query.subqueries.WithLabelValues(statusFailure, q.queryType).Inc()
 		q.RecordError(ctx, errors.New("failed to execute query"))
 		return logqlmodel.Result{}, ErrSchedulingFailed
 	}
@@ -301,7 +301,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	gotrace.Log(ctx, "collect_result", "start")
 	builder, err := e.execute(ctx, q, params, pipeline)
 	if err != nil {
-		e.metrics.subqueries.WithLabelValues(statusFailure).Inc()
+		e.metrics.query.subqueries.WithLabelValues(statusFailure, q.queryType).Inc()
 		q.RecordError(ctx, errors.New("error during query execution"))
 		return logqlmodel.Result{}, err
 	}
@@ -365,7 +365,7 @@ func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Pa
 	ctx, span := xcap.StartSpan(ctx, tracer, "Engine.buildLogicalPlan")
 	defer span.End()
 
-	timer := prometheus.NewTimer(e.metrics.logicalPlanning)
+	timer := prometheus.NewTimer(e.metrics.planning.logical.WithLabelValues(q.queryType))
 
 	var deleteReqs []*deletion.Request
 	if e.deleteGetter != nil {
@@ -412,7 +412,7 @@ func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.P
 	ctx, span := xcap.StartSpan(ctx, tracer, "Engine.buildPhysicalPlan")
 	defer span.End()
 
-	timer := prometheus.NewTimer(e.metrics.physicalPlanning)
+	timer := prometheus.NewTimer(e.metrics.planning.physical.WithLabelValues(q.queryType))
 
 	// TODO(rfratto): It feels strange that we need to past the start/end time
 	// to the physical planner. Isn't it already represented by the logical
@@ -526,7 +526,7 @@ func (e *Engine) metastoreSectionsResolver(ctx context.Context, parent *query, l
 
 		var plan *physical.Plan
 		{
-			timer := prometheus.NewTimer(e.metrics.physicalPlanning)
+			timer := prometheus.NewTimer(e.metrics.planning.physical.WithLabelValues(q.queryType))
 
 			plan, err = planner.Plan(ctx, selector, predicates, start, end)
 			if err != nil {
@@ -564,7 +564,7 @@ func (e *Engine) metastoreSectionsResolver(ctx context.Context, parent *query, l
 
 		var resp metastore.CollectSectionsResponse
 		{
-			timer := prometheus.NewTimer(e.metrics.execution)
+			timer := prometheus.NewTimer(e.metrics.execution.duration.WithLabelValues(q.queryType))
 
 			resp, err = e.metastore.CollectSections(ctx, metastore.CollectSectionsRequest{
 				// externalize EOFs returned by executor pipelines (executor.EOF -> io.EOF)
@@ -609,7 +609,7 @@ func (e *Engine) execute(ctx context.Context, q *query, params logql.Params, pip
 	ctx, span := xcap.StartSpan(ctx, tracer, "Engine.execute")
 	defer span.End()
 
-	timer := prometheus.NewTimer(e.metrics.execution)
+	timer := prometheus.NewTimer(e.metrics.execution.duration.WithLabelValues(q.queryType))
 
 	var builder ResultBuilder
 	switch params.GetExpression().(type) {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -242,6 +242,8 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 		"cache_enabled", cacheEnabled,
 	)
 
+	e.metrics.observeLogQLShape(q.queryType, logqlShapeOf(params.QueryString(), params.GetExpression()))
+
 	ctx, task := gotrace.NewTask(ctx, "Engine.Execute")
 	defer task.End()
 
@@ -384,7 +386,11 @@ func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Pa
 		return nil, ErrNotSupported
 	}
 
-	if err := logical.Optimize(logicalPlan); err != nil {
+	var opt logical.Optimizer
+	err = opt.Optimize(logicalPlan)
+	passes := opt.Report()
+	e.metrics.recordLogicalPasses(passes)
+	if err != nil {
 		level.Warn(q.Logger()).Log("msg", "failed to optimize logical plan", "err", err)
 		q.RecordError(ctx, err)
 		return nil, ErrNotSupported
@@ -398,6 +404,7 @@ func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Pa
 
 		"plan", logicalPlan.String(),
 		"duration_ms", duration.Milliseconds(),
+		"passes_fired", encodeLogicalPasses(passes),
 	)
 	span.SetAttributes(
 		attribute.Stringer("plan", logicalPlan),
@@ -432,6 +439,7 @@ func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.P
 		return nil, ErrNotSupported
 	}
 
+	var rules map[string]bool
 	{
 		optimizeStart := time.Now()
 
@@ -441,6 +449,8 @@ func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.P
 			q.RecordError(ctx, err)
 			return nil, ErrNotSupported
 		}
+		rules = planner.FiredRules()
+		e.metrics.recordPhysicalRules(rules)
 
 		optimizeDuration := time.Since(optimizeStart)
 		span.Record(statPhysicalOptimizeDuration.Observe(int64(optimizeDuration)))
@@ -456,7 +466,9 @@ func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.P
 	duration := timer.ObserveDuration()
 	span.Record(statPhysicalPlanDuration.Observe(int64(duration)))
 
-	printPhysicalPlanSummary(q, physicalPlan, duration)
+	e.metrics.observePhysicalShape(physicalPlanShapeOf(physicalPlan))
+
+	printPhysicalPlanSummary(q, physicalPlan, duration, rules)
 	span.SetAttributes(
 		attribute.String("plan", physical.PrintAsTree(physicalPlan)),
 	)
@@ -467,7 +479,7 @@ func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.P
 
 // printExecutionSummary prints a general summary of the execution, including
 // timing and cache information.
-func printPhysicalPlanSummary(q *query, plan *physical.Plan, duration time.Duration) {
+func printPhysicalPlanSummary(q *query, plan *physical.Plan, duration time.Duration, rules map[string]bool) {
 	var (
 		indexQueryDuration, _ = q.capture.Value(statPhysicalIndexQueryDuration).Int64()
 		optimizeDuration, _   = q.capture.Value(statPhysicalOptimizeDuration).Int64()
@@ -493,7 +505,7 @@ func printPhysicalPlanSummary(q *query, plan *physical.Plan, duration time.Durat
 			"other":       otherDuration,
 		}),
 
-		// TODO(rfratto): include stats on which optimization passes applied/didn't apply
+		"rules_fired", encodePhysicalRules(rules),
 
 		// Large plans result in log line truncation, retain the other
 		// kvs by moving this to the end.
@@ -537,7 +549,9 @@ func (e *Engine) metastoreSectionsResolver(ctx context.Context, parent *query, l
 			duration := timer.ObserveDuration()
 			q.rootRegion.Record(statPhysicalPlanDuration.Observe(int64(duration)))
 
-			printPhysicalPlanSummary(q, plan, duration)
+			// Index queries plan via planner.Plan and don't run the rule-based
+			// optimizer, so there are no rule firings to report here.
+			printPhysicalPlanSummary(q, plan, duration, nil)
 		}
 
 		// Disable admission lanes for metastore queries

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/units"
+	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
@@ -249,6 +250,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 
 	ctx, span := xcap.StartSpan(ctx, tracer, "Engine.Execute",
 		trace.WithAttributes(
+			attribute.Stringer("query_id", q.id),
 			attribute.String("type", string(logql.GetRangeType(params))),
 			attribute.String("query", params.QueryString()),
 			attribute.Stringer("start", params.Start()),
@@ -369,7 +371,9 @@ func isMetricQuery(expr syntax.Expr) bool {
 
 // buildLogicalPlan builds a logical plan from the given params.
 func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Params) (*logical.Plan, error) {
-	ctx, span := xcap.StartSpan(ctx, tracer, "Engine.buildLogicalPlan")
+	ctx, span := xcap.StartSpan(ctx, tracer, "Engine.buildLogicalPlan",
+		trace.WithAttributes(attribute.Stringer("query_id", q.id)),
+	)
 	defer span.End()
 
 	timer := prometheus.NewTimer(e.metrics.planning.logical.WithLabelValues(q.queryType))
@@ -421,7 +425,9 @@ func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Pa
 
 // buildPhysicalPlan builds a physical plan from the given logical plan.
 func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.Params, catalog *physical.MetastoreCatalog, logicalPlan *logical.Plan) (*physical.Plan, error) {
-	ctx, span := xcap.StartSpan(ctx, tracer, "Engine.buildPhysicalPlan")
+	ctx, span := xcap.StartSpan(ctx, tracer, "Engine.buildPhysicalPlan",
+		trace.WithAttributes(attribute.Stringer("query_id", q.id)),
+	)
 	defer span.End()
 
 	timer := prometheus.NewTimer(e.metrics.planning.physical.WithLabelValues(q.queryType))
@@ -624,10 +630,22 @@ func printMetastoreLocalitySummary(q *query, sectionsResolved int) {
 }
 
 // execute reads from the pipeline and produces a result.
-func (e *Engine) execute(ctx context.Context, q *query, params logql.Params, pipeline executor.Pipeline) (ResultBuilder, error) {
-	ctx, span := xcap.StartSpan(ctx, tracer, "Engine.execute")
+func (e *Engine) execute(ctx context.Context, q *query, params logql.Params, pipeline executor.Pipeline) (_ ResultBuilder, err error) {
+	ctx, span := xcap.StartSpan(ctx, tracer, "Engine.execute",
+		trace.WithAttributes(attribute.Stringer("query_id", q.id)),
+	)
 	defer span.End()
 
+	// Classify any non-EOF failure returned from result collection. EOF is
+	// handled inline and never escapes as an error, so a non-nil err here is
+	// always a real failure.
+	defer func() {
+		if err != nil {
+			e.metrics.execution.resultErrors.WithLabelValues(resultErrorClass(err)).Inc()
+		}
+	}()
+
+	executeStart := time.Now()
 	timer := prometheus.NewTimer(e.metrics.execution.duration.WithLabelValues(q.queryType))
 
 	var builder ResultBuilder
@@ -654,6 +672,11 @@ func (e *Engine) execute(ctx context.Context, q *query, params logql.Params, pip
 	var (
 		totalReadBatchTime    time.Duration
 		totalProcessBatchTime time.Duration
+		totalBatches          int64
+		totalBytes            int64
+
+		gotFirstBatch    bool
+		timeToFirstBatch time.Duration
 	)
 
 	for {
@@ -673,6 +696,13 @@ func (e *Engine) execute(ctx context.Context, q *query, params logql.Params, pip
 			return builder, err
 		}
 
+		if !gotFirstBatch {
+			gotFirstBatch = true
+			timeToFirstBatch = time.Since(executeStart)
+		}
+		totalBatches++
+		totalBytes += recordBatchBytes(rec)
+
 		startTime = time.Now()
 		builder.CollectRecord(rec)
 		totalProcessBatchTime += time.Since(startTime)
@@ -683,11 +713,52 @@ func (e *Engine) execute(ctx context.Context, q *query, params logql.Params, pip
 	span.Record(statReadBatchDuration.Observe(int64(totalReadBatchTime)))
 	span.Record(statProcessBatchDuration.Observe(int64(totalProcessBatchTime)))
 
+	// Result-collection observability, observed once per query.
+	e.metrics.execution.resultRows.Observe(float64(builder.Len()))
+	e.metrics.execution.timeToFirstBatch.WithLabelValues(q.queryType).Observe(timeToFirstBatch.Seconds())
+	e.metrics.execution.resultGetBatch.Observe(totalReadBatchTime.Seconds())
+	e.metrics.execution.resultProcess.Observe(totalProcessBatchTime.Seconds())
+	e.metrics.execution.resultSizeBytes.Observe(float64(totalBytes))
+	e.metrics.execution.batchesAccumulated.Add(float64(totalBatches))
+	e.metrics.execution.bytesAccumulated.Add(float64(totalBytes))
+
+	// Mirror the per-query result stats onto the capture so they can be
+	// surfaced on the execution-summary log line.
+	span.Record(statResultRows.Observe(int64(builder.Len())))
+	span.Record(statTimeToFirstBatch.Observe(int64(timeToFirstBatch)))
+	span.Record(statResultSizeBytes.Observe(totalBytes))
+
 	printExecutionSummary(q, duration)
 	printLogLocalitySummary(q)
 
 	span.SetStatus(codes.Ok, "")
 	return builder, nil
+}
+
+// recordBatchBytes returns the total in-memory size in bytes of all column
+// buffers in a RecordBatch.
+func recordBatchBytes(rec arrow.RecordBatch) int64 {
+	var n int64
+	for i := 0; i < int(rec.NumCols()); i++ {
+		n += int64(rec.Column(i).Data().SizeInBytes())
+	}
+	return n
+}
+
+// resultErrorClass classifies a result-collection error into one of a small,
+// bounded set of label values to keep metric cardinality fixed. Unrecognized
+// errors are reported as "other".
+func resultErrorClass(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "deadline_exceeded"
+	default:
+		return "other"
+	}
 }
 
 // printExecutionSummary prints a general summary of the execution, including
@@ -701,6 +772,10 @@ func printExecutionSummary(q *query, duration time.Duration) {
 		otherDuration           = calculateResidual(duration, readBatchDuration, processBatchDuration)
 
 		logSections = xcap.Value[int64](q.capture, xcap.StatMetastoreSectionsResolved)
+
+		resultRows, _       = q.capture.Value(statResultRows).Int64()
+		timeToFirstBatch, _ = q.capture.Value(statTimeToFirstBatch).Int64()
+		resultSizeBytes, _  = q.capture.Value(statResultSizeBytes).Int64()
 
 		tasksPruned           = xcap.Value[int64](q.capture, workflow.StatPrunedTasks)
 		tasksPlanned          = xcap.Value[int64](q.capture, scheduler.StatPlannedTasks)
@@ -731,6 +806,11 @@ func printExecutionSummary(q *query, duration time.Duration) {
 		"duration_read_batch_ms", time.Duration(readBatchDuration).Milliseconds(),
 		"duration_process_batch_ms", time.Duration(processBatchDuration).Milliseconds(),
 		"duration_other_ms", otherDuration.Milliseconds(),
+
+		// Result info
+		"result_rows", resultRows,
+		"time_to_first_batch_ms", time.Duration(timeToFirstBatch).Milliseconds(),
+		"result_size_bytes", resultSizeBytes,
 
 		"dominant_phase", calculateDominantPhase(map[string]time.Duration{
 			"read_batch":    time.Duration(readBatchDuration),

--- a/pkg/engine/engine_query.go
+++ b/pkg/engine/engine_query.go
@@ -106,7 +106,7 @@ func (q *query) Prepare(ctx context.Context, plan *physical.Plan, useAdmissionLa
 	ctx, span := xcap.StartSpan(ctx, tracer, "query.Prepare")
 	defer span.End()
 
-	timer := prometheus.NewTimer(q.engine.metrics.workflowPlanning)
+	timer := prometheus.NewTimer(q.engine.metrics.planning.prepare.WithLabelValues(q.queryType))
 
 	var maxRunningScanTasks int
 	if useAdmissionLanes {

--- a/pkg/engine/engine_query.go
+++ b/pkg/engine/engine_query.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
 	"github.com/grafana/loki/v3/pkg/xcap"
@@ -201,6 +202,31 @@ func (q *query) Close() {
 
 		otherDuration = calculateResidual(q.finishTime.Sub(q.startTime), logicalPlanDuration, physicalPlanDuration, prepareDuration, executeDuration)
 	)
+
+	m := q.engine.metrics
+
+	// The residual histogram mirrors the duration_other_ms field on the
+	// query-summary line below and is observed for every query.
+	m.query.other.WithLabelValues(q.queryType).Observe(otherDuration.Seconds())
+
+	// Fan-out histograms count tasks per query, matching how printExecutionSummary
+	// computes them: tasksPlanned is the count after pruning, and the pre-pruning
+	// total is tasksPruned + tasksPlanned.
+	//
+	// Queries that fail during logical or physical planning never generate any
+	// tasks, so observing them would flood the histograms with zeros that say
+	// nothing about fan-out. We only observe once at least one task was generated;
+	// a query that generated tasks but had them all pruned legitimately records a
+	// tasks_per_query of zero.
+	var (
+		tasksPlanned   = xcap.Value[int64](q.capture, scheduler.StatPlannedTasks)
+		tasksPruned    = xcap.Value[int64](q.capture, workflow.StatPrunedTasks)
+		tasksGenerated = tasksPruned + tasksPlanned
+	)
+	if tasksGenerated > 0 {
+		m.execution.tasksPerQuery.WithLabelValues(q.queryType).Observe(float64(tasksPlanned))
+		m.execution.tasksGenerated.WithLabelValues(q.queryType).Observe(float64(tasksGenerated))
+	}
 
 	q.logger.Log(
 		"msg", "query-summary",

--- a/pkg/engine/engine_query_test.go
+++ b/pkg/engine/engine_query_test.go
@@ -1,0 +1,79 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler"
+	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
+)
+
+// TestQueryClose_FanoutObservation pins the decision that the per-query fan-out
+// histograms are observed only once a query has generated at least one task, so
+// queries that fail during planning don't flood the histograms with zeros. The
+// residual duration histogram is observed unconditionally.
+func TestQueryClose_FanoutObservation(t *testing.T) {
+	tests := []struct {
+		name         string
+		tasksPlanned int64
+		tasksPruned  int64
+		recordTasks  bool
+		wantFanout   bool
+	}{
+		{
+			name:        "failed during planning observes no fan-out",
+			recordTasks: false,
+			wantFanout:  false,
+		},
+		{
+			name:         "query that generated tasks observes fan-out",
+			tasksPlanned: 4,
+			tasksPruned:  1,
+			recordTasks:  true,
+			wantFanout:   true,
+		},
+		{
+			name:         "all tasks pruned still observes fan-out",
+			tasksPlanned: 0,
+			tasksPruned:  3,
+			recordTasks:  true,
+			wantFanout:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := prometheus.NewRegistry()
+			e := &Engine{
+				logger:  log.NewNopLogger(),
+				metrics: newMetrics(reg),
+			}
+
+			ctx := user.InjectOrgID(t.Context(), "test-tenant")
+			q, _, err := e.newQuery(ctx, log.NewNopLogger(), "logs", false)
+			require.NoError(t, err)
+
+			if tt.recordTasks {
+				q.rootRegion.Record(scheduler.StatPlannedTasks.Observe(tt.tasksPlanned))
+				q.rootRegion.Record(workflow.StatPrunedTasks.Observe(tt.tasksPruned))
+			}
+
+			q.Close()
+
+			// The residual duration histogram is always observed.
+			require.Equal(t, 1, testutil.CollectAndCount(e.metrics.query.other), "residual duration always observed")
+
+			wantSeries := 0
+			if tt.wantFanout {
+				wantSeries = 1
+			}
+			require.Equal(t, wantSeries, testutil.CollectAndCount(e.metrics.execution.tasksPerQuery), "tasks_per_query observation")
+			require.Equal(t, wantSeries, testutil.CollectAndCount(e.metrics.execution.tasksGenerated), "tasks_generated_per_query observation")
+		})
+	}
+}

--- a/pkg/engine/internal/planner/logical/logical_optimize.go
+++ b/pkg/engine/internal/planner/logical/logical_optimize.go
@@ -12,17 +12,54 @@ import (
 )
 
 type optimizationPass interface {
-	Apply(*Plan) error
+	// Name returns a stable, bounded identifier for the pass, used as a metric
+	// label and in plan-summary logs.
+	Name() string
+	// Apply runs the pass on p. It reports whether it changed the plan
+	// (applied) and any error encountered.
+	Apply(p *Plan) (applied bool, err error)
+}
+
+// PassFiring records the outcome of a single logical optimizer pass: whether it
+// changed the plan (Applicable), whether it ran without error (Succeeded), and
+// the error if it failed.
+type PassFiring struct {
+	Name       string
+	Applicable bool
+	Succeeded  bool
+	Err        error
 }
 
 // Optimize performs optimizations on p.
 func Optimize(p *Plan) error {
+	var o Optimizer
+	return o.Optimize(p)
+}
+
+// Optimizer runs the logical optimization passes on a plan, recording the
+// outcome of each pass for observability.
+type Optimizer struct {
+	firings []PassFiring
+}
+
+// Optimize performs optimizations on p and records the firing of each pass
+// into the receiver. The recorded report includes the pass that failed (if
+// any), so callers can record observability even when optimization fails.
+func (o *Optimizer) Optimize(p *Plan) error {
 	passes := []optimizationPass{
 		simplifyRegexPass{},
 	}
 
+	o.firings = make([]PassFiring, 0, len(passes))
 	for _, pass := range passes {
-		if err := pass.Apply(p); err != nil {
+		applied, err := pass.Apply(p)
+		o.firings = append(o.firings, PassFiring{
+			Name:       pass.Name(),
+			Applicable: applied,
+			Succeeded:  err == nil,
+			Err:        err,
+		})
+		if err != nil {
 			return err
 		}
 	}
@@ -35,10 +72,19 @@ func Optimize(p *Plan) error {
 	return nil
 }
 
+// Report returns the firing of each pass from the most recent call to
+// [Optimizer.Optimize]. It returns nil if Optimize has not been called.
+func (o *Optimizer) Report() []PassFiring {
+	return o.firings
+}
+
 type simplifyRegexPass struct{}
 
-func (pass simplifyRegexPass) Apply(p *Plan) error {
+func (pass simplifyRegexPass) Name() string { return "SimplifyRegex" }
+
+func (pass simplifyRegexPass) Apply(p *Plan) (bool, error) {
 	var operandBuffer []*Value
+	applied := false
 
 	// NOTE(rfratto): We can't do a range loop here because we're modifying the
 	// slice as we iterate over it.
@@ -51,17 +97,18 @@ func (pass simplifyRegexPass) Apply(p *Plan) error {
 
 		simplified, changed, err := pass.simplifyBinop(b)
 		if err != nil {
-			return err
+			return applied, err
 		} else if !changed {
 			// No simplification performed.
 			continue
 		}
+		applied = true
 
 		// The final element in simplified becomes the "return" of the regex
 		// simplification, and is what other nodes will now reference.
 		newValue, ok := simplified[len(simplified)-1].(Value)
 		if !ok {
-			return fmt.Errorf("expected regex simplify to end in a Value")
+			return applied, fmt.Errorf("expected regex simplify to end in a Value")
 		}
 
 		instrs := extractInstructions(simplified)
@@ -84,7 +131,7 @@ func (pass simplifyRegexPass) Apply(p *Plan) error {
 		}
 	}
 
-	return nil
+	return applied, nil
 }
 
 func (pass simplifyRegexPass) shouldApply(b *BinOp) bool {

--- a/pkg/engine/internal/planner/logical/logical_optimize_test.go
+++ b/pkg/engine/internal/planner/logical/logical_optimize_test.go
@@ -67,6 +67,53 @@ RETURN %25
 	require.Equal(t, expect, actual, "Actual plan:\n%s", actual)
 }
 
+func TestOptimizer_Report(t *testing.T) {
+	tests := []struct {
+		name           string
+		query          string
+		wantApplicable bool
+	}{
+		{
+			name:           "regex line filter is simplified",
+			query:          `{job="loki"} |~ "error|fatal"`,
+			wantApplicable: true,
+		},
+		{
+			name:           "no regex to simplify",
+			query:          `{job="loki"} |= "error"`,
+			wantApplicable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params, err := logql.NewLiteralParams(
+				tt.query,
+				time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2025, time.January, 2, 0, 0, 0, 0, time.UTC),
+				0 /* step */, 0, /* duration */
+				logproto.BACKWARD,
+				1000,
+				[]string{"0_of_1"},
+				nil,
+			)
+			require.NoError(t, err)
+
+			p, err := BuildPlan(context.Background(), params)
+			require.NoError(t, err)
+
+			var opt Optimizer
+			err = opt.Optimize(p)
+			require.NoError(t, err)
+			require.Equal(t, []PassFiring{{
+				Name:       "SimplifyRegex",
+				Applicable: tt.wantApplicable,
+				Succeeded:  true,
+			}}, opt.Report())
+		})
+	}
+}
+
 func Test_simplifyRegexPass_IgnoreStreamSelector(t *testing.T) {
 	// See comment in logical_optimize.go for why stream selectors can't have
 	// regex simplification rules applied yet.

--- a/pkg/engine/internal/planner/physical/optimizer.go
+++ b/pkg/engine/internal/planner/physical/optimizer.go
@@ -37,8 +37,11 @@ func (o *Optimization) withRules(rules ...rule) *Optimization {
 	return o
 }
 
-func (o *Optimization) optimize(node Node) {
+// optimize runs the optimization to a fixed point and reports whether it changed
+// the node at least once.
+func (o *Optimization) optimize(node Node) bool {
 	iterations, maxIterations := 0, 10
+	applied := false
 
 	for iterations < maxIterations {
 		iterations++
@@ -47,7 +50,10 @@ func (o *Optimization) optimize(node Node) {
 			// Stop immediately if an optimization pass produced no changes.
 			break
 		}
+		applied = true
 	}
+
+	return applied
 }
 
 func (o *Optimization) applyRules(node Node) bool {
@@ -72,10 +78,15 @@ func NewOptimizer(plan *Plan, passes []*Optimization) *Optimizer {
 	return &Optimizer{plan: plan, optimisations: passes}
 }
 
-func (o *Optimizer) Optimize(node Node) {
+// Optimize runs every optimization pass over node and returns a map from
+// optimization name to whether it applied at least once.
+func (o *Optimizer) Optimize(node Node) map[string]bool {
+	firings := make(map[string]bool, len(o.optimisations))
 	for _, optimisation := range o.optimisations {
-		optimisation.optimize(node)
+		applied := optimisation.optimize(node)
+		firings[optimisation.name] = applied
 	}
+	return firings
 }
 
 // addUniqueColumnExpr adds a column to the projections list if it's not already present

--- a/pkg/engine/internal/planner/physical/optimizer_test.go
+++ b/pkg/engine/internal/planner/physical/optimizer_test.go
@@ -1,6 +1,10 @@
 package physical
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
 )
@@ -37,4 +41,32 @@ func dummyPlan() *Plan {
 	_ = plan.graph.AddEdge(dag.Edge[Node]{Parent: filter1, Child: scanSet})
 
 	return plan
+}
+
+// countingRule fires (returns true) a fixed number of times before reporting no
+// further changes, mimicking a rule that reaches a fixed point.
+type countingRule struct{ fires int }
+
+func (r *countingRule) apply(Node) bool {
+	if r.fires <= 0 {
+		return false
+	}
+	r.fires--
+	return true
+}
+
+func TestOptimizer_Optimize_RuleFirings(t *testing.T) {
+	plan := dummyPlan()
+	root := plan.Roots()[0]
+
+	optimizer := NewOptimizer(plan, []*Optimization{
+		newOptimization("Applied", plan).withRules(&countingRule{fires: 2}),
+		newOptimization("NotApplied", plan).withRules(&countingRule{fires: 0}),
+	})
+
+	firings := optimizer.Optimize(root)
+	require.Equal(t, map[string]bool{
+		"Applied":    true,
+		"NotApplied": false,
+	}, firings)
 }

--- a/pkg/engine/internal/planner/physical/planner.go
+++ b/pkg/engine/internal/planner/physical/planner.go
@@ -91,6 +91,17 @@ type Planner struct {
 	context *Context
 	catalog Catalog
 	plan    *Plan
+
+	// firedRules holds the rule firings from the most recent call to
+	// Optimize, so callers can surface them as observability without changing
+	// the Optimize signature.
+	firedRules map[string]bool
+}
+
+// FiredRules returns the rule firings recorded by the most recent call to
+// [Planner.Optimize]. It returns nil if Optimize has not been called.
+func (p *Planner) FiredRules() map[string]bool {
+	return p.firedRules
 }
 
 // NewPlanner creates a new planner instance with the given context.
@@ -749,6 +760,7 @@ func disambiguateExpression(expr Expression, conflictingLabels []string) (Expres
 // Optimize runs optimization passes over the plan, modifying it
 // if any optimizations can be applied.
 func (p *Planner) Optimize(plan *Plan) (*Plan, error) {
+	p.firedRules = nil
 	for i, root := range plan.Roots() {
 		optimizations := []*Optimization{
 			newOptimization("PredicatePushdown", plan).withRules(
@@ -776,7 +788,14 @@ func (p *Planner) Optimize(plan *Plan) (*Plan, error) {
 			),
 		}
 		optimizer := NewOptimizer(plan, optimizations)
-		optimizer.Optimize(root)
+		fired := optimizer.Optimize(root)
+		if p.firedRules == nil {
+			p.firedRules = fired
+		} else {
+			for name, applied := range fired {
+				p.firedRules[name] = p.firedRules[name] || applied
+			}
+		}
 		if i == 1 {
 			return nil, errors.New("physical plan must only have exactly one root node")
 		}

--- a/pkg/engine/internal/planner/physical/planner_test.go
+++ b/pkg/engine/internal/planner/physical/planner_test.go
@@ -249,6 +249,17 @@ func TestPlanner_Convert(t *testing.T) {
 	physicalPlan, err = planner.Optimize(physicalPlan)
 	require.NoError(t, err)
 	t.Logf("Optimized plan\n%s\n", PrintAsTree(physicalPlan))
+
+	// Optimize records a firing for every optimization pass, each with a stable
+	// name.
+	firings := planner.FiredRules()
+	require.NotEmpty(t, firings)
+	names := make([]string, 0, len(firings))
+	for name := range firings {
+		require.NotEmpty(t, name)
+		names = append(names, name)
+	}
+	require.Subset(t, names, []string{"PredicatePushdown", "ProjectionPushdown"})
 }
 
 func TestPlanner_Convert_WithParse(t *testing.T) {

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -629,6 +629,7 @@ func (s *Scheduler) requeueTask(t *task, pos fair.Position) {
 	// Undo the scope cost that was applied when the task was popped.
 	_ = s.taskQueue.AdjustScope(t.scope, -1)
 
+	t.MarkRequeued()
 	s.metrics.requeueTotal.Inc()
 
 	if len(s.readyWorkers) > 0 {

--- a/pkg/engine/internal/scheduler/schedulerstat/schedulerstat.go
+++ b/pkg/engine/internal/scheduler/schedulerstat/schedulerstat.go
@@ -37,4 +37,14 @@ var (
 	// sum of the partitions is a residual that indicates an unaccounted-for
 	// phase.
 	TaskTotalDuration = xcap.NewStatisticInt64("scheduler.task.duration", xcap.AggregationTypeSum)
+
+	// TaskFinishTime is the wall-clock time (Unix nanoseconds) at which the
+	// scheduler observed the task reach a terminal state. It is recorded once
+	// per task and rides the task's capture back to the workflow, which uses it
+	// to approximate the query's critical path.
+	//
+	// AggregationTypeMax keeps the latest observed finish time when captures are
+	// merged; the per-task read in the workflow is unaffected because each task
+	// records this stat exactly once.
+	TaskFinishTime = xcap.NewStatisticInt64("scheduler.task.finish.time", xcap.AggregationTypeMax)
 )

--- a/pkg/engine/internal/scheduler/schedulerstat/schedulerstat.go
+++ b/pkg/engine/internal/scheduler/schedulerstat/schedulerstat.go
@@ -24,6 +24,10 @@ var (
 	// never reached a worker.
 	TaskExecutionDuration = xcap.NewStatisticInt64("scheduler.task.execution.duration", xcap.AggregationTypeSum)
 
+	// TaskAssignmentRetries is the number of times a task was requeued after a
+	// failed assignment attempt before it reached a terminal state.
+	TaskAssignmentRetries = xcap.NewStatisticInt64("scheduler.task.assignment.retries", xcap.AggregationTypeSum)
+
 	// TaskTotalDuration is the total time (in nanoseconds) from scheduler
 	// registration to terminal state, regardless of which phases the task
 	// passed through.

--- a/pkg/engine/internal/scheduler/task.go
+++ b/pkg/engine/internal/scheduler/task.go
@@ -28,6 +28,7 @@ type task struct {
 	queueTime   time.Time // Time when task was enqueued.
 	assignTime  time.Time // Time when task was assigned to a worker.
 	interrupted bool      // Cancellation requested but not yet confirmed.
+	requeues    int       // Number of times the task was requeued after a failed assignment.
 
 	// capture holds individual task information from any source:
 	//
@@ -153,6 +154,14 @@ func (t *task) MarkQueued() {
 	t.queueTime = time.Now()
 }
 
+// MarkRequeued records that the task was requeued after a failed assignment
+// attempt, incrementing its assignment retry count.
+func (t *task) MarkRequeued() {
+	t.mut.Lock()
+	defer t.mut.Unlock()
+	t.requeues++
+}
+
 // MarkInterrupted records that cancellation has been requested for this task.
 func (t *task) MarkInterrupted() bool {
 	t.mut.Lock()
@@ -208,8 +217,10 @@ func (t *task) TryAssign(doAssign func() error) error {
 // the task has reached a terminal state.
 func (t *task) RecordTerminalObservations(now time.Time) {
 	t.mut.RLock()
-	queueTime, assignTime := t.queueTime, t.assignTime
+	queueTime, assignTime, requeues := t.queueTime, t.assignTime, t.requeues
 	t.mut.RUnlock()
+
+	t.region.Record(schedulerstat.TaskAssignmentRetries.Observe(int64(requeues)))
 
 	if !queueTime.IsZero() && assignTime.IsZero() {
 		t.region.Record(schedulerstat.TaskQueueDuration.Observe(now.Sub(queueTime).Nanoseconds()))

--- a/pkg/engine/internal/scheduler/task.go
+++ b/pkg/engine/internal/scheduler/task.go
@@ -213,6 +213,9 @@ func (t *task) TryAssign(doAssign func() error) error {
 //     was assigned to a worker.
 //   - [schedulerstat.TaskTotalDuration] is always recorded.
 //
+// It also records [schedulerstat.TaskFinishTime], the absolute terminal
+// timestamp, which the workflow uses to approximate the query's critical path.
+//
 // RecordTerminalObservations must only be called once per task and only when
 // the task has reached a terminal state.
 func (t *task) RecordTerminalObservations(now time.Time) {
@@ -229,5 +232,6 @@ func (t *task) RecordTerminalObservations(now time.Time) {
 		t.region.Record(schedulerstat.TaskExecutionDuration.Observe(now.Sub(assignTime).Nanoseconds()))
 	}
 	t.region.Record(schedulerstat.TaskTotalDuration.Observe(now.Sub(t.createTime).Nanoseconds()))
+	t.region.Record(schedulerstat.TaskFinishTime.Observe(now.UnixNano()))
 	t.region.End()
 }

--- a/pkg/engine/internal/scheduler/task_test.go
+++ b/pkg/engine/internal/scheduler/task_test.go
@@ -1,0 +1,44 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/schedulerstat"
+	"github.com/grafana/loki/v3/pkg/xcap"
+)
+
+func TestTask_AssignmentRetries(t *testing.T) {
+	tests := []struct {
+		name     string
+		requeues int
+	}{
+		{name: "no retries", requeues: 0},
+		{name: "single retry", requeues: 1},
+		{name: "multiple retries", requeues: 3},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			captureCtx, capture := xcap.NewCapture(t.Context(), nil)
+			_, region := xcap.StartRegion(captureCtx, "scheduler")
+
+			task := &task{
+				createTime: time.Now(),
+				capture:    capture,
+				region:     region,
+			}
+
+			for range tc.requeues {
+				task.MarkRequeued()
+			}
+
+			task.RecordTerminalObservations(time.Now())
+
+			require.Equal(t, int64(tc.requeues), xcap.Value[int64](capture, schedulerstat.TaskAssignmentRetries),
+				"assignment retry count should equal the number of requeues")
+		})
+	}
+}

--- a/pkg/engine/internal/scheduler/wire/metrics.go
+++ b/pkg/engine/internal/scheduler/wire/metrics.go
@@ -65,7 +65,7 @@ func (m *Metrics) incMessageQueued() {
 }
 
 func (m *Metrics) decMessageQueued() {
-	m.messagesQueued.Inc()
+	m.messagesQueued.Dec()
 }
 
 func (m *Metrics) incMessageSent(messageType string) {

--- a/pkg/engine/internal/scheduler/wire/metrics.go
+++ b/pkg/engine/internal/scheduler/wire/metrics.go
@@ -13,8 +13,8 @@ type Metrics struct {
 
 	framesReceivedTotal *prometheus.CounterVec
 	messagesQueued      prometheus.Gauge
-	messagesSentTotal   prometheus.Counter
-	messageRTTSeconds   prometheus.Histogram
+	messagesSentTotal   *prometheus.CounterVec
+	messageRTTSeconds   *prometheus.HistogramVec
 }
 
 func NewMetrics() *Metrics {
@@ -25,30 +25,39 @@ func NewMetrics() *Metrics {
 		framesReceivedTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_engine_scheduler_wire_frames_received_total",
 			Help: "Total number of frames received by the wire",
-		}, []string{"type"}),
+		}, []string{"type", "message_type"}),
 		messagesQueued: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "loki_engine_scheduler_wire_messages_queued",
 			Help: "Number of messages queued by the wire",
 		}),
-		messagesSentTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		messagesSentTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_engine_scheduler_wire_messages_sent_total",
 			Help: "Number of messages sent by a peer",
-		}),
-		messageRTTSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		}, []string{"message_type"}),
+		messageRTTSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "loki_engine_scheduler_wire_message_rtt_seconds",
 			Help:                            "Round-trip time to synchronously send a message to another peer",
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
-		}),
+		}, []string{"message_type"}),
 	}
 }
 
 func (m *Metrics) Register(reg prometheus.Registerer) error { return reg.Register(m.reg) }
 func (m *Metrics) Unregister(reg prometheus.Registerer)     { reg.Unregister(m.reg) }
 
-func (m *Metrics) incFrameReceived(frameType string) {
-	m.framesReceivedTotal.WithLabelValues(frameType).Inc()
+func (m *Metrics) incFrameReceived(frame Frame) {
+	m.framesReceivedTotal.WithLabelValues(frame.FrameKind().String(), frameMessageType(frame)).Inc()
+}
+
+// frameMessageType returns the application [MessageKind] carried by frame, or
+// "none" for frames that don't carry a message (acks, nacks, discards).
+func frameMessageType(frame Frame) string {
+	if mf, ok := frame.(MessageFrame); ok && mf.Message != nil {
+		return mf.Message.Kind().String()
+	}
+	return "none"
 }
 
 func (m *Metrics) incMessageQueued() {
@@ -59,10 +68,10 @@ func (m *Metrics) decMessageQueued() {
 	m.messagesQueued.Inc()
 }
 
-func (m *Metrics) incMessageSent() {
-	m.messagesSentTotal.Inc()
+func (m *Metrics) incMessageSent(messageType string) {
+	m.messagesSentTotal.WithLabelValues(messageType).Inc()
 }
 
-func (m *Metrics) newMessageRTTTimer() *prometheus.Timer {
-	return prometheus.NewTimer(m.messageRTTSeconds)
+func (m *Metrics) newMessageRTTTimer(messageType string) *prometheus.Timer {
+	return prometheus.NewTimer(m.messageRTTSeconds.WithLabelValues(messageType))
 }

--- a/pkg/engine/internal/scheduler/wire/peer.go
+++ b/pkg/engine/internal/scheduler/wire/peer.go
@@ -83,7 +83,7 @@ func (p *Peer) recvMessages(ctx context.Context) error {
 			return err
 		}
 
-		p.Metrics.incFrameReceived(frame.FrameKind().String())
+		p.Metrics.incFrameReceived(frame)
 
 		switch frame := frame.(type) {
 		case MessageFrame:
@@ -237,9 +237,9 @@ func (p *Peer) SendMessage(ctx context.Context, message Message) error {
 	p.sentRequests.Store(reqID, req)
 	defer p.sentRequests.Delete(reqID)
 
-	timer := p.Metrics.newMessageRTTTimer()
+	timer := p.Metrics.newMessageRTTTimer(message.Kind().String())
 	defer timer.ObserveDuration()
-	p.Metrics.incMessageSent()
+	p.Metrics.incMessageSent(message.Kind().String())
 
 	if err := p.enqueueFrame(ctx, MessageFrame{ID: reqID, Message: message}); err != nil {
 		return err
@@ -266,7 +266,7 @@ func (p *Peer) SendMessageAsync(ctx context.Context, message Message) error {
 	p.lazyInit()
 
 	reqID := p.requestID.Inc()
-	p.Metrics.incMessageSent()
+	p.Metrics.incMessageSent(message.Kind().String())
 	return p.enqueueFrame(ctx, MessageFrame{ID: reqID, Message: message})
 }
 

--- a/pkg/engine/internal/worker/metrics.go
+++ b/pkg/engine/internal/worker/metrics.go
@@ -7,22 +7,47 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+// Task type label values used to partition per-task worker metrics. A leaf task
+// reads directly from storage (it has no external task sources); a non-leaf
+// task receives its input from one or more child tasks.
+const (
+	taskTypeLeaf    = "leaf"
+	taskTypeNonLeaf = "non_leaf"
+)
+
 // metrics is a container of metrics for a worker.
 type metrics struct {
 	// registry to collect metrics as a unit.
 	reg *prometheus.Registry
 
-	tasksAssignedTotal prometheus.Counter
-	taskExecSeconds    prometheus.Histogram
+	tasksAssignedTotal       prometheus.Counter
+	rejectedAssignmentsTotal prometheus.Counter
+	taskExecSeconds          *prometheus.HistogramVec
 
 	// Per-pass phase durations (one observation per loop iteration).
 	passComputeSeconds prometheus.Histogram
 	passWriteSeconds   prometheus.Histogram
 
-	// Task-wide phase durations (one observation per drainPipeline call).
-	taskReadSeconds    prometheus.Histogram
-	taskComputeSeconds prometheus.Histogram
-	taskWriteSeconds   prometheus.Histogram
+	// Task-wide phase durations (one observation per drainPipeline call),
+	// partitioned by task_type.
+	taskReadSeconds    *prometheus.HistogramVec
+	taskComputeSeconds *prometheus.HistogramVec
+	taskWriteSeconds   *prometheus.HistogramVec
+
+	// setupSeconds measures the time spent preparing a task for execution
+	// (before draining its pipeline), partitioned by task_type.
+	setupSeconds *prometheus.HistogramVec
+
+	// Task status-update send path (worker -> scheduler).
+	statusUpdateSeconds     prometheus.Histogram
+	statusUpdateErrorsTotal *prometheus.CounterVec
+
+	// Task I/O counters, read from per-task captures at task completion. Only
+	// leaf tasks download from object storage today, so these are zero for
+	// non-leaf tasks until that changes.
+	pagesDownloadedTotal prometheus.Counter
+	pagesPrunedTotal     prometheus.Counter
+	bytesDownloadedTotal prometheus.Counter
 }
 
 func newMetrics() *metrics {
@@ -35,14 +60,18 @@ func newMetrics() *metrics {
 			Name: "loki_engine_worker_tasks_assigned_total",
 			Help: "Total number of tasks assigned to the worker",
 		}),
-		taskExecSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		rejectedAssignmentsTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "loki_engine_worker_rejected_assignments_total",
+			Help: "Total number of task assignments the worker rejected because no thread slot was available (worker-side counterpart to the scheduler's assignment_backoffs_total)",
+		}),
+		taskExecSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name: "loki_engine_worker_task_exec_seconds",
 			Help: "Number of seconds a task took to complete successfully",
 
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
-		}),
+		}, []string{"task_type"}),
 
 		passComputeSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name: "loki_engine_worker_pass_compute_seconds",
@@ -61,29 +90,64 @@ func newMetrics() *metrics {
 			NativeHistogramMinResetDuration: time.Hour,
 		}),
 
-		taskReadSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		taskReadSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name: "loki_engine_worker_task_read_seconds",
 			Help: "Total time spent in the read phase for a task",
 
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
-		}),
-		taskComputeSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		}, []string{"task_type"}),
+		taskComputeSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name: "loki_engine_worker_task_compute_seconds",
 			Help: "Total time spent in the compute phase for a task",
 
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
-		}),
-		taskWriteSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		}, []string{"task_type"}),
+		taskWriteSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name: "loki_engine_worker_task_write_seconds",
 			Help: "Total time spent in the write phase for a task",
 
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"task_type"}),
+
+		setupSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name: "loki_engine_worker_setup_seconds",
+			Help: "Time spent preparing a task for execution before its pipeline is drained",
+
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"task_type"}),
+
+		statusUpdateSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name: "loki_engine_worker_status_update_seconds",
+			Help: "Time spent sending a task's terminal status update to the scheduler and waiting for acknowledgement",
+
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		}),
+		statusUpdateErrorsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_worker_status_update_errors_total",
+			Help: "Total number of failures sending a task's terminal status update to the scheduler, by error class",
+		}, []string{"error_class"}),
+
+		pagesDownloadedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "loki_engine_worker_pages_downloaded_total",
+			Help: "Total number of pages downloaded from object storage during task execution",
+		}),
+		pagesPrunedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "loki_engine_worker_pages_pruned_total",
+			Help: "Total number of pages pruned via metadata before download during task execution",
+		}),
+		bytesDownloadedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "loki_engine_worker_bytes_downloaded_total",
+			Help: "Total number of bytes downloaded from object storage during task execution",
 		}),
 	}
 }

--- a/pkg/engine/internal/worker/metrics_helpers_test.go
+++ b/pkg/engine/internal/worker/metrics_helpers_test.go
@@ -1,0 +1,71 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
+	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
+)
+
+func TestTaskTypeLabel(t *testing.T) {
+	node := &physical.Limit{NodeID: ulid.Make()}
+
+	tests := []struct {
+		name string
+		task *workflow.Task
+		want string
+	}{
+		{
+			name: "no sources is leaf",
+			task: &workflow.Task{},
+			want: taskTypeLeaf,
+		},
+		{
+			name: "with sources is non-leaf",
+			task: &workflow.Task{
+				Sources: map[physical.Node][]*workflow.Stream{
+					node: {{ULID: ulid.Make()}},
+				},
+			},
+			want: taskTypeNonLeaf,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, taskTypeLabel(tt.task))
+		})
+	}
+}
+
+func TestStatusUpdateErrorClass(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "nil", err: nil, want: "none"},
+		{name: "canceled", err: context.Canceled, want: "canceled"},
+		{name: "wrapped canceled", err: fmt.Errorf("send: %w", context.Canceled), want: "canceled"},
+		{name: "deadline", err: context.DeadlineExceeded, want: "timeout"},
+		{name: "conn closed", err: wire.ErrConnClosed, want: "conn_closed"},
+		{name: "client error", err: wire.Errorf(http.StatusTooManyRequests, "busy"), want: "rejected"},
+		{name: "server error", err: wire.Errorf(http.StatusInternalServerError, "boom"), want: "server_error"},
+		{name: "wrapped server error", err: fmt.Errorf("send: %w", wire.Errorf(http.StatusBadGateway, "boom")), want: "server_error"},
+		{name: "other", err: errors.New("nope"), want: "other"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, statusUpdateErrorClass(tt.err))
+		})
+	}
+}

--- a/pkg/engine/internal/worker/pipeline_node.go
+++ b/pkg/engine/internal/worker/pipeline_node.go
@@ -1,0 +1,195 @@
+package worker
+
+import (
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+
+	"github.com/grafana/loki/v3/pkg/xcap"
+)
+
+// pipelineRegionSuffix is the suffix the executor appends to an operator's type
+// name when it wraps the operator in an xcap region. observedPipeline names its
+// per-operator read region "<op_type>.Read" (see executor.NewObservedPipeline),
+// so the suffix both identifies operator regions in a capture and is stripped to
+// recover the operator type.
+const pipelineRegionSuffix = ".Read"
+
+// pipelineRegionStat holds the per-operator statistics observedPipeline already
+// collected for a single executor node, addressed by its xcap region
+// identifiers. It is the cold-path input to [buildPipelineNodes]: every field is
+// read from a finalized capture after execution, so assembling these records
+// touches no per-batch hot path.
+type pipelineRegionStat struct {
+	// ID is the operator region's own identifier.
+	ID xcap.ID
+	// ParentID is the identifier of the operator region's parent. It may refer
+	// to a non-operator region (such as the task root), in which case the
+	// operator is treated as having no operator parent.
+	ParentID xcap.ID
+	// Name is the operator region's name, e.g. "DataObjScan.Read".
+	Name string
+	// ReadCalls is xcap.StatPipelineReadCalls: batches produced by this operator.
+	ReadCalls int64
+	// RowsOut is xcap.StatPipelineRowsOut: rows produced by this operator.
+	RowsOut int64
+	// ReadDuration is xcap.StatPipelineReadDuration: wall time around this
+	// operator's Read, inclusive of its children.
+	ReadDuration time.Duration
+}
+
+// pipelineNode is one per-operator record describing this task's operator tree,
+// derived from collected statistics by [buildPipelineNodes].
+type pipelineNode struct {
+	// OperatorID is the operator region's own identifier.
+	OperatorID xcap.ID
+	// ParentOperatorID is the identifier of the parent operator region, or the
+	// zero ID when this operator has no operator parent.
+	ParentOperatorID xcap.ID
+	// OpType is the operator type: the region name without the ".Read" suffix.
+	OpType string
+	// SelfDuration is the exclusive wall-clock self-time of this operator: its
+	// ReadDuration minus the sum of its direct children's ReadDuration, clamped
+	// at zero. It is wall-clock time, not true CPU time — it still includes time
+	// the operator spent blocked (e.g. on I/O or a downstream sink) and only
+	// excludes time attributed to its direct children.
+	SelfDuration time.Duration
+	// BatchesOut is the number of batches this operator produced.
+	BatchesOut int64
+	// BatchesIn is the sum of batches produced by this operator's direct
+	// children.
+	BatchesIn int64
+	// RowsOut is the number of rows this operator produced.
+	RowsOut int64
+}
+
+// buildPipelineNodes assembles one [pipelineNode] per operator region from the
+// statistics collected during execution. It is a pure function: it reads only
+// the supplied records and performs no I/O.
+//
+// Parent/child relationships are resolved within the supplied set. A record's
+// ParentOperatorID is preserved only when it refers to another record in
+// regions, so an operator whose parent is a non-operator region (such as the
+// task root) reports the zero ID. BatchesIn and the exclusive SelfDuration are
+// computed from each operator's direct children within the set.
+func buildPipelineNodes(regions []pipelineRegionStat) []pipelineNode {
+	// Index regions by ID and group direct children by parent so each operator's
+	// children can be resolved in a single pass.
+	known := make(map[xcap.ID]struct{}, len(regions))
+	for _, r := range regions {
+		known[r.ID] = struct{}{}
+	}
+	children := make(map[xcap.ID][]pipelineRegionStat, len(regions))
+	for _, r := range regions {
+		if _, ok := known[r.ParentID]; ok {
+			children[r.ParentID] = append(children[r.ParentID], r)
+		}
+	}
+
+	nodes := make([]pipelineNode, 0, len(regions))
+	for _, r := range regions {
+		var (
+			childReadDuration time.Duration
+			batchesIn         int64
+		)
+		for _, c := range children[r.ID] {
+			childReadDuration += c.ReadDuration
+			batchesIn += c.ReadCalls
+		}
+
+		self := r.ReadDuration - childReadDuration
+		if self < 0 {
+			self = 0
+		}
+
+		var parent xcap.ID
+		if _, ok := known[r.ParentID]; ok {
+			parent = r.ParentID
+		}
+
+		nodes = append(nodes, pipelineNode{
+			OperatorID:       r.ID,
+			ParentOperatorID: parent,
+			OpType:           strings.TrimSuffix(r.Name, pipelineRegionSuffix),
+			SelfDuration:     self,
+			BatchesOut:       r.ReadCalls,
+			BatchesIn:        batchesIn,
+			RowsOut:          r.RowsOut,
+		})
+	}
+	return nodes
+}
+
+// pipelineRegionsFromCapture extracts the operator regions from a finalized
+// capture. Operator regions are those observedPipeline created, identified by
+// the ".Read" suffix the executor gives them. Statistics are read from the
+// already-aggregated observations, so this runs entirely on the cold path.
+func pipelineRegionsFromCapture(capture *xcap.Capture) []pipelineRegionStat {
+	if capture == nil {
+		return nil
+	}
+
+	var out []pipelineRegionStat
+	for _, region := range capture.Regions() {
+		name := region.Name()
+		if !strings.HasSuffix(name, pipelineRegionSuffix) {
+			continue
+		}
+
+		stat := pipelineRegionStat{
+			ID:       region.ID(),
+			ParentID: region.ParentID(),
+			Name:     name,
+		}
+		for _, obs := range region.Observations() {
+			switch obs.Statistic.Key() {
+			case xcap.StatPipelineReadCalls.Key():
+				if v, ok := obs.Int64(); ok {
+					stat.ReadCalls = v
+				}
+			case xcap.StatPipelineRowsOut.Key():
+				if v, ok := obs.Int64(); ok {
+					stat.RowsOut = v
+				}
+			case xcap.StatPipelineReadDuration.Key():
+				if v, ok := obs.Float64(); ok {
+					stat.ReadDuration = time.Duration(v * float64(time.Second))
+				}
+			}
+		}
+		out = append(out, stat)
+	}
+	return out
+}
+
+// logPipelineNodes emits one pipeline-node debug log line per operator in the
+// task's operator tree, read from the task's finalized capture. It reads only
+// already-collected statistics and adds nothing to the per-batch hot path.
+// Emission is gated at debug level, like the execution-plan-detail log, because
+// there is one line per operator per task.
+//
+// op_self_ms is wall-clock self-time, not true CPU. operator_id /
+// parent_operator_id are the per-task xcap region identifiers describing this
+// task's operator tree, not the physical-plan node ids. query_id is omitted
+// because it isn't available to the worker; the logger already carries task_id,
+// and the per-task summary log carries query_id, so join on task_id to recover it.
+func logPipelineNodes(logger log.Logger, capture *xcap.Capture) {
+	for _, node := range buildPipelineNodes(pipelineRegionsFromCapture(capture)) {
+		var parent string
+		if !node.ParentOperatorID.IsZero() {
+			parent = node.ParentOperatorID.String()
+		}
+		level.Debug(logger).Log(
+			"msg", "pipeline-node",
+			"operator_id", node.OperatorID.String(),
+			"parent_operator_id", parent,
+			"op_type", node.OpType,
+			"op_self_ms", node.SelfDuration.Milliseconds(),
+			"batches_out", node.BatchesOut,
+			"batches_in", node.BatchesIn,
+			"rows_out", node.RowsOut,
+		)
+	}
+}

--- a/pkg/engine/internal/worker/pipeline_node_test.go
+++ b/pkg/engine/internal/worker/pipeline_node_test.go
@@ -1,0 +1,125 @@
+package worker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/xcap"
+)
+
+func TestBuildPipelineNodes(t *testing.T) {
+	// Stable IDs so expectations can reference them by name. external is never
+	// added to the input set, so any region parented to it has no operator
+	// parent.
+	var (
+		external = xcap.NewID()
+		rootID   = xcap.NewID()
+		leftID   = xcap.NewID()
+		rightID  = xcap.NewID()
+		grandID  = xcap.NewID()
+	)
+
+	tests := []struct {
+		name  string
+		input []pipelineRegionStat
+		want  map[xcap.ID]pipelineNode
+	}{
+		{
+			name: "operator tree with self-time, batches_in and parent linkage",
+			input: []pipelineRegionStat{
+				// Root operator; its parent is a non-operator region.
+				{ID: rootID, ParentID: external, Name: "Limit.Read", ReadCalls: 10, RowsOut: 1000, ReadDuration: 100 * time.Millisecond},
+				// Two direct children of root.
+				{ID: leftID, ParentID: rootID, Name: "Filter.Read", ReadCalls: 4, RowsOut: 400, ReadDuration: 30 * time.Millisecond},
+				{ID: rightID, ParentID: rootID, Name: "DataObjScan.Read", ReadCalls: 3, RowsOut: 300, ReadDuration: 20 * time.Millisecond},
+				// Grandchild under the left child.
+				{ID: grandID, ParentID: leftID, Name: "Projection.Read", ReadCalls: 2, RowsOut: 200, ReadDuration: 25 * time.Millisecond},
+			},
+			want: map[xcap.ID]pipelineNode{
+				rootID: {
+					OperatorID:       rootID,
+					ParentOperatorID: xcap.ID{}, // parent is a non-operator region.
+					OpType:           "Limit",
+					SelfDuration:     50 * time.Millisecond, // 100 - (30 + 20)
+					BatchesOut:       10,
+					BatchesIn:        7, // 4 + 3
+					RowsOut:          1000,
+				},
+				leftID: {
+					OperatorID:       leftID,
+					ParentOperatorID: rootID,
+					OpType:           "Filter",
+					SelfDuration:     5 * time.Millisecond, // 30 - 25
+					BatchesOut:       4,
+					BatchesIn:        2,
+					RowsOut:          400,
+				},
+				rightID: {
+					OperatorID:       rightID,
+					ParentOperatorID: rootID,
+					OpType:           "DataObjScan",
+					SelfDuration:     20 * time.Millisecond, // no children
+					BatchesOut:       3,
+					BatchesIn:        0,
+					RowsOut:          300,
+				},
+				grandID: {
+					OperatorID:       grandID,
+					ParentOperatorID: leftID,
+					OpType:           "Projection",
+					SelfDuration:     25 * time.Millisecond, // no children
+					BatchesOut:       2,
+					BatchesIn:        0,
+					RowsOut:          200,
+				},
+			},
+		},
+		{
+			name: "self-time clamps at zero when children exceed parent",
+			input: []pipelineRegionStat{
+				{ID: rootID, ParentID: external, Name: "Merge.Read", ReadCalls: 1, ReadDuration: 10 * time.Millisecond},
+				{ID: leftID, ParentID: rootID, Name: "Filter.Read", ReadCalls: 1, ReadDuration: 40 * time.Millisecond},
+			},
+			want: map[xcap.ID]pipelineNode{
+				rootID: {
+					OperatorID:   rootID,
+					OpType:       "Merge",
+					SelfDuration: 0, // 10 - 40, clamped
+					BatchesOut:   1,
+					BatchesIn:    1,
+				},
+				leftID: {
+					OperatorID:       leftID,
+					ParentOperatorID: rootID,
+					OpType:           "Filter",
+					SelfDuration:     40 * time.Millisecond,
+					BatchesOut:       1,
+				},
+			},
+		},
+		{
+			name:  "no regions yields no nodes",
+			input: nil,
+			want:  map[xcap.ID]pipelineNode{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildPipelineNodes(tt.input)
+
+			// Exactly one record per input region.
+			require.Len(t, got, len(tt.want), "one record per node")
+
+			byID := make(map[xcap.ID]pipelineNode, len(got))
+			for _, n := range got {
+				_, dup := byID[n.OperatorID]
+				require.False(t, dup, "duplicate record for operator %s", n.OperatorID)
+				byID[n.OperatorID] = n
+			}
+			require.Equal(t, tt.want, byID)
+		})
+	}
+}

--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
@@ -128,6 +129,9 @@ func (t *thread) setState(state threadState) {
 
 func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	defer job.Close()
+
+	setupStart := time.Now()
+	taskType := taskTypeLabel(job.Task)
 
 	ctx, task := gotrace.NewTask(ctx, "thread.runJob")
 	defer task.End()
@@ -290,8 +294,12 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 		level.Warn(logger).Log("msg", "failed to inform scheduler of task status", "err", err)
 	}
 
+	// Record the time spent preparing the task before we begin draining its
+	// pipeline (planning, pipeline construction, and source binding setup).
+	t.Metrics.setupSeconds.WithLabelValues(taskType).Observe(time.Since(setupStart).Seconds())
+
 	gotrace.Log(ctx, "drain_pipeline", "start")
-	_, drainErr := t.drainPipeline(ctx, pipeline, sinksForJob(job), logger)
+	_, drainErr := t.drainPipeline(ctx, taskType, pipeline, sinksForJob(job), logger)
 	gotrace.Log(ctx, "drain_pipeline", "done")
 
 	var terminalStatus workflow.TaskStatus
@@ -323,6 +331,17 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	capture.End()
 	terminalStatus.Capture = capture
 
+	// Expose task I/O counts as worker counters by reading the values already
+	// accumulated in the per-task capture (the same stats logged in the task
+	// summary). Only leaf tasks download from object storage today, so these are
+	// zero for non-leaf tasks; recording unconditionally keeps the counters
+	// correct if a non-leaf task ever starts downloading.
+	pagesDownloaded := xcap.Value[int64](capture, xcap.StatDatasetPrimaryPagesDownloaded) +
+		xcap.Value[int64](capture, xcap.StatDatasetSecondaryPagesDownloaded)
+	t.Metrics.pagesDownloadedTotal.Add(float64(pagesDownloaded))
+	t.Metrics.pagesPrunedTotal.Add(float64(xcap.Value[int64](capture, dataobj.StatDatasetPagesPruned)))
+	t.Metrics.bytesDownloadedTotal.Add(float64(xcap.Value[int64](capture, dataobj.StatObjectBytesDownloaded)))
+
 	duration := time.Since(startTime)
 
 	logValues := []any{
@@ -333,7 +352,7 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	logValues = append(logValues, xcap.SummaryLogValues(capture)...)
 
 	level.Info(logger).Log(logValues...)
-	t.Metrics.taskExecSeconds.Observe(duration.Seconds())
+	t.Metrics.taskExecSeconds.WithLabelValues(taskType).Observe(duration.Seconds())
 
 	// Send the terminal status synchronously so the scheduler can update its
 	// thread-capacity bookkeeping and merge the Capture before the worker
@@ -342,12 +361,54 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	// We use a detached context so a cancelled job context does not prevent us
 	// from delivering the final status (and in particular, the Capture).
 	sendCtx := context.WithoutCancel(ctx)
-	if err := job.Scheduler.SendMessage(sendCtx, wire.TaskStatusMessage{
+	sendStart := time.Now()
+	sendErr := job.Scheduler.SendMessage(sendCtx, wire.TaskStatusMessage{
 		ID:     job.Task.ULID,
 		Status: terminalStatus,
-	}); err != nil {
-		level.Warn(logger).Log("msg", "failed to inform scheduler of task status", "err", err)
+	})
+	t.Metrics.statusUpdateSeconds.Observe(time.Since(sendStart).Seconds())
+	if sendErr != nil {
+		t.Metrics.statusUpdateErrorsTotal.WithLabelValues(statusUpdateErrorClass(sendErr)).Inc()
+		level.Warn(logger).Log("msg", "failed to inform scheduler of task status", "err", sendErr)
 	}
+}
+
+// taskTypeLabel returns the task_type metric label for task: [taskTypeLeaf] if
+// the task has no external task sources (it reads directly from storage),
+// otherwise [taskTypeNonLeaf]. This mirrors the leaf/non-leaf classification
+// used in the per-task summary log.
+func taskTypeLabel(task *workflow.Task) string {
+	if len(task.Sources) == 0 {
+		return taskTypeLeaf
+	}
+	return taskTypeNonLeaf
+}
+
+// statusUpdateErrorClass maps an error from the status-update send path to a
+// bounded label value for the status_update_errors_total counter.
+func statusUpdateErrorClass(err error) string {
+	switch {
+	case err == nil:
+		return "none"
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout"
+	case errors.Is(err, wire.ErrConnClosed):
+		return "conn_closed"
+	}
+
+	var wireErr *wire.Error
+	if errors.As(err, &wireErr) {
+		switch {
+		case wireErr.Code >= 400 && wireErr.Code < 500:
+			return "rejected"
+		case wireErr.Code >= 500:
+			return "server_error"
+		}
+	}
+
+	return "other"
 }
 
 // recordBatchBytes returns the total in-memory size in bytes of all column
@@ -360,7 +421,7 @@ func recordBatchBytes(rec arrow.RecordBatch) int64 {
 	return n
 }
 
-func (t *thread) drainPipeline(ctx context.Context, pipeline executor.Pipeline, sinks []recordSink, logger log.Logger) (int, error) {
+func (t *thread) drainPipeline(ctx context.Context, taskType string, pipeline executor.Pipeline, sinks []recordSink, logger log.Logger) (int, error) {
 	region := xcap.RegionFromContext(ctx)
 
 	startRead := time.Now()
@@ -418,9 +479,9 @@ func (t *thread) drainPipeline(ctx context.Context, pipeline executor.Pipeline, 
 	}
 
 	// Task-wide phase durations.
-	t.Metrics.taskReadSeconds.Observe(readDuration.Seconds())
-	t.Metrics.taskComputeSeconds.Observe(totalComputeTime.Seconds())
-	t.Metrics.taskWriteSeconds.Observe(totalWriteTime.Seconds())
+	t.Metrics.taskReadSeconds.WithLabelValues(taskType).Observe(readDuration.Seconds())
+	t.Metrics.taskComputeSeconds.WithLabelValues(taskType).Observe(totalComputeTime.Seconds())
+	t.Metrics.taskWriteSeconds.WithLabelValues(taskType).Observe(totalWriteTime.Seconds())
 
 	// Record execution sub-phase durations on the task region so the workflow
 	// can include them in the per-task summary log.

--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -331,6 +331,11 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	capture.End()
 	terminalStatus.Capture = capture
 
+	// Emit a per-operator pipeline-node trace from the finalized capture. This
+	// reads only statistics already collected during execution (no per-batch
+	// work) and is gated at debug level, like execution-plan-detail.
+	logPipelineNodes(logger, capture)
+
 	// Expose task I/O counts as worker counters by reading the values already
 	// accumulated in the per-task capture (the same stats logged in the task
 	// summary). Only leaf tasks download from object storage today, so these are

--- a/pkg/engine/internal/worker/thread_test.go
+++ b/pkg/engine/internal/worker/thread_test.go
@@ -74,7 +74,7 @@ func TestThread_drainPipeline(t *testing.T) {
 
 	sink := &mockRecordSink{}
 	th := &thread{Logger: log.NewNopLogger(), Metrics: newMetrics()}
-	totalRows, err := th.drainPipeline(ctx, pipeline, []recordSink{sink}, log.NewNopLogger())
+	totalRows, err := th.drainPipeline(ctx, taskTypeLeaf, pipeline, []recordSink{sink}, log.NewNopLogger())
 	require.NoError(t, err)
 	require.Equal(t, 3, totalRows)
 

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -380,6 +380,7 @@ func (w *Worker) handleSchedulerConn(ctx context.Context, logger log.Logger, con
 
 		if err := w.jobManager.Send(ctx, job); err != nil {
 			job.Close() // Clean up resources associated with the job.
+			w.metrics.rejectedAssignmentsTotal.Inc()
 			return wire.Errorf(http.StatusTooManyRequests, "no threads available")
 		}
 

--- a/pkg/engine/internal/workflow/critical_path.go
+++ b/pkg/engine/internal/workflow/critical_path.go
@@ -1,0 +1,83 @@
+package workflow
+
+import (
+	"github.com/go-kit/log/level"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
+)
+
+// logCriticalPath emits the per-query critical-path log lines, one per task on
+// the path. It is called from Close, after UnregisterManifest has driven every
+// task to a terminal state and recorded its finish time, so the task DAG and
+// all per-task finish times are available.
+func (wf *Workflow) logCriticalPath() {
+	wf.tasksMut.RLock()
+	path := criticalPath(&wf.graph, wf.taskFinish)
+	wf.tasksMut.RUnlock()
+
+	total := len(path)
+	for position, task := range path {
+		level.Info(wf.logger).Log(
+			"msg", "critical-path",
+			"query_id", wf.opts.ID,
+			"task_id", task.ULID,
+			"cp_position", position,
+			"cp_total_length", total,
+		)
+	}
+}
+
+// criticalPath approximates the query's critical path through the task DAG,
+// returning the tasks on the path ordered from root (position 0) down to a
+// leaf.
+//
+// The path is built by walking the DAG downward from a root: at each node the
+// child with the latest finish time is chosen as the gating child. Finish time
+// (the absolute terminal timestamp recorded by the scheduler in
+// [schedulerstat.TaskFinishTime]) is a more honest "what gated this node"
+// signal than raw duration, but this is still an approximation: the true
+// critical path is determined by which child delivered the last batch a parent
+// needed, which the workflow does not observe.
+//
+// Tasks participate regardless of terminal status (success, failure, or
+// cancellation): selection is purely by finish time. Short-circuited or
+// pre-assignment-cancelled tasks tend to finish early and so are rarely chosen
+// as the gating child, which matches the intent.
+//
+// If the graph has multiple roots, criticalPath starts from the root with the
+// latest finish time. Query workflows have a single root today (the physical
+// planner enforces exactly one root node), so this only matters for
+// hypothetical multi-root graphs.
+//
+// A task missing from finish is treated as having finish time 0, so a path is
+// still produced even if some finish times were never recorded.
+func criticalPath(graph *dag.Graph[*Task], finish map[*Task]int64) []*Task {
+	current := latestFinisher(graph.Roots(), finish)
+	if current == nil {
+		return nil
+	}
+
+	var path []*Task
+	for current != nil {
+		path = append(path, current)
+		current = latestFinisher(graph.Children(current), finish)
+	}
+	return path
+}
+
+// latestFinisher returns the task in candidates with the greatest finish time,
+// or nil if candidates is empty. Ties are broken by keeping the first task in
+// iteration order, which keeps selection deterministic for a given graph.
+func latestFinisher(candidates []*Task, finish map[*Task]int64) *Task {
+	var (
+		best     *Task
+		bestTime int64
+	)
+	for _, candidate := range candidates {
+		t := finish[candidate]
+		if best == nil || t > bestTime {
+			best, bestTime = candidate, t
+		}
+	}
+	return best
+}

--- a/pkg/engine/internal/workflow/critical_path_test.go
+++ b/pkg/engine/internal/workflow/critical_path_test.go
@@ -1,0 +1,135 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
+)
+
+func TestCriticalPath(t *testing.T) {
+	// newTask returns a task with a deterministic, recognizable ULID so that
+	// failures point back at a named node.
+	newTask := func(name byte) *Task {
+		var id ulid.ULID
+		id[len(id)-1] = name
+		return &Task{ULID: id}
+	}
+
+	// buildGraph constructs a DAG from parent->children edges. Tasks are
+	// referenced by name and shared across edges via the returned lookup.
+	buildGraph := func(edges map[byte][]byte) (dag.Graph[*Task], map[byte]*Task) {
+		var graph dag.Graph[*Task]
+		tasks := map[byte]*Task{}
+		get := func(name byte) *Task {
+			if _, ok := tasks[name]; !ok {
+				tasks[name] = graph.Add(newTask(name))
+			}
+			return tasks[name]
+		}
+		for parent, children := range edges {
+			p := get(parent)
+			for _, child := range children {
+				c := get(child)
+				require.NoError(t, graph.AddEdge(dag.Edge[*Task]{Parent: p, Child: c}))
+			}
+		}
+		return graph, tasks
+	}
+
+	tests := []struct {
+		name string
+		// edges describes the DAG as parent -> children.
+		edges map[byte][]byte
+		// finish maps task name to its finish time signal.
+		finish map[byte]int64
+		// want is the expected critical path by task name, root first.
+		want []byte
+	}{
+		{
+			name:   "single task",
+			edges:  map[byte][]byte{'A': nil},
+			finish: map[byte]int64{'A': 10},
+			want:   []byte{'A'},
+		},
+		{
+			name: "linear chain",
+			edges: map[byte][]byte{
+				'A': {'B'},
+				'B': {'C'},
+			},
+			finish: map[byte]int64{'A': 30, 'B': 20, 'C': 10},
+			want:   []byte{'A', 'B', 'C'},
+		},
+		{
+			name: "picks latest-finishing child at fan-out",
+			edges: map[byte][]byte{
+				'A': {'B', 'C'},
+				'B': {'D'},
+				'C': {'E'},
+			},
+			// C finishes later than B, so the path follows A -> C -> E.
+			finish: map[byte]int64{'A': 100, 'B': 40, 'C': 60, 'D': 10, 'E': 20},
+			want:   []byte{'A', 'C', 'E'},
+		},
+		{
+			name: "deeper branch can be shorter when its gating child finishes last",
+			edges: map[byte][]byte{
+				'A': {'B', 'C'},
+				'C': {'D', 'E'},
+			},
+			// B finishes after C, so the path stops at the B leaf.
+			finish: map[byte]int64{'A': 100, 'B': 90, 'C': 50, 'D': 10, 'E': 20},
+			want:   []byte{'A', 'B'},
+		},
+		{
+			name: "multiple roots starts from latest-finishing root",
+			edges: map[byte][]byte{
+				'A': {'C'},
+				'B': {'D'},
+			},
+			// Root B finishes after root A, so the path starts at B.
+			finish: map[byte]int64{'A': 50, 'B': 80, 'C': 10, 'D': 20},
+			want:   []byte{'B', 'D'},
+		},
+		{
+			name: "missing finish times still produce a path",
+			edges: map[byte][]byte{
+				'A': {'B', 'C'},
+			},
+			// No finish times recorded: ties resolve to first child in order.
+			finish: map[byte]int64{},
+			want:   []byte{'A', 'B'},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			graph, tasks := buildGraph(tc.edges)
+
+			finish := map[*Task]int64{}
+			for name, value := range tc.finish {
+				finish[tasks[name]] = value
+			}
+
+			got := criticalPath(&graph, finish)
+
+			gotNames := make([]byte, len(got))
+			for i, task := range got {
+				gotNames[i] = task.ULID[len(task.ULID)-1]
+			}
+			require.Equal(t, tc.want, gotNames)
+
+			// cp_position is the slice index and cp_total_length is len(path);
+			// assert the invariant the emitter relies on.
+			require.Len(t, got, len(tc.want))
+		})
+	}
+}
+
+func TestCriticalPath_EmptyGraph(t *testing.T) {
+	var graph dag.Graph[*Task]
+	require.Nil(t, criticalPath(&graph, map[*Task]int64{}))
+}

--- a/pkg/engine/internal/workflow/task_summary.go
+++ b/pkg/engine/internal/workflow/task_summary.go
@@ -70,6 +70,9 @@ func (wf *Workflow) printTaskSummary(task *Task, oldState TaskState, newStatus T
 		"duration_execution_send_ms", time.Duration(durExecutionSend).Milliseconds(),
 		"duration_execution_other_ms", time.Duration(durExecutionOther).Milliseconds(),
 
+		// Assignment
+		"assignment_retry_count", xcap.Value[int64](capture, schedulerstat.TaskAssignmentRetries),
+
 		// Stage 9 (leaf) counters.
 		"pages_total", xcap.Value[int64](capture, dataobj.StatDatasetPagesTotal),
 		"pages_pruned", xcap.Value[int64](capture, dataobj.StatDatasetPagesPruned),

--- a/pkg/engine/internal/workflow/workflow.go
+++ b/pkg/engine/internal/workflow/workflow.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/schedulerstat"
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/xcap"
@@ -139,6 +140,10 @@ type Workflow struct {
 
 	tasksMut   sync.RWMutex
 	taskStates map[*Task]TaskState
+	// taskFinish records each task's terminal finish time (Unix nanoseconds),
+	// read from the task's capture as it reaches a terminal state. It is used
+	// to approximate the query's critical path once every task is terminal.
+	taskFinish map[*Task]int64
 
 	streamsMut   sync.RWMutex
 	streamStates map[*Stream]StreamState
@@ -175,6 +180,7 @@ func New(ctx context.Context, opts Options, logger log.Logger, runner Runner, pl
 			logger:       logger,
 			runner:       runner,
 			taskStates:   make(map[*Task]TaskState),
+			taskFinish:   make(map[*Task]int64),
 			streamStates: make(map[*Stream]StreamState),
 		}, nil
 	}
@@ -194,6 +200,7 @@ func New(ctx context.Context, opts Options, logger log.Logger, runner Runner, pl
 		resultsPipeline: newStreamPipe(),
 
 		taskStates:   make(map[*Task]TaskState),
+		taskFinish:   make(map[*Task]int64),
 		streamStates: make(map[*Stream]StreamState),
 	}
 	// Detach cancellation from the caller's ctx so a cancellation of the
@@ -286,6 +293,11 @@ func (wf *Workflow) Close() {
 	if err := wf.runner.UnregisterManifest(context.Background(), wf.manifest); err != nil {
 		level.Warn(wf.logger).Log("msg", "failed to unregister workflow manifest", "err", err)
 	}
+
+	// UnregisterManifest synchronously drives every remaining task to a terminal
+	// state and delivers its status, so by here the DAG and all per-task finish
+	// times are recorded and the critical path is complete.
+	wf.logCriticalPath()
 }
 
 // Run executes the workflow, returning a pipeline to read results from. The
@@ -523,6 +535,15 @@ func (wf *Workflow) handleTerminalStateChange(ctx context.Context, task *Task, o
 
 	if newStatus.Capture != nil {
 		wf.mergeCapture(newStatus.Capture)
+
+		// Stash the task's terminal finish time for the critical-path walk. The
+		// per-task capture is merged away into wf.capture, so this is the only
+		// point at which the per-task value is available.
+		if finish, ok := xcap.TryValue[int64](newStatus.Capture, schedulerstat.TaskFinishTime); ok {
+			wf.tasksMut.Lock()
+			wf.taskFinish[task] = finish
+			wf.tasksMut.Unlock()
+		}
 	}
 
 	if newStatus.Statistics != nil {

--- a/pkg/engine/metrics.go
+++ b/pkg/engine/metrics.go
@@ -39,7 +39,8 @@ type metrics struct {
 // queryMetrics covers whole-query outcome and duration.
 
 type queryMetrics struct {
-	subqueries *prometheus.CounterVec // {status, query_type}
+	subqueries *prometheus.CounterVec   // {status, query_type}
+	other      *prometheus.HistogramVec // {query_type}
 }
 
 // planningMetrics covers logical, physical, and prepare planning.
@@ -73,7 +74,9 @@ type planningMetrics struct {
 // executionMetrics covers query execution and result collection.
 
 type executionMetrics struct {
-	duration *prometheus.HistogramVec // {query_type}
+	duration       *prometheus.HistogramVec // {query_type}
+	tasksPerQuery  *prometheus.HistogramVec // {query_type}
+	tasksGenerated *prometheus.HistogramVec // {query_type}
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
@@ -83,6 +86,10 @@ func newMetrics(r prometheus.Registerer) *metrics {
 				Name: "loki_engine_v2_subqueries_total",
 				Help: "Total number of subqueries executed with the new engine",
 			}, []string{status, queryTypeLabel}),
+			other: newNativeHistogramVec(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_other_duration_seconds",
+				Help: "Per-query residual duration in seconds: wall-clock time not attributed to any tracked phase (mirrors the duration_other_ms summary field)",
+			}, []string{queryTypeLabel}),
 		},
 
 		planning: planningMetrics{
@@ -163,6 +170,14 @@ func newMetrics(r prometheus.Registerer) *metrics {
 					prometheus.DefBuckets,                    // 0.005s -> 10s
 					prometheus.LinearBuckets(15, 5.0, 10)..., // 15s -> 60s
 				),
+			}, []string{queryTypeLabel}),
+			tasksPerQuery: newNativeHistogramVec(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_tasks_per_query",
+				Help: "Number of tasks per query after pruning",
+			}, []string{queryTypeLabel}),
+			tasksGenerated: newNativeHistogramVec(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_tasks_generated_per_query",
+				Help: "Number of tasks generated per query before pruning",
 			}, []string{queryTypeLabel}),
 		},
 	}

--- a/pkg/engine/metrics.go
+++ b/pkg/engine/metrics.go
@@ -85,6 +85,18 @@ type executionMetrics struct {
 	duration       *prometheus.HistogramVec // {query_type}
 	tasksPerQuery  *prometheus.HistogramVec // {query_type}
 	tasksGenerated *prometheus.HistogramVec // {query_type}
+
+	// Result-collection stats, observed once per query at the end of
+	// (*Engine).execute. They mirror fields emitted on the execution-summary
+	// log line.
+	resultRows         prometheus.Histogram
+	timeToFirstBatch   *prometheus.HistogramVec
+	resultGetBatch     prometheus.Histogram
+	resultProcess      prometheus.Histogram
+	resultSizeBytes    prometheus.Histogram
+	resultErrors       *prometheus.CounterVec
+	batchesAccumulated prometheus.Counter
+	bytesAccumulated   prometheus.Counter
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
@@ -191,6 +203,39 @@ func newMetrics(r prometheus.Registerer) *metrics {
 				Name: "loki_engine_v2_tasks_generated_per_query",
 				Help: "Number of tasks generated per query before pruning",
 			}, []string{queryTypeLabel}),
+
+			resultRows: newNativeHistogram(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_result_rows",
+				Help: "Number of rows in the collected query result",
+			}),
+			timeToFirstBatch: newNativeHistogramVec(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_time_to_first_batch_seconds",
+				Help: "Time in seconds from the start of result collection to the first non-EOF batch read from the pipeline",
+			}, []string{queryTypeLabel}),
+			resultGetBatch: newNativeHistogram(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_result_get_batch_seconds",
+				Help: "Total time in seconds spent reading batches from the pipeline during result collection",
+			}),
+			resultProcess: newNativeHistogram(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_result_process_seconds",
+				Help: "Total time in seconds spent collecting batches into the result builder during result collection",
+			}),
+			resultSizeBytes: newNativeHistogram(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_result_size_bytes",
+				Help: "Total in-memory size in bytes of the record batches accumulated during result collection",
+			}),
+			resultErrors: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+				Name: "loki_engine_v2_result_errors_total",
+				Help: "Total number of result-collection failures, split by error class",
+			}, []string{errorClassLabel}),
+			batchesAccumulated: promauto.With(r).NewCounter(prometheus.CounterOpts{
+				Name: "loki_engine_v2_batches_accumulated_total",
+				Help: "Total number of record batches accumulated into result builders during result collection",
+			}),
+			bytesAccumulated: promauto.With(r).NewCounter(prometheus.CounterOpts{
+				Name: "loki_engine_v2_bytes_accumulated_total",
+				Help: "Total in-memory size in bytes of record batches accumulated into result builders during result collection",
+			}),
 		},
 	}
 }

--- a/pkg/engine/metrics.go
+++ b/pkg/engine/metrics.go
@@ -1,10 +1,13 @@
 package engine
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/logical"
 )
 
 var (
@@ -13,7 +16,13 @@ var (
 	statusFailure        = "failure"
 	statusNotImplemented = "notimplemented"
 
-	queryTypeLabel = "query_type"
+	queryTypeLabel  = "query_type"
+	hasRegexLabel   = "has_regex"
+	passNameLabel   = "pass_name"
+	ruleNameLabel   = "rule_name"
+	applicableLabel = "applicable"
+	succeededLabel  = "succeeded"
+	errorClassLabel = "error_class"
 )
 
 // metrics groups the v2 engine's query-grain metrics by query lifecycle phase.
@@ -28,18 +37,41 @@ type metrics struct {
 }
 
 // queryMetrics covers whole-query outcome and duration.
+
 type queryMetrics struct {
 	subqueries *prometheus.CounterVec // {status, query_type}
 }
 
 // planningMetrics covers logical, physical, and prepare planning.
+
 type planningMetrics struct {
 	logical  *prometheus.HistogramVec // {query_type}
 	physical *prometheus.HistogramVec // {query_type}
 	prepare  *prometheus.HistogramVec // {query_type}
+
+	// LogQL query-shape stats, observed once per query.
+
+	logqlLengthChars    *prometheus.HistogramVec // {query_type}
+	logqlLabelMatchers  *prometheus.HistogramVec // {query_type}
+	logqlPipelineStages *prometheus.HistogramVec // {query_type}
+	queriesWithRegex    *prometheus.CounterVec   // {query_type, has_regex}
+
+	// Physical plan-shape stats, observed once per query after physical planning.
+
+	physicalPlanDepth                 prometheus.Histogram
+	physicalPlanNodeCount             prometheus.Histogram
+	physicalPlanMaxFanout             prometheus.Histogram
+	physicalPlanPartitionableSubtrees prometheus.Histogram
+
+	// Optimizer pass/rule firing counters.
+
+	logicalPassTotal  *prometheus.CounterVec // {pass_name, applicable, succeeded}
+	logicalPassErrors *prometheus.CounterVec // {pass_name, error_class}
+	physicalRuleTotal *prometheus.CounterVec // {rule_name, applicable}
 }
 
 // executionMetrics covers query execution and result collection.
+
 type executionMetrics struct {
 	duration *prometheus.HistogramVec // {query_type}
 }
@@ -74,6 +106,53 @@ func newMetrics(r prometheus.Registerer) *metrics {
 					prometheus.LinearBuckets(15, 5.0, 10)..., // 15s -> 60s
 				),
 			}, []string{queryTypeLabel}),
+
+			logqlLengthChars: newNativeHistogramVec(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_logql_length_chars",
+				Help: "Length of the incoming LogQL query string in characters",
+			}, []string{queryTypeLabel}),
+			logqlLabelMatchers: newNativeHistogramVec(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_logql_label_matchers",
+				Help: "Number of stream-selector label matchers in the incoming LogQL query",
+			}, []string{queryTypeLabel}),
+			logqlPipelineStages: newNativeHistogramVec(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_logql_pipeline_stages",
+				Help: "Number of pipeline stages in the incoming LogQL query",
+			}, []string{queryTypeLabel}),
+			queriesWithRegex: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+				Name: "loki_engine_v2_queries_with_regex_total",
+				Help: "Total number of queries split by whether they use a regex matcher or filter",
+			}, []string{queryTypeLabel, hasRegexLabel}),
+
+			physicalPlanDepth: newNativeHistogram(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_physical_plan_depth",
+				Help: "Depth (longest root-to-leaf path, in nodes) of the physical plan",
+			}),
+			physicalPlanNodeCount: newNativeHistogram(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_physical_plan_node_count",
+				Help: "Number of nodes in the physical plan",
+			}),
+			physicalPlanMaxFanout: newNativeHistogram(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_physical_plan_max_fanout",
+				Help: "Maximum number of children of any node in the physical plan",
+			}),
+			physicalPlanPartitionableSubtrees: newNativeHistogram(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_physical_plan_partitionable_subtrees",
+				Help: "Number of partitionable (Parallelize) subtrees in the physical plan",
+			}),
+
+			logicalPassTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+				Name: "loki_engine_v2_logical_pass_total",
+				Help: "Total number of logical optimizer pass runs, split by whether the pass applied and succeeded",
+			}, []string{passNameLabel, applicableLabel, succeededLabel}),
+			logicalPassErrors: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+				Name: "loki_engine_v2_logical_pass_errors_total",
+				Help: "Total number of logical optimizer pass failures, split by error class",
+			}, []string{passNameLabel, errorClassLabel}),
+			physicalRuleTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+				Name: "loki_engine_v2_physical_rule_total",
+				Help: "Total number of physical optimizer rule runs, split by whether the rule applied",
+			}, []string{ruleNameLabel, applicableLabel}),
 		},
 
 		execution: executionMetrics{
@@ -89,10 +168,62 @@ func newMetrics(r prometheus.Registerer) *metrics {
 	}
 }
 
+// observeLogQLShape records the LogQL query-shape metrics for the given query
+// type.
+func (m *metrics) observeLogQLShape(queryType string, shape logqlShape) {
+	m.planning.logqlLengthChars.WithLabelValues(queryType).Observe(float64(shape.lengthChars))
+	m.planning.logqlLabelMatchers.WithLabelValues(queryType).Observe(float64(shape.labelMatchers))
+	m.planning.logqlPipelineStages.WithLabelValues(queryType).Observe(float64(shape.pipelineStages))
+	m.planning.queriesWithRegex.WithLabelValues(queryType, strconv.FormatBool(shape.hasRegex)).Inc()
+}
+
+// observePhysicalShape records the physical plan-shape metrics.
+func (m *metrics) observePhysicalShape(shape physicalShape) {
+	m.planning.physicalPlanDepth.Observe(float64(shape.depth))
+	m.planning.physicalPlanNodeCount.Observe(float64(shape.nodeCount))
+	m.planning.physicalPlanMaxFanout.Observe(float64(shape.maxFanout))
+	m.planning.physicalPlanPartitionableSubtrees.Observe(float64(shape.partitionableSubtrees))
+}
+
+// recordLogicalPasses records optimizer firing counters from the logical pass
+// firings produced during logical optimization.
+func (m *metrics) recordLogicalPasses(firings []logical.PassFiring) {
+	for _, f := range firings {
+		m.planning.logicalPassTotal.WithLabelValues(
+			f.Name,
+			strconv.FormatBool(f.Applicable),
+			strconv.FormatBool(f.Succeeded),
+		).Inc()
+		if !f.Succeeded {
+			m.planning.logicalPassErrors.WithLabelValues(f.Name, errorClass(f.Err)).Inc()
+		}
+	}
+}
+
+// recordPhysicalRules records optimizer firing counters from the physical rule
+// firings produced during physical optimization. Physical rules have no error
+// path, so there is no success/error dimension to record.
+func (m *metrics) recordPhysicalRules(rules map[string]bool) {
+	for name, applied := range rules {
+		m.planning.physicalRuleTotal.WithLabelValues(
+			name,
+			strconv.FormatBool(applied),
+		).Inc()
+	}
+}
+
 func newNativeHistogramVec(r prometheus.Registerer, opts prometheus.HistogramOpts, labels []string) *prometheus.HistogramVec {
+	applyNativeHistogramOpts(&opts)
+	return promauto.With(r).NewHistogramVec(opts, labels)
+}
+
+func newNativeHistogram(r prometheus.Registerer, opts prometheus.HistogramOpts) prometheus.Histogram {
+	applyNativeHistogramOpts(&opts)
+	return promauto.With(r).NewHistogram(opts)
+}
+
+func applyNativeHistogramOpts(opts *prometheus.HistogramOpts) {
 	opts.NativeHistogramBucketFactor = 1.1
 	opts.NativeHistogramMaxBucketNumber = 100
 	opts.NativeHistogramMinResetDuration = time.Hour
-
-	return promauto.With(r).NewHistogramVec(opts, labels)
 }

--- a/pkg/engine/metrics.go
+++ b/pkg/engine/metrics.go
@@ -12,58 +12,87 @@ var (
 	statusSuccess        = "success"
 	statusFailure        = "failure"
 	statusNotImplemented = "notimplemented"
+
+	queryTypeLabel = "query_type"
 )
 
+// metrics groups the v2 engine's query-grain metrics by query lifecycle phase.
+// The core struct holds one sub-struct per phase; each sub-struct owns the
+// metrics observed during that phase.
+//
 // NOTE: Metrics are subject to rapid change!
 type metrics struct {
-	subqueries       *prometheus.CounterVec
-	logicalPlanning  prometheus.Histogram
-	physicalPlanning prometheus.Histogram
-	workflowPlanning prometheus.Histogram
-	execution        prometheus.Histogram
+	query     queryMetrics
+	planning  planningMetrics
+	execution executionMetrics
+}
+
+// queryMetrics covers whole-query outcome and duration.
+type queryMetrics struct {
+	subqueries *prometheus.CounterVec // {status, query_type}
+}
+
+// planningMetrics covers logical, physical, and prepare planning.
+type planningMetrics struct {
+	logical  *prometheus.HistogramVec // {query_type}
+	physical *prometheus.HistogramVec // {query_type}
+	prepare  *prometheus.HistogramVec // {query_type}
+}
+
+// executionMetrics covers query execution and result collection.
+type executionMetrics struct {
+	duration *prometheus.HistogramVec // {query_type}
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
 	return &metrics{
-		subqueries: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Name: "loki_engine_v2_subqueries_total",
-			Help: "Total number of subqueries executed with the new engine",
-		}, []string{status}),
-		logicalPlanning: newNativeHistogram(r, prometheus.HistogramOpts{
-			Name: "loki_engine_v2_logical_planning_duration_seconds",
-			Help: "Duration of logical query planning in seconds",
-		}),
-		physicalPlanning: newNativeHistogram(r, prometheus.HistogramOpts{
-			Name: "loki_engine_v2_physical_planning_duration_seconds",
-			Help: "Duration of physical query planning in seconds",
-			Buckets: append(
-				prometheus.DefBuckets,                    // 0.005s -> 10s
-				prometheus.LinearBuckets(15, 5.0, 10)..., // 15s -> 60s
-			),
-		}),
-		workflowPlanning: newNativeHistogram(r, prometheus.HistogramOpts{
-			Name: "loki_engine_v2_workflow_planning_duration_seconds",
-			Help: "Duration of workflow query planning in seconds",
-			Buckets: append(
-				prometheus.DefBuckets,                    // 0.005s -> 10s
-				prometheus.LinearBuckets(15, 5.0, 10)..., // 15s -> 60s
-			),
-		}),
-		execution: newNativeHistogram(r, prometheus.HistogramOpts{
-			Name: "loki_engine_v2_execution_duration_seconds",
-			Help: "Duration of query execution in seconds",
-			Buckets: append(
-				prometheus.DefBuckets,                    // 0.005s -> 10s
-				prometheus.LinearBuckets(15, 5.0, 10)..., // 15s -> 60s
-			),
-		}),
+		query: queryMetrics{
+			subqueries: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+				Name: "loki_engine_v2_subqueries_total",
+				Help: "Total number of subqueries executed with the new engine",
+			}, []string{status, queryTypeLabel}),
+		},
+
+		planning: planningMetrics{
+			logical: newNativeHistogramVec(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_logical_planning_duration_seconds",
+				Help: "Duration of logical query planning in seconds",
+			}, []string{queryTypeLabel}),
+			physical: newNativeHistogramVec(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_physical_planning_duration_seconds",
+				Help: "Duration of physical query planning in seconds",
+				Buckets: append(
+					prometheus.DefBuckets,                    // 0.005s -> 10s
+					prometheus.LinearBuckets(15, 5.0, 10)..., // 15s -> 60s
+				),
+			}, []string{queryTypeLabel}),
+			prepare: newNativeHistogramVec(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_prepare_duration_seconds",
+				Help: "Duration of query preparation in seconds",
+				Buckets: append(
+					prometheus.DefBuckets,                    // 0.005s -> 10s
+					prometheus.LinearBuckets(15, 5.0, 10)..., // 15s -> 60s
+				),
+			}, []string{queryTypeLabel}),
+		},
+
+		execution: executionMetrics{
+			duration: newNativeHistogramVec(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_execution_duration_seconds",
+				Help: "Duration of query execution in seconds",
+				Buckets: append(
+					prometheus.DefBuckets,                    // 0.005s -> 10s
+					prometheus.LinearBuckets(15, 5.0, 10)..., // 15s -> 60s
+				),
+			}, []string{queryTypeLabel}),
+		},
 	}
 }
 
-func newNativeHistogram(r prometheus.Registerer, opts prometheus.HistogramOpts) prometheus.Histogram {
+func newNativeHistogramVec(r prometheus.Registerer, opts prometheus.HistogramOpts, labels []string) *prometheus.HistogramVec {
 	opts.NativeHistogramBucketFactor = 1.1
 	opts.NativeHistogramMaxBucketNumber = 100
 	opts.NativeHistogramMinResetDuration = time.Hour
 
-	return promauto.With(r).NewHistogram(opts)
+	return promauto.With(r).NewHistogramVec(opts, labels)
 }

--- a/pkg/engine/metrics.go
+++ b/pkg/engine/metrics.go
@@ -23,6 +23,13 @@ var (
 	applicableLabel = "applicable"
 	succeededLabel  = "succeeded"
 	errorClassLabel = "error_class"
+	stageLabel      = "stage"
+	reasonLabel     = "reason"
+
+	stageLogicalPlanning  = "logical_planning"
+	stagePhysicalPlanning = "physical_planning"
+	stagePrepare          = "prepare"
+	stageExecution        = "execution"
 )
 
 // metrics groups the v2 engine's query-grain metrics by query lifecycle phase.
@@ -39,8 +46,9 @@ type metrics struct {
 // queryMetrics covers whole-query outcome and duration.
 
 type queryMetrics struct {
-	subqueries *prometheus.CounterVec   // {status, query_type}
-	other      *prometheus.HistogramVec // {query_type}
+	subqueries    *prometheus.CounterVec   // {status, query_type}
+	stageFailures *prometheus.CounterVec   // {stage, reason, query_type}
+	other         *prometheus.HistogramVec // {query_type}
 }
 
 // planningMetrics covers logical, physical, and prepare planning.
@@ -86,6 +94,10 @@ func newMetrics(r prometheus.Registerer) *metrics {
 				Name: "loki_engine_v2_subqueries_total",
 				Help: "Total number of subqueries executed with the new engine",
 			}, []string{status, queryTypeLabel}),
+			stageFailures: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+				Name: "loki_engine_v2_stage_failures_total",
+				Help: "Total number of query failures by engine stage and reason.",
+			}, []string{stageLabel, reasonLabel, queryTypeLabel}),
 			other: newNativeHistogramVec(r, prometheus.HistogramOpts{
 				Name: "loki_engine_v2_other_duration_seconds",
 				Help: "Per-query residual duration in seconds: wall-clock time not attributed to any tracked phase (mirrors the duration_other_ms summary field)",

--- a/pkg/engine/shape.go
+++ b/pkg/engine/shape.go
@@ -1,0 +1,217 @@
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/logical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/logql/log"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+)
+
+// logqlShape summarizes the shape of an incoming LogQL query for observability.
+// It is observed once per query.
+type logqlShape struct {
+	// lengthChars is the length of the query string in characters.
+	lengthChars int
+	// labelMatchers is the number of stream-selector label matchers.
+	labelMatchers int
+	// pipelineStages is the number of pipeline stages across all selectors.
+	pipelineStages int
+	// hasRegex reports whether the query uses a regex stream-selector matcher
+	// or a regex line filter (|~, !~).
+	hasRegex bool
+}
+
+// logqlShapeOf computes the [logqlShape] of the parsed expr. queryString is the
+// raw query text used for the character-length stat.
+//
+// hasRegex is an approximation: it covers regex stream-selector matchers and
+// regex line filters, which are the common cases. It does not inspect regex
+// label filters, whose underlying filterer is unexported in the log package.
+func logqlShapeOf(queryString string, expr syntax.Expr) logqlShape {
+	shape := logqlShape{lengthChars: len(queryString)}
+	if expr == nil {
+		return shape
+	}
+
+	if sel := logSelectorOf(expr); sel != nil {
+		matchers := sel.Matchers()
+		shape.labelMatchers = len(matchers)
+		for _, m := range matchers {
+			if m.Type == labels.MatchRegexp || m.Type == labels.MatchNotRegexp {
+				shape.hasRegex = true
+			}
+		}
+	}
+
+	expr.Walk(func(e syntax.Expr) bool {
+		switch n := e.(type) {
+		case *syntax.PipelineExpr:
+			shape.pipelineStages += len(n.MultiStages)
+		case *syntax.LineFilterExpr:
+			if n.Ty == log.LineMatchRegexp || n.Ty == log.LineMatchNotRegexp {
+				shape.hasRegex = true
+			}
+		}
+		return true
+	})
+
+	return shape
+}
+
+// logSelectorOf returns the log selector expression backing expr, unwrapping a
+// metric query's selector when necessary. It returns nil if no selector can be
+// resolved.
+func logSelectorOf(expr syntax.Expr) syntax.LogSelectorExpr {
+	switch e := expr.(type) {
+	case syntax.SampleExpr:
+		sel, err := e.Selector()
+		if err != nil {
+			return nil
+		}
+		return sel
+	case syntax.LogSelectorExpr:
+		return e
+	default:
+		return nil
+	}
+}
+
+// physicalShape summarizes the shape of a physical plan for observability. It
+// is observed once per query after physical planning succeeds.
+type physicalShape struct {
+	// depth is the longest root-to-leaf path, counted in nodes (a single-node
+	// plan has depth 1).
+	depth int
+	// nodeCount is the total number of nodes in the plan.
+	nodeCount int
+	// maxFanout is the largest number of children of any node.
+	maxFanout int
+	// partitionableSubtrees is the number of Parallelize nodes.
+	partitionableSubtrees int
+}
+
+// physicalPlanShapeOf computes the [physicalShape] of plan by walking it.
+func physicalPlanShapeOf(plan *physical.Plan) physicalShape {
+	var shape physicalShape
+	if plan == nil {
+		return shape
+	}
+	shape.nodeCount = plan.Len()
+
+	visited := make(map[physical.Node]struct{})
+	depths := make(map[physical.Node]int)
+	for _, root := range plan.Roots() {
+		collectPhysicalShape(plan, root, visited, &shape)
+		if d := physicalNodeDepth(plan, root, depths); d > shape.depth {
+			shape.depth = d
+		}
+	}
+	return shape
+}
+
+// collectPhysicalShape walks the subtree rooted at n, accumulating fanout and
+// Parallelize counts into shape. visited dedupes nodes reachable by multiple
+// paths.
+func collectPhysicalShape(plan *physical.Plan, n physical.Node, visited map[physical.Node]struct{}, shape *physicalShape) {
+	if _, ok := visited[n]; ok {
+		return
+	}
+	visited[n] = struct{}{}
+
+	children := plan.Children(n)
+	if len(children) > shape.maxFanout {
+		shape.maxFanout = len(children)
+	}
+	if n.Type() == physical.NodeTypeParallelize {
+		shape.partitionableSubtrees++
+	}
+
+	for _, c := range children {
+		collectPhysicalShape(plan, c, visited, shape)
+	}
+}
+
+// physicalNodeDepth returns the depth (in nodes) of the longest path from n to a
+// leaf, memoizing results in depths.
+func physicalNodeDepth(plan *physical.Plan, n physical.Node, depths map[physical.Node]int) int {
+	if d, ok := depths[n]; ok {
+		return d
+	}
+
+	best := 0
+	for _, c := range plan.Children(n) {
+		if d := physicalNodeDepth(plan, c, depths); d > best {
+			best = d
+		}
+	}
+	depth := best + 1
+	depths[n] = depth
+	return depth
+}
+
+// errorClass classifies err into a bounded label value derived from its Go
+// type. The set of types is fixed by the optimizer code, so cardinality stays
+// bounded. It returns the empty string for a nil error.
+func errorClass(err error) string {
+	if err == nil {
+		return ""
+	}
+	return fmt.Sprintf("%T", err)
+}
+
+// logicalPassEntry is the compact JSON representation of a single logical pass
+// firing, used in the logical-plan-summary log line.
+type logicalPassEntry struct {
+	Name       string `json:"name"`
+	Applicable bool   `json:"applicable"`
+	Succeeded  bool   `json:"succeeded"`
+}
+
+// physicalRuleEntry is the compact JSON representation of a single physical rule
+// firing, used in the physical-plan-summary log line. Physical rules have no
+// error path, so there is no succeeded dimension.
+type physicalRuleEntry struct {
+	Name       string `json:"name"`
+	Applicable bool   `json:"applicable"`
+}
+
+// encodeLogicalPasses encodes logical pass firings as a compact JSON array
+// string suitable for a logfmt field value.
+func encodeLogicalPasses(firings []logical.PassFiring) string {
+	entries := make([]logicalPassEntry, 0, len(firings))
+	for _, f := range firings {
+		entries = append(entries, logicalPassEntry{Name: f.Name, Applicable: f.Applicable, Succeeded: f.Succeeded})
+	}
+	return encodeFirings(entries)
+}
+
+// encodePhysicalRules encodes physical rule firings as a compact JSON array
+// string suitable for a logfmt field value. Rules are emitted in
+// deterministic (sorted) name order.
+func encodePhysicalRules(rules map[string]bool) string {
+	names := make([]string, 0, len(rules))
+	for name := range rules {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	entries := make([]physicalRuleEntry, 0, len(rules))
+	for _, name := range names {
+		entries = append(entries, physicalRuleEntry{Name: name, Applicable: rules[name]})
+	}
+	return encodeFirings(entries)
+}
+
+func encodeFirings(entries any) string {
+	b, err := json.Marshal(entries)
+	if err != nil {
+		return "[]"
+	}
+	return string(b)
+}

--- a/pkg/engine/shape_test.go
+++ b/pkg/engine/shape_test.go
@@ -1,0 +1,148 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/logical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+)
+
+func TestLogQLShapeOf(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  logqlShape
+	}{
+		{
+			name:  "bare stream selector",
+			query: `{app="test"}`,
+			want: logqlShape{
+				lengthChars:    len(`{app="test"}`),
+				labelMatchers:  1,
+				pipelineStages: 0,
+				hasRegex:       false,
+			},
+		},
+		{
+			name:  "multiple matchers with regex matcher",
+			query: `{app="test", env=~"prod|dev"}`,
+			want: logqlShape{
+				lengthChars:   len(`{app="test", env=~"prod|dev"}`),
+				labelMatchers: 2,
+				hasRegex:      true,
+			},
+		},
+		{
+			name:  "pipeline stages without regex",
+			query: `{app="test"} |= "error" | json | level="warn"`,
+			want: logqlShape{
+				lengthChars:    len(`{app="test"} |= "error" | json | level="warn"`),
+				labelMatchers:  1,
+				pipelineStages: 3,
+				hasRegex:       false,
+			},
+		},
+		{
+			name:  "regex line filter",
+			query: `{app="test"} |~ "err.*"`,
+			want: logqlShape{
+				lengthChars:    len(`{app="test"} |~ "err.*"`),
+				labelMatchers:  1,
+				pipelineStages: 1,
+				hasRegex:       true,
+			},
+		},
+		{
+			name:  "metric query unwraps selector",
+			query: `sum(rate({app="test"} |= "x" [5m]))`,
+			want: logqlShape{
+				lengthChars:    len(`sum(rate({app="test"} |= "x" [5m]))`),
+				labelMatchers:  1,
+				pipelineStages: 1,
+				hasRegex:       false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr, err := syntax.ParseExpr(tt.query)
+			require.NoError(t, err)
+
+			got := logqlShapeOf(tt.query, expr)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLogQLShapeOf_NilExpr(t *testing.T) {
+	got := logqlShapeOf("", nil)
+	require.Equal(t, logqlShape{}, got)
+}
+
+func TestPhysicalPlanShapeOf(t *testing.T) {
+	// Build the following plan:
+	//
+	//	limit (root)
+	//	  merge            (fanout 2)
+	//	    parallelize
+	//	      scan1
+	//	    parallelize
+	//	      scan2
+	plan := &physical.Plan{}
+	g := plan.Graph()
+
+	limit := g.Add(physical.Node(&physical.Limit{NodeID: ulid.Make()}))
+	merge := g.Add(physical.Node(&physical.Merge{NodeID: ulid.Make()}))
+	par1 := g.Add(physical.Node(&physical.Parallelize{NodeID: ulid.Make()}))
+	par2 := g.Add(physical.Node(&physical.Parallelize{NodeID: ulid.Make()}))
+	scan1 := g.Add(physical.Node(&physical.DataObjScan{NodeID: ulid.Make()}))
+	scan2 := g.Add(physical.Node(&physical.DataObjScan{NodeID: ulid.Make()}))
+
+	for _, e := range []dag.Edge[physical.Node]{
+		{Parent: limit, Child: merge},
+		{Parent: merge, Child: par1},
+		{Parent: merge, Child: par2},
+		{Parent: par1, Child: scan1},
+		{Parent: par2, Child: scan2},
+	} {
+		require.NoError(t, g.AddEdge(e))
+	}
+
+	got := physicalPlanShapeOf(plan)
+	require.Equal(t, physicalShape{
+		depth:                 4, // limit -> merge -> parallelize -> scan
+		nodeCount:             6,
+		maxFanout:             2, // merge has two children
+		partitionableSubtrees: 2, // two Parallelize nodes
+	}, got)
+}
+
+func TestPhysicalPlanShapeOf_Nil(t *testing.T) {
+	require.Equal(t, physicalShape{}, physicalPlanShapeOf(nil))
+}
+
+func TestEncodeFirings(t *testing.T) {
+	t.Run("logical", func(t *testing.T) {
+		firings := []logical.PassFiring{
+			{Name: "SimplifyRegex", Applicable: true, Succeeded: true},
+		}
+		require.Equal(t, `[{"name":"SimplifyRegex","applicable":true,"succeeded":true}]`, encodeLogicalPasses(firings))
+	})
+
+	t.Run("physical", func(t *testing.T) {
+		rules := map[string]bool{
+			"PredicatePushdown": false,
+		}
+		require.Equal(t, `[{"name":"PredicatePushdown","applicable":false}]`, encodePhysicalRules(rules))
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		require.Equal(t, `[]`, encodeLogicalPasses(nil))
+	})
+}

--- a/pkg/engine/stats.go
+++ b/pkg/engine/stats.go
@@ -19,4 +19,11 @@ var (
 
 	statReadBatchDuration    = xcap.NewStatisticInt64("execute.read_batch.duration", xcap.AggregationTypeSum)
 	statProcessBatchDuration = xcap.NewStatisticInt64("execute.process_batch.duration", xcap.AggregationTypeSum)
+
+	// Result-collection stats, recorded once per query in (*Engine).execute and
+	// surfaced on the execution-summary log line.
+
+	statResultRows       = xcap.NewStatisticInt64("execute.result.rows", xcap.AggregationTypeSum)
+	statTimeToFirstBatch = xcap.NewStatisticInt64("execute.result.time_to_first_batch", xcap.AggregationTypeSum)
+	statResultSizeBytes  = xcap.NewStatisticInt64("execute.result.size_bytes", xcap.AggregationTypeSum)
 )

--- a/pkg/engine/stats_test.go
+++ b/pkg/engine/stats_test.go
@@ -1,0 +1,36 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
+)
+
+func TestResultErrorClass(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "nil", err: nil, want: ""},
+		{name: "canceled", err: context.Canceled, want: "canceled"},
+		{name: "wrapped canceled", err: fmt.Errorf("read batch: %w", context.Canceled), want: "canceled"},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, want: "deadline_exceeded"},
+		{name: "wrapped deadline", err: fmt.Errorf("read batch: %w", context.DeadlineExceeded), want: "deadline_exceeded"},
+		{name: "other", err: errors.New("boom"), want: "other"},
+		// EOF should never reach the classifier (it is handled inline), but if
+		// it ever did it must fall into the bounded "other" bucket.
+		{name: "eof", err: executor.EOF, want: "other"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, resultErrorClass(tt.err))
+		})
+	}
+}

--- a/pkg/xcap/region.go
+++ b/pkg/xcap/region.go
@@ -97,6 +97,33 @@ func (r *Region) Record(o Observation) {
 	agg.Record(o)
 }
 
+// Name returns the name of the region.
+func (r *Region) Name() string {
+	if r == nil {
+		return ""
+	}
+	return r.name
+}
+
+// ID returns the unique identifier of the region.
+func (r *Region) ID() ID {
+	if r == nil {
+		return zeroID
+	}
+	return r.id
+}
+
+// ParentID returns the identifier of the region's parent. It returns the zero
+// ID if the region has no parent (i.e. it is a root region).
+func (r *Region) ParentID() ID {
+	if r == nil {
+		return zeroID
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.parentID
+}
+
 // Observations returns all aggregated observations recorded in the region.
 func (r *Region) Observations() []AggregatedObservation {
 	r.mu.RLock()


### PR DESCRIPTION
> [!NOTE] 
> This is intended to be reviewed commit-by-commit.

Adds observability across the experimental v2 query engine so its queries are easier to reason about. Almost entirely additive: new metrics, a few new log lines, and some span attributes spread across the engine's stages.

The new signals roughly cover:

- logical/physical/prepare planning, and which optimizer passes ran
- query and plan shape
- the scheduler's wire messaging and task assignment
- worker execution timing, I/O, and caches
- a per-query critical path and a per-operator pipeline trace
- result collection

It also folds in a small fix for a wire gauge.