### PR TITLE
chore: Move error utilities to a new package

### DIFF
--- a/clients/pkg/util/client.go
+++ b/clients/pkg/util/client.go
@@ -20,8 +20,8 @@ import (
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
-	lokiutil "github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/build"
+	lokiutil "github.com/grafana/loki/v3/pkg/util/errors"
 )
 
 const (
@@ -468,7 +468,7 @@ func (c *client) send(ctx context.Context, tenantID string, buf []byte) (int, er
 	if err != nil {
 		return -1, err
 	}
-	defer lokiutil.LogError("closing response body", resp.Body.Close)
+	defer lokiutil.LogError(c.logger, "closing response body", resp.Body.Close)
 
 	if resp.StatusCode/100 != 2 {
 		scanner := bufio.NewScanner(io.LimitReader(resp.Body, maxErrMsgLen))

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -1,23 +1,18 @@
 package util //nolint:revive
 
+// Forwarder to avoid editing dozens of files that use these names.
+
 import (
-	"bytes"
 	"context"
-	"errors"
-	"fmt"
 
 	"github.com/go-kit/log/level"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
+	"github.com/grafana/loki/v3/pkg/util/errors"
 	"github.com/grafana/loki/v3/pkg/util/log"
 )
 
 // LogError logs any error returned by f; useful when deferring Close etc.
 func LogError(message string, f func() error) {
-	if err := f(); err != nil {
-		level.Error(log.Logger).Log("message", message, "error", err)
-	}
+	errors.LogError(log.Logger, message, f)
 }
 
 // LogError logs any error returned by f; useful when deferring Close etc.
@@ -27,123 +22,10 @@ func LogErrorWithContext(ctx context.Context, message string, f func() error) {
 	}
 }
 
-// The MultiError type implements the error interface, and contains the
-// Errors used to construct it.
-type MultiError []error
-
-// Returns a concatenated string of the contained errors
-func (es MultiError) Error() string {
-	var buf bytes.Buffer
-
-	if len(es) > 1 {
-		_, _ = fmt.Fprintf(&buf, "%d errors: ", len(es))
-	}
-
-	for i, err := range es {
-		if i != 0 {
-			buf.WriteString("; ")
-		}
-		buf.WriteString(err.Error())
-	}
-
-	return buf.String()
-}
-
-// Add adds the error to the error list if it is not nil.
-func (es *MultiError) Add(err error) {
-	if err == nil {
-		return
-	}
-	if merr, ok := err.(MultiError); ok {
-		*es = append(*es, merr...)
-	} else {
-		*es = append(*es, err)
-	}
-}
-
-// Err returns the error list as an error or nil if it is empty.
-func (es MultiError) Err() error {
-	if len(es) == 0 {
-		return nil
-	}
-	return es
-}
-
-// Is tells if all errors are the same as the target error.
-func (es MultiError) Is(target error) bool {
-	if len(es) == 0 {
-		return false
-	}
-	for _, err := range es {
-		if !errors.Is(err, target) {
-			return false
-		}
-	}
-	return true
-}
-
-// IsDeadlineExceeded tells if all errors are either context.DeadlineExceeded or grpc codes.DeadlineExceeded.
-func (es MultiError) IsDeadlineExceeded() bool {
-	if len(es) == 0 {
-		return false
-	}
-	for _, err := range es {
-		if errors.Is(err, context.DeadlineExceeded) {
-			continue
-		}
-		s, ok := status.FromError(err)
-		if ok && s.Code() == codes.DeadlineExceeded {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
-// GroupedErrors implements the error interface, and it contains the errors used to construct it
-// grouped by the error message.
-type GroupedErrors struct {
-	MultiError
-}
-
-// Error Returns a concatenated string of the errors grouped by the error message along with the number of occurrences
-// of each error message.
-func (es GroupedErrors) Error() string {
-	mapErrs := make(map[string]int, len(es.MultiError))
-	for _, err := range es.MultiError {
-		mapErrs[err.Error()]++
-	}
-
-	var idx int
-	var buf bytes.Buffer
-	uniqueErrs := len(mapErrs)
-	for err, n := range mapErrs {
-		if idx != 0 {
-			buf.WriteString("; ")
-		}
-		if uniqueErrs > 1 || n > 1 {
-			_, _ = fmt.Fprintf(&buf, "%d errors like: ", n)
-		}
-		buf.WriteString(err)
-		idx++
-	}
-
-	return buf.String()
-}
+type MultiError = errors.MultiError
+type GroupedErrors = errors.GroupedErrors
 
 // IsConnCanceled returns true, if error is from a closed gRPC connection.
-// copied from https://github.com/etcd-io/etcd/blob/7f47de84146bdc9225d2080ec8678ca8189a2d2b/clientv3/client.go#L646
 func IsConnCanceled(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	// >= gRPC v1.23.x
-	s, ok := status.FromError(err)
-	if ok {
-		// connection is canceled or server has already closed the connection
-		return s.Code() == codes.Canceled || s.Message() == "transport is closing"
-	}
-
-	return false
+	return errors.IsConnCanceled(err)
 }

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/go-kit/log/level"
+
 	"github.com/grafana/loki/v3/pkg/util/errors"
 	"github.com/grafana/loki/v3/pkg/util/log"
 )

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -1,0 +1,141 @@
+package errors
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// LogError logs any error returned by f; useful when deferring Close etc.
+func LogError(logger log.Logger, message string, f func() error) {
+	if err := f(); err != nil {
+		level.Error(logger).Log("message", message, "error", err)
+	}
+}
+
+// The MultiError type implements the error interface, and contains the
+// Errors used to construct it.
+type MultiError []error
+
+// Returns a concatenated string of the contained errors
+func (es MultiError) Error() string {
+	var buf bytes.Buffer
+
+	if len(es) > 1 {
+		_, _ = fmt.Fprintf(&buf, "%d errors: ", len(es))
+	}
+
+	for i, err := range es {
+		if i != 0 {
+			buf.WriteString("; ")
+		}
+		buf.WriteString(err.Error())
+	}
+
+	return buf.String()
+}
+
+// Add adds the error to the error list if it is not nil.
+func (es *MultiError) Add(err error) {
+	if err == nil {
+		return
+	}
+	if merr, ok := err.(MultiError); ok {
+		*es = append(*es, merr...)
+	} else {
+		*es = append(*es, err)
+	}
+}
+
+// Err returns the error list as an error or nil if it is empty.
+func (es MultiError) Err() error {
+	if len(es) == 0 {
+		return nil
+	}
+	return es
+}
+
+// Is tells if all errors are the same as the target error.
+func (es MultiError) Is(target error) bool {
+	if len(es) == 0 {
+		return false
+	}
+	for _, err := range es {
+		if !errors.Is(err, target) {
+			return false
+		}
+	}
+	return true
+}
+
+// IsDeadlineExceeded tells if all errors are either context.DeadlineExceeded or grpc codes.DeadlineExceeded.
+func (es MultiError) IsDeadlineExceeded() bool {
+	if len(es) == 0 {
+		return false
+	}
+	for _, err := range es {
+		if errors.Is(err, context.DeadlineExceeded) {
+			continue
+		}
+		s, ok := status.FromError(err)
+		if ok && s.Code() == codes.DeadlineExceeded {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// GroupedErrors implements the error interface, and it contains the errors used to construct it
+// grouped by the error message.
+type GroupedErrors struct {
+	MultiError
+}
+
+// Error Returns a concatenated string of the errors grouped by the error message along with the number of occurrences
+// of each error message.
+func (es GroupedErrors) Error() string {
+	mapErrs := make(map[string]int, len(es.MultiError))
+	for _, err := range es.MultiError {
+		mapErrs[err.Error()]++
+	}
+
+	var idx int
+	var buf bytes.Buffer
+	uniqueErrs := len(mapErrs)
+	for err, n := range mapErrs {
+		if idx != 0 {
+			buf.WriteString("; ")
+		}
+		if uniqueErrs > 1 || n > 1 {
+			_, _ = fmt.Fprintf(&buf, "%d errors like: ", n)
+		}
+		buf.WriteString(err)
+		idx++
+	}
+
+	return buf.String()
+}
+
+// IsConnCanceled returns true, if error is from a closed gRPC connection.
+// copied from https://github.com/etcd-io/etcd/blob/7f47de84146bdc9225d2080ec8678ca8189a2d2b/clientv3/client.go#L646
+func IsConnCanceled(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// >= gRPC v1.23.x
+	s, ok := status.FromError(err)
+	if ok {
+		// connection is canceled or server has already closed the connection
+		return s.Code() == codes.Canceled || s.Message() == "transport is closing"
+	}
+
+	return false
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is part of a series of small refactorings aimed at reducing the dependencies of `loki/clients/pkg/...`. (#22337,#22338)

Create a new package so callers wishing to use just the error utilities don't drag in all the other dependencies of `util`.

`LogError` now takes the `Logger` as a parameter, and `client.send` uses its own logger rather than the Loki global one.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- NA Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- NA If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)