### PR TITLE
fix: Return 400 error when parsing unknown fields in push payload to prevent silent data loss

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -162,6 +162,7 @@ type metrics struct {
 	ingesterAppendTimeouts                *prometheus.CounterVec
 	replicationFactor                     prometheus.Gauge
 	streamShardCount                      prometheus.Counter
+	zeroStreamCount                       *prometheus.CounterVec
 	tenantPushSanitizedStructuredMetadata *prometheus.CounterVec
 
 	// kafka metrics
@@ -193,6 +194,11 @@ func newMetrics(registerer prometheus.Registerer) *metrics {
 			Name:      "stream_sharding_count",
 			Help:      "Total number of times the distributor has sharded streams",
 		}),
+		zeroStreamCount: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "distributor_push_zero_streams_count",
+			Help:      "Total number of push requests with 0 streams",
+		}, []string{"tenant", "stage"}),
 		tenantPushSanitizedStructuredMetadata: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Namespace: constants.Loki,
 			Name:      "distributor_push_structured_metadata_sanitized_total",
@@ -604,6 +610,7 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 
 	// Return early if request does not contain any streams
 	if len(req.Streams) == 0 {
+		d.m.zeroStreamCount.WithLabelValues(tenantID, "pre-validation").Inc()
 		return &logproto.PushResponse{}, httpgrpc.Errorf(http.StatusUnprocessableEntity, validation.MissingStreamsErrorMsg)
 	}
 
@@ -833,6 +840,7 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 
 	// Return early if none of the streams contained entries
 	if len(streams) == 0 {
+		d.m.zeroStreamCount.WithLabelValues(tenantID, "post-validation").Inc()
 		return &logproto.PushResponse{}, validationErr
 	}
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -156,6 +156,77 @@ type KafkaProducer interface {
 	Close()
 }
 
+type metrics struct {
+	// distributor metrics
+	ingesterAppends                       *prometheus.CounterVec
+	ingesterAppendTimeouts                *prometheus.CounterVec
+	replicationFactor                     prometheus.Gauge
+	streamShardCount                      prometheus.Counter
+	tenantPushSanitizedStructuredMetadata *prometheus.CounterVec
+
+	// kafka metrics
+	kafkaAppends           *prometheus.CounterVec
+	kafkaWriteBytesTotal   prometheus.Counter
+	kafkaWriteLatency      prometheus.Histogram
+	kafkaRecordsPerRequest prometheus.Histogram
+}
+
+func newMetrics(registerer prometheus.Registerer) *metrics {
+	return &metrics{
+		ingesterAppends: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "distributor_ingester_appends_total",
+			Help:      "The total number of batch appends sent to ingesters.",
+		}, []string{"ingester"}),
+		ingesterAppendTimeouts: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "distributor_ingester_append_timeouts_total",
+			Help:      "The total number of failed batch appends sent to ingesters due to timeouts.",
+		}, []string{"ingester"}),
+		replicationFactor: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
+			Namespace: constants.Loki,
+			Name:      "distributor_replication_factor",
+			Help:      "The configured replication factor.",
+		}),
+		streamShardCount: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "stream_sharding_count",
+			Help:      "Total number of times the distributor has sharded streams",
+		}),
+		tenantPushSanitizedStructuredMetadata: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "distributor_push_structured_metadata_sanitized_total",
+			Help:      "The total number of times we've had to sanitize structured metadata (names or values) at ingestion time per tenant.",
+		}, []string{"tenant", "format"}),
+
+		kafkaAppends: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "distributor_kafka_appends_total",
+			Help:      "The total number of appends sent to kafka ingest path.",
+		}, []string{"partition", "status"}),
+		kafkaWriteLatency: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
+			Namespace:                       constants.Loki,
+			Name:                            "distributor_kafka_latency_seconds",
+			Help:                            "Latency to write an incoming request to the ingest storage.",
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
+			NativeHistogramMaxBucketNumber:  100,
+			Buckets:                         prometheus.DefBuckets,
+		}),
+		kafkaWriteBytesTotal: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "distributor_kafka_sent_bytes_total",
+			Help:      "Total number of bytes sent to the ingest storage.",
+		}),
+		kafkaRecordsPerRequest: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
+			Namespace: constants.Loki,
+			Name:      "distributor_kafka_records_per_write_request",
+			Help:      "The number of records a single per-partition write request has been split into.",
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 8),
+		}),
+	}
+}
+
 // Distributor coordinates replicates and distribution of log streams.
 type Distributor struct {
 	services.Service
@@ -163,6 +234,7 @@ type Distributor struct {
 	cfg              Config
 	ingesterCfg      ingester.Config
 	logger           log.Logger
+	m                *metrics
 	clientCfg        ingester_client.Config
 	tenantConfigs    *runtime.TenantConfigs
 	tenantsRetention *retention.TenantsRetention
@@ -193,13 +265,6 @@ type Distributor struct {
 
 	RequestParserWrapper push.RequestParserWrapper
 
-	// metrics
-	ingesterAppends                       *prometheus.CounterVec
-	ingesterAppendTimeouts                *prometheus.CounterVec
-	replicationFactor                     prometheus.Gauge
-	streamShardCount                      prometheus.Counter
-	tenantPushSanitizedStructuredMetadata *prometheus.CounterVec
-
 	usageTracker   push.UsageTracker
 	ingesterTasks  chan pushIngesterTask
 	ingesterTaskWg sync.WaitGroup
@@ -220,12 +285,6 @@ type Distributor struct {
 	// Track the max inflight bytes in the last 1 minute.
 	inflightBytesHighWatermark prometheus.Summary
 	inflightBytes              atomic.Int64
-
-	// kafka metrics
-	kafkaAppends           *prometheus.CounterVec
-	kafkaWriteBytesTotal   prometheus.Counter
-	kafkaWriteLatency      prometheus.Histogram
-	kafkaRecordsPerRequest prometheus.Histogram
 }
 
 // New a distributor creates.
@@ -367,56 +426,7 @@ func New(
 		tee:                   tee,
 		usageTracker:          usageTracker,
 		ingesterTasks:         make(chan pushIngesterTask),
-		ingesterAppends: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
-			Namespace: constants.Loki,
-			Name:      "distributor_ingester_appends_total",
-			Help:      "The total number of batch appends sent to ingesters.",
-		}, []string{"ingester"}),
-		ingesterAppendTimeouts: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
-			Namespace: constants.Loki,
-			Name:      "distributor_ingester_append_timeouts_total",
-			Help:      "The total number of failed batch appends sent to ingesters due to timeouts.",
-		}, []string{"ingester"}),
-		replicationFactor: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
-			Namespace: constants.Loki,
-			Name:      "distributor_replication_factor",
-			Help:      "The configured replication factor.",
-		}),
-		streamShardCount: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
-			Namespace: constants.Loki,
-			Name:      "stream_sharding_count",
-			Help:      "Total number of times the distributor has sharded streams",
-		}),
-		tenantPushSanitizedStructuredMetadata: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
-			Namespace: constants.Loki,
-			Name:      "distributor_push_structured_metadata_sanitized_total",
-			Help:      "The total number of times we've had to sanitize structured metadata (names or values) at ingestion time per tenant.",
-		}, []string{"tenant", "format"}),
-		kafkaAppends: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
-			Namespace: constants.Loki,
-			Name:      "distributor_kafka_appends_total",
-			Help:      "The total number of appends sent to kafka ingest path.",
-		}, []string{"partition", "status"}),
-		kafkaWriteLatency: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
-			Namespace:                       constants.Loki,
-			Name:                            "distributor_kafka_latency_seconds",
-			Help:                            "Latency to write an incoming request to the ingest storage.",
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMinResetDuration: 1 * time.Hour,
-			NativeHistogramMaxBucketNumber:  100,
-			Buckets:                         prometheus.DefBuckets,
-		}),
-		kafkaWriteBytesTotal: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
-			Namespace: constants.Loki,
-			Name:      "distributor_kafka_sent_bytes_total",
-			Help:      "Total number of bytes sent to the ingest storage.",
-		}),
-		kafkaRecordsPerRequest: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
-			Namespace: constants.Loki,
-			Name:      "distributor_kafka_records_per_write_request",
-			Help:      "The number of records a single per-partition write request has been split into.",
-			Buckets:   prometheus.ExponentialBuckets(1, 2, 8),
-		}),
+		m:                     newMetrics(registerer),
 		writeFailuresManager:  writefailures.NewManager(logger, registerer, cfg.WriteFailuresLogging, configs, "distributor"),
 		kafkaWriter:           kafkaWriter,
 		partitionRing:         partitionRing,
@@ -449,7 +459,7 @@ func New(
 	d.distributorsRing = distributorsRing
 	d.distributorsLifecycler = distributorsLifecycler
 
-	d.replicationFactor.Set(float64(ingestersRing.ReplicationFactor()))
+	d.m.replicationFactor.Set(float64(ingestersRing.ReplicationFactor()))
 	rfStats.Set(int64(ingestersRing.ReplicationFactor()))
 
 	rs := NewRateStore(
@@ -732,11 +742,11 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 						normalizedBuilder.Del(lbl.Name)
 						normalizedBuilder.Set(normalized, lbl.Value)
 
-						d.tenantPushSanitizedStructuredMetadata.WithLabelValues(tenantID, format).Inc()
+						d.m.tenantPushSanitizedStructuredMetadata.WithLabelValues(tenantID, format).Inc()
 					}
 					if strings.ContainsRune(lbl.Value, utf8.RuneError) {
 						normalizedBuilder.Set(normalized, strings.Map(removeInvalidUtf, lbl.Value))
-						d.tenantPushSanitizedStructuredMetadata.WithLabelValues(tenantID, format).Inc()
+						d.m.tenantPushSanitizedStructuredMetadata.WithLabelValues(tenantID, format).Inc()
 					}
 				}
 
@@ -1247,7 +1257,7 @@ func (d *Distributor) shardStream(stream logproto.Stream, pushSize int, tenantID
 		return []KeyedStream{{HashKey: lokiring.TokenFor(tenantID, stream.Labels), HashKeyNoShard: stream.Hash, Stream: stream, Policy: policy}}
 	}
 
-	d.streamShardCount.Inc()
+	d.m.streamShardCount.Inc()
 	if shardStreamsCfg.LoggingEnabled {
 		level.Info(logger).Log("msg", "sharding request", "shard_count", shardCount)
 	}
@@ -1444,12 +1454,12 @@ func (d *Distributor) sendStreamsErr(ctx context.Context, ingester ring.Instance
 	}
 
 	_, err = c.(logproto.PusherClient).Push(ctx, req)
-	d.ingesterAppends.WithLabelValues(ingester.Addr).Inc()
+	d.m.ingesterAppends.WithLabelValues(ingester.Addr).Inc()
 	if err != nil {
 		if e, ok := status.FromError(err); ok {
 			switch e.Code() {
 			case codes.DeadlineExceeded:
-				d.ingesterAppendTimeouts.WithLabelValues(ingester.Addr).Inc()
+				d.m.ingesterAppendTimeouts.WithLabelValues(ingester.Addr).Inc()
 			}
 		}
 	}
@@ -1462,7 +1472,7 @@ func (d *Distributor) sendStreamsToKafka(ctx context.Context, tenant string, str
 	if err != nil {
 		// We need to add len(streams) to the counter as we later count successes and
 		// failures per stream too.
-		d.kafkaAppends.WithLabelValues("kafka", "fail").Add(float64(len(streams)))
+		d.m.kafkaAppends.WithLabelValues("kafka", "fail").Add(float64(len(streams)))
 		tracker.doneWithResult(err)
 		return
 	}
@@ -1473,23 +1483,23 @@ func (d *Distributor) sendStreamsToKafka(ctx context.Context, tenant string, str
 		tracker.doneWithResult(nil)
 		return
 	}
-	d.kafkaRecordsPerRequest.Observe(float64(len(records)))
+	d.m.kafkaRecordsPerRequest.Observe(float64(len(records)))
 	// Produce the records to Kafka.
-	writeLatency := prometheus.NewTimer(d.kafkaWriteLatency)
+	writeLatency := prometheus.NewTimer(d.m.kafkaWriteLatency)
 	results := d.kafkaWriter.ProduceSync(ctx, records)
 	if count, sizeBytes := successfulProduceRecordsStats(results); count > 0 {
 		// TODO(grobinson): We should emit the write latency even when we failed.
 		// This has been kept as-is for now to preserve behavior.
 		writeLatency.ObserveDuration()
-		d.kafkaWriteBytesTotal.Add(float64(sizeBytes))
+		d.m.kafkaWriteBytesTotal.Add(float64(sizeBytes))
 	}
 	var finalErr error
 	for _, result := range results {
 		if result.Err != nil {
-			d.kafkaAppends.WithLabelValues(fmt.Sprintf("partition_%d", result.Record.Partition), "fail").Inc()
+			d.m.kafkaAppends.WithLabelValues(fmt.Sprintf("partition_%d", result.Record.Partition), "fail").Inc()
 			finalErr = result.Err
 		} else {
-			d.kafkaAppends.WithLabelValues(fmt.Sprintf("partition_%d", result.Record.Partition), "success").Inc()
+			d.m.kafkaAppends.WithLabelValues(fmt.Sprintf("partition_%d", result.Record.Partition), "success").Inc()
 		}
 	}
 	tracker.doneWithResult(finalErr)

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -933,10 +933,10 @@ func TestStreamShard(t *testing.T) {
 			require.NoError(t, err)
 
 			d := Distributor{
-				rateStore:        &fakeRateStore{pushRate: 1},
-				validator:        validator,
-				streamShardCount: prometheus.NewCounter(prometheus.CounterOpts{}),
-				shardTracker:     NewShardTracker(),
+				rateStore:    &fakeRateStore{pushRate: 1},
+				validator:    validator,
+				m:            newMetrics(prometheus.NewPedanticRegistry()),
+				shardTracker: NewShardTracker(),
 			}
 
 			derivedStreams := d.shardStream(baseStream, tc.streamSize, "fake", "", d.validator.ShardStreams("fake"))
@@ -978,10 +978,10 @@ func TestStreamShardAcrossCalls(t *testing.T) {
 
 	t.Run("it generates 4 shards across 2 calls when calculated shards = 2 * entries per call", func(t *testing.T) {
 		d := Distributor{
-			rateStore:        &fakeRateStore{pushRate: 1},
-			validator:        validator,
-			streamShardCount: prometheus.NewCounter(prometheus.CounterOpts{}),
-			shardTracker:     NewShardTracker(),
+			rateStore:    &fakeRateStore{pushRate: 1},
+			validator:    validator,
+			m:            newMetrics(prometheus.NewPedanticRegistry()),
+			shardTracker: NewShardTracker(),
 		}
 
 		derivedStreams := d.shardStream(baseStream, streamRate, "fake", "", d.validator.ShardStreams("fake"))
@@ -1307,9 +1307,9 @@ func BenchmarkShardStream(b *testing.B) {
 
 	distributorBuilder := func(shards int) *Distributor {
 		d := &Distributor{
-			validator:        validator,
-			streamShardCount: prometheus.NewCounter(prometheus.CounterOpts{}),
-			shardTracker:     NewShardTracker(),
+			validator:    validator,
+			m:            newMetrics(prometheus.NewPedanticRegistry()),
+			shardTracker: NewShardTracker(),
 			// streamSize is always zero, so number of shards will be dictated just by the rate returned from store.
 			rateStore: &fakeRateStore{rate: int64(desiredRate*shards - 1)},
 		}
@@ -2586,7 +2586,7 @@ func TestDistributor_StructuredMetadataSanitization(t *testing.T) {
 		response, err := distributors[0].Push(ctx, &request)
 		require.NoError(t, err)
 		assert.Equal(t, tc.expectedResponse, response)
-		assert.Equal(t, tc.numSanitizations, testutil.ToFloat64(distributors[0].tenantPushSanitizedStructuredMetadata.WithLabelValues("test", constants.Loki)))
+		assert.Equal(t, tc.numSanitizations, testutil.ToFloat64(distributors[0].m.tenantPushSanitizedStructuredMetadata.WithLabelValues("test", constants.Loki)))
 	}
 }
 

--- a/pkg/loghttp/query.go
+++ b/pkg/loghttp/query.go
@@ -123,6 +123,9 @@ func (s *LogProtoStream) UnmarshalJSON(data []byte) error {
 				return err
 			}
 			s.Entries = entries
+		default:
+			// return error when parsing unknown field
+			return errors.New("found unknown field: " + string(key))
 		}
 		return nil
 	})

--- a/pkg/util/unmarshal/legacy/unmarshal.go
+++ b/pkg/util/unmarshal/legacy/unmarshal.go
@@ -3,12 +3,14 @@ package unmarshal
 import (
 	"io"
 
-	json "github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
 // DecodePushRequest directly decodes json to a logproto.PushRequest
 func DecodePushRequest(b io.Reader, r *logproto.PushRequest) error {
-	return json.NewDecoder(b).Decode(r)
+	dec := jsoniter.NewDecoder(b)
+	dec.DisallowUnknownFields() // return error when parsing unknown field)
+	return dec.Decode(r)
 }

--- a/pkg/util/unmarshal/legacy/unmarshal_test.go
+++ b/pkg/util/unmarshal/legacy/unmarshal_test.go
@@ -1,7 +1,6 @@
 package unmarshal
 
 import (
-	"io"
 	"log"
 	"strings"
 	"testing"
@@ -14,29 +13,33 @@ import (
 
 // covers requests to /api/prom/push
 var pushTests = []struct {
-	expected []logproto.Stream
-	actual   string
+	expected    logproto.PushRequest
+	expectedErr bool
+	payload     string
 }{
 	{
-		[]logproto.Stream{
-			{
-				Entries: []logproto.Entry{
-					{
-						Timestamp: mustParse(time.RFC3339Nano, "2019-09-13T18:32:22.380001319Z"),
-						Line:      "super line",
-					},
-					{
-						Timestamp: mustParse(time.RFC3339Nano, "2019-09-13T18:32:23.380001319Z"),
-						Line:      "super line with labels",
-						StructuredMetadata: []logproto.LabelAdapter{
-							{Name: "a", Value: "1"},
-							{Name: "b", Value: "2"},
+		logproto.PushRequest{
+			Streams: []logproto.Stream{
+				{
+					Entries: []logproto.Entry{
+						{
+							Timestamp: mustParse(time.RFC3339Nano, "2019-09-13T18:32:22.380001319Z"),
+							Line:      "super line",
+						},
+						{
+							Timestamp: mustParse(time.RFC3339Nano, "2019-09-13T18:32:23.380001319Z"),
+							Line:      "super line with labels",
+							StructuredMetadata: []logproto.LabelAdapter{
+								{Name: "a", Value: "1"},
+								{Name: "b", Value: "2"},
+							},
 						},
 					},
+					Labels: `{test="test"}`,
 				},
-				Labels: `{test="test"}`,
 			},
 		},
+		false,
 		`{
 			"streams":[
 				{
@@ -59,18 +62,48 @@ var pushTests = []struct {
 			]
 		}`,
 	},
+
+	{
+		logproto.PushRequest{},
+		false,
+		`{}`,
+	},
+
+	{
+		logproto.PushRequest{},
+		true,
+		`{
+			"streams": [],
+			"invalid": true,
+		}`,
+	},
+
+	{
+		logproto.PushRequest{},
+		true,
+		`{
+			"streams": [
+			  {
+					"labels": "{}",
+					"invalid": [],
+				}
+			],
+		}`,
+	},
 }
 
 func Test_DecodePushRequest(t *testing.T) {
-
-	for i, pushTest := range pushTests {
+	for i, tt := range pushTests {
 		var actual logproto.PushRequest
-		closer := io.NopCloser(strings.NewReader(pushTest.actual))
+		r := strings.NewReader(tt.payload)
 
-		err := DecodePushRequest(closer, &actual)
-		require.NoError(t, err)
-
-		require.Equalf(t, pushTest.expected, actual.Streams, "Push Test %d failed", i)
+		err := DecodePushRequest(r, &actual)
+		if tt.expectedErr {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			require.Equalf(t, tt.expected, actual, "Push Test %d failed", i)
+		}
 	}
 }
 

--- a/pkg/util/unmarshal/unmarshal.go
+++ b/pkg/util/unmarshal/unmarshal.go
@@ -14,7 +14,9 @@ import (
 func DecodePushRequest(b io.Reader, r *logproto.PushRequest) error {
 	var request loghttp.PushRequest
 
-	if err := jsoniter.NewDecoder(b).Decode(&request); err != nil {
+	dec := jsoniter.NewDecoder(b)
+	dec.DisallowUnknownFields() // return error when parsing unknown field
+	if err := dec.Decode(&request); err != nil {
 		return err
 	}
 

--- a/pkg/util/unmarshal/unmarshal_test.go
+++ b/pkg/util/unmarshal/unmarshal_test.go
@@ -159,6 +159,34 @@ func Test_DecodePushRequest(t *testing.T) {
 			]
 		}`,
 		},
+
+		{
+			name:        "invalid top level field",
+			expected:    nil,
+			expectedErr: true,
+			actual: `{
+				"invalid": {}
+			}`,
+		},
+
+		{
+			name:        "invalid field",
+			expected:    nil,
+			expectedErr: true,
+			actual: `{
+				"streams": [
+				  {
+						"stream": {
+					    "job": "push-payload-test"
+						},
+						"values": [
+						  ["123456789012345", "super line"]
+						]
+						"invalid": []
+				  },
+				]
+			}`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var actual logproto.PushRequest


### PR DESCRIPTION
### Summary

Loki still supports two push endpoints: the regular `/loki/api/v1/push` and the legacy (long deprecated) `/api/prom/push`. They also have different push payload formats:

**regular**

```json
{
  "streams": [
    {
      "stream": {<LABELS>},
      "values": [
        ["<TIMESTAMP>", "<LOGLINE>"],
        ...
      ]      
    },
    ...
  ]
}
```

vs **legacy**

```json
{
  "streams": [
    {
      "labels": "<JSON_ENCODED_LABELS>",
      "entries": [
        {"ts": "<TIMESTAMP>", "line": "<LOGLINE>"},
        ...
      ]
    },
    ...
  ]
}
```

#### Test

With this PR, both the legacy endpoint and the regular endpoint return an error when an unknown field is detected in the payload when parsing the JSON.

```
Executing legacy.json on /api/prom/push => 204
loghttp.PushRequest.Streams: []loghttp.LogProtoStream: unmarshalerDecoder: found unknown field: labels, error found in #10 byte of ...|   ]
    }
  ]
}|..., bigger context ...|at 2026-06-23T08:13:50.1782202430Z"}
      ]
    }
  ]
}|...
Executing legacy.json on /loki/api/v1/push => 400
push.PushRequest.Streams: []push.Stream: push.Stream.ReadObject: found unknown field: stream, error found in #10 byte of ...|  "stream": {"job": |..., bigger context ...|{
  "streams": [
    {
      "stream": {"job": "payload-push-test"},
      "values": [
|...
Executing payload.json on /api/prom/push => 400
Executing payload.json on /loki/api/v1/push => 204
```