### PR TITLE
refactor(dataobj): Encapsulate bloom/regex matching in postings via FuncPredicate

### DIFF
--- a/pkg/dataobj/internal/dataset/predicate.go
+++ b/pkg/dataobj/internal/dataset/predicate.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"iter"
 	"unsafe"
-
-	"github.com/prometheus/prometheus/model/labels"
 )
 
 // Predicate is an expression used to filter rows in a [RowReader].
@@ -74,27 +72,6 @@ type (
 		// If Keep returns true, the row is kept.
 		Keep func(column Column, value Value) bool
 	}
-
-	// BloomMatchPredicate is a [Predicate] which asserts that a row may only be
-	// included if the bloom filter stored in Column's binary value tests positive
-	// for Value.
-	//
-	// Instances of BloomMatchPredicate are ineligible for page filtering: a bloom
-	// blob has no min/max page statistics to prune on.
-	BloomMatchPredicate struct {
-		Column Column
-		Value  []byte
-	}
-
-	// RegexMatchPredicate is a [Predicate] which asserts that a row may only be
-	// included if Column's string value matches Matcher.
-	//
-	// Instances of RegexMatchPredicate are ineligible for page filtering: a regex
-	// has no min/max page statistics to prune on.
-	RegexMatchPredicate struct {
-		Column  Column
-		Matcher *labels.FastRegexMatcher
-	}
 )
 
 func (AndPredicate) isPredicate()         {}
@@ -107,8 +84,6 @@ func (InPredicate) isPredicate()          {}
 func (GreaterThanPredicate) isPredicate() {}
 func (LessThanPredicate) isPredicate()    {}
 func (FuncPredicate) isPredicate()        {}
-func (BloomMatchPredicate) isPredicate()  {}
-func (RegexMatchPredicate) isPredicate()  {}
 
 // WalkPredicate traverses a predicate in depth-first order: it starts by
 // calling fn(p). If fn(p) returns true, WalkPredicate is invoked recursively
@@ -138,8 +113,6 @@ func WalkPredicate(p Predicate, fn func(p Predicate) bool) {
 	case GreaterThanPredicate: // No children.
 	case LessThanPredicate: // No children.
 	case FuncPredicate: // No children.
-	case BloomMatchPredicate: // No children.
-	case RegexMatchPredicate: // No children.
 
 	default:
 		panic(fmt.Sprintf("dataset.WalkPredicate: unsupported predicate type %T", p))

--- a/pkg/dataobj/internal/dataset/row_reader.go
+++ b/pkg/dataobj/internal/dataset/row_reader.go
@@ -7,8 +7,6 @@ import (
 	"io"
 	"iter"
 
-	"github.com/bits-and-blooms/bloom/v3"
-
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/bitmask"
@@ -379,32 +377,6 @@ func checkPredicate(p Predicate, lookup map[Column]int, row Row) bool {
 		}
 		return p.Keep(p.Column, row.Values[columnIndex])
 
-	case BloomMatchPredicate:
-		columnIndex, ok := lookup[p.Column]
-		if !ok {
-			panic("checkPredicate: column not found")
-		}
-		value := row.Values[columnIndex]
-		if value.IsNil() || value.Type() != p.Column.ColumnDesc().Type.Physical {
-			return false
-		}
-		var filter bloom.BloomFilter
-		if err := filter.UnmarshalBinary(value.Binary()); err != nil {
-			return false
-		}
-		return filter.Test(p.Value)
-
-	case RegexMatchPredicate:
-		columnIndex, ok := lookup[p.Column]
-		if !ok {
-			panic("checkPredicate: column not found")
-		}
-		value := row.Values[columnIndex]
-		if value.IsNil() || value.Type() != p.Column.ColumnDesc().Type.Physical {
-			return false
-		}
-		return p.Matcher.MatchString(string(value.Binary()))
-
 	default:
 		panic(fmt.Sprintf("unsupported predicate type %T", p))
 	}
@@ -575,10 +547,6 @@ func (r *RowReader) validatePredicate() error {
 				err = process(p.Column)
 			case FuncPredicate:
 				err = process(p.Column)
-			case BloomMatchPredicate:
-				err = process(p.Column)
-			case RegexMatchPredicate:
-				err = process(p.Column)
 			case AndPredicate, OrPredicate, NotPredicate, TruePredicate, FalsePredicate, nil:
 				// No columns to process.
 			default:
@@ -698,10 +666,6 @@ func (r *RowReader) fillPrimaryMask(mask *bitmask.Mask) {
 				process(p.Column)
 			case FuncPredicate:
 				process(p.Column)
-			case BloomMatchPredicate:
-				process(p.Column)
-			case RegexMatchPredicate:
-				process(p.Column)
 			case AndPredicate, OrPredicate, NotPredicate, TruePredicate, FalsePredicate, nil:
 				// No columns to process.
 			default:
@@ -773,7 +737,7 @@ func (r *RowReader) buildPredicateRanges(ctx context.Context, p Predicate) (rang
 	case LessThanPredicate:
 		return r.buildColumnPredicateRanges(ctx, p.Column, p)
 
-	case TruePredicate, FuncPredicate, BloomMatchPredicate, RegexMatchPredicate, nil:
+	case TruePredicate, FuncPredicate, nil:
 		// These predicates (and nil) don't support any filtering, so it maps to
 		// the full range being valid.
 		//
@@ -998,10 +962,6 @@ func (r *RowReader) predicateColumns(p Predicate, keep func(c Column) bool) ([]C
 		case LessThanPredicate:
 			columns[p.Column] = struct{}{}
 		case FuncPredicate:
-			columns[p.Column] = struct{}{}
-		case BloomMatchPredicate:
-			columns[p.Column] = struct{}{}
-		case RegexMatchPredicate:
 			columns[p.Column] = struct{}{}
 		case AndPredicate, OrPredicate, NotPredicate, TruePredicate, FalsePredicate, nil:
 			// No columns to process.

--- a/pkg/dataobj/internal/dataset/row_reader_test.go
+++ b/pkg/dataobj/internal/dataset/row_reader_test.go
@@ -970,19 +970,3 @@ func Test_Reader_Stats(t *testing.T) {
 	require.Equal(t, int64(3), obsMap[dataobj.StatDatasetPrimaryRowsRead.Name()])
 	require.Equal(t, int64(1), obsMap[dataobj.StatDatasetSecondaryRowsRead.Name()])
 }
-
-// readAllRows reads all rows from a dataset with the given columns and predicates.
-func readAllRows(t *testing.T, dset Dataset, columns []Column, predicates ...Predicate) []Row {
-	t.Helper()
-
-	r := NewRowReader(RowReaderOptions{
-		Dataset:    dset,
-		Columns:    columns,
-		Predicates: predicates,
-	})
-	defer r.Close()
-
-	rows, err := readDataset(r, 3)
-	require.NoError(t, err)
-	return rows
-}

--- a/pkg/dataobj/internal/dataset/row_reader_test.go
+++ b/pkg/dataobj/internal/dataset/row_reader_test.go
@@ -11,9 +11,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/dustin/go-humanize"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -186,36 +184,6 @@ func TestRowReader_ReadWithPageFilteringOnEmptyPredicate(t *testing.T) {
 	expectedLastNames := []string{"[nil]"}
 	require.Equal(t, expectedFirstNames, actualFirstNames)
 	require.Equal(t, expectedLastNames, actualLastNames)
-}
-
-func TestRowReader_BloomMatchPredicate(t *testing.T) {
-	hit := bloom.NewWithEstimates(100, 0.01)
-	hit.Add([]byte("foo"))
-	hitBytes, err := hit.MarshalBinary()
-	require.NoError(t, err)
-
-	miss := bloom.NewWithEstimates(100, 0.01)
-	miss.Add([]byte("bar"))
-	missBytes, err := miss.MarshalBinary()
-	require.NoError(t, err)
-
-	dset, col := buildBinaryColumnDataset(t, [][]byte{hitBytes, missBytes, []byte("not-a-bloom")})
-
-	rows := readAllRows(t, dset, []Column{col}, BloomMatchPredicate{Column: col, Value: []byte("foo")})
-	require.Len(t, rows, 1)
-	require.Equal(t, hitBytes, rows[0].Values[0].Binary())
-}
-
-func TestRowReader_RegexMatchPredicate(t *testing.T) {
-	re, err := labels.NewFastRegexMatcher("foo.*")
-	require.NoError(t, err)
-
-	dset, col := buildBinaryColumnDataset(t, [][]byte{[]byte("foobar"), []byte("baz"), []byte("foo")})
-
-	rows := readAllRows(t, dset, []Column{col}, RegexMatchPredicate{Column: col, Matcher: re})
-	require.Len(t, rows, 2)
-	require.Equal(t, []byte("foobar"), rows[0].Values[0].Binary())
-	require.Equal(t, []byte("foo"), rows[1].Values[0].Binary())
 }
 
 func Test_Reader_ReadWithPredicate_NoSecondary(t *testing.T) {
@@ -1001,33 +969,6 @@ func Test_Reader_Stats(t *testing.T) {
 	require.Equal(t, int64(3), obsMap[dataobj.StatDatasetRowsAfterPruning.Name()])
 	require.Equal(t, int64(3), obsMap[dataobj.StatDatasetPrimaryRowsRead.Name()])
 	require.Equal(t, int64(1), obsMap[dataobj.StatDatasetSecondaryRowsRead.Name()])
-}
-
-// buildBinaryColumnDataset creates a dataset with a single binary column containing the given values.
-func buildBinaryColumnDataset(t *testing.T, values [][]byte) (Dataset, Column) {
-	t.Helper()
-
-	builder, err := NewColumnBuilder("bloom_data", BuilderOptions{
-		Type:        ColumnType{Physical: datasetmd.PHYSICAL_TYPE_BINARY, Logical: "binary"},
-		Compression: datasetmd.COMPRESSION_TYPE_NONE,
-		Encoding:    datasetmd.ENCODING_TYPE_PLAIN,
-		Statistics:  StatisticsOptions{},
-	})
-	require.NoError(t, err)
-
-	for i, val := range values {
-		require.NoError(t, builder.Append(i, BinaryValue(val)))
-	}
-
-	col, err := builder.Flush()
-	require.NoError(t, err)
-
-	dset := FromMemory([]*MemColumn{col})
-	cols, err := result.Collect(dset.ListColumns(context.Background()))
-	require.NoError(t, err)
-	require.Len(t, cols, 1)
-
-	return dset, cols[0]
 }
 
 // readAllRows reads all rows from a dataset with the given columns and predicates.

--- a/pkg/dataobj/sections/postings/predicate.go
+++ b/pkg/dataobj/sections/postings/predicate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/apache/arrow-go/v18/arrow/scalar"
+	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/arrowconv"
@@ -258,11 +259,37 @@ func mapPredicate(p Predicate, columnLookup map[*Column]dataset.Column) (dataset
 		}
 		return dataset.LessThanPredicate{Column: lookupColumn(p.Column, columnLookup), Value: value}, nil
 	case BloomMatchPredicate:
-		return dataset.BloomMatchPredicate{Column: lookupColumn(p.Column, columnLookup), Value: p.Value}, nil
+		col := lookupColumn(p.Column, columnLookup)
+		return dataset.FuncPredicate{Column: col, Keep: bloomKeep(col, p.Value)}, nil
 	case RegexMatchPredicate:
-		return dataset.RegexMatchPredicate{Column: lookupColumn(p.Column, columnLookup), Matcher: p.Matcher}, nil
+		col := lookupColumn(p.Column, columnLookup)
+		return dataset.FuncPredicate{Column: col, Keep: regexKeep(col, p.Matcher)}, nil
 	default:
 		panic(fmt.Sprintf("unsupported predicate type %T", p))
+	}
+}
+
+func bloomKeep(col dataset.Column, value []byte) func(dataset.Column, dataset.Value) bool {
+	physical := col.ColumnDesc().Type.Physical
+	return func(_ dataset.Column, v dataset.Value) bool {
+		if v.IsNil() || v.Type() != physical {
+			return false
+		}
+		var filter bloom.BloomFilter
+		if err := filter.UnmarshalBinary(v.Binary()); err != nil {
+			return false
+		}
+		return filter.Test(value)
+	}
+}
+
+func regexKeep(col dataset.Column, matcher *labels.FastRegexMatcher) func(dataset.Column, dataset.Value) bool {
+	physical := col.ColumnDesc().Type.Physical
+	return func(_ dataset.Column, v dataset.Value) bool {
+		if v.IsNil() || v.Type() != physical {
+			return false
+		}
+		return matcher.MatchString(string(v.Binary()))
 	}
 }
 

--- a/pkg/dataobj/sections/postings/predicate_test.go
+++ b/pkg/dataobj/sections/postings/predicate_test.go
@@ -1,0 +1,69 @@
+package postings
+
+import (
+	"testing"
+
+	"github.com/bits-and-blooms/bloom/v3"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
+)
+
+func binaryColumn() dataset.Column {
+	return &dataset.MemColumn{
+		Desc: dataset.ColumnDesc{
+			Type: dataset.ColumnType{Physical: datasetmd.PHYSICAL_TYPE_BINARY},
+		},
+	}
+}
+
+func marshaledBloom(t *testing.T, members ...string) []byte {
+	t.Helper()
+	f := bloom.NewWithEstimates(100, 0.01)
+	for _, m := range members {
+		f.Add([]byte(m))
+	}
+	b, err := f.MarshalBinary()
+	require.NoError(t, err)
+	return b
+}
+
+func TestBloomKeep_Hit(t *testing.T) {
+	col := binaryColumn()
+	keep := bloomKeep(col, []byte("foo"))
+	require.True(t, keep(col, dataset.BinaryValue(marshaledBloom(t, "foo"))))
+	require.False(t, keep(col, dataset.BinaryValue(marshaledBloom(t, "bar"))))
+}
+
+func TestBloomKeep_MalformedValue(t *testing.T) {
+	col := binaryColumn()
+	keep := bloomKeep(col, []byte("foo"))
+	require.False(t, keep(col, dataset.BinaryValue([]byte("not-a-bloom"))))
+}
+
+func TestBloomKeep_NilOrTypeMismatch(t *testing.T) {
+	col := binaryColumn()
+	keep := bloomKeep(col, []byte("foo"))
+	require.False(t, keep(col, dataset.Value{}))
+	require.False(t, keep(col, dataset.Int64Value(1)))
+}
+
+func TestRegexKeep_Match(t *testing.T) {
+	re, err := labels.NewFastRegexMatcher("foo.*")
+	require.NoError(t, err)
+	col := binaryColumn()
+	keep := regexKeep(col, re)
+	require.True(t, keep(col, dataset.BinaryValue([]byte("foobar"))))
+	require.False(t, keep(col, dataset.BinaryValue([]byte("baz"))))
+}
+
+func TestRegexKeep_NilOrTypeMismatch(t *testing.T) {
+	re, err := labels.NewFastRegexMatcher("foo.*")
+	require.NoError(t, err)
+	col := binaryColumn()
+	keep := regexKeep(col, re)
+	require.False(t, keep(col, dataset.Value{}))
+	require.False(t, keep(col, dataset.Int64Value(1)))
+}

--- a/pkg/dataobj/sections/postings/row_reader_test.go
+++ b/pkg/dataobj/sections/postings/row_reader_test.go
@@ -260,6 +260,60 @@ func TestRowReader_BloomMatchPredicate(t *testing.T) {
 	require.Equal(t, 0, countMatches("absent-value"))
 }
 
+func TestRowReader_NotBloomMatchPredicate(t *testing.T) {
+	ctx := context.Background()
+
+	b := postings.NewBuilder(nil, 0, 0, 1<<20)
+	ts := time.Unix(0, 0).UTC()
+
+	b.PrepareBloomColumn("/obj", 0, "pod", 1000)
+	require.NoError(t, b.ObserveBloomPosting(postings.BloomObservation{
+		ObjectPath:       "/obj",
+		SectionIndex:     0,
+		ColumnName:       "pod",
+		Value:            "foo",
+		StreamID:         1,
+		Timestamp:        ts,
+		UncompressedSize: 100,
+	}))
+
+	objBuilder := dataobj.NewBuilder(nil)
+	require.NoError(t, objBuilder.Append(b))
+	obj, closer, err := objBuilder.Flush()
+	require.NoError(t, err)
+	defer closer.Close()
+
+	var sec *postings.Section
+	for _, s := range obj.Sections() {
+		if !postings.CheckSection(s) {
+			continue
+		}
+		sec, err = postings.Open(ctx, s)
+		require.NoError(t, err)
+		break
+	}
+	require.NotNil(t, sec)
+
+	bloomCol := getSectionColumn(t, sec, postings.ColumnTypeBloomFilter)
+	require.NotNil(t, bloomCol)
+
+	countMatches := func(value string) int {
+		rr := postings.NewRowReader(ctx, sec, []postings.Predicate{
+			postings.NotPredicate{Inner: postings.BloomMatchPredicate{Column: bloomCol, Value: []byte(value)}},
+		})
+		defer func() { _ = rr.Close() }()
+		var got int
+		for rr.Next() {
+			got++
+		}
+		require.NoError(t, rr.Err())
+		return got
+	}
+
+	require.Equal(t, 0, countMatches("foo"))
+	require.Equal(t, 1, countMatches("absent-value"))
+}
+
 // TestRowReader_RegexMatchPredicate verifies RegexMatchPredicate filters rows
 // to only those matching a target regex.
 func TestRowReader_RegexMatchPredicate(t *testing.T) {
@@ -333,4 +387,59 @@ func TestRowReader_RegexMatchPredicate(t *testing.T) {
 
 	require.Equal(t, 2, countMatches("foo.*")) // foobar, foo
 	require.Equal(t, 0, countMatches("nope.*"))
+}
+
+func TestRowReader_NotRegexMatchPredicate(t *testing.T) {
+	ctx := context.Background()
+
+	b := postings.NewBuilder(nil, 0, 0, 1<<20)
+	ts := time.Unix(0, 0).UTC()
+
+	for i, lv := range []string{"foobar", "baz", "foo"} {
+		b.ObserveLabelPosting(postings.LabelObservation{
+			ObjectPath:       "/obj",
+			SectionIndex:     0,
+			ColumnName:       "pod",
+			LabelValue:       lv,
+			StreamID:         int64(i + 1),
+			Timestamp:        ts,
+			UncompressedSize: 100,
+		})
+	}
+
+	objBuilder := dataobj.NewBuilder(nil)
+	require.NoError(t, objBuilder.Append(b))
+	obj, closer, err := objBuilder.Flush()
+	require.NoError(t, err)
+	defer closer.Close()
+
+	var sec *postings.Section
+	for _, s := range obj.Sections() {
+		if !postings.CheckSection(s) {
+			continue
+		}
+		sec, err = postings.Open(ctx, s)
+		require.NoError(t, err)
+		break
+	}
+	require.NotNil(t, sec)
+
+	lvCol := getSectionColumn(t, sec, postings.ColumnTypeLabelValue)
+	require.NotNil(t, lvCol)
+
+	re, err := labels.NewFastRegexMatcher("foo.*")
+	require.NoError(t, err)
+
+	rr := postings.NewRowReader(ctx, sec, []postings.Predicate{
+		postings.NotPredicate{Inner: postings.RegexMatchPredicate{Column: lvCol, Matcher: re}},
+	})
+	defer func() { _ = rr.Close() }()
+
+	var got []string
+	for rr.Next() {
+		got = append(got, rr.At().LabelValue)
+	}
+	require.NoError(t, rr.Err())
+
+	require.Equal(t, []string{"baz"}, got)
 }


### PR DESCRIPTION
The low-level dataset package no longer knows what a bloom filter or a regex is.

This addresses the review comment on #22551 asking that these predicates be defined at the section level rather than leaking into the dataset scan layer. It also fixes a latent panic: negated bloom/regex predicates (e.g. a label != regex matcher) previously reached simplifyNotPredicate's default arm and panicked; they now degrade to a graceful full-range scan.