### PR TITLE
chore: Wrapping io.EOF and our custom EOF

### DIFF
--- a/pkg/engine/internal/executor/pipeline.go
+++ b/pkg/engine/internal/executor/pipeline.go
@@ -67,7 +67,7 @@ type ContributingTimeRangeChangedNotifier interface {
 var (
 	errNotImplemented  = errors.New("pipeline not implemented")
 	errPipelineNotOpen = errors.New("pipeline not opened")
-	EOF                = fmt.Errorf("pipeline exhausted: %w", io.EOF)
+	EOF                = fmt.Errorf("pipeline exhausted: %w", io.EOF) //nolint:revive,staticcheck
 )
 
 type state struct {

--- a/pkg/engine/internal/executor/pipeline.go
+++ b/pkg/engine/internal/executor/pipeline.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -66,7 +67,7 @@ type ContributingTimeRangeChangedNotifier interface {
 var (
 	errNotImplemented  = errors.New("pipeline not implemented")
 	errPipelineNotOpen = errors.New("pipeline not opened")
-	EOF                = errors.New("pipeline exhausted") //nolint:revive,staticcheck
+	EOF                = fmt.Errorf("pipeline exhausted: %w", io.EOF)
 )
 
 type state struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

I have found `sending result to peer: pipeline exhausted` in our logs. We return our own `executor.EOF` from pipelines, but we also have a bunch of section readers and other types that also return `io.EOF`. In many places an error is checked by `errors.Is(err, io.EOF)` which fails on our custom error, and vice versa. Instead of grooming a hundred of places and replacing one check on another (with a high chance that I miss something) I decided to wrap `io.EOF` into our `executor.EOF` with `%w` which would pass both checks. 

**Which issue(s) this PR fixes**:
Fixes `sending result to peer: pipeline exhausted`.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
