### PR TITLE
feat(ruler)!: Always wipe the remote-write WAL on startup

### DIFF
--- a/docs/sources/operations/recording-rules.md
+++ b/docs/sources/operations/recording-rules.md
@@ -28,14 +28,9 @@ is that Prometheus will, for example, reject a remote-write request with 100 sam
 
 ### Start-up
 
-When the `ruler` starts up, it will load the WALs for the tenants who have recording rules. These WAL files are stored
-on disk and are loaded into memory.
-
-{{< admonition type="note" >}}
-WALs are loaded one at a time upon start-up. This is a current limitation of the Loki ruler.
-For this reason, it is advisable that the number of rule groups serviced by a ruler be kept to a reasonable size, since
-_no rule evaluation occurs while WAL replay is in progress (this includes alerting rules)_.
-{{< /admonition >}}
+When the `ruler` starts up, it deletes (wipes) its remote-write WAL directory and starts each tenant with a fresh, empty
+WAL. WAL data left over from a previous run is not replayed, so any samples that had not yet been flushed to remote storage
+before the restart are discarded.
 
 
 ### Truncation
@@ -159,14 +154,14 @@ by Prometheus maintainer Callum Styan.
 ### Appender Not Ready
 
 Each tenant's WAL has an "appender" internally; this appender is used to _append_ samples to the WAL. The appender is marked
-as _not ready_ until the WAL replay is complete upon startup. If the WAL is corrupted for some reason, or is taking a long
-time to replay, you can determine this by alerting on `loki_ruler_wal_appender_ready < 1`.
+as _not ready_ until the WAL storage has been initialized upon startup. You can alert on `loki_ruler_wal_appender_ready < 1`
+to detect tenants whose WAL is not yet ready to accept samples.
 
 ### Corrupt WAL
 
 If a disk fails or the `ruler` does not terminate correctly, there's a chance one or more tenant WALs can become corrupted.
-A mechanism exists for automatically repairing the WAL, but this cannot handle every conceivable scenario. In this case,
-the `loki_ruler_wal_corruptions_repair_failed_total` metric will be incremented.
+The `ruler` wipes its WAL directory on startup, so any WAL left over from a previous run — corrupt or not — is discarded and
+recreated fresh rather than replayed.
 
 ### Found another failure mode?
 

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -51,6 +51,15 @@ The legacy Prometheus-compatible `/api/prom` endpoints that were deprecated in L
 
 You must migrate any clients, dashboards, or automation that still use these endpoints to their `/loki/api/v1/` equivalents before upgrading. Requests to the removed endpoints will result in `404` errors.
 
+### Breaking change: Ruler always wipes its remote-write WAL on startup
+
+The ruler now deletes (wipes) its remote-write write-ahead log (WAL) directory on startup and starts each tenant with a fresh, empty WAL. WAL data left over from a previous run is no longer replayed, so any samples that had not yet been flushed to remote storage before a restart are discarded. For recording rules this is generally safe, since rules are re-evaluated and re-sent after startup.
+
+As a result, the following have been removed:
+
+- The `-ruler.enable-wal-replay` flag and its per-tenant equivalent `ruler_enable_wal_replay` (in `limits_config`). The ruler no longer replays the WAL, so these settings no longer have any effect. Remove them from your configuration; the `deprecated-config-checker` tool will flag them.
+- The ruler WAL metrics that only ever reported replay or repair activity: `loki_ruler_wal_corruptions_total`, `loki_ruler_wal_corruptions_repair_failed_total`, `loki_ruler_wal_corruptions_repair_succeeded_total`, and `loki_ruler_wal_replay_duration`. Remove any dashboards or alerts that reference them.
+
 ### Breaking change: Removal of various configuration options
 
 - The deprecated per-tenant setting `unordered_writes` has been removed. Loki now always allows unordered writes.

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -4672,11 +4672,6 @@ discover_generic_fields:
 # CLI flag: -ruler.tenant-shard-size
 [ruler_tenant_shard_size: <int> | default = 0]
 
-# Enable WAL replay on ruler startup. Disabling this can reduce memory usage on
-# startup at the cost of not recovering in-memory WAL metrics on restart.
-# CLI flag: -ruler.enable-wal-replay
-[ruler_enable_wal_replay: <boolean> | default = true]
-
 # Disable recording rules remote-write.
 [ruler_remote_write_disabled: <boolean>]
 

--- a/pkg/ruler/base/compat.go
+++ b/pkg/ruler/base/compat.go
@@ -143,7 +143,6 @@ type RulesLimits interface {
 	RulerMaxRuleGroupsPerTenant(userID string) int
 	RulerMaxRulesPerRuleGroup(userID string) int
 	RulerAlertManagerConfig(userID string) *config.AlertManagerConfig
-	RulerEnableWALReplay(userID string) bool
 }
 
 func MetricsQueryFunc(qf rules.QueryFunc, queries, failedQueries prometheus.Counter) rules.QueryFunc {

--- a/pkg/ruler/base/ruler_test.go
+++ b/pkg/ruler/base/ruler_test.go
@@ -88,7 +88,6 @@ type ruleLimits struct {
 	maxRulesPerRuleGroup int
 	maxRuleGroups        int
 	alertManagerConfig   map[string]*config.AlertManagerConfig
-	enableWALReplay      bool
 }
 
 func (r ruleLimits) RulerTenantShardSize(_ string) int {
@@ -105,10 +104,6 @@ func (r ruleLimits) RulerMaxRulesPerRuleGroup(_ string) int {
 
 func (r ruleLimits) RulerAlertManagerConfig(tenantID string) *config.AlertManagerConfig {
 	return r.alertManagerConfig[tenantID]
-}
-
-func (r ruleLimits) RulerEnableWALReplay(_ string) bool {
-	return r.enableWALReplay
 }
 
 func testQueryableFunc(q storage.Querier) storage.QueryableFunc {
@@ -144,7 +139,7 @@ func testSetup(t *testing.T, q storage.Querier) (*promql.Engine, storage.Queryab
 	reg := prometheus.NewRegistry()
 	queryable := testQueryableFunc(q)
 
-	return engine, queryable, pusher, l, ruleLimits{maxRuleGroups: 20, maxRulesPerRuleGroup: 15, enableWALReplay: true}, reg
+	return engine, queryable, pusher, l, ruleLimits{maxRuleGroups: 20, maxRulesPerRuleGroup: 15}, reg
 }
 
 func newManager(t *testing.T, cfg Config, q storage.Querier) *DefaultMultiTenantManager {

--- a/pkg/ruler/registry.go
+++ b/pkg/ruler/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -57,7 +58,19 @@ func newWALRegistry(logger log.Logger, reg prometheus.Registerer, config Config,
 		return nullRegistry{}
 	}
 
-	manager := createInstanceManager(logger, reg, overrides)
+	// Wipe the WAL directory before any per-tenant storage is opened. This runs
+	// exactly once per ruler startup (newWALRegistry is called once), unlike the
+	// per-tenant wal.NewStorage which is re-invoked whenever a tenant instance
+	// restarts. Because the WAL is always discarded here, there is nothing to
+	// replay when the per-tenant storage is later opened.
+	level.Info(logger).Log("msg", "wiping ruler WAL directory on startup", "dir", config.WAL.Dir)
+	if err := os.RemoveAll(config.WAL.Dir); err != nil {
+		// Non-fatal: a failed wipe just leaves stale data on disk, so we log and
+		// continue rather than blocking ruler startup.
+		level.Error(logger).Log("msg", "failed to wipe ruler WAL directory on startup", "dir", config.WAL.Dir, "err", err)
+	}
+
+	manager := createInstanceManager(logger, reg)
 
 	return &walRegistry{
 		logger:    logger,
@@ -75,11 +88,10 @@ func newWALRegistry(logger log.Logger, reg prometheus.Registerer, config Config,
 	}
 }
 
-func createInstanceManager(logger log.Logger, reg prometheus.Registerer, overrides RulesLimits) *instance.BasicManager {
+func createInstanceManager(logger log.Logger, reg prometheus.Registerer) *instance.BasicManager {
 	tenantManager := &tenantWALManager{
-		reg:       reg,
-		logger:    log.With(logger, "manager", "tenant-wal"),
-		overrides: overrides,
+		reg:    reg,
+		logger: log.With(logger, "manager", "tenant-wal"),
 	}
 
 	return instance.NewBasicManager(instance.BasicManagerConfig{
@@ -455,9 +467,8 @@ type readyChecker interface {
 }
 
 type tenantWALManager struct {
-	logger    log.Logger
-	reg       prometheus.Registerer
-	overrides RulesLimits
+	logger log.Logger
+	reg    prometheus.Registerer
 }
 
 func (t *tenantWALManager) newInstance(c instance.Config) (instance.ManagedInstance, error) {
@@ -465,14 +476,8 @@ func (t *tenantWALManager) newInstance(c instance.Config) (instance.ManagedInsta
 		"tenant": c.Tenant,
 	}, t.reg)
 
-	// Get the per-tenant setting for WAL replay from overrides
-	enableReplay := true // Default to true for backward compatibility
-	if t.overrides != nil {
-		enableReplay = t.overrides.RulerEnableWALReplay(c.Tenant)
-	}
-
 	// create the instance with our custom walFactory
-	return instance.New(reg, c, wal.NewMetrics(reg), t.logger, enableReplay)
+	return instance.New(reg, c, wal.NewMetrics(reg), t.logger)
 }
 
 type storageRegistryMetrics struct {

--- a/pkg/ruler/registry_test.go
+++ b/pkg/ruler/registry_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -167,11 +169,9 @@ func newFakeLimitsBackwardCompat() fakeLimits {
 		limits: map[string]*validation.Limits{
 			enabledRWTenant: {
 				RulerRemoteWriteQueueCapacity: 987,
-				RulerEnableWALReplay:          true,
 			},
 			disabledRWTenant: {
 				RulerRemoteWriteDisabled: true,
-				RulerEnableWALReplay:     false,
 			},
 			additionalHeadersRWTenant: {
 				RulerRemoteWriteHeaders: validation.NewOverwriteMarshalingStringMap(map[string]string{
@@ -232,11 +232,9 @@ func newFakeLimits() fakeLimits {
 						QueueConfig: config.QueueConfig{Capacity: 987},
 					},
 				},
-				RulerEnableWALReplay: true,
 			},
 			disabledRWTenant: {
 				RulerRemoteWriteDisabled: true,
-				RulerEnableWALReplay:     false,
 			},
 			additionalHeadersRWTenant: {
 				RulerRemoteWriteConfig: map[string]config.RemoteWriteConfig{
@@ -935,6 +933,51 @@ func TestWALRegistryCreation(t *testing.T) {
 
 	_, ok = regDisabled.(nullRegistry)
 	assert.Truef(t, ok, "instance is not of expected type")
+}
+
+func TestWALRegistryWipeOnStartup(t *testing.T) {
+	overrides, err := validation.NewOverrides(validation.Limits{}, nil)
+	require.NoError(t, err)
+
+	configWithDir := func(dir string, remoteWriteEnabled bool) Config {
+		cfg := Config{
+			RemoteWrite: RemoteWriteConfig{Enabled: remoteWriteEnabled},
+		}
+		cfg.WAL.Dir = dir
+		return cfg
+	}
+
+	// seedWAL creates a WAL directory containing leftover per-tenant WAL data,
+	// mimicking what a previous ruler run would have left on disk.
+	seedWAL := func(t *testing.T) string {
+		t.Helper()
+		walDir := filepath.Join(t.TempDir(), "ruler-wal")
+		segment := filepath.Join(walDir, "tenant", "wal", "00000000")
+		require.NoError(t, os.MkdirAll(filepath.Dir(segment), 0o755))
+		require.NoError(t, os.WriteFile(segment, []byte("stale"), 0o644))
+		return walDir
+	}
+
+	t.Run("wipes the WAL directory on startup", func(t *testing.T) {
+		walDir := seedWAL(t)
+
+		reg := newWALRegistry(log.NewNopLogger(), nil, configWithDir(walDir, true), overrides)
+		t.Cleanup(reg.stop)
+
+		_, statErr := os.Stat(walDir)
+		require.Truef(t, os.IsNotExist(statErr), "expected WAL dir to be wiped, stat err: %v", statErr)
+	})
+
+	t.Run("does not wipe when remote-write is disabled", func(t *testing.T) {
+		walDir := seedWAL(t)
+
+		// With remote-write disabled the WAL is never used, so newWALRegistry
+		// short-circuits to a null registry and must not touch the directory.
+		newWALRegistry(log.NewNopLogger(), nil, configWithDir(walDir, false), overrides)
+
+		_, statErr := os.Stat(filepath.Join(walDir, "tenant", "wal", "00000000"))
+		require.NoError(t, statErr, "expected WAL contents to be preserved when remote-write is disabled")
+	})
 }
 
 func TestStorageSetup(t *testing.T) {

--- a/pkg/ruler/storage/instance/instance.go
+++ b/pkg/ruler/storage/instance/instance.go
@@ -186,13 +186,13 @@ type Instance struct {
 
 // New creates a new Instance with a directory for storing the WAL. The instance
 // will not start until Run is called on the instance.
-func New(reg prometheus.Registerer, cfg Config, metrics *wal.Metrics, logger log.Logger, enableReplay bool) (*Instance, error) {
+func New(reg prometheus.Registerer, cfg Config, metrics *wal.Metrics, logger log.Logger) (*Instance, error) {
 	logger = log.With(logger, "instance", cfg.Name)
 
 	instWALDir := filepath.Join(cfg.Dir, cfg.Tenant)
 
 	newWal := func(reg prometheus.Registerer) (walStorage, error) {
-		return wal.NewStorage(logger, metrics, reg, instWALDir, enableReplay)
+		return wal.NewStorage(logger, metrics, reg, instWALDir)
 	}
 
 	return newInstance(cfg, reg, logger, newWal, cfg.Tenant)

--- a/pkg/ruler/storage/wal/metrics.go
+++ b/pkg/ruler/storage/wal/metrics.go
@@ -14,10 +14,6 @@ type Metrics struct {
 	TotalRemovedSeries     prometheus.Counter
 	TotalAppendedSamples   prometheus.Counter
 	TotalAppendedExemplars prometheus.Counter
-	TotalCorruptions       prometheus.Counter
-	TotalFailedRepairs     prometheus.Counter
-	TotalSucceededRepairs  prometheus.Counter
-	ReplayDuration         prometheus.Histogram
 	DiskSize               prometheus.Gauge
 }
 
@@ -53,27 +49,6 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 		Help: "Total number of exemplars appended to a tenant's WAL",
 	})
 
-	m.TotalCorruptions = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "corruptions_total",
-		Help: "Total number of corruptions observed in a tenant's WAL",
-	})
-
-	m.TotalFailedRepairs = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "corruptions_repair_failed_total",
-		Help: "Total number of corruptions unsuccessfully repaired in a tenant's WAL",
-	})
-
-	m.TotalSucceededRepairs = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "corruptions_repair_succeeded_total",
-		Help: "Total number of corruptions successfully repaired in a tenant's WAL",
-	})
-
-	m.ReplayDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "replay_duration",
-		Help:    "Total duration in seconds it took to replay a tenant's WAL",
-		Buckets: prometheus.ExponentialBuckets(0.01, 4, 6),
-	})
-
 	m.DiskSize = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "disk_size",
 		Help: "Size of each tenant's WAL on disk",
@@ -90,10 +65,6 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 			m.TotalRemovedSeries,
 			m.TotalAppendedSamples,
 			m.TotalAppendedExemplars,
-			m.TotalCorruptions,
-			m.TotalFailedRepairs,
-			m.TotalSucceededRepairs,
-			m.ReplayDuration,
 			m.DiskSize,
 		)
 	}
@@ -112,10 +83,6 @@ func (m *Metrics) Unregister() {
 		m.TotalRemovedSeries,
 		m.TotalAppendedSamples,
 		m.TotalAppendedExemplars,
-		m.TotalCorruptions,
-		m.TotalFailedRepairs,
-		m.TotalSucceededRepairs,
-		m.ReplayDuration,
 		m.DiskSize,
 	}
 	for _, c := range cs {

--- a/pkg/ruler/storage/wal/wal.go
+++ b/pkg/ruler/storage/wal/wal.go
@@ -70,7 +70,7 @@ type Storage struct {
 }
 
 // NewStorage makes a new Storage.
-func NewStorage(logger log.Logger, metrics *Metrics, registerer prometheus.Registerer, path string, enableReplay bool) (*Storage, error) {
+func NewStorage(logger log.Logger, metrics *Metrics, registerer prometheus.Registerer, path string) (*Storage, error) {
 	w, err := wlog.NewSize(util_log.SlogFromGoKit(logger), registerer, SubDirectory(path), wlog.DefaultSegmentSize, compression.Snappy)
 	if err != nil {
 		return nil, err
@@ -106,25 +106,8 @@ func NewStorage(logger log.Logger, metrics *Metrics, registerer prometheus.Regis
 		}
 	}
 
-	start := time.Now()
-	if enableReplay {
-		if err := storage.replayWAL(); err != nil {
-			metrics.TotalCorruptions.Inc()
-
-			level.Warn(storage.logger).Log("msg", "encountered WAL read error, attempting repair", "err", err)
-			if err := w.Repair(err); err != nil {
-				metrics.TotalFailedRepairs.Inc()
-				metrics.ReplayDuration.Observe(time.Since(start).Seconds())
-				return nil, errors.Wrap(err, "repair corrupted WAL")
-			}
-
-			metrics.TotalSucceededRepairs.Inc()
-		}
-		metrics.ReplayDuration.Observe(time.Since(start).Seconds())
-	} else {
-		level.Info(storage.logger).Log("msg", "WAL replay disabled")
-	}
-
+	// The ruler wipes the WAL directory on startup (see newWALRegistry), so a
+	// freshly-opened WAL is always empty; there is nothing to replay.
 	go storage.recordSize()
 
 	return storage, nil
@@ -132,190 +115,6 @@ func NewStorage(logger log.Logger, metrics *Metrics, registerer prometheus.Regis
 
 func (w *Storage) SetWriteNotified(writeNotified wlog.WriteNotified) {
 	w.writeNotified = writeNotified
-}
-
-func (w *Storage) replayWAL() error {
-	w.walMtx.RLock()
-	defer w.walMtx.RUnlock()
-
-	if w.walClosed {
-		return ErrWALClosed
-	}
-
-	level.Info(w.logger).Log("msg", "replaying WAL, this may take a while", "dir", w.wal.Dir())
-	dir, startFrom, err := wlog.LastCheckpoint(w.wal.Dir())
-	if err != nil && err != record.ErrNotFound {
-		return errors.Wrap(err, "find last checkpoint")
-	}
-
-	if err == nil {
-		sr, err := wlog.NewSegmentsReader(dir)
-		if err != nil {
-			return errors.Wrap(err, "open checkpoint")
-		}
-		defer func() {
-			if err := sr.Close(); err != nil {
-				level.Warn(w.logger).Log("msg", "error while closing the wal segments reader", "err", err)
-			}
-		}()
-
-		// A corrupted checkpoint is a hard error for now and requires user
-		// intervention. There's likely little data that can be recovered anyway.
-		if err := w.loadWAL(wlog.NewReader(sr)); err != nil {
-			return errors.Wrap(err, "backfill checkpoint")
-		}
-		startFrom++
-		level.Info(w.logger).Log("msg", "WAL checkpoint loaded")
-	}
-
-	// Find the last segment.
-	_, last, err := wlog.Segments(w.wal.Dir())
-	if err != nil {
-		return errors.Wrap(err, "finding WAL segments")
-	}
-
-	// Backfill segments from the most recent checkpoint onwards.
-	for i := startFrom; i <= last; i++ {
-		s, err := wlog.OpenReadSegment(wlog.SegmentName(w.wal.Dir(), i))
-		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("open WAL segment: %d", i))
-		}
-
-		sr := wlog.NewSegmentBufReader(s)
-		err = w.loadWAL(wlog.NewReader(sr))
-		if err := sr.Close(); err != nil {
-			level.Warn(w.logger).Log("msg", "error while closing the wal segments reader", "err", err)
-		}
-		if err != nil {
-			return err
-		}
-		level.Info(w.logger).Log("msg", "WAL segment loaded", "segment", i, "maxSegment", last)
-	}
-
-	return nil
-}
-
-func (w *Storage) loadWAL(r *wlog.Reader) (err error) {
-	var dec record.Decoder
-
-	var (
-		decoded    = make(chan interface{}, 10)
-		errCh      = make(chan error, 1)
-		seriesPool = sync.Pool{
-			New: func() interface{} {
-				return []record.RefSeries{}
-			},
-		}
-		samplesPool = sync.Pool{
-			New: func() interface{} {
-				return []record.RefSample{}
-			},
-		}
-	)
-
-	go func() {
-		defer close(decoded)
-		for r.Next() {
-			rec := r.Record()
-			switch dec.Type(rec) {
-			case record.Series:
-				series := seriesPool.Get().([]record.RefSeries)[:0]
-				series, err = dec.Series(rec, series)
-				if err != nil {
-					errCh <- &wlog.CorruptionErr{
-						Err:     errors.Wrap(err, "decode series"),
-						Segment: r.Segment(),
-						Offset:  r.Offset(),
-					}
-					return
-				}
-				decoded <- series
-			case record.Samples:
-				samples := samplesPool.Get().([]record.RefSample)[:0]
-				samples, err = dec.Samples(rec, samples)
-				if err != nil {
-					errCh <- &wlog.CorruptionErr{
-						Err:     errors.Wrap(err, "decode samples"),
-						Segment: r.Segment(),
-						Offset:  r.Offset(),
-					}
-				}
-				decoded <- samples
-			case record.Tombstones, record.Exemplars:
-				// We don't care about decoding tombstones or exemplars
-				continue
-			default:
-				errCh <- &wlog.CorruptionErr{
-					Err:     errors.Errorf("invalid record type %v", dec.Type(rec)),
-					Segment: r.Segment(),
-					Offset:  r.Offset(),
-				}
-				return
-			}
-		}
-	}()
-
-	biggestRef := chunks.HeadSeriesRef(w.ref.Load())
-
-	for d := range decoded {
-		switch v := d.(type) {
-		case []record.RefSeries:
-			for _, s := range v {
-				// If this is a new series, create it in memory without a timestamp.
-				// If we read in a sample for it, we'll use the timestamp of the latest
-				// sample. Otherwise, the series is stale and will be deleted once
-				// the truncation is performed.
-				if w.series.getByID(s.Ref) == nil {
-					series := &memSeries{ref: s.Ref, lset: s.Labels, lastTs: 0}
-					w.series.set(labels.StableHash(s.Labels), series)
-
-					w.metrics.NumActiveSeries.Inc()
-					w.metrics.TotalCreatedSeries.Inc()
-
-					if biggestRef <= s.Ref {
-						biggestRef = s.Ref
-					}
-				}
-			}
-
-			//nolint:staticcheck
-			seriesPool.Put(v)
-		case []record.RefSample:
-			for _, s := range v {
-				// Update the lastTs for the series based
-				series := w.series.getByID(s.Ref)
-				if series == nil {
-					level.Warn(w.logger).Log("msg", "found sample referencing non-existing series, skipping")
-					continue
-				}
-
-				series.Lock()
-				if s.T > series.lastTs {
-					series.lastTs = s.T
-				}
-				series.Unlock()
-			}
-
-			//nolint:staticcheck
-			samplesPool.Put(v)
-		default:
-			panic(fmt.Errorf("unexpected decoded type: %T", d))
-		}
-	}
-
-	w.ref.Store(uint64(biggestRef))
-
-	select {
-	case err := <-errCh:
-		return err
-	default:
-	}
-
-	if r.Err() != nil {
-		return errors.Wrap(r.Err(), "read records")
-	}
-
-	return nil
 }
 
 // Directory returns the path where the WAL storage is held.

--- a/pkg/ruler/storage/wal/wal.go
+++ b/pkg/ruler/storage/wal/wal.go
@@ -106,8 +106,6 @@ func NewStorage(logger log.Logger, metrics *Metrics, registerer prometheus.Regis
 		}
 	}
 
-	// The ruler wipes the WAL directory on startup (see newWALRegistry), so a
-	// freshly-opened WAL is always empty; there is nothing to replay.
 	go storage.recordSize()
 
 	return storage, nil

--- a/pkg/ruler/storage/wal/wal_test.go
+++ b/pkg/ruler/storage/wal/wal_test.go
@@ -24,7 +24,7 @@ import (
 
 func newTestStorage(walDir string) (*Storage, error) {
 	metrics := NewMetrics(prometheus.DefaultRegisterer)
-	return NewStorage(log.NewNopLogger(), metrics, nil, walDir, true)
+	return NewStorage(log.NewNopLogger(), metrics, nil, walDir)
 }
 
 func TestStorage_InvalidSeries(t *testing.T) {
@@ -135,12 +135,6 @@ func TestStorage_ExistingWAL(t *testing.T) {
 		require.NoError(t, s.Close())
 	}()
 
-	// Verify that the storage picked up existing series when it
-	// replayed the WAL.
-	for series := range s.series.iterator().Channel() {
-		require.Greater(t, series.lastTs, int64(0), "series timestamp not updated")
-	}
-
 	app = s.Appender(context.Background())
 
 	for _, metric := range payload[len(payload)/2:] {
@@ -170,7 +164,7 @@ func TestStorage_ExistingWAL(t *testing.T) {
 	require.Equal(t, expectedExemplars, actualExemplars)
 }
 
-func TestStorage_ExistingWAL_RefID(t *testing.T) {
+func TestStorage_ExistingWAL_NoReplay(t *testing.T) {
 	walDir := t.TempDir()
 
 	s, err := newTestStorage(walDir)
@@ -189,12 +183,19 @@ func TestStorage_ExistingWAL_RefID(t *testing.T) {
 	require.NoError(t, s.Truncate(0))
 	require.NoError(t, s.Close())
 
-	// Create a new storage and see what the ref ID is initialized to.
+	// Reopening the WAL must not replay it. The ruler wipes the WAL on startup,
+	// so a freshly-opened storage starts with no series and a zero ref ID.
 	s, err = newTestStorage(walDir)
 	require.NoError(t, err)
 	defer require.NoError(t, s.Close())
 
-	require.Equal(t, uint64(len(payload)), s.ref.Load(), "cached ref ID should be equal to the number of series written")
+	require.Equal(t, uint64(0), s.ref.Load(), "ref ID must not be restored from the WAL since replay was removed")
+
+	count := 0
+	for range s.series.iterator().Channel() {
+		count++
+	}
+	require.Equal(t, 0, count, "no series should be loaded from the WAL since replay was removed")
 }
 
 func TestStorage_Truncate(t *testing.T) {
@@ -321,53 +322,6 @@ func TestStorage_TruncateAfterClose(t *testing.T) {
 
 	require.NoError(t, s.Close())
 	require.Error(t, ErrWALClosed, s.Truncate(0))
-}
-
-func TestStorage_DisableReplay(t *testing.T) {
-	walDir := t.TempDir()
-
-	// Create a WAL and write some data to it
-	metrics := NewMetrics(prometheus.DefaultRegisterer)
-	s, err := NewStorage(log.NewNopLogger(), metrics, nil, walDir, true)
-	require.NoError(t, err)
-
-	app := s.Appender(context.Background())
-
-	// Write some samples
-	payload := buildSeries([]string{"foo", "bar", "baz"})
-	for _, metric := range payload {
-		metric.Write(t, app)
-	}
-
-	require.NoError(t, app.Commit())
-	require.NoError(t, s.Close())
-
-	// Create a new WAL with replay disabled
-	s, err = NewStorage(log.NewNopLogger(), metrics, nil, walDir, false)
-	require.NoError(t, err)
-
-	// Verify that no series were loaded (replay didn't happen)
-	count := 0
-	for range s.series.iterator().Channel() {
-		count++
-	}
-	require.Equal(t, 0, count, "no series should have been loaded with replay disabled")
-
-	require.NoError(t, s.Close())
-
-	// Create a new WAL with replay enabled
-	s, err = NewStorage(log.NewNopLogger(), metrics, nil, walDir, true)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, s.Close())
-	}()
-
-	// Verify that series were loaded (replay happened)
-	count = 0
-	for range s.series.iterator().Channel() {
-		count++
-	}
-	require.Equal(t, len(payload), count, "series should have been loaded with replay enabled")
 }
 
 type sample struct {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -166,7 +166,6 @@ type Limits struct {
 	RulerMaxRuleGroupsPerTenant int                              `yaml:"ruler_max_rule_groups_per_tenant" json:"ruler_max_rule_groups_per_tenant"`
 	RulerAlertManagerConfig     *ruler_config.AlertManagerConfig `yaml:"ruler_alertmanager_config" json:"ruler_alertmanager_config" doc:"hidden"`
 	RulerTenantShardSize        int                              `yaml:"ruler_tenant_shard_size" json:"ruler_tenant_shard_size"`
-	RulerEnableWALReplay        bool                             `yaml:"ruler_enable_wal_replay" json:"ruler_enable_wal_replay" doc:"description=Enable WAL replay on ruler startup. Disabling this can reduce memory usage on startup at the cost of not recovering in-memory WAL metrics on restart."`
 
 	// TODO(dannyk): add HTTP client overrides (basic auth / tls config, etc)
 	// Ruler remote-write limits.
@@ -469,7 +468,6 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.RulerMaxRulesPerRuleGroup, "ruler.max-rules-per-rule-group", 0, "Maximum number of rules per rule group per-tenant. 0 to disable.")
 	f.IntVar(&l.RulerMaxRuleGroupsPerTenant, "ruler.max-rule-groups-per-tenant", 0, "Maximum number of rule groups per-tenant. 0 to disable.")
 	f.IntVar(&l.RulerTenantShardSize, "ruler.tenant-shard-size", 0, "The default tenant's shard size when shuffle-sharding is enabled in the ruler. When this setting is specified in the per-tenant overrides, a value of 0 disables shuffle sharding for the tenant.")
-	f.BoolVar(&l.RulerEnableWALReplay, "ruler.enable-wal-replay", true, "Enable WAL replay on ruler startup. Disabling this can reduce memory usage on startup at the cost of not recovering in-memory WAL metrics on restart.")
 
 	f.StringVar(&l.PerTenantOverrideConfig, "limits.per-user-override-config", "", "Feature renamed to 'runtime configuration', flag deprecated in favor of -runtime-config.file (runtime_config.file in YAML).")
 	_ = l.RetentionPeriod.Set("0s")
@@ -1026,11 +1024,6 @@ func (o *Overrides) MaxQueryLookback(_ context.Context, userID string) time.Dura
 // RulerTenantShardSize returns shard size (number of rulers) used by this tenant when using shuffle-sharding strategy.
 func (o *Overrides) RulerTenantShardSize(userID string) int {
 	return o.getOverridesForUser(userID).RulerTenantShardSize
-}
-
-// RulerEnableWALReplay returns whether WAL replay is enabled for a given user.
-func (o *Overrides) RulerEnableWALReplay(userID string) bool {
-	return o.getOverridesForUser(userID).RulerEnableWALReplay
 }
 
 func (o *Overrides) IngestionPartitionsTenantShardSize(userID string) int {

--- a/tools/deprecated-config-checker/checker/checker_test.go
+++ b/tools/deprecated-config-checker/checker/checker_test.go
@@ -39,6 +39,7 @@ var (
 		"limits_config.enforce_metric_name",
 		"limits_config.ruler_evaluation_delay_duration",
 		"limits_config.allow_deletes",
+		"limits_config.ruler_enable_wal_replay",
 		"storage_config.bigtable",
 		"storage_config.cassandra",
 		"storage_config.boltdb",
@@ -90,10 +91,12 @@ var (
 		"overrides.foo.ruler_evaluation_delay_duration",
 		"overrides.foo.enforce_metric_name",
 		"overrides.foo.allow_deletes",
+		"overrides.foo.ruler_enable_wal_replay",
 		"overrides.bar.unordered_writes",
 		"overrides.bar.ruler_evaluation_delay_duration",
 		"overrides.bar.enforce_metric_name",
 		"overrides.bar.allow_deletes",
+		"overrides.bar.ruler_enable_wal_replay",
 	}
 
 	expectedRuntimeConfigDeprecates = []string{

--- a/tools/deprecated-config-checker/deleted-config.yaml
+++ b/tools/deprecated-config-checker/deleted-config.yaml
@@ -91,3 +91,4 @@ limits_config:
   ruler_evaluation_delay_duration: "This setting is removed."
   enforce_metric_name: "This setting is removed."
   allow_deletes: "This setting is removed."
+  ruler_enable_wal_replay: "This setting is removed. The ruler now always wipes its remote-write WAL on startup, so there is nothing to replay."

--- a/tools/deprecated-config-checker/test-fixtures/config.yaml
+++ b/tools/deprecated-config-checker/test-fixtures/config.yaml
@@ -123,6 +123,7 @@ limits_config:
   unordered_writes: true # REMOVED
   enforce_metric_name: true # DELETED
   ruler_evaluation_delay_duration: 1m # DELETED
+  ruler_enable_wal_replay: true # DELETED
   ruler_remote_write_url: "push.123abc.net" # DEPRECATED
   ruler_remote_write_timeout: 1m # DEPRECATED
   ruler_remote_write_headers: ["foo", "bar"] # DEPRECATED

--- a/tools/deprecated-config-checker/test-fixtures/runtime-config.yaml
+++ b/tools/deprecated-config-checker/test-fixtures/runtime-config.yaml
@@ -4,6 +4,7 @@ overrides:
     unordered_writes: true # REMOVED
     enforce_metric_name: true # DELETED
     ruler_evaluation_delay_duration: 1m # DELETED
+    ruler_enable_wal_replay: true # DELETED
     ruler_remote_write_url: "push.123abc.net" # DEPRECATED
     ruler_remote_write_timeout: 1m # DEPRECATED
     ruler_remote_write_headers: ["foo", "bar"] # DEPRECATED


### PR DESCRIPTION
**What this PR does**: The ruler now deletes its remote-write WAL directory on startup instead of replaying it. Previously the WAL was persisted across restarts and replayed into memory on boot (optionally skippable via `-ruler.enable-wal-replay`), but it was never deleted. Now it's wiped unconditionally when the ruler comes up.

Since the WAL is always discarded on startup, there's never anything to replay — so I ripped out the replay machinery entirely, along with the `ruler_enable_wal_replay` setting that controlled it.

The wipe happens once per process in `newWALRegistry`, before any per-tenant storage is opened. I deliberately did *not* put it in `wal.NewStorage`: that function is re-invoked every time a tenant instance restarts (the `BasicManager` runs each instance's `Run` in a restart loop), so wiping there would blow away accumulated WAL data on any transient restart instead of only at process start.

**Breaking changes**:
- Removed the `-ruler.enable-wal-replay` flag and the `ruler_enable_wal_replay` per-tenant limit. Neither means anything now that the WAL is always wiped.
- Removed these ruler WAL metrics, which only ever recorded replay/repair activity: `loki_ruler_wal_corruptions_total`, `loki_ruler_wal_corruptions_repair_failed_total`, `loki_ruler_wal_corruptions_repair_succeeded_total`, `loki_ruler_wal_replay_duration`.

**Tradeoff worth calling out**: any samples sitting in the WAL that hadn't been flushed to remote storage before a restart are now lost — we no longer recover in-memory series on boot. For recording rules this is generally fine (they re-evaluate and re-send), but it's a real behavior change so I want it explicit.

Docs updated: regenerated the config reference and rewrote the now-stale "Start-up", "Appender Not Ready", and "Corrupt WAL" sections of the recording-rules page.