### PR TITLE
feat(dataobj-compactor): Log merge executor planning

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1633,6 +1633,12 @@ dataobj:
     # CLI flag: -dataobj.compaction.logs.max-runs-per-task
     [logs_max_runs_per_task: <int> | default = 3]
 
+    # Experimental: Minimum total compactable data (sum of all runs'
+    # uncompressed size) that justifies log compaction. Converged windows below
+    # this floor are skipped.
+    # CLI flag: -dataobj.compaction.logs.min-compaction-size
+    [logs_min_compaction_size: <int> | default = 4MiB]
+
     # Experimental: Coordinator-side timeout around the inline ToC
     # ReplaceIndexPointers call. Not a task TTL.
     # CLI flag: -dataobj.compaction.toc-consolidate-timeout

--- a/pkg/dataobj/compaction/v2/calculator.go
+++ b/pkg/dataobj/compaction/v2/calculator.go
@@ -18,6 +18,16 @@ type run struct {
 	topMaxTimestamp int64
 }
 
+func (r *run) Sections() []*compactionv2pb.SectionRef { return r.sections }
+
+func (r *run) Size() uint64 {
+	var total uint64
+	for _, s := range r.sections {
+		total += uint64(s.UncompressedSize)
+	}
+	return total
+}
+
 // cmpSortKey compares two composite (labels, timestamp) sort keys
 // lexicographically -- labels first, then timestamp.
 // Returns -1 if a < b, 0 if equal, +1 if a > b.

--- a/pkg/dataobj/compaction/v2/plan.go
+++ b/pkg/dataobj/compaction/v2/plan.go
@@ -1,62 +1,73 @@
 package compactionv2
 
 import (
-	"context"
 	"fmt"
 
 	compactionv2pb "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2/proto"
 )
 
-// Plan sorts the input sections into P runs and groups them into
-// ⌈P/K⌉ task batches: runs [0..K) -> task 0, runs [K..2K) -> task 1, ...
-//
-// The output is deterministic for a given input regardless of the input order.
+// Run is one non-overlapping layer of sections over the sort key.
+type Run interface {
+	// Sections returns the run's sections in sorted order.
+	Sections() []*compactionv2pb.SectionRef
+	// Size returns the sum of the run's sections' UncompressedSize.
+	Size() uint64
+}
+
+// CalculateRuns sorts [sections] in place and returns the resulting runs.
+func CalculateRuns(sections []*compactionv2pb.SectionRef) []Run {
+	calculated := calculateRuns(sections)
+	runs := make([]Run, len(calculated))
+	for i, r := range calculated {
+		runs[i] = r
+	}
+	return runs
+}
+
+// IsTerminal reports whether a converged window is already a single run (or
+// none), or when the total data across all runs is below minCompactionSize.
+func IsTerminal(runs []Run, minCompactionSize uint64) bool {
+	if len(runs) <= 1 {
+		return true
+	}
+	var total uint64
+	for _, r := range runs {
+		total += r.Size()
+	}
+	return total < minCompactionSize
+}
+
+// Plan groups [runs] into ⌈P/K⌉ task batches: runs [0..K) -> task
+// 0, runs [K..2K) -> task 1, ... The output is deterministic for a given input.
 //
 // Special cases:
-//   - len(sections) == 0  -> returns nil (no tasks).
-//   - k >= P              -> returns a single TaskSpec containing all runs.
-//
-// K must be greater than 0. Plan sorts the input sections slice in place;
-// callers that need the original order must copy beforehand. The contract
-// requires non-nil SectionRef entries.
-//
-// The ctx parameter is currently not used. The algorithm runs to completion
-// without honoring cancellation, because partial output would violate the
-// determinism contract.
+//   - len(runs) == 0 -> returns nil (no tasks).
+//   - k >= P         -> returns a single TaskSpec containing all runs.
 func Plan(
-	ctx context.Context,
-	sections []*compactionv2pb.SectionRef,
+	runs []Run,
 	tenant string,
 	k int,
 	sortSchema []string,
 ) []*compactionv2pb.TaskSpec {
-	_ = ctx
 	if k <= 0 {
 		panic(fmt.Sprintf("k must be > 0, got %d", k))
 	}
-	if len(sections) == 0 {
+	if len(runs) == 0 {
 		return nil
 	}
 
-	calculated := calculateRuns(sections)
-	if len(calculated) == 0 {
-		return nil
+	refs := make([]*compactionv2pb.RunRef, len(runs))
+	for i, r := range runs {
+		refs[i] = &compactionv2pb.RunRef{Sections: r.Sections()}
 	}
 
-	// Materialize runs as RunRefs in creation order.
-	runs := make([]*compactionv2pb.RunRef, len(calculated))
-	for i, r := range calculated {
-		runs[i] = &compactionv2pb.RunRef{Sections: r.sections}
-	}
-
-	// Group into ⌈P/K⌉ TaskSpec batches.
-	numTasks := (len(runs) + k - 1) / k
+	numTasks := (len(refs) + k - 1) / k
 	tasks := make([]*compactionv2pb.TaskSpec, 0, numTasks)
-	for start := 0; start < len(runs); start += k {
-		end := min(start+k, len(runs))
+	for start := 0; start < len(refs); start += k {
+		end := min(start+k, len(refs))
 		tasks = append(tasks, &compactionv2pb.TaskSpec{
 			Tenant:     tenant,
-			Runs:       runs[start:end],
+			Runs:       refs[start:end],
 			SortSchema: sortSchema,
 		})
 	}

--- a/pkg/dataobj/compaction/v2/plan_test.go
+++ b/pkg/dataobj/compaction/v2/plan_test.go
@@ -1,8 +1,6 @@
 package compactionv2
 
 import (
-	"context"
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,139 +8,73 @@ import (
 	compactionv2pb "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2/proto"
 )
 
-func TestPlan_EmptyInput(t *testing.T) {
-	got := Plan(context.Background(), nil, "tenantA", 3, nil)
-	require.Nil(t, got, "empty input should produce no tasks")
+type fakeRun struct {
+	sections []*compactionv2pb.SectionRef
+	size     uint64
+}
 
-	got = Plan(context.Background(), []*compactionv2pb.SectionRef{}, "tenantA", 3, nil)
-	require.Nil(t, got)
+func (f fakeRun) Sections() []*compactionv2pb.SectionRef { return f.sections }
+func (f fakeRun) Size() uint64                           { return f.size }
+
+func TestPlan_EmptyInput(t *testing.T) {
+	require.Nil(t, Plan(nil, "tenantA", 3, nil))
+	require.Nil(t, Plan([]Run{}, "tenantA", 3, nil))
 }
 
 func TestPlan_InvalidK_Panics(t *testing.T) {
-	sections := []*compactionv2pb.SectionRef{sec("o", 0, "a", "b")}
-
-	require.PanicsWithValue(t, "k must be > 0, got 0", func() {
-		Plan(context.Background(), sections, "tenantA", 0, nil)
-	}, "k=0 must panic")
-
-	require.PanicsWithValue(t, "k must be > 0, got -1", func() {
-		Plan(context.Background(), sections, "tenantA", -1, nil)
-	}, "negative k must panic")
-
-	// Empty input + k<=0: panic still fires (k validation is unconditional).
-	require.Panics(t, func() {
-		Plan(context.Background(), nil, "tenantA", 0, nil)
-	}, "k<=0 panic fires even with empty input")
+	runs := []Run{fakeRun{sections: []*compactionv2pb.SectionRef{{ObjectPath: "a"}}}}
+	require.PanicsWithValue(t, "k must be > 0, got 0", func() { Plan(runs, "tenantA", 0, nil) })
+	require.PanicsWithValue(t, "k must be > 0, got -1", func() { Plan(runs, "tenantA", -1, nil) })
+	// nil runs (typed []Run) with k<=0 still panics on k before the empty check.
+	require.PanicsWithValue(t, "k must be > 0, got 0", func() { Plan(nil, "tenantA", 0, nil) })
 }
 
-func TestPlan_SingleSection(t *testing.T) {
-	s := sec("o", 0, "a", "b")
-	got := Plan(context.Background(), []*compactionv2pb.SectionRef{s}, "tenantA", 8, nil)
-
-	require.Len(t, got, 1, "P=1 K=8 should produce exactly 1 task")
+func TestPlan_SingleRun(t *testing.T) {
+	s := &compactionv2pb.SectionRef{ObjectPath: "a", SectionIndex: 0}
+	got := Plan([]Run{fakeRun{sections: []*compactionv2pb.SectionRef{s}}}, "tenantA", 8, nil)
+	require.Len(t, got, 1)
 	require.Equal(t, "tenantA", got[0].Tenant)
 	require.Len(t, got[0].Runs, 1)
-	require.Equal(t, []*compactionv2pb.SectionRef{s}, got[0].Runs[0].Sections)
 }
 
 func TestPlan_KGrouping_P10_K3(t *testing.T) {
-	// Construct exactly 10 piles by feeding 10 mutually-overlapping sections.
-	// All share MinKey "a" but have different MaxKeys (and stable_ids), so each
-	// section creates its own pile.
-	sections := make([]*compactionv2pb.SectionRef, 0, 10)
-	for i := 0; i < 10; i++ {
-		// MaxKey = "z" so all of them overlap pairwise (MinKey "a" < MaxKey "z").
-		sections = append(sections, sec("o", int64(i), "a", "z"))
+	runs := make([]Run, 10)
+	for i := range runs {
+		runs[i] = fakeRun{sections: []*compactionv2pb.SectionRef{{ObjectPath: "o", SectionIndex: int64(i)}}}
 	}
-
-	got := Plan(context.Background(), sections, "tenantA", 3, nil)
-
-	require.Len(t, got, 4, "P=10 K=3 should produce ⌈10/3⌉ = 4 tasks")
-	require.Equal(t, "tenantA", got[0].Tenant)
-
-	// Verify task sizes: 3, 3, 3, 1.
+	got := Plan(runs, "tenantA", 3, nil)
+	require.Len(t, got, 4) // ceil(10/3)
 	require.Len(t, got[0].Runs, 3)
 	require.Len(t, got[1].Runs, 3)
 	require.Len(t, got[2].Runs, 3)
 	require.Len(t, got[3].Runs, 1)
-
-	// Total piles across all tasks == 10.
-	total := 0
-	for _, tsk := range got {
-		total += len(tsk.Runs)
-	}
-	require.Equal(t, 10, total)
 }
 
 func TestPlan_KGreaterThanP(t *testing.T) {
-	// 3 mutually-overlapping sections (P=3); K=100 → 1 task with 3 piles.
-	sections := []*compactionv2pb.SectionRef{
-		sec("o", 0, "a", "z"),
-		sec("o", 1, "a", "z"),
-		sec("o", 2, "a", "z"),
+	runs := make([]Run, 3)
+	for i := range runs {
+		runs[i] = fakeRun{sections: []*compactionv2pb.SectionRef{{ObjectPath: "o", SectionIndex: int64(i)}}}
 	}
-
-	got := Plan(context.Background(), sections, "tenantB", 100, nil)
+	got := Plan(runs, "tenantB", 100, nil)
 	require.Len(t, got, 1)
-	require.Equal(t, "tenantB", got[0].Tenant)
 	require.Len(t, got[0].Runs, 3)
 }
 
-func TestPlan_Determinism(t *testing.T) {
-	// Mix of overlapping and non-overlapping sections.
-	base := []*compactionv2pb.SectionRef{
-		sec("o", 0, "01", "03"),
-		sec("o", 1, "02", "04"),
-		sec("o", 2, "05", "07"),
-		sec("o", 3, "06", "10"),
-		sec("o", 4, "11", "13"),
-		sec("o", 5, "12", "14"),
-		sec("o", 6, "15", "18"),
-		sec("p", 0, "02", "06"),
-		sec("p", 1, "08", "09"),
-	}
-
-	want := Plan(context.Background(), append([]*compactionv2pb.SectionRef(nil), base...), "tenantA", 3, nil)
-
-	r := rand.New(rand.NewSource(1337))
-	for trial := 0; trial < 10; trial++ {
-		shuffled := append([]*compactionv2pb.SectionRef(nil), base...)
-		r.Shuffle(len(shuffled), func(i, j int) {
-			shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
-		})
-		got := Plan(context.Background(), shuffled, "tenantA", 3, nil)
-
-		require.Equal(t, len(want), len(got), "trial %d: task count must be deterministic", trial)
-		for i := range want {
-			require.Equal(t, want[i].Tenant, got[i].Tenant)
-			require.Equal(t, len(want[i].Runs), len(got[i].Runs), "trial %d: task %d run count", trial, i)
-			for j := range want[i].Runs {
-				require.Equal(t, want[i].Runs[j].Sections, got[i].Runs[j].Sections,
-					"trial %d: task %d run %d sections", trial, i, j)
-			}
-		}
-	}
-}
-
 func TestPlan_TenantPassThrough(t *testing.T) {
-	sections := []*compactionv2pb.SectionRef{sec("o", 0, "a", "b"), sec("o", 1, "a", "c")}
-	for _, tenant := range []string{"", "tenant-1", "tenant_with_strange_chars-A.B/C"} {
-		got := Plan(context.Background(), sections, tenant, 1, nil)
-		for _, tsk := range got {
-			require.Equal(t, tenant, tsk.Tenant)
-		}
+	runs := []Run{fakeRun{sections: []*compactionv2pb.SectionRef{{ObjectPath: "a"}}}}
+	for _, tenant := range []string{"t1", "t2"} {
+		got := Plan(runs, tenant, 1, nil)
+		require.Equal(t, tenant, got[0].Tenant)
 	}
 }
 
 func TestPlan_StampsSortSchema(t *testing.T) {
-	sections := []*compactionv2pb.SectionRef{
-		{ObjectPath: "o0", SectionIndex: 0, MinKey: []string{"a"}, MaxKey: []string{"a"}},
-		{ObjectPath: "o1", SectionIndex: 0, MinKey: []string{"b"}, MaxKey: []string{"b"}},
+	schema := []string{"label:service_name"}
+	runs := make([]Run, 3)
+	for i := range runs {
+		runs[i] = fakeRun{sections: []*compactionv2pb.SectionRef{{ObjectPath: "o", SectionIndex: int64(i)}}}
 	}
-	schema := []string{"service_name"}
-
-	tasks := Plan(context.Background(), sections, "t1", 2, schema)
-
+	tasks := Plan(runs, "t1", 2, schema)
 	require.NotEmpty(t, tasks)
 	for _, ts := range tasks {
 		require.Equal(t, schema, ts.SortSchema)
@@ -150,10 +82,67 @@ func TestPlan_StampsSortSchema(t *testing.T) {
 }
 
 func TestPlan_NilSortSchemaStaysEmpty(t *testing.T) {
-	sections := []*compactionv2pb.SectionRef{{ObjectPath: "o0", SectionIndex: 0}}
-
-	tasks := Plan(context.Background(), sections, "t1", 2, nil)
-
+	runs := []Run{fakeRun{sections: []*compactionv2pb.SectionRef{{ObjectPath: "a"}}}}
+	tasks := Plan(runs, "t1", 2, nil)
 	require.NotEmpty(t, tasks)
 	require.Empty(t, tasks[0].SortSchema)
+}
+
+func TestRun_SizeAndSections(t *testing.T) {
+	s1 := &compactionv2pb.SectionRef{ObjectPath: "a", SectionIndex: 0, UncompressedSize: 100}
+	s2 := &compactionv2pb.SectionRef{ObjectPath: "a", SectionIndex: 1, UncompressedSize: 250}
+
+	var r Run = &run{sections: []*compactionv2pb.SectionRef{s1, s2}}
+
+	require.Equal(t, uint64(350), r.Size())
+	require.Equal(t, []*compactionv2pb.SectionRef{s1, s2}, r.Sections())
+}
+
+func TestRun_SizeEmpty(t *testing.T) {
+	var r Run = &run{sections: nil}
+	require.Equal(t, uint64(0), r.Size())
+	require.Empty(t, r.Sections())
+}
+
+func TestCalculateRuns_EmptyInput(t *testing.T) {
+	require.Empty(t, CalculateRuns(nil))
+	require.Empty(t, CalculateRuns([]*compactionv2pb.SectionRef{}))
+}
+
+func TestCalculateRuns_WrapsRunsAndSortsInPlace(t *testing.T) {
+	// Two non-overlapping same-tuple sections (disjoint, ordered times) chain
+	// into one run; passed out of order to prove in-place sorting.
+	a := &compactionv2pb.SectionRef{ObjectPath: "a", SectionIndex: 0, MinKey: []string{"svc"}, MaxKey: []string{"svc"}, MinTimestamp: 10, MaxTimestamp: 20, UncompressedSize: 5}
+	b := &compactionv2pb.SectionRef{ObjectPath: "b", SectionIndex: 0, MinKey: []string{"svc"}, MaxKey: []string{"svc"}, MinTimestamp: 30, MaxTimestamp: 40, UncompressedSize: 7}
+
+	input := []*compactionv2pb.SectionRef{b, a}
+	runs := CalculateRuns(input)
+
+	require.Len(t, runs, 1)
+	require.Equal(t, uint64(12), runs[0].Size())
+	require.Equal(t, []*compactionv2pb.SectionRef{a, b}, input, "input sorted in place")
+}
+
+func TestIsTerminal(t *testing.T) {
+	const floor = uint64(100)
+	run := func(size uint64) Run { return fakeRun{size: size} }
+
+	tests := []struct {
+		name     string
+		runs     []Run
+		terminal bool
+	}{
+		{"no runs", nil, true},
+		{"single run below floor", []Run{run(1)}, true},
+		{"single run above floor", []Run{run(500)}, true},
+		{"two runs total >= floor", []Run{run(60), run(60)}, false},
+		{"two runs total exactly floor", []Run{run(50), run(50)}, false},
+		{"two runs total below floor", []Run{run(10), run(20)}, true},
+		{"many tiny runs below floor (small tenant)", []Run{run(5), run(5), run(5)}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.terminal, IsTerminal(tc.runs, floor))
+		})
+	}
 }

--- a/pkg/engine/compactor/config.go
+++ b/pkg/engine/compactor/config.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 )
 
@@ -46,6 +47,11 @@ type Config struct {
 	// LogMaxRunsPerTask (K for log compaction) is the maximum number of runs a
 	// single LogMerge task may consume. Kept separate from index max runs
 	LogMaxRunsPerTask int `yaml:"logs_max_runs_per_task"`
+
+	// LogMinCompactionSize is the minimum total compactable data (sum of all
+	// runs' uncompressed size) that justifies log compaction. Converged
+	// windows below this floor are skipped.
+	LogMinCompactionSize flagext.Bytes `yaml:"logs_min_compaction_size"`
 
 	// ToCConsolidateTimeout bounds the coordinator's inline ReplaceIndexPointers
 	// call. NOT a task TTL — applied as context.WithTimeout around the metastore
@@ -174,6 +180,9 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 		"Experimental: Maximum runs per IndexMerge task (K). Memory grows linearly with K.")
 	f.IntVar(&cfg.LogMaxRunsPerTask, prefix+"logs.max-runs-per-task", defaultLogMaxRunsPerTask,
 		"Experimental: Maximum runs per LogMerge task (K for log compaction). Separate from max-runs-per-task to scale independently")
+	_ = cfg.LogMinCompactionSize.Set("4MB")
+	f.Var(&cfg.LogMinCompactionSize, prefix+"logs.min-compaction-size",
+		"Experimental: Minimum total compactable data (sum of all runs' uncompressed size) that justifies log compaction. Converged windows below this floor are skipped.")
 	f.DurationVar(&cfg.ToCConsolidateTimeout, prefix+"toc-consolidate-timeout", defaultToCConsolidateTimeout,
 		"Experimental: Coordinator-side timeout around the inline ToC ReplaceIndexPointers call. Not a task TTL.")
 	f.BoolVar(&cfg.DryRun, prefix+"dry-run", false,
@@ -236,6 +245,9 @@ func (cfg *Config) Validate() error {
 	if cfg.LogMaxRunsPerTask <= 0 {
 		return errInvalidLogMaxRunsPerTask
 	}
+	if cfg.LogMinCompactionSize == 0 {
+		return errInvalidLogMinCompactionSize
+	}
 
 	if err := cfg.IndexobjBuilder.Validate(); err != nil {
 		return fmt.Errorf("invalid indexobj builder config: %w", err)
@@ -253,4 +265,5 @@ var (
 	errInvalidToCConsolidateTimeout        = errors.New("dataobj.compaction.toc_consolidate_timeout must be > 0 when compaction is enabled")
 	errInvalidMaxRunsPerTask               = errors.New("dataobj.compaction.max_runs_per_task must be > 0 when compaction is enabled")
 	errInvalidLogMaxRunsPerTask            = errors.New("dataobj.compaction.logs.max_runs_per_task must be > 0 when compaction is enabled")
+	errInvalidLogMinCompactionSize         = errors.New("dataobj.compaction.logs.min_compaction_size must be > 0 when compaction is enabled")
 )

--- a/pkg/engine/compactor/config.go
+++ b/pkg/engine/compactor/config.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/flagext"
+
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 )
 

--- a/pkg/engine/compactor/config_test.go
+++ b/pkg/engine/compactor/config_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/grafana/dskit/flagext"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,4 +35,30 @@ func TestConfig_ValidateRejectsBadValues(t *testing.T) {
 			require.ErrorIs(t, err, tc.wantErr)
 		})
 	}
+}
+
+func TestConfig_LogMinCompactionSizeValidation(t *testing.T) {
+	// Build a valid enabled config, driving LogMinCompactionSize through the flag
+	// parser so this one test covers both parsing and validation.
+	base := func(t *testing.T, args ...string) Config {
+		t.Helper()
+		var cfg Config
+		fs := flag.NewFlagSet("test", flag.PanicOnError)
+		cfg.RegisterFlagsWithPrefix("dataobj.compaction.", fs)
+		require.NoError(t, fs.Parse(args))
+		cfg.Enabled = true
+		cfg.Scheduler.Endpoint = defaultEndpoint
+		return cfg
+	}
+
+	t.Run("parsed value passes and is applied", func(t *testing.T) {
+		cfg := base(t, "--dataobj.compaction.logs.min-compaction-size=8MB")
+		require.Equal(t, flagext.Bytes(8*1024*1024), cfg.LogMinCompactionSize)
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("zero fails", func(t *testing.T) {
+		cfg := base(t, "--dataobj.compaction.logs.min-compaction-size=0")
+		require.ErrorIs(t, cfg.Validate(), errInvalidLogMinCompactionSize)
+	})
 }

--- a/pkg/engine/compactor/coordinator.go
+++ b/pkg/engine/compactor/coordinator.go
@@ -184,6 +184,9 @@ func (c *coordinator) runCycle(ctx context.Context) {
 		}
 	}
 
+	if compacted == 0 && failed == 0 && logCompacted > 0 {
+		cycleOutcome = "log_compacted"
+	}
 	c.metrics.observeCycle(cycleOutcome, duration)
 
 	//TODO(twhitney): will want a metric for this
@@ -272,9 +275,10 @@ type compactionStats struct {
 }
 
 // compactTenantLogs plans and dispatches log-merge tasks for a window with a
-// converged index. It reads the index's stats sections, forms runs, and
-// dispatches one LogMerge plan per task. Returns tenantCycleConverged when
-// there is no log work, tenantCycleLogCompacted when plans were dispatched.
+// converged index. It dispatches LogMerge tasks, then swaps the ToC. Returns
+// tenantCycleConverged when the window is terminal (no work) or the ToC swap is
+// a race-loss / already-converged no-op, tenantCycleLogCompacted when the swap
+// succeeds, and tenantCycleFailed on error.
 func (c *coordinator) compactTenantLogs(
 	ctx context.Context,
 	tenant string,
@@ -286,12 +290,14 @@ func (c *coordinator) compactTenantLogs(
 		return tenantCycleFailed, fmt.Errorf("reading log section refs: %w", err)
 	}
 
-	tasks := v2.Plan(ctx, sections, tenant, c.cfg.LogMaxRunsPerTask, sortSchema)
-	if len(tasks) == 0 {
-		level.Debug(c.logger).Log("msg", "log-compaction: no tasks",
+	runs := v2.CalculateRuns(sections)
+	if v2.IsTerminal(runs, uint64(c.cfg.LogMinCompactionSize)) {
+		level.Debug(c.logger).Log("msg", "log-compaction: window not worth compacting, skipping",
 			"tenant", tenant, "window", window)
 		return tenantCycleConverged, nil
 	}
+
+	tasks := v2.Plan(runs, tenant, c.cfg.LogMaxRunsPerTask, sortSchema)
 
 	var pathBuilder indexMergePath
 	var idBuf bytes.Buffer
@@ -318,8 +324,32 @@ func (c *coordinator) compactTenantLogs(
 		return tenantCycleFailed, fmt.Errorf("failed to execute log-merge tasks: %w", err)
 	}
 
-	level.Info(c.logger).Log("msg", "log-compaction dispatched",
-		"tenant", tenant, "window", window, "tasks", len(tasks))
+	oldPaths := []string{converged.Path}
+	newEntries := makeTocEntries(tasks, outputs)
+
+	level.Debug(c.logger).Log("msg", "log-compacted",
+		"tenant", tenant, "window", window,
+		"dry_run", c.cfg.DryRun,
+		"tasks", len(tasks),
+		"removed_index", converged.Path,
+		"added_indexes", strings.Join(outputs, ","),
+	)
+
+	if c.cfg.DryRun {
+		return tenantCycleLogCompacted, nil
+	}
+
+	phase2Ctx, cancel := context.WithTimeout(ctx, c.cfg.ToCConsolidateTimeout)
+	defer cancel()
+	swapped, err := c.metastoreWriter.ReplaceIndexPointers(phase2Ctx, window, tenant, oldPaths, newEntries)
+	if err != nil {
+		return tenantCycleFailed, fmt.Errorf("failed to replace index pointers after log-compaction: %w", err)
+	}
+	if !swapped {
+		level.Debug(c.logger).Log("msg", "log-compaction ToC replace race-loss / already-converged",
+			"tenant", tenant, "window", window)
+		return tenantCycleConverged, nil
+	}
 	return tenantCycleLogCompacted, nil
 }
 
@@ -336,7 +366,8 @@ func (c *coordinator) compactTenant(
 ) (compactionStats, error) {
 	// Plan.
 	sections := sectionRefsFor(entries)
-	tasks := v2.Plan(ctx, sections, tenant, c.cfg.MaxRunsPerTask, nil)
+	runs := v2.CalculateRuns(sections)
+	tasks := v2.Plan(runs, tenant, c.cfg.MaxRunsPerTask, nil)
 	if len(tasks) == 0 {
 		level.Debug(c.logger).Log("msg", "tenant cycle: planner produced no tasks",
 			"tenant", tenant, "window", window)

--- a/pkg/engine/compactor/coordinator_test.go
+++ b/pkg/engine/compactor/coordinator_test.go
@@ -25,6 +25,10 @@ type fakeRunner struct {
 	mu    sync.Mutex
 	calls []runCall
 	err   error // returned from every call when non-nil
+
+	// failOnCall, when > 0, makes the Nth run invocation (1-based) return an
+	// error while all others succeed. Used to simulate one failed job.
+	failOnCall int
 }
 
 type runCall struct {
@@ -35,8 +39,15 @@ type runCall struct {
 func (f *fakeRunner) run(_ context.Context, opts workflow.Options, plan *physical.Plan) error {
 	f.mu.Lock()
 	f.calls = append(f.calls, runCall{opts, plan})
+	n := len(f.calls)
 	f.mu.Unlock()
-	return f.err
+	if f.err != nil {
+		return f.err
+	}
+	if f.failOnCall > 0 && n == f.failOnCall {
+		return errors.New("fakeRunner: forced failure on call")
+	}
+	return nil
 }
 
 func (f *fakeRunner) snapshot() []runCall {
@@ -91,6 +102,7 @@ func newTestCoordinator(t *testing.T, bucket objstore.Bucket, runner *fakeRunner
 			PollingInterval:           5 * time.Minute,
 			MaxRunsPerTask:            2,
 			LogMaxRunsPerTask:         2,
+			LogMinCompactionSize:      1,
 			ToCConsolidateTimeout:     30 * time.Second,
 			MaxRunningCompactionTasks: 4,
 			PlanVersion:               1,
@@ -295,16 +307,17 @@ func TestCompactTenantLogs_DispatchesLogMergePlans(t *testing.T) {
 	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
 	convergedPath := "indexes/aa/converged"
 
-	// Two disjoint-time label tuples chain into 1 run -> 1 task (K=2).
+	// Same tuple, overlapping times -> 2 runs -> still dispatches after the
+	// terminal gate (total size 200 clears the test floor of 1).
 	buildIndexWithStats(ctx, t, bucket, "acme", convergedPath, []stats.Stat{
 		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "service_name",
-			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 20, RowCount: 1, UncompressedSize: 100},
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 30, RowCount: 1, UncompressedSize: 100},
 		{ObjectPath: "logs/log-1", SectionIndex: 0, SortSchema: "service_name",
-			Labels: map[string]string{"service_name": "billing"}, MinTimestamp: 30, MaxTimestamp: 40, RowCount: 1, UncompressedSize: 100},
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 20, MaxTimestamp: 40, RowCount: 1, UncompressedSize: 100},
 	})
 
 	runner := &fakeRunner{}
-	replacer := &fakeReplacer{}
+	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
 
 	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
@@ -313,7 +326,7 @@ func TestCompactTenantLogs_DispatchesLogMergePlans(t *testing.T) {
 	require.Equal(t, tenantCycleLogCompacted, result)
 
 	dispatches := runner.snapshot()
-	require.Len(t, dispatches, 1, "one run -> one task -> one LogMerge plan")
+	require.Len(t, dispatches, 1, "two runs -> one task -> one LogMerge plan")
 	require.Equal(t, []string{"compaction", "log-merge"}, dispatches[0].opts.Actor)
 
 	root, err := dispatches[0].plan.Root()
@@ -323,7 +336,9 @@ func TestCompactTenantLogs_DispatchesLogMergePlans(t *testing.T) {
 	require.Equal(t, []string{"label:service_name"}, node.SortSchema)
 	require.NotEmpty(t, node.OutputIndexPath)
 
-	require.Empty(t, replacer.snapshot(), "no TOC swap on the log path")
+	swaps := replacer.snapshot()
+	require.Len(t, swaps, 1, "log path now swaps the ToC after dispatch")
+	require.Equal(t, []string{convergedPath}, swaps[0].oldPaths)
 }
 
 func TestCompactTenantLogs_NoStatsRowsForTenantIsConverged(t *testing.T) {
@@ -358,18 +373,207 @@ func TestRunCycle_ConvergedTenantTriggersLogCompaction(t *testing.T) {
 
 	buildIndexWithStats(ctx, t, bucket, "solo", convergedPath, []stats.Stat{
 		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "service_name",
-			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 20, RowCount: 1, UncompressedSize: 100},
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 30, RowCount: 1, UncompressedSize: 100},
+		{ObjectPath: "logs/log-0", SectionIndex: 1, SortSchema: "service_name",
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 20, MaxTimestamp: 40, RowCount: 1, UncompressedSize: 100},
 	})
 	writeToCWithIndexes(ctx, t, bucket, map[string][]testIndex{
 		"solo": {{path: convergedPath, start: window.Add(1 * time.Hour), end: window.Add(2 * time.Hour)}},
 	})
 
 	runner := &fakeRunner{}
-	replacer := &fakeReplacer{}
+	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
 
 	c.runCycle(ctx)
 
 	require.Len(t, runner.snapshot(), 1, "converged tenant now dispatches a LogMerge plan")
-	require.Empty(t, replacer.snapshot(), "no TOC swap on the log path")
+	require.Len(t, replacer.snapshot(), 1, "converged tenant now swaps the ToC")
+}
+
+func TestCompactTenantLogs_TerminalSingleRunSkips(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
+	convergedPath := "indexes/aa/converged"
+
+	// Single stat row -> P=1 -> terminal regardless of size.
+	buildIndexWithStats(ctx, t, bucket, "acme", convergedPath, []stats.Stat{
+		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "service_name",
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 20, RowCount: 1, UncompressedSize: 100},
+	})
+
+	runner := &fakeRunner{}
+	replacer := &fakeReplacer{swapped: true}
+	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
+
+	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
+	result, err := c.compactTenantLogs(ctx, "acme", window, entry)
+
+	require.NoError(t, err)
+	require.Equal(t, tenantCycleConverged, result)
+	require.Empty(t, runner.snapshot(), "terminal window dispatches no plans")
+	require.Empty(t, replacer.snapshot(), "terminal window performs no swap")
+}
+
+func TestCompactTenantLogs_TerminalBelowFloorSkips(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
+	convergedPath := "indexes/aa/converged"
+
+	// Two overlapping same-tuple rows -> P=2, total size 30, below the 1GiB floor.
+	buildIndexWithStats(ctx, t, bucket, "acme", convergedPath, []stats.Stat{
+		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "service_name",
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 30, RowCount: 1, UncompressedSize: 10},
+		{ObjectPath: "logs/log-1", SectionIndex: 0, SortSchema: "service_name",
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 20, MaxTimestamp: 40, RowCount: 1, UncompressedSize: 20},
+	})
+
+	runner := &fakeRunner{}
+	replacer := &fakeReplacer{swapped: true}
+	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
+	c.cfg.LogMinCompactionSize = 1 << 30 // 1GiB floor; 30 bytes is below it
+
+	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
+	result, err := c.compactTenantLogs(ctx, "acme", window, entry)
+
+	require.NoError(t, err)
+	require.Equal(t, tenantCycleConverged, result)
+	require.Empty(t, runner.snapshot())
+	require.Empty(t, replacer.snapshot())
+}
+
+func twoRunConvergedBucket(ctx context.Context, t *testing.T, tenant, path string) objstore.Bucket {
+	t.Helper()
+	bucket := objstore.NewInMemBucket()
+	buildIndexWithStats(ctx, t, bucket, tenant, path, []stats.Stat{
+		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "service_name",
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 30, RowCount: 1, UncompressedSize: 100},
+		{ObjectPath: "logs/log-1", SectionIndex: 0, SortSchema: "service_name",
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 20, MaxTimestamp: 40, RowCount: 1, UncompressedSize: 100},
+	})
+	return bucket
+}
+
+func TestCompactTenantLogs_SwapsToC(t *testing.T) {
+	ctx := context.Background()
+	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
+	convergedPath := "indexes/aa/converged"
+	bucket := twoRunConvergedBucket(ctx, t, "acme", convergedPath)
+
+	runner := &fakeRunner{}
+	replacer := &fakeReplacer{swapped: true}
+	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
+
+	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
+	result, err := c.compactTenantLogs(ctx, "acme", window, entry)
+
+	require.NoError(t, err)
+	require.Equal(t, tenantCycleLogCompacted, result)
+	require.NotEmpty(t, runner.snapshot(), "non-terminal window dispatches plans")
+
+	calls := replacer.snapshot()
+	require.Len(t, calls, 1)
+	require.Equal(t, []string{convergedPath}, calls[0].oldPaths)
+	require.NotEmpty(t, calls[0].newEntries)
+}
+
+func TestCompactTenantLogs_SwapErrorFails(t *testing.T) {
+	ctx := context.Background()
+	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
+	convergedPath := "indexes/aa/converged"
+	bucket := twoRunConvergedBucket(ctx, t, "acme", convergedPath)
+
+	runner := &fakeRunner{}
+	replacer := &fakeReplacer{err: errors.New("boom")}
+	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
+
+	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
+	result, err := c.compactTenantLogs(ctx, "acme", window, entry)
+
+	require.Error(t, err)
+	require.Equal(t, tenantCycleFailed, result)
+}
+
+func TestCompactTenantLogs_SwapRaceLossConverged(t *testing.T) {
+	ctx := context.Background()
+	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
+	convergedPath := "indexes/aa/converged"
+	bucket := twoRunConvergedBucket(ctx, t, "acme", convergedPath)
+
+	runner := &fakeRunner{}
+	replacer := &fakeReplacer{swapped: false}
+	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
+
+	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
+	result, err := c.compactTenantLogs(ctx, "acme", window, entry)
+
+	require.NoError(t, err)
+	require.Equal(t, tenantCycleConverged, result)
+}
+
+func TestCompactTenantLogs_DryRunSkipsSwap(t *testing.T) {
+	ctx := context.Background()
+	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
+	convergedPath := "indexes/aa/converged"
+	bucket := twoRunConvergedBucket(ctx, t, "acme", convergedPath)
+
+	runner := &fakeRunner{}
+	replacer := &fakeReplacer{swapped: true}
+	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
+	c.cfg.DryRun = true
+
+	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
+	result, err := c.compactTenantLogs(ctx, "acme", window, entry)
+
+	require.NoError(t, err)
+	require.Equal(t, tenantCycleLogCompacted, result)
+	require.NotEmpty(t, runner.snapshot(), "dry-run still dispatches")
+	require.Empty(t, replacer.snapshot(), "dry-run must not swap the ToC")
+}
+
+func TestCompactTenantLogs_PartialFailureNoSwap(t *testing.T) {
+	ctx := context.Background()
+	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
+	convergedPath := "indexes/aa/converged"
+	bucket := twoRunConvergedBucket(ctx, t, "acme", convergedPath)
+
+	runner := &fakeRunner{failOnCall: 1}
+	replacer := &fakeReplacer{swapped: true}
+	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
+
+	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
+	result, err := c.compactTenantLogs(ctx, "acme", window, entry)
+
+	require.Error(t, err)
+	require.Equal(t, tenantCycleFailed, result)
+	require.Empty(t, replacer.snapshot(), "partial failure must not swap the ToC")
+}
+
+func TestCompactTenantLogs_DeterministicOutputPaths(t *testing.T) {
+	ctx := context.Background()
+	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
+	convergedPath := "indexes/aa/converged"
+	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
+
+	run := func() []metastore.TableOfContentsEntry {
+		bucket := twoRunConvergedBucket(ctx, t, "acme", convergedPath)
+		runner := &fakeRunner{}
+		replacer := &fakeReplacer{swapped: true}
+		c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
+		_, err := c.compactTenantLogs(ctx, "acme", window, entry)
+		require.NoError(t, err)
+		calls := replacer.snapshot()
+		require.Len(t, calls, 1)
+		return calls[0].newEntries
+	}
+
+	first := run()
+	second := run()
+
+	require.Equal(t, len(first), len(second))
+	for i := range first {
+		require.Equal(t, first[i].Path, second[i].Path, "output index paths must be deterministic across cycles")
+	}
 }

--- a/pkg/engine/compactor/metrics.go
+++ b/pkg/engine/compactor/metrics.go
@@ -21,7 +21,7 @@ type coordinatorMetrics struct {
 	indexesPerTenantWindow     *prometheus.GaugeVec // tenant
 
 	// cyclesTotal counts coordinator cycles by outcome.
-	cyclesTotal *prometheus.CounterVec // outcome=toc_not_found|index_load_err|no_indexes|converged|compaction_failed|compacted_with_failures|compacted
+	cyclesTotal *prometheus.CounterVec // outcome=toc_not_found|index_load_err|no_indexes|converged|compaction_failed|compacted_with_failures|compacted|log_compacted
 
 	// tenantCyclesTotal counts per-tenant cycle outcomes.
 	tenantCyclesTotal *prometheus.CounterVec // outcome=compacted|log_compacted|converged|failed, tenant

--- a/pkg/engine/compactor/metrics.go
+++ b/pkg/engine/compactor/metrics.go
@@ -21,7 +21,7 @@ type coordinatorMetrics struct {
 	indexesPerTenantWindow     *prometheus.GaugeVec // tenant
 
 	// cyclesTotal counts coordinator cycles by outcome.
-	cyclesTotal *prometheus.CounterVec // outcome=toc_not_found|index_load_err|no_indexes|converged|compaction_failed|compacted_with_failures|compacted|log_compacted
+	cyclesTotal *prometheus.CounterVec // outcome=toc_not_found|index_load_err|no_indexes|converged|compaction_failed|compacted_with_failures|compacted
 
 	// tenantCyclesTotal counts per-tenant cycle outcomes.
 	tenantCyclesTotal *prometheus.CounterVec // outcome=compacted|log_compacted|converged|failed, tenant


### PR DESCRIPTION
## What

Builds on the log compaction planning/scheduling work (#23125) to gate and finalize log-merge execution.

- Add a `Run` interface over calculated runs and `CalculateRuns` to expose them
- `Plan` now takes `[]Run` and drops the `ctx` argument
- Add a size-based `IsTerminal` predicate and a `logs.min-compaction-size` config
- Gate log-compaction on the terminal predicate so undersized windows are skipped
- Swap the ToC after a successful log compaction (with dry-run handling)
- Guard deterministic log-compaction output paths with tests

## Why

Without a terminal predicate the compactor would repeatedly re-compact windows that
are already at (or below) an acceptable size, wasting work and churning the ToC. Gating
execution on a size threshold lets undersized windows accumulate before they are merged,
and swapping the ToC only after a successful, non-dry-run compaction keeps the index
consistent with what was actually written.

Splitting `CalculateRuns` from `Plan` separates the decision of *what* to compact from
*how* to execute it, which keeps the terminal gate testable and lets callers inspect the
planned runs before committing to execution.
