### PR TITLE
chore: Fix linter errors on `main` branch

### DIFF
--- a/pkg/ruler/registry_test.go
+++ b/pkg/ruler/registry_test.go
@@ -724,7 +724,6 @@ func TestTenantRemoteWriteHeadersNotMutateOverrides(t *testing.T) {
 		limits: map[string]*validation.Limits{
 			additionalHeadersRWTenant: {
 				RulerRemoteWriteHeaders: validation.NewOverwriteMarshalingStringMap(sharedHeaders),
-				RulerEnableWALReplay:    true,
 			},
 		},
 	}
@@ -783,7 +782,6 @@ func TestTenantRemoteWriteHeadersConcurrentRefresh(t *testing.T) {
 		limits: map[string]*validation.Limits{
 			headersRaceTenant: {
 				RulerRemoteWriteHeaders: validation.NewOverwriteMarshalingStringMap(sharedHeaders),
-				RulerEnableWALReplay:    true,
 			},
 		},
 	}


### PR DESCRIPTION
### Summary

Linter/test compile errors appeared on main after merging https://github.com/grafana/loki/pull/22509 which was not up-to-date with main and missed a code change that got removed with the PR.