### PR TITLE
chore(engine): Improve accounting of phase timings in query & task summaries

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -312,11 +312,11 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 		q.RecordError(ctx, errors.New("failed to execute query"))
 		return logqlmodel.Result{}, ErrSchedulingFailed
 	}
-	closePipeline := func() {
+	closePipeline := sync.OnceFunc(func() {
 		start := time.Now()
 		pipeline.Close()
 		q.rootRegion.Record(statCloseDuration.Observe(int64(time.Since(start))))
-	}
+	})
 	defer closePipeline()
 
 	gotrace.Log(ctx, "collect_result", "start")

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	gotrace "runtime/trace"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/alecthomas/units"
@@ -223,7 +224,9 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	if err != nil {
 		return logqlmodel.Result{}, err
 	}
-	defer q.Close()
+
+	closeQuery := runOnceFunc(q.Close)
+	defer closeQuery()
 
 	// We save the pre-query logger so we can pass it to buildPhysicalPlan,
 	// which creates a subquery.
@@ -292,7 +295,14 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 		q.RecordError(ctx, errors.New("failed to create execution plan"))
 		return logqlmodel.Result{}, ErrPlanningFailed
 	}
-	defer wf.Close()
+	closeWorkflow := runOnceFunc(func() {
+		// workflow close can spend non-trivial time as it needs to send
+		// cancel messages to running tasks and close open streams.
+		start := time.Now()
+		wf.Close()
+		q.rootRegion.Record(statCloseDuration.Observe(int64(time.Since(start))))
+	})
+	defer closeWorkflow()
 	gotrace.Log(ctx, "workflow_planning", "done")
 
 	pipeline, err := wf.Run(ctx)
@@ -304,7 +314,12 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 		q.RecordError(ctx, errors.New("failed to execute query"))
 		return logqlmodel.Result{}, ErrSchedulingFailed
 	}
-	defer pipeline.Close()
+	closePipeline := runOnceFunc(func() {
+		start := time.Now()
+		pipeline.Close()
+		q.rootRegion.Record(statCloseDuration.Observe(int64(time.Since(start))))
+	})
+	defer closePipeline()
 
 	gotrace.Log(ctx, "collect_result", "start")
 	builder, err := e.execute(ctx, q, params, pipeline)
@@ -316,14 +331,15 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	}
 	gotrace.Log(ctx, "collect_result", "done")
 
-	// Close the pipeline to calculate the stats.
-	pipeline.Close()
-	span.SetStatus(codes.Ok, "")
+	// record close timings to capture.
+	closePipeline()
+	closeWorkflow()
 
-	// explicitly call End() before exporting even though we have a defer above.
-	// It is safe to call End() multiple times.
+	span.SetStatus(codes.Ok, "")
+	// End() span to record observations as attributes.
 	span.End()
-	q.Close()
+
+	closeQuery()
 
 	totalQueueTime := xcap.Value[int64](q.capture, schedulerstat.TaskQueueDuration)
 	stats := q.capture.ToStatsSummary(q.Duration(), time.Duration(totalQueueTime), builder.Len())
@@ -370,13 +386,34 @@ func isMetricQuery(expr syntax.Expr) bool {
 }
 
 // buildLogicalPlan builds a logical plan from the given params.
-func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Params) (*logical.Plan, error) {
+func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Params) (logicalPlan *logical.Plan, retErr error) {
 	ctx, span := xcap.StartSpan(ctx, tracer, "Engine.buildLogicalPlan",
 		trace.WithAttributes(attribute.Stringer("query_id", q.id)),
 	)
 	defer span.End()
 
+	var (
+		optimizeReport []logical.PassFiring
+	)
+
 	timer := prometheus.NewTimer(e.metrics.planning.logical.WithLabelValues(q.queryType))
+	defer func() {
+		duration := timer.ObserveDuration()
+		span.Record(statLogicalPlanDuration.Observe(int64(duration)))
+
+		var planStr string
+		if logicalPlan != nil {
+			planStr = logicalPlan.String()
+		}
+
+		level.Info(q.logger).Log(
+			"msg", "logical-plan-summary",
+			"status", phaseStatus(retErr),
+			"plan", planStr,
+			"duration_ms", duration.Milliseconds(),
+			"passes_fired", encodeLogicalPasses(optimizeReport),
+		)
+	}()
 
 	var deleteReqs []*deletion.Request
 	if e.deleteGetter != nil {
@@ -388,7 +425,8 @@ func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Pa
 		}
 	}
 
-	logicalPlan, err := logical.BuildPlanWithDeletes(ctx, params, deleteReqs)
+	var err error
+	logicalPlan, err = logical.BuildPlanWithDeletes(ctx, params, deleteReqs)
 	if err != nil {
 		level.Warn(q.Logger()).Log("msg", "failed to create logical plan", "err", err)
 		q.RecordError(ctx, err)
@@ -397,24 +435,14 @@ func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Pa
 
 	var opt logical.Optimizer
 	err = opt.Optimize(logicalPlan)
-	passes := opt.Report()
-	e.metrics.recordLogicalPasses(passes)
+	optimizeReport = opt.Report()
+	e.metrics.recordLogicalPasses(optimizeReport)
 	if err != nil {
 		level.Warn(q.Logger()).Log("msg", "failed to optimize logical plan", "err", err)
 		q.RecordError(ctx, err)
 		return nil, fmt.Errorf("%w: %w", ErrNotSupported, err)
 	}
 
-	duration := timer.ObserveDuration()
-	span.Record(statLogicalPlanDuration.Observe(int64(duration)))
-
-	level.Info(q.logger).Log(
-		"msg", "logical-plan-summary",
-
-		"plan", logicalPlan.String(),
-		"duration_ms", duration.Milliseconds(),
-		"passes_fired", encodeLogicalPasses(passes),
-	)
 	span.SetAttributes(
 		attribute.Stringer("plan", logicalPlan),
 	)
@@ -424,13 +452,25 @@ func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Pa
 }
 
 // buildPhysicalPlan builds a physical plan from the given logical plan.
-func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.Params, catalog *physical.MetastoreCatalog, logicalPlan *logical.Plan) (*physical.Plan, error) {
+func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.Params, catalog *physical.MetastoreCatalog, logicalPlan *logical.Plan) (physicalPlan *physical.Plan, retErr error) {
 	ctx, span := xcap.StartSpan(ctx, tracer, "Engine.buildPhysicalPlan",
 		trace.WithAttributes(attribute.Stringer("query_id", q.id)),
 	)
 	defer span.End()
 
+	var rules map[string]bool
+
 	timer := prometheus.NewTimer(e.metrics.planning.physical.WithLabelValues(q.queryType))
+	defer func() {
+		duration := timer.ObserveDuration()
+		span.Record(statPhysicalPlanDuration.Observe(int64(duration)))
+
+		if retErr == nil {
+			e.metrics.observePhysicalShape(physicalPlanShapeOf(physicalPlan))
+		}
+
+		printPhysicalPlanSummary(q, physicalPlan, duration, rules, retErr)
+	}()
 
 	// TODO(rfratto): It feels strange that we need to past the start/end time
 	// to the physical planner. Isn't it already represented by the logical
@@ -450,7 +490,6 @@ func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.P
 		return nil, ErrNotSupported
 	}
 
-	var rules map[string]bool
 	{
 		optimizeStart := time.Now()
 
@@ -474,12 +513,6 @@ func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.P
 		return nil, ErrNotSupported
 	}
 
-	duration := timer.ObserveDuration()
-	span.Record(statPhysicalPlanDuration.Observe(int64(duration)))
-
-	e.metrics.observePhysicalShape(physicalPlanShapeOf(physicalPlan))
-
-	printPhysicalPlanSummary(q, physicalPlan, duration, rules)
 	span.SetAttributes(
 		attribute.String("plan", physical.PrintAsTree(physicalPlan)),
 	)
@@ -490,20 +523,29 @@ func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.P
 
 // printExecutionSummary prints a general summary of the execution, including
 // timing and cache information.
-func printPhysicalPlanSummary(q *query, plan *physical.Plan, duration time.Duration, rules map[string]bool) {
+func printPhysicalPlanSummary(q *query, plan *physical.Plan, duration time.Duration, rules map[string]bool, err error) {
 	var (
 		indexQueryDuration, _ = q.capture.Value(statPhysicalIndexQueryDuration).Int64()
 		optimizeDuration, _   = q.capture.Value(statPhysicalOptimizeDuration).Int64()
 
 		otherDuration = calculateResidual(duration, indexQueryDuration, optimizeDuration)
+
+		planLen int
+		planStr string
 	)
+
+	if plan != nil {
+		planLen = plan.Len()
+		planStr = physical.PrintAsTree(plan)
+	}
 
 	level.Info(q.Logger()).Log(
 		"msg", "physical-plan-summary",
+		"status", phaseStatus(err),
 
 		// Plan stats.
 		"duration_ms", duration.Milliseconds(),
-		"plan_node_count", plan.Len(),
+		"plan_node_count", planLen,
 
 		// Timing info
 		"duration_index_query_ms", time.Duration(indexQueryDuration).Milliseconds(),
@@ -520,7 +562,7 @@ func printPhysicalPlanSummary(q *query, plan *physical.Plan, duration time.Durat
 
 		// Large plans result in log line truncation, retain the other
 		// kvs by moving this to the end.
-		"plan", physical.PrintAsTree(plan),
+		"plan", planStr,
 	)
 }
 
@@ -548,21 +590,24 @@ func (e *Engine) metastoreSectionsResolver(ctx context.Context, parent *query, l
 		}()
 
 		var plan *physical.Plan
-		{
+		if err := func() error {
+			var err error
 			timer := prometheus.NewTimer(e.metrics.planning.physical.WithLabelValues(q.queryType))
+			defer func() {
+				duration := timer.ObserveDuration()
+				q.rootRegion.Record(statPhysicalPlanDuration.Observe(int64(duration)))
+				printPhysicalPlanSummary(q, plan, duration, nil, err)
+			}()
 
 			plan, err = planner.Plan(ctx, selector, predicates, start, end)
 			if err != nil {
 				q.RecordError(ctx, err)
-				return nil, fmt.Errorf("index query: build plan: %w", err)
+				return fmt.Errorf("index query: build plan: %w", err)
 			}
 
-			duration := timer.ObserveDuration()
-			q.rootRegion.Record(statPhysicalPlanDuration.Observe(int64(duration)))
-
-			// Index queries plan via planner.Plan and don't run the rule-based
-			// optimizer, so there are no rule firings to report here.
-			printPhysicalPlanSummary(q, plan, duration, nil)
+			return nil
+		}(); err != nil {
+			return nil, err
 		}
 
 		// Disable admission lanes for metastore queries
@@ -572,7 +617,11 @@ func (e *Engine) metastoreSectionsResolver(ctx context.Context, parent *query, l
 			q.RecordError(ctx, err)
 			return nil, fmt.Errorf("index query: build workflow: %w", err)
 		}
-		defer wf.Close()
+		defer func() {
+			start := time.Now()
+			wf.Close()
+			q.rootRegion.Record(statCloseDuration.Observe(int64(time.Since(start))))
+		}()
 
 		pipeline, err := wf.Run(ctx)
 		if err != nil {
@@ -580,17 +629,26 @@ func (e *Engine) metastoreSectionsResolver(ctx context.Context, parent *query, l
 			return nil, fmt.Errorf("index query: run workflow: %w", err)
 		}
 		reader := executor.TranslateEOF(pipeline)
-		defer reader.Close()
+		defer func() {
+			start := time.Now()
+			reader.Close()
+			q.rootRegion.Record(statCloseDuration.Observe(int64(time.Since(start))))
+		}()
 
-		if err := reader.Open(ctx); err != nil {
+		executionTimer := prometheus.NewTimer(e.metrics.execution.duration.WithLabelValues(q.queryType))
+		defer func() {
+			duration := executionTimer.ObserveDuration()
+			q.rootRegion.Record(statExecutionDuration.Observe(int64(duration)))
+			printExecutionSummary(q, duration, err)
+		}()
+
+		if err = reader.Open(ctx); err != nil {
 			q.RecordError(ctx, err)
 			return nil, fmt.Errorf("index query: open pipeline: %w", err)
 		}
 
 		var resp metastore.CollectSectionsResponse
 		{
-			timer := prometheus.NewTimer(e.metrics.execution.duration.WithLabelValues(q.queryType))
-
 			resp, err = e.metastore.CollectSections(ctx, metastore.CollectSectionsRequest{
 				// externalize EOFs returned by executor pipelines (executor.EOF -> io.EOF)
 				// because metastore is not aware about executor implementation details
@@ -600,11 +658,6 @@ func (e *Engine) metastoreSectionsResolver(ctx context.Context, parent *query, l
 				q.RecordError(ctx, err)
 				return nil, fmt.Errorf("index query: collect sections: %w", err)
 			}
-
-			executionDuration := timer.ObserveDuration()
-			q.rootRegion.Record(statExecutionDuration.Observe(int64(executionDuration)))
-
-			printExecutionSummary(q, executionDuration)
 		}
 
 		sectionsResolved := len(resp.SectionsResponse.Sections)
@@ -647,6 +700,13 @@ func (e *Engine) execute(ctx context.Context, q *query, params logql.Params, pip
 
 	executeStart := time.Now()
 	timer := prometheus.NewTimer(e.metrics.execution.duration.WithLabelValues(q.queryType))
+	defer func() {
+		duration := timer.ObserveDuration()
+		span.Record(statExecutionDuration.Observe(int64(duration)))
+
+		printExecutionSummary(q, duration, err)
+		printLogLocalitySummary(q)
+	}()
 
 	var builder ResultBuilder
 	switch params.GetExpression().(type) {
@@ -708,8 +768,6 @@ func (e *Engine) execute(ctx context.Context, q *query, params logql.Params, pip
 		totalProcessBatchTime += time.Since(startTime)
 	}
 
-	duration := timer.ObserveDuration()
-	span.Record(statExecutionDuration.Observe(int64(duration)))
 	span.Record(statReadBatchDuration.Observe(int64(totalReadBatchTime)))
 	span.Record(statProcessBatchDuration.Observe(int64(totalProcessBatchTime)))
 
@@ -727,9 +785,6 @@ func (e *Engine) execute(ctx context.Context, q *query, params logql.Params, pip
 	span.Record(statResultRows.Observe(int64(builder.Len())))
 	span.Record(statTimeToFirstBatch.Observe(int64(timeToFirstBatch)))
 	span.Record(statResultSizeBytes.Observe(totalBytes))
-
-	printExecutionSummary(q, duration)
-	printLogLocalitySummary(q)
 
 	span.SetStatus(codes.Ok, "")
 	return builder, nil
@@ -765,7 +820,7 @@ func resultErrorClass(err error) string {
 // timing and cache information.
 //
 // Stats that are not reported in the capture are left empty.
-func printExecutionSummary(q *query, duration time.Duration) {
+func printExecutionSummary(q *query, duration time.Duration, err error) {
 	var (
 		readBatchDuration, _    = q.capture.Value(statReadBatchDuration).Int64()
 		processBatchDuration, _ = q.capture.Value(statProcessBatchDuration).Int64()
@@ -798,6 +853,7 @@ func printExecutionSummary(q *query, duration time.Duration) {
 
 	level.Info(q.Logger()).Log(
 		"msg", "execution-summary",
+		"status", phaseStatus(err),
 
 		// Stats
 		"duration_ms", duration.Milliseconds(),
@@ -854,4 +910,16 @@ func printLogLocalitySummary(q *query) {
 		"stream_pages_total", streamPagesTotal,
 		"stream_relevant_pages", streamRelevantPages,
 	)
+}
+
+func phaseStatus(err error) string {
+	if err == nil {
+		return "success"
+	}
+	return "failed"
+}
+
+func runOnceFunc(fn func()) func() {
+	var once sync.Once
+	return func() { once.Do(fn) }
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -224,9 +224,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	if err != nil {
 		return logqlmodel.Result{}, err
 	}
-
-	closeQuery := runOnceFunc(q.Close)
-	defer closeQuery()
+	defer q.Close()
 
 	// We save the pre-query logger so we can pass it to buildPhysicalPlan,
 	// which creates a subquery.
@@ -295,7 +293,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 		q.RecordError(ctx, errors.New("failed to create execution plan"))
 		return logqlmodel.Result{}, ErrPlanningFailed
 	}
-	closeWorkflow := runOnceFunc(func() {
+	closeWorkflow := sync.OnceFunc(func() {
 		// workflow close can spend non-trivial time as it needs to send
 		// cancel messages to running tasks and close open streams.
 		start := time.Now()
@@ -314,11 +312,11 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 		q.RecordError(ctx, errors.New("failed to execute query"))
 		return logqlmodel.Result{}, ErrSchedulingFailed
 	}
-	closePipeline := runOnceFunc(func() {
+	closePipeline := func() {
 		start := time.Now()
 		pipeline.Close()
 		q.rootRegion.Record(statCloseDuration.Observe(int64(time.Since(start))))
-	})
+	}
 	defer closePipeline()
 
 	gotrace.Log(ctx, "collect_result", "start")
@@ -339,7 +337,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 	// End() span to record observations as attributes.
 	span.End()
 
-	closeQuery()
+	q.Close()
 
 	totalQueueTime := xcap.Value[int64](q.capture, schedulerstat.TaskQueueDuration)
 	stats := q.capture.ToStatsSummary(q.Duration(), time.Duration(totalQueueTime), builder.Len())
@@ -917,9 +915,4 @@ func phaseStatus(err error) string {
 		return "success"
 	}
 	return "failed"
-}
-
-func runOnceFunc(fn func()) func() {
-	var once sync.Once
-	return func() { once.Do(fn) }
 }

--- a/pkg/engine/engine_query.go
+++ b/pkg/engine/engine_query.go
@@ -103,11 +103,27 @@ func (q *query) Duration() time.Duration {
 
 // Prepare constucts a workflow from the given physical plan. The returned
 // workflow must be closed to release resources.
-func (q *query) Prepare(ctx context.Context, plan *physical.Plan, useAdmissionLanes bool) (*workflow.Workflow, error) {
+func (q *query) Prepare(ctx context.Context, plan *physical.Plan, useAdmissionLanes bool) (wf *workflow.Workflow, err error) {
 	ctx, span := xcap.StartSpan(ctx, tracer, "query.Prepare")
 	defer span.End()
 
 	timer := prometheus.NewTimer(q.engine.metrics.planning.prepare.WithLabelValues(q.queryType))
+	defer func() {
+		duration := timer.ObserveDuration()
+		span.Record(statPrepareDuration.Observe(int64(duration)))
+
+		taskLen := 0
+		if wf != nil {
+			taskLen = wf.Len()
+		}
+
+		level.Info(q.logger).Log(
+			"msg", "execution-plan-summary",
+			"status", phaseStatus(err),
+			"duration_ms", duration.Milliseconds(),
+			"tasks", taskLen,
+		)
+	}()
 
 	var maxRunningScanTasks int
 	if useAdmissionLanes {
@@ -134,26 +150,19 @@ func (q *query) Prepare(ctx context.Context, plan *physical.Plan, useAdmissionLa
 		DebugTasks:   q.engine.limits.DebugEngineTasks(q.tenantID),
 		DebugStreams: q.engine.limits.DebugEngineStreams(q.tenantID),
 	}
-	wf, err := workflow.New(ctx, opts, q.logger, q.engine.scheduler.inner, plan)
+
+	wf, err = workflow.New(ctx, opts, q.logger, q.engine.scheduler.inner, plan)
 	if err != nil {
 		level.Warn(q.logger).Log("msg", "failed to create workflow", "err", err)
 		q.RecordError(ctx, err)
 		return nil, ErrNotSupported
 	}
 
-	duration := timer.ObserveDuration()
-	span.Record(statPrepareDuration.Observe(int64(duration)))
-
 	// The execution plan can be way more verbose than the physical plan, so we
 	// only log it at debug level.
 	level.Debug(q.logger).Log(
 		"msg", "execution-plan-detail",
 		"plan", workflow.Sprint(wf),
-	)
-	level.Info(q.logger).Log(
-		"msg", "execution-plan-summary",
-		"duration_ms", duration.Milliseconds(),
-		"tasks", wf.Len(),
 	)
 
 	span.SetStatus(codes.Ok, "")
@@ -199,8 +208,9 @@ func (q *query) Close() {
 		physicalPlanDuration, _ = q.capture.Value(statPhysicalPlanDuration).Int64()
 		prepareDuration, _      = q.capture.Value(statPrepareDuration).Int64()
 		executeDuration, _      = q.capture.Value(statExecutionDuration).Int64()
+		closeDuration, _        = q.capture.Value(statCloseDuration).Int64()
 
-		otherDuration = calculateResidual(q.finishTime.Sub(q.startTime), logicalPlanDuration, physicalPlanDuration, prepareDuration, executeDuration)
+		otherDuration = calculateResidual(q.finishTime.Sub(q.startTime), logicalPlanDuration, physicalPlanDuration, prepareDuration, executeDuration, closeDuration)
 	)
 
 	m := q.engine.metrics
@@ -208,6 +218,7 @@ func (q *query) Close() {
 	// The residual histogram mirrors the duration_other_ms field on the
 	// query-summary line below and is observed for every query.
 	m.query.other.WithLabelValues(q.queryType).Observe(otherDuration.Seconds())
+	m.query.close.WithLabelValues(q.queryType).Observe(time.Duration(closeDuration).Seconds())
 
 	// Fan-out histograms count tasks per query, matching how printExecutionSummary
 	// computes them: tasksPlanned is the count after pruning, and the pre-pruning
@@ -246,6 +257,7 @@ func (q *query) Close() {
 		"duration_physical_plan_ms", time.Duration(physicalPlanDuration).Milliseconds(),
 		"duration_prepare_ms", time.Duration(prepareDuration).Milliseconds(),
 		"duration_execute_ms", time.Duration(executeDuration).Milliseconds(),
+		"duration_close_ms", time.Duration(closeDuration).Milliseconds(),
 		"duration_other_ms", otherDuration.Milliseconds(),
 
 		"dominant_phase", calculateDominantPhase(map[string]time.Duration{
@@ -253,6 +265,7 @@ func (q *query) Close() {
 			"physical": time.Duration(physicalPlanDuration),
 			"prepare":  time.Duration(prepareDuration),
 			"execute":  time.Duration(executeDuration),
+			"close":    time.Duration(closeDuration),
 			"other":    otherDuration,
 		}),
 

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -664,6 +664,10 @@ func (s *Scheduler) finalizeAssignment(ctx context.Context, t *task, worker *wor
 		s.resourcesMut.Lock()
 		defer s.resourcesMut.Unlock()
 
+		assignTime := t.AssignTime() // Set by [task.TryAssign] by the previous caller before this runs.
+		queueDuration := assignTime.Sub(t.QueueTime())
+		s.metrics.taskQueueSeconds.Observe(assignTime.Sub(t.QueueTime()).Seconds())
+
 		if t.State().Terminal() {
 			// The task reached a terminal state between TryAssign and now. The
 			// worker may still have the assignment, so we tell it to not
@@ -673,10 +677,6 @@ func (s *Scheduler) finalizeAssignment(ctx context.Context, t *task, worker *wor
 		}
 
 		worker.Assign(t)
-		assignTime := t.AssignTime() // Set by [task.TryAssign] by the previous caller before this runs.
-		queueDuration := assignTime.Sub(t.QueueTime())
-		s.metrics.taskQueueSeconds.Observe(queueDuration.Seconds())
-		t.region.Record(schedulerstat.TaskQueueDuration.Observe(queueDuration.Nanoseconds()))
 
 		if t.wfRegion != nil {
 			t.wfRegion.Record(StatAssignedTasks.Observe(1))

--- a/pkg/engine/internal/scheduler/task.go
+++ b/pkg/engine/internal/scheduler/task.go
@@ -205,12 +205,15 @@ func (t *task) TryAssign(doAssign func() error) error {
 //
 // The recorded durations partition the task's total lifetime:
 //
-//   - [schedulerstat.TaskQueueDuration] is recorded if the task was enqueued
-//     but never assigned to a worker (covering pre-assignment cancellations
-//     of queued tasks). Tasks that were assigned have their queue duration
-//     recorded earlier, at assignment time.
+//   - [schedulerstat.TaskQueueDuration] is recorded for any task that was
+//     enqueued. It spans from enqueue until assignment, or until the terminal
+//     state if the task was never assigned. Recording it here, rather than in
+//     [finalizeAssignment] to ensure we record it before the region ends for
+//     tasks that reach terminal state even before assignment finalization.
+//
 //   - [schedulerstat.TaskExecutionDuration] is recorded for any task that
 //     was assigned to a worker.
+//
 //   - [schedulerstat.TaskTotalDuration] is always recorded.
 //
 // It also records [schedulerstat.TaskFinishTime], the absolute terminal
@@ -225,8 +228,14 @@ func (t *task) RecordTerminalObservations(now time.Time) {
 
 	t.region.Record(schedulerstat.TaskAssignmentRetries.Observe(int64(requeues)))
 
-	if !queueTime.IsZero() && assignTime.IsZero() {
-		t.region.Record(schedulerstat.TaskQueueDuration.Observe(now.Sub(queueTime).Nanoseconds()))
+	if !queueTime.IsZero() {
+		// Queue time ends at assignment, or at the terminal state if the task
+		// was never assigned.
+		queueEnd := now
+		if !assignTime.IsZero() {
+			queueEnd = assignTime
+		}
+		t.region.Record(schedulerstat.TaskQueueDuration.Observe(queueEnd.Sub(queueTime).Nanoseconds()))
 	}
 	if !assignTime.IsZero() {
 		t.region.Record(schedulerstat.TaskExecutionDuration.Observe(now.Sub(assignTime).Nanoseconds()))

--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -133,7 +133,7 @@ func (t *thread) setState(state threadState) {
 func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	defer job.Close()
 
-	setupStart := time.Now()
+	startTime := time.Now()
 	taskType := taskTypeLabel(job.Task)
 
 	ctx, task := gotrace.NewTask(ctx, "thread.runJob")
@@ -164,7 +164,6 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 		countCachedSources += len(streams)
 	}
 
-	startTime := time.Now()
 	level.Info(logger).Log(
 		"msg", "starting task",
 		"plan", physical.PrintAsTree(job.Task.Fragment),
@@ -301,7 +300,9 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 
 	// Record the time spent preparing the task before we begin draining its
 	// pipeline (planning, pipeline construction, and source binding setup).
-	t.Metrics.setupSeconds.WithLabelValues(taskType).Observe(time.Since(setupStart).Seconds())
+	setupDuration := time.Since(startTime)
+	span.Record(workerstat.TaskExecutionSetupDuration.Observe(setupDuration.Nanoseconds()))
+	t.Metrics.setupSeconds.WithLabelValues(taskType).Observe(setupDuration.Seconds())
 
 	gotrace.Log(ctx, "drain_pipeline", "start")
 	_, drainErr := t.drainPipeline(ctx, taskType, pipeline, sinksForJob(job), logger)

--- a/pkg/engine/internal/worker/workerstat/workerstat.go
+++ b/pkg/engine/internal/worker/workerstat/workerstat.go
@@ -9,6 +9,10 @@ import "github.com/grafana/loki/v3/pkg/xcap"
 // and the worker.
 
 var (
+	// TaskExecutionSetupDuration is the time (in nanoseconds) spent preparing a
+	// task for execution before its pipeline is opened and drained.
+	TaskExecutionSetupDuration = xcap.NewStatisticInt64("worker.task.execution.setup.duration", xcap.AggregationTypeSum)
+
 	// TaskExecutionOpenDuration is the time (in nanoseconds) spent opening the
 	// root pipeline before the worker began draining record batches from it.
 	TaskExecutionOpenDuration = xcap.NewStatisticInt64("worker.task.execution.open.duration", xcap.AggregationTypeSum)

--- a/pkg/engine/internal/workflow/task_summary.go
+++ b/pkg/engine/internal/workflow/task_summary.go
@@ -29,11 +29,12 @@ func (wf *Workflow) printTaskSummary(task *Task, oldState TaskState, newStatus T
 		durExecution = xcap.Value[int64](capture, schedulerstat.TaskExecutionDuration)
 		durOther     = durTotal - durStaging - durQueue - durExecution
 
+		durExecutionSetup    = xcap.Value[int64](capture, workerstat.TaskExecutionSetupDuration)
 		durExecutionOpen     = xcap.Value[int64](capture, workerstat.TaskExecutionOpenDuration)
 		durExecutionRead     = xcap.Value[int64](capture, workerstat.TaskExecutionReadDuration)
 		durExecutionReadRecv = xcap.Value[int64](capture, workerstat.TaskExecutionReadRecvDuration)
 		durExecutionSend     = xcap.Value[int64](capture, workerstat.TaskExecutionSendDuration)
-		durExecutionOther    = durExecution - durExecutionOpen - durExecutionRead - durExecutionSend
+		durExecutionOther    = durExecution - durExecutionSetup - durExecutionOpen - durExecutionRead - durExecutionSend
 
 		pagesDownloaded = xcap.Value[int64](capture, xcap.StatDatasetPrimaryPagesDownloaded) + xcap.Value[int64](capture, xcap.StatDatasetSecondaryPagesDownloaded)
 		bytesDownloaded = xcap.Value[int64](capture, xcap.StatDatasetPrimaryColumnBytes) + xcap.Value[int64](capture, xcap.StatDatasetSecondaryColumnBytes)
@@ -65,6 +66,7 @@ func (wf *Workflow) printTaskSummary(task *Task, oldState TaskState, newStatus T
 		"duration_other_ms", time.Duration(durOther).Milliseconds(),
 
 		// Breakdown timings
+		"duration_execution_setup_ms", time.Duration(durExecutionSetup).Milliseconds(),
 		"duration_execution_open_ms", time.Duration(durExecutionOpen).Milliseconds(),
 		"duration_execution_read_ms", time.Duration(durExecutionRead).Milliseconds(),
 		"duration_execution_read_recv_ms", time.Duration(durExecutionReadRecv).Milliseconds(),

--- a/pkg/engine/internal/workflow/workflow.go
+++ b/pkg/engine/internal/workflow/workflow.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/oklog/ulid/v2"
@@ -22,7 +21,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/schedulerstat"
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
-	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/xcap"
 )
 
@@ -127,9 +125,6 @@ type Workflow struct {
 	resultsStream   *Stream
 	resultsPipeline *streamPipe
 	manifest        *Manifest
-
-	statsMut sync.Mutex
-	stats    stats.Result
 
 	captureMut sync.Mutex
 	// used to merge and link task regions
@@ -314,29 +309,19 @@ func (wf *Workflow) Run(ctx context.Context) (pipeline executor.Pipeline, err er
 	// wf.Run tracks the lifetime of the workflow execution.
 	ctx, wf.span = xcap.StartSpan(ctx, tracer, "wf.Run")
 
-	wrapped := &wrappedPipeline{
-		inner: wf.resultsPipeline,
-		onClose: func() {
-			// Merge final stats results back into the caller.
-			wf.statsMut.Lock()
-			defer wf.statsMut.Unlock()
-			stats.JoinResults(ctx, wf.stats)
-		},
-	}
-
 	// Start dispatching in background goroutine
 	gotrace.Log(ctx, "dispatch_tasks", "starting dispatch of "+strconv.Itoa(len(wf.manifest.Tasks))+" tasks")
 	go func() {
 		err := wf.dispatchTasks(ctx, wf.manifest.Tasks)
 		if err != nil {
 			wf.resultsPipeline.SetError(err)
-			wrapped.Close()
+			wf.resultsPipeline.Close()
 		} else {
 			gotrace.Log(ctx, "dispatch_tasks", "all tasks dispatched")
 		}
 	}()
 
-	return wrapped, nil
+	return wf.resultsPipeline, nil
 }
 
 // dispatchTasks groups the slice of tasks by their associated "admission lane" (token bucket)
@@ -554,10 +539,6 @@ func (wf *Workflow) handleTerminalStateChange(ctx context.Context, task *Task, o
 		wf.mergeCapture(newStatus.Capture)
 	}
 
-	if newStatus.Statistics != nil {
-		wf.mergeResults(*newStatus.Statistics)
-	}
-
 	// task reached a terminal state. We need to detect if task's immediate
 	// children should be canceled. We only look at immediate unterminated
 	// children, since canceling them will trigger onTaskChange to process
@@ -644,30 +625,4 @@ func (wf *Workflow) mergeCapture(capture *xcap.Capture) {
 	defer wf.captureMut.Unlock()
 
 	wf.capture.Merge(wf.parentRegion, capture)
-}
-
-func (wf *Workflow) mergeResults(results stats.Result) {
-	wf.statsMut.Lock()
-	defer wf.statsMut.Unlock()
-
-	wf.stats.Merge(results)
-}
-
-type wrappedPipeline struct {
-	inner   executor.Pipeline
-	onClose func()
-}
-
-func (p *wrappedPipeline) Open(ctx context.Context) error {
-	return p.inner.Open(ctx)
-}
-
-func (p *wrappedPipeline) Read(ctx context.Context) (arrow.RecordBatch, error) {
-	return p.inner.Read(ctx)
-}
-
-// Close closes the resources of the pipeline.
-func (p *wrappedPipeline) Close() {
-	p.inner.Close()
-	p.onClose()
 }

--- a/pkg/engine/metrics.go
+++ b/pkg/engine/metrics.go
@@ -49,6 +49,7 @@ type queryMetrics struct {
 	subqueries    *prometheus.CounterVec   // {status, query_type}
 	stageFailures *prometheus.CounterVec   // {stage, reason, query_type}
 	other         *prometheus.HistogramVec // {query_type}
+	close         *prometheus.HistogramVec // {query_type}
 }
 
 // planningMetrics covers logical, physical, and prepare planning.
@@ -113,6 +114,10 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			other: newNativeHistogramVec(r, prometheus.HistogramOpts{
 				Name: "loki_engine_v2_other_duration_seconds",
 				Help: "Per-query residual duration in seconds: wall-clock time not attributed to any tracked phase (mirrors the duration_other_ms summary field)",
+			}, []string{queryTypeLabel}),
+			close: newNativeHistogramVec(r, prometheus.HistogramOpts{
+				Name: "loki_engine_v2_close_duration_seconds",
+				Help: "Duration of query close (workflow and pipeline teardown) in seconds",
 			}, []string{queryTypeLabel}),
 		},
 

--- a/pkg/engine/stats.go
+++ b/pkg/engine/stats.go
@@ -9,6 +9,7 @@ var (
 	statPhysicalPlanDuration = xcap.NewStatisticInt64("plan.physical.duration", xcap.AggregationTypeSum)
 	statPrepareDuration      = xcap.NewStatisticInt64("prepare.duration", xcap.AggregationTypeSum)
 	statExecutionDuration    = xcap.NewStatisticInt64("execution.duration", xcap.AggregationTypeSum)
+	statCloseDuration        = xcap.NewStatisticInt64("close.duration", xcap.AggregationTypeSum)
 
 	// Physical plan subphases
 


### PR DESCRIPTION
**What this PR does / why we need it**:

1. Phase timings are recorded only in success path, `query-summary` accounts for the time spent in the failed phase in `other` bucket. This PR updates each phase to record it's timing even when it failed.
2. We are not tracking `wf.Close()` timings, scheduler can spend non-trivial amount of time here as this step requires sending cancellation messages to running tasks and Close messages for Open streams. This is now tracked in `close` phase
3. Fixes a race that prevented queue time from being recorded. A quick task can reach terminal state even before the scheduler runs finalizeAssignment which is one of the places where it records the queue time. Recording queue times even for assigned tasks in `RecordTerminalObservations`.
4. Record `setup` time for tasks. It's probably important to also record termination times but we close the capture before sending `TaskStatusMessage` to the scheduler, so we cannot correctly record it.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
