### PR TITLE
docs: fix label name regex — colons are not valid in Loki label names

### DIFF
--- a/docs/sources/get-started/labels/_index.md
+++ b/docs/sources/get-started/labels/_index.md
@@ -159,7 +159,7 @@ That being said, in some cases you may wish to add some extra labels, which can 
 
 Loki places the same restrictions on label naming as [Prometheus](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels):
 
-- It may contain ASCII letters and digits, as well as underscores and colons. It must match the regex `[a-zA-Z_:][a-zA-Z0-9_:]*`.
+- It may contain ASCII letters, digits, and underscores. It must match the regex `[a-zA-Z_][a-zA-Z0-9_]*`. Colons are reserved for Prometheus recording rules and are **not** valid in Loki label names.
 - Unsupported characters in the label should be converted to an underscore. For example, the label `app.kubernetes.io/name` should be written as `app_kubernetes_io_name`.
 - However, do not begin and end your label names with double underscores, as this naming convention is used for internal labels, for example, \__stream_shard__, that are hidden by default in the label browser, query builder, and autocomplete to avoid creating confusion for users.
 


### PR DESCRIPTION
## Summary

Fixes #19673.

The label format documentation incorrectly stated that Loki label names
may contain colons and cited the regex `[a-zA-Z_:][a-zA-Z0-9_:]*`.
This is the **metric-name** regex from the Prometheus data model, not
the **label-name** regex.

Loki inherits Prometheus's label naming rules:

| Kind | Regex | Colons? |
|---|---|---|
| Metric names | `[a-zA-Z_:][a-zA-Z0-9_:]*` | ✅ (reserved for recording rules) |
| Label names | `[a-zA-Z_][a-zA-Z0-9_]*` | ❌ |

Attempting to push a stream with a label name that contains a colon
(e.g. `"bad:label"`) returns:

```
HTTP/1.1 400 Bad Request
couldn't parse labels: 1:5: parse error: unexpected character inside braces: ':'
```

This PR:
- Corrects the regex to `[a-zA-Z_][a-zA-Z0-9_]*`
- Updates the prose to remove the reference to colons
- Adds a note explaining that colons are reserved for Prometheus recording rules

## Test plan

- [ ] Verify the rendered docs show the correct regex
- [ ] Confirm that pushing a stream with `"bad:label"` returns 400 as shown in #19673

🤖 Generated with [Claude Code](https://claude.com/claude-code)