### PR TITLE
chore!: Remove deprecated `per_tenant_override_config` and `per_tenant_override_period`

### DIFF
--- a/docs/sources/operations/storage/retention.md
+++ b/docs/sources/operations/storage/retention.md
@@ -122,7 +122,8 @@ limits_config:
   - selector: '{namespace="dev"}'
     priority: 1
     period: 24h
-  per_tenant_override_config: /etc/overrides.yaml
+runtime_config:
+  file: /etc/overrides.yaml
 ...
 ```
 

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -73,10 +73,11 @@ As a result, the following have been removed:
 - The `-ruler.enable-wal-replay` flag and its per-tenant equivalent `ruler_enable_wal_replay` (in `limits_config`). The ruler no longer replays the WAL, so these settings no longer have any effect. Remove them from your configuration; the `deprecated-config-checker` tool will flag them.
 - The ruler WAL metrics that only ever reported replay or repair activity: `loki_ruler_wal_corruptions_total`, `loki_ruler_wal_corruptions_repair_failed_total`, `loki_ruler_wal_corruptions_repair_succeeded_total`, and `loki_ruler_wal_replay_duration`. Remove any dashboards or alerts that reference them.
 
-### Breaking change: Removal of various configuration options
+### Breaking change: Removal of various deprecated configuration options
 
-- The deprecated per-tenant setting `unordered_writes` has been removed. Loki now always allows unordered writes.
-- The deprecated setting `-store.index-cache-write` (`chunk_store_config.write_dedupe_cache_config` block in the yaml file) has been removed as it was only used for legacy storage backends that have been removed as well.
+- The settings `-limits.per-user-override-config` (`limits_config.per_tenant_override_config`) and `-limits.per-user-override-period` (`limits_config.per_tenant_override_period`) have been removed in favor of `-runtime-config.file` (`runtime_config.file`) and `-runtime-config.reload-period` (`runtime_config.period`) respectively.
+- The per-tenant setting `unordered_writes` has been removed. Loki now always allows unordered writes.
+- The setting `-store.index-cache-write` (`chunk_store_config.write_dedupe_cache_config` block in the yaml file) has been removed as it was only used for legacy storage backends that have been removed as well.
 - The setting `-store.index-cache-read` (`storage_config.index_queries_cache_config` block in the yaml file) has been removed as it was only used for legacy storage backends (`boltdb-shipper`) that have been removed as well.
 - The setting `-store.index-cache-validity` (`storage_config.index_cache_validity` block in the yaml file) has been removed as it was only used in combination with the removed `-store.index-cache-read` setting.
 

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -4792,16 +4792,6 @@ ruler_remote_write_sigv4_config:
 # 'retention_period' is used.
 [retention_stream: <list of StreamRetentions>]
 
-# Feature renamed to 'runtime configuration', flag deprecated in favor of
-# -runtime-config.file (runtime_config.file in YAML).
-# CLI flag: -limits.per-user-override-config
-[per_tenant_override_config: <string> | default = ""]
-
-# Feature renamed to 'runtime configuration'; flag deprecated in favor of
-# -runtime-config.reload-period (runtime_config.period in YAML).
-# CLI flag: -limits.per-user-override-period
-[per_tenant_override_period: <duration> | default = 10s]
-
 # Define streams sharding behavior.
 shard_streams:
   # Automatically shard streams to keep them under the per-stream rate limit.

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -7555,7 +7555,7 @@ Configuration for `tracing`.
 
 ## Runtime Configuration file
 
-Loki has a concept of "runtime config" file, which is simply a file that is reloaded while Loki is running. It is used by some Loki components to allow operator to change some aspects of Loki configuration without restarting it. File is specified by using `-runtime-config.file=<filename>` flag and reload period (which defaults to 10 seconds) can be changed by `-runtime-config.reload-period=<duration>` flag. Previously this mechanism was only used by limits overrides, and flags were called `-limits.per-user-override-config=<filename>` and `-limits.per-user-override-period=10s` respectively. These are still used, if `-runtime-config.file=<filename>` is not specified.
+Loki has a concept of "runtime config" file, which is simply a file that is reloaded while Loki is running. It is used by some Loki components to allow operator to change some aspects of Loki configuration without restarting it. File is specified by using `-runtime-config.file=<filename>` flag and reload period (which defaults to 10 seconds) can be changed by `-runtime-config.reload-period=<duration>` flag.
 
 At the moment, two components use runtime configuration: limits and multi KV store.
 

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -6082,8 +6082,7 @@ remote_write:
   [enabled: <boolean> | default = false]
 
   # Minimum period to wait between refreshing remote-write reconfigurations.
-  # This should be greater than or equivalent to
-  # -limits.per-user-override-period.
+  # This should be greater than or equivalent to -runtime-config.reload-period.
   # CLI flag: -ruler.remote-write.config-refresh-period
   [config_refresh_period: <duration> | default = 10s]
 

--- a/docs/templates/configuration.template
+++ b/docs/templates/configuration.template
@@ -86,7 +86,7 @@ Pass the `-config.expand-env` flag at the command line to enable this way of set
 
 ## Runtime Configuration file
 
-Loki has a concept of "runtime config" file, which is simply a file that is reloaded while Loki is running. It is used by some Loki components to allow operator to change some aspects of Loki configuration without restarting it. File is specified by using `-runtime-config.file=<filename>` flag and reload period (which defaults to 10 seconds) can be changed by `-runtime-config.reload-period=<duration>` flag. Previously this mechanism was only used by limits overrides, and flags were called `-limits.per-user-override-config=<filename>` and `-limits.per-user-override-period=10s` respectively. These are still used, if `-runtime-config.file=<filename>` is not specified.
+Loki has a concept of "runtime config" file, which is simply a file that is reloaded while Loki is running. It is used by some Loki components to allow operator to change some aspects of Loki configuration without restarting it. File is specified by using `-runtime-config.file=<filename>` flag and reload period (which defaults to 10 seconds) can be changed by `-runtime-config.reload-period=<duration>` flag.
 
 At the moment, two components use runtime configuration: limits and multi KV store.
 

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -429,12 +429,9 @@ func (c *Component) run() error {
 
 	if err := cfg.DynamicUnmarshal(&config, append(
 		c.flags,
-		"-config.file",
-		c.configFile,
-		"-limits.per-user-override-config",
-		c.overridesFile,
-		"-limits.per-user-override-period",
-		"1s",
+		"-config.file", c.configFile,
+		"-runtime-config.file", c.overridesFile,
+		"-runtime-config.reload-period", "1s",
 	), flagset); err != nil {
 		return err
 	}

--- a/integration/loki_micro_services_delete_test.go
+++ b/integration/loki_micro_services_delete_test.go
@@ -46,7 +46,6 @@ func TestMicroServicesDeleteRequest(t *testing.T) {
 			"-compactor.delete-request-cancel-period=-60s",
 			"-compactor.deletion-mode=filter-only",
 			"-compactor.delete-max-interval=0",
-			"-limits.per-user-override-period=1s",
 		)
 		tDistributor = clu.AddComponent(
 			"distributor",

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -285,13 +285,6 @@ func (t *Loki) initRing() (_ services.Service, err error) {
 
 func (t *Loki) initRuntimeConfig() (services.Service, error) {
 	if len(t.Cfg.RuntimeConfig.LoadPath) == 0 {
-		if len(t.Cfg.LimitsConfig.PerTenantOverrideConfig) != 0 {
-			t.Cfg.RuntimeConfig.LoadPath = []string{t.Cfg.LimitsConfig.PerTenantOverrideConfig}
-		}
-		t.Cfg.RuntimeConfig.ReloadPeriod = time.Duration(t.Cfg.LimitsConfig.PerTenantOverridePeriod)
-	}
-
-	if len(t.Cfg.RuntimeConfig.LoadPath) == 0 {
 		// no need to initialize module if load path is empty
 		return nil, nil
 	}

--- a/pkg/ruler/config.go
+++ b/pkg/ruler/config.go
@@ -122,7 +122,7 @@ func (c *RemoteWriteConfig) Clone() (*RemoteWriteConfig, error) {
 func (c *RemoteWriteConfig) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&c.AddOrgIDHeader, "ruler.remote-write.add-org-id-header", true, "Add X-Scope-OrgID header in remote write requests.")
 	f.BoolVar(&c.Enabled, "ruler.remote-write.enabled", false, "Enable remote-write functionality.")
-	f.DurationVar(&c.ConfigRefreshPeriod, "ruler.remote-write.config-refresh-period", 10*time.Second, "Minimum period to wait between refreshing remote-write reconfigurations. This should be greater than or equivalent to -limits.per-user-override-period.")
+	f.DurationVar(&c.ConfigRefreshPeriod, "ruler.remote-write.config-refresh-period", 10*time.Second, "Minimum period to wait between refreshing remote-write reconfigurations. This should be greater than or equivalent to -runtime-config.reload-period.")
 
 	if c.Clients == nil {
 		c.Clients = make(map[string]config.RemoteWriteConfig)

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -214,10 +214,6 @@ type Limits struct {
 	RetentionPeriod model.Duration    `yaml:"retention_period" json:"retention_period"`
 	StreamRetention []StreamRetention `yaml:"retention_stream,omitempty" json:"retention_stream,omitempty" doc:"description=Per-stream retention to apply, if the retention is enabled on the compactor side.\nExample:\n retention_stream:\n - selector: '{namespace=\"dev\"}'\n priority: 1\n period: 24h\n- selector: '{container=\"nginx\"}'\n priority: 1\n period: 744h\nSelector is a Prometheus labels matchers that will apply the 'period' retention only if the stream is matching. In case multiple streams are matching, the highest priority will be picked. If no rule is matched the 'retention_period' is used."`
 
-	// Config for overrides, convenient if it goes here.
-	PerTenantOverrideConfig string         `yaml:"per_tenant_override_config" json:"per_tenant_override_config"`
-	PerTenantOverridePeriod model.Duration `yaml:"per_tenant_override_period" json:"per_tenant_override_period"`
-
 	ShardStreams shardstreams.Config `yaml:"shard_streams" json:"shard_streams" doc:"description=Define streams sharding behavior."`
 
 	BlockedQueries []*validation.BlockedQuery `yaml:"blocked_queries,omitempty" json:"blocked_queries,omitempty"`
@@ -469,12 +465,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.RulerMaxRuleGroupsPerTenant, "ruler.max-rule-groups-per-tenant", 0, "Maximum number of rule groups per-tenant. 0 to disable.")
 	f.IntVar(&l.RulerTenantShardSize, "ruler.tenant-shard-size", 0, "The default tenant's shard size when shuffle-sharding is enabled in the ruler. When this setting is specified in the per-tenant overrides, a value of 0 disables shuffle sharding for the tenant.")
 
-	f.StringVar(&l.PerTenantOverrideConfig, "limits.per-user-override-config", "", "Feature renamed to 'runtime configuration', flag deprecated in favor of -runtime-config.file (runtime_config.file in YAML).")
 	_ = l.RetentionPeriod.Set("0s")
 	f.Var(&l.RetentionPeriod, "store.retention", "Retention period to apply to stored data, only applies if retention_enabled is true in the compactor config. As of version 2.8.0, a zero value of 0 or 0s disables retention. In previous releases, Loki did not properly honor a zero value to disable retention and a really large value should be used instead.")
-
-	_ = l.PerTenantOverridePeriod.Set("10s")
-	f.Var(&l.PerTenantOverridePeriod, "limits.per-user-override-period", "Feature renamed to 'runtime configuration'; flag deprecated in favor of -runtime-config.reload-period (runtime_config.period in YAML).")
 
 	_ = l.QuerySplitDuration.Set("1h")
 	f.Var(&l.QuerySplitDuration, "querier.split-queries-by-interval", "Split queries by a time interval and execute in parallel. The value 0 disables splitting by time. This also determines how cache keys are chosen when result caching is enabled.")

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -76,8 +76,6 @@ ruler_max_rules_per_rule_group: 210
 ruler_max_rule_groups_per_tenant: 220
 ruler_remote_write_sigv4_config:
   region: us-east-1
-per_tenant_override_config: ""
-per_tenant_override_period: 230s
 query_timeout: 5m
 shard_streams:
   enabled: true
@@ -122,8 +120,6 @@ volume_max_series: 10001
   "ruler_remote_write_sigv4_config": {
     "region": "us-east-1"
   },
-  "per_tenant_override_config": "",
-  "per_tenant_override_period": "230s",
   "query_timeout": "5m",
   "shard_streams": {
     "desired_rate": "4mb",

--- a/tools/deprecated-config-checker/checker/checker_test.go
+++ b/tools/deprecated-config-checker/checker/checker_test.go
@@ -41,6 +41,8 @@ var (
 		"limits_config.ruler_evaluation_delay_duration",
 		"limits_config.allow_deletes",
 		"limits_config.ruler_enable_wal_replay",
+		"limits_config.per_tenant_override_config",
+		"limits_config.per_tenant_override_period",
 		"storage_config.bigtable",
 		"storage_config.cassandra",
 		"storage_config.boltdb",
@@ -82,8 +84,6 @@ var (
 		"limits_config.ruler_remote_write_queue_max_backoff",
 		"limits_config.ruler_remote_write_queue_retry_on_ratelimit",
 		"limits_config.ruler_remote_write_sigv4_config",
-		"limits_config.per_tenant_override_config",
-		"limits_config.per_tenant_override_period",
 	}
 
 	expectedRuntimeConfigDeletes = []string{
@@ -92,11 +92,15 @@ var (
 		"overrides.foo.enforce_metric_name",
 		"overrides.foo.allow_deletes",
 		"overrides.foo.ruler_enable_wal_replay",
+		"overrides.foo.per_tenant_override_config",
+		"overrides.foo.per_tenant_override_period",
 		"overrides.bar.unordered_writes",
 		"overrides.bar.ruler_evaluation_delay_duration",
 		"overrides.bar.enforce_metric_name",
 		"overrides.bar.allow_deletes",
 		"overrides.bar.ruler_enable_wal_replay",
+		"overrides.bar.per_tenant_override_config",
+		"overrides.bar.per_tenant_override_period",
 	}
 
 	expectedRuntimeConfigDeprecates = []string{
@@ -113,8 +117,6 @@ var (
 		"overrides.foo.ruler_remote_write_queue_max_backoff",
 		"overrides.foo.ruler_remote_write_queue_retry_on_ratelimit",
 		"overrides.foo.ruler_remote_write_sigv4_config",
-		"overrides.foo.per_tenant_override_config",
-		"overrides.foo.per_tenant_override_period",
 		"overrides.bar.ruler_remote_write_url",
 		"overrides.bar.ruler_remote_write_timeout",
 		"overrides.bar.ruler_remote_write_headers",
@@ -128,8 +130,6 @@ var (
 		"overrides.bar.ruler_remote_write_queue_max_backoff",
 		"overrides.bar.ruler_remote_write_queue_retry_on_ratelimit",
 		"overrides.bar.ruler_remote_write_sigv4_config",
-		"overrides.bar.per_tenant_override_config",
-		"overrides.bar.per_tenant_override_period",
 	}
 )
 

--- a/tools/deprecated-config-checker/deleted-config.yaml
+++ b/tools/deprecated-config-checker/deleted-config.yaml
@@ -94,3 +94,5 @@ limits_config:
   enforce_metric_name: "This setting is removed."
   allow_deletes: "This setting is removed."
   ruler_enable_wal_replay: "This setting is removed. The ruler now always wipes its remote-write WAL on startup, so there is nothing to replay."
+  per_tenant_override_config: "This setting is removed in favor of runtime_config.file"
+  per_tenant_override_period: "This setting is removed in favor of runtime_config.period"

--- a/tools/deprecated-config-checker/deprecated-config.yaml
+++ b/tools/deprecated-config-checker/deprecated-config.yaml
@@ -41,8 +41,6 @@ limits_config:
   ruler_remote_write_queue_max_backoff: "Use ruler_remote_write_config instead."
   ruler_remote_write_queue_retry_on_ratelimit: "Use ruler_remote_write_config instead."
   ruler_remote_write_sigv4_config: "Use ruler_remote_write_config instead."
-  per_tenant_override_config: "Feature renamed to 'runtime configuration', flag deprecated in favor of runtime_config.file"
-  per_tenant_override_period: "Feature renamed to 'runtime configuration', flag deprecated in favor of runtime_config.period"
 
 server:
   grpc_server_stats_tracking_enabled: "Deprecated, currently doesn't do anything, will be removed in a future version."

--- a/tools/deprecated-config-checker/test-fixtures/config.yaml
+++ b/tools/deprecated-config-checker/test-fixtures/config.yaml
@@ -139,6 +139,6 @@ limits_config:
   ruler_remote_write_queue_retry_on_ratelimit: true # DEPRECATED
   ruler_remote_write_sigv4_config: # DEPRECATED
     region: "wherever"
-  per_tenant_override_config: ./overrides.yaml # DEPRECATED
-  per_tenant_override_period: 5s # DEPRECATED
+  per_tenant_override_config: ./overrides.yaml # DELETED
+  per_tenant_override_period: 5s # DELETED
   allow_deletes: true # DELETED


### PR DESCRIPTION
### Summary

Both `per_tenant_override_config` and `per_tenant_override_period` were deprecated and are removed in favor of `runtime_config.file` and `runtime_config.period`.