### PR TITLE
fix(v2-engine): Treat absent column as empty string in scan-layer predicate pushdown to match v1 LogQL semantics

### DIFF
--- a/pkg/engine/internal/executor/dataobjscan_predicate.go
+++ b/pkg/engine/internal/executor/dataobjscan_predicate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/memory"
@@ -175,6 +176,21 @@ func buildLogsComparison(expr *physical.BinaryExpr, columns []*logs.Column) (log
 		return nil, err
 	}
 
+	// When the column is absent from this section, LogQL says an absent label
+	// compares as the empty string "" — the same semantic the post-scan filter
+	// layer already applies. Evaluate the operator against "" and prune the
+	// section accordingly. predicateForAbsentColumn returns ok=false to
+	// indicate the op/literal combination isn't string-shaped and the caller
+	// should fall through to the per-op default (preserved below for null
+	// literals and for numeric comparisons that aren't meaningful against "").
+	if col == nil {
+		if p, ok, err := predicateForAbsentColumn(expr.Op, s); err != nil {
+			return nil, err
+		} else if ok {
+			return p, nil
+		}
+	}
+
 	switch expr.Op {
 	case types.BinaryOpEq:
 		if col == nil && s.IsValid() {
@@ -268,6 +284,78 @@ func buildLogsComparison(expr *physical.BinaryExpr, columns []*logs.Column) (log
 	}
 
 	return nil, fmt.Errorf("unsupported binary operator %s in logs predicate", expr.Op)
+}
+
+// predicateForAbsentColumn returns the section-level predicate for an
+// expression of the form `<absent column> op literal`. LogQL semantics — also
+// applied by the post-scan filter layer — treat an absent label as the empty
+// string "", so for string-typed literals the predicate reduces to a constant:
+// evaluate `"" op literal` and return TruePredicate (every row in the section
+// matches) or FalsePredicate (none match).
+//
+// Returns ok=false for non-string literals (null, integer, timestamp, etc.) so
+// the caller can fall through to the per-op default — those literals don't
+// have a meaningful "" comparison and the prior, conservative section-prune
+// behaviour is preserved.
+func predicateForAbsentColumn(op types.BinaryOp, s scalar.Scalar) (logs.Predicate, bool, error) {
+	var lit string
+	switch v := s.(type) {
+	case *scalar.String:
+		lit = string(v.Data())
+	case *scalar.Binary:
+		lit = string(v.Data())
+	default:
+		return nil, false, nil
+	}
+
+	var matches bool
+	switch op {
+	case types.BinaryOpEq:
+		matches = lit == ""
+	case types.BinaryOpNeq:
+		matches = lit != ""
+	case types.BinaryOpGt:
+		matches = "" > lit // always false ("" is the smallest string)
+	case types.BinaryOpGte:
+		matches = "" >= lit // true only when lit == ""
+	case types.BinaryOpLt:
+		matches = "" < lit // true for any non-empty lit
+	case types.BinaryOpLte:
+		matches = true // "" <= anything
+	case types.BinaryOpMatchSubstr:
+		matches = strings.Contains("", lit) // true only when lit == ""
+	case types.BinaryOpNotMatchSubstr:
+		matches = !strings.Contains("", lit)
+	case types.BinaryOpMatchRe:
+		re, err := regexp.Compile(lit)
+		if err != nil {
+			return nil, false, err
+		}
+		matches = re.MatchString("")
+	case types.BinaryOpNotMatchRe:
+		re, err := regexp.Compile(lit)
+		if err != nil {
+			return nil, false, err
+		}
+		matches = !re.MatchString("")
+	case types.BinaryOpEqCaseInsensitive:
+		matches = matchutil.EqualUpper([]byte(""), []byte(lit))
+	case types.BinaryOpNotEqCaseInsensitive:
+		matches = !matchutil.EqualUpper([]byte(""), []byte(lit))
+	case types.BinaryOpMatchSubstrCaseInsensitive:
+		matches = matchutil.ContainsUpper([]byte(""), []byte(lit))
+	case types.BinaryOpNotMatchSubstrCaseInsensitive:
+		matches = !matchutil.ContainsUpper([]byte(""), []byte(lit))
+	default:
+		// Pattern ops and any future ops without an "" evaluation rule:
+		// leave to the per-op default.
+		return nil, false, nil
+	}
+
+	if matches {
+		return logs.TruePredicate{}, true, nil
+	}
+	return logs.FalsePredicate{}, true, nil
 }
 
 // findColumn finds a column by ref in the slice of columns. If ref is invalid,

--- a/pkg/engine/internal/executor/dataobjscan_predicate_test.go
+++ b/pkg/engine/internal/executor/dataobjscan_predicate_test.go
@@ -370,6 +370,145 @@ func Test_buildLogsPredicate(t *testing.T) {
 			},
 			expect: logs.TruePredicate{}, // not match against non-existent column always passes
 		},
+
+		// LogQL: an absent label compares as "". The section-prune layer must
+		// agree with the post-scan filter layer so we don't silently drop
+		// sections whose absent column would have matched.
+		{
+			name: `binary EQ "" (invalid column) — absent matches empty literal`,
+			expr: &physical.BinaryExpr{
+				Op:    types.BinaryOpEq,
+				Left:  columnRef(types.ColumnTypeMetadata, "nonexistent"),
+				Right: physical.NewLiteral(""),
+			},
+			expect: logs.TruePredicate{},
+		},
+		{
+			name: `binary NEQ "" (invalid column) — absent does not differ from empty literal`,
+			expr: &physical.BinaryExpr{
+				Op:    types.BinaryOpNeq,
+				Left:  columnRef(types.ColumnTypeMetadata, "nonexistent"),
+				Right: physical.NewLiteral(""),
+			},
+			expect: logs.FalsePredicate{},
+		},
+		{
+			name: `binary GTE "" (invalid column) — "" >= "" is true`,
+			expr: &physical.BinaryExpr{
+				Op:    types.BinaryOpGte,
+				Left:  columnRef(types.ColumnTypeMetadata, "nonexistent"),
+				Right: physical.NewLiteral(""),
+			},
+			expect: logs.TruePredicate{},
+		},
+		{
+			name: `binary LTE any string (invalid column) — "" <= anything is true`,
+			expr: &physical.BinaryExpr{
+				Op:    types.BinaryOpLte,
+				Left:  columnRef(types.ColumnTypeMetadata, "nonexistent"),
+				Right: physical.NewLiteral("zzz"),
+			},
+			expect: logs.TruePredicate{},
+		},
+		{
+			name: `binary LT non-empty (invalid column) — "" < non-empty is true`,
+			expr: &physical.BinaryExpr{
+				Op:    types.BinaryOpLt,
+				Left:  columnRef(types.ColumnTypeMetadata, "nonexistent"),
+				Right: physical.NewLiteral("foo"),
+			},
+			expect: logs.TruePredicate{},
+		},
+		{
+			name: `binary GT "" (invalid column) — "" > "" is false`,
+			expr: &physical.BinaryExpr{
+				Op:    types.BinaryOpGt,
+				Left:  columnRef(types.ColumnTypeMetadata, "nonexistent"),
+				Right: physical.NewLiteral(""),
+			},
+			expect: logs.FalsePredicate{},
+		},
+		{
+			name: `binary MATCH_STR "" (invalid column) — "" contains "" is true`,
+			expr: &physical.BinaryExpr{
+				Op:    types.BinaryOpMatchSubstr,
+				Left:  columnRef(types.ColumnTypeMetadata, "nonexistent"),
+				Right: physical.NewLiteral(""),
+			},
+			expect: logs.TruePredicate{},
+		},
+		{
+			name: `binary NOT_MATCH_STR "" (invalid column) — !("" contains "") is false`,
+			expr: &physical.BinaryExpr{
+				Op:    types.BinaryOpNotMatchSubstr,
+				Left:  columnRef(types.ColumnTypeMetadata, "nonexistent"),
+				Right: physical.NewLiteral(""),
+			},
+			expect: logs.FalsePredicate{},
+		},
+		{
+			name: `binary MATCH_RE ".*" (invalid column) — matches ""`,
+			expr: &physical.BinaryExpr{
+				Op:    types.BinaryOpMatchRe,
+				Left:  columnRef(types.ColumnTypeMetadata, "nonexistent"),
+				Right: physical.NewLiteral(".*"),
+			},
+			expect: logs.TruePredicate{},
+		},
+		{
+			name: `binary MATCH_RE ".+" (invalid column) — does not match ""`,
+			expr: &physical.BinaryExpr{
+				Op:    types.BinaryOpMatchRe,
+				Left:  columnRef(types.ColumnTypeMetadata, "nonexistent"),
+				Right: physical.NewLiteral(".+"),
+			},
+			expect: logs.FalsePredicate{},
+		},
+		{
+			name: `binary NOT_MATCH_RE ".+" (invalid column) — "" does not match .+, so negation passes`,
+			expr: &physical.BinaryExpr{
+				Op:    types.BinaryOpNotMatchRe,
+				Left:  columnRef(types.ColumnTypeMetadata, "nonexistent"),
+				Right: physical.NewLiteral(".+"),
+			},
+			expect: logs.TruePredicate{},
+		},
+		{
+			name: `binary EQ_CI "" (invalid column) — absent matches empty literal case-insensitively`,
+			expr: &physical.BinaryExpr{
+				Op:    types.BinaryOpEqCaseInsensitive,
+				Left:  columnRef(types.ColumnTypeMetadata, "nonexistent"),
+				Right: physical.NewLiteral(""),
+			},
+			expect: logs.TruePredicate{},
+		},
+		{
+			name: `binary NOT_EQ_CI "" (invalid column) — absent does not differ from empty literal`,
+			expr: &physical.BinaryExpr{
+				Op:    types.BinaryOpNotEqCaseInsensitive,
+				Left:  columnRef(types.ColumnTypeMetadata, "nonexistent"),
+				Right: physical.NewLiteral(""),
+			},
+			expect: logs.FalsePredicate{},
+		},
+		{
+			name: `binary MATCH_STR_CI "" (invalid column) — "" contains "" case-insensitively is true`,
+			expr: &physical.BinaryExpr{
+				Op:    types.BinaryOpMatchSubstrCaseInsensitive,
+				Left:  columnRef(types.ColumnTypeMetadata, "nonexistent"),
+				Right: physical.NewLiteral(""),
+			},
+			expect: logs.TruePredicate{},
+		},
+		{
+			name: `binary NOT_MATCH_STR_CI "" (invalid column) — case-insensitive negation of contains is false`,
+			expr: &physical.BinaryExpr{
+				Op:    types.BinaryOpNotMatchSubstrCaseInsensitive,
+				Left:  columnRef(types.ColumnTypeMetadata, "nonexistent"),
+				Right: physical.NewLiteral(""),
+			},
+			expect: logs.FalsePredicate{},
+		},
 	}
 
 	for _, tc := range tt {

--- a/pkg/logql/bench/queries/regression/log-queries.yaml
+++ b/pkg/logql/bench/queries/regression/log-queries.yaml
@@ -28,3 +28,26 @@ queries:
       log_format: logfmt
       detected_fields:
         - error
+  - description: filter `field=""` on absent column must match (not silently prune the section)
+    query: ${SELECTOR} | logfmt | field_that_does_not_exist=""
+    kind: log
+    time_range:
+      length: 24h
+    directions: backward # forward log queries unsupported by v2 engine
+    tags:
+      - logfmt
+      - label-filter
+      - absent-field
+      - empty-string
+      - section-prune
+    notes: >
+      Regression for the v2 scan-layer predicate-pushdown bug. LogQL says an
+      absent label compares as "" — the post-scan filter layer already treats
+      null column entries as "". But section-level pruning happens first:
+      `dataobjscan_predicate.go` returned FalsePredicate whenever a referenced
+      column was missing from a section AND the literal was non-null, which
+      silently dropped the section even for `field=""`. v1 returns all rows
+      (the absent label matches the empty literal). v2 must do the same.
+      Catches any regression to the section-prune layer.
+    requires:
+      log_format: logfmt


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a v2-engine correctness bug where label filters on a column absent from a dataobj section silently dropped the entire section, even when LogQL semantics required the section to be included. Most visible for `| field=""` and `| field=~".*"` idioms (e.g. "give me rows where this label is absent"): v2 returned zero rows from sections whose schema didn't include the referenced column, while v1 returned every row in those sections.

**Fix**

When the referenced column is absent and the literal is string-shaped, evaluate the operator against `""` directly and return `TruePredicate` / `FalsePredicate` based on the result. The decision is constant across the whole section because all rows would compute the same answer (column doesn't exist → every row reads `""`).

Implemented as a small helper `predicateForAbsentColumn(op, scalar)` covering all the string-typed comparators (`Eq`, `Neq`, `Gt`, `Gte`, `Lt`, `Lte`, `MatchSubstr`, `NotMatchSubstr`, `MatchRe`, `NotMatchRe`, plus the case-insensitive variants), invoked from a new early-return block at the top of the comparison switch. For non-string literals (null, integer, timestamp) the helper returns `ok=false` and the existing per-op switch arms remain in charge — their behaviour is unchanged.

Each branch in the helper uses the same Go primitive v1 uses against `""`:
- `==` / `!=`: direct string compare
- `>` / `>=` / `<` / `<=`: lexicographic string compare
- substring: `strings.Contains("", literal)`
- regex: `regexp.Compile(literal).MatchString("")`
- case-insensitive: `matchutil.EqualUpper` / `matchutil.ContainsUpper` against `[]byte("")`

So `field=~".+"` → false, `field=~".*"` → true, `field|="foo"` → false, etc., exactly matching what v1 would compute per-row.

**Scope**

Only string-shaped literals are affected. Numeric and null literal branches preserve the original predicates, so this PR doesn't alter numeric label filters (`| duration > 100ms`) or `field=null` semantics.

The predicate-pushdown rule (`canApplyPredicate`) only pushes filters on `Builtin` or `Metadata` columns to the scan layer. Generated columns (`__error__`, `__error_details__`) and unresolved `Ambiguous` columns never reach `buildLogsPredicate`, so this PR does not change their behaviour — the post-scan filter layer continues to handle them.
