### PR TITLE
fix(ruler): Populate RulerStorage from `common.filesystem` config

### DIFF
--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -71,6 +71,12 @@ limits_config:
       - action: drop
         attributes: [email]
 
+# local rule storage is set by common.storage.filesystem.rules_directory
+# ruler_storage:
+#   backend: local
+#   local:
+#     directory: {{.sharedDataPath}}/rules
+
 storage_config:
   # Legacy config
   named_stores:
@@ -120,6 +126,9 @@ ruler:
       store: inmemory
   wal:
     dir: {{.sharedDataPath}}/ruler-wal
+  # local rule storage is set by common.storage.filesystem.rules_directory
+  # however, even if this is set, ruler_storage has precedence over ruler.storage 
+  # when storage.use_thanos_objstore is true, so keep it for testing purpose
   storage:
     type: local
     local:

--- a/integration/loki_rule_eval_test.go
+++ b/integration/loki_rule_eval_test.go
@@ -16,26 +16,28 @@ import (
 
 	"github.com/grafana/loki/v3/integration/client"
 	"github.com/grafana/loki/v3/integration/cluster"
-
 	"github.com/grafana/loki/v3/pkg/ruler"
 )
 
-// TestLocalRuleEval tests that rules are evaluated locally with an embedded query engine
+// mode=EvalModeLocal tests that rules are evaluated locally with an embedded query engine
 // and that the results are written to the backend correctly.
-func TestLocalRuleEval(t *testing.T) {
-	testRuleEval(t, ruler.EvalModeLocal)
-}
-
-// TestRemoteRuleEval tests that rules are evaluated remotely against a configured query-frontend
+// mode=EvalModeRemote tests that rules are evaluated remotely against a configured query-frontend
 // and that the results are written to the backend correctly.
-func TestRemoteRuleEval(t *testing.T) {
-	testRuleEval(t, ruler.EvalModeRemote)
+func TestRuleEval(t *testing.T) {
+	for _, mode := range []string{ruler.EvalModeLocal, ruler.EvalModeRemote} {
+		for _, useThanosObjstore := range []bool{false, true} {
+			name := fmt.Sprintf("mode=%v/use_thanos_objstore=%v", mode, useThanosObjstore)
+			t.Run(name, func(t *testing.T) {
+				testRuleEval(t, mode, useThanosObjstore)
+			})
+		}
+	}
 }
 
 // The only way we can test rule evaluation in an integration test is to use the remote-write feature.
 // In this test we stub out a remote-write receiver and check that the expected data is sent to it.
 // Both the local and the remote rule evaluation modes should produce the same result.
-func testRuleEval(t *testing.T, mode string) {
+func testRuleEval(t *testing.T, mode string, useThanosObjstore bool) {
 	clu := cluster.New(nil, cluster.SchemaWithTSDB, func(c *cluster.Cluster) {
 		c.SetSchemaVer("v13")
 	})
@@ -115,6 +117,7 @@ func testRuleEval(t *testing.T, mode string) {
 		"ruler",
 		"-target=ruler",
 		"-common.compactor-address="+tCompactor.HTTPURL(),
+		fmt.Sprintf("-use-thanos-objstore=%v", useThanosObjstore),
 	)
 
 	rwHandler := func(called *bool, test func(w http.ResponseWriter, r *http.Request)) *httptest.Server {

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/grafana/loki/v3/pkg/loki/common"
+	"github.com/grafana/loki/v3/pkg/storage/bucket/filesystem"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/types"
@@ -604,9 +605,22 @@ func applyStorageConfig(cfg, defaults *ConfigWrapper) error {
 	if !reflect.DeepEqual(cfg.Common.Storage.FSConfig, filesystemDefaults) {
 		configsFound++
 
+		// Although the common section specifies "filesystem", the ruler is
+		// configured with "local".
+		// The reason is that the ruler handles rules managed in a local directory
+		// differntly than rules managed via the API where it stores them on object
+		// storage.
+		// The legacy RuleStore (configured via Ruler.StoreConfig) did not support
+		// a "filesystem" object client, whereas the new RuleStore (configured via
+		// RulerStorage) does support "filesystem".
 		applyConfig = func(r *ConfigWrapper) {
 			r.Ruler.StoreConfig.Type = "local"
 			r.Ruler.StoreConfig.Local = local.Config{Directory: r.Common.Storage.FSConfig.RulesDirectory}
+
+			r.RulerStorage.Backend = "local"
+			r.RulerStorage.Local = local.Config{Directory: r.Common.Storage.FSConfig.RulesDirectory}
+			r.RulerStorage.Filesystem = filesystem.Config{Directory: r.Common.Storage.FSConfig.RulesDirectory}
+
 			r.StorageConfig.FSConfig.Directory = r.Common.Storage.FSConfig.ChunksDirectory
 		}
 	}


### PR DESCRIPTION
### Summary

When `common.storage.filesystem` is configured, config_wrapper only populated the legacy `Ruler.StoreConfig`. With `use_thanos_objstore` enabled, initRulerStorage reads the new `RulerStorage` config instead, which was left at its defaults and therefore treated as unconfigured. Set RulerStorage's local and filesystem directories from the common rules_directory so the thanos objstore path resolves rules correctly.

The ruler still uses the "local" backend for filesystem: rules managed in a local directory are handled differently than rules managed via the API, and the legacy RuleStore never supported a "filesystem" object client while the new RuleStore does.

Extend TestRuleEval to run both evaluation modes against use_thanos_objstore true and false.