### PR TITLE
ci: Install wiresmith protobuf compiler in loki build image

### DIFF
--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -13,6 +13,11 @@ RUN git config --global --add safe.directory $SRC_DIR
 RUN echo "Install dependencies ..."
 RUN $SRC_DIR/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh $INSTALL_WORKFLOW_DEPS_ARGS
 
+# wiresmith is the protobuf compiler used by the `make wiresmith-protos` target.
+# Installed directly here (not via the loki-release-vendored deps script) so the
+# binary is present on PATH without editing vendored files.
+RUN go install github.com/grafana/wiresmith/cmd/wiresmith@v0.0.0-20260618160438-f15959a1e4e7
+
 RUN useradd -ms /bin/bash $USER
 USER $USER
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Installs the pinned `wiresmith` protobuf compiler (`github.com/grafana/wiresmith/cmd/wiresmith@v0.0.0-20260618160438-f15959a1e4e7`) into `loki-build-image/Dockerfile`. This makes the compiler available on `PATH` in the build image so proto regeneration (`make wiresmith-protos`) for the gogo→wiresmith migration (draft #22382) doesn't require a per-CI-run install step. The pin matches the go.mod pseudo-version used on that migration branch.

**Which issue(s) this PR fixes**:
N/A — no linked issue.

**Special notes for your reviewer**:
This only touches the build image and does not bump the wiresmith pin itself (pin bumps are tracked separately on the migration branch). The build image's golang base (`golang:1.26.4`, pinned in `.github/workflows/check.yml`) already satisfies wiresmith's `go 1.26.4` requirement.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added — N/A, build-image-only change with no user-facing behavior
- [x] Tests updated — N/A, no testable logic added; the added `RUN` line is exercised whenever the build image itself is built
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md` — N/A, internal build tooling only, no user-facing upgrade impact
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15) — N/A, not a configuration change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
