### PR TITLE
feat: Support per-policy stream sharding overrides

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -610,10 +610,12 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 	shouldDiscoverLevels := fieldDetector.shouldDiscoverLogLevels()
 	shouldDiscoverGenericFields := fieldDetector.shouldDiscoverGenericFields()
 
-	shardStreamsCfg := d.validator.ShardStreams(tenantID)
-	maybeShardByRate := func(stream logproto.Stream, pushSize int, policy string) {
+	// The shard-streams config is resolved per stream from its policy (see PolicyShardStreams)
+	// and threaded into these closures, so a policy can override the tenant sharding behavior
+	// (e.g. toggle time sharding or use a different desired_rate).
+	maybeShardByRate := func(stream logproto.Stream, pushSize int, policy string, shardStreamsCfg shardstreams.Config) {
 		if shardStreamsCfg.Enabled {
-			streams = append(streams, d.shardStream(stream, pushSize, tenantID, policy)...)
+			streams = append(streams, d.shardStream(stream, pushSize, tenantID, policy, shardStreamsCfg)...)
 			return
 		}
 		streams = append(streams, KeyedStream{
@@ -624,21 +626,21 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 		})
 	}
 
-	maybeShardStreams := func(stream logproto.Stream, labels labels.Labels, pushSize int, policy string) {
+	maybeShardStreams := func(stream logproto.Stream, labels labels.Labels, pushSize int, policy string, shardStreamsCfg shardstreams.Config) {
 		if !shardStreamsCfg.TimeShardingEnabled {
-			maybeShardByRate(stream, pushSize, policy)
+			maybeShardByRate(stream, pushSize, policy, shardStreamsCfg)
 			return
 		}
 
 		ignoreRecentFrom := now.Add(-shardStreamsCfg.TimeShardingIgnoreRecent)
 		streamsByTime, ok := shardStreamByTime(stream, labels, d.ingesterCfg.MaxChunkAge/2, ignoreRecentFrom)
 		if !ok {
-			maybeShardByRate(stream, pushSize, policy)
+			maybeShardByRate(stream, pushSize, policy, shardStreamsCfg)
 			return
 		}
 
 		for _, ts := range streamsByTime {
-			maybeShardByRate(ts.Stream, ts.linesTotalLen, policy)
+			maybeShardByRate(ts.Stream, ts.linesTotalLen, policy, shardStreamsCfg)
 		}
 	}
 
@@ -802,7 +804,7 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 			b.bytes += streamEntriesSize
 			b.lines += n
 
-			maybeShardStreams(stream, lbs, streamEntriesSize, policy)
+			maybeShardStreams(stream, lbs, streamEntriesSize, policy, d.validator.PolicyShardStreams(tenantID, policy))
 		}
 		return nil
 	}()
@@ -1236,8 +1238,7 @@ func shardStreamByTime(stream logproto.Stream, lbls labels.Labels, timeShardLen 
 // streams and their associated keys for hashing to ingesters.
 //
 // The number of shards is limited by the number of entries.
-func (d *Distributor) shardStream(stream logproto.Stream, pushSize int, tenantID string, policy string) []KeyedStream {
-	shardStreamsCfg := d.validator.ShardStreams(tenantID)
+func (d *Distributor) shardStream(stream logproto.Stream, pushSize int, tenantID string, policy string, shardStreamsCfg shardstreams.Config) []KeyedStream {
 	logger := log.With(util_log.WithUserID(tenantID, d.logger), "stream", stream.Labels)
 	shardCount := d.shardCountFor(logger, &stream, pushSize, tenantID, shardStreamsCfg)
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -36,6 +36,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/grafana/loki/v3/pkg/distributor/shardstreams"
 	"github.com/grafana/loki/v3/pkg/ingester"
 	"github.com/grafana/loki/v3/pkg/ingester/client"
 	"github.com/grafana/loki/v3/pkg/limits"
@@ -939,7 +940,7 @@ func TestStreamShard(t *testing.T) {
 				shardTracker:     NewShardTracker(),
 			}
 
-			derivedStreams := d.shardStream(baseStream, tc.streamSize, "fake", "")
+			derivedStreams := d.shardStream(baseStream, tc.streamSize, "fake", "", d.validator.ShardStreams("fake"))
 			require.Len(t, derivedStreams, tc.wantDerivedStreamSize)
 
 			for _, s := range derivedStreams {
@@ -984,7 +985,7 @@ func TestStreamShardAcrossCalls(t *testing.T) {
 			shardTracker:     NewShardTracker(),
 		}
 
-		derivedStreams := d.shardStream(baseStream, streamRate, "fake", "")
+		derivedStreams := d.shardStream(baseStream, streamRate, "fake", "", d.validator.ShardStreams("fake"))
 		require.Len(t, derivedStreams, 2)
 
 		for i, s := range derivedStreams {
@@ -995,7 +996,7 @@ func TestStreamShardAcrossCalls(t *testing.T) {
 			require.Equal(t, lbls.Get(ingester.ShardLbName), fmt.Sprint(i))
 		}
 
-		derivedStreams = d.shardStream(baseStream, streamRate, "fake", "")
+		derivedStreams = d.shardStream(baseStream, streamRate, "fake", "", d.validator.ShardStreams("fake"))
 		require.Len(t, derivedStreams, 2)
 
 		for i, s := range derivedStreams {
@@ -1323,7 +1324,7 @@ func BenchmarkShardStream(b *testing.B) {
 
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			d.shardStream(stream, 0, "fake", "") //nolint:errcheck
+			d.shardStream(stream, 0, "fake", "", d.validator.ShardStreams("fake")) //nolint:errcheck
 		}
 	})
 
@@ -1333,7 +1334,7 @@ func BenchmarkShardStream(b *testing.B) {
 
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			d.shardStream(stream, 0, "fake", "") //nolint:errcheck
+			d.shardStream(stream, 0, "fake", "", d.validator.ShardStreams("fake")) //nolint:errcheck
 		}
 	})
 
@@ -1343,7 +1344,7 @@ func BenchmarkShardStream(b *testing.B) {
 
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			d.shardStream(stream, 0, "fake", "") //nolint:errcheck
+			d.shardStream(stream, 0, "fake", "", d.validator.ShardStreams("fake")) //nolint:errcheck
 		}
 	})
 
@@ -1353,7 +1354,7 @@ func BenchmarkShardStream(b *testing.B) {
 
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			d.shardStream(stream, 0, "fake", "") //nolint:errcheck
+			d.shardStream(stream, 0, "fake", "", d.validator.ShardStreams("fake")) //nolint:errcheck
 		}
 	})
 }
@@ -1869,6 +1870,69 @@ func TestDistributor_PushIngestionRateLimitMultiplePolicies(t *testing.T) {
 		assert.Nil(t, resp)
 		assert.Equal(t, expectedErr, err)
 	}
+}
+
+// TestDistributor_PushShardStreamsPolicyOverride verifies that a per-policy shard_streams
+// override is applied in the push path: a policy that enables time sharding gets its streams
+// split with a __time_shard__ label, while streams on the tenant default (time sharding off)
+// do not.
+func TestDistributor_PushShardStreamsPolicyOverride(t *testing.T) {
+	limits := &validation.Limits{}
+	flagext.DefaultValues(limits)
+	limits.RejectOldSamples = false // we push intentionally old logs to trigger time sharding
+	// Tenant default leaves time sharding off; the "foo" policy turns it on via an override.
+	limits.PolicyStreamMapping = validation.PolicyStreamMapping{
+		"foo": []*validation.PriorityStream{{Selector: `{app="foo"}`, Priority: 1}},
+	}
+	timeOn := true
+	limits.PolicyOverrideLimits = map[string]validation.PolicyOverridableLimits{
+		"foo": {ShardStreams: &shardstreams.PerPolicyConfigOverride{TimeShardingEnabled: &timeOn}},
+	}
+	require.NoError(t, limits.Validate())
+
+	// prepare() builds distributors with ingester MaxChunkAge=2h → time-shard length 1h.
+	distributors, ingesters := prepare(t, 1, 3, limits, nil)
+
+	// Logs older than time_sharding_ignore_recent (40m default), spanning two 1h buckets.
+	old := time.Now().Add(-3 * time.Hour)
+	mkReq := func(lbls string) *logproto.PushRequest {
+		return &logproto.PushRequest{Streams: []logproto.Stream{{
+			Labels: lbls,
+			Entries: []logproto.Entry{
+				{Timestamp: old, Line: "a"},
+				{Timestamp: old.Add(time.Hour + time.Minute), Line: "b"},
+			},
+		}}}
+	}
+
+	_, err := distributors[0].Push(ctx, mkReq(`{app="foo"}`))
+	require.NoError(t, err)
+	_, err = distributors[0].Push(ctx, mkReq(`{app="other"}`))
+	require.NoError(t, err)
+
+	// Give the async ingester pushes time to land.
+	time.Sleep(20 * time.Millisecond)
+
+	fooSharded, otherSharded := false, false
+	for i := range ingesters {
+		ingesters[i].mu.Lock()
+		for _, pr := range ingesters[i].pushed {
+			for _, st := range pr.Streams {
+				if !strings.Contains(st.Labels, "__time_shard__") {
+					continue
+				}
+				if strings.Contains(st.Labels, `app="foo"`) {
+					fooSharded = true
+				}
+				if strings.Contains(st.Labels, `app="other"`) {
+					otherSharded = true
+				}
+			}
+		}
+		ingesters[i].mu.Unlock()
+	}
+	require.True(t, fooSharded, "foo stream should be time-sharded via the per-policy override")
+	require.False(t, otherSharded, "non-foo stream should not be time-sharded (tenant default off)")
 }
 
 func TestDistributor_PushIngestionBlocked(t *testing.T) {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1910,8 +1910,26 @@ func TestDistributor_PushShardStreamsPolicyOverride(t *testing.T) {
 	_, err = distributors[0].Push(ctx, mkReq(`{app="other"}`))
 	require.NoError(t, err)
 
-	// Give the async ingester pushes time to land.
-	time.Sleep(20 * time.Millisecond)
+	// The ingester writes are async (serviced by the distributor's ingester worker pool), so wait
+	// until both requests' streams have reached the ingesters before asserting.
+	streamPushed := func(app string) bool {
+		for i := range ingesters {
+			ingesters[i].mu.Lock()
+			for _, pr := range ingesters[i].pushed {
+				for _, st := range pr.Streams {
+					if strings.Contains(st.Labels, `app="`+app+`"`) {
+						ingesters[i].mu.Unlock()
+						return true
+					}
+				}
+			}
+			ingesters[i].mu.Unlock()
+		}
+		return false
+	}
+	require.Eventually(t, func() bool {
+		return streamPushed("foo") && streamPushed("other")
+	}, time.Second, 10*time.Millisecond, "expected both streams to reach the ingesters")
 
 	fooSharded, otherSharded := false, false
 	for i := range ingesters {

--- a/pkg/distributor/limits.go
+++ b/pkg/distributor/limits.go
@@ -31,6 +31,7 @@ type Limits interface {
 	LogLevelFromJSONMaxDepth(userID string) int
 
 	ShardStreams(userID string) shardstreams.Config
+	PolicyShardStreams(userID, policy string) shardstreams.Config
 	IngestionRateStrategy() string
 	IngestionRateBytes(userID string) float64
 	IngestionBurstSizeBytes(userID string) int

--- a/pkg/distributor/shardstreams/config.go
+++ b/pkg/distributor/shardstreams/config.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"time"
 
+	"github.com/prometheus/common/model"
+
 	"github.com/grafana/loki/v3/pkg/util/flagext"
 )
 
@@ -28,4 +30,39 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, fs *flag.FlagSet) {
 	fs.BoolVar(&cfg.LoggingEnabled, prefix+".logging-enabled", false, "Enable logging when sharding streams")
 	cfg.DesiredRate.Set("1536KB") //nolint:errcheck
 	fs.Var(&cfg.DesiredRate, prefix+".desired-rate", "threshold used to cut a new shard. Default (1536KB) means if a rate is above 1536KB/s, it will be sharded.")
+}
+
+// PerPolicyConfigOverride holds optional per-policy overrides for the sharding Config. Each field is a
+// pointer so that a nil field inherits the value from the base (tenant) Config — this lets a
+// policy change just one setting (e.g. toggle time sharding) without restating the rest.
+type PerPolicyConfigOverride struct {
+	Enabled                  *bool             `yaml:"enabled" json:"enabled" doc:"description=Override shard_streams.enabled for a specific policy."`
+	DesiredRate              *flagext.ByteSize `yaml:"desired_rate" json:"desired_rate" doc:"description=Override shard_streams.desired_rate for a specific policy."`
+	TimeShardingEnabled      *bool             `yaml:"time_sharding_enabled" json:"time_sharding_enabled" doc:"description=Override shard_streams.time_sharding_enabled for a specific policy."`
+	TimeShardingIgnoreRecent *model.Duration   `yaml:"time_sharding_ignore_recent" json:"time_sharding_ignore_recent" doc:"description=Override shard_streams.time_sharding_ignore_recent for a specific policy."`
+	LoggingEnabled           *bool             `yaml:"logging_enabled" json:"logging_enabled" doc:"description=Override shard_streams.logging_enabled for a specific policy."`
+}
+
+// ApplyTo returns base with only the override's non-nil fields replaced. A nil override (or one
+// with all-nil fields) returns base unchanged.
+func (o *PerPolicyConfigOverride) ApplyTo(base Config) Config {
+	if o == nil {
+		return base
+	}
+	if o.Enabled != nil {
+		base.Enabled = *o.Enabled
+	}
+	if o.DesiredRate != nil {
+		base.DesiredRate = *o.DesiredRate
+	}
+	if o.TimeShardingEnabled != nil {
+		base.TimeShardingEnabled = *o.TimeShardingEnabled
+	}
+	if o.TimeShardingIgnoreRecent != nil {
+		base.TimeShardingIgnoreRecent = time.Duration(*o.TimeShardingIgnoreRecent)
+	}
+	if o.LoggingEnabled != nil {
+		base.LoggingEnabled = *o.LoggingEnabled
+	}
+	return base
 }

--- a/pkg/distributor/shardstreams/config_test.go
+++ b/pkg/distributor/shardstreams/config_test.go
@@ -1,0 +1,88 @@
+package shardstreams
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/util/flagext"
+)
+
+func TestPerPolicyConfigOverride_ApplyTo(t *testing.T) {
+	base := Config{
+		Enabled:                  true,
+		DesiredRate:              flagext.ByteSize(1536 * 1024),
+		TimeShardingEnabled:      false,
+		TimeShardingIgnoreRecent: 40 * time.Minute,
+		LoggingEnabled:           false,
+	}
+
+	boolPtr := func(b bool) *bool { return &b }
+	bytePtr := func(b flagext.ByteSize) *flagext.ByteSize { return &b }
+	durPtr := func(d model.Duration) *model.Duration { return &d }
+
+	// withBase returns a copy of base with fn applied, for readable per-field expectations.
+	withBase := func(fn func(c *Config)) Config {
+		c := base
+		fn(&c)
+		return c
+	}
+
+	for _, tc := range []struct {
+		name     string
+		override *PerPolicyConfigOverride
+		expected Config
+	}{
+		{
+			name:     "nil override inherits base",
+			override: nil,
+			expected: base,
+		},
+		{
+			name:     "empty override inherits base",
+			override: &PerPolicyConfigOverride{},
+			expected: base,
+		},
+		{
+			name:     "only time sharding overridden, rest inherited",
+			override: &PerPolicyConfigOverride{TimeShardingEnabled: boolPtr(true)},
+			expected: withBase(func(c *Config) { c.TimeShardingEnabled = true }),
+		},
+		{
+			name:     "only desired rate overridden, rest inherited",
+			override: &PerPolicyConfigOverride{DesiredRate: bytePtr(flagext.ByteSize(512 * 1024))},
+			expected: withBase(func(c *Config) { c.DesiredRate = flagext.ByteSize(512 * 1024) }),
+		},
+		{
+			name: "all fields overridden",
+			override: &PerPolicyConfigOverride{
+				Enabled:                  boolPtr(false),
+				DesiredRate:              bytePtr(flagext.ByteSize(512 * 1024)),
+				TimeShardingEnabled:      boolPtr(true),
+				TimeShardingIgnoreRecent: durPtr(model.Duration(10 * time.Minute)),
+				LoggingEnabled:           boolPtr(true),
+			},
+			expected: Config{
+				Enabled:                  false,
+				DesiredRate:              flagext.ByteSize(512 * 1024),
+				TimeShardingEnabled:      true,
+				TimeShardingIgnoreRecent: 10 * time.Minute,
+				LoggingEnabled:           true,
+			},
+		},
+		{
+			name:     "zero-value fields replace, not inherit",
+			override: &PerPolicyConfigOverride{Enabled: boolPtr(false), DesiredRate: bytePtr(0)},
+			expected: withBase(func(c *Config) {
+				c.Enabled = false
+				c.DesiredRate = 0
+			}),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.override.ApplyTo(base))
+		})
+	}
+}

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -669,6 +669,9 @@ func (l *Limits) Validate() error {
 		if pl.PerStreamRateLimit.Val() < 0 || pl.PerStreamRateLimitBurst.Val() < 0 {
 			return fmt.Errorf("policy_override_limits[%q]: per_stream_rate_limit and per_stream_rate_limit_burst must be >= 0", policy)
 		}
+		if pl.ShardStreams != nil && pl.ShardStreams.DesiredRate != nil && pl.ShardStreams.DesiredRate.Val() < 0 {
+			return fmt.Errorf("policy_override_limits[%q]: shard_streams.desired_rate must be >= 0", policy)
+		}
 	}
 
 	if _, err := deletionmode.ParseMode(l.DeletionMode); err != nil {
@@ -1240,6 +1243,21 @@ func (o *Overrides) ShardStreams(userID string) shardstreams.Config {
 	return o.getOverridesForUser(userID).ShardStreams
 }
 
+// PolicyShardStreams returns the effective shard_streams config for a stream resolved to the
+// given policy: the tenant shard_streams config with the policy's overrides (if any) applied.
+// A stream with no policy (or a policy without a shard_streams override) gets the tenant config.
+func (o *Overrides) PolicyShardStreams(userID, policy string) shardstreams.Config {
+	limits := o.getOverridesForUser(userID)
+	base := limits.ShardStreams
+	if policy == "" || len(limits.PolicyOverrideLimits) == 0 {
+		return base
+	}
+	if pl, exists := limits.PolicyOverrideLimits[policy]; exists {
+		return pl.ShardStreams.ApplyTo(base)
+	}
+	return base
+}
+
 func (o *Overrides) BlockedQueries(_ context.Context, userID string) []*validation.BlockedQuery {
 	return o.getOverridesForUser(userID).BlockedQueries
 }
@@ -1534,6 +1552,11 @@ type PolicyOverridableLimits struct {
 	IngestionBurstSizeMB    float64          `yaml:"ingestion_burst_size_mb" json:"ingestion_burst_size_mb" doc:"ingestion_burst_size_mb for a specific policy. When unset (0), falls back to the tenant ingestion_burst_size_mb."`
 	PerStreamRateLimit      flagext.ByteSize `yaml:"per_stream_rate_limit" json:"per_stream_rate_limit" doc:"per_stream_rate_limit for a specific policy. Replaces the tenant per_stream_rate_limit for streams matching the policy."`
 	PerStreamRateLimitBurst flagext.ByteSize `yaml:"per_stream_rate_limit_burst" json:"per_stream_rate_limit_burst" doc:"per_stream_rate_limit_burst for a specific policy."`
+
+	// ShardStreams overrides the tenant shard_streams config for a specific policy. Only the
+	// fields set here change; unset fields inherit the tenant shard_streams config (see
+	// PerPolicyConfigOverride.ApplyTo).
+	ShardStreams *shardstreams.PerPolicyConfigOverride `yaml:"shard_streams" json:"shard_streams" doc:"shard_streams overrides for a specific policy. Only the set fields override the tenant shard_streams config."`
 }
 
 func NewOverwriteMarshalingStringMap(m map[string]string) OverwriteMarshalingStringMap {

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/compactor/deletionmode"
 	"github.com/grafana/loki/v3/pkg/compression"
+	"github.com/grafana/loki/v3/pkg/distributor/shardstreams"
 	"github.com/grafana/loki/v3/pkg/loghttp/push"
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/util/flagext"
@@ -740,6 +741,55 @@ func TestLimits_PolicyRateOverrides(t *testing.T) {
 	require.False(t, ok)
 	_, ok = overrides.PolicyPerStreamRateLimit("tenant1", "finance")
 	require.False(t, ok)
+}
+
+func TestPolicyShardStreams(t *testing.T) {
+	timeOn := true
+	desired := flagext.ByteSize(512 * 1024)
+	base := shardstreams.Config{
+		Enabled:                  true,
+		DesiredRate:              flagext.ByteSize(1536 * 1024),
+		TimeShardingEnabled:      false,
+		TimeShardingIgnoreRecent: 40 * time.Minute,
+	}
+	limits := &Limits{
+		ShardStreams: base,
+		PolicyOverrideLimits: map[string]PolicyOverridableLimits{
+			// Only flips time sharding; everything else must inherit the tenant config.
+			"foo": {ShardStreams: &shardstreams.PerPolicyConfigOverride{TimeShardingEnabled: &timeOn}},
+			// Overrides the desired rate only.
+			"finance": {ShardStreams: &shardstreams.PerPolicyConfigOverride{DesiredRate: &desired}},
+			// Policy entry exists but has no shard_streams override → tenant config.
+			"ops": {IngestionRateMB: 5},
+		},
+	}
+	overrides := &Overrides{defaultLimits: limits, tenantLimits: nil}
+
+	// No policy → tenant config unchanged.
+	require.Equal(t, base, overrides.PolicyShardStreams("tenant1", ""))
+
+	// foo → only time sharding flipped, rest inherited.
+	got := overrides.PolicyShardStreams("tenant1", "foo")
+	require.True(t, got.TimeShardingEnabled)
+	require.True(t, got.Enabled)
+	require.Equal(t, base.DesiredRate, got.DesiredRate)
+	require.Equal(t, base.TimeShardingIgnoreRecent, got.TimeShardingIgnoreRecent)
+
+	// finance → only desired rate overridden.
+	got = overrides.PolicyShardStreams("tenant1", "finance")
+	require.Equal(t, flagext.ByteSize(512*1024), got.DesiredRate)
+	require.False(t, got.TimeShardingEnabled)
+	require.True(t, got.Enabled)
+
+	// policy entry without a shard_streams override → tenant config.
+	require.Equal(t, base, overrides.PolicyShardStreams("tenant1", "ops"))
+
+	// unknown policy → tenant config.
+	require.Equal(t, base, overrides.PolicyShardStreams("tenant1", "unknown"))
+
+	// nil PolicyOverrideLimits → tenant config.
+	limits.PolicyOverrideLimits = nil
+	require.Equal(t, base, overrides.PolicyShardStreams("tenant1", "foo"))
 }
 
 func TestOTLPConfig(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Extends the per-policy override mechanism (`policy_override_limits`) to **stream sharding**, so a policy can override the tenant `shard_streams` config — including **toggling time sharding** or using a different `desired_rate`.

**Semantics — inherit + override:** a new `shardstreams.PerPolicyConfigOverride` holds optional (pointer) fields; `ApplyTo(base)` layers only the set fields onto the tenant `shard_streams` config (a `nil` field inherits). This lets a policy flip just one setting (e.g. `time_sharding_enabled`) without restating the rest — avoiding the footgun of a whole-config replace silently disabling sharding.

Example config:
```yaml
policy_override_limits:
  some_policy:
    shard_streams:
      time_sharding_enabled: true   # everything else inherits the tenant shard_streams
```

Implementation notes:
- `Overrides.PolicyShardStreams(userID, policy)` resolves the effective config (tenant config with the policy's overrides applied; falls back to the tenant config for no-policy / no-override).
- The distributor resolves the effective config per stream (policy is already known at the sharding call site) and threads it through `maybeShardStreams` → `maybeShardByRate` → `shardStream` (which no longer re-fetches the tenant config). `shardCountFor`/`divideEntriesBetweenShards`/`createShards` already took the config, so they now receive the per-policy one unchanged.
- **Distributor-only** — sharding happens at push time; the ingester does not shard, so there are no ingester changes.
- The `shard_streams` sub-field stays `doc:"hidden"`, consistent with the rest of `policy_override_limits`.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
- Naming follows the existing per-policy accessors (`PolicyShardStreams`, like `PolicyIngestionRateBytes`).
- Tests: `PerPolicyConfigOverride.ApplyTo` (table-driven), `Overrides.PolicyShardStreams` (inherit / partial override / no-override entry / unknown / empty / nil map), and an end-to-end distributor test that a policy with a `time_sharding_enabled` override produces `__time_shard__` streams in the push path while the tenant default (off) does not.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added (config field is `doc:"hidden"`, consistent with the rest of `policy_override_limits` — no generated docs change)
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md` (none — additive, opt-in)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. (N/A)
