### PR TITLE
fix(v2-engine): Wrap results cache inside step-align so cache sees aligned bounds

### DIFF
--- a/pkg/engine/handler.go
+++ b/pkg/engine/handler.go
@@ -86,10 +86,6 @@ func executorHandler(
 		h.(*queryHandler).retentionChecker = newRetentionChecker(limits, logger)
 	}
 
-	if cfg.AlignQueriesWithStep {
-		h = newMetricStepAlignMiddleware().Wrap(h)
-	}
-
 	if cache.IsCacheConfigured(cfg.ResultsCache.CacheConfig) {
 		newCache := func(suffix string, cacheType stats.CacheType) (cache.Cache, error) {
 			cfgCopy := cfg.ResultsCache.CacheConfig
@@ -122,6 +118,16 @@ func executorHandler(
 			return nil, fmt.Errorf("creating engine cache middleware: %w", err)
 		}
 		h = cacheMw.Wrap(h)
+	}
+
+	// Step alignment must wrap the cache so the cache sees aligned start/end.
+	// Otherwise the cache keys, stored extent bounds, and the per-read
+	// [extractMatrix] clip all use the un-aligned request bounds, which
+	// silently drops the leading floor-aligned sample on every cache hit
+	// (the engine emits it on cache miss, the cache writes it once, then
+	// every subsequent read clips it back out).
+	if cfg.AlignQueriesWithStep {
+		h = newMetricStepAlignMiddleware().Wrap(h)
 	}
 
 	h = metricsRecordingMiddleware{logger: logger}.Wrap(h)

--- a/pkg/engine/handler_test.go
+++ b/pkg/engine/handler_test.go
@@ -2,8 +2,12 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
 	"time"
 
@@ -11,6 +15,8 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/user"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/logql"
@@ -21,6 +27,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/querier/queryrange"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	querytest "github.com/grafana/loki/v3/pkg/querier/testutil"
+	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
+	"github.com/grafana/loki/v3/pkg/storage/chunk/cache/resultscache"
 )
 
 type mockEngine struct {
@@ -1174,4 +1182,140 @@ func TestQueryHandler_ValidateInstantRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMetricStepAlignBeforeCache asserts that the step-alignment middleware
+// runs *before* the results-cache middleware in the v2 engine handler chain,
+// by exercising the production [HandlerFromExecutor] composition end-to-end.
+//
+// The cache extractor ([queryrangebase.PrometheusResponseExtractor.Extract])
+// drops samples outside [req.Start, req.End] on every cache read. If alignment
+// ran inside the cache (cache wrapping alignment), the cache would see the
+// un-aligned request bounds, store extents under those bounds, and clip out
+// the leading floor-aligned sample on every cache hit — turning a 4-sample
+// metric response into 3 silently. By wrapping cache inside alignment, the
+// cache sees the aligned start/end, so the leading sample falls inside the
+// stored extent and survives the per-read [extractMatrix] clip.
+func TestMetricStepAlignBeforeCache(t *testing.T) {
+	const stepMs = int64(172_000) // 172s — does not divide evenly into 12:00:00.
+	// start = 12:00:00 UTC = 1782734400_000ms. 1782734400000 % 172000 = 152000ms.
+	// → aligned start = 1782734400000 - 152000 = 1782734248000 = 11:57:28 UTC.
+	startMs := int64(1782734400_000)
+	alignedStartMs := (startMs / stepMs) * stepMs
+	endMs := startMs + 3*stepMs
+	alignedEndMs := (endMs / stepMs) * stepMs
+
+	// Track the start each invocation of the inner executor sees, so we can
+	// confirm alignment ran before the cache layer. Count invocations so
+	// we can assert the second query actually hit the cache (rather than
+	// silently missing and re-computing the same response).
+	var (
+		capturedStartMs int64
+		executorCalls   int
+	)
+	exec := &mockEngine{
+		executeFunc: func(_ context.Context, params logql.Params) (logqlmodel.Result, error) {
+			executorCalls++
+			capturedStartMs = params.Start().UnixMilli()
+			// Emit samples on the aligned step grid: aligned_start, +step, ...
+			// The first sample at aligned_start is BEFORE the requested startMs;
+			// it must be preserved across cache reads.
+			samples := make([]promql.FPoint, 0, 4)
+			for ts := alignedStartMs; ts <= alignedEndMs; ts += stepMs {
+				samples = append(samples, promql.FPoint{T: ts, F: float64(ts)})
+			}
+			return logqlmodel.Result{
+				Data: promql.Matrix{
+					{Metric: labels.EmptyLabels(), Floats: samples},
+				},
+			}, nil
+		},
+	}
+
+	cfg := Config{
+		Executor:             ExecutorConfig{BatchSize: 100},
+		AlignQueriesWithStep: true,
+		ResultsCache: resultscache.Config{
+			CacheConfig: cache.Config{Cache: cache.NewMockCache()},
+		},
+	}
+	limits := &mockLimits{Limits: &querytest.MockLimits{MaxEntriesLimitPerQueryVal: 1000}}
+
+	// Use the production handler composition so the test depends on the
+	// actual middleware order in [executorHandler].
+	httpHandler, err := HandlerFromExecutor(cfg, log.NewNopLogger(), exec, limits, nil)
+	require.NoError(t, err)
+
+	doQuery := func() []promql.FPoint {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "http://localhost/loki/api/v1/query_range?"+url.Values{
+			"query": {`count_over_time({app="test"}[1m])`},
+			"start": {strconv.FormatInt(startMs*int64(time.Millisecond), 10)},
+			"end":   {strconv.FormatInt(endMs*int64(time.Millisecond), 10)},
+			"step":  {strconv.FormatInt(stepMs/1000, 10)},
+		}.Encode(), nil)
+		req = req.WithContext(user.InjectOrgID(req.Context(), "fake"))
+		rec := httptest.NewRecorder()
+		httpHandler.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+		return parsePromSamples(t, rec.Body.Bytes())
+	}
+
+	// First call: cache miss — executor must be invoked exactly once.
+	got1 := doQuery()
+	require.Equal(t, 1, executorCalls, "first call should invoke the executor (cache miss)")
+	require.Equal(t, alignedStartMs, capturedStartMs,
+		"alignment must run before the engine sees the request")
+	require.Len(t, got1, 4,
+		"cache-miss path must return all four aligned samples including the leading one at %v",
+		time.UnixMilli(alignedStartMs).UTC().Format(time.RFC3339Nano))
+	require.Equal(t, alignedStartMs, got1[0].T,
+		"first sample must be at the floor-aligned start")
+
+	// Second call: cache hit — executor must NOT be invoked again, and the
+	// response must still contain the leading aligned sample. With the fix,
+	// the cache key, stored extent bounds, and the read-time clip all use
+	// the aligned start, so the leading sample at aligned_start survives.
+	// With the pre-fix order, extractMatrix would clip samples to
+	// [startMs, endMs] and drop the leading sample.
+	got2 := doQuery()
+	require.Equal(t, 1, executorCalls,
+		"second call must be served from cache (executor should not run again)")
+	require.Len(t, got2, 4,
+		"cache-hit path must preserve the leading aligned sample (regression: cache wrapping alignment would yield 3)")
+	require.Equal(t, got1, got2,
+		"cache-hit response must equal cache-miss response")
+}
+
+// parsePromSamples decodes the JSON body of a Loki /query_range matrix
+// response and returns the samples of the (single) series.
+func parsePromSamples(t *testing.T, body []byte) []promql.FPoint {
+	t.Helper()
+	var resp struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Metric map[string]string `json:"metric"`
+				Values [][]any           `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(body, &resp), "body=%s", body)
+	require.Equal(t, "success", resp.Status, "body=%s", body)
+	require.Equal(t, "matrix", resp.Data.ResultType)
+	require.Len(t, resp.Data.Result, 1, "expected exactly one series; body=%s", body)
+	pts := make([]promql.FPoint, 0, len(resp.Data.Result[0].Values))
+	for _, pair := range resp.Data.Result[0].Values {
+		require.Len(t, pair, 2)
+		// Prometheus encodes timestamps in seconds as float64.
+		tsSec, ok := pair[0].(float64)
+		require.True(t, ok, "ts is %T: %v", pair[0], pair[0])
+		valStr, ok := pair[1].(string)
+		require.True(t, ok, "value is %T: %v", pair[1], pair[1])
+		v, err := strconv.ParseFloat(valStr, 64)
+		require.NoError(t, err)
+		pts = append(pts, promql.FPoint{T: int64(tsSec * 1000), F: v})
+	}
+	return pts
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

#### What
Swap the wrap order of the step-align middleware and the results-cache middleware in the v2 engine handler (`pkg/engine/handler.go`). Alignment now runs **before** cache, mirroring v1's chain, so the cache sees step-aligned request bounds.

#### Why

`pkg/engine/handler.go` composes the v2 handler chain like this:

```go
if cfg.AlignQueriesWithStep {
    h = newMetricStepAlignMiddleware().Wrap(h)  // alignment (inner before fix)
}
if cache.IsCacheConfigured(...) {
    h = cacheMw.Wrap(h)                          // cache (outer before fix)
}
```

Wrap order means the outer wrap runs first, so the pre-fix execution order was:

HTTP → cacheMw → metricStepAlign → queryHandler

Loki's results cache extractor([extractMatrix](https://github.com/grafana/loki/blob/e16efe7f94254f57f85246fd35db7533f35c1b5b/pkg/querier/queryrange/queryrangebase/results_cache.go#L316)) filters samples to [`req.Start`, `req.End`] on every cache read. Because the cache saw the un-aligned request bounds, the per-read clip dropped any sample the engine emitted before `req.Start`, including the leading sample at the floor-aligned grid point that the alignment middleware would have exposed to a downstream reader.

The net observable symptom in a query I debugged was:

- First run of a metric query with a step that doesn't divide evenly into start (e.g. start=12:00:00, step 172s → aligned
11:57:28): engine emits the leading sample -> handleMiss returns the raw response unfiltered -> client sees N samples.
- Second run of the same query: handleHit runs extractMatrix with the un-aligned [`req.Start`, `req.End`] -> drops the 11:57:28 sample -> client sees N-1 samples.

v1 doesn't have this issue because its middleware chain aligns before entering the results cache: StepAlign → SplitByInterval → results_cache → ...
By the time v1's cache sees a request, both alignment layers have run, and the stored/extracted bounds match the engine's sample grid.

#### How

Move the AlignQueriesWithStep block after the cache block in executorHandler, so alignment becomes the outer wrap. Post-fix execution order:

HTTP → metricsRecording → metricStepAlign → cacheMw → queryHandler

The cache key, the stored extent bounds, and the per-read clip all now operate on the aligned bounds. The leading sample lives inside the clip window on every hit.

#### Regression risk

- Log queries: metricStepAlign early-returns for non-SampleExpr requests. Unaffected ✅.
- Instant queries: routed as *LokiInstantRequest; middleware's type assertion bypasses them. Unaffected ✅.
- AlignQueriesWithStep=false: alignment middleware isn't wrapped. Chain is cacheMw → queryHandler. Identical to pre-fix behaviour under that config. Unaffected ✅.
- Cache disabled: cache middleware isn't wrapped. Chain is metricStepAlign → queryHandler. Identical to pre-fix behaviour. Unaffected ✅.
- Existing entries: cache keys now use aligned start. One-time miss spike until the 12h validity expires, and entries repopulate under the new keys.
