### PR TITLE
fix(operator): Use native AWS Auth when STS is enabled

### DIFF
--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -28,6 +28,7 @@ common:
         bucket_name: {{ .Buckets }}
         region: {{ .Region }}
         endpoint: s3.{{.Region}}.amazonaws.com
+        native_aws_auth_enabled: true
         {{- else }}
         endpoint: {{ .Endpoint }}
         bucket_name: {{ .Buckets }}

--- a/operator/internal/manifests/internal/config/testdata/sts/config.yaml
+++ b/operator/internal/manifests/internal/config/testdata/sts/config.yaml
@@ -11,6 +11,7 @@ common:
       s3:
         bucket_name: my-bucket
         endpoint: s3.my-region.amazonaws.com
+        native_aws_auth_enabled: true
         region: my-region
   compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
   ring:


### PR DESCRIPTION
**What this PR does / why we need it**:
On AWS STS clusters with CCO (Cloud Credential Operator), credentials are delivered via AWS_SHARED_CREDENTIALS_FILE environment variable. The objstore/minio-go client does not support this credential method. The thanos/objstore has a config flag to instead of minio use the AWS SDK v2 for Auth.

**Which issue(s) this PR fixes**:
https://redhat.atlassian.net/browse/LOG-9539

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
