### PR TITLE
chore: Unit tests for missing protobuf marshaling/unmarshaling code

### DIFF
--- a/pkg/engine/internal/proto/expressionpb/marshal_types.go
+++ b/pkg/engine/internal/proto/expressionpb/marshal_types.go
@@ -51,6 +51,7 @@ var (
 		VARIADIC_OP_PARSE_JSON:     types.VariadicOpParseJSON,
 		VARIADIC_OP_PARSE_LABELFMT: types.VariadicOpParseLabelfmt,
 		VARIADIC_OP_PARSE_LINEFMT:  types.VariadicOpParseLinefmt,
+		VARIADIC_OP_PARSE_REGEXP:   types.VariadicOpParseRegexp,
 	}
 
 	nativeColumnTypeLookup = map[ColumnType]types.ColumnType{

--- a/pkg/engine/internal/proto/expressionpb/marshal_types_test.go
+++ b/pkg/engine/internal/proto/expressionpb/marshal_types_test.go
@@ -1,0 +1,82 @@
+package expressionpb
+
+import (
+	"testing"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/proto/testutils"
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+)
+
+// The tests in this file guard against silent drift between the proto enums
+// declared in expressionpb.pb.go, the corresponding types.* enums declared in
+// pkg/engine/internal/types, and the lookup tables in marshal_types.go /
+// unmarshal_types.go.
+//
+// Whenever a new value is added to either the proto enum or the types.* enum
+// but the lookup tables are not updated, conversions silently fail at runtime
+// (MarshalType / UnmarshalType return "unsupported" errors that callers may
+// ignore or surface poorly). These tests catch that drift at build time.
+
+func TestLookupCompleteness_UnaryOp(t *testing.T) {
+	testutils.CheckEnumLookup(t,
+		"UnaryOp",
+		UnaryOp_name,
+		testutils.CountConstantsOfType(t, "../../types/operators.go", "UnaryOp"),
+		nativeUnaryOpLookup,
+		protoUnaryOpLookup,
+		func(v int32) UnaryOp { return UnaryOp(v) },
+		func(v UnaryOp) (types.UnaryOp, error) { return v.MarshalType() },
+		func(v types.UnaryOp) (UnaryOp, error) {
+			var p UnaryOp
+			return p, p.UnmarshalType(v)
+		},
+	)
+}
+
+func TestLookupCompleteness_BinaryOp(t *testing.T) {
+	testutils.CheckEnumLookup(t,
+		"BinaryOp",
+		BinaryOp_name,
+		testutils.CountConstantsOfType(t, "../../types/operators.go", "BinaryOp"),
+		nativeBinaryOpLookup,
+		protoBinaryOpLookup,
+		func(v int32) BinaryOp { return BinaryOp(v) },
+		func(v BinaryOp) (types.BinaryOp, error) { return v.MarshalType() },
+		func(v types.BinaryOp) (BinaryOp, error) {
+			var p BinaryOp
+			return p, p.UnmarshalType(v)
+		},
+	)
+}
+
+func TestLookupCompleteness_VariadicOp(t *testing.T) {
+	testutils.CheckEnumLookup(t,
+		"VariadicOp",
+		VariadicOp_name,
+		testutils.CountConstantsOfType(t, "../../types/operators.go", "VariadicOp"),
+		nativeVariadicOpLookup,
+		protoVariadicOpLookup,
+		func(v int32) VariadicOp { return VariadicOp(v) },
+		func(v VariadicOp) (types.VariadicOp, error) { return v.MarshalType() },
+		func(v types.VariadicOp) (VariadicOp, error) {
+			var p VariadicOp
+			return p, p.UnmarshalType(v)
+		},
+	)
+}
+
+func TestLookupCompleteness_ColumnType(t *testing.T) {
+	testutils.CheckEnumLookup(t,
+		"ColumnType",
+		ColumnType_name,
+		testutils.CountConstantsOfType(t, "../../types/column.go", "ColumnType"),
+		nativeColumnTypeLookup,
+		protoColumnTypeLookup,
+		func(v int32) ColumnType { return ColumnType(v) },
+		func(v ColumnType) (types.ColumnType, error) { return v.MarshalType() },
+		func(v types.ColumnType) (ColumnType, error) {
+			var p ColumnType
+			return p, p.UnmarshalType(v)
+		},
+	)
+}

--- a/pkg/engine/internal/proto/expressionpb/round_trip_test.go
+++ b/pkg/engine/internal/proto/expressionpb/round_trip_test.go
@@ -1,0 +1,99 @@
+package expressionpb_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/proto/expressionpb"
+	"github.com/grafana/loki/v3/pkg/engine/internal/proto/testutils"
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+	"github.com/grafana/loki/v3/pkg/logql/log"
+)
+
+// TestRoundTripExpressions_Reflection round-trips every concrete
+// physical.Expression implementation through the protobuf encoding and
+// asserts that the recovered expression deep-equals the input. It catches
+// "added a field to an Expression struct but forgot to copy it in
+// marshal.go / unmarshal.go" silent bugs.
+//
+// *UnaryExpr, *BinaryExpr, *VariadicExpr, and *ColumnExpr are filled by
+// reflection so new fields are covered automatically. *LiteralExpr has an
+// unexported `inner types.Literal` field that reflection cannot set, so its
+// values are enumerated explicitly — once per concrete literal type
+// recognized by types.NewLiteral. Adding a new literal type here goes
+// hand-in-hand with adding marshal/unmarshal cases.
+func TestRoundTripExpressions_Reflection(t *testing.T) {
+	reflectionCases := []physical.Expression{
+		new(physical.UnaryExpr),
+		new(physical.BinaryExpr),
+		new(physical.VariadicExpr),
+		new(physical.ColumnExpr),
+	}
+	for _, e := range reflectionCases {
+		name := reflect.TypeOf(e).Elem().Name()
+		t.Run(name, func(t *testing.T) {
+			newExpressionFiller().Fill(reflect.ValueOf(e).Elem())
+			assertExpressionRoundTrip(t, e)
+		})
+	}
+
+	literalCases := []struct {
+		name  string
+		value any
+	}{
+		{"NullLiteral", nil},
+		{"BoolLiteral", true},
+		{"StringLiteral", "hello"},
+		{"IntegerLiteral", int64(42)},
+		{"FloatLiteral", 3.14},
+		{"TimestampLiteral", types.Timestamp(1_700_000_000_000_000_000)},
+		{"DurationLiteral", types.Duration(5_000_000_000)},
+		{"BytesLiteral", types.Bytes(1024)},
+		{"StringListLiteral", []string{"a", "b", "c"}},
+		{"LabelFmtListLiteral", []log.LabelFmt{{Name: "n", Value: "v", Rename: true}}},
+	}
+	for _, lit := range literalCases {
+		t.Run(lit.name, func(t *testing.T) {
+			assertExpressionRoundTrip(t, physical.NewLiteral(lit.value))
+		})
+	}
+}
+
+func assertExpressionRoundTrip(t *testing.T, expected physical.Expression) {
+	t.Helper()
+	var protoExpr expressionpb.Expression
+	require.NoError(t, protoExpr.UnmarshalPhysical(expected))
+	actual, err := protoExpr.MarshalPhysical()
+	require.NoError(t, err)
+	require.Equal(t, expected, actual,
+		"round-trip mismatch — a field on %T is likely not copied in expressionpb marshal.go / unmarshal.go",
+		expected)
+}
+
+// newExpressionFiller wires the engine-specific overrides for expression
+// round-trip tests on top of the generic testutils.Filler.
+func newExpressionFiller() *testutils.Filler {
+	f := testutils.NewFiller()
+
+	// Any physical.Expression interface field gets a *ColumnExpr — keeps each
+	// expression's test focused on its own fields rather than recursing into
+	// another expression's marshaling tree.
+	f.RegisterInterface(reflect.TypeOf((*physical.Expression)(nil)).Elem(), func(f *testutils.Filler) reflect.Value {
+		c := &physical.ColumnExpr{}
+		f.Fill(reflect.ValueOf(c).Elem())
+		return reflect.ValueOf(c)
+	})
+
+	// Enum-like types must be values present in the proto lookup map,
+	// otherwise marshal returns an error. Coverage of all enum values is
+	// handled separately by TestLookupCompleteness_*.
+	f.RegisterFixed(types.UnaryOpNot)
+	f.RegisterFixed(types.BinaryOpEq)
+	f.RegisterFixed(types.VariadicOpParseLogfmt)
+	f.RegisterFixed(types.ColumnTypeLabel)
+
+	return f
+}

--- a/pkg/engine/internal/proto/physicalpb/marshal_types_test.go
+++ b/pkg/engine/internal/proto/physicalpb/marshal_types_test.go
@@ -1,0 +1,49 @@
+package physicalpb
+
+import (
+	"testing"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/proto/testutils"
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+)
+
+// The tests in this file guard against silent drift between the proto enums
+// declared in physicalpb.pb.go, the corresponding types.* enums declared in
+// pkg/engine/internal/types, and the lookup tables in marshal_types.go /
+// unmarshal_types.go.
+//
+// Whenever a new value is added to either the proto enum or the types.* enum
+// but the lookup tables are not updated, conversions silently fail at runtime.
+// These tests catch that drift at build time.
+
+func TestLookupCompleteness_AggregateRangeOp(t *testing.T) {
+	testutils.CheckEnumLookup(t,
+		"AggregateRangeOp",
+		AggregateRangeOp_name,
+		testutils.CountConstantsOfType(t, "../../types/aggregations.go", "RangeAggregationType"),
+		nativeRangeAggregationLookup,
+		protoAggregateRangeLookup,
+		func(v int32) AggregateRangeOp { return AggregateRangeOp(v) },
+		func(v AggregateRangeOp) (types.RangeAggregationType, error) { return v.marshalType() },
+		func(v types.RangeAggregationType) (AggregateRangeOp, error) {
+			var p AggregateRangeOp
+			return p, p.unmarshalType(v)
+		},
+	)
+}
+
+func TestLookupCompleteness_AggregateVectorOp(t *testing.T) {
+	testutils.CheckEnumLookup(t,
+		"AggregateVectorOp",
+		AggregateVectorOp_name,
+		testutils.CountConstantsOfType(t, "../../types/aggregations.go", "VectorAggregationType"),
+		nativeVectorAggregationLookup,
+		protoAggregateVectorLookup,
+		func(v int32) AggregateVectorOp { return AggregateVectorOp(v) },
+		func(v AggregateVectorOp) (types.VectorAggregationType, error) { return v.marshalType() },
+		func(v types.VectorAggregationType) (AggregateVectorOp, error) {
+			var p AggregateVectorOp
+			return p, p.unmarshalType(v)
+		},
+	)
+}

--- a/pkg/engine/internal/proto/physicalpb/round_trip_test.go
+++ b/pkg/engine/internal/proto/physicalpb/round_trip_test.go
@@ -1,0 +1,128 @@
+package physicalpb_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/proto/physicalpb"
+	"github.com/grafana/loki/v3/pkg/engine/internal/proto/testutils"
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
+)
+
+// TestRoundTripNodes_Reflection uses reflection to construct each supported
+// physical.Node with every settable field set to a distinct non-zero value,
+// runs each through the protobuf marshal/unmarshal round trip, and asserts
+// that the recovered node deep-equals the input. This catches "added a struct
+// field but forgot to copy it in marshal_node.go / unmarshal_node.go" silent
+// bugs without requiring the test author to enumerate every field.
+//
+// TODO: physical.LogMerge is omitted because it has no proto representation:
+// the type switches in marshal_node.go and unmarshal_node.go don't include it,
+// so any plan containing it errors out at serialization time. Adding it
+// here would surface that gap, but as a separate finding from this test's
+// "fields not copied" focus. Once proto support lands, add it to the list.
+func TestRoundTripNodes_Reflection(t *testing.T) {
+	cases := []physical.Node{
+		new(physical.Batching),
+		new(physical.Cache),
+		new(physical.ColumnCompat),
+		new(physical.DataObjScan),
+		new(physical.Filter),
+		new(physical.IndexMerge),
+		new(physical.Join),
+		new(physical.Limit),
+		new(physical.Merge),
+		new(physical.Parallelize),
+		new(physical.PointersScan),
+		new(physical.Projection),
+		new(physical.RangeAggregation),
+		new(physical.ScanSet),
+		new(physical.TopK),
+		new(physical.VectorAggregation),
+		//new(physical.LogMerge),
+	}
+
+	for _, n := range cases {
+		name := reflect.TypeOf(n).Elem().Name()
+		t.Run(name, func(t *testing.T) {
+			newPhysicalFiller().Fill(reflect.ValueOf(n).Elem())
+
+			var graph dag.Graph[physical.Node]
+			graph.Add(n)
+			expected := physical.FromGraph(graph)
+
+			var protoPlan physicalpb.Plan
+			require.NoError(t, protoPlan.UnmarshalPhysical(expected))
+			actual, err := protoPlan.MarshalPhysical()
+			require.NoError(t, err)
+
+			actualRoot, err := actual.Root()
+			require.NoError(t, err)
+			require.Equal(t, n, actualRoot,
+				"round-trip mismatch — a field on %s is likely not copied in marshal_node.go or unmarshal_node.go",
+				name)
+		})
+	}
+}
+
+// newPhysicalFiller wires the engine-specific overrides on top of the
+// generic testutils.Filler: interface constructors, valid enum values, and
+// the ScanTarget discriminated-union fixer.
+func newPhysicalFiller() *testutils.Filler {
+	f := testutils.NewFiller()
+
+	// physical.Expression and physical.ColumnExpression: pick the simplest
+	// concrete implementation (*ColumnExpr) so the test stays focused on
+	// node-level fields, not on the expression marshaling tree (which is
+	// exercised separately in expressionpb).
+	colExprCtor := func(f *testutils.Filler) reflect.Value {
+		c := &physical.ColumnExpr{}
+		f.Fill(reflect.ValueOf(c).Elem())
+		return reflect.ValueOf(c)
+	}
+	f.RegisterInterface(reflect.TypeOf((*physical.Expression)(nil)).Elem(), colExprCtor)
+	f.RegisterInterface(reflect.TypeOf((*physical.ColumnExpression)(nil)).Elem(), colExprCtor)
+
+	// Enum-like types must be set to values present in the proto lookup map,
+	// otherwise marshal returns an error and the round trip fails for the
+	// wrong reason. TestLookupCompleteness_* separately ensures every value
+	// is reachable.
+	f.RegisterFixed(types.UnaryOpNot)
+	f.RegisterFixed(types.BinaryOpEq)
+	f.RegisterFixed(types.VariadicOpParseLogfmt)
+	f.RegisterFixed(types.ColumnTypeLabel)
+	f.RegisterFixed(types.RangeAggregationTypeCount)
+	f.RegisterFixed(types.VectorAggregationTypeSum)
+
+	// physical.ScanTarget is a discriminated union: Type determines whether
+	// DataObject or Pointers is set (and only one at a time). The generic
+	// filler would set both, which the marshal code does not support. Inside
+	// a ScanTarget the inner scan's NodeID is intentionally dropped (the
+	// marshal code passes ulid.Zero to MarshalPhysical because "Targets
+	// aren't real nodes"), so the fixer zeros it out to keep the round trip
+	// symmetric.
+	f.RegisterSpecific(reflect.TypeOf(physical.ScanTarget{}), func(f *testutils.Filler) reflect.Value {
+		target := physical.ScanTarget{}
+		if f.Next()%2 == 0 {
+			target.Type = physical.ScanTypeDataObject
+			d := &physical.DataObjScan{}
+			f.Fill(reflect.ValueOf(d).Elem())
+			d.NodeID = ulid.ULID{}
+			target.DataObject = d
+		} else {
+			target.Type = physical.ScanTypePointers
+			p := &physical.PointersScan{}
+			f.Fill(reflect.ValueOf(p).Elem())
+			p.NodeID = ulid.ULID{}
+			target.Pointers = p
+		}
+		return reflect.ValueOf(target)
+	})
+
+	return f
+}

--- a/pkg/engine/internal/proto/testutils/filler.go
+++ b/pkg/engine/internal/proto/testutils/filler.go
@@ -1,0 +1,144 @@
+package testutils
+
+import (
+	"encoding/binary"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+)
+
+// Filler walks a reflect.Value and assigns every settable field a distinct
+// non-zero value, recursing into composite kinds. Interface fields and
+// concrete types with semantic constraints (valid enum values, unexported
+// fields, discriminated unions) are handled via per-type registries that the
+// caller sets up before invoking Fill.
+//
+// Filler is the shared engine for tests that detect "added a struct field but
+// forgot to copy it in marshal/unmarshal" silent bugs without requiring the
+// test author to enumerate every field.
+type Filler struct {
+	counter int
+
+	interfaceCtors  map[reflect.Type]func(*Filler) reflect.Value
+	specificFillers map[reflect.Type]func(*Filler) reflect.Value
+}
+
+// NewFiller returns a Filler with built-in handlers for time.Time,
+// time.Duration, and ulid.ULID (deterministic non-zero values, no monotonic
+// clock, stable location). Callers add further overrides via
+// RegisterInterface, RegisterSpecific, or RegisterFixed before calling Fill.
+func NewFiller() *Filler {
+	f := &Filler{
+		interfaceCtors:  map[reflect.Type]func(*Filler) reflect.Value{},
+		specificFillers: map[reflect.Type]func(*Filler) reflect.Value{},
+	}
+	f.RegisterSpecific(reflect.TypeOf(time.Time{}), func(f *Filler) reflect.Value {
+		return reflect.ValueOf(time.Unix(int64(f.Next())*1000, 0).UTC())
+	})
+	f.RegisterSpecific(reflect.TypeOf(time.Duration(0)), func(f *Filler) reflect.Value {
+		return reflect.ValueOf(time.Duration(f.Next()) * time.Millisecond)
+	})
+	f.RegisterSpecific(reflect.TypeOf(ulid.ULID{}), func(f *Filler) reflect.Value {
+		var u ulid.ULID
+		binary.BigEndian.PutUint64(u[:8], uint64(f.Next()))
+		binary.BigEndian.PutUint64(u[8:], uint64(f.Next()))
+		return reflect.ValueOf(u)
+	})
+	return f
+}
+
+// RegisterInterface adds (or replaces) a constructor for an interface type.
+// The returned reflect.Value must implement iface and contain non-zero data.
+func (f *Filler) RegisterInterface(iface reflect.Type, ctor func(*Filler) reflect.Value) {
+	f.interfaceCtors[iface] = ctor
+}
+
+// RegisterSpecific adds (or replaces) a constructor for a concrete type that
+// has semantic constraints (e.g. valid enum values, discriminated unions,
+// unexported fields that reflection cannot set).
+func (f *Filler) RegisterSpecific(t reflect.Type, ctor func(*Filler) reflect.Value) {
+	f.specificFillers[t] = ctor
+}
+
+// RegisterFixed is a convenience for RegisterSpecific when the type should
+// always be filled with the same value (typical for enum-like types where any
+// valid non-zero value will do).
+func (f *Filler) RegisterFixed(v any) {
+	rv := reflect.ValueOf(v)
+	f.specificFillers[rv.Type()] = func(*Filler) reflect.Value { return rv }
+}
+
+// Next returns the next counter value. Custom registered fillers can call
+// this to keep their values distinct across invocations.
+func (f *Filler) Next() int {
+	f.counter++
+	return f.counter
+}
+
+// Fill populates v with non-zero data, applying registered overrides where
+// available and recursing into composite types.
+func (f *Filler) Fill(v reflect.Value) {
+	if !v.CanSet() {
+		return
+	}
+	t := v.Type()
+	if c, ok := f.specificFillers[t]; ok {
+		v.Set(c(f))
+		return
+	}
+	switch t.Kind() {
+	case reflect.Interface:
+		c, ok := f.interfaceCtors[t]
+		if !ok {
+			panic(fmt.Sprintf("Filler: no constructor registered for interface %s", t))
+		}
+		v.Set(c(f))
+	case reflect.Pointer:
+		ptr := reflect.New(t.Elem())
+		f.Fill(ptr.Elem())
+		v.Set(ptr)
+	case reflect.Slice:
+		const n = 2
+		s := reflect.MakeSlice(t, n, n)
+		for i := 0; i < n; i++ {
+			f.Fill(s.Index(i))
+		}
+		v.Set(s)
+	case reflect.Map:
+		m := reflect.MakeMap(t)
+		for i := 0; i < 2; i++ {
+			k := reflect.New(t.Key()).Elem()
+			f.Fill(k)
+			val := reflect.New(t.Elem()).Elem()
+			f.Fill(val)
+			m.SetMapIndex(k, val)
+		}
+		v.Set(m)
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			f.Fill(v.Index(i))
+		}
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Field(i)
+			if !field.CanSet() {
+				continue
+			}
+			f.Fill(field)
+		}
+	case reflect.String:
+		v.SetString(fmt.Sprintf("s%d", f.Next()))
+	case reflect.Bool:
+		v.SetBool(true)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v.SetInt(int64(f.Next()))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v.SetUint(uint64(f.Next()))
+	case reflect.Float32, reflect.Float64:
+		v.SetFloat(float64(f.Next()))
+	default:
+		panic(fmt.Sprintf("Filler: unsupported kind %s for type %s", t.Kind(), t))
+	}
+}

--- a/pkg/engine/internal/proto/testutils/reflect.go
+++ b/pkg/engine/internal/proto/testutils/reflect.go
@@ -1,0 +1,119 @@
+package testutils
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// checkEnumLookup verifies that a proto enum, its corresponding types.* enum,
+// and the marshal/unmarshal lookup maps are consistent. It asserts that:
+//   - the proto enum and the types.* enum have the same number of values
+//     (catches "added to one side but not the other");
+//   - both lookup maps have one entry per proto enum value (catches "added to
+//     both enums but forgot to update the lookup");
+//   - every proto enum value is a key in the marshal lookup;
+//   - the marshal and unmarshal lookup maps are inverses of each other (which,
+//     combined with the cardinality checks, implies every types.* value is
+//     also covered);
+//   - every proto enum value round-trips through MarshalType / UnmarshalType
+//     to its original value.
+func CheckEnumLookup[Proto, Native comparable](
+	t *testing.T,
+	name string,
+	protoNameMap map[int32]string,
+	typesEnumCount int,
+	nativeLookup map[Proto]Native,
+	protoLookup map[Native]Proto,
+	intToProto func(int32) Proto,
+	marshalFn func(Proto) (Native, error),
+	unmarshalFn func(Native) (Proto, error),
+) {
+	t.Helper()
+	protoCount := len(protoNameMap)
+
+	require.Equalf(t, typesEnumCount, protoCount,
+		"%s: types.* enum has %d constants but proto enum has %d values - did you add a value to one side without the other? Check pkg/engine/internal/types/*.go and the .proto file",
+		name, typesEnumCount, protoCount)
+
+	require.Equalf(t, protoCount, len(nativeLookup),
+		"%s: marshal lookup has %d entries but proto enum has %d values - missing entry in marshal_types.go?",
+		name, len(nativeLookup), protoCount)
+	require.Equalf(t, protoCount, len(protoLookup),
+		"%s: unmarshal lookup has %d entries but proto enum has %d values - missing entry in unmarshal_types.go?",
+		name, len(protoLookup), protoCount)
+
+	for v := range protoNameMap {
+		p := intToProto(v)
+		_, ok := nativeLookup[p]
+		require.Truef(t, ok, "%s: marshal lookup missing entry for proto value %v", name, p)
+	}
+
+	for protoVal, nativeVal := range nativeLookup {
+		backProto, ok := protoLookup[nativeVal]
+		require.Truef(t, ok,
+			"%s: unmarshal lookup missing entry for native value %v (mapped from %v in marshal lookup)",
+			name, nativeVal, protoVal)
+		require.Equalf(t, protoVal, backProto,
+			"%s: lookups are not inverses - marshal[%v]=%v but unmarshal[%v]=%v",
+			name, protoVal, nativeVal, nativeVal, backProto)
+	}
+
+	for v := range protoNameMap {
+		p := intToProto(v)
+		n, err := marshalFn(p)
+		require.NoErrorf(t, err, "%s: MarshalType failed for %v", name, p)
+		back, err := unmarshalFn(n)
+		require.NoErrorf(t, err, "%s: UnmarshalType failed for %v (marshaled from %v)", name, n, p)
+		require.Equalf(t, p, back,
+			"%s: round-trip mismatch %v -> %v -> %v", name, p, n, back)
+	}
+}
+
+// countConstantsOfType returns the number of top-level constants of the named
+// type declared in the given Go source file. It walks const blocks and tracks
+// type inheritance: inside a const block, a spec that has neither an explicit
+// type nor an explicit value inherits both from the previous spec, so a single
+// type declaration at the top of an iota block applies to all subsequent
+// identifiers.
+func CountConstantsOfType(t *testing.T, file string, typeName string) int {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, file, nil, 0)
+	require.NoErrorf(t, err, "parsing %s", file)
+
+	var count int
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+		var currentType string
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			switch {
+			case vs.Type != nil:
+				if id, ok := vs.Type.(*ast.Ident); ok {
+					currentType = id.Name
+				} else {
+					currentType = ""
+				}
+			case vs.Values != nil:
+				// An explicit value with no explicit type breaks the inherited
+				// type carried over from the previous spec.
+				currentType = ""
+			}
+			if currentType == typeName {
+				count += len(vs.Names)
+			}
+		}
+	}
+	require.NotZerof(t, count, "no constants of type %s found in %s", typeName, file)
+	return count
+}

--- a/pkg/engine/internal/proto/testutils/reflect.go
+++ b/pkg/engine/internal/proto/testutils/reflect.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// checkEnumLookup verifies that a proto enum, its corresponding types.* enum,
+// CheckEnumLookup verifies that a proto enum, its corresponding types.* enum,
 // and the marshal/unmarshal lookup maps are consistent. It asserts that:
 //   - the proto enum and the types.* enum have the same number of values
 //     (catches "added to one side but not the other");
@@ -73,7 +73,7 @@ func CheckEnumLookup[Proto, Native comparable](
 	}
 }
 
-// countConstantsOfType returns the number of top-level constants of the named
+// CountConstantsOfType returns the number of top-level constants of the named
 // type declared in the given Go source file. It walks const blocks and tracks
 // type inheritance: inside a const block, a spec that has neither an explicit
 // type nor an explicit value inherits both from the previous spec, so a single


### PR DESCRIPTION
**What this PR does / why we need it**:

I was investigating failing Thor queries and found error messages about missing `Projection.Expressions` field in logs for scheduler tasks. The root cause was a missing `VARIADIC_OP_PARSE_REGEXP:   types.VariadicOpParseRegexp,` mapping in marshaling code.

We have had bugs like this before. To avoid future bugs like this one I am adding few unit tests that do some reflection magic and compare enums from `types` package agains protobuf definitions and explode when something is missing. Also, structures are filled with non zero values via reflection and marshal->unmarshal equality is verified. This prevents any drift between Go types and corresponding protobuf messages.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
