### PR TITLE
chore: Add metrics for number of retries in indexgateway client

### DIFF
--- a/pkg/bloomgateway/client.go
+++ b/pkg/bloomgateway/client.go
@@ -118,7 +118,7 @@ type GatewayClient struct {
 	logger      log.Logger
 	metrics     *clientMetrics
 	pool        clientPool
-	dnsProvider *discovery.DNS
+	dnsProvider discovery.DNS
 }
 
 func NewClient(cfg ClientConfig, registerer prometheus.Registerer, logger log.Logger) (*GatewayClient, error) {
@@ -138,8 +138,6 @@ func NewClient(cfg ClientConfig, registerer prometheus.Registerer, logger log.Lo
 	}
 
 	dnsProvider := discovery.NewDNS(logger, cfg.PoolConfig.CheckInterval, cfg.Addresses, nil)
-	// Make an attempt to do one DNS lookup so we can start with addresses
-	dnsProvider.RunOnce()
 
 	pool, err := NewJumpHashClientPool(clientFactory, dnsProvider, cfg.PoolConfig.CheckInterval, logger)
 	if err != nil {

--- a/pkg/indexgateway/client.go
+++ b/pkg/indexgateway/client.go
@@ -102,7 +102,7 @@ type GatewayClient struct {
 	logger                            log.Logger
 	cfg                               ClientConfig
 	storeGatewayClientRequestDuration *prometheus.HistogramVec
-	dnsProvider                       *discovery.DNS
+	dnsProvider                       discovery.DNS
 	pool                              *client.Pool
 	ring                              ring.ReadRing
 	limits                            Limits
@@ -202,9 +202,6 @@ func NewGatewayClient(cfg ClientConfig, r prometheus.Registerer, limits Limits, 
 		//TODO(ewelch) we can't use metrics in the provider because of duplicate registration errors
 		dnsProvider := discovery.NewDNS(logger, sgClient.cfg.PoolConfig.ClientCleanupPeriod, sgClient.cfg.Address, nil)
 		sgClient.dnsProvider = dnsProvider
-
-		// Make an attempt to do one DNS lookup so we can start with addresses
-		dnsProvider.RunOnce()
 
 		discovery := func() ([]string, error) {
 			return dnsProvider.Addresses(), nil
@@ -320,19 +317,7 @@ func (s *GatewayClient) GetVolume(ctx context.Context, in *logproto.VolumeReques
 }
 
 func (s *GatewayClient) GetShards(ctx context.Context, in *logproto.ShardsRequest) (res *logproto.ShardsResponse, err error) {
-
-	// We try to get the shards from the index gateway,
-	// but if it's not implemented, we fall back to the stats.
-	// We limit the maximum number of errors to 2 to avoid
-	// cascading all requests to new node(s) when
-	// the idx-gw replicas start to update to a version
-	// which supports the new API.
-	var (
-		maxErrs = 2
-		errCt   int
-	)
-
-	if err := s.poolDoWithStrategy(
+	if err := s.poolDo(
 		ctx,
 		func(client logproto.IndexGatewayClient) error {
 			perReplicaResult := &logproto.ShardsResponse{}
@@ -363,28 +348,17 @@ func (s *GatewayClient) GetShards(ctx context.Context, in *logproto.ShardsReques
 		func(addrs []string) []string {
 			return addressesForQueryEndTime(addrs, in.Through.Time(), s.buckets, time.Now().UTC())
 		},
-		func(_ error) bool {
-			errCt++
-			return errCt <= maxErrs
-		},
 	); err != nil {
 		return nil, err
 	}
 	return res, nil
 }
 
+const maxErrors int = 2
+
 // poolDo executes the given function for each Index Gateway instance in the ring mapping to the correct tenant in the index.
 // In case of callback failure, we'll try another member of the ring for that tenant ID.
 func (s *GatewayClient) poolDo(ctx context.Context, callback func(client logproto.IndexGatewayClient) error, filterServerList func([]string) []string) error {
-	return s.poolDoWithStrategy(ctx, callback, filterServerList, func(error) bool { return true })
-}
-
-func (s *GatewayClient) poolDoWithStrategy(
-	ctx context.Context,
-	callback func(client logproto.IndexGatewayClient) error,
-	filterServerList func([]string) []string,
-	shouldRetry func(error) bool,
-) error {
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return errors.Wrap(err, "index gateway client get tenant ID")
@@ -410,6 +384,7 @@ func (s *GatewayClient) poolDoWithStrategy(
 		addrs[i], addrs[j] = addrs[j], addrs[i]
 	})
 
+	errCount := 0
 	var lastErr error
 	for _, addr := range addrs {
 		if s.cfg.LogGatewayRequests {
@@ -425,9 +400,10 @@ func (s *GatewayClient) poolDoWithStrategy(
 		client := (genericClient.(logproto.IndexGatewayClient))
 		if err := callback(client); err != nil {
 			lastErr = err
+			errCount++
 			level.Error(s.logger).Log("msg", fmt.Sprintf("client do failed for instance %s", addr), "err", err)
 
-			if !shouldRetry(err) {
+			if errCount > maxErrors {
 				return err
 			}
 			continue

--- a/pkg/indexgateway/client.go
+++ b/pkg/indexgateway/client.go
@@ -242,7 +242,7 @@ func (s *GatewayClient) GetChunkRef(ctx context.Context, in *logproto.GetChunkRe
 		return err
 	}, func(addrs []string) []string {
 		return addressesForQueryEndTime(addrs, in.Through.Time(), s.buckets, time.Now().UTC())
-	})
+	}, -1)
 	return resp, err
 }
 
@@ -256,7 +256,7 @@ func (s *GatewayClient) GetSeries(ctx context.Context, in *logproto.GetSeriesReq
 		return err
 	}, func(addrs []string) []string {
 		return addressesForQueryEndTime(addrs, in.Through.Time(), s.buckets, time.Now().UTC())
-	})
+	}, -1)
 	return resp, err
 }
 
@@ -270,7 +270,7 @@ func (s *GatewayClient) LabelNamesForMetricName(ctx context.Context, in *logprot
 		return err
 	}, func(addrs []string) []string {
 		return addressesForQueryEndTime(addrs, in.Through.Time(), s.buckets, time.Now().UTC())
-	})
+	}, -1)
 	return resp, err
 }
 
@@ -284,7 +284,7 @@ func (s *GatewayClient) LabelValuesForMetricName(ctx context.Context, in *logpro
 		return err
 	}, func(addrs []string) []string {
 		return addressesForQueryEndTime(addrs, in.Through.Time(), s.buckets, time.Now().UTC())
-	})
+	}, -1)
 	return resp, err
 }
 
@@ -298,7 +298,7 @@ func (s *GatewayClient) GetStats(ctx context.Context, in *logproto.IndexStatsReq
 		return err
 	}, func(addrs []string) []string {
 		return addressesForQueryEndTime(addrs, in.Through.Time(), s.buckets, time.Now().UTC())
-	})
+	}, -1)
 	return resp, err
 }
 
@@ -312,7 +312,7 @@ func (s *GatewayClient) GetVolume(ctx context.Context, in *logproto.VolumeReques
 		return err
 	}, func(addrs []string) []string {
 		return addressesForQueryEndTime(addrs, in.Through.Time(), s.buckets, time.Now().UTC())
-	})
+	}, -1)
 	return resp, err
 }
 
@@ -348,6 +348,7 @@ func (s *GatewayClient) GetShards(ctx context.Context, in *logproto.ShardsReques
 		func(addrs []string) []string {
 			return addressesForQueryEndTime(addrs, in.Through.Time(), s.buckets, time.Now().UTC())
 		},
+		2,
 	); err != nil {
 		return nil, err
 	}
@@ -358,7 +359,12 @@ const maxErrors int = 2
 
 // poolDo executes the given function for each Index Gateway instance in the ring mapping to the correct tenant in the index.
 // In case of callback failure, we'll try another member of the ring for that tenant ID.
-func (s *GatewayClient) poolDo(ctx context.Context, callback func(client logproto.IndexGatewayClient) error, filterServerList func([]string) []string) error {
+func (s *GatewayClient) poolDo(
+	ctx context.Context,
+	callback func(client logproto.IndexGatewayClient) error,
+	filterServerList func([]string) []string,
+	maxRetries int, // -1 for unlimited retries, 0 to disable retries
+) error {
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return errors.Wrap(err, "index gateway client get tenant ID")
@@ -403,7 +409,7 @@ func (s *GatewayClient) poolDo(ctx context.Context, callback func(client logprot
 			errCount++
 			level.Error(s.logger).Log("msg", fmt.Sprintf("client do failed for instance %s", addr), "err", err)
 
-			if errCount > maxErrors {
+			if maxRetries >= 0 && errCount > maxRetries {
 				return err
 			}
 			continue

--- a/pkg/indexgateway/client.go
+++ b/pkg/indexgateway/client.go
@@ -102,6 +102,7 @@ type GatewayClient struct {
 	logger                            log.Logger
 	cfg                               ClientConfig
 	storeGatewayClientRequestDuration *prometheus.HistogramVec
+	retriesHistogram                  *prometheus.HistogramVec
 	dnsProvider                       discovery.DNS
 	pool                              *client.Pool
 	ring                              ring.ReadRing
@@ -132,6 +133,23 @@ func NewGatewayClient(cfg ClientConfig, r prometheus.Registerer, limits Limits, 
 		}
 	}
 
+	retries := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: constants.Loki,
+		Name:      "index_gateway_request_retries",
+		Help:      "Number of retries attempted before a successful or failed index gateway request",
+		Buckets:   []float64{0, 1, 2, 3, 4, 5, 10, 15, 20, 25, 30, 40, 50, 100},
+	}, []string{"status"})
+	if r != nil {
+		err := r.Register(retries)
+		if err != nil {
+			alreadyErr, ok := err.(prometheus.AlreadyRegisteredError)
+			if !ok {
+				return nil, err
+			}
+			retries = alreadyErr.ExistingCollector.(*prometheus.HistogramVec)
+		}
+	}
+
 	buckets := make([]time.Duration, len(cfg.TimeBasedShardingBuckets))
 	for i := range len(buckets) {
 		b, err := time.ParseDuration(cfg.TimeBasedShardingBuckets[i])
@@ -148,6 +166,7 @@ func NewGatewayClient(cfg ClientConfig, r prometheus.Registerer, limits Limits, 
 		logger:                            logger,
 		cfg:                               cfg,
 		storeGatewayClientRequestDuration: latency,
+		retriesHistogram:                  retries,
 		ring:                              cfg.Ring,
 		limits:                            limits,
 		buckets:                           buckets,
@@ -355,8 +374,6 @@ func (s *GatewayClient) GetShards(ctx context.Context, in *logproto.ShardsReques
 	return res, nil
 }
 
-const maxErrors int = 2
-
 // poolDo executes the given function for each Index Gateway instance in the ring mapping to the correct tenant in the index.
 // In case of callback failure, we'll try another member of the ring for that tenant ID.
 func (s *GatewayClient) poolDo(
@@ -410,14 +427,17 @@ func (s *GatewayClient) poolDo(
 			level.Error(s.logger).Log("msg", fmt.Sprintf("client do failed for instance %s", addr), "err", err)
 
 			if maxRetries >= 0 && errCount > maxRetries {
+				s.retriesHistogram.WithLabelValues("failure").Observe(float64(errCount))
 				return err
 			}
 			continue
 		}
 
+		s.retriesHistogram.WithLabelValues("success").Observe(float64(errCount))
 		return nil
 	}
 
+	s.retriesHistogram.WithLabelValues("failure").Observe(float64(errCount))
 	return lastErr
 }
 

--- a/pkg/indexgateway/client_test.go
+++ b/pkg/indexgateway/client_test.go
@@ -17,11 +17,12 @@ import (
 	dskitclient "github.com/grafana/dskit/ring/client"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/user"
-	"github.com/grafana/loki/v3/pkg/util/discovery"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/grafana/loki/v3/pkg/util/discovery"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/util/constants"

--- a/pkg/indexgateway/client_test.go
+++ b/pkg/indexgateway/client_test.go
@@ -2,6 +2,7 @@ package indexgateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"testing"
@@ -9,17 +10,39 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/kv/consul"
 	"github.com/grafana/dskit/ring"
+	dskitclient "github.com/grafana/dskit/ring/client"
 	"github.com/grafana/dskit/services"
+	"github.com/grafana/dskit/user"
+	"github.com/grafana/loki/v3/pkg/util/discovery"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 	"github.com/grafana/loki/v3/pkg/validation"
 )
+
+type mockDnsProvider struct {
+	addrs []string
+}
+
+func newMockDnsProvider(addrs []string) discovery.DNS {
+	return &mockDnsProvider{
+		addrs: addrs,
+	}
+}
+
+func (m *mockDnsProvider) Addresses() []string {
+	return m.addrs
+}
+
+func (m *mockDnsProvider) Stop() {}
 
 type mockIndexGatewayServer struct {
 	logproto.IndexGatewayServer
@@ -28,6 +51,25 @@ type mockIndexGatewayServer struct {
 func (m mockIndexGatewayServer) GetChunkRef(context.Context, *logproto.GetChunkRefRequest) (*logproto.GetChunkRefResponse, error) {
 	return &logproto.GetChunkRefResponse{}, nil
 }
+
+type mockGatewayConn struct {
+	logproto.IndexGatewayClient
+	grpc_health_v1.HealthClient
+	returnErrors bool
+}
+
+func (m *mockGatewayConn) GetChunkRef(context.Context, *logproto.GetChunkRefRequest, ...grpc.CallOption) (*logproto.GetChunkRefResponse, error) {
+	if m.returnErrors {
+		return nil, errors.New("mock error")
+	}
+	return &logproto.GetChunkRefResponse{}, nil
+}
+
+func (m *mockGatewayConn) Check(context.Context, *grpc_health_v1.HealthCheckRequest, ...grpc.CallOption) (*grpc_health_v1.HealthCheckResponse, error) {
+	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
+}
+
+func (m *mockGatewayConn) Close() error { return nil }
 
 type mockTenantLimits map[string]*validation.Limits
 
@@ -154,6 +196,78 @@ func TestGatewayClient_RingMode(t *testing.T) {
 		require.Len(t, addrs, s)
 		require.ElementsMatch(t, addrs, []string{"index-gateway-2", "index-gateway-3", "index-gateway-5"})
 	})
+}
+
+func createSimpleGatewayClient(t *testing.T, addrs []string) (log.Logger, *dskitclient.Pool, *GatewayClient) {
+	logger := log.NewNopLogger()
+	r := prometheus.NewRegistry()
+	o, _ := validation.NewOverrides(validation.Limits{}, nil)
+	client, err := NewGatewayClient(
+		ClientConfig{
+			Mode:             "simple",
+			GRPCClientConfig: grpcclient.Config{},
+			Address:          "1.1.1.1",
+		},
+		r, o, logger, constants.Loki)
+	require.NoError(t, err)
+	defer client.Stop()
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), client.pool))
+	client.dnsProvider = newMockDnsProvider(addrs)
+	pool := configurePool(t, client, logger, 0)
+	return logger, pool, client
+}
+
+func configurePool(t *testing.T, client *GatewayClient, logger log.Logger, numErrorsToReturn int) *dskitclient.Pool {
+	pool := dskitclient.NewPool(
+		"test",
+		dskitclient.PoolConfig{CheckInterval: time.Hour},
+		func() ([]string, error) { return client.dnsProvider.Addresses(), nil },
+		dskitclient.PoolAddrFunc(func(string) (dskitclient.PoolClient, error) {
+			var returnErrors bool
+			if numErrorsToReturn > 0 {
+				numErrorsToReturn--
+				returnErrors = true
+			} else {
+				returnErrors = false
+			}
+			return &mockGatewayConn{returnErrors: returnErrors}, nil
+		}),
+		nil, logger,
+	)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), pool))
+	client.pool = pool
+	return pool
+}
+
+func TestGatewayClient_SimpleMode_Retries(t *testing.T) {
+	logger, _, client := createSimpleGatewayClient(t, []string{"1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4"})
+	ctx := user.InjectOrgID(context.Background(), "tenant-123")
+
+	// Retry up to 2 errors
+	for numErrorsToReturn := 0; numErrorsToReturn <= 2; numErrorsToReturn++ {
+		configurePool(t, client, logger, numErrorsToReturn)
+		_, err := client.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
+		require.NoError(t, err)
+	}
+
+	// Fail after 3 errors
+	configurePool(t, client, logger, 3)
+	_, err := client.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
+	require.Error(t, err)
+}
+
+func TestGatewayClient_SimpleMode_ShuffleSharding(t *testing.T) {
+	_, pool, client := createSimpleGatewayClient(t, []string{
+		"0.0.0.0", "1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4",
+		"5.5.5.5", "6.6.6.6", "7.7.7.7", "8.8.8.8", "9.9.9.9",
+	})
+	client.limits = mockLimits{maxCapacity: 0.5}
+	for i := 0; i < 1000; i++ {
+		ctx := user.InjectOrgID(context.Background(), "tenant-01")
+		_, err := client.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
+		require.NoError(t, err)
+	}
+	require.Len(t, pool.RegisteredAddresses(), 5)
 }
 
 func TestDoubleRegistration(t *testing.T) {

--- a/pkg/indexgateway/client_test.go
+++ b/pkg/indexgateway/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"testing"
 	"time"
@@ -64,6 +65,26 @@ func (m *mockGatewayConn) GetChunkRef(context.Context, *logproto.GetChunkRefRequ
 		return nil, errors.New("mock error")
 	}
 	return &logproto.GetChunkRefResponse{}, nil
+}
+
+func (m *mockGatewayConn) GetShards(_ context.Context, _ *logproto.ShardsRequest, _ ...grpc.CallOption) (logproto.IndexGateway_GetShardsClient, error) {
+	if m.returnErrors {
+		return nil, errors.New("mock error")
+	}
+	return &mockShardsClient{}, nil
+}
+
+type mockShardsClient struct {
+	grpc.ClientStream
+	done bool
+}
+
+func (m *mockShardsClient) Recv() (*logproto.ShardsResponse, error) {
+	if m.done {
+		return nil, io.EOF
+	}
+	m.done = true
+	return &logproto.ShardsResponse{}, nil
 }
 
 func (m *mockGatewayConn) Check(context.Context, *grpc_health_v1.HealthCheckRequest, ...grpc.CallOption) (*grpc_health_v1.HealthCheckResponse, error) {
@@ -240,19 +261,42 @@ func configurePool(t *testing.T, client *GatewayClient, logger log.Logger, numEr
 	return pool
 }
 
-func TestGatewayClient_SimpleMode_Retries(t *testing.T) {
-	logger, _, client := createSimpleGatewayClient(t, []string{"1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4"})
+func TestGatewayClient_SimpleMode_RetriesGetShards(t *testing.T) {
+	logger, _, client := createSimpleGatewayClient(t, []string{
+		"0.0.0.0", "1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4",
+		"5.5.5.5", "6.6.6.6", "7.7.7.7", "8.8.8.8", "9.9.9.9",
+	})
 	ctx := user.InjectOrgID(context.Background(), "tenant-123")
 
 	// Retry up to 2 errors
 	for numErrorsToReturn := 0; numErrorsToReturn <= 2; numErrorsToReturn++ {
 		configurePool(t, client, logger, numErrorsToReturn)
-		_, err := client.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
+		_, err := client.GetShards(ctx, &logproto.ShardsRequest{})
 		require.NoError(t, err)
 	}
 
 	// Fail after 3 errors
 	configurePool(t, client, logger, 3)
+	_, err := client.GetShards(ctx, &logproto.ShardsRequest{})
+	require.Error(t, err)
+}
+
+func TestGatewayClient_SimpleMode_OtherMethods(t *testing.T) {
+	logger, _, client := createSimpleGatewayClient(t, []string{
+		"0.0.0.0", "1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4",
+		"5.5.5.5", "6.6.6.6", "7.7.7.7", "8.8.8.8", "9.9.9.9",
+	})
+	ctx := user.InjectOrgID(context.Background(), "tenant-123")
+
+	// Retry until we run out of index gateways
+	for numErrorsToReturn := 0; numErrorsToReturn <= 9; numErrorsToReturn++ {
+		configurePool(t, client, logger, numErrorsToReturn)
+		_, err := client.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
+		require.NoError(t, err)
+	}
+
+	// Fail after every gateway has been tried
+	configurePool(t, client, logger, 10)
 	_, err := client.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
 	require.Error(t, err)
 }

--- a/pkg/indexgateway/client_test.go
+++ b/pkg/indexgateway/client_test.go
@@ -30,21 +30,21 @@ import (
 	"github.com/grafana/loki/v3/pkg/validation"
 )
 
-type mockDnsProvider struct {
+type mockDNSProvider struct {
 	addrs []string
 }
 
-func newMockDnsProvider(addrs []string) discovery.DNS {
-	return &mockDnsProvider{
+func newMockDNSProvider(addrs []string) discovery.DNS {
+	return &mockDNSProvider{
 		addrs: addrs,
 	}
 }
 
-func (m *mockDnsProvider) Addresses() []string {
+func (m *mockDNSProvider) Addresses() []string {
 	return m.addrs
 }
 
-func (m *mockDnsProvider) Stop() {}
+func (m *mockDNSProvider) Stop() {}
 
 type mockIndexGatewayServer struct {
 	logproto.IndexGatewayServer
@@ -234,7 +234,7 @@ func createSimpleGatewayClient(t *testing.T, addrs []string) (log.Logger, *dskit
 	require.NoError(t, err)
 	defer client.Stop()
 	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), client.pool))
-	client.dnsProvider = newMockDnsProvider(addrs)
+	client.dnsProvider = newMockDNSProvider(addrs)
 	pool := configurePool(t, client, logger, 0)
 	return logger, pool, client
 }

--- a/pkg/util/discovery/dns.go
+++ b/pkg/util/discovery/dns.go
@@ -9,23 +9,28 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/grafana/dskit/dns"
+	dskitdns "github.com/grafana/dskit/dns"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type DNS struct {
+type DNS interface {
+	Addresses() []string
+	Stop()
+}
+
+type dns struct {
 	logger        log.Logger
 	cleanupPeriod time.Duration
 	addresses     []string
 	stop          chan struct{}
 	done          sync.WaitGroup
 	once          sync.Once
-	dnsProvider   *dns.Provider
+	dnsProvider   *dskitdns.Provider
 }
 
-func NewDNS(logger log.Logger, cleanupPeriod time.Duration, address string, reg prometheus.Registerer) *DNS {
-	dnsProvider := dns.NewProvider(dns.GolangResolverType, 0, logger, reg)
-	d := &DNS{
+func NewDNS(logger log.Logger, cleanupPeriod time.Duration, address string, reg prometheus.Registerer) DNS {
+	dnsProvider := dskitdns.NewProvider(dskitdns.GolangResolverType, 0, logger, reg)
+	d := &dns{
 		logger:        logger,
 		cleanupPeriod: cleanupPeriod,
 		addresses:     strings.Split(address, ","),
@@ -33,27 +38,24 @@ func NewDNS(logger log.Logger, cleanupPeriod time.Duration, address string, reg 
 		done:          sync.WaitGroup{},
 		dnsProvider:   dnsProvider,
 	}
+	d.runDiscovery() // Make an attempt to do one DNS lookup so we can start with addresses
 	go d.discoveryLoop()
 	d.done.Add(1)
 	return d
 }
 
-func (d *DNS) RunOnce() {
-	d.runDiscovery()
-}
-
-func (d *DNS) Addresses() []string {
+func (d *dns) Addresses() []string {
 	return d.dnsProvider.Addresses()
 }
 
-func (d *DNS) Stop() {
+func (d *dns) Stop() {
 	// Integration tests were calling Stop() multiple times, so we need to make sure
 	// that we only close the stop channel once.
 	d.once.Do(func() { close(d.stop) })
 	d.done.Wait()
 }
 
-func (d *DNS) discoveryLoop() {
+func (d *dns) discoveryLoop() {
 	ticker := time.NewTicker(d.cleanupPeriod)
 	defer func() {
 		ticker.Stop()
@@ -70,7 +72,7 @@ func (d *DNS) discoveryLoop() {
 	}
 }
 
-func (d *DNS) runDiscovery() {
+func (d *dns) runDiscovery() {
 	ctx, cancel := context.WithTimeoutCause(context.Background(), 5*time.Second, fmt.Errorf("DNS lookup timeout: %v", d.addresses))
 	defer cancel()
 	err := d.dnsProvider.Resolve(ctx, d.addresses)


### PR DESCRIPTION
I would like to bound the number of retries on the indexgateway client because it seems like dangerous behaviour to retry against every single index gateway for a single request. In service to that, I'm first proposing that we add a metric so that we can see how many retries are being used in practice. 

- This change also increases test coverage of client.go, for which it makes DNS into an interface so it can be mocked. 
- Also move DNS's initial call to runDiscovery() to happen in the constructor rather than being called immediately after the constructor in all usages.
- This change also includes a refactor of index gateway client to simplify it a little bit. 