### PR TITLE
fix(compactor): Fix delete request when using Thanos objstore client with filesystem backend

### DIFF
--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/compactor/deletion"
 	"github.com/grafana/loki/v3/pkg/compactor/jobqueue"
 	"github.com/grafana/loki/v3/pkg/compactor/retention"
+	"github.com/grafana/loki/v3/pkg/storage/bucket"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/local"
 	chunk_util "github.com/grafana/loki/v3/pkg/storage/chunk/client/util"
@@ -266,7 +267,14 @@ func (c *Compactor) init(
 			} else {
 				raw = objectClient
 			}
+			// Chunk keys for filesystem-backed stores must be encoded with FSEncoder
+			// so that they match the keys written by the rest of the storage stack
+			// (see storage.NewChunkClient). This applies both to the legacy filesystem
+			// object client and to the thanos object store adapter backed by a
+			// filesystem bucket.
 			if _, ok := raw.(*local.FSObjectClient); ok {
+				encoder = client.FSEncoder
+			} else if adapter, ok := raw.(*bucket.ObjectClientAdapter); ok && adapter.IsBackendFilesystem() {
 				encoder = client.FSEncoder
 			}
 			chunkClient := client.NewClient(objectClient, encoder, schemaConfig)

--- a/pkg/storage/bucket/object_client_adapter.go
+++ b/pkg/storage/bucket/object_client_adapter.go
@@ -24,6 +24,9 @@ type ObjectClientAdapter struct {
 	logger               log.Logger
 	supportsUpdatedAt    bool
 	isRetryableErr       func(err error) bool
+	// storeType is the resolved backend type (e.g. filesystem, s3, gcs), used by
+	// callers that need backend-specific behaviour such as chunk key encoding.
+	storeType string
 }
 
 func NewObjectClient(ctx context.Context, backend string, cfg ConfigWithNamedStores, component string, hedgingCfg hedging.Config, disableRetries bool, logger log.Logger) (*ObjectClientAdapter, error) {
@@ -73,6 +76,7 @@ func NewObjectClient(ctx context.Context, backend string, cfg ConfigWithNamedSto
 		hedgedBucket:      hedgedBucket,
 		logger:            log.With(logger, "component", "bucket_to_object_client_adapter"),
 		supportsUpdatedAt: slices.Contains(bucket.SupportedIterOptions(), objstore.UpdatedAt),
+		storeType:         storeType,
 		// default to no retryable errors. Override with WithRetryableErrFunc
 		isRetryableErr: func(_ error) bool {
 			return false
@@ -90,6 +94,12 @@ func NewObjectClient(ctx context.Context, backend string, cfg ConfigWithNamedSto
 }
 
 func (o *ObjectClientAdapter) Stop() {
+}
+
+// IsBackendFilesystem reports whether the underlying object storage backend is
+// the local filesystem.
+func (o *ObjectClientAdapter) IsBackendFilesystem() bool {
+	return o.storeType == Filesystem
 }
 
 // ObjectExists checks if a given objectKey exists in the bucket

--- a/pkg/storage/bucket/object_client_adapter_test.go
+++ b/pkg/storage/bucket/object_client_adapter_test.go
@@ -127,3 +127,19 @@ func TestObjectClientAdapter_List(t *testing.T) {
 		require.Equal(t, tt.storageCommonPref, storageCommonPref)
 	}
 }
+
+func TestObjectClientAdapter_IsBackendFilesystem(t *testing.T) {
+	// A filesystem-backed adapter must report true so that callers select the
+	// FSEncoder for chunk keys (see compactor chunk client setup).
+	client, err := NewObjectClient(context.Background(), "filesystem", ConfigWithNamedStores{
+		Config: Config{
+			Filesystem: filesystem.Config{Directory: t.TempDir()},
+		},
+	}, "test", hedging.Config{}, false, log.NewNopLogger())
+	require.NoError(t, err)
+	require.True(t, client.IsBackendFilesystem())
+
+	// Non-filesystem backends must report false.
+	require.False(t, (&ObjectClientAdapter{storeType: S3}).IsBackendFilesystem())
+	require.False(t, (&ObjectClientAdapter{storeType: GCS}).IsBackendFilesystem())
+}


### PR DESCRIPTION
### Summary 
The compactor selected the chunk-key encoder via a concrete type assertion on *local.FSObjectClient. With use_thanos_objstore enabled the object client is a *bucket.ObjectClientAdapter, so FSEncoder was skipped and chunks were looked up with raw, un-encoded keys. This diverged from the keys written by the rest of the storage stack (storage.NewChunkClient applies FSEncoder for the thanos filesystem backend), causing chunk rewrites during retention to fail and line-filter delete requests to remain stuck in the received state.
