### PR TITLE
fix(fluentd): repair multi-thread output spec on modern rspec-support

### DIFF
--- a/clients/cmd/fluentd/spec/gems/fluent/plugin/loki_output_spec.rb
+++ b/clients/cmd/fluentd/spec/gems/fluent/plugin/loki_output_spec.rb
@@ -323,15 +323,17 @@ RSpec.describe Fluent::Plugin::LokiOutput do
   end
 
   context 'when output is multi-thread' do
-    let(:thread) do
-      class_double(
-        'Thread',
-        current: { _fluentd_plugin_helper_thread_title: 'thread1' }
-      ).as_stubbed_const
+    # The plugin reads the flush thread title from a fiber-local variable
+    # (Thread.current[:_fluentd_plugin_helper_thread_title] in out_loki.rb).
+    # Set the real thread-local instead of stubbing the Thread constant: stubbing
+    # Thread.current breaks rspec-support internals, which call
+    # Thread.current.thread_variable_get.
+    before do
+      Thread.current[:_fluentd_plugin_helper_thread_title] = 'thread1'
     end
 
-    before do
-      allow(Thread).to receive(:new).and_yield(thread)
+    after do
+      Thread.current[:_fluentd_plugin_helper_thread_title] = nil
     end
 
     it 'adds the fluentd_label by default' do


### PR DESCRIPTION
**What this PR does / why we need it**:
Running the fluentd plugin test suite as documented (`bin/setup` then `bin/test` in `clients/cmd/fluentd`) currently fails on a clean checkout of `main`.
Every example in the `when output is multi-thread` context, because the failure escapes into RSpec's own machinery, the remainder of the run:

```
NoMethodError: undefined method 'thread_variable_get' for an instance of Hash
```

The multi-thread examples replace the entire `Thread` constant via `class_double('Thread', current: {...}).as_stubbed_const`, so `Thread.current` returns a plain `Hash`.
Since rspec-support 3.13, `RSpec::Support.thread_local_data` calls Thread.current.thread_variable_get(:__rspec)`, which a `Hash` does not respond to.
This wasn't a problem when the test was written because older rspec-support used `Thread.current[:__rspec]` (which a `Hash` happens to support).
Because `Gemfile.lock` is gitignored, every setup resolves the latest 3.13.x and hits the breakage.

The fix stops stubbing the `Thread` constant altogether and instead sets the
real fiber-local variable the plugin actually reads (`Thread.current[:_fluentd_plugin_helper_thread_title]`), resetting it after
each example.
The old `allow(Thread).to receive(:new)` stub is dropped since the plugin never calls `Thread.new`.

After this change `bin/test` reports `21 examples, 0 failures` with 100% line
coverage.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
- #18252 fixes the same breakage as part of a larger refactor (it extracts a `current_thread_label` method and stubs that). That PR has been stalled for some time, so this is a minimal, self-contained fix to get `bin/test` green on `main` in the meantime. The two touch the same context block but the approach here avoids duplicating #18252's production-code change.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
