### PR TITLE
perf(querier): Avoid expensive shuffle sharding when shardSize=0

### DIFF
--- a/pkg/querier/ingester_querier.go
+++ b/pkg/querier/ingester_querier.go
@@ -173,15 +173,18 @@ func (q *IngesterQuerier) forAllIngesters(ctx context.Context, f func(context.Co
 			return nil, err
 		}
 		shardSize := q.getShardCountForTenant(tenantID)
-		subring := q.partitionRing
-		// Do not shuffle shard if the shard size is 0. When the size is 0, it
-		// creates a shuffle shard which contains the complete set of partitions,
-		// which is the same as not shuffle sharding at all.
-		if shardSize > 0 {
-			subring, err = q.partitionRing.ShuffleShardWithLookback(tenantID, shardSize, q.querierConfig.QueryIngestersWithin, time.Now())
-			if err != nil {
-				return nil, err
-			}
+		// When the tenant has no configured shard size, share a single subring
+		// across all such tenants by using a fixed identifier. The resulting set
+		// of partitions is tenant-independent when size == 0, so per-tenant
+		// shuffle sharding would just waste CPU and cache memory recomputing the
+		// same answer.
+		shuffleShardIdentifier := tenantID
+		if shardSize == 0 {
+			shuffleShardIdentifier = ""
+		}
+		subring, err := q.partitionRing.ShuffleShardWithLookback(shuffleShardIdentifier, shardSize, q.querierConfig.QueryIngestersWithin, time.Now())
+		if err != nil {
+			return nil, err
 		}
 		replicationSets, err := subring.GetReplicationSetsForOperation(ring.Read)
 		if err != nil {

--- a/pkg/querier/ingester_querier.go
+++ b/pkg/querier/ingester_querier.go
@@ -172,10 +172,16 @@ func (q *IngesterQuerier) forAllIngesters(ctx context.Context, f func(context.Co
 		if err != nil {
 			return nil, err
 		}
-		tenantShards := q.getShardCountForTenant(tenantID)
-		subring, err := q.partitionRing.ShuffleShardWithLookback(tenantID, tenantShards, q.querierConfig.QueryIngestersWithin, time.Now())
-		if err != nil {
-			return nil, err
+		shardSize := q.getShardCountForTenant(tenantID)
+		subring := q.partitionRing
+		// Do not shuffle shard if the shard size is 0. When the size is 0, it
+		// creates a shuffle shard which contains the complete set of partitions,
+		// which is the same as not shuffle sharding at all.
+		if shardSize > 0 {
+			subring, err = q.partitionRing.ShuffleShardWithLookback(tenantID, shardSize, q.querierConfig.QueryIngestersWithin, time.Now())
+			if err != nil {
+				return nil, err
+			}
 		}
 		replicationSets, err := subring.GetReplicationSetsForOperation(ring.Read)
 		if err != nil {


### PR DESCRIPTION
When running at very high scale, this operation becomes expensive either in terms of CPU to create the shuffle shards, or memory to cache them.

This is similar to the change in https://github.com/grafana/loki/commit/34e5cc937e8ef3802de9cdb5b98607ac0eef1486 on the distributor side.

We can't just skip the call to ShuffleShardWithLookback altogether because we need the logic within it to filter based on partition states - we want ACTIVE partitions and and LEAVING partitions within the lookback period, but not PENDING or JOINING partitions. Pulling this logic over itself would be about 40 lines of code duplicated across from dskit, so I prefer to do this slightly hacky change instead, with the expectation that we're going to have to re-visit this code anyway as this implementation of shuffle sharding doesn't scale very well.

This has been run in a pre-production environment overnight without any problems. 