### PR TITLE
fix(promtail): Do not drop log lines when the drop stage source is absent

### DIFF
--- a/clients/pkg/logentry/stages/drop.go
+++ b/clients/pkg/logentry/stages/drop.go
@@ -243,6 +243,13 @@ func (m *dropStage) shouldDrop(e Entry) bool {
 				extractedData = append(extractedData, s)
 			}
 		}
+		// No configured source was found, so the source condition is not met: don't drop.
+		if len(extractedData) == 0 {
+			if Debug {
+				level.Debug(m.logger).Log("msg", "line will not be dropped, none of the provided sources were found in the extracted map")
+			}
+			return false
+		}
 		if !m.cfg.regex.MatchString(strings.Join(extractedData, *m.cfg.Separator)) {
 			// Not a match to the regex, don't drop
 			if Debug {

--- a/clients/pkg/logentry/stages/drop_test.go
+++ b/clients/pkg/logentry/stages/drop_test.go
@@ -328,6 +328,42 @@ func Test_dropStage_Process(t *testing.T) {
 			shouldDrop: false,
 		},
 		{
+			name: "Regex matches empty string but source is absent",
+			config: &DropConfig{
+				Source:     "key",
+				Expression: ptrFromString(".*"),
+			},
+			labels: model.LabelSet{},
+			extracted: map[string]interface{}{
+				"pokey": "pal1",
+			},
+			shouldDrop: false,
+		},
+		{
+			name: "Regex matches empty string but all sources are absent",
+			config: &DropConfig{
+				Source:     []string{"key1", "key2"},
+				Expression: ptrFromString(".*"),
+			},
+			labels: model.LabelSet{},
+			extracted: map[string]interface{}{
+				"other": "val",
+			},
+			shouldDrop: false,
+		},
+		{
+			name: "Regex matches empty string and source is present",
+			config: &DropConfig{
+				Source:     "key",
+				Expression: ptrFromString(".*"),
+			},
+			labels: model.LabelSet{},
+			extracted: map[string]interface{}{
+				"key": "anything",
+			},
+			shouldDrop: true,
+		},
+		{
 			name: "Regex Did Not Match Line",
 			config: &DropConfig{
 				Expression: ptrFromString(".*val.*"),


### PR DESCRIPTION
**What this PR does / why we need it**:

The `drop` pipeline stage treats its conditions as an AND, and the source-only branch already returns "don't drop" when a configured `source` key is missing from the extracted map. The combined `source` + `expression` branch did not: it built the match string only from sources that were present, so when none were found the joined string was empty and a regex that matches the empty string (e.g. `.*`) dropped the line.

For example, a drop stage configured with `source: key` and `expression: ".*"` dropped every line that had no `key` field extracted, silently discarding data.

This returns early (don't drop) when none of the configured sources are present, matching the behaviour of the source-only branch.

**Which issue(s) this PR fixes**:
N/A — found while reviewing `clients/pkg/logentry/stages`.

**Special notes for your reviewer**:
- The existing `Regex No Matching Source` test only passed because its regex `.*val.*` does not match the empty string, so the empty-join path was never exercised. Added cases for a single absent source and multiple absent sources with an empty-string-matching regex (both fail on `main`), plus a guard case confirming a present source with `.*` still drops.
- Only the combined `source` + `expression` branch changes; the source-only and expression-only branches are untouched.

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files
