### PR TITLE
fix(logcli): include structured metadata in tail output

### DIFF
--- a/pkg/logcli/client/client.go
+++ b/pkg/logcli/client/client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/index/seriesvolume"
 	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/build"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
 )
 
 const (
@@ -722,6 +723,8 @@ func (c *DefaultClient) wsConnect(path, query string, quiet bool) (*websocket.Co
 	if err != nil {
 		return nil, err
 	}
+
+	h.Set(httpreq.LokiEncodingFlagsHeader, string(httpreq.FlagCategorizeLabels))
 
 	ws := websocket.Dialer{
 		TLSClientConfig: tlsConfig,

--- a/pkg/logcli/query/tail.go
+++ b/pkg/logcli/query/tail.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/gorilla/websocket"
 	"github.com/grafana/dskit/backoff"
+	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/logcli/client"
 	"github.com/grafana/loki/v3/pkg/logcli/output"
@@ -92,7 +93,7 @@ func (q *Query) TailQuery(delayFor time.Duration, c client.Client, out output.Lo
 			return
 		}
 
-		labels := loghttp.LabelSet{}
+		streamLabels := loghttp.LabelSet{}
 		for _, stream := range tailResponse.Streams {
 			if !q.NoLabels {
 				if len(q.IgnoreLabelsKey) > 0 || len(q.ShowLabelsKey) > 0 {
@@ -107,15 +108,22 @@ func (q *Query) TailQuery(delayFor time.Duration, c client.Client, out output.Lo
 						ls = matchLabels(false, ls, q.ShowLabelsKey)
 					}
 
-					labels = ls
+					streamLabels = ls
 
 				} else {
-					labels = stream.Labels
+					streamLabels = stream.Labels
 				}
 			}
 
 			for _, entry := range stream.Entries {
-				out.FormatAndPrintln(entry.Timestamp, labels, 0, entry.Line)
+				merged := make(loghttp.LabelSet, len(streamLabels)+entry.StructuredMetadata.Len())
+				for k, v := range streamLabels {
+					merged[k] = v
+				}
+				entry.StructuredMetadata.Range(func(lbl labels.Label) {
+					merged[lbl.Name] = lbl.Value
+				})
+				out.FormatAndPrintln(entry.Timestamp, merged, 0, entry.Line)
 				lastReceivedTimestamp = entry.Timestamp
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When tailing with logcli, the first batch of log entries shows structured metadata correctly, but any live entries that arrive while the tail is running are missing it. It turns out that the initial batch comes from the store, which merges structured metadata into the stream labels before returning the results, so everything looks correct at first. Live entries come directly from the ingesters, where the metadata remains separate. Since logcli wasn't requesting structured metadata in the WebSocket response using FlagCategorizeLabels, the server didn't include it.
The fix has two parts: request structured metadata from the server and use it when printing live log entries.

**Which issue(s) this PR fixes**:
Fixes #22928

**Special notes for your reviewer**:
Tested on Loki v3.7.2. Before the fix, streaming log lines showed only stream labels. After the fix, structured metadata fields appear consistently across both the initial batch and live entries.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)