### PR TITLE
fix(dataobj): Source index ToC time range from postings sections and enable page pruning on kind

### DIFF
--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -491,10 +491,6 @@ func (b *Builder) TimeRanges() []multitenancy.TimeRange {
 	return timeRanges
 }
 
-// unionTimeRange folds the candidate range (candMin, candMax) into the
-// accumulated (curMin, curMax). A candidate whose min is zero is treated as no
-// contribution (the aggregator convention: zero min means no observations). A
-// zero accumulator is replaced by the first contributing candidate.
 func unionTimeRange(curMin, curMax, candMin, candMax time.Time) (time.Time, time.Time) {
 	if candMin.IsZero() {
 		return curMin, curMax

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -455,10 +455,33 @@ func (b *Builder) estimatedSize() int {
 }
 
 // TimeRanges returns the time range of the data in the builder, by tenant.
+// For each tenant, the range is the union of its streams and postings ranges;
+// a source with no observations (zero time range) does not contribute.
 func (b *Builder) TimeRanges() []multitenancy.TimeRange {
-	timeRanges := make([]multitenancy.TimeRange, 0, len(b.streams))
-	for tenantID, tenantStreams := range b.streams {
-		minTime, maxTime := tenantStreams.TimeRange()
+	tenantIDs := make(map[string]struct{}, len(b.streams)+len(b.postings))
+	for tenantID := range b.streams {
+		tenantIDs[tenantID] = struct{}{}
+	}
+	for tenantID := range b.postings {
+		tenantIDs[tenantID] = struct{}{}
+	}
+
+	timeRanges := make([]multitenancy.TimeRange, 0, len(tenantIDs))
+	for tenantID := range tenantIDs {
+		var minTime, maxTime time.Time
+
+		if s, ok := b.streams[tenantID]; ok {
+			sMin, sMax := s.TimeRange()
+			minTime, maxTime = unionTimeRange(minTime, maxTime, sMin, sMax)
+		}
+		if p, ok := b.postings[tenantID]; ok {
+			pMin, pMax := p.TimeRange()
+			minTime, maxTime = unionTimeRange(minTime, maxTime, pMin, pMax)
+		}
+
+		if minTime.IsZero() && maxTime.IsZero() {
+			continue
+		}
 		timeRanges = append(timeRanges, multitenancy.TimeRange{
 			Tenant:  tenantID,
 			MinTime: minTime,
@@ -466,6 +489,23 @@ func (b *Builder) TimeRanges() []multitenancy.TimeRange {
 		})
 	}
 	return timeRanges
+}
+
+// unionTimeRange folds the candidate range (candMin, candMax) into the
+// accumulated (curMin, curMax). A candidate whose min is zero is treated as no
+// contribution (the aggregator convention: zero min means no observations). A
+// zero accumulator is replaced by the first contributing candidate.
+func unionTimeRange(curMin, curMax, candMin, candMax time.Time) (time.Time, time.Time) {
+	if candMin.IsZero() {
+		return curMin, curMax
+	}
+	if curMin.IsZero() || candMin.Before(curMin) {
+		curMin = candMin
+	}
+	if curMax.IsZero() || candMax.After(curMax) {
+		curMax = candMax
+	}
+	return curMin, curMax
 }
 
 // Flush flushes all buffered data to the buffer provided. Calling Flush can result

--- a/pkg/dataobj/index/indexobj/builder_test.go
+++ b/pkg/dataobj/index/indexobj/builder_test.go
@@ -288,3 +288,54 @@ func TestBuilder_TimeRanges_StreamsAndPostingsUnion(t *testing.T) {
 	require.Equal(t, base.Add(-time.Hour), ranges[0].MinTime)
 	require.Equal(t, base.Add(2*time.Hour), ranges[0].MaxTime)
 }
+
+func TestUnionTimeRange(t *testing.T) {
+	base := time.Unix(1000, 0).UTC()
+
+	// Case 1: candidate has no data (candMin zero) -> accumulator returned unchanged.
+	min, max := unionTimeRange(base, base.Add(time.Hour), time.Time{}, time.Time{})
+	require.Equal(t, base, min)
+	require.Equal(t, base.Add(time.Hour), max)
+
+	// Case 2: accumulator zero, candidate non-zero -> candidate returned.
+	min, max = unionTimeRange(time.Time{}, time.Time{}, base, base.Add(time.Hour))
+	require.Equal(t, base, min)
+	require.Equal(t, base.Add(time.Hour), max)
+
+	// Case 3: both non-zero, candidate widens on both ends -> widened range.
+	min, max = unionTimeRange(base.Add(time.Hour), base.Add(2*time.Hour), base, base.Add(3*time.Hour))
+	require.Equal(t, base, min)
+	require.Equal(t, base.Add(3*time.Hour), max)
+
+	// Case 4: both non-zero, candidate inside accumulator -> accumulator unchanged.
+	min, max = unionTimeRange(base, base.Add(3*time.Hour), base.Add(time.Hour), base.Add(2*time.Hour))
+	require.Equal(t, base, min)
+	require.Equal(t, base.Add(3*time.Hour), max)
+
+	// Case 5: accumulator zero AND candidate zero -> both zero out.
+	min, max = unionTimeRange(time.Time{}, time.Time{}, time.Time{}, time.Time{})
+	require.True(t, min.IsZero())
+	require.True(t, max.IsZero())
+}
+
+func TestBuilder_TimeRanges_AfterReset(t *testing.T) {
+	b, err := NewBuilder(testBuilderConfig, nil)
+	require.NoError(t, err)
+
+	base := time.Unix(8000, 0).UTC()
+	tenant := "test-tenant"
+
+	// Observe a label posting so TimeRanges() is non-empty.
+	b.ObserveLabelPosting(tenant, postings.LabelObservation{
+		ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x",
+		StreamID: 1, Timestamp: base,
+	})
+
+	ranges := b.TimeRanges()
+	require.Len(t, ranges, 1)
+
+	// After Reset, TimeRanges() must be empty.
+	b.Reset()
+	ranges = b.TimeRanges()
+	require.Empty(t, ranges)
+}

--- a/pkg/dataobj/index/indexobj/builder_test.go
+++ b/pkg/dataobj/index/indexobj/builder_test.go
@@ -293,29 +293,29 @@ func TestUnionTimeRange(t *testing.T) {
 	base := time.Unix(1000, 0).UTC()
 
 	// Case 1: candidate has no data (candMin zero) -> accumulator returned unchanged.
-	min, max := unionTimeRange(base, base.Add(time.Hour), time.Time{}, time.Time{})
-	require.Equal(t, base, min)
-	require.Equal(t, base.Add(time.Hour), max)
+	gotMin, gotMax := unionTimeRange(base, base.Add(time.Hour), time.Time{}, time.Time{})
+	require.Equal(t, base, gotMin)
+	require.Equal(t, base.Add(time.Hour), gotMax)
 
 	// Case 2: accumulator zero, candidate non-zero -> candidate returned.
-	min, max = unionTimeRange(time.Time{}, time.Time{}, base, base.Add(time.Hour))
-	require.Equal(t, base, min)
-	require.Equal(t, base.Add(time.Hour), max)
+	gotMin, gotMax = unionTimeRange(time.Time{}, time.Time{}, base, base.Add(time.Hour))
+	require.Equal(t, base, gotMin)
+	require.Equal(t, base.Add(time.Hour), gotMax)
 
 	// Case 3: both non-zero, candidate widens on both ends -> widened range.
-	min, max = unionTimeRange(base.Add(time.Hour), base.Add(2*time.Hour), base, base.Add(3*time.Hour))
-	require.Equal(t, base, min)
-	require.Equal(t, base.Add(3*time.Hour), max)
+	gotMin, gotMax = unionTimeRange(base.Add(time.Hour), base.Add(2*time.Hour), base, base.Add(3*time.Hour))
+	require.Equal(t, base, gotMin)
+	require.Equal(t, base.Add(3*time.Hour), gotMax)
 
 	// Case 4: both non-zero, candidate inside accumulator -> accumulator unchanged.
-	min, max = unionTimeRange(base, base.Add(3*time.Hour), base.Add(time.Hour), base.Add(2*time.Hour))
-	require.Equal(t, base, min)
-	require.Equal(t, base.Add(3*time.Hour), max)
+	gotMin, gotMax = unionTimeRange(base, base.Add(3*time.Hour), base.Add(time.Hour), base.Add(2*time.Hour))
+	require.Equal(t, base, gotMin)
+	require.Equal(t, base.Add(3*time.Hour), gotMax)
 
 	// Case 5: accumulator zero AND candidate zero -> both zero out.
-	min, max = unionTimeRange(time.Time{}, time.Time{}, time.Time{}, time.Time{})
-	require.True(t, min.IsZero())
-	require.True(t, max.IsZero())
+	gotMin, gotMax = unionTimeRange(time.Time{}, time.Time{}, time.Time{}, time.Time{})
+	require.True(t, gotMin.IsZero())
+	require.True(t, gotMax.IsZero())
 }
 
 func TestBuilder_TimeRanges_AfterReset(t *testing.T) {

--- a/pkg/dataobj/index/indexobj/builder_test.go
+++ b/pkg/dataobj/index/indexobj/builder_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/indexpointers"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/pointers"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 )
 
@@ -200,4 +202,89 @@ func BenchmarkIndexObjBuilder_ObserveLogLine(b *testing.B) {
 			require.NoError(b, err)
 		}
 	}
+}
+
+func TestBuilder_TimeRanges_PostingsOnly(t *testing.T) {
+	b, err := NewBuilder(testBuilderConfig, nil)
+	require.NoError(t, err)
+
+	base := time.Unix(8000, 0).UTC()
+	tenant := "tenant-a"
+
+	b.ObserveLabelPosting(tenant, postings.LabelObservation{
+		ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x",
+		StreamID: 1, Timestamp: base,
+	})
+	b.ObserveLabelPosting(tenant, postings.LabelObservation{
+		ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "y",
+		StreamID: 2, Timestamp: base.Add(time.Hour),
+	})
+
+	ranges := b.TimeRanges()
+	require.Len(t, ranges, 1)
+	require.Equal(t, tenant, ranges[0].Tenant)
+	require.Equal(t, base, ranges[0].MinTime)
+	require.Equal(t, base.Add(time.Hour), ranges[0].MaxTime)
+}
+
+func TestBuilder_TimeRanges_MultiTenantUnion(t *testing.T) {
+	b, err := NewBuilder(testBuilderConfig, nil)
+	require.NoError(t, err)
+
+	base := time.Unix(9000, 0).UTC()
+
+	// tenant-a: postings only.
+	b.ObserveLabelPosting("tenant-a", postings.LabelObservation{
+		ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x",
+		StreamID: 1, Timestamp: base,
+	})
+	// tenant-b: postings only, different window.
+	b.ObserveLabelPosting("tenant-b", postings.LabelObservation{
+		ObjectPath: "/b", SectionIndex: 0, ColumnName: "app", LabelValue: "z",
+		StreamID: 1, Timestamp: base.Add(2 * time.Hour),
+	})
+
+	ranges := b.TimeRanges()
+	require.Len(t, ranges, 2)
+
+	byTenant := map[string]multitenancy.TimeRange{}
+	for _, r := range ranges {
+		byTenant[r.Tenant] = r
+	}
+	require.Equal(t, base, byTenant["tenant-a"].MinTime)
+	require.Equal(t, base, byTenant["tenant-a"].MaxTime)
+	require.Equal(t, base.Add(2*time.Hour), byTenant["tenant-b"].MinTime)
+	require.Equal(t, base.Add(2*time.Hour), byTenant["tenant-b"].MaxTime)
+}
+
+func TestBuilder_TimeRanges_StreamsAndPostingsUnion(t *testing.T) {
+	b, err := NewBuilder(testBuilderConfig, nil)
+	require.NoError(t, err)
+
+	base := time.Unix(10000, 0).UTC()
+	tenant := "tenant-a"
+
+	// Streams cover [base, base+1h]; postings extend the window on both ends.
+	_, err = b.AppendStream(tenant, streams.Stream{
+		Labels:           labels.FromStrings("app", "x"),
+		MinTimestamp:     base,
+		MaxTimestamp:     base.Add(time.Hour),
+		UncompressedSize: 1,
+	})
+	require.NoError(t, err)
+
+	b.ObserveLabelPosting(tenant, postings.LabelObservation{
+		ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x",
+		StreamID: 1, Timestamp: base.Add(-time.Hour),
+	})
+	b.ObserveLabelPosting(tenant, postings.LabelObservation{
+		ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x",
+		StreamID: 2, Timestamp: base.Add(2 * time.Hour),
+	})
+
+	ranges := b.TimeRanges()
+	require.Len(t, ranges, 1)
+	require.Equal(t, tenant, ranges[0].Tenant)
+	require.Equal(t, base.Add(-time.Hour), ranges[0].MinTime)
+	require.Equal(t, base.Add(2*time.Hour), ranges[0].MaxTime)
 }

--- a/pkg/dataobj/sections/postings/bloom_aggregator.go
+++ b/pkg/dataobj/sections/postings/bloom_aggregator.go
@@ -198,7 +198,6 @@ func (a *bloomAggregator) EstimatedSize() int {
 
 // TimeRange returns the minimum and maximum observation timestamp seen by the
 // aggregator. It returns zero time.Time values when nothing has been observed.
-// Columns that were prepared but never observed do not contribute.
 func (a *bloomAggregator) TimeRange() (time.Time, time.Time) {
 	return a.minTimestamp, a.maxTimestamp
 }

--- a/pkg/dataobj/sections/postings/bloom_aggregator.go
+++ b/pkg/dataobj/sections/postings/bloom_aggregator.go
@@ -3,6 +3,7 @@ package postings
 import (
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/bits-and-blooms/bloom/v3"
 
@@ -58,6 +59,8 @@ func (e *bloomPostingEntry) BitmapBytes() []byte {
 type bloomAggregator struct {
 	entries       map[bloomPostingKey]*bloomPostingEntry
 	estimatedSize int
+	minTimestamp  time.Time
+	maxTimestamp  time.Time
 }
 
 // newBloomAggregator creates a new bloomAggregator.
@@ -132,6 +135,14 @@ func (a *bloomAggregator) Observe(obs BloomObservation) error {
 	}
 	entry.UncompressedSize += obs.UncompressedSize
 
+	ts := obs.Timestamp.UTC()
+	if a.minTimestamp.IsZero() || ts.Before(a.minTimestamp) {
+		a.minTimestamp = ts
+	}
+	if a.maxTimestamp.IsZero() || ts.After(a.maxTimestamp) {
+		a.maxTimestamp = ts
+	}
+
 	return nil
 }
 
@@ -185,8 +196,17 @@ func (a *bloomAggregator) EstimatedSize() int {
 	return a.estimatedSize
 }
 
+// TimeRange returns the minimum and maximum observation timestamp seen by the
+// aggregator. It returns zero time.Time values when nothing has been observed.
+// Columns that were prepared but never observed do not contribute.
+func (a *bloomAggregator) TimeRange() (time.Time, time.Time) {
+	return a.minTimestamp, a.maxTimestamp
+}
+
 // Reset clears all accumulated state including prepared columns.
 func (a *bloomAggregator) Reset() {
 	a.entries = make(map[bloomPostingKey]*bloomPostingEntry)
 	a.estimatedSize = 0
+	a.minTimestamp = time.Time{}
+	a.maxTimestamp = time.Time{}
 }

--- a/pkg/dataobj/sections/postings/bloom_aggregator_test.go
+++ b/pkg/dataobj/sections/postings/bloom_aggregator_test.go
@@ -10,28 +10,28 @@ import (
 func TestBloomAggregator_TimeRange(t *testing.T) {
 	a := newBloomAggregator()
 
-	min, max := a.TimeRange()
-	require.True(t, min.IsZero(), "empty aggregator min must be zero")
-	require.True(t, max.IsZero(), "empty aggregator max must be zero")
+	gotMin, gotMax := a.TimeRange()
+	require.True(t, gotMin.IsZero(), "empty aggregator min must be zero")
+	require.True(t, gotMax.IsZero(), "empty aggregator max must be zero")
 
 	// Prepared but never observed: must NOT contribute a range.
 	a.PrepareColumn("/a", 0, "svc", 16)
-	min, max = a.TimeRange()
-	require.True(t, min.IsZero(), "prepared-but-unobserved min must be zero")
-	require.True(t, max.IsZero(), "prepared-but-unobserved max must be zero")
+	gotMin, gotMax = a.TimeRange()
+	require.True(t, gotMin.IsZero(), "prepared-but-unobserved min must be zero")
+	require.True(t, gotMax.IsZero(), "prepared-but-unobserved max must be zero")
 
 	base := time.Unix(2000, 0).UTC()
 	require.NoError(t, a.Observe(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "v1", StreamID: 1, Timestamp: base}))
 	require.NoError(t, a.Observe(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "v2", StreamID: 2, Timestamp: base.Add(-300 * time.Second)}))
 
-	min, max = a.TimeRange()
-	require.Equal(t, base.Add(-300*time.Second), min)
-	require.Equal(t, base, max)
+	gotMin, gotMax = a.TimeRange()
+	require.Equal(t, base.Add(-300*time.Second), gotMin)
+	require.Equal(t, base, gotMax)
 
 	a.Reset()
-	min, max = a.TimeRange()
-	require.True(t, min.IsZero(), "after Reset min must be zero")
-	require.True(t, max.IsZero(), "after Reset max must be zero")
+	gotMin, gotMax = a.TimeRange()
+	require.True(t, gotMin.IsZero(), "after Reset min must be zero")
+	require.True(t, gotMax.IsZero(), "after Reset max must be zero")
 }
 
 func TestBloomAggregator_TimeRange_ObserveAtUnixEpoch(t *testing.T) {
@@ -41,10 +41,10 @@ func TestBloomAggregator_TimeRange_ObserveAtUnixEpoch(t *testing.T) {
 	a.PrepareColumn("/a", 0, "svc", 16)
 	require.NoError(t, a.Observe(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "v", StreamID: 1, Timestamp: epoch}))
 
-	min, max := a.TimeRange()
+	gotMin, gotMax := a.TimeRange()
 	// A genuine observation at the Unix epoch is recorded, not mistaken for
 	// "no observations".
-	require.False(t, min.IsZero(), "epoch observation must not read as empty")
-	require.Equal(t, epoch, min)
-	require.Equal(t, epoch, max)
+	require.False(t, gotMin.IsZero(), "epoch observation must not read as empty")
+	require.Equal(t, epoch, gotMin)
+	require.Equal(t, epoch, gotMax)
 }

--- a/pkg/dataobj/sections/postings/bloom_aggregator_test.go
+++ b/pkg/dataobj/sections/postings/bloom_aggregator_test.go
@@ -1,0 +1,50 @@
+package postings
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBloomAggregator_TimeRange(t *testing.T) {
+	a := newBloomAggregator()
+
+	min, max := a.TimeRange()
+	require.True(t, min.IsZero(), "empty aggregator min must be zero")
+	require.True(t, max.IsZero(), "empty aggregator max must be zero")
+
+	// Prepared but never observed: must NOT contribute a range.
+	a.PrepareColumn("/a", 0, "svc", 16)
+	min, max = a.TimeRange()
+	require.True(t, min.IsZero(), "prepared-but-unobserved min must be zero")
+	require.True(t, max.IsZero(), "prepared-but-unobserved max must be zero")
+
+	base := time.Unix(2000, 0).UTC()
+	require.NoError(t, a.Observe(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "v1", StreamID: 1, Timestamp: base}))
+	require.NoError(t, a.Observe(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "v2", StreamID: 2, Timestamp: base.Add(-300 * time.Second)}))
+
+	min, max = a.TimeRange()
+	require.Equal(t, base.Add(-300*time.Second), min)
+	require.Equal(t, base, max)
+
+	a.Reset()
+	min, max = a.TimeRange()
+	require.True(t, min.IsZero(), "after Reset min must be zero")
+	require.True(t, max.IsZero(), "after Reset max must be zero")
+}
+
+func TestBloomAggregator_TimeRange_ObserveAtUnixEpoch(t *testing.T) {
+	a := newBloomAggregator()
+	epoch := time.Unix(0, 0).UTC()
+
+	a.PrepareColumn("/a", 0, "svc", 16)
+	require.NoError(t, a.Observe(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "v", StreamID: 1, Timestamp: epoch}))
+
+	min, max := a.TimeRange()
+	// A genuine observation at the Unix epoch is recorded, not mistaken for
+	// "no observations".
+	require.False(t, min.IsZero(), "epoch observation must not read as empty")
+	require.Equal(t, epoch, min)
+	require.Equal(t, epoch, max)
+}

--- a/pkg/dataobj/sections/postings/builder.go
+++ b/pkg/dataobj/sections/postings/builder.go
@@ -2,6 +2,7 @@ package postings
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -40,6 +41,26 @@ func (b *Builder) SetTenant(tenant string) { b.tenant = tenant }
 
 // Tenant returns the tenant for this builder.
 func (b *Builder) Tenant() string { return b.tenant }
+
+// TimeRange returns the minimum and maximum observation timestamp across all
+// observed label and bloom postings, as the union of the two aggregators. It
+// returns zero time.Time values when nothing has been observed.
+//
+// Call TimeRange before Flush: Flush resets the builder and clears the range.
+func (b *Builder) TimeRange() (time.Time, time.Time) {
+	lMin, lMax := b.labels.TimeRange()
+	bMin, bMax := b.blooms.TimeRange()
+
+	min := lMin
+	if min.IsZero() || (!bMin.IsZero() && bMin.Before(min)) {
+		min = bMin
+	}
+	max := lMax
+	if max.IsZero() || (!bMax.IsZero() && bMax.After(max)) {
+		max = bMax
+	}
+	return min, max
+}
 
 // Type returns the [dataobj.SectionType] of the postings builder.
 func (b *Builder) Type() dataobj.SectionType { return sectionType }

--- a/pkg/dataobj/sections/postings/builder.go
+++ b/pkg/dataobj/sections/postings/builder.go
@@ -51,15 +51,15 @@ func (b *Builder) TimeRange() (time.Time, time.Time) {
 	lMin, lMax := b.labels.TimeRange()
 	bMin, bMax := b.blooms.TimeRange()
 
-	min := lMin
-	if min.IsZero() || (!bMin.IsZero() && bMin.Before(min)) {
-		min = bMin
+	minTime := lMin
+	if minTime.IsZero() || (!bMin.IsZero() && bMin.Before(minTime)) {
+		minTime = bMin
 	}
-	max := lMax
-	if max.IsZero() || (!bMax.IsZero() && bMax.After(max)) {
-		max = bMax
+	maxTime := lMax
+	if maxTime.IsZero() || (!bMax.IsZero() && bMax.After(maxTime)) {
+		maxTime = bMax
 	}
-	return min, max
+	return minTime, maxTime
 }
 
 // Type returns the [dataobj.SectionType] of the postings builder.

--- a/pkg/dataobj/sections/postings/builder_test.go
+++ b/pkg/dataobj/sections/postings/builder_test.go
@@ -994,3 +994,62 @@ func TestBuilder_SplitPreservesAllEntries(t *testing.T) {
 	// All values should be preserved in sorted order.
 	require.Equal(t, expectedValues, allValues, "all entries must be preserved across sections")
 }
+
+func TestBuilder_TimeRange(t *testing.T) {
+	b := NewBuilder(nil, 0, 0, 1024)
+
+	min, max := b.TimeRange()
+	require.True(t, min.IsZero())
+	require.True(t, max.IsZero())
+	require.NotEqual(t, time.Unix(0, 0).UTC(), min, "empty min must not be the Unix epoch")
+
+	base := time.Unix(5000, 0).UTC()
+
+	// Label-only.
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x", StreamID: 1, Timestamp: base})
+	min, max = b.TimeRange()
+	require.Equal(t, base, min)
+	require.Equal(t, base, max)
+
+	// Bloom observation extends the range on both ends.
+	b.PrepareBloomColumn("/a", 0, "svc", 16)
+	require.NoError(t, b.ObserveBloomPosting(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "v", StreamID: 2, Timestamp: base.Add(-time.Hour)}))
+	require.NoError(t, b.ObserveBloomPosting(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "w", StreamID: 3, Timestamp: base.Add(time.Hour)}))
+
+	min, max = b.TimeRange()
+	require.Equal(t, base.Add(-time.Hour), min)
+	require.Equal(t, base.Add(time.Hour), max)
+
+	// Reset clears the range back to empty (verifies Builder.Reset propagates
+	// to both aggregators).
+	b.Reset()
+	min, max = b.TimeRange()
+	require.True(t, min.IsZero(), "after Reset min must be zero")
+	require.True(t, max.IsZero(), "after Reset max must be zero")
+}
+
+func TestBuilder_TimeRange_BloomOnly(t *testing.T) {
+	b := NewBuilder(nil, 0, 0, 1024)
+	base := time.Unix(6000, 0).UTC()
+
+	b.PrepareBloomColumn("/a", 0, "svc", 16)
+	require.NoError(t, b.ObserveBloomPosting(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "v", StreamID: 1, Timestamp: base}))
+
+	min, max := b.TimeRange()
+	require.Equal(t, base, min)
+	require.Equal(t, base, max)
+}
+
+func TestBuilder_TimeRange_PreparedBloomNoObservation(t *testing.T) {
+	b := NewBuilder(nil, 0, 0, 1024)
+	base := time.Unix(7000, 0).UTC()
+
+	// Label observation sets the range.
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x", StreamID: 1, Timestamp: base})
+	// Prepared-but-unobserved bloom column must not widen the range.
+	b.PrepareBloomColumn("/a", 0, "svc", 16)
+
+	min, max := b.TimeRange()
+	require.Equal(t, base, min)
+	require.Equal(t, base, max)
+}

--- a/pkg/dataobj/sections/postings/builder_test.go
+++ b/pkg/dataobj/sections/postings/builder_test.go
@@ -1158,34 +1158,34 @@ func TestBuilder_SplitPreservesAllEntries(t *testing.T) {
 func TestBuilder_TimeRange(t *testing.T) {
 	b := NewBuilder(nil, 0, 0, 1024)
 
-	min, max := b.TimeRange()
-	require.True(t, min.IsZero())
-	require.True(t, max.IsZero())
-	require.NotEqual(t, time.Unix(0, 0).UTC(), min, "empty min must not be the Unix epoch")
+	gotMin, gotMax := b.TimeRange()
+	require.True(t, gotMin.IsZero())
+	require.True(t, gotMax.IsZero())
+	require.NotEqual(t, time.Unix(0, 0).UTC(), gotMin, "empty min must not be the Unix epoch")
 
 	base := time.Unix(5000, 0).UTC()
 
 	// Label-only.
 	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x", StreamID: 1, Timestamp: base})
-	min, max = b.TimeRange()
-	require.Equal(t, base, min)
-	require.Equal(t, base, max)
+	gotMin, gotMax = b.TimeRange()
+	require.Equal(t, base, gotMin)
+	require.Equal(t, base, gotMax)
 
 	// Bloom observation extends the range on both ends.
 	b.PrepareBloomColumn("/a", 0, "svc", 16)
 	require.NoError(t, b.ObserveBloomPosting(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "v", StreamID: 2, Timestamp: base.Add(-time.Hour)}))
 	require.NoError(t, b.ObserveBloomPosting(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "w", StreamID: 3, Timestamp: base.Add(time.Hour)}))
 
-	min, max = b.TimeRange()
-	require.Equal(t, base.Add(-time.Hour), min)
-	require.Equal(t, base.Add(time.Hour), max)
+	gotMin, gotMax = b.TimeRange()
+	require.Equal(t, base.Add(-time.Hour), gotMin)
+	require.Equal(t, base.Add(time.Hour), gotMax)
 
 	// Reset clears the range back to empty (verifies Builder.Reset propagates
 	// to both aggregators).
 	b.Reset()
-	min, max = b.TimeRange()
-	require.True(t, min.IsZero(), "after Reset min must be zero")
-	require.True(t, max.IsZero(), "after Reset max must be zero")
+	gotMin, gotMax = b.TimeRange()
+	require.True(t, gotMin.IsZero(), "after Reset min must be zero")
+	require.True(t, gotMax.IsZero(), "after Reset max must be zero")
 }
 
 func TestBuilder_TimeRange_BloomOnly(t *testing.T) {
@@ -1195,9 +1195,9 @@ func TestBuilder_TimeRange_BloomOnly(t *testing.T) {
 	b.PrepareBloomColumn("/a", 0, "svc", 16)
 	require.NoError(t, b.ObserveBloomPosting(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "v", StreamID: 1, Timestamp: base}))
 
-	min, max := b.TimeRange()
-	require.Equal(t, base, min)
-	require.Equal(t, base, max)
+	gotMin, gotMax := b.TimeRange()
+	require.Equal(t, base, gotMin)
+	require.Equal(t, base, gotMax)
 }
 
 func TestBuilder_TimeRange_PreparedBloomNoObservation(t *testing.T) {
@@ -1209,7 +1209,7 @@ func TestBuilder_TimeRange_PreparedBloomNoObservation(t *testing.T) {
 	// Prepared-but-unobserved bloom column must not widen the range.
 	b.PrepareBloomColumn("/a", 0, "svc", 16)
 
-	min, max := b.TimeRange()
-	require.Equal(t, base, min)
-	require.Equal(t, base, max)
+	gotMin, gotMax := b.TimeRange()
+	require.Equal(t, base, gotMin)
+	require.Equal(t, base, gotMax)
 }

--- a/pkg/dataobj/sections/postings/builder_test.go
+++ b/pkg/dataobj/sections/postings/builder_test.go
@@ -20,15 +20,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/xcap"
 )
 
-// decodeInt64Stat decodes a serialized INT64 stat value (page/column MinValue or
-// MaxValue) to its int64.
-func decodeInt64Stat(t *testing.T, b []byte) int64 {
-	t.Helper()
-	var v dataset.Value
-	require.NoError(t, v.UnmarshalBinary(b))
-	return v.Int64()
-}
-
 func timeUnix(sec, nsec int64) time.Time { return time.Unix(sec, nsec).UTC() }
 
 // checkBit returns true if bit n is set in the LSB-encoded bitmap data.
@@ -407,7 +398,7 @@ func TestBuilder_AllLabel(t *testing.T) {
 func TestBuilder_FlushResetsBuilder(t *testing.T) {
 	b := NewBuilder(nil, 0, 0, 1<<20)
 
-	ts := time.Unix(0, 0)
+	ts := time.Unix(0, 0).UTC()
 	b.ObserveLabelPosting(LabelObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col", LabelValue: "v", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 
 	obj, closer := flushToObject(t, b)
@@ -418,6 +409,9 @@ func TestBuilder_FlushResetsBuilder(t *testing.T) {
 	require.Empty(t, b.labels.entries, "builder should have no label entries after flush")
 	require.Empty(t, b.blooms.entries, "builder should have no bloom entries after flush")
 	require.Zero(t, b.EstimatedSize(), "builder should have zero estimated size after flush")
+	minTime, maxTime := b.TimeRange()
+	require.True(t, minTime.IsZero(), "TimeRange min must be zero after flush")
+	require.True(t, maxTime.IsZero(), "TimeRange max must be zero after flush")
 }
 
 // TestBuilder_KindColumnRangeStats verifies the kind column carries range
@@ -437,6 +431,15 @@ func TestBuilder_KindColumnRangeStats(t *testing.T) {
 
 	require.Equal(t, int64(KindBloom), kindStat(t, sections[0]), "first section must be the bloom section")
 	require.Equal(t, int64(KindLabel), kindStat(t, sections[1]), "second section must be the label section")
+}
+
+// decodeInt64Stat decodes a serialized INT64 stat value (page/column MinValue or
+// MaxValue) to its int64.
+func decodeInt64Stat(t *testing.T, b []byte) int64 {
+	t.Helper()
+	var v dataset.Value
+	require.NoError(t, v.UnmarshalBinary(b))
+	return v.Int64()
 }
 
 // kindStat returns the kind column's range-stat value for a single-kind
@@ -536,8 +539,8 @@ func readWithKindPredicate(t *testing.T, sec *Section, wantKind int64) (rows int
 
 	require.NoError(t, reader.Open(ctx))
 
+	buf := make([]dataset.Row, 16)
 	for {
-		buf := make([]dataset.Row, 16)
 		n, err := reader.Read(ctx, buf)
 		rows += n
 		if errors.Is(err, io.EOF) {

--- a/pkg/dataobj/sections/postings/builder_test.go
+++ b/pkg/dataobj/sections/postings/builder_test.go
@@ -14,8 +14,20 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/internal/columnar"
 	"github.com/grafana/loki/v3/pkg/util/arrowtest"
+	"github.com/grafana/loki/v3/pkg/xcap"
 )
+
+// decodeInt64Stat decodes a serialized INT64 stat value (page/column MinValue or
+// MaxValue) to its int64.
+func decodeInt64Stat(t *testing.T, b []byte) int64 {
+	t.Helper()
+	var v dataset.Value
+	require.NoError(t, v.UnmarshalBinary(b))
+	return v.Int64()
+}
 
 func timeUnix(sec, nsec int64) time.Time { return time.Unix(sec, nsec).UTC() }
 
@@ -406,6 +418,151 @@ func TestBuilder_FlushResetsBuilder(t *testing.T) {
 	require.Empty(t, b.labels.entries, "builder should have no label entries after flush")
 	require.Empty(t, b.blooms.entries, "builder should have no bloom entries after flush")
 	require.Zero(t, b.EstimatedSize(), "builder should have zero estimated size after flush")
+}
+
+// TestBuilder_KindColumnRangeStats verifies the kind column carries range
+// statistics so a kind predicate can prune pages whose kind is out of range.
+func TestBuilder_KindColumnRangeStats(t *testing.T) {
+	b := NewBuilder(nil, 0, 0, 1<<20)
+
+	ts := time.Unix(0, 1000).UTC()
+	b.PrepareBloomColumn("/a", 0, "svc", 16)
+	require.NoError(t, b.ObserveBloomPosting(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "v", StreamID: 1, Timestamp: ts}))
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "env", LabelValue: "x", StreamID: 2, Timestamp: ts})
+
+	// Blooms are encoded before labels, so each section is single-kind and the
+	// kind column's range stats pin that kind (min == max).
+	sections := flushAndOpenSections(t, b)
+	require.Len(t, sections, 2)
+
+	require.Equal(t, int64(KindBloom), kindStat(t, sections[0]), "first section must be the bloom section")
+	require.Equal(t, int64(KindLabel), kindStat(t, sections[1]), "second section must be the label section")
+}
+
+// kindStat returns the kind column's range-stat value for a single-kind
+// section, asserting the column carries stats and that min == max.
+func kindStat(t *testing.T, sec *Section) int64 {
+	t.Helper()
+
+	var kindCol *Column
+	for _, c := range sec.Columns() {
+		if c.Type == ColumnTypeKind {
+			kindCol = c
+			break
+		}
+	}
+	require.NotNil(t, kindCol, "kind column must be present")
+
+	stats := kindCol.inner.Metadata().Statistics
+	require.NotNil(t, stats, "kind column must carry statistics")
+	require.NotNil(t, stats.MinValue, "kind column must carry a min value")
+	require.NotNil(t, stats.MaxValue, "kind column must carry a max value")
+
+	minKind := decodeInt64Stat(t, stats.MinValue)
+	maxKind := decodeInt64Stat(t, stats.MaxValue)
+	require.Equal(t, minKind, maxKind, "kind min and max must be equal within a section")
+	return minKind
+}
+
+// TestBuilder_KindColumnPruning verifies that a kind == X equality predicate
+// prunes the section whose kind is not X: reading the bloom section with a
+// label predicate (and vice versa) returns no rows, while the matching
+// predicate returns all rows.
+func TestBuilder_KindColumnPruning(t *testing.T) {
+	b := NewBuilder(nil, 0, 0, 1<<20)
+
+	ts := time.Unix(0, 1000).UTC()
+	b.PrepareBloomColumn("/a", 0, "svc", 16)
+	require.NoError(t, b.ObserveBloomPosting(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "v", StreamID: 1, Timestamp: ts}))
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "env", LabelValue: "x", StreamID: 2, Timestamp: ts})
+
+	// Blooms are encoded before labels: sections[0] is the bloom section,
+	// sections[1] is the label section.
+	sections := flushAndOpenSections(t, b)
+	require.Len(t, sections, 2)
+
+	bloomSection, labelSection := sections[0], sections[1]
+
+	// Matching kind: the row is returned and no page is pruned.
+	rows, pruned := readWithKindPredicate(t, bloomSection, int64(KindBloom))
+	require.Equal(t, 1, rows, "bloom section with kind=bloom must return the row")
+	require.Equal(t, int64(0), pruned, "matching kind must not prune the page")
+
+	rows, pruned = readWithKindPredicate(t, labelSection, int64(KindLabel))
+	require.Equal(t, 1, rows, "label section with kind=label must return the row")
+	require.Equal(t, int64(0), pruned, "matching kind must not prune the page")
+
+	// Non-matching kind: the kind column's range stats let the reader skip the
+	// page entirely, so a page is pruned and no row is read.
+	rows, pruned = readWithKindPredicate(t, bloomSection, int64(KindLabel))
+	require.Equal(t, 0, rows, "bloom section with kind=label must return no rows")
+	require.Equal(t, int64(1), pruned, "non-matching kind must prune the page via range stats")
+
+	rows, pruned = readWithKindPredicate(t, labelSection, int64(KindBloom))
+	require.Equal(t, 0, rows, "label section with kind=bloom must return no rows")
+	require.Equal(t, int64(1), pruned, "non-matching kind must prune the page via range stats")
+}
+
+// readWithKindPredicate reads sec through a dataset RowReader with a
+// kind == wantKind equality predicate and returns the number of rows returned
+// and the number of pages pruned by page-level range statistics.
+func readWithKindPredicate(t *testing.T, sec *Section, wantKind int64) (rows int, pagesPruned int64) {
+	t.Helper()
+
+	dset, err := columnar.MakeDataset(sec.inner, columnarColumns(sec))
+	require.NoError(t, err)
+
+	cols := dset.Columns()
+	var kindCol dataset.Column
+	for i, c := range sec.Columns() {
+		if c.Type == ColumnTypeKind {
+			kindCol = cols[i]
+			break
+		}
+	}
+	require.NotNil(t, kindCol, "kind column not found in dataset")
+
+	reader := dataset.NewRowReader(dataset.RowReaderOptions{
+		Dataset: dset,
+		Columns: cols,
+		Predicates: []dataset.Predicate{
+			dataset.EqualPredicate{Column: kindCol, Value: dataset.Int64Value(wantKind)},
+		},
+	})
+
+	ctx, _ := xcap.NewCapture(context.Background(), nil)
+	ctx, region := xcap.StartRegion(ctx, "postings.kindPruning")
+	defer region.End()
+
+	require.NoError(t, reader.Open(ctx))
+
+	for {
+		buf := make([]dataset.Row, 16)
+		n, err := reader.Read(ctx, buf)
+		rows += n
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+	}
+
+	for _, obs := range region.Observations() {
+		if obs.Statistic.Name() == dataobj.StatDatasetPagesPruned.Name() {
+			pagesPruned = obs.Value.(int64)
+		}
+	}
+	return rows, pagesPruned
+}
+
+// columnarColumns returns the inner columnar columns for a postings section,
+// in the same order as sec.Columns().
+func columnarColumns(sec *Section) []*columnar.Column {
+	cols := sec.Columns()
+	inner := make([]*columnar.Column, len(cols))
+	for i, c := range cols {
+		inner[i] = c.inner
+	}
+	return inner
 }
 
 // TestBuilder_Type verifies that the section type is correct.

--- a/pkg/dataobj/sections/postings/encode_columnar.go
+++ b/pkg/dataobj/sections/postings/encode_columnar.go
@@ -117,6 +117,9 @@ func (p *postingsEncoder) encodeColumns(bloomEntries []BloomEntry, labelEntries 
 		},
 		Encoding:    datasetmd.ENCODING_TYPE_DELTA,
 		Compression: datasetmd.COMPRESSION_TYPE_ZSTD,
+		Statistics: dataset.StatisticsOptions{
+			StoreRangeStats: true,
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("creating kind column: %w", err)

--- a/pkg/dataobj/sections/postings/label_aggregator.go
+++ b/pkg/dataobj/sections/postings/label_aggregator.go
@@ -1,6 +1,8 @@
 package postings
 
 import (
+	"time"
+
 	"github.com/grafana/loki/v3/pkg/memory"
 )
 
@@ -40,6 +42,8 @@ func (e *labelPostingEntry) BitmapBytes() []byte {
 type labelAggregator struct {
 	entries       map[labelPostingKey]*labelPostingEntry
 	estimatedSize int
+	minTimestamp  time.Time
+	maxTimestamp  time.Time
 }
 
 // newLabelAggregator creates a new labelAggregator.
@@ -59,6 +63,14 @@ func (a *labelAggregator) Observe(obs LabelObservation) {
 	}
 
 	tsNano := obs.Timestamp.UnixNano()
+
+	ts := obs.Timestamp.UTC()
+	if a.minTimestamp.IsZero() || ts.Before(a.minTimestamp) {
+		a.minTimestamp = ts
+	}
+	if a.maxTimestamp.IsZero() || ts.After(a.maxTimestamp) {
+		a.maxTimestamp = ts
+	}
 
 	entry, ok := a.entries[key]
 	if !ok {
@@ -126,8 +138,16 @@ func (a *labelAggregator) EstimatedSize() int {
 	return a.estimatedSize
 }
 
+// TimeRange returns the minimum and maximum observation timestamp seen by the
+// aggregator. It returns zero time.Time values when nothing has been observed.
+func (a *labelAggregator) TimeRange() (time.Time, time.Time) {
+	return a.minTimestamp, a.maxTimestamp
+}
+
 // Reset clears all accumulated state.
 func (a *labelAggregator) Reset() {
 	a.entries = make(map[labelPostingKey]*labelPostingEntry)
 	a.estimatedSize = 0
+	a.minTimestamp = time.Time{}
+	a.maxTimestamp = time.Time{}
 }

--- a/pkg/dataobj/sections/postings/label_aggregator_test.go
+++ b/pkg/dataobj/sections/postings/label_aggregator_test.go
@@ -1,0 +1,47 @@
+package postings
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLabelAggregator_TimeRange(t *testing.T) {
+	a := newLabelAggregator()
+
+	min, max := a.TimeRange()
+	require.True(t, min.IsZero(), "empty aggregator min must be zero")
+	require.True(t, max.IsZero(), "empty aggregator max must be zero")
+	// Empty must be the zero time.Time, NOT the Unix epoch (guards against the
+	// store-int64-and-convert anti-pattern).
+	require.NotEqual(t, time.Unix(0, 0).UTC(), min, "empty min must not be the Unix epoch")
+
+	base := time.Unix(1000, 0).UTC()
+	a.Observe(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x", StreamID: 1, Timestamp: base})
+	a.Observe(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x", StreamID: 2, Timestamp: base.Add(-500 * time.Second)})
+	a.Observe(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "env", LabelValue: "y", StreamID: 3, Timestamp: base.Add(500 * time.Second)})
+
+	min, max = a.TimeRange()
+	require.Equal(t, base.Add(-500*time.Second), min)
+	require.Equal(t, base.Add(500*time.Second), max)
+
+	a.Reset()
+	min, max = a.TimeRange()
+	require.True(t, min.IsZero(), "after Reset min must be zero")
+	require.True(t, max.IsZero(), "after Reset max must be zero")
+}
+
+func TestLabelAggregator_TimeRange_ObserveAtUnixEpoch(t *testing.T) {
+	a := newLabelAggregator()
+	epoch := time.Unix(0, 0).UTC()
+
+	a.Observe(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x", StreamID: 1, Timestamp: epoch})
+
+	min, max := a.TimeRange()
+	// A genuine observation at the Unix epoch is recorded, not mistaken for
+	// "no observations".
+	require.False(t, min.IsZero(), "epoch observation must not read as empty")
+	require.Equal(t, epoch, min)
+	require.Equal(t, epoch, max)
+}

--- a/pkg/dataobj/sections/postings/label_aggregator_test.go
+++ b/pkg/dataobj/sections/postings/label_aggregator_test.go
@@ -10,26 +10,26 @@ import (
 func TestLabelAggregator_TimeRange(t *testing.T) {
 	a := newLabelAggregator()
 
-	min, max := a.TimeRange()
-	require.True(t, min.IsZero(), "empty aggregator min must be zero")
-	require.True(t, max.IsZero(), "empty aggregator max must be zero")
+	gotMin, gotMax := a.TimeRange()
+	require.True(t, gotMin.IsZero(), "empty aggregator min must be zero")
+	require.True(t, gotMax.IsZero(), "empty aggregator max must be zero")
 	// Empty must be the zero time.Time, NOT the Unix epoch (guards against the
 	// store-int64-and-convert anti-pattern).
-	require.NotEqual(t, time.Unix(0, 0).UTC(), min, "empty min must not be the Unix epoch")
+	require.NotEqual(t, time.Unix(0, 0).UTC(), gotMin, "empty min must not be the Unix epoch")
 
 	base := time.Unix(1000, 0).UTC()
 	a.Observe(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x", StreamID: 1, Timestamp: base})
 	a.Observe(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x", StreamID: 2, Timestamp: base.Add(-500 * time.Second)})
 	a.Observe(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "env", LabelValue: "y", StreamID: 3, Timestamp: base.Add(500 * time.Second)})
 
-	min, max = a.TimeRange()
-	require.Equal(t, base.Add(-500*time.Second), min)
-	require.Equal(t, base.Add(500*time.Second), max)
+	gotMin, gotMax = a.TimeRange()
+	require.Equal(t, base.Add(-500*time.Second), gotMin)
+	require.Equal(t, base.Add(500*time.Second), gotMax)
 
 	a.Reset()
-	min, max = a.TimeRange()
-	require.True(t, min.IsZero(), "after Reset min must be zero")
-	require.True(t, max.IsZero(), "after Reset max must be zero")
+	gotMin, gotMax = a.TimeRange()
+	require.True(t, gotMin.IsZero(), "after Reset min must be zero")
+	require.True(t, gotMax.IsZero(), "after Reset max must be zero")
 }
 
 func TestLabelAggregator_TimeRange_ObserveAtUnixEpoch(t *testing.T) {
@@ -38,10 +38,10 @@ func TestLabelAggregator_TimeRange_ObserveAtUnixEpoch(t *testing.T) {
 
 	a.Observe(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x", StreamID: 1, Timestamp: epoch})
 
-	min, max := a.TimeRange()
+	gotMin, gotMax := a.TimeRange()
 	// A genuine observation at the Unix epoch is recorded, not mistaken for
 	// "no observations".
-	require.False(t, min.IsZero(), "epoch observation must not read as empty")
-	require.Equal(t, epoch, min)
-	require.Equal(t, epoch, max)
+	require.False(t, gotMin.IsZero(), "epoch observation must not read as empty")
+	require.Equal(t, epoch, gotMin)
+	require.Equal(t, epoch, gotMax)
 }


### PR DESCRIPTION
## What

Sources the metastore ToC per-tenant index-object time range (`indexpointer` `StartTs`/`EndTs`) from postings sections, and enables page pruning on the postings `kind` column.

- Postings aggregators (`labelAggregator`, `bloomAggregator`) and `postings.Builder` now track and expose an aggregate min/max timestamp via `TimeRange()`, using the same zero-value/`IsZero()` convention as `streams.Builder`. The bloom aggregate is folded in `Observe` (not `PrepareColumn`) to avoid the per-entry `math.MaxInt64`/`MinInt64` sentinels leaking into the range.
- `indexobj.Builder.TimeRanges()` now unions each tenant's streams and postings ranges over the union of tenant keys, instead of reading streams only.
- `encode_columnar.go` enables `StoreRangeStats` on the `kind` column. Within a postings section `kind` is constant, so a `kind == KindLabel`/`KindBloom` predicate can prune entire sections' pages.

## Why

Once the index builders stop writing streams/pointers sections, `indexobj.Builder.TimeRanges()` would return empty (it read only `b.streams`), the indexer would treat it as "nothing to flush", and the ToC entry for the index object would never be written — breaking time-window section selection at query time. Postings already carry per-entry timestamps; this aggregates and propagates them so the ToC range stays correct. The compaction path is unchanged: it derives ranges from source `SectionRef`s and stays correct by induction once the ingest leaf is accurate.

## Notes

- `min_timestamp`/`max_timestamp` page stats and reader predicate pushdown are a deliberate follow-up, not in this PR.
- Kind-column pruning is verified non-tautologically via `StatDatasetPagesPruned`.
