### PR TITLE
fix(pattern): add TenantConfigs dep to PatternIngesterTee and nil guard in sendBatch

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -829,7 +829,7 @@ func (t *Loki) setupModuleManager() error {
 		BloomBuilder:                 {Server, BloomStore, Analytics, Store, UIRing},
 		BloomStore:                   {IndexGatewayRing, BloomGatewayClient},
 		PatternRingClient:            {Server, MemberlistKV, Analytics},
-		PatternIngesterTee:           {Server, Overrides, MemberlistKV, Analytics, PatternRingClient},
+		PatternIngesterTee:           {Server, Overrides, MemberlistKV, Analytics, PatternRingClient, TenantConfigs},
 		PatternIngester:              {Server, MemberlistKV, Analytics, PatternRingClient, PatternIngesterTee, Overrides, UIRing},
 		IngesterQuerier:              {Ring, PartitionRing, Overrides},
 		QuerySchedulerRing:           {Overrides, MemberlistKV},

--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -374,7 +374,7 @@ func (ts *TeeService) sendBatch(ctx context.Context, clientRequest clientRequest
 
 					// this is basically the same as logging push request streams,
 					// so put it behind the same flag
-					if ts.tenantCfgs.LogPushRequestStreams(clientRequest.tenant) {
+					if ts.tenantCfgs != nil && ts.tenantCfgs.LogPushRequestStreams(clientRequest.tenant) {
 						level.Debug(ts.logger).
 							Log(
 								"msg", "forwarded push request to pattern ingester",

--- a/pkg/pattern/tee_service_test.go
+++ b/pkg/pattern/tee_service_test.go
@@ -21,6 +21,27 @@ import (
 	"github.com/grafana/loki/pkg/push"
 )
 
+func TestPatternTee_NilTenantCfgs(t *testing.T) {
+	tee, _ := getTestTee(t)
+	tee.tenantCfgs = nil
+
+	ctx := context.Background()
+	clientReq := clientRequest{
+		ingesterAddr: "ingester0",
+		tenant:       "test-tenant",
+		reqs: []*logproto.PushRequest{{
+			Streams: []logproto.Stream{{
+				Labels:  `{foo="bar"}`,
+				Entries: []logproto.Entry{{Timestamp: time.Now(), Line: "test line"}},
+			}},
+		}},
+	}
+
+	require.NotPanics(t, func() {
+		tee.sendBatch(ctx, clientReq)
+	})
+}
+
 func getTestTee(t *testing.T) (*TeeService, *mockPoolClient) {
 	cfg := Config{}
 	cfg.RegisterFlags(flag.NewFlagSet("test", flag.PanicOnError)) // set up defaults


### PR DESCRIPTION
**What this PR does / why we need it**:
PatternIngesterTee was missing TenantConfigs from its module deps. Distributor depends on both TenantConfigs and PatternIngesterTee as siblings, so they can initialize in any order, if PatternIngesterTee runs first, t.tenantConfigs is nil when passed into NewTeeService. It gets stored and later dereferenced in the background batchSender goroutine once a push succeeds, causing an intermittent panic.
Added TenantConfigs to the dep list to enforce init order, and a nil guard on ts.tenantCfgs in sendBatch as a safety net

**Which issue(s) this PR fixes**:
Fixes #23075

**Special notes for your reviewer**:
TestStreamPatternPersistenceOnPrune in pkg/pattern fails on main before this PR, pre-existing flaky test, unrelated to these changes

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
