### PR TITLE
fix(v1-engine): Shard mapper inflating outer sum over non-additive range aggregations

### DIFF
--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -63,6 +63,8 @@ func TestMappingEquivalence(t *testing.T) {
 		{`avg_over_time({a=~".+"} | logfmt | unwrap value [1s]) without (stream)`, true, nil},
 		{`avg_over_time({a=~".+"} | logfmt | drop level | unwrap value [1s])`, true, nil},
 		{`avg_over_time({a=~".+"} | logfmt | drop level | unwrap value [1s]) without (stream)`, true, nil},
+		{`sum(avg_over_time({a=~".+"} | logfmt | unwrap value [1s]) by (a))`, true, nil},
+		{`sum(max_over_time({a=~".+"} | logfmt | unwrap value [1s]) by (a))`, true, nil},
 		{`quantile_over_time(0.99, {a=~".+"} | logfmt | unwrap value [1s])`, true, []string{ShardQuantileOverTime}},
 		{`quantile_over_time(0.99, {a=~".+"} | logfmt | unwrap value [1s] offset 2s)`, true, []string{ShardQuantileOverTime}},
 		{

--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -242,6 +242,19 @@ func (m ShardMapper) mapVectorAggregationExpr(expr *syntax.VectorAggregationExpr
 		switch expr.Operation {
 
 		case syntax.OpTypeSum:
+			if syntax.ReducesLabels(expr.Left) {
+				// skip the opaque per-shard rewrite at this level. If labels are
+				// reduced (e.g. an inner range aggregation has by/without, or a
+				// parser-stage drops/keeps/renames labels), the same series may
+				// exist on multiple shards. Per-shard partial results from a
+				// non-additive inner range aggregation (avg_over_time,
+				// max_over_time, ...) cannot be combined by an outer sum.
+				// Fall through to recursively map the inner expression first —
+				// mapRangeAggregationExpr knows how to decompose each range
+				// aggregation correctly (e.g. avg_over_time into
+				// sum_over_time/count_over_time) — and then re-wrap with sum.
+				break
+			}
 			// sum(x) -> sum(sum(x, shard=1) ++ sum(x, shard=2)...)
 			return m.wrappedShardedVectorAggr(expr, r)
 

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -205,9 +205,11 @@ func TestMappingStrings(t *testing.T) {
 			in: `max(sum by (abc) (rate({foo="bar"} | json | label_format bazz=buzz [5m])))`,
 			out: `max(
 				sum by (abc) (
-					downstream<sumby(abc)(rate({foo="bar"}|json|label_formatbazz=buzz[5m])),shard=0_of_2>
-					++
-					downstream<sumby(abc)(rate({foo="bar"}|json|label_formatbazz=buzz[5m])),shard=1_of_2>
+					sum without() (
+						downstream<rate({foo="bar"}|json|label_formatbazz=buzz[5m]),shard=0_of_2>
+						++
+						downstream<rate({foo="bar"}|json|label_formatbazz=buzz[5m]),shard=1_of_2>
+					)
 				)
 			)`,
 		},
@@ -323,9 +325,11 @@ func TestMappingStrings(t *testing.T) {
 		{
 			in: `sum(count_over_time({foo="bar"} | logfmt | label_format bar=baz | bar="buz" [5m])) by (bar)`,
 			out: `sum by (bar) (
-				downstream<sum by (bar) (count_over_time({foo="bar"}|logfmt|label_formatbar=baz|bar="buz"[5m])),shard=0_of_2>
-				++
-				downstream<sum by (bar) (count_over_time({foo="bar"}|logfmt|label_formatbar=baz|bar="buz"[5m])),shard=1_of_2>
+				sum without() (
+					downstream<count_over_time({foo="bar"}|logfmt|label_formatbar=baz|bar="buz"[5m]),shard=0_of_2>
+					++
+					downstream<count_over_time({foo="bar"}|logfmt|label_formatbar=baz|bar="buz"[5m]),shard=1_of_2>
+				)
 			)`,
 		},
 		{
@@ -401,18 +405,50 @@ func TestMappingStrings(t *testing.T) {
 			)`,
 		},
 		{
+			in: `sum(avg_over_time({job=~"myapps.*"} |= "stats" | json busy="utilization" | unwrap busy [5m]) by (cluster))`,
+			out: `sum(
+				(
+					sum by (cluster) (
+						downstream<sum by (cluster) (sum_over_time({job=~"myapps.*"}|="stats" | json busy="utilization" | unwrap busy [5m])),shard=0_of_2>
+						++
+						downstream<sum by (cluster) (sum_over_time({job=~"myapps.*"}|="stats" | json busy="utilization" | unwrap busy [5m])),shard=1_of_2>
+					)
+					/
+					sum by (cluster) (
+						downstream<sum by (cluster) (count_over_time({job=~"myapps.*"}|="stats" | json busy="utilization" [5m])),shard=0_of_2>
+						++
+						downstream<sum by (cluster) (count_over_time({job=~"myapps.*"}|="stats" | json busy="utilization" [5m])),shard=1_of_2>
+					)
+				)
+			)`,
+		},
+		{
+			in: `sum(max_over_time({job=~"myapps.*"} |= "stats" | json busy="utilization" | unwrap busy [5m]) by (cluster))`,
+			out: `sum(
+				max by (cluster) (
+					downstream<max_over_time({job=~"myapps.*"}|="stats" | json busy="utilization" | unwrap busy [5m]) by (cluster),shard=0_of_2>
+					++
+					downstream<max_over_time({job=~"myapps.*"}|="stats" | json busy="utilization" | unwrap busy [5m]) by (cluster),shard=1_of_2>
+				)
+			)`,
+		},
+		{
 			in: `avg_over_time({job=~"myapps.*"} |= "stats" | json | keep busy | unwrap busy [5m])`,
 			out: `(
 				sum without() (
-					downstream<sum without() (sum_over_time({job=~"myapps.*"} |="stats" | json | keep busy | unwrap busy [5m])),shard=0_of_2>
-					++
-					downstream<sum without() (sum_over_time({job=~"myapps.*"} |="stats" | json | keep busy | unwrap busy [5m])),shard=1_of_2>
+					sum without() (
+						downstream<sum_over_time({job=~"myapps.*"} |="stats" | json | keep busy | unwrap busy [5m]),shard=0_of_2>
+						++
+						downstream<sum_over_time({job=~"myapps.*"} |="stats" | json | keep busy | unwrap busy [5m]),shard=1_of_2>
+					)
 				)
 				/
 				sum without(busy) (
-					downstream<sum without(busy) (count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m])),shard=0_of_2>
-					++
-					downstream<sum without(busy) (count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m])),shard=1_of_2>
+					sum without() (
+						downstream<count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m]),shard=0_of_2>
+						++
+						downstream<count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m]),shard=1_of_2>
+					)
 				)
 			)`,
 		},
@@ -420,15 +456,19 @@ func TestMappingStrings(t *testing.T) {
 			in: `avg_over_time({job=~"myapps.*"} |= "stats" | json | keep busy | unwrap busy [5m]) without (foo)`,
 			out: `(
 				sum without(foo) (
-					downstream<sum without(foo) (sum_over_time({job=~"myapps.*"} |="stats" | json | keep busy | unwrap busy [5m])),shard=0_of_2>
-					++
-					downstream<sum without(foo) (sum_over_time({job=~"myapps.*"} |="stats" | json | keep busy | unwrap busy [5m])),shard=1_of_2>
+					sum without() (
+						downstream<sum_over_time({job=~"myapps.*"} |="stats" | json | keep busy | unwrap busy [5m]),shard=0_of_2>
+						++
+						downstream<sum_over_time({job=~"myapps.*"} |="stats" | json | keep busy | unwrap busy [5m]),shard=1_of_2>
+					)
 				)
 				/
 				sum without(foo,busy) (
-					downstream<sum without(foo,busy) (count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m])),shard=0_of_2>
-					++
-					downstream<sum without(foo,busy) (count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m])),shard=1_of_2>
+					sum without() (
+						downstream<count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m]),shard=0_of_2>
+						++
+						downstream<count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m]),shard=1_of_2>
+					)
 				)
 			)`,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a sharding-correctness bug in the LogQL shard mapper: queries shaped as `sum(<non-additive-range-agg>(...) by (X))` — e.g. `sum(avg_over_time(... | unwrap foo [5m]) by (container))`, `sum(max_over_time(...) by (container))` were returning results inflated by approximately the shard count when sharding was enabled.

**Root cause**

`mapVectorAggregationExpr`'s `OpTypeSum` case unconditionally invoked `wrappedShardedVectorAggr`, which treats the inner expression as opaque and rewrites the query as:

sum( Concat[ per-shard sum((...) by (X)) ] )

For additive inner range aggregations (`rate`, `count_over_time`, `sum_over_time`, `bytes_over_time`, `bytes_rate`) this is mathematically correct — per-shard partial sums combine under the outer sum. But for non-additive inner range aggregations — `avg_over_time`, `max_over_time`, `min_over_time`, `stddev_over_time`, etc. — each shard computes its own local aggregate over series that share the by-group label set `X` within that shard, and the outer sum then adds those local values together. Since the same `X` group can have streams routed to multiple shards (sharding is by full stream hash, not by `X`), the same group's contribution gets counted once per shard.

The sibling cases `OpTypeMin`, `OpTypeMax`, `OpTypeCount` already had a `ReducesLabels(expr.Left)` guard to skip this opaque rewrite when the inner expression had label-reducing structure (inner `by/without` grouping, `label_format` rename, `keep`, `drop`). `OpTypeSum` was missing it.

**Fix**

Added the same `ReducesLabels(expr.Left)` check to `OpTypeSum`. When the inner expression reduces labels, `OpTypeSum` now falls through to the existing "shard a child node" path, which recursively calls `m.Map` on the inner expression. `mapRangeAggregationExpr` already knows how to correctly decompose each range aggregation:

- `avg_over_time(...) by (X)` → `sum by (X)(sum_over_time(...)) / sum by (X)(count_over_time(...))`
- `max_over_time(...) by (X)` → `max by (X)(Concat[max_over_time(...) by (X)])`

The outer `sum` is then re-wrapped around the correctly-sharded inner expression. For additive inner aggregations the new rewrite is mathematically equivalent to the old one (just with the cross-shard merge attached at a different node), so nothing else regresses.