### PR TITLE
fix(compactor): Dataobj compaction metrics registration and restrictive-S3 IndexMerge probe

### DIFF
--- a/pkg/engine/compactor/coordinator.go
+++ b/pkg/engine/compactor/coordinator.go
@@ -229,6 +229,7 @@ func (c *coordinator) runTenantCycle(
 		return tenantCycleFailed
 	}
 	c.metrics.observeTenantCycle(tenant, "compacted", tenantDuration, stats)
+	c.metrics.observeEntries(tenant, entries, c.clock())
 	return tenantCycleCompacted
 }
 

--- a/pkg/engine/internal/executor/index_merge.go
+++ b/pkg/engine/internal/executor/index_merge.go
@@ -37,8 +37,15 @@ func (c *Context) doIndexMerge(ctx context.Context, node *physical.IndexMerge) e
 		return errors.New("no object store bucket configured")
 	}
 
-	// Check if output already exists (short-circuit on retry)
-	exists, err := c.bucket.Exists(ctx, node.OutputIndexPath)
+	// Check if output already exists (short-circuit on retry).
+	//
+	// We probe with a GetObject rather than Exists/HeadObject: under IRSA roles
+	// that grant s3:GetObject/s3:PutObject but not s3:ListBucket, a HeadObject on
+	// a missing key returns 403 AccessDenied instead of 404 NoSuchKey, which
+	// objstore surfaces as a hard error. GetObject returns a genuine NoSuchKey on
+	// a missing key without requiring ListBucket. Treat access-denied here as
+	// "not present" too, so a restrictive read policy never blocks the merge.
+	exists, err := c.outputExists(ctx, node.OutputIndexPath)
 	if err != nil {
 		return fmt.Errorf("checking output existence: %w", err)
 	}
@@ -102,6 +109,23 @@ func (c *Context) doIndexMerge(ctx context.Context, node *physical.IndexMerge) e
 		c.indexMergeObserver.ObserveIndexMergeOutput(node.Tenant, obj.Size(), uncompressedBytes)
 	}
 	return nil
+}
+
+// outputExists reports whether the IndexMerge output object is already present.
+// It probes with GetObject so a restrictive read policy (s3:GetObject without
+// s3:ListBucket) still yields a correct answer: a missing key returns
+// not-found, and an access-denied response is treated as not-present rather
+// than a fatal error.
+func (c *Context) outputExists(ctx context.Context, path string) (bool, error) {
+	rc, err := c.bucket.Get(ctx, path)
+	if err != nil {
+		if c.bucket.IsObjNotFoundErr(err) || c.bucket.IsAccessDeniedErr(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	_ = rc.Close()
+	return true, nil
 }
 
 // classifyRuns scans all sections of each referenced source object and

--- a/pkg/engine/internal/executor/index_merge_test.go
+++ b/pkg/engine/internal/executor/index_merge_test.go
@@ -807,10 +807,10 @@ func readStatsRowsFromBucket(ctx context.Context, t *testing.T, bucket objstore.
 	return rows
 }
 
-// countingBucket wraps an objstore.Bucket and counts Exists and Upload calls.
+// countingBucket wraps an objstore.Bucket and counts Get and Upload calls.
 type countingBucket struct {
 	underlying  objstore.Bucket
-	existsCount int64
+	getCount    int64
 	uploadCount int64
 }
 
@@ -826,11 +826,11 @@ func (cb *countingBucket) Upload(ctx context.Context, name string, r io.Reader) 
 }
 
 func (cb *countingBucket) Exists(ctx context.Context, name string) (bool, error) {
-	cb.existsCount++
 	return cb.underlying.Exists(ctx, name)
 }
 
 func (cb *countingBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	cb.getCount++
 	return cb.underlying.Get(ctx, name)
 }
 
@@ -896,8 +896,8 @@ func (cb *countingBucket) Close() error {
 	return cb.underlying.Close()
 }
 
-func (cb *countingBucket) ExistsCount() int64 {
-	return cb.existsCount
+func (cb *countingBucket) GetCount() int64 {
+	return cb.getCount
 }
 
 func (cb *countingBucket) UploadCount() int64 {
@@ -905,7 +905,7 @@ func (cb *countingBucket) UploadCount() int64 {
 }
 
 func (cb *countingBucket) ResetCounts() {
-	cb.existsCount = 0
+	cb.getCount = 0
 	cb.uploadCount = 0
 }
 
@@ -1223,8 +1223,8 @@ func TestExecuteIndexMerge_ExistenceShortCircuit(t *testing.T) {
 	err = execCtx.doIndexMerge(ctx, node)
 	require.NoError(t, err)
 
-	// Verify Exists was called once and Upload was not called.
-	require.Equal(t, int64(1), bucket.ExistsCount())
+	// Verify the output was probed once via Get and Upload was not called.
+	require.Equal(t, int64(1), bucket.GetCount())
 	require.Equal(t, int64(0), bucket.UploadCount())
 }
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -2411,6 +2411,7 @@ func (t *Loki) initDataObjCompactionPlanner() (services.Service, error) {
 		Bucket:          indexBucket,
 		MetastoreWriter: tocWriter,
 		Logger:          logger,
+		Registerer:      prometheus.DefaultRegisterer,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What this PR does

Three small fixes to dataobj index compaction, discovered while bringing dataobj compaction up in dev.

### 1. `fix(compactor): observe entries on compacted tenant cycle path`

`coordinator.runTenantCycle` calls `observeEntries` on the converged and failed return paths, but was missing on the **compacted** path. 

### 2. `fix(engine): probe IndexMerge output with GetObject to tolerate restrictive S3 read policy`

The IndexMerge short-circuit used `bucket.Exists` (HeadObject) to detect an already-written output. Under IRSA/IAM roles that grant `s3:GetObject`/`s3:PutObject` but **not** `s3:ListBucket`, S3 HeadObject on a *missing* key returns `403 AccessDenied` instead of `404 NoSuchKey`. thanos objstore's `IsObjNotFoundErr` only matches `NoSuchKey`, so the missing-output probe surfaced as a hard error and blocked every merge:

```
err="... checking output existence: stat s3 object: Access Denied."
tenants_total=49 tenants_compacted=0 tenants_converged=0 tenants_failed=49
```

The fix replaces `Exists` with a helper that probes via `Get` (GetObject). GetObject returns a genuine `NoSuchKey` on a missing key without requiring `ListBucket`.

### 3. `fix(compactor): register dataobj compaction planner metrics`

`initDataObjCompactionPlanner` built `enginecompactor.PlannerParams` without setting `Registerer`, leaving it nil. `promauto.With(nil)` silently drops all 12 planner/coordinator metrics added in #22087. The worker init path already sets `Registerer: prometheus.DefaultRegisterer`; this aligns the planner path so its metrics are actually registered.
