### PR TITLE
feat(dataobj): Add bloom and regex pushdown predicates to dataset scans

### DIFF
--- a/pkg/dataobj/internal/dataset/predicate.go
+++ b/pkg/dataobj/internal/dataset/predicate.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"iter"
 	"unsafe"
+
+	"github.com/prometheus/prometheus/model/labels"
 )
 
 // Predicate is an expression used to filter rows in a [RowReader].
@@ -72,6 +74,27 @@ type (
 		// If Keep returns true, the row is kept.
 		Keep func(column Column, value Value) bool
 	}
+
+	// BloomMatchPredicate is a [Predicate] which asserts that a row may only be
+	// included if the bloom filter stored in Column's binary value tests positive
+	// for Value.
+	//
+	// Instances of BloomMatchPredicate are ineligible for page filtering: a bloom
+	// blob has no min/max page statistics to prune on.
+	BloomMatchPredicate struct {
+		Column Column
+		Value  []byte
+	}
+
+	// RegexMatchPredicate is a [Predicate] which asserts that a row may only be
+	// included if Column's string value matches Matcher.
+	//
+	// Instances of RegexMatchPredicate are ineligible for page filtering: a regex
+	// has no min/max page statistics to prune on.
+	RegexMatchPredicate struct {
+		Column  Column
+		Matcher *labels.FastRegexMatcher
+	}
 )
 
 func (AndPredicate) isPredicate()         {}
@@ -84,6 +107,8 @@ func (InPredicate) isPredicate()          {}
 func (GreaterThanPredicate) isPredicate() {}
 func (LessThanPredicate) isPredicate()    {}
 func (FuncPredicate) isPredicate()        {}
+func (BloomMatchPredicate) isPredicate()  {}
+func (RegexMatchPredicate) isPredicate()  {}
 
 // WalkPredicate traverses a predicate in depth-first order: it starts by
 // calling fn(p). If fn(p) returns true, WalkPredicate is invoked recursively
@@ -113,6 +138,8 @@ func WalkPredicate(p Predicate, fn func(p Predicate) bool) {
 	case GreaterThanPredicate: // No children.
 	case LessThanPredicate: // No children.
 	case FuncPredicate: // No children.
+	case BloomMatchPredicate: // No children.
+	case RegexMatchPredicate: // No children.
 
 	default:
 		panic(fmt.Sprintf("dataset.WalkPredicate: unsupported predicate type %T", p))

--- a/pkg/dataobj/internal/dataset/row_reader.go
+++ b/pkg/dataobj/internal/dataset/row_reader.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"iter"
 
+	"github.com/bits-and-blooms/bloom/v3"
+
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/bitmask"
@@ -377,6 +379,32 @@ func checkPredicate(p Predicate, lookup map[Column]int, row Row) bool {
 		}
 		return p.Keep(p.Column, row.Values[columnIndex])
 
+	case BloomMatchPredicate:
+		columnIndex, ok := lookup[p.Column]
+		if !ok {
+			panic("checkPredicate: column not found")
+		}
+		value := row.Values[columnIndex]
+		if value.IsNil() || value.Type() != p.Column.ColumnDesc().Type.Physical {
+			return false
+		}
+		var filter bloom.BloomFilter
+		if err := filter.UnmarshalBinary(value.Binary()); err != nil {
+			return false
+		}
+		return filter.Test(p.Value)
+
+	case RegexMatchPredicate:
+		columnIndex, ok := lookup[p.Column]
+		if !ok {
+			panic("checkPredicate: column not found")
+		}
+		value := row.Values[columnIndex]
+		if value.IsNil() || value.Type() != p.Column.ColumnDesc().Type.Physical {
+			return false
+		}
+		return p.Matcher.MatchString(string(value.Binary()))
+
 	default:
 		panic(fmt.Sprintf("unsupported predicate type %T", p))
 	}
@@ -547,6 +575,10 @@ func (r *RowReader) validatePredicate() error {
 				err = process(p.Column)
 			case FuncPredicate:
 				err = process(p.Column)
+			case BloomMatchPredicate:
+				err = process(p.Column)
+			case RegexMatchPredicate:
+				err = process(p.Column)
 			case AndPredicate, OrPredicate, NotPredicate, TruePredicate, FalsePredicate, nil:
 				// No columns to process.
 			default:
@@ -666,6 +698,10 @@ func (r *RowReader) fillPrimaryMask(mask *bitmask.Mask) {
 				process(p.Column)
 			case FuncPredicate:
 				process(p.Column)
+			case BloomMatchPredicate:
+				process(p.Column)
+			case RegexMatchPredicate:
+				process(p.Column)
 			case AndPredicate, OrPredicate, NotPredicate, TruePredicate, FalsePredicate, nil:
 				// No columns to process.
 			default:
@@ -737,7 +773,7 @@ func (r *RowReader) buildPredicateRanges(ctx context.Context, p Predicate) (rang
 	case LessThanPredicate:
 		return r.buildColumnPredicateRanges(ctx, p.Column, p)
 
-	case TruePredicate, FuncPredicate, nil:
+	case TruePredicate, FuncPredicate, BloomMatchPredicate, RegexMatchPredicate, nil:
 		// These predicates (and nil) don't support any filtering, so it maps to
 		// the full range being valid.
 		//
@@ -977,6 +1013,10 @@ func (r *RowReader) predicateColumns(p Predicate, keep func(c Column) bool) ([]C
 		case LessThanPredicate:
 			columns[p.Column] = struct{}{}
 		case FuncPredicate:
+			columns[p.Column] = struct{}{}
+		case BloomMatchPredicate:
+			columns[p.Column] = struct{}{}
+		case RegexMatchPredicate:
 			columns[p.Column] = struct{}{}
 		case AndPredicate, OrPredicate, NotPredicate, TruePredicate, FalsePredicate, nil:
 			// No columns to process.

--- a/pkg/dataobj/internal/dataset/row_reader.go
+++ b/pkg/dataobj/internal/dataset/row_reader.go
@@ -873,25 +873,9 @@ func (r *RowReader) buildColumnPredicateRanges(ctx context.Context, c Column, p 
 		pageStart    int
 		lastPageSize int
 
-		// datalocality stat collection
-		// For logs sections, we track streamID clustering as the data locality property.
-		isStreamCol = isStreamIDColumn(c)
-		// For pointer sections, we track column name clustering as the data locality property.
-		isColumnNameCol                                 = isColumnNameColumn(c)
-		observeLocalityStats                            = isStreamCol || isColumnNameCol
-		totalPagesStat, relevantPagesStat, pageRunsStat *xcap.StatisticInt64
-		prevPageIncluded                                bool // used for tracking avg run length
+		isStreamCol      = isStreamIDColumn(c)
+		prevPageIncluded bool // used for tracking avg run length
 	)
-
-	if isStreamCol {
-		totalPagesStat = dataobj.StatStreamPagesTotal
-		relevantPagesStat = dataobj.StatStreamRelevantPages
-		pageRunsStat = dataobj.StatStreamPageRuns
-	} else if isColumnNameCol {
-		totalPagesStat = dataobj.StatPostingsColumnNamePagesTotal
-		relevantPagesStat = dataobj.StatPostingsColumnNameRelevantPages
-		pageRunsStat = dataobj.StatPostingsColumnNamePageRuns
-	}
 
 	for result := range c.ListPages(ctx) {
 		pageStart += lastPageSize
@@ -908,8 +892,8 @@ func (r *RowReader) buildColumnPredicateRanges(ctx context.Context, c Column, p 
 			End:   uint64(pageStart + pageInfo.RowCount),
 		}
 
-		if observeLocalityStats {
-			region.Record(totalPagesStat.Observe(1))
+		if isStreamCol {
+			region.Record(dataobj.StatStreamPagesTotal.Observe(1))
 		}
 
 		minValue, maxValue, err := readMinMax(pageInfo.Stats)
@@ -919,13 +903,14 @@ func (r *RowReader) buildColumnPredicateRanges(ctx context.Context, c Column, p 
 			// No stats, so we add the whole range.
 			ranges.Add(pageRange)
 
-			if observeLocalityStats {
-				region.Record(relevantPagesStat.Observe(1))
+			if isStreamCol {
+				region.Record(dataobj.StatStreamRelevantPages.Observe(1))
 
 				// record start of a new run
 				if !prevPageIncluded {
-					region.Record(pageRunsStat.Observe(1))
+					region.Record(dataobj.StatStreamPageRuns.Observe(1))
 				}
+
 			}
 
 			prevPageIncluded = true
@@ -957,12 +942,12 @@ func (r *RowReader) buildColumnPredicateRanges(ctx context.Context, c Column, p 
 		if include {
 			ranges.Add(pageRange)
 
-			if observeLocalityStats {
-				region.Record(relevantPagesStat.Observe(1))
+			if isStreamCol {
+				region.Record(dataobj.StatStreamRelevantPages.Observe(1))
 
 				// track start of a new run
 				if !prevPageIncluded {
-					region.Record(pageRunsStat.Observe(1))
+					region.Record(dataobj.StatStreamPageRuns.Observe(1))
 				}
 			}
 		} else {
@@ -1057,8 +1042,4 @@ func isStreamIDPredicate(p Predicate) bool {
 
 func isStreamIDColumn(col Column) bool {
 	return col.ColumnDesc().Type.Logical == "stream_id"
-}
-
-func isColumnNameColumn(col Column) bool {
-	return col.ColumnDesc().Type.Logical == "column_name"
 }

--- a/pkg/dataobj/internal/dataset/row_reader_test.go
+++ b/pkg/dataobj/internal/dataset/row_reader_test.go
@@ -11,7 +11,9 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/dustin/go-humanize"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -184,6 +186,36 @@ func TestRowReader_ReadWithPageFilteringOnEmptyPredicate(t *testing.T) {
 	expectedLastNames := []string{"[nil]"}
 	require.Equal(t, expectedFirstNames, actualFirstNames)
 	require.Equal(t, expectedLastNames, actualLastNames)
+}
+
+func TestRowReader_BloomMatchPredicate(t *testing.T) {
+	hit := bloom.NewWithEstimates(100, 0.01)
+	hit.Add([]byte("foo"))
+	hitBytes, err := hit.MarshalBinary()
+	require.NoError(t, err)
+
+	miss := bloom.NewWithEstimates(100, 0.01)
+	miss.Add([]byte("bar"))
+	missBytes, err := miss.MarshalBinary()
+	require.NoError(t, err)
+
+	dset, col := buildBinaryColumnDataset(t, [][]byte{hitBytes, missBytes, []byte("not-a-bloom")})
+
+	rows := readAllRows(t, dset, []Column{col}, BloomMatchPredicate{Column: col, Value: []byte("foo")})
+	require.Len(t, rows, 1)
+	require.Equal(t, hitBytes, rows[0].Values[0].Binary())
+}
+
+func TestRowReader_RegexMatchPredicate(t *testing.T) {
+	re, err := labels.NewFastRegexMatcher("foo.*")
+	require.NoError(t, err)
+
+	dset, col := buildBinaryColumnDataset(t, [][]byte{[]byte("foobar"), []byte("baz"), []byte("foo")})
+
+	rows := readAllRows(t, dset, []Column{col}, RegexMatchPredicate{Column: col, Matcher: re})
+	require.Len(t, rows, 2)
+	require.Equal(t, []byte("foobar"), rows[0].Values[0].Binary())
+	require.Equal(t, []byte("foo"), rows[1].Values[0].Binary())
 }
 
 func Test_Reader_ReadWithPredicate_NoSecondary(t *testing.T) {
@@ -969,4 +1001,47 @@ func Test_Reader_Stats(t *testing.T) {
 	require.Equal(t, int64(3), obsMap[dataobj.StatDatasetRowsAfterPruning.Name()])
 	require.Equal(t, int64(3), obsMap[dataobj.StatDatasetPrimaryRowsRead.Name()])
 	require.Equal(t, int64(1), obsMap[dataobj.StatDatasetSecondaryRowsRead.Name()])
+}
+
+// buildBinaryColumnDataset creates a dataset with a single binary column containing the given values.
+func buildBinaryColumnDataset(t *testing.T, values [][]byte) (Dataset, Column) {
+	t.Helper()
+
+	builder, err := NewColumnBuilder("bloom_data", BuilderOptions{
+		Type:        ColumnType{Physical: datasetmd.PHYSICAL_TYPE_BINARY, Logical: "binary"},
+		Compression: datasetmd.COMPRESSION_TYPE_NONE,
+		Encoding:    datasetmd.ENCODING_TYPE_PLAIN,
+		Statistics:  StatisticsOptions{},
+	})
+	require.NoError(t, err)
+
+	for i, val := range values {
+		require.NoError(t, builder.Append(i, BinaryValue(val)))
+	}
+
+	col, err := builder.Flush()
+	require.NoError(t, err)
+
+	dset := FromMemory([]*MemColumn{col})
+	cols, err := result.Collect(dset.ListColumns(context.Background()))
+	require.NoError(t, err)
+	require.Len(t, cols, 1)
+
+	return dset, cols[0]
+}
+
+// readAllRows reads all rows from a dataset with the given columns and predicates.
+func readAllRows(t *testing.T, dset Dataset, columns []Column, predicates ...Predicate) []Row {
+	t.Helper()
+
+	r := NewRowReader(RowReaderOptions{
+		Dataset:    dset,
+		Columns:    columns,
+		Predicates: predicates,
+	})
+	defer r.Close()
+
+	rows, err := readDataset(r, 3)
+	require.NoError(t, err)
+	return rows
 }

--- a/pkg/dataobj/metastore/index_sections_reader.go
+++ b/pkg/dataobj/metastore/index_sections_reader.go
@@ -67,11 +67,6 @@ type indexSectionsReader struct {
 	bloomRowsRead            uint64
 	pointerSectionProductive []bool
 
-	// metrics, when non-nil, receives per-object/per-flow observations at Close.
-	// statsRecorded guards against double-recording if Close runs more than once.
-	metrics       *ObjectMetastoreMetrics
-	statsRecorded bool
-
 	// readSpan for recording observations, it is created once during init.
 	readSpan *xcap.Span
 }
@@ -88,7 +83,6 @@ func newIndexSectionsReader(
 	matchers []*labels.Matcher,
 	predicates []*labels.Matcher,
 	batchSize int,
-	metrics *ObjectMetastoreMetrics,
 ) *indexSectionsReader {
 	// Only keep equal predicates for bloom filtering
 	var equalPredicates []*labels.Matcher
@@ -112,7 +106,6 @@ func newIndexSectionsReader(
 		end:                end,
 		matchingStreamIDs:  make(map[int64]struct{}),
 		labelNamesByStream: make(map[int64][]string),
-		metrics:            metrics,
 	}
 }
 
@@ -458,16 +451,10 @@ func (r *indexSectionsReader) Read(ctx context.Context) (arrow.RecordBatch, erro
 		return nil, io.EOF
 	}
 
-	var (
-		rec arrow.RecordBatch
-		err error
-	)
 	if len(r.predicates) == 0 {
-		rec, err = r.readPointers(ctx)
-	} else {
-		rec, err = r.readWithBloomFiltering(ctx)
+		return r.readPointers(ctx)
 	}
-	return rec, err
+	return r.readWithBloomFiltering(ctx)
 }
 
 func (r *indexSectionsReader) lazyReadStreams(ctx context.Context) error {
@@ -567,11 +554,6 @@ func (r *indexSectionsReader) Close() {
 	closeAll(r.streamsReaders)
 	closeAll(r.pointersReaders)
 	closeAll(r.bloomReaders)
-
-	if r.initialized && r.metrics != nil && !r.statsRecorded {
-		r.statsRecorded = true
-		r.metrics.indexReadRowsPerObject.WithLabelValues(flowStreams).Observe(float64(r.totalReadRows()))
-	}
 
 	if r.readSpan != nil {
 		r.readSpan.End()

--- a/pkg/dataobj/metastore/index_sections_reader_test.go
+++ b/pkg/dataobj/metastore/index_sections_reader_test.go
@@ -23,7 +23,7 @@ import (
 func TestIndexSectionsReader_NoSelectorReturnsEOF(t *testing.T) {
 	t.Parallel()
 
-	r := newIndexSectionsReader(log.NewNopLogger(), nil, now, now, nil, nil, 8192, nil)
+	r := newIndexSectionsReader(log.NewNopLogger(), nil, now, now, nil, nil, 8192)
 	require.NoError(t, r.Open(context.Background()))
 
 	rec, err := r.Read(context.Background())
@@ -34,7 +34,7 @@ func TestIndexSectionsReader_NoSelectorReturnsEOF(t *testing.T) {
 func TestIndexSectionsReader_ReadBeforeOpenReturnsError(t *testing.T) {
 	t.Parallel()
 
-	r := newIndexSectionsReader(log.NewNopLogger(), nil, now, now, nil, nil, 8192, nil)
+	r := newIndexSectionsReader(log.NewNopLogger(), nil, now, now, nil, nil, 8192)
 
 	rec, err := r.Read(context.Background())
 	require.ErrorIs(t, err, errIndexSectionsReaderNotOpen)
@@ -72,7 +72,7 @@ func TestIndexSectionsReader_MissingOrgIDReturnsError(t *testing.T) {
 	end := now.Add(-time.Hour)
 	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "app", "foo")}
 
-	r := newIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, nil, 8192, nil)
+	r := newIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, nil, 8192)
 
 	// Context without org ID should fail during Open.
 	require.Error(t, r.Open(context.Background()))
@@ -120,7 +120,7 @@ func TestIndexSectionsReader_FiltersByStreamMatcherAndTime(t *testing.T) {
 	end := now.Add(-time.Hour)
 	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "app", "foo")}
 
-	r := newIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, nil, 8192, nil)
+	r := newIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, nil, 8192)
 	t.Cleanup(r.Close)
 	require.NoError(t, r.Open(ctx))
 
@@ -173,7 +173,7 @@ func TestIndexSectionsReader_NoPredicatesPassthrough(t *testing.T) {
 	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "app", "foo")}
 
 	// No predicates - should pass through all matching records
-	r := newIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, nil, 8192, nil)
+	r := newIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, nil, 8192)
 	t.Cleanup(r.Close)
 	require.NoError(t, r.Open(ctx))
 
@@ -228,7 +228,7 @@ func TestIndexSectionsReader_IgnoresNonEqualPredicates(t *testing.T) {
 		labels.MustNewMatcher(labels.MatchRegexp, "traceID", "abcd"),
 	}
 
-	r := newIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, predicates, 8192, nil)
+	r := newIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, predicates, 8192)
 	t.Cleanup(r.Close)
 	require.NoError(t, r.Open(ctx))
 
@@ -277,7 +277,7 @@ func TestIndexSectionsReader_FiltersByBloomOnSectionKey(t *testing.T) {
 		labels.MustNewMatcher(labels.MatchEqual, "traceID", "abcd"),
 	}
 
-	r := newIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, predicates, 8192, nil)
+	r := newIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, predicates, 8192)
 	t.Cleanup(r.Close)
 	require.NoError(t, r.Open(ctx))
 
@@ -338,7 +338,7 @@ func TestIndexSectionsReader_PredicateMissReturnsEOF(t *testing.T) {
 		labels.MustNewMatcher(labels.MatchEqual, "traceID", "doesnotexist"),
 	}
 
-	r := newIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, predicates, 8192, nil)
+	r := newIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, predicates, 8192)
 	t.Cleanup(r.Close)
 	require.NoError(t, r.Open(ctx))
 
@@ -392,7 +392,7 @@ func TestIndexSectionsReader_LabelPredicatesFiltered(t *testing.T) {
 		labels.MustNewMatcher(labels.MatchEqual, "app", "foo"),
 	}
 
-	r := newIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, predicates, 8192, nil)
+	r := newIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, predicates, 8192)
 	t.Cleanup(r.Close)
 	require.NoError(t, r.Open(ctx))
 
@@ -476,7 +476,6 @@ func TestIndexSectionsReader_MultipleBlooms(t *testing.T) {
 					labels.MustNewMatcher(labels.MatchEqual, "userID", tc.userIDValue),
 				},
 				8192,
-				nil,
 			)
 			t.Cleanup(r.Close)
 			require.NoError(t, r.Open(ctx))
@@ -498,7 +497,7 @@ func TestIndexSectionsReader_MultipleBlooms(t *testing.T) {
 func TestIndexSectionsReader_Read_SkipsNilStreamsReader(t *testing.T) {
 	t.Parallel()
 
-	r := newIndexSectionsReader(log.NewNopLogger(), nil, now, now, nil, nil, 8192, nil)
+	r := newIndexSectionsReader(log.NewNopLogger(), nil, now, now, nil, nil, 8192)
 	r.initialized = true
 	r.streamsReaders = []*streams.Reader{nil}
 	t.Cleanup(r.Close)
@@ -517,7 +516,7 @@ func TestIndexSectionsReader_Read_SkipsNilStreamsReader(t *testing.T) {
 func TestIndexSectionsReader_Read_SkipsNilPointersReader(t *testing.T) {
 	t.Parallel()
 
-	r := newIndexSectionsReader(log.NewNopLogger(), nil, now, now, nil, nil, 8192, nil)
+	r := newIndexSectionsReader(log.NewNopLogger(), nil, now, now, nil, nil, 8192)
 	r.initialized = true
 	r.readStreams = true
 	r.hasData = true
@@ -546,7 +545,6 @@ func TestIndexSectionsReader_ReadMatchedSectionKeys_SkipsNilBloomReader(t *testi
 		nil,
 		[]*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "traceID", "abcd")},
 		8192,
-		nil,
 	)
 	r.bloomReaders = []*pointers.Reader{nil}
 

--- a/pkg/dataobj/metastore/metrics.go
+++ b/pkg/dataobj/metastore/metrics.go
@@ -100,10 +100,6 @@ type ObjectMetastoreMetrics struct {
 	resolvedSectionsTotalDuration       prometheus.Histogram
 	resolvedSectionsTotal               prometheus.Histogram
 	resolvedSectionsRatio               prometheus.Histogram
-
-	postingsReaderSelectedTotal *prometheus.CounterVec
-	resolvedSectionsPerObject   *prometheus.HistogramVec
-	indexReadRowsPerObject      *prometheus.HistogramVec
 }
 
 func NewObjectMetastoreMetrics(reg prometheus.Registerer) *ObjectMetastoreMetrics {
@@ -196,26 +192,6 @@ func NewObjectMetastoreMetrics(reg prometheus.Registerer) *ObjectMetastoreMetric
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: 0,
 		}),
-		postingsReaderSelectedTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "loki_metastore_postings_reader_selected_total",
-			Help: "Total number of index objects routed in the read path when read_postings_sections is enabled",
-		}, []string{"flow"}),
-		resolvedSectionsPerObject: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:                            "loki_metastore_resolved_sections_per_object",
-			Help:                            "Number of sections resolved from a single index object",
-			Buckets:                         nil,
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: 0,
-		}, []string{"flow"}),
-		indexReadRowsPerObject: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:                            "loki_metastore_index_read_rows_per_object",
-			Help:                            "Number of index rows read while resolving a single index object",
-			Buckets:                         nil,
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: 0,
-		}, []string{"flow"}),
 	}
 	metrics.register(reg)
 
@@ -237,7 +213,4 @@ func (p *ObjectMetastoreMetrics) register(reg prometheus.Registerer) {
 	reg.MustRegister(p.resolvedSectionsTotalDuration)
 	reg.MustRegister(p.resolvedSectionsTotal)
 	reg.MustRegister(p.resolvedSectionsRatio)
-	reg.MustRegister(p.postingsReaderSelectedTotal)
-	reg.MustRegister(p.resolvedSectionsPerObject)
-	reg.MustRegister(p.indexReadRowsPerObject)
 }

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -584,11 +584,13 @@ func (m *ObjectMetastore) Sections(ctx context.Context, req SectionsRequest) (Se
 				return fmt.Errorf("collect sections: %w", err)
 			}
 
+			// Merge the section descriptors for the object into the global section descriptors in one batch
+			sectionsMu.Lock()
+
 			// this is temporary, the stats will be collected differently in a distributed metastore
 			statsProvider := reader.(bloomStatsProvider)
-			readRows := statsProvider.totalReadRows()
-			sectionsMu.Lock()
-			totalSections.Add(readRows)
+			totalSections.Add(statsProvider.totalReadRows())
+
 			sections = append(sections, sectionsResp.SectionsResponse.Sections...)
 			sectionsMu.Unlock()
 
@@ -640,7 +642,6 @@ func (m *ObjectMetastore) IndexSectionsReader(ctx context.Context, req IndexSect
 		}
 		// Index objects written before postings still read from streams sections
 		if hasPostings {
-			m.metrics.postingsReaderSelectedTotal.WithLabelValues(flowPostings).Inc()
 			reader := newPostingsIndexSectionsReader(
 				m.logger,
 				idxObj,
@@ -649,11 +650,9 @@ func (m *ObjectMetastore) IndexSectionsReader(ctx context.Context, req IndexSect
 				req.SectionsRequest.Matchers,
 				req.SectionsRequest.Predicates,
 				req.BatchSize,
-				m.metrics,
 			)
 			return IndexSectionsReaderResponse{Reader: reader}, nil
 		}
-		m.metrics.postingsReaderSelectedTotal.WithLabelValues(flowStreams).Inc()
 	}
 
 	reader := newIndexSectionsReader(
@@ -664,16 +663,10 @@ func (m *ObjectMetastore) IndexSectionsReader(ctx context.Context, req IndexSect
 		req.SectionsRequest.Matchers,
 		req.SectionsRequest.Predicates,
 		req.BatchSize,
-		m.metrics,
 	)
+
 	return IndexSectionsReaderResponse{Reader: reader}, nil
 }
-
-// Read path flow labels for per-flow metric attribution.
-const (
-	flowPostings = "postings"
-	flowStreams  = "streams"
-)
 
 // hasPostingsSection reports whether obj contains a postings section for the tenant
 func hasPostingsSection(ctx context.Context, obj *dataobj.Object) (bool, error) {

--- a/pkg/dataobj/metastore/postings_index_sections_reader.go
+++ b/pkg/dataobj/metastore/postings_index_sections_reader.go
@@ -51,11 +51,6 @@ type postingsIndexSectionsReader struct {
 	// Stats
 	bloomRowsRead uint64
 
-	// metrics, when non-nil, receives per-object/per-flow observations at Close.
-	// statsRecorded guards against double-recording if Close runs more than once.
-	metrics       *ObjectMetastoreMetrics
-	statsRecorded bool
-
 	// readSpan for recording observations, it is created once during the first Read.
 	readSpan *xcap.Span
 }
@@ -67,7 +62,6 @@ func newPostingsIndexSectionsReader(
 	matchers []*labels.Matcher,
 	predicates []*labels.Matcher,
 	batchSize int,
-	metrics *ObjectMetastoreMetrics,
 ) *postingsIndexSectionsReader {
 	// Only keep equal predicates for bloom filtering
 	var equalPredicates []*labels.Matcher
@@ -89,7 +83,6 @@ func newPostingsIndexSectionsReader(
 		batchSize:  batchSize,
 		start:      start,
 		end:        end,
-		metrics:    metrics,
 	}
 }
 
@@ -144,7 +137,6 @@ func (r *postingsIndexSectionsReader) init(ctx context.Context) error {
 		}
 
 		readers = append(readers, reader)
-		sp.Record(StatMetastorePointerSectionsOpened.Observe(1))
 	}
 	r.postingsReaders = readers
 
@@ -195,14 +187,8 @@ func (r *postingsIndexSectionsReader) lazyResolveStreams(ctx context.Context) er
 
 		acc := postings.NewStreamScan(r.matchers, r.start, r.end)
 		for _, reader := range r.postingsReaders {
-			productive, err := reader.ScanLabelsInto(ctx, acc, r.batchSize)
-			if err != nil {
+			if err := reader.ScanLabelsInto(ctx, acc, r.batchSize); err != nil {
 				return fmt.Errorf("scanning postings labels: %w", err)
-			}
-			// Recorded at the metastore layer (rather than inside the postings
-			// reader) so the postings package need not depend on metastore stats.
-			if productive {
-				region.Record(StatMetastorePointerSectionsProductive.Observe(1))
 			}
 		}
 		res := acc.Finalize(ctx)
@@ -341,12 +327,6 @@ func (r *postingsIndexSectionsReader) readMatchedSectionKeys(ctx context.Context
 func (r *postingsIndexSectionsReader) Close() {
 	closeAll(r.postingsReaders)
 
-	if r.initialized && r.metrics != nil && !r.statsRecorded {
-		r.statsRecorded = true
-		r.metrics.indexReadRowsPerObject.WithLabelValues(flowPostings).Observe(float64(r.totalReadRows()))
-		r.metrics.resolvedSectionsPerObject.WithLabelValues(flowPostings).Observe(float64(r.resolvedSectionCount()))
-	}
-
 	if r.readSpan != nil {
 		r.readSpan.End()
 	}
@@ -354,17 +334,6 @@ func (r *postingsIndexSectionsReader) Close() {
 
 func (r *postingsIndexSectionsReader) totalReadRows() uint64 {
 	return r.bloomRowsRead
-}
-
-// resolvedSectionCount returns the number of distinct sections resolved for this
-// object, i.e. the distinct (object path, section) tuples across the resolved
-// pointer rows after stream matching and bloom filtering.
-func (r *postingsIndexSectionsReader) resolvedSectionCount() int {
-	seen := make(map[SectionKey]struct{}, len(r.pointerRows))
-	for _, row := range r.pointerRows {
-		seen[SectionKey{ObjectPath: row.ObjectPath, SectionIdx: row.SectionIndex}] = struct{}{}
-	}
-	return len(seen)
 }
 
 const (

--- a/pkg/dataobj/metastore/postings_index_sections_reader_test.go
+++ b/pkg/dataobj/metastore/postings_index_sections_reader_test.go
@@ -23,7 +23,7 @@ import (
 func TestPostingsIndexSectionsReader_ReadBeforeOpenReturnsError(t *testing.T) {
 	t.Parallel()
 
-	r := newPostingsIndexSectionsReader(log.NewNopLogger(), nil, now, now, nil, nil, 0, nil)
+	r := newPostingsIndexSectionsReader(log.NewNopLogger(), nil, now, now, nil, nil, 0)
 
 	rec, err := r.Read(context.Background())
 	require.ErrorIs(t, err, errIndexSectionsReaderNotOpen)
@@ -33,7 +33,7 @@ func TestPostingsIndexSectionsReader_ReadBeforeOpenReturnsError(t *testing.T) {
 func TestPostingsIndexSectionsReader_NoSelectorReturnsEOF(t *testing.T) {
 	t.Parallel()
 
-	r := newPostingsIndexSectionsReader(log.NewNopLogger(), nil, now, now, nil, nil, 0, nil)
+	r := newPostingsIndexSectionsReader(log.NewNopLogger(), nil, now, now, nil, nil, 0)
 	require.NoError(t, r.Open(context.Background()))
 
 	rec, err := r.Read(context.Background())
@@ -47,7 +47,7 @@ func TestPostingsIndexSectionsReader_MissingOrgIDReturnsError(t *testing.T) {
 	obj := buildPostingsFixture(t)
 	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "app", "foo")}
 
-	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, now.Add(-4*time.Hour), now.Add(-time.Hour), matchers, nil, 0, nil)
+	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, now.Add(-4*time.Hour), now.Add(-time.Hour), matchers, nil, 0)
 
 	// Context without org ID should fail during Open.
 	require.Error(t, r.Open(context.Background()))
@@ -63,7 +63,7 @@ func TestPostingsIndexSectionsReader_ReadsPointers(t *testing.T) {
 	end := now.Add(-time.Hour)
 	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "app", "foo")}
 
-	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, nil, 0, nil)
+	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, nil, 0)
 	t.Cleanup(r.Close)
 	require.NoError(t, r.Open(ctx))
 
@@ -93,7 +93,7 @@ func TestPostingsIndexSectionsReader_CombinesAcrossPostingsSections(t *testing.T
 	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "app", "foo")}
 
 	obj := buildMultiPostingsSectionsFixture(t)
-	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, now.Add(-4*time.Hour), now.Add(-time.Hour), matchers, nil, 0, nil)
+	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, now.Add(-4*time.Hour), now.Add(-time.Hour), matchers, nil, 0)
 	t.Cleanup(r.Close)
 
 	require.NoError(t, r.Open(ctx))
@@ -128,7 +128,7 @@ func TestPostingsIndexSectionsReader_PagesPointerOutput(t *testing.T) {
 	// Two postings sections ⇒ two pointer rows for app=foo; batchSize=1 forces
 	// two batches.
 	obj := buildMultiPostingsSectionsFixture(t)
-	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, now.Add(-4*time.Hour), now.Add(-time.Hour), matchers, nil, 1, nil)
+	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, now.Add(-4*time.Hour), now.Add(-time.Hour), matchers, nil, 1)
 	t.Cleanup(r.Close)
 	require.NoError(t, r.Open(ctx))
 
@@ -163,7 +163,7 @@ func TestPostingsIndexSectionsReader_ANDMatchersAcrossPostingsSections(t *testin
 	}
 
 	obj := buildPostingsANDAcrossSectionsFixture(t)
-	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, now.Add(-4*time.Hour), now.Add(-time.Hour), matchers, nil, 0, nil)
+	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, now.Add(-4*time.Hour), now.Add(-time.Hour), matchers, nil, 0)
 	t.Cleanup(r.Close)
 
 	require.NoError(t, r.Open(ctx))
@@ -190,7 +190,7 @@ func TestPostingsIndexSectionsReader_NoPostingsSectionReturnsEOF(t *testing.T) {
 	obj := buildStreamsPointersFixture(t)
 	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "app", "foo")}
 
-	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, now.Add(-4*time.Hour), now.Add(-time.Hour), matchers, nil, 0, nil)
+	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, now.Add(-4*time.Hour), now.Add(-time.Hour), matchers, nil, 0)
 	t.Cleanup(r.Close)
 	require.NoError(t, r.Open(ctx))
 	require.Empty(t, r.postingsReaders, "no postings section ⇒ no postings readers")
@@ -212,7 +212,7 @@ func TestPostingsIndexSectionsReader_StreamLabelPredicateOnDisjointName(t *testi
 	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "app", "foo")}
 	predicates := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "team", "ops")}
 
-	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, predicates, 0, nil)
+	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, predicates, 0)
 	t.Cleanup(r.Close)
 	require.NoError(t, r.Open(ctx))
 
@@ -244,7 +244,7 @@ func TestPostingsIndexSectionsReader_StreamLabelPredicateOnlyOnNonMatchingStream
 	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "app", "foo")}
 	predicates := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "team", "ops")}
 
-	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, predicates, 0, nil)
+	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, predicates, 0)
 	t.Cleanup(r.Close)
 	require.NoError(t, r.Open(ctx))
 
@@ -263,7 +263,7 @@ func TestPostingsIndexSectionsReader_StreamIDCollisionAcrossObjects(t *testing.T
 	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "app", "foo")}
 
 	obj := buildPostingsStreamIDCollisionFixture(t)
-	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, nil, 0, nil)
+	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, nil, 0)
 	t.Cleanup(r.Close)
 	require.NoError(t, r.Open(ctx))
 
@@ -287,7 +287,7 @@ func TestPostingsIndexSectionsReader_EndToEnd(t *testing.T) {
 	appFoo := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "app", "foo")}
 
 	t.Run("selector resolves to matching streams from postings alone", func(t *testing.T) {
-		r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, inWindowStart, inWindowEnd, appFoo, nil, 0, nil)
+		r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, inWindowStart, inWindowEnd, appFoo, nil, 0)
 		t.Cleanup(r.Close)
 		require.NoError(t, r.Open(ctx))
 		require.NotEmpty(t, r.postingsReaders)
@@ -319,7 +319,7 @@ func TestPostingsIndexSectionsReader_EndToEnd(t *testing.T) {
 	})
 
 	t.Run("time window outside the data returns EOF", func(t *testing.T) {
-		r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, now.Add(-30*time.Minute), now, appFoo, nil, 0, nil)
+		r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, now.Add(-30*time.Minute), now, appFoo, nil, 0)
 		t.Cleanup(r.Close)
 		require.NoError(t, r.Open(ctx))
 
@@ -330,7 +330,7 @@ func TestPostingsIndexSectionsReader_EndToEnd(t *testing.T) {
 
 	t.Run("structured-metadata bloom selects the section", func(t *testing.T) {
 		predicates := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "traceID", "abcd")}
-		r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, inWindowStart, inWindowEnd, appFoo, predicates, 0, nil)
+		r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, inWindowStart, inWindowEnd, appFoo, predicates, 0)
 		t.Cleanup(r.Close)
 		require.NoError(t, r.Open(ctx))
 
@@ -350,7 +350,7 @@ func TestPostingsIndexSectionsReader_EndToEnd(t *testing.T) {
 
 	t.Run("structured-metadata bloom miss prunes the section", func(t *testing.T) {
 		predicates := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "traceID", "doesnotexist")}
-		r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, inWindowStart, inWindowEnd, appFoo, predicates, 0, nil)
+		r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, inWindowStart, inWindowEnd, appFoo, predicates, 0)
 		t.Cleanup(r.Close)
 		require.NoError(t, r.Open(ctx))
 
@@ -361,7 +361,7 @@ func TestPostingsIndexSectionsReader_EndToEnd(t *testing.T) {
 
 	t.Run("non-equal predicates are ignored for bloom filtering", func(t *testing.T) {
 		predicates := []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "traceID", "abcd")}
-		r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, inWindowStart, inWindowEnd, appFoo, predicates, 0, nil)
+		r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, inWindowStart, inWindowEnd, appFoo, predicates, 0)
 		t.Cleanup(r.Close)
 		require.NoError(t, r.Open(ctx))
 
@@ -384,7 +384,7 @@ func TestPostingsIndexSectionsReader_RetryAfterBloomErrorStillFiltersPredicates(
 	// This predicate intentionally misses so a correctly filtered retry returns EOF.
 	predicates := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "traceID", "doesnotexist")}
 
-	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, predicates, 0, nil)
+	r := newPostingsIndexSectionsReader(log.NewNopLogger(), obj, start, end, matchers, predicates, 0)
 	t.Cleanup(r.Close)
 	require.NoError(t, r.Open(ctx))
 	require.NoError(t, r.lazyResolveStreams(ctx))

--- a/pkg/dataobj/sections/postings/bloom_match.go
+++ b/pkg/dataobj/sections/postings/bloom_match.go
@@ -8,10 +8,8 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/bits-and-blooms/bloom/v3"
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/prometheus/model/labels"
 
-	utillog "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/xcap"
 )
 
@@ -22,7 +20,6 @@ type Key struct {
 	SectionIndex int64
 }
 
-// MatchSections returns the section keys matching every Equal matcher.
 func MatchSections(ctx context.Context, batches []arrow.RecordBatch, matchers []*labels.Matcher) (map[Key]struct{}, error) {
 	// Filter to MatchEqual matchers only; other types are handled on separate caller paths.
 	equalMatchers := make([]*labels.Matcher, 0, len(matchers))
@@ -45,11 +42,6 @@ func MatchSections(ctx context.Context, batches []arrow.RecordBatch, matchers []
 		if bloomDeserializeFailures > 0 {
 			xcap.RegionFromContext(ctx).Record(
 				StatPostingsBloomDeserializeFailures.Observe(bloomDeserializeFailures),
-			)
-			level.Warn(utillog.WithContext(ctx, utillog.Logger)).Log(
-				"msg", "corrupt bloom filters skipped during postings section matching; affected sections treated as candidates",
-				"deserialize_failures", bloomDeserializeFailures,
-				"predicates", len(equalMatchers),
 			)
 		}
 	}()

--- a/pkg/dataobj/sections/postings/export_test.go
+++ b/pkg/dataobj/sections/postings/export_test.go
@@ -13,7 +13,7 @@ func (r *Reader) ResolveStreamsAndPointers(ctx context.Context, matchers []*labe
 		return &StreamScanResult{}, nil
 	}
 	acc := NewStreamScan(matchers, start, end)
-	if _, err := r.ScanLabelsInto(ctx, acc, streamScanBatchSize); err != nil {
+	if err := r.ScanLabelsInto(ctx, acc, streamScanBatchSize); err != nil {
 		return nil, err
 	}
 	return acc.Finalize(ctx), nil

--- a/pkg/dataobj/sections/postings/reader.go
+++ b/pkg/dataobj/sections/postings/reader.go
@@ -25,9 +25,6 @@ import (
 
 var tracer = otel.Tracer("pkg/dataobj/sections/postings")
 
-// RegionPrefix is the prefix used for postings reader xcap regions.
-var RegionPrefix = "postings.Reader."
-
 // ReaderOptions customizes the behavior of a [Reader].
 type ReaderOptions struct {
 	// Columns to read. Each column must belong to the same [Section].
@@ -203,7 +200,7 @@ func (r *Reader) Read(ctx context.Context, batchSize int) (arrow.RecordBatch, er
 	}
 
 	if r.readSpan == nil {
-		ctx, r.readSpan = xcap.StartSpan(ctx, tracer, RegionPrefix+"Read")
+		ctx, r.readSpan = xcap.StartSpan(ctx, tracer, "postings.Reader.Read")
 	} else {
 		ctx = xcap.ContextWithSpan(ctx, r.readSpan)
 	}
@@ -226,7 +223,7 @@ func (r *Reader) init(ctx context.Context) error {
 		r.opts.Allocator = memory.DefaultAllocator
 	}
 
-	ctx, span := xcap.StartSpan(ctx, tracer, RegionPrefix+"Open")
+	ctx, span := xcap.StartSpan(ctx, tracer, "postings.Reader.Open")
 	defer span.End()
 
 	cols := r.opts.Columns
@@ -329,7 +326,7 @@ func (r *Reader) readBloomRows(ctx context.Context, columnNames []string) (arrow
 		return nil, errReaderNotOpen
 	}
 
-	ctx, span := xcap.StartSpan(ctx, tracer, RegionPrefix+"ReadBloomRows")
+	ctx, span := xcap.StartSpan(ctx, tracer, "postings.Reader.ReadBloomRows")
 	defer span.End()
 	defer r.alloc.Reclaim()
 
@@ -626,20 +623,16 @@ func matcherMatchesMissingLabel(m *labels.Matcher) bool {
 	}
 }
 
-// ScanLabelsInto drains this reader's KindLabel rows in batchSize-row batches into acc.
-// ScanLabelsInto scans this section's KindLabel rows into acc. It returns
-// whether the section was productive (yielded at least one matching stream) so
-// the metastore layer can record the metastore.sections.productive stat without
-// the postings package depending on the metastore package.
-func (r *Reader) ScanLabelsInto(ctx context.Context, acc *StreamScan, batchSize int) (bool, error) {
+// ScanLabelsInto drains this reader's KindLabel rows in batchSize-row batches into acc
+func (r *Reader) ScanLabelsInto(ctx context.Context, acc *StreamScan, batchSize int) error {
 	if !r.ready {
-		return false, errReaderNotOpen
+		return errReaderNotOpen
 	}
 	if batchSize <= 0 {
 		batchSize = streamScanBatchSize
 	}
 
-	ctx, span := xcap.StartSpan(ctx, tracer, RegionPrefix+"ScanLabels")
+	ctx, span := xcap.StartSpan(ctx, tracer, "postings.Reader.ScanLabels")
 	defer span.End()
 	defer r.alloc.Reclaim()
 
@@ -654,7 +647,7 @@ func (r *Reader) ScanLabelsInto(ctx context.Context, acc *StreamScan, batchSize 
 		ColumnTypeKind,
 	)
 	if err != nil {
-		return false, fmt.Errorf("finding ScanLabels columns: %w", err)
+		return fmt.Errorf("finding ScanLabels columns: %w", err)
 	}
 	colObjectPath, colSectionIndex, colColumnName, colLabelValue, colStreamIDBitmap, colMinTs, colMaxTs, colKind :=
 		cols[0], cols[1], cols[2], cols[3], cols[4], cols[5], cols[6], cols[7]
@@ -673,9 +666,9 @@ func (r *Reader) ScanLabelsInto(ctx context.Context, acc *StreamScan, batchSize 
 
 	dset, err := columnar.MakeDataset(innerSection, innerColumns)
 	if err != nil {
-		return false, fmt.Errorf("creating dataset: %w", err)
+		return fmt.Errorf("creating dataset: %w", err)
 	} else if len(dset.Columns()) != len(innerColumns) {
-		return false, fmt.Errorf("dataset has %d columns, expected %d", len(dset.Columns()), len(innerColumns))
+		return fmt.Errorf("dataset has %d columns, expected %d", len(dset.Columns()), len(innerColumns))
 	}
 
 	columnLookup := map[*Column]dataset.Column{
@@ -697,7 +690,7 @@ func (r *Reader) ScanLabelsInto(ctx context.Context, acc *StreamScan, batchSize 
 	}
 	preds, err := mapPredicates([]Predicate{kindEq}, columnLookup)
 	if err != nil {
-		return false, fmt.Errorf("mapping predicates: %w", err)
+		return fmt.Errorf("mapping predicates: %w", err)
 	}
 
 	innerOptions := dataset.RowReaderOptions{
@@ -709,7 +702,7 @@ func (r *Reader) ScanLabelsInto(ctx context.Context, acc *StreamScan, batchSize 
 	adapter := columnar.NewReaderAdapter(innerOptions)
 	defer func() { _ = adapter.Close() }()
 	if err := adapter.Open(ctx); err != nil {
-		return false, fmt.Errorf("opening ScanLabels adapter: %w", err)
+		return fmt.Errorf("opening ScanLabels adapter: %w", err)
 	}
 
 	// Inner schema (8 fields) — must match the columnar batch column count/order.
@@ -724,32 +717,29 @@ func (r *Reader) ScanLabelsInto(ctx context.Context, acc *StreamScan, batchSize 
 		columnToField(colKind),
 	}, nil)
 
-	var productive bool
 	for {
 		colBatch, readErr := adapter.Read(ctx, r.alloc, batchSize)
 		if colBatch != nil && colBatch.NumRows() > 0 {
 			innerRB, convErr := arrowconv.ToRecordBatch(colBatch, innerSchema)
 			if convErr != nil {
-				return false, fmt.Errorf("converting ScanLabels columnar batch to arrow: %w", convErr)
+				return fmt.Errorf("converting ScanLabels columnar batch to arrow: %w", convErr)
 			}
-			batchProductive, err := accumulateStreamScan(
+			if err := accumulateStreamScan(
 				innerRB,
 				acc,
-			)
-			if err != nil {
-				return false, err
+			); err != nil {
+				return err
 			}
-			productive = productive || batchProductive
 		}
 		if errors.Is(readErr, io.EOF) {
 			break
 		}
 		if readErr != nil {
-			return false, fmt.Errorf("reading ScanLabels batch: %w", readErr)
+			return fmt.Errorf("reading ScanLabels batch: %w", readErr)
 		}
 	}
 
-	return productive, nil
+	return nil
 }
 
 // Finalize ANDs the per-matcher stream sets and scopes the accumulated pointer
@@ -852,39 +842,37 @@ func intersectMatcherStreams(perMatcherStreams map[matcherIndex]map[StreamRef]st
 func accumulateStreamScan(
 	rb arrow.RecordBatch,
 	acc *StreamScan,
-) (bool, error) {
+) error {
 	if rb.NumRows() == 0 {
-		return false, nil
+		return nil
 	}
-	var productive bool
-
 	objectPathCol, ok := rb.Column(0).(*array.String)
 	if !ok {
-		return productive, fmt.Errorf("ResolveStreamsAndPointers object_path has unexpected type %T", rb.Column(0))
+		return fmt.Errorf("ResolveStreamsAndPointers object_path has unexpected type %T", rb.Column(0))
 	}
 	sectionIndexCol, ok := rb.Column(1).(*array.Int64)
 	if !ok {
-		return productive, fmt.Errorf("ResolveStreamsAndPointers section_index has unexpected type %T", rb.Column(1))
+		return fmt.Errorf("ResolveStreamsAndPointers section_index has unexpected type %T", rb.Column(1))
 	}
 	columnNameCol, ok := rb.Column(2).(*array.String)
 	if !ok {
-		return productive, fmt.Errorf("ResolveStreamsAndPointers column_name has unexpected type %T", rb.Column(2))
+		return fmt.Errorf("ResolveStreamsAndPointers column_name has unexpected type %T", rb.Column(2))
 	}
 	labelValueCol, ok := rb.Column(3).(*array.String)
 	if !ok {
-		return productive, fmt.Errorf("ResolveStreamsAndPointers label_value has unexpected type %T", rb.Column(3))
+		return fmt.Errorf("ResolveStreamsAndPointers label_value has unexpected type %T", rb.Column(3))
 	}
 	bitmapCol, ok := rb.Column(4).(*array.Binary)
 	if !ok {
-		return productive, fmt.Errorf("ResolveStreamsAndPointers stream_id_bitmap has unexpected type %T", rb.Column(4))
+		return fmt.Errorf("ResolveStreamsAndPointers stream_id_bitmap has unexpected type %T", rb.Column(4))
 	}
 	minTsCol, ok := rb.Column(5).(*array.Timestamp)
 	if !ok {
-		return productive, fmt.Errorf("ResolveStreamsAndPointers min_timestamp has unexpected type %T", rb.Column(5))
+		return fmt.Errorf("ResolveStreamsAndPointers min_timestamp has unexpected type %T", rb.Column(5))
 	}
 	maxTsCol, ok := rb.Column(6).(*array.Timestamp)
 	if !ok {
-		return productive, fmt.Errorf("ResolveStreamsAndPointers max_timestamp has unexpected type %T", rb.Column(6))
+		return fmt.Errorf("ResolveStreamsAndPointers max_timestamp has unexpected type %T", rb.Column(6))
 	}
 
 	for i := 0; i < int(rb.NumRows()); i++ {
@@ -946,7 +934,6 @@ func accumulateStreamScan(
 		if len(matched) == 0 && !boundsOK {
 			continue
 		}
-		productive = true
 
 		// Single decode of the LSB bitmap: byte b, bit p set => streamID = b*8+p.
 		for byteIdx, b := range bitmapBytes {
@@ -991,7 +978,7 @@ func accumulateStreamScan(
 			}
 		}
 	}
-	return productive, nil
+	return nil
 }
 
 // mapPredicates translates a slice of postings [Predicate] values into the

--- a/pkg/dataobj/stat.go
+++ b/pkg/dataobj/stat.go
@@ -84,16 +84,4 @@ var (
 	// stream-ID pages. A single run means all relevant pages are back-to-back;
 	// a count equal to relevant pages means every relevant page is isolated.
 	StatStreamPageRuns = xcap.NewStatisticInt64("dataobj.stream.pages.runs", xcap.AggregationTypeSum)
-
-	// StatPostingsColumnNamePagesTotal is the total number of pages in the
-	// postings column-name column.
-	StatPostingsColumnNamePagesTotal = xcap.NewStatisticInt64("postings.column_name.pages.total", xcap.AggregationTypeSum)
-
-	// StatPostingsColumnNameRelevantPages is the number of postings column-name
-	// pages whose min/max range overlaps queried label names.
-	StatPostingsColumnNameRelevantPages = xcap.NewStatisticInt64("postings.column_name.pages.relevant", xcap.AggregationTypeSum)
-
-	// StatPostingsColumnNamePageRuns is the number of contiguous runs of
-	// relevant postings column-name pages.
-	StatPostingsColumnNamePageRuns = xcap.NewStatisticInt64("postings.column_name.pages.runs", xcap.AggregationTypeSum)
 )

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -24,7 +24,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
-	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
 	"github.com/grafana/loki/v3/pkg/engine/internal/deletion"
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/logical"
@@ -712,41 +711,13 @@ func (e *Engine) metastoreSectionsResolver(ctx context.Context, parent *query, l
 }
 
 func printMetastoreLocalitySummary(q *query, sectionsResolved int) {
-	var (
-		tocTables          = xcap.Value[int64](q.capture, metastore.StatMetastoreTocTables)
-		indexObjects       = xcap.Value[int64](q.capture, metastore.StatMetastoreIndexObjects)
-		sectionsOpened     = xcap.Value[int64](q.capture, metastore.StatMetastorePointerSectionsOpened)
-		sectionsProductive = xcap.Value[int64](q.capture, metastore.StatMetastorePointerSectionsProductive)
-
-		streamsRead  = xcap.Value[int64](q.capture, metastore.StatMetastoreStreamsRead)
-		pointersRead = xcap.Value[int64](q.capture, metastore.StatMetastoreSectionPointersRead)
-
-		postingsLabelsResolved           = xcap.Value[int64](q.capture, postings.StatPostingsLabelsResolved)
-		postingsPointersRead             = xcap.Value[int64](q.capture, postings.StatPostingsPointersRead)
-		postingsBloomRowsRead            = xcap.Value[int64](q.capture, postings.StatPostingsBloomRowsRead)
-		postingsBloomDeserializeFailures = xcap.Value[int64](q.capture, postings.StatPostingsBloomDeserializeFailures)
-
-		pagesTotal    = xcap.ValueFromRegion[int64](q.capture, postings.RegionPrefix, dataobj.StatPostingsColumnNamePagesTotal)
-		pagesRelevant = xcap.ValueFromRegion[int64](q.capture, postings.RegionPrefix, dataobj.StatPostingsColumnNameRelevantPages)
-		pageRuns      = xcap.ValueFromRegion[int64](q.capture, postings.RegionPrefix, dataobj.StatPostingsColumnNamePageRuns)
-	)
-
 	level.Info(q.Logger()).Log(
 		"msg", "metastore-locality-summary",
-		"toc_tables", tocTables,
-		"index_objects", indexObjects,
-		"index_sections_opened", sectionsOpened,
-		"index_sections_productive", sectionsProductive,
+		"toc_tables", xcap.Value[int64](q.capture, metastore.StatMetastoreTocTables),
+		"index_objects", xcap.Value[int64](q.capture, metastore.StatMetastoreIndexObjects),
+		"index_sections_opened", xcap.Value[int64](q.capture, metastore.StatMetastorePointerSectionsOpened),
+		"index_sections_productive", xcap.Value[int64](q.capture, metastore.StatMetastorePointerSectionsProductive),
 		"logs_sections_resolved", sectionsResolved,
-		"streams_read", streamsRead,
-		"pointers_read", pointersRead,
-		"postings_labels_resolved", postingsLabelsResolved,
-		"postings_pointers_read", postingsPointersRead,
-		"postings_bloom_rows_read", postingsBloomRowsRead,
-		"postings_bloom_deserialize_failures", postingsBloomDeserializeFailures,
-		"postings_column_name_pages_total", pagesTotal,
-		"postings_column_name_pages_relevant", pagesRelevant,
-		"postings_column_name_page_runs", pageRuns,
 	)
 }
 

--- a/pkg/engine/internal/workflow/admission_control.go
+++ b/pkg/engine/internal/workflow/admission_control.go
@@ -104,15 +104,6 @@ func isScanTask(task *Task) bool {
 	return false
 }
 
-func isPostingsScanTask(task *Task) bool {
-	for node := range task.Fragment.Graph().Nodes() {
-		if node.Type() == physical.NodeTypePointersScan {
-			return true
-		}
-	}
-	return false
-}
-
 func isCompactionTask(task *Task) bool {
 	for node := range task.Fragment.Graph().Nodes() {
 		switch node.Type() {

--- a/pkg/engine/internal/workflow/task_summary.go
+++ b/pkg/engine/internal/workflow/task_summary.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
-	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/schedulerstat"
@@ -96,9 +95,7 @@ func (wf *Workflow) printTaskSummary(task *Task, oldState TaskState, newStatus T
 		"cache_check", taskResultCacheOutcome(capture),
 	)
 
-	if isPostingsScanTask(task) {
-		wf.printTaskPostingsLocalitySummary(task, capture)
-	} else if isScanTask(task) {
+	if isScanTask(task) {
 		// print log section data locality as a separate log line.
 		wf.printTaskLogLocalitySummary(task, capture)
 	}
@@ -127,26 +124,6 @@ func (wf *Workflow) printTaskLogLocalitySummary(task *Task, capture *xcap.Captur
 		"stream_row_relevance", ratio(relevantRows, rowsTotal),
 		"stream_page_relevance", ratio(streamRelevantPages, streamPagesTotal),
 		"stream_page_fragmentation", ratio(streamPageRuns, streamRelevantPages),
-	)
-}
-
-func (wf *Workflow) printTaskPostingsLocalitySummary(task *Task, capture *xcap.Capture) {
-	pagesTotal := xcap.ValueFromRegion[int64](capture, postings.RegionPrefix, dataobj.StatPostingsColumnNamePagesTotal)
-	pagesRelevant := xcap.ValueFromRegion[int64](capture, postings.RegionPrefix, dataobj.StatPostingsColumnNameRelevantPages)
-	pageRuns := xcap.ValueFromRegion[int64](capture, postings.RegionPrefix, dataobj.StatPostingsColumnNamePageRuns)
-
-	level.Info(wf.logger).Log(
-		"msg", "task-postings-locality-summary",
-		// Identity
-		"task_id", task.ULID,
-		"query_id", wf.opts.ID,
-
-		// Locality
-		"postings_column_name_pages_total", pagesTotal,
-		"postings_column_name_pages_relevant", pagesRelevant,
-		"postings_column_name_page_runs", pageRuns,
-		"postings_page_relevance", ratio(pagesRelevant, pagesTotal),
-		"postings_page_fragmentation", ratio(pageRuns, pagesRelevant),
 	)
 }
 


### PR DESCRIPTION
## What

Add `BloomMatchPredicate` and `RegexMatchPredicate` to the dataset scan layer and wire them through predicate evaluation, validation, masking, and column selection.

## Why

The postings resolver pushes bloom membership and regex selection down into dataset scans rather than filtering after the fact. Both predicates are ineligible for page min/max pruning (a bloom or regex has no orderable statistics), so they fall back to a full-range scan.

## Stack

1. memory bitmap set algebra — #22550
2. dataset pushdown predicates — #22551
3. revert #22143 — #22580
4. postings Scanner primitives — #22582
5. metastore resolver + engine — #22583

_Based on #22550._