### PR TITLE
feat: Add a minimum number of shuffle shard size in index gateway client

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -6834,6 +6834,12 @@ tsdb_shipper:
     # CLI flag: -tsdb.shipper.index-gateway-client.time-based-sharding-buckets
     [time_based_sharding_buckets: <list of strings> | default = []]
 
+    # Minimum number of index gateway instances included in the shuffle shard,
+    # regardless of the max-capacity setting. A value of 0 disables the minimum.
+    # Only applies to simple mode.
+    # CLI flag: -tsdb.shipper.index-gateway-client.min-shuffle-shard-size
+    [min_shuffle_shard_size: <int> | default = 3]
+
   [ingestername: <string> | default = ""]
 
   [mode: <string> | default = ""]

--- a/pkg/indexgateway/client.go
+++ b/pkg/indexgateway/client.go
@@ -76,6 +76,10 @@ type ClientConfig struct {
 	GRCPStreamClientInterceptors []grpc.StreamClientInterceptor `yaml:"-"`
 
 	TimeBasedShardingBuckets []string `yaml:"time_based_sharding_buckets" category:"Experimental"`
+
+	// MinShuffleShardSize is the minimum number of index gateway instances included in the
+	// shuffle shard, regardless of the max-capacity setting. Only applies to simple mode.
+	MinShuffleShardSize int `yaml:"min_shuffle_shard_size"`
 }
 
 // RegisterFlagsWithPrefix register client-specific flags with the given prefix.
@@ -92,6 +96,7 @@ func (i *ClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 		prefix+".time-based-sharding-buckets",
 		"Experimental: Defines buckets for time-based sharding. Time based sharding only takes affect when index gateways run in simple mode. To enable client side time-based sharding of queries across index gateway instances set at least one bucket in the format of a string representation of a time.Duration, e.g. ['168h', '336h', '504h']",
 	)
+	f.IntVar(&i.MinShuffleShardSize, prefix+".min-shuffle-shard-size", 3, "Minimum number of index gateway instances included in the shuffle shard, regardless of the max-capacity setting. A value of 0 disables the minimum. Only applies to simple mode.")
 }
 
 func (i *ClientConfig) RegisterFlags(f *flag.FlagSet) {
@@ -458,6 +463,9 @@ func (s *GatewayClient) jumpHashShuffleSharding(tenant string, addrs []string) [
 
 	maxAvailableGateways := len(addrs)
 	numUserGateways := int(math.Ceil(float64(maxAvailableGateways) * f))
+	if numUserGateways < s.cfg.MinShuffleShardSize {
+		numUserGateways = s.cfg.MinShuffleShardSize
+	}
 	if numUserGateways >= maxAvailableGateways {
 		return addrs
 	}

--- a/pkg/indexgateway/client_test.go
+++ b/pkg/indexgateway/client_test.go
@@ -376,16 +376,75 @@ func Test_jumpHashShuffleSharding(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			mockLimits := &mockLimits{maxCapacity: tt.factor}
-			client := &GatewayClient{limits: mockLimits}
+			// MinShuffleShardSize=0 so the floor does not interfere with these cases
+			client := &GatewayClient{limits: mockLimits, cfg: ClientConfig{MinShuffleShardSize: 0}}
 
 			result := client.jumpHashShuffleSharding("tenant1", tt.input)
 			require.Equal(t, tt.expected, result)
 		})
 	}
 
+	t.Run("min shard size", func(t *testing.T) {
+		tenGateways := func() []string {
+			addrs := make([]string, 10)
+			for i := range addrs {
+				addrs[i] = fmt.Sprintf("gateway-%d", i)
+			}
+			return addrs
+		}()
+
+		tests := []struct {
+			description  string
+			addrs        []string
+			factor       float64
+			minShardSize int
+			expectedLen  int
+		}{
+			{
+				description:  "floors the computed size",
+				addrs:        tenGateways,
+				factor:       0.1, // ceil(10*0.1)=1, raised to min=3
+				minShardSize: 3,
+				expectedLen:  3,
+			},
+			{
+				description:  "does not reduce a larger computed size",
+				addrs:        tenGateways,
+				factor:       0.5, // ceil(10*0.5)=5, already > min=3
+				minShardSize: 3,
+				expectedLen:  5,
+			},
+			{
+				description:  "0 disables the floor",
+				addrs:        tenGateways,
+				factor:       0.1, // ceil(10*0.1)=1, min=0 leaves it at 1
+				minShardSize: 0,
+				expectedLen:  1,
+			},
+			{
+				description:  "capped at total available gateways",
+				addrs:        []string{"gateway-0", "gateway-1", "gateway-2", "gateway-3"},
+				factor:       0.1, // ceil(4*0.1)=1, min=10 exceeds total so returns all 4
+				minShardSize: 10,
+				expectedLen:  4,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.description, func(t *testing.T) {
+				client := &GatewayClient{
+					limits: &mockLimits{maxCapacity: tt.factor},
+					cfg:    ClientConfig{MinShuffleShardSize: tt.minShardSize},
+				}
+				result := client.jumpHashShuffleSharding("tenant1", tt.addrs)
+				require.Len(t, result, tt.expectedLen)
+			})
+		}
+	})
+
 	t.Run("same tenant gets same subset", func(t *testing.T) {
 		mockLimits := &mockLimits{maxCapacity: 0.5}
-		client := &GatewayClient{limits: mockLimits}
+		client := &GatewayClient{limits: mockLimits, cfg: ClientConfig{MinShuffleShardSize: 0}}
 
 		addrs := []string{"gateway-1", "gateway-2", "gateway-3"}
 
@@ -400,7 +459,7 @@ func Test_jumpHashShuffleSharding(t *testing.T) {
 
 	t.Run("different tenants get different subsets", func(t *testing.T) {
 		mockLimits := &mockLimits{maxCapacity: 0.3}
-		client := &GatewayClient{limits: mockLimits}
+		client := &GatewayClient{limits: mockLimits, cfg: ClientConfig{MinShuffleShardSize: 0}}
 
 		addrs := make([]string, 9)
 		for i := range len(addrs) {


### PR DESCRIPTION
Currently, the effective minimum is 1. This is dangerous because it can result in an outage during a routine deployment, or a single pod going down. I've raised the default to 3, and added a config option to allow this to be tweaked.