### PR TITLE
feat(compaction): Build index over compacted log objects in LogMerge

### DIFF
--- a/pkg/engine/internal/executor/log_merge.go
+++ b/pkg/engine/internal/executor/log_merge.go
@@ -14,10 +14,13 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
+	dataobjindex "github.com/grafana/loki/v3/pkg/dataobj/index"
+	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 	"github.com/grafana/loki/v3/pkg/dataobj/sortmerge"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/xcap"
 )
 
 func (c *Context) executeLogMerge(node *physical.LogMerge) Pipeline {
@@ -49,14 +52,19 @@ func (c *Context) doLogObjectMerge(ctx context.Context, node *physical.LogMerge)
 		return err
 	}
 	if len(sources) == 0 {
-		level.Info(c.logger).Log("msg", "LogMerge: no source log sections, nothing to compact", "tenant", node.Tenant)
-		return nil
+		return fmt.Errorf("LogMerge: no source log sections for tenant %q", node.Tenant)
 	}
 
 	table, err := buildGlobalStreamTable(sources, node.SortSchema)
 	if err != nil {
 		return err
 	}
+
+	indexBuilder, err := indexobj.NewBuilder(c.indexobjCfg, c.scratchStore)
+	if err != nil {
+		return fmt.Errorf("creating index builder: %w", err)
+	}
+	calc := dataobjindex.NewCalculator(indexBuilder)
 
 	sections, remaps := sectionsWithRemaps(sources, table)
 	merged, err := sortmerge.IteratorWithStreamRemap(ctx, sections, remaps, table.sortKeys, node.SortSchema)
@@ -65,7 +73,7 @@ func (c *Context) doLogObjectMerge(ctx context.Context, node *physical.LogMerge)
 	}
 
 	// Consume the globally-sorted stream and build compacted object
-	w := c.newLogObjectWriter(node, table)
+	w := c.newLogObjectWriter(node, table, calc)
 	for res := range merged {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -83,8 +91,23 @@ func (c *Context) doLogObjectMerge(ctx context.Context, node *physical.LogMerge)
 		return err
 	}
 	if stats.OutputObjects == 0 {
-		level.Info(c.logger).Log("msg", "LogMerge: no records to compact", "tenant", node.Tenant)
-		return nil
+		return fmt.Errorf("LogMerge: produced no compacted objects for tenant %q", node.Tenant)
+	}
+
+	idxObj, idxCloser, err := calc.Flush()
+	if err != nil {
+		return fmt.Errorf("flushing index: %w", err)
+	}
+
+	idxBytes, err := c.uploadLogObject(ctx, node.OutputIndexPath, idxObj)
+	if err != nil {
+		return errors.Join(fmt.Errorf("uploading index %q: %w", node.OutputIndexPath, err), idxCloser.Close())
+	}
+	if err := idxCloser.Close(); err != nil {
+		return fmt.Errorf("closing index %q: %w", node.OutputIndexPath, err)
+	}
+	if region := xcap.RegionFromContext(ctx); region != nil {
+		region.Record(statLogMergeIndexBytes.Observe(idxBytes))
 	}
 
 	stats.SourceObjects = len(sources)
@@ -92,8 +115,6 @@ func (c *Context) doLogObjectMerge(ctx context.Context, node *physical.LogMerge)
 		stats.InputSections += len(s.logsSections)
 	}
 
-	// The compacted object(s) are logged for reference; the downstream index build
-	// and ToC swap land in a follow-up.
 	level.Info(c.logger).Log(
 		"msg", "LogMerge: built compacted log object(s)",
 		"tenant", node.Tenant,
@@ -311,6 +332,7 @@ type logObjectWriter struct {
 	c     *Context
 	node  *physical.LogMerge
 	table *globalStreamTable
+	calc  *dataobjindex.Calculator
 
 	logsMetrics    *logs.Metrics
 	streamsMetrics *streams.Metrics
@@ -329,11 +351,12 @@ type logObjectWriter struct {
 	stats logMergeStats
 }
 
-func (c *Context) newLogObjectWriter(node *physical.LogMerge, table *globalStreamTable) *logObjectWriter {
+func (c *Context) newLogObjectWriter(node *physical.LogMerge, table *globalStreamTable, calc *dataobjindex.Calculator) *logObjectWriter {
 	w := &logObjectWriter{
 		c:              c,
 		node:           node,
 		table:          table,
+		calc:           calc,
 		logsMetrics:    logs.NewMetrics(),
 		streamsMetrics: streams.NewMetrics(),
 		targetObject:   int(c.indexobjCfg.TargetObjectSize),
@@ -418,9 +441,18 @@ func (w *logObjectWriter) finalizeAndUpload(ctx context.Context) error {
 	defer closer.Close()
 
 	path := logMergeOutputPath(w.node.OutputIndexPath, w.stats.OutputObjects)
-	size, err := w.c.uploadLogObject(ctx, path, obj)
-	if err != nil {
-		return fmt.Errorf("uploading %q: %w", path, err)
+
+	size, upErr := w.c.uploadLogObject(ctx, path, obj)
+	if upErr != nil {
+		return errors.Join(fmt.Errorf("uploading %q: %w", path, upErr), closer.Close())
+	}
+
+	// Build the index over the just-written object while it is still in memory.
+	if err := w.calc.Calculate(ctx, w.c.logger, obj, path); err != nil {
+		return errors.Join(fmt.Errorf("indexing %q: %w", path, err), closer.Close())
+	}
+	if err := closer.Close(); err != nil {
+		return fmt.Errorf("closing compacted object %q: %w", path, err)
 	}
 
 	level.Info(w.c.logger).Log(

--- a/pkg/engine/internal/executor/log_merge_test.go
+++ b/pkg/engine/internal/executor/log_merge_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -17,6 +18,8 @@ import (
 	compactionv2pb "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2/proto"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/stats"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -196,8 +199,9 @@ func TestCollectLogSources_ExcludesOtherTenants(t *testing.T) {
 func newSmallObjectExecutorContext(t *testing.T, bucket objstore.Bucket) *Context {
 	t.Helper()
 	c := newTestExecutorContext(t, bucket)
+	c.indexobjCfg.TargetPageSize = 512
 	c.indexobjCfg.TargetObjectSize = 1000 // bytes; forces splitting
-	c.indexobjCfg.TargetSectionSize = 4096
+	c.indexobjCfg.TargetSectionSize = 800
 	return c
 }
 
@@ -354,20 +358,6 @@ func TestDoLogObjectMerge_MergesAndSplits(t *testing.T) {
 	require.Equal(t, 36, totalRecords)
 }
 
-func TestDoLogObjectMerge_EmptyRunsIsNoOp(t *testing.T) {
-	ctx := context.Background()
-	bucket := objstore.NewInMemBucket()
-
-	c := newTestExecutorContext(t, bucket)
-	node := &physical.LogMerge{Tenant: "T", SortSchema: []string{"label:app"}, OutputIndexPath: "out/index"}
-
-	require.NoError(t, c.doLogObjectMerge(ctx, node))
-
-	ok, err := bucket.Exists(ctx, logMergeOutputPath(node.OutputIndexPath, 0))
-	require.NoError(t, err)
-	require.False(t, ok, "no output object should be written for an empty merge")
-}
-
 func TestDoLogObjectMerge_ExistingOutputShortCircuits(t *testing.T) {
 	ctx := context.Background()
 	bucket := objstore.NewInMemBucket()
@@ -405,4 +395,257 @@ func TestDoLogObjectMerge_ExistingOutputShortCircuits(t *testing.T) {
 	ok, err := bucket.Exists(ctx, logMergeOutputPath(node.OutputIndexPath, 0))
 	require.NoError(t, err)
 	require.False(t, ok, "compacted log objects must not be written when output index already exists")
+}
+
+// collectIndexSections opens the index object at node.OutputIndexPath and
+// returns the postings/stats section kinds present for the tenant plus the set
+// of object paths referenced by KindLabel postings rows.
+func collectIndexSections(ctx context.Context, t *testing.T, bucket objstore.Bucket, node *physical.LogMerge) (kinds map[string]bool, postingsPaths map[string]bool) {
+	t.Helper()
+
+	obj, err := dataobj.FromBucket(ctx, bucket, node.OutputIndexPath, 0)
+	require.NoError(t, err)
+
+	kinds = make(map[string]bool)
+	postingsPaths = make(map[string]bool)
+
+	for _, sec := range obj.Sections() {
+		if sec.Tenant != node.Tenant {
+			continue
+		}
+		switch {
+		case stats.CheckSection(sec):
+			kinds["stats"] = true
+		case postings.CheckSection(sec):
+			kinds["postings"] = true
+
+			ps, err := postings.Open(ctx, sec)
+			require.NoError(t, err)
+			func() {
+				rr := postings.NewRowReader(ctx, ps, nil)
+				defer rr.Close()
+				for rr.Next() {
+					if row := rr.At(); row.ObjectPath != "" {
+						postingsPaths[row.ObjectPath] = true
+					}
+				}
+				require.NoError(t, rr.Err())
+			}()
+		}
+	}
+	return kinds, postingsPaths
+}
+
+func TestDoLogObjectMerge_WritesIndexOverCompactedObjects(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+
+	const tenant = "T"
+	sortSchema := []string{"label:app"}
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	buildSourceLogObject(t, bucket, "objA", sortSchema, map[string][]testStream{
+		tenant: {
+			{labels: `{app="a"}`, entries: linesAt(base, 3)},
+			{labels: `{app="b"}`, entries: linesAt(base, 2)},
+		},
+	})
+	buildSourceLogObject(t, bucket, "objB", sortSchema, map[string][]testStream{
+		tenant: {
+			{labels: `{app="c"}`, entries: linesAt(base.Add(time.Hour), 4)},
+		},
+	})
+
+	c := newTestExecutorContext(t, bucket)
+	node := &physical.LogMerge{
+		Tenant:          tenant,
+		SortSchema:      sortSchema,
+		OutputIndexPath: "index/out",
+		Runs: []*compactionv2pb.RunRef{
+			{Sections: []*compactionv2pb.SectionRef{{ObjectPath: "objA"}, {ObjectPath: "objB"}}},
+		},
+	}
+
+	require.NoError(t, c.doLogObjectMerge(ctx, node))
+
+	ok, err := bucket.Exists(ctx, node.OutputIndexPath)
+	require.NoError(t, err)
+	require.True(t, ok, "index object must be written at OutputIndexPath")
+
+	kinds, postingsPaths := collectIndexSections(ctx, t, bucket, node)
+	require.True(t, kinds["stats"], "index must contain a stats section")
+	require.True(t, kinds["postings"], "index must contain a postings section")
+
+	compacted := make(map[string]bool)
+	for i := 0; ; i++ {
+		p := logMergeOutputPath(node.OutputIndexPath, i)
+		exists, err := bucket.Exists(ctx, p)
+		require.NoError(t, err)
+		if !exists {
+			break
+		}
+		compacted[p] = true
+	}
+	require.NotEmpty(t, compacted, "at least one compacted object must exist")
+	require.NotEmpty(t, postingsPaths, "postings must reference at least one object path")
+	for p := range postingsPaths {
+		require.True(t, compacted[p], "postings object_path %q must be a compacted object", p)
+		require.False(t, p == "objA" || p == "objB", "postings must not reference source object paths")
+	}
+}
+
+func TestDoLogObjectMerge_IndexCoversAllSplitObjects(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+
+	const tenant = "T"
+	sortSchema := []string{"label:app"}
+	ta := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tb := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	tc := time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC)
+
+	buildSourceLogObject(t, bucket, "objA", sortSchema, map[string][]testStream{
+		tenant: {
+			{labels: `{app="a"}`, entries: wideLinesAt(ta, 4)},
+			{labels: `{app="b"}`, entries: wideLinesAt(ta, 4)},
+			{labels: `{app="c"}`, entries: wideLinesAt(ta, 4)},
+		},
+	})
+	buildSourceLogObject(t, bucket, "objB", sortSchema, map[string][]testStream{
+		tenant: {
+			{labels: `{app="b"}`, entries: wideLinesAt(tb, 4)},
+			{labels: `{app="c"}`, entries: wideLinesAt(tb, 4)},
+			{labels: `{app="d"}`, entries: wideLinesAt(tb, 4)},
+		},
+	})
+	buildSourceLogObject(t, bucket, "objC", sortSchema, map[string][]testStream{
+		tenant: {
+			{labels: `{app="c"}`, entries: wideLinesAt(tc, 4)},
+			{labels: `{app="d"}`, entries: wideLinesAt(tc, 4)},
+			{labels: `{app="e"}`, entries: wideLinesAt(tc, 4)},
+		},
+	})
+
+	c := newSmallObjectExecutorContext(t, bucket)
+	node := &physical.LogMerge{
+		Tenant:          tenant,
+		SortSchema:      sortSchema,
+		OutputIndexPath: "index/out",
+		Runs: []*compactionv2pb.RunRef{
+			{Sections: []*compactionv2pb.SectionRef{{ObjectPath: "objA"}, {ObjectPath: "objB"}, {ObjectPath: "objC"}}},
+		},
+	}
+
+	require.NoError(t, c.doLogObjectMerge(ctx, node))
+
+	compacted := make(map[string]bool)
+	for i := 0; ; i++ {
+		p := logMergeOutputPath(node.OutputIndexPath, i)
+		exists, err := bucket.Exists(ctx, p)
+		require.NoError(t, err)
+		if !exists {
+			break
+		}
+		compacted[p] = true
+	}
+	require.GreaterOrEqual(t, len(compacted), 2, "output must be split into multiple objects")
+
+	_, postingsPaths := collectIndexSections(ctx, t, bucket, node)
+	require.Equal(t, compacted, postingsPaths, "postings must reference every compacted object")
+}
+
+func TestDoLogObjectMerge_EmptyRunsErrors(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+
+	c := newTestExecutorContext(t, bucket)
+	node := &physical.LogMerge{Tenant: "T", SortSchema: []string{"label:app"}, OutputIndexPath: "index/out"}
+
+	require.Error(t, c.doLogObjectMerge(ctx, node), "empty runs must error so the coordinator skips the ToC swap")
+
+	ok, err := bucket.Exists(ctx, node.OutputIndexPath)
+	require.NoError(t, err)
+	require.False(t, ok, "no index object should be written when there are no sources")
+
+	ok, err = bucket.Exists(ctx, logMergeOutputPath(node.OutputIndexPath, 0))
+	require.NoError(t, err)
+	require.False(t, ok, "no compacted object should be written for an empty merge")
+}
+
+func TestDoLogObjectMerge_ZeroOutputObjectsErrors(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+
+	sortSchema := []string{"label:app"}
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// The object holds only tenant "other" data. The node targets tenant "T",
+	// so a source is collected but no records for "T" are produced.
+	buildSourceLogObject(t, bucket, "objA", sortSchema, map[string][]testStream{
+		"other": {{labels: `{app="a"}`, entries: linesAt(base, 3)}},
+	})
+
+	c := newTestExecutorContext(t, bucket)
+	node := &physical.LogMerge{
+		Tenant:          "T",
+		SortSchema:      sortSchema,
+		OutputIndexPath: "index/out",
+		Runs: []*compactionv2pb.RunRef{
+			{Sections: []*compactionv2pb.SectionRef{{ObjectPath: "objA"}}},
+		},
+	}
+
+	require.Error(t, c.doLogObjectMerge(ctx, node), "zero output objects must error")
+
+	ok, err := bucket.Exists(ctx, node.OutputIndexPath)
+	require.NoError(t, err)
+	require.False(t, ok, "no index object should be written when no output was produced")
+}
+
+// removeFailingStore wraps a scratch.Store and fails every Remove, simulating a
+// scratch-cleanup failure surfaced through a flushed object's closer.
+type removeFailingStore struct {
+	scratch.Store
+}
+
+func (removeFailingStore) Remove(scratch.Handle) error {
+	return errors.New("scratch remove failed")
+}
+
+func TestDoLogObjectMerge_CompactedObjectCloseErrorPropagates(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+
+	const tenant = "T"
+	sortSchema := []string{"label:app"}
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	buildSourceLogObject(t, bucket, "objA", sortSchema, map[string][]testStream{
+		tenant: {{labels: `{app="a"}`, entries: linesAt(base, 3)}},
+	})
+
+	c := newTestExecutorContext(t, bucket)
+	c.scratchStore = removeFailingStore{c.scratchStore}
+	node := &physical.LogMerge{
+		Tenant:          tenant,
+		SortSchema:      sortSchema,
+		OutputIndexPath: "index/out",
+		Runs: []*compactionv2pb.RunRef{
+			{Sections: []*compactionv2pb.SectionRef{{ObjectPath: "objA"}}},
+		},
+	}
+
+	err := c.doLogObjectMerge(ctx, node)
+	require.Error(t, err, "a failing closer must surface as an error, not be dropped")
+	require.ErrorContains(t, err, "scratch remove failed")
+
+	ok, err := bucket.Exists(ctx, node.OutputIndexPath)
+	require.NoError(t, err)
+	require.False(t, ok, "no index should be written when a compacted object fails to close")
+
+	// The compacted object is uploaded before its closer runs, so it lands even
+	// though the close failure aborts the merge before the index is built.
+	ok, err = bucket.Exists(ctx, logMergeOutputPath(node.OutputIndexPath, 0))
+	require.NoError(t, err)
+	require.True(t, ok, "the compacted object is uploaded before the failing close")
 }

--- a/pkg/engine/internal/executor/stats.go
+++ b/pkg/engine/internal/executor/stats.go
@@ -37,12 +37,17 @@ var (
 	DataObjScanCacheBytes   = xcap.NewStatisticInt64("dataobjscan.cache.bytes", xcap.AggregationTypeSum)
 )
 
-// IndexMerge statistics. Count the number of equal-key collisions observed
-// during a K-way index merge. A non-zero value indicates the upstream
-// invariant, that each (ObjectPath, SectionIndex) is referenced by exactly one
-// source index, has been violated — the merge tolerates this via last-wins, but
-// we want to know how often it happens.
+// Compaction statistics.
 var (
+	// Count the number of equal-key collisions observed
+	// during a K-way index merge. A non-zero value indicates the upstream
+	// invariant, that each (ObjectPath, SectionIndex) is referenced by exactly one
+	// source index, has been violated — the merge tolerates this via last-wins, but
+	// we want to know how often it happens.
 	statIndexMergeDuplicatePostings = xcap.NewStatisticInt64("index.merge.duplicate.postings", xcap.AggregationTypeSum)
 	statIndexMergeDuplicateStats    = xcap.NewStatisticInt64("index.merge.duplicate.stats", xcap.AggregationTypeSum)
+
+	// Encoded byte size of the index object written over the
+	// compacted log objects produced by a LogMerge task.
+	statLogMergeIndexBytes = xcap.NewStatisticInt64("logmerge.index.bytes", xcap.AggregationTypeSum)
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Write indexes for newly compacted log objects. This PR builds that index inline, while the just-written object is still in memory, which avoids a second read of the object from storage.

The output writer now owns an index calculator: each compacted object is indexed as it is uploaded, and the merged index is flushed and uploaded alongside the data, recording its encoded size via a new `logmerge.index.bytes` statistic. Empty source runs and zero-output merges are treated as errors so a silently-empty compaction cannot masquerade as success.

This builds directly on #23117 (log-object merge) and #23201 (log merge executor planning), both now merged.