### PR TITLE
feat: Add circuit breaker to drop traffic

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3457,6 +3457,25 @@ dataobj_tee:
   # used instead.
   # CLI flag: -distributor.dataobj-tee.use-rendezvous-hashing
   [use_rendezvous_hashing: <boolean> | default = false]
+
+circuit_breaker:
+  # Enable circuit breakers.
+  # CLI flag: -distributor.circuit-breaker.enabled
+  [enabled: <boolean> | default = false]
+
+  # The open period.
+  # CLI flag: -distributor.circuit-breaker.open-period
+  [open_period: <duration> | default = 1s]
+
+  # The minimum number of successive failures required to open the circuit
+  # breaker.
+  # CLI flag: -distributor.circuit-breaker.min-failures
+  [min_failures: <int> | default = 1]
+
+  # The number of permitted trial requests in the half-open state. All requests
+  # must succeed to close the circuit breaker, any failure re-opens it.
+  # CLI flag: -distributor.circuit-breaker.permitted-trials
+  [permitted_trials: <int> | default = 1]
 ```
 
 ### etcd

--- a/pkg/distributor/circuit_breaker.go
+++ b/pkg/distributor/circuit_breaker.go
@@ -1,0 +1,221 @@
+package distributor
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	circuitBreakerClosed = iota
+	circuitBreakerOpen
+	circuitBreakerHalfOpen
+)
+
+var (
+	circuitBreakerStateDesc = prometheus.NewDesc(
+		"loki_distributor_circuit_breaker_state",
+		"The state of the circuit breaker.",
+		nil,
+		nil,
+	)
+	circuitBreakerOpenDesc = prometheus.NewDesc(
+		"loki_distributor_circuit_breaker_open_total",
+		"The number of times the circuit breaker opened.",
+		nil,
+		nil,
+	)
+)
+
+var (
+	noopDoneFunc = func(_ error) {}
+)
+
+// An interface for circuit breakers.
+type circuitBreaker interface {
+	// Allow returns true if the request can proceed, otherwise false. It returns
+	// a done callback that MUST be called when the request is finished.
+	Allow() (bool, func(err error))
+}
+
+// A trialCircuitBreaker is a traditional circuit breaker. The circuit breaker
+// is opened after a minimum number of successive failures, where it drops all
+// requests for the duration of the open period. At the end of the open period
+// it transitions to the half-open state where it allows a maximum number of
+// "trial" requests. If all trial requests are successful, the circuit breaker
+// transitions to closed, otherwise it re-opens and starts again.
+type trialCircuitBreaker struct {
+	lastOpened                         time.Time
+	isOpenErr                          func(err error) bool
+	noopDoneFunc                       func(error)
+	openPeriod                         time.Duration
+	state                              int
+	totalOpens                         int
+	successes, trials, permittedTrials int
+	failures, minFailures              int
+	// term is incremented on each state transition. It ensures that a doneFunc
+	// is called iff its term matches the current term. Without this, results
+	// from previous terms would affect the current term and cause incorrect
+	// behavior. A simple example is a request from a previous closed state
+	// mistaken as a trial request of the current half-open state.
+	term int
+	mtx  sync.Mutex
+}
+
+// newTrialCircuitBreaker returns a trial new circuit breaker.
+func newTrialCircuitBreaker(
+	openPeriod time.Duration,
+	minFailures int,
+	permittedTrials int,
+	isOpenErr func(err error) bool,
+) *trialCircuitBreaker {
+	return &trialCircuitBreaker{
+		state:           circuitBreakerClosed,
+		openPeriod:      openPeriod,
+		minFailures:     minFailures,
+		permittedTrials: permittedTrials,
+		isOpenErr:       isOpenErr,
+		noopDoneFunc:    noopDoneFunc,
+	}
+}
+
+// Allow implements [circuitBreaker].
+func (b *trialCircuitBreaker) Allow() (ok bool, done func(err error)) {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	ok = b.handleAllow()
+	if !ok {
+		return ok, b.noopDoneFunc
+	}
+	// Bind the func to the current term.
+	term := b.term
+	return ok, func(err error) { b.doneFunc(term, err) }
+}
+
+// Describe implements [prometheus.Collector].
+func (b *trialCircuitBreaker) Describe(descs chan<- *prometheus.Desc) {
+	descs <- circuitBreakerStateDesc
+	descs <- circuitBreakerOpenDesc
+}
+
+// Collect implements [prometheus.Collector].
+func (b *trialCircuitBreaker) Collect(metrics chan<- prometheus.Metric) {
+	b.mtx.Lock()
+	var (
+		state      = float64(b.state)
+		totalOpens = float64(b.totalOpens)
+	)
+	b.mtx.Unlock()
+	metrics <- prometheus.MustNewConstMetric(
+		circuitBreakerStateDesc,
+		prometheus.GaugeValue,
+		state,
+	)
+	metrics <- prometheus.MustNewConstMetric(
+		circuitBreakerOpenDesc,
+		prometheus.CounterValue,
+		totalOpens,
+	)
+}
+
+func (b *trialCircuitBreaker) handleAllow() bool {
+	switch b.state {
+	case circuitBreakerClosed:
+		return true
+	case circuitBreakerOpen:
+		return b.handleOpenState()
+	case circuitBreakerHalfOpen:
+		return b.handleHalfOpenState()
+	default:
+		// defer will ensure that mtx is unlocked even after a panic.
+		panic("Unknown state")
+	}
+}
+
+func (b *trialCircuitBreaker) handleOpenState() bool {
+	if time.Since(b.lastOpened) > b.openPeriod {
+		b.halfOpen()
+		return b.handleHalfOpenState()
+	}
+	return false
+}
+
+func (b *trialCircuitBreaker) handleHalfOpenState() bool {
+	if b.trials < b.permittedTrials {
+		b.trials++
+		return true
+	}
+	return false
+}
+
+// A reference to doneFunc is returned in successful calls to [Allow].
+func (b *trialCircuitBreaker) doneFunc(term int, err error) {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	// The doneFunc must not run if its for a previous term.
+	if term != b.term {
+		return
+	}
+	if b.isOpenErr(err) {
+		b.handleOpenErr(err)
+		return
+	}
+	b.handleSuccess()
+}
+
+func (b *trialCircuitBreaker) handleOpenErr(_ error) {
+	switch b.state {
+	case circuitBreakerClosed:
+		// Increment the number of successive failures (reset to 0 in [handleSuccess]).
+		// If it exceeds the minimum number of failures transition to open state.
+		b.failures++
+		if b.failures >= b.minFailures {
+			b.open()
+		}
+	case circuitBreakerHalfOpen:
+		// A failure in the half-open state re-opens the circuit breaker. This is
+		// essential for correctness to avoid deadlocks in the half-open state where
+		// all trial requests have completed but neither threshold to close or re-open
+		// the circuit breaker was satisifed.
+		b.open()
+	default:
+		// circuitBreakerOpen is unreachable: Allow() returns noopDoneFunc when open,
+		// and the term check in doneFunc prevents stale calls.
+		panic("Invalid state for handleOpenErr")
+	}
+}
+
+func (b *trialCircuitBreaker) handleSuccess() {
+	// Reset the number of successive failures.
+	b.failures = 0
+	if b.state == circuitBreakerHalfOpen {
+		b.successes++
+		// If all trial requests are successful, transition to close state.
+		if b.successes >= b.permittedTrials {
+			b.close()
+		}
+	}
+}
+
+func (b *trialCircuitBreaker) open() {
+	b.newTerm(circuitBreakerOpen)
+	b.lastOpened = time.Now()
+	b.totalOpens++
+}
+
+func (b *trialCircuitBreaker) halfOpen() {
+	b.newTerm(circuitBreakerHalfOpen)
+}
+
+func (b *trialCircuitBreaker) close() {
+	b.newTerm(circuitBreakerClosed)
+}
+
+func (b *trialCircuitBreaker) newTerm(state int) {
+	b.state = state
+	b.term++
+	b.trials = 0
+	b.successes = 0
+	b.failures = 0
+}

--- a/pkg/distributor/circuit_breaker_test.go
+++ b/pkg/distributor/circuit_breaker_test.go
@@ -1,0 +1,235 @@
+package distributor
+
+import (
+	"errors"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrialCircuitBreaker(t *testing.T) {
+	isAnyErr := func(err error) bool { return err != nil }
+
+	t.Run("allows requests when closed", func(t *testing.T) {
+		b := newTrialCircuitBreaker(time.Second, 1, 1, isAnyErr)
+		ok, doneFunc := b.Allow()
+		require.True(t, ok)
+		require.NotNil(t, doneFunc)
+		require.Equal(t, circuitBreakerClosed, b.state)
+	})
+
+	t.Run("transitions to open on error", func(t *testing.T) {
+		b := newTrialCircuitBreaker(time.Second, 1, 1, isAnyErr)
+		ok, doneFunc := b.Allow()
+		require.True(t, ok)
+		doneFunc(errors.New("some error occurred"))
+		require.Equal(t, circuitBreakerOpen, b.state)
+	})
+
+	t.Run("transitions to open after 3 successive errors", func(t *testing.T) {
+		b := newTrialCircuitBreaker(time.Second, 3, 1, isAnyErr)
+		// The first two errors should increment the failure counter but not open
+		// the circuit breaker.
+		ok, doneFunc := b.Allow()
+		require.True(t, ok)
+		doneFunc(errors.New("some error occurred"))
+		require.Equal(t, circuitBreakerClosed, b.state)
+		require.Equal(t, 1, b.failures)
+
+		ok, doneFunc = b.Allow()
+		require.True(t, ok)
+		doneFunc(errors.New("some error occurred"))
+		require.Equal(t, circuitBreakerClosed, b.state)
+		require.Equal(t, 2, b.failures)
+
+		// The third error should open it.
+		ok, doneFunc = b.Allow()
+		require.True(t, ok)
+		doneFunc(errors.New("some error occurred"))
+		require.Equal(t, circuitBreakerOpen, b.state)
+		// The failure counter is reset to 0 at the start of each term.
+		require.Equal(t, 0, b.failures)
+	})
+
+	t.Run("success resets failure counter when closed", func(t *testing.T) {
+		b := newTrialCircuitBreaker(time.Second, 3, 1, isAnyErr)
+		// An error should increment the failure counter.
+		ok, doneFunc := b.Allow()
+		require.True(t, ok)
+		doneFunc(errors.New("some error occurred"))
+		require.Equal(t, circuitBreakerClosed, b.state)
+		require.Equal(t, 1, b.failures)
+		// A success should reset the failure counter.
+		ok, doneFunc = b.Allow()
+		require.True(t, ok)
+		doneFunc(nil)
+		require.Equal(t, circuitBreakerClosed, b.state)
+		require.Equal(t, 0, b.failures)
+	})
+
+	t.Run("rejects all requests when open", func(t *testing.T) {
+		b := newTrialCircuitBreaker(time.Second, 1, 1, isAnyErr)
+		b.state = circuitBreakerOpen
+		b.lastOpened = time.Now()
+
+		var calls int
+		b.noopDoneFunc = func(_ error) {
+			calls++
+		}
+
+		ok, doneFunc := b.Allow()
+		require.False(t, ok)
+		require.NotNil(t, doneFunc)
+		require.Equal(t, circuitBreakerOpen, b.state)
+
+		// When the circuit breaker is open, the doneFunc should be a noopDoneFunc.
+		require.Equal(t, 0, calls)
+		doneFunc(nil)
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("transitions to half-open after open period", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			b := newTrialCircuitBreaker(time.Second, 1, 1, isAnyErr)
+			b.state = circuitBreakerOpen
+			b.lastOpened = time.Now()
+
+			// Sleep until the end of the open period, should remain in open.
+			time.Sleep(1 * time.Second)
+			ok, _ := b.Allow()
+			require.False(t, ok)
+			require.Equal(t, circuitBreakerOpen, b.state)
+
+			// Should switch to half-open.
+			time.Sleep(1 * time.Second)
+			ok, _ = b.Allow()
+			require.True(t, ok)
+			require.Equal(t, circuitBreakerHalfOpen, b.state)
+		})
+	})
+
+	t.Run("allows up 10 trial requests when half-open, additional requests are dropped", func(t *testing.T) {
+		b := newTrialCircuitBreaker(time.Second, 1, 10, isAnyErr)
+		b.state = circuitBreakerHalfOpen
+		for range 10 {
+			ok, _ := b.Allow()
+			require.True(t, ok)
+		}
+		// The 11th request is dropped.
+		ok, _ := b.Allow()
+		require.False(t, ok)
+		require.Equal(t, circuitBreakerHalfOpen, b.state)
+	})
+
+	t.Run("transitions to closed when all trial requests succeed", func(t *testing.T) {
+		b := newTrialCircuitBreaker(time.Second, 1, 10, isAnyErr)
+		b.state = circuitBreakerHalfOpen
+		for range 9 {
+			ok, doneFunc := b.Allow()
+			require.True(t, ok)
+			doneFunc(nil)
+		}
+		ok, doneFunc := b.Allow()
+		require.True(t, ok)
+		require.Equal(t, circuitBreakerHalfOpen, b.state)
+		// When the last request succeeds it should transition to closed.
+		doneFunc(nil)
+		require.Equal(t, circuitBreakerClosed, b.state)
+	})
+
+	t.Run("transitions to open when a trial request fails", func(t *testing.T) {
+		b := newTrialCircuitBreaker(time.Second, 1, 10, isAnyErr)
+		b.state = circuitBreakerHalfOpen
+
+		// The first trial request is successful.
+		ok, doneFunc := b.Allow()
+		require.True(t, ok)
+		doneFunc(nil)
+		require.Equal(t, circuitBreakerHalfOpen, b.state)
+
+		// The second trial request fails.
+		ok, doneFunc = b.Allow()
+		require.True(t, ok)
+		doneFunc(errors.New("an error occurred"))
+		require.Equal(t, circuitBreakerOpen, b.state)
+	})
+
+	t.Run("state transition increments term", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			b := newTrialCircuitBreaker(time.Second, 1, 1, isAnyErr)
+			require.Equal(t, 0, b.term)
+
+			// Transition from closed to open increments the term.
+			ok, doneFunc := b.Allow()
+			require.True(t, ok)
+			doneFunc(errors.New("an error occurred"))
+			require.Equal(t, circuitBreakerOpen, b.state)
+			require.Equal(t, 1, b.term)
+
+			// Transition from open to half-open increments the term.
+			time.Sleep(2 * time.Second)
+			_, doneFunc = b.Allow()
+			require.Equal(t, circuitBreakerHalfOpen, b.state)
+			require.Equal(t, 2, b.term)
+
+			// Transition from half-open to open increments the term.
+			doneFunc(errors.New("an error occurred"))
+			require.Equal(t, circuitBreakerOpen, b.state)
+			require.Equal(t, 3, b.term)
+
+			// Transition back to half-open increments the term once more.
+			time.Sleep(2 * time.Second)
+			_, doneFunc = b.Allow()
+			require.Equal(t, circuitBreakerHalfOpen, b.state)
+			require.Equal(t, 4, b.term)
+
+			// Transition from half-open to closed increments the term.
+			doneFunc(nil)
+			require.Equal(t, circuitBreakerClosed, b.state)
+			require.Equal(t, 5, b.term)
+		})
+	})
+
+	t.Run("transition to half-open resets counters", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			b := newTrialCircuitBreaker(time.Second, 1, 3, isAnyErr)
+			b.state = circuitBreakerOpen
+			b.lastOpened = time.Now()
+
+			// Set the counters to some non-zero value.
+			b.trials, b.successes, b.failures = 4, 5, 6
+			time.Sleep(2 * time.Second)
+			_, _ = b.Allow()
+			require.Equal(t, 1, b.trials)
+			require.Equal(t, 0, b.successes)
+			require.Equal(t, 0, b.failures)
+			require.Equal(t, circuitBreakerHalfOpen, b.state)
+		})
+	})
+
+	t.Run("doneFunc with previous term is skipped", func(t *testing.T) {
+		b := newTrialCircuitBreaker(time.Second, 3, 1, isAnyErr)
+
+		// If we pass an error to doneFunc, we expect the failure counter to be
+		// incremented.
+		ok, doneFunc := b.Allow()
+		require.True(t, ok)
+		doneFunc(errors.New("an error occurred"))
+		require.Equal(t, 1, b.failures)
+
+		// If we repeat this, but advance the term, no increment should happen.
+		ok, doneFunc = b.Allow()
+		require.True(t, ok)
+		b.term++
+		doneFunc(errors.New("an error occurred"))
+		require.Equal(t, 1, b.failures)
+
+		// Now the term matches once more, the failure counter should be incremented.
+		ok, doneFunc = b.Allow()
+		require.True(t, ok)
+		doneFunc(errors.New("an error occurred"))
+		require.Equal(t, 2, b.failures)
+	})
+}

--- a/pkg/distributor/circuit_breaker_test.go
+++ b/pkg/distributor/circuit_breaker_test.go
@@ -210,26 +210,40 @@ func TestTrialCircuitBreaker(t *testing.T) {
 	})
 
 	t.Run("doneFunc with previous term is skipped", func(t *testing.T) {
-		b := newTrialCircuitBreaker(time.Second, 3, 1, isAnyErr)
+		synctest.Test(t, func(t *testing.T) {
+			b := newTrialCircuitBreaker(time.Second, 2, 1, isAnyErr)
 
-		// If we pass an error to doneFunc, we expect the failure counter to be
-		// incremented.
-		ok, doneFunc := b.Allow()
-		require.True(t, ok)
-		doneFunc(errors.New("an error occurred"))
-		require.Equal(t, 1, b.failures)
+			// If we pass an error to doneFunc, we expect the failure counter to be
+			// incremented.
+			ok, doneFunc := b.Allow()
+			require.True(t, ok)
+			doneFunc(errors.New("an error occurred"))
+			require.Equal(t, 1, b.failures)
 
-		// If we repeat this, but advance the term, no increment should happen.
-		ok, doneFunc = b.Allow()
-		require.True(t, ok)
-		b.term++
-		doneFunc(errors.New("an error occurred"))
-		require.Equal(t, 1, b.failures)
+			// We keep this doneFunc around to show that it is skipped in later terms.
+			ok, lateDoneFunc := b.Allow()
+			require.True(t, ok)
 
-		// Now the term matches once more, the failure counter should be incremented.
-		ok, doneFunc = b.Allow()
-		require.True(t, ok)
-		doneFunc(errors.New("an error occurred"))
-		require.Equal(t, 2, b.failures)
+			// Open the circuit breaker.
+			ok, doneFunc = b.Allow()
+			require.True(t, ok)
+			doneFunc(errors.New("an error occurred"))
+			require.Equal(t, circuitBreakerOpen, b.state)
+
+			// Transition to half-open.
+			time.Sleep(2 * time.Second)
+			ok, doneFunc = b.Allow()
+			require.True(t, ok)
+			require.Equal(t, circuitBreakerHalfOpen, b.state)
+
+			// A failure should re-open the circuit breaker, but since lateDoneFunc is
+			// from a previous term, it is skipped.
+			lateDoneFunc(errors.New("an error occurred"))
+			require.Equal(t, circuitBreakerHalfOpen, b.state)
+
+			// A failure from the current term should re-open the circuit breaker.
+			doneFunc(errors.New("an error occurred"))
+			require.Equal(t, circuitBreakerOpen, b.state)
+		})
 	})
 }

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -113,7 +113,8 @@ type Config struct {
 
 	KafkaConfig kafka.Config `yaml:"-"`
 
-	DataObjTeeConfig DataObjTeeConfig `yaml:"dataobj_tee"`
+	DataObjTeeConfig DataObjTeeConfig     `yaml:"dataobj_tee"`
+	CircuitBreaker   CircuitBreakerConfig `yaml:"circuit_breaker"`
 }
 
 // RegisterFlags registers distributor-related flags.
@@ -121,6 +122,7 @@ func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
 	cfg.OTLPConfig.RegisterFlags(fs)
 	cfg.DistributorRing.RegisterFlags(fs)
 	cfg.DataObjTeeConfig.RegisterFlags(fs)
+	cfg.CircuitBreaker.RegisterFlags(fs)
 	cfg.RateStore.RegisterFlagsWithPrefix("distributor.rate-store", fs)
 	cfg.WriteFailuresLogging.RegisterFlagsWithPrefix("distributor.write-failures-logging", fs)
 	fs.IntVar(&cfg.MaxRecvMsgSize, "distributor.max-recv-msg-size", 100<<20, "The maximum size of a received message.")
@@ -139,9 +141,42 @@ func (cfg *Config) Validate() error {
 	if err := cfg.DataObjTeeConfig.Validate(); err != nil {
 		return err
 	}
+	if err := cfg.CircuitBreaker.Validate(); err != nil {
+		return err
+	}
 	// Set default maxDecompressedSize if not configured (50x maxRecvMsgSize)
 	if cfg.MaxDecompressedSize == 0 && cfg.MaxRecvMsgSize > 0 {
 		cfg.MaxDecompressedSize = int64(cfg.MaxRecvMsgSize) * 50
+	}
+	return nil
+}
+
+type CircuitBreakerConfig struct {
+	Enabled         bool          `yaml:"enabled"`
+	OpenPeriod      time.Duration `yaml:"open_period"`
+	MinFailures     int           `yaml:"min_failures"`
+	PermittedTrials int           `yaml:"permitted_trials"`
+}
+
+func (cfg *CircuitBreakerConfig) RegisterFlags(f *flag.FlagSet) {
+	f.BoolVar(&cfg.Enabled, "distributor.circuit-breaker.enabled", false, "Enable circuit breakers.")
+	f.DurationVar(&cfg.OpenPeriod, "distributor.circuit-breaker.open-period", time.Second, "The open period.")
+	f.IntVar(&cfg.MinFailures, "distributor.circuit-breaker.min-failures", 1, "The minimum number of successive failures required to open the circuit breaker.")
+	f.IntVar(&cfg.PermittedTrials, "distributor.circuit-breaker.permitted-trials", 1, "The number of permitted trial requests in the half-open state. All requests must succeed to close the circuit breaker, any failure re-opens it.")
+}
+
+func (cfg *CircuitBreakerConfig) Validate() error {
+	if !cfg.Enabled {
+		return nil
+	}
+	if cfg.OpenPeriod <= 0 {
+		return errors.New("the open period must be a positive duration")
+	}
+	if cfg.MinFailures < 1 {
+		return errors.New("the minimum number of failures must be at least 1")
+	}
+	if cfg.PermittedTrials < 1 {
+		return errors.New("the permitted number of trials must be at least 1")
 	}
 	return nil
 }
@@ -297,6 +332,7 @@ type Distributor struct {
 	// Track the max inflight bytes in the last 1 minute.
 	inflightBytesHighWatermark prometheus.Summary
 	inflightBytes              atomic.Int64
+	circuitBreaker             circuitBreaker
 }
 
 // New a distributor creates.
@@ -450,6 +486,19 @@ func New(
 			Objectives: map[float64]float64{1.0: 0.1},
 			MaxAge:     time.Minute,
 		}),
+	}
+
+	if cfg.CircuitBreaker.Enabled {
+		circuitBreaker := newTrialCircuitBreaker(
+			cfg.CircuitBreaker.OpenPeriod,
+			cfg.CircuitBreaker.MinFailures,
+			cfg.CircuitBreaker.PermittedTrials,
+			func(err error) bool {
+				return errors.Is(err, kgo.ErrMaxBuffered)
+			},
+		)
+		registerer.MustRegister(circuitBreaker)
+		d.circuitBreaker = circuitBreaker
 	}
 
 	if overrides.IngestionRateStrategy() == validation.GlobalIngestionRateStrategy {

--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -42,6 +42,25 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 		return
 	}
 
+	// TODO: In future, we want to be able to compose this with the middleware pattern,
+	// but this requires refactor of this file to support next handlers. We will do
+	// this at a later time.
+	var (
+		circuitBreakerOk       bool
+		circuitBreakerDoneFunc func(err error)
+		circuitBreakerErr      error
+	)
+	if d.circuitBreaker != nil {
+		circuitBreakerOk, circuitBreakerDoneFunc = d.circuitBreaker.Allow()
+		// Must be wrapped in a closure so circuitBreakerErr is evaluated when the
+		// deferred function runs.
+		defer func() { circuitBreakerDoneFunc(circuitBreakerErr) }()
+		if !circuitBreakerOk {
+			errorWriter(w, "circuit breaker open, request denied", http.StatusServiceUnavailable, logger)
+			return
+		}
+	}
+
 	if d.RequestParserWrapper != nil {
 		pushRequestParser = d.RequestParserWrapper(pushRequestParser)
 	}
@@ -162,6 +181,7 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 		return
 	}
 
+	circuitBreakerErr = err
 	resp, ok := httpgrpc.HTTPResponseFromError(err)
 	if ok {
 		body := string(resp.Body)


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds support for circuit breakers in the distributors to drop excess traffic under high load. The initial error that is supported is when the Kafka buffer is full. We will add a second error condition for max inflight bytes in a follow up PR.

This implementation is a bit different from that in #23112 in that it performs a number of trial requests immediately, and if any of those fail, the circuit breaker opens again. In testing, I found this this allowed us to sustain up to 100% higher throughput at peak while still effectively preventing overload.

<img width="2910" height="7634" alt="_Users_grobinson_go_src_github com_grafana_loki_circuit_breaker_flowchart html (1)" src="https://github.com/user-attachments/assets/c6a2cdcc-d98e-414a-b2d8-8e80aab37e97" />

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
