### PR TITLE
chore: Reduce map accesses in aggregations

### DIFF
--- a/pkg/engine/internal/executor/aggregator.go
+++ b/pkg/engine/internal/executor/aggregator.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"errors"
 	"maps"
+	"math"
 	"slices"
 	"strings"
 	"time"
@@ -56,10 +57,13 @@ const (
 
 // aggregator is used to aggregate sample values by a set of grouping keys for each point in time.
 type aggregator struct {
-	points    map[time.Time]map[uint64]*groupState // holds the groupState for each point in time series
-	digest    *xxhash.Digest                       // used to compute key for each group
-	operation aggregationOperation                 // aggregation type
-	labels    map[string]arrow.Field               // combined list of all label fields for all sample values
+	points    map[uint64][]groupState // holds the groupState for each point in time series
+	digest    *xxhash.Digest          // used to compute key for each group
+	operation aggregationOperation    // aggregation type
+	labels    map[string]arrow.Field  // combined list of all label fields for all sample values
+	from      int64
+	to        int64
+	step      int64
 
 	// Track unique series across all timestamps to enforce maxSeries limit
 	maxSeries    int                          // maximum number of unique series allowed (0 means no limit)
@@ -70,19 +74,17 @@ type aggregator struct {
 }
 
 // newAggregator creates a new aggregator with the specified grouping.
-func newAggregator(pointsSizeHint int, operation aggregationOperation) *aggregator {
+func newAggregator(operation aggregationOperation, from time.Time, to time.Time, step time.Duration) *aggregator {
 	a := aggregator{
 		digest:       xxhash.New(),
 		operation:    operation,
 		labels:       make(map[string]arrow.Field),
 		uniqueSeries: make(map[uint64]map[string]string),
 		interner:     &interner{interned: make(map[string]string, 16)}, // 16 is arbitrary initial capacity
-	}
-
-	if pointsSizeHint > 0 {
-		a.points = make(map[time.Time]map[uint64]*groupState, pointsSizeHint)
-	} else {
-		a.points = make(map[time.Time]map[uint64]*groupState)
+		from:         from.UnixNano(),
+		to:           to.UnixNano(),
+		step:         step.Nanoseconds(),
+		points:       make(map[uint64][]groupState),
 	}
 
 	return &a
@@ -103,39 +105,30 @@ func (a *aggregator) SetMaxSeries(maxSeries int) {
 	a.maxSeries = maxSeries
 }
 
-func (a *aggregator) add(ts time.Time, value float64, key uint64) {
-	point, ok := a.points[ts]
+func (a *aggregator) add(ts int64, value float64, key uint64) {
+	timesForKey, ok := a.points[key]
 	if !ok {
-		point = make(map[uint64]*groupState)
-		a.points[ts] = point
+		timesForKey = make([]groupState, 1+(a.to-a.from)/a.step)
+		a.points[key] = timesForKey
 	}
 
-	if state, ok := point[key]; ok {
-		// TODO: handle hash collisions
-
-		// accumulate value based on aggregation type
-		switch a.operation {
-		case aggregationOperationSum:
-			state.value += value
-		case aggregationOperationMax:
-			if value > state.value {
-				state.value = value
-			}
-		case aggregationOperationMin:
-			if value < state.value {
-				state.value = value
-			}
-		case aggregationOperationAvg:
-			state.value += value
+	timeIndex := (ts - a.from) / a.step
+	switch a.operation {
+	case aggregationOperationSum:
+		timesForKey[timeIndex].value += value
+	case aggregationOperationMax:
+		timesForKey[timeIndex].value = math.Max(timesForKey[timeIndex].value, value)
+	case aggregationOperationMin:
+		if timesForKey[timeIndex].count == 0 {
+			timesForKey[timeIndex].value = value
+		} else {
+			timesForKey[timeIndex].value = math.Min(timesForKey[timeIndex].value, value)
 		}
-
-		state.count++
-	} else {
-		point[key] = &groupState{
-			value: value,
-			count: int64(1),
-		}
+	case aggregationOperationAvg:
+		timesForKey[timeIndex].value += value
 	}
+
+	timesForKey[timeIndex].count++
 }
 
 // AddN adds new sample values to the aggregation for the given timestamps and grouping labels.
@@ -185,7 +178,7 @@ func (a *aggregator) AddN(timestamps []time.Time, value float64, labels []arrow.
 
 	// Add all observations to the aggregation
 	for _, ts := range timestamps {
-		a.add(ts, value, key)
+		a.add(ts.UnixNano(), value, key)
 	}
 
 	return nil
@@ -208,15 +201,20 @@ func (a *aggregator) BuildRecord() (arrow.RecordBatch, error) {
 
 	// preallocate all builders to the total amount of rows
 	total := 0
-	for _, ts := range sortedTimestamps {
-		total += len(a.points[ts])
-	}
+	total += len(a.points) * int((a.to-a.from)/a.step)
 	rb.Reserve(total)
 
-	for _, ts := range sortedTimestamps {
-		tsValue, _ := arrow.TimestampFromTime(ts, arrow.Nanosecond)
+	// Iterate over the timestamps in order to produce a timestamp ordered output
+	// It is more efficient to iterate over each series but then the output would not be ordered.
+	for i, timestamp := range sortedTimestamps {
+		for key, points := range a.points {
+			entry := points[i]
+			if entry.count == 0 {
+				continue
+			}
 
-		for key, entry := range a.points[ts] {
+			tsValue := arrow.Timestamp(timestamp)
+
 			var value float64
 			switch a.operation {
 			case aggregationOperationAvg:
@@ -258,8 +256,10 @@ func (a *aggregator) Reset() {
 }
 
 // getSortedTimestamps returns all timestamps in sorted order
-func (a *aggregator) getSortedTimestamps() []time.Time {
-	return slices.SortedFunc(maps.Keys(a.points), func(a, b time.Time) int {
-		return a.Compare(b)
-	})
+func (a *aggregator) getSortedTimestamps() []int64 {
+	timestamps := make([]int64, 0, (a.to-a.from)/a.step)
+	for i := a.from; i <= a.to; i += a.step {
+		timestamps = append(timestamps, i)
+	}
+	return timestamps
 }

--- a/pkg/engine/internal/executor/aggregator_test.go
+++ b/pkg/engine/internal/executor/aggregator_test.go
@@ -26,11 +26,11 @@ func TestAggregator(t *testing.T) {
 	colSvc := semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String).FQN()
 
 	t.Run("basic SUM aggregation with record building", func(t *testing.T) {
-		agg := newAggregator(10, aggregationOperationSum)
-		agg.AddLabels(groupBy)
-
 		ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
+
+		agg := newAggregator(aggregationOperationSum, ts1, ts2, ts2.Sub(ts1))
+		agg.AddLabels(groupBy)
 
 		// Add test data
 		// ts1: prod/app1 = 10, prod/app2 = 20, dev/app1 = 30
@@ -66,11 +66,11 @@ func TestAggregator(t *testing.T) {
 	})
 
 	t.Run("basic AVG aggregation with record building", func(t *testing.T) {
-		agg := newAggregator(10, aggregationOperationAvg)
-		agg.AddLabels(groupBy)
-
 		ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
+
+		agg := newAggregator(aggregationOperationAvg, ts1, ts2, ts2.Sub(ts1))
+		agg.AddLabels(groupBy)
 
 		// Add test data
 		// ts1: prod/app1 = 10, prod/app2 = 20, dev/app1 = 30
@@ -107,12 +107,13 @@ func TestAggregator(t *testing.T) {
 	})
 
 	t.Run("basic COUNT aggregation with record building", func(t *testing.T) {
-		agg := newAggregator(10, aggregationOperationCount)
-		agg.AddLabels(groupBy)
 
 		ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
 		ts3 := time.Date(2024, 1, 1, 10, 2, 0, 0, time.UTC)
+
+		agg := newAggregator(aggregationOperationCount, ts1, ts3, ts2.Sub(ts1))
+		agg.AddLabels(groupBy)
 
 		// Add test data
 		// ts1: add one datapoint for prod/app1, prod/app2, and dev/app1
@@ -159,11 +160,11 @@ func TestAggregator(t *testing.T) {
 	})
 
 	t.Run("basic MAX aggregation with record building", func(t *testing.T) {
-		agg := newAggregator(10, aggregationOperationMax)
-		agg.AddLabels(groupBy)
-
 		ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
+
+		agg := newAggregator(aggregationOperationMax, ts1, ts2, ts2.Sub(ts1))
+		agg.AddLabels(groupBy)
 
 		// Add test data
 		// ts1: add one datapoint for prod/app1, prod/app2, and dev/app1
@@ -201,11 +202,11 @@ func TestAggregator(t *testing.T) {
 	})
 
 	t.Run("basic MIN aggregation with record building", func(t *testing.T) {
-		agg := newAggregator(10, aggregationOperationMin)
-		agg.AddLabels(groupBy)
-
 		ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
+
+		agg := newAggregator(aggregationOperationMin, ts1, ts2, ts2.Sub(ts1))
+		agg.AddLabels(groupBy)
 
 		// Add test data
 		// ts1: add one datapoint for prod/app1, prod/app2, and dev/app1
@@ -246,11 +247,11 @@ func TestAggregator(t *testing.T) {
 		// Empty groupBy represents sum by () or sum(...) - all values aggregated into single group
 		groupBy := []arrow.Field{}
 
-		agg := newAggregator(1, aggregationOperationSum)
-		agg.AddLabels(groupBy)
-
 		ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
+
+		agg := newAggregator(aggregationOperationSum, ts1, ts2, ts2.Sub(ts1))
+		agg.AddLabels(groupBy)
 
 		// Add test data
 		// ts1: prod/app1 = 10, prod/app2 = 20, dev/app1 = 30
@@ -283,10 +284,10 @@ func TestAggregator(t *testing.T) {
 	})
 
 	t.Run("basic SUM aggregation with without() grouping", func(t *testing.T) {
-		agg := newAggregator(10, aggregationOperationSum)
-
 		ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
+
+		agg := newAggregator(aggregationOperationSum, ts1, ts2, ts2.Sub(ts1))
 
 		buildFields := func(names ...string) []arrow.Field {
 			result := make([]arrow.Field, len(names))
@@ -334,12 +335,12 @@ func TestAggregator(t *testing.T) {
 	})
 
 	t.Run("series limit enforcement", func(t *testing.T) {
-		agg := newAggregator(10, aggregationOperationSum)
-		agg.AddLabels(groupBy)
-		agg.SetMaxSeries(3) // Limit to 3 series
-
 		ts1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 		ts2 := time.Date(2024, 1, 1, 10, 1, 0, 0, time.UTC)
+
+		agg := newAggregator(aggregationOperationSum, ts1, ts2, ts2.Sub(ts1))
+		agg.AddLabels(groupBy)
+		agg.SetMaxSeries(3) // Limit to 3 series
 
 		// Add first 3 series at ts1 - should succeed
 		err := agg.AddN([]time.Time{ts1}, 10, groupBy, []string{"prod", "app1"})
@@ -376,12 +377,14 @@ func BenchmarkAggregator(b *testing.B) {
 		semconv.FieldFromIdent(semconv.NewIdentifier("service", types.ColumnTypeLabel, types.Loki.String), true),
 	}
 
-	agg := newAggregator(10, aggregationOperationSum)
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	agg := newAggregator(aggregationOperationSum, start, end, 60*time.Second)
 	agg.AddLabels(fields)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(i) * time.Second)
+		ts := start.Add(time.Duration(i%3600) * time.Second)
 		env := fmt.Sprintf("env-%d", i%3)
 		cluster := fmt.Sprintf("cluster-%d", i%10)
 		service := fmt.Sprintf("service-%d", i%7)

--- a/pkg/engine/internal/executor/executor.go
+++ b/pkg/engine/internal/executor/executor.go
@@ -475,6 +475,9 @@ func (c *Context) executeVectorAggregation(ctx context.Context, plan *physical.V
 		grouping:       plan.Grouping,
 		operation:      plan.Operation,
 		maxQuerySeries: plan.MaxQuerySeries,
+		start:          plan.Start,
+		end:            plan.End,
+		step:           plan.Step,
 	})
 	if err != nil {
 		return errorPipeline(ctx, err)
@@ -665,6 +668,9 @@ func nodeAttributes(n physical.Node) []attribute.KeyValue {
 			attribute.String("operation", string(rune(n.Operation))),
 			attribute.Int("num_grouping", len(n.Grouping.Columns)),
 			attribute.Bool("grouping_without", n.Grouping.Without),
+			attribute.Int64("start_ts", n.Start.UnixNano()),
+			attribute.Int64("end_ts", n.End.UnixNano()),
+			attribute.Int64("step", int64(n.Step)),
 		)
 
 	case *physical.ColumnCompat:

--- a/pkg/engine/internal/executor/range_aggregation.go
+++ b/pkg/engine/internal/executor/range_aggregation.go
@@ -116,7 +116,12 @@ func (r *rangeAggregationPipeline) init() {
 		panic(fmt.Sprintf("unknown range aggregation operation: %v", r.opts.operation))
 	}
 
-	r.aggregator = newAggregator(len(windows), op)
+	if r.opts.startTs == r.opts.endTs {
+		// Instant query
+		r.opts.step = 1
+	}
+
+	r.aggregator = newAggregator(op, r.opts.startTs, r.opts.endTs, r.opts.step)
 	r.aggregator.SetMaxSeries(r.opts.maxQuerySeries)
 }
 

--- a/pkg/engine/internal/executor/vector_aggregate.go
+++ b/pkg/engine/internal/executor/vector_aggregate.go
@@ -21,6 +21,11 @@ type vectorAggregationOptions struct {
 	grouping       physical.Grouping
 	operation      types.VectorAggregationType
 	maxQuerySeries int // maximum number of unique series allowed (0 means no limit)
+
+	// Hints for more efficient processing
+	start time.Time
+	end   time.Time
+	step  time.Duration
 }
 
 // vectorAggregationPipeline is a pipeline that performs vector aggregations.
@@ -60,7 +65,12 @@ func newVectorAggregationPipeline(inputs []Pipeline, evaluator *expressionEvalua
 		panic(fmt.Sprintf("unknown vector aggregation operation: %v", opts.operation))
 	}
 
-	agg := newAggregator(0, op)
+	if opts.start == opts.end {
+		// Instant query
+		opts.step = 1
+	}
+
+	agg := newAggregator(op, opts.start, opts.end, opts.step)
 	agg.SetMaxSeries(opts.maxQuerySeries)
 
 	return &vectorAggregationPipeline{

--- a/pkg/engine/internal/executor/vector_aggregate_test.go
+++ b/pkg/engine/internal/executor/vector_aggregate_test.go
@@ -95,6 +95,9 @@ func TestVectorAggregationPipeline(t *testing.T) {
 		grouping:       grouping,
 		operation:      types.VectorAggregationTypeSum,
 		maxQuerySeries: 0, // no limit for test
+		start:          t1,
+		end:            t3,
+		step:           t2.Sub(t1),
 	})
 	require.NoError(t, err)
 	defer pipeline.Close()
@@ -196,6 +199,8 @@ func TestVectorAggregationPipeline_MissingGroupingColumn(t *testing.T) {
 		},
 		operation:      types.VectorAggregationTypeSum,
 		maxQuerySeries: 0,
+		start:          ts,
+		end:            ts,
 	}
 
 	inputA := NewArrowtestPipeline(schemaWithLevel, rowsWithLevel)
@@ -296,6 +301,8 @@ func TestVectorAggregationPipeline_WithoutGroupsByShortName(t *testing.T) {
 		},
 		operation:      types.VectorAggregationTypeSum,
 		maxQuerySeries: 0,
+		start:          ts,
+		end:            ts,
 	}
 
 	inputA := NewArrowtestPipeline(schemaA, rowsA)
@@ -390,6 +397,8 @@ func TestVectorAggregationPipeline_WithoutSortsColumns(t *testing.T) {
 		},
 		operation:      types.VectorAggregationTypeSum,
 		maxQuerySeries: 0,
+		start:          ts,
+		end:            ts,
 	}
 
 	inputA := NewArrowtestPipeline(schemaA, rowsA)

--- a/pkg/engine/internal/planner/logical/builder.go
+++ b/pkg/engine/internal/planner/logical/builder.go
@@ -180,12 +180,17 @@ func (b *Builder) RangeAggregation(
 func (b *Builder) VectorAggregation(
 	grouping Grouping,
 	operation types.VectorAggregationType,
+	startTS, endTS time.Time,
+	step time.Duration,
 ) *Builder {
 	return &Builder{
 		val: &VectorAggregation{
 			Table:     b.val,
 			Grouping:  grouping,
 			Operation: operation,
+			Start:     startTS,
+			End:       endTS,
+			Step:      step,
 		},
 	}
 }

--- a/pkg/engine/internal/planner/logical/format_tree_test.go
+++ b/pkg/engine/internal/planner/logical/format_tree_test.go
@@ -174,6 +174,9 @@ func TestFormatVectorAggregationQuery(t *testing.T) {
 			Without: false,
 		},
 		types.VectorAggregationTypeSum,
+		time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC), // Start Time
+		time.Date(1970, 1, 1, 1, 0, 0, 0, time.UTC), // End Time
+		time.Minute,
 	)
 
 	// Convert to plan so that node IDs get populated

--- a/pkg/engine/internal/planner/logical/node_vector_aggregate.go
+++ b/pkg/engine/internal/planner/logical/node_vector_aggregate.go
@@ -2,6 +2,7 @@ package logical
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 )
@@ -18,6 +19,10 @@ type VectorAggregation struct {
 
 	// The type of aggregation operation to perform (e.g., sum, min, max)
 	Operation types.VectorAggregationType
+
+	Start time.Time
+	End   time.Time
+	Step  time.Duration
 }
 
 var (

--- a/pkg/engine/internal/planner/logical/planner.go
+++ b/pkg/engine/internal/planner/logical/planner.go
@@ -418,6 +418,9 @@ func walkVectorAggregation(e *syntax.VectorAggregationExpr, wc *walkContext) (Va
 		Table:     left,
 		Grouping:  convertGrouping(e.Grouping),
 		Operation: vecAggType,
+		Start:     wc.params.Start(),
+		End:       wc.params.End(),
+		Step:      wc.params.Step(),
 	}, nil
 }
 

--- a/pkg/engine/internal/planner/physical/node_vector_aggregate.go
+++ b/pkg/engine/internal/planner/physical/node_vector_aggregate.go
@@ -1,6 +1,8 @@
 package physical
 
 import (
+	"time"
+
 	"github.com/oklog/ulid/v2"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
@@ -19,6 +21,11 @@ type VectorAggregation struct {
 
 	// MaxQuerySeries is the maximum number of unique series allowed (0 means no limit)
 	MaxQuerySeries int
+
+	// Hints for more efficient processing
+	Start time.Time
+	End   time.Time
+	Step  time.Duration
 }
 
 // ID implements the [Node] interface.

--- a/pkg/engine/internal/planner/physical/planner.go
+++ b/pkg/engine/internal/planner/physical/planner.go
@@ -499,6 +499,10 @@ func (p *Planner) processVectorAggregation(lp *logical.VectorAggregation, ctx *C
 		},
 		Operation:      lp.Operation,
 		MaxQuerySeries: ctx.maxQuerySeries,
+		// Query hints for more efficient processing
+		Start: lp.Start,
+		End:   lp.End,
+		Step:  lp.Step,
 	}
 	p.plan.graph.Add(node)
 	child, err := p.process(lp.Table, ctx)

--- a/pkg/engine/internal/planner/physical/rule_projection_pushdown_test.go
+++ b/pkg/engine/internal/planner/physical/rule_projection_pushdown_test.go
@@ -495,6 +495,9 @@ func TestProjectionPushdown_PushesRequestedKeysToParseOperations(t *testing.T) {
 						Without: false,
 					},
 					types.VectorAggregationTypeSum,
+					time.Unix(0, 0),
+					time.Unix(3600, 0),
+					5*time.Minute,
 				)
 				return builder.Value()
 			},
@@ -582,6 +585,9 @@ func TestProjectionPushdown_PushesRequestedKeysToParseOperations(t *testing.T) {
 						Without: false,
 					},
 					types.VectorAggregationTypeSum,
+					time.Unix(0, 0),
+					time.Unix(3600, 0),
+					5*time.Minute,
 				)
 				return builder.Value()
 			},
@@ -665,6 +671,9 @@ func TestProjectionPushdown_PushesRequestedKeysToParseOperations(t *testing.T) {
 						Without: false,
 					},
 					types.VectorAggregationTypeSum,
+					time.Unix(0, 0),
+					time.Unix(3600, 0),
+					5*time.Minute,
 				)
 				return builder.Value()
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
Some metric queries, especially those with small steps that generate a lot of data points can take a significant amount of time in aggregation code, specifically fetching and updating points via map accesses.
Before
<img width="1664" height="503" alt="image" src="https://github.com/user-attachments/assets/1fc70017-dfa0-4264-9c7f-06c0080eab2e" />

I switch this around to have a map of series pointing to an array of points instead, which means fewer hashing and memory accesses as the array is more cache friendly. To support this, the aggregator needs to know how many points it will need, so I had to pipe the start/end/step into the aggregator. This was simple for range_aggregation but required a bit more plumbing for vector_aggregation which didn't previously need those parameters.

After
<img width="1656" height="471" alt="image" src="https://github.com/user-attachments/assets/f2a81760-e560-4fa7-88f8-42bedc028382" />

For sparse series that have few data points within the query time range, this could allocate more memory than necessary for the map equivalent, but I believe the performance is worth it. 

Aggregator's benchmark results
```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/engine/internal/executor
cpu: Apple M3 Max
              │ before.aggregator.txt │        after.aggregator.txt         │
              │        sec/op         │   sec/op     vs base                │
Aggregator-14             545.0n ± 1%   203.8n ± 0%  -62.61% (p=0.000 n=10)

              │ before.aggregator.txt │        after.aggregator.txt        │
              │         B/op          │    B/op     vs base                │
Aggregator-14             383.00 ± 1%   32.00 ± 0%  -91.64% (p=0.000 n=10)

              │ before.aggregator.txt │        after.aggregator.txt        │
              │       allocs/op       │ allocs/op   vs base                │
Aggregator-14              6.000 ± 0%   3.000 ± 0%  -50.00% (p=0.000 n=10)
```

Range Aggregation's benchmark results
```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/engine/internal/executor
cpu: Apple M3 Max
                                              │  before.txt   │           after.array.txt            │
                                              │    sec/op     │    sec/op     vs base                │
RangeAggregation/10_intervals-14                 4.256µ ±  0%   3.593µ ±  4%  -15.57% (p=0.000 n=10)
RangeAggregation/10_intervals,_10_series-14      13.12µ ±  1%   11.61µ ±  2%  -11.52% (p=0.000 n=10)
RangeAggregation/10_intervals,_1000_series-14   1028.5µ ±  1%   883.3µ ±  1%  -14.11% (p=0.000 n=10)
RangeAggregation/10_intervals,_100k_series-14    310.3m ± 26%   192.6m ± 28%  -37.92% (p=0.000 n=10)
geomean                                          365.4µ         290.3µ        -20.56%

                                              │  before.txt  │            after.array.txt            │
                                              │ datapoints/s │ datapoints/s   vs base                │
RangeAggregation/10_intervals-14                2.350M ±  0%    2.783M ±  4%  +18.44% (p=0.000 n=10)
RangeAggregation/10_intervals,_10_series-14     7.620M ±  1%    8.612M ±  2%  +13.02% (p=0.000 n=10)
RangeAggregation/10_intervals,_1000_series-14   9.723M ±  1%   11.321M ±  1%  +16.43% (p=0.000 n=10)
RangeAggregation/10_intervals,_100k_series-14   3.257M ± 33%    5.192M ± 22%  +59.39% (p=0.000 n=10)
geomean                                         4.880M          6.127M        +25.55%

                                              │  before.txt   │            after.array.txt            │
                                              │     B/op      │     B/op       vs base                │
RangeAggregation/10_intervals-14                5.139Ki ±  0%   4.783Ki ±  0%   -6.92% (p=0.000 n=10)
RangeAggregation/10_intervals,_10_series-14     9.653Ki ±  0%   8.594Ki ±  0%  -10.98% (p=0.000 n=10)
RangeAggregation/10_intervals,_1000_series-14   612.5Ki ±  0%   533.2Ki ±  0%  -12.95% (p=0.000 n=10)
RangeAggregation/10_intervals,_100k_series-14   77.20Mi ± 24%   47.64Mi ± 20%  -38.28% (p=0.000 n=10)
geomean                                         221.4Ki         180.8Ki        -18.32%

                                              │  before.txt  │           after.array.txt            │
                                              │  allocs/op   │  allocs/op    vs base                │
RangeAggregation/10_intervals-14                 65.00 ±  0%    57.00 ±  0%  -12.31% (p=0.000 n=10)
RangeAggregation/10_intervals,_10_series-14     127.00 ±  0%    74.00 ±  0%  -41.73% (p=0.000 n=10)
RangeAggregation/10_intervals,_1000_series-14   6.575k ±  0%   1.567k ±  0%  -76.17% (p=0.000 n=10)
RangeAggregation/10_intervals,_100k_series-14   825.1k ± 21%   167.0k ± 20%  -79.76% (p=0.000 n=10)
geomean                                         2.587k         1.025k        -60.38%
```