### PR TITLE
chore(engine): Instrument scheduler/worker communication

### DIFF
--- a/pkg/engine/internal/metrictimer/timer.go
+++ b/pkg/engine/internal/metrictimer/timer.go
@@ -1,0 +1,159 @@
+// Package metrictimer provides a small helper for timing named operations.
+package metrictimer
+
+import "time"
+
+// Time runs fn and returns how long it took along with fn's error. It is the
+// single-observation counterpart to [Timer]: use it at sites that time exactly
+// one call and record a single duration, rather than partitioning an operation
+// into named phases. The caller records the returned duration into its own
+// histogram.
+func Time(fn func() error) (time.Duration, error) {
+	start := time.Now()
+	err := fn()
+	return time.Since(start), err
+}
+
+// Phase is a bounded metric phase label value.
+type Phase string
+
+// String returns p as a metric label value.
+func (p Phase) String() string { return string(p) }
+
+// Outcome is a bounded metric outcome label value.
+type Outcome string
+
+// String returns o as a metric label value.
+func (o Outcome) String() string { return string(o) }
+
+// Config configures a Timer.
+type Config struct {
+	// Emit records one duration row. Required.
+	Emit func(Phase, Outcome, time.Duration)
+
+	// Total is the phase value to emit for the operation total when HasTotal is true.
+	Total Phase
+
+	// HasTotal controls whether Done emits a total row.
+	HasTotal bool
+
+	// Start is the operation start time. Defaults to time.Now().
+	Start time.Time
+
+	// Rows is the initial capacity for buffered rows. Defaults to 4.
+	Rows int
+}
+
+// Timer times one operation as a sequence of named phases plus an optional
+// total, and flushes all observations when the operation ends.
+//
+// Phases are named at the start of their interval: Phase closes the previous
+// interval and opens p; Done closes the final open interval. Observe records a
+// discrete duration measured by another resource. A nil *Timer is a no-op.
+//
+// Within one operation, either partition time with Phase or record discrete
+// durations with Observe/Region; do not call Observe or Region while a Phase
+// interval is open, or that time is counted twice (once in the row and once in
+// the open phase).
+type Timer struct {
+	emit func(Phase, Outcome, time.Duration)
+
+	total    Phase
+	hasTotal bool
+
+	start   time.Time
+	open    time.Time
+	cur     Phase
+	inPhase bool
+
+	rows []row
+}
+
+type row struct {
+	phase Phase
+	dur   time.Duration
+}
+
+// New creates a Timer from cfg. It returns nil when cfg.Emit is nil.
+func New(cfg Config) *Timer {
+	if cfg.Emit == nil {
+		return nil
+	}
+	if cfg.Start.IsZero() {
+		cfg.Start = time.Now()
+	}
+	if cfg.Rows <= 0 {
+		cfg.Rows = 4
+	}
+	return &Timer{
+		emit:     cfg.Emit,
+		total:    cfg.Total,
+		hasTotal: cfg.HasTotal,
+		start:    cfg.Start,
+		rows:     make([]row, 0, cfg.Rows),
+	}
+}
+
+// Phase closes the currently-open interval and opens p.
+func (t *Timer) Phase(p Phase) {
+	if t == nil || t.emit == nil {
+		return
+	}
+
+	now := time.Now()
+	if t.inPhase {
+		t.rows = append(t.rows, row{phase: t.cur, dur: now.Sub(t.open)})
+	}
+	t.cur = p
+	t.open = now
+	t.inPhase = true
+}
+
+// Observe records d for p without disturbing the currently-open interval.
+func (t *Timer) Observe(p Phase, d time.Duration) {
+	if t == nil || t.emit == nil || d < 0 {
+		return
+	}
+	t.rows = append(t.rows, row{phase: p, dur: d})
+}
+
+// Region runs fn and records the elapsed time for p. Region does not disturb
+// the currently-open interval.
+func (t *Timer) Region(p Phase, fn func() error) error {
+	if t == nil || t.emit == nil {
+		return fn()
+	}
+
+	start := time.Now()
+	err := fn()
+	t.rows = append(t.rows, row{phase: p, dur: time.Since(start)})
+	return err
+}
+
+// Done closes the final open interval, emits all buffered rows with out, and
+// emits the optional total row. Done is idempotent: it renders t inert, so a
+// second call (or a stray Phase/Observe/Region afterward) is a no-op.
+func (t *Timer) Done(out Outcome) {
+	if t == nil || t.emit == nil {
+		return
+	}
+
+	now := time.Now()
+	if t.inPhase {
+		t.rows = append(t.rows, row{phase: t.cur, dur: now.Sub(t.open)})
+	}
+	if t.hasTotal {
+		t.rows = append(t.rows, row{phase: t.total, dur: now.Sub(t.start)})
+	}
+
+	for _, row := range t.rows {
+		t.emit(row.phase, out, row.dur)
+	}
+
+	t.emit = nil
+	t.inPhase = false
+	t.cur = ""
+	t.open = time.Time{}
+	t.start = time.Time{}
+	t.rows = t.rows[:0]
+}

--- a/pkg/engine/internal/obslock/obslock.go
+++ b/pkg/engine/internal/obslock/obslock.go
@@ -1,0 +1,186 @@
+// Package obslock provides an observed [sync.RWMutex] that records how long
+// callers wait to acquire a lock and how long they hold it. The scheduler and
+// worker share it so both emit lock_wait_seconds and lock_hold_seconds with the
+// same lock, mode, and reason labels.
+package obslock
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Metrics holds the wait and hold histograms shared by observed mutexes. Wait
+// and hold are partitioned by lock (the mutex name), mode (read or write), and
+// reason (the acquisition call site).
+type Metrics struct {
+	waitSeconds *prometheus.HistogramVec
+	holdSeconds *prometheus.HistogramVec
+}
+
+// NewMetrics registers the wait and hold histograms under the provided metric
+// names and returns the Metrics that observed mutexes record into.
+func NewMetrics(reg prometheus.Registerer, waitName, holdName string) *Metrics {
+	return &Metrics{
+		waitSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: waitName,
+			Help: "Time spent waiting to acquire a lock before the acquisition succeeded",
+		}, []string{"lock", "mode", "reason"}),
+		holdSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: holdName,
+			Help: "Time a lock was held by a single critical section, from acquisition to release",
+		}, []string{"lock", "mode", "reason"}),
+	}
+}
+
+func newNativeHistogramVec(r prometheus.Registerer, opts prometheus.HistogramOpts, labels []string) *prometheus.HistogramVec {
+	opts.NativeHistogramBucketFactor = 1.1
+	opts.NativeHistogramMaxBucketNumber = 100
+	opts.NativeHistogramMinResetDuration = time.Hour
+	return promauto.With(r).NewHistogramVec(opts, labels)
+}
+
+// Describe sends the descriptors of the wait and hold histograms to ch so
+// callers can enumerate the lock metrics (for example, in a metric-inventory
+// test). A nil *Metrics describes nothing.
+func (m *Metrics) Describe(ch chan<- *prometheus.Desc) {
+	if m == nil {
+		return
+	}
+	m.waitSeconds.Describe(ch)
+	m.holdSeconds.Describe(ch)
+}
+
+func (m *Metrics) observeWait(lock, mode, reason string, d time.Duration) {
+	if m == nil {
+		return
+	}
+	m.waitSeconds.WithLabelValues(lock, mode, reason).Observe(d.Seconds())
+}
+
+func (m *Metrics) observeHold(lock, mode, reason string, d time.Duration) {
+	if m == nil {
+		return
+	}
+	m.holdSeconds.WithLabelValues(lock, mode, reason).Observe(d.Seconds())
+}
+
+// Lock and mode label values.
+const (
+	modeRead  = "read"
+	modeWrite = "write"
+)
+
+// RWMutex wraps a [sync.RWMutex] with instrumentation for acquisition wait time
+// and critical-section hold time.
+//
+// The zero value is not usable; call [RWMutex.Init] before first use.
+type RWMutex struct {
+	mu   sync.RWMutex
+	name string
+	m    *Metrics
+}
+
+// Init binds the mutex to its metrics and lock name. It must be called once
+// before the mutex is used and before any goroutine can acquire it.
+func (o *RWMutex) Init(name string, m *Metrics) {
+	o.name = name
+	o.m = m
+}
+
+// Mutex wraps a [sync.Mutex] with instrumentation for acquisition wait time and
+// critical-section hold time. It is the exclusive-only counterpart to
+// [RWMutex] for locks that never need a shared read mode; its acquisitions are
+// always recorded with mode "write".
+//
+// The zero value acquires the lock but records nothing until [Mutex.Init] binds
+// it to its metrics and lock name.
+type Mutex struct {
+	mu   sync.Mutex
+	name string
+	m    *Metrics
+}
+
+// Init binds the mutex to its metrics and lock name. It should be called once
+// before the mutex is used and before any goroutine can acquire it.
+func (o *Mutex) Init(name string, m *Metrics) {
+	o.name = name
+	o.m = m
+}
+
+// Lock acquires the mutex for the given reason and returns a guard that
+// releases it. The guard must be released exactly once with [Guard.Unlock].
+func (o *Mutex) Lock(reason string) Guard {
+	waitStart := time.Now()
+	o.mu.Lock()
+	wait := time.Since(waitStart)
+	o.m.observeWait(o.name, modeWrite, reason, wait)
+
+	holdStart := time.Now()
+	return Guard{
+		Wait: wait,
+		release: func() {
+			hold := time.Since(holdStart)
+			o.mu.Unlock()
+			o.m.observeHold(o.name, modeWrite, reason, hold)
+		},
+	}
+}
+
+// Guard releases a lock acquired from an [RWMutex]. Wait is the time spent
+// waiting to acquire the lock. The guard must be released exactly once with the
+// method matching how it was acquired.
+type Guard struct {
+	Wait    time.Duration
+	release func()
+}
+
+// Unlock releases a write lock acquired by [RWMutex.Lock].
+func (g Guard) Unlock() {
+	if g.release != nil {
+		g.release()
+	}
+}
+
+// RUnlock releases a read lock acquired by [RWMutex.RLock].
+func (g Guard) RUnlock() { g.Unlock() }
+
+// Lock acquires the write lock for the given reason and returns a guard that
+// releases it. The guard must be released exactly once.
+func (o *RWMutex) Lock(reason string) Guard {
+	waitStart := time.Now()
+	o.mu.Lock()
+	wait := time.Since(waitStart)
+	o.m.observeWait(o.name, modeWrite, reason, wait)
+
+	holdStart := time.Now()
+	return Guard{
+		Wait: wait,
+		release: func() {
+			hold := time.Since(holdStart)
+			o.mu.Unlock()
+			o.m.observeHold(o.name, modeWrite, reason, hold)
+		},
+	}
+}
+
+// RLock acquires the read lock for the given reason and returns a guard that
+// releases it. The guard must be released exactly once.
+func (o *RWMutex) RLock(reason string) Guard {
+	waitStart := time.Now()
+	o.mu.RLock()
+	wait := time.Since(waitStart)
+	o.m.observeWait(o.name, modeRead, reason, wait)
+
+	holdStart := time.Now()
+	return Guard{
+		Wait: wait,
+		release: func() {
+			hold := time.Since(holdStart)
+			o.mu.RUnlock()
+			o.m.observeHold(o.name, modeRead, reason, hold)
+		},
+	}
+}

--- a/pkg/engine/internal/obslock/obslock_test.go
+++ b/pkg/engine/internal/obslock/obslock_test.go
@@ -1,0 +1,97 @@
+package obslock
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRWMutexObservesWaitAndHold is a contract test: acquiring and releasing the
+// observed mutex must record exactly one wait and one hold sample under the
+// lock, mode, and reason of the acquisition.
+func TestRWMutexObservesWaitAndHold(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	metrics := NewMetrics(reg, "test_lock_wait_seconds", "test_lock_hold_seconds")
+
+	var mut RWMutex
+	mut.Init("resourcesMut", metrics)
+
+	writeGuard := mut.Lock("cancel")
+	time.Sleep(time.Millisecond)
+	writeGuard.Unlock()
+
+	readGuard := mut.RLock("find_tasks")
+	time.Sleep(time.Millisecond)
+	readGuard.RUnlock()
+
+	require.Equal(t, uint64(1), histogramSampleCount(t, reg, "test_lock_wait_seconds", map[string]string{
+		"lock": "resourcesMut", "mode": modeWrite, "reason": "cancel",
+	}))
+	require.Equal(t, uint64(1), histogramSampleCount(t, reg, "test_lock_hold_seconds", map[string]string{
+		"lock": "resourcesMut", "mode": modeWrite, "reason": "cancel",
+	}))
+	require.Equal(t, uint64(1), histogramSampleCount(t, reg, "test_lock_wait_seconds", map[string]string{
+		"lock": "resourcesMut", "mode": modeRead, "reason": "find_tasks",
+	}))
+	require.Equal(t, uint64(1), histogramSampleCount(t, reg, "test_lock_hold_seconds", map[string]string{
+		"lock": "resourcesMut", "mode": modeRead, "reason": "find_tasks",
+	}))
+}
+
+// TestMutexObservesWaitAndHold is the exclusive-only counterpart contract test:
+// acquiring and releasing the plain observed mutex must record exactly one wait
+// and one hold sample, always under mode "write".
+func TestMutexObservesWaitAndHold(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	metrics := NewMetrics(reg, "test_lock_wait_seconds", "test_lock_hold_seconds")
+
+	var mut Mutex
+	mut.Init("conn_write", metrics)
+
+	guard := mut.Lock("send_frame")
+	time.Sleep(time.Millisecond)
+	guard.Unlock()
+
+	require.Equal(t, uint64(1), histogramSampleCount(t, reg, "test_lock_wait_seconds", map[string]string{
+		"lock": "conn_write", "mode": modeWrite, "reason": "send_frame",
+	}))
+	require.Equal(t, uint64(1), histogramSampleCount(t, reg, "test_lock_hold_seconds", map[string]string{
+		"lock": "conn_write", "mode": modeWrite, "reason": "send_frame",
+	}))
+}
+
+func histogramSampleCount(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) uint64 {
+	t.Helper()
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if labelsEqual(metric, labels) {
+				return metric.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+
+	require.Failf(t, "metric not found", "metric %s with labels %v was not collected", name, labels)
+	return 0
+}
+
+func labelsEqual(metric *dto.Metric, want map[string]string) bool {
+	if len(metric.GetLabel()) != len(want) {
+		return false
+	}
+	for _, label := range metric.GetLabel() {
+		if want[label.GetName()] != label.GetValue() {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/engine/internal/scheduler/collector.go
+++ b/pkg/engine/internal/scheduler/collector.go
@@ -88,8 +88,8 @@ func newCollector(sched *Scheduler) *collector {
 // computeLoad returns the active load on the scheduler: the sum of running and
 // pending tasks.
 func computeLoad(sched *Scheduler) float64 {
-	sched.resourcesMut.RLock()
-	defer sched.resourcesMut.RUnlock()
+	guard := sched.resourcesMut.RLock("collector_compute_load")
+	defer guard.RUnlock()
 
 	var load uint64
 
@@ -122,8 +122,8 @@ func (mc *collector) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (mc *collector) collectResourceStats(ch chan<- prometheus.Metric) {
-	mc.sched.resourcesMut.RLock()
-	defer mc.sched.resourcesMut.RUnlock()
+	guard := mc.sched.resourcesMut.RLock("collector_resource_stats")
+	defer guard.RUnlock()
 
 	var (
 		tasksByState   = make(map[workflow.TaskState]int)
@@ -166,8 +166,8 @@ func (mc *collector) collectConnStats(ch chan<- prometheus.Metric) {
 }
 
 func (mc *collector) collectAssignStats(ch chan<- prometheus.Metric) {
-	mc.sched.assignMut.RLock()
-	defer mc.sched.assignMut.RUnlock()
+	guard := mc.sched.assignMut.RLock("collector_assign_stats")
+	defer guard.RUnlock()
 
 	ch <- prometheus.MustNewConstMetric(mc.readyWorkers, prometheus.GaugeValue, float64(len(mc.sched.connectedWorkers)))
 	ch <- prometheus.MustNewConstMetric(mc.taskQueue, prometheus.GaugeValue, float64(mc.sched.taskQueue.Len()))

--- a/pkg/engine/internal/scheduler/metrics.go
+++ b/pkg/engine/internal/scheduler/metrics.go
@@ -5,6 +5,10 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/metrictimer"
+	"github.com/grafana/loki/v3/pkg/engine/internal/obslock"
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
 )
 
 // metrics is a container of metrics for a scheduler.
@@ -20,13 +24,46 @@ type metrics struct {
 
 	taskQueueSeconds prometheus.Histogram
 	taskExecSeconds  prometheus.Histogram
+
+	handlerPhaseSeconds     *prometheus.HistogramVec
+	assignmentHopSeconds    *prometheus.HistogramVec
+	assignmentAttemptsTotal *prometheus.CounterVec
+
+	// lock holds the instruments for the scheduler's observed mutexes.
+	lock *obslock.Metrics
 }
+
+// Handler phase label values shared by multiple handlers. Phase values used at a
+// single call site are inlined as string literals there.
+const (
+	phaseTotal metrictimer.Phase = "total"
+)
+
+// Outcome label values.
+const (
+	outcomeAck          metrictimer.Outcome = "ack"
+	outcomeNack         metrictimer.Outcome = "nack"
+	outcomeSuccess      metrictimer.Outcome = "success"
+	outcomeEmpty        metrictimer.Outcome = "empty"
+	outcomeCanceled     metrictimer.Outcome = "canceled"
+	outcomeConnClosed   metrictimer.Outcome = "conn_closed"
+	outcomeAssigned     metrictimer.Outcome = "assigned"
+	outcomeReady        metrictimer.Outcome = "ready"
+	outcomeUnassignable metrictimer.Outcome = "unassignable"
+	outcomeNack429      metrictimer.Outcome = "nack_429"
+	outcomeTimeout      metrictimer.Outcome = "timeout"
+	outcomeSendError    metrictimer.Outcome = "send_error"
+)
 
 func newMetrics() *metrics {
 	reg := prometheus.NewRegistry()
 
 	return &metrics{
 		reg: reg,
+		lock: obslock.NewMetrics(reg,
+			"loki_engine_scheduler_lock_wait_seconds",
+			"loki_engine_scheduler_lock_hold_seconds",
+		),
 
 		tasksTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_engine_scheduler_tasks_total",
@@ -49,24 +86,85 @@ func newMetrics() *metrics {
 			Help: "Total number of times a task was requeued after a failed assignment attempt",
 		}),
 
-		taskQueueSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		taskQueueSeconds: newNativeHistogram(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_scheduler_task_queue_seconds",
 			Help: "Number of seconds a task sat in a queue before being assigned to a worker thread",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}),
 
-		taskExecSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		taskExecSeconds: newNativeHistogram(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_scheduler_task_exec_seconds",
 			Help: "Number of seconds a task took to complete successfully",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}),
+
+		handlerPhaseSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_scheduler_handler_phase_seconds",
+			Help: "Time spent in bounded scheduler handler phases",
+		}, []string{"message_type", "phase", "outcome"}),
+		assignmentHopSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_scheduler_assignment_hop_seconds",
+			Help: "Time spent in scheduler task-assignment hops",
+		}, []string{"phase", "outcome"}),
+		assignmentAttemptsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_scheduler_assignment_attempts_total",
+			Help: "Total number of scheduler TaskAssign attempts by outcome",
+		}, []string{"outcome"}),
 	}
+}
+
+func newNativeHistogramVec(r prometheus.Registerer, opts prometheus.HistogramOpts, labels []string) *prometheus.HistogramVec {
+	applyNativeHistogramOpts(&opts)
+	return promauto.With(r).NewHistogramVec(opts, labels)
+}
+
+func newNativeHistogram(r prometheus.Registerer, opts prometheus.HistogramOpts) prometheus.Histogram {
+	applyNativeHistogramOpts(&opts)
+	return promauto.With(r).NewHistogram(opts)
+}
+
+func applyNativeHistogramOpts(opts *prometheus.HistogramOpts) {
+	opts.NativeHistogramBucketFactor = 1.1
+	opts.NativeHistogramMaxBucketNumber = 100
+	opts.NativeHistogramMinResetDuration = time.Hour
+}
+
+func (m *metrics) startHandler(kind wire.MessageKind) *metrictimer.Timer {
+	if m == nil {
+		return nil
+	}
+	messageType := kind.String()
+	return metrictimer.New(metrictimer.Config{
+		Total:    phaseTotal,
+		HasTotal: true,
+		Rows:     4,
+		Emit: func(phase metrictimer.Phase, outcome metrictimer.Outcome, d time.Duration) {
+			m.handlerPhaseSeconds.WithLabelValues(messageType, phase.String(), outcome.String()).Observe(d.Seconds())
+		},
+	})
+}
+
+func handlerOutcome(err error) metrictimer.Outcome {
+	if err != nil {
+		return outcomeNack
+	}
+	return outcomeAck
+}
+
+func (m *metrics) startAssignmentHop(phase metrictimer.Phase) *metrictimer.Timer {
+	if m == nil {
+		return nil
+	}
+	return metrictimer.New(metrictimer.Config{
+		Total:    phase,
+		HasTotal: true,
+		Rows:     1,
+		Emit: func(p metrictimer.Phase, outcome metrictimer.Outcome, d time.Duration) {
+			m.assignmentHopSeconds.WithLabelValues(p.String(), outcome.String()).Observe(d.Seconds())
+		},
+	})
+}
+
+func (m *metrics) incAssignmentAttempt(outcome metrictimer.Outcome) {
+	m.assignmentAttemptsTotal.WithLabelValues(outcome.String()).Inc()
 }
 
 // Register registers metrics to report to reg.

--- a/pkg/engine/internal/scheduler/metrics_inventory_test.go
+++ b/pkg/engine/internal/scheduler/metrics_inventory_test.go
@@ -1,0 +1,96 @@
+package scheduler
+
+import (
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMetricInventory pins the exact set of metrics this package owns and the
+// label keys each carries. It guards the observability question tree: dropping,
+// renaming, or relabeling any of these metrics fails the test so the change is
+// deliberate. The actual set is derived by reflecting over the metrics struct's
+// collector fields, so a newly added metric that is missing from the expected
+// map fails too. Label values are checked separately by the label-bound tests.
+func TestMetricInventory(t *testing.T) {
+	expected := map[string][]string{
+		"loki_engine_scheduler_assignment_attempts_total": {"outcome"},
+		"loki_engine_scheduler_assignment_backoffs_total": nil,
+		"loki_engine_scheduler_assignment_hop_seconds":    {"outcome", "phase"},
+		"loki_engine_scheduler_connections_total":         nil,
+		"loki_engine_scheduler_handler_phase_seconds":     {"message_type", "outcome", "phase"},
+		"loki_engine_scheduler_lock_hold_seconds":         {"lock", "mode", "reason"},
+		"loki_engine_scheduler_lock_wait_seconds":         {"lock", "mode", "reason"},
+		"loki_engine_scheduler_streams_total":             {"state"},
+		"loki_engine_scheduler_task_exec_seconds":         nil,
+		"loki_engine_scheduler_task_queue_seconds":        nil,
+		"loki_engine_scheduler_task_requeue_total":        nil,
+		"loki_engine_scheduler_tasks_total":               {"state"},
+	}
+
+	require.Equal(t, expected, metricInventory(t, newMetrics()))
+}
+
+// describer is satisfied by prometheus collectors and by *obslock.Metrics.
+type describer interface {
+	Describe(chan<- *prometheus.Desc)
+}
+
+var descLabelsRe = regexp.MustCompile(`fqName: "([^"]+)".*variableLabels: \{([^}]*)\}`)
+
+// metricInventory reflects over every collector field of a metrics value
+// (including the shared obslock lock metrics) and returns each registered
+// metric's fully-qualified name mapped to its sorted label keys.
+func metricInventory(t *testing.T, m any) map[string][]string {
+	t.Helper()
+
+	describers := collectDescribers(reflect.ValueOf(m).Elem())
+
+	ch := make(chan *prometheus.Desc)
+	go func() {
+		defer close(ch)
+		for _, d := range describers {
+			d.Describe(ch)
+		}
+	}()
+
+	inventory := make(map[string][]string)
+	for desc := range ch {
+		match := descLabelsRe.FindStringSubmatch(desc.String())
+		require.NotNilf(t, match, "could not parse descriptor %q", desc.String())
+
+		var keys []string
+		for _, key := range strings.Split(match[2], ",") {
+			if key != "" {
+				keys = append(keys, key)
+			}
+		}
+		sort.Strings(keys)
+		inventory[match[1]] = keys
+	}
+	return inventory
+}
+
+// collectDescribers returns every struct field of v that is a metric collector,
+// reading unexported fields via reflection so the inventory stays authoritative
+// without a hand-maintained accessor.
+func collectDescribers(v reflect.Value) []describer {
+	var out []describer
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		if !f.CanAddr() {
+			continue
+		}
+		fv := reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem().Interface()
+		if d, ok := fv.(describer); ok && d != nil {
+			out = append(out, d)
+		}
+	}
+	return out
+}

--- a/pkg/engine/internal/scheduler/metricstest_test.go
+++ b/pkg/engine/internal/scheduler/metricstest_test.go
@@ -1,0 +1,119 @@
+package scheduler
+
+// This file holds shared metric-assertion test helpers used across the
+// scheduler package's tests.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func histogramSampleCount(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) uint64 {
+	t.Helper()
+
+	metric := metricWithLabels(t, reg, name, labels)
+	histogram := metric.GetHistogram()
+	require.NotNil(t, histogram, "metric %s with labels %v should be a histogram", name, labels)
+	return histogram.GetSampleCount()
+}
+
+func metricWithLabels(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) *dto.Metric {
+	t.Helper()
+
+	family := metricFamily(t, reg, name)
+	for _, metric := range family.GetMetric() {
+		if metricLabels(metric).equals(labels) {
+			return metric
+		}
+	}
+
+	require.Failf(t, "metric not found", "metric %s with labels %v was not collected", name, labels)
+	return nil
+}
+
+func metricFamily(t *testing.T, reg *prometheus.Registry, name string) *dto.MetricFamily {
+	t.Helper()
+
+	for _, family := range gatherFamilies(t, reg) {
+		if metricNameMatches(family.GetName(), name) {
+			return family
+		}
+	}
+
+	require.Failf(t, "metric family not found", "metric family %s was not collected", name)
+	return nil
+}
+
+func metricNameMatches(got, want string) bool {
+	return got == want || got == strings.TrimSuffix(want, "_total") || got+"_total" == want
+}
+
+func gatherFamilies(t *testing.T, reg *prometheus.Registry) []*dto.MetricFamily {
+	t.Helper()
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	return families
+}
+
+type metricLabelSet map[string]string
+
+func metricLabels(metric *dto.Metric) metricLabelSet {
+	labels := make(metricLabelSet, len(metric.GetLabel()))
+	for _, label := range metric.GetLabel() {
+		labels[label.GetName()] = label.GetValue()
+	}
+	return labels
+}
+
+// equals reports whether the label set is exactly want and carries no other
+// labels, so an accidentally added (for example high-cardinality) label fails
+// the lookup instead of being silently ignored.
+func (s metricLabelSet) equals(want map[string]string) bool {
+	if len(s) != len(want) {
+		return false
+	}
+	for name, value := range want {
+		if s[name] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func requireMetricLabelsBounded(t *testing.T, reg *prometheus.Registry, name string, allowed map[string]map[string]struct{}) {
+	t.Helper()
+
+	family := metricFamily(t, reg, name)
+	require.NotEmpty(t, family.GetMetric(), "metric %s should have at least one sample", name)
+	for _, metric := range family.GetMetric() {
+		labels := metricLabels(metric)
+		// Reject any label name outside the allowed set so an accidentally added
+		// (for example high-cardinality) label fails the test.
+		require.Lenf(t, labels, len(allowed), "metric %s has unexpected labels: %v", name, labels)
+		for label, values := range allowed {
+			value, ok := labels[label]
+			require.Truef(t, ok, "metric %s should have label %q", name, label)
+			require.Containsf(t, values, value, "metric %s label %q had unbounded value %q", name, label, value)
+		}
+	}
+}
+
+func stringSet(values ...any) map[string]struct{} {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		switch value := value.(type) {
+		case string:
+			set[value] = struct{}{}
+		case interface{ String() string }:
+			set[value.String()] = struct{}{}
+		default:
+			panic("unsupported stringSet value")
+		}
+	}
+	return set
+}

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -22,6 +22,8 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/grafana/loki/v3/pkg/engine/internal/metrictimer"
+	"github.com/grafana/loki/v3/pkg/engine/internal/obslock"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/queue/fair"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
@@ -52,11 +54,11 @@ type Scheduler struct {
 	// Current set of connections, used for collecting metrics.
 	connections sync.Map // map[*workerConn]struct{}
 
-	resourcesMut sync.RWMutex
+	resourcesMut obslock.RWMutex
 	streams      map[ulid.ULID]*stream // All known streams (regardless of state)
 	tasks        map[ulid.ULID]*task   // All known tasks (regardless of state)
 
-	assignMut        sync.RWMutex
+	assignMut        obslock.RWMutex
 	taskQueue        fair.Queue[*task]
 	connectedWorkers map[*workerConn]struct{}
 
@@ -103,6 +105,8 @@ func New(config Config) (*Scheduler, error) {
 	}
 
 	s.metrics = newMetrics()
+	s.resourcesMut.Init("resourcesMut", s.metrics.lock)
+	s.assignMut.Init("assignMut", s.metrics.lock)
 	s.collector = newCollector(s)
 
 	return s, nil
@@ -164,21 +168,7 @@ func (s *Scheduler) handleConn(ctx context.Context, conn wire.Conn) {
 		Buffer: 128,
 
 		Handler: func(ctx context.Context, _ *wire.Peer, msg wire.Message) error {
-			switch msg := msg.(type) {
-			case wire.StreamDataMessage:
-				return s.handleStreamData(ctx, wc, msg)
-			case wire.WorkerHelloMessage:
-				return s.handleWorkerHello(ctx, wc, msg)
-			case wire.WorkerReadyMessage:
-				return s.markWorkerReady(ctx, wc)
-			case wire.TaskStatusMessage:
-				return s.handleTaskStatus(ctx, wc, msg)
-			case wire.StreamStatusMessage:
-				return s.handleStreamStatus(ctx, wc, msg)
-
-			default:
-				return fmt.Errorf("unsupported message kind %q", msg.Kind())
-			}
+			return s.handleMessage(ctx, wc, msg)
 		},
 	}
 
@@ -201,13 +191,35 @@ func (s *Scheduler) handleConn(ctx context.Context, conn wire.Conn) {
 	s.removeWorker(ctx, wc, err)
 }
 
-func (s *Scheduler) handleStreamData(ctx context.Context, worker *workerConn, msg wire.StreamDataMessage) error {
+func (s *Scheduler) handleMessage(ctx context.Context, worker *workerConn, msg wire.Message) (err error) {
+	switch msg := msg.(type) {
+	case wire.StreamDataMessage:
+		return s.handleStreamData(ctx, worker, msg)
+	case wire.WorkerHelloMessage:
+		return s.handleWorkerHello(ctx, worker, msg)
+	case wire.WorkerReadyMessage:
+		return s.markWorkerReady(ctx, worker)
+	case wire.TaskStatusMessage:
+		return s.handleTaskStatus(ctx, worker, msg)
+	case wire.StreamStatusMessage:
+		return s.handleStreamStatus(ctx, worker, msg)
+	default:
+		phases := s.metrics.startHandler(msg.Kind())
+		defer func() { phases.Done(handlerOutcome(err)) }()
+		return fmt.Errorf("unsupported message kind %q", msg.Kind())
+	}
+}
+
+func (s *Scheduler) handleStreamData(ctx context.Context, worker *workerConn, msg wire.StreamDataMessage) (err error) {
+	phases := s.metrics.startHandler(msg.Kind())
+	defer func() { phases.Done(handlerOutcome(err)) }()
+
 	if err := worker.MarkDataPlane(); err != nil {
 		return err
 	}
 
-	s.resourcesMut.RLock()
-	defer s.resourcesMut.RUnlock()
+	resourcesGuard := s.resourcesMut.RLock("handle_stream_data")
+	defer resourcesGuard.RUnlock()
 
 	registered, found := s.streams[msg.StreamID]
 	if !found {
@@ -216,10 +228,15 @@ func (s *Scheduler) handleStreamData(ctx context.Context, worker *workerConn, ms
 		return fmt.Errorf("scheduler is not listening for data for stream %s", msg.StreamID)
 	}
 
-	return registered.localReceiver.Write(ctx, msg.Data)
+	return phases.Region("downstream_write", func() error {
+		return registered.localReceiver.Write(ctx, msg.Data)
+	})
 }
 
-func (s *Scheduler) handleWorkerHello(ctx context.Context, worker *workerConn, msg wire.WorkerHelloMessage) error {
+func (s *Scheduler) handleWorkerHello(ctx context.Context, worker *workerConn, msg wire.WorkerHelloMessage) (err error) {
+	phases := s.metrics.startHandler(msg.Kind())
+	defer func() { phases.Done(handlerOutcome(err)) }()
+
 	if err := worker.HandleHello(msg); err != nil {
 		return err
 	}
@@ -229,9 +246,15 @@ func (s *Scheduler) handleWorkerHello(ctx context.Context, worker *workerConn, m
 	return nil
 }
 
-func (s *Scheduler) markWorkerReady(ctx context.Context, worker *workerConn) error {
-	s.assignMut.Lock()
-	defer s.assignMut.Unlock()
+func (s *Scheduler) markWorkerReady(ctx context.Context, worker *workerConn) (err error) {
+	phases := s.metrics.startHandler(wire.WorkerReadyMessage{}.Kind())
+	defer func() { phases.Done(handlerOutcome(err)) }()
+
+	hop := s.metrics.startAssignmentHop("worker_ready_handler")
+	defer func() { hop.Done(handlerOutcome(err)) }()
+
+	assignGuard := s.assignMut.Lock("mark_worker_ready")
+	defer assignGuard.Unlock()
 
 	if err := worker.MarkReady(); err != nil {
 		return err
@@ -241,7 +264,6 @@ func (s *Scheduler) markWorkerReady(ctx context.Context, worker *workerConn) err
 		nudgeSemaphore(worker.wake)
 	} else {
 		s.connectedWorkers[worker] = struct{}{}
-
 		go s.workerLoop(ctx, worker)
 	}
 
@@ -263,7 +285,10 @@ func nudgeSemaphore(sema chan struct{}) {
 	}
 }
 
-func (s *Scheduler) handleTaskStatus(ctx context.Context, worker *workerConn, msg wire.TaskStatusMessage) error {
+func (s *Scheduler) handleTaskStatus(ctx context.Context, worker *workerConn, msg wire.TaskStatusMessage) (err error) {
+	phases := s.metrics.startHandler(msg.Kind())
+	defer func() { phases.Done(handlerOutcome(err)) }()
+
 	if got, want := worker.Type(), connectionTypeControlPlane; got != want {
 		return fmt.Errorf("worker connection must be in state %q, got %q", want, got)
 	}
@@ -271,8 +296,8 @@ func (s *Scheduler) handleTaskStatus(ctx context.Context, worker *workerConn, ms
 	var n notifier
 	defer n.Notify(ctx)
 
-	s.resourcesMut.Lock()
-	defer s.resourcesMut.Unlock()
+	resourcesGuard := s.resourcesMut.Lock("handle_task_status")
+	defer resourcesGuard.Unlock()
 
 	task, found := s.tasks[msg.ID]
 	if !found {
@@ -330,7 +355,10 @@ func (s *Scheduler) handleTaskStatus(ctx context.Context, worker *workerConn, ms
 	return nil
 }
 
-func (s *Scheduler) handleStreamStatus(ctx context.Context, worker *workerConn, msg wire.StreamStatusMessage) error {
+func (s *Scheduler) handleStreamStatus(ctx context.Context, worker *workerConn, msg wire.StreamStatusMessage) (err error) {
+	phases := s.metrics.startHandler(msg.Kind())
+	defer func() { phases.Done(handlerOutcome(err)) }()
+
 	if got, want := worker.Type(), connectionTypeControlPlane; got != want {
 		return fmt.Errorf("worker connection must be in state %q, got %q", want, got)
 	}
@@ -338,8 +366,8 @@ func (s *Scheduler) handleStreamStatus(ctx context.Context, worker *workerConn, 
 	var n notifier
 	defer n.Notify(ctx)
 
-	s.resourcesMut.Lock()
-	defer s.resourcesMut.Unlock()
+	resourcesGuard := s.resourcesMut.Lock("handle_stream_status")
+	defer resourcesGuard.Unlock()
 
 	stream, found := s.streams[msg.StreamID]
 	if !found {
@@ -391,11 +419,11 @@ func (s *Scheduler) removeWorker(ctx context.Context, worker *workerConn, reason
 	var n notifier
 	defer n.Notify(ctx)
 
-	s.resourcesMut.Lock()
-	defer s.resourcesMut.Unlock()
+	resourcesGuard := s.resourcesMut.Lock("remove_worker")
+	defer resourcesGuard.Unlock()
 
-	s.assignMut.Lock()
-	defer s.assignMut.Unlock()
+	assignGuard := s.assignMut.Lock("remove_worker")
+	defer assignGuard.Unlock()
 
 	for _, task := range worker.Assigned() {
 		wasInterrupted := task.Interrupted()
@@ -467,17 +495,26 @@ func (s *Scheduler) assignTasks(ctx context.Context) {
 	level.Debug(s.logger).Log("msg", "performing task assignment")
 
 	for ctx.Err() == nil {
+		prepare := s.metrics.startAssignmentHop("prepare_assignment")
 		assignment, ok := s.prepareAssignment()
+		prepareOutcome := outcomeSuccess
+		if !ok {
+			prepareOutcome = outcomeEmpty
+		}
+		prepare.Done(prepareOutcome)
 		if !ok {
 			return
 		}
 
 		// Send the task to a waiting worker goroutine. This blocks until a
 		// worker is available, providing natural backpressure.
+		handoff := s.metrics.startAssignmentHop("tasks_ch_handoff_wait")
 		select {
 		case <-ctx.Done():
+			handoff.Done(outcomeCanceled)
 			return
 		case s.tasksCh <- assignment:
+			handoff.Done(outcomeSuccess)
 		}
 	}
 }
@@ -490,12 +527,16 @@ func (s *Scheduler) workerLoop(ctx context.Context, worker *workerConn) {
 	for {
 		var assignment taskAssignment
 
+		waitAssignment := s.metrics.startAssignmentHop("wait_assignment")
 		select {
 		case <-ctx.Done():
+			waitAssignment.Done(outcomeCanceled)
 			return
 		case <-worker.done:
+			waitAssignment.Done(outcomeConnClosed)
 			return
 		case assignment = <-s.tasksCh:
+			waitAssignment.Done(outcomeAssigned)
 		}
 
 		level.Debug(s.logger).Log("msg", "assigning task", "id", assignment.msg.Task.ULID, "conn", worker.RemoteAddr())
@@ -504,6 +545,7 @@ func (s *Scheduler) workerLoop(ctx context.Context, worker *workerConn) {
 		// fast-responding worker can't race with the post-assignment
 		// bookkeeping in finalizeAssignment. On success it also records the
 		// assignment timestamp on the task before releasing mut.
+		roundtrip := s.metrics.startAssignmentHop("taskassign_roundtrip")
 		err := assignment.t.TryAssign(func() error {
 			// TODO(rfratto): allow assignment timeout to be configurable.
 			sendCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
@@ -511,6 +553,9 @@ func (s *Scheduler) workerLoop(ctx context.Context, worker *workerConn) {
 
 			return worker.SendMessage(sendCtx, assignment.msg)
 		})
+		attemptOutcome := assignmentAttemptOutcome(err)
+		roundtrip.Done(attemptOutcome)
+		s.metrics.incAssignmentAttempt(attemptOutcome)
 
 		if err != nil && errors.Is(err, errUnassignable) {
 			// Task is already in a terminal state or has been interrupted,
@@ -518,7 +563,9 @@ func (s *Scheduler) workerLoop(ctx context.Context, worker *workerConn) {
 			continue
 		} else if err != nil {
 			// Generic error: restore the task to its original queue position.
+			requeue := s.metrics.startAssignmentHop("error_requeue")
 			s.requeueTask(assignment.t, assignment.pos)
+			requeue.Done(attemptOutcome)
 
 			if isTooManyRequestsError(err) {
 				s.metrics.backoffsTotal.Inc()
@@ -545,12 +592,16 @@ func (s *Scheduler) workerLoop(ctx context.Context, worker *workerConn) {
 // returns true if the assignment loop should resume, or false if it should
 // exit.
 func (s *Scheduler) parkWorker(ctx context.Context, worker *workerConn) bool {
+	hop := s.metrics.startAssignmentHop("park_worker_wait")
 	select {
 	case <-ctx.Done():
+		hop.Done(outcomeCanceled)
 		return false
 	case <-worker.done:
+		hop.Done(outcomeConnClosed)
 		return false
 	case <-worker.wake:
+		hop.Done(outcomeReady)
 		return true
 	}
 }
@@ -560,11 +611,11 @@ func (s *Scheduler) parkWorker(ctx context.Context, worker *workerConn) bool {
 //
 // Returns false if the queue is empty or if there are no ready workers.
 func (s *Scheduler) prepareAssignment() (taskAssignment, bool) {
-	s.resourcesMut.RLock()
-	defer s.resourcesMut.RUnlock()
+	resourcesGuard := s.resourcesMut.RLock("prepare_assignment")
+	defer resourcesGuard.RUnlock()
 
-	s.assignMut.Lock()
-	defer s.assignMut.Unlock()
+	assignGuard := s.assignMut.Lock("prepare_assignment")
+	defer assignGuard.Unlock()
 
 	// clean up any terminal tasks at the front of the queue.
 	for s.taskQueue.Len() > 0 && s.peekTask().status.State.Terminal() {
@@ -624,8 +675,8 @@ func (s *Scheduler) buildAssignMessage(t *task) wire.TaskAssignMessage {
 // requeueTask re-inserts a task at its original position after a failed
 // assignment, undoing the scope cost adjustment.
 func (s *Scheduler) requeueTask(t *task, pos fair.Position) {
-	s.assignMut.Lock()
-	defer s.assignMut.Unlock()
+	assignGuard := s.assignMut.Lock("requeue_task")
+	defer assignGuard.Unlock()
 
 	if t.State().Terminal() {
 		return
@@ -656,12 +707,13 @@ type pendingMessage struct {
 
 // finalizeAssignment completes the assignment of the task to the worker.
 func (s *Scheduler) finalizeAssignment(ctx context.Context, t *task, worker *workerConn, sentStates map[ulid.ULID]workflow.StreamState) {
+	hop := s.metrics.startAssignmentHop("finalize_assignment")
 	var pendingMsgs []pendingMessage
 
 	// Collect bookkeeping and messages under lock.
 	func() {
-		s.resourcesMut.Lock()
-		defer s.resourcesMut.Unlock()
+		resourcesGuard := s.resourcesMut.Lock("finalize_assignment")
+		defer resourcesGuard.Unlock()
 
 		assignTime := t.AssignTime() // Set by [task.TryAssign] by the previous caller before this runs.
 		queueDuration := assignTime.Sub(t.QueueTime())
@@ -726,6 +778,7 @@ func (s *Scheduler) finalizeAssignment(ctx context.Context, t *task, worker *wor
 	for _, p := range pendingMsgs {
 		_ = p.peer.SendMessageAsync(ctx, p.msg)
 	}
+	hop.Done(outcomeSuccess)
 }
 
 // prepareBindMessage prepares a StreamBindMessage for the given stream if both
@@ -772,6 +825,21 @@ func isTooManyRequestsError(err error) bool {
 	return errors.As(err, &wireError) && wireError.Code == http.StatusTooManyRequests
 }
 
+func assignmentAttemptOutcome(err error) metrictimer.Outcome {
+	switch {
+	case err == nil:
+		return outcomeSuccess
+	case errors.Is(err, errUnassignable):
+		return outcomeUnassignable
+	case isTooManyRequestsError(err):
+		return outcomeNack429
+	case errors.Is(err, context.DeadlineExceeded):
+		return outcomeTimeout
+	default:
+		return outcomeSendError
+	}
+}
+
 // workerSubscribe sends a WorkerSubscribe message to the provided worker. The
 // worker will eventually send a WorkerReady message in response.
 func (s *Scheduler) workerSubscribe(ctx context.Context, worker *workerConn) {
@@ -802,8 +870,8 @@ func (s *Scheduler) RegisterManifest(ctx context.Context, manifest *workflow.Man
 		return err
 	}
 
-	s.resourcesMut.Lock()
-	defer s.resourcesMut.Unlock()
+	resourcesGuard := s.resourcesMut.Lock("register_manifest")
+	defer resourcesGuard.Unlock()
 
 	var errs []error
 
@@ -920,8 +988,8 @@ NextTask:
 func (s *Scheduler) registerManifestScope(manifest *workflow.Manifest) (fair.Scope, error) {
 	scope := manifestScope(manifest)
 
-	s.assignMut.Lock()
-	defer s.assignMut.Unlock()
+	assignGuard := s.assignMut.Lock("register_manifest_scope")
+	defer assignGuard.Unlock()
 
 	if err := s.taskQueue.RegisterScope(scope); err != nil {
 		return nil, err
@@ -955,8 +1023,8 @@ func (s *Scheduler) UnregisterManifest(ctx context.Context, manifest *workflow.M
 		level.Warn(s.logger).Log("msg", "failed unregistering queue scope", "id", manifest.ID, "err", err)
 	}
 
-	s.resourcesMut.Lock()
-	defer s.resourcesMut.Unlock()
+	resourcesGuard := s.resourcesMut.Lock("unregister_manifest")
+	defer resourcesGuard.Unlock()
 
 	var errs []error
 
@@ -1038,8 +1106,8 @@ func (s *Scheduler) UnregisterManifest(ctx context.Context, manifest *workflow.M
 func (s *Scheduler) unregisterManifestScope(manifest *workflow.Manifest) error {
 	scope := manifestScope(manifest)
 
-	s.assignMut.Lock()
-	defer s.assignMut.Unlock()
+	assignGuard := s.assignMut.Lock("unregister_manifest_scope")
+	defer assignGuard.Unlock()
 
 	if err := s.taskQueue.UnregisterScope(scope); err != nil {
 		return err
@@ -1063,8 +1131,8 @@ func (s *Scheduler) Listen(ctx context.Context, writer workflow.RecordWriter, st
 	var pending *pendingMessage
 
 	err := func() error {
-		s.resourcesMut.Lock()
-		defer s.resourcesMut.Unlock()
+		resourcesGuard := s.resourcesMut.Lock("listen")
+		defer resourcesGuard.Unlock()
 
 		registered, found := s.streams[stream.ULID]
 		if !found {
@@ -1142,8 +1210,8 @@ func (s *Scheduler) Start(ctx context.Context, tasks ...*workflow.Task) error {
 // findTasks gets a list of [task] from workflow tasks. Returns an error if any
 // of the tasks weren't recognized.
 func (s *Scheduler) findTasks(tasks []*workflow.Task) ([]*task, error) {
-	s.resourcesMut.RLock()
-	defer s.resourcesMut.RUnlock()
+	resourcesGuard := s.resourcesMut.RLock("find_tasks")
+	defer resourcesGuard.RUnlock()
 
 	res := make([]*task, 0, len(tasks))
 
@@ -1164,8 +1232,8 @@ func (s *Scheduler) findTasks(tasks []*workflow.Task) ([]*task, error) {
 }
 
 func (s *Scheduler) enqueueTasks(tasks []*task) {
-	s.assignMut.Lock()
-	defer s.assignMut.Unlock()
+	assignGuard := s.assignMut.Lock("enqueue_tasks")
+	defer assignGuard.Unlock()
 
 	for _, task := range tasks {
 		// Ignore tasks that aren't in the initial state (created). This
@@ -1190,8 +1258,8 @@ func (s *Scheduler) markPending(ctx context.Context, tasks []*task) {
 	var n notifier
 	defer n.Notify(ctx)
 
-	s.resourcesMut.Lock()
-	defer s.resourcesMut.Unlock()
+	resourcesGuard := s.resourcesMut.Lock("mark_pending")
+	defer resourcesGuard.Unlock()
 
 	for _, task := range tasks {
 		if changed, _ := task.SetState(s.metrics, workflow.TaskStatus{State: workflow.TaskStatePending}); !changed {
@@ -1220,8 +1288,8 @@ func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 	var n notifier
 	defer n.Notify(ctx)
 
-	s.resourcesMut.Lock()
-	defer s.resourcesMut.Unlock()
+	resourcesGuard := s.resourcesMut.Lock("cancel")
+	defer resourcesGuard.Unlock()
 
 	var errs []error
 

--- a/pkg/engine/internal/scheduler/scheduler_test.go
+++ b/pkg/engine/internal/scheduler/scheduler_test.go
@@ -1377,6 +1377,96 @@ func TestScheduler_worker(t *testing.T) {
 	})
 }
 
+func TestScheduler_assignmentMetricsUseBoundedLabels(t *testing.T) {
+	sched := newTestScheduler(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+
+	conn, err := sched.DialFrom(ctx, wire.LocalWorker)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	messages := make(chan wire.Message, 10)
+	peer := wire.Peer{
+		Logger:  log.NewNopLogger(),
+		Metrics: wire.NewMetrics(),
+		Conn:    conn,
+		Handler: func(ctx context.Context, _ *wire.Peer, message wire.Message) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case messages <- message:
+				return nil
+			}
+		},
+	}
+	go func() { _ = peer.Serve(ctx) }()
+
+	require.NoError(t, peer.SendMessage(ctx, wire.WorkerHelloMessage{Threads: 1}), "Scheduler should accept hello message")
+	require.NoError(t, peer.SendMessage(ctx, wire.WorkerReadyMessage{}), "Scheduler should accept ready message")
+
+	exampleTask := &workflow.Task{ULID: ulid.Make()}
+	manifest := &workflow.Manifest{
+		Tasks:              []*workflow.Task{exampleTask},
+		StreamEventHandler: nopStreamHandler,
+		TaskEventHandler:   nopTaskHandler,
+	}
+	require.NoError(t, sched.RegisterManifest(t.Context(), manifest), "Scheduler should accept valid manifest")
+	require.NoError(t, sched.Start(t.Context(), exampleTask), "Scheduler should start registered task")
+
+WaitAssign:
+	for {
+		select {
+		case <-ctx.Done():
+			require.Fail(t, "timed out before assignment")
+		case msg := <-messages:
+			switch msg := msg.(type) {
+			case wire.WorkerSubscribeMessage:
+				continue
+			case wire.TaskAssignMessage:
+				require.Equal(t, exampleTask.ULID, msg.Task.ULID)
+				break WaitAssign
+			default:
+				require.Failf(t, "unexpected message", "unexpected message type %T", msg)
+			}
+		}
+	}
+
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(sched.metrics.assignmentAttemptsTotal.WithLabelValues(outcomeSuccess.String())) == 1
+	}, 5*time.Second, 10*time.Millisecond, "successful assignment attempt should be recorded")
+
+	requireMetricLabelsBounded(t, sched.metrics.reg, "loki_engine_scheduler_handler_phase_seconds", map[string]map[string]struct{}{
+		"message_type": stringSet(wire.WorkerHelloMessage{}.Kind().String(), wire.WorkerReadyMessage{}.Kind().String()),
+		"phase":        stringSet(phaseTotal),
+		"outcome":      stringSet(outcomeAck),
+	})
+	// assignment_hop_seconds now carries every worker-loop phase too, including
+	// the wait_assignment and error_requeue phases folded in from the removed
+	// worker_loop_phase_seconds_total counter.
+	requireMetricLabelsBounded(t, sched.metrics.reg, "loki_engine_scheduler_assignment_hop_seconds", map[string]map[string]struct{}{
+		"phase": stringSet(
+			"worker_ready_handler", "prepare_assignment", "tasks_ch_handoff_wait",
+			"wait_assignment", "taskassign_roundtrip", "error_requeue",
+			"finalize_assignment", "park_worker_wait",
+		),
+		"outcome": stringSet(
+			outcomeAck, outcomeNack, outcomeSuccess, outcomeEmpty, outcomeAssigned,
+			outcomeCanceled, outcomeConnClosed, outcomeReady, outcomeUnassignable,
+			outcomeNack429, outcomeTimeout, outcomeSendError,
+		),
+	})
+
+	// The handler-phase helper must actually emit the total phase for a handled
+	// message, not just keep its labels bounded.
+	require.GreaterOrEqual(t, histogramSampleCount(t, sched.metrics.reg, "loki_engine_scheduler_handler_phase_seconds", map[string]string{
+		"message_type": wire.WorkerReadyMessage{}.Kind().String(),
+		"phase":        phaseTotal.String(),
+		"outcome":      outcomeAck.String(),
+	}), uint64(1), "WorkerReady handler should record a total phase")
+}
+
 // TestScheduler_workerParkOnBackoff verifies that a 429 from a worker parks the
 // worker's assignment loop, and that a subsequent ready message resumes assignment of
 // the requeued task.
@@ -1442,10 +1532,12 @@ func TestScheduler_workerParkOnBackoff(t *testing.T) {
 		if testutil.ToFloat64(sched.metrics.backoffsTotal) < 1 {
 			return false
 		}
-		sched.assignMut.RLock()
-		defer sched.assignMut.RUnlock()
+		guard := sched.assignMut.RLock("collector_assign_stats")
+		defer guard.RUnlock()
 		return len(sched.connectedWorkers) == 1
 	}, 5*time.Second, 10*time.Millisecond, "worker should remain ready (loop parks, not torn down) after a 429")
+	require.Equal(t, 1.0, testutil.ToFloat64(sched.metrics.assignmentAttemptsTotal), "one failed and requeued attempt should be counted once")
+	require.Equal(t, 1.0, testutil.ToFloat64(sched.metrics.assignmentAttemptsTotal.WithLabelValues(outcomeNack429.String())), "failed attempt should keep its send outcome")
 
 	// Now accept assignments and signal a freed thread. The parked loop should
 	// resume and re-assign the requeued task.

--- a/pkg/engine/internal/scheduler/wire/codec.go
+++ b/pkg/engine/internal/scheduler/wire/codec.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/grafana/dskit/httpgrpc"
@@ -30,6 +31,52 @@ type protobufCodec struct {
 	*arrowcodec.ArrowCodec
 }
 
+// encode encodes a frame as protobuf and returns the on-wire bytes.
+// Format: [uvarint length][protobuf payload].
+//
+// scratch is a reusable buffer whose backing array encode grows and reuses to
+// avoid allocating a fresh length-prefix+payload buffer per frame. Callers pass
+// the previous return value back in; because a connection serializes its sends
+// under its write lock, the buffer is safe to reuse across that connection's
+// sends. The returned slice aliases scratch's array and stays valid only until
+// the next encode call on the same buffer.
+func (c *protobufCodec) encode(frame Frame, m *Metrics, scratch []byte) []byte {
+	mc := &metricCodec{protobufCodec: c, m: m}
+
+	// Convert wire.Frame to protobuf.
+	pbFrame, err := mc.frameToPbFrame(frame)
+	if err != nil {
+		panic(fmt.Errorf("failed to convert frame to protobuf: %w", err))
+	}
+
+	// Marshal to bytes.
+	marshalStart := time.Now()
+	payload, err := proto.Marshal(pbFrame)
+	if err != nil {
+		panic(fmt.Errorf("failed to marshal protobuf: %w", err))
+	}
+	mc.observeCodecStage(codecOperationEncode, codecStageProtobufMarshal, frame, time.Since(marshalStart))
+
+	// Write the length prefix (uvarint) then the payload into the reusable
+	// buffer.
+	var prefix [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(prefix[:], uint64(len(payload)))
+	buf := append(scratch[:0], prefix[:n]...)
+	buf = append(buf, payload...)
+	return buf
+}
+
+func readUvarint(r io.Reader) (length uint64, prefixBytes int, err error) {
+	byteReader, ok := r.(io.ByteReader)
+	if !ok {
+		byteReader = &byteReaderAdapter{r: r}
+	}
+
+	countingReader := &countingByteReader{r: byteReader}
+	length, err = binary.ReadUvarint(countingReader)
+	return length, countingReader.n, err
+}
+
 // byteReaderAdapter adapts an io.Reader to io.ByteReader without buffering.
 // This is used to read uvarint length prefixes byte-by-byte without
 // consuming extra data that might be needed for subsequent reads.
@@ -43,82 +90,99 @@ func (br *byteReaderAdapter) ReadByte() (byte, error) {
 	return b[0], err
 }
 
-// EncodeTo encodes a frame as protobuf and writes it to the writer.
-// Format: [uvarint length][protobuf payload]
-func (c *protobufCodec) EncodeTo(w io.Writer, frame Frame) error {
-	// Convert wire.Frame to protobuf
-	pbFrame, err := c.frameToPbFrame(frame)
-	if err != nil {
-		panic(fmt.Errorf("failed to convert frame to protobuf: %w", err))
-	}
-
-	// Marshal to bytes
-	data, err := proto.Marshal(pbFrame)
-	if err != nil {
-		panic(fmt.Errorf("failed to marshal protobuf: %w", err))
-	}
-
-	// Write length prefix (uvarint)
-	length := uint64(len(data))
-	buf := make([]byte, binary.MaxVarintLen64)
-	n := binary.PutUvarint(buf, length)
-	if _, err := w.Write(buf[:n]); err != nil {
-		return fmt.Errorf("failed to write length prefix: %w", err)
-	}
-
-	// Write payload
-	written, err := w.Write(data)
-	if err != nil {
-		return fmt.Errorf("failed to write payload: %w", err)
-	}
-	if written != len(data) {
-		return fmt.Errorf("incomplete write: wrote %d bytes, expected %d", written, len(data))
-	}
-
-	return nil
+type countingByteReader struct {
+	r io.ByteReader
+	n int
 }
 
-// DecodeFrom reads and decodes a frame from the bound reader.
-// Format: [uvarint length][protobuf payload]
-func (c *protobufCodec) DecodeFrom(r io.Reader) (Frame, error) {
-	// Read length prefix (uvarint)
-	// binary.ReadUvarint requires a ByteReader, so we wrap if needed
-	byteReader, ok := r.(io.ByteReader)
-	if !ok {
-		byteReader = &byteReaderAdapter{r: r}
+func (br *countingByteReader) ReadByte() (byte, error) {
+	b, err := br.r.ReadByte()
+	if err == nil {
+		br.n++
 	}
+	return b, err
+}
 
-	length, err := binary.ReadUvarint(byteReader)
+// metricCodec binds a [protobufCodec] to the [*Metrics] used for one encode or
+// decode call. It is instantiated per call so the conversion helpers and
+// codec-stage timing can read Metrics from a field instead of threading it
+// through every signature. A nil m records nothing.
+type metricCodec struct {
+	*protobufCodec
+	m *Metrics
+}
+
+func (c *metricCodec) observeCodecStage(operation codecOperation, stage codecStage, frame Frame, d time.Duration) {
+	if c.m == nil || d < 0 {
+		return
+	}
+	labels := labelsForFrame(frame, "")
+	c.m.frameCodecStageSeconds.WithLabelValues(operation.String(), stage.String(), labels.frameType, labels.messageType).Observe(d.Seconds())
+}
+
+func (c *metricCodec) observeMessageCodecStage(operation codecOperation, stage codecStage, kind MessageKind, d time.Duration) {
+	if c.m == nil || d < 0 {
+		return
+	}
+	c.m.frameCodecStageSeconds.WithLabelValues(operation.String(), stage.String(), FrameKindMessage.String(), kind.String()).Observe(d.Seconds())
+}
+
+// decode reads and decodes the next frame from r, returning the frame and the
+// number of on-wire bytes consumed (including the length prefix). It emits its
+// own frame_receive_seconds read and deserialize phases; the receive path has
+// no outcome dimension. decode is only reached over HTTP/2.
+func (c *protobufCodec) decode(r io.Reader, m *Metrics) (Frame, int, error) {
+	mc := &metricCodec{protobufCodec: c, m: m}
+
+	readStart := time.Now()
+
+	// Read length prefix (uvarint).
+	length, prefixBytes, err := readUvarint(r)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read length prefix: %w", err)
+		return nil, 0, fmt.Errorf("failed to read length prefix: %w", err)
 	}
 
 	// Read payload
 	data := make([]byte, length)
 	n, err := io.ReadFull(r, data)
+	readDuration := time.Since(readStart)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read payload: %w", err)
+		return nil, 0, fmt.Errorf("failed to read payload: %w", err)
 	}
 	if uint64(n) != length {
-		return nil, fmt.Errorf("incomplete read: read %d bytes, expected %d", n, length)
+		return nil, 0, fmt.Errorf("incomplete read: read %d bytes, expected %d", n, length)
 	}
 
-	// Unmarshal protobuf
+	deserializeStart := time.Now()
+
+	// Unmarshal protobuf.
+	unmarshalStart := time.Now()
 	pbFrame := &wirepb.Frame{}
 	if err := proto.Unmarshal(data, pbFrame); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal protobuf: %w", err)
+		return nil, 0, fmt.Errorf("failed to unmarshal protobuf: %w", err)
 	}
+	protobufUnmarshalDuration := time.Since(unmarshalStart)
 
-	// Convert protobuf to wire.Frame
-	frame, err := c.frameFromPbFrame(pbFrame)
+	// Convert protobuf to wire.Frame.
+	frame, err := mc.frameFromPbFrame(pbFrame)
+	deserializeDuration := time.Since(deserializeStart)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert protobuf to frame: %w", err)
+		return nil, 0, fmt.Errorf("failed to convert protobuf to frame: %w", err)
 	}
+	mc.observeCodecStage(codecOperationDecode, codecStageProtobufUnmarshal, frame, protobufUnmarshalDuration)
 
-	return frame, nil
+	// Emit our own receive-side read and deserialize phases now that the frame
+	// (and thus its labels) is known.
+	receive := m.startFrameReceive(transportHTTP2, frame, sendModeInternal)
+	receive.Observe(phaseReadBytes, readDuration)
+	receive.Observe(phaseDeserialize, deserializeDuration)
+	receive.Done()
+
+	return frame, prefixBytes + n, nil
 }
 
-func (c *protobufCodec) frameFromPbFrame(f *wirepb.Frame) (Frame, error) {
+func (c *metricCodec) frameFromPbFrame(f *wirepb.Frame) (Frame, error) {
+
 	if f == nil {
 		return nil, errors.New("nil frame")
 	}
@@ -162,7 +226,8 @@ func (c *protobufCodec) errorFromPb(errPb *wirepb.Error) *Error {
 	}
 }
 
-func (c *protobufCodec) messageFromPbMessage(mf *wirepb.MessageFrame) (Message, error) {
+func (c *metricCodec) messageFromPbMessage(mf *wirepb.MessageFrame) (Message, error) {
+
 	if mf == nil {
 		return nil, errors.New("nil message frame")
 	}
@@ -241,7 +306,9 @@ func (c *protobufCodec) messageFromPbMessage(mf *wirepb.MessageFrame) (Message, 
 		}, nil
 
 	case *wirepb.MessageFrame_StreamData:
+		arrowStart := time.Now()
 		record, err := c.DeserializeArrowRecord(k.StreamData.Data)
+		c.observeMessageCodecStage(codecOperationDecode, codecStageArrowDecode, MessageKindStreamData, time.Since(arrowStart))
 		if err != nil {
 			return nil, fmt.Errorf("failed to deserialize arrow record: %w", err)
 		}
@@ -265,12 +332,15 @@ func (c *protobufCodec) messageFromPbMessage(mf *wirepb.MessageFrame) (Message, 
 	}
 }
 
-func (c *protobufCodec) taskFromPbTask(t *wirepb.Task) (*workflow.Task, error) {
+func (c *metricCodec) taskFromPbTask(t *wirepb.Task) (*workflow.Task, error) {
+
 	if t == nil {
 		return nil, fmt.Errorf("nil task")
 	}
 
+	planStart := time.Now()
 	fragment, err := t.Fragment.MarshalPhysical()
+	c.observeMessageCodecStage(codecOperationDecode, codecStageTaskAssignDecode, MessageKindTaskAssign, time.Since(planStart))
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal fragment: %w", err)
 	}
@@ -437,7 +507,8 @@ func (c *protobufCodec) cachedSourcesFromPb(pbMap map[string]*wirepb.CachedSourc
 	return result, nil
 }
 
-func (c *protobufCodec) frameToPbFrame(from Frame) (*wirepb.Frame, error) {
+func (c *metricCodec) frameToPbFrame(from Frame) (*wirepb.Frame, error) {
+
 	if from == nil {
 		return nil, errors.New("nil frame")
 	}
@@ -489,7 +560,8 @@ func (c *protobufCodec) errorToPb(e *Error) *wirepb.Error {
 	}
 }
 
-func (c *protobufCodec) messageToPbMessage(from Message) (*wirepb.MessageFrame, error) {
+func (c *metricCodec) messageToPbMessage(from Message) (*wirepb.MessageFrame, error) {
+
 	if from == nil {
 		return nil, errors.New("nil message")
 	}
@@ -568,8 +640,10 @@ func (c *protobufCodec) messageToPbMessage(from Message) (*wirepb.MessageFrame, 
 		}
 
 	case StreamDataMessage:
-		// Serialize Arrow record to bytes
+		// Serialize Arrow record to bytes.
+		arrowStart := time.Now()
 		data, err := c.SerializeArrowRecord(v.Data)
+		c.observeMessageCodecStage(codecOperationEncode, codecStageArrowEncode, MessageKindStreamData, time.Since(arrowStart))
 		if err != nil {
 			return nil, fmt.Errorf("failed to serialize arrow record: %w", err)
 		}
@@ -595,15 +669,19 @@ func (c *protobufCodec) messageToPbMessage(from Message) (*wirepb.MessageFrame, 
 	return mf, nil
 }
 
-func (c *protobufCodec) taskToPbTask(from *workflow.Task) (*wirepb.Task, error) {
+func (c *metricCodec) taskToPbTask(from *workflow.Task) (*wirepb.Task, error) {
+
 	if from == nil {
 		return nil, errors.New("nil task")
 	}
 
 	fragment := &physicalpb.Plan{}
+	planStart := time.Now()
 	if err := fragment.UnmarshalPhysical(from.Fragment); err != nil {
+		c.observeMessageCodecStage(codecOperationEncode, codecStageTaskAssignEncode, MessageKindTaskAssign, time.Since(planStart))
 		return nil, fmt.Errorf("failed to unmarshal fragment: %w", err)
 	}
+	c.observeMessageCodecStage(codecOperationEncode, codecStageTaskAssignEncode, MessageKindTaskAssign, time.Since(planStart))
 
 	sources, err := c.nodeStreamMapToPbNodeStreamList(from.Sources)
 	if err != nil {

--- a/pkg/engine/internal/scheduler/wire/codec_test.go
+++ b/pkg/engine/internal/scheduler/wire/codec_test.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"bytes"
 	"errors"
 	"net"
 	"net/http"
@@ -41,13 +42,14 @@ func TestProtobufCodec_Frames(t *testing.T) {
 	}
 
 	codec := DefaultFrameCodec
+	mc := &metricCodec{protobufCodec: codec}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			pbFrame, err := codec.frameToPbFrame(tt.frame)
+			pbFrame, err := mc.frameToPbFrame(tt.frame)
 			require.NoError(t, err)
 
-			actualFrame, err := codec.frameFromPbFrame(pbFrame)
+			actualFrame, err := mc.frameFromPbFrame(pbFrame)
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.frame, actualFrame)
@@ -193,6 +195,7 @@ func TestProtobufCodec_Messages(t *testing.T) {
 	}
 
 	codec := DefaultFrameCodec
+	mc := &metricCodec{protobufCodec: codec}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -201,10 +204,10 @@ func TestProtobufCodec_Messages(t *testing.T) {
 				Message: tt.message,
 			}
 
-			pbFrame, err := codec.frameToPbFrame(frame)
+			pbFrame, err := mc.frameToPbFrame(frame)
 			require.NoError(t, err)
 
-			actualFrame, err := codec.frameFromPbFrame(pbFrame)
+			actualFrame, err := mc.frameFromPbFrame(pbFrame)
 			require.NoError(t, err)
 
 			assert.Equal(t, frame, actualFrame)
@@ -215,6 +218,7 @@ func TestProtobufCodec_Messages(t *testing.T) {
 func TestProtobufCodec_StreamDataMessage(t *testing.T) {
 	streamULID := ulid.Make()
 	codec := DefaultFrameCodec
+	mc := &metricCodec{protobufCodec: codec}
 
 	originalRecord := createTestArrowRecord()
 
@@ -228,10 +232,10 @@ func TestProtobufCodec_StreamDataMessage(t *testing.T) {
 		Message: message,
 	}
 
-	pbFrame, err := codec.frameToPbFrame(frame)
+	pbFrame, err := mc.frameToPbFrame(frame)
 	require.NoError(t, err)
 
-	actualFrame, err := codec.frameFromPbFrame(pbFrame)
+	actualFrame, err := mc.frameFromPbFrame(pbFrame)
 	require.NoError(t, err)
 
 	actualMessage := actualFrame.(MessageFrame).Message.(StreamDataMessage)
@@ -243,6 +247,82 @@ func TestProtobufCodec_StreamDataMessage(t *testing.T) {
 	assert.True(t, originalRecord.Schema().Equal(actualMessage.Data.Schema()))
 	assert.Equal(t, originalRecord.NumRows(), actualMessage.Data.NumRows())
 	assert.Equal(t, originalRecord.NumCols(), actualMessage.Data.NumCols())
+}
+
+func TestProtobufCodec_Metrics(t *testing.T) {
+	codec := DefaultFrameCodec
+	metrics := NewMetrics()
+
+	streamData := MessageFrame{
+		ID: 1,
+		Message: StreamDataMessage{
+			StreamID: ulid.Make(),
+			Data:     createTestArrowRecord(),
+		},
+	}
+	streamDataBytes := codec.encode(streamData, metrics, nil)
+	decodedStreamData, size, err := codec.decode(bytes.NewReader(streamDataBytes), metrics)
+	require.NoError(t, err)
+	require.Equal(t, len(streamDataBytes), size)
+	metrics.observeFrameBytes(directionIncoming, decodedStreamData, sendModeInternal, size)
+
+	taskAssign := MessageFrame{
+		ID: 2,
+		Message: TaskAssignMessage{
+			Task: &workflow.Task{
+				ULID:     ulid.Make(),
+				TenantID: "test-tenant",
+				Fragment: &physical.Plan{},
+				Sources:  map[physical.Node][]*workflow.Stream{},
+				Sinks:    map[physical.Node][]*workflow.Stream{},
+			},
+			StreamStates: map[ulid.ULID]workflow.StreamState{},
+		},
+	}
+	taskAssignBytes := codec.encode(taskAssign, metrics, nil)
+	decodedTaskAssign, size, err := codec.decode(bytes.NewReader(taskAssignBytes), metrics)
+	require.NoError(t, err)
+	require.Equal(t, len(taskAssignBytes), size)
+	metrics.observeFrameBytes(directionOutgoing, decodedTaskAssign, sendModeSync, size)
+
+	for _, tc := range []struct {
+		operation   codecOperation
+		stage       codecStage
+		messageType string
+	}{
+		{codecOperationEncode, codecStageArrowEncode, MessageKindStreamData.String()},
+		{codecOperationDecode, codecStageArrowDecode, MessageKindStreamData.String()},
+		{codecOperationEncode, codecStageProtobufMarshal, MessageKindStreamData.String()},
+		{codecOperationDecode, codecStageProtobufUnmarshal, MessageKindStreamData.String()},
+		{codecOperationEncode, codecStageTaskAssignEncode, MessageKindTaskAssign.String()},
+		{codecOperationDecode, codecStageTaskAssignDecode, MessageKindTaskAssign.String()},
+	} {
+		require.Equal(t, uint64(1), histogramCount(t, metrics.reg,
+			"loki_engine_scheduler_wire_frame_codec_stage_seconds",
+			map[string]string{
+				"operation":    tc.operation.String(),
+				"stage":        tc.stage.String(),
+				"frame_type":   FrameKindMessage.String(),
+				"message_type": tc.messageType,
+			}))
+	}
+
+	require.Equal(t, uint64(1), histogramCount(t, metrics.reg,
+		"loki_engine_scheduler_wire_frame_size_bytes",
+		map[string]string{
+			"direction":    directionIncoming.String(),
+			"frame_type":   FrameKindMessage.String(),
+			"message_type": MessageKindStreamData.String(),
+			"mode":         sendModeInternal.String(),
+		}))
+	require.Equal(t, uint64(1), histogramCount(t, metrics.reg,
+		"loki_engine_scheduler_wire_frame_size_bytes",
+		map[string]string{
+			"direction":    directionOutgoing.String(),
+			"frame_type":   FrameKindMessage.String(),
+			"message_type": MessageKindTaskAssign.String(),
+			"mode":         sendModeSync.String(),
+		}))
 }
 
 func TestProtobufCodec_TaskStates(t *testing.T) {
@@ -258,6 +338,7 @@ func TestProtobufCodec_TaskStates(t *testing.T) {
 	}
 
 	codec := DefaultFrameCodec
+	mc := &metricCodec{protobufCodec: codec}
 
 	for _, state := range states {
 		t.Run(state.String(), func(t *testing.T) {
@@ -273,10 +354,10 @@ func TestProtobufCodec_TaskStates(t *testing.T) {
 				Message: message,
 			}
 
-			pbFrame, err := codec.frameToPbFrame(frame)
+			pbFrame, err := mc.frameToPbFrame(frame)
 			require.NoError(t, err)
 
-			actualFrame, err := codec.frameFromPbFrame(pbFrame)
+			actualFrame, err := mc.frameFromPbFrame(pbFrame)
 			require.NoError(t, err)
 
 			actualMessage := actualFrame.(MessageFrame).Message.(TaskStatusMessage)
@@ -296,6 +377,7 @@ func TestProtobufCodec_StreamStates(t *testing.T) {
 	}
 
 	codec := DefaultFrameCodec
+	mc := &metricCodec{protobufCodec: codec}
 
 	for _, state := range states {
 		t.Run(state.String(), func(t *testing.T) {
@@ -309,10 +391,10 @@ func TestProtobufCodec_StreamStates(t *testing.T) {
 				Message: message,
 			}
 
-			pbFrame, err := codec.frameToPbFrame(frame)
+			pbFrame, err := mc.frameToPbFrame(frame)
 			require.NoError(t, err)
 
-			actualFrame, err := codec.frameFromPbFrame(pbFrame)
+			actualFrame, err := mc.frameFromPbFrame(pbFrame)
 			require.NoError(t, err)
 
 			actualMessage := actualFrame.(MessageFrame).Message.(StreamStatusMessage)
@@ -323,27 +405,28 @@ func TestProtobufCodec_StreamStates(t *testing.T) {
 
 func TestProtobufCodec_ErrorCases(t *testing.T) {
 	codec := DefaultFrameCodec
+	mc := &metricCodec{protobufCodec: codec}
 
 	t.Run("nil frame to protobuf", func(t *testing.T) {
-		_, err := codec.frameToPbFrame(nil)
+		_, err := mc.frameToPbFrame(nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "nil frame")
 	})
 
 	t.Run("nil frame from protobuf", func(t *testing.T) {
-		_, err := codec.frameFromPbFrame(nil)
+		_, err := mc.frameFromPbFrame(nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "nil frame")
 	})
 
 	t.Run("nil message to protobuf", func(t *testing.T) {
-		_, err := codec.messageToPbMessage(nil)
+		_, err := mc.messageToPbMessage(nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "nil message")
 	})
 
 	t.Run("nil task to protobuf", func(t *testing.T) {
-		_, err := codec.taskToPbTask(nil)
+		_, err := mc.taskToPbTask(nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "nil task")
 	})

--- a/pkg/engine/internal/scheduler/wire/metrics.go
+++ b/pkg/engine/internal/scheduler/wire/metrics.go
@@ -5,43 +5,214 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/metrictimer"
+	"github.com/grafana/loki/v3/pkg/engine/internal/obslock"
 )
+
+type sendMode string
+
+// sendMode label values. A send is "sync" when issued through [Peer.SendMessage]
+// (the caller waits for an ack) and "async" through [Peer.SendMessageAsync].
+// Frames the peer handles on behalf of the remote side are "internal": the
+// sync/async distinction is a send-side concept that is not carried on the
+// wire for incoming messages. The Prometheus label is named "mode".
+const (
+	sendModeSync     sendMode = "sync"
+	sendModeAsync    sendMode = "async"
+	sendModeInternal sendMode = "internal"
+)
+
+func (m sendMode) String() string { return string(m) }
+
+type queueName string
+
+// queue label values. The queue implies the direction (the outgoing queue is
+// outbound; the incoming and dispatch queues are inbound), so queue metrics do
+// not carry a separate direction label.
+const (
+	queueOutgoing     queueName = "peer_outgoing"
+	queueIncoming     queueName = "peer_incoming"
+	queueConnDispatch queueName = "conn_dispatch"
+)
+
+func (q queueName) String() string { return string(q) }
+
+type direction string
+
+// direction label values.
+const (
+	directionIncoming direction = "incoming"
+	directionOutgoing direction = "outgoing"
+)
+
+func (d direction) String() string { return string(d) }
+
+type transport string
+
+// transport label values.
+const (
+	transportHTTP2 transport = "http2"
+	transportLocal transport = "local"
+)
+
+func (t transport) String() string { return string(t) }
+
+// outcome label values for a synchronous round trip.
+const (
+	outcomeNone       metrictimer.Outcome = ""
+	outcomeAck        metrictimer.Outcome = "ack"
+	outcomeNack       metrictimer.Outcome = "nack"
+	outcomeTimeout    metrictimer.Outcome = "timeout"
+	outcomeCanceled   metrictimer.Outcome = "canceled"
+	outcomeConnClosed metrictimer.Outcome = "conn_closed"
+	outcomeSendError  metrictimer.Outcome = "send_error"
+)
+
+// phase label values for frame send and receive histograms.
+const (
+	phaseConnSendTotal       metrictimer.Phase = "conn_send_total"
+	phaseDeserialize         metrictimer.Phase = "deserialize"
+	phaseFlush               metrictimer.Phase = "flush"
+	phaseLocalChannelReceive metrictimer.Phase = "local_channel_receive"
+	phaseReadBytes           metrictimer.Phase = "read_bytes"
+	phaseRouteToQueue        metrictimer.Phase = "route_to_queue_or_result"
+	phaseSerialize           metrictimer.Phase = "serialize"
+	phaseWrite               metrictimer.Phase = "write"
+
+	phaseHandlerTotal   metrictimer.Phase = "handler_total"
+	phaseRoundtripTotal metrictimer.Phase = "roundtrip_total"
+)
+
+type codecOperation string
+
+// frame_codec_stage_seconds operation label values.
+const (
+	codecOperationDecode codecOperation = "decode"
+	codecOperationEncode codecOperation = "encode"
+)
+
+func (o codecOperation) String() string { return string(o) }
+
+type codecStage string
+
+// frame_codec_stage_seconds stage label values.
+const (
+	codecStageArrowDecode       codecStage = "arrow_decode"
+	codecStageArrowEncode       codecStage = "arrow_encode"
+	codecStageProtobufMarshal   codecStage = "protobuf_marshal"
+	codecStageProtobufUnmarshal codecStage = "protobuf_unmarshal"
+	codecStageTaskAssignDecode  codecStage = "taskassign_plan_decode"
+	codecStageTaskAssignEncode  codecStage = "taskassign_plan_encode"
+)
+
+func (s codecStage) String() string { return string(s) }
 
 // Metrics is a set of metrics for a Peer.
 type Metrics struct {
 	reg *prometheus.Registry
 
 	framesReceivedTotal *prometheus.CounterVec
-	messagesQueued      prometheus.Gauge
 	messagesSentTotal   *prometheus.CounterVec
-	messageRTTSeconds   *prometheus.HistogramVec
+
+	frameQueueLength       *prometheus.GaugeVec
+	frameQueueWaitSeconds  *prometheus.HistogramVec
+	queueBlockedSenders    *prometheus.GaugeVec
+	frameSendSeconds       *prometheus.HistogramVec
+	frameReceiveSeconds    *prometheus.HistogramVec
+	frameCodecStageSeconds *prometheus.HistogramVec
+	frameBytesTotal        *prometheus.CounterVec
+	frameSizeBytes         *prometheus.HistogramVec
+	writeBusySecondsTotal  *prometheus.CounterVec
+	connectionsActive      *prometheus.GaugeVec
+	handlerSeconds         *prometheus.HistogramVec
+
+	messageRoundtripSeconds *prometheus.HistogramVec
+
+	// lock holds the instruments for the connection write mutex.
+	lock *obslock.Metrics
 }
 
 func NewMetrics() *Metrics {
 	reg := prometheus.NewRegistry()
+
 	return &Metrics{
 		reg: reg,
+		lock: obslock.NewMetrics(reg,
+			"loki_engine_scheduler_wire_lock_wait_seconds",
+			"loki_engine_scheduler_wire_lock_hold_seconds",
+		),
 
 		framesReceivedTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_engine_scheduler_wire_frames_received_total",
 			Help: "Total number of frames received by the wire",
 		}, []string{"type", "message_type"}),
-		messagesQueued: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-			Name: "loki_engine_scheduler_wire_messages_queued",
-			Help: "Number of messages queued by the wire",
-		}),
 		messagesSentTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_engine_scheduler_wire_messages_sent_total",
-			Help: "Number of messages sent by a peer",
-		}, []string{"message_type"}),
-		messageRTTSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-			Name:                            "loki_engine_scheduler_wire_message_rtt_seconds",
-			Help:                            "Round-trip time to synchronously send a message to another peer",
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
-		}, []string{"message_type"}),
+			Help: "Number of messages a peer accepted for sending, including async sends that carry no round trip",
+		}, []string{"message_type", "mode"}),
+
+		frameQueueLength: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "loki_engine_scheduler_wire_frame_queue_length",
+			Help: "Number of frames currently waiting in a peer or connection dispatch queue",
+		}, []string{"queue", "frame_type", "message_type", "mode"}),
+		frameQueueWaitSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_scheduler_wire_frame_queue_wait_seconds",
+			Help: "Time a frame waited in a peer or connection dispatch queue before being dequeued",
+		}, []string{"queue", "frame_type", "message_type", "mode"}),
+		queueBlockedSenders: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "loki_engine_scheduler_wire_queue_blocked_senders",
+			Help: "Number of goroutines currently blocked trying to enqueue into a peer or connection queue",
+		}, []string{"queue", "frame_type", "message_type", "mode"}),
+		frameSendSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_scheduler_wire_frame_send_seconds",
+			Help: "Time spent in send-side phases for a wire frame",
+		}, []string{"phase", "transport", "frame_type", "message_type", "mode"}),
+		frameReceiveSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_scheduler_wire_frame_receive_seconds",
+			Help: "Time spent in receive-side phases for a wire frame",
+		}, []string{"phase", "transport", "frame_type", "message_type", "mode"}),
+		frameCodecStageSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_scheduler_wire_frame_codec_stage_seconds",
+			Help: "Time spent in codec sub-stages for wire-frame serialization and deserialization",
+		}, []string{"operation", "stage", "frame_type", "message_type"}),
+		frameBytesTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_scheduler_wire_frame_bytes_total",
+			Help: "Total encoded wire-frame bytes sent or received, including the length prefix",
+		}, []string{"direction", "frame_type", "message_type", "mode"}),
+		frameSizeBytes: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_scheduler_wire_frame_size_bytes",
+			Help: "Encoded wire-frame size in bytes, including the length prefix",
+		}, []string{"direction", "frame_type", "message_type", "mode"}),
+		writeBusySecondsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_scheduler_wire_write_busy_seconds_total",
+			Help: "Wall-clock seconds each connection write path was busy sending frames",
+		}, []string{"transport"}),
+		connectionsActive: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "loki_engine_scheduler_wire_connections_active",
+			Help: "Number of active wire peer connections by transport",
+		}, []string{"transport"}),
+		handlerSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_scheduler_wire_handler_seconds",
+			Help: "Time spent in the receiver's application handler before an ack or nack is enqueued",
+		}, []string{"message_type", "outcome"}),
+
+		messageRoundtripSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_scheduler_wire_message_roundtrip_seconds",
+			Help: "Time to synchronously send a message to another peer and receive its acknowledgement, by outcome",
+		}, []string{"message_type", "outcome", "mode"}),
 	}
+}
+
+func newNativeHistogramVec(r prometheus.Registerer, opts prometheus.HistogramOpts, labels []string) *prometheus.HistogramVec {
+	applyNativeHistogramOpts(&opts)
+	return promauto.With(r).NewHistogramVec(opts, labels)
+}
+
+func applyNativeHistogramOpts(opts *prometheus.HistogramOpts) {
+	opts.NativeHistogramBucketFactor = 1.1
+	opts.NativeHistogramMaxBucketNumber = 100
+	opts.NativeHistogramMinResetDuration = time.Hour
 }
 
 func (m *Metrics) Register(reg prometheus.Registerer) error { return reg.Register(m.reg) }
@@ -52,7 +223,8 @@ func (m *Metrics) incFrameReceived(frame Frame) {
 }
 
 // frameMessageType returns the application [MessageKind] carried by frame, or
-// "none" for frames that don't carry a message (acks, nacks, discards).
+// "none" for frames that don't carry a message (acks, nacks, discards). It is
+// used only by the legacy frames_received_total metric.
 func frameMessageType(frame Frame) string {
 	if mf, ok := frame.(MessageFrame); ok && mf.Message != nil {
 		return mf.Message.Kind().String()
@@ -60,18 +232,205 @@ func frameMessageType(frame Frame) string {
 	return "none"
 }
 
-func (m *Metrics) incMessageQueued() {
-	m.messagesQueued.Inc()
+// frameLabels are the bounded labels shared by mixed frame metrics.
+type frameLabels struct {
+	frameType   string
+	messageType string
+	sendMode    sendMode
 }
 
-func (m *Metrics) decMessageQueued() {
-	m.messagesQueued.Dec()
+func labelsForFrame(frame Frame, mode sendMode) frameLabels {
+	labels := frameLabels{
+		frameType:   frame.FrameKind().String(),
+		messageType: "none",
+		sendMode:    mode,
+	}
+	if mf, ok := frame.(MessageFrame); ok {
+		labels.messageType = "unknown"
+		if mf.Message != nil {
+			labels.messageType = mf.Message.Kind().String()
+		}
+	}
+	return labels
 }
 
-func (m *Metrics) incMessageSent(messageType string) {
-	m.messagesSentTotal.WithLabelValues(messageType).Inc()
+func (m *Metrics) incMessageSent(kind MessageKind, mode sendMode) {
+	m.messagesSentTotal.WithLabelValues(kind.String(), mode.String()).Inc()
 }
 
-func (m *Metrics) newMessageRTTTimer(messageType string) *prometheus.Timer {
-	return prometheus.NewTimer(m.messageRTTSeconds.WithLabelValues(messageType))
+func (m *Metrics) incFrameQueued(queue queueName, frame Frame, mode sendMode) {
+	labels := labelsForFrame(frame, mode)
+	m.frameQueueLength.WithLabelValues(queue.String(), labels.frameType, labels.messageType, labels.sendMode.String()).Inc()
+}
+
+func (m *Metrics) decFrameQueued(queue queueName, frame Frame, mode sendMode) {
+	labels := labelsForFrame(frame, mode)
+	m.frameQueueLength.WithLabelValues(queue.String(), labels.frameType, labels.messageType, labels.sendMode.String()).Dec()
+}
+
+func (m *Metrics) observeFrameQueueWait(queue queueName, frame Frame, mode sendMode, d time.Duration) {
+	labels := labelsForFrame(frame, mode)
+	m.frameQueueWaitSeconds.WithLabelValues(queue.String(), labels.frameType, labels.messageType, labels.sendMode.String()).Observe(d.Seconds())
+}
+
+func (m *Metrics) incQueueBlockedSender(queue queueName, frame Frame, mode sendMode) {
+	labels := labelsForFrame(frame, mode)
+	m.queueBlockedSenders.WithLabelValues(queue.String(), labels.frameType, labels.messageType, labels.sendMode.String()).Inc()
+}
+
+func (m *Metrics) decQueueBlockedSender(queue queueName, frame Frame, mode sendMode) {
+	labels := labelsForFrame(frame, mode)
+	m.queueBlockedSenders.WithLabelValues(queue.String(), labels.frameType, labels.messageType, labels.sendMode.String()).Dec()
+}
+
+func (m *Metrics) noteQueueBlockedSender(queue queueName, frame Frame, mode sendMode) func() {
+	if m == nil {
+		return func() {}
+	}
+	m.incQueueBlockedSender(queue, frame, mode)
+	return func() { m.decQueueBlockedSender(queue, frame, mode) }
+}
+
+// noteBlockedEnqueue records a frame that is about to block waiting for room in
+// a queue: it increments both the queue length and the blocked-sender gauge and
+// returns a function that decrements both once the enqueue settles (whether it
+// succeeded, was canceled, or the connection closed). Coupling the two gauges
+// keeps a single defer at the call site instead of one decrement per branch.
+func (m *Metrics) noteBlockedEnqueue(queue queueName, frame Frame, mode sendMode) func() {
+	if m == nil {
+		return func() {}
+	}
+	m.incFrameQueued(queue, frame, mode)
+	m.incQueueBlockedSender(queue, frame, mode)
+	return func() {
+		m.decFrameQueued(queue, frame, mode)
+		m.decQueueBlockedSender(queue, frame, mode)
+	}
+}
+
+func (m *Metrics) startFrameSend(tr transport, frame Frame, mode sendMode) *metrictimer.Timer {
+	if m == nil {
+		return nil
+	}
+	labels := labelsForFrame(frame, mode)
+	return metrictimer.New(metrictimer.Config{
+		Total:    phaseConnSendTotal,
+		HasTotal: true,
+		Rows:     6,
+		Emit: func(p metrictimer.Phase, _ metrictimer.Outcome, d time.Duration) {
+			m.frameSendSeconds.WithLabelValues(p.String(), tr.String(), labels.frameType, labels.messageType, labels.sendMode.String()).Observe(d.Seconds())
+			// write_busy is the wall-clock time the write path was actually
+			// busy, so one send timer feeds both metrics without a separate
+			// timer object. A local send takes no write lock, so its single
+			// conn_send_total row is the busy time. An HTTP/2 send waits on
+			// writeMu first (recorded on its own as the conn_write lock), so
+			// summing only the write-path phases keeps that lock wait out of
+			// write_busy.
+			switch tr {
+			case transportLocal:
+				if p == phaseConnSendTotal {
+					m.addWriteBusy(tr, d)
+				}
+			case transportHTTP2:
+				switch p {
+				case phaseSerialize, phaseWrite, phaseFlush:
+					m.addWriteBusy(tr, d)
+				}
+			}
+		},
+	})
+}
+
+// frameReceiveTimer records receive-side phase durations for one frame. The
+// receive path has no outcome dimension, so unlike the send timer it exposes
+// none. The zero value records nothing.
+type frameReceiveTimer struct {
+	t *metrictimer.Timer
+}
+
+func (m *Metrics) startFrameReceive(tr transport, frame Frame, mode sendMode) frameReceiveTimer {
+	if m == nil {
+		return frameReceiveTimer{}
+	}
+	labels := labelsForFrame(frame, mode)
+	return frameReceiveTimer{t: metrictimer.New(metrictimer.Config{
+		Rows: 4,
+		Emit: func(p metrictimer.Phase, _ metrictimer.Outcome, d time.Duration) {
+			m.frameReceiveSeconds.WithLabelValues(p.String(), tr.String(), labels.frameType, labels.messageType, labels.sendMode.String()).Observe(d.Seconds())
+		},
+	})}
+}
+
+// Observe records d for phase p on the receive timer.
+func (r frameReceiveTimer) Observe(p metrictimer.Phase, d time.Duration) { r.t.Observe(p, d) }
+
+// Done flushes the receive timer's buffered phases.
+func (r frameReceiveTimer) Done() { r.t.Done("") }
+
+// timeFrameReceive runs fn and records its elapsed time to frame_receive_seconds
+// for phase p as a single observation. The receive path has no outcome
+// dimension. A nil *Metrics still runs fn.
+func (m *Metrics) timeFrameReceive(phase metrictimer.Phase, tr transport, frame Frame, mode sendMode, fn func() error) error {
+	if m == nil {
+		return fn()
+	}
+
+	d, err := metrictimer.Time(fn)
+	m.observeFrameReceive(phase, tr, frame, mode, d)
+	return err
+}
+
+func (m *Metrics) observeFrameReceive(phase metrictimer.Phase, tr transport, frame Frame, mode sendMode, d time.Duration) {
+	timer := m.startFrameReceive(tr, frame, mode)
+	timer.Observe(phase, d)
+	timer.Done()
+}
+
+func (m *Metrics) observeFrameBytes(dir direction, frame Frame, mode sendMode, size int) {
+	if m == nil {
+		return
+	}
+	labels := labelsForFrame(frame, mode)
+	m.frameBytesTotal.WithLabelValues(dir.String(), labels.frameType, labels.messageType, labels.sendMode.String()).Add(float64(size))
+	m.frameSizeBytes.WithLabelValues(dir.String(), labels.frameType, labels.messageType, labels.sendMode.String()).Observe(float64(size))
+}
+
+func (m *Metrics) addWriteBusy(tr transport, d time.Duration) {
+	m.writeBusySecondsTotal.WithLabelValues(tr.String()).Add(d.Seconds())
+}
+
+func (m *Metrics) markActive(tr transport) {
+	m.connectionsActive.WithLabelValues(tr.String()).Inc()
+}
+
+func (m *Metrics) markInactive(tr transport) {
+	m.connectionsActive.WithLabelValues(tr.String()).Dec()
+}
+
+func (m *Metrics) startPeerHandler(messageType string) *metrictimer.Timer {
+	if m == nil {
+		return nil
+	}
+	return metrictimer.New(metrictimer.Config{
+		Total:    phaseHandlerTotal,
+		HasTotal: true,
+		Rows:     1,
+		Emit: func(_ metrictimer.Phase, out metrictimer.Outcome, d time.Duration) {
+			m.handlerSeconds.WithLabelValues(messageType, out.String()).Observe(d.Seconds())
+		},
+	})
+}
+
+func (m *Metrics) startMessageRoundtrip(kind MessageKind, mode sendMode) *metrictimer.Timer {
+	if m == nil {
+		return nil
+	}
+	return metrictimer.New(metrictimer.Config{
+		Total:    phaseRoundtripTotal,
+		HasTotal: true,
+		Rows:     1,
+		Emit: func(_ metrictimer.Phase, out metrictimer.Outcome, d time.Duration) {
+			m.messageRoundtripSeconds.WithLabelValues(kind.String(), out.String(), mode.String()).Observe(d.Seconds())
+		},
+	})
 }

--- a/pkg/engine/internal/scheduler/wire/metrics_inventory_test.go
+++ b/pkg/engine/internal/scheduler/wire/metrics_inventory_test.go
@@ -1,0 +1,100 @@
+package wire
+
+import (
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMetricInventory pins the exact set of metrics this package owns and the
+// label keys each carries. It guards the observability question tree: dropping,
+// renaming, or relabeling any of these metrics fails the test so the change is
+// deliberate. The actual set is derived by reflecting over the Metrics struct's
+// collector fields, so a newly added metric that is missing from the expected
+// map fails too. Label values are checked separately by the label-bound tests.
+func TestMetricInventory(t *testing.T) {
+	expected := map[string][]string{
+		"loki_engine_scheduler_wire_connections_active":        {"transport"},
+		"loki_engine_scheduler_wire_frame_bytes_total":         {"direction", "frame_type", "message_type", "mode"},
+		"loki_engine_scheduler_wire_frame_codec_stage_seconds": {"frame_type", "message_type", "operation", "stage"},
+		"loki_engine_scheduler_wire_frame_queue_length":        {"frame_type", "message_type", "mode", "queue"},
+		"loki_engine_scheduler_wire_frame_queue_wait_seconds":  {"frame_type", "message_type", "mode", "queue"},
+		"loki_engine_scheduler_wire_frame_receive_seconds":     {"frame_type", "message_type", "mode", "phase", "transport"},
+		"loki_engine_scheduler_wire_frame_send_seconds":        {"frame_type", "message_type", "mode", "phase", "transport"},
+		"loki_engine_scheduler_wire_frame_size_bytes":          {"direction", "frame_type", "message_type", "mode"},
+		"loki_engine_scheduler_wire_frames_received_total":     {"message_type", "type"},
+		"loki_engine_scheduler_wire_handler_seconds":           {"message_type", "outcome"},
+		"loki_engine_scheduler_wire_lock_hold_seconds":         {"lock", "mode", "reason"},
+		"loki_engine_scheduler_wire_lock_wait_seconds":         {"lock", "mode", "reason"},
+		"loki_engine_scheduler_wire_message_roundtrip_seconds": {"message_type", "mode", "outcome"},
+		"loki_engine_scheduler_wire_messages_sent_total":       {"message_type", "mode"},
+		"loki_engine_scheduler_wire_queue_blocked_senders":     {"frame_type", "message_type", "mode", "queue"},
+		"loki_engine_scheduler_wire_write_busy_seconds_total":  {"transport"},
+	}
+
+	require.Equal(t, expected, metricInventory(t, NewMetrics()))
+}
+
+// describer is satisfied by prometheus collectors and by *obslock.Metrics.
+type describer interface {
+	Describe(chan<- *prometheus.Desc)
+}
+
+var descLabelsRe = regexp.MustCompile(`fqName: "([^"]+)".*variableLabels: \{([^}]*)\}`)
+
+// metricInventory reflects over every collector field of a *Metrics value
+// (including the shared obslock lock metrics) and returns each registered
+// metric's fully-qualified name mapped to its sorted label keys.
+func metricInventory(t *testing.T, m any) map[string][]string {
+	t.Helper()
+
+	describers := collectDescribers(reflect.ValueOf(m).Elem())
+
+	ch := make(chan *prometheus.Desc)
+	go func() {
+		defer close(ch)
+		for _, d := range describers {
+			d.Describe(ch)
+		}
+	}()
+
+	inventory := make(map[string][]string)
+	for desc := range ch {
+		match := descLabelsRe.FindStringSubmatch(desc.String())
+		require.NotNilf(t, match, "could not parse descriptor %q", desc.String())
+
+		var keys []string
+		for _, key := range strings.Split(match[2], ",") {
+			if key != "" {
+				keys = append(keys, key)
+			}
+		}
+		sort.Strings(keys)
+		inventory[match[1]] = keys
+	}
+	return inventory
+}
+
+// collectDescribers returns every struct field of v that is a metric collector,
+// reading unexported fields via reflection so the inventory stays authoritative
+// without a hand-maintained accessor.
+func collectDescribers(v reflect.Value) []describer {
+	var out []describer
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		if !f.CanAddr() {
+			continue
+		}
+		fv := reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem().Interface()
+		if d, ok := fv.(describer); ok && d != nil {
+			out = append(out, d)
+		}
+	}
+	return out
+}

--- a/pkg/engine/internal/scheduler/wire/metrics_test.go
+++ b/pkg/engine/internal/scheduler/wire/metrics_test.go
@@ -1,0 +1,455 @@
+package wire
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/metrictimer"
+)
+
+func TestPeer_Metrics_Roundtrip(t *testing.T) {
+	tt := []struct {
+		name        string
+		handlerErr  error
+		wantOutcome metrictimer.Outcome
+	}{
+		{name: "ack", handlerErr: nil, wantOutcome: outcomeAck},
+		{name: "nack", handlerErr: Errorf(429, "busy"), wantOutcome: outcomeNack},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			clientMetrics := NewMetrics()
+			client := &Peer{Logger: log.NewNopLogger(), Metrics: clientMetrics, Buffer: 4}
+
+			server := &Peer{
+				Logger:  log.NewNopLogger(),
+				Metrics: NewMetrics(),
+				Buffer:  4,
+				Handler: func(_ context.Context, _ *Peer, _ Message) error { return tc.handlerErr },
+			}
+
+			peerPair(ctx, t, client, server)
+
+			err := client.SendMessage(ctx, WorkerReadyMessage{})
+			if tc.handlerErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+
+			kind := WorkerReadyMessage{}.Kind().String()
+
+			// Round trip recorded once under the right outcome, mode="sync".
+			require.Equal(t, uint64(1), histogramCount(t, clientMetrics.reg,
+				"loki_engine_scheduler_wire_message_roundtrip_seconds",
+				map[string]string{"message_type": kind, "outcome": tc.wantOutcome.String(), "mode": sendModeSync.String()}))
+
+			// Deprecated alias is removed.
+			require.Nil(t, gatherFamily(t, clientMetrics.reg, "loki_engine_scheduler_wire_message_rtt_seconds"))
+
+			// Send counted once as a mode send.
+			require.Equal(t, float64(1), counterValue(t, clientMetrics.reg,
+				"loki_engine_scheduler_wire_messages_sent_total",
+				map[string]string{"message_type": kind, "mode": sendModeSync.String()}))
+
+			// Both queues drain back to empty once the round trip completes.
+			require.Eventually(t, func() bool {
+				return gaugeSum(t, clientMetrics.reg, "loki_engine_scheduler_wire_frame_queue_length") == 0
+			}, 5*time.Second, 10*time.Millisecond, "client queues should drain")
+		})
+	}
+}
+
+func TestPeer_Metrics_AsyncSend(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	clientMetrics := NewMetrics()
+	client := &Peer{Logger: log.NewNopLogger(), Metrics: clientMetrics, Buffer: 4}
+
+	handled := make(chan struct{}, 1)
+	server := &Peer{
+		Logger:  log.NewNopLogger(),
+		Metrics: NewMetrics(),
+		Buffer:  4,
+		Handler: func(_ context.Context, _ *Peer, _ Message) error {
+			handled <- struct{}{}
+			return nil
+		},
+	}
+
+	peerPair(ctx, t, client, server)
+
+	require.NoError(t, client.SendMessageAsync(ctx, WorkerReadyMessage{}))
+
+	select {
+	case <-handled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server never handled async message")
+	}
+
+	kind := WorkerReadyMessage{}.Kind().String()
+
+	// Async sends are counted, with mode="async", and never record a round trip.
+	require.Equal(t, float64(1), counterValue(t, clientMetrics.reg,
+		"loki_engine_scheduler_wire_messages_sent_total",
+		map[string]string{"message_type": kind, "mode": sendModeAsync.String()}))
+	require.Equal(t, 0, collectCount(t, clientMetrics.reg, "loki_engine_scheduler_wire_message_roundtrip_seconds"))
+}
+
+func TestPeer_Metrics_RoundtripOutcomeClassifiers(t *testing.T) {
+	deadlineCtx, cancelDeadline := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancelDeadline()
+	canceledCtx, cancelCanceled := context.WithCancel(context.Background())
+	cancelCanceled()
+
+	require.Equal(t, outcomeTimeout, contextOutcome(deadlineCtx))
+	require.Equal(t, outcomeCanceled, contextOutcome(canceledCtx))
+
+	require.Equal(t, outcomeConnClosed, sendErrorOutcome(ErrConnClosed))
+	require.Equal(t, outcomeTimeout, sendErrorOutcome(context.DeadlineExceeded))
+	require.Equal(t, outcomeCanceled, sendErrorOutcome(context.Canceled))
+	require.Equal(t, outcomeSendError, sendErrorOutcome(errors.New("send failed")))
+
+	require.Equal(t, outcomeAck, resultOutcome(nil))
+	require.Equal(t, outcomeNack, resultOutcome(Errorf(429, "busy")))
+	require.Equal(t, outcomeSendError, resultOutcome(errors.New("local delivery failed")))
+}
+
+func TestPeer_Metrics_SendMessageFailureOutcomes(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		setup       func(*Peer) context.Context
+		wantErr     error
+		wantOutcome metrictimer.Outcome
+	}{
+		{
+			name: "timeout",
+			setup: func(*Peer) context.Context {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+				<-ctx.Done()
+				cancel()
+				return ctx
+			},
+			wantErr:     context.DeadlineExceeded,
+			wantOutcome: outcomeTimeout,
+		},
+		{
+			name: "canceled",
+			setup: func(*Peer) context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			wantErr:     context.Canceled,
+			wantOutcome: outcomeCanceled,
+		},
+		{
+			name: "connection closed",
+			setup: func(p *Peer) context.Context {
+				p.lazyInit()
+				close(p.done)
+				return context.Background()
+			},
+			wantErr:     ErrConnClosed,
+			wantOutcome: outcomeConnClosed,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			metrics := NewMetrics()
+			peer := &Peer{Logger: log.NewNopLogger(), Metrics: metrics, Buffer: 0}
+			ctx := tc.setup(peer)
+
+			err := peer.SendMessage(ctx, WorkerReadyMessage{})
+			require.ErrorIs(t, err, tc.wantErr)
+
+			require.Equal(t, uint64(1), histogramCount(t, metrics.reg,
+				"loki_engine_scheduler_wire_message_roundtrip_seconds",
+				map[string]string{
+					"message_type": WorkerReadyMessage{}.Kind().String(),
+					"outcome":      tc.wantOutcome.String(),
+					"mode":         sendModeSync.String(),
+				}))
+		})
+	}
+}
+
+func TestPeer_Metrics_ActiveConnection(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clientMetrics := NewMetrics()
+	client := &Peer{Logger: log.NewNopLogger(), Metrics: clientMetrics, Buffer: 4}
+	server := &Peer{Logger: log.NewNopLogger(), Metrics: NewMetrics(), Buffer: 4}
+
+	peerPair(ctx, t, client, server)
+
+	require.Eventually(t, func() bool {
+		return gaugeValue(t, clientMetrics.reg,
+			"loki_engine_scheduler_wire_connections_active",
+			map[string]string{"transport": transportLocal.String()}) == 1
+	}, 5*time.Second, 10*time.Millisecond, "client connection should be marked active")
+
+	cancel()
+
+	require.Eventually(t, func() bool {
+		return gaugeValue(t, clientMetrics.reg,
+			"loki_engine_scheduler_wire_connections_active",
+			map[string]string{"transport": transportLocal.String()}) == 0
+	}, 5*time.Second, 10*time.Millisecond, "client connection should be marked inactive")
+}
+
+func TestPeer_Metrics_BlockedOutgoingQueue(t *testing.T) {
+	metrics := NewMetrics()
+	peer := &Peer{Logger: log.NewNopLogger(), Metrics: metrics, Buffer: 1}
+	peer.lazyInit()
+
+	frame := MessageFrame{ID: 1, Message: WorkerReadyMessage{}}
+	peer.outgoing <- outgoingFrame{frame: frame, sendMode: sendModeAsync, enqueuedAt: time.Now()}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- peer.SendMessageAsync(ctx, WorkerReadyMessage{})
+	}()
+
+	labels := map[string]string{
+		"queue":        queueOutgoing.String(),
+		"frame_type":   FrameKindMessage.String(),
+		"message_type": WorkerReadyMessage{}.Kind().String(),
+		"mode":         sendModeAsync.String(),
+	}
+	require.Eventually(t, func() bool {
+		return gaugeValue(t, metrics.reg, "loki_engine_scheduler_wire_queue_blocked_senders", labels) == 1
+	}, 5*time.Second, 10*time.Millisecond, "sender should be blocked by the full outgoing queue")
+
+	cancel()
+	require.ErrorIs(t, <-errCh, context.Canceled)
+	require.Eventually(t, func() bool {
+		return gaugeValue(t, metrics.reg, "loki_engine_scheduler_wire_queue_blocked_senders", labels) == 0
+	}, 5*time.Second, 10*time.Millisecond, "blocked-sender gauge should drain")
+}
+
+func TestPeer_Metrics_LocalRoundTripFrameLabels(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	clientMetrics := NewMetrics()
+	client := &Peer{Logger: log.NewNopLogger(), Metrics: clientMetrics, Buffer: 4}
+	server := &Peer{
+		Logger:  log.NewNopLogger(),
+		Metrics: NewMetrics(),
+		Buffer:  4,
+		Handler: func(context.Context, *Peer, Message) error { return nil },
+	}
+	peerPair(ctx, t, client, server)
+
+	require.NoError(t, client.SendMessage(ctx, WorkerReadyMessage{}))
+
+	messageType := WorkerReadyMessage{}.Kind().String()
+	// A local send times only the connection total (the dropped
+	// local_channel_send phase equalled it), which also feeds write_busy.
+	require.Equal(t, uint64(1), histogramCount(t, clientMetrics.reg,
+		"loki_engine_scheduler_wire_frame_send_seconds",
+		map[string]string{
+			"phase":        phaseConnSendTotal.String(),
+			"transport":    transportLocal.String(),
+			"frame_type":   FrameKindMessage.String(),
+			"message_type": messageType,
+			"mode":         sendModeSync.String(),
+		}))
+	require.Equal(t, uint64(1), histogramCount(t, clientMetrics.reg,
+		"loki_engine_scheduler_wire_frame_receive_seconds",
+		map[string]string{
+			"phase":        phaseLocalChannelReceive.String(),
+			"transport":    transportLocal.String(),
+			"frame_type":   FrameKindAck.String(),
+			"message_type": "none",
+			"mode":         sendModeInternal.String(),
+		}))
+}
+
+// TestHTTP2WriteBusyExcludesLockWait proves that the write-lock wait on an
+// HTTP/2 send lands in the conn_write wire lock metric but not in
+// write_busy_seconds_total, which measures only the actual write path.
+func TestHTTP2WriteBusyExcludesLockWait(t *testing.T) {
+	metrics := NewMetrics()
+	ctx := context.Background()
+
+	conn := newHTTP2Conn(ctx, LocalScheduler, LocalWorker, io.NopCloser(&bytes.Buffer{}), io.Discard, nil, DefaultFrameCodec)
+	conn.setMetrics(metrics)
+
+	// Hold the write lock so the send has to wait to acquire it.
+	hold := conn.writeMu.Lock("test_hold")
+
+	const lockWait = 50 * time.Millisecond
+	sendErr := make(chan error, 1)
+	go func() { sendErr <- conn.sendFrame(ctx, AckFrame{ID: 1}, sendModeInternal) }()
+
+	time.Sleep(lockWait)
+	hold.Unlock()
+	require.NoError(t, <-sendErr)
+
+	// The wait to acquire writeMu is attributed to the wire lock metric.
+	waitLabels := map[string]string{"lock": "conn_write", "mode": "write", "reason": "send_frame"}
+	require.Equal(t, uint64(1), histogramCount(t, metrics.reg, "loki_engine_scheduler_wire_lock_wait_seconds", waitLabels))
+	lockWaitSum := histogramSum(t, metrics.reg, "loki_engine_scheduler_wire_lock_wait_seconds", waitLabels)
+	require.Greater(t, lockWaitSum, lockWait.Seconds()/2, "the writeMu acquisition wait should be recorded on the wire lock metric")
+
+	// write_busy is only the actual write path (serialize + write + flush), so
+	// it must exclude the lock wait entirely.
+	busy := counterValue(t, metrics.reg, "loki_engine_scheduler_wire_write_busy_seconds_total", map[string]string{"transport": transportHTTP2.String()})
+	require.Less(t, busy, lockWaitSum, "write_busy must exclude the writeMu acquisition wait")
+}
+
+// peerPair wires two Peers together over an in-process Local connection and
+// runs both until the test's context is canceled.
+func peerPair(ctx context.Context, t *testing.T, client *Peer, server *Peer) {
+	t.Helper()
+
+	listener := &Local{Address: LocalScheduler}
+
+	accepted := make(chan Conn, 1)
+	go func() {
+		conn, err := listener.Accept(ctx)
+		if err != nil {
+			return
+		}
+		accepted <- conn
+	}()
+
+	clientConn, err := listener.DialFrom(ctx, LocalWorker)
+	require.NoError(t, err)
+
+	var serverConn Conn
+	select {
+	case serverConn = <-accepted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for server connection")
+	}
+
+	client.Conn = clientConn
+	server.Conn = serverConn
+
+	go func() { _ = client.Serve(ctx) }()
+	go func() { _ = server.Serve(ctx) }()
+}
+
+func gatherFamily(t *testing.T, reg *prometheus.Registry, name string) *dto.MetricFamily {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, fam := range families {
+		if fam.GetName() == name {
+			return fam
+		}
+	}
+	return nil
+}
+
+// labelsMatch reports whether metric carries exactly the wanted label set and
+// no others. Exact matching means an accidentally added label (for example a
+// high-cardinality one) fails the lookup instead of being silently ignored.
+func labelsMatch(metric *dto.Metric, want map[string]string) bool {
+	if len(metric.GetLabel()) != len(want) {
+		return false
+	}
+	for _, lp := range metric.GetLabel() {
+		if want[lp.GetName()] != lp.GetValue() {
+			return false
+		}
+	}
+	return true
+}
+
+func histogramCount(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) uint64 {
+	t.Helper()
+	fam := gatherFamily(t, reg, name)
+	if fam == nil {
+		return 0
+	}
+	for _, m := range fam.GetMetric() {
+		if labelsMatch(m, labels) {
+			return m.GetHistogram().GetSampleCount()
+		}
+	}
+	return 0
+}
+
+func histogramSum(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) float64 {
+	t.Helper()
+	fam := gatherFamily(t, reg, name)
+	if fam == nil {
+		return 0
+	}
+	for _, m := range fam.GetMetric() {
+		if labelsMatch(m, labels) {
+			return m.GetHistogram().GetSampleSum()
+		}
+	}
+	return 0
+}
+
+func counterValue(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) float64 {
+	t.Helper()
+	fam := gatherFamily(t, reg, name)
+	if fam == nil {
+		return 0
+	}
+	for _, m := range fam.GetMetric() {
+		if labelsMatch(m, labels) {
+			return m.GetCounter().GetValue()
+		}
+	}
+	return 0
+}
+
+func gaugeValue(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) float64 {
+	t.Helper()
+	fam := gatherFamily(t, reg, name)
+	if fam == nil {
+		return 0
+	}
+	for _, m := range fam.GetMetric() {
+		if labelsMatch(m, labels) {
+			return m.GetGauge().GetValue()
+		}
+	}
+	return 0
+}
+
+func gaugeSum(t *testing.T, reg *prometheus.Registry, name string) float64 {
+	t.Helper()
+	fam := gatherFamily(t, reg, name)
+	if fam == nil {
+		return 0
+	}
+	var sum float64
+	for _, m := range fam.GetMetric() {
+		sum += m.GetGauge().GetValue()
+	}
+	return sum
+}
+
+func collectCount(t *testing.T, reg *prometheus.Registry, name string) int {
+	t.Helper()
+	fam := gatherFamily(t, reg, name)
+	if fam == nil {
+		return 0
+	}
+	return len(fam.GetMetric())
+}

--- a/pkg/engine/internal/scheduler/wire/peer.go
+++ b/pkg/engine/internal/scheduler/wire/peer.go
@@ -7,11 +7,14 @@ import (
 	"net/http"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/metrictimer"
 )
 
 // Peer wraps a [Conn] into a synchronous API that acts as both a
@@ -25,13 +28,28 @@ type Peer struct {
 	Handler Handler // Handler for incoming messages from the remote peer.
 	Buffer  int     // Buffer size for incoming and outgoing messages.
 
-	done     chan struct{}     // Closed when the peer connection is closed.
-	incoming chan MessageFrame // Buffered frame of incoming messages.
-	outgoing chan Frame        // Buffered frame of outgoing frames.
+	done     chan struct{}        // Closed when the peer connection is closed.
+	incoming chan incomingMessage // Buffered queue of incoming messages.
+	outgoing chan outgoingFrame   // Buffered queue of outgoing frames.
 	initOnce sync.Once
 
 	requestID    atomic.Uint64
 	sentRequests sync.Map // map[uint64]*request
+}
+
+// outgoingFrame wraps a Frame queued for sending with the metadata needed to
+// attribute its time spent waiting in the outgoing queue.
+type outgoingFrame struct {
+	frame      Frame
+	sendMode   sendMode
+	enqueuedAt time.Time
+}
+
+// incomingMessage wraps a received MessageFrame with the time it was enqueued
+// so the incoming-queue wait can be measured.
+type incomingMessage struct {
+	frame      MessageFrame
+	enqueuedAt time.Time
 }
 
 // Handler is a function that handles a message received from the peer. The
@@ -49,6 +67,11 @@ type Handler func(ctx context.Context, peer *Peer, message Message) error
 // Serve runs the peer, blocking until the provided context is canceled.
 func (p *Peer) Serve(ctx context.Context) error {
 	p.lazyInit()
+	p.Conn.setMetrics(p.Metrics)
+
+	transport := p.Conn.transport()
+	p.Metrics.markActive(transport)
+	defer p.Metrics.markInactive(transport)
 
 	// Defer connection close here in Serve since Peer does not have an explicit Close method.
 	defer p.Conn.Close()
@@ -65,8 +88,8 @@ func (p *Peer) Serve(ctx context.Context) error {
 func (p *Peer) lazyInit() {
 	p.initOnce.Do(func() {
 		p.done = make(chan struct{})
-		p.incoming = make(chan MessageFrame, p.Buffer)
-		p.outgoing = make(chan Frame, p.Buffer)
+		p.incoming = make(chan incomingMessage, p.Buffer)
+		p.outgoing = make(chan outgoingFrame, p.Buffer)
 	})
 }
 
@@ -85,52 +108,79 @@ func (p *Peer) recvMessages(ctx context.Context) error {
 
 		p.Metrics.incFrameReceived(frame)
 
-		switch frame := frame.(type) {
-		case MessageFrame:
-			// Queue the message for processing.
-			select {
-			case p.incoming <- frame:
-				p.Metrics.incMessageQueued()
-			case <-ctx.Done():
-				return nil
-			}
-
-		case AckFrame:
-			// If there's still a listener for this request, inform them of
-			// the success.
-			val, found := p.sentRequests.Load(frame.ID)
-			if !found {
-				continue
-			}
-			req := val.(*request)
-
-			select {
-			case req.result <- nil:
-			default:
-				level.Warn(p.Logger).Log("msg", "ignoring duplicate acknowledgement")
-			}
-
-		case NackFrame:
-			// If there's still a listener for this request, inform them of
-			// the error.
-			val, found := p.sentRequests.Load(frame.ID)
-			if !found {
-				continue
-			}
-			req := val.(*request)
-
-			select {
-			case req.result <- frame.Error:
-			default:
-				level.Warn(p.Logger).Log("msg", "ignoring duplicate acknowledgement")
-			}
-
-		case DiscardFrame:
-			// TODO(rfratto): cancel handleMessage goroutine
-
-		default:
-			level.Warn(p.Logger).Log("msg", "unknown frame type", "type", reflect.TypeOf(frame).String())
+		err = p.Metrics.timeFrameReceive(phaseRouteToQueue, p.Conn.transport(), frame, sendModeInternal, func() error {
+			return p.routeFrame(ctx, frame)
+		})
+		if err != nil {
+			return err
 		}
+	}
+}
+
+func (p *Peer) routeFrame(ctx context.Context, frame Frame) error {
+	switch frame := frame.(type) {
+	case MessageFrame:
+		return p.enqueueIncoming(ctx, frame)
+
+	case AckFrame:
+		// If there's still a listener for this request, inform them of
+		// the success.
+		val, found := p.sentRequests.Load(frame.ID)
+		if !found {
+			return nil
+		}
+		req := val.(*request)
+
+		select {
+		case req.result <- nil:
+		default:
+			level.Warn(p.Logger).Log("msg", "ignoring duplicate acknowledgement")
+		}
+
+	case NackFrame:
+		// If there's still a listener for this request, inform them of
+		// the error.
+		val, found := p.sentRequests.Load(frame.ID)
+		if !found {
+			return nil
+		}
+		req := val.(*request)
+
+		select {
+		case req.result <- frame.Error:
+		default:
+			level.Warn(p.Logger).Log("msg", "ignoring duplicate acknowledgement")
+		}
+
+	case DiscardFrame:
+		// TODO(rfratto): cancel handleMessage goroutine
+
+	default:
+		level.Warn(p.Logger).Log("msg", "unknown frame type", "type", reflect.TypeOf(frame).String())
+	}
+	return nil
+}
+
+func (p *Peer) enqueueIncoming(ctx context.Context, frame MessageFrame) error {
+	queued := incomingMessage{frame: frame, enqueuedAt: time.Now()}
+	select {
+	case p.incoming <- queued:
+		p.noteFrameEnqueued(queueIncoming, frame, sendModeInternal)
+		return nil
+	case <-ctx.Done():
+		return nil
+	default:
+	}
+
+	done := p.noteQueueBlockedSender(queueIncoming, frame, sendModeInternal)
+	defer done()
+
+	select {
+	case p.incoming <- queued:
+		p.noteFrameEnqueued(queueIncoming, frame, sendModeInternal)
+		return nil
+	case <-ctx.Done():
+		return nil
 	}
 }
 
@@ -141,8 +191,8 @@ func (p *Peer) handleIncoming(ctx context.Context) error {
 			return nil
 		case <-p.done:
 			return nil // Closed connection.
-		case frame := <-p.incoming:
-			p.Metrics.decMessageQueued()
+		case queued := <-p.incoming:
+			frame := p.dequeueIncoming(queued)
 			p.processMessage(ctx, frame.ID, frame.Message)
 		}
 	}
@@ -155,13 +205,37 @@ func (p *Peer) handleOutgoing(ctx context.Context) error {
 			return nil
 		case <-p.done:
 			return nil // Closed connection.
-		case frame := <-p.outgoing:
-			if err := p.Conn.Send(ctx, frame); err != nil && ctx.Err() == nil {
+		case queued := <-p.outgoing:
+			frame, sendMode := p.dequeueOutgoing(queued)
+			if err := p.Conn.sendFrame(ctx, frame, sendMode); err != nil && ctx.Err() == nil {
 				level.Warn(p.Logger).Log("msg", "failed to send message", "error", err)
 				p.notifyError(frame, err)
 			}
 		}
 	}
+}
+
+func (p *Peer) dequeueIncoming(queued incomingMessage) MessageFrame {
+	p.noteFrameDequeued(queueIncoming, queued.frame, sendModeInternal, queued.enqueuedAt)
+	return queued.frame
+}
+
+func (p *Peer) dequeueOutgoing(queued outgoingFrame) (Frame, sendMode) {
+	p.noteFrameDequeued(queueOutgoing, queued.frame, queued.sendMode, queued.enqueuedAt)
+	return queued.frame, queued.sendMode
+}
+
+func (p *Peer) noteFrameEnqueued(queue queueName, frame Frame, sendMode sendMode) {
+	p.Metrics.incFrameQueued(queue, frame, sendMode)
+}
+
+func (p *Peer) noteFrameDequeued(queue queueName, frame Frame, sendMode sendMode, enqueuedAt time.Time) {
+	p.Metrics.decFrameQueued(queue, frame, sendMode)
+	p.Metrics.observeFrameQueueWait(queue, frame, sendMode, time.Since(enqueuedAt))
+}
+
+func (p *Peer) noteQueueBlockedSender(queue queueName, frame Frame, sendMode sendMode) func() {
+	return p.Metrics.noteQueueBlockedSender(queue, frame, sendMode)
 }
 
 // notifyError notifies any request listeners of a frame that an error occurred
@@ -190,18 +264,28 @@ func (p *Peer) notifyError(frame Frame, err error) {
 
 // processMessage handles a message received from the peer.
 func (p *Peer) processMessage(ctx context.Context, id uint64, message Message) {
+	messageType := "unknown"
+	if message != nil {
+		messageType = message.Kind().String()
+	}
+
+	timer := p.Metrics.startPeerHandler(messageType)
+	outcome := outcomeNack
+	defer func() { timer.Done(outcome) }()
+
 	if p.Handler == nil {
-		_ = p.enqueueFrame(ctx, NackFrame{ID: id, Error: Errorf(http.StatusNotImplemented, "not implemented")})
+		_ = p.enqueueFrame(ctx, NackFrame{ID: id, Error: Errorf(http.StatusNotImplemented, "not implemented")}, sendModeInternal)
 		return
 	}
 
 	switch err := p.Handler(ctx, p, message); err {
 	case nil:
+		outcome = outcomeAck
 		// TODO(rfratto): What should we do if this fails? Logs? Metrics?
-		_ = p.enqueueFrame(ctx, AckFrame{ID: id})
+		_ = p.enqueueFrame(ctx, AckFrame{ID: id}, sendModeInternal)
 	default:
 		// TODO(rfratto): What should we do if this fails? Logs? Metrics?
-		_ = p.enqueueFrame(ctx, NackFrame{ID: id, Error: convertError(err)})
+		_ = p.enqueueFrame(ctx, NackFrame{ID: id, Error: convertError(err)}, sendModeInternal)
 	}
 }
 
@@ -237,23 +321,64 @@ func (p *Peer) SendMessage(ctx context.Context, message Message) error {
 	p.sentRequests.Store(reqID, req)
 	defer p.sentRequests.Delete(reqID)
 
-	timer := p.Metrics.newMessageRTTTimer(message.Kind().String())
-	defer timer.ObserveDuration()
-	p.Metrics.incMessageSent(message.Kind().String())
+	roundtrip := p.Metrics.startMessageRoundtrip(message.Kind(), sendModeSync)
+	outcome := outcomeSendError
+	defer func() { roundtrip.Done(outcome) }()
+	p.Metrics.incMessageSent(message.Kind(), sendModeSync)
 
-	if err := p.enqueueFrame(ctx, MessageFrame{ID: reqID, Message: message}); err != nil {
+	if err := p.enqueueFrame(ctx, MessageFrame{ID: reqID, Message: message}, sendModeSync); err != nil {
+		outcome = sendErrorOutcome(err)
 		return err
 	}
 
 	select {
 	case <-ctx.Done():
 		// TODO(rfratto): queue a DiscardFrame
+		outcome = contextOutcome(ctx)
 		return ctx.Err()
 	case <-p.done:
+		outcome = outcomeConnClosed
 		return ErrConnClosed
 	case err := <-req.result:
+		outcome = resultOutcome(err)
 		return err
 	}
+}
+
+// contextOutcome classifies a canceled context into a round-trip outcome.
+func contextOutcome(ctx context.Context) metrictimer.Outcome {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return outcomeTimeout
+	}
+	return outcomeCanceled
+}
+
+// sendErrorOutcome classifies an enqueue error into a round-trip outcome.
+func sendErrorOutcome(err error) metrictimer.Outcome {
+	switch {
+	case errors.Is(err, ErrConnClosed):
+		return outcomeConnClosed
+	case errors.Is(err, context.DeadlineExceeded):
+		return outcomeTimeout
+	case errors.Is(err, context.Canceled):
+		return outcomeCanceled
+	default:
+		return outcomeSendError
+	}
+}
+
+// resultOutcome classifies the result delivered to a request into a round-trip
+// outcome. A nil result is an ack, a wire [*Error] is a nack from the remote
+// handler, and any other error is a local delivery failure.
+func resultOutcome(err error) metrictimer.Outcome {
+	if err == nil {
+		return outcomeAck
+	}
+	var wireErr *Error
+	if errors.As(err, &wireErr) {
+		return outcomeNack
+	}
+	return outcomeSendError
 }
 
 // SendMessageAsync sends a message to the remote peer asynchronously.
@@ -266,18 +391,35 @@ func (p *Peer) SendMessageAsync(ctx context.Context, message Message) error {
 	p.lazyInit()
 
 	reqID := p.requestID.Inc()
-	p.Metrics.incMessageSent(message.Kind().String())
-	return p.enqueueFrame(ctx, MessageFrame{ID: reqID, Message: message})
+	p.Metrics.incMessageSent(message.Kind(), sendModeAsync)
+	return p.enqueueFrame(ctx, MessageFrame{ID: reqID, Message: message}, sendModeAsync)
 }
 
-// enqueueFrame enqueues a frame to be sent to the remote peer.
-func (p *Peer) enqueueFrame(ctx context.Context, frame Frame) error {
+// enqueueFrame enqueues a frame to be sent to the remote peer. sendMode records
+// how the send was issued (sync|async|internal) for queue metrics.
+func (p *Peer) enqueueFrame(ctx context.Context, frame Frame, sendMode sendMode) error {
+	queued := outgoingFrame{frame: frame, sendMode: sendMode, enqueuedAt: time.Now()}
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-p.done:
 		return ErrConnClosed
-	case p.outgoing <- frame:
+	case p.outgoing <- queued:
+		p.noteFrameEnqueued(queueOutgoing, frame, sendMode)
+		return nil
+	default:
+	}
+
+	done := p.noteQueueBlockedSender(queueOutgoing, frame, sendMode)
+	defer done()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-p.done:
+		return ErrConnClosed
+	case p.outgoing <- queued:
+		p.noteFrameEnqueued(queueOutgoing, frame, sendMode)
 		return nil
 	}
 }

--- a/pkg/engine/internal/scheduler/wire/wire.go
+++ b/pkg/engine/internal/scheduler/wire/wire.go
@@ -63,4 +63,14 @@ type Conn interface {
 
 	// RemoteAddr returns the address of the remote side of the connection.
 	RemoteAddr() net.Addr
+
+	// transport returns the bounded transport label for metrics.
+	transport() transport
+
+	// setMetrics binds the metrics used by the connection's internal send and
+	// receive paths.
+	setMetrics(*Metrics)
+
+	// sendFrame sends frame with the send mode label supplied by Peer.
+	sendFrame(context.Context, Frame, sendMode) error
 }

--- a/pkg/engine/internal/scheduler/wire/wire_http2.go
+++ b/pkg/engine/internal/scheduler/wire/wire_http2.go
@@ -13,7 +13,10 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"go.uber.org/atomic"
 	"golang.org/x/net/http2"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/obslock"
 )
 
 // peerAddressHeader is the header used to advertise the address to connect back
@@ -176,16 +179,23 @@ type http2Conn struct {
 	responseController *http.ResponseController
 	cleanup            func() // Optional cleanup function
 
-	writeMu   sync.Mutex
+	writeMu   obslock.Mutex
 	closeOnce sync.Once
 	closed    chan struct{}
+
+	// scratch is the reusable encode buffer for this connection's sends. It is
+	// only ever touched while holding writeMu, so it needs no further guarding.
+	scratch []byte
+
+	metrics atomic.Pointer[Metrics]
 
 	incomingCh chan incomingFrame
 }
 
 type incomingFrame struct {
-	frame Frame
-	err   error
+	frame      Frame
+	err        error
+	enqueuedAt time.Time
 }
 
 var _ Conn = (*http2Conn)(nil)
@@ -214,24 +224,81 @@ func newHTTP2Conn(
 	return c
 }
 
+func (c *http2Conn) setMetrics(metrics *Metrics) {
+	c.metrics.Store(metrics)
+	if metrics != nil {
+		c.writeMu.Init("conn_write", metrics.lock)
+	}
+}
+
+func (c *http2Conn) transport() transport { return transportHTTP2 }
+
 func (c *http2Conn) readLoop(ctx context.Context) {
 	for {
-		frame, err := c.codec.DecodeFrom(c.reader)
-		incoming := incomingFrame{frame: frame, err: err}
+		metrics := c.metrics.Load()
+		frame, size, err := c.codec.decode(c.reader, metrics)
+		if err == nil && metrics != nil {
+			metrics.observeFrameBytes(directionIncoming, frame, sendModeInternal, size)
+		}
+
+		incoming := incomingFrame{frame: frame, err: err, enqueuedAt: time.Now()}
+		if err := c.enqueueIncoming(ctx, incoming); err != nil {
+			return
+		}
+	}
+}
+
+func (c *http2Conn) enqueueIncoming(ctx context.Context, incoming incomingFrame) error {
+	metrics := c.metrics.Load()
+	if incoming.err != nil || metrics == nil {
 		select {
 		case <-ctx.Done():
-			return
+			return ctx.Err()
 		case <-c.closed:
-			return
+			return ErrConnClosed
 		case c.incomingCh <- incoming:
+			return nil
 		}
+	}
+
+	frame := incoming.frame
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.closed:
+		return ErrConnClosed
+	case c.incomingCh <- incoming:
+		metrics.observeFrameQueueWait(queueConnDispatch, frame, sendModeInternal, time.Since(incoming.enqueuedAt))
+		return nil
+	default:
+	}
+
+	done := metrics.noteBlockedEnqueue(queueConnDispatch, frame, sendModeInternal)
+	defer done()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.closed:
+		return ErrConnClosed
+	case c.incomingCh <- incoming:
+		metrics.observeFrameQueueWait(queueConnDispatch, frame, sendModeInternal, time.Since(incoming.enqueuedAt))
+		return nil
 	}
 }
 
 // Send sends a frame over the connection.
 func (c *http2Conn) Send(ctx context.Context, frame Frame) error {
-	c.writeMu.Lock()
-	defer c.writeMu.Unlock()
+	return c.sendFrame(ctx, frame, sendModeInternal)
+}
+
+func (c *http2Conn) sendFrame(ctx context.Context, frame Frame, sendMode sendMode) error {
+	metrics := c.metrics.Load()
+	timer := metrics.startFrameSend(transportHTTP2, frame, sendMode)
+	defer timer.Done(outcomeNone)
+
+	guard := c.writeMu.Lock("send_frame")
+	defer guard.Unlock()
 
 	select {
 	case <-c.ctx.Done():
@@ -243,21 +310,31 @@ func (c *http2Conn) Send(ctx context.Context, frame Frame) error {
 	default:
 	}
 
-	err := c.codec.EncodeTo(c.writer, frame)
+	timer.Phase(phaseSerialize)
+	c.scratch = c.codec.encode(frame, metrics, c.scratch)
+	data := c.scratch
+
+	timer.Phase(phaseWrite)
+	written, err := c.writer.Write(data)
 	if err != nil && isHTTP2Error(err) {
 		return ErrConnClosed
 	} else if err != nil {
 		return fmt.Errorf("write frame: %w", err)
 	}
+	if written != len(data) {
+		return fmt.Errorf("write frame: incomplete write: wrote %d bytes, expected %d", written, len(data))
+	}
+	metrics.observeFrameBytes(directionOutgoing, frame, sendMode, len(data))
 
-	// Flush after each frame to ensure immediate delivery
+	// Flush after each frame to ensure immediate delivery.
+	timer.Phase(phaseFlush)
 	if c.responseController != nil {
-		err := c.responseController.Flush()
-		if err != nil && isHTTP2Error(err) {
-			return ErrConnClosed
-		} else if err != nil {
-			return fmt.Errorf("flush response: %w", err)
-		}
+		err = c.responseController.Flush()
+	}
+	if err != nil && isHTTP2Error(err) {
+		return ErrConnClosed
+	} else if err != nil {
+		return fmt.Errorf("flush response: %w", err)
 	}
 
 	return nil
@@ -279,12 +356,13 @@ func (c *http2Conn) Recv(ctx context.Context) (Frame, error) {
 
 // Close closes the connection.
 func (c *http2Conn) Close() error {
-	c.writeMu.Lock()
-	defer c.writeMu.Unlock()
+	guard := c.writeMu.Lock("close")
+	defer guard.Unlock()
 
 	var err error
 	c.closeOnce.Do(func() {
 		close(c.closed)
+
 		err = c.reader.Close()
 		if c.cleanup != nil {
 			c.cleanup()

--- a/pkg/engine/internal/scheduler/wire/wire_local.go
+++ b/pkg/engine/internal/scheduler/wire/wire_local.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
+
+	"go.uber.org/atomic"
 )
 
 var (
@@ -132,11 +135,31 @@ type localConn struct {
 
 	write chan<- Frame
 	read  <-chan Frame
+
+	metrics atomic.Pointer[Metrics]
 }
 
 var _ Conn = (*localConn)(nil)
 
+func (c *localConn) setMetrics(metrics *Metrics) {
+	c.metrics.Store(metrics)
+}
+
+func (c *localConn) transport() transport { return transportLocal }
+
 func (c *localConn) Send(ctx context.Context, frame Frame) error {
+	return c.sendFrame(ctx, frame, sendModeInternal)
+}
+
+func (c *localConn) sendFrame(ctx context.Context, frame Frame, sendMode sendMode) error {
+	metrics := c.metrics.Load()
+	timer := metrics.startFrameSend(transportLocal, frame, sendMode)
+	defer timer.Done(outcomeNone)
+
+	return c.send(ctx, frame)
+}
+
+func (c *localConn) send(ctx context.Context, frame Frame) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -148,6 +171,8 @@ func (c *localConn) Send(ctx context.Context, frame Frame) error {
 }
 
 func (c *localConn) Recv(ctx context.Context) (Frame, error) {
+	start := time.Now()
+
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -158,6 +183,9 @@ func (c *localConn) Recv(ctx context.Context) (Frame, error) {
 			// Close our end, in case it's not already closed.
 			_ = c.Close()
 			return nil, ErrConnClosed
+		}
+		if metrics := c.metrics.Load(); metrics != nil {
+			metrics.observeFrameReceive(phaseLocalChannelReceive, transportLocal, frame, sendModeInternal, time.Since(start))
 		}
 		return frame, nil
 	}

--- a/pkg/engine/internal/worker/job_manager_test.go
+++ b/pkg/engine/internal/worker/job_manager_test.go
@@ -33,7 +33,8 @@ func Test_jobManager(t *testing.T) {
 		ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 		defer cancel()
 
-		require.NoError(t, jm.WaitReady(ctx), "WaitReady should return when a Recv call is waiting")
+		err := jm.WaitReady(ctx)
+		require.NoError(t, err, "WaitReady should return when a Recv call is waiting")
 	})
 
 	t.Run("Send fails with no calls to Recv", func(t *testing.T) {

--- a/pkg/engine/internal/worker/metrics.go
+++ b/pkg/engine/internal/worker/metrics.go
@@ -1,18 +1,75 @@
 package worker
 
 import (
+	"context"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/metrictimer"
+	"github.com/grafana/loki/v3/pkg/engine/internal/obslock"
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
 )
+
+type taskType string
 
 // Task type label values used to partition per-task worker metrics. A leaf task
 // reads directly from storage (it has no external task sources); a non-leaf
 // task receives its input from one or more child tasks.
 const (
-	taskTypeLeaf    = "leaf"
-	taskTypeNonLeaf = "non_leaf"
+	taskTypeLeaf    taskType = "leaf"
+	taskTypeNonLeaf taskType = "non_leaf"
+)
+
+func (t taskType) String() string { return string(t) }
+
+// Handler phase label values.
+const (
+	phaseTotal           metrictimer.Phase = "total"
+	phaseSourceWriteWait metrictimer.Phase = "source_write_wait"
+)
+
+type sendMode string
+
+// send mode label values. The Prometheus label is named "mode".
+const (
+	sendModeSync     sendMode = "sync"
+	sendModeAsync    sendMode = "async"
+	sendModeInternal sendMode = "internal"
+)
+
+func (m sendMode) String() string { return string(m) }
+
+// Slot phase label values.
+const (
+	slotPhaseCompute metrictimer.Phase = "compute"
+	slotPhaseComm    metrictimer.Phase = "comm"
+)
+
+// Outcome label values shared by bounded worker metrics.
+const (
+	outcomeAck        metrictimer.Outcome = "ack"
+	outcomeNack       metrictimer.Outcome = "nack"
+	outcomeSuccess    metrictimer.Outcome = "success"
+	outcomeCanceled   metrictimer.Outcome = "canceled"
+	outcomeTimeout    metrictimer.Outcome = "timeout"
+	outcomeConnClosed metrictimer.Outcome = "conn_closed"
+	outcomeError      metrictimer.Outcome = "error"
+	outcomeNack429    metrictimer.Outcome = "nack_429"
+
+	outcomeAssigned   metrictimer.Outcome = "assigned"
+	outcomeShutdown   metrictimer.Outcome = "shutdown"
+	outcomeUnknown    metrictimer.Outcome = "unknown"
+	outcomeFailed     metrictimer.Outcome = "failed"
+	outcomeSent       metrictimer.Outcome = "sent"
+	outcomeNoReady429 metrictimer.Outcome = "no_ready_429"
+	outcomeCtxError   metrictimer.Outcome = "ctx_error"
+
+	outcomeNone        metrictimer.Outcome = "none"
+	outcomeRejected    metrictimer.Outcome = "rejected"
+	outcomeServerError metrictimer.Outcome = "server_error"
+	outcomeOther       metrictimer.Outcome = "other"
 )
 
 // metrics is a container of metrics for a worker.
@@ -42,6 +99,12 @@ type metrics struct {
 	statusUpdateSeconds     prometheus.Histogram
 	statusUpdateErrorsTotal *prometheus.CounterVec
 
+	handlerPhaseSeconds  *prometheus.HistogramVec
+	commSiteWaitSeconds  *prometheus.HistogramVec
+	slotPhaseSeconds     *prometheus.CounterVec
+	slotReadyWaitSeconds *prometheus.HistogramVec
+	jobHandoffSeconds    *prometheus.HistogramVec
+
 	// Task I/O counters, read from per-task captures at task completion. Only
 	// leaf tasks download from object storage today, so these are zero for
 	// non-leaf tasks until that changes.
@@ -53,6 +116,9 @@ type metrics struct {
 	operatorSelfSeconds  *prometheus.HistogramVec
 	operatorRowsInTotal  *prometheus.CounterVec
 	operatorRowsOutTotal *prometheus.CounterVec
+
+	// lock holds the instruments for the worker's observed mutex.
+	lock *obslock.Metrics
 }
 
 func newMetrics() *metrics {
@@ -60,6 +126,10 @@ func newMetrics() *metrics {
 
 	return &metrics{
 		reg: reg,
+		lock: obslock.NewMetrics(reg,
+			"loki_engine_worker_lock_wait_seconds",
+			"loki_engine_worker_lock_hold_seconds",
+		),
 
 		tasksAssignedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "loki_engine_worker_tasks_assigned_total",
@@ -69,78 +139,66 @@ func newMetrics() *metrics {
 			Name: "loki_engine_worker_rejected_assignments_total",
 			Help: "Total number of task assignments the worker rejected because no thread slot was available (worker-side counterpart to the scheduler's assignment_backoffs_total)",
 		}),
-		taskExecSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		taskExecSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_task_exec_seconds",
 			Help: "Number of seconds a task took to complete successfully",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"task_type"}),
 
-		passReadSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		passReadSeconds: newNativeHistogram(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_pass_read_seconds",
 			Help: "Duration of a single read-phase pass",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}),
-		passSendSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		passSendSeconds: newNativeHistogram(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_pass_send_seconds",
 			Help: "Duration of a single send-phase pass",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}),
 
-		taskOpenSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		taskOpenSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_task_open_seconds",
 			Help: "Total time spent opening a task's pipeline (Pipeline.Open)",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"task_type"}),
-		taskReadSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		taskReadSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_task_read_seconds",
 			Help: "Total time spent in the read phase (Pipeline.Read) for a task",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"task_type"}),
-		taskSendSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		taskSendSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_task_send_seconds",
 			Help: "Total time spent in the send phase for a task",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"task_type"}),
 
-		setupSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		setupSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_setup_seconds",
 			Help: "Time spent preparing a task for execution before its pipeline is drained",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"task_type"}),
 
-		statusUpdateSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		statusUpdateSeconds: newNativeHistogram(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_status_update_seconds",
 			Help: "Time spent sending a task's terminal status update to the scheduler and waiting for acknowledgement",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}),
 		statusUpdateErrorsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_engine_worker_status_update_errors_total",
 			Help: "Total number of failures sending a task's terminal status update to the scheduler, by error class",
 		}, []string{"error_class"}),
+		handlerPhaseSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_worker_handler_phase_seconds",
+			Help: "Time spent in bounded worker handler phases",
+		}, []string{"message_type", "phase", "outcome"}),
+		commSiteWaitSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_worker_comm_site_wait_seconds",
+			Help: "Time a worker task spent waiting at a bounded communication site",
+		}, []string{"site", "mode", "message_type", "task_type", "outcome"}),
+		slotPhaseSeconds: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_engine_worker_slot_phase_seconds_total",
+			Help: "Worker slot busy wall time partitioned into time the main task goroutine spent blocked on communication versus computing",
+		}, []string{"phase", "task_type", "outcome"}),
+		slotReadyWaitSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_worker_slot_ready_wait_seconds",
+			Help: "Time from a worker slot becoming ready until it receives a job or exits",
+		}, []string{"outcome"}),
+		jobHandoffSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
+			Name: "loki_engine_worker_job_handoff_seconds",
+			Help: "Time for the TaskAssign handler to hand a job to a ready worker thread",
+		}, []string{"outcome"}),
 
 		pagesDownloadedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "loki_engine_worker_pages_downloaded_total",
@@ -148,20 +206,16 @@ func newMetrics() *metrics {
 		}),
 		pagesPrunedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "loki_engine_worker_pages_pruned_total",
-			Help: "Total number of pages pruned via metadata before download during task execution",
+			Help: "Total number of pages pruned via metadata before download",
 		}),
 		bytesDownloadedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "loki_engine_worker_bytes_downloaded_total",
 			Help: "Total number of bytes downloaded from object storage during task execution",
 		}),
 
-		operatorSelfSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		operatorSelfSeconds: newNativeHistogramVec(reg, prometheus.HistogramOpts{
 			Name: "loki_engine_worker_operator_self_seconds",
 			Help: "Per-operator wall-clock (not CPU) self-time, exclusive of child operators, by operator type",
-
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"operator_type"}),
 		operatorRowsInTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_engine_worker_operator_rows_in_total",
@@ -172,6 +226,93 @@ func newMetrics() *metrics {
 			Help: "Total rows produced by an operator, by operator type",
 		}, []string{"operator_type"}),
 	}
+}
+
+func newNativeHistogramVec(r prometheus.Registerer, opts prometheus.HistogramOpts, labels []string) *prometheus.HistogramVec {
+	applyNativeHistogramOpts(&opts)
+	return promauto.With(r).NewHistogramVec(opts, labels)
+}
+
+func newNativeHistogram(r prometheus.Registerer, opts prometheus.HistogramOpts) prometheus.Histogram {
+	applyNativeHistogramOpts(&opts)
+	return promauto.With(r).NewHistogram(opts)
+}
+
+func applyNativeHistogramOpts(opts *prometheus.HistogramOpts) {
+	opts.NativeHistogramBucketFactor = 1.1
+	opts.NativeHistogramMaxBucketNumber = 100
+	opts.NativeHistogramMinResetDuration = time.Hour
+}
+
+func (m *metrics) startHandler(kind wire.MessageKind) *metrictimer.Timer {
+	if m == nil {
+		return nil
+	}
+	messageType := kind.String()
+	return metrictimer.New(metrictimer.Config{
+		Total:    phaseTotal,
+		HasTotal: true,
+		Rows:     4,
+		Emit: func(phase metrictimer.Phase, outcome metrictimer.Outcome, d time.Duration) {
+			m.handlerPhaseSeconds.WithLabelValues(messageType, phase.String(), outcome.String()).Observe(d.Seconds())
+		},
+	})
+}
+
+func handlerOutcome(err error) metrictimer.Outcome {
+	if err != nil {
+		return outcomeNack
+	}
+	return outcomeAck
+}
+
+// timeCommSite times fn as a single blocking call at a bounded communication
+// site, recording its wait and outcome to comm_site_wait_seconds. It returns
+// the measured duration so callers can also fold it into slot utilization, plus
+// fn's error. A nil *metrics still runs fn. site is used at exactly one call
+// site apiece, so it is passed as a plain string rather than a named enum.
+// comm_site_wait_seconds is the per-site attribution layer; slot
+// comm-vs-compute utilization is accumulated separately on the main runJob
+// goroutine.
+func (m *metrics) timeCommSite(site string, mode sendMode, messageType wire.MessageKind, taskType taskType, fn func() error) (time.Duration, error) {
+	d, err := metrictimer.Time(fn)
+	if m != nil {
+		m.observeCommSite(site, mode, messageType, taskType, commOutcome(err), d)
+	}
+	return d, err
+}
+
+// timeSend times a fire-and-forget or acknowledged send at a communication
+// site: it sends msg to sender (asynchronously when mode is async, otherwise
+// synchronously) and records the wait to comm_site_wait_seconds, deriving the
+// message_type label from msg. It is the send-shaped counterpart to
+// timeCommSite, sparing pure-send sites a one-line callback.
+func (m *metrics) timeSend(ctx context.Context, sender *wire.Peer, site string, mode sendMode, taskType taskType, msg wire.Message) (time.Duration, error) {
+	return m.timeCommSite(site, mode, msg.Kind(), taskType, func() error {
+		if mode == sendModeAsync {
+			return sender.SendMessageAsync(ctx, msg)
+		}
+		return sender.SendMessage(ctx, msg)
+	})
+}
+
+func (m *metrics) observeCommSite(site string, mode sendMode, messageType wire.MessageKind, taskType taskType, outcome metrictimer.Outcome, d time.Duration) {
+	m.commSiteWaitSeconds.WithLabelValues(site, mode.String(), messageType.String(), taskType.String(), outcome.String()).Observe(d.Seconds())
+}
+
+func (m *metrics) addSlotPhase(phase metrictimer.Phase, taskType taskType, outcome metrictimer.Outcome, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	m.slotPhaseSeconds.WithLabelValues(phase.String(), taskType.String(), outcome.String()).Add(d.Seconds())
+}
+
+func (m *metrics) observeSlotReadyWait(outcome metrictimer.Outcome, d time.Duration) {
+	m.slotReadyWaitSeconds.WithLabelValues(outcome.String()).Observe(d.Seconds())
+}
+
+func (m *metrics) observeJobHandoff(outcome metrictimer.Outcome, d time.Duration) {
+	m.jobHandoffSeconds.WithLabelValues(outcome.String()).Observe(d.Seconds())
 }
 
 // Register registers metrics to report to reg.

--- a/pkg/engine/internal/worker/metrics_helpers_test.go
+++ b/pkg/engine/internal/worker/metrics_helpers_test.go
@@ -14,6 +14,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/engine/internal/metrictimer"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
@@ -59,7 +60,7 @@ func TestTaskTypeLabel(t *testing.T) {
 	tests := []struct {
 		name string
 		task *workflow.Task
-		want string
+		want taskType
 	}{
 		{
 			name: "no sources is leaf",
@@ -88,17 +89,17 @@ func TestStatusUpdateErrorClass(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
-		want string
+		want metrictimer.Outcome
 	}{
-		{name: "nil", err: nil, want: "none"},
-		{name: "canceled", err: context.Canceled, want: "canceled"},
-		{name: "wrapped canceled", err: fmt.Errorf("send: %w", context.Canceled), want: "canceled"},
-		{name: "deadline", err: context.DeadlineExceeded, want: "timeout"},
-		{name: "conn closed", err: wire.ErrConnClosed, want: "conn_closed"},
-		{name: "client error", err: wire.Errorf(http.StatusTooManyRequests, "busy"), want: "rejected"},
-		{name: "server error", err: wire.Errorf(http.StatusInternalServerError, "boom"), want: "server_error"},
-		{name: "wrapped server error", err: fmt.Errorf("send: %w", wire.Errorf(http.StatusBadGateway, "boom")), want: "server_error"},
-		{name: "other", err: errors.New("nope"), want: "other"},
+		{name: "nil", err: nil, want: outcomeNone},
+		{name: "canceled", err: context.Canceled, want: outcomeCanceled},
+		{name: "wrapped canceled", err: fmt.Errorf("send: %w", context.Canceled), want: outcomeCanceled},
+		{name: "deadline", err: context.DeadlineExceeded, want: outcomeTimeout},
+		{name: "conn closed", err: wire.ErrConnClosed, want: outcomeConnClosed},
+		{name: "client error", err: wire.Errorf(http.StatusTooManyRequests, "busy"), want: outcomeRejected},
+		{name: "server error", err: wire.Errorf(http.StatusInternalServerError, "boom"), want: outcomeServerError},
+		{name: "wrapped server error", err: fmt.Errorf("send: %w", wire.Errorf(http.StatusBadGateway, "boom")), want: outcomeServerError},
+		{name: "other", err: errors.New("nope"), want: outcomeOther},
 	}
 
 	for _, tt := range tests {

--- a/pkg/engine/internal/worker/metrics_inventory_test.go
+++ b/pkg/engine/internal/worker/metrics_inventory_test.go
@@ -1,0 +1,108 @@
+package worker
+
+import (
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMetricInventory pins the exact set of metrics this package owns and the
+// label keys each carries. It guards the observability question tree: dropping,
+// renaming, or relabeling any of these metrics fails the test so the change is
+// deliberate. The actual set is derived by reflecting over the metrics struct's
+// collector fields, so a newly added metric that is missing from the expected
+// map fails too. Label values are checked separately by the label-bound tests.
+func TestMetricInventory(t *testing.T) {
+	expected := map[string][]string{
+		"loki_engine_worker_bytes_downloaded_total":     nil,
+		"loki_engine_worker_comm_site_wait_seconds":     {"message_type", "mode", "outcome", "site", "task_type"},
+		"loki_engine_worker_handler_phase_seconds":      {"message_type", "outcome", "phase"},
+		"loki_engine_worker_job_handoff_seconds":        {"outcome"},
+		"loki_engine_worker_lock_hold_seconds":          {"lock", "mode", "reason"},
+		"loki_engine_worker_lock_wait_seconds":          {"lock", "mode", "reason"},
+		"loki_engine_worker_operator_rows_in_total":     {"operator_type"},
+		"loki_engine_worker_operator_rows_out_total":    {"operator_type"},
+		"loki_engine_worker_operator_self_seconds":      {"operator_type"},
+		"loki_engine_worker_pages_downloaded_total":     nil,
+		"loki_engine_worker_pages_pruned_total":         nil,
+		"loki_engine_worker_pass_read_seconds":          nil,
+		"loki_engine_worker_pass_send_seconds":          nil,
+		"loki_engine_worker_rejected_assignments_total": nil,
+		"loki_engine_worker_setup_seconds":              {"task_type"},
+		"loki_engine_worker_slot_phase_seconds_total":   {"outcome", "phase", "task_type"},
+		"loki_engine_worker_slot_ready_wait_seconds":    {"outcome"},
+		"loki_engine_worker_status_update_errors_total": {"error_class"},
+		"loki_engine_worker_status_update_seconds":      nil,
+		"loki_engine_worker_task_exec_seconds":          {"task_type"},
+		"loki_engine_worker_task_open_seconds":          {"task_type"},
+		"loki_engine_worker_task_read_seconds":          {"task_type"},
+		"loki_engine_worker_task_send_seconds":          {"task_type"},
+		"loki_engine_worker_tasks_assigned_total":       nil,
+	}
+
+	require.Equal(t, expected, metricInventory(t, newMetrics()))
+}
+
+// describer is satisfied by prometheus collectors and by *obslock.Metrics.
+type describer interface {
+	Describe(chan<- *prometheus.Desc)
+}
+
+var descLabelsRe = regexp.MustCompile(`fqName: "([^"]+)".*variableLabels: \{([^}]*)\}`)
+
+// metricInventory reflects over every collector field of a metrics value
+// (including the shared obslock lock metrics) and returns each registered
+// metric's fully-qualified name mapped to its sorted label keys.
+func metricInventory(t *testing.T, m any) map[string][]string {
+	t.Helper()
+
+	describers := collectDescribers(reflect.ValueOf(m).Elem())
+
+	ch := make(chan *prometheus.Desc)
+	go func() {
+		defer close(ch)
+		for _, d := range describers {
+			d.Describe(ch)
+		}
+	}()
+
+	inventory := make(map[string][]string)
+	for desc := range ch {
+		match := descLabelsRe.FindStringSubmatch(desc.String())
+		require.NotNilf(t, match, "could not parse descriptor %q", desc.String())
+
+		var keys []string
+		for _, key := range strings.Split(match[2], ",") {
+			if key != "" {
+				keys = append(keys, key)
+			}
+		}
+		sort.Strings(keys)
+		inventory[match[1]] = keys
+	}
+	return inventory
+}
+
+// collectDescribers returns every struct field of v that is a metric collector,
+// reading unexported fields via reflection so the inventory stays authoritative
+// without a hand-maintained accessor.
+func collectDescribers(v reflect.Value) []describer {
+	var out []describer
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		if !f.CanAddr() {
+			continue
+		}
+		fv := reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem().Interface()
+		if d, ok := fv.(describer); ok && d != nil {
+			out = append(out, d)
+		}
+	}
+	return out
+}

--- a/pkg/engine/internal/worker/metrics_labels_test.go
+++ b/pkg/engine/internal/worker/metrics_labels_test.go
@@ -1,0 +1,261 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
+	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
+	"github.com/grafana/loki/v3/pkg/util/arrowtest"
+)
+
+type metricLabelSet map[string]string
+
+func TestWorkerHandlerPhaseLabelsForTaskAssign(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	listener := &wire.Local{Address: wire.LocalScheduler}
+	t.Cleanup(func() { require.NoError(t, listener.Close(context.Background())) })
+
+	acceptedConn := make(chan wire.Conn, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept(ctx)
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		acceptedConn <- conn
+	}()
+
+	workerConn, err := listener.DialFrom(ctx, wire.LocalWorker)
+	require.NoError(t, err)
+
+	var schedulerConn wire.Conn
+	select {
+	case err := <-acceptErr:
+		require.NoError(t, err)
+	case schedulerConn = <-acceptedConn:
+	}
+
+	helloReceived := make(chan struct{})
+	schedulerPeer := &wire.Peer{
+		Logger:  log.NewNopLogger(),
+		Metrics: wire.NewMetrics(),
+		Conn:    schedulerConn,
+		Handler: func(_ context.Context, _ *wire.Peer, msg wire.Message) error {
+			if _, ok := msg.(wire.WorkerHelloMessage); ok {
+				select {
+				case <-helloReceived:
+				default:
+					close(helloReceived)
+				}
+			}
+			return nil
+		},
+	}
+	go func() { _ = schedulerPeer.Serve(ctx) }()
+
+	m := newMetrics()
+	w := &Worker{
+		logger:      log.NewNopLogger(),
+		numThreads:  1,
+		wireMetrics: wire.NewMetrics(),
+		metrics:     m,
+		jobManager:  newJobManager(),
+		sources:     make(map[ulid.ULID]*streamSource),
+		sinks:       make(map[ulid.ULID]*streamSink),
+		jobs:        make(map[ulid.ULID]*threadJob),
+	}
+
+	workerDone := make(chan error, 1)
+	go func() { workerDone <- w.handleSchedulerConn(ctx, log.NewNopLogger(), workerConn) }()
+
+	select {
+	case <-helloReceived:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for WorkerHello")
+	}
+
+	err = schedulerPeer.SendMessage(ctx, wire.TaskAssignMessage{
+		Task: &workflow.Task{
+			ULID:     ulid.Make(),
+			TenantID: "test-tenant",
+		},
+		Metadata: http.Header{},
+	})
+	var wireErr *wire.Error
+	require.ErrorAs(t, err, &wireErr)
+	require.EqualValues(t, http.StatusTooManyRequests, wireErr.Code)
+
+	// The handler now records only its total phase: the lock_wait phase is
+	// covered by the worker lock_wait_seconds metric and the job_manager_send
+	// phase by job_handoff_seconds.
+	require.ElementsMatch(t, []metricLabelSet{
+		{"message_type": wire.TaskAssignMessage{}.Kind().String(), "phase": phaseTotal.String(), "outcome": outcomeNack.String()},
+	}, collectLabelSets(t, m.handlerPhaseSeconds))
+
+	cancel()
+	select {
+	case err := <-workerDone:
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, wire.ErrConnClosed) {
+			require.NoError(t, err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for worker connection to stop")
+	}
+}
+
+func TestWorkerHandlerPhaseLabelsForStreamData(t *testing.T) {
+	streamID := ulid.Make()
+	source := &streamSource{}
+	node := &nodeSource{}
+	require.NoError(t, source.Bind(node))
+
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := node.Read(t.Context())
+		readDone <- err
+	}()
+
+	m := newMetrics()
+	w := &Worker{
+		metrics: m,
+		sources: map[ulid.ULID]*streamSource{streamID: source},
+	}
+	rec := arrowtest.Rows{{"a": int64(1)}}.Record(memory.DefaultAllocator, arrow.NewSchema([]arrow.Field{
+		{Name: "a", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	}, nil))
+
+	var err error
+	func() {
+		phases := m.startHandler(wire.StreamDataMessage{}.Kind())
+		defer func() { phases.Done(handlerOutcome(err)) }()
+		err = w.handleDataMessage(t.Context(), wire.StreamDataMessage{StreamID: streamID, Data: rec}, phases)
+	}()
+	require.NoError(t, err)
+	require.NoError(t, <-readDone)
+
+	// lock_wait is no longer recorded as a handler phase (it lives in
+	// lock_wait_seconds); source_write_wait and the total remain.
+	require.ElementsMatch(t, []metricLabelSet{
+		{"message_type": wire.StreamDataMessage{}.Kind().String(), "phase": phaseTotal.String(), "outcome": outcomeAck.String()},
+		{"message_type": wire.StreamDataMessage{}.Kind().String(), "phase": phaseSourceWriteWait.String(), "outcome": outcomeAck.String()},
+	}, collectLabelSets(t, m.handlerPhaseSeconds))
+}
+
+func TestWorkerStreamDataCommSiteLabels(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	listener := &wire.Local{Address: wire.LocalWorker}
+	t.Cleanup(func() { require.NoError(t, listener.Close(context.Background())) })
+
+	received := make(chan wire.StreamDataMessage, 1)
+	go func() {
+		conn, err := listener.Accept(ctx)
+		if err != nil {
+			return
+		}
+		peer := &wire.Peer{
+			Logger:  log.NewNopLogger(),
+			Metrics: wire.NewMetrics(),
+			Conn:    conn,
+			Handler: func(_ context.Context, _ *wire.Peer, msg wire.Message) error {
+				if data, ok := msg.(wire.StreamDataMessage); ok {
+					received <- data
+				}
+				time.Sleep(time.Millisecond)
+				return nil
+			},
+		}
+		_ = peer.Serve(ctx)
+	}()
+
+	m := newMetrics()
+	streamID := ulid.Make()
+	sink := &streamSink{
+		Logger:      log.NewNopLogger(),
+		Metrics:     m,
+		WireMetrics: wire.NewMetrics(),
+		Stream:      &workflow.Stream{ULID: streamID, TenantID: "test-tenant"},
+		TaskType:    taskTypeLeaf,
+		Dialer: func(ctx context.Context, _ net.Addr) (wire.Conn, error) {
+			return listener.DialFrom(ctx, wire.LocalScheduler)
+		},
+	}
+	sink.lazyInit()
+	t.Cleanup(sink.cancel)
+	sink.destination = wire.LocalWorker
+	close(sink.bound)
+
+	rec := arrowtest.Rows{{"a": int64(1)}}.Record(memory.DefaultAllocator, arrow.NewSchema([]arrow.Field{
+		{Name: "a", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	}, nil))
+	require.NoError(t, sink.Send(ctx, rec))
+	select {
+	case got := <-received:
+		require.Equal(t, streamID, got.StreamID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for StreamDataMessage")
+	}
+
+	// The stream-data send site records its wait as the attribution layer. Slot
+	// comm/compute utilization is accumulated separately on the main runJob
+	// goroutine and is exercised by the slot_phase tests.
+	require.ElementsMatch(t, []metricLabelSet{
+		{"site": "stream_data_sync", "mode": sendModeSync.String(), "message_type": wire.StreamDataMessage{}.Kind().String(), "task_type": taskTypeLeaf.String(), "outcome": outcomeSuccess.String()},
+	}, collectLabelSets(t, m.commSiteWaitSeconds))
+}
+
+func collectLabelSets(t *testing.T, collector prometheus.Collector) []metricLabelSet {
+	t.Helper()
+
+	metrics := make(chan prometheus.Metric)
+	go func() {
+		defer close(metrics)
+		collector.Collect(metrics)
+	}()
+
+	var labelSets []metricLabelSet
+	for metric := range metrics {
+		var dtoMetric dto.Metric
+		require.NoError(t, metric.Write(&dtoMetric))
+
+		labels := make(metricLabelSet, len(dtoMetric.Label))
+		for _, label := range dtoMetric.Label {
+			labels[label.GetName()] = label.GetValue()
+		}
+		labelSets = append(labelSets, labels)
+	}
+	sort.Slice(labelSets, func(i, j int) bool { return labelSetKey(labelSets[i]) < labelSetKey(labelSets[j]) })
+	return labelSets
+}
+
+func labelSetKey(labels metricLabelSet) string {
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var out string
+	for _, key := range keys {
+		out += key + "=" + labels[key] + ";"
+	}
+	return out
+}

--- a/pkg/engine/internal/worker/node_source.go
+++ b/pkg/engine/internal/worker/node_source.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
 	"github.com/grafana/loki/v3/pkg/engine/internal/worker/workerstat"
 	"github.com/grafana/loki/v3/pkg/xcap"
 )
@@ -18,6 +19,9 @@ import (
 // Records are made available by a [nodeSource] calling [nodeSource.Write],
 // after which each record can be read by the [nodeSource.Read] method.
 type nodeSource struct {
+	Metrics  *metrics
+	TaskType taskType
+
 	initOnce  sync.Once
 	closeOnce sync.Once
 
@@ -51,19 +55,23 @@ func (src *nodeSource) Read(ctx context.Context) (arrow.RecordBatch, error) {
 		region.Record(workerstat.TaskExecutionReadRecvDuration.Observe(recvDuration.Nanoseconds()))
 	}()
 
-	src.lazyInit()
+	var rec arrow.RecordBatch
+	_, err := src.Metrics.timeCommSite("node_source_read_wait", sendModeInternal, wire.StreamDataMessage{}.Kind(), src.TaskType, func() error {
+		src.lazyInit()
 
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-src.closed:
-		if ep := src.failErr.Load(); ep != nil {
-			return nil, *ep
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-src.closed:
+			if ep := src.failErr.Load(); ep != nil {
+				return *ep
+			}
+			return executor.EOF
+		case rec = <-src.records:
+			return nil
 		}
-		return nil, executor.EOF
-	case rec := <-src.records:
-		return rec, nil
-	}
+	})
+	return rec, err
 }
 
 func (src *nodeSource) lazyInit() {

--- a/pkg/engine/internal/worker/slot_phase.go
+++ b/pkg/engine/internal/worker/slot_phase.go
@@ -1,0 +1,57 @@
+package worker
+
+import (
+	"time"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/metrictimer"
+)
+
+// slotPhaseTracker accumulates, over one worker slot's lifetime, how long the
+// main runJob goroutine spent blocked on communication. Because a slot has a
+// single serial thread of execution, its communication waits never overlap, so
+// a plain sum is exact. At slot end it emits the comm-blocked seconds and the
+// remaining compute seconds (total - comm) to the slot_phase metric.
+//
+// Only the main runJob goroutine mutates a tracker, so it needs no locking.
+// Communication that runs on other goroutines (Merge prefetch reads, the async
+// bind enqueue on a handler goroutine) is intentionally not counted: while it
+// runs, the main goroutine is genuinely computing.
+type slotPhaseTracker struct {
+	metrics  *metrics
+	taskType taskType
+	start    time.Time
+
+	commBlocked time.Duration
+}
+
+func newSlotPhaseTracker(metrics *metrics, taskType taskType, start time.Time) *slotPhaseTracker {
+	return &slotPhaseTracker{metrics: metrics, taskType: taskType, start: start}
+}
+
+// AddComm adds d to the slot's comm-blocked total. It is called from the main
+// runJob goroutine at each communication wait it incurs: the pipeline reads for
+// input and the sends it issues for output and status.
+func (t *slotPhaseTracker) AddComm(d time.Duration) {
+	if t == nil || d <= 0 {
+		return
+	}
+	t.commBlocked += d
+}
+
+// Observe emits the slot's comm-blocked and compute seconds. compute is the slot
+// lifetime minus the comm-blocked total and is never negative.
+func (t *slotPhaseTracker) Observe(end time.Time, outcome metrictimer.Outcome) {
+	if t == nil || t.metrics == nil || end.Before(t.start) {
+		return
+	}
+
+	total := end.Sub(t.start)
+	comm := t.commBlocked
+	if comm > total {
+		comm = total
+	}
+	compute := total - comm
+
+	t.metrics.addSlotPhase(slotPhaseComm, t.taskType, outcome, comm)
+	t.metrics.addSlotPhase(slotPhaseCompute, t.taskType, outcome, compute)
+}

--- a/pkg/engine/internal/worker/slot_phase_test.go
+++ b/pkg/engine/internal/worker/slot_phase_test.go
@@ -1,0 +1,76 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSlotPhaseTrackerComputeIsLifetimeMinusComm is the utilization invariant:
+// comm-blocked is the plain sum of the main goroutine's communication waits, and
+// compute is the slot lifetime minus that sum.
+func TestSlotPhaseTrackerComputeIsLifetimeMinusComm(t *testing.T) {
+	base := time.Unix(0, 0)
+	m := newMetrics()
+	tracker := newSlotPhaseTracker(m, taskTypeLeaf, base)
+
+	tracker.AddComm(2 * time.Second)
+	tracker.AddComm(4 * time.Second)
+
+	tracker.Observe(base.Add(10*time.Second), outcomeSuccess)
+
+	comm := testutil.ToFloat64(m.slotPhaseSeconds.WithLabelValues(slotPhaseComm.String(), taskTypeLeaf.String(), outcomeSuccess.String()))
+	compute := testutil.ToFloat64(m.slotPhaseSeconds.WithLabelValues(slotPhaseCompute.String(), taskTypeLeaf.String(), outcomeSuccess.String()))
+
+	require.InDelta(t, 6.0, comm, 1e-9)
+	require.InDelta(t, 4.0, compute, 1e-9)
+	require.InDelta(t, 10.0, comm+compute, 1e-9)
+}
+
+type slowClosingSink struct{ delay time.Duration }
+
+func (s slowClosingSink) Close(context.Context) error {
+	time.Sleep(s.delay)
+	return nil
+}
+
+// TestCloseSinksCountsCloseSendAsComm is a contract test for the main-goroutine
+// sink-close status send: its wait must land in the slot's comm-blocked total,
+// not in compute. It fails if closeSinks stops adding the close duration to the
+// slot.
+func TestCloseSinksCountsCloseSendAsComm(t *testing.T) {
+	base := time.Now()
+	m := newMetrics()
+	tracker := newSlotPhaseTracker(m, taskTypeLeaf, base)
+
+	const closeDelay = 20 * time.Millisecond
+	closeSinks(context.Background(), []closableSink{slowClosingSink{delay: closeDelay}}, tracker, log.NewNopLogger())
+
+	tracker.Observe(time.Now(), outcomeSuccess)
+
+	comm := testutil.ToFloat64(m.slotPhaseSeconds.WithLabelValues(slotPhaseComm.String(), taskTypeLeaf.String(), outcomeSuccess.String()))
+	// The close send blocked the main goroutine, so comm must include it.
+	require.GreaterOrEqual(t, comm, closeDelay.Seconds())
+}
+
+// TestSlotPhaseTrackerComputeNeverNegative ensures comm is clamped to the slot
+// lifetime so compute never goes negative even if accumulated comm exceeds it.
+func TestSlotPhaseTrackerComputeNeverNegative(t *testing.T) {
+	base := time.Unix(0, 0)
+	m := newMetrics()
+	tracker := newSlotPhaseTracker(m, taskTypeLeaf, base)
+
+	tracker.AddComm(20 * time.Second)
+
+	tracker.Observe(base.Add(5*time.Second), outcomeSuccess)
+
+	comm := testutil.ToFloat64(m.slotPhaseSeconds.WithLabelValues(slotPhaseComm.String(), taskTypeLeaf.String(), outcomeSuccess.String()))
+	compute := testutil.ToFloat64(m.slotPhaseSeconds.WithLabelValues(slotPhaseCompute.String(), taskTypeLeaf.String(), outcomeSuccess.String()))
+
+	require.InDelta(t, 5.0, comm, 1e-9)
+	require.InDelta(t, 0.0, compute, 1e-9)
+}

--- a/pkg/engine/internal/worker/stream_sink.go
+++ b/pkg/engine/internal/worker/stream_sink.go
@@ -19,10 +19,13 @@ import (
 
 // streamSink allows for sending records remotely across a stream.
 type streamSink struct {
-	Logger      log.Logger
+	Logger  log.Logger
+	Metrics *metrics
+
 	WireMetrics *wire.Metrics
 	Scheduler   *wire.Peer
 	Stream      *workflow.Stream
+	TaskType    taskType
 	Dialer      func(ctx context.Context, addr net.Addr) (wire.Conn, error)
 
 	initOnce  sync.Once
@@ -48,7 +51,7 @@ func (sink *streamSink) Bind(ctx context.Context, destination net.Addr) error {
 		bound = true
 
 		// Best-effort inform the scheduler that we're ready to send data.
-		_ = sink.Scheduler.SendMessageAsync(ctx, wire.StreamStatusMessage{
+		_, _ = sink.Metrics.timeSend(ctx, sink.Scheduler, "stream_status_open_async", sendModeAsync, sink.TaskType, wire.StreamStatusMessage{
 			StreamID: sink.Stream.ULID,
 			State:    workflow.StreamStateOpen,
 		})
@@ -112,25 +115,28 @@ func (sink *streamSink) Send(ctx context.Context, rec arrow.RecordBatch) error {
 }
 
 func (sink *streamSink) send(ctx context.Context, rec arrow.RecordBatch) error {
-	peer, err := sink.getPeer(ctx)
-	if err != nil {
-		return fmt.Errorf("connecting to peer: %w", err)
-	}
-
 	// TODO(rfratto): We should send a Blocked status update to the scheduler if
 	// SendMessage doesn't finish quickly enough.
 	//
 	// We need to find a way to efficiently do that here that doesn't cancel the
 	// send.
-	err = peer.SendMessage(ctx, wire.StreamDataMessage{
-		StreamID: sink.Stream.ULID,
-		Data:     rec,
-	})
-	if err != nil {
-		return fmt.Errorf("sending data to peer: %w", err)
-	}
+	// stream_data keeps its callback because it also resolves the peer before
+	// sending; getPeer is timed inside the same site rather than split out.
+	_, err := sink.Metrics.timeCommSite("stream_data_sync", sendModeSync, wire.StreamDataMessage{}.Kind(), sink.TaskType, func() error {
+		peer, err := sink.getPeer(ctx)
+		if err != nil {
+			return fmt.Errorf("connecting to peer: %w", err)
+		}
 
-	return nil
+		if err := peer.SendMessage(ctx, wire.StreamDataMessage{
+			StreamID: sink.Stream.ULID,
+			Data:     rec,
+		}); err != nil {
+			return fmt.Errorf("sending data to peer: %w", err)
+		}
+		return nil
+	})
+	return err
 }
 
 func (sink *streamSink) getPeer(ctx context.Context) (*wire.Peer, error) {
@@ -196,7 +202,7 @@ func (sink *streamSink) Close(ctx context.Context) error {
 		sink.cancel()
 
 		// Best-effort inform the scheduler that we're done sending data.
-		err = sink.Scheduler.SendMessageAsync(ctx, wire.StreamStatusMessage{
+		_, err = sink.Metrics.timeSend(ctx, sink.Scheduler, "stream_status_closed_async", sendModeAsync, sink.TaskType, wire.StreamStatusMessage{
 			StreamID: sink.Stream.ULID,
 			State:    workflow.StreamStateClosed,
 		})

--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"runtime/pprof"
 	gotrace "runtime/trace"
 	"sync"
@@ -22,6 +23,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
+	"github.com/grafana/loki/v3/pkg/engine/internal/metrictimer"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
 	"github.com/grafana/loki/v3/pkg/engine/internal/worker/workerstat"
@@ -35,6 +37,26 @@ import (
 // RecordSink sends record batches to a destination. Used by drainPipeline so callers can inject mocks in tests.
 type recordSink interface {
 	Send(ctx context.Context, rec arrow.RecordBatch) error
+}
+
+// closableSink closes a sink at task end. Used by closeSinks so tests can inject
+// a sink whose close blocks.
+type closableSink interface {
+	Close(ctx context.Context) error
+}
+
+// closeSinks closes each sink so downstream tasks unblock. Every close issues a
+// StreamStatusClosed send on the calling (main runJob) goroutine, so its wait is
+// added to the slot's comm-blocked total, not counted as compute.
+func closeSinks(ctx context.Context, sinks []closableSink, slotPhase *slotPhaseTracker, logger log.Logger) {
+	for _, sink := range sinks {
+		closeStart := time.Now()
+		err := sink.Close(ctx)
+		slotPhase.AddComm(time.Since(closeStart))
+		if err != nil {
+			level.Warn(logger).Log("msg", "failed to close sink", "err", err)
+		}
+	}
 }
 
 // sinksForJob returns the job's sinks as a slice for use with drainPipeline.
@@ -114,7 +136,20 @@ func (t *thread) Run(ctx context.Context) error {
 		level.Debug(t.Logger).Log("msg", "requesting task")
 
 		t.setState(threadStateReady)
-		job, err := t.JobManager.Recv(ctx)
+
+		// slot_ready_wait_seconds is the single "how long a thread slot sat
+		// unfilled" signal: time the Recv that fills (or exits) the slot.
+		var job *threadJob
+		waited, err := metrictimer.Time(func() error {
+			var recvErr error
+			job, recvErr = t.JobManager.Recv(ctx)
+			return recvErr
+		})
+		readyOutcome := outcomeAssigned
+		if err != nil {
+			readyOutcome = outcomeShutdown
+		}
+		t.Metrics.observeSlotReadyWait(readyOutcome, waited)
 		if err != nil {
 			return nil
 		}
@@ -135,6 +170,9 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 
 	startTime := time.Now()
 	taskType := taskTypeLabel(job.Task)
+	slotPhase := newSlotPhaseTracker(t.Metrics, taskType, startTime)
+	slotOutcome := outcomeUnknown
+	defer func() { slotPhase.Observe(time.Now(), slotOutcome) }()
 
 	ctx, task := gotrace.NewTask(ctx, "thread.runJob")
 	defer task.End()
@@ -144,6 +182,7 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 
 	root, err := job.Task.Fragment.Root()
 	if err != nil {
+		slotOutcome = outcomeFailed
 		level.Error(logger).Log("msg", "failed to get root node", "err", err)
 		return
 	}
@@ -208,7 +247,7 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 			// source decrements it when done. Spawning drainCachedSources also
 			// increments the count once and decrements it on return. When the
 			// count reaches zero, the nodeSource closes automatically.
-			input := new(nodeSource)
+			input := &nodeSource{Metrics: t.Metrics, TaskType: taskType}
 
 			var errs []error
 
@@ -271,8 +310,12 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	notifier, ok := executor.Unwrap(pipeline).(executor.ContributingTimeRangeChangedNotifier)
 	if ok {
 		notifier.SubscribeToTimeRangeChanges(func(ts time.Time, lessThan bool) {
-			// Send a Running task status update with the current time range
-			err := job.Scheduler.SendMessage(ctx, wire.TaskStatusMessage{
+			// Send a Running task status update with the current time range.
+			// This callback fires synchronously from within pipeline.Read, so its
+			// wait is already inside the Read time counted toward the slot's
+			// comm-blocked total; it is recorded here for per-site attribution
+			// only and is not added to the slot total a second time.
+			_, err := t.Metrics.timeSend(ctx, job.Scheduler, "task_status_contributing_range_sync", sendModeSync, taskType, wire.TaskStatusMessage{
 				ID: job.Task.ULID,
 				Status: workflow.TaskStatus{
 					State: workflow.TaskStateRunning,
@@ -288,10 +331,11 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 		})
 	}
 
-	err = job.Scheduler.SendMessageAsync(ctx, wire.TaskStatusMessage{
+	runningWait, err := t.Metrics.timeSend(ctx, job.Scheduler, "task_status_running_async", sendModeAsync, taskType, wire.TaskStatusMessage{
 		ID:     job.Task.ULID,
 		Status: workflow.TaskStatus{State: workflow.TaskStateRunning},
 	})
+	slotPhase.AddComm(runningWait)
 	if err != nil {
 		// For now, we'll continue even if the scheduler didn't get the message
 		// about the task status.
@@ -302,10 +346,10 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	// pipeline (planning, pipeline construction, and source binding setup).
 	setupDuration := time.Since(startTime)
 	span.Record(workerstat.TaskExecutionSetupDuration.Observe(setupDuration.Nanoseconds()))
-	t.Metrics.setupSeconds.WithLabelValues(taskType).Observe(setupDuration.Seconds())
+	t.Metrics.setupSeconds.WithLabelValues(taskType.String()).Observe(setupDuration.Seconds())
 
 	gotrace.Log(ctx, "drain_pipeline", "start")
-	_, drainErr := t.drainPipeline(ctx, taskType, pipeline, sinksForJob(job), logger)
+	_, drainErr := t.drainPipeline(ctx, taskType, slotPhase, pipeline, sinksForJob(job), logger)
 	gotrace.Log(ctx, "drain_pipeline", "done")
 
 	var terminalStatus workflow.TaskStatus
@@ -323,11 +367,11 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	}
 
 	// Close all sinks regardless of outcome so downstream tasks unblock.
+	toClose := make([]closableSink, 0, len(job.Sinks))
 	for _, sink := range job.Sinks {
-		if err := sink.Close(ctx); err != nil {
-			level.Warn(logger).Log("msg", "failed to close sink", "err", err)
-		}
+		toClose = append(toClose, sink)
 	}
+	closeSinks(ctx, toClose, slotPhase, logger)
 
 	// Close before ending capture to ensure all observations are recorded.
 	pipeline.Close()
@@ -364,7 +408,7 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	logValues = append(logValues, xcap.SummaryLogValues(capture)...)
 
 	level.Info(logger).Log(logValues...)
-	t.Metrics.taskExecSeconds.WithLabelValues(taskType).Observe(duration.Seconds())
+	t.Metrics.taskExecSeconds.WithLabelValues(taskType.String()).Observe(duration.Seconds())
 
 	// Send the terminal status synchronously so the scheduler can update its
 	// thread-capacity bookkeeping and merge the Capture before the worker
@@ -373,14 +417,21 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 	// We use a detached context so a cancelled job context does not prevent us
 	// from delivering the final status (and in particular, the Capture).
 	sendCtx := context.WithoutCancel(ctx)
-	sendStart := time.Now()
-	sendErr := job.Scheduler.SendMessage(sendCtx, wire.TaskStatusMessage{
+	sendWait, sendErr := t.Metrics.timeSend(sendCtx, job.Scheduler, "task_status_terminal_sync", sendModeSync, taskType, wire.TaskStatusMessage{
 		ID:     job.Task.ULID,
 		Status: terminalStatus,
 	})
-	t.Metrics.statusUpdateSeconds.Observe(time.Since(sendStart).Seconds())
+	slotPhase.AddComm(sendWait)
+	t.Metrics.statusUpdateSeconds.Observe(sendWait.Seconds())
+	if terminalStatus.State == workflow.TaskStateCompleted && sendErr == nil {
+		slotOutcome = outcomeSuccess
+	} else if terminalStatus.State == workflow.TaskStateCancelled {
+		slotOutcome = outcomeCanceled
+	} else {
+		slotOutcome = outcomeFailed
+	}
 	if sendErr != nil {
-		t.Metrics.statusUpdateErrorsTotal.WithLabelValues(statusUpdateErrorClass(sendErr)).Inc()
+		t.Metrics.statusUpdateErrorsTotal.WithLabelValues(statusUpdateErrorClass(sendErr).String()).Inc()
 		level.Warn(logger).Log("msg", "failed to inform scheduler of task status", "err", sendErr)
 	}
 }
@@ -389,7 +440,7 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 // the task has no external task sources (it reads directly from storage),
 // otherwise [taskTypeNonLeaf]. This mirrors the leaf/non-leaf classification
 // used in the per-task summary log.
-func taskTypeLabel(task *workflow.Task) string {
+func taskTypeLabel(task *workflow.Task) taskType {
 	if len(task.Sources) == 0 {
 		return taskTypeLeaf
 	}
@@ -398,29 +449,53 @@ func taskTypeLabel(task *workflow.Task) string {
 
 // statusUpdateErrorClass maps an error from the status-update send path to a
 // bounded label value for the status_update_errors_total counter.
-func statusUpdateErrorClass(err error) string {
+func statusUpdateErrorClass(err error) metrictimer.Outcome {
 	switch {
 	case err == nil:
-		return "none"
+		return outcomeNone
 	case errors.Is(err, context.Canceled):
-		return "canceled"
+		return outcomeCanceled
 	case errors.Is(err, context.DeadlineExceeded):
-		return "timeout"
+		return outcomeTimeout
 	case errors.Is(err, wire.ErrConnClosed):
-		return "conn_closed"
+		return outcomeConnClosed
 	}
 
 	var wireErr *wire.Error
 	if errors.As(err, &wireErr) {
 		switch {
 		case wireErr.Code >= 400 && wireErr.Code < 500:
-			return "rejected"
+			return outcomeRejected
 		case wireErr.Code >= 500:
-			return "server_error"
+			return outcomeServerError
 		}
 	}
 
-	return "other"
+	return outcomeOther
+}
+
+func commOutcome(err error) metrictimer.Outcome {
+	switch {
+	case err == nil:
+		return outcomeSuccess
+	case errors.Is(err, executor.EOF):
+		return outcomeSuccess
+	case errors.Is(err, context.Canceled):
+		return outcomeCanceled
+	case errors.Is(err, context.DeadlineExceeded):
+		return outcomeTimeout
+	case errors.Is(err, wire.ErrConnClosed):
+		return outcomeConnClosed
+	}
+
+	var wireErr *wire.Error
+	if errors.As(err, &wireErr) {
+		if wireErr.Code == http.StatusTooManyRequests {
+			return outcomeNack429
+		}
+		return outcomeNack
+	}
+	return outcomeError
 }
 
 // recordBatchBytes returns the total in-memory size in bytes of all column
@@ -433,7 +508,7 @@ func recordBatchBytes(rec arrow.RecordBatch) int64 {
 	return n
 }
 
-func (t *thread) drainPipeline(ctx context.Context, taskType string, pipeline executor.Pipeline, sinks []recordSink, logger log.Logger) (int, error) {
+func (t *thread) drainPipeline(ctx context.Context, taskType taskType, slotPhase *slotPhaseTracker, pipeline executor.Pipeline, sinks []recordSink, logger log.Logger) (int, error) {
 	region := xcap.RegionFromContext(ctx)
 
 	var (
@@ -445,9 +520,9 @@ func (t *thread) drainPipeline(ctx context.Context, taskType string, pipeline ex
 	// Record on every exit, including failures, so a task that errors still
 	// reports where its time went; the region observations feed the summary log.
 	defer func() {
-		t.Metrics.taskOpenSeconds.WithLabelValues(taskType).Observe(openDuration.Seconds())
-		t.Metrics.taskReadSeconds.WithLabelValues(taskType).Observe(totalReadTime.Seconds())
-		t.Metrics.taskSendSeconds.WithLabelValues(taskType).Observe(totalSendTime.Seconds())
+		t.Metrics.taskOpenSeconds.WithLabelValues(taskType.String()).Observe(openDuration.Seconds())
+		t.Metrics.taskReadSeconds.WithLabelValues(taskType.String()).Observe(totalReadTime.Seconds())
+		t.Metrics.taskSendSeconds.WithLabelValues(taskType.String()).Observe(totalSendTime.Seconds())
 
 		region.Record(workerstat.TaskExecutionOpenDuration.Observe(openDuration.Nanoseconds()))
 		region.Record(workerstat.TaskExecutionReadDuration.Observe(totalReadTime.Nanoseconds()))
@@ -466,6 +541,9 @@ func (t *thread) drainPipeline(ctx context.Context, taskType string, pipeline ex
 		startRead := time.Now()
 		rec, err := pipeline.Read(ctx)
 		readDuration := time.Since(startRead)
+		// The main goroutine is blocked reading its input; count it toward the
+		// slot's comm-blocked time.
+		slotPhase.AddComm(readDuration)
 		// Count every pass toward the task total; the per-pass histogram skips
 		// error passes to avoid skewing pass latencies.
 		totalReadTime += readDuration
@@ -497,6 +575,9 @@ func (t *thread) drainPipeline(ctx context.Context, taskType string, pipeline ex
 			}
 		}
 		sendDuration := time.Since(startSend)
+		// The main goroutine is blocked sending its output; count it toward the
+		// slot's comm-blocked time.
+		slotPhase.AddComm(sendDuration)
 		t.Metrics.passSendSeconds.Observe(sendDuration.Seconds())
 		totalSendTime += sendDuration
 

--- a/pkg/engine/internal/worker/thread_test.go
+++ b/pkg/engine/internal/worker/thread_test.go
@@ -76,7 +76,7 @@ func TestThread_drainPipeline(t *testing.T) {
 
 	sink := &mockRecordSink{}
 	th := &thread{Logger: log.NewNopLogger(), Metrics: newMetrics()}
-	totalRows, err := th.drainPipeline(ctx, taskTypeLeaf, pipeline, []recordSink{sink}, log.NewNopLogger())
+	totalRows, err := th.drainPipeline(ctx, taskTypeLeaf, nil, pipeline, []recordSink{sink}, log.NewNopLogger())
 	require.NoError(t, err)
 	require.Equal(t, 3, totalRows)
 
@@ -106,7 +106,7 @@ func TestThread_drainPipeline_RecordsPhasesOnFailure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			th := &thread{Logger: log.NewNopLogger(), Metrics: newMetrics()}
-			_, err := th.drainPipeline(t.Context(), taskTypeLeaf, tt.pipeline, nil, log.NewNopLogger())
+			_, err := th.drainPipeline(t.Context(), taskTypeLeaf, nil, tt.pipeline, nil, log.NewNopLogger())
 			require.Error(t, err)
 
 			require.Equal(t, 1, testutil.CollectAndCount(th.Metrics.taskOpenSeconds))

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -26,6 +26,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
+	"github.com/grafana/loki/v3/pkg/engine/internal/metrictimer"
+	"github.com/grafana/loki/v3/pkg/engine/internal/obslock"
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
 	"github.com/grafana/loki/v3/pkg/scratch"
@@ -119,7 +121,7 @@ type Worker struct {
 	dialer   wire.Dialer
 	listener wire.Listener
 
-	resourcesMut sync.RWMutex
+	resourcesMut obslock.RWMutex
 	sources      map[ulid.ULID]*streamSource
 	sinks        map[ulid.ULID]*streamSink
 	jobs         map[ulid.ULID]*threadJob
@@ -155,7 +157,7 @@ func New(config Config) (*Worker, error) {
 		numThreads = runtime.GOMAXPROCS(0)
 	}
 
-	return &Worker{
+	w := &Worker{
 		config:      config,
 		logger:      config.Logger,
 		wireMetrics: wire.NewMetrics(),
@@ -173,7 +175,9 @@ func New(config Config) (*Worker, error) {
 		collector: newCollector(),
 
 		jobManager: newJobManager(),
-	}, nil
+	}
+	w.resourcesMut.Init("resourcesMut", w.metrics.lock)
+	return w, nil
 }
 
 // Service returns the service used to manage the lifecycle of the worker.
@@ -303,13 +307,11 @@ func (w *Worker) handleConn(ctx context.Context, conn wire.Conn) {
 		// Allow for a backlog of 8 frames before backpressure is applied.
 		Buffer: 8,
 
-		Handler: func(ctx context.Context, _ *wire.Peer, msg wire.Message) error {
-			switch msg := msg.(type) {
-			case wire.StreamDataMessage:
-				return w.handleDataMessage(ctx, msg)
-			default:
-				return fmt.Errorf("unsupported message type %T", msg)
-			}
+		Handler: func(ctx context.Context, _ *wire.Peer, msg wire.Message) (err error) {
+			phases := w.metrics.startHandler(msg.Kind())
+			defer func() { phases.Done(handlerOutcome(err)) }()
+
+			return w.handleDataMessage(ctx, msg, phases)
 		},
 	}
 
@@ -388,12 +390,23 @@ func (w *Worker) handleSchedulerConn(ctx context.Context, logger log.Logger, con
 			return err
 		}
 
-		if err := w.jobManager.Send(ctx, job); err != nil {
+		// Time the handoff once into job_handoff_seconds; the handler no longer
+		// double-records it as a job_manager_send phase.
+		handoff, err := metrictimer.Time(func() error {
+			return w.jobManager.Send(ctx, job)
+		})
+		if err != nil {
+			outcome := outcomeNoReady429
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				outcome = outcomeCtxError
+			}
+			w.metrics.observeJobHandoff(outcome, handoff)
 			job.Close()                 // Clean up resources associated with the job.
 			_ = handleWorkerSubscribe() // handleWorkerSubscribe can only return nil
 			w.metrics.rejectedAssignmentsTotal.Inc()
 			return wire.Errorf(http.StatusTooManyRequests, "no threads available")
 		}
+		w.metrics.observeJobHandoff(outcomeSent, handoff)
 
 		w.metrics.tasksAssignedTotal.Inc()
 		return nil
@@ -407,7 +420,10 @@ func (w *Worker) handleSchedulerConn(ctx context.Context, logger log.Logger, con
 		// Allow for a backlog of 128 frames before backpressure is applied.
 		Buffer: 128,
 
-		Handler: func(ctx context.Context, peer *wire.Peer, msg wire.Message) error {
+		Handler: func(ctx context.Context, peer *wire.Peer, msg wire.Message) (err error) {
+			phases := w.metrics.startHandler(msg.Kind())
+			defer func() { phases.Done(handlerOutcome(err)) }()
+
 			switch msg := msg.(type) {
 			case wire.WorkerSubscribeMessage:
 				return handleWorkerSubscribe()
@@ -452,7 +468,9 @@ func (w *Worker) handleSchedulerConn(ctx context.Context, logger log.Logger, con
 			case <-waitReady:
 			}
 
-			// Wait for a thread to become ready for another job
+			// Wait for a thread to become ready for another job. Per-slot
+			// ready->filled latency is measured on the thread itself as
+			// slot_ready_wait_seconds.
 			if err := w.jobManager.WaitReady(ctx); err != nil {
 				return nil
 			}
@@ -477,8 +495,8 @@ func (w *Worker) handleSchedulerConn(ctx context.Context, logger log.Logger, con
 // newJob returns an error if there was a ULID collision for the job or any of
 // its streams.
 func (w *Worker) newJob(ctx context.Context, scheduler *wire.Peer, logger log.Logger, msg wire.TaskAssignMessage) (job *threadJob, err error) {
-	w.resourcesMut.Lock()
-	defer w.resourcesMut.Unlock()
+	guard := w.resourcesMut.Lock("new_job")
+	defer guard.Unlock()
 
 	var (
 		sources = make(map[ulid.ULID]*streamSource)
@@ -533,9 +551,11 @@ func (w *Worker) newJob(ctx context.Context, scheduler *wire.Peer, logger log.Lo
 		for _, taskSink := range taskSinks {
 			sink := &streamSink{
 				Logger:      log.With(logger, "stream", taskSink.ULID),
+				Metrics:     w.metrics,
 				WireMetrics: w.wireMetrics,
 				Scheduler:   scheduler,
 				Stream:      taskSink,
+				TaskType:    taskTypeLabel(msg.Task),
 				Dialer:      w.dial,
 			}
 
@@ -570,8 +590,8 @@ func (w *Worker) newJob(ctx context.Context, scheduler *wire.Peer, logger log.Lo
 		Sinks:   sinks,
 
 		Close: func() {
-			w.resourcesMut.Lock()
-			defer w.resourcesMut.Unlock()
+			guard := w.resourcesMut.Lock("close_job")
+			defer guard.Unlock()
 
 			for sourceID := range sources {
 				delete(w.sources, sourceID)
@@ -593,9 +613,9 @@ func (w *Worker) newJob(ctx context.Context, scheduler *wire.Peer, logger log.Lo
 }
 
 func (w *Worker) handleCancelMessage(msg wire.TaskCancelMessage) error {
-	w.resourcesMut.RLock()
+	guard := w.resourcesMut.RLock("handle_cancel")
 	job, found := w.jobs[msg.ID]
-	w.resourcesMut.RUnlock()
+	guard.RUnlock()
 
 	if !found {
 		return fmt.Errorf("task %s not found", msg.ID)
@@ -610,20 +630,22 @@ func (w *Worker) handleCancelMessage(msg wire.TaskCancelMessage) error {
 }
 
 func (w *Worker) handleBindMessage(ctx context.Context, msg wire.StreamBindMessage) error {
-	w.resourcesMut.RLock()
+	guard := w.resourcesMut.RLock("handle_bind")
 	sink, found := w.sinks[msg.StreamID]
-	w.resourcesMut.RUnlock()
+	guard.RUnlock()
 
 	if !found {
 		return fmt.Errorf("stream %s not found", msg.StreamID)
 	}
-	return sink.Bind(ctx, msg.Receiver)
+
+	err := sink.Bind(ctx, msg.Receiver)
+	return err
 }
 
 func (w *Worker) handleStreamStatusMessage(msg wire.StreamStatusMessage) error {
-	w.resourcesMut.RLock()
+	guard := w.resourcesMut.RLock("handle_stream_status")
 	source, found := w.sources[msg.StreamID]
-	w.resourcesMut.RUnlock()
+	guard.RUnlock()
 
 	if !found {
 		return fmt.Errorf("stream %s not found", msg.StreamID)
@@ -636,15 +658,23 @@ func (w *Worker) handleStreamStatusMessage(msg wire.StreamStatusMessage) error {
 	return nil
 }
 
-func (w *Worker) handleDataMessage(ctx context.Context, msg wire.StreamDataMessage) error {
-	w.resourcesMut.RLock()
-	source, found := w.sources[msg.StreamID]
-	w.resourcesMut.RUnlock()
+func (w *Worker) handleDataMessage(ctx context.Context, msg wire.Message, phases *metrictimer.Timer) error {
+	streamData, ok := msg.(wire.StreamDataMessage)
+	if !ok {
+		return fmt.Errorf("unsupported message type %T", msg)
+	}
+
+	guard := w.resourcesMut.RLock("handle_stream_data")
+	source, found := w.sources[streamData.StreamID]
+	guard.RUnlock()
 
 	if !found {
-		return fmt.Errorf("stream %s not found for receiving data", msg.StreamID)
+		return fmt.Errorf("stream %s not found for receiving data", streamData.StreamID)
 	}
-	return source.Write(ctx, msg.Data)
+
+	return phases.Region(phaseSourceWriteWait, func() error {
+		return source.Write(ctx, streamData.Data)
+	})
 }
 
 // RegisterMetrics registers metrics about s to report to reg.


### PR DESCRIPTION
Adds Prometheus metrics to the engine's scheduler/worker communication path so RPC latency can be attributed to a cause: queue wait, lock contention, handler time, serialization, and transport. Instrumentation only, no behavior change (native histograms, bounded labels).