### PR TITLE
chore: Push down empty VectorAgg to RangeAgg nodes

### DIFF
--- a/pkg/engine/internal/planner/physical/rule_group_by_pushdown.go
+++ b/pkg/engine/internal/planner/physical/rule_group_by_pushdown.go
@@ -1,6 +1,7 @@
 package physical
 
 import (
+	"fmt"
 	"slices"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
@@ -21,10 +22,11 @@ func (r *groupByPushdown) apply(root Node) bool {
 
 	var changed bool
 	for _, n := range nodes {
+		fmt.Println("applyGroupByPushdown", n.Type())
 		vecAgg := n.(*VectorAggregation)
 
-		// Can only push down a non-empty by() label set
-		if vecAgg.Grouping.Without || len(vecAgg.Grouping.Columns) == 0 {
+		// Cannot push down a without() grouping
+		if vecAgg.Grouping.Without {
 			continue
 		}
 
@@ -56,24 +58,30 @@ func (r *groupByPushdown) applyToTargets(node Node, grouping []ColumnExpression,
 	var changed bool
 	switch node := node.(type) {
 	case *RangeAggregation:
+		fmt.Println("applyGroupByPushdownToTargets", node.Type(), node.Grouping.Without, grouping, supportedAggTypes)
 		if !slices.Contains(supportedAggTypes, node.Operation) {
+			fmt.Println("applyGroupByPushdownToTargets", node.Type(), "not supported")
 			return false
 		}
 
-		// Cannot push down into without()
+		// Cannot push down into a non-empty without()
+		// RangeAggregation's without(X) cannot be overriden. However, an empty without() is treated as an No grouping instead of Unbounded grouping.
 		if node.Grouping.Without && len(node.Grouping.Columns) > 0 {
+			fmt.Println("applyGroupByPushdownToTargets", node.Type(), "cannot push down into a non-empty without()")
 			return false
 		}
 
 		for _, colExpr := range grouping {
 			colExpr, ok := colExpr.(*ColumnExpr)
 			if !ok {
+				fmt.Println("applyGroupByPushdownToTargets", node.Type(), "not a ColumnExpr")
 				continue
 			}
 
 			var wasAdded bool
 			node.Grouping.Columns, wasAdded = addUniqueColumnExpr(node.Grouping.Columns, colExpr)
 			if wasAdded {
+				fmt.Println("applyGroupByPushdownToTargets", node.Type(), "was added")
 				node.Grouping.Without = false
 				changed = true
 			}

--- a/pkg/engine/internal/planner/physical/rule_group_by_pushdown.go
+++ b/pkg/engine/internal/planner/physical/rule_group_by_pushdown.go
@@ -1,7 +1,6 @@
 package physical
 
 import (
-	"fmt"
 	"slices"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
@@ -22,10 +21,9 @@ func (r *groupByPushdown) apply(root Node) bool {
 
 	var changed bool
 	for _, n := range nodes {
-		fmt.Println("applyGroupByPushdown", n.Type())
 		vecAgg := n.(*VectorAggregation)
 
-		// Cannot push down a without() grouping
+		// VectorAggregation: Cannot push down a without() grouping
 		if vecAgg.Grouping.Without {
 			continue
 		}
@@ -58,30 +56,24 @@ func (r *groupByPushdown) applyToTargets(node Node, grouping []ColumnExpression,
 	var changed bool
 	switch node := node.(type) {
 	case *RangeAggregation:
-		fmt.Println("applyGroupByPushdownToTargets", node.Type(), node.Grouping.Without, grouping, supportedAggTypes)
 		if !slices.Contains(supportedAggTypes, node.Operation) {
-			fmt.Println("applyGroupByPushdownToTargets", node.Type(), "not supported")
 			return false
 		}
 
-		// Cannot push down into a non-empty without()
 		// RangeAggregation's without(X) cannot be overriden. However, an empty without() is treated as an No grouping instead of Unbounded grouping.
 		if node.Grouping.Without && len(node.Grouping.Columns) > 0 {
-			fmt.Println("applyGroupByPushdownToTargets", node.Type(), "cannot push down into a non-empty without()")
 			return false
 		}
 
 		for _, colExpr := range grouping {
 			colExpr, ok := colExpr.(*ColumnExpr)
 			if !ok {
-				fmt.Println("applyGroupByPushdownToTargets", node.Type(), "not a ColumnExpr")
 				continue
 			}
 
 			var wasAdded bool
 			node.Grouping.Columns, wasAdded = addUniqueColumnExpr(node.Grouping.Columns, colExpr)
 			if wasAdded {
-				fmt.Println("applyGroupByPushdownToTargets", node.Type(), "was added")
 				node.Grouping.Without = false
 				changed = true
 			}

--- a/pkg/engine/internal/planner/physical/rule_group_by_pushdown.go
+++ b/pkg/engine/internal/planner/physical/rule_group_by_pushdown.go
@@ -23,8 +23,11 @@ func (r *groupByPushdown) apply(root Node) bool {
 	for _, n := range nodes {
 		vecAgg := n.(*VectorAggregation)
 
-		// VectorAggregation: Cannot push down a without() grouping
-		if vecAgg.Grouping.Without {
+		if vecAgg.Grouping.Without && len(vecAgg.Grouping.Columns) == 0 {
+			// No changes required: Empty without() grouping will aggregation over all possible columns, so it cannot make a child column set stricter.
+			continue
+		} else if vecAgg.Grouping.Without {
+			// TODO: Support pushing down VectorAggregation without(X) groupings
 			continue
 		}
 
@@ -60,8 +63,8 @@ func (r *groupByPushdown) applyToTargets(node Node, grouping []ColumnExpression,
 			return false
 		}
 
-		// RangeAggregation's without(X) cannot be overriden. However, an empty without() is treated as an No grouping instead of Unbounded grouping.
 		if node.Grouping.Without && len(node.Grouping.Columns) > 0 {
+			// TODO: Add support for computing the strictest column set in Without(X) cases.
 			return false
 		}
 
@@ -77,6 +80,12 @@ func (r *groupByPushdown) applyToTargets(node Node, grouping []ColumnExpression,
 				node.Grouping.Without = false
 				changed = true
 			}
+		}
+
+		if len(grouping) == 0 {
+			// RangeAggregation with empty without(), meaning all columns, can always be overridden by a stricter column set from the parent.
+			node.Grouping.Without = false
+			changed = true
 		}
 
 		return changed

--- a/pkg/engine/internal/planner/physical/rule_group_by_pushdown_test.go
+++ b/pkg/engine/internal/planner/physical/rule_group_by_pushdown_test.go
@@ -10,116 +10,137 @@ import (
 )
 
 func TestGroupByPushdown(t *testing.T) {
-	t.Run("pushdown to RangeAggregation", func(t *testing.T) {
-		grouping := Grouping{
-			Columns: []ColumnExpression{
-				&ColumnExpr{Ref: types.ColumnRef{Column: "service", Type: types.ColumnTypeLabel}},
-				&ColumnExpr{Ref: types.ColumnRef{Column: "level", Type: types.ColumnTypeLabel}},
-			},
-			Without: false,
-		}
-
-		// generate plan for sum by(service, instance) (count_over_time{...}[])
-		plan := &Plan{}
+	type testCase struct {
+		name              string
+		rangeAggOperation types.RangeAggregationType
+		vectorAgg         *VectorAggregation
+		expectedRangeAgg  *RangeAggregation
+	}
+	testCases := []testCase{
 		{
-			scanSet := plan.graph.Add(&ScanSet{
-				Targets: []*ScanTarget{
-					{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
-					{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
-				},
-
-				Predicates: []Expression{},
-			})
-			rangeAgg := plan.graph.Add(&RangeAggregation{
-				Operation: types.RangeAggregationTypeCount,
-			})
-			vectorAgg := plan.graph.Add(&VectorAggregation{
+			name:              "pushdown to RangeAggregation with empty group by",
+			rangeAggOperation: types.RangeAggregationTypeCount,
+			vectorAgg: &VectorAggregation{
 				Operation: types.VectorAggregationTypeSum,
-				Grouping:  grouping,
-			})
-
-			_ = plan.graph.AddEdge(dag.Edge[Node]{Parent: vectorAgg, Child: rangeAgg})
-			_ = plan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: scanSet})
-		}
-
-		// apply optimisation
-		optimizations := []*Optimization{
-			newOptimization("groupBy pushdown", plan).withRules(
-				&groupByPushdown{plan: plan},
-			),
-		}
-		o := NewOptimizer(plan, optimizations)
-		o.Optimize(plan.Roots()[0])
-
-		expectedPlan := &Plan{}
-		{
-			scanSet := expectedPlan.graph.Add(&ScanSet{
-				Targets: []*ScanTarget{
-					{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
-					{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
+				Grouping: Grouping{
+					Columns: []ColumnExpression{
+						&ColumnExpr{Ref: types.ColumnRef{Column: "service", Type: types.ColumnTypeLabel}},
+						&ColumnExpr{Ref: types.ColumnRef{Column: "level", Type: types.ColumnTypeLabel}},
+					},
 				},
-				Predicates: []Expression{},
-			})
-			rangeAgg := expectedPlan.graph.Add(&RangeAggregation{
-				Operation: types.RangeAggregationTypeCount,
-				Grouping:  grouping,
-			})
-			vectorAgg := expectedPlan.graph.Add(&VectorAggregation{
-				Operation: types.VectorAggregationTypeSum,
-				Grouping:  grouping,
-			})
-
-			_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: vectorAgg, Child: rangeAgg})
-			_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: scanSet})
-		}
-
-		actual := PrintAsTree(plan)
-		expected := PrintAsTree(expectedPlan)
-		require.Equal(t, expected, actual)
-	})
-
-	t.Run("MAX->SUM is not allowed", func(t *testing.T) {
-		grouping := Grouping{
-			Columns: []ColumnExpression{
-				&ColumnExpr{Ref: types.ColumnRef{Column: "service", Type: types.ColumnTypeLabel}},
 			},
-			Without: false,
-		}
-
-		// generate plan for max by(service) (sum_over_time{...}[])
-		plan := &Plan{}
-		{
-			scanSet := plan.graph.Add(&ScanSet{
-				Targets: []*ScanTarget{
-					{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
-					{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
+			expectedRangeAgg: &RangeAggregation{
+				Operation: types.RangeAggregationTypeCount,
+				Grouping: Grouping{
+					Columns: []ColumnExpression{
+						&ColumnExpr{Ref: types.ColumnRef{Column: "service", Type: types.ColumnTypeLabel}},
+						&ColumnExpr{Ref: types.ColumnRef{Column: "level", Type: types.ColumnTypeLabel}},
+					},
+					Without: false,
 				},
-				Predicates: []Expression{},
-			})
-			rangeAgg := plan.graph.Add(&RangeAggregation{
-				Operation: types.RangeAggregationTypeSum,
-			})
-			vectorAgg := plan.graph.Add(&VectorAggregation{
+			},
+		},
+		{
+			name:              "pushdown to RangeAggregation with empty group by",
+			rangeAggOperation: types.RangeAggregationTypeCount,
+			vectorAgg: &VectorAggregation{
+				Operation: types.VectorAggregationTypeSum,
+				Grouping: Grouping{
+					Columns: []ColumnExpression{},
+					Without: false,
+				},
+			},
+			expectedRangeAgg: &RangeAggregation{
+				Operation: types.RangeAggregationTypeCount,
+				Grouping: Grouping{
+					Columns: []ColumnExpression{},
+					Without: false,
+				},
+			},
+		},
+		{
+			name:              "pushdown to RangeAggregation as 'without'",
+			rangeAggOperation: types.RangeAggregationTypeCount,
+			vectorAgg: &VectorAggregation{
+				Operation: types.VectorAggregationTypeSum,
+				Grouping: Grouping{
+					Columns: []ColumnExpression{
+						&ColumnExpr{Ref: types.ColumnRef{Column: "service", Type: types.ColumnTypeLabel}},
+					},
+					Without: true,
+				},
+			},
+			expectedRangeAgg: &RangeAggregation{
+				Operation: types.RangeAggregationTypeCount,
+			},
+		},
+		{
+			name:              "MAX->SUM is not allowed",
+			rangeAggOperation: types.RangeAggregationTypeSum,
+			vectorAgg: &VectorAggregation{
 				Operation: types.VectorAggregationTypeMax,
-				Grouping:  grouping,
-			})
+				Grouping: Grouping{
+					Columns: []ColumnExpression{
+						&ColumnExpr{Ref: types.ColumnRef{Column: "service", Type: types.ColumnTypeLabel}},
+					},
+				},
+			},
+			expectedRangeAgg: &RangeAggregation{
+				Operation: types.RangeAggregationTypeSum,
+			},
+		},
+	}
 
-			_ = plan.graph.AddEdge(dag.Edge[Node]{Parent: vectorAgg, Child: rangeAgg})
-			_ = plan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: scanSet})
-		}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// generate plan for sum by(service, instance) (count_over_time{...}[])
+			plan := &Plan{}
+			{
+				scanSet := plan.graph.Add(&ScanSet{
+					Targets: []*ScanTarget{
+						{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
+						{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
+					},
 
-		orig := PrintAsTree(plan)
+					Predicates: []Expression{},
+				})
+				rangeAgg := plan.graph.Add(&RangeAggregation{
+					Operation: testCase.rangeAggOperation,
+				})
+				vectorAgg := plan.graph.Add(testCase.vectorAgg)
 
-		// apply optimisation
-		optimizations := []*Optimization{
-			newOptimization("projection pushdown", plan).withRules(
-				&groupByPushdown{plan: plan},
-			),
-		}
-		o := NewOptimizer(plan, optimizations)
-		o.Optimize(plan.Roots()[0])
+				_ = plan.graph.AddEdge(dag.Edge[Node]{Parent: vectorAgg, Child: rangeAgg})
+				_ = plan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: scanSet})
+			}
 
-		actual := PrintAsTree(plan)
-		require.Equal(t, orig, actual)
-	})
+			// apply optimisation
+			optimizations := []*Optimization{
+				newOptimization("groupBy pushdown", plan).withRules(
+					&groupByPushdown{plan: plan},
+				),
+			}
+			o := NewOptimizer(plan, optimizations)
+			o.Optimize(plan.Roots()[0])
+
+			expectedPlan := &Plan{}
+			{
+				scanSet := expectedPlan.graph.Add(&ScanSet{
+					Targets: []*ScanTarget{
+						{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
+						{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
+					},
+					Predicates: []Expression{},
+				})
+				rangeAgg := expectedPlan.graph.Add(testCase.expectedRangeAgg)
+				vectorAgg := expectedPlan.graph.Add(testCase.vectorAgg)
+
+				_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: vectorAgg, Child: rangeAgg})
+				_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: scanSet})
+			}
+
+			actual := PrintAsTree(plan)
+			expected := PrintAsTree(expectedPlan)
+			require.Equal(t, expected, actual)
+		})
+	}
 }

--- a/pkg/engine/internal/planner/physical/rule_projection_pushdown.go
+++ b/pkg/engine/internal/planner/physical/rule_projection_pushdown.go
@@ -33,7 +33,7 @@ func (r *projectionPushdown) propagateProjections(node Node, projections []Colum
 	var changed bool
 	switch node := node.(type) {
 	case *RangeAggregation:
-		if node.Grouping.Without {
+		if node.Grouping.Without && len(node.Grouping.Columns) > 0 {
 			return changed
 		}
 		// [Source] RangeAggregation requires partitionBy columns & timestamp.

--- a/pkg/engine/internal/planner/physical/rule_projection_pushdown.go
+++ b/pkg/engine/internal/planner/physical/rule_projection_pushdown.go
@@ -33,7 +33,7 @@ func (r *projectionPushdown) propagateProjections(node Node, projections []Colum
 	var changed bool
 	switch node := node.(type) {
 	case *RangeAggregation:
-		if node.Grouping.Without && len(node.Grouping.Columns) > 0 {
+		if node.Grouping.Without {
 			return changed
 		}
 		// [Source] RangeAggregation requires partitionBy columns & timestamp.

--- a/pkg/engine/internal/planner/physical/rule_projection_pushdown_test.go
+++ b/pkg/engine/internal/planner/physical/rule_projection_pushdown_test.go
@@ -72,6 +72,62 @@ func TestProjectionPushdown(t *testing.T) {
 		require.Equal(t, expected, actual)
 	})
 
+	t.Run("range aggregation empty by() grouping -> scanset", func(t *testing.T) {
+		grouping := Grouping{
+			Columns: []ColumnExpression{},
+			Without: false,
+		}
+
+		plan := &Plan{}
+		{
+			scanset := plan.graph.Add(&ScanSet{
+				Targets: []*ScanTarget{
+					{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
+					{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
+				},
+			})
+			rangeAgg := plan.graph.Add(&RangeAggregation{
+				Operation: types.RangeAggregationTypeCount,
+				Grouping:  grouping,
+			})
+
+			_ = plan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: scanset})
+		}
+
+		// apply optimisations
+		optimizations := []*Optimization{
+			newOptimization("projection pushdown", plan).withRules(
+				&projectionPushdown{plan: plan},
+			),
+		}
+		o := NewOptimizer(plan, optimizations)
+		firings := o.Optimize(plan.Roots()[0])
+		require.True(t, firings["projection pushdown"])
+
+		expectedPlan := &Plan{}
+		{
+			projected := []ColumnExpression{&ColumnExpr{Ref: types.ColumnRef{Column: types.ColumnNameBuiltinTimestamp, Type: types.ColumnTypeBuiltin}}}
+			scanset := expectedPlan.graph.Add(&ScanSet{
+				Targets: []*ScanTarget{
+					{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
+					{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
+				},
+				Projections: projected, // Only Timestamp is required by the RangeAggregation.
+			})
+
+			rangeAgg := expectedPlan.graph.Add(&RangeAggregation{
+				Operation: types.RangeAggregationTypeCount,
+				Grouping:  grouping,
+			})
+
+			_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: scanset})
+		}
+
+		actual := PrintAsTree(plan)
+		expected := PrintAsTree(expectedPlan)
+		require.Equal(t, expected, actual)
+	})
+
 	t.Run("range aggregation empty without() grouping -> scanset", func(t *testing.T) {
 		grouping := Grouping{
 			Columns: []ColumnExpression{},
@@ -101,17 +157,17 @@ func TestProjectionPushdown(t *testing.T) {
 			),
 		}
 		o := NewOptimizer(plan, optimizations)
-		o.Optimize(plan.Roots()[0])
+		firings := o.Optimize(plan.Roots()[0])
+		require.False(t, firings["projection pushdown"])
 
 		expectedPlan := &Plan{}
 		{
-			projected := []ColumnExpression{&ColumnExpr{Ref: types.ColumnRef{Column: types.ColumnNameBuiltinTimestamp, Type: types.ColumnTypeBuiltin}}}
 			scanset := expectedPlan.graph.Add(&ScanSet{
 				Targets: []*ScanTarget{
 					{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
 					{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
 				},
-				Projections: projected,
+				// Nothing is projected because the RangeAggregation requires all columns.
 			})
 
 			rangeAgg := expectedPlan.graph.Add(&RangeAggregation{

--- a/pkg/engine/internal/planner/physical/rule_projection_pushdown_test.go
+++ b/pkg/engine/internal/planner/physical/rule_projection_pushdown_test.go
@@ -72,6 +72,61 @@ func TestProjectionPushdown(t *testing.T) {
 		require.Equal(t, expected, actual)
 	})
 
+	t.Run("range aggregation empty without() grouping -> scanset", func(t *testing.T) {
+		grouping := Grouping{
+			Columns: []ColumnExpression{},
+			Without: true,
+		}
+
+		plan := &Plan{}
+		{
+			scanset := plan.graph.Add(&ScanSet{
+				Targets: []*ScanTarget{
+					{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
+					{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
+				},
+			})
+			rangeAgg := plan.graph.Add(&RangeAggregation{
+				Operation: types.RangeAggregationTypeCount,
+				Grouping:  grouping,
+			})
+
+			_ = plan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: scanset})
+		}
+
+		// apply optimisations
+		optimizations := []*Optimization{
+			newOptimization("projection pushdown", plan).withRules(
+				&projectionPushdown{plan: plan},
+			),
+		}
+		o := NewOptimizer(plan, optimizations)
+		o.Optimize(plan.Roots()[0])
+
+		expectedPlan := &Plan{}
+		{
+			projected := []ColumnExpression{&ColumnExpr{Ref: types.ColumnRef{Column: types.ColumnNameBuiltinTimestamp, Type: types.ColumnTypeBuiltin}}}
+			scanset := expectedPlan.graph.Add(&ScanSet{
+				Targets: []*ScanTarget{
+					{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
+					{Type: ScanTypeDataObject, DataObject: &DataObjScan{}},
+				},
+				Projections: projected,
+			})
+
+			rangeAgg := expectedPlan.graph.Add(&RangeAggregation{
+				Operation: types.RangeAggregationTypeCount,
+				Grouping:  grouping,
+			})
+
+			_ = expectedPlan.graph.AddEdge(dag.Edge[Node]{Parent: rangeAgg, Child: scanset})
+		}
+
+		actual := PrintAsTree(plan)
+		expected := PrintAsTree(expectedPlan)
+		require.Equal(t, expected, actual)
+	})
+
 	t.Run("filter -> scanset", func(t *testing.T) {
 		filterPredicates := []Expression{
 			&BinaryExpr{

--- a/pkg/engine/internal/planner/planner_test.go
+++ b/pkg/engine/internal/planner/planner_test.go
@@ -210,19 +210,18 @@ VectorAggregation operation=sum group_by=(ambiguous.bar)
 			query:   `sum(count_over_time({app="foo"} | detected_level="error" | json | logfmt | drop __error__,__error_details__[1m]))`,
 			expected: `
 VectorAggregation operation=sum group_by=()
-└── RangeAggregation operation=sum start=2025-01-01T00:00:00Z end=2025-01-01T01:00:00Z step=0s range=1m0s
-    └── Parallelize
-        └── RangeAggregation operation=count start=2025-01-01T00:00:00Z end=2025-01-01T01:00:00Z step=0s range=1m0s
-            └── Projection all=true drop=(ambiguous.__error__, ambiguous.__error_details__)
-                └── Compat src=parsed dst=parsed collisions=(label, metadata)
-                    └── Projection all=true expand=(PARSE_LOGFMT(builtin.message, [], false, false))
-                        └── Compat src=parsed dst=parsed collisions=(label, metadata)
-                            └── Projection all=true expand=(PARSE_JSON(builtin.message, [], false, false))
-                                └── Filter predicate[0]=EQ(ambiguous.detected_level, "error")
-                                    └── Compat src=metadata dst=metadata collisions=(label)
-                                        └── ScanSet num_targets=2 predicate[0]=GTE(builtin.timestamp, 2024-12-31T23:59:00Z) predicate[1]=LT(builtin.timestamp, 2025-01-01T01:00:00Z)
-                                                ├── @target type=ScanTypeDataObject location=objects/00/0000000000.dataobj streams=5 section_id=1 projections=() predicate[0]=EQ(metadata.detected_level, "error")
-                                                └── @target type=ScanTypeDataObject location=objects/00/0000000000.dataobj streams=5 section_id=0 projections=() predicate[0]=EQ(metadata.detected_level, "error")
+└── Parallelize
+    └── RangeAggregation operation=count start=2025-01-01T00:00:00Z end=2025-01-01T01:00:00Z step=0s range=1m0s group_by=()
+        └── Projection all=true drop=(ambiguous.__error__, ambiguous.__error_details__)
+            └── Compat src=parsed dst=parsed collisions=(label, metadata)
+                └── Projection all=true expand=(PARSE_LOGFMT(builtin.message, [], false, false))
+                    └── Compat src=parsed dst=parsed collisions=(label, metadata)
+                        └── Projection all=true expand=(PARSE_JSON(builtin.message, [], false, false))
+                            └── Filter predicate[0]=EQ(ambiguous.detected_level, "error")
+                                └── Compat src=metadata dst=metadata collisions=(label)
+                                    └── ScanSet num_targets=2 projections=(ambiguous.detected_level, builtin.message, builtin.timestamp) predicate[0]=GTE(builtin.timestamp, 2024-12-31T23:59:00Z) predicate[1]=LT(builtin.timestamp, 2025-01-01T01:00:00Z)
+                                            ├── @target type=ScanTypeDataObject location=objects/00/0000000000.dataobj streams=5 section_id=1 projections=() predicate[0]=EQ(metadata.detected_level, "error")
+                                            └── @target type=ScanTypeDataObject location=objects/00/0000000000.dataobj streams=5 section_id=0 projections=() predicate[0]=EQ(metadata.detected_level, "error")
 `,
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
Push down an empty VectorAggregation `sum by ()` down to the RangeAggregation node
Range Aggregation inherits `without ()` by default from Logical plan. Meaning "Apply aggregations with unbounded cardinality" and expects the VectorAggregation to sum it back up.

This PR pushs down empty `sum by ()` to request no groupings from the RangeAggregation, which makes it significantly more efficient for empty sums.