### PR TITLE
fix(dataobj): Truncate section timestamps in explorer inspect response

### DIFF
--- a/pkg/dataobj/explorer/inspect.go
+++ b/pkg/dataobj/explorer/inspect.go
@@ -101,15 +101,23 @@ func (s *Service) handleInspect(w http.ResponseWriter, r *http.Request) {
 
 	metadata := inspectFile(r.Context(), s.logger, s.bucket, filename)
 	metadata.LastModified = attrs.LastModified.UTC()
-	for _, section := range metadata.Sections {
-		section.MinTimestamp = section.MinTimestamp.UTC().Truncate(time.Second)
-		section.MaxTimestamp = section.MaxTimestamp.UTC().Truncate(time.Second)
-	}
+	normalizeSectionTimestamps(metadata.Sections)
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(metadata); err != nil {
 		http.Error(w, fmt.Sprintf("failed to encode response: %v", err), http.StatusInternalServerError)
 		return
+	}
+}
+
+// normalizeSectionTimestamps normalizes each section's MinTimestamp and
+// MaxTimestamp to UTC, truncated to the second, in place. sections must be
+// addressed by index: SectionMetadata is a value type, so ranging by value
+// would mutate copies and silently discard the normalization.
+func normalizeSectionTimestamps(sections []SectionMetadata) {
+	for i := range sections {
+		sections[i].MinTimestamp = sections[i].MinTimestamp.UTC().Truncate(time.Second)
+		sections[i].MaxTimestamp = sections[i].MaxTimestamp.UTC().Truncate(time.Second)
 	}
 }
 

--- a/pkg/dataobj/explorer/inspect_test.go
+++ b/pkg/dataobj/explorer/inspect_test.go
@@ -71,3 +71,27 @@ func TestInspectFile_IndexPointers(t *testing.T) {
 	require.True(t, start.Equal(row.StartTs))
 	require.True(t, end.Equal(row.EndTs))
 }
+
+func TestNormalizeSectionTimestamps(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	minTs := time.Date(2026, 6, 3, 8, 0, 0, 123456789, loc)
+	maxTs := time.Date(2026, 6, 3, 9, 30, 0, 987654321, loc)
+
+	sections := []SectionMetadata{
+		{Type: "streams", MinTimestamp: minTs, MaxTimestamp: maxTs},
+		{Type: "indexpointers", MinTimestamp: minTs, MaxTimestamp: maxTs},
+	}
+
+	normalizeSectionTimestamps(sections)
+
+	for i, s := range sections {
+		require.Equalf(t, time.UTC, s.MinTimestamp.Location(), "section %d MinTimestamp location", i)
+		require.Equalf(t, time.UTC, s.MaxTimestamp.Location(), "section %d MaxTimestamp location", i)
+		require.Zerof(t, s.MinTimestamp.Nanosecond(), "section %d MinTimestamp nanosecond", i)
+		require.Zerof(t, s.MaxTimestamp.Nanosecond(), "section %d MaxTimestamp nanosecond", i)
+		require.Truef(t, minTs.Truncate(time.Second).Equal(s.MinTimestamp), "section %d MinTimestamp value", i)
+		require.Truef(t, maxTs.Truncate(time.Second).Equal(s.MaxTimestamp), "section %d MaxTimestamp value", i)
+	}
+}


### PR DESCRIPTION
handleInspect normalized each SectionMetadata's MinTimestamp and MaxTimestamp to UTC, truncated to the second, using `for _, section := range metadata.Sections`. SectionMetadata is a value type, so `section` was a per-iteration copy and both assignments were silently discarded, leaving the JSON response with un-normalized timestamps.

Only the streams and indexpointers sections populate these fields, so the impact is cosmetic: the dataobj explorer debug UI could show non-UTC or sub-second timestamps for those sections.

Extract the loop into normalizeSectionTimestamps, iterating by index so the mutation applies to the underlying slice, and add a regression test that exercises the helper directly with a non-UTC, sub-second input.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
