### PR TITLE
fix: ProduceSync hangs until context canceled if len(records) == 0

### DIFF
--- a/pkg/kafka/client/writer_client.go
+++ b/pkg/kafka/client/writer_client.go
@@ -302,6 +302,10 @@ func (c *Producer) Close() {
 // This function honors the configure max buffered bytes and refuse to produce a record, returnin kgo.ErrMaxBuffered,
 // if the configured limit is reached.
 func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.ProduceResults {
+	if len(records) == 0 {
+		return kgo.ProduceResults{}
+	}
+
 	c.produceRequestsTotal.Add(float64(len(records)))
 
 	// Call interceptor with all records if configured.

--- a/pkg/kafka/client/writer_client_test.go
+++ b/pkg/kafka/client/writer_client_test.go
@@ -85,6 +85,17 @@ func TestNewWriterClient(t *testing.T) {
 }
 
 func TestProducer(t *testing.T) {
+	t.Run("no records", func(t *testing.T) {
+		_, kafkaCfg := testkafka.CreateCluster(t, 1, "test-topic")
+		client, err := NewWriterClient("test-client", kafkaCfg, 100, log.NewNopLogger(), prometheus.NewRegistry())
+		require.NoError(t, err)
+
+		producer := NewProducer("test-producer", client, 1024*1024, prometheus.NewRegistry())
+
+		results := producer.ProduceSync(t.Context(), []*kgo.Record{})
+		require.Len(t, results, 0)
+	})
+
 	t.Run("on context canceled", func(t *testing.T) {
 		_, kafkaCfg := testkafka.CreateCluster(t, 1, "test-topic")
 		client, err := NewWriterClient("test-client", kafkaCfg, 100, log.NewNopLogger(), prometheus.NewRegistry())


### PR DESCRIPTION
**What this PR does / why we need it**:

This used to hang until the context was canceled.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
