### PR TITLE
fix(ci): Fix zizmor findings for operator-images in Loki 3.7

### DIFF
--- a/.github/workflows/operator-images.yaml
+++ b/.github/workflows/operator-images.yaml
@@ -8,8 +8,14 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish-grafana-operator:
+    permissions:
+      contents: "read"
+      id-token: "write"
     uses: ./.github/workflows/operator-reusable-image-build.yml
     with:
       dockerfile: "operator/Dockerfile"
@@ -19,6 +25,9 @@ jobs:
       tag: "latest"
 
   publish-openshift-operator:
+    permissions:
+      contents: "read"
+      id-token: "write"
     uses: ./.github/workflows/operator-reusable-image-build.yml
     with:
       dockerfile: "operator/Dockerfile"
@@ -28,6 +37,9 @@ jobs:
       tag: "latest"
 
   publish-openshift-bundle:
+    permissions:
+      contents: "read"
+      id-token: "write"
     uses: ./.github/workflows/operator-reusable-image-build.yml
     with:
       dockerfile: "operator/bundle/openshift/bundle.Dockerfile"
@@ -37,6 +49,9 @@ jobs:
       tag: "latest"
 
   publish-openshift-size-calculator:
+    permissions:
+      contents: "read"
+      id-token: "write"
     uses: ./.github/workflows/operator-reusable-image-build.yml
     with:
       dockerfile: "operator/calculator.Dockerfile"


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes zizmor warnings in 3.7.  This workflow file is unused in this branch.

[Sample](https://github.com/grafana/loki/pull/22818#issuecomment-4843034787) findings
**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
