### PR TITLE
chore(engine): Add communication-plane metrics

### DIFF
--- a/pkg/engine/internal/scheduler/comm_metrics.go
+++ b/pkg/engine/internal/scheduler/comm_metrics.go
@@ -1,0 +1,117 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
+	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
+)
+
+const (
+	assignmentOutcomeAssigned     = "assigned"
+	assignmentOutcomeRejected     = "rejected"
+	assignmentOutcomeTimeout      = "timeout"
+	assignmentOutcomeCanceled     = "canceled"
+	assignmentOutcomeConnClosed   = "conn_closed"
+	assignmentOutcomeUnassignable = "unassignable"
+	assignmentOutcomeSendError    = "send_error"
+	assignmentOutcomeOtherError   = "other_error"
+)
+
+const (
+	taskStatusOutcomeAccepted     = "accepted"
+	taskStatusOutcomeStale        = "stale"
+	taskStatusOutcomeHandlerError = "handler_error"
+)
+
+const (
+	taskStatusPhaseTotal = "total"
+)
+
+const (
+	taskStatusStateClassRunning  = "running"
+	taskStatusStateClassTerminal = "terminal"
+	taskStatusStateClassOther    = "other"
+)
+
+const (
+	taskStatusStaleTaskNotFound      = "task_not_found"
+	taskStatusStaleInvalidTransition = "invalid_transition"
+	taskStatusStaleDuplicateNoop     = "duplicate_noop"
+)
+
+const (
+	messageOutcomeAccepted   = "accepted"
+	messageOutcomeTimeout    = "timeout"
+	messageOutcomeCanceled   = "canceled"
+	messageOutcomeConnClosed = "conn_closed"
+	messageOutcomeSendError  = "send_error"
+)
+
+func observeTaskAssignment(m *metrics, outcome string, d time.Duration) {
+	m.taskAssignmentAttemptsTotal.WithLabelValues(outcome).Inc()
+	if d > 0 {
+		m.taskAssignmentSendSeconds.WithLabelValues(outcome).Observe(d.Seconds())
+	}
+}
+
+func classifyTaskAssignmentOutcome(err error) string {
+	switch {
+	case err == nil:
+		return assignmentOutcomeAssigned
+	case errors.Is(err, errUnassignable):
+		return assignmentOutcomeUnassignable
+	case isTooManyRequestsError(err):
+		return assignmentOutcomeRejected
+	case errors.Is(err, context.DeadlineExceeded):
+		return assignmentOutcomeTimeout
+	case errors.Is(err, context.Canceled):
+		return assignmentOutcomeCanceled
+	case errors.Is(err, wire.ErrConnClosed):
+		return assignmentOutcomeConnClosed
+	}
+
+	var wireError *wire.Error
+	if errors.As(err, &wireError) {
+		return assignmentOutcomeOtherError
+	}
+	return assignmentOutcomeSendError
+}
+
+func classifyMessageOutcome(err error) string {
+	switch {
+	case err == nil:
+		return messageOutcomeAccepted
+	case errors.Is(err, context.DeadlineExceeded):
+		return messageOutcomeTimeout
+	case errors.Is(err, context.Canceled):
+		return messageOutcomeCanceled
+	case errors.Is(err, wire.ErrConnClosed):
+		return messageOutcomeConnClosed
+	default:
+		return messageOutcomeSendError
+	}
+}
+
+func taskStatusStateClass(state workflow.TaskState) string {
+	switch {
+	case state == workflow.TaskStateRunning:
+		return taskStatusStateClassRunning
+	case state.Terminal():
+		return taskStatusStateClassTerminal
+	default:
+		return taskStatusStateClassOther
+	}
+}
+
+func isWireStatus(err error, status int) bool {
+	var wireError *wire.Error
+	return errors.As(err, &wireError) && wireError.Code == int32(status)
+}
+
+func isTooManyRequestsError(err error) bool {
+	return isWireStatus(err, http.StatusTooManyRequests)
+}

--- a/pkg/engine/internal/scheduler/comm_metrics_test.go
+++ b/pkg/engine/internal/scheduler/comm_metrics_test.go
@@ -1,0 +1,55 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
+	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
+)
+
+func TestClassifyTaskAssignmentOutcome(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "assigned", err: nil, want: assignmentOutcomeAssigned},
+		{name: "unassignable", err: errUnassignable, want: assignmentOutcomeUnassignable},
+		{name: "rejected", err: wire.Errorf(http.StatusTooManyRequests, "busy"), want: assignmentOutcomeRejected},
+		{name: "timeout", err: context.DeadlineExceeded, want: assignmentOutcomeTimeout},
+		{name: "canceled", err: context.Canceled, want: assignmentOutcomeCanceled},
+		{name: "connection closed", err: wire.ErrConnClosed, want: assignmentOutcomeConnClosed},
+		{name: "wire error", err: wire.Errorf(http.StatusInternalServerError, "failed"), want: assignmentOutcomeOtherError},
+		{name: "send error", err: errors.New("write failed"), want: assignmentOutcomeSendError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, classifyTaskAssignmentOutcome(tt.err))
+		})
+	}
+}
+
+func TestTaskStatusStateClass(t *testing.T) {
+	tests := []struct {
+		state workflow.TaskState
+		want  string
+	}{
+		{state: workflow.TaskStateRunning, want: taskStatusStateClassRunning},
+		{state: workflow.TaskStateCompleted, want: taskStatusStateClassTerminal},
+		{state: workflow.TaskStateCancelled, want: taskStatusStateClassTerminal},
+		{state: workflow.TaskStateFailed, want: taskStatusStateClassTerminal},
+		{state: workflow.TaskStatePending, want: taskStatusStateClassOther},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.state.String(), func(t *testing.T) {
+			require.Equal(t, tt.want, taskStatusStateClass(tt.state))
+		})
+	}
+}

--- a/pkg/engine/internal/scheduler/metrics.go
+++ b/pkg/engine/internal/scheduler/metrics.go
@@ -20,6 +20,16 @@ type metrics struct {
 
 	taskQueueSeconds prometheus.Histogram
 	taskExecSeconds  prometheus.Histogram
+
+	taskAssignmentAttemptsTotal *prometheus.CounterVec
+	taskAssignmentSendSeconds   *prometheus.HistogramVec
+	taskAssignmentRequeueTotal  *prometheus.CounterVec
+
+	taskStatusMessagesTotal  *prometheus.CounterVec
+	taskStatusHandlerSeconds *prometheus.HistogramVec
+	taskStatusStaleTotal     *prometheus.CounterVec
+
+	workerSubscriptionsTotal *prometheus.CounterVec
 }
 
 func newMetrics() *metrics {
@@ -66,6 +76,37 @@ func newMetrics() *metrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		}),
+
+		taskAssignmentAttemptsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_scheduler_task_assignment_attempts_total",
+			Help: "Total number of scheduler task assignment attempts by outcome.",
+		}, []string{"outcome"}),
+		taskAssignmentSendSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_scheduler_task_assignment_send_seconds",
+			Help: "Time spent sending TaskAssign messages to workers by assignment outcome.",
+		}, []string{"outcome"}),
+		taskAssignmentRequeueTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_scheduler_task_assignment_requeue_total",
+			Help: "Total number of task assignment requeues by reason.",
+		}, []string{"reason"}),
+
+		taskStatusMessagesTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_scheduler_task_status_messages_total",
+			Help: "Total number of scheduler TaskStatus messages by state class and outcome.",
+		}, []string{"state_class", "outcome"}),
+		taskStatusHandlerSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_scheduler_task_status_handler_seconds",
+			Help: "Time spent handling TaskStatus messages by phase, state class, and outcome.",
+		}, []string{"phase", "state_class", "outcome"}),
+		taskStatusStaleTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_scheduler_task_status_stale_total",
+			Help: "Total number of stale or ignored TaskStatus messages by reason.",
+		}, []string{"reason"}),
+
+		workerSubscriptionsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_scheduler_worker_subscriptions_total",
+			Help: "Total number of WorkerSubscribe messages sent by outcome.",
+		}, []string{"outcome"}),
 	}
 }
 
@@ -74,3 +115,12 @@ func (m *metrics) Register(reg prometheus.Registerer) error { return reg.Registe
 
 // Unregister unregisters metrics from the provided Registerer.
 func (m *metrics) Unregister(reg prometheus.Registerer) { reg.Unregister(m.reg) }
+
+// newNativeHistogramVec creates a HistogramVec that uses native histogram
+// buckets, registered to reg.
+func newNativeHistogramVec(reg prometheus.Registerer, opts prometheus.HistogramOpts, labels []string) *prometheus.HistogramVec {
+	opts.NativeHistogramBucketFactor = 1.1
+	opts.NativeHistogramMaxBucketNumber = 100
+	opts.NativeHistogramMinResetDuration = time.Hour
+	return promauto.With(reg).NewHistogramVec(opts, labels)
+}

--- a/pkg/engine/internal/scheduler/metrics.go
+++ b/pkg/engine/internal/scheduler/metrics.go
@@ -59,22 +59,14 @@ func newMetrics() *metrics {
 			Help: "Total number of times a task was requeued after a failed assignment attempt",
 		}),
 
-		taskQueueSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		taskQueueSeconds: newNativeHistogram(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_scheduler_task_queue_seconds",
 			Help: "Number of seconds a task sat in a queue before being assigned to a worker thread",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}),
 
-		taskExecSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		taskExecSeconds: newNativeHistogram(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_scheduler_task_exec_seconds",
 			Help: "Number of seconds a task took to complete successfully",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}),
 
 		taskAssignmentAttemptsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
@@ -115,6 +107,15 @@ func (m *metrics) Register(reg prometheus.Registerer) error { return reg.Registe
 
 // Unregister unregisters metrics from the provided Registerer.
 func (m *metrics) Unregister(reg prometheus.Registerer) { reg.Unregister(m.reg) }
+
+// newNativeHistogram creates a Histogram that uses native histogram buckets,
+// registered to reg.
+func newNativeHistogram(reg prometheus.Registerer, opts prometheus.HistogramOpts) prometheus.Histogram {
+	opts.NativeHistogramBucketFactor = 1.1
+	opts.NativeHistogramMaxBucketNumber = 100
+	opts.NativeHistogramMinResetDuration = time.Hour
+	return promauto.With(reg).NewHistogram(opts)
+}
 
 // newNativeHistogramVec creates a HistogramVec that uses native histogram
 // buckets, registered to reg.

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -159,6 +159,7 @@ func (s *Scheduler) handleConn(ctx context.Context, conn wire.Conn) {
 		Logger:  logger,
 		Metrics: s.wireMetrics,
 		Conn:    conn,
+		Role:    wire.RoleScheduler,
 
 		// Allow for a backlog of 128 frames before backpressure is applied.
 		Buffer: 128,
@@ -205,6 +206,7 @@ func (s *Scheduler) handleStreamData(ctx context.Context, worker *workerConn, ms
 	if err := worker.MarkDataPlane(); err != nil {
 		return err
 	}
+	worker.SetPlane(wire.PlaneData)
 
 	s.resourcesMut.RLock()
 	defer s.resourcesMut.RUnlock()
@@ -223,6 +225,7 @@ func (s *Scheduler) handleWorkerHello(ctx context.Context, worker *workerConn, m
 	if err := worker.HandleHello(msg); err != nil {
 		return err
 	}
+	worker.SetPlane(wire.PlaneControl)
 
 	// Request to be notified when the worker is ready.
 	s.workerSubscribe(ctx, worker)
@@ -264,8 +267,33 @@ func nudgeSemaphore(sema chan struct{}) {
 }
 
 func (s *Scheduler) handleTaskStatus(ctx context.Context, worker *workerConn, msg wire.TaskStatusMessage) error {
+	start := time.Now()
+	res, err := s.applyTaskStatus(ctx, worker, msg)
+
+	stateClass := taskStatusStateClass(msg.Status.State)
+	s.metrics.taskStatusMessagesTotal.WithLabelValues(stateClass, res.outcome).Inc()
+	s.metrics.taskStatusHandlerSeconds.WithLabelValues(taskStatusPhaseTotal, stateClass, res.outcome).Observe(time.Since(start).Seconds())
+	if res.staleReason != "" {
+		s.metrics.taskStatusStaleTotal.WithLabelValues(res.staleReason).Inc()
+	}
+	return err
+}
+
+// taskStatusResult classifies the outcome of applying a TaskStatus message so
+// handleTaskStatus can record metrics in one place without interleaving them
+// with the handler logic. staleReason is empty unless the status was stale or
+// rejected.
+type taskStatusResult struct {
+	outcome     string
+	staleReason string
+}
+
+// applyTaskStatus applies an incoming TaskStatus message to scheduler state and
+// returns how the message was classified. It performs no metric recording; that
+// is the caller's job.
+func (s *Scheduler) applyTaskStatus(ctx context.Context, worker *workerConn, msg wire.TaskStatusMessage) (taskStatusResult, error) {
 	if got, want := worker.Type(), connectionTypeControlPlane; got != want {
-		return fmt.Errorf("worker connection must be in state %q, got %q", want, got)
+		return taskStatusResult{outcome: taskStatusOutcomeHandlerError}, fmt.Errorf("worker connection must be in state %q, got %q", want, got)
 	}
 
 	var n notifier
@@ -276,58 +304,60 @@ func (s *Scheduler) handleTaskStatus(ctx context.Context, worker *workerConn, ms
 
 	task, found := s.tasks[msg.ID]
 	if !found {
-		return fmt.Errorf("task %s not found", msg.ID)
+		return taskStatusResult{outcome: taskStatusOutcomeHandlerError, staleReason: taskStatusStaleTaskNotFound}, fmt.Errorf("task %s not found", msg.ID)
 	}
 
 	changed, err := task.SetState(s.metrics, msg.Status)
 	if err != nil {
-		return err
-	} else if changed {
-		newState := msg.Status.State
-		if owner := task.owner; owner != nil && newState.Terminal() {
-			owner.Unassign(task)
-		}
-
-		switch newState {
-		case workflow.TaskStateCompleted:
-			task.wfRegion.Record(StatExecutedTasks.Observe(1))
-
-			if assignTime := task.AssignTime(); !assignTime.IsZero() {
-				// The execution time of the task is the duration from when it
-				// was first assigned to when we received the completion status.
-				//
-				// We skip the observation when assignTime is zero, which can
-				// happen when a task completes before we can process the
-				// assignment. If we didn't skip these, we'd record an
-				// observation of the maximum time.Duration value (290 years).
-				s.metrics.taskExecSeconds.Observe(time.Since(assignTime).Seconds())
-			}
-		case workflow.TaskStateCancelled:
-			// The worker has confirmed cancellation of a previously assigned
-			// task from [Scheduler.Cancel].
-			task.wfRegion.Record(StatCanceledAssignedTasks.Observe(1))
-		case workflow.TaskStateFailed:
-			task.wfRegion.Record(StatFailedTasks.Observe(1))
-		}
-
-		// Terminal states may include a capture from the worker; if so, we want
-		// to roll these up into our own per-task capture to give the event
-		// handler full visibility into the task's execution.
-		notifyStatus := msg.Status
-		if newState.Terminal() {
-			task.RecordTerminalObservations(time.Now())
-			task.capture.Merge(nil, notifyStatus.Capture)
-			notifyStatus.Capture = task.capture
-		}
-
-		// Notify the handler about the change.
-		n.AddTaskEvent(taskNotification{
-			Handler:   task.handler,
-			Task:      task.inner,
-			NewStatus: notifyStatus,
-		})
+		return taskStatusResult{outcome: taskStatusOutcomeHandlerError, staleReason: taskStatusStaleInvalidTransition}, err
+	} else if !changed {
+		return taskStatusResult{outcome: taskStatusOutcomeStale, staleReason: taskStatusStaleDuplicateNoop}, nil
 	}
-	return nil
+
+	newState := msg.Status.State
+	if owner := task.owner; owner != nil && newState.Terminal() {
+		owner.Unassign(task)
+	}
+
+	switch newState {
+	case workflow.TaskStateCompleted:
+		task.wfRegion.Record(StatExecutedTasks.Observe(1))
+
+		if assignTime := task.AssignTime(); !assignTime.IsZero() {
+			// The execution time of the task is the duration from when it
+			// was first assigned to when we received the completion status.
+			//
+			// We skip the observation when assignTime is zero, which can
+			// happen when a task completes before we can process the
+			// assignment. If we didn't skip these, we'd record an
+			// observation of the maximum time.Duration value (290 years).
+			s.metrics.taskExecSeconds.Observe(time.Since(assignTime).Seconds())
+		}
+	case workflow.TaskStateCancelled:
+		// The worker has confirmed cancellation of a previously assigned
+		// task from [Scheduler.Cancel].
+		task.wfRegion.Record(StatCanceledAssignedTasks.Observe(1))
+	case workflow.TaskStateFailed:
+		task.wfRegion.Record(StatFailedTasks.Observe(1))
+	}
+
+	// Terminal states may include a capture from the worker; if so, we want
+	// to roll these up into our own per-task capture to give the event
+	// handler full visibility into the task's execution.
+	notifyStatus := msg.Status
+	if newState.Terminal() {
+		task.RecordTerminalObservations(time.Now())
+		task.capture.Merge(nil, notifyStatus.Capture)
+		notifyStatus.Capture = task.capture
+	}
+
+	// Notify the handler about the change.
+	n.AddTaskEvent(taskNotification{
+		Handler:   task.handler,
+		Task:      task.inner,
+		NewStatus: notifyStatus,
+	})
+	return taskStatusResult{outcome: taskStatusOutcomeAccepted}, nil
 }
 
 func (s *Scheduler) handleStreamStatus(ctx context.Context, worker *workerConn, msg wire.StreamStatusMessage) error {
@@ -504,13 +534,19 @@ func (s *Scheduler) workerLoop(ctx context.Context, worker *workerConn) {
 		// fast-responding worker can't race with the post-assignment
 		// bookkeeping in finalizeAssignment. On success it also records the
 		// assignment timestamp on the task before releasing mut.
+		var sendDuration time.Duration
 		err := assignment.t.TryAssign(func() error {
 			// TODO(rfratto): allow assignment timeout to be configurable.
 			sendCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 
-			return worker.SendMessage(sendCtx, assignment.msg)
+			start := time.Now()
+			err := worker.SendMessage(sendCtx, assignment.msg)
+			sendDuration = time.Since(start)
+			return err
 		})
+		assignmentOutcome := classifyTaskAssignmentOutcome(err)
+		observeTaskAssignment(s.metrics, assignmentOutcome, sendDuration)
 
 		if err != nil && errors.Is(err, errUnassignable) {
 			// Task is already in a terminal state or has been interrupted,
@@ -518,7 +554,7 @@ func (s *Scheduler) workerLoop(ctx context.Context, worker *workerConn) {
 			continue
 		} else if err != nil {
 			// Generic error: restore the task to its original queue position.
-			s.requeueTask(assignment.t, assignment.pos)
+			s.requeueTask(assignment.t, assignment.pos, assignmentOutcome)
 
 			if isTooManyRequestsError(err) {
 				s.metrics.backoffsTotal.Inc()
@@ -623,7 +659,7 @@ func (s *Scheduler) buildAssignMessage(t *task) wire.TaskAssignMessage {
 
 // requeueTask re-inserts a task at its original position after a failed
 // assignment, undoing the scope cost adjustment.
-func (s *Scheduler) requeueTask(t *task, pos fair.Position) {
+func (s *Scheduler) requeueTask(t *task, pos fair.Position, reason string) {
 	s.assignMut.Lock()
 	defer s.assignMut.Unlock()
 
@@ -637,6 +673,7 @@ func (s *Scheduler) requeueTask(t *task, pos fair.Position) {
 
 	t.MarkRequeued()
 	s.metrics.requeueTotal.Inc()
+	s.metrics.taskAssignmentRequeueTotal.WithLabelValues(reason).Inc()
 
 	if len(s.connectedWorkers) > 0 {
 		nudgeSemaphore(s.assignSema)
@@ -763,19 +800,12 @@ func (s *Scheduler) prepareBindMessage(check *stream) *pendingMessage {
 	return nil
 }
 
-func isTooManyRequestsError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	var wireError *wire.Error
-	return errors.As(err, &wireError) && wireError.Code == http.StatusTooManyRequests
-}
-
 // workerSubscribe sends a WorkerSubscribe message to the provided worker. The
 // worker will eventually send a WorkerReady message in response.
 func (s *Scheduler) workerSubscribe(ctx context.Context, worker *workerConn) {
-	if err := worker.SendMessageAsync(ctx, wire.WorkerSubscribeMessage{}); err != nil {
+	err := worker.SendMessageAsync(ctx, wire.WorkerSubscribeMessage{})
+	s.metrics.workerSubscriptionsTotal.WithLabelValues(classifyMessageOutcome(err)).Inc()
+	if err != nil {
 		level.Warn(s.logger).Log("msg", "failed to request subscription for ready worker thread", "err", err)
 	}
 }

--- a/pkg/engine/internal/scheduler/wire/codec.go
+++ b/pkg/engine/internal/scheduler/wire/codec.go
@@ -46,41 +46,71 @@ func (br *byteReaderAdapter) ReadByte() (byte, error) {
 // EncodeTo encodes a frame as protobuf and writes it to the writer.
 // Format: [uvarint length][protobuf payload]
 func (c *protobufCodec) EncodeTo(w io.Writer, frame Frame) error {
-	// Convert wire.Frame to protobuf
-	pbFrame, err := c.frameToPbFrame(frame)
-	if err != nil {
-		panic(fmt.Errorf("failed to convert frame to protobuf: %w", err))
-	}
+	_, err := c.encodeSizedTo(w, frame)
+	return err
+}
 
-	// Marshal to bytes
-	data, err := proto.Marshal(pbFrame)
+func (c *protobufCodec) encodeSizedTo(w io.Writer, frame Frame) (int, error) {
+	data, err := c.encodePayload(frame)
 	if err != nil {
-		panic(fmt.Errorf("failed to marshal protobuf: %w", err))
+		panic(err)
 	}
 
 	// Write length prefix (uvarint)
 	length := uint64(len(data))
-	buf := make([]byte, binary.MaxVarintLen64)
-	n := binary.PutUvarint(buf, length)
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], length)
 	if _, err := w.Write(buf[:n]); err != nil {
-		return fmt.Errorf("failed to write length prefix: %w", err)
+		return 0, fmt.Errorf("failed to write length prefix: %w", err)
 	}
 
 	// Write payload
 	written, err := w.Write(data)
 	if err != nil {
-		return fmt.Errorf("failed to write payload: %w", err)
+		return 0, fmt.Errorf("failed to write payload: %w", err)
 	}
 	if written != len(data) {
-		return fmt.Errorf("incomplete write: wrote %d bytes, expected %d", written, len(data))
+		return 0, fmt.Errorf("incomplete write: wrote %d bytes, expected %d", written, len(data))
 	}
 
-	return nil
+	return n + written, nil
+}
+
+func (c *protobufCodec) encodedSize(frame Frame) (int, error) {
+	data, err := c.encodePayload(frame)
+	if err != nil {
+		return 0, err
+	}
+
+	return uvarintSize(uint64(len(data))) + len(data), nil
+}
+
+func uvarintSize(v uint64) int {
+	var lengthPrefix [binary.MaxVarintLen64]byte
+	return binary.PutUvarint(lengthPrefix[:], v)
+}
+
+func (c *protobufCodec) encodePayload(frame Frame) ([]byte, error) {
+	pbFrame, err := c.frameToPbFrame(frame)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert frame to protobuf: %w", err)
+	}
+
+	data, err := proto.Marshal(pbFrame)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal protobuf: %w", err)
+	}
+	return data, nil
 }
 
 // DecodeFrom reads and decodes a frame from the bound reader.
 // Format: [uvarint length][protobuf payload]
 func (c *protobufCodec) DecodeFrom(r io.Reader) (Frame, error) {
+	frame, _, err := c.decodeSizedFrom(r)
+	return frame, err
+}
+
+func (c *protobufCodec) decodeSizedFrom(r io.Reader) (Frame, int, error) {
 	// Read length prefix (uvarint)
 	// binary.ReadUvarint requires a ByteReader, so we wrap if needed
 	byteReader, ok := r.(io.ByteReader)
@@ -90,32 +120,33 @@ func (c *protobufCodec) DecodeFrom(r io.Reader) (Frame, error) {
 
 	length, err := binary.ReadUvarint(byteReader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read length prefix: %w", err)
+		return nil, 0, fmt.Errorf("failed to read length prefix: %w", err)
 	}
+	prefixSize := uvarintSize(length)
 
 	// Read payload
 	data := make([]byte, length)
 	n, err := io.ReadFull(r, data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read payload: %w", err)
+		return nil, 0, fmt.Errorf("failed to read payload: %w", err)
 	}
 	if uint64(n) != length {
-		return nil, fmt.Errorf("incomplete read: read %d bytes, expected %d", n, length)
+		return nil, 0, fmt.Errorf("incomplete read: read %d bytes, expected %d", n, length)
 	}
 
 	// Unmarshal protobuf
 	pbFrame := &wirepb.Frame{}
 	if err := proto.Unmarshal(data, pbFrame); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal protobuf: %w", err)
+		return nil, 0, fmt.Errorf("failed to unmarshal protobuf: %w", err)
 	}
 
 	// Convert protobuf to wire.Frame
 	frame, err := c.frameFromPbFrame(pbFrame)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert protobuf to frame: %w", err)
+		return nil, 0, fmt.Errorf("failed to convert protobuf to frame: %w", err)
 	}
 
-	return frame, nil
+	return frame, prefixSize + n, nil
 }
 
 func (c *protobufCodec) frameFromPbFrame(f *wirepb.Frame) (Frame, error) {

--- a/pkg/engine/internal/scheduler/wire/metrics.go
+++ b/pkg/engine/internal/scheduler/wire/metrics.go
@@ -51,6 +51,11 @@ const (
 )
 
 const (
+	messageClientModeSync  = "sync"
+	messageClientModeAsync = "async"
+)
+
+const (
 	queueDirectionIncoming = "incoming"
 	queueDirectionOutgoing = "outgoing"
 )
@@ -112,8 +117,8 @@ func NewMetrics() *Metrics {
 		}, []string{"role", "plane", "direction", "message_type", "outcome"}),
 		messageClientSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_scheduler_wire_message_client_seconds",
-			Help: "Time spent synchronously sending a wire message and waiting for acknowledgement.",
-		}, []string{"role", "plane", "message_type", "outcome"}),
+			Help: "Time a SendMessage or SendMessageAsync caller waits for the send API to return.",
+		}, []string{"role", "plane", "mode", "message_type", "outcome"}),
 		messageHandlerSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_scheduler_wire_message_handler_seconds",
 			Help: "Time spent handling an incoming wire message in the application handler.",
@@ -227,15 +232,18 @@ func (o sendObservation) finish(role Role, plane Plane, err error) {
 	o.m.pendingRequests.WithLabelValues(string(o.role), string(o.plane), o.messageType).Dec()
 
 	outcome := classifyClientOutcome(err)
-	o.m.messageClientSeconds.WithLabelValues(string(role), string(plane), o.messageType, outcome).Observe(time.Since(o.start).Seconds())
+	o.m.messageClientSeconds.WithLabelValues(string(role), string(plane), messageClientModeSync, o.messageType, outcome).Observe(time.Since(o.start).Seconds())
 	o.m.messagesTotal.WithLabelValues(string(role), string(plane), messageDirectionSent, o.messageType, outcome).Inc()
 }
 
 // recordAsyncSend records metrics for one asynchronous send, which completes as
 // soon as the frame is accepted into the outgoing queue.
-func (m *Metrics) recordAsyncSend(role Role, plane Plane, messageType string, err error) {
+func (m *Metrics) recordAsyncSend(role Role, plane Plane, messageType string, d time.Duration, err error) {
 	m.messagesSentTotal.WithLabelValues(messageType).Inc()
-	m.messagesTotal.WithLabelValues(string(role), string(plane), messageDirectionSent, messageType, classifyAsyncOutcome(err)).Inc()
+
+	outcome := classifyAsyncOutcome(err)
+	m.messageClientSeconds.WithLabelValues(string(role), string(plane), messageClientModeAsync, messageType, outcome).Observe(d.Seconds())
+	m.messagesTotal.WithLabelValues(string(role), string(plane), messageDirectionSent, messageType, outcome).Inc()
 }
 
 // receiveObservation records metrics across the lifetime of one incoming

--- a/pkg/engine/internal/scheduler/wire/metrics.go
+++ b/pkg/engine/internal/scheduler/wire/metrics.go
@@ -1,10 +1,58 @@
 package wire
 
 import (
+	"context"
+	"errors"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Role identifies the local peer's role for communication metrics.
+type Role string
+
+const (
+	// RoleUnknown is used when the local peer role is not known.
+	RoleUnknown Role = "unknown"
+	// RoleScheduler is used for scheduler-side peers.
+	RoleScheduler Role = "scheduler"
+	// RoleWorker is used for worker-side peers.
+	RoleWorker Role = "worker"
+)
+
+// Plane identifies the communication plane for a peer.
+type Plane string
+
+const (
+	// PlaneUnknown is used when the communication plane is not known.
+	PlaneUnknown Plane = "unknown"
+	// PlaneControl is used for scheduler/worker control traffic.
+	PlaneControl Plane = "control"
+	// PlaneData is used for stream data traffic.
+	PlaneData Plane = "data"
+)
+
+const (
+	messageOutcomeAck          = "ack"
+	messageOutcomeNack         = "nack"
+	messageOutcomeTimeout      = "timeout"
+	messageOutcomeCanceled     = "canceled"
+	messageOutcomeConnClosed   = "conn_closed"
+	messageOutcomeSendError    = "send_error"
+	messageOutcomeHandlerError = "handler_error"
+	messageOutcomeUnsupported  = "unsupported"
+	messageOutcomeAccepted     = "accepted"
+)
+
+const (
+	messageDirectionSent     = "sent"
+	messageDirectionReceived = "received"
+)
+
+const (
+	queueDirectionIncoming = "incoming"
+	queueDirectionOutgoing = "outgoing"
 )
 
 // Metrics is a set of metrics for a Peer.
@@ -15,6 +63,15 @@ type Metrics struct {
 	messagesQueued      prometheus.Gauge
 	messagesSentTotal   *prometheus.CounterVec
 	messageRTTSeconds   *prometheus.HistogramVec
+
+	messagesTotal         *prometheus.CounterVec
+	messageClientSeconds  *prometheus.HistogramVec
+	messageHandlerSeconds *prometheus.HistogramVec
+	incomingQueueSeconds  *prometheus.HistogramVec
+	outgoingQueueSeconds  *prometheus.HistogramVec
+	queueDepth            *prometheus.GaugeVec
+	pendingRequests       *prometheus.GaugeVec
+	handlerInflight       *prometheus.GaugeVec
 }
 
 func NewMetrics() *Metrics {
@@ -41,11 +98,53 @@ func NewMetrics() *Metrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"message_type"}),
+
+		messagesTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_scheduler_wire_messages_total",
+			Help: "Total number of wire messages sent or received by outcome.",
+		}, []string{"role", "plane", "direction", "message_type", "outcome"}),
+		messageClientSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_scheduler_wire_message_client_seconds",
+			Help: "Time spent synchronously sending a wire message and waiting for acknowledgement.",
+		}, []string{"role", "plane", "message_type", "outcome"}),
+		messageHandlerSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_scheduler_wire_message_handler_seconds",
+			Help: "Time spent handling an incoming wire message in the application handler.",
+		}, []string{"role", "plane", "message_type", "outcome"}),
+		incomingQueueSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_scheduler_wire_incoming_queue_seconds",
+			Help: "Time an incoming wire message spent waiting in the peer queue before handling.",
+		}, []string{"role", "plane", "message_type"}),
+		outgoingQueueSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_scheduler_wire_outgoing_queue_seconds",
+			Help: "Time an outgoing wire frame spent waiting in the peer queue before sending.",
+		}, []string{"role", "plane", "frame_kind", "message_type"}),
+		queueDepth: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "loki_engine_scheduler_wire_queue_depth",
+			Help: "Current number of frames queued by direction.",
+		}, []string{"role", "plane", "direction"}),
+		pendingRequests: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "loki_engine_scheduler_wire_pending_requests",
+			Help: "Current number of synchronous requests waiting for acknowledgement.",
+		}, []string{"role", "plane", "message_type"}),
+		handlerInflight: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "loki_engine_scheduler_wire_handler_inflight",
+			Help: "Current number of incoming message handlers running.",
+		}, []string{"role", "plane", "message_type"}),
 	}
 }
 
 func (m *Metrics) Register(reg prometheus.Registerer) error { return reg.Register(m.reg) }
 func (m *Metrics) Unregister(reg prometheus.Registerer)     { reg.Unregister(m.reg) }
+
+// newNativeHistogramVec creates a HistogramVec that uses native histogram
+// buckets, registered to reg.
+func newNativeHistogramVec(reg prometheus.Registerer, opts prometheus.HistogramOpts, labels []string) *prometheus.HistogramVec {
+	opts.NativeHistogramBucketFactor = 1.1
+	opts.NativeHistogramMaxBucketNumber = 100
+	opts.NativeHistogramMinResetDuration = time.Hour
+	return promauto.With(reg).NewHistogramVec(opts, labels)
+}
 
 func (m *Metrics) incFrameReceived(frame Frame) {
 	m.framesReceivedTotal.WithLabelValues(frame.FrameKind().String(), frameMessageType(frame)).Inc()
@@ -68,10 +167,140 @@ func (m *Metrics) decMessageQueued() {
 	m.messagesQueued.Dec()
 }
 
-func (m *Metrics) incMessageSent(messageType string) {
-	m.messagesSentTotal.WithLabelValues(messageType).Inc()
+func (m *Metrics) incQueueDepth(role Role, plane Plane, direction string) {
+	m.queueDepth.WithLabelValues(string(role), string(plane), direction).Inc()
 }
 
-func (m *Metrics) newMessageRTTTimer(messageType string) *prometheus.Timer {
-	return prometheus.NewTimer(m.messageRTTSeconds.WithLabelValues(messageType))
+func (m *Metrics) decQueueDepth(role Role, plane Plane, direction string) {
+	m.queueDepth.WithLabelValues(string(role), string(plane), direction).Dec()
+}
+
+func (m *Metrics) observeIncomingQueue(role Role, plane Plane, messageType string, d time.Duration) {
+	m.incomingQueueSeconds.WithLabelValues(string(role), string(plane), messageType).Observe(d.Seconds())
+}
+
+func (m *Metrics) observeOutgoingQueue(role Role, plane Plane, frameKind string, messageType string, d time.Duration) {
+	m.outgoingQueueSeconds.WithLabelValues(string(role), string(plane), frameKind, messageType).Observe(d.Seconds())
+}
+
+// sendObservation records metrics across the lifetime of one synchronous send.
+// The role and plane captured at the start balance the pending-request gauge;
+// the outcome metrics use the labels passed to finish, which may differ if the
+// plane was discovered mid-call.
+type sendObservation struct {
+	m           *Metrics
+	role        Role
+	plane       Plane
+	messageType string
+	start       time.Time
+	timer       *prometheus.Timer
+}
+
+// beginSend starts recording a synchronous send. finish must be called once.
+func (m *Metrics) beginSend(role Role, plane Plane, messageType string) sendObservation {
+	m.messagesSentTotal.WithLabelValues(messageType).Inc()
+	m.pendingRequests.WithLabelValues(string(role), string(plane), messageType).Inc()
+	return sendObservation{
+		m:           m,
+		role:        role,
+		plane:       plane,
+		messageType: messageType,
+		start:       time.Now(),
+		timer:       prometheus.NewTimer(m.messageRTTSeconds.WithLabelValues(messageType)),
+	}
+}
+
+func (o sendObservation) finish(role Role, plane Plane, err error) {
+	o.timer.ObserveDuration()
+	o.m.pendingRequests.WithLabelValues(string(o.role), string(o.plane), o.messageType).Dec()
+
+	outcome := classifyClientOutcome(err)
+	o.m.messageClientSeconds.WithLabelValues(string(role), string(plane), o.messageType, outcome).Observe(time.Since(o.start).Seconds())
+	o.m.messagesTotal.WithLabelValues(string(role), string(plane), messageDirectionSent, o.messageType, outcome).Inc()
+}
+
+// recordAsyncSend records metrics for one asynchronous send, which completes as
+// soon as the frame is accepted into the outgoing queue.
+func (m *Metrics) recordAsyncSend(role Role, plane Plane, messageType string, err error) {
+	m.messagesSentTotal.WithLabelValues(messageType).Inc()
+	m.messagesTotal.WithLabelValues(string(role), string(plane), messageDirectionSent, messageType, classifyAsyncOutcome(err)).Inc()
+}
+
+// receiveObservation records metrics across the lifetime of one incoming
+// message handler. The labels captured at the start balance the
+// handler-inflight gauge; finish uses the labels passed to it for the outcome
+// metrics.
+type receiveObservation struct {
+	m           *Metrics
+	role        Role
+	plane       Plane
+	messageType string
+	start       time.Time
+}
+
+// beginReceive starts recording an incoming handler. finish must be called once.
+func (m *Metrics) beginReceive(role Role, plane Plane, messageType string) receiveObservation {
+	m.handlerInflight.WithLabelValues(string(role), string(plane), messageType).Inc()
+	return receiveObservation{
+		m:           m,
+		role:        role,
+		plane:       plane,
+		messageType: messageType,
+		start:       time.Now(),
+	}
+}
+
+func (o receiveObservation) finish(role Role, plane Plane, err error) {
+	o.m.handlerInflight.WithLabelValues(string(o.role), string(o.plane), o.messageType).Dec()
+
+	outcome := classifyHandlerOutcome(err)
+	o.m.messageHandlerSeconds.WithLabelValues(string(role), string(plane), o.messageType, outcome).Observe(time.Since(o.start).Seconds())
+	o.m.messagesTotal.WithLabelValues(string(role), string(plane), messageDirectionReceived, o.messageType, outcome).Inc()
+}
+
+func classifyClientOutcome(err error) string {
+	switch {
+	case err == nil:
+		return messageOutcomeAck
+	case errors.Is(err, context.DeadlineExceeded):
+		return messageOutcomeTimeout
+	case errors.Is(err, context.Canceled):
+		return messageOutcomeCanceled
+	case errors.Is(err, ErrConnClosed):
+		return messageOutcomeConnClosed
+	}
+
+	var wireError *Error
+	if errors.As(err, &wireError) {
+		return messageOutcomeNack
+	}
+
+	return messageOutcomeSendError
+}
+
+func classifyAsyncOutcome(err error) string {
+	switch {
+	case err == nil:
+		return messageOutcomeAccepted
+	case errors.Is(err, context.DeadlineExceeded):
+		return messageOutcomeTimeout
+	case errors.Is(err, context.Canceled):
+		return messageOutcomeCanceled
+	case errors.Is(err, ErrConnClosed):
+		return messageOutcomeConnClosed
+	default:
+		return messageOutcomeSendError
+	}
+}
+
+func classifyHandlerOutcome(err error) string {
+	if err == nil {
+		return messageOutcomeAck
+	}
+
+	var wireError *Error
+	if errors.As(err, &wireError) && wireError.Code == 501 {
+		return messageOutcomeUnsupported
+	}
+	return messageOutcomeHandlerError
 }

--- a/pkg/engine/internal/scheduler/wire/metrics.go
+++ b/pkg/engine/internal/scheduler/wire/metrics.go
@@ -60,6 +60,8 @@ type Metrics struct {
 	reg *prometheus.Registry
 
 	framesReceivedTotal *prometheus.CounterVec
+	framesTotal         *prometheus.CounterVec
+	frameBytesTotal     *prometheus.CounterVec
 	messagesQueued      prometheus.Gauge
 	messagesSentTotal   *prometheus.CounterVec
 	messageRTTSeconds   *prometheus.HistogramVec
@@ -83,6 +85,14 @@ func NewMetrics() *Metrics {
 			Name: "loki_engine_scheduler_wire_frames_received_total",
 			Help: "Total number of frames received by the wire",
 		}, []string{"type", "message_type"}),
+		framesTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_scheduler_wire_frames_total",
+			Help: "Total number of encoded wire frames sent or received by role, plane, direction, frame kind, and message type.",
+		}, []string{"role", "plane", "direction", "frame_kind", "message_type"}),
+		frameBytesTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_scheduler_wire_frame_bytes_total",
+			Help: "Total encoded bytes in wire frames sent or received by role, plane, direction, frame kind, and message type.",
+		}, []string{"role", "plane", "direction", "frame_kind", "message_type"}),
 		messagesQueued: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "loki_engine_scheduler_wire_messages_queued",
 			Help: "Number of messages queued by the wire",
@@ -145,6 +155,11 @@ func newNativeHistogramVec(reg prometheus.Registerer, opts prometheus.HistogramO
 
 func (m *Metrics) incFrameReceived(frame Frame) {
 	m.framesReceivedTotal.WithLabelValues(frame.FrameKind().String(), frameMessageType(frame)).Inc()
+}
+
+func (m *Metrics) recordFrame(role Role, plane Plane, direction string, frame Frame, messageType string, size int) {
+	m.framesTotal.WithLabelValues(string(role), string(plane), direction, frame.FrameKind().String(), messageType).Inc()
+	m.frameBytesTotal.WithLabelValues(string(role), string(plane), direction, frame.FrameKind().String(), messageType).Add(float64(size))
 }
 
 // frameMessageType returns the application [MessageKind] carried by frame, or

--- a/pkg/engine/internal/scheduler/wire/metrics.go
+++ b/pkg/engine/internal/scheduler/wire/metrics.go
@@ -91,12 +91,9 @@ func NewMetrics() *Metrics {
 			Name: "loki_engine_scheduler_wire_messages_sent_total",
 			Help: "Number of messages sent by a peer",
 		}, []string{"message_type"}),
-		messageRTTSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-			Name:                            "loki_engine_scheduler_wire_message_rtt_seconds",
-			Help:                            "Round-trip time to synchronously send a message to another peer",
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
+		messageRTTSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_scheduler_wire_message_rtt_seconds",
+			Help: "Round-trip time to synchronously send a message to another peer",
 		}, []string{"message_type"}),
 
 		messagesTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{

--- a/pkg/engine/internal/scheduler/wire/metrics_test.go
+++ b/pkg/engine/internal/scheduler/wire/metrics_test.go
@@ -1,0 +1,130 @@
+package wire
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestObservationGaugeBalance pins the subtlest property of the send/receive
+// observations: the pending-request and handler-inflight gauges must net to
+// zero across begin/finish even when the plane is discovered mid-call, because
+// the gauge Dec must use the labels captured at begin, not the final labels.
+func TestObservationGaugeBalance(t *testing.T) {
+	const messageType = "TestMessage"
+
+	t.Run("send", func(t *testing.T) {
+		m := NewMetrics()
+		obs := m.beginSend(RoleScheduler, PlaneUnknown, messageType)
+		require.Equal(t, 1.0, testutil.ToFloat64(m.pendingRequests.WithLabelValues(string(RoleScheduler), string(PlaneUnknown), messageType)))
+
+		// finish with a different plane, as if the connection was classified
+		// after the send began.
+		obs.finish(RoleScheduler, PlaneControl, nil)
+		require.Equal(t, 0.0, testutil.ToFloat64(m.pendingRequests.WithLabelValues(string(RoleScheduler), string(PlaneUnknown), messageType)), "gauge must be decremented on the begin labels")
+		require.Equal(t, 0.0, testutil.ToFloat64(m.pendingRequests.WithLabelValues(string(RoleScheduler), string(PlaneControl), messageType)), "gauge must not leak onto the finish labels")
+	})
+
+	t.Run("receive", func(t *testing.T) {
+		m := NewMetrics()
+		obs := m.beginReceive(RoleScheduler, PlaneUnknown, messageType)
+		require.Equal(t, 1.0, testutil.ToFloat64(m.handlerInflight.WithLabelValues(string(RoleScheduler), string(PlaneUnknown), messageType)))
+
+		obs.finish(RoleScheduler, PlaneControl, nil)
+		require.Equal(t, 0.0, testutil.ToFloat64(m.handlerInflight.WithLabelValues(string(RoleScheduler), string(PlaneUnknown), messageType)), "gauge must be decremented on the begin labels")
+		require.Equal(t, 0.0, testutil.ToFloat64(m.handlerInflight.WithLabelValues(string(RoleScheduler), string(PlaneControl), messageType)), "gauge must not leak onto the finish labels")
+	})
+}
+
+func TestFrameMessageType(t *testing.T) {
+	tests := []struct {
+		name  string
+		frame Frame
+		want  string
+	}{
+		{name: "message frame", frame: MessageFrame{Message: TaskAssignMessage{}}, want: "TaskAssign"},
+		{name: "message frame without message", frame: MessageFrame{}, want: "none"},
+		{name: "ack frame", frame: AckFrame{}, want: "none"},
+		{name: "nack frame", frame: NackFrame{}, want: "none"},
+		{name: "discard frame", frame: DiscardFrame{}, want: "none"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, frameMessageType(tt.frame))
+		})
+	}
+}
+
+func TestProcessMessagePreservesMessageTypeOnAckFrames(t *testing.T) {
+	tests := []struct {
+		name       string
+		handlerErr error
+		wantKind   FrameKind
+	}{
+		{name: "ack", wantKind: FrameKindAck},
+		{name: "nack", handlerErr: errors.New("failed"), wantKind: FrameKindNack},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Peer{
+				Metrics: NewMetrics(),
+				Role:    RoleScheduler,
+				Buffer:  1,
+				Handler: func(context.Context, *Peer, Message) error { return tt.handlerErr },
+			}
+			p.lazyInit()
+			p.SetPlane(PlaneControl)
+
+			p.processMessage(t.Context(), 1, TaskAssignMessage{})
+
+			queued := <-p.outgoing
+			require.Equal(t, tt.wantKind, queued.frame.FrameKind())
+			require.Equal(t, "TaskAssign", queued.messageType)
+		})
+	}
+}
+
+func TestClassifyClientOutcome(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "ack", err: nil, want: messageOutcomeAck},
+		{name: "timeout", err: context.DeadlineExceeded, want: messageOutcomeTimeout},
+		{name: "canceled", err: context.Canceled, want: messageOutcomeCanceled},
+		{name: "connection closed", err: ErrConnClosed, want: messageOutcomeConnClosed},
+		{name: "nack", err: Errorf(http.StatusTooManyRequests, "busy"), want: messageOutcomeNack},
+		{name: "send error", err: errors.New("write failed"), want: messageOutcomeSendError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, classifyClientOutcome(tt.err))
+		})
+	}
+}
+
+func TestClassifyHandlerOutcome(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "ack", err: nil, want: messageOutcomeAck},
+		{name: "unsupported", err: Errorf(http.StatusNotImplemented, "unsupported"), want: messageOutcomeUnsupported},
+		{name: "handler error", err: errors.New("failed"), want: messageOutcomeHandlerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, classifyHandlerOutcome(tt.err))
+		})
+	}
+}

--- a/pkg/engine/internal/scheduler/wire/metrics_test.go
+++ b/pkg/engine/internal/scheduler/wire/metrics_test.go
@@ -184,6 +184,80 @@ func TestRecordFrameTraffic(t *testing.T) {
 	)))
 }
 
+func TestRecvMessagesInfersPlaneBeforeRecordingFrameTraffic(t *testing.T) {
+	tests := []struct {
+		name    string
+		message Message
+		want    Plane
+	}{
+		{name: "stream data is data plane", message: StreamDataMessage{}, want: PlaneData},
+		{name: "worker hello is control plane", message: WorkerHelloMessage{}, want: PlaneControl},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewMetrics()
+			frame := MessageFrame{ID: 42, Message: tt.message}
+			size := 123
+
+			conn := &scriptedRecvConn{frame: frame, size: size}
+			p := &Peer{
+				Metrics: m,
+				Conn:    conn,
+				Role:    RoleScheduler,
+				Buffer:  1,
+			}
+			p.lazyInit()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- p.recvMessages(ctx) }()
+
+			select {
+			case queued := <-p.incoming:
+				require.Equal(t, tt.want, queued.plane)
+			case <-time.After(time.Second):
+				t.Fatal("timeout waiting for queued message")
+			}
+
+			cancel()
+			require.NoError(t, <-done)
+
+			messageType := tt.message.Kind().String()
+			require.Equal(t, 1.0, testutil.ToFloat64(m.framesTotal.WithLabelValues(
+				string(RoleScheduler),
+				string(tt.want),
+				messageDirectionReceived,
+				FrameKindMessage.String(),
+				messageType,
+			)))
+			require.Equal(t, float64(size), testutil.ToFloat64(m.frameBytesTotal.WithLabelValues(
+				string(RoleScheduler),
+				string(tt.want),
+				messageDirectionReceived,
+				FrameKindMessage.String(),
+				messageType,
+			)))
+			require.Equal(t, 0.0, testutil.ToFloat64(m.framesTotal.WithLabelValues(
+				string(RoleScheduler),
+				string(PlaneUnknown),
+				messageDirectionReceived,
+				FrameKindMessage.String(),
+				messageType,
+			)))
+		})
+	}
+}
+
+func TestInferPlaneFromMessageDoesNotOverwriteKnownPlane(t *testing.T) {
+	p := &Peer{}
+	p.SetPlane(PlaneControl)
+	p.inferPlaneFromMessage(StreamDataMessage{})
+
+	_, plane := p.labels()
+	require.Equal(t, PlaneControl, plane)
+}
+
 func TestRecvMessagesRecordsAckFrameWithRequestMessageType(t *testing.T) {
 	m := NewMetrics()
 	ackFrame := AckFrame{ID: 42}

--- a/pkg/engine/internal/scheduler/wire/metrics_test.go
+++ b/pkg/engine/internal/scheduler/wire/metrics_test.go
@@ -3,12 +3,43 @@ package wire
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
+
+type scriptedRecvConn struct {
+	frame Frame
+	size  int
+	sent  bool
+}
+
+func (c *scriptedRecvConn) Send(context.Context, Frame) error { return nil }
+
+func (c *scriptedRecvConn) Recv(ctx context.Context) (Frame, error) {
+	frame, _, err := c.recvWithSize(ctx)
+	return frame, err
+}
+
+func (c *scriptedRecvConn) recvWithSize(ctx context.Context) (Frame, int, error) {
+	if !c.sent {
+		c.sent = true
+		return c.frame, c.size, nil
+	}
+
+	<-ctx.Done()
+	return nil, 0, ctx.Err()
+}
+
+func (c *scriptedRecvConn) Close() error { return nil }
+
+func (c *scriptedRecvConn) LocalAddr() net.Addr { return nil }
+
+func (c *scriptedRecvConn) RemoteAddr() net.Addr { return nil }
 
 // TestObservationGaugeBalance pins the subtlest property of the send/receive
 // observations: the pending-request and handler-inflight gauges must net to
@@ -58,6 +89,82 @@ func TestFrameMessageType(t *testing.T) {
 			require.Equal(t, tt.want, frameMessageType(tt.frame))
 		})
 	}
+}
+
+func TestRecordFrameTraffic(t *testing.T) {
+	m := NewMetrics()
+	frame := MessageFrame{ID: 42, Message: WorkerReadyMessage{}}
+	size, err := DefaultFrameCodec.encodedSize(frame)
+	require.NoError(t, err)
+
+	m.recordFrame(RoleScheduler, PlaneControl, messageDirectionSent, frame, "WorkerReady", size)
+
+	require.Equal(t, 1.0, testutil.ToFloat64(m.framesTotal.WithLabelValues(
+		string(RoleScheduler),
+		string(PlaneControl),
+		messageDirectionSent,
+		FrameKindMessage.String(),
+		"WorkerReady",
+	)))
+	require.Equal(t, float64(size), testutil.ToFloat64(m.frameBytesTotal.WithLabelValues(
+		string(RoleScheduler),
+		string(PlaneControl),
+		messageDirectionSent,
+		FrameKindMessage.String(),
+		"WorkerReady",
+	)))
+}
+
+func TestRecvMessagesRecordsAckFrameWithRequestMessageType(t *testing.T) {
+	m := NewMetrics()
+	ackFrame := AckFrame{ID: 42}
+	size, err := DefaultFrameCodec.encodedSize(ackFrame)
+	require.NoError(t, err)
+
+	conn := &scriptedRecvConn{frame: ackFrame, size: size}
+	p := &Peer{
+		Metrics: m,
+		Conn:    conn,
+		Role:    RoleScheduler,
+	}
+	p.lazyInit()
+	p.SetPlane(PlaneControl)
+	p.sentRequests.Store(uint64(42), &request{
+		messageType: "TaskAssign",
+		result:      make(chan error, 1),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- p.recvMessages(ctx) }()
+
+	val, found := p.sentRequests.Load(uint64(42))
+	require.True(t, found)
+	req := val.(*request)
+	select {
+	case err := <-req.result:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for ack")
+	}
+	cancel()
+	require.NoError(t, <-done)
+
+	require.Equal(t, 1.0, testutil.ToFloat64(m.framesTotal.WithLabelValues(
+		string(RoleScheduler),
+		string(PlaneControl),
+		messageDirectionReceived,
+		FrameKindAck.String(),
+		"TaskAssign",
+	)))
+	require.Equal(t, float64(size), testutil.ToFloat64(m.frameBytesTotal.WithLabelValues(
+		string(RoleScheduler),
+		string(PlaneControl),
+		messageDirectionReceived,
+		FrameKindAck.String(),
+		"TaskAssign",
+	)))
 }
 
 func TestProcessMessagePreservesMessageTypeOnAckFrames(t *testing.T) {

--- a/pkg/engine/internal/scheduler/wire/metrics_test.go
+++ b/pkg/engine/internal/scheduler/wire/metrics_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,6 +59,13 @@ func TestObservationGaugeBalance(t *testing.T) {
 		obs.finish(RoleScheduler, PlaneControl, nil)
 		require.Equal(t, 0.0, testutil.ToFloat64(m.pendingRequests.WithLabelValues(string(RoleScheduler), string(PlaneUnknown), messageType)), "gauge must be decremented on the begin labels")
 		require.Equal(t, 0.0, testutil.ToFloat64(m.pendingRequests.WithLabelValues(string(RoleScheduler), string(PlaneControl), messageType)), "gauge must not leak onto the finish labels")
+		require.Equal(t, uint64(1), histogramSampleCount(t, m, "loki_engine_scheduler_wire_message_client_seconds", map[string]string{
+			"role":         string(RoleScheduler),
+			"plane":        string(PlaneControl),
+			"mode":         messageClientModeSync,
+			"message_type": messageType,
+			"outcome":      messageOutcomeAck,
+		}))
 	})
 
 	t.Run("receive", func(t *testing.T) {
@@ -69,6 +77,67 @@ func TestObservationGaugeBalance(t *testing.T) {
 		require.Equal(t, 0.0, testutil.ToFloat64(m.handlerInflight.WithLabelValues(string(RoleScheduler), string(PlaneUnknown), messageType)), "gauge must be decremented on the begin labels")
 		require.Equal(t, 0.0, testutil.ToFloat64(m.handlerInflight.WithLabelValues(string(RoleScheduler), string(PlaneControl), messageType)), "gauge must not leak onto the finish labels")
 	})
+}
+
+func TestRecordAsyncSendObservesClientWait(t *testing.T) {
+	m := NewMetrics()
+
+	m.recordAsyncSend(RoleWorker, PlaneControl, "WorkerReady", time.Second, nil)
+
+	metric := histogramMetric(t, m, "loki_engine_scheduler_wire_message_client_seconds", map[string]string{
+		"role":         string(RoleWorker),
+		"plane":        string(PlaneControl),
+		"mode":         messageClientModeAsync,
+		"message_type": "WorkerReady",
+		"outcome":      messageOutcomeAccepted,
+	})
+	require.Equal(t, uint64(1), metric.GetHistogram().GetSampleCount())
+	require.Equal(t, 1.0, metric.GetHistogram().GetSampleSum())
+	require.Equal(t, 1.0, testutil.ToFloat64(m.messagesTotal.WithLabelValues(
+		string(RoleWorker),
+		string(PlaneControl),
+		messageDirectionSent,
+		"WorkerReady",
+		messageOutcomeAccepted,
+	)))
+}
+
+func histogramSampleCount(t *testing.T, m *Metrics, name string, labels map[string]string) uint64 {
+	t.Helper()
+
+	return histogramMetric(t, m, name, labels).GetHistogram().GetSampleCount()
+}
+
+func histogramMetric(t *testing.T, m *Metrics, name string, labels map[string]string) *dto.Metric {
+	t.Helper()
+
+	families, err := m.reg.Gather()
+	require.NoError(t, err)
+
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if metricHasLabels(metric, labels) {
+				return metric
+			}
+		}
+	}
+	t.Fatalf("metric %s with labels %v not found", name, labels)
+	return nil
+}
+
+func metricHasLabels(metric *dto.Metric, labels map[string]string) bool {
+	if len(metric.GetLabel()) != len(labels) {
+		return false
+	}
+	for _, label := range metric.GetLabel() {
+		if labels[label.GetName()] != label.GetValue() {
+			return false
+		}
+	}
+	return true
 }
 
 func TestFrameMessageType(t *testing.T) {

--- a/pkg/engine/internal/scheduler/wire/peer.go
+++ b/pkg/engine/internal/scheduler/wire/peer.go
@@ -115,11 +115,38 @@ type queuedFrame struct {
 	enqueuedAt  time.Time
 }
 
+type sizedSender interface {
+	sendWithSize(context.Context, Frame) (int, error)
+}
+
+type sizedReceiver interface {
+	recvWithSize(context.Context) (Frame, int, error)
+}
+
+func (p *Peer) sendFrame(ctx context.Context, frame Frame) (int, bool, error) {
+	if conn, ok := p.Conn.(sizedSender); ok {
+		size, err := conn.sendWithSize(ctx, frame)
+		return size, true, err
+	}
+
+	return 0, false, p.Conn.Send(ctx, frame)
+}
+
+func (p *Peer) recvFrame(ctx context.Context) (Frame, int, bool, error) {
+	if conn, ok := p.Conn.(sizedReceiver); ok {
+		frame, size, err := conn.recvWithSize(ctx)
+		return frame, size, true, err
+	}
+
+	frame, err := p.Conn.Recv(ctx)
+	return frame, 0, false, err
+}
+
 func (p *Peer) recvMessages(ctx context.Context) error {
 	defer close(p.done)
 
 	for {
-		frame, err := p.Conn.Recv(ctx)
+		frame, frameSize, hasFrameSize, err := p.recvFrame(ctx)
 		if err != nil {
 			if ctx.Err() != nil {
 				// Context got canceled; shut down
@@ -129,11 +156,16 @@ func (p *Peer) recvMessages(ctx context.Context) error {
 		}
 
 		p.Metrics.incFrameReceived(frame)
+		role, plane := p.labels()
 
 		switch frame := frame.(type) {
 		case MessageFrame:
+			messageType := frameMessageType(frame)
+			if hasFrameSize {
+				p.Metrics.recordFrame(role, plane, messageDirectionReceived, frame, messageType, frameSize)
+			}
+
 			// Queue the message for processing.
-			role, plane := p.labels()
 			p.Metrics.incMessageQueued()
 			p.Metrics.incQueueDepth(role, plane, queueDirectionIncoming)
 			select {
@@ -147,11 +179,18 @@ func (p *Peer) recvMessages(ctx context.Context) error {
 		case AckFrame:
 			// If there's still a listener for this request, inform them of
 			// the success.
-			val, found := p.sentRequests.Load(frame.ID)
-			if !found {
+			var req *request
+			messageType := "none"
+			if val, found := p.sentRequests.Load(frame.ID); found {
+				req = val.(*request)
+				messageType = req.messageType
+			}
+			if hasFrameSize {
+				p.Metrics.recordFrame(role, plane, messageDirectionReceived, frame, messageType, frameSize)
+			}
+			if req == nil {
 				continue
 			}
-			req := val.(*request)
 
 			select {
 			case req.result <- nil:
@@ -162,11 +201,18 @@ func (p *Peer) recvMessages(ctx context.Context) error {
 		case NackFrame:
 			// If there's still a listener for this request, inform them of
 			// the error.
-			val, found := p.sentRequests.Load(frame.ID)
-			if !found {
+			var req *request
+			messageType := "none"
+			if val, found := p.sentRequests.Load(frame.ID); found {
+				req = val.(*request)
+				messageType = req.messageType
+			}
+			if hasFrameSize {
+				p.Metrics.recordFrame(role, plane, messageDirectionReceived, frame, messageType, frameSize)
+			}
+			if req == nil {
 				continue
 			}
-			req := val.(*request)
 
 			select {
 			case req.result <- frame.Error:
@@ -175,6 +221,9 @@ func (p *Peer) recvMessages(ctx context.Context) error {
 			}
 
 		case DiscardFrame:
+			if hasFrameSize {
+				p.Metrics.recordFrame(role, plane, messageDirectionReceived, frame, frameMessageType(frame), frameSize)
+			}
 			// TODO(rfratto): cancel handleMessage goroutine
 
 		default:
@@ -214,9 +263,16 @@ func (p *Peer) handleOutgoing(ctx context.Context) error {
 		case queued := <-p.outgoing:
 			p.Metrics.decQueueDepth(queued.role, queued.plane, queueDirectionOutgoing)
 			p.Metrics.observeOutgoingQueue(queued.role, queued.plane, queued.frame.FrameKind().String(), queued.messageType, time.Since(queued.enqueuedAt))
-			if err := p.Conn.Send(ctx, queued.frame); err != nil && ctx.Err() == nil {
-				level.Warn(p.Logger).Log("msg", "failed to send message", "error", err)
-				p.notifyError(queued.frame, err)
+			frameSize, hasFrameSize, err := p.sendFrame(ctx, queued.frame)
+			if err != nil {
+				if ctx.Err() == nil {
+					level.Warn(p.Logger).Log("msg", "failed to send message", "error", err)
+					p.notifyError(queued.frame, err)
+				}
+				continue
+			}
+			if hasFrameSize {
+				p.Metrics.recordFrame(queued.role, queued.plane, messageDirectionSent, queued.frame, queued.messageType, frameSize)
 			}
 		}
 	}
@@ -315,7 +371,8 @@ func convertError(err error) *Error {
 }
 
 type request struct {
-	result chan error
+	messageType string
+	result      chan error
 }
 
 // SendMessage sends a message to the remote peer. SendMessage blocks until the
@@ -328,14 +385,16 @@ func (p *Peer) SendMessage(ctx context.Context, message Message) (err error) {
 	p.lazyInit()
 
 	reqID := p.requestID.Inc()
+	messageType := message.Kind().String()
 	req := &request{
-		result: make(chan error, 1),
+		messageType: messageType,
+		result:      make(chan error, 1),
 	}
 	p.sentRequests.Store(reqID, req)
 	defer p.sentRequests.Delete(reqID)
 
 	role, plane := p.labels()
-	obs := p.Metrics.beginSend(role, plane, message.Kind().String())
+	obs := p.Metrics.beginSend(role, plane, messageType)
 	defer func() {
 		// Re-read labels: the first message on a connection can classify an
 		// initially unknown peer as control or data plane.

--- a/pkg/engine/internal/scheduler/wire/peer.go
+++ b/pkg/engine/internal/scheduler/wire/peer.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -25,10 +26,19 @@ type Peer struct {
 	Handler Handler // Handler for incoming messages from the remote peer.
 	Buffer  int     // Buffer size for incoming and outgoing messages.
 
-	done     chan struct{}     // Closed when the peer connection is closed.
-	incoming chan MessageFrame // Buffered frame of incoming messages.
-	outgoing chan Frame        // Buffered frame of outgoing frames.
+	// Role is the role of the local peer for communication metrics. It is set at
+	// construction, immutable once Serve runs, and defaults to RoleUnknown.
+	Role Role
+
+	done     chan struct{}      // Closed when the peer connection is closed.
+	incoming chan queuedMessage // Buffered frame of incoming messages.
+	outgoing chan queuedFrame   // Buffered frame of outgoing frames.
 	initOnce sync.Once
+
+	// plane is the communication plane for metrics. Unlike Role, a peer's plane
+	// is often not known until its first message arrives, so it is discovered at
+	// runtime through SetPlane rather than set at construction.
+	plane atomic.String
 
 	requestID    atomic.Uint64
 	sentRequests sync.Map // map[uint64]*request
@@ -65,9 +75,44 @@ func (p *Peer) Serve(ctx context.Context) error {
 func (p *Peer) lazyInit() {
 	p.initOnce.Do(func() {
 		p.done = make(chan struct{})
-		p.incoming = make(chan MessageFrame, p.Buffer)
-		p.outgoing = make(chan Frame, p.Buffer)
+		p.incoming = make(chan queuedMessage, p.Buffer)
+		p.outgoing = make(chan queuedFrame, p.Buffer)
 	})
+}
+
+// SetPlane updates the communication plane label used for future peer metrics.
+// A peer's plane is often not known until its first message arrives.
+func (p *Peer) SetPlane(plane Plane) {
+	p.plane.Store(string(plane))
+}
+
+// labels returns the role and plane labels for the peer's metrics. Role is
+// immutable; plane may have been updated by SetPlane.
+func (p *Peer) labels() (Role, Plane) {
+	role := p.Role
+	if role == "" {
+		role = RoleUnknown
+	}
+	plane := Plane(p.plane.Load())
+	if plane == "" {
+		plane = PlaneUnknown
+	}
+	return role, plane
+}
+
+type queuedMessage struct {
+	frame      MessageFrame
+	role       Role
+	plane      Plane
+	enqueuedAt time.Time
+}
+
+type queuedFrame struct {
+	frame       Frame
+	role        Role
+	plane       Plane
+	messageType string
+	enqueuedAt  time.Time
 }
 
 func (p *Peer) recvMessages(ctx context.Context) error {
@@ -88,10 +133,14 @@ func (p *Peer) recvMessages(ctx context.Context) error {
 		switch frame := frame.(type) {
 		case MessageFrame:
 			// Queue the message for processing.
+			role, plane := p.labels()
+			p.Metrics.incMessageQueued()
+			p.Metrics.incQueueDepth(role, plane, queueDirectionIncoming)
 			select {
-			case p.incoming <- frame:
-				p.Metrics.incMessageQueued()
+			case p.incoming <- queuedMessage{frame: frame, role: role, plane: plane, enqueuedAt: time.Now()}:
 			case <-ctx.Done():
+				p.Metrics.decMessageQueued()
+				p.Metrics.decQueueDepth(role, plane, queueDirectionIncoming)
 				return nil
 			}
 
@@ -135,31 +184,63 @@ func (p *Peer) recvMessages(ctx context.Context) error {
 }
 
 func (p *Peer) handleIncoming(ctx context.Context) error {
+	defer p.drainIncomingQueue()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-p.done:
 			return nil // Closed connection.
-		case frame := <-p.incoming:
+		case queued := <-p.incoming:
+			role, plane := p.labels()
 			p.Metrics.decMessageQueued()
-			p.processMessage(ctx, frame.ID, frame.Message)
+			p.Metrics.decQueueDepth(queued.role, queued.plane, queueDirectionIncoming)
+			p.Metrics.observeIncomingQueue(role, plane, queued.frame.Message.Kind().String(), time.Since(queued.enqueuedAt))
+			p.processMessage(ctx, queued.frame.ID, queued.frame.Message)
 		}
 	}
 }
 
 func (p *Peer) handleOutgoing(ctx context.Context) error {
+	defer p.drainOutgoingQueue()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-p.done:
 			return nil // Closed connection.
-		case frame := <-p.outgoing:
-			if err := p.Conn.Send(ctx, frame); err != nil && ctx.Err() == nil {
+		case queued := <-p.outgoing:
+			p.Metrics.decQueueDepth(queued.role, queued.plane, queueDirectionOutgoing)
+			p.Metrics.observeOutgoingQueue(queued.role, queued.plane, queued.frame.FrameKind().String(), queued.messageType, time.Since(queued.enqueuedAt))
+			if err := p.Conn.Send(ctx, queued.frame); err != nil && ctx.Err() == nil {
 				level.Warn(p.Logger).Log("msg", "failed to send message", "error", err)
-				p.notifyError(frame, err)
+				p.notifyError(queued.frame, err)
 			}
+		}
+	}
+}
+
+func (p *Peer) drainIncomingQueue() {
+	for {
+		select {
+		case queued := <-p.incoming:
+			p.Metrics.decMessageQueued()
+			p.Metrics.decQueueDepth(queued.role, queued.plane, queueDirectionIncoming)
+		default:
+			return
+		}
+	}
+}
+
+func (p *Peer) drainOutgoingQueue() {
+	for {
+		select {
+		case queued := <-p.outgoing:
+			p.Metrics.decQueueDepth(queued.role, queued.plane, queueDirectionOutgoing)
+		default:
+			return
 		}
 	}
 }
@@ -190,19 +271,35 @@ func (p *Peer) notifyError(frame Frame, err error) {
 
 // processMessage handles a message received from the peer.
 func (p *Peer) processMessage(ctx context.Context, id uint64, message Message) {
-	if p.Handler == nil {
-		_ = p.enqueueFrame(ctx, NackFrame{ID: id, Error: Errorf(http.StatusNotImplemented, "not implemented")})
+	messageType := message.Kind().String()
+	role, plane := p.labels()
+	obs := p.Metrics.beginReceive(role, plane, messageType)
+
+	err := p.handle(ctx, message)
+
+	// Re-read labels after the handler: the first message on a connection can
+	// classify an initially unknown peer as control or data plane.
+	role, plane = p.labels()
+	obs.finish(role, plane, err)
+
+	if err != nil {
+		// TODO(rfratto): What should we do if this fails? Logs? Metrics?
+		_ = p.enqueueFrameWithMessageType(ctx, NackFrame{ID: id, Error: convertError(err)}, messageType)
 		return
 	}
 
-	switch err := p.Handler(ctx, p, message); err {
-	case nil:
-		// TODO(rfratto): What should we do if this fails? Logs? Metrics?
-		_ = p.enqueueFrame(ctx, AckFrame{ID: id})
-	default:
-		// TODO(rfratto): What should we do if this fails? Logs? Metrics?
-		_ = p.enqueueFrame(ctx, NackFrame{ID: id, Error: convertError(err)})
+	// TODO(rfratto): What should we do if this fails? Logs? Metrics?
+	_ = p.enqueueFrameWithMessageType(ctx, AckFrame{ID: id}, messageType)
+}
+
+// handle dispatches a message to the application handler, returning the
+// handler's result. If no handler is configured, it returns a not-implemented
+// error.
+func (p *Peer) handle(ctx context.Context, message Message) error {
+	if p.Handler == nil {
+		return Errorf(http.StatusNotImplemented, "not implemented")
 	}
+	return p.Handler(ctx, p, message)
 }
 
 func convertError(err error) *Error {
@@ -227,7 +324,7 @@ type request struct {
 //
 // [Peer.Serve] must be running when SendMessage is called, otherwise it blocks
 // until the context is canceled.
-func (p *Peer) SendMessage(ctx context.Context, message Message) error {
+func (p *Peer) SendMessage(ctx context.Context, message Message) (err error) {
 	p.lazyInit()
 
 	reqID := p.requestID.Inc()
@@ -237,11 +334,16 @@ func (p *Peer) SendMessage(ctx context.Context, message Message) error {
 	p.sentRequests.Store(reqID, req)
 	defer p.sentRequests.Delete(reqID)
 
-	timer := p.Metrics.newMessageRTTTimer(message.Kind().String())
-	defer timer.ObserveDuration()
-	p.Metrics.incMessageSent(message.Kind().String())
+	role, plane := p.labels()
+	obs := p.Metrics.beginSend(role, plane, message.Kind().String())
+	defer func() {
+		// Re-read labels: the first message on a connection can classify an
+		// initially unknown peer as control or data plane.
+		role, plane := p.labels()
+		obs.finish(role, plane, err)
+	}()
 
-	if err := p.enqueueFrame(ctx, MessageFrame{ID: reqID, Message: message}); err != nil {
+	if err = p.enqueueFrame(ctx, MessageFrame{ID: reqID, Message: message}); err != nil {
 		return err
 	}
 
@@ -251,7 +353,7 @@ func (p *Peer) SendMessage(ctx context.Context, message Message) error {
 		return ctx.Err()
 	case <-p.done:
 		return ErrConnClosed
-	case err := <-req.result:
+	case err = <-req.result:
 		return err
 	}
 }
@@ -266,18 +368,29 @@ func (p *Peer) SendMessageAsync(ctx context.Context, message Message) error {
 	p.lazyInit()
 
 	reqID := p.requestID.Inc()
-	p.Metrics.incMessageSent(message.Kind().String())
-	return p.enqueueFrame(ctx, MessageFrame{ID: reqID, Message: message})
+	err := p.enqueueFrame(ctx, MessageFrame{ID: reqID, Message: message})
+
+	role, plane := p.labels()
+	p.Metrics.recordAsyncSend(role, plane, message.Kind().String(), err)
+	return err
 }
 
 // enqueueFrame enqueues a frame to be sent to the remote peer.
 func (p *Peer) enqueueFrame(ctx context.Context, frame Frame) error {
+	return p.enqueueFrameWithMessageType(ctx, frame, frameMessageType(frame))
+}
+
+func (p *Peer) enqueueFrameWithMessageType(ctx context.Context, frame Frame, messageType string) error {
+	role, plane := p.labels()
+	p.Metrics.incQueueDepth(role, plane, queueDirectionOutgoing)
 	select {
 	case <-ctx.Done():
+		p.Metrics.decQueueDepth(role, plane, queueDirectionOutgoing)
 		return ctx.Err()
 	case <-p.done:
+		p.Metrics.decQueueDepth(role, plane, queueDirectionOutgoing)
 		return ErrConnClosed
-	case p.outgoing <- frame:
+	case p.outgoing <- queuedFrame{frame: frame, role: role, plane: plane, messageType: messageType, enqueuedAt: time.Now()}:
 		return nil
 	}
 }

--- a/pkg/engine/internal/scheduler/wire/peer.go
+++ b/pkg/engine/internal/scheduler/wire/peer.go
@@ -418,8 +418,8 @@ func (p *Peer) SendMessage(ctx context.Context, message Message) (err error) {
 }
 
 // SendMessageAsync sends a message to the remote peer asynchronously.
-// SendMessageAsync blocks until the message has been sent over the connection
-// but does not wait for an acknowledgement or response.
+// SendMessageAsync blocks until the message has been accepted into the outgoing
+// queue but does not wait for an acknowledgement or response.
 //
 // [Peer.Serve] must be running before SendMessageAsync is called, otherwise it
 // blocks until the context is canceled.
@@ -427,10 +427,12 @@ func (p *Peer) SendMessageAsync(ctx context.Context, message Message) error {
 	p.lazyInit()
 
 	reqID := p.requestID.Inc()
+	messageType := message.Kind().String()
+	start := time.Now()
 	err := p.enqueueFrame(ctx, MessageFrame{ID: reqID, Message: message})
 
 	role, plane := p.labels()
-	p.Metrics.recordAsyncSend(role, plane, message.Kind().String(), err)
+	p.Metrics.recordAsyncSend(role, plane, messageType, time.Since(start), err)
 	return err
 }
 

--- a/pkg/engine/internal/scheduler/wire/peer.go
+++ b/pkg/engine/internal/scheduler/wire/peer.go
@@ -100,6 +100,23 @@ func (p *Peer) labels() (Role, Plane) {
 	return role, plane
 }
 
+func (p *Peer) inferPlaneFromMessage(message Message) {
+	// Frame traffic is recorded before the application handler runs. Classify
+	// new peers from the first message frame so those bytes don't land on the
+	// unknown plane; already-classified peers keep their existing plane.
+	_, plane := p.labels()
+	if plane != PlaneUnknown || message == nil {
+		return
+	}
+
+	switch message.Kind() {
+	case MessageKindStreamData:
+		p.SetPlane(PlaneData)
+	default:
+		p.SetPlane(PlaneControl)
+	}
+}
+
 type queuedMessage struct {
 	frame      MessageFrame
 	role       Role
@@ -156,10 +173,11 @@ func (p *Peer) recvMessages(ctx context.Context) error {
 		}
 
 		p.Metrics.incFrameReceived(frame)
-		role, plane := p.labels()
 
 		switch frame := frame.(type) {
 		case MessageFrame:
+			p.inferPlaneFromMessage(frame.Message)
+			role, plane := p.labels()
 			messageType := frameMessageType(frame)
 			if hasFrameSize {
 				p.Metrics.recordFrame(role, plane, messageDirectionReceived, frame, messageType, frameSize)
@@ -177,6 +195,7 @@ func (p *Peer) recvMessages(ctx context.Context) error {
 			}
 
 		case AckFrame:
+			role, plane := p.labels()
 			// If there's still a listener for this request, inform them of
 			// the success.
 			var req *request
@@ -199,6 +218,7 @@ func (p *Peer) recvMessages(ctx context.Context) error {
 			}
 
 		case NackFrame:
+			role, plane := p.labels()
 			// If there's still a listener for this request, inform them of
 			// the error.
 			var req *request
@@ -221,6 +241,7 @@ func (p *Peer) recvMessages(ctx context.Context) error {
 			}
 
 		case DiscardFrame:
+			role, plane := p.labels()
 			if hasFrameSize {
 				p.Metrics.recordFrame(role, plane, messageDirectionReceived, frame, frameMessageType(frame), frameSize)
 			}

--- a/pkg/engine/internal/scheduler/wire/wire_http2.go
+++ b/pkg/engine/internal/scheduler/wire/wire_http2.go
@@ -185,6 +185,7 @@ type http2Conn struct {
 
 type incomingFrame struct {
 	frame Frame
+	size  int
 	err   error
 }
 
@@ -216,8 +217,8 @@ func newHTTP2Conn(
 
 func (c *http2Conn) readLoop(ctx context.Context) {
 	for {
-		frame, err := c.codec.DecodeFrom(c.reader)
-		incoming := incomingFrame{frame: frame, err: err}
+		frame, size, err := c.codec.decodeSizedFrom(c.reader)
+		incoming := incomingFrame{frame: frame, size: size, err: err}
 		select {
 		case <-ctx.Done():
 			return
@@ -230,50 +231,60 @@ func (c *http2Conn) readLoop(ctx context.Context) {
 
 // Send sends a frame over the connection.
 func (c *http2Conn) Send(ctx context.Context, frame Frame) error {
+	_, err := c.sendWithSize(ctx, frame)
+	return err
+}
+
+func (c *http2Conn) sendWithSize(ctx context.Context, frame Frame) (int, error) {
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
 
 	select {
 	case <-c.ctx.Done():
-		return ErrConnClosed
+		return 0, ErrConnClosed
 	case <-ctx.Done():
-		return ctx.Err()
+		return 0, ctx.Err()
 	case <-c.closed:
-		return ErrConnClosed
+		return 0, ErrConnClosed
 	default:
 	}
 
-	err := c.codec.EncodeTo(c.writer, frame)
+	size, err := c.codec.encodeSizedTo(c.writer, frame)
 	if err != nil && isHTTP2Error(err) {
-		return ErrConnClosed
+		return 0, ErrConnClosed
 	} else if err != nil {
-		return fmt.Errorf("write frame: %w", err)
+		return 0, fmt.Errorf("write frame: %w", err)
 	}
 
 	// Flush after each frame to ensure immediate delivery
 	if c.responseController != nil {
 		err := c.responseController.Flush()
 		if err != nil && isHTTP2Error(err) {
-			return ErrConnClosed
+			return 0, ErrConnClosed
 		} else if err != nil {
-			return fmt.Errorf("flush response: %w", err)
+			return 0, fmt.Errorf("flush response: %w", err)
 		}
 	}
 
-	return nil
+	return size, nil
 }
 
 // Recv receives a frame from the connection.
 func (c *http2Conn) Recv(ctx context.Context) (Frame, error) {
+	frame, _, err := c.recvWithSize(ctx)
+	return frame, err
+}
+
+func (c *http2Conn) recvWithSize(ctx context.Context) (Frame, int, error) {
 	select {
 	case <-c.ctx.Done():
-		return nil, ErrConnClosed
+		return nil, 0, ErrConnClosed
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, 0, ctx.Err()
 	case <-c.closed:
-		return nil, ErrConnClosed
+		return nil, 0, ErrConnClosed
 	case f := <-c.incomingCh:
-		return f.frame, f.err
+		return f.frame, f.size, f.err
 	}
 }
 

--- a/pkg/engine/internal/worker/comm_metrics.go
+++ b/pkg/engine/internal/worker/comm_metrics.go
@@ -1,0 +1,160 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
+)
+
+const (
+	assignmentOutcomeAssigned   = "assigned"
+	assignmentOutcomeRejected   = "rejected"
+	assignmentOutcomeOtherError = "other_error"
+)
+
+const (
+	assignmentPhaseNewJob        = "new_job"
+	assignmentPhaseThreadHandoff = "thread_handoff"
+	assignmentPhaseTotal         = "total"
+)
+
+const (
+	streamOutcomeSent       = "sent"
+	streamOutcomeReceived   = "received"
+	streamOutcomeTimeout    = "timeout"
+	streamOutcomeCanceled   = "canceled"
+	streamOutcomeConnClosed = "conn_closed"
+	streamOutcomeSendError  = "send_error"
+	streamOutcomeOtherError = "other_error"
+)
+
+const (
+	streamPhaseBindWait     = "bind_wait"
+	streamPhaseDial         = "dial"
+	streamPhaseLookupSource = "lookup_source"
+	streamPhaseRetryBackoff = "retry_backoff"
+	streamPhaseSourceWrite  = "source_write"
+	streamPhaseTotal        = "total"
+)
+
+const (
+	messageDirectionSent     = "sent"
+	messageDirectionReceived = "received"
+)
+
+const (
+	messageOutcomeAccepted     = "accepted"
+	messageOutcomeTimeout      = "timeout"
+	messageOutcomeCanceled     = "canceled"
+	messageOutcomeConnClosed   = "conn_closed"
+	messageOutcomeSendError    = "send_error"
+	messageOutcomeHandlerError = "handler_error"
+)
+
+const (
+	schedulerConnectionStateConnected = "connected"
+)
+
+const (
+	reconnectReasonDialError  = "dial_error"
+	reconnectReasonConnClosed = "conn_closed"
+	reconnectReasonOtherError = "other_error"
+)
+
+func classifyMessageOutcome(err error) string {
+	switch {
+	case err == nil:
+		return messageOutcomeAccepted
+	case errors.Is(err, context.DeadlineExceeded):
+		return messageOutcomeTimeout
+	case errors.Is(err, context.Canceled):
+		return messageOutcomeCanceled
+	case errors.Is(err, wire.ErrConnClosed):
+		return messageOutcomeConnClosed
+	default:
+		return messageOutcomeSendError
+	}
+}
+
+func classifyReceiveOutcome(err error) string {
+	switch {
+	case err == nil:
+		return messageOutcomeAccepted
+	case errors.Is(err, context.DeadlineExceeded):
+		return messageOutcomeTimeout
+	case errors.Is(err, context.Canceled):
+		return messageOutcomeCanceled
+	case errors.Is(err, wire.ErrConnClosed):
+		return messageOutcomeConnClosed
+	default:
+		return messageOutcomeHandlerError
+	}
+}
+
+func classifyStreamOutcome(err error, success string) string {
+	switch {
+	case err == nil:
+		return success
+	case errors.Is(err, context.DeadlineExceeded):
+		return streamOutcomeTimeout
+	case errors.Is(err, context.Canceled):
+		return streamOutcomeCanceled
+	case errors.Is(err, wire.ErrConnClosed):
+		return streamOutcomeConnClosed
+	default:
+		return streamOutcomeOtherError
+	}
+}
+
+type streamDataReceiveObservation struct {
+	m     *metrics
+	start time.Time
+}
+
+func (m *metrics) beginStreamDataReceive() streamDataReceiveObservation {
+	return streamDataReceiveObservation{m: m, start: time.Now()}
+}
+
+func (o streamDataReceiveObservation) finish(err error) {
+	o.m.streamDataReceiveSeconds.WithLabelValues(streamPhaseTotal, classifyStreamOutcome(err, streamOutcomeReceived)).Observe(time.Since(o.start).Seconds())
+}
+
+type streamDataReceivePhase struct {
+	m     *metrics
+	phase string
+	start time.Time
+}
+
+func (o streamDataReceiveObservation) beginPhase(phase string) streamDataReceivePhase {
+	return streamDataReceivePhase{m: o.m, phase: phase, start: time.Now()}
+}
+
+func (p streamDataReceivePhase) finish(err error) {
+	p.m.streamDataReceiveSeconds.WithLabelValues(p.phase, classifyStreamOutcome(err, streamOutcomeReceived)).Observe(time.Since(p.start).Seconds())
+}
+
+func classifyReconnectReason(err error) string {
+	if errors.Is(err, wire.ErrConnClosed) {
+		return reconnectReasonConnClosed
+	}
+	return reconnectReasonOtherError
+}
+
+func recordBatchSize(rec arrow.RecordBatch) uint64 {
+	if rec == nil {
+		return 0
+	}
+
+	var size uint64
+	for _, col := range rec.Columns() {
+		if col == nil || col.Data() == nil {
+			continue
+		}
+		size += col.Data().SizeInBytes()
+	}
+	return size
+}

--- a/pkg/engine/internal/worker/comm_metrics.go
+++ b/pkg/engine/internal/worker/comm_metrics.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/apache/arrow-go/v18/arrow"
-
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
 )
 
@@ -142,19 +140,4 @@ func classifyReconnectReason(err error) string {
 		return reconnectReasonConnClosed
 	}
 	return reconnectReasonOtherError
-}
-
-func recordBatchSize(rec arrow.RecordBatch) uint64 {
-	if rec == nil {
-		return 0
-	}
-
-	var size uint64
-	for _, col := range rec.Columns() {
-		if col == nil || col.Data() == nil {
-			continue
-		}
-		size += col.Data().SizeInBytes()
-	}
-	return size
 }

--- a/pkg/engine/internal/worker/comm_metrics_test.go
+++ b/pkg/engine/internal/worker/comm_metrics_test.go
@@ -1,0 +1,71 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
+)
+
+func TestClassifyStreamOutcome(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "success", err: nil, want: streamOutcomeSent},
+		{name: "timeout", err: context.DeadlineExceeded, want: streamOutcomeTimeout},
+		{name: "canceled", err: context.Canceled, want: streamOutcomeCanceled},
+		{name: "connection closed", err: wire.ErrConnClosed, want: streamOutcomeConnClosed},
+		{name: "other error", err: errors.New("failed"), want: streamOutcomeOtherError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, classifyStreamOutcome(tt.err, streamOutcomeSent))
+		})
+	}
+}
+
+func TestClassifyMessageOutcome(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "accepted", err: nil, want: messageOutcomeAccepted},
+		{name: "timeout", err: context.DeadlineExceeded, want: messageOutcomeTimeout},
+		{name: "canceled", err: context.Canceled, want: messageOutcomeCanceled},
+		{name: "connection closed", err: wire.ErrConnClosed, want: messageOutcomeConnClosed},
+		{name: "send error", err: errors.New("failed"), want: messageOutcomeSendError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, classifyMessageOutcome(tt.err))
+		})
+	}
+}
+
+func TestClassifyReceiveOutcome(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "accepted", err: nil, want: messageOutcomeAccepted},
+		{name: "timeout", err: context.DeadlineExceeded, want: messageOutcomeTimeout},
+		{name: "canceled", err: context.Canceled, want: messageOutcomeCanceled},
+		{name: "connection closed", err: wire.ErrConnClosed, want: messageOutcomeConnClosed},
+		{name: "handler error", err: errors.New("failed"), want: messageOutcomeHandlerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, classifyReceiveOutcome(tt.err))
+		})
+	}
+}

--- a/pkg/engine/internal/worker/metrics.go
+++ b/pkg/engine/internal/worker/metrics.go
@@ -42,6 +42,22 @@ type metrics struct {
 	statusUpdateSeconds     prometheus.Histogram
 	statusUpdateErrorsTotal *prometheus.CounterVec
 
+	taskAssignmentHandlerSeconds *prometheus.HistogramVec
+
+	streamDataSendSeconds      *prometheus.HistogramVec
+	streamDataSentTotal        *prometheus.CounterVec
+	streamDataSentBytesTotal   prometheus.Counter
+	streamDataSentBatchesTotal prometheus.Counter
+	streamDataRetriesTotal     *prometheus.CounterVec
+	streamDataReceiveSeconds   *prometheus.HistogramVec
+	streamBindTotal            *prometheus.CounterVec
+	streamStatusTotal          *prometheus.CounterVec
+
+	readyNotificationsTotal    *prometheus.CounterVec
+	readyWaitSeconds           *prometheus.HistogramVec
+	schedulerConnectionsActive *prometheus.GaugeVec
+	schedulerReconnectsTotal   *prometheus.CounterVec
+
 	// Task I/O counters, read from per-task captures at task completion. Only
 	// leaf tasks download from object storage today, so these are zero for
 	// non-leaf tasks until that changes.
@@ -142,6 +158,61 @@ func newMetrics() *metrics {
 			Help: "Total number of failures sending a task's terminal status update to the scheduler, by error class",
 		}, []string{"error_class"}),
 
+		taskAssignmentHandlerSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_worker_task_assignment_handler_seconds",
+			Help: "Time spent handling TaskAssign messages by phase and outcome.",
+		}, []string{"phase", "outcome"}),
+
+		streamDataSendSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_worker_stream_data_send_seconds",
+			Help: "Time spent sending StreamData messages from streamSink.Send by phase and outcome.",
+		}, []string{"phase", "outcome"}),
+		streamDataSentTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_worker_stream_data_sent_total",
+			Help: "Total number of StreamData send attempts by outcome.",
+		}, []string{"outcome"}),
+		streamDataSentBytesTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "loki_engine_worker_stream_data_sent_bytes_total",
+			Help: "Total bytes sent in StreamData record batches.",
+		}),
+		streamDataSentBatchesTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "loki_engine_worker_stream_data_sent_batches_total",
+			Help: "Total record batches sent in StreamData messages.",
+		}),
+		streamDataRetriesTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_worker_stream_data_retries_total",
+			Help: "Total StreamData send retries by reason.",
+		}, []string{"reason"}),
+		streamDataReceiveSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_worker_stream_data_receive_seconds",
+			Help: "Time spent receiving StreamData messages by phase and outcome.",
+		}, []string{"phase", "outcome"}),
+		streamBindTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_worker_stream_bind_total",
+			Help: "Total number of StreamBind messages handled by outcome.",
+		}, []string{"outcome"}),
+		streamStatusTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_worker_stream_status_total",
+			Help: "Total number of StreamStatus messages by direction and outcome.",
+		}, []string{"direction", "outcome"}),
+
+		readyNotificationsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_worker_ready_notifications_total",
+			Help: "Total number of WorkerReady notifications sent by outcome.",
+		}, []string{"outcome"}),
+		readyWaitSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_worker_ready_wait_seconds",
+			Help: "Time spent waiting for a worker thread to become ready before notifying a scheduler.",
+		}, []string{"outcome"}),
+		schedulerConnectionsActive: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "loki_engine_worker_scheduler_connections_active",
+			Help: "Current number of active scheduler connections by state.",
+		}, []string{"state"}),
+		schedulerReconnectsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_worker_scheduler_reconnects_total",
+			Help: "Total number of scheduler connection retries by reason.",
+		}, []string{"reason"}),
+
 		pagesDownloadedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "loki_engine_worker_pages_downloaded_total",
 			Help: "Total number of pages downloaded from object storage during task execution",
@@ -179,6 +250,15 @@ func (m *metrics) Register(reg prometheus.Registerer) error { return reg.Registe
 
 // Unregister unregisters metrics from the provided Registerer.
 func (m *metrics) Unregister(reg prometheus.Registerer) { reg.Unregister(m.reg) }
+
+// newNativeHistogramVec creates a HistogramVec that uses native histogram
+// buckets, registered to reg.
+func newNativeHistogramVec(reg prometheus.Registerer, opts prometheus.HistogramOpts, labels []string) *prometheus.HistogramVec {
+	opts.NativeHistogramBucketFactor = 1.1
+	opts.NativeHistogramMaxBucketNumber = 100
+	opts.NativeHistogramMinResetDuration = time.Hour
+	return promauto.With(reg).NewHistogramVec(opts, labels)
+}
 
 // observeOperatorCost records each operator's self-time and row counts, by type.
 func (m *metrics) observeOperatorCost(nodes []pipelineNode) {

--- a/pkg/engine/internal/worker/metrics.go
+++ b/pkg/engine/internal/worker/metrics.go
@@ -85,73 +85,41 @@ func newMetrics() *metrics {
 			Name: "loki_engine_worker_rejected_assignments_total",
 			Help: "Total number of task assignments the worker rejected because no thread slot was available (worker-side counterpart to the scheduler's assignment_backoffs_total)",
 		}),
-		taskExecSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		taskExecSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_task_exec_seconds",
 			Help: "Number of seconds a task took to complete successfully",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"task_type"}),
 
-		passReadSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		passReadSeconds: newNativeHistogram(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_pass_read_seconds",
 			Help: "Duration of a single read-phase pass",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}),
-		passSendSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		passSendSeconds: newNativeHistogram(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_pass_send_seconds",
 			Help: "Duration of a single send-phase pass",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}),
 
-		taskOpenSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		taskOpenSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_task_open_seconds",
 			Help: "Total time spent opening a task's pipeline (Pipeline.Open)",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"task_type"}),
-		taskReadSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		taskReadSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_task_read_seconds",
 			Help: "Total time spent in the read phase (Pipeline.Read) for a task",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"task_type"}),
-		taskSendSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		taskSendSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_task_send_seconds",
 			Help: "Total time spent in the send phase for a task",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"task_type"}),
 
-		setupSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		setupSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_setup_seconds",
 			Help: "Time spent preparing a task for execution before its pipeline is drained",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"task_type"}),
 
-		statusUpdateSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		statusUpdateSeconds: newNativeHistogram(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_status_update_seconds",
 			Help: "Time spent sending a task's terminal status update to the scheduler and waiting for acknowledgement",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}),
 		statusUpdateErrorsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_engine_worker_status_update_errors_total",
@@ -226,13 +194,9 @@ func newMetrics() *metrics {
 			Help: "Total number of bytes downloaded from object storage during task execution",
 		}),
 
-		operatorSelfSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		operatorSelfSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_operator_self_seconds",
 			Help: "Per-operator wall-clock (not CPU) self-time, exclusive of child operators, by operator type",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"operator_type"}),
 		operatorRowsInTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_engine_worker_operator_rows_in_total",
@@ -250,6 +214,15 @@ func (m *metrics) Register(reg prometheus.Registerer) error { return reg.Registe
 
 // Unregister unregisters metrics from the provided Registerer.
 func (m *metrics) Unregister(reg prometheus.Registerer) { reg.Unregister(m.reg) }
+
+// newNativeHistogram creates a Histogram that uses native histogram buckets,
+// registered to reg.
+func newNativeHistogram(reg prometheus.Registerer, opts prometheus.HistogramOpts) prometheus.Histogram {
+	opts.NativeHistogramBucketFactor = 1.1
+	opts.NativeHistogramMaxBucketNumber = 100
+	opts.NativeHistogramMinResetDuration = time.Hour
+	return promauto.With(reg).NewHistogram(opts)
+}
 
 // newNativeHistogramVec creates a HistogramVec that uses native histogram
 // buckets, registered to reg.

--- a/pkg/engine/internal/worker/metrics_helpers_test.go
+++ b/pkg/engine/internal/worker/metrics_helpers_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/oklog/ulid/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -17,6 +19,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
+	"github.com/grafana/loki/v3/pkg/util/arrowtest"
 )
 
 func TestObserveOperatorCost(t *testing.T) {
@@ -51,6 +54,40 @@ func histogramCountSum(t *testing.T, vec *prometheus.HistogramVec, lvs ...string
 	var dm dto.Metric
 	require.NoError(t, obs.(prometheus.Metric).Write(&dm))
 	return dm.GetHistogram().GetSampleCount(), dm.GetHistogram().GetSampleSum()
+}
+
+func TestHandleDataMessageRecordsReceivePhases(t *testing.T) {
+	schema := arrow.NewSchema([]arrow.Field{{Name: "line", Type: arrow.BinaryTypes.String}}, nil)
+	rec := arrowtest.Rows{{"line": "hello"}}.Record(memory.DefaultAllocator, schema)
+	defer rec.Release()
+
+	streamID := ulid.Make()
+	input := new(nodeSource)
+	source := new(streamSource)
+	require.NoError(t, source.Bind(input))
+
+	w := &Worker{
+		metrics: newMetrics(),
+		sources: map[ulid.ULID]*streamSource{streamID: source},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	readErr := make(chan error, 1)
+	go func() {
+		_, err := input.Read(ctx)
+		readErr <- err
+	}()
+
+	err := w.handleDataMessage(ctx, wire.StreamDataMessage{StreamID: streamID, Data: rec})
+	require.NoError(t, err)
+	require.NoError(t, <-readErr)
+
+	for _, phase := range []string{streamPhaseLookupSource, streamPhaseSourceWrite, streamPhaseTotal} {
+		count, _ := histogramCountSum(t, w.metrics.streamDataReceiveSeconds, phase, streamOutcomeReceived)
+		require.Equal(t, uint64(1), count, "phase %s should be recorded once", phase)
+	}
 }
 
 func TestTaskTypeLabel(t *testing.T) {

--- a/pkg/engine/internal/worker/stream_sink.go
+++ b/pkg/engine/internal/worker/stream_sink.go
@@ -95,7 +95,7 @@ func (sink *streamSink) Send(ctx context.Context, rec arrow.RecordBatch) (err er
 		sink.Metrics.streamDataSentTotal.WithLabelValues(outcome).Inc()
 		if err == nil {
 			sink.Metrics.streamDataSentBatchesTotal.Inc()
-			sink.Metrics.streamDataSentBytesTotal.Add(float64(recordBatchSize(rec)))
+			sink.Metrics.streamDataSentBytesTotal.Add(float64(recordBatchBytes(rec)))
 		}
 	}()
 

--- a/pkg/engine/internal/worker/stream_sink.go
+++ b/pkg/engine/internal/worker/stream_sink.go
@@ -19,7 +19,9 @@ import (
 
 // streamSink allows for sending records remotely across a stream.
 type streamSink struct {
-	Logger      log.Logger
+	Logger log.Logger
+	// Metrics is required and records stream send/bind/status metrics.
+	Metrics     *metrics
 	WireMetrics *wire.Metrics
 	Scheduler   *wire.Peer
 	Stream      *workflow.Stream
@@ -48,10 +50,11 @@ func (sink *streamSink) Bind(ctx context.Context, destination net.Addr) error {
 		bound = true
 
 		// Best-effort inform the scheduler that we're ready to send data.
-		_ = sink.Scheduler.SendMessageAsync(ctx, wire.StreamStatusMessage{
+		err := sink.Scheduler.SendMessageAsync(ctx, wire.StreamStatusMessage{
 			StreamID: sink.Stream.ULID,
 			State:    workflow.StreamStateOpen,
 		})
+		sink.Metrics.streamStatusTotal.WithLabelValues(messageDirectionSent, classifyMessageOutcome(err)).Inc()
 
 		sink.destination = destination
 		close(sink.bound) // Wake up any Send goroutines
@@ -82,8 +85,19 @@ func (sink *streamSink) lazyInit() {
 // connection is lost.
 //
 // Send can be aborted by cancelling the provided context.
-func (sink *streamSink) Send(ctx context.Context, rec arrow.RecordBatch) error {
+func (sink *streamSink) Send(ctx context.Context, rec arrow.RecordBatch) (err error) {
 	sink.lazyInit()
+
+	start := time.Now()
+	defer func() {
+		outcome := classifyStreamOutcome(err, streamOutcomeSent)
+		sink.Metrics.streamDataSendSeconds.WithLabelValues(streamPhaseTotal, outcome).Observe(time.Since(start).Seconds())
+		sink.Metrics.streamDataSentTotal.WithLabelValues(outcome).Inc()
+		if err == nil {
+			sink.Metrics.streamDataSentBatchesTotal.Inc()
+			sink.Metrics.streamDataSentBytesTotal.Add(float64(recordBatchSize(rec)))
+		}
+	}()
 
 	bo := backoff.New(ctx, backoff.Config{
 		MinBackoff: 100 * time.Millisecond,
@@ -94,7 +108,7 @@ func (sink *streamSink) Send(ctx context.Context, rec arrow.RecordBatch) error {
 		// We only want to retry on errors about the connection closing; errors
 		// where the peer rejected our payload should be considered
 		// nonretryable.
-		err := sink.send(ctx, rec)
+		err = sink.send(ctx, rec)
 		if err == nil {
 			break
 		}
@@ -105,10 +119,20 @@ func (sink *streamSink) Send(ctx context.Context, rec arrow.RecordBatch) error {
 		}
 
 		level.Warn(sink.Logger).Log("msg", "failed to send data to peer", "err", err)
-		bo.Wait()
+		sink.waitRetry(bo)
 	}
 
 	return bo.Err()
+}
+
+// waitRetry counts a stream-data retry, waits for the backoff to elapse, and
+// records how long the backoff took.
+func (sink *streamSink) waitRetry(bo *backoff.Backoff) {
+	sink.Metrics.streamDataRetriesTotal.WithLabelValues(streamOutcomeConnClosed).Inc()
+
+	start := time.Now()
+	bo.Wait()
+	sink.Metrics.streamDataSendSeconds.WithLabelValues(streamPhaseRetryBackoff, classifyStreamOutcome(bo.Err(), streamOutcomeSent)).Observe(time.Since(start).Seconds())
 }
 
 func (sink *streamSink) send(ctx context.Context, rec arrow.RecordBatch) error {
@@ -135,12 +159,16 @@ func (sink *streamSink) send(ctx context.Context, rec arrow.RecordBatch) error {
 
 func (sink *streamSink) getPeer(ctx context.Context) (*wire.Peer, error) {
 	// Wait for destination.
+	bindWaitStart := time.Now()
 	select {
 	case <-ctx.Done():
+		sink.Metrics.streamDataSendSeconds.WithLabelValues(streamPhaseBindWait, classifyStreamOutcome(ctx.Err(), streamOutcomeSent)).Observe(time.Since(bindWaitStart).Seconds())
 		return nil, ctx.Err()
 	case <-sink.ctx.Done():
+		sink.Metrics.streamDataSendSeconds.WithLabelValues(streamPhaseBindWait, streamOutcomeConnClosed).Observe(time.Since(bindWaitStart).Seconds())
 		return nil, wire.ErrConnClosed
 	case <-sink.bound:
+		sink.Metrics.streamDataSendSeconds.WithLabelValues(streamPhaseBindWait, streamOutcomeSent).Observe(time.Since(bindWaitStart).Seconds())
 	}
 
 	sink.destConnMut.Lock()
@@ -150,7 +178,9 @@ func (sink *streamSink) getPeer(ctx context.Context) (*wire.Peer, error) {
 		return sink.destConn, nil
 	}
 
+	dialStart := time.Now()
 	conn, err := sink.Dialer(ctx, sink.destination)
+	sink.Metrics.streamDataSendSeconds.WithLabelValues(streamPhaseDial, classifyStreamOutcome(err, streamOutcomeSent)).Observe(time.Since(dialStart).Seconds())
 	if err != nil {
 		return nil, err
 	}
@@ -159,8 +189,10 @@ func (sink *streamSink) getPeer(ctx context.Context) (*wire.Peer, error) {
 		Logger:  sink.Logger,
 		Metrics: sink.WireMetrics,
 		Conn:    conn,
+		Role:    wire.RoleWorker,
 		Handler: nil, // This is a send-only connection.
 	}
+	peer.SetPlane(wire.PlaneData)
 
 	go func() {
 		if err := peer.Serve(sink.ctx); err != nil && errors.Is(err, context.Canceled) {
@@ -200,6 +232,7 @@ func (sink *streamSink) Close(ctx context.Context) error {
 			StreamID: sink.Stream.ULID,
 			State:    workflow.StreamStateClosed,
 		})
+		sink.Metrics.streamStatusTotal.WithLabelValues(messageDirectionSent, classifyMessageOutcome(err)).Inc()
 	})
 
 	return err

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -299,6 +299,7 @@ func (w *Worker) handleConn(ctx context.Context, conn wire.Conn) {
 		Logger:  logger,
 		Metrics: w.wireMetrics,
 		Conn:    conn,
+		Role:    wire.RoleWorker,
 
 		// Allow for a backlog of 8 frames before backpressure is applied.
 		Buffer: 8,
@@ -312,6 +313,7 @@ func (w *Worker) handleConn(ctx context.Context, conn wire.Conn) {
 			}
 		},
 	}
+	peer.SetPlane(wire.PlaneData)
 
 	// Handle communication with the peer until the context is canceled or some
 	// error occurs.
@@ -336,6 +338,7 @@ func (w *Worker) schedulerLoop(ctx context.Context, addr net.Addr) error {
 	for bo.Ongoing() {
 		conn, err := w.dial(ctx, addr)
 		if err != nil {
+			w.metrics.schedulerReconnectsTotal.WithLabelValues(reconnectReasonDialError).Inc()
 			level.Warn(logger).Log("msg", "dial to scheduler failed, will retry after backoff", "err", err)
 			bo.Wait()
 			continue
@@ -350,6 +353,7 @@ func (w *Worker) schedulerLoop(ctx context.Context, addr net.Addr) error {
 			level.Debug(logger).Log("msg", "context canceled. stopping scheduler loop")
 			break
 		} else if err != nil {
+			w.metrics.schedulerReconnectsTotal.WithLabelValues(classifyReconnectReason(err)).Inc()
 			level.Warn(logger).Log("msg", "connection to scheduler closed; will reconnect after backoff", "err", err)
 			bo.Wait()
 			continue
@@ -367,6 +371,8 @@ func (w *Worker) dial(ctx context.Context, addr net.Addr) (wire.Conn, error) {
 // handleSchedulerConn handles a single connection to a scheduler.
 func (w *Worker) handleSchedulerConn(ctx context.Context, logger log.Logger, conn wire.Conn) error {
 	level.Info(logger).Log("msg", "connected to scheduler")
+	w.metrics.schedulerConnectionsActive.WithLabelValues(schedulerConnectionStateConnected).Inc()
+	defer w.metrics.schedulerConnectionsActive.WithLabelValues(schedulerConnectionStateConnected).Dec()
 
 	// waitReady is used to signal that the scheduler should be told when
 	// there's a ready thread.
@@ -382,13 +388,33 @@ func (w *Worker) handleSchedulerConn(ctx context.Context, logger log.Logger, con
 		return nil
 	}
 
-	handleAssignment := func(peer *wire.Peer, msg wire.TaskAssignMessage) error {
+	handleAssignment := func(peer *wire.Peer, msg wire.TaskAssignMessage) (err error) {
+		outcome := assignmentOutcomeAssigned
+		start := time.Now()
+		var newJobDuration, handoffDuration time.Duration
+		defer func() {
+			w.metrics.taskAssignmentHandlerSeconds.WithLabelValues(assignmentPhaseTotal, outcome).Observe(time.Since(start).Seconds())
+			if newJobDuration > 0 {
+				w.metrics.taskAssignmentHandlerSeconds.WithLabelValues(assignmentPhaseNewJob, outcome).Observe(newJobDuration.Seconds())
+			}
+			if handoffDuration > 0 {
+				w.metrics.taskAssignmentHandlerSeconds.WithLabelValues(assignmentPhaseThreadHandoff, outcome).Observe(handoffDuration.Seconds())
+			}
+		}()
+
+		newJobStart := time.Now()
 		job, err := w.newJob(ctx, peer, logger, msg)
+		newJobDuration = time.Since(newJobStart)
 		if err != nil {
+			outcome = assignmentOutcomeOtherError
 			return err
 		}
 
-		if err := w.jobManager.Send(ctx, job); err != nil {
+		handoffStart := time.Now()
+		err = w.jobManager.Send(ctx, job)
+		handoffDuration = time.Since(handoffStart)
+		if err != nil {
+			outcome = assignmentOutcomeRejected
 			job.Close()                 // Clean up resources associated with the job.
 			_ = handleWorkerSubscribe() // handleWorkerSubscribe can only return nil
 			w.metrics.rejectedAssignmentsTotal.Inc()
@@ -403,6 +429,7 @@ func (w *Worker) handleSchedulerConn(ctx context.Context, logger log.Logger, con
 		Logger:  logger,
 		Metrics: w.wireMetrics,
 		Conn:    conn,
+		Role:    wire.RoleWorker,
 
 		// Allow for a backlog of 128 frames before backpressure is applied.
 		Buffer: 128,
@@ -431,6 +458,8 @@ func (w *Worker) handleSchedulerConn(ctx context.Context, logger log.Logger, con
 		},
 	}
 
+	peer.SetPlane(wire.PlaneControl)
+
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error { return peer.Serve(ctx) })
 
@@ -452,13 +481,18 @@ func (w *Worker) handleSchedulerConn(ctx context.Context, logger log.Logger, con
 			case <-waitReady:
 			}
 
-			// Wait for a thread to become ready for another job
-			if err := w.jobManager.WaitReady(ctx); err != nil {
+			// Wait for a thread to become ready for another job.
+			waitStart := time.Now()
+			err := w.jobManager.WaitReady(ctx)
+			w.metrics.readyWaitSeconds.WithLabelValues(classifyMessageOutcome(err)).Observe(time.Since(waitStart).Seconds())
+			if err != nil {
 				return nil
 			}
 
 			// Notify the scheduler.
-			if err := peer.SendMessageAsync(ctx, wire.WorkerReadyMessage{}); err != nil {
+			err = peer.SendMessageAsync(ctx, wire.WorkerReadyMessage{})
+			w.metrics.readyNotificationsTotal.WithLabelValues(classifyMessageOutcome(err)).Inc()
+			if err != nil {
 				level.Warn(logger).Log("msg", "failed to send ready message", "err", err)
 			}
 		}
@@ -533,6 +567,7 @@ func (w *Worker) newJob(ctx context.Context, scheduler *wire.Peer, logger log.Lo
 		for _, taskSink := range taskSinks {
 			sink := &streamSink{
 				Logger:      log.With(logger, "stream", taskSink.ULID),
+				Metrics:     w.metrics,
 				WireMetrics: w.wireMetrics,
 				Scheduler:   scheduler,
 				Stream:      taskSink,
@@ -609,7 +644,11 @@ func (w *Worker) handleCancelMessage(msg wire.TaskCancelMessage) error {
 	return nil
 }
 
-func (w *Worker) handleBindMessage(ctx context.Context, msg wire.StreamBindMessage) error {
+func (w *Worker) handleBindMessage(ctx context.Context, msg wire.StreamBindMessage) (err error) {
+	defer func() {
+		w.metrics.streamBindTotal.WithLabelValues(classifyReceiveOutcome(err)).Inc()
+	}()
+
 	w.resourcesMut.RLock()
 	sink, found := w.sinks[msg.StreamID]
 	w.resourcesMut.RUnlock()
@@ -620,7 +659,11 @@ func (w *Worker) handleBindMessage(ctx context.Context, msg wire.StreamBindMessa
 	return sink.Bind(ctx, msg.Receiver)
 }
 
-func (w *Worker) handleStreamStatusMessage(msg wire.StreamStatusMessage) error {
+func (w *Worker) handleStreamStatusMessage(msg wire.StreamStatusMessage) (err error) {
+	defer func() {
+		w.metrics.streamStatusTotal.WithLabelValues(messageDirectionReceived, classifyReceiveOutcome(err)).Inc()
+	}()
+
 	w.resourcesMut.RLock()
 	source, found := w.sources[msg.StreamID]
 	w.resourcesMut.RUnlock()
@@ -636,15 +679,32 @@ func (w *Worker) handleStreamStatusMessage(msg wire.StreamStatusMessage) error {
 	return nil
 }
 
-func (w *Worker) handleDataMessage(ctx context.Context, msg wire.StreamDataMessage) error {
-	w.resourcesMut.RLock()
-	source, found := w.sources[msg.StreamID]
-	w.resourcesMut.RUnlock()
+func (w *Worker) handleDataMessage(ctx context.Context, msg wire.StreamDataMessage) (err error) {
+	obs := w.metrics.beginStreamDataReceive()
+	defer func() { obs.finish(err) }()
 
-	if !found {
-		return fmt.Errorf("stream %s not found for receiving data", msg.StreamID)
+	lookupPhase := obs.beginPhase(streamPhaseLookupSource)
+	source, err := w.lookupStreamSource(msg.StreamID)
+	lookupPhase.finish(err)
+	if err != nil {
+		return err
 	}
-	return source.Write(ctx, msg.Data)
+
+	writePhase := obs.beginPhase(streamPhaseSourceWrite)
+	err = source.Write(ctx, msg.Data)
+	writePhase.finish(err)
+	return err
+}
+
+func (w *Worker) lookupStreamSource(streamID ulid.ULID) (*streamSource, error) {
+	w.resourcesMut.RLock()
+	defer w.resourcesMut.RUnlock()
+
+	source, found := w.sources[streamID]
+	if !found {
+		return nil, fmt.Errorf("stream %s not found for receiving data", streamID)
+	}
+	return source, nil
 }
 
 // RegisterMetrics registers metrics about s to report to reg.


### PR DESCRIPTION
Adds additional scheduler-worker communication metrics for the new engine.

This keeps the existing metrics and adds low-cardinality signals for:

- generic wire message outcomes, queue depth, queue time, handler time, and pending requests
- scheduler assignment and TaskStatus outcomes
- worker assignment, readiness, reconnects, stream sends, stream receives, binds, and statuses
- outgoing ACK/NACK queue time by original message type