### PR TITLE
fix(distributor): Return HTTP 400 error when parsing unknown field in push payload

### DIFF
--- a/pkg/loghttp/query.go
+++ b/pkg/loghttp/query.go
@@ -123,6 +123,9 @@ func (s *LogProtoStream) UnmarshalJSON(data []byte) error {
 				return err
 			}
 			s.Entries = entries
+		default:
+			// return error when parsing unknown field
+			return errors.New("found unknown field: " + string(key))
 		}
 		return nil
 	})

--- a/pkg/util/unmarshal/legacy/unmarshal.go
+++ b/pkg/util/unmarshal/legacy/unmarshal.go
@@ -3,12 +3,14 @@ package unmarshal
 import (
 	"io"
 
-	json "github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
 // DecodePushRequest directly decodes json to a logproto.PushRequest
 func DecodePushRequest(b io.Reader, r *logproto.PushRequest) error {
-	return json.NewDecoder(b).Decode(r)
+	dec := jsoniter.NewDecoder(b)
+	dec.DisallowUnknownFields() // return error when parsing unknown field)
+	return dec.Decode(r)
 }

--- a/pkg/util/unmarshal/legacy/unmarshal_test.go
+++ b/pkg/util/unmarshal/legacy/unmarshal_test.go
@@ -1,7 +1,6 @@
 package unmarshal
 
 import (
-	"io"
 	"log"
 	"strings"
 	"testing"
@@ -14,29 +13,33 @@ import (
 
 // covers requests to /api/prom/push
 var pushTests = []struct {
-	expected []logproto.Stream
-	actual   string
+	expected    logproto.PushRequest
+	expectedErr bool
+	payload     string
 }{
 	{
-		[]logproto.Stream{
-			{
-				Entries: []logproto.Entry{
-					{
-						Timestamp: mustParse(time.RFC3339Nano, "2019-09-13T18:32:22.380001319Z"),
-						Line:      "super line",
-					},
-					{
-						Timestamp: mustParse(time.RFC3339Nano, "2019-09-13T18:32:23.380001319Z"),
-						Line:      "super line with labels",
-						StructuredMetadata: []logproto.LabelAdapter{
-							{Name: "a", Value: "1"},
-							{Name: "b", Value: "2"},
+		logproto.PushRequest{
+			Streams: []logproto.Stream{
+				{
+					Entries: []logproto.Entry{
+						{
+							Timestamp: mustParse(time.RFC3339Nano, "2019-09-13T18:32:22.380001319Z"),
+							Line:      "super line",
+						},
+						{
+							Timestamp: mustParse(time.RFC3339Nano, "2019-09-13T18:32:23.380001319Z"),
+							Line:      "super line with labels",
+							StructuredMetadata: []logproto.LabelAdapter{
+								{Name: "a", Value: "1"},
+								{Name: "b", Value: "2"},
+							},
 						},
 					},
+					Labels: `{test="test"}`,
 				},
-				Labels: `{test="test"}`,
 			},
 		},
+		false,
 		`{
 			"streams":[
 				{
@@ -59,18 +62,48 @@ var pushTests = []struct {
 			]
 		}`,
 	},
+
+	{
+		logproto.PushRequest{},
+		false,
+		`{}`,
+	},
+
+	{
+		logproto.PushRequest{},
+		true,
+		`{
+			"streams": [],
+			"invalid": true,
+		}`,
+	},
+
+	{
+		logproto.PushRequest{},
+		true,
+		`{
+			"streams": [
+			  {
+					"labels": "{}",
+					"invalid": [],
+				}
+			],
+		}`,
+	},
 }
 
 func Test_DecodePushRequest(t *testing.T) {
-
-	for i, pushTest := range pushTests {
+	for i, tt := range pushTests {
 		var actual logproto.PushRequest
-		closer := io.NopCloser(strings.NewReader(pushTest.actual))
+		r := strings.NewReader(tt.payload)
 
-		err := DecodePushRequest(closer, &actual)
-		require.NoError(t, err)
-
-		require.Equalf(t, pushTest.expected, actual.Streams, "Push Test %d failed", i)
+		err := DecodePushRequest(r, &actual)
+		if tt.expectedErr {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			require.Equalf(t, tt.expected, actual, "Push Test %d failed", i)
+		}
 	}
 }
 

--- a/pkg/util/unmarshal/unmarshal.go
+++ b/pkg/util/unmarshal/unmarshal.go
@@ -14,7 +14,9 @@ import (
 func DecodePushRequest(b io.Reader, r *logproto.PushRequest) error {
 	var request loghttp.PushRequest
 
-	if err := jsoniter.NewDecoder(b).Decode(&request); err != nil {
+	dec := jsoniter.NewDecoder(b)
+	dec.DisallowUnknownFields() // return error when parsing unknown field
+	if err := dec.Decode(&request); err != nil {
 		return err
 	}
 

--- a/pkg/util/unmarshal/unmarshal_test.go
+++ b/pkg/util/unmarshal/unmarshal_test.go
@@ -159,6 +159,34 @@ func Test_DecodePushRequest(t *testing.T) {
 			]
 		}`,
 		},
+
+		{
+			name:        "invalid top level field",
+			expected:    nil,
+			expectedErr: true,
+			actual: `{
+				"invalid": {}
+			}`,
+		},
+
+		{
+			name:        "invalid field",
+			expected:    nil,
+			expectedErr: true,
+			actual: `{
+				"streams": [
+				  {
+						"stream": {
+					    "job": "push-payload-test"
+						},
+						"values": [
+						  ["123456789012345", "super line"]
+						]
+						"invalid": []
+				  },
+				]
+			}`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var actual logproto.PushRequest


### PR DESCRIPTION
### Summary

Loki still supports two push endpoints: the regular `/loki/api/v1/push` and the legacy (long deprecated) `/api/prom/push`. They also have different push payload formats:

**regular**

```json
{
  "streams": [
    {
      "stream": {<LABELS>},
      "values": [
        ["<TIMESTAMP>", "<LOGLINE>"],
        ...
      ]      
    },
    ...
  ]
}
```

vs **legacy**

```json
{
  "streams": [
    {
      "labels": "<JSON_ENCODED_LABELS>",
      "entries": [
        {"ts": "<TIMESTAMP>", "line": "<LOGLINE>"},
        ...
      ]
    },
    ...
  ]
}
```

#### Test

With this PR, both the legacy endpoint and the regular endpoint return an error when an unknown field is detected in the payload when parsing the JSON.

Previously, sending a wrong payload schema would result in unnoticed data loss.

```
Executing legacy.json on /api/prom/push => 204
loghttp.PushRequest.Streams: []loghttp.LogProtoStream: unmarshalerDecoder: found unknown field: labels, error found in #10 byte of ...|   ]
    }
  ]
}|..., bigger context ...|at 2026-06-23T08:13:50.1782202430Z"}
      ]
    }
  ]
}|...
Executing legacy.json on /loki/api/v1/push => 400
push.PushRequest.Streams: []push.Stream: push.Stream.ReadObject: found unknown field: stream, error found in #10 byte of ...|  "stream": {"job": |..., bigger context ...|{
  "streams": [
    {
      "stream": {"job": "payload-push-test"},
      "values": [
|...
Executing payload.json on /api/prom/push => 400
Executing payload.json on /loki/api/v1/push => 204
```