### PR TITLE
fix(fluentd): replace unmaintained yajl-ruby with the json gem

### DIFF
--- a/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb
+++ b/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb
@@ -19,7 +19,7 @@ require 'fluent/env'
 require 'fluent/plugin/output'
 require 'net/http'
 require 'rubygems/version'
-require 'yajl'
+require 'json'
 require 'time'
 require 'zlib'
 require 'stringio'
@@ -209,7 +209,7 @@ module Fluent
 
         res_summary = "#{res.code} #{res.message} #{res.body}"
         log.warn "failed to write post to #{@uri} (#{res_summary})"
-        log.debug Yajl.dump(body)
+        log.debug sanitized_json(body)
 
         # Only retry 429 and 500s
         raise(LogPostError, res_summary) if res.is_a?(Net::HTTPTooManyRequests) || res.is_a?(Net::HTTPServerError)
@@ -281,7 +281,7 @@ module Fluent
         req.add_field('Content-Type', 'application/json')
         req.add_field('Authorization', "Bearer #{@auth_token_bearer}") unless @auth_token_bearer.nil?
         req.add_field('X-Scope-OrgID', tenant) if tenant
-        payload = Yajl.dump(body)
+        payload = sanitized_json(body)
         if @compress == :gzip
           req.add_field('Content-Encoding', 'gzip')
           compressed = StringIO.new
@@ -342,6 +342,37 @@ module Fluent
         end
       end
 
+      def sanitized_json(payload)
+        JSON.generate(payload)
+      rescue JSON::GeneratorError, EncodingError
+        JSON.generate(scrub_invalid_utf8(payload))
+      end
+
+      # Recursively replace invalid UTF-8 byte sequences with '?' so JSON.generate does
+      # not raise on them. yajl used to pass such bytes through unchanged; JSON.generate
+      # validates encoding, so labels and log lines are sanitized before serialization.
+      def scrub_invalid_utf8(value)
+        case value
+        when String
+          if value.encoding == Encoding::UTF_8
+            value.valid_encoding? ? value : value.scrub('?')
+          elsif value.encoding == Encoding::ASCII_8BIT
+            # Treat binary as UTF-8 bytes: encode() would replace every byte >= 0x80,
+            # while scrubbing preserves any valid UTF-8 sequences in the string.
+            s = value.dup.force_encoding(Encoding::UTF_8)
+            s.valid_encoding? ? s : s.scrub!('?')
+          else
+            value.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: '?')
+          end
+        when Hash
+          value.each_with_object({}) { |(k, v), h| h[scrub_invalid_utf8(k)] = scrub_invalid_utf8(v) }
+        when Array
+          value.map { |v| scrub_invalid_utf8(v) }
+        else
+          value
+        end
+      end
+
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def record_to_line(record)
         line = ''
@@ -350,7 +381,7 @@ module Fluent
         else
           case @line_format
           when :json
-            line = Yajl.dump(record)
+            line = sanitized_json(record)
           when :key_value
             formatted_labels = []
             record.each do |k, v|

--- a/clients/cmd/fluentd/spec/gems/fluent/plugin/loki_output_spec.rb
+++ b/clients/cmd/fluentd/spec/gems/fluent/plugin/loki_output_spec.rb
@@ -5,7 +5,7 @@ require 'fileutils'
 require 'openssl'
 require 'tmpdir'
 require 'time'
-require 'yajl'
+require 'json'
 require 'fluent/test'
 require 'fluent/test/driver/output'
 require 'fluent/test/helpers'
@@ -147,7 +147,7 @@ RSpec.describe Fluent::Plugin::LokiOutput do
     expect(payload[0]['values'].count).to eq 1
     expect(payload[0]['values'][0][0]).to eq '1546270458000000000'
     expect(payload[0]['values'][0][1]).to eq(
-      "{\"message\":\"\xC1 rest of line\",\"number\":1.2345,\"stream\":\"stdout\"}"
+      '{"message":"? rest of line","number":1.2345,"stream":"stdout"}'
     )
   end
 
@@ -181,7 +181,7 @@ RSpec.describe Fluent::Plugin::LokiOutput do
     expect(body[:streams][0]['stream'].empty?).to eq true
     expect(body[:streams][0]['values'].count).to eq 1
     expect(body[:streams][0]['values'][0][0]).to eq '1546270458000000000'
-    expect(body[:streams][0]['values'][0][1]).to eq Yajl.dump(line1[1])
+    expect(body[:streams][0]['values'][0][1]).to eq JSON.generate(line1[1])
   end
 
   it 'extracts record key as label' do
@@ -201,7 +201,7 @@ RSpec.describe Fluent::Plugin::LokiOutput do
     expect(body[:streams][0]['stream']).to eq('stream' => 'stdout')
     expect(body[:streams][0]['values'].count).to eq 1
     expect(body[:streams][0]['values'][0][0]).to eq '1546270458000000000'
-    expect(body[:streams][0]['values'][0][1]).to eq Yajl.dump('message' => content[0])
+    expect(body[:streams][0]['values'][0][1]).to eq JSON.generate('message' => content[0])
   end
 
   it 'extracts nested record key as label' do
@@ -221,7 +221,7 @@ RSpec.describe Fluent::Plugin::LokiOutput do
     expect(body[:streams][0]['stream']).to eq('pod' => 'podname')
     expect(body[:streams][0]['values'].count).to eq 1
     expect(body[:streams][0]['values'][0][0]).to eq '1546270458000000000'
-    expect(body[:streams][0]['values'][0][1]).to eq Yajl.dump('message' => content[0], 'kubernetes' => {})
+    expect(body[:streams][0]['values'][0][1]).to eq JSON.generate('message' => content[0], 'kubernetes' => {})
   end
 
   it 'extracts nested record key as label and drop key after' do
@@ -242,7 +242,7 @@ RSpec.describe Fluent::Plugin::LokiOutput do
     expect(body[:streams][0]['stream']).to eq('pod' => 'podname')
     expect(body[:streams][0]['values'].count).to eq 1
     expect(body[:streams][0]['values'][0][0]).to eq '1546270458000000000'
-    expect(body[:streams][0]['values'][0][1]).to eq Yajl.dump('message' => content[0])
+    expect(body[:streams][0]['values'][0][1]).to eq JSON.generate('message' => content[0])
   end
 
   it 'formats as simple string when only 1 record key' do


### PR DESCRIPTION
**What this PR does / why we need it**:
Hi, I'm a member of the Fluentd core team.
Since `yajl-ruby` is no longer maintained, we are planning to replace it, and it will no longer be bundled starting from the upcoming Fluentd v1.20.
Ref. https://github.com/fluent/fluentd/pull/5383

This PR replaces `yajl-ruby` with the standard `json` gem to ensure future compatibility for this plugin.

`yajl-ruby` is effectively unmaintained and fails to build on Ruby 4.1, so this PR removes the plugin's dependency on it and switches JSON serialization to the Ruby standard library's `json` gem (`Yajl.dump` → `JSON.generate`).

There is one behavioral difference to account for: `yajl` does **not** validate string encoding and passes invalid UTF-8 bytes straight through into the output (emitting technically-invalid JSON), whereas `JSON.generate` validates and raises `JSON::GeneratorError` on invalid byte sequences. For a log shipper this raise is a footgun — a single bad byte in one record would fail the whole chunk write and trigger retries/backpressure.

1. Future Compatibility: `yajl-ruby` is no longer actively maintained and relies on internal C APIs that are removed in Ruby 4.1. Migrating to the standard `json` gem ensures the plugin can continue to be built and used in future Ruby environments. Ref. https://github.com/ruby/ruby/pull/15447, https://github.com/brianmario/yajl-ruby/issues/233
2. Performance: The standard `json` gem has seen significant improvements in recent updates and now outperforms `yajl-ruby`.

```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
  gem 'yajl-ruby', require: 'yajl'
  gem 'json'
end

Benchmark.ips do |x|
  json = '{"a":"Alpha","b":true,"c":12345,"d":[true,[false,[-123456789,null],3.9676,["Something else.",false],null]],"e":{"zero":null,"one":1,"two":2,"three":[3],"four":[0,1,2,3,4]},"f":null,"h":{"a":{"b":{"c":{"d":{"e":{"f":{"g":null}}}}}}},"i":[[[[[[[null]]]]]]]}'

  x.report('Yajl.load') {
    Yajl.load(json)
  }
  x.report('JSON.parse') {
    JSON.parse(json)
  }

  x.compare!
end
```

```
ruby 4.0.5 (2026-05-20 revision 64336ffd0e) +PRISM [x86_64-linux]
Warming up --------------------------------------
           Yajl.load    20.019k i/100ms
          JSON.parse    80.144k i/100ms
Calculating -------------------------------------
           Yajl.load    202.875k (± 0.2%) i/s    (4.93 μs/i) -      1.021M in   5.032515s
          JSON.parse    808.103k (± 0.2%) i/s    (1.24 μs/i) -      4.087M in   5.057949s

Comparison:
JSON.parse:   808103.0 i/s
 Yajl.load:   202874.5 i/s - 3.98x  slower
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
- Behavior change: with `line_format json`, invalid UTF-8 in a log line is now emitted as `?` instead of being passed through as raw (invalid-JSON) bytes. The corresponding spec is updated to assert the sanitized output.
- To pass tests in CI, it requires https://github.com/grafana/loki/pull/22854 changes.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
