### PR TITLE
chore(clients): Reduce logproto package dependency

### DIFF
--- a/clients/pkg/util/api.go
+++ b/clients/pkg/util/api.go
@@ -6,13 +6,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
-	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/pkg/push"
 )
 
 // Entry is a log entry with labels.
 type Entry struct {
 	Labels model.LabelSet
-	logproto.Entry
+	push.Entry
 }
 
 type InstrumentedEntryHandler interface {

--- a/clients/pkg/util/batch.go
+++ b/clients/pkg/util/batch.go
@@ -11,7 +11,7 @@ import (
 	"github.com/golang/snappy"
 	"github.com/prometheus/common/model"
 
-	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/pkg/push"
 )
 
 const (
@@ -23,7 +23,7 @@ const (
 // and entries in a single batch request. In case of multi-tenant Promtail, log
 // streams for each tenant are stored in a dedicated batch.
 type batch struct {
-	streams   map[string]*logproto.Stream
+	streams   map[string]*push.Stream
 	bytes     int
 	createdAt time.Time
 
@@ -32,7 +32,7 @@ type batch struct {
 
 func newBatch(maxStreams int, entries ...Entry) *batch {
 	b := &batch{
-		streams:    map[string]*logproto.Stream{},
+		streams:    map[string]*push.Stream{},
 		bytes:      0,
 		createdAt:  time.Now(),
 		maxStreams: maxStreams,
@@ -63,9 +63,9 @@ func (b *batch) add(entry Entry) error {
 		return fmt.Errorf(errMaxStreamsLimitExceeded, streams, b.maxStreams, labels)
 	}
 	// Add the entry as a new stream
-	b.streams[labels] = &logproto.Stream{
+	b.streams[labels] = &push.Stream{
 		Labels:  labels,
-		Entries: []logproto.Entry{entry.Entry},
+		Entries: []push.Entry{entry.Entry},
 	}
 	return nil
 }
@@ -126,9 +126,9 @@ func (b *batch) encode() ([]byte, int, error) {
 }
 
 // creates push request and returns it, together with number of entries
-func (b *batch) createPushRequest() (*logproto.PushRequest, int) {
-	req := logproto.PushRequest{
-		Streams: make([]logproto.Stream, 0, len(b.streams)),
+func (b *batch) createPushRequest() (*push.PushRequest, int) {
+	req := push.PushRequest{
+		Streams: make([]push.Stream, 0, len(b.streams)),
 	}
 
 	entriesCount := 0


### PR DESCRIPTION
**What this PR does / why we need it**:

This is part of a series of small refactorings aimed at reducing the dependencies of `loki/clients/pkg/...`. (#22337)

Some of the types in `logproto` are a pass-through to package `push`, which is in a separate module.
By changing those to depend directly on `push` we can reduce the amount of dependencies dragged in.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- NA If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
