### PR TITLE
Clarify lokitool rules format and check wording

### DIFF
--- a/docs/sources/alert/_index.md
+++ b/docs/sources/alert/_index.md
@@ -232,6 +232,9 @@ An example workflow is included below:
 # format the rules.yaml file, reordering keys and reformatting PromQL expressions
 lokitool rules format ./output/rules.yaml
 
+# lint the rules against best practices without rewriting the file
+lokitool rules check ./output/rules.yaml
+
 # diff rules against the currently managed ruleset in Loki
 lokitool rules diff --rule-dirs=./output
 
@@ -256,6 +259,10 @@ lokitool rules sync --rule-dirs=./output --namespaces-regex='^prod-.*'
 # print the remote ruleset
 lokitool rules print
 ```
+
+{{< admonition type="note" >}}
+`lokitool rules lint` is a deprecated alias for `lokitool rules format` and is kept only for backward compatibility.
+{{< /admonition >}}
 
 {{< admonition type="note" >}}
 The `diff` and `sync` commands support namespace filtering with the following flags (only one can be used at a time):

--- a/pkg/tool/commands/rules.go
+++ b/pkg/tool/commands/rules.go
@@ -121,11 +121,11 @@ func (r *RuleCommand) Register(app *kingpin.Application) {
 		Command("prepare", "Modifies a set of rules by including an specific label in aggregations.").
 		Action(r.prepare)
 	formatCmd := rulesCmd.
-		Command("format", "Formats a set of rule files. It reorders keys alphabetically, uses 4 spaces as indentation, and formats PromQL expressions to a single line. `lint` is an alias for `format` and is deprecated.").
+		Command("format", "Formats a set of rule files. It reorders keys alphabetically, uses 4 spaces as indentation, and formats PromQL expressions to a single line. The `lint` alias is deprecated and kept only for backward compatibility.").
 		Alias("lint").
 		Action(r.format)
 	checkCmd := rulesCmd.
-		Command("check", "Runs various best practice checks against rules.").
+		Command("check", "Lints rules against best-practice checks without rewriting the files.").
 		Action(r.checkRecordingRuleNames)
 
 	// Require Loki cluster address and tentant ID on all these commands

--- a/pkg/tool/commands/rules_test.go
+++ b/pkg/tool/commands/rules_test.go
@@ -1,10 +1,13 @@
 package commands
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/tool/rules/rwrulefmt"
 )
@@ -60,4 +63,40 @@ func TestCheckDuplicates(t *testing.T) {
 			assert.Equal(t, tc.want, checkDuplicates(tc.in))
 		})
 	}
+}
+
+func TestRuleCommandHelpClarifiesFormatAndCheck(t *testing.T) {
+	app := kingpin.New("lokitool", "A command-line tool to manage Loki.")
+	var ruleCommand RuleCommand
+	ruleCommand.Register(app)
+
+	t.Run("rules help", func(t *testing.T) {
+		ctx, err := app.ParseContext([]string{"rules"})
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		app.Writer(&buf)
+		require.NoError(t, app.UsageForContext(ctx))
+
+		out := buf.String()
+		assert.Contains(t, out, "rules format [<flags>] [<rule-files>...]")
+		assert.Contains(t, out, "The `lint`")
+		assert.Contains(t, out, "alias is deprecated and kept only for backward compatibility.")
+		assert.Contains(t, out, "rules check [<flags>] [<rule-files>...]")
+		assert.Contains(t, out, "Lints rules against best-practice checks without rewriting the files.")
+	})
+
+	t.Run("format help", func(t *testing.T) {
+		ctx, err := app.ParseContext([]string{"rules", "format"})
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		app.Writer(&buf)
+		require.NoError(t, app.UsageForContext(ctx))
+
+		out := buf.String()
+		assert.Contains(t, out, "The `lint` alias")
+		assert.Contains(t, out, "is deprecated and kept only for backward compatibility.")
+		assert.Contains(t, out, "The rule files to format.")
+	})
 }


### PR DESCRIPTION
## What
- clarify that `lokitool rules format` rewrites rule files
- clarify that `lokitool rules check` is the lint-style, non-mutating validation step
- add a docs example for `lokitool rules check` and note that `rules lint` is a deprecated alias for `rules format`
- cover the CLI help text with a focused unit test

## Why
Fixes #20288. The current naming/help text still leaves room for confusion because `lint` is a deprecated alias for `format`, while `check` is the command that performs best-practice linting.

## Testing
- `go test ./pkg/tool/commands`
- `go run ./cmd/lokitool rules --help`