### PR TITLE
chore(ci): Bump release-workflows lib to 1e32d81a

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
+      "version": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "e1624a406cd0ce5aa48d33db2c9986360c5de7f6",
-      "sum": "eznTU6aKSX91kgs+CKmhoCO8pJwwXYzH0acl5WT8l60="
+      "version": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3",
+      "sum": "6B5rTccFjpHo20u9OSpLg8RE52yPjTwlm1t90mh9Ugw="
     }
   ],
   "legacyImports": false

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -283,9 +283,9 @@ local runner = import 'runner.libsonnet',
             --consider-all-branches \
             --dry-run \
             --dry-run-output release.json \
-            --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --manifest-file .release-please-manifest.json \
-            --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --release-type simple \
             --repo-url "${{ env.RELEASE_REPO }}" \
             --separate-pull-requests false \
@@ -297,9 +297,9 @@ local runner = import 'runner.libsonnet',
             --consider-all-branches \
             --dry-run \
             --dry-run-output release.json \
-            --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --manifest-file .release-please-manifest.json \
-            --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --release-type simple \
             --repo-url "${{ env.RELEASE_REPO }}" \
             --separate-pull-requests false \

--- a/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
@@ -43,11 +43,11 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         yarn exec -- release-please release-pr \
           --changelog-path "${CHANGELOG_PATH}" \
           --consider-all-branches \
-          --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+          --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
           --label "backport main,autorelease: pending,product-approved" \
           --manifest-file .release-please-manifest.json \
           --pull-request-footer "%s" \
-          --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+          --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
           --release-as "$(echo $OUTPUTS_VERSION | tr -d '"')" \
           --release-type simple \
           --repo-url "${{ env.RELEASE_REPO }}" \
@@ -100,12 +100,13 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
                    releaseStep('download binaries')
                    + step.withRun(|||
                      echo "downloading binaries to $(pwd)/dist"
+                     mkdir -p dist
                      gcloud artifacts generic download \
                        --project="grafanalabs-dev" \
                        --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
                        --location="us" \
                        --package=binaries \
-                       --version=${{ github.sha }} \
+                       --version=$(echo ${SHA} | tr -d '"') \
                        --destination=dist/
                    |||),
 
@@ -208,7 +209,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
             --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
             --location="us" \
             --package=images \
-            --version=${{ github.sha }} \
+            --version=$(echo ${SHA} | tr -d '"') \
             --destination=images/
         |||),
         step.new('publish docker images', './lib/actions/push-images')
@@ -245,7 +246,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
             --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
             --location="us" \
             --package=plugins \
-            --version=${{ github.sha }} \
+            --version=$(echo ${SHA} | tr -d '"') \
             --destination=plugins/
           mkdir -p "release/%s"
         ||| % path),

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
     "with":
       "build_image": "golang:1.26.4"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
+      "release_lib_ref": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
     "with":
       "build_image": "golang:1.26.4"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
+      "release_lib_ref": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
       "skip_validation": false
       "use_github_app_token": true
   "logql-analyzer-image":
@@ -12,7 +12,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
+      "RELEASE_LIB_REF": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -152,7 +152,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
+      "RELEASE_LIB_REF": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -292,7 +292,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
+      "RELEASE_LIB_REF": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -432,7 +432,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
+      "RELEASE_LIB_REF": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -572,7 +572,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
+      "RELEASE_LIB_REF": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -8,7 +8,7 @@ env:
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
+  RELEASE_LIB_REF: "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   VERSIONING_STRATEGY: "always-bump-minor"
@@ -18,11 +18,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
+    uses: "grafana/loki-release/.github/workflows/check.yml@1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
     with:
       build_image: "golang:1.26.4"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
+      release_lib_ref: "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
       skip_validation: false
   create-release-pr:
     needs:
@@ -84,11 +84,11 @@ jobs:
         yarn exec -- release-please release-pr \
           --changelog-path "${CHANGELOG_PATH}" \
           --consider-all-branches \
-          --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+          --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
           --label "backport main,autorelease: pending,product-approved" \
           --manifest-file .release-please-manifest.json \
           --pull-request-footer "Merging this PR will release the [artifacts](https://console.cloud.google.com/storage/browser/${BUILD_ARTIFACTS_BUCKET}/${SHA}) of ${SHA}" \
-          --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+          --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
           --release-as "$(echo $OUTPUTS_VERSION | tr -d '"')" \
           --release-type simple \
           --repo-url "${{ env.RELEASE_REPO }}" \
@@ -1034,9 +1034,9 @@ jobs:
             --consider-all-branches \
             --dry-run \
             --dry-run-output release.json \
-            --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --manifest-file .release-please-manifest.json \
-            --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --release-type simple \
             --repo-url "${{ env.RELEASE_REPO }}" \
             --separate-pull-requests false \
@@ -1048,9 +1048,9 @@ jobs:
             --consider-all-branches \
             --dry-run \
             --dry-run-output release.json \
-            --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --manifest-file .release-please-manifest.json \
-            --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --release-type simple \
             --repo-url "${{ env.RELEASE_REPO }}" \
             --separate-pull-requests false \

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -8,7 +8,7 @@ env:
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
+  RELEASE_LIB_REF: "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   VERSIONING_STRATEGY: "always-bump-patch"
@@ -18,11 +18,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
+    uses: "grafana/loki-release/.github/workflows/check.yml@1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
     with:
       build_image: "golang:1.26.4"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
+      release_lib_ref: "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
       skip_validation: false
   create-release-pr:
     needs:
@@ -84,11 +84,11 @@ jobs:
         yarn exec -- release-please release-pr \
           --changelog-path "${CHANGELOG_PATH}" \
           --consider-all-branches \
-          --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+          --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
           --label "backport main,autorelease: pending,product-approved" \
           --manifest-file .release-please-manifest.json \
           --pull-request-footer "Merging this PR will release the [artifacts](https://console.cloud.google.com/storage/browser/${BUILD_ARTIFACTS_BUCKET}/${SHA}) of ${SHA}" \
-          --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+          --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
           --release-as "$(echo $OUTPUTS_VERSION | tr -d '"')" \
           --release-type simple \
           --repo-url "${{ env.RELEASE_REPO }}" \
@@ -1034,9 +1034,9 @@ jobs:
             --consider-all-branches \
             --dry-run \
             --dry-run-output release.json \
-            --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --manifest-file .release-please-manifest.json \
-            --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --release-type simple \
             --repo-url "${{ env.RELEASE_REPO }}" \
             --separate-pull-requests false \
@@ -1048,9 +1048,9 @@ jobs:
             --consider-all-branches \
             --dry-run \
             --dry-run-output release.json \
-            --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --manifest-file .release-please-manifest.json \
-            --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --release-type simple \
             --repo-url "${{ env.RELEASE_REPO }}" \
             --separate-pull-requests false \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ env:
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "e1624a406cd0ce5aa48d33db2c9986360c5de7f6"
+  RELEASE_LIB_REF: "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
   RELEASE_REPO: "grafana/loki"
 jobs:
   createRelease:
@@ -57,12 +57,13 @@ jobs:
     - name: "download binaries"
       run: |
         echo "downloading binaries to $(pwd)/dist"
+        mkdir -p dist
         gcloud artifacts generic download \
           --project="grafanalabs-dev" \
           --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
           --location="us" \
           --package=binaries \
-          --version=${{ github.sha }} \
+          --version=$(echo ${SHA} | tr -d '"') \
           --destination=dist/
       working-directory: "release"
     - env:
@@ -241,7 +242,7 @@ jobs:
           --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
           --location="us" \
           --package=plugins \
-          --version=${{ github.sha }} \
+          --version=$(echo ${SHA} | tr -d '"') \
           --destination=plugins/
         mkdir -p "release/clients/cmd/docker-driver"
     - name: "publish docker driver"
@@ -284,7 +285,7 @@ jobs:
           --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
           --location="us" \
           --package=images \
-          --version=${{ github.sha }} \
+          --version=$(echo ${SHA} | tr -d '"') \
           --destination=images/
     - name: "publish docker images"
       uses: "./lib/actions/push-images"


### PR DESCRIPTION
**What this PR does / why we need it**:
Bring k310 current with main: releaseLibRef e1624a40 → 1e32d81a. Carries the capitalized release-PR title patterns (#305/#368), should-release title parsing (#369), createRelease `mkdir -p dist` (#370), and artifact download by release sha (#371). Regenerated via `make release-workflows`.
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
