### PR TITLE
test: De-flake TestPartitionReader_BasicFunctionality

### DIFF
--- a/pkg/kafka/partition/reader_test.go
+++ b/pkg/kafka/partition/reader_test.go
@@ -114,21 +114,25 @@ func TestPartitionReader_BasicFunctionality(t *testing.T) {
 	require.NoError(t, producer.ProduceSync(context.Background(), records...).FirstErr())
 	require.NoError(t, producer.ProduceSync(context.Background(), records...).FirstErr())
 
-	// Wait for records to be processed
-	assert.Eventually(t, func() bool {
-		return len(consumer.recordsChan) == 2
+	// Collect the processed records. The reader may deliver the two produced
+	// records as a single batch or as separate batches depending on fetch
+	// timing, so accumulate across batches and assert on the total.
+	var received []Record
+	require.Eventually(t, func() bool {
+		for {
+			select {
+			case batch := <-consumer.recordsChan:
+				received = append(received, batch...)
+			default:
+				return len(received) == 2
+			}
+		}
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Verify the records
-	for i := 0; i < 2; i++ {
-		select {
-		case receivedRecords := <-consumer.recordsChan:
-			require.Len(t, receivedRecords, 1)
-			assert.Equal(t, "test-tenant", receivedRecords[0].TenantID)
-			assert.Equal(t, records[0].Value, receivedRecords[0].Content)
-		case <-time.After(1 * time.Second):
-			t.Fatal("Timeout waiting for records")
-		}
+	for _, rec := range received {
+		assert.Equal(t, "test-tenant", rec.TenantID)
+		assert.Equal(t, records[0].Value, rec.Content)
 	}
 
 	err = services.StopAndAwaitTerminated(context.Background(), partitionReader)


### PR DESCRIPTION
**What this PR does / why we need it**:

`TestPartitionReader_BasicFunctionality` is flaky. The test produces two records with two separate `ProduceSync` calls and assumed each produce would be delivered to the consumer as its own batch — i.e. two `[]Record` of length 1, giving a channel length of 2. It then asserted `len(consumer.recordsChan) == 2` and `require.Len(receivedRecords, 1)` per batch.

In reality the reader may deliver both records in a *single* fetch, in which case the consumer receives **one** `[]Record` of length 2. When that happens:
- `assert.Eventually(len(recordsChan) == 2)` never becomes true ("Condition never satisfied"), and
- `require.Len(receivedRecords, 1)` sees 2 records and fails ("should have 1 item(s), but has 2").

This is exactly the failure observed in CI on #21266 (which does not touch `pkg/kafka`).

**Fix**: accumulate records across batches and assert on the *total* record count (2) and each record's tenant and content, instead of assuming one batch per produce.

**Verification**: the merged-batch case is rare (~0.2%), so it only reproduces under load. Running the test 500× at 50-way concurrency reproduced the single-batch `[2]` shape once; all 500 runs passed with the new assertion (the old one would have failed on that run).

**Which issue(s) this PR fixes**:
N/A — CI flake.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)