### PR TITLE
chore(storage)!: Use Thanos storage clients by default

### DIFF
--- a/docs/sources/configure/examples/configuration-examples.md
+++ b/docs/sources/configure/examples/configuration-examples.md
@@ -306,6 +306,7 @@ schema_config:
         prefix: index_
 
 storage_config:
+  use_thanos_objstore: false # COS is not yet supported by Thanos storage client
   cos:
     bucketnames: <bucket1, bucket2>
     endpoint: <endpoint>
@@ -335,6 +336,7 @@ schema_config:
         prefix: index_
 
 storage_config:
+  use_thanos_objstore: false # COS is not yet supported by Thanos storage client
   cos:
     bucketnames: <bucket1, bucket2>
     endpoint: <endpoint>
@@ -350,10 +352,10 @@ storage_config:
 
 ```yaml
 
-# This partial configuration uses IBM Cloud Object Storage (COS) for chunk storage. 
+# This partial configuration uses IBM Cloud Object Storage (COS) for chunk storage.
 # A trusted profile will be used for authenticating with COS. We can either pass
 # the trusted profile name or trusted profile ID along with the compute resource token file.
-# If we pass both trusted profile name and trusted profile ID it should be of 
+# If we pass both trusted profile name and trusted profile ID it should be of
 # the same trusted profile.
 # In order to use trusted profile authentication we need to follow an additional step to create a trusted profile.
 # For more details about creating a trusted profile, see https://cloud.ibm.com/docs/account?topic=account-create-trusted-profile&interface=ui.
@@ -371,6 +373,7 @@ schema_config:
         prefix: index_
 
 storage_config:
+  use_thanos_objstore: false # COS is not yet supported by Thanos storage client
   cos:
     bucketnames: <bucket1, bucket2>
     endpoint: <endpoint>

--- a/docs/sources/configure/examples/yaml/11-COS-HMAC-Example.yaml
+++ b/docs/sources/configure/examples/yaml/11-COS-HMAC-Example.yaml
@@ -13,6 +13,7 @@ schema_config:
         prefix: index_
 
 storage_config:
+  use_thanos_objstore: false # COS is not yet supported by Thanos storage client
   cos:
     bucketnames: <bucket1, bucket2>
     endpoint: <endpoint>

--- a/docs/sources/configure/examples/yaml/12-COS-APIKey-Example.yaml
+++ b/docs/sources/configure/examples/yaml/12-COS-APIKey-Example.yaml
@@ -13,6 +13,7 @@ schema_config:
         prefix: index_
 
 storage_config:
+  use_thanos_objstore: false # COS is not yet supported by Thanos storage client
   cos:
     bucketnames: <bucket1, bucket2>
     endpoint: <endpoint>

--- a/docs/sources/configure/examples/yaml/13-COS-Trusted-Profile-Example.yaml
+++ b/docs/sources/configure/examples/yaml/13-COS-Trusted-Profile-Example.yaml
@@ -1,7 +1,7 @@
-# This partial configuration uses IBM Cloud Object Storage (COS) for chunk storage. 
+# This partial configuration uses IBM Cloud Object Storage (COS) for chunk storage.
 # A trusted profile will be used for authenticating with COS. We can either pass
 # the trusted profile name or trusted profile ID along with the compute resource token file.
-# If we pass both trusted profile name and trusted profile ID it should be of 
+# If we pass both trusted profile name and trusted profile ID it should be of
 # the same trusted profile.
 # In order to use trusted profile authentication we need to follow an additional step to create a trusted profile.
 # For more details about creating a trusted profile, see https://cloud.ibm.com/docs/account?topic=account-create-trusted-profile&interface=ui.
@@ -19,6 +19,7 @@ schema_config:
         prefix: index_
 
 storage_config:
+  use_thanos_objstore: false # COS is not yet supported by Thanos storage client
   cos:
     bucketnames: <bucket1, bucket2>
     endpoint: <endpoint>

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -50,13 +50,19 @@ Before configuring any v14 period, upgrade all components to a version that can
 read the v14 index format. Rolling back after v14 data has been written requires
 stopping new v14 writes first, because earlier binaries cannot read v14 indexes.
 
+### Breaking change: Thanos storage clients are used by default
+
+The default value of `storage_config.use_thanos_objstore` changed from `false` to `true`, enabling the Thanos based object store clients by default if not otherwise explicitly specified.
+
+Please refer to [Migrate to Thanos storage clients](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/migrate/migrate-storage-clients/) for how to migrate your configuration.
+
 ### Breaking change: Fully remove Simple Scalable Deployment (SSD) mode
 
 Simple Scalable Deployment (SSD) mode is being deprecated and removed in Loki 4.0. The targets `write`, `read`, and `backend`, as well as the configuration option `-legacy-read-mode` are not available any more and Loki will fail to start if used.
 
-For the best possible experience in production, we recommend deploying Loki in distributed mode. Please refer to the [Migrating from SSD to distributed](https://grafana.com/docs/loki/<LOKI_VERSION>/migrate/ssd-to-distributed/) guide for instructions how to migrate your deployment to distributed mode.
+For the best possible experience in production, we recommend deploying Loki in distributed mode. Please refer to the [Migrating from SSD to distributed](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/migrate/ssd-to-distributed/) guide for instructions how to migrate your deployment to distributed mode.
 
-A second option for smaller scale deployments that still need high availability, is to migrate to HA Monolithic, which reduces the complexity of the deployment. Please refer to the [Migrate from SSD to HA Monolithic](https://grafana.com/docs/loki/<LOKI_VERSION>/migrate/ssd-to-ha-monolithic/) guide for instructions how to migrate your deployment.
+A second option for smaller scale deployments that still need high availability, is to migrate to HA Monolithic, which reduces the complexity of the deployment. Please refer to the [Migrate from SSD to HA Monolithic](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/migrate/ssd-to-ha-monolithic/) guide for instructions how to migrate your deployment.
 
 ### Breaking change: Removal of various configuration options
 

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -6755,7 +6755,7 @@ congestion_control:
 # `storage_config.object_store` or `common.storage.object_store` block takes
 # effect.
 # CLI flag: -use-thanos-objstore
-[use_thanos_objstore: <boolean> | default = false]
+[use_thanos_objstore: <boolean> | default = true]
 
 object_store:
   # The thanos_object_store_config block configures the connection to object

--- a/pkg/dataobj/consumer/service.go
+++ b/pkg/dataobj/consumer/service.go
@@ -172,7 +172,7 @@ func New(kafkaCfg kafka.Config, cfg Config, mCfg metastore.Config, bucket objsto
 		wrapped,
 	)
 	s.processor = newProcessor(
-		NewTOCAlignedMultiBuilder(builderFactory, int(cfg.BuilderConfig.TargetObjectSize)),
+		NewTOCAlignedMultiBuilder(builderFactory, int(cfg.TargetObjectSize)),
 		records,
 		flushCommitter,
 		cfg.IdleFlushTimeout,

--- a/pkg/loghttp/push/otlplabels/labels.go
+++ b/pkg/loghttp/push/otlplabels/labels.go
@@ -125,11 +125,12 @@ func ResourceAttrsToStreamLabels(attrs pcommon.Map, otlpConfig OTLPConfig, disco
 			return false
 		}
 
-		if action == IndexLabel {
+		switch action {
+		case IndexLabel:
 			for _, lbl := range attributeAsLabels {
 				result.StreamLabels[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
 			}
-		} else if action == StructuredMetadata {
+		case StructuredMetadata:
 			result.StructuredMetadata = append(result.StructuredMetadata, attributeAsLabels...)
 		}
 

--- a/pkg/storage/chunk/client/aws/s3_storage_client_test.go
+++ b/pkg/storage/chunk/client/aws/s3_storage_client_test.go
@@ -606,7 +606,7 @@ func TestPutObject_SwiftRejects_AWSChunked(t *testing.T) {
 			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
 <Error>
   <Code>NotImplemented</Code>
-  <Message>Transfering payloads in multiple chunks using aws-chunked is not supported</Message>
+  <Message>Transferring payloads in multiple chunks using aws-chunked is not supported</Message>
 </Error>`))
 			return
 		}

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -303,7 +304,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.Hedging.RegisterFlagsWithPrefix("store.", f)
 	cfg.CongestionControl.RegisterFlagsWithPrefix("store.", f)
 
-	f.BoolVar(&cfg.UseThanosObjstore, "use-thanos-objstore", false, "Enables the use of thanos-io/objstore clients for connecting to object storage. When set to true, the configuration inside `storage_config.object_store` or `common.storage.object_store` block takes effect.")
+	f.BoolVar(&cfg.UseThanosObjstore, "use-thanos-objstore", true, "Enables the use of thanos-io/objstore clients for connecting to object storage. When set to true, the configuration inside `storage_config.object_store` or `common.storage.object_store` block takes effect.")
 	cfg.ObjectStore.RegisterFlagsWithPrefix("object-store.", f)
 
 	f.StringVar(&cfg.ObjectPrefix, "store.object-prefix", "", "The prefix to all keys inserted in object storage. Example: loki-instances/west/")
@@ -337,6 +338,10 @@ func (cfg *Config) Validate() error {
 	}
 	if err := cfg.AlibabaStorageConfig.Validate(); err != nil {
 		return errors.Wrap(err, "invalid Alibaba Storage config")
+	}
+
+	if !cfg.UseThanosObjstore {
+		level.Warn(util_log.Logger).Log("msg", "the legacy object store clients are deprecated and their usage is not recommended any more. please migrate to thanos objstore based clients by setting `use_thanos_objstore: true`.")
 	}
 
 	return cfg.NamedStores.Validate()

--- a/pkg/storage/factory_test.go
+++ b/pkg/storage/factory_test.go
@@ -163,51 +163,54 @@ func TestNewObjectClient_prefixing(t *testing.T) {
 		return cfg
 	}
 
-	t.Run("no prefix", func(t *testing.T) {
-		cfg := newFSCfg(t)
+	for _, testCase := range []struct {
+		name             string
+		prefix           string
+		expectedPrefix   string
+		isPrefixedClient bool
+		useThanosClient  bool
+	}{
+		{
+			name:             "no prefix",
+			prefix:           "",
+			isPrefixedClient: false,
+		},
+		{
+			name:             "prefix with trailing slash",
+			prefix:           "my/prefix/",
+			expectedPrefix:   "my/prefix/",
+			isPrefixedClient: true,
+		},
+		{
+			name:             "prefix without trailing slash",
+			prefix:           "my/prefix",
+			expectedPrefix:   "my/prefix/",
+			isPrefixedClient: true,
+		},
+		{
+			name:             "prefix with leading and trailing slash",
+			prefix:           "/my/prefix/",
+			expectedPrefix:   "my/prefix/",
+			isPrefixedClient: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := newFSCfg(t)
+			cfg.ObjectPrefix = testCase.prefix
+			cfg.UseThanosObjstore = testCase.useThanosClient
 
-		objectClient, err := NewObjectClient("filesystem", "test", cfg, cm)
-		require.NoError(t, err)
+			objectClient, err := NewObjectClient("filesystem", "test", cfg, cm)
+			require.NoError(t, err)
 
-		_, ok := objectClient.(client.PrefixedObjectClient)
-		assert.False(t, ok)
-	})
-
-	t.Run("prefix with trailing /", func(t *testing.T) {
-		cfg := newFSCfg(t)
-		cfg.ObjectPrefix = "my/prefix/"
-
-		objectClient, err := NewObjectClient("filesystem", "test", cfg, cm)
-		require.NoError(t, err)
-
-		prefixed, ok := objectClient.(client.PrefixedObjectClient)
-		assert.True(t, ok)
-		assert.Equal(t, "my/prefix/", prefixed.GetPrefix())
-	})
-
-	t.Run("prefix without trailing /", func(t *testing.T) {
-		cfg := newFSCfg(t)
-		cfg.ObjectPrefix = "my/prefix"
-
-		objectClient, err := NewObjectClient("filesystem", "test", cfg, cm)
-		require.NoError(t, err)
-
-		prefixed, ok := objectClient.(client.PrefixedObjectClient)
-		assert.True(t, ok)
-		assert.Equal(t, "my/prefix/", prefixed.GetPrefix())
-	})
-
-	t.Run("prefix with starting and trailing /", func(t *testing.T) {
-		cfg := newFSCfg(t)
-		cfg.ObjectPrefix = "/my/prefix/"
-
-		objectClient, err := NewObjectClient("filesystem", "test", cfg, cm)
-		require.NoError(t, err)
-
-		prefixed, ok := objectClient.(client.PrefixedObjectClient)
-		assert.True(t, ok)
-		assert.Equal(t, "my/prefix/", prefixed.GetPrefix())
-	})
+			prefixed, ok := objectClient.(client.PrefixedObjectClient)
+			if testCase.isPrefixedClient {
+				assert.True(t, ok)
+				assert.Equal(t, testCase.expectedPrefix, prefixed.GetPrefix())
+			} else {
+				require.False(t, ok)
+			}
+		})
+	}
 }
 
 // // DefaultSchemaConfig creates a simple schema config for testing


### PR DESCRIPTION
### Summary

This PR changes the default value of `storage_config.use_thanos_objstore` to `true`.
To continue using the legacy clients, the setting needs to be explicitly set to to `false`.

Please refer to the "Migrate to Thanos storage clients" migration guide https://grafana.com/docs/loki/latest/setup/migrate/migrate-storage-clients/ for how to update your configuration.