### PR TITLE
fix(ruler): Allow partial per-tenant remote_write config overrides

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -246,7 +246,7 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus/alertmanager v0.33.0 // indirect
-	github.com/prometheus/client_golang/exp v0.0.0-20260624042014-28914d017fba // indirect
+	github.com/prometheus/client_golang/exp v0.0.0-20260624042014-28914d017fba
 	github.com/puzpuzpuz/xsync/v4 v4.5.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/pkg/ruler/base/error_translate_queryable.go
+++ b/pkg/ruler/base/error_translate_queryable.go
@@ -11,8 +11,14 @@ import (
 	"github.com/prometheus/prometheus/util/annotations"
 
 	storage_errors "github.com/grafana/loki/v3/pkg/storage/errors"
-	"github.com/grafana/loki/v3/pkg/validation"
 )
+
+// LimitError are errors that do not comply with the limits specified.
+type LimitError string
+
+func (e LimitError) Error() string {
+	return string(e)
+}
 
 // TranslateToPromqlAPIError converts error to one of promql.Errors for consumption in PromQL API.
 // PromQL API only recognizes few errors, and converts everything else to HTTP status code 422.
@@ -38,7 +44,7 @@ func TranslateToPromqlAPIError(err error) error {
 	case promql.ErrStorage, promql.ErrTooManySamples, promql.ErrQueryCanceled, promql.ErrQueryTimeout:
 		// Don't translate those, just in case we use them internally.
 		return err
-	case storage_errors.QueryError, validation.LimitError:
+	case storage_errors.QueryError, LimitError:
 		// This will be returned with status code 422 by Prometheus API.
 		return err
 	default:

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/model/timestamp"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	ruler "github.com/grafana/loki/v3/pkg/ruler/base"
+	rulerconfig "github.com/grafana/loki/v3/pkg/ruler/config"
 	"github.com/grafana/loki/v3/pkg/ruler/rulespb"
 	rulerutil "github.com/grafana/loki/v3/pkg/ruler/util"
 	"github.com/grafana/loki/v3/pkg/util"
@@ -42,7 +42,7 @@ type RulesLimits interface {
 	RulerRemoteWriteTimeout(userID string) time.Duration
 	RulerRemoteWriteHeaders(userID string) map[string]string
 	RulerRemoteWriteRelabelConfigs(userID string) []*rulerutil.RelabelConfig
-	RulerRemoteWriteConfig(userID string, id string) *config.RemoteWriteConfig
+	RulerRemoteWriteConfig(userID string, id string) *rulerconfig.RemoteWriteConfig
 	RulerRemoteWriteQueueCapacity(userID string) int
 	RulerRemoteWriteQueueMinShards(userID string) int
 	RulerRemoteWriteQueueMaxShards(userID string) int

--- a/pkg/ruler/config.go
+++ b/pkg/ruler/config.go
@@ -7,16 +7,16 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/config"
+	promconfig "github.com/prometheus/prometheus/config"
 	"go.yaml.in/yaml/v4"
 
-	ruler "github.com/grafana/loki/v3/pkg/ruler/base"
+	rulerbase "github.com/grafana/loki/v3/pkg/ruler/base"
 	"github.com/grafana/loki/v3/pkg/ruler/storage/cleaner"
 	"github.com/grafana/loki/v3/pkg/ruler/storage/instance"
 )
 
 type Config struct {
-	ruler.Config `yaml:",inline"`
+	rulerbase.Config `yaml:",inline"`
 
 	WAL instance.Config `yaml:"wal,omitempty"`
 	// we cannot define this in the WAL config since it creates an import cycle
@@ -53,11 +53,11 @@ func (c *Config) Validate() error {
 }
 
 type RemoteWriteConfig struct {
-	Client              *config.RemoteWriteConfig           `yaml:"client,omitempty" doc:"deprecated|description=Use 'clients' instead. Configure remote write client."`
-	Clients             map[string]config.RemoteWriteConfig `yaml:"clients,omitempty" doc:"description=Configure remote write clients. A map with remote client id as key. For details, see https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write Specifying a header with key 'X-Scope-OrgID' under the 'headers' section of RemoteWriteConfig is not permitted. If specified, it will be dropped during config parsing."`
-	Enabled             bool                                `yaml:"enabled"`
-	ConfigRefreshPeriod time.Duration                       `yaml:"config_refresh_period"`
-	AddOrgIDHeader      bool                                `yaml:"add_org_id_header" doc:"description=Add an X-Scope-OrgID header in remote write requests with the tenant ID of a Loki tenant that the recording rules are part of."`
+	Client              *promconfig.RemoteWriteConfig           `yaml:"client,omitempty" doc:"deprecated|description=Use 'clients' instead. Configure remote write client."`
+	Clients             map[string]promconfig.RemoteWriteConfig `yaml:"clients,omitempty" doc:"description=Configure remote write clients. A map with remote client id as key. For details, see https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write Specifying a header with key 'X-Scope-OrgID' under the 'headers' section of RemoteWriteConfig is not permitted. If specified, it will be dropped during config parsing."`
+	Enabled             bool                                    `yaml:"enabled"`
+	ConfigRefreshPeriod time.Duration                           `yaml:"config_refresh_period"`
+	AddOrgIDHeader      bool                                    `yaml:"add_org_id_header" doc:"description=Add an X-Scope-OrgID header in remote write requests with the tenant ID of a Loki tenant that the recording rules are part of."`
 }
 
 func (c *RemoteWriteConfig) Validate() error {
@@ -125,6 +125,6 @@ func (c *RemoteWriteConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&c.ConfigRefreshPeriod, "ruler.remote-write.config-refresh-period", 10*time.Second, "Minimum period to wait between refreshing remote-write reconfigurations. This should be greater than or equivalent to -runtime-config.reload-period.")
 
 	if c.Clients == nil {
-		c.Clients = make(map[string]config.RemoteWriteConfig)
+		c.Clients = make(map[string]promconfig.RemoteWriteConfig)
 	}
 }

--- a/pkg/ruler/config/remotewrite.go
+++ b/pkg/ruler/config/remotewrite.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	remoteapi "github.com/prometheus/client_golang/exp/api/remote"
+	commonconfig "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	promconfig "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/prometheus/prometheus/storage/remote/azuread"
+	"github.com/prometheus/prometheus/storage/remote/googleiam"
+	"github.com/prometheus/sigv4"
+)
+
+// RemoteWriteConfig is the per-tenant overrides configuration for remote write.
+// This is a copy of the [promconfig.RemoteWriteConfig] without custom unmarshaling.
+// It is needed because we don't want field validation during unmarshaling, e.g. for null values.
+// That allows tenants to specify only a subset of fields in the overrides.
+type RemoteWriteConfig struct {
+	URL                  *commonconfig.URL `yaml:"url,omitempty"`
+	RemoteTimeout        model.Duration    `yaml:"remote_timeout,omitempty"`
+	Headers              map[string]string `yaml:"headers,omitempty"`
+	WriteRelabelConfigs  []*relabel.Config `yaml:"write_relabel_configs,omitempty"`
+	Name                 string            `yaml:"name,omitempty"`
+	SendExemplars        bool              `yaml:"send_exemplars,omitempty"`
+	SendNativeHistograms bool              `yaml:"send_native_histograms,omitempty"`
+	RoundRobinDNS        bool              `yaml:"round_robin_dns,omitempty"`
+	// ProtobufMessage specifies the protobuf message to use against the remote
+	// receiver as specified in https://prometheus.io/docs/specs/remote_write_spec_2_0/
+	ProtobufMessage remoteapi.WriteMessageType `yaml:"protobuf_message,omitempty"`
+
+	// // We cannot do proper Go type embedding below as the parser will then parse
+	// // values arbitrarily into the overflow maps of further-down types.
+	HTTPClientConfig commonconfig.HTTPClientConfig `yaml:",inline"`
+	QueueConfig      promconfig.QueueConfig        `yaml:"queue_config,omitempty"`
+	MetadataConfig   promconfig.MetadataConfig     `yaml:"metadata_config,omitempty"`
+	SigV4Config      *sigv4.SigV4Config            `yaml:"sigv4,omitempty"`
+	AzureADConfig    *azuread.AzureADConfig        `yaml:"azuread,omitempty"`
+	GoogleIAMConfig  *googleiam.Config             `yaml:"google_iam,omitempty"`
+}
+
+// Static check to ensure safe conversion between structs
+var _ = (*promconfig.RemoteWriteConfig)(&RemoteWriteConfig{})

--- a/pkg/ruler/registry.go
+++ b/pkg/ruler/registry.go
@@ -359,8 +359,9 @@ func (r *walRegistry) getTenantRemoteWriteConfig(tenant string, base RemoteWrite
 				clt.WriteRelabelConfigs = v.WriteRelabelConfigs
 			}
 
-			// Cast [rulerconfig.RemoteWriteOverridesConfig] to [config.RemoteWriteConfig] so it can be used to merge with [clt].
-			// This can be done safely because the structs are identical.
+			// Cast [rulerconfig.RemoteWriteConfig] to [config.RemoteWriteConfig] so it can be used to merge with [clt].
+			// This can be done safely without copying, because the structs are identical
+			// and mergo only reads [casted].
 			casted := (*config.RemoteWriteConfig)(v)
 			// merge with override
 			if err := mergo.Merge(&clt, casted, mergo.WithOverride); err != nil {

--- a/pkg/ruler/registry.go
+++ b/pkg/ruler/registry.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
 	"dario.cat/mergo"
 	"github.com/go-kit/log"
@@ -359,8 +360,11 @@ func (r *walRegistry) getTenantRemoteWriteConfig(tenant string, base RemoteWrite
 				clt.WriteRelabelConfigs = v.WriteRelabelConfigs
 			}
 
+			// Cast [rulerconfig.RemoteWriteOverridesConfig] to [config.RemoteWriteConfig] so it can be used to merge with [clt].
+			// This can be done safely because the structs are identical.
+			casted := (*config.RemoteWriteConfig)(unsafe.Pointer(v))
 			// merge with override
-			if err := mergo.Merge(&clt, *v, mergo.WithOverride); err != nil {
+			if err := mergo.Merge(&clt, casted, mergo.WithOverride); err != nil {
 				return nil, fmt.Errorf("failed to apply remote write clients configs: %w", err)
 			}
 		}

--- a/pkg/ruler/registry.go
+++ b/pkg/ruler/registry.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unsafe"
 
 	"dario.cat/mergo"
 	"github.com/go-kit/log"
@@ -362,7 +361,7 @@ func (r *walRegistry) getTenantRemoteWriteConfig(tenant string, base RemoteWrite
 
 			// Cast [rulerconfig.RemoteWriteOverridesConfig] to [config.RemoteWriteConfig] so it can be used to merge with [clt].
 			// This can be done safely because the structs are identical.
-			casted := (*config.RemoteWriteConfig)(unsafe.Pointer(v))
+			casted := (*config.RemoteWriteConfig)(v)
 			// merge with override
 			if err := mergo.Merge(&clt, casted, mergo.WithOverride); err != nil {
 				return nil, fmt.Errorf("failed to apply remote write clients configs: %w", err)

--- a/pkg/ruler/registry_test.go
+++ b/pkg/ruler/registry_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/sigv4"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
@@ -365,9 +364,9 @@ func TestTenantRemoteWriteConfigWithOverride(t *testing.T) {
 	require.NoError(t, err)
 
 	// tenant has not disable remote-write so will inherit the global one
-	assert.Len(t, tenantCfg.RemoteWrite, 1)
+	require.Len(t, tenantCfg.RemoteWrite, 1)
 	// but the tenant has an override for the queue capacity
-	assert.Equal(t, tenantCfg.RemoteWrite[0].QueueConfig.Capacity, 987)
+	require.Equal(t, tenantCfg.RemoteWrite[0].QueueConfig.Capacity, 987)
 
 	reg = setupRegistry(t, cfg, newFakeLimits())
 
@@ -375,7 +374,7 @@ func TestTenantRemoteWriteConfigWithOverride(t *testing.T) {
 	require.NoError(t, err)
 
 	// tenant has not disable remote-write so will inherit the global one
-	assert.Len(t, tenantCfg.RemoteWrite, 2)
+	require.Len(t, tenantCfg.RemoteWrite, 2)
 	// but the tenant has an override for the queue capacity for the first client
 	// second client remains unchanged
 	expected := []int{
@@ -387,7 +386,7 @@ func TestTenantRemoteWriteConfigWithOverride(t *testing.T) {
 		actual = append(actual, rw.QueueConfig.Capacity)
 	}
 
-	assert.ElementsMatch(t, actual, expected, "QueueConfig capacity do not match")
+	require.ElementsMatch(t, actual, expected, "QueueConfig capacity do not match")
 }
 
 func TestTenantRemoteWriteConfigWithOverrideConcurrentAccess(t *testing.T) {
@@ -448,9 +447,9 @@ func TestTenantRemoteWriteConfigWithoutOverride(t *testing.T) {
 	require.NoError(t, err)
 
 	// tenant has not disable remote-write so will inherit the global one
-	assert.Len(t, tenantCfg.RemoteWrite, 1)
+	require.Len(t, tenantCfg.RemoteWrite, 1)
 	// but the tenant has an override for the queue capacity
-	assert.Equal(t, tenantCfg.RemoteWrite[0].QueueConfig.Capacity, defaultCapacity)
+	require.Equal(t, tenantCfg.RemoteWrite[0].QueueConfig.Capacity, defaultCapacity)
 
 	reg = setupRegistry(t, cfg, newFakeLimits())
 
@@ -459,7 +458,7 @@ func TestTenantRemoteWriteConfigWithoutOverride(t *testing.T) {
 	require.NoError(t, err)
 
 	// tenant has not disable remote-write so will inherit the global one
-	assert.Len(t, tenantCfg.RemoteWrite, 2)
+	require.Len(t, tenantCfg.RemoteWrite, 2)
 	// but the tenant has an override for the queue capacity for the first client
 	expected := []int{
 		defaultCapacity,
@@ -470,7 +469,7 @@ func TestTenantRemoteWriteConfigWithoutOverride(t *testing.T) {
 		actual = append(actual, rw.QueueConfig.Capacity)
 	}
 
-	assert.ElementsMatch(t, actual, expected, "QueueConfig capacity do not match")
+	require.ElementsMatch(t, actual, expected, "QueueConfig capacity do not match")
 }
 
 func TestTenantMultiRemoteWriteConfigWithoutOverride(t *testing.T) {
@@ -479,7 +478,7 @@ func TestTenantMultiRemoteWriteConfigWithoutOverride(t *testing.T) {
 	tenantCfg, err := reg.getTenantConfig(multiRemoteWriteTenant)
 	require.NoError(t, err)
 
-	assert.Len(t, tenantCfg.RemoteWrite, 2)
+	require.Len(t, tenantCfg.RemoteWrite, 2)
 
 	// Both remote clients have their queue capacity and timeout overwritten
 	expectedCap := []int{
@@ -491,7 +490,7 @@ func TestTenantMultiRemoteWriteConfigWithoutOverride(t *testing.T) {
 		actualCap = append(actualCap, rw.QueueConfig.Capacity)
 	}
 
-	assert.ElementsMatch(t, actualCap, expectedCap, "QueueConfig capacity do not match")
+	require.ElementsMatch(t, actualCap, expectedCap, "QueueConfig capacity do not match")
 
 	expectedDurations := []model.Duration{
 		model.Duration(10),
@@ -502,7 +501,7 @@ func TestTenantMultiRemoteWriteConfigWithoutOverride(t *testing.T) {
 	for _, rw := range tenantCfg.RemoteWrite {
 		actualDurations = append(actualDurations, rw.RemoteTimeout)
 	}
-	assert.ElementsMatch(t, actualDurations, expectedDurations, "RemoteTimeouts do not match")
+	require.ElementsMatch(t, actualDurations, expectedDurations, "RemoteTimeouts do not match")
 
 	// First remote client's HTTPClientConfig is overrwritten
 	expected := []commonconfig.HTTPClientConfig{
@@ -523,7 +522,7 @@ func TestTenantMultiRemoteWriteConfigWithoutOverride(t *testing.T) {
 		actual = append(actual, rw.HTTPClientConfig)
 	}
 
-	assert.ElementsMatch(t, actual, expected, "HTTPClientConfig do not match")
+	require.ElementsMatch(t, actual, expected, "HTTPClientConfig do not match")
 
 	// Second remote client's URL is overrwritten
 	expectedURLs := []commonconfig.URL{
@@ -535,7 +534,7 @@ func TestTenantMultiRemoteWriteConfigWithoutOverride(t *testing.T) {
 	for _, rw := range tenantCfg.RemoteWrite {
 		actualURLs = append(actualURLs, *rw.URL)
 	}
-	assert.ElementsMatch(t, actualURLs, expectedURLs, "URLs do not match")
+	require.ElementsMatch(t, actualURLs, expectedURLs, "URLs do not match")
 }
 
 func TestRulerRemoteWriteSigV4ConfigWithOverrides(t *testing.T) {
@@ -545,11 +544,10 @@ func TestRulerRemoteWriteSigV4ConfigWithOverrides(t *testing.T) {
 	require.NoError(t, err)
 
 	// tenant has not disable remote-write so will inherit the global one
-	assert.Len(t, tenantCfg.RemoteWrite, 1)
+	require.Len(t, tenantCfg.RemoteWrite, 1)
 	// ensure sigv4 config is not nil and overwritten
-	if assert.NotNil(t, tenantCfg.RemoteWrite[0].SigV4Config) {
-		assert.Equal(t, sigV4TenantRegion, tenantCfg.RemoteWrite[0].SigV4Config.Region)
-	}
+	require.NotNil(t, tenantCfg.RemoteWrite[0].SigV4Config)
+	require.Equal(t, sigV4TenantRegion, tenantCfg.RemoteWrite[0].SigV4Config.Region)
 
 	reg = setupSigV4Registry(t, cfg, newFakeLimits())
 
@@ -557,7 +555,7 @@ func TestRulerRemoteWriteSigV4ConfigWithOverrides(t *testing.T) {
 	require.NoError(t, err)
 
 	// tenant has not disable remote-write so will inherit the global one
-	assert.Len(t, tenantCfg.RemoteWrite, 2)
+	require.Len(t, tenantCfg.RemoteWrite, 2)
 	// ensure sigv4 config is not nil and overwritten for first client
 	// ensure sigv4 config is not nil and not overwritten for second client
 	expected := []string{
@@ -569,7 +567,7 @@ func TestRulerRemoteWriteSigV4ConfigWithOverrides(t *testing.T) {
 		actual = append(actual, rw.SigV4Config.Region)
 	}
 
-	assert.ElementsMatch(t, actual, expected, "SigV4Config regions do not match")
+	require.ElementsMatch(t, actual, expected, "SigV4Config regions do not match")
 }
 
 func TestRulerRemoteWriteSigV4ConfigWithoutOverrides(t *testing.T) {
@@ -580,11 +578,10 @@ func TestRulerRemoteWriteSigV4ConfigWithoutOverrides(t *testing.T) {
 	require.NoError(t, err)
 
 	// tenant has not disable remote-write so will inherit the global one
-	assert.Len(t, tenantCfg.RemoteWrite, 1)
+	require.Len(t, tenantCfg.RemoteWrite, 1)
 	// ensure sigv4 config is not nil and the global value
-	if assert.NotNil(t, tenantCfg.RemoteWrite[0].SigV4Config) {
-		assert.Equal(t, tenantCfg.RemoteWrite[0].SigV4Config.Region, sigV4GlobalRegion)
-	}
+	require.NotNil(t, tenantCfg.RemoteWrite[0].SigV4Config)
+	require.Equal(t, tenantCfg.RemoteWrite[0].SigV4Config.Region, sigV4GlobalRegion)
 
 	reg = setupSigV4Registry(t, cfg, newFakeLimits())
 
@@ -593,14 +590,12 @@ func TestRulerRemoteWriteSigV4ConfigWithoutOverrides(t *testing.T) {
 	require.NoError(t, err)
 
 	// tenant has not disable remote-write so will inherit the global one
-	assert.Len(t, tenantCfg.RemoteWrite, 2)
+	require.Len(t, tenantCfg.RemoteWrite, 2)
 	// ensure sigv4 config is not nil and the global value
-	if assert.NotNil(t, tenantCfg.RemoteWrite[0].SigV4Config) {
-		assert.Equal(t, tenantCfg.RemoteWrite[0].SigV4Config.Region, sigV4GlobalRegion)
-	}
-	if assert.NotNil(t, tenantCfg.RemoteWrite[1].SigV4Config) {
-		assert.Equal(t, tenantCfg.RemoteWrite[1].SigV4Config.Region, sigV4GlobalRegion)
-	}
+	require.NotNil(t, tenantCfg.RemoteWrite[0].SigV4Config)
+	require.Equal(t, tenantCfg.RemoteWrite[0].SigV4Config.Region, sigV4GlobalRegion)
+	require.NotNil(t, tenantCfg.RemoteWrite[1].SigV4Config)
+	require.Equal(t, tenantCfg.RemoteWrite[1].SigV4Config.Region, sigV4GlobalRegion)
 }
 
 func TestTenantRemoteWriteConfigDisabled(t *testing.T) {
@@ -610,7 +605,7 @@ func TestTenantRemoteWriteConfigDisabled(t *testing.T) {
 	require.NoError(t, err)
 
 	// this tenant has remote-write disabled
-	assert.Len(t, tenantCfg.RemoteWrite, 0)
+	require.Len(t, tenantCfg.RemoteWrite, 0)
 
 	reg = setupRegistry(t, cfg, newFakeLimits())
 
@@ -618,7 +613,7 @@ func TestTenantRemoteWriteConfigDisabled(t *testing.T) {
 	require.NoError(t, err)
 
 	// this tenant has remote-write disabled
-	assert.Len(t, tenantCfg.RemoteWrite, 0)
+	require.Len(t, tenantCfg.RemoteWrite, 0)
 }
 
 func TestTenantRemoteWriteHTTPConfigMaintained(t *testing.T) {
@@ -628,8 +623,8 @@ func TestTenantRemoteWriteHTTPConfigMaintained(t *testing.T) {
 	require.NoError(t, err)
 
 	// HTTP client config is not currently overrideable, all tenants' configs should inherit base
-	assert.Equal(t, "foo", tenantCfg.RemoteWrite[0].HTTPClientConfig.BasicAuth.Username)
-	assert.Equal(t, commonconfig.Secret("bar"), tenantCfg.RemoteWrite[0].HTTPClientConfig.BasicAuth.Password)
+	require.Equal(t, "foo", tenantCfg.RemoteWrite[0].HTTPClientConfig.BasicAuth.Username)
+	require.Equal(t, commonconfig.Secret("bar"), tenantCfg.RemoteWrite[0].HTTPClientConfig.BasicAuth.Password)
 
 	reg = setupRegistry(t, cfg, newFakeLimits())
 
@@ -657,7 +652,7 @@ func TestTenantRemoteWriteHTTPConfigMaintained(t *testing.T) {
 		actual = append(actual, rw.HTTPClientConfig)
 	}
 
-	assert.ElementsMatch(t, actual, expected, "HTTPClientConfigs do not match")
+	require.ElementsMatch(t, actual, expected, "HTTPClientConfigs do not match")
 }
 
 func TestTenantRemoteWriteHeaderOverride(t *testing.T) {
@@ -666,27 +661,27 @@ func TestTenantRemoteWriteHeaderOverride(t *testing.T) {
 	tenantCfg, err := reg.getTenantConfig(additionalHeadersRWTenant)
 	require.NoError(t, err)
 
-	assert.Len(t, tenantCfg.RemoteWrite[0].Headers, 2)
+	require.Len(t, tenantCfg.RemoteWrite[0].Headers, 2)
 	// ensure that tenant cannot override X-Scope-OrgId header
-	assert.Equal(t, tenantCfg.RemoteWrite[0].Headers[user.OrgIDHeaderName], additionalHeadersRWTenant)
+	require.Equal(t, tenantCfg.RemoteWrite[0].Headers[user.OrgIDHeaderName], additionalHeadersRWTenant)
 	// but that the additional header defined is set
-	assert.Equal(t, tenantCfg.RemoteWrite[0].Headers["Additional"], "Header")
+	require.Equal(t, tenantCfg.RemoteWrite[0].Headers["Additional"], "Header")
 	// the original header must be removed
-	assert.Equal(t, tenantCfg.RemoteWrite[0].Headers["Base"], "")
+	require.Equal(t, tenantCfg.RemoteWrite[0].Headers["Base"], "")
 
 	tenantCfg, err = reg.getTenantConfig(enabledRWTenant)
 	require.NoError(t, err)
 
 	// and a user who didn't set any header overrides still gets the X-Scope-OrgId header
-	assert.Equal(t, tenantCfg.RemoteWrite[0].Headers[user.OrgIDHeaderName], enabledRWTenant)
+	require.Equal(t, tenantCfg.RemoteWrite[0].Headers[user.OrgIDHeaderName], enabledRWTenant)
 
 	reg = setupRegistry(t, cfg, newFakeLimits())
 
 	tenantCfg, err = reg.getTenantConfig(additionalHeadersRWTenant)
 	require.NoError(t, err)
 
-	assert.Len(t, tenantCfg.RemoteWrite[0].Headers, 2)
-	assert.Len(t, tenantCfg.RemoteWrite[1].Headers, 2)
+	require.Len(t, tenantCfg.RemoteWrite[0].Headers, 2)
+	require.Len(t, tenantCfg.RemoteWrite[1].Headers, 2)
 
 	// Ensure that overrides take plus but that tenant cannot override X-Scope-OrgId header
 	expected := []map[string]string{
@@ -705,14 +700,14 @@ func TestTenantRemoteWriteHeaderOverride(t *testing.T) {
 		actual = append(actual, rw.Headers)
 	}
 
-	assert.ElementsMatch(t, actual, expected, "Headers do not match")
+	require.ElementsMatch(t, actual, expected, "Headers do not match")
 
 	tenantCfg, err = reg.getTenantConfig(enabledRWTenant)
 	require.NoError(t, err)
 
 	// and a user who didn't set any header overrides still gets the X-Scope-OrgId header
-	assert.Equal(t, tenantCfg.RemoteWrite[0].Headers[user.OrgIDHeaderName], enabledRWTenant)
-	assert.Equal(t, tenantCfg.RemoteWrite[1].Headers[user.OrgIDHeaderName], enabledRWTenant)
+	require.Equal(t, tenantCfg.RemoteWrite[0].Headers[user.OrgIDHeaderName], enabledRWTenant)
+	require.Equal(t, tenantCfg.RemoteWrite[1].Headers[user.OrgIDHeaderName], enabledRWTenant)
 }
 
 func TestTenantRemoteWriteHeadersNotMutateOverrides(t *testing.T) {
@@ -841,11 +836,11 @@ func TestTenantRemoteWriteHeadersReset(t *testing.T) {
 	tenantCfg, err := reg.getTenantConfig(noHeadersRWTenant)
 	require.NoError(t, err)
 
-	assert.Len(t, tenantCfg.RemoteWrite[0].Headers, 1)
+	require.Len(t, tenantCfg.RemoteWrite[0].Headers, 1)
 	// ensure that tenant cannot override X-Scope-OrgId header
-	assert.Equal(t, tenantCfg.RemoteWrite[0].Headers[user.OrgIDHeaderName], noHeadersRWTenant)
+	require.Equal(t, tenantCfg.RemoteWrite[0].Headers[user.OrgIDHeaderName], noHeadersRWTenant)
 	// the original header must be removed
-	assert.Equal(t, tenantCfg.RemoteWrite[0].Headers["Base"], "")
+	require.Equal(t, tenantCfg.RemoteWrite[0].Headers["Base"], "")
 
 	reg = setupRegistry(t, cfg, newFakeLimits())
 
@@ -868,7 +863,7 @@ func TestTenantRemoteWriteHeadersReset(t *testing.T) {
 		actual = append(actual, rw.Headers)
 	}
 
-	assert.ElementsMatch(t, actual, expected, "Headers do not match")
+	require.ElementsMatch(t, actual, expected, "Headers do not match")
 }
 
 func TestTenantRemoteWriteHeadersNoOverride(t *testing.T) {
@@ -877,11 +872,11 @@ func TestTenantRemoteWriteHeadersNoOverride(t *testing.T) {
 	tenantCfg, err := reg.getTenantConfig(enabledRWTenant)
 	require.NoError(t, err)
 
-	assert.Len(t, tenantCfg.RemoteWrite[0].Headers, 2)
+	require.Len(t, tenantCfg.RemoteWrite[0].Headers, 2)
 	// ensure that tenant cannot override X-Scope-OrgId header
-	assert.Equal(t, tenantCfg.RemoteWrite[0].Headers[user.OrgIDHeaderName], enabledRWTenant)
+	require.Equal(t, tenantCfg.RemoteWrite[0].Headers[user.OrgIDHeaderName], enabledRWTenant)
 	// the original header must be present
-	assert.Equal(t, tenantCfg.RemoteWrite[0].Headers["Base"], "value")
+	require.Equal(t, tenantCfg.RemoteWrite[0].Headers["Base"], "value")
 
 	reg = setupRegistry(t, cfg, newFakeLimits())
 
@@ -905,7 +900,7 @@ func TestTenantRemoteWriteHeadersNoOverride(t *testing.T) {
 		actual = append(actual, rw.Headers)
 	}
 
-	assert.ElementsMatch(t, actual, expected, "Headers do not match")
+	require.ElementsMatch(t, actual, expected, "Headers do not match")
 }
 
 func TestTenantRemoteWriteHeadersNoOrgIDHeader(t *testing.T) {
@@ -915,11 +910,11 @@ func TestTenantRemoteWriteHeadersNoOrgIDHeader(t *testing.T) {
 	tenantCfg, err := reg.getTenantConfig(enabledRWTenant)
 	require.NoError(t, err)
 
-	assert.Len(t, tenantCfg.RemoteWrite[0].Headers, 1)
+	require.Len(t, tenantCfg.RemoteWrite[0].Headers, 1)
 	// ensure that X-Scope-OrgId header is missing
-	assert.Equal(t, tenantCfg.RemoteWrite[0].Headers[user.OrgIDHeaderName], "")
+	require.Equal(t, tenantCfg.RemoteWrite[0].Headers[user.OrgIDHeaderName], "")
 	// the original header must be present
-	assert.Equal(t, tenantCfg.RemoteWrite[0].Headers["Base"], "value")
+	require.Equal(t, tenantCfg.RemoteWrite[0].Headers["Base"], "value")
 
 	cfg.RemoteWrite.AddOrgIDHeader = false
 	reg = setupRegistry(t, cfg, newFakeLimits())
@@ -942,7 +937,7 @@ func TestTenantRemoteWriteHeadersNoOrgIDHeader(t *testing.T) {
 		actual = append(actual, rw.Headers)
 	}
 
-	assert.ElementsMatch(t, actual, expected, "Headers do not match")
+	require.ElementsMatch(t, actual, expected, "Headers do not match")
 }
 
 func TestRelabelConfigOverrides(t *testing.T) {
@@ -952,7 +947,7 @@ func TestRelabelConfigOverrides(t *testing.T) {
 	require.NoError(t, err)
 
 	// it should also override the default label configs
-	assert.Len(t, tenantCfg.RemoteWrite[0].WriteRelabelConfigs, 2)
+	require.Len(t, tenantCfg.RemoteWrite[0].WriteRelabelConfigs, 2)
 
 	reg = setupRegistry(t, cfg, newFakeLimits())
 
@@ -977,7 +972,7 @@ func TestRelabelConfigOverrides(t *testing.T) {
 		}
 	}
 
-	assert.ElementsMatch(t, actual, expected, "Headers do not match")
+	require.ElementsMatch(t, actual, expected, "Headers do not match")
 }
 
 func TestRelabelConfigOverridesNilWriteRelabels(t *testing.T) {
@@ -991,7 +986,7 @@ func TestRelabelConfigOverridesNilWriteRelabels(t *testing.T) {
 	for _, rc := range expectedConfigs {
 		rc.NameValidationScheme = model.UTF8Validation
 	}
-	assert.Equal(t, tenantCfg.RemoteWrite[0].WriteRelabelConfigs, expectedConfigs)
+	require.Equal(t, tenantCfg.RemoteWrite[0].WriteRelabelConfigs, expectedConfigs)
 
 	reg = setupRegistry(t, cfg, newFakeLimits())
 
@@ -1016,7 +1011,7 @@ func TestRelabelConfigOverridesNilWriteRelabels(t *testing.T) {
 		}
 	}
 
-	assert.ElementsMatch(t, actual, expected, "WriteRelabelConfigs do not match")
+	require.ElementsMatch(t, actual, expected, "WriteRelabelConfigs do not match")
 }
 
 func TestRelabelConfigOverridesEmptySliceWriteRelabels(t *testing.T) {
@@ -1026,7 +1021,7 @@ func TestRelabelConfigOverridesEmptySliceWriteRelabels(t *testing.T) {
 	require.NoError(t, err)
 
 	// if there is an empty slice of relabel configs, it should clear existing relabel configs
-	assert.Len(t, tenantCfg.RemoteWrite[0].WriteRelabelConfigs, 0)
+	require.Len(t, tenantCfg.RemoteWrite[0].WriteRelabelConfigs, 0)
 }
 
 func TestRelabelConfigOverridesWithErrors(t *testing.T) {
@@ -1049,7 +1044,7 @@ func TestWALRegistryCreation(t *testing.T) {
 	}, overrides)
 
 	_, ok := regEnabled.(*walRegistry)
-	assert.Truef(t, ok, "instance is not of expected type")
+	require.Truef(t, ok, "instance is not of expected type")
 
 	// if remote-write is disabled, setup a null registry
 	regDisabled := newWALRegistry(log.NewNopLogger(), nil, Config{
@@ -1059,7 +1054,7 @@ func TestWALRegistryCreation(t *testing.T) {
 	}, overrides)
 
 	_, ok = regDisabled.(nullRegistry)
-	assert.Truef(t, ok, "instance is not of expected type")
+	require.Truef(t, ok, "instance is not of expected type")
 }
 
 func TestWALRegistryWipeOnStartup(t *testing.T) {
@@ -1119,7 +1114,7 @@ func TestStorageSetup(t *testing.T) {
 	})
 
 	app := reg.Appender(user.InjectOrgID(context.Background(), enabledRWTenant))
-	assert.Equalf(t, "*storage.fanoutAppender", fmt.Sprintf("%T", app), "instance is not of expected type")
+	require.Equalf(t, "*storage.fanoutAppender", fmt.Sprintf("%T", app), "instance is not of expected type")
 }
 
 func TestStorageSetupWithRemoteWriteDisabled(t *testing.T) {
@@ -1132,7 +1127,7 @@ func TestStorageSetupWithRemoteWriteDisabled(t *testing.T) {
 	// if remote-write is disabled, we use a discardingAppender to not write to the WAL
 	app := reg.Appender(user.InjectOrgID(context.Background(), disabledRWTenant))
 	_, ok := app.(discardingAppender)
-	assert.Truef(t, ok, "instance is not of expected type")
+	require.Truef(t, ok, "instance is not of expected type")
 
 	// same test with regular config
 	reg = setupRegistry(t, cfg, newFakeLimits())
@@ -1140,7 +1135,7 @@ func TestStorageSetupWithRemoteWriteDisabled(t *testing.T) {
 
 	app = reg.Appender(user.InjectOrgID(context.Background(), disabledRWTenant))
 	_, ok = app.(discardingAppender)
-	assert.Truef(t, ok, "instance is not of expected type")
+	require.Truef(t, ok, "instance is not of expected type")
 }
 
 type fakeLimits struct {

--- a/pkg/ruler/registry_test.go
+++ b/pkg/ruler/registry_test.go
@@ -16,9 +16,9 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/user"
-	promConfig "github.com/prometheus/common/config"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/config"
+	promconfig "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/sigv4"
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
+	rulerconfig "github.com/grafana/loki/v3/pkg/ruler/config"
 	"github.com/grafana/loki/v3/pkg/ruler/storage/instance"
 	"github.com/grafana/loki/v3/pkg/ruler/util"
 	"github.com/grafana/loki/v3/pkg/util/test"
@@ -56,13 +57,13 @@ var remoteURL, _ = url.Parse("http://remote-write")
 var backCompatCfg = Config{
 	RemoteWrite: RemoteWriteConfig{
 		AddOrgIDHeader: true,
-		Client: &config.RemoteWriteConfig{
-			URL: &promConfig.URL{URL: remoteURL},
-			QueueConfig: config.QueueConfig{
+		Client: &promconfig.RemoteWriteConfig{
+			URL: &commonconfig.URL{URL: remoteURL},
+			QueueConfig: promconfig.QueueConfig{
 				Capacity: defaultCapacity,
 			},
-			HTTPClientConfig: promConfig.HTTPClientConfig{
-				BasicAuth: &promConfig.BasicAuth{
+			HTTPClientConfig: commonconfig.HTTPClientConfig{
+				BasicAuth: &commonconfig.BasicAuth{
 					Password: "bar",
 					Username: "foo",
 				},
@@ -80,14 +81,14 @@ var backCompatCfg = Config{
 				},
 			},
 		},
-		Clients: map[string]config.RemoteWriteConfig{
+		Clients: map[string]promconfig.RemoteWriteConfig{
 			"default": {
-				URL: &promConfig.URL{URL: remoteURL},
-				QueueConfig: config.QueueConfig{
+				URL: &commonconfig.URL{URL: remoteURL},
+				QueueConfig: promconfig.QueueConfig{
 					Capacity: defaultCapacity,
 				},
-				HTTPClientConfig: promConfig.HTTPClientConfig{
-					BasicAuth: &promConfig.BasicAuth{
+				HTTPClientConfig: commonconfig.HTTPClientConfig{
+					BasicAuth: &commonconfig.BasicAuth{
 						Password: "bar",
 						Username: "foo",
 					},
@@ -115,14 +116,14 @@ var remoteURL2, _ = url.Parse("http://remote-write2")
 var cfg = Config{
 	RemoteWrite: RemoteWriteConfig{
 		AddOrgIDHeader: true,
-		Clients: map[string]config.RemoteWriteConfig{
+		Clients: map[string]promconfig.RemoteWriteConfig{
 			remote1: {
-				URL: &promConfig.URL{URL: remoteURL},
-				QueueConfig: config.QueueConfig{
+				URL: &commonconfig.URL{URL: remoteURL},
+				QueueConfig: promconfig.QueueConfig{
 					Capacity: defaultCapacity,
 				},
-				HTTPClientConfig: promConfig.HTTPClientConfig{
-					BasicAuth: &promConfig.BasicAuth{
+				HTTPClientConfig: commonconfig.HTTPClientConfig{
+					BasicAuth: &commonconfig.BasicAuth{
 						Password: "bar",
 						Username: "foo",
 					},
@@ -141,12 +142,12 @@ var cfg = Config{
 				},
 			},
 			remote2: {
-				URL: &promConfig.URL{URL: remoteURL2},
-				QueueConfig: config.QueueConfig{
+				URL: &commonconfig.URL{URL: remoteURL2},
+				QueueConfig: promconfig.QueueConfig{
 					Capacity: capacity,
 				},
-				HTTPClientConfig: promConfig.HTTPClientConfig{
-					BasicAuth: &promConfig.BasicAuth{
+				HTTPClientConfig: commonconfig.HTTPClientConfig{
+					BasicAuth: &commonconfig.BasicAuth{
 						Password: "bar2",
 						Username: "foo2",
 					},
@@ -233,9 +234,9 @@ func newFakeLimits() fakeLimits {
 	return fakeLimits{
 		limits: map[string]*validation.Limits{
 			enabledRWTenant: {
-				RulerRemoteWriteConfig: map[string]config.RemoteWriteConfig{
+				RulerRemoteWriteConfig: map[string]rulerconfig.RemoteWriteConfig{
 					remote1: {
-						QueueConfig: config.QueueConfig{Capacity: 987},
+						QueueConfig: promconfig.QueueConfig{Capacity: 987},
 					},
 				},
 			},
@@ -243,7 +244,7 @@ func newFakeLimits() fakeLimits {
 				RulerRemoteWriteDisabled: true,
 			},
 			additionalHeadersRWTenant: {
-				RulerRemoteWriteConfig: map[string]config.RemoteWriteConfig{
+				RulerRemoteWriteConfig: map[string]rulerconfig.RemoteWriteConfig{
 					remote1: {
 						Headers: map[string]string{
 							user.OrgIDHeaderName:                         "overridden",
@@ -256,14 +257,14 @@ func newFakeLimits() fakeLimits {
 				},
 			},
 			noHeadersRWTenant: {
-				RulerRemoteWriteConfig: map[string]config.RemoteWriteConfig{
+				RulerRemoteWriteConfig: map[string]rulerconfig.RemoteWriteConfig{
 					remote1: {
 						Headers: map[string]string{},
 					},
 				},
 			},
 			customRelabelsTenant: {
-				RulerRemoteWriteConfig: map[string]config.RemoteWriteConfig{
+				RulerRemoteWriteConfig: map[string]rulerconfig.RemoteWriteConfig{
 					remote1: {
 						WriteRelabelConfigs: []*relabel.Config{
 							{
@@ -283,14 +284,14 @@ func newFakeLimits() fakeLimits {
 			},
 			nilRelabelsTenant: {},
 			emptySliceRelabelsTenant: {
-				RulerRemoteWriteConfig: map[string]config.RemoteWriteConfig{
+				RulerRemoteWriteConfig: map[string]rulerconfig.RemoteWriteConfig{
 					remote1: {
 						WriteRelabelConfigs: []*relabel.Config{},
 					},
 				},
 			},
 			sigV4ConfigTenant: {
-				RulerRemoteWriteConfig: map[string]config.RemoteWriteConfig{
+				RulerRemoteWriteConfig: map[string]rulerconfig.RemoteWriteConfig{
 					remote1: {
 						SigV4Config: &sigv4.SigV4Config{
 							Region: sigV4TenantRegion,
@@ -299,18 +300,18 @@ func newFakeLimits() fakeLimits {
 				},
 			},
 			multiRemoteWriteTenant: {
-				RulerRemoteWriteConfig: map[string]config.RemoteWriteConfig{
+				RulerRemoteWriteConfig: map[string]rulerconfig.RemoteWriteConfig{
 					remote1: {
-						QueueConfig:   config.QueueConfig{Capacity: 987},
+						QueueConfig:   promconfig.QueueConfig{Capacity: 987},
 						RemoteTimeout: model.Duration(42),
-						HTTPClientConfig: promConfig.HTTPClientConfig{
+						HTTPClientConfig: commonconfig.HTTPClientConfig{
 							BearerToken: "test-token",
 						},
 					},
 					remote2: {
-						QueueConfig:   config.QueueConfig{Capacity: 800},
+						QueueConfig:   promconfig.QueueConfig{Capacity: 800},
 						RemoteTimeout: model.Duration(10),
-						URL:           &promConfig.URL{URL: newRemoteURL2},
+						URL:           &commonconfig.URL{URL: newRemoteURL2},
 					},
 				},
 			},
@@ -504,20 +505,20 @@ func TestTenantMultiRemoteWriteConfigWithoutOverride(t *testing.T) {
 	assert.ElementsMatch(t, actualDurations, expectedDurations, "RemoteTimeouts do not match")
 
 	// First remote client's HTTPClientConfig is overrwritten
-	expected := []promConfig.HTTPClientConfig{
+	expected := []commonconfig.HTTPClientConfig{
 		{
 			BearerToken: "test-token",
-			BasicAuth: &promConfig.BasicAuth{
+			BasicAuth: &commonconfig.BasicAuth{
 				Password: "bar",
 				Username: "foo",
 			}},
 		{
-			BasicAuth: &promConfig.BasicAuth{
+			BasicAuth: &commonconfig.BasicAuth{
 				Password: "bar2",
 				Username: "foo2",
 			}},
 	}
-	actual := []promConfig.HTTPClientConfig{}
+	actual := []commonconfig.HTTPClientConfig{}
 	for _, rw := range tenantCfg.RemoteWrite {
 		actual = append(actual, rw.HTTPClientConfig)
 	}
@@ -525,12 +526,12 @@ func TestTenantMultiRemoteWriteConfigWithoutOverride(t *testing.T) {
 	assert.ElementsMatch(t, actual, expected, "HTTPClientConfig do not match")
 
 	// Second remote client's URL is overrwritten
-	expectedURLs := []promConfig.URL{
+	expectedURLs := []commonconfig.URL{
 		{URL: newRemoteURL2},
 		{URL: remoteURL},
 	}
 
-	actualURLs := []promConfig.URL{}
+	actualURLs := []commonconfig.URL{}
 	for _, rw := range tenantCfg.RemoteWrite {
 		actualURLs = append(actualURLs, *rw.URL)
 	}
@@ -628,7 +629,7 @@ func TestTenantRemoteWriteHTTPConfigMaintained(t *testing.T) {
 
 	// HTTP client config is not currently overrideable, all tenants' configs should inherit base
 	assert.Equal(t, "foo", tenantCfg.RemoteWrite[0].HTTPClientConfig.BasicAuth.Username)
-	assert.Equal(t, promConfig.Secret("bar"), tenantCfg.RemoteWrite[0].HTTPClientConfig.BasicAuth.Password)
+	assert.Equal(t, commonconfig.Secret("bar"), tenantCfg.RemoteWrite[0].HTTPClientConfig.BasicAuth.Password)
 
 	reg = setupRegistry(t, cfg, newFakeLimits())
 
@@ -636,22 +637,22 @@ func TestTenantRemoteWriteHTTPConfigMaintained(t *testing.T) {
 	require.NoError(t, err)
 
 	// HTTP client config is not currently overrideable, all tenants' configs should inherit base
-	expected := []promConfig.HTTPClientConfig{
+	expected := []commonconfig.HTTPClientConfig{
 		{
-			BasicAuth: &promConfig.BasicAuth{
+			BasicAuth: &commonconfig.BasicAuth{
 				Username: "foo",
-				Password: promConfig.Secret("bar"),
+				Password: commonconfig.Secret("bar"),
 			},
 		},
 		{
-			BasicAuth: &promConfig.BasicAuth{
+			BasicAuth: &commonconfig.BasicAuth{
 				Username: "foo2",
-				Password: promConfig.Secret("bar2"),
+				Password: commonconfig.Secret("bar2"),
 			},
 		},
 	}
 
-	actual := []promConfig.HTTPClientConfig{}
+	actual := []commonconfig.HTTPClientConfig{}
 	for _, rw := range tenantCfg.RemoteWrite {
 		actual = append(actual, rw.HTTPClientConfig)
 	}
@@ -763,10 +764,10 @@ func TestTenantRemoteWriteHeadersConcurrentRefresh(t *testing.T) {
 			AddOrgIDHeader:      true,
 			Enabled:             true,
 			ConfigRefreshPeriod: time.Hour,
-			Clients: map[string]config.RemoteWriteConfig{
+			Clients: map[string]promconfig.RemoteWriteConfig{
 				"default": {
-					URL: &promConfig.URL{URL: remoteWriteURL},
-					QueueConfig: config.QueueConfig{
+					URL: &commonconfig.URL{URL: remoteWriteURL},
+					QueueConfig: promconfig.QueueConfig{
 						Capacity:          10000,
 						MinShards:         4,
 						MaxShards:         8,

--- a/pkg/ruler/registry_test.go
+++ b/pkg/ruler/registry_test.go
@@ -607,7 +607,7 @@ func TestTenantRemoteWriteConfig(t *testing.T) {
 	defaultCfg := Config{
 		RemoteWrite: RemoteWriteConfig{
 			Clients: map[string]promconfig.RemoteWriteConfig{
-				client: promconfig.RemoteWriteConfig{
+				client: {
 					Name:             "default-remote-write",
 					URL:              &commonconfig.URL{URL: remoteWriteURL},
 					RemoteTimeout:    model.Duration(30 * time.Second),
@@ -617,7 +617,7 @@ func TestTenantRemoteWriteConfig(t *testing.T) {
 					MetadataConfig:   promconfig.DefaultMetadataConfig,
 					HTTPClientConfig: promconfig.DefaultRemoteWriteHTTPClientConfig,
 					WriteRelabelConfigs: []*relabel.Config{ // single relabel config: keep all
-						&relabel.Config{
+						{
 							Separator:            relabel.DefaultRelabelConfig.Separator,
 							Replacement:          relabel.DefaultRelabelConfig.Replacement,
 							NameValidationScheme: relabel.DefaultRelabelConfig.NameValidationScheme,
@@ -638,16 +638,16 @@ func TestTenantRemoteWriteConfig(t *testing.T) {
 		"foo": {
 			RulerRemoteWriteDisabled: true,
 			RulerRemoteWriteConfig: map[string]rulerconfig.RemoteWriteConfig{
-				client: rulerconfig.RemoteWriteConfig{
+				client: {
 					URL: &commonconfig.URL{URL: overrideURL},
 				},
 			},
 		},
 		"bar": {
 			RulerRemoteWriteConfig: map[string]rulerconfig.RemoteWriteConfig{
-				client: rulerconfig.RemoteWriteConfig{
+				client: {
 					WriteRelabelConfigs: []*relabel.Config{
-						&relabel.Config{ // single relabel config: drop all
+						{ // single relabel config: drop all
 							SourceLabels: model.LabelNames{"__name__"},
 							Regex:        reAll,
 							Action:       "drop",

--- a/pkg/ruler/registry_test.go
+++ b/pkg/ruler/registry_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/user"
+	remoteapi "github.com/prometheus/client_golang/exp/api/remote"
 	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	promconfig "github.com/prometheus/prometheus/config"
@@ -596,6 +597,95 @@ func TestRulerRemoteWriteSigV4ConfigWithoutOverrides(t *testing.T) {
 	require.Equal(t, tenantCfg.RemoteWrite[0].SigV4Config.Region, sigV4GlobalRegion)
 	require.NotNil(t, tenantCfg.RemoteWrite[1].SigV4Config)
 	require.Equal(t, tenantCfg.RemoteWrite[1].SigV4Config.Region, sigV4GlobalRegion)
+}
+
+func TestTenantRemoteWriteConfig(t *testing.T) {
+	const client = "default"
+
+	remoteWriteURL, _ := url.Parse("http://remote-write-default.example.com/prom/api/push")
+	reAll, _ := relabel.NewRegexp(".*")
+	defaultCfg := Config{
+		RemoteWrite: RemoteWriteConfig{
+			Clients: map[string]promconfig.RemoteWriteConfig{
+				client: promconfig.RemoteWriteConfig{
+					Name:             "default-remote-write",
+					URL:              &commonconfig.URL{URL: remoteWriteURL},
+					RemoteTimeout:    model.Duration(30 * time.Second),
+					Headers:          map[string]string{},
+					ProtobufMessage:  remoteapi.WriteV1MessageType,
+					QueueConfig:      promconfig.DefaultQueueConfig,
+					MetadataConfig:   promconfig.DefaultMetadataConfig,
+					HTTPClientConfig: promconfig.DefaultRemoteWriteHTTPClientConfig,
+					WriteRelabelConfigs: []*relabel.Config{ // single relabel config: keep all
+						&relabel.Config{
+							Separator:            relabel.DefaultRelabelConfig.Separator,
+							Replacement:          relabel.DefaultRelabelConfig.Replacement,
+							NameValidationScheme: relabel.DefaultRelabelConfig.NameValidationScheme,
+							SourceLabels:         model.LabelNames{"__name__"},
+							Regex:                reAll,
+							Action:               relabel.Keep,
+						},
+					},
+				},
+			},
+			Enabled:             true,
+			ConfigRefreshPeriod: time.Second,
+		},
+	}
+
+	overrideURL, _ := url.Parse("http://remote-write-override.example.com/prom/api/push")
+	tenantOverrides := fakeLimits{limits: map[string]*validation.Limits{
+		"foo": {
+			RulerRemoteWriteDisabled: true,
+			RulerRemoteWriteConfig: map[string]rulerconfig.RemoteWriteConfig{
+				client: rulerconfig.RemoteWriteConfig{
+					URL: &commonconfig.URL{URL: overrideURL},
+				},
+			},
+		},
+		"bar": {
+			RulerRemoteWriteConfig: map[string]rulerconfig.RemoteWriteConfig{
+				client: rulerconfig.RemoteWriteConfig{
+					WriteRelabelConfigs: []*relabel.Config{
+						&relabel.Config{ // single relabel config: drop all
+							SourceLabels: model.LabelNames{"__name__"},
+							Regex:        reAll,
+							Action:       "drop",
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	reg := setupRegistry(t, defaultCfg, tenantOverrides)
+
+	t.Run("no custom tenant overrides", func(t *testing.T) {
+		tenantCfg, err := reg.getTenantConfig("anyone")
+		require.NoError(t, err)
+		require.Len(t, tenantCfg.RemoteWrite, 1) // default config
+
+		clientCfg := defaultCfg.RemoteWrite.Clients[client]
+		require.Equal(t, clientCfg.URL, tenantCfg.RemoteWrite[0].URL)
+		require.Equal(t, "anyone-rw-default", tenantCfg.RemoteWrite[0].Name)
+	})
+
+	t.Run("tenant with disabled remote write", func(t *testing.T) {
+		tenantCfg, err := reg.getTenantConfig("foo")
+		require.NoError(t, err)
+		require.Len(t, tenantCfg.RemoteWrite, 0) // no config
+	})
+
+	t.Run("tenant with write relabel config", func(t *testing.T) {
+		tenantCfg, err := reg.getTenantConfig("bar")
+		require.NoError(t, err)
+		require.Len(t, tenantCfg.RemoteWrite, 1) // overrides config
+		require.Equal(t, "bar-rw-default", tenantCfg.RemoteWrite[0].Name)
+		require.Len(t, tenantCfg.RemoteWrite[0].WriteRelabelConfigs, 1)
+		require.Equal(t, relabel.Action("drop"), tenantCfg.RemoteWrite[0].WriteRelabelConfigs[0].Action)
+		clientCfg := defaultCfg.RemoteWrite.Clients[client]
+		require.Equal(t, clientCfg.URL, tenantCfg.RemoteWrite[0].URL)
+	})
 }
 
 func TestTenantRemoteWriteConfigDisabled(t *testing.T) {

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/sigv4"
 	yaml "go.yaml.in/yaml/v4"
@@ -26,7 +25,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/loghttp/push"
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
-	ruler_config "github.com/grafana/loki/v3/pkg/ruler/config"
+	rulerconfig "github.com/grafana/loki/v3/pkg/ruler/config"
 	"github.com/grafana/loki/v3/pkg/ruler/util"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/sharding"
 	"github.com/grafana/loki/v3/pkg/util/flagext"
@@ -162,10 +161,10 @@ type Limits struct {
 	VolumeMaxSeries                      int              `yaml:"volume_max_series" json:"volume_max_series" doc:"description=The maximum number of aggregated series in a log-volume response"`
 
 	// Ruler defaults and limits.
-	RulerMaxRulesPerRuleGroup   int                              `yaml:"ruler_max_rules_per_rule_group" json:"ruler_max_rules_per_rule_group"`
-	RulerMaxRuleGroupsPerTenant int                              `yaml:"ruler_max_rule_groups_per_tenant" json:"ruler_max_rule_groups_per_tenant"`
-	RulerAlertManagerConfig     *ruler_config.AlertManagerConfig `yaml:"ruler_alertmanager_config" json:"ruler_alertmanager_config" doc:"hidden"`
-	RulerTenantShardSize        int                              `yaml:"ruler_tenant_shard_size" json:"ruler_tenant_shard_size"`
+	RulerMaxRulesPerRuleGroup   int                             `yaml:"ruler_max_rules_per_rule_group" json:"ruler_max_rules_per_rule_group"`
+	RulerMaxRuleGroupsPerTenant int                             `yaml:"ruler_max_rule_groups_per_tenant" json:"ruler_max_rule_groups_per_tenant"`
+	RulerAlertManagerConfig     *rulerconfig.AlertManagerConfig `yaml:"ruler_alertmanager_config" json:"ruler_alertmanager_config" doc:"hidden"`
+	RulerTenantShardSize        int                             `yaml:"ruler_tenant_shard_size" json:"ruler_tenant_shard_size"`
 
 	// TODO(dannyk): add HTTP client overrides (basic auth / tls config, etc)
 	// Ruler remote-write limits.
@@ -201,7 +200,7 @@ type Limits struct {
 	// deprecated use RulerRemoteWriteConfig instead
 	RulerRemoteWriteSigV4Config *sigv4.SigV4Config `yaml:"ruler_remote_write_sigv4_config" json:"ruler_remote_write_sigv4_config" doc:"deprecated|description=Use 'ruler_remote_write_config' instead. Configures AWS's Signature Verification 4 signing process to sign every remote write request."`
 
-	RulerRemoteWriteConfig map[string]config.RemoteWriteConfig `yaml:"ruler_remote_write_config,omitempty" json:"ruler_remote_write_config,omitempty" doc:"description=Configures global and per-tenant limits for remote write clients. A map with remote client id as key."`
+	RulerRemoteWriteConfig map[string]rulerconfig.RemoteWriteConfig `yaml:"ruler_remote_write_config,omitempty" json:"ruler_remote_write_config,omitempty" doc:"description=Configures global and per-tenant limits for remote write clients. A map with remote client id as key."`
 
 	// TODO(dannyk): possible enhancement is to align this with rule group interval
 	RulerRemoteEvaluationTimeout         time.Duration `yaml:"ruler_remote_evaluation_timeout" json:"ruler_remote_evaluation_timeout" doc:"description=Timeout for a remote rule evaluation. Defaults to the value of 'querier.query-timeout'."`
@@ -348,13 +347,6 @@ type StreamRetention struct {
 	Priority int               `yaml:"priority" json:"priority" doc:"description:The larger the value, the higher the priority."`
 	Selector string            `yaml:"selector" json:"selector" doc:"description:Stream selector expression."`
 	Matchers []*labels.Matcher `yaml:"-" json:"-"` // populated during validation.
-}
-
-// LimitError are errors that do not comply with the limits specified.
-type LimitError string
-
-func (e LimitError) Error() string {
-	return string(e)
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -1002,7 +994,7 @@ func (o *Overrides) RulerMaxRuleGroupsPerTenant(userID string) int {
 }
 
 // RulerAlertManagerConfig returns the alertmanager configurations to use for a given user.
-func (o *Overrides) RulerAlertManagerConfig(userID string) *ruler_config.AlertManagerConfig {
+func (o *Overrides) RulerAlertManagerConfig(userID string) *rulerconfig.AlertManagerConfig {
 	return o.getOverridesForUser(userID).RulerAlertManagerConfig
 }
 
@@ -1089,7 +1081,7 @@ func (o *Overrides) RulerRemoteWriteSigV4Config(userID string) *sigv4.SigV4Confi
 }
 
 // RulerRemoteWriteConfig returns the remote-write configurations to use for a given user and a given remote client.
-func (o *Overrides) RulerRemoteWriteConfig(userID string, id string) *config.RemoteWriteConfig {
+func (o *Overrides) RulerRemoteWriteConfig(userID string, id string) *rulerconfig.RemoteWriteConfig {
 	if c, ok := o.getOverridesForUser(userID).RulerRemoteWriteConfig[id]; ok {
 		return &c
 	}


### PR DESCRIPTION
### Summary

The per-tenant ruler_remote_write_config used Prometheus' RemoteWriteConfig, whose custom YAML unmarshaling validates fields and rejects partial/null values, preventing tenants from overriding only a subset of fields. Introduce RemoteWriteConfig, a layout-identical copy without custom unmarshaling, and merge it via a safe pointer cast.

Move LimitError into the ruler base package to avoid an import cycle.