### PR TITLE
chore: Update helm-test Dockefile to Go 1.26.4 [release-3.6.x]

### DIFF
--- a/production/helm/loki/src/helm-test/Dockerfile
+++ b/production/helm/loki/src/helm-test/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.26.2
+ARG GO_VERSION=1.26
 FROM golang:${GO_VERSION} as build
 
 # build via Makefile target helm-test-image in root


### PR DESCRIPTION
1.26.4 is used everywhere else throughout the code.