### PR TITLE
feat(logql): Push max_query_series down to the range vector iterators

### DIFF
--- a/pkg/logql/count_min_sketch.go
+++ b/pkg/logql/count_min_sketch.go
@@ -339,6 +339,11 @@ func (e *countMinSketchVectorAggEvaluator) Error() error {
 	return e.nextEvaluator.Error()
 }
 
+// SetMaxOutputSeries does not enforce this limit. Count-min-sketch aggregations
+// are joined via JoinCountMinSketchVector rather than JoinSampleVector and are
+// not covered by max_query_series enforcement here.
+func (*countMinSketchVectorAggEvaluator) SetMaxOutputSeries(int) {}
+
 // CountMinSketchVectorStepEvaluator evaluates a count min sketch into a promql.Vector.
 type CountMinSketchVectorStepEvaluator struct {
 	exhausted bool
@@ -386,6 +391,10 @@ func (*CountMinSketchVectorStepEvaluator) Close() error { return nil }
 
 func (*CountMinSketchVectorStepEvaluator) Error() error { return nil }
 
+// SetMaxOutputSeries does not enforce this limit (count-min-sketch path, see
+// countMinSketchVectorAggEvaluator).
+func (*CountMinSketchVectorStepEvaluator) SetMaxOutputSeries(int) {}
+
 var _ StepEvaluator = (*CountMinSketchEvalStepEvaluator)(nil)
 
 // CountMinSketchEvalStepEvaluator transforms a CountMinSketchEvalExpr into a CountMinSketchVector.
@@ -425,5 +434,9 @@ func (e *CountMinSketchEvalStepEvaluator) Next() (bool, int64, StepResult) {
 func (*CountMinSketchEvalStepEvaluator) Close() error { return nil }
 
 func (*CountMinSketchEvalStepEvaluator) Error() error { return nil }
+
+// SetMaxOutputSeries does not enforce this limit (count-min-sketch path, see
+// countMinSketchVectorAggEvaluator).
+func (*CountMinSketchEvalStepEvaluator) SetMaxOutputSeries(int) {}
 
 func (e *CountMinSketchEvalStepEvaluator) Explain(_ Node) {}

--- a/pkg/logql/downstream.go
+++ b/pkg/logql/downstream.go
@@ -834,6 +834,14 @@ func (e *ConcatStepEvaluator) Error() error {
 	}
 }
 
+// SetMaxOutputSeries does not enforce the limit. It concatenates the results of
+// sharded sub-queries, so its per-step output can contain the same group once
+// per shard and is larger than the merged result the parent aggregation
+// produces; its count is therefore not a lower bound on the query output. The
+// limit could instead be pushed into each downstream leg whose expression is
+// itself limit-safe, which is left for a follow-up.
+func (*ConcatStepEvaluator) SetMaxOutputSeries(int) {}
+
 // NewResultStepEvaluator coerces a downstream vector or matrix into a StepEvaluator
 func NewResultStepEvaluator(res logqlmodel.Result, params Params) (StepEvaluator, error) {
 	var (

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -405,6 +405,13 @@ func (q *query) evalSample(ctx context.Context, expr syntax.SampleExpr) (promql_
 	}
 	defer util.LogErrorWithContext(ctx, "closing SampleExpr", stepEvaluator.Close)
 
+	maxSeriesCapture := func(id string) int { return q.limits.MaxQuerySeries(ctx, id) }
+	maxSeries := validation.SmallestPositiveIntPerTenant(tenantIDs, maxSeriesCapture)
+	// logs drilldown has special partial results handling, so don't set max output series
+	if !httpreq.IsLogsDrilldownRequest(ctx) {
+		stepEvaluator.SetMaxOutputSeries(maxSeries)
+	}
+
 	next, _, r := stepEvaluator.Next()
 	if stepEvaluator.Error() != nil {
 		return nil, stepEvaluator.Error()
@@ -413,8 +420,6 @@ func (q *query) evalSample(ctx context.Context, expr syntax.SampleExpr) (promql_
 	if next && r != nil {
 		switch vec := r.(type) {
 		case SampleVector:
-			maxSeriesCapture := func(id string) int { return q.limits.MaxQuerySeries(ctx, id) }
-			maxSeries := validation.SmallestPositiveIntPerTenant(tenantIDs, maxSeriesCapture)
 			mfl := false
 			if rae, ok := expr.(*syntax.RangeAggregationExpr); ok && (rae.Operation == syntax.OpRangeTypeFirstWithTimestamp || rae.Operation == syntax.OpRangeTypeLastWithTimestamp) {
 				mfl = true

--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -2728,6 +2728,8 @@ func (m *mockStepEvaluator) Close() error {
 func (m *mockStepEvaluator) Explain(_ Node) {
 }
 
+func (m *mockStepEvaluator) SetMaxOutputSeries(int) {}
+
 // storeSampleResult implements StepResult for testing
 type storeSampleResult struct {
 	vector promql.Vector

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -768,12 +768,9 @@ func (r *RangeVectorEvaluator) Error() error {
 	return r.iter.Error()
 }
 
-// SetMaxOutputSeries does not enforce the limit. A range aggregation emits one
-// series per stream, which is typically far more than the query output once a
-// vector aggregation reduces above it, so the limit cannot be applied here. It
-// would only be sound when this range aggregation is itself the query root with
-// no reducing parent, a case JoinSampleVector already handles.
-func (*RangeVectorEvaluator) SetMaxOutputSeries(int) {}
+// SetMaxOutputSeries forwards the limit to the underlying range vector iterator,
+// which caps the distinct series it holds per window.
+func (r *RangeVectorEvaluator) SetMaxOutputSeries(n int) { r.iter.SetMaxSeries(n) }
 
 type AbsentRangeVectorEvaluator struct {
 	iter RangeVectorIterator

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -430,6 +430,11 @@ type VectorAggEvaluator struct {
 	expr          *syntax.VectorAggregationExpr
 	buf           []byte
 	lb            *labels.Builder
+
+	// maxOutputSeries is the currently enforced only at the level of this evaluator
+	// zero means no limit. todo: push down to child evaluators when possible.
+	maxOutputSeries int
+	err             error
 }
 
 func (e *VectorAggEvaluator) Next() (bool, int64, StepResult) {
@@ -457,6 +462,11 @@ func (e *VectorAggEvaluator) Next() (bool, int64, StepResult) {
 		group, ok := result[groupingKey]
 		// Add a new group if it doesn't exist.
 		if !ok {
+			if e.maxOutputSeries > 0 && len(result) >= e.maxOutputSeries {
+				e.err = logqlmodel.NewSeriesLimitError(e.maxOutputSeries)
+				return false, 0, SampleVector{}
+			}
+
 			var m labels.Labels
 
 			if e.expr.Grouping.Without {
@@ -634,8 +644,22 @@ func (e *VectorAggEvaluator) Close() error {
 }
 
 func (e *VectorAggEvaluator) Error() error {
+	if e.err != nil {
+		return e.err
+	}
 	return e.nextEvaluator.Error()
 }
+
+// SetMaxOutputSeries CAN enforce the limit. A vector aggregation
+// (sum/count/avg/min/max/topk/...) reduces its input, so when it sits on the
+// root path its output is <= the query output and enforcing here never rejects
+// a query the root would accept. The check lives in Next(): the step fails once
+// a single step accumulates more than n distinct groups.
+//
+// It cannot be pushed below this node: the child (a range aggregation) emits one
+// series per stream, i.e. strictly more series than this aggregation produces,
+// so the child's count is not a lower bound on the query output.
+func (e *VectorAggEvaluator) SetMaxOutputSeries(n int) { e.maxOutputSeries = n }
 
 func newRangeAggEvaluator(
 	it iter.PeekingSampleIterator,
@@ -744,6 +768,13 @@ func (r *RangeVectorEvaluator) Error() error {
 	return r.iter.Error()
 }
 
+// SetMaxOutputSeries does not enforce the limit. A range aggregation emits one
+// series per stream, which is typically far more than the query output once a
+// vector aggregation reduces above it, so the limit cannot be applied here. It
+// would only be sound when this range aggregation is itself the query root with
+// no reducing parent, a case JoinSampleVector already handles.
+func (*RangeVectorEvaluator) SetMaxOutputSeries(int) {}
+
 type AbsentRangeVectorEvaluator struct {
 	iter RangeVectorIterator
 	lbs  labels.Labels
@@ -785,6 +816,10 @@ func (r AbsentRangeVectorEvaluator) Error() error {
 	}
 	return r.iter.Error()
 }
+
+// SetMaxOutputSeries does not enforce the limit. absent_over_time emits at most
+// a single synthetic series, so the limit is never relevant here.
+func (*AbsentRangeVectorEvaluator) SetMaxOutputSeries(int) {}
 
 // newBinOpStepEvaluator explicitly does not handle when both legs are literals as
 // it makes the type system simpler and these are reduced in mustNewBinOpExpr
@@ -941,6 +976,21 @@ func (e *BinOpStepEvaluator) Error() error {
 		return util.MultiError(errs)
 	}
 }
+
+// SetMaxOutputSeries does not enforce the limit today: at the root its output
+// already equals the query output, so there is nothing to gain over the
+// enforcement JoinSampleVector performs. This is, however, the most valuable
+// place to push the limit down next:
+//   - `or`: the result is the union of both legs, so output >= each leg. The
+//     limit can be pushed into BOTH operands.
+//   - group_left (CardManyToOne) / group_right (CardOneToMany): the result has
+//     roughly the cardinality of the "many" side (the left / right leg
+//     respectively), so the limit can be pushed into that leg. Caveat: unmatched
+//     "many"-side series are dropped, so this can reject slightly early.
+//
+// It must NOT be pushed into `and`, `unless`, or one-to-one matches: these can
+// drop series, so a leg's count is not a lower bound on the query output.
+func (*BinOpStepEvaluator) SetMaxOutputSeries(int) {}
 
 func matchingSignature(sample promql.Sample, opts *syntax.BinOpOptions) uint64 {
 	if opts == nil || opts.VectorMatching == nil {
@@ -1207,6 +1257,13 @@ func (e *LiteralStepEvaluator) Error() error {
 	return e.nextEv.Error()
 }
 
+// SetMaxOutputSeries (a scalar/vector operation such as `sum(...) / 60`) does
+// not enforce the limit. For arithmetic operators it preserves the vector
+// operand's series one-to-one, so the limit could be pushed into that child; but
+// a filtering comparison without `bool` (e.g. `sum(...) > 5`) drops series, so
+// pushing down is only sound for non-filtering operators. Left to the root.
+func (*LiteralStepEvaluator) SetMaxOutputSeries(int) {}
+
 // VectorIterator return simple vector like (1).
 type VectorIterator struct {
 	stepMs, endMs, currentMs int64
@@ -1245,6 +1302,10 @@ func (r *VectorIterator) Close() error {
 func (r *VectorIterator) Error() error {
 	return nil
 }
+
+// SetMaxOutputSeries does not enforce the limit: a literal vector such as
+// `vector(1)` produces a single series.
+func (*VectorIterator) SetMaxOutputSeries(int) {}
 
 // newLabelReplaceEvaluator
 func newLabelReplaceEvaluator(
@@ -1315,6 +1376,12 @@ func (e *LabelReplaceEvaluator) Close() error {
 func (e *LabelReplaceEvaluator) Error() error {
 	return e.nextEvaluator.Error()
 }
+
+// SetMaxOutputSeries does not enforce the limit and it must never be pushed
+// below label_replace: rewriting a label can merge several distinct input series
+// into a single output series, so its output is <= its input and the input count
+// is not a lower bound on the query output.
+func (*LabelReplaceEvaluator) SetMaxOutputSeries(int) {}
 
 // This is to replace missing timeseries during absent_over_time aggregation.
 func absentLabels(expr syntax.SampleExpr) (labels.Labels, error) {
@@ -1587,6 +1654,11 @@ type VariantsEvaluator struct {
 func (it *VariantsEvaluator) Error() error {
 	return it.err
 }
+
+// SetMaxOutputSeries does not enforce this limit. Variant queries apply their own
+// per-variant series limiting in JoinMultiVariantSampleVector, which this limit
+// does not model.
+func (*VariantsEvaluator) SetMaxOutputSeries(int) {}
 
 // Explain returns a print of the step evaluation tree
 func (it *VariantsEvaluator) Explain(_ Node) {

--- a/pkg/logql/evaluator_test.go
+++ b/pkg/logql/evaluator_test.go
@@ -1,6 +1,8 @@
 package logql
 
 import (
+	"errors"
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -11,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
 )
 
 func TestDefaultEvaluator_DivideByZero(t *testing.T) {
@@ -331,6 +334,56 @@ func TestLiteralStepEvaluator(t *testing.T) {
 	}
 }
 
+func TestVectorAggEvaluator_MaxOutputSeries(t *testing.T) {
+	expr, err := syntax.ParseSampleExpr(`sum by (foo) (count_over_time({app="x"}[1m]))`)
+	require.NoError(t, err)
+	aggExpr := expr.(*syntax.VectorAggregationExpr)
+
+	// a step vector with n distinct values of "foo" produces n aggregation groups.
+	mkVec := func(n int) promql.Vector {
+		vec := make(promql.Vector, 0, n)
+		for i := range n {
+			vec = append(vec, promql.Sample{T: 0, F: 1, Metric: labels.FromStrings("foo", fmt.Sprintf("v%d", i))})
+		}
+		return vec
+	}
+
+	newAgg := func(maxSeries int, vec promql.Vector) *VectorAggEvaluator {
+		e := &VectorAggEvaluator{
+			nextEvaluator: &returnVectorEvaluator{vec: vec},
+			expr:          aggExpr,
+			buf:           make([]byte, 0, 1024),
+			lb:            labels.NewBuilder(labels.EmptyLabels()),
+		}
+		e.SetMaxOutputSeries(maxSeries)
+		return e
+	}
+
+	t.Run("fails fast when a single step exceeds the limit", func(t *testing.T) {
+		e := newAgg(3, mkVec(5))
+		ok, _, _ := e.Next()
+		require.False(t, ok)
+		require.Error(t, e.Error())
+		require.True(t, errors.Is(e.Error(), logqlmodel.ErrLimit))
+	})
+
+	t.Run("passes when at the limit", func(t *testing.T) {
+		e := newAgg(3, mkVec(3))
+		ok, _, r := e.Next()
+		require.True(t, ok)
+		require.NoError(t, e.Error())
+		require.Len(t, r.SampleVector(), 3)
+	})
+
+	t.Run("no limit when unset", func(t *testing.T) {
+		e := newAgg(0, mkVec(5))
+		ok, _, r := e.Next()
+		require.True(t, ok)
+		require.NoError(t, e.Error())
+		require.Len(t, r.SampleVector(), 5)
+	})
+}
+
 type emptyEvaluator struct{}
 
 func (*emptyEvaluator) Next() (ok bool, ts int64, r StepResult) {
@@ -346,6 +399,8 @@ func (*emptyEvaluator) Error() error {
 }
 
 func (*emptyEvaluator) Explain(Node) {}
+
+func (*emptyEvaluator) SetMaxOutputSeries(int) {}
 
 // returnVectorEvaluator returns elements of vector
 // passed in, everytime it's `Next()` is called. Used for testing.
@@ -368,6 +423,8 @@ func (*returnVectorEvaluator) Error() error {
 func (*returnVectorEvaluator) Explain(Node) {
 
 }
+
+func (*returnVectorEvaluator) SetMaxOutputSeries(int) {}
 
 func newReturnVectorEvaluator(vec []float64) *returnVectorEvaluator {
 	testTime := time.Now().Unix()

--- a/pkg/logql/first_last_over_time.go
+++ b/pkg/logql/first_last_over_time.go
@@ -204,6 +204,11 @@ func (*mergeOverTimeStepEvaluator) Close() error { return nil }
 
 func (*mergeOverTimeStepEvaluator) Error() error { return nil }
 
+// SetMaxOutputSeries does not enforce the limit. It merges sharded
+// first/last_over_time results and emits one series per stream; the limit is
+// enforced above it (and by JoinSampleVector).
+func (*mergeOverTimeStepEvaluator) SetMaxOutputSeries(int) {}
+
 func NewMergeFirstOverTimeStepEvaluator(params Params, m []promql.Matrix, offset time.Duration) StepEvaluator {
 	if len(m) == 0 {
 		return EmptyEvaluator[SampleVector]{}

--- a/pkg/logql/matrix.go
+++ b/pkg/logql/matrix.go
@@ -61,3 +61,8 @@ func (m *MatrixStepEvaluator) Next() (bool, int64, StepResult) {
 func (m *MatrixStepEvaluator) Close() error { return nil }
 
 func (m *MatrixStepEvaluator) Error() error { return nil }
+
+// SetMaxOutputSeries does not enforce the limit. It replays a materialized
+// matrix produced downstream (e.g. by a shard); the limit is enforced by the
+// aggregation or the root that consumes it.
+func (*MatrixStepEvaluator) SetMaxOutputSeries(int) {}

--- a/pkg/logql/quantile_over_time_sketch.go
+++ b/pkg/logql/quantile_over_time_sketch.go
@@ -177,6 +177,11 @@ func (e *QuantileSketchStepEvaluator) Error() error {
 	return e.iter.Error()
 }
 
+// SetMaxOutputSeries does not enforce this limit. Probabilistic quantile queries
+// are joined via JoinQuantileSketchVector rather than JoinSampleVector and are
+// not covered by max_query_series enforcement here.
+func (*QuantileSketchStepEvaluator) SetMaxOutputSeries(int) {}
+
 func (e *QuantileSketchStepEvaluator) Explain(parent Node) {
 	parent.Child("QuantileSketch")
 }
@@ -353,6 +358,10 @@ func (*QuantileSketchMatrixStepEvaluator) Close() error { return nil }
 
 func (*QuantileSketchMatrixStepEvaluator) Error() error { return nil }
 
+// SetMaxOutputSeries does not enforce this limit (quantile-sketch path, see
+// QuantileSketchStepEvaluator).
+func (*QuantileSketchMatrixStepEvaluator) SetMaxOutputSeries(int) {}
+
 func (*QuantileSketchMatrixStepEvaluator) Explain(parent Node) {
 	parent.Child("QuantileSketchMatrix")
 }
@@ -398,3 +407,7 @@ func (e *QuantileSketchVectorStepEvaluator) Next() (bool, int64, StepResult) {
 func (*QuantileSketchVectorStepEvaluator) Close() error { return nil }
 
 func (*QuantileSketchVectorStepEvaluator) Error() error { return nil }
+
+// SetMaxOutputSeries does not enforce this limit (quantile-sketch path, see
+// QuantileSketchStepEvaluator).
+func (*QuantileSketchVectorStepEvaluator) SetMaxOutputSeries(int) {}

--- a/pkg/logql/quantile_over_time_sketch_test.go
+++ b/pkg/logql/quantile_over_time_sketch_test.go
@@ -94,6 +94,8 @@ func (e errorRangeVectorIterator) Error() error {
 	return e.err
 }
 
+func (errorRangeVectorIterator) SetMaxSeries(int) {}
+
 type errorStepEvaluator struct {
 	err error
 }

--- a/pkg/logql/quantile_over_time_sketch_test.go
+++ b/pkg/logql/quantile_over_time_sketch_test.go
@@ -112,6 +112,8 @@ func (e errorStepEvaluator) Error() error {
 
 func (e errorStepEvaluator) Explain(Node) {}
 
+func (e errorStepEvaluator) SetMaxOutputSeries(int) {}
+
 func BenchmarkJoinQuantileSketchVector(b *testing.B) {
 	selRange := (5 * time.Second).Nanoseconds()
 	step := (30 * time.Second)

--- a/pkg/logql/range_vector.go
+++ b/pkg/logql/range_vector.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/iter"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/logql/vector"
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
 )
 
 // BatchRangeVectorAggregator aggregates samples for a given range of samples.
@@ -37,6 +38,9 @@ type RangeVectorIterator interface {
 	At() (int64, StepResult)
 	Close() error
 	Error() error
+	// SetMaxSeries bounds the number of distinct series the iterator will hold in
+	// a single range window. Zero means no limit.
+	SetMaxSeries(n int)
 }
 
 func newRangeVectorIterator(
@@ -97,7 +101,14 @@ type batchRangeVectorIterator struct {
 	metrics                              map[string]labels.Labels
 	at                                   []promql.Sample
 	agg                                  BatchRangeVectorAggregator
+
+	// maxSeries bounds the distinct series held in window (0 == no limit); err
+	// latches a series-limit error once a window exceeds it. See SetMaxSeries.
+	maxSeries int
+	err       error
 }
+
+func (r *batchRangeVectorIterator) SetMaxSeries(n int) { r.maxSeries = n }
 
 func (r *batchRangeVectorIterator) Next() bool {
 	// slides the range window to the next position
@@ -118,6 +129,9 @@ func (r *batchRangeVectorIterator) Close() error {
 }
 
 func (r *batchRangeVectorIterator) Error() error {
+	if r.err != nil {
+		return r.err
+	}
 	return r.iter.Err()
 }
 
@@ -163,6 +177,10 @@ func (r *batchRangeVectorIterator) load(start, end int64) {
 		var ok bool
 		series, ok = r.window[lbs]
 		if !ok {
+			if r.maxSeries > 0 && len(r.window) >= r.maxSeries {
+				r.err = logqlmodel.NewSeriesLimitError(r.maxSeries)
+				return
+			}
 			var metric labels.Labels
 			if metric, ok = r.metrics[lbs]; !ok {
 				var err error
@@ -512,7 +530,14 @@ type streamRangeVectorIterator struct {
 	r                                    *syntax.RangeAggregationExpr
 	metrics                              map[string]labels.Labels
 	at                                   []promql.Sample
+
+	// maxSeries bounds the distinct series held per window (0 == no limit); err
+	// latches a series-limit error once a window exceeds it. See SetMaxSeries.
+	maxSeries int
+	err       error
 }
+
+func (r *streamRangeVectorIterator) SetMaxSeries(n int) { r.maxSeries = n }
 
 func (r *streamRangeVectorIterator) Next() bool {
 	// slides the range window to the next position
@@ -535,6 +560,9 @@ func (r *streamRangeVectorIterator) Close() error {
 }
 
 func (r *streamRangeVectorIterator) Error() error {
+	if r.err != nil {
+		return r.err
+	}
 	return r.iter.Err()
 }
 
@@ -555,6 +583,10 @@ func (r *streamRangeVectorIterator) load(start, end int64) {
 		var ok bool
 		rangeAgg, ok = r.windowRangeAgg[lbs]
 		if !ok {
+			if r.maxSeries > 0 && len(r.windowRangeAgg) >= r.maxSeries {
+				r.err = logqlmodel.NewSeriesLimitError(r.maxSeries)
+				return
+			}
 			var metric labels.Labels
 			if _, ok = r.metrics[lbs]; !ok {
 				var err error

--- a/pkg/logql/range_vector_test.go
+++ b/pkg/logql/range_vector_test.go
@@ -2,6 +2,7 @@ package logql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -18,6 +19,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/sketch"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/logql/vector"
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
 )
 
 var samples = []logproto.Sample{
@@ -60,6 +62,96 @@ func newfakePeekingSampleIterator(samples []logproto.Sample) iter.PeekingSampleI
 
 func newSample(t time.Time, v float64, metric labels.Labels) promql.Sample {
 	return promql.Sample{Metric: metric, T: t.UnixMilli(), F: v}
+}
+
+// newNSeriesPeekingIterator returns a peeking sample iterator over n distinct
+// series, each with a single sample at ts. Used to exercise the per-window
+// series limit.
+func newNSeriesPeekingIterator(n int, ts time.Time) iter.PeekingSampleIterator {
+	its := make([]iter.SampleIterator, 0, n)
+	for i := range n {
+		lbl, _ := syntax.ParseLabels(fmt.Sprintf(`{app="foo", id="%d"}`, i))
+		its = append(its, iter.NewSeriesIterator(logproto.Series{
+			Labels:     lbl.String(),
+			Samples:    []logproto.Sample{{Timestamp: ts.UnixNano(), Hash: uint64(i), Value: 1.}},
+			StreamHash: labels.StableHash(lbl),
+		}))
+	}
+	return iter.NewPeekingSampleIterator(iter.NewSortSampleIterator(its))
+}
+
+// TestRangeVectorIterator_MaxSeries verifies that both range vector iterators
+// stop loading and latch a series-limit error once a single window exceeds the
+// max output series limit, and that the window is bounded to the limit.
+func TestRangeVectorIterator_MaxSeries(t *testing.T) {
+	const (
+		maxSeries = 3
+		nSeries   = 5
+	)
+	var (
+		ts       = time.Unix(6, 0)
+		selRange = (5 * time.Second).Nanoseconds()
+		step     = (30 * time.Second).Nanoseconds()
+		start    = time.Unix(10, 0).UnixNano()
+		end      = time.Unix(100, 0).UnixNano()
+		expr     = &syntax.RangeAggregationExpr{Operation: syntax.OpRangeTypeCount}
+	)
+
+	t.Run("streaming", func(t *testing.T) {
+		it := &streamRangeVectorIterator{
+			iter:     newNSeriesPeekingIterator(nSeries, ts),
+			step:     step,
+			end:      end,
+			selRange: selRange,
+			metrics:  map[string]labels.Labels{},
+			r:        expr,
+			current:  start - step,
+		}
+		it.SetMaxSeries(maxSeries)
+
+		require.True(t, it.Next())
+		require.Error(t, it.Error())
+		require.True(t, errors.Is(it.Error(), logqlmodel.ErrLimit))
+		require.Len(t, it.windowRangeAgg, maxSeries)
+	})
+
+	t.Run("batch", func(t *testing.T) {
+		agg, err := aggregator(expr)
+		require.NoError(t, err)
+		it := &batchRangeVectorIterator{
+			iter:     newNSeriesPeekingIterator(nSeries, ts),
+			step:     step,
+			end:      end,
+			selRange: selRange,
+			metrics:  map[string]labels.Labels{},
+			window:   map[string]*promql.Series{},
+			agg:      agg,
+			current:  start - step,
+		}
+		it.SetMaxSeries(maxSeries)
+
+		require.True(t, it.Next())
+		require.Error(t, it.Error())
+		require.True(t, errors.Is(it.Error(), logqlmodel.ErrLimit))
+		require.Len(t, it.window, maxSeries)
+	})
+
+	t.Run("under limit does not error", func(t *testing.T) {
+		it := &streamRangeVectorIterator{
+			iter:     newNSeriesPeekingIterator(maxSeries, ts),
+			step:     step,
+			end:      end,
+			selRange: selRange,
+			metrics:  map[string]labels.Labels{},
+			r:        expr,
+			current:  start - step,
+		}
+		it.SetMaxSeries(maxSeries)
+
+		require.True(t, it.Next())
+		require.NoError(t, it.Error())
+		require.Len(t, it.windowRangeAgg, maxSeries)
+	})
 }
 
 func Benchmark_RangeVectorIteratorCompare(b *testing.B) {

--- a/pkg/logql/step_evaluator.go
+++ b/pkg/logql/step_evaluator.go
@@ -36,6 +36,12 @@ type StepEvaluator interface {
 	Error() error
 	// Explain returns a print of the step evaluation tree
 	Explain(Node)
+	// SetMaxOutputSeries informs the evaluator of the maximum number of output
+	// series the query is allowed to produce. Ideally all implementations would perfectly
+	// detect when the output series should be evaluated at the current level and when it
+	// is safe to push the limit down to child evaluators. We are nowhere near this. Currently
+	// we have some basic implementations only at the root for some evaluators
+	SetMaxOutputSeries(n int)
 }
 
 type EmptyEvaluator[R StepResult] struct {
@@ -54,3 +60,7 @@ func (EmptyEvaluator[_]) Error() error { return nil }
 func (e EmptyEvaluator[_]) Next() (ok bool, ts int64, r StepResult) {
 	return false, 0, e.value
 }
+
+// SetMaxOutputSeries implements StepEvaluator. EmptyEvaluator produces no
+// series, so the limit is a no-op.
+func (EmptyEvaluator[_]) SetMaxOutputSeries(int) {}

--- a/pkg/logql/step_evaluator.go
+++ b/pkg/logql/step_evaluator.go
@@ -39,8 +39,9 @@ type StepEvaluator interface {
 	// SetMaxOutputSeries informs the evaluator of the maximum number of output
 	// series the query is allowed to produce. Ideally all implementations would perfectly
 	// detect when the output series should be evaluated at the current level and when it
-	// is safe to push the limit down to child evaluators. We are nowhere near this. Currently
-	// we have some basic implementations only at the root for some evaluators
+	// is safe to push the limit down to child evaluators. We are nowhere near this and it would be quite
+	// difficult. Implementing this should be done carefully. Currently we are only setting this at the
+	// root level in evalSample and never pushing down.
 	SetMaxOutputSeries(n int)
 }
 

--- a/pkg/logql/vector.go
+++ b/pkg/logql/vector.go
@@ -94,3 +94,7 @@ func (e *VectorStepEvaluator) Close() error {
 func (e *VectorStepEvaluator) Error() error {
 	return nil
 }
+
+// SetMaxOutputSeries does not enforce the limit. It replays a materialized
+// vector produced downstream; the limit is enforced above it.
+func (*VectorStepEvaluator) SetMaxOutputSeries(int) {}


### PR DESCRIPTION
**What this PR does**: pushes the `max_query_series` limit down the v1 LogQL evaluator tree so high-cardinality queries fail fast — and with bounded memory — instead of only being caught at the root in `JoinSampleVector` after a full step is already materialized.

It adds `SetMaxOutputSeries` to the `StepEvaluator` interface, set once on the root evaluator in `evalSample`. Each evaluator decides whether it can soundly enforce it (only sound when the node's output series count is `<=` the query output). Two do so today:
- `VectorAggEvaluator` — fails once a single step exceeds the limit of distinct groups.
- the streaming + batch range vector iterators — cap the distinct series held per window and fail on the limit+1'th, so we stop loading instead of materializing millions of series. This is the one that actually bounds memory.

Everything else is a documented no-op for now; pushing into `or` operands / the many-side of `group_left` is a follow-up.

**Enforced one level deeper** — the range aggregation is the root, so the iterator caps it:
```
count_over_time({app="foo"} | pattern "<message>" [1h])
rate({app="foo"}[5m])
```

**Limit stays above the range aggregation** — a parent holds it and the range agg never sees it:
```
sum(count_over_time({app="foo"} | pattern "<message>" [1h]))
count_over_time(...) or count_over_time(...)
```
The `sum(...)` case is the known gap: its output is 1 series so nothing trips, yet the range agg underneath still loads every series into memory. Bounding that needs a separate intermediate-cardinality limit and is left as a follow-up.

`JoinSampleVector` stays as the backstop and Logs Drilldown is excluded (it wants partial results), so no query outcome changes — this just fails earlier and cheaper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)