### PR TITLE
fix: YAML decode failures in recent versions of go-yaml

### DIFF
--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -586,7 +586,7 @@ func Test_PatternRateThreshold(t *testing.T) {
 	}{
 		{
 			name:     "when using default value",
-			yaml:     ``,
+			yaml:     `{}`,
 			expected: 1.0,
 		},
 		{


### PR DESCRIPTION
This commit fixes a bug in `Test_PatternRateThreshold` where it tries to decode an empty string as a valid YAML mapping. In recent versions of go-yaml, this returns an error "no documents in stream". To fix this, we instead use what is known in the YAML spec as a "flow mapping", which is equivalent of declaring an empty object in JSON.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
