### PR TITLE
chore: Park workers when full

### DIFF
--- a/pkg/engine/internal/proto/wirepb/wirepb.pb.go
+++ b/pkg/engine/internal/proto/wirepb/wirepb.pb.go
@@ -654,9 +654,7 @@ func (m *WorkerHelloMessage) GetThreads() uint64 {
 }
 
 // WorkerSubscribeMessage is sent by a scheduler to request a WorkerReadyMessage
-// from workers once they have at least one worker thread available.
-//
-// The subscription is cleared once the next WorkerReadyMessage is sent.
+// from workers whenever they transition from being fully occupied to having worker threads available.
 type WorkerSubscribeMessage struct {
 }
 

--- a/pkg/engine/internal/proto/wirepb/wirepb.proto
+++ b/pkg/engine/internal/proto/wirepb/wirepb.proto
@@ -76,9 +76,7 @@ message WorkerHelloMessage {
 }
 
 // WorkerSubscribeMessage is sent by a scheduler to request a WorkerReadyMessage
-// from workers once they have at least one worker thread available.
-//
-// The subscription is cleared once the next WorkerReadyMessage is sent.
+// from workers whenever they transition from being fully occupied to having worker threads available.
 message WorkerSubscribeMessage {}
 
 // WorkerReadyMessage is sent by a worker to the scheduler to signal that

--- a/pkg/engine/internal/scheduler/collector.go
+++ b/pkg/engine/internal/scheduler/collector.go
@@ -33,9 +33,7 @@ var _ prometheus.Collector = (*collector)(nil)
 // saturation average metrics will only be computed after calling
 // [collector.Process].
 func newCollector(sched *Scheduler) *collector {
-	var (
-		loadSource ewma.SourceFunc = func() float64 { return computeLoad(sched) }
-	)
+	var loadSource ewma.SourceFunc = func() float64 { return computeLoad(sched) }
 
 	return &collector{
 		sched: sched,
@@ -148,9 +146,7 @@ func (mc *collector) collectResourceStats(ch chan<- prometheus.Metric) {
 }
 
 func (mc *collector) collectConnStats(ch chan<- prometheus.Metric) {
-	var (
-		totalConnections int
-	)
+	var totalConnections int
 
 	mc.sched.connections.Range(func(key, _ any) bool {
 		wc := key.(*workerConn)
@@ -173,7 +169,7 @@ func (mc *collector) collectAssignStats(ch chan<- prometheus.Metric) {
 	mc.sched.assignMut.RLock()
 	defer mc.sched.assignMut.RUnlock()
 
-	ch <- prometheus.MustNewConstMetric(mc.readyWorkers, prometheus.GaugeValue, float64(len(mc.sched.readyWorkers)))
+	ch <- prometheus.MustNewConstMetric(mc.readyWorkers, prometheus.GaugeValue, float64(len(mc.sched.connectedWorkers)))
 	ch <- prometheus.MustNewConstMetric(mc.taskQueue, prometheus.GaugeValue, float64(mc.sched.taskQueue.Len()))
 }
 

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -146,7 +146,10 @@ func (s *Scheduler) handleConn(ctx context.Context, conn wire.Conn) {
 	logger := log.With(s.logger, "remote_addr", conn.RemoteAddr())
 	level.Info(logger).Log("msg", "handling connection")
 
-	wc := &workerConn{done: make(chan struct{}), wake: make(chan struct{}, 1)}
+	wc := &workerConn{
+		done: make(chan struct{}),
+		wake: make(chan struct{}, 1),
+	}
 
 	s.connections.Store(wc, struct{}{})
 	defer s.connections.Delete(wc)

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -235,19 +235,11 @@ func (s *Scheduler) markWorkerReady(ctx context.Context, worker *workerConn) err
 		return err
 	}
 
-	if _, alreadyReady := s.readyWorkers[worker]; alreadyReady {
-		// The worker already has a long-lived assignment loop. A fresh ready
-		// message means it has freed a thread, so un-park the loop (if it
-		// parked on a previous 429) rather than starting a second loop.
+	if _, exists := s.readyWorkers[worker]; exists {
 		nudgeSemaphore(worker.wake)
 	} else {
 		s.readyWorkers[worker] = struct{}{}
 
-		// Spawn the single, long-lived goroutine that assigns tasks to this
-		// worker by reading from tasksCh. Unlike the previous design, the loop
-		// is not torn down on a 429: it parks and resumes on the next ready
-		// message, so worker threads don't sit idle waiting for a fresh
-		// subscribe round trip.
 		go s.workerLoop(ctx, worker)
 	}
 
@@ -488,13 +480,6 @@ func (s *Scheduler) assignTasks(ctx context.Context) {
 	}
 }
 
-// workerLoop assigns tasks to a single worker by reading from the shared
-// tasksCh. It is long-lived: it runs until the connection is closed or the
-// scheduler shuts down. When the worker reports it is at capacity (429), the
-// loop parks instead of exiting and resumes when the worker advertises a freed
-// thread via a ready message. This avoids the teardown + re-subscribe round
-// trip that previously left worker threads idle while tasks queued.
-//
 // TODO(ashwanth): When there is only a single worker (say single-binary)
 // all assignments go through a single workerLoop. Because SendMessage blocks
 // until the worker ACKs, the per-task round-trip overhead adds up
@@ -533,14 +518,9 @@ func (s *Scheduler) workerLoop(ctx context.Context, worker *workerConn) {
 			// Generic error: restore the task to its original queue position.
 			s.requeueTask(assignment.t, assignment.pos)
 
-			// If it's a 429 the worker is at capacity. Keep the loop and the
-			// worker's ready status alive and park until the worker advertises
-			// a freed thread. This keeps the worker eligible for assignment so
-			// the next ready message resumes dispatch immediately, without the
-			// expensive teardown + re-subscribe cycle.
 			if isTooManyRequestsError(err) {
 				s.metrics.backoffsTotal.Inc()
-				if !s.parkWorker(ctx, worker) {
+				if resume := s.parkWorker(ctx, worker); !resume {
 					return
 				}
 				continue
@@ -562,11 +542,6 @@ func (s *Scheduler) workerLoop(ctx context.Context, worker *workerConn) {
 // nudges worker.wake), the worker disconnects, or the scheduler shuts down. It
 // returns true if the assignment loop should resume, or false if it should
 // exit.
-//
-// While parked the worker remains in s.readyWorkers so the assign loop keeps
-// preparing work for it; that work waits on the unbuffered tasksCh until this
-// loop resumes, providing backpressure without busy-spinning against a full
-// worker.
 func (s *Scheduler) parkWorker(ctx context.Context, worker *workerConn) bool {
 	select {
 	case <-ctx.Done():

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -57,9 +57,9 @@ type Scheduler struct {
 	streams      map[ulid.ULID]*stream // All known streams (regardless of state)
 	tasks        map[ulid.ULID]*task   // All known tasks (regardless of state)
 
-	assignMut    sync.RWMutex
-	taskQueue    fair.Queue[*task]
-	readyWorkers map[*workerConn]struct{}
+	assignMut        sync.RWMutex
+	taskQueue        fair.Queue[*task]
+	connectedWorkers map[*workerConn]struct{}
 
 	assignSema chan struct{}       // assignSema signals that task assignment is ready.
 	tasksCh    chan taskAssignment // channel for sending task assignments to worker routines.
@@ -95,7 +95,7 @@ func New(config Config) (*Scheduler, error) {
 		streams: make(map[ulid.ULID]*stream),
 		tasks:   make(map[ulid.ULID]*task),
 
-		readyWorkers: make(map[*workerConn]struct{}),
+		connectedWorkers: make(map[*workerConn]struct{}),
 
 		assignSema: make(chan struct{}, 1),
 		tasksCh:    make(chan taskAssignment),
@@ -238,10 +238,10 @@ func (s *Scheduler) markWorkerReady(ctx context.Context, worker *workerConn) err
 		return err
 	}
 
-	if _, exists := s.readyWorkers[worker]; exists {
+	if _, exists := s.connectedWorkers[worker]; exists {
 		nudgeSemaphore(worker.wake)
 	} else {
-		s.readyWorkers[worker] = struct{}{}
+		s.connectedWorkers[worker] = struct{}{}
 
 		go s.workerLoop(ctx, worker)
 	}
@@ -450,7 +450,7 @@ func (s *Scheduler) removeWorker(ctx context.Context, worker *workerConn, reason
 	}
 
 	// Remove the worker from the ready list, if it exists.
-	delete(s.readyWorkers, worker)
+	delete(s.connectedWorkers, worker)
 }
 
 func (s *Scheduler) runAssignLoop(ctx context.Context) error {
@@ -572,7 +572,7 @@ func (s *Scheduler) prepareAssignment() (taskAssignment, bool) {
 		s.taskQueue.Pop()
 	}
 
-	if len(s.readyWorkers) == 0 || s.taskQueue.Len() == 0 {
+	if len(s.connectedWorkers) == 0 || s.taskQueue.Len() == 0 {
 		return taskAssignment{}, false
 	}
 
@@ -639,7 +639,7 @@ func (s *Scheduler) requeueTask(t *task, pos fair.Position) {
 	t.MarkRequeued()
 	s.metrics.requeueTotal.Inc()
 
-	if len(s.readyWorkers) > 0 {
+	if len(s.connectedWorkers) > 0 {
 		nudgeSemaphore(s.assignSema)
 	}
 }
@@ -1183,7 +1183,7 @@ func (s *Scheduler) enqueueTasks(tasks []*task) {
 		}
 	}
 
-	if len(s.readyWorkers) > 0 && s.taskQueue.Len() > 0 {
+	if len(s.connectedWorkers) > 0 && s.taskQueue.Len() > 0 {
 		nudgeSemaphore(s.assignSema)
 	}
 }

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -146,7 +146,7 @@ func (s *Scheduler) handleConn(ctx context.Context, conn wire.Conn) {
 	logger := log.With(s.logger, "remote_addr", conn.RemoteAddr())
 	level.Info(logger).Log("msg", "handling connection")
 
-	wc := &workerConn{done: make(chan struct{})}
+	wc := &workerConn{done: make(chan struct{}), wake: make(chan struct{}, 1)}
 
 	s.connections.Store(wc, struct{}{})
 	defer s.connections.Delete(wc)
@@ -234,17 +234,22 @@ func (s *Scheduler) markWorkerReady(ctx context.Context, worker *workerConn) err
 	if err := worker.MarkReady(); err != nil {
 		return err
 	}
-	s.readyWorkers[worker] = struct{}{}
 
-	// Spawn a goroutine that assigns tasks to this worker by reading
-	// from the tasksCh. The goroutine exits on 429/error/disconnect.
-	//
-	// It's possible for this to launch multiple goroutines if the worker
-	// (incorrectly) sends more than one ready message. If this happens
-	// the worker basically gets a higher weight towards task assignment
-	// as more than a single routine is picking from the shared channel.
-	// But backpressure would still work as expected if worker can't keep up.
-	go s.workerLoop(ctx, worker)
+	if _, alreadyReady := s.readyWorkers[worker]; alreadyReady {
+		// The worker already has a long-lived assignment loop. A fresh ready
+		// message means it has freed a thread, so un-park the loop (if it
+		// parked on a previous 429) rather than starting a second loop.
+		nudgeSemaphore(worker.wake)
+	} else {
+		s.readyWorkers[worker] = struct{}{}
+
+		// Spawn the single, long-lived goroutine that assigns tasks to this
+		// worker by reading from tasksCh. Unlike the previous design, the loop
+		// is not torn down on a 429: it parks and resumes on the next ready
+		// message, so worker threads don't sit idle waiting for a fresh
+		// subscribe round trip.
+		go s.workerLoop(ctx, worker)
+	}
 
 	// Wake [Scheduler.runAssignLoop] so it feeds tasks into tasksCh.
 	if s.taskQueue.Len() > 0 {
@@ -483,9 +488,12 @@ func (s *Scheduler) assignTasks(ctx context.Context) {
 	}
 }
 
-// workerLoop assigns tasks to a single worker by reading from the
-// shared tasksCh. It continues assigning until the worker NACKs, an error
-// occurs, or the connection is closed.
+// workerLoop assigns tasks to a single worker by reading from the shared
+// tasksCh. It is long-lived: it runs until the connection is closed or the
+// scheduler shuts down. When the worker reports it is at capacity (429), the
+// loop parks instead of exiting and resumes when the worker advertises a freed
+// thread via a ready message. This avoids the teardown + re-subscribe round
+// trip that previously left worker threads idle while tasks queued.
 //
 // TODO(ashwanth): When there is only a single worker (say single-binary)
 // all assignments go through a single workerLoop. Because SendMessage blocks
@@ -522,19 +530,20 @@ func (s *Scheduler) workerLoop(ctx context.Context, worker *workerConn) {
 			// so we can skip the send and move on to the next task.
 			continue
 		} else if err != nil {
-			// Generic error.
+			// Generic error: restore the task to its original queue position.
 			s.requeueTask(assignment.t, assignment.pos)
 
-			// if its 429, remove from ready workers and fire subscribe request.
+			// If it's a 429 the worker is at capacity. Keep the loop and the
+			// worker's ready status alive and park until the worker advertises
+			// a freed thread. This keeps the worker eligible for assignment so
+			// the next ready message resumes dispatch immediately, without the
+			// expensive teardown + re-subscribe cycle.
 			if isTooManyRequestsError(err) {
-				s.assignMut.Lock()
-				delete(s.readyWorkers, worker)
-				s.assignMut.Unlock()
-
 				s.metrics.backoffsTotal.Inc()
-				s.workerSubscribe(ctx, worker)
-
-				return
+				if !s.parkWorker(ctx, worker) {
+					return
+				}
+				continue
 			}
 
 			level.Warn(s.logger).Log("msg", "failed to assign task", "id", assignment.msg.Task.ULID, "conn", worker.RemoteAddr(), "err", err)
@@ -546,6 +555,26 @@ func (s *Scheduler) workerLoop(ctx context.Context, worker *workerConn) {
 		gotrace.Log(assignment.t.runtimeTraceCtx, "task_assigned", assignment.t.inner.ULID.String()+" -> "+worker.RemoteAddr().String())
 
 		s.finalizeAssignment(ctx, assignment.t, worker, assignment.msg.StreamStates)
+	}
+}
+
+// parkWorker blocks until the worker advertises freed capacity (a ready message
+// nudges worker.wake), the worker disconnects, or the scheduler shuts down. It
+// returns true if the assignment loop should resume, or false if it should
+// exit.
+//
+// While parked the worker remains in s.readyWorkers so the assign loop keeps
+// preparing work for it; that work waits on the unbuffered tasksCh until this
+// loop resumes, providing backpressure without busy-spinning against a full
+// worker.
+func (s *Scheduler) parkWorker(ctx context.Context, worker *workerConn) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-worker.done:
+		return false
+	case <-worker.wake:
+		return true
 	}
 }
 

--- a/pkg/engine/internal/scheduler/scheduler_test.go
+++ b/pkg/engine/internal/scheduler/scheduler_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"sync"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/services"
 	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
@@ -1373,6 +1375,90 @@ func TestScheduler_worker(t *testing.T) {
 			}
 		}
 	})
+}
+
+// TestScheduler_workerParkOnBackoff verifies that a 429 from a worker parks the
+// worker's assignment loop (keeping it eligible for assignment) instead of
+// tearing it down, and that a subsequent ready message resumes assignment of
+// the requeued task without requiring a fresh subscribe round trip.
+func TestScheduler_workerParkOnBackoff(t *testing.T) {
+	sched := newTestScheduler(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+
+	conn, err := sched.DialFrom(ctx, wire.LocalWorker)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// reject controls whether the worker NACKs assignments with a 429.
+	var reject atomic.Bool
+	reject.Store(true)
+
+	assigns := make(chan *workflow.Task, 10)
+
+	peer := wire.Peer{
+		Logger:  log.NewNopLogger(),
+		Metrics: wire.NewMetrics(),
+		Conn:    conn,
+		Handler: func(ctx context.Context, _ *wire.Peer, message wire.Message) error {
+			if msg, ok := message.(wire.TaskAssignMessage); ok {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case assigns <- msg.Task:
+				}
+				if reject.Load() {
+					return wire.Errorf(http.StatusTooManyRequests, "no threads available")
+				}
+			}
+			return nil
+		},
+	}
+	go func() { _ = peer.Serve(ctx) }()
+
+	require.NoError(t, peer.SendMessage(ctx, wire.WorkerHelloMessage{Threads: 1}), "Scheduler should accept hello message")
+	require.NoError(t, peer.SendMessage(ctx, wire.WorkerReadyMessage{}), "Scheduler should accept ready message")
+
+	exampleTask := &workflow.Task{ULID: ulid.Make()}
+	manifest := &workflow.Manifest{
+		Tasks:              []*workflow.Task{exampleTask},
+		StreamEventHandler: nopStreamHandler,
+		TaskEventHandler:   nopTaskHandler,
+	}
+	require.NoError(t, sched.RegisterManifest(t.Context(), manifest), "Scheduler should accept valid manifest")
+	require.NoError(t, sched.Start(t.Context(), exampleTask), "Scheduler should start registered task")
+
+	// First attempt: the worker NACKs with a 429.
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timed out before first assignment attempt")
+	case got := <-assigns:
+		require.Equal(t, exampleTask.ULID, got.ULID)
+	}
+
+	// After the 429 the scheduler should record a backoff but keep the worker
+	// in the ready set: the loop parks rather than being torn down.
+	require.Eventually(t, func() bool {
+		if testutil.ToFloat64(sched.metrics.backoffsTotal) < 1 {
+			return false
+		}
+		sched.assignMut.RLock()
+		defer sched.assignMut.RUnlock()
+		return len(sched.readyWorkers) == 1
+	}, 5*time.Second, 10*time.Millisecond, "worker should remain ready (loop parks, not torn down) after a 429")
+
+	// Now accept assignments and signal a freed thread. The parked loop should
+	// resume and re-assign the requeued task.
+	reject.Store(false)
+	require.NoError(t, peer.SendMessage(ctx, wire.WorkerReadyMessage{}), "Scheduler should accept ready message")
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timed out before requeued task was reassigned")
+	case got := <-assigns:
+		require.Equal(t, exampleTask.ULID, got.ULID, "requeued task should be reassigned once the worker readies again")
+	}
 }
 
 func newTestScheduler(t *testing.T) *Scheduler {

--- a/pkg/engine/internal/scheduler/scheduler_test.go
+++ b/pkg/engine/internal/scheduler/scheduler_test.go
@@ -1378,9 +1378,8 @@ func TestScheduler_worker(t *testing.T) {
 }
 
 // TestScheduler_workerParkOnBackoff verifies that a 429 from a worker parks the
-// worker's assignment loop (keeping it eligible for assignment) instead of
-// tearing it down, and that a subsequent ready message resumes assignment of
-// the requeued task without requiring a fresh subscribe round trip.
+// worker's assignment loop, and that a subsequent ready message resumes assignment of
+// the requeued task.
 func TestScheduler_workerParkOnBackoff(t *testing.T) {
 	sched := newTestScheduler(t)
 

--- a/pkg/engine/internal/scheduler/scheduler_test.go
+++ b/pkg/engine/internal/scheduler/scheduler_test.go
@@ -1444,7 +1444,7 @@ func TestScheduler_workerParkOnBackoff(t *testing.T) {
 		}
 		sched.assignMut.RLock()
 		defer sched.assignMut.RUnlock()
-		return len(sched.readyWorkers) == 1
+		return len(sched.connectedWorkers) == 1
 	}, 5*time.Second, 10*time.Millisecond, "worker should remain ready (loop parks, not torn down) after a 429")
 
 	// Now accept assignments and signal a freed thread. The parked loop should

--- a/pkg/engine/internal/scheduler/worker_conn.go
+++ b/pkg/engine/internal/scheduler/worker_conn.go
@@ -72,8 +72,7 @@ type workerConn struct {
 
 	// wake un-parks the worker's assignment loop after it has parked on a 429.
 	// A WorkerReady received while the loop is already running nudges this
-	// channel to signal that the worker has freed a thread. It is a buffered
-	// channel of size 1 used as a coalescing notification.
+	// channel to signal that the worker has freed a thread.
 	wake chan struct{}
 }
 

--- a/pkg/engine/internal/scheduler/worker_conn.go
+++ b/pkg/engine/internal/scheduler/worker_conn.go
@@ -69,6 +69,12 @@ type workerConn struct {
 	// done is closed when the worker connection is closed. It is used to signal
 	// worker goroutines to exit.
 	done chan struct{}
+
+	// wake un-parks the worker's assignment loop after it has parked on a 429.
+	// A WorkerReady received while the loop is already running nudges this
+	// channel to signal that the worker has freed a thread. It is a buffered
+	// channel of size 1 used as a coalescing notification.
+	wake chan struct{}
 }
 
 // Type returns the type of the worker connection.

--- a/pkg/engine/internal/worker/job_manager.go
+++ b/pkg/engine/internal/worker/job_manager.go
@@ -47,13 +47,13 @@ type threadJob struct {
 //   - The worker calls [jobManager.Send] when it is assigned a task from the
 //     scheduler, which fails if there are no ready threads.
 //
-//   - The worker calls [jobManager.WaitReady] to inform a scheduler when
-//     there is at least one ready worker thread.
+//   - The worker calls [jobManager.WaitReady] / [jobManager.WaitBusy] to track
+//     when the pool transitions between having spare capacity and being fully
+//     busy, so it can advertise readiness to a scheduler.
 type jobManager struct {
 	mut        sync.RWMutex
 	waiting    int
-	readyTotal uint64        // Monotonic count of threads that have become ready.
-	waitCond   chan struct{} // Channel-based condition variable to permit cancellation
+	waitCond   chan struct{} // Closed and recreated on every change to waiting.
 	cancelCond chan struct{} // Channel-based condition variable to cancel Recv
 
 	jobCh chan *threadJob
@@ -90,15 +90,20 @@ func (jm *jobManager) Recv(ctx context.Context) (*threadJob, error) {
 	}
 }
 
-// broadcast wakes all blocked calls to WaitReady.
+// broadcast records that another thread is waiting for a job and wakes any
+// blocked calls to WaitReady / WaitBusy.
 func (jm *jobManager) broadcast() {
 	jm.mut.Lock()
 	defer jm.mut.Unlock()
 
 	jm.waiting++
-	jm.readyTotal++
+	jm.notify()
+}
 
-	close(jm.waitCond) // Wakes all blocked calls to WaitReady
+// notify wakes all goroutines blocked on a change to waiting (WaitReady and
+// WaitBusy). Callers must hold jm.mut for writing.
+func (jm *jobManager) notify() {
+	close(jm.waitCond) // Wakes all blocked calls to WaitReady / WaitBusy.
 	jm.waitCond = make(chan struct{})
 }
 
@@ -111,6 +116,7 @@ func (jm *jobManager) cancelWaiting() {
 		panic("jobManager.cancelWaiting called with no waiting calls")
 	}
 	jm.waiting--
+	jm.notify() // waiting decreased; wake WaitBusy.
 
 	close(jm.cancelCond)
 	jm.cancelCond = make(chan struct{})
@@ -151,6 +157,7 @@ func (jm *jobManager) Send(ctx context.Context, job *threadJob) error {
 	switch {
 	case sent:
 		jm.waiting--
+		jm.notify() // waiting decreased; wake WaitBusy.
 		return nil
 	case !sent && ctx.Err() != nil:
 		return ctx.Err()
@@ -188,43 +195,28 @@ func (jm *jobManager) WaitReady(ctx context.Context) error {
 	return ctx.Err()
 }
 
-// readyCursor returns a cursor for [jobManager.AwaitReady] positioned so that
-// the first call advertises the number of threads currently available.
-// A freshly connected scheduler can use this to advertise current capacity
-// without replaying the entire history of thread-ready events.
-func (jm *jobManager) readyCursor() uint64 {
+// WaitFull blocks until there are no waiting calls to [jobManager.Recv] (every
+// thread is busy), or until ctx is done. It is the inverse of WaitReady.
+func (jm *jobManager) WaitFull(ctx context.Context) error {
 	jm.mut.RLock()
 	defer jm.mut.RUnlock()
 
-	if jm.readyTotal < uint64(jm.waiting) {
-		return 0
-	}
-	return jm.readyTotal - uint64(jm.waiting)
-}
-
-// AwaitReady blocks until the cumulative count of threads that have become
-// ready exceeds seen, then returns the new cumulative count.
-//
-// Unlike [jobManager.WaitReady], which is level-triggered and returns
-// immediately whenever any thread is waiting, AwaitReady lets a caller emit
-// exactly one signal per freed thread.
-func (jm *jobManager) AwaitReady(ctx context.Context, seen uint64) (uint64, error) {
-	jm.mut.RLock()
-	defer jm.mut.RUnlock()
-
-	for jm.readyTotal <= seen && ctx.Err() == nil {
+	for ctx.Err() == nil && jm.waiting != 0 {
+		// Get the current condition variable channel.
 		waitCh := jm.waitCond
 
+		// Unlock the mutex while waiting for waitCh to close.
 		jm.mut.RUnlock()
+
 		select {
 		case <-ctx.Done():
 		case <-waitCh:
 		}
+
+		// Re-lock the mutex so the condition can be safely checked again on
+		// the next loop.
 		jm.mut.RLock()
 	}
 
-	if ctx.Err() != nil {
-		return jm.readyTotal, ctx.Err()
-	}
-	return jm.readyTotal, nil
+	return ctx.Err()
 }

--- a/pkg/engine/internal/worker/job_manager.go
+++ b/pkg/engine/internal/worker/job_manager.go
@@ -51,11 +51,10 @@ type threadJob struct {
 //     when threads become ready, so it can advertise spare capacity to a
 //     scheduler once per batch of newly-ready threads.
 type jobManager struct {
-	mut             sync.RWMutex
-	waiting         int
-	readyGeneration uint64        // Monotonic count of threads becoming ready; bumped on every Recv.
-	waitCond        chan struct{} // Closed and recreated on every change to waiting.
-	cancelCond      chan struct{} // Channel-based condition variable to cancel Recv
+	mut        sync.RWMutex
+	waiting    int
+	waitCond   chan struct{} // Closed and recreated on every change to waiting.
+	cancelCond chan struct{} // Channel-based condition variable to cancel Recv
 
 	jobCh chan *threadJob
 }
@@ -98,7 +97,6 @@ func (jm *jobManager) broadcast() {
 	defer jm.mut.Unlock()
 
 	jm.waiting++
-	jm.readyGeneration++
 	jm.notify()
 }
 
@@ -168,14 +166,12 @@ func (jm *jobManager) Send(ctx context.Context, job *threadJob) error {
 	}
 }
 
-// WaitReady blocks until a thread has become ready since generation `last`,
-// returning the new generation. It lets the readiness emitter advertise spare
-// capacity to the scheduler as a batch, regardless of when the threads became ready.
-func (jm *jobManager) WaitReady(ctx context.Context, lastGeneration uint64) (uint64, error) {
+// WaitReady blocks until a thread has become ready for another job.
+func (jm *jobManager) WaitReady(ctx context.Context) error {
 	jm.mut.RLock()
 	defer jm.mut.RUnlock()
 
-	for ctx.Err() == nil && jm.readyGeneration == lastGeneration {
+	for ctx.Err() == nil && jm.waiting == 0 {
 		waitCh := jm.waitCond
 
 		jm.mut.RUnlock()
@@ -186,5 +182,5 @@ func (jm *jobManager) WaitReady(ctx context.Context, lastGeneration uint64) (uin
 		jm.mut.RLock()
 	}
 
-	return jm.readyGeneration, ctx.Err()
+	return ctx.Err()
 }

--- a/pkg/engine/internal/worker/job_manager.go
+++ b/pkg/engine/internal/worker/job_manager.go
@@ -52,6 +52,7 @@ type threadJob struct {
 type jobManager struct {
 	mut        sync.RWMutex
 	waiting    int
+	readyTotal uint64        // Monotonic count of threads that have become ready.
 	waitCond   chan struct{} // Channel-based condition variable to permit cancellation
 	cancelCond chan struct{} // Channel-based condition variable to cancel Recv
 
@@ -95,6 +96,7 @@ func (jm *jobManager) broadcast() {
 	defer jm.mut.Unlock()
 
 	jm.waiting++
+	jm.readyTotal++
 
 	close(jm.waitCond) // Wakes all blocked calls to WaitReady
 	jm.waitCond = make(chan struct{})
@@ -184,4 +186,48 @@ func (jm *jobManager) WaitReady(ctx context.Context) error {
 	}
 
 	return ctx.Err()
+}
+
+// readyCursor returns a cursor for [jobManager.AwaitReady] positioned so that
+// the first call advertises exactly the number of threads currently available.
+// A freshly connected scheduler can use this to advertise current capacity
+// without replaying the entire history of thread-ready events.
+func (jm *jobManager) readyCursor() uint64 {
+	jm.mut.RLock()
+	defer jm.mut.RUnlock()
+
+	if jm.readyTotal < uint64(jm.waiting) {
+		return 0
+	}
+	return jm.readyTotal - uint64(jm.waiting)
+}
+
+// AwaitReady blocks until the cumulative count of threads that have become
+// ready exceeds seen, then returns the new cumulative count. Callers pass the
+// value previously returned (starting from [jobManager.readyCursor]) to receive
+// an edge-triggered signal for every thread that becomes ready, without missing
+// or coalescing events across calls.
+//
+// Unlike [jobManager.WaitReady], which is level-triggered and returns
+// immediately whenever any thread is waiting, AwaitReady lets a caller emit
+// exactly one signal (credit) per freed thread.
+func (jm *jobManager) AwaitReady(ctx context.Context, seen uint64) (uint64, error) {
+	jm.mut.RLock()
+	defer jm.mut.RUnlock()
+
+	for jm.readyTotal <= seen && ctx.Err() == nil {
+		waitCh := jm.waitCond
+
+		jm.mut.RUnlock()
+		select {
+		case <-ctx.Done():
+		case <-waitCh:
+		}
+		jm.mut.RLock()
+	}
+
+	if ctx.Err() != nil {
+		return jm.readyTotal, ctx.Err()
+	}
+	return jm.readyTotal, nil
 }

--- a/pkg/engine/internal/worker/job_manager.go
+++ b/pkg/engine/internal/worker/job_manager.go
@@ -189,7 +189,7 @@ func (jm *jobManager) WaitReady(ctx context.Context) error {
 }
 
 // readyCursor returns a cursor for [jobManager.AwaitReady] positioned so that
-// the first call advertises exactly the number of threads currently available.
+// the first call advertises the number of threads currently available.
 // A freshly connected scheduler can use this to advertise current capacity
 // without replaying the entire history of thread-ready events.
 func (jm *jobManager) readyCursor() uint64 {
@@ -203,14 +203,11 @@ func (jm *jobManager) readyCursor() uint64 {
 }
 
 // AwaitReady blocks until the cumulative count of threads that have become
-// ready exceeds seen, then returns the new cumulative count. Callers pass the
-// value previously returned (starting from [jobManager.readyCursor]) to receive
-// an edge-triggered signal for every thread that becomes ready, without missing
-// or coalescing events across calls.
+// ready exceeds seen, then returns the new cumulative count.
 //
 // Unlike [jobManager.WaitReady], which is level-triggered and returns
 // immediately whenever any thread is waiting, AwaitReady lets a caller emit
-// exactly one signal (credit) per freed thread.
+// exactly one signal per freed thread.
 func (jm *jobManager) AwaitReady(ctx context.Context, seen uint64) (uint64, error) {
 	jm.mut.RLock()
 	defer jm.mut.RUnlock()

--- a/pkg/engine/internal/worker/job_manager.go
+++ b/pkg/engine/internal/worker/job_manager.go
@@ -47,14 +47,15 @@ type threadJob struct {
 //   - The worker calls [jobManager.Send] when it is assigned a task from the
 //     scheduler, which fails if there are no ready threads.
 //
-//   - The worker calls [jobManager.WaitReady] / [jobManager.WaitBusy] to track
-//     when the pool transitions between having spare capacity and being fully
-//     busy, so it can advertise readiness to a scheduler.
+//   - The worker's readiness emitter calls [jobManager.WaitReadyGen] to learn
+//     when threads become ready, so it can advertise spare capacity to a
+//     scheduler once per batch of newly-ready threads.
 type jobManager struct {
-	mut        sync.RWMutex
-	waiting    int
-	waitCond   chan struct{} // Closed and recreated on every change to waiting.
-	cancelCond chan struct{} // Channel-based condition variable to cancel Recv
+	mut             sync.RWMutex
+	waiting         int
+	readyGeneration uint64        // Monotonic count of threads becoming ready; bumped on every Recv.
+	waitCond        chan struct{} // Closed and recreated on every change to waiting.
+	cancelCond      chan struct{} // Channel-based condition variable to cancel Recv
 
 	jobCh chan *threadJob
 }
@@ -97,13 +98,14 @@ func (jm *jobManager) broadcast() {
 	defer jm.mut.Unlock()
 
 	jm.waiting++
+	jm.readyGeneration++
 	jm.notify()
 }
 
-// notify wakes all goroutines blocked on a change to waiting (WaitReady and
-// WaitBusy). Callers must hold jm.mut for writing.
+// notify wakes all goroutines blocked on a change to waiting (WaitReadyGen).
+// Callers must hold jm.mut for writing.
 func (jm *jobManager) notify() {
-	close(jm.waitCond) // Wakes all blocked calls to WaitReady / WaitBusy.
+	close(jm.waitCond) // Wakes all blocked calls to WaitReadyGen.
 	jm.waitCond = make(chan struct{})
 }
 
@@ -116,7 +118,7 @@ func (jm *jobManager) cancelWaiting() {
 		panic("jobManager.cancelWaiting called with no waiting calls")
 	}
 	jm.waiting--
-	jm.notify() // waiting decreased; wake WaitBusy.
+	jm.notify()
 
 	close(jm.cancelCond)
 	jm.cancelCond = make(chan struct{})
@@ -157,7 +159,7 @@ func (jm *jobManager) Send(ctx context.Context, job *threadJob) error {
 	switch {
 	case sent:
 		jm.waiting--
-		jm.notify() // waiting decreased; wake WaitBusy.
+		jm.notify()
 		return nil
 	case !sent && ctx.Err() != nil:
 		return ctx.Err()
@@ -166,57 +168,23 @@ func (jm *jobManager) Send(ctx context.Context, job *threadJob) error {
 	}
 }
 
-// WaitReady blocks until there is at least one waiting call to
-// [jobManager.Recv], indicating that [jobManager.Send] can be called.
-//
-// Note that other goroutines may consume all Send slots between this call
-// returning and calling Send, causing Send to return an error.
-func (jm *jobManager) WaitReady(ctx context.Context) error {
+// WaitReady blocks until a thread has become ready since generation `last`,
+// returning the new generation. It lets the readiness emitter advertise spare
+// capacity to the scheduler as a batch, regardless of when the threads became ready.
+func (jm *jobManager) WaitReady(ctx context.Context, lastGeneration uint64) (uint64, error) {
 	jm.mut.RLock()
 	defer jm.mut.RUnlock()
 
-	for ctx.Err() == nil && jm.waiting == 0 {
-		// Get the current condition variable channel.
+	for ctx.Err() == nil && jm.readyGeneration == lastGeneration {
 		waitCh := jm.waitCond
 
-		// Unlock the mutex while waiting for waitCh to close.
 		jm.mut.RUnlock()
-
 		select {
 		case <-ctx.Done():
 		case <-waitCh:
 		}
-
-		// Re-lock the mutex so the condition can be safely checked again on
-		// the next loop.
 		jm.mut.RLock()
 	}
 
-	return ctx.Err()
-}
-
-// WaitFull blocks until there are no waiting calls to [jobManager.Recv] (every
-// thread is busy), or until ctx is done. It is the inverse of WaitReady.
-func (jm *jobManager) WaitFull(ctx context.Context) error {
-	jm.mut.RLock()
-	defer jm.mut.RUnlock()
-
-	for ctx.Err() == nil && jm.waiting != 0 {
-		// Get the current condition variable channel.
-		waitCh := jm.waitCond
-
-		// Unlock the mutex while waiting for waitCh to close.
-		jm.mut.RUnlock()
-
-		select {
-		case <-ctx.Done():
-		case <-waitCh:
-		}
-
-		// Re-lock the mutex so the condition can be safely checked again on
-		// the next loop.
-		jm.mut.RLock()
-	}
-
-	return ctx.Err()
+	return jm.readyGeneration, ctx.Err()
 }

--- a/pkg/engine/internal/worker/job_manager.go
+++ b/pkg/engine/internal/worker/job_manager.go
@@ -47,13 +47,12 @@ type threadJob struct {
 //   - The worker calls [jobManager.Send] when it is assigned a task from the
 //     scheduler, which fails if there are no ready threads.
 //
-//   - The worker's readiness emitter calls [jobManager.WaitReadyGen] to learn
-//     when threads become ready, so it can advertise spare capacity to a
-//     scheduler once per batch of newly-ready threads.
+//   - The worker calls [jobManager.WaitReady] to inform a scheduler when
+//     there is at least one ready worker thread.
 type jobManager struct {
 	mut        sync.RWMutex
 	waiting    int
-	waitCond   chan struct{} // Closed and recreated on every change to waiting.
+	waitCond   chan struct{} // Channel-based condition variable to permit cancellation
 	cancelCond chan struct{} // Channel-based condition variable to cancel Recv
 
 	jobCh chan *threadJob
@@ -90,20 +89,14 @@ func (jm *jobManager) Recv(ctx context.Context) (*threadJob, error) {
 	}
 }
 
-// broadcast records that another thread is waiting for a job and wakes any
-// blocked calls to WaitReady / WaitBusy.
+// broadcast wakes all blocked calls to WaitReady.
 func (jm *jobManager) broadcast() {
 	jm.mut.Lock()
 	defer jm.mut.Unlock()
 
 	jm.waiting++
-	jm.notify()
-}
 
-// notify wakes all goroutines blocked on a change to waiting (WaitReadyGen).
-// Callers must hold jm.mut for writing.
-func (jm *jobManager) notify() {
-	close(jm.waitCond) // Wakes all blocked calls to WaitReadyGen.
+	close(jm.waitCond) // Wakes all blocked calls to WaitReady
 	jm.waitCond = make(chan struct{})
 }
 
@@ -116,7 +109,6 @@ func (jm *jobManager) cancelWaiting() {
 		panic("jobManager.cancelWaiting called with no waiting calls")
 	}
 	jm.waiting--
-	jm.notify()
 
 	close(jm.cancelCond)
 	jm.cancelCond = make(chan struct{})
@@ -157,7 +149,6 @@ func (jm *jobManager) Send(ctx context.Context, job *threadJob) error {
 	switch {
 	case sent:
 		jm.waiting--
-		jm.notify()
 		return nil
 	case !sent && ctx.Err() != nil:
 		return ctx.Err()
@@ -166,19 +157,29 @@ func (jm *jobManager) Send(ctx context.Context, job *threadJob) error {
 	}
 }
 
-// WaitReady blocks until a thread has become ready for another job.
+// WaitReady blocks until there is at least one waiting call to
+// [jobManager.Recv], indicating that [jobManager.Send] can be called.
+//
+// Note that other goroutines may consume all Send slots between this call
+// returning and calling Send, causing Send to return an error.
 func (jm *jobManager) WaitReady(ctx context.Context) error {
 	jm.mut.RLock()
 	defer jm.mut.RUnlock()
 
 	for ctx.Err() == nil && jm.waiting == 0 {
+		// Get the current condition variable channel.
 		waitCh := jm.waitCond
 
+		// Unlock the mutex while waiting for waitCh to close.
 		jm.mut.RUnlock()
+
 		select {
 		case <-ctx.Done():
 		case <-waitCh:
 		}
+
+		// Re-lock the mutex so the condition can be safely checked again on
+		// the next loop.
 		jm.mut.RLock()
 	}
 

--- a/pkg/engine/internal/worker/job_manager_test.go
+++ b/pkg/engine/internal/worker/job_manager_test.go
@@ -107,4 +107,99 @@ func Test_jobManager(t *testing.T) {
 			require.ErrorIs(t, err, errNoReadyThreads, "Send should fail if there are no ready threads")
 		})
 	})
+
+	t.Run("WaitBusy returns immediately when no thread is waiting", func(t *testing.T) {
+		jm := newJobManager()
+		require.NoError(t, jm.WaitFull(t.Context()), "WaitBusy should return immediately when the pool is fully busy")
+	})
+
+	t.Run("WaitBusy blocks until the waiting thread receives a job", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			jm := newJobManager()
+
+			go func() {
+				_, _ = jm.Recv(t.Context())
+			}()
+
+			// Wait for the Recv call to be waiting.
+			synctest.Wait()
+
+			busyDone := make(chan error, 1)
+			go func() { busyDone <- jm.WaitFull(t.Context()) }()
+
+			// WaitBusy must not return while a thread is still waiting.
+			synctest.Wait()
+			select {
+			case <-busyDone:
+				t.Fatal("WaitBusy returned while a thread was still waiting")
+			default:
+			}
+
+			// Delivering a job makes the waiting thread busy.
+			require.NoError(t, jm.Send(t.Context(), new(threadJob)))
+
+			synctest.Wait()
+			require.NoError(t, <-busyDone, "WaitBusy should return once every thread is busy")
+		})
+	})
+
+	t.Run("WaitBusy unblocks when a waiting Recv is cancelled", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			jm := newJobManager()
+
+			recvCtx, cancelRecv := context.WithCancel(t.Context())
+			go func() {
+				_, _ = jm.Recv(recvCtx)
+			}()
+
+			synctest.Wait()
+
+			busyDone := make(chan error, 1)
+			go func() { busyDone <- jm.WaitFull(t.Context()) }()
+
+			synctest.Wait()
+			select {
+			case <-busyDone:
+				t.Fatal("WaitBusy returned while a thread was still waiting")
+			default:
+			}
+
+			// Cancelling the Recv drops the waiting count back to zero.
+			cancelRecv()
+
+			synctest.Wait()
+			require.NoError(t, <-busyDone, "WaitBusy should return after the waiting Recv is cancelled")
+		})
+	})
+
+	t.Run("WaitReady/WaitBusy alternate across a busy->ready cycle", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			jm := newJobManager()
+
+			// Initially fully busy: WaitReady blocks, WaitBusy returns.
+			require.NoError(t, jm.WaitFull(t.Context()))
+
+			go func() {
+				_, _ = jm.Recv(t.Context())
+			}()
+			synctest.Wait()
+
+			// A thread is now waiting: WaitReady returns, WaitBusy blocks.
+			require.NoError(t, jm.WaitReady(t.Context()), "WaitReady should return once a thread is waiting")
+
+			busyDone := make(chan error, 1)
+			go func() { busyDone <- jm.WaitFull(t.Context()) }()
+			synctest.Wait()
+			select {
+			case <-busyDone:
+				t.Fatal("WaitBusy returned while a thread was still waiting")
+			default:
+			}
+
+			// Assign the task: pool is fully busy again, WaitBusy returns.
+			require.NoError(t, jm.Send(t.Context(), new(threadJob)))
+			synctest.Wait()
+			require.NoError(t, <-busyDone, "WaitBusy should return after the thread becomes busy")
+		})
+	})
 }

--- a/pkg/engine/internal/worker/job_manager_test.go
+++ b/pkg/engine/internal/worker/job_manager_test.go
@@ -2,41 +2,13 @@ package worker
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"testing/synctest"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
 func Test_jobManager(t *testing.T) {
-	t.Run("WaitReady blocks until a Recv call is waiting", func(t *testing.T) {
-		// Use synctest so this doesn't take a real minute to execute.
-		synctest.Test(t, func(t *testing.T) {
-			jm := newJobManager()
-
-			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
-			defer cancel()
-
-			err := jm.WaitReady(ctx)
-			require.ErrorIs(t, err, context.DeadlineExceeded, "WaitReady should wait until context cancellation if there are no ready threads")
-		})
-	})
-
-	t.Run("WaitReady returns when a Recv call is waiting", func(t *testing.T) {
-		jm := newJobManager()
-
-		go func() {
-			_, _ = jm.Recv(t.Context())
-		}()
-
-		ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
-		defer cancel()
-
-		require.NoError(t, jm.WaitReady(ctx), "WaitReady should return when a Recv call is waiting")
-	})
-
 	t.Run("Send fails with no calls to Recv", func(t *testing.T) {
 		jm := newJobManager()
 
@@ -45,39 +17,40 @@ func Test_jobManager(t *testing.T) {
 	})
 
 	t.Run("Send succeeds with a call to Recv", func(t *testing.T) {
-		jm := newJobManager()
-		job := new(threadJob)
+		synctest.Test(t, func(t *testing.T) {
+			jm := newJobManager()
+			job := new(threadJob)
 
-		var wg sync.WaitGroup
-		defer wg.Wait()
+			recvDone := make(chan struct{})
+			go func() {
+				defer close(recvDone)
+				actual, err := jm.Recv(t.Context())
+				require.NoError(t, err, "Recv should not fail when a job is sent")
+				require.Equal(t, job, actual, "Recv should return the sent job")
+			}()
 
-		wg.Go(func() {
-			actual, err := jm.Recv(t.Context())
-			require.NoError(t, err, "Recv should not fail when a job is sent")
-			require.Equal(t, job, actual, "Recv should return the sent job")
+			// Wait for the Recv call to be registered as waiting.
+			synctest.Wait()
+
+			require.NoError(t, jm.Send(t.Context(), job), "Send should not fail when a Recv call is active")
+			<-recvDone
 		})
-
-		ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
-		defer cancel()
-
-		require.NoError(t, jm.WaitReady(ctx), "WaitReady should not time out")
-		require.NoError(t, jm.Send(t.Context(), job), "Send should not fail when a Recv call is active")
 	})
 
 	t.Run("Send fails if the receiver exits", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			jm := newJobManager()
 
-			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
-			defer cancel()
-
+			recvCtx, cancelRecv := context.WithCancel(t.Context())
 			go func() {
-				_, _ = jm.Recv(ctx)
+				_, _ = jm.Recv(recvCtx)
 			}()
 
-			require.NoError(t, jm.WaitReady(ctx), "WaitReady should not time out")
+			// Wait for the Recv call to be registered as waiting.
+			synctest.Wait()
 
-			cancel()
+			cancelRecv()
+			synctest.Wait()
 
 			err := jm.Send(t.Context(), new(threadJob))
 			require.ErrorIs(t, err, errNoReadyThreads, "Send should fail if there are no ready threads")
@@ -94,9 +67,8 @@ func Test_jobManager(t *testing.T) {
 				}()
 			}
 
-			// Wait for all Recv calls to be waiting
+			// Wait for all Recv calls to be waiting.
 			synctest.Wait()
-			require.NoError(t, jm.WaitReady(t.Context()), "WaitReady should not fail when a Recv call is waiting")
 
 			for range 10 {
 				require.NoError(t, jm.Send(t.Context(), new(threadJob)), "Send should not fail when there are waiting threads")
@@ -108,98 +80,58 @@ func Test_jobManager(t *testing.T) {
 		})
 	})
 
-	t.Run("WaitBusy returns immediately when no thread is waiting", func(t *testing.T) {
-		jm := newJobManager()
-		require.NoError(t, jm.WaitFull(t.Context()), "WaitBusy should return immediately when the pool is fully busy")
-	})
-
-	t.Run("WaitBusy blocks until the waiting thread receives a job", func(t *testing.T) {
+	t.Run("WaitReady blocks until a thread becomes ready", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			jm := newJobManager()
 
+			genDone := make(chan uint64, 1)
 			go func() {
-				_, _ = jm.Recv(t.Context())
+				gen, err := jm.WaitReady(t.Context(), 0)
+				require.NoError(t, err)
+				genDone <- gen
 			}()
 
-			// Wait for the Recv call to be waiting.
-			synctest.Wait()
-
-			busyDone := make(chan error, 1)
-			go func() { busyDone <- jm.WaitFull(t.Context()) }()
-
-			// WaitBusy must not return while a thread is still waiting.
+			// No ready threads yet: WaitReady must block.
 			synctest.Wait()
 			select {
-			case <-busyDone:
-				t.Fatal("WaitBusy returned while a thread was still waiting")
+			case <-genDone:
+				t.Fatal("WaitReady returned before any thread was ready")
 			default:
 			}
 
-			// Delivering a job makes the waiting thread busy.
-			require.NoError(t, jm.Send(t.Context(), new(threadJob)))
-
+			// A thread becoming ready advances the generation and unblocks it.
+			go func() { _, _ = jm.Recv(t.Context()) }()
 			synctest.Wait()
-			require.NoError(t, <-busyDone, "WaitBusy should return once every thread is busy")
+			require.Equal(t, uint64(1), <-genDone, "WaitReady should return the advanced generation")
 		})
 	})
 
-	t.Run("WaitBusy unblocks when a waiting Recv is cancelled", func(t *testing.T) {
+	t.Run("WaitReady coalesces a burst of newly-ready threads", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			jm := newJobManager()
 
-			recvCtx, cancelRecv := context.WithCancel(t.Context())
-			go func() {
-				_, _ = jm.Recv(recvCtx)
-			}()
-
-			synctest.Wait()
-
-			busyDone := make(chan error, 1)
-			go func() { busyDone <- jm.WaitFull(t.Context()) }()
-
-			synctest.Wait()
-			select {
-			case <-busyDone:
-				t.Fatal("WaitBusy returned while a thread was still waiting")
-			default:
+			// Several threads become ready before anyone observes the generation.
+			for range 5 {
+				go func() { _, _ = jm.Recv(t.Context()) }()
 			}
-
-			// Cancelling the Recv drops the waiting count back to zero.
-			cancelRecv()
-
 			synctest.Wait()
-			require.NoError(t, <-busyDone, "WaitBusy should return after the waiting Recv is cancelled")
+
+			// A single call observes the whole burst as one generation jump.
+			gen, err := jm.WaitReady(t.Context(), 0)
+			require.NoError(t, err)
+			require.Equal(t, uint64(5), gen, "the burst should collapse into a single generation value")
 		})
 	})
 
-	t.Run("WaitReady/WaitBusy alternate across a busy->ready cycle", func(t *testing.T) {
+	t.Run("WaitReady returns when the context is cancelled", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			jm := newJobManager()
 
-			// Initially fully busy: WaitReady blocks, WaitBusy returns.
-			require.NoError(t, jm.WaitFull(t.Context()))
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
 
-			go func() {
-				_, _ = jm.Recv(t.Context())
-			}()
-			synctest.Wait()
-
-			// A thread is now waiting: WaitReady returns, WaitBusy blocks.
-			require.NoError(t, jm.WaitReady(t.Context()), "WaitReady should return once a thread is waiting")
-
-			busyDone := make(chan error, 1)
-			go func() { busyDone <- jm.WaitFull(t.Context()) }()
-			synctest.Wait()
-			select {
-			case <-busyDone:
-				t.Fatal("WaitBusy returned while a thread was still waiting")
-			default:
-			}
-
-			// Assign the task: pool is fully busy again, WaitBusy returns.
-			require.NoError(t, jm.Send(t.Context(), new(threadJob)))
-			synctest.Wait()
-			require.NoError(t, <-busyDone, "WaitBusy should return after the thread becomes busy")
+			_, err := jm.WaitReady(ctx, 0)
+			require.ErrorIs(t, err, context.Canceled)
 		})
 	})
 }

--- a/pkg/engine/internal/worker/job_manager_test.go
+++ b/pkg/engine/internal/worker/job_manager_test.go
@@ -4,11 +4,38 @@ import (
 	"context"
 	"testing"
 	"testing/synctest"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
 func Test_jobManager(t *testing.T) {
+	t.Run("WaitReady blocks until a Recv call is waiting", func(t *testing.T) {
+		// Use synctest so this doesn't take a real minute to execute.
+		synctest.Test(t, func(t *testing.T) {
+			jm := newJobManager()
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+
+			err := jm.WaitReady(ctx)
+			require.ErrorIs(t, err, context.DeadlineExceeded, "WaitReady should wait until context cancellation if there are no ready threads")
+		})
+	})
+
+	t.Run("WaitReady returns when a Recv call is waiting", func(t *testing.T) {
+		jm := newJobManager()
+
+		go func() {
+			_, _ = jm.Recv(t.Context())
+		}()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+		defer cancel()
+
+		require.NoError(t, jm.WaitReady(ctx), "WaitReady should return when a Recv call is waiting")
+	})
+
 	t.Run("Send fails with no calls to Recv", func(t *testing.T) {
 		jm := newJobManager()
 

--- a/pkg/engine/internal/worker/job_manager_test.go
+++ b/pkg/engine/internal/worker/job_manager_test.go
@@ -84,25 +84,25 @@ func Test_jobManager(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			jm := newJobManager()
 
-			genDone := make(chan uint64, 1)
+			done := make(chan struct{})
 			go func() {
-				gen, err := jm.WaitReady(t.Context(), 0)
+				defer close(done)
+				err := jm.WaitReady(t.Context())
 				require.NoError(t, err)
-				genDone <- gen
 			}()
 
 			// No ready threads yet: WaitReady must block.
 			synctest.Wait()
 			select {
-			case <-genDone:
-				t.Fatal("WaitReady returned before any thread was ready")
+			case <-done:
+				t.Fatal("WaitReady returned before any thread became ready")
 			default:
 			}
 
-			// A thread becoming ready advances the generation and unblocks it.
+			// A thread becoming ready unblocks WaitReady.
 			go func() { _, _ = jm.Recv(t.Context()) }()
 			synctest.Wait()
-			require.Equal(t, uint64(1), <-genDone, "WaitReady should return the advanced generation")
+			<-done
 		})
 	})
 
@@ -117,9 +117,8 @@ func Test_jobManager(t *testing.T) {
 			synctest.Wait()
 
 			// A single call observes the whole burst as one generation jump.
-			gen, err := jm.WaitReady(t.Context(), 0)
+			err := jm.WaitReady(t.Context())
 			require.NoError(t, err)
-			require.Equal(t, uint64(5), gen, "the burst should collapse into a single generation value")
 		})
 	})
 
@@ -130,7 +129,7 @@ func Test_jobManager(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			cancel()
 
-			_, err := jm.WaitReady(ctx, 0)
+			err := jm.WaitReady(ctx)
 			require.ErrorIs(t, err, context.Canceled)
 		})
 	})

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -435,32 +435,26 @@ func (w *Worker) handleSchedulerConn(ctx context.Context, logger log.Logger, con
 		// Wait for the scheduler's initial subscribe before advertising
 		// readiness. The scheduler sends a single WorkerSubscribe once it has
 		// processed our WorkerHello; from then on we self-advertise capacity
-		// for the lifetime of the connection, emitting one WorkerReady per
-		// thread that frees up. This keeps the scheduler's per-worker
-		// assignment loop fed without a subscribe round trip after every task.
+		// for the lifetime of the connection.
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-waitReady:
 		}
 
-		// Start advertising from the current available capacity so a
-		// late-joining scheduler is told how many threads are free right now,
-		// rather than replaying every historical thread-ready event.
-		seen := w.jobManager.readyCursor()
 		for {
-			cur, err := w.jobManager.AwaitReady(ctx, seen)
-			if err != nil {
-				// Context got canceled; abort.
-				return nil
+			// Wait until at least one thread is ready to receive a task.
+			if err := w.jobManager.WaitReady(ctx); err != nil {
+				continue
 			}
 
-			// Emit one ready (credit) for each thread that became available
-			// since we last advertised.
-			for ; seen < cur; seen++ {
-				if err := peer.SendMessageAsync(ctx, wire.WorkerReadyMessage{}); err != nil {
-					level.Warn(logger).Log("msg", "failed to send ready message", "err", err)
-				}
+			if err := peer.SendMessageAsync(ctx, wire.WorkerReadyMessage{}); err != nil {
+				level.Warn(logger).Log("msg", "failed to send ready message", "err", err)
+			}
+
+			// Wait until all threads are busy.
+			if err := w.jobManager.WaitFull(ctx); err != nil {
+				continue
 			}
 		}
 	})

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -442,19 +442,17 @@ func (w *Worker) handleSchedulerConn(ctx context.Context, logger log.Logger, con
 		case <-waitReady:
 		}
 
+		// Advertise readiness once per batch of newly-ready threads.
+		// The generation number is used to ensure all Readying threads are caught.
+		var waitGeneration uint64
 		for {
-			// Wait until at least one thread is ready to receive a task.
-			if err := w.jobManager.WaitReady(ctx); err != nil {
+			var err error
+			if waitGeneration, err = w.jobManager.WaitReady(ctx, waitGeneration); err != nil {
 				return nil
 			}
 
 			if err := peer.SendMessageAsync(ctx, wire.WorkerReadyMessage{}); err != nil {
 				level.Warn(logger).Log("msg", "failed to send ready message", "err", err)
-			}
-
-			// Wait until all threads are busy before proceeding.
-			if err := w.jobManager.WaitFull(ctx); err != nil {
-				return nil
 			}
 		}
 	})

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -445,16 +445,16 @@ func (w *Worker) handleSchedulerConn(ctx context.Context, logger log.Logger, con
 		for {
 			// Wait until at least one thread is ready to receive a task.
 			if err := w.jobManager.WaitReady(ctx); err != nil {
-				continue
+				return nil
 			}
 
 			if err := peer.SendMessageAsync(ctx, wire.WorkerReadyMessage{}); err != nil {
 				level.Warn(logger).Log("msg", "failed to send ready message", "err", err)
 			}
 
-			// Wait until all threads are busy.
+			// Wait until all threads are busy before proceeding.
 			if err := w.jobManager.WaitFull(ctx); err != nil {
-				continue
+				return nil
 			}
 		}
 	})

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -380,6 +380,7 @@ func (w *Worker) handleSchedulerConn(ctx context.Context, logger log.Logger, con
 
 		if err := w.jobManager.Send(ctx, job); err != nil {
 			job.Close() // Clean up resources associated with the job.
+			handleWorkerSubscribe()
 			w.metrics.rejectedAssignmentsTotal.Inc()
 			return wire.Errorf(http.StatusTooManyRequests, "no threads available")
 		}
@@ -432,25 +433,21 @@ func (w *Worker) handleSchedulerConn(ctx context.Context, logger log.Logger, con
 	}
 
 	g.Go(func() error {
-		// Wait for the scheduler's initial subscribe before advertising
-		// readiness. The scheduler sends a single WorkerSubscribe once it has
-		// processed our WorkerHello; from then on we self-advertise capacity
-		// for the lifetime of the connection.
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-waitReady:
-		}
-
-		// Advertise readiness once per batch of newly-ready threads.
-		// The generation number is used to ensure all Readying threads are caught.
-		var waitGeneration uint64
 		for {
-			var err error
-			if waitGeneration, err = w.jobManager.WaitReady(ctx, waitGeneration); err != nil {
+			// Wait for the scheduler to require a WorkerReady message.
+			// This happens automatically before sending a http.StatusTooManyRequests error
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-waitReady:
+			}
+
+			// Wait for a thread to become ready for another job
+			if err := w.jobManager.WaitReady(ctx); err != nil {
 				return nil
 			}
 
+			// Notify the scheduler.
 			if err := peer.SendMessageAsync(ctx, wire.WorkerReadyMessage{}); err != nil {
 				level.Warn(logger).Log("msg", "failed to send ready message", "err", err)
 			}

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -379,8 +379,8 @@ func (w *Worker) handleSchedulerConn(ctx context.Context, logger log.Logger, con
 		}
 
 		if err := w.jobManager.Send(ctx, job); err != nil {
-			job.Close() // Clean up resources associated with the job.
-			handleWorkerSubscribe()
+			job.Close()                 // Clean up resources associated with the job.
+			_ = handleWorkerSubscribe() // handleWorkerSubscribe can only return nil
 			w.metrics.rejectedAssignmentsTotal.Inc()
 			return wire.Errorf(http.StatusTooManyRequests, "no threads available")
 		}

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -432,25 +432,37 @@ func (w *Worker) handleSchedulerConn(ctx context.Context, logger log.Logger, con
 	}
 
 	g.Go(func() error {
-		for {
-			// Wait for a signal that we want to wait for a ready thread.
-			select {
-			case <-ctx.Done():
-				return nil
-			case <-waitReady:
-			}
-
-			if err := w.jobManager.WaitReady(ctx); err != nil {
-				// Context got canceled; abort.
-				break
-			}
-
-			if err := peer.SendMessageAsync(ctx, wire.WorkerReadyMessage{}); err != nil {
-				level.Warn(logger).Log("msg", "failed to send ready message", "err", err)
-			}
+		// Wait for the scheduler's initial subscribe before advertising
+		// readiness. The scheduler sends a single WorkerSubscribe once it has
+		// processed our WorkerHello; from then on we self-advertise capacity
+		// for the lifetime of the connection, emitting one WorkerReady per
+		// thread that frees up. This keeps the scheduler's per-worker
+		// assignment loop fed without a subscribe round trip after every task.
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-waitReady:
 		}
 
-		return nil
+		// Start advertising from the current available capacity so a
+		// late-joining scheduler is told how many threads are free right now,
+		// rather than replaying every historical thread-ready event.
+		seen := w.jobManager.readyCursor()
+		for {
+			cur, err := w.jobManager.AwaitReady(ctx, seen)
+			if err != nil {
+				// Context got canceled; abort.
+				return nil
+			}
+
+			// Emit one ready (credit) for each thread that became available
+			// since we last advertised.
+			for ; seen < cur; seen++ {
+				if err := peer.SendMessageAsync(ctx, wire.WorkerReadyMessage{}); err != nil {
+					level.Warn(logger).Log("msg", "failed to send ready message", "err", err)
+				}
+			}
+		}
 	})
 
 	// Wait for all worker goroutines to exit.


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates scheduler workerLoops to park after receiving a TooManyRequests (429) response from a worker, instead of shutting down the goroutine and deleting it from the workers map. This avoids a whole roundtrip of WorkerSubscribe and WorkerReady messages from the Scheduler.

This case is significant because it triggers when the worker pool is oversaturated and workers are filling, releasing and re-filling their worker slots very quickly.

I had Claude run some tests against this setup and it concluded that the scheduler is able to keep workers busy more frequently under load (busy_frac is closer to 1.0). This test uses 200ms execution time per task.
<img width="748" height="97" alt="image" src="https://github.com/user-attachments/assets/0c110634-03a1-4166-b0e7-f9514029f56b" />

Here's an example from running this is a more busy cluster. Green is the new code, Yellow is Loki's existing query-frontend execution path. There are definitely some outliers, but this change appears to enable Loki to operate more consistently under high load.
<img width="546" height="231" alt="image" src="https://github.com/user-attachments/assets/023bcd7e-4d8b-4a4c-a023-ba636773b86f" />

