### PR TITLE
feat(compactor): Add new `increase_generation_numbers` endpoint

### DIFF
--- a/pkg/compactor/deletion/delete_requests_manager_test.go
+++ b/pkg/compactor/deletion/delete_requests_manager_test.go
@@ -1450,6 +1450,9 @@ type mockDeleteRequestsStore struct {
 	getAllRequestedForQuerytimeFiltering bool
 
 	genNumber string
+
+	updatedCacheGenForUser string
+	updateGenErr           error
 }
 
 func (m *mockDeleteRequestsStore) GetUnprocessedShards(_ context.Context) ([]deletionproto.DeleteRequest, error) {
@@ -1506,6 +1509,11 @@ func (m *mockDeleteRequestsStore) GetAllDeleteRequestsForUser(_ context.Context,
 
 func (m *mockDeleteRequestsStore) GetCacheGenerationNumber(_ context.Context, _ string) (string, error) {
 	return m.genNumber, m.getErr
+}
+
+func (m *mockDeleteRequestsStore) UpdateCacheGenerationNumber(_ context.Context, userID string) error {
+	m.updatedCacheGenForUser = userID
+	return m.updateGenErr
 }
 
 func (m *mockDeleteRequestsStore) MarkShardAsProcessed(_ context.Context, req deletionproto.DeleteRequest) error {

--- a/pkg/compactor/deletion/delete_requests_store.go
+++ b/pkg/compactor/deletion/delete_requests_store.go
@@ -37,6 +37,9 @@ type DeleteRequestsStore interface {
 	RemoveDeleteRequest(ctx context.Context, userID string, requestID string) error
 	GetDeleteRequest(ctx context.Context, userID, requestID string) (deletionproto.DeleteRequest, error)
 	GetCacheGenerationNumber(ctx context.Context, userID string) (string, error)
+	// UpdateCacheGenerationNumber bumps the cache generation number for the user
+	// so that any query result caches for the user get invalidated.
+	UpdateCacheGenerationNumber(ctx context.Context, userID string) error
 	MergeShardedRequests(ctx context.Context) error
 
 	// ToDo(Sandeep): To keep changeset smaller, below 2 methods treat a single shard as individual request. This can be refactored later in a separate PR.
@@ -196,6 +199,14 @@ func (d deleteRequestsStoreTee) GetDeleteRequest(ctx context.Context, userID, re
 
 func (d deleteRequestsStoreTee) GetCacheGenerationNumber(ctx context.Context, userID string) (string, error) {
 	return d.primaryStore.GetCacheGenerationNumber(ctx, userID)
+}
+
+func (d deleteRequestsStoreTee) UpdateCacheGenerationNumber(ctx context.Context, userID string) error {
+	if err := d.primaryStore.UpdateCacheGenerationNumber(ctx, userID); err != nil {
+		return err
+	}
+
+	return d.backupStore.UpdateCacheGenerationNumber(ctx, userID)
 }
 
 func (d deleteRequestsStoreTee) MergeShardedRequests(ctx context.Context) error {

--- a/pkg/compactor/deletion/delete_requests_store_boltdb.go
+++ b/pkg/compactor/deletion/delete_requests_store_boltdb.go
@@ -279,6 +279,14 @@ func (ds *deleteRequestsStoreBoltDB) GetCacheGenerationNumber(ctx context.Contex
 	return genNumber, nil
 }
 
+// UpdateCacheGenerationNumber bumps the cache generation number for the user so any query result caches get invalidated.
+func (ds *deleteRequestsStoreBoltDB) UpdateCacheGenerationNumber(ctx context.Context, userID string) error {
+	writeBatch := ds.indexClient.NewWriteBatch()
+	ds.updateCacheGen(userID, writeBatch)
+
+	return ds.indexClient.BatchWrite(ctx, writeBatch)
+}
+
 func (ds *deleteRequestsStoreBoltDB) queryDeleteRequests(ctx context.Context, deleteQuery boltdbcommon.Query) ([]deletionproto.DeleteRequest, error) {
 	var deleteRequests []deletionproto.DeleteRequest
 	var err error

--- a/pkg/compactor/deletion/delete_requests_store_sqlite.go
+++ b/pkg/compactor/deletion/delete_requests_store_sqlite.go
@@ -448,6 +448,19 @@ func (ds *deleteRequestsStoreSQLite) GetCacheGenerationNumber(ctx context.Contex
 	return genNumber, nil
 }
 
+// UpdateCacheGenerationNumber bumps the cache generation number for the user so any query result caches get invalidated.
+func (ds *deleteRequestsStoreSQLite) UpdateCacheGenerationNumber(ctx context.Context, userID string) error {
+	return ds.sqliteStore.Exec(ctx, true, sqlQuery{
+		query: sqlUpdateCacheGen,
+		execOpts: &sqlitex.ExecOptions{
+			Args: []any{
+				userID,
+				time.Now().UnixNano(),
+			},
+		},
+	})
+}
+
 func (ds *deleteRequestsStoreSQLite) queryDeleteRequests(ctx context.Context, query string, args []any) ([]deletionproto.DeleteRequest, error) {
 	var requests []deletionproto.DeleteRequest
 	if err := ds.sqliteStore.Exec(ctx, false, sqlQuery{

--- a/pkg/compactor/deletion/delete_requests_store_test.go
+++ b/pkg/compactor/deletion/delete_requests_store_test.go
@@ -145,6 +145,40 @@ func TestAllDeleteRequestsStoreTypes(t *testing.T) {
 	}
 }
 
+func TestUpdateCacheGenerationNumberStoreTypes(t *testing.T) {
+	for _, storeType := range []DeleteRequestsStoreDBType{DeleteRequestsStoreDBTypeBoltDB, DeleteRequestsStoreDBTypeSQLite} {
+		t.Run(string(storeType), func(t *testing.T) {
+			tc := setupStoreType(t, storeType)
+			defer tc.store.Stop()
+
+			// no gen number exists for the user yet
+			before, err := tc.store.GetCacheGenerationNumber(context.Background(), user1)
+			require.NoError(t, err)
+			require.Empty(t, before)
+
+			require.NoError(t, tc.store.UpdateCacheGenerationNumber(context.Background(), user1))
+
+			after, err := tc.store.GetCacheGenerationNumber(context.Background(), user1)
+			require.NoError(t, err)
+			require.NotEmpty(t, after)
+
+			// bumping again should yield a different (greater) gen number
+			time.Sleep(time.Millisecond)
+			require.NoError(t, tc.store.UpdateCacheGenerationNumber(context.Background(), user1))
+
+			bumped, err := tc.store.GetCacheGenerationNumber(context.Background(), user1)
+			require.NoError(t, err)
+			require.NotEqual(t, after, bumped)
+			require.Greater(t, bumped, after)
+
+			// it should not affect other users
+			otherUser, err := tc.store.GetCacheGenerationNumber(context.Background(), user2)
+			require.NoError(t, err)
+			require.Empty(t, otherUser)
+		})
+	}
+}
+
 func TestBatchCreateGetAllStoreTypes(t *testing.T) {
 	for _, storeType := range []DeleteRequestsStoreDBType{DeleteRequestsStoreDBTypeBoltDB, DeleteRequestsStoreDBTypeSQLite} {
 		t.Run(string(storeType), func(t *testing.T) {

--- a/pkg/compactor/deletion/delete_requests_store_test.go
+++ b/pkg/compactor/deletion/delete_requests_store_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -169,7 +170,14 @@ func TestUpdateCacheGenerationNumberStoreTypes(t *testing.T) {
 			bumped, err := tc.store.GetCacheGenerationNumber(context.Background(), user1)
 			require.NoError(t, err)
 			require.NotEqual(t, after, bumped)
-			require.Greater(t, bumped, after)
+
+			// the gen number is a unix nano timestamp; compare numerically so the
+			// assertion stays correct regardless of the string representation.
+			afterNum, err := strconv.ParseInt(after, 10, 64)
+			require.NoError(t, err)
+			bumpedNum, err := strconv.ParseInt(bumped, 10, 64)
+			require.NoError(t, err)
+			require.Greater(t, bumpedNum, afterNum)
 
 			// it should not affect other users
 			otherUser, err := tc.store.GetCacheGenerationNumber(context.Background(), user2)

--- a/pkg/compactor/deletion/request_handler.go
+++ b/pkg/compactor/deletion/request_handler.go
@@ -328,6 +328,31 @@ func (dm *DeleteRequestHandler) GetCacheGenerationNumberHandler(w http.ResponseW
 	}
 }
 
+// UpdateCacheGenerationNumberHandler bumps a user's cache generation number so that
+// any query result caches for the user get invalidated. This is used, for example, to
+// resolve query result inconsistencies after replaying historical data for a tenant.
+func (dm *DeleteRequestHandler) UpdateCacheGenerationNumberHandler(w http.ResponseWriter, r *http.Request) {
+	if dm == nil {
+		http.Error(w, "Retention is not enabled", http.StatusBadRequest)
+		return
+	}
+	ctx := r.Context()
+	userID, err := tenant.TenantID(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := dm.deleteRequestsStore.UpdateCacheGenerationNumber(ctx, userID); err != nil {
+		level.Error(util_log.Logger).Log("msg", "error updating cache generation number", "user", userID, "err", err)
+		http.Error(w, fmt.Sprintf("error updating cache generation number %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	level.Info(util_log.Logger).Log("msg", "cache generation number updated for user", "user", userID)
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func query(params url.Values) (string, syntax.LogSelectorExpr, error) {
 	query := params.Get("query")
 	if len(query) == 0 {

--- a/pkg/compactor/deletion/request_handler_test.go
+++ b/pkg/compactor/deletion/request_handler_test.go
@@ -373,42 +373,50 @@ func TestGetAllDeleteRequestsHandler(t *testing.T) {
 }
 
 func TestUpdateCacheGenerationNumberHandler(t *testing.T) {
-	t.Run("it bumps the cache generation number for the user", func(t *testing.T) {
-		store := &mockDeleteRequestsStore{}
-		h := NewDeleteRequestHandler(store, 0, 0, nil)
+	for _, tc := range []struct {
+		name               string
+		orgID              string
+		updateGenErr       error
+		expectedCode       int
+		expectedBody       string
+		expectedUpdateUser string
+	}{
+		{
+			name:               "it bumps the cache generation number for the user",
+			orgID:              "org-id",
+			expectedCode:       http.StatusNoContent,
+			expectedUpdateUser: "org-id",
+		},
+		{
+			name:               "it returns 500 when the store errors",
+			orgID:              "org-id",
+			updateGenErr:       errors.New("something bad"),
+			expectedCode:       http.StatusInternalServerError,
+			expectedUpdateUser: "org-id",
+		},
+		{
+			name:         "it returns 400 when there is no org id",
+			orgID:        "",
+			expectedCode: http.StatusBadRequest,
+			expectedBody: "no org id\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &mockDeleteRequestsStore{updateGenErr: tc.updateGenErr}
+			h := NewDeleteRequestHandler(store, 0, 0, nil)
 
-		req := buildRequest("org-id", ``, "", "", false)
+			req := buildRequest(tc.orgID, ``, "", "", false)
 
-		w := httptest.NewRecorder()
-		h.UpdateCacheGenerationNumberHandler(w, req)
+			w := httptest.NewRecorder()
+			h.UpdateCacheGenerationNumberHandler(w, req)
 
-		require.Equal(t, http.StatusNoContent, w.Code)
-		require.Equal(t, "org-id", store.updatedCacheGenForUser)
-	})
-
-	t.Run("it returns 500 when the store errors", func(t *testing.T) {
-		store := &mockDeleteRequestsStore{updateGenErr: errors.New("something bad")}
-		h := NewDeleteRequestHandler(store, 0, 0, nil)
-
-		req := buildRequest("org-id", ``, "", "", false)
-
-		w := httptest.NewRecorder()
-		h.UpdateCacheGenerationNumberHandler(w, req)
-
-		require.Equal(t, http.StatusInternalServerError, w.Code)
-	})
-
-	t.Run("it returns 400 when there is no org id", func(t *testing.T) {
-		h := NewDeleteRequestHandler(&mockDeleteRequestsStore{}, 0, 0, nil)
-
-		req := buildRequest("", ``, "", "", false)
-
-		w := httptest.NewRecorder()
-		h.UpdateCacheGenerationNumberHandler(w, req)
-
-		require.Equal(t, http.StatusBadRequest, w.Code)
-		require.Equal(t, "no org id\n", w.Body.String())
-	})
+			require.Equal(t, tc.expectedCode, w.Code)
+			require.Equal(t, tc.expectedUpdateUser, store.updatedCacheGenForUser)
+			if tc.expectedBody != "" {
+				require.Equal(t, tc.expectedBody, w.Body.String())
+			}
+		})
+	}
 }
 
 func buildRequest(orgID, query, start, end string, forQuerytimeFiltering bool) *http.Request {

--- a/pkg/compactor/deletion/request_handler_test.go
+++ b/pkg/compactor/deletion/request_handler_test.go
@@ -372,6 +372,45 @@ func TestGetAllDeleteRequestsHandler(t *testing.T) {
 	})
 }
 
+func TestUpdateCacheGenerationNumberHandler(t *testing.T) {
+	t.Run("it bumps the cache generation number for the user", func(t *testing.T) {
+		store := &mockDeleteRequestsStore{}
+		h := NewDeleteRequestHandler(store, 0, 0, nil)
+
+		req := buildRequest("org-id", ``, "", "", false)
+
+		w := httptest.NewRecorder()
+		h.UpdateCacheGenerationNumberHandler(w, req)
+
+		require.Equal(t, http.StatusNoContent, w.Code)
+		require.Equal(t, "org-id", store.updatedCacheGenForUser)
+	})
+
+	t.Run("it returns 500 when the store errors", func(t *testing.T) {
+		store := &mockDeleteRequestsStore{updateGenErr: errors.New("something bad")}
+		h := NewDeleteRequestHandler(store, 0, 0, nil)
+
+		req := buildRequest("org-id", ``, "", "", false)
+
+		w := httptest.NewRecorder()
+		h.UpdateCacheGenerationNumberHandler(w, req)
+
+		require.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("it returns 400 when there is no org id", func(t *testing.T) {
+		h := NewDeleteRequestHandler(&mockDeleteRequestsStore{}, 0, 0, nil)
+
+		req := buildRequest("", ``, "", "", false)
+
+		w := httptest.NewRecorder()
+		h.UpdateCacheGenerationNumberHandler(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Equal(t, "no org id\n", w.Body.String())
+	})
+}
+
 func buildRequest(orgID, query, start, end string, forQuerytimeFiltering bool) *http.Request {
 	var req *http.Request
 	if orgID == "" {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1835,6 +1835,7 @@ func (t *Loki) initCompactor() (services.Service, error) {
 		t.Server.HTTP.Path(constants.PathLokiDelete).Methods("GET").Handler(t.addCompactorMiddleware(t.compactor.DeleteRequestsHandler.GetAllDeleteRequestsHandler))
 		t.Server.HTTP.Path(constants.PathLokiDelete).Methods("DELETE").Handler(t.addCompactorMiddleware(t.compactor.DeleteRequestsHandler.CancelDeleteRequestHandler))
 		t.Server.HTTP.Path(constants.PathLokiCacheGenNumbers).Methods("GET").Handler(t.addCompactorMiddleware(t.compactor.DeleteRequestsHandler.GetCacheGenerationNumberHandler))
+		t.Server.HTTP.Path(constants.PathLokiIncreaseCacheGenNumbers).Methods("POST", "PUT").Handler(t.addCompactorMiddleware(t.compactor.DeleteRequestsHandler.UpdateCacheGenerationNumberHandler))
 		grpc.RegisterCompactorServer(t.Server.GRPC, t.compactor.DeleteRequestsGRPCHandler)
 	}
 

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1835,7 +1835,7 @@ func (t *Loki) initCompactor() (services.Service, error) {
 		t.Server.HTTP.Path(constants.PathLokiDelete).Methods("GET").Handler(t.addCompactorMiddleware(t.compactor.DeleteRequestsHandler.GetAllDeleteRequestsHandler))
 		t.Server.HTTP.Path(constants.PathLokiDelete).Methods("DELETE").Handler(t.addCompactorMiddleware(t.compactor.DeleteRequestsHandler.CancelDeleteRequestHandler))
 		t.Server.HTTP.Path(constants.PathLokiCacheGenNumbers).Methods("GET").Handler(t.addCompactorMiddleware(t.compactor.DeleteRequestsHandler.GetCacheGenerationNumberHandler))
-		t.Server.HTTP.Path(constants.PathLokiIncreaseCacheGenNumbers).Methods("POST", "PUT").Handler(t.addCompactorMiddleware(t.compactor.DeleteRequestsHandler.UpdateCacheGenerationNumberHandler))
+		t.Server.HTTP.Path(constants.PathLokiIncreaseCacheGenNumbers).Methods("POST").Handler(t.addCompactorMiddleware(t.compactor.DeleteRequestsHandler.UpdateCacheGenerationNumberHandler))
 		grpc.RegisterCompactorServer(t.Server.GRPC, t.compactor.DeleteRequestsGRPCHandler)
 	}
 

--- a/pkg/util/constants/api_paths.go
+++ b/pkg/util/constants/api_paths.go
@@ -29,7 +29,7 @@ const (
 	// Delete requests (compactor)
 	PathLokiDelete                  = "/loki/api/v1/delete"
 	PathLokiCacheGenNumbers         = "/loki/api/v1/cache/generation_numbers"
-	PathLokiIncreaseCacheGenNumbers = "/loki/api/v1/cache/increase_generation_numbers"
+	PathLokiIncreaseCacheGenNumbers = "/loki/api/v1/cache/generation_numbers/increase"
 	// Ingest
 	PathLokiPush = "/loki/api/v1/push"
 )

--- a/pkg/util/constants/api_paths.go
+++ b/pkg/util/constants/api_paths.go
@@ -27,8 +27,9 @@ const (
 	PathLokiRulesNamespace      = "/loki/api/v1/rules/{namespace}"
 	PathLokiRulesNamespaceGroup = "/loki/api/v1/rules/{namespace}/{groupName}"
 	// Delete requests (compactor)
-	PathLokiDelete          = "/loki/api/v1/delete"
-	PathLokiCacheGenNumbers = "/loki/api/v1/cache/generation_numbers"
+	PathLokiDelete                  = "/loki/api/v1/delete"
+	PathLokiCacheGenNumbers         = "/loki/api/v1/cache/generation_numbers"
+	PathLokiIncreaseCacheGenNumbers = "/loki/api/v1/cache/increase_generation_numbers"
 	// Ingest
 	PathLokiPush = "/loki/api/v1/push"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a new compactor endpoint that can be used to immediately expire the query results cache by increasing the gen number.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
