### PR TITLE
chore: Remove plan printing from the hot path

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -565,12 +565,10 @@ func printPhysicalPlanSummary(q *query, plan *physical.Plan, duration time.Durat
 		otherDuration = calculateResidual(duration, indexQueryDuration, optimizeDuration)
 
 		planLen int
-		planStr string
 	)
 
 	if plan != nil {
 		planLen = plan.Len()
-		planStr = physical.PrintAsTree(plan)
 	}
 
 	level.Info(q.Logger()).Log(
@@ -597,6 +595,9 @@ func printPhysicalPlanSummary(q *query, plan *physical.Plan, duration time.Durat
 
 	// PrintAsTree can take significant amount of time, so get it off the hot path.
 	go func() {
+		if plan == nil {
+			return
+		}
 		plan := physical.PrintAsTree(plan)
 		level.Debug(q.Logger()).Log(
 			"msg", "physical-plan",
@@ -649,6 +650,7 @@ func (e *Engine) metastoreSectionsResolver(ctx context.Context, parent *query, l
 			return nil, fmt.Errorf("index query: build workflow: %w", err)
 		}
 
+		// Disable admission lanes for metastore queries
 		useAdmissionLanes := false
 		wf, err := q.Prepare(ctx, plan, useAdmissionLanes)
 		if err != nil {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -551,10 +551,6 @@ func (e *Engine) buildPhysicalPlan(ctx context.Context, q *query, params logql.P
 		return nil, ErrNotSupported
 	}
 
-	span.SetAttributes(
-		attribute.String("plan", physical.PrintAsTree(physicalPlan)),
-	)
-
 	span.SetStatus(codes.Ok, "")
 	return physicalPlan, nil
 }
@@ -597,11 +593,16 @@ func printPhysicalPlanSummary(q *query, plan *physical.Plan, duration time.Durat
 		}),
 
 		"rules_fired", encodePhysicalRules(rules),
-
-		// Large plans result in log line truncation, retain the other
-		// kvs by moving this to the end.
-		"plan", planStr,
 	)
+
+	// PrintAsTree can take significant amount of time, so get it off the hot path.
+	go func() {
+		plan := physical.PrintAsTree(plan)
+		level.Debug(q.Logger()).Log(
+			"msg", "physical-plan",
+			"plan", plan,
+		)
+	}()
 }
 
 func (e *Engine) metastoreSectionsResolver(ctx context.Context, parent *query, logger log.Logger, cacheEnabled bool) physical.MetastoreSectionsResolver {
@@ -645,15 +646,14 @@ func (e *Engine) metastoreSectionsResolver(ctx context.Context, parent *query, l
 
 			return nil
 		}(); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("index query: build workflow: %w", err)
 		}
 
-		// Disable admission lanes for metastore queries
 		useAdmissionLanes := false
 		wf, err := q.Prepare(ctx, plan, useAdmissionLanes)
 		if err != nil {
 			q.RecordError(ctx, err)
-			return nil, fmt.Errorf("index query: build workflow: %w", err)
+			return nil, fmt.Errorf("index query: prepare workflow: %w", err)
 		}
 		defer func() {
 			start := time.Now()

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -598,10 +598,10 @@ func printPhysicalPlanSummary(q *query, plan *physical.Plan, duration time.Durat
 		if plan == nil {
 			return
 		}
-		plan := physical.PrintAsTree(plan)
+		planStr := physical.PrintAsTree(plan)
 		level.Debug(q.Logger()).Log(
-			"msg", "physical-plan",
-			"plan", plan,
+			"msg", "physical-plan-detail",
+			"plan", planStr,
 		)
 	}()
 }
@@ -647,7 +647,7 @@ func (e *Engine) metastoreSectionsResolver(ctx context.Context, parent *query, l
 
 			return nil
 		}(); err != nil {
-			return nil, fmt.Errorf("index query: build workflow: %w", err)
+			return nil, err
 		}
 
 		// Disable admission lanes for metastore queries
@@ -655,7 +655,7 @@ func (e *Engine) metastoreSectionsResolver(ctx context.Context, parent *query, l
 		wf, err := q.Prepare(ctx, plan, useAdmissionLanes)
 		if err != nil {
 			q.RecordError(ctx, err)
-			return nil, fmt.Errorf("index query: prepare workflow: %w", err)
+			return nil, fmt.Errorf("index query: build workflow: %w", err)
 		}
 		defer func() {
 			start := time.Now()

--- a/pkg/engine/engine_query.go
+++ b/pkg/engine/engine_query.go
@@ -160,7 +160,8 @@ func (q *query) Prepare(ctx context.Context, plan *physical.Plan, useAdmissionLa
 
 	// The execution plan can be way more verbose than the physical plan, so we
 	// only log it at debug level.
-	level.Debug(q.logger).Log(
+	// Sprint is expensive on large workflows due to iterating all the nodes, so also execute it off the hot path.
+	go level.Debug(q.logger).Log(
 		"msg", "execution-plan-detail",
 		"plan", workflow.Sprint(wf),
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
It turns out that printing plans can be expensive when there are a lot of nodes in a query (Over 1 second!) which contributed to high "Staging" times in large queries before they start doing any work.
This PR:
* Only prints the physical plan once
* Pushes printing of physical & workflow plans off the hot path using goroutines. 

This PR reduced the staging time from 1.3s down to 500ms on the queries I tested.

I couldn't see an obvious way to optimize the print functions themselves. I also checked that nothing later mutates the plan passed to the goroutine, but this solution still feels brittle to me - I'm open to suggestions!