### PR TITLE
fix(ci): Remove test checking for nfpm vars, like main

### DIFF
--- a/tools/packaging/nfpm.sh
+++ b/tools/packaging/nfpm.sh
@@ -1,14 +1,5 @@
 #!/usr/bin/env bash
 
-if [[ -z "${NFPM_SIGNING_KEY_FILE}" ]]; then
-    echo "NFPM_SIGNING_KEY_FILE is not set"
-    exit 1
-fi
-if [[ -z "${NFPM_PASSPHRASE}" ]]; then
-    echo "NFPM_PASSPHRASE is not set"
-    exit 1
-fi
-
 rm -rf dist/tmp && mkdir -p dist/tmp/packages
 unzip dist/\*.zip -d dist/tmp/packages
 

--- a/tools/packaging/nfpm.sh
+++ b/tools/packaging/nfpm.sh
@@ -3,7 +3,7 @@
 rm -rf dist/tmp && mkdir -p dist/tmp/packages
 unzip dist/\*.zip -d dist/tmp/packages
 
-for name in loki loki-canary logcli promtail; do
+for name in loki loki-canary logcli; do
     for arch in amd64 arm64 arm; do
         config_path="dist/tmp/config-${name}-${arch}.json"
         jsonnet -V "name=${name}" -V "arch=${arch}" "tools/packaging/nfpm.jsonnet" > "${config_path}"


### PR DESCRIPTION
**What this PR does / why we need it**:
To fix the error seen [here](https://github.com/grafana/loki/actions/runs/27957814201/job/82733441816)
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
