### PR TITLE
fix(dataobj-tee): Fix problem with hotspots when rateBytes=0

### DIFF
--- a/pkg/distributor/segment.go
+++ b/pkg/distributor/segment.go
@@ -51,6 +51,7 @@ type segmentationPartitionResolver struct {
 	// Metrics.
 	resolveFailed                   prometheus.Counter
 	resolveTotal                    prometheus.Counter
+	resolveRateAbsent               prometheus.Counter
 	tenantShuffleShardSize          prometheus.Histogram
 	segmentationKeyShuffleShardSize prometheus.Histogram
 }
@@ -75,6 +76,10 @@ func newSegmentationPartitionResolver(
 		resolveTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "loki_distributor_segmentation_partition_resolver_keys_total",
 			Help: "Total number of segmentation keys passed to the resolver.",
+		}),
+		resolveRateAbsent: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "loki_distributor_segmentation_partition_resolver_keys_rate_absent_total",
+			Help: "Total number of segmentation keys that we skipped shuffle sharding on segmentation key for due to absent rate.",
 		}),
 		tenantShuffleShardSize: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:                            "loki_distributor_segmentation_partition_resolver_tenant_shuffle_shard_size",
@@ -124,7 +129,17 @@ func (r *segmentationPartitionResolver) resolveRendezvousHashing(tenant string, 
 	shuffleSharder = shuffleSharder.ShuffleShard(tenant, numTenantShuffleShardPartitions)
 
 	// Shuffle shard for the segmentation key.
-	numSegKeyShuffleShardPartitions := numPartitionsForRateRendezvousHashing(rateBytes, r.perPartitionRateBytes, shuffleSharder.Size())
+	var numSegKeyShuffleShardPartitions int
+	if rateBytes == 0 {
+		// rateBytes being 0 doesn't imply that the segmentation key has low/no traffic, it
+		// tells us that we don't have rate data for this segmentation key.
+		// If the segmentation key rate is unknown, don't shard based on the segmentation key - all the
+		// traffic for that key would end up in one partition, potentially creating a hotspot.
+		r.resolveRateAbsent.Inc()
+		numSegKeyShuffleShardPartitions = shuffleSharder.Size()
+	} else {
+		numSegKeyShuffleShardPartitions = numPartitionsForRateRendezvousHashing(rateBytes, r.perPartitionRateBytes, shuffleSharder.Size())
+	}
 	shuffleSharder = shuffleSharder.ShuffleShard(string(key), numSegKeyShuffleShardPartitions)
 
 	r.tenantShuffleShardSize.Observe(float64(numTenantShuffleShardPartitions))

--- a/pkg/distributor/segment.go
+++ b/pkg/distributor/segment.go
@@ -188,9 +188,12 @@ func (r *segmentationPartitionResolver) resolveConsistentHashing(tenant string, 
 		r.resolveFailed.Inc()
 		return 0, fmt.Errorf("failed to shuffle shard tenant: %w", err)
 	}
+	r.tenantShuffleShardSize.Observe(float64(subring.ActivePartitionsCount()))
+
 	// If the rate is 0, we cannot make a decision to shuffle shard the segmentation
 	// key. We fallback to choosing a partition for the hash key.
 	if rateBytes == 0 {
+		r.resolveRateAbsent.Inc()
 		return subring.ActivePartitionForKey(hashKey)
 	}
 	numShuffleShardPartitions := numPartitionsForRateConsistentHashing(rateBytes, r.perPartitionRateBytes, subring.ActivePartitionsCount())
@@ -204,6 +207,7 @@ func (r *segmentationPartitionResolver) resolveConsistentHashing(tenant string, 
 		r.resolveFailed.Inc()
 		return 0, fmt.Errorf("failed to get segmentation key subring: %w", err)
 	}
+	r.segmentationKeyShuffleShardSize.Observe(float64(subring.ActivePartitionsCount()))
 	// TODO(grobinson): We need to use a different method that does not depend on
 	// stream sharding, as this information comes from the ingesters.
 	return subring.ActivePartitionForKey(hashKey)

--- a/pkg/distributor/segment.go
+++ b/pkg/distributor/segment.go
@@ -127,6 +127,7 @@ func (r *segmentationPartitionResolver) resolveRendezvousHashing(tenant string, 
 		numTenantShuffleShardPartitions = numPartitionsForRateRendezvousHashing(tenantRateLimitBytes, r.perPartitionRateBytes, shuffleSharder.Size())
 	}
 	shuffleSharder = shuffleSharder.ShuffleShard(tenant, numTenantShuffleShardPartitions)
+	r.tenantShuffleShardSize.Observe(float64(numTenantShuffleShardPartitions))
 
 	// Shuffle shard for the segmentation key.
 	var numSegKeyShuffleShardPartitions int
@@ -139,11 +140,9 @@ func (r *segmentationPartitionResolver) resolveRendezvousHashing(tenant string, 
 		numSegKeyShuffleShardPartitions = shuffleSharder.Size()
 	} else {
 		numSegKeyShuffleShardPartitions = numPartitionsForRateRendezvousHashing(rateBytes, r.perPartitionRateBytes, shuffleSharder.Size())
+		r.segmentationKeyShuffleShardSize.Observe(float64(numSegKeyShuffleShardPartitions))
 	}
 	shuffleSharder = shuffleSharder.ShuffleShard(string(key), numSegKeyShuffleShardPartitions)
-
-	r.tenantShuffleShardSize.Observe(float64(numTenantShuffleShardPartitions))
-	r.segmentationKeyShuffleShardSize.Observe(float64(numSegKeyShuffleShardPartitions))
 
 	// Finally, shard based on the hash key.
 	partition, err := shuffleSharder.Shard(hashKey)
@@ -194,7 +193,6 @@ func (r *segmentationPartitionResolver) resolveConsistentHashing(tenant string, 
 	// key. We fallback to choosing a partition for the hash key.
 	if rateBytes == 0 {
 		r.resolveRateAbsent.Inc()
-		r.segmentationKeyShuffleShardSize.Observe(float64(subring.ActivePartitionsCount()))
 		return subring.ActivePartitionForKey(hashKey)
 	}
 	numShuffleShardPartitions := numPartitionsForRateConsistentHashing(rateBytes, r.perPartitionRateBytes, subring.ActivePartitionsCount())

--- a/pkg/distributor/segment.go
+++ b/pkg/distributor/segment.go
@@ -194,12 +194,14 @@ func (r *segmentationPartitionResolver) resolveConsistentHashing(tenant string, 
 	// key. We fallback to choosing a partition for the hash key.
 	if rateBytes == 0 {
 		r.resolveRateAbsent.Inc()
+		r.segmentationKeyShuffleShardSize.Observe(float64(subring.ActivePartitionsCount()))
 		return subring.ActivePartitionForKey(hashKey)
 	}
 	numShuffleShardPartitions := numPartitionsForRateConsistentHashing(rateBytes, r.perPartitionRateBytes, subring.ActivePartitionsCount())
 	// If the segmentation key is small enough that it does not need to be sharded,
 	// we can avoid doing an expensive shuffle shard.
 	if numShuffleShardPartitions == 1 {
+		r.segmentationKeyShuffleShardSize.Observe(1)
 		return subring.ActivePartitionForKey(uint32(key.Sum64()))
 	}
 	subring, err = subring.ShuffleShard(string(key), numShuffleShardPartitions)

--- a/pkg/distributor/segment_test.go
+++ b/pkg/distributor/segment_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"hash/fnv"
+	"math"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -111,9 +114,9 @@ func TestSegmentationPartitionResolver_Resolve(t *testing.T) {
 		require.EqualError(t, err, "no active partitions")
 
 		require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-			# HELP loki_distributor_segmentation_partition_resolver_keys_randomly_sharded_total Total number of segmentation keys that fell back to a random active partition due to absent rate.
-			# TYPE loki_distributor_segmentation_partition_resolver_keys_randomly_sharded_total counter
-			loki_distributor_segmentation_partition_resolver_keys_randomly_sharded_total 1
+			# HELP loki_distributor_segmentation_partition_resolver_keys_rate_absent_total Total number of segmentation keys that we skipped shuffle sharding on segmentation key for due to absent rate.
+			# TYPE loki_distributor_segmentation_partition_resolver_keys_rate_absent_total counter
+			loki_distributor_segmentation_partition_resolver_keys_rate_absent_total 1
 			# HELP loki_distributor_segmentation_partition_resolver_keys_failed_total Total number of segmentation keys that could not be resolved.
 			# TYPE loki_distributor_segmentation_partition_resolver_keys_failed_total counter
 			loki_distributor_segmentation_partition_resolver_keys_failed_total 1
@@ -121,7 +124,7 @@ func TestSegmentationPartitionResolver_Resolve(t *testing.T) {
 			# TYPE loki_distributor_segmentation_partition_resolver_keys_total counter
 			loki_distributor_segmentation_partition_resolver_keys_total 1
 		`),
-			"loki_distributor_segmentation_partition_resolver_keys_allback_total",
+			"loki_distributor_segmentation_partition_resolver_keys_rate_absent_total",
 			"loki_distributor_segmentation_partition_resolver_keys_failed_total",
 			"loki_distributor_segmentation_partition_resolver_keys_total",
 		))
@@ -137,9 +140,9 @@ func TestSegmentationPartitionResolver_Resolve(t *testing.T) {
 		require.Equal(t, int32(1), partition)
 
 		require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-			# HELP loki_distributor_segmentation_partition_resolver_keys_randomly_sharded_total Total number of segmentation keys that fell back to a random active partition due to absent rate.
-			# TYPE loki_distributor_segmentation_partition_resolver_keys_randomly_sharded_total counter
-			loki_distributor_segmentation_partition_resolver_keys_randomly_sharded_total 1
+			# HELP loki_distributor_segmentation_partition_resolver_keys_rate_absent_total Total number of segmentation keys that we skipped shuffle sharding on segmentation key for due to absent rate.
+			# TYPE loki_distributor_segmentation_partition_resolver_keys_rate_absent_total counter
+			loki_distributor_segmentation_partition_resolver_keys_rate_absent_total 1
 			# HELP loki_distributor_segmentation_partition_resolver_keys_failed_total Total number of segmentation keys that could not be resolved.
 			# TYPE loki_distributor_segmentation_partition_resolver_keys_failed_total counter
 			loki_distributor_segmentation_partition_resolver_keys_failed_total 0
@@ -147,7 +150,7 @@ func TestSegmentationPartitionResolver_Resolve(t *testing.T) {
 			# TYPE loki_distributor_segmentation_partition_resolver_keys_total counter
 			loki_distributor_segmentation_partition_resolver_keys_total 1
 		`),
-			"loki_distributor_segmentation_partition_resolver_keys_allback_total",
+			"loki_distributor_segmentation_partition_resolver_keys_rate_absent_total",
 			"loki_distributor_segmentation_partition_resolver_keys_failed_total",
 			"loki_distributor_segmentation_partition_resolver_keys_total",
 		))
@@ -181,7 +184,7 @@ func TestSegmentationPartitionResolver_TenantShuffleShard(t *testing.T) {
 		expectedNumShards    int
 	}{
 		{500, 500, 1},
-		{0, 0, 1},
+		{0, 0, 5},
 		{1_000_000, 0, 5},
 		{1500, 1500, 2},
 		{3000, 1500, 2},
@@ -201,4 +204,207 @@ func TestSegmentationPartitionResolver_TenantShuffleShard(t *testing.T) {
 			require.Len(t, seen, test.expectedNumShards)
 		})
 	}
+}
+
+// buildResolvers constructs a rendezvous and consistent-hashing segmentationPartitionResolver
+// backed by the same set of partition IDs. Both are ready to use for uniformity tests.
+func buildResolvers(t *testing.T, partitionIDs []int32, perPartitionRateBytes uint64) (rendezvousResolver, consistentResolver *segmentationPartitionResolver) {
+	t.Helper()
+
+	chRingDesc := ring.PartitionRingDesc{
+		Partitions: make(map[int32]ring.PartitionDesc, len(partitionIDs)),
+		Owners:     make(map[string]ring.OwnerDesc, len(partitionIDs)),
+	}
+	tokenSpacing := uint64(math.MaxUint32) / uint64(len(partitionIDs))
+	for i, id := range partitionIDs {
+		chRingDesc.Partitions[id] = ring.PartitionDesc{
+			Id:             id,
+			Tokens:         []uint32{uint32(uint64(i) * tokenSpacing)},
+			State:          ring.PartitionActive,
+			StateTimestamp: time.Now().Unix(),
+		}
+		chRingDesc.Owners[fmt.Sprintf("owner-%d", i)] = ring.OwnerDesc{
+			OwnedPartition:   id,
+			State:            ring.OwnerActive,
+			UpdatedTimestamp: time.Now().Unix(),
+		}
+	}
+	chRing, err := ring.NewPartitionRing(chRingDesc)
+	require.NoError(t, err)
+
+	rendezvousResolver = newSegmentationPartitionResolver(
+		perPartitionRateBytes, true, nil,
+		newPartitionRingWatcher(t, partitionIDs...),
+		prometheus.NewRegistry(), log.NewNopLogger(),
+	)
+	consistentResolver = newSegmentationPartitionResolver(
+		perPartitionRateBytes, false,
+		mockPartitionRingReader{ring: chRing}, nil,
+		prometheus.NewRegistry(), log.NewNopLogger(),
+	)
+	return rendezvousResolver, consistentResolver
+}
+
+type uniformityStream struct {
+	tenant    string
+	segKey    segmentationKey
+	hashKey   uint32
+	rateBytes uint64
+	sizeBytes float64 // actual data volume, independent of rateBytes used for routing
+}
+
+// measureEntropy resolves every stream against the given resolver, accumulates
+// sizeBytes per partition, and returns the normalized Shannon entropy.
+func measureEntropy(t *testing.T, resolver *segmentationPartitionResolver, partitionIDs []int32, streams []uniformityStream, tenantRateLimitBytes uint64) float64 {
+	t.Helper()
+	partitionLoad := make(map[int32]float64, len(partitionIDs))
+	for _, id := range partitionIDs {
+		partitionLoad[id] = 0
+	}
+	for _, s := range streams {
+		partition, err := resolver.Resolve(s.tenant, s.segKey, s.hashKey, s.rateBytes, tenantRateLimitBytes)
+		require.NoError(t, err)
+		partitionLoad[partition] += s.sizeBytes
+	}
+
+	total := 0.0
+	for _, load := range partitionLoad {
+		total += load
+	}
+	entropy := 0.0
+	for _, load := range partitionLoad {
+		if load > 0 {
+			p := load / total
+			entropy -= p * math.Log2(p)
+		}
+	}
+	maxEntropy := math.Log2(float64(len(partitionIDs)))
+	normalized := entropy / maxEntropy
+
+	minLoad, maxLoad := math.MaxFloat64, 0.0
+	for _, load := range partitionLoad {
+		if load < minLoad {
+			minLoad = load
+		}
+		if load > maxLoad {
+			maxLoad = load
+		}
+	}
+	t.Logf("total=%.1f MB/s  min=%.1f MB/s  max=%.1f MB/s  ratio=%.2f  entropy=%.4f",
+		total/1e6, minLoad/1e6, maxLoad/1e6, maxLoad/minLoad, normalized)
+	return normalized
+}
+
+// TestSegmentationPartitionResolver_ThroughputUniformity measures how evenly each
+// implementation distributes ingestion load across partitions using Shannon entropy.
+// Both resolvers receive the same (tenant, segmentation key) pairs with random
+// throughputs, letting us compare their uniformity directly.
+// Normalized entropy (H / log2(numPartitions)) of 1.0 means perfectly uniform load.
+func TestSegmentationPartitionResolver_ThroughputUniformity(t *testing.T) {
+	const (
+		numPartitions        = 10
+		numTenants           = 1
+		numSegKeys           = 100 // per tenant — enough to cover all partitions reliably
+		perPartitionRateMBps = 10
+		numTenantPartitions  = 10 // partitions each tenant's rate limit maps to
+		minThroughputMBps    = 1
+		maxThroughputMBps    = 50
+		minNormalizedEntropy = 0.95
+	)
+
+	perPartitionRateBytes := uint64(perPartitionRateMBps * 1024 * 1024)
+	tenantRateLimitBytes := uint64(numTenantPartitions * perPartitionRateMBps * 1024 * 1024)
+
+	partitionIDs := make([]int32, numPartitions)
+	for i := range numPartitions {
+		partitionIDs[i] = int32(i)
+	}
+	rendezvousRes, consistentRes := buildResolvers(t, partitionIDs, perPartitionRateBytes)
+
+	rng := rand.New(rand.NewSource(42))
+	streams := make([]uniformityStream, 0, numTenants*numSegKeys)
+	for ti := range numTenants {
+		for si := range numSegKeys {
+			throughputMBps := minThroughputMBps + rng.Intn(maxThroughputMBps-minThroughputMBps+1)
+			rate := uint64(throughputMBps) * 1024 * 1024
+			streams = append(streams, uniformityStream{
+				tenant:    fmt.Sprintf("tenant-%d", ti),
+				segKey:    segmentationKey(fmt.Sprintf("segkey-%d", si)),
+				hashKey:   fnv32(ti*numSegKeys + si),
+				rateBytes: rate,
+				sizeBytes: float64(rate),
+			})
+		}
+	}
+
+	for _, tc := range []struct {
+		name                 string
+		resolver             *segmentationPartitionResolver
+		minNormalizedEntropy float64
+	}{
+		{"rendezvous", rendezvousRes, minNormalizedEntropy},
+		// Consistent hashing included for comparison only — no minimum threshold.
+		{"consistent", consistentRes, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			normalized := measureEntropy(t, tc.resolver, partitionIDs, streams, tenantRateLimitBytes)
+			if tc.minNormalizedEntropy > 0 {
+				require.GreaterOrEqual(t, normalized, tc.minNormalizedEntropy,
+					"throughput should be uniformly distributed across partitions")
+			}
+		})
+	}
+}
+
+// TestSegmentationPartitionResolver_ZeroRate_DistributesByHashKey verifies that
+// rendezvous hashing distributes streams by their hash key when rateBytes=0.
+func TestSegmentationPartitionResolver_ZeroRate_DistributesByHashKey(t *testing.T) {
+	const (
+		numPartitions        = 10
+		numStreams           = 200
+		minNormalizedEntropy = 0.9
+	)
+
+	partitionIDs := make([]int32, numPartitions)
+	for i := range numPartitions {
+		partitionIDs[i] = int32(i)
+	}
+	rendezvousRes, consistentRes := buildResolvers(t, partitionIDs, 10*1024*1024)
+
+	rng := rand.New(rand.NewSource(42))
+	streams := make([]uniformityStream, numStreams)
+	for i := range numStreams {
+		streams[i] = uniformityStream{
+			tenant:    "tenant",
+			segKey:    "my-service", // all streams share one segkey
+			hashKey:   rng.Uint32(), // but each has a distinct label hash
+			rateBytes: 0,            // unknown — simulates fresh deployment
+			sizeBytes: 1,
+		}
+	}
+
+	for _, tc := range []struct {
+		name     string
+		resolver *segmentationPartitionResolver
+	}{
+		{"rendezvous", rendezvousRes},
+		{"consistent", consistentRes},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			normalized := measureEntropy(t, tc.resolver, partitionIDs, streams, 0)
+			require.GreaterOrEqual(t, normalized, float64(minNormalizedEntropy),
+				"streams with rateBytes=0 must spread across partitions by hash key; "+
+					"before the fix all streams for a segkey collapsed to one partition")
+		})
+	}
+}
+
+// fnv32 hashes an integer to a well-distributed uint32, suitable for use as a
+// stream hash key in tests. Using raw sequential values is not representative —
+// they cluster near 0 and defeat consistent hashing's clockwise ring walk.
+func fnv32(n int) uint32 {
+	h := fnv.New32a()
+	b := [4]byte{byte(n), byte(n >> 8), byte(n >> 16), byte(n >> 24)}
+	h.Write(b[:])
+	return h.Sum32()
 }


### PR DESCRIPTION
Also add tests for evenness of distribution across partitions.

The problem here is that rateBytes being 0 doesn't mean that the rate of that segmentation key is zero/low, it means that we don't currently have rate data for that segmentation key. Currently, a large segmentation key can end up getting send disproportionately to a single partition (shuffle sharded with k=1 by segmentation key), whereas it should be spread more evenly by sharding by hashKey. This PR changes the rendezvous implementation to match the consistent hashing implementations behaviour in this situation. 