### PR TITLE
chore(compactor): Retry transient errors for delete operations

### DIFF
--- a/pkg/compactor/index_set.go
+++ b/pkg/compactor/index_set.go
@@ -374,14 +374,14 @@ func (is *indexSet) removeFileFromStorage(object storage.IndexFile) error {
 			level.Warn(is.logger).Log(
 				"msg", "delete from storage: retrying transient error",
 				"file", object.Name,
-				"err", "err",
+				"err", err,
 			)
 			retry.Wait()
 		} else if is.baseIndexSet.IsFileNotFoundErr(err) {
 			level.Warn(is.logger).Log(
 				"msg", "delete from storage: ignoring file not found error",
 				"file", object.Name,
-				"err", "err",
+				"err", err,
 			)
 			return nil
 		} else {

--- a/pkg/compactor/index_set.go
+++ b/pkg/compactor/index_set.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/backoff"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -23,6 +25,12 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/storage"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
+
+var deleteFileBackoffConfig = backoff.Config{
+	MinBackoff: 100 * time.Millisecond,
+	MaxBackoff: time.Second,
+	MaxRetries: 5,
+}
 
 type IndexSet interface {
 	GetTableName() string
@@ -342,13 +350,46 @@ func (is *indexSet) removeFilesFromStorage() error {
 	level.Info(is.logger).Log("msg", "removing source db files from storage", "count", len(is.sourceObjects))
 
 	for _, object := range is.sourceObjects {
-		err := is.baseIndexSet.DeleteFile(is.ctx, is.tableName, is.userID, object.Name)
-		if err != nil {
+		if err := is.removeFileFromStorage(object); err != nil {
+			level.Error(is.logger).Log("msg", "failed to remove source db file from storage", "file", object.Name, "err", err)
 			return err
 		}
 	}
 
 	return nil
+}
+
+// removeFileFromStorage deletes the object from storage.
+// It retries transient errors and treats FileNotFound errors
+// as a success. A missing file should not stall compaction.
+func (is *indexSet) removeFileFromStorage(object storage.IndexFile) error {
+	retry := backoff.New(is.ctx, deleteFileBackoffConfig)
+	for retry.Ongoing() {
+		err := is.baseIndexSet.DeleteFile(is.ctx, is.tableName, is.userID, object.Name)
+		if err == nil {
+			return nil
+		}
+
+		if is.baseIndexSet.IsRetryableErr(err) {
+			level.Warn(is.logger).Log(
+				"msg", "delete from storage: retrying transient error",
+				"file", object.Name,
+				"err", "err",
+			)
+			retry.Wait()
+		} else if is.baseIndexSet.IsFileNotFoundErr(err) {
+			level.Warn(is.logger).Log(
+				"msg", "delete from storage: ignoring file not found error",
+				"file", object.Name,
+				"err", "err",
+			)
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	return retry.Err()
 }
 
 // done takes care of file operations which includes:

--- a/pkg/compactor/index_set_test.go
+++ b/pkg/compactor/index_set_test.go
@@ -313,13 +313,13 @@ func TestIndexSet_RemoveFilesFromStorageRetries(t *testing.T) {
 func setDeleteSourceObjectsBackoffConfigForTest(t *testing.T) func() {
 	t.Helper()
 
-	originalConfig := deleteSourceObjectsBackoffConfig
-	deleteSourceObjectsBackoffConfig.MinBackoff = time.Nanosecond
-	deleteSourceObjectsBackoffConfig.MaxBackoff = time.Nanosecond
-	deleteSourceObjectsBackoffConfig.MaxRetries = 3
+	originalConfig := deleteFileBackoffConfig
+	deleteFileBackoffConfig.MinBackoff = time.Nanosecond
+	deleteFileBackoffConfig.MaxBackoff = time.Nanosecond
+	deleteFileBackoffConfig.MaxRetries = 3
 
 	return func() {
-		deleteSourceObjectsBackoffConfig = originalConfig
+		deleteFileBackoffConfig = originalConfig
 	}
 }
 

--- a/pkg/compactor/index_set_test.go
+++ b/pkg/compactor/index_set_test.go
@@ -1,11 +1,15 @@
 package compactor
 
 import (
+	"context"
+	"errors"
+	"io"
 	"slices"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -13,6 +17,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/compactor/deletion"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/storage/config"
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/storage"
 )
 
 type indexUpdatesRecorder struct {
@@ -223,4 +228,150 @@ func TestIndexSet_ApplyIndexUpdates(t *testing.T) {
 	require.Len(t, indexUpdatesRecorder.removedChunks, 0)
 	// it would not index any new chunks since all the source chunks were marked missing
 	require.Len(t, indexUpdatesRecorder.indexedChunks, 0)
+}
+
+func TestIndexSet_RemoveFilesFromStorageRetries(t *testing.T) {
+	restoreConfig := setDeleteSourceObjectsBackoffConfigForTest(t)
+	defer restoreConfig()
+
+	retryableErr := errors.New("transient error")
+	nonRetryableErr := errors.New("non-retryable error")
+
+	tests := []struct {
+		name              string
+		sourceObjects     []storage.IndexFile
+		deleteErrors      map[string][]error
+		retryableErr      error
+		expectedErr       error
+		expectedErrString string
+		expectedCalls     map[string]int
+	}{
+		{
+			name:          "retries retryable errors until delete succeeds",
+			sourceObjects: []storage.IndexFile{{Name: "source.gz"}},
+			deleteErrors: map[string][]error{
+				"source.gz": {retryableErr, retryableErr},
+			},
+			retryableErr: retryableErr,
+			expectedCalls: map[string]int{
+				"source.gz": 3,
+			},
+		},
+		{
+			name:          "fail after max retries",
+			sourceObjects: []storage.IndexFile{{Name: "failed.gz"}},
+			deleteErrors: map[string][]error{
+				"failed.gz": {retryableErr, retryableErr, retryableErr},
+			},
+			retryableErr:      retryableErr,
+			expectedErrString: "terminated after 3 retries",
+			expectedCalls: map[string]int{
+				"failed.gz": 3,
+			},
+		},
+		{
+			name:          "does not retry non-retryable errors",
+			sourceObjects: []storage.IndexFile{{Name: "source.gz"}},
+			deleteErrors: map[string][]error{
+				"source.gz": {nonRetryableErr},
+			},
+			retryableErr: retryableErr,
+			expectedErr:  nonRetryableErr,
+			expectedCalls: map[string]int{
+				"source.gz": 1,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseIndexSet := newDeleteRetryIndexSet(tt.sourceObjects, tt.deleteErrors, tt.retryableErr)
+			indexSet := &indexSet{
+				ctx:           context.Background(),
+				tableName:     "test",
+				baseIndexSet:  baseIndexSet,
+				sourceObjects: tt.sourceObjects,
+				logger:        log.NewNopLogger(),
+			}
+
+			err := indexSet.removeFilesFromStorage()
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr)
+			} else if tt.expectedErrString != "" {
+				require.ErrorContains(t, err, tt.expectedErrString)
+			} else {
+				require.NoError(t, err)
+			}
+
+			for fileName, expectedCalls := range tt.expectedCalls {
+				require.Equal(t, expectedCalls, baseIndexSet.deleteCalls[fileName])
+			}
+		})
+	}
+}
+
+func setDeleteSourceObjectsBackoffConfigForTest(t *testing.T) func() {
+	t.Helper()
+
+	originalConfig := deleteSourceObjectsBackoffConfig
+	deleteSourceObjectsBackoffConfig.MinBackoff = time.Nanosecond
+	deleteSourceObjectsBackoffConfig.MaxBackoff = time.Nanosecond
+	deleteSourceObjectsBackoffConfig.MaxRetries = 3
+
+	return func() {
+		deleteSourceObjectsBackoffConfig = originalConfig
+	}
+}
+
+type deleteRetryIndexSet struct {
+	sourceObjects []storage.IndexFile
+	deleteErrors  map[string][]error
+	deleteCalls   map[string]int
+	notFoundErr   error
+	retryableErr  error
+}
+
+func newDeleteRetryIndexSet(sourceObjects []storage.IndexFile, deleteErrors map[string][]error, retryableErr error) *deleteRetryIndexSet {
+	return &deleteRetryIndexSet{
+		sourceObjects: sourceObjects,
+		deleteErrors:  deleteErrors,
+		deleteCalls:   map[string]int{},
+		notFoundErr:   errors.New("not found"),
+		retryableErr:  retryableErr,
+	}
+}
+
+func (d *deleteRetryIndexSet) RefreshIndexTableCache(_ context.Context, _ string) {}
+
+func (d *deleteRetryIndexSet) ListFiles(_ context.Context, _, _ string, _ bool) ([]storage.IndexFile, error) {
+	return d.sourceObjects, nil
+}
+
+func (d *deleteRetryIndexSet) GetFile(_ context.Context, _, _, _ string) (io.ReadCloser, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (d *deleteRetryIndexSet) PutFile(_ context.Context, _, _, _ string, _ io.ReadSeeker) error {
+	return errors.New("not implemented")
+}
+
+func (d *deleteRetryIndexSet) DeleteFile(_ context.Context, _, _, fileName string) error {
+	calls := d.deleteCalls[fileName]
+	d.deleteCalls[fileName] = calls + 1
+	if calls < len(d.deleteErrors[fileName]) {
+		return d.deleteErrors[fileName][calls]
+	}
+	return nil
+}
+
+func (d *deleteRetryIndexSet) IsFileNotFoundErr(err error) bool {
+	return errors.Is(err, d.notFoundErr)
+}
+
+func (d *deleteRetryIndexSet) IsRetryableErr(err error) bool {
+	return errors.Is(err, d.retryableErr)
+}
+
+func (d *deleteRetryIndexSet) IsUserBasedIndexSet() bool {
+	return false
 }

--- a/pkg/logql/bench/discover/pkg/tsdb/download_test.go
+++ b/pkg/logql/bench/discover/pkg/tsdb/download_test.go
@@ -22,6 +22,7 @@ type fakeIndexStorageClient struct {
 	listUserFilesFn  func(ctx context.Context, tableName, userID string, bypassCache bool) ([]shipperstorage.IndexFile, error)
 	getUserFileFn    func(ctx context.Context, tableName, userID, fileName string) (io.ReadCloser, error)
 	isNotFoundErrFn  func(error) bool
+	isRetryableErrFn func(error) bool
 	listTablesFn     func(ctx context.Context) ([]string, error)
 	refreshTablesFn  func(ctx context.Context)
 	refreshTableFn   func(ctx context.Context, tableName string)
@@ -114,6 +115,13 @@ func (f fakeIndexStorageClient) IsFileNotFoundErr(err error) bool {
 		return false
 	}
 	return f.isNotFoundErrFn(err)
+}
+
+func (f fakeIndexStorageClient) IsRetryableErr(err error) bool {
+	if f.isRetryableErrFn == nil {
+		return false
+	}
+	return f.isRetryableErrFn(err)
 }
 
 func (f fakeIndexStorageClient) Stop() {

--- a/pkg/storage/stores/shipper/indexshipper/storage/client.go
+++ b/pkg/storage/stores/shipper/indexshipper/storage/client.go
@@ -37,6 +37,7 @@ type Client interface {
 	ListTables(ctx context.Context) ([]string, error)
 	RefreshIndexTableCache(ctx context.Context, tableName string)
 	IsFileNotFoundErr(err error) bool
+	IsRetryableErr(err error) bool
 	Stop()
 }
 
@@ -157,6 +158,10 @@ func (s *indexStorageClient) DeleteUserFile(ctx context.Context, tableName, user
 
 func (s *indexStorageClient) IsFileNotFoundErr(err error) bool {
 	return s.objectClient.IsObjectNotFoundErr(err)
+}
+
+func (s *indexStorageClient) IsRetryableErr(err error) bool {
+	return s.objectClient.IsRetryableErr(err)
 }
 
 func (s *indexStorageClient) Stop() {

--- a/pkg/storage/stores/shipper/indexshipper/storage/index_set.go
+++ b/pkg/storage/stores/shipper/indexshipper/storage/index_set.go
@@ -19,6 +19,7 @@ type IndexSet interface {
 	PutFile(ctx context.Context, tableName, userID, fileName string, file io.ReadSeeker) error
 	DeleteFile(ctx context.Context, tableName, userID, fileName string) error
 	IsFileNotFoundErr(err error) bool
+	IsRetryableErr(err error) bool
 	IsUserBasedIndexSet() bool
 }
 
@@ -104,6 +105,10 @@ func (i indexSet) DeleteFile(ctx context.Context, tableName, userID, fileName st
 
 func (i indexSet) IsFileNotFoundErr(err error) bool {
 	return i.client.IsFileNotFoundErr(err)
+}
+
+func (i indexSet) IsRetryableErr(err error) bool {
+	return i.client.IsRetryableErr(err)
 }
 
 func (i indexSet) IsUserBasedIndexSet() bool {


### PR DESCRIPTION
**What this PR does / why we need it**:

Compaction deletes source files as part of clean-up step. If any of the delete operations fail due to transient backend errors, it marks the compaction cycle as failed and stops processing the next set of tables. 

This PR updates the deletion code to retry retryable errors so that compaction is more resilient against cloud provider transient errors.  It also considers `NotFound` errors as a success and moves forward with the next steps as a missing file should not block compaction from making progress.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
