### PR TITLE
chore(ci): Bump release-workflows lib for createRelease dist fix

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "22c2fa76d6384771cfd9e5b2e36df46a0d644118"
+      "version": "961a0dadb24cc4102187fc700dc3242152a17c21"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "22c2fa76d6384771cfd9e5b2e36df46a0d644118",
-      "sum": "C0F0M5jY9Yt/efeSHbKLtrVLkHC2yJCVrPYwoZyBfoU="
+      "version": "961a0dadb24cc4102187fc700dc3242152a17c21",
+      "sum": "wRqJsn/VQuVR82sEt2iVVhoRgluV8prnzF49uusne/A="
     }
   ],
   "legacyImports": false

--- a/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
@@ -100,6 +100,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
                    releaseStep('download binaries')
                    + step.withRun(|||
                      echo "downloading binaries to $(pwd)/dist"
+                     mkdir -p dist
                      gcloud artifacts generic download \
                        --project="grafanalabs-dev" \
                        --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@22c2fa76d6384771cfd9e5b2e36df46a0d644118"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@961a0dadb24cc4102187fc700dc3242152a17c21"
     "with":
       "build_image": "golang:1.26.4"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "22c2fa76d6384771cfd9e5b2e36df46a0d644118"
+      "release_lib_ref": "961a0dadb24cc4102187fc700dc3242152a17c21"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@22c2fa76d6384771cfd9e5b2e36df46a0d644118"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@961a0dadb24cc4102187fc700dc3242152a17c21"
     "with":
       "build_image": "golang:1.26.4"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "22c2fa76d6384771cfd9e5b2e36df46a0d644118"
+      "release_lib_ref": "961a0dadb24cc4102187fc700dc3242152a17c21"
       "skip_validation": false
       "use_github_app_token": true
   "logql-analyzer-image":
@@ -12,7 +12,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "22c2fa76d6384771cfd9e5b2e36df46a0d644118"
+      "RELEASE_LIB_REF": "961a0dadb24cc4102187fc700dc3242152a17c21"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -152,7 +152,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "22c2fa76d6384771cfd9e5b2e36df46a0d644118"
+      "RELEASE_LIB_REF": "961a0dadb24cc4102187fc700dc3242152a17c21"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -292,7 +292,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "22c2fa76d6384771cfd9e5b2e36df46a0d644118"
+      "RELEASE_LIB_REF": "961a0dadb24cc4102187fc700dc3242152a17c21"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -432,7 +432,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "22c2fa76d6384771cfd9e5b2e36df46a0d644118"
+      "RELEASE_LIB_REF": "961a0dadb24cc4102187fc700dc3242152a17c21"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -572,7 +572,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "22c2fa76d6384771cfd9e5b2e36df46a0d644118"
+      "RELEASE_LIB_REF": "961a0dadb24cc4102187fc700dc3242152a17c21"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -8,7 +8,7 @@ env:
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "22c2fa76d6384771cfd9e5b2e36df46a0d644118"
+  RELEASE_LIB_REF: "961a0dadb24cc4102187fc700dc3242152a17c21"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   VERSIONING_STRATEGY: "always-bump-minor"
@@ -18,11 +18,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@22c2fa76d6384771cfd9e5b2e36df46a0d644118"
+    uses: "grafana/loki-release/.github/workflows/check.yml@961a0dadb24cc4102187fc700dc3242152a17c21"
     with:
       build_image: "golang:1.26.4"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "22c2fa76d6384771cfd9e5b2e36df46a0d644118"
+      release_lib_ref: "961a0dadb24cc4102187fc700dc3242152a17c21"
       skip_validation: false
   create-release-pr:
     needs:

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -8,7 +8,7 @@ env:
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "22c2fa76d6384771cfd9e5b2e36df46a0d644118"
+  RELEASE_LIB_REF: "961a0dadb24cc4102187fc700dc3242152a17c21"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   VERSIONING_STRATEGY: "always-bump-patch"
@@ -18,11 +18,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@22c2fa76d6384771cfd9e5b2e36df46a0d644118"
+    uses: "grafana/loki-release/.github/workflows/check.yml@961a0dadb24cc4102187fc700dc3242152a17c21"
     with:
       build_image: "golang:1.26.4"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "22c2fa76d6384771cfd9e5b2e36df46a0d644118"
+      release_lib_ref: "961a0dadb24cc4102187fc700dc3242152a17c21"
       skip_validation: false
   create-release-pr:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ env:
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "22c2fa76d6384771cfd9e5b2e36df46a0d644118"
+  RELEASE_LIB_REF: "961a0dadb24cc4102187fc700dc3242152a17c21"
   RELEASE_REPO: "grafana/loki"
 jobs:
   createRelease:
@@ -57,6 +57,7 @@ jobs:
     - name: "download binaries"
       run: |
         echo "downloading binaries to $(pwd)/dist"
+        mkdir -p dist
         gcloud artifacts generic download \
           --project="grafanalabs-dev" \
           --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \


### PR DESCRIPTION
**What this PR does / why we need it**:
Vendors https://github.com/grafana/loki-release/pull/370
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
