### PR TITLE
perf: Improve performance of JSON sample marshalling

### DIFF
--- a/pkg/logproto/compat.go
+++ b/pkg/logproto/compat.go
@@ -235,6 +235,19 @@ func unsafeSampleJsoniterDecode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 	}
 }
 
+func LabelAdaptersJsoniterEncode(lbls []LabelAdapter, stream *jsoniter.Stream) {
+	stream.WriteObjectStart()
+	for i, v := range lbls {
+		if i != 0 {
+			stream.WriteMore()
+		}
+		stream.WriteString(v.Name)
+		stream.WriteRaw(`:`)
+		stream.WriteString(v.Value)
+	}
+	stream.WriteObjectEnd()
+}
+
 func init() {
 	jsoniter.RegisterTypeEncoderFunc("logproto.LegacySample", unsafeSampleJsoniterEncode, nil)
 	jsoniter.RegisterTypeDecoderFunc("logproto.LegacySample", unsafeSampleJsoniterDecode)

--- a/pkg/logproto/compat.go
+++ b/pkg/logproto/compat.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/util/jsonutil"
 	attribute "go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
@@ -192,9 +193,9 @@ func SampleJsoniterEncode(legacySample *LegacySample, stream *jsoniter.Stream) {
 	}
 
 	stream.WriteArrayStart()
-	stream.WriteFloat64(float64(legacySample.TimestampMs) / float64(time.Second/time.Millisecond))
+	jsonutil.MarshalTimestamp(legacySample.TimestampMs, stream)
 	stream.WriteMore()
-	stream.WriteString(model.SampleValue(legacySample.Value).String())
+	jsonutil.MarshalFloat(legacySample.Value, stream)
 	stream.WriteArrayEnd()
 }
 

--- a/pkg/logproto/compat.go
+++ b/pkg/logproto/compat.go
@@ -180,9 +180,12 @@ func (s *LegacySample) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func SampleJsoniterEncode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+func unsafeSampleJsoniterEncode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	legacySample := (*LegacySample)(ptr)
+	SampleJsoniterEncode(legacySample, stream)
+}
 
+func SampleJsoniterEncode(legacySample *LegacySample, stream *jsoniter.Stream) {
 	if isTesting && math.IsNaN(legacySample.Value) {
 		stream.Error = fmt.Errorf("test sample")
 		return
@@ -195,7 +198,7 @@ func SampleJsoniterEncode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	stream.WriteArrayEnd()
 }
 
-func SampleJsoniterDecode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+func unsafeSampleJsoniterDecode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 	if !iter.ReadArray() {
 		iter.ReportError("logproto.LegacySample", "expected [")
 		return
@@ -232,8 +235,8 @@ func SampleJsoniterDecode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 }
 
 func init() {
-	jsoniter.RegisterTypeEncoderFunc("logproto.LegacySample", SampleJsoniterEncode, func(unsafe.Pointer) bool { return false })
-	jsoniter.RegisterTypeDecoderFunc("logproto.LegacySample", SampleJsoniterDecode)
+	jsoniter.RegisterTypeEncoderFunc("logproto.LegacySample", unsafeSampleJsoniterEncode, nil)
+	jsoniter.RegisterTypeDecoderFunc("logproto.LegacySample", unsafeSampleJsoniterDecode)
 }
 
 // Combine unique values from multiple LabelResponses into a single, sorted LabelResponse.

--- a/pkg/querier/queryrange/codec_test.go
+++ b/pkg/querier/queryrange/codec_test.go
@@ -2673,7 +2673,7 @@ func Benchmark_CodecEncodeLogs(b *testing.B) {
 	resp := &LokiResponse{
 		Status:    loghttp.QueryStatusSuccess,
 		Direction: logproto.BACKWARD,
-		Version:   uint32(loghttp.VersionV1),
+		Version:   1,
 		Limit:     1000,
 		Data: LokiData{
 			ResultType: loghttp.ResultTypeStream,

--- a/pkg/querier/queryrange/codec_test.go
+++ b/pkg/querier/queryrange/codec_test.go
@@ -2798,12 +2798,13 @@ func Benchmark_CodecDecodeSeries(b *testing.B) {
 
 func Benchmark_MergeResponses(b *testing.B) {
 	responses := make([]queryrangebase.Response, 100)
+	seriesData := generateSeries()
 	for i := range responses {
 		responses[i] = &LokiSeriesResponse{
 			Status:     "200",
 			Version:    1,
 			Statistics: stats.Result{},
-			Data:       generateSeries(),
+			Data:       seriesData,
 		}
 	}
 

--- a/pkg/querier/queryrange/codec_test.go
+++ b/pkg/querier/queryrange/codec_test.go
@@ -2663,6 +2663,29 @@ func Benchmark_CodecDecodeLogs(b *testing.B) {
 	}
 }
 
+func Benchmark_CodecEncodeLogs(b *testing.B) {
+	u := &url.URL{Path: "/loki/api/v1/query_range"}
+	req := &http.Request{
+		Method:     "GET",
+		RequestURI: u.String(),
+		URL:        u,
+	}
+	resp := &LokiResponse{
+		Status:    loghttp.QueryStatusSuccess,
+		Direction: logproto.BACKWARD,
+		Version:   uint32(loghttp.VersionV1),
+		Limit:     1000,
+		Data: LokiData{
+			ResultType: loghttp.ResultTypeStream,
+			Result:     generateStream(),
+		},
+	}
+	for b.Loop() {
+		_, err := DefaultCodec.EncodeResponse(b.Context(), req, resp)
+		require.Nil(b, err)
+	}
+}
+
 func Benchmark_CodecDecodeSamples(b *testing.B) {
 	ctx := context.Background()
 	u := &url.URL{Path: "/loki/api/v1/query_range"}
@@ -2700,6 +2723,28 @@ func Benchmark_CodecDecodeSamples(b *testing.B) {
 		})
 		require.NoError(b, err)
 		require.NotNil(b, result)
+	}
+}
+
+func Benchmark_CodecEncodeSamples(b *testing.B) {
+	u := &url.URL{Path: "/loki/api/v1/query_range"}
+	req := &http.Request{
+		Method:     "GET",
+		RequestURI: u.String(), // This is what the httpgrpc code looks at.
+		URL:        u,
+	}
+	resp := &LokiPromResponse{
+		Response: &queryrangebase.PrometheusResponse{
+			Status: loghttp.QueryStatusSuccess,
+			Data: queryrangebase.PrometheusData{
+				ResultType: loghttp.ResultTypeMatrix,
+				Result:     generateMatrix(),
+			},
+		},
+	}
+	for b.Loop() {
+		_, err := DefaultCodec.EncodeResponse(b.Context(), req, resp)
+		require.Nil(b, err)
 	}
 }
 
@@ -2775,7 +2820,7 @@ func Benchmark_MergeResponses(b *testing.B) {
 func generateMatrix() (res []queryrangebase.SampleStream) {
 	for i := 0; i < 100; i++ {
 		s := queryrangebase.SampleStream{
-			Labels:  []logproto.LabelAdapter{},
+			Labels:  []logproto.LabelAdapter{{Name: "foo", Value: strconv.Itoa(i)}, {Name: "buzz", Value: "bar"}, {Name: "cluster", Value: "us-central2"}, {Name: "namespace", Value: "loki-dev"}, {Name: "container", Value: "query-frontend"}},
 			Samples: []logproto.LegacySample{},
 		}
 		for j := 0; j < 1000; j++ {

--- a/pkg/querier/queryrange/detected_fields_test.go
+++ b/pkg/querier/queryrange/detected_fields_test.go
@@ -1437,13 +1437,15 @@ func BenchmarkQuerierDetectedFields(b *testing.B) {
 		maxQuerierBytesRead:     100,
 	}
 
-	request := logproto.DetectedFieldsRequest{
-		Start:     time.Now().Add(-1 * time.Minute),
-		End:       time.Now(),
-		Query:     `{type="test"}`,
-		LineLimit: 1000,
-		Limit:     1000,
-	}
+	request := NewDetectedFieldsRequest(
+		time.Now().Add(-1*time.Minute),
+		time.Now(),
+		1000,
+		1000,
+		60000,
+		`{type="test"}`,
+		`http://example.com`,
+	)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -1462,7 +1464,7 @@ func BenchmarkQuerierDetectedFields(b *testing.B) {
 		ctx := context.Background()
 		ctx = user.InjectOrgID(ctx, "test-tenant")
 
-		resp, err := handler.Do(ctx, &request)
+		resp, err := handler.Do(ctx, request)
 		assert.NoError(b, err)
 
 		_, ok := resp.(*DetectedFieldsResponse)

--- a/pkg/querier/queryrange/queryrangebase/query_range.go
+++ b/pkg/querier/queryrange/queryrangebase/query_range.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"sort"
 	"time"
+	"unsafe"
 
 	"github.com/grafana/dskit/httpgrpc"
 	jsoniter "github.com/json-iterator/go"
@@ -54,6 +55,10 @@ type prometheusCodec struct {
 	// when creating empty responses during merge, it need to be aware what kind of valueType it should create with.
 	// helps other middlewares to filter the correct result type.
 	resultType model.ValueType
+}
+
+func init() {
+	jsoniter.RegisterTypeEncoderFunc("queryrangebase.SampleStream", SampleStreamJsoniterEncode, nil)
 }
 
 // WithStartEnd clones the current `PrometheusRequest` with a new `start` and `end` timestamp.
@@ -298,6 +303,25 @@ func (s *SampleStream) MarshalJSON() ([]byte, error) {
 		Values: s.Samples,
 	}
 	return json.Marshal(stream)
+}
+
+func SampleStreamJsoniterEncode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	s := (*SampleStream)(ptr)
+
+	stream.WriteObjectStart()
+	stream.WriteObjectField("metric")
+	logproto.LabelAdaptersJsoniterEncode(s.Labels, stream)
+	stream.WriteMore()
+	stream.WriteObjectField("values")
+	stream.WriteArrayStart()
+	for i := range s.Samples {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		logproto.SampleJsoniterEncode(&s.Samples[i], stream)
+	}
+	stream.WriteArrayEnd()
+	stream.WriteObjectEnd()
 }
 
 func matrixMerge(resps []*PrometheusResponse) []SampleStream {

--- a/pkg/querier/queryrange/views_test.go
+++ b/pkg/querier/queryrange/views_test.go
@@ -311,12 +311,13 @@ func Benchmark_DecodeMergeEncodeCycle(b *testing.B) {
 	require.NoError(b, err)
 
 	responses := make([]*LokiSeriesResponse, 100)
+	seriesData := generateSeries()
 	for i := range responses {
 		responses[i] = &LokiSeriesResponse{
 			Status:     "200",
 			Version:    1,
 			Statistics: stats.Result{},
-			Data:       generateSeries(),
+			Data:       seriesData,
 		}
 	}
 

--- a/vendor/github.com/prometheus/prometheus/util/jsonutil/marshal.go
+++ b/vendor/github.com/prometheus/prometheus/util/jsonutil/marshal.go
@@ -1,0 +1,137 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonutil
+
+import (
+	"math"
+	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/prometheus/prometheus/model/histogram"
+)
+
+// MarshalTimestamp marshals a point timestamp using the passed jsoniter stream.
+func MarshalTimestamp(t int64, stream *jsoniter.Stream) {
+	// Write out the timestamp as a float divided by 1000.
+	// This is ~3x faster than converting to a float.
+	if t < 0 {
+		stream.WriteRaw(`-`)
+		t = -t
+	}
+	stream.WriteInt64(t / 1000)
+	fraction := t % 1000
+	if fraction != 0 {
+		stream.WriteRaw(`.`)
+		if fraction < 100 {
+			stream.WriteRaw(`0`)
+		}
+		if fraction < 10 {
+			stream.WriteRaw(`0`)
+		}
+		stream.WriteInt64(fraction)
+	}
+}
+
+// MarshalFloat marshals a float value using the passed jsoniter stream.
+func MarshalFloat(f float64, stream *jsoniter.Stream) {
+	stream.WriteRaw(`"`)
+	// Taken from https://github.com/json-iterator/go/blob/master/stream_float.go#L71 as a workaround
+	// to https://github.com/json-iterator/go/issues/365 (jsoniter, to follow json standard, doesn't allow inf/nan).
+	buf := stream.Buffer()
+	abs := math.Abs(f)
+	fmt := byte('f')
+	// Note: Must use float32 comparisons for underlying float32 value to get precise cutoffs right.
+	if abs != 0 {
+		if abs < 1e-6 || abs >= 1e21 {
+			fmt = 'e'
+		}
+	}
+	buf = strconv.AppendFloat(buf, f, fmt, -1, 64)
+	stream.SetBuffer(buf)
+	stream.WriteRaw(`"`)
+}
+
+// MarshalHistogram marshals a histogram value using the passed jsoniter stream.
+// It writes something like:
+//
+//	{
+//	    "count": "42",
+//	    "sum": "34593.34",
+//	    "buckets": [
+//	      [ 3, "-0.25", "0.25", "3"],
+//	      [ 0, "0.25", "0.5", "12"],
+//	      [ 0, "0.5", "1", "21"],
+//	      [ 0, "2", "4", "6"]
+//	    ]
+//	}
+//
+// The 1st element in each bucket array determines if the boundaries are
+// inclusive (AKA closed) or exclusive (AKA open):
+//
+//	0: lower exclusive, upper inclusive
+//	1: lower inclusive, upper exclusive
+//	2: both exclusive
+//	3: both inclusive
+//
+// The 2nd and 3rd elements are the lower and upper boundary. The 4th element is
+// the bucket count.
+func MarshalHistogram(h *histogram.FloatHistogram, stream *jsoniter.Stream) {
+	stream.WriteObjectStart()
+	stream.WriteObjectField(`count`)
+	MarshalFloat(h.Count, stream)
+	stream.WriteMore()
+	stream.WriteObjectField(`sum`)
+	MarshalFloat(h.Sum, stream)
+
+	bucketFound := false
+	it := h.AllBucketIterator()
+	for it.Next() {
+		bucket := it.At()
+		if bucket.Count == 0 {
+			continue // No need to expose empty buckets in JSON.
+		}
+		stream.WriteMore()
+		if !bucketFound {
+			stream.WriteObjectField(`buckets`)
+			stream.WriteArrayStart()
+		}
+		bucketFound = true
+		boundaries := 2 // Exclusive on both sides AKA open interval.
+		if bucket.LowerInclusive {
+			if bucket.UpperInclusive {
+				boundaries = 3 // Inclusive on both sides AKA closed interval.
+			} else {
+				boundaries = 1 // Inclusive only on lower end AKA right open.
+			}
+		} else {
+			if bucket.UpperInclusive {
+				boundaries = 0 // Inclusive only on upper end AKA left open.
+			}
+		}
+		stream.WriteArrayStart()
+		stream.WriteInt(boundaries)
+		stream.WriteMore()
+		MarshalFloat(bucket.Lower, stream)
+		stream.WriteMore()
+		MarshalFloat(bucket.Upper, stream)
+		stream.WriteMore()
+		MarshalFloat(bucket.Count, stream)
+		stream.WriteArrayEnd()
+	}
+	if bucketFound {
+		stream.WriteArrayEnd()
+	}
+	stream.WriteObjectEnd()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1469,6 +1469,7 @@ github.com/prometheus/prometheus/util/compression
 github.com/prometheus/prometheus/util/convertnhcb
 github.com/prometheus/prometheus/util/features
 github.com/prometheus/prometheus/util/gate
+github.com/prometheus/prometheus/util/jsonutil
 github.com/prometheus/prometheus/util/kahansum
 github.com/prometheus/prometheus/util/logging
 github.com/prometheus/prometheus/util/namevalidationutil


### PR DESCRIPTION
**What this PR does / why we need it**:

* Fix one benchmark - `BenchmarkQuerierDetectedFields` - which did not work at all.
The code needs a different type. Use the utility function to improve detection of future drift.

* Added new benchmarks for encoding logs and samples. Also add labels to generated data

* Make the `unsafe.Pointer` functions unexported, for use only with `jsoniter`.

* Marshal samples using Prometheus utils - both timestamp and value have been optimised for speed inside Prometheus.

* Add a jsoniter encoder for SampleStream.
This avoids going via a map for the labels, and via an extra buffer copy for the samples.

### Benchmarks: 

```
goos: linux
goarch: amd64
pkg: github.com/grafana/loki/v3/pkg/querier/queryrange
cpu: Intel(R) Core(TM) i7-14700K
                       │   before    │               after                │
                       │   sec/op    │   sec/op     vs base               │
_CodecEncodeSamples-28   6.950m ± 2%   3.898m ± 1%  -43.92% (p=0.002 n=6)

                       │    before     │                after                │
                       │     B/op      │     B/op       vs base              │
_CodecEncodeSamples-28   5.022Mi ± 10%   4.733Mi ± 10%  -5.75% (p=0.026 n=6)

                       │     before     │               after                │
                       │   allocs/op    │  allocs/op   vs base               │
_CodecEncodeSamples-28   100938.00 ± 0%   21.00 ± 10%  -99.98% (p=0.002 n=6)
```

**Special notes for your reviewer**:

I would recommend careful review, as any change in the output could be noticeable by end-users.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- NA If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
