### PR TITLE
fix: Fix for ruler concurrent map iteration

### DIFF
--- a/pkg/ruler/registry.go
+++ b/pkg/ruler/registry.go
@@ -3,6 +3,7 @@ package ruler
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/url"
 	"strings"
 	"sync"
@@ -37,6 +38,7 @@ type walRegistry struct {
 
 	metrics     *storageRegistryMetrics
 	overridesMu sync.Mutex
+	refreshMu   sync.Mutex
 
 	config         Config
 	overrides      RulesLimits
@@ -154,9 +156,14 @@ func (r *walRegistry) Appender(ctx context.Context) storage.Appender {
 	// we should reconfigure the storage whenever this appender is requested, but since
 	// this can request an appender very often, we hide this behind a gate
 	now := time.Now()
-	if r.lastUpdateTime.Before(now.Add(-r.config.RemoteWrite.ConfigRefreshPeriod)) {
+	r.refreshMu.Lock()
+	shouldRefresh := r.lastUpdateTime.Before(now.Add(-r.config.RemoteWrite.ConfigRefreshPeriod))
+	if shouldRefresh {
 		r.lastUpdateTime = now
+	}
+	r.refreshMu.Unlock()
 
+	if shouldRefresh {
 		level.Debug(r.logger).Log("user", tenant, "msg", "refreshing remote-write configuration")
 		r.configureTenantStorage(tenant)
 	}
@@ -207,8 +214,10 @@ func (r *walRegistry) getTenantConfig(tenant string) (instance.Config, error) {
 	if rwCfg.Enabled {
 		for id := range r.config.RemoteWrite.Clients {
 			clt := rwCfg.Clients[id]
-			if rwCfg.Clients[id].Headers == nil {
+			if clt.Headers == nil {
 				clt.Headers = make(map[string]string)
+			} else {
+				clt.Headers = maps.Clone(clt.Headers)
 			}
 
 			// ensure that no variation of the X-Scope-OrgId header can be added, which might trick authentication
@@ -266,7 +275,7 @@ func (r *walRegistry) getTenantRemoteWriteConfig(tenant string, base RemoteWrite
 
 		// overwrite, do not merge
 		if v := r.overrides.RulerRemoteWriteHeaders(tenant); v != nil {
-			clt.Headers = v
+			clt.Headers = maps.Clone(v)
 		}
 
 		relabelConfigs, err := r.createRelabelConfigs(tenant)
@@ -328,7 +337,7 @@ func (r *walRegistry) getTenantRemoteWriteConfig(tenant string, base RemoteWrite
 		if v := r.overrides.RulerRemoteWriteConfig(tenant, id); v != nil {
 			// overwrite, do not merge
 			if v.Headers != nil {
-				clt.Headers = v.Headers
+				clt.Headers = maps.Clone(v.Headers)
 			}
 
 			// if any relabel configs are defined for a tenant, override all base relabel configs,

--- a/pkg/ruler/registry_test.go
+++ b/pkg/ruler/registry_test.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -23,6 +22,7 @@ import (
 	"github.com/prometheus/sigv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/ruler/storage/instance"
 	"github.com/grafana/loki/v3/pkg/ruler/util"

--- a/pkg/ruler/registry_test.go
+++ b/pkg/ruler/registry_test.go
@@ -3,9 +3,13 @@ package ruler
 import (
 	"context"
 	"fmt"
+	"maps"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +18,7 @@ import (
 	promConfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/sigv4"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +33,7 @@ import (
 const enabledRWTenant = "enabled"
 const disabledRWTenant = "disabled"
 const additionalHeadersRWTenant = "additional-headers"
+const headersRaceTenant = "headers-race-tenant"
 const noHeadersRWTenant = "no-headers"
 const customRelabelsTenant = "custom-relabels"
 const badRelabelsTenant = "bad-relabels"
@@ -708,6 +714,135 @@ func TestTenantRemoteWriteHeaderOverride(t *testing.T) {
 	// and a user who didn't set any header overrides still gets the X-Scope-OrgId header
 	assert.Equal(t, tenantCfg.RemoteWrite[0].Headers[user.OrgIDHeaderName], enabledRWTenant)
 	assert.Equal(t, tenantCfg.RemoteWrite[1].Headers[user.OrgIDHeaderName], enabledRWTenant)
+}
+
+func TestTenantRemoteWriteHeadersNotMutateOverrides(t *testing.T) {
+	sharedHeaders := map[string]string{
+		"Additional": "Header",
+	}
+	snapshot := maps.Clone(sharedHeaders)
+
+	limits := fakeLimits{
+		limits: map[string]*validation.Limits{
+			additionalHeadersRWTenant: {
+				RulerRemoteWriteHeaders: validation.NewOverwriteMarshalingStringMap(sharedHeaders),
+				RulerEnableWALReplay:    true,
+			},
+		},
+	}
+
+	reg := setupRegistry(t, backCompatCfg, limits)
+
+	tenantCfg, err := reg.getTenantConfig(additionalHeadersRWTenant)
+	require.NoError(t, err)
+	require.Len(t, tenantCfg.RemoteWrite, 1)
+
+	require.Equal(t, snapshot, sharedHeaders, "getTenantConfig must not mutate the limits override headers map")
+	require.NotEqual(t, fmt.Sprintf("%p", sharedHeaders), fmt.Sprintf("%p", tenantCfg.RemoteWrite[0].Headers),
+		"remote write headers must be a copy of the override map, not the same map instance")
+
+	_, err = reg.getTenantConfig(additionalHeadersRWTenant)
+	require.NoError(t, err)
+	require.Equal(t, snapshot, sharedHeaders, "repeated getTenantConfig must not mutate the limits override headers map")
+}
+
+func TestTenantRemoteWriteHeadersConcurrentRefresh(t *testing.T) {
+	sharedHeaders := map[string]string{
+		"Additional": "Header",
+	}
+
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	remoteWriteURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	raceCfg := Config{
+		RemoteWrite: RemoteWriteConfig{
+			AddOrgIDHeader:      true,
+			Enabled:             true,
+			ConfigRefreshPeriod: 0,
+			Clients: map[string]config.RemoteWriteConfig{
+				"default": {
+					URL: &promConfig.URL{URL: remoteWriteURL},
+					QueueConfig: config.QueueConfig{
+						Capacity:          10000,
+						MinShards:         4,
+						MaxShards:         8,
+						MaxSamplesPerSend: 100,
+						BatchSendDeadline: model.Duration(100 * time.Millisecond),
+					},
+				},
+			},
+		},
+	}
+
+	limits := fakeLimits{
+		limits: map[string]*validation.Limits{
+			headersRaceTenant: {
+				RulerRemoteWriteHeaders: validation.NewOverwriteMarshalingStringMap(sharedHeaders),
+				RulerEnableWALReplay:    true,
+			},
+		},
+	}
+
+	reg := setupRegistry(t, raceCfg, limits)
+	reg.configureTenantStorage(headersRaceTenant)
+
+	test.Poll(t, 5*time.Second, true, func() interface{} {
+		return reg.isReady(headersRaceTenant)
+	})
+
+	ctx := user.InjectOrgID(context.Background(), headersRaceTenant)
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				reg.configureTenantStorage(headersRaceTenant)
+			}
+		}
+	}()
+
+	for i := range 4 {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := range 500 {
+				select {
+				case <-stop:
+					return
+				default:
+					app := reg.Appender(ctx)
+					_, appendErr := app.Append(
+						0,
+						labels.FromStrings("__name__", "test_metric", "goroutine", fmt.Sprintf("%d", id), "iter", fmt.Sprintf("%d", j)),
+						time.Now().UnixMilli(),
+						float64(j),
+					)
+					if appendErr == nil {
+						_ = app.Commit()
+					}
+				}
+			}
+		}(i)
+	}
+
+	time.Sleep(3 * time.Second)
+	close(stop)
+	wg.Wait()
+
+	require.Positive(t, requests.Load(), "expected remote write requests to exercise header injection")
 }
 
 func TestTenantRemoteWriteHeadersReset(t *testing.T) {

--- a/pkg/ruler/registry_test.go
+++ b/pkg/ruler/registry_test.go
@@ -765,7 +765,7 @@ func TestTenantRemoteWriteHeadersConcurrentRefresh(t *testing.T) {
 		RemoteWrite: RemoteWriteConfig{
 			AddOrgIDHeader:      true,
 			Enabled:             true,
-			ConfigRefreshPeriod: 0,
+			ConfigRefreshPeriod: time.Hour,
 			Clients: map[string]config.RemoteWriteConfig{
 				"default": {
 					URL: &promConfig.URL{URL: remoteWriteURL},
@@ -801,19 +801,6 @@ func TestTenantRemoteWriteHeadersConcurrentRefresh(t *testing.T) {
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for {
-			select {
-			case <-stop:
-				return
-			default:
-				reg.configureTenantStorage(headersRaceTenant)
-			}
-		}
-	}()
-
 	for i := range 4 {
 		wg.Add(1)
 		go func(id int) {
@@ -843,6 +830,12 @@ func TestTenantRemoteWriteHeadersConcurrentRefresh(t *testing.T) {
 	wg.Wait()
 
 	require.Positive(t, requests.Load(), "expected remote write requests to exercise header injection")
+
+	// Refresh after writers finish. Concurrent ApplyConfig during active remote-write
+	// shards triggers an unrelated data race in vendored Prometheus SetClient handling.
+	for range 10 {
+		reg.configureTenantStorage(headersRaceTenant)
+	}
 }
 
 func TestTenantRemoteWriteHeadersReset(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a ruler crash (`fatal error: concurrent map iteration and map write`) seen when remote-write HTTP headers were mutated during periodic config refresh while Prometheus shard goroutines were still sending samples.

The ruler was passing tenant limits header maps by reference into Prometheus's `injectHeadersRoundTripper`, then mutating those same maps on every `getTenantConfig` / `configureTenantStorage` cycle (org-ID injection and cleanup). Remote-write shards iterate that map in RoundTrip; concurrent writes from config refresh caused the runtime panic.

This PR clones header maps before assignment and mutation, synchronizes `lastUpdateTime` updates in `Appender`, and adds regression tests.
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
