### PR TITLE
feat(engine): Name the unimplemented feature when the v2 engine falls back

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -268,7 +268,7 @@ func (e *Engine) Execute(ctx context.Context, params logql.Params) (logqlmodel.R
 		e.metrics.query.subqueries.WithLabelValues(statusNotImplemented, q.queryType).Inc()
 		e.metrics.query.stageFailures.WithLabelValues(stageLogicalPlanning, statusNotImplemented, q.queryType).Inc()
 		q.RecordError(ctx, errors.New("failed to create logical plan"))
-		return logqlmodel.Result{}, ErrNotSupported
+		return logqlmodel.Result{}, err
 	}
 	gotrace.Log(ctx, "logical_planning", "done")
 
@@ -392,7 +392,7 @@ func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Pa
 	if err != nil {
 		level.Warn(q.Logger()).Log("msg", "failed to create logical plan", "err", err)
 		q.RecordError(ctx, err)
-		return nil, ErrNotSupported
+		return nil, fmt.Errorf("%w: %w", ErrNotSupported, err)
 	}
 
 	var opt logical.Optimizer
@@ -402,7 +402,7 @@ func (e *Engine) buildLogicalPlan(ctx context.Context, q *query, params logql.Pa
 	if err != nil {
 		level.Warn(q.Logger()).Log("msg", "failed to optimize logical plan", "err", err)
 		q.RecordError(ctx, err)
-		return nil, ErrNotSupported
+		return nil, fmt.Errorf("%w: %w", ErrNotSupported, err)
 	}
 
 	duration := timer.ObserveDuration()

--- a/pkg/engine/internal/planner/logical/planner.go
+++ b/pkg/engine/internal/planner/logical/planner.go
@@ -19,11 +19,14 @@ import (
 )
 
 var (
-	errUnimplemented     = errors.New("query contains unimplemented features")
-	unimplementedFeature = func(s string) error { return fmt.Errorf("%w: %s", errUnimplemented, s) }
+	errUnimplemented = errors.New("query contains unimplemented features")
 
 	tracer = otel.Tracer("pkg/engine/internal/planner/logical")
 )
+
+func unimplementedFeature(s string) error {
+	return fmt.Errorf("%w: %s", errUnimplemented, s)
+}
 
 // BuildPlan converts a LogQL query represented as [logql.Params] into a logical [Plan].
 // It may return an error as second argument in case the traversal of the AST of the query fails.
@@ -218,10 +221,10 @@ func buildPlanForLogQuery(
 				return true
 			case syntax.OpParserTypeUnpack, syntax.OpParserTypePattern:
 				// keeping these as a distinct cases so we remember to implement them later
-				err = errUnimplemented
+				err = unimplementedFeature(fmt.Sprintf("log parser %q", e.Op))
 				return false
 			default:
-				err = errUnimplemented
+				err = unimplementedFeature(fmt.Sprintf("log parser %q", e.Op))
 				return false
 			}
 		case *syntax.LabelFilterExpr:
@@ -237,7 +240,7 @@ func buildPlanForLogQuery(
 			}
 			return true
 		case *syntax.LogfmtExpressionParserExpr, *syntax.JSONExpressionParserExpr:
-			err = errUnimplemented
+			err = unimplementedFeature(fmt.Sprintf("expression parser %T", e))
 			return false // do not traverse children
 		case *syntax.LineFmtExpr:
 			hasFmtExpr = true
@@ -267,7 +270,7 @@ func buildPlanForLogQuery(
 
 			return true
 		default:
-			err = errUnimplemented
+			err = unimplementedFeature(fmt.Sprintf("log pipeline stage %T", e))
 			return false // do not traverse children
 		}
 	})
@@ -288,7 +291,7 @@ func buildPlanForLogQuery(
 func walkRangeAggregation(e *syntax.RangeAggregationExpr, wc *walkContext) (Value, error) {
 	// offsets are not yet supported.
 	if e.Left.Offset != 0 {
-		return nil, errUnimplemented
+		return nil, unimplementedFeature("range aggregation with offset")
 	}
 
 	logSelectorExpr, err := e.Selector()
@@ -319,7 +322,7 @@ func walkRangeAggregation(e *syntax.RangeAggregationExpr, wc *walkContext) (Valu
 		case syntax.OpConvDuration, syntax.OpConvDurationSeconds:
 			unwrapOperation = types.UnaryOpCastDuration
 		default:
-			return nil, errUnimplemented
+			return nil, unimplementedFeature(fmt.Sprintf("unwrap conversion operation %q", e.Left.Unwrap.Operation))
 		}
 
 		// Unwrap turns a column into numerical `value` column, and that original column should be dropped from the result.
@@ -371,7 +374,7 @@ func walkRangeAggregation(e *syntax.RangeAggregationExpr, wc *walkContext) (Valu
 			rangeAggType = types.RangeAggregationTypeCount // rate is implemented as count_over_time/$interval
 		}
 	default:
-		return nil, errUnimplemented
+		return nil, unimplementedFeature(fmt.Sprintf("range aggregation operation %q", e.Operation))
 	}
 
 	builder = builder.RangeAggregation(
@@ -398,7 +401,7 @@ func walkVectorAggregation(e *syntax.VectorAggregationExpr, wc *walkContext) (Va
 
 	vecAggType := convertVectorAggregationType(e.Operation)
 	if vecAggType == types.VectorAggregationTypeInvalid {
-		return nil, errUnimplemented
+		return nil, unimplementedFeature(fmt.Sprintf("vector aggregation operation %q", e.Operation))
 	}
 
 	return &VectorAggregation{
@@ -436,13 +439,13 @@ func walkBinOp(e *syntax.BinOpExpr, wc *walkContext) (Value, error) {
 
 	op := convertBinaryArithmeticOp(e.Op)
 	if op == types.BinaryOpInvalid {
-		return nil, errUnimplemented
+		return nil, unimplementedFeature(fmt.Sprintf("binary operator %q", e.Op))
 	}
 
 	// this is to check that there is only one non-literal input on either side, otherwise it is not implemented yet.
 	// TODO remove when inner joins on timestamp are implemented
 	if hasNonMathExpressionChild(left) && hasNonMathExpressionChild(right) {
-		return nil, errUnimplemented
+		return nil, unimplementedFeature("binary operation between two non-scalar expressions")
 	}
 
 	return &BinOp{
@@ -474,7 +477,7 @@ func walk(e syntax.Expr, wc *walkContext) (Value, error) {
 		return walkLiteral(e, wc)
 	}
 
-	return nil, errUnimplemented
+	return nil, unimplementedFeature(fmt.Sprintf("sample expression %T", e))
 }
 
 func buildPlanForSampleQuery(ctx context.Context, e syntax.SampleExpr, params logql.Params, deletes []*deletion.Request) (Value, error) {

--- a/pkg/engine/internal/planner/logical/planner_test.go
+++ b/pkg/engine/internal/planner/logical/planner_test.go
@@ -551,6 +551,44 @@ RETURN %17
 	})
 }
 
+// TestConvertAST_UnimplementedErrorNamesFeature ensures that when the planner
+// rejects a query it cannot build, the returned error names the specific
+// unsupported feature (wrapping errUnimplemented) rather than the bare sentinel.
+func TestConvertAST_UnimplementedErrorNamesFeature(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		statement string
+		feature   string
+	}{
+		{
+			name:      "range aggregation with offset",
+			statement: `count_over_time({app="foo"}[5m] offset 5m)`,
+			feature:   "range aggregation with offset",
+		},
+		{
+			name:      "unsupported log parser",
+			statement: `{app="foo"} | pattern "<msg>"`,
+			feature:   `log parser "pattern"`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := &query{
+				statement: tc.statement,
+				start:     3600,
+				end:       7200,
+				step:      time.Minute,
+				direction: logproto.BACKWARD,
+				limit:     1000,
+			}
+
+			plan, err := BuildPlan(context.Background(), q)
+			require.Nil(t, plan)
+			require.ErrorIs(t, err, errUnimplemented)
+			require.ErrorContains(t, err, tc.feature)
+		})
+	}
+}
+
 func TestPlannerCreatesCastOperationForUnwrap(t *testing.T) {
 	t.Run("creates projection with unary cast operation instruction for metric query with unwrap duration", func(t *testing.T) {
 		// Query with duration unwrap in a sum_over_time metric query


### PR DESCRIPTION
**What this PR does**: When the v2 engine can't build a logical plan it returns `ErrNotSupported`, the query falls back to the old engine, and we log a warning. Until now that warning just said "unsupported query" with a bare sentinel error — which told us a query fell back but gave us no idea *which* unimplemented feature caused it. This PR threads the specific feature through to that log line.

The planner already had a `unimplementedFeature(s string)` helper but most call sites were returning the bare `errUnimplemented` sentinel instead. I went through the planner and gave each one a concrete message: which log parser, which range aggregation op, which binary operator, etc. The engine then wraps `ErrNotSupported` around the planner error (`fmt.Errorf("%w: %w", ErrNotSupported, err)`) so the detail bubbles all the way up to the warning in `handler.go`.

The important bit for reviewers: the `errors.Is(err, ErrNotSupported)` checks in `querier/http.go` and `handler.go` that drive the fallback still work, because the wrapped error still matches the sentinel. So behavior is unchanged — we just get visibility into what's actually unimplemented in the wild.

**Other changes**:
- Converted `unimplementedFeature` from a func var to a plain function. No reason for it to be a var, and it reads better next to `BuildPlan`.
- Added `TestConvertAST_UnimplementedErrorNamesFeature` to lock in that the error both matches `errUnimplemented` and names the feature, so we don't silently regress back to the bare sentinel.