### PR TITLE
fix(querier): isolate per-tenant request state in MultiTenantQuerier

### DIFF
--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -81,7 +81,8 @@ func (q *MultiTenantQuerier) SelectLogs(ctx context.Context, params logql.Select
 	for id := range matchedTenants {
 		singleContext := user.InjectOrgID(ctx, id)
 
-		tenantParams := params
+		cpy := *params.QueryRequest
+		tenantParams := logql.SelectLogParams{QueryRequest: &cpy}
 
 		if tenantChunkOverrides, ok := storeOverridesByTenant[id]; ok {
 			tenantParams = tenantParams.WithStoreChunks(&logproto.ChunkRefGroup{Refs: tenantChunkOverrides})
@@ -124,7 +125,8 @@ func (q *MultiTenantQuerier) SelectSamples(ctx context.Context, params logql.Sel
 	i := 0
 	for id := range matchedTenants {
 		singleContext := user.InjectOrgID(ctx, id)
-		tenantParams := params
+		cpy := *params.SampleQueryRequest
+		tenantParams := logql.SelectSampleParams{SampleQueryRequest: &cpy}
 
 		if tenantChunkOverrides, ok := storeOverridesByTenant[id]; ok {
 			tenantParams = tenantParams.WithStoreChunks(&logproto.ChunkRefGroup{Refs: tenantChunkOverrides})
@@ -158,7 +160,12 @@ func (q *MultiTenantQuerier) Label(ctx context.Context, req *logproto.LabelReque
 	responses := make([]*logproto.LabelResponse, len(tenantIDs))
 	for i, id := range tenantIDs {
 		singleContext := user.InjectOrgID(ctx, id)
-		resp, err := q.Querier.Label(singleContext, req)
+		reqCopy := *req
+		startCopy := *req.Start
+		endCopy := *req.End
+		reqCopy.Start = &startCopy
+		reqCopy.End = &endCopy
+		resp, err := q.Querier.Label(singleContext, &reqCopy)
 		if err != nil {
 			return nil, err
 		}
@@ -187,7 +194,8 @@ func (q *MultiTenantQuerier) Series(ctx context.Context, req *logproto.SeriesReq
 	responses := make([]*logproto.SeriesResponse, len(tenantIDs))
 	for i, id := range tenantIDs {
 		singleContext := user.InjectOrgID(ctx, id)
-		resp, err := q.Querier.Series(singleContext, req)
+		reqCopy := *req
+		resp, err := q.Querier.Series(singleContext, &reqCopy)
 		if err != nil {
 			return nil, err
 		}
@@ -350,7 +358,8 @@ func (q *MultiTenantQuerier) DetectedLabels(ctx context.Context, req *logproto.D
 	responses := make([]*logproto.DetectedLabelsResponse, len(tenantIDs))
 	for i, id := range tenantIDs {
 		singleContext := user.InjectOrgID(ctx, id)
-		resp, err := q.Querier.DetectedLabels(singleContext, req)
+		reqCopy := *req
+		resp, err := q.Querier.DetectedLabels(singleContext, &reqCopy)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/querier/multi_tenant_querier_test.go
+++ b/pkg/querier/multi_tenant_querier_test.go
@@ -709,6 +709,148 @@ func TestMultiTenantQuerier_DetectedLabels(t *testing.T) {
 	}
 }
 
+func TestMultiTenantQuerier_SelectLogs_ParamsIsolated(t *testing.T) {
+	originalStart := time.Unix(100, 0)
+	originalEnd := time.Unix(200, 0)
+
+	callCount := 0
+	querier := newQuerierMock()
+	querier.On("SelectLogs", mock.Anything, mock.Anything).Return(
+		func() iter.EntryIterator { return mockStreamIterator(1, 2) }, nil,
+	).Run(func(args mock.Arguments) {
+		p := args.Get(1).(logql.SelectLogParams)
+		require.Equal(t, originalStart, p.Start, "tenant %d received mutated Start", callCount)
+		require.Equal(t, originalEnd, p.End, "tenant %d received mutated End", callCount)
+		require.Nil(t, p.Deletes, "tenant %d received non-nil Deletes", callCount)
+
+		p.Start = time.Unix(150, 0)
+		p.End = time.Unix(180, 0)
+		p.Deletes = []*logproto.Delete{{Selector: "fake", Start: 0, End: 1}}
+		callCount++
+	})
+
+	multiTenantQuerier := NewMultiTenantQuerier(querier, log.NewNopLogger())
+
+	selector := `{type="test"}`
+	ctx := user.InjectOrgID(context.Background(), "1|2")
+	params := logql.SelectLogParams{QueryRequest: &logproto.QueryRequest{
+		Selector:  selector,
+		Direction: logproto.BACKWARD,
+		Start:     originalStart,
+		End:       originalEnd,
+		Plan:      &plan.QueryPlan{AST: syntax.MustParseExpr(selector)},
+	}}
+
+	_, err := multiTenantQuerier.SelectLogs(ctx, params)
+	require.NoError(t, err)
+	require.Equal(t, 2, callCount, "both tenants should be queried")
+}
+
+func TestMultiTenantQuerier_SelectSamples_ParamsIsolated(t *testing.T) {
+	originalStart := time.Unix(100, 0)
+	originalEnd := time.Unix(200, 0)
+
+	callCount := 0
+	querier := newQuerierMock()
+	querier.On("SelectSamples", mock.Anything, mock.Anything).Return(
+		func() iter.SampleIterator { return newSampleIterator() }, nil,
+	).Run(func(args mock.Arguments) {
+		p := args.Get(1).(logql.SelectSampleParams)
+		require.Equal(t, originalStart, p.Start, "tenant %d received mutated Start", callCount)
+		require.Equal(t, originalEnd, p.End, "tenant %d received mutated End", callCount)
+		require.Nil(t, p.Deletes, "tenant %d received non-nil Deletes", callCount)
+
+		p.Start = time.Unix(150, 0)
+		p.End = time.Unix(180, 0)
+		p.Deletes = []*logproto.Delete{{Selector: "fake", Start: 0, End: 1}}
+		callCount++
+	})
+
+	multiTenantQuerier := NewMultiTenantQuerier(querier, log.NewNopLogger())
+
+	selector := `count_over_time({foo="bar"}[1m]) > 10`
+	ctx := user.InjectOrgID(context.Background(), "1|2")
+	params := logql.SelectSampleParams{SampleQueryRequest: &logproto.SampleQueryRequest{
+		Selector: selector,
+		Start:    originalStart,
+		End:      originalEnd,
+		Plan:     &plan.QueryPlan{AST: syntax.MustParseExpr(selector)},
+	}}
+
+	_, err := multiTenantQuerier.SelectSamples(ctx, params)
+	require.NoError(t, err)
+	require.Equal(t, 2, callCount, "both tenants should be queried")
+}
+
+func TestMultiTenantQuerier_Label_RequestIsolated(t *testing.T) {
+	originalStart := time.Unix(100, 0)
+	originalEnd := time.Unix(200, 0)
+
+	callCount := 0
+	querier := newQuerierMock()
+	querier.On("Label", mock.Anything, mock.Anything).Return(
+		&logproto.LabelResponse{Values: []string{"val1"}}, nil,
+	).Run(func(args mock.Arguments) {
+		req := args.Get(1).(*logproto.LabelRequest)
+		require.Equal(t, originalStart, *req.Start, "tenant %d received mutated Start", callCount)
+		require.Equal(t, originalEnd, *req.End, "tenant %d received mutated End", callCount)
+
+		mutatedStart := time.Unix(150, 0)
+		mutatedEnd := time.Unix(180, 0)
+		*req.Start = mutatedStart
+		*req.End = mutatedEnd
+		callCount++
+	})
+
+	multiTenantQuerier := NewMultiTenantQuerier(querier, log.NewNopLogger())
+
+	ctx := user.InjectOrgID(context.Background(), "1|2")
+	startCopy := originalStart
+	endCopy := originalEnd
+	req := &logproto.LabelRequest{
+		Name:   "test",
+		Values: false,
+		Start:  &startCopy,
+		End:    &endCopy,
+	}
+
+	_, err := multiTenantQuerier.Label(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 2, callCount, "both tenants should be queried")
+}
+
+func TestMultiTenantQuerier_Series_RequestIsolated(t *testing.T) {
+	originalStart := time.Unix(100, 0)
+	originalEnd := time.Unix(200, 0)
+
+	callCount := 0
+	querier := newQuerierMock()
+	querier.On("Series", mock.Anything, mock.Anything).Return(
+		func() *logproto.SeriesResponse { return &logproto.SeriesResponse{Series: []logproto.SeriesIdentifier{}} }, nil,
+	).Run(func(args mock.Arguments) {
+		req := args.Get(1).(*logproto.SeriesRequest)
+		require.Equal(t, originalStart, req.Start, "tenant %d received mutated Start", callCount)
+		require.Equal(t, originalEnd, req.End, "tenant %d received mutated End", callCount)
+
+		req.Start = time.Unix(150, 0)
+		req.End = time.Unix(180, 0)
+		callCount++
+	})
+
+	multiTenantQuerier := NewMultiTenantQuerier(querier, log.NewNopLogger())
+
+	ctx := user.InjectOrgID(context.Background(), "1|2")
+	req := &logproto.SeriesRequest{
+		Start:  originalStart,
+		End:    originalEnd,
+		Groups: []string{`{type="test"}`},
+	}
+
+	_, err := multiTenantQuerier.Series(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 2, callCount, "both tenants should be queried")
+}
+
 func TestMultiTenantQuerierPatterns(t *testing.T) {
 	now := time.Now()
 


### PR DESCRIPTION
## Summary

- `MultiTenantQuerier` shared a single request pointer across per-tenant iterations in `SelectLogs`, `SelectSamples`, `Label`, `Series`, and `DetectedLabels`
- `SingleTenantQuerier` mutates `Start`, `End`, and `Deletes` on the request during execution, poisoning subsequent tenants' query parameters
- Deep-copy the request struct before each iteration so mutations in one tenant's execution path cannot affect another

Closes #21936

## Test plan

- [x] Added unit tests for `SelectLogs`, `SelectSamples`, `Label`, and `Series` that simulate downstream mutation and verify each tenant receives original params
- [x] All existing `TestMultiTenantQuerier*` tests pass
- [ ] Validated with the reproduction script from the issue (multi-tenant query over ingester/store boundary window)