### PR TITLE
chore: Publish release images to the GAR mirror, skip docker plugin

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "660b018d3a8df2fa14d778f7566a39a6db240957"
+      "version": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "660b018d3a8df2fa14d778f7566a39a6db240957",
-      "sum": "LAoQ8i+XIGzyrM39haD0BwyE2/bz5ZCSZs64fnXVRc0="
+      "version": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501",
+      "sum": "nhv9Nblyvooc8PgiyVpydSFq4g8qAWGPtzC8SjqB7gI="
     }
   ],
   "legacyImports": false

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -8,9 +8,9 @@ local goVersion = std.extVar('GO_VERSION');
 local buildImage = 'golang:%s' % goVersion;
 local golangCiLintVersion = 'v2.10.1';
 local imageBuildTimeoutMin = 60;
-local imagePrefix = 'grafana';
 local weeklyImageRegistry = 'us-docker.pkg.dev';
 local weeklyImagePrefix = '%s/grafanalabs-global/dockerhub-loki-prod-mirror' % weeklyImageRegistry;
+local imagePrefix = weeklyImagePrefix;
 local dockerPluginDir = 'clients/cmd/docker-driver';
 local runner = import 'workflows/runner.libsonnet',
       r = runner.withDefaultMapping();  // Do we need a different mapping?
@@ -91,6 +91,7 @@ local weeklyImageJobs = {
       pluginBuildDir=dockerPluginDir,
       releaseBranchTemplate='release-\\${major}.\\${minor}.x',
       releaseRepo='grafana/loki',
+      publishDockerPlugins=false,
     ), false, false
   ),
   'check.yml': std.manifestYamlDoc({

--- a/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
@@ -202,8 +202,8 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         common.fetchReleaseLib,
         step.new('Set up QEMU', 'docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392'),  // v3
         step.new('set up docker buildx', 'docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2'),  //v3
-        step.new('Login to DockerHub', 'grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7'),  // v1.0.4
-        step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136'),  // v1.0.2
+        step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136')  // v1.0.2
+        + step.with({ registry: 'us-docker.pkg.dev' }),
         step.new('download images')
         + step.withEnv({
           SHA: '${{ needs.createRelease.outputs.sha }}',

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@660b018d3a8df2fa14d778f7566a39a6db240957"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
     "with":
       "build_image": "golang:1.26.4"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "660b018d3a8df2fa14d778f7566a39a6db240957"
+      "release_lib_ref": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@660b018d3a8df2fa14d778f7566a39a6db240957"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
     "with":
       "build_image": "golang:1.26.4"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "660b018d3a8df2fa14d778f7566a39a6db240957"
+      "release_lib_ref": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
       "skip_validation": false
       "use_github_app_token": true
   "logql-analyzer-image":
@@ -12,7 +12,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "660b018d3a8df2fa14d778f7566a39a6db240957"
+      "RELEASE_LIB_REF": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -152,7 +152,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "660b018d3a8df2fa14d778f7566a39a6db240957"
+      "RELEASE_LIB_REF": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -292,7 +292,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "660b018d3a8df2fa14d778f7566a39a6db240957"
+      "RELEASE_LIB_REF": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -432,7 +432,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "660b018d3a8df2fa14d778f7566a39a6db240957"
+      "RELEASE_LIB_REF": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -572,7 +572,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "660b018d3a8df2fa14d778f7566a39a6db240957"
+      "RELEASE_LIB_REF": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -7,8 +7,8 @@ env:
   DRY_RUN: false
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
-  IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "660b018d3a8df2fa14d778f7566a39a6db240957"
+  IMAGE_PREFIX: "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
+  RELEASE_LIB_REF: "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   VERSIONING_STRATEGY: "always-bump-minor"
@@ -18,11 +18,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@660b018d3a8df2fa14d778f7566a39a6db240957"
+    uses: "grafana/loki-release/.github/workflows/check.yml@00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
     with:
       build_image: "golang:1.26.4"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "660b018d3a8df2fa14d778f7566a39a6db240957"
+      release_lib_ref: "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
       skip_validation: false
   create-release-pr:
     needs:

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -7,8 +7,8 @@ env:
   DRY_RUN: false
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
-  IMAGE_PREFIX: "grafana"
-  RELEASE_LIB_REF: "660b018d3a8df2fa14d778f7566a39a6db240957"
+  IMAGE_PREFIX: "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
+  RELEASE_LIB_REF: "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   VERSIONING_STRATEGY: "always-bump-patch"
@@ -18,11 +18,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@660b018d3a8df2fa14d778f7566a39a6db240957"
+    uses: "grafana/loki-release/.github/workflows/check.yml@00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
     with:
       build_image: "golang:1.26.4"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "660b018d3a8df2fa14d778f7566a39a6db240957"
+      release_lib_ref: "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
       skip_validation: false
   create-release-pr:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@ env:
   BUILD_ARTIFACTS_BUCKET: "loki-build-artifacts"
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
-  IMAGE_PREFIX: "grafana"
+  IMAGE_PREFIX: "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "660b018d3a8df2fa14d778f7566a39a6db240957"
+  RELEASE_LIB_REF: "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
   RELEASE_REPO: "grafana/loki"
 jobs:
   createRelease:
@@ -210,56 +210,6 @@ jobs:
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
         fi
       working-directory: "release"
-  publishDockerPlugins:
-    needs:
-    - "createRelease"
-    permissions:
-      id-token: "write"
-    runs-on: "ubuntu-x64"
-    steps:
-    - name: "pull release library code"
-      uses: "actions/checkout@v4"
-      with:
-        path: "lib"
-        persist-credentials: false
-        ref: "${{ env.RELEASE_LIB_REF }}"
-        repository: "grafana/loki-release"
-    - name: "pull code to release"
-      uses: "actions/checkout@v4"
-      with:
-        path: "release"
-        persist-credentials: false
-        repository: "${{ env.RELEASE_REPO }}"
-    - name: "Set up QEMU"
-      uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392"
-    - name: "set up docker buildx"
-      uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - name: "Login to DockerHub"
-      uses: "grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7"
-    - name: "Login to GAR"
-      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
-    - env:
-        SHA: "${{ needs.createRelease.outputs.sha }}"
-      name: "download and prepare plugins"
-      run: |
-        echo "downloading plugins to $(pwd)/plugins"
-        mkdir -p plugins
-        gcloud artifacts generic download \
-          --project="grafanalabs-dev" \
-          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
-          --location="us" \
-          --package=plugins \
-          --version=$(echo ${SHA} | tr -d '"') \
-          --destination=plugins/
-        mkdir -p "release/clients/cmd/docker-driver"
-    - name: "publish docker driver"
-      uses: "./lib/actions/push-images"
-      with:
-        buildDir: "release/clients/cmd/docker-driver"
-        imageDir: "plugins"
-        imagePrefix: "${{ env.IMAGE_PREFIX }}"
-        isLatest: "${{ needs.createRelease.outputs.isLatest }}"
-        isPlugin: true
   publishImages:
     needs:
     - "createRelease"
@@ -278,10 +228,10 @@ jobs:
       uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392"
     - name: "set up docker buildx"
       uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
-    - name: "Login to DockerHub"
-      uses: "grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7"
     - name: "Login to GAR"
       uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      with:
+        registry: "us-docker.pkg.dev"
     - env:
         SHA: "${{ needs.createRelease.outputs.sha }}"
       name: "download images"
@@ -305,7 +255,6 @@ jobs:
     needs:
     - "createRelease"
     - "publishImages"
-    - "publishDockerPlugins"
     outputs:
       name: "${{ needs.createRelease.outputs.name }}"
     permissions:


### PR DESCRIPTION
Points the stable image publish at the GAR mirror (`us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror`) instead of Docker Hub, matching the weekly path, and disables the loki-docker-driver plugin publish (it cannot go to GAR). Also bumps loki-release to pick up the GAR registry login on publishImages.
