### PR TITLE
chore(stats): Correctly account staging time for cancelled tasks

### DIFF
--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -22,7 +22,6 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/schedulerstat"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/queue/fair"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
@@ -1177,7 +1176,6 @@ func (s *Scheduler) enqueueTasks(tasks []*task) {
 		}
 
 		task.MarkQueued()
-		task.region.Record(schedulerstat.TaskStagingDuration.Observe(task.QueueTime().Sub(task.createTime).Nanoseconds()))
 		if err := s.taskQueue.Push(task.scope, task); err != nil {
 			level.Error(s.logger).Log("msg", "failed to enqueue task; task will not be executed", "id", task.inner.ULID, "err", err)
 		}

--- a/pkg/engine/internal/scheduler/schedulerstat/schedulerstat.go
+++ b/pkg/engine/internal/scheduler/schedulerstat/schedulerstat.go
@@ -10,8 +10,9 @@ import "github.com/grafana/loki/v3/pkg/xcap"
 
 var (
 	// TaskStagingDuration is the time (in nanoseconds) a task spent staged
-	// between scheduler registration and being enqueued for assignment. Not
-	// recorded for tasks that never reached the queue.
+	// between scheduler registration and being enqueued for assignment. For
+	// a task that was never enqueued, this stat captures the entire duration
+	// from registration to terminal state.
 	TaskStagingDuration = xcap.NewStatisticInt64("scheduler.task.staging.duration", xcap.AggregationTypeSum)
 
 	// TaskQueueDuration is the time (in nanoseconds) a task spent enqueued before

--- a/pkg/engine/internal/scheduler/task.go
+++ b/pkg/engine/internal/scheduler/task.go
@@ -229,6 +229,8 @@ func (t *task) RecordTerminalObservations(now time.Time) {
 	t.region.Record(schedulerstat.TaskAssignmentRetries.Observe(int64(requeues)))
 
 	if !queueTime.IsZero() {
+		t.region.Record(schedulerstat.TaskStagingDuration.Observe(queueTime.Sub(t.createTime).Nanoseconds()))
+
 		// Queue time ends at assignment, or at the terminal state if the task
 		// was never assigned.
 		queueEnd := now
@@ -236,7 +238,12 @@ func (t *task) RecordTerminalObservations(now time.Time) {
 			queueEnd = assignTime
 		}
 		t.region.Record(schedulerstat.TaskQueueDuration.Observe(queueEnd.Sub(queueTime).Nanoseconds()))
+	} else {
+		// For a task that was never enqueued, record the entire duration
+		// from creation to terminal state as staging duration.
+		t.region.Record(schedulerstat.TaskStagingDuration.Observe(now.Sub(t.createTime).Nanoseconds()))
 	}
+
 	if !assignTime.IsZero() {
 		t.region.Record(schedulerstat.TaskExecutionDuration.Observe(now.Sub(assignTime).Nanoseconds()))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Capture staging duration for cancelled tasks. For a task that is never enqueued, entire duration from it's registration to terminal state is considered as staging duration.

This PR also moves the staging duration capture for successfully enqueued tasks to `RecordTerminalObservations` to ensure exactly-once recording. We risk recording it twice in `enqueueTasks` and `RecordTerminalObservations` if a task is cancelled right around dispatch.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
