### PR TITLE
fix(engine): Handle scheduler and worker connection drops correctly

### DIFF
--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -131,7 +131,7 @@ func (s *Scheduler) run(ctx context.Context) error {
 func (s *Scheduler) runAcceptLoop(ctx context.Context) error {
 	for {
 		conn, err := s.listener.Accept(ctx)
-		if err != nil && ctx.Err() == nil {
+		if err != nil && ctx.Err() != nil {
 			return nil
 		} else if err != nil {
 			level.Warn(s.logger).Log("msg", "failed to accept connection", "err", err)

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -188,10 +188,10 @@ func (s *Scheduler) handleConn(ctx context.Context, conn wire.Conn) {
 	// Handle communication with the peer until the context is canceled or some
 	// error occurs.
 	err := peer.Serve(ctx)
-	if err != nil && ctx.Err() == nil && !errors.Is(err, wire.ErrConnClosed) {
-		level.Warn(logger).Log("msg", "serve error", "err", err)
-	} else {
+	if ctx.Err() != nil || errors.Is(err, wire.ErrConnClosed) {
 		level.Debug(logger).Log("msg", "connection closed")
+	} else if err != nil {
+		level.Warn(logger).Log("msg", "serve error", "err", err)
 	}
 
 	// Signal any worker routines associated with this connection to exit.

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -188,7 +188,7 @@ func (s *Scheduler) handleConn(ctx context.Context, conn wire.Conn) {
 	// Handle communication with the peer until the context is canceled or some
 	// error occurs.
 	err := peer.Serve(ctx)
-	if err != nil && ctx.Err() != nil && !errors.Is(err, wire.ErrConnClosed) {
+	if err != nil && ctx.Err() == nil && !errors.Is(err, wire.ErrConnClosed) {
 		level.Warn(logger).Log("msg", "serve error", "err", err)
 	} else {
 		level.Debug(logger).Log("msg", "connection closed")

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -131,7 +131,7 @@ func (s *Scheduler) run(ctx context.Context) error {
 func (s *Scheduler) runAcceptLoop(ctx context.Context) error {
 	for {
 		conn, err := s.listener.Accept(ctx)
-		if err != nil && ctx.Err() != nil {
+		if err != nil && ctx.Err() == nil {
 			return nil
 		} else if err != nil {
 			level.Warn(s.logger).Log("msg", "failed to accept connection", "err", err)

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -316,10 +316,10 @@ func (w *Worker) handleConn(ctx context.Context, conn wire.Conn) {
 	// Handle communication with the peer until the context is canceled or some
 	// error occurs.
 	err := peer.Serve(ctx)
-	if err != nil && ctx.Err() == nil && !errors.Is(err, wire.ErrConnClosed) {
-		level.Warn(logger).Log("msg", "serve error", "err", err)
-	} else {
+	if ctx.Err() != nil || errors.Is(err, wire.ErrConnClosed) {
 		level.Debug(logger).Log("msg", "connection closed")
+	} else if err != nil {
+		level.Warn(logger).Log("msg", "serve error", "err", err)
 	}
 }
 
@@ -345,7 +345,11 @@ func (w *Worker) schedulerLoop(ctx context.Context, addr net.Addr) error {
 		// terminated connections, so we reset it as long as the dial succeeds.
 		bo.Reset()
 
-		if err := w.handleSchedulerConn(ctx, logger, conn); err != nil && ctx.Err() == nil {
+		err = w.handleSchedulerConn(ctx, logger, conn)
+		if ctx.Err() != nil {
+			level.Debug(logger).Log("msg", "context canceled. stopping scheduler loop")
+			break
+		} else if err != nil {
 			level.Warn(logger).Log("msg", "connection to scheduler closed; will reconnect after backoff", "err", err)
 			bo.Wait()
 			continue

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -316,7 +316,7 @@ func (w *Worker) handleConn(ctx context.Context, conn wire.Conn) {
 	// Handle communication with the peer until the context is canceled or some
 	// error occurs.
 	err := peer.Serve(ctx)
-	if err != nil && ctx.Err() != nil && !errors.Is(err, wire.ErrConnClosed) {
+	if err != nil && ctx.Err() == nil && !errors.Is(err, wire.ErrConnClosed) {
 		level.Warn(logger).Log("msg", "serve error", "err", err)
 	} else {
 		level.Debug(logger).Log("msg", "connection closed")

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -345,7 +345,7 @@ func (w *Worker) schedulerLoop(ctx context.Context, addr net.Addr) error {
 		// terminated connections, so we reset it as long as the dial succeeds.
 		bo.Reset()
 
-		if err := w.handleSchedulerConn(ctx, logger, conn); err != nil && ctx.Err() != nil {
+		if err := w.handleSchedulerConn(ctx, logger, conn); err != nil && ctx.Err() == nil {
 			level.Warn(logger).Log("msg", "connection to scheduler closed; will reconnect after backoff", "err", err)
 			bo.Wait()
 			continue

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -280,7 +280,7 @@ func (w *Worker) run(ctx context.Context) error {
 func (w *Worker) runAcceptLoop(ctx context.Context) {
 	for {
 		conn, err := w.listener.Accept(ctx)
-		if err != nil && ctx.Err() == nil {
+		if err != nil && ctx.Err() != nil {
 			return
 		} else if err != nil {
 			level.Warn(w.logger).Log("msg", "failed to accept connection", "err", err)

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -280,7 +280,7 @@ func (w *Worker) run(ctx context.Context) error {
 func (w *Worker) runAcceptLoop(ctx context.Context) {
 	for {
 		conn, err := w.listener.Accept(ctx)
-		if err != nil && ctx.Err() != nil {
+		if err != nil && ctx.Err() == nil {
 			return
 		} else if err != nil {
 			level.Warn(w.logger).Log("msg", "failed to accept connection", "err", err)


### PR DESCRIPTION
In a handful of spots we were checking a construction like:

```
if err != nil && ctx.Err() != nil {
```

to mean if there's an error but it's not b/c the service context is shutting down then log it or return it or whatever. i believe this is incorrect and it should be:

```
if err != nil && ctx.Err() == nil {
```

in the second case if we have an error but the context error IS nil then we want to make sure we log/return it.