### PR TITLE
fix(v2-engine): Preserve explicit empty values from line_format/label_format through mergeColumns to match v1

### DIFF
--- a/pkg/engine/internal/executor/project.go
+++ b/pkg/engine/internal/executor/project.go
@@ -242,9 +242,18 @@ func labelFmtRenameSources(expr physical.Expression) map[string]struct{} {
 	return renameSources
 }
 
-// mergeColumns merges two columns by preferring non-null and non-empty values from the new column (b).
-// If b has a null or empty value at index i, keep the value from a at that index.
-// If b has a non-null and non-empty value at index i, use the value from b (overwriting a).
+// mergeColumns merges two columns by preferring values from the new column (b),
+// falling back to the old column (a) only where b is null. An explicit empty
+// string in b is treated as a real value and overwrites a.
+//
+// The null-vs-empty distinction matters: producers (line_format / label_format
+// / logfmt / json / regexp) emit null only when this row didn't contribute a
+// value for the key (so the old column's value should survive), and emit ""
+// when the value is genuinely empty (template rendered "", rename source was
+// "", parsed key extracted an empty value). Treating "" as a missing value
+// silently turned every "rendered to empty" into "keep original", which
+// diverges from v1 — most visibly for `line_format` whose output column always
+// collides with the builtin `message` column.
 func mergeColumns(a, b arrow.Array) arrow.Array {
 	// Only handle string arrays for now (which is what parsers produce)
 	aStr, aOk := a.(*array.String)
@@ -259,8 +268,8 @@ func mergeColumns(a, b arrow.Array) arrow.Array {
 	builder.Reserve(aStr.Len())
 
 	for i := range aStr.Len() {
-		if bStr.IsNull(i) || bStr.Value(i) == "" {
-			// New value is null or empty, keep old value
+		if bStr.IsNull(i) {
+			// New column has no value for this row, keep the old one.
 			if aStr.IsNull(i) {
 				builder.AppendNull()
 			} else {

--- a/pkg/engine/internal/executor/project_test.go
+++ b/pkg/engine/internal/executor/project_test.go
@@ -1035,6 +1035,39 @@ func TestNewProjectPipeline_LabelFmtRenameDropsSourceColumn(t *testing.T) {
 				"utf8.label.foo":                 "dev",
 			}},
 		},
+		{
+			// Template renders to empty (literal ""); the pre-existing destination
+			// label `foo` must be overwritten with "". v1 semantics: a template
+			// always writes its result, including an empty result.`
+			name: "template literal empty overwrites existing destination",
+			dataFields: []arrow.Field{
+				semconv.FieldFromFQN("utf8.label.foo", false),
+			},
+			dataValues: arrowtest.Row{"utf8.label.foo": "old"},
+			labelFmts:  []log.LabelFmt{{Name: "foo", Value: "", Rename: false}},
+			expected: arrowtest.Rows{{
+				"utf8.builtin.message":           msg,
+				"timestamp_ns.builtin.timestamp": ts,
+				"utf8.label.foo":                 "",
+			}},
+		},
+		{
+			// Template references a label whose value is empty; the rendered
+			// result is "" and that overwrites the pre-existing destination.
+			name: "template referencing empty-valued label overwrites existing destination",
+			dataFields: []arrow.Field{
+				semconv.FieldFromFQN("utf8.label.foo", false),
+				semconv.FieldFromFQN("utf8.label.bar", false),
+			},
+			dataValues: arrowtest.Row{"utf8.label.foo": "old", "utf8.label.bar": ""},
+			labelFmts:  []log.LabelFmt{{Name: "foo", Value: "{{.bar}}", Rename: false}},
+			expected: arrowtest.Rows{{
+				"utf8.builtin.message":           msg,
+				"timestamp_ns.builtin.timestamp": ts,
+				"utf8.label.bar":                 "",
+				"utf8.label.foo":                 "",
+			}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1076,6 +1109,113 @@ func TestNewProjectPipeline_LabelFmtRenameDropsSourceColumn(t *testing.T) {
 			actualRows, err := arrowtest.RecordRows(record)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, actualRows)
+		})
+	}
+}
+
+// TestNewProjectPipeline_LineFmtReplacesMessageWithEmpty verifies that when
+// `line_format` renders to "" the builtin `message` column is replaced with ""
+// — matching v1, which always overwrites the line with the template output
+// (including empty). Previously mergeColumns treated a new-column "" as
+// "missing, keep old" and silently kept the original raw log line.
+func TestNewProjectPipeline_LineFmtReplacesMessageWithEmpty(t *testing.T) {
+	ts := time.Unix(1700000000, 0).UTC()
+
+	tests := []struct {
+		name     string
+		template string
+		// extraFields/extraValues add a parsed column whose value the template
+		// may reference. Empty/nil means no extra column.
+		extraFields []arrow.Field
+		extraValues arrowtest.Row
+		// expectedMessage is the value of the builtin.message column after the
+		// pipeline runs.
+		expectedMessage string
+	}{
+		{
+			name:            "literal empty template renders to empty line",
+			template:        "",
+			expectedMessage: "",
+		},
+		{
+			name:            "missing-key under missingkey=zero renders to empty line",
+			template:        "{{.does_not_exist}}",
+			expectedMessage: "",
+		},
+		{
+			name:            "simple-key whose column does not exist in batch renders to empty line",
+			template:        "{{.also_missing}}",
+			expectedMessage: "",
+		},
+		{
+			name:            "simple-key whose column has an empty value renders to empty line",
+			template:        "{{.orgID}}",
+			extraFields:     []arrow.Field{semconv.FieldFromFQN("utf8.parsed.orgID", true)},
+			extraValues:     arrowtest.Row{"utf8.parsed.orgID": ""},
+			expectedMessage: "",
+		},
+		{
+			name:            "simple-key whose column has a non-empty value renders the value",
+			template:        "{{.orgID}}",
+			extraFields:     []arrow.Field{semconv.FieldFromFQN("utf8.parsed.orgID", true)},
+			extraValues:     arrowtest.Row{"utf8.parsed.orgID": "tenant-7"},
+			expectedMessage: "tenant-7",
+		},
+		{
+			name:            "general template rendering empty still replaces the line",
+			template:        "{{.orgID}}{{.also_missing}}",
+			extraFields:     []arrow.Field{semconv.FieldFromFQN("utf8.parsed.orgID", true)},
+			extraValues:     arrowtest.Row{"utf8.parsed.orgID": ""},
+			expectedMessage: "",
+		},
+		{
+			name:            "literal non-empty template replaces the line",
+			template:        "CONSTANT",
+			expectedMessage: "CONSTANT",
+		},
+	}
+
+	originalMsg := "time=... orgID=\"\" status=401"
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := arrow.NewSchema(append([]arrow.Field{
+				semconv.FieldFromIdent(semconv.ColumnIdentMessage, false),
+				semconv.FieldFromIdent(semconv.ColumnIdentTimestamp, false),
+			}, tt.extraFields...), nil)
+
+			row := arrowtest.Row{
+				"utf8.builtin.message":           originalMsg,
+				"timestamp_ns.builtin.timestamp": ts,
+			}
+			for k, v := range tt.extraValues {
+				row[k] = v
+			}
+
+			input := NewArrowtestPipeline(schema, arrowtest.Rows{row})
+			parseExpr := &physical.VariadicExpr{
+				Op: types.VariadicOpParseLinefmt,
+				Expressions: []physical.Expression{
+					&physical.ColumnExpr{Ref: semconv.ColumnIdentMessage.ColumnRef()},
+					physical.NewLiteral([]string{}),
+					physical.NewLiteral(tt.template),
+				},
+			}
+			proj := &physical.Projection{
+				Expressions: []physical.Expression{parseExpr},
+				All:         true,
+				Expand:      true,
+			}
+
+			pipeline, err := NewProjectPipeline(input, proj, newExpressionEvaluator())
+			require.NoError(t, err)
+			record, err := pipeline.Read(t.Context())
+			require.NoError(t, err)
+
+			actualRows, err := arrowtest.RecordRows(record)
+			require.NoError(t, err)
+			require.Len(t, actualRows, 1)
+			require.Equal(t, tt.expectedMessage, actualRows[0]["utf8.builtin.message"])
 		})
 	}
 }

--- a/pkg/logql/bench/queries/regression/log-queries.yaml
+++ b/pkg/logql/bench/queries/regression/log-queries.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=../schema.json
+---
+queries:
+  - description: line_format renders empty template output as empty line, not original raw line
+    query: ${SELECTOR} | logfmt | line_format `{{.error}}`
+    kind: log
+    time_range:
+      length: 24h
+    directions: backward # forward log queries unsupported by v2 engine
+    tags:
+      - logfmt
+      - line_format
+      - absent-field
+      - empty-rendering
+    notes: >
+      Regression for the v2 mergeColumns "empty-as-missing" bug.
+      The `error` logfmt field is only emitted for error-level lines, so its
+      parsed column is null for every non-error row. After PR #22342,
+      valueStrOrEmpty renders null entries as "" at the template-input
+      boundary, so `{{.error}}` renders to "" on non-error rows. Before the
+      mergeColumns fix, the projection layer treated that "" as "missing,
+      keep old" and silently returned the original raw log line for those
+      rows — making line_format appear to have no effect. v1 always
+      overwrites the line with the template output, including an empty
+      result. The returned lines and per-stream counts must match v1 across
+      both error and non-error rows.
+    requires:
+      log_format: logfmt
+      detected_fields:
+        - error


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a v2-engine correctness bug where `| line_format` (and template-path `| label_format` writing over an existing label) appeared to have no effect whenever the rendered template output was an empty string. The bug is most visible in queries like `... | logfmt | line_format "{{.orgID}}"` against log streams whose `orgID` field is empty for a subset of rows: v2 returned the original raw log line for those rows instead of the empty line v1 produces.

**Root cause**

`mergeColumns` in `pkg/engine/internal/executor/project.go` reconciles a parser/format stage's output column with the same-named existing column in the batch (the builtin `message` column for `line_format`, a label column for `label_format`). Its fallback rule conflated two distinct producer signals:

- `null` (the producer found no value for this row) — fall back to old column ✓
- `""` (the producer explicitly produced an empty value — template rendered empty, parsed key was an explicit empty value, etc.) — fall back to old column ✗

Treating `""` as "missing, keep old" silently dropped every "rendered to empty" into a no-op. For `line_format`, whose output always collides with the builtin `message` column, this was immediately apparent: the line remained the original raw log line.

**Fix**

`mergeColumns` now falls back to the old column **only on `null`**, never on `""`.