### PR TITLE
feat(querylimits): Allow TSDB sharding strategy overrides

### DIFF
--- a/pkg/querier/queryrange/limits/definitions.go
+++ b/pkg/querier/queryrange/limits/definitions.go
@@ -28,7 +28,7 @@ type Limits interface {
 	TSDBMaxQueryParallelism(context.Context, string) int
 	// TSDBMaxBytesPerShard returns the limit to the number of bytes a single shard
 	TSDBMaxBytesPerShard(string) int
-	TSDBShardingStrategy(userID string) string
+	TSDBShardingStrategy(context.Context, string) string
 
 	RequiredLabels(context.Context, string) []string
 	RequiredNumberLabels(context.Context, string) int

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -203,7 +203,7 @@ func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (que
 	var strategy logql.ShardingStrategy
 
 	if conf.IndexType == types.IndexTypeTSDB {
-		v := ast.limits.TSDBShardingStrategy(tenants[0])
+		v := ast.limits.TSDBShardingStrategy(ctx, tenants[0])
 		version, err := logql.ParseShardVersion(v)
 		if err != nil {
 			level.Warn(spLogger).Log(

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -338,6 +338,66 @@ func Test_astMapper_QuerySizeLimits(t *testing.T) {
 	}
 }
 
+func Test_astMapper_TSDBShardingStrategyUsesContext(t *testing.T) {
+	type strategyContextKey struct{}
+
+	handler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+		switch req.(type) {
+		case *logproto.IndexStatsRequest:
+			return &IndexStatsResponse{
+				Response: &logproto.IndexStatsResponse{
+					Bytes: 100,
+				},
+			}, nil
+		case *LokiRequest:
+			return lokiResps[0], nil
+		default:
+			return nil, fmt.Errorf("request not supported: %T", req)
+		}
+	})
+
+	calls := 0
+	mware := newASTMapperware(
+		ShardingConfigs{
+			config.PeriodConfig{
+				IndexType: types.IndexTypeTSDB,
+			},
+		},
+		testEngineOpts,
+		handler,
+		handler,
+		nil,
+		log.NewNopLogger(),
+		nilShardingMetrics,
+		fakeLimits{
+			maxSeries:               math.MaxInt32,
+			maxQueryParallelism:     1,
+			tsdbMaxQueryParallelism: 1,
+			queryTimeout:            time.Minute,
+			tsdbShardingStrategy: func(ctx context.Context, userID string) string {
+				calls++
+				require.Equal(t, "strategy-context", ctx.Value(strategyContextKey{}))
+				require.Equal(t, "tenant-a", userID)
+				return logql.PowerOfTwoVersion.String()
+			},
+		},
+		0,
+		[]string{},
+	)
+
+	req := defaultReq()
+	req.Query = `{app="foo"}`
+	req.Plan = &plan.QueryPlan{
+		AST: syntax.MustParseExpr(req.Query),
+	}
+	ctx := context.WithValue(context.Background(), strategyContextKey{}, "strategy-context")
+	ctx = user.InjectOrgID(ctx, "tenant-a")
+
+	_, err := mware.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+}
+
 func Test_ShardingByPass(t *testing.T) {
 	called := 0
 	handler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -1402,6 +1402,7 @@ type fakeLimits struct {
 	maxMetadataCacheFreshness   time.Duration
 	volumeEnabled               bool
 	enableMultiVariantQueries   bool
+	tsdbShardingStrategy        func(context.Context, string) string
 }
 
 func (f fakeLimits) QuerySplitDuration(key string) time.Duration {
@@ -1529,7 +1530,10 @@ func (f fakeLimits) TSDBMaxBytesPerShard(_ string) int {
 	return valid.DefaultTSDBMaxBytesPerShard
 }
 
-func (f fakeLimits) TSDBShardingStrategy(string) string {
+func (f fakeLimits) TSDBShardingStrategy(ctx context.Context, userID string) string {
+	if f.tsdbShardingStrategy != nil {
+		return f.tsdbShardingStrategy(ctx, userID)
+	}
 	return logql.PowerOfTwoVersion.String()
 }
 

--- a/pkg/util/querylimits/limiter.go
+++ b/pkg/util/querylimits/limiter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 
+	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/util/limiter"
 	logutil "github.com/grafana/loki/v3/pkg/util/log"
 )
@@ -129,4 +130,19 @@ func (l *Limiter) MaxQueryBytesRead(ctx context.Context, userID string) int {
 	}
 	level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using request limit", "limit", "MaxQueryBytesRead", "tenant", userID, "query-limit", requestLimits.MaxQueryBytesRead.Val(), "original-limit", original)
 	return requestLimits.MaxQueryBytesRead.Val()
+}
+
+func (l *Limiter) TSDBShardingStrategy(ctx context.Context, userID string) string {
+	original := l.CombinedLimits.TSDBShardingStrategy(ctx, userID)
+	requestLimits := ExtractQueryLimitsFromContext(ctx)
+	if requestLimits == nil || requestLimits.TSDBShardingStrategy == "" {
+		return original
+	}
+
+	if _, err := logql.ParseShardVersion(requestLimits.TSDBShardingStrategy); err != nil {
+		return original
+	}
+
+	level.Debug(logutil.WithContext(ctx, l.logger)).Log("msg", "using request limit", "limit", "TSDBShardingStrategy", "tenant", userID, "query-limit", requestLimits.TSDBShardingStrategy, "original-limit", original)
+	return requestLimits.TSDBShardingStrategy
 }

--- a/pkg/util/querylimits/limiter_test.go
+++ b/pkg/util/querylimits/limiter_test.go
@@ -282,7 +282,7 @@ func TestLimiter_TSDBShardingStrategy(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tLimits := map[string]*validation.Limits{
-				"fake": &validation.Limits{
+				"fake": {
 					TSDBShardingStrategy: tc.configured,
 				},
 			}

--- a/pkg/util/querylimits/limiter_test.go
+++ b/pkg/util/querylimits/limiter_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/validation"
 )
 
@@ -246,4 +247,58 @@ func TestLimiter_MergeLimits(t *testing.T) {
 	ctx := InjectQueryLimitsIntoContext(context.Background(), limits)
 
 	require.ElementsMatch(t, []string{"one", "two", "three"}, l.RequiredLabels(ctx, "fake"))
+}
+
+func TestLimiter_TSDBShardingStrategy(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		configured string
+		override   string
+		expected   string
+	}{
+		{
+			name:       "default returns configured strategy",
+			configured: logql.BoundedVersion.String(),
+			expected:   logql.BoundedVersion.String(),
+		},
+		{
+			name:       "power of two override wins over bounded",
+			configured: logql.BoundedVersion.String(),
+			override:   logql.PowerOfTwoVersion.String(),
+			expected:   logql.PowerOfTwoVersion.String(),
+		},
+		{
+			name:       "bounded override wins over power of two",
+			configured: logql.PowerOfTwoVersion.String(),
+			override:   logql.BoundedVersion.String(),
+			expected:   logql.BoundedVersion.String(),
+		},
+		{
+			name:       "invalid override preserves configured strategy",
+			configured: logql.BoundedVersion.String(),
+			override:   "invalid",
+			expected:   logql.BoundedVersion.String(),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tLimits := map[string]*validation.Limits{
+				"fake": &validation.Limits{
+					TSDBShardingStrategy: tc.configured,
+				},
+			}
+
+			overrides, err := validation.NewOverrides(validation.Limits{}, newMockTenantLimits(tLimits))
+			require.NoError(t, err)
+			l := NewLimiter(log.NewNopLogger(), overrides)
+
+			ctx := context.Background()
+			if tc.override != "" {
+				ctx = InjectQueryLimitsIntoContext(ctx, QueryLimits{
+					TSDBShardingStrategy: tc.override,
+				})
+			}
+
+			require.Equal(t, tc.expected, l.TSDBShardingStrategy(ctx, "fake"))
+		})
+	}
 }

--- a/pkg/util/querylimits/middleware_test.go
+++ b/pkg/util/querylimits/middleware_test.go
@@ -46,14 +46,15 @@ func Test_MiddlewareWithBrokenHeader(t *testing.T) {
 
 func Test_MiddlewareWithHeader(t *testing.T) {
 	limits := QueryLimits{
-		model.Duration(1 * time.Second),
-		model.Duration(1 * time.Second),
-		model.Duration(1 * time.Second),
-		1,
-		model.Duration(1 * time.Second),
-		[]string{"foo", "bar"},
-		10,
-		10,
+		MaxQueryLength:          model.Duration(1 * time.Second),
+		MaxQueryRange:           model.Duration(1 * time.Second),
+		MaxQueryLookback:        model.Duration(1 * time.Second),
+		MaxEntriesLimitPerQuery: 1,
+		QueryTimeout:            model.Duration(1 * time.Second),
+		RequiredLabels:          []string{"foo", "bar"},
+		RequiredNumberLabels:    10,
+		MaxQueryBytesRead:       10,
+		TSDBShardingStrategy:    "power_of_two",
 	}
 
 	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {

--- a/pkg/util/querylimits/propagation.go
+++ b/pkg/util/querylimits/propagation.go
@@ -33,6 +33,7 @@ type QueryLimits struct {
 	RequiredLabels          []string         `json:"requiredLabels,omitempty"`
 	RequiredNumberLabels    int              `json:"minimumLabelsNumber,omitempty"`
 	MaxQueryBytesRead       flagext.ByteSize `json:"maxQueryBytesRead,omitempty"`
+	TSDBShardingStrategy    string           `json:"tsdbShardingStrategy,omitempty"`
 }
 
 func UnmarshalQueryLimits(data []byte) (*QueryLimits, error) {

--- a/pkg/util/querylimits/propagation_test.go
+++ b/pkg/util/querylimits/propagation_test.go
@@ -25,7 +25,7 @@ func TestInjectAndExtractQueryLimits(t *testing.T) {
 
 func TestDeserializingQueryLimits(t *testing.T) {
 	// full limits
-	payload := `{"maxEntriesLimitPerQuery": 100, "maxQueryLength": "2d", "maxQueryLookback": "2w", "maxQueryTime": "5s", "maxQueryBytesRead": "1MB", "maxQuerierBytesRead": "1MB"}`
+	payload := `{"maxEntriesLimitPerQuery": 100, "maxQueryLength": "2d", "maxQueryLookback": "2w", "maxQueryTime": "5s", "maxQueryBytesRead": "1MB", "maxQuerierBytesRead": "1MB", "tsdbShardingStrategy": "power_of_two"}`
 	limits, err := UnmarshalQueryLimits([]byte(payload))
 	require.NoError(t, err)
 	require.Equal(t, model.Duration(2*24*time.Hour), limits.MaxQueryLength)
@@ -33,6 +33,7 @@ func TestDeserializingQueryLimits(t *testing.T) {
 	require.Equal(t, model.Duration(5*time.Second), limits.QueryTimeout)
 	require.Equal(t, 100, limits.MaxEntriesLimitPerQuery)
 	require.Equal(t, 1*1024*1024, limits.MaxQueryBytesRead.Val())
+	require.Equal(t, "power_of_two", limits.TSDBShardingStrategy)
 	// some limits are empty
 	payload = `{"maxQueryLength":"1h"}`
 	limits, err = UnmarshalQueryLimits([]byte(payload))
@@ -41,6 +42,7 @@ func TestDeserializingQueryLimits(t *testing.T) {
 	require.Equal(t, model.Duration(0), limits.MaxQueryLookback)
 	require.Equal(t, 0, limits.MaxEntriesLimitPerQuery)
 	require.Equal(t, 0, limits.MaxQueryBytesRead.Val())
+	require.Empty(t, limits.TSDBShardingStrategy)
 }
 
 func TestSerializingQueryLimits(t *testing.T) {
@@ -51,11 +53,12 @@ func TestSerializingQueryLimits(t *testing.T) {
 		MaxEntriesLimitPerQuery: 100,
 		QueryTimeout:            model.Duration(5 * time.Second),
 		MaxQueryBytesRead:       1 * 1024 * 1024,
+		TSDBShardingStrategy:    "power_of_two",
 	}
 
 	actual, err := MarshalQueryLimits(&limits)
 	require.NoError(t, err)
-	expected := `{"maxEntriesLimitPerQuery": 100, "maxQueryLength": "2d", "maxQueryLookback": "2w", "maxQueryTime": "5s", "maxQueryBytesRead": "1MB"}`
+	expected := `{"maxEntriesLimitPerQuery": 100, "maxQueryLength": "2d", "maxQueryLookback": "2w", "maxQueryTime": "5s", "maxQueryBytesRead": "1MB", "tsdbShardingStrategy": "power_of_two"}`
 	require.JSONEq(t, expected, string(actual))
 
 	// some limits are empty

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -902,7 +902,7 @@ func (o *Overrides) TSDBMaxBytesPerShard(userID string) int {
 }
 
 // TSDBShardingStrategy returns the sharding strategy to use in query planning.
-func (o *Overrides) TSDBShardingStrategy(userID string) string {
+func (o *Overrides) TSDBShardingStrategy(_ context.Context, userID string) string {
 	return o.getOverridesForUser(userID).TSDBShardingStrategy
 }
 


### PR DESCRIPTION
## Summary
- Add `tsdbShardingStrategy` to per-request query limits so a single Loki request can override TSDB sharding strategy.
- Make the queryrange TSDB sharding strategy limit lookup context-aware and wire query sharding to use the request context.
- Validate request strategy overrides with `logql.ParseShardVersion`, preserving configured tenant/global strategy when the override is empty or invalid.

## API changes
- `pkg/querier/queryrange/limits.Limits.TSDBShardingStrategy` now has signature `TSDBShardingStrategy(context.Context, string) string`.
- `pkg/validation.Overrides.TSDBShardingStrategy` now accepts `context.Context`; it intentionally ignores it because validation overrides remain tenant/global config only.
- Types implementing `pkg/util/limiter.CombinedLimits` may need to update their `TSDBShardingStrategy` method signature because it embeds the queryrange limits interface.

## Test plan
- `go test ./pkg/util/querylimits ./pkg/querier/queryrange ./pkg/validation`

## Rollout notes
- Runtime config semantics for `tsdb_sharding_strategy` are unchanged.
- Existing query-limit headers remain compatible; the new `tsdbShardingStrategy` JSON field is additive and omitted when empty.

Made with [Cursor](https://cursor.com)