### PR TITLE
fix(v1-engine): Shard mapper inflating outer sum over non-additive range aggregations

### DIFF
--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -63,6 +63,24 @@ func TestMappingEquivalence(t *testing.T) {
 		{`avg_over_time({a=~".+"} | logfmt | unwrap value [1s]) without (stream)`, true, nil},
 		{`avg_over_time({a=~".+"} | logfmt | drop level | unwrap value [1s])`, true, nil},
 		{`avg_over_time({a=~".+"} | logfmt | drop level | unwrap value [1s]) without (stream)`, true, nil},
+		// outer sum around a non-additive range aggregation with label
+		// reduction: sharded plan must fall through to the range-aggr merger
+		// so per-shard partials are combined by max/min/... — otherwise the
+		// outer sum inflates when the same output labelset lands on multiple
+		// shards.
+		{`sum(max_over_time({a=~".+"} | logfmt | unwrap value [1s]) by (a))`, true, nil},
+		{`sum(max_over_time({a=~".+"} | logfmt | drop level | unwrap value [1s]))`, true, nil},
+		{`sum by (a) (max_over_time({a=~".+"} | logfmt | unwrap value [1s]))`, true, nil},
+		// outer sum around an additive range aggregation with label reduction:
+		// sharded plan must keep the fast per-shard sum-compression path.
+		{`sum(count_over_time({a=~".+"} | logfmt | drop level [1s]))`, false, nil},
+		{`sum(rate({a=~".+"} | logfmt | drop level [1s]))`, false, nil},
+		// outer sum around a nested non-additive vector aggregation (avg)
+		// with grouping: the inner avg is non-additive under an outer sum,
+		// so per-shard partial averages cannot be combined by an outer sum
+		// when the same output labelset lands on multiple shards. Guard
+		// must route via avg's own sum/count decomposition.
+		{`sum(avg by (a) (rate({a=~".+"}[1s])))`, true, nil},
 		{`quantile_over_time(0.99, {a=~".+"} | logfmt | unwrap value [1s])`, true, []string{ShardQuantileOverTime}},
 		{`quantile_over_time(0.99, {a=~".+"} | logfmt | unwrap value [1s] offset 2s)`, true, []string{ShardQuantileOverTime}},
 		{

--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -243,6 +243,26 @@ func (m ShardMapper) mapVectorAggregationExpr(expr *syntax.VectorAggregationExpr
 
 		case syntax.OpTypeSum:
 			// sum(x) -> sum(sum(x, shard=1) ++ sum(x, shard=2)...)
+			//
+			// This opaque per-shard rewrite is safe only if the per-shard
+			// partials can be combined by an outer sum. That fails when BOTH
+			// hold:
+			//   1. Downstream stages can collapse the same output labelset
+			//      across shards (drop/keep/labelfmt rename, or an explicit
+			//      by/without inside a range/vector aggregation), and
+			//   2. The inner range aggregation is non-additive
+			//      (max/min/avg/quantile/first/last/etc.). Its per-shard
+			//      partials require a semantically-appropriate combiner
+			//      (max/min/re-avg/sketch merge) before an outer sum.
+			//
+			// When both conditions hold, fall through to child-level mapping
+			// so mapRangeAggregationExpr can decompose with the right merger.
+			// Additive inners (count/rate/bytes/bytes_rate/sum_over_time) keep
+			// the fast leaf-compression path even under label reduction — an
+			// outer sum is the correct combiner regardless of collapse.
+			if syntax.ReducesLabels(expr.Left) && syntax.HasNonAdditiveAggr(expr.Left) {
+				break
+			}
 			return m.wrappedShardedVectorAggr(expr, r)
 
 		case syntax.OpTypeMin, syntax.OpTypeMax:

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -432,6 +432,106 @@ func TestMappingStrings(t *testing.T) {
 				)
 			)`,
 		},
+		// Outer sum around a non-additive range aggregation with label
+		// reduction: must fall through to the range-aggr merger so per-shard
+		// partials are combined by max/min/... — not by the outer sum.
+		{
+			in: `sum(max_over_time({foo="bar"} | logfmt | drop level | unwrap bar [5m]))`,
+			out: `sum(
+				max without () (
+					downstream<max_over_time({foo="bar"} | logfmt | drop level | unwrap bar [5m]), shard=0_of_2>
+					++
+					downstream<max_over_time({foo="bar"} | logfmt | drop level | unwrap bar [5m]), shard=1_of_2>
+				)
+			)`,
+		},
+		{
+			in: `sum(min_over_time({foo="bar"} | logfmt | unwrap bar [5m]) by (baz))`,
+			out: `sum(
+				min by (baz) (
+					downstream<min_over_time({foo="bar"} | logfmt | unwrap bar [5m]) by (baz), shard=0_of_2>
+					++
+					downstream<min_over_time({foo="bar"} | logfmt | unwrap bar [5m]) by (baz), shard=1_of_2>
+				)
+			)`,
+		},
+		{
+			in: `sum(max_over_time({foo="bar"} | json | label_format new=level | unwrap value [5m]))`,
+			out: `sum(
+				max without () (
+					downstream<max_over_time({foo="bar"} | json | label_format new=level | unwrap value [5m]), shard=0_of_2>
+					++
+					downstream<max_over_time({foo="bar"} | json | label_format new=level | unwrap value [5m]), shard=1_of_2>
+				)
+			)`,
+		},
+		{
+			in: `sum(max_over_time({foo="bar"} | logfmt | unwrap bar [5m]) without (baz))`,
+			out: `sum(
+				max without (baz) (
+					downstream<max_over_time({foo="bar"} | logfmt | unwrap bar [5m]) without (baz), shard=0_of_2>
+					++
+					downstream<max_over_time({foo="bar"} | logfmt | unwrap bar [5m]) without (baz), shard=1_of_2>
+				)
+			)`,
+		},
+		{
+			in: `sum(avg by (a) (rate({foo="bar"}[5m])))`,
+			out: `sum(
+				(
+					sum by (a) (
+						downstream<sum by (a) (rate({foo="bar"}[5m])), shard=0_of_2>
+						++
+						downstream<sum by (a) (rate({foo="bar"}[5m])), shard=1_of_2>
+					)
+					/
+					sum by (a) (
+						downstream<count by (a) (rate({foo="bar"}[5m])), shard=0_of_2>
+						++
+						downstream<count by (a) (rate({foo="bar"}[5m])), shard=1_of_2>
+					)
+				)
+			)`,
+		},
+		{
+			// avg_over_time with drop: guard fires and mapRangeAggregationExpr's
+			// avg-decomposition kicks in. Both the resulting sum(sum_over_time)
+			// and sum(count_over_time) are additive → fast path at each leg.
+			in: `sum(avg_over_time({foo="bar"} | logfmt | drop level | unwrap bar [5m]))`,
+			out: `sum(
+				(
+					sum without () (
+						downstream<sum without () (sum_over_time({foo="bar"} | logfmt | drop level | unwrap bar [5m])), shard=0_of_2>
+						++
+						downstream<sum without () (sum_over_time({foo="bar"} | logfmt | drop level | unwrap bar [5m])), shard=1_of_2>
+					)
+					/
+					sum without (bar) (
+						downstream<sum without (bar) (count_over_time({foo="bar"} | logfmt | drop level [5m])), shard=0_of_2>
+						++
+						downstream<sum without (bar) (count_over_time({foo="bar"} | logfmt | drop level [5m])), shard=1_of_2>
+					)
+				)
+			)`,
+		},
+		// Outer sum around an additive range aggregation with label reduction:
+		// per-shard sum-compression is safe — preserve the fast path.
+		{
+			in: `sum(count_over_time({foo="bar"} | logfmt | drop __error__ [5m]))`,
+			out: `sum(
+				downstream<sum(count_over_time({foo="bar"} | logfmt | drop __error__ [5m])), shard=0_of_2>
+				++
+				downstream<sum(count_over_time({foo="bar"} | logfmt | drop __error__ [5m])), shard=1_of_2>
+			)`,
+		},
+		{
+			in: `sum(count_over_time({foo="bar"} | logfmt | label_format new=level [5m]))`,
+			out: `sum(
+				downstream<sum(count_over_time({foo="bar"} | logfmt | label_format new=level [5m])), shard=0_of_2>
+				++
+				downstream<sum(count_over_time({foo="bar"} | logfmt | label_format new=level [5m])), shard=1_of_2>
+			)`,
+		},
 		// should be noop if VectorExpr
 		{
 			in:  `vector(0)`,

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -2414,6 +2414,62 @@ func ReducesLabels(e Expr) (conflict bool) {
 	return
 }
 
+// IsAdditiveRangeOp reports whether a range aggregation op is additive across
+// shards: combining per-shard partial results by addition yields the true
+// global result. The additive set matches the operations in [rangeMergeMap]
+// (in the shardmapper) that map to [OpTypeSum] as their cross-shard combiner.
+//
+// Additive: count_over_time, rate, bytes_over_time, bytes_rate, sum_over_time.
+// Non-additive: max_over_time, min_over_time, avg_over_time, quantile_over_time,
+// stddev_over_time, stdvar_over_time, first_over_time, last_over_time,
+// absent_over_time, rate_counter. For non-additive ops, an outer `sum` must not
+// opaquely push down into per-shard `sum(<op>)` when downstream stages can
+// collapse the same output labelset across shards, because the cross-shard
+// combiner then adds where it should max/min/re-avg/etc.
+func IsAdditiveRangeOp(op string) bool {
+	switch op {
+	case OpRangeTypeCount, OpRangeTypeRate, OpRangeTypeBytes, OpRangeTypeBytesRate, OpRangeTypeSum:
+		return true
+	}
+	return false
+}
+
+// HasNonAdditiveAggr reports whether e contains any aggregation whose
+// operation is non-additive across shards (see [IsAdditiveRangeOp]), or a
+// nested [VectorAggregationExpr] that is non-additive under an outer sum.
+//
+// Used by the shard mapper's [OpTypeSum] case together with [ReducesLabels]
+// to detect queries whose opaque per-shard sum-pushdown would inflate the
+// result: label reduction can produce the same output labelset on multiple
+// shards, and outer sum is the wrong combiner for non-additive per-shard
+// partial values.
+//
+// Nested vector aggregations considered non-additive here are limited to
+// [OpTypeAvg]. sum/count are additive across shards. min/max are already
+// rejected by the outer sum's own Shardable check when nested as its direct
+// child (see [VectorAggregationExpr.Shardable] OpTypeSum branch). Other
+// non-additive vector ops (stddev/stdvar/topk/bottomk) are absent from
+// [shardableOps], so the outer expression becomes unshardable and this
+// helper is not reached for them.
+func HasNonAdditiveAggr(e Expr) (found bool) {
+	e.Walk(func(node Expr) bool {
+		switch n := node.(type) {
+		case *RangeAggregationExpr:
+			if !IsAdditiveRangeOp(n.Operation) {
+				found = true
+				return false
+			}
+		case *VectorAggregationExpr:
+			if n.Operation == OpTypeAvg {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return
+}
+
 func groupingReducesLabels(grp *Grouping) bool {
 	if grp == nil {
 		return false


### PR DESCRIPTION
**What this PR does / why we need it**:

Narrows the guard on the v1 shard mapper's `OpTypeSum` sum-pushdown to fire only when the inner is genuinely non-additive across shards, restoring the fast leaf-compression path for additive-inner queries like `sum(count_over_time({...} | drop __error__))` that were regressing on max-series-per-query limits.

#### Background

PR [#22396](https://github.com/grafana/loki/pull/22396) fixed a correctness bug where `sum(max_over_time({...} | drop foo))` and similar shapes returned inflated results (roughly proportional to shard count). The v1 shard mapper was opaquely pushing `sum(...)` into each shard and then combining per-shard partials by *addition*, which is the correct combiner only when the inner range aggregation is additive. For non-additive inners (max/min/avg/quantile/etc.), correct combination requires a semantically-appropriate merger (max/min/re-avg/sketch merge) *before* the outer sum.

That fix guarded on `ReducesLabels(expr.Left)`. The guard was too broad: it also routed additive-inner queries (`sum(count_over_time | drop foo)`, `sum(rate | drop foo)`, etc.) through the merger path. The per-shard leaf then emitted raw per-labelset scan output, whose intermediate cardinality is determined by the underlying data, blowing up `max_series_per_query` on queries that used to work fine earlier.

This PR restores #22396's correctness fix on a narrower gate — the inner must be non-additive, AND the query must have label reduction, leaving the fast path intact for additive-inner shapes.

#### Change

- Added `IsAdditiveRangeOp` and `HasNonAdditiveAggr` helpers in `pkg/logql/syntax/ast.go`. The additive set is `{count_over_time, rate, bytes_over_time, bytes_rate, sum_over_time}` — the ops in `rangeMergeMap` that use `OpTypeSum` as their cross-shard combiner. `HasNonAdditiveAggr` walks both `RangeAggregationExpr` and `VectorAggregationExpr` (`avg` is the only vector op that reaches the guard, sum/count are additive; min/max are rejected by the outer sum's own `Shardable` check; stddev/stdvar/topk/bottomk aren't in `shardableOps`).
- Replaced `#22396`'s guard in `mapVectorAggregationExpr`'s `OpTypeSum` case with `ReducesLabels(expr.Left) && HasNonAdditiveAggr(expr.Left)`.

#### Behaviour matrix

For `sum(x)` where the outer sum is shardable:

| `x` | Additive inner? | Reduction anywhere? | Plan chosen | Correct? | Cardinality |
|---|---|---|---|---|---|
| `rate({...}[5m])` | yes | no | fast (per-shard `sum`) | ✓ | leaf-compressed |
| `count_over_time({...} \| drop __error__)` | yes | yes | fast | ✓ | leaf-compressed (restores #22918 regression) |
| `count_over_time({...} \| label_format bar=baz)` | yes | yes | fast | ✓ | leaf-compressed |
| `max_over_time({...}[5m])` | no | no | fast | ✓ (streams don't split across shards) | leaf-compressed |
| `max_over_time({...} \| drop foo)` | no | yes | merger (`max without ()`) | ✓ (correctness bug on `main` fixed) | raw per-labelset leaf output |
| `max_over_time({...}) by (foo)` | no | yes | merger (`max by (foo)`) | ✓ (correctness bug on `main` fixed) | raw per-labelset leaf output |
| `sum by (foo)(max_over_time(...))` | no | yes | merger via recursion | ✓ | raw per-labelset leaf output |
| `avg by (a)(rate({...}))` | no (avg is non-additive) | yes | avg's sum/count decomposition | ✓ (correctness bug on `main` fixed) | leaf-compressed at each leg |
| `quantile_over_time(0.99, {...} \| drop foo)` | no | yes | falls to `mapRangeAggregationExpr` with `topLevel=false` → quantile unshardable → unsharded execution | ✓ | unbounded — inherent to unsharded |
| `count(range_aggr)`, `avg(range_aggr)`, `min/max(range_aggr)`, `topk/bottomk(...)`, `label_replace(...)`, `vector(N)`, `sum(literal)` | — | — | not reached by this guard (outer sum's `Shardable` returns false or upstream check gates them) | ✓ unchanged | unchanged |

#### Side-effects introduced by this change

Correctness-first: fixing the inflation bug shifts these shapes to plans that are semantically correct but may be slower or hit different resource limits than before.

* `sum(quantile_over_time({...} | drop foo))` becomes unsharded:

Previously, silently wrong (but succeeding) `sum(quantile_over_time | drop foo)` queries may now fail with timeout / bytes-limit errors on large ranges. `sum(quantile_over_time(...))` is arithmetically ill-defined since summing per-labelset quantile values doesn't compose to anything probabilistically meaningful. Users writing this shape almost always intended `avg(quantile_over_time(...))`, a bare `quantile_over_time(...)`, or `quantile_over_time(...) by (foo)` for per-group quantiles. So the affected user population is small: users who wrote it by mistake, or who genuinely wanted the arithmetic sum.

* `sum(non_additive | drop|keep|label_format-rename)` becomes cardinality-heavy:

The merger path (`max without ()`, `min by (foo)`, avg decomposition, etc.) emits raw per-labelset scan output from each shard's leaf. Intermediate cardinality is set by the underlying data's series count, not by what was dropped. On streams with high per-line series counts (traces, request ids, per-line span/user labels), this can hit `max_series_per_query` even though the final scalar collapses correctly. Same failure mode as the cause of reverting the previous PR, but on a limited set of queries.

Note that this is inherent in non-additive semantics under label collapse since no plan-shape can provide both correctness *and* leaf-compression for `sum(max/min/avg/quantile | reduction)`. Users see a visible query error rather than a silently wrong result. Follow-ups A (special-case engine-reserved labels) and C (sketch-based non-additive aggregations) exist as future mitigations.