### PR TITLE
fix(detected_fields): try both json and logfmt parsers

### DIFF
--- a/pkg/querier/queryrange/detected_fields.go
+++ b/pkg/querier/queryrange/detected_fields.go
@@ -406,18 +406,31 @@ func parseEntry(entry push.Entry, lbls *logql_log.LabelsBuilder) (map[string][]s
 	}
 
 	line := entry.Line
-	parser := "json"
+	var parsers []string
+
 	jsonParser := logql_log.NewJSONParser(true)
 	_, jsonSuccess := jsonParser.Process(0, []byte(line), lblBuilder)
-	if !jsonSuccess || lblBuilder.HasErr() {
+	if jsonSuccess && !lblBuilder.HasErr() {
+		parsers = append(parsers, "json")
+	} else {
 		lblBuilder.Reset()
+	}
 
-		logFmtParser := logql_log.NewLogfmtParser(false, false)
-		parser = "logfmt"
-		_, logfmtSuccess := logFmtParser.Process(0, []byte(line), lblBuilder)
-		if !logfmtSuccess || lblBuilder.HasErr() {
-			return parsed, nil
+	logFmtParser := logql_log.NewLogfmtParser(false, false)
+	logfmtBuilder := logql_log.NewBaseLabelsBuilder().ForLabels(streamLbls, labels.StableHash(streamLbls))
+	_, logfmtSuccess := logFmtParser.Process(0, []byte(line), logfmtBuilder)
+	if logfmtSuccess && !logfmtBuilder.HasErr() {
+		logfmtLabels := logfmtBuilder.LabelsResult().Parsed()
+		if logfmtLabels.Len() > 0 {
+			parsers = append(parsers, "logfmt")
+			logfmtLabels.Range(func(lbl labels.Label) {
+				lblBuilder.Set(logql_log.ParsedLabel, lbl.Name, lbl.Value)
+			})
 		}
+	}
+
+	if len(parsers) == 0 {
+		return parsed, nil
 	}
 
 	parsedLabels := map[string]map[string]struct{}{}
@@ -456,7 +469,7 @@ func parseEntry(entry push.Entry, lbls *logql_log.LabelsBuilder) (map[string][]s
 		result[lbl] = vals
 	}
 
-	return result, []string{parser}
+	return result, parsers
 }
 
 func getParsedLabels(entry push.Entry) map[string][]string {

--- a/pkg/querier/queryrange/detected_fields_test.go
+++ b/pkg/querier/queryrange/detected_fields_test.go
@@ -183,7 +183,7 @@ func Test_parseDetectedFields(t *testing.T) {
 				parsers := df[expected].parsers
 
 				require.Len(t, parsers, 1, "expected only json parser for %s", expected)
-				require.Equal(t, "json", parsers[0], "expected only json parser for %s", expected)
+				require.Contains(t, parsers, "json", "expected json and logfmt parser for %s", expected)
 			}
 
 			// multiple parsers for fields that exist in both streams
@@ -272,7 +272,7 @@ func Test_parseDetectedFields(t *testing.T) {
 				parsers := df[expected].parsers
 
 				require.Len(t, parsers, 1, "expected only json parser for %s", expected)
-				require.Equal(t, "json", parsers[0], "expected only json parser for %s", expected)
+				require.Contains(t, parsers, "json", "expected json and logfmt parser for %s", expected)
 			}
 
 			// multiple parsers for fields that exist in both streams
@@ -614,7 +614,7 @@ func Test_parseDetectedFields(t *testing.T) {
 				parsers := df[expected].parsers
 
 				require.Len(t, parsers, 1, "expected only json parser for %s", expected)
-				require.Equal(t, "json", parsers[0], "expected only json parser for %s", expected)
+				require.Contains(t, parsers, "json", "expected json and logfmt parser for %s", expected)
 			}
 
 			// multiple parsers for fields that exist in both streams
@@ -819,7 +819,7 @@ func Test_parseDetectedFields(t *testing.T) {
 				parsers := df[expected].parsers
 
 				require.Len(t, parsers, 1, "expected only json parser for %s", expected)
-				require.Equal(t, "json", parsers[0], "expected only json parser for %s", expected)
+				require.Contains(t, parsers, "json", "expected json and logfmt parser for %s", expected)
 			}
 
 			// multiple parsers for fields that exist in both streams


### PR DESCRIPTION
**What this PR does / why we need it**:
The detected_fields API only tried one parser per log line. For lines
with nested fields inside JSON string values, it returned the wrong
parser, causing Logs Drilldown to generate queries that returned
empty results.

**Which issue(s) this PR fixes**:
Fixes #21689