### PR TITLE
chore(docs): Add Docker compose example for HA Monolithic deployment

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,15 +1,17 @@
-# Loki examples
+# Examples
 
-This directory contains examples and example configuration for Loki and Promtail.
+This directory contains Docker compose examples for how to deploy Loki.
 
-## Hosted logs in Grafana Cloud
+> [!WARNING]
+> These examples are meant for demonstration purposes only and are not meant to be deployed in production environments.
 
-You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid installing, maintaining, and scaling your own instance of Grafana Loki. The free forever plan includes 50GB of free logs. [Create an account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-loki&plcmt=in-text).
+> [!NOTE]
+> You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid installing, maintaining, and scaling your own instance of Grafana Loki. The free forever plan includes 50GB of free logs. [Create an account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-loki&plcmt=in-text).
 
-## Getting started with Loki
+## Contents
 
-Configuration files in the `getting-started` directory are used by the [Loki getting started guide](https://grafana.com/docs/loki/latest/get-started/).
+1. **`getting-started/`**
+   Example of a Loki monolithic deployment with Alloy, Grafana, and NGINX.
 
-## Sending logs from Heroku to Loki
-
-Configuration files in the `promtail-heroku` directory are used by the [Promtail and Heroku blogpost](https://grafana.com/blog/2022/09/19/how-to-easily-configure-grafana-loki-and-promtail-to-receive-logs-from-heroku/).
+1. **`ha-monolithic/`**
+   Example of a Loki highly available monolithic deployment with NGINX.

--- a/examples/ha-monolithic/README.md
+++ b/examples/ha-monolithic/README.md
@@ -2,7 +2,7 @@
 
 HA monolithic deployment is a replacement for the Simple Scalable Deployment (removed with Loki 4.0) where high availability is more important than scalability.
 
-This example demonstrates how to run a number of single binary Loki instances (`-target=all`) behind a reverse proxy (NGINX) for high availability and durability. The demo uses Docker compose, but the mechanics can be applied to any other deployment model, such as Helm or Tanka.
+This example demonstrates how to run a number of single-binary Loki instances (`-target=all`) behind a reverse proxy (NGINX) for high availability and durability. The demo uses Docker compose, but the mechanics can be applied to any other deployment model, such as Helm or Tanka.
 
 This folder contains a `docker-compose.yaml` and a `config` directory with configuration files for Loki and NGIX.
 

--- a/examples/ha-monolithic/README.md
+++ b/examples/ha-monolithic/README.md
@@ -1,0 +1,64 @@
+# HA Monolithic deployment
+
+HA monolithic deployment is a replacement for the Simple Scalable Deployment (removed with Loki 4.0) where high availability is more important than scalability.
+
+This example demonstrates how to run a number of single binary Loki instances (`-target=all`) behind a reverse proxy (NGINX) for high availability and durability. The demo uses Docker compose, but the mechanics can be applied to any other deployment model, such as Helm or Tanka.
+
+This folder contains a `docker-compose.yaml` and a `config` directory with configuration files for Loki and NGIX.
+
+## Usage
+
+To use the latest features of Loki, you need to build the Docker image from main locally.
+
+```bash
+make loki-image
+```
+
+Then replace the `image` in `docker-compose.yaml`.
+
+```bash
+docker compose up
+```
+
+## Architecture
+
+```mermaid
+graph TB
+    Client(["Client"])
+    nginx["Load Balancer\n:3100"]
+    subgraph ring ["Ring (RF=3)"]
+        subgraph loki1_container ["loki-1"]
+            loki1["-target=all\n:3100\n:9095\n:7946"]
+            loki1 --- loki1_vol[("local disk")]
+        end
+        subgraph loki2_container ["loki-2"]
+            loki2["-target=all\n:3100\n:9095\n:7946"]
+            loki2 --- loki2_vol[("local disk")]
+        end
+        subgraph loki3_container ["loki-3"]
+            loki3["-target=all\n:3100\n:9095\n:7946"]
+            loki3 --- loki3_vol[("local disk")]
+        end
+        subgraph loki4_container ["loki-4"]
+            loki4["-target=all\n:3100\n:9095\n:7946"]
+            loki4 --- loki4_vol[("local disk")]
+        end
+        subgraph loki5_container ["loki-5"]
+            loki5["-target=all\n:3100\n:9095\n:7946"]
+            loki5 --- loki5_vol[("local disk")]
+        end
+    end
+
+
+    objstore[("Object Storage\n(S3, GCS, Azure Blob, ...)")]
+
+    Client -->|"HTTP :3100"| nginx
+
+    nginx ---> loki1
+    nginx ---> loki2
+    nginx ---> loki3
+    nginx ---> loki4
+    nginx ---> loki5
+
+    loki1 & loki2 & loki3 & loki4 & loki5 -----|"write/read"| objstore
+```

--- a/examples/ha-monolithic/README.md
+++ b/examples/ha-monolithic/README.md
@@ -39,14 +39,6 @@ graph TB
             loki3["-target=all\n:3100\n:9095\n:7946"]
             loki3 --- loki3_vol[("local disk")]
         end
-        subgraph loki4_container ["loki-4"]
-            loki4["-target=all\n:3100\n:9095\n:7946"]
-            loki4 --- loki4_vol[("local disk")]
-        end
-        subgraph loki5_container ["loki-5"]
-            loki5["-target=all\n:3100\n:9095\n:7946"]
-            loki5 --- loki5_vol[("local disk")]
-        end
     end
 
 
@@ -57,8 +49,6 @@ graph TB
     nginx ---> loki1
     nginx ---> loki2
     nginx ---> loki3
-    nginx ---> loki4
-    nginx ---> loki5
 
-    loki1 & loki2 & loki3 & loki4 & loki5 -----|"write/read"| objstore
+    loki1 & loki2 & loki3 -----|"write/read"| objstore
 ```

--- a/examples/ha-monolithic/config/loki.yaml
+++ b/examples/ha-monolithic/config/loki.yaml
@@ -1,0 +1,130 @@
+# Loki HA Monolithic
+
+auth_enabled: true
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9095
+  log_level: info
+  http_server_idle_timeout: 120s
+  http_server_read_timeout: 310s # must be slightly longer than query timeout
+  http_server_write_timeout: 310s # must be slightly longer than query timeout
+
+common:
+  path_prefix: /loki
+  replication_factor: 3
+  compactor_grpc_address: loki-1:9095
+  ring:
+    instance_id: ${LOKI_INSTANCE_ID}
+    heartbeat_period: 1m
+    heartbeat_timeout: 5m
+    kvstore:
+      store: memberlist
+
+memberlist:
+  bind_addr: ["0.0.0.0"]
+  bind_port: 7946
+  join_members:
+    - "loki-1:7946"
+    - "loki-2:7946"
+    - "loki-3:7946"
+    - "loki-4:7946"
+    - "loki-5:7946"
+  abort_if_cluster_join_fails: false
+  cluster_label: loki-ha-monolithic
+  cluster_label_verification_disabled: false
+
+schema_config:
+  configs:
+    - from: 2026-01-01
+      store: tsdb
+      object_store: s3
+      schema: v13
+      index:
+        prefix: loki_index_
+        period: 24h
+
+storage_config:
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+  aws: ## legacy object client
+    endpoint: minio:9000
+    insecure: true
+    bucketnames: loki-chunks
+    access_key_id: loki
+    secret_access_key: supersecret
+    s3forcepathstyle: true
+  use_thanos_objstore: true
+  object_store: ## thanos storage client
+    s3:
+      endpoint: minio:9000
+      insecure: true
+      bucket_name: loki-chunks
+      access_key_id: loki
+      secret_access_key: supersecret
+
+ingester:
+  chunk_idle_period: 10m
+  max_chunk_age: 1h
+  chunk_encoding: snappy
+  chunk_target_size: 2097152 # 2MB
+  chunk_block_size: 262144 # 256KB
+  wal:
+    dir: /loki/wal
+    enabled: true
+    replay_memory_ceiling: 1GB
+    flush_on_shutdown: true
+  lifecycler:
+    num_tokens: 512
+    tokens_file_path: /loki/ring-tokens
+    unregister_on_shutdown: true # Set to false if you want to keep ingesters in LEAVING state while restarting them
+  shutdown_marker_path: /loki
+
+frontend:
+  log_queries_longer_than: 5s
+  compress_responses: true
+
+query_range:
+  align_queries_with_step: true
+  max_retries: 5
+  parallelise_shardable_queries: true
+
+compactor:
+  apply_retention_interval: 1h
+  compaction_interval: 5m
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: s3
+  horizontal_scaling_mode: ${COMPACTOR_MODE:-worker}
+
+ruler:
+  storage:
+    type: s3
+    s3:
+      endpoint: minio:9000
+      insecure: true
+      bucketnames: loki-ruler
+      access_key_id: loki
+      secret_access_key: supersecret
+      s3forcepathstyle: true
+
+limits_config:
+  allow_structured_metadata: true
+  discover_log_levels: true
+  ingestion_rate_mb: 20
+  ingestion_burst_size_mb: 10
+  max_global_streams_per_user: 10000
+  query_timeout: 300s
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  retention_period: 7d
+  shard_streams:
+    desired_rate: 262144 # 256KB
+    enabled: true
+    time_sharding_enabled: true
+  split_queries_by_interval: 1h
+  volume_enabled: true
+
+analytics:
+  reporting_enabled: false

--- a/examples/ha-monolithic/config/loki.yaml
+++ b/examples/ha-monolithic/config/loki.yaml
@@ -7,8 +7,8 @@ server:
   grpc_listen_port: 9095
   log_level: info
   http_server_idle_timeout: 120s
-  http_server_read_timeout: 310s # must be slightly longer than query timeout
-  http_server_write_timeout: 310s # must be slightly longer than query timeout
+  http_server_read_timeout: 310s # must be slightly longer than limits_config.query_timeout
+  http_server_write_timeout: 310s # must be slightly longer than limits_config.query_timeout
 
 common:
   path_prefix: /loki

--- a/examples/ha-monolithic/config/loki.yaml
+++ b/examples/ha-monolithic/config/loki.yaml
@@ -28,8 +28,6 @@ memberlist:
     - "loki-1:7946"
     - "loki-2:7946"
     - "loki-3:7946"
-    - "loki-4:7946"
-    - "loki-5:7946"
   abort_if_cluster_join_fails: false
   cluster_label: loki-ha-monolithic
   cluster_label_verification_disabled: false
@@ -48,13 +46,6 @@ storage_config:
   tsdb_shipper:
     active_index_directory: /loki/index
     cache_location: /loki/index_cache
-  aws: ## legacy object client
-    endpoint: minio:9000
-    insecure: true
-    bucketnames: loki-chunks
-    access_key_id: loki
-    secret_access_key: supersecret
-    s3forcepathstyle: true
   use_thanos_objstore: true
   object_store: ## thanos storage client
     s3:

--- a/examples/ha-monolithic/config/nginx.conf
+++ b/examples/ha-monolithic/config/nginx.conf
@@ -1,0 +1,95 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    access_log  /var/log/nginx/access.log  combined;
+
+    sendfile          on;
+    keepalive_timeout 65;
+
+    # -------------------------------------------------------------------------
+    # Loki upstream – round-robin across all three replicas.
+    # -------------------------------------------------------------------------
+    upstream loki {
+        server loki-1:3100;
+        server loki-2:3100;
+        server loki-3:3100;
+        server loki-4:3100;
+        server loki-5:3100;
+    }
+
+    upstream compactor {
+        server loki-1:3100;
+    }
+
+    # -------------------------------------------------------------------------
+    # Server block – accepts all Loki traffic on port 3100 and proxies it to
+    # the upstream group.  Large request/response bodies (log streams, query
+    # results) require elevated buffer and timeout settings.
+    # -------------------------------------------------------------------------
+    server {
+        listen 3100;
+
+        # Forward push and query requests to the Loki cluster.
+        location / {
+            proxy_pass       http://loki;
+
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Timeouts – long-running tail/query requests need generous values.
+            proxy_connect_timeout  10s;
+            proxy_send_timeout    600s;
+            proxy_read_timeout    600s;
+
+            # Buffer settings for large log payloads.
+            proxy_request_buffering  off;
+            proxy_buffering          off;
+
+            # Allow large push payloads.
+            client_max_body_size 50m;
+        }
+
+        location ~ ^/loki/api/v1/(cache|delete) {
+            proxy_pass       http://compactor;
+
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_connect_timeout  10s;
+            proxy_send_timeout     60s;
+            proxy_read_timeout     60s;
+
+            # Buffer settings for large log payloads.
+            proxy_request_buffering  off;
+            proxy_buffering          off;
+
+            # Allow large push payloads.
+            client_max_body_size 50m;
+        }
+
+        location = / {
+            return 200 'Hello Loki!\nhttps://grafana.com/docs/loki/latest/send-data/';
+        }
+
+        # Health check endpoint – returns 200 once all upstreams are reachable.
+        location /nginx-health {
+            access_log off;
+            return 200 "healthy\n";
+        }
+    }
+}

--- a/examples/ha-monolithic/config/nginx.conf
+++ b/examples/ha-monolithic/config/nginx.conf
@@ -17,30 +17,20 @@ http {
     sendfile          on;
     keepalive_timeout 65;
 
-    # -------------------------------------------------------------------------
-    # Loki upstream – round-robin across all three replicas.
-    # -------------------------------------------------------------------------
     upstream loki {
         server loki-1:3100;
         server loki-2:3100;
         server loki-3:3100;
-        server loki-4:3100;
-        server loki-5:3100;
     }
 
     upstream compactor {
         server loki-1:3100;
     }
 
-    # -------------------------------------------------------------------------
-    # Server block – accepts all Loki traffic on port 3100 and proxies it to
-    # the upstream group.  Large request/response bodies (log streams, query
-    # results) require elevated buffer and timeout settings.
-    # -------------------------------------------------------------------------
     server {
         listen 3100;
 
-        # Forward push and query requests to the Loki cluster.
+        # Forward push and query requests to the Loki instances .
         location / {
             proxy_pass       http://loki;
 
@@ -62,7 +52,8 @@ http {
             client_max_body_size 50m;
         }
 
-        location ~ ^/loki/api/v1/(cache|delete) {
+        # Forward delete requests to the main compactor instance.
+        location ~ ^/loki/api/v1/delete {
             proxy_pass       http://compactor;
 
             proxy_set_header Host              $host;
@@ -82,8 +73,24 @@ http {
             client_max_body_size 50m;
         }
 
+        # Forward tail websocket request to the Loki instances.
+        location ~ /loki/api/v1/tail {
+            proxy_pass       http://loki;
+
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Upgrade websocket connection
+            proxy_set_header Upgrade           $http_upgrade;
+            proxy_set_header Connection        "upgrade";
+        }
+
         location = / {
-            return 200 'Hello Loki!\nhttps://grafana.com/docs/loki/latest/send-data/';
+            access_log   off;
+            default_type text/html;
+            return 200 '<center><h1>HA Monolithic Loki</h1><p>Go to the <a href="/ring">Ring Status</a> page to verify that all three Loki instances joined the ring and are in an <code>ACTIVE</code> state.</p><p>Visit the Grafana Loki documentation at <a href="https://grafana.com/docs/loki/latest/">grafana.com</a>.</p></center>';
         }
 
         # Health check endpoint – returns 200 once all upstreams are reachable.

--- a/examples/ha-monolithic/config/overrides.yaml
+++ b/examples/ha-monolithic/config/overrides.yaml
@@ -1,0 +1,9 @@
+overrides:
+  tenant-a:
+    ingestion_rate_mb: 50
+    shard_streams:
+      desired_rate: 128KB
+  tenant-b:
+    ingestion_rate_mb: 50
+    shard_streams:
+      desired_rate: 128KB

--- a/examples/ha-monolithic/docker-compose.yaml
+++ b/examples/ha-monolithic/docker-compose.yaml
@@ -1,0 +1,184 @@
+# =============================================================================
+# Loki Single Binary – Docker Compose
+# =============================================================================
+# Services
+#   minio            – S3-compatible object storage (chunks + ruler buckets)
+#   minio-init       – one-shot container that creates required MinIO buckets
+#   loki-1/2/3/4/5   – Loki single-binary replicas (target=all), RF=3
+#   nginx            – reverse proxy / load balancer in front of Loki
+#
+# Usage
+#   docker compose up -d
+#
+# Loki ring:      http://localhost:3100/ring
+# MinIO console:  http://localhost:9001  (loki / supersecret)
+# =============================================================================
+
+name: loki-ha-singlebinary
+
+# ---------------------------------------------------------------------------
+# Re-usable fragment
+# ---------------------------------------------------------------------------
+x-loki-common: &loki-common
+  image: grafana/loki:high-available-single-binary-6b96915-WIP
+  command:
+    [
+      "-config.file=/etc/loki/loki.yaml",
+      "-runtime-config.file=/etc/loki/overrides.yaml",
+      "-config.expand-env=true",
+      "-target=all",
+    ]
+  depends_on:
+    minio-init:
+      condition: service_completed_successfully
+  networks:
+    - loki
+  healthcheck:
+    test: ["CMD", "/usr/bin/loki", "-health"]
+    interval: 10s
+    timeout: 5s
+    retries: 10
+    start_period: 30s
+
+services:
+  # ---------------------------------------------------------------------------
+  # MinIO – object storage backend
+  # ---------------------------------------------------------------------------
+  minio:
+    image: minio/minio:latest
+    entrypoint: ["minio", "server", "/data", "--console-address", ":9001"]
+    environment:
+      MINIO_ROOT_USER: loki
+      MINIO_ROOT_PASSWORD: supersecret
+    volumes:
+      - minio-data:/data
+    ports:
+      - "9000:9000" # S3 API
+      - "9001:9001" # MinIO web console
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    networks:
+      - loki
+
+  # ---------------------------------------------------------------------------
+  # minio-init – creates buckets once MinIO is healthy, then exits.
+  # ---------------------------------------------------------------------------
+  minio-init:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+        mc alias set minio http://minio:9000 loki supersecret &&
+        mc mb --ignore-existing minio/loki-chunks &&
+        mc mb --ignore-existing minio/loki-ruler &&
+        echo 'Buckets created.'
+      "
+    networks:
+      - loki
+
+  # ---------------------------------------------------------------------------
+  # Loki replicas (single binary, target=all)
+  # ---------------------------------------------------------------------------
+  loki-1:
+    <<: *loki-common
+    container_name: loki-1
+    hostname: loki-1
+    environment:
+      LOKI_INSTANCE_ID: loki-1
+      COMPACTOR_MODE: main
+    volumes:
+      # - ./config/loki.yaml:/etc/loki/loki.yaml:ro
+      - ./config:/etc/loki:ro
+      - loki-1-data:/loki
+
+  loki-2:
+    <<: *loki-common
+    container_name: loki-2
+    hostname: loki-2
+    environment:
+      LOKI_INSTANCE_ID: loki-2
+    volumes:
+      # - ./config/loki.yaml:/etc/loki/loki.yaml:ro
+      - ./config:/etc/loki:ro
+      - loki-2-data:/loki
+
+  loki-3:
+    <<: *loki-common
+    container_name: loki-3
+    hostname: loki-3
+    environment:
+      LOKI_INSTANCE_ID: loki-3
+    volumes:
+      # - ./config/loki.yaml:/etc/loki/loki.yaml:ro
+      - ./config:/etc/loki:ro
+      - loki-3-data:/loki
+
+  loki-4:
+    <<: *loki-common
+    container_name: loki-4
+    hostname: loki-4
+    environment:
+      LOKI_INSTANCE_ID: loki-4
+    volumes:
+      # - ./config/loki.yaml:/etc/loki/loki.yaml:ro
+      - ./config:/etc/loki:ro
+      - loki-4-data:/loki
+
+  loki-5:
+    <<: *loki-common
+    container_name: loki-5
+    hostname: loki-5
+    environment:
+      LOKI_INSTANCE_ID: loki-5
+    volumes:
+      # - ./config/loki.yaml:/etc/loki/loki.yaml:ro
+      - ./config:/etc/loki:ro
+      - loki-5-data:/loki
+
+  # ---------------------------------------------------------------------------
+  # NGINX – reverse proxy / load balancer
+  # ---------------------------------------------------------------------------
+  nginx:
+    image: nginx:alpine
+    container_name: nginx
+    volumes:
+      - ./config/nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "3100:3100" # Loki HTTP API (push + query)
+    depends_on:
+      - loki-1
+      - loki-2
+      - loki-3
+      - loki-4
+      - loki-5
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3100/nginx-health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - loki
+
+# ---------------------------------------------------------------------------
+# Volumes
+# ---------------------------------------------------------------------------
+volumes:
+  minio-data:
+  loki-1-data:
+  loki-2-data:
+  loki-3-data:
+  loki-4-data:
+  loki-5-data:
+
+# ---------------------------------------------------------------------------
+# Networks
+# ---------------------------------------------------------------------------
+networks:
+  loki:
+    driver: bridge

--- a/examples/ha-monolithic/docker-compose.yaml
+++ b/examples/ha-monolithic/docker-compose.yaml
@@ -1,26 +1,20 @@
 # =============================================================================
-# Loki Single Binary – Docker Compose
+# Loki HA Monolithic – Docker Compose
 # =============================================================================
 # Services
 #   minio            – S3-compatible object storage (chunks + ruler buckets)
 #   minio-init       – one-shot container that creates required MinIO buckets
-#   loki-1/2/3/4/5   – Loki single-binary replicas (target=all), RF=3
+#   loki-1/2/3       – Loki single-binary replicas (target=all), RF=3
 #   nginx            – reverse proxy / load balancer in front of Loki
 #
 # Usage
 #   docker compose up -d
-#
-# Loki ring:      http://localhost:3100/ring
-# MinIO console:  http://localhost:9001  (loki / supersecret)
 # =============================================================================
 
-name: loki-ha-singlebinary
+name: loki-ha-monolithic
 
-# ---------------------------------------------------------------------------
-# Re-usable fragment
-# ---------------------------------------------------------------------------
 x-loki-common: &loki-common
-  image: grafana/loki:high-available-single-binary-6b96915-WIP
+  image: grafana/loki:3.7.2
   command:
     [
       "-config.file=/etc/loki/loki.yaml",
@@ -41,11 +35,8 @@ x-loki-common: &loki-common
     start_period: 30s
 
 services:
-  # ---------------------------------------------------------------------------
-  # MinIO – object storage backend
-  # ---------------------------------------------------------------------------
   minio:
-    image: minio/minio:latest
+    image: pgsty/minio:latest
     entrypoint: ["minio", "server", "/data", "--console-address", ":9001"]
     environment:
       MINIO_ROOT_USER: loki
@@ -64,11 +55,8 @@ services:
     networks:
       - loki
 
-  # ---------------------------------------------------------------------------
-  # minio-init – creates buckets once MinIO is healthy, then exits.
-  # ---------------------------------------------------------------------------
   minio-init:
-    image: minio/mc:latest
+    image: pgsty/mc:latest
     depends_on:
       minio:
         condition: service_healthy
@@ -82,9 +70,6 @@ services:
     networks:
       - loki
 
-  # ---------------------------------------------------------------------------
-  # Loki replicas (single binary, target=all)
-  # ---------------------------------------------------------------------------
   loki-1:
     <<: *loki-common
     container_name: loki-1
@@ -93,7 +78,6 @@ services:
       LOKI_INSTANCE_ID: loki-1
       COMPACTOR_MODE: main
     volumes:
-      # - ./config/loki.yaml:/etc/loki/loki.yaml:ro
       - ./config:/etc/loki:ro
       - loki-1-data:/loki
 
@@ -104,7 +88,6 @@ services:
     environment:
       LOKI_INSTANCE_ID: loki-2
     volumes:
-      # - ./config/loki.yaml:/etc/loki/loki.yaml:ro
       - ./config:/etc/loki:ro
       - loki-2-data:/loki
 
@@ -115,48 +98,21 @@ services:
     environment:
       LOKI_INSTANCE_ID: loki-3
     volumes:
-      # - ./config/loki.yaml:/etc/loki/loki.yaml:ro
       - ./config:/etc/loki:ro
       - loki-3-data:/loki
 
-  loki-4:
-    <<: *loki-common
-    container_name: loki-4
-    hostname: loki-4
-    environment:
-      LOKI_INSTANCE_ID: loki-4
-    volumes:
-      # - ./config/loki.yaml:/etc/loki/loki.yaml:ro
-      - ./config:/etc/loki:ro
-      - loki-4-data:/loki
-
-  loki-5:
-    <<: *loki-common
-    container_name: loki-5
-    hostname: loki-5
-    environment:
-      LOKI_INSTANCE_ID: loki-5
-    volumes:
-      # - ./config/loki.yaml:/etc/loki/loki.yaml:ro
-      - ./config:/etc/loki:ro
-      - loki-5-data:/loki
-
-  # ---------------------------------------------------------------------------
-  # NGINX – reverse proxy / load balancer
-  # ---------------------------------------------------------------------------
   nginx:
     image: nginx:alpine
     container_name: nginx
     volumes:
       - ./config/nginx.conf:/etc/nginx/nginx.conf:ro
     ports:
-      - "3100:3100" # Loki HTTP API (push + query)
+      - "3100:3100"
     depends_on:
       - loki-1
       - loki-2
       - loki-3
-      - loki-4
-      - loki-5
+    restart: always
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:3100/nginx-health"]
       interval: 10s
@@ -165,20 +121,11 @@ services:
     networks:
       - loki
 
-# ---------------------------------------------------------------------------
-# Volumes
-# ---------------------------------------------------------------------------
 volumes:
   minio-data:
   loki-1-data:
   loki-2-data:
   loki-3-data:
-  loki-4-data:
-  loki-5-data:
 
-# ---------------------------------------------------------------------------
-# Networks
-# ---------------------------------------------------------------------------
 networks:
   loki:
-    driver: bridge


### PR DESCRIPTION
### Summary

This PR adds a new Docker compose example for HA Monolithic deployment.

```bash
cd examples/ha-monolithic
docker compose up
```