### PR TITLE
ci: Fix permissions of generated files when running BUILD_IN_CONTAINER=true

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ define run_in_container
 			fi; \
 		fi))
 
-	@docker build --rm $(OCI_BUILD_ARGS) --build-arg "SRC_DIR=/src/loki" --build-arg "INSTALL_WORKFLOW_DEPS_ARGS=$(INSTALL_WORKFLOW_DEPS_ARGS)" \
+	@docker build --rm $(OCI_BUILD_ARGS) --build-arg "USER=$(shell whoami)" --build-arg "SRC_DIR=/src/loki" --build-arg "INSTALL_WORKFLOW_DEPS_ARGS=$(INSTALL_WORKFLOW_DEPS_ARGS)" \
 		-f loki-build-image/Dockerfile \
 		-t $(MAKEFILE_IMAGE) \
 		.
@@ -124,6 +124,7 @@ define run_in_container
 		-v $(shell pwd):/src/loki$(MOUNT_FLAGS) \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		$(GIT_MOUNT) \
+		--user $(shell whoami) \
 		--entrypoint /usr/bin/make \
 		-e SRC_DIR=/src/loki \
 		-e BUILD_IN_CONTAINER=false \

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -5,12 +5,16 @@ FROM $BUILD_IMAGE
 
 ARG SRC_DIR=/src/loki
 ARG INSTALL_WORKFLOW_DEPS_ARGS
+ARG USER=loki
 
 COPY .github $SRC_DIR/.github
 
 RUN git config --global --add safe.directory $SRC_DIR
 RUN echo "Install dependencies ..."
 RUN $SRC_DIR/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh $INSTALL_WORKFLOW_DEPS_ARGS
+
+RUN useradd -ms /bin/bash $USER
+USER $USER
 
 WORKDIR $SRC_DIR
 ENTRYPOINT [ "/usr/bin/make" ]


### PR DESCRIPTION
### Summary

When running a make target that generates/changes files, such as `loki-mixin`, these files are then owned by `root`, since the container user is `root`.
This can cause permission problems when switching between branches locally.

See also https://www.docker.com/blog/understanding-the-docker-user-instruction/

#### Example

Run `make loki-mixin`.

**before**
```
$ ls -las production/loki-mixin-compiled-ssd/dashboards/loki-bloom-build.json
256 -rw-r--r-- 1 root root 259585 Jun 25 13:13 production/loki-mixin-compiled-ssd/dashboards/loki-bloom-build.json
```

**after**
```
$ ls -las production/loki-mixin-compiled-ssd/dashboards/loki-bloom-build.json
256 -rw-r--r-- 1 christian christian 259585 Jun 25 13:15 production/loki-mixin-compiled-ssd/dashboards/loki-bloom-build.json
```