### PR TITLE
fix(v2-engine): Place label_format outputs in Parsed category and remove pre-existing same-name labels to match v1

### DIFF
--- a/pkg/engine/internal/executor/parse.go
+++ b/pkg/engine/internal/executor/parse.go
@@ -70,9 +70,6 @@ func parseFn(op types.VariadicOp) VariadicFunction {
 		newFields := make([]arrow.Field, 0, len(headers))
 		for _, header := range headers {
 			ct := types.ColumnTypeParsed
-			if op == types.VariadicOpParseLabelfmt {
-				ct = types.ColumnTypeLabel
-			}
 			if header == semconv.ColumnIdentError.ShortName() || header == semconv.ColumnIdentErrorDetails.ShortName() {
 				ct = types.ColumnTypeGenerated
 			}

--- a/pkg/engine/internal/executor/project.go
+++ b/pkg/engine/internal/executor/project.go
@@ -124,7 +124,7 @@ func newKeepPipeline(colRefs []types.ColumnRef, keepFunc func([]types.ColumnRef,
 
 func newExpandPipeline(expr physical.Expression, evaluator *expressionEvaluator, input Pipeline) (*GenericPipeline, error) {
 	identCache := semconv.NewIdentifierCache()
-	renamedLabelSources := labelFmtRenameSources(expr)
+	labelFmtRemovedNames := labelFmtRemovedColumnNames(expr)
 
 	return newGenericPipeline(func(ctx context.Context, inputs []Pipeline) (arrow.RecordBatch, error) {
 		if len(inputs) != 1 {
@@ -151,12 +151,19 @@ func newExpandPipeline(expr physical.Expression, evaluator *expressionEvaluator,
 			if err != nil {
 				return nil, err
 			}
-			_, shouldDelete := renamedLabelSources[ident.ShortName()]
-			// A `label_format dst=src` rename removes the source label regardless of
-			// which category it came from (stream label, structured metadata, or a
-			// parsed field), matching the classic engine which
-			// deletes the name from every category. Only builtin/generated columns
-			// (timestamp, message, __error__, value) must be preserved.
+			_, shouldDelete := labelFmtRemovedNames[ident.ShortName()]
+			// label_format removes label-like columns whose short name matches
+			// either a rename source or a SET/rename target:
+			//   - `label_format dst=src` (rename): remove `src` (the source
+			//     vanishes from the label set) and `dst` (so the new column
+			//     replaces any pre-existing one rather than colliding with it).
+			//   - `label_format dst=value` (SET): remove `dst` so the new
+			//     column replaces any pre-existing one.
+			// This mirrors v1's LabelsFormatter.Process which calls
+			// lbs.Set(ParsedLabel, ...), and lbs.Set(ParsedLabel) deletes the
+			// same name from stream/metadata categories before adding the
+			// parsed value. Only builtin/generated columns (timestamp, message,
+			// __error__, value) are preserved.
 			shouldDelete = shouldDelete && isLabelLikeColumn(ident.ColumnType())
 			if !ident.Equal(semconv.ColumnIdentValue) && !shouldDelete {
 				outputCols = append(outputCols, batch.Column(i))
@@ -217,7 +224,16 @@ func isLabelLikeColumn(ct types.ColumnType) bool {
 	}
 }
 
-func labelFmtRenameSources(expr physical.Expression) map[string]struct{} {
+// labelFmtRemovedColumnNames returns the set of short column names that
+// label_format must strip from the input before adding the new parsed
+// columns. For each labelfmt entry:
+//   - the target (Name) is always removed, so the new value replaces any
+//     pre-existing column of the same name regardless of category.
+//   - the source (Value) is additionally removed when Rename is true, so
+//     the original column disappears from the label set as v1 does.
+//
+// Returns nil when the expression isn't a labelfmt parse or has no entries.
+func labelFmtRemovedColumnNames(expr physical.Expression) map[string]struct{} {
 	parseExpr, ok := expr.(*physical.VariadicExpr)
 	if !ok || parseExpr.Op != types.VariadicOpParseLabelfmt || len(parseExpr.Expressions) < 3 {
 		return nil
@@ -230,16 +246,17 @@ func labelFmtRenameSources(expr physical.Expression) map[string]struct{} {
 	if !ok {
 		return nil
 	}
-	renameSources := make(map[string]struct{})
+	removed := make(map[string]struct{})
 	for _, labelFmt := range labelFmts {
+		removed[labelFmt.Name] = struct{}{}
 		if labelFmt.Rename {
-			renameSources[labelFmt.Value] = struct{}{}
+			removed[labelFmt.Value] = struct{}{}
 		}
 	}
-	if len(renameSources) == 0 {
+	if len(removed) == 0 {
 		return nil
 	}
-	return renameSources
+	return removed
 }
 
 // mergeColumns merges two columns by preferring values from the new column (b),

--- a/pkg/engine/internal/executor/project_test.go
+++ b/pkg/engine/internal/executor/project_test.go
@@ -978,7 +978,7 @@ func TestNewProjectPipeline_LabelFmtRenameDropsSourceColumn(t *testing.T) {
 			expected: arrowtest.Rows{{
 				"utf8.builtin.message":           msg,
 				"timestamp_ns.builtin.timestamp": ts,
-				"utf8.label.foo":                 "dev",
+				"utf8.parsed.foo":                "dev",
 			}},
 		},
 		{
@@ -989,7 +989,7 @@ func TestNewProjectPipeline_LabelFmtRenameDropsSourceColumn(t *testing.T) {
 			expected: arrowtest.Rows{{
 				"utf8.builtin.message":           msg,
 				"timestamp_ns.builtin.timestamp": ts,
-				"utf8.label.foo":                 "dev",
+				"utf8.parsed.foo":                "dev",
 			}},
 		},
 		{
@@ -1000,7 +1000,7 @@ func TestNewProjectPipeline_LabelFmtRenameDropsSourceColumn(t *testing.T) {
 			expected: arrowtest.Rows{{
 				"utf8.builtin.message":           msg,
 				"timestamp_ns.builtin.timestamp": ts,
-				"utf8.label.foo":                 "dev",
+				"utf8.parsed.foo":                "dev",
 			}},
 		},
 		{
@@ -1014,14 +1014,15 @@ func TestNewProjectPipeline_LabelFmtRenameDropsSourceColumn(t *testing.T) {
 				"utf8.builtin.message":           msg,
 				"timestamp_ns.builtin.timestamp": ts,
 				"utf8.generated.bar":             "dev",
-				"utf8.label.foo":                 "dev",
+				"utf8.parsed.foo":                "dev",
 			}},
 		},
 		{
 			// Collision: the rename destination `foo` already exists as a label.
-			// The source `bar` is dropped and the existing `foo` is overwritten
-			// with the source's value (mirrors v1 "rename and overwrite existing
-			// label").
+			// Both the source `bar` and the existing `foo` label are dropped,
+			// and the rename's value lands at `parsed.foo` (mirrors v1, where
+			// LabelsFormatter calls lbs.Set(ParsedLabel, "foo", "dev") which
+			// deletes any stream-label `foo` before writing the parsed value).
 			name: "rename overwrites existing destination label",
 			dataFields: []arrow.Field{
 				semconv.FieldFromFQN("utf8.label.foo", false),
@@ -1032,13 +1033,14 @@ func TestNewProjectPipeline_LabelFmtRenameDropsSourceColumn(t *testing.T) {
 			expected: arrowtest.Rows{{
 				"utf8.builtin.message":           msg,
 				"timestamp_ns.builtin.timestamp": ts,
-				"utf8.label.foo":                 "dev",
+				"utf8.parsed.foo":                "dev",
 			}},
 		},
 		{
 			// Template renders to empty (literal ""); the pre-existing destination
-			// label `foo` must be overwritten with "". v1 semantics: a template
-			// always writes its result, including an empty result.`
+			// label `foo` is removed and the new `parsed.foo` carries the rendered
+			// empty value. v1 semantics: a template always writes its result,
+			// including an empty result.
 			name: "template literal empty overwrites existing destination",
 			dataFields: []arrow.Field{
 				semconv.FieldFromFQN("utf8.label.foo", false),
@@ -1048,12 +1050,13 @@ func TestNewProjectPipeline_LabelFmtRenameDropsSourceColumn(t *testing.T) {
 			expected: arrowtest.Rows{{
 				"utf8.builtin.message":           msg,
 				"timestamp_ns.builtin.timestamp": ts,
-				"utf8.label.foo":                 "",
+				"utf8.parsed.foo":                "",
 			}},
 		},
 		{
 			// Template references a label whose value is empty; the rendered
-			// result is "" and that overwrites the pre-existing destination.
+			// result is "" and lands at `parsed.foo`, while the pre-existing
+			// `label.foo` is dropped.
 			name: "template referencing empty-valued label overwrites existing destination",
 			dataFields: []arrow.Field{
 				semconv.FieldFromFQN("utf8.label.foo", false),
@@ -1065,7 +1068,27 @@ func TestNewProjectPipeline_LabelFmtRenameDropsSourceColumn(t *testing.T) {
 				"utf8.builtin.message":           msg,
 				"timestamp_ns.builtin.timestamp": ts,
 				"utf8.label.bar":                 "",
-				"utf8.label.foo":                 "",
+				"utf8.parsed.foo":                "",
+			}},
+		},
+		{
+			// `label_format foo="bar"` must NOT touch `foo_extracted` — it's
+			// a different short name.
+			name: "set target preserves the matching _extracted column",
+			dataFields: []arrow.Field{
+				semconv.FieldFromFQN("utf8.label.foo", false),
+				semconv.FieldFromFQN("utf8.parsed.foo_extracted", false),
+			},
+			dataValues: arrowtest.Row{
+				"utf8.label.foo":            "from-stream",
+				"utf8.parsed.foo_extracted": "from-json",
+			},
+			labelFmts: []log.LabelFmt{{Name: "foo", Value: "bar", Rename: false}},
+			expected: arrowtest.Rows{{
+				"utf8.builtin.message":           msg,
+				"timestamp_ns.builtin.timestamp": ts,
+				"utf8.parsed.foo":                "bar",
+				"utf8.parsed.foo_extracted":      "from-json",
 			}},
 		},
 	}

--- a/pkg/logql/bench/queries/regression/log-queries.yaml
+++ b/pkg/logql/bench/queries/regression/log-queries.yaml
@@ -51,3 +51,43 @@ queries:
       Catches any regression to the section-prune layer.
     requires:
       log_format: logfmt
+  - description: label_format with a literal empty value must emit the new label as parsed (not silently drop it)
+    query: ${SELECTOR} | label_format new_field=""
+    kind: log
+    time_range:
+      length: 24h
+    directions: backward # forward log queries unsupported by v2 engine
+    tags:
+      - label_format
+      - empty-value
+      - absent-field
+    notes: >
+      Regression for the v2 label_format empty-value drop. v1's
+      LabelsFormatter calls lbs.Set(ParsedLabel, "new_field", ""), so the
+      label survives in the parsed category and the streamsResultBuilder's
+      parsedEmptyKeys workaround surfaces it in the response. Pre-fix v2
+      classified labelfmt outputs as the Label category, and the result
+      builder explicitly drops empty Label-category values to match
+      stream-label-empty-drop semantics — silently removing the
+      labelfmt-produced empty. v1 returns rows with new_field="" present in
+      the parsed labels.
+  - description: label_format rename drops the source label and the target carries its value
+    query: ${SELECTOR} | label_format renamed_label=service_name
+    kind: log
+    time_range:
+      length: 24h
+    directions: backward # forward log queries unsupported by v2 engine
+    tags:
+      - label_format
+      - rename
+    requires:
+      labels:
+        - service_name
+    notes: >
+      Baseline guard for v1↔v2 parity on the labelfmt rename semantics:
+      the source label is removed from the label set and the target
+      carries the source's value as a parsed label. Important because the
+      fix also reclassifies labelfmt outputs from Label to Parsed
+      category and extends the input-deletion logic to remove targets in
+      addition to rename sources — a regression here would land at the
+      result-builder boundary, not at the executor unit test.

--- a/pkg/logql/bench/queries/regression/structured-metadata.yaml
+++ b/pkg/logql/bench/queries/regression/structured-metadata.yaml
@@ -14,6 +14,8 @@ queries:
     requires:
       structured_metadata:
         - detected_level
+      keywords:
+        - error
   - description: JSON parsing with duration filter and structured metadata
     query: ${SELECTOR} | json | duration_seconds > 0.1 | detected_level!="debug"
     skip: true # numeric label filter (> 0.1) unsupported by v2 engine

--- a/pkg/logql/bench/queries/regression/structured-metadata.yaml
+++ b/pkg/logql/bench/queries/regression/structured-metadata.yaml
@@ -82,3 +82,28 @@ queries:
         - detected_level
       keywords:
         - refused
+  - description: label_format rename target replaces pre-existing structured metadata of the same name
+    query: ${SELECTOR} | label_format detected_level=service_name
+    kind: log
+    time_range:
+      length: 24h
+    directions: backward # forward log queries unsupported by v2 engine
+    tags:
+      - label_format
+      - rename
+      - structured-metadata
+    requires:
+      labels:
+        - service_name
+      structured_metadata:
+        - detected_level
+    notes: >
+      v1's lbs.Set(ParsedLabel, "detected_level", v) silently deletes
+      detected_level from stream/metadata categories before adding the
+      parsed value, so the renamed target overwrites the pre-existing
+      structured-metadata detected_level. Pre-fix v2 left two coexisting
+      detected_level columns in the Arrow output (one from metadata, one
+      from the labelfmt projection), and the streamsResultBuilder dedup
+      surfaced the older metadata value — making the rename appear to do
+      nothing for detected_level while still dropping the source label.
+      v1 returns detected_level carrying service_name's value.


### PR DESCRIPTION
**What this PR does / why we need it**:

`label_format` in v2 diverged from v1 in two ways:

* Outputs were categorised as stream labels, not parsed labels.

v1 always adds labelfmt outputs to the Parsed category. v2 hardcoded them to `ColumnTypeLabel` (stream-label) in `parse.go`.

* pre-existing same-name labels were not removed.

v1's `lbs.Set(ParsedLabel, n, v)` deletes `n` from the stream and structured-metadata categories before adding the parsed value, so the labelfmt target always wins. v2 only removed the rename source, never the target so any pre-existing column of the same name flowed through and either:

- collided with the new labelfmt column in the downstream `ColumnCompat`, which renamed the labelfmt output to `<name>_extracted`, or
- coexisted with the new column when the pre-existing value lived in structured metadata, and the result builder's category-aware dedup surfaced the stale metadata value.

The PR fixes both issues.

**Symptoms (pre-fix v2 vs v1):**

| Query | v1 | Pre-fix v2 |
|---|---|---|
| `{...} \| label_format foo=""` | `foo=""` present | `foo` missing |
| `{...} \| label_format detected_level=service_name` (where `detected_level` exists in structured metadata) | `detected_level` carries `service_name`'s value | `detected_level` unchanged; only the source label is dropped |
| `{namespace="x"} \| json \| label_format foo=newvalue` (where `label.foo="old"` existed) | `foo="newvalue"` | `foo="old"` AND `foo_extracted="newvalue"` |