### PR TITLE
fix(v2-engine): Make label_format and line_format input lookups category-aware to skip NULL same-short-name shadows and match v1

### DIFF
--- a/pkg/engine/internal/executor/parse.go
+++ b/pkg/engine/internal/executor/parse.go
@@ -420,15 +420,3 @@ func unsafeBytes(s string) []byte {
 func unsafeString(b []byte) string {
 	return unsafe.String(unsafe.SliceData(b), len(b))
 }
-
-// valueStrOrEmpty returns the column's string value at row i, treating null
-// entries as the empty string. This matches v1 query engine where
-// an absent label reads as "": template expressions
-// like `{{.field}}` then render consistently regardless of whether the parser
-// produced a null entry on a present column or omitted the column entirely.
-func valueStrOrEmpty(col arrow.Array, i int) string {
-	if col.IsNull(i) {
-		return ""
-	}
-	return col.ValueStr(i)
-}

--- a/pkg/engine/internal/executor/parse_labelfmt.go
+++ b/pkg/engine/internal/executor/parse_labelfmt.go
@@ -30,13 +30,17 @@ func buildLabelfmtColumns(input arrow.RecordBatch, sourceCol *array.String, labe
 	return buildColumns(input, sourceCol, nil, parseFunc, types.VariadicOpParseLabelfmt, types.LabelfmtParserErrorType)
 }
 
-// tokenizeLabelfmt parses labelfmt input using the standard decoder
-// Returns a map of key-value pairs with first-wins semantics for duplicates
+// tokenizeLabelfmt parses labelfmt input using the standard decoder.
+// Returns a map of key-value pairs containing only the labelfmt targets (and
+// the error/error_details builtins). Categories from the input batch are
+// preserved when populating the LabelsBuilder so that GetWithCategory honours
+// v1's parsed > structured-metadata > stream precedence.
 func tokenizeLabelfmt(input arrow.RecordBatch, line string, decoder *log.LabelsFormatter, labelFmts []log.LabelFmt) (map[string]string, error) {
-	lbls := buildLabelsFromInput(input)
-	var builder = log.NewBaseLabelsBuilder().ForLabels(lbls, labels.StableHash(lbls))
+	stream, metadata, parsed := buildLabelsFromInput(input)
+	var builder = log.NewBaseLabelsBuilder().ForLabels(stream, labels.StableHash(stream))
 	builder.Reset()
-	builder.Add(log.StructuredMetadataLabel, lbls)
+	builder.Add(log.StructuredMetadataLabel, metadata)
+	builder.Add(log.ParsedLabel, parsed)
 
 	var timestampIdx = -1
 	for i := 0; i < len(input.Columns()); i++ {
@@ -71,10 +75,40 @@ func tokenizeLabelfmt(input arrow.RecordBatch, line string, decoder *log.LabelsF
 	return result, nil
 }
 
-func buildLabelsFromInput(input arrow.RecordBatch) labels.Labels {
-	var labelList []labels.Label
+// buildLabelsFromInput returns the row's input labels bucketed by their
+// Arrow column category, matching v1's stream / structured-metadata / parsed
+// triplet. NULL cells are skipped — a same-short-name column at a different
+// category can be NULL for this row (whether contributed by another stream
+// in the same dataobj section, or NULL'd in-place by an upstream
+// ColumnCompat), and treating that NULL as an empty string would shadow the
+// surviving entry and make GetWithCategory's result non-deterministic.
+//
+// Generated columns (e.g. __error__, __error_details__) are bucketed with
+// parsed labels to match v1, where lbs.SetErr / SetErrorDetails write into
+// the ParsedLabel category. Builtin (timestamp, message) and ambiguous
+// columns are excluded — they are not part of the label set.
+func buildLabelsFromInput(input arrow.RecordBatch) (stream, metadata, parsed labels.Labels) {
+	var streamList, metadataList, parsedList []labels.Label
 	for i := 0; i < int(input.NumCols()); i++ {
-		labelList = append(labelList, labels.Label{Name: semconv.MustParseFQN(input.ColumnName(i)).ColumnRef().Column, Value: valueStrOrEmpty(input.Column(i), 0)})
+		ident, err := semconv.ParseFQN(input.ColumnName(i))
+		if err != nil {
+			continue
+		}
+		col := input.Column(i)
+		if col.IsNull(0) {
+			// Column present in the schema but no value on this row — treat
+			// as label absent (matches v1, which has no NULL state).
+			continue
+		}
+		l := labels.Label{Name: ident.ColumnRef().Column, Value: col.ValueStr(0)}
+		switch ident.ColumnType() {
+		case types.ColumnTypeLabel:
+			streamList = append(streamList, l)
+		case types.ColumnTypeMetadata:
+			metadataList = append(metadataList, l)
+		case types.ColumnTypeParsed, types.ColumnTypeGenerated:
+			parsedList = append(parsedList, l)
+		}
 	}
-	return labels.New(labelList...)
+	return labels.New(streamList...), labels.New(metadataList...), labels.New(parsedList...)
 }

--- a/pkg/engine/internal/executor/parse_labelfmt_test.go
+++ b/pkg/engine/internal/executor/parse_labelfmt_test.go
@@ -12,91 +12,198 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/semconv"
-	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/logql/log"
 )
 
+// labelfmtTestColumn describes one column appended to the Arrow schema
+// after the implicit message + timestamp builtins. Used by
+// TestTokenizeLabelFmt to drive both the simple single-column cases and
+// the duplicate-short-name cases from one table.
+type labelfmtTestColumn struct {
+	fqn   string
+	value string
+	null  bool
+}
+
 func TestTokenizeLabelFmt(t *testing.T) {
 	timestamp := time.Now().In(time.UTC)
-	schema := arrow.NewSchema(
-		[]arrow.Field{
-			semconv.FieldFromIdent(semconv.ColumnIdentMessage, false),
-			semconv.FieldFromIdent(semconv.ColumnIdentTimestamp, false),
-			semconv.FieldFromIdent(semconv.NewIdentifier("namespace", types.ColumnTypeMetadata, types.Loki.String), true),
-		},
-		nil, // No metadata
+
+	const (
+		realPod = "querier-1234"
+		other   = "other-stream-value"
 	)
+
 	tests := []struct {
-		name          string
-		line          string
-		timeVal       arrow.Timestamp
-		namespace     string
-		nullNamespace bool // when true, append NULL for namespace instead of the namespace string
-		fmts          []log.LabelFmt
-		want          map[string]string
+		name    string
+		line    string
+		timeVal arrow.Timestamp
+		// cols is the list of label-like / metadata / parsed columns to
+		// append after the builtin message + timestamp columns. Order is
+		// preserved in the Arrow schema so duplicate-short-name cases can
+		// validate that the labelfmt result is order-independent.
+		cols []labelfmtTestColumn
+		fmts []log.LabelFmt
+		want map[string]string
 	}{
 		{
-			name:      "simple rename",
-			line:      "this is my test line of logs",
-			timeVal:   arrow.Timestamp(timestamp.UnixNano()),
-			namespace: "dev",
-			fmts:      []log.LabelFmt{{Name: "foo", Value: "namespace", Rename: true}},
-			want:      map[string]string{"foo": "dev"},
+			name:    "simple rename",
+			line:    "this is my test line of logs",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols:    []labelfmtTestColumn{{fqn: "utf8.metadata.namespace", value: "dev"}},
+			fmts:    []log.LabelFmt{{Name: "foo", Value: "namespace", Rename: true}},
+			want:    map[string]string{"foo": "dev"},
 		},
 		{
-			name:      "new label",
-			line:      "this is my test line of logs",
-			timeVal:   arrow.Timestamp(timestamp.UnixNano()),
-			namespace: "dev",
-			fmts:      []log.LabelFmt{{Name: "logTimeNanos", Value: "{{ __timestamp__ | unixEpochNanos }}", Rename: false}},
-			want:      map[string]string{"logTimeNanos": strconv.FormatInt(timestamp.UTC().UnixNano(), 10)},
+			name:    "new label",
+			line:    "this is my test line of logs",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols:    []labelfmtTestColumn{{fqn: "utf8.metadata.namespace", value: "dev"}},
+			fmts:    []log.LabelFmt{{Name: "logTimeNanos", Value: "{{ __timestamp__ | unixEpochNanos }}", Rename: false}},
+			want:    map[string]string{"logTimeNanos": strconv.FormatInt(timestamp.UTC().UnixNano(), 10)},
 		},
 		{
-			name:      "rename and label",
-			line:      "this is my test line of logs",
-			timeVal:   arrow.Timestamp(timestamp.Add(10 * time.Second).UTC().UnixNano()),
-			namespace: "dev",
-			fmts:      []log.LabelFmt{{Name: "foo", Value: "namespace", Rename: true}, {Name: "logTimeNanos", Value: "{{ __timestamp__ | unixEpochNanos }}", Rename: false}},
-			want:      map[string]string{"foo": "dev", "logTimeNanos": strconv.FormatInt(timestamp.Add(10*time.Second).UTC().UnixNano(), 10)},
+			name:    "rename and label",
+			line:    "this is my test line of logs",
+			timeVal: arrow.Timestamp(timestamp.Add(10 * time.Second).UTC().UnixNano()),
+			cols:    []labelfmtTestColumn{{fqn: "utf8.metadata.namespace", value: "dev"}},
+			fmts:    []log.LabelFmt{{Name: "foo", Value: "namespace", Rename: true}, {Name: "logTimeNanos", Value: "{{ __timestamp__ | unixEpochNanos }}", Rename: false}},
+			want:    map[string]string{"foo": "dev", "logTimeNanos": strconv.FormatInt(timestamp.Add(10*time.Second).UTC().UnixNano(), 10)},
 		},
 		{
 			// Null entries on a parsed/metadata column must be exposed to the label
-			// formatter as "" to match v1 engine
-			name:          "null entry renders as empty",
-			line:          "line",
-			timeVal:       arrow.Timestamp(timestamp.UnixNano()),
-			nullNamespace: true,
-			fmts:          []log.LabelFmt{{Name: "tag", Value: "x{{.namespace}}y", Rename: false}},
-			want:          map[string]string{"tag": "xy"},
+			// formatter as "" to match v1 engine.
+			name:    "null entry renders as empty",
+			line:    "line",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols:    []labelfmtTestColumn{{fqn: "utf8.metadata.namespace", null: true}},
+			fmts:    []log.LabelFmt{{Name: "tag", Value: "x{{.namespace}}y", Rename: false}},
+			want:    map[string]string{"tag": "xy"},
+		},
+		// --- Duplicate-short-name cases ---
+		// Two Arrow columns with different FQNs share a short name —
+		// typically a stream-label column with a real value and a same-name
+		// structured-metadata column that is NULL for this row (either
+		// contributed by another stream in the same dataobj section or
+		// NULL'd in place by an upstream ColumnCompat).
+		{
+			name:    "label.pod first, metadata.pod NULL — rename uses stream value",
+			line:    "line",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols: []labelfmtTestColumn{
+				{fqn: "utf8.label.pod", value: realPod},
+				{fqn: "utf8.metadata.pod", null: true},
+			},
+			fmts: []log.LabelFmt{{Name: "foo", Value: "pod", Rename: true}},
+			want: map[string]string{"foo": realPod},
+		},
+		{
+			name:    "metadata.pod NULL first, label.pod second — rename uses stream value",
+			line:    "line",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols: []labelfmtTestColumn{
+				{fqn: "utf8.metadata.pod", null: true},
+				{fqn: "utf8.label.pod", value: realPod},
+			},
+			fmts: []log.LabelFmt{{Name: "foo", Value: "pod", Rename: true}},
+			want: map[string]string{"foo": realPod},
+		},
+		{
+			name:    "label.pod and metadata.pod both set — stream value wins via base+add collision",
+			line:    "line",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols: []labelfmtTestColumn{
+				{fqn: "utf8.label.pod", value: realPod},
+				{fqn: "utf8.metadata.pod", value: other},
+			},
+			fmts: []log.LabelFmt{{Name: "foo", Value: "pod", Rename: true}},
+			want: map[string]string{"foo": realPod},
+		},
+		{
+			// pod doesn't exist in either category for this row — rename
+			// is a no-op, matching v1 where lbs.GetWithCategory returns
+			// ok=false and LabelsFormatter.Process silently skips the
+			// rename.
+			name:    "both NULL — rename is a no-op",
+			line:    "line",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols: []labelfmtTestColumn{
+				{fqn: "utf8.label.pod", null: true},
+				{fqn: "utf8.metadata.pod", null: true},
+			},
+			fmts: []log.LabelFmt{{Name: "foo", Value: "pod", Rename: true}},
+			want: map[string]string{},
+		},
+		{
+			name:    "label.pod set, metadata.pod NULL, metadata.pod_extracted set — rename foo=pod_extracted returns real metadata value",
+			line:    "line",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols: []labelfmtTestColumn{
+				{fqn: "utf8.label.pod", value: realPod},
+				{fqn: "utf8.metadata.pod", null: true},
+				{fqn: "utf8.metadata.pod_extracted", value: "real-extracted-value"},
+			},
+			fmts: []log.LabelFmt{{Name: "foo", Value: "pod_extracted", Rename: true}},
+			want: map[string]string{"foo": "real-extracted-value"},
 		},
 	}
 
 	for _, tt := range tests {
 		synctest.Test(t, func(t *testing.T) {
-			// Create builders for each column
-			logBuilder := array.NewStringBuilder(memory.DefaultAllocator)
-			tsBuilder := array.NewTimestampBuilder(memory.DefaultAllocator, &arrow.TimestampType{Unit: arrow.Nanosecond, TimeZone: "UTC"})
-			namespaceBuilder := array.NewStringBuilder(memory.DefaultAllocator)
-
-			logBuilder.Append(tt.line)
-			tsBuilder.Append(tt.timeVal)
-			if tt.nullNamespace {
-				namespaceBuilder.AppendNull()
-			} else {
-				namespaceBuilder.Append(tt.namespace)
-			}
-
-			// Build the arrays
-			logArray := logBuilder.NewArray()
-			tsArray := tsBuilder.NewArray()
-			namespaceArray := namespaceBuilder.NewArray()
-			columns := []arrow.Array{logArray, tsArray, namespaceArray}
-			recordBatch := array.NewRecordBatch(schema, columns, 1)
+			record := buildLabelfmtTestRecord(t, tt.line, tt.timeVal, tt.cols)
 			decoder, err := log.NewLabelsFormatter(tt.fmts)
 			require.NoError(t, err)
-			result, err := tokenizeLabelfmt(recordBatch, tt.line, decoder, tt.fmts)
+			result, err := tokenizeLabelfmt(record, tt.line, decoder, tt.fmts)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, result)
 		})
 	}
+}
+
+// buildLabelfmtTestRecord assembles a 1-row Arrow RecordBatch with the
+// builtin message + timestamp columns followed by the caller's
+// label/metadata/parsed columns in the order given.
+func buildLabelfmtTestRecord(t *testing.T, line string, timeVal arrow.Timestamp, cols []labelfmtTestColumn) arrow.RecordBatch {
+	t.Helper()
+	fields := []arrow.Field{
+		semconv.FieldFromIdent(semconv.ColumnIdentMessage, false),
+		semconv.FieldFromIdent(semconv.ColumnIdentTimestamp, false),
+	}
+	arrays := []arrow.Array{
+		stringArrayOf(line),
+		timestampArrayOfTs(timeVal),
+	}
+	for _, c := range cols {
+		ident, err := semconv.ParseFQN(c.fqn)
+		require.NoError(t, err, "test column FQN %q", c.fqn)
+		fields = append(fields, semconv.FieldFromIdent(ident, true))
+		if c.null {
+			arrays = append(arrays, nullStringArray())
+		} else {
+			arrays = append(arrays, stringArrayOf(c.value))
+		}
+	}
+	schema := arrow.NewSchema(fields, nil)
+	return array.NewRecordBatch(schema, arrays, 1)
+}
+
+func stringArrayOf(v string) *array.String {
+	b := array.NewStringBuilder(memory.DefaultAllocator)
+	b.Append(v)
+	return b.NewStringArray()
+}
+
+func nullStringArray() *array.String {
+	b := array.NewStringBuilder(memory.DefaultAllocator)
+	b.AppendNull()
+	return b.NewStringArray()
+}
+
+func timestampArrayOf(t time.Time) *array.Timestamp {
+	return timestampArrayOfTs(arrow.Timestamp(t.UnixNano()))
+}
+
+func timestampArrayOfTs(ts arrow.Timestamp) *array.Timestamp {
+	b := array.NewTimestampBuilder(memory.DefaultAllocator, &arrow.TimestampType{Unit: arrow.Nanosecond, TimeZone: "UTC"})
+	b.Append(ts)
+	return b.NewTimestampArray()
 }

--- a/pkg/engine/internal/executor/parse_labelfmt_test.go
+++ b/pkg/engine/internal/executor/parse_labelfmt_test.go
@@ -198,10 +198,6 @@ func nullStringArray() *array.String {
 	return b.NewStringArray()
 }
 
-func timestampArrayOf(t time.Time) *array.Timestamp {
-	return timestampArrayOfTs(arrow.Timestamp(t.UnixNano()))
-}
-
 func timestampArrayOfTs(ts arrow.Timestamp) *array.Timestamp {
 	b := array.NewTimestampBuilder(memory.DefaultAllocator, &arrow.TimestampType{Unit: arrow.Nanosecond, TimeZone: "UTC"})
 	b.Append(ts)

--- a/pkg/engine/internal/executor/parse_linefmt.go
+++ b/pkg/engine/internal/executor/parse_linefmt.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/semconv"
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
@@ -97,25 +98,24 @@ func (lf *LineFormatter) Process(line string, input arrow.RecordBatch, result ma
 	if messageIdx < 0 {
 		return "", fmt.Errorf("message column not found")
 	}
+
+	// Bucket input columns so `{{.X}}` lookups resolve deterministically
+	// when the same short name exists at multiple categories and one side
+	// is NULL for this row. builtin columns are looked up separately so
+	// references like `{{.timestamp}}` keep working but cannot be shadowed
+	// by a NULL label-like column of the same short name.
+	stream, metadata, parsed := buildLabelsFromInput(input)
+	builtin := buildBuiltinColumnsFromInput(input)
+
 	if lf.simpleKey != "" {
-		var simpleKeyIdx = -1
-		for i := 0; i < len(input.Columns()); i++ {
-			colIdent := semconv.MustParseFQN(input.ColumnName(i)).ColumnRef().Column
-			if lf.simpleKey == colIdent {
-				simpleKeyIdx = i
-				break
-			}
-		}
-		if simpleKeyIdx < 0 {
-			// Column not present in the schema for this batch (e.g. when no row in
-			// the batch contributed a value for the key, so the parser never created it).
-			// To match v1 engine and the general template path's
-			// `missingkey=zero` semantic: render "" silently, do not raise a
-			// parser error / __error__ label.
+		val, found := lookupCategorized(lf.simpleKey, stream, metadata, parsed, builtin)
+		if !found {
+			// Column absent in every category for this row. Match v1 and the
+			// general template path's `missingkey=zero` semantic: render ""
+			// silently, do not raise a parser error / __error__ label.
 			result[types.ColumnNameBuiltinMessage] = ""
 			return "", nil
 		}
-		val := valueStrOrEmpty(input.Column(simpleKeyIdx), 0)
 		result[types.ColumnNameBuiltinMessage] = val
 		return val, nil
 	}
@@ -137,10 +137,17 @@ func (lf *LineFormatter) Process(line string, input arrow.RecordBatch, result ma
 	}
 	lf.currentTs = ts.UnixNano()
 
-	m := make(map[string]string)
-	for i := 0; i < len(input.Columns()); i++ {
-		m[semconv.MustParseFQN(input.ColumnName(i)).ColumnRef().Column] = valueStrOrEmpty(input.Column(i), 0)
+	// Merge low → high precedence so later writes win: builtin → stream →
+	// metadata → parsed. Matches v1's LabelsBuilder precedence
+	// (parsed > metadata > stream); builtin (timestamp, message, value) is
+	// the lowest tier so a user-set label of the same name still wins.
+	m := make(map[string]string, len(builtin)+stream.Len()+metadata.Len()+parsed.Len())
+	for k, v := range builtin {
+		m[k] = v
 	}
+	stream.Range(func(l labels.Label) { m[l.Name] = l.Value })
+	metadata.Range(func(l labels.Label) { m[l.Name] = l.Value })
+	parsed.Range(func(l labels.Label) { m[l.Name] = l.Value })
 
 	if err := lf.Execute(lf.buf, m); err != nil {
 		return line, err
@@ -148,4 +155,49 @@ func (lf *LineFormatter) Process(line string, input arrow.RecordBatch, result ma
 	result[types.ColumnNameBuiltinMessage] = lf.buf.String()
 
 	return lf.buf.String(), nil
+}
+
+// lookupCategorized resolves `name` in v1's category precedence
+// (parsed > metadata > stream), falling back to builtin (timestamp,
+// message, value) for v2's `{{.timestamp}}` style references. Returns
+// ("", false) when absent everywhere — matches v1 + Go template
+// `missingkey=zero`.
+func lookupCategorized(name string, stream, metadata, parsed labels.Labels, builtin map[string]string) (string, bool) {
+	if parsed.Has(name) {
+		return parsed.Get(name), true
+	}
+	if metadata.Has(name) {
+		return metadata.Get(name), true
+	}
+	if stream.Has(name) {
+		return stream.Get(name), true
+	}
+	if v, ok := builtin[name]; ok {
+		return v, true
+	}
+	return "", false
+}
+
+// buildBuiltinColumnsFromInput returns the row's builtin Arrow columns
+// (timestamp, message, value) as short-name → value pairs, skipping NULL
+// cells. Short names are unique within this category so iteration order
+// is safe. Supports v2's `{{.timestamp}}` references in line templates
+// without mixing them into the label-like buckets.
+func buildBuiltinColumnsFromInput(input arrow.RecordBatch) map[string]string {
+	m := map[string]string{}
+	for i := 0; i < int(input.NumCols()); i++ {
+		ident, err := semconv.ParseFQN(input.ColumnName(i))
+		if err != nil {
+			continue
+		}
+		if ident.ColumnType() != types.ColumnTypeBuiltin {
+			continue
+		}
+		col := input.Column(i)
+		if col.IsNull(0) {
+			continue
+		}
+		m[ident.ColumnRef().Column] = col.ValueStr(0)
+	}
+	return m
 }

--- a/pkg/engine/internal/executor/parse_linefmt_test.go
+++ b/pkg/engine/internal/executor/parse_linefmt_test.go
@@ -15,65 +15,63 @@ import (
 
 func TestLinefmtParser_Process(t *testing.T) {
 	timestamp := time.Now().In(time.UTC).Add(time.Duration(1) * time.Second)
-	schema := arrow.NewSchema(
-		[]arrow.Field{
-			semconv.FieldFromIdent(semconv.ColumnIdentMessage, false),
-			semconv.FieldFromIdent(semconv.ColumnIdentTimestamp, false),
-			semconv.FieldFromIdent(semconv.NewIdentifier("namespace", types.ColumnTypeMetadata, types.Loki.String), true),
-		},
-		nil, // No metadata
-	)
+
+	const realPod = "querier-1234"
+
 	tests := []struct {
-		name          string
-		line          string
-		timeVal       arrow.Timestamp
-		namespace     string
-		nullNamespace bool // when true, append NULL for namespace instead of the namespace string
-		lineFmt       string
-		want          string
+		name    string
+		line    string
+		timeVal arrow.Timestamp
+		// cols is the list of label-like / metadata / parsed columns to
+		// append after the builtin message + timestamp columns. Order is
+		// preserved in the Arrow schema so duplicate-short-name cases can
+		// validate the line_format result is order-independent.
+		cols    []labelfmtTestColumn
+		lineFmt string
+		want    string
 	}{
 		{
-			name:      "simple replacement",
-			line:      "this is my test line of logs",
-			timeVal:   arrow.Timestamp(timestamp.UnixNano()),
-			namespace: "dev",
-			lineFmt:   "{{.namespace}}",
-			want:      "dev",
+			name:    "simple replacement",
+			line:    "this is my test line of logs",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols:    []labelfmtTestColumn{{fqn: "utf8.metadata.namespace", value: "dev"}},
+			lineFmt: "{{.namespace}}",
+			want:    "dev",
 		},
 		{
-			name:      "replacement plus addition",
-			line:      "this is my test line of logs",
-			timeVal:   arrow.Timestamp(timestamp.UnixNano()),
-			namespace: "dev",
-			lineFmt:   "{{.namespace}} foo",
-			want:      "dev foo",
+			name:    "replacement plus addition",
+			line:    "this is my test line of logs",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols:    []labelfmtTestColumn{{fqn: "utf8.metadata.namespace", value: "dev"}},
+			lineFmt: "{{.namespace}} foo",
+			want:    "dev foo",
 		},
 		{
-			name:      "timestamp",
-			line:      "this is my test line of logs",
-			timeVal:   arrow.Timestamp(timestamp.UnixNano()),
-			namespace: "dev",
-			lineFmt:   "{{.timestamp}} foo",
-			want:      timestamp.In(time.UTC).Format("2006-01-02T15:04:05.999999999Z") + " foo",
+			name:    "timestamp",
+			line:    "this is my test line of logs",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols:    []labelfmtTestColumn{{fqn: "utf8.metadata.namespace", value: "dev"}},
+			lineFmt: "{{.timestamp}} foo",
+			want:    timestamp.In(time.UTC).Format("2006-01-02T15:04:05.999999999Z") + " foo",
 		},
 		{
-			// Null entries on a parsed/metadata column must render as "" to match v1 engine
-			name:          "simple-key path on null entry renders as empty",
-			line:          "line",
-			timeVal:       arrow.Timestamp(timestamp.UnixNano()),
-			nullNamespace: true,
-			lineFmt:       "{{.namespace}}",
-			want:          "",
+			// Null entries on a parsed/metadata column must render as "" to match v1 engine.
+			name:    "simple-key path on null entry renders as empty",
+			line:    "line",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols:    []labelfmtTestColumn{{fqn: "utf8.metadata.namespace", null: true}},
+			lineFmt: "{{.namespace}}",
+			want:    "",
 		},
 		{
 			// Same intent as above but exercises the general template path
 			// (mixed text + field reference).
-			name:          "general template path on null entry renders as empty",
-			line:          "line",
-			timeVal:       arrow.Timestamp(timestamp.UnixNano()),
-			nullNamespace: true,
-			lineFmt:       "{{.namespace}} foo",
-			want:          " foo",
+			name:    "general template path on null entry renders as empty",
+			line:    "line",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols:    []labelfmtTestColumn{{fqn: "utf8.metadata.namespace", null: true}},
+			lineFmt: "{{.namespace}} foo",
+			want:    " foo",
 		},
 		{
 			// `{{.foo}}` references a key that is not in the schema (no column
@@ -81,41 +79,87 @@ func TestLinefmtParser_Process(t *testing.T) {
 			// "missing key" parser error which surfaced as an __error__ label on
 			// the row; v1 silently renders "" via Go template's missingkey=zero.
 			// Must render "" with no error.
-			name:      "simple-key path on missing key renders as empty",
-			line:      "line",
-			timeVal:   arrow.Timestamp(timestamp.UnixNano()),
-			namespace: "dev",
-			lineFmt:   "{{.foo}}",
-			want:      "",
+			name:    "simple-key path on missing key renders as empty",
+			line:    "line",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols:    []labelfmtTestColumn{{fqn: "utf8.metadata.namespace", value: "dev"}},
+			lineFmt: "{{.foo}}",
+			want:    "",
+		},
+		// --- Duplicate-short-name cases ---
+		// Two Arrow columns with different FQNs share a short name —
+		// typically a stream-label column with a real value and a same-name
+		// structured-metadata column that is NULL for this row (either
+		// contributed by another stream in the same dataobj section or
+		// NULL'd in place by an upstream ColumnCompat). Both the simple-key
+		// fast path and the general template path must look up the label by
+		// category priority (parsed > metadata > stream) and skip NULLs,
+		// rather than collapsing every column to a short-name map keyed by
+		// Arrow iteration order.
+		{
+			name:    "simple-key path, label.pod first metadata.pod NULL — renders stream value",
+			line:    "line",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols: []labelfmtTestColumn{
+				{fqn: "utf8.label.pod", value: realPod},
+				{fqn: "utf8.metadata.pod", null: true},
+			},
+			lineFmt: "{{.pod}}",
+			want:    realPod,
+		},
+		{
+			name:    "simple-key path, metadata.pod NULL first label.pod second — renders stream value",
+			line:    "line",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols: []labelfmtTestColumn{
+				{fqn: "utf8.metadata.pod", null: true},
+				{fqn: "utf8.label.pod", value: realPod},
+			},
+			lineFmt: "{{.pod}}",
+			want:    realPod,
+		},
+		{
+			name:    "general template path, label.pod first metadata.pod NULL — renders stream value",
+			line:    "line",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols: []labelfmtTestColumn{
+				{fqn: "utf8.label.pod", value: realPod},
+				{fqn: "utf8.metadata.pod", null: true},
+			},
+			lineFmt: "pod={{.pod}}",
+			want:    "pod=" + realPod,
+		},
+		{
+			name:    "general template path, metadata.pod NULL first label.pod second — renders stream value",
+			line:    "line",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols: []labelfmtTestColumn{
+				{fqn: "utf8.metadata.pod", null: true},
+				{fqn: "utf8.label.pod", value: realPod},
+			},
+			lineFmt: "pod={{.pod}}",
+			want:    "pod=" + realPod,
+		},
+		{
+			name:    "both NULL — renders empty (matches v1 missingkey=zero)",
+			line:    "line",
+			timeVal: arrow.Timestamp(timestamp.UnixNano()),
+			cols: []labelfmtTestColumn{
+				{fqn: "utf8.label.pod", null: true},
+				{fqn: "utf8.metadata.pod", null: true},
+			},
+			lineFmt: "{{.pod}}",
+			want:    "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create builders for each column
-			logBuilder := array.NewStringBuilder(memory.DefaultAllocator)
-			tsBuilder := array.NewTimestampBuilder(memory.DefaultAllocator, &arrow.TimestampType{Unit: arrow.Nanosecond, TimeZone: "UTC"})
-			namespaceBuilder := array.NewStringBuilder(memory.DefaultAllocator)
-
-			logBuilder.Append(tt.line)
-			tsBuilder.Append(tt.timeVal)
-			if tt.nullNamespace {
-				namespaceBuilder.AppendNull()
-			} else {
-				namespaceBuilder.Append(tt.namespace)
-			}
-
-			// Build the arrays
-			logArray := logBuilder.NewArray()
-			tsArray := tsBuilder.NewArray()
-			namespaceArray := namespaceBuilder.NewArray()
-			columns := []arrow.Array{logArray, tsArray, namespaceArray}
-			recordBatch := array.NewRecordBatch(schema, columns, 1)
-
+			record := buildLabelfmtTestRecord(t, tt.line, tt.timeVal, tt.cols)
 			parser, err := NewFormatter(tt.lineFmt)
 			require.NoError(t, err)
-			var result = map[string]string{}
-			output, processErr := parser.Process(tt.line, recordBatch, result)
+			result := map[string]string{}
+			output, processErr := parser.Process(tt.line, record, result)
 			require.NoError(t, processErr)
 			require.Equal(t, tt.want, output)
 			require.Equal(t, tt.want, result["message"])


### PR DESCRIPTION
**What this PR does / why we need it**:

`label_format` and `line_format` in v2 produced non-deterministic, sometimes wrong results when the input Arrow batch contained two columns sharing the same short name across categories (e.g. `label.pod` + `metadata.pod`). v1 has no equivalent ambiguity because its readers categorise labels at storage read time, and `LabelsBuilder.GetWithCategory` resolves with a fixed precedence (`parsed > metadata > stream`).

In v2, this shape is common since Arrow batches carry the union of column schemas across the underlying dataobj section. Streams that never wrote a given metadata key still see a `metadata.<key>` column in the schema with
all-NULL cells, because some other stream in the same section did write it. `ColumnCompat` rename also leaves a NULL'd source column in place alongside its new `_extracted` sibling.

#### User-visible symptoms

| Query | v1 | Pre-fix v2 |
|---|---|---|
| `{job="loki-dev/loki"} \| label_format foo=pod` | `foo=<real pod>` on every row | `foo=<real pod>` on some rows, missing on others |
| `{job="loki-dev/loki"} \| line_format "pod={{.pod}}"` | `pod=<real pod>` on every row | `pod=` (empty) on some rows |
| `{job="loki-dev/loki"} \| json \| label_format foo=name_extracted` | `foo=<JSON-extracted name>` | `foo=<stream name value>` (ghost-shadow via `_extracted` suffix in `LabelsBuilder.Add`) |

The first two are non-determinism: the OLD `buildLabelsFromInput` and `LineFormatter.Process` flattened every Arrow column to a short-name map keyed by iteration order, and `valueStrOrEmpty` turned NULL cells into `""`. Whichever same-short-name column iterated last in the batch's schema overwrote the real value.

The third is a separate v1 divergence, the OLD `Add(StructuredMetadataLabel, lbls)` pattern introduced: [passing the flat label set as both base and as a metadata add](https://github.com/grafana/loki/blob/bb93c6005cf2f40ddd64734e3d4db8e02e29c874/pkg/engine/internal/executor/parse_labelfmt.go#L37-L39) caused `LabelsBuilder.Add` to suffix every label with `_extracted`, creating ghost entries that shadowed real `_extracted` columns produced by ColumnCompat upstream.

#### Fix

`pkg/engine/internal/executor/parse_labelfmt.go`
  - Rewrite `buildLabelsFromInput` to return three `labels.Labels` buckets (stream / structured-metadata / parsed) matching v1's triplet. Skip NULL cells. Bucket generated columns (`__error__`, `__error_details__`) with parsed labels to match v1's `lbs.SetErr`.
  - `tokenizeLabelfmt` calls `ForLabels(stream)` + `Add(Metadata, metadata)` + `Add(Parsed, parsed)` so `GetWithCategory` resolves by v1 precedence and the per-category `_extracted` suffix logic in `Add` no longer creates ghost shadows of real `_extracted` columns.

`pkg/engine/internal/executor/parse_linefmt.go`
  - `LineFormatter.Process` simple-key fast path now uses `lookupCategorized` to resolve the template field by category priority (`parsed > metadata > stream`) and only falls back to builtin (timestamp, message, value) if absent from all label-like categories.
  - General template path builds the template input map in low → high precedence (`builtin → stream → metadata → parsed`), so a user-set label wins over a builtin of the same name and parsed wins over everything.