### PR TITLE
chore(engine): Per-operator and per-task execution observability for the v2 engine

### DIFF
--- a/pkg/engine/internal/executor/executor.go
+++ b/pkg/engine/internal/executor/executor.go
@@ -147,7 +147,7 @@ func (c *Context) execute(ctx context.Context, node physical.Node) Pipeline {
 	case *physical.Filter:
 		return NewObservedPipeline(n.Type().String(), nodeAttributes(n), c.executeFilter(ctx, n, inputs))
 	case *physical.Projection:
-		return NewObservedPipeline(n.Type().String(), nodeAttributes(n), c.executeProjection(ctx, n, inputs))
+		return NewObservedPipeline(operatorRegionName(n), nodeAttributes(n), c.executeProjection(ctx, n, inputs))
 	case *physical.RangeAggregation:
 		return NewObservedPipeline(n.Type().String(), nodeAttributes(n), c.executeRangeAggregation(ctx, n, inputs))
 	case *physical.VectorAggregation:
@@ -568,6 +568,22 @@ func (c *Context) executeScanSet(ctx context.Context, set *physical.ScanSet) Pip
 	}
 
 	return pipeline
+}
+
+// operatorRegionName returns the xcap region name for a node. For a parse or
+// format projection it appends the function (e.g. "Projection/PARSE_LOGFMT") so
+// per-parser cost is attributable instead of lumped under "Projection".
+func operatorRegionName(n physical.Node) string {
+	name := n.Type().String()
+	if p, ok := n.(*physical.Projection); ok {
+		for _, e := range p.Expressions {
+			if v, ok := e.(*physical.VariadicExpr); ok {
+				name += "/" + v.Op.String()
+				break
+			}
+		}
+	}
+	return name
 }
 
 // nodeAttributes returns OTel span attributes relevant to the given physical

--- a/pkg/engine/internal/executor/executor_test.go
+++ b/pkg/engine/internal/executor/executor_test.go
@@ -10,8 +10,28 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
+
+func TestOperatorRegionName(t *testing.T) {
+	tests := []struct {
+		name string
+		node physical.Node
+		want string
+	}{
+		{"non-projection node uses its type", &physical.Limit{}, "Limit"},
+		{"column projection is not a parser", &physical.Projection{Expressions: []physical.Expression{&physical.ColumnExpr{}}}, "Projection"},
+		{"logfmt projection names the parser", &physical.Projection{Expressions: []physical.Expression{&physical.VariadicExpr{Op: types.VariadicOpParseLogfmt}}}, "Projection/PARSE_LOGFMT"},
+		{"json projection names the parser", &physical.Projection{Expressions: []physical.Expression{&physical.VariadicExpr{Op: types.VariadicOpParseJSON}}}, "Projection/PARSE_JSON"},
+		{"parser is found among multiple expressions", &physical.Projection{Expressions: []physical.Expression{&physical.ColumnExpr{}, &physical.VariadicExpr{Op: types.VariadicOpParseRegexp}}}, "Projection/PARSE_REGEXP"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, operatorRegionName(tt.node))
+		})
+	}
+}
 
 func TestExecutor(t *testing.T) {
 	t.Run("pipeline fails if plan is nil", func(t *testing.T) {

--- a/pkg/engine/internal/worker/metrics.go
+++ b/pkg/engine/internal/worker/metrics.go
@@ -51,6 +51,7 @@ type metrics struct {
 
 	// Per-operator-type cost; operator_type is bounded (operator/parser names).
 	operatorSelfSeconds  *prometheus.HistogramVec
+	operatorRowsInTotal  *prometheus.CounterVec
 	operatorRowsOutTotal *prometheus.CounterVec
 }
 
@@ -162,6 +163,10 @@ func newMetrics() *metrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"operator_type"}),
+		operatorRowsInTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_worker_operator_rows_in_total",
+			Help: "Total rows an operator consumed from its child operators, by operator type (zero for leaves)",
+		}, []string{"operator_type"}),
 		operatorRowsOutTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_engine_worker_operator_rows_out_total",
 			Help: "Total rows produced by an operator, by operator type",
@@ -175,10 +180,11 @@ func (m *metrics) Register(reg prometheus.Registerer) error { return reg.Registe
 // Unregister unregisters metrics from the provided Registerer.
 func (m *metrics) Unregister(reg prometheus.Registerer) { reg.Unregister(m.reg) }
 
-// observeOperatorCost records each operator's self-time and rows out, by type.
+// observeOperatorCost records each operator's self-time and row counts, by type.
 func (m *metrics) observeOperatorCost(nodes []pipelineNode) {
 	for _, n := range nodes {
 		m.operatorSelfSeconds.WithLabelValues(n.OpType).Observe(n.SelfDuration.Seconds())
+		m.operatorRowsInTotal.WithLabelValues(n.OpType).Add(float64(n.RowsIn))
 		m.operatorRowsOutTotal.WithLabelValues(n.OpType).Add(float64(n.RowsOut))
 	}
 }

--- a/pkg/engine/internal/worker/metrics.go
+++ b/pkg/engine/internal/worker/metrics.go
@@ -25,14 +25,14 @@ type metrics struct {
 	taskExecSeconds          *prometheus.HistogramVec
 
 	// Per-pass phase durations (one observation per loop iteration).
-	passComputeSeconds prometheus.Histogram
-	passWriteSeconds   prometheus.Histogram
+	passReadSeconds prometheus.Histogram
+	passSendSeconds prometheus.Histogram
 
 	// Task-wide phase durations (one observation per drainPipeline call),
 	// partitioned by task_type.
-	taskReadSeconds    *prometheus.HistogramVec
-	taskComputeSeconds *prometheus.HistogramVec
-	taskWriteSeconds   *prometheus.HistogramVec
+	taskOpenSeconds *prometheus.HistogramVec
+	taskReadSeconds *prometheus.HistogramVec
+	taskSendSeconds *prometheus.HistogramVec
 
 	// setupSeconds measures the time spent preparing a task for execution
 	// (before draining its pipeline), partitioned by task_type.
@@ -77,42 +77,42 @@ func newMetrics() *metrics {
 			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"task_type"}),
 
-		passComputeSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name: "loki_engine_worker_pass_compute_seconds",
-			Help: "Duration of a single compute phase pass",
+		passReadSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name: "loki_engine_worker_pass_read_seconds",
+			Help: "Duration of a single read-phase pass",
 
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		}),
-		passWriteSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name: "loki_engine_worker_pass_write_seconds",
-			Help: "Duration of a single write phase pass",
+		passSendSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name: "loki_engine_worker_pass_send_seconds",
+			Help: "Duration of a single send-phase pass",
 
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		}),
 
+		taskOpenSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name: "loki_engine_worker_task_open_seconds",
+			Help: "Total time spent opening a task's pipeline (Pipeline.Open)",
+
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"task_type"}),
 		taskReadSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name: "loki_engine_worker_task_read_seconds",
-			Help: "Total time spent in the read phase for a task",
+			Help: "Total time spent in the read phase (Pipeline.Read) for a task",
 
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"task_type"}),
-		taskComputeSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-			Name: "loki_engine_worker_task_compute_seconds",
-			Help: "Total time spent in the compute phase for a task",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
-		}, []string{"task_type"}),
-		taskWriteSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-			Name: "loki_engine_worker_task_write_seconds",
-			Help: "Total time spent in the write phase for a task",
+		taskSendSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name: "loki_engine_worker_task_send_seconds",
+			Help: "Total time spent in the send phase for a task",
 
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,

--- a/pkg/engine/internal/worker/metrics.go
+++ b/pkg/engine/internal/worker/metrics.go
@@ -48,6 +48,10 @@ type metrics struct {
 	pagesDownloadedTotal prometheus.Counter
 	pagesPrunedTotal     prometheus.Counter
 	bytesDownloadedTotal prometheus.Counter
+
+	// Per-operator-type cost; operator_type is bounded (operator/parser names).
+	operatorSelfSeconds  *prometheus.HistogramVec
+	operatorRowsOutTotal *prometheus.CounterVec
 }
 
 func newMetrics() *metrics {
@@ -149,6 +153,19 @@ func newMetrics() *metrics {
 			Name: "loki_engine_worker_bytes_downloaded_total",
 			Help: "Total number of bytes downloaded from object storage during task execution",
 		}),
+
+		operatorSelfSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name: "loki_engine_worker_operator_self_seconds",
+			Help: "Per-operator wall-clock (not CPU) self-time, exclusive of child operators, by operator type",
+
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"operator_type"}),
+		operatorRowsOutTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_worker_operator_rows_out_total",
+			Help: "Total rows produced by an operator, by operator type",
+		}, []string{"operator_type"}),
 	}
 }
 
@@ -157,3 +174,11 @@ func (m *metrics) Register(reg prometheus.Registerer) error { return reg.Registe
 
 // Unregister unregisters metrics from the provided Registerer.
 func (m *metrics) Unregister(reg prometheus.Registerer) { reg.Unregister(m.reg) }
+
+// observeOperatorCost records each operator's self-time and rows out, by type.
+func (m *metrics) observeOperatorCost(nodes []pipelineNode) {
+	for _, n := range nodes {
+		m.operatorSelfSeconds.WithLabelValues(n.OpType).Observe(n.SelfDuration.Seconds())
+		m.operatorRowsOutTotal.WithLabelValues(n.OpType).Add(float64(n.RowsOut))
+	}
+}

--- a/pkg/engine/internal/worker/metrics_helpers_test.go
+++ b/pkg/engine/internal/worker/metrics_helpers_test.go
@@ -6,14 +6,49 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
 )
+
+func TestObserveOperatorCost(t *testing.T) {
+	m := newMetrics()
+	m.observeOperatorCost([]pipelineNode{
+		{OpType: "DataObjScan", SelfDuration: 20 * time.Millisecond, RowsOut: 300},
+		{OpType: "Projection/PARSE_LOGFMT", SelfDuration: 30 * time.Millisecond, RowsOut: 250},
+		{OpType: "DataObjScan", SelfDuration: 10 * time.Millisecond, RowsOut: 100},
+	})
+
+	require.Equal(t, float64(400), testutil.ToFloat64(m.operatorRowsOutTotal.WithLabelValues("DataObjScan")))
+	require.Equal(t, float64(250), testutil.ToFloat64(m.operatorRowsOutTotal.WithLabelValues("Projection/PARSE_LOGFMT")))
+
+	// Self-time is grouped by operator type and recorded in seconds: DataObjScan
+	// gets 0.02 + 0.01 over two samples, the parser gets 0.03 over one.
+	scanCount, scanSum := histogramCountSum(t, m.operatorSelfSeconds, "DataObjScan")
+	require.Equal(t, uint64(2), scanCount)
+	require.InDelta(t, 0.03, scanSum, 1e-9)
+
+	parseCount, parseSum := histogramCountSum(t, m.operatorSelfSeconds, "Projection/PARSE_LOGFMT")
+	require.Equal(t, uint64(1), parseCount)
+	require.InDelta(t, 0.03, parseSum, 1e-9)
+}
+
+func histogramCountSum(t *testing.T, vec *prometheus.HistogramVec, lvs ...string) (uint64, float64) {
+	t.Helper()
+	obs, err := vec.GetMetricWithLabelValues(lvs...)
+	require.NoError(t, err)
+	var dm dto.Metric
+	require.NoError(t, obs.(prometheus.Metric).Write(&dm))
+	return dm.GetHistogram().GetSampleCount(), dm.GetHistogram().GetSampleSum()
+}
 
 func TestTaskTypeLabel(t *testing.T) {
 	node := &physical.Limit{NodeID: ulid.Make()}

--- a/pkg/engine/internal/worker/metrics_helpers_test.go
+++ b/pkg/engine/internal/worker/metrics_helpers_test.go
@@ -23,12 +23,15 @@ func TestObserveOperatorCost(t *testing.T) {
 	m := newMetrics()
 	m.observeOperatorCost([]pipelineNode{
 		{OpType: "DataObjScan", SelfDuration: 20 * time.Millisecond, RowsOut: 300},
-		{OpType: "Projection/PARSE_LOGFMT", SelfDuration: 30 * time.Millisecond, RowsOut: 250},
+		{OpType: "Projection/PARSE_LOGFMT", SelfDuration: 30 * time.Millisecond, RowsIn: 400, RowsOut: 250},
 		{OpType: "DataObjScan", SelfDuration: 10 * time.Millisecond, RowsOut: 100},
 	})
 
 	require.Equal(t, float64(400), testutil.ToFloat64(m.operatorRowsOutTotal.WithLabelValues("DataObjScan")))
 	require.Equal(t, float64(250), testutil.ToFloat64(m.operatorRowsOutTotal.WithLabelValues("Projection/PARSE_LOGFMT")))
+	// Leaves have no operator input; the parser consumed its child's rows.
+	require.Equal(t, float64(0), testutil.ToFloat64(m.operatorRowsInTotal.WithLabelValues("DataObjScan")))
+	require.Equal(t, float64(400), testutil.ToFloat64(m.operatorRowsInTotal.WithLabelValues("Projection/PARSE_LOGFMT")))
 
 	// Self-time is grouped by operator type and recorded in seconds: DataObjScan
 	// gets 0.02 + 0.01 over two samples, the parser gets 0.03 over one.

--- a/pkg/engine/internal/worker/pipeline_node.go
+++ b/pkg/engine/internal/worker/pipeline_node.go
@@ -64,6 +64,9 @@ type pipelineNode struct {
 	BatchesIn int64
 	// RowsOut is the number of rows this operator produced.
 	RowsOut int64
+	// RowsIn is the sum of rows produced by this operator's direct children (its
+	// input from upstream operators; zero for a leaf, whose input is storage).
+	RowsIn int64
 }
 
 // buildPipelineNodes assembles one [pipelineNode] per operator region from the
@@ -73,8 +76,8 @@ type pipelineNode struct {
 // Parent/child relationships are resolved within the supplied set. A record's
 // ParentOperatorID is preserved only when it refers to another record in
 // regions, so an operator whose parent is a non-operator region (such as the
-// task root) reports the zero ID. BatchesIn and the exclusive SelfDuration are
-// computed from each operator's direct children within the set.
+// task root) reports the zero ID. BatchesIn, RowsIn, and the exclusive
+// SelfDuration are computed from each operator's direct children within the set.
 func buildPipelineNodes(regions []pipelineRegionStat) []pipelineNode {
 	// Index regions by ID and group direct children by parent so each operator's
 	// children can be resolved in a single pass.
@@ -94,10 +97,12 @@ func buildPipelineNodes(regions []pipelineRegionStat) []pipelineNode {
 		var (
 			childReadDuration time.Duration
 			batchesIn         int64
+			rowsIn            int64
 		)
 		for _, c := range children[r.ID] {
 			childReadDuration += c.ReadDuration
 			batchesIn += c.ReadCalls
+			rowsIn += c.RowsOut
 		}
 
 		self := r.ReadDuration - childReadDuration
@@ -118,6 +123,7 @@ func buildPipelineNodes(regions []pipelineRegionStat) []pipelineNode {
 			BatchesOut:       r.ReadCalls,
 			BatchesIn:        batchesIn,
 			RowsOut:          r.RowsOut,
+			RowsIn:           rowsIn,
 		})
 	}
 	return nodes
@@ -174,6 +180,7 @@ type packedPipelineNode struct {
 	SelfMS     int64  `json:"self_ms"`
 	BatchesIn  int64  `json:"batches_in"`
 	BatchesOut int64  `json:"batches_out"`
+	RowsIn     int64  `json:"rows_in"`
 	RowsOut    int64  `json:"rows_out"`
 }
 
@@ -200,6 +207,7 @@ func packPipelineNodes(nodes []pipelineNode) []packedPipelineNode {
 			SelfMS:     n.SelfDuration.Milliseconds(),
 			BatchesIn:  n.BatchesIn,
 			BatchesOut: n.BatchesOut,
+			RowsIn:     n.RowsIn,
 			RowsOut:    n.RowsOut,
 		}
 	}

--- a/pkg/engine/internal/worker/pipeline_node.go
+++ b/pkg/engine/internal/worker/pipeline_node.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -164,32 +165,62 @@ func pipelineRegionsFromCapture(capture *xcap.Capture) []pipelineRegionStat {
 	return out
 }
 
-// logPipelineNodes emits one pipeline-node debug log line per operator in the
-// task's operator tree, read from the task's finalized capture. It reads only
-// already-collected statistics and adds nothing to the per-batch hot path.
-// Emission is gated at debug level, like the execution-plan-detail log, because
-// there is one line per operator per task.
-//
-// op_self_ms is wall-clock self-time, not true CPU. operator_id /
-// parent_operator_id are the per-task xcap region identifiers describing this
-// task's operator tree, not the physical-plan node ids. query_id is omitted
-// because it isn't available to the worker; the logger already carries task_id,
-// and the per-task summary log carries query_id, so join on task_id to recover it.
-func logPipelineNodes(logger log.Logger, capture *xcap.Capture) {
-	for _, node := range buildPipelineNodes(pipelineRegionsFromCapture(capture)) {
-		var parent string
-		if !node.ParentOperatorID.IsZero() {
-			parent = node.ParentOperatorID.String()
-		}
-		level.Debug(logger).Log(
-			"msg", "pipeline-node",
-			"operator_id", node.OperatorID.String(),
-			"parent_operator_id", parent,
-			"op_type", node.OpType,
-			"op_self_ms", node.SelfDuration.Milliseconds(),
-			"batches_out", node.BatchesOut,
-			"batches_in", node.BatchesIn,
-			"rows_out", node.RowsOut,
-		)
+// packedPipelineNode is one operator in the packed per-task pipeline trace.
+// Parent is the array index of the operator's parent, or -1 when it has no
+// operator parent.
+type packedPipelineNode struct {
+	Op         string `json:"op"`
+	Parent     int    `json:"parent"`
+	SelfMS     int64  `json:"self_ms"`
+	BatchesIn  int64  `json:"batches_in"`
+	BatchesOut int64  `json:"batches_out"`
+	RowsOut    int64  `json:"rows_out"`
+}
+
+// packPipelineNodes converts the per-operator records into the packed form
+// emitted in the pipeline trace, replacing each operator's parent ID with the
+// parent's index in the returned slice (-1 when it has no operator parent).
+func packPipelineNodes(nodes []pipelineNode) []packedPipelineNode {
+	index := make(map[xcap.ID]int, len(nodes))
+	for i, n := range nodes {
+		index[n.OperatorID] = i
 	}
+
+	packed := make([]packedPipelineNode, len(nodes))
+	for i, n := range nodes {
+		parent := -1
+		if !n.ParentOperatorID.IsZero() {
+			if p, ok := index[n.ParentOperatorID]; ok {
+				parent = p
+			}
+		}
+		packed[i] = packedPipelineNode{
+			Op:         n.OpType,
+			Parent:     parent,
+			SelfMS:     n.SelfDuration.Milliseconds(),
+			BatchesIn:  n.BatchesIn,
+			BatchesOut: n.BatchesOut,
+			RowsOut:    n.RowsOut,
+		}
+	}
+	return packed
+}
+
+// logPipelineTrace emits one always-on line for a task that executed operators,
+// packing its operator tree (see packedPipelineNode) as a JSON array. It reads
+// only already-collected statistics, so it adds no per-batch work. self_ms is
+// wall-clock self-time, not CPU; join on task_id (carried by the logger) to the
+// per-task summary to recover query_id.
+func logPipelineTrace(logger log.Logger, capture *xcap.Capture) {
+	nodes := buildPipelineNodes(pipelineRegionsFromCapture(capture))
+	if len(nodes) == 0 {
+		return
+	}
+
+	packed, err := json.Marshal(packPipelineNodes(nodes))
+	if err != nil {
+		level.Warn(logger).Log("msg", "failed to encode pipeline trace", "err", err)
+		return
+	}
+	level.Info(logger).Log("msg", "pipeline-trace", "pipeline", string(packed))
 }

--- a/pkg/engine/internal/worker/pipeline_node.go
+++ b/pkg/engine/internal/worker/pipeline_node.go
@@ -207,12 +207,10 @@ func packPipelineNodes(nodes []pipelineNode) []packedPipelineNode {
 }
 
 // logPipelineTrace emits one always-on line for a task that executed operators,
-// packing its operator tree (see packedPipelineNode) as a JSON array. It reads
-// only already-collected statistics, so it adds no per-batch work. self_ms is
-// wall-clock self-time, not CPU; join on task_id (carried by the logger) to the
-// per-task summary to recover query_id.
-func logPipelineTrace(logger log.Logger, capture *xcap.Capture) {
-	nodes := buildPipelineNodes(pipelineRegionsFromCapture(capture))
+// packing its operator tree (see packedPipelineNode) as a JSON array. self_ms
+// is wall-clock self-time, not CPU; join on task_id (carried by the logger) to
+// the per-task summary to recover query_id.
+func logPipelineTrace(logger log.Logger, nodes []pipelineNode) {
 	if len(nodes) == 0 {
 		return
 	}

--- a/pkg/engine/internal/worker/pipeline_node_test.go
+++ b/pkg/engine/internal/worker/pipeline_node_test.go
@@ -1,13 +1,76 @@
 package worker
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/xcap"
 )
+
+func TestPackPipelineNodes(t *testing.T) {
+	var (
+		rootID = xcap.NewID()
+		midID  = xcap.NewID()
+		leafID = xcap.NewID()
+		absent = xcap.NewID()
+	)
+
+	tests := []struct {
+		name  string
+		nodes []pipelineNode
+		want  string
+	}{
+		{
+			name: "root and child link by index",
+			nodes: []pipelineNode{
+				{OperatorID: rootID, OpType: "Limit", SelfDuration: 50 * time.Millisecond, BatchesOut: 10, BatchesIn: 4, RowsOut: 1000},
+				{OperatorID: leafID, ParentOperatorID: rootID, OpType: "Projection/PARSE_LOGFMT", SelfDuration: 30 * time.Millisecond, BatchesOut: 4, RowsOut: 400},
+			},
+			want: `[
+				{"op":"Limit","parent":-1,"self_ms":50,"batches_in":4,"batches_out":10,"rows_out":1000},
+				{"op":"Projection/PARSE_LOGFMT","parent":0,"self_ms":30,"batches_in":0,"batches_out":4,"rows_out":400}
+			]`,
+		},
+		{
+			name: "multi-level tree links to the right index",
+			nodes: []pipelineNode{
+				{OperatorID: rootID, OpType: "Limit"},
+				{OperatorID: midID, ParentOperatorID: rootID, OpType: "Filter"},
+				{OperatorID: leafID, ParentOperatorID: midID, OpType: "DataObjScan"},
+			},
+			want: `[
+				{"op":"Limit","parent":-1,"self_ms":0,"batches_in":0,"batches_out":0,"rows_out":0},
+				{"op":"Filter","parent":0,"self_ms":0,"batches_in":0,"batches_out":0,"rows_out":0},
+				{"op":"DataObjScan","parent":1,"self_ms":0,"batches_in":0,"batches_out":0,"rows_out":0}
+			]`,
+		},
+		{
+			name: "parent not in set falls back to -1",
+			nodes: []pipelineNode{
+				{OperatorID: leafID, ParentOperatorID: absent, OpType: "DataObjScan"},
+			},
+			want: `[{"op":"DataObjScan","parent":-1,"self_ms":0,"batches_in":0,"batches_out":0,"rows_out":0}]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := json.Marshal(packPipelineNodes(tt.nodes))
+			require.NoError(t, err)
+			require.JSONEq(t, tt.want, string(b))
+		})
+	}
+}
+
+func TestLogPipelineTrace_NoNodesEmitsNothing(t *testing.T) {
+	var buf bytes.Buffer
+	logPipelineTrace(log.NewLogfmtLogger(&buf), nil)
+	require.Empty(t, buf.String())
+}
 
 func TestBuildPipelineNodes(t *testing.T) {
 	// Stable IDs so expectations can reference them by name. external is never

--- a/pkg/engine/internal/worker/pipeline_node_test.go
+++ b/pkg/engine/internal/worker/pipeline_node_test.go
@@ -28,12 +28,12 @@ func TestPackPipelineNodes(t *testing.T) {
 		{
 			name: "root and child link by index",
 			nodes: []pipelineNode{
-				{OperatorID: rootID, OpType: "Limit", SelfDuration: 50 * time.Millisecond, BatchesOut: 10, BatchesIn: 4, RowsOut: 1000},
+				{OperatorID: rootID, OpType: "Limit", SelfDuration: 50 * time.Millisecond, BatchesOut: 10, BatchesIn: 4, RowsIn: 400, RowsOut: 1000},
 				{OperatorID: leafID, ParentOperatorID: rootID, OpType: "Projection/PARSE_LOGFMT", SelfDuration: 30 * time.Millisecond, BatchesOut: 4, RowsOut: 400},
 			},
 			want: `[
-				{"op":"Limit","parent":-1,"self_ms":50,"batches_in":4,"batches_out":10,"rows_out":1000},
-				{"op":"Projection/PARSE_LOGFMT","parent":0,"self_ms":30,"batches_in":0,"batches_out":4,"rows_out":400}
+				{"op":"Limit","parent":-1,"self_ms":50,"batches_in":4,"batches_out":10,"rows_in":400,"rows_out":1000},
+				{"op":"Projection/PARSE_LOGFMT","parent":0,"self_ms":30,"batches_in":0,"batches_out":4,"rows_in":0,"rows_out":400}
 			]`,
 		},
 		{
@@ -44,9 +44,9 @@ func TestPackPipelineNodes(t *testing.T) {
 				{OperatorID: leafID, ParentOperatorID: midID, OpType: "DataObjScan"},
 			},
 			want: `[
-				{"op":"Limit","parent":-1,"self_ms":0,"batches_in":0,"batches_out":0,"rows_out":0},
-				{"op":"Filter","parent":0,"self_ms":0,"batches_in":0,"batches_out":0,"rows_out":0},
-				{"op":"DataObjScan","parent":1,"self_ms":0,"batches_in":0,"batches_out":0,"rows_out":0}
+				{"op":"Limit","parent":-1,"self_ms":0,"batches_in":0,"batches_out":0,"rows_in":0,"rows_out":0},
+				{"op":"Filter","parent":0,"self_ms":0,"batches_in":0,"batches_out":0,"rows_in":0,"rows_out":0},
+				{"op":"DataObjScan","parent":1,"self_ms":0,"batches_in":0,"batches_out":0,"rows_in":0,"rows_out":0}
 			]`,
 		},
 		{
@@ -54,7 +54,7 @@ func TestPackPipelineNodes(t *testing.T) {
 			nodes: []pipelineNode{
 				{OperatorID: leafID, ParentOperatorID: absent, OpType: "DataObjScan"},
 			},
-			want: `[{"op":"DataObjScan","parent":-1,"self_ms":0,"batches_in":0,"batches_out":0,"rows_out":0}]`,
+			want: `[{"op":"DataObjScan","parent":-1,"self_ms":0,"batches_in":0,"batches_out":0,"rows_in":0,"rows_out":0}]`,
 		},
 	}
 	for _, tt := range tests {
@@ -109,6 +109,7 @@ func TestBuildPipelineNodes(t *testing.T) {
 					BatchesOut:       10,
 					BatchesIn:        7, // 4 + 3
 					RowsOut:          1000,
+					RowsIn:           700, // 400 + 300
 				},
 				leftID: {
 					OperatorID:       leftID,
@@ -118,6 +119,7 @@ func TestBuildPipelineNodes(t *testing.T) {
 					BatchesOut:       4,
 					BatchesIn:        2,
 					RowsOut:          400,
+					RowsIn:           200,
 				},
 				rightID: {
 					OperatorID:       rightID,

--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -331,10 +331,8 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	capture.End()
 	terminalStatus.Capture = capture
 
-	// Emit a per-operator pipeline-node trace from the finalized capture. This
-	// reads only statistics already collected during execution (no per-batch
-	// work) and is gated at debug level, like execution-plan-detail.
-	logPipelineNodes(logger, capture)
+	// Emit the per-task pipeline trace from the finalized capture.
+	logPipelineTrace(logger, capture)
 
 	// Expose task I/O counts as worker counters by reading the values already
 	// accumulated in the per-task capture (the same stats logged in the task

--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -430,27 +430,43 @@ func recordBatchBytes(rec arrow.RecordBatch) int64 {
 func (t *thread) drainPipeline(ctx context.Context, taskType string, pipeline executor.Pipeline, sinks []recordSink, logger log.Logger) (int, error) {
 	region := xcap.RegionFromContext(ctx)
 
-	startRead := time.Now()
-	if err := pipeline.Open(ctx); err != nil {
-		return 0, err
-	}
-	readDuration := time.Since(startRead)
-
 	var (
-		totalRows        int
-		totalComputeTime time.Duration
-		totalWriteTime   time.Duration
+		openDuration  time.Duration
+		totalReadTime time.Duration
+		totalSendTime time.Duration
 	)
 
+	// Record on every exit, including failures, so a task that errors still
+	// reports where its time went; the region observations feed the summary log.
+	defer func() {
+		t.Metrics.taskOpenSeconds.WithLabelValues(taskType).Observe(openDuration.Seconds())
+		t.Metrics.taskReadSeconds.WithLabelValues(taskType).Observe(totalReadTime.Seconds())
+		t.Metrics.taskSendSeconds.WithLabelValues(taskType).Observe(totalSendTime.Seconds())
+
+		region.Record(workerstat.TaskExecutionOpenDuration.Observe(openDuration.Nanoseconds()))
+		region.Record(workerstat.TaskExecutionReadDuration.Observe(totalReadTime.Nanoseconds()))
+		region.Record(workerstat.TaskExecutionSendDuration.Observe(totalSendTime.Nanoseconds()))
+	}()
+
+	startOpen := time.Now()
+	openErr := pipeline.Open(ctx)
+	openDuration = time.Since(startOpen)
+	if openErr != nil {
+		return 0, openErr
+	}
+
+	var totalRows int
 	for {
-		startCompute := time.Now()
+		startRead := time.Now()
 		rec, err := pipeline.Read(ctx)
-		computeDuration := time.Since(startCompute)
+		readDuration := time.Since(startRead)
+		// Count every pass toward the task total; the per-pass histogram skips
+		// error passes to avoid skewing pass latencies.
+		totalReadTime += readDuration
 		if err == nil || errors.Is(err, executor.EOF) {
-			t.Metrics.passComputeSeconds.Observe(computeDuration.Seconds())
-			totalComputeTime += computeDuration
+			t.Metrics.passReadSeconds.Observe(readDuration.Seconds())
 		}
-		if err != nil && errors.Is(err, executor.EOF) {
+		if errors.Is(err, executor.EOF) {
 			break
 		} else if err != nil {
 			return totalRows, err
@@ -474,26 +490,15 @@ func (t *thread) drainPipeline(ctx context.Context, taskType string, pipeline ex
 				level.Warn(logger).Log("msg", "failed to send result", "err", err)
 			}
 		}
-		writeDuration := time.Since(startSend)
-		t.Metrics.passWriteSeconds.Observe(writeDuration.Seconds())
-		totalWriteTime += writeDuration
+		sendDuration := time.Since(startSend)
+		t.Metrics.passSendSeconds.Observe(sendDuration.Seconds())
+		totalSendTime += sendDuration
 
 		region.Record(xcap.TaskRecordsSent.Observe(1))
 		region.Record(xcap.TaskRowsSent.Observe(rec.NumRows()))
 		region.Record(xcap.TaskWireBytes.Observe(recordBatchBytes(rec)))
-		region.Record(xcap.TaskSendDuration.Observe(writeDuration.Seconds()))
+		region.Record(xcap.TaskSendDuration.Observe(sendDuration.Seconds()))
 	}
-
-	// Task-wide phase durations.
-	t.Metrics.taskReadSeconds.WithLabelValues(taskType).Observe(readDuration.Seconds())
-	t.Metrics.taskComputeSeconds.WithLabelValues(taskType).Observe(totalComputeTime.Seconds())
-	t.Metrics.taskWriteSeconds.WithLabelValues(taskType).Observe(totalWriteTime.Seconds())
-
-	// Record execution sub-phase durations on the task region so the workflow
-	// can include them in the per-task summary log.
-	region.Record(workerstat.TaskExecutionOpenDuration.Observe(readDuration.Nanoseconds()))
-	region.Record(workerstat.TaskExecutionReadDuration.Observe(totalComputeTime.Nanoseconds()))
-	region.Record(workerstat.TaskExecutionSendDuration.Observe(totalWriteTime.Nanoseconds()))
 
 	return totalRows, nil
 }

--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -331,8 +331,11 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	capture.End()
 	terminalStatus.Capture = capture
 
-	// Emit the per-task pipeline trace from the finalized capture.
-	logPipelineTrace(logger, capture)
+	// Build the task's operator tree once from the finalized capture (cold
+	// path), then both log it and record per-operator-type cost.
+	pipelineNodes := buildPipelineNodes(pipelineRegionsFromCapture(capture))
+	logPipelineTrace(logger, pipelineNodes)
+	t.Metrics.observeOperatorCost(pipelineNodes)
 
 	// Expose task I/O counts as worker counters by reading the values already
 	// accumulated in the per-task capture (the same stats logged in the task

--- a/pkg/engine/internal/worker/thread_test.go
+++ b/pkg/engine/internal/worker/thread_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"testing/synctest"
@@ -11,6 +12,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/go-kit/log"
 	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
@@ -82,6 +84,36 @@ func TestThread_drainPipeline(t *testing.T) {
 	defer sink.mu.Unlock()
 	require.Equal(t, 3, sink.SendCount, "one send per record")
 	require.Equal(t, int64(3), sink.TotalRows)
+}
+
+type failingPipeline struct {
+	openErr error
+	readErr error
+}
+
+func (p failingPipeline) Open(context.Context) error                      { return p.openErr }
+func (p failingPipeline) Read(context.Context) (arrow.RecordBatch, error) { return nil, p.readErr }
+func (p failingPipeline) Close()                                          {}
+
+func TestThread_drainPipeline_RecordsPhasesOnFailure(t *testing.T) {
+	tests := []struct {
+		name     string
+		pipeline executor.Pipeline
+	}{
+		{"open fails", failingPipeline{openErr: errors.New("open boom")}},
+		{"read fails", failingPipeline{readErr: errors.New("read boom")}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			th := &thread{Logger: log.NewNopLogger(), Metrics: newMetrics()}
+			_, err := th.drainPipeline(t.Context(), taskTypeLeaf, tt.pipeline, nil, log.NewNopLogger())
+			require.Error(t, err)
+
+			require.Equal(t, 1, testutil.CollectAndCount(th.Metrics.taskOpenSeconds))
+			require.Equal(t, 1, testutil.CollectAndCount(th.Metrics.taskReadSeconds))
+			require.Equal(t, 1, testutil.CollectAndCount(th.Metrics.taskSendSeconds))
+		})
+	}
 }
 
 func TestThread_runJob_IgnoresClosedSourceBindErrors(t *testing.T) {

--- a/pkg/engine/internal/workflow/critical_path.go
+++ b/pkg/engine/internal/workflow/critical_path.go
@@ -1,29 +1,36 @@
 package workflow
 
 import (
-	"github.com/go-kit/log/level"
-
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
 )
 
-// logCriticalPath emits the per-query critical-path log lines, one per task on
-// the path. It is called from Close, after UnregisterManifest has driven every
-// task to a terminal state and recorded its finish time, so the task DAG and
-// all per-task finish times are available.
-func (wf *Workflow) logCriticalPath() {
-	wf.tasksMut.RLock()
-	path := criticalPath(&wf.graph, wf.taskFinish)
-	wf.tasksMut.RUnlock()
+// pendingSummary is a terminal task's state, retained for its deferred summary
+// (see Workflow.pendingSummaries).
+type pendingSummary struct {
+	oldState TaskState
+	status   TaskStatus
 
-	total := len(path)
-	for position, task := range path {
-		level.Info(wf.logger).Log(
-			"msg", "critical-path",
-			"query_id", wf.opts.ID,
-			"task_id", task.ULID,
-			"cp_position", position,
-			"cp_total_length", total,
-		)
+	taskFinishNanos int64
+}
+
+// flushTaskSummaries logs the deferred per-task summaries at Close, flagging the
+// tasks on the critical path. onTaskChange records each summary and finish time
+// under the terminal-state lock, so on the normal path all are present once the
+// results pipeline closes (every task terminal).
+func (wf *Workflow) flushTaskSummaries() {
+	wf.tasksMut.RLock()
+	defer wf.tasksMut.RUnlock()
+
+	onPath := make(map[*Task]struct{})
+	for _, task := range criticalPath(&wf.graph, wf.pendingSummaries) {
+		onPath[task] = struct{}{}
+	}
+
+	// TODO(rfratto): make Workflow.Close a hard barrier; a fail-fast query can drop
+	// a sibling that finishes at the instant of teardown (failing task unaffected).
+	for t, s := range wf.pendingSummaries {
+		_, critical := onPath[t]
+		wf.printTaskSummary(t, s.oldState, s.status, critical)
 	}
 }
 
@@ -49,10 +56,10 @@ func (wf *Workflow) logCriticalPath() {
 // planner enforces exactly one root node), so this only matters for
 // hypothetical multi-root graphs.
 //
-// A task missing from finish is treated as having finish time 0, so a path is
-// still produced even if some finish times were never recorded.
-func criticalPath(graph *dag.Graph[*Task], finish map[*Task]int64) []*Task {
-	current := latestFinisher(graph.Roots(), finish)
+// A task missing from summaries is treated as having finish time 0, so a path
+// is still produced even if some finish times were never recorded.
+func criticalPath(graph *dag.Graph[*Task], summaries map[*Task]pendingSummary) []*Task {
+	current := latestFinisher(graph.Roots(), summaries)
 	if current == nil {
 		return nil
 	}
@@ -60,7 +67,7 @@ func criticalPath(graph *dag.Graph[*Task], finish map[*Task]int64) []*Task {
 	var path []*Task
 	for current != nil {
 		path = append(path, current)
-		current = latestFinisher(graph.Children(current), finish)
+		current = latestFinisher(graph.Children(current), summaries)
 	}
 	return path
 }
@@ -68,13 +75,13 @@ func criticalPath(graph *dag.Graph[*Task], finish map[*Task]int64) []*Task {
 // latestFinisher returns the task in candidates with the greatest finish time,
 // or nil if candidates is empty. Ties are broken by keeping the first task in
 // iteration order, which keeps selection deterministic for a given graph.
-func latestFinisher(candidates []*Task, finish map[*Task]int64) *Task {
+func latestFinisher(candidates []*Task, summaries map[*Task]pendingSummary) *Task {
 	var (
 		best     *Task
 		bestTime int64
 	)
 	for _, candidate := range candidates {
-		t := finish[candidate]
+		t := summaries[candidate].taskFinishNanos
 		if best == nil || t > bestTime {
 			best, bestTime = candidate, t
 		}

--- a/pkg/engine/internal/workflow/critical_path_test.go
+++ b/pkg/engine/internal/workflow/critical_path_test.go
@@ -1,13 +1,93 @@
 package workflow
 
 import (
+	"bytes"
+	"context"
+	"strings"
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/schedulerstat"
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
+	"github.com/grafana/loki/v3/pkg/xcap"
 )
+
+func TestFlushTaskSummaries_FlagsCriticalPath(t *testing.T) {
+	newTask := func(name byte) *Task {
+		var id ulid.ULID
+		id[len(id)-1] = name
+		return &Task{ULID: id, Fragment: physical.FromGraph(dag.Graph[physical.Node]{})}
+	}
+
+	var graph dag.Graph[*Task]
+	a := graph.Add(newTask('A'))
+	b := graph.Add(newTask('B'))
+	c := graph.Add(newTask('C'))
+	require.NoError(t, graph.AddEdge(dag.Edge[*Task]{Parent: a, Child: b}))
+	require.NoError(t, graph.AddEdge(dag.Edge[*Task]{Parent: a, Child: c}))
+
+	// C finishes after B, so the critical path is A -> C; B is off the path.
+	_, capture := xcap.NewCapture(context.Background(), nil)
+	terminal := func(finish int64) pendingSummary {
+		return pendingSummary{oldState: TaskStateRunning, status: TaskStatus{State: TaskStateCompleted, Capture: capture}, taskFinishNanos: finish}
+	}
+
+	var buf bytes.Buffer
+	wf := &Workflow{
+		logger:           log.NewLogfmtLogger(&buf),
+		graph:            graph,
+		pendingSummaries: map[*Task]pendingSummary{a: terminal(100), b: terminal(20), c: terminal(40)},
+	}
+
+	wf.flushTaskSummaries()
+
+	out := buf.String()
+	require.Equal(t, 3, strings.Count(out, "msg=task-summary"), "one summary per task")
+
+	lineFor := func(task *Task) string {
+		for _, ln := range strings.Split(out, "\n") {
+			if strings.Contains(ln, " task_id="+task.ULID.String()) {
+				return ln
+			}
+		}
+		return ""
+	}
+	require.Contains(t, lineFor(a), "on_critical_path=true")
+	require.Contains(t, lineFor(c), "on_critical_path=true")
+	require.Contains(t, lineFor(b), "on_critical_path=false")
+}
+
+func TestOnTaskChange_DefersSummary(t *testing.T) {
+	var graph dag.Graph[*Task]
+	task := graph.Add(&Task{ULID: ulid.Make(), Fragment: physical.FromGraph(dag.Graph[physical.Node]{})})
+
+	wf := &Workflow{
+		logger:           log.NewNopLogger(),
+		runner:           newFakeRunner(),
+		graph:            graph,
+		taskStates:       make(map[*Task]TaskState),
+		resultsPipeline:  newStreamPipe(),
+		pendingSummaries: make(map[*Task]pendingSummary),
+	}
+	capCtx, capture := xcap.NewCapture(context.Background(), nil)
+	_, region := xcap.StartRegion(capCtx, "task")
+	region.Record(schedulerstat.TaskFinishTime.Observe(42))
+
+	// A terminal transition records the summary and finish time together,
+	// deferred (not logged).
+	wf.onTaskChange(context.Background(), task, TaskStatus{State: TaskStateCompleted, Capture: capture})
+	require.Len(t, wf.pendingSummaries, 1)
+	require.Contains(t, wf.pendingSummaries, task)
+	require.Equal(t, int64(42), wf.pendingSummaries[task].taskFinishNanos)
+
+	// A duplicate terminal notification does not double-record.
+	wf.onTaskChange(context.Background(), task, TaskStatus{State: TaskStateCompleted, Capture: capture})
+	require.Len(t, wf.pendingSummaries, 1)
+}
 
 func TestCriticalPath(t *testing.T) {
 	// newTask returns a task with a deterministic, recognizable ULID so that
@@ -109,27 +189,24 @@ func TestCriticalPath(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			graph, tasks := buildGraph(tc.edges)
 
-			finish := map[*Task]int64{}
+			summaries := map[*Task]pendingSummary{}
 			for name, value := range tc.finish {
-				finish[tasks[name]] = value
+				summary := pendingSummary{taskFinishNanos: value}
+				summaries[tasks[name]] = summary
 			}
 
-			got := criticalPath(&graph, finish)
+			got := criticalPath(&graph, summaries)
 
 			gotNames := make([]byte, len(got))
 			for i, task := range got {
 				gotNames[i] = task.ULID[len(task.ULID)-1]
 			}
 			require.Equal(t, tc.want, gotNames)
-
-			// cp_position is the slice index and cp_total_length is len(path);
-			// assert the invariant the emitter relies on.
-			require.Len(t, got, len(tc.want))
 		})
 	}
 }
 
 func TestCriticalPath_EmptyGraph(t *testing.T) {
 	var graph dag.Graph[*Task]
-	require.Nil(t, criticalPath(&graph, map[*Task]int64{}))
+	require.Nil(t, criticalPath(&graph, map[*Task]pendingSummary{}))
 }

--- a/pkg/engine/internal/workflow/task_summary.go
+++ b/pkg/engine/internal/workflow/task_summary.go
@@ -14,7 +14,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/xcap"
 )
 
-func (wf *Workflow) printTaskSummary(task *Task, oldState TaskState, newStatus TaskStatus) {
+func (wf *Workflow) printTaskSummary(task *Task, oldState TaskState, newStatus TaskStatus, onCriticalPath bool) {
 	capture := newStatus.Capture
 	if capture == nil {
 		// Every terminal notification carries the per-task capture. Skip
@@ -53,6 +53,7 @@ func (wf *Workflow) printTaskSummary(task *Task, oldState TaskState, newStatus T
 
 		// Outcome
 		"status", taskStatusName(newStatus.State),
+		"on_critical_path", onCriticalPath,
 		"cancellation_phase", cancellationPhaseName(oldState, newStatus.State),
 		"error", newStatus.Error,
 
@@ -133,10 +134,10 @@ func ratio(part, total int64) float64 {
 
 // parentTaskID returns the task's parent ULID, or the zero ULID if the task
 // is a root (one-parent assumption per the workflow planner).
+//
+// tasksMut must be held by the caller.
 func (wf *Workflow) parentTaskID(task *Task) any {
-	wf.tasksMut.RLock()
 	parents := wf.graph.Parents(task)
-	wf.tasksMut.RUnlock()
 
 	if len(parents) == 0 {
 		return nil

--- a/pkg/engine/internal/workflow/workflow.go
+++ b/pkg/engine/internal/workflow/workflow.go
@@ -138,12 +138,9 @@ type Workflow struct {
 
 	span *xcap.Span
 
-	tasksMut   sync.RWMutex
-	taskStates map[*Task]TaskState
-	// taskFinish records each task's terminal finish time (Unix nanoseconds),
-	// read from the task's capture as it reaches a terminal state. It is used
-	// to approximate the query's critical path once every task is terminal.
-	taskFinish map[*Task]int64
+	tasksMut         sync.RWMutex
+	taskStates       map[*Task]TaskState
+	pendingSummaries map[*Task]pendingSummary // Holds terminal task state until Close.
 
 	streamsMut   sync.RWMutex
 	streamStates map[*Stream]StreamState
@@ -176,12 +173,12 @@ func New(ctx context.Context, opts Options, logger log.Logger, runner Runner, pl
 	if graph.Len() == 0 {
 		level.Debug(logger).Log("msg", "workflow plan is empty")
 		return &Workflow{
-			opts:         opts,
-			logger:       logger,
-			runner:       runner,
-			taskStates:   make(map[*Task]TaskState),
-			taskFinish:   make(map[*Task]int64),
-			streamStates: make(map[*Stream]StreamState),
+			opts:             opts,
+			logger:           logger,
+			runner:           runner,
+			taskStates:       make(map[*Task]TaskState),
+			streamStates:     make(map[*Stream]StreamState),
+			pendingSummaries: make(map[*Task]pendingSummary),
 		}, nil
 	}
 
@@ -199,9 +196,9 @@ func New(ctx context.Context, opts Options, logger log.Logger, runner Runner, pl
 		resultsStream:   results,
 		resultsPipeline: newStreamPipe(),
 
-		taskStates:   make(map[*Task]TaskState),
-		taskFinish:   make(map[*Task]int64),
-		streamStates: make(map[*Stream]StreamState),
+		taskStates:       make(map[*Task]TaskState),
+		streamStates:     make(map[*Stream]StreamState),
+		pendingSummaries: make(map[*Task]pendingSummary),
 	}
 	// Detach cancellation from the caller's ctx so a cancellation of the
 	// planning context does not abort the manifest registration, but keep
@@ -297,7 +294,7 @@ func (wf *Workflow) Close() {
 	// UnregisterManifest synchronously drives every remaining task to a terminal
 	// state and delivers its status, so by here the DAG and all per-task finish
 	// times are recorded and the critical path is complete.
-	wf.logCriticalPath()
+	wf.flushTaskSummaries()
 }
 
 // Run executes the workflow, returning a pipeline to read results from. The
@@ -505,6 +502,9 @@ func (wf *Workflow) onTaskChange(ctx context.Context, task *Task, newStatus Task
 	wf.tasksMut.Lock()
 	oldState := wf.taskStates[task]
 	wf.taskStates[task] = newStatus.State
+	if newStatus.State.Terminal() && oldState != newStatus.State {
+		wf.recordTerminal(task, oldState, newStatus)
+	}
 	wf.tasksMut.Unlock()
 
 	if newStatus.State.Terminal() {
@@ -512,6 +512,23 @@ func (wf *Workflow) onTaskChange(ctx context.Context, task *Task, newStatus Task
 	} else {
 		wf.handleNonTerminalStateChange(ctx, task, newStatus)
 	}
+}
+
+// recordTerminal stashes a terminal task's summary and finish time for Close to
+// emit. Recording both under one lock is what lets flushTaskSummaries trust that
+// observing every task terminal implies every summary and finish is present.
+// wf.tasksMut must be held.
+func (wf *Workflow) recordTerminal(task *Task, oldState TaskState, newStatus TaskStatus) {
+	summary := pendingSummary{
+		oldState: oldState,
+		status:   newStatus,
+	}
+	if newStatus.Capture != nil {
+		if finish, ok := xcap.TryValue[int64](newStatus.Capture, schedulerstat.TaskFinishTime); ok {
+			summary.taskFinishNanos = finish
+		}
+	}
+	wf.pendingSummaries[task] = summary
 }
 
 func (wf *Workflow) handleTerminalStateChange(ctx context.Context, task *Task, oldState TaskState, newStatus TaskStatus) {
@@ -535,15 +552,6 @@ func (wf *Workflow) handleTerminalStateChange(ctx context.Context, task *Task, o
 
 	if newStatus.Capture != nil {
 		wf.mergeCapture(newStatus.Capture)
-
-		// Stash the task's terminal finish time for the critical-path walk. The
-		// per-task capture is merged away into wf.capture, so this is the only
-		// point at which the per-task value is available.
-		if finish, ok := xcap.TryValue[int64](newStatus.Capture, schedulerstat.TaskFinishTime); ok {
-			wf.tasksMut.Lock()
-			wf.taskFinish[task] = finish
-			wf.tasksMut.Unlock()
-		}
 	}
 
 	if newStatus.Statistics != nil {
@@ -583,9 +591,6 @@ func (wf *Workflow) handleTerminalStateChange(ctx context.Context, task *Task, o
 
 	// Close the results pipeline if it was waiting on this task to finish.
 	wf.maybeCloseResults()
-
-	// Print the summary at the very end to track full end-to-end task time.
-	wf.printTaskSummary(task, oldState, newStatus)
 }
 
 func (wf *Workflow) handleNonTerminalStateChange(ctx context.Context, task *Task, newStatus TaskStatus) {


### PR DESCRIPTION
Adds attribution for operator and parse functions to track where a slow query spent its time granularly.

Also aligns metric names with log field names and merges critical path logging into the task-summary log line.

Intended to be reviewed commit-by-commit.