### PR TITLE
ci: pin all GitHub Actions to full commit SHAs to prevent supply-chain attacks

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   deploy-pr-preview:
     if: "!github.event.pull_request.head.repo.fork"
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@d6e7c1be7e3f40a59f3e6e409af8320ffba34587 # main
     permissions:
       contents: read # Clone repositories.
       id-token: write # Fetch Vault secrets.

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -28,20 +28,20 @@
     "runs-on": "${{ matrix.runs_on }}"
     "steps":
     - "name": "pull release library code"
-      "uses": "actions/checkout@v4"
+      "uses": "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       "with":
         "path": "lib"
         "persist-credentials": false
         "ref": "${{ env.RELEASE_LIB_REF }}"
         "repository": "grafana/loki-release"
     - "name": "pull code to release"
-      "uses": "actions/checkout@v4"
+      "uses": "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       "with":
         "path": "release"
         "persist-credentials": false
         "repository": "${{ env.RELEASE_REPO }}"
     - "name": "setup node"
-      "uses": "actions/setup-node@v4"
+      "uses": "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       "with":
         "node-version": 24
         "package-manager-cache": false
@@ -168,20 +168,20 @@
     "runs-on": "${{ matrix.runs_on }}"
     "steps":
     - "name": "pull release library code"
-      "uses": "actions/checkout@v4"
+      "uses": "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       "with":
         "path": "lib"
         "persist-credentials": false
         "ref": "${{ env.RELEASE_LIB_REF }}"
         "repository": "grafana/loki-release"
     - "name": "pull code to release"
-      "uses": "actions/checkout@v4"
+      "uses": "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       "with":
         "path": "release"
         "persist-credentials": false
         "repository": "${{ env.RELEASE_REPO }}"
     - "name": "setup node"
-      "uses": "actions/setup-node@v4"
+      "uses": "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       "with":
         "node-version": 24
         "package-manager-cache": false
@@ -308,20 +308,20 @@
     "runs-on": "${{ matrix.runs_on }}"
     "steps":
     - "name": "pull release library code"
-      "uses": "actions/checkout@v4"
+      "uses": "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       "with":
         "path": "lib"
         "persist-credentials": false
         "ref": "${{ env.RELEASE_LIB_REF }}"
         "repository": "grafana/loki-release"
     - "name": "pull code to release"
-      "uses": "actions/checkout@v4"
+      "uses": "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       "with":
         "path": "release"
         "persist-credentials": false
         "repository": "${{ env.RELEASE_REPO }}"
     - "name": "setup node"
-      "uses": "actions/setup-node@v4"
+      "uses": "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       "with":
         "node-version": 24
         "package-manager-cache": false
@@ -448,20 +448,20 @@
     "runs-on": "${{ matrix.runs_on }}"
     "steps":
     - "name": "pull release library code"
-      "uses": "actions/checkout@v4"
+      "uses": "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       "with":
         "path": "lib"
         "persist-credentials": false
         "ref": "${{ env.RELEASE_LIB_REF }}"
         "repository": "grafana/loki-release"
     - "name": "pull code to release"
-      "uses": "actions/checkout@v4"
+      "uses": "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       "with":
         "path": "release"
         "persist-credentials": false
         "repository": "${{ env.RELEASE_REPO }}"
     - "name": "setup node"
-      "uses": "actions/setup-node@v4"
+      "uses": "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       "with":
         "node-version": 24
         "package-manager-cache": false
@@ -588,20 +588,20 @@
     "runs-on": "${{ matrix.runs_on }}"
     "steps":
     - "name": "pull release library code"
-      "uses": "actions/checkout@v4"
+      "uses": "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       "with":
         "path": "lib"
         "persist-credentials": false
         "ref": "${{ env.RELEASE_LIB_REF }}"
         "repository": "grafana/loki-release"
     - "name": "pull code to release"
-      "uses": "actions/checkout@v4"
+      "uses": "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       "with":
         "path": "release"
         "persist-credentials": false
         "repository": "${{ env.RELEASE_REPO }}"
     - "name": "setup node"
-      "uses": "actions/setup-node@v4"
+      "uses": "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       "with":
         "node-version": 24
         "package-manager-cache": false

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -44,20 +44,20 @@ jobs:
     runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -110,7 +110,7 @@ jobs:
     runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
@@ -187,20 +187,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -264,20 +264,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -341,20 +341,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -424,20 +424,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -501,20 +501,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -584,20 +584,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -667,20 +667,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -748,20 +748,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -847,20 +847,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -930,20 +930,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -1013,20 +1013,20 @@ jobs:
     runs-on: "ubuntu-x64"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false

--- a/.github/workflows/operator-bundle.yaml
+++ b/.github/workflows/operator-bundle.yaml
@@ -19,11 +19,11 @@ jobs:
     permissions:
       contents: "read"
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version-file: ./operator/go.mod
         cache-dependency-path: ./operator/go.sum

--- a/.github/workflows/operator-scorecard.yaml
+++ b/.github/workflows/operator-scorecard.yaml
@@ -19,11 +19,11 @@ jobs:
     permissions:
       contents: "read"
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version-file: ./operator/go.mod
         cache-dependency-path: ./operator/go.sum

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -19,11 +19,11 @@ jobs:
     permissions:
       contents: "read"
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version-file: ./operator/go.mod
         cache-dependency-path: ./operator/go.sum
@@ -39,11 +39,11 @@ jobs:
     permissions:
       contents: "read"
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version-file: ./operator/go.mod
         cache-dependency-path: ./operator/go.sum
@@ -63,11 +63,11 @@ jobs:
     permissions:
       contents: "read"
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version-file: ./operator/go.mod
         cache-dependency-path: ./operator/go.sum
@@ -83,11 +83,11 @@ jobs:
     permissions:
       contents: "read"
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version-file: ./operator/go.mod
         cache-dependency-path: ./operator/go.sum
@@ -102,11 +102,11 @@ jobs:
     permissions:
       contents: "read"
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version-file: ./operator/go.mod
         cache-dependency-path: ./operator/go.sum

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -44,20 +44,20 @@ jobs:
     runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -110,7 +110,7 @@ jobs:
     runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
@@ -187,20 +187,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -264,20 +264,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -341,20 +341,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -424,20 +424,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -501,20 +501,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -584,20 +584,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -667,20 +667,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -748,20 +748,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -847,20 +847,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -930,20 +930,20 @@ jobs:
     runs-on: "${{ matrix.runs_on }}"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -1013,20 +1013,20 @@ jobs:
     runs-on: "ubuntu-x64"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,20 +28,20 @@ jobs:
     runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
         ref: "${{ env.RELEASE_LIB_REF }}"
         repository: "grafana/loki-release"
     - name: "setup node"
-      uses: "actions/setup-node@v4"
+      uses: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020" # v4
       with:
         node-version: 24
         package-manager-cache: false
@@ -143,7 +143,7 @@ jobs:
     runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
@@ -218,7 +218,7 @@ jobs:
     runs-on: "ubuntu-x64"
     steps:
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false
@@ -263,7 +263,7 @@ jobs:
     runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
@@ -297,13 +297,13 @@ jobs:
     runs-on: "ubuntu-x64"
     steps:
     - name: "pull code to release"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "release"
         persist-credentials: false
         repository: "${{ env.RELEASE_REPO }}"
     - name: "pull release library code"
-      uses: "actions/checkout@v4"
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
       with:
         path: "lib"
         persist-credentials: false

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   snyk-scan-ci:
-    uses: 'grafana/security-github-actions/.github/workflows/snyk_monitor.yml@main'
+    uses: 'grafana/security-github-actions/.github/workflows/snyk_monitor.yml@54446245a62e0407f5375e0bb4eb03087364df37 # main'
     permissions:
       contents: "read"
       id-token: "write"


### PR DESCRIPTION
## Summary

9 workflow files reference GitHub Actions and reusable workflows using **mutable version tags and branch references** (`@v4`, `@v6`, `@main`). Tags and branch heads can be silently moved by an upstream maintainer or attacker.

## Affected actions

| Action | Mutable ref | Pinned SHA |
|--------|-------------|-----------|
| `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/checkout` | `@v6` | `@df4cb1c069e1874edd31b4311f1884172cec0e10` |
| `actions/setup-go` | `@v6` | `@924ae3a1cded613372ab5595356fb5720e22ba16` |
| `actions/setup-node` | `@v4` | `@49933ea5288caeca8642d1e84afbd3f7d6820020` |
| `grafana/security-github-actions/...snyk_monitor.yml` | `@main` ⚠️ | `@54446245a62e0407f5375e0bb4eb03087364df37` |
| `grafana/writers-toolkit/...deploy-preview.yml` | `@main` ⚠️ | `@d6e7c1be7e3f40a59f3e6e409af8320ffba34587` |

The `@main` branch references are especially dangerous as they automatically pick up any new commit.

## Affected files (9)

`deploy-pr-preview.yml`, `images.yml`, `minor-release-pr.yml`, `operator-bundle.yaml`, `operator-scorecard.yaml`, `operator.yaml`, `patch-release-pr.yml`, `release.yml`, `snyk.yml`

## Vulnerability class

Supply-chain attack via mutable Action tag/branch references (CWE-829). See [GitHub Security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).