### PR TITLE
feat: Add circuit breaker to drop traffic

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3452,6 +3452,23 @@ dataobj_tee:
   # used instead.
   # CLI flag: -distributor.dataobj-tee.use-rendezvous-hashing
   [use_rendezvous_hashing: <boolean> | default = false]
+
+circuit_breaker:
+  # Enable circuit breakers.
+  # CLI flag: -distributor.circuit-breaker.enabled
+  [enabled: <boolean> | default = false]
+
+  # The open period.
+  # CLI flag: -distributor.circuit-breaker.open-period
+  [open_period: <duration> | default = 1s]
+
+  # The half-open period.
+  # CLI flag: -distributor.circuit-breaker.half-open-period
+  [half_open_period: <duration> | default = 30s]
+
+  # The maximum number of requests permitted at a time in the half-open period.
+  # CLI flag: -distributor.circuit-breaker.max-requests
+  [max_requests: <int> | default = 100]
 ```
 
 ### etcd

--- a/pkg/distributor/circuit_breaker.go
+++ b/pkg/distributor/circuit_breaker.go
@@ -107,6 +107,9 @@ func (b *linearRampCircuitBreaker) doneFunc(err error) {
 }
 
 func (b *linearRampCircuitBreaker) open() {
+	if b.state == circuitBreakerOpen {
+		return
+	}
 	b.state = circuitBreakerOpen
 	b.lastOpened = time.Now()
 }

--- a/pkg/distributor/circuit_breaker.go
+++ b/pkg/distributor/circuit_breaker.go
@@ -1,0 +1,152 @@
+package distributor
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	circuitBreakerClosed = iota
+	circuitBreakerOpen
+	circuitBreakerHalfOpen
+)
+
+var (
+	circuitBreakerStateDesc = prometheus.NewDesc(
+		"loki_distributor_circuit_breaker_state",
+		"The state of the circuit breaker.",
+		nil,
+		nil,
+	)
+)
+
+var (
+	noopDoneFunc = func(_ error) {}
+)
+
+// An interface for circuit breakers.
+type circuitBreaker interface {
+	// Allow returns true if the request can proceed, otherwise false. It returns
+	// a done callback that MUST be called when the request is finished.
+	Allow() (bool, func(err error))
+}
+
+// A linearRampCircuitBreaker is a circuit breaker which, in half-open state,
+// accepts more requests for each second that passes in half-opened until
+// the half-open period is over.
+type linearRampCircuitBreaker struct {
+	state                      int
+	openPeriod, halfOpenPeriod time.Duration
+	lastOpened                 time.Time
+	isOpenErr                  func(err error) bool
+	maxRequests                int
+	requests                   int
+	mtx                        sync.Mutex
+}
+
+// newLinearRampCircuitBreaker returns a new circuit breaker which remains
+// open until the end of the open window, and half-open until the end of the
+// half-open window. It drops all requests in the open state, and drops all
+// requests over max requests in half open state. It never drops requests
+// in closed state.
+func newLinearRampCircuitBreaker(
+	openPeriod, halfOpenPeriod time.Duration,
+	isOpenErr func(err error) bool,
+	maxRequests int,
+) *linearRampCircuitBreaker {
+	return &linearRampCircuitBreaker{
+		state:          circuitBreakerClosed,
+		openPeriod:     openPeriod,
+		halfOpenPeriod: halfOpenPeriod,
+		isOpenErr:      isOpenErr,
+		maxRequests:    maxRequests,
+	}
+}
+
+// Allow implements [circuitBreaker].
+func (b *linearRampCircuitBreaker) Allow() (ok bool, done func(err error)) {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	ok = b.handleAllow()
+	if !ok {
+		return ok, noopDoneFunc
+	}
+	b.requests++
+	return ok, b.doneFunc
+}
+
+// Describe implements [prometheus.Collector].
+func (b *linearRampCircuitBreaker) Describe(descs chan<- *prometheus.Desc) {
+	descs <- circuitBreakerStateDesc
+}
+
+// Collect implements [prometheus.Collector].
+func (b *linearRampCircuitBreaker) Collect(metrics chan<- prometheus.Metric) {
+	b.mtx.Lock()
+	state := float64(b.state)
+	b.mtx.Unlock()
+	metrics <- prometheus.MustNewConstMetric(
+		circuitBreakerStateDesc,
+		prometheus.GaugeValue,
+		state,
+	)
+}
+
+// A reference to doneFunc is returned in successful calls to [Allow]. It subtracts
+// 1 from the requests counter and also checks if the (optional) error should open
+// the circuit breaker.
+func (b *linearRampCircuitBreaker) doneFunc(err error) {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	b.requests--
+	if b.isOpenErr(err) {
+		b.open()
+	}
+}
+
+func (b *linearRampCircuitBreaker) open() {
+	b.state = circuitBreakerOpen
+	b.lastOpened = time.Now()
+}
+
+func (b *linearRampCircuitBreaker) handleAllow() bool {
+	switch b.state {
+	case circuitBreakerClosed:
+		return true
+	case circuitBreakerOpen:
+		return b.handleOpenState()
+	case circuitBreakerHalfOpen:
+		return b.handleHalfOpenState()
+	default:
+		// defer will ensure that mtx is unlocked even after a panic.
+		panic("Unknown state")
+	}
+}
+
+func (b *linearRampCircuitBreaker) handleOpenState() bool {
+	if time.Since(b.lastOpened) > b.openPeriod {
+		b.state = circuitBreakerHalfOpen
+		return b.handleHalfOpenState()
+	}
+	return false
+}
+
+func (b *linearRampCircuitBreaker) handleHalfOpenState() bool {
+	d := time.Since(b.lastOpened)
+	if d > b.openPeriod+b.halfOpenPeriod {
+		b.state = circuitBreakerClosed
+		return true
+	}
+	return b.allowHalfOpen(d - b.openPeriod)
+}
+
+// allowHalfOpen returns true if a request is allowed d seconds into the
+// half-open period. The number of allowed requests increases from 0 to
+// maxRequests in equal increments over the half-open period.
+func (b *linearRampCircuitBreaker) allowHalfOpen(d time.Duration) bool {
+	ramp := d.Seconds() / b.halfOpenPeriod.Seconds()
+	rampMax := int(float64(b.maxRequests) * ramp)
+	return b.requests < min(b.maxRequests, rampMax)
+}

--- a/pkg/distributor/circuit_breaker_test.go
+++ b/pkg/distributor/circuit_breaker_test.go
@@ -28,6 +28,31 @@ func TestLinearRampCircuitBreaker(t *testing.T) {
 		require.Equal(t, circuitBreakerOpen, b.state)
 	})
 
+	t.Run("transitions to open are de-bounced", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			b := newLinearRampCircuitBreaker(time.Second, 10*time.Second, isAnyErr, 10)
+
+			// Make two calls to Allow so we can have two separate doneFuncs.
+			ok, doneFunc := b.Allow()
+			require.True(t, ok)
+			ok2, doneFunc2 := b.Allow()
+			require.True(t, ok2)
+
+			// The first doneFunc should open the circuit breaker.
+			doneFunc(errors.New("some error occurred"))
+			require.Equal(t, circuitBreakerOpen, b.state)
+			now := time.Now()
+			require.Equal(t, now, b.lastOpened)
+
+			// Sleep 1ms, and then use doneFunc2 to open the circuit breaker a second
+			// time. It should be de-bounced.
+			time.Sleep(time.Millisecond)
+			doneFunc2(errors.New("some error occurred"))
+			require.Equal(t, circuitBreakerOpen, b.state)
+			require.Equal(t, now, b.lastOpened)
+		})
+	})
+
 	t.Run("rejects all requests when open", func(t *testing.T) {
 		b := newLinearRampCircuitBreaker(time.Second, 10*time.Second, isAnyErr, 10)
 		b.state = circuitBreakerOpen
@@ -107,7 +132,6 @@ func TestLinearRampCircuitBreaker(t *testing.T) {
 			// The 10th should be allowed now we've called one of the done funcs from
 			// the previous requests.
 			doneFuncs[0](nil)
-			doneFuncs = doneFuncs[1:]
 			ok, _ = b.Allow()
 			require.True(t, ok)
 		})

--- a/pkg/distributor/circuit_breaker_test.go
+++ b/pkg/distributor/circuit_breaker_test.go
@@ -10,66 +10,137 @@ import (
 )
 
 func TestLinearRampCircuitBreaker(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		b := newLinearRampCircuitBreaker(
-			time.Second,
-			10*time.Second,
-			func(err error) bool { return err != nil },
-			10,
-		)
+	isAnyErr := func(err error) bool { return err != nil }
 
+	t.Run("allows requests when closed", func(t *testing.T) {
+		b := newLinearRampCircuitBreaker(time.Second, 10*time.Second, isAnyErr, 10)
 		ok, doneFunc := b.Allow()
 		require.True(t, ok)
 		require.NotNil(t, doneFunc)
 		require.Equal(t, circuitBreakerClosed, b.state)
-		// Check that the doneFunc decrements the request counter.
-		require.Equal(t, 1, b.requests)
-		doneFunc(nil)
-		require.Equal(t, 0, b.requests)
+	})
 
-		// An error should open the circuit breaker.
-		ok, doneFunc = b.Allow()
+	t.Run("transitions to open on error", func(t *testing.T) {
+		b := newLinearRampCircuitBreaker(time.Second, 10*time.Second, isAnyErr, 10)
+		ok, doneFunc := b.Allow()
 		require.True(t, ok)
 		doneFunc(errors.New("some error occurred"))
 		require.Equal(t, circuitBreakerOpen, b.state)
+	})
 
-		// Sleep until the end of the open period, should remain in open.
-		time.Sleep(1 * time.Second)
-		ok, _ = b.Allow()
+	t.Run("rejects all requests when open", func(t *testing.T) {
+		b := newLinearRampCircuitBreaker(time.Second, 10*time.Second, isAnyErr, 10)
+		b.state = circuitBreakerOpen
+		b.lastOpened = time.Now()
+
+		ok, doneFunc := b.Allow()
 		require.False(t, ok)
+		require.NotNil(t, doneFunc)
 		require.Equal(t, circuitBreakerOpen, b.state)
+	})
 
-		// Should switch to half-open.
-		time.Sleep(1 * time.Second)
-		ok, doneFunc = b.Allow()
-		require.True(t, ok)
-		require.Equal(t, circuitBreakerHalfOpen, b.state)
-		doneFunc(nil)
+	t.Run("transitions to half-open after open period", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			b := newLinearRampCircuitBreaker(time.Second, 10*time.Second, isAnyErr, 10)
+			b.state = circuitBreakerOpen
+			b.lastOpened = time.Now()
 
-		// At 1s into a 10s half-open period the ramp is 0.1. This means at most one
-		// request can be processed at a time.
-		ok, doneFunc = b.Allow()
-		require.True(t, ok)
-		ok2, doneFunc2 := b.Allow()
-		require.False(t, ok2)
-		doneFunc(nil)
-		doneFunc2(nil)
+			// Sleep until the end of the open period, should remain in open.
+			time.Sleep(1 * time.Second)
+			ok, _ := b.Allow()
+			require.False(t, ok)
+			require.Equal(t, circuitBreakerOpen, b.state)
 
-		// At 9s into a 10s half-open period the ramp is 0.9. This means 9 requests
-		// can be processed at a time.
-		time.Sleep(8 * time.Second)
-		for i := 0; i < 9; i++ {
+			// Should switch to half-open.
+			time.Sleep(1 * time.Second)
 			ok, _ = b.Allow()
 			require.True(t, ok)
-		}
-		// The 10th request should be rejected.
-		ok, _ = b.Allow()
-		require.False(t, ok)
+			require.Equal(t, circuitBreakerHalfOpen, b.state)
+		})
+	})
 
-		// Should switch to closed.
-		time.Sleep(2 * time.Second)
-		ok, _ = b.Allow()
-		require.True(t, ok)
-		require.Equal(t, circuitBreakerClosed, b.state)
+	t.Run("allows some requests when half-open", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			b := newLinearRampCircuitBreaker(time.Second, 10*time.Second, isAnyErr, 10)
+			b.state = circuitBreakerHalfOpen
+			b.lastOpened = time.Now().Add(-time.Second)
+
+			// At 0 seconds into the 10s half-open period, no requests are allowed as
+			// a whole second has not passed.
+			ok, doneFunc := b.Allow()
+			require.False(t, ok)
+			doneFunc(nil)
+
+			// At 1s into a 10s half-open period the ramp is 0.1. This means at most one
+			// request can be processed at a time.
+			time.Sleep(1 * time.Second)
+			ok, doneFunc = b.Allow()
+			require.True(t, ok)
+
+			// The second request should fail.
+			ok2, doneFunc2 := b.Allow()
+			require.False(t, ok2)
+			doneFunc2(nil)
+			doneFunc(nil)
+
+			// At 9s into a 10s half-open period the ramp is 0.9. This means 9 requests
+			// can be processed at a time.
+			time.Sleep(8 * time.Second)
+			doneFuncs := make([]func(err error), 0, 10)
+			for range 9 {
+				ok, doneFunc = b.Allow()
+				require.True(t, ok)
+				doneFuncs = append(doneFuncs, doneFunc)
+			}
+
+			// The 10th request should be rejected.
+			ok, doneFunc = b.Allow()
+			require.False(t, ok)
+			doneFuncs = append(doneFuncs, doneFunc)
+
+			// The 10th should be allowed now we've called one of the done funcs from
+			// the previous requests.
+			doneFuncs[0](nil)
+			doneFuncs = doneFuncs[1:]
+			ok, _ = b.Allow()
+			require.True(t, ok)
+		})
+	})
+
+	t.Run("transitions to closed after half-open period", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			b := newLinearRampCircuitBreaker(time.Second, 10*time.Second, isAnyErr, 10)
+			b.state = circuitBreakerHalfOpen
+			b.lastOpened = time.Now().Add(-time.Second)
+
+			// Sleep until the end of the half-open period, should remain half open.
+			time.Sleep(10 * time.Second)
+			ok, _ := b.Allow()
+			require.True(t, ok)
+			require.Equal(t, circuitBreakerHalfOpen, b.state)
+
+			// Should switch to closed.
+			time.Sleep(1 * time.Second)
+			ok, _ = b.Allow()
+			require.True(t, ok)
+			require.Equal(t, circuitBreakerClosed, b.state)
+		})
+	})
+
+	t.Run("transitions to open if error occurs in half-open period", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			b := newLinearRampCircuitBreaker(time.Second, 10*time.Second, isAnyErr, 10)
+			b.state = circuitBreakerHalfOpen
+			b.lastOpened = time.Now().Add(-time.Second)
+
+			// We are 5 seconds into the half open window, and then an error occurs,
+			// should transition back to open.
+			time.Sleep(5 * time.Second)
+			ok, doneFunc := b.Allow()
+			require.True(t, ok)
+			require.Equal(t, circuitBreakerHalfOpen, b.state)
+			doneFunc(errors.New("an error occurred"))
+			require.Equal(t, circuitBreakerOpen, b.state)
+		})
 	})
 }

--- a/pkg/distributor/circuit_breaker_test.go
+++ b/pkg/distributor/circuit_breaker_test.go
@@ -1,0 +1,75 @@
+package distributor
+
+import (
+	"errors"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinearRampCircuitBreaker(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		b := newLinearRampCircuitBreaker(
+			time.Second,
+			10*time.Second,
+			func(err error) bool { return err != nil },
+			10,
+		)
+
+		ok, doneFunc := b.Allow()
+		require.True(t, ok)
+		require.NotNil(t, doneFunc)
+		require.Equal(t, circuitBreakerClosed, b.state)
+		// Check that the doneFunc decrements the request counter.
+		require.Equal(t, 1, b.requests)
+		doneFunc(nil)
+		require.Equal(t, 0, b.requests)
+
+		// An error should open the circuit breaker.
+		ok, doneFunc = b.Allow()
+		require.True(t, ok)
+		doneFunc(errors.New("some error occurred"))
+		require.Equal(t, circuitBreakerOpen, b.state)
+
+		// Sleep until the end of the open period, should remain in open.
+		time.Sleep(1 * time.Second)
+		ok, _ = b.Allow()
+		require.False(t, ok)
+		require.Equal(t, circuitBreakerOpen, b.state)
+
+		// Should switch to half-open.
+		time.Sleep(1 * time.Second)
+		ok, doneFunc = b.Allow()
+		require.True(t, ok)
+		require.Equal(t, circuitBreakerHalfOpen, b.state)
+		doneFunc(nil)
+
+		// At 1s into a 10s half-open period the ramp is 0.1. This means at most one
+		// request can be processed at a time.
+		ok, doneFunc = b.Allow()
+		require.True(t, ok)
+		ok2, doneFunc2 := b.Allow()
+		require.False(t, ok2)
+		doneFunc(nil)
+		doneFunc2(nil)
+
+		// At 9s into a 10s half-open period the ramp is 0.9. This means 9 requests
+		// can be processed at a time.
+		time.Sleep(8 * time.Second)
+		for i := 0; i < 9; i++ {
+			ok, _ = b.Allow()
+			require.True(t, ok)
+		}
+		// The 10th request should be rejected.
+		ok, _ = b.Allow()
+		require.False(t, ok)
+
+		// Should switch to closed.
+		time.Sleep(2 * time.Second)
+		ok, _ = b.Allow()
+		require.True(t, ok)
+		require.Equal(t, circuitBreakerClosed, b.state)
+	})
+}

--- a/pkg/distributor/circuit_breaker_test.go
+++ b/pkg/distributor/circuit_breaker_test.go
@@ -37,6 +37,12 @@ func TestLinearRampCircuitBreaker(t *testing.T) {
 		require.False(t, ok)
 		require.NotNil(t, doneFunc)
 		require.Equal(t, circuitBreakerOpen, b.state)
+
+		// When the circuit breaker is open, the requests counter should not be
+		// incremented, and the doneFunc should be a noopDoneFunc.
+		require.Equal(t, b.requests, 0)
+		doneFunc(nil)
+		require.Equal(t, b.requests, 0)
 	})
 
 	t.Run("transitions to half-open after open period", func(t *testing.T) {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -113,7 +113,8 @@ type Config struct {
 
 	KafkaConfig kafka.Config `yaml:"-"`
 
-	DataObjTeeConfig DataObjTeeConfig `yaml:"dataobj_tee"`
+	DataObjTeeConfig DataObjTeeConfig     `yaml:"dataobj_tee"`
+	CircuitBreaker   CircuitBreakerConfig `yaml:"circuit_breaker"`
 }
 
 // RegisterFlags registers distributor-related flags.
@@ -121,6 +122,7 @@ func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
 	cfg.OTLPConfig.RegisterFlags(fs)
 	cfg.DistributorRing.RegisterFlags(fs)
 	cfg.DataObjTeeConfig.RegisterFlags(fs)
+	cfg.CircuitBreaker.RegisterFlags(fs)
 	cfg.RateStore.RegisterFlagsWithPrefix("distributor.rate-store", fs)
 	cfg.WriteFailuresLogging.RegisterFlagsWithPrefix("distributor.write-failures-logging", fs)
 	fs.IntVar(&cfg.MaxRecvMsgSize, "distributor.max-recv-msg-size", 100<<20, "The maximum size of a received message.")
@@ -139,9 +141,42 @@ func (cfg *Config) Validate() error {
 	if err := cfg.DataObjTeeConfig.Validate(); err != nil {
 		return err
 	}
+	if err := cfg.CircuitBreaker.Validate(); err != nil {
+		return err
+	}
 	// Set default maxDecompressedSize if not configured (50x maxRecvMsgSize)
 	if cfg.MaxDecompressedSize == 0 && cfg.MaxRecvMsgSize > 0 {
 		cfg.MaxDecompressedSize = int64(cfg.MaxRecvMsgSize) * 50
+	}
+	return nil
+}
+
+type CircuitBreakerConfig struct {
+	Enabled        bool          `yaml:"enabled"`
+	OpenPeriod     time.Duration `yaml:"open_period"`
+	HalfOpenPeriod time.Duration `yaml:"half_open_period"`
+	MaxRequests    int           `yaml:"max_requests"`
+}
+
+func (cfg *CircuitBreakerConfig) RegisterFlags(f *flag.FlagSet) {
+	f.BoolVar(&cfg.Enabled, "distributor.circuit-breaker.enabled", false, "Enable circuit breakers.")
+	f.DurationVar(&cfg.OpenPeriod, "distributor.circuit-breaker.open-period", time.Second, "The open period.")
+	f.DurationVar(&cfg.HalfOpenPeriod, "distributor.circuit-breaker.half-open-period", 30*time.Second, "The half-open period.")
+	f.IntVar(&cfg.MaxRequests, "distributor.circuit-breaker.max-requests", 100, "The maximum number of requests permitted at a time in the half-open period.")
+}
+
+func (cfg *CircuitBreakerConfig) Validate() error {
+	if !cfg.Enabled {
+		return nil
+	}
+	if cfg.OpenPeriod < 0 {
+		return errors.New("the open period must be a positive duration")
+	}
+	if cfg.HalfOpenPeriod <= 0 {
+		return errors.New("the half-open period must be a positive duration")
+	}
+	if cfg.MaxRequests <= 0 {
+		return errors.New("the max requests in half-open period cannot be less than or equal to zero")
 	}
 	return nil
 }
@@ -297,6 +332,7 @@ type Distributor struct {
 	// Track the max inflight bytes in the last 1 minute.
 	inflightBytesHighWatermark prometheus.Summary
 	inflightBytes              atomic.Int64
+	circuitBreaker             circuitBreaker
 }
 
 // New a distributor creates.
@@ -450,6 +486,19 @@ func New(
 			Objectives: map[float64]float64{1.0: 0.1},
 			MaxAge:     time.Minute,
 		}),
+	}
+
+	if cfg.CircuitBreaker.Enabled {
+		circuitBreaker := newLinearRampCircuitBreaker(
+			cfg.CircuitBreaker.OpenPeriod,
+			cfg.CircuitBreaker.HalfOpenPeriod,
+			func(err error) bool {
+				return errors.Is(err, kgo.ErrMaxBuffered)
+			},
+			cfg.CircuitBreaker.MaxRequests,
+		)
+		registerer.MustRegister(circuitBreaker)
+		d.circuitBreaker = circuitBreaker
 	}
 
 	if overrides.IngestionRateStrategy() == validation.GlobalIngestionRateStrategy {

--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -45,14 +45,20 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 	// TODO: In future, we want to be able to compose this with the middleware pattern,
 	// but this requires refactor of this file to support next handlers. We will do
 	// this at a later time.
-	var circuitBreakerDoneFunc func(err error)
+	var (
+		circuitBreakerOk       bool
+		circuitBreakerDoneFunc func(err error)
+		circuitBreakerErr      error
+	)
 	if d.circuitBreaker != nil {
-		var ok bool
-		ok, circuitBreakerDoneFunc = d.circuitBreaker.Allow()
-		if !ok {
+		circuitBreakerOk, circuitBreakerDoneFunc = d.circuitBreaker.Allow()
+		if !circuitBreakerOk {
 			errorWriter(w, "circuit breaker open, request denied", http.StatusServiceUnavailable, logger)
 			return
 		}
+		// Must be wrapped in a func to avoid capture of circuitBreakerErr, otherwise
+		// updates to the err variable are invisible.
+		defer func() { circuitBreakerDoneFunc(circuitBreakerErr) }()
 	}
 
 	if d.RequestParserWrapper != nil {
@@ -165,9 +171,6 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 	}
 
 	_, err = d.PushWithResolver(r.Context(), req, streamResolver, format)
-	if circuitBreakerDoneFunc != nil {
-		circuitBreakerDoneFunc(err)
-	}
 	if err == nil {
 		if d.tenantConfigs.LogPushRequest(tenantID) {
 			level.Debug(logger).Log(
@@ -178,6 +181,7 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 		return
 	}
 
+	circuitBreakerErr = err
 	resp, ok := httpgrpc.HTTPResponseFromError(err)
 	if ok {
 		body := string(resp.Body)

--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -52,13 +52,13 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 	)
 	if d.circuitBreaker != nil {
 		circuitBreakerOk, circuitBreakerDoneFunc = d.circuitBreaker.Allow()
+		// Must be wrapped in a func to avoid capture of circuitBreakerErr, otherwise
+		// updates to the err variable are invisible.
+		defer func() { circuitBreakerDoneFunc(circuitBreakerErr) }()
 		if !circuitBreakerOk {
 			errorWriter(w, "circuit breaker open, request denied", http.StatusServiceUnavailable, logger)
 			return
 		}
-		// Must be wrapped in a func to avoid capture of circuitBreakerErr, otherwise
-		// updates to the err variable are invisible.
-		defer func() { circuitBreakerDoneFunc(circuitBreakerErr) }()
 	}
 
 	if d.RequestParserWrapper != nil {

--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -42,6 +42,19 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 		return
 	}
 
+	// TODO: In future, we want to be able to compose this with the middleware pattern,
+	// but this requires refactor of this file to support next handlers. We will do
+	// this at a later time.
+	var circuitBreakerDoneFunc func(err error)
+	if d.circuitBreaker != nil {
+		var ok bool
+		ok, circuitBreakerDoneFunc = d.circuitBreaker.Allow()
+		if !ok {
+			errorWriter(w, "circuit breaker open, request denied", http.StatusServiceUnavailable, logger)
+			return
+		}
+	}
+
 	if d.RequestParserWrapper != nil {
 		pushRequestParser = d.RequestParserWrapper(pushRequestParser)
 	}
@@ -152,6 +165,9 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 	}
 
 	_, err = d.PushWithResolver(r.Context(), req, streamResolver, format)
+	if circuitBreakerDoneFunc != nil {
+		circuitBreakerDoneFunc(err)
+	}
 	if err == nil {
 		if d.tenantConfigs.LogPushRequest(tenantID) {
 			level.Debug(logger).Log(


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds support for circuit breakers in the distributors to drop excess traffic under high load. The initial error that is supported is when the Kafka buffer is full. We will add a second error condition for max inflight bytes in a follow up PR.

While the circuit breaker uses a mutex, it has been tested at several 100 requests/sec in a test env. We keep the critical section short to keep mutex contention as small as possible. Out of 10 minutes of continuous profiles, during testing, the cumulative time spent in the circuit breaker was 50ms.

<img width="1433" height="269" alt="Screenshot 2026-07-08 at 13 06 04" src="https://github.com/user-attachments/assets/2c0fe880-2124-444a-9048-e64b9e21ee09" />

Below is a flowchart showing how it works:

<img width="2910" height="7634" alt="_Users_grobinson_go_src_github com_grafana_loki_circuit_breaker_flowchart html (1)" src="https://github.com/user-attachments/assets/29973b38-7f44-4fcf-ae20-3947b4606e05" />

[circuit_breaker_flowchart.html](https://github.com/user-attachments/files/29800581/circuit_breaker_flowchart.html)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
