### PR TITLE
feat(retention): Use chunk IngestedAt for retention decisions

### DIFF
--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -376,7 +376,7 @@ func (c *Compactor) initDeletes(objectClient client.ObjectClient, indexUpdatePro
 		return err
 	}
 
-	c.expirationChecker = newExpirationChecker(retention.NewExpirationChecker(limits), c.deleteRequestsManager)
+	c.expirationChecker = newExpirationChecker(retention.NewExpirationChecker(limits, r), c.deleteRequestsManager)
 	return nil
 }
 

--- a/pkg/compactor/retention/expiration.go
+++ b/pkg/compactor/retention/expiration.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -37,6 +38,7 @@ type ExpirationChecker interface {
 type expirationChecker struct {
 	tenantsRetention         *TenantsRetention
 	latestRetentionStartTime latestRetentionStartTime
+	metrics                  *expirationMetrics
 }
 
 type Limits interface {
@@ -47,9 +49,10 @@ type Limits interface {
 	PoliciesStreamMapping(userID string) validation.PolicyStreamMapping
 }
 
-func NewExpirationChecker(limits Limits) ExpirationChecker {
+func NewExpirationChecker(limits Limits, r prometheus.Registerer) ExpirationChecker {
 	return &expirationChecker{
 		tenantsRetention: NewTenantsRetention(limits),
+		metrics:          newExpirationMetrics(r),
 	}
 }
 
@@ -61,18 +64,31 @@ func (e *expirationChecker) Expired(userID []byte, chk Chunk, lbls labels.Labels
 	if period <= 0 {
 		return false, nil
 	}
-	return now.Sub(chk.Through) > period, nil
+	// Default to the chunk's data time range. IngestedAt is the latest append time,
+	// so when present, backfilled chunks are retained until its ingested content expires.
+	expirationFrom := chk.Through
+	if chk.IngestedAt != 0 {
+		expirationFrom = chk.IngestedAt
+	}
+	expired := now.Sub(expirationFrom) > period
+	if expired && chk.IngestedAt != 0 {
+		e.metrics.chunksExpiredByIngestionTime.Inc()
+	}
+	return expired, nil
 }
 
 // DropFromIndex tells if it is okay to drop the chunk entry from index table.
 // We check if tableEndTime is out of retention period, calculated using the labels from the chunk.
 // If the tableEndTime is out of retention then we can drop the chunk entry without removing the chunk from the store.
-func (e *expirationChecker) DropFromIndex(userID []byte, _ Chunk, labels labels.Labels, tableEndTime model.Time, now model.Time) bool {
+func (e *expirationChecker) DropFromIndex(userID []byte, chk Chunk, labels labels.Labels, tableEndTime model.Time, now model.Time) bool {
 	userIDStr := unsafeGetString(userID)
 	period := e.tenantsRetention.RetentionPeriodFor(userIDStr, labels)
 	// The 0 value should disable retention
 	if period <= 0 {
 		return false
+	}
+	if chk.IngestedAt != 0 {
+		return now.Sub(chk.IngestedAt) > period
 	}
 	return now.Sub(tableEndTime) > period
 }

--- a/pkg/compactor/retention/expiration.go
+++ b/pkg/compactor/retention/expiration.go
@@ -64,8 +64,10 @@ func (e *expirationChecker) Expired(userID []byte, chk Chunk, lbls labels.Labels
 	if period <= 0 {
 		return false, nil
 	}
-	// Default to the chunk's data time range. IngestedAt is the latest append time,
-	// so when present, backfilled chunks are retained until its ingested content expires.
+	// Default to the chunk's data time range (Through). When the chunk carries an
+	// ingestion timestamp (IngestedAt, stamped at flush for backfilled data),
+	// measure retention from that instead, so recently-ingested data is not expired
+	// by its older log time.
 	expirationFrom := chk.Through
 	if chk.IngestedAt != 0 {
 		expirationFrom = chk.IngestedAt

--- a/pkg/compactor/retention/expiration_test.go
+++ b/pkg/compactor/retention/expiration_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/flagext"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -106,7 +108,7 @@ func Test_expirationChecker_Expired(t *testing.T) {
 	o, err := overridesTestConfig(d, f)
 	require.NoError(t, err)
 
-	e := NewExpirationChecker(o)
+	e := NewExpirationChecker(o, nil)
 	tests := []struct {
 		name   string
 		userID string
@@ -126,6 +128,56 @@ func Test_expirationChecker_Expired(t *testing.T) {
 			actual, nonDeletedIntervalFilters := e.Expired([]byte(tt.userID), tt.chunk, mustParseLabels(tt.labels), nil, "", model.Now())
 			require.Equal(t, tt.want, actual)
 			require.Nil(t, nonDeletedIntervalFilters)
+		})
+	}
+}
+
+func Test_expirationChecker_Expired_UsesIngestedAt(t *testing.T) {
+	d := defaultLimitsTestConfig()
+	d.RetentionPeriod = model.Duration(time.Hour)
+	o, err := overridesTestConfig(d, fakeOverrides{})
+	require.NoError(t, err)
+
+	reg := prometheus.NewPedanticRegistry()
+	e := NewExpirationChecker(o, reg)
+
+	now := model.Now()
+	tests := []struct {
+		name            string
+		chunk           Chunk
+		want            bool
+		wantMetricDelta float64
+	}{
+		{
+			name:  "zero IngestedAt falls back to Through (expired)",
+			chunk: Chunk{From: now.Add(-3 * time.Hour), Through: now.Add(-2 * time.Hour)},
+			want:  true,
+		},
+		{
+			name:  "zero IngestedAt falls back to Through (not expired)",
+			chunk: Chunk{From: now.Add(-3 * time.Hour), Through: now.Add(-30 * time.Minute)},
+			want:  false,
+		},
+		{
+			name:  "old Through but recent IngestedAt is retained",
+			chunk: Chunk{From: now.Add(-72 * time.Hour), Through: now.Add(-48 * time.Hour), IngestedAt: now.Add(-30 * time.Minute)},
+			want:  false,
+		},
+		{
+			name:            "old IngestedAt expires even if Through is recent",
+			chunk:           Chunk{From: now.Add(-3 * time.Hour), Through: now.Add(-1 * time.Minute), IngestedAt: now.Add(-2 * time.Hour)},
+			want:            true,
+			wantMetricDelta: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := testutil.ToFloat64(e.(*expirationChecker).metrics.chunksExpiredByIngestionTime)
+			actual, filterFn := e.Expired([]byte("1"), tt.chunk, mustParseLabels(`{foo="buzz"}`), nil, "", now)
+			require.Equal(t, tt.want, actual)
+			require.Nil(t, filterFn)
+			after := testutil.ToFloat64(e.(*expirationChecker).metrics.chunksExpiredByIngestionTime)
+			require.Equal(t, tt.wantMetricDelta, after-before)
 		})
 	}
 }
@@ -183,7 +235,7 @@ func Test_expirationChecker_Expired_zeroValue(t *testing.T) {
 	}
 	o, err := overridesTestConfig(d, f)
 	require.NoError(t, err)
-	e := NewExpirationChecker(o)
+	e := NewExpirationChecker(o, nil)
 	tests := []struct {
 		name   string
 		userID string
@@ -231,7 +283,7 @@ func Test_expirationChecker_Expired_zeroValueOverride(t *testing.T) {
 	o, err := overridesTestConfig(d, f)
 	require.NoError(t, err)
 
-	e := NewExpirationChecker(o)
+	e := NewExpirationChecker(o, nil)
 	tests := []struct {
 		name   string
 		userID string
@@ -267,7 +319,7 @@ func Test_expirationChecker_DropFromIndex_zeroValue(t *testing.T) {
 	}
 	o, err := overridesTestConfig(d, f)
 	require.NoError(t, err)
-	e := NewExpirationChecker(o)
+	e := NewExpirationChecker(o, nil)
 
 	chunkFrom := model.Now().Add(-3 * time.Hour)
 	chunkThrough := model.Now().Add(-2 * time.Hour)
@@ -282,6 +334,8 @@ func Test_expirationChecker_DropFromIndex_zeroValue(t *testing.T) {
 		{"tenant with no override should not delete", "1", `{foo="buzz"}`, Chunk{From: chunkFrom, Through: chunkThrough}, model.Now().Add(-48 * time.Hour), false},
 		{"tenant with override tableEndTime within retention period should not delete", "2", `{foo="buzz"}`, Chunk{From: chunkFrom, Through: chunkThrough}, model.Now().Add(-1 * time.Hour), false},
 		{"tenant with override should delete", "2", `{foo="buzz"}`, Chunk{From: chunkFrom, Through: chunkThrough}, model.Now().Add(-48 * time.Hour), true},
+		{"tenant with override old tableEndTime but recent IngestedAt should not delete", "2", `{foo="buzz"}`, Chunk{From: chunkFrom, Through: chunkThrough, IngestedAt: model.Now().Add(-1 * time.Hour)}, model.Now().Add(-48 * time.Hour), false},
+		{"tenant with override expired IngestedAt should delete even with recent tableEndTime", "2", `{foo="buzz"}`, Chunk{From: chunkFrom, Through: chunkThrough, IngestedAt: model.Now().Add(-48 * time.Hour)}, model.Now().Add(-1 * time.Hour), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -306,7 +360,7 @@ func Test_expirationChecker_CanSkipSeries(t *testing.T) {
 	}
 	o, err := overridesTestConfig(d, f)
 	require.NoError(t, err)
-	e := NewExpirationChecker(o)
+	e := NewExpirationChecker(o, nil)
 
 	tests := []struct {
 		name        string

--- a/pkg/compactor/retention/metrics.go
+++ b/pkg/compactor/retention/metrics.go
@@ -48,6 +48,20 @@ func newSweeperMetrics(r prometheus.Registerer) *sweeperMetrics {
 	}
 }
 
+type expirationMetrics struct {
+	chunksExpiredByIngestionTime prometheus.Counter
+}
+
+func newExpirationMetrics(r prometheus.Registerer) *expirationMetrics {
+	return &expirationMetrics{
+		chunksExpiredByIngestionTime: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Namespace: "loki_compactor",
+			Name:      "retention_chunks_expired_by_ingestion_time_total",
+			Help:      "Total number of chunks expired based on their ingestion time (IngestedAt) rather than their data time range.",
+		}),
+	}
+}
+
 type markerMetrics struct {
 	tableProcessedTotal           *prometheus.CounterVec
 	tableMarksCreatedTotal        *prometheus.CounterVec

--- a/pkg/compactor/retention/retention_test.go
+++ b/pkg/compactor/retention/retention_test.go
@@ -163,7 +163,7 @@ func Test_Retention(t *testing.T) {
 			store.Stop()
 
 			// marks and sweep
-			expiration := NewExpirationChecker(tt.limits)
+			expiration := NewExpirationChecker(tt.limits, nil)
 			workDir := filepath.Join(t.TempDir(), "retention")
 			// must not fail the process because deletion must be retried
 			chunkClient := newMockChunkClient(true)
@@ -265,18 +265,18 @@ func Test_EmptyTable(t *testing.T) {
 	require.Len(t, tables, 1)
 
 	// disabled retention should not do anything to the table
-	empty, modified, err := markForDelete(context.Background(), 0, tables[0].name, &noopWriter{}, tables[0], NewExpirationChecker(&fakeLimits{}), nil, util_log.Logger)
+	empty, modified, err := markForDelete(context.Background(), 0, tables[0].name, &noopWriter{}, tables[0], NewExpirationChecker(&fakeLimits{}, nil), nil, util_log.Logger)
 	require.NoError(t, err)
 	require.False(t, empty)
 	require.False(t, modified)
 
 	// Set a very low retention to make sure all chunks are marked for deletion which will create an empty table.
-	empty, modified, err = markForDelete(context.Background(), 0, tables[0].name, &noopWriter{}, tables[0], NewExpirationChecker(&fakeLimits{perTenant: map[string]retentionLimit{"1": {retentionPeriod: time.Second}, "2": {retentionPeriod: time.Second}}}), nil, util_log.Logger)
+	empty, modified, err = markForDelete(context.Background(), 0, tables[0].name, &noopWriter{}, tables[0], NewExpirationChecker(&fakeLimits{perTenant: map[string]retentionLimit{"1": {retentionPeriod: time.Second}, "2": {retentionPeriod: time.Second}}}, nil), nil, util_log.Logger)
 	require.NoError(t, err)
 	require.True(t, empty)
 	require.True(t, modified)
 
-	_, _, err = markForDelete(context.Background(), 0, tables[0].name, &noopWriter{}, newTable("test"), NewExpirationChecker(&fakeLimits{}), nil, util_log.Logger)
+	_, _, err = markForDelete(context.Background(), 0, tables[0].name, &noopWriter{}, newTable("test"), NewExpirationChecker(&fakeLimits{}, nil), nil, util_log.Logger)
 	require.Equal(t, err, errNoChunksFound)
 }
 
@@ -1070,7 +1070,7 @@ func TestMarkForDelete_DropChunkFromIndex(t *testing.T) {
 
 	for i, table := range tables {
 		empty, _, err := markForDelete(context.Background(), 0, table.name, &noopWriter{}, table,
-			NewExpirationChecker(fakeLimits{perTenant: map[string]retentionLimit{"1": {retentionPeriod: retentionPeriod}}}), nil, util_log.Logger)
+			NewExpirationChecker(fakeLimits{perTenant: map[string]retentionLimit{"1": {retentionPeriod: retentionPeriod}}}, nil), nil, util_log.Logger)
 		require.NoError(t, err)
 		if i == 7 {
 			require.False(t, empty)

--- a/pkg/compactor/retention/retention_test.go
+++ b/pkg/compactor/retention/retention_test.go
@@ -308,6 +308,61 @@ func createChunk(t testing.TB, userID string, lbs labels.Labels, from model.Time
 	return c
 }
 
+// TestChunkRewriterPreservesIngestedAtWhenReindexing covers the chunk rewriter
+// path that runs during a partial delete: when only some lines of a chunk are
+// removed, the chunk is decoded, filtered, re-encoded and re-indexed. This test
+// asserts that IngestedAt survives that round-trip, both on the re-indexed entry
+// and on the chunk written back to the store. If it didn't, a delete request
+// against backfilled data would reset its ingestion time and the data would then
+// expire by its (old) log time — defeating ingestion-time retention.
+//
+// v14 is the schema this feature targets (FormatV4 persists IngestedAt). Note the
+// index here is a mock (*table) that records what IndexChunk receives, so this
+// test exercises the rewriter's preservation logic, not the on-disk index format
+// (that round-trip is covered by the tsdb indexshipper tests).
+func TestChunkRewriterPreservesIngestedAtWhenReindexing(t *testing.T) {
+	now := model.Now()
+	schema := allSchemas[5] // v14
+	tableInterval := ExtractIntervalFromTableName(schema.config.IndexTables.TableFor(now))
+	ingestedAt := now.Add(-30 * time.Minute)
+
+	// A chunk spanning two hours with a non-zero IngestedAt, as a backfilled chunk would have.
+	originalChunk := createChunk(t, "1", labels.FromStrings("foo", "bar"), tableInterval.Start, tableInterval.Start.Add(2*time.Hour))
+	originalChunk.IngestedAt = ingestedAt
+	require.NoError(t, originalChunk.Encode())
+
+	store := newTestStore(t)
+	require.NoError(t, store.Put(context.TODO(), []chunk.Chunk{originalChunk}))
+	store.Stop()
+
+	indexTables := store.indexTables()
+	require.Len(t, indexTables, 1)
+	indexTable := indexTables[0]
+
+	// Rewrite the chunk, deleting only its first hour so a new (filtered) chunk is produced and re-indexed.
+	cr := newChunkRewriter(store.chunkClient, indexTable.name, indexTable)
+	wroteChunks, linesDeleted, err := cr.rewriteChunk(context.Background(), []byte(originalChunk.UserID), Chunk{
+		ChunkID: getChunkID(originalChunk.ChunkRef),
+		From:    originalChunk.From,
+		Through: originalChunk.Through,
+	}, tableInterval, func(ts time.Time, _ string, _ labels.Labels) bool {
+		return ts.UnixNano() <= tableInterval.Start.Add(time.Hour).UnixNano()
+	})
+	require.NoError(t, err)
+	require.True(t, linesDeleted)
+	require.True(t, wroteChunks)
+
+	// The re-indexed chunk must carry the original IngestedAt.
+	require.Equal(t, []model.Time{ingestedAt}, indexTable.indexedIngestedAt)
+
+	// Both the original (not yet swept) and the rewritten chunk in the store keep IngestedAt.
+	chunks := store.GetChunks(originalChunk.UserID, originalChunk.From, originalChunk.Through, originalChunk.Metric)
+	require.Len(t, chunks, 2)
+	for _, chk := range chunks {
+		require.Equal(t, ingestedAt, chk.IngestedAt)
+	}
+}
+
 func TestChunkRewriter(t *testing.T) {
 	minListMarkDelay = 1 * time.Second
 	now := model.Now()

--- a/pkg/compactor/retention/util_test.go
+++ b/pkg/compactor/retention/util_test.go
@@ -100,6 +100,18 @@ var (
 					}},
 				RowShards: 16,
 			},
+			{
+				From:       dayFromTime(start.Add(150 * time.Hour)),
+				IndexType:  "tsdb",
+				ObjectType: "filesystem",
+				Schema:     "v14",
+				IndexTables: config.IndexPeriodicTableConfig{
+					PeriodicTableConfig: config.PeriodicTableConfig{
+						Prefix: "index_",
+						Period: time.Hour * 24,
+					}},
+				RowShards: 16,
+			},
 		},
 	}
 	allSchemas = []struct {
@@ -112,6 +124,7 @@ var (
 		{"v11", schemaCfg.Configs[2].From.Time, schemaCfg.Configs[2]},
 		{"v12", schemaCfg.Configs[3].From.Time, schemaCfg.Configs[3]},
 		{"v13", schemaCfg.Configs[4].From.Time, schemaCfg.Configs[4]},
+		{"v14", schemaCfg.Configs[5].From.Time, schemaCfg.Configs[5]},
 	}
 
 	sweepMetrics = newSweeperMetrics(prometheus.DefaultRegisterer)
@@ -127,8 +140,9 @@ func mustParseLabels(labels string) labels.Labels {
 }
 
 type table struct {
-	name   string
-	chunks map[string]map[string][]logproto.ChunkRef
+	name              string
+	chunks            map[string]map[string][]logproto.ChunkRef
+	indexedIngestedAt []model.Time
 }
 
 func (t *table) ChunkExists(_ []byte, _ labels.Labels, _ logproto.ChunkRef) (bool, error) {
@@ -167,9 +181,10 @@ func (t *table) ForEachSeries(ctx context.Context, callback SeriesCallback) erro
 	return ctx.Err()
 }
 
-func (t *table) IndexChunk(chunkRef logproto.ChunkRef, lbls labels.Labels, _ model.Time, _ uint32, _ uint32) (bool, error) {
+func (t *table) IndexChunk(chunkRef logproto.ChunkRef, lbls labels.Labels, ingestedAt model.Time, _ uint32, _ uint32) (bool, error) {
 	seriesID := lbls.String()
 	t.chunks[chunkRef.UserID][seriesID] = append(t.chunks[chunkRef.UserID][seriesID], chunkRef)
+	t.indexedIngestedAt = append(t.indexedIngestedAt, ingestedAt)
 	return true, nil
 }
 


### PR DESCRIPTION
Read side of the ingestion-time retention stack (#21931), follow-up to #22812.

Makes the compactor measure retention from a chunk's `IngestedAt` when set, falling back to the data time range otherwise. This keeps backfilled / late-arriving data (old `Through`, recent ingestion) alive until retention elapses from ingestion time.

- `Expired` expires on `IngestedAt` when present, else `Through`.
- `DropFromIndex` keys off `IngestedAt` when present, else `tableEndTime`.
- Adds `loki_compactor_retention_chunks_expired_by_ingestion_time_total`.

The index plumbing (`retention.Chunk.IngestedAt`, `IndexChunk` signature, store/tsdb persistence) already landed in #22370; this PR only wires the read side. No-op where `IngestedAt` is zero (pre-v14 periods), so behavior is unchanged for existing data.

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format
