### PR TITLE
fix(v1-engine): Handling of absent-as-empty semantics for key="" filters in bloom filters

### DIFF
--- a/pkg/storage/bloom/v1/bloom_tester.go
+++ b/pkg/storage/bloom/v1/bloom_tester.go
@@ -187,9 +187,28 @@ func (kvm keyValueMatcherTest) match(series labels.Labels, bloom filter.Checker,
 		return true
 	}
 
-	// It's in the series if the key is set and has the same value.
-	// By checking val != "" we handle `{env="prod"} | user=""`.
 	val := series.Get(kvm.matcher.Key)
+
+	// LogQL: an absent label compares as the empty string, so `key=""` must
+	// match rows where the label is absent. The bloom is positive-only — it
+	// stores `key=value` tokens that were seen, never "this key is absent for
+	// all rows in this chunk." So when the filter value is "" and the key is
+	// not carried by the series labels, we can't disambiguate "no row had
+	// this key" (every row matches) from "every row had this key with a
+	// non-empty value" (no row matches). The safe action is to not prune —
+	// let the per-row label filter decide.
+	if kvm.matcher.Value == "" && val == "" {
+		return true
+	}
+
+	// inSeries is true iff the series labels actually carry this key with the
+	// filter's value — a real, non-empty series-label match. The val != ""
+	// guard keeps inSeries honest: series.Get returns "" both for absent keys
+	// and (rarely) for present-but-empty values, so without the guard we'd
+	// spuriously assert an "in-series match" for any key the series doesn't
+	// have whenever the filter value is also "". That absent-key/empty-filter
+	// case is handled by the escape hatch above; this line is strictly
+	// "key is a stream label with this exact non-empty value."
 	inSeries := val != "" && val == kvm.matcher.Value
 
 	inBloom := bloom.Test(combined)

--- a/pkg/storage/bloom/v1/bloom_tester_test.go
+++ b/pkg/storage/bloom/v1/bloom_tester_test.go
@@ -62,9 +62,13 @@ func TestLabelMatchersToBloomTest(t *testing.T) {
 			match: false,
 		},
 		{
-			name:  "filter non-indexed key with empty value",
+			// LogQL: `field=""` matches rows where the label is absent OR
+			// empty. Blooms can't positively assert "label is absent", so the
+			// bloom test must pass (no chunk pruning); the per-row label
+			// filter decides each row downstream.
+			name:  "non-indexed key with empty value passes (bloom can't prove absence)",
 			query: `{app="fake"} | noexist=""`,
-			match: false,
+			match: true,
 		},
 		{
 			name:  "ignore label from series",
@@ -90,6 +94,16 @@ func TestLabelMatchersToBloomTest(t *testing.T) {
 			name:  "ignore label from series with empty value",
 			query: `{app="fake"} | app=""`,
 			match: false,
+		},
+		{
+			// Trace_id is a structured-metadata key (recorded per row in the
+			// bloom for some rows). Some rows in the chunk may have it absent;
+			// LogQL says those match `trace_id=""`. The bloom can't tell us
+			// "no row had trace_id" so the chunk must pass; the per-row
+			// filter handles each row.
+			name:  "structured-metadata key with empty-value filter passes the bloom",
+			query: `{app="fake"} | trace_id=""`,
+			match: true,
 		},
 		{
 			name:  "ignore unsupported operator",


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a v1 correctness bug where label filters of the form `| field=""` could silently drop chunks at the bloom-filter layer whenever the key was not carried by the series labels. LogQL says an absent label compares as the empty string, so `field=""` must match rows where the label is absent. The bloom-tester returned `false` (prune) in that case, so chunks whose rows would have matched were never read.

**Root cause**

`keyValueMatcherTest.match` decides whether a chunk should be admitted by:

```go
val := series.Get(kvm.matcher.Key)
inSeries := val != "" && val == kvm.matcher.Value
inBloom := bloom.Test(combined)
return inSeries || inBloom
```

`inSeries` asserts "the key is in the series labels with the filter's exact value" — a non-empty series-label match. The `val != ""` guard exists to prevent a false positive when both the series-stored value and the filter value are `""` (`series.Get` returns `""` for absent keys, so without the guard we'd spuriously claim a series-label match for any key the series doesn't have whenever the filter is also `""`).

The gap: with `val != ""` in place, the case `val == "" && kvm.matcher.Value == ""` flows through to `inBloom`, but the bloom is positive-only — it stores `key=value` tokens that were seen, never "this key is absent for all rows in this chunk." So when both `val` and the filter value are `""`, neither `inSeries` nor `inBloom` can return `true` for the absent-key case, and the function returns `false` → prune. Per LogQL, rows where `key` is absent should match `key=""`, so the chunk needs to be admitted — not pruned.

The result is field-name-dependent flakiness: identical `field=""` queries against the same data can return very different counts depending on whether the bloom has ever seen the literal `key=` token for that field name. Equivalent regex forms (`=~"^$"`, `=~""`, `!~".+"`) avoid the bug entirely because the regex simplifier collapses them to `TrueFilter` / `NoopLabelFilter` before they reach the bloom-tester.

**Fix**

Add an early return in `keyValueMatcherTest.match` for the absent-key + empty-filter case:

```go
val := series.Get(kvm.matcher.Key)

if kvm.matcher.Value == "" && val == "" {
    return true
}

inSeries := val != "" && val == kvm.matcher.Value
inBloom := bloom.Test(combined)
return inSeries || inBloom
```

This preserves every other path — including the legitimate pruning case `{app="fake"} | app=""` where `app="fake"` is a stream label so every row inherits a non-empty `app` value and `app=""` matches none (the bloom's `app=` test correctly says "not in bloom", and we still prune). The fix only changes behaviour in the single quadrant `val == "" && kvm.matcher.Value == ""`.

The comment on the `val != ""` guard is rewritten to describe what the guard truly does — keep `inSeries` honest as a real, non-empty series-label match — and to explicitly route the absent-key/empty-filter case through the new escape hatch.

**Scope**

Behaviour by quadrant of `(val, kvm.matcher.Value)`:

- `("",  "")` — **pass** (new escape hatch; LogQL absent-as-empty)
- `("",  "x")` — bloom decides; `inSeries=false`, correctly prunes when no row has `key=x` in metadata
- `("x", "")` — bloom decides; symmetric case, stream label is the non-empty ground truth, bloom rules out metadata overrides
- `("x", "x")` — **pass** via `inSeries=true`
- `("x", "y")` — bloom decides; falls through to `inBloom`

Only the first quadrant changes. Non-empty-value filters, all other operators (`!=`, `=~`, `!~`, etc.), and the series-label-based pruning are untouched.
