### PR TITLE
feat(dataobj-compactor): Add compaction dry-run flag with audit logging

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1622,6 +1622,12 @@ dataobj:
     # CLI flag: -dataobj.compaction.toc-consolidate-timeout
     [toc_consolidate_timeout: <duration> | default = 30s]
 
+    # Experimental: Skip the post-compaction ToC ReplaceIndexPointers swap.
+    # Planning, IndexMerge task execution, and per-output audit logging still
+    # run, but the ToC is never mutated.
+    # CLI flag: -dataobj.compaction.dry-run
+    [dry_run: <boolean> | default = false]
+
     # Experimental: Plan version hashed into IndexMerge output paths. Bump to
     # invalidate previously-written outputs after a planner-algorithm change.
     # CLI flag: -dataobj.compaction.plan-version

--- a/pkg/engine/compactor/config.go
+++ b/pkg/engine/compactor/config.go
@@ -43,6 +43,12 @@ type Config struct {
 	// RPC; on expiry the cycle aborts inline and the next polling tick re-plans.
 	ToCConsolidateTimeout time.Duration `yaml:"toc_consolidate_timeout"`
 
+	// DryRun, when true, skips the post-compaction ReplaceIndexPointers ToC
+	// swap. Planning and IndexMerge task execution still run and the
+	// per-output audit log is still emitted, but the ToC is never mutated.
+	// Intended for testing index compaction.
+	DryRun bool `yaml:"dry_run"`
+
 	// PlanVersion is hashed into IndexMerge output paths so a planner
 	// change invalidates previously-written outputs. Bump on any
 	// breaking change to the planner or merge semantics. Stored as uint
@@ -154,6 +160,8 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 		"Experimental: Maximum runs per IndexMerge task (K). Memory grows linearly with K.")
 	f.DurationVar(&cfg.ToCConsolidateTimeout, prefix+"toc-consolidate-timeout", defaultToCConsolidateTimeout,
 		"Experimental: Coordinator-side timeout around the inline ToC ReplaceIndexPointers call. Not a task TTL.")
+	f.BoolVar(&cfg.DryRun, prefix+"dry-run", false,
+		"Experimental: Skip the post-compaction ToC ReplaceIndexPointers swap. Planning, IndexMerge task execution, and per-output audit logging still run, but the ToC is never mutated.")
 	f.UintVar(&cfg.PlanVersion, prefix+"plan-version", defaultPlanVersion,
 		"Experimental: Plan version hashed into IndexMerge output paths. Bump to invalidate previously-written outputs after a planner-algorithm change.")
 	f.StringVar(&cfg.Scheduler.AdvertiseAddr, prefix+"scheduler.advertise-addr", "",

--- a/pkg/engine/compactor/coordinator.go
+++ b/pkg/engine/compactor/coordinator.go
@@ -3,6 +3,7 @@ package compactor
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-kit/log"
@@ -227,6 +228,18 @@ func (c *coordinator) runTenantCycle(
 		oldPaths[i] = e.Path
 	}
 	newEntries := makeTocEntries(tasks, outputs)
+
+	level.Debug(c.logger).Log("msg", "compacted indexes",
+		"tenant", tenant, "window", window,
+		"dry_run", c.cfg.DryRun,
+		"tasks", len(tasks),
+		"removed_indexes", strings.Join(oldPaths, ","),
+		"added_indexes", strings.Join(outputs, ","),
+	)
+
+	if c.cfg.DryRun {
+		return nil
+	}
 
 	phase2Ctx, cancel := context.WithTimeout(ctx, c.cfg.ToCConsolidateTimeout)
 	defer cancel()

--- a/pkg/engine/compactor/coordinator_test.go
+++ b/pkg/engine/compactor/coordinator_test.go
@@ -262,6 +262,36 @@ func TestRunTenantCycle_HardSwapErrorPropagates(t *testing.T) {
 	require.ErrorIs(t, err, swapErr)
 }
 
+// TestRunCycle_DryRunSkipsToCSwapButLogs verifies that with DryRun=true the
+// coordinator still runs Phase 1 (IndexMerge dispatch) but never calls
+// ReplaceIndexPointers so the ToC is left untouched.
+func TestRunCycle_DryRunSkipsToCSwapButLogs(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
+
+	writeToCWithIndexes(ctx, t, bucket, map[string][]testIndex{
+		"acme": {
+			{path: "indexes/aa/src-0", start: window.Add(1 * time.Hour), end: window.Add(5 * time.Hour)},
+			{path: "indexes/bb/src-1", start: window.Add(2 * time.Hour), end: window.Add(6 * time.Hour)},
+			{path: "indexes/cc/src-2", start: window.Add(3 * time.Hour), end: window.Add(7 * time.Hour)},
+		},
+	})
+
+	runner := &fakeRunner{}
+	replacer := &fakeReplacer{swapped: true}
+	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
+	c.cfg.DryRun = true
+
+	c.runCycle(ctx)
+
+	// Phase 1 still runs: 3 overlapping piles ÷ K=2 ⇒ 2 tasks.
+	require.Len(t, runner.snapshot(), 2, "dry-run still dispatches IndexMerge tasks")
+
+	// ToC is never mutated.
+	require.Empty(t, replacer.snapshot(), "dry-run must not call ReplaceIndexPointers")
+}
+
 // TestRunCycle_NoToC verifies a missing ToC is a no-op cycle: no panic, no
 // Phase 1 dispatch, no Phase 2 commit. The next poll tick will re-read.
 func TestRunCycle_NoToC(t *testing.T) {


### PR DESCRIPTION
## What

Adds a `dataobj.compaction.dry-run` flag (default `false`) that skips the post-compaction ToC `ReplaceIndexPointers` swap.

## Why

Lets us exercise index compaction in a real environment without mutating the ToC. IndexMerge tasks still run, so the merged output objects are written to object storage and can be pulled to verify compaction is working correctly. A debug-level `compacted indexes` log line records the whole-file source and output paths each cycle so the source→output mapping is auditable.

## Notes

- No behavior change when the flag is unset.
- Config reference docs regenerated.