### PR TITLE
chore: Enabling batching multiple HTTP/2 sends

### DIFF
--- a/pkg/engine/internal/scheduler/wire/peer.go
+++ b/pkg/engine/internal/scheduler/wire/peer.go
@@ -149,6 +149,7 @@ func (p *Peer) handleIncoming(ctx context.Context) error {
 }
 
 func (p *Peer) handleOutgoing(ctx context.Context) error {
+	var batch []Frame
 	for {
 		select {
 		case <-ctx.Done():
@@ -156,10 +157,25 @@ func (p *Peer) handleOutgoing(ctx context.Context) error {
 		case <-p.done:
 			return nil // Closed connection.
 		case frame := <-p.outgoing:
-			if err := p.Conn.Send(ctx, frame); err != nil && ctx.Err() == nil {
-				level.Warn(p.Logger).Log("msg", "failed to send message", "error", err)
-				p.notifyError(frame, err)
+			batch = append(batch[:0], frame)
+			drainOutgoing(p.outgoing, &batch)
+			if err := p.Conn.SendBatch(ctx, batch); err != nil && ctx.Err() == nil {
+				level.Warn(p.Logger).Log("msg", "failed to send messages", "error", err, "batch", len(batch))
+				for _, f := range batch {
+					p.notifyError(f, err)
+				}
 			}
+		}
+	}
+}
+
+func drainOutgoing(ch <-chan Frame, batch *[]Frame) {
+	for {
+		select {
+		case f := <-ch:
+			*batch = append(*batch, f)
+		default:
+			return
 		}
 	}
 }

--- a/pkg/engine/internal/scheduler/wire/wire.go
+++ b/pkg/engine/internal/scheduler/wire/wire.go
@@ -43,7 +43,7 @@ type Conn interface {
 	//
 	// Send returns an error if the context is canceled or if the connection is
 	// closed.
-	Send(context.Context, Frame) error
+	SendBatch(context.Context, []Frame) error
 
 	// Recv receives the next Frame from the peer. Recv blocks until a Frame is
 	// available. Recv returns an error if the context is canceled or if the

--- a/pkg/engine/internal/scheduler/wire/wire_http2.go
+++ b/pkg/engine/internal/scheduler/wire/wire_http2.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -177,6 +178,7 @@ type http2Conn struct {
 	cleanup            func() // Optional cleanup function
 
 	writeMu   sync.Mutex
+	writeBuf  bytes.Buffer // reusable encode buffer, guarded by writeMu
 	closeOnce sync.Once
 	closed    chan struct{}
 
@@ -228,8 +230,11 @@ func (c *http2Conn) readLoop(ctx context.Context) {
 	}
 }
 
-// Send sends a frame over the connection.
-func (c *http2Conn) Send(ctx context.Context, frame Frame) error {
+func (c *http2Conn) SendBatch(ctx context.Context, frames []Frame) error {
+	if len(frames) == 0 {
+		return nil
+	}
+
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
 
@@ -243,19 +248,25 @@ func (c *http2Conn) Send(ctx context.Context, frame Frame) error {
 	default:
 	}
 
-	err := c.codec.EncodeTo(c.writer, frame)
-	if err != nil && isHTTP2Error(err) {
-		return ErrConnClosed
-	} else if err != nil {
-		return fmt.Errorf("write frame: %w", err)
+	c.writeBuf.Reset()
+	for _, frame := range frames {
+		if err := c.codec.EncodeTo(&c.writeBuf, frame); err != nil {
+			return fmt.Errorf("encode frame: %w", err)
+		}
 	}
 
-	// Flush after each frame to ensure immediate delivery
-	if c.responseController != nil {
-		err := c.responseController.Flush()
-		if err != nil && isHTTP2Error(err) {
+	if _, err := c.writer.Write(c.writeBuf.Bytes()); err != nil {
+		if isHTTP2Error(err) {
 			return ErrConnClosed
-		} else if err != nil {
+		}
+		return fmt.Errorf("write frames: %w", err)
+	}
+
+	if c.responseController != nil {
+		if err := c.responseController.Flush(); err != nil {
+			if isHTTP2Error(err) {
+				return ErrConnClosed
+			}
 			return fmt.Errorf("flush response: %w", err)
 		}
 	}

--- a/pkg/engine/internal/scheduler/wire/wire_http2_test.go
+++ b/pkg/engine/internal/scheduler/wire/wire_http2_test.go
@@ -60,7 +60,7 @@ func TestHTTP2BasicConnectivity(t *testing.T) {
 
 	// Send a frame from client to server
 	testFrame := wire.AckFrame{ID: 42}
-	err = clientConn.Send(ctx, testFrame)
+	err = clientConn.SendBatch(ctx, []wire.Frame{testFrame})
 	require.NoError(t, err)
 
 	// Receive on server
@@ -70,7 +70,7 @@ func TestHTTP2BasicConnectivity(t *testing.T) {
 
 	// Send a frame back from server to client
 	responseFrame := wire.AckFrame{ID: 43}
-	err = serverConn.Send(ctx, responseFrame)
+	err = serverConn.SendBatch(ctx, []wire.Frame{responseFrame})
 	require.NoError(t, err)
 
 	// Receive on client
@@ -525,7 +525,7 @@ func TestHTTP2MessageFrameSerialization(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Send message frame
 			frame := wire.MessageFrame{ID: 123, Message: tc.message}
-			err := clientConn.Send(ctx, frame)
+			err := clientConn.SendBatch(ctx, []wire.Frame{frame})
 			require.NoError(t, err)
 
 			// Receive and verify
@@ -584,7 +584,7 @@ func TestHTTP_NoPanicOnServerWriteAfterClose(t *testing.T) {
 	for range 100 {
 		wg.Go(func() {
 			for range 10_000 {
-				err := serverConn.Send(ctx, wire.AckFrame{ID: 1})
+				err := serverConn.SendBatch(ctx, []wire.Frame{wire.AckFrame{ID: 1}})
 				if err != nil && errors.Is(err, wire.ErrConnClosed) {
 					return
 				}
@@ -641,7 +641,7 @@ func TestHTTP_NoPanicOnClientWriteAfterClose(t *testing.T) {
 	for range 100 {
 		wg.Go(func() {
 			for range 10_000 {
-				err := clientConn.Send(ctx, wire.AckFrame{ID: 1})
+				err := clientConn.SendBatch(ctx, []wire.Frame{wire.AckFrame{ID: 1}})
 				if err != nil && errors.Is(err, wire.ErrConnClosed) {
 					return
 				}

--- a/pkg/engine/internal/scheduler/wire/wire_local.go
+++ b/pkg/engine/internal/scheduler/wire/wire_local.go
@@ -136,15 +136,17 @@ type localConn struct {
 
 var _ Conn = (*localConn)(nil)
 
-func (c *localConn) Send(ctx context.Context, frame Frame) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-c.alive.Done(): // Conn closed
-		return ErrConnClosed
-	case c.write <- frame:
-		return nil
+func (c *localConn) SendBatch(ctx context.Context, frames []Frame) error {
+	for _, frame := range frames {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-c.alive.Done(): // Conn closed
+			return ErrConnClosed
+		case c.write <- frame:
+		}
 	}
+	return nil
 }
 
 func (c *localConn) Recv(ctx context.Context) (Frame, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR batches multiple waiting frames into a single HTTP/2 DATA message if possible.
When under load, profiles show that a lot of time is spent in syscalls related to sending data. This PR attempts to reduce that overhead by grouping Frames into single HTTP/2 messages on the wire.

Tested against a query which reduced it from 28s E2E down to 22s E2E. I also think this will help when the scheduler is under pressure, though I don't have evidence for that.