### PR TITLE
revert: Remove deprecated `/api/prom` API endpoints (#21569)

### DIFF
--- a/cmd/querytee/main.go
+++ b/cmd/querytee/main.go
@@ -101,11 +101,16 @@ func lokiReadRoutes(cfg Config) []querytee.Route {
 		{Path: constants.PathLokiLabels, RouteName: "api_v1_labels", Methods: []string{"GET"}, ResponseComparator: nil},
 		{Path: constants.PathLokiLabelNameValues, RouteName: "api_v1_label_name_values", Methods: []string{"GET"}, ResponseComparator: nil},
 		{Path: constants.PathLokiSeries, RouteName: "api_v1_series", Methods: []string{"GET"}, ResponseComparator: nil},
+		{Path: constants.PathPromQuery, RouteName: "api_prom_query", Methods: []string{"GET", "POST"}, ResponseComparator: samplesComparator},
+		{Path: constants.PathPromLabel, RouteName: "api_prom_label", Methods: []string{"GET"}, ResponseComparator: nil},
+		{Path: constants.PathPromLabelNameValues, RouteName: "api_prom_label_name_values", Methods: []string{"GET"}, ResponseComparator: nil},
+		{Path: constants.PathPromSeries, RouteName: "api_prom_series", Methods: []string{"GET"}, ResponseComparator: nil},
 	}
 }
 
 func lokiWriteRoutes() []querytee.Route {
 	return []querytee.Route{
 		{Path: constants.PathLokiPush, RouteName: "api_v1_push", Methods: []string{"POST"}, ResponseComparator: nil},
+		{Path: constants.PathPromPush, RouteName: "api_prom_push", Methods: []string{"POST"}, ResponseComparator: nil},
 	}
 }

--- a/docs/sources/configure/examples/query-frontend.md
+++ b/docs/sources/configure/examples/query-frontend.md
@@ -40,7 +40,7 @@ data:
     # X-Scope-OrgID header. `fake` will be substituted in instead.
     auth_enabled: false
 
-    # We don't want the default prefix.
+    # We don't want the usual /api/prom prefix.
     http_prefix:
 
     server:

--- a/docs/sources/query/log_queries/_index.md
+++ b/docs/sources/query/log_queries/_index.md
@@ -545,14 +545,14 @@ The regular expression must contain a least one named sub-match (e.g `(?P<name>r
 For example the parser `| regexp "(?P<method>\\w+) (?P<path>[\\w|/]+) \\((?P<status>\\d+?)\\) (?P<duration>.*)"` will extract from the following line:
 
 ```log
-POST /loki/api/v1/query_range (200) 1.5s
+POST /api/prom/api/v1/query_range (200) 1.5s
 ```
 
 those labels:
 
 ```kv
 "method" => "POST"
-"path" => "/loki/api/v1/query_range"
+"path" => "/api/prom/api/v1/query_range"
 "status" => "200"
 "duration" => "1.5s"
 ```

--- a/docs/sources/query/logcli/getting-started.md
+++ b/docs/sources/query/logcli/getting-started.md
@@ -2113,9 +2113,9 @@ logcli labels job
 ```
 
 ```bash
-https://logs-prod-008.grafana.net/loki/api/v1/label/job/values
-loki-prod/consul
-loki-prod/loki-gw
+https://logs-dev-ops-tools1.grafana.net/api/prom/label/job/values
+loki-ops/consul
+loki-ops/loki-gw
 ```
 
 Print all labels and their unique values. This command is especially useful for finding [high-cardinality labels](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/labels/#cardinality) in the index.
@@ -2145,12 +2145,12 @@ cluster             1          10
 Get all logs for a given stream
 
 ```bash
-logcli query '{job="loki-prod/consul"}'
+logcli query '{job="loki-ops/consul"}'
 ```
 
 ```bash
-https://logs-prod-008.grafana.net/loki/api/v1/query?query=%7Bjob%3D%22loki-prod%2Fconsul%22%7D&limit=30&start=1529928228&end=1529931828&direction=backward&regexp=
-Common labels: {job="loki-prod/consul", namespace="loki-prod"}
+https://logs-dev-ops-tools1.grafana.net/api/prom/query?query=%7Bjob%3D%22loki-ops%2Fconsul%22%7D&limit=30&start=1529928228&end=1529931828&direction=backward&regexp=
+Common labels: {job="loki-ops/consul", namespace="loki-ops"}
 2018-06-25T12:52:09Z {instance="consul-8576459955-pl75w"} 2018/06/25 12:52:09 [INFO] raft: Snapshot to 475409 complete
 2018-06-25T12:52:09Z {instance="consul-8576459955-pl75w"} 2018/06/25 12:52:09 [INFO] raft: Compacting logs from 456973 to 465169
 ```

--- a/docs/sources/query/query_examples.md
+++ b/docs/sources/query/query_examples.md
@@ -116,7 +116,7 @@ Consider this logfmt log line.
 To extract the method and the path of this logfmt log line,
 
 ```log
-level=debug ts=2020-10-02T10:10:42.092268913Z caller=logging.go:66 traceID=a9d4d8a928d8db1 msg="POST /loki/api/v1/query_range (200) 1.5s"
+level=debug ts=2020-10-02T10:10:42.092268913Z caller=logging.go:66 traceID=a9d4d8a928d8db1 msg="POST /api/prom/api/v1/query_range (200) 1.5s"
 ```
 
 To extract the method and the path,
@@ -126,7 +126,7 @@ use multiple parsers (logfmt and regexp):
 {job="loki-ops/query-frontend"} | logfmt | line_format "{{.msg}}" | regexp "(?P<method>\\w+) (?P<path>[\\w|/]+) \\((?P<status>\\d+?)\\) (?P<duration>.*)"
 ```
 
-This is possible because the `| line_format` reformats the log line to become `POST /loki/api/v1/query_range (200) 1.5s` which can then be parsed with the `| regexp ...` parser.
+This is possible because the `| line_format` reformats the log line to become `POST /api/prom/api/v1/query_range (200) 1.5s` which can then be parsed with the `| regexp ...` parser.
 
 ## Log line formatting examples
 

--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -89,8 +89,16 @@ These HTTP endpoints are exposed by the `ruler` component:
 - [`POST /loki/api/v1/rules/{namespace}`](#set-rule-group)
 - [`DELETE /loki/api/v1/rules/{namespace}/{groupName}`](#delete-rule-group)
 - [`DELETE /loki/api/v1/rules/{namespace}`](#delete-namespace)
+- [`GET /api/prom/rules`](#list-rule-groups)
+- [`GET /api/prom/rules/{namespace}`](#get-rule-groups-by-namespace)
+- [`GET /api/prom/rules/{namespace}/{groupName}`](#get-rule-group)
+- [`POST /api/prom/rules/{namespace}`](#set-rule-group)
+- [`DELETE /api/prom/rules/{namespace}/{groupName}`](#delete-rule-group)
+- [`DELETE /api/prom/rules/{namespace}`](#delete-namespace)
 - [`GET /prometheus/api/v1/rules`](#list-rules)
 - [`GET /prometheus/api/v1/alerts`](#list-alerts)
+
+API endpoints starting with `/api/prom` are [Prometheus API-compatible](https://prometheus.io/docs/prometheus/latest/querying/api/) and the result formats can be used interchangeably.
 
 ### Log deletion endpoints
 
@@ -105,6 +113,22 @@ These endpoints are exposed by the `compactor`, `backend`, and `all` components:
 These HTTP endpoints are exposed by all individual components:
 
 - [`GET /loki/api/v1/format_query`](#format-a-logql-query)
+
+### Deprecated endpoints
+
+{{< admonition type="note" >}}
+The following endpoints are deprecated.While they still exist and work, they should not be used for new deployments.
+Existing deployments should upgrade to use the supported endpoints.
+{{< /admonition >}}
+
+| Deprecated | Replacement |
+| ---------- | ----------- |
+| `POST /api/prom/push` | [`POST /loki/api/v1/push`](#ingest-logs) |
+| `GET /api/prom/tail` | [`GET /loki/api/v1/tail`](#stream-logs) |
+| `GET /api/prom/query` | [`GET /loki/api/v1/query`](#query-logs-at-a-single-point-in-time) |
+| `GET /api/prom/label` | [`GET /loki/api/v1/labels`](#query-labels) |
+| `GET /api/prom/label/<name>/values` | [`GET /loki/api/v1/label/<name>/values`](#query-label-values) |
+| `GET /api/prom/series` | [`GET /loki/api/v1/series`](#query-streams) |
 
 ## Format
 

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -37,20 +37,6 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 ## Main / Unreleased
 
-### Breaking change: Removal of deprecated `/api/prom` API endpoints
-
-The legacy Prometheus-compatible `/api/prom` endpoints that were deprecated in Loki 2.x have been removed:
-
-| Removed endpoint  | Replacement |
-| ----------------- | ----------- |
-| `/api/prom/push`  | [Ingest logs](https://grafana.com/docs/loki/<LOKI_VERSION>/reference/loki-http-api/#ingest-logs) |
-| `/api/prom/tail`  | [Stream logs](https://grafana.com/docs/loki/<LOKI_VERSION>/reference/loki-http-api/#stream-logs) |
-| `/api/prom/query` | [Query logs at a single point in time](https://grafana.com/docs/loki/<LOKI_VERSION>/reference/loki-http-api/#query-logs-at-a-single-point-in-time) |
-| `/api/prom/label` | [Query labels](https://grafana.com/docs/loki/<LOKI_VERSION>/reference/loki-http-api/#query-labels) |
-| `/api/prom/rules` | [Rules endpoints](https://grafana.com/docs/loki/<LOKI_VERSION>/reference/loki-http-api/#rules-endpoints) |
-
-You must migrate any clients, dashboards, or automation that still use these endpoints to their `/loki/api/v1/` equivalents before upgrading. Requests to the removed endpoints will result in `404` errors.
-
 ### Breaking change: Removal of various configuration options
 
 - The deprecated per-tenant setting `unordered_writes` has been removed. Loki now always allows unordered writes.

--- a/examples/getting-started/docker-compose.yaml
+++ b/examples/getting-started/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - minio
     healthcheck:
-      test: ["CMD", "/usr/bin/loki", "-health"]
+      test: [ "CMD", "/usr/bin/loki", "-health" ]
       start_period: 30s
       interval: 10s
       timeout: 5s
@@ -35,7 +35,7 @@ services:
     volumes:
       - ./loki-config.yaml:/etc/loki/config.yaml
     healthcheck:
-      test: ["CMD", "/usr/bin/loki", "-health"]
+      test: [ "CMD", "/usr/bin/loki", "-health" ]
       start_period: 30s
       interval: 10s
       timeout: 5s
@@ -50,7 +50,7 @@ services:
     volumes:
       - ./alloy-local-config.yaml:/etc/alloy/config.alloy:ro
       - /var/run/docker.sock:/var/run/docker.sock
-    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    command:  run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
     ports:
       - 12345:12345
     depends_on:
@@ -77,7 +77,7 @@ services:
     volumes:
       - ./.data/minio:/data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      test: [ "CMD", "curl", "-f", "http://localhost:9000/minio/health/live" ]
       interval: 15s
       timeout: 20s
       retries: 5
@@ -113,11 +113,7 @@ services:
     ports:
       - "3000:3000"
     healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1",
-        ]
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -135,13 +131,14 @@ services:
     depends_on:
       - gateway
     healthcheck:
-      test: ["CMD", "/usr/bin/loki", "-health"]
+      test: [ "CMD", "/usr/bin/loki", "-health" ]
       start_period: 30s
       interval: 30s
       timeout: 10s
       retries: 5
     networks:
       - loki
+    
 
   gateway:
     image: nginx:latest
@@ -171,6 +168,20 @@ services:
               auth_basic off;
             }
 
+            location = /api/prom/push {
+              proxy_pass       http://write:3100\$$request_uri;
+            }
+
+            location = /api/prom/tail {
+              proxy_pass       http://read:3100\$$request_uri;
+              proxy_set_header Upgrade \$$http_upgrade;
+              proxy_set_header Connection "upgrade";
+            }
+
+            location ~ /api/prom/.* {
+              proxy_pass       http://read:3100\$$request_uri;
+            }
+
             location = /loki/api/v1/push {
               proxy_pass       http://write:3100\$$request_uri;
             }
@@ -197,6 +208,7 @@ services:
       retries: 5
     networks:
       - loki
+  
 
   flog:
     image: mingrammer/flog

--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -172,7 +172,7 @@ func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objsto
 		wrapped,
 	)
 	s.processor = newProcessor(
-		NewTOCAlignedMultiBuilder(builderFactory, int(cfg.TargetObjectSize)),
+		NewTOCAlignedMultiBuilder(builderFactory, int(cfg.BuilderConfig.TargetObjectSize)),
 		records,
 		flushCommitter,
 		cfg.IdleFlushTimeout,

--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -173,7 +173,7 @@ func (c *DefaultClient) Series(matchers []string, start, end time.Time, quiet bo
 	return &seriesResponse, nil
 }
 
-// LiveTailQueryConn uses /loki/api/v1/tail to set up a websocket connection and returns it
+// LiveTailQueryConn uses /api/prom/tail to set up a websocket connection and returns it
 func (c *DefaultClient) LiveTailQueryConn(queryStr string, delayFor time.Duration, limit int, start time.Time, quiet bool) (*websocket.Conn, error) {
 	params := util.NewQueryStringBuilder()
 	params.SetString("query", queryStr)

--- a/pkg/loghttp/legacy/labels.go
+++ b/pkg/loghttp/legacy/labels.go
@@ -1,0 +1,6 @@
+package loghttp
+
+// LabelResponse represents the http json response to a label query
+type LabelResponse struct {
+	Values []string `json:"values,omitempty"`
+}

--- a/pkg/loghttp/legacy/query.go
+++ b/pkg/loghttp/legacy/query.go
@@ -1,0 +1,22 @@
+package loghttp
+
+import (
+	"time"
+)
+
+// QueryResponse represents the http json response to a label query
+type QueryResponse struct {
+	Streams []*Stream `json:"streams,omitempty"`
+}
+
+// Stream represents a log stream.  It includes a set of log entries and their labels.
+type Stream struct {
+	Labels  string  `json:"labels"`
+	Entries []Entry `json:"entries"`
+}
+
+// Entry represents a log entry.  It includes a log message and the time it occurred at.
+type Entry struct {
+	Timestamp time.Time `json:"ts"`
+	Line      string    `json:"line"`
+}

--- a/pkg/loghttp/push/otlplabels/labels.go
+++ b/pkg/loghttp/push/otlplabels/labels.go
@@ -125,12 +125,11 @@ func ResourceAttrsToStreamLabels(attrs pcommon.Map, otlpConfig OTLPConfig, disco
 			return false
 		}
 
-		switch action {
-		case IndexLabel:
+		if action == IndexLabel {
 			for _, lbl := range attributeAsLabels {
 				result.StreamLabels[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
 			}
-		case StructuredMetadata:
+		} else if action == StructuredMetadata {
 			result.StructuredMetadata = append(result.StructuredMetadata, attributeAsLabels...)
 		}
 

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -28,12 +28,14 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/analytics"
+	"github.com/grafana/loki/v3/pkg/loghttp"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/runtime"
 	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 	"github.com/grafana/loki/v3/pkg/util/unmarshal"
+	unmarshal2 "github.com/grafana/loki/v3/pkg/util/unmarshal/legacy"
 )
 
 var (
@@ -370,7 +372,11 @@ func parsePushRequestBody(r *http.Request, maxRecvMsgSize int, maxDecompressedSi
 
 		// todo once https://github.com/weaveworks/common/commit/73225442af7da93ec8f6a6e2f7c8aafaee3f8840 is in Loki.
 		// We can try to pass the body as bytes.buffer instead to avoid reading into another buffer.
-		err = unmarshal.DecodePushRequest(body, &req)
+		if loghttp.GetVersion(r.RequestURI) == loghttp.VersionV1 {
+			err = unmarshal.DecodePushRequest(body, &req)
+		} else {
+			err = unmarshal2.DecodePushRequest(body, &req)
+		}
 
 		if err != nil {
 			return nil, err

--- a/pkg/loghttp/query.go
+++ b/pkg/loghttp/query.go
@@ -13,7 +13,11 @@ import (
 	json "github.com/json-iterator/go"
 	"github.com/prometheus/common/model"
 
+	"github.com/grafana/dskit/httpgrpc"
+
 	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/util"
 )
@@ -523,6 +527,23 @@ func ParseRangeQuery(r *http.Request) (*RangeQuery, error) {
 
 	if result.Interval < 0 {
 		return nil, errNegativeInterval
+	}
+
+	if GetVersion(r.URL.Path) == VersionLegacy {
+		result.Query, err = parseRegexQuery(r)
+		if err != nil {
+			return nil, httpgrpc.Errorf(http.StatusBadRequest, "%s", err.Error())
+		}
+
+		expr, err := syntax.ParseExpr(result.Query)
+		if err != nil {
+			return nil, err
+		}
+
+		// short circuit metric queries
+		if _, ok := expr.(syntax.SampleExpr); ok {
+			return nil, httpgrpc.Errorf(http.StatusBadRequest, "legacy endpoints only support %s result type", logqlmodel.ValueTypeStreams)
+		}
 	}
 
 	return &result, nil

--- a/pkg/loghttp/versions.go
+++ b/pkg/loghttp/versions.go
@@ -1,0 +1,23 @@
+package loghttp
+
+import (
+	"strings"
+)
+
+// Version holds a loghttp version
+type Version int
+
+// Valid Version values
+const (
+	VersionLegacy = Version(iota)
+	VersionV1
+)
+
+// GetVersion returns the loghttp version for a given path.
+func GetVersion(uri string) Version {
+	if strings.Contains(strings.ToLower(uri), "/loki/api/v1") {
+		return VersionV1
+	}
+
+	return VersionLegacy
+}

--- a/pkg/loghttp/versions_test.go
+++ b/pkg/loghttp/versions_test.go
@@ -1,0 +1,33 @@
+package loghttp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GetVersion(t *testing.T) {
+	require.Equal(t, GetVersion("/loki/api/v1/query_range"), VersionV1)
+	require.Equal(t, GetVersion("/loki/api/v1/query"), VersionV1)
+	require.Equal(t, GetVersion("/loki/api/v1/labels"), VersionV1)
+	require.Equal(t, GetVersion("/loki/api/v1/label/{name}/values"), VersionV1)
+	require.Equal(t, GetVersion("/loki/api/v1/tail"), VersionV1)
+
+	require.Equal(t, GetVersion("/api/prom/query"), VersionLegacy)
+	require.Equal(t, GetVersion("/api/prom/label"), VersionLegacy)
+	require.Equal(t, GetVersion("/api/prom/label/{name}/values"), VersionLegacy)
+	require.Equal(t, GetVersion("/api/prom/tail"), VersionLegacy)
+
+	require.Equal(t, GetVersion("/LOKI/api/v1/query_range"), VersionV1)
+	require.Equal(t, GetVersion("/LOKI/api/v1/query"), VersionV1)
+	require.Equal(t, GetVersion("/LOKI/api/v1/labels"), VersionV1)
+	require.Equal(t, GetVersion("/LOKI/api/v1/label/{name}/values"), VersionV1)
+	require.Equal(t, GetVersion("/LOKI/api/v1/tail"), VersionV1)
+
+	require.Equal(t, GetVersion("/API/prom/query"), VersionLegacy)
+	require.Equal(t, GetVersion("/API/prom/label"), VersionLegacy)
+	require.Equal(t, GetVersion("/API/prom/label/{name}/values"), VersionLegacy)
+	require.Equal(t, GetVersion("/API/prom/tail"), VersionLegacy)
+
+	require.NotEqual(t, int64(VersionV1), int64(VersionLegacy))
+}

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -414,6 +414,7 @@ func (t *Loki) initDistributor() (services.Service, error) {
 		t.InternalServer.HTTP.Path("/distributor/ring").Methods("GET", "POST").Handler(t.distributor)
 	}
 
+	t.Server.HTTP.Path(constants.PathPromPush).Methods("POST").Handler(lokiPushHandler)
 	t.Server.HTTP.Path(constants.PathLokiPush).Methods("POST").Handler(lokiPushHandler)
 	t.Server.HTTP.Path("/otlp/v1/logs").Methods("POST").Handler(otlpPushHandler)
 	return t.distributor, nil
@@ -689,6 +690,16 @@ func (t *Loki) initQuerier() (services.Service, error) {
 		router.Path(constants.PathLokiIndexVolumeRange).Methods("GET", "POST").Handler(volumeRangeHTTPMiddleware.Wrap(httpHandler))
 		router.Path(constants.PathLokiPatterns).Methods("GET", "POST").Handler(httpHandler)
 
+		router.Path(constants.PathPromQuery).Methods("GET", "POST").Handler(
+			middleware.Merge(
+				httpMiddleware,
+				querier.WrapQuerySpanAndTimeout("query.LogQuery", t.Overrides),
+			).Wrap(httpHandler),
+		)
+
+		router.Path(constants.PathPromLabel).Methods("GET", "POST").Handler(labelsHTTPMiddleware.Wrap(httpHandler))
+		router.Path(constants.PathPromLabelNameValues).Methods("GET", "POST").Handler(labelsHTTPMiddleware.Wrap(httpHandler))
+		router.Path(constants.PathPromSeries).Methods("GET", "POST").Handler(seriesHTTPMiddleware.Wrap(httpHandler))
 	}
 
 	// We always want to register tail routes externally, tail requests are different from normal queries, they
@@ -702,6 +713,7 @@ func (t *Loki) initQuerier() (services.Service, error) {
 	// on the external router.
 	tailQuerier := tail.NewQuerier(t.ingesterQuerier, t.Querier, deleteStore, t.Overrides, t.Cfg.Querier.TailMaxDuration, tail.NewMetrics(prometheus.DefaultRegisterer), log.With(util_log.Logger, "component", "tail-querier"))
 	t.Server.HTTP.Path(constants.PathLokiTail).Methods("GET", "POST").Handler(httpMiddleware.Wrap(http.HandlerFunc(tailQuerier.TailHandler)))
+	t.Server.HTTP.Path(constants.PathPromTail).Methods("GET", "POST").Handler(httpMiddleware.Wrap(http.HandlerFunc(tailQuerier.TailHandler)))
 
 	internalMiddlewares := []queryrangebase.Middleware{
 		serverutil.RecoveryMiddleware,
@@ -1283,11 +1295,17 @@ func (t *Loki) initQueryFrontend() (_ services.Service, err error) {
 	t.Server.HTTP.Path(constants.PathLokiIndexShards).Methods("GET", "POST").Handler(frontendHandler)
 	t.Server.HTTP.Path(constants.PathLokiIndexVolume).Methods("GET", "POST").Handler(frontendHandler)
 	t.Server.HTTP.Path(constants.PathLokiIndexVolumeRange).Methods("GET", "POST").Handler(frontendHandler)
+	t.Server.HTTP.Path(constants.PathPromQuery).Methods("GET", "POST").Handler(frontendHandler)
+	t.Server.HTTP.Path(constants.PathPromLabel).Methods("GET", "POST").Handler(frontendHandler)
+	t.Server.HTTP.Path(constants.PathPromLabelNameValues).Methods("GET", "POST").Handler(frontendHandler)
+	t.Server.HTTP.Path(constants.PathPromSeries).Methods("GET", "POST").Handler(frontendHandler)
+
 	// Only register tailing requests if this process does not act as a Querier
 	// If this process is also a Querier the Querier will register the tail endpoints.
 	if !t.isModuleActive(Querier) {
 		// defer tail endpoints to the default handler
 		t.Server.HTTP.Path(constants.PathLokiTail).Methods("GET", "POST").Handler(defaultHandler)
+		t.Server.HTTP.Path(constants.PathPromTail).Methods("GET", "POST").Handler(defaultHandler)
 	}
 
 	if t.frontend == nil {
@@ -1586,6 +1604,14 @@ func (t *Loki) initRuler() (_ services.Service, err error) {
 		// Prometheus Rule API Routes
 		t.Server.HTTP.Path(constants.PathPrometheusRules).Methods("GET").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.rulerAPI.PrometheusRules)))
 		t.Server.HTTP.Path(constants.PathPrometheusAlerts).Methods("GET").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.rulerAPI.PrometheusAlerts)))
+
+		// Ruler Legacy API Routes
+		t.Server.HTTP.Path(constants.PathPromRules).Methods("GET").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.rulerAPI.ListRules)))
+		t.Server.HTTP.Path(constants.PathPromRulesNamespace).Methods("GET").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.rulerAPI.ListRules)))
+		t.Server.HTTP.Path(constants.PathPromRulesNamespace).Methods("POST").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.rulerAPI.CreateRuleGroup)))
+		t.Server.HTTP.Path(constants.PathPromRulesNamespace).Methods("DELETE").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.rulerAPI.DeleteNamespace)))
+		t.Server.HTTP.Path(constants.PathPromRulesNamespaceGroup).Methods("GET").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.rulerAPI.GetRuleGroup)))
+		t.Server.HTTP.Path(constants.PathPromRulesNamespaceGroup).Methods("DELETE").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.rulerAPI.DeleteRuleGroup)))
 
 		// Ruler API Routes
 		t.Server.HTTP.Path(constants.PathLokiRules).Methods("GET").Handler(t.HTTPAuthMiddleware.Wrap(http.HandlerFunc(t.rulerAPI.ListRules)))

--- a/pkg/lokifrontend/frontend/v1/frontend_test.go
+++ b/pkg/lokifrontend/frontend/v1/frontend_test.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
+	"github.com/grafana/loki/v3/pkg/loghttp"
 	"github.com/grafana/loki/v3/pkg/lokifrontend/frontend/transport"
 	"github.com/grafana/loki/v3/pkg/lokifrontend/frontend/v1/frontendv1pb"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange"
@@ -61,12 +62,12 @@ func init() {
 const (
 	query        = "/loki/api/v1/query_range?end=1536716898&query=sum%28container_memory_rss%29+by+%28namespace%29&start=1536673680&step=120"
 	responseBody = `{"status":"success","data":{"resultType":"Matrix","result":[{"metric":{"foo":"bar"},"values":[[1536673680,"137"],[1536673780,"137"]]}]}}`
-	labelQuery   = `/loki/api/v1/label/foo/values`
+	labelQuery   = `/api/prom/label/foo/values`
 )
 
 func TestFrontend(t *testing.T) {
 	handler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
-		return &queryrange.LokiLabelNamesResponse{Data: []string{"Hello", "world"}, Version: 1}, nil
+		return &queryrange.LokiLabelNamesResponse{Data: []string{"Hello", "world"}, Version: uint32(loghttp.VersionV1)}, nil
 	})
 	test := func(addr string, _ *Frontend) {
 		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/%s", addr, labelQuery), nil)
@@ -82,7 +83,7 @@ func TestFrontend(t *testing.T) {
 		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
-		assert.JSONEq(t, `{"status":"success","data":["Hello","world"]}`, string(body))
+		assert.JSONEq(t, `{"values":["Hello", "world"]}`, string(body))
 	}
 
 	testFrontend(t, defaultFrontendConfig(), handler, test, false, nil)
@@ -98,7 +99,7 @@ func TestFrontendPropagateTrace(t *testing.T) {
 		traceID := sp.SpanContext().TraceID().String()
 		observedTraceID <- traceID
 
-		return &queryrange.LokiLabelNamesResponse{Data: []string{"Hello", "world"}, Version: 1}, nil
+		return &queryrange.LokiLabelNamesResponse{Data: []string{"Hello", "world"}, Version: uint32(loghttp.VersionV1)}, nil
 	})
 
 	test := func(addr string, _ *Frontend) {
@@ -125,7 +126,7 @@ func TestFrontendPropagateTrace(t *testing.T) {
 		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
-		assert.JSONEq(t, `{"status":"success","data":["Hello","world"]}`, string(body))
+		assert.JSONEq(t, `{"values":["Hello", "world"]}`, string(body))
 
 		// Query should do one call.
 		assert.Equal(t, traceID, <-observedTraceID)
@@ -202,7 +203,7 @@ func TestFrontendCancel(t *testing.T) {
 
 func TestFrontendMetricsCleanup(t *testing.T) {
 	handler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
-		return &queryrange.LokiLabelNamesResponse{Data: []string{"Hello", "world"}, Version: 1}, nil
+		return &queryrange.LokiLabelNamesResponse{Data: []string{"Hello", "world"}, Version: uint32(loghttp.VersionV1)}, nil
 	})
 
 	for _, matchMaxConcurrency := range []bool{false, true} {
@@ -222,7 +223,7 @@ func TestFrontendMetricsCleanup(t *testing.T) {
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
-			assert.JSONEq(t, `{"status":"success","data":["Hello","world"]}`, string(body))
+			assert.JSONEq(t, `{"values":["Hello", "world"]}`, string(body))
 
 			require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 				# HELP loki_query_frontend_queue_length Number of queries in the queue.

--- a/pkg/push/types.go
+++ b/pkg/push/types.go
@@ -27,6 +27,31 @@ type Entry struct {
 	Parsed             LabelsAdapter `protobuf:"bytes,4,opt,name=parsed,proto3" json:"parsed,omitempty"`
 }
 
+// MarshalJSON implements json.Marshaler.
+// In Loki, this method should only be used by the
+// Legacy encoder used when hitting the deprecated /api/promt/query endpoint.
+// We will ignore the categorized labels and only return the stream labels.
+func (m *Stream) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Labels  string  `json:"labels"`
+		Entries []Entry `json:"entries"`
+	}{
+		Labels:  m.Labels,
+		Entries: m.Entries,
+	})
+}
+
+// MarshalJSON implements json.Marshaler.
+// In Loki, this method should only be used by the
+// Legacy encoder used when hitting the deprecated /api/promt/query endpoint.
+// We will ignore the structured metadata.
+func (m *Entry) MarshalJSON() ([]byte, error) {
+	type raw Entry
+	e := raw(*m)
+	e.StructuredMetadata = nil
+	return json.Marshal(e)
+}
+
 // LabelAdapter should be a copy of the Prometheus labels.Label type.
 // We cannot import Prometheus in this package because it would create many dependencies
 // in other projects importing this package. Instead, we copy the definition here, which should

--- a/pkg/querier/handler.go
+++ b/pkg/querier/handler.go
@@ -62,7 +62,7 @@ func (h *Handler) Do(ctx context.Context, req queryrangebase.Request) (queryrang
 
 		return &queryrange.LokiSeriesResponse{
 			Status:     "success",
-			Version:    1,
+			Version:    uint32(loghttp.VersionV1),
 			Data:       result.Series,
 			Statistics: statResult,
 		}, nil
@@ -74,7 +74,7 @@ func (h *Handler) Do(ctx context.Context, req queryrangebase.Request) (queryrang
 
 		return &queryrange.LokiLabelNamesResponse{
 			Status:  "success",
-			Version: 1,
+			Version: uint32(loghttp.VersionV1),
 			Data:    res.Values,
 		}, nil
 	case *logproto.IndexStatsRequest:

--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -42,6 +42,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
 	"github.com/grafana/loki/v3/pkg/util/marshal"
+	marshal_legacy "github.com/grafana/loki/v3/pkg/util/marshal/legacy"
 	"github.com/grafana/loki/v3/pkg/util/querylimits"
 )
 
@@ -673,11 +674,12 @@ func (Codec) DecodeHTTPGrpcResponse(r *httpgrpc.HTTPResponse, req queryrangebase
 }
 
 func (Codec) EncodeHTTPGrpcResponse(_ context.Context, req *httpgrpc.HTTPRequest, res queryrangebase.Response) (*httpgrpc.HTTPResponse, error) {
+	version := loghttp.GetVersion(req.Url)
 	var buf bytes.Buffer
 
 	encodingFlags := httpreq.ExtractEncodingFlagsFromProto(req)
 
-	err := encodeResponseJSONTo(res, &buf, encodingFlags)
+	err := encodeResponseJSONTo(version, res, &buf, encodingFlags)
 	if err != nil {
 		return nil, err
 	}
@@ -775,6 +777,7 @@ func (c Codec) EncodeRequest(ctx context.Context, r queryrangebase.Request) (*ht
 			params["storeChunks"] = []string{string(b)}
 		}
 		u := &url.URL{
+			// the request could come /api/prom/query but we want to only use the new api.
 			Path:     "/loki/api/v1/query_range",
 			RawQuery: params.Encode(),
 		}
@@ -838,6 +841,7 @@ func (c Codec) EncodeRequest(ctx context.Context, r queryrangebase.Request) (*ht
 			params["shards"] = request.Shards
 		}
 		u := &url.URL{
+			// the request could come /api/prom/query but we want to only use the new api.
 			Path:     "/loki/api/v1/query",
 			RawQuery: params.Encode(),
 		}
@@ -1084,7 +1088,7 @@ func decodeResponseJSONFrom(buf []byte, req queryrangebase.Request, headers http
 
 		return &LokiSeriesResponse{
 			Status:  resp.Status,
-			Version: 1,
+			Version: uint32(loghttp.GetVersion(req.Path)),
 			Headers: httpResponseHeadersToPromResponseHeaders(headers),
 			Data:    resp.Data,
 		}, nil
@@ -1095,7 +1099,7 @@ func decodeResponseJSONFrom(buf []byte, req queryrangebase.Request, headers http
 		}
 		return &LokiLabelNamesResponse{
 			Status:  resp.Status,
-			Version: 1,
+			Version: uint32(loghttp.GetVersion(req.Path())),
 			Data:    resp.Data,
 			Headers: httpResponseHeadersToPromResponseHeaders(headers),
 		}, nil
@@ -1179,18 +1183,20 @@ func decodeResponseJSONFrom(buf []byte, req queryrangebase.Request, headers http
 				return nil, err
 			}
 
+			var path string
 			switch r := req.(type) {
-			case *LokiRequest, *LokiInstantRequest:
-				// do nothing
+			case *LokiRequest:
+				path = r.GetPath()
+			case *LokiInstantRequest:
+				path = r.GetPath()
 			default:
 				return nil, fmt.Errorf("expected *LokiRequest or *LokiInstantRequest, got (%T)", r)
 			}
-
 			return &LokiResponse{
 				Status:     resp.Status,
 				Direction:  params.Direction(),
 				Limit:      params.Limit(),
-				Version:    1,
+				Version:    uint32(loghttp.GetVersion(path)),
 				Statistics: resp.Data.Statistics,
 				Data: LokiData{
 					ResultType: loghttp.ResultTypeStream,
@@ -1290,17 +1296,18 @@ func (Codec) EncodeResponse(ctx context.Context, req *http.Request, res queryran
 	}
 
 	// Default to JSON.
+	version := loghttp.GetVersion(req.RequestURI)
 	encodingFlags := httpreq.ExtractEncodingFlags(req)
-	return encodeResponseJSON(ctx, res, encodingFlags)
+	return encodeResponseJSON(ctx, version, res, encodingFlags)
 }
 
-func encodeResponseJSON(ctx context.Context, res queryrangebase.Response, encodeFlags httpreq.EncodingFlags) (*http.Response, error) {
+func encodeResponseJSON(ctx context.Context, version loghttp.Version, res queryrangebase.Response, encodeFlags httpreq.EncodingFlags) (*http.Response, error) {
 	_, sp := tracer.Start(ctx, "codec.EncodeResponse")
 	defer sp.End()
 
 	var buf bytes.Buffer
 
-	err := encodeResponseJSONTo(res, &buf, encodeFlags)
+	err := encodeResponseJSONTo(version, res, &buf, encodeFlags)
 	if err != nil {
 		return nil, err
 	}
@@ -1317,7 +1324,7 @@ func encodeResponseJSON(ctx context.Context, res queryrangebase.Response, encode
 	return &resp, nil
 }
 
-func encodeResponseJSONTo(res queryrangebase.Response, w io.Writer, encodeFlags httpreq.EncodingFlags) error {
+func encodeResponseJSONTo(version loghttp.Version, res queryrangebase.Response, w io.Writer, encodeFlags httpreq.EncodingFlags) error {
 	switch response := res.(type) {
 	case *LokiPromResponse:
 		return response.encodeTo(w)
@@ -1330,8 +1337,18 @@ func encodeResponseJSONTo(res queryrangebase.Response, w io.Writer, encodeFlags 
 				Entries: stream.Entries,
 			}
 		}
-		if err := marshal.WriteQueryResponseJSON(logqlmodel.Streams(streams), response.Warnings, response.Statistics, w, encodeFlags); err != nil {
-			return err
+		if version == loghttp.VersionLegacy {
+			result := logqlmodel.Result{
+				Data:       logqlmodel.Streams(streams),
+				Statistics: response.Statistics,
+			}
+			if err := marshal_legacy.WriteQueryResponseJSON(result, w); err != nil {
+				return err
+			}
+		} else {
+			if err := marshal.WriteQueryResponseJSON(logqlmodel.Streams(streams), response.Warnings, response.Statistics, w, encodeFlags); err != nil {
+				return err
+			}
 		}
 	case *MergedSeriesResponseView:
 		if err := WriteSeriesResponseViewJSON(response, w); err != nil {
@@ -1342,8 +1359,14 @@ func encodeResponseJSONTo(res queryrangebase.Response, w io.Writer, encodeFlags 
 			return err
 		}
 	case *LokiLabelNamesResponse:
-		if err := marshal.WriteLabelResponseJSON(response.Data, w); err != nil {
-			return err
+		if loghttp.Version(response.Version) == loghttp.VersionLegacy {
+			if err := marshal_legacy.WriteLabelResponseJSON(logproto.LabelResponse{Values: response.Data}, w); err != nil {
+				return err
+			}
+		} else {
+			if err := marshal.WriteLabelResponseJSON(response.Data, w); err != nil {
+				return err
+			}
 		}
 	case *IndexStatsResponse:
 		if err := marshal.WriteIndexStatsResponseJSON(response.Response, w); err != nil {
@@ -2141,12 +2164,12 @@ func NewEmptyResponse(r queryrangebase.Request) (queryrangebase.Response, error)
 	case *LokiSeriesRequest:
 		return &LokiSeriesResponse{
 			Status:  loghttp.QueryStatusSuccess,
-			Version: 1,
+			Version: uint32(loghttp.GetVersion(req.Path)),
 		}, nil
 	case *LabelRequest:
 		return &LokiLabelNamesResponse{
 			Status:  loghttp.QueryStatusSuccess,
-			Version: 1,
+			Version: uint32(loghttp.GetVersion(req.Path())),
 		}, nil
 	case *LokiInstantRequest:
 		// instant queries in the frontend are always metrics queries.
@@ -2173,7 +2196,7 @@ func NewEmptyResponse(r queryrangebase.Request) (queryrangebase.Response, error)
 			Status:    loghttp.QueryStatusSuccess,
 			Direction: req.Direction,
 			Limit:     req.Limit,
-			Version:   1,
+			Version:   uint32(loghttp.GetVersion(req.Path)),
 			Data: LokiData{
 				ResultType: loghttp.ResultTypeStream,
 			},

--- a/pkg/querier/queryrange/codec_test.go
+++ b/pkg/querier/queryrange/codec_test.go
@@ -89,7 +89,22 @@ func Test_codec_EncodeDecodeRequest(t *testing.T) {
 				AST: syntax.MustParseExpr(`{foo="bar"}`),
 			},
 		}, false},
-
+		{"legacy query_range with refexp", func() (*http.Request, error) {
+			return http.NewRequest(http.MethodGet,
+				fmt.Sprintf(`/api/prom/query?start=%d&end=%d&query={foo="bar"}&interval=10&limit=200&direction=BACKWARD&regexp=foo`, start.UnixNano(), end.UnixNano()), nil)
+		}, &LokiRequest{
+			Query:     `{foo="bar"} |~ "foo"`,
+			Limit:     200,
+			Step:      14000, // step is expected in ms; calculated default if request param not present
+			Interval:  10000, // interval is expected in ms
+			Direction: logproto.BACKWARD,
+			Path:      "/api/prom/query",
+			StartTs:   start,
+			EndTs:     end,
+			Plan: &plan.QueryPlan{
+				AST: syntax.MustParseExpr(`{foo="bar"} |~ "foo"`),
+			},
+		}, false},
 		{"series", func() (*http.Request, error) {
 			return http.NewRequest(http.MethodGet,
 				fmt.Sprintf(`/series?start=%d&end=%d&match={foo="bar"}`, start.UnixNano(), end.UnixNano()), nil)
@@ -473,7 +488,7 @@ func Test_codec_DecodeResponse(t *testing.T) {
 				Status:    loghttp.QueryStatusSuccess,
 				Direction: logproto.FORWARD,
 				Limit:     100,
-				Version:   1,
+				Version:   uint32(loghttp.VersionV1),
 				Data: LokiData{
 					ResultType: loghttp.ResultTypeStream,
 					Result:     logStreams,
@@ -488,7 +503,7 @@ func Test_codec_DecodeResponse(t *testing.T) {
 				Status:    loghttp.QueryStatusSuccess,
 				Direction: logproto.FORWARD,
 				Limit:     100,
-				Version:   1,
+				Version:   uint32(loghttp.VersionV1),
 				Data: LokiData{
 					ResultType: loghttp.ResultTypeStream,
 					Result:     logStreamsWithStructuredMetadata,
@@ -503,7 +518,7 @@ func Test_codec_DecodeResponse(t *testing.T) {
 				Status:    loghttp.QueryStatusSuccess,
 				Direction: logproto.FORWARD,
 				Limit:     100,
-				Version:   1,
+				Version:   uint32(loghttp.VersionV1),
 				Data: LokiData{
 					ResultType: loghttp.ResultTypeStream,
 					Result:     logStreamsWithCategories,
@@ -511,17 +526,39 @@ func Test_codec_DecodeResponse(t *testing.T) {
 				Statistics: statsResult,
 			}, "",
 		},
-
+		{
+			"streams legacy", &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(streamsString))},
+			&LokiRequest{Direction: logproto.FORWARD, Limit: 100, Path: "/api/prom/query_range"},
+			&LokiResponse{
+				Status:    loghttp.QueryStatusSuccess,
+				Direction: logproto.FORWARD,
+				Limit:     100,
+				Version:   uint32(loghttp.VersionLegacy),
+				Data: LokiData{
+					ResultType: loghttp.ResultTypeStream,
+					Result:     logStreams,
+				},
+				Statistics: statsResult,
+			}, "",
+		},
 		{
 			"series", &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(seriesString))},
 			&LokiSeriesRequest{Path: "/loki/api/v1/series"},
 			&LokiSeriesResponse{
 				Status:  "success",
-				Version: 1,
+				Version: uint32(loghttp.VersionV1),
 				Data:    seriesData,
 			}, "",
 		},
-
+		{
+			"labels legacy", &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(labelsString))},
+			NewLabelRequest(time.Now(), time.Now(), "", "", "/api/prom/label"),
+			&LokiLabelNamesResponse{
+				Status:  "success",
+				Version: uint32(loghttp.VersionLegacy),
+				Data:    labelsData,
+			}, "",
+		},
 		{
 			"index stats", &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(indexStatsString))},
 			&logproto.IndexStatsRequest{},
@@ -1195,7 +1232,7 @@ func Test_codec_EncodeResponse(t *testing.T) {
 				Status:    loghttp.QueryStatusSuccess,
 				Direction: logproto.FORWARD,
 				Limit:     100,
-				Version:   1,
+				Version:   uint32(loghttp.VersionV1),
 				Data: LokiData{
 					ResultType: loghttp.ResultTypeStream,
 					Result:     logStreams,
@@ -1209,7 +1246,7 @@ func Test_codec_EncodeResponse(t *testing.T) {
 				Status:    loghttp.QueryStatusSuccess,
 				Direction: logproto.FORWARD,
 				Limit:     100,
-				Version:   1,
+				Version:   uint32(loghttp.VersionV1),
 				Data: LokiData{
 					ResultType: loghttp.ResultTypeStream,
 					Result:     logStreamsWithCategories,
@@ -1221,12 +1258,25 @@ func Test_codec_EncodeResponse(t *testing.T) {
 				httpreq.LokiEncodingFlagsHeader: string(httpreq.FlagCategorizeLabels),
 			},
 		},
-
+		{
+			"loki legacy", "/api/promt/query",
+			&LokiResponse{
+				Status:    loghttp.QueryStatusSuccess,
+				Direction: logproto.FORWARD,
+				Limit:     100,
+				Version:   uint32(loghttp.VersionLegacy),
+				Data: LokiData{
+					ResultType: loghttp.ResultTypeStream,
+					Result:     logStreams,
+				},
+				Statistics: statsResult,
+			}, streamsStringLegacy, false, nil,
+		},
 		{
 			"loki series", "/loki/api/v1/series",
 			&LokiSeriesResponse{
 				Status:  "success",
-				Version: 1,
+				Version: uint32(loghttp.VersionV1),
 				Data:    seriesData,
 			}, seriesString, false, nil,
 		},
@@ -1234,11 +1284,18 @@ func Test_codec_EncodeResponse(t *testing.T) {
 			"loki labels", "/loki/api/v1/labels",
 			&LokiLabelNamesResponse{
 				Status:  "success",
-				Version: 1,
+				Version: uint32(loghttp.VersionV1),
 				Data:    labelsData,
 			}, labelsString, false, nil,
 		},
-
+		{
+			"loki labels legacy", "/api/prom/label",
+			&LokiLabelNamesResponse{
+				Status:  "success",
+				Version: uint32(loghttp.VersionLegacy),
+				Data:    labelsData,
+			}, labelsLegacyString, false, nil,
+		},
 		{
 			"index stats", "/loki/api/v1/index/stats",
 			&IndexStatsResponse{
@@ -2307,6 +2364,8 @@ var (
 			]
 		}
 	}`
+	streamsStringLegacy = `{
+		` + statsResultString + `"streams":[{"labels":"{test=\"test\"}","entries":[{"ts":"1970-01-02T10:17:36.789012345Z","line":"super line"}]},{"labels":"{test=\"test\", x=\"a\", y=\"b\"}","entries":[{"ts":"1970-01-02T10:17:36.789012346Z","line":"super line2"}]}, {"labels":"{test=\"test\", x=\"a\", y=\"b\", z=\"text\"}","entries":[{"ts":"1970-01-02T10:17:36.789012346Z","line":"super line3 z=text"}]}]}`
 	logStreamsWithStructuredMetadata = []logproto.Stream{
 		{
 			Labels: `{test="test"}`,
@@ -2413,6 +2472,12 @@ var (
 	labelsString = `{
 		"status": "success",
 		"data": [
+			"foo",
+			"bar"
+		]
+	}`
+	labelsLegacyString = `{
+		"values": [
 			"foo",
 			"bar"
 		]
@@ -2630,7 +2695,7 @@ func Benchmark_CodecDecodeLogs(b *testing.B) {
 	resp, err := DefaultCodec.EncodeResponse(ctx, req, &LokiResponse{
 		Status:    loghttp.QueryStatusSuccess,
 		Direction: logproto.BACKWARD,
-		Version:   1,
+		Version:   uint32(loghttp.VersionV1),
 		Limit:     1000,
 		Data: LokiData{
 			ResultType: loghttp.ResultTypeStream,

--- a/pkg/querier/queryrange/engine_router_test.go
+++ b/pkg/querier/queryrange/engine_router_test.go
@@ -283,7 +283,7 @@ func Test_engineRouter_Do(t *testing.T) {
 			Status:    loghttp.QueryStatusSuccess,
 			Direction: r.(*LokiRequest).Direction,
 			Limit:     r.(*LokiRequest).Limit,
-			Version:   1,
+			Version:   uint32(loghttp.VersionV1),
 			Data: LokiData{
 				ResultType: loghttp.ResultTypeStream,
 				Result: []logproto.Stream{
@@ -336,7 +336,7 @@ func Test_engineRouter_Do(t *testing.T) {
 				Limit:     1000,
 				Step:      1000,
 				Direction: logproto.BACKWARD,
-				Path:      "/loki/api/v1/query_range",
+				Path:      "/api/prom/query_range",
 				Plan: &plan.QueryPlan{
 					AST: syntax.MustParseExpr(`{foo="bar"}`),
 				},

--- a/pkg/querier/queryrange/labels_cache_test.go
+++ b/pkg/querier/queryrange/labels_cache_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/loghttp"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
@@ -87,7 +88,7 @@ func TestLabelsCache(t *testing.T) {
 	composeLabelsResp := func(lbls []string, splits int64) *LokiLabelNamesResponse {
 		return &LokiLabelNamesResponse{
 			Status:  "success",
-			Version: 1,
+			Version: uint32(loghttp.VersionV1),
 			Data:    lbls,
 			Statistics: stats.Result{
 				Summary: stats.Summary{
@@ -274,7 +275,7 @@ func TestLabelCache_freshness(t *testing.T) {
 
 			labelsResp := &LokiLabelNamesResponse{
 				Status:  "success",
-				Version: 1,
+				Version: uint32(loghttp.VersionV1),
 				Data:    []string{"bar", "buzz"},
 				Statistics: stats.Result{
 					Summary: stats.Summary{

--- a/pkg/querier/queryrange/log_result_cache.go
+++ b/pkg/querier/queryrange/log_result_cache.go
@@ -385,7 +385,7 @@ func emptyResponse(lokiReq *LokiRequest) *LokiResponse {
 		Statistics: stats.Result{},
 		Direction:  lokiReq.Direction,
 		Limit:      lokiReq.Limit,
-		Version:    1,
+		Version:    uint32(loghttp.GetVersion(lokiReq.Path)),
 		Data: LokiData{
 			ResultType: loghttp.ResultTypeStream,
 			Result:     []logproto.Stream{},

--- a/pkg/querier/queryrange/log_result_cache_test.go
+++ b/pkg/querier/queryrange/log_result_cache_test.go
@@ -707,9 +707,9 @@ func TestExtractLokiResponse(t *testing.T) {
 			extractThrough: time.Unix(52, 0),
 			expectedResp: mergeLokiResponse(
 				// empty responses here are to avoid failing test due to difference in count of subqueries in query stats
-				&LokiResponse{Limit: entriesLimit, Version: 1},
-				&LokiResponse{Limit: entriesLimit, Version: 1},
-				&LokiResponse{Limit: entriesLimit, Version: 1},
+				&LokiResponse{Limit: entriesLimit},
+				&LokiResponse{Limit: entriesLimit},
+				&LokiResponse{Limit: entriesLimit},
 			),
 		},
 	} {
@@ -761,7 +761,7 @@ func nonEmptyResponse(lokiReq *LokiRequest, start, end time.Time, labels string)
 		Statistics: stats.Result{},
 		Direction:  lokiReq.Direction,
 		Limit:      lokiReq.Limit,
-		Version:    1,
+		Version:    uint32(loghttp.GetVersion(lokiReq.Path)),
 		Data: LokiData{
 			ResultType: loghttp.ResultTypeStream,
 			Result: []logproto.Stream{

--- a/pkg/querier/queryrange/parquet_test.go
+++ b/pkg/querier/queryrange/parquet_test.go
@@ -42,7 +42,7 @@ func TestEncodeLogsParquet(t *testing.T) {
 		Status:    loghttp.QueryStatusSuccess,
 		Direction: logproto.FORWARD,
 		Limit:     100,
-		Version:   1,
+		Version:   uint32(loghttp.VersionV1),
 		Data: LokiData{
 			ResultType: loghttp.ResultTypeStream,
 			Result:     logStreams,

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -245,13 +245,15 @@ func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (que
 		return ast.next.Do(ctx, r)
 	}
 
+	var path string
 	switch r := r.(type) {
-	case *LokiRequest, *LokiInstantRequest:
-		// do nothing
+	case *LokiRequest:
+		path = r.GetPath()
+	case *LokiInstantRequest:
+		path = r.GetPath()
 	default:
 		return nil, fmt.Errorf("expected *LokiRequest or *LokiInstantRequest, got (%T)", r)
 	}
-
 	query := ast.ng.Query(ctx, logql.ParamsWithExpressionOverride{Params: params, ExpressionOverride: parsed})
 
 	res, err := query.Exec(ctx)
@@ -290,7 +292,7 @@ func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (que
 			Status:     loghttp.QueryStatusSuccess,
 			Direction:  params.Direction(),
 			Limit:      params.Limit(),
-			Version:    1,
+			Version:    uint32(loghttp.GetVersion(path)),
 			Statistics: res.Statistics,
 			Data: LokiData{
 				ResultType: loghttp.ResultTypeStream,

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -1202,7 +1202,7 @@ func Test_getOperation(t *testing.T) {
 		},
 		{
 			name:       "range_query_prom",
-			path:       "/loki/api/v1/query_range",
+			path:       "/api/prom/query",
 			expectedOp: QueryRangeOp,
 		},
 		{
@@ -1217,7 +1217,7 @@ func Test_getOperation(t *testing.T) {
 		},
 		{
 			name:       "series_query_prom",
-			path:       "/loki/api/v1/series",
+			path:       "/api/prom/series",
 			expectedOp: SeriesOp,
 		},
 		{
@@ -1227,7 +1227,7 @@ func Test_getOperation(t *testing.T) {
 		},
 		{
 			name:       "labels_query_prom",
-			path:       "/loki/api/v1/labels",
+			path:       "/api/prom/labels",
 			expectedOp: LabelNamesOp,
 		},
 		{
@@ -1237,7 +1237,7 @@ func Test_getOperation(t *testing.T) {
 		},
 		{
 			name:       "labels_query_prom",
-			path:       "/loki/api/v1/label",
+			path:       "/api/prom/label",
 			expectedOp: LabelNamesOp,
 		},
 		{
@@ -1247,7 +1247,7 @@ func Test_getOperation(t *testing.T) {
 		},
 		{
 			name:       "label_values_query_prom",
-			path:       "/loki/api/v1/label/__name__/values",
+			path:       "/api/prom/label/__name__/values",
 			expectedOp: LabelNamesOp,
 		},
 		{

--- a/pkg/querier/queryrange/serialize.go
+++ b/pkg/querier/queryrange/serialize.go
@@ -3,6 +3,7 @@ package queryrange
 import (
 	"net/http"
 
+	"github.com/grafana/loki/v3/pkg/loghttp"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
 	serverutil "github.com/grafana/loki/v3/pkg/util/server"
@@ -82,8 +83,9 @@ func (rt *serializeHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	version := loghttp.GetVersion(r.RequestURI)
 	encodingFlags := httpreq.ExtractEncodingFlags(r)
-	if err := encodeResponseJSONTo(response, w, encodingFlags); err != nil {
+	if err := encodeResponseJSONTo(version, response, w, encodingFlags); err != nil {
 		serverutil.WriteError(err, w)
 	}
 }

--- a/pkg/querier/queryrange/serialize_test.go
+++ b/pkg/querier/queryrange/serialize_test.go
@@ -26,7 +26,7 @@ func TestResponseFormat(t *testing.T) {
 		expectedRespone string
 	}{
 		{
-			url: "/loki/api/v1/query",
+			url: "/api/prom/query",
 			response: &LokiResponse{
 				Direction: logproto.BACKWARD,
 				Limit:     200,
@@ -49,17 +49,18 @@ func TestResponseFormat(t *testing.T) {
 			},
 			expectedCode: http.StatusOK,
 			expectedRespone: `{
-				"status": "success",
-				"data": {
-				  "resultType": "streams",
 				` + statsResultString + `
-				  "result": [{
-					"stream": {"foo": "bar"},
-					"values": [
-					  ["123456789012345", "super line"]
-					]
-				  }]
-				}
+				"streams": [
+				  {
+				    "labels": "{foo=\"bar\"}",
+				    "entries": [
+				      {
+				        "line": "super line",
+				        "ts": "1970-01-02T10:17:36.789012345Z"
+				      }
+				    ]
+				  }
+				]
 			}`,
 		},
 		{

--- a/pkg/querier/queryrange/series_cache_test.go
+++ b/pkg/querier/queryrange/series_cache_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/loghttp"
+
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
@@ -96,7 +98,7 @@ func TestSeriesCache(t *testing.T) {
 
 		return &LokiSeriesResponse{
 			Status:  "success",
-			Version: 1,
+			Version: uint32(loghttp.VersionV1),
 			Data:    data,
 			Statistics: stats.Result{
 				Summary: stats.Summary{
@@ -319,7 +321,7 @@ func TestSeriesCache_freshness(t *testing.T) {
 
 			seriesResp := &LokiSeriesResponse{
 				Status:  "success",
-				Version: 1,
+				Version: uint32(loghttp.VersionV1),
 				Data: []logproto.SeriesIdentifier{
 					{
 						Labels: []logproto.SeriesIdentifier_LabelsEntry{{Key: "cluster", Value: "eu-west"}, {Key: "namespace", Value: "prod"}},

--- a/pkg/querier/queryrange/split_by_interval_test.go
+++ b/pkg/querier/queryrange/split_by_interval_test.go
@@ -1376,7 +1376,7 @@ func Test_splitByInterval_Do(t *testing.T) {
 			Status:    loghttp.QueryStatusSuccess,
 			Direction: r.(*LokiRequest).Direction,
 			Limit:     r.(*LokiRequest).Limit,
-			Version:   1,
+			Version:   uint32(loghttp.VersionV1),
 			Data: LokiData{
 				ResultType: loghttp.ResultTypeStream,
 				Result: []logproto.Stream{
@@ -1415,7 +1415,7 @@ func Test_splitByInterval_Do(t *testing.T) {
 				Limit:     1000,
 				Step:      1,
 				Direction: logproto.BACKWARD,
-				Path:      "/loki/api/v1/query_range",
+				Path:      "/api/prom/query_range",
 			},
 			&LokiResponse{
 				Status:     loghttp.QueryStatusSuccess,
@@ -1448,7 +1448,7 @@ func Test_splitByInterval_Do(t *testing.T) {
 				Limit:     1000,
 				Step:      1,
 				Direction: logproto.FORWARD,
-				Path:      "/loki/api/v1/query_range",
+				Path:      "/api/prom/query_range",
 			},
 			&LokiResponse{
 				Status:     loghttp.QueryStatusSuccess,
@@ -1481,7 +1481,7 @@ func Test_splitByInterval_Do(t *testing.T) {
 				Limit:     2,
 				Step:      1,
 				Direction: logproto.FORWARD,
-				Path:      "/loki/api/v1/query_range",
+				Path:      "/api/prom/query_range",
 			},
 			&LokiResponse{
 				Status:     loghttp.QueryStatusSuccess,
@@ -1512,7 +1512,7 @@ func Test_splitByInterval_Do(t *testing.T) {
 				Limit:     2,
 				Step:      1,
 				Direction: logproto.BACKWARD,
-				Path:      "/loki/api/v1/query_range",
+				Path:      "/api/prom/query_range",
 			},
 			&LokiResponse{
 				Status:     loghttp.QueryStatusSuccess,
@@ -1550,7 +1550,7 @@ func Test_series_splitByInterval_Do(t *testing.T) {
 	next := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
 		return &LokiSeriesResponse{
 			Status:  "success",
-			Version: 1,
+			Version: uint32(loghttp.VersionV1),
 			Data: []logproto.SeriesIdentifier{
 				{
 					Labels: []logproto.SeriesIdentifier_LabelsEntry{
@@ -1782,7 +1782,7 @@ func Test_ExitEarly(t *testing.T) {
 			Status:    loghttp.QueryStatusSuccess,
 			Direction: r.(*LokiRequest).Direction,
 			Limit:     r.(*LokiRequest).Limit,
-			Version:   1,
+			Version:   uint32(loghttp.VersionV1),
 			Data: LokiData{
 				ResultType: loghttp.ResultTypeStream,
 				Result: []logproto.Stream{
@@ -1817,7 +1817,7 @@ func Test_ExitEarly(t *testing.T) {
 		Limit:     2,
 		Step:      1,
 		Direction: logproto.FORWARD,
-		Path:      "/loki/api/v1/query_range",
+		Path:      "/api/prom/query_range",
 	}
 
 	expected := &LokiResponse{
@@ -1869,7 +1869,7 @@ func Test_DoesntDeadlock(t *testing.T) {
 			Status:    loghttp.QueryStatusSuccess,
 			Direction: r.(*LokiRequest).Direction,
 			Limit:     r.(*LokiRequest).Limit,
-			Version:   1,
+			Version:   uint32(loghttp.VersionV1),
 			Data: LokiData{
 				ResultType: loghttp.ResultTypeStream,
 				Result: []logproto.Stream{
@@ -1905,7 +1905,7 @@ func Test_DoesntDeadlock(t *testing.T) {
 		Limit:     uint32(n / 2),
 		Step:      1,
 		Direction: logproto.FORWARD,
-		Path:      "/loki/api/v1/query_range",
+		Path:      "/api/prom/query_range",
 	}
 
 	ctx := user.InjectOrgID(context.Background(), "1")

--- a/pkg/querier/tail/http.go
+++ b/pkg/querier/tail/http.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/util/marshal"
+	marshal_legacy "github.com/grafana/loki/v3/pkg/util/marshal/legacy"
 	serverutil "github.com/grafana/loki/v3/pkg/util/server"
 )
 
@@ -43,6 +44,7 @@ func (q *Querier) TailHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	encodingFlags := httpreq.ExtractEncodingFlags(r)
+	version := loghttp.GetVersion(r.RequestURI)
 
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
@@ -110,7 +112,11 @@ func (q *Querier) TailHandler(w http.ResponseWriter, r *http.Request) {
 		select {
 		case response = <-responseChan:
 			var err error
-			err = marshal.WriteTailResponseJSON(*response, connWriter, encodingFlags)
+			if version == loghttp.VersionV1 {
+				err = marshal.WriteTailResponseJSON(*response, connWriter, encodingFlags)
+			} else {
+				err = marshal_legacy.WriteTailResponseJSON(*response, conn)
+			}
 			if err != nil {
 				level.Error(logger).Log("msg", "Error writing to websocket", "err", err)
 				if err := conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseInternalServerErr, err.Error())); err != nil {

--- a/pkg/querytee/goldfish/manager.go
+++ b/pkg/querytee/goldfish/manager.go
@@ -528,7 +528,7 @@ func extractTenant(r *http.Request) string {
 }
 
 func getQueryType(path, query string) string {
-	isQueryRoute := path == constants.PathLokiQueryRange || path == constants.PathLokiQuery
+	isQueryRoute := path == constants.PathLokiQueryRange || path == constants.PathLokiQuery || path == constants.PathPromQuery
 	if isQueryRoute {
 		if query == "" {
 			return unknown
@@ -543,13 +543,13 @@ func getQueryType(path, query string) string {
 		}
 		return qt
 	}
-	if path == constants.PathLokiSeries {
+	if path == constants.PathLokiSeries || path == constants.PathPromSeries {
 		return logql.QueryTypeSeries
 	}
-	if path == constants.PathLokiLabels || path == constants.PathLokiLabel {
+	if path == constants.PathLokiLabels || path == constants.PathLokiLabel || path == constants.PathPromLabel {
 		return logql.QueryTypeLabels
 	}
-	if strings.HasPrefix(path, constants.PathLokiLabel+"/") && strings.HasSuffix(path, "/values") {
+	if strings.HasPrefix(path, constants.PathPromLabelPrefix) && strings.HasSuffix(path, constants.PathPromLabelSuffix) {
 		return logql.QueryTypeLabels
 	}
 	if path == constants.PathLokiIndexStats {

--- a/pkg/querytee/proxy_endpoint_test.go
+++ b/pkg/querytee/proxy_endpoint_test.go
@@ -321,15 +321,49 @@ func Test_ProxyEndpoint_QueryRequests(t *testing.T) {
 }
 
 func Test_ProxyEndpoint_WriteRequests(t *testing.T) {
+	var (
+		requestCount atomic.Uint64
+		wg           sync.WaitGroup
+		testHandler  http.HandlerFunc
+	)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer wg.Done()
+		defer requestCount.Add(1)
+		testHandler(w, r)
+	})
+	backend1 := httptest.NewServer(handler)
+	defer backend1.Close()
+	backendURL1, err := url.Parse(backend1.URL)
+	require.NoError(t, err)
+
+	backend2 := httptest.NewServer(handler)
+	defer backend2.Close()
+	backendURL2, err := url.Parse(backend2.URL)
+	require.NoError(t, err)
+
+	proxyBackend1, err := NewProxyBackend("backend-1", backendURL1, time.Second, true)
+	require.NoError(t, err)
+	proxyBackend2, err := NewProxyBackend("backend-2", backendURL2, time.Second, false)
+	require.NoError(t, err)
+	backends := []*ProxyBackend{
+		proxyBackend1,
+		proxyBackend2.WithFilter(regexp.MustCompile(regexp.QuoteMeta(constants.PathLokiPush))),
+	}
+	// endpoint := createTestEndpoint(backends, "test", nil, false)
+	metrics := NewProxyMetrics(nil)
+	logger := log.NewNopLogger()
+	endpoint := NewProxyEndpoint(backends, "test", metrics, logger, nil, false)
+
 	for _, tc := range []struct {
-		name           string
-		requestFactory func(*testing.T) *http.Request
-		handlerFactory func(*testing.T) http.HandlerFunc
-		counts         int
+		name    string
+		request func(*testing.T) *http.Request
+		handler func(*testing.T) http.HandlerFunc
+		counts  int
 	}{
 		{
 			name: "POST-request",
-			requestFactory: func(t *testing.T) *http.Request {
+			request: func(t *testing.T) *http.Request {
 				r, err := http.NewRequest("POST", "http://test"+constants.PathLokiPush, strings.NewReader(`{"streams":[{"stream":{"job":"test"},"values":[["1","test"]]}]}`))
 				r.Header.Set("test-X", "test-X-value")
 				r.Header["Content-Type"] = []string{"application/json"}
@@ -337,7 +371,7 @@ func Test_ProxyEndpoint_WriteRequests(t *testing.T) {
 				require.NoError(t, err)
 				return r
 			},
-			handlerFactory: func(t *testing.T) http.HandlerFunc {
+			handler: func(t *testing.T) http.HandlerFunc {
 				return func(w http.ResponseWriter, r *http.Request) {
 					require.Equal(t, "test-X-value", r.Header.Get("test-X"))
 					w.WriteHeader(204)
@@ -347,7 +381,7 @@ func Test_ProxyEndpoint_WriteRequests(t *testing.T) {
 		},
 		{
 			name: "POST-filter-accept-encoding",
-			requestFactory: func(t *testing.T) *http.Request {
+			request: func(t *testing.T) *http.Request {
 				r, err := http.NewRequest("POST", "http://test"+constants.PathLokiPush, strings.NewReader(`{"streams":[{"stream":{"job":"test"},"values":[["1","test"]]}]}`))
 				r.Header["Content-Type"] = []string{"application/json"}
 				r.Header.Set("Accept-Encoding", "gzip")
@@ -355,7 +389,7 @@ func Test_ProxyEndpoint_WriteRequests(t *testing.T) {
 				require.NoError(t, err)
 				return r
 			},
-			handlerFactory: func(t *testing.T) http.HandlerFunc {
+			handler: func(t *testing.T) http.HandlerFunc {
 				return func(w http.ResponseWriter, r *http.Request) {
 					require.Equal(t, 0, len(r.Header.Values("Accept-Encoding")))
 					w.WriteHeader(204)
@@ -365,14 +399,14 @@ func Test_ProxyEndpoint_WriteRequests(t *testing.T) {
 		},
 		{
 			name: "POST-filtered",
-			requestFactory: func(t *testing.T) *http.Request {
-				r, err := http.NewRequest("POST", "http://test/prom/api/push", strings.NewReader(`{"streams":[{"stream":{"job":"test"},"values":[["1","test"]]}]}`))
+			request: func(t *testing.T) *http.Request {
+				r, err := http.NewRequest("POST", "http://test"+constants.PathPromPush, strings.NewReader(`{"streams":[{"stream":{"job":"test"},"values":[["1","test"]]}]}`))
 				r.Header["Content-Type"] = []string{"application/json"}
 				r.Header.Set("X-Scope-OrgID", "test-tenant")
 				require.NoError(t, err)
 				return r
 			},
-			handlerFactory: func(_ *testing.T) http.HandlerFunc {
+			handler: func(_ *testing.T) http.HandlerFunc {
 				return func(w http.ResponseWriter, _ *http.Request) {
 					w.WriteHeader(204)
 				}
@@ -381,48 +415,21 @@ func Test_ProxyEndpoint_WriteRequests(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			var (
-				requestCount atomic.Uint64
-				wg           sync.WaitGroup
-			)
-
 			// reset request count
 			requestCount.Store(0)
 			wg.Add(tc.counts)
 
-			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				requestCount.Add(1)
-				tc.handlerFactory(t)(w, r)
-				wg.Done()
-			})
+			if tc.handler == nil {
+				testHandler = func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(204)
+				}
 
-			backend1 := httptest.NewServer(handler)
-			defer backend1.Close()
-			backendURL1, err := url.Parse(backend1.URL)
-			require.NoError(t, err)
-
-			backend2 := httptest.NewServer(handler)
-			defer backend2.Close()
-			backendURL2, err := url.Parse(backend2.URL)
-			require.NoError(t, err)
-
-			proxyBackend1, err := NewProxyBackend("backend-1", backendURL1, time.Second, true)
-			require.NoError(t, err)
-
-			proxyBackend2, err := NewProxyBackend("backend-2", backendURL2, time.Second, false)
-			require.NoError(t, err)
-
-			backends := []*ProxyBackend{
-				proxyBackend1,
-				proxyBackend2.WithFilter(regexp.MustCompile(regexp.QuoteMeta(constants.PathLokiPush))),
+			} else {
+				testHandler = tc.handler(t)
 			}
 
-			metrics := NewProxyMetrics(nil)
-			logger := log.NewNopLogger()
-			endpoint := NewProxyEndpoint(backends, "test", metrics, logger, nil, false)
-
 			w := httptest.NewRecorder()
-			endpoint.ServeHTTP(w, tc.requestFactory(t))
+			endpoint.ServeHTTP(w, tc.request(t))
 			require.Equal(t, 204, w.Code)
 
 			done := make(chan struct{})
@@ -434,7 +441,6 @@ func Test_ProxyEndpoint_WriteRequests(t *testing.T) {
 			select {
 			case <-done:
 			case <-time.After(10 * time.Second):
-				t.Log("expected", tc.counts, "actual", requestCount.Load())
 				t.Fatal("timeout waiting for backend requests to complete")
 			}
 			require.Equal(t, uint64(tc.counts), requestCount.Load())

--- a/pkg/querytee/proxy_test.go
+++ b/pkg/querytee/proxy_test.go
@@ -87,12 +87,12 @@ func Test_Proxy_RequestsForwarding(t *testing.T) {
 		"two backends with the same path prefix": {
 			backends: []mockedBackend{
 				{
-					pathPrefix: "/loki/api/v1",
-					handler:    mockQueryResponse("/loki/api/v1"+constants.PathLokiQuery, 200, querySingleMetric1),
+					pathPrefix: "/api/prom",
+					handler:    mockQueryResponse("/api/prom"+constants.PathLokiQuery, 200, querySingleMetric1),
 				},
 				{
-					pathPrefix: "/loki/api/v1",
-					handler:    mockQueryResponse("/loki/api/v1"+constants.PathLokiQuery, 200, querySingleMetric2),
+					pathPrefix: "/api/prom",
+					handler:    mockQueryResponse("/api/prom"+constants.PathLokiQuery, 200, querySingleMetric2),
 				},
 			},
 			preferredBackendIdx: 0,

--- a/pkg/ruler/base/api_test.go
+++ b/pkg/ruler/base/api_test.go
@@ -541,7 +541,7 @@ func TestRuler_PrometheusRules(t *testing.T) {
 
 			a := NewAPI(r, r.store, log.NewNopLogger())
 
-			req := requestFor(t, "GET", "https://localhost:8080/loki/api/v1/rules"+tc.queryParams, nil, tc.tenantID)
+			req := requestFor(t, "GET", "https://localhost:8080/api/prom/api/v1/rules"+tc.queryParams, nil, tc.tenantID)
 			w := httptest.NewRecorder()
 			a.PrometheusRules(w, req)
 
@@ -619,7 +619,7 @@ func TestRuler_PrometheusAlerts(t *testing.T) {
 
 			a := NewAPI(r, r.store, log.NewNopLogger())
 
-			req := requestFor(t, http.MethodGet, "https://localhost:8080/loki/api/v1/alerts", nil, test.tenantID)
+			req := requestFor(t, http.MethodGet, "https://localhost:8080/api/prom/api/v1/alerts", nil, test.tenantID)
 			w := httptest.NewRecorder()
 			a.PrometheusAlerts(w, req)
 

--- a/pkg/storage/chunk/client/aws/s3_storage_client_test.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client_test.go
@@ -606,7 +606,7 @@ func TestPutObject_SwiftRejects_AWSChunked(t *testing.T) {
 			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
 <Error>
   <Code>NotImplemented</Code>
-  <Message>Transferring payloads in multiple chunks using aws-chunked is not supported</Message>
+  <Message>Transfering payloads in multiple chunks using aws-chunked is not supported</Message>
 </Error>`))
 			return
 		}

--- a/pkg/tool/client/client.go
+++ b/pkg/tool/client/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/grafana/dskit/crypto/tls"
 	"github.com/pkg/errors"
@@ -16,7 +17,8 @@ import (
 )
 
 const (
-	rulerAPIPath = "/loki/api/v1/rules"
+	rulerAPIPath  = "/loki/api/v1/rules"
+	legacyAPIPath = "/api/prom/rules"
 )
 
 var (
@@ -26,12 +28,13 @@ var (
 
 // Config is used to configure a Ruler Client
 type Config struct {
-	User      string `yaml:"user"`
-	Key       string `yaml:"key"`
-	Address   string `yaml:"address"`
-	ID        string `yaml:"id"`
-	TLS       tls.ClientConfig
-	AuthToken string `yaml:"auth_token"`
+	User            string `yaml:"user"`
+	Key             string `yaml:"key"`
+	Address         string `yaml:"address"`
+	ID              string `yaml:"id"`
+	TLS             tls.ClientConfig
+	UseLegacyRoutes bool   `yaml:"use_legacy_routes"`
+	AuthToken       string `yaml:"auth_token"`
 }
 
 // LokiClient is used to get and load rules into a Loki ruler
@@ -79,6 +82,9 @@ func New(cfg Config) (*LokiClient, error) {
 	}
 
 	path := rulerAPIPath
+	if cfg.UseLegacyRoutes {
+		path = legacyAPIPath
+	}
 
 	return &LokiClient{
 		user:      cfg.User,
@@ -89,6 +95,20 @@ func New(cfg Config) (*LokiClient, error) {
 		apiPath:   path,
 		authToken: cfg.AuthToken,
 	}, nil
+}
+
+// Query executes a PromQL query against the Cortex cluster.
+func (r *LokiClient) Query(ctx context.Context, query string) (*http.Response, error) {
+
+	query = fmt.Sprintf("query=%s&time=%d", query, time.Now().Unix())
+	escapedQuery := url.PathEscape(query)
+
+	res, err := r.doRequest(ctx, "/api/prom/api/v1/query?"+escapedQuery, "GET", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }
 
 func (r *LokiClient) doRequest(ctx context.Context, path, method string, payload []byte) (*http.Response, error) {

--- a/pkg/tool/commands/rules.go
+++ b/pkg/tool/commands/rules.go
@@ -140,6 +140,11 @@ func (r *RuleCommand) Register(app *kingpin.Application) {
 			Required().
 			StringVar(&r.ClientConfig.ID)
 
+		c.Flag("use-legacy-routes", "If set, API requests to loki will use the legacy /api/prom/ routes, alternatively set LOKI_USE_LEGACY_ROUTES.").
+			Default("false").
+			Envar("LOKI_USE_LEGACY_ROUTES").
+			BoolVar(&r.ClientConfig.UseLegacyRoutes)
+
 		c.Flag("tls-ca-path", "TLS CA certificate to verify Loki API as part of mTLS, alternatively set LOKI_TLS_CA_PATH.").
 			Default("").
 			Envar("LOKI_TLS_CA_PATH").
@@ -240,6 +245,11 @@ func (r *RuleCommand) setup(_ *kingpin.ParseContext) error {
 		ruleLoadTimestamp,
 		ruleLoadSuccessTimestamp,
 	)
+
+	// Loki's non-legacy route does not match Cortex, but the legacy one does.
+	if r.Backend == rules.LokiBackend {
+		r.ClientConfig.UseLegacyRoutes = true
+	}
 
 	cli, err := client.New(r.ClientConfig)
 	if err != nil {

--- a/pkg/util/constants/api_paths.go
+++ b/pkg/util/constants/api_paths.go
@@ -33,6 +33,22 @@ const (
 	PathLokiPush = "/loki/api/v1/push"
 )
 
+// Prometheus-compatible (legacy) API path constants.
+const (
+	PathPromQuery           = "/api/prom/query"
+	PathPromLabel           = "/api/prom/label"
+	PathPromLabelPrefix     = "/api/prom/label/" // prefix for path matching
+	PathPromLabelSuffix     = "/values"
+	PathPromLabelNameValues = "/api/prom/label/{name}/values"
+	PathPromSeries          = "/api/prom/series"
+	PathPromPush            = "/api/prom/push"
+	PathPromTail            = "/api/prom/tail"
+	// Ruler
+	PathPromRules               = "/api/prom/rules"
+	PathPromRulesNamespace      = "/api/prom/rules/{namespace}"
+	PathPromRulesNamespaceGroup = "/api/prom/rules/{namespace}/{groupName}"
+)
+
 // Prometheus API paths (used by ruler).
 const (
 	PathPrometheusRules  = "/prometheus/api/v1/rules"

--- a/pkg/util/marshal/legacy/marshal.go
+++ b/pkg/util/marshal/legacy/marshal.go
@@ -1,0 +1,44 @@
+// Package marshal converts internal objects to loghttp model objects.  This package is designed to work with
+// models in pkg/loghttp/legacy.
+package marshal
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/gorilla/websocket"
+	json "github.com/json-iterator/go"
+
+	loghttp "github.com/grafana/loki/v3/pkg/loghttp/legacy"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
+)
+
+// Note that the below methods directly marshal the values passed in.  This is because these objects currently marshal
+// cleanly to the legacy http protocol (because that was how it was initially implemented).  If this ever changes,
+// it will be caught by testing and we will have to handle legacy like we do v1:  1) exchange a variety of structs for
+// for loghttp model objects 2) marshal the loghttp model objects
+
+// WriteQueryResponseJSON marshals promql.Value to legacy loghttp JSON and then writes it to the provided io.Writer
+func WriteQueryResponseJSON(v logqlmodel.Result, w io.Writer) error {
+	if v.Data.Type() != logqlmodel.ValueTypeStreams {
+		return fmt.Errorf("legacy endpoints only support %s result type, current type is %s", logqlmodel.ValueTypeStreams, v.Data.Type())
+	}
+
+	j := map[string]interface{}{
+		"streams": v.Data,
+		"stats":   v.Statistics,
+	}
+
+	return json.NewEncoder(w).Encode(j)
+}
+
+// WriteLabelResponseJSON marshals the logproto.LabelResponse to legacy loghttp JSON and then writes it to the provided writer
+func WriteLabelResponseJSON(l logproto.LabelResponse, w io.Writer) error {
+	return json.NewEncoder(w).Encode(l)
+}
+
+// WriteTailResponseJSON marshals the TailResponse to legacy loghttp JSON and then writes it to the provided connection
+func WriteTailResponseJSON(r loghttp.TailResponse, c *websocket.Conn) error {
+	return c.WriteJSON(r)
+}

--- a/pkg/util/marshal/legacy/marshal_test.go
+++ b/pkg/util/marshal/legacy/marshal_test.go
@@ -1,0 +1,439 @@
+package marshal
+
+import (
+	"bytes"
+	"log"
+	"testing"
+	"time"
+
+	json "github.com/json-iterator/go"
+	"github.com/stretchr/testify/require"
+
+	loghttp "github.com/grafana/loki/v3/pkg/loghttp/legacy"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
+)
+
+// covers responses from /api/prom/query
+var queryTests = []struct {
+	actual   logqlmodel.Streams
+	expected string
+}{
+	{
+		logqlmodel.Streams{
+			logproto.Stream{
+				Entries: []logproto.Entry{
+					{
+						Timestamp: mustParse(time.RFC3339Nano, "2019-09-13T18:32:22.380001319Z"),
+						Line:      "super line",
+					},
+					{
+						Timestamp: mustParse(time.RFC3339Nano, "2019-09-13T18:32:23.380001319Z"),
+						Line:      "super line with labels",
+						StructuredMetadata: []logproto.LabelAdapter{
+							{Name: "foo", Value: "a"},
+							{Name: "bar", Value: "b"},
+						},
+					},
+				},
+				Labels: `{test="test"}`,
+			},
+		},
+		`{
+			"streams":[
+				{
+					"labels":"{test=\"test\"}",
+					"entries":[
+						{
+							"ts": "2019-09-13T18:32:22.380001319Z",
+							"line": "super line"
+						},
+						{
+							"ts": "2019-09-13T18:32:23.380001319Z",
+							"line": "super line with labels"
+						}
+					]
+				}
+			],
+			"stats" : {
+				"index": {
+					"bloomFilterTime": 0,
+					"chunkRefsLookupTime": 0,
+					"postFilterChunks": 0,
+					"totalChunks": 0,
+					"totalStreams": 0,
+					"usedBloomFilters": false,
+					"shardsDuration": 0
+				},
+				"ingester" : {
+					"store": {
+						"chunksDownloadTime": 0,
+						"congestionControlLatency": 0,
+						"totalChunksRef": 0,
+						"totalChunksDownloaded": 0,
+						"chunkRefsFetchTime": 0,
+						"queryReferencedStructuredMetadata": false,
+						"queryUsedV2Engine": false,
+				 		"pipelineWrapperFilteredLines": 0,
+						"chunk" :{
+							"compressedBytes": 0,
+							"decompressedBytes": 0,
+							"decompressedLines": 0,
+							"decompressedStructuredMetadataBytes": 0,
+							"headChunkBytes": 0,
+							"headChunkLines": 0,
+							"headChunkStructuredMetadataBytes": 0,
+							"postFilterLines": 0,
+							"totalDuplicates": 0
+						},
+						"dataobj":{
+							"pageBatches": 0,
+							"pagesDownloaded": 0,
+							"pagesDownloadedBytes": 0,
+							"pagesScanned": 0,
+							"postFilterRows": 0,
+							"postPredicateRows": 0,
+							"postPredicateDecompressedBytes": 0,
+							"postPredicateStructuredMetadataBytes": 0,
+							"prePredicateDecompressedRows": 0,
+							"prePredicateDecompressedBytes": 0,
+							"prePredicateDecompressedStructuredMetadataBytes": 0,
+							"totalPageDownloadTime": 0,
+							"totalRowsAvailable": 0,
+							"wireBytesTransferred": 0
+						}
+					},
+					"totalBatches": 0,
+					"totalChunksMatched": 0,
+					"totalLinesSent": 0,
+					"totalReached": 0
+				},
+				"querier": {
+					"querierExecTime": 0,
+					"store": {
+						"chunksDownloadTime": 0,
+						"congestionControlLatency": 0,
+						"totalChunksRef": 0,
+						"totalChunksDownloaded": 0,
+						"chunkRefsFetchTime": 0,
+						"queryReferencedStructuredMetadata": false,
+						"queryUsedV2Engine": false,
+		                "pipelineWrapperFilteredLines": 0,
+						"chunk" :{
+							"compressedBytes": 0,
+							"decompressedBytes": 0,
+							"decompressedLines": 0,
+							"decompressedStructuredMetadataBytes": 0,
+							"headChunkBytes": 0,
+							"headChunkLines": 0,
+							"headChunkStructuredMetadataBytes": 0,
+							"postFilterLines": 0,
+							"totalDuplicates": 0
+						},
+						"dataobj":{
+							"pageBatches": 0,
+							"pagesDownloaded": 0,
+							"pagesDownloadedBytes": 0,
+							"pagesScanned": 0,
+							"postFilterRows": 0,
+							"postPredicateRows": 0,
+							"postPredicateDecompressedBytes": 0,
+							"postPredicateStructuredMetadataBytes": 0,
+							"prePredicateDecompressedRows": 0,
+							"prePredicateDecompressedBytes": 0,
+							"prePredicateDecompressedStructuredMetadataBytes": 0,
+							"totalPageDownloadTime": 0,
+							"totalRowsAvailable": 0,
+							"wireBytesTransferred": 0
+						}
+					}
+				},
+				"cache": {
+					"chunk": {
+						"entriesFound": 0,
+						"entriesRequested": 0,
+						"entriesStored": 0,
+						"bytesReceived": 0,
+						"bytesSent": 0,
+						"requests": 0,
+						"downloadTime": 0,
+						"queryLengthServed": 0
+					},
+					"index": {
+						"entriesFound": 0,
+						"entriesRequested": 0,
+						"entriesStored": 0,
+						"bytesReceived": 0,
+						"bytesSent": 0,
+						"requests": 0,
+						"downloadTime": 0,
+						"queryLengthServed": 0
+					},
+					"statsResult": {
+						"entriesFound": 0,
+						"entriesRequested": 0,
+						"entriesStored": 0,
+						"bytesReceived": 0,
+						"bytesSent": 0,
+						"requests": 0,
+						"downloadTime": 0,
+						"queryLengthServed": 0
+					},
+					"seriesResult": {
+						"entriesFound": 0,
+						"entriesRequested": 0,
+						"entriesStored": 0,
+						"bytesReceived": 0,
+						"bytesSent": 0,
+						"requests": 0,
+						"downloadTime": 0,
+						"queryLengthServed": 0
+					},
+					"labelResult": {
+						"entriesFound": 0,
+						"entriesRequested": 0,
+						"entriesStored": 0,
+						"bytesReceived": 0,
+						"bytesSent": 0,
+						"requests": 0,
+						"downloadTime": 0,
+						"queryLengthServed": 0
+					},
+					"volumeResult": {
+						"entriesFound": 0,
+						"entriesRequested": 0,
+						"entriesStored": 0,
+						"bytesReceived": 0,
+						"bytesSent": 0,
+						"requests": 0,
+						"downloadTime": 0,
+						"queryLengthServed": 0
+					},
+					"instantMetricResult": {
+						"entriesFound": 0,
+						"entriesRequested": 0,
+						"entriesStored": 0,
+						"bytesReceived": 0,
+						"bytesSent": 0,
+						"requests": 0,
+						"downloadTime": 0,
+						"queryLengthServed": 0
+					},
+					"result": {
+						"entriesFound": 0,
+						"entriesRequested": 0,
+						"entriesStored": 0,
+						"bytesReceived": 0,
+						"bytesSent": 0,
+						"requests": 0,
+						"downloadTime": 0,
+						"queryLengthServed": 0
+					},
+					"logResult": {
+						"entriesFound": 0,
+						"entriesRequested": 0,
+						"entriesStored": 0,
+						"bytesReceived": 0,
+						"bytesSent": 0,
+						"requests": 0,
+						"downloadTime": 0,
+						"queryLengthServed": 0
+					},
+					"taskResult": {
+						"entriesFound": 0,
+						"entriesRequested": 0,
+						"entriesStored": 0,
+						"bytesReceived": 0,
+						"bytesSent": 0,
+						"requests": 0,
+						"downloadTime": 0,
+						"queryLengthServed": 0
+					}
+				},
+				"summary": {
+					"bytesProcessedPerSecond": 0,
+					"execTime": 0,
+					"linesProcessedPerSecond": 0,
+					"queueTime": 0,
+                    "shards": 0,
+                    "splits": 0,
+					"subqueries": 0,
+					"totalBytesProcessed": 0,
+                    "totalEntriesReturned": 0,
+					"totalLinesProcessed": 0,
+					"totalStructuredMetadataBytesProcessed": 0,
+                    "totalPostFilterLines": 0
+				}
+			}
+		}`,
+	},
+}
+
+// covers responses from /api/prom/label and /api/prom/label/{name}/values
+var labelTests = []struct {
+	actual   logproto.LabelResponse
+	expected string
+}{
+	{
+		logproto.LabelResponse{
+			Values: []string{
+				"label1",
+				"test",
+				"value",
+			},
+		},
+		`{"values": ["label1", "test", "value"]}`,
+	},
+}
+
+// covers responses from /api/prom/tail and /api/prom/tail
+var tailTests = []struct {
+	actual   loghttp.TailResponse
+	expected string
+}{
+	{
+		loghttp.TailResponse{
+			Streams: []logproto.Stream{
+				{
+					Entries: []logproto.Entry{
+						{
+							Timestamp: mustParse(time.RFC3339Nano, "2019-09-13T18:32:22.380001319Z"),
+							Line:      "super line",
+						},
+						{
+							Timestamp: mustParse(time.RFC3339Nano, "2019-09-13T18:32:23.380001319Z"),
+							Line:      "super line with labels",
+							StructuredMetadata: []logproto.LabelAdapter{
+								{Name: "foo", Value: "a"},
+								{Name: "bar", Value: "b"},
+							},
+						},
+					},
+					Labels: "{test=\"test\"}",
+				},
+			},
+			DroppedEntries: []loghttp.DroppedEntry{
+				{
+					Timestamp: mustParse(time.RFC3339Nano, "2019-09-13T18:32:22.380001319Z"),
+					Labels:    "{test=\"test\"}",
+				},
+			},
+		},
+		`{
+			"streams": [
+				{
+					"labels": "{test=\"test\"}",
+					"entries": [
+						{
+							"ts": "2019-09-13T18:32:22.380001319Z",
+							"line": "super line"
+						},
+						{
+							"ts": "2019-09-13T18:32:23.380001319Z",
+							"line": "super line with labels"
+						}
+					]
+				}
+			],
+			"dropped_entries": [
+				{
+					"Timestamp": "2019-09-13T18:32:22.380001319Z",
+					"Labels": "{test=\"test\"}"
+				}
+			]
+		}`,
+	},
+}
+
+func Test_WriteQueryResponseJSON(t *testing.T) {
+	for i, queryTest := range queryTests {
+		var b bytes.Buffer
+		err := WriteQueryResponseJSON(logqlmodel.Result{Data: queryTest.actual}, &b)
+		require.NoError(t, err)
+
+		testJSONBytesEqual(t, []byte(queryTest.expected), b.Bytes(), "Query Test %d failed", i)
+	}
+}
+
+func Test_WriteLabelResponseJSON(t *testing.T) {
+	for i, labelTest := range labelTests {
+		var b bytes.Buffer
+		err := WriteLabelResponseJSON(labelTest.actual, &b)
+		require.NoError(t, err)
+
+		testJSONBytesEqual(t, []byte(labelTest.expected), b.Bytes(), "Label Test %d failed", i)
+	}
+}
+
+func Test_MarshalTailResponse(t *testing.T) {
+	for i, tailTest := range tailTests {
+		// marshal model object
+		bytes, err := json.Marshal(tailTest.actual)
+		require.NoError(t, err)
+
+		testJSONBytesEqual(t, []byte(tailTest.expected), bytes, "Tail Test %d failed", i)
+	}
+}
+
+func Test_QueryResponseMarshalLoop(t *testing.T) {
+	for i, queryTest := range queryTests {
+		var r map[string]interface{}
+
+		err := json.Unmarshal([]byte(queryTest.expected), &r)
+		require.NoError(t, err)
+
+		jsonOut, err := json.Marshal(r)
+		require.NoError(t, err)
+
+		testJSONBytesEqual(t, []byte(queryTest.expected), jsonOut, "Query Marshal Loop %d failed", i)
+	}
+}
+
+func Test_LabelResponseMarshalLoop(t *testing.T) {
+	for i, labelTest := range labelTests {
+		var r loghttp.LabelResponse
+
+		err := json.Unmarshal([]byte(labelTest.expected), &r)
+		require.NoError(t, err)
+
+		jsonOut, err := json.Marshal(r)
+		require.NoError(t, err)
+
+		testJSONBytesEqual(t, []byte(labelTest.expected), jsonOut, "Label Marshal Loop %d failed", i)
+	}
+}
+
+func Test_TailResponseMarshalLoop(t *testing.T) {
+	for i, tailTest := range tailTests {
+		var r loghttp.TailResponse
+
+		err := json.Unmarshal([]byte(tailTest.expected), &r)
+		require.NoError(t, err)
+
+		jsonOut, err := json.Marshal(r)
+		require.NoError(t, err)
+
+		testJSONBytesEqual(t, []byte(tailTest.expected), jsonOut, "Tail Marshal Loop %d failed", i)
+	}
+}
+
+func testJSONBytesEqual(t *testing.T, expected []byte, actual []byte, msg string, args ...interface{}) {
+	var expectedValue map[string]interface{}
+	err := json.Unmarshal(expected, &expectedValue)
+	require.NoError(t, err)
+
+	var actualValue map[string]interface{}
+	err = json.Unmarshal(actual, &actualValue)
+	require.NoError(t, err)
+
+	require.Equalf(t, expectedValue, actualValue, msg, args)
+}
+
+func mustParse(l string, t string) time.Time {
+	ret, err := time.Parse(l, t)
+	if err != nil {
+		log.Fatalf("Failed to parse %s", t)
+	}
+
+	return ret
+}

--- a/pkg/util/marshal/marshal.go
+++ b/pkg/util/marshal/marshal.go
@@ -17,15 +17,26 @@ import (
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
+	marshal_legacy "github.com/grafana/loki/v3/pkg/util/marshal/legacy"
 )
 
 func WriteResponseJSON(r *http.Request, v any, w http.ResponseWriter) error {
 	switch result := v.(type) {
 	case logqlmodel.Result:
+		version := loghttp.GetVersion(r.RequestURI)
 		encodeFlags := httpreq.ExtractEncodingFlags(r)
-		return WriteQueryResponseJSON(result.Data, result.Warnings, result.Statistics, w, encodeFlags)
+		if version == loghttp.VersionV1 {
+			return WriteQueryResponseJSON(result.Data, result.Warnings, result.Statistics, w, encodeFlags)
+		}
+
+		return marshal_legacy.WriteQueryResponseJSON(result, w)
 	case *logproto.LabelResponse:
-		return WriteLabelResponseJSON(result.GetValues(), w)
+		version := loghttp.GetVersion(r.RequestURI)
+		if version == loghttp.VersionV1 {
+			return WriteLabelResponseJSON(result.GetValues(), w)
+		}
+
+		return marshal_legacy.WriteLabelResponseJSON(*result, w)
 	case *logproto.SeriesResponse:
 		return WriteSeriesResponseJSON(result.GetSeries(), w)
 	case *logproto.IndexStatsResponse:

--- a/pkg/util/unmarshal/legacy/unmarshal.go
+++ b/pkg/util/unmarshal/legacy/unmarshal.go
@@ -1,0 +1,14 @@
+package unmarshal
+
+import (
+	"io"
+
+	json "github.com/json-iterator/go"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+// DecodePushRequest directly decodes json to a logproto.PushRequest
+func DecodePushRequest(b io.Reader, r *logproto.PushRequest) error {
+	return json.NewDecoder(b).Decode(r)
+}

--- a/pkg/util/unmarshal/legacy/unmarshal_test.go
+++ b/pkg/util/unmarshal/legacy/unmarshal_test.go
@@ -1,0 +1,84 @@
+package unmarshal
+
+import (
+	"io"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+// covers requests to /api/prom/push
+var pushTests = []struct {
+	expected []logproto.Stream
+	actual   string
+}{
+	{
+		[]logproto.Stream{
+			{
+				Entries: []logproto.Entry{
+					{
+						Timestamp: mustParse(time.RFC3339Nano, "2019-09-13T18:32:22.380001319Z"),
+						Line:      "super line",
+					},
+					{
+						Timestamp: mustParse(time.RFC3339Nano, "2019-09-13T18:32:23.380001319Z"),
+						Line:      "super line with labels",
+						StructuredMetadata: []logproto.LabelAdapter{
+							{Name: "a", Value: "1"},
+							{Name: "b", Value: "2"},
+						},
+					},
+				},
+				Labels: `{test="test"}`,
+			},
+		},
+		`{
+			"streams":[
+				{
+					"labels":"{test=\"test\"}",
+					"entries":[
+						{
+							"ts": "2019-09-13T18:32:22.380001319Z",
+							"line": "super line"
+						},
+						{
+							"ts": "2019-09-13T18:32:23.380001319Z",
+							"line": "super line with labels",
+							"structuredMetadata": {
+								"a": "1",
+								"b": "2"
+							}
+						}
+					]
+				}
+			]
+		}`,
+	},
+}
+
+func Test_DecodePushRequest(t *testing.T) {
+
+	for i, pushTest := range pushTests {
+		var actual logproto.PushRequest
+		closer := io.NopCloser(strings.NewReader(pushTest.actual))
+
+		err := DecodePushRequest(closer, &actual)
+		require.NoError(t, err)
+
+		require.Equalf(t, pushTest.expected, actual.Streams, "Push Test %d failed", i)
+	}
+}
+
+func mustParse(l string, t string) time.Time {
+	ret, err := time.Parse(l, t)
+	if err != nil {
+		log.Fatalf("Failed to parse %s", t)
+	}
+
+	return ret
+}

--- a/vendor/github.com/grafana/loki/pkg/push/types.go
+++ b/vendor/github.com/grafana/loki/pkg/push/types.go
@@ -27,6 +27,31 @@ type Entry struct {
 	Parsed             LabelsAdapter `protobuf:"bytes,4,opt,name=parsed,proto3" json:"parsed,omitempty"`
 }
 
+// MarshalJSON implements json.Marshaler.
+// In Loki, this method should only be used by the
+// Legacy encoder used when hitting the deprecated /api/promt/query endpoint.
+// We will ignore the categorized labels and only return the stream labels.
+func (m *Stream) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Labels  string  `json:"labels"`
+		Entries []Entry `json:"entries"`
+	}{
+		Labels:  m.Labels,
+		Entries: m.Entries,
+	})
+}
+
+// MarshalJSON implements json.Marshaler.
+// In Loki, this method should only be used by the
+// Legacy encoder used when hitting the deprecated /api/promt/query endpoint.
+// We will ignore the structured metadata.
+func (m *Entry) MarshalJSON() ([]byte, error) {
+	type raw Entry
+	e := raw(*m)
+	e.StructuredMetadata = nil
+	return json.Marshal(e)
+}
+
 // LabelAdapter should be a copy of the Prometheus labels.Label type.
 // We cannot import Prometheus in this package because it would create many dependencies
 // in other projects importing this package. Instead, we copy the definition here, which should


### PR DESCRIPTION
This reverts commit 8d82d8560f7b780151c319d6faf945915ae885d4 on `main`