### PR TITLE
fix: Return unknonwn level when severity_text contains unrecognized values

### DIFF
--- a/pkg/distributor/field_detection.go
+++ b/pkg/distributor/field_detection.go
@@ -171,8 +171,8 @@ func normalizeLogLevel(level string) string {
 	case bytes.EqualFold(levelBytes, fatal):
 		return constants.LogLevelFatal
 	default:
-		// Return the original value if it doesn't match any known level
-		return level
+		// Return unknown if it doesn't match any known level. This is consistent with detectLogLevelFromLogEntry
+		return constants.LogLevelUnknown
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Whenever severity_text contains values other than the known levels, it adds them directly to detected_level. This results in unbounded cardinality for detected_level, thus resulting in large drain sizes. This PR just fixes that method to return `unknown` level which is consistent with the other flows.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
