### PR TITLE
fix(logcli): Prevent panic and incorrect result when listing label values from a local file

### DIFF
--- a/pkg/logcli/client/file.go
+++ b/pkg/logcli/client/file.go
@@ -152,8 +152,13 @@ func (f *FileClient) ListLabelNames(_ bool, _, _ time.Time) (*loghttp.LabelRespo
 }
 
 func (f *FileClient) ListLabelValues(name string, _ bool, _, _ time.Time) (*loghttp.LabelResponse, error) {
+	// f.labels is sorted, so a binary search returns the index at which name
+	// would be inserted. The label only exists when that index is in range and
+	// the element there is an exact match; sort.SearchStrings never returns a
+	// negative value, so the previous i < 0 check could never detect a missing
+	// label and would return a wrong value or panic with an out-of-range index.
 	i := sort.SearchStrings(f.labels, name)
-	if i < 0 {
+	if i >= len(f.labels) || f.labels[i] != name {
 		return &loghttp.LabelResponse{}, nil
 	}
 

--- a/pkg/logcli/client/file_test.go
+++ b/pkg/logcli/client/file_test.go
@@ -161,14 +161,43 @@ func TestFileClient_ListLabelNames(t *testing.T) {
 }
 
 func TestFileClient_ListLabelValues(t *testing.T) {
-	c := newEmptyClient(t)
-	values, err := c.ListLabelValues(defaultLabelKey, true, time.Now(), time.Now())
-	require.NoError(t, err)
-	assert.Equal(t, &loghttp.LabelResponse{
-		Data:   []string{defaultLabelValue},
-		Status: loghttp.QueryStatusSuccess,
-	}, values)
+	cases := []struct {
+		name     string
+		label    string
+		expected *loghttp.LabelResponse
+	}{
+		{
+			name:  "existing label returns its value",
+			label: defaultLabelKey,
+			expected: &loghttp.LabelResponse{
+				Data:   []string{defaultLabelValue},
+				Status: loghttp.QueryStatusSuccess,
+			},
+		},
+		{
+			// Sorts before defaultLabelKey ("source"); previously returned the
+			// fabricated value defaultLabelValue instead of an empty response.
+			name:     "missing label sorting before the existing label returns empty",
+			label:    "aaa",
+			expected: &loghttp.LabelResponse{},
+		},
+		{
+			// Sorts after defaultLabelKey ("source"); previously panicked with an
+			// index out of range because the search index equals len(f.labels).
+			name:     "missing label sorting after the existing label returns empty",
+			label:    "zzz",
+			expected: &loghttp.LabelResponse{},
+		},
+	}
 
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			client := newEmptyClient(t)
+			values, err := client.ListLabelValues(c.label, true, time.Now(), time.Now())
+			require.NoError(t, err)
+			assert.Equal(t, c.expected, values)
+		})
+	}
 }
 
 func TestFileClient_Series(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

`logcli` can query a local log file via `--file`, which uses `FileClient`.
`FileClient.ListLabelValues` looked up a label with `sort.SearchStrings` and guarded the result with `if i < 0`. `sort.SearchStrings` returns the insertion index in `[0, len(labels)]` and never returns a negative value, so that guard  was dead code and missing labels were never detected. `FileClient` only knows the `source` label, so:

- A label name sorting after `source` (e.g. `logcli labels zone --file=...`) produced an index equal to `len(labels)`, causing an index-out-of-range panic.
- A label name sorting before `source` (e.g. `logcli labels app --file=...`) returned index `0`, yielding the fabricated value `logcli` for a label that
  does not exist.

This change guards the binary-search result with a bounds-and-exact-match check so missing labels return an empty response instead of panicking or returning a
wrong value.

**Which issue(s) this PR fixes**:
N/A — found while reviewing `pkg/logcli/client`.

**Special notes for your reviewer**:
The existing test only covered the `source` label, where `SearchStrings` happens to return index `0`, so the bug was uncovered. I converted the test to a table test adding two missing-label cases (sorting before and after `source`) that fail on `main` (panic / wrong value) and pass with this fix.

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files
