### PR TITLE
chore(logsobj): Remap stream IDs in sort key order

### DIFF
--- a/pkg/dataobj/consumer/flush_test.go
+++ b/pkg/dataobj/consumer/flush_test.go
@@ -28,7 +28,7 @@ func TestFlusher_Flush(t *testing.T) {
 			now          = time.Now()
 		)
 		// Create a builder and append some logs so it can be flushed.
-		realBuilder, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory(), logsobj.NewBuilderMetrics())
+		realBuilder, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory(), logsobj.NewBuilderMetrics(), log.NewNopLogger(), nil)
 		require.NoError(t, err)
 		testBuilder = &mockBuilder{builder: realBuilder}
 		require.NoError(t, testBuilder.Append("test", logproto.Stream{

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -160,7 +160,7 @@ func (cfg *BuilderConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet
 
 	f.StringVar(&cfg.DataobjSortOrder, prefix+"dataobj-sort-order", sortStreamASC, "The desired sort order of the logs section. Can either be `stream-asc` (order by streamID ascending and timestamp descending) or `timestamp-desc` (order by timestamp descending and streamID ascending).")
 	f.BoolVar(&cfg.AppendOrderedEnabled, prefix+"append-ordered-enabled", true, "Skips intermediate stripe sorting and merging. Expects data to be sorted before appending.")
-	f.BoolVar(&cfg.DataobjUseSortSchema, prefix+"dataobj-use-sort-schema", false, "Experimental: When enabled, use the per-tenant sort_schema tenant config to determine sort order of data objects instead of dataobj-sort-order.")
+	f.BoolVar(&cfg.DataobjUseSortSchema, prefix+"dataobj-use-sort-schema", false, "Experimental: When enabled, use the per-tenant sort_schema tenant config to determine sort order of data objects. dataobj-sort-order is used as fallback sort order if schema labels are empty for a tenant.")
 }
 
 // Validate validates the BuilderConfig.
@@ -224,9 +224,6 @@ type Builder struct {
 	streams map[string]*streams.Builder
 	logs    map[string]*logs.Builder
 
-	// sortSchemaLabels caches the schema labels for enabled tenants.
-	sortSchemaLabels map[string][]string
-
 	// earliestRecordTime tracks the timestamp of the earliest record appended
 	// to the builder. It is required for the metastore index.
 	earliestRecordTime time.Time
@@ -254,15 +251,14 @@ func NewBuilder(cfg BuilderConfig, scratchStore scratch.Store, metrics *BuilderM
 	}
 
 	return &Builder{
-		cfg:              cfg,
-		metrics:          metrics,
-		logger:           logger,
-		overrides:        overrides,
-		labelCache:       labelCache,
-		builder:          dataobj.NewBuilder(scratchStore),
-		streams:          make(map[string]*streams.Builder),
-		logs:             make(map[string]*logs.Builder),
-		sortSchemaLabels: make(map[string][]string),
+		cfg:        cfg,
+		metrics:    metrics,
+		logger:     logger,
+		overrides:  overrides,
+		labelCache: labelCache,
+		builder:    dataobj.NewBuilder(scratchStore),
+		streams:    make(map[string]*streams.Builder),
+		logs:       make(map[string]*logs.Builder),
 	}, nil
 }
 
@@ -300,7 +296,6 @@ func (b *Builder) initBuilder(tenant string) {
 			}
 		}
 
-		b.sortSchemaLabels[tenant] = schemaLabels
 		lb := logs.NewBuilder(b.metrics.logs, logs.BuilderOptions{
 			PageSizeHint:              int(b.cfg.TargetPageSize),
 			PageMaxRowCount:           b.cfg.MaxPageRows,
@@ -346,11 +341,14 @@ func (b *Builder) Append(tenant string, stream logproto.Stream, recTime time.Tim
 	defer timer.ObserveDuration()
 
 	var sortKey string
-	if schemaLabels := b.sortSchemaLabels[tenant]; len(schemaLabels) > 0 {
-		var err error
-		sortKey, err = computeSortKey(ls, schemaLabels)
-		if err != nil {
-			return fmt.Errorf("compute sort key for tenant %s: %w", tenant, err)
+	if b.cfg.DataobjUseSortSchema && b.overrides != nil {
+		schemaLabels := b.overrides.SortSchemaLabels(tenant)
+		if len(schemaLabels) > 0 {
+			var err error
+			sortKey, err = computeSortKey(ls, schemaLabels)
+			if err != nil {
+				return fmt.Errorf("compute sort key for tenant %s: %w", tenant, err)
+			}
 		}
 	}
 
@@ -648,7 +646,6 @@ func (b *Builder) Reset() {
 	// relative to our memory limit. Maybe we will consider this in future.
 	clear(b.logs)
 	clear(b.streams)
-	clear(b.sortSchemaLabels)
 
 	b.earliestRecordTime = time.Time{}
 	b.currentSizeEstimate = 0

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -275,22 +275,29 @@ func (b *Builder) initBuilder(tenant string) {
 	}
 	if _, ok := b.logs[tenant]; !ok {
 		var schemaLabels []string
-		if b.cfg.DataobjUseSortSchema && b.overrides != nil {
-			schemaLabels = b.overrides.SortSchemaLabels(tenant)
-		}
-
 		sortOrder := parseSortOrder(b.cfg.DataobjSortOrder)
 		appendStrategy := appendStrategy(b.cfg.AppendOrderedEnabled)
 
-		if len(schemaLabels) > 0 {
-			sortOrder = logs.SortSchemaASC
+		if b.cfg.DataobjUseSortSchema {
+			if b.overrides != nil {
+				schemaLabels = b.overrides.SortSchemaLabels(tenant)
+			}
 
-			// TODO(ashwanth): SortSchemaASC does not support AppendUnordered
-			// It cannot merge stripes with schema ordering. This is
-			// good to have as sorting stripes can help lower peak
-			// memory usage compared to sorting entire section at once.
-			// Force to always use AppendOrdered temporarily.
-			appendStrategy = logs.AppendOrdered
+			if len(schemaLabels) == 0 {
+				level.Warn(b.logger).Log("msg", "sort schema labels not configured, falling back to dataobj_sort_order", "tenant", tenant, "dataobj_sort_order", b.cfg.DataobjSortOrder)
+			} else {
+				schemaLabelsStr := strings.Join(schemaLabels, ",")
+				level.Info(b.logger).Log("msg", "sort schema configured, dataobj-sort-order value will be ignored.", "tenant", tenant, "schema_labels", schemaLabelsStr)
+
+				sortOrder = logs.SortSchemaASC
+
+				// TODO(ashwanth): SortSchemaASC does not support AppendUnordered
+				// It cannot merge stripes with schema ordering. This is
+				// good to have as sorting stripes can help lower peak
+				// memory usage compared to sorting entire section at once.
+				// Force to always use AppendOrdered temporarily.
+				appendStrategy = logs.AppendOrdered
+			}
 		}
 
 		b.sortSchemaLabels[tenant] = schemaLabels
@@ -525,21 +532,12 @@ func (b *Builder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataob
 		)
 
 		if b.cfg.DataobjUseSortSchema {
-			if len(sections) > 0 {
-				firstSec, err := logs.Open(ctx, sections[0])
-				if err != nil {
-					return nil, nil, fmt.Errorf("opening logs section to read schema labels: %w", err)
-				}
-				schemaLabels, err = firstSec.SchemaLabels()
-				if err != nil {
-					return nil, nil, fmt.Errorf("reading schema labels from logs section: %w", err)
-				}
-			}
-			if len(schemaLabels) == 0 && b.overrides != nil {
+			if b.overrides != nil {
 				schemaLabels = b.overrides.SortSchemaLabels(tenant)
 			}
+
 			if len(schemaLabels) == 0 {
-				level.Warn(b.logger).Log("msg", "sort schema: no schema labels resolved, falling back to dataobj_sort_order", "tenant", tenant, "overrides_configured", b.overrides != nil)
+				level.Warn(b.logger).Log("msg", "sort schema labels not configured, falling back to dataobj_sort_order", "tenant", tenant, "dataobj_sort_order", b.cfg.DataobjSortOrder)
 			}
 		}
 

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -561,7 +561,7 @@ func (b *Builder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataob
 		}
 
 		if len(schemaLabels) > 0 {
-			streamIter, streamRemap, err := sortAndRemapStreams(streamsSectionIter(ctx, streamsSection), tenant, schemaLabels, streamsSection.NumStreams())
+			streamIter, streamRemap, err := sortAndRemapStreams(streamsSectionIter(ctx, streamsSection), tenant, schemaLabels, streamsSection.NumRows())
 			if err != nil {
 				return nil, nil, fmt.Errorf("building stream ID remap for tenant %s: %w", tenant, err)
 			}

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -576,7 +576,7 @@ func (b *Builder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataob
 			}
 
 			sortOrder = logs.SortSchemaASC
-			iter, iterErr = sortedSchemaIter(ctx, sections, streamRemap.sortKeys, streamRemap.ids, parseSortOrder(b.cfg.DataobjSortOrder))
+			iter, iterErr = sortedSchemaIter(ctx, sections, streamRemap.sortKeys, streamRemap.ids)
 		} else {
 			if err := b.buildStreamSection(ctx, tenant, streamsSectionIter(ctx, streamSections[0]), sb); err != nil {
 				return nil, nil, err

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -555,9 +555,13 @@ func (b *Builder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataob
 			return nil, nil, fmt.Errorf("multiple streams sections found for tenant: %v", tenant)
 		}
 
+		streamsSection, err := streams.Open(ctx, streamSections[0])
+		if err != nil {
+			return nil, nil, fmt.Errorf("opening streams section for tenant %s: %w", tenant, err)
+		}
+
 		if len(schemaLabels) > 0 {
-			var err error
-			streamIter, streamRemap, err := sortAndRemapStreams(streamsSectionIter(ctx, streamSections[0]), tenant, schemaLabels)
+			streamIter, streamRemap, err := sortAndRemapStreams(streamsSectionIter(ctx, streamsSection), tenant, schemaLabels, streamsSection.NumStreams())
 			if err != nil {
 				return nil, nil, fmt.Errorf("building stream ID remap for tenant %s: %w", tenant, err)
 			}
@@ -569,7 +573,7 @@ func (b *Builder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataob
 			sortOrder = logs.SortSchemaASC
 			iter, iterErr = sortedSchemaIter(ctx, sections, streamRemap.sortKeys, streamRemap.ids)
 		} else {
-			if err := b.buildStreamSection(ctx, tenant, streamsSectionIter(ctx, streamSections[0]), sb); err != nil {
+			if err := b.buildStreamSection(ctx, tenant, streamsSectionIter(ctx, streamsSection), sb); err != nil {
 				return nil, nil, err
 			}
 
@@ -701,8 +705,8 @@ func (b *Builder) buildStreamSection(ctx context.Context, tenant string, iter re
 }
 
 type streamIDRemap struct {
-	sortKeys map[int64]string
-	ids      map[int64]int64
+	sortKeys []string
+	ids      []int64
 }
 
 type streamWithSortKey struct {
@@ -723,12 +727,12 @@ type streamWithSortKey struct {
 // compression and pruning at query time.
 //
 // Log records must also be remapped to keep their stream references valid.
-func sortAndRemapStreams(iter result.Seq[streams.Stream], tenant string, schemaLabels []string) (result.Seq[streams.Stream], streamIDRemap, error) {
+func sortAndRemapStreams(iter result.Seq[streams.Stream], tenant string, schemaLabels []string, numStreams int) (result.Seq[streams.Stream], streamIDRemap, error) {
 	var (
-		collected []streamWithSortKey
+		collected = make([]streamWithSortKey, 0, numStreams)
 		remap     = streamIDRemap{
-			sortKeys: make(map[int64]string),
-			ids:      make(map[int64]int64),
+			sortKeys: make([]string, numStreams+1),
+			ids:      make([]int64, numStreams+1),
 		}
 	)
 
@@ -758,7 +762,10 @@ func sortAndRemapStreams(iter result.Seq[streams.Stream], tenant string, schemaL
 		oldID := collected[i].stream.ID
 		newID := int64(i + 1)
 
-		if prevNewID, ok := remap.ids[oldID]; ok {
+		if oldID <= 0 || oldID > int64(numStreams) {
+			return nil, streamIDRemap{}, fmt.Errorf("stream id %d out of range for tenant %s with %d streams", oldID, tenant, numStreams)
+		}
+		if prevNewID := remap.ids[oldID]; prevNewID != 0 {
 			return nil, streamIDRemap{}, fmt.Errorf("duplicate stream id for tenant %s: old id %d maps to both %d and %d", tenant, oldID, prevNewID, newID)
 		}
 
@@ -779,12 +786,8 @@ func sortAndRemapStreams(iter result.Seq[streams.Stream], tenant string, schemaL
 	}), remap, nil
 }
 
-func streamsSectionIter(ctx context.Context, sec *dataobj.Section) result.Seq[streams.Stream] {
+func streamsSectionIter(ctx context.Context, section *streams.Section) result.Seq[streams.Stream] {
 	return result.Iter(func(yield func(streams.Stream) bool) error {
-		section, err := streams.Open(ctx, sec)
-		if err != nil {
-			return fmt.Errorf("failed to open streams section: %w", err)
-		}
 		for res := range streams.IterSection(ctx, section) {
 			stream, err := res.Value()
 			if err != nil {

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -2,11 +2,13 @@
 package logsobj
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"time"
 
@@ -449,9 +451,8 @@ func (b *Builder) Flush() (*dataobj.Object, io.Closer, error) {
 
 // CopyAndSort takes an existing [dataobj.Object] and rewrites the logs sections
 // so the logs are sorted object-wide. The order of the sections is deterministic.
-// For each tenant, first come the streams sections in the order of the old object
-// and second come the new, rewritten logs sections. Tenants are sorted in natural
-// order.
+// For each tenant, first comes the streams section, and second come the
+// new, rewritten logs sections. Tenants are sorted in natural order.
 func (b *Builder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataobj.Object, io.Closer, error) {
 	// Must reset builder when done.
 	defer b.Reset()
@@ -477,28 +478,6 @@ func (b *Builder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataob
 		case <-ctx.Done():
 			return nil, nil, ctx.Err()
 		default:
-		}
-
-		for _, sec := range obj.Sections().Filter(func(s *dataobj.Section) bool { return streams.CheckSection(s) && s.Tenant == tenant }) {
-			sb.Reset()
-			sb.SetTenant(sec.Tenant)
-			// Copy section into new builder. This is *very* inefficient at the moment!
-			// TODO(chaudum): Create implementation of SectionBuilder interface that can copy entire ranges from a SectionReader.
-			section, err := streams.Open(ctx, sec)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to open streams section: %w", err)
-			}
-			iter := streams.IterSection(ctx, section)
-			for res := range iter {
-				val, err := res.Value()
-				if err != nil {
-					return nil, nil, err
-				}
-				sb.AppendValue(val)
-			}
-			if err := b.builder.Append(sb); err != nil {
-				return nil, nil, err
-			}
 		}
 
 		var sections []*dataobj.Section
@@ -538,14 +517,36 @@ func (b *Builder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataob
 			}
 		}
 
+		var streamSections []*dataobj.Section
+		for _, sec := range obj.Sections().Filter(func(s *dataobj.Section) bool {
+			return streams.CheckSection(s) && s.Tenant == tenant
+		}) {
+			streamSections = append(streamSections, sec)
+		}
+		if len(streamSections) == 0 {
+			return nil, nil, fmt.Errorf("no streams sections found for tenant: %v", tenant)
+		} else if len(streamSections) > 1 {
+			return nil, nil, fmt.Errorf("multiple streams sections found for tenant: %v", tenant)
+		}
+
 		if len(schemaLabels) > 0 {
-			sortKeys, err := buildSortKeys(ctx, obj, tenant, schemaLabels)
+			var err error
+			streamIter, streamRemap, err := sortAndRemapStreams(streamsSectionIter(ctx, streamSections[0]), tenant, schemaLabels)
 			if err != nil {
-				return nil, nil, fmt.Errorf("building sort keys for tenant %s: %w", tenant, err)
+				return nil, nil, fmt.Errorf("building stream ID remap for tenant %s: %w", tenant, err)
 			}
+
+			if err := b.buildStreamSection(ctx, tenant, streamIter, sb); err != nil {
+				return nil, nil, err
+			}
+
 			sortOrder = logs.SortSchemaASC
-			iter, iterErr = sortedSchemaIter(ctx, sections, sortKeys, parseSortOrder(b.cfg.DataobjSortOrder))
+			iter, iterErr = sortedSchemaIter(ctx, sections, streamRemap.sortKeys, streamRemap.ids, parseSortOrder(b.cfg.DataobjSortOrder))
 		} else {
+			if err := b.buildStreamSection(ctx, tenant, streamsSectionIter(ctx, streamSections[0]), sb); err != nil {
+				return nil, nil, err
+			}
+
 			sortOrder = parseSortOrder(b.cfg.DataobjSortOrder)
 			iter, iterErr = sortmerge.Iterator(ctx, sections, sortOrder)
 		}
@@ -651,28 +652,123 @@ func (b *Builder) drainLogsIter(ctx context.Context, iter result.Seq[logs.Record
 	return b.builder.Append(lb)
 }
 
-func buildSortKeys(ctx context.Context, obj *dataobj.Object, tenant string, schemaLabels []string) (map[int64]string, error) {
-	sortKeys := make(map[int64]string)
-	for _, sec := range obj.Sections().Filter(func(s *dataobj.Section) bool {
-		return streams.CheckSection(s) && s.Tenant == tenant
-	}) {
+// buildStreamSection consumes an iterator, appending each stream to the provided
+// streams.Builder, and adds it to the sections accumulator.
+func (b *Builder) buildStreamSection(ctx context.Context, tenant string, iter result.Seq[streams.Stream], sb *streams.Builder) error {
+	sb.Reset()
+	sb.SetTenant(tenant)
+
+	for res := range iter {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		stream, err := res.Value()
+		if err != nil {
+			return err
+		}
+		sb.AppendValue(stream)
+	}
+	return b.builder.Append(sb)
+}
+
+type streamIDRemap struct {
+	sortKeys map[int64]string
+	ids      map[int64]int64
+}
+
+type streamWithSortKey struct {
+	stream  streams.Stream
+	sortKey string
+}
+
+// sortAndRemapStreams orders the streams by the sort key and reassigns
+// stream IDs in sort key order. It returns an iterator over the remapped
+// streams and a mapping from old stream IDs to new stream IDs.
+//
+// Stream IDs are originally assigned in the order streams are first recorded.
+// After sort key ordering, streams are clustered by sort key, but their
+// original IDs may no longer be monotonic in that order.
+//
+// Reassigning IDs in sort-key order makes the persisted sort metadata
+// [streamID ASC, timestamp DESC] match the physical row order and improves
+// compression and pruning at query time.
+//
+// Log records must also be remapped to keep their stream references valid.
+func sortAndRemapStreams(iter result.Seq[streams.Stream], tenant string, schemaLabels []string) (result.Seq[streams.Stream], streamIDRemap, error) {
+	var (
+		collected []streamWithSortKey
+		remap     = streamIDRemap{
+			sortKeys: make(map[int64]string),
+			ids:      make(map[int64]int64),
+		}
+	)
+
+	for res := range iter {
+		stream, err := res.Value()
+		if err != nil {
+			return nil, streamIDRemap{}, err
+		}
+		k, err := computeSortKey(stream.Labels, schemaLabels)
+		if err != nil {
+			return nil, streamIDRemap{}, err
+		}
+		collected = append(collected, streamWithSortKey{
+			stream:  stream,
+			sortKey: k,
+		})
+	}
+
+	slices.SortFunc(collected, func(a, b streamWithSortKey) int {
+		if res := cmp.Compare(a.sortKey, b.sortKey); res != 0 {
+			return res
+		}
+		return cmp.Compare(a.stream.ID, b.stream.ID)
+	})
+
+	for i := range collected {
+		oldID := collected[i].stream.ID
+		newID := int64(i + 1)
+
+		if prevNewID, ok := remap.ids[oldID]; ok {
+			return nil, streamIDRemap{}, fmt.Errorf("duplicate stream id for tenant %s: old id %d maps to both %d and %d", tenant, oldID, prevNewID, newID)
+		}
+
+		remap.sortKeys[oldID] = collected[i].sortKey
+		remap.ids[oldID] = newID
+
+		// Remap to the new stream ID.
+		collected[i].stream.ID = newID
+	}
+
+	return result.Iter(func(yield func(streams.Stream) bool) error {
+		for _, entry := range collected {
+			if !yield(entry.stream) {
+				return nil
+			}
+		}
+		return nil
+	}), remap, nil
+}
+
+func streamsSectionIter(ctx context.Context, sec *dataobj.Section) result.Seq[streams.Stream] {
+	return result.Iter(func(yield func(streams.Stream) bool) error {
 		section, err := streams.Open(ctx, sec)
 		if err != nil {
-			return nil, fmt.Errorf("opening streams section: %w", err)
+			return fmt.Errorf("failed to open streams section: %w", err)
 		}
 		for res := range streams.IterSection(ctx, section) {
 			stream, err := res.Value()
 			if err != nil {
-				return nil, err
+				return err
 			}
-			k, err := computeSortKey(stream.Labels, schemaLabels)
-			if err != nil {
-				return nil, err
+			if !yield(stream) {
+				return nil
 			}
-			sortKeys[stream.ID] = k
 		}
-	}
-	return sortKeys, nil
+		return nil
+	})
 }
 
 // computeSortKey builds a composite sort key from stream labels using FQN entries.

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -224,6 +224,9 @@ type Builder struct {
 	streams map[string]*streams.Builder
 	logs    map[string]*logs.Builder
 
+	// sortSchemaLabels caches the schema labels for enabled tenants.
+	sortSchemaLabels map[string][]string
+
 	// earliestRecordTime tracks the timestamp of the earliest record appended
 	// to the builder. It is required for the metastore index.
 	earliestRecordTime time.Time
@@ -251,13 +254,14 @@ func NewBuilder(cfg BuilderConfig, scratchStore scratch.Store, metrics *BuilderM
 	}
 
 	return &Builder{
-		cfg:        cfg,
-		metrics:    metrics,
-		logger:     log.NewNopLogger(),
-		labelCache: labelCache,
-		builder:    dataobj.NewBuilder(scratchStore),
-		streams:    make(map[string]*streams.Builder),
-		logs:       make(map[string]*logs.Builder),
+		cfg:              cfg,
+		metrics:          metrics,
+		logger:           log.NewNopLogger(),
+		labelCache:       labelCache,
+		builder:          dataobj.NewBuilder(scratchStore),
+		streams:          make(map[string]*streams.Builder),
+		logs:             make(map[string]*logs.Builder),
+		sortSchemaLabels: make(map[string][]string),
 	}, nil
 }
 
@@ -279,14 +283,35 @@ func (b *Builder) initBuilder(tenant string) {
 		b.streams[tenant] = sb
 	}
 	if _, ok := b.logs[tenant]; !ok {
+		var schemaLabels []string
+		if b.cfg.DataobjUseSortSchema && b.overrides != nil {
+			schemaLabels = b.overrides.SortSchemaLabels(tenant)
+		}
+
+		sortOrder := parseSortOrder(b.cfg.DataobjSortOrder)
+		appendStrategy := appendStrategy(b.cfg.AppendOrderedEnabled)
+
+		if len(schemaLabels) > 0 {
+			sortOrder = logs.SortSchemaASC
+
+			// TODO(ashwanth): SortSchemaASC does not support AppendUnordered
+			// It cannot merge stripes with schema ordering. This is
+			// good to have as sorting stripes can help lower peak
+			// memory usage compared to sorting entire section at once.
+			// Force to always use AppendOrdered temporarily.
+			appendStrategy = logs.AppendOrdered
+		}
+
+		b.sortSchemaLabels[tenant] = schemaLabels
 		lb := logs.NewBuilder(b.metrics.logs, logs.BuilderOptions{
 			PageSizeHint:              int(b.cfg.TargetPageSize),
 			PageMaxRowCount:           b.cfg.MaxPageRows,
 			BufferSize:                int(b.cfg.BufferSize),
 			StripeMergeLimit:          b.cfg.SectionStripeMergeLimit,
-			AppendStrategy:            appendStrategy(b.cfg.AppendOrderedEnabled),
+			AppendStrategy:            appendStrategy,
 			EstimatedCompressionRatio: b.cfg.EstimatedCompressionRatio,
-			SortOrder:                 parseSortOrder(b.cfg.DataobjSortOrder),
+			SortOrder:                 sortOrder,
+			SchemaLabels:              schemaLabels,
 		})
 		lb.SetTenant(tenant)
 		b.logs[tenant] = lb
@@ -322,6 +347,15 @@ func (b *Builder) Append(tenant string, stream logproto.Stream, recTime time.Tim
 	timer := prometheus.NewTimer(b.metrics.appendTime)
 	defer timer.ObserveDuration()
 
+	var sortKey string
+	if schemaLabels := b.sortSchemaLabels[tenant]; len(schemaLabels) > 0 {
+		var err error
+		sortKey, err = computeSortKey(ls, schemaLabels)
+		if err != nil {
+			return fmt.Errorf("compute sort key for tenant %s: %w", tenant, err)
+		}
+	}
+
 	for _, entry := range stream.Entries {
 		sz := int64(len(entry.Line))
 		for _, md := range entry.StructuredMetadata {
@@ -335,6 +369,7 @@ func (b *Builder) Append(tenant string, stream logproto.Stream, recTime time.Tim
 			Timestamp: entry.Timestamp,
 			Metadata:  convertMetadata(entry.StructuredMetadata),
 			Line:      []byte(entry.Line),
+			SortKey:   sortKey,
 		})
 
 		// If our logs section has gotten big enough, we want to flush it to the
@@ -620,6 +655,7 @@ func (b *Builder) Reset() {
 	// relative to our memory limit. Maybe we will consider this in future.
 	clear(b.logs)
 	clear(b.streams)
+	clear(b.sortSchemaLabels)
 
 	b.earliestRecordTime = time.Time{}
 	b.currentSizeEstimate = 0

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -247,7 +247,7 @@ const (
 // NewBuilder creates a new [Builder] which stores log-oriented data objects.
 //
 // NewBuilder returns an error if the provided config is invalid.
-func NewBuilder(cfg BuilderConfig, scratchStore scratch.Store, metrics *BuilderMetrics) (*Builder, error) {
+func NewBuilder(cfg BuilderConfig, scratchStore scratch.Store, metrics *BuilderMetrics, logger log.Logger, overrides TenantOverrides) (*Builder, error) {
 	labelCache, err := lru.New[string, labels.Labels](5000)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create LRU cache: %w", err)
@@ -256,23 +256,14 @@ func NewBuilder(cfg BuilderConfig, scratchStore scratch.Store, metrics *BuilderM
 	return &Builder{
 		cfg:              cfg,
 		metrics:          metrics,
-		logger:           log.NewNopLogger(),
+		logger:           logger,
+		overrides:        overrides,
 		labelCache:       labelCache,
 		builder:          dataobj.NewBuilder(scratchStore),
 		streams:          make(map[string]*streams.Builder),
 		logs:             make(map[string]*logs.Builder),
 		sortSchemaLabels: make(map[string][]string),
 	}, nil
-}
-
-// SetOverrides configures per-tenant overrides used when DataobjUseSortSchema is enabled.
-func (b *Builder) SetOverrides(overrides TenantOverrides) {
-	b.overrides = overrides
-}
-
-// SetLogger sets the logger used by the builder.
-func (b *Builder) SetLogger(logger log.Logger) {
-	b.logger = logger
 }
 
 // initBuilder initializes the builders for the tenant.

--- a/pkg/dataobj/consumer/logsobj/builder_e2e_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_e2e_test.go
@@ -1,0 +1,321 @@
+package logsobj
+
+import (
+	"cmp"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/push"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+// TestBuilder_EndToEnd is a sanity check for the full builder pipeline:
+// Append -> Flush (intermediate object) -> CopyAndSort (final object).
+//
+// The dataset is randomly generated with a fixed seed to broadly exercise:
+// - intermediate log sections are individually ordered.
+// - sort merge of the intermediate log sections and object-wide ordering.
+// - stream ID mapping to ensure they are consistent with the sort key order.
+//
+// TODO(ashwanth): SortSchemaASC does not support AppendUnordered because
+// stripe merging cannot use schema-based ordering. Once that is fixed, this
+// test should be updated to also run with AppendOrderedEnabled=false for
+// schema sort cases.
+func TestBuilder_EndToEnd(t *testing.T) {
+	tenants := []string{"t1", "t2", "t10"}
+	apps := []string{"zoo", "alpha", "middle"}
+	instances := []string{"b", "a"}
+	schemaLabels := []string{"label:app"}
+
+	// Local config: bigger sections so each holds many records with real
+	// internal disorder. AppendOrdered is used because SortSchemaASC does
+	// not yet support stripe merging (AppendUnordered).
+	baseCfg := BuilderConfig{
+		BuilderBaseConfig: BuilderBaseConfig{
+			TargetPageSize:          2048,
+			TargetObjectSize:        1 << 20,
+			TargetSectionSize:       64 << 10, // 64 KiB
+			BufferSize:              16 << 10, // 16 KiB
+			SectionStripeMergeLimit: 2,
+		},
+		AppendOrderedEnabled: true,
+	}
+
+	makeOverrides := func() TenantOverrides {
+		overrides := tenantOverrides{}
+		for _, tenant := range tenants {
+			overrides[tenant] = schemaLabels
+		}
+		return overrides
+	}
+
+	appendDataset := func(t *testing.T, b *Builder) {
+		t.Helper()
+
+		rng := rand.New(rand.NewSource(42))
+		refTime := time.Date(2025, time.September, 17, 12, 0, 0, 0, time.UTC)
+
+		// 1000 entries across 3 tenants (~333 per tenant) with ~1 KiB lines
+		// and 64 KiB sections gives ~5 sections per tenant.
+		const numEntries = 1000
+
+		for i := range numEntries {
+			tenant := tenants[rng.Intn(len(tenants))]
+			app := apps[rng.Intn(len(apps))]
+			instance := instances[rng.Intn(len(instances))]
+			// [-64s, +63s] window around refTime; narrow enough to guarantee timestamp ties.
+			ts := refTime.Add(time.Duration(rng.Intn(128)-64) * time.Second)
+
+			md := push.LabelsAdapter{
+				{Name: "trace_id", Value: fmt.Sprintf("trace-%04d", i)},
+			}
+			if rng.Intn(4) == 0 {
+				md = append(md, push.LabelAdapter{Name: "span_id", Value: fmt.Sprintf("span-%04d", i)})
+			}
+
+			require.NoError(t, b.Append(tenant, logproto.Stream{
+				Labels: fmt.Sprintf(`{app=%q,instance=%q}`, app, instance),
+				Entries: []push.Entry{{
+					Timestamp:          ts,
+					Line:               builderE2ELine(tenant, app, instance, i),
+					StructuredMetadata: md,
+				}},
+			}, ts))
+		}
+	}
+
+	for _, tc := range []struct {
+		name          string
+		sortOrder     string
+		useSortSchema bool
+	}{
+		{name: "SortOrderStreamASC", sortOrder: sortStreamASC},
+		{name: "SortOrderTimestampDESC", sortOrder: sortTimestampDESC},
+		{name: "UseSchemaSort", sortOrder: sortStreamASC, useSortSchema: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseCfg
+			cfg.DataobjSortOrder = tc.sortOrder
+			cfg.DataobjUseSortSchema = tc.useSortSchema
+
+			overrides := makeOverrides()
+			var expectedSchemaLabels []string
+			if tc.useSortSchema {
+				expectedSchemaLabels = schemaLabels
+			}
+
+			b, err := NewBuilder(cfg, nil, NewBuilderMetrics())
+			require.NoError(t, err)
+			if overrides != nil {
+				b.SetOverrides(overrides)
+			}
+			appendDataset(t, b)
+
+			obj1, closer, err := b.Flush()
+			require.NoError(t, err)
+			defer closer.Close()
+
+			intermediateByTenant := make(map[string][]builderE2EResolvedRecord, len(tenants))
+			for _, tenant := range tenants {
+				require.Equal(t, 1, countTenantSections(obj1, tenant, streams.CheckSection))
+				require.Greater(t, countTenantSections(obj1, tenant, logs.CheckSection), 1)
+
+				assertBuilderE2ESchemaLabels(t, obj1, tenant, expectedSchemaLabels)
+
+				for _, sec := range obj1.Sections().Filter(func(s *dataobj.Section) bool {
+					return logs.CheckSection(s) && s.Tenant == tenant
+				}) {
+					// logs are ordered within each section.
+					assertBuilderE2EOrdered(t, resolveTenantLogsSection(t, obj1, tenant, sec), tc.sortOrder, expectedSchemaLabels)
+				}
+				intermediateByTenant[tenant] = resolveTenantLogs(t, obj1, tenant)
+			}
+
+			mergeBuilder, err := NewBuilder(cfg, nil, NewBuilderMetrics())
+			require.NoError(t, err)
+			if overrides != nil {
+				mergeBuilder.SetOverrides(overrides)
+			}
+			obj2, closer2, err := mergeBuilder.CopyAndSort(t.Context(), obj1)
+			require.NoError(t, err)
+			defer closer2.Close()
+
+			require.ElementsMatch(t, obj1.Tenants(), obj2.Tenants())
+			for _, tenant := range tenants {
+				require.Equal(t, 1, countTenantSections(obj2, tenant, streams.CheckSection))
+				require.Greater(t, countTenantSections(obj2, tenant, logs.CheckSection), 1)
+				assertBuilderE2ESchemaLabels(t, obj2, tenant, expectedSchemaLabels)
+
+				got := resolveTenantLogs(t, obj2, tenant)
+				assertBuilderE2ESameContent(t, intermediateByTenant[tenant], got)
+				assertBuilderE2EOrdered(t, got, tc.sortOrder, expectedSchemaLabels)
+			}
+		})
+	}
+}
+
+type builderE2EResolvedRecord struct {
+	streamID int64
+	labels   labels.Labels
+	ts       int64
+	line     string
+	metadata string
+}
+
+func builderE2ELine(tenant, app, instance string, i int) string {
+	switch {
+	case i%7 == 0:
+		return ""
+	case i%5 == 0:
+		return "short"
+	default:
+		prefix := fmt.Sprintf("%s/%s/%s/%02d/", tenant, app, instance, i)
+		return prefix + strings.Repeat("x", 1024-len(prefix))
+	}
+}
+
+func resolveTenantLogs(t *testing.T, obj *dataobj.Object, tenant string) []builderE2EResolvedRecord {
+	t.Helper()
+	streamLabels := tenantStreamLabels(t, obj, tenant)
+
+	var records []builderE2EResolvedRecord
+	for _, sec := range obj.Sections().Filter(func(s *dataobj.Section) bool {
+		return logs.CheckSection(s) && s.Tenant == tenant
+	}) {
+		records = append(records, resolveLogsSection(t, streamLabels, sec)...)
+	}
+	return records
+}
+
+func resolveTenantLogsSection(t *testing.T, obj *dataobj.Object, tenant string, sec *dataobj.Section) []builderE2EResolvedRecord {
+	t.Helper()
+	return resolveLogsSection(t, tenantStreamLabels(t, obj, tenant), sec)
+}
+
+func tenantStreamLabels(t *testing.T, obj *dataobj.Object, tenant string) map[int64]labels.Labels {
+	t.Helper()
+	streamLabels := make(map[int64]labels.Labels)
+	for _, sec := range obj.Sections().Filter(func(s *dataobj.Section) bool {
+		return streams.CheckSection(s) && s.Tenant == tenant
+	}) {
+		streamSection, err := streams.Open(t.Context(), sec)
+		require.NoError(t, err)
+		for res := range streams.IterSection(t.Context(), streamSection) {
+			stream, err := res.Value()
+			require.NoError(t, err)
+			streamLabels[stream.ID] = stream.Labels
+		}
+	}
+	return streamLabels
+}
+
+func resolveLogsSection(t *testing.T, streamLabels map[int64]labels.Labels, sec *dataobj.Section) []builderE2EResolvedRecord {
+	t.Helper()
+	var records []builderE2EResolvedRecord
+	for res := range iterLogsSection(t, sec) {
+		record, err := res.Value()
+		require.NoError(t, err)
+
+		ls, ok := streamLabels[record.StreamID]
+		require.Truef(t, ok, "record references unknown stream ID %d", record.StreamID)
+		records = append(records, builderE2EResolvedRecord{
+			streamID: record.StreamID,
+			labels:   ls,
+			ts:       record.Timestamp.UnixNano(),
+			line:     string(record.Line),
+			metadata: record.Metadata.String(),
+		})
+	}
+	return records
+}
+
+func assertBuilderE2ESameContent(t *testing.T, want, got []builderE2EResolvedRecord) {
+	t.Helper()
+	require.Equal(t, contentCounts(want), contentCounts(got))
+}
+
+func contentCounts(records []builderE2EResolvedRecord) map[string]int {
+	counts := make(map[string]int, len(records))
+	for _, record := range records {
+		key := fmt.Sprintf("%s\x00%d\x00%s\x00%s", record.labels.String(), record.ts, record.line, record.metadata)
+		counts[key]++
+	}
+	return counts
+}
+
+func assertBuilderE2EOrdered(t *testing.T, records []builderE2EResolvedRecord, sortOrder string, schemaLabels []string) {
+	t.Helper()
+	for i := 1; i < len(records); i++ {
+		require.LessOrEqualf(t, compareRecords(t, records[i-1], records[i], sortOrder, schemaLabels), 0,
+			"records out of order at index %d: %+v then %+v", i, records[i-1], records[i])
+	}
+}
+
+func compareRecords(t *testing.T, a, b builderE2EResolvedRecord, sortOrder string, schemaLabels []string) int {
+	t.Helper()
+
+	if len(schemaLabels) > 0 {
+		aKey, err := computeSortKey(a.labels, schemaLabels)
+		require.NoError(t, err)
+
+		bKey, err := computeSortKey(b.labels, schemaLabels)
+		require.NoError(t, err)
+
+		if res := cmp.Compare(aKey, bKey); res != 0 {
+			return res
+		}
+		if res := cmp.Compare(a.streamID, b.streamID); res != 0 {
+			return res
+		}
+		return cmp.Compare(b.ts, a.ts)
+	} else if sortOrder == sortStreamASC {
+
+		if res := cmp.Compare(a.streamID, b.streamID); res != 0 {
+			return res
+		}
+		return cmp.Compare(b.ts, a.ts)
+	} else if sortOrder == sortTimestampDESC {
+		if res := cmp.Compare(b.ts, a.ts); res != 0 {
+			return res
+		}
+		return cmp.Compare(a.streamID, b.streamID)
+	} else {
+		t.Fatalf("unknown sort order: %q", sortOrder)
+		return 0
+	}
+}
+
+func countTenantSections(obj *dataobj.Object, tenant string, check func(*dataobj.Section) bool) int {
+	count := 0
+	for _, sec := range obj.Sections().Filter(func(s *dataobj.Section) bool {
+		return check(s) && s.Tenant == tenant
+	}) {
+		if sec != nil {
+			count++
+		}
+	}
+	return count
+}
+
+func assertBuilderE2ESchemaLabels(t *testing.T, obj *dataobj.Object, tenant string, want []string) {
+	t.Helper()
+	for _, sec := range obj.Sections().Filter(func(s *dataobj.Section) bool {
+		return logs.CheckSection(s) && s.Tenant == tenant
+	}) {
+		logsSection, err := logs.Open(t.Context(), sec)
+		require.NoError(t, err)
+		got, err := logsSection.SchemaLabels()
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	}
+}

--- a/pkg/dataobj/consumer/logsobj/builder_e2e_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
@@ -114,11 +115,8 @@ func TestBuilder_EndToEnd(t *testing.T) {
 				expectedSchemaLabels = schemaLabels
 			}
 
-			b, err := NewBuilder(cfg, nil, NewBuilderMetrics())
+			b, err := NewBuilder(cfg, nil, NewBuilderMetrics(), log.NewNopLogger(), overrides)
 			require.NoError(t, err)
-			if overrides != nil {
-				b.SetOverrides(overrides)
-			}
 			appendDataset(t, b)
 
 			obj1, closer, err := b.Flush()
@@ -141,11 +139,8 @@ func TestBuilder_EndToEnd(t *testing.T) {
 				intermediateByTenant[tenant] = resolveTenantLogs(t, obj1, tenant)
 			}
 
-			mergeBuilder, err := NewBuilder(cfg, nil, NewBuilderMetrics())
+			mergeBuilder, err := NewBuilder(cfg, nil, NewBuilderMetrics(), log.NewNopLogger(), overrides)
 			require.NoError(t, err)
-			if overrides != nil {
-				mergeBuilder.SetOverrides(overrides)
-			}
 			obj2, closer2, err := mergeBuilder.CopyAndSort(t.Context(), obj1)
 			require.NoError(t, err)
 			defer closer2.Close()

--- a/pkg/dataobj/consumer/logsobj/builder_e2e_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_e2e_test.go
@@ -289,10 +289,10 @@ func compareRecords(t *testing.T, a, b builderE2EResolvedRecord, sortOrder strin
 			return res
 		}
 		return cmp.Compare(a.streamID, b.streamID)
-	} else {
-		t.Fatalf("unknown sort order: %q", sortOrder)
-		return 0
 	}
+
+	t.Fatalf("unknown sort order: %q", sortOrder)
+	return 0
 }
 
 func countTenantSections(obj *dataobj.Object, tenant string, check func(*dataobj.Section) bool) int {

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
@@ -77,7 +78,7 @@ func TestBuilder(t *testing.T) {
 	}
 
 	t.Run("Build", func(t *testing.T) {
-		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
+		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics(), log.NewNopLogger(), nil)
 		require.NoError(t, err)
 
 		for _, entry := range testStreams {
@@ -98,7 +99,7 @@ func TestBuilder_Append(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
+	builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics(), log.NewNopLogger(), nil)
 	require.NoError(t, err)
 
 	tenant := "test"
@@ -147,13 +148,13 @@ func TestBuilder_EarliestRecordTime(t *testing.T) {
 	}
 
 	t.Run("zero on an empty builder", func(t *testing.T) {
-		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
+		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics(), log.NewNopLogger(), nil)
 		require.NoError(t, err)
 		require.True(t, builder.GetEarliestRecordTime().IsZero())
 	})
 
 	t.Run("set on first append", func(t *testing.T) {
-		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
+		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics(), log.NewNopLogger(), nil)
 		require.NoError(t, err)
 
 		recTime := time.Unix(100, 0).UTC()
@@ -162,7 +163,7 @@ func TestBuilder_EarliestRecordTime(t *testing.T) {
 	})
 
 	t.Run("tracks the minimum across appends", func(t *testing.T) {
-		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
+		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics(), log.NewNopLogger(), nil)
 		require.NoError(t, err)
 
 		require.NoError(t, builder.Append("tenant", newStream(), time.Unix(100, 0).UTC()))
@@ -175,7 +176,7 @@ func TestBuilder_EarliestRecordTime(t *testing.T) {
 	})
 
 	t.Run("reset on Reset", func(t *testing.T) {
-		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
+		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics(), log.NewNopLogger(), nil)
 		require.NoError(t, err)
 
 		require.NoError(t, builder.Append("tenant", newStream(), time.Unix(100, 0).UTC()))
@@ -184,7 +185,7 @@ func TestBuilder_EarliestRecordTime(t *testing.T) {
 	})
 
 	t.Run("reset on Flush", func(t *testing.T) {
-		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
+		builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics(), log.NewNopLogger(), nil)
 		require.NoError(t, err)
 
 		require.NoError(t, builder.Append("tenant", newStream(), time.Unix(100, 0).UTC()))
@@ -196,7 +197,7 @@ func TestBuilder_EarliestRecordTime(t *testing.T) {
 }
 
 func TestBuilder_CopyAndSort(t *testing.T) {
-	builder, _ := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
+	builder, _ := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics(), log.NewNopLogger(), nil)
 
 	now := time.Date(2025, time.September, 17, 0, 0, 0, 0, time.UTC)
 	numRows := 16 // 16 rows with 1KiB each line and 8KiB section size ~> 2 logs sections per tenant
@@ -218,7 +219,7 @@ func TestBuilder_CopyAndSort(t *testing.T) {
 	require.NoError(t, err)
 	defer closer1.Close()
 
-	newBuilder, _ := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
+	newBuilder, _ := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics(), log.NewNopLogger(), nil)
 
 	obj2, closer2, err := newBuilder.CopyAndSort(t.Context(), obj1)
 	require.NoError(t, err)
@@ -335,10 +336,7 @@ func BenchmarkBuilder_CopyAndSort(b *testing.B) {
 
 	for _, bc := range benchCases {
 		b.Run(bc.name, func(b *testing.B) {
-			builder, _ := NewBuilder(bc.cfg, nil, NewBuilderMetrics())
-			if bc.overrides != nil {
-				builder.SetOverrides(bc.overrides)
-			}
+			builder, _ := NewBuilder(bc.cfg, nil, NewBuilderMetrics(), log.NewNopLogger(), bc.overrides)
 
 			for _, tenant := range tenants {
 				for i := range numRows {
@@ -360,10 +358,7 @@ func BenchmarkBuilder_CopyAndSort(b *testing.B) {
 			require.NoError(b, err)
 			defer closer1.Close()
 
-			newBuilder, _ := NewBuilder(bc.cfg, nil, NewBuilderMetrics())
-			if bc.overrides != nil {
-				newBuilder.SetOverrides(bc.overrides)
-			}
+			newBuilder, _ := NewBuilder(bc.cfg, nil, NewBuilderMetrics(), log.NewNopLogger(), bc.overrides)
 
 			b.Logf("sections=%d, size=%d", obj1.Sections().Count(logs.CheckSection), obj1.Size())
 			b.ResetTimer()
@@ -401,11 +396,8 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 
 	buildObj := func(t *testing.T, cfg BuilderConfig, tenant string, appVals []string, overrides TenantOverrides) *dataobj.Object {
 		t.Helper()
-		b, err := NewBuilder(cfg, nil, NewBuilderMetrics())
+		b, err := NewBuilder(cfg, nil, NewBuilderMetrics(), log.NewNopLogger(), overrides)
 		require.NoError(t, err)
-		if overrides != nil {
-			b.SetOverrides(overrides)
-		}
 		for _, app := range appVals {
 			for i := range 4 {
 				require.NoError(t, b.Append(tenant, logproto.Stream{
@@ -425,11 +417,8 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 
 	copyAndSort := func(t *testing.T, cfg BuilderConfig, src *dataobj.Object, overrides TenantOverrides) *dataobj.Object {
 		t.Helper()
-		b, err := NewBuilder(cfg, nil, NewBuilderMetrics())
+		b, err := NewBuilder(cfg, nil, NewBuilderMetrics(), log.NewNopLogger(), overrides)
 		require.NoError(t, err)
-		if overrides != nil {
-			b.SetOverrides(overrides)
-		}
 		obj, closer, err := b.CopyAndSort(t.Context(), src)
 		require.NoError(t, err)
 		t.Cleanup(func() { closer.Close() })
@@ -503,9 +492,8 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 		cfg := makeCfg(true)
 		overrides := tenantOverrides{"schema-tenant": {"label:app"}}
 
-		b, err := NewBuilder(cfg, nil, NewBuilderMetrics())
+		b, err := NewBuilder(cfg, nil, NewBuilderMetrics(), log.NewNopLogger(), overrides)
 		require.NoError(t, err)
-		b.SetOverrides(overrides)
 		for _, app := range []string{"zoo", "alpha", "middle"} {
 			for i := range 4 {
 				require.NoError(t, b.Append("schema-tenant", logproto.Stream{
@@ -633,9 +621,8 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 	t.Run("multi-label compound key", func(t *testing.T) {
 		cfg := makeCfg(true)
 		overrides := tenantOverrides{"t1": {"label:namespace", "label:app"}}
-		b, err := NewBuilder(cfg, nil, NewBuilderMetrics())
+		b, err := NewBuilder(cfg, nil, NewBuilderMetrics(), log.NewNopLogger(), overrides)
 		require.NoError(t, err)
-		b.SetOverrides(overrides)
 
 		type entry struct{ ns, app string }
 		for _, e := range []entry{{"ns-b", "app-z"}, {"ns-a", "app-z"}, {"ns-a", "app-a"}, {"ns-b", "app-a"}} {
@@ -687,9 +674,8 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 		overrides := tenantOverrides{"t1": {"label:app"}}
 		schemaLabels := []string{"label:app"}
 
-		b, err := NewBuilder(cfg, nil, NewBuilderMetrics())
+		b, err := NewBuilder(cfg, nil, NewBuilderMetrics(), log.NewNopLogger(), overrides)
 		require.NoError(t, err)
-		b.SetOverrides(overrides)
 
 		streamsToAppend := []struct {
 			app      string

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -483,6 +483,61 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 		timestampsDescWithinGroups(t, obj2, "t1")
 	})
 
+	t.Run("initial flush emits schema-ordered logs sections", func(t *testing.T) {
+		cfg := makeCfg(true)
+		overrides := tenantOverrides{"t1": {"label:app"}}
+		obj := buildObj(t, cfg, "t1", []string{"zoo", "alpha", "middle"}, overrides)
+
+		streamToApp := make(map[int64]string)
+		for _, sec := range obj.Sections().Filter(func(s *dataobj.Section) bool {
+			return streams.CheckSection(s) && s.Tenant == "t1"
+		}) {
+			streamSec, err := streams.Open(t.Context(), sec)
+			require.NoError(t, err)
+			for res := range streams.IterSection(t.Context(), streamSec) {
+				val, err := res.Value()
+				require.NoError(t, err)
+				streamToApp[val.ID] = val.Labels.Get("app")
+			}
+		}
+
+		for _, sec := range obj.Sections().Filter(func(s *dataobj.Section) bool {
+			return logs.CheckSection(s) && s.Tenant == "t1"
+		}) {
+			logsSection, err := logs.Open(t.Context(), sec)
+			require.NoError(t, err)
+			schemaLabels, err := logsSection.SchemaLabels()
+			require.NoError(t, err)
+			require.Equal(t, []string{"label:app"}, schemaLabels)
+
+			var (
+				prevApp      string
+				prevStreamID int64
+				prevTS       time.Time
+				firstRecord  = true
+			)
+			for res := range iterLogsSection(t, sec) {
+				val, err := res.Value()
+				require.NoError(t, err)
+				app := streamToApp[val.StreamID]
+				if !firstRecord {
+					switch {
+					case app != prevApp:
+						require.GreaterOrEqual(t, app, prevApp)
+					case val.StreamID != prevStreamID:
+						require.GreaterOrEqual(t, val.StreamID, prevStreamID)
+					default:
+						require.LessOrEqual(t, val.Timestamp.UnixNano(), prevTS.UnixNano())
+					}
+				}
+				prevApp = app
+				prevStreamID = val.StreamID
+				prevTS = val.Timestamp
+				firstRecord = false
+			}
+		}
+	})
+
 	t.Run("idempotent: second CopyAndSort reads schema from metadata, not overrides", func(t *testing.T) {
 		cfg := makeCfg(true)
 		overrides := tenantOverrides{"t1": {"label:app"}}

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/rand"
 	"strings"
 	"testing"
 	"time"
@@ -261,40 +262,118 @@ func TestBuilder_CopyAndSort(t *testing.T) {
 }
 
 func BenchmarkBuilder_CopyAndSort(b *testing.B) {
-	builder, _ := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
-
 	now := time.Date(2025, time.September, 17, 0, 0, 0, 0, time.UTC)
-	numRows := 8192   // 16 rows with 1KiB each line and 8KiB section size ~> 2 logs sections per tenant. 48KB total
-	sizeOfRow := 1024 // 1KiB log line
+	numRows := 768 << 10 // 786432 rows per tenant
+	sizeOfRow := 1024
 	tenants := []string{"tenant-a", "tenant-b", "tenant-c"}
+	apps := []string{"alpha", "bravo", "charlie", "delta"}
+	instances := []string{"i-0", "i-1", "i-2"}
 
-	for _, tenant := range tenants {
-		for i := range numRows {
-			err := builder.Append(tenant, logproto.Stream{
-				Labels: `{cluster="test",app="foo"}`,
-				Entries: []push.Entry{{
-					Timestamp: now.Add(time.Duration(i%8) * time.Second),
-					Line:      strings.Repeat("a", 1024), // 1KiB log line
-				}},
-			}, now.Add(time.Duration(i%8)*time.Second))
-			require.NoError(b, err)
-		}
+	// Pre-generate random lines so they don't compress away.
+	// 256 unique lines reused round-robin keeps setup cheap
+	// while defeating columnar compression.
+	//
+	// This is done to avoid all lines from ending up in a single section.
+	// CopyAndSort is only tested when we are merging multiple input sections.
+	const numLines = 256
+	rng := rand.New(rand.NewSource(42))
+	linePool := make([]string, numLines)
+	for i := range linePool {
+		buf := make([]byte, sizeOfRow)
+		rng.Read(buf)
+		linePool[i] = string(buf)
 	}
 
-	dataSize := numRows * sizeOfRow * len(tenants) // 8192 rows * 1KiB each line * 3 tenants = 24MB
-	b.SetBytes(int64(dataSize))
+	// Need ~128K rows per section to reach target size of 128 MiB.
+	// ~6 logs sections per tenant would require ~768K rows per tenant.
+	benchBaseCfg := BuilderBaseConfig{
+		TargetPageSize:          2 << 20,   // 2 MiB
+		TargetObjectSize:        128 << 20, // 128 MiB (compressed)
+		TargetSectionSize:       128 << 20, // 128 MiB (uncompressed)
+		BufferSize:              16 << 20,  // 16 MiB
+		SectionStripeMergeLimit: 2,
+	}
 
-	obj1, closer1, err := builder.Flush()
-	require.NoError(b, err)
-	defer closer1.Close()
+	benchCases := []struct {
+		name      string
+		cfg       BuilderConfig
+		overrides TenantOverrides
+		labels    func(tenant string, i int) string
+	}{
+		{
+			name: "default",
+			cfg: BuilderConfig{
+				BuilderBaseConfig: benchBaseCfg,
+				DataobjSortOrder:  sortTimestampDESC,
+			},
+			labels: func(_ string, i int) string {
+				app := apps[i%len(apps)]
+				inst := instances[i%len(instances)]
+				return fmt.Sprintf(`{cluster="test",app=%q,instance=%q}`, app, inst)
+			},
+		},
+		{
+			name: "sort_schema",
+			cfg: BuilderConfig{
+				BuilderBaseConfig:    benchBaseCfg,
+				DataobjSortOrder:     sortStreamASC,
+				DataobjUseSortSchema: true,
+				AppendOrderedEnabled: true,
+			},
+			overrides: tenantOverrides{
+				"tenant-a": {"label:app"},
+				"tenant-b": {"label:app"},
+				"tenant-c": {"label:app"},
+			},
+			labels: func(_ string, i int) string {
+				app := apps[i%len(apps)]
+				inst := instances[i%len(instances)]
+				return fmt.Sprintf(`{cluster="test",app=%q,instance=%q}`, app, inst)
+			},
+		},
+	}
 
-	newBuilder, _ := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics())
+	for _, bc := range benchCases {
+		b.Run(bc.name, func(b *testing.B) {
+			builder, _ := NewBuilder(bc.cfg, nil, NewBuilderMetrics())
+			if bc.overrides != nil {
+				builder.SetOverrides(bc.overrides)
+			}
 
-	for b.Loop() {
-		newBuilder.Reset()
-		_, closer2, err := newBuilder.CopyAndSort(b.Context(), obj1)
-		require.NoError(b, err)
-		defer closer2.Close()
+			for _, tenant := range tenants {
+				for i := range numRows {
+					err := builder.Append(tenant, logproto.Stream{
+						Labels: bc.labels(tenant, i),
+						Entries: []push.Entry{{
+							Timestamp: now.Add(time.Duration(i%8) * time.Second),
+							Line:      linePool[i%numLines],
+						}},
+					}, now.Add(time.Duration(i%8)*time.Second))
+					require.NoError(b, err)
+				}
+			}
+
+			dataSize := numRows * sizeOfRow * len(tenants)
+			b.SetBytes(int64(dataSize))
+
+			obj1, closer1, err := builder.Flush()
+			require.NoError(b, err)
+			defer closer1.Close()
+
+			newBuilder, _ := NewBuilder(bc.cfg, nil, NewBuilderMetrics())
+			if bc.overrides != nil {
+				newBuilder.SetOverrides(bc.overrides)
+			}
+
+			b.Logf("sections=%d, size=%d", obj1.Sections().Count(logs.CheckSection), obj1.Size())
+			b.ResetTimer()
+			for b.Loop() {
+				newBuilder.Reset()
+				_, closer2, err := newBuilder.CopyAndSort(b.Context(), obj1)
+				require.NoError(b, err)
+				defer closer2.Close()
+			}
+		})
 	}
 }
 

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/push"
@@ -602,6 +603,179 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 		require.Equal(t, []pair{{"ns-a", "app-a"}, {"ns-a", "app-z"}, {"ns-b", "app-a"}, {"ns-b", "app-z"}}, got)
 	})
 
+	t.Run("stream IDs remapped to sort key order", func(t *testing.T) {
+		cfg := makeCfg(true)
+		overrides := tenantOverrides{"t1": {"label:app"}}
+		schemaLabels := []string{"label:app"}
+
+		b, err := NewBuilder(cfg, nil, NewBuilderMetrics())
+		require.NoError(t, err)
+		b.SetOverrides(overrides)
+
+		streamsToAppend := []struct {
+			app      string
+			instance string
+		}{
+			{app: "zoo", instance: "b"},
+			{app: "alpha", instance: "b"},
+			{app: "middle", instance: "a"},
+			{app: "alpha", instance: "a"},
+			{app: "zoo", instance: "a"},
+			{app: "middle", instance: "b"},
+		}
+
+		for streamIdx, stream := range streamsToAppend {
+			entries := make([]push.Entry, 0, 3)
+			for i := range 3 {
+				ts := now.Add(time.Duration(i) * time.Second)
+				entries = append(entries, push.Entry{
+					Timestamp: ts,
+					Line:      fmt.Sprintf("%s/%s/%d/%s", stream.app, stream.instance, i, strings.Repeat("x", 1024)),
+					StructuredMetadata: push.LabelsAdapter{
+						{Name: "trace_id", Value: fmt.Sprintf("trace-%d-%d", streamIdx, i)},
+					},
+				})
+			}
+			require.NoError(t, b.Append("t1", logproto.Stream{
+				Labels:  fmt.Sprintf(`{app=%q,instance=%q}`, stream.app, stream.instance),
+				Entries: entries,
+			}, now))
+		}
+
+		obj1, closer1, err := b.Flush()
+		require.NoError(t, err)
+		defer closer1.Close()
+
+		obj2 := copyAndSort(t, cfg, obj1, overrides)
+
+		type streamSnapshot struct {
+			id     int64
+			labels labels.Labels
+		}
+		readStreams := func(t *testing.T, obj *dataobj.Object) []streamSnapshot {
+			t.Helper()
+
+			var got []streamSnapshot
+			for _, sec := range obj.Sections().Filter(func(s *dataobj.Section) bool {
+				return streams.CheckSection(s) && s.Tenant == "t1"
+			}) {
+				streamSec, err := streams.Open(t.Context(), sec)
+				require.NoError(t, err)
+				for res := range streams.IterSection(t.Context(), streamSec) {
+					stream, err := res.Value()
+					require.NoError(t, err)
+					got = append(got, streamSnapshot{id: stream.ID, labels: stream.Labels})
+				}
+			}
+			return got
+		}
+
+		type logSnapshot struct {
+			streamID int64
+			labels   labels.Labels
+			ts       int64
+			line     string
+			metadata string
+		}
+		readLogs := func(t *testing.T, obj *dataobj.Object, streamByID map[int64]labels.Labels) []logSnapshot {
+			t.Helper()
+
+			var got []logSnapshot
+			for _, sec := range obj.Sections().Filter(func(s *dataobj.Section) bool {
+				return logs.CheckSection(s) && s.Tenant == "t1"
+			}) {
+				for res := range iterLogsSection(t, sec) {
+					record, err := res.Value()
+					require.NoError(t, err)
+
+					ls, ok := streamByID[record.StreamID]
+					require.Truef(t, ok, "record references unknown stream ID %d", record.StreamID)
+					got = append(got, logSnapshot{
+						streamID: record.StreamID,
+						labels:   ls,
+						ts:       record.Timestamp.UnixNano(),
+						line:     string(record.Line),
+						metadata: record.Metadata.String(),
+					})
+				}
+			}
+			return got
+		}
+
+		streamsBefore := readStreams(t, obj1)
+		streamsAfter := readStreams(t, obj2)
+		require.Len(t, streamsAfter, len(streamsBefore))
+
+		var beforeLabels, afterLabels []string
+		for _, stream := range streamsBefore {
+			beforeLabels = append(beforeLabels, stream.labels.String())
+		}
+
+		streamIDsAfter := make(map[int64]struct{}, len(streamsAfter))
+		for i, stream := range streamsAfter {
+			require.Equal(t, int64(i+1), stream.id)
+			afterLabels = append(afterLabels, stream.labels.String())
+			streamIDsAfter[stream.id] = struct{}{}
+
+			if i > 0 {
+				prevKey, err := computeSortKey(streamsAfter[i-1].labels, schemaLabels)
+				require.NoError(t, err)
+				currKey, err := computeSortKey(stream.labels, schemaLabels)
+				require.NoError(t, err)
+				require.LessOrEqual(t, prevKey, currKey)
+			}
+		}
+		require.ElementsMatch(t, beforeLabels, afterLabels)
+
+		logsBefore := readLogs(t, obj1, func() map[int64]labels.Labels {
+			m := make(map[int64]labels.Labels, len(streamsBefore))
+			for _, stream := range streamsBefore {
+				m[stream.id] = stream.labels
+			}
+			return m
+		}())
+		logsAfter := readLogs(t, obj2, func() map[int64]labels.Labels {
+			m := make(map[int64]labels.Labels, len(streamsAfter))
+			for _, stream := range streamsAfter {
+				m[stream.id] = stream.labels
+			}
+			return m
+		}())
+
+		contentCounts := func(records []logSnapshot) map[string]int {
+			counts := make(map[string]int, len(records))
+			for _, record := range records {
+				key := fmt.Sprintf("%s\x00%d\x00%s\x00%s", record.labels.String(), record.ts, record.line, record.metadata)
+				counts[key]++
+			}
+			return counts
+		}
+		require.Equal(t, contentCounts(logsBefore), contentCounts(logsAfter))
+
+		for i, record := range logsAfter {
+			_, ok := streamIDsAfter[record.streamID]
+			require.Truef(t, ok, "record references unknown stream ID %d", record.streamID)
+
+			if i == 0 {
+				continue
+			}
+			prev := logsAfter[i-1]
+			prevKey, err := computeSortKey(prev.labels, schemaLabels)
+			require.NoError(t, err)
+			currKey, err := computeSortKey(record.labels, schemaLabels)
+			require.NoError(t, err)
+
+			switch {
+			case prevKey != currKey:
+				require.LessOrEqual(t, prevKey, currKey)
+			case prev.streamID != record.streamID:
+				require.LessOrEqual(t, prev.streamID, record.streamID)
+			default:
+				require.LessOrEqual(t, record.ts, prev.ts)
+			}
+		}
+	})
+
 	t.Run("flag off: schema config ignored, DataobjSortOrder used", func(t *testing.T) {
 		cfg := makeCfg(false)
 		overrides := tenantOverrides{"t1": {"label:app"}}
@@ -633,6 +807,65 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 			require.Empty(t, schemaLabels, "SchemaLabels must be absent when flag is off")
 		}
 	})
+}
+
+func TestComputeSortKey(t *testing.T) {
+	tests := []struct {
+		name         string
+		labels       labels.Labels
+		schemaLabels []string
+		want         string
+		wantErr      bool
+	}{
+		{
+			name:         "single label",
+			labels:       labels.FromStrings("app", "foo"),
+			schemaLabels: []string{"label:app"},
+			want:         "foo",
+		},
+		{
+			name:         "multiple labels",
+			labels:       labels.FromStrings("namespace", "ns", "app", "foo"),
+			schemaLabels: []string{"label:namespace", "label:app"},
+			want:         "ns\x00foo",
+		},
+		{
+			name:         "missing label",
+			labels:       labels.FromStrings("app", "foo"),
+			schemaLabels: []string{"label:missing"},
+			want:         "",
+		},
+		{
+			name:         "invalid fqn without colon",
+			labels:       labels.FromStrings("app", "foo"),
+			schemaLabels: []string{"app"},
+			wantErr:      true,
+		},
+		{
+			name:         "invalid fqn type",
+			labels:       labels.FromStrings("app", "foo"),
+			schemaLabels: []string{"metadata:app"},
+			wantErr:      true,
+		},
+		{
+			name:         "empty schema labels",
+			labels:       labels.FromStrings("app", "foo"),
+			schemaLabels: nil,
+			want:         "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := computeSortKey(tt.labels, tt.schemaLabels)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func iterLogsSection(t *testing.T, section *dataobj.Section) result.Seq[logs.Record] {

--- a/pkg/dataobj/consumer/logsobj/factory.go
+++ b/pkg/dataobj/consumer/logsobj/factory.go
@@ -58,13 +58,5 @@ func (f *BuilderFactory) NewSorterBuilder() (*Builder, error) {
 }
 
 func (f *BuilderFactory) newBuilderWithMetrics(metrics *BuilderMetrics) (*Builder, error) {
-	b, err := NewBuilder(f.cfg, f.scratchStore, metrics)
-	if err != nil {
-		return nil, err
-	}
-	if f.overrides != nil {
-		b.SetOverrides(f.overrides)
-	}
-	b.SetLogger(f.logger)
-	return b, nil
+	return NewBuilder(f.cfg, f.scratchStore, metrics, f.logger, f.overrides)
 }

--- a/pkg/dataobj/consumer/logsobj/pool_test.go
+++ b/pkg/dataobj/consumer/logsobj/pool_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/scratch"
@@ -12,7 +13,7 @@ import (
 
 func TestSizedBuilderPool(t *testing.T) {
 	t.Run("Get returns the next builder, and nil when the pool is empty", func(t *testing.T) {
-		builder, err := NewBuilder(testBuilderConfig, scratch.NewMemory(), NewBuilderMetrics())
+		builder, err := NewBuilder(testBuilderConfig, scratch.NewMemory(), NewBuilderMetrics(), log.NewNopLogger(), nil)
 		require.NoError(t, err)
 		pool := NewSizedBuilderPool([]*Builder{builder})
 		// The first call to [Get] should return the builder.
@@ -28,7 +29,7 @@ func TestSizedBuilderPool(t *testing.T) {
 	})
 
 	t.Run("Wait blocks until a builder is available", func(t *testing.T) {
-		builder, err := NewBuilder(testBuilderConfig, scratch.NewMemory(), NewBuilderMetrics())
+		builder, err := NewBuilder(testBuilderConfig, scratch.NewMemory(), NewBuilderMetrics(), log.NewNopLogger(), nil)
 		require.NoError(t, err)
 		pool := NewSizedBuilderPool([]*Builder{builder})
 		// The first call to [Wait] should not block.

--- a/pkg/dataobj/consumer/logsobj/sort.go
+++ b/pkg/dataobj/consumer/logsobj/sort.go
@@ -2,6 +2,7 @@ package logsobj
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
@@ -13,21 +14,34 @@ import (
 // sort keys, sorts globally by schema key, and returns an iterator in schema
 // order suitable for AppendOrdered.
 func sortedSchemaIter(
-	ctx context.Context, sections []*dataobj.Section, sortKeys map[int64]string, fallbackOrder logs.SortOrder,
+	ctx context.Context, sections []*dataobj.Section, sortKeys map[int64]string, streamIDs map[int64]int64, fallbackOrder logs.SortOrder,
 ) (result.Seq[logs.Record], error) {
 	iter, err := sortmerge.Iterator(ctx, sections, fallbackOrder)
 	if err != nil {
 		return nil, err
 	}
+
 	var recs []logs.Record
 	for res := range iter {
 		rec, err := res.Value()
 		if err != nil {
 			return nil, err
 		}
-		rec.SortKey = sortKeys[rec.StreamID]
+
+		oldStreamID := rec.StreamID
+		sortKey, ok := sortKeys[oldStreamID]
+		if !ok {
+			return nil, fmt.Errorf("missing schema sort key for stream ID %d", oldStreamID)
+		}
+		streamID, ok := streamIDs[oldStreamID]
+		if !ok {
+			return nil, fmt.Errorf("missing stream ID remap for stream ID %d", oldStreamID)
+		}
+		rec.SortKey = sortKey
+		rec.StreamID = streamID
 		recs = append(recs, rec)
 	}
+
 	logs.SortRecords(recs, logs.SortSchemaASC)
 	return result.Iter(func(yield func(logs.Record) bool) error {
 		for _, r := range recs {

--- a/pkg/dataobj/consumer/logsobj/sort.go
+++ b/pkg/dataobj/consumer/logsobj/sort.go
@@ -13,7 +13,7 @@ import (
 // sortedSchemaIter merges schema-sorted input sections, injects schema sort
 // keys, remaps stream IDs, and returns an iterator suitable for AppendOrdered.
 func sortedSchemaIter(
-	ctx context.Context, sections []*dataobj.Section, sortKeys map[int64]string, streamIDs map[int64]int64,
+	ctx context.Context, sections []*dataobj.Section, sortKeys []string, streamIDs []int64,
 ) (result.Seq[logs.Record], error) {
 	iter, err := sortmerge.IteratorForSchema(ctx, sections, sortKeys)
 	if err != nil {
@@ -28,12 +28,16 @@ func sortedSchemaIter(
 			}
 
 			oldStreamID := rec.StreamID
-			sortKey, ok := sortKeys[oldStreamID]
-			if !ok {
+			if oldStreamID <= 0 || oldStreamID >= int64(len(sortKeys)) {
 				return fmt.Errorf("missing schema sort key for stream ID %d", oldStreamID)
 			}
-			streamID, ok := streamIDs[oldStreamID]
-			if !ok {
+			sortKey := sortKeys[oldStreamID]
+
+			if oldStreamID >= int64(len(streamIDs)) {
+				return fmt.Errorf("missing stream ID remap for stream ID %d", oldStreamID)
+			}
+			streamID := streamIDs[oldStreamID]
+			if streamID == 0 {
 				return fmt.Errorf("missing stream ID remap for stream ID %d", oldStreamID)
 			}
 			rec.SortKey = sortKey

--- a/pkg/dataobj/consumer/logsobj/sort.go
+++ b/pkg/dataobj/consumer/logsobj/sort.go
@@ -10,42 +10,35 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/sortmerge"
 )
 
-// sortedSchemaIter reads all records from the input sections, injects schema
-// sort keys, sorts globally by schema key, and returns an iterator in schema
-// order suitable for AppendOrdered.
+// sortedSchemaIter merges schema-sorted input sections, injects schema sort
+// keys, remaps stream IDs, and returns an iterator suitable for AppendOrdered.
 func sortedSchemaIter(
-	ctx context.Context, sections []*dataobj.Section, sortKeys map[int64]string, streamIDs map[int64]int64, fallbackOrder logs.SortOrder,
+	ctx context.Context, sections []*dataobj.Section, sortKeys map[int64]string, streamIDs map[int64]int64,
 ) (result.Seq[logs.Record], error) {
-	iter, err := sortmerge.Iterator(ctx, sections, fallbackOrder)
+	iter, err := sortmerge.IteratorForSchema(ctx, sections, sortKeys)
 	if err != nil {
 		return nil, err
 	}
 
-	var recs []logs.Record
-	for res := range iter {
-		rec, err := res.Value()
-		if err != nil {
-			return nil, err
-		}
-
-		oldStreamID := rec.StreamID
-		sortKey, ok := sortKeys[oldStreamID]
-		if !ok {
-			return nil, fmt.Errorf("missing schema sort key for stream ID %d", oldStreamID)
-		}
-		streamID, ok := streamIDs[oldStreamID]
-		if !ok {
-			return nil, fmt.Errorf("missing stream ID remap for stream ID %d", oldStreamID)
-		}
-		rec.SortKey = sortKey
-		rec.StreamID = streamID
-		recs = append(recs, rec)
-	}
-
-	logs.SortRecords(recs, logs.SortSchemaASC)
 	return result.Iter(func(yield func(logs.Record) bool) error {
-		for _, r := range recs {
-			if !yield(r) {
+		for res := range iter {
+			rec, err := res.Value()
+			if err != nil {
+				return err
+			}
+
+			oldStreamID := rec.StreamID
+			sortKey, ok := sortKeys[oldStreamID]
+			if !ok {
+				return fmt.Errorf("missing schema sort key for stream ID %d", oldStreamID)
+			}
+			streamID, ok := streamIDs[oldStreamID]
+			if !ok {
+				return fmt.Errorf("missing stream ID remap for stream ID %d", oldStreamID)
+			}
+			rec.SortKey = sortKey
+			rec.StreamID = streamID
+			if !yield(rec) {
 				return nil
 			}
 		}

--- a/pkg/dataobj/consumer/mock_test.go
+++ b/pkg/dataobj/consumer/mock_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
@@ -122,7 +123,7 @@ func (f *testBuilderFactory) NewBuilder() (*logsobj.Builder, error) {
 		return nil, errors.New("boom")
 	}
 	f.created++
-	return logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory(), f.metrics)
+	return logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory(), f.metrics, log.NewNopLogger(), nil)
 }
 
 // mockMultiBuilder wraps the production [TOCAlignedMultiBuilder] so processor

--- a/pkg/dataobj/consumer/processor_test.go
+++ b/pkg/dataobj/consumer/processor_test.go
@@ -305,7 +305,7 @@ func TestPartitionProcessor_FlushSplitsAcrossWindows(t *testing.T) {
 func newTestBuilder(t *testing.T, reg prometheus.Registerer) *logsobj.Builder {
 	m := logsobj.NewBuilderMetrics()
 	require.NoError(t, m.Register(reg))
-	b, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory(), m)
+	b, err := logsobj.NewBuilder(testBuilderCfg, scratch.NewMemory(), m, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	return b
 }

--- a/pkg/dataobj/index/builder_test.go
+++ b/pkg/dataobj/index/builder_test.go
@@ -457,7 +457,7 @@ func buildLogObject(t *testing.T, app string, path string, bucket objstore.Bucke
 			SectionStripeMergeLimit: 2,
 		},
 		DataobjSortOrder: "stream-asc",
-	}, nil, logsobj.NewBuilderMetrics())
+	}, nil, logsobj.NewBuilderMetrics(), log.NewNopLogger(), nil)
 	require.NoError(t, err)
 
 	for i := 0; i < 10; i++ {

--- a/pkg/dataobj/index/calculate_bench_test.go
+++ b/pkg/dataobj/index/calculate_bench_test.go
@@ -92,7 +92,7 @@ func buildBenchDataobj(tb testing.TB, tenants, streamsPerTenant, entriesPerStrea
 			BufferSize:              4 << 20,
 			SectionStripeMergeLimit: 2,
 		},
-	}, scratch.NewMemory(), logsobj.NewBuilderMetrics())
+	}, scratch.NewMemory(), logsobj.NewBuilderMetrics(), log.NewNopLogger(), nil)
 	require.NoError(tb, err)
 
 	// Deterministic so iteration-to-iteration variance is only from scheduling.

--- a/pkg/dataobj/index/calculate_test.go
+++ b/pkg/dataobj/index/calculate_test.go
@@ -46,7 +46,7 @@ func createTestLogObject(t *testing.T, tenants int) *dataobj.Object {
 			BufferSize:              2048 * 8,
 			SectionStripeMergeLimit: 2,
 		},
-	}, nil, logsobj.NewBuilderMetrics())
+	}, nil, logsobj.NewBuilderMetrics(), log.NewNopLogger(), nil)
 	require.NoError(t, err)
 
 	// Add test streams with structured metadata

--- a/pkg/dataobj/metastore/object_test.go
+++ b/pkg/dataobj/metastore/object_test.go
@@ -807,7 +807,7 @@ func newTestDataBuilder(t testing.TB) *testDataBuilder {
 			BufferSize:              1024 * 1024,      // 1MB
 			SectionStripeMergeLimit: 2,
 		},
-	}, nil, logsobj.NewBuilderMetrics())
+	}, nil, logsobj.NewBuilderMetrics(), log.NewNopLogger(), nil)
 	require.NoError(t, err)
 
 	logger := log.NewLogfmtLogger(os.Stdout)

--- a/pkg/dataobj/sections/logs/builder.go
+++ b/pkg/dataobj/sections/logs/builder.go
@@ -373,9 +373,14 @@ func sortInfo(sort SortOrder, schemaLabels []string) *datasetmd_v2.SortInfo {
 			},
 		}
 	case SortSchemaASC:
+		// Schema sorting clusters rows by the configured sort key. Within each sort-key
+		// cluster, we also order by stream ID and descending timestamp so entries from
+		// the same stream remain localized. This preserves stream-locality benefits for
+		// queries that cannot use the schema sort key.
 		return &datasetmd_v2.SortInfo{
 			SchemaLabels: schemaLabels,
 			ColumnSorts: []*datasetmd_v2.SortInfo_ColumnSort{
+				{ColumnIndex: 0, Direction: datasetmd_v2.SORT_DIRECTION_ASCENDING},  // StreamID ASC
 				{ColumnIndex: 1, Direction: datasetmd_v2.SORT_DIRECTION_DESCENDING}, // Timestamp DESC
 			},
 		}

--- a/pkg/dataobj/sections/logs/iter.go
+++ b/pkg/dataobj/sections/logs/iter.go
@@ -103,11 +103,18 @@ func DecodeRow(columns []*Column, row dataset.Row, record *Record, sym *symboliz
 	defer labelpool.Put(labelBuilder)
 
 	for columnIndex, columnValue := range row.Values {
+		column := columns[columnIndex]
+
 		if columnValue.IsNil() || columnValue.IsZero() {
+			switch column.Type {
+			case ColumnTypeMessage:
+				// Clear the message field so callers that reuse the Record
+				// don't see stale line data from a previous row.
+				record.Line = record.Line[:0]
+			}
 			continue
 		}
 
-		column := columns[columnIndex]
 		switch column.Type {
 		case ColumnTypeStreamID:
 			if ty := columnValue.Type(); ty != datasetmd.PHYSICAL_TYPE_INT64 {

--- a/pkg/dataobj/sections/logs/iter_test.go
+++ b/pkg/dataobj/sections/logs/iter_test.go
@@ -44,7 +44,7 @@ func TestDecode(t *testing.T) {
 			},
 		},
 		{
-			name: "nil values are skipped",
+			name: "nil metadata columns are skipped",
 			columns: []*Column{
 				{Type: ColumnTypeStreamID},
 				{Type: ColumnTypeTimestamp},
@@ -64,6 +64,29 @@ func TestDecode(t *testing.T) {
 				Timestamp: time.Unix(0, 1234567890000000000),
 				Metadata:  labels.EmptyLabels(),
 				Line:      []byte("test message"),
+			},
+		},
+		{
+			name: "empty message clears the previous Record.Line",
+			columns: []*Column{
+				{Type: ColumnTypeStreamID},
+				{Type: ColumnTypeTimestamp},
+				{Type: ColumnTypeMetadata, Name: "app"},
+				{Type: ColumnTypeMessage},
+			},
+			row: dataset.Row{
+				Values: []dataset.Value{
+					dataset.Int64Value(123),
+					dataset.Int64Value(1234567890000000000),
+					{},
+					dataset.BinaryValue(nil),
+				},
+			},
+			expected: Record{
+				StreamID:  123,
+				Timestamp: time.Unix(0, 1234567890000000000),
+				Metadata:  labels.EmptyLabels(),
+				Line:      []byte(""),
 			},
 		},
 		{
@@ -116,9 +139,10 @@ func TestDecode(t *testing.T) {
 		},
 	}
 
+	// reuse record to capture potential issues with stale data from previous rows
+	record := Record{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			record := Record{}
 			err := DecodeRow(tt.columns, tt.row, &record, nil)
 			if tt.wantErr {
 				require.Error(t, err)

--- a/pkg/dataobj/sections/logs/table_build.go
+++ b/pkg/dataobj/sections/logs/table_build.go
@@ -74,7 +74,11 @@ func sortRecords(records []Record, sortOrder SortOrder) {
 			}
 			return reverseOrderIfEqual(cmp.Compare(a.StreamID, b.StreamID))
 		case SortSchemaASC:
+			// Sort by [schema sort key ASC, streamID ASC, timestamp DESC].
 			if res := cmp.Compare(a.SortKey, b.SortKey); res != 0 {
+				return res
+			}
+			if res := cmp.Compare(a.StreamID, b.StreamID); res != 0 {
 				return res
 			}
 			return reverseOrderIfEqual(b.Timestamp.Compare(a.Timestamp))

--- a/pkg/dataobj/sections/logs/table_merge.go
+++ b/pkg/dataobj/sections/logs/table_merge.go
@@ -205,7 +205,7 @@ func (seq *DatasetSequence) Close() {
 }
 
 // CompareForSortSchema returns a comparison function for k-way merge using
-// schema-based sort order: [sortKey ASC, timestamp DESC].
+// schema-based sort order: [sortKey ASC, streamID ASC, timestamp DESC].
 // sortKeys maps streamID to its pre-computed sort key.
 // math.MaxInt64 is treated as a sentinel (loser-tree maxValue) and always compares greater.
 func CompareForSortSchema(sortKeys map[int64]string) func(result.Result[dataset.Row], result.Result[dataset.Row]) bool {
@@ -225,6 +225,9 @@ func CompareForSortSchema(sortKeys map[int64]string) func(result.Result[dataset.
 			aKey := sortKeys[aStreamID]
 			bKey := sortKeys[bStreamID]
 			if res := cmp.Compare(aKey, bKey); res != 0 {
+				return res
+			}
+			if res := cmp.Compare(aStreamID, bStreamID); res != 0 {
 				return res
 			}
 			aTS := ra.Values[1].Int64()

--- a/pkg/dataobj/sections/logs/table_merge.go
+++ b/pkg/dataobj/sections/logs/table_merge.go
@@ -208,7 +208,7 @@ func (seq *DatasetSequence) Close() {
 // schema-based sort order: [sortKey ASC, streamID ASC, timestamp DESC].
 // sortKeys maps streamID to its pre-computed sort key.
 // math.MaxInt64 is treated as a sentinel (loser-tree maxValue) and always compares greater.
-func CompareForSortSchema(sortKeys map[int64]string) func(result.Result[dataset.Row], result.Result[dataset.Row]) bool {
+func CompareForSortSchema(sortKeys []string) func(result.Result[dataset.Row], result.Result[dataset.Row]) bool {
 	return func(a, b result.Result[dataset.Row]) bool {
 		return result.Compare(a, b, func(ra, rb dataset.Row) int {
 			aStreamID := ra.Values[0].Int64()

--- a/pkg/dataobj/sections/logs/table_merge.go
+++ b/pkg/dataobj/sections/logs/table_merge.go
@@ -210,30 +210,30 @@ func (seq *DatasetSequence) Close() {
 // math.MaxInt64 is treated as a sentinel (loser-tree maxValue) and always compares greater.
 func CompareForSortSchema(sortKeys []string) func(result.Result[dataset.Row], result.Result[dataset.Row]) bool {
 	return func(a, b result.Result[dataset.Row]) bool {
-		return result.Compare(a, b, func(ra, rb dataset.Row) int {
-			aStreamID := ra.Values[0].Int64()
-			bStreamID := rb.Values[0].Int64()
-			if aStreamID == math.MaxInt64 && bStreamID == math.MaxInt64 {
-				return 0
-			}
-			if aStreamID == math.MaxInt64 {
-				return 1
-			}
-			if bStreamID == math.MaxInt64 {
-				return -1
-			}
-			aKey := sortKeys[aStreamID]
-			bKey := sortKeys[bStreamID]
-			if res := cmp.Compare(aKey, bKey); res != 0 {
-				return res
-			}
-			if res := cmp.Compare(aStreamID, bStreamID); res != 0 {
-				return res
-			}
-			aTS := ra.Values[1].Int64()
-			bTS := rb.Values[1].Int64()
-			return cmp.Compare(bTS, aTS)
-		}) < 0
+		aVal, aErr := a.Value()
+		bVal, bErr := b.Value()
+
+		// Put errors first so we return errors early.
+		if aErr != nil {
+			return true
+		} else if bErr != nil {
+			return false
+		}
+
+		aStreamID := aVal.Values[0].Int64()
+		bStreamID := bVal.Values[0].Int64()
+
+		aKey := sortKeys[aStreamID]
+		bKey := sortKeys[bStreamID]
+		if res := cmp.Compare(aKey, bKey); res != 0 {
+			return res < 0
+		}
+		if res := cmp.Compare(aStreamID, bStreamID); res != 0 {
+			return res < 0
+		}
+		aTS := aVal.Values[1].Int64()
+		bTS := bVal.Values[1].Int64()
+		return bTS < aTS
 	}
 }
 

--- a/pkg/dataobj/sections/logs/table_merge.go
+++ b/pkg/dataobj/sections/logs/table_merge.go
@@ -223,6 +223,15 @@ func CompareForSortSchema(sortKeys []string) func(result.Result[dataset.Row], re
 		aStreamID := aVal.Values[0].Int64()
 		bStreamID := bVal.Values[0].Int64()
 
+		// Guard against the loser-tree sentinel (MaxInt64 means sequence exhausted).
+		// The sentinel must never "win" the tournament.
+		if aStreamID == math.MaxInt64 {
+			return false
+		}
+		if bStreamID == math.MaxInt64 {
+			return true
+		}
+
 		aKey := sortKeys[aStreamID]
 		bKey := sortKeys[bStreamID]
 		if res := cmp.Compare(aKey, bKey); res != 0 {

--- a/pkg/dataobj/sections/logs/table_test.go
+++ b/pkg/dataobj/sections/logs/table_test.go
@@ -175,6 +175,20 @@ func TestSortRecords_SortSchemaASC(t *testing.T) {
 			expectedLineOrder: []string{"C", "B", "A"},
 		},
 		{
+			// SortSchemaASC with equal sort keys falls back to streamID ASC before timestamp DESC
+			name:      "SortSchemaASC_equalSortKeysUsesStreamID",
+			sortOrder: SortSchemaASC,
+			input: []Record{
+				{StreamID: 15, Timestamp: t1, SortKey: "app-b", Line: []byte("A")},
+				{StreamID: 15, Timestamp: t3, SortKey: "app-a", Line: []byte("B")},
+				{StreamID: 15, Timestamp: t1, SortKey: "app-a", Line: []byte("C")},
+				{StreamID: 10, Timestamp: t2, SortKey: "app-a", Line: []byte("D")},
+				{StreamID: 20, Timestamp: t1, SortKey: "app-b", Line: []byte("E")},
+				{StreamID: 20, Timestamp: t1, SortKey: "app-a", Line: []byte("F")},
+			},
+			expectedLineOrder: []string{"D", "B", "C", "F", "A", "E"},
+		},
+		{
 			// SortSchemaASC with equal timestamps uses primary ordering
 			name:      "SortSchemaASC_equalTimestamps",
 			sortOrder: SortSchemaASC,

--- a/pkg/dataobj/sections/streams/streams.go
+++ b/pkg/dataobj/sections/streams/streams.go
@@ -80,6 +80,14 @@ func (s *Section) init() error {
 // sections) are skipped.
 func (s *Section) Columns() []*Column { return s.columns }
 
+// NumRows returns the number of rows in the section.
+func (s *Section) NumRows() int {
+	if len(s.columns) == 0 {
+		return 0
+	}
+	return int(s.columns[0].inner.Metadata().RowsCount)
+}
+
 // A Column represents one of the columns in the streams section. Valid columns
 // can only be retrieved by calling [Section.Columns].
 //

--- a/pkg/dataobj/sortmerge/sortmerge.go
+++ b/pkg/dataobj/sortmerge/sortmerge.go
@@ -24,6 +24,23 @@ import (
 // multiple logs sections. It requires that the input sections are sorted
 // according to sort.
 func Iterator(ctx context.Context, sections []*dataobj.Section, sort logs.SortOrder) (result.Seq[logs.Record], error) {
+	return iterator(ctx, sections, logs.CompareForSortOrder(sort))
+}
+
+// IteratorForSchema returns an iterator that performs a k-way merge of records
+// from multiple schema-sorted logs sections. The input sections must be sorted
+// by [schema sort key ASC, streamID ASC, timestamp DESC].
+//
+// It expects sortKeys to contain a mapping from StreamID to schema sort key.
+func IteratorForSchema(ctx context.Context, sections []*dataobj.Section, sortKeys map[int64]string) (result.Seq[logs.Record], error) {
+	return iterator(ctx, sections, logs.CompareForSortSchema(sortKeys))
+}
+
+func iterator(
+	ctx context.Context,
+	sections []*dataobj.Section,
+	less func(result.Result[dataset.Row], result.Result[dataset.Row]) bool,
+) (result.Seq[logs.Record], error) {
 	sequences := make([]*sectionSequence, 0, len(sections))
 
 	// The buffer size is a trade-off between memory overhead and performance: Share a sensible batch size amongst the sections.
@@ -68,7 +85,7 @@ func Iterator(ctx context.Context, sections []*dataobj.Section, sort logs.SortOr
 		},
 	})
 
-	tree := loser.New(sequences, maxValue, sectionSequenceAt, logs.CompareForSortOrder(sort), sectionSequenceClose)
+	tree := loser.New(sequences, maxValue, sectionSequenceAt, less, sectionSequenceClose)
 
 	return result.Iter(
 		func(yield func(logs.Record) bool) error {

--- a/pkg/dataobj/sortmerge/sortmerge.go
+++ b/pkg/dataobj/sortmerge/sortmerge.go
@@ -32,7 +32,7 @@ func Iterator(ctx context.Context, sections []*dataobj.Section, sort logs.SortOr
 // by [schema sort key ASC, streamID ASC, timestamp DESC].
 //
 // It expects sortKeys to contain a mapping from StreamID to schema sort key.
-func IteratorForSchema(ctx context.Context, sections []*dataobj.Section, sortKeys map[int64]string) (result.Seq[logs.Record], error) {
+func IteratorForSchema(ctx context.Context, sections []*dataobj.Section, sortKeys []string) (result.Seq[logs.Record], error) {
 	return iterator(ctx, sections, logs.CompareForSortSchema(sortKeys))
 }
 

--- a/pkg/dataobj/sortmerge/sortmerge_test.go
+++ b/pkg/dataobj/sortmerge/sortmerge_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/pkg/push"
@@ -33,7 +34,7 @@ const testTenant = "test"
 func buildObject(t *testing.T, labels string, base time.Time, lineCount int) (*dataobj.Object, func()) {
 	t.Helper()
 
-	b, err := logsobj.NewBuilder(testBuilderConfig, nil, logsobj.NewBuilderMetrics())
+	b, err := logsobj.NewBuilder(testBuilderConfig, nil, logsobj.NewBuilderMetrics(), log.NewNopLogger(), nil)
 	require.NoError(t, err)
 
 	entries := make([]push.Entry, 0, lineCount)

--- a/pkg/engine/internal/executor/dataobjscan_test.go
+++ b/pkg/engine/internal/executor/dataobjscan_test.go
@@ -341,7 +341,7 @@ func buildDataobj(t testing.TB, streams []logproto.Stream) *dataobj.Object {
 			SectionStripeMergeLimit: 2,
 		},
 		DataobjSortOrder: "timestamp-desc",
-	}, nil, logsobj.NewBuilderMetrics())
+	}, nil, logsobj.NewBuilderMetrics(), log.NewNopLogger(), nil)
 	require.NoError(t, err)
 
 	for _, stream := range streams {

--- a/pkg/engine/internal/util/objtest/objtest.go
+++ b/pkg/engine/internal/util/objtest/objtest.go
@@ -59,7 +59,7 @@ func NewBuilder(t *testing.T) *Builder {
 
 	var builderConfig logsobj.BuilderConfig
 	builderConfig.RegisterFlagsWithPrefix("", flag.NewFlagSet("", flag.PanicOnError)) // Acquire defaults
-	logsBuilder, err := logsobj.NewBuilder(builderConfig, nil, logsobj.NewBuilderMetrics())
+	logsBuilder, err := logsobj.NewBuilder(builderConfig, nil, logsobj.NewBuilderMetrics(), log.NewNopLogger(), nil)
 	require.NoError(t, err, "expected to be able to create logs builder")
 
 	indexWriterBucket := objstore.NewPrefixedBucket(bucket, "index/v0")

--- a/pkg/logql/bench/store_dataobj.go
+++ b/pkg/logql/bench/store_dataobj.go
@@ -72,6 +72,8 @@ func NewDataObjStore(dir, tenant string) (*DataObjStore, error) {
 		return nil, fmt.Errorf("failed to create bucket: %w", err)
 	}
 
+	logger := level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowWarn())
+
 	builder, err := logsobj.NewBuilder(logsobj.BuilderConfig{
 		BuilderBaseConfig: logsobj.BuilderBaseConfig{
 			TargetPageSize:          2 * 1024 * 1024, // 2MB
@@ -81,12 +83,11 @@ func NewDataObjStore(dir, tenant string) (*DataObjStore, error) {
 			BufferSize:              16 * 1024 * 1024,  // 16MB
 			SectionStripeMergeLimit: 2,
 		},
-	}, nil, logsobj.NewBuilderMetrics())
+	}, nil, logsobj.NewBuilderMetrics(), logger, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create builder: %w", err)
 	}
 
-	logger := level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowWarn())
 	logsMetastoreToc := metastore.NewTableOfContentsWriter(bucket, logger)
 	uploader := uploader.New(uploader.Config{SHAPrefixSize: 2}, bucket, logger)
 

--- a/tools/dataobj-sort/main.go
+++ b/tools/dataobj-sort/main.go
@@ -53,7 +53,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	b, err := logsobj.NewBuilder(cfg, scr, nil)
+	b, err := logsobj.NewBuilder(cfg, scr, nil, gokitlog.NewNopLogger(), nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Stream IDs are originally assigned in the order streams are first recorded. After sort key ordering,
streams are clustered by sort key, but their original IDs may no longer be monotonic in their order.

Reassigning IDs in sort-key order makes the persisted sort metadata `[streamID ASC, timestamp DESC]`
match the physical row order. More importantly, it also allows effective pruning of stream ID pages based on `min/max` stats, without stream ID ordering we lose the high selectivity benefits of this column.

- Remap stream IDs during `CopyAndSort` so they are sequential in sort-key order.
- Apply schema sort order during the initial Flush so intermediate log
  sections are already schema-ordered, making the subsequent merge
  cheaper.
- Switch `sortedSchemaIter` from collect-and-sort to a streaming merge via
  `sortmerge.IteratorForSchema` to reduce peak memory usage.
- Include `StreamID ASC` in the `SortSchemaASC` sort metadata alongside
  `Timestamp DESC`.
- Add end-to-end builder test covering Append -> Flush -> CopyAndSort
  across multiple tenants and sort modes.
- Update the benchmark to cover schema sorting & generate log lines that are random
   to allow creation of more than one section.

16% faster. ~25% less bytes per op. But streaming allocates more objects, smaller but more.
There is scope to improve this further, i can pick that in a follow-up.
```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj
cpu: Apple M5 Pro
                                   │ /tmp/main.txt │           /tmp/after.txt           │
                                   │    sec/op     │   sec/op     vs base               │
Builder_CopyAndSort/default-15         1.604 ± ∞ ¹   1.591 ± ∞ ¹        ~ (p=0.841 n=5)
Builder_CopyAndSort/sort_schema-15     2.160 ± ∞ ¹   1.806 ± ∞ ¹  -16.39% (p=0.008 n=5)
geomean                                1.862         1.695         -8.96%
¹ need >= 6 samples for confidence interval at level 0.95

                                   │ /tmp/main.txt │            /tmp/after.txt            │
                                   │      B/s      │      B/s       vs base               │
Builder_CopyAndSort/default-15       1.402Gi ± ∞ ¹   1.415Gi ± ∞ ¹        ~ (p=0.841 n=5)
Builder_CopyAndSort/sort_schema-15   1.042Gi ± ∞ ¹   1.246Gi ± ∞ ¹  +19.60% (p=0.008 n=5)
geomean                              1.209Gi         1.328Gi         +9.84%
¹ need >= 6 samples for confidence interval at level 0.95

                                   │ /tmp/main.txt │            /tmp/after.txt            │
                                   │     B/op      │     B/op       vs base               │
Builder_CopyAndSort/default-15       3.243Gi ± ∞ ¹   3.246Gi ± ∞ ¹        ~ (p=0.421 n=5)
Builder_CopyAndSort/sort_schema-15   4.502Gi ± ∞ ¹   3.395Gi ± ∞ ¹  -24.60% (p=0.008 n=5)
geomean                              3.821Gi         3.320Gi        -13.12%
¹ need >= 6 samples for confidence interval at level 0.95

                                   │ /tmp/main.txt │            /tmp/after.txt             │
                                   │   allocs/op   │   allocs/op    vs base                │
Builder_CopyAndSort/default-15        4.876M ± ∞ ¹    4.876M ± ∞ ¹         ~ (p=0.548 n=5)
Builder_CopyAndSort/sort_schema-15    4.879M ± ∞ ¹   11.565M ± ∞ ¹  +137.02% (p=0.008 n=5)
geomean                               4.878M          7.510M         +53.96%
¹ need >= 6 samples for confidence interval at level 0.95

```


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
