### PR TITLE
fix(chunkenc): reject out-of-range varint lengths when decoding chunks

### DIFF
--- a/pkg/chunkenc/encoding_helpers.go
+++ b/pkg/chunkenc/encoding_helpers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"hash"
 	"hash/crc32"
+	"math"
 )
 
 // encbuf is a helper type to populate a byte slice with various types.
@@ -59,7 +60,17 @@ type decbuf struct {
 	e error
 }
 
-func (d *decbuf) uvarint() int { return int(d.uvarint64()) }
+func (d *decbuf) uvarint() int {
+	x := d.uvarint64()
+	// A varint larger than math.MaxInt would wrap to a negative int, which then
+	// slips past the len(d.b) < n bounds check in bytes() and turns into a
+	// negative make/reslice length at the call sites. Reject it here instead.
+	if x > math.MaxInt {
+		d.e = ErrInvalidSize
+		return 0
+	}
+	return int(x)
+}
 
 // crc32 returns a CRC32 checksum over the remaining bytes.
 func (d *decbuf) crc32() uint32 {

--- a/pkg/chunkenc/encoding_helpers_test.go
+++ b/pkg/chunkenc/encoding_helpers_test.go
@@ -1,0 +1,48 @@
+package chunkenc
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecbufUvarintRejectsOverflow(t *testing.T) {
+	tmp := make([]byte, binary.MaxVarintLen64)
+
+	// A varint that does not fit in an int must be rejected rather than
+	// wrapping to a negative value.
+	n := binary.PutUvarint(tmp, uint64(math.MaxUint64))
+	d := decbuf{b: tmp[:n]}
+	require.Equal(t, 0, d.uvarint())
+	require.ErrorIs(t, d.err(), ErrInvalidSize)
+
+	// A value that fits is still decoded unchanged.
+	n = binary.PutUvarint(tmp, 12345)
+	d = decbuf{b: tmp[:n]}
+	require.Equal(t, 12345, d.uvarint())
+	require.NoError(t, d.err())
+}
+
+// A head block whose entry count varint exceeds math.MaxInt used to wrap to a
+// negative int and panic in make([]entry, ln). It must now fail cleanly.
+func TestHeadBlockLoadBytesRejectsOverflowingLength(t *testing.T) {
+	tmp := make([]byte, binary.MaxVarintLen64)
+	var b []byte
+	b = append(b, ChunkFormatV3) // version
+
+	n := binary.PutUvarint(tmp, uint64(math.MaxUint64)) // entry count
+	b = append(b, tmp[:n]...)
+	n = binary.PutUvarint(tmp, 0) // size
+	b = append(b, tmp[:n]...)
+	n = binary.PutVarint(tmp, 0) // mint
+	b = append(b, tmp[:n]...)
+	n = binary.PutVarint(tmp, 0) // maxt
+	b = append(b, tmp[:n]...)
+
+	hb := &headBlock{}
+	require.NotPanics(t, func() {
+		require.Error(t, hb.LoadBytes(b))
+	})
+}

--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -1561,6 +1561,10 @@ func (si *bufferedIterator) moveNext() (int64, []byte, labels.Labels, bool) {
 	// TS and line length
 	decompressedBytes += 2 * binary.MaxVarintLen64
 
+	if lineSize < 0 {
+		si.err = fmt.Errorf("invalid line length in chunk: %d", lineSize)
+		return 0, nil, labels.EmptyLabels(), false
+	}
 	if lineSize >= maxLineLength {
 		si.err = fmt.Errorf("line too long %d, maximum %d", lineSize, maxLineLength)
 		return 0, nil, labels.EmptyLabels(), false
@@ -1629,6 +1633,11 @@ func (si *bufferedIterator) moveNext() (int64, []byte, labels.Labels, bool) {
 		l, nSymbolsWidth = binary.Uvarint(si.readBuf[symbolsSectionLengthWidth:si.readBufValid])
 		nSymbols = int(l)
 		lastAttempt = si.readBufValid
+	}
+
+	if nSymbols < 0 {
+		si.err = fmt.Errorf("invalid structured metadata symbol count in chunk: %d", nSymbols)
+		return 0, nil, labels.EmptyLabels(), false
 	}
 
 	// Number of labels


### PR DESCRIPTION
**What this PR does / why we need it**:

Decoding a chunk with a malformed length field panics the reader:

    panic: runtime error: makeslice: len out of range
        pkg/chunkenc/memchunk.go:323 (*headBlock).LoadBytes -> make([]entry, ln)

`decbuf.uvarint()` narrows the uint64 varint straight to `int`. A value above `math.MaxInt` wraps to a negative `int`, which then slips past the `len(d.b) < n` guard in `decbuf.bytes()` and lands as a negative length in `make`/reslice at the decode sites (`headBlock.LoadBytes`, `newByteChunk`, `unorderedHeadBlock.loadBytes`, `symbols`). The decbuf type documents that it does all bounds checking, so the fix belongs there: reject a varint that does not fit a non-negative `int`.

`bufferedIterator.moveNext` reads its line length and structured-metadata symbol count with `binary.Uvarint` directly rather than through `decbuf`, so it gets the same negative-length guard inline (the existing `lineSize >= maxLineLength` check only catches large positive values).

Reproducer is committed as `TestHeadBlockLoadBytesRejectsOverflowingLength` (panics before the change, returns an error after) plus `TestDecbufUvarintRejectsOverflow`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Behavior for valid chunks is unchanged; legitimate counts are far below `math.MaxInt`. The reject path reuses the existing `ErrInvalidSize`.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
