### PR TITLE
fix: Version absent from build_info metric

### DIFF
--- a/pkg/util/build/build.go
+++ b/pkg/util/build/build.go
@@ -17,7 +17,8 @@ var (
 )
 
 func init() {
-	// Copy settings for this build into Prometheus common package, where they are fetched by Prometheus client_golang.
+	// Loki uses the metrics from prometheus/common/version. Here we set the values
+	// that are used in those metrics.
 	version.Version = Version
 	version.Revision = Revision
 	version.Branch = Branch


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/grafana/loki/pull/22281 stopped updating `prometheus/common/version`, which broke the `build_info` metric. Loki uses this metric in its release automation.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
