### PR TITLE
fix(engine): Propagate errors from marshalExpressions

### DIFF
--- a/pkg/engine/internal/proto/physicalpb/marshal_node.go
+++ b/pkg/engine/internal/proto/physicalpb/marshal_node.go
@@ -193,6 +193,11 @@ func (n *AggregateVector) MarshalPhysical(nodeID ulid.ULID) (physical.Node, erro
 // MarshalPhysical converts a protobuf DataObjScan into a physical plan node. Returns
 // an error if the conversion fails or is unsupported.
 func (n *DataObjScan) MarshalPhysical(nodeID ulid.ULID) (physical.Node, error) {
+	predicates, err := marshalExpressions(n.Predicates)
+	if err != nil {
+		return nil, err
+	}
+
 	return &physical.DataObjScan{
 		NodeID: nodeID,
 
@@ -200,7 +205,7 @@ func (n *DataObjScan) MarshalPhysical(nodeID ulid.ULID) (physical.Node, error) {
 		Section:      int(n.Section),
 		StreamIDs:    n.StreamIds,
 		Projections:  marshalColumnExpressions(n.Projections),
-		Predicates:   marshalExpressions(n.Predicates),
+		Predicates:   predicates,
 		MaxTimeRange: marshalTimeRange(n.MaxTimeRange),
 	}, nil
 }
@@ -216,20 +221,20 @@ func marshalTimeRange(timeRange *TimeRange) physical.TimeRange {
 	}
 }
 
-func marshalExpressions(exprs []*expressionpb.Expression) []physical.Expression {
+func marshalExpressions(exprs []*expressionpb.Expression) ([]physical.Expression, error) {
 	if exprs == nil {
-		return nil
+		return nil, nil
 	}
 
 	out := make([]physical.Expression, len(exprs))
 	for i, expr := range exprs {
 		expression, err := expr.MarshalPhysical()
 		if err != nil {
-			return nil
+			return nil, err
 		}
 		out[i] = expression
 	}
-	return out
+	return out, nil
 }
 
 func marshalExpression(expr *expressionpb.Expression) (physical.Expression, error) {
@@ -242,10 +247,15 @@ func marshalExpression(expr *expressionpb.Expression) (physical.Expression, erro
 // MarshalPhysical converts a protobuf Filter into a physical plan node. Returns
 // an error if the conversion fails or is unsupported.
 func (n *Filter) MarshalPhysical(nodeID ulid.ULID) (physical.Node, error) {
+	predicates, err := marshalExpressions(n.Predicates)
+	if err != nil {
+		return nil, err
+	}
+
 	return &physical.Filter{
 		NodeID: nodeID,
 
-		Predicates: marshalExpressions(n.Predicates),
+		Predicates: predicates,
 	}, nil
 }
 
@@ -263,10 +273,15 @@ func (n *Limit) MarshalPhysical(nodeID ulid.ULID) (physical.Node, error) {
 // MarshalPhysical converts a protobuf Projection into a physical plan node. Returns
 // an error if the conversion fails or is unsupported.
 func (n *Projection) MarshalPhysical(nodeID ulid.ULID) (physical.Node, error) {
+	expressions, err := marshalExpressions(n.Expressions)
+	if err != nil {
+		return nil, err
+	}
+
 	return &physical.Projection{
 		NodeID: nodeID,
 
-		Expressions: marshalExpressions(n.Expressions),
+		Expressions: expressions,
 		All:         n.All,
 		Expand:      n.Expand,
 		Drop:        n.Drop,
@@ -316,12 +331,17 @@ func (n *ScanSet) MarshalPhysical(nodeID ulid.ULID) (physical.Node, error) {
 		targets[i] = target
 	}
 
+	predicates, err := marshalExpressions(n.Predicates)
+	if err != nil {
+		return nil, err
+	}
+
 	return &physical.ScanSet{
 		NodeID: nodeID,
 
 		Targets:     targets,
 		Projections: marshalColumnExpressions(n.Projections),
-		Predicates:  marshalExpressions(n.Predicates),
+		Predicates:  predicates,
 	}, nil
 }
 
@@ -402,12 +422,17 @@ func (n *PointersScan) MarshalPhysical(nodeID ulid.ULID) (physical.Node, error) 
 		return nil, err
 	}
 
+	predicates, err := marshalExpressions(n.Predicates)
+	if err != nil {
+		return nil, err
+	}
+
 	return &physical.PointersScan{
 		NodeID: nodeID,
 
 		Location:   physical.DataObjLocation(n.Location),
 		Selector:   selector,
-		Predicates: marshalExpressions(n.Predicates),
+		Predicates: predicates,
 		Start:      n.Start,
 		End:        n.End,
 	}, nil


### PR DESCRIPTION
**What this PR does**: `marshalExpressions` was swallowing any error from converting a protobuf expression back into a physical expression — it returned `nil` and dropped the error on the floor. When a worker decodes a plan fragment it got from the scheduler, that silently turns a real conversion failure into an empty expression list. The executor then blows up downstream with a misleading `failed to execute pipeline: projection expects at least one expression, got 0` instead of telling you what actually went wrong.

This makes `marshalExpressions` return its error and bubbles it up through the five node decoders that call it: `DataObjScan`, `Filter`, `Projection`, `ScanSet`, and `PointersScan`.

A few notes:
- This is purely an error-handling change. It doesn't change *which* plans decode successfully — anything that decoded before still decodes the same way.
- It does change *where* a bad decode surfaces. Today these queries fail at execution time with the projection error above; after this they fail earlier at decode time in `taskFromPbTask` with the real error (e.g. `unsupported variadic operator PARSE_REGEXP`).
- The concrete trigger I was chasing is a `| regexp` query over the distributed path: `VARIADIC_OP_PARSE_REGEXP` is in the encode map (`protoVariadicOpLookup`) but missing from the decode map (`nativeVariadicOpLookup`), so the worker can't convert it back. **This PR does not fix that gap** — it just makes the failure say what's actually wrong. The map fix is a separate change.
- I left `marshalColumnExpressions` alone, which has the identical swallow pattern. Happy to fix it here too, but I kept this scoped to the expression path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)