### PR TITLE
chore(xcap): Update Merge to aggregate observations for matching regions

### DIFF
--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -22,7 +22,12 @@ import (
 )
 
 var tracer = otel.Tracer("pkg/dataobj/sections/logs")
-var RegionPrefix = "logs.Reader."
+
+// RegionOpen is the xcap region name for the [Reader.Open] operation.
+var RegionOpen = "logs.Reader.Open"
+
+// RegionRead is the xcap region name for the [Reader.Read] operation.
+var RegionRead = "logs.Reader.Read"
 
 // ReaderOptions customizes the behavior of a [Reader].
 type ReaderOptions struct {
@@ -189,7 +194,7 @@ func (r *Reader) Read(ctx context.Context, batchSize int) (arrow.RecordBatch, er
 	}
 
 	if r.readSpan == nil {
-		ctx, r.readSpan = xcap.StartSpan(ctx, tracer, RegionPrefix+"Read")
+		ctx, r.readSpan = xcap.StartSpan(ctx, tracer, RegionRead)
 	} else {
 		// inject span into context for inner readers to record observations.
 		ctx = xcap.ContextWithSpan(ctx, r.readSpan)
@@ -223,7 +228,7 @@ func (r *Reader) init(ctx context.Context) error {
 		r.opts.Allocator = memory.DefaultAllocator
 	}
 
-	ctx, span := xcap.StartSpan(ctx, tracer, RegionPrefix+"Open")
+	ctx, span := xcap.StartSpan(ctx, tracer, RegionOpen)
 	defer span.End()
 
 	// Compose dataset using projected columns and any additional columns

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -363,13 +363,12 @@ func statsSummary(capture *xcap.Capture, execTime, queueTime time.Duration, tota
 
 	// Dataobj row/byte stats scoped to logs reader regions only.
 	// TODO: track and report TotalStructuredMetadataBytesProcessed
-	const logsReader = "logs.Reader.Read"
-	result.Querier.Store.Dataobj.PrePredicateDecompressedBytes = xcap.ValueFromRegion[int64](capture, logsReader, dataobj.StatDatasetPrimaryRowBytes)
-	result.Querier.Store.Dataobj.PostPredicateDecompressedBytes = xcap.ValueFromRegion[int64](capture, logsReader, dataobj.StatDatasetSecondaryRowBytes)
-	result.Querier.Store.Dataobj.PrePredicateDecompressedRows = xcap.ValueFromRegion[int64](capture, logsReader, dataobj.StatDatasetPrimaryRowsRead)
+	result.Querier.Store.Dataobj.PrePredicateDecompressedBytes = xcap.ValueFromRegion[int64](capture, logs.RegionRead, dataobj.StatDatasetPrimaryRowBytes)
+	result.Querier.Store.Dataobj.PostPredicateDecompressedBytes = xcap.ValueFromRegion[int64](capture, logs.RegionRead, dataobj.StatDatasetSecondaryRowBytes)
+	result.Querier.Store.Dataobj.PrePredicateDecompressedRows = xcap.ValueFromRegion[int64](capture, logs.RegionRead, dataobj.StatDatasetPrimaryRowsRead)
 	// TODO: this will report the wrong value if the plan has a filter stage.
 	// pick the min of row_out from filter and scan nodes.
-	result.Querier.Store.Dataobj.PostFilterRows = xcap.ValueFromRegion[int64](capture, logsReader, dataobj.StatDatasetSecondaryRowsRead)
+	result.Querier.Store.Dataobj.PostFilterRows = xcap.ValueFromRegion[int64](capture, logs.RegionRead, dataobj.StatDatasetSecondaryRowsRead)
 
 	// Cache and wire stats aggregated globally across all regions.
 	taskHits := xcap.Value[int64](capture, executor.TaskCacheHits) + xcap.Value[int64](capture, executor.DataObjScanCacheHits)
@@ -936,10 +935,10 @@ func printExecutionSummary(q *query, duration time.Duration, err error) {
 
 func printLogLocalitySummary(q *query) {
 	var (
-		rowsTotal           = xcap.ValueFromRegion[int64](q.capture, logs.RegionPrefix, dataobj.StatDatasetMaxRows)
-		relevantRows        = xcap.ValueFromRegion[int64](q.capture, logs.RegionPrefix, dataobj.StatStreamRelevantRows)
-		streamPagesTotal    = xcap.ValueFromRegion[int64](q.capture, logs.RegionPrefix, dataobj.StatStreamPagesTotal)
-		streamRelevantPages = xcap.ValueFromRegion[int64](q.capture, logs.RegionPrefix, dataobj.StatStreamRelevantPages)
+		rowsTotal           = xcap.ValueFromRegion[int64](q.capture, logs.RegionOpen, dataobj.StatDatasetMaxRows)
+		relevantRows        = xcap.ValueFromRegion[int64](q.capture, logs.RegionRead, dataobj.StatStreamRelevantRows)
+		streamPagesTotal    = xcap.ValueFromRegion[int64](q.capture, logs.RegionOpen, dataobj.StatStreamPagesTotal)
+		streamRelevantPages = xcap.ValueFromRegion[int64](q.capture, logs.RegionOpen, dataobj.StatStreamRelevantPages)
 	)
 
 	level.Info(q.Logger()).Log(

--- a/pkg/engine/internal/workflow/task_summary.go
+++ b/pkg/engine/internal/workflow/task_summary.go
@@ -102,11 +102,11 @@ func (wf *Workflow) printTaskSummary(task *Task, oldState TaskState, newStatus T
 }
 
 func (wf *Workflow) printTaskLogLocalitySummary(task *Task, capture *xcap.Capture) {
-	rowsTotal := xcap.ValueFromRegion[int64](capture, logs.RegionPrefix, dataobj.StatDatasetMaxRows)
-	relevantRows := xcap.ValueFromRegion[int64](capture, logs.RegionPrefix, dataobj.StatStreamRelevantRows)
-	streamPagesTotal := xcap.ValueFromRegion[int64](capture, logs.RegionPrefix, dataobj.StatStreamPagesTotal)
-	streamRelevantPages := xcap.ValueFromRegion[int64](capture, logs.RegionPrefix, dataobj.StatStreamRelevantPages)
-	streamPageRuns := xcap.ValueFromRegion[int64](capture, logs.RegionPrefix, dataobj.StatStreamPageRuns)
+	rowsTotal := xcap.ValueFromRegion[int64](capture, logs.RegionOpen, dataobj.StatDatasetMaxRows)
+	relevantRows := xcap.ValueFromRegion[int64](capture, logs.RegionRead, dataobj.StatStreamRelevantRows)
+	streamPagesTotal := xcap.ValueFromRegion[int64](capture, logs.RegionOpen, dataobj.StatStreamPagesTotal)
+	streamRelevantPages := xcap.ValueFromRegion[int64](capture, logs.RegionOpen, dataobj.StatStreamRelevantPages)
+	streamPageRuns := xcap.ValueFromRegion[int64](capture, logs.RegionOpen, dataobj.StatStreamPageRuns)
 
 	level.Info(wf.logger).Log(
 		"msg", "task-log-locality-summary",

--- a/pkg/xcap/capture.go
+++ b/pkg/xcap/capture.go
@@ -57,7 +57,6 @@ package xcap
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/gogo/protobuf/proto"
@@ -76,6 +75,9 @@ type Capture struct {
 	// regions are all regions created within this capture.
 	regions []*Region
 
+	// regionByName is a look-up table for regions by name.
+	regionByName map[string][]*Region
+
 	// ended indicates whether End() has been called.
 	ended bool
 }
@@ -83,8 +85,9 @@ type Capture struct {
 // NewCapture creates a new Capture and attaches it to the provided [context.Context]
 func NewCapture(ctx context.Context, attributes []attribute.KeyValue) (context.Context, *Capture) {
 	capture := &Capture{
-		attributes: attributes,
-		regions:    make([]*Region, 0),
+		attributes:   attributes,
+		regions:      make([]*Region, 0),
+		regionByName: make(map[string][]*Region),
 	}
 
 	ctx = contextWithCapture(ctx, capture)
@@ -104,8 +107,8 @@ func (c *Capture) End() {
 	c.ended = true
 }
 
-// AddRegion adds a region to this capture. This is called by Region
-// when it is created.
+// AddRegion adds a region to this capture. This is called by [StartRegion]
+// when a region is created.
 func (c *Capture) AddRegion(r *Region) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -115,6 +118,7 @@ func (c *Capture) AddRegion(r *Region) {
 	}
 
 	c.regions = append(c.regions, r)
+	c.regionByName[r.name] = append(c.regionByName[r.name], r)
 }
 
 // Regions returns all regions in this capture.
@@ -125,42 +129,62 @@ func (c *Capture) Regions() []*Region {
 	return c.regions
 }
 
-// LinkParent assigns the provided region as the parent
-// to all root regions of the capture.
-func (c *Capture) LinkParent(parent *Region) {
-	c.mu.RLock()
-	regions := make([]*Region, len(c.regions))
-	copy(regions, c.regions)
-	c.mu.RUnlock()
-
-	for _, region := range regions {
-		region.mu.Lock()
-		if region.parentID.IsZero() {
-			region.parentID = parent.id
-		}
-		region.mu.Unlock()
-	}
-}
-
-// Merge incorporates all regions from src into c. If parent is non-nil, the
-// root regions of src are re-parented onto it before being added to c,
-// preserving the parent/child relationships when src's data is presented as
-// part of c's hierarchy.
+// Merge incorporates all regions from src into c by accumulating observations
+// into matching regions. If a region whose name matches an existing region in
+// c is encountered, its observations are folded into that existing region using
+// each statistic's aggregation semantics ([AggregatedObservation.Merge]).
+// If no region with that name exists in c, a new region is created and
+// observations are copied from src.
 //
-// Regions are shared by reference between c and src after Merge returns.
-//
-// Merge is a no-op if c or src is nil, or if c has already been ended.
+// Unlike a naïve append-based merge, this keeps the number of regions in c
+// bounded by the number of unique region names across all merged captures.
 func (c *Capture) Merge(parent *Region, src *Capture) {
 	if c == nil || src == nil {
 		return
 	}
 
-	if parent != nil {
-		src.LinkParent(parent)
+	// snapshot src.regions under src's read lock to avoid holding two capture
+	// locks simultaneously.
+	src.mu.RLock()
+	srcRegions := make([]*Region, len(src.regions))
+	copy(srcRegions, src.regions)
+	src.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.ended {
+		return
 	}
 
-	for _, region := range src.Regions() {
-		c.AddRegion(region)
+	for _, srcRegion := range srcRegions {
+		if dsts := c.regionByName[srcRegion.name]; len(dsts) > 0 {
+			// A region with this name already exists: fold observations
+			// into it. Lock order: c.mu (held) → srcRegion.mu → dst.mu
+			// (inside MergeObservations).
+			//
+			// We always merge into the last region in the slice, there
+			// is no strong reason to prefer the last one, it is just
+			// a simple deterministic choice.
+			dsts[len(dsts)-1].MergeObservations(srcRegion)
+			continue
+		}
+
+		// no region with this name exists, create a new one.
+		dst := &Region{
+			id:           newID(),
+			name:         srcRegion.name,
+			observations: make(map[StatisticKey]*AggregatedObservation),
+		}
+
+		// Parent every merged region onto the provided parent.
+		if parent != nil {
+			dst.parentID = parent.id
+		}
+		dst.MergeObservations(srcRegion)
+
+		c.regions = append(c.regions, dst)
+		c.regionByName[dst.name] = append(c.regionByName[dst.name], dst)
 	}
 }
 
@@ -259,21 +283,22 @@ func (c *Capture) Value(stat Statistic) *AggregatedObservation {
 	return rolled
 }
 
-// ValueFromRegion computes the value of a statistic from regions with
-// names that start with prefix. If the statistic is not present in any matching
-// region, ValueFromRegion returns nil.
-func (c *Capture) ValueFromRegion(prefix string, stat Statistic) *AggregatedObservation {
+// ValueFromRegion computes the value of a statistic from all regions with the
+// given exact name. If the statistic is not present in any matching region,
+// ValueFromRegion returns nil.
+func (c *Capture) ValueFromRegion(name string, stat Statistic) *AggregatedObservation {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
+
+	regions := c.regionByName[name]
+	if len(regions) == 0 {
+		return nil
+	}
 
 	key := stat.Key()
 	var rolled *AggregatedObservation
 
-	for _, region := range c.regions {
-		if !strings.HasPrefix(region.name, prefix) {
-			continue
-		}
-
+	for _, region := range regions {
 		region.mu.RLock()
 		obs, ok := region.observations[key]
 		if !ok {
@@ -306,12 +331,12 @@ func Value[T any](c *Capture, stat Statistic) T {
 	return v
 }
 
-// ValueFromRegion gets a typed value from a capture, aggregating only
-// regions with names that start with prefix. If the statistic is not present in
-// any matching region, or the statistic is not of type T, ValueFromRegion
-// returns the zero value for T.
-func ValueFromRegion[T any](c *Capture, prefix string, stat Statistic) T {
-	rolled := c.ValueFromRegion(prefix, stat)
+// ValueFromRegion gets a typed value from a capture, aggregating only regions
+// whose name exactly matches name. If the statistic is not present in any
+// matching region, or the statistic is not of type T, ValueFromRegion returns
+// the zero value for T.
+func ValueFromRegion[T any](c *Capture, name string, stat Statistic) T {
+	rolled := c.ValueFromRegion(name, stat)
 	if rolled == nil {
 		var zero T
 		return zero

--- a/pkg/xcap/capture_test.go
+++ b/pkg/xcap/capture_test.go
@@ -120,7 +120,7 @@ func TestCapture_AddRegion(t *testing.T) {
 }
 
 func TestCapture_Merge(t *testing.T) {
-	t.Run("merges all regions from src into dst", func(t *testing.T) {
+	t.Run("distinct-named regions are all present after merge", func(t *testing.T) {
 		ctxDst, dst := NewCapture(context.Background(), nil)
 		ctxSrc, src := NewCapture(context.Background(), nil)
 
@@ -138,21 +138,7 @@ func TestCapture_Merge(t *testing.T) {
 		require.ElementsMatch(t, []string{"dst-region", "src-region-1", "src-region-2"}, got)
 	})
 
-	t.Run("re-parents src root regions when parent is provided", func(t *testing.T) {
-		ctxDst, dst := NewCapture(context.Background(), nil)
-		_, dstParent := StartRegion(ctxDst, "dst-parent")
-
-		ctxSrc, src := NewCapture(context.Background(), nil)
-		_, srcRoot := StartRegion(ctxSrc, "src-root")
-
-		require.True(t, srcRoot.parentID.IsZero(), "src root should have no parent before merge")
-
-		dst.Merge(dstParent, src)
-
-		require.Equal(t, dstParent.id, srcRoot.parentID, "src root should be re-parented onto dstParent")
-	})
-
-	t.Run("does not change parent for src non-root regions", func(t *testing.T) {
+	t.Run("all merged regions are parented onto provided parent", func(t *testing.T) {
 		ctxDst, dst := NewCapture(context.Background(), nil)
 		_, dstParent := StartRegion(ctxDst, "dst-parent")
 
@@ -164,11 +150,18 @@ func TestCapture_Merge(t *testing.T) {
 
 		dst.Merge(dstParent, src)
 
-		require.Equal(t, dstParent.id, srcRoot.parentID, "src-root should be re-parented onto dstParent")
-		require.Equal(t, srcRoot.id, srcChild.parentID, "src-child should keep its original parent (src-root)")
+		// The accumulating merge collapses the src hierarchy: every merged
+		// region is parented directly onto dstParent.
+		dstRoots := dst.regionByName["src-root"]
+		require.Len(t, dstRoots, 1)
+		require.Equal(t, dstParent.id, dstRoots[0].parentID, "dst region for src root should be parented onto dstParent")
+
+		dstChildren := dst.regionByName["src-child"]
+		require.Len(t, dstChildren, 1)
+		require.Equal(t, dstParent.id, dstChildren[0].parentID, "dst region for src non-root should also be parented onto dstParent")
 	})
 
-	t.Run("observations roll up across merged regions", func(t *testing.T) {
+	t.Run("observations roll up across merged regions with distinct names", func(t *testing.T) {
 		stat := NewStatisticInt64("merged.value", AggregationTypeSum)
 
 		ctxDst, dst := NewCapture(context.Background(), nil)
@@ -211,6 +204,88 @@ func TestCapture_Merge(t *testing.T) {
 
 		dst.Merge(nil, src)
 		require.Empty(t, dst.Regions(), "ended dst should not absorb new regions")
+	})
+
+	t.Run("same-named region observations are accumulated across merges", func(t *testing.T) {
+		stat := NewStatisticInt64("rows.scanned", AggregationTypeSum)
+		_, dst := NewCapture(context.Background(), nil)
+
+		// Simulate N task completions, each contributing a capture with the
+		// same region name. Expect the values to be collapsed into one region.
+		const tasks = 5
+		for i := 0; i < tasks; i++ {
+			ctxSrc, src := NewCapture(context.Background(), nil)
+			_, r := StartRegion(ctxSrc, "task.region")
+			r.Record(stat.Observe(100))
+			r.End()
+			src.End()
+			dst.Merge(nil, src)
+		}
+
+		// Only one region should exist regardless of the number of merges.
+		require.Len(t, dst.Regions(), 1, "accumulating merge should collapse same-named regions")
+
+		value, ok := TryValue[int64](dst, stat)
+		require.True(t, ok)
+		require.Equal(t, int64(tasks*100), value, "accumulated value should equal sum across all merged captures")
+	})
+
+	t.Run("multiple distinct region names each accumulate independently", func(t *testing.T) {
+		statA := NewStatisticInt64("bytes.a", AggregationTypeSum)
+		statB := NewStatisticInt64("bytes.b", AggregationTypeSum)
+
+		_, dst := NewCapture(context.Background(), nil)
+
+		const tasks = 3
+		for i := 0; i < tasks; i++ {
+			ctxSrc, src := NewCapture(context.Background(), nil)
+			_, ra := StartRegion(ctxSrc, "region.a")
+			ra.Record(statA.Observe(10))
+			ra.End()
+			_, rb := StartRegion(ctxSrc, "region.b")
+			rb.Record(statB.Observe(20))
+			rb.End()
+			src.End()
+			dst.Merge(nil, src)
+		}
+
+		require.Len(t, dst.Regions(), 2, "one collapsed region per unique name")
+		require.Equal(t, int64(tasks*10), Value[int64](dst, statA))
+		require.Equal(t, int64(tasks*20), Value[int64](dst, statB))
+	})
+
+	t.Run("accumulating merge handles Min and Max correctly", func(t *testing.T) {
+		statMin := NewStatisticFloat64("latency.min", AggregationTypeMin)
+		statMax := NewStatisticInt64("rows.max", AggregationTypeMax)
+
+		_, dst := NewCapture(context.Background(), nil)
+
+		for _, pair := range [][2]int64{{10, 50}, {3, 200}, {7, 100}} {
+			ctxSrc, src := NewCapture(context.Background(), nil)
+			_, r := StartRegion(ctxSrc, "task.region")
+			r.Record(statMin.Observe(float64(pair[0])))
+			r.Record(statMax.Observe(pair[1]))
+			r.End()
+			src.End()
+			dst.Merge(nil, src)
+		}
+
+		require.Equal(t, float64(3), Value[float64](dst, statMin), "min should be the smallest across all merges")
+		require.Equal(t, int64(200), Value[int64](dst, statMax), "max should be the largest across all merges")
+	})
+
+	t.Run("regionByName index is populated after merge", func(t *testing.T) {
+		ctxSrc, src := NewCapture(context.Background(), nil)
+		_, _ = StartRegion(ctxSrc, "alpha")
+		_, _ = StartRegion(ctxSrc, "beta")
+		src.End()
+
+		_, dst := NewCapture(context.Background(), nil)
+		dst.Merge(nil, src)
+
+		require.Len(t, dst.regionByName["alpha"], 1, "index should contain alpha")
+		require.Len(t, dst.regionByName["beta"], 1, "index should contain beta")
+		require.Empty(t, dst.regionByName["gamma"], "index should not contain unknown name")
 	})
 }
 
@@ -373,6 +448,10 @@ func TestCapture_ValueFromRegion(t *testing.T) {
 	logsOpen.Record(stat.Observe(100))
 	logsOpen.End()
 
+	_, logsOpen2 := StartRegion(ctx, "logs.Reader.Open")
+	logsOpen2.Record(stat.Observe(25))
+	logsOpen2.End()
+
 	_, logsRead := StartRegion(ctx, "logs.Reader.Read")
 	logsRead.Record(stat.Observe(50))
 	logsRead.End()
@@ -381,15 +460,20 @@ func TestCapture_ValueFromRegion(t *testing.T) {
 	streamsOpen.Record(stat.Observe(1000))
 	streamsOpen.End()
 
-	got := capture.ValueFromRegion("logs.Reader.", stat)
-	require.NotNil(t, got)
-	require.Equal(t, int64(150), got.Value)
-	require.Equal(t, 2, got.Count)
-	require.Equal(t, stat.Key(), got.Statistic.Key())
+	// Exact name matches only the Open region.
+	gotOpen := capture.ValueFromRegion("logs.Reader.Open", stat)
+	require.NotNil(t, gotOpen)
+	require.Equal(t, int64(125), gotOpen.Value)
+	require.Equal(t, 2, gotOpen.Count)
 
-	require.Equal(t, int64(150), ValueFromRegion[int64](capture, "logs.Reader", stat))
-	require.Zero(t, ValueFromRegion[int64](capture, "missing.Reader", stat))
-	require.Zero(t, ValueFromRegion[float64](capture, "logs.Reader", stat))
+	// Exact name matches only the Read region.
+	gotRead := capture.ValueFromRegion("logs.Reader.Read", stat)
+	require.NotNil(t, gotRead)
+	require.Equal(t, int64(50), gotRead.Value)
+	require.Equal(t, 1, gotRead.Count)
+
+	// Prefix is not a match — no region is named "logs.Reader." exactly.
+	require.Nil(t, capture.ValueFromRegion("logs.Reader.", stat))
 }
 
 func TestCapture_GetAllStatistics(t *testing.T) {

--- a/pkg/xcap/region.go
+++ b/pkg/xcap/region.go
@@ -137,6 +137,32 @@ func (r *Region) Observations() []AggregatedObservation {
 	return observations
 }
 
+// MergeObservations folds all observations from src into r using
+// [AggregatedObservation.Merge] semantics.
+func (r *Region) MergeObservations(src *Region) {
+	if r == nil || src == nil {
+		return
+	}
+
+	src.mu.RLock()
+	defer src.mu.RUnlock()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for key, srcObs := range src.observations {
+		if existing, ok := r.observations[key]; ok {
+			existing.Merge(srcObs)
+		} else {
+			r.observations[key] = &AggregatedObservation{
+				Statistic: srcObs.Statistic,
+				Value:     srcObs.Value,
+				Count:     srcObs.Count,
+			}
+		}
+	}
+}
+
 // End completes the Region. Updates to the Region are ignored after
 // calling End.
 func (r *Region) End() {

--- a/pkg/xcap/unmarshal.go
+++ b/pkg/xcap/unmarshal.go
@@ -22,6 +22,8 @@ func fromProtoCapture(protoCapture *proto.Capture, capture *Capture) error {
 		statsIndex[uint32(i)] = stat
 	}
 
+	capture.regionByName = make(map[string][]*Region)
+
 	// Unmarshal regions
 	for _, protoRegion := range protoCapture.Regions {
 		region, err := fromProtoRegion(protoRegion, statsIndex)


### PR DESCRIPTION
**What this PR does / why we need it**:

`Merge` method of a Capture currently performs a simple append of source regions. For large queries
creating 1000s of tasks, the workflow capture post merge would contain a very high number of regions. 

1. We do not need this granularity. For example we only care about aggregated observations from all `logs.Reader.Read` regions, but not the individual observation value within a region.
2. Having to process 1000s of regions to compute an observation value for `xcap.Value()` is inefficient.

This PR updates the `Merge` to aggregate observations within matching regions. This would effectively
add one region per distinct region name to the final capture when merging regions with the same name
from task captures.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
