### PR TITLE
fix(canary): Support one-way TLS and -insecure without client cert files

### DIFF
--- a/pkg/canary/reader/reader.go
+++ b/pkg/canary/reader/reader.go
@@ -118,11 +118,16 @@ func NewReader(writer io.Writer,
 	// http.DefaultClient will be used in the case that the connection to Loki is http or TLS without client certs.
 	httpClient := http.DefaultClient
 	if tlsConfig != nil && (certFile != "" || keyFile != "" || caFile != "") {
-		// For the mTLS case, use a http.Client configured with the client side certificates.
-		tlsSettings := config.TLSRoundTripperSettings{
-			CA:   config.NewFileSecret(caFile),
-			Cert: config.NewFileSecret(certFile),
-			Key:  config.NewFileSecret(keyFile),
+		// Only watch the files that were configured; reading an empty path fails.
+		tlsSettings := config.TLSRoundTripperSettings{}
+		if caFile != "" {
+			tlsSettings.CA = config.NewFileSecret(caFile)
+		}
+		if certFile != "" {
+			tlsSettings.Cert = config.NewFileSecret(certFile)
+		}
+		if keyFile != "" {
+			tlsSettings.Key = config.NewFileSecret(keyFile)
 		}
 		rt, err := config.NewTLSRoundTripper(tlsConfig, tlsSettings, func(tls *tls.Config) (http.RoundTripper, error) {
 			return &http.Transport{TLSClientConfig: tls}, nil

--- a/pkg/canary/writer/push.go
+++ b/pkg/canary/writer/push.go
@@ -91,11 +91,17 @@ func NewPush(
 	scheme := "http"
 
 	// setup tls transport
-	if tlsCfg != nil {
-		tlsSettings := config.TLSRoundTripperSettings{
-			CA:   config.NewFileSecret(caFile),
-			Cert: config.NewFileSecret(certFile),
-			Key:  config.NewFileSecret(keyFile),
+	if tlsCfg != nil && (certFile != "" || keyFile != "" || caFile != "") {
+		// Only watch the files that were configured; reading an empty path fails.
+		tlsSettings := config.TLSRoundTripperSettings{}
+		if caFile != "" {
+			tlsSettings.CA = config.NewFileSecret(caFile)
+		}
+		if certFile != "" {
+			tlsSettings.Cert = config.NewFileSecret(certFile)
+		}
+		if keyFile != "" {
+			tlsSettings.Key = config.NewFileSecret(keyFile)
 		}
 		rt, err := config.NewTLSRoundTripper(tlsCfg, tlsSettings, func(tls *tls.Config) (http.RoundTripper, error) {
 			return &http.Transport{TLSClientConfig: tls}, nil
@@ -104,6 +110,10 @@ func NewPush(
 			return nil, fmt.Errorf("failed to create TLS config for transport: %w", err)
 		}
 		client.Transport = rt
+		scheme = "https"
+	} else if tlsCfg != nil {
+		// TLS without cert/CA files, e.g. system CA pool or -insecure.
+		client.Transport = &http.Transport{TLSClientConfig: tlsCfg}
 		scheme = "https"
 	}
 

--- a/pkg/canary/writer/push_test.go
+++ b/pkg/canary/writer/push_test.go
@@ -1,11 +1,16 @@
 package writer
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -103,6 +108,85 @@ func Test_Push(t *testing.T) {
 	push.WriteEntry(ts, payload)
 	resp = <-testCfg.responses
 	assertResponse(t, resp, true, labelSet("name", "loki-canary", "pod", "abc"), ts, payload, 1)
+}
+
+// Test_PushTLS covers TLS without client cert/key files, which previously
+// failed because the writer tried to read empty file paths (issue #22639).
+func Test_PushTLS(t *testing.T) {
+	backoffCfg := backoff.Config{
+		MinBackoff: 300 * time.Millisecond,
+		MaxBackoff: 5 * time.Minute,
+		MaxRetries: 10,
+	}
+
+	newTLSPush := func(t *testing.T, server *httptest.Server, tlsConfig *tls.Config, caFile, certFile, keyFile string) (EntryWriter, error) {
+		t.Helper()
+		return NewPush(
+			server.Listener.Addr().String(),
+			testTenant,
+			2*time.Second,
+			config.DefaultHTTPClientConfig,
+			"name",
+			"loki-canary",
+			"stream",
+			"stdout",
+			true, // useTLS
+			tlsConfig,
+			caFile,
+			certFile,
+			keyFile,
+			"",
+			"",
+			&backoffCfg,
+			1,
+			log.NewNopLogger(),
+		)
+	}
+
+	t.Run("TLS enabled with insecure skip verify and no cert files", func(t *testing.T) {
+		responses := make(chan response, 1)
+		server := httptest.NewTLSServer(createServerHandler(responses))
+		defer server.Close()
+
+		tlsConfig, err := config.NewTLSConfig(&config.TLSConfig{InsecureSkipVerify: true})
+		require.NoError(t, err)
+
+		push, err := newTLSPush(t, server, tlsConfig, "", "", "")
+		require.NoError(t, err)
+
+		ts, payload := testPayload()
+		push.WriteEntry(ts, payload)
+		resp := <-responses
+		assertResponse(t, resp, false, labelSet("name", "loki-canary", "stream", "stdout"), ts, payload, 1)
+	})
+
+	t.Run("one-way TLS with a CA file and no client cert", func(t *testing.T) {
+		responses := make(chan response, 1)
+		server := httptest.NewTLSServer(createServerHandler(responses))
+		defer server.Close()
+
+		caFile := writeCertFile(t, server.Certificate())
+
+		tlsConfig, err := config.NewTLSConfig(&config.TLSConfig{CAFile: caFile})
+		require.NoError(t, err)
+
+		push, err := newTLSPush(t, server, tlsConfig, caFile, "", "")
+		require.NoError(t, err)
+
+		ts, payload := testPayload()
+		push.WriteEntry(ts, payload)
+		resp := <-responses
+		assertResponse(t, resp, false, labelSet("name", "loki-canary", "stream", "stdout"), ts, payload, 1)
+	})
+}
+
+// writeCertFile PEM-encodes cert to a temp file and returns its path.
+func writeCertFile(t *testing.T, cert *x509.Certificate) string {
+	t.Helper()
+	caFile := filepath.Join(t.TempDir(), "ca.crt")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	require.NoError(t, os.WriteFile(caFile, pemBytes, 0o600))
+	return caFile
 }
 
 // test batching log lines and ensure the testing resp contains exactly 10 unique entries

--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,8 @@ Entries should include a reference to the pull request that introduced the chang
 
 ## Unreleased
 
+- [BUGFIX] Allow disabling the Loki Canary (`lokiCanary.enabled: false`) without also having to disable Helm tests. The Helm test is already skipped when the canary is disabled, so the validation that hard-failed in that case has been removed. [#22639](https://github.com/grafana/loki/issues/22639)
+
 ## 7.1.0
 
 - [CHANGE] Changed version of Grafana Enterprise Logs to 3.6.8 (updated `enterprise.version`, and `enterprise.image.tag`).

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -3,7 +3,7 @@ name: loki
 description: Helm chart for Grafana Enterprise Logs supporting monolithic, simple scalable, and microservices modes.
 type: application
 appVersion: 3.6.8
-version: 7.1.0
+version: 7.1.1
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 7.1.0](https://img.shields.io/badge/Version-7.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.8](https://img.shields.io/badge/AppVersion-3.6.8-informational?style=flat-square)
+![Version: 7.1.1](https://img.shields.io/badge/Version-7.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.8](https://img.shields.io/badge/AppVersion-3.6.8-informational?style=flat-square)
 
 Helm chart for Grafana Enterprise Logs supporting monolithic, simple scalable, and microservices modes.
 

--- a/production/helm/loki/templates/validate.yaml
+++ b/production/helm/loki/templates/validate.yaml
@@ -2,10 +2,6 @@
 {{- fail "Top level 'config' is not allowed. Most common configuration sections are exposed under the `loki` section. If you need to override the whole config, provide the configuration as a string that can contain template expressions under `loki.config`. Alternatively, you can provide the configuration as an external secret." }}
 {{- end }}
 
-{{- if and (not .Values.lokiCanary.enabled) .Values.test.enabled }}
-{{- fail "Helm test requires the Loki Canary to be enabled"}}
-{{- end }}
-
 {{- $singleBinaryReplicas := int .Values.singleBinary.replicas }}
 {{- $isUsingFilesystem := eq (include "loki.isUsingObjectStorage" .) "false" }}
 {{- $atLeastOneScalableReplica := or (gt (int .Values.backend.replicas) 0) (gt (int .Values.read.replicas) 0) (gt (int .Values.write.replicas) 0) }}


### PR DESCRIPTION
**What this PR does / why we need it**:

loki-canary failed to connect over TLS unless a full mTLS client cert/key pair was provided. The writer built its TLS transport whenever TLS was enabled and then tried to read empty cert/CA file paths, so `-insecure` and CA-only (one-way TLS) configs errored with `unable to read file`. The reader had the same problem for the CA-only case.

Both the reader and writer now only read the cert/key/ca files that were actually configured, and fall back to a plain TLS transport when none are given. This makes `-insecure` and one-way TLS with a custom CA work, while mTLS keeps behaving as before.

It also removes the Helm chart validation that hard-failed when the Loki Canary was disabled while tests were enabled. The test resources are already gated on the canary being enabled, so the canary can now be disabled without having to also disable tests.

**Which issue(s) this PR fixes**:
Fixes #22639

**Special notes for your reviewer**:

This covers the bug parts of #22639. Two of the four points reported there were really usage/expected behaviour (`-tls` alone uses the system CA pool, and the "unable to use specified CA cert file" error came from mounting files that weren't valid PEM), so they're not changed here.

The writer change mirrors the guard the reader already had, plus both now skip empty file paths so one-way TLS with just a CA works. The added `Test_PushTLS` covers the `-insecure` (no files) and CA-only cases against a real TLS test server, and fails without the fix. The Helm chart change is verified with `helm template` (canary disabled + tests enabled now renders instead of failing, and the test pod is correctly skipped).

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
