### PR TITLE
feat(compaction): Implement merge for log objects

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -345,7 +345,7 @@ func (b *Builder) Append(tenant string, stream logproto.Stream, recTime time.Tim
 		schemaLabels := b.overrides.SortSchemaLabels(tenant)
 		if len(schemaLabels) > 0 {
 			var err error
-			sortKey, err = computeSortKey(ls, schemaLabels)
+			sortKey, err = ComputeSortKey(ls, schemaLabels)
 			if err != nil {
 				return fmt.Errorf("compute sort key for tenant %s: %w", tenant, err)
 			}
@@ -736,7 +736,7 @@ func sortAndRemapStreams(iter result.Seq[streams.Stream], tenant string, schemaL
 		if err != nil {
 			return nil, streamIDRemap{}, err
 		}
-		k, err := computeSortKey(stream.Labels, schemaLabels)
+		k, err := ComputeSortKey(stream.Labels, schemaLabels)
 		if err != nil {
 			return nil, streamIDRemap{}, err
 		}
@@ -796,16 +796,16 @@ func streamsSectionIter(ctx context.Context, section *streams.Section) result.Se
 	})
 }
 
-// computeSortKey builds a composite sort key from stream labels using FQN entries.
+// ComputeSortKey builds a composite sort key from stream labels using FQN entries.
 // Each FQN must be "label:<name>" — validation.SortSchema.Validate() enforces this.
-func computeSortKey(ls labels.Labels, schemaLabels []string) (string, error) {
+func ComputeSortKey(ls labels.Labels, schemaLabels []string) (string, error) {
 	if len(schemaLabels) == 0 {
 		return "", nil
 	}
 	resolveLabel := func(fqn string) (string, error) {
 		typ, name, ok := strings.Cut(fqn, ":")
 		if !ok || typ != "label" {
-			return "", fmt.Errorf("computeSortKey: unexpected FQN %q — only \"label:<name>\" is supported", fqn)
+			return "", fmt.Errorf("ComputeSortKey: unexpected FQN %q — only \"label:<name>\" is supported", fqn)
 		}
 		return ls.Get(name), nil
 	}

--- a/pkg/dataobj/consumer/logsobj/builder_e2e_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_e2e_test.go
@@ -260,10 +260,10 @@ func compareRecords(t *testing.T, a, b builderE2EResolvedRecord, sortOrder strin
 	t.Helper()
 
 	if len(schemaLabels) > 0 {
-		aKey, err := computeSortKey(a.labels, schemaLabels)
+		aKey, err := ComputeSortKey(a.labels, schemaLabels)
 		require.NoError(t, err)
 
-		bKey, err := computeSortKey(b.labels, schemaLabels)
+		bKey, err := ComputeSortKey(b.labels, schemaLabels)
 		require.NoError(t, err)
 
 		if res := cmp.Compare(aKey, bKey); res != 0 {

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -783,9 +783,9 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 			streamIDsAfter[stream.id] = struct{}{}
 
 			if i > 0 {
-				prevKey, err := computeSortKey(streamsAfter[i-1].labels, schemaLabels)
+				prevKey, err := ComputeSortKey(streamsAfter[i-1].labels, schemaLabels)
 				require.NoError(t, err)
-				currKey, err := computeSortKey(stream.labels, schemaLabels)
+				currKey, err := ComputeSortKey(stream.labels, schemaLabels)
 				require.NoError(t, err)
 				require.LessOrEqual(t, prevKey, currKey)
 			}
@@ -825,9 +825,9 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 				continue
 			}
 			prev := logsAfter[i-1]
-			prevKey, err := computeSortKey(prev.labels, schemaLabels)
+			prevKey, err := ComputeSortKey(prev.labels, schemaLabels)
 			require.NoError(t, err)
-			currKey, err := computeSortKey(record.labels, schemaLabels)
+			currKey, err := ComputeSortKey(record.labels, schemaLabels)
 			require.NoError(t, err)
 
 			switch {
@@ -922,7 +922,7 @@ func TestComputeSortKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := computeSortKey(tt.labels, tt.schemaLabels)
+			got, err := ComputeSortKey(tt.labels, tt.schemaLabels)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/pkg/dataobj/sortmerge/sortmerge.go
+++ b/pkg/dataobj/sortmerge/sortmerge.go
@@ -167,6 +167,7 @@ type sectionSequence struct {
 	logs.DatasetSequence
 	section *logs.Section
 	remap   map[int64]int64
+	err     error
 }
 
 var _ loser.Sequence = (*sectionSequence)(nil)
@@ -184,8 +185,17 @@ func (s *sectionSequence) Next() bool {
 	}
 	if g, ok := s.remap[row.Values[0].Int64()]; ok {
 		row.Values[0] = dataset.Int64Value(g)
+	} else {
+		s.err = fmt.Errorf("sort merge: logs record references stream ID %d absent from stream remap", row.Values[0].Int64())
 	}
 	return true
+}
+
+func (s *sectionSequence) At() result.Result[dataset.Row] {
+	if s.err != nil {
+		return result.Error[dataset.Row](s.err)
+	}
+	return s.DatasetSequence.At()
 }
 
 func sectionSequenceAt(seq *sectionSequence) result.Result[dataset.Row] { return seq.At() }

--- a/pkg/dataobj/sortmerge/sortmerge.go
+++ b/pkg/dataobj/sortmerge/sortmerge.go
@@ -26,7 +26,7 @@ import (
 // multiple logs sections. It requires that the input sections are sorted
 // according to sort.
 func Iterator(ctx context.Context, sections []*dataobj.Section, sort logs.SortOrder) (result.Seq[logs.Record], error) {
-	return iterator(ctx, sections, logs.CompareForSortOrder(sort))
+	return iterator(ctx, sections, iteratorOptions{less: logs.CompareForSortOrder(sort)})
 }
 
 // IteratorForSchema returns an iterator that performs a k-way merge of records
@@ -35,7 +35,7 @@ func Iterator(ctx context.Context, sections []*dataobj.Section, sort logs.SortOr
 //
 // It expects sortKeys to contain a mapping from StreamID to schema sort key.
 func IteratorForSchema(ctx context.Context, sections []*dataobj.Section, sortKeys []string) (result.Seq[logs.Record], error) {
-	return iterator(ctx, sections, logs.CompareForSortSchema(sortKeys))
+	return iterator(ctx, sections, iteratorOptions{less: logs.CompareForSortSchema(sortKeys)})
 }
 
 // IteratorWithStreamRemap performs a k-way merge over logs sections drawn from
@@ -43,11 +43,33 @@ func IteratorForSchema(ctx context.Context, sections []*dataobj.Section, sortKey
 // via remaps[i] (the map for sections[i]) before records are compared, so one
 // merge can order records across objects.
 func IteratorWithStreamRemap(ctx context.Context, sections []*dataobj.Section, remaps []map[int64]int64, globalSortKeys []string, expectedSchema []string) (result.Seq[logs.Record], error) {
-	if len(sections) != len(remaps) {
-		return nil, fmt.Errorf("sortmerge: got %d sections but %d remaps", len(sections), len(remaps))
+	return iterator(ctx, sections, iteratorOptions{
+		less:     logs.CompareForSortSchema(globalSortKeys),
+		remaps:   remaps,
+		sortKeys: globalSortKeys,
+		schema:   expectedSchema,
+	})
+}
+
+// iteratorOptions are options for k-way merge implementation
+type iteratorOptions struct {
+	// required -
+	less     func(result.Result[dataset.Row], result.Result[dataset.Row]) bool
+	remaps   []map[int64]int64
+	sortKeys []string
+	schema   []string
+}
+
+func iterator(
+	ctx context.Context,
+	sections []*dataobj.Section,
+	opts iteratorOptions,
+) (result.Seq[logs.Record], error) {
+	if opts.remaps != nil && len(sections) != len(opts.remaps) {
+		return nil, fmt.Errorf("sort merge: got %d sections but %d remaps", len(sections), len(opts.remaps))
 	}
 
-	sequences := make([]*remapSectionSequence, 0, len(sections))
+	sequences := make([]*sectionSequence, 0, len(sections))
 	bufferSize := max(128, 8192/max(1, len(sections)))
 
 	for i, s := range sections {
@@ -56,121 +78,14 @@ func IteratorWithStreamRemap(ctx context.Context, sections []*dataobj.Section, r
 			return nil, fmt.Errorf("failed to open logs section: %w", err)
 		}
 
-		schema, err := sec.SchemaLabels()
-		if err != nil {
-			return nil, fmt.Errorf("reading section schema labels: %w", err)
-		}
-		if !slices.Equal(schema, expectedSchema) {
-			return nil, fmt.Errorf("section schema %v does not match expected sort schema %v", schema, expectedSchema)
-		}
-
-		ds, err := logs.MakeColumnarDataset(sec)
-		if err != nil {
-			return nil, fmt.Errorf("creating columnar dataset: %w", err)
-		}
-
-		columns, err := result.Collect(ds.ListColumns(ctx))
-		if err != nil {
-			return nil, err
-		}
-
-		r := dataset.NewRowReader(dataset.RowReaderOptions{
-			Dataset:  ds,
-			Columns:  columns,
-			Prefetch: true,
-		})
-		if err := r.Open(ctx); err != nil {
-			return nil, fmt.Errorf("opening dataset row reader: %w", err)
-		}
-
-		sequences = append(sequences, &remapSectionSequence{
-			section:         sec,
-			remap:           remaps[i],
-			DatasetSequence: logs.NewDatasetSequence(r, bufferSize),
-		})
-	}
-
-	maxValue := result.Value(dataset.Row{
-		Index: math.MaxInt,
-		Values: []dataset.Value{
-			dataset.Int64Value(math.MaxInt64), // StreamID
-			dataset.Int64Value(math.MinInt64), // Timestamp
-		},
-	})
-
-	tree := loser.New(sequences, maxValue, remapSectionSequenceAt, logs.CompareForSortSchema(globalSortKeys), remapSectionSequenceClose)
-	sym := symbolizer.New(1024, 100_000)
-
-	return result.Iter(
-		func(yield func(logs.Record) bool) error {
-			defer tree.Close()
-			for tree.Next() {
-				seq := tree.Winner()
-
-				row, err := remapSectionSequenceAt(seq).Value()
-				if err != nil {
-					return err
-				}
-
-				var record logs.Record
-				if err := logs.DecodeRow(seq.section.Columns(), row, &record, sym); err != nil {
-					return err
-				}
-				// StreamID was rewritten to the global ID in the row; annotate the
-				// sort key so downstream builders (SortSchemaASC) sort correctly.
-				if record.StreamID >= 0 && int(record.StreamID) < len(globalSortKeys) {
-					record.SortKey = globalSortKeys[record.StreamID]
-				}
-				if !yield(record) {
-					return nil
-				}
+		if opts.schema != nil {
+			schema, err := sec.SchemaLabels()
+			if err != nil {
+				return nil, fmt.Errorf("reading section schema labels: %w", err)
 			}
-			return nil
-		}), nil
-}
-
-// remapSectionSequence wraps a section cursor and rewrites its local stream IDs
-// into a global space as rows are produced.
-type remapSectionSequence struct {
-	logs.DatasetSequence
-	section *logs.Section
-	remap   map[int64]int64
-}
-
-var _ loser.Sequence = (*remapSectionSequence)(nil)
-
-func (s *remapSectionSequence) Next() bool {
-	if !s.DatasetSequence.Next() {
-		return false
-	}
-	res := s.DatasetSequence.At()
-	row, err := res.Value()
-	if err != nil {
-		return true // error is surfaced via At() to the consumer
-	}
-	if g, ok := s.remap[row.Values[0].Int64()]; ok {
-		row.Values[0] = dataset.Int64Value(g)
-	}
-	return true
-}
-
-func remapSectionSequenceAt(seq *remapSectionSequence) result.Result[dataset.Row] { return seq.At() }
-func remapSectionSequenceClose(seq *remapSectionSequence)                         { seq.Close() }
-
-func iterator(
-	ctx context.Context,
-	sections []*dataobj.Section,
-	less func(result.Result[dataset.Row], result.Result[dataset.Row]) bool,
-) (result.Seq[logs.Record], error) {
-	sequences := make([]*sectionSequence, 0, len(sections))
-
-	// The buffer size is a trade-off between memory overhead and performance: Share a sensible batch size amongst the sections.
-	bufferSize := max(128, 8192/max(1, len(sections)))
-
-	for _, s := range sections {
-		sec, err := logs.Open(ctx, s)
-		if err != nil {
-			return nil, fmt.Errorf("failed to open logs section: %w", err)
+			if !slices.Equal(schema, opts.schema) {
+				return nil, fmt.Errorf("section schema %v does not match expected sort schema %v", schema, opts.schema)
+			}
 		}
 
 		ds, err := logs.MakeColumnarDataset(sec)
@@ -192,10 +107,14 @@ func iterator(
 			return nil, fmt.Errorf("opening dataset row reader: %w", err)
 		}
 
-		sequences = append(sequences, &sectionSequence{
+		seq := &sectionSequence{
 			section:         sec,
 			DatasetSequence: logs.NewDatasetSequence(r, bufferSize),
-		})
+		}
+		if opts.remaps != nil {
+			seq.remap = opts.remaps[i]
+		}
+		sequences = append(sequences, seq)
 	}
 
 	maxValue := result.Value(dataset.Row{
@@ -206,7 +125,13 @@ func iterator(
 		},
 	})
 
-	tree := loser.New(sequences, maxValue, sectionSequenceAt, less, sectionSequenceClose)
+	tree := loser.New(sequences, maxValue, sectionSequenceAt, opts.less, sectionSequenceClose)
+
+	// Use interning on remap path, which reads multiple sections
+	var sym *symbolizer.Symbolizer
+	if opts.sortKeys != nil {
+		sym = symbolizer.New(1024, 100_000)
+	}
 
 	return result.Iter(
 		func(yield func(logs.Record) bool) error {
@@ -220,21 +145,46 @@ func iterator(
 				}
 
 				var record logs.Record
-				err = logs.DecodeRow(seq.section.Columns(), row, &record, nil)
-				if err != nil || !yield(record) {
+				if err := logs.DecodeRow(seq.section.Columns(), row, &record, sym); err != nil {
 					return err
+				}
+				// StreamID was rewritten to the global ID in the row; annotate the
+				// sort key so downstream builders (SortSchemaASC) sort correctly.
+				if opts.sortKeys != nil && record.StreamID >= 0 && int(record.StreamID) < len(opts.sortKeys) {
+					record.SortKey = opts.sortKeys[record.StreamID]
+				}
+				if !yield(record) {
+					return nil
 				}
 			}
 			return nil
 		}), nil
 }
 
+// sectionSequence wraps a section cursor. When remap is non-nil it rewrites the
+// section's local stream IDs into a global space as rows are produced.
 type sectionSequence struct {
 	logs.DatasetSequence
 	section *logs.Section
+	remap   map[int64]int64
 }
 
-var _ loser.Sequence = (*sectionSequence)(nil)
+func (s *sectionSequence) Next() bool {
+	if !s.DatasetSequence.Next() {
+		return false
+	}
+	if s.remap == nil {
+		return true
+	}
+	row, err := s.DatasetSequence.At().Value()
+	if err != nil {
+		return true // error is surfaced via At() to the consumer
+	}
+	if g, ok := s.remap[row.Values[0].Int64()]; ok {
+		row.Values[0] = dataset.Int64Value(g)
+	}
+	return true
+}
 
 func sectionSequenceAt(seq *sectionSequence) result.Result[dataset.Row] { return seq.At() }
 func sectionSequenceClose(seq *sectionSequence)                         { seq.Close() }

--- a/pkg/dataobj/sortmerge/sortmerge.go
+++ b/pkg/dataobj/sortmerge/sortmerge.go
@@ -12,10 +12,12 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/symbolizer"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/util/loser"
 )
@@ -35,6 +37,125 @@ func Iterator(ctx context.Context, sections []*dataobj.Section, sort logs.SortOr
 func IteratorForSchema(ctx context.Context, sections []*dataobj.Section, sortKeys []string) (result.Seq[logs.Record], error) {
 	return iterator(ctx, sections, logs.CompareForSortSchema(sortKeys))
 }
+
+// IteratorWithStreamRemap performs a k-way merge over logs sections drawn from
+// multiple source objects. Each section's stream IDs are rewritten into a single global space
+// via remaps[i] (the map for sections[i]) before records are compared, so one
+// merge can order records across objects.
+func IteratorWithStreamRemap(ctx context.Context, sections []*dataobj.Section, remaps []map[int64]int64, globalSortKeys []string, expectedSchema []string) (result.Seq[logs.Record], error) {
+	if len(sections) != len(remaps) {
+		return nil, fmt.Errorf("sortmerge: got %d sections but %d remaps", len(sections), len(remaps))
+	}
+
+	sequences := make([]*remapSectionSequence, 0, len(sections))
+	bufferSize := max(128, 8192/max(1, len(sections)))
+
+	for i, s := range sections {
+		sec, err := logs.Open(ctx, s)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open logs section: %w", err)
+		}
+
+		schema, err := sec.SchemaLabels()
+		if err != nil {
+			return nil, fmt.Errorf("reading section schema labels: %w", err)
+		}
+		if !slices.Equal(schema, expectedSchema) {
+			return nil, fmt.Errorf("section schema %v does not match expected sort schema %v", schema, expectedSchema)
+		}
+
+		ds, err := logs.MakeColumnarDataset(sec)
+		if err != nil {
+			return nil, fmt.Errorf("creating columnar dataset: %w", err)
+		}
+
+		columns, err := result.Collect(ds.ListColumns(ctx))
+		if err != nil {
+			return nil, err
+		}
+
+		r := dataset.NewRowReader(dataset.RowReaderOptions{
+			Dataset:  ds,
+			Columns:  columns,
+			Prefetch: true,
+		})
+		if err := r.Open(ctx); err != nil {
+			return nil, fmt.Errorf("opening dataset row reader: %w", err)
+		}
+
+		sequences = append(sequences, &remapSectionSequence{
+			section:         sec,
+			remap:           remaps[i],
+			DatasetSequence: logs.NewDatasetSequence(r, bufferSize),
+		})
+	}
+
+	maxValue := result.Value(dataset.Row{
+		Index: math.MaxInt,
+		Values: []dataset.Value{
+			dataset.Int64Value(math.MaxInt64), // StreamID
+			dataset.Int64Value(math.MinInt64), // Timestamp
+		},
+	})
+
+	tree := loser.New(sequences, maxValue, remapSectionSequenceAt, logs.CompareForSortSchema(globalSortKeys), remapSectionSequenceClose)
+	sym := symbolizer.New(1024, 100_000)
+
+	return result.Iter(
+		func(yield func(logs.Record) bool) error {
+			defer tree.Close()
+			for tree.Next() {
+				seq := tree.Winner()
+
+				row, err := remapSectionSequenceAt(seq).Value()
+				if err != nil {
+					return err
+				}
+
+				var record logs.Record
+				if err := logs.DecodeRow(seq.section.Columns(), row, &record, sym); err != nil {
+					return err
+				}
+				// StreamID was rewritten to the global ID in the row; annotate the
+				// sort key so downstream builders (SortSchemaASC) sort correctly.
+				if record.StreamID >= 0 && int(record.StreamID) < len(globalSortKeys) {
+					record.SortKey = globalSortKeys[record.StreamID]
+				}
+				if !yield(record) {
+					return nil
+				}
+			}
+			return nil
+		}), nil
+}
+
+// remapSectionSequence wraps a section cursor and rewrites its local stream IDs
+// into a global space as rows are produced.
+type remapSectionSequence struct {
+	logs.DatasetSequence
+	section *logs.Section
+	remap   map[int64]int64
+}
+
+var _ loser.Sequence = (*remapSectionSequence)(nil)
+
+func (s *remapSectionSequence) Next() bool {
+	if !s.DatasetSequence.Next() {
+		return false
+	}
+	res := s.DatasetSequence.At()
+	row, err := res.Value()
+	if err != nil {
+		return true // error is surfaced via At() to the consumer
+	}
+	if g, ok := s.remap[row.Values[0].Int64()]; ok {
+		row.Values[0] = dataset.Int64Value(g)
+	}
+	return true
+}
+
+func remapSectionSequenceAt(seq *remapSectionSequence) result.Result[dataset.Row] { return seq.At() }
+func remapSectionSequenceClose(seq *remapSectionSequence)                         { seq.Close() }
 
 func iterator(
 	ctx context.Context,

--- a/pkg/dataobj/sortmerge/sortmerge.go
+++ b/pkg/dataobj/sortmerge/sortmerge.go
@@ -169,6 +169,8 @@ type sectionSequence struct {
 	remap   map[int64]int64
 }
 
+var _ loser.Sequence = (*sectionSequence)(nil)
+
 func (s *sectionSequence) Next() bool {
 	if !s.DatasetSequence.Next() {
 		return false

--- a/pkg/dataobj/sortmerge/sortmerge_test.go
+++ b/pkg/dataobj/sortmerge/sortmerge_test.go
@@ -1,7 +1,9 @@
 package sortmerge_test
 
 import (
+	"cmp"
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -13,6 +15,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 	"github.com/grafana/loki/v3/pkg/dataobj/sortmerge"
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
@@ -136,4 +139,169 @@ func TestIterator_NoSections(t *testing.T) {
 		_, err := res.Value()
 		t.Fatalf("expected no records from zero-section iterator; got record err=%v", err)
 	}
+}
+
+type schemaOverrides []string
+
+func (s schemaOverrides) SortSchemaLabels(_ string) []string { return s }
+
+// buildSchemaObject builds a schema-sorted (SortSchemaASC) in-memory object for
+// the given per-label entries. Labels may be appended out of sort-key order to
+// exercise stream-ID remapping.
+func buildSchemaObject(t *testing.T, sortSchema []string, byLabel map[string][]push.Entry) (*dataobj.Object, func()) {
+	t.Helper()
+
+	cfg := testBuilderConfig
+	cfg.DataobjSortOrder = "timestamp-desc"
+	cfg.AppendOrderedEnabled = true
+	cfg.DataobjUseSortSchema = true
+
+	b, err := logsobj.NewBuilder(cfg, nil, logsobj.NewBuilderMetrics(), log.NewNopLogger(), schemaOverrides(sortSchema))
+	require.NoError(t, err)
+
+	for lbls, entries := range byLabel {
+		require.NoError(t, b.Append(testTenant, logproto.Stream{Labels: lbls, Entries: entries}, entries[0].Timestamp))
+	}
+
+	obj, closer, err := b.Flush()
+	require.NoError(t, err)
+	return obj, func() { _ = closer.Close() }
+}
+
+// planGlobalStreams reads the streams sections of the given objects and assigns
+// disjoint global stream IDs in (sortKey, sourceIdx, sourceStreamID) order, returning
+// the flattened logs sections plus the per-section remap and globalSortKeys the
+// merge needs. This mirrors what the compactor executor does.
+func planGlobalStreams(ctx context.Context, t *testing.T, objs []*dataobj.Object, sortSchema []string) ([]*dataobj.Section, []map[int64]int64, []string) {
+	t.Helper()
+
+	type entry struct {
+		sourceIdx      int
+		sourceStreamID int64
+		sortKey        string
+	}
+	var all []entry
+	perObjLogs := make([][]*dataobj.Section, len(objs))
+
+	for sourceIdx, obj := range objs {
+		for _, sec := range obj.Sections().Filter(func(s *dataobj.Section) bool {
+			return streams.CheckSection(s) && s.Tenant == testTenant
+		}) {
+			ss, err := streams.Open(ctx, sec)
+			require.NoError(t, err)
+			for res := range streams.IterSection(ctx, ss) {
+				stream, err := res.Value()
+				require.NoError(t, err)
+				key, err := logsobj.ComputeSortKey(stream.Labels, sortSchema)
+				require.NoError(t, err)
+				all = append(all, entry{sourceIdx: sourceIdx, sourceStreamID: stream.ID, sortKey: key})
+			}
+		}
+		for _, sec := range obj.Sections().Filter(func(s *dataobj.Section) bool {
+			return logs.CheckSection(s) && s.Tenant == testTenant
+		}) {
+			perObjLogs[sourceIdx] = append(perObjLogs[sourceIdx], sec)
+		}
+	}
+
+	slices.SortFunc(all, func(a, b entry) int {
+		if r := cmp.Compare(a.sortKey, b.sortKey); r != 0 {
+			return r
+		}
+		if r := cmp.Compare(a.sourceIdx, b.sourceIdx); r != 0 {
+			return r
+		}
+		return cmp.Compare(a.sourceStreamID, b.sourceStreamID)
+	})
+
+	remapsByObj := make([]map[int64]int64, len(objs))
+	for i := range remapsByObj {
+		remapsByObj[i] = map[int64]int64{}
+	}
+	globalSortKeys := make([]string, len(all)+1)
+	for i, e := range all {
+		gid := int64(i + 1)
+		globalSortKeys[gid] = e.sortKey
+		remapsByObj[e.sourceIdx][e.sourceStreamID] = gid
+	}
+
+	var sections []*dataobj.Section
+	var remaps []map[int64]int64
+	for sourceIdx := range objs {
+		for _, sec := range perObjLogs[sourceIdx] {
+			sections = append(sections, sec)
+			remaps = append(remaps, remapsByObj[sourceIdx])
+		}
+	}
+	return sections, remaps, globalSortKeys
+}
+
+// TestIteratorWithStreamRemap_MergesAcrossObjects merges two schema-sorted
+// objects with independent stream-ID spaces and overlapping labels, and verifies
+// the output carries global stream IDs and is globally ordered by
+// [sortKey ASC, globalStreamID ASC, timestamp DESC].
+func TestIteratorWithStreamRemap_MergesAcrossObjects(t *testing.T) {
+	ctx := context.Background()
+	sortSchema := []string{"label:app"}
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	ent := func(base time.Time, n int) []push.Entry {
+		out := make([]push.Entry, 0, n)
+		for i := range n {
+			out = append(out, push.Entry{Timestamp: base.Add(time.Duration(i) * time.Second).UTC(), Line: "x"})
+		}
+		return out
+	}
+
+	// Append labels out of sort order (b before a) so remapping must reorder.
+	objA, closeA := buildSchemaObject(t, sortSchema, map[string][]push.Entry{
+		`{app="b"}`: ent(t0, 2),
+		`{app="a"}`: ent(t0, 2),
+	})
+	defer closeA()
+	objB, closeB := buildSchemaObject(t, sortSchema, map[string][]push.Entry{
+		`{app="a"}`: ent(t0.Add(time.Hour), 2),
+		`{app="c"}`: ent(t0.Add(time.Hour), 2),
+	})
+	defer closeB()
+
+	sections, remaps, globalSortKeys := planGlobalStreams(ctx, t, []*dataobj.Object{objA, objB}, sortSchema)
+
+	iter, err := sortmerge.IteratorWithStreamRemap(ctx, sections, remaps, globalSortKeys, sortSchema)
+	require.NoError(t, err)
+
+	var (
+		count int
+		prev  logs.Record
+		first = true
+	)
+	for res := range iter {
+		rec, err := res.Value()
+		require.NoError(t, err)
+
+		// StreamID must be a valid global ID, and SortKey must be annotated from it.
+		require.Greater(t, rec.StreamID, int64(0))
+		require.Less(t, int(rec.StreamID), len(globalSortKeys))
+		require.Equal(t, globalSortKeys[rec.StreamID], rec.SortKey)
+
+		if !first {
+			require.LessOrEqual(t, recOrder(prev, rec), 0,
+				"output must be globally sorted by [sortKey, globalStreamID, ts DESC]")
+		}
+		prev, first = rec, false
+		count++
+	}
+	// objA (2 streams x 2) + objB (2 streams x 2) = 8 records; no dedup.
+	require.Equal(t, 8, count)
+}
+
+// recOrder compares records by [sortKey ASC, streamID ASC, timestamp DESC].
+func recOrder(a, b logs.Record) int {
+	if r := cmp.Compare(a.SortKey, b.SortKey); r != 0 {
+		return r
+	}
+	if r := cmp.Compare(a.StreamID, b.StreamID); r != 0 {
+		return r
+	}
+	return cmp.Compare(b.Timestamp.UnixNano(), a.Timestamp.UnixNano())
 }

--- a/pkg/engine/internal/executor/log_merge.go
+++ b/pkg/engine/internal/executor/log_merge.go
@@ -1,13 +1,22 @@
 package executor
 
 import (
-	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
+	"time"
 
 	"github.com/go-kit/log/level"
+	"github.com/prometheus/prometheus/model/labels"
 
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
+	"github.com/grafana/loki/v3/pkg/dataobj/sortmerge"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 )
 
@@ -21,6 +30,7 @@ func (c *Context) executeLogMerge(node *physical.LogMerge) Pipeline {
 }
 
 func (c *Context) doLogObjectMerge(ctx context.Context, node *physical.LogMerge) error {
+	start := time.Now()
 	if c.bucket == nil {
 		return errors.New("no object store bucket configured")
 	}
@@ -34,9 +44,436 @@ func (c *Context) doLogObjectMerge(ctx context.Context, node *physical.LogMerge)
 		return nil
 	}
 
-	if err := c.bucket.Upload(ctx, node.OutputIndexPath, bytes.NewReader(nil)); err != nil {
-		return fmt.Errorf("uploading merged index: %w", err)
+	sources, err := c.collectLogSources(ctx, node)
+	if err != nil {
+		return err
+	}
+	if len(sources) == 0 {
+		level.Info(c.logger).Log("msg", "LogMerge: no source log sections, nothing to compact", "tenant", node.Tenant)
+		return nil
 	}
 
+	table, err := buildGlobalStreamTable(sources, node.SortSchema)
+	if err != nil {
+		return err
+	}
+
+	sections, remaps := sectionsWithRemaps(sources, table)
+	merged, err := sortmerge.IteratorWithStreamRemap(ctx, sections, remaps, table.sortKeys, node.SortSchema)
+	if err != nil {
+		return fmt.Errorf("starting k-way log merge: %w", err)
+	}
+
+	// Consume the globally-sorted stream and build compacted object(s). Ranging
+	// here (rather than passing the iterator to a helper) avoids naming the
+	// dataobj-internal result.Seq type, which this package cannot import.
+	w := c.newLogObjectWriter(node, table)
+	for res := range merged {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		rec, err := res.Value()
+		if err != nil {
+			return err
+		}
+		if err := w.add(ctx, rec); err != nil {
+			return err
+		}
+	}
+	stats, err := w.finish(ctx)
+	if err != nil {
+		return err
+	}
+	if stats.OutputObjects == 0 {
+		level.Info(c.logger).Log("msg", "LogMerge: no records to compact", "tenant", node.Tenant)
+		return nil
+	}
+
+	stats.SourceObjects = len(sources)
+	for _, s := range sources {
+		stats.InputSections += len(s.logsSections)
+	}
+
+	// The compacted object(s) are logged for reference; the downstream index build
+	// and ToC swap land in a follow-up.
+	level.Info(c.logger).Log(
+		"msg", "LogMerge: built compacted log object(s)",
+		"tenant", node.Tenant,
+		"source_objects", stats.SourceObjects,
+		"input_sections", stats.InputSections,
+		"output_objects", stats.OutputObjects,
+		"output_streams", stats.OutputStreams,
+		"output_records", stats.OutputRecords,
+		"output_bytes", stats.OutputBytesCompressed,
+		"output_bytes_uncompressed", stats.OutputBytesUncompressed,
+		"sort_schema", strings.Join(node.SortSchema, ","),
+		"duration", time.Since(start),
+	)
 	return nil
+}
+
+// logMergeStats summarizes a completed LogMerge for the reference log line.
+type logMergeStats struct {
+	SourceObjects           int
+	InputSections           int
+	OutputObjects           int
+	OutputStreams           int
+	OutputRecords           int
+	OutputBytesCompressed   int64
+	OutputBytesUncompressed int64
+}
+
+// logMergeOutputPath derives the deterministic object-storage key for the i-th
+// compacted log object from the node's OutputIndexPath. It stays in the same
+// bucket
+func logMergeOutputPath(outputIndexPath string, i int) string {
+	return fmt.Sprintf("%s.compacted-log.%d", outputIndexPath, i)
+}
+
+type logSource struct {
+	path         string
+	logsSections []*dataobj.Section
+	streams      map[int64]streams.Stream
+}
+
+// collectLogSources opens every unique source object referenced by node.Runs and
+// returns the tenant's logs sections plus its localStreamID->stream map. Objects are deduplicated by path
+func (c *Context) collectLogSources(ctx context.Context, node *physical.LogMerge) ([]*logSource, error) {
+	// Deduplicate object paths across all runs
+	seen := make(map[string]struct{})
+	var paths []string
+	for _, run := range node.Runs {
+		if run == nil {
+			continue
+		}
+		for _, sec := range run.Sections {
+			if sec == nil {
+				continue
+			}
+			if _, ok := seen[sec.ObjectPath]; ok {
+				continue
+			}
+			seen[sec.ObjectPath] = struct{}{}
+			paths = append(paths, sec.ObjectPath)
+		}
+	}
+	// Gather log and streams sections
+	sources := make([]*logSource, 0, len(paths))
+	for _, path := range paths {
+		obj, err := dataobj.FromBucket(ctx, c.bucket, path, 0)
+		if err != nil {
+			return nil, fmt.Errorf("opening object %q: %w", path, err)
+		}
+
+		var (
+			logsSections   []*dataobj.Section
+			streamSections []*dataobj.Section
+		)
+		for _, sec := range obj.Sections() {
+			if sec.Tenant != node.Tenant {
+				continue
+			}
+			switch {
+			case logs.CheckSection(sec):
+				logsSections = append(logsSections, sec)
+			case streams.CheckSection(sec):
+				streamSections = append(streamSections, sec)
+			}
+		}
+
+		if len(logsSections) == 0 {
+			continue
+		}
+
+		if len(streamSections) == 0 {
+			return nil, fmt.Errorf("object %q has logs sections but no streams section for tenant %q", path, node.Tenant)
+		}
+		if len(streamSections) > 1 {
+			return nil, fmt.Errorf("object %q has %d streams sections for tenant %q, expected exactly one", path, len(streamSections), node.Tenant)
+		}
+
+		srcStreams, err := resolveStreams(ctx, streamSections[0])
+		if err != nil {
+			return nil, fmt.Errorf("resolving streams for object %q: %w", path, err)
+		}
+
+		sources = append(sources, &logSource{
+			path:         path,
+			logsSections: logsSections,
+			streams:      srcStreams,
+		})
+	}
+
+	return sources, nil
+}
+
+// resolveStreams decodes a streams section into a map from local stream ID to its
+// stream (labels + aggregates). Labels are deep-copied so they remain valid after
+// the underlying reader buffers are reused.
+func resolveStreams(ctx context.Context, section *dataobj.Section) (map[int64]streams.Stream, error) {
+	sec, err := streams.Open(ctx, section)
+	if err != nil {
+		return nil, fmt.Errorf("opening streams section: %w", err)
+	}
+
+	out := make(map[int64]streams.Stream)
+	for res := range streams.IterSection(ctx, sec) {
+		stream, err := res.Value()
+		if err != nil {
+			return nil, err
+		}
+		stream.Labels = stream.Labels.Copy()
+		out[stream.ID] = stream
+	}
+	return out, nil
+}
+
+// globalStreamTable holds the disjoint global stream assignment for a merge
+type globalStreamTable struct {
+	sortKeys       []string          // index = global ID (1..N); [0] unused
+	streams        []streams.Stream  // index = global ID; source stream with aggregates
+	streamIDRemaps []map[int64]int64 // per source object (by index): sourceStreamID -> globalID
+}
+
+// buildGlobalStreamTable computes the global stream assignment from all sources.
+func buildGlobalStreamTable(sources []*logSource, sortSchema []string) (*globalStreamTable, error) {
+	type entry struct {
+		sourceIdx      int
+		sourceStreamID int64
+		sortKey        string
+		stream         streams.Stream
+	}
+
+	var allEntries []entry
+	for sourceIdx, src := range sources {
+		for sourceStreamID, s := range src.streams {
+			key, err := logsobj.ComputeSortKey(s.Labels, sortSchema)
+			if err != nil {
+				return nil, fmt.Errorf("computing sort key for object %q: %w", src.path, err)
+			}
+			allEntries = append(allEntries, entry{
+				sourceIdx:      sourceIdx,
+				sourceStreamID: sourceStreamID,
+				sortKey:        key,
+				stream:         s,
+			})
+		}
+	}
+
+	// Order by (sortKey, sourceIdx, sourceStreamID) so global IDs are sort-key-major
+	// and each source section stays monotonic under the merge comparator.
+	slices.SortFunc(allEntries, func(a, b entry) int {
+		if r := cmp.Compare(a.sortKey, b.sortKey); r != 0 {
+			return r
+		}
+		if r := cmp.Compare(a.sourceIdx, b.sourceIdx); r != 0 {
+			return r
+		}
+		return cmp.Compare(a.sourceStreamID, b.sourceStreamID)
+	})
+
+	table := &globalStreamTable{
+		sortKeys:       make([]string, len(allEntries)+1),
+		streams:        make([]streams.Stream, len(allEntries)+1),
+		streamIDRemaps: make([]map[int64]int64, len(sources)),
+	}
+	for i := range table.streamIDRemaps {
+		table.streamIDRemaps[i] = make(map[int64]int64)
+	}
+	for i, e := range allEntries {
+		gid := int64(i + 1)
+		table.sortKeys[gid] = e.sortKey
+		s := e.stream
+		s.ID = gid
+		table.streams[gid] = s
+		table.streamIDRemaps[e.sourceIdx][e.sourceStreamID] = gid
+	}
+	return table, nil
+}
+
+// sectionsWithRemaps flattens the sources' logs sections and, in lockstep, the
+// per-section local->global stream-ID remap the merge consumes.
+func sectionsWithRemaps(sources []*logSource, table *globalStreamTable) ([]*dataobj.Section, []map[int64]int64) {
+	var (
+		sections []*dataobj.Section
+		remaps   []map[int64]int64
+	)
+	for sourceIdx, src := range sources {
+		for _, sec := range src.logsSections {
+			sections = append(sections, sec)
+			remaps = append(remaps, table.streamIDRemaps[sourceIdx])
+		}
+	}
+	return sections, remaps
+}
+
+// logObjectWriter consumes the globally-sorted merged record stream and builds
+// one or more compacted log objects, split at TargetObjectSize (never splitting a
+// stream across objects)
+type logObjectWriter struct {
+	c     *Context
+	node  *physical.LogMerge
+	table *globalStreamTable
+
+	logsMetrics    *logs.Metrics
+	streamsMetrics *streams.Metrics
+	targetObject   int
+	targetSection  int
+
+	builder       *dataobj.Builder
+	lb            *logs.Builder
+	sb            *streams.Builder
+	objSize       int
+	objStreams    int
+	objRecords    int
+	curGlobalID   int64
+	curObjLocalID int64
+
+	stats logMergeStats
+}
+
+func (c *Context) newLogObjectWriter(node *physical.LogMerge, table *globalStreamTable) *logObjectWriter {
+	w := &logObjectWriter{
+		c:              c,
+		node:           node,
+		table:          table,
+		logsMetrics:    logs.NewMetrics(),
+		streamsMetrics: streams.NewMetrics(),
+		targetObject:   int(c.indexobjCfg.TargetObjectSize),
+		targetSection:  int(c.indexobjCfg.TargetSectionSize),
+	}
+	w.startObject()
+	return w
+}
+
+func (w *logObjectWriter) startObject() {
+	w.builder = dataobj.NewBuilder(w.c.scratchStore)
+	w.lb = logs.NewBuilder(w.logsMetrics, w.c.logsBuilderOptions(w.node.SortSchema))
+	w.lb.SetTenant(w.node.Tenant)
+	w.sb = streams.NewBuilder(w.streamsMetrics, int(w.c.indexobjCfg.TargetPageSize), w.c.indexobjCfg.MaxPageRows)
+	w.sb.SetTenant(w.node.Tenant)
+	w.objSize, w.objStreams, w.objRecords = 0, 0, 0
+	w.curGlobalID, w.curObjLocalID = 0, 0
+}
+
+// add appends one merged record (carrying a global stream ID), rolling to a new
+// output object at stream boundaries once the current object reaches its target
+// size, and re-basing stream IDs to 1..M within each object.
+func (w *logObjectWriter) add(ctx context.Context, rec logs.Record) error {
+	if rec.StreamID != w.curGlobalID {
+
+		if w.objRecords > 0 && w.targetObject > 0 && w.objSize >= w.targetObject {
+			if err := w.finalizeAndUpload(ctx); err != nil {
+				return err
+			}
+			w.startObject()
+		}
+		w.curGlobalID = rec.StreamID
+		w.curObjLocalID++
+		s := w.table.streams[rec.StreamID]
+		s.ID = w.curObjLocalID
+		w.sb.AppendValue(s)
+		w.objStreams++
+	}
+
+	rec.StreamID = w.curObjLocalID
+	w.lb.Append(rec)
+	w.objRecords++
+	w.objSize += logRecordSize(rec)
+
+	if w.lb.UncompressedSize() > w.targetSection {
+		if err := w.builder.Append(w.lb); err != nil {
+			return fmt.Errorf("appending logs section: %w", err)
+		}
+		w.lb.Reset()
+		w.lb.SetTenant(w.node.Tenant)
+	}
+	return nil
+}
+
+// finish flushes and uploads the last in-progress object (if any) and returns the
+// accumulated stats.
+func (w *logObjectWriter) finish(ctx context.Context) (logMergeStats, error) {
+	if w.objRecords > 0 {
+		if err := w.finalizeAndUpload(ctx); err != nil {
+			return w.stats, err
+		}
+	}
+	return w.stats, nil
+}
+
+func (w *logObjectWriter) finalizeAndUpload(ctx context.Context) error {
+	if w.lb.UncompressedSize() > 0 {
+		if err := w.builder.Append(w.lb); err != nil {
+			return fmt.Errorf("appending logs section: %w", err)
+		}
+	}
+	if err := w.builder.Append(w.sb); err != nil {
+		return fmt.Errorf("appending streams section: %w", err)
+	}
+
+	obj, closer, err := w.builder.Flush()
+	if err != nil {
+		return fmt.Errorf("flushing object: %w", err)
+	}
+	path := logMergeOutputPath(w.node.OutputIndexPath, w.stats.OutputObjects)
+	size, upErr := w.c.uploadLogObject(ctx, path, obj)
+	_ = closer.Close()
+	if upErr != nil {
+		return fmt.Errorf("uploading %q: %w", path, upErr)
+	}
+
+	level.Info(w.c.logger).Log(
+		"msg", "LogMerge: uploaded compacted log object",
+		"tenant", w.node.Tenant,
+		"path", path,
+		"object_index", w.stats.OutputObjects,
+		"streams", w.objStreams,
+		"records", w.objRecords,
+		"bytes", size,
+	)
+	w.stats.OutputObjects++
+	w.stats.OutputStreams += w.objStreams
+	w.stats.OutputRecords += w.objRecords
+	w.stats.OutputBytesCompressed += size
+	w.stats.OutputBytesUncompressed += int64(w.objSize)
+	return nil
+}
+
+// logsBuilderOptions builds the logs section options for a schema-sorted output,
+// sized from the executor's shared builder config.
+func (c *Context) logsBuilderOptions(sortSchema []string) logs.BuilderOptions {
+	return logs.BuilderOptions{
+		PageSizeHint:     int(c.indexobjCfg.TargetPageSize),
+		PageMaxRowCount:  c.indexobjCfg.MaxPageRows,
+		BufferSize:       int(c.indexobjCfg.BufferSize),
+		StripeMergeLimit: c.indexobjCfg.SectionStripeMergeLimit,
+		AppendStrategy:   logs.AppendOrdered,
+		SortOrder:        logs.SortSchemaASC,
+		SchemaLabels:     sortSchema,
+	}
+}
+
+// logRecordSize approximates a record's uncompressed footprint the same way the
+// ingest builder does: line length plus structured-metadata value lengths.
+func logRecordSize(rec logs.Record) int {
+	size := len(rec.Line)
+	rec.Metadata.Range(func(l labels.Label) {
+		size += len(l.Value)
+	})
+	return size
+}
+
+// uploadLogObject streams a built object to the bucket and returns its encoded size.
+func (c *Context) uploadLogObject(ctx context.Context, path string, obj *dataobj.Object) (int64, error) {
+	reader, err := obj.Reader(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("getting object reader: %w", err)
+	}
+	defer reader.Close()
+
+	if err := c.bucket.Upload(ctx, path, reader); err != nil {
+		return 0, err
+	}
+	return obj.Size(), nil
 }

--- a/pkg/engine/internal/executor/log_merge.go
+++ b/pkg/engine/internal/executor/log_merge.go
@@ -64,9 +64,7 @@ func (c *Context) doLogObjectMerge(ctx context.Context, node *physical.LogMerge)
 		return fmt.Errorf("starting k-way log merge: %w", err)
 	}
 
-	// Consume the globally-sorted stream and build compacted object(s). Ranging
-	// here (rather than passing the iterator to a helper) avoids naming the
-	// dataobj-internal result.Seq type, which this package cannot import.
+	// Consume the globally-sorted stream and build compacted object
 	w := c.newLogObjectWriter(node, table)
 	for res := range merged {
 		if err := ctx.Err(); err != nil {
@@ -291,8 +289,7 @@ func buildGlobalStreamTable(sources []*logSource, sortSchema []string) (*globalS
 	return table, nil
 }
 
-// sectionsWithRemaps flattens the sources' logs sections and, in lockstep, the
-// per-section local->global stream-ID remap the merge consumes.
+// sectionsWithRemaps flattens the sources' logs sections
 func sectionsWithRemaps(sources []*logSource, table *globalStreamTable) ([]*dataobj.Section, []map[int64]int64) {
 	var (
 		sections []*dataobj.Section

--- a/pkg/engine/internal/executor/log_merge.go
+++ b/pkg/engine/internal/executor/log_merge.go
@@ -399,6 +399,8 @@ func (w *logObjectWriter) finish(ctx context.Context) (logMergeStats, error) {
 	return w.stats, nil
 }
 
+// finalizeAndUpload appends the pending sections, flushes them into one compacted
+// log object, and uploads it to a deterministic key.
 func (w *logObjectWriter) finalizeAndUpload(ctx context.Context) error {
 	if w.lb.UncompressedSize() > 0 {
 		if err := w.builder.Append(w.lb); err != nil {
@@ -413,11 +415,12 @@ func (w *logObjectWriter) finalizeAndUpload(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("flushing object: %w", err)
 	}
+	defer closer.Close()
+
 	path := logMergeOutputPath(w.node.OutputIndexPath, w.stats.OutputObjects)
-	size, upErr := w.c.uploadLogObject(ctx, path, obj)
-	_ = closer.Close()
-	if upErr != nil {
-		return fmt.Errorf("uploading %q: %w", path, upErr)
+	size, err := w.c.uploadLogObject(ctx, path, obj)
+	if err != nil {
+		return fmt.Errorf("uploading %q: %w", path, err)
 	}
 
 	level.Info(w.c.logger).Log(

--- a/pkg/engine/internal/executor/log_merge_test.go
+++ b/pkg/engine/internal/executor/log_merge_test.go
@@ -1,0 +1,408 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+
+	"github.com/grafana/loki/pkg/push"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	compactionv2pb "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2/proto"
+	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/scratch"
+)
+
+// sortSchemaOverrides is a logsobj.TenantOverrides stub returning a fixed sort
+// schema (ordered FQN sort keys) for every tenant.
+type sortSchemaOverrides []string
+
+func (s sortSchemaOverrides) SortSchemaLabels(_ string) []string { return s }
+
+// testStream is a labeled set of entries appended to a source log object.
+type testStream struct {
+	labels  string
+	entries []push.Entry
+}
+
+// linesAt builds count entries for a stream, one second apart starting at base.
+func linesAt(base time.Time, count int) []push.Entry {
+	entries := make([]push.Entry, 0, count)
+	for i := range count {
+		entries = append(entries, push.Entry{
+			Timestamp: base.Add(time.Duration(i) * time.Second).UTC(),
+			Line:      "line",
+		})
+	}
+	return entries
+}
+
+// wideLinesAt builds count entries with ~100-byte lines so a handful of records
+// exceed a small TargetObjectSize and force the merge to split its output.
+func wideLinesAt(base time.Time, count int) []push.Entry {
+	entries := make([]push.Entry, 0, count)
+	for i := range count {
+		entries = append(entries, push.Entry{
+			Timestamp: base.Add(time.Duration(i) * time.Second).UTC(),
+			Line:      strings.Repeat("x", 100),
+		})
+	}
+	return entries
+}
+
+// buildSourceLogObject builds a schema-sorted log data object from the given
+// per-tenant streams and uploads it to the bucket. When sortSchema is non-empty
+// the object is written in SortSchemaASC order for that schema.
+func buildSourceLogObject(t *testing.T, bucket objstore.Bucket, path string, sortSchema []string, byTenant map[string][]testStream) {
+	t.Helper()
+
+	cfg := logsobj.BuilderConfig{
+		BuilderBaseConfig: logsobj.BuilderBaseConfig{
+			TargetPageSize:            2048,
+			MaxPageRows:               10000,
+			TargetObjectSize:          1 << 22, // 4 MiB
+			TargetSectionSize:         1 << 21, // 2 MiB
+			BufferSize:                2048 * 8,
+			SectionStripeMergeLimit:   2,
+			EstimatedCompressionRatio: 8,
+		},
+		DataobjSortOrder:     "timestamp-desc",
+		AppendOrderedEnabled: true,
+		DataobjUseSortSchema: len(sortSchema) > 0,
+	}
+
+	b, err := logsobj.NewBuilder(cfg, scratch.NewMemory(), logsobj.NewBuilderMetrics(), log.NewNopLogger(), sortSchemaOverrides(sortSchema))
+	require.NoError(t, err)
+
+	for tenant, streams := range byTenant {
+		for _, s := range streams {
+			require.NotEmpty(t, s.entries, "test stream must have at least one entry")
+			require.NoError(t, b.Append(tenant, logproto.Stream{
+				Labels:  s.labels,
+				Entries: s.entries,
+			}, s.entries[0].Timestamp))
+		}
+	}
+
+	obj, closer, err := b.Flush()
+	require.NoError(t, err)
+	defer closer.Close()
+
+	require.NoError(t, uploadObjectToBucket(context.Background(), bucket, path, obj))
+}
+
+func TestCollectLogSources_DedupsAndResolvesLabels(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+
+	const tenant = "T"
+	sortSchema := []string{"label:app"}
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	buildSourceLogObject(t, bucket, "objA", sortSchema, map[string][]testStream{
+		tenant: {
+			{labels: `{app="a"}`, entries: linesAt(base, 3)},
+			{labels: `{app="b"}`, entries: linesAt(base, 2)},
+		},
+	})
+	buildSourceLogObject(t, bucket, "objB", sortSchema, map[string][]testStream{
+		tenant: {
+			{labels: `{app="b"}`, entries: linesAt(base.Add(time.Hour), 2)},
+			{labels: `{app="c"}`, entries: linesAt(base.Add(time.Hour), 4)},
+		},
+	})
+
+	c := newTestExecutorContext(t, bucket)
+	node := &physical.LogMerge{
+		Tenant:     tenant,
+		SortSchema: sortSchema,
+		Runs: []*compactionv2pb.RunRef{
+			// objA is referenced twice (and by two runs) to exercise dedup.
+			{Sections: []*compactionv2pb.SectionRef{{ObjectPath: "objA"}, {ObjectPath: "objA"}}},
+			{Sections: []*compactionv2pb.SectionRef{{ObjectPath: "objB"}, {ObjectPath: "objA"}}},
+		},
+	}
+
+	sources, err := c.collectLogSources(ctx, node)
+	require.NoError(t, err)
+	require.Len(t, sources, 2, "duplicate object paths must be collapsed to one source each")
+
+	byPath := make(map[string]*logSource, len(sources))
+	for _, s := range sources {
+		byPath[s.path] = s
+		require.NotEmpty(t, s.logsSections, "source %q must have at least one logs section", s.path)
+	}
+
+	require.Contains(t, byPath, "objA")
+	require.Contains(t, byPath, "objB")
+
+	appValues := func(s *logSource) map[string]bool {
+		got := make(map[string]bool)
+		for _, st := range s.streams {
+			got[st.Labels.Get("app")] = true
+		}
+		return got
+	}
+	require.Equal(t, map[string]bool{"a": true, "b": true}, appValues(byPath["objA"]))
+	require.Equal(t, map[string]bool{"b": true, "c": true}, appValues(byPath["objB"]))
+}
+
+func TestCollectLogSources_ExcludesOtherTenants(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+
+	const tenant = "T"
+	sortSchema := []string{"label:app"}
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// One multi-tenant object: only tenant T's sections should be collected.
+	buildSourceLogObject(t, bucket, "objMulti", sortSchema, map[string][]testStream{
+		tenant:  {{labels: `{app="a"}`, entries: linesAt(base, 3)}},
+		"other": {{labels: `{app="z"}`, entries: linesAt(base, 3)}},
+	})
+
+	c := newTestExecutorContext(t, bucket)
+	node := &physical.LogMerge{
+		Tenant:     tenant,
+		SortSchema: sortSchema,
+		Runs: []*compactionv2pb.RunRef{
+			{Sections: []*compactionv2pb.SectionRef{{ObjectPath: "objMulti"}}},
+		},
+	}
+
+	sources, err := c.collectLogSources(ctx, node)
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	apps := make(map[string]bool)
+	for _, st := range sources[0].streams {
+		apps[st.Labels.Get("app")] = true
+	}
+	require.Equal(t, map[string]bool{"a": true}, apps, "other tenants' streams must be excluded")
+}
+
+// newSmallObjectExecutorContext is like newTestExecutorContext but with a tiny
+// TargetObjectSize so the merge splits its output across multiple objects.
+func newSmallObjectExecutorContext(t *testing.T, bucket objstore.Bucket) *Context {
+	t.Helper()
+	c := newTestExecutorContext(t, bucket)
+	c.indexobjCfg.TargetObjectSize = 1000 // bytes; forces splitting
+	c.indexobjCfg.TargetSectionSize = 4096
+	return c
+}
+
+// outputRecord is one decoded record read back from a compacted output object.
+type outputRecord struct {
+	app      string
+	streamID int64
+	ts       time.Time
+}
+
+// readCompactedObjects loads every compacted log object the merge wrote for node
+// (paths logMergeOutputPath(node.OutputIndexPath, 0..)), stopping at the first
+// missing index. For each object it returns the streamID->app map and the
+// records in stored (schema-sorted) order.
+func readCompactedObjects(ctx context.Context, t *testing.T, bucket objstore.Bucket, node *physical.LogMerge) []struct {
+	streamApp map[int64]string
+	records   []outputRecord
+} {
+	t.Helper()
+
+	var out []struct {
+		streamApp map[int64]string
+		records   []outputRecord
+	}
+	for i := 0; ; i++ {
+		path := logMergeOutputPath(node.OutputIndexPath, i)
+		ok, err := bucket.Exists(ctx, path)
+		require.NoError(t, err)
+		if !ok {
+			break
+		}
+
+		obj, err := dataobj.FromBucket(ctx, bucket, path, 0)
+		require.NoError(t, err)
+
+		streamApp := make(map[int64]string)
+		for _, sec := range obj.Sections().Filter(streams.CheckSection) {
+			if sec.Tenant != node.Tenant {
+				continue
+			}
+			ss, err := streams.Open(ctx, sec)
+			require.NoError(t, err)
+			for res := range streams.IterSection(ctx, ss) {
+				s, err := res.Value()
+				require.NoError(t, err)
+				streamApp[s.ID] = s.Labels.Get("app")
+			}
+		}
+
+		var records []outputRecord
+		for _, sec := range obj.Sections().Filter(logs.CheckSection) {
+			if sec.Tenant != node.Tenant {
+				continue
+			}
+			ls, err := logs.Open(ctx, sec)
+			require.NoError(t, err)
+			for res := range logs.IterSection(ctx, ls) {
+				rec, err := res.Value()
+				require.NoError(t, err)
+				records = append(records, outputRecord{
+					app:      streamApp[rec.StreamID],
+					streamID: rec.StreamID,
+					ts:       rec.Timestamp,
+				})
+			}
+		}
+
+		out = append(out, struct {
+			streamApp map[int64]string
+			records   []outputRecord
+		}{streamApp: streamApp, records: records})
+	}
+	return out
+}
+
+func TestDoLogObjectMerge_MergesAndSplits(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+
+	const tenant = "T"
+	sortSchema := []string{"label:app"}
+	ta := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	tc := time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC)
+
+	// Overlapping label sets across objects (a,b,c / b,c,d / c,d,e). With the
+	// k-way merge (no cross-object stream dedup) every source stream becomes its
+	// own output stream: 9 source streams -> 9 output streams.
+	buildSourceLogObject(t, bucket, "objA", sortSchema, map[string][]testStream{
+		tenant: {
+			{labels: `{app="a"}`, entries: wideLinesAt(ta, 4)},
+			{labels: `{app="b"}`, entries: wideLinesAt(ta, 4)},
+			{labels: `{app="c"}`, entries: wideLinesAt(ta, 4)},
+		},
+	})
+	buildSourceLogObject(t, bucket, "objB", sortSchema, map[string][]testStream{
+		tenant: {
+			{labels: `{app="b"}`, entries: wideLinesAt(tb, 4)},
+			{labels: `{app="c"}`, entries: wideLinesAt(tb, 4)},
+			{labels: `{app="d"}`, entries: wideLinesAt(tb, 4)},
+		},
+	})
+	buildSourceLogObject(t, bucket, "objC", sortSchema, map[string][]testStream{
+		tenant: {
+			{labels: `{app="c"}`, entries: wideLinesAt(tc, 4)},
+			{labels: `{app="d"}`, entries: wideLinesAt(tc, 4)},
+			{labels: `{app="e"}`, entries: wideLinesAt(tc, 4)},
+		},
+	})
+
+	c := newSmallObjectExecutorContext(t, bucket)
+	node := &physical.LogMerge{
+		Tenant:          tenant,
+		SortSchema:      sortSchema,
+		OutputIndexPath: "out/index",
+		Runs: []*compactionv2pb.RunRef{
+			{Sections: []*compactionv2pb.SectionRef{{ObjectPath: "objA"}, {ObjectPath: "objB"}, {ObjectPath: "objC"}}},
+		},
+	}
+
+	require.NoError(t, c.doLogObjectMerge(ctx, node))
+
+	objs := readCompactedObjects(ctx, t, bucket, node)
+	require.GreaterOrEqual(t, len(objs), 2, "output must be split into multiple objects")
+
+	totalStreams := 0
+	totalRecords := 0
+	distinctApps := make(map[string]bool)
+	for objIdx, o := range objs {
+		totalStreams += len(o.streamApp)
+		totalRecords += len(o.records)
+		for _, app := range o.streamApp {
+			distinctApps[app] = true
+		}
+
+		// Each object is schema-sorted by [app ASC, streamID ASC, timestamp DESC].
+		for i := 1; i < len(o.records); i++ {
+			prev, curr := o.records[i-1], o.records[i]
+			require.LessOrEqual(t, prev.app, curr.app, "apps must be non-decreasing within object %d", objIdx)
+			if prev.app == curr.app {
+				require.LessOrEqual(t, prev.streamID, curr.streamID, "streamIDs must be non-decreasing within an app")
+				if prev.streamID == curr.streamID {
+					require.False(t, curr.ts.After(prev.ts), "timestamps must be non-increasing within a stream")
+				}
+			}
+		}
+	}
+
+	// No cross-object dedup: 9 source streams => 9 output streams.
+	require.Equal(t, 9, totalStreams)
+	// The 5 distinct label sets are all present.
+	require.Equal(t, map[string]bool{"a": true, "b": true, "c": true, "d": true, "e": true}, distinctApps)
+	// 9 stream-appends x 4 entries = 36 records.
+	require.Equal(t, 36, totalRecords)
+}
+
+func TestDoLogObjectMerge_EmptyRunsIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+
+	c := newTestExecutorContext(t, bucket)
+	node := &physical.LogMerge{Tenant: "T", SortSchema: []string{"label:app"}, OutputIndexPath: "out/index"}
+
+	require.NoError(t, c.doLogObjectMerge(ctx, node))
+
+	ok, err := bucket.Exists(ctx, logMergeOutputPath(node.OutputIndexPath, 0))
+	require.NoError(t, err)
+	require.False(t, ok, "no output object should be written for an empty merge")
+}
+
+func TestDoLogObjectMerge_ExistingOutputShortCircuits(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+
+	const tenant = "T"
+	sortSchema := []string{"label:app"}
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	buildSourceLogObject(t, bucket, "objA", sortSchema, map[string][]testStream{
+		tenant: {{labels: `{app="a"}`, entries: linesAt(base, 3)}},
+	})
+
+	c := newTestExecutorContext(t, bucket)
+	node := &physical.LogMerge{
+		Tenant:          tenant,
+		SortSchema:      sortSchema,
+		OutputIndexPath: "out/index",
+		Runs: []*compactionv2pb.RunRef{
+			{Sections: []*compactionv2pb.SectionRef{{ObjectPath: "objA"}}},
+		},
+	}
+
+	// Pre-seed the output index path: the merge must short-circuit and not build.
+	require.NoError(t, bucket.Upload(ctx, node.OutputIndexPath, strings.NewReader("sentinel")))
+
+	require.NoError(t, c.doLogObjectMerge(ctx, node))
+
+	got, err := bucket.Get(ctx, node.OutputIndexPath)
+	require.NoError(t, err)
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, got)
+	require.NoError(t, err)
+	require.NoError(t, got.Close())
+	require.Equal(t, "sentinel", buf.String(), "existing output must be left untouched")
+
+	ok, err := bucket.Exists(ctx, logMergeOutputPath(node.OutputIndexPath, 0))
+	require.NoError(t, err)
+	require.False(t, ok, "compacted log objects must not be written when output index already exists")
+}


### PR DESCRIPTION
**Description:**

- Adds worker implementation to add k-way merge for log objects using k-way merge
- Generalizes the sortmerge Iterator implementation to accept a opts in order to customize with remaps
- StreamIDs are re-computed for the merged section and the stream-section is re-computed


This PR doesn't update indexes or TOCs resulting from the newly created object. It is deferred to another subsequent implementations. 