### PR TITLE
fix(v2-engine): Match v1 logfmt non-strict behavior (silently swallow parse errors)

### DIFF
--- a/pkg/engine/internal/executor/expressions_test.go
+++ b/pkg/engine/internal/executor/expressions_test.go
@@ -678,7 +678,7 @@ func TestLogfmtParser(t *testing.T) {
 			},
 		},
 		{
-			name: "handle errors with error columns",
+			name: "non-strict handles errors without adding error columns",
 			schema: arrow.NewSchema([]arrow.Field{
 				semconv.FieldFromFQN("utf8.builtin.message", true),
 			}, nil),
@@ -690,25 +690,19 @@ func TestLogfmtParser(t *testing.T) {
 			requestedKeys:  []string{"level", "status"},
 			strict:         false,
 			keepEmpty:      false,
-			expectedFields: 4, // 4 columns: level, status, __error__, __error_details__
+			expectedFields: 2, // level, status — no __error__ / __error_details__ in non-strict.
 			expectedOutput: arrowtest.Rows{
 				{
-					"utf8.parsed.level":                   "info",
-					"utf8.parsed.status":                  "200",
-					semconv.ColumnIdentError.FQN():        "",
-					semconv.ColumnIdentErrorDetails.FQN(): "",
+					"utf8.parsed.level":  "info",
+					"utf8.parsed.status": "200",
 				},
 				{
-					"utf8.parsed.level":                   "error",
-					"utf8.parsed.status":                  nil,
-					semconv.ColumnIdentError.FQN():        types.LogfmtParserErrorType,
-					semconv.ColumnIdentErrorDetails.FQN(): "logfmt syntax error at pos 8 : unexpected '='",
+					"utf8.parsed.level":  "error",
+					"utf8.parsed.status": nil,
 				},
 				{
-					"utf8.parsed.level":                   nil,
-					"utf8.parsed.status":                  nil,
-					semconv.ColumnIdentError.FQN():        types.LogfmtParserErrorType,
-					semconv.ColumnIdentErrorDetails.FQN(): "logfmt syntax error at pos 27 : unterminated quoted value",
+					"utf8.parsed.level":  nil,
+					"utf8.parsed.status": nil,
 				},
 			},
 		},
@@ -751,7 +745,7 @@ func TestLogfmtParser(t *testing.T) {
 			},
 		},
 		{
-			name: "extract all keys with errors when none requested",
+			name: "non-strict extract all keys ignores errors, no error columns",
 			schema: arrow.NewSchema([]arrow.Field{
 				semconv.FieldFromFQN("utf8.builtin.message", true),
 			}, nil),
@@ -764,39 +758,31 @@ func TestLogfmtParser(t *testing.T) {
 			requestedKeys:  nil, // nil means extract all keys
 			strict:         false,
 			keepEmpty:      false,
-			expectedFields: 6, // 5 columns: level, method, status, code __error__, __error_details__
+			expectedFields: 4, // level, method, status, code — no __error__ / __error_details__.
 			expectedOutput: arrowtest.Rows{
 				{
-					"utf8.parsed.level":                   "info",
-					"utf8.parsed.method":                  "GET",
-					"utf8.parsed.status":                  "200",
-					"utf8.parsed.code":                    nil,
-					semconv.ColumnIdentError.FQN():        "",
-					semconv.ColumnIdentErrorDetails.FQN(): "",
+					"utf8.parsed.level":  "info",
+					"utf8.parsed.method": "GET",
+					"utf8.parsed.status": "200",
+					"utf8.parsed.code":   nil,
 				},
 				{
-					"utf8.parsed.level":                   nil,
-					"utf8.parsed.method":                  nil,
-					"utf8.parsed.status":                  nil,
-					"utf8.parsed.code":                    "500",
-					semconv.ColumnIdentError.FQN():        types.LogfmtParserErrorType,
-					semconv.ColumnIdentErrorDetails.FQN(): "logfmt syntax error at pos 7 : unexpected '='",
+					"utf8.parsed.level":  nil,
+					"utf8.parsed.method": nil,
+					"utf8.parsed.status": nil,
+					"utf8.parsed.code":   "500",
 				},
 				{
-					"utf8.parsed.level":                   nil,
-					"utf8.parsed.method":                  nil,
-					"utf8.parsed.status":                  nil,
-					"utf8.parsed.code":                    nil,
-					semconv.ColumnIdentError.FQN():        types.LogfmtParserErrorType,
-					semconv.ColumnIdentErrorDetails.FQN(): "logfmt syntax error at pos 38 : unterminated quoted value",
+					"utf8.parsed.level":  nil,
+					"utf8.parsed.method": nil,
+					"utf8.parsed.status": nil,
+					"utf8.parsed.code":   nil,
 				},
 				{
-					"utf8.parsed.level":                   "debug",
-					"utf8.parsed.method":                  "POST",
-					"utf8.parsed.status":                  nil,
-					"utf8.parsed.code":                    nil,
-					semconv.ColumnIdentError.FQN():        "",
-					semconv.ColumnIdentErrorDetails.FQN(): "",
+					"utf8.parsed.level":  "debug",
+					"utf8.parsed.method": "POST",
+					"utf8.parsed.status": nil,
+					"utf8.parsed.code":   nil,
 				},
 			},
 		},
@@ -992,7 +978,7 @@ func TestLogfmtParser(t *testing.T) {
 			},
 		},
 		{
-			name: "non-strict mode of logfmt includes partial parsed columns",
+			name: "non-strict mode of logfmt includes partial parsed columns without error labels",
 			schema: arrow.NewSchema([]arrow.Field{
 				semconv.FieldFromFQN("utf8.builtin.message", true),
 			}, nil),
@@ -1004,28 +990,22 @@ func TestLogfmtParser(t *testing.T) {
 			requestedKeys:  []string{"status", "level", "method"},
 			strict:         false,
 			keepEmpty:      false,
-			expectedFields: 5, // status, level, method, __error__, __error_details__
+			expectedFields: 3, // status, level, method — no __error__ / __error_details__.
 			expectedOutput: arrowtest.Rows{
 				{
-					"utf8.parsed.status":               "200",
-					"utf8.parsed.level":                "info",
-					"utf8.parsed.method":               "GET",
-					"utf8.generated.__error__":         "",
-					"utf8.generated.__error_details__": "",
+					"utf8.parsed.status": "200",
+					"utf8.parsed.level":  "info",
+					"utf8.parsed.method": "GET",
 				},
 				{
-					"utf8.parsed.status":               "500",
-					"utf8.parsed.level":                nil,
-					"utf8.parsed.method":               "POST",
-					"utf8.generated.__error__":         "LogfmtParserErr",
-					"utf8.generated.__error_details__": "logfmt syntax error at pos 18 : unexpected '='",
+					"utf8.parsed.status": "500",
+					"utf8.parsed.level":  nil,
+					"utf8.parsed.method": "POST",
 				},
 				{
-					"utf8.parsed.status":               "201",
-					"utf8.parsed.level":                "debug",
-					"utf8.parsed.method":               nil,
-					"utf8.generated.__error__":         "",
-					"utf8.generated.__error_details__": "",
+					"utf8.parsed.status": "201",
+					"utf8.parsed.level":  "debug",
+					"utf8.parsed.method": nil,
 				},
 			},
 		},

--- a/pkg/engine/internal/executor/parse_logfmt.go
+++ b/pkg/engine/internal/executor/parse_logfmt.go
@@ -65,11 +65,10 @@ func tokenizeLogfmt(input string, requestedKeys []string, strict bool, keepEmpty
 	// Check for parsing errors
 	if err := decoder.Err(); err != nil {
 		if strict {
-			// In strict mode, return the error immediately
+			// In strict mode, return the error immediately.
 			return nil, err
 		}
-		// In non-strict mode, return partial results with the error
-		return result, err
+		// Do not return any error in non-struct mode.
 	}
 
 	return result, nil

--- a/pkg/engine/internal/executor/parse_logfmt.go
+++ b/pkg/engine/internal/executor/parse_logfmt.go
@@ -68,7 +68,7 @@ func tokenizeLogfmt(input string, requestedKeys []string, strict bool, keepEmpty
 			// In strict mode, return the error immediately.
 			return nil, err
 		}
-		// Do not return any error in non-struct mode.
+		// Do not return any error in non-strict mode.
 	}
 
 	return result, nil

--- a/pkg/engine/internal/executor/project_test.go
+++ b/pkg/engine/internal/executor/project_test.go
@@ -839,41 +839,34 @@ func TestNewProjectPipeline_DuplicateColumnPanic(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedRows := arrowtest.Rows{
-			// Row 1: JSON parsed status="200", logfmt fails (null) → keep "200"
+			// Row 1: JSON parsed status="200", logfmt fails → keep "200".
+			// Non-strict logfmt does not add [__error__] / [__error_details__].
 			{
-				"utf8.builtin.message":             `{"level":"info","status":200}`,
-				"utf8.generated.__error__":         "LogfmtParserErr",
-				"utf8.generated.__error_details__": "logfmt syntax error at pos 2 : unexpected '\"'",
-				"utf8.parsed.level":                nil, // logfmt didn't parse, so null
-				"utf8.parsed.method":               nil,
-				"utf8.parsed.status":               "200", // Kept from original JSON parse
+				"utf8.builtin.message": `{"level":"info","status":200}`,
+				"utf8.parsed.level":    nil, // logfmt didn't parse, so null
+				"utf8.parsed.method":   nil,
+				"utf8.parsed.status":   "200", // Kept from original JSON parse
 			},
 			// Row 2: No previous status (null), logfmt parses status="404" → use "404"
 			{
-				"utf8.builtin.message":             `level=info status=404 method=GET`,
-				"utf8.generated.__error__":         "",
-				"utf8.generated.__error_details__": "",
-				"utf8.parsed.level":                "info",
-				"utf8.parsed.method":               "GET",
-				"utf8.parsed.status":               "404",
+				"utf8.builtin.message": `level=info status=404 method=GET`,
+				"utf8.parsed.level":    "info",
+				"utf8.parsed.method":   "GET",
+				"utf8.parsed.status":   "404",
 			},
-			// Row 3: JSON parsed status="500", logfmt fails (null) → keep "500"
+			// Row 3: JSON parsed status="500", logfmt fails → keep "500"
 			{
-				"utf8.builtin.message":             `{"level":"error","status":500}`,
-				"utf8.generated.__error__":         "LogfmtParserErr",
-				"utf8.generated.__error_details__": "logfmt syntax error at pos 2 : unexpected '\"'",
-				"utf8.parsed.level":                nil, // logfmt didn't parse, so null
-				"utf8.parsed.method":               nil,
-				"utf8.parsed.status":               "500", // Kept from original JSON parse
+				"utf8.builtin.message": `{"level":"error","status":500}`,
+				"utf8.parsed.level":    nil,
+				"utf8.parsed.method":   nil,
+				"utf8.parsed.status":   "500",
 			},
 			// Row 4: No previous status (null), logfmt also does't parse status
 			{
-				"utf8.builtin.message":             `level=info method=GET`,
-				"utf8.generated.__error__":         "",
-				"utf8.generated.__error_details__": "",
-				"utf8.parsed.level":                "info",
-				"utf8.parsed.method":               "GET",
-				"utf8.parsed.status":               nil,
+				"utf8.builtin.message": `level=info method=GET`,
+				"utf8.parsed.level":    "info",
+				"utf8.parsed.method":   "GET",
+				"utf8.parsed.status":   nil,
 			},
 		}
 

--- a/pkg/logql/bench/queries/regression/log-queries.yaml
+++ b/pkg/logql/bench/queries/regression/log-queries.yaml
@@ -91,3 +91,28 @@ queries:
       category and extends the input-deletion logic to remove targets in
       addition to rename sources — a regression here would land at the
       result-builder boundary, not at the executor unit test.
+  - description: non-strict logfmt on an unparseable line must not add __error__ (matches v1 silent-swallow)
+    query: ${SELECTOR} | logfmt
+    kind: log
+    time_range:
+      length: 24h
+    directions: backward # forward log queries unsupported by v2 engine
+    tags:
+      - logfmt
+      - parser-error
+      - non-strict
+      - stream-identity
+    requires:
+      log_format: unstructured
+    notes: >
+      Regression for the v1↔v2 stream_missing / stream_entry_count_mismatch
+      goldfish reports. v1's [log.LogfmtParser] only sets [__error__] when
+      strict=true (see `l.strict && l.dec.Err() != nil` guard in
+      pkg/logql/log/parser.go); default `| logfmt` is non-strict and
+      silently swallows parse errors. v2's executor used to unconditionally
+      surface parse errors via [__error__] / [__error_details__], which
+      changed stream identity for the same underlying rows and produced
+      per-stream diffs vs v1 whenever the log line wasn't logfmt-formatted
+      (plain-text lines, embedded JSON bodies with `"`, etc). Stream label
+      sets and per-stream entry counts must match v1 across parseable and
+      unparseable lines.


### PR DESCRIPTION
**What this PR does / why we need it**:

#### What

In non-strict mode, `| logfmt` in the v2 engine no longer attaches `__error__` / `__error_details__` columns to unparseable rows. Matches v1's `log.LogfmtParser`, which only sets the error label when `strict=true`.

#### Why

For any log line that isn't logfmt-formatted (plain-text lines, embedded JSON bodies, etc.), the v2 executor was surfacing the decoder error via `__error__` even for the default non-strict parser. Same rows on both engines, therefore carried different label sets(v2 had two extra labels), which changed stream identity and broke v1↔v2 parity.
