### PR TITLE
fix(storage): Fix index filename issue with legacy S3 client and `chunk_delimiter: "-"`

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -6207,7 +6207,8 @@ The `s3_storage_config` block configures the connection to Amazon S3 object stor
 
 # Delimiter used to replace the default delimiter ':' in chunk IDs when storing
 # chunks. This is mainly intended when you run a MinIO instance on a Windows
-# machine. You should not change this value inflight.
+# machine. You must not change this value during operations, otherwise you may
+# not be able to read existing chunks from object storage.
 # CLI flag: -<prefix>.s3.chunk-delimiter
 [chunk_delimiter: <string> | default = ""]
 

--- a/pkg/storage/chunk/client/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client.go
@@ -402,7 +402,7 @@ func (a *S3ObjectClient) objectAttributes(ctx context.Context, objectKey, method
 		lastErr = instrument.CollectedRequest(ctx, method, s3RequestDuration, instrument.ErrorCode, func(_ context.Context) error {
 			headObjectInput := &s3.HeadObjectInput{
 				Bucket: aws.String(a.bucketFromKey(objectKey)),
-				Key:    aws.String(a.convertObjectKey(objectKey, true)),
+				Key:    aws.String(a.rewriteKey(objectKey)),
 			}
 			headOutput, requestErr := a.S3.HeadObject(ctx, headObjectInput)
 			if requestErr != nil {
@@ -432,7 +432,7 @@ func (a *S3ObjectClient) DeleteObject(ctx context.Context, objectKey string) err
 	return instrument.CollectedRequest(ctx, "S3.DeleteObject", s3RequestDuration, instrument.ErrorCode, func(ctx context.Context) error {
 		deleteObjectInput := &s3.DeleteObjectInput{
 			Bucket: aws.String(a.bucketFromKey(objectKey)),
-			Key:    aws.String(a.convertObjectKey(objectKey, true)),
+			Key:    aws.String(a.rewriteKey(objectKey)),
 		}
 
 		_, err := a.S3.DeleteObject(ctx, deleteObjectInput)
@@ -469,7 +469,7 @@ func (a *S3ObjectClient) GetObject(ctx context.Context, objectKey string) (io.Re
 			var requestErr error
 			resp, requestErr = a.hedgedS3.GetObject(ctx, &s3.GetObjectInput{
 				Bucket: aws.String(a.bucketFromKey(objectKey)),
-				Key:    aws.String(a.convertObjectKey(objectKey, true)),
+				Key:    aws.String(a.rewriteKey(objectKey)),
 			})
 			return requestErr
 		})
@@ -504,7 +504,7 @@ func (a *S3ObjectClient) GetObjectRange(ctx context.Context, objectKey string, o
 			var requestErr error
 			resp, requestErr = a.hedgedS3.GetObject(ctx, &s3.GetObjectInput{
 				Bucket: aws.String(a.bucketFromKey(objectKey)),
-				Key:    aws.String(a.convertObjectKey(objectKey, true)),
+				Key:    aws.String(a.rewriteKey(objectKey)),
 				Range:  aws.String(fmt.Sprintf("bytes=%d-%d", offset, offset+length-1)),
 			})
 			return requestErr
@@ -549,7 +549,7 @@ func (a *S3ObjectClient) PutObject(ctx context.Context, objectKey string, object
 		putObjectInput := &s3.PutObjectInput{
 			Body:              readSeeker,
 			Bucket:            aws.String(a.bucketFromKey(objectKey)),
-			Key:               aws.String(a.convertObjectKey(objectKey, true)),
+			Key:               aws.String(a.rewriteKey(objectKey)),
 			StorageClass:      types.StorageClass(a.cfg.StorageClass),
 			ChecksumAlgorithm: types.ChecksumAlgorithmSha256,
 			ChecksumSHA256:    aws.String(sha256Checksum),
@@ -588,7 +588,7 @@ func (a *S3ObjectClient) List(ctx context.Context, prefix, delimiter string) ([]
 
 				for _, content := range output.Contents {
 					storageObjects = append(storageObjects, client.StorageObject{
-						Key:        a.convertObjectKey(*content.Key, false),
+						Key:        *content.Key, // don't rewrite key
 						ModifiedAt: *content.LastModified,
 					})
 				}
@@ -725,14 +725,10 @@ func (a *S3ObjectClient) IsRetryableErr(err error) bool {
 	return IsRetryableErr(err)
 }
 
-// convertObjectKey modifies the object key based on a delimiter and a mode flag determining conversion.
-func (a *S3ObjectClient) convertObjectKey(objectKey string, toS3 bool) string {
+// rewriteKey modifies the object key based on a delimiter
+func (a *S3ObjectClient) rewriteKey(key string) string {
 	if len(a.cfg.ChunkDelimiter) == 1 {
-		if toS3 {
-			objectKey = strings.ReplaceAll(objectKey, ":", a.cfg.ChunkDelimiter)
-		} else {
-			objectKey = strings.ReplaceAll(objectKey, a.cfg.ChunkDelimiter, ":")
-		}
+		return strings.ReplaceAll(key, ":", a.cfg.ChunkDelimiter)
 	}
-	return objectKey
+	return key
 }

--- a/pkg/storage/chunk/client/aws/s3_storage_client.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client.go
@@ -115,7 +115,7 @@ func (cfg *S3Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.Var(&cfg.SecretAccessKey, prefix+"s3.secret-access-key", "AWS Secret Access Key")
 	f.Var(&cfg.SessionToken, prefix+"s3.session-token", "AWS Session Token")
 	f.BoolVar(&cfg.Insecure, prefix+"s3.insecure", false, "Disable https on s3 connection.")
-	f.StringVar(&cfg.ChunkDelimiter, prefix+"s3.chunk-delimiter", "", "Delimiter used to replace the default delimiter ':' in chunk IDs when storing chunks. This is mainly intended when you run a MinIO instance on a Windows machine. You should not change this value inflight.")
+	f.StringVar(&cfg.ChunkDelimiter, prefix+"s3.chunk-delimiter", "", "Delimiter used to replace the default delimiter ':' in chunk IDs when storing chunks. This is mainly intended when you run a MinIO instance on a Windows machine. You must not change this value during operations, otherwise you may not be able to read existing chunks from object storage.")
 	f.BoolVar(&cfg.DisableDualstack, prefix+"s3.disable-dualstack", false, "Disable forcing S3 dualstack endpoint usage.")
 
 	cfg.SSEConfig.RegisterFlagsWithPrefix(prefix+"s3.sse.", f)

--- a/pkg/storage/chunk/client/aws/s3_storage_client_test.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client_test.go
@@ -314,17 +314,17 @@ func Test_Hedging(t *testing.T) {
 	}
 }
 
-type MockS3Client struct {
-	s3.Client
+type testAttributesS3Client struct {
+	*s3.Client
 	HeadObjectFunc func(context.Context, *s3.HeadObjectInput) (*s3.HeadObjectOutput, error)
 }
 
-func (m *MockS3Client) HeadObject(ctx context.Context, input *s3.HeadObjectInput, _ ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+func (m *testAttributesS3Client) HeadObject(ctx context.Context, input *s3.HeadObjectInput, _ ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
 	return m.HeadObjectFunc(ctx, input)
 }
 
 func Test_GetAttributes(t *testing.T) {
-	mockS3 := &MockS3Client{
+	mockS3 := &testAttributesS3Client{
 		HeadObjectFunc: func(_ context.Context, _ *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
 			var size int64 = 128
 			return &s3.HeadObjectOutput{ContentLength: &size}, nil
@@ -412,7 +412,7 @@ func Test_RetryLogic(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			callCount := atomic.NewInt32(0)
 
-			mockS3 := &MockS3Client{
+			mockS3 := &testAttributesS3Client{
 				HeadObjectFunc: func(_ context.Context, _ *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
 					callNum := callCount.Inc()
 					if !tc.exists {
@@ -639,4 +639,183 @@ func TestPutObject_SwiftRejects_AWSChunked(t *testing.T) {
 	err = client.PutObject(context.Background(), "logs/chunk-001", bytes.NewReader(body))
 	require.NoError(t, err,
 		"PutObject must succeed against OpenStack Swift (no aws-chunked should be sent)")
+}
+
+// TestRewriteKey asserts the fix for rewriting using a chunk delimiter
+// the S3 client must only convert colons (":") to the configured chunk
+// delimiter, and must never convert delimiter characters back to colons. The
+// latter corrupted TSDB index file names (which contain dashes) when the
+// delimiter was "-", producing invalid paths such as
+// "...:compactor:...:....tsdb".
+func TestRewriteKey(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		delimiter string
+		key       string
+		expected  string
+	}{
+		{
+			name:      "no delimiter configured leaves key untouched",
+			delimiter: "",
+			key:       "fake/01234567890123456789/1234567890:1234567890:abcdef",
+			expected:  "fake/01234567890123456789/1234567890:1234567890:abcdef",
+		},
+		{
+			name:      "chunk key colons are converted to dash delimiter",
+			delimiter: "-",
+			key:       "fake/01234567890123456789/1234567890:1234567890:abcdef",
+			expected:  "fake/01234567890123456789/1234567890-1234567890-abcdef",
+		},
+		{
+			name:      "tsdb index file name with dashes is not corrupted",
+			delimiter: "-",
+			key:       "loki_index_v2_20598/fake/1779799681971192955-compactor-1779659125419-1779761781223-4eafaf2b.tsdb",
+			expected:  "loki_index_v2_20598/fake/1779799681971192955-compactor-1779659125419-1779761781223-4eafaf2b.tsdb",
+		},
+		{
+			name:      "chunk key colons are converted to dot delimiter",
+			delimiter: ".",
+			key:       "fake/01234567890123456789/1234567890:1234567890:abcdef",
+			expected:  "fake/01234567890123456789/1234567890.1234567890.abcdef",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &S3ObjectClient{cfg: S3Config{ChunkDelimiter: tc.delimiter}}
+			require.Equal(t, tc.expected, client.rewriteKey(tc.key))
+		})
+	}
+}
+
+type mockS3Backend struct {
+	*s3.Client
+	objects map[string]string // backend key -> body
+	getKeys []string          // keys requested via GetObject
+	putKeys []string          // keys written via PutObject
+}
+
+func (m *mockS3Backend) ListObjectsV2(_ context.Context, _ *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	out := &s3.ListObjectsV2Output{IsTruncated: aws.Bool(false)}
+	for key := range m.objects {
+		out.Contents = append(out.Contents, types.Object{
+			Key:          aws.String(key),
+			LastModified: aws.Time(time.Unix(0, 0)),
+		})
+	}
+	return out, nil
+}
+
+func (m *mockS3Backend) GetObject(_ context.Context, params *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	key := aws.ToString(params.Key)
+	m.getKeys = append(m.getKeys, key)
+	body, ok := m.objects[key]
+	if !ok {
+		return nil, &types.NoSuchKey{}
+	}
+	return &s3.GetObjectOutput{
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: aws.Int64(int64(len(body))),
+	}, nil
+}
+
+func (m *mockS3Backend) PutObject(_ context.Context, params *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	key := aws.ToString(params.Key)
+	m.putKeys = append(m.putKeys, key)
+	body, err := io.ReadAll(params.Body)
+	if err != nil {
+		return nil, err
+	}
+	if m.objects == nil {
+		m.objects = map[string]string{}
+	}
+	m.objects[key] = string(body)
+	return &s3.PutObjectOutput{}, nil
+}
+
+// TestChunkDelimiter_IndexRoundTrip asserts the fix from commit d3214a7a6b
+// using a full S3ObjectClient against a mock S3 backend.
+//
+// When the chunk delimiter is "-" (as used to escape colons in chunk keys),
+// the client must NOT rewrite the dashes in a TSDB index file name back to
+// colons. The previous implementation did, which produced invalid local index
+// paths such as "...:compactor:...:....tsdb" and caused index downloads to fail.
+//
+// The test exercises the real code path: List returns the object keys as
+// stored, and GetObject requests the exact same key from the backend.
+func TestChunkDelimiter_RoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		delimiter string
+		localKey  string
+		remoteKey string
+	}{
+		{
+			name:      "chunk object with no delimiter",
+			delimiter: "",
+			localKey:  "fake/01234567890123456789/1234567890:1234567890:deadbeef",
+			remoteKey: "fake/01234567890123456789/1234567890:1234567890:deadbeef",
+		},
+		{
+			name:      "chunk object with dash delimiter",
+			delimiter: "-",
+			localKey:  "fake/01234567890123456789/1234567890:1234567890:deadbeef",
+			remoteKey: "fake/01234567890123456789/1234567890-1234567890-deadbeef",
+		},
+		{
+			name:      "chunk object with dot delimiter",
+			delimiter: ".",
+			localKey:  "fake/01234567890123456789/1234567890:1234567890:deadbeef",
+			remoteKey: "fake/01234567890123456789/1234567890.1234567890.deadbeef",
+		},
+		{
+			name:      "index object with dash delimiter",
+			delimiter: "-",
+			localKey:  "loki_index_v2_20598/fake/1779799681971192955-compactor-1779659125419-1779761781223-4eafaf2b.tsdb",
+			remoteKey: "loki_index_v2_20598/fake/1779799681971192955-compactor-1779659125419-1779761781223-4eafaf2b.tsdb",
+		},
+		{
+			name:      "index object with dot delimiter",
+			delimiter: ".",
+			localKey:  "loki_index_v2_20598/fake/1779799681971192955-compactor-1779659125419-1779761781223-4eafaf2b.tsdb",
+			remoteKey: "loki_index_v2_20598/fake/1779799681971192955-compactor-1779659125419-1779761781223-4eafaf2b.tsdb",
+		},
+	} {
+
+		t.Run(tc.name, func(tt *testing.T) {
+			mock := &mockS3Backend{
+				objects: map[string]string{
+					tc.remoteKey: tc.name,
+				},
+			}
+			client := &S3ObjectClient{
+				cfg:         S3Config{ChunkDelimiter: tc.delimiter},
+				bucketNames: []string{"test"},
+				S3:          mock,
+				hedgedS3:    mock,
+			}
+
+			ctx := tt.Context()
+
+			// PutObject
+			require.NoError(tt, client.PutObject(ctx, tc.localKey, strings.NewReader(tc.name)))
+			require.ElementsMatch(tt, []string{tc.remoteKey}, mock.putKeys)
+
+			// List
+			objects, _, err := client.List(ctx, "", "")
+			require.NoError(tt, err)
+			keys := make([]string, 0, len(objects))
+			for _, o := range objects {
+				keys = append(keys, o.Key)
+			}
+			require.ElementsMatch(tt, []string{tc.remoteKey}, keys)
+
+			// GetObject
+			rc, _, err := client.GetObject(ctx, tc.localKey)
+			require.NoError(tt, err)
+			body, err := io.ReadAll(rc)
+			require.NoError(tt, err)
+			require.NoError(tt, rc.Close())
+			require.Equal(tt, tc.name, string(body))
+			require.ElementsMatch(tt, []string{tc.remoteKey}, mock.getKeys)
+		})
+	}
 }


### PR DESCRIPTION
### Summary

When using the legacy S3 storage client (`use_thanos_objstore: false`)
in combination with `chunk_delimiter: "-"`, the object client
downloading TSDB indexes failed because of the conversion of dashes to
colons in the file name, e.g.

```
1779799681971192955-compactor-1779659125419-1779761781223-4eafaf2b.tsdb
=>
1779799681971192955:compactor:1779659125419:1779761781223:4eafaf2b.tsdb
```

The latter is an invalid TSDB file name and therefore causes the error

```
level=error caller=index_set.go:133 table-name=loki_index_v2_20598 user-id=fake msg="failed to open existing index file /var/loki/tsdb-shipper-cache/loki_index_v2_20598/fake/1779799681971192955:compactor:1779659125419:1779761781223:4eafaf2b.tsdb, removing the file and continuing without it to let the sync operation catch up" err="invalid tsdb path: /var/loki/tsdb-shipper-cache/loki_index_v2_20598/fake/1779799681971192955:compactor:1779659125419:1779761781223:4eafaf2b.tsdb"
```

Unlike the [Azure blob client](https://github.com/grafana/loki/blob/33b30c883ad3de81c4831c2fa9bf7f3244d43471/pkg/storage/bucket/azure/key_rewrite_bucket.go#L11-L15), that also rewrites colons to the
configured delimiter (`-`) for chunk objects, the S3 client
implementation wrongly also converted dashes back to colons when
retrieving files.

This PR fixes the rewrite of the object key by only converting colons
(`:`) to the specified delimiter (`-`) which applies for chunks only.

Note, this bug only occurred when the delimiter was a dash `-`, since
that's a hard-coded requirement of the index filename. Other delimiters,
such as dot (`.`) would not cause this issue.

#### TODO

- [x] Add test case

---

Fixes: https://github.com/grafana/loki/issues/22061
Closes: https://github.com/grafana/loki/pull/22135