### PR TITLE
docs: clarify that pattern parser can capture only partial log line fields

### DIFF
--- a/docs/sources/query/log_queries/_index.md
+++ b/docs/sources/query/log_queries/_index.md
@@ -519,6 +519,8 @@ Literals can be any sequence of UTF-8 characters, including whitespace character
 
 By default, a pattern expression is anchored at the start of the log line. If the expression starts with literals, then the log line must also start with the same set of literals. Use `<_>` at the beginning of the expression if you don't want to anchor the expression at the start.
 
+You do not need to capture every part of the log line in your pattern. You can write a pattern that only captures the fields you need, using `<_>` to skip over any parts you want to ignore.
+
 Consider the log line
 
 ```log


### PR DESCRIPTION
## Summary

Fixes #9948.

The pattern parser section explained how `<_>` can be used to skip the beginning of a log line, but it did not explicitly state that you can skip over **any** part of the line — not just the beginning.

Users coming from a regex background might assume they need to match every character in the log line. This PR adds a sentence that directly states: you only need to capture the fields you care about; use `<_>` to skip the rest.

The existing example already demonstrates this (using `<_> msg="<method> <path> (<status>) <latency>"` to skip everything before `msg=`), but the prose did not make the intent explicit.

## Test plan

- [ ] Verify the rendered docs show the new sentence in the Pattern section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)