### PR TITLE
feat(ingester): Set chunk IngestedAt at flush for backfilled streams

### DIFF
--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -25,7 +25,9 @@ import (
 	"github.com/grafana/loki/v3/pkg/chunkenc"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
+	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/util"
+	"github.com/grafana/loki/v3/pkg/util/constants"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
 
@@ -533,6 +535,10 @@ func (i *Ingester) flushChunks(ctx context.Context, fp model.Fingerprint, labelP
 			lastTime,
 		)
 
+		// Record the ingestion time for backfilled chunks so retention can be
+		// measured from ingestion rather than from the log timestamps.
+		i.maybeSetIngestedAt(&ch, firstTime)
+
 		// encodeChunk mutates the chunk so we must pass by reference
 		if err := i.encodeChunk(ctx, &ch, c); err != nil {
 			return err
@@ -561,6 +567,27 @@ func (i *Ingester) markChunkAsFlushed(desc *chunkDesc, chunkMtx sync.Locker) {
 	chunkMtx.Lock()
 	defer chunkMtx.Unlock()
 	desc.flushed = time.Now()
+}
+
+// maybeSetIngestedAt records the ingestion time on chunks belonging to backfilled
+// streams (those carrying the __backfill__ label) so that, under TSDB FormatV4
+// (schema v14), retention can be measured from ingestion rather than from the log
+// timestamps. Live chunks, and chunks in periods that don't support FormatV4, keep
+// the zero value and fall back to Through-based retention.
+func (i *Ingester) maybeSetIngestedAt(ch *chunk.Chunk, chunkTime model.Time) {
+	if ch.Metric.Get(constants.BackfillLabel) != "true" {
+		return
+	}
+
+	// Only FormatV4 periods persist IngestedAt; the encoder drops it for older
+	// formats, but gate here too so non-v14 chunks never carry a misleading
+	// in-memory ingestion time.
+	schemaCfg := config.SchemaConfig{Configs: i.periodicConfigs}
+	if !schemaCfg.SupportsIngestedAtForTime(chunkTime) {
+		return
+	}
+
+	ch.IngestedAt = model.Now()
 }
 
 // closeChunk closes the given chunk while locking it to ensure that new blocks are cut before flushing.

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -535,8 +535,8 @@ func (i *Ingester) flushChunks(ctx context.Context, fp model.Fingerprint, labelP
 			lastTime,
 		)
 
-		// Record the ingestion time for backfilled chunks so retention can be
-		// measured from ingestion rather than from the log timestamps.
+		// For backfilled chunks, stamp the flush time as IngestedAt so retention
+		// can be measured from ingestion rather than from the log timestamps.
 		i.maybeSetIngestedAt(&ch, firstTime)
 
 		// encodeChunk mutates the chunk so we must pass by reference
@@ -569,24 +569,30 @@ func (i *Ingester) markChunkAsFlushed(desc *chunkDesc, chunkMtx sync.Locker) {
 	desc.flushed = time.Now()
 }
 
-// maybeSetIngestedAt records the ingestion time on chunks belonging to backfilled
-// streams (those carrying the __backfill__ label) so that, under TSDB FormatV4
-// (schema v14), retention can be measured from ingestion rather than from the log
-// timestamps. Live chunks, and chunks in periods that don't support FormatV4, keep
-// the zero value and fall back to Through-based retention.
+// maybeSetIngestedAt stamps the flush time as the chunk's IngestedAt for chunks
+// belonging to backfilled streams (those carrying the __backfill__ label), so that
+// under TSDB FormatV4 (schema v14) retention can be measured from ingestion rather
+// than from the log timestamps. Live chunks, and chunks whose period does not
+// support FormatV4, keep the zero value and fall back to Through-based retention.
 func (i *Ingester) maybeSetIngestedAt(ch *chunk.Chunk, chunkTime model.Time) {
 	if ch.Metric.Get(constants.BackfillLabel) != "true" {
 		return
 	}
 
-	// Only FormatV4 periods persist IngestedAt; the encoder drops it for older
-	// formats, but gate here too so non-v14 chunks never carry a misleading
-	// in-memory ingestion time.
+	// Resolve the schema from the chunk's own time (its From). That's deliberate:
+	// the index format is selected per chunk time bounds (see tsdb.IndexBuckets),
+	// so the gate must match the period the chunk is actually written under.
+	// Resolving from the chunk's (old) backfill time is safe because replay is only
+	// enabled once the schema is v14, so a backfilled chunk's time always resolves
+	// to a v14+ period and this passes; the check still guards against ever
+	// stamping IngestedAt onto a non-FormatV4 index.
 	schemaCfg := config.SchemaConfig{Configs: i.periodicConfigs}
 	if !schemaCfg.SupportsIngestedAtForTime(chunkTime) {
 		return
 	}
 
+	// Stamp the flush time. Backfilled chunks are flushed shortly after they are
+	// ingested, so at the day precision used by the index this matches ingestion.
 	ch.IngestedAt = model.Now()
 }
 

--- a/pkg/ingester/flush_test.go
+++ b/pkg/ingester/flush_test.go
@@ -203,6 +203,77 @@ func buildChunkDecs(t testing.TB) []*chunkDesc {
 	return res
 }
 
+func TestMaybeSetIngestedAt(t *testing.T) {
+	v14 := []config.PeriodConfig{{From: config.DayTime{Time: 0}, Schema: "v14"}}
+	v13 := []config.PeriodConfig{{From: config.DayTime{Time: 0}, Schema: "v13"}}
+
+	backfill := labels.FromStrings("app", "foo", constants.BackfillLabel, "true")
+	live := labels.FromStrings("app", "foo")
+
+	for _, tc := range []struct {
+		name    string
+		periods []config.PeriodConfig
+		metric  labels.Labels
+		wantSet bool
+	}{
+		{"backfill stream under v14 records ingestion time", v14, backfill, true},
+		{"live stream under v14 stays zero", v14, live, false},
+		{"backfill stream under v13 stays zero", v13, backfill, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			i := &Ingester{periodicConfigs: tc.periods}
+			ch := chunk.Chunk{Metric: tc.metric}
+
+			before := model.Now()
+			i.maybeSetIngestedAt(&ch, model.Now())
+
+			if tc.wantSet {
+				require.NotEqual(t, model.Time(0), ch.IngestedAt)
+				require.GreaterOrEqual(t, int64(ch.IngestedAt), int64(before))
+			} else {
+				require.Equal(t, model.Time(0), ch.IngestedAt)
+			}
+		})
+	}
+}
+
+func TestFlushChunksSetsIngestedAtForBackfill(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		labels  labels.Labels
+		wantSet bool
+	}{
+		{"backfill stream", labels.FromStrings("app", "foo", constants.BackfillLabel, "true"), true},
+		{"live stream", labels.FromStrings("app", "foo"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, ing := newTestStore(t, defaultIngesterTestConfig(t), nil)
+			// Use a v14 period so the chunk's index would persist IngestedAt.
+			ing.periodicConfigs = []config.PeriodConfig{{From: config.DayTime{Time: 0}, Schema: "v14"}}
+			ctx := user.InjectOrgID(context.Background(), "foo")
+
+			var captured []chunk.Chunk
+			store.onPut = func(_ context.Context, chunks []chunk.Chunk) error {
+				captured = append(captured, chunks...)
+				return nil
+			}
+
+			before := model.Now()
+			require.NoError(t, ing.flushChunks(ctx, 0, tc.labels, buildChunkDecs(t), &sync.RWMutex{}))
+
+			require.NotEmpty(t, captured)
+			for _, c := range captured {
+				if tc.wantSet {
+					require.NotEqual(t, model.Time(0), c.IngestedAt)
+					require.GreaterOrEqual(t, int64(c.IngestedAt), int64(before))
+				} else {
+					require.Equal(t, model.Time(0), c.IngestedAt)
+				}
+			}
+		})
+	}
+}
+
 func TestWALFullFlush(t *testing.T) {
 	// technically replaced with a fake wal, but the ingester New() function creates a regular wal first,
 	// so we enable creation/cleanup even though it remains unused.

--- a/pkg/ingester/flush_test.go
+++ b/pkg/ingester/flush_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/index/stats"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/sharding"
+	storagetypes "github.com/grafana/loki/v3/pkg/storage/types"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 	"github.com/grafana/loki/v3/pkg/validation"
 )
@@ -204,8 +205,8 @@ func buildChunkDecs(t testing.TB) []*chunkDesc {
 }
 
 func TestMaybeSetIngestedAt(t *testing.T) {
-	v14 := []config.PeriodConfig{{From: config.DayTime{Time: 0}, Schema: "v14"}}
-	v13 := []config.PeriodConfig{{From: config.DayTime{Time: 0}, Schema: "v13"}}
+	v14 := []config.PeriodConfig{{From: config.DayTime{Time: 0}, IndexType: storagetypes.IndexTypeTSDB, Schema: "v14"}}
+	v13 := []config.PeriodConfig{{From: config.DayTime{Time: 0}, IndexType: storagetypes.IndexTypeTSDB, Schema: "v13"}}
 
 	backfill := labels.FromStrings("app", "foo", constants.BackfillLabel, "true")
 	live := labels.FromStrings("app", "foo")
@@ -249,7 +250,7 @@ func TestFlushChunksSetsIngestedAtForBackfill(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			store, ing := newTestStore(t, defaultIngesterTestConfig(t), nil)
 			// Use a v14 period so the chunk's index would persist IngestedAt.
-			ing.periodicConfigs = []config.PeriodConfig{{From: config.DayTime{Time: 0}, Schema: "v14"}}
+			ing.periodicConfigs = []config.PeriodConfig{{From: config.DayTime{Time: 0}, IndexType: storagetypes.IndexTypeTSDB, Schema: "v14"}}
 			ctx := user.InjectOrgID(context.Background(), "foo")
 
 			var captured []chunk.Chunk

--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -434,6 +434,9 @@ func (cfg *PeriodConfig) TSDBFormat() (int, error) {
 // SupportsIngestedAt reports whether this period persists the per-chunk
 // IngestedAt timestamp (TSDB index FormatV4, schema v14).
 func (cfg *PeriodConfig) SupportsIngestedAt() bool {
+	if cfg.IndexType != types.IndexTypeTSDB {
+		return false
+	}
 	format, err := cfg.TSDBFormat()
 	return err == nil && format >= index.FormatV4
 }

--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -431,6 +431,13 @@ func (cfg *PeriodConfig) TSDBFormat() (int, error) {
 	}
 }
 
+// SupportsIngestedAt reports whether this period persists the per-chunk
+// IngestedAt timestamp (TSDB index FormatV4, schema v14).
+func (cfg *PeriodConfig) SupportsIngestedAt() bool {
+	format, err := cfg.TSDBFormat()
+	return err == nil && format >= index.FormatV4
+}
+
 // Validate the period config.
 func (cfg PeriodConfig) validate() error {
 	if cfg.IndexType == types.IndexTypeTSDB && cfg.IndexTables.Period != ObjectStorageIndexRequiredPeriod {
@@ -706,6 +713,16 @@ func (cfg SchemaConfig) SchemaForTime(t model.Time) (PeriodConfig, error) {
 		}
 	}
 	return PeriodConfig{}, fmt.Errorf("no schema config found for time %v", t)
+}
+
+// SupportsIngestedAtForTime reports whether the schema active at time t persists
+// the per-chunk IngestedAt timestamp (TSDB index FormatV4, schema v14).
+func (cfg SchemaConfig) SupportsIngestedAtForTime(t model.Time) bool {
+	p, err := cfg.SchemaForTime(t)
+	if err != nil {
+		return false
+	}
+	return p.SupportsIngestedAt()
 }
 
 // TableFor calculates the table shard for a given point in time.

--- a/pkg/storage/config/schema_config_test.go
+++ b/pkg/storage/config/schema_config_test.go
@@ -962,3 +962,29 @@ func TestChunkKeys(t *testing.T) {
 		})
 	}
 }
+
+func TestSupportsIngestedAtForTime(t *testing.T) {
+	cfg := SchemaConfig{Configs: []PeriodConfig{
+		{
+			From:      DayTime{Time: model.TimeFromUnix(0)},
+			IndexType: types.IndexTypeTSDB,
+			Schema:    "v13",
+		},
+		{
+			From:      DayTime{Time: model.TimeFromUnix(1000)},
+			IndexType: types.IndexTypeTSDB,
+			Schema:    "v14",
+		},
+	}}
+
+	require.False(t, cfg.SupportsIngestedAtForTime(model.TimeFromUnix(500)), "v13 period must not support IngestedAt")
+	require.True(t, cfg.SupportsIngestedAtForTime(model.TimeFromUnix(2000)), "v14 period must support IngestedAt")
+	require.False(t, cfg.SupportsIngestedAtForTime(model.TimeFromUnix(-1000)), "time before any period must not support IngestedAt")
+
+	v12 := SchemaConfig{Configs: []PeriodConfig{{
+		From:      DayTime{Time: model.TimeFromUnix(0)},
+		IndexType: types.IndexTypeTSDB,
+		Schema:    "v12",
+	}}}
+	require.False(t, v12.SupportsIngestedAtForTime(model.TimeFromUnix(500)), "v12 period must not support IngestedAt")
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/chunk.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/chunk.go
@@ -15,7 +15,8 @@ type ChunkMeta struct {
 
 	MinTime, MaxTime int64
 
-	// IngestedAt is the time at which the chunk was ingested. It is recorded only
+	// IngestedAt is the time the chunk was ingested into storage, stamped at flush
+	// time (not the time the original log lines were received). It is recorded only
 	// for backfilled chunks — those whose stream carries the __backfill__="true"
 	// label — and is zero for all other (live) chunks. In TSDB FormatV4 it is
 	// encoded as a day-precision delta against MaxTime, rounded up to the next UTC

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/chunk.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/chunk.go
@@ -15,11 +15,18 @@ type ChunkMeta struct {
 
 	MinTime, MaxTime int64
 
-	// IngestedAt stores the chunk ingestion timestamp.
-	// It is encoded at day precision in TSDB FormatV4, rounded up to the next UTC
-	// day boundary (or kept on the same boundary if already aligned) so retention
-	// measured from ingestion never expires a chunk early, and defaults to zero for
-	// legacy files.
+	// IngestedAt is the time at which the chunk was ingested. It is recorded only
+	// for backfilled chunks — those whose stream carries the __backfill__="true"
+	// label — and is zero for all other (live) chunks. In TSDB FormatV4 it is
+	// encoded as a day-precision delta against MaxTime, rounded up to the next UTC
+	// day boundary so retention measured from ingestion never expires a chunk early.
+	//
+	// It is also zero when the index version predates FormatV4 and does not carry
+	// this field.
+	//
+	// Example: MaxTime is 2026-01-10 14:30 UTC and the chunk was ingested on
+	// 2026-01-12 08:00 UTC. The ingestion time rounds up to 2026-01-13 00:00 UTC
+	// and MaxTime's day is 2026-01-10, so the stored delta is +3 days.
 	IngestedAt int64
 
 	// Bytes stored, rounded to nearest KB


### PR DESCRIPTION
**What this PR does / why we need it**:

Stamps `chunk.IngestedAt = now` at flush for chunks belonging to backfilled streams — those carrying the `__backfill__="true"` label injected by the `X-Loki-Backfill-Day` header (#22628) — under schema v14 / TSDB FormatV4. This lets retention be measured from ingestion for backfilled data. Live chunks (and non-v14 periods) keep the zero sentinel and fall back to `Through`-based retention.

Builds on the FormatV4 index foundation (#22370). The retention read side (`expirationChecker.Expired` consuming `IngestedAt`) is a follow-up.

**Why gate on the stream label, and not...**
- _the HTTP header_: making the backfill header available down in the flush logic would require threading it through far more of the write path.
- _setting the field on all chunks where `MaxTime != current day`_: that misclassifies chunks straddling the UTC midnight boundary — a live chunk that closes just after midnight would be wrongly treated as backfill.

**Which issue(s) this PR fixes**:

Part of the ingestion-time retention stack (#21931).

**Special notes for your reviewer**:

No header/gRPC, distributor/validator, or compactor/retention changes — scoped to the write path only.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
