### PR TITLE
feat(metastore): Add postings metrics

### DIFF
--- a/pkg/dataobj/metastore/index_sections_reader.go
+++ b/pkg/dataobj/metastore/index_sections_reader.go
@@ -29,10 +29,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/xcap"
 )
 
-type bloomStatsProvider interface {
-	totalReadRows() uint64
-}
-
 // indexSectionsReader combines pointer scanning and bloom filtering into a single reader.
 // It reads section pointers matching stream matchers and time range, then applies
 // bloom filter predicates to further filter the results.
@@ -67,18 +63,13 @@ type indexSectionsReader struct {
 	bloomRowsRead            uint64
 	pointerSectionProductive []bool
 
-	// metrics, when non-nil, receives per-object observations at Close.
-	// statsRecorded guards against double-recording if Close runs more than once.
-	metrics       *ObjectMetastoreMetrics
-	statsRecorded bool
-
 	// readSpan for recording observations, it is created once during init.
 	readSpan *xcap.Span
 }
 
 var (
 	_ ArrowRecordBatchReader = (*indexSectionsReader)(nil)
-	_ bloomStatsProvider     = (*indexSectionsReader)(nil)
+	_ statsProvider          = (*indexSectionsReader)(nil)
 )
 
 func newIndexSectionsReader(
@@ -560,11 +551,6 @@ func (r *indexSectionsReader) Close() {
 	closeAll(r.pointersReaders)
 	closeAll(r.bloomReaders)
 
-	if r.initialized && r.metrics != nil && !r.statsRecorded {
-		r.statsRecorded = true
-		r.metrics.indexReadRowsPerObject.Observe(float64(r.totalReadRows()))
-	}
-
 	if r.readSpan != nil {
 		r.readSpan.End()
 	}
@@ -913,4 +899,12 @@ func (r *indexSectionsReader) buildKeepBitmask(rec arrow.RecordBatch, matchedSec
 
 func (r *indexSectionsReader) totalReadRows() uint64 {
 	return r.bloomRowsRead
+}
+
+// stats reports per-object read stats.
+func (r *indexSectionsReader) stats() readerStats {
+	return readerStats{
+		Initialized: r.initialized,
+		ReadRows:    r.totalReadRows(),
+	}
 }

--- a/pkg/dataobj/metastore/metrics.go
+++ b/pkg/dataobj/metastore/metrics.go
@@ -100,7 +100,10 @@ type ObjectMetastoreMetrics struct {
 	resolvedSectionsTotalDuration       prometheus.Histogram
 	resolvedSectionsTotal               prometheus.Histogram
 	resolvedSectionsRatio               prometheus.Histogram
-	indexReadRowsPerObject              prometheus.Histogram
+
+	indexReadFlowTotal        *prometheus.CounterVec
+	indexReadRowsPerObject    *prometheus.HistogramVec
+	resolvedSectionsPerObject prometheus.Histogram
 }
 
 func NewObjectMetastoreMetrics(reg prometheus.Registerer) *ObjectMetastoreMetrics {
@@ -193,9 +196,21 @@ func NewObjectMetastoreMetrics(reg prometheus.Registerer) *ObjectMetastoreMetric
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: 0,
 		}),
-		indexReadRowsPerObject: prometheus.NewHistogram(prometheus.HistogramOpts{
+		indexReadFlowTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_metastore_index_read_flow_total",
+			Help: "Total number of index objects routed to each read flow",
+		}, []string{"flow"}),
+		indexReadRowsPerObject: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "loki_metastore_index_read_rows_per_object",
 			Help:                            "Number of index rows read while resolving a single index object",
+			Buckets:                         nil,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 0,
+		}, []string{"flow"}),
+		resolvedSectionsPerObject: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:                            "loki_metastore_resolved_sections_per_object",
+			Help:                            "Number of sections resolved from a single index object",
 			Buckets:                         nil,
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
@@ -222,5 +237,7 @@ func (p *ObjectMetastoreMetrics) register(reg prometheus.Registerer) {
 	reg.MustRegister(p.resolvedSectionsTotalDuration)
 	reg.MustRegister(p.resolvedSectionsTotal)
 	reg.MustRegister(p.resolvedSectionsRatio)
+	reg.MustRegister(p.indexReadFlowTotal)
 	reg.MustRegister(p.indexReadRowsPerObject)
+	reg.MustRegister(p.resolvedSectionsPerObject)
 }

--- a/pkg/dataobj/metastore/object.go
+++ b/pkg/dataobj/metastore/object.go
@@ -595,8 +595,8 @@ func (m *ObjectMetastore) Sections(ctx context.Context, req SectionsRequest) (Se
 			sectionsMu.Lock()
 
 			// this is temporary, the stats will be collected differently in a distributed metastore
-			statsProvider := reader.(bloomStatsProvider)
-			totalSections.Add(statsProvider.totalReadRows())
+			sp := reader.(statsProvider)
+			totalSections.Add(sp.stats().ReadRows)
 
 			sections = append(sections, sectionsResp.SectionsResponse.Sections...)
 			sectionsMu.Unlock()
@@ -647,7 +647,9 @@ func (m *ObjectMetastore) IndexSectionsReader(ctx context.Context, req IndexSect
 	}
 
 	var reader ArrowRecordBatchReader
+	flow := flowStreams
 	if m.readPostingsSections && hasPostingsSection(idxObj, tenant) {
+		flow = flowPostings
 		reader = newPostingsIndexSectionsReader(
 			m.logger,
 			idxObj,
@@ -668,6 +670,9 @@ func (m *ObjectMetastore) IndexSectionsReader(ctx context.Context, req IndexSect
 			req.BatchSize,
 		)
 	}
+
+	m.metrics.indexReadFlowTotal.WithLabelValues(flow).Inc()
+	reader = &instrumentedReader{ArrowRecordBatchReader: reader, metrics: m.metrics, flow: flow}
 
 	return IndexSectionsReaderResponse{Reader: reader}, nil
 }
@@ -748,6 +753,8 @@ func (m *ObjectMetastore) CollectSections(ctx context.Context, req CollectSectio
 			break
 		}
 	}
+
+	m.metrics.resolvedSectionsPerObject.Observe(float64(len(objectSectionDescriptors)))
 
 	sections := make([]*DataobjSectionDescriptor, 0, len(objectSectionDescriptors))
 	for _, s := range objectSectionDescriptors {

--- a/pkg/dataobj/metastore/object_test.go
+++ b/pkg/dataobj/metastore/object_test.go
@@ -876,7 +876,16 @@ func TestIndexSectionsReader_SelectsPostingsWhenPresent(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.IsType(t, &postingsIndexSectionsReader{}, resp.Reader)
+	require.IsType(t, &postingsIndexSectionsReader{}, unwrapReader(resp.Reader))
+}
+
+// unwrapReader returns the reader that IndexSectionsReader selected, unwrapping
+// the metrics decorator applied when read_postings_sections is enabled.
+func unwrapReader(r ArrowRecordBatchReader) ArrowRecordBatchReader {
+	if ir, ok := r.(*instrumentedReader); ok {
+		return ir.ArrowRecordBatchReader
+	}
+	return r
 }
 
 func TestIndexSectionsReader_FallbackWhenNoPostings(t *testing.T) {
@@ -892,7 +901,7 @@ func TestIndexSectionsReader_FallbackWhenNoPostings(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.IsType(t, &indexSectionsReader{}, resp.Reader)
+	require.IsType(t, &indexSectionsReader{}, unwrapReader(resp.Reader))
 }
 
 // TestCollectSections_PostingsAndLegacyParity builds the same logical stream

--- a/pkg/dataobj/metastore/postings_index_sections_reader.go
+++ b/pkg/dataobj/metastore/postings_index_sections_reader.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	_ ArrowRecordBatchReader = (*postingsIndexSectionsReader)(nil)
-	_ bloomStatsProvider     = (*postingsIndexSectionsReader)(nil)
+	_ statsProvider          = (*postingsIndexSectionsReader)(nil)
 )
 
 // postingsResultSchema is the pointers-section Arrow schema the resolver's
@@ -222,6 +222,13 @@ func (r *postingsIndexSectionsReader) Close() {
 
 func (r *postingsIndexSectionsReader) totalReadRows() uint64 {
 	return r.resolvedRefs
+}
+
+func (r *postingsIndexSectionsReader) stats() readerStats {
+	return readerStats{
+		Initialized: r.initialized,
+		ReadRows:    r.totalReadRows(),
+	}
 }
 
 // sectionResultsToRecordBatch serializes expanded per-stream rows into the

--- a/pkg/dataobj/metastore/stats.go
+++ b/pkg/dataobj/metastore/stats.go
@@ -1,6 +1,10 @@
 package metastore
 
-import "github.com/grafana/loki/v3/pkg/xcap"
+import (
+	"sync"
+
+	"github.com/grafana/loki/v3/pkg/xcap"
+)
 
 // Metastore statistics.
 var (
@@ -25,3 +29,40 @@ var (
 	StatMetastoreSectionPointersRead     = xcap.NewStatisticInt64("metastore.sections.pointers.read", xcap.AggregationTypeSum)
 	StatMetastoreSectionPointersReadTime = xcap.NewStatisticFloat64("metastore.sections.pointers.read.duration", xcap.AggregationTypeSum)
 )
+
+const (
+	flowPostings = "postings"
+	flowStreams  = "streams"
+)
+
+type readerStats struct {
+	// Initialized is false when the reader never performed a read, in which case
+	// ReadRows is meaningless and must not be observed.
+	Initialized bool
+	ReadRows    uint64
+}
+
+type statsProvider interface {
+	stats() readerStats
+}
+
+type instrumentedReader struct {
+	ArrowRecordBatchReader
+	metrics *ObjectMetastoreMetrics
+	flow    string
+	once    sync.Once
+}
+
+func (r *instrumentedReader) stats() readerStats {
+	return r.ArrowRecordBatchReader.(statsProvider).stats()
+}
+
+func (r *instrumentedReader) Close() {
+	r.once.Do(func() {
+		s := r.stats()
+		if s.Initialized {
+			r.metrics.indexReadRowsPerObject.WithLabelValues(r.flow).Observe(float64(s.ReadRows))
+		}
+	})
+	r.ArrowRecordBatchReader.Close()
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding metrics similar to what was added in https://github.com/grafana/loki/pull/22493 (with a few differences though):
1. `loki_metastore_index_read_flow_total` - with `flow` label, counter, increased every time we select index / postings reader
2. `loki_metastore_resolved_sections_per_object` - without `flow` label (adding flow label would require sending the flow type over the wire), histogram, how many unique sections were collected from an index object.
3. `loki_metastore_index_read_rows_per_object` - with `flow` label, histogram, how many rows was read from a single index object.

I also replace `bloomStatsProvider` with a more generic `statsProvider` that is supposed to return all the reader-related statistics. `instrumentedReader` wrapper later (on `.Close()` flushes these stats).

Data locality metrics will be added in a follow up (but separate) PR.