### PR TITLE
fix(dataobj-explorer): Prevent arbitrary file read via path traversal

### DIFF
--- a/pkg/dataobj/explorer/download.go
+++ b/pkg/dataobj/explorer/download.go
@@ -20,6 +20,10 @@ func (s *Service) handleDownload(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "file parameter is required", http.StatusBadRequest)
 		return
 	}
+	if err := validateObjectKey(filename); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	attrs, err := s.bucket.Attributes(r.Context(), filename)
 	if err != nil {

--- a/pkg/dataobj/explorer/inspect.go
+++ b/pkg/dataobj/explorer/inspect.go
@@ -92,6 +92,10 @@ func (s *Service) handleInspect(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "file parameter is required", http.StatusBadRequest)
 		return
 	}
+	if err := validateObjectKey(filename); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	attrs, err := s.bucket.Attributes(r.Context(), filename)
 	if err != nil {

--- a/pkg/dataobj/explorer/list.go
+++ b/pkg/dataobj/explorer/list.go
@@ -30,6 +30,12 @@ func (s *Service) handleList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	dir := r.URL.Query().Get("path")
+	if dir != "" {
+		if err := validateObjectKey(dir); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
 	level.Debug(s.logger).Log("msg", "listing directory", "path", dir)
 
 	files := make([]fileInfo, 0)

--- a/pkg/dataobj/explorer/service.go
+++ b/pkg/dataobj/explorer/service.go
@@ -3,13 +3,32 @@ package explorer
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
+	"path/filepath"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/services"
 	"github.com/thanos-io/objstore"
 )
+
+// errInvalidObjectKey is returned for a request key that could escape the
+// configured object store root. The filesystem backend joins the key onto its
+// root directory with no containment, so a key like "../../etc/passwd" would
+// otherwise resolve to an arbitrary path on the host.
+var errInvalidObjectKey = errors.New("invalid path: must stay within the object store root")
+
+// validateObjectKey rejects absolute keys and keys with ".." segments that
+// traverse outside the bucket root. filepath.IsLocal mirrors the filepath.Join
+// the filesystem backend uses, so it accepts ordinary object keys and rejects
+// exactly the keys that would escape.
+func validateObjectKey(key string) error {
+	if !filepath.IsLocal(key) {
+		return errInvalidObjectKey
+	}
+	return nil
+}
 
 type Service struct {
 	*services.BasicService

--- a/pkg/dataobj/explorer/traversal_test.go
+++ b/pkg/dataobj/explorer/traversal_test.go
@@ -1,0 +1,94 @@
+package explorer
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore/providers/filesystem"
+)
+
+// newFilesystemService returns an explorer backed by the filesystem object
+// store rooted at root. The filesystem backend joins request keys onto root
+// without containment, which is the backend the traversal tests exercise.
+func newFilesystemService(t *testing.T, root string) *Service {
+	t.Helper()
+
+	bkt, err := filesystem.NewBucket(root)
+	require.NoError(t, err)
+
+	svc, err := New(bkt, log.NewNopLogger())
+	require.NoError(t, err)
+	return svc
+}
+
+func TestHandlersRejectPathTraversal(t *testing.T) {
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "bucket")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+
+	// A secret file outside the bucket root that must never be reachable.
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "secret.txt"), []byte("top secret"), 0o600))
+	// A legitimate object inside the root.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "object.dat"), []byte("ok"), 0o600))
+
+	svc := newFilesystemService(t, root)
+
+	traversals := []string{"../secret.txt", "../../etc/passwd", "/etc/passwd"}
+
+	for _, key := range traversals {
+		t.Run("download "+key, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/dataobj/api/v1/download?file="+key, nil)
+			svc.handleDownload(rr, req)
+
+			require.Equal(t, http.StatusBadRequest, rr.Code)
+			body, _ := io.ReadAll(rr.Result().Body)
+			require.NotContains(t, string(body), "top secret")
+		})
+
+		t.Run("inspect "+key, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/dataobj/api/v1/inspect?file="+key, nil)
+			svc.handleInspect(rr, req)
+
+			require.Equal(t, http.StatusBadRequest, rr.Code)
+		})
+
+		t.Run("list "+key, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/dataobj/api/v1/list?path="+key, nil)
+			svc.handleList(rr, req)
+
+			require.Equal(t, http.StatusBadRequest, rr.Code)
+		})
+	}
+}
+
+func TestHandlersAllowInRootKeys(t *testing.T) {
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "bucket")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "object.dat"), []byte("ok"), 0o600))
+
+	svc := newFilesystemService(t, root)
+
+	// A normal in-root download still works.
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/dataobj/api/v1/download?file=object.dat", nil)
+	svc.handleDownload(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	body, _ := io.ReadAll(rr.Result().Body)
+	require.Equal(t, "ok", string(body))
+
+	// Listing the root (empty path) is allowed.
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/dataobj/api/v1/list", nil)
+	svc.handleList(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The dataobj explorer handlers take an object key straight from the request (`?file=` in `download`/`inspect`, `?path=` in `list`) and hand it to the object store with no containment. On the filesystem backend the key is `filepath.Join`ed onto the store root, so `..` segments resolve outside it and any file on the host becomes readable through the explorer, which is mounted on the HTTP server without auth.

The join happens in the thanos filesystem provider, so the guard has to sit in the handlers. `validateObjectKey` rejects absolute keys and `..` traversal with `filepath.IsLocal`, which mirrors the join the backend performs; ordinary keys and the root listing still pass.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

Against a filesystem-backed store, before:

    GET /dataobj/api/v1/download?file=../secret.txt   ->  200, body is the out-of-root file

After the same request returns 400. The new test drives all three handlers with `../`, `../../etc/passwd`, and `/etc/passwd`, and keeps an in-root download and the empty-path root listing working.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.
