### PR TITLE
chore(engine): Support discard frames in the scheduler wire protocol 🤖🤖🤖

### DIFF
--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -149,7 +149,13 @@ func (s *Scheduler) handleConn(ctx context.Context, conn wire.Conn) {
 	logger := log.With(s.logger, "remote_addr", conn.RemoteAddr())
 	level.Info(logger).Log("msg", "handling connection")
 
+	// connCtx is scoped to this connection so goroutines started for it (e.g.
+	// workerLoop) stop when it closes, independent of any single message handler.
+	connCtx, cancelConn := context.WithCancel(ctx)
+	defer cancelConn()
+
 	wc := &workerConn{
+		ctx:  connCtx,
 		done: make(chan struct{}),
 		wake: make(chan struct{}, 1),
 	}
@@ -198,7 +204,7 @@ func (s *Scheduler) handleMessage(ctx context.Context, worker *workerConn, msg w
 	case wire.WorkerHelloMessage:
 		return s.handleWorkerHello(ctx, worker, msg)
 	case wire.WorkerReadyMessage:
-		return s.markWorkerReady(ctx, worker)
+		return s.markWorkerReady(worker)
 	case wire.TaskStatusMessage:
 		return s.handleTaskStatus(ctx, worker, msg)
 	case wire.StreamStatusMessage:
@@ -246,7 +252,7 @@ func (s *Scheduler) handleWorkerHello(ctx context.Context, worker *workerConn, m
 	return nil
 }
 
-func (s *Scheduler) markWorkerReady(ctx context.Context, worker *workerConn) (err error) {
+func (s *Scheduler) markWorkerReady(worker *workerConn) (err error) {
 	phases := s.metrics.startHandler(wire.WorkerReadyMessage{}.Kind())
 	defer func() { phases.Done(handlerOutcome(err)) }()
 
@@ -264,7 +270,10 @@ func (s *Scheduler) markWorkerReady(ctx context.Context, worker *workerConn) (er
 		nudgeSemaphore(worker.wake)
 	} else {
 		s.connectedWorkers[worker] = struct{}{}
-		go s.workerLoop(ctx, worker)
+		// workerLoop outlives this WorkerReady handler, so it runs under the
+		// connection context, not the handler's (which ends when the handler
+		// returns).
+		go s.workerLoop(worker.ctx, worker)
 	}
 
 	// Wake [Scheduler.runAssignLoop] so it feeds tasks into tasksCh.

--- a/pkg/engine/internal/scheduler/wire/metrics.go
+++ b/pkg/engine/internal/scheduler/wire/metrics.go
@@ -67,6 +67,7 @@ const (
 	outcomeCanceled   metrictimer.Outcome = "canceled"
 	outcomeConnClosed metrictimer.Outcome = "conn_closed"
 	outcomeSendError  metrictimer.Outcome = "send_error"
+	outcomeDiscarded  metrictimer.Outcome = "discarded"
 )
 
 // phase label values for frame send and receive histograms.

--- a/pkg/engine/internal/scheduler/wire/metrics_test.go
+++ b/pkg/engine/internal/scheduler/wire/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/go-kit/log"
@@ -245,42 +246,47 @@ func TestPeer_Metrics_BlockedOutgoingQueue(t *testing.T) {
 }
 
 func TestPeer_Metrics_LocalRoundTripFrameLabels(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	clientMetrics := NewMetrics()
-	client := &Peer{Logger: log.NewNopLogger(), Metrics: clientMetrics, Buffer: 4}
-	server := &Peer{
-		Logger:  log.NewNopLogger(),
-		Metrics: NewMetrics(),
-		Buffer:  4,
-		Handler: func(context.Context, *Peer, Message) error { return nil },
-	}
-	peerPair(ctx, t, client, server)
+		clientMetrics := NewMetrics()
+		client := &Peer{Logger: log.NewNopLogger(), Metrics: clientMetrics, Buffer: 4}
+		server := &Peer{
+			Logger:  log.NewNopLogger(),
+			Metrics: NewMetrics(),
+			Buffer:  4,
+			Handler: func(context.Context, *Peer, Message) error { return nil },
+		}
+		peerPair(ctx, t, client, server)
 
-	require.NoError(t, client.SendMessage(ctx, WorkerReadyMessage{}))
+		require.NoError(t, client.SendMessage(ctx, WorkerReadyMessage{}))
 
-	messageType := WorkerReadyMessage{}.Kind().String()
-	// A local send times only the connection total (the dropped
-	// local_channel_send phase equalled it), which also feeds write_busy.
-	require.Equal(t, uint64(1), histogramCount(t, clientMetrics.reg,
-		"loki_engine_scheduler_wire_frame_send_seconds",
-		map[string]string{
-			"phase":        phaseConnSendTotal.String(),
-			"transport":    transportLocal.String(),
-			"frame_type":   FrameKindMessage.String(),
-			"message_type": messageType,
-			"mode":         sendModeSync.String(),
-		}))
-	require.Equal(t, uint64(1), histogramCount(t, clientMetrics.reg,
-		"loki_engine_scheduler_wire_frame_receive_seconds",
-		map[string]string{
-			"phase":        phaseLocalChannelReceive.String(),
-			"transport":    transportLocal.String(),
-			"frame_type":   FrameKindAck.String(),
-			"message_type": "none",
-			"mode":         sendModeInternal.String(),
-		}))
+		// Wait for the outgoing goroutine to record the send-side metric.
+		synctest.Wait()
+
+		messageType := WorkerReadyMessage{}.Kind().String()
+		// A local send times only the connection total (the dropped
+		// local_channel_send phase equalled it), which also feeds write_busy.
+		require.Equal(t, uint64(1), histogramCount(t, clientMetrics.reg,
+			"loki_engine_scheduler_wire_frame_send_seconds",
+			map[string]string{
+				"phase":        phaseConnSendTotal.String(),
+				"transport":    transportLocal.String(),
+				"frame_type":   FrameKindMessage.String(),
+				"message_type": messageType,
+				"mode":         sendModeSync.String(),
+			}))
+		require.Equal(t, uint64(1), histogramCount(t, clientMetrics.reg,
+			"loki_engine_scheduler_wire_frame_receive_seconds",
+			map[string]string{
+				"phase":        phaseLocalChannelReceive.String(),
+				"transport":    transportLocal.String(),
+				"frame_type":   FrameKindAck.String(),
+				"message_type": "none",
+				"mode":         sendModeInternal.String(),
+			}))
+	})
 }
 
 // TestHTTP2WriteBusyExcludesLockWait proves that the write-lock wait on an

--- a/pkg/engine/internal/scheduler/wire/peer.go
+++ b/pkg/engine/internal/scheduler/wire/peer.go
@@ -35,6 +35,17 @@ type Peer struct {
 
 	requestID    atomic.Uint64
 	sentRequests sync.Map // map[uint64]*request
+	inflight     sync.Map // map[uint64]*inflightHandler
+}
+
+// errDiscarded is the cancel cause set on a handler's context by a DiscardFrame.
+var errDiscarded = errors.New("message discarded by remote peer")
+
+// inflightHandler tracks an in-flight incoming message; the incoming
+// counterpart to [request].
+type inflightHandler struct {
+	ctx    context.Context // Canceled with errDiscarded when the message is discarded.
+	cancel context.CancelCauseFunc
 }
 
 // outgoingFrame wraps a Frame queued for sending with the metadata needed to
@@ -62,6 +73,10 @@ type incomingMessage struct {
 // Once Handler returns, the sending peer will be informed about the
 // message delivery status. If Handler returns an error, the error
 // message will be sent to the peer.
+//
+// ctx is scoped to this message: it is canceled when Handler returns or when
+// the peer discards the message. Work that must outlive Handler must not use
+// it.
 type Handler func(ctx context.Context, peer *Peer, message Message) error
 
 // Serve runs the peer, blocking until the provided context is canceled.
@@ -120,6 +135,10 @@ func (p *Peer) recvMessages(ctx context.Context) error {
 func (p *Peer) routeFrame(ctx context.Context, frame Frame) error {
 	switch frame := frame.(type) {
 	case MessageFrame:
+		// Register the in-flight entry before enqueueing so a DiscardFrame routed
+		// after it (in arrival order) can cancel the handler.
+		handlerCtx, cancel := context.WithCancelCause(ctx)
+		p.inflight.Store(frame.ID, &inflightHandler{ctx: handlerCtx, cancel: cancel})
 		return p.enqueueIncoming(ctx, frame)
 
 	case AckFrame:
@@ -153,7 +172,10 @@ func (p *Peer) routeFrame(ctx context.Context, frame Frame) error {
 		}
 
 	case DiscardFrame:
-		// TODO(rfratto): cancel handleMessage goroutine
+		// Cancel the handler; an unknown ID already finished, so it's a no-op.
+		if v, ok := p.inflight.Load(frame.ID); ok {
+			v.(*inflightHandler).cancel(errDiscarded)
+		}
 
 	default:
 		level.Warn(p.Logger).Log("msg", "unknown frame type", "type", reflect.TypeOf(frame).String())
@@ -193,9 +215,23 @@ func (p *Peer) handleIncoming(ctx context.Context) error {
 			return nil // Closed connection.
 		case queued := <-p.incoming:
 			frame := p.dequeueIncoming(queued)
-			p.processMessage(ctx, frame.ID, frame.Message)
+			p.handleMessage(ctx, frame.ID, frame.Message)
 		}
 	}
+}
+
+// handleMessage runs id's handler under its per-message context (so a
+// DiscardFrame can cancel it) and releases the in-flight entry afterward.
+func (p *Peer) handleMessage(ctx context.Context, id uint64, message Message) {
+	if v, ok := p.inflight.Load(id); ok {
+		h := v.(*inflightHandler)
+		ctx = h.ctx
+		defer func() {
+			p.inflight.Delete(id)
+			h.cancel(nil)
+		}()
+	}
+	p.processMessage(ctx, id, message)
 }
 
 func (p *Peer) handleOutgoing(ctx context.Context) error {
@@ -273,12 +309,27 @@ func (p *Peer) processMessage(ctx context.Context, id uint64, message Message) {
 	outcome := outcomeNack
 	defer func() { timer.Done(outcome) }()
 
+	// Drop a message discarded before the handler started.
+	if context.Cause(ctx) == errDiscarded {
+		outcome = outcomeDiscarded
+		return
+	}
+
 	if p.Handler == nil {
 		_ = p.enqueueFrame(ctx, NackFrame{ID: id, Error: Errorf(http.StatusNotImplemented, "not implemented")}, sendModeInternal)
 		return
 	}
 
-	switch err := p.Handler(ctx, p, message); err {
+	err := p.Handler(ctx, p, message)
+
+	// Skip the response if the message was discarded while the handler ran. A
+	// discard racing in just after this check still acks, but that ack is ignored.
+	if context.Cause(ctx) == errDiscarded {
+		outcome = outcomeDiscarded
+		return
+	}
+
+	switch err {
 	case nil:
 		outcome = outcomeAck
 		// TODO(rfratto): What should we do if this fails? Logs? Metrics?

--- a/pkg/engine/internal/scheduler/wire/peer.go
+++ b/pkg/engine/internal/scheduler/wire/peer.go
@@ -384,7 +384,8 @@ func (p *Peer) SendMessage(ctx context.Context, message Message) error {
 
 	select {
 	case <-ctx.Done():
-		// TODO(rfratto): queue a DiscardFrame
+		// Tell the remote peer we don't care about the result anymore.
+		p.queueDiscard(reqID)
 		outcome = contextOutcome(ctx)
 		return ctx.Err()
 	case <-p.done:
@@ -393,6 +394,19 @@ func (p *Peer) SendMessage(ctx context.Context, message Message) error {
 	case err := <-req.result:
 		outcome = resultOutcome(err)
 		return err
+	}
+}
+
+// queueDiscard tells the remote peer to stop processing message id. It does not
+// block, and drops the discard if the outgoing queue is full.
+func (p *Peer) queueDiscard(id uint64) {
+	frame := DiscardFrame{ID: id}
+	queued := outgoingFrame{frame: frame, sendMode: sendModeInternal, enqueuedAt: time.Now()}
+	select {
+	case p.outgoing <- queued:
+		p.noteFrameEnqueued(queueOutgoing, frame, sendModeInternal)
+	default:
+		level.Debug(p.Logger).Log("msg", "dropping discard frame; outgoing queue full", "id", id)
 	}
 }
 

--- a/pkg/engine/internal/scheduler/wire/peer_internal_test.go
+++ b/pkg/engine/internal/scheduler/wire/peer_internal_test.go
@@ -1,0 +1,32 @@
+package wire
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPeer_processMessageHonorsDiscard covers nil-handler and unknown-ID discards.
+func TestPeer_processMessageHonorsDiscard(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("discarded message is dropped and its entry released", func(t *testing.T) {
+		p := &Peer{Metrics: NewMetrics(), Buffer: 4}
+		p.lazyInit()
+
+		hctx, cancel := context.WithCancelCause(ctx)
+		p.inflight.Store(uint64(1), &inflightHandler{ctx: hctx, cancel: cancel})
+		cancel(errDiscarded)
+		p.handleMessage(ctx, 1, WorkerReadyMessage{})
+
+		_, ok := p.inflight.Load(uint64(1))
+		require.False(t, ok, "entry should be released")
+		require.Empty(t, p.outgoing, "a discarded message must not be acked or nacked")
+	})
+
+	t.Run("discard for an unknown id is a no-op", func(t *testing.T) {
+		p := &Peer{}
+		require.NoError(t, p.routeFrame(ctx, DiscardFrame{ID: 999}))
+	})
+}

--- a/pkg/engine/internal/scheduler/wire/peer_internal_test.go
+++ b/pkg/engine/internal/scheduler/wire/peer_internal_test.go
@@ -3,9 +3,38 @@ package wire
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 )
+
+// TestPeer_SendMessageCancelDoesNotBlockOnFullQueue verifies canceling
+// SendMessage returns promptly with a full outgoing queue.
+func TestPeer_SendMessageCancelDoesNotBlockOnFullQueue(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Buffer 1 and no Serve: the message frame fills the only outgoing slot.
+		p := &Peer{Logger: log.NewNopLogger(), Metrics: NewMetrics(), Buffer: 1}
+		p.lazyInit()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		sendErr := make(chan error, 1)
+		go func() { sendErr <- p.SendMessage(ctx, WorkerReadyMessage{}) }()
+
+		synctest.Wait() // The message frame has taken the only outgoing slot.
+		require.Len(t, p.outgoing, 1)
+
+		cancel()
+		synctest.Wait()
+		select {
+		case err := <-sendErr:
+			require.ErrorIs(t, err, context.Canceled)
+		default:
+			t.Fatal("SendMessage did not return after cancellation with a full outgoing queue")
+		}
+	})
+}
 
 // TestPeer_processMessageHonorsDiscard covers nil-handler and unknown-ID discards.
 func TestPeer_processMessageHonorsDiscard(t *testing.T) {

--- a/pkg/engine/internal/scheduler/wire/peer_test.go
+++ b/pkg/engine/internal/scheduler/wire/peer_test.go
@@ -106,6 +106,40 @@ func TestPeer_DiscardDropsQueuedMessage(t *testing.T) {
 	})
 }
 
+// TestPeer_SendMessageCancelEmitsDiscard verifies canceling SendMessage cancels
+// the remote handler.
+func TestPeer_SendMessageCancelEmitsDiscard(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+
+		started, canceled := make(chan struct{}), make(chan struct{})
+		handler := func(hctx context.Context, _ *wire.Peer, _ wire.Message) error {
+			close(started)
+			<-hctx.Done()
+			close(canceled)
+			return hctx.Err()
+		}
+
+		clientConn, serverConn := dialLocal(ctx, t)
+		defer serve(ctx, newServer(serverConn, handler))()
+		client := &wire.Peer{Logger: log.NewNopLogger(), Metrics: wire.NewMetrics(), Conn: clientConn, Buffer: 4}
+		defer serve(ctx, client)()
+
+		sendCtx, sendCancel := context.WithCancel(ctx)
+		sendErr := make(chan error, 1)
+		go func() { sendErr <- client.SendMessage(sendCtx, wire.WorkerReadyMessage{}) }()
+
+		synctest.Wait()
+		requireClosed(t, started, "server handler did not start")
+
+		sendCancel()
+		synctest.Wait()
+		requireClosed(t, canceled, "server handler was not canceled by the discard")
+		require.ErrorIs(t, <-sendErr, context.Canceled)
+	})
+}
+
+// dialLocal returns a connected Local Conn pair.
 func dialLocal(ctx context.Context, t *testing.T) (client, server wire.Conn) {
 	t.Helper()
 

--- a/pkg/engine/internal/scheduler/wire/peer_test.go
+++ b/pkg/engine/internal/scheduler/wire/peer_test.go
@@ -1,0 +1,152 @@
+package wire_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"testing/synctest"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
+)
+
+// TestPeer_DiscardCancelsRunningHandler verifies a discard cancels a running
+// handler and suppresses its ack.
+func TestPeer_DiscardCancelsRunningHandler(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+
+		started, canceled := make(chan struct{}), make(chan struct{})
+		handler := func(hctx context.Context, _ *wire.Peer, m wire.Message) error {
+			if _, ok := m.(wire.TaskStatusMessage); ok { // the discarded message
+				close(started)
+				<-hctx.Done()
+				close(canceled)
+				return hctx.Err()
+			}
+			return nil // probe
+		}
+
+		client, serverConn := dialLocal(ctx, t)
+		defer serve(ctx, newServer(serverConn, handler))()
+
+		require.NoError(t, client.Send(ctx, wire.MessageFrame{ID: 1, Message: wire.TaskStatusMessage{}}))
+		synctest.Wait()
+		requireClosed(t, started, "handler did not start")
+
+		require.NoError(t, client.Send(ctx, wire.DiscardFrame{ID: 1}))
+		synctest.Wait()
+		requireClosed(t, canceled, "handler was not canceled by the discard")
+
+		// A probe's ack should be the only reply, proving message 1 wasn't acked.
+		require.NoError(t, client.Send(ctx, wire.MessageFrame{ID: 2, Message: wire.WorkerReadyMessage{}}))
+		frame, err := client.Recv(ctx)
+		require.NoError(t, err)
+		ack, ok := frame.(wire.AckFrame)
+		require.True(t, ok, "expected an ack, got %#v", frame)
+		require.Equal(t, uint64(2), ack.ID, "message 1 should not have been acked")
+	})
+}
+
+// TestPeer_DiscardDropsQueuedMessage verifies a discard for a queued message
+// skips its handler and ack.
+func TestPeer_DiscardDropsQueuedMessage(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+
+		release, firstStarted := make(chan struct{}), make(chan struct{})
+		var secondHandled atomic.Bool
+		handler := func(hctx context.Context, _ *wire.Peer, m wire.Message) error {
+			switch m.(type) {
+			case wire.TaskStatusMessage: // blocks handleIncoming
+				close(firstStarted)
+				select {
+				case <-release:
+				case <-hctx.Done():
+				}
+			case wire.WorkerReadyMessage: // discarded; must not run
+				secondHandled.Store(true)
+			}
+			return nil // probe
+		}
+
+		client, serverConn := dialLocal(ctx, t)
+		defer serve(ctx, newServer(serverConn, handler))()
+
+		require.NoError(t, client.Send(ctx, wire.MessageFrame{ID: 1, Message: wire.TaskStatusMessage{}}))
+		synctest.Wait()
+		requireClosed(t, firstStarted, "first handler did not start")
+
+		// Queue message 2, then discard it before the handler is free.
+		require.NoError(t, client.Send(ctx, wire.MessageFrame{ID: 2, Message: wire.WorkerReadyMessage{}}))
+		synctest.Wait()
+		require.NoError(t, client.Send(ctx, wire.DiscardFrame{ID: 2}))
+		synctest.Wait()
+
+		close(release)
+		synctest.Wait()
+		require.False(t, secondHandled.Load(), "discarded message must not be handled")
+
+		frame, err := client.Recv(ctx)
+		require.NoError(t, err)
+		ack, ok := frame.(wire.AckFrame)
+		require.True(t, ok, "expected an ack, got %#v", frame)
+		require.Equal(t, uint64(1), ack.ID)
+
+		// The next ack should be a probe's, proving message 2 wasn't acked.
+		require.NoError(t, client.Send(ctx, wire.MessageFrame{ID: 3, Message: wire.WorkerHelloMessage{}}))
+		frame, err = client.Recv(ctx)
+		require.NoError(t, err)
+		ack, ok = frame.(wire.AckFrame)
+		require.True(t, ok, "expected an ack, got %#v", frame)
+		require.Equal(t, uint64(3), ack.ID, "message 2 should not have been acked")
+	})
+}
+
+func dialLocal(ctx context.Context, t *testing.T) (client, server wire.Conn) {
+	t.Helper()
+
+	listener := &wire.Local{Address: wire.LocalScheduler}
+	t.Cleanup(func() { _ = listener.Close(context.Background()) })
+
+	type result struct {
+		conn wire.Conn
+		err  error
+	}
+	accepted := make(chan result, 1)
+	go func() {
+		c, err := listener.Accept(ctx)
+		accepted <- result{c, err}
+	}()
+
+	client, err := listener.DialFrom(ctx, wire.LocalWorker)
+	require.NoError(t, err)
+	r := <-accepted
+	require.NoError(t, r.err)
+	return client, r.conn
+}
+
+// serve runs peer.Serve and returns a func to stop it and wait for exit.
+func serve(ctx context.Context, peer *wire.Peer) (stop func()) {
+	serveCtx, cancel := context.WithCancel(ctx)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { defer wg.Done(); _ = peer.Serve(serveCtx) }()
+	return func() { cancel(); wg.Wait() }
+}
+
+func requireClosed(t *testing.T, ch <-chan struct{}, msg string) {
+	t.Helper()
+	select {
+	case <-ch:
+	default:
+		t.Fatal(msg)
+	}
+}
+
+func newServer(conn wire.Conn, handler wire.Handler) *wire.Peer {
+	return &wire.Peer{Logger: log.NewNopLogger(), Metrics: wire.NewMetrics(), Conn: conn, Handler: handler, Buffer: 4}
+}

--- a/pkg/engine/internal/scheduler/worker_conn.go
+++ b/pkg/engine/internal/scheduler/worker_conn.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"maps"
@@ -55,6 +56,11 @@ func (t connectionType) String() string {
 type workerConn struct {
 	// Peer connection to the worker.
 	*wire.Peer
+
+	// ctx is scoped to the lifetime of the connection. Long-lived goroutines
+	// started from a message handler (whose own context ends when the handler
+	// returns) must run under this instead.
+	ctx context.Context
 
 	// mutex of the worker. Protects all fields.
 	mut sync.RWMutex


### PR DESCRIPTION
The scheduler wire protocol defined a DiscardFrame that never got sent or used. This PR adds support for it on both sides.
