### PR TITLE
chore: Bump loki-release to pick up github-release fix

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "5f9df7bc2982ed2faa63925979af611e9443120d"
+      "version": "8834ccf472ac60f2a1b426bf741a368873b3440f"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "5f9df7bc2982ed2faa63925979af611e9443120d",
-      "sum": "2boqpkDPv3Mrj6EyHA8rRsaPGE6144uKXs0UltK2psw="
+      "version": "8834ccf472ac60f2a1b426bf741a368873b3440f",
+      "sum": "skOsNdM5Nfko92Vg/rzBdsCGanBB2OEHMpYEXGJ1gn4="
     }
   ],
   "legacyImports": false

--- a/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
@@ -149,8 +149,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
                        --target-branch "$(echo $OUTPUTS_BRANCH | tr -d '"')" \
                        --token "$(echo $OUTPUTS_TOKEN | tr -d '"')" \
                        --shas-to-tag "$(echo $OUTPUTS_PR_NUMBER | tr -d '"'):$(echo ${SHA} | tr -d '"')" \
-                       --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
-                       --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}")
+                       --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}")
                      echo "$output"
                      if [[ "$output" == "[]" || -z "$output" ]]; then
                        echo "::error::release-please did not create a release"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@5f9df7bc2982ed2faa63925979af611e9443120d"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@8834ccf472ac60f2a1b426bf741a368873b3440f"
     "with":
       "build_image": "golang:1.26.4"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "5f9df7bc2982ed2faa63925979af611e9443120d"
+      "release_lib_ref": "8834ccf472ac60f2a1b426bf741a368873b3440f"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@5f9df7bc2982ed2faa63925979af611e9443120d"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@8834ccf472ac60f2a1b426bf741a368873b3440f"
     "with":
       "build_image": "golang:1.26.4"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "5f9df7bc2982ed2faa63925979af611e9443120d"
+      "release_lib_ref": "8834ccf472ac60f2a1b426bf741a368873b3440f"
       "skip_validation": false
       "use_github_app_token": true
   "logql-analyzer-image":
@@ -12,7 +12,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "5f9df7bc2982ed2faa63925979af611e9443120d"
+      "RELEASE_LIB_REF": "8834ccf472ac60f2a1b426bf741a368873b3440f"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -152,7 +152,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "5f9df7bc2982ed2faa63925979af611e9443120d"
+      "RELEASE_LIB_REF": "8834ccf472ac60f2a1b426bf741a368873b3440f"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -292,7 +292,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "5f9df7bc2982ed2faa63925979af611e9443120d"
+      "RELEASE_LIB_REF": "8834ccf472ac60f2a1b426bf741a368873b3440f"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -432,7 +432,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "5f9df7bc2982ed2faa63925979af611e9443120d"
+      "RELEASE_LIB_REF": "8834ccf472ac60f2a1b426bf741a368873b3440f"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -572,7 +572,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "5f9df7bc2982ed2faa63925979af611e9443120d"
+      "RELEASE_LIB_REF": "8834ccf472ac60f2a1b426bf741a368873b3440f"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -8,7 +8,7 @@ env:
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "5f9df7bc2982ed2faa63925979af611e9443120d"
+  RELEASE_LIB_REF: "8834ccf472ac60f2a1b426bf741a368873b3440f"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   VERSIONING_STRATEGY: "always-bump-minor"
@@ -18,11 +18,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@5f9df7bc2982ed2faa63925979af611e9443120d"
+    uses: "grafana/loki-release/.github/workflows/check.yml@8834ccf472ac60f2a1b426bf741a368873b3440f"
     with:
       build_image: "golang:1.26.4"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "5f9df7bc2982ed2faa63925979af611e9443120d"
+      release_lib_ref: "8834ccf472ac60f2a1b426bf741a368873b3440f"
       skip_validation: false
   create-release-pr:
     needs:

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -8,7 +8,7 @@ env:
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "5f9df7bc2982ed2faa63925979af611e9443120d"
+  RELEASE_LIB_REF: "8834ccf472ac60f2a1b426bf741a368873b3440f"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   VERSIONING_STRATEGY: "always-bump-patch"
@@ -18,11 +18,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@5f9df7bc2982ed2faa63925979af611e9443120d"
+    uses: "grafana/loki-release/.github/workflows/check.yml@8834ccf472ac60f2a1b426bf741a368873b3440f"
     with:
       build_image: "golang:1.26.4"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "5f9df7bc2982ed2faa63925979af611e9443120d"
+      release_lib_ref: "8834ccf472ac60f2a1b426bf741a368873b3440f"
       skip_validation: false
   create-release-pr:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ env:
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "5f9df7bc2982ed2faa63925979af611e9443120d"
+  RELEASE_LIB_REF: "8834ccf472ac60f2a1b426bf741a368873b3440f"
   RELEASE_REPO: "grafana/loki"
 jobs:
   createRelease:
@@ -102,8 +102,7 @@ jobs:
           --target-branch "$(echo $OUTPUTS_BRANCH | tr -d '"')" \
           --token "$(echo $OUTPUTS_TOKEN | tr -d '"')" \
           --shas-to-tag "$(echo $OUTPUTS_PR_NUMBER | tr -d '"'):$(echo ${SHA} | tr -d '"')" \
-          --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}" \
-          --group-pull-request-title-pattern "chore\${scope}: Release\${component} \${version}")
+          --pull-request-title-pattern "chore\${scope}: Release\${component} \${version}")
         echo "$output"
         if [[ "$output" == "[]" || -z "$output" ]]; then
           echo "::error::release-please did not create a release"


### PR DESCRIPTION
Vendors grafana/loki-release#377 (github-release title-pattern fix) and regenerates the workflows.
