### PR TITLE
chore: Add support for govulncheck ignore list to avoid blocking PRs on irrelevant or invalid vulnerabilities

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -43,5 +43,11 @@ jobs:
       - name: Run govulncheck
         # Symbol-aware reachability so the large vendored tree doesn't
         # drown the signal; we only get fired for vulns actually reachable
-        # from a main package.
-        run: govulncheck -mode=source -show=verbose ./...
+        # from a main package. -format=json always exits 0, so the gate below
+        # parses the output and decides pass/fail against the ignore list.
+        run: govulncheck -format=json -mode=source ./... > govulncheck.json
+      - name: Gate results against ignore list
+        # Fails on any reachable vulnerability whose ID is not in
+        # .govulncheck-ignore.txt (each ignored ID requires a documented
+        # justification). Suppressed and stale entries are reported.
+        run: bash .github/workflows/scripts/govulncheck-filter.sh govulncheck.json .govulncheck-ignore.txt

--- a/.github/workflows/scripts/govulncheck-filter.sh
+++ b/.github/workflows/scripts/govulncheck-filter.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Gate govulncheck JSON results against an ignore list.
+#
+# govulncheck with -format=json ALWAYS exits 0 (regardless of findings), so this
+# script parses its streaming JSON output and decides pass/fail itself:
+#
+#   * FAIL (exit 1) if any *reachable* vulnerability is reported whose OSV id is
+#     not in the ignore list. "Reachable" means govulncheck traced a call into
+#     the vulnerable symbol — the sink frame (trace[0]) has a "function". This
+#     mirrors the exit-code-3 semantics of govulncheck's default text mode and
+#     ignores informational/module-only findings.
+#   * PASS (exit 0) otherwise. IDs present in the ignore list are reported as
+#     suppressed; ignore-list entries that match nothing are warned about so the
+#     list stays current.
+#
+# Written for portability (POSIX-ish bash, works on bash 3.2+): no mapfile and
+# no associative arrays.
+#
+# Usage: govulncheck-filter.sh <govulncheck-json> <ignore-file>
+
+set -euo pipefail
+
+json="${1:?usage: govulncheck-filter.sh <govulncheck-json> <ignore-file>}"
+ignore_file="${2:-}"
+
+command -v jq >/dev/null || { echo "error: jq is required" >&2; exit 2; }
+
+# Fail closed if the input is not a recognizable govulncheck JSON stream. Without
+# this, an empty/truncated file (govulncheck crashed mid-write) or a future
+# change to govulncheck's output shape would make the jq filter below match
+# nothing, yielding a silent "no vulnerabilities" pass — the worst failure
+# direction for a security gate. govulncheck always emits a `config` message
+# first, so its absence means we are not looking at trustworthy output.
+jq -e 'select(.config != null)' "$json" >/dev/null 2>&1 || {
+  echo "::error::'$json' is not a valid govulncheck JSON stream (no config message) — failing closed" >&2
+  exit 2
+}
+
+# Normalize the ignore list to "ID<TAB>justification" lines (comments stripped),
+# stored in a temp file so we can look entries up without associative arrays.
+ignore_norm="$(mktemp)"
+trap 'rm -f "$ignore_norm"' EXIT
+if [ -n "$ignore_file" ] && [ -f "$ignore_file" ]; then
+  sed 's/\r$//' "$ignore_file" \
+    | { grep -vE '^[[:space:]]*(#|$)' || true; } \
+    | while IFS= read -r line; do
+        id="$(printf '%s' "${line%%#*}" | tr -d '[:space:]')"
+        [ -z "$id" ] && continue
+        reason="${line#*#}"
+        [ "$reason" = "$line" ] && reason="(no justification given)"
+        reason="$(printf '%s' "$reason" | sed 's/^[[:space:]]*//')"
+        printf '%s\t%s\n' "$id" "$reason"
+      done > "$ignore_norm"
+fi
+ignored_ids() { cut -f1 "$ignore_norm"; }
+reason_for()  { awk -F'\t' -v id="$1" '$1==id{$1="";sub(/^\t/,"");print;exit}' "$ignore_norm"; }
+
+# Distinct OSV ids of reachable findings (the vulnerable symbol is actually called).
+# Assumption (govulncheck v1.x source mode): for every *called* vulnerability,
+# govulncheck emits at least one finding whose sink frame (trace[0]) carries a
+# "function". Re-validate this filter when bumping GOVULNCHECK_VERSION.
+reachable="$(jq -r 'select(.finding.trace[0].function != null) | .finding.osv' "$json" | sort -u)"
+
+fail="" ; suppressed=""
+while IFS= read -r id; do
+  [ -z "$id" ] && continue
+  if ignored_ids | grep -qxF "$id"; then
+    suppressed="${suppressed}${id}"$'\n'
+  else
+    fail="${fail}${id}"$'\n'
+  fi
+done <<EOF
+$reachable
+EOF
+
+# Hygiene: flag ignore-list entries that no longer match any finding.
+while IFS= read -r id; do
+  [ -z "$id" ] && continue
+  printf '%s\n' "$reachable" | grep -qxF "$id" \
+    || echo "::warning::ignore-list entry ${id} matched no finding — remove it from ${ignore_file}"
+done <<EOF
+$(ignored_ids)
+EOF
+
+if [ -n "$suppressed" ]; then
+  echo "Suppressed by ignore list:"
+  printf '%s' "$suppressed" | while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    echo "  - ${id}: $(reason_for "$id")"
+  done
+fi
+
+if [ -n "$fail" ]; then
+  echo
+  echo "::error::govulncheck found reachable vulnerabilities not in the ignore list:"
+  printf '%s' "$fail" | while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    echo "  x ${id}  (https://pkg.go.dev/vuln/${id})"
+    { jq -r --arg id "$id" '
+        select(.finding.osv == $id and .finding.trace[0].function != null)
+        | .finding
+        | "      call: " + ([.trace[] | (.package // .module) + (if .function then "." + .function else "" end)] | reverse | join(" -> "))
+      ' "$json" | sort -u | head -n 5; } || true
+  done
+  exit 1
+fi
+
+echo "OK: no un-ignored reachable vulnerabilities."

--- a/.github/workflows/scripts/govulncheck-filter.sh
+++ b/.github/workflows/scripts/govulncheck-filter.sh
@@ -14,8 +14,7 @@
 #     suppressed; ignore-list entries that match nothing are warned about so the
 #     list stays current.
 #
-# Written for portability (POSIX-ish bash, works on bash 3.2+): no mapfile and
-# no associative arrays.
+# Written for portability across bash 3.2+ (no mapfile, no associative arrays).
 #
 # Usage: govulncheck-filter.sh <govulncheck-json> <ignore-file>
 
@@ -32,76 +31,76 @@ command -v jq >/dev/null || { echo "error: jq is required" >&2; exit 2; }
 # nothing, yielding a silent "no vulnerabilities" pass — the worst failure
 # direction for a security gate. govulncheck always emits a `config` message
 # first, so its absence means we are not looking at trustworthy output.
-jq -e 'select(.config != null)' "$json" >/dev/null 2>&1 || {
-  echo "::error::'$json' is not a valid govulncheck JSON stream (no config message) — failing closed" >&2
+jq -e 'select(.config != null)' "${json}" >/dev/null 2>&1 || {
+  echo "::error::'${json}' is not a valid govulncheck JSON stream (no config message) — failing closed" >&2
   exit 2
 }
 
 # Normalize the ignore list to "ID<TAB>justification" lines (comments stripped),
 # stored in a temp file so we can look entries up without associative arrays.
 ignore_norm="$(mktemp)"
-trap 'rm -f "$ignore_norm"' EXIT
-if [ -n "$ignore_file" ] && [ -f "$ignore_file" ]; then
-  sed 's/\r$//' "$ignore_file" \
+trap 'rm -f "${ignore_norm}"' EXIT
+if [[ -n "${ignore_file}" ]] && [[ -f "${ignore_file}" ]]; then
+  sed 's/\r$//' "${ignore_file}" \
     | { grep -vE '^[[:space:]]*(#|$)' || true; } \
     | while IFS= read -r line; do
         id="$(printf '%s' "${line%%#*}" | tr -d '[:space:]')"
-        [ -z "$id" ] && continue
+        [[ -z "${id}" ]] && continue
         reason="${line#*#}"
-        [ "$reason" = "$line" ] && reason="(no justification given)"
-        reason="$(printf '%s' "$reason" | sed 's/^[[:space:]]*//')"
-        printf '%s\t%s\n' "$id" "$reason"
-      done > "$ignore_norm"
+        [[ "${reason}" = "${line}" ]] && reason="(no justification given)"
+        reason="$(printf '%s' "${reason}" | sed 's/^[[:space:]]*//')"
+        printf '%s\t%s\n' "${id}" "${reason}"
+      done > "${ignore_norm}"
 fi
-ignored_ids() { cut -f1 "$ignore_norm"; }
-reason_for()  { awk -F'\t' -v id="$1" '$1==id{$1="";sub(/^\t/,"");print;exit}' "$ignore_norm"; }
+ignored_ids() { cut -f1 "${ignore_norm}"; }
+reason_for()  { awk -F'\t' -v id="$1" '$1==id{$1="";sub(/^\t/,"");print;exit}' "${ignore_norm}"; }
 
 # Distinct OSV ids of reachable findings (the vulnerable symbol is actually called).
 # Assumption (govulncheck v1.x source mode): for every *called* vulnerability,
 # govulncheck emits at least one finding whose sink frame (trace[0]) carries a
 # "function". Re-validate this filter when bumping GOVULNCHECK_VERSION.
-reachable="$(jq -r 'select(.finding.trace[0].function != null) | .finding.osv' "$json" | sort -u)"
+reachable="$(jq -r 'select(.finding.trace[0].function != null) | .finding.osv' "${json}" | sort -u)"
 
 fail="" ; suppressed=""
 while IFS= read -r id; do
-  [ -z "$id" ] && continue
-  if ignored_ids | grep -qxF "$id"; then
+  [[ -z "${id}" ]] && continue
+  if cut -f1 "${ignore_norm}" | grep -qxF "${id}"; then
     suppressed="${suppressed}${id}"$'\n'
   else
     fail="${fail}${id}"$'\n'
   fi
 done <<EOF
-$reachable
+${reachable}
 EOF
 
 # Hygiene: flag ignore-list entries that no longer match any finding.
 while IFS= read -r id; do
-  [ -z "$id" ] && continue
-  printf '%s\n' "$reachable" | grep -qxF "$id" \
+  [[ -z "${id}" ]] && continue
+  printf '%s\n' "${reachable}" | grep -qxF "${id}" \
     || echo "::warning::ignore-list entry ${id} matched no finding — remove it from ${ignore_file}"
 done <<EOF
 $(ignored_ids)
 EOF
 
-if [ -n "$suppressed" ]; then
+if [[ -n "${suppressed}" ]]; then
   echo "Suppressed by ignore list:"
-  printf '%s' "$suppressed" | while IFS= read -r id; do
-    [ -z "$id" ] && continue
-    echo "  - ${id}: $(reason_for "$id")"
+  printf '%s' "${suppressed}" | while IFS= read -r id; do
+    [[ -z "${id}" ]] && continue
+    echo "  - ${id}: $(reason_for "${id}")"
   done
 fi
 
-if [ -n "$fail" ]; then
+if [[ -n "${fail}" ]]; then
   echo
   echo "::error::govulncheck found reachable vulnerabilities not in the ignore list:"
-  printf '%s' "$fail" | while IFS= read -r id; do
-    [ -z "$id" ] && continue
+  printf '%s' "${fail}" | while IFS= read -r id; do
+    [[ -z "${id}" ]] && continue
     echo "  x ${id}  (https://pkg.go.dev/vuln/${id})"
-    { jq -r --arg id "$id" '
+    { jq -r --arg id "${id}" '
         select(.finding.osv == $id and .finding.trace[0].function != null)
         | .finding
         | "      call: " + ([.trace[] | (.package // .module) + (if .function then "." + .function else "" end)] | reverse | join(" -> "))
-      ' "$json" | sort -u | head -n 5; } || true
+      ' "${json}" | sort -u | head -n 5; } || true
   done
   exit 1
 fi

--- a/.govulncheck-ignore.txt
+++ b/.govulncheck-ignore.txt
@@ -1,0 +1,15 @@
+# govulncheck ignore list
+#
+# Each non-comment line suppresses one Go vulnerability ID from failing the
+# govulncheck CI gate (.github/workflows/govulncheck.yml). The gate still fails
+# on every other reachable vulnerability.
+#
+# Only add an entry after confirming the finding is NOT exploitable in Loki,
+# and document why and when to revisit. A reviewed, reachable vulnerability
+# must be FIXED, not ignored — keep this list short. Entries that no longer
+# match any finding are surfaced as CI warnings so the list can be pruned.
+#
+# Format:
+#   GO-XXXX-NNNN   # justification — owner, date, revisit condition
+
+GO-2026-5662   # Prometheus web-UI stored XSS (CVE-2026-40179). UNREVIEWED report with imprecise pseudo-version mapping; the fix (escapeHTML, prometheus#18506, on main since 2026-04-04) is already present in the pinned prometheus commit (dated 2026-06-12). The vulnerable code is the TypeScript/React web UI, which Loki neither builds nor ships — all reported traces (annotations/zeropool/almost) are false positives. Added 2026-06-29 (sandeep). Revisit when the Go vuln DB records a fixed pseudo-version for the prometheus v0.312/main line.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a maintainable suppression mechanism to the `govulncheck` PR check.

`govulncheck` has no native ignore flag, and `-format=json` always exits `0`, so today a single unactionable finding (e.g. an unreviewed advisory with imprecise version mapping) red-bars every PR that touches Go files, with no way to suppress it short of disabling the check.

## Changes

- **`.govulncheck-ignore.txt`** — explicit, reviewable ignore list. One OSV ID per line, each requiring an inline justification (owner, date, revisit condition). Seeded with `GO-2026-5662`.
- **`.github/workflows/scripts/govulncheck-filter.sh`** — runs the scan output through the ignore list and computes the pass/fail gate itself (since JSON mode exits `0`). Fails on any **reachable** vulnerability (vulnerable symbol actually called) whose ID is not listed; preserves the existing symbol-level reachability semantics.
- **`.github/workflows/govulncheck.yml`** — switches the run step to `-format=json` and adds the gate step.

## Behavior

| Scenario | Result |
|---|---|
| Reachable vuln, not in ignore list | **fail** (with call path + advisory link) |
| Reachable vuln, in ignore list | pass (reported as suppressed) |
| No vulnerabilities | pass |
| Ignore entry no longer matches anything | pass + stale-entry warning |
| Scanner output missing or invalid (crash, truncation, wrong tool) | **fail closed** (`exit 2`) |

The check asserts a `config` message is present before trusting an empty result, so a crashed scan or a future change to govulncheck's output format cannot silently disable the gate.

## Seeded suppression

`GO-2026-5662` (Prometheus web-UI stored XSS, CVE-2026-40179) is a false
trigger, not a real exposure. It's an **unreviewed** advisory auto-generated
from the GHSA, and two defects in the report cause govulncheck to misfire:

- **No symbol/package scoping.** The report carries no `ecosystem_specific.imports`, so govulncheck can't tell where the vulnerable code lives and conservatively flags the *entire* `prometheus` module — hence ~2,500 bogus traces through unrelated packages (`annotations`, `zeropool`, `almost`) that have nothing to do with the actual (TypeScript) UI code.
- **Incomplete version range.** The report records `fixed` boundaries only for the `3.5` and `3.11` release lines, none for the `3.12`/`main` line that the pinned dependency tracks. So it reports `Fixed in: N/A` and flags the pin as affected — even though the upstream fix (prometheus#18506) landed on `main` on 2026-04-04, well before the pinned commit on 2026-06-12.

The entry will self-flag as stale once the Go vuln DB records a fixed version for the 3.12 line, prompting its removal.
