### PR TITLE
refactor(util): Move ring watcher out of pkg/util into pkg/util/ring

### DIFF
--- a/pkg/lokifrontend/frontend/v2/frontend_scheduler_worker.go
+++ b/pkg/lokifrontend/frontend/v2/frontend_scheduler_worker.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/scheduler/schedulerpb"
 	"github.com/grafana/loki/v3/pkg/util"
+	lokiring "github.com/grafana/loki/v3/pkg/util/ring"
 )
 
 type frontendSchedulerWorkers struct {
@@ -49,7 +50,7 @@ func newFrontendSchedulerWorkers(cfg Config, frontendAddress string, ring ring.R
 	switch {
 	case ring != nil:
 		// Use the scheduler ring and RingWatcher to find schedulers.
-		w, err := util.NewRingWatcher(log.With(logger, "component", "frontend-scheduler-worker"), ring, cfg.DNSLookupPeriod, f)
+		w, err := lokiring.NewRingWatcher(log.With(logger, "component", "frontend-scheduler-worker"), ring, cfg.DNSLookupPeriod, f)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/querier/queryrange"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/v3/pkg/util"
+	lokiring "github.com/grafana/loki/v3/pkg/util/ring"
 )
 
 var tracer = otel.Tracer("pkg/querier/worker")
@@ -175,7 +176,7 @@ func newQuerierWorkerWithProcessor(grpcCfg grpcclient.Config, maxConcReq int, dn
 	}
 
 	if ring != nil {
-		w, err := util.NewRingWatcher(log.With(logger, "component", "querier-scheduler-worker"), ring, dnsLookupPeriod, f)
+		w, err := lokiring.NewRingWatcher(log.With(logger, "component", "querier-scheduler-worker"), ring, dnsLookupPeriod, f)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -635,7 +635,7 @@ func (s *Scheduler) running(ctx context.Context) error {
 			if !s.cfg.UseSchedulerRing {
 				continue
 			}
-			isInSet, err := lokiring.IsInReplicationSet(s.ringManager.Ring, util.RingKeyOfLeader, s.ringManager.RingLifecycler.GetInstanceAddr())
+			isInSet, err := lokiring.IsInReplicationSet(s.ringManager.Ring, lokiring.RingKeyOfLeader, s.ringManager.RingLifecycler.GetInstanceAddr())
 			if err != nil {
 				level.Error(s.log).Log("msg", "failed to query the ring to see if scheduler instance is in ReplicatonSet, will try again", "err", err)
 				continue

--- a/pkg/util/ring/ring_watcher.go
+++ b/pkg/util/ring/ring_watcher.go
@@ -1,4 +1,4 @@
-package util //nolint:revive
+package ring
 
 import (
 	"context"
@@ -8,6 +8,8 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
+
+	"github.com/grafana/loki/v3/pkg/util"
 )
 
 const (
@@ -17,13 +19,13 @@ const (
 type ringWatcher struct {
 	log           log.Logger
 	ring          ring.ReadRing
-	notifications DNSNotifications
+	notifications util.DNSNotifications
 	lookupPeriod  time.Duration
 	addresses     []string
 }
 
 // NewRingWatcher creates a new Ring watcher and returns a service that is wrapping it.
-func NewRingWatcher(log log.Logger, ring ring.ReadRing, lookupPeriod time.Duration, notifications DNSNotifications) (services.Service, error) {
+func NewRingWatcher(log log.Logger, ring ring.ReadRing, lookupPeriod time.Duration, notifications util.DNSNotifications) (services.Service, error) {
 	w := &ringWatcher{
 		log:           log,
 		ring:          ring,


### PR DESCRIPTION
**What this PR does / why we need it**:

This is born from the Loki Operator which was struggling with the number of transitive dependencies being imported. This can cause conflicts with package versions and increases the CVE surface significantly.

`pkg/util/ring_watcher.go` is the only file in the grab-bag `pkg/util` package that imports `dskit/ring`, which transitively pulls in the entire clustering / KV stack — `hashicorp/memberlist`, `consul`, `serf`, and `etcd`. Because Go compiles whole packages, every importer of `pkg/util` inherits that heavy tail regardless of what they actually use.

This PR moves `NewRingWatcher` (and the `RingKeyOfLeader` key it uses) from `pkg/util` into the existing `pkg/util/ring` package, which already depends on `dskit/ring`. The three in-tree callers (frontend scheduler worker, querier worker, scheduler) are updated.

After this, `pkg/util` no longer imports `dskit/ring`: `go list -deps ./pkg/util` drops from **126 to 97 modules**, removing the memberlist / consul / serf / etcd tail from every `pkg/util` consumer.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

- **Breaking change for Go API consumers**: external callers of `util.NewRingWatcher` and `util.RingKeyOfLeader` must switch to `github.com/grafana/loki/v3/pkg/util/ring`. No backwards-compatible alias is provided on purpose — an alias would re-import `dskit/ring` back into `pkg/util` and defeat the entire change. This is a Go import-path change only; it does not affect Loki runtime/config upgrades.
- Independent of (and mergeable in any order with) the companion #22368, which decouples the LogQL parser from `pkg/util` / `logqlmodel`.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
