### PR TITLE
fix(bloomshipper): Prevent index-gateway panic on shutdown

### DIFF
--- a/pkg/storage/stores/shipper/bloomshipper/client.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client.go
@@ -533,7 +533,13 @@ func (c *cachedListOpObjectClient) Stop() {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
+	// Stop is idempotent: closing c.done twice would panic.
+	select {
+	case <-c.done:
+		return
+	default:
+	}
+
 	close(c.done)
-	c.cache = nil
 	c.ObjectClient.Stop()
 }


### PR DESCRIPTION
## What

Fixes a `panic: assignment to entry in nil map` crash on `index-gateway` pods.

The panic originated in `cachedListOpObjectClient` ([client.go](../blob/master/pkg/storage/stores/shipper/bloomshipper/client.go)):

```
panic: assignment to entry in nil map
  ...bloomshipper.(*cachedListOpObjectClient).List(...)
      pkg/storage/stores/shipper/bloomshipper/client.go:534
  ...bloomshipper.(*BloomStore).ResolveMetas(...)
  ...bloomgateway.(*BloomQuerier).FilterChunkRefs(...)
  ...indexgateway.(*Gateway).GetChunkRef(...)
```

### Root cause

A shutdown race between `Stop()` and an in-flight `List()`:

1. `List()` misses the cache, calls the downstream `ObjectClient.List`, then blocks on `c.mtx.Lock()` to store the result.
2. `Stop()` wins the lock first and runs `c.cache = nil`.
3. `List()` then acquires the lock and executes `c.cache[prefix] = ...` → write to a nil map → panic.

The panic immediately followed `received SIGINT/SIGTERM` in the pod logs, confirming it happens on shutdown.

## Changes

This PR makes two small changes to `Stop()`:

1. **Remove `c.cache = nil`.** This assignment was the sole cause of the race. It served no purpose — the client is discarded on `Stop()` and the map is reclaimed by the GC once the client is unreferenced. Removing it means `List()` can never observe a nil cache, eliminating the panic without adding any defensive checks on the hot path.

2. **Make `Stop()` idempotent.** `close(c.done)` would panic if `Stop()` were ever called twice. A guarded `select` on `c.done` now makes a second call a no-op, removing a second latent panic.

## Testing

- `go test ./pkg/storage/stores/shipper/bloomshipper/` passes, including with `-race`.