### PR TITLE
feat: Add X-Loki-Backfill-Day header to label backfilled streams

### DIFF
--- a/pkg/loghttp/push/backfill.go
+++ b/pkg/loghttp/push/backfill.go
@@ -1,0 +1,49 @@
+package push
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// HTTPHeaderBackfillDayKey is the HTTP header set by a backfill worker to mark a push as backfill
+// data for a given day. When present and valid, Loki adds the internal labels constants.BackfillLabel
+// and constants.BackfillDayLabel to every stream in the request.
+const HTTPHeaderBackfillDayKey = "X-Loki-Backfill-Day"
+
+// backfillDayLayout is the required format for the X-Loki-Backfill-Day header value.
+const backfillDayLayout = "2006-01-02"
+
+// backfillDayContextKey is used as a key for context values to avoid collisions.
+type backfillDayContextKey int
+
+const backfillDayKey backfillDayContextKey = 1
+
+// ExtractAndValidateBackfillDay reads the X-Loki-Backfill-Day header from r.
+// It returns ("", false, nil) when the header is absent or empty. When the header is set it must be
+// a valid YYYY-MM-DD date; otherwise it returns an error so the push is rejected with HTTP 400.
+func ExtractAndValidateBackfillDay(r *http.Request) (string, bool, error) {
+	day := r.Header.Get(HTTPHeaderBackfillDayKey)
+	if day == "" {
+		return "", false, nil
+	}
+	if _, err := time.Parse(backfillDayLayout, day); err != nil {
+		return "", false, fmt.Errorf("invalid %s header %q: must be a date in YYYY-MM-DD format", HTTPHeaderBackfillDayKey, day)
+	}
+	return day, true, nil
+}
+
+// InjectBackfillDayContext returns a derived context carrying the validated backfill day.
+func InjectBackfillDayContext(ctx context.Context, day string) context.Context {
+	return context.WithValue(ctx, backfillDayKey, day)
+}
+
+// ExtractBackfillDayContext returns the backfill day stored in ctx, or "" if none is set.
+func ExtractBackfillDayContext(ctx context.Context) string {
+	day, ok := ctx.Value(backfillDayKey).(string)
+	if !ok {
+		return ""
+	}
+	return day
+}

--- a/pkg/loghttp/push/backfill_test.go
+++ b/pkg/loghttp/push/backfill_test.go
@@ -1,0 +1,204 @@
+package push
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	gokitlog "github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/util/constants"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+)
+
+const testBackfillDay = "2026-06-10"
+
+func TestExtractAndValidateBackfillDay(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		setHeader bool
+		value     string
+		wantDay   string
+		wantOK    bool
+		wantErr   bool
+	}{
+		{name: "no header"},
+		{name: "empty header", setHeader: true, value: ""},
+		{name: "valid", setHeader: true, value: "2026-06-10", wantDay: "2026-06-10", wantOK: true},
+		{name: "wrong separators", setHeader: true, value: "2026/06/10", wantErr: true},
+		{name: "not a date", setHeader: true, value: "yesterday", wantErr: true},
+		{name: "out of range", setHeader: true, value: "2026-13-40", wantErr: true},
+		{name: "has time component", setHeader: true, value: "2026-06-10T00:00:00Z", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, "/loki/api/v1/push", nil)
+			if tc.setHeader {
+				r.Header.Set(HTTPHeaderBackfillDayKey, tc.value)
+			}
+
+			day, ok, err := ExtractAndValidateBackfillDay(r)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), HTTPHeaderBackfillDayKey)
+				require.False(t, ok)
+				require.Empty(t, day)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantOK, ok)
+			require.Equal(t, tc.wantDay, day)
+		})
+	}
+}
+
+func TestBackfillDayContext(t *testing.T) {
+	require.Empty(t, ExtractBackfillDayContext(context.Background()))
+
+	ctx := InjectBackfillDayContext(context.Background(), testBackfillDay)
+	require.Equal(t, testBackfillDay, ExtractBackfillDayContext(ctx))
+}
+
+func TestParseRequest_BackfillDay(t *testing.T) {
+	const lokiBody = `{"streams":[{"stream":{"foo":"bar"},"values":[["1570818238000000000","fizzbuzz"]]}]}`
+
+	parse := func(r *http.Request, parser RequestParser, limits *fakeLimits) (*logproto.PushRequest, error) {
+		streamResolver := newMockStreamResolver("fake", limits)
+		data, _, err := ParseRequest(util_log.Logger, "fake", 100<<20, 100<<20, r, limits, nil, parser, NewMockTracker(), streamResolver, "", "loki")
+		return data, err
+	}
+
+	t.Run("loki: header adds backfill labels to every stream", func(t *testing.T) {
+		req, err := parse(newBackfillLokiRequest(lokiBody, testBackfillDay), ParseLokiRequest, &fakeLimits{enabled: true, labels: []string{"foo"}})
+		require.NoError(t, err)
+		require.Len(t, req.Streams, 1)
+		requireBackfillLabels(t, req.Streams[0].Labels)
+		// Original labels are preserved.
+		lbs, err := syntax.ParseLabels(req.Streams[0].Labels)
+		require.NoError(t, err)
+		require.Equal(t, "bar", lbs.Get("foo"))
+	})
+
+	t.Run("loki: no header leaves labels untouched", func(t *testing.T) {
+		req, err := parse(newBackfillLokiRequest(lokiBody, ""), ParseLokiRequest, &fakeLimits{enabled: true, labels: []string{"foo"}})
+		require.NoError(t, err)
+		require.Len(t, req.Streams, 1)
+		requireNoBackfillLabels(t, req.Streams[0].Labels)
+	})
+
+	t.Run("malformed header rejects the whole push", func(t *testing.T) {
+		req, err := parse(newBackfillLokiRequest(lokiBody, "06-10-2026"), ParseLokiRequest, &fakeLimits{enabled: true})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), HTTPHeaderBackfillDayKey)
+		require.Nil(t, req)
+	})
+
+	t.Run("otlp: header adds backfill labels", func(t *testing.T) {
+		req, err := parse(newBackfillOTLPRequest(t, singleResourceLogs("service.name", "service-1"), testBackfillDay), ParseOTLPRequest, &fakeLimits{enabled: true})
+		require.NoError(t, err)
+		require.Len(t, req.Streams, 1)
+		requireBackfillLabels(t, req.Streams[0].Labels)
+	})
+
+	t.Run("otlp: restrictive tenant config cannot drop backfill labels", func(t *testing.T) {
+		// Service-name discovery is off and the only indexed attribute does not match the resource,
+		// so without injection this stream would carry no index labels at all.
+		req, err := parse(newBackfillOTLPRequest(t, singleResourceLogs("service.name", "service-1"), testBackfillDay), ParseOTLPRequest, &fakeLimits{enabled: false, indexAttributes: []string{"nonexistent"}})
+		require.NoError(t, err)
+		require.Len(t, req.Streams, 1)
+		requireBackfillLabels(t, req.Streams[0].Labels)
+	})
+}
+
+// TestOTLPBackfillLabelsOnCombinedStreams covers the per-log-record stream path, where a log
+// attribute promoted to an index label produces a stream from combinedLabels (a copy of the resource
+// stream labels). The backfill labels must be inherited there too.
+func TestOTLPBackfillLabelsOnCombinedStreams(t *testing.T) {
+	now := time.Unix(0, time.Now().UnixNano())
+
+	cfg := DefaultOTLPConfig(GlobalOTLPConfig{DefaultOTLPResourceAttributesAsIndexLabels: []string{"service.name"}})
+	cfg.LogAttributes = []AttributesConfig{{Action: IndexLabel, Attributes: []string{"detected_level"}}}
+
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "svc")
+	rec := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	rec.Body().SetStr("hello")
+	rec.SetTimestamp(pcommon.Timestamp(now.UnixNano()))
+	rec.Attributes().PutStr("detected_level", "info")
+
+	stats := NewPushStats()
+	streamResolver := newMockStreamResolver("fake", &fakeLimits{})
+	ctx := InjectBackfillDayContext(context.Background(), testBackfillDay)
+
+	pushReq, err := otlpToLokiPushRequest(ctx, ld, "fake", cfg, nil, []string{}, NewMockTracker(), stats, gokitlog.NewNopLogger(), streamResolver, constants.OTLP)
+	require.NoError(t, err)
+
+	nonEmpty := 0
+	for _, s := range pushReq.Streams {
+		if len(s.Entries) == 0 {
+			continue
+		}
+		nonEmpty++
+		requireBackfillLabels(t, s.Labels)
+		require.Contains(t, s.Labels, `detected_level="info"`)
+	}
+	require.Equal(t, 1, nonEmpty, "expected one combined stream carrying the indexed log attribute")
+}
+
+func newBackfillLokiRequest(body, backfillDay string) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/loki/api/v1/push", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	if backfillDay != "" {
+		r.Header.Set(HTTPHeaderBackfillDayKey, backfillDay)
+	}
+	return r
+}
+
+func newBackfillOTLPRequest(t *testing.T, ld plog.Logs, backfillDay string) *http.Request {
+	t.Helper()
+	body, err := (&plog.JSONMarshaler{}).MarshalLogs(ld)
+	require.NoError(t, err)
+	r := httptest.NewRequest(http.MethodPost, "/otlp/v1/logs", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	if backfillDay != "" {
+		r.Header.Set(HTTPHeaderBackfillDayKey, backfillDay)
+	}
+	return r
+}
+
+func singleResourceLogs(resourceAttrs ...string) plog.Logs {
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	for i := 0; i+1 < len(resourceAttrs); i += 2 {
+		rl.Resource().Attributes().PutStr(resourceAttrs[i], resourceAttrs[i+1])
+	}
+	rec := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	rec.Body().SetStr("test body")
+	rec.SetTimestamp(pcommon.Timestamp(time.Now().UnixNano()))
+	return ld
+}
+
+func requireBackfillLabels(t *testing.T, labelsStr string) {
+	t.Helper()
+	lbs, err := syntax.ParseLabels(labelsStr)
+	require.NoError(t, err, "labels=%s", labelsStr)
+	require.Equal(t, "true", lbs.Get(constants.BackfillLabel), "labels=%s", labelsStr)
+	require.Equal(t, testBackfillDay, lbs.Get(constants.BackfillDayLabel), "labels=%s", labelsStr)
+}
+
+func requireNoBackfillLabels(t *testing.T, labelsStr string) {
+	t.Helper()
+	lbs, err := syntax.ParseLabels(labelsStr)
+	require.NoError(t, err, "labels=%s", labelsStr)
+	require.False(t, lbs.Has(constants.BackfillLabel), "labels=%s", labelsStr)
+	require.False(t, lbs.Has(constants.BackfillDayLabel), "labels=%s", labelsStr)
+}

--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -156,6 +156,11 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 		logPushRequestStreams = tenantConfigs.LogPushRequestStreams(userID)
 	}
 
+	// If this is a backfill push (X-Loki-Backfill-Day header), every stream gets the internal
+	// backfill labels added below. Done here (not via OTLP attribute promotion) so a tenant's OTLP
+	// config cannot drop them.
+	backfillDay := ExtractBackfillDayContext(ctx)
+
 	mostRecentEntryTimestamp := time.Time{}
 	for i := 0; i < rls.Len(); i++ {
 		sls := rls.At(i).ScopeLogs()
@@ -169,6 +174,11 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 
 		resourceAttributesAsStructuredMetadata := resResult.StructuredMetadata
 		streamLabels := resResult.StreamLabels
+
+		if backfillDay != "" {
+			streamLabels[constants.BackfillLabel] = "true"
+			streamLabels[constants.BackfillDayLabel] = model.LabelValue(backfillDay)
+		}
 
 		var pushedLabels model.LabelSet
 		if logServiceNameDiscovery {

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -179,6 +179,14 @@ type Stats struct {
 }
 
 func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, maxDecompressedSize int64, r *http.Request, limits Limits, tenantConfigs *runtime.TenantConfigs, pushRequestParser RequestParser, tracker UsageTracker, streamResolver StreamResolver, presumedAgentIP, format string) (*logproto.PushRequest, *Stats, error) {
+	// If the X-Loki-Backfill-Day header is set, validate it and stash the day in the request context
+	// so the format parsers (Loki and OTLP) add the internal backfill labels to every stream.
+	if day, ok, err := ExtractAndValidateBackfillDay(r); err != nil {
+		return nil, nil, err
+	} else if ok {
+		r = r.Clone(InjectBackfillDayContext(r.Context(), day))
+	}
+
 	req, pushStats, err := pushRequestParser(userID, r, limits, tenantConfigs, maxRecvMsgSize, maxDecompressedSize, tracker, streamResolver, logger)
 	if err != nil && !errors.Is(err, ErrAllLogsFiltered) {
 		if errors.Is(err, util.ErrMessageSizeTooLarge) {
@@ -418,6 +426,10 @@ func ParseLokiRequest(userID string, r *http.Request, limits Limits, tenantConfi
 		logServiceNameDiscovery = tenantConfigs.LogServiceNameDiscovery(userID)
 	}
 
+	// If this is a backfill push (X-Loki-Backfill-Day header), every stream gets the internal
+	// backfill labels added below.
+	backfillDay := ExtractBackfillDayContext(r.Context())
+
 	for i := range req.Streams {
 		s := req.Streams[i]
 
@@ -453,6 +465,13 @@ func ParseLokiRequest(userID string, r *http.Request, limits Limits, tenantConfi
 
 			lb := labels.NewBuilder(lbs)
 			lbs = lb.Set(LabelServiceName, serviceName).Labels()
+		}
+
+		if backfillDay != "" {
+			lbs = labels.NewBuilder(lbs).
+				Set(constants.BackfillLabel, "true").
+				Set(constants.BackfillDayLabel, backfillDay).
+				Labels()
 		}
 
 		// Update labels. They were sanitized and potentially with the added service_name label.

--- a/pkg/loghttp/push/push_test.go
+++ b/pkg/loghttp/push/push_test.go
@@ -72,7 +72,12 @@ func marshalProto(m proto.Message) []byte {
 }
 
 func TestParseRequest(t *testing.T) {
-	var previousBytesReceived, previousStructuredMetadataBytesReceived, previousLinesReceived int
+	// These are process-wide analytics counters that other tests in this package may have already
+	// incremented; capture the current values as the baseline so the per-iteration deltas below are
+	// correct regardless of test execution order.
+	previousBytesReceived := int(bytesReceivedStats.Value()["total"].(int64))
+	previousStructuredMetadataBytesReceived := int(structuredMetadataBytesReceivedStats.Value()["total"].(int64))
+	previousLinesReceived := int(linesReceivedStats.Value()["total"].(int64))
 	for index, test := range []struct {
 		path                            string
 		body                            string

--- a/pkg/util/constants/internal_streams.go
+++ b/pkg/util/constants/internal_streams.go
@@ -5,6 +5,10 @@ const (
 	AggregatedMetricLabel = "__aggregated_metric__"
 	// PatternLabel is the label added to streams containing detected patterns
 	PatternLabel = "__pattern__"
+	// BackfillLabel marks streams ingested via the backfill path (X-Loki-Backfill-Day header).
+	BackfillLabel = "__backfill__"
+	// BackfillDayLabel partitions backfilled streams by the backfill day (YYYY-MM-DD).
+	BackfillDayLabel = "__backfill_day__"
 	// LogsDrilldownAppName is the app name used to identify requests from Logs Drilldown
 	LogsDrilldownAppName = "grafana-lokiexplore-app"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an `X-Loki-Backfill-Day=<YYYY-MM-DD>` push header for backfilling. When set, Loki stamps two internal labels onto every stream in the request (native Loki + OTLP) so backfilled data can be targeted (`/flush/tenant?streams={__backfill__="true"}`) and partitioned by day:

- `__backfill__="true"`
- `__backfill_day__="<day>"`

Validated in `ParseRequest` (strict `YYYY-MM-DD`, else HTTP 400); labels are injected at parse time so a tenant's OTLP config can't drop them.

**Special notes for your reviewer**:

- Honored for any tenant, no gating — like the existing `X-Loki-Ingestion-Policy` header.
- `TestParseRequest` now captures a live analytics-counter baseline instead of assuming zero (was order-dependent).

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.
