### PR TITLE
fix(logql/bench): Expand query definitions that omit kind and directions instead of silently dropping them 🤖🤖🤖

### DIFF
--- a/pkg/logql/bench/query_registry.go
+++ b/pkg/logql/bench/query_registry.go
@@ -11,6 +11,7 @@ import (
 	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
 )
 
 // QueryDirection specifies which direction(s) to run a log query
@@ -203,13 +204,20 @@ func (r *QueryRegistry) loadFile(filePath string, suite Suite, fileName string) 
 		}
 		q.Source = fmt.Sprintf("%s/%s:%d", suite, fileName, lineNum)
 
+		// Default the kind before the directions: the directions default
+		// below is gated on the kind, so a definition that declares
+		// neither would otherwise keep Directions empty and expand to
+		// zero test cases in ExpandQuery, silently dropping it from the
+		// corpus. The kind is inferred from the query shape (mirroring
+		// TestCase.Kind), falling back to "log" (the schema default)
+		// when the query does not parse.
+		if q.Kind != kindMetric && q.Kind != kindLog {
+			q.Kind = inferQueryKind(q.Query)
+		}
+
 		// Default directions to "both" for log queries
 		if q.Directions == "" && q.Kind == kindLog {
 			q.Directions = DirectionBoth
-		}
-
-		if q.Kind == "" || (q.Kind != kindMetric && q.Kind != kindLog) {
-			q.Kind = kindLog
 		}
 
 		// Validate time range
@@ -234,6 +242,34 @@ func (r *QueryRegistry) loadFile(filePath string, suite Suite, fileName string) 
 	}
 
 	return queryFile.Queries, nil
+}
+
+// queryKindPlaceholders substitutes the registry's template placeholders
+// with syntactically valid LogQL fragments so a still-templated query can
+// be parsed for kind inference before variable resolution happens. The
+// dummy values never reach the wire; they only make syntax.ParseExpr
+// accept the query shape.
+var queryKindPlaceholders = strings.NewReplacer(
+	placeholderSelector, `{placeholder="x"}`,
+	placeholderRange, "5m",
+	placeholderLabelName, "placeholder",
+	placeholderLabelValue, "x",
+)
+
+// inferQueryKind classifies a query definition as "metric" or "log" by
+// parsing the placeholder-substituted query, mirroring TestCase.Kind
+// (which runs the same check on the resolved query). It falls back to
+// "log" (the schema default) when the query does not parse even after
+// substitution.
+func inferQueryKind(query string) string {
+	expr, err := syntax.ParseExpr(queryKindPlaceholders.Replace(query))
+	if err != nil {
+		return kindLog
+	}
+	if _, ok := expr.(syntax.SampleExpr); ok {
+		return kindMetric
+	}
+	return kindLog
 }
 
 // extractQueryLineNumbers extracts line numbers for each query in the YAML

--- a/pkg/logql/bench/query_registry_test.go
+++ b/pkg/logql/bench/query_registry_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -167,4 +168,63 @@ queries:
 			}
 		})
 	}
+}
+
+// staticResolver is a minimal VariableResolver that returns queries
+// unchanged and a fixed time range, so expansion can be tested without
+// dataset metadata.
+type staticResolver struct{}
+
+func (staticResolver) ResolveQuery(query string, _ QueryRequirements, _ bool) (string, error) {
+	return query, nil
+}
+
+func (staticResolver) GetTimeRange(length time.Duration) (time.Time, time.Time, error) {
+	end := time.Unix(0, 0).UTC().Add(length)
+	return time.Unix(0, 0).UTC(), end, nil
+}
+
+// TestQueryRegistry_DefaultKindBeforeDirections pins the loadFile
+// defaulting order: a definition that declares neither kind nor
+// directions must still expand to at least one test case. Before the
+// kind was defaulted ahead of the directions, such definitions ended up
+// with Kind="log" but Directions="" and ExpandQuery emitted zero test
+// cases, silently dropping them from the corpus (eight metric-shaped
+// definitions in exhaustive/aggregations.yaml were affected).
+func TestQueryRegistry_DefaultKindBeforeDirections(t *testing.T) {
+	yamlContent := `
+queries:
+  - description: Metric query without explicit kind
+    query: 'max by (level) (avg_over_time(${SELECTOR} | logfmt | unwrap duration(duration) [${RANGE}]))'
+    time_range:
+      length: 24h
+      step: 1m
+  - description: Log query without explicit kind or directions
+    query: '${SELECTOR} |= "error"'
+    time_range:
+      length: 24h
+`
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.yaml")
+	require.NoError(t, os.WriteFile(testFile, []byte(yamlContent), 0644))
+
+	registry := NewQueryRegistry(tmpDir)
+	queries, err := registry.loadFile(testFile, SuiteFast, "test.yaml")
+	require.NoError(t, err)
+	require.Len(t, queries, 2)
+
+	metricDef, logDef := queries[0], queries[1]
+	require.Equal(t, kindMetric, metricDef.Kind, "metric-shaped query should infer kind=metric")
+	require.Equal(t, kindLog, logDef.Kind, "log-shaped query should infer kind=log")
+	require.Equal(t, DirectionBoth, logDef.Directions, "log query should default to both directions")
+
+	// No definition may expand to zero test cases.
+	metricCases, err := registry.ExpandQuery(metricDef, staticResolver{}, false)
+	require.NoError(t, err)
+	require.Len(t, metricCases, 1, "metric query should expand to a single forward case")
+	require.Equal(t, time.Minute, metricCases[0].Step)
+
+	logCases, err := registry.ExpandQuery(logDef, staticResolver{}, false)
+	require.NoError(t, err)
+	require.Len(t, logCases, 2, "log query should expand to forward and backward cases")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`QueryRegistry.loadFile` defaults `Directions` before `Kind`, and the directions default is gated on `q.Kind == kindLog`:

```go
// Default directions to "both" for log queries
if q.Directions == "" && q.Kind == kindLog {
    q.Directions = DirectionBoth
}

if q.Kind == "" || (q.Kind != kindMetric && q.Kind != kindLog) {
    q.Kind = kindLog
}
```

A query definition that declares **neither** `kind` nor `directions` therefore ends up with `Kind="log"` but `Directions=""` — and `ExpandQuery`'s direction switch matches no case, so the definition expands to **zero test cases** and silently vanishes from the corpus.

Eight metric-shaped definitions in `queries/exhaustive/aggregations.yaml` hit exactly this today (all declare a `step` but no `kind`):

```text
exhaustive/aggregations.yaml:177 "Loki duration unwrap with logfmt"
exhaustive/aggregations.yaml:193 "Max of min duration by level"
exhaustive/aggregations.yaml:209 "Avg duration by level"
exhaustive/aggregations.yaml:225 "Max avg duration without grouping"
exhaustive/aggregations.yaml:239 "Max avg duration by level without service_name"
exhaustive/aggregations.yaml:257 "Max sum without grouping modifier"
exhaustive/aggregations.yaml:271 "Avg duration without grouping"
exhaustive/aggregations.yaml:285 "Sum duration without outer aggregation"
```

**The fix**: default the kind *before* the directions. Rather than blindly defaulting to `"log"` (which would mis-expand those eight metric queries into two direction-tagged log cases with no step), the kind is inferred from the query shape via `syntax.ParseExpr` on a placeholder-substituted query — mirroring what `TestCase.Kind()` already does on the resolved query — falling back to `"log"` (the `schema.json` default) when the query does not parse. With the fix, the eight definitions each expand to exactly one forward metric case carrying the YAML's `1m` step.

This was found while consuming `pkg/logql/bench`'s query corpus in an external differential-testing compatibility harness: the corpus's expanded case count was silently 8 short of what the YAML files declare.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

- `TestQueryRegistry_DefaultKindBeforeDirections` pins the defaulting order: a kind-less metric-shaped definition infers `kind=metric` and expands to a single forward case with its step; a kind-less log definition still defaults to both directions.
- `go test ./pkg/logql/bench/` passes (73 tests). A scratch check confirms that after this change no loaded definition is left with `Kind="log"` and empty `Directions` across the fast, regression, and exhaustive suites (89 non-skip definitions total), versus 8 such zero-expansion definitions on current `main`.
- No changelog/upgrade-guide impact: this is internal benchmark/test tooling.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
