### PR TITLE
revert: Fix(v1-engine): Shard mapper inflating outer sum over non-additive range aggregations (#22396)

### DIFF
--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -63,8 +63,6 @@ func TestMappingEquivalence(t *testing.T) {
 		{`avg_over_time({a=~".+"} | logfmt | unwrap value [1s]) without (stream)`, true, nil},
 		{`avg_over_time({a=~".+"} | logfmt | drop level | unwrap value [1s])`, true, nil},
 		{`avg_over_time({a=~".+"} | logfmt | drop level | unwrap value [1s]) without (stream)`, true, nil},
-		{`sum(avg_over_time({a=~".+"} | logfmt | unwrap value [1s]) by (a))`, true, nil},
-		{`sum(max_over_time({a=~".+"} | logfmt | unwrap value [1s]) by (a))`, true, nil},
 		{`quantile_over_time(0.99, {a=~".+"} | logfmt | unwrap value [1s])`, true, []string{ShardQuantileOverTime}},
 		{`quantile_over_time(0.99, {a=~".+"} | logfmt | unwrap value [1s] offset 2s)`, true, []string{ShardQuantileOverTime}},
 		{

--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -242,19 +242,6 @@ func (m ShardMapper) mapVectorAggregationExpr(expr *syntax.VectorAggregationExpr
 		switch expr.Operation {
 
 		case syntax.OpTypeSum:
-			if syntax.ReducesLabels(expr.Left) {
-				// skip the opaque per-shard rewrite at this level. If labels are
-				// reduced (e.g. an inner range aggregation has by/without, or a
-				// parser-stage drops/keeps/renames labels), the same series may
-				// exist on multiple shards. Per-shard partial results from a
-				// non-additive inner range aggregation (avg_over_time,
-				// max_over_time, ...) cannot be combined by an outer sum.
-				// Fall through to recursively map the inner expression first —
-				// mapRangeAggregationExpr knows how to decompose each range
-				// aggregation correctly (e.g. avg_over_time into
-				// sum_over_time/count_over_time) — and then re-wrap with sum.
-				break
-			}
 			// sum(x) -> sum(sum(x, shard=1) ++ sum(x, shard=2)...)
 			return m.wrappedShardedVectorAggr(expr, r)
 

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -205,11 +205,9 @@ func TestMappingStrings(t *testing.T) {
 			in: `max(sum by (abc) (rate({foo="bar"} | json | label_format bazz=buzz [5m])))`,
 			out: `max(
 				sum by (abc) (
-					sum without() (
-						downstream<rate({foo="bar"}|json|label_formatbazz=buzz[5m]),shard=0_of_2>
-						++
-						downstream<rate({foo="bar"}|json|label_formatbazz=buzz[5m]),shard=1_of_2>
-					)
+					downstream<sumby(abc)(rate({foo="bar"}|json|label_formatbazz=buzz[5m])),shard=0_of_2>
+					++
+					downstream<sumby(abc)(rate({foo="bar"}|json|label_formatbazz=buzz[5m])),shard=1_of_2>
 				)
 			)`,
 		},
@@ -325,11 +323,9 @@ func TestMappingStrings(t *testing.T) {
 		{
 			in: `sum(count_over_time({foo="bar"} | logfmt | label_format bar=baz | bar="buz" [5m])) by (bar)`,
 			out: `sum by (bar) (
-				sum without() (
-					downstream<count_over_time({foo="bar"}|logfmt|label_formatbar=baz|bar="buz"[5m]),shard=0_of_2>
-					++
-					downstream<count_over_time({foo="bar"}|logfmt|label_formatbar=baz|bar="buz"[5m]),shard=1_of_2>
-				)
+				downstream<sum by (bar) (count_over_time({foo="bar"}|logfmt|label_formatbar=baz|bar="buz"[5m])),shard=0_of_2>
+				++
+				downstream<sum by (bar) (count_over_time({foo="bar"}|logfmt|label_formatbar=baz|bar="buz"[5m])),shard=1_of_2>
 			)`,
 		},
 		{
@@ -405,50 +401,18 @@ func TestMappingStrings(t *testing.T) {
 			)`,
 		},
 		{
-			in: `sum(avg_over_time({job=~"myapps.*"} |= "stats" | json busy="utilization" | unwrap busy [5m]) by (cluster))`,
-			out: `sum(
-				(
-					sum by (cluster) (
-						downstream<sum by (cluster) (sum_over_time({job=~"myapps.*"}|="stats" | json busy="utilization" | unwrap busy [5m])),shard=0_of_2>
-						++
-						downstream<sum by (cluster) (sum_over_time({job=~"myapps.*"}|="stats" | json busy="utilization" | unwrap busy [5m])),shard=1_of_2>
-					)
-					/
-					sum by (cluster) (
-						downstream<sum by (cluster) (count_over_time({job=~"myapps.*"}|="stats" | json busy="utilization" [5m])),shard=0_of_2>
-						++
-						downstream<sum by (cluster) (count_over_time({job=~"myapps.*"}|="stats" | json busy="utilization" [5m])),shard=1_of_2>
-					)
-				)
-			)`,
-		},
-		{
-			in: `sum(max_over_time({job=~"myapps.*"} |= "stats" | json busy="utilization" | unwrap busy [5m]) by (cluster))`,
-			out: `sum(
-				max by (cluster) (
-					downstream<max_over_time({job=~"myapps.*"}|="stats" | json busy="utilization" | unwrap busy [5m]) by (cluster),shard=0_of_2>
-					++
-					downstream<max_over_time({job=~"myapps.*"}|="stats" | json busy="utilization" | unwrap busy [5m]) by (cluster),shard=1_of_2>
-				)
-			)`,
-		},
-		{
 			in: `avg_over_time({job=~"myapps.*"} |= "stats" | json | keep busy | unwrap busy [5m])`,
 			out: `(
 				sum without() (
-					sum without() (
-						downstream<sum_over_time({job=~"myapps.*"} |="stats" | json | keep busy | unwrap busy [5m]),shard=0_of_2>
-						++
-						downstream<sum_over_time({job=~"myapps.*"} |="stats" | json | keep busy | unwrap busy [5m]),shard=1_of_2>
-					)
+					downstream<sum without() (sum_over_time({job=~"myapps.*"} |="stats" | json | keep busy | unwrap busy [5m])),shard=0_of_2>
+					++
+					downstream<sum without() (sum_over_time({job=~"myapps.*"} |="stats" | json | keep busy | unwrap busy [5m])),shard=1_of_2>
 				)
 				/
 				sum without(busy) (
-					sum without() (
-						downstream<count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m]),shard=0_of_2>
-						++
-						downstream<count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m]),shard=1_of_2>
-					)
+					downstream<sum without(busy) (count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m])),shard=0_of_2>
+					++
+					downstream<sum without(busy) (count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m])),shard=1_of_2>
 				)
 			)`,
 		},
@@ -456,19 +420,15 @@ func TestMappingStrings(t *testing.T) {
 			in: `avg_over_time({job=~"myapps.*"} |= "stats" | json | keep busy | unwrap busy [5m]) without (foo)`,
 			out: `(
 				sum without(foo) (
-					sum without() (
-						downstream<sum_over_time({job=~"myapps.*"} |="stats" | json | keep busy | unwrap busy [5m]),shard=0_of_2>
-						++
-						downstream<sum_over_time({job=~"myapps.*"} |="stats" | json | keep busy | unwrap busy [5m]),shard=1_of_2>
-					)
+					downstream<sum without(foo) (sum_over_time({job=~"myapps.*"} |="stats" | json | keep busy | unwrap busy [5m])),shard=0_of_2>
+					++
+					downstream<sum without(foo) (sum_over_time({job=~"myapps.*"} |="stats" | json | keep busy | unwrap busy [5m])),shard=1_of_2>
 				)
 				/
 				sum without(foo,busy) (
-					sum without() (
-						downstream<count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m]),shard=0_of_2>
-						++
-						downstream<count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m]),shard=1_of_2>
-					)
+					downstream<sum without(foo,busy) (count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m])),shard=0_of_2>
+					++
+					downstream<sum without(foo,busy) (count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m])),shard=1_of_2>
 				)
 			)`,
 		},


### PR DESCRIPTION
This reverts commit 37e6e0bef7d3c8f45f7eac92d8590e864b110470.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes incident where log volume histograms are failing to load.
We will eventually need to fix forward.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
