### PR TITLE
docs: Backport mermaid fix 3.6

### DIFF
--- a/docs/sources/operations/loki-canary/_index.md
+++ b/docs/sources/operations/loki-canary/_index.md
@@ -17,7 +17,7 @@ artificial log lines,
 such that Loki Canary forms information about the performance of the Loki cluster.
 The information is available as Prometheus time series metrics.
 
-```mermaid
+{{< mermaid >}}
 graph LR
     subgraph nodes["x Node"]
         lc["loki-canary"] --> lf["log file"] --> al["Alloy"]
@@ -25,7 +25,7 @@ graph LR
 
     al -->|push| loki
     lc -->|websocket| loki
-```
+{{< /mermaid >}}
 
 Loki Canary writes a log to standard output and stores the timestamp in an internal
 array. The contents look something like this:


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of https://github.com/grafana/loki/pull/22384 to the 3.6 branch so that the commit is signed.