### PR TITLE
chore(operator): Build operator with Go 1.26.4

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26.3 as builder
+FROM golang:1.26.4 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/operator/calculator.Dockerfile
+++ b/operator/calculator.Dockerfile
@@ -1,5 +1,5 @@
 # Build the calculator binary
-FROM golang:1.26.3 as builder
+FROM golang:1.26.4 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -2,7 +2,7 @@ module github.com/grafana/loki/operator
 
 go 1.25.7
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	dario.cat/mergo v1.0.2

--- a/operator/netlify.toml
+++ b/operator/netlify.toml
@@ -6,7 +6,7 @@
   # HUGO_VERSION = "..." is set by bingo which allows reproducible local environment.
   NODE_VERSION = "22.10.0"
   NPM_VERSION = "10.9.0"
-  GO_VERSION = "1.26.3"
+  GO_VERSION = "1.26.4"
 
 [context.production]
   command = "(env && mkdir /tmp/gobin && make web GOBIN=/tmp/gobin) || (sleep 30; false)"

--- a/operator/passthrough-gateway.Dockerfile
+++ b/operator/passthrough-gateway.Dockerfile
@@ -1,5 +1,5 @@
 # Build the passthrough-gateway binary
-FROM golang:1.26.3 as builder
+FROM golang:1.26.4 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Go version used by the operator build to the latest release.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
