### PR TITLE
fix(v2-engine): Push regexp parser source column to scan projections

### DIFF
--- a/pkg/engine/internal/planner/physical/rule_projection_pushdown.go
+++ b/pkg/engine/internal/planner/physical/rule_projection_pushdown.go
@@ -64,12 +64,15 @@ func (r *projectionPushdown) propagateProjections(node Node, projections []Colum
 					projections = append(projections, e.Left.(ColumnExpression))
 				}
 			case *VariadicExpr:
-				if e.Op == types.VariadicOpParseJSON || e.Op == types.VariadicOpParseLogfmt {
+				switch e.Op {
+				case types.VariadicOpParseJSON, types.VariadicOpParseLogfmt:
 					projectionNodeChanged, projsToPropagate := r.handleParse(e, projections)
 					projections = append(projections, projsToPropagate...)
 					if projectionNodeChanged {
 						changed = true
 					}
+				case types.VariadicOpParseRegexp:
+					projections = append(projections, r.handleParseRegexp(e)...)
 				}
 			}
 		}
@@ -225,6 +228,19 @@ func (r *projectionPushdown) handleParse(expr *VariadicExpr, projections []Colum
 	projections = append(projections, exprs.sourceColumnExpr)
 	projections = append(projections, collisionSources...)
 	return changed, projections
+}
+
+// handleParseRegexp returns the regexp parser's source column so the scan
+// loads the line content the pattern is applied against.
+func (r *projectionPushdown) handleParseRegexp(expr *VariadicExpr) []ColumnExpression {
+	if len(expr.Expressions) < 1 {
+		return nil
+	}
+	sourceCol, ok := expr.Expressions[0].(*ColumnExpr)
+	if !ok {
+		return nil
+	}
+	return []ColumnExpression{sourceCol}
 }
 
 // parseExprs is a helper struct for unpacking and packing parse arguments from generic expressions.

--- a/pkg/engine/internal/planner/physical/rule_projection_pushdown_test.go
+++ b/pkg/engine/internal/planner/physical/rule_projection_pushdown_test.go
@@ -430,6 +430,78 @@ func TestProjectionPushdown_PushesRequestedKeysToParseOperations(t *testing.T) {
 			},
 		},
 		{
+			name: "RangeAggregation with GroupBy on regexp named-capture output",
+			buildLogical: func() logical.Value {
+				// count_over_time({app="test"} | regexp "(?P<referrer>[^ ]+)" [5m]) by (referrer)
+				builder := logical.NewBuilder(&logical.MakeTable{
+					Selector: &logical.BinOp{
+						Left:  logical.NewColumnRef("app", types.ColumnTypeLabel),
+						Right: logical.NewLiteral("test"),
+						Op:    types.BinaryOpEq,
+					},
+					Shard: logical.NewShard(0, 1),
+				})
+				builder = builder.ParseRegexp("(?P<referrer>[^ ]+)")
+				builder = builder.RangeAggregation(
+					logical.Grouping{
+						Columns: []logical.ColumnRef{
+							{Ref: types.ColumnRef{Column: "referrer", Type: types.ColumnTypeAmbiguous}},
+						},
+						Without: false,
+					},
+					types.RangeAggregationTypeCount,
+					time.Unix(0, 0),
+					time.Unix(3600, 0),
+					5*time.Minute,
+					5*time.Minute,
+				)
+				return builder.Value()
+			},
+			// Regexp has no requestedKeys; we only assert the scan projections.
+			expectedParseKeysRequested:     nil,
+			expectedDataObjScanProjections: []string{"message", "referrer", "timestamp"},
+		},
+		{
+			name: "Filter on regexp named-capture output",
+			buildLogical: func() logical.Value {
+				// sum by (app) (count_over_time({app="test"} | regexp "(?P<lvl>[^ ]+)" | lvl="error" [5m]))
+				builder := logical.NewBuilder(&logical.MakeTable{
+					Selector: &logical.BinOp{
+						Left:  logical.NewColumnRef("app", types.ColumnTypeLabel),
+						Right: logical.NewLiteral("test"),
+						Op:    types.BinaryOpEq,
+					},
+					Shard: logical.NewShard(0, 1),
+				})
+				builder = builder.ParseRegexp("(?P<lvl>[^ ]+)")
+				builder = builder.Select(&logical.BinOp{
+					Left:  logical.NewColumnRef("lvl", types.ColumnTypeAmbiguous),
+					Right: logical.NewLiteral("error"),
+					Op:    types.BinaryOpEq,
+				})
+				builder = builder.RangeAggregation(
+					logical.NoGrouping,
+					types.RangeAggregationTypeCount,
+					time.Unix(0, 0),
+					time.Unix(3600, 0),
+					5*time.Minute,
+					5*time.Minute,
+				)
+				builder = builder.VectorAggregation(
+					logical.Grouping{
+						Columns: []logical.ColumnRef{
+							{Ref: types.ColumnRef{Column: "app", Type: types.ColumnTypeLabel}},
+						},
+						Without: false,
+					},
+					types.VectorAggregationTypeSum,
+				)
+				return builder.Value()
+			},
+			expectedParseKeysRequested:     nil,
+			expectedDataObjScanProjections: []string{"app", "lvl", "message", "timestamp"},
+		},
+		{
 			name: "RangeAggregation with GroupBy on ambiguous columns",
 			buildLogical: func() logical.Value {
 				// count_over_time({app="test"} | logfmt [5m]) by (duration, service)
@@ -744,14 +816,20 @@ func TestProjectionPushdown_PushesRequestedKeysToParseOperations(t *testing.T) {
 			require.NotNil(t, projectionNode, "Projection not found in plan")
 			var requestedKeys *LiteralExpr
 			for _, expr := range projectionNode.Expressions {
-				switch expr := expr.(type) {
-				case *VariadicExpr:
-					// Parse expressions: [sourceCol, requestedKeys, strict, keepEmpty]
-					// We want the requestedKeys (index 1)
-					if len(expr.Expressions) >= 2 {
-						if e, ok := expr.Expressions[1].(*LiteralExpr); ok {
-							requestedKeys = e
-						}
+				ve, ok := expr.(*VariadicExpr)
+				if !ok {
+					continue
+				}
+				// Only JSON / logfmt carry requestedKeys at arg index 1. The regexp
+				// parser's arg index 1 is the pattern literal (a StringLiteral),
+				// not a requested-keys list — interpreting it as requestedKeys
+				// would falsely fail the literal-type assertion below.
+				if ve.Op != types.VariadicOpParseJSON && ve.Op != types.VariadicOpParseLogfmt {
+					continue
+				}
+				if len(ve.Expressions) >= 2 {
+					if e, ok := ve.Expressions[1].(*LiteralExpr); ok {
+						requestedKeys = e
 					}
 				}
 			}

--- a/pkg/logql/bench/queries/regression/metric-queries.yaml
+++ b/pkg/logql/bench/queries/regression/metric-queries.yaml
@@ -332,3 +332,24 @@ queries:
       log_format: logfmt
       detected_fields:
         - error
+  - description: Group by a regexp named-capture output
+    query: sum by (word) (count_over_time(${SELECTOR} | regexp `^(?P<word>\S+)` [${RANGE}]))
+    kind: metric
+    time_range:
+      length: 24h
+      step: 1m
+    tags:
+      - count_over_time
+      - regexp
+      - grouping
+      - named-capture
+    notes: >
+      Regression for the v2 projection-pushdown fix. The regexp parser's
+      source column (the builtin `message`) was never projected to the
+      scan, so the parser saw null lines and every named-capture group
+      collapsed to the empty value — v2 returned a single empty series
+      with a constant per-bucket count while v1 returned one series per
+      distinct first token. Left format-agnostic on purpose so the entry
+      runs against every generator (json, logfmt, unstructured) — the
+      pattern `^\S+` matches any non-empty line. The series label set
+      and per-series counts must match v1.


### PR DESCRIPTION
**What this PR does / why we need it**:

The v2 projection-pushdown rule now recognises `VariadicOpParseRegexp` and pushes the parser's source column down to the scan, alongside the existing JSON / logfmt cases.

#### Why

A metric query whose extractor includes a `regexp` parser collapsed every row under an empty group, returning a constant per-bucket count instead of the per-group counts v1 returns.

The projection-pushdown rule only handled `VariadicOpParseJSON` and `VariadicOpParseLogfmt`. For regexp, the parser's source column (the built-in message) was never added to the scan's projection list, so the scan returned null lines and the parser had no content to match the pattern against. All named-capture outputs were empty, and the group-by collapsed every row under the single empty group.

#### How

`propagateProjections` now switches on the parse op and dispatches to a new `handleParseRegexp` helper for the regexp case. The helper returns the source column from `expr.Expressions[0]` so it flows down to the scan. Unlike JSON / logfmt, regexp has no requestedKeys to rewrite. Its output labels come from the named capture groups in the pattern literal at runtime, so only the source column needs to be projected.
