### PR TITLE
ci: Synchronize release and documentation workflows with main [release-3.6.x]

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "eb4e89778be445f9e79533b704cbdee404592eb4"
+      "version": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+      "version": "a3091f6507615a4646e399870071074d66c30826"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "eb4e89778be445f9e79533b704cbdee404592eb4",
-      "sum": "F1Sz4AL7p6uDMdFsQCXWM3v5DpaWrjbODRSXn2gKBIU="
+      "version": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3",
+      "sum": "6B5rTccFjpHo20u9OSpLg8RE52yPjTwlm1t90mh9Ugw="
     }
   ],
   "legacyImports": false

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3",
-      "sum": "6B5rTccFjpHo20u9OSpLg8RE52yPjTwlm1t90mh9Ugw="
+      "version": "a3091f6507615a4646e399870071074d66c30826",
+      "sum": "6dSEhHcVcb+4k4au5LhQoIGB8epLqyFoOlib8UdM/uM="
     }
   ],
   "legacyImports": false

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -4,12 +4,13 @@ local lokiRelease = import 'workflows/main.jsonnet',
       build = lokiRelease.build;
 local releaseLibRef = (import 'jsonnetfile.json').dependencies[0].version;
 local checkTemplate = 'grafana/loki-release/.github/workflows/check.yml@%s' % releaseLibRef;
-local buildImageVersion = std.extVar('BUILD_IMAGE_VERSION');
 local goVersion = std.extVar('GO_VERSION');
-local buildImage = 'grafana/loki-build-image:%s' % buildImageVersion;
-local golangCiLintVersion = 'v2.11.4';
+local buildImage = 'golang:%s' % goVersion;
+local golangCiLintVersion = 'v2.10.1';
 local imageBuildTimeoutMin = 60;
 local imagePrefix = 'grafana';
+local weeklyImageRegistry = 'us-docker.pkg.dev';
+local weeklyImagePrefix = '%s/grafanalabs-global/dockerhub-loki-prod-mirror' % weeklyImageRegistry;
 local dockerPluginDir = 'clients/cmd/docker-driver';
 local runner = import 'workflows/runner.libsonnet',
       r = runner.withDefaultMapping();  // Do we need a different mapping?
@@ -28,16 +29,17 @@ local imageJobs = {
   logcli: build.image('logcli', 'cmd/logcli', platform=platforms.all),
   'loki-canary': build.image('loki-canary', 'cmd/loki-canary', platform=platforms.all),
   'loki-canary-boringcrypto': build.image('loki-canary-boringcrypto', 'cmd/loki-canary-boringcrypto', platform=platforms.all),
-  promtail: build.image('promtail', 'clients/cmd/promtail', platform=platforms.all),
   querytee: build.image('loki-query-tee', 'cmd/querytee', platform=[r.forPlatform('linux/amd64'), r.forPlatform('linux/arm64')]),
   'loki-docker-driver': build.dockerPlugin('loki-docker-driver', dockerPluginDir, buildImage=buildImage, platform=[r.forPlatform('linux/amd64'), r.forPlatform('linux/arm64')]),
+  'loki-helm-test': build.image('loki-helm-test', 'production/helm/loki/src/helm-test', platform=platforms.all),
 };
 
 local weeklyImageJobs = {
   loki: build.weeklyImage('loki', 'cmd/loki', platform=platforms.all),
   'loki-canary': build.weeklyImage('loki-canary', 'cmd/loki-canary', platform=platforms.all),
   'loki-canary-boringcrypto': build.weeklyImage('loki-canary-boringcrypto', 'cmd/loki-canary-boringcrypto', platform=platforms.all),
-  promtail: build.weeklyImage('promtail', 'clients/cmd/promtail', platform=platforms.all),
+  'loki-query-tee': build.weeklyImage('loki-query-tee', 'cmd/querytee'),
+  'logql-analyzer': build.weeklyImage('logql-analyzer', 'cmd/logql-analyzer', platform=platforms.all),
 };
 
 {
@@ -47,6 +49,7 @@ local weeklyImageJobs = {
       buildImage=buildImage,
       checkTemplate=checkTemplate,
       distRunsOn='ubuntu-x64',
+      distOptionalTargets=['dist/loki-linux-riscv64'],
       golangCiLintVersion=golangCiLintVersion,
       imageBuildTimeoutMin=imageBuildTimeoutMin,
       imageJobs=imageJobs,
@@ -55,7 +58,6 @@ local weeklyImageJobs = {
       releaseRepo='grafana/loki',
       skipArm=false,
       skipValidation=false,
-      useGitHubAppToken=true,
       versioningStrategy='always-bump-patch',
     ) + {
       name: 'Prepare Patch Release PR',
@@ -67,6 +69,7 @@ local weeklyImageJobs = {
       buildImage=buildImage,
       checkTemplate=checkTemplate,
       distRunsOn='ubuntu-x64',
+      distOptionalTargets=['dist/loki-linux-riscv64'],
       golangCiLintVersion=golangCiLintVersion,
       imageBuildTimeoutMin=imageBuildTimeoutMin,
       imageJobs=imageJobs,
@@ -75,7 +78,6 @@ local weeklyImageJobs = {
       releaseRepo='grafana/loki',
       skipArm=false,
       skipValidation=false,
-      useGitHubAppToken=true,
       versioningStrategy='always-bump-minor',
     ) + {
       name: 'Prepare Minor Release PR from Weekly',
@@ -84,13 +86,11 @@ local weeklyImageJobs = {
   'release.yml': std.manifestYamlDoc(
     lokiRelease.releaseWorkflow(
       branches=['release-[0-9]+.[0-9]+.x', 'k[0-9]+', 'main'],
-      getDockerCredsFromVault=true,
-      imagePrefix='grafana',
+      imagePrefix=imagePrefix,
       releaseLibRef=releaseLibRef,
       pluginBuildDir=dockerPluginDir,
       releaseBranchTemplate='release-\\${major}.\\${minor}.x',
       releaseRepo='grafana/loki',
-      useGitHubAppToken=true,
     ), false, false
   ),
   'check.yml': std.manifestYamlDoc({
@@ -156,7 +156,7 @@ local weeklyImageJobs = {
           BUILD_TIMEOUT: imageBuildTimeoutMin,
           RELEASE_REPO: 'grafana/loki',
           RELEASE_LIB_REF: releaseLibRef,
-          IMAGE_PREFIX: imagePrefix,
+          IMAGE_PREFIX: weeklyImagePrefix,
           GO_VERSION: goVersion,
         })
       for name in std.objectFields(weeklyImageJobs)
@@ -170,31 +170,59 @@ local weeklyImageJobs = {
         + job.withNeeds(['%s-image' % name])
         + job.withEnv({
           BUILD_TIMEOUT: imageBuildTimeoutMin,
-          IMAGE_DIGEST_AMD64: '${{ needs.%(name)s-image.outputs.image_digest_linux_amd64 }}' % name,
-          IMAGE_DIGEST_ARM64: '${{ needs.%(name)s-image.outputs.image_digest_linux_arm64 }}' % name,
-          IMAGE_DIGEST_ARM: '${{ needs.%(name)s-image.outputs.image_digest_linux_arm }}' % name,
-          OUTPUTS_IMAGE_NAME: '${{ needs.%(name)s-image.outputs.image_name }}' % name,
-          OUTPUTS_IMAGE_TAG: '${{ needs.%(name)s-image.outputs.image_tag }}' % name,
+          IMAGE_DIGEST_AMD64: '${{ needs.%s-image.outputs.image_digest_linux_amd64 }}' % name,
+          IMAGE_DIGEST_ARM64: '${{ needs.%s-image.outputs.image_digest_linux_arm64 }}' % name,
+          IMAGE_DIGEST_ARM: '${{ needs.%s-image.outputs.image_digest_linux_arm }}' % name,
+          OUTPUTS_IMAGE_NAME: '${{ needs.%s-image.outputs.image_name }}' % name,
+          OUTPUTS_IMAGE_TAG: '${{ needs.%s-image.outputs.image_tag }}' % name,
+          IMAGE_NAME: '%s/%s' % [weeklyImagePrefix, name],
         })
         + job.withSteps([
           step.new('Set up Docker buildx', 'docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2'),  // v3
-          step.new('Login to DockerHub (from Vault)', 'grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746'),  // main
+          step.new('Login to DockerHub', 'grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7'),  // v1.0.4
+          step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136')  // v1.0.2
+          + step.with({ registry: weeklyImageRegistry }),
           step.new('Publish multi-arch manifest')
           + step.withRun(|||
             # Unfortunately there is no better way atm than having a separate named output for each digest
             echo "linux/arm64 $IMAGE_DIGEST_ARM64"
             echo "linux/amd64 $IMAGE_DIGEST_AMD64"
             echo "linux/arm   $IMAGE_DIGEST_ARM"
-            IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+
+            # 'needs.%(name)s-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
+            # See https://github.com/actions/runner/issues/2316
+            # Using the IMAGE_NAME env variable instead
+            IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+
             echo "Create multi-arch manifest for $IMAGE"
             docker buildx imagetools create -t $IMAGE \
-              ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
-              ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
-              ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+              ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+              ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+              ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
             docker buildx imagetools inspect $IMAGE
-          ||| % { name: '%s-image' % name }),
+          ||| % { name: name }),
         ])
       for name in std.objectFields(weeklyImageJobs)
+    } + {
+      'trigger-cd': job.new()
+                    + job.withNeeds(['loki-image', 'loki-manifest', 'loki-canary-manifest'])
+                    + job.withIf("github.ref == 'refs/heads/main'")
+                    + job.withPermissions({
+                      contents: 'read',
+                      'id-token': 'write',
+                    })
+                    + job.withEnv({
+                      IMAGE_TAG: '${{ needs.loki-image.outputs.image_tag }}',
+                    })
+                    + job.withSteps([
+                      step.new('Trigger CD workflow', 'grafana/shared-workflows/actions/trigger-argo-workflow@8b88213bca76e86f9f59b43038cc5d7545452436')  // main
+                      + step.with({
+                        instance: 'ops',
+                        namespace: 'loki-cd',
+                        workflow_template: 'loki-continuous-deployment',
+                        parameters: 'imageTag=${{ env.IMAGE_TAG }}',
+                      }),
+                    ]),
     },
   }),
 }

--- a/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/build.libsonnet
@@ -34,8 +34,7 @@ local runner = import 'runner.libsonnet',
       common.fetchReleaseLib,
       common.fetchReleaseRepo,
       common.setupNode,
-      common.fetchGcsCredentials,
-      common.googleAuth,
+      common.enableCorepack,
 
       step.new('Set up Docker buildx', 'docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2'),  // v3
 
@@ -63,15 +62,23 @@ local runner = import 'runner.libsonnet',
         outputs: 'type=docker,dest=release/images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar' % name,
         'build-args': 'IMAGE_TAG=${{ needs.version.outputs.version }}',
       }),
-      step.new('Upload artifacts', 'google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0')  // v2
-      + step.withIf('${{ fromJSON(needs.version.outputs.pr_created) }}')
-      + step.with({
-        path: 'release/images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar' % name,
-        destination: '${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images',  //TODO: make bucket configurable
-        process_gcloudignore: false,
-      }),
-    ]),
 
+      step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136'),
+      releaseStep('upload artifacts')
+      + step.withIf('${{ fromJSON(needs.version.outputs.pr_created) }}')
+      + step.withEnv({
+        path: 'images/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar' % name,
+      })
+      + step.withRun(|||
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      |||),
+      ]),
 
   weeklyImage: function(
     name,
@@ -102,9 +109,12 @@ local runner = import 'runner.libsonnet',
       common.fetchReleaseLib,
       common.fetchReleaseRepo,
       common.setupNode,
+      common.enableCorepack,
 
       step.new('Set up Docker buildx', 'docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2'),  // v3
-      step.new('Login to DockerHub (from Vault)', 'grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25'),  // main
+      step.new('Login to DockerHub', 'grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7'),  // v1.0.4
+      step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136')  // v1.0.2
+      + step.with({ registry: 'us-docker.pkg.dev' }),
 
       releaseStep('Get weekly version')
       + step.withId('weekly-version')
@@ -175,8 +185,7 @@ local runner = import 'runner.libsonnet',
       common.fetchReleaseLib,
       common.fetchReleaseRepo,
       common.setupNode,
-      common.fetchGcsCredentials,
-      common.googleAuth,
+      common.enableCorepack,
 
       step.new('Set up QEMU', 'docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392'),  // v3
       step.new('set up docker buildx', 'docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2'),  //v3
@@ -229,13 +238,21 @@ local runner = import 'runner.libsonnet',
         .
       ||| % [name, name]),
 
-      step.new('upload artifacts', 'google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0')  // v2
+      step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136'),
+      releaseStep('upload artifacts')
       + step.withIf('${{ fromJSON(needs.version.outputs.pr_created) }}')
-      + step.with({
-        path: 'release/plugins/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar' % name,
-        destination: '${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/plugins',
-        process_gcloudignore: false,
-      }),
+      + step.withEnv({
+        path: 'plugins/%s-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar' % name,
+      })
+      + step.withRun(|||
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=plugins \
+          --version=${{ github.sha }}
+      |||),
     ]),
 
   version:
@@ -249,26 +266,26 @@ local runner = import 'runner.libsonnet',
       common.fetchReleaseLib,
       common.fetchReleaseRepo,
       common.setupNode,
+      common.enableCorepack,
       common.extractBranchName,
       common.githubAppToken,
-      common.setToken,
       releaseLibStep('get release version')
       + step.withId('version')
       + step.withEnv({
         OUTPUTS_BRANCH: '${{ steps.extract_branch.outputs.branch }}',
-        OUTPUTS_TOKEN: '${{ steps.github_app_token.outputs.token }}',
+        OUTPUTS_TOKEN: '${{ steps.get_github_app_token.outputs.token }}',
       })
       + step.withRun(|||
-        npm install
+        yarn install
 
         if [[ -z "${{ env.RELEASE_AS }}" ]]; then
-          npm exec -- release-please release-pr \
+          yarn exec -- release-please release-pr \
             --consider-all-branches \
             --dry-run \
             --dry-run-output release.json \
-            --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --manifest-file .release-please-manifest.json \
-            --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --release-type simple \
             --repo-url "${{ env.RELEASE_REPO }}" \
             --separate-pull-requests false \
@@ -276,13 +293,13 @@ local runner = import 'runner.libsonnet',
             --token "$OUTPUTS_TOKEN" \
             --versioning-strategy "${{ env.VERSIONING_STRATEGY }}"
         else
-          npm exec -- release-please release-pr \
+          yarn exec -- release-please release-pr \
             --consider-all-branches \
             --dry-run \
             --dry-run-output release.json \
-            --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --manifest-file .release-please-manifest.json \
-            --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --release-type simple \
             --repo-url "${{ env.RELEASE_REPO }}" \
             --separate-pull-requests false \
@@ -302,7 +319,7 @@ local runner = import 'runner.libsonnet',
         if [[ `jq length release.json` -eq 0 ]]; then 
           echo "pr_created=false" >> $GITHUB_OUTPUT
         else
-          version="$(npm run --silent get-version)"
+          version="$(yarn run --silent get-version)"
           echo "Parsed version: ${version}"
           echo "version=${version}" >> $GITHUB_OUTPUT
           echo "pr_created=true" >> $GITHUB_OUTPUT
@@ -314,25 +331,13 @@ local runner = import 'runner.libsonnet',
       pr_created: '${{ steps.version.outputs.pr_created }}',
     }),
 
-  dist: function(buildImage, skipArm=true, useGCR=false, makeTargets=['dist', 'packages'], optionalTargets=[], runsOn='ubuntu-x64')
+  dist: function(buildImage, skipArm=true, makeTargets=['dist', 'packages'], optionalTargets=[], runsOn='ubuntu-x64')
     job.new(runsOn)
     + job.withPermissions({
       'id-token': 'write',
     })
     + job.withSteps([
       common.fetchReleaseRepo,
-      common.fetchGcsCredentials,
-      common.googleAuth,
-      common.setupGoogleCloudSdk,
-
-      step.new('get nfpm signing keys', 'grafana/shared-workflows/actions/get-vault-secrets@fa48192dac470ae356b3f7007229f3ac28c48a25')  // main
-      + step.withId('get-secrets')
-      + step.with({
-        common_secrets: |||
-          NFPM_SIGNING_KEY=packages-gpg:private-key
-          NFPM_PASSPHRASE=packages-gpg:passphrase
-        |||,
-      }),
 
       releaseStep('build artifacts')
       + step.withIf('${{ fromJSON(needs.version.outputs.pr_created) }}')
@@ -340,31 +345,21 @@ local runner = import 'runner.libsonnet',
         BUILD_IN_CONTAINER: false,
         DRONE_TAG: '${{ needs.version.outputs.version }}',
         IMAGE_TAG: '${{ needs.version.outputs.version }}',
-        NFPM_SIGNING_KEY_FILE: 'nfpm-private-key.key',
         SKIP_ARM: skipArm,
       })
       //TODO: the workdir here is loki specific
       + step.withRun(
-        (
-          if useGCR then |||
-            gcloud auth configure-docker
-          ||| else ''
-        ) +
         |||
           cat <<EOF | docker run \
             --interactive \
             --env BUILD_IN_CONTAINER \
             --env DRONE_TAG \
             --env IMAGE_TAG \
-            --env NFPM_PASSPHRASE \
-            --env NFPM_SIGNING_KEY \
-            --env NFPM_SIGNING_KEY_FILE \
             --env SKIP_ARM \
             --volume .:/src/loki \
             --workdir /src/loki \
             --entrypoint /bin/sh "%s"
             git config --global --add safe.directory /src/loki
-            echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
             if echo "%s" | grep -q "golang"; then
               /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
             fi
@@ -382,11 +377,6 @@ local runner = import 'runner.libsonnet',
         IMAGE_TAG: '${{ needs.version.outputs.version }}',
       })
       + if std.length(optionalTargets) > 0 then step.withRun(
-        (
-          if useGCR then |||
-            gcloud auth configure-docker
-          ||| else ''
-        ) +
         |||
           cat <<EOF | docker run \
             --interactive \
@@ -412,13 +402,21 @@ local runner = import 'runner.libsonnet',
         |||
       ),
 
-      step.new('upload artifacts', 'google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0')  // v2
+      step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136'),
+      releaseStep('upload artifacts')
       + step.withIf('${{ fromJSON(needs.version.outputs.pr_created) }}')
-      + step.with({
-        path: 'release/dist',
-        destination: '${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}',  //TODO: make bucket configurable
-        process_gcloudignore: false,
-      }),
+      + step.withEnv({
+        path: 'dist/',
+      })
+      + step.withRun(|||
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source-directory=${{env.path}} \
+          --package=binaries \
+          --version=${{ github.sha }}
+      |||),
     ])
     + job.withOutputs({
       version: '${{ needs.version.outputs.version }}',

--- a/.github/vendor/github.com/grafana/loki-release/workflows/common.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/common.libsonnet
@@ -106,9 +106,16 @@
 
   setupNode: $.step.new('setup node', 'actions/setup-node@v4')
              + $.step.with({
-               'node-version': 20,
+               'node-version': 24,
                'package-manager-cache': false,
              }),
+
+  // Enable Corepack so the pinned yarn version from package.json's
+  // packageManager field is provisioned. Required because the GitHub-hosted
+  // runners ship yarn 1.x by default, and `yarn install` / `yarn exec` would
+  // otherwise run under yarn 1.x against a yarn 4 lockfile.
+  enableCorepack: $.step.new('enable corepack')
+                  + $.step.withRun('corepack enable'),
 
   makeTarget: function(target) 'make %s' % target,
 
@@ -119,22 +126,7 @@
     ],
   },
 
-  fetchGcsCredentials: $.step.new('fetch gcs credentials from vault', 'grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760')
-                       + $.step.withId('fetch_gcs_credentials')
-                       + $.step.with({
-                         repo_secrets: 'GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key',
-                       }),
-
-  googleAuth: $.step.new('auth gcs', 'google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f')  // v2
-              + $.step.with({
-                credentials_json: '${{ env.GCS_SERVICE_ACCOUNT_KEY }}',
-              }),
-  setupGoogleCloudSdk: $.step.new('Set up Cloud SDK', 'google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a')  // v2
-                       + $.step.with({
-                         version: '>= 452.0.0',
-                       }),
-
-  extractBranchName: $.releaseStep('extract branch name')
+  extractBranchName: $.step.new('extract branch name')
                      + $.step.withId('extract_branch')
                      + $.step.withRun(|||
                        echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
@@ -147,34 +139,15 @@
 
   githubAppToken: $.step.new('get github app token', 'grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0')  // create-github-app-token/v0.2.2
                   + $.step.withId('get_github_app_token')
-                  + $.step.withIf('${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}')
                   + $.step.with({
                     github_app: '${{ env.GITHUB_APP }}',
                   }),
 
-  setToken: $.step.new('set github token')
-            + $.step.withId('github_app_token')
-            + $.step.withEnv({
-              OUTPUTS_TOKEN: '${{ steps.get_github_app_token.outputs.token }}',
-            })
-            + $.step.withRun(|||
-              if [[ "${USE_GITHUB_APP_TOKEN}" == "true" ]]; then
-                echo "token=$OUTPUTS_TOKEN" >> $GITHUB_OUTPUT
-              else
-                echo "token=${{ secrets.GH_TOKEN }}" >> $GITHUB_OUTPUT
-              fi
-            |||),
-
-  validationJob: function(useGCR=false)
+  validationJob: function()
     $.job.new()
     + $.job.withContainer({
       image: '${{ inputs.build_image }}',
-    } + if useGCR then {
-      credentials: {
-        username: '_json_key',
-        password: '${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}',
-      },
-    } else {})
+    })
     + $.job.withEnv({
       BUILD_IN_CONTAINER: false,
       SKIP_VALIDATION: '${{ inputs.skip_validation }}',

--- a/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
@@ -17,7 +17,6 @@
     distOptionalTargets=[],
     distRunsOn='ubuntu-x64',
     dryRun=false,
-    dockerUsername='grafana',
     golangCiLintVersion='v2.3.0',
     imageBuildTimeoutMin=25,
     imageJobs={},
@@ -27,11 +26,10 @@
     releaseRepo='grafana/loki-release',
     skipArm=false,
     skipValidation=false,
-    useGitHubAppToken=true,
-    useGCR=false,
     versioningStrategy='always-bump-patch',
                     ) {
     local githubApp = if releaseRepo == 'grafana/enterprise-logs' then 'enterprise-logs-app' else 'loki-gh-app',
+    local garRepoSlug = if releaseRepo == 'grafana/enterprise-logs' then 'enterprise-logs' else 'loki',
 
     name: 'create release PR',
     on: {
@@ -50,13 +48,12 @@
       BUILD_ARTIFACTS_BUCKET: buildArtifactsBucket,
       BUILD_TIMEOUT: imageBuildTimeoutMin,
       CHANGELOG_PATH: changelogPath,
-      DOCKER_USERNAME: dockerUsername,
       DRY_RUN: dryRun,
       IMAGE_PREFIX: imagePrefix,
       RELEASE_LIB_REF: releaseLibRef,
       RELEASE_REPO: releaseRepo,
+      GAR_REPO_SLUG: garRepoSlug,
       SKIP_VALIDATION: skipValidation,
-      USE_GITHUB_APP_TOKEN: useGitHubAppToken,
       VERSIONING_STRATEGY: versioningStrategy,
       GITHUB_APP: githubApp,
     } + if releaseAs != null then {
@@ -76,13 +73,9 @@
                build_image: buildImage,
                golang_ci_lint_version: golangCiLintVersion,
                release_lib_ref: releaseLibRef,
-               use_github_app_token: useGitHubAppToken,
-             })
-             + if useGCR then $.job.withSecrets({
-               GCS_SERVICE_ACCOUNT_KEY: '${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}',
-             }) else {},
+             }),
       version: $.build.version + $.common.job.withNeeds(validationSteps),
-      dist: $.build.dist(buildImage, skipArm, useGCR, distMakeTargets, distOptionalTargets, distRunsOn)
+      dist: $.build.dist(buildImage, skipArm, distMakeTargets, distOptionalTargets, distRunsOn)
             + $.common.job.withNeeds(['version'])
             + $.common.job.withPermissions({
               contents: 'write',
@@ -97,8 +90,6 @@
   releaseWorkflow: function(
     branches=['release-[0-9].[0-9].x', 'k[0-9]*'],
     buildArtifactsBucket='loki-build-artifacts',
-    dockerUsername='grafanabot',
-    getDockerCredsFromVault=false,
     imagePrefix='grafana',
     pluginBuildDir='release/plugin-tmp-dir',
     publishBucket='',
@@ -106,11 +97,11 @@
     releaseLibRef='main',
     releaseRepo='grafana/loki-release',
     releaseBranchTemplate='release-\\${major}.\\${minor}.x',
-    useGitHubAppToken=true,
     dockerPluginPath='clients/cmd/docker-driver',
     publishDockerPlugins=true,
                   ) {
     local githubApp = if releaseRepo == 'grafana/enterprise-logs' then 'enterprise-logs-app' else 'loki-gh-app',
+    local garRepoSlug = if releaseRepo == 'grafana/enterprise-logs' then 'enterprise-logs' else 'loki',
 
     name: 'create release',
     on: {
@@ -130,7 +121,7 @@
       IMAGE_PREFIX: imagePrefix,
       RELEASE_LIB_REF: releaseLibRef,
       RELEASE_REPO: releaseRepo,
-      USE_GITHUB_APP_TOKEN: useGitHubAppToken,
+      GAR_REPO_SLUG: garRepoSlug,
       GITHUB_APP: githubApp,
     } + if publishToGCS then {
       PUBLISH_BUCKET: publishBucket,
@@ -153,9 +144,9 @@
           'id-token': 'write',
         },
       },
-      publishImages: $.release.publishImages(getDockerCredsFromVault, dockerUsername),
+      publishImages: $.release.publishImages(),
     } + (if publishDockerPlugins then {
-           publishDockerPlugins: $.release.publishDockerPlugins(pluginBuildDir, getDockerCredsFromVault, dockerUsername),
+           publishDockerPlugins: $.release.publishDockerPlugins(pluginBuildDir),
            publishRelease: $.release.publishRelease(['createRelease', 'publishImages', 'publishDockerPlugins']),
          } else {
            publishRelease: $.release.publishRelease(['createRelease', 'publishImages']),
@@ -209,7 +200,6 @@
     },
     env: {
       RELEASE_LIB_REF: '${{ inputs.release_lib_ref }}',
-      USE_GITHUB_APP_TOKEN: '${{ inputs.use_github_app_token }}',
     },
     jobs: $.validate,
   },
@@ -248,12 +238,6 @@
             type: 'boolean',
           },
         },
-        secrets: {
-          GCS_SERVICE_ACCOUNT_KEY: {
-            description: 'GCS service account key',
-            required: false,
-          },
-        },
       },
     },
     permissions: {
@@ -265,7 +249,6 @@
     },
     env: {
       RELEASE_LIB_REF: '${{ inputs.release_lib_ref }}',
-      USE_GITHUB_APP_TOKEN: '${{ inputs.use_github_app_token }}',
     },
     jobs: $.validateGel,
   },

--- a/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
@@ -23,31 +23,31 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
       common.fetchReleaseRepo,
       common.fetchReleaseLib,
       common.setupNode,
+      common.enableCorepack,
       common.extractBranchName,
       common.githubAppToken,
-      common.setToken,
 
       releaseLibStep('release please')
       + step.withId('release')
       + step.withEnv({
         SHA: '${{ github.sha }}',
         OUTPUTS_BRANCH: '${{ steps.extract_branch.outputs.branch }}',
-        OUTPUTS_TOKEN: '${{ steps.github_app_token.outputs.token }}',
+        OUTPUTS_TOKEN: '${{ steps.get_github_app_token.outputs.token }}',
         OUTPUTS_VERSION: '${{ needs.dist.outputs.version }}',
       })
       //TODO make bucket configurable
       //TODO make a type/release in the backport action
       //TODO backport action should not bring over autorelease: pending label
       + step.withRun(|||
-        npm install
-        npm exec -- release-please release-pr \
+        yarn install
+        yarn exec -- release-please release-pr \
           --changelog-path "${CHANGELOG_PATH}" \
           --consider-all-branches \
-          --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+          --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
           --label "backport main,autorelease: pending,product-approved" \
           --manifest-file .release-please-manifest.json \
           --pull-request-footer "%s" \
-          --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+          --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
           --release-as "$(echo $OUTPUTS_VERSION | tr -d '"')" \
           --release-type simple \
           --repo-url "${{ env.RELEASE_REPO }}" \
@@ -93,25 +93,27 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
                    common.fetchReleaseRepo,
                    common.fetchReleaseLib,
                    common.setupNode,
-                   common.fetchGcsCredentials,
-                   common.googleAuth,
-                   common.setupGoogleCloudSdk,
+                   common.enableCorepack,
                    common.githubAppToken,
-                   common.setToken,
 
-                   // exits with code 1 if the url does not match
-                   // meaning there are no artifacts for that sha
-                   // we need to handle this if we're going to run this pipeline on every merge to main
+                   step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136'),
                    releaseStep('download binaries')
                    + step.withRun(|||
                      echo "downloading binaries to $(pwd)/dist"
-                     gsutil cp -r gs://${BUILD_ARTIFACTS_BUCKET}/$(echo ${SHA} | tr -d '"')/dist .
+                     mkdir -p dist
+                     gcloud artifacts generic download \
+                       --project="grafanalabs-dev" \
+                       --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+                       --location="us" \
+                       --package=binaries \
+                       --version=$(echo ${SHA} | tr -d '"') \
+                       --destination=dist/
                    |||),
 
                    releaseStep('check if release exists')
                    + step.withId('check_release')
                    + step.withEnv({
-                     GH_TOKEN: '${{ steps.github_app_token.outputs.token }}',
+                     GH_TOKEN: '${{ steps.get_github_app_token.outputs.token }}',
                      OUTPUTS_NAME: '${{ needs.shouldRelease.outputs.name }}',
                    })
                    + step.withRun(|||
@@ -134,13 +136,13 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
                    + step.withIf('${{ !fromJSON(steps.check_release.outputs.exists) }}')
                    + step.withEnv({
                      OUTPUTS_BRANCH: '${{ needs.shouldRelease.outputs.branch }}',
-                     OUTPUTS_TOKEN: '${{ steps.github_app_token.outputs.token }}',
+                     OUTPUTS_TOKEN: '${{ steps.get_github_app_token.outputs.token }}',
                      OUTPUTS_PR_NUMBER: '${{ needs.shouldRelease.outputs.prNumber }}',
                      SHA: '${{ needs.shouldRelease.outputs.sha }}',
                    })
                    + step.withRun(|||
-                     npm install
-                     npm exec -- release-please github-release \
+                     yarn install
+                     yarn exec -- release-please github-release \
                        --draft \
                        --release-type simple \
                        --repo-url "${{ env.RELEASE_REPO }}" \
@@ -152,20 +154,27 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
                    releaseStep('upload artifacts')
                    + step.withId('upload')
                    + step.withEnv({
-                     GH_TOKEN: '${{ steps.github_app_token.outputs.token }}',
+                     GH_TOKEN: '${{ steps.get_github_app_token.outputs.token }}',
                      OUTPUTS_NAME: '${{ needs.shouldRelease.outputs.name }}',
                    })
                    + step.withRun(|||
                      gh release upload --clobber $(echo $OUTPUTS_NAME | tr -d '"') dist/*
                    |||),
 
-                   step.new('release artifacts', 'google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0')  // v2
+                   releaseStep('release artifacts')
                    + step.withIf('${{ fromJSON(env.PUBLISH_TO_GCS) }}')
-                   + step.with({
+                   + step.withRun(|||
+                     echo "downloading binaries to $(pwd)/dist"
+                     gcloud artifacts generic upload \
+                       --project="grafanalabs-global" \
+                       --repository="generic-${{ env.GAR_REPO_SLUG }}-prod" \
+                       --location="us" \
+                       --source-directory=${{ env.path }}, \
+                       --package=binaries \
+                       --version=${{ github.sha }}
+                   |||)
+                   + step.withEnv({
                      path: 'release/dist',
-                     destination: '${{ env.PUBLISH_BUCKET }}',
-                     parent: false,
-                     process_gcloudignore: false,
                    }),
                  ])
                  + job.withOutputs({
@@ -176,7 +185,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
                    exists: '${{ steps.check_release.outputs.exists }}',
                  }),
 
-  publishImages: function(getDockerCredsFromVault=false, dockerUsername='grafanabot')
+  publishImages: function()
     job.new()
     + job.withNeeds(['createRelease'])
     + job.withPermissions({
@@ -185,33 +194,23 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
     + job.withSteps(
       [
         common.fetchReleaseLib,
-        common.fetchGcsCredentials,
-        common.googleAuth,
-        common.setupGoogleCloudSdk,
         step.new('Set up QEMU', 'docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392'),  // v3
         step.new('set up docker buildx', 'docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2'),  //v3
-      ] + (if getDockerCredsFromVault then [
-             step.new('Login to DockerHub (from vault)', 'grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25'),  // main
-           ] else [
-             step.new('fetch docker credentials from vault', 'grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760')
-             + step.withId('fetch_docker_credentials')
-             + step.with({
-               repo_secrets: 'DOCKER_PASSWORD=docker:password',
-             }),
-             step.new('Login to DockerHub (from secrets)', 'docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772')  // v3
-             + step.with({
-               username: dockerUsername,
-               password: '${{ env.DOCKER_PASSWORD }}',
-             }),
-           ]) +
-      [
+        step.new('Login to DockerHub', 'grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7'),  // v1.0.4
+        step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136'),  // v1.0.2
         step.new('download images')
         + step.withEnv({
           SHA: '${{ needs.createRelease.outputs.sha }}',
         })
         + step.withRun(|||
           echo "downloading images to $(pwd)/images"
-          gsutil cp -r gs://${BUILD_ARTIFACTS_BUCKET}/$(echo ${SHA} | tr -d '"')/images .
+          gcloud artifacts generic download \
+            --project="grafanalabs-dev" \
+            --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+            --location="us" \
+            --package=images \
+            --version=$(echo ${SHA} | tr -d '"') \
+            --destination=images/
         |||),
         step.new('publish docker images', './lib/actions/push-images')
         + step.with({
@@ -222,7 +221,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
       ]
     ),
 
-  publishDockerPlugins: function(path, getDockerCredsFromVault=false, dockerUsername='grafanabot')
+  publishDockerPlugins: function(path)
     job.new()
     + job.withNeeds(['createRelease'])
     + job.withPermissions({
@@ -232,33 +231,23 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
       [
         common.fetchReleaseLib,
         common.fetchReleaseRepo,
-        common.fetchGcsCredentials,
-        common.googleAuth,
-        common.setupGoogleCloudSdk,
         step.new('Set up QEMU', 'docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392'),  // v3
         step.new('set up docker buildx', 'docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2'),  //v3
-      ] + (if getDockerCredsFromVault then [
-             step.new('Login to DockerHub (from vault)', 'grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25'),  // main
-           ] else [
-             step.new('fetch docker credentials from vault', 'grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760')
-             + step.withId('fetch_docker_credentials')
-             + step.with({
-               repo_secrets: 'DOCKER_PASSWORD=docker:password',
-             }),
-             step.new('Login to DockerHub (from secrets)', 'docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772')  // v3
-             + step.with({
-               username: dockerUsername,
-               password: '${{ env.DOCKER_PASSWORD }}',
-             }),
-           ]) +
-      [
+        step.new('Login to DockerHub', 'grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7'),  // v1.0.4
+        step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136'),  // v1.0.2
         step.new('download and prepare plugins')
         + step.withEnv({
           SHA: '${{ needs.createRelease.outputs.sha }}',
         })
         + step.withRun(|||
-          echo "downloading images to $(pwd)/plugins"
-          gsutil cp -r gs://${BUILD_ARTIFACTS_BUCKET}/$(echo ${SHA} | tr -d '"')/plugins .
+          echo "downloading plugins to $(pwd)/plugins"
+          gcloud artifacts generic download \
+            --project="grafanalabs-dev" \
+            --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+            --location="us" \
+            --package=plugins \
+            --version=$(echo ${SHA} | tr -d '"') \
+            --destination=plugins/
           mkdir -p "release/%s"
         ||| % path),
         step.new('publish docker driver', './lib/actions/push-images')
@@ -282,11 +271,10 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
     + job.withSteps([
       common.fetchReleaseRepo,
       common.githubAppToken,
-      common.setToken,
       releaseStep('publish release')
       + step.withIf('${{ !fromJSON(needs.createRelease.outputs.exists) || (needs.createRelease.outputs.draft && fromJSON(needs.createRelease.outputs.draft)) }}')
       + step.withEnv({
-        GH_TOKEN: '${{ steps.github_app_token.outputs.token }}',
+        GH_TOKEN: '${{ steps.get_github_app_token.outputs.token }}',
         OUTPUTS_NAME: '${{ needs.createRelease.outputs.name }}',
         OUTPUTS_IS_LATEST: '${{ needs.createRelease.outputs.isLatest }}',
       })
@@ -308,16 +296,15 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
       common.fetchReleaseRepo,
       common.extractBranchName,
       common.githubAppToken,
-      common.setToken,
 
       releaseStep('create release branch')
       + step.withId('create_branch')
       + step.withEnv({
-        GH_TOKEN: '${{ steps.github_app_token.outputs.token }}',
+        GH_TOKEN: '${{ steps.get_github_app_token.outputs.token }}',
         VERSION: '${{ needs.publishRelease.outputs.name }}',
         OUTPUTS_NAME: '${{ needs.publishRelease.outputs.name }}',
         OUTPUTS_BRANCH: '${{ steps.extract_branch.outputs.branch }}',
-        OUTPUTS_TOKEN: '${{ steps.github_app_token.outputs.token }}',
+        OUTPUTS_TOKEN: '${{ steps.get_github_app_token.outputs.token }}',
       })
       + step.withRun(|||
         # Debug and clean the version variable

--- a/.github/vendor/github.com/grafana/loki-release/workflows/validate-gel.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/validate-gel.libsonnet
@@ -33,7 +33,7 @@ local setupValidationDeps = function(job) job {
   ] + job.steps,
 };
 
-local validationJob = _validationJob(false);
+local validationJob = _validationJob();
 
 
 {

--- a/.github/vendor/github.com/grafana/loki-release/workflows/validate.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/validate.libsonnet
@@ -175,7 +175,7 @@ local validationJob = _validationJob();
         + step.with({
           version: '${{ inputs.golang_ci_lint_version }}',
           'only-new-issues': false,  // we want a PR to fail if the target branch fails
-          args: '-v --timeout 15m --build-tags linux,promtail_journal_enabled',
+          args: '-v --timeout 15m --build-tags linux',
         }),
       ],
     )

--- a/.github/vendor/github.com/grafana/loki-release/workflows/validate.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/validate.libsonnet
@@ -30,7 +30,7 @@ local setupValidationDeps = function(job) job {
   ] + job.steps,
 };
 
-local validationJob = _validationJob(false);
+local validationJob = _validationJob();
 
 {
   local validationMakeStep = function(name, target)

--- a/.github/vendor/github.com/grafana/loki-release/workflows/workflows.jsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/workflows.jsonnet
@@ -15,7 +15,7 @@ local dockerPluginDir = 'clients/cmd/docker-driver';
       buildImage=buildImage,
       buildArtifactsBucket='loki-build-artifacts',
       branches=['release-[0-9]+.[0-9]+.x'],
-      imagePrefix='trevorwhitney075',
+      imagePrefix='us-docker.pkg.dev/grafanalabs-dev/docker-loki-dev',
       releaseLibRef='main',
       releaseRepo='grafana/loki-release',
       distRunsOn='ubuntu-26.04',
@@ -36,7 +36,7 @@ local dockerPluginDir = 'clients/cmd/docker-driver';
       buildArtifactsBucket='loki-build-artifacts',
       branches=['release-[0-9]+.[0-9]+.x'],
       dryRun=true,
-      imagePrefix='trevorwhitney075',
+      imagePrefix='us-docker.pkg.dev/grafanalabs-dev/docker-loki-dev',
       releaseLibRef='main',
       releaseRepo='grafana/loki-release',
       skipValidation=false,
@@ -52,13 +52,10 @@ local dockerPluginDir = 'clients/cmd/docker-driver';
     lokiRelease.releaseWorkflow(
       branches=['release-[0-9]+.[0-9]+.x'],
       buildArtifactsBucket='loki-build-artifacts',
-      dockerUsername='trevorwhitney075',
-      getDockerCredsFromVault=false,
-      imagePrefix='trevorwhitney075',
+      imagePrefix='us-docker.pkg.dev/grafanalabs-dev/docker-loki-dev',
       pluginBuildDir=dockerPluginDir,
       releaseLibRef='main',
       releaseRepo='grafana/loki-release',
-      useGitHubAppToken=true,
     ) + {
       name: 'Create Release',
       on+: {

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@a3091f6507615a4646e399870071074d66c30826"
     "with":
       "build_image": "golang:1.26.4"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+      "release_lib_ref": "a3091f6507615a4646e399870071074d66c30826"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@eb4e89778be445f9e79533b704cbdee404592eb4"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
     "with":
-      "build_image": "grafana/loki-build-image:0.35.2"
-      "golang_ci_lint_version": "v2.11.4"
-      "release_lib_ref": "eb4e89778be445f9e79533b704cbdee404592eb4"
+      "build_image": "golang:1.26.4"
+      "golang_ci_lint_version": "v2.10.1"
+      "release_lib_ref": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,18 +1,18 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@eb4e89778be445f9e79533b704cbdee404592eb4"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
     "with":
-      "build_image": "grafana/loki-build-image:0.35.2"
-      "golang_ci_lint_version": "v2.11.4"
-      "release_lib_ref": "eb4e89778be445f9e79533b704cbdee404592eb4"
+      "build_image": "golang:1.26.4"
+      "golang_ci_lint_version": "v2.10.1"
+      "release_lib_ref": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
       "skip_validation": false
       "use_github_app_token": true
-  "loki-canary-boringcrypto-image":
+  "logql-analyzer-image":
     "env":
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
-      "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "eb4e89778be445f9e79533b704cbdee404592eb4"
+      "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
+      "RELEASE_LIB_REF": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -43,12 +43,158 @@
     - "name": "setup node"
       "uses": "actions/setup-node@v4"
       "with":
-        "node-version": 20
+        "node-version": 24
         "package-manager-cache": false
+    - "name": "enable corepack"
+      "run": "corepack enable"
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25"
+    - "name": "Login to DockerHub"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
+    - "id": "weekly-version"
+      "name": "Get weekly version"
+      "run": |
+        version=$(./tools/image-tag)
+        echo "image_version=$version" >> $GITHUB_OUTPUT
+        echo "image_name=${{ env.IMAGE_PREFIX }}/logql-analyzer" >> $GITHUB_OUTPUT
+        echo "image_full_name=${{ env.IMAGE_PREFIX }}/logql-analyzer:$version" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "id": "platform"
+      "name": "Parse image platform"
+      "run": |
+        platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
+        echo "platform=${platform}" >> $GITHUB_OUTPUT
+        echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    - "id": "build-push"
+      "name": "Build and push"
+      "timeout-minutes": "${{ fromJSON(env.BUILD_TIMEOUT) }}"
+      "uses": "docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1"
+      "with":
+        "build-args": |
+          IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
+          GO_VERSION=${{ env.GO_VERSION }}
+        "context": "release"
+        "file": "release/cmd/logql-analyzer/Dockerfile"
+        "outputs": "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
+        "platforms": "${{ matrix.arch }}"
+        "provenance": true
+        "tags": "${{ steps.weekly-version.outputs.image_name }}"
+    - "env":
+        "OUTPUTS_DIGEST": "${{ steps.build-push.outputs.digest }}"
+      "id": "digest"
+      "name": "Process image digest"
+      "run": |
+        arch=$(echo ${{ matrix.arch }} | tr "/" "_")
+        echo "digest_$arch=$OUTPUTS_DIGEST" >> $GITHUB_OUTPUT
+      "working-directory": "release"
+    "strategy":
+      "fail-fast": true
+      "matrix":
+        "include":
+        - "arch": "linux/amd64"
+          "runs_on":
+          - "ubuntu-x64"
+        - "arch": "linux/arm64"
+          "runs_on":
+          - "ubuntu-arm64"
+        - "arch": "linux/arm"
+          "runs_on":
+          - "ubuntu-arm64"
+  "logql-analyzer-manifest":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "IMAGE_DIGEST_AMD64": "${{ needs.logql-analyzer-image.outputs.image_digest_linux_amd64 }}"
+      "IMAGE_DIGEST_ARM": "${{ needs.logql-analyzer-image.outputs.image_digest_linux_arm }}"
+      "IMAGE_DIGEST_ARM64": "${{ needs.logql-analyzer-image.outputs.image_digest_linux_arm64 }}"
+      "IMAGE_NAME": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror/logql-analyzer"
+      "OUTPUTS_IMAGE_NAME": "${{ needs.logql-analyzer-image.outputs.image_name }}"
+      "OUTPUTS_IMAGE_TAG": "${{ needs.logql-analyzer-image.outputs.image_tag }}"
+    "needs":
+    - "logql-analyzer-image"
+    "permissions":
+      "contents": "read"
+      "id-token": "write"
+    "runs-on": "ubuntu-x64"
+    "steps":
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
+    - "name": "Login to DockerHub"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
+    - "name": "Publish multi-arch manifest"
+      "run": |
+        # Unfortunately there is no better way atm than having a separate named output for each digest
+        echo "linux/arm64 $IMAGE_DIGEST_ARM64"
+        echo "linux/amd64 $IMAGE_DIGEST_AMD64"
+        echo "linux/arm   $IMAGE_DIGEST_ARM"
+        
+        # 'needs.logql-analyzer-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
+        # See https://github.com/actions/runner/issues/2316
+        # Using the IMAGE_NAME env variable instead
+        IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
+        echo "Create multi-arch manifest for $IMAGE"
+        docker buildx imagetools create -t $IMAGE \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+        docker buildx imagetools inspect $IMAGE
+  "loki-canary-boringcrypto-image":
+    "env":
+      "BUILD_TIMEOUT": 60
+      "GO_VERSION": "1.26.4"
+      "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
+      "RELEASE_LIB_REF": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+      "RELEASE_REPO": "grafana/loki"
+    "needs":
+    - "check"
+    "outputs":
+      "image_digest_linux_amd64": "${{ steps.digest.outputs.digest_linux_amd64 }}"
+      "image_digest_linux_arm": "${{ steps.digest.outputs.digest_linux_arm }}"
+      "image_digest_linux_arm64": "${{ steps.digest.outputs.digest_linux_arm64 }}"
+      "image_name": "${{ steps.weekly-version.outputs.image_name }}"
+      "image_tag": "${{ steps.weekly-version.outputs.image_version }}"
+    "permissions":
+      "contents": "read"
+      "id-token": "write"
+    "runs-on": "${{ matrix.runs_on }}"
+    "steps":
+    - "name": "pull release library code"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "lib"
+        "persist-credentials": false
+        "ref": "${{ env.RELEASE_LIB_REF }}"
+        "repository": "grafana/loki-release"
+    - "name": "pull code to release"
+      "uses": "actions/checkout@v4"
+      "with":
+        "path": "release"
+        "persist-credentials": false
+        "repository": "${{ env.RELEASE_REPO }}"
+    - "name": "setup node"
+      "uses": "actions/setup-node@v4"
+      "with":
+        "node-version": 24
+        "package-manager-cache": false
+    - "name": "enable corepack"
+      "run": "corepack enable"
+    - "name": "Set up Docker buildx"
+      "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
+    - "name": "Login to DockerHub"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
     - "id": "weekly-version"
       "name": "Get weekly version"
       "run": |
@@ -105,6 +251,7 @@
       "IMAGE_DIGEST_AMD64": "${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_amd64 }}"
       "IMAGE_DIGEST_ARM": "${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm }}"
       "IMAGE_DIGEST_ARM64": "${{ needs.loki-canary-boringcrypto-image.outputs.image_digest_linux_arm64 }}"
+      "IMAGE_NAME": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror/loki-canary-boringcrypto"
       "OUTPUTS_IMAGE_NAME": "${{ needs.loki-canary-boringcrypto-image.outputs.image_name }}"
       "OUTPUTS_IMAGE_TAG": "${{ needs.loki-canary-boringcrypto-image.outputs.image_tag }}"
     "needs":
@@ -116,27 +263,36 @@
     "steps":
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746"
+    - "name": "Login to DockerHub"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
         echo "linux/arm64 $IMAGE_DIGEST_ARM64"
         echo "linux/amd64 $IMAGE_DIGEST_AMD64"
         echo "linux/arm   $IMAGE_DIGEST_ARM"
-        IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
+        # 'needs.loki-canary-boringcrypto-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
+        # See https://github.com/actions/runner/issues/2316
+        # Using the IMAGE_NAME env variable instead
+        IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
   "loki-canary-image":
     "env":
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
-      "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "eb4e89778be445f9e79533b704cbdee404592eb4"
+      "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
+      "RELEASE_LIB_REF": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -167,12 +323,18 @@
     - "name": "setup node"
       "uses": "actions/setup-node@v4"
       "with":
-        "node-version": 20
+        "node-version": 24
         "package-manager-cache": false
+    - "name": "enable corepack"
+      "run": "corepack enable"
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25"
+    - "name": "Login to DockerHub"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
     - "id": "weekly-version"
       "name": "Get weekly version"
       "run": |
@@ -229,6 +391,7 @@
       "IMAGE_DIGEST_AMD64": "${{ needs.loki-canary-image.outputs.image_digest_linux_amd64 }}"
       "IMAGE_DIGEST_ARM": "${{ needs.loki-canary-image.outputs.image_digest_linux_arm }}"
       "IMAGE_DIGEST_ARM64": "${{ needs.loki-canary-image.outputs.image_digest_linux_arm64 }}"
+      "IMAGE_NAME": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror/loki-canary"
       "OUTPUTS_IMAGE_NAME": "${{ needs.loki-canary-image.outputs.image_name }}"
       "OUTPUTS_IMAGE_TAG": "${{ needs.loki-canary-image.outputs.image_tag }}"
     "needs":
@@ -240,27 +403,36 @@
     "steps":
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746"
+    - "name": "Login to DockerHub"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
         echo "linux/arm64 $IMAGE_DIGEST_ARM64"
         echo "linux/amd64 $IMAGE_DIGEST_AMD64"
         echo "linux/arm   $IMAGE_DIGEST_ARM"
-        IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
+        # 'needs.loki-canary-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
+        # See https://github.com/actions/runner/issues/2316
+        # Using the IMAGE_NAME env variable instead
+        IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
   "loki-image":
     "env":
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
-      "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "eb4e89778be445f9e79533b704cbdee404592eb4"
+      "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
+      "RELEASE_LIB_REF": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -291,12 +463,18 @@
     - "name": "setup node"
       "uses": "actions/setup-node@v4"
       "with":
-        "node-version": 20
+        "node-version": 24
         "package-manager-cache": false
+    - "name": "enable corepack"
+      "run": "corepack enable"
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25"
+    - "name": "Login to DockerHub"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
     - "id": "weekly-version"
       "name": "Get weekly version"
       "run": |
@@ -353,6 +531,7 @@
       "IMAGE_DIGEST_AMD64": "${{ needs.loki-image.outputs.image_digest_linux_amd64 }}"
       "IMAGE_DIGEST_ARM": "${{ needs.loki-image.outputs.image_digest_linux_arm }}"
       "IMAGE_DIGEST_ARM64": "${{ needs.loki-image.outputs.image_digest_linux_arm64 }}"
+      "IMAGE_NAME": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror/loki"
       "OUTPUTS_IMAGE_NAME": "${{ needs.loki-image.outputs.image_name }}"
       "OUTPUTS_IMAGE_TAG": "${{ needs.loki-image.outputs.image_tag }}"
     "needs":
@@ -364,27 +543,36 @@
     "steps":
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746"
+    - "name": "Login to DockerHub"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
         echo "linux/arm64 $IMAGE_DIGEST_ARM64"
         echo "linux/amd64 $IMAGE_DIGEST_AMD64"
         echo "linux/arm   $IMAGE_DIGEST_ARM"
-        IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
+        # 'needs.loki-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
+        # See https://github.com/actions/runner/issues/2316
+        # Using the IMAGE_NAME env variable instead
+        IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
-  "promtail-image":
+  "loki-query-tee-image":
     "env":
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
-      "IMAGE_PREFIX": "grafana"
-      "RELEASE_LIB_REF": "eb4e89778be445f9e79533b704cbdee404592eb4"
+      "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
+      "RELEASE_LIB_REF": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -415,19 +603,25 @@
     - "name": "setup node"
       "uses": "actions/setup-node@v4"
       "with":
-        "node-version": 20
+        "node-version": 24
         "package-manager-cache": false
+    - "name": "enable corepack"
+      "run": "corepack enable"
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25"
+    - "name": "Login to DockerHub"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
     - "id": "weekly-version"
       "name": "Get weekly version"
       "run": |
         version=$(./tools/image-tag)
         echo "image_version=$version" >> $GITHUB_OUTPUT
-        echo "image_name=${{ env.IMAGE_PREFIX }}/promtail" >> $GITHUB_OUTPUT
-        echo "image_full_name=${{ env.IMAGE_PREFIX }}/promtail:$version" >> $GITHUB_OUTPUT
+        echo "image_name=${{ env.IMAGE_PREFIX }}/loki-query-tee" >> $GITHUB_OUTPUT
+        echo "image_full_name=${{ env.IMAGE_PREFIX }}/loki-query-tee:$version" >> $GITHUB_OUTPUT
       "working-directory": "release"
     - "id": "platform"
       "name": "Parse image platform"
@@ -445,7 +639,7 @@
           IMAGE_TAG=${{ steps.weekly-version.outputs.image_version }}
           GO_VERSION=${{ env.GO_VERSION }}
         "context": "release"
-        "file": "release/clients/cmd/promtail/Dockerfile"
+        "file": "release/cmd/querytee/Dockerfile"
         "outputs": "push-by-digest=true,type=image,name=${{ steps.weekly-version.outputs.image_name }},push=true"
         "platforms": "${{ matrix.arch }}"
         "provenance": true
@@ -471,16 +665,17 @@
         - "arch": "linux/arm"
           "runs_on":
           - "ubuntu-arm64"
-  "promtail-manifest":
+  "loki-query-tee-manifest":
     "env":
       "BUILD_TIMEOUT": 60
-      "IMAGE_DIGEST_AMD64": "${{ needs.promtail-image.outputs.image_digest_linux_amd64 }}"
-      "IMAGE_DIGEST_ARM": "${{ needs.promtail-image.outputs.image_digest_linux_arm }}"
-      "IMAGE_DIGEST_ARM64": "${{ needs.promtail-image.outputs.image_digest_linux_arm64 }}"
-      "OUTPUTS_IMAGE_NAME": "${{ needs.promtail-image.outputs.image_name }}"
-      "OUTPUTS_IMAGE_TAG": "${{ needs.promtail-image.outputs.image_tag }}"
+      "IMAGE_DIGEST_AMD64": "${{ needs.loki-query-tee-image.outputs.image_digest_linux_amd64 }}"
+      "IMAGE_DIGEST_ARM": "${{ needs.loki-query-tee-image.outputs.image_digest_linux_arm }}"
+      "IMAGE_DIGEST_ARM64": "${{ needs.loki-query-tee-image.outputs.image_digest_linux_arm64 }}"
+      "IMAGE_NAME": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror/loki-query-tee"
+      "OUTPUTS_IMAGE_NAME": "${{ needs.loki-query-tee-image.outputs.image_name }}"
+      "OUTPUTS_IMAGE_TAG": "${{ needs.loki-query-tee-image.outputs.image_tag }}"
     "needs":
-    - "promtail-image"
+    - "loki-query-tee-image"
     "permissions":
       "contents": "read"
       "id-token": "write"
@@ -488,21 +683,50 @@
     "steps":
     - "name": "Set up Docker buildx"
       "uses": "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - "name": "Login to DockerHub (from Vault)"
-      "uses": "grafana/shared-workflows/actions/dockerhub-login@75804962c1ba608148988c1e2dc35fbb0ee21746"
+    - "name": "Login to DockerHub"
+      "uses": "grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7"
+    - "name": "Login to GAR"
+      "uses": "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      "with":
+        "registry": "us-docker.pkg.dev"
     - "name": "Publish multi-arch manifest"
       "run": |
         # Unfortunately there is no better way atm than having a separate named output for each digest
         echo "linux/arm64 $IMAGE_DIGEST_ARM64"
         echo "linux/amd64 $IMAGE_DIGEST_AMD64"
         echo "linux/arm   $IMAGE_DIGEST_ARM"
-        IMAGE="${OUTPUTS_IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
+        # 'needs.loki-query-tee-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
+        # See https://github.com/actions/runner/issues/2316
+        # Using the IMAGE_NAME env variable instead
+        IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
+        
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
-          ${OUTPUTS_IMAGE_NAME}@${IMAGE_DIGEST_ARM}
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
+          ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
+  "trigger-cd":
+    "env":
+      "IMAGE_TAG": "${{ needs.loki-image.outputs.image_tag }}"
+    "if": "github.ref == 'refs/heads/main'"
+    "needs":
+    - "loki-image"
+    - "loki-manifest"
+    - "loki-canary-manifest"
+    "permissions":
+      "contents": "read"
+      "id-token": "write"
+    "runs-on": "ubuntu-x64"
+    "steps":
+    - "name": "Trigger CD workflow"
+      "uses": "grafana/shared-workflows/actions/trigger-argo-workflow@8b88213bca76e86f9f59b43038cc5d7545452436"
+      "with":
+        "instance": "ops"
+        "namespace": "loki-cd"
+        "parameters": "imageTag=${{ env.IMAGE_TAG }}"
+        "workflow_template": "loki-continuous-deployment"
 "name": "Publish images"
 "on":
   "push":

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@a3091f6507615a4646e399870071074d66c30826"
     "with":
       "build_image": "golang:1.26.4"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+      "release_lib_ref": "a3091f6507615a4646e399870071074d66c30826"
       "skip_validation": false
       "use_github_app_token": true
   "logql-analyzer-image":
@@ -12,7 +12,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+      "RELEASE_LIB_REF": "a3091f6507615a4646e399870071074d66c30826"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -152,7 +152,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+      "RELEASE_LIB_REF": "a3091f6507615a4646e399870071074d66c30826"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -292,7 +292,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+      "RELEASE_LIB_REF": "a3091f6507615a4646e399870071074d66c30826"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -432,7 +432,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+      "RELEASE_LIB_REF": "a3091f6507615a4646e399870071074d66c30826"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -572,7 +572,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+      "RELEASE_LIB_REF": "a3091f6507615a4646e399870071074d66c30826"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -8,7 +8,7 @@ env:
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+  RELEASE_LIB_REF: "a3091f6507615a4646e399870071074d66c30826"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   VERSIONING_STRATEGY: "always-bump-minor"
@@ -18,11 +18,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+    uses: "grafana/loki-release/.github/workflows/check.yml@a3091f6507615a4646e399870071074d66c30826"
     with:
       build_image: "golang:1.26.4"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+      release_lib_ref: "a3091f6507615a4646e399870071074d66c30826"
       skip_validation: false
   create-release-pr:
     needs:

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -4,14 +4,13 @@ env:
   BUILD_ARTIFACTS_BUCKET: "loki-build-artifacts"
   BUILD_TIMEOUT: 60
   CHANGELOG_PATH: "CHANGELOG.md"
-  DOCKER_USERNAME: "grafana"
   DRY_RUN: false
+  GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "eb4e89778be445f9e79533b704cbdee404592eb4"
+  RELEASE_LIB_REF: "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
-  USE_GITHUB_APP_TOKEN: true
   VERSIONING_STRATEGY: "always-bump-minor"
 jobs:
   check:
@@ -19,13 +18,12 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@eb4e89778be445f9e79533b704cbdee404592eb4"
+    uses: "grafana/loki-release/.github/workflows/check.yml@1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
     with:
-      build_image: "grafana/loki-build-image:0.35.2"
-      golang_ci_lint_version: "v2.11.4"
-      release_lib_ref: "eb4e89778be445f9e79533b704cbdee404592eb4"
+      build_image: "golang:1.26.4"
+      golang_ci_lint_version: "v2.10.1"
+      release_lib_ref: "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
       skip_validation: false
-      use_github_app_token: true
   create-release-pr:
     needs:
     - "dist"
@@ -37,7 +35,7 @@ jobs:
     - "loki-canary"
     - "loki-canary-boringcrypto"
     - "loki-docker-driver"
-    - "promtail"
+    - "loki-helm-test"
     - "querytee"
     permissions:
       contents: "write"
@@ -61,46 +59,36 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
+    - name: "enable corepack"
+      run: "corepack enable"
     - id: "extract_branch"
       name: "extract branch name"
       run: |
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-      working-directory: "release"
     - id: "get_github_app_token"
-      if: "${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}"
       name: "get github app token"
       uses: "grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0"
       with:
         github_app: "${{ env.GITHUB_APP }}"
     - env:
-        OUTPUTS_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"
-      id: "github_app_token"
-      name: "set github token"
-      run: |
-        if [[ "${USE_GITHUB_APP_TOKEN}" == "true" ]]; then
-          echo "token=$OUTPUTS_TOKEN" >> $GITHUB_OUTPUT
-        else
-          echo "token=${{ secrets.GH_TOKEN }}" >> $GITHUB_OUTPUT
-        fi
-    - env:
         OUTPUTS_BRANCH: "${{ steps.extract_branch.outputs.branch }}"
-        OUTPUTS_TOKEN: "${{ steps.github_app_token.outputs.token }}"
+        OUTPUTS_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"
         OUTPUTS_VERSION: "${{ needs.dist.outputs.version }}"
         SHA: "${{ github.sha }}"
       id: "release"
       name: "release please"
       run: |
-        npm install
-        npm exec -- release-please release-pr \
+        yarn install
+        yarn exec -- release-please release-pr \
           --changelog-path "${CHANGELOG_PATH}" \
           --consider-all-branches \
-          --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+          --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
           --label "backport main,autorelease: pending,product-approved" \
           --manifest-file .release-please-manifest.json \
           --pull-request-footer "Merging this PR will release the [artifacts](https://console.cloud.google.com/storage/browser/${BUILD_ARTIFACTS_BUCKET}/${SHA}) of ${SHA}" \
-          --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+          --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
           --release-as "$(echo $OUTPUTS_VERSION | tr -d '"')" \
           --release-type simple \
           --repo-url "${{ env.RELEASE_REPO }}" \
@@ -127,31 +115,10 @@ jobs:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up Cloud SDK"
-      uses: "google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a"
-      with:
-        version: ">= 452.0.0"
-    - id: "get-secrets"
-      name: "get nfpm signing keys"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@fa48192dac470ae356b3f7007229f3ac28c48a25"
-      with:
-        common_secrets: |
-          NFPM_SIGNING_KEY=packages-gpg:private-key
-          NFPM_PASSPHRASE=packages-gpg:passphrase
     - env:
         BUILD_IN_CONTAINER: false
         DRONE_TAG: "${{ needs.version.outputs.version }}"
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
-        NFPM_SIGNING_KEY_FILE: "nfpm-private-key.key"
         SKIP_ARM: false
       if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "build artifacts"
@@ -161,16 +128,12 @@ jobs:
           --env BUILD_IN_CONTAINER \
           --env DRONE_TAG \
           --env IMAGE_TAG \
-          --env NFPM_PASSPHRASE \
-          --env NFPM_SIGNING_KEY \
-          --env NFPM_SIGNING_KEY_FILE \
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.35.2"
+          --entrypoint /bin/sh "golang:1.26.4"
           git config --global --add safe.directory /src/loki
-          echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
-          if echo "grafana/loki-build-image:0.35.2" | grep -q "golang"; then
+          if echo "golang:1.26.4" | grep -q "golang"; then
             /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
           fi
           make dist packages
@@ -184,15 +147,36 @@ jobs:
       if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "build optional artifacts"
       run: |
-        echo "Nothing to do"
+        cat <<EOF | docker run \
+          --interactive \
+          --env BUILD_IN_CONTAINER \
+          --env DRONE_TAG \
+          --env IMAGE_TAG \
+          --volume .:/src/loki \
+          --workdir /src/loki \
+          --entrypoint /bin/sh "golang:1.26.4"
+          git config --global --add safe.directory /src/loki
+          if echo "golang:1.26.4" | grep -q "golang"; then
+            /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
+          fi
+          make dist/loki-linux-riscv64
+        EOF
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "dist/"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}"
-        path: "release/dist"
-        process_gcloudignore: false
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source-directory=${{env.path}} \
+          --package=binaries \
+          --version=${{ github.sha }}
+      working-directory: "release"
   fluent-bit:
     needs:
     - "version"
@@ -218,17 +202,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -253,13 +230,21 @@ jobs:
         outputs: "type=docker,dest=release/images/fluent-bit-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/fluent-bit-plugin-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/fluent-bit-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/fluent-bit-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -292,17 +277,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -327,13 +305,21 @@ jobs:
         outputs: "type=docker,dest=release/images/fluent-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/fluent-plugin-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/fluent-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/fluent-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -366,17 +352,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -401,13 +380,21 @@ jobs:
         outputs: "type=docker,dest=release/images/logcli-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/logcli:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/logcli-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/logcli-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -446,17 +433,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -481,13 +461,21 @@ jobs:
         outputs: "type=docker,dest=release/images/logstash-output-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/logstash-output-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/logstash-output-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/logstash-output-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -520,17 +508,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -555,13 +536,21 @@ jobs:
         outputs: "type=docker,dest=release/images/loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -600,17 +589,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -635,13 +617,21 @@ jobs:
         outputs: "type=docker,dest=release/images/loki-canary-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-canary:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/loki-canary-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/loki-canary-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -680,17 +670,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -715,13 +698,21 @@ jobs:
         outputs: "type=docker,dest=release/images/loki-canary-boringcrypto-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/loki-canary-boringcrypto-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/loki-canary-boringcrypto-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -758,17 +749,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392"
     - name: "set up docker buildx"
@@ -796,7 +780,7 @@ jobs:
         build-args: |
           IMAGE_TAG=${{ needs.version.outputs.version }}
           GOARCH=${{ steps.platform.outputs.platform_short }}
-          BUILD_IMAGE=grafana/loki-build-image:0.35.2
+          BUILD_IMAGE=golang:1.26.4
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=local,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}"
@@ -812,13 +796,21 @@ jobs:
         tar -cf release/plugins/loki-docker-driver-${OUTPUTS_VERSION}-${OUTPUTS_PLATFORM}.tar \
         -C release/plugins/loki-docker-driver-${OUTPUTS_VERSION}-${OUTPUTS_PLATFORM} \
         .
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/plugins"
-        path: "release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=plugins \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -829,7 +821,7 @@ jobs:
         - arch: "linux/arm64"
           runs_on:
           - "ubuntu-arm64"
-  promtail:
+  loki-helm-test:
     needs:
     - "version"
     permissions:
@@ -854,17 +846,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -885,17 +870,25 @@ jobs:
       with:
         build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
-        file: "release/clients/cmd/promtail/Dockerfile"
-        outputs: "type=docker,dest=release/images/promtail-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        file: "release/production/helm/loki/src/helm-test/Dockerfile"
+        outputs: "type=docker,dest=release/images/loki-helm-test-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
-        tags: "${{ env.IMAGE_PREFIX }}/promtail:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/promtail-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+        tags: "${{ env.IMAGE_PREFIX }}/loki-helm-test:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/loki-helm-test-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -934,17 +927,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -969,13 +955,21 @@ jobs:
         outputs: "type=docker,dest=release/images/loki-query-tee-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-query-tee:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/loki-query-tee-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/loki-query-tee-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -1014,45 +1008,35 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
+    - name: "enable corepack"
+      run: "corepack enable"
     - id: "extract_branch"
       name: "extract branch name"
       run: |
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-      working-directory: "release"
     - id: "get_github_app_token"
-      if: "${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}"
       name: "get github app token"
       uses: "grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0"
       with:
         github_app: "${{ env.GITHUB_APP }}"
     - env:
-        OUTPUTS_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"
-      id: "github_app_token"
-      name: "set github token"
-      run: |
-        if [[ "${USE_GITHUB_APP_TOKEN}" == "true" ]]; then
-          echo "token=$OUTPUTS_TOKEN" >> $GITHUB_OUTPUT
-        else
-          echo "token=${{ secrets.GH_TOKEN }}" >> $GITHUB_OUTPUT
-        fi
-    - env:
         OUTPUTS_BRANCH: "${{ steps.extract_branch.outputs.branch }}"
-        OUTPUTS_TOKEN: "${{ steps.github_app_token.outputs.token }}"
+        OUTPUTS_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"
       id: "version"
       name: "get release version"
       run: |
-        npm install
+        yarn install
         
         if [[ -z "${{ env.RELEASE_AS }}" ]]; then
-          npm exec -- release-please release-pr \
+          yarn exec -- release-please release-pr \
             --consider-all-branches \
             --dry-run \
             --dry-run-output release.json \
-            --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --manifest-file .release-please-manifest.json \
-            --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --release-type simple \
             --repo-url "${{ env.RELEASE_REPO }}" \
             --separate-pull-requests false \
@@ -1060,13 +1044,13 @@ jobs:
             --token "$OUTPUTS_TOKEN" \
             --versioning-strategy "${{ env.VERSIONING_STRATEGY }}"
         else
-          npm exec -- release-please release-pr \
+          yarn exec -- release-please release-pr \
             --consider-all-branches \
             --dry-run \
             --dry-run-output release.json \
-            --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --manifest-file .release-please-manifest.json \
-            --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --release-type simple \
             --repo-url "${{ env.RELEASE_REPO }}" \
             --separate-pull-requests false \
@@ -1086,7 +1070,7 @@ jobs:
         if [[ `jq length release.json` -eq 0 ]]; then 
           echo "pr_created=false" >> $GITHUB_OUTPUT
         else
-          version="$(npm run --silent get-version)"
+          version="$(yarn run --silent get-version)"
           echo "Parsed version: ${version}"
           echo "version=${version}" >> $GITHUB_OUTPUT
           echo "pr_created=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -4,14 +4,13 @@ env:
   BUILD_ARTIFACTS_BUCKET: "loki-build-artifacts"
   BUILD_TIMEOUT: 60
   CHANGELOG_PATH: "CHANGELOG.md"
-  DOCKER_USERNAME: "grafana"
   DRY_RUN: false
+  GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "eb4e89778be445f9e79533b704cbdee404592eb4"
+  RELEASE_LIB_REF: "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
-  USE_GITHUB_APP_TOKEN: true
   VERSIONING_STRATEGY: "always-bump-patch"
 jobs:
   check:
@@ -19,13 +18,12 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@eb4e89778be445f9e79533b704cbdee404592eb4"
+    uses: "grafana/loki-release/.github/workflows/check.yml@1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
     with:
-      build_image: "grafana/loki-build-image:0.35.2"
-      golang_ci_lint_version: "v2.11.4"
-      release_lib_ref: "eb4e89778be445f9e79533b704cbdee404592eb4"
+      build_image: "golang:1.26.4"
+      golang_ci_lint_version: "v2.10.1"
+      release_lib_ref: "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
       skip_validation: false
-      use_github_app_token: true
   create-release-pr:
     needs:
     - "dist"
@@ -37,7 +35,7 @@ jobs:
     - "loki-canary"
     - "loki-canary-boringcrypto"
     - "loki-docker-driver"
-    - "promtail"
+    - "loki-helm-test"
     - "querytee"
     permissions:
       contents: "write"
@@ -61,46 +59,36 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
+    - name: "enable corepack"
+      run: "corepack enable"
     - id: "extract_branch"
       name: "extract branch name"
       run: |
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-      working-directory: "release"
     - id: "get_github_app_token"
-      if: "${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}"
       name: "get github app token"
       uses: "grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0"
       with:
         github_app: "${{ env.GITHUB_APP }}"
     - env:
-        OUTPUTS_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"
-      id: "github_app_token"
-      name: "set github token"
-      run: |
-        if [[ "${USE_GITHUB_APP_TOKEN}" == "true" ]]; then
-          echo "token=$OUTPUTS_TOKEN" >> $GITHUB_OUTPUT
-        else
-          echo "token=${{ secrets.GH_TOKEN }}" >> $GITHUB_OUTPUT
-        fi
-    - env:
         OUTPUTS_BRANCH: "${{ steps.extract_branch.outputs.branch }}"
-        OUTPUTS_TOKEN: "${{ steps.github_app_token.outputs.token }}"
+        OUTPUTS_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"
         OUTPUTS_VERSION: "${{ needs.dist.outputs.version }}"
         SHA: "${{ github.sha }}"
       id: "release"
       name: "release please"
       run: |
-        npm install
-        npm exec -- release-please release-pr \
+        yarn install
+        yarn exec -- release-please release-pr \
           --changelog-path "${CHANGELOG_PATH}" \
           --consider-all-branches \
-          --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+          --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
           --label "backport main,autorelease: pending,product-approved" \
           --manifest-file .release-please-manifest.json \
           --pull-request-footer "Merging this PR will release the [artifacts](https://console.cloud.google.com/storage/browser/${BUILD_ARTIFACTS_BUCKET}/${SHA}) of ${SHA}" \
-          --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+          --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
           --release-as "$(echo $OUTPUTS_VERSION | tr -d '"')" \
           --release-type simple \
           --repo-url "${{ env.RELEASE_REPO }}" \
@@ -127,31 +115,10 @@ jobs:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up Cloud SDK"
-      uses: "google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a"
-      with:
-        version: ">= 452.0.0"
-    - id: "get-secrets"
-      name: "get nfpm signing keys"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@fa48192dac470ae356b3f7007229f3ac28c48a25"
-      with:
-        common_secrets: |
-          NFPM_SIGNING_KEY=packages-gpg:private-key
-          NFPM_PASSPHRASE=packages-gpg:passphrase
     - env:
         BUILD_IN_CONTAINER: false
         DRONE_TAG: "${{ needs.version.outputs.version }}"
         IMAGE_TAG: "${{ needs.version.outputs.version }}"
-        NFPM_SIGNING_KEY_FILE: "nfpm-private-key.key"
         SKIP_ARM: false
       if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "build artifacts"
@@ -161,16 +128,12 @@ jobs:
           --env BUILD_IN_CONTAINER \
           --env DRONE_TAG \
           --env IMAGE_TAG \
-          --env NFPM_PASSPHRASE \
-          --env NFPM_SIGNING_KEY \
-          --env NFPM_SIGNING_KEY_FILE \
           --env SKIP_ARM \
           --volume .:/src/loki \
           --workdir /src/loki \
-          --entrypoint /bin/sh "grafana/loki-build-image:0.35.2"
+          --entrypoint /bin/sh "golang:1.26.4"
           git config --global --add safe.directory /src/loki
-          echo "${NFPM_SIGNING_KEY}" > $NFPM_SIGNING_KEY_FILE
-          if echo "grafana/loki-build-image:0.35.2" | grep -q "golang"; then
+          if echo "golang:1.26.4" | grep -q "golang"; then
             /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
           fi
           make dist packages
@@ -184,15 +147,36 @@ jobs:
       if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "build optional artifacts"
       run: |
-        echo "Nothing to do"
+        cat <<EOF | docker run \
+          --interactive \
+          --env BUILD_IN_CONTAINER \
+          --env DRONE_TAG \
+          --env IMAGE_TAG \
+          --volume .:/src/loki \
+          --workdir /src/loki \
+          --entrypoint /bin/sh "golang:1.26.4"
+          git config --global --add safe.directory /src/loki
+          if echo "golang:1.26.4" | grep -q "golang"; then
+            /src/loki/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh dist
+          fi
+          make dist/loki-linux-riscv64
+        EOF
       working-directory: "release"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "dist/"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}"
-        path: "release/dist"
-        process_gcloudignore: false
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source-directory=${{env.path}} \
+          --package=binaries \
+          --version=${{ github.sha }}
+      working-directory: "release"
   fluent-bit:
     needs:
     - "version"
@@ -218,17 +202,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -253,13 +230,21 @@ jobs:
         outputs: "type=docker,dest=release/images/fluent-bit-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/fluent-bit-plugin-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/fluent-bit-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/fluent-bit-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -292,17 +277,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -327,13 +305,21 @@ jobs:
         outputs: "type=docker,dest=release/images/fluent-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/fluent-plugin-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/fluent-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/fluent-plugin-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -366,17 +352,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -401,13 +380,21 @@ jobs:
         outputs: "type=docker,dest=release/images/logcli-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/logcli:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/logcli-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/logcli-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -446,17 +433,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -481,13 +461,21 @@ jobs:
         outputs: "type=docker,dest=release/images/logstash-output-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/logstash-output-loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/logstash-output-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/logstash-output-loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -520,17 +508,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -555,13 +536,21 @@ jobs:
         outputs: "type=docker,dest=release/images/loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/loki-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -600,17 +589,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -635,13 +617,21 @@ jobs:
         outputs: "type=docker,dest=release/images/loki-canary-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-canary:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/loki-canary-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/loki-canary-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -680,17 +670,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -715,13 +698,21 @@ jobs:
         outputs: "type=docker,dest=release/images/loki-canary-boringcrypto-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-canary-boringcrypto:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/loki-canary-boringcrypto-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/loki-canary-boringcrypto-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -758,17 +749,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392"
     - name: "set up docker buildx"
@@ -796,7 +780,7 @@ jobs:
         build-args: |
           IMAGE_TAG=${{ needs.version.outputs.version }}
           GOARCH=${{ steps.platform.outputs.platform_short }}
-          BUILD_IMAGE=grafana/loki-build-image:0.35.2
+          BUILD_IMAGE=golang:1.26.4
         context: "release"
         file: "release/clients/cmd/docker-driver/Dockerfile"
         outputs: "type=local,dest=release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}"
@@ -812,13 +796,21 @@ jobs:
         tar -cf release/plugins/loki-docker-driver-${OUTPUTS_VERSION}-${OUTPUTS_PLATFORM}.tar \
         -C release/plugins/loki-docker-driver-${OUTPUTS_VERSION}-${OUTPUTS_PLATFORM} \
         .
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
       name: "upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/plugins"
-        path: "release/plugins/loki-docker-driver-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{env.path}} \
+          --package=plugins \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -829,7 +821,7 @@ jobs:
         - arch: "linux/arm64"
           runs_on:
           - "ubuntu-arm64"
-  promtail:
+  loki-helm-test:
     needs:
     - "version"
     permissions:
@@ -854,17 +846,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -885,17 +870,25 @@ jobs:
       with:
         build-args: "IMAGE_TAG=${{ needs.version.outputs.version }}"
         context: "release"
-        file: "release/clients/cmd/promtail/Dockerfile"
-        outputs: "type=docker,dest=release/images/promtail-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+        file: "release/production/helm/loki/src/helm-test/Dockerfile"
+        outputs: "type=docker,dest=release/images/loki-helm-test-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
-        tags: "${{ env.IMAGE_PREFIX }}/promtail:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/promtail-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+        tags: "${{ env.IMAGE_PREFIX }}/loki-helm-test:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/loki-helm-test-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -934,17 +927,10 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
+    - name: "enable corepack"
+      run: "corepack enable"
     - name: "Set up Docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
     - id: "platform"
@@ -969,13 +955,21 @@ jobs:
         outputs: "type=docker,dest=release/images/loki-query-tee-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
         platforms: "${{ matrix.arch }}"
         tags: "${{ env.IMAGE_PREFIX }}/loki-query-tee:${{ needs.version.outputs.version }}-${{ steps.platform.outputs.platform_short }}"
-    - if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
-      name: "Upload artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.BUILD_ARTIFACTS_BUCKET }}/${{ github.sha }}/images"
-        path: "release/images/loki-query-tee-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
-        process_gcloudignore: false
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+    - env:
+        path: "images/loki-query-tee-${{ needs.version.outputs.version}}-${{ steps.platform.outputs.platform }}.tar"
+      if: "${{ fromJSON(needs.version.outputs.pr_created) }}"
+      name: "upload artifacts"
+      run: |
+        gcloud artifacts generic upload \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --source=${{ env.path }} \
+          --package=images \
+          --version=${{ github.sha }}
+      working-directory: "release"
     strategy:
       fail-fast: true
       matrix:
@@ -1014,45 +1008,35 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
+    - name: "enable corepack"
+      run: "corepack enable"
     - id: "extract_branch"
       name: "extract branch name"
       run: |
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-      working-directory: "release"
     - id: "get_github_app_token"
-      if: "${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}"
       name: "get github app token"
       uses: "grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0"
       with:
         github_app: "${{ env.GITHUB_APP }}"
     - env:
-        OUTPUTS_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"
-      id: "github_app_token"
-      name: "set github token"
-      run: |
-        if [[ "${USE_GITHUB_APP_TOKEN}" == "true" ]]; then
-          echo "token=$OUTPUTS_TOKEN" >> $GITHUB_OUTPUT
-        else
-          echo "token=${{ secrets.GH_TOKEN }}" >> $GITHUB_OUTPUT
-        fi
-    - env:
         OUTPUTS_BRANCH: "${{ steps.extract_branch.outputs.branch }}"
-        OUTPUTS_TOKEN: "${{ steps.github_app_token.outputs.token }}"
+        OUTPUTS_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"
       id: "version"
       name: "get release version"
       run: |
-        npm install
+        yarn install
         
         if [[ -z "${{ env.RELEASE_AS }}" ]]; then
-          npm exec -- release-please release-pr \
+          yarn exec -- release-please release-pr \
             --consider-all-branches \
             --dry-run \
             --dry-run-output release.json \
-            --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --manifest-file .release-please-manifest.json \
-            --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --release-type simple \
             --repo-url "${{ env.RELEASE_REPO }}" \
             --separate-pull-requests false \
@@ -1060,13 +1044,13 @@ jobs:
             --token "$OUTPUTS_TOKEN" \
             --versioning-strategy "${{ env.VERSIONING_STRATEGY }}"
         else
-          npm exec -- release-please release-pr \
+          yarn exec -- release-please release-pr \
             --consider-all-branches \
             --dry-run \
             --dry-run-output release.json \
-            --group-pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --manifest-file .release-please-manifest.json \
-            --pull-request-title-pattern "chore\${scope}: release\${component} \${version}" \
+            --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
             --release-type simple \
             --repo-url "${{ env.RELEASE_REPO }}" \
             --separate-pull-requests false \
@@ -1086,7 +1070,7 @@ jobs:
         if [[ `jq length release.json` -eq 0 ]]; then 
           echo "pr_created=false" >> $GITHUB_OUTPUT
         else
-          version="$(npm run --silent get-version)"
+          version="$(yarn run --silent get-version)"
           echo "Parsed version: ${version}"
           echo "version=${version}" >> $GITHUB_OUTPUT
           echo "pr_created=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -8,7 +8,7 @@ env:
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+  RELEASE_LIB_REF: "a3091f6507615a4646e399870071074d66c30826"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   VERSIONING_STRATEGY: "always-bump-patch"
@@ -18,11 +18,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+    uses: "grafana/loki-release/.github/workflows/check.yml@a3091f6507615a4646e399870071074d66c30826"
     with:
       build_image: "golang:1.26.4"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+      release_lib_ref: "a3091f6507615a4646e399870071074d66c30826"
       skip_validation: false
   create-release-pr:
     needs:

--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -6,16 +6,19 @@ on:
       - main
     paths:
       - "docs/sources/**"
-  workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   sync:
     if: github.repository == 'grafana/loki'
     permissions:
       contents: read
       id-token: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: grafana/writers-toolkit/publish-technical-documentation@publish-technical-documentation/v1

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -9,15 +9,19 @@ on:
     paths:
       - "docs/sources/**"
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   sync:
     if: github.repository == 'grafana/loki'
     permissions:
       contents: read
       id-token: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,12 @@ concurrency:
   group: "create-release-${{ github.sha }}"
 env:
   BUILD_ARTIFACTS_BUCKET: "loki-build-artifacts"
+  GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "eb4e89778be445f9e79533b704cbdee404592eb4"
+  RELEASE_LIB_REF: "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
   RELEASE_REPO: "grafana/loki"
-  USE_GITHUB_APP_TOKEN: true
 jobs:
   createRelease:
     env:
@@ -43,44 +43,31 @@ jobs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-        node-version: 20
+        node-version: 24
         package-manager-cache: false
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up Cloud SDK"
-      uses: "google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a"
-      with:
-        version: ">= 452.0.0"
+    - name: "enable corepack"
+      run: "corepack enable"
     - id: "get_github_app_token"
-      if: "${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}"
       name: "get github app token"
       uses: "grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0"
       with:
         github_app: "${{ env.GITHUB_APP }}"
-    - env:
-        OUTPUTS_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"
-      id: "github_app_token"
-      name: "set github token"
-      run: |
-        if [[ "${USE_GITHUB_APP_TOKEN}" == "true" ]]; then
-          echo "token=$OUTPUTS_TOKEN" >> $GITHUB_OUTPUT
-        else
-          echo "token=${{ secrets.GH_TOKEN }}" >> $GITHUB_OUTPUT
-        fi
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
     - name: "download binaries"
       run: |
         echo "downloading binaries to $(pwd)/dist"
-        gsutil cp -r gs://${BUILD_ARTIFACTS_BUCKET}/$(echo ${SHA} | tr -d '"')/dist .
+        mkdir -p dist
+        gcloud artifacts generic download \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --package=binaries \
+          --version=$(echo ${SHA} | tr -d '"') \
+          --destination=dist/
       working-directory: "release"
     - env:
-        GH_TOKEN: "${{ steps.github_app_token.outputs.token }}"
+        GH_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"
         OUTPUTS_NAME: "${{ needs.shouldRelease.outputs.name }}"
       id: "check_release"
       name: "check if release exists"
@@ -101,14 +88,14 @@ jobs:
     - env:
         OUTPUTS_BRANCH: "${{ needs.shouldRelease.outputs.branch }}"
         OUTPUTS_PR_NUMBER: "${{ needs.shouldRelease.outputs.prNumber }}"
-        OUTPUTS_TOKEN: "${{ steps.github_app_token.outputs.token }}"
+        OUTPUTS_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"
         SHA: "${{ needs.shouldRelease.outputs.sha }}"
       id: "release"
       if: "${{ !fromJSON(steps.check_release.outputs.exists) }}"
       name: "create release"
       run: |
-        npm install
-        npm exec -- release-please github-release \
+        yarn install
+        yarn exec -- release-please github-release \
           --draft \
           --release-type simple \
           --repo-url "${{ env.RELEASE_REPO }}" \
@@ -117,21 +104,27 @@ jobs:
           --shas-to-tag "$(echo $OUTPUTS_PR_NUMBER | tr -d '"'):$(echo ${SHA} | tr -d '"')"
       working-directory: "lib"
     - env:
-        GH_TOKEN: "${{ steps.github_app_token.outputs.token }}"
+        GH_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"
         OUTPUTS_NAME: "${{ needs.shouldRelease.outputs.name }}"
       id: "upload"
       name: "upload artifacts"
       run: |
         gh release upload --clobber $(echo $OUTPUTS_NAME | tr -d '"') dist/*
       working-directory: "release"
-    - if: "${{ fromJSON(env.PUBLISH_TO_GCS) }}"
-      name: "release artifacts"
-      uses: "google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0"
-      with:
-        destination: "${{ env.PUBLISH_BUCKET }}"
-        parent: false
+    - env:
         path: "release/dist"
-        process_gcloudignore: false
+      if: "${{ fromJSON(env.PUBLISH_TO_GCS) }}"
+      name: "release artifacts"
+      run: |
+        echo "downloading binaries to $(pwd)/dist"
+        gcloud artifacts generic upload \
+          --project="grafanalabs-global" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-prod" \
+          --location="us" \
+          --source-directory=${{ env.path }}, \
+          --package=binaries \
+          --version=${{ github.sha }}
+      working-directory: "release"
   createReleaseBranch:
     needs:
     - "publishRelease"
@@ -153,28 +146,16 @@ jobs:
       name: "extract branch name"
       run: |
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-      working-directory: "release"
     - id: "get_github_app_token"
-      if: "${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}"
       name: "get github app token"
       uses: "grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0"
       with:
         github_app: "${{ env.GITHUB_APP }}"
     - env:
-        OUTPUTS_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"
-      id: "github_app_token"
-      name: "set github token"
-      run: |
-        if [[ "${USE_GITHUB_APP_TOKEN}" == "true" ]]; then
-          echo "token=$OUTPUTS_TOKEN" >> $GITHUB_OUTPUT
-        else
-          echo "token=${{ secrets.GH_TOKEN }}" >> $GITHUB_OUTPUT
-        fi
-    - env:
-        GH_TOKEN: "${{ steps.github_app_token.outputs.token }}"
+        GH_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"
         OUTPUTS_BRANCH: "${{ steps.extract_branch.outputs.branch }}"
         OUTPUTS_NAME: "${{ needs.publishRelease.outputs.name }}"
-        OUTPUTS_TOKEN: "${{ steps.github_app_token.outputs.token }}"
+        OUTPUTS_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"
         VERSION: "${{ needs.publishRelease.outputs.name }}"
       id: "create_branch"
       name: "create release branch"
@@ -243,31 +224,26 @@ jobs:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up Cloud SDK"
-      uses: "google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a"
-      with:
-        version: ">= 452.0.0"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392"
     - name: "set up docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - name: "Login to DockerHub (from vault)"
-      uses: "grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25"
+    - name: "Login to DockerHub"
+      uses: "grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7"
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
     - env:
         SHA: "${{ needs.createRelease.outputs.sha }}"
       name: "download and prepare plugins"
       run: |
-        echo "downloading images to $(pwd)/plugins"
-        gsutil cp -r gs://${BUILD_ARTIFACTS_BUCKET}/$(echo ${SHA} | tr -d '"')/plugins .
+        echo "downloading plugins to $(pwd)/plugins"
+        gcloud artifacts generic download \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --package=plugins \
+          --version=$(echo ${SHA} | tr -d '"') \
+          --destination=plugins/
         mkdir -p "release/clients/cmd/docker-driver"
     - name: "publish docker driver"
       uses: "./lib/actions/push-images"
@@ -291,31 +267,26 @@ jobs:
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
-    - id: "fetch_gcs_credentials"
-      name: "fetch gcs credentials from vault"
-      uses: "grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760"
-      with:
-        repo_secrets: "GCS_SERVICE_ACCOUNT_KEY=gcs:service-account-key"
-    - name: "auth gcs"
-      uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f"
-      with:
-        credentials_json: "${{ env.GCS_SERVICE_ACCOUNT_KEY }}"
-    - name: "Set up Cloud SDK"
-      uses: "google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a"
-      with:
-        version: ">= 452.0.0"
     - name: "Set up QEMU"
       uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392"
     - name: "set up docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - name: "Login to DockerHub (from vault)"
-      uses: "grafana/shared-workflows/actions/dockerhub-login@fa48192dac470ae356b3f7007229f3ac28c48a25"
+    - name: "Login to DockerHub"
+      uses: "grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7"
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
     - env:
         SHA: "${{ needs.createRelease.outputs.sha }}"
       name: "download images"
       run: |
         echo "downloading images to $(pwd)/images"
-        gsutil cp -r gs://${BUILD_ARTIFACTS_BUCKET}/$(echo ${SHA} | tr -d '"')/images .
+        gcloud artifacts generic download \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --package=images \
+          --version=$(echo ${SHA} | tr -d '"') \
+          --destination=images/
     - name: "publish docker images"
       uses: "./lib/actions/push-images"
       with:
@@ -341,23 +312,12 @@ jobs:
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - id: "get_github_app_token"
-      if: "${{ fromJSON(env.USE_GITHUB_APP_TOKEN) }}"
       name: "get github app token"
       uses: "grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0"
       with:
         github_app: "${{ env.GITHUB_APP }}"
     - env:
-        OUTPUTS_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"
-      id: "github_app_token"
-      name: "set github token"
-      run: |
-        if [[ "${USE_GITHUB_APP_TOKEN}" == "true" ]]; then
-          echo "token=$OUTPUTS_TOKEN" >> $GITHUB_OUTPUT
-        else
-          echo "token=${{ secrets.GH_TOKEN }}" >> $GITHUB_OUTPUT
-        fi
-    - env:
-        GH_TOKEN: "${{ steps.github_app_token.outputs.token }}"
+        GH_TOKEN: "${{ steps.get_github_app_token.outputs.token }}"
         OUTPUTS_IS_LATEST: "${{ needs.createRelease.outputs.isLatest }}"
         OUTPUTS_NAME: "${{ needs.createRelease.outputs.name }}"
       if: "${{ !fromJSON(needs.createRelease.outputs.exists) || (needs.createRelease.outputs.draft && fromJSON(needs.createRelease.outputs.draft)) }}"
@@ -396,7 +356,6 @@ jobs:
       name: "extract branch name"
       run: |
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-      working-directory: "release"
     - id: "should_release"
       name: "should a release be created?"
       uses: "./lib/actions/should-release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ env:
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "1e32d81ad6fbbd8c271e0bf79ce84c3e65efb0d3"
+  RELEASE_LIB_REF: "a3091f6507615a4646e399870071074d66c30826"
   RELEASE_REPO: "grafana/loki"
 jobs:
   createRelease:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,7 @@ linters:
     - unconvert
   disable:
     - unparam
+    - unused # Ignore unused results for release branches which are primarily only used for bug fixes.
   settings:
     depguard:
       rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,7 +39,6 @@ linters:
     - unconvert
   disable:
     - unparam
-    - unused
   settings:
     depguard:
       rules:
@@ -47,6 +46,8 @@ linters:
           deny:
             - pkg: github.com/go-kit/kit/log
               desc: Use github.com/go-kit/log instead of github.com/go-kit/kit/log
+    goconst:
+      min-occurrences: 5
     misspell:
       ignore-rules:
         - strat
@@ -58,8 +59,16 @@ linters:
       - legacy
       - std-error-handling
     rules:
+      - linters:
+          - revive
+        path: (.*)\.go$
+        text: "avoid meaningless package names"
+      - linters:
+          - revive
+        path: (.*)\.go$
+        text: "avoid package names that conflict with Go standard library"
       - path: pkg/scheduler/scheduler.go
-        text: 'SA1019: msg.GetHttpRequest is deprecated: Do not use'
+        text: "SA1019: msg.GetHttpRequest is deprecated: Do not use"
       - linters:
           - goconst
         path: (.+)_test\.go

--- a/Makefile
+++ b/Makefile
@@ -364,17 +364,11 @@ ifeq ($(SKIP_ARM),true)
 	CGO_ENABLED=0 $(GOX) -osarch="linux/amd64 darwin/amd64 windows/amd64 freebsd/amd64" ./cmd/logcli
 	CGO_ENABLED=0 $(GOX) -osarch="linux/amd64 darwin/amd64 windows/amd64 freebsd/amd64" ./cmd/loki-canary
 	CGO_ENABLED=0 $(GOX) -osarch="linux/amd64 darwin/amd64 windows/amd64 freebsd/amd64" ./cmd/lokitool
-	CGO_ENABLED=0 $(GOX) -osarch="darwin/amd64 windows/amd64 windows/386 freebsd/amd64" ./clients/cmd/promtail
-	CGO_ENABLED=1 $(CGO_GOX) -tags promtail_journal_enabled -osarch="linux/amd64" ./clients/cmd/promtail
 else
 	CGO_ENABLED=0 $(GOX) -osarch="linux/amd64 linux/arm64 linux/arm darwin/amd64 darwin/arm64 windows/amd64 freebsd/amd64" ./cmd/loki
 	CGO_ENABLED=0 $(GOX) -osarch="linux/amd64 linux/arm64 linux/arm darwin/amd64 darwin/arm64 windows/amd64 freebsd/amd64" ./cmd/logcli
 	CGO_ENABLED=0 $(GOX) -osarch="linux/amd64 linux/arm64 linux/arm darwin/amd64 darwin/arm64 windows/amd64 freebsd/amd64" ./cmd/loki-canary
 	CGO_ENABLED=0 $(GOX) -osarch="linux/amd64 linux/arm64 linux/arm darwin/amd64 darwin/arm64 windows/amd64 freebsd/amd64" ./cmd/lokitool
-	CGO_ENABLED=0 $(GOX) -osarch="darwin/amd64 darwin/arm64 windows/amd64 windows/386 freebsd/amd64" ./clients/cmd/promtail
-	PKG_CONFIG_PATH="/usr/lib/aarch64-linux-gnu/pkgconfig" CC="aarch64-linux-gnu-gcc" $(CGO_GOX)  -tags promtail_journal_enabled  -osarch="linux/arm64" ./clients/cmd/promtail
-	PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabihf/pkgconfig" CC="arm-linux-gnueabihf-gcc" $(CGO_GOX)  -tags promtail_journal_enabled  -osarch="linux/arm" ./clients/cmd/promtail
-	CGO_ENABLED=1 $(CGO_GOX) -tags promtail_journal_enabled -osarch="linux/amd64" ./clients/cmd/promtail
 endif
 	for i in dist/*; do zip -j -m $$i.zip $$i; done
 	pushd dist && sha256sum * > SHA256SUMS && popd

--- a/tools/packaging/nfpm.jsonnet
+++ b/tools/packaging/nfpm.jsonnet
@@ -32,28 +32,6 @@ local overrides = {
       postinstall: './tools/packaging/loki-postinstall.sh',
     },
   },
-
-  promtail: {
-    description: |||
-      Promtail is an agent which ships the contents of local logs to a private Grafana Loki instance or Grafana Cloud.
-      It is usually deployed to every machine that has applications needed to be monitored.
-    |||,
-    license: 'Apache-2.0',
-    contents+: [
-      {
-        src: './tools/packaging/promtail.service',
-        dst: '/etc/systemd/system/promtail.service',
-      },
-      {
-        src: './tools/packaging/promtail-minimal-config.yaml',
-        dst: '/etc/promtail/config.yml',
-        type: 'config|noreplace',
-      },
-    ],
-    scripts: {
-      postinstall: './tools/packaging/promtail-postinstall.sh',
-    },
-  },
 };
 
 local name = std.extVar('name');

--- a/tools/packaging/nfpm.sh
+++ b/tools/packaging/nfpm.sh
@@ -12,7 +12,7 @@ fi
 rm -rf dist/tmp && mkdir -p dist/tmp/packages
 unzip dist/\*.zip -d dist/tmp/packages
 
-for name in loki loki-canary logcli promtail; do
+for name in loki loki-canary logcli; do
     for arch in amd64 arm64 arm; do
         config_path="dist/tmp/config-${name}-${arch}.json"
         jsonnet -V "name=${name}" -V "arch=${arch}" "tools/packaging/nfpm.jsonnet" > "${config_path}"

--- a/tools/packaging/verify-deb-install.sh
+++ b/tools/packaging/verify-deb-install.sh
@@ -15,10 +15,6 @@ cat <<EOF | docker exec --interactive "${image}" sh
     dpkg -i ${dir}/dist/loki_*_amd64.deb
     [ "\$(systemctl is-active loki)" = "active" ] || (echo "loki is inactive" && exit 1)
 
-    # Install promtail and check it's running
-    dpkg -i ${dir}/dist/promtail_*_amd64.deb
-    [ "\$(systemctl is-active promtail)" = "active" ] || (echo "promtail is inactive" && exit 1)
-
     # Write some logs
     mkdir -p /var/log/
     echo "blablabla" >> /var/log/messages

--- a/tools/packaging/verify-rpm-install.sh
+++ b/tools/packaging/verify-rpm-install.sh
@@ -18,10 +18,6 @@ cat <<EOF | docker exec --interactive "${image}" sh
     rpm -i ${dir}/dist/loki-*.x86_64.rpm
     [ "\$(systemctl is-active loki)" = "active" ] || (echo "loki is inactive" && exit 1)
 
-    # Install promtail and check it's running
-    rpm -i ${dir}/dist/promtail-*.x86_64.rpm
-    [ "\$(systemctl is-active promtail)" = "active" ] || (echo "promtail is inactive" && exit 1)
-
     # Write some logs
     mkdir -p /var/log/
     echo "blablabla" >> /var/log/messages


### PR DESCRIPTION
Updates the following to match up with main:

* .github/jsonnetfile.json
* .github/release-workflows.jsonnet
* .github/publish-technical-documentation-next.yml
* .github/publish-technical-documentation-release.yml

Then `make release-workflows` was ran to regenerate managed workflows from Jsonnet.