### PR TITLE
fix(operator): Emit empty telemetry labels when status is unknown

### DIFF
--- a/operator/internal/metrics/lokistack.go
+++ b/operator/internal/metrics/lokistack.go
@@ -93,7 +93,7 @@ func (l *lokiStackCollector) Collect(m chan<- prometheus.Metric) {
 
 		infoLabels := append(labels,
 			string(stack.Spec.Storage.Secret.Type),
-			storageCredentialsMode(&stack),
+			string(stack.Status.Storage.CredentialMode),
 			currentSchemaVersion(&stack),
 			tenancyMode(&stack),
 		)
@@ -159,16 +159,9 @@ func (l *lokiStackCollector) Collect(m chan<- prometheus.Metric) {
 	}
 }
 
-func storageCredentialsMode(stack *lokiv1.LokiStack) string {
-	if stack.Spec.Storage.Secret.CredentialMode != "" {
-		return string(stack.Spec.Storage.Secret.CredentialMode)
-	}
-	return string(lokiv1.CredentialModeStatic)
-}
-
 func currentSchemaVersion(stack *lokiv1.LokiStack) string {
 	if len(stack.Status.Storage.Schemas) == 0 {
-		return string(lokiv1.ObjectStorageSchemaV11)
+		return ""
 	}
 
 	return string(stack.Status.Storage.Schemas[len(stack.Status.Storage.Schemas)-1].Version)
@@ -216,8 +209,9 @@ func componentReplicas(stack *lokiv1.LokiStack, defaults *lokiv1.LokiStackSpec) 
 }
 
 func tenancyMode(stack *lokiv1.LokiStack) string {
-	if stack.Spec.Tenants == nil || stack.Spec.Tenants.Mode == "" {
-		return "static"
+	if stack.Spec.Tenants == nil {
+		return ""
 	}
+
 	return string(stack.Spec.Tenants.Mode)
 }

--- a/operator/internal/metrics/lokistack_test.go
+++ b/operator/internal/metrics/lokistack_test.go
@@ -60,6 +60,7 @@ func TestLokiStackMetricsCollect(t *testing.T) {
 						},
 						Status: lokiv1.LokiStackStatus{
 							Storage: lokiv1.LokiStackStorageStatus{
+								CredentialMode: lokiv1.CredentialModeStatic,
 								Schemas: []lokiv1.ObjectStorageSchema{
 									{
 										Version:       lokiv1.ObjectStorageSchemaV11,
@@ -86,7 +87,72 @@ lokistack_component_replicas{component="ruler",size="1x.demo",stack_name="test-s
 lokistack_global_ingestion_rate_limit_bytes{size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace"} 4194304
 # HELP lokistack_info Information about deployed LokiStack instances. Value is always 1.
 # TYPE lokistack_info gauge
-lokistack_info{credential_mode="static",object_storage_type="s3",schema_version="v11",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace",tenancy_mode="static"} 1
+lokistack_info{credential_mode="static",object_storage_type="s3",schema_version="v11",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace",tenancy_mode=""} 1
+# HELP lokistack_status_condition Counts the current status conditions of the LokiStack.
+# TYPE lokistack_status_condition gauge
+lokistack_status_condition{condition="Degraded",reason="",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace",status="false"} 1
+lokistack_status_condition{condition="Degraded",reason="",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace",status="true"} 0
+lokistack_status_condition{condition="Failed",reason="",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace",status="false"} 1
+lokistack_status_condition{condition="Failed",reason="",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace",status="true"} 0
+lokistack_status_condition{condition="Pending",reason="",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace",status="false"} 1
+lokistack_status_condition{condition="Pending",reason="",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace",status="true"} 0
+lokistack_status_condition{condition="Ready",reason="",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace",status="false"} 1
+lokistack_status_condition{condition="Ready",reason="",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace",status="true"} 0
+`,
+		},
+		{
+			desc:     "demo with different tenancy and credential-mode",
+			k8sError: nil,
+			stacks: &lokiv1.LokiStackList{
+				Items: []lokiv1.LokiStack{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-stack",
+							Namespace: "test-namespace",
+						},
+						Spec: lokiv1.LokiStackSpec{
+							Size: lokiv1.SizeOneXDemo,
+							Storage: lokiv1.ObjectStorageSpec{
+								Secret: lokiv1.ObjectStorageSecretSpec{
+									CredentialMode: lokiv1.CredentialModeToken,
+									Type:           lokiv1.ObjectStorageSecretS3,
+									Name:           "storage-secret",
+								},
+							},
+							Tenants: &lokiv1.TenantsSpec{
+								Mode: lokiv1.Static,
+							},
+						},
+						Status: lokiv1.LokiStackStatus{
+							Storage: lokiv1.LokiStackStorageStatus{
+								CredentialMode: lokiv1.CredentialModeToken,
+								Schemas: []lokiv1.ObjectStorageSchema{
+									{
+										Version:       lokiv1.ObjectStorageSchemaV11,
+										EffectiveDate: "2020-01-01",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantMetrics: `# HELP lokistack_component_replicas Replica count for components.
+# TYPE lokistack_component_replicas gauge
+lokistack_component_replicas{component="compactor",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace"} 1
+lokistack_component_replicas{component="distributor",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace"} 1
+lokistack_component_replicas{component="gateway",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace"} 2
+lokistack_component_replicas{component="index-gateway",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace"} 1
+lokistack_component_replicas{component="ingester",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace"} 1
+lokistack_component_replicas{component="querier",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace"} 1
+lokistack_component_replicas{component="query-frontend",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace"} 1
+lokistack_component_replicas{component="ruler",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace"} 1
+# HELP lokistack_global_ingestion_rate_limit_bytes Global ingestion rate limit in bytes.
+# TYPE lokistack_global_ingestion_rate_limit_bytes gauge
+lokistack_global_ingestion_rate_limit_bytes{size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace"} 4194304
+# HELP lokistack_info Information about deployed LokiStack instances. Value is always 1.
+# TYPE lokistack_info gauge
+lokistack_info{credential_mode="token",object_storage_type="s3",schema_version="v11",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace",tenancy_mode="static"} 1
 # HELP lokistack_status_condition Counts the current status conditions of the LokiStack.
 # TYPE lokistack_status_condition gauge
 lokistack_status_condition{condition="Degraded",reason="",size="1x.demo",stack_name="test-stack",stack_namespace="test-namespace",status="false"} 1
@@ -127,6 +193,7 @@ lokistack_status_condition{condition="Ready",reason="",size="1x.demo",stack_name
 								},
 							},
 							Storage: lokiv1.LokiStackStorageStatus{
+								CredentialMode: lokiv1.CredentialModeStatic,
 								Schemas: []lokiv1.ObjectStorageSchema{
 									{
 										Version:       lokiv1.ObjectStorageSchemaV11,
@@ -153,7 +220,7 @@ lokistack_component_replicas{component="ruler",size="1x.small",stack_name="test-
 lokistack_global_ingestion_rate_limit_bytes{size="1x.small",stack_name="test-stack",stack_namespace="test-namespace"} 15728640
 # HELP lokistack_info Information about deployed LokiStack instances. Value is always 1.
 # TYPE lokistack_info gauge
-lokistack_info{credential_mode="static",object_storage_type="s3",schema_version="v11",size="1x.small",stack_name="test-stack",stack_namespace="test-namespace",tenancy_mode="static"} 1
+lokistack_info{credential_mode="static",object_storage_type="s3",schema_version="v11",size="1x.small",stack_name="test-stack",stack_namespace="test-namespace",tenancy_mode=""} 1
 # HELP lokistack_status_condition Counts the current status conditions of the LokiStack.
 # TYPE lokistack_status_condition gauge
 lokistack_status_condition{condition="Degraded",reason="",size="1x.small",stack_name="test-stack",stack_namespace="test-namespace",status="false"} 1
@@ -206,6 +273,7 @@ lokistack_status_condition{condition="Warning",reason="StorageNeedsSchemaUpdate"
 								},
 							},
 							Storage: lokiv1.LokiStackStorageStatus{
+								CredentialMode: lokiv1.CredentialModeStatic,
 								Schemas: []lokiv1.ObjectStorageSchema{
 									{
 										Version:       lokiv1.ObjectStorageSchemaV11,
@@ -232,7 +300,7 @@ lokistack_component_replicas{component="ruler",size="1x.small",stack_name="test-
 lokistack_global_ingestion_rate_limit_bytes{size="1x.small",stack_name="test-stack",stack_namespace="test-namespace"} 15728640
 # HELP lokistack_info Information about deployed LokiStack instances. Value is always 1.
 # TYPE lokistack_info gauge
-lokistack_info{credential_mode="static",object_storage_type="s3",schema_version="v11",size="1x.small",stack_name="test-stack",stack_namespace="test-namespace",tenancy_mode="static"} 1
+lokistack_info{credential_mode="static",object_storage_type="s3",schema_version="v11",size="1x.small",stack_name="test-stack",stack_namespace="test-namespace",tenancy_mode=""} 1
 # HELP lokistack_status_condition Counts the current status conditions of the LokiStack.
 # TYPE lokistack_status_condition gauge
 lokistack_status_condition{condition="Degraded",reason="",size="1x.small",stack_name="test-stack",stack_namespace="test-namespace",status="false"} 1
@@ -245,6 +313,63 @@ lokistack_status_condition{condition="Ready",reason="ReadyComponents",size="1x.s
 lokistack_status_condition{condition="Ready",reason="ReadyComponents",size="1x.small",stack_name="test-stack",stack_namespace="test-namespace",status="true"} 1
 lokistack_status_condition{condition="Warning",reason="StorageNeedsSchemaUpdate",size="1x.small",stack_name="test-stack",stack_namespace="test-namespace",status="false"} 1
 lokistack_status_condition{condition="Warning",reason="StorageNeedsSchemaUpdate",size="1x.small",stack_name="test-stack",stack_namespace="test-namespace",status="true"} 0
+`,
+		},
+		{
+			desc:     "stack with no status",
+			k8sError: nil,
+			stacks: &lokiv1.LokiStackList{
+				Items: []lokiv1.LokiStack{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "storage-stack",
+							Namespace: "test-ns",
+						},
+						Spec: lokiv1.LokiStackSpec{
+							Size: lokiv1.SizeOneXSmall,
+							Storage: lokiv1.ObjectStorageSpec{
+								Secret: lokiv1.ObjectStorageSecretSpec{
+									Type:           lokiv1.ObjectStorageSecretS3,
+									Name:           "s3-secret",
+									CredentialMode: lokiv1.CredentialModeToken,
+								},
+								Schemas: []lokiv1.ObjectStorageSchema{
+									{
+										Version:       lokiv1.ObjectStorageSchemaV13,
+										EffectiveDate: "2025-01-01",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantMetrics: `# HELP lokistack_component_replicas Replica count for components.
+# TYPE lokistack_component_replicas gauge
+lokistack_component_replicas{component="compactor",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns"} 1
+lokistack_component_replicas{component="distributor",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns"} 2
+lokistack_component_replicas{component="gateway",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns"} 2
+lokistack_component_replicas{component="index-gateway",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns"} 2
+lokistack_component_replicas{component="ingester",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns"} 3
+lokistack_component_replicas{component="querier",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns"} 2
+lokistack_component_replicas{component="query-frontend",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns"} 2
+lokistack_component_replicas{component="ruler",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns"} 2
+# HELP lokistack_global_ingestion_rate_limit_bytes Global ingestion rate limit in bytes.
+# TYPE lokistack_global_ingestion_rate_limit_bytes gauge
+lokistack_global_ingestion_rate_limit_bytes{size="1x.small",stack_name="storage-stack",stack_namespace="test-ns"} 15728640
+# HELP lokistack_info Information about deployed LokiStack instances. Value is always 1.
+# TYPE lokistack_info gauge
+lokistack_info{credential_mode="",object_storage_type="s3",schema_version="",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns",tenancy_mode=""} 1
+# HELP lokistack_status_condition Counts the current status conditions of the LokiStack.
+# TYPE lokistack_status_condition gauge
+lokistack_status_condition{condition="Degraded",reason="",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns",status="false"} 1
+lokistack_status_condition{condition="Degraded",reason="",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns",status="true"} 0
+lokistack_status_condition{condition="Failed",reason="",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns",status="false"} 1
+lokistack_status_condition{condition="Failed",reason="",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns",status="true"} 0
+lokistack_status_condition{condition="Pending",reason="",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns",status="false"} 1
+lokistack_status_condition{condition="Pending",reason="",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns",status="true"} 0
+lokistack_status_condition{condition="Ready",reason="",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns",status="false"} 1
+lokistack_status_condition{condition="Ready",reason="",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns",status="true"} 0
 `,
 		},
 		{
@@ -310,7 +435,7 @@ lokistack_component_replicas{component="ruler",size="1x.small",stack_name="stora
 lokistack_global_ingestion_rate_limit_bytes{size="1x.small",stack_name="storage-stack",stack_namespace="test-ns"} 15728640
 # HELP lokistack_info Information about deployed LokiStack instances. Value is always 1.
 # TYPE lokistack_info gauge
-lokistack_info{credential_mode="token",object_storage_type="s3",schema_version="v13",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns",tenancy_mode="static"} 1
+lokistack_info{credential_mode="token",object_storage_type="s3",schema_version="v13",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns",tenancy_mode=""} 1
 # HELP lokistack_status_condition Counts the current status conditions of the LokiStack.
 # TYPE lokistack_status_condition gauge
 lokistack_status_condition{condition="Degraded",reason="",size="1x.small",stack_name="storage-stack",stack_namespace="test-ns",status="false"} 1
@@ -358,6 +483,7 @@ lokistack_status_condition{condition="Ready",reason="",size="1x.small",stack_nam
 						},
 						Status: lokiv1.LokiStackStatus{
 							Storage: lokiv1.LokiStackStorageStatus{
+								CredentialMode: lokiv1.CredentialModeStatic,
 								Schemas: []lokiv1.ObjectStorageSchema{
 									{
 										Version:       lokiv1.ObjectStorageSchemaV13,
@@ -384,7 +510,7 @@ lokistack_component_replicas{component="ruler",size="1x.small",stack_name="custo
 lokistack_global_ingestion_rate_limit_bytes{size="1x.small",stack_name="custom-stack",stack_namespace="test-ns"} 15728640
 # HELP lokistack_info Information about deployed LokiStack instances. Value is always 1.
 # TYPE lokistack_info gauge
-lokistack_info{credential_mode="static",object_storage_type="gcs",schema_version="v13",size="1x.small",stack_name="custom-stack",stack_namespace="test-ns",tenancy_mode="static"} 1
+lokistack_info{credential_mode="static",object_storage_type="gcs",schema_version="v13",size="1x.small",stack_name="custom-stack",stack_namespace="test-ns",tenancy_mode=""} 1
 # HELP lokistack_status_condition Counts the current status conditions of the LokiStack.
 # TYPE lokistack_status_condition gauge
 lokistack_status_condition{condition="Degraded",reason="",size="1x.small",stack_name="custom-stack",stack_namespace="test-ns",status="false"} 1
@@ -453,7 +579,7 @@ lokistack_component_replicas{component="ruler",size="1x.medium",stack_name="full
 lokistack_global_ingestion_rate_limit_bytes{size="1x.medium",stack_name="full-stack",stack_namespace="logging"} 104857600
 # HELP lokistack_info Information about deployed LokiStack instances. Value is always 1.
 # TYPE lokistack_info gauge
-lokistack_info{credential_mode="token-cco",object_storage_type="s3",schema_version="v11",size="1x.medium",stack_name="full-stack",stack_namespace="logging",tenancy_mode="static"} 1
+lokistack_info{credential_mode="token-cco",object_storage_type="s3",schema_version="v11",size="1x.medium",stack_name="full-stack",stack_namespace="logging",tenancy_mode=""} 1
 # HELP lokistack_status_condition Counts the current status conditions of the LokiStack.
 # TYPE lokistack_status_condition gauge
 lokistack_status_condition{condition="Degraded",reason="",size="1x.medium",stack_name="full-stack",stack_namespace="logging",status="false"} 1


### PR DESCRIPTION
**What this PR does / why we need it**:

The telemetry code currently emits "known defaults" when the LokiStack has no status yet, possibly skewing statistics towards old defaults. This PR changes this behavior to emit empty labels instead.

It also reads the `CredentialMode` from the status instead of spec, so that changed defaults on certain clusters are properly reflected.

**Which issue(s) this PR fixes**:

Refs https://redhat.atlassian.net/browse/LOG-9540

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
