### PR TITLE
fix(scheduler): warn and enforce fixed ring params instead of rejecting

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -2057,6 +2057,17 @@ func (t *Loki) initQuerySchedulerRing() (_ services.Service, err error) {
 	// Set some config sections from other config sections in the config struct
 	t.Cfg.QueryScheduler.SchedulerRing.ListenPort = t.Cfg.Server.GRPCListenPort
 
+	// num_tokens/replication_factor exist via the shared ring config but are fixed for the
+	// scheduler ring (built from the constants below), so a configured value is ignored.
+	if t.Cfg.QueryScheduler.SchedulerRing.NumTokens != scheduler.NumTokens {
+		level.Warn(util_log.Logger).Log("msg", "ignoring configured query_scheduler.scheduler_ring.num_tokens; it is fixed for the scheduler ring", "configured", t.Cfg.QueryScheduler.SchedulerRing.NumTokens, "fixed", scheduler.NumTokens)
+		t.Cfg.QueryScheduler.SchedulerRing.NumTokens = scheduler.NumTokens
+	}
+	if t.Cfg.QueryScheduler.SchedulerRing.ReplicationFactor != scheduler.ReplicationFactor {
+		level.Warn(util_log.Logger).Log("msg", "ignoring configured query_scheduler.scheduler_ring.replication_factor; it is fixed for the scheduler ring", "configured", t.Cfg.QueryScheduler.SchedulerRing.ReplicationFactor, "fixed", scheduler.ReplicationFactor)
+		t.Cfg.QueryScheduler.SchedulerRing.ReplicationFactor = scheduler.ReplicationFactor
+	}
+
 	managerMode := lokiring.ClientMode
 	if t.Cfg.isTarget(QueryScheduler) || t.Cfg.isTarget(Backend) || t.Cfg.isTarget(All) || (t.Cfg.LegacyReadTarget && t.Cfg.isTarget(Read)) {
 		managerMode = lokiring.ServerMode

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -132,12 +132,9 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 }
 
 func (cfg *Config) Validate() error {
-	if cfg.SchedulerRing.NumTokens != NumTokens {
-		return errors.New("Num tokens must not be changed as it will not take effect")
-	}
-	if cfg.SchedulerRing.ReplicationFactor != ReplicationFactor {
-		return errors.New("Replication factor must not be changed as it will not take effect")
-	}
+	// NumTokens and ReplicationFactor are fixed for the scheduler ring (built from the constants
+	// directly), so a configured value never takes effect. We don't reject a mismatch: that would
+	// crash boot for setting a field that's ignored anyway. Reset and warned in initQuerySchedulerRing.
 	return nil
 }
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -160,6 +160,15 @@ func TestProtobufBackwardsCompatibility(t *testing.T) {
 	})
 }
 
+func TestConfig_Validate_AllowsNonDefaultRingParams(t *testing.T) {
+	// Fixed ring params set in config must not fail Validate; they're reset at ring construction.
+	cfg := Config{}
+	cfg.SchedulerRing.NumTokens = 999
+	cfg.SchedulerRing.ReplicationFactor = 1
+
+	require.NoError(t, cfg.Validate())
+}
+
 type mockSchedulerForFrontendFrontendLoopServer struct {
 	msg    *schedulerpb.SchedulerToFrontend
 	recvFn func() (*schedulerpb.FrontendToScheduler, error)


### PR DESCRIPTION
## Summary

`scheduler_ring` reuses the shared ring config, so `num_tokens` and `replication_factor` appear in config but are fixed for the scheduler ring (1 and 2); the ring is built from those constants, so a configured value is ignored.

`Validate()` used to return a fatal error when either was set to a non-default, so explicitly setting `query_scheduler.scheduler_ring.replication_factor` crashed Loki on boot, for a field that's ignored anyway.

This removes the fatal check. At ring construction the value is reset to the fixed one and a warning is logged.

Closes #19890

## Test plan

- [x] Unit test: non-default ring params pass `Validate()` without error
- [x] Existing scheduler tests + `go vet` pass
