### PR TITLE
chore: Replace CLI flag for loading runtime file in config.libsonnet

### DIFF
--- a/production/ksonnet/loki/config.libsonnet
+++ b/production/ksonnet/loki/config.libsonnet
@@ -169,7 +169,7 @@
 
     commonArgs: {
       'config.file': '/etc/loki/config/config.yaml',
-      'limits.per-user-override-config': '/etc/loki/overrides/overrides.yaml',
+      'runtime-config.file': '/etc/loki/overrides/overrides.yaml',
     },
 
     commonEnvs: [],


### PR DESCRIPTION
PR #22856 removed the deprecated -limits.per-user-override-config in favour of -runtime-config.file
This PR updates the jsonnet lib accordingly.
