### PR TITLE
feat(storage): Add opt-in TSDB schema v14 writer support

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -37,6 +37,19 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 ## Main / Unreleased
 
+### TSDB schema v14
+
+Loki now supports the experimental TSDB storage schema `v14`. Schema v14 uses the
+same chunk format as v13 and changes only the TSDB index format, which adds a
+per-chunk ingestion timestamp used by ingestion-time retention features.
+
+v13 remains the recommended schema. To opt in to v14, add a new `period_config`
+with a future `from` date and `schema: v14`; existing v13 periods are unaffected.
+
+Before configuring any v14 period, upgrade all components to a version that can
+read the v14 index format. Rolling back after v14 data has been written requires
+stopping new v14 writes first, because earlier binaries cannot read v14 indexes.
+
 ### Breaking change: Removal of various configuration options
 
 - The deprecated per-tenant setting `unordered_writes` has been removed. Loki now always allows unordered writes.

--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -422,8 +422,10 @@ func (cfg *PeriodConfig) TSDBFormat() (int, error) {
 	switch {
 	case sver <= 12:
 		return index.FormatV2, nil
-	default: // for v13 and above
+	case sver == 13:
 		return index.FormatV3, nil
+	default:
+		return index.FormatV4, nil
 	}
 }
 
@@ -447,7 +449,7 @@ func (cfg PeriodConfig) validate() error {
 	}
 
 	switch v {
-	case 10, 11, 12, 13:
+	case 10, 11, 12, 13, 14:
 		if cfg.RowShards == 0 {
 			return fmt.Errorf("must have row_shards > 0 (current: %d) for schema (%s)", cfg.RowShards, cfg.Schema)
 		}

--- a/pkg/storage/config/schema_config_test.go
+++ b/pkg/storage/config/schema_config_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/grafana/loki/v3/pkg/chunkenc"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
@@ -296,31 +297,6 @@ func TestSchemaConfig_Validate(t *testing.T) {
 	}
 }
 
-func TestPeriodConfig_TSDBFormat_V14RequiresSchemaSupport(t *testing.T) {
-	v14 := PeriodConfig{
-		Schema:    "v14",
-		RowShards: 16,
-		IndexType: "tsdb",
-		IndexTables: IndexPeriodicTableConfig{
-			PathPrefix:          "index/",
-			PeriodicTableConfig: PeriodicTableConfig{Period: ObjectStorageIndexRequiredPeriod},
-		},
-		ChunkTables: PeriodicTableConfig{Period: 0},
-	}
-
-	require.ErrorContains(t, v14.validate(), "invalid schema version")
-
-	format, err := v14.TSDBFormat()
-	require.NoError(t, err)
-	require.Equal(t, index.FormatV3, format)
-
-	v13 := v14
-	v13.Schema = "v13"
-	format, err = v13.TSDBFormat()
-	require.NoError(t, err)
-	require.Equal(t, index.FormatV3, format)
-}
-
 func TestPeriodConfig_Validate(t *testing.T) {
 	for _, tc := range []struct {
 		desc string
@@ -402,6 +378,18 @@ func TestPeriodConfig_Validate(t *testing.T) {
 			desc: "v13",
 			in: PeriodConfig{
 				Schema:    "v13",
+				RowShards: 16,
+				IndexTables: IndexPeriodicTableConfig{
+					PathPrefix:          "index/",
+					PeriodicTableConfig: PeriodicTableConfig{Period: 0},
+				},
+				ChunkTables: PeriodicTableConfig{Period: 0},
+			},
+		},
+		{
+			desc: "v14",
+			in: PeriodConfig{
+				Schema:    "v14",
 				RowShards: 16,
 				IndexTables: IndexPeriodicTableConfig{
 					PathPrefix:          "index/",
@@ -584,6 +572,19 @@ func TestVersionAsInt(t *testing.T) {
 			},
 			expected: int(13),
 		},
+		{
+			name: "v14",
+			schemaCfg: SchemaConfig{
+				Configs: []PeriodConfig{
+					{
+						From:      DayTime{Time: 0},
+						Schema:    "v14",
+						RowShards: 16,
+					},
+				},
+			},
+			expected: int(14),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			version, err := tc.schemaCfg.Configs[0].VersionAsInt()
@@ -593,6 +594,51 @@ func TestVersionAsInt(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestPeriodConfigFormatMappings(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		schema      string
+		wantChunk   byte
+		wantHeadFmt chunkenc.HeadBlockFmt
+		wantTSDB    int
+	}{
+		{
+			name:        "v12",
+			schema:      "v12",
+			wantChunk:   chunkenc.ChunkFormatV3,
+			wantHeadFmt: chunkenc.ChunkHeadFormatFor(chunkenc.ChunkFormatV3),
+			wantTSDB:    index.FormatV2,
+		},
+		{
+			name:        "v13",
+			schema:      "v13",
+			wantChunk:   chunkenc.ChunkFormatV4,
+			wantHeadFmt: chunkenc.ChunkHeadFormatFor(chunkenc.ChunkFormatV4),
+			wantTSDB:    index.FormatV3,
+		},
+		{
+			name:        "v14",
+			schema:      "v14",
+			wantChunk:   chunkenc.ChunkFormatV4,
+			wantHeadFmt: chunkenc.ChunkHeadFormatFor(chunkenc.ChunkFormatV4),
+			wantTSDB:    index.FormatV4,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := PeriodConfig{Schema: tc.schema, RowShards: 16}
+
+			chunkFmt, headFmt, err := cfg.ChunkFormat()
+			require.NoError(t, err)
+			require.Equal(t, tc.wantChunk, chunkFmt)
+			require.Equal(t, tc.wantHeadFmt, headFmt)
+
+			tsdbFmt, err := cfg.TSDBFormat()
+			require.NoError(t, err)
+			require.Equal(t, tc.wantTSDB, tsdbFmt)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This is PR 2 of the ingestion-time retention stack split out from #21931.

This PR adds opt-in schema v14 writer support on top of the FormatV4 reader foundation. Schema v14 maps TSDB indexes to FormatV4 while continuing to use the same chunk encoding format as schema v13.

Schema version mapping:

| Schema | Chunk Format | TSDB Index Format | What changed |
|--------|--------------|-------------------|--------------|
| v12 | ChunkFormatV3 (UnorderedHeadBlock) | FormatV2 | — |
| v13 | ChunkFormatV4 (UnorderedWithStructuredMetadata) | FormatV3 | Paged chunks |
| v14 | ChunkFormatV4 (same as v13) | FormatV4 | +IngestedAt per chunk |

Key changes in this PR:

- Allows `schema: v14` in schema config validation.
- Maps schema v14 to TSDB index FormatV4.
- Keeps schema v14 on ChunkFormatV4, matching v13 chunk encoding.
- Documents schema v14 as the schema that persists chunk `IngestedAt` in TSDB indexes.
- Extends schema validation and mapping tests.

This PR intentionally only enables the schema/writer mapping. The ingestion-time retention behavior and backfill header handling are in the next stacked PR.

Stack:

1. `hay-kot/loki-formatv4-reader`: FormatV4 reader foundation and passive preservation
2. This PR: opt-in schema v14 writer support
3. `hay-kot/loki-backfill-retention`: backfill header and ingestion-time retention behavior

**Which issue(s) this PR fixes**:

Part of #21931

**Special notes for your reviewer**:

- This PR depends on the FormatV4 reader foundation branch.
- Schema v14 changes the TSDB index format only; it does not introduce a new chunk encoding format.
- Users must explicitly configure schema v14 for writes to use FormatV4.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
