### PR TITLE
fix(index-gateway): Register IndexGatewayInterceptors before Server

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -897,6 +897,12 @@ func (t *Loki) setupModuleManager() error {
 		deps[Server] = append(deps[Server], IngesterGRPCInterceptors)
 	}
 
+	// Ensure index gateway interceptors are registered before the server reads
+	// cfg.GRPCMiddleware to build its gRPC chain.
+	if t.Cfg.isTarget(IndexGateway) {
+		deps[Server] = append(deps[Server], IndexGatewayInterceptors)
+	}
+
 	if t.Cfg.InternalServer.Enable {
 		for key, ds := range deps {
 			idx := -1

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -222,6 +222,19 @@ func TestUIServiceInitialization(t *testing.T) {
 	})
 }
 
+// TestIndexGatewayInterceptorsOrderedBeforeServer is a regression test for a
+// bug where initServer was called before initIndexGatewayInterceptors, resulting
+// in the interceptors not being effective.
+func TestIndexGatewayInterceptorsOrderedBeforeServer(t *testing.T) {
+	dir := t.TempDir()
+	cfg := minimalWorkingConfig(t, dir, IndexGateway)
+	c, err := New(cfg)
+	require.NoError(t, err)
+
+	require.Contains(t, c.ModuleManager.DependenciesForModule(Server), IndexGatewayInterceptors,
+		"Server must list IndexGatewayInterceptors as a dependency when target=index-gateway")
+}
+
 func minimalWorkingConfig(t *testing.T, dir, target string, cfgTransformers ...func(*Config)) Config {
 	prepareGlobalMetricsRegistry(t)
 


### PR DESCRIPTION
- This fixes a bug where these would run in the other order, resulting in `loki_index_gateway_requests_total` metric not being emitted.
- This happened because `initIndexGatewayInterceptors` sets t.Cfg.Server.GRPCMiddleware` - if this doesn't happen before the server is constructed, then the server is constructed without the middleware.

Tested in a pre-production environment: 
- Before this change it's easy to reproduce this by replacing a couple of index-gateway pods until one doesn't emit this metric. 
- After this change I can no longer reproduce this. 