### PR TITLE
ci: Only run PR labeler on grafana/loki

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,9 +7,10 @@ permissions:
 
 jobs:
   triage:
+    # Only runs on the public grafana/loki repo: the loki-gh-app token broker isn't available elsewhere.
     # We don't run the triaging for PRs from forks because those can't use the loki-gh-app token broker.
     # We don't use GitHub actions app (secrets.GITHUB_TOKEN) because PRs created by the bot don't trigger CI.
-    if: ${{ ! github.event.pull_request.head.repo.fork }}
+    if: ${{ github.repository == 'grafana/loki' && ! github.event.pull_request.head.repo.fork }}
 
     runs-on: ubuntu-x64-small
     permissions:


### PR DESCRIPTION
## What this does

Gates the Pull Request Labeler job so it only runs on the public `grafana/loki` repo:

```yaml
if: ${{ github.repository == 'grafana/loki' && ! github.event.pull_request.head.repo.fork }}
```

## Why

The labeler mints a token from the `loki-gh-app` broker (`create-github-app-token`). That App/broker is only available on `grafana/loki`. On private copies and mirrors of the repo the token-generation step fails, so the workflow can never succeed there.

The existing fork guard is kept: external contributors open PRs from forks against `grafana/loki`, and those PRs also can't use the broker. The new `github.repository` check is independent of it — it gates on the base repo, while the fork check gates on the PR's head repo.