### PR TITLE
fix(version): Copy build info to Prometheus common library

### DIFF
--- a/pkg/util/build/build.go
+++ b/pkg/util/build/build.go
@@ -2,6 +2,8 @@ package build
 
 import (
 	"runtime"
+
+	"github.com/prometheus/common/version"
 )
 
 // These variables are set from the Makefile.
@@ -15,6 +17,12 @@ var (
 )
 
 func init() {
+	// Copy settings for this build into Prometheus common package, where they are fetched by Prometheus client_golang.
+	version.Version = Version
+	version.Revision = Revision
+	version.Branch = Branch
+	version.BuildUser = BuildUser
+	version.BuildDate = BuildDate
 	GoVersion = runtime.Version()
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The values there are read by Prometheus client_golang to populate the `loki_build_info` metric.
This got broken by #22281.

**Special notes for your reviewer**:

I couldn't see how to test this since the important bit happens in an `init` function.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- NA Tests updated
- NA Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- NA If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
