### PR TITLE
fix(metastore): Recognize non-equality label filters as stream labels

### DIFF
--- a/pkg/dataobj/metastore/index_sections_reader.go
+++ b/pkg/dataobj/metastore/index_sections_reader.go
@@ -44,6 +44,13 @@ type indexSectionsReader struct {
 	// Bloom filter predicates (will be filtered to remove stream labels after streams are resolved)
 	predicates []*labels.Matcher
 
+	// predicateNames holds the label names of every predicate, regardless of
+	// match type. It is used to decide which stream-label columns to read so
+	// that label filters of any match type (=, !=, =~, !~) are recognized as
+	// stream labels during disambiguation. Bloom filtering still only uses the
+	// equality-only predicates above.
+	predicateNames map[string]struct{}
+
 	batchSize int
 
 	// Reader state
@@ -80,9 +87,12 @@ func newIndexSectionsReader(
 	predicates []*labels.Matcher,
 	batchSize int,
 ) *indexSectionsReader {
-	// Only keep equal predicates for bloom filtering
+	// Only keep equal predicates for bloom filtering, but track every predicate
+	// name so non-equality label filters are still recognized as stream labels.
 	var equalPredicates []*labels.Matcher
+	predicateNames := make(map[string]struct{}, len(predicates))
 	for _, p := range predicates {
+		predicateNames[p.Name] = struct{}{}
 		if p.Type == labels.MatchEqual {
 			equalPredicates = append(equalPredicates, p)
 		}
@@ -97,6 +107,7 @@ func newIndexSectionsReader(
 		obj:                obj,
 		matchers:           matchers,
 		predicates:         equalPredicates,
+		predicateNames:     predicateNames,
 		batchSize:          batchSize,
 		start:              start,
 		end:                end,
@@ -136,10 +147,7 @@ func (r *indexSectionsReader) init(ctx context.Context) error {
 
 	sStart, sEnd := r.scalarTimestamps()
 
-	predicateKeys := make(map[string]struct{}, len(r.predicates))
-	for _, predicate := range r.predicates {
-		predicateKeys[predicate.Name] = struct{}{}
-	}
+	predicateKeys := r.predicateNames
 
 	var (
 		unopenedStreams  []*dataobj.Section

--- a/pkg/dataobj/metastore/object_test.go
+++ b/pkg/dataobj/metastore/object_test.go
@@ -583,6 +583,38 @@ func TestSectionsForLabelsByStreamID(t *testing.T) {
 			wantCount:  1,
 			wantLabels: []string{"env"},
 		},
+		{
+			// A non-equality label filter (e.g. `| env!="prod"`) references a
+			// stream label by name just like an equality filter. Its label name
+			// must be recognized as a stream label so the physical planner keeps
+			// it ambiguous instead of mistyping it as structured metadata and
+			// pushing it to the dataobj scan (which would drop all matching rows).
+			name: "not-equal predicate returns predicate label names",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "app", "bar"),
+			},
+			predicates: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchNotEqual, "env", "prod"),
+			},
+			start:      now.Add(-4 * time.Hour),
+			end:        now.Add(time.Hour),
+			wantCount:  1,
+			wantLabels: []string{"env"},
+		},
+		{
+			// Same as above but for a regex-match label filter (e.g. `| env=~"d.*"`).
+			name: "regex-match predicate returns predicate label names",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "app", "bar"),
+			},
+			predicates: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchRegexp, "env", "d.*"),
+			},
+			start:      now.Add(-4 * time.Hour),
+			end:        now.Add(time.Hour),
+			wantCount:  1,
+			wantLabels: []string{"env"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/engine/internal/worker/worker_test.go
+++ b/pkg/engine/internal/worker/worker_test.go
@@ -433,3 +433,121 @@ var _ net.Addr = testAddr("")
 
 func (addr testAddr) Network() string { return "local" }
 func (addr testAddr) String() string  { return string(addr) }
+
+// TestNonEqualityLabelFilterOnStreamLabel guards against a regression where a
+// non-equality label filter (!=, =~, !~) on a stream label was disambiguated
+// to structured metadata and pushed to the dataobj scan, where the absent
+// column produced an unsatisfiable predicate and dropped all matching rows.
+func TestNonEqualityLabelFilterOnStreamLabel(t *testing.T) {
+	streamData := []logproto.Stream{
+		{
+			Labels: `{app="loki", provider="idology"}`,
+			Entries: []logproto.Entry{
+				{Timestamp: time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC), Line: "idology line"},
+			},
+		},
+		{
+			Labels: `{app="loki", provider="other"}`,
+			Entries: []logproto.Entry{
+				{Timestamp: time.Date(2025, time.January, 1, 0, 0, 1, 0, time.UTC), Line: "other line"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		query     string
+		wantLines []string
+	}{
+		{
+			name:      "equality",
+			query:     `{app="loki"} | provider="idology"`,
+			wantLines: []string{"idology line"},
+		},
+		{
+			name:      "inequality",
+			query:     `{app="loki"} | provider!="other"`,
+			wantLines: []string{"idology line"},
+		},
+		{
+			name:      "regex match",
+			query:     `{app="loki"} | provider=~"idol.*"`,
+			wantLines: []string{"idology line"},
+		},
+		{
+			name:      "regex not match",
+			query:     `{app="loki"} | provider!~"oth.*"`,
+			wantLines: []string{"idology line"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := runLabelFilterQuery(t, tt.query, streamData...)
+			lines := make([]string, 0, len(got))
+			for _, row := range got {
+				lines = append(lines, row["utf8.builtin.message"].(string))
+			}
+			require.ElementsMatch(t, tt.wantLines, lines)
+		})
+	}
+}
+
+func runLabelFilterQuery(t *testing.T, query string, streams ...logproto.Stream) arrowtest.Rows {
+	t.Helper()
+
+	builder := objtest.NewBuilder(t)
+
+	logger := log.NewNopLogger()
+	if testing.Verbose() {
+		logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	}
+
+	net := newTestNetwork()
+	sched := newTestScheduler(t, logger, net)
+	_ = newTestWorker(t, logger, builder.Location(), net)
+
+	ctx := user.InjectOrgID(t.Context(), objtest.Tenant)
+
+	builder.Append(ctx, streams...)
+	builder.Close()
+
+	params, err := logql.NewLiteralParams(
+		query,
+		time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2025, time.January, 2, 0, 0, 0, 0, time.UTC),
+		0,
+		0,
+		logproto.BACKWARD,
+		1000,
+		[]string{"0_of_1"},
+		nil,
+	)
+	require.NoError(t, err)
+
+	wf := buildWorkflow(ctx, t, logger, builder.Location(), sched, params)
+	pipeline, err := wf.Run(ctx)
+	require.NoError(t, err)
+
+	// Read the pipeline directly (rather than the shared readTable helper) so an
+	// empty result set produces a clean assertion failure instead of a panic.
+	var recs []arrow.RecordBatch
+	for {
+		rec, err := pipeline.Read(ctx)
+		if rec != nil && rec.NumRows() > 0 {
+			recs = append(recs, rec)
+		}
+		if err != nil && errors.Is(err, executor.EOF) {
+			break
+		}
+		require.NoError(t, err)
+	}
+
+	if len(recs) == 0 {
+		return arrowtest.Rows{}
+	}
+
+	actual, err := arrowtest.TableRows(memory.DefaultAllocator, array.NewTableFromRecords(recs[0].Schema(), recs))
+	require.NoError(t, err)
+	return actual
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a silent data-loss bug in the new reads path: a non-equality label filter on a stream label (e.g. `{app="loki"} | provider!="other"`) returns **zero results** instead of the matching logs. The `=` variant is unaffected.

Root cause is in the metastore's `indexSectionsReader`. To decide which stream-label columns to read (so it can report back which of the query's ambiguous predicate names are actually stream labels), it reused the same predicate set it keeps for bloom filtering — which is filtered to equality (`MatchEqual`) only. As a result, a non-equality predicate's label name was never used to select its stream-label column, the column was never read, and the metastore never reported that name as a stream label.

Downstream, the physical planner treats an unreported name as structured metadata (`disambiguateExpression`) and pushes the predicate into the `DataObjScan`. Because the label only exists as a stream label — there is no matching structured-metadata column — the predicate matches nothing and silently drops every matching row.

The fix separates the two concerns that were conflated:
- **Bloom filtering** stays equality-only (correct — blooms need concrete values).
- **Stream-label column selection** now uses a new `predicateNames` set that tracks every predicate name regardless of match type.