### PR TITLE
chore(deps): Enable Renovate pseudo-version tracking for dskit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -231,6 +231,22 @@
       },
     },
     {
+      // Track dskit via pseudo-versions only (closest to main); mirrors the prometheus rule below.
+      // dskit has no semver tags, so without explicit digest enablement the global `digest.enabled: false`
+      // prevents Renovate from bumping its pseudo-version pin.
+      matchPackageNames: ['github.com/grafana/dskit'],
+      matchBaseBranches: ['main'],
+      matchFileNames: [
+        '!operator/go.mod',
+        '!operator/api/loki/go.mod',
+      ],
+      allowedVersions: '/^v[0-9]+\\.[0-9]+\\.[0-9]+-0\\.\\d{14}-[a-f0-9]+$/',
+      enabled: true,
+      digest: {
+        enabled: true,
+      },
+    },
+    {
       // Last: do not bump github.com/grafana/loki/pkg/push in any go.mod (overrides broader enable rules).
       matchManagers: ['gomod'],
       matchPackageNames: ['github.com/grafana/loki/pkg/push'],


### PR DESCRIPTION
## Summary

`github.com/grafana/dskit` is pinned via a Go pseudo-version (it has no semver tags). The repo-wide `digest.enabled: false` in `.github/renovate.json5` causes Renovate to skip pseudo-version → newer-pseudo-version bumps for gomod packages unless explicitly opted in.

dskit isn't excluded anywhere by name — it's just collateral damage from that global setting. Mimir gets dskit bumps for free because it extends `config:recommended` and leaves digests enabled; Loki needs an explicit override.

## Why

This mirrors the existing `github.com/prometheus/prometheus` rule that already does the same thing for the same reason. Without it, dskit only gets updated via manual PRs like #22296.

## Change

Adds a `packageRules` entry for `github.com/grafana/dskit`:
- scoped to `main`
- excludes `operator/go.mod` and `operator/api/loki/go.mod` to respect existing operator opt-outs
- restricts `allowedVersions` to the pseudo-version regex
- re-enables `digest` updates for this package