### PR TITLE
chore(otlp): Track bytes received after attribute expansion

### DIFF
--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -230,7 +230,7 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 		}
 
 		// Calculate resource attributes metadata size for stats
-		resourceAttributesAsStructuredMetadataSize := loki_util.StructuredMetadataSize(resourceAttributesAsStructuredMetadata)
+		resourceAttributesAsStructuredMetadataSize := int64(loki_util.StructuredMetadataSize(resourceAttributesAsStructuredMetadata))
 		retentionPeriodForUser := streamResolver.RetentionPeriodFor(lbs)
 		policy := streamResolver.PolicyFor(ctx, lbs)
 
@@ -247,8 +247,8 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 			stats.ResourceAndSourceMetadataLabels[policy] = make(map[time.Duration]push.LabelsAdapter)
 		}
 
-		stats.StructuredMetadataBytes[policy][retentionPeriodForUser] += int64(resourceAttributesAsStructuredMetadataSize)
-		totalBytesReceived += int64(resourceAttributesAsStructuredMetadataSize)
+		stats.StructuredMetadataBytes[policy][retentionPeriodForUser] += resourceAttributesAsStructuredMetadataSize
+		totalBytesReceived += resourceAttributesAsStructuredMetadataSize
 
 		stats.ResourceAndSourceMetadataLabels[policy][retentionPeriodForUser] = append(stats.ResourceAndSourceMetadataLabels[policy][retentionPeriodForUser], resourceAttributesAsStructuredMetadata...)
 
@@ -268,9 +268,9 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 			}
 			scopeAttributesAsStructuredMetadata := scopeResult.StructuredMetadata
 
-			scopeAttributesAsStructuredMetadataSize := loki_util.StructuredMetadataSize(scopeAttributesAsStructuredMetadata)
-			stats.StructuredMetadataBytes[policy][retentionPeriodForUser] += int64(scopeAttributesAsStructuredMetadataSize)
-			totalBytesReceived += int64(scopeAttributesAsStructuredMetadataSize)
+			scopeAttributesAsStructuredMetadataSize := int64(loki_util.StructuredMetadataSize(scopeAttributesAsStructuredMetadata))
+			stats.StructuredMetadataBytes[policy][retentionPeriodForUser] += scopeAttributesAsStructuredMetadataSize
+			totalBytesReceived += scopeAttributesAsStructuredMetadataSize
 
 			stats.ResourceAndSourceMetadataLabels[policy][retentionPeriodForUser] = append(stats.ResourceAndSourceMetadataLabels[policy][retentionPeriodForUser], scopeAttributesAsStructuredMetadata...)
 			for k := 0; k < logs.Len(); k++ {
@@ -335,6 +335,7 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 
 				entry.StructuredMetadata = append(entry.StructuredMetadata, resourceAttributesAsStructuredMetadata...)
 				entry.StructuredMetadata = append(entry.StructuredMetadata, scopeAttributesAsStructuredMetadata...)
+
 				stream := pushRequestsByStream[entryLabelsStr]
 				stream.Entries = append(stream.Entries, entry)
 				pushRequestsByStream[entryLabelsStr] = stream
@@ -349,13 +350,18 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 				// This keeps the same accounting intention without risk of negative values
 				stats.StructuredMetadataBytes[entryPolicy][entryRetentionPeriod] += entryOwnMetadataSize
 
+				lineSize := int64(len(entry.Line))
 				if _, ok := stats.LogLinesBytes[entryPolicy]; !ok {
 					stats.LogLinesBytes[entryPolicy] = make(map[time.Duration]int64)
 				}
-				stats.LogLinesBytes[entryPolicy][entryRetentionPeriod] += int64(len(entry.Line))
+				stats.LogLinesBytes[entryPolicy][entryRetentionPeriod] += lineSize
+
+				// Track the expanded entry size including the resource and scope attributes that are copied into the entry's structured metadata.
+				// This is the actual size of the entry that will be ingested.
+				stats.TotalExpandedEntriesSize += lineSize + entryOwnMetadataSize + resourceAttributesAsStructuredMetadataSize + scopeAttributesAsStructuredMetadataSize
 
 				totalBytesReceived += entryOwnMetadataSize
-				totalBytesReceived += int64(len(entry.Line))
+				totalBytesReceived += lineSize
 
 				stats.PolicyNumLines[entryPolicy]++
 				if entry.Timestamp.After(stats.MostRecentEntryTimestamp) {

--- a/pkg/loghttp/push/otlp_test.go
+++ b/pkg/loghttp/push/otlp_test.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 
 	"github.com/grafana/loki/pkg/push"
@@ -670,7 +671,17 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 			)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedPushRequest, *pushReq)
-			require.Equal(t, tc.expectedStats, *stats)
+
+			// TotalExpandedEntriesSize is the size of each entry after resource/scope attributes have been
+			// merged into its structured metadata, which is exactly what expectedPushRequest's entries already
+			// contain.
+			expectedStats := tc.expectedStats
+			for _, stream := range tc.expectedPushRequest.Streams {
+				for i := range stream.Entries {
+					expectedStats.TotalExpandedEntriesSize += int64(util.EntryTotalSize(&stream.Entries[i]))
+				}
+			}
+			require.Equal(t, expectedStats, *stats)
 
 			totalBytes := 0.0
 			for _, policyMapping := range stats.LogLinesBytes {

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -44,8 +44,14 @@ var (
 	bytesIngested = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: constants.Loki,
 		Name:      "distributor_bytes_received_total",
-		Help:      "The total number of uncompressed bytes received per tenant. Includes structured metadata bytes.",
+		Help:      "The total number of uncompressed bytes received per tenant. Includes structured metadata bytes. For OTLP, resource and scope attributes are considered only once per request.",
 	}, []string{"tenant", "retention_hours", "is_internal_stream", "policy", "format"}) // TODO rename is_internal_stream to has_internal_streams
+
+	expandedBytesIngested = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: constants.Loki,
+		Name:      "distributor_expanded_bytes_received_total",
+		Help:      "The total number of uncompressed bytes received per tenant. Includes structured metadata bytes. For OTLP, all attributes added as structured metadata are considered.",
+	}, []string{"tenant", "format"})
 
 	structuredMetadataBytesIngested = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: constants.Loki,
@@ -176,6 +182,12 @@ type Stats struct {
 	Extra []any
 
 	HasInternalStreams bool // True if any of the streams has aggregated metrics or is a pattern stream
+
+	// TotalExpandedEntriesSize is the total size of all entries including the size of resource and scope
+	// attributes that are copied into the entry's structured metadata.
+	// This is the actual size of data that is being ingested and stored in Loki.
+	// For non-OTLP requests, TotalExpandedEntriesSize should be the same as the total size of LogLinesBytes and StructuredMetadataBytes.
+	TotalExpandedEntriesSize int64
 }
 
 func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, maxDecompressedSize int64, r *http.Request, limits Limits, tenantConfigs *runtime.TenantConfigs, pushRequestParser RequestParser, tracker UsageTracker, streamResolver StreamResolver, presumedAgentIP, format string) (*logproto.PushRequest, *Stats, error) {
@@ -247,6 +259,8 @@ func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, maxDecom
 		}
 	}
 
+	expandedBytesIngested.WithLabelValues(userID, format).Add(float64(pushStats.TotalExpandedEntriesSize))
+
 	var totalNumLines int64
 	// incrementing tenant metrics if we have a tenant.
 	for policy, numLines := range pushStats.PolicyNumLines {
@@ -270,6 +284,7 @@ func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, maxDecom
 		"entriesSize", humanize.Bytes(uint64(entriesSize)),
 		"structuredMetadataSize", humanize.Bytes(uint64(structuredMetadataSize)),
 		"totalSize", humanize.Bytes(uint64(entriesSize + pushStats.StreamLabelsSize)),
+		"totalExpandedSize", humanize.Bytes(uint64(pushStats.TotalExpandedEntriesSize + pushStats.StreamLabelsSize)),
 		"mostRecentLagMs", mostRecentLagMs,
 	}
 
@@ -543,7 +558,9 @@ func CalculateStreamsStats(ctx context.Context, userID string, req *logproto.Pus
 			pushStats.PolicyNumLines[policy]++
 			entryLabelsSize := int64(util.StructuredMetadataSize(e.StructuredMetadata))
 			pushStats.LogLinesBytes[policy][retentionPeriod] += int64(len(e.Line))
-			streamSizeBytes += int64(util.EntryTotalSize(&e))
+			entryTotal := int64(util.EntryTotalSize(&e))
+			streamSizeBytes += entryTotal
+			pushStats.TotalExpandedEntriesSize += entryTotal
 			pushStats.StructuredMetadataBytes[policy][retentionPeriod] += entryLabelsSize
 
 			if e.Timestamp.After(pushStats.MostRecentEntryTimestamp) {

--- a/pkg/loghttp/push/push_test.go
+++ b/pkg/loghttp/push/push_test.go
@@ -362,6 +362,7 @@ func TestParseRequest(t *testing.T) {
 
 			structuredMetadataBytesIngested.Reset()
 			bytesIngested.Reset()
+			expandedBytesIngested.Reset()
 			linesIngested.Reset()
 			if test.fakeLimits == nil {
 				test.fakeLimits = &fakeLimits{enabled: test.enableServiceDiscovery}
@@ -480,6 +481,15 @@ func TestParseRequest(t *testing.T) {
 					expectedStreamLabelsSize += len(lbs.String())
 				}
 				require.EqualValues(t, expectedStreamLabelsSize, stats.StreamLabelsSize)
+
+				// For non-OTLP (Loki) requests, TotalExpandedEntriesSize should equal the combined size of
+				// log lines and structured metadata bytes, since there are no resource/scope attributes to expand.
+				require.EqualValues(t, totalBytes, stats.TotalExpandedEntriesSize)
+				require.Equal(
+					t,
+					float64(totalBytes),
+					testutil.ToFloat64(expandedBytesIngested.WithLabelValues("fake", "loki")),
+				)
 			} else {
 				assert.Errorf(t, err, "Should give error for %d", index)
 				assert.Nil(t, data, "Should not give data for %d", index)
@@ -490,6 +500,7 @@ func TestParseRequest(t *testing.T) {
 				require.Equal(t, float64(0), testutil.ToFloat64(structuredMetadataBytesIngested.WithLabelValues("fake", "1" /* We use "1" here because fakeLimits.RetentionHoursFor returns "1" */, fmt.Sprintf("%t", test.aggregatedMetric), policy, "loki")))
 				require.Equal(t, float64(0), testutil.ToFloat64(bytesIngested.WithLabelValues("fake", "1" /* We use "1" here because fakeLimits.RetentionHoursFor returns "1" */, fmt.Sprintf("%t", test.aggregatedMetric), policy, "loki")))
 				require.Equal(t, float64(0), testutil.ToFloat64(linesIngested.WithLabelValues("fake", fmt.Sprintf("%t", test.aggregatedMetric), policy, "loki")))
+				require.Equal(t, float64(0), testutil.ToFloat64(expandedBytesIngested.WithLabelValues("fake", "loki")))
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Resource and scope attributes that are not promoted as stream labels are added as structured metadata to each entry of that request. `push request parsed` currently only tracks the size of entries before the expansion.

This pr adds `totalExpandedSize` stat to the log line along with a new metric `loki_distributor_expanded_bytes_received_total` to track the total size of entries in a request after the expansion of resource and scope attributes to all entries. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
