### PR TITLE
feat(postings): Add postings data locality to xcap

### DIFF
--- a/pkg/dataobj/internal/dataset/row_reader.go
+++ b/pkg/dataobj/internal/dataset/row_reader.go
@@ -37,6 +37,18 @@ type RowReaderOptions struct {
 	// starts. To reduce read latency, this option should only be disabled when
 	// the entire Dataset is already held in memory.
 	Prefetch bool
+
+	// StatsTracker keeps track of the various reader internal stats.
+	StatsTracker RowReaderStatsTracker
+}
+
+type RowReaderStatsTracker interface {
+	OnColumnPredicateBuilt(column Column, stats ColumnReadPageStats)
+}
+
+type ColumnReadPageStats struct {
+	Total    uint64
+	Relevant uint64
 }
 
 // A RowReader reads [Row]s from a [Dataset].
@@ -839,6 +851,9 @@ func (r *RowReader) buildColumnPredicateRanges(ctx context.Context, c Column, p 
 
 		isStreamCol      = isStreamIDColumn(c)
 		prevPageIncluded bool // used for tracking avg run length
+
+		totalPages    = uint64(c.ColumnDesc().PagesCount)
+		relevantPages = uint64(0)
 	)
 
 	for result := range c.ListPages(ctx) {
@@ -866,6 +881,7 @@ func (r *RowReader) buildColumnPredicateRanges(ctx context.Context, c Column, p 
 		} else if minValue.IsNil() || maxValue.IsNil() {
 			// No stats, so we add the whole range.
 			ranges.Add(pageRange)
+			relevantPages++
 
 			if isStreamCol {
 				region.Record(dataobj.StatStreamRelevantPages.Observe(1))
@@ -905,6 +921,7 @@ func (r *RowReader) buildColumnPredicateRanges(ctx context.Context, c Column, p 
 
 		if include {
 			ranges.Add(pageRange)
+			relevantPages++
 
 			if isStreamCol {
 				region.Record(dataobj.StatStreamRelevantPages.Observe(1))
@@ -923,6 +940,10 @@ func (r *RowReader) buildColumnPredicateRanges(ctx context.Context, c Column, p 
 		}
 
 		prevPageIncluded = include
+	}
+
+	if r.opts.StatsTracker != nil {
+		r.opts.StatsTracker.OnColumnPredicateBuilt(c, ColumnReadPageStats{totalPages, relevantPages})
 	}
 
 	return ranges, nil

--- a/pkg/dataobj/internal/dataset/row_reader_stats_test.go
+++ b/pkg/dataobj/internal/dataset/row_reader_stats_test.go
@@ -1,0 +1,146 @@
+package dataset
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
+)
+
+type recordedPredicateBuild struct {
+	logical string
+	stats   ColumnReadPageStats
+}
+
+type recordingStatsTracker struct {
+	calls []recordedPredicateBuild
+}
+
+func (r *recordingStatsTracker) OnColumnPredicateBuilt(col Column, stats ColumnReadPageStats) {
+	r.calls = append(r.calls, recordedPredicateBuild{
+		logical: col.ColumnDesc().Type.Logical,
+		stats:   stats,
+	})
+}
+
+// TestBuildColumnPredicateRanges_ReportsPageStats verifies that the stats
+// tracker receives the column's total page count and only the pages that
+// survive page-level pruning as relevant. Pages that lack min/max stats are
+// always relevant, so they are counted even when the predicate would otherwise
+// prune them.
+func TestBuildColumnPredicateRanges_ReportsPageStats(t *testing.T) {
+	ctx := context.Background()
+	ds, cols := buildSingleColumnStatsDataset(t)
+
+	tt := []struct {
+		name         string
+		predicate    Predicate
+		wantRelevant uint64
+	}{
+		{
+			// 50 falls inside page 0's [0,100] range; page 1 has no stats so it is
+			// always relevant; page 2's [800,1000] range is pruned.
+			name:         "matches a page with stats plus the no-stats page",
+			predicate:    EqualPredicate{Column: cols[0], Value: Int64Value(50)},
+			wantRelevant: 2,
+		},
+		{
+			// 5000 is outside both pages with stats; only the no-stats page 1
+			// remains relevant.
+			name:         "matches only the no-stats page",
+			predicate:    EqualPredicate{Column: cols[0], Value: Int64Value(5000)},
+			wantRelevant: 1,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			tracker := &recordingStatsTracker{}
+			r := NewRowReader(RowReaderOptions{
+				Dataset:      ds,
+				Columns:      cols,
+				Predicates:   []Predicate{tc.predicate},
+				StatsTracker: tracker,
+			})
+			defer r.Close()
+
+			// initDownloader builds the predicate ranges once per predicate, which
+			// is the same path the reader uses in production.
+			require.NoError(t, r.initDownloader(ctx))
+
+			require.Len(t, tracker.calls, 1, "tracker is notified once per column predicate")
+			require.Equal(t, "number", tracker.calls[0].logical)
+			require.Equal(t, uint64(3), tracker.calls[0].stats.Total, "total equals the column's page count")
+			require.Equal(t, tc.wantRelevant, tracker.calls[0].stats.Relevant)
+		})
+	}
+}
+
+// TestBuildColumnPredicateRanges_NilStatsTracker verifies that range building
+// tolerates the absence of a stats tracker.
+func TestBuildColumnPredicateRanges_NilStatsTracker(t *testing.T) {
+	ctx := context.Background()
+	ds, cols := buildSingleColumnStatsDataset(t)
+
+	r := NewRowReader(RowReaderOptions{
+		Dataset:    ds,
+		Columns:    cols,
+		Predicates: []Predicate{EqualPredicate{Column: cols[0], Value: Int64Value(50)}},
+		// StatsTracker intentionally left nil.
+	})
+	defer r.Close()
+
+	require.NotPanics(t, func() {
+		require.NoError(t, r.initDownloader(ctx))
+	})
+}
+
+// buildSingleColumnStatsDataset builds a one-column dataset with three pages:
+// two carry min/max stats and the middle page carries none.
+func buildSingleColumnStatsDataset(t *testing.T) (Dataset, []Column) {
+	t.Helper()
+
+	dset := FromMemory([]*MemColumn{
+		{
+			Desc: ColumnDesc{
+				Tag:        "value",
+				Type:       ColumnType{Physical: datasetmd.PHYSICAL_TYPE_INT64, Logical: "number"},
+				RowsCount:  1000,
+				PagesCount: 3,
+			},
+			Pages: []*MemPage{
+				{
+					Desc: PageDesc{
+						RowCount: 250, // 0 - 249
+						Stats: &datasetmd.Statistics{
+							MinValue: encodeInt64Value(t, 0),
+							MaxValue: encodeInt64Value(t, 100),
+						},
+					},
+				},
+				{
+					Desc: PageDesc{
+						RowCount: 500, // 250 - 749, no stats
+					},
+				},
+				{
+					Desc: PageDesc{
+						RowCount: 250, // 750 - 999
+						Stats: &datasetmd.Statistics{
+							MinValue: encodeInt64Value(t, 800),
+							MaxValue: encodeInt64Value(t, 1000),
+						},
+					},
+				},
+			},
+		},
+	})
+
+	cols, err := result.Collect(dset.ListColumns(context.Background()))
+	require.NoError(t, err)
+
+	return dset, cols
+}

--- a/pkg/dataobj/metastore/stats.go
+++ b/pkg/dataobj/metastore/stats.go
@@ -28,6 +28,34 @@ var (
 	StatMetastoreStreamsReadTime         = xcap.NewStatisticFloat64("metastore.sections.streams.read.duration", xcap.AggregationTypeSum)
 	StatMetastoreSectionPointersRead     = xcap.NewStatisticInt64("metastore.sections.pointers.read", xcap.AggregationTypeSum)
 	StatMetastoreSectionPointersReadTime = xcap.NewStatisticFloat64("metastore.sections.pointers.read.duration", xcap.AggregationTypeSum)
+
+	// StatPostingsLabelColumnNameTotalPages – the total number of "column_name" column pages for label-based postings,
+	// sum across all the sections.
+	StatPostingsLabelColumnNameTotalPages = xcap.NewStatisticInt64(
+		"dataobj.postings.label.column_name.pages.total",
+		xcap.AggregationTypeSum,
+	)
+
+	// StatPostingsLabelColumnNameRelevantPages – the total number of "column_name" column relevant pages for
+	// label-based postings, sum across all the sections.
+	StatPostingsLabelColumnNameRelevantPages = xcap.NewStatisticInt64(
+		"dataobj.postings.label.column_name.pages.relevant",
+		xcap.AggregationTypeSum,
+	)
+
+	// StatPostingsBloomColumnNameTotalPages – the total number of "column_name" column pages for bloom-based postings,
+	// sum across all the sections.
+	StatPostingsBloomColumnNameTotalPages = xcap.NewStatisticInt64(
+		"dataobj.postings.bloom.column_name.pages.total",
+		xcap.AggregationTypeSum,
+	)
+
+	// StatPostingsBloomColumnNameRelevantPages – the total number of "column_name" column relevant pages for
+	// bloom-based postings, sum across all the sections.
+	StatPostingsBloomColumnNameRelevantPages = xcap.NewStatisticInt64(
+		"dataobj.postings.bloom.column_name.pages.relevant",
+		xcap.AggregationTypeSum,
+	)
 )
 
 const (

--- a/pkg/dataobj/metastore/stats_tracker_test.go
+++ b/pkg/dataobj/metastore/stats_tracker_test.go
@@ -1,0 +1,71 @@
+package metastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
+	"github.com/grafana/loki/v3/pkg/xcap"
+)
+
+func columnWithLogical(logical string) dataset.Column {
+	return &dataset.MemColumn{
+		Desc: dataset.ColumnDesc{Type: dataset.ColumnType{Logical: logical}},
+	}
+}
+
+// TestSectionStatsTracker_OnColumnPredicateBuilt verifies that only the
+// "column_name" column is tracked, that its total page count is treated as
+// idempotent, and that relevant pages accumulate across predicate builds.
+func TestSectionStatsTracker_OnColumnPredicateBuilt(t *testing.T) {
+	nameCol := columnWithLogical(postings.ColumnTypeColumnName.String())
+	otherCol := columnWithLogical(postings.ColumnTypeLabelValue.String())
+
+	st := &sectionStatsTracker{}
+
+	st.OnColumnPredicateBuilt(nameCol, dataset.ColumnReadPageStats{Total: 5, Relevant: 2})
+	st.OnColumnPredicateBuilt(nameCol, dataset.ColumnReadPageStats{Total: 5, Relevant: 3})
+
+	require.Equal(t, uint64(5), st.columnNamePages.Total, "total is set per build, not summed")
+	require.Equal(t, uint64(5), st.columnNamePages.Relevant, "relevant accumulates across builds")
+
+	// A non-column_name column must not affect the counters.
+	st.OnColumnPredicateBuilt(otherCol, dataset.ColumnReadPageStats{Total: 99, Relevant: 99})
+
+	require.Equal(t, uint64(5), st.columnNamePages.Total)
+	require.Equal(t, uint64(5), st.columnNamePages.Relevant)
+}
+
+// TestStatsTracker_Report verifies that Report sums page counts across sections
+// and records label and bloom reads into their own separate statistics.
+func TestStatsTracker_Report(t *testing.T) {
+	nameCol := columnWithLogical(postings.ColumnTypeColumnName.String())
+
+	st := newStatsTracker(2)
+	st.SectionLabelTracker(0).OnColumnPredicateBuilt(nameCol, dataset.ColumnReadPageStats{Total: 10, Relevant: 3})
+	st.SectionLabelTracker(1).OnColumnPredicateBuilt(nameCol, dataset.ColumnReadPageStats{Total: 20, Relevant: 5})
+	st.SectionBloomTracker(0).OnColumnPredicateBuilt(nameCol, dataset.ColumnReadPageStats{Total: 7, Relevant: 1})
+
+	ctx, capture := xcap.NewCapture(context.Background(), nil)
+	ctx, _ = xcap.StartRegion(ctx, "test")
+
+	st.Report(ctx)
+
+	require.Equal(t, int64(30), xcap.Value[int64](capture, StatPostingsLabelColumnNameTotalPages))
+	require.Equal(t, int64(8), xcap.Value[int64](capture, StatPostingsLabelColumnNameRelevantPages))
+	require.Equal(t, int64(7), xcap.Value[int64](capture, StatPostingsBloomColumnNameTotalPages),
+		"bloom totals are independent of label totals")
+	require.Equal(t, int64(1), xcap.Value[int64](capture, StatPostingsBloomColumnNameRelevantPages))
+}
+
+// TestStatsTracker_Report_NoRegion verifies Report is a no-op (rather than a
+// panic) when the context carries no xcap region.
+func TestStatsTracker_Report_NoRegion(t *testing.T) {
+	st := newStatsTracker(0)
+	require.NotPanics(t, func() {
+		st.Report(context.Background())
+	})
+}

--- a/pkg/dataobj/metastore/stream_selector.go
+++ b/pkg/dataobj/metastore/stream_selector.go
@@ -9,8 +9,10 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
 	"github.com/grafana/loki/v3/pkg/memory"
+	"github.com/grafana/loki/v3/pkg/xcap"
 )
 
 // SectionStreams holds the matching streams within one logs section
@@ -73,14 +75,17 @@ func (s *streamSelector) selectStreams(ctx context.Context, sections []*postings
 		return nil, err
 	}
 
+	stats := newStatsTracker(len(sections))
+	defer stats.Report(ctx)
+
 	startNanos, endNanos := s.start.UnixNano(), s.end.UnixNano()
 
-	accums, err := s.eval(ctx, sections, compiledMatchers, compiledFilters, startNanos, endNanos)
+	accums, err := s.eval(ctx, sections, compiledMatchers, compiledFilters, startNanos, endNanos, stats)
 	if err != nil {
 		return nil, err
 	}
 
-	survivors, ambiguousNamesByRef, err := s.admitSections(ctx, sections, accums)
+	survivors, ambiguousNamesByRef, err := s.admitSections(ctx, sections, accums, stats)
 	if err != nil {
 		return nil, err
 	}
@@ -110,11 +115,12 @@ func (s *streamSelector) eval(
 	matchers []postings.CompiledMatcher,
 	filters []postings.CompiledMatcher,
 	startNanos, endNanos int64,
+	stats *statsTracker,
 ) (map[postings.SectionRef]*accum, error) {
 	accums := make(map[postings.SectionRef]*accum)
 
 	if len(matchers) > 0 {
-		if err := s.matchMatchers(ctx, sections, matchers, accums, startNanos, endNanos); err != nil {
+		if err := s.matchMatchers(ctx, sections, matchers, accums, startNanos, endNanos, stats); err != nil {
 			return nil, err
 		}
 		if len(accums) == 0 {
@@ -123,7 +129,7 @@ func (s *streamSelector) eval(
 	}
 
 	if len(filters) > 0 {
-		if err := s.matchFilters(ctx, sections, filters, accums, startNanos, endNanos); err != nil {
+		if err := s.matchFilters(ctx, sections, filters, accums, startNanos, endNanos, stats); err != nil {
 			return nil, err
 		}
 		if len(accums) == 0 {
@@ -144,14 +150,16 @@ func (s *streamSelector) matchMatchers(
 	cms []postings.CompiledMatcher,
 	accums map[postings.SectionRef]*accum,
 	startNanos, endNanos int64,
+	stats *statsTracker,
 ) error {
 	perMatcherHits := make([]map[postings.SectionRef]*memory.Bitmap, len(cms))
 	for i := range perMatcherHits {
 		perMatcherHits[i] = make(map[postings.SectionRef]*memory.Bitmap)
 	}
 
-	for _, sec := range sections {
-		matches, err := postings.NewScanner(sec).MatchLabels(ctx, nil, cms)
+	for sID, sec := range sections {
+		sectionStats := stats.SectionLabelTracker(sID)
+		matches, err := postings.NewScanner(sec).MatchLabels(ctx, nil, cms, sectionStats)
 		if err != nil {
 			return err
 		}
@@ -187,6 +195,7 @@ func (s *streamSelector) matchFilters(
 	cms []postings.CompiledMatcher,
 	accums map[postings.SectionRef]*accum,
 	startNanos, endNanos int64,
+	stats *statsTracker,
 ) error {
 	present := make([]map[postings.SectionRef]*memory.Bitmap, len(cms))
 	matched := make([]map[postings.SectionRef]*memory.Bitmap, len(cms))
@@ -195,8 +204,9 @@ func (s *streamSelector) matchFilters(
 		matched[i] = make(map[postings.SectionRef]*memory.Bitmap)
 	}
 
-	for _, sec := range sections {
-		streams, err := postings.NewScanner(sec).LabelStreams(ctx, nil, cms)
+	for sID, sec := range sections {
+		sectionStats := stats.SectionLabelTracker(sID)
+		streams, err := postings.NewScanner(sec).LabelStreams(ctx, nil, cms, sectionStats)
 		if err != nil {
 			return err
 		}
@@ -313,7 +323,7 @@ func (s *streamSelector) finalize(ref postings.SectionRef, acc *accum, startNano
 }
 
 // admitSections applies blooms and collects ambiguous names in a single pass.
-func (s *streamSelector) admitSections(ctx context.Context, sections []*postings.Section, accums map[postings.SectionRef]*accum) (map[postings.SectionRef]struct{}, map[postings.SectionRef]map[string]struct{}, error) {
+func (s *streamSelector) admitSections(ctx context.Context, sections []*postings.Section, accums map[postings.SectionRef]*accum, stats *statsTracker) (map[postings.SectionRef]struct{}, map[postings.SectionRef]map[string]struct{}, error) {
 	if len(s.equalPredicates) == 0 {
 		return nil, nil, nil
 	}
@@ -327,9 +337,10 @@ func (s *streamSelector) admitSections(ctx context.Context, sections []*postings
 	ambiguousHits := make([]map[postings.SectionRef]map[string]struct{}, len(sections))
 	g, ctx := errgroup.WithContext(ctx)
 	for i := range sections {
+		sectionStats := stats.SectionBloomTracker(i)
 		g.Go(func() error {
 			scanner := postings.NewScanner(sections[i])
-			matched, ambiguous, err := scanner.MatcherHits(ctx, s.equalPredicates)
+			matched, ambiguous, err := scanner.MatcherHits(ctx, s.equalPredicates, sectionStats)
 			if err != nil {
 				return err
 			}
@@ -462,4 +473,73 @@ func (s *streamSelector) ambiguousNames(acc *accum) []string {
 		}
 	}
 	return out
+}
+
+type statsTracker struct {
+	bySectionLabelReads map[int]*sectionStatsTracker
+	bySectionBloomReads map[int]*sectionStatsTracker
+}
+
+func newStatsTracker(sectionsCount int) *statsTracker {
+	return &statsTracker{
+		bySectionLabelReads: make(map[int]*sectionStatsTracker, sectionsCount),
+		bySectionBloomReads: make(map[int]*sectionStatsTracker, sectionsCount),
+	}
+}
+
+func (s *statsTracker) SectionLabelTracker(sID int) *sectionStatsTracker {
+	st, ok := s.bySectionLabelReads[sID]
+	if !ok {
+		st = &sectionStatsTracker{}
+		s.bySectionLabelReads[sID] = st
+	}
+	return st
+}
+
+func (s *statsTracker) SectionBloomTracker(sID int) *sectionStatsTracker {
+	st, ok := s.bySectionBloomReads[sID]
+	if !ok {
+		st = &sectionStatsTracker{}
+		s.bySectionBloomReads[sID] = st
+	}
+	return st
+}
+
+func (s *statsTracker) Report(ctx context.Context) {
+	region := xcap.RegionFromContext(ctx)
+
+	// "column_name" column stats
+	var (
+		labelColumnNameTotalPages    = uint64(0)
+		labelColumnNameRelevantPages = uint64(0)
+		bloomColumnNameTotalPages    = uint64(0)
+		bloomColumnNameRelevantPages = uint64(0)
+	)
+
+	for _, st := range s.bySectionLabelReads {
+		labelColumnNameTotalPages += st.columnNamePages.Total
+		labelColumnNameRelevantPages += st.columnNamePages.Relevant
+	}
+
+	for _, st := range s.bySectionBloomReads {
+		bloomColumnNameTotalPages += st.columnNamePages.Total
+		bloomColumnNameRelevantPages += st.columnNamePages.Relevant
+	}
+
+	region.Record(StatPostingsLabelColumnNameTotalPages.Observe(int64(labelColumnNameTotalPages)))
+	region.Record(StatPostingsLabelColumnNameRelevantPages.Observe(int64(labelColumnNameRelevantPages)))
+	region.Record(StatPostingsBloomColumnNameTotalPages.Observe(int64(bloomColumnNameTotalPages)))
+	region.Record(StatPostingsBloomColumnNameRelevantPages.Observe(int64(bloomColumnNameRelevantPages)))
+}
+
+type sectionStatsTracker struct {
+	columnNamePages dataset.ColumnReadPageStats
+}
+
+func (st *sectionStatsTracker) OnColumnPredicateBuilt(c dataset.Column, pages dataset.ColumnReadPageStats) {
+	if c.ColumnDesc().Type.Logical != postings.ColumnTypeColumnName.String() {
+		return
+	}
+	st.columnNamePages.Total = pages.Total
+	st.columnNamePages.Relevant += pages.Relevant
 }

--- a/pkg/dataobj/sections/postings/reader.go
+++ b/pkg/dataobj/sections/postings/reader.go
@@ -31,6 +31,9 @@ type ReaderOptions struct {
 	// Allocator to use for allocating Arrow records. If nil,
 	// [memory.DefaultAllocator] is used.
 	Allocator memory.Allocator
+
+	// StatsTracker keeps track of the various reader internal stats.
+	StatsTracker dataset.RowReaderStatsTracker
 }
 
 // validate returns an error if opts is invalid. ReaderOptions are valid when
@@ -199,10 +202,11 @@ func (r *Reader) init(ctx context.Context) error {
 	}
 
 	innerOptions := dataset.RowReaderOptions{
-		Dataset:    dset,
-		Columns:    dset.Columns(),
-		Predicates: preds,
-		Prefetch:   true,
+		Dataset:      dset,
+		Columns:      dset.Columns(),
+		Predicates:   preds,
+		Prefetch:     true,
+		StatsTracker: r.opts.StatsTracker,
 	}
 	if r.inner == nil {
 		r.inner = columnar.NewReaderAdapter(innerOptions)

--- a/pkg/dataobj/sections/postings/row_reader.go
+++ b/pkg/dataobj/sections/postings/row_reader.go
@@ -9,6 +9,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
 	iter "github.com/grafana/loki/v3/pkg/iter/v2"
 )
 
@@ -30,18 +31,30 @@ type RowReader struct {
 	exhausted bool  // set when Next has returned false; further calls return false without work
 }
 
+type ReaderOption func(*ReaderOptions)
+
+func WithStatsTracker(tracker dataset.RowReaderStatsTracker) ReaderOption {
+	return func(r *ReaderOptions) {
+		r.StatsTracker = tracker
+	}
+}
+
 // NewRowReader creates a RowReader over all of sec's columns, applying the
 // provided predicates when scanning. The underlying reader is opened lazily on
 // the first call to Next. The provided ctx governs all subsequent I/O (Open and
 // Read).
-func NewRowReader(ctx context.Context, sec *Section, preds []Predicate) *RowReader {
+func NewRowReader(ctx context.Context, sec *Section, preds []Predicate, optFuncs ...ReaderOption) *RowReader {
+	opts := ReaderOptions{
+		Columns:    sec.Columns(),
+		Predicates: preds,
+		Allocator:  memory.DefaultAllocator,
+	}
+	for _, optFunc := range optFuncs {
+		optFunc(&opts)
+	}
 	return &RowReader{
-		ctx: ctx,
-		reader: NewReader(ReaderOptions{
-			Columns:    sec.Columns(),
-			Predicates: preds,
-			Allocator:  memory.DefaultAllocator,
-		}),
+		ctx:    ctx,
+		reader: NewReader(opts),
 	}
 }
 

--- a/pkg/dataobj/sections/postings/scanner.go
+++ b/pkg/dataobj/sections/postings/scanner.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/columnar"
 	"github.com/grafana/loki/v3/pkg/compute"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
 	"github.com/grafana/loki/v3/pkg/memory"
-	"github.com/grafana/loki/v3/pkg/xcap"
 )
 
 // MatchedStreams is one logs section's result from a name and value scan.
@@ -47,7 +47,7 @@ func NewScanner(sec *Section) *Scanner { return &Scanner{sec: sec} }
 // The Matched bitmaps in the result are allocated from alloc (a nil alloc uses
 // Go's built-in allocation). They outlive the scan, so the caller must not
 // reclaim alloc while the returned map is in use.
-func (s *Scanner) MatchLabels(ctx context.Context, alloc *memory.Allocator, cms []CompiledMatcher) (map[SectionRef][]MatchedStreams, error) {
+func (s *Scanner) MatchLabels(ctx context.Context, alloc *memory.Allocator, cms []CompiledMatcher, statsTracker dataset.RowReaderStatsTracker) (map[SectionRef][]MatchedStreams, error) {
 	kindCol := sectionColumn(s.sec, ColumnTypeKind)
 	nameCol := sectionColumn(s.sec, ColumnTypeColumnName)
 	valueCol := sectionColumn(s.sec, ColumnTypeLabelValue)
@@ -67,7 +67,7 @@ func (s *Scanner) MatchLabels(ctx context.Context, alloc *memory.Allocator, cms 
 	pred := matchLabelsPredicate(kindCol, nameCol, valueCol, cms)
 
 	out := make(map[SectionRef][]MatchedStreams)
-	err := s.eachRow(ctx, pred, func(row Row) {
+	err := s.eachRow(ctx, pred, statsTracker, func(row Row) {
 		cands := byName[row.ColumnName]
 		if len(cands) == 0 {
 			return
@@ -122,7 +122,7 @@ func matchLabelsPredicate(kindCol, nameCol, valueCol *Column, cms []CompiledMatc
 // The Present and Matched bitmaps in the result are allocated from alloc (a nil
 // alloc uses Go's built-in allocation). They outlive the scan, so the caller
 // must not reclaim alloc while the returned map is in use.
-func (s *Scanner) LabelStreams(ctx context.Context, alloc *memory.Allocator, cms []CompiledMatcher) (map[SectionRef][]LabelStreams, error) {
+func (s *Scanner) LabelStreams(ctx context.Context, alloc *memory.Allocator, cms []CompiledMatcher, statsTracker dataset.RowReaderStatsTracker) (map[SectionRef][]LabelStreams, error) {
 	kindCol := sectionColumn(s.sec, ColumnTypeKind)
 	nameCol := sectionColumn(s.sec, ColumnTypeColumnName)
 	if kindCol == nil || nameCol == nil {
@@ -138,7 +138,7 @@ func (s *Scanner) LabelStreams(ctx context.Context, alloc *memory.Allocator, cms
 	}
 
 	out := make(map[SectionRef][]LabelStreams)
-	err := s.eachRow(ctx, labelNamesPredicate(kindCol, nameCol, byName), func(row Row) {
+	err := s.eachRow(ctx, labelNamesPredicate(kindCol, nameCol, byName), statsTracker, func(row Row) {
 		cands := byName[row.ColumnName]
 		if len(cands) == 0 {
 			return
@@ -177,8 +177,8 @@ func labelNamesPredicate(kindCol, nameCol *Column, names map[string][]int) Predi
 	}
 }
 
-func (s *Scanner) eachRow(ctx context.Context, pred Predicate, fn func(Row)) error {
-	rr := NewRowReader(ctx, s.sec, []Predicate{pred})
+func (s *Scanner) eachRow(ctx context.Context, pred Predicate, statsTracker dataset.RowReaderStatsTracker, fn func(Row)) error {
+	rr := NewRowReader(ctx, s.sec, []Predicate{pred}, WithStatsTracker(statsTracker))
 	defer rr.Close()
 	for rr.Next() {
 		row := rr.At()
@@ -259,7 +259,7 @@ func extendBitmap(alloc *memory.Allocator, b memory.Bitmap, n int) memory.Bitmap
 // per-section (name,value) bloom hits. The second is the per-section set of
 // matcher names that occur as a stream label. Returns nil maps when the section
 // lacks the required columns.
-func (s *Scanner) MatcherHits(ctx context.Context, matchers []*labels.Matcher) (map[SectionRef]map[PredicateValue]struct{}, map[SectionRef]map[string]struct{}, error) {
+func (s *Scanner) MatcherHits(ctx context.Context, matchers []*labels.Matcher, statsTracker dataset.RowReaderStatsTracker) (map[SectionRef]map[PredicateValue]struct{}, map[SectionRef]map[string]struct{}, error) {
 	kindCol := sectionColumn(s.sec, ColumnTypeKind)
 	nameCol := sectionColumn(s.sec, ColumnTypeColumnName)
 	bloomCol := sectionColumn(s.sec, ColumnTypeBloomFilter)
@@ -279,11 +279,9 @@ func (s *Scanner) MatcherHits(ctx context.Context, matchers []*labels.Matcher) (
 	}
 
 	matched := make(map[SectionRef]map[PredicateValue]struct{})
-	var bloomRowsRead int64
 	if pred := s.bloomMatchPredicate(kindCol, nameCol, bloomCol, matchers); pred != nil {
-		br := NewRowReader(ctx, s.sec, []Predicate{pred})
+		br := NewRowReader(ctx, s.sec, []Predicate{pred}, WithStatsTracker(statsTracker))
 		for br.Next() {
-			bloomRowsRead++
 			row := br.At()
 			p := byName[row.ColumnName]
 			if p == nil {
@@ -304,7 +302,6 @@ func (s *Scanner) MatcherHits(ctx context.Context, matchers []*labels.Matcher) (
 		}
 		_ = br.Close()
 	}
-	xcap.RegionFromContext(ctx).Record(StatPostingsBloomRowsRead.Observe(bloomRowsRead))
 
 	// matchers are predicates from outside the stream selector, so a name may
 	// resolve to either a stream label or a parsed/metadata label. Report which

--- a/pkg/dataobj/sections/postings/scanner_test.go
+++ b/pkg/dataobj/sections/postings/scanner_test.go
@@ -36,7 +36,7 @@ func TestScanner_MatchLabel_PushesValuePredicate(t *testing.T) {
 	require.NoError(t, err)
 
 	got := scanAll(t, secs, func(sc *postings.Scanner) (map[postings.SectionRef][]postings.MatchedStreams, error) {
-		return sc.MatchLabels(ctx, nil, []postings.CompiledMatcher{cm})
+		return sc.MatchLabels(ctx, nil, []postings.CompiledMatcher{cm}, nil)
 	})
 	require.Len(t, got, 1)
 
@@ -64,7 +64,7 @@ func TestScanner_LabelStreams_PresentAndMatched(t *testing.T) {
 	require.NoError(t, err)
 
 	got := scanAll(t, secs, func(sc *postings.Scanner) (map[postings.SectionRef][]postings.LabelStreams, error) {
-		return sc.LabelStreams(ctx, nil, []postings.CompiledMatcher{cm})
+		return sc.LabelStreams(ctx, nil, []postings.CompiledMatcher{cm}, nil)
 	})
 	require.Len(t, got, 1)
 
@@ -97,7 +97,7 @@ func TestScanner_LabelStreams_UnionZeroExtends(t *testing.T) {
 	require.NoError(t, err)
 
 	got := scanAll(t, secs, func(sc *postings.Scanner) (map[postings.SectionRef][]postings.LabelStreams, error) {
-		return sc.LabelStreams(ctx, nil, []postings.CompiledMatcher{cm})
+		return sc.LabelStreams(ctx, nil, []postings.CompiledMatcher{cm}, nil)
 	})
 	require.Len(t, got, 1)
 
@@ -133,7 +133,7 @@ func TestScanner_MatchLabels_MultiMatcherAttribution(t *testing.T) {
 	)
 
 	got := scanAll(t, secs, func(sc *postings.Scanner) (map[postings.SectionRef][]postings.MatchedStreams, error) {
-		return sc.MatchLabels(ctx, nil, cms)
+		return sc.MatchLabels(ctx, nil, cms, nil)
 	})
 	require.Len(t, got, 1)
 
@@ -164,7 +164,7 @@ func TestScanner_MatchLabels_SharedNameDisambiguation(t *testing.T) {
 	)
 
 	got := scanAll(t, secs, func(sc *postings.Scanner) (map[postings.SectionRef][]postings.MatchedStreams, error) {
-		return sc.MatchLabels(ctx, nil, cms)
+		return sc.MatchLabels(ctx, nil, cms, nil)
 	})
 	require.Len(t, got, 1)
 
@@ -195,7 +195,7 @@ func TestScanner_LabelStreams_MultiMatcherAttribution(t *testing.T) {
 	)
 
 	got := scanAll(t, secs, func(sc *postings.Scanner) (map[postings.SectionRef][]postings.LabelStreams, error) {
-		return sc.LabelStreams(ctx, nil, cms)
+		return sc.LabelStreams(ctx, nil, cms, nil)
 	})
 	require.Len(t, got, 1)
 
@@ -260,7 +260,7 @@ func TestScanner_MatcherHits(t *testing.T) {
 
 	var hitFound bool
 	for _, sec := range secs {
-		hits, _, err := postings.NewScanner(sec).MatcherHits(ctx, matchers)
+		hits, _, err := postings.NewScanner(sec).MatcherHits(ctx, matchers, nil)
 		require.NoError(t, err)
 		if _, ok := hits[ref][postings.PredicateValue{Name: "trace_id", Value: "abc"}]; ok {
 			hitFound = true
@@ -294,7 +294,7 @@ func TestScanner_MatcherHits_MultiBloomSinglePass(t *testing.T) {
 
 	got := make(map[postings.PredicateValue]struct{})
 	for _, sec := range secs {
-		hits, _, err := postings.NewScanner(sec).MatcherHits(ctx, matchers)
+		hits, _, err := postings.NewScanner(sec).MatcherHits(ctx, matchers, nil)
 		require.NoError(t, err)
 		for pv := range hits[ref] {
 			got[pv] = struct{}{}
@@ -321,7 +321,7 @@ func TestScanner_MatcherHits_AttributesByValueNotName(t *testing.T) {
 	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "app", "mimir")}
 
 	for _, sec := range secs {
-		hits, _, err := postings.NewScanner(sec).MatcherHits(ctx, matchers)
+		hits, _, err := postings.NewScanner(sec).MatcherHits(ctx, matchers, nil)
 		require.NoError(t, err)
 		_, hit := hits[ref][postings.PredicateValue{Name: "app", Value: "mimir"}]
 		require.False(t, hit, "matching column name but wrong value must not attribute a hit")
@@ -342,7 +342,7 @@ func TestScanner_MatcherHits_DuplicateNameRejected(t *testing.T) {
 		labels.MustNewMatcher(labels.MatchEqual, "app", "bar"),
 	}
 	for _, sec := range secs {
-		_, _, err := postings.NewScanner(sec).MatcherHits(ctx, matchers)
+		_, _, err := postings.NewScanner(sec).MatcherHits(ctx, matchers, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "duplicate equal-predicate name")
 	}
@@ -368,7 +368,7 @@ func TestScanner_MatcherHits_LabelNamesSinglePass(t *testing.T) {
 
 	got := make(map[string]struct{})
 	for _, sec := range secs {
-		_, ambiguous, err := postings.NewScanner(sec).MatcherHits(ctx, matchers)
+		_, ambiguous, err := postings.NewScanner(sec).MatcherHits(ctx, matchers, nil)
 		require.NoError(t, err)
 		for name := range ambiguous[ref] {
 			got[name] = struct{}{}

--- a/pkg/dataobj/sections/postings/stats.go
+++ b/pkg/dataobj/sections/postings/stats.go
@@ -5,14 +5,6 @@ import (
 	"fmt"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
-	"github.com/grafana/loki/v3/pkg/xcap"
-)
-
-// Postings xcap statistics.
-var (
-	// StatPostingsBloomRowsRead counts bloom rows scanned while resolving
-	// postings sections.
-	StatPostingsBloomRowsRead = xcap.NewStatisticInt64("postings.bloom.rows.read", xcap.AggregationTypeSum)
 )
 
 type (

--- a/pkg/engine/internal/workflow/admission_control.go
+++ b/pkg/engine/internal/workflow/admission_control.go
@@ -104,6 +104,15 @@ func isScanTask(task *Task) bool {
 	return false
 }
 
+func isPostingsScanTask(task *Task) bool {
+	for node := range task.Fragment.Graph().Nodes() {
+		if node.Type() == physical.NodeTypePointersScan {
+			return true
+		}
+	}
+	return false
+}
+
 func isCompactionTask(task *Task) bool {
 	for node := range task.Fragment.Graph().Nodes() {
 		switch node.Type() {

--- a/pkg/engine/internal/workflow/postings_locality_test.go
+++ b/pkg/engine/internal/workflow/postings_locality_test.go
@@ -1,0 +1,85 @@
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
+	"github.com/grafana/loki/v3/pkg/xcap"
+)
+
+func TestRatio(t *testing.T) {
+	require.Equal(t, 0.0, ratio(0, 0), "no pages -> zero, not NaN")
+	require.Equal(t, 0.0, ratio(5, 0), "zero total is guarded against divide-by-zero")
+	require.Equal(t, 0.25, ratio(1, 4))
+	require.Equal(t, 1.0, ratio(4, 4))
+	// Relevant pages accumulate across predicate builds while total does not, so
+	// the relevance ratio can legitimately exceed 1.0.
+	require.Equal(t, 2.5, ratio(5, 2))
+}
+
+func TestIsPostingsScanTask(t *testing.T) {
+	t.Run("PointersScan node is a postings scan", func(t *testing.T) {
+		g := dag.Graph[physical.Node]{}
+		g.Add(&physical.PointersScan{})
+		task := &Task{ULID: ulid.Make(), Fragment: physical.FromGraph(g)}
+		require.True(t, isPostingsScanTask(task))
+	})
+
+	t.Run("DataObjScan node is not a postings scan", func(t *testing.T) {
+		g := dag.Graph[physical.Node]{}
+		g.Add(&physical.DataObjScan{})
+		task := &Task{ULID: ulid.Make(), Fragment: physical.FromGraph(g)}
+		require.False(t, isPostingsScanTask(task))
+	})
+
+	t.Run("empty fragment is not a postings scan", func(t *testing.T) {
+		task := &Task{ULID: ulid.Make(), Fragment: physical.FromGraph(dag.Graph[physical.Node]{})}
+		require.False(t, isPostingsScanTask(task))
+	})
+}
+
+// TestPrintTaskSummary_LocalityRouting verifies that printTaskSummary routes a
+// task to the correct locality summary. A PointersScan task must produce the
+// postings-locality line, not the log-locality line — a PointersScan also
+// satisfies isScanTask, so this guards the branch ordering in printTaskSummary.
+func TestPrintTaskSummary_LocalityRouting(t *testing.T) {
+	t.Run("PointersScan routes to postings locality", func(t *testing.T) {
+		out := runTaskSummary(t, &physical.PointersScan{})
+		require.Contains(t, out, "task-postings-locality-summary")
+		require.NotContains(t, out, "task-log-locality-summary")
+	})
+
+	t.Run("DataObjScan routes to log locality", func(t *testing.T) {
+		out := runTaskSummary(t, &physical.DataObjScan{})
+		require.Contains(t, out, "task-log-locality-summary")
+		require.NotContains(t, out, "task-postings-locality-summary")
+	})
+}
+
+// runTaskSummary drives printTaskSummary for a single-node fragment and returns
+// the emitted log output.
+func runTaskSummary(t *testing.T, node physical.Node) string {
+	t.Helper()
+
+	g := dag.Graph[physical.Node]{}
+	g.Add(node)
+	task := &Task{ULID: ulid.Make(), Fragment: physical.FromGraph(g)}
+
+	var buf bytes.Buffer
+	wf := &Workflow{
+		logger: log.NewLogfmtLogger(&buf),
+		graph:  dag.Graph[*Task]{},
+	}
+
+	_, capture := xcap.NewCapture(context.Background(), nil)
+	wf.printTaskSummary(task, TaskStateCreated, TaskStatus{State: TaskStateRunning, Capture: capture}, false)
+
+	return buf.String()
+}

--- a/pkg/engine/internal/workflow/task_summary.go
+++ b/pkg/engine/internal/workflow/task_summary.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-kit/log/level"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/engine/internal/executor"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
@@ -95,7 +96,9 @@ func (wf *Workflow) printTaskSummary(task *Task, oldState TaskState, newStatus T
 		"cache_check", taskResultCacheOutcome(capture),
 	)
 
-	if isScanTask(task) {
+	if isPostingsScanTask(task) {
+		wf.printTaskPostingsLocalitySummary(task, capture)
+	} else if isScanTask(task) {
 		// print log section data locality as a separate log line.
 		wf.printTaskLogLocalitySummary(task, capture)
 	}
@@ -124,6 +127,31 @@ func (wf *Workflow) printTaskLogLocalitySummary(task *Task, capture *xcap.Captur
 		"stream_row_relevance", ratio(relevantRows, rowsTotal),
 		"stream_page_relevance", ratio(streamRelevantPages, streamPagesTotal),
 		"stream_page_fragmentation", ratio(streamPageRuns, streamRelevantPages),
+	)
+}
+
+func (wf *Workflow) printTaskPostingsLocalitySummary(task *Task, capture *xcap.Capture) {
+	labelPagesTotal := xcap.Value[int64](capture, metastore.StatPostingsLabelColumnNameTotalPages)
+	labelPagesRelevant := xcap.Value[int64](capture, metastore.StatPostingsLabelColumnNameRelevantPages)
+
+	bloomPagesTotal := xcap.Value[int64](capture, metastore.StatPostingsBloomColumnNameTotalPages)
+	bloomPagesRelevant := xcap.Value[int64](capture, metastore.StatPostingsBloomColumnNameRelevantPages)
+
+	level.Info(wf.logger).Log(
+		"msg", "task-postings-locality-summary",
+		// Identity
+		"task_id", task.ULID,
+		"query_id", wf.opts.ID,
+		"parent_task_id", wf.parentTaskID(task),
+
+		// Locality
+		"postings_label_column_name_pages_total", labelPagesTotal,
+		"postings_label_column_name_pages_relevant", labelPagesRelevant,
+		"postings_label_column_name_page_relevance", ratio(labelPagesRelevant, labelPagesTotal),
+
+		"postings_bloom_column_name_pages_total", bloomPagesTotal,
+		"postings_bloom_column_name_pages_relevant", bloomPagesRelevant,
+		"postings_bloom_column_name_page_relevance", ratio(bloomPagesRelevant, bloomPagesTotal),
 	)
 }
 


### PR DESCRIPTION
**What**
Adds stats that show how many postings pages we read vs. how many were actually useful, to measure page locality of the column_name column during stream selection.

**Why**                                                                                                                                                         
Reading streams scans postings pages, and page-level stats let the reader skip pages that can't match. We had no way to see how well that skipping works. These stats make it visible.
                                                                 
**Changes**
- Dataset row reader can report, per column, total pages vs. relevant pages (the ones kept after pruning) via a new optional StatsTracker hook.
- Postings reader/scanner pass the tracker through to the dataset reader.
- Stream selector collects the counts per section - separately for label and bloom scans - and records 4 new stats: dataobj.postings.{label,bloom}.column_name.pages.{total,relevant}.
- Workflow logs a task-postings-locality-summary line (with a relevance ratio) for postings scan tasks.
- Removed the old postings.bloom.rows.read stat; the page stats replace it.