### PR TITLE
test: Add e2e test running Loki in a container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,6 +406,11 @@ test: all ## run the unit tests
 test-integration:
 	$(GOTEST) -count=1 -v -tags=integration -timeout 15m ./integration
 
+# Container-based end-to-end tests (see integration/e2e/README.md). These build
+# the Loki image and run it in Docker, so they need a running Docker daemon.
+test-integration-e2e: loki-image
+	LOKI_IMAGE=$(LOKI_IMAGE) $(GOTEST) -count=1 -v -tags=requires_docker -timeout 15m ./integration/e2e/...
+
 compare-coverage:
 	./tools/diff_coverage.sh $(old) $(new) $(packages)
 

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5
-	github.com/prometheus/prometheus v0.311.3-0.20260415124738-34cebfe9536c
+	github.com/prometheus/prometheus v0.311.3
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/segmentio/fasthash v1.0.3
 	github.com/sony/gobreaker/v2 v2.4.0
@@ -147,6 +147,8 @@ require (
 	k8s.io/utils v0.0.0-20251218160917-61b37f7a4624
 	zombiezen.com/go/sqlite v1.4.2
 )
+
+require github.com/grafana/e2e v0.1.2-0.20260504080022-0f57c9f0da68
 
 require (
 	cel.dev/expr v0.25.1 // indirect
@@ -441,3 +443,8 @@ replace github.com/grafana/loki/pkg/push => ./pkg/push
 replace github.com/influxdata/go-syslog/v3 => github.com/leodido/go-syslog/v4 v4.4.0
 
 replace github.com/thanos-io/objstore => github.com/grafana/objstore v0.0.0-20260507144615-6c81ea69c9a9
+
+// github.com/grafana/e2e (used by integration/e2e) requires a newer prometheus
+// tag than the commit Loki pins. Keep Loki's pinned prometheus; e2e only uses the
+// stable model/labels and prompb packages.
+replace github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.311.3-0.20260415124738-34cebfe9536c

--- a/go.sum
+++ b/go.sum
@@ -490,6 +490,8 @@ github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5T
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/grafana/dskit v0.0.0-20260605193902-3f568b4219b0 h1:M5ol2sYaIAitAEeJqVF6EiB0EyEnN5uq6seGzrBjmcI=
 github.com/grafana/dskit v0.0.0-20260605193902-3f568b4219b0/go.mod h1:6n9jITeGJSb4RIAEj9RyeXaRG3hoC1KNl22tRiVPQ/8=
+github.com/grafana/e2e v0.1.2-0.20260504080022-0f57c9f0da68 h1:+GLaDMc1zkYNTMHZq3ljGaRSm1IcOxQvpBNn0YUyh60=
+github.com/grafana/e2e v0.1.2-0.20260504080022-0f57c9f0da68/go.mod h1:o6aUPNFrl7H0XjIdBpXSU2Gou6vVwctVBuSvWPN7Ogg=
 github.com/grafana/gomemcache v0.0.0-20251127154401-74f93547077b h1:5qp8/5YPt/Z2RW5QHsxvwE05+LWQYIXydP2MwOkMfb8=
 github.com/grafana/gomemcache v0.0.0-20251127154401-74f93547077b/go.mod h1:j/s0jkda4UXTemDs7Pgw/vMT06alWc42CHisvYac0qw=
 github.com/grafana/jsonparser v0.0.0-20241004153430-023329977675 h1:U94jQ2TQr1m3HNyE8efSdyaBbDrdPaWImXyenuKZ/nw=

--- a/integration/e2e/README.md
+++ b/integration/e2e/README.md
@@ -1,0 +1,57 @@
+# Container-based end-to-end tests
+
+These tests start Loki **containers** on a Docker network and exercise them
+via their API. They use the [`github.com/grafana/e2e`](https://github.com/grafana/e2e) framework
+(`NewScenario`, `NewHTTPService`, readiness probes, …), which shells out to the
+`docker` CLI to manage containers.
+
+This is different from the tests under [`integration`](../../integration),
+which run Loki targets inside the test binary. Here we test the actual published
+container image end to end.
+
+## Requirements
+
+- A running Docker daemon.
+- A Loki image to run. By default the tests read the image from the `LOKI_IMAGE`
+  environment variable, falling back to `grafana/loki:latest` when unset.
+
+## Running
+
+The easiest way is the Makefile target, which builds the local image and points
+the tests at it:
+
+```sh
+make test-integration-e2e
+```
+
+Or run them directly against an image of your choice:
+
+```sh
+# build the local image first (produces grafana/loki:<image-tag>)
+make loki-image
+
+LOKI_IMAGE=grafana/loki:$(./tools/image-tag) \
+  go test -tags requires_docker -v -timeout 15m ./integration/e2e/...
+```
+
+The tests are guarded by the `requires_docker` build tag, so a normal
+`go test ./...` does not pick them up.
+
+## Adding a test
+
+```go
+s, err := e2e.NewScenario("loki-e2e")
+require.NoError(t, err)
+defer s.Close()
+
+require.NoError(t, os.WriteFile(filepath.Join(s.SharedDir(), "config.yaml"), []byte(singleBinaryConfig), 0o644))
+
+loki := NewSingleBinary("loki")
+require.NoError(t, s.StartAndWaitReady(loki))
+
+c := NewClient(loki.HTTPEndpoint(), "")
+// ... push and query
+```
+
+The scenario's shared directory is mounted into every container at `/shared`,
+which is where the config and the filesystem object store live.

--- a/integration/e2e/loki.go
+++ b/integration/e2e/loki.go
@@ -1,0 +1,77 @@
+//go:build requires_docker
+
+package e2e
+
+import (
+	"os"
+
+	"github.com/grafana/e2e"
+)
+
+const (
+	httpPort = 3100
+	grpcPort = 9095
+)
+
+// singleBinaryConfig is a minimal all-in-one Loki configuration using the local
+// filesystem for object storage and an in-memory ring.
+// Storage lives under /loki, an ephemeral in-container path that is discarded
+// when the container is removed (--rm).
+const singleBinaryConfig = `
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9095
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+`
+
+// NewSingleBinary returns an all-in-one Loki service (every target in one
+// process) reading the config written to /shared/config.yaml. Extra command
+// line flags can be appended to override config values.
+func NewSingleBinary(name string, flags ...string) *e2e.HTTPService {
+	args := append([]string{
+		"-config.file=/shared/config.yaml",
+		"-target=all",
+	}, flags...)
+
+	img := "grafana/loki:latest"
+	if e := os.Getenv("LOKI_IMAGE"); e != "" {
+		img = e
+	}
+
+	svc := e2e.NewHTTPService(
+		name,
+		img,
+		// The image's entrypoint is the loki binary, so disable it and invoke
+		// the binary explicitly with our arguments.
+		e2e.NewCommandWithoutEntrypoint("/usr/bin/loki", args...),
+		e2e.NewHTTPReadinessProbe(httpPort, "/ready", 200, 299),
+		httpPort,
+		grpcPort,
+	)
+
+	return svc
+}

--- a/integration/e2e/loki_test.go
+++ b/integration/e2e/loki_test.go
@@ -1,0 +1,62 @@
+//go:build requires_docker
+
+// These tests need a running Docker daemon plus a Loki image.
+//
+// For example:
+//
+//	LOKI_IMAGE=grafana/loki:main-89ea0d4 go test -tags requires_docker ./integration/e2e/...
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/grafana/e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/integration/client"
+)
+
+// TestSingleBinaryPushAndQuery starts an all-in-one Loki container, pushes a log
+// line over the HTTP push API, and queries it back via query_range.
+func TestSingleBinaryPushAndQuery(t *testing.T) {
+	s, err := e2e.NewScenario("loki-e2e")
+	require.NoError(t, err)
+	defer s.Close()
+
+	// Write the Loki config into the shared directory mounted at /shared.
+	require.NoError(t, os.WriteFile(filepath.Join(s.SharedDir(), "config.yaml"), []byte(singleBinaryConfig), 0o644))
+
+	loki := NewSingleBinary("loki")
+	require.NoError(t, s.StartAndWaitReady(loki))
+
+	c := client.New("fake", "", "http://"+loki.HTTPEndpoint())
+
+	const logLine = "hello e2e world"
+	labels := map[string]string{"task": "e2e-test"}
+	pushedAt := time.Now()
+
+	require.NoError(t, c.PushLogLine(logLine, pushedAt, nil, labels))
+
+	// The push is acknowledged once it's in the ingester, but it may take a
+	// moment to become queryable, so poll.
+	require.Eventually(t, func() bool {
+		resp, err := c.RunRangeQueryWithStartEnd(t.Context(), `{task="e2e-test"}`, pushedAt.Add(-time.Minute), pushedAt.Add(time.Minute))
+		if err != nil {
+			t.Logf("query_range error (will retry): %v", err)
+			return false
+		}
+		assert.Equal(t, "streams", resp.Data.ResultType)
+		for _, stream := range resp.Data.Stream {
+			for _, val := range stream.Values {
+				if val[1] == logLine {
+					return true
+				}
+			}
+		}
+		return false
+	}, 30*time.Second, 500*time.Millisecond, "pushed log line was not returned by query_range")
+}

--- a/vendor/github.com/grafana/e2e/.golangci.yml
+++ b/vendor/github.com/grafana/e2e/.golangci.yml
@@ -1,0 +1,64 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - depguard
+    - errcheck
+    - govet
+    - ineffassign
+    - misspell
+    - revive
+    - staticcheck
+    - unused
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: "github.com/pkg/errors"
+              desc: use stdlib errors and fmt.Errorf with %w instead
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: empty-block
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: exported
+          disabled: true
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: superfluous-else
+        - name: time-naming
+        - name: unexported-return
+        - name: unreachable-code
+        - name: unused-parameter
+        - name: var-declaration
+        - name: var-naming
+    errcheck:
+      exclude-functions:
+        - (github.com/go-kit/log.Logger).Log
+
+formatters:
+  enable:
+    - goimports
+    - gofmt
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/grafana/e2e
+
+run:
+  timeout: 5m
+  build-tags:
+    - netgo
+    - requires_docker

--- a/vendor/github.com/grafana/e2e/LICENSE
+++ b/vendor/github.com/grafana/e2e/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 Grafana Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/grafana/e2e/Makefile
+++ b/vendor/github.com/grafana/e2e/Makefile
@@ -1,0 +1,14 @@
+.PHONY: test
+test:
+	go test -tags netgo -timeout 30m -race -count 1 ./...
+
+.PHONY: lint
+lint:
+	go run github.com/client9/misspell/cmd/misspell@v0.3.4 -error README.md LICENSE
+
+	# Configured via .golangci.yml.
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0 run
+
+.PHONY: integration
+integration:
+	go test -tags netgo,requires_docker -timeout 30m -v -count=1 ./

--- a/vendor/github.com/grafana/e2e/README.md
+++ b/vendor/github.com/grafana/e2e/README.md
@@ -1,0 +1,7 @@
+# Grafana E2E
+
+This library contains utilities that are useful for running E2E tests using docker containers.
+
+## License
+
+[Apache 2.0 License](https://github.com/grafana/dskit/blob/main/LICENSE)

--- a/vendor/github.com/grafana/e2e/composite_service.go
+++ b/vendor/github.com/grafana/e2e/composite_service.go
@@ -1,0 +1,93 @@
+// Package e2e provides utilities for running end-to-end tests using Docker containers.
+package e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/grafana/dskit/backoff"
+)
+
+// CompositeHTTPService abstract an higher-level service composed, under the hood,
+// by 2+ HTTPService.
+type CompositeHTTPService struct {
+	services []*HTTPService
+
+	// Generic retry backoff.
+	retryBackoff *backoff.Backoff
+}
+
+func NewCompositeHTTPService(services ...*HTTPService) *CompositeHTTPService {
+	return &CompositeHTTPService{
+		services: services,
+		retryBackoff: backoff.New(context.Background(), backoff.Config{
+			MinBackoff: 300 * time.Millisecond,
+			MaxBackoff: 600 * time.Millisecond,
+			MaxRetries: 50, // Sometimes the CI is slow ¯\_(ツ)_/¯
+		}),
+	}
+}
+
+func (s *CompositeHTTPService) NumInstances() int {
+	return len(s.services)
+}
+
+func (s *CompositeHTTPService) Instances() []*HTTPService {
+	return s.services
+}
+
+// WaitSumMetrics waits for at least one instance of each given metric names to be present and their sums, returning true
+// when passed to given isExpected(...).
+func (s *CompositeHTTPService) WaitSumMetrics(isExpected func(sums ...float64) bool, metricNames ...string) error {
+	return s.WaitSumMetricsWithOptions(isExpected, metricNames)
+}
+
+func (s *CompositeHTTPService) WaitSumMetricsWithOptions(isExpected func(sums ...float64) bool, metricNames []string, opts ...MetricsOption) error {
+	var (
+		sums    []float64
+		err     error
+		options = buildMetricsOptions(opts)
+	)
+
+	for s.retryBackoff.Reset(); s.retryBackoff.Ongoing(); {
+		sums, err = s.SumMetrics(metricNames, opts...)
+		if options.WaitMissingMetrics && errors.Is(err, errMissingMetric) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+
+		if isExpected(sums...) {
+			return nil
+		}
+
+		s.retryBackoff.Wait()
+	}
+
+	return fmt.Errorf("unable to find metrics %s with expected values. Last error: %v. Last values: %v", metricNames, err, sums)
+}
+
+// SumMetrics returns the sum of the values of each given metric names.
+func (s *CompositeHTTPService) SumMetrics(metricNames []string, opts ...MetricsOption) ([]float64, error) {
+	sums := make([]float64, len(metricNames))
+
+	for _, service := range s.services {
+		partials, err := service.SumMetrics(metricNames, opts...)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(partials) != len(sums) {
+			return nil, fmt.Errorf("unexpected mismatching sum metrics results (got %d, expected %d)", len(partials), len(sums))
+		}
+
+		for i := 0; i < len(sums); i++ {
+			sums[i] += partials[i]
+		}
+	}
+
+	return sums, nil
+}

--- a/vendor/github.com/grafana/e2e/logger.go
+++ b/vendor/github.com/grafana/e2e/logger.go
@@ -1,0 +1,44 @@
+package e2e
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+)
+
+// Global logger to use in integration tests. We use a global logger to simplify
+// writing integration tests and avoiding having to pass the logger instance
+// every time.
+var logger log.Logger
+
+func init() {
+	logger = NewLogger(os.Stdout)
+}
+
+type Logger struct {
+	w io.Writer
+}
+
+func NewLogger(w io.Writer) *Logger {
+	return &Logger{
+		w: w,
+	}
+}
+
+func (l *Logger) Log(keyvals ...interface{}) error {
+	log := strings.Builder{}
+	log.WriteString(time.Now().Format("15:04:05"))
+
+	for _, v := range keyvals {
+		log.WriteString(" " + fmt.Sprint(v))
+	}
+
+	log.WriteString("\n")
+
+	_, err := l.w.Write([]byte(log.String()))
+	return err
+}

--- a/vendor/github.com/grafana/e2e/metrics.go
+++ b/vendor/github.com/grafana/e2e/metrics.go
@@ -1,0 +1,167 @@
+package e2e
+
+import (
+	"math"
+
+	io_prometheus_client "github.com/prometheus/client_model/go"
+)
+
+func getMetricValue(m *io_prometheus_client.Metric) float64 {
+	if m.GetGauge() != nil {
+		return m.GetGauge().GetValue()
+	} else if m.GetCounter() != nil {
+		return m.GetCounter().GetValue()
+	} else if m.GetHistogram() != nil {
+		return m.GetHistogram().GetSampleSum()
+	} else if m.GetSummary() != nil {
+		return m.GetSummary().GetSampleSum()
+	}
+	return 0
+}
+
+func getMetricCount(m *io_prometheus_client.Metric) float64 {
+	if m.GetHistogram() != nil {
+		return float64(m.GetHistogram().GetSampleCount())
+	} else if m.GetSummary() != nil {
+		return float64(m.GetSummary().GetSampleCount())
+	}
+	return 0
+}
+
+func getValues(metrics []*io_prometheus_client.Metric, opts MetricsOptions) []float64 {
+	values := make([]float64, 0, len(metrics))
+	for _, m := range metrics {
+		values = append(values, opts.GetValue(m))
+	}
+	return values
+}
+
+func filterMetrics(metrics []*io_prometheus_client.Metric, opts MetricsOptions) []*io_prometheus_client.Metric {
+	// If no label matcher is configured, then no filtering should be done.
+	if len(opts.LabelMatchers) == 0 {
+		return metrics
+	}
+	if len(metrics) == 0 {
+		return metrics
+	}
+
+	filtered := make([]*io_prometheus_client.Metric, 0, len(metrics))
+
+	for _, m := range metrics {
+		metricLabels := map[string]string{}
+		for _, lp := range m.GetLabel() {
+			metricLabels[lp.GetName()] = lp.GetValue()
+		}
+
+		matches := true
+		for _, matcher := range opts.LabelMatchers {
+			if !matcher.Matches(metricLabels[matcher.Name]) {
+				matches = false
+				break
+			}
+		}
+
+		if !matches {
+			continue
+		}
+
+		filtered = append(filtered, m)
+	}
+
+	return filtered
+}
+
+func SumValues(values []float64) float64 {
+	sum := 0.0
+	for _, v := range values {
+		sum += v
+	}
+	return sum
+}
+
+func EqualsSingle(expected float64) func(float64) bool {
+	return func(v float64) bool {
+		return v == expected || (math.IsNaN(v) && math.IsNaN(expected))
+	}
+}
+
+// Equals is an isExpected function for WaitSumMetrics that returns true if given single sum is equals to given value.
+func Equals(value float64) func(sums ...float64) bool {
+	return func(sums ...float64) bool {
+		if len(sums) != 1 {
+			panic("equals: expected one value")
+		}
+		return sums[0] == value || math.IsNaN(sums[0]) && math.IsNaN(value)
+	}
+}
+
+// Greater is an isExpected function for WaitSumMetrics that returns true if given single sum is greater than given value.
+func Greater(value float64) func(sums ...float64) bool {
+	return func(sums ...float64) bool {
+		if len(sums) != 1 {
+			panic("greater: expected one value")
+		}
+		return sums[0] > value
+	}
+}
+
+// GreaterOrEqual is an isExpected function for WaitSumMetrics that returns true if given single sum is greater or equal than given value.
+func GreaterOrEqual(value float64) func(sums ...float64) bool {
+	return func(sums ...float64) bool {
+		if len(sums) != 1 {
+			panic("greater: expected one value")
+		}
+		return sums[0] >= value
+	}
+}
+
+// Less is an isExpected function for WaitSumMetrics that returns true if given single sum is less than given value.
+func Less(value float64) func(sums ...float64) bool {
+	return func(sums ...float64) bool {
+		if len(sums) != 1 {
+			panic("less: expected one value")
+		}
+		return sums[0] < value
+	}
+}
+
+// Between is an isExpected function for WaitSumMetrics that returns true if given single sum is greater than or equal to lower
+// and less than or equal to upper.
+func Between(lower, upper float64) func(sums ...float64) bool {
+	return func(sums ...float64) bool {
+		if len(sums) != 1 {
+			panic("equals: expected one value")
+		}
+		return sums[0] >= lower && sums[0] <= upper
+	}
+}
+
+// EqualsAmongTwo is an isExpected function for WaitSumMetrics that returns true if first sum is equal to the second.
+// NOTE: Be careful on scrapes in between of process that changes two metrics. Those are
+// usually not atomic.
+func EqualsAmongTwo(sums ...float64) bool {
+	if len(sums) != 2 {
+		panic("equalsAmongTwo: expected two values")
+	}
+	return sums[0] == sums[1]
+}
+
+// GreaterAmongTwo is an isExpected function for WaitSumMetrics that returns true if first sum is greater than second.
+// NOTE: Be careful on scrapes in between of process that changes two metrics. Those are
+// usually not atomic.
+func GreaterAmongTwo(sums ...float64) bool {
+	if len(sums) != 2 {
+		panic("greaterAmongTwo: expected two values")
+	}
+	return sums[0] > sums[1]
+}
+
+// LessAmongTwo is an isExpected function for WaitSumMetrics that returns true if first sum is smaller than second.
+// NOTE: Be careful on scrapes in between of process that changes two metrics. Those are
+// usually not atomic.
+func LessAmongTwo(sums ...float64) bool {
+	if len(sums) != 2 {
+		panic("lessAmongTwo: expected two values")
+	}
+	return sums[0] < sums[1]
+}

--- a/vendor/github.com/grafana/e2e/metrics_options.go
+++ b/vendor/github.com/grafana/e2e/metrics_options.go
@@ -1,0 +1,58 @@
+package e2e
+
+import (
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+var (
+	DefaultMetricsOptions = MetricsOptions{
+		GetValue:           getMetricValue,
+		WaitMissingMetrics: false,
+	}
+)
+
+// GetMetricValueFunc defined the signature of a function used to get the metric value.
+type GetMetricValueFunc func(m *io_prometheus_client.Metric) float64
+
+// MetricsOption defined the signature of a function used to manipulate options.
+type MetricsOption func(*MetricsOptions)
+
+// MetricsOptions is the structure holding all options.
+type MetricsOptions struct {
+	GetValue           GetMetricValueFunc
+	LabelMatchers      []*labels.Matcher
+	WaitMissingMetrics bool
+	SkipMissingMetrics bool
+}
+
+// WithMetricCount is an option to get the histogram/summary count as metric value.
+func WithMetricCount(opts *MetricsOptions) {
+	opts.GetValue = getMetricCount
+}
+
+// WithLabelMatchers is an option to filter only matching series.
+func WithLabelMatchers(matchers ...*labels.Matcher) MetricsOption {
+	return func(opts *MetricsOptions) {
+		opts.LabelMatchers = matchers
+	}
+}
+
+// WithWaitMissingMetrics is an option to wait whenever an expected metric is missing. If this
+// option is not enabled, will return error on missing metrics.
+func WaitMissingMetrics(opts *MetricsOptions) {
+	opts.WaitMissingMetrics = true
+}
+
+// SkipWaitMissingMetrics is an option to skip/ignore whenever an expected metric is missing.
+func SkipMissingMetrics(opts *MetricsOptions) {
+	opts.SkipMissingMetrics = true
+}
+
+func buildMetricsOptions(opts []MetricsOption) MetricsOptions {
+	result := DefaultMetricsOptions
+	for _, opt := range opts {
+		opt(&result)
+	}
+	return result
+}

--- a/vendor/github.com/grafana/e2e/scenario.go
+++ b/vendor/github.com/grafana/e2e/scenario.go
@@ -1,0 +1,268 @@
+package e2e
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+)
+
+const (
+	ContainerSharedDir = "/shared"
+)
+
+type Service interface {
+	Name() string
+	Start(networkName, dir string) error
+	WaitReady() error
+
+	// It should be ok to Stop and Kill more than once, with next invokes being noop.
+	Kill() error
+	Stop() error
+}
+
+type Scenario struct {
+	services []Service
+
+	networkName string
+	sharedDir   string
+}
+
+func NewScenario(networkName string) (*Scenario, error) {
+	s := &Scenario{networkName: networkName}
+
+	var err error
+	s.sharedDir, err = GetTempDirectory()
+	if err != nil {
+		return nil, err
+	}
+
+	// Force a shutdown in order to cleanup from a spurious situation in case
+	// the previous tests run didn't cleanup correctly.
+	s.shutdown()
+
+	args := []string{
+		"network", "create", networkName,
+	}
+
+	if extraArgs := os.Getenv("DOCKER_NETWORK_CREATE_EXTRA_ARGS"); extraArgs != "" {
+		args = append(
+			args,
+			strings.Split(extraArgs, ",")...,
+		)
+	}
+
+	// Setup the docker network.
+	if out, err := RunCommandAndGetOutput("docker", args...); err != nil {
+		logger.Log(string(out))
+		s.clean()
+		return nil, fmt.Errorf("create docker network '%s': %w", networkName, err)
+	}
+
+	return s, nil
+}
+
+// SharedDir returns the absolute path of the directory on the host that is shared with all services in docker.
+func (s *Scenario) SharedDir() string {
+	return s.sharedDir
+}
+
+// NetworkName returns the network name that scenario is responsible for.
+func (s *Scenario) NetworkName() string {
+	return s.networkName
+}
+
+func (s *Scenario) isRegistered(name string) bool {
+	for _, service := range s.services {
+		if service.Name() == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Scenario) StartAndWaitReady(services ...Service) error {
+	if err := s.Start(services...); err != nil {
+		return err
+	}
+	return s.WaitReady(services...)
+}
+
+func (s *Scenario) Start(services ...Service) error {
+	var (
+		wg        = sync.WaitGroup{}
+		startedMx = sync.Mutex{}
+		started   = make([]Service, 0, len(services))
+		errsMx    = sync.Mutex{}
+		errs      []error
+	)
+
+	// Ensure provided services don't conflict with existing ones.
+	if err := s.assertNoConflicts(services...); err != nil {
+		return err
+	}
+
+	// Start the services concurrently.
+	wg.Add(len(services))
+
+	for _, service := range services {
+		go func(service Service) {
+			defer wg.Done()
+
+			logger.Log("Starting", service.Name())
+
+			// Start the service.
+			if err := service.Start(s.networkName, s.SharedDir()); err != nil {
+				errsMx.Lock()
+				errs = append(errs, err)
+				errsMx.Unlock()
+				return
+			}
+
+			logger.Log("Started", service.Name())
+
+			startedMx.Lock()
+			started = append(started, service)
+			startedMx.Unlock()
+		}(service)
+	}
+
+	// Wait until all services have been started.
+	wg.Wait()
+
+	// Add the successfully started services to the scenario.
+	s.services = append(s.services, started...)
+
+	return errors.Join(errs...)
+}
+
+func (s *Scenario) Stop(services ...Service) error {
+	for _, service := range services {
+		if !s.isRegistered(service.Name()) {
+			return fmt.Errorf("unable to stop service %s because it does not exist", service.Name())
+		}
+		if err := service.Stop(); err != nil {
+			return err
+		}
+
+		// Remove the service from the list of services.
+		for i, entry := range s.services {
+			if entry.Name() == service.Name() {
+				s.services = append(s.services[:i], s.services[i+1:]...)
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Scenario) WaitReady(services ...Service) error {
+	for _, service := range services {
+		if !s.isRegistered(service.Name()) {
+			return fmt.Errorf("unable to wait for service %s because it does not exist", service.Name())
+		}
+		if err := service.WaitReady(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Scenario) Close() {
+	if s == nil {
+		return
+	}
+	s.shutdown()
+	s.clean()
+}
+
+func (s *Scenario) assertNoConflicts(services ...Service) error {
+	// Build a map of services already registered.
+	names := map[string]struct{}{}
+	for _, service := range s.services {
+		names[service.Name()] = struct{}{}
+	}
+
+	// Check if input services conflict with already existing ones or between them.
+	for _, service := range services {
+		if _, exists := names[service.Name()]; exists {
+			return fmt.Errorf("another service with the same name '%s' exists", service.Name())
+		}
+
+		names[service.Name()] = struct{}{}
+	}
+
+	return nil
+}
+
+// TODO(bwplotka): Add comments.
+func (s *Scenario) clean() {
+	if err := os.RemoveAll(s.sharedDir); err != nil {
+		logger.Log("error while removing sharedDir", s.sharedDir, "err:", err)
+	}
+}
+
+func (s *Scenario) shutdown() {
+	// Kill the services concurrently.
+	wg := sync.WaitGroup{}
+	wg.Add(len(s.services))
+
+	for _, srv := range s.services {
+		go func(service Service) {
+			defer wg.Done()
+
+			if err := service.Kill(); err != nil {
+				logger.Log("Unable to kill service", service.Name(), ":", err.Error())
+			}
+		}(srv)
+	}
+
+	// Wait until all services have been killed.
+	wg.Wait()
+
+	// Ensure there are no leftover containers.
+	if out, err := RunCommandAndGetOutput(
+		"docker",
+		"ps",
+		"-a",
+		"--quiet",
+		"--filter",
+		fmt.Sprintf("network=%s", s.networkName),
+	); err == nil {
+		for _, containerID := range strings.Split(string(out), "\n") {
+			containerID = strings.TrimSpace(containerID)
+			if containerID == "" {
+				continue
+			}
+
+			if out, err = RunCommandAndGetOutput("docker", "rm", "--force", containerID); err != nil {
+				logger.Log(string(out))
+				logger.Log("Unable to cleanup leftover container", containerID, ":", err.Error())
+			}
+		}
+	} else {
+		logger.Log(string(out))
+		logger.Log("Unable to cleanup leftover containers:", err.Error())
+	}
+
+	// Teardown the docker network. In case the network does not exists (ie. this function
+	// is called during the setup of the scenario) we skip the removal in order to not log
+	// an error which may be misleading.
+	if ok, err := existDockerNetwork(s.networkName); ok || err != nil {
+		if out, err := RunCommandAndGetOutput("docker", "network", "rm", s.networkName); err != nil {
+			logger.Log(string(out))
+			logger.Log("Unable to remove docker network", s.networkName, ":", err.Error())
+		}
+	}
+}
+
+func existDockerNetwork(networkName string) (bool, error) {
+	out, err := RunCommandAndGetOutput("docker", "network", "ls", "--quiet", "--filter", fmt.Sprintf("name=%s", networkName))
+	if err != nil {
+		logger.Log(string(out))
+		logger.Log("Unable to check if docker network", networkName, "exists:", err.Error())
+	}
+
+	return strings.TrimSpace(string(out)) != "", nil
+}

--- a/vendor/github.com/grafana/e2e/service.go
+++ b/vendor/github.com/grafana/e2e/service.go
@@ -1,0 +1,762 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/backoff"
+	"github.com/grafana/dskit/runutil"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+)
+
+var (
+	dockerIPv4PortPattern = regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+:(\d+)$`)
+	errMissingMetric      = errors.New("metric not found")
+)
+
+// ConcreteService represents microservice with optional ports which will be discoverable from docker
+// with <name>:<port>. For connecting from test, use `Endpoint` method.
+//
+// ConcreteService can be reused (started and stopped many time), but it can represent only one running container
+// at the time.
+type ConcreteService struct {
+	name         string
+	image        string
+	networkPorts []int
+	env          map[string]string
+	user         string
+	command      *Command
+	cmd          *exec.Cmd
+	readiness    ReadinessProbe
+	privileged   bool
+	volumes      map[string]string // host path -> container path
+
+	// Maps container ports to dynamically binded local ports.
+	networkPortsContainerToLocal map[int]int
+
+	// Generic retry backoff.
+	retryBackoff *backoff.Backoff
+
+	// docker NetworkName used to start this container.
+	// If empty it means service is stopped.
+	usedNetworkName string
+}
+
+func NewConcreteService(
+	name string,
+	image string,
+	command *Command,
+	readiness ReadinessProbe,
+	networkPorts ...int,
+) *ConcreteService {
+	return &ConcreteService{
+		name:                         name,
+		image:                        image,
+		networkPorts:                 networkPorts,
+		command:                      command,
+		networkPortsContainerToLocal: map[int]int{},
+		readiness:                    readiness,
+		retryBackoff: backoff.New(context.Background(), backoff.Config{
+			MinBackoff: 300 * time.Millisecond,
+			MaxBackoff: 600 * time.Millisecond,
+			MaxRetries: 100, // Sometimes the CI is slow ¯\_(ツ)_/¯
+		}),
+	}
+}
+
+func (s *ConcreteService) isExpectedRunning() bool {
+	return s.usedNetworkName != ""
+}
+
+func (s *ConcreteService) Name() string { return s.name }
+
+// Less often used options.
+
+func (s *ConcreteService) SetBackoff(cfg backoff.Config) {
+	s.retryBackoff = backoff.New(context.Background(), cfg)
+}
+
+func (s *ConcreteService) SetEnvVars(env map[string]string) {
+	s.env = env
+}
+
+func (s *ConcreteService) SetUser(user string) {
+	s.user = user
+}
+
+func (s *ConcreteService) SetVolumes(volumes map[string]string) {
+	s.volumes = volumes
+}
+
+func (s *ConcreteService) SetPrivileged(privileged bool) {
+	s.privileged = privileged
+}
+
+func (s *ConcreteService) Start(networkName, sharedDir string) (err error) {
+	// In case of any error, if the container was already created, we
+	// have to cleanup removing it. We ignore the error of the "docker rm"
+	// because we don't know if the container was created or not.
+	defer func() {
+		if err != nil {
+			_, _ = RunCommandAndGetOutput("docker", "rm", "--force", s.name)
+		}
+	}()
+
+	s.cmd = exec.Command("docker", s.buildDockerRunArgs(networkName, sharedDir)...)
+	s.cmd.Stdout = &LinePrefixLogger{prefix: s.name + ": ", logger: logger}
+	s.cmd.Stderr = &LinePrefixLogger{prefix: s.name + ": ", logger: logger}
+	if err = s.cmd.Start(); err != nil {
+		return err
+	}
+	s.usedNetworkName = networkName
+
+	// Wait until the container has been started.
+	if err = s.WaitForRunning(); err != nil {
+		return err
+	}
+
+	// Get the dynamic local ports mapped to the container.
+	for _, containerPort := range s.networkPorts {
+		var out []byte
+
+		out, err = RunCommandAndGetOutput("docker", "port", s.containerName(), strconv.Itoa(containerPort))
+		if err != nil {
+			// Catch init errors.
+			if werr := s.WaitForRunning(); werr != nil {
+				return fmt.Errorf("failed to get mapping for port as container %s exited: %v: %w", s.containerName(), err, werr)
+			}
+			return fmt.Errorf("unable to get mapping for port %d; service: %s; output: %q: %w", containerPort, s.name, out, err)
+		}
+
+		localPort, err := parseDockerIPv4Port(string(out))
+		if err != nil {
+			return fmt.Errorf("unable to get mapping for port %d (output: %s); service: %s: %w", containerPort, string(out), s.name, err)
+		}
+
+		s.networkPortsContainerToLocal[containerPort] = localPort
+	}
+
+	logger.Log("Ports for container:", s.containerName(), "Mapping:", s.networkPortsContainerToLocal)
+	return nil
+}
+
+func (s *ConcreteService) Stop() error {
+	if !s.isExpectedRunning() {
+		return nil
+	}
+
+	logger.Log("Stopping", s.name)
+
+	if out, err := RunCommandAndGetOutput("docker", "stop", "--time=30", s.containerName()); err != nil {
+		logger.Log(string(out))
+		return err
+	}
+	s.usedNetworkName = ""
+
+	return s.cmd.Wait()
+}
+
+func (s *ConcreteService) Kill() error {
+	if !s.isExpectedRunning() {
+		return nil
+	}
+
+	logger.Log("Killing", s.name)
+
+	if out, err := RunCommandAndGetOutput("docker", "kill", s.containerName()); err != nil {
+		logger.Log(string(out))
+		return err
+	}
+
+	// Wait until the container actually stopped. However, this could fail if
+	// the container already exited, so we just ignore the error.
+	_, _ = RunCommandAndGetOutput("docker", "wait", s.containerName())
+
+	s.usedNetworkName = ""
+
+	logger.Log("Killed", s.name)
+	return nil
+}
+
+// Endpoint returns external (from host perspective) service endpoint (host:port) for given internal port.
+// External means that it will be accessible only from host, but not from docker containers.
+//
+// If your service is not running, this method returns incorrect `stopped` endpoint.
+func (s *ConcreteService) Endpoint(port int) string {
+	if !s.isExpectedRunning() {
+		return "stopped"
+	}
+
+	// Map the container port to the local port.
+	localPort, ok := s.networkPortsContainerToLocal[port]
+	if !ok {
+		return ""
+	}
+
+	// Use an IPv4 address instead of "localhost" hostname because our port mapping assumes IPv4
+	// (a port published by a Docker container could be different between IPv4 and IPv6).
+	return fmt.Sprintf("127.0.0.1:%d", localPort)
+}
+
+// NetworkEndpoint returns internal service endpoint (host:port) for given internal port.
+// Internal means that it will be accessible only from docker containers within the network that this
+// service is running in. If you configure your local resolver with docker DNS namespace you can access it from host
+// as well. Use `Endpoint` for host access.
+//
+// If your service is not running, use `NetworkEndpointFor` instead.
+func (s *ConcreteService) NetworkEndpoint(port int) string {
+	if s.usedNetworkName == "" {
+		return "stopped"
+	}
+	return s.NetworkEndpointFor(s.usedNetworkName, port)
+}
+
+// NetworkEndpointFor returns internal service endpoint (host:port) for given internal port and network.
+// Internal means that it will be accessible only from docker containers within the given network. If you configure
+// your local resolver with docker DNS namespace you can access it from host as well.
+//
+// This method return correct endpoint for the service in any state.
+func (s *ConcreteService) NetworkEndpointFor(networkName string, port int) string {
+	return fmt.Sprintf("%s:%d", NetworkContainerHost(networkName, s.name), port)
+}
+
+func (s *ConcreteService) SetReadinessProbe(probe ReadinessProbe) {
+	s.readiness = probe
+}
+
+func (s *ConcreteService) Ready() error {
+	if !s.isExpectedRunning() {
+		return fmt.Errorf("service %s is stopped", s.Name())
+	}
+
+	// Ensure the service has a readiness probe configure.
+	if s.readiness == nil {
+		return nil
+	}
+
+	return s.readiness.Ready(s)
+}
+
+func (s *ConcreteService) containerName() string {
+	return NetworkContainerHost(s.usedNetworkName, s.name)
+}
+
+func (s *ConcreteService) WaitForRunning() (err error) {
+	if !s.isExpectedRunning() {
+		return fmt.Errorf("service %s is stopped", s.Name())
+	}
+
+	for s.retryBackoff.Reset(); s.retryBackoff.Ongoing(); {
+		// Enforce a timeout on the command execution because we've seen some flaky tests
+		// stuck here.
+
+		var out []byte
+		out, err = RunCommandWithTimeoutAndGetOutput(5*time.Second, "docker", "inspect", "--format={{json .State.Running}}", s.containerName())
+		if err != nil {
+			s.retryBackoff.Wait()
+			continue
+		}
+
+		if out == nil {
+			err = fmt.Errorf("nil output")
+			s.retryBackoff.Wait()
+			continue
+		}
+
+		str := strings.TrimSpace(string(out))
+		if str != "true" {
+			err = fmt.Errorf("unexpected output: %q", str)
+			s.retryBackoff.Wait()
+			continue
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("docker container %s failed to start: %v", s.name, err)
+}
+
+func (s *ConcreteService) WaitReady() (err error) {
+	if !s.isExpectedRunning() {
+		return fmt.Errorf("service %s is stopped", s.Name())
+	}
+
+	for s.retryBackoff.Reset(); s.retryBackoff.Ongoing(); {
+		err = s.Ready()
+		if err == nil {
+			return nil
+		}
+
+		s.retryBackoff.Wait()
+	}
+
+	return fmt.Errorf("the service %s is not ready; err: %v", s.name, err)
+}
+
+func (s *ConcreteService) buildDockerRunArgs(networkName, sharedDir string) []string {
+	args := []string{"run", "--rm", "--net=" + networkName, "--name=" + networkName + "-" + s.name, "--hostname=" + s.name}
+
+	// If running a dind container, this needs to be privileged.
+	if s.privileged {
+		args = append(args, "--privileged")
+	}
+
+	// For Drone CI users, expire the container after 6 hours using drone-gc
+	args = append(args, "--label", fmt.Sprintf("io.drone.expires=%d", time.Now().Add(6*time.Hour).Unix()))
+
+	// Mount the shared/ directory into the container
+	args = append(args, "-v", fmt.Sprintf("%s:%s:z", sharedDir, ContainerSharedDir))
+
+	// Mount additional volumes
+	for hostPath, containerPath := range s.volumes {
+		args = append(args, "-v", fmt.Sprintf("%s:%s:z", hostPath, containerPath))
+	}
+
+	// Environment variables
+	for name, value := range s.env {
+		args = append(args, "-e", name+"="+value)
+	}
+
+	if s.user != "" {
+		args = append(args, "--user", s.user)
+	}
+
+	// Published ports
+	for _, port := range s.networkPorts {
+		args = append(args, "-p", strconv.Itoa(port))
+	}
+
+	// Disable entrypoint if required
+	if s.command != nil && s.command.entrypointDisabled {
+		args = append(args, "--entrypoint", "")
+	}
+
+	args = append(args, s.image)
+
+	if s.command != nil {
+		args = append(args, s.command.cmd)
+		args = append(args, s.command.args...)
+	}
+
+	return args
+}
+
+// Exec runs the provided against a the docker container specified by this
+// service. It returns the stdout, stderr, and error response from attempting
+// to run the command.
+func (s *ConcreteService) Exec(command *Command) (string, string, error) {
+	args := []string{"exec", s.containerName()}
+	args = append(args, command.cmd)
+	args = append(args, command.args...)
+
+	cmd := exec.Command("docker", args...)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+
+	return stdout.String(), stderr.String(), err
+}
+
+// NetworkContainerHost return the hostname of the container within the network. This is
+// the address a container should use to connect to other containers.
+func NetworkContainerHost(networkName, containerName string) string {
+	return fmt.Sprintf("%s-%s", networkName, containerName)
+}
+
+// NetworkContainerHostPort return the host:port address of a container within the network.
+func NetworkContainerHostPort(networkName, containerName string, port int) string {
+	return fmt.Sprintf("%s-%s:%d", networkName, containerName, port)
+}
+
+type Command struct {
+	cmd                string
+	args               []string
+	entrypointDisabled bool
+}
+
+func NewCommand(cmd string, args ...string) *Command {
+	return &Command{
+		cmd:  cmd,
+		args: args,
+	}
+}
+
+func NewCommandWithoutEntrypoint(cmd string, args ...string) *Command {
+	return &Command{
+		cmd:                cmd,
+		args:               args,
+		entrypointDisabled: true,
+	}
+}
+
+type ReadinessProbe interface {
+	Ready(service *ConcreteService) (err error)
+}
+
+// HTTPReadinessProbe checks readiness by making HTTP(S) call and checking for expected response status code.
+type HTTPReadinessProbe struct {
+	schema                   string
+	port                     int
+	path                     string
+	expectedStatusRangeStart int
+	expectedStatusRangeEnd   int
+	expectedContent          []string
+
+	// The TLS config to use when issuing the HTTPS request.
+	clientTLSConfig *tls.Config
+}
+
+func NewHTTPReadinessProbe(port int, path string, expectedStatusRangeStart, expectedStatusRangeEnd int, expectedContent ...string) *HTTPReadinessProbe {
+	return &HTTPReadinessProbe{
+		schema:                   "http",
+		port:                     port,
+		path:                     path,
+		expectedStatusRangeStart: expectedStatusRangeStart,
+		expectedStatusRangeEnd:   expectedStatusRangeEnd,
+		expectedContent:          expectedContent,
+	}
+}
+
+func NewHTTPSReadinessProbe(port int, path, serverName, clientKeyFile, clientCertFile, rootCertFile string, expectedStatusRangeStart, expectedStatusRangeEnd int, expectedContent ...string) (*HTTPReadinessProbe, error) {
+	// Load client certificate and private key.
+	cert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("error creating x509 keypair from client cert file %s and client key file %s: %w", clientCertFile, clientKeyFile, err)
+	}
+
+	caCert, err := os.ReadFile(rootCertFile)
+	if err != nil {
+		return nil, fmt.Errorf("error opening root CA cert file %s: %w", rootCertFile, err)
+	}
+
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	return &HTTPReadinessProbe{
+		schema:                   "https",
+		port:                     port,
+		path:                     path,
+		expectedStatusRangeStart: expectedStatusRangeStart,
+		expectedStatusRangeEnd:   expectedStatusRangeEnd,
+		expectedContent:          expectedContent,
+		clientTLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			RootCAs:      caCertPool,
+			ServerName:   serverName,
+		},
+	}, nil
+}
+
+func (p *HTTPReadinessProbe) Ready(service *ConcreteService) (err error) {
+	endpoint := service.Endpoint(p.port)
+	switch endpoint {
+	case "":
+		return fmt.Errorf("cannot get service endpoint for port %d", p.port)
+	case "stopped":
+		return errors.New("service has stopped")
+	}
+
+	res, err := DoGetTLS(p.schema+"://"+endpoint+p.path, p.clientTLSConfig)
+	if err != nil {
+		return err
+	}
+
+	defer runutil.ExhaustCloseWithErrCapture(&err, res.Body, "response readiness")
+	body, _ := io.ReadAll(res.Body)
+
+	if res.StatusCode < p.expectedStatusRangeStart || res.StatusCode > p.expectedStatusRangeEnd {
+		return fmt.Errorf("expected code in range: [%v, %v], got status code: %v and body: %v", p.expectedStatusRangeStart, p.expectedStatusRangeEnd, res.StatusCode, string(body))
+	}
+
+	for _, expected := range p.expectedContent {
+		if !strings.Contains(string(body), expected) {
+			return fmt.Errorf("expected body containing %s, got: %v", expected, string(body))
+		}
+	}
+
+	return nil
+}
+
+// TCPReadinessProbe checks readiness by ensure a TCP connection can be established.
+type TCPReadinessProbe struct {
+	port int
+}
+
+func NewTCPReadinessProbe(port int) *TCPReadinessProbe {
+	return &TCPReadinessProbe{
+		port: port,
+	}
+}
+
+func (p *TCPReadinessProbe) Ready(service *ConcreteService) (err error) {
+	endpoint := service.Endpoint(p.port)
+	switch endpoint {
+	case "":
+		return fmt.Errorf("cannot get service endpoint for port %d", p.port)
+	case "stopped":
+		return errors.New("service has stopped")
+	}
+
+	conn, err := net.DialTimeout("tcp", endpoint, time.Second)
+	if err != nil {
+		return err
+	}
+
+	return conn.Close()
+}
+
+// CmdReadinessProbe checks readiness by `Exec`ing a command (within container) which returns 0 to consider status being ready
+type CmdReadinessProbe struct {
+	cmd *Command
+}
+
+func NewCmdReadinessProbe(cmd *Command) *CmdReadinessProbe {
+	return &CmdReadinessProbe{cmd: cmd}
+}
+
+func (p *CmdReadinessProbe) Ready(service *ConcreteService) error {
+	_, _, err := service.Exec(p.cmd)
+	return err
+}
+
+type LinePrefixLogger struct {
+	prefix string
+	logger log.Logger
+}
+
+func (w *LinePrefixLogger) Write(p []byte) (n int, err error) {
+	for _, line := range strings.Split(string(p), "\n") {
+		// Skip empty lines
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// Write the prefix + line to the wrapped writer
+		if err := w.logger.Log(w.prefix + line); err != nil {
+			return 0, err
+		}
+	}
+
+	return len(p), nil
+}
+
+// HTTPService represents opinionated microservice with at least HTTP port that as mandatory requirement,
+// serves metrics.
+type HTTPService struct {
+	*ConcreteService
+
+	metricsTimeout time.Duration
+	httpPort       int
+}
+
+func NewHTTPService(
+	name string,
+	image string,
+	command *Command,
+	readiness ReadinessProbe,
+	httpPort int,
+	otherPorts ...int,
+) *HTTPService {
+	return &HTTPService{
+		ConcreteService: NewConcreteService(name, image, command, readiness, append(otherPorts, httpPort)...),
+		metricsTimeout:  time.Second,
+		httpPort:        httpPort,
+	}
+}
+
+func (s *HTTPService) SetMetricsTimeout(timeout time.Duration) {
+	s.metricsTimeout = timeout
+}
+
+func (s *HTTPService) Metrics() (_ string, err error) {
+	// Map the container port to the local port
+	localPort := s.networkPortsContainerToLocal[s.httpPort]
+
+	// Fetch metrics.
+	// Use an IPv4 address instead of "localhost" hostname because our port mapping assumes IPv4
+	// (a port published by a Docker container could be different between IPv4 and IPv6).
+	res, err := DoGetWithTimeout(fmt.Sprintf("http://127.0.0.1:%d/metrics", localPort), s.metricsTimeout)
+	if err != nil {
+		return "", err
+	}
+
+	// Check the status code.
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return "", fmt.Errorf("unexpected status code %d while fetching metrics", res.StatusCode)
+	}
+
+	defer runutil.ExhaustCloseWithErrCapture(&err, res.Body, "metrics response")
+	body, err := io.ReadAll(res.Body)
+
+	return string(body), err
+}
+
+func (s *HTTPService) HTTPPort() int {
+	return s.httpPort
+}
+
+func (s *HTTPService) HTTPEndpoint() string {
+	return s.Endpoint(s.httpPort)
+}
+
+func (s *HTTPService) NetworkHTTPEndpoint() string {
+	return s.NetworkEndpoint(s.httpPort)
+}
+
+func (s *HTTPService) NetworkHTTPEndpointFor(networkName string) string {
+	return s.NetworkEndpointFor(networkName, s.httpPort)
+}
+
+// WaitSumMetrics waits for at least one instance of each given metric names to be present and their sums, returning true
+// when passed to given isExpected(...).
+func (s *HTTPService) WaitSumMetrics(isExpected func(sums ...float64) bool, metricNames ...string) error {
+	return s.WaitSumMetricsWithOptions(isExpected, metricNames)
+}
+
+func (s *HTTPService) WaitSumMetricsWithOptions(isExpected func(sums ...float64) bool, metricNames []string, opts ...MetricsOption) error {
+	var (
+		sums    []float64
+		err     error
+		options = buildMetricsOptions(opts)
+	)
+
+	for s.retryBackoff.Reset(); s.retryBackoff.Ongoing(); {
+		sums, err = s.SumMetrics(metricNames, opts...)
+		if options.WaitMissingMetrics && errors.Is(err, errMissingMetric) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+
+		if isExpected(sums...) {
+			return nil
+		}
+
+		s.retryBackoff.Wait()
+	}
+
+	return fmt.Errorf("unable to find metrics %s with expected values. Last error: %v. Last values: %v", metricNames, err, sums)
+}
+
+// SumMetrics returns the sum of the values of each given metric names.
+func (s *HTTPService) SumMetrics(metricNames []string, opts ...MetricsOption) ([]float64, error) {
+	options := buildMetricsOptions(opts)
+	sums := make([]float64, len(metricNames))
+
+	metrics, err := s.Metrics()
+	if err != nil {
+		return nil, err
+	}
+
+	tp := expfmt.NewTextParser(model.UTF8Validation)
+	families, err := tp.TextToMetricFamilies(strings.NewReader(metrics))
+	if err != nil {
+		return nil, err
+	}
+
+	for i, m := range metricNames {
+		sums[i] = 0.0
+
+		// Get the metric family.
+		mf, ok := families[m]
+		if !ok {
+			if options.SkipMissingMetrics {
+				continue
+			}
+
+			return nil, fmt.Errorf("metric=%s service=%s: %w", m, s.name, errMissingMetric)
+		}
+
+		// Filter metrics.
+		metrics := filterMetrics(mf.GetMetric(), options)
+		if len(metrics) == 0 {
+			if options.SkipMissingMetrics {
+				continue
+			}
+
+			return nil, fmt.Errorf("metric=%s service=%s: %w", m, s.name, errMissingMetric)
+		}
+
+		sums[i] = SumValues(getValues(metrics, options))
+	}
+
+	return sums, nil
+}
+
+// WaitRemovedMetric waits until a metric disappear from the list of metrics exported by the service.
+func (s *HTTPService) WaitRemovedMetric(metricName string, opts ...MetricsOption) error {
+	options := buildMetricsOptions(opts)
+
+	for s.retryBackoff.Reset(); s.retryBackoff.Ongoing(); {
+		// Fetch metrics.
+		metrics, err := s.Metrics()
+		if err != nil {
+			return err
+		}
+
+		// Parse metrics.
+		tp := expfmt.NewTextParser(model.UTF8Validation)
+		families, err := tp.TextToMetricFamilies(strings.NewReader(metrics))
+		if err != nil {
+			return err
+		}
+
+		// Get the metric family.
+		mf, ok := families[metricName]
+		if !ok {
+			return nil
+		}
+
+		// Filter metrics.
+		if len(filterMetrics(mf.GetMetric(), options)) == 0 {
+			return nil
+		}
+
+		s.retryBackoff.Wait()
+	}
+
+	return fmt.Errorf("the metric %s is still exported by %s", metricName, s.name)
+}
+
+// parseDockerIPv4Port parses the input string which is expected to be the output of "docker port"
+// command and returns the first IPv4 port found.
+func parseDockerIPv4Port(out string) (int, error) {
+	// The "docker port" output may be multiple lines if both IPv4 and IPv6 are supported,
+	// so we need to parse each line.
+	for _, line := range strings.Split(out, "\n") {
+		matches := dockerIPv4PortPattern.FindStringSubmatch(strings.TrimSpace(line))
+		if len(matches) != 2 {
+			continue
+		}
+
+		port, err := strconv.Atoi(matches[1])
+		if err != nil {
+			continue
+		}
+
+		return port, nil
+	}
+
+	// We've not been able to parse the output format.
+	return 0, errors.New("unknown output format")
+}

--- a/vendor/github.com/grafana/e2e/util.go
+++ b/vendor/github.com/grafana/e2e/util.go
@@ -1,0 +1,262 @@
+package e2e
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"math"
+	"math/rand"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/prompb"
+)
+
+func RunCommandAndGetOutput(name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+	return cmd.CombinedOutput()
+}
+
+func RunCommandWithTimeoutAndGetOutput(timeout time.Duration, name string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	return cmd.CombinedOutput()
+}
+
+func EmptyFlags() map[string]string {
+	return map[string]string{}
+}
+
+func MergeFlags(inputs ...map[string]string) map[string]string {
+	output := MergeFlagsWithoutRemovingEmpty(inputs...)
+
+	for k, v := range output {
+		if v == "" {
+			delete(output, k)
+		}
+	}
+
+	return output
+}
+
+func MergeFlagsWithoutRemovingEmpty(inputs ...map[string]string) map[string]string {
+	output := map[string]string{}
+
+	for _, input := range inputs {
+		for name, value := range input {
+			output[name] = value
+		}
+	}
+
+	return output
+}
+
+func BuildArgs(flags map[string]string) []string {
+	args := make([]string, 0, len(flags))
+
+	for name, value := range flags {
+		if value != "" {
+			args = append(args, name+"="+value)
+		} else {
+			args = append(args, name)
+		}
+	}
+
+	return args
+}
+
+// DoGet performs an HTTP GET request towards the supplied URL and using a
+// timeout of 1 second.
+func DoGet(url string) (*http.Response, error) {
+	return doRequestWithTimeout("GET", url, nil, nil, time.Second)
+}
+
+// DoGetWithTimeout performs an HTTP GET request towards the supplied URL and using a
+// specified timeout.
+func DoGetWithTimeout(url string, timeout time.Duration) (*http.Response, error) {
+	return doRequestWithTimeout("GET", url, nil, nil, timeout)
+}
+
+// DoGetTLS is like DoGet but allows to configure a TLS config.
+func DoGetTLS(url string, tlsConfig *tls.Config) (*http.Response, error) {
+	return doRequestWithTimeout("GET", url, nil, tlsConfig, time.Second)
+}
+
+// DoPost performs a HTTP POST request towards the supplied URL with an empty
+// body and using a timeout of 1 second.
+func DoPost(url string) (*http.Response, error) {
+	return doRequestWithTimeout("POST", url, strings.NewReader(""), nil, time.Second)
+}
+
+func doRequestWithTimeout(method, url string, body io.Reader, tlsConfig *tls.Config, timeout time.Duration) (*http.Response, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+
+	return client.Do(req)
+}
+
+// TimeToMilliseconds returns the input time as milliseconds, using the same
+// formula used by Prometheus in order to get the same timestamp when asserting
+// on query results. The formula we're mimicking here is Prometheus parseTime().
+// See: https://github.com/prometheus/prometheus/blob/df80dc4d3970121f2f76cba79050983ffb3cdbb0/web/api/v1/api.go#L1690-L1694
+func TimeToMilliseconds(t time.Time) int64 {
+	// Convert to seconds.
+	sec := float64(t.Unix()) + float64(t.Nanosecond())/1e9
+
+	// Parse seconds.
+	s, ns := math.Modf(sec)
+
+	// Round nanoseconds part.
+	ns = math.Round(ns*1000) / 1000
+
+	// Convert to millis.
+	return (int64(s) * 1e3) + (int64(ns * 1e3))
+}
+
+func GenerateSeries(name string, ts time.Time, additionalLabels ...prompb.Label) (series []prompb.TimeSeries, vector model.Vector, matrix model.Matrix) {
+	tsMillis := TimeToMilliseconds(ts)
+	value := rand.Float64()
+
+	lbls := append(
+		[]prompb.Label{
+			{Name: string(model.MetricNameLabel), Value: name},
+		},
+		additionalLabels...,
+	)
+
+	// Generate the series
+	series = append(series, prompb.TimeSeries{
+		Labels: lbls,
+		Exemplars: []prompb.Exemplar{
+			{Value: value, Timestamp: tsMillis, Labels: []prompb.Label{
+				{Name: "trace_id", Value: "1234"},
+			}},
+		},
+		Samples: []prompb.Sample{
+			{Value: value, Timestamp: tsMillis},
+		},
+	})
+
+	// Generate the expected vector and matrix when querying it
+	metric := model.Metric{}
+	metric[model.MetricNameLabel] = model.LabelValue(name)
+	for _, lbl := range additionalLabels {
+		metric[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
+	}
+
+	vector = append(vector, &model.Sample{
+		Metric:    metric,
+		Value:     model.SampleValue(value),
+		Timestamp: model.Time(tsMillis),
+	})
+
+	matrix = append(matrix, &model.SampleStream{
+		Metric: metric,
+		Values: []model.SamplePair{
+			{
+				Timestamp: model.Time(tsMillis),
+				Value:     model.SampleValue(value),
+			},
+		},
+	})
+
+	return
+}
+
+func GenerateNSeries(nSeries, nExemplars int, name func() string, ts time.Time, additionalLabels func() []prompb.Label) (series []prompb.TimeSeries, vector model.Vector) {
+	tsMillis := TimeToMilliseconds(ts)
+
+	// Generate the series
+	for i := 0; i < nSeries; i++ {
+		lbls := []prompb.Label{
+			{Name: string(model.MetricNameLabel), Value: name()},
+		}
+		if additionalLabels != nil {
+			lbls = append(lbls, additionalLabels()...)
+		}
+
+		value := rand.Float64()
+
+		exemplars := []prompb.Exemplar{}
+		if i < nExemplars {
+			exemplars = []prompb.Exemplar{
+				{Value: value, Timestamp: tsMillis, Labels: []prompb.Label{{Name: "trace_id", Value: "1234"}}},
+			}
+		}
+
+		series = append(series, prompb.TimeSeries{
+			Labels: lbls,
+			Samples: []prompb.Sample{
+				{Value: value, Timestamp: tsMillis},
+			},
+			Exemplars: exemplars,
+		})
+	}
+
+	// Generate the expected vector when querying it
+	for i := 0; i < nSeries; i++ {
+		metric := model.Metric{}
+		for _, lbl := range series[i].Labels {
+			metric[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
+		}
+
+		vector = append(vector, &model.Sample{
+			Metric:    metric,
+			Value:     model.SampleValue(series[i].Samples[0].Value),
+			Timestamp: model.Time(tsMillis),
+		})
+	}
+	return
+}
+
+// GetTempDirectory creates a temporary directory for shared integration
+// test files, either in the working directory or a directory referenced by
+// the E2E_TEMP_DIR environment variable
+func GetTempDirectory() (string, error) {
+	var (
+		dir string
+		err error
+	)
+	// If a temp dir is referenced, return that
+	if os.Getenv("E2E_TEMP_DIR") != "" {
+		dir = os.Getenv("E2E_TEMP_DIR")
+	} else {
+		dir, err = os.Getwd()
+		if err != nil {
+			return "", err
+		}
+	}
+
+	tmpDir, err := os.MkdirTemp(dir, "e2e_integration_test")
+	if err != nil {
+		return "", err
+	}
+	// Allow use of the temporary directory for testing with non-root
+	// users.
+	if err := os.Chmod(tmpDir, 0777); err != nil {
+		return "", err
+	}
+	absDir, err := filepath.Abs(tmpDir)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return "", err
+	}
+
+	return absDir, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -961,6 +961,9 @@ github.com/grafana/dskit/test
 github.com/grafana/dskit/timeutil
 github.com/grafana/dskit/tracing
 github.com/grafana/dskit/user
+# github.com/grafana/e2e v0.1.2-0.20260504080022-0f57c9f0da68
+## explicit; go 1.25.5
+github.com/grafana/e2e
 # github.com/grafana/gomemcache v0.0.0-20251127154401-74f93547077b
 ## explicit; go 1.21
 github.com/grafana/gomemcache/memcache
@@ -1423,7 +1426,7 @@ github.com/prometheus/otlptranslator
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v0.311.3-0.20260415124738-34cebfe9536c
+# github.com/prometheus/prometheus v0.311.3 => github.com/prometheus/prometheus v0.311.3-0.20260415124738-34cebfe9536c
 ## explicit; go 1.25.0
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -2507,3 +2510,4 @@ zombiezen.com/go/sqlite/sqlitex
 # github.com/grafana/loki/pkg/push => ./pkg/push
 # github.com/influxdata/go-syslog/v3 => github.com/leodido/go-syslog/v4 v4.4.0
 # github.com/thanos-io/objstore => github.com/grafana/objstore v0.0.0-20260507144615-6c81ea69c9a9
+# github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.311.3-0.20260415124738-34cebfe9536c


### PR DESCRIPTION
**What this PR does / why we need it**:

As a stronger test of the build, run a test invoking the Loki container and check it can ingest and query log lines.

**Special notes for your reviewer**:

This is using the same framework as Mimir - [see information there](https://github.com/grafana/mimir/blob/main/docs/internal/contributing/how-integration-tests-work.md).

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- NA If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
