### PR TITLE
chore: Apply several aggregation optimizations

### DIFF
--- a/pkg/engine/internal/executor/aggregator.go
+++ b/pkg/engine/internal/executor/aggregator.go
@@ -82,32 +82,12 @@ func (a *aggregator) SetMaxSeries(maxSeries int) {
 	a.maxSeries = maxSeries
 }
 
-// Add adds a new sample value to the aggregation for the given timestamp and grouping label values.
-// It expects labelValues to be in the same order as the groupBy columns.
-func (a *aggregator) Add(ts time.Time, value float64, labels []arrow.Field, labelValues []string) error {
-	if len(labels) != len(labelValues) {
-		panic("len(labels) != len(labelValues)")
-	}
-
+func (a *aggregator) Add(ts time.Time, value float64, key uint64) {
+	// Add all observations to the aggregation
 	point, ok := a.points[ts]
 	if !ok {
 		point = make(map[uint64]*groupState)
 		a.points[ts] = point
-	}
-
-	var key uint64
-	if len(labelValues) != 0 {
-		a.digest.Reset()
-		for i, val := range labelValues {
-			if i > 0 {
-				_, _ = a.digest.Write([]byte{0}) // separator
-			}
-
-			_, _ = a.digest.WriteString(labels[i].Name)
-			_, _ = a.digest.Write([]byte("="))
-			_, _ = a.digest.WriteString(val)
-		}
-		key = a.digest.Sum64()
 	}
 
 	if state, ok := point[key]; ok {
@@ -131,35 +111,66 @@ func (a *aggregator) Add(ts time.Time, value float64, labels []arrow.Field, labe
 
 		state.count++
 	} else {
-		if series, exists := a.uniqueSeries[key]; !exists {
-			// Check series limit before adding a new series
-			if a.maxSeries > 0 && len(a.uniqueSeries) >= a.maxSeries {
-				return ErrSeriesLimitExceeded
-			}
-
-			if len(labels) > 0 {
-				series = make(map[string]string)
-				for i, v := range labelValues {
-					// copy the value as this is backed by the arrow array data buffer.
-					// We could retain the record to avoid this copy, but that would hold
-					// all other columns in memory for as long as the query is evaluated.
-					cloned, ok := a.clonedLabelValues[v]
-					if !ok {
-						cloned = strings.Clone(v)
-						a.clonedLabelValues[v] = cloned
-					}
-					series[labels[i].Name] = cloned
-				}
-			}
-
-			a.uniqueSeries[key] = series
-		}
-
 		point[key] = &groupState{
 			value: value,
 			count: int64(1),
 		}
 	}
+}
+
+// Add adds a new sample value to the aggregation for the given timestamp and grouping label values.
+// It expects labelValues to be in the same order as the groupBy columns.
+func (a *aggregator) AddN(timestamps []time.Time, value float64, labels []arrow.Field, labelValues []string) error {
+	if len(labels) != len(labelValues) {
+		panic("len(labels) != len(labelValues)")
+	}
+
+	// Calculate the hash key for all windows
+	var key uint64
+	if len(labelValues) != 0 {
+		a.digest.Reset()
+		for i, val := range labelValues {
+			if i > 0 {
+				_, _ = a.digest.Write([]byte{0}) // separator
+			}
+
+			_, _ = a.digest.WriteString(labels[i].Name)
+			_, _ = a.digest.Write([]byte("="))
+			_, _ = a.digest.WriteString(val)
+		}
+		key = a.digest.Sum64()
+	}
+
+	// Record the unique series if its new
+	if series, exists := a.uniqueSeries[key]; !exists {
+		// Check series limit before adding a new series
+		if a.maxSeries > 0 && len(a.uniqueSeries) >= a.maxSeries {
+			return ErrSeriesLimitExceeded
+		}
+
+		if len(labels) > 0 {
+			series = make(map[string]string)
+			for i, v := range labelValues {
+				// copy the value as this is backed by the arrow array data buffer.
+				// We could retain the record to avoid this copy, but that would hold
+				// all other columns in memory for as long as the query is evaluated.
+				cloned, ok := a.clonedLabelValues[v]
+				if !ok {
+					cloned = strings.Clone(v)
+					a.clonedLabelValues[v] = cloned
+				}
+				series[labels[i].Name] = cloned
+			}
+		}
+
+		a.uniqueSeries[key] = series
+	}
+
+	// Add all observations to the aggregation
+	for _, ts := range timestamps {
+		a.Add(ts, value, key)
+	}
+
 	return nil
 }
 

--- a/pkg/engine/internal/executor/aggregator.go
+++ b/pkg/engine/internal/executor/aggregator.go
@@ -17,6 +17,23 @@ import (
 
 var ErrSeriesLimitExceeded = errors.New("maximum number of series limit exceeded")
 
+type interner struct {
+	interned map[string]string
+}
+
+func (s *interner) Get(name string) string {
+	if value, ok := s.interned[name]; ok {
+		return value
+	}
+	cloned := strings.Clone(name)
+	s.interned[cloned] = cloned
+	return cloned
+}
+
+func (s *interner) Reset() {
+	clear(s.interned)
+}
+
 type groupState struct {
 	value float64 // aggregated value
 	count int64   // values counter
@@ -46,16 +63,19 @@ type aggregator struct {
 	// Track unique series across all timestamps to enforce maxSeries limit
 	maxSeries    int                          // maximum number of unique series allowed (0 means no limit)
 	uniqueSeries map[uint64]map[string]string // tracks unique series across all timestamps
+
+	// Intern unique symbols to reduce memory usage
+	interner *interner
 }
 
 // newAggregator creates a new aggregator with the specified grouping.
 func newAggregator(pointsSizeHint int, operation aggregationOperation) *aggregator {
 	a := aggregator{
-		digest:            xxhash.New(),
-		operation:         operation,
-		clonedLabelValues: make(map[string]string),
-		labels:            make(map[string]arrow.Field),
-		uniqueSeries:      make(map[uint64]map[string]string),
+		digest:       xxhash.New(),
+		operation:    operation,
+		labels:       make(map[string]arrow.Field),
+		uniqueSeries: make(map[uint64]map[string]string),
+		interner:     &interner{interned: make(map[string]string, 16)}, // 16 is arbitrary initial capacity
 	}
 
 	if pointsSizeHint > 0 {
@@ -82,8 +102,7 @@ func (a *aggregator) SetMaxSeries(maxSeries int) {
 	a.maxSeries = maxSeries
 }
 
-func (a *aggregator) Add(ts time.Time, value float64, key uint64) {
-	// Add all observations to the aggregation
+func (a *aggregator) add(ts time.Time, value float64, key uint64) {
 	point, ok := a.points[ts]
 	if !ok {
 		point = make(map[uint64]*groupState)
@@ -151,15 +170,12 @@ func (a *aggregator) AddN(timestamps []time.Time, value float64, labels []arrow.
 		if len(labels) > 0 {
 			series = make(map[string]string)
 			for i, v := range labelValues {
-				// copy the value as this is backed by the arrow array data buffer.
+				// intern the name & value, as the parameters are owned by the caller and may be reused.
 				// We could retain the record to avoid this copy, but that would hold
 				// all other columns in memory for as long as the query is evaluated.
-				cloned, ok := a.clonedLabelValues[v]
-				if !ok {
-					cloned = strings.Clone(v)
-					a.clonedLabelValues[v] = cloned
-				}
-				series[labels[i].Name] = cloned
+				internedLabel := a.interner.Get(labels[i].Name)
+				internedValue := a.interner.Get(v)
+				series[internedLabel] = internedValue
 			}
 		}
 
@@ -168,7 +184,7 @@ func (a *aggregator) AddN(timestamps []time.Time, value float64, labels []arrow.
 
 	// Add all observations to the aggregation
 	for _, ts := range timestamps {
-		a.Add(ts, value, key)
+		a.add(ts, value, key)
 	}
 
 	return nil
@@ -237,7 +253,7 @@ func (a *aggregator) Reset() {
 	}
 
 	clear(a.uniqueSeries)
-	clear(a.clonedLabelValues)
+	a.interner.Reset()
 }
 
 // getSortedTimestamps returns all timestamps in sorted order

--- a/pkg/engine/internal/executor/aggregator.go
+++ b/pkg/engine/internal/executor/aggregator.go
@@ -21,6 +21,7 @@ type interner struct {
 	interned map[string]string
 }
 
+// Get returns an interned copy of the input string. It is safe to call with unsafe strings.
 func (s *interner) Get(name string) string {
 	if value, ok := s.interned[name]; ok {
 		return value
@@ -30,6 +31,7 @@ func (s *interner) Get(name string) string {
 	return cloned
 }
 
+// Reset clears the interner and resets it to its initial empty state.
 func (s *interner) Reset() {
 	clear(s.interned)
 }
@@ -54,11 +56,10 @@ const (
 
 // aggregator is used to aggregate sample values by a set of grouping keys for each point in time.
 type aggregator struct {
-	points            map[time.Time]map[uint64]*groupState // holds the groupState for each point in time series
-	digest            *xxhash.Digest                       // used to compute key for each group
-	operation         aggregationOperation                 // aggregation type
-	labels            map[string]arrow.Field               // combined list of all label fields for all sample values
-	clonedLabelValues map[string]string                    // cache of cloned strings to reduce allocations for repeated values
+	points    map[time.Time]map[uint64]*groupState // holds the groupState for each point in time series
+	digest    *xxhash.Digest                       // used to compute key for each group
+	operation aggregationOperation                 // aggregation type
+	labels    map[string]arrow.Field               // combined list of all label fields for all sample values
 
 	// Track unique series across all timestamps to enforce maxSeries limit
 	maxSeries    int                          // maximum number of unique series allowed (0 means no limit)
@@ -137,7 +138,7 @@ func (a *aggregator) add(ts time.Time, value float64, key uint64) {
 	}
 }
 
-// Add adds a new sample value to the aggregation for the given timestamp and grouping label values.
+// AddN adds new sample values to the aggregation for the given timestamps and grouping labels.
 // It expects labelValues to be in the same order as the groupBy columns.
 func (a *aggregator) AddN(timestamps []time.Time, value float64, labels []arrow.Field, labelValues []string) error {
 	if len(labels) != len(labelValues) {

--- a/pkg/engine/internal/executor/aggregator_test.go
+++ b/pkg/engine/internal/executor/aggregator_test.go
@@ -14,12 +14,10 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/arrowtest"
 )
 
-var (
-	groupBy = []arrow.Field{
-		semconv.FieldFromIdent(semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String), true),
-		semconv.FieldFromIdent(semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String), true),
-	}
-)
+var groupBy = []arrow.Field{
+	semconv.FieldFromIdent(semconv.NewIdentifier("env", types.ColumnTypeLabel, types.Loki.String), true),
+	semconv.FieldFromIdent(semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String), true),
+}
 
 func TestAggregator(t *testing.T) {
 	colTs := semconv.ColumnIdentTimestamp.FQN()
@@ -36,19 +34,18 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: prod/app1 = 10, prod/app2 = 20, dev/app1 = 30
-		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
+		_ = agg.AddN([]time.Time{ts1}, 10, groupBy, []string{"prod", "app1"})
+		_ = agg.AddN([]time.Time{ts1}, 20, groupBy, []string{"prod", "app2"})
+		_ = agg.AddN([]time.Time{ts1}, 30, groupBy, []string{"dev", "app1"})
 
 		// ts2: prod/app1 = 15, prod/app2 = 25, dev/app2 = 35
-		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
+		_ = agg.AddN([]time.Time{ts2}, 15, groupBy, []string{"prod", "app1"})
+		_ = agg.AddN([]time.Time{ts2}, 25, groupBy, []string{"prod", "app2"})
+		_ = agg.AddN([]time.Time{ts2}, 35, groupBy, []string{"dev", "app2"})
 
 		// Add more data to same groups to test aggregation
-		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be 15
-		_ = agg.Add(ts2, 10, groupBy, []string{"prod", "app1"}) // prod/app1 at ts2 should now be 25
-
+		_ = agg.AddN([]time.Time{ts1}, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be 15
+		_ = agg.AddN([]time.Time{ts2}, 10, groupBy, []string{"prod", "app1"}) // prod/app1 at ts2 should now be 25
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
 
@@ -77,18 +74,18 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: prod/app1 = 10, prod/app2 = 20, dev/app1 = 30
-		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
+		_ = agg.AddN([]time.Time{ts1}, 10, groupBy, []string{"prod", "app1"})
+		_ = agg.AddN([]time.Time{ts1}, 20, groupBy, []string{"prod", "app2"})
+		_ = agg.AddN([]time.Time{ts1}, 30, groupBy, []string{"dev", "app1"})
 
 		// ts2: prod/app1 = 15, prod/app2 = 25, dev/app2 = 35
-		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
+		_ = agg.AddN([]time.Time{ts2}, 15, groupBy, []string{"prod", "app1"})
+		_ = agg.AddN([]time.Time{ts2}, 25, groupBy, []string{"prod", "app2"})
+		_ = agg.AddN([]time.Time{ts2}, 35, groupBy, []string{"dev", "app2"})
 
 		// Add more data to same groups to test aggregation
-		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be 7.5
-		_ = agg.Add(ts2, 10, groupBy, []string{"prod", "app1"}) // prod/app1 at ts2 should now be 12.5
+		_ = agg.AddN([]time.Time{ts1}, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be 7.5
+		_ = agg.AddN([]time.Time{ts2}, 10, groupBy, []string{"prod", "app1"}) // prod/app1 at ts2 should now be 12.5
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -119,24 +116,24 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: add one datapoint for prod/app1, prod/app2, and dev/app1
-		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
+		_ = agg.AddN([]time.Time{ts1}, 10, groupBy, []string{"prod", "app1"})
+		_ = agg.AddN([]time.Time{ts1}, 20, groupBy, []string{"prod", "app2"})
+		_ = agg.AddN([]time.Time{ts1}, 30, groupBy, []string{"dev", "app1"})
 
 		// ts2: add another datapoint for prod/app1, prod/app2, and dev/app2
-		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
+		_ = agg.AddN([]time.Time{ts2}, 15, groupBy, []string{"prod", "app1"})
+		_ = agg.AddN([]time.Time{ts2}, 25, groupBy, []string{"prod", "app2"})
+		_ = agg.AddN([]time.Time{ts2}, 35, groupBy, []string{"dev", "app2"})
 
 		// ts3: add another datapoint for prod/app1, prod/app2, and dev/app2
-		_ = agg.Add(ts3, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts3, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts3, 35, groupBy, []string{"dev", "app2"})
+		_ = agg.AddN([]time.Time{ts3}, 15, groupBy, []string{"prod", "app1"})
+		_ = agg.AddN([]time.Time{ts3}, 25, groupBy, []string{"prod", "app2"})
+		_ = agg.AddN([]time.Time{ts3}, 35, groupBy, []string{"dev", "app2"})
 
 		// Add more datapoints for prod/app1 and prod/app2
-		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be count 2
-		_ = agg.Add(ts2, 10, groupBy, []string{"prod", "app2"}) // prod/app2 at ts2 should now be count 2
-		_ = agg.Add(ts1, 25, groupBy, []string{"prod", "app1"}) // prod/app1 at ts1 should now be count 3
+		_ = agg.AddN([]time.Time{ts1}, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be count 2
+		_ = agg.AddN([]time.Time{ts2}, 10, groupBy, []string{"prod", "app2"}) // prod/app2 at ts2 should now be count 2
+		_ = agg.AddN([]time.Time{ts1}, 25, groupBy, []string{"prod", "app1"}) // prod/app1 at ts1 should now be count 3
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -170,19 +167,19 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: add one datapoint for prod/app1, prod/app2, and dev/app1
-		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
+		_ = agg.AddN([]time.Time{ts1}, 10, groupBy, []string{"prod", "app1"})
+		_ = agg.AddN([]time.Time{ts1}, 20, groupBy, []string{"prod", "app2"})
+		_ = agg.AddN([]time.Time{ts1}, 30, groupBy, []string{"dev", "app1"})
 
 		// ts2: add another datapoint for prod/app1, prod/app2, and dev/app2
-		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
+		_ = agg.AddN([]time.Time{ts2}, 15, groupBy, []string{"prod", "app1"})
+		_ = agg.AddN([]time.Time{ts2}, 25, groupBy, []string{"prod", "app2"})
+		_ = agg.AddN([]time.Time{ts2}, 35, groupBy, []string{"dev", "app2"})
 
 		// Add more datapoints for prod/app1 and prod/app2
-		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should still be 10
-		_ = agg.Add(ts2, 50, groupBy, []string{"prod", "app2"}) // prod/app2 at ts2 should now be 50
-		_ = agg.Add(ts1, 15, groupBy, []string{"prod", "app1"}) // prod/app1 at ts1 should now be 15
+		_ = agg.AddN([]time.Time{ts1}, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should still be 10
+		_ = agg.AddN([]time.Time{ts2}, 50, groupBy, []string{"prod", "app2"}) // prod/app2 at ts2 should now be 50
+		_ = agg.AddN([]time.Time{ts1}, 15, groupBy, []string{"prod", "app1"}) // prod/app1 at ts1 should now be 15
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -212,19 +209,19 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: add one datapoint for prod/app1, prod/app2, and dev/app1
-		_ = agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
+		_ = agg.AddN([]time.Time{ts1}, 10, groupBy, []string{"prod", "app1"})
+		_ = agg.AddN([]time.Time{ts1}, 20, groupBy, []string{"prod", "app2"})
+		_ = agg.AddN([]time.Time{ts1}, 30, groupBy, []string{"dev", "app1"})
 
 		// ts2: add another datapoint for prod/app1, prod/app2, and dev/app2
-		_ = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, groupBy, []string{"prod", "app2"})
-		_ = agg.Add(ts2, 35, groupBy, []string{"dev", "app2"})
+		_ = agg.AddN([]time.Time{ts2}, 15, groupBy, []string{"prod", "app1"})
+		_ = agg.AddN([]time.Time{ts2}, 25, groupBy, []string{"prod", "app2"})
+		_ = agg.AddN([]time.Time{ts2}, 35, groupBy, []string{"dev", "app2"})
 
 		// Add more datapoints for prod/app1 and prod/app2
-		_ = agg.Add(ts1, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be 5
-		_ = agg.Add(ts2, 40, groupBy, []string{"prod", "app2"}) // prod/app2 at ts2 should still be 25
-		_ = agg.Add(ts1, 25, groupBy, []string{"prod", "app1"}) // prod/app1 at ts1 should still be 5
+		_ = agg.AddN([]time.Time{ts1}, 5, groupBy, []string{"prod", "app1"})  // prod/app1 at ts1 should now be 5
+		_ = agg.AddN([]time.Time{ts2}, 40, groupBy, []string{"prod", "app2"}) // prod/app2 at ts2 should still be 25
+		_ = agg.AddN([]time.Time{ts1}, 25, groupBy, []string{"prod", "app1"}) // prod/app1 at ts1 should still be 5
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -257,17 +254,17 @@ func TestAggregator(t *testing.T) {
 
 		// Add test data
 		// ts1: prod/app1 = 10, prod/app2 = 20, dev/app1 = 30
-		_ = agg.Add(ts1, 10, groupBy, []string{}) // "prod", "app1"
-		_ = agg.Add(ts1, 20, groupBy, []string{}) // "prod", "app2"
-		_ = agg.Add(ts1, 30, groupBy, []string{}) // "dev", "app1"
+		_ = agg.AddN([]time.Time{ts1}, 10, groupBy, []string{}) // "prod", "app1"
+		_ = agg.AddN([]time.Time{ts1}, 20, groupBy, []string{}) // "prod", "app2"
+		_ = agg.AddN([]time.Time{ts1}, 30, groupBy, []string{}) // "dev", "app1"
 
 		// ts2: prod/app1 = 15, prod/app2 = 25, dev/app2 = 35
-		_ = agg.Add(ts2, 15, groupBy, []string{}) // "prod", "app1"
-		_ = agg.Add(ts2, 25, groupBy, []string{}) // "prod", "app2"
-		_ = agg.Add(ts2, 35, groupBy, []string{}) // "dev", "app2"
+		_ = agg.AddN([]time.Time{ts2}, 15, groupBy, []string{}) // "prod", "app1"
+		_ = agg.AddN([]time.Time{ts2}, 25, groupBy, []string{}) // "prod", "app2"
+		_ = agg.AddN([]time.Time{ts2}, 35, groupBy, []string{}) // "dev", "app2"
 
-		_ = agg.Add(ts1, 5, groupBy, []string{})  // "prod", "app1"
-		_ = agg.Add(ts2, 10, groupBy, []string{}) // "prod", "app1"
+		_ = agg.AddN([]time.Time{ts1}, 5, groupBy, []string{})  // "prod", "app1"
+		_ = agg.AddN([]time.Time{ts2}, 10, groupBy, []string{}) // "prod", "app1"
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -302,17 +299,17 @@ func TestAggregator(t *testing.T) {
 		agg.AddLabels(buildFields("env", "service", "cluster", "method"))
 
 		// Add test data
-		_ = agg.Add(ts1, 10, buildFields("env", "service"), []string{"prod", "app1"})
-		_ = agg.Add(ts1, 20, buildFields("env", "cluster"), []string{"prod", "east-1"})
-		_ = agg.Add(ts1, 30, buildFields("method"), []string{"init"})
+		_ = agg.AddN([]time.Time{ts1}, 10, buildFields("env", "service"), []string{"prod", "app1"})
+		_ = agg.AddN([]time.Time{ts1}, 20, buildFields("env", "cluster"), []string{"prod", "east-1"})
+		_ = agg.AddN([]time.Time{ts1}, 30, buildFields("method"), []string{"init"})
 
-		_ = agg.Add(ts2, 15, buildFields("env", "service"), []string{"prod", "app1"})
-		_ = agg.Add(ts2, 25, buildFields("env", "cluster"), []string{"prod", "east-1"})
-		_ = agg.Add(ts2, 35, buildFields("method"), []string{"init"})
+		_ = agg.AddN([]time.Time{ts2}, 15, buildFields("env", "service"), []string{"prod", "app1"})
+		_ = agg.AddN([]time.Time{ts2}, 25, buildFields("env", "cluster"), []string{"prod", "east-1"})
+		_ = agg.AddN([]time.Time{ts2}, 35, buildFields("method"), []string{"init"})
 
 		// Add more data to same groups to test aggregation
-		_ = agg.Add(ts1, 5, buildFields("env", "service"), []string{"prod", "app1"})
-		_ = agg.Add(ts2, 10, buildFields("env", "cluster"), []string{"prod", "east-1"})
+		_ = agg.AddN([]time.Time{ts1}, 5, buildFields("env", "service"), []string{"prod", "app1"})
+		_ = agg.AddN([]time.Time{ts2}, 10, buildFields("env", "cluster"), []string{"prod", "east-1"})
 
 		record, err := agg.BuildRecord()
 		require.NoError(t, err)
@@ -345,29 +342,29 @@ func TestAggregator(t *testing.T) {
 		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
 
 		// Add first 3 series at ts1 - should succeed
-		err := agg.Add(ts1, 10, groupBy, []string{"prod", "app1"})
+		err := agg.AddN([]time.Time{ts1}, 10, groupBy, []string{"prod", "app1"})
 		require.NoError(t, err)
 
-		err = agg.Add(ts1, 20, groupBy, []string{"prod", "app2"})
+		err = agg.AddN([]time.Time{ts1}, 20, groupBy, []string{"prod", "app2"})
 		require.NoError(t, err)
 
-		err = agg.Add(ts1, 30, groupBy, []string{"dev", "app1"})
+		err = agg.AddN([]time.Time{ts1}, 30, groupBy, []string{"dev", "app1"})
 		require.NoError(t, err)
 
 		// Try to add 4th unique series should fail
-		err = agg.Add(ts2, 10, groupBy, []string{"dev", "app2"})
+		err = agg.AddN([]time.Time{ts2}, 10, groupBy, []string{"dev", "app2"})
 		require.Error(t, err)
 		require.True(t, errors.Is(err, ErrSeriesLimitExceeded))
 
 		// Adding same series again at different timestamp should succeed (not a new unique series)
-		err = agg.Add(ts2, 15, groupBy, []string{"prod", "app1"})
+		err = agg.AddN([]time.Time{ts2}, 15, groupBy, []string{"prod", "app1"})
 		require.NoError(t, err)
 
 		// unset the limit
 		agg.SetMaxSeries(0)
 
 		// Now adding new series should succeed
-		err = agg.Add(ts2, 10, groupBy, []string{"dev", "app2"})
+		err = agg.AddN([]time.Time{ts2}, 10, groupBy, []string{"dev", "app2"})
 		require.NoError(t, err)
 	})
 }
@@ -389,6 +386,6 @@ func BenchmarkAggregator(b *testing.B) {
 		cluster := fmt.Sprintf("cluster-%d", i%10)
 		service := fmt.Sprintf("service-%d", i%7)
 
-		_ = agg.Add(ts, 10, fields, []string{env, cluster, service})
+		_ = agg.AddN([]time.Time{ts}, 10, fields, []string{env, cluster, service})
 	}
 }

--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -164,9 +164,6 @@ func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch,
 		inputReadTime time.Duration
 	)
 
-	labelValuesCache := newLabelValuesCache()
-	fieldsCache := newFieldsCache()
-
 	r.aggregator.Reset() // reset before reading new inputs
 	inputsExhausted := false
 	for !inputsExhausted {
@@ -216,6 +213,8 @@ func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch,
 				valArr = valVec.(*array.Float64)
 			}
 
+			labelNames := make([]arrow.Field, 0, len(groupingFields))
+			labelValues := make([]string, 0, len(arrays))
 			windowEnds := make([]time.Time, 0, 4) // best guess
 			for row := range int(record.NumRows()) {
 				windows := r.windowsForTimestamp(tsCol.Value(row).ToTime(arrow.Nanosecond))
@@ -232,15 +231,22 @@ func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch,
 					value = valArr.Value(row)
 				}
 
-				labelValues := labelValuesCache.getLabelValues(arrays, row)
-				labels := fieldsCache.getFields(arrays, groupingFields, row)
+				labelValues = labelValues[:0]
+				labelNames = labelNames[:0]
+				for i, arr := range arrays {
+					if arr.IsNull(row) {
+						continue
+					}
+					labelValues = append(labelValues, arr.Value(row))
+					labelNames = append(labelNames, groupingFields[i])
+				}
 
 				windowEnds = windowEnds[:0]
 				for _, w := range windows {
 					windowEnds = append(windowEnds, w.end)
 				}
 
-				if err := r.aggregator.AddN(windowEnds, value, labels, labelValues); err != nil {
+				if err := r.aggregator.AddN(windowEnds, value, labelNames, labelValues); err != nil {
 					return nil, err
 				}
 			}

--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -216,6 +216,7 @@ func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch,
 				valArr = valVec.(*array.Float64)
 			}
 
+			windowEnds := make([]time.Time, 0, 4) // best guess
 			for row := range int(record.NumRows()) {
 				windows := r.windowsForTimestamp(tsCol.Value(row).ToTime(arrow.Nanosecond))
 				if len(windows) == 0 {
@@ -234,10 +235,13 @@ func (r *rangeAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch,
 				labelValues := labelValuesCache.getLabelValues(arrays, row)
 				labels := fieldsCache.getFields(arrays, groupingFields, row)
 
+				windowEnds = windowEnds[:0]
 				for _, w := range windows {
-					if err := r.aggregator.Add(w.end, value, labels, labelValues); err != nil {
-						return nil, err
-					}
+					windowEnds = append(windowEnds, w.end)
+				}
+
+				if err := r.aggregator.AddN(windowEnds, value, labels, labelValues); err != nil {
+					return nil, err
 				}
 			}
 		}

--- a/pkg/engine/internal/executor/range_aggregation_test.go
+++ b/pkg/engine/internal/executor/range_aggregation_test.go
@@ -1,11 +1,13 @@
 package executor
 
 import (
+	"fmt"
 	"slices"
 	"testing"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/assertions"
@@ -27,6 +29,93 @@ var (
 
 func init() {
 	assertions.Enabled = true
+}
+
+func BenchmarkRangeAggregation(b *testing.B) {
+	opts := &rangeAggregationOptions{
+		grouping: physical.Grouping{
+			Columns: []physical.ColumnExpression{
+				&physical.ColumnExpr{
+					Ref: types.ColumnRef{
+						Column: "env",
+						Type:   types.ColumnTypeAmbiguous,
+					},
+				},
+				&physical.ColumnExpr{
+					Ref: types.ColumnRef{
+						Column: "service",
+						Type:   types.ColumnTypeAmbiguous,
+					},
+				},
+			},
+			Without: false,
+		},
+		startTs:       time.Unix(0, 0).UTC(),
+		rangeInterval: 10 * time.Second,
+		operation:     types.RangeAggregationTypeCount,
+	}
+
+	type testCase struct {
+		name      string
+		intervals int
+		series    int
+	}
+
+	cases := []testCase{
+		{
+			name:      "10 intervals",
+			intervals: 10,
+			series:    1,
+		},
+		{
+			name:      "10 intervals, 10 series",
+			intervals: 10,
+			series:    10,
+		},
+		{
+			name:      "10 intervals, 1000 series",
+			intervals: 10,
+			series:    1000,
+		},
+		{
+			name:      "10 intervals, 100k series",
+			intervals: 10,
+			series:    100000,
+		},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			innerOpts := *opts
+			innerOpts.endTs = innerOpts.startTs.Add(innerOpts.rangeInterval * time.Duration(tc.intervals))
+			fakeInput := arrowtest.Rows{}
+			for i := range tc.series {
+				for j := range tc.intervals {
+					fakeInput = append(fakeInput, arrowtest.Row{colTs: time.Unix(int64(j)*int64(opts.rangeInterval.Seconds()), 0).UTC(), colEnv: "prod", colSvc: fmt.Sprintf("app%d", i)})
+				}
+			}
+			input := NewBufferedPipeline(fakeInput.Record(memory.DefaultAllocator, fakeInput.Schema()))
+			input.Reset()
+
+			pipeline, err := newRangeAggregationPipeline([]Pipeline{input}, newExpressionEvaluator(), innerOpts)
+			require.NoError(b, err)
+			defer pipeline.Close()
+
+			b.ResetTimer()
+			for b.Loop() {
+				record, err := pipeline.Read(b.Context())
+				if err == EOF {
+					input.Reset()
+					pipeline.inputsExhausted = false
+					continue
+				}
+				require.NoError(b, err)
+				record.Release()
+			}
+
+			b.ReportMetric(float64(tc.series*tc.intervals*b.N)/b.Elapsed().Seconds(), "datapoints/s")
+		})
+	}
 }
 
 func TestRangeAggregationPipeline_instant(t *testing.T) {

--- a/pkg/engine/internal/executor/range_aggregation_test.go
+++ b/pkg/engine/internal/executor/range_aggregation_test.go
@@ -102,16 +102,24 @@ func BenchmarkRangeAggregation(b *testing.B) {
 			defer pipeline.Close()
 
 			b.ResetTimer()
+			rowsProduced := 0
+			eofCount := 0
 			for b.Loop() {
-				record, err := pipeline.Read(b.Context())
+				rec, err := pipeline.Read(b.Context())
 				if err == EOF {
+					eofCount++
 					input.Reset()
 					pipeline.inputsExhausted = false
+					pipeline.aggregator.Reset()
 					continue
 				}
+				rowsProduced += int(rec.NumRows())
+				rec.Release()
 				require.NoError(b, err)
-				record.Release()
 			}
+
+			// Check at least one row per non-EOF iteration was produced.
+			require.GreaterOrEqual(b, rowsProduced, b.N-eofCount)
 
 			b.ReportMetric(float64(tc.series*tc.intervals*b.N)/b.Elapsed().Seconds(), "datapoints/s")
 		})

--- a/pkg/engine/internal/executor/util.go
+++ b/pkg/engine/internal/executor/util.go
@@ -2,17 +2,10 @@ package executor
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/apache/arrow-go/v18/arrow"
-	"github.com/apache/arrow-go/v18/arrow/array"
-	"github.com/cespare/xxhash/v2"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/semconv"
-)
-
-var (
-	separator = []byte{0}
 )
 
 // columnForIdent returns the column ([arrow.Array]) and its column index in the schema of the given input batch ([arrow.RecordBatch]).
@@ -33,83 +26,4 @@ func columnForFQN(fqn string, batch arrow.RecordBatch) (arrow.Array, int, error)
 	}
 
 	return batch.Column(indices[0]), indices[0], nil
-}
-
-// labelValuesCache returns label values for a given row in range and vector aggregators, but cache them in order
-// to reduce object allocations for repeated label sets. Strings are copied to avoid referencing the Arrow data buffer.
-type labelValuesCache struct {
-	digest *xxhash.Digest
-	cache  map[uint64][]string
-}
-
-func newLabelValuesCache() *labelValuesCache {
-	return &labelValuesCache{
-		digest: xxhash.New(),
-		cache:  make(map[uint64][]string),
-	}
-}
-
-func (c *labelValuesCache) getLabelValues(arrays []*array.String, row int) []string {
-	// Compute an xxhash over the non-null label values to form the cache key.
-	c.digest.Reset()
-	for _, arr := range arrays {
-		if !arr.IsNull(row) {
-			_, _ = c.digest.Write(separator)
-			_, _ = c.digest.WriteString(arr.Value(row))
-		}
-	}
-	key := c.digest.Sum64()
-
-	labelValues, ok := c.cache[key]
-	// In case of a cache miss, scan the row again and copy the label values.
-	if !ok {
-		labelValues = make([]string, 0, len(arrays))
-		for _, arr := range arrays {
-			if !arr.IsNull(row) {
-				labelValues = append(labelValues, strings.Clone(arr.Value(row)))
-			}
-		}
-		c.cache[key] = labelValues
-	}
-
-	return labelValues
-}
-
-// fieldsCache returns labels for a given row in range and vector aggregators, but cache them in order
-// to reduce object allocations for repeated label sets. It first scans the row for non-null labels and computes xxhash.
-// In case of a cache miss it scans the row again and allocates arrays for label names.
-type fieldsCache struct {
-	digest *xxhash.Digest
-	cache  map[uint64][]arrow.Field
-}
-
-func newFieldsCache() *fieldsCache {
-	return &fieldsCache{
-		digest: xxhash.New(),
-		cache:  make(map[uint64][]arrow.Field),
-	}
-}
-
-func (c *fieldsCache) getFields(arrays []*array.String, fields []arrow.Field, row int) []arrow.Field {
-	c.digest.Reset()
-	for i, arr := range arrays {
-		if !arr.IsNull(row) {
-			_, _ = c.digest.Write(separator)
-			_, _ = c.digest.WriteString(fields[i].Name)
-		}
-	}
-	key := c.digest.Sum64()
-
-	labels, ok := c.cache[key]
-	if !ok {
-		labels = make([]arrow.Field, 0, len(arrays))
-		for i, arr := range arrays {
-			if !arr.IsNull(row) {
-				labels = append(labels, fields[i])
-			}
-		}
-		c.cache[key] = labels
-	}
-
-	return labels
 }

--- a/pkg/engine/internal/executor/vector_aggregate.go
+++ b/pkg/engine/internal/executor/vector_aggregate.go
@@ -42,15 +42,13 @@ type vectorAggregationPipeline struct {
 	identCache *semconv.IdentifierCache
 }
 
-var (
-	vectorAggregationOperations = map[types.VectorAggregationType]aggregationOperation{
-		types.VectorAggregationTypeSum:   aggregationOperationSum,
-		types.VectorAggregationTypeCount: aggregationOperationCount,
-		types.VectorAggregationTypeAvg:   aggregationOperationAvg,
-		types.VectorAggregationTypeMax:   aggregationOperationMax,
-		types.VectorAggregationTypeMin:   aggregationOperationMin,
-	}
-)
+var vectorAggregationOperations = map[types.VectorAggregationType]aggregationOperation{
+	types.VectorAggregationTypeSum:   aggregationOperationSum,
+	types.VectorAggregationTypeCount: aggregationOperationCount,
+	types.VectorAggregationTypeAvg:   aggregationOperationAvg,
+	types.VectorAggregationTypeMax:   aggregationOperationMax,
+	types.VectorAggregationTypeMin:   aggregationOperationMin,
+}
 
 func newVectorAggregationPipeline(inputs []Pipeline, evaluator *expressionEvaluator, opts vectorAggregationOptions) (*vectorAggregationPipeline, error) {
 	if len(inputs) == 0 {
@@ -168,7 +166,7 @@ func (v *vectorAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch
 				labelValues := labelValuesCache.getLabelValues(arrays, row)
 				labels := fieldsCache.getFields(arrays, groupingFields, row)
 
-				if err := v.aggregator.Add(tsCol.Value(row).ToTime(arrow.Nanosecond), valueArr.Value(row), labels, labelValues); err != nil {
+				if err := v.aggregator.AddN([]time.Time{tsCol.Value(row).ToTime(arrow.Nanosecond)}, valueArr.Value(row), labels, labelValues); err != nil {
 					return nil, err
 				}
 			}

--- a/pkg/engine/internal/executor/vector_aggregate.go
+++ b/pkg/engine/internal/executor/vector_aggregate.go
@@ -107,9 +107,6 @@ func (v *vectorAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch
 	var (
 		inputReadTime time.Duration
 		startedAt     = time.Now()
-
-		labelValuesCache = newLabelValuesCache()
-		fieldsCache      = newFieldsCache()
 	)
 
 	v.aggregator.Reset() // reset before reading new inputs
@@ -158,15 +155,24 @@ func (v *vectorAggregationPipeline) read(ctx context.Context) (arrow.RecordBatch
 
 			v.aggregator.AddLabels(groupingFields)
 
+			labelNames := make([]arrow.Field, 0, len(groupingFields))
+			labelValues := make([]string, 0, len(arrays))
 			for row := range int(record.NumRows()) {
 				if valueArr.IsNull(row) {
 					continue
 				}
 
-				labelValues := labelValuesCache.getLabelValues(arrays, row)
-				labels := fieldsCache.getFields(arrays, groupingFields, row)
+				labelValues = labelValues[:0]
+				labelNames = labelNames[:0]
+				for i, arr := range arrays {
+					if arr.IsNull(row) {
+						continue
+					}
+					labelValues = append(labelValues, arr.Value(row))
+					labelNames = append(labelNames, groupingFields[i])
+				}
 
-				if err := v.aggregator.AddN([]time.Time{tsCol.Value(row).ToTime(arrow.Nanosecond)}, valueArr.Value(row), labels, labelValues); err != nil {
+				if err := v.aggregator.AddN([]time.Time{tsCol.Value(row).ToTime(arrow.Nanosecond)}, valueArr.Value(row), labelNames, labelValues); err != nil {
 					return nil, err
 				}
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Applies a few optimizations for range/generic aggregation
* Added a benchmark to confirm the changes
* Adds N samples at once for a single label when multiple windows are matched
* Removes label caching in the range_aggregation & vector aggregation, instead favouring the non-mutable strings direct from the arrow buffers. This avoids hashing labels twice for every add.
* Adds ~a generic symbolizer~ string interning for label names and values to reduce allocs, particularly over the label names, which weren't interned before.

I've also identified that empty vector aggregation is not pushing down parameters to range aggregation, so an empty vector agg actually generates one range agg datapoint for every unique combination of labels. I've tackled that in [this](https://github.com/grafana/loki/pull/22530) PR. BuildRecord takes a long time in this scenario, as it must copy each unique series to a new arrow buffer.

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/engine/internal/executor
cpu: Apple M3 Max
                                              │  before.txt   │              after.txt               │
                                              │    sec/op     │    sec/op     vs base                │
RangeAggregation/10_intervals-14                 3.447µ ±  3%   3.284µ ±  2%   -4.74% (p=0.001 n=10)
RangeAggregation/10_intervals,_10_series-14     11.377µ ±  2%   8.607µ ±  1%  -24.34% (p=0.000 n=10)
RangeAggregation/10_intervals,_1000_series-14    846.8µ ±  1%   576.9µ ±  4%  -31.87% (p=0.000 n=10)
RangeAggregation/10_intervals,_100k_series-14   130.91m ± 16%   81.95m ± 10%  -37.40% (p=0.000 n=10)
geomean                                          256.8µ         191.2µ        -25.54%

                                              │  before.txt  │               after.txt               │
                                              │ datapoints/s │ datapoints/s   vs base                │
RangeAggregation/10_intervals-14                2.901M ±  3%    3.045M ±  2%   +4.96% (p=0.001 n=10)
RangeAggregation/10_intervals,_10_series-14     8.790M ±  2%   11.618M ±  1%  +32.18% (p=0.000 n=10)
RangeAggregation/10_intervals,_1000_series-14   11.81M ±  1%    17.33M ±  3%  +46.79% (p=0.000 n=10)
RangeAggregation/10_intervals,_100k_series-14   7.640M ± 19%   12.206M ± 11%  +59.77% (p=0.000 n=10)
geomean                                         6.926M          9.302M        +34.30%

                                              │  before.txt   │              after.txt               │
                                              │     B/op      │     B/op      vs base                │
RangeAggregation/10_intervals-14                4.650Ki ±  0%   4.654Ki ± 0%   +0.08% (p=0.000 n=10)
RangeAggregation/10_intervals,_10_series-14     6.757Ki ±  0%   6.284Ki ± 0%   -7.00% (p=0.000 n=10)
RangeAggregation/10_intervals,_1000_series-14   305.7Ki ±  0%   207.8Ki ± 0%  -32.01% (p=0.000 n=10)
RangeAggregation/10_intervals,_100k_series-14   32.73Mi ± 10%   22.57Mi ± 4%  -31.04% (p=0.000 n=10)
geomean                                         134.0Ki         108.9Ki       -18.72%

                                              │  before.txt  │               after.txt               │
                                              │  allocs/op   │  allocs/op   vs base                  │
RangeAggregation/10_intervals-14                 59.00 ±  0%    59.00 ± 0%        ~ (p=1.000 n=10) ¹
RangeAggregation/10_intervals,_10_series-14      92.00 ±  0%    77.00 ± 0%  -16.30% (p=0.000 n=10)
RangeAggregation/10_intervals,_1000_series-14   3.572k ±  0%   2.063k ± 0%  -42.25% (p=0.000 n=10)
RangeAggregation/10_intervals,_100k_series-14   389.4k ± 10%   207.9k ± 4%  -46.62% (p=0.000 n=10)
geomean                                         1.658k         1.181k       -28.73%
¹ all samples are equal
```