### PR TITLE
fix(v2-engine): Treat null string column entries as empty string in label/line filters to match v1 LogQL semantics

### DIFF
--- a/pkg/engine/internal/executor/functions.go
+++ b/pkg/engine/internal/executor/functions.go
@@ -43,37 +43,37 @@ func init() {
 
 	// Functions for [types.BinaryOpEq]
 	binaryFunctions.register(types.BinaryOpEq, arrow.FixedWidthTypes.Boolean, &genericBoolFunction[*array.Boolean, bool]{eval: func(a, b bool) (bool, error) { return a == b, nil }})
-	binaryFunctions.register(types.BinaryOpEq, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{eval: func(a, b string) (bool, error) { return a == b, nil }})
+	binaryFunctions.register(types.BinaryOpEq, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{nullAsZero: true, eval: func(a, b string) (bool, error) { return a == b, nil }})
 	binaryFunctions.register(types.BinaryOpEq, arrow.PrimitiveTypes.Int64, &genericBoolFunction[*array.Int64, int64]{eval: func(a, b int64) (bool, error) { return a == b, nil }})
 	binaryFunctions.register(types.BinaryOpEq, arrow.FixedWidthTypes.Timestamp_ns, &genericBoolFunction[*array.Timestamp, arrow.Timestamp]{eval: func(a, b arrow.Timestamp) (bool, error) { return a == b, nil }})
 	binaryFunctions.register(types.BinaryOpEq, arrow.PrimitiveTypes.Float64, &genericBoolFunction[*array.Float64, float64]{eval: func(a, b float64) (bool, error) { return a == b, nil }})
 	// Functions for [types.BinaryOpNeq]
 	binaryFunctions.register(types.BinaryOpNeq, arrow.FixedWidthTypes.Boolean, &genericBoolFunction[*array.Boolean, bool]{eval: func(a, b bool) (bool, error) { return a != b, nil }})
-	binaryFunctions.register(types.BinaryOpNeq, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{eval: func(a, b string) (bool, error) { return a != b, nil }})
+	binaryFunctions.register(types.BinaryOpNeq, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{nullAsZero: true, eval: func(a, b string) (bool, error) { return a != b, nil }})
 	binaryFunctions.register(types.BinaryOpNeq, arrow.PrimitiveTypes.Int64, &genericBoolFunction[*array.Int64, int64]{eval: func(a, b int64) (bool, error) { return a != b, nil }})
 	binaryFunctions.register(types.BinaryOpNeq, arrow.FixedWidthTypes.Timestamp_ns, &genericBoolFunction[*array.Timestamp, arrow.Timestamp]{eval: func(a, b arrow.Timestamp) (bool, error) { return a != b, nil }})
 	binaryFunctions.register(types.BinaryOpNeq, arrow.PrimitiveTypes.Float64, &genericBoolFunction[*array.Float64, float64]{eval: func(a, b float64) (bool, error) { return a != b, nil }})
 	// Functions for [types.BinaryOpGt]
 	binaryFunctions.register(types.BinaryOpGt, arrow.FixedWidthTypes.Boolean, &genericBoolFunction[*array.Boolean, bool]{eval: func(a, b bool) (bool, error) { return boolToInt(a) > boolToInt(b), nil }})
-	binaryFunctions.register(types.BinaryOpGt, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{eval: func(a, b string) (bool, error) { return a > b, nil }})
+	binaryFunctions.register(types.BinaryOpGt, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{nullAsZero: true, eval: func(a, b string) (bool, error) { return a > b, nil }})
 	binaryFunctions.register(types.BinaryOpGt, arrow.PrimitiveTypes.Int64, &genericBoolFunction[*array.Int64, int64]{eval: func(a, b int64) (bool, error) { return a > b, nil }})
 	binaryFunctions.register(types.BinaryOpGt, arrow.FixedWidthTypes.Timestamp_ns, &genericBoolFunction[*array.Timestamp, arrow.Timestamp]{eval: func(a, b arrow.Timestamp) (bool, error) { return a > b, nil }})
 	binaryFunctions.register(types.BinaryOpGt, arrow.PrimitiveTypes.Float64, &genericBoolFunction[*array.Float64, float64]{eval: func(a, b float64) (bool, error) { return a > b, nil }})
 	// Functions for [types.BinaryOpGte]
 	binaryFunctions.register(types.BinaryOpGte, arrow.FixedWidthTypes.Boolean, &genericBoolFunction[*array.Boolean, bool]{eval: func(a, b bool) (bool, error) { return boolToInt(a) >= boolToInt(b), nil }})
-	binaryFunctions.register(types.BinaryOpGte, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{eval: func(a, b string) (bool, error) { return a >= b, nil }})
+	binaryFunctions.register(types.BinaryOpGte, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{nullAsZero: true, eval: func(a, b string) (bool, error) { return a >= b, nil }})
 	binaryFunctions.register(types.BinaryOpGte, arrow.PrimitiveTypes.Int64, &genericBoolFunction[*array.Int64, int64]{eval: func(a, b int64) (bool, error) { return a >= b, nil }})
 	binaryFunctions.register(types.BinaryOpGte, arrow.FixedWidthTypes.Timestamp_ns, &genericBoolFunction[*array.Timestamp, arrow.Timestamp]{eval: func(a, b arrow.Timestamp) (bool, error) { return a >= b, nil }})
 	binaryFunctions.register(types.BinaryOpGte, arrow.PrimitiveTypes.Float64, &genericBoolFunction[*array.Float64, float64]{eval: func(a, b float64) (bool, error) { return a >= b, nil }})
 	// Functions for [types.BinaryOpLt]
 	binaryFunctions.register(types.BinaryOpLt, arrow.FixedWidthTypes.Boolean, &genericBoolFunction[*array.Boolean, bool]{eval: func(a, b bool) (bool, error) { return boolToInt(a) < boolToInt(b), nil }})
-	binaryFunctions.register(types.BinaryOpLt, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{eval: func(a, b string) (bool, error) { return a < b, nil }})
+	binaryFunctions.register(types.BinaryOpLt, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{nullAsZero: true, eval: func(a, b string) (bool, error) { return a < b, nil }})
 	binaryFunctions.register(types.BinaryOpLt, arrow.PrimitiveTypes.Int64, &genericBoolFunction[*array.Int64, int64]{eval: func(a, b int64) (bool, error) { return a < b, nil }})
 	binaryFunctions.register(types.BinaryOpLt, arrow.FixedWidthTypes.Timestamp_ns, &genericBoolFunction[*array.Timestamp, arrow.Timestamp]{eval: func(a, b arrow.Timestamp) (bool, error) { return a < b, nil }})
 	binaryFunctions.register(types.BinaryOpLt, arrow.PrimitiveTypes.Float64, &genericBoolFunction[*array.Float64, float64]{eval: func(a, b float64) (bool, error) { return a < b, nil }})
 	// Functions for [types.BinaryOpLte]
 	binaryFunctions.register(types.BinaryOpLte, arrow.FixedWidthTypes.Boolean, &genericBoolFunction[*array.Boolean, bool]{eval: func(a, b bool) (bool, error) { return boolToInt(a) <= boolToInt(b), nil }})
-	binaryFunctions.register(types.BinaryOpLte, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{eval: func(a, b string) (bool, error) { return a <= b, nil }})
+	binaryFunctions.register(types.BinaryOpLte, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{nullAsZero: true, eval: func(a, b string) (bool, error) { return a <= b, nil }})
 	binaryFunctions.register(types.BinaryOpLte, arrow.PrimitiveTypes.Int64, &genericBoolFunction[*array.Int64, int64]{eval: func(a, b int64) (bool, error) { return a <= b, nil }})
 	binaryFunctions.register(types.BinaryOpLte, arrow.FixedWidthTypes.Timestamp_ns, &genericBoolFunction[*array.Timestamp, arrow.Timestamp]{eval: func(a, b arrow.Timestamp) (bool, error) { return a <= b, nil }})
 	binaryFunctions.register(types.BinaryOpLte, arrow.PrimitiveTypes.Float64, &genericBoolFunction[*array.Float64, float64]{eval: func(a, b float64) (bool, error) { return a <= b, nil }})
@@ -84,9 +84,9 @@ func init() {
 	// Functions for [types.BinaryOpXor]
 	binaryFunctions.register(types.BinaryOpXor, arrow.FixedWidthTypes.Boolean, &genericBoolFunction[*array.Boolean, bool]{eval: func(a, b bool) (bool, error) { return a != b, nil }})
 	// Functions for [types.BinaryOpMatchSubstr]
-	binaryFunctions.register(types.BinaryOpMatchSubstr, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{eval: func(a, b string) (bool, error) { return strings.Contains(a, b), nil }})
+	binaryFunctions.register(types.BinaryOpMatchSubstr, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{nullAsZero: true, eval: func(a, b string) (bool, error) { return strings.Contains(a, b), nil }})
 	// Functions for [types.BinaryOpNotMatchSubstr]
-	binaryFunctions.register(types.BinaryOpNotMatchSubstr, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{eval: func(a, b string) (bool, error) { return !strings.Contains(a, b), nil }})
+	binaryFunctions.register(types.BinaryOpNotMatchSubstr, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{nullAsZero: true, eval: func(a, b string) (bool, error) { return !strings.Contains(a, b), nil }})
 	// Functions for [types.BinaryOpMatchRe]
 	binaryFunctions.register(types.BinaryOpMatchRe, arrow.BinaryTypes.String, &regexpFunction{eval: func(a, b string, reg *regexp.Regexp) (bool, error) {
 		if reg == nil {
@@ -113,19 +113,19 @@ func init() {
 	}})
 
 	// Functions for [types.BinaryOpEqCaseInsensitive]
-	binaryFunctions.register(types.BinaryOpEqCaseInsensitive, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{eval: func(a, b string) (bool, error) {
+	binaryFunctions.register(types.BinaryOpEqCaseInsensitive, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{nullAsZero: true, eval: func(a, b string) (bool, error) {
 		return matchutil.EqualUpper([]byte(a), []byte(b)), nil
 	}})
 	// Functions for [types.BinaryOpNotEqCaseInsensitive]
-	binaryFunctions.register(types.BinaryOpNotEqCaseInsensitive, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{eval: func(a, b string) (bool, error) {
+	binaryFunctions.register(types.BinaryOpNotEqCaseInsensitive, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{nullAsZero: true, eval: func(a, b string) (bool, error) {
 		return !matchutil.EqualUpper([]byte(a), []byte(b)), nil
 	}})
 	// Functions for [types.BinaryOpMatchSubstrCaseInsensitive]
-	binaryFunctions.register(types.BinaryOpMatchSubstrCaseInsensitive, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{eval: func(a, b string) (bool, error) {
+	binaryFunctions.register(types.BinaryOpMatchSubstrCaseInsensitive, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{nullAsZero: true, eval: func(a, b string) (bool, error) {
 		return matchutil.ContainsUpper([]byte(a), []byte(b)), nil
 	}})
 	// Functions for [types.BinaryOpNotMatchSubstrCaseInsensitive]
-	binaryFunctions.register(types.BinaryOpNotMatchSubstrCaseInsensitive, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{eval: func(a, b string) (bool, error) {
+	binaryFunctions.register(types.BinaryOpNotMatchSubstrCaseInsensitive, arrow.BinaryTypes.String, &genericBoolFunction[*array.String, string]{nullAsZero: true, eval: func(a, b string) (bool, error) {
 		return !matchutil.ContainsUpper([]byte(a), []byte(b)), nil
 	}})
 
@@ -247,11 +247,39 @@ func (b *binaryFuncReg) GetForSignature(op types.BinaryOp, ltype arrow.DataType)
 	return fn, nil
 }
 
+// coerceNullEntries returns the pair of values to compare at row i, applying
+// the LogQL filter null-handling rule: when the comparison is column-vs-literal
+// (one side is a scalar), a null on the non-scalar side is treated as the zero
+// value of T. For strings that is "", which matches v1's behaviour where an
+// absent label compares as "" — so e.g. `| foo=""` and `| foo=~".*"` both match
+// rows where foo is absent. If neither side is a scalar and at least one is
+// null, returns skip=true so the caller preserves the existing null
+// short-circuit (no LogQL semantic applies to that shape).
+//
+// Only enable this via [genericBoolFunction.nullAsZero] for string-typed
+// registrations. For numeric LogQL ops, an absent unwrapped value is dropped
+// rather than coerced to zero, so the old null short-circuit is still correct.
+func coerceNullEntries[E arrow.TypedArray[T], T arrow.ValueType](lhs, rhs E, i int, lhsIsScalar, rhsIsScalar bool) (a, b T, skip bool) {
+	lhsNull := lhs.IsNull(i)
+	rhsNull := rhs.IsNull(i)
+	var zero T
+	switch {
+	case lhsNull && rhsIsScalar:
+		return zero, rhs.Value(i), false
+	case rhsNull && lhsIsScalar:
+		return lhs.Value(i), zero, false
+	case lhsNull || rhsNull:
+		return zero, zero, true
+	default:
+		return lhs.Value(i), rhs.Value(i), false
+	}
+}
+
 type regexpFunction struct {
 	eval func(a, b string, reg *regexp.Regexp) (bool, error)
 }
 
-func (f *regexpFunction) Evaluate(lhs arrow.Array, rhs arrow.Array, _, rhsIsScalar bool) (arrow.Array, error) {
+func (f *regexpFunction) Evaluate(lhs arrow.Array, rhs arrow.Array, lhsIsScalar, rhsIsScalar bool) (arrow.Array, error) {
 	if lhs.Len() != rhs.Len() {
 		return nil, arrow.ErrIndex
 	}
@@ -291,11 +319,12 @@ func (f *regexpFunction) Evaluate(lhs arrow.Array, rhs arrow.Array, _, rhsIsScal
 	}
 
 	for i := range lhsArr.Len() {
-		if lhsArr.IsNull(i) || rhsArr.IsNull(i) {
+		a, b, skip := coerceNullEntries(lhsArr, rhsArr, i, lhsIsScalar, rhsIsScalar)
+		if skip {
 			builder.Append(false)
 			continue
 		}
-		res, err := f.eval(lhsArr.Value(i), rhsArr.Value(i), re)
+		res, err := f.eval(a, b, re)
 		if err != nil {
 			return nil, err
 		}
@@ -310,10 +339,16 @@ func (f *regexpFunction) Evaluate(lhs arrow.Array, rhs arrow.Array, _, rhsIsScal
 // and can be used for any array type with comparable elements.
 type genericBoolFunction[E arrow.TypedArray[T], T arrow.ValueType] struct {
 	eval func(a, b T) (bool, error)
+	// nullAsZero, when true, applies LogQL filter null semantics: in the
+	// column-vs-literal shape, a null on the column side is treated as the
+	// zero value of T (i.e. "" for strings). Set on registrations for
+	// string-typed label/line filter comparators. Leave false for numeric
+	// comparisons, where LogQL drops the row rather than coercing.
+	nullAsZero bool
 }
 
 // Evaluate implements BinaryFunction.
-func (f *genericBoolFunction[E, T]) Evaluate(lhs arrow.Array, rhs arrow.Array, _, _ bool) (arrow.Array, error) {
+func (f *genericBoolFunction[E, T]) Evaluate(lhs arrow.Array, rhs arrow.Array, lhsIsScalar, rhsIsScalar bool) (arrow.Array, error) {
 	if lhs.Len() != rhs.Len() {
 		return nil, arrow.ErrIndex
 	}
@@ -332,11 +367,20 @@ func (f *genericBoolFunction[E, T]) Evaluate(lhs arrow.Array, rhs arrow.Array, _
 	builder.Reserve(lhsArr.Len())
 
 	for i := range lhsArr.Len() {
-		if lhsArr.IsNull(i) || rhsArr.IsNull(i) {
+		var a, b T
+		var skip bool
+		if f.nullAsZero {
+			a, b, skip = coerceNullEntries(lhsArr, rhsArr, i, lhsIsScalar, rhsIsScalar)
+		} else if lhsArr.IsNull(i) || rhsArr.IsNull(i) {
+			skip = true
+		} else {
+			a, b = lhsArr.Value(i), rhsArr.Value(i)
+		}
+		if skip {
 			builder.Append(false)
 			continue
 		}
-		res, err := f.eval(lhsArr.Value(i), rhsArr.Value(i))
+		res, err := f.eval(a, b)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/engine/internal/executor/functions_test.go
+++ b/pkg/engine/internal/executor/functions_test.go
@@ -880,6 +880,111 @@ func TestNullValueHandling(t *testing.T) {
 	}
 }
 
+// TestStringFilterNullAsEmpty verifies the LogQL filter null-coercion semantics:
+// when a string comparator runs as column-vs-literal (one side is a scalar), a
+// null entry on the column side is treated as the empty string "". This matches
+// v1, where an absent label compares as "" so `| foo=""` and `| foo=~".*"` both
+// match rows where foo is absent.
+func TestStringFilterNullAsEmpty(t *testing.T) {
+	// Each case constructs a single-row pair so the boolean result speaks
+	// directly to "does this column entry, treated as '', match this literal?".
+	cases := []struct {
+		name string
+		op   types.BinaryOp
+		// lhs row 0: nullable string. nil means null; ptr-to-string means present.
+		lhs *string
+		// rhs row 0: scalar literal string. The test always sets rhsIsScalar=true.
+		rhs      string
+		expected bool
+	}{
+		// BinaryOpEq — `orgID = ""` matches an absent (null) orgID.
+		{name: "Eq null lhs vs empty literal", op: types.BinaryOpEq, lhs: nil, rhs: "", expected: true},
+		{name: "Eq null lhs vs non-empty literal", op: types.BinaryOpEq, lhs: nil, rhs: "foo", expected: false},
+		{name: "Eq present empty lhs vs empty literal", op: types.BinaryOpEq, lhs: strPtr(""), rhs: "", expected: true},
+		{name: "Eq present value vs matching literal", op: types.BinaryOpEq, lhs: strPtr("foo"), rhs: "foo", expected: true},
+
+		// BinaryOpNeq — `orgID != "foo"` is true for absent (null) orgID.
+		{name: "Neq null lhs vs empty literal", op: types.BinaryOpNeq, lhs: nil, rhs: "", expected: false},
+		{name: "Neq null lhs vs non-empty literal", op: types.BinaryOpNeq, lhs: nil, rhs: "foo", expected: true},
+
+		// BinaryOpMatchRe — the bug shape: `orgID=~"(?i).*.*"` must match null.
+		{name: "MatchRe null lhs vs match-all", op: types.BinaryOpMatchRe, lhs: nil, rhs: ".*", expected: true},
+		{name: "MatchRe null lhs vs (?i).*.*", op: types.BinaryOpMatchRe, lhs: nil, rhs: "(?i).*.*", expected: true},
+		{name: "MatchRe null lhs vs require-non-empty", op: types.BinaryOpMatchRe, lhs: nil, rhs: ".+", expected: false},
+		{name: "MatchRe null lhs vs literal-foo", op: types.BinaryOpMatchRe, lhs: nil, rhs: "foo", expected: false},
+
+		// BinaryOpNotMatchRe — inversion of the above.
+		{name: "NotMatchRe null lhs vs match-all", op: types.BinaryOpNotMatchRe, lhs: nil, rhs: ".*", expected: false},
+		{name: "NotMatchRe null lhs vs require-non-empty", op: types.BinaryOpNotMatchRe, lhs: nil, rhs: ".+", expected: true},
+
+		// BinaryOpEqCaseInsensitive — same null-as-"" behaviour for the CI variants.
+		{name: "EqCaseInsensitive null lhs vs empty literal", op: types.BinaryOpEqCaseInsensitive, lhs: nil, rhs: "", expected: true},
+		{name: "EqCaseInsensitive null lhs vs FOO", op: types.BinaryOpEqCaseInsensitive, lhs: nil, rhs: "FOO", expected: false},
+
+		// BinaryOpMatchSubstr — `column |= "foo"` is false when the column is null.
+		// (In practice this op runs against the non-null message column, but the
+		// coercion still yields the LogQL-consistent answer here.)
+		{name: "MatchSubstr null lhs vs needle", op: types.BinaryOpMatchSubstr, lhs: nil, rhs: "foo", expected: false},
+		{name: "MatchSubstr null lhs vs empty needle", op: types.BinaryOpMatchSubstr, lhs: nil, rhs: "", expected: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var nulls []bool
+			values := []string{""}
+			if tc.lhs == nil {
+				nulls = []bool{true}
+			} else {
+				values[0] = *tc.lhs
+			}
+			lhsArr := createStringArray(values, nulls)
+			rhsArr := createStringArray([]string{tc.rhs}, nil)
+
+			fn, err := binaryFunctions.GetForSignature(tc.op, arrow.BinaryTypes.String)
+			require.NoError(t, err)
+
+			// rhsIsScalar=true is the column-vs-literal shape LogQL filters
+			// always produce. The fix only applies in this shape.
+			result, err := fn.Evaluate(lhsArr, rhsArr, false, true)
+			require.NoError(t, err)
+
+			got, _ := extractBoolValues(result)
+			require.Equal(t, []bool{tc.expected}, got)
+		})
+	}
+}
+
+// TestStringFilterNullAsEmpty_SymmetricLhsScalar verifies the coercion is
+// symmetric: a null on the rhs paired with a scalar lhs literal is also
+// coerced to "". The logical builder always puts the column on the left and
+// the literal on the right today, so this branch isn't reached by current
+// LogQL syntax; the test guards it for future-proofing.
+func TestStringFilterNullAsEmpty_SymmetricLhsScalar(t *testing.T) {
+	lhsArr := createStringArray([]string{""}, nil)          // scalar literal ""
+	rhsArr := createStringArray([]string{""}, []bool{true}) // null column on rhs
+
+	fn, err := binaryFunctions.GetForSignature(types.BinaryOpEq, arrow.BinaryTypes.String)
+	require.NoError(t, err)
+	result, err := fn.Evaluate(lhsArr, rhsArr, true, false)
+	require.NoError(t, err)
+	got, _ := extractBoolValues(result)
+	require.Equal(t, []bool{true}, got, `"" = null-as-"" should be true`)
+
+	// Symmetric case for regex.
+	lhsRe := createStringArray([]string{".*"}, nil)
+	rhsRe := createStringArray([]string{""}, []bool{true})
+	fn, err = binaryFunctions.GetForSignature(types.BinaryOpMatchRe, arrow.BinaryTypes.String)
+	require.NoError(t, err)
+	// NOTE: regex requires the pattern on the rhs; when lhs is scalar, eval
+	// treats lhs as the haystack. We only verify the null-rhs coercion does
+	// not crash and the loop completes — the LogQL semantic for this shape is
+	// undefined, but symmetry must not regress existing tests.
+	_, err = fn.Evaluate(lhsRe, rhsRe, true, false)
+	require.NoError(t, err)
+}
+
+func strPtr(s string) *string { return &s }
+
 func TestArrayLengthMismatch(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/logql/bench/queries/regression/metric-queries.yaml
+++ b/pkg/logql/bench/queries/regression/metric-queries.yaml
@@ -246,3 +246,25 @@ queries:
       log_format: logfmt
       detected_fields:
         - level
+  - description: Count with label equality filter on parsed field that is null on some rows
+    query: count_over_time(${SELECTOR} | logfmt | error="" [${RANGE}])
+    kind: metric
+    time_range:
+      length: 24h
+      step: 1m
+    tags:
+      - count_over_time
+      - logfmt
+      - label-filter
+      - absent-field
+    notes: >
+      Regression for the v2 filter null-coercion fix. The "error" logfmt field
+      is only emitted for error-level lines, so its parsed column is null on
+      every non-error row. LogQL says an absent label compares as "" (matching
+      v1); pre-fix the v2 engine short-circuited any filter on a null column to
+      false, so this count was 0 while v1 returned the count of non-error rows.
+      Must equal v1.
+    requires:
+      log_format: logfmt
+      detected_fields:
+        - error


### PR DESCRIPTION
**What this PR does / why we need it**:

_Problem:_

In the v2 engine, label/line filters on parsed string columns silently drop rows whose column entry is null. For example, `{app="my-service"} | logfmt | user_id=~".*"` returns fewer (or zero) rows than v1 when some lines have `user_id=""` or no user_id field.

_Root cause:_

In LogQL, an absent label evaluates to "". v1 honors this naturally (labels are map[string]string). v2 stores parsed labels as Arrow columns that can hold nulls, and the string comparators in [executor/functions.go](https://github.com/grafana/loki/blob/5585d0e7183bd9f381af1a61e1aa8e50c4a96151/pkg/engine/internal/executor/functions.go#L375-L378) short-circuited any null to false, which is wrong for the column-vs-literal shape every LogQL filter takes.

_Fix:_

In `genericBoolFunction` and `regexpFunction`, when one side is a scalar literal (already plumbed through BinaryFunction.Evaluate), treat a null on the column side as "". Gated by a new nullAsZero flag set only on string-typed registrations; numeric/boolean paths are untouched (a missing unwrapped number should drop, not coerce to 0). The column-vs-column branch is unchanged.
