### PR TITLE
chore: Adjust sortmerge.Iterator sequence batch sizes

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -259,6 +259,44 @@ func TestBuilder_CopyAndSort(t *testing.T) {
 	}
 }
 
+func BenchmarkBuilder_CopyAndSort(b *testing.B) {
+	builder, _ := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
+
+	now := time.Date(2025, time.September, 17, 0, 0, 0, 0, time.UTC)
+	numRows := 8192   // 16 rows with 1KiB each line and 8KiB section size ~> 2 logs sections per tenant. 48KB total
+	sizeOfRow := 1024 // 1KiB log line
+	tenants := []string{"tenant-a", "tenant-b", "tenant-c"}
+
+	for _, tenant := range tenants {
+		for i := range numRows {
+			err := builder.Append(tenant, logproto.Stream{
+				Labels: `{cluster="test",app="foo"}`,
+				Entries: []push.Entry{{
+					Timestamp: now.Add(time.Duration(i%8) * time.Second),
+					Line:      strings.Repeat("a", 1024), // 1KiB log line
+				}},
+			}, now.Add(time.Duration(i%8)*time.Second))
+			require.NoError(b, err)
+		}
+	}
+
+	dataSize := numRows * sizeOfRow * len(tenants) // 8192 rows * 1KiB each line * 3 tenants = 24MB
+	b.SetBytes(int64(dataSize))
+
+	obj1, closer1, err := builder.Flush()
+	require.NoError(b, err)
+	defer closer1.Close()
+
+	newBuilder, _ := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
+
+	for b.Loop() {
+		newBuilder.Reset()
+		_, closer2, err := newBuilder.CopyAndSort(b.Context(), obj1)
+		require.NoError(b, err)
+		defer closer2.Close()
+	}
+}
+
 // tenantOverrides maps tenant IDs to their schema labels.
 type tenantOverrides map[string][]string
 

--- a/pkg/dataobj/sortmerge/sortmerge.go
+++ b/pkg/dataobj/sortmerge/sortmerge.go
@@ -25,6 +25,10 @@ import (
 // according to sort.
 func Iterator(ctx context.Context, sections []*dataobj.Section, sort logs.SortOrder) (result.Seq[logs.Record], error) {
 	sequences := make([]*sectionSequence, 0, len(sections))
+
+	// The buffer size is a trade-off between memory overhead and performance: Share a sensible batch size amongst the sections.
+	bufferSize := max(128, 8192/len(sections))
+
 	for _, s := range sections {
 		sec, err := logs.Open(ctx, s)
 		if err != nil {
@@ -52,7 +56,7 @@ func Iterator(ctx context.Context, sections []*dataobj.Section, sort logs.SortOr
 
 		sequences = append(sequences, &sectionSequence{
 			section:         sec,
-			DatasetSequence: logs.NewDatasetSequence(r, 8<<10),
+			DatasetSequence: logs.NewDatasetSequence(r, bufferSize),
 		})
 	}
 

--- a/pkg/dataobj/sortmerge/sortmerge.go
+++ b/pkg/dataobj/sortmerge/sortmerge.go
@@ -27,7 +27,7 @@ func Iterator(ctx context.Context, sections []*dataobj.Section, sort logs.SortOr
 	sequences := make([]*sectionSequence, 0, len(sections))
 
 	// The buffer size is a trade-off between memory overhead and performance: Share a sensible batch size amongst the sections.
-	bufferSize := max(128, 8192/len(sections))
+	bufferSize := max(128, 8192/max(1, len(sections)))
 
 	for _, s := range sections {
 		sec, err := logs.Open(ctx, s)


### PR DESCRIPTION
**What this PR does / why we need it**:
Small improvement to memory allocations when sorting dataobject sections

Previously we would read 8192 rows per section at once for the loser tree, with potentially unbounded section counts (some object have 10s or 100s). That isn't so bad in itself, but the contained dataset.Value data buffers are designed to grow to the size of the largest seen value, so if a batch contains very large log lines for one read, the data buffers will grow to accommodate those lines, even if all subsequent lines are smaller.
We don't have proper control over this beyond the maximum log line size of 256KB. 256KB * 8192 = up to 2GB per section. This can manifest for some larger clients.

I added a benchmark that sorts 24MB of data to verify. This is a quick fix to reduce memory usage. Bigger batch sizes tend to be more efficient to read from so I now share a maximum batch size based on the number of sections.

According to the benchmark, throughput increased (I don't really trust the exact number) but crucially the allocations per op has reduced by 58%, from 5MB/sort to 2MB/sort.
```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj
cpu: Apple M3 Max
                       │ before.txt  │              after.txt              │
                       │   sec/op    │   sec/op     vs base                │
Builder_CopyAndSort-14   860.9µ ± 2%   768.9µ ± 2%  -10.69% (p=0.000 n=10)

                       │  before.txt  │              after.txt               │
                       │     B/s      │     B/s       vs base                │
Builder_CopyAndSort-14   27.22Gi ± 2%   30.48Gi ± 2%  +11.96% (p=0.000 n=10)

                       │  before.txt  │              after.txt               │
                       │     B/op     │     B/op      vs base                │
Builder_CopyAndSort-14   4.983Mi ± 0%   2.050Mi ± 0%  -58.86% (p=0.000 n=10)

                       │ before.txt  │             after.txt              │
                       │  allocs/op  │  allocs/op   vs base               │
Builder_CopyAndSort-14   11.44k ± 0%   11.43k ± 0%  -0.04% (p=0.000 n=10)
```