### PR TITLE
fix(v2-engine): Renaming of label using label_format in v2 must drop all label types except builtin/generated ones

### DIFF
--- a/pkg/engine/internal/executor/project.go
+++ b/pkg/engine/internal/executor/project.go
@@ -152,7 +152,12 @@ func newExpandPipeline(expr physical.Expression, evaluator *expressionEvaluator,
 				return nil, err
 			}
 			_, shouldDelete := renamedLabelSources[ident.ShortName()]
-			shouldDelete = shouldDelete && ident.ColumnType() == types.ColumnTypeLabel // only overwrite labels, not other column types
+			// A `label_format dst=src` rename removes the source label regardless of
+			// which category it came from (stream label, structured metadata, or a
+			// parsed field), matching the classic engine which
+			// deletes the name from every category. Only builtin/generated columns
+			// (timestamp, message, __error__, value) must be preserved.
+			shouldDelete = shouldDelete && isLabelLikeColumn(ident.ColumnType())
 			if !ident.Equal(semconv.ColumnIdentValue) && !shouldDelete {
 				outputCols = append(outputCols, batch.Column(i))
 				outputFields = append(outputFields, field)
@@ -197,6 +202,19 @@ func newExpandPipeline(expr physical.Expression, evaluator *expressionEvaluator,
 		outputSchema := arrow.NewSchema(outputFields, &metadata)
 		return array.NewRecordBatch(outputSchema, outputCols, batch.NumRows()), nil
 	}, input), nil
+}
+
+// isLabelLikeColumn reports whether a column of the given type participates in
+// the label set that LogQL operates on (and therefore can be the source of a
+// `label_format` rename). Builtin and generated columns (timestamp, message,
+// __error__, value) are excluded.
+func isLabelLikeColumn(ct types.ColumnType) bool {
+	switch ct {
+	case types.ColumnTypeLabel, types.ColumnTypeParsed, types.ColumnTypeMetadata, types.ColumnTypeAmbiguous:
+		return true
+	default:
+		return false
+	}
 }
 
 func labelFmtRenameSources(expr physical.Expression) map[string]struct{} {

--- a/pkg/engine/internal/executor/project_test.go
+++ b/pkg/engine/internal/executor/project_test.go
@@ -958,57 +958,124 @@ func TestNewProjectPipeline_DuplicateColumnPanic(t *testing.T) {
 }
 
 func TestNewProjectPipeline_LabelFmtRenameDropsSourceColumn(t *testing.T) {
-	schema := arrow.NewSchema([]arrow.Field{
-		semconv.FieldFromIdent(semconv.ColumnIdentMessage, false),
-		semconv.FieldFromIdent(semconv.ColumnIdentTimestamp, false),
-		semconv.FieldFromFQN("utf8.label.bar", false),
-	}, nil)
-
 	ts := time.Unix(1700000000, 0).UTC()
-	rows := arrowtest.Rows{
+
+	msg := "rename bar to foo"
+	tests := []struct {
+		name string
+		// dataFields/dataValues are the input columns in addition to the
+		// constant message and timestamp columns.
+		dataFields []arrow.Field
+		dataValues arrowtest.Row
+		labelFmts  []log.LabelFmt
+		expected   arrowtest.Rows
+	}{
 		{
-			"utf8.builtin.message":           "rename bar to foo",
-			"timestamp_ns.builtin.timestamp": ts,
-			"utf8.label.bar":                 "dev",
+			name:       "stream label source is dropped",
+			dataFields: []arrow.Field{semconv.FieldFromFQN("utf8.label.bar", false)},
+			dataValues: arrowtest.Row{"utf8.label.bar": "dev"},
+			labelFmts:  []log.LabelFmt{{Name: "foo", Value: "bar", Rename: true}},
+			expected: arrowtest.Rows{{
+				"utf8.builtin.message":           msg,
+				"timestamp_ns.builtin.timestamp": ts,
+				"utf8.label.foo":                 "dev",
+			}},
 		},
-	}
-
-	input := NewArrowtestPipeline(schema, rows)
-	parseExpr := &physical.VariadicExpr{
-		Op: types.VariadicOpParseLabelfmt,
-		Expressions: []physical.Expression{
-			&physical.ColumnExpr{Ref: semconv.ColumnIdentMessage.ColumnRef()},
-			physical.NewLiteral([]string{}),
-			physical.NewLiteral([]log.LabelFmt{
-				{Name: "foo", Value: "bar", Rename: true},
-			}),
-		},
-	}
-
-	proj := &physical.Projection{
-		Expressions: []physical.Expression{parseExpr},
-		All:         true,
-		Expand:      true,
-	}
-
-	pipeline, err := NewProjectPipeline(input, proj, newExpressionEvaluator())
-	require.NoError(t, err)
-	record, err := pipeline.Read(t.Context())
-	require.NoError(t, err)
-
-	fieldNames := make([]string, 0, len(record.Schema().Fields()))
-	for _, field := range record.Schema().Fields() {
-		fieldNames = append(fieldNames, field.Name)
-	}
-	require.NotContains(t, fieldNames, "utf8.label.bar")
-
-	actualRows, err := arrowtest.RecordRows(record)
-	require.NoError(t, err)
-	require.Equal(t, arrowtest.Rows{
 		{
-			"utf8.builtin.message":           "rename bar to foo",
-			"timestamp_ns.builtin.timestamp": ts,
-			"utf8.label.foo":                 "dev",
+			name:       "parsed source is dropped",
+			dataFields: []arrow.Field{semconv.FieldFromFQN("utf8.parsed.bar", false)},
+			dataValues: arrowtest.Row{"utf8.parsed.bar": "dev"},
+			labelFmts:  []log.LabelFmt{{Name: "foo", Value: "bar", Rename: true}},
+			expected: arrowtest.Rows{{
+				"utf8.builtin.message":           msg,
+				"timestamp_ns.builtin.timestamp": ts,
+				"utf8.label.foo":                 "dev",
+			}},
 		},
-	}, actualRows)
+		{
+			name:       "metadata source is dropped",
+			dataFields: []arrow.Field{semconv.FieldFromFQN("utf8.metadata.bar", false)},
+			dataValues: arrowtest.Row{"utf8.metadata.bar": "dev"},
+			labelFmts:  []log.LabelFmt{{Name: "foo", Value: "bar", Rename: true}},
+			expected: arrowtest.Rows{{
+				"utf8.builtin.message":           msg,
+				"timestamp_ns.builtin.timestamp": ts,
+				"utf8.label.foo":                 "dev",
+			}},
+		},
+		{
+			// Generated columns are not label-like, so the source column survives
+			// the rename even though its short name matches the rename source.
+			name:       "generated source is preserved",
+			dataFields: []arrow.Field{semconv.FieldFromFQN("utf8.generated.bar", false)},
+			dataValues: arrowtest.Row{"utf8.generated.bar": "dev"},
+			labelFmts:  []log.LabelFmt{{Name: "foo", Value: "bar", Rename: true}},
+			expected: arrowtest.Rows{{
+				"utf8.builtin.message":           msg,
+				"timestamp_ns.builtin.timestamp": ts,
+				"utf8.generated.bar":             "dev",
+				"utf8.label.foo":                 "dev",
+			}},
+		},
+		{
+			// Collision: the rename destination `foo` already exists as a label.
+			// The source `bar` is dropped and the existing `foo` is overwritten
+			// with the source's value (mirrors v1 "rename and overwrite existing
+			// label").
+			name: "rename overwrites existing destination label",
+			dataFields: []arrow.Field{
+				semconv.FieldFromFQN("utf8.label.foo", false),
+				semconv.FieldFromFQN("utf8.label.bar", false),
+			},
+			dataValues: arrowtest.Row{"utf8.label.foo": "old", "utf8.label.bar": "dev"},
+			labelFmts:  []log.LabelFmt{{Name: "foo", Value: "bar", Rename: true}},
+			expected: arrowtest.Rows{{
+				"utf8.builtin.message":           msg,
+				"timestamp_ns.builtin.timestamp": ts,
+				"utf8.label.foo":                 "dev",
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := arrow.NewSchema(append([]arrow.Field{
+				semconv.FieldFromIdent(semconv.ColumnIdentMessage, false),
+				semconv.FieldFromIdent(semconv.ColumnIdentTimestamp, false),
+			}, tt.dataFields...), nil)
+
+			row := arrowtest.Row{
+				"utf8.builtin.message":           msg,
+				"timestamp_ns.builtin.timestamp": ts,
+			}
+			for k, v := range tt.dataValues {
+				row[k] = v
+			}
+
+			input := NewArrowtestPipeline(schema, arrowtest.Rows{row})
+			parseExpr := &physical.VariadicExpr{
+				Op: types.VariadicOpParseLabelfmt,
+				Expressions: []physical.Expression{
+					&physical.ColumnExpr{Ref: semconv.ColumnIdentMessage.ColumnRef()},
+					physical.NewLiteral([]string{}),
+					physical.NewLiteral(tt.labelFmts),
+				},
+			}
+
+			proj := &physical.Projection{
+				Expressions: []physical.Expression{parseExpr},
+				All:         true,
+				Expand:      true,
+			}
+
+			pipeline, err := NewProjectPipeline(input, proj, newExpressionEvaluator())
+			require.NoError(t, err)
+			record, err := pipeline.Read(t.Context())
+			require.NoError(t, err)
+
+			actualRows, err := arrowtest.RecordRows(record)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, actualRows)
+		})
+	}
 }

--- a/pkg/logql/bench/queries/regression/metric-queries.yaml
+++ b/pkg/logql/bench/queries/regression/metric-queries.yaml
@@ -268,3 +268,28 @@ queries:
       log_format: logfmt
       detected_fields:
         - error
+  - description: Group by a label_format-renamed source field
+    query: sum by (msg) (count_over_time(${SELECTOR} | logfmt | label_format msg_label=msg [${RANGE}]))
+    kind: metric
+    time_range:
+      length: 24h
+      step: 1m
+    tags:
+      - count_over_time
+      - logfmt
+      - label_format
+      - rename
+      - grouping
+    notes: >
+      Regression for the v2 label_format rename source-drop fix. `label_format
+      msg_label=msg` is a rename, so the source label `msg` must be removed
+      (matching v1's LabelsBuilder.Del, which deletes the name from every label
+      category). Grouping by `msg` after the rename must therefore collapse to a
+      single series whose `msg` is absent. Pre-fix the v2 engine kept the parsed
+      source column `msg` (the projection only dropped rename sources of type
+      stream-label, not parsed/metadata), so this produced one series per distinct
+      msg value instead of the single v1 series. Must equal v1.
+    requires:
+      log_format: logfmt
+      detected_fields:
+        - msg


### PR DESCRIPTION
**What this PR does / why we need it**:

##### Summary

The v2 query engine did not remove the **source** label of a `label_format` rename (`| label_format dst=src`) when the source came from a parsed field (e.g. `| json` / `| logfmt`) or structured metadata. The classic (v1) engine deletes the source label in all of these cases, so the same query returned an extra label in v2.

##### Root cause

label_format dst=src is a rename, which must drop src. In v2, the source drop happens in [newExpandPipeline](https://github.com/grafana/loki/blob/28e27ef49c7672ed4704c34f504bd6be790bc919/pkg/engine/internal/executor/project.go#L155), but the guard only fired for ColumnTypeLabel. This causes a mismatch with v1 engine, which removes the name from every label category (stream label, structured metadata, and parsed), not just stream labels.

##### Fix

Broaden the guard to drop the source for all label-like column types (Label, Parsed, Metadata, Ambiguous). Builtin and generated columns (timestamp, message, value, __error__) are intentionally preserved.
