### PR TITLE
chore: Use reverse input order as fallback during initial sort

### DIFF
--- a/pkg/dataobj/sections/logs/table_build.go
+++ b/pkg/dataobj/sections/logs/table_build.go
@@ -66,22 +66,30 @@ func sortRecords(records []Record, sortOrder SortOrder) {
 			if res := cmp.Compare(a.StreamID, b.StreamID); res != 0 {
 				return res
 			}
-			return b.Timestamp.Compare(a.Timestamp)
+			return reverseOrderIfEqual(b.Timestamp.Compare(a.Timestamp))
 		case SortTimestampDESC:
 			// Sort by [timestamp DESC, streamID ASC]
 			if res := b.Timestamp.Compare(a.Timestamp); res != 0 {
 				return res
 			}
-			return cmp.Compare(a.StreamID, b.StreamID)
+			return reverseOrderIfEqual(cmp.Compare(a.StreamID, b.StreamID))
 		case SortSchemaASC:
 			if res := cmp.Compare(a.SortKey, b.SortKey); res != 0 {
 				return res
 			}
-			return b.Timestamp.Compare(a.Timestamp)
+			return reverseOrderIfEqual(b.Timestamp.Compare(a.Timestamp))
 		default:
 			panic("invalid sort order")
 		}
 	})
+}
+
+// reverseOrderIfEqual reverses the order of the elements if the result is otherwise equal.
+func reverseOrderIfEqual(res int) int {
+	if res != 0 {
+		return res
+	}
+	return -1
 }
 
 // SortRecords sorts records in place by sortOrder. For SortSchemaASC each

--- a/pkg/dataobj/sections/logs/table_build.go
+++ b/pkg/dataobj/sections/logs/table_build.go
@@ -59,7 +59,7 @@ func buildTable(buf *tableBuffer, pageSize, pageRowCount int, compressionOpts *d
 
 // sortRecords sorts the set of records according to the specified sort order.
 func sortRecords(records []Record, sortOrder SortOrder) {
-	slices.SortFunc(records, func(a, b Record) int {
+	slices.SortStableFunc(records, func(a, b Record) int {
 		switch sortOrder {
 		case SortStreamASC:
 			// Sort by [streamID ASC, timestamp DESC]

--- a/pkg/dataobj/sections/logs/table_test.go
+++ b/pkg/dataobj/sections/logs/table_test.go
@@ -140,39 +140,165 @@ func Test_mergeTables(t *testing.T) {
 }
 
 func TestSortRecords_SortSchemaASC(t *testing.T) {
+	type testCase struct {
+		name              string
+		sortOrder         SortOrder
+		input             []Record
+		expectedLineOrder []string
+	}
+
 	t1 := time.Unix(1, 0)
 	t2 := time.Unix(2, 0)
 	t3 := time.Unix(3, 0)
 
-	records := []Record{
-		{StreamID: 10, Timestamp: t1, SortKey: "app-b", Line: []byte("b-old")},
-		{StreamID: 10, Timestamp: t1, SortKey: "app-b", Line: []byte("b-old-2")}, // Stable sort: Ensure a second record with the same sort key is emitted in the order it was presented.
-		{StreamID: 20, Timestamp: t3, SortKey: "app-a", Line: []byte("a-new")},
-		{StreamID: 21, Timestamp: t1, SortKey: "app-a", Line: []byte("a-old")},
-		{StreamID: 11, Timestamp: t2, SortKey: "app-b", Line: []byte("b-mid")},
-		{StreamID: 22, Timestamp: t2, SortKey: "app-a", Line: []byte("a-mid")},
-		{StreamID: 12, Timestamp: t3, SortKey: "app-b", Line: []byte("b-new")},
+	testCases := []testCase{
+		{
+			// SortSchemaASC basic case
+			name:      "SortSchemaASC_basic",
+			sortOrder: SortSchemaASC,
+			input: []Record{
+				{Timestamp: t1, SortKey: "app-a", Line: []byte("A")},
+				{Timestamp: t2, SortKey: "app-b", Line: []byte("B")},
+				{Timestamp: t3, SortKey: "app-c", Line: []byte("C")},
+			},
+			expectedLineOrder: []string{"A", "B", "C"},
+		},
+		{
+			// SortSchemaASC with equal sort keys falls back to timestamp DESC
+			name:      "SortSchemaASC_equalSortKeys",
+			sortOrder: SortSchemaASC,
+			input: []Record{
+				{Timestamp: t1, SortKey: "app-a", Line: []byte("A")},
+				{Timestamp: t2, SortKey: "app-a", Line: []byte("B")},
+				{Timestamp: t3, SortKey: "app-a", Line: []byte("C")},
+			},
+			expectedLineOrder: []string{"C", "B", "A"},
+		},
+		{
+			// SortSchemaASC with equal timestamps uses primary ordering
+			name:      "SortSchemaASC_equalTimestamps",
+			sortOrder: SortSchemaASC,
+			input: []Record{
+				{Timestamp: t1, SortKey: "app-a", Line: []byte("A")},
+				{Timestamp: t1, SortKey: "app-b", Line: []byte("B")},
+				{Timestamp: t1, SortKey: "app-c", Line: []byte("C")},
+			},
+			expectedLineOrder: []string{"A", "B", "C"},
+		},
+		{
+			// SortSchemaASC with equal sort keys and equal timestamps falls back to reverse input ordering
+			name:      "SortSchemaASC_equalSortKeysAndTimestamps",
+			sortOrder: SortSchemaASC,
+			input: []Record{
+				{Timestamp: t1, SortKey: "app-a", Line: []byte("A")},
+				{Timestamp: t1, SortKey: "app-a", Line: []byte("B")},
+				{Timestamp: t1, SortKey: "app-a", Line: []byte("C")},
+			},
+			expectedLineOrder: []string{"C", "B", "A"},
+		},
+		{
+			// SortStreamASC basic case
+			name:      "SortStreamASC_basic",
+			sortOrder: SortStreamASC,
+			input: []Record{
+				{StreamID: 10, Timestamp: t1, Line: []byte("A")},
+				{StreamID: 20, Timestamp: t2, Line: []byte("B")},
+				{StreamID: 30, Timestamp: t3, Line: []byte("C")},
+			},
+			expectedLineOrder: []string{"A", "B", "C"},
+		},
+		{
+			// SortStreamASC with equal stream IDs falls back to timestamp DESC
+			name:      "SortStreamASC_equalStreamIDs",
+			sortOrder: SortStreamASC,
+			input: []Record{
+				{StreamID: 10, Timestamp: t1, Line: []byte("A")},
+				{StreamID: 10, Timestamp: t2, Line: []byte("B")},
+				{StreamID: 10, Timestamp: t3, Line: []byte("C")},
+			},
+			expectedLineOrder: []string{"C", "B", "A"},
+		},
+		{
+			// SortStreamASC with equal timestamps uses primary ordering
+			name:      "SortStreamASC_equalTimestamps",
+			sortOrder: SortStreamASC,
+			input: []Record{
+				{StreamID: 10, Timestamp: t1, Line: []byte("A")},
+				{StreamID: 20, Timestamp: t1, Line: []byte("B")},
+				{StreamID: 30, Timestamp: t1, Line: []byte("C")},
+			},
+			expectedLineOrder: []string{"A", "B", "C"},
+		},
+		{
+			// SortStreamASC with equal stream IDs and equal timestamps falls back to reverse input ordering
+			name:      "SortStreamASC_equalStreamIDsAndTimestamps",
+			sortOrder: SortStreamASC,
+			input: []Record{
+				{StreamID: 10, Timestamp: t1, Line: []byte("A")},
+				{StreamID: 10, Timestamp: t1, Line: []byte("B")},
+				{StreamID: 10, Timestamp: t1, Line: []byte("C")},
+				{StreamID: 10, Timestamp: t2, Line: []byte("D")},
+				{StreamID: 10, Timestamp: t2, Line: []byte("E")},
+				{StreamID: 10, Timestamp: t3, Line: []byte("F")},
+				{StreamID: 10, Timestamp: t3, Line: []byte("G")},
+			},
+			expectedLineOrder: []string{"G", "F", "E", "D", "C", "B", "A"},
+		},
+		{
+			// SortTimestampDESC basic case
+			name:      "SortTimestampDESC_basic",
+			sortOrder: SortTimestampDESC,
+			input: []Record{
+				{StreamID: 10, Timestamp: t1, Line: []byte("A")},
+				{StreamID: 20, Timestamp: t2, Line: []byte("B")},
+				{StreamID: 30, Timestamp: t3, Line: []byte("C")},
+			},
+			expectedLineOrder: []string{"C", "B", "A"},
+		},
+		{
+			// SortTimestampDESC with equal stream IDs
+			name:      "SortTimestampDESC_equalStreamIDs",
+			sortOrder: SortTimestampDESC,
+			input: []Record{
+				{StreamID: 10, Timestamp: t1, Line: []byte("A")},
+				{StreamID: 10, Timestamp: t2, Line: []byte("B")},
+				{StreamID: 10, Timestamp: t3, Line: []byte("C")},
+			},
+			expectedLineOrder: []string{"C", "B", "A"},
+		},
+		{
+			// SortTimestampDESC with equal timestamps falls back to stream ID ASC
+			name:      "SortTimestampDESC_equalTimestamps",
+			sortOrder: SortTimestampDESC,
+			input: []Record{
+				{StreamID: 10, Timestamp: t1, Line: []byte("A")},
+				{StreamID: 20, Timestamp: t1, Line: []byte("B")},
+				{StreamID: 30, Timestamp: t1, Line: []byte("C")},
+			},
+			expectedLineOrder: []string{"A", "B", "C"},
+		},
+		{
+			// SortTimestampDESC with equal timestamps and equal stream IDs falls back to reverse input ordering
+			name:      "SortTimestampDESC_equalTimestampsAndStreamIDs",
+			sortOrder: SortTimestampDESC,
+			input: []Record{
+				{StreamID: 10, Timestamp: t1, Line: []byte("A")},
+				{StreamID: 10, Timestamp: t1, Line: []byte("B")},
+				{StreamID: 10, Timestamp: t1, Line: []byte("C")},
+			},
+			expectedLineOrder: []string{"C", "B", "A"},
+		},
 	}
 
-	sortRecords(records, SortSchemaASC)
-
-	var lines []string
-	for _, r := range records {
-		lines = append(lines, string(r.Line))
-	}
-
-	// app-a records first (sort key ASC), timestamp DESC within group
-	require.Equal(t, []string{"a-new", "a-mid", "a-old", "b-new", "b-mid", "b-old", "b-old-2"}, lines)
-
-	for i := 0; i < len(records)-1; i++ {
-		a, b := records[i], records[i+1]
-		if a.SortKey == b.SortKey {
-			require.True(t, a.Timestamp.After(b.Timestamp) || a.Timestamp.Equal(b.Timestamp),
-				"within same sort key, timestamps must be DESC: got %v then %v", a.Timestamp, b.Timestamp)
-		} else {
-			require.LessOrEqual(t, a.SortKey, b.SortKey,
-				"sort keys must be ASC across groups: got %q then %q", a.SortKey, b.SortKey)
-		}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			sortRecords(testCase.input, testCase.sortOrder)
+			var lines []string
+			for _, r := range testCase.input {
+				lines = append(lines, string(r.Line))
+			}
+			require.Equal(t, testCase.expectedLineOrder, lines)
+		})
 	}
 }
 

--- a/pkg/engine/internal/executor/topk_batch.go
+++ b/pkg/engine/internal/executor/topk_batch.go
@@ -219,9 +219,9 @@ func (b *topkBatch) less(left, right *topkReference) bool {
 
 	switch {
 	case b.Ascending:
-		return left.LabelHash < right.LabelHash
-	default:
 		return left.LabelHash > right.LabelHash
+	default:
+		return left.LabelHash < right.LabelHash
 	}
 }
 

--- a/pkg/engine/internal/executor/topk_batch.go
+++ b/pkg/engine/internal/executor/topk_batch.go
@@ -219,9 +219,9 @@ func (b *topkBatch) less(left, right *topkReference) bool {
 
 	switch {
 	case b.Ascending:
-		return left.LabelHash > right.LabelHash
-	default:
 		return left.LabelHash < right.LabelHash
+	default:
+		return left.LabelHash > right.LabelHash
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds reverse-input-ordering as a fallback to sorting data objects during initial build.
This kicks in if both the primary and secondary sort order are equal (usually Stream ID and timestamp) and ensures the following behaviour:
Entries `{t1, A} {t1, B} {t2, C} {t2, D}`
 sort as `{t2, D} {t2, C} {t1, B} {t1, A}`
 instead of previous `{t2, C} {t2, D} {t1, A} {t1, B}`
