### PR TITLE
fix(engine/scheduler): Remove lock-convoy & wire deadlocks stalling d…

### DIFF
--- a/pkg/engine/internal/scheduler/notifier.go
+++ b/pkg/engine/internal/scheduler/notifier.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 
+	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/wire"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
 )
 
@@ -21,13 +22,18 @@ type taskNotification struct {
 }
 
 // A notifier is responsible for invoking [workflow.StreamEventHandler] and
-// [workflow.TaskEventHandler].
+// [workflow.TaskEventHandler], and for delivering best-effort wire messages to
+// workers.
 //
 // Notifier is used to avoid deadlocks so notifications can be held without any
-// mutexes held.
+// mutexes held. Buffering best-effort worker messages here (rather than sending
+// them inline) ensures the send — which can block on a full connection buffer —
+// happens after the caller has released the scheduler's locks, so a slow or
+// backed-up worker connection can't stall the whole scheduler.
 type notifier struct {
 	streamNotifications []streamNotification
 	taskNotifications   []taskNotification
+	messages            []pendingMessage
 }
 
 // AddStreamEvent buffers a stream event notification.
@@ -40,8 +46,25 @@ func (n *notifier) AddTaskEvent(notification taskNotification) {
 	n.taskNotifications = append(n.taskNotifications, notification)
 }
 
-// Notify handles all pending notifications.
+// AddMessage buffers a best-effort message to send to a worker once the
+// caller's locks have been released (see [notifier.Notify]).
+func (n *notifier) AddMessage(peer *workerConn, msg wire.Message) {
+	if peer == nil {
+		return
+	}
+	n.messages = append(n.messages, pendingMessage{peer: peer, msg: msg})
+}
+
+// Notify handles all pending notifications and buffered worker messages.
+//
+// Messages are sent before invoking handlers to preserve the previous ordering
+// where messages were dispatched to workers before the deferred handler
+// callbacks ran.
 func (n *notifier) Notify(ctx context.Context) {
+	for _, m := range n.messages {
+		_ = m.peer.SendMessageAsync(ctx, m.msg)
+	}
+
 	for _, ev := range n.streamNotifications {
 		ev.Handler(ctx, ev.Stream, ev.NewState)
 	}

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -296,8 +296,20 @@ func (s *Scheduler) handleTaskStatus(ctx context.Context, worker *workerConn, ms
 	var n notifier
 	defer n.Notify(ctx)
 
-	resourcesGuard := s.resourcesMut.Lock("handle_task_status")
-	defer resourcesGuard.Unlock()
+	// A read lock is sufficient here: handleTaskStatus only reads the
+	// resourcesMut-protected maps (s.tasks) and task.owner (which is only ever
+	// written under the full write lock, in finalizeAssignment). All mutations
+	// it performs are to per-task state (guarded by task.mut via SetState /
+	// RecordTerminalObservations) or per-worker state (guarded by worker.mut via
+	// Unassign), and status messages for a given task are serialized on a single
+	// connection's handler goroutine.
+	//
+	// Task status messages are the highest-frequency scheduler event; taking the
+	// write lock here would serialize every status update against dispatch
+	// (finalizeAssignment) and cancellation (Cancel), throttling the scheduler
+	// under load. Using a read lock lets status processing run concurrently.
+	resourcesGuard := s.resourcesMut.RLock("handle_task_status")
+	defer resourcesGuard.RUnlock()
 
 	task, found := s.tasks[msg.ID]
 	if !found {
@@ -309,7 +321,7 @@ func (s *Scheduler) handleTaskStatus(ctx context.Context, worker *workerConn, ms
 		return err
 	} else if changed {
 		newState := msg.Status.State
-		if owner := task.owner; owner != nil && newState.Terminal() {
+		if owner := task.owner.Load(); owner != nil && newState.Terminal() {
 			owner.Unassign(task)
 		}
 
@@ -366,8 +378,16 @@ func (s *Scheduler) handleStreamStatus(ctx context.Context, worker *workerConn, 
 	var n notifier
 	defer n.Notify(ctx)
 
-	resourcesGuard := s.resourcesMut.Lock("handle_stream_status")
-	defer resourcesGuard.Unlock()
+	// A read lock is sufficient: stream state transitions are guarded by the
+	// per-stream stateMut (via changeStreamState -> setState), and we only read
+	// the resourcesMut-protected maps (s.streams, s.tasks) and task.owner (only
+	// ever written under the full write lock). Stream-status messages are the
+	// highest-frequency scheduler event during fan-in teardown; holding the
+	// write lock here serializes them against dispatch and cancellation and
+	// backs up the per-connection message goroutines. Using a read lock lets
+	// them run concurrently.
+	resourcesGuard := s.resourcesMut.RLock("handle_stream_status")
+	defer resourcesGuard.RUnlock()
 
 	stream, found := s.streams[msg.StreamID]
 	if !found {
@@ -387,13 +407,17 @@ func (s *Scheduler) changeStreamState(ctx context.Context, n *notifier, target *
 	}
 
 	// If we have a receiver, inform them about the change. This is a
-	// best-effort message so we don't need to wait for acknowledgement.
+	// best-effort message; we buffer it on the notifier so it is sent after the
+	// caller releases resourcesMut rather than blocking the lock on a full
+	// connection buffer.
 	receiver, found := s.tasks[target.taskReceiver]
-	if found && receiver.owner != nil {
-		_ = receiver.owner.SendMessageAsync(ctx, wire.StreamStatusMessage{
-			StreamID: target.inner.ULID,
-			State:    newState,
-		})
+	if found {
+		if owner := receiver.owner.Load(); owner != nil {
+			n.AddMessage(owner, wire.StreamStatusMessage{
+				StreamID: target.inner.ULID,
+				State:    newState,
+			})
+		}
 	}
 
 	// Inform the owner about the change.
@@ -587,12 +611,30 @@ func (s *Scheduler) workerLoop(ctx context.Context, worker *workerConn) {
 	}
 }
 
+// parkRetryInterval bounds how long a parked workerLoop waits before
+// re-attempting dispatch even without an explicit wake-up. See parkWorker.
+const parkRetryInterval = 100 * time.Millisecond
+
 // parkWorker blocks until the worker advertises freed capacity (a ready message
 // nudges worker.wake), the worker disconnects, or the scheduler shuts down. It
 // returns true if the assignment loop should resume, or false if it should
 // exit.
+//
+// A parked workerLoop is normally resumed by a WorkerReady (worker.wake) sent
+// when a worker thread frees. That readiness signal is edge-triggered and
+// demand-based (the worker only re-advertises after rejecting an assignment
+// with 429), which makes it possible to lose an edge: a parked workerLoop makes
+// no further dispatch attempts, so it can never trigger a new 429 to re-arm the
+// worker's readiness — leaving a worker with idle threads stranded and its tasks
+// undispatched. To guarantee liveness we also wake up periodically and
+// re-attempt dispatch; if the worker is genuinely full it simply returns 429 and
+// re-parks, and if it has freed capacity the assignment succeeds.
 func (s *Scheduler) parkWorker(ctx context.Context, worker *workerConn) bool {
+	timer := time.NewTimer(parkRetryInterval)
+	defer timer.Stop()
+
 	hop := s.metrics.startAssignmentHop("park_worker_wait")
+
 	select {
 	case <-ctx.Done():
 		hop.Done(outcomeCanceled)
@@ -603,6 +645,8 @@ func (s *Scheduler) parkWorker(ctx context.Context, worker *workerConn) bool {
 	case <-worker.wake:
 		hop.Done(outcomeReady)
 		return true
+	case <-timer.C:
+		return true
 	}
 }
 
@@ -611,34 +655,49 @@ func (s *Scheduler) parkWorker(ctx context.Context, worker *workerConn) bool {
 //
 // Returns false if the queue is empty or if there are no ready workers.
 func (s *Scheduler) prepareAssignment() (taskAssignment, bool) {
-	resourcesGuard := s.resourcesMut.RLock("prepare_assignment")
-	defer resourcesGuard.RUnlock()
+	t, pos, ok := func() (*task, fair.Position, bool) {
+		resourcesGuard := s.resourcesMut.RLock("prepare_assignment")
+		defer resourcesGuard.RUnlock()
 
-	assignGuard := s.assignMut.Lock("prepare_assignment")
-	defer assignGuard.Unlock()
+		assignGuard := s.assignMut.Lock("prepare_assignment")
+		defer assignGuard.Unlock()
 
-	// clean up any terminal tasks at the front of the queue.
-	for s.taskQueue.Len() > 0 && s.peekTask().status.State.Terminal() {
-		s.taskQueue.Pop()
-	}
+		// clean up any terminal tasks at the front of the queue.
+		//
+		// Read the state through State() (which holds task.mut) rather than
+		// touching task.status directly: the field is mutated concurrently by
+		// SetState under task.mut.
+		for s.taskQueue.Len() > 0 && s.peekTask().State().Terminal() {
+			s.taskQueue.Pop()
+		}
 
-	if len(s.connectedWorkers) == 0 || s.taskQueue.Len() == 0 {
+		if len(s.connectedWorkers) == 0 || s.taskQueue.Len() == 0 {
+			return nil, fair.Position{}, false
+		}
+
+		t, scope, pos := s.taskQueue.Pop()
+		if scope != nil {
+			// For now, we will treat every task as having an equal cost of 1.
+			//
+			// This provides some level of fairness, but not all tasks need the
+			// same amount of time to complete, so tenants running heavy queries
+			// do not get properly penalized.
+			//
+			// TODO(rfratto): Introduce a better cost estimate for tasks, which
+			// may need to include re-adjusting the scope after task completion
+			// if the cost estimate was wrong.
+			_ = s.taskQueue.AdjustScope(scope, 1)
+		}
+
+		return t, pos, true
+	}()
+
+	if !ok {
 		return taskAssignment{}, false
 	}
 
-	t, scope, pos := s.taskQueue.Pop()
-	if scope != nil {
-		// For now, we will treat every task as having an equal cost of 1.
-		//
-		// This provides some level of fairness, but not all tasks need the
-		// same amount of time to complete, so tenants running heavy queries
-		// do not get properly penalized.
-		//
-		// TODO(rfratto): Introduce a better cost estimate for tasks, which
-		// may need to include re-adjusting the scope after task completion
-		// if the cost estimate was wrong.
-		_ = s.taskQueue.AdjustScope(scope, 1)
-	}
+	guard := s.resourcesMut.Lock("prepare_assignment")
+	defer guard.Unlock()
 
 	msg := s.buildAssignMessage(t)
 	return taskAssignment{t: t, pos: pos, msg: msg}, true
@@ -665,7 +724,7 @@ func (s *Scheduler) buildAssignMessage(t *task) wire.TaskAssignMessage {
 				continue
 			}
 
-			msg.StreamStates[rawSource.ULID] = source.state
+			msg.StreamStates[rawSource.ULID] = source.getState()
 		}
 	}
 
@@ -710,15 +769,21 @@ func (s *Scheduler) finalizeAssignment(ctx context.Context, t *task, worker *wor
 	hop := s.metrics.startAssignmentHop("finalize_assignment")
 	var pendingMsgs []pendingMessage
 
-	// Collect bookkeeping and messages under lock.
+	// Collect bookkeeping and messages under a read lock. A read lock is
+	// sufficient because everything here either reads the resourcesMut-protected
+	// maps (s.streams, s.tasks) or mutates state guarded by its own lock: the
+	// owner via task.markAssigned (task.mut) and the worker's task set via
+	// worker.Assign (worker.mut). Using the write lock here would serialize every
+	// dispatch — including the expensive per-source bind-message loop for
+	// fan-in root tasks — and starve concurrent readers, stalling dispatch.
 	func() {
-		resourcesGuard := s.resourcesMut.Lock("finalize_assignment")
-		defer resourcesGuard.Unlock()
+		resourcesGuard := s.resourcesMut.RLock("finalize_assignment")
+		defer resourcesGuard.RUnlock()
 
 		assignTime := t.AssignTime() // Set by [task.TryAssign] by the previous caller before this runs.
 		s.metrics.taskQueueSeconds.Observe(assignTime.Sub(t.QueueTime()).Seconds())
 
-		if t.State().Terminal() {
+		if !t.markAssigned(worker) {
 			// The task reached a terminal state between TryAssign and now. The
 			// worker may still have the assignment, so we tell it to not
 			// bother.
@@ -734,14 +799,16 @@ func (s *Scheduler) finalizeAssignment(ctx context.Context, t *task, worker *wor
 
 		// Reconcile stream states: send updates for any that changed while sending.
 		for streamID, sentState := range sentStates {
-			if current, found := s.streams[streamID]; found && current.state != sentState {
-				pendingMsgs = append(pendingMsgs, pendingMessage{
-					peer: worker,
-					msg: wire.StreamStatusMessage{
-						StreamID: streamID,
-						State:    current.state,
-					},
-				})
+			if current, found := s.streams[streamID]; found {
+				if curState := current.getState(); curState != sentState {
+					pendingMsgs = append(pendingMsgs, pendingMessage{
+						peer: worker,
+						msg: wire.StreamStatusMessage{
+							StreamID: streamID,
+							State:    curState,
+						},
+					})
+				}
 			}
 		}
 
@@ -781,25 +848,33 @@ func (s *Scheduler) finalizeAssignment(ctx context.Context, t *task, worker *wor
 // prepareBindMessage must be called while the resourcesMut lock is held.
 func (s *Scheduler) prepareBindMessage(check *stream) *pendingMessage {
 	sendingTask, hasSendingTask := s.tasks[check.taskSender]
-	if !hasSendingTask || sendingTask.owner == nil {
+	var sendingOwner *workerConn
+	if hasSendingTask {
+		sendingOwner = sendingTask.owner.Load()
+	}
+	if sendingOwner == nil {
 		// No sender, abort early.
 		return nil
 	}
 
 	receivingTask, hasReceivingTask := s.tasks[check.taskReceiver]
-	if hasReceivingTask && receivingTask.owner != nil {
+	var receivingOwner *workerConn
+	if hasReceivingTask {
+		receivingOwner = receivingTask.owner.Load()
+	}
+	if receivingOwner != nil {
 		// Bind the address of the receiving owner to the sender.
 		return &pendingMessage{
-			peer: sendingTask.owner,
+			peer: sendingOwner,
 			msg: wire.StreamBindMessage{
 				StreamID: check.inner.ULID,
-				Receiver: receivingTask.owner.RemoteAddr(),
+				Receiver: receivingOwner.RemoteAddr(),
 			},
 		}
 	} else if check.localReceiver != nil {
 		// We're listening for results ourselves; bind our address to the sender.
 		return &pendingMessage{
-			peer: sendingTask.owner,
+			peer: sendingOwner,
 			msg: wire.StreamBindMessage{
 				StreamID: check.inner.ULID,
 				Receiver: s.listener.Addr(),
@@ -1055,8 +1130,10 @@ func (s *Scheduler) UnregisterManifest(ctx context.Context, manifest *workflow.M
 		// canceled and it can stop processing it.
 		//
 		// This is a best-effort message, so we don't wait for acknowledgement.
-		if owner := registered.owner; owner != nil {
-			_ = owner.SendMessageAsync(ctx, wire.TaskCancelMessage{ID: registered.inner.ULID})
+		// Buffer it on the notifier so the send happens after resourcesMut is
+		// released rather than blocking the lock on a full connection buffer.
+		if owner := registered.owner.Load(); owner != nil {
+			n.AddMessage(owner, wire.TaskCancelMessage{ID: registered.inner.ULID})
 		}
 
 		registered.RecordTerminalObservations(time.Now())
@@ -1114,7 +1191,7 @@ func (s *Scheduler) unregisterManifestScope(manifest *workflow.Manifest) error {
 func (s *Scheduler) deleteTask(t *task) {
 	delete(s.tasks, t.inner.ULID)
 
-	if owner := t.owner; owner != nil {
+	if owner := t.owner.Load(); owner != nil {
 		owner.Unassign(t)
 	}
 }
@@ -1252,8 +1329,17 @@ func (s *Scheduler) markPending(ctx context.Context, tasks []*task) {
 	var n notifier
 	defer n.Notify(ctx)
 
-	resourcesGuard := s.resourcesMut.Lock("mark_pending")
-	defer resourcesGuard.Unlock()
+	// We intentionally do NOT hold s.resourcesMut here. markPending only mutates
+	// per-task state (guarded by each task's own mut via SetState) and builds
+	// local notifications; it never touches the resourcesMut-protected maps
+	// (s.tasks, s.streams) or task.owner.
+	//
+	// Holding resourcesMut would be actively harmful: the dispatcher assigns
+	// tasks concurrently via TryAssign, which holds a task's mut for the whole
+	// duration of the (up to 5s) SendMessage to a worker. If markPending held
+	// resourcesMut while SetState blocked on that same task's mut, it would pin
+	// the global resourcesMut behind a single worker's send latency and starve
+	// prepareAssignment (which needs resourcesMut.RLock), stalling all dispatch.
 
 	for _, task := range tasks {
 		if changed, _ := task.SetState(s.metrics, workflow.TaskStatus{State: workflow.TaskStatePending}); !changed {
@@ -1282,8 +1368,18 @@ func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 	var n notifier
 	defer n.Notify(ctx)
 
-	resourcesGuard := s.resourcesMut.Lock("cancel")
-	defer resourcesGuard.Unlock()
+	// A read lock is sufficient: Cancel only reads the resourcesMut-protected
+	// maps (s.tasks, s.streams) and task.owner (written only under the full
+	// write lock, in finalizeAssignment). Everything it mutates is per-task
+	// state (guarded by task.mut) or per-stream state (guarded by the stream's
+	// stateMut, via closeTaskSinks -> changeStreamState). During workflow
+	// teardown / short-circuit, Cancel is invoked in a storm (hundreds
+	// concurrently, from workflow event handlers on the connection goroutines);
+	// holding the write lock serializes them and starves the dispatcher's
+	// prepareAssignment read lock, stalling dispatch. A read lock lets them run
+	// concurrently.
+	resourcesGuard := s.resourcesMut.RLock("cancel")
+	defer resourcesGuard.RUnlock()
 
 	var errs []error
 
@@ -1310,7 +1406,7 @@ func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 
 		region := registered.wfRegion
 
-		if owner := registered.owner; owner != nil && registered.MarkInterrupted() {
+		if owner := registered.owner.Load(); owner != nil && registered.MarkInterrupted() {
 			// The task is currently running on a worker. We don't want to
 			// transition the task's state here so we can let the worker send
 			// final stats before acknowledging cancellation.
@@ -1319,7 +1415,12 @@ func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 			// handleTaskStatus. MarkInterrupted makes the cancel message
 			// at most once: a redundant Cancel for an already-interrupted task
 			// is a no-op.
-			_ = owner.SendMessageAsync(ctx, wire.TaskCancelMessage{ID: registered.inner.ULID})
+			//
+			// Buffer the send on the notifier so it happens after resourcesMut is
+			// released: a short-circuit cancellation storm can otherwise back up
+			// a worker's connection buffer and stall the scheduler while the lock
+			// is held.
+			n.AddMessage(owner, wire.TaskCancelMessage{ID: registered.inner.ULID})
 		} else if changed, _ := registered.SetState(s.metrics, workflow.TaskStatus{State: workflow.TaskStateCancelled}); changed {
 			// No worker is executing this task, so we transition the state
 			// directly as the scheduler is the source of truth.

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -393,12 +393,12 @@ func (s *Scheduler) handleStreamStatus(ctx context.Context, worker *workerConn, 
 	if !found {
 		return fmt.Errorf("stream %s not found", msg.StreamID)
 	}
-	return s.changeStreamState(ctx, &n, stream, msg.State)
+	return s.changeStreamState(&n, stream, msg.State)
 }
 
 // changeStreamState updates the state of the target stream. changeStreamState
 // must be called while the resourcesMut lock is held.
-func (s *Scheduler) changeStreamState(ctx context.Context, n *notifier, target *stream, newState workflow.StreamState) error {
+func (s *Scheduler) changeStreamState(n *notifier, target *stream, newState workflow.StreamState) error {
 	changed, err := target.setState(s.metrics, newState)
 	if err != nil {
 		return err

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -1400,7 +1400,7 @@ func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 		// still closes any associated streams.
 		prevState := registered.State()
 		if prevState.Terminal() {
-			s.closeTaskSinks(ctx, &n, registered)
+			s.closeTaskSinks(&n, registered)
 			continue
 		}
 
@@ -1452,7 +1452,7 @@ func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 			})
 		}
 
-		s.closeTaskSinks(ctx, &n, registered)
+		s.closeTaskSinks(&n, registered)
 	}
 
 	if len(errs) > 0 {
@@ -1465,7 +1465,7 @@ func (s *Scheduler) Cancel(ctx context.Context, tasks ...*workflow.Task) error {
 // closed) and queues stream-state notifications onto n.
 //
 // closeTaskSinks must be called while resourcesMut is held.
-func (s *Scheduler) closeTaskSinks(ctx context.Context, n *notifier, t *task) {
+func (s *Scheduler) closeTaskSinks(n *notifier, t *task) {
 	for _, sinks := range t.inner.Sinks {
 		for _, rawSink := range sinks {
 			sink, ok := s.streams[rawSink.ULID]

--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -1473,7 +1473,7 @@ func (s *Scheduler) closeTaskSinks(ctx context.Context, n *notifier, t *task) {
 				continue
 			}
 
-			_ = s.changeStreamState(ctx, n, sink, workflow.StreamStateClosed)
+			_ = s.changeStreamState(n, sink, workflow.StreamStateClosed)
 		}
 	}
 }

--- a/pkg/engine/internal/scheduler/stream.go
+++ b/pkg/engine/internal/scheduler/stream.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/grafana/loki/v3/pkg/engine/internal/obslock"
 	"github.com/oklog/ulid/v2"
+
+	"github.com/grafana/loki/v3/pkg/engine/internal/obslock"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
 )

--- a/pkg/engine/internal/scheduler/stream.go
+++ b/pkg/engine/internal/scheduler/stream.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/grafana/loki/v3/pkg/engine/internal/obslock"
 	"github.com/oklog/ulid/v2"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
@@ -14,7 +15,13 @@ type stream struct {
 	inner   *workflow.Stream
 	handler workflow.StreamEventHandler
 
-	state workflow.StreamState
+	// stateMut guards state so that stream-state transitions do not require the
+	// scheduler's global resourcesMut write lock. This lets the hot
+	// handleStreamStatus path (which floods the scheduler during fan-in
+	// teardown) hold only resourcesMut.RLock, mirroring how task state is
+	// guarded by the per-task mutex.
+	stateMut obslock.Mutex
+	state    workflow.StreamState
 
 	localReceiver workflow.RecordWriter // Local receiver (for root task results)
 	taskReceiver  ulid.ULID             // ID of the receiving task.
@@ -28,12 +35,22 @@ var validStreamTransitions = map[workflow.StreamState][]workflow.StreamState{
 	workflow.StreamStateClosed:  {}, // Closed streams cannot transition to any other state.
 }
 
+// getState returns the current state of the stream.
+func (s *stream) getState() workflow.StreamState {
+	guard := s.stateMut.Lock("get_state")
+	defer guard.Unlock()
+	return s.state
+}
+
 // setState updates the state of the stream. setState returns an error if the
 // transition is invalid.
 //
 // Returns true if the state was updated, false otherwise (such as if the task
 // is already in the desired state).
 func (s *stream) setState(m *metrics, newState workflow.StreamState) (bool, error) {
+	guard := s.stateMut.Lock("set_state")
+	defer guard.Unlock()
+
 	oldState := s.state
 
 	if newState == oldState {

--- a/pkg/engine/internal/scheduler/task.go
+++ b/pkg/engine/internal/scheduler/task.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/schedulerstat"
@@ -53,8 +54,11 @@ type task struct {
 	wfRegion        *xcap.Region
 	runtimeTraceCtx context.Context
 
-	// Protected by [Scheduler.resourcesMut].
-	owner *workerConn
+	// owner is the worker the task is currently assigned to (nil if unassigned).
+	// It is an atomic pointer rather than being guarded by resourcesMut so that
+	// the per-dispatch finalizeAssignment path — which sets it — does not need
+	// the global write lock and can run concurrently with other readers.
+	owner atomic.Pointer[workerConn]
 }
 
 var validTaskTransitions = map[workflow.TaskState][]workflow.TaskState{
@@ -174,20 +178,36 @@ func (t *task) MarkInterrupted() bool {
 	return true
 }
 
-// TryAssign calls doAssign, holding a mutex on the task to prevent concurrent
-// modification to t's state.
+// TryAssign calls doAssign to send the task's assignment to a worker.
 //
 // If doAssign returns nil, the assign time is recorded and TryAssign returns
-// nil. Otherwise, TryAssign returns the error from doAssign without making any
-// changes.
+// nil. Otherwise, TryAssign returns the error from doAssign without recording
+// the assign time.
 //
 // If the task is in a terminal state or has been interrupted, TryAssign
 // returns [errUnassignable] without calling doAssign.
+//
+// TryAssign deliberately does NOT hold t.mut for the duration of doAssign.
+// doAssign performs a blocking, network-round-trip send to the worker (up to
+// several seconds under load), and t.mut is also acquired by hot scheduler
+// paths — handleTaskStatus, finalizeAssignment, and Cancel — several of which
+// hold the global resourcesMut while calling t.SetState. Holding t.mut across
+// the send would therefore pin resourcesMut behind a single worker's send
+// latency and starve the dispatcher (prepareAssignment needs resourcesMut),
+// stalling all task dispatch.
+//
+// Releasing t.mut during the send is safe: a task that becomes terminal or
+// interrupted between the pre-check and the send is caught by the terminal
+// re-check in [Scheduler.finalizeAssignment] (which runs under resourcesMut
+// after TryAssign returns and cancels the assignment on the worker), and
+// callers already tolerate assignTime being unset when a worker responds
+// before the assignment is finalized.
 func (t *task) TryAssign(doAssign func() error) error {
-	t.mut.Lock()
-	defer t.mut.Unlock()
+	t.mut.RLock()
+	unassignable := t.status.State.Terminal() || t.interrupted
+	t.mut.RUnlock()
 
-	if t.status.State.Terminal() || t.interrupted {
+	if unassignable {
 		return errUnassignable
 	}
 
@@ -195,8 +215,29 @@ func (t *task) TryAssign(doAssign func() error) error {
 		return err
 	}
 
+	t.mut.Lock()
 	t.assignTime = time.Now()
+	t.mut.Unlock()
 	return nil
+}
+
+// markAssigned records wc as the task's owner unless the task has already
+// reached a terminal state, returning true if the task was marked assigned.
+//
+// Holding t.mut makes the terminal check and the owner store atomic with
+// respect to SetState, so a task that goes terminal concurrently (e.g. a fast
+// worker completing it, or a Cancel) is never left owned by a worker. This lets
+// finalizeAssignment run under resourcesMut.RLock instead of the global write
+// lock.
+func (t *task) markAssigned(wc *workerConn) bool {
+	t.mut.Lock()
+	defer t.mut.Unlock()
+
+	if t.status.State.Terminal() {
+		return false
+	}
+	t.owner.Store(wc)
+	return true
 }
 
 // RecordTerminalObservations records the scheduler-side per-task duration

--- a/pkg/engine/internal/scheduler/task.go
+++ b/pkg/engine/internal/scheduler/task.go
@@ -6,8 +6,9 @@ import (
 	"net/http"
 	"slices"
 	"sync"
-	"sync/atomic"
 	"time"
+
+	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/engine/internal/scheduler/schedulerstat"
 	"github.com/grafana/loki/v3/pkg/engine/internal/util/queue/fair"

--- a/pkg/engine/internal/scheduler/wire/metrics_test.go
+++ b/pkg/engine/internal/scheduler/wire/metrics_test.go
@@ -212,37 +212,12 @@ func TestPeer_Metrics_ActiveConnection(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond, "client connection should be marked inactive")
 }
 
-func TestPeer_Metrics_BlockedOutgoingQueue(t *testing.T) {
-	metrics := NewMetrics()
-	peer := &Peer{Logger: log.NewNopLogger(), Metrics: metrics, Buffer: 1}
-	peer.lazyInit()
-
-	frame := MessageFrame{ID: 1, Message: WorkerReadyMessage{}}
-	peer.outgoing <- outgoingFrame{frame: frame, sendMode: sendModeAsync, enqueuedAt: time.Now()}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- peer.SendMessageAsync(ctx, WorkerReadyMessage{})
-	}()
-
-	labels := map[string]string{
-		"queue":        queueOutgoing.String(),
-		"frame_type":   FrameKindMessage.String(),
-		"message_type": WorkerReadyMessage{}.Kind().String(),
-		"mode":         sendModeAsync.String(),
-	}
-	require.Eventually(t, func() bool {
-		return gaugeValue(t, metrics.reg, "loki_engine_scheduler_wire_queue_blocked_senders", labels) == 1
-	}, 5*time.Second, 10*time.Millisecond, "sender should be blocked by the full outgoing queue")
-
-	cancel()
-	require.ErrorIs(t, <-errCh, context.Canceled)
-	require.Eventually(t, func() bool {
-		return gaugeValue(t, metrics.reg, "loki_engine_scheduler_wire_queue_blocked_senders", labels) == 0
-	}, 5*time.Second, 10*time.Millisecond, "blocked-sender gauge should drain")
-}
+// NOTE: the outgoing queue is intentionally an unbounded, non-blocking queue
+// (see Peer.enqueueFrame) so that a handler running on the incoming goroutine
+// never blocks on a backed-up peer — this prevents a duplex-connection deadlock.
+// Because outgoing sends never block, there is no "blocked outgoing sender"
+// metric to assert; the blocked-sender gauge is still exercised by the bounded
+// incoming queue on the receive path.
 
 func TestPeer_Metrics_LocalRoundTripFrameLabels(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/pkg/engine/internal/scheduler/wire/peer.go
+++ b/pkg/engine/internal/scheduler/wire/peer.go
@@ -30,8 +30,17 @@ type Peer struct {
 
 	done     chan struct{}        // Closed when the peer connection is closed.
 	incoming chan incomingMessage // Buffered queue of incoming messages.
-	outgoing chan outgoingFrame   // Buffered queue of outgoing frames.
 	initOnce sync.Once
+
+	// Outbound frames are held in an unbounded queue drained by handleOutgoing,
+	// rather than a bounded channel. enqueueFrame is called by message handlers
+	// running on the incoming goroutine; if it could block (as a full bounded
+	// channel would), incoming processing would stall and the duplex connection
+	// could deadlock once both peers' outbound buffers fill. A non-blocking
+	// enqueue guarantees receiving never waits on sending.
+	outMu    sync.Mutex
+	outQueue []outgoingFrame
+	outWake  chan struct{} // Buffered(1) signal that outQueue is non-empty.
 
 	requestID    atomic.Uint64
 	sentRequests sync.Map // map[uint64]*request
@@ -89,7 +98,7 @@ func (p *Peer) lazyInit() {
 	p.initOnce.Do(func() {
 		p.done = make(chan struct{})
 		p.incoming = make(chan incomingMessage, p.Buffer)
-		p.outgoing = make(chan outgoingFrame, p.Buffer)
+		p.outWake = make(chan struct{}, 1)
 	})
 }
 
@@ -200,17 +209,39 @@ func (p *Peer) handleIncoming(ctx context.Context) error {
 
 func (p *Peer) handleOutgoing(ctx context.Context) error {
 	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-p.done:
-			return nil // Closed connection.
-		case queued := <-p.outgoing:
+		p.outMu.Lock()
+		batch := p.outQueue
+		p.outQueue = nil
+		p.outMu.Unlock()
+
+		for _, queued := range batch {
 			frame, sendMode := p.dequeueOutgoing(queued)
 			if err := p.Conn.sendFrame(ctx, frame, sendMode); err != nil && ctx.Err() == nil {
 				level.Warn(p.Logger).Log("msg", "failed to send message", "error", err)
 				p.notifyError(frame, err)
 			}
+		}
+
+		// If we drained frames, loop again immediately to pick up anything
+		// enqueued while we were sending (checking for shutdown first).
+		if len(batch) > 0 {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-p.done:
+				return nil
+			default:
+			}
+			continue
+		}
+
+		// Queue empty: wait for a wake-up or shutdown.
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-p.done:
+			return nil // Closed connection.
+		case <-p.outWake:
 		}
 	}
 }
@@ -395,33 +426,36 @@ func (p *Peer) SendMessageAsync(ctx context.Context, message Message) error {
 	return p.enqueueFrame(ctx, MessageFrame{ID: reqID, Message: message}, sendModeAsync)
 }
 
-// enqueueFrame enqueues a frame to be sent to the remote peer. sendMode records
-// how the send was issued (sync|async|internal) for queue metrics.
+// enqueueFrame enqueues a frame to be sent to the remote peer.
+// enqueueFrame appends a frame to the unbounded outbound queue and signals
+// handleOutgoing. It never blocks on a slow or backed-up peer. This is
+// essential: enqueueFrame runs on the incoming/handler goroutine, so blocking
+// here would stall incoming processing and can deadlock the duplex connection
+// when both peers' outbound buffers fill (e.g. under a stream-status /
+// cancellation storm). Backpressure is handled at the protocol layer
+// (WorkerReady / 429), not by blocking raw frame delivery.
 func (p *Peer) enqueueFrame(ctx context.Context, frame Frame, sendMode sendMode) error {
-	queued := outgoingFrame{frame: frame, sendMode: sendMode, enqueuedAt: time.Now()}
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-p.done:
 		return ErrConnClosed
-	case p.outgoing <- queued:
-		p.noteFrameEnqueued(queueOutgoing, frame, sendMode)
-		return nil
 	default:
 	}
 
-	done := p.noteQueueBlockedSender(queueOutgoing, frame, sendMode)
-	defer done()
+	queued := outgoingFrame{frame: frame, sendMode: sendMode, enqueuedAt: time.Now()}
+
+	p.outMu.Lock()
+	p.outQueue = append(p.outQueue, queued)
+	p.outMu.Unlock()
+
+	p.noteFrameEnqueued(queueOutgoing, frame, sendMode)
 
 	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-p.done:
-		return ErrConnClosed
-	case p.outgoing <- queued:
-		p.noteFrameEnqueued(queueOutgoing, frame, sendMode)
-		return nil
+	case p.outWake <- struct{}{}:
+	default:
 	}
+	return nil
 }
 
 // LocalAddr returns the address of the local peer.

--- a/pkg/engine/internal/scheduler/worker_conn.go
+++ b/pkg/engine/internal/scheduler/worker_conn.go
@@ -143,11 +143,12 @@ func (wc *workerConn) Assigned() []*task {
 }
 
 // Assign assigns a task to the worker.
+// Assign records that the task is tracked by this worker connection so it can
+// be cleaned up if the worker disconnects. The task's owner pointer is set
+// separately by [task.markAssigned] under the task's own mutex.
 func (wc *workerConn) Assign(assigned *task) {
 	wc.mut.Lock()
 	defer wc.mut.Unlock()
-
-	assigned.owner = wc
 
 	if wc.tasks == nil {
 		wc.tasks = make(map[*task]struct{})

--- a/pkg/engine/internal/workflow/stream_pipe.go
+++ b/pkg/engine/internal/workflow/stream_pipe.go
@@ -44,7 +44,7 @@ func newEOFPipeline() eofPipeline { return eofPipeline{} }
 func newStreamPipe() *streamPipe {
 	return &streamPipe{
 		closed:  make(chan struct{}),
-		results: make(chan arrow.RecordBatch),
+		results: make(chan arrow.RecordBatch, 256),
 		errCond: make(chan struct{}),
 	}
 }
@@ -59,12 +59,16 @@ func (pipe *streamPipe) Read(ctx context.Context) (arrow.RecordBatch, error) {
 		return nil, ctx.Err()
 	case <-pipe.errCond:
 		return nil, pipe.err
-	case <-pipe.closed:
-		// Check to see if the pipeline has a more specific error before falling
-		// back to EOF.
+	//case <-pipe.closed:
+	//	// Check to see if the pipeline has a more specific error before falling
+	//	// back to EOF.
+	//	return nil, pipe.checkError(executor.EOF)
+	case rec, ok := <-pipe.results:
+		if ok {
+			return rec, nil
+		}
+
 		return nil, pipe.checkError(executor.EOF)
-	case rec := <-pipe.results:
-		return rec, nil
 	}
 }
 
@@ -108,5 +112,6 @@ func (pipe *streamPipe) SetError(err error) {
 func (pipe *streamPipe) Close() {
 	pipe.closeOnce.Do(func() {
 		close(pipe.closed)
+		close(pipe.results)
 	})
 }


### PR DESCRIPTION
…ispatch

Under the dummy-scheduler benchmark the scheduler stalls: dispatch freezes for seconds at a time. Root causes were locks/blocking held across the hot dispatch path, serializing everything behind a single global lock or a full connection buffer. Fixes:

- wire.Peer: make the outbound queue non-blocking/unbounded so a handler on the receive goroutine never blocks on a backed-up peer (removes a bidirectional duplex-connection deadlock under the stream-status/cancel storm).
- scheduler: take resourcesMut as a read lock on the hot paths (handleTaskStatus, handleStreamStatus, Cancel, finalizeAssignment); guard per-stream state with a stream-local mutex and per-task owner with an atomic pointer so those paths no longer need the global write lock.
- task.TryAssign: don't hold the task mutex across the (blocking) worker send; finalizeAssignment uses task.markAssigned to keep the terminal-check + owner assignment atomic without the global lock.
- notifier: buffer best-effort worker messages and send them after locks are released.
- parkWorker: wake periodically as a safety net against a lost readiness edge stranding a worker that has freed threads.
- workflow.streamPipe: buffer the results channel and signal EOF by closing it (draining buffered batches first) instead of racing a close signal against buffered records, so result delivery neither blocks the sender synchronously nor drops batches on close.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
