### PR TITLE
fix(operator): Update all components PDBs to maxUnavailable of 1

### DIFF
--- a/operator/internal/manifests/distributor.go
+++ b/operator/internal/manifests/distributor.go
@@ -236,7 +236,6 @@ func configureDistributorGRPCServicePKI(deployment *appsv1.Deployment, opts Opti
 // Distributor pods.
 func newDistributorPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 	l := ComponentLabels(LabelDistributorComponent, opts.Name)
-	mu := intstr.FromInt(1)
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
@@ -251,7 +250,7 @@ func newDistributorPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudg
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},
-			MaxUnavailable: &mu,
+			MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 		},
 	}
 }

--- a/operator/internal/manifests/distributor.go
+++ b/operator/internal/manifests/distributor.go
@@ -251,7 +251,7 @@ func newDistributorPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudg
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},
-			MinAvailable: &mu,
+			MaxUnavailable: &mu,
 		},
 	}
 }

--- a/operator/internal/manifests/distributor_test.go
+++ b/operator/internal/manifests/distributor_test.go
@@ -116,8 +116,8 @@ func TestBuildDistributor_PodDisruptionBudget(t *testing.T) {
 	require.NotNil(t, pdb)
 	require.Equal(t, "abcd-distributor", pdb.Name)
 	require.Equal(t, "efgh", pdb.Namespace)
-	require.NotNil(t, pdb.Spec.MinAvailable.IntVal)
-	require.Equal(t, int32(1), pdb.Spec.MinAvailable.IntVal)
+	require.NotNil(t, pdb.Spec.MaxUnavailable.IntVal)
+	require.Equal(t, int32(1), pdb.Spec.MaxUnavailable.IntVal)
 	require.EqualValues(t, ComponentLabels(LabelDistributorComponent, opts.Name), pdb.Spec.Selector.MatchLabels)
 }
 

--- a/operator/internal/manifests/gateway.go
+++ b/operator/internal/manifests/gateway.go
@@ -520,7 +520,6 @@ func NewServiceAccountTokenSecret(opts Options) client.Object {
 // Gateway pods.
 func NewGatewayPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 	l := ComponentLabels(LabelGatewayComponent, opts.Name)
-	mu := intstr.FromInt(1)
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
@@ -535,7 +534,7 @@ func NewGatewayPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},
-			MaxUnavailable: &mu,
+			MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 		},
 	}
 }

--- a/operator/internal/manifests/gateway.go
+++ b/operator/internal/manifests/gateway.go
@@ -535,7 +535,7 @@ func NewGatewayPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},
-			MinAvailable: &mu,
+			MaxUnavailable: &mu,
 		},
 	}
 }

--- a/operator/internal/manifests/gateway_test.go
+++ b/operator/internal/manifests/gateway_test.go
@@ -1445,8 +1445,8 @@ func TestBuildGateway_PodDisruptionBudget(t *testing.T) {
 	require.NotNil(t, pdb)
 	require.Equal(t, "abcd-gateway", pdb.Name)
 	require.Equal(t, "efgh", pdb.Namespace)
-	require.NotNil(t, pdb.Spec.MinAvailable.IntVal)
-	require.Equal(t, int32(1), pdb.Spec.MinAvailable.IntVal)
+	require.NotNil(t, pdb.Spec.MaxUnavailable.IntVal)
+	require.Equal(t, int32(1), pdb.Spec.MaxUnavailable.IntVal)
 	require.EqualValues(t, ComponentLabels(LabelGatewayComponent, opts.Name), pdb.Spec.Selector.MatchLabels)
 }
 

--- a/operator/internal/manifests/indexgateway.go
+++ b/operator/internal/manifests/indexgateway.go
@@ -252,7 +252,7 @@ func NewIndexGatewayHTTPService(opts Options) *corev1.Service {
 // index-gateway pods.
 func NewIndexGatewayPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 	l := ComponentLabels(LabelIndexGatewayComponent, opts.Name)
-	ma := intstr.FromInt(1)
+	mu := intstr.FromInt(1)
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
@@ -267,7 +267,7 @@ func NewIndexGatewayPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBud
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},
-			MinAvailable: &ma,
+			MaxUnavailable: &mu,
 		},
 	}
 }

--- a/operator/internal/manifests/indexgateway.go
+++ b/operator/internal/manifests/indexgateway.go
@@ -252,7 +252,6 @@ func NewIndexGatewayHTTPService(opts Options) *corev1.Service {
 // index-gateway pods.
 func NewIndexGatewayPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 	l := ComponentLabels(LabelIndexGatewayComponent, opts.Name)
-	mu := intstr.FromInt(1)
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
@@ -267,7 +266,7 @@ func NewIndexGatewayPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBud
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},
-			MaxUnavailable: &mu,
+			MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 		},
 	}
 }

--- a/operator/internal/manifests/indexgateway_test.go
+++ b/operator/internal/manifests/indexgateway_test.go
@@ -123,8 +123,8 @@ func TestBuildIndexGateway_PodDisruptionBudget(t *testing.T) {
 	require.NotNil(t, pdb)
 	require.Equal(t, "abcd-index-gateway", pdb.Name)
 	require.Equal(t, "efgh", pdb.Namespace)
-	require.NotNil(t, pdb.Spec.MinAvailable.IntVal)
-	require.Equal(t, int32(1), pdb.Spec.MinAvailable.IntVal)
+	require.NotNil(t, pdb.Spec.MaxUnavailable.IntVal)
+	require.Equal(t, int32(1), pdb.Spec.MaxUnavailable.IntVal)
 	require.EqualValues(t, ComponentLabels(LabelIndexGatewayComponent, opts.Name),
 		pdb.Spec.Selector.MatchLabels)
 }

--- a/operator/internal/manifests/ingester.go
+++ b/operator/internal/manifests/ingester.go
@@ -290,16 +290,7 @@ func configureIngesterGRPCServicePKI(sts *appsv1.StatefulSet, opts Options) erro
 // Ingester pods.
 func newIngesterPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 	l := ComponentLabels(LabelIngesterComponent, opts.Name)
-	rf := DefaultLokiStackSpec(opts.Stack.Size).Replication.Factor
-	if opts.Stack.Replication != nil && opts.Stack.Replication.Factor != 0 {
-		rf = opts.Stack.Replication.Factor
-	}
-
-	pdbMinAvailable := rf
-	if pdbMinAvailable >= opts.Stack.Template.Ingester.Replicas {
-		pdbMinAvailable = max(1, opts.Stack.Template.Ingester.Replicas-1)
-	}
-	minAvailable := intstr.FromInt32(pdbMinAvailable)
+	mu := intstr.FromInt(1)
 
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
@@ -315,7 +306,7 @@ func newIngesterPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget 
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},
-			MinAvailable: &minAvailable,
+			MaxUnavailable: &mu,
 		},
 	}
 }

--- a/operator/internal/manifests/ingester.go
+++ b/operator/internal/manifests/ingester.go
@@ -290,8 +290,6 @@ func configureIngesterGRPCServicePKI(sts *appsv1.StatefulSet, opts Options) erro
 // Ingester pods.
 func newIngesterPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 	l := ComponentLabels(LabelIngesterComponent, opts.Name)
-	mu := intstr.FromInt(1)
-
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
@@ -306,7 +304,7 @@ func newIngesterPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget 
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},
-			MaxUnavailable: &mu,
+			MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 		},
 	}
 }

--- a/operator/internal/manifests/ingester_test.go
+++ b/operator/internal/manifests/ingester_test.go
@@ -131,7 +131,6 @@ func TestBuildIngester_PodDisruptionBudget(t *testing.T) {
 	require.NotNil(t, pdb.Spec.MaxUnavailable.IntVal)
 	require.Equal(t, int32(1), pdb.Spec.MaxUnavailable.IntVal)
 	require.EqualValues(t, ComponentLabels(LabelIngesterComponent, opts.Name), pdb.Spec.Selector.MatchLabels)
-
 }
 
 func TestNewIngesterStatefulSet_TopologySpreadConstraints(t *testing.T) {

--- a/operator/internal/manifests/ingester_test.go
+++ b/operator/internal/manifests/ingester_test.go
@@ -104,61 +104,34 @@ func TestNewIngesterStatefulSet_SelectorMatchesLabels(t *testing.T) {
 }
 
 func TestBuildIngester_PodDisruptionBudget(t *testing.T) {
-	for _, tc := range []struct {
-		Name                 string
-		Replicas             int
-		ExpectedMinAvailable int
-		Size                 lokiv1.LokiStackSizeType
-	}{
-		{
-			Name:                 "replication factor = replicas",
-			Size:                 lokiv1.SizeOneXExtraSmall,
-			Replicas:             2,
-			ExpectedMinAvailable: 1,
-		},
-		{
-			Name:                 "replication factor < replicas",
-			Size:                 lokiv1.SizeOneXMedium,
-			Replicas:             3,
-			ExpectedMinAvailable: 2,
-		},
-		{
-			Name:                 "replication factor > replicas",
-			Size:                 lokiv1.SizeOneXDemo,
-			Replicas:             1,
-			ExpectedMinAvailable: 1,
-		},
-	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			opts := Options{
-				Name:      "abcd",
-				Namespace: "efgh",
-				Gates:     v1.FeatureGates{},
-				Stack: lokiv1.LokiStackSpec{
-					Size: tc.Size,
-					Template: &lokiv1.LokiTemplateSpec{
-						Ingester: &lokiv1.LokiComponentSpec{
-							Replicas: int32(tc.Replicas),
-						},
-					},
-					Tenants: &lokiv1.TenantsSpec{
-						Mode: lokiv1.OpenshiftLogging,
-					},
+	opts := Options{
+		Name:      "abcd",
+		Namespace: "efgh",
+		Gates:     v1.FeatureGates{},
+		Stack: lokiv1.LokiStackSpec{
+			Size: lokiv1.SizeOneXExtraSmall,
+			Template: &lokiv1.LokiTemplateSpec{
+				Ingester: &lokiv1.LokiComponentSpec{
+					Replicas: 2,
 				},
-			}
-			objs, err := BuildIngester(opts)
-			require.NoError(t, err)
-			require.Len(t, objs, 4)
-
-			pdb := objs[3].(*policyv1.PodDisruptionBudget)
-			require.NotNil(t, pdb)
-			require.Equal(t, "abcd-ingester", pdb.Name)
-			require.Equal(t, "efgh", pdb.Namespace)
-			require.NotNil(t, pdb.Spec.MinAvailable.IntVal)
-			require.Equal(t, int32(tc.ExpectedMinAvailable), pdb.Spec.MinAvailable.IntVal)
-			require.EqualValues(t, ComponentLabels(LabelIngesterComponent, opts.Name), pdb.Spec.Selector.MatchLabels)
-		})
+			},
+			Tenants: &lokiv1.TenantsSpec{
+				Mode: lokiv1.OpenshiftLogging,
+			},
+		},
 	}
+	objs, err := BuildIngester(opts)
+	require.NoError(t, err)
+	require.Len(t, objs, 4)
+
+	pdb := objs[3].(*policyv1.PodDisruptionBudget)
+	require.NotNil(t, pdb)
+	require.Equal(t, "abcd-ingester", pdb.Name)
+	require.Equal(t, "efgh", pdb.Namespace)
+	require.NotNil(t, pdb.Spec.MaxUnavailable.IntVal)
+	require.Equal(t, int32(1), pdb.Spec.MaxUnavailable.IntVal)
+	require.EqualValues(t, ComponentLabels(LabelIngesterComponent, opts.Name), pdb.Spec.Selector.MatchLabels)
+
 }
 
 func TestNewIngesterStatefulSet_TopologySpreadConstraints(t *testing.T) {

--- a/operator/internal/manifests/querier.go
+++ b/operator/internal/manifests/querier.go
@@ -2,7 +2,6 @@ package manifests
 
 import (
 	"fmt"
-	"math"
 	"path"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -231,10 +230,7 @@ func NewQuerierHTTPService(opts Options) *corev1.Service {
 // NewQuerierPodDisruptionBudget returns a PodDisruptionBudget for the LokiStack querier pods.
 func NewQuerierPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 	l := ComponentLabels(LabelQuerierComponent, opts.Name)
-
-	// Have at least N-1 replicas available, unless N==1 in which case the minimum available is 1.
-	replicas := opts.Stack.Template.Querier.Replicas
-	ma := intstr.FromInt(int(math.Max(1, float64(replicas-1))))
+	mu := intstr.FromInt(1)
 
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
@@ -250,7 +246,7 @@ func NewQuerierPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},
-			MinAvailable: &ma,
+			MaxUnavailable: &mu,
 		},
 	}
 }

--- a/operator/internal/manifests/querier.go
+++ b/operator/internal/manifests/querier.go
@@ -230,8 +230,6 @@ func NewQuerierHTTPService(opts Options) *corev1.Service {
 // NewQuerierPodDisruptionBudget returns a PodDisruptionBudget for the LokiStack querier pods.
 func NewQuerierPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 	l := ComponentLabels(LabelQuerierComponent, opts.Name)
-	mu := intstr.FromInt(1)
-
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
@@ -246,7 +244,7 @@ func NewQuerierPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},
-			MaxUnavailable: &mu,
+			MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 		},
 	}
 }

--- a/operator/internal/manifests/querier_test.go
+++ b/operator/internal/manifests/querier_test.go
@@ -109,60 +109,6 @@ func TestBuildQuerier_PodDisruptionBudget(t *testing.T) {
 		want policyv1.PodDisruptionBudget
 	}{
 		{
-			name: "Querier with 1 replica",
-			opts: Options{
-				Name:      "abcd",
-				Namespace: "efgh",
-				Stack: lokiv1.LokiStackSpec{
-					Template: &lokiv1.LokiTemplateSpec{
-						Querier: &lokiv1.LokiComponentSpec{
-							Replicas: 1,
-						},
-					},
-				},
-			},
-			want: policyv1.PodDisruptionBudget{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abcd-querier",
-					Namespace: "efgh",
-					Labels:    ComponentLabels(LabelQuerierComponent, "abcd"),
-				},
-				Spec: policyv1.PodDisruptionBudgetSpec{
-					MinAvailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
-					Selector: &metav1.LabelSelector{
-						MatchLabels: ComponentLabels(LabelQuerierComponent, "abcd"),
-					},
-				},
-			},
-		},
-		{
-			name: "Querier with 2 replicas",
-			opts: Options{
-				Name:      "abcd",
-				Namespace: "efgh",
-				Stack: lokiv1.LokiStackSpec{
-					Template: &lokiv1.LokiTemplateSpec{
-						Querier: &lokiv1.LokiComponentSpec{
-							Replicas: 2,
-						},
-					},
-				},
-			},
-			want: policyv1.PodDisruptionBudget{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "abcd-querier",
-					Namespace: "efgh",
-					Labels:    ComponentLabels(LabelQuerierComponent, "abcd"),
-				},
-				Spec: policyv1.PodDisruptionBudgetSpec{
-					MinAvailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
-					Selector: &metav1.LabelSelector{
-						MatchLabels: ComponentLabels(LabelQuerierComponent, "abcd"),
-					},
-				},
-			},
-		},
-		{
 			name: "Querier with 3 replicas",
 			opts: Options{
 				Name:      "abcd",
@@ -182,7 +128,7 @@ func TestBuildQuerier_PodDisruptionBudget(t *testing.T) {
 					Labels:    ComponentLabels(LabelQuerierComponent, "abcd"),
 				},
 				Spec: policyv1.PodDisruptionBudgetSpec{
-					MinAvailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 2},
+					MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
 					Selector: &metav1.LabelSelector{
 						MatchLabels: ComponentLabels(LabelQuerierComponent, "abcd"),
 					},

--- a/operator/internal/manifests/query-frontend.go
+++ b/operator/internal/manifests/query-frontend.go
@@ -238,7 +238,6 @@ func NewQueryFrontendHTTPService(opts Options) *corev1.Service {
 // query-frontend pods.
 func NewQueryFrontendPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 	l := ComponentLabels(LabelQueryFrontendComponent, opts.Name)
-	mu := intstr.FromInt(1)
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
@@ -253,7 +252,7 @@ func NewQueryFrontendPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBu
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},
-			MaxUnavailable: &mu,
+			MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 		},
 	}
 }

--- a/operator/internal/manifests/query-frontend.go
+++ b/operator/internal/manifests/query-frontend.go
@@ -238,7 +238,7 @@ func NewQueryFrontendHTTPService(opts Options) *corev1.Service {
 // query-frontend pods.
 func NewQueryFrontendPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 	l := ComponentLabels(LabelQueryFrontendComponent, opts.Name)
-	ma := intstr.FromInt(1)
+	mu := intstr.FromInt(1)
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
@@ -253,7 +253,7 @@ func NewQueryFrontendPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBu
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},
-			MinAvailable: &ma,
+			MaxUnavailable: &mu,
 		},
 	}
 }

--- a/operator/internal/manifests/query-frontend_test.go
+++ b/operator/internal/manifests/query-frontend_test.go
@@ -112,8 +112,8 @@ func TestBuildQueryFrontend_PodDisruptionBudget(t *testing.T) {
 	require.NotNil(t, pdb)
 	require.Equal(t, "abcd-query-frontend", pdb.Name)
 	require.Equal(t, "efgh", pdb.Namespace)
-	require.NotNil(t, pdb.Spec.MinAvailable.IntVal)
-	require.Equal(t, int32(1), pdb.Spec.MinAvailable.IntVal)
+	require.NotNil(t, pdb.Spec.MaxUnavailable.IntVal)
+	require.Equal(t, int32(1), pdb.Spec.MaxUnavailable.IntVal)
 	require.EqualValues(t, ComponentLabels(LabelQueryFrontendComponent, opts.Name), pdb.Spec.Selector.MatchLabels)
 }
 

--- a/operator/internal/manifests/ruler.go
+++ b/operator/internal/manifests/ruler.go
@@ -382,8 +382,6 @@ func ruleVolumeItems(configMapName string, tenants map[string]TenantConfig) []co
 // NewRulerPodDisruptionBudget returns a PodDisruptionBudget for the LokiStack ruler pods.
 func NewRulerPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 	l := ComponentLabels(LabelRulerComponent, opts.Name)
-	mu := intstr.FromInt(1)
-
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
@@ -398,7 +396,7 @@ func NewRulerPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},
-			MaxUnavailable: &mu,
+			MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 		},
 	}
 }

--- a/operator/internal/manifests/ruler.go
+++ b/operator/internal/manifests/ruler.go
@@ -382,8 +382,7 @@ func ruleVolumeItems(configMapName string, tenants map[string]TenantConfig) []co
 // NewRulerPodDisruptionBudget returns a PodDisruptionBudget for the LokiStack ruler pods.
 func NewRulerPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 	l := ComponentLabels(LabelRulerComponent, opts.Name)
-
-	ma := intstr.FromInt(1)
+	mu := intstr.FromInt(1)
 
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
@@ -399,7 +398,7 @@ func NewRulerPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},
-			MinAvailable: &ma,
+			MaxUnavailable: &mu,
 		},
 	}
 }

--- a/operator/internal/manifests/ruler_test.go
+++ b/operator/internal/manifests/ruler_test.go
@@ -217,8 +217,8 @@ func TestBuildRuler_PodDisruptionBudget(t *testing.T) {
 	require.NotNil(t, pdb)
 	require.Equal(t, "abcd-ruler", pdb.Name)
 	require.Equal(t, "efgh", pdb.Namespace)
-	require.NotNil(t, pdb.Spec.MinAvailable.IntVal)
-	require.Equal(t, int32(1), pdb.Spec.MinAvailable.IntVal)
+	require.NotNil(t, pdb.Spec.MaxUnavailable.IntVal)
+	require.Equal(t, int32(1), pdb.Spec.MaxUnavailable.IntVal)
 	require.EqualValues(t, ComponentLabels(LabelRulerComponent, opts.Name), pdb.Spec.Selector.MatchLabels)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit modifies all operator components to have PDBs set to maxUnavailable of 1, as realistically we want to ensure these components do not have more than one disrupted replica at a time.

cc: @JoaoBraveCoding as discussed offline

**Which issue(s) this PR fixes**:
https://redhat.atlassian.net/browse/LOG-9402

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
