### PR TITLE
fix(engine/v2): Push line_format & label_format field refs to upstream parsers

### DIFF
--- a/pkg/engine/internal/planner/physical/rule_projection_pushdown.go
+++ b/pkg/engine/internal/planner/physical/rule_projection_pushdown.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/semconv"
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+	"github.com/grafana/loki/v3/pkg/logql/log"
 )
 
 var _ rule = (*projectionPushdown)(nil)
@@ -73,6 +74,10 @@ func (r *projectionPushdown) propagateProjections(node Node, projections []Colum
 					}
 				case types.VariadicOpParseRegexp:
 					projections = append(projections, r.handleParseRegexp(e)...)
+				case types.VariadicOpParseLinefmt:
+					projections = append(projections, r.handleParseLinefmt(e)...)
+				case types.VariadicOpParseLabelfmt:
+					projections = append(projections, r.handleParseLabelfmt(e)...)
 				}
 			}
 		}
@@ -228,6 +233,75 @@ func (r *projectionPushdown) handleParse(expr *VariadicExpr, projections []Colum
 	projections = append(projections, exprs.sourceColumnExpr)
 	projections = append(projections, collisionSources...)
 	return changed, projections
+}
+
+// handleParseLinefmt returns the fields referenced by the line_format
+// template as Ambiguous column expressions, so an upstream parser
+// (logfmt / json) extracts them into the batch before line_format
+// consumes them. Without this, template lookups like {{.mint}}
+// silently render "" via missingkey=zero — breaking any subsequent
+// regexp/filter that needs the templated content.
+func (r *projectionPushdown) handleParseLinefmt(expr *VariadicExpr) []ColumnExpression {
+	if len(expr.Expressions) < 3 {
+		return nil
+	}
+	tmplLit, ok := expr.Expressions[2].(*LiteralExpr)
+	if !ok {
+		return nil
+	}
+	tmplStr, ok := tmplLit.Literal().Any().(string)
+	if !ok || tmplStr == "" {
+		return nil
+	}
+	formatter, err := log.NewFormatter(tmplStr)
+	if err != nil {
+		return nil
+	}
+	names := formatter.RequiredLabelNames()
+	if len(names) == 0 {
+		return nil
+	}
+	out := make([]ColumnExpression, 0, len(names))
+	for _, name := range names {
+		out = append(out, &ColumnExpr{Ref: types.ColumnRef{Column: name, Type: types.ColumnTypeAmbiguous}})
+	}
+	return out
+}
+
+// handleParseLabelfmt returns the columns referenced by label_format
+// stages as Ambiguous column expressions, so an upstream parser
+// (logfmt / json) extracts them into the batch before label_format
+// consumes them. Two forms feed into RequiredLabelNames():
+//   - rename: `label_format new=old` requires the source column `old`
+//     so the rename target has a value (the parser only sees real keys).
+//   - template: `label_format tag="{{.foo}}"` requires each field
+//     referenced by the Go template; missing ones silently render ""
+//     via missingkey=zero.
+func (r *projectionPushdown) handleParseLabelfmt(expr *VariadicExpr) []ColumnExpression {
+	if len(expr.Expressions) < 3 {
+		return nil
+	}
+	fmtLit, ok := expr.Expressions[2].(*LiteralExpr)
+	if !ok {
+		return nil
+	}
+	fmts, ok := fmtLit.Literal().Any().([]log.LabelFmt)
+	if !ok || len(fmts) == 0 {
+		return nil
+	}
+	formatter, err := log.NewLabelsFormatter(fmts)
+	if err != nil {
+		return nil
+	}
+	names := formatter.RequiredLabelNames()
+	if len(names) == 0 {
+		return nil
+	}
+	out := make([]ColumnExpression, 0, len(names))
+	for _, name := range names {
+		out = append(out, &ColumnExpr{Ref: types.ColumnRef{Column: name, Type: types.ColumnTypeAmbiguous}})
+	}
+	return out
 }
 
 // handleParseRegexp returns the regexp parser's source column so the scan

--- a/pkg/engine/internal/planner/physical/rule_projection_pushdown_test.go
+++ b/pkg/engine/internal/planner/physical/rule_projection_pushdown_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/logical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/types"
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
+	"github.com/grafana/loki/v3/pkg/logql/log"
 )
 
 func TestProjectionPushdown(t *testing.T) {
@@ -829,6 +830,123 @@ func TestProjectionPushdown_PushesRequestedKeysToParseOperations(t *testing.T) {
 				return builder.Value()
 			},
 		},
+		{
+			name: "line_format template fields are added to upstream logfmt requestedKeys",
+			buildLogical: func() logical.Value {
+				// sum by (app) (sum_over_time({app="test"} | logfmt | line_format "{{.mint}}" | regexp "(?P<val>\d+)" | unwrap val [5m]))
+				builder := logical.NewBuilder(&logical.MakeTable{
+					Selector: &logical.BinOp{
+						Left:  logical.NewColumnRef("app", types.ColumnTypeLabel),
+						Right: logical.NewLiteral("test"),
+						Op:    types.BinaryOpEq,
+					},
+					Shard: logical.NewShard(0, 1),
+				})
+				builder = builder.Parse(types.VariadicOpParseLogfmt, false, false)
+				builder = builder.Format(types.VariadicOpParseLinefmt, logical.NewLiteral("{{.mint}}"))
+				builder = builder.ParseRegexp(`(?P<val>\d+)`)
+				builder = builder.Cast("val", types.UnaryOpCastFloat)
+				builder = builder.ProjectDrop(&logical.ColumnRef{
+					Ref: types.ColumnRef{Column: "val", Type: types.ColumnTypeAmbiguous},
+				})
+				builder = builder.RangeAggregation(
+					logical.NoGrouping,
+					types.RangeAggregationTypeSum,
+					time.Unix(0, 0),
+					time.Unix(3600, 0),
+					5*time.Minute,
+					5*time.Minute,
+				)
+				builder = builder.VectorAggregation(
+					logical.Grouping{
+						Columns: []logical.ColumnRef{
+							{Ref: types.ColumnRef{Column: "app", Type: types.ColumnTypeLabel}},
+						},
+						Without: false,
+					},
+					types.VectorAggregationTypeSum,
+				)
+				return builder.Value()
+			},
+			expectedParseKeysRequested:     []string{"mint", "val"},
+			expectedDataObjScanProjections: []string{"app", "message", "mint", "timestamp", "val"},
+		},
+		{
+			name: "label_format rename source is added to upstream logfmt requestedKeys",
+			buildLogical: func() logical.Value {
+				// sum by (msg_new) (count_over_time({app="test"} | logfmt | label_format msg_new=msg [5m]))
+				builder := logical.NewBuilder(&logical.MakeTable{
+					Selector: &logical.BinOp{
+						Left:  logical.NewColumnRef("app", types.ColumnTypeLabel),
+						Right: logical.NewLiteral("test"),
+						Op:    types.BinaryOpEq,
+					},
+					Shard: logical.NewShard(0, 1),
+				})
+				builder = builder.Parse(types.VariadicOpParseLogfmt, false, false)
+				builder = builder.Format(types.VariadicOpParseLabelfmt, logical.NewLiteral([]log.LabelFmt{
+					log.NewRenameLabelFmt("msg_new", "msg"),
+				}))
+				builder = builder.RangeAggregation(
+					logical.NoGrouping,
+					types.RangeAggregationTypeCount,
+					time.Unix(0, 0),
+					time.Unix(3600, 0),
+					5*time.Minute,
+					5*time.Minute,
+				)
+				builder = builder.VectorAggregation(
+					logical.Grouping{
+						Columns: []logical.ColumnRef{
+							{Ref: types.ColumnRef{Column: "msg_new", Type: types.ColumnTypeAmbiguous}},
+						},
+						Without: false,
+					},
+					types.VectorAggregationTypeSum,
+				)
+				return builder.Value()
+			},
+			expectedParseKeysRequested:     []string{"msg", "msg_new"},
+			expectedDataObjScanProjections: []string{"message", "msg", "msg_new", "timestamp"},
+		},
+		{
+			name: "label_format template fields are added to upstream logfmt requestedKeys",
+			buildLogical: func() logical.Value {
+				// sum by (tag) (count_over_time({app="test"} | logfmt | label_format tag=`x{{.error}}y` [5m]))
+				builder := logical.NewBuilder(&logical.MakeTable{
+					Selector: &logical.BinOp{
+						Left:  logical.NewColumnRef("app", types.ColumnTypeLabel),
+						Right: logical.NewLiteral("test"),
+						Op:    types.BinaryOpEq,
+					},
+					Shard: logical.NewShard(0, 1),
+				})
+				builder = builder.Parse(types.VariadicOpParseLogfmt, false, false)
+				builder = builder.Format(types.VariadicOpParseLabelfmt, logical.NewLiteral([]log.LabelFmt{
+					log.NewTemplateLabelFmt("tag", "x{{.error}}y"),
+				}))
+				builder = builder.RangeAggregation(
+					logical.NoGrouping,
+					types.RangeAggregationTypeCount,
+					time.Unix(0, 0),
+					time.Unix(3600, 0),
+					5*time.Minute,
+					5*time.Minute,
+				)
+				builder = builder.VectorAggregation(
+					logical.Grouping{
+						Columns: []logical.ColumnRef{
+							{Ref: types.ColumnRef{Column: "tag", Type: types.ColumnTypeAmbiguous}},
+						},
+						Without: false,
+					},
+					types.VectorAggregationTypeSum,
+				)
+				return builder.Value()
+			},
+			expectedParseKeysRequested:     []string{"error", "tag"},
+			expectedDataObjScanProjections: []string{"error", "message", "tag", "timestamp"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -860,12 +978,19 @@ func TestProjectionPushdown_PushesRequestedKeysToParseOperations(t *testing.T) {
 			optimizedPlan, err := planner.Optimize(physicalPlan)
 			require.NoError(t, err)
 
-			var projectionNode *Projection
+			// Collect ALL Projection nodes rather than the last one iterated
+			// (map iteration order is non-deterministic), and find the one
+			// carrying the parse (JSON / logfmt) VariadicExpr — that's the
+			// node whose requestedKeys we assert on. A pipeline can have
+			// several Projection nodes (parser + line_format + regexp +
+			// cast + drop each become one) so picking the last-iterated
+			// makes the assertion flaky when more than one is present.
+			var projectionNodes []*Projection
 			projections := map[string]struct{}{}
 			projectionRefs := map[types.ColumnRef]struct{}{}
 			for node := range optimizedPlan.graph.Nodes() {
 				if pn, ok := node.(*Projection); ok {
-					projectionNode = pn
+					projectionNodes = append(projectionNodes, pn)
 					continue
 				}
 				if pn, ok := node.(*ScanSet); ok {
@@ -877,24 +1002,29 @@ func TestProjectionPushdown_PushesRequestedKeysToParseOperations(t *testing.T) {
 				}
 			}
 
-			require.NotNil(t, projectionNode, "Projection not found in plan")
+			require.NotEmpty(t, projectionNodes, "Projection not found in plan")
 			var requestedKeys *LiteralExpr
-			for _, expr := range projectionNode.Expressions {
-				ve, ok := expr.(*VariadicExpr)
-				if !ok {
-					continue
-				}
-				// Only JSON / logfmt carry requestedKeys at arg index 1. The regexp
-				// parser's arg index 1 is the pattern literal (a StringLiteral),
-				// not a requested-keys list — interpreting it as requestedKeys
-				// would falsely fail the literal-type assertion below.
-				if ve.Op != types.VariadicOpParseJSON && ve.Op != types.VariadicOpParseLogfmt {
-					continue
-				}
-				if len(ve.Expressions) >= 2 {
-					if e, ok := ve.Expressions[1].(*LiteralExpr); ok {
-						requestedKeys = e
+			for _, projectionNode := range projectionNodes {
+				for _, expr := range projectionNode.Expressions {
+					ve, ok := expr.(*VariadicExpr)
+					if !ok {
+						continue
 					}
+					// Only JSON / logfmt carry requestedKeys at arg index 1. The regexp
+					// parser's arg index 1 is the pattern literal (a StringLiteral),
+					// not a requested-keys list — interpreting it as requestedKeys
+					// would falsely fail the literal-type assertion below.
+					if ve.Op != types.VariadicOpParseJSON && ve.Op != types.VariadicOpParseLogfmt {
+						continue
+					}
+					if len(ve.Expressions) >= 2 {
+						if e, ok := ve.Expressions[1].(*LiteralExpr); ok {
+							requestedKeys = e
+						}
+					}
+				}
+				if requestedKeys != nil {
+					break
 				}
 			}
 

--- a/pkg/logql/bench/queries/regression/metric-queries.yaml
+++ b/pkg/logql/bench/queries/regression/metric-queries.yaml
@@ -380,3 +380,86 @@ queries:
       bind to the parsed capture (matching v1's parsed-label semantics —
       v1 has no builtin `message` label), not to the raw log line. The
       series label set and per-series counts must match v1.
+  - description: Unwrap a value extracted from line_format template output
+    query: sum by (level) (sum_over_time(${SELECTOR} | logfmt | line_format `{{.bytes}}` | regexp `(?P<val>\d+)` | unwrap val [${RANGE}]))
+    kind: metric
+    time_range:
+      length: 24h
+      step: 1m
+    tags:
+      - unwrap
+      - sum_over_time
+      - logfmt
+      - line_format
+      - regexp
+      - grouping
+    notes: >
+      Regression for the v2 line_format projection-pushdown fix. The
+      `line_format "{{.bytes}}"` template references `bytes`, which is
+      not consumed by any downstream filter or grouping (the downstream
+      `regexp` produces `val` and the group-by uses stream label
+      `level`). Pre-fix, projection pushdown narrowed logfmt's
+      requestedKeys to `[val]` (plus stream columns), so logfmt never
+      extracted `bytes`, `line_format` rendered "" via missingkey=zero,
+      `regexp` matched nothing, and `unwrap val` produced empty. Post-fix
+      the template's referenced fields are added to logfmt's
+      requestedKeys and per-level sums match v1. Must equal v1.
+    requires:
+      log_format: logfmt
+      unwrappable_fields:
+        - bytes
+      detected_fields:
+        - level
+  - description: Group by a label_format-renamed destination whose source is only known via the rename
+    query: sum by (msg_new) (count_over_time(${SELECTOR} | logfmt | label_format msg_new=msg [${RANGE}]))
+    kind: metric
+    time_range:
+      length: 24h
+      step: 1m
+    tags:
+      - count_over_time
+      - logfmt
+      - label_format
+      - rename
+      - grouping
+    notes: >
+      Regression for the v2 label_format projection-pushdown fix. The
+      pipeline renames `msg` to `msg_new` and the outer aggregation
+      groups on the destination `msg_new`. Nothing else references the
+      source `msg`. Pre-fix, projection pushdown asked logfmt for
+      `msg_new` (which isn't a real logfmt key) and never asked for the
+      rename source `msg`, so logfmt extracted nothing, the rename
+      produced null, and grouping collapsed to a single empty series.
+      Post-fix, `handleParseLabelfmt` adds the rename source to
+      requestedKeys so `msg` is extracted and per-msg series match v1.
+      Must equal v1.
+    requires:
+      log_format: logfmt
+      detected_fields:
+        - msg
+  - description: label_format template field ref not pinned by any filter or grouping
+    query: sum by (tag) (count_over_time(${SELECTOR} | logfmt | label_format tag=`x{{.msg}}y` [${RANGE}]))
+    kind: metric
+    time_range:
+      length: 24h
+      step: 1m
+    tags:
+      - count_over_time
+      - logfmt
+      - label_format
+      - template
+      - grouping
+    notes: >
+      Companion to the label_format rename regression above, exercising
+      the template branch of `handleParseLabelfmt`. The template
+      references `msg` but no filter or grouping pins it. Pre-fix,
+      logfmt was asked only for `tag` (not a real key) and never
+      extracted `msg`, so the template rendered `"xy"` via
+      missingkey=zero and every stream collapsed onto a single
+      `tag="xy"` series. Post-fix, the template's referenced fields are
+      added to logfmt's requestedKeys and per-msg series match v1. Must
+      equal v1.
+    requires:
+      log_format: logfmt
+      detected_fields:
+        - msg


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a v2 query engine correctness gap in which fields referenced only by a `line_format` or `label_format` stage were not projected from the upstream `logfmt`/`json` parser. Because projection pushdown narrows a parser's `requestedKeys` to what downstream stages consume, template lookups like `line_format "{{.mint}}"` or `label_format tag="x{{.error}}y"` and rename sources like `label_format new=old` are silently rendered as `""` via `missingkey=zero`. Any downstream `regexp` / `label_filter` / `unwrap` / group-by that depended on the templated or renamed value then collapsed to empty results or a single degenerate series, while v1 returned the expected data.

The fix extends `propagateProjections` in `pkg/engine/internal/planner/physical/rule_projection_pushdown.go` with two new cases:

- `VariadicOpParseLinefmt` → `handleParseLinefmt` extracts `log.NewFormatter(tmpl).RequiredLabelNames()` and adds each as an ambiguous `ColumnExpr`, so upstream parsers extract the template's referenced fields.
- `VariadicOpParseLabelfmt` → `handleParseLabelfmt` builds a `log.LabelsFormatter` and calls `RequiredLabelNames()`, which covers both the rename source (`old` in `new=old`) and template field refs.

Note: the rule runs only on metric queries and only descends past a `RangeAggregation` whose `Grouping.Without` is `false`, so bare `sum(sum_over_time(...))` / `max(max_over_time(...))` pipelines are unaffected, since they extract all keys today. This fix targets the `sum by (x)` shape, where projection propagation had already narrowed the parser and dropped template fields.
