### PR TITLE
docs: Update Release Notes 3.6.12

### DIFF
--- a/docs/sources/release-notes/v3-6.md
+++ b/docs/sources/release-notes/v3-6.md
@@ -42,7 +42,6 @@ Other improvements include the following:
 * **compactor HS:** Add a dashboard for monitoring deletion with horizontally scalable compactor ([#18588](https://github.com/grafana/loki/issues/18588)) ([10db8ab](https://github.com/grafana/loki/commit/10db8abb58742a252e2a0b47355ca715031b0e9f))
 * **compactor HS:** Add a job runner for processing of deletion jobs ([#18058](https://github.com/grafana/loki/issues/18058))
 * **compactor HS:** Add job queue and deletion job builder ([#17843](https://github.com/grafana/loki/issues/17843))
-(#17843)
 * **compactor HS:** Add jsonnet for deploying horizontally scalable compactor ([#18550](https://github.com/grafana/loki/issues/18550)) ([5e28950](https://github.com/grafana/loki/commit/5e28950556c6ba0f97db8b5450bec89c82fbd682))
 * **compactor HS:** Add support for applying storage updates after finishing processing of deletion manifest ([#18294](https://github.com/grafana/loki/issues/18294)) ([ba3c670](https://github.com/grafana/loki/commit/ba3c67076a87d7916faef49e10573511988387b7))
 * **compactor HS:** Add support for worker for processing of jobs from the compactor's job queue ([#18165](https://github.com/grafana/loki/issues/18165)) ([d05c4bc](https://github.com/grafana/loki/commit/d05c4bc500be779f35b6e25823da940a6e236229))
@@ -91,7 +90,6 @@ Other improvements include the following:
 * **helm:** Allow enabling user namespaces ([#18661](https://github.com/grafana/loki/issues/18661))
 * **helm:** Allow external memcached setup ([#17432](https://github.com/grafana/loki/issues/17432)) ([013aa17](https://github.com/grafana/loki/commit/013aa17716dd96b7bd2004d8388f1f03f5b6efee))
 * **helm:** Allow extraObjects to be defined as either a list or dictionary.([#13252](https://github.com/grafana/loki/issues/13252))
-(#13252)
 * **helm:** Allow passing tenant password hash instead of password ([#17049](https://github.com/grafana/loki/issues/17049)) ([20b97f7](https://github.com/grafana/loki/commit/20b97f77b0ae381f0c6dc16368f34e27f0e81141))
 * **helm:** Allow setting labels for ingesters ([#18536](https://github.com/grafana/loki/issues/18536)) ([ab426be](https://github.com/grafana/loki/commit/ab426be4592da204c0e0aa668e0b5670aac99eac))
 * **helm:** Enable rules sidecar for the ruler pods ([#17231](https://github.com/grafana/loki/issues/17231)) ([2c5ad02](https://github.com/grafana/loki/commit/2c5ad028a1f2e36590560a8091b162644bd06a36))
@@ -192,11 +190,30 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 ## Bug fixes
 
+### 3.6.12 (2026-06-24)
+
+* **deps:** Update `go.opentelemetry.io/otel/sdk` to v1.43.0 ([#21480](https://github.com/grafana/loki/issues/21480)) ([47fb29e](https://github.com/grafana/loki/commit/47fb29e)).
+* **security/HIGH:** Update `github.com/containerd/containerd/v2` to v2.0.9 ([#22204](https://github.com/grafana/loki/issues/22204)) ([ed38a68](https://github.com/grafana/loki/commit/ed38a68)).
+* **security/HIGH:** Update `github.com/prometheus/prometheus` to v0.311.3 in cmd/segment-inspect (release-3.6.x) ([#22205](https://github.com/grafana/loki/issues/22205)) ([bfd37e4](https://github.com/grafana/loki/commit/bfd37e4)).
+* **security/HIGH:** Update `go.opentelemetry.io/otel` to v1.41.0 in cmd/segment-inspect (release-3.6.x) ([#22206](https://github.com/grafana/loki/issues/22206)) ([0ed7bce](https://github.com/grafana/loki/commit/0ed7bce)).
+* **security/MEDIUM:** Update `github.com/grafana/loki/v3` to v3.6.4 in cmd/dataobj-inspect (release-3.6.x) ([#22209](https://github.com/grafana/loki/issues/22209)) ([d6117ed](https://github.com/grafana/loki/commit/d6117ed)).
+* **security/MEDIUM:** Update `github.com/grafana/loki/v3` to v3.6.4 in cmd/segment-inspect (release-3.6.x) ([#22210](https://github.com/grafana/loki/issues/22210)) ([186b9a9](https://github.com/grafana/loki/commit/186b9a9)).
+* **deps:** Update `golang.org/x/crypto` to v0.52.0 ([#22212](https://github.com/grafana/loki/issues/22212)) ([424e5ff](https://github.com/grafana/loki/commit/424e5ff)).
+* **deps:** Update `golang.org/x/net` to v0.55.0 ([#22213](https://github.com/grafana/loki/issues/22213)) ([90ae8f3](https://github.com/grafana/loki/commit/90ae8f3)).
+* **deps:** Update `golang.org/x/sys` to v0.44.0 ([#22214](https://github.com/grafana/loki/issues/22214)) ([49b9a22](https://github.com/grafana/loki/commit/49b9a22)).
+* **deps:** Update `golang.org/x/sys` to v0.44.0 in cmd/dataobj-inspect (release-3.6.x) ([#22215](https://github.com/grafana/loki/issues/22215)) ([c696c66](https://github.com/grafana/loki/commit/c696c66)).
+* **deps:** Update `golang.org/x/crypto` to v0.52.0 in cmd/segment-inspect (release-3.6.x) ([#22216](https://github.com/grafana/loki/issues/22216)) ([807ffd7](https://github.com/grafana/loki/commit/807ffd7)).
+* **deps:** Update `golang.org/x/net` to v0.55.0 in cmd/segment-inspect (release-3.6.x) ([#22217](https://github.com/grafana/loki/issues/22217)) ([7081875](https://github.com/grafana/loki/commit/7081875)).
+* **deps:** Update `golang.org/x/sys` to v0.44.0 in cmd/segment-inspect (release-3.6.x) ([#22218](https://github.com/grafana/loki/issues/22218)) ([36deca1](https://github.com/grafana/loki/commit/36deca1)).
+* **deps:** Update `golang.org/x/net` to v0.55.0 in pkg/push (release-3.6.x) ([#22224](https://github.com/grafana/loki/issues/22224)) ([0c53ce1](https://github.com/grafana/loki/commit/0c53ce1)).
+* **deps:** Update go toolchain to v1.25.11 in cmd/chunks-inspect (release-3.6.x) ([#22202](https://github.com/grafana/loki/issues/22202)) ([90e12c9](https://github.com/grafana/loki/commit/90e12c9)).
+* **deps:** Update go toolchain to v1.25.11 in cmd/segment-inspect (release-3.6.x) ([#22203](https://github.com/grafana/loki/issues/22203)) ([2c67a33](https://github.com/grafana/loki/commit/2c67a33)).
+
 ### 3.6.11 (2025-05-13)
 
 * CVEs in release 3.7.x ([#21771](https://github.com/grafana/loki/issues/21771)) ([bb4c5d8](https://github.com/grafana/loki/commit/bb4c5d8758b8540cb742466683143a9ea93743c8))
-* **deps:** Update module github.com/aws/aws-sdk-go-v2/service/s3 to v1.97.3 [security] (release-3.7.x) ([#21457](https://github.com/grafana/loki/issues/21457)) ([7bc9450](https://github.com/grafana/loki/commit/7bc945082fd7ef7632a9bfd18cc22f23130ea64a)).
-* **ruler:** Fix ruler panic related to unset validation scheme (backport release-3.7.x) ([#21401](https://github.com/grafana/loki/issues/21401)) ([cf65729](https://github.com/grafana/loki/commit/cf65729674b1f0be8011223c474df3e2e5253216)).
+* **deps:** Update module github.com/aws/aws-sdk-go-v2/service/s3 to v1.97.3 ([#21457](https://github.com/grafana/loki/issues/21457)) ([7bc9450](https://github.com/grafana/loki/commit/7bc945082fd7ef7632a9bfd18cc22f23130ea64a)).
+* **ruler:** Fix ruler panic related to unset validation scheme ([#21401](https://github.com/grafana/loki/issues/21401)) ([cf65729](https://github.com/grafana/loki/commit/cf65729674b1f0be8011223c474df3e2e5253216)).
 * **storage:** Attach SHA-256 checksum on PutObject for Object Lock buckets ([#21849](https://github.com/grafana/loki/issues/21849)) ([7df13d9](https://github.com/grafana/loki/commit/7df13d9ad3993700c3aff23edf5dfa2966281416)).
 
 ### 3.6.10 (2025-04-03)
@@ -205,17 +222,17 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 ### 3.6.9 (2025-04-01)
 
-This release does not exist.  We triggered the release pipeline, but it decided to play an April Fool's joke on us and did not generate the release.
+This release does not exist. We triggered the release pipeline, but it decided to play an April Fool's joke on us and did not generate the release.
 
 ### 3.6.8 (2025-03-25)
 
-* **deps:**  Upgrade `go.opentelemetry.io/otel/sdk` from v1.38.0 to v1.40.0 ([#21115](https://github.com/grafana/loki/issues/21115)) ([d1ab148](https://github.com/grafana/loki/commit/d1ab148aa279e9e5263f699fa1b1a0e1eec14f1a)).
-* **deps:**  Upgrade Go to 1.25.8 (release-3.6.x) ([#21240](https://github.com/grafana/loki/issues/21240)) ([10d2666](https://github.com/grafana/loki/commit/10d266699420c158410e5af2521fff6ac4440d61)).
-* **deps:**  Upgrade Go used by querytee/promtail to 3.6 ([#21244](https://github.com/grafana/loki/issues/21244)) ([41a4e0c](https://github.com/grafana/loki/commit/41a4e0c702d35c52181ffb32d34bf8ad98cd7717)).
-* **deps:**  Use different debian version for fluent-bit ([#21247](https://github.com/grafana/loki/issues/21247)) ([138c391](https://github.com/grafana/loki/commit/138c391fd0237b8bf1eb9ecf9eb14d8ce04727c5)).
-* **deps:** Update module github.com/buger/jsonparser to v1.1.2 [security] (release-3.6.x) ([#21201](https://github.com/grafana/loki/issues/21201)) ([3185466](https://github.com/grafana/loki/commit/318546620179a198d9af21baab9c601f5cc367c1)).
-* **deps:** Update module go.opentelemetry.io/otel/sdk to v1.40.0 [security] (release-3.6.x) ([#20887](https://github.com/grafana/loki/issues/20887)) ([d267ad3](https://github.com/grafana/loki/commit/d267ad368873ab3886519b975c86d76ded05741b)).
-* **deps:** Update module google.golang.org/grpc to v1.79.3 [security] (release-3.6.x) ([#21193](https://github.com/grafana/loki/issues/21193)) ([87dff41](https://github.com/grafana/loki/commit/87dff4138d72c6616c47bcd2d46f04692af8d01f)).
+* **deps:** Upgrade `go.opentelemetry.io/otel/sdk` from v1.38.0 to v1.40.0 ([#21115](https://github.com/grafana/loki/issues/21115)) ([d1ab148](https://github.com/grafana/loki/commit/d1ab148aa279e9e5263f699fa1b1a0e1eec14f1a)).
+* **deps:** Upgrade Go to 1.25.8 (release-3.6.x) ([#21240](https://github.com/grafana/loki/issues/21240)) ([10d2666](https://github.com/grafana/loki/commit/10d266699420c158410e5af2521fff6ac4440d61)).
+* **deps:** Upgrade Go used by querytee/promtail to 3.6 ([#21244](https://github.com/grafana/loki/issues/21244)) ([41a4e0c](https://github.com/grafana/loki/commit/41a4e0c702d35c52181ffb32d34bf8ad98cd7717)).
+* **deps:** Use different debian version for fluent-bit ([#21247](https://github.com/grafana/loki/issues/21247)) ([138c391](https://github.com/grafana/loki/commit/138c391fd0237b8bf1eb9ecf9eb14d8ce04727c5)).
+* **deps:** Update module github.com/buger/jsonparser to v1.1.2 ([#21201](https://github.com/grafana/loki/issues/21201)) ([3185466](https://github.com/grafana/loki/commit/318546620179a198d9af21baab9c601f5cc367c1)).
+* **deps:** Update module go.opentelemetry.io/otel/sdk to v1.40.0 ([#20887](https://github.com/grafana/loki/issues/20887)) ([d267ad3](https://github.com/grafana/loki/commit/d267ad368873ab3886519b975c86d76ded05741b)).
+* **deps:** Update module google.golang.org/grpc to v1.79.3 ([#21193](https://github.com/grafana/loki/issues/21193)) ([87dff41](https://github.com/grafana/loki/commit/87dff4138d72c6616c47bcd2d46f04692af8d01f)).
 
 ### 3.6.7 (2025-02-23)
 
@@ -344,7 +361,6 @@ This release does not exist.  We triggered the release pipeline, but it decided 
 * **deps:** Update module github.com/opentracing-contrib/go-grpc to v0.1.2 (main) ([#17164](https://github.com/grafana/loki/issues/17164)) ([23b47ce](https://github.com/grafana/loki/commit/23b47ce7a5c707dc046547165d9c2e8d812ec8ba))
 * **deps:** Update module github.com/oschwald/geoip2-golang to v1.13.0 (main) ([#18354](https://github.com/grafana/loki/issues/18354))
 * **deps:** Update module github.com/parquet-go/parquet-go to v0.25.1 (main) ([#18013](https://github.com/grafana/loki/issues/18013))
-(#18013)
 * **deps:** Update module github.com/pressly/goose/v3 to v3.26.0 (main) ([#19417](https://github.com/grafana/loki/issues/19417))
 * **deps:** Update module github.com/prometheus/client_golang to v1.23.0 (main) ([#18674](https://github.com/grafana/loki/issues/18674)) ([07a627a](https://github.com/grafana/loki/commit/07a627a40d59f405f140d13d425e1b15b4fd1a8b))
 * **deps:** Update module github.com/prometheus/client_model to v0.6.2 (main) ([#17171](https://github.com/grafana/loki/issues/17171)) ([fa84382](https://github.com/grafana/loki/commit/fa8438278835f82af329fb5a00df7d9b0a398965))
@@ -390,7 +406,6 @@ This release does not exist.  We triggered the release pipeline, but it decided 
 * **deps:** Update dependency tailwind-merge to v3.3.1 (main) ([#18061](https://github.com/grafana/loki/issues/18061))
 * **deps:** Update dependency zod to v3.25.76 (main) ([#18359](https://github.com/grafana/loki/issues/18359)) ([eb1e039](https://github.com/grafana/loki/commit/eb1e03962463ba8fe120fe44ce02f1f8b6598d91))
 * **deps:** Update dependency zod to v4 (main) ([#18392](https://github.com/grafana/loki/issues/18392))
-(#18392)
 * **deps:** Update module zombiezen.com/go/sqlite to v1.4.2 (main) ([#17903](https://github.com/grafana/loki/issues/17903))
 * **distributor:** Disable metadata topic writes ([#17437](https://github.com/grafana/loki/issues/17437)) ([46b2271](https://github.com/grafana/loki/commit/46b2271aacd26734979667da61d5c9d24a8efb2b))
 * **distributor:** Revert remove colons from level detection ([#16999](https://github.com/grafana/loki/issues/16999)) ([e678b61](https://github.com/grafana/loki/commit/e678b615c18f52a23862d5d3ff39102989ec8374))


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Release Notes for the 3.6.12 patch release.
Also cleans up a few copy/paste errors.