### PR TITLE
chore: Bump loki-release for the publish mkdir fix

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "8834ccf472ac60f2a1b426bf741a368873b3440f"
+      "version": "660b018d3a8df2fa14d778f7566a39a6db240957"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "8834ccf472ac60f2a1b426bf741a368873b3440f",
-      "sum": "skOsNdM5Nfko92Vg/rzBdsCGanBB2OEHMpYEXGJ1gn4="
+      "version": "660b018d3a8df2fa14d778f7566a39a6db240957",
+      "sum": "LAoQ8i+XIGzyrM39haD0BwyE2/bz5ZCSZs64fnXVRc0="
     }
   ],
   "legacyImports": false

--- a/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
@@ -210,6 +210,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         })
         + step.withRun(|||
           echo "downloading images to $(pwd)/images"
+          mkdir -p images
           gcloud artifacts generic download \
             --project="grafanalabs-dev" \
             --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
@@ -247,6 +248,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         })
         + step.withRun(|||
           echo "downloading plugins to $(pwd)/plugins"
+          mkdir -p plugins
           gcloud artifacts generic download \
             --project="grafanalabs-dev" \
             --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@8834ccf472ac60f2a1b426bf741a368873b3440f"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@660b018d3a8df2fa14d778f7566a39a6db240957"
     "with":
       "build_image": "golang:1.26.4"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "8834ccf472ac60f2a1b426bf741a368873b3440f"
+      "release_lib_ref": "660b018d3a8df2fa14d778f7566a39a6db240957"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@8834ccf472ac60f2a1b426bf741a368873b3440f"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@660b018d3a8df2fa14d778f7566a39a6db240957"
     "with":
       "build_image": "golang:1.26.4"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "8834ccf472ac60f2a1b426bf741a368873b3440f"
+      "release_lib_ref": "660b018d3a8df2fa14d778f7566a39a6db240957"
       "skip_validation": false
       "use_github_app_token": true
   "logql-analyzer-image":
@@ -12,7 +12,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "8834ccf472ac60f2a1b426bf741a368873b3440f"
+      "RELEASE_LIB_REF": "660b018d3a8df2fa14d778f7566a39a6db240957"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -152,7 +152,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "8834ccf472ac60f2a1b426bf741a368873b3440f"
+      "RELEASE_LIB_REF": "660b018d3a8df2fa14d778f7566a39a6db240957"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -292,7 +292,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "8834ccf472ac60f2a1b426bf741a368873b3440f"
+      "RELEASE_LIB_REF": "660b018d3a8df2fa14d778f7566a39a6db240957"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -432,7 +432,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "8834ccf472ac60f2a1b426bf741a368873b3440f"
+      "RELEASE_LIB_REF": "660b018d3a8df2fa14d778f7566a39a6db240957"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -572,7 +572,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "8834ccf472ac60f2a1b426bf741a368873b3440f"
+      "RELEASE_LIB_REF": "660b018d3a8df2fa14d778f7566a39a6db240957"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -8,7 +8,7 @@ env:
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "8834ccf472ac60f2a1b426bf741a368873b3440f"
+  RELEASE_LIB_REF: "660b018d3a8df2fa14d778f7566a39a6db240957"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   VERSIONING_STRATEGY: "always-bump-minor"
@@ -18,11 +18,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@8834ccf472ac60f2a1b426bf741a368873b3440f"
+    uses: "grafana/loki-release/.github/workflows/check.yml@660b018d3a8df2fa14d778f7566a39a6db240957"
     with:
       build_image: "golang:1.26.4"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "8834ccf472ac60f2a1b426bf741a368873b3440f"
+      release_lib_ref: "660b018d3a8df2fa14d778f7566a39a6db240957"
       skip_validation: false
   create-release-pr:
     needs:

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -8,7 +8,7 @@ env:
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "8834ccf472ac60f2a1b426bf741a368873b3440f"
+  RELEASE_LIB_REF: "660b018d3a8df2fa14d778f7566a39a6db240957"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   VERSIONING_STRATEGY: "always-bump-patch"
@@ -18,11 +18,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@8834ccf472ac60f2a1b426bf741a368873b3440f"
+    uses: "grafana/loki-release/.github/workflows/check.yml@660b018d3a8df2fa14d778f7566a39a6db240957"
     with:
       build_image: "golang:1.26.4"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "8834ccf472ac60f2a1b426bf741a368873b3440f"
+      release_lib_ref: "660b018d3a8df2fa14d778f7566a39a6db240957"
       skip_validation: false
   create-release-pr:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ env:
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "grafana"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "8834ccf472ac60f2a1b426bf741a368873b3440f"
+  RELEASE_LIB_REF: "660b018d3a8df2fa14d778f7566a39a6db240957"
   RELEASE_REPO: "grafana/loki"
 jobs:
   createRelease:
@@ -243,6 +243,7 @@ jobs:
       name: "download and prepare plugins"
       run: |
         echo "downloading plugins to $(pwd)/plugins"
+        mkdir -p plugins
         gcloud artifacts generic download \
           --project="grafanalabs-dev" \
           --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
@@ -286,6 +287,7 @@ jobs:
       name: "download images"
       run: |
         echo "downloading images to $(pwd)/images"
+        mkdir -p images
         gcloud artifacts generic download \
           --project="grafanalabs-dev" \
           --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \


### PR DESCRIPTION
Vendors grafana/loki-release#378 (mkdir before the image/plugin gcloud download) and regenerates the workflows.
