### PR TITLE
perf(logql): Cap series accumulation at the max_query_series limit

### DIFF
--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -574,20 +574,16 @@ func (q *query) JoinSampleVector(ctx context.Context, next bool, r StepResult, s
 	for next {
 		vec = r.SampleVector()
 
-		if httpreq.IsLogsDrilldownRequest(ctx) {
-			// For Logs Drilldown requests, use limited vectorsToSeries to prevent exceeding maxSeries
-			limitExceeded := vectorsToSeriesWithLimit(vec, seriesIndex, maxSeries)
-			// If the limit was exceeded (series were skipped), add warning and break
-			if limitExceeded {
-				metadata.FromContext(ctx).AddWarning(fmt.Sprintf("maximum number of series (%d) reached for a single query; returning partial results", maxSeries))
-				break // Break out of the loop to return partial results
-			}
-		} else {
-			// For non-drilldown requests, use unlimited vectorsToSeries and check for hard limit
-			vectorsToSeries(vec, seriesIndex)
-			if len(seriesIndex) > maxSeries {
+		// vectorsToSeriesWithLimit stops accumulating once maxSeries distinct series
+		// exist and reports whether the limit was hit, so seriesIndex never grows past
+		// maxSeries regardless of request type.
+		if vectorsToSeriesWithLimit(vec, seriesIndex, maxSeries) {
+			if !httpreq.IsLogsDrilldownRequest(ctx) {
 				return nil, logqlmodel.NewSeriesLimitError(maxSeries)
 			}
+			// Logs Drilldown returns partial results with a warning instead of failing.
+			metadata.FromContext(ctx).AddWarning(fmt.Sprintf("maximum number of series (%d) reached for a single query; returning partial results", maxSeries))
+			break
 		}
 
 		next, _, r = stepEvaluator.Next()


### PR DESCRIPTION
**What this PR does**: tightens how `JoinSampleVector` accumulates series while enforcing `max_query_series`. The non-drilldown path used to fold *every* series of each step into `seriesIndex` with the unlimited `vectorsToSeries` and only then check `len(seriesIndex) > maxSeries` — so an oversized step would balloon the map to the full step size purely to reject it. Both request types now go through `vectorsToSeriesWithLimit`, which stops accumulating the moment the distinct count crosses `maxSeries`. The only thing that differs afterward is how we handle hitting the limit: normal requests error, Logs Drilldown returns partial results with a warning (unchanged).

This is behavior-preserving. `vectorsToSeriesWithLimit` reports the limit was hit on exactly the same condition the old `len(seriesIndex) > maxSeries` check fired on, so the error / partial-result decision is identical — it just caps the map instead of overshooting first. As a bonus it collapses the two nearly-duplicate accumulation branches into one.

To be clear about scope: this is a minor peak-memory win on the rejection path only. It does **not** address the core problem — the streams loaded *below* the aggregation, which is where the real cost is. `max_query_series` is an output limit and can't be pushed down past series-reducing constructions (`sum by`, `unless`, ...) without correctness issues; fixing that properly needs a separate input-series limit. Writeup and options in grafana/loki-private#2553.