### PR TITLE
fix(ci): Re-enable docker plugin publishing

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
+      "version": "7ab449296de23c4e7ef562d1988135d28c71bce9"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501",
-      "sum": "nhv9Nblyvooc8PgiyVpydSFq4g8qAWGPtzC8SjqB7gI="
+      "version": "7ab449296de23c4e7ef562d1988135d28c71bce9",
+      "sum": "kWzQTko0+bId7oI8ErjAXdnTc7R5uLSY1zBTRC0341k="
     }
   ],
   "legacyImports": false

--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -87,11 +87,12 @@ local weeklyImageJobs = {
     lokiRelease.releaseWorkflow(
       branches=['release-[0-9]+.[0-9]+.x', 'k[0-9]+', 'main'],
       imagePrefix=imagePrefix,
+      pluginImagePrefix=imagePrefix,
       releaseLibRef=releaseLibRef,
       pluginBuildDir=dockerPluginDir,
       releaseBranchTemplate='release-\\${major}.\\${minor}.x',
       releaseRepo='grafana/loki',
-      publishDockerPlugins=false,
+      publishDockerPlugins=true,
     ), false, false
   ),
   'check.yml': std.manifestYamlDoc({

--- a/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/main.jsonnet
@@ -91,6 +91,7 @@
     branches=['release-[0-9].[0-9].x', 'k[0-9]*'],
     buildArtifactsBucket='loki-build-artifacts',
     imagePrefix='grafana',
+    pluginImagePrefix=null,
     pluginBuildDir='release/plugin-tmp-dir',
     publishBucket='',
     publishToGCS=false,
@@ -102,6 +103,7 @@
                   ) {
     local githubApp = if releaseRepo == 'grafana/enterprise-logs' then 'enterprise-logs-app' else 'loki-gh-app',
     local garRepoSlug = if releaseRepo == 'grafana/enterprise-logs' then 'enterprise-logs' else 'loki',
+    local effectivePluginImagePrefix = if pluginImagePrefix != null then pluginImagePrefix else imagePrefix,
 
     name: 'create release',
     on: {
@@ -119,6 +121,7 @@
     env: {
       BUILD_ARTIFACTS_BUCKET: buildArtifactsBucket,
       IMAGE_PREFIX: imagePrefix,
+      PLUGIN_IMAGE_PREFIX: effectivePluginImagePrefix,
       RELEASE_LIB_REF: releaseLibRef,
       RELEASE_REPO: releaseRepo,
       GAR_REPO_SLUG: garRepoSlug,

--- a/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
@@ -175,12 +175,12 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
                        --project="grafanalabs-global" \
                        --repository="generic-${{ env.GAR_REPO_SLUG }}-prod" \
                        --location="us" \
-                       --source-directory=${{ env.path }}, \
+                       --source-directory=${{ env.path }} \
                        --package=binaries \
                        --version=${{ github.sha }}
                    |||)
                    + step.withEnv({
-                     path: 'release/dist',
+                     path: 'dist',
                    }),
                  ])
                  + job.withOutputs({
@@ -240,8 +240,8 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         common.fetchReleaseRepo,
         step.new('Set up QEMU', 'docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392'),  // v3
         step.new('set up docker buildx', 'docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2'),  //v3
-        step.new('Login to DockerHub', 'grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7'),  // v1.0.4
-        step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136'),  // v1.0.2
+        step.new('Login to GAR', 'grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136')  // v1.0.2
+        + step.with({ registry: 'us-docker.pkg.dev' }),
         step.new('download and prepare plugins')
         + step.withEnv({
           SHA: '${{ needs.createRelease.outputs.sha }}',
@@ -261,7 +261,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         step.new('publish docker driver', './lib/actions/push-images')
         + step.with({
           imageDir: 'plugins',
-          imagePrefix: '${{ env.IMAGE_PREFIX }}',
+          imagePrefix: '${{ env.PLUGIN_IMAGE_PREFIX }}',
           isPlugin: true,
           buildDir: 'release/%s' % path,
           isLatest: '${{ needs.createRelease.outputs.isLatest }}',

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@7ab449296de23c4e7ef562d1988135d28c71bce9"
     "with":
       "build_image": "golang:1.26.4"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
+      "release_lib_ref": "7ab449296de23c4e7ef562d1988135d28c71bce9"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@7ab449296de23c4e7ef562d1988135d28c71bce9"
     "with":
       "build_image": "golang:1.26.4"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
+      "release_lib_ref": "7ab449296de23c4e7ef562d1988135d28c71bce9"
       "skip_validation": false
       "use_github_app_token": true
   "logql-analyzer-image":
@@ -12,7 +12,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
+      "RELEASE_LIB_REF": "7ab449296de23c4e7ef562d1988135d28c71bce9"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -152,7 +152,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
+      "RELEASE_LIB_REF": "7ab449296de23c4e7ef562d1988135d28c71bce9"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -292,7 +292,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
+      "RELEASE_LIB_REF": "7ab449296de23c4e7ef562d1988135d28c71bce9"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -432,7 +432,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
+      "RELEASE_LIB_REF": "7ab449296de23c4e7ef562d1988135d28c71bce9"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -572,7 +572,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.4"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
+      "RELEASE_LIB_REF": "7ab449296de23c4e7ef562d1988135d28c71bce9"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -8,7 +8,7 @@ env:
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-  RELEASE_LIB_REF: "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
+  RELEASE_LIB_REF: "7ab449296de23c4e7ef562d1988135d28c71bce9"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   VERSIONING_STRATEGY: "always-bump-minor"
@@ -18,11 +18,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
+    uses: "grafana/loki-release/.github/workflows/check.yml@7ab449296de23c4e7ef562d1988135d28c71bce9"
     with:
       build_image: "golang:1.26.4"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
+      release_lib_ref: "7ab449296de23c4e7ef562d1988135d28c71bce9"
       skip_validation: false
   create-release-pr:
     needs:

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -8,7 +8,7 @@ env:
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-  RELEASE_LIB_REF: "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
+  RELEASE_LIB_REF: "7ab449296de23c4e7ef562d1988135d28c71bce9"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   VERSIONING_STRATEGY: "always-bump-patch"
@@ -18,11 +18,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
+    uses: "grafana/loki-release/.github/workflows/check.yml@7ab449296de23c4e7ef562d1988135d28c71bce9"
     with:
       build_image: "golang:1.26.4"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
+      release_lib_ref: "7ab449296de23c4e7ef562d1988135d28c71bce9"
       skip_validation: false
   create-release-pr:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,9 @@ env:
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
+  PLUGIN_IMAGE_PREFIX: "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "00f0ddb8d0d0b5e53ee1bf87a6d8a2e007e6e501"
+  RELEASE_LIB_REF: "7ab449296de23c4e7ef562d1988135d28c71bce9"
   RELEASE_REPO: "grafana/loki"
 jobs:
   createRelease:
@@ -118,7 +119,7 @@ jobs:
         gh release upload --clobber $(echo $OUTPUTS_NAME | tr -d '"') dist/*
       working-directory: "release"
     - env:
-        path: "release/dist"
+        path: "dist"
       if: "${{ fromJSON(env.PUBLISH_TO_GCS) }}"
       name: "release artifacts"
       run: |
@@ -127,7 +128,7 @@ jobs:
           --project="grafanalabs-global" \
           --repository="generic-${{ env.GAR_REPO_SLUG }}-prod" \
           --location="us" \
-          --source-directory=${{ env.path }}, \
+          --source-directory=${{ env.path }} \
           --package=binaries \
           --version=${{ github.sha }}
       working-directory: "release"
@@ -210,6 +211,56 @@ jobs:
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
         fi
       working-directory: "release"
+  publishDockerPlugins:
+    needs:
+    - "createRelease"
+    permissions:
+      id-token: "write"
+    runs-on: "ubuntu-x64"
+    steps:
+    - name: "pull release library code"
+      uses: "actions/checkout@v4"
+      with:
+        path: "lib"
+        persist-credentials: false
+        ref: "${{ env.RELEASE_LIB_REF }}"
+        repository: "grafana/loki-release"
+    - name: "pull code to release"
+      uses: "actions/checkout@v4"
+      with:
+        path: "release"
+        persist-credentials: false
+        repository: "${{ env.RELEASE_REPO }}"
+    - name: "Set up QEMU"
+      uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392"
+    - name: "set up docker buildx"
+      uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"
+    - name: "Login to GAR"
+      uses: "grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136"
+      with:
+        registry: "us-docker.pkg.dev"
+    - env:
+        SHA: "${{ needs.createRelease.outputs.sha }}"
+      name: "download and prepare plugins"
+      run: |
+        echo "downloading plugins to $(pwd)/plugins"
+        mkdir -p plugins
+        gcloud artifacts generic download \
+          --project="grafanalabs-dev" \
+          --repository="generic-${{ env.GAR_REPO_SLUG }}-dev" \
+          --location="us" \
+          --package=plugins \
+          --version=$(echo ${SHA} | tr -d '"') \
+          --destination=plugins/
+        mkdir -p "release/clients/cmd/docker-driver"
+    - name: "publish docker driver"
+      uses: "./lib/actions/push-images"
+      with:
+        buildDir: "release/clients/cmd/docker-driver"
+        imageDir: "plugins"
+        imagePrefix: "${{ env.PLUGIN_IMAGE_PREFIX }}"
+        isLatest: "${{ needs.createRelease.outputs.isLatest }}"
+        isPlugin: true
   publishImages:
     needs:
     - "createRelease"
@@ -255,6 +306,7 @@ jobs:
     needs:
     - "createRelease"
     - "publishImages"
+    - "publishDockerPlugins"
     outputs:
       name: "${{ needs.createRelease.outputs.name }}"
     permissions:


### PR DESCRIPTION
**What this PR does / why we need it**:
Pulls in [this](https://github.com/grafana/loki-release/pull/382) release code, and re-enables publishing the docker plugin

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
