### PR TITLE
fix(config): Apply common object storage config to the ruler storage

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -73,6 +73,10 @@ As a result, the following have been removed:
 - The `-ruler.enable-wal-replay` flag and its per-tenant equivalent `ruler_enable_wal_replay` (in `limits_config`). The ruler no longer replays the WAL, so these settings no longer have any effect. Remove them from your configuration; the `deprecated-config-checker` tool will flag them.
 - The ruler WAL metrics that only ever reported replay or repair activity: `loki_ruler_wal_corruptions_total`, `loki_ruler_wal_corruptions_repair_failed_total`, `loki_ruler_wal_corruptions_repair_succeeded_total`, and `loki_ruler_wal_replay_duration`. Remove any dashboards or alerts that reference them.
 
+### Common object storage config is now applied to the ruler storage
+
+When `use_thanos_objstore` is enabled, the `common.storage.object_store` configuration is now also applied to `ruler_storage`, the same way the legacy common storage types have always been applied to the ruler. This means settings such as TLS, credentials, and endpoints configured in the common object storage section are inherited by the ruler instead of being silently ignored. An explicitly configured `ruler_storage` section still takes precedence. If you previously relied on the ruler not starting because `ruler_storage` was left unconfigured while `common.storage.object_store` was set, the ruler will now start using the common object storage configuration.
+
 ### Breaking change: Removal of various configuration options
 
 - The deprecated per-tenant setting `unordered_writes` has been removed. Loki now always allows unordered writes.

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/grafana/loki/v3/pkg/loki/common"
+	"github.com/grafana/loki/v3/pkg/storage/bucket"
 	"github.com/grafana/loki/v3/pkg/storage/bucket/filesystem"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/v3/pkg/storage/config"
@@ -696,6 +697,22 @@ func applyStorageConfig(cfg, defaults *ConfigWrapper) error {
 	if !reflect.DeepEqual(cfg.Common.Storage.ObjectStore, defaults.StorageConfig.ObjectStore.Config) {
 		applyConfig = func(r *ConfigWrapper) {
 			r.StorageConfig.ObjectStore.Config = r.Common.Storage.ObjectStore
+
+			// Like the legacy storage types above, the common object storage config
+			// must also be applied to the ruler storage. The ruler reads its bucket
+			// configuration from the separate ruler_storage section when
+			// use_thanos_objstore is enabled, so without this the ruler would not
+			// inherit common settings such as TLS or credentials.
+			// The ruler backend cannot be stored in the bucket config itself, so it is
+			// inferred from which backend is configured in the common config; if none
+			// or several backends are configured we cannot infer it and leave the
+			// ruler storage untouched.
+			if r.StorageConfig.UseThanosObjstore {
+				if backend := commonObjectStoreBackend(&r.Common.Storage.ObjectStore, &defaults.StorageConfig.ObjectStore.Config); backend != "" {
+					r.RulerStorage.Backend = backend
+					r.RulerStorage.Config = r.Common.Storage.ObjectStore
+				}
+			}
 		}
 	}
 
@@ -708,6 +725,37 @@ func applyStorageConfig(cfg, defaults *ConfigWrapper) error {
 	}
 
 	return nil
+}
+
+// commonObjectStoreBackend returns the name of the single object storage backend
+// configured in the common config, or an empty string when none or more than one
+// backend is configured.
+func commonObjectStoreBackend(common, defaults *bucket.Config) string {
+	backends := []struct {
+		name       string
+		configured bool
+	}{
+		{bucket.S3, !reflect.DeepEqual(common.S3, defaults.S3)},
+		{bucket.GCS, !reflect.DeepEqual(common.GCS, defaults.GCS)},
+		{bucket.Azure, !reflect.DeepEqual(common.Azure, defaults.Azure)},
+		{bucket.Swift, !reflect.DeepEqual(common.Swift, defaults.Swift)},
+		{bucket.Filesystem, !reflect.DeepEqual(common.Filesystem, defaults.Filesystem)},
+		{bucket.Alibaba, !reflect.DeepEqual(common.Alibaba, defaults.Alibaba)},
+		{bucket.BOS, !reflect.DeepEqual(common.BOS, defaults.BOS)},
+	}
+
+	backend := ""
+	for _, b := range backends {
+		if !b.configured {
+			continue
+		}
+		if backend != "" {
+			return ""
+		}
+		backend = b.name
+	}
+
+	return backend
 }
 
 func betterTSDBShipperDefaults(cfg *ConfigWrapper) {

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -792,14 +792,73 @@ storage_config:
     object_store:
       gcs:
         bucket_name: foobar
-        chunk_buffer_size: 17`
+        chunk_buffer_size: 17
+storage_config:
+  use_thanos_objstore: true`
 
 			config, _ := testContext(commonStorageConfig, nil)
 
 			assert.Equal(t, "foobar", config.StorageConfig.ObjectStore.GCS.BucketName)
 			assert.Equal(t, 17, config.StorageConfig.ObjectStore.GCS.ChunkBufferSize)
 
-			// TODO: common config should be set on ruler bucket config
+			// should be set on ruler bucket config
+			assert.Equal(t, "gcs", config.RulerStorage.Backend)
+			assert.Equal(t, "foobar", config.RulerStorage.GCS.BucketName)
+			assert.Equal(t, 17, config.RulerStorage.GCS.ChunkBufferSize)
+		})
+
+		t.Run("when common object_store config is provided, the http config such as TLS settings should be applied to the ruler storage", func(t *testing.T) {
+			commonStorageConfig := `common:
+  storage:
+    object_store:
+      s3:
+        endpoint: s3.example.local:443
+        http:
+          tls_ca_path: /var/lib/acme-ca/ca.crt
+storage_config:
+  use_thanos_objstore: true`
+
+			config, _ := testContext(commonStorageConfig, nil)
+
+			assert.Equal(t, "s3.example.local:443", config.StorageConfig.ObjectStore.S3.Endpoint)
+			assert.Equal(t, "/var/lib/acme-ca/ca.crt", config.StorageConfig.ObjectStore.S3.HTTP.TLSConfig.CAPath)
+
+			assert.Equal(t, "s3", config.RulerStorage.Backend)
+			assert.Equal(t, "s3.example.local:443", config.RulerStorage.S3.Endpoint)
+			assert.Equal(t, "/var/lib/acme-ca/ca.crt", config.RulerStorage.S3.HTTP.TLSConfig.CAPath)
+		})
+
+		t.Run("when use_thanos_objstore is not enabled, common object_store config is not applied to the ruler storage", func(t *testing.T) {
+			commonStorageConfig := `common:
+  storage:
+    object_store:
+      gcs:
+        bucket_name: foobar
+storage_config:
+  use_thanos_objstore: false`
+
+			config, defaults := testContext(commonStorageConfig, nil)
+
+			assert.Equal(t, "foobar", config.StorageConfig.ObjectStore.GCS.BucketName)
+			assert.Equal(t, defaults.RulerStorage, config.RulerStorage)
+		})
+
+		t.Run("when multiple object_store backends are provided, the ruler storage backend cannot be inferred and is left untouched", func(t *testing.T) {
+			commonStorageConfig := `common:
+  storage:
+    object_store:
+      gcs:
+        bucket_name: foobar
+      s3:
+        endpoint: s3.example.local:443
+storage_config:
+  use_thanos_objstore: true`
+
+			config, defaults := testContext(commonStorageConfig, nil)
+
+			assert.Equal(t, "foobar", config.StorageConfig.ObjectStore.GCS.BucketName)
+			assert.Equal(t, "s3.example.local:443", config.StorageConfig.ObjectStore.S3.Endpoint)
+			assert.Equal(t, defaults.RulerStorage, config.RulerStorage)
 		})
 
 		t.Run("explicit thanos object storage config provided via config file is preserved", func(t *testing.T) {
@@ -810,6 +869,7 @@ storage_config:
         bucket_name: foobar
         chunk_buffer_size: 17
 storage_config:
+  use_thanos_objstore: true
   object_store:
     gcs:
       bucket_name: barfoo
@@ -820,7 +880,35 @@ storage_config:
 			assert.Equal(t, "barfoo", config.StorageConfig.ObjectStore.GCS.BucketName)
 			assert.Equal(t, 27, config.StorageConfig.ObjectStore.GCS.ChunkBufferSize)
 
-			// TODO: common config should be set on ruler bucket config
+			// the ruler storage should be set from the common config
+			assert.Equal(t, "gcs", config.RulerStorage.Backend)
+			assert.Equal(t, "foobar", config.RulerStorage.GCS.BucketName)
+			assert.Equal(t, 17, config.RulerStorage.GCS.ChunkBufferSize)
+		})
+
+		t.Run("explicit ruler_storage config provided via config file is preserved", func(t *testing.T) {
+			explicitRulerStorageConfig := `common:
+  storage:
+    object_store:
+      gcs:
+        bucket_name: foobar
+        chunk_buffer_size: 17
+storage_config:
+  use_thanos_objstore: true
+ruler_storage:
+  backend: gcs
+  gcs:
+    bucket_name: ruler-bucket`
+
+			config, _ := testContext(explicitRulerStorageConfig, nil)
+
+			assert.Equal(t, "foobar", config.StorageConfig.ObjectStore.GCS.BucketName)
+
+			// the explicitly configured ruler bucket wins over the common config,
+			// while settings not configured in ruler_storage are inherited from it
+			assert.Equal(t, "gcs", config.RulerStorage.Backend)
+			assert.Equal(t, "ruler-bucket", config.RulerStorage.GCS.BucketName)
+			assert.Equal(t, 17, config.RulerStorage.GCS.ChunkBufferSize)
 		})
 
 		t.Run("named storage config provided via config file is preserved", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

When `use_thanos_objstore` is enabled, the ruler reads its bucket configuration from the separate `ruler_storage` section. Unlike every legacy storage type (s3, gcs, azure, swift, ...), the `common.storage.object_store` config was never propagated there, so settings such as TLS CA, credentials and endpoints configured in the common section were silently ignored by the ruler. In a simple scalable deployment this surfaces as `tls: failed to verify certificate: x509: certificate signed by unknown authority` errors on the backend target (which runs the ruler), while the read and write components work fine.

This PR applies the common object storage config to `ruler_storage` as well, mirroring how the legacy storage types have always been applied to the ruler:

- The ruler storage backend is inferred from which single object store backend is configured in the common config; when none or several backends are configured, the ruler storage is left untouched (preserving today's behavior, including "ruler does not start when its storage is unconfigured").
- Nothing changes when `use_thanos_objstore` is disabled, so legacy setups are unaffected.
- An explicitly configured `ruler_storage` section still takes precedence, since the config file is re-applied on top of the dynamic config.

This also resolves two long-standing `TODO: common config should be set on ruler bucket config` comments in the config wrapper tests.

**Which issue(s) this PR fixes**:
Fixes #22319

**Special notes for your reviewer**:

The new test "when common object_store config is provided, the http config such as TLS settings should be applied to the ruler storage" reproduces the exact scenario from the issue (custom CA via `s3.http.tls_ca_path`). Since the ruler may now start in setups where `common.storage.object_store` is set but `ruler_storage` was intentionally left unconfigured, this behavior change is documented in the upgrade guide.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
