### PR TITLE
fix(logql): reject non-identifier characters in lexer fallthrough

### DIFF
--- a/pkg/logql/syntax/lex.go
+++ b/pkg/logql/syntax/lex.go
@@ -253,8 +253,33 @@ func (l *lexer) Lex(lval *syntaxSymType) int {
 		return tok
 	}
 
+	if !validIdentifier(tokenText) {
+		l.Error("invalid identifier \"" + tokenText + "\"")
+		return 0
+	}
+
 	lval.str = tokenText
 	return IDENTIFIER
+}
+
+// validIdentifier checks if s is a valid LogQL identifier.
+// Valid identifiers follow Prometheus label naming rules: [a-zA-Z_][a-zA-Z0-9_]*.
+func validIdentifier(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	for i, r := range s {
+		if i == 0 {
+			if !unicode.IsLetter(r) && r != '_' {
+				return false
+			}
+		} else {
+			if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func (l *lexer) Error(msg string) {

--- a/pkg/logql/syntax/parser_test.go
+++ b/pkg/logql/syntax/parser_test.go
@@ -3375,6 +3375,10 @@ var ParseTestCases = []struct {
 		},
 		err: nil,
 	},
+	{
+		in:  `{pod="pod_name"} | \!=""`,
+		err: logqlmodel.NewParseError(`invalid identifier "\"`, 1, 20),
+	},
 }
 
 func TestParse(t *testing.T) {


### PR DESCRIPTION
A backslash or any character not matching Prometheus label naming rules ([a-zA-Z_][a-zA-Z0-9_]*) was silently accepted as an IDENTIFIER token via the lexer fallthrough path. This allowed invalid queries like `{pod=\"pod_name\"} | \\!=\"\"` to pass the frontend parser and reach the query scheduler, causing a 500 error.

The fix validates all IDENTIFIER tokens against Prometheus label naming rules and returns a parse error for invalid characters, ensuring they are caught at the frontend with a 4xx response.

- add `validIdentifier` check in lexer fallthrough path
- add test case for the reported invalid query

Fixes #21738

Signed-off-by: Mohamed Sabbar <med1sabar@gmail.com>