### PR TITLE
test(logql): Reproduce drop __error__ sharding cardinality explosion

### DIFF
--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -152,6 +152,34 @@ func TestMappingStrings(t *testing.T) {
 			)`,
 		},
 		{
+			// Baseline: sum(count_over_time(...)) with no label-reducing stage
+			// keeps the sum-pushdown optimization. Each shard leaf is
+			// sum(count_over_time(...)), so the extractor injects the outer
+			// grouping (noLabels=true) and collapses every line to {} at the
+			// source.
+			in: `sum(count_over_time({foo="bar"}[1m]))`,
+			out: `sum(
+				downstream<sum(count_over_time({foo="bar"}[1m])), shard=0_of_2>
+				++ downstream<sum(count_over_time({foo="bar"}[1m])), shard=1_of_2>
+			)`,
+		},
+		{
+			// Reproducer: adding `| drop __error__` trips ReducesLabels, which
+			// disables the sum-pushdown. The shard leaf becomes a bare
+			// count_over_time(...) whose extractor runs with noLabels=false, so
+			// GroupedLabels() retains the full labelset (stream + structured
+			// metadata) per series instead of {} — exploding intermediate
+			// cardinality even though the outer sum still collapses the final
+			// result.
+			in: `sum(count_over_time({foo="bar"} | drop __error__ [1m]))`,
+			out: `sum(
+				sum without() (
+					downstream<count_over_time({foo="bar"} | drop __error__[1m]), shard=0_of_2>
+					++ downstream<count_over_time({foo="bar"} | drop __error__[1m]), shard=1_of_2>
+				)
+			)`,
+		},
+		{
 			in: `max(count(rate({foo="bar"}[5m]))) / 2`,
 			out: `(max(
 				sum(

--- a/pkg/logql/syntax/extractor_test.go
+++ b/pkg/logql/syntax/extractor_test.go
@@ -1,6 +1,7 @@
 package syntax
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -108,6 +109,70 @@ func Test_Extractor(t *testing.T) {
 			require.Len(t, extractors, 1)
 		})
 	}
+}
+
+// Test_DropError_CardinalityExplosion reproduces the structured-metadata
+// cardinality explosion caused by adding `| drop __error__` to a
+// `sum(count_over_time(...))` query.
+//
+// The query-frontend shard mapper rewrites the two queries differently because
+// `drop` trips syntax.ReducesLabels:
+//
+//	sum(count_over_time({...}[r]))                   -> shard leaf: sum(count_over_time(...))
+//	sum(count_over_time({...} | drop __error__[r]))  -> shard leaf: count_over_time(...)  (bare)
+//
+// The `sum(count_over_time(...))` leaf injects the outer sum's grouping into the
+// extractor (noLabels=true), so LabelsBuilder.GroupedLabels() collapses every
+// line to {}. The bare count_over_time(...) leaf runs its extractor with
+// noLabels=false, so GroupedLabels() returns the full labelset — including all
+// structured metadata — for every line. That is the cardinality explosion.
+func Test_DropError_CardinalityExplosion(t *testing.T) {
+	t.Parallel()
+
+	stream := labels.FromStrings("job", "loki-prod-036/querier")
+	const numLines = 100
+
+	// extractSeries runs the query's extractor over numLines log lines, each
+	// carrying a unique structured-metadata value (the high-cardinality
+	// dimension that blows up, e.g. a trace_id), and returns the set of
+	// distinct output series identities.
+	extractSeries := func(t *testing.T, query string) map[string]struct{} {
+		t.Helper()
+		expr, err := ParseSampleExpr(query)
+		require.NoError(t, err)
+
+		extractors, err := expr.Extractors()
+		require.NoError(t, err)
+		require.Len(t, extractors, 1)
+
+		streamEx := extractors[0].ForStream(stream)
+		series := make(map[string]struct{})
+		for i := 0; i < numLines; i++ {
+			sm := labels.FromStrings("trace_id", fmt.Sprintf("trace-%d", i))
+			samples, ok := streamEx.Process(0, []byte("a log line"), sm)
+			require.True(t, ok)
+			for _, s := range samples {
+				series[s.Labels.String()] = struct{}{}
+			}
+		}
+		return series
+	}
+
+	// Baseline: the sum-pushdown leaf collapses every line to a single {} series
+	// regardless of structured-metadata cardinality.
+	baseline := extractSeries(t, `sum(count_over_time({job="loki-prod-036/querier"}[5m]))`)
+	require.Len(t, baseline, 1,
+		"sum(count_over_time(...)) leaf should collapse all lines to a single series")
+
+	// Reproducer: the bare count_over_time(...) leaf produced by the shard
+	// mapper for the `drop __error__` variant emits one series per unique
+	// structured-metadata value.
+	exploded := extractSeries(t, `count_over_time({job="loki-prod-036/querier"} | drop __error__ [5m])`)
+	require.Len(t, exploded, numLines,
+		"bare count_over_time(... | drop __error__) leaf explodes to one series per structured metadata value")
+
+	require.Greater(t, len(exploded), len(baseline),
+		"adding `| drop __error__` must not increase series cardinality, but it does")
 }
 
 func Test_MultiVariantExpr_Extractors(t *testing.T) {


### PR DESCRIPTION
## Summary

Draft PR with characterization tests that reproduce a cardinality explosion when `| drop __error__` is added to a `sum(count_over_time(...))` query.

Motivating pair of queries (only difference is the `drop` stage):

```logql
sum(count_over_time({job=~"loki-prod-036/querier.*"}[$__auto]))                    # fine
sum(count_over_time({job=~"loki-prod-036/querier.*"} | drop __error__ [$__auto]))  # cardinality explodes
```

## Root cause

The divergence happens in the query-frontend **shard mapper**, not in pipeline execution.

`syntax.ReducesLabels` flags **any** `DropLabelsExpr` as label-reducing:

```go
// pkg/logql/syntax/ast.go
case *KeepLabelsExpr, *DropLabelsExpr:
    conflict = true
```

In `mapVectorAggregationExpr`, the `sum` case bails out of the sum-pushdown optimization when the child reduces labels:

```go
// pkg/logql/shardmapper.go
case syntax.OpTypeSum:
    if syntax.ReducesLabels(expr.Left) {
        break // skip wrappedShardedVectorAggr
    }
    return m.wrappedShardedVectorAggr(expr, r)
```

Result — the two queries map to different sharded ASTs:

```
no drop:  sum( downstream<sum(count_over_time({...}[r])), shard=i> ++ ... )
drop:     sum( sum without() ( downstream<count_over_time({...} | drop __error__[r]), shard=i> ++ ... ) )
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bare range-agg leaf
```

The sum-pushdown leaf (`sum(count_over_time(...))`) injects the outer grouping into the extractor via `VectorAggregationExpr.Extractors()`, giving `noLabels=true`, so `LabelsBuilder.GroupedLabels()` collapses every line to `{}`.

The bare `count_over_time(...)` leaf calls `RangeAggregationExpr.Extractors()` → `extractor(nil)`, so `noLabels=false`. Because the extractor always `Add`s structured metadata (`hasAdd()==true`), `GroupedLabels()` returns the full labelset — stream labels + **all structured metadata** — for every line. On querier streams with high-cardinality structured metadata (trace IDs, request IDs, ...) this produces one series per unique combination.

The outer `sum by ()` still collapses the *final* result to a single series, but the intermediate series each querier materializes and streams back explode — driving memory, network, and `max_query_series` limit hits.

Note: `drop __error__` is otherwise a no-op here (no parser sets `__error__`; it just calls `ResetError()`). Its only observable effect is tripping `ReducesLabels`.

## What's in this PR

- `pkg/logql/shardmapper_test.go` — `TestMappingStrings` cases asserting the two divergent sharded ASTs.
- `pkg/logql/syntax/extractor_test.go` — `Test_DropError_CardinalityExplosion`: the pushdown leaf collapses 100 lines (each with a unique structured-metadata value) to 1 series; the bare `drop __error__` leaf produces 100 series.

These are characterization tests documenting current (buggy) behavior; they'll need to flip once a fix lands.

## Proposed fix (for discussion, not included)

Special-case error-only drops in `ReducesLabels`: a `drop __error__` / `drop __error_details__` (by name, or matchers targeting only the error slots) does not reduce the user-visible labelset and should not disable the sum-pushdown. `keep` and drops of real labels should keep their current behavior. Wanted to align on the approach before implementing, since `ReducesLabels` also guards correctness for non-additive inner range aggregations.

Made with [Cursor](https://cursor.com)