### PR TITLE
fix: Revert to returning arbitrary values in detected_level and add tests

### DIFF
--- a/pkg/distributor/field_detection.go
+++ b/pkg/distributor/field_detection.go
@@ -171,8 +171,8 @@ func normalizeLogLevel(level string) string {
 	case bytes.EqualFold(levelBytes, fatal):
 		return constants.LogLevelFatal
 	default:
-		// Return unknown if it doesn't match any known level. This is consistent with detectLogLevelFromLogEntry
-		return constants.LogLevelUnknown
+		// Return the original value if it doesn't match any known level.
+		return level
 	}
 }
 

--- a/pkg/distributor/field_detection_test.go
+++ b/pkg/distributor/field_detection_test.go
@@ -222,6 +222,8 @@ func Test_DetectLogLevels(t *testing.T) {
 			{`{foo="bar", level="Debug"}`, constants.LogLevelDebug},
 			{`{foo="bar", level="FaTaL"}`, constants.LogLevelFatal},
 			{`{foo="bar", level="tRaCe"}`, constants.LogLevelTrace},
+			{`{foo="bar", level="informational"}`, "informational"},
+			{`{foo="bar", level="notice"}`, "notice"},
 		}
 
 		for _, tc := range testCases {

--- a/pkg/distributor/field_detection_test.go
+++ b/pkg/distributor/field_detection_test.go
@@ -788,6 +788,78 @@ func Test_detectLogLevelFromLogEntryWithCustomLabels(t *testing.T) {
 	}
 }
 
+// Test_detectLogLevelFromOTLPSeverityNumber tests level detection against the OTLP severity_number
+func Test_detectLogLevelFromOTLPSeverityNumber(t *testing.T) {
+	ld := newFieldDetector(
+		validationContext{
+			discoverLogLevels:       true,
+			allowStructuredMetadata: true,
+			logLevelFields:          []string{"level", "LEVEL", "Level", "severity", "SEVERITY", "Severity", "lvl", "LVL", "Lvl"},
+		})
+
+	entryWithSeverityNumber := func(value string) logproto.Entry {
+		return logproto.Entry{
+			Line: "some log message",
+			StructuredMetadata: push.LabelsAdapter{
+				{Name: loghttp_push.OTLPSeverityNumber, Value: value},
+			},
+		}
+	}
+
+	t.Run("named severity numbers map to their band", func(t *testing.T) {
+		for _, tc := range []struct {
+			name             string
+			severityNumber   plog.SeverityNumber
+			expectedLogLevel string
+		}{
+			// Trace band (1-4)
+			{"trace lower bound", plog.SeverityNumberTrace, constants.LogLevelTrace},
+			{"trace upper bound", plog.SeverityNumberTrace4, constants.LogLevelTrace},
+			// Debug band (5-8)
+			{"debug lower bound", plog.SeverityNumberDebug, constants.LogLevelDebug},
+			{"debug upper bound", plog.SeverityNumberDebug2, constants.LogLevelDebug},
+			{"debug upper bound", plog.SeverityNumberDebug4, constants.LogLevelDebug},
+			// Info band (9-12)
+			{"info lower bound", plog.SeverityNumberInfo, constants.LogLevelInfo},
+			{"info upper bound", plog.SeverityNumberInfo4, constants.LogLevelInfo},
+			// Warn band (13-16)
+			{"warn lower bound", plog.SeverityNumberWarn, constants.LogLevelWarn},
+			{"warn upper bound", plog.SeverityNumberWarn4, constants.LogLevelWarn},
+			// Error band (17-20)
+			{"error lower bound", plog.SeverityNumberError, constants.LogLevelError},
+			{"error upper bound", plog.SeverityNumberError4, constants.LogLevelError},
+			// Fatal band (21-24)
+			{"fatal lower bound", plog.SeverityNumberFatal, constants.LogLevelFatal},
+			{"fatal upper bound", plog.SeverityNumberFatal4, constants.LogLevelFatal},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				entry := entryWithSeverityNumber(fmt.Sprintf("%d", tc.severityNumber))
+				detectedLogLevel := ld.detectLogLevelFromLogEntry(entry, logproto.FromLabelAdaptersToLabels(entry.StructuredMetadata))
+				require.Equal(t, tc.expectedLogLevel, detectedLogLevel, "severity number: %d", tc.severityNumber)
+			})
+		}
+	})
+
+	t.Run("out-of-range and invalid severity numbers", func(t *testing.T) {
+		for _, tc := range []struct {
+			name             string
+			value            string
+			expectedLogLevel string
+		}{
+			{"unspecified maps to unknown", fmt.Sprintf("%d", plog.SeverityNumberUnspecified), constants.LogLevelUnknown},
+			{"just above fatal4 maps to unknown", "25", constants.LogLevelUnknown},
+			{"well above the range maps to unknown", "100", constants.LogLevelUnknown},
+			{"non-numeric value falls back to info", "foo", constants.LogLevelInfo},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				entry := entryWithSeverityNumber(tc.value)
+				detectedLogLevel := ld.detectLogLevelFromLogEntry(entry, logproto.FromLabelAdaptersToLabels(entry.StructuredMetadata))
+				require.Equal(t, tc.expectedLogLevel, detectedLogLevel, "severity number value: %s", tc.value)
+			})
+		}
+	})
+}
+
 func Benchmark_extractLogLevelFromLogLine(b *testing.B) {
 	// looks scary, but it is some random text of about 1000 chars from charset a-zA-Z0-9
 	logLine := "dGzJ6rKk Zj U04SWEqEK4Uwho8 DpNyLz0 Nfs61HJ fz5iKVigg 44 kabOz7ghviGmVONriAdz4lA 7Kis1OTvZGT3 " +


### PR DESCRIPTION
**What this PR does / why we need it**:

Reverts https://github.com/grafana/loki/pull/22373/changes as it caused problems for some users who were relying on arbitrary fields in detectected_level.

