### PR TITLE
fix(compaction): Correct source bucket and metrics for log-compaction path

### DIFF
--- a/pkg/engine/compactor/coordinator.go
+++ b/pkg/engine/compactor/coordinator.go
@@ -234,20 +234,18 @@ func (c *coordinator) runTenantCycle(
 	if len(entries) == 1 {
 		result, stats, err := c.compactTenantLogs(ctx, tenant, window, entries[0])
 		tenantDuration := c.clock().Sub(tenantStart)
+		c.metrics.observeEntries(tenant, entries, c.clock())
 		switch {
 		case err != nil:
 			level.Warn(c.logger).Log("msg", "tenant log-compaction failed",
 				"tenant", tenant, "window", window, "err", err)
-			c.metrics.observeTenantCycle(tenant, "failed", tenantDuration, compactionStats{})
-			c.metrics.observeEntries(tenant, entries, c.clock())
+			c.metrics.observeTenantLogCycle(tenant, "failed", tenantDuration, compactionStats{})
 			return tenantCycleFailed
 		case result == tenantCycleConverged:
-			c.metrics.observeTenantCycle(tenant, "converged", tenantDuration, compactionStats{})
-			c.metrics.observeEntries(tenant, entries, c.clock())
+			c.metrics.observeTenantLogCycle(tenant, "converged", tenantDuration, compactionStats{})
 			return tenantCycleConverged
 		default:
-			c.metrics.observeTenantCycle(tenant, "log_compacted", tenantDuration, stats)
-			c.metrics.observeEntries(tenant, entries, c.clock())
+			c.metrics.observeTenantLogCycle(tenant, "compacted", tenantDuration, stats)
 			return tenantCycleLogCompacted
 		}
 	}

--- a/pkg/engine/compactor/coordinator.go
+++ b/pkg/engine/compactor/coordinator.go
@@ -232,7 +232,7 @@ func (c *coordinator) runTenantCycle(
 	}
 
 	if len(entries) == 1 {
-		result, err := c.compactTenantLogs(ctx, tenant, window, entries[0])
+		result, stats, err := c.compactTenantLogs(ctx, tenant, window, entries[0])
 		tenantDuration := c.clock().Sub(tenantStart)
 		switch {
 		case err != nil:
@@ -246,7 +246,7 @@ func (c *coordinator) runTenantCycle(
 			c.metrics.observeEntries(tenant, entries, c.clock())
 			return tenantCycleConverged
 		default:
-			c.metrics.observeTenantCycle(tenant, "log_compacted", tenantDuration, compactionStats{})
+			c.metrics.observeTenantCycle(tenant, "log_compacted", tenantDuration, stats)
 			c.metrics.observeEntries(tenant, entries, c.clock())
 			return tenantCycleLogCompacted
 		}
@@ -284,17 +284,17 @@ func (c *coordinator) compactTenantLogs(
 	tenant string,
 	window time.Time,
 	converged indexEntry,
-) (tenantCycleResult, error) {
+) (tenantCycleResult, compactionStats, error) {
 	sections, sortSchema, err := logSectionRefsFor(ctx, c.bucket, tenant, converged.Path)
 	if err != nil {
-		return tenantCycleFailed, fmt.Errorf("reading log section refs: %w", err)
+		return tenantCycleFailed, compactionStats{}, fmt.Errorf("reading log section refs: %w", err)
 	}
 
 	runs := v2.CalculateRuns(sections)
 	if v2.IsTerminal(runs, uint64(c.cfg.LogMinCompactionSize)) {
 		level.Debug(c.logger).Log("msg", "log-compaction: window not worth compacting, skipping",
 			"tenant", tenant, "window", window)
-		return tenantCycleConverged, nil
+		return tenantCycleConverged, compactionStats{}, nil
 	}
 
 	tasks := v2.Plan(runs, tenant, c.cfg.LogMaxRunsPerTask, sortSchema)
@@ -321,11 +321,19 @@ func (c *coordinator) compactTenantLogs(
 		})
 	}
 	if err := g.Wait(); err != nil {
-		return tenantCycleFailed, fmt.Errorf("failed to execute log-merge tasks: %w", err)
+		return tenantCycleFailed, compactionStats{}, fmt.Errorf("failed to execute log-merge tasks: %w", err)
 	}
 
 	oldPaths := []string{converged.Path}
 	newEntries := makeTocEntries(tasks, outputs)
+
+	// removed = the single converged index this window replaces; added = the
+	// merged indexes written; dispatched = log-merge tasks run this cycle.
+	stats := compactionStats{
+		removed:    len(oldPaths),
+		added:      len(outputs),
+		dispatched: len(tasks),
+	}
 
 	level.Debug(c.logger).Log("msg", "log-compacted",
 		"tenant", tenant, "window", window,
@@ -336,21 +344,23 @@ func (c *coordinator) compactTenantLogs(
 	)
 
 	if c.cfg.DryRun {
-		return tenantCycleLogCompacted, nil
+		// Tasks ran but the ToC was left untouched, so no indexes were
+		// added/removed; only report the tasks dispatched.
+		return tenantCycleLogCompacted, compactionStats{dispatched: len(tasks)}, nil
 	}
 
 	phase2Ctx, cancel := context.WithTimeout(ctx, c.cfg.ToCConsolidateTimeout)
 	defer cancel()
 	swapped, err := c.metastoreWriter.ReplaceIndexPointers(phase2Ctx, window, tenant, oldPaths, newEntries)
 	if err != nil {
-		return tenantCycleFailed, fmt.Errorf("failed to replace index pointers after log-compaction: %w", err)
+		return tenantCycleFailed, compactionStats{}, fmt.Errorf("failed to replace index pointers after log-compaction: %w", err)
 	}
 	if !swapped {
 		level.Debug(c.logger).Log("msg", "log-compaction ToC replace race-loss / already-converged",
 			"tenant", tenant, "window", window)
-		return tenantCycleConverged, nil
+		return tenantCycleConverged, compactionStats{}, nil
 	}
-	return tenantCycleLogCompacted, nil
+	return tenantCycleLogCompacted, stats, nil
 }
 
 // compactTenant performs the per-(tenant, window) compaction. Returns the

--- a/pkg/engine/compactor/coordinator_test.go
+++ b/pkg/engine/compactor/coordinator_test.go
@@ -321,9 +321,16 @@ func TestCompactTenantLogs_DispatchesLogMergePlans(t *testing.T) {
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
 
 	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
-	result, err := c.compactTenantLogs(ctx, "acme", window, entry)
+	result, stats, err := c.compactTenantLogs(ctx, "acme", window, entry)
 	require.NoError(t, err)
 	require.Equal(t, tenantCycleLogCompacted, result)
+
+	// A successful log-compaction reports its index/task deltas so the
+	// indexes_added/removed and tasks metrics reflect the work (regression:
+	// these were previously dropped, leaving the log-compaction path invisible).
+	require.Equal(t, 1, stats.removed, "the single converged index is removed")
+	require.Equal(t, 1, stats.added, "one merged index is added")
+	require.Equal(t, 1, stats.dispatched, "one log-merge task is dispatched")
 
 	dispatches := runner.snapshot()
 	require.Len(t, dispatches, 1, "two runs -> one task -> one LogMerge plan")
@@ -359,7 +366,7 @@ func TestCompactTenantLogs_NoStatsRowsForTenantIsConverged(t *testing.T) {
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
 
 	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
-	result, err := c.compactTenantLogs(ctx, "acme", window, entry)
+	result, _, err := c.compactTenantLogs(ctx, "acme", window, entry)
 	require.NoError(t, err)
 	require.Equal(t, tenantCycleConverged, result)
 	require.Empty(t, runner.snapshot())
@@ -408,7 +415,7 @@ func TestCompactTenantLogs_TerminalSingleRunSkips(t *testing.T) {
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
 
 	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
-	result, err := c.compactTenantLogs(ctx, "acme", window, entry)
+	result, _, err := c.compactTenantLogs(ctx, "acme", window, entry)
 
 	require.NoError(t, err)
 	require.Equal(t, tenantCycleConverged, result)
@@ -436,7 +443,7 @@ func TestCompactTenantLogs_TerminalBelowFloorSkips(t *testing.T) {
 	c.cfg.LogMinCompactionSize = 1 << 30 // 1GiB floor; 30 bytes is below it
 
 	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
-	result, err := c.compactTenantLogs(ctx, "acme", window, entry)
+	result, _, err := c.compactTenantLogs(ctx, "acme", window, entry)
 
 	require.NoError(t, err)
 	require.Equal(t, tenantCycleConverged, result)
@@ -467,7 +474,7 @@ func TestCompactTenantLogs_SwapsToC(t *testing.T) {
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
 
 	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
-	result, err := c.compactTenantLogs(ctx, "acme", window, entry)
+	result, _, err := c.compactTenantLogs(ctx, "acme", window, entry)
 
 	require.NoError(t, err)
 	require.Equal(t, tenantCycleLogCompacted, result)
@@ -490,7 +497,7 @@ func TestCompactTenantLogs_SwapErrorFails(t *testing.T) {
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
 
 	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
-	result, err := c.compactTenantLogs(ctx, "acme", window, entry)
+	result, _, err := c.compactTenantLogs(ctx, "acme", window, entry)
 
 	require.Error(t, err)
 	require.Equal(t, tenantCycleFailed, result)
@@ -507,7 +514,7 @@ func TestCompactTenantLogs_SwapRaceLossConverged(t *testing.T) {
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
 
 	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
-	result, err := c.compactTenantLogs(ctx, "acme", window, entry)
+	result, _, err := c.compactTenantLogs(ctx, "acme", window, entry)
 
 	require.NoError(t, err)
 	require.Equal(t, tenantCycleConverged, result)
@@ -525,7 +532,7 @@ func TestCompactTenantLogs_DryRunSkipsSwap(t *testing.T) {
 	c.cfg.DryRun = true
 
 	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
-	result, err := c.compactTenantLogs(ctx, "acme", window, entry)
+	result, _, err := c.compactTenantLogs(ctx, "acme", window, entry)
 
 	require.NoError(t, err)
 	require.Equal(t, tenantCycleLogCompacted, result)
@@ -544,7 +551,7 @@ func TestCompactTenantLogs_PartialFailureNoSwap(t *testing.T) {
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
 
 	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
-	result, err := c.compactTenantLogs(ctx, "acme", window, entry)
+	result, _, err := c.compactTenantLogs(ctx, "acme", window, entry)
 
 	require.Error(t, err)
 	require.Equal(t, tenantCycleFailed, result)
@@ -562,7 +569,7 @@ func TestCompactTenantLogs_DeterministicOutputPaths(t *testing.T) {
 		runner := &fakeRunner{}
 		replacer := &fakeReplacer{swapped: true}
 		c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)))
-		_, err := c.compactTenantLogs(ctx, "acme", window, entry)
+		_, _, err := c.compactTenantLogs(ctx, "acme", window, entry)
 		require.NoError(t, err)
 		calls := replacer.snapshot()
 		require.Len(t, calls, 1)

--- a/pkg/engine/compactor/metrics.go
+++ b/pkg/engine/compactor/metrics.go
@@ -147,7 +147,8 @@ func (m *coordinatorMetrics) observeCycle(outcome string, duration time.Duration
 }
 
 // observeTenantCycle records per-tenant cycle outcomes and counts. stats is
-// only consulted for the compacted outcome; pass the zero value otherwise.
+// consulted for the work-producing outcomes (compacted, log_compacted); pass
+// the zero value for converged/failed.
 func (m *coordinatorMetrics) observeTenantCycle(
 	tenant string,
 	outcome string,
@@ -162,7 +163,9 @@ func (m *coordinatorMetrics) observeTenantCycle(
 	if outcome != "converged" {
 		m.tenantCycleDurationSeconds.WithLabelValues(outcome).Observe(duration.Seconds())
 	}
-	if outcome == "compacted" {
+	// Both the index-compaction (compacted) and log-compaction (log_compacted)
+	// paths add/remove indexes and dispatch tasks, so record their deltas.
+	if outcome == "compacted" || outcome == "log_compacted" {
 		m.indexesRemovedTotal.WithLabelValues(tenant).Add(float64(stats.removed))
 		m.indexesAddedTotal.WithLabelValues(tenant).Add(float64(stats.added))
 		m.tasksTotal.WithLabelValues(tenant).Add(float64(stats.dispatched))

--- a/pkg/engine/compactor/metrics.go
+++ b/pkg/engine/compactor/metrics.go
@@ -23,8 +23,11 @@ type coordinatorMetrics struct {
 	// cyclesTotal counts coordinator cycles by outcome.
 	cyclesTotal *prometheus.CounterVec // outcome=toc_not_found|index_load_err|no_indexes|converged|compaction_failed|compacted_with_failures|compacted
 
-	// tenantCyclesTotal counts per-tenant cycle outcomes.
-	tenantCyclesTotal *prometheus.CounterVec // outcome=compacted|log_compacted|converged|failed, tenant
+	// tenantCyclesTotal counts per-tenant index-compaction cycle outcomes.
+	tenantCyclesTotal *prometheus.CounterVec // outcome=compacted|converged|failed, tenant
+
+	// tenantLogCyclesTotal counts per-tenant log-compaction cycle outcomes.
+	tenantLogCyclesTotal *prometheus.CounterVec // outcome=compacted|converged|failed, tenant
 
 	// indexesRemovedTotal counts source indexes removed by compaction
 	// (cumulative). Use with indexesAddedTotal to compute net reduction:
@@ -68,7 +71,11 @@ func newCoordinatorMetrics(reg prometheus.Registerer) *coordinatorMetrics {
 		}, []string{labelOutcome}),
 		tenantCyclesTotal: f.NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_dataobj_compaction_tenant_cycles_total",
-			Help: "Per-tenant cycle outcomes. compacted = ran index compaction successfully, log_compacted = converged window dispatched log-merge tasks, converged = no index or single index with no log-merge work, failed = cycle returned error.",
+			Help: "Per-tenant index-compaction cycle outcomes. compacted = ran index compaction successfully, converged = no index or single index (log-compaction path), failed = cycle returned error.",
+		}, []string{labelOutcome, labelTenant}),
+		tenantLogCyclesTotal: f.NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_dataobj_compaction_tenant_log_cycles_total",
+			Help: "Per-tenant log-compaction cycle outcomes. compacted = converged window dispatched log-merge tasks, converged = single index with no log-merge work, failed = cycle returned error.",
 		}, []string{labelOutcome, labelTenant}),
 		indexesRemovedTotal: f.NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_dataobj_compaction_indexes_removed_total",
@@ -146,9 +153,9 @@ func (m *coordinatorMetrics) observeCycle(outcome string, duration time.Duration
 	m.cycleDurationSeconds.Observe(duration.Seconds())
 }
 
-// observeTenantCycle records per-tenant cycle outcomes and counts. stats is
-// consulted for the work-producing outcomes (compacted, log_compacted); pass
-// the zero value for converged/failed.
+// observeTenantCycle records per-tenant index-compaction cycle outcomes and
+// counts. stats is consulted for the compacted outcome; pass the zero value for
+// converged/failed.
 func (m *coordinatorMetrics) observeTenantCycle(
 	tenant string,
 	outcome string,
@@ -158,14 +165,41 @@ func (m *coordinatorMetrics) observeTenantCycle(
 	if m == nil {
 		return
 	}
-	// The converged outcome only bumps tenantCyclesTotal
 	m.tenantCyclesTotal.WithLabelValues(outcome, tenant).Inc()
+	m.recordTenantCycle(tenant, outcome, duration, stats)
+}
+
+// observeTenantLogCycle records per-tenant log-compaction cycle outcomes and
+// counts. stats is consulted for the compacted outcome; pass the zero value for
+// converged/failed.
+func (m *coordinatorMetrics) observeTenantLogCycle(
+	tenant string,
+	outcome string,
+	duration time.Duration,
+	stats compactionStats,
+) {
+	if m == nil {
+		return
+	}
+	m.tenantLogCyclesTotal.WithLabelValues(outcome, tenant).Inc()
+	m.recordTenantCycle(tenant, outcome, duration, stats)
+}
+
+// recordTenantCycle records the duration and index/task deltas shared by both
+// index- and log-compaction cycles.
+func (m *coordinatorMetrics) recordTenantCycle(
+	tenant string,
+	outcome string,
+	duration time.Duration,
+	stats compactionStats,
+) {
+	// The converged outcome skips the duration histogram.
 	if outcome != "converged" {
 		m.tenantCycleDurationSeconds.WithLabelValues(outcome).Observe(duration.Seconds())
 	}
-	// Both the index-compaction (compacted) and log-compaction (log_compacted)
-	// paths add/remove indexes and dispatch tasks, so record their deltas.
-	if outcome == "compacted" || outcome == "log_compacted" {
+	// The compacted outcome adds/removes indexes and dispatches tasks, so
+	// record its deltas.
+	if outcome == "compacted" {
 		m.indexesRemovedTotal.WithLabelValues(tenant).Add(float64(stats.removed))
 		m.indexesAddedTotal.WithLabelValues(tenant).Add(float64(stats.added))
 		m.tasksTotal.WithLabelValues(tenant).Add(float64(stats.dispatched))

--- a/pkg/engine/compactor/worker.go
+++ b/pkg/engine/compactor/worker.go
@@ -21,6 +21,7 @@ type WorkerParams struct {
 	Config WorkerConfig
 
 	Bucket       objstore.Bucket
+	DataBucket   objstore.Bucket     // unprefixed bucket for reading source log objects; nil falls back to Bucket
 	Metastore    metastore.Metastore // may be nil in tests where no task ever arrives
 	ScratchStore scratch.Store
 
@@ -84,6 +85,7 @@ func NewWorker(params WorkerParams) (*Worker, error) {
 	inner, err := engine.NewWorker(engine.WorkerParams{
 		Logger:       log.With(logger, "component", "dataobj-compaction-worker"),
 		Bucket:       params.Bucket,
+		DataBucket:   params.DataBucket,
 		Metastore:    params.Metastore,
 		ScratchStore: params.ScratchStore,
 		Config: engine.WorkerConfig{

--- a/pkg/engine/internal/executor/executor.go
+++ b/pkg/engine/internal/executor/executor.go
@@ -58,6 +58,13 @@ type Config struct {
 	Bucket    objstore.Bucket
 	Metastore metastore.Metastore
 
+	// DataBucket reads source log objects during LogMerge compaction. Unlike
+	// Bucket (which the compaction wiring prefixes with the index-storage
+	// prefix for index I/O and ToC), source log objects are stored at the
+	// unprefixed dataobj root, so they must be read through this bucket.
+	// Optional; when nil the executor falls back to Bucket.
+	DataBucket objstore.Bucket
+
 	// GetExternalInputs is an optional function called for each node in the
 	// plan. If GetExternalInputs returns a non-nil slice of Pipelines, they
 	// will be used as inputs to the pipeline of node.
@@ -82,6 +89,7 @@ func Run(ctx context.Context, cfg Config, plan *physical.Plan, logger log.Logger
 		prefetchBytes:      cfg.PrefetchBytes,
 		mergePrefetchCount: cfg.MergePrefetchCount,
 		bucket:             cfg.Bucket,
+		dataBucket:         cfg.DataBucket,
 		metastore:          cfg.Metastore,
 		logger:             logger,
 		evaluator:          newExpressionEvaluator(),
@@ -108,11 +116,12 @@ type Context struct {
 	batchSize     int64
 	prefetchBytes int64
 
-	logger    log.Logger
-	plan      *physical.Plan
-	evaluator *expressionEvaluator
-	bucket    objstore.Bucket
-	metastore metastore.Metastore
+	logger     log.Logger
+	plan       *physical.Plan
+	evaluator  *expressionEvaluator
+	bucket     objstore.Bucket
+	dataBucket objstore.Bucket
+	metastore  metastore.Metastore
 
 	getExternalInputs func(ctx context.Context, node physical.Node) []Pipeline
 

--- a/pkg/engine/internal/executor/log_merge.go
+++ b/pkg/engine/internal/executor/log_merge.go
@@ -454,7 +454,6 @@ func (w *logObjectWriter) finalizeAndUpload(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("flushing object: %w", err)
 	}
-	defer closer.Close()
 
 	path := logMergeOutputPath(w.node.OutputIndexPath, w.stats.OutputObjects)
 

--- a/pkg/engine/internal/executor/log_merge.go
+++ b/pkg/engine/internal/executor/log_merge.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/thanos-io/objstore"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
@@ -30,6 +31,17 @@ func (c *Context) executeLogMerge(node *physical.LogMerge) Pipeline {
 		}
 		return emptyPipeline()
 	}, nil)
+}
+
+// sourceBucket returns the bucket to read source log objects from. Source
+// objects are stored at the unprefixed dataobj root, so it prefers dataBucket
+// and falls back to bucket when dataBucket is unset (e.g. query-only workers or
+// tests that share a single bucket).
+func (c *Context) sourceBucket() objstore.Bucket {
+	if c.dataBucket != nil {
+		return c.dataBucket
+	}
+	return c.bucket
 }
 
 func (c *Context) doLogObjectMerge(ctx context.Context, node *physical.LogMerge) error {
@@ -176,10 +188,14 @@ func (c *Context) collectLogSources(ctx context.Context, node *physical.LogMerge
 			paths = append(paths, sec.ObjectPath)
 		}
 	}
+	// Source log objects live at the unprefixed dataobj root, not under the
+	// index-storage prefix that c.bucket carries, so read them via dataBucket.
+	srcBucket := c.sourceBucket()
+
 	// Gather log and streams sections
 	sources := make([]*logSource, 0, len(paths))
 	for _, path := range paths {
-		obj, err := dataobj.FromBucket(ctx, c.bucket, path, 0)
+		obj, err := dataobj.FromBucket(ctx, srcBucket, path, 0)
 		if err != nil {
 			return nil, fmt.Errorf("opening object %q: %w", path, err)
 		}

--- a/pkg/engine/internal/executor/log_merge_test.go
+++ b/pkg/engine/internal/executor/log_merge_test.go
@@ -194,6 +194,44 @@ func TestCollectLogSources_ExcludesOtherTenants(t *testing.T) {
 	require.Equal(t, map[string]bool{"a": true}, apps, "other tenants' streams must be excluded")
 }
 
+// TestCollectLogSources_ReadsFromUnprefixedDataBucket reproduces the bug where
+// the compaction worker was wired with only the index-prefixed bucket. Source
+// log objects live at the unprefixed dataobj root, so reading them through the
+// prefixed bucket prepended the index prefix and failed with "key does not
+// exist". collectLogSources must read sources from dataBucket (unprefixed).
+func TestCollectLogSources_ReadsFromUnprefixedDataBucket(t *testing.T) {
+	ctx := context.Background()
+
+	const tenant = "T"
+	sortSchema := []string{"label:app"}
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Source log objects are written at the unprefixed root, exactly as the
+	// uploader writes them (objects/<sha>/<sha>).
+	root := objstore.NewInMemBucket()
+	buildSourceLogObject(t, root, "objects/09/abcdef", sortSchema, map[string][]testStream{
+		tenant: {{labels: `{app="a"}`, entries: linesAt(base, 3)}},
+	})
+
+	// bucket is the index-prefixed view the compaction wiring hands the
+	// executor; dataBucket is the unprefixed root for reading source objects.
+	c := newTestExecutorContext(t, objstore.NewPrefixedBucket(root, "dataobj/index/v0"))
+	c.dataBucket = root
+
+	node := &physical.LogMerge{
+		Tenant:     tenant,
+		SortSchema: sortSchema,
+		Runs: []*compactionv2pb.RunRef{
+			{Sections: []*compactionv2pb.SectionRef{{ObjectPath: "objects/09/abcdef"}}},
+		},
+	}
+
+	sources, err := c.collectLogSources(ctx, node)
+	require.NoError(t, err, "source objects must resolve against the unprefixed data bucket")
+	require.Len(t, sources, 1)
+	require.Equal(t, "objects/09/abcdef", sources[0].path)
+}
+
 // newSmallObjectExecutorContext is like newTestExecutorContext but with a tiny
 // TargetObjectSize so the merge splits its output across multiple objects.
 func newSmallObjectExecutorContext(t *testing.T, bucket objstore.Bucket) *Context {

--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -103,6 +103,7 @@ type thread struct {
 	BatchSize      int64
 	PrefetchBytes  int64
 	Bucket         objstore.Bucket
+	DataBucket     objstore.Bucket
 	Metastore      metastore.Metastore
 	Logger         log.Logger
 	StreamFilterer executor.RequestStreamFilterer
@@ -125,6 +126,15 @@ func (t *thread) State() threadState {
 	t.stateMut.RLock()
 	defer t.stateMut.RUnlock()
 	return t.state
+}
+
+// dataBucketXCap wraps the source-object bucket for tracing, returning nil when
+// no separate data bucket is configured so the executor falls back to Bucket.
+func (t *thread) dataBucketXCap() objstore.Bucket {
+	if t.DataBucket == nil {
+		return nil
+	}
+	return bucket.NewXCapBucket(t.DataBucket)
 }
 
 // Run starts the thread. Run will request and run tasks in a loop until the
@@ -215,6 +225,7 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 		BatchSize:      t.BatchSize,
 		PrefetchBytes:  t.PrefetchBytes,
 		Bucket:         bucket.NewXCapBucket(t.Bucket),
+		DataBucket:     t.dataBucketXCap(),
 		Metastore:      t.Metastore,
 		StreamFilterer: t.StreamFilterer,
 		TaskCaches:     t.TaskCaches,

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -45,6 +45,12 @@ type Config struct {
 	// Bucket to read stored data from.
 	Bucket objstore.Bucket
 
+	// DataBucket reads source log objects during LogMerge compaction. When the
+	// compaction wiring prefixes Bucket with the index-storage prefix, source
+	// log objects (stored at the unprefixed dataobj root) must be read through
+	// this bucket. Optional; nil falls back to Bucket.
+	DataBucket objstore.Bucket
+
 	// Metastore client to access indexes.
 	Metastore metastore.Metastore
 
@@ -203,6 +209,7 @@ func (w *Worker) run(ctx context.Context) error {
 			PrefetchBytes:  w.config.PrefetchBytes,
 			Logger:         log.With(w.logger, "thread", i),
 			Bucket:         w.config.Bucket,
+			DataBucket:     w.config.DataBucket,
 			Metastore:      w.config.Metastore,
 			StreamFilterer: w.config.StreamFilterer,
 			TaskCaches:     w.taskCaches,

--- a/pkg/engine/worker.go
+++ b/pkg/engine/worker.go
@@ -43,6 +43,12 @@ type WorkerParams struct {
 	Bucket    objstore.Bucket     // Bucket to read stored data from.
 	Metastore metastore.Metastore // Metastore to access indexes.
 
+	// DataBucket reads source log objects during LogMerge compaction. When
+	// Bucket is prefixed with the index-storage prefix (compaction wiring),
+	// source log objects live at the unprefixed dataobj root and must be read
+	// through this bucket. Optional; nil falls back to Bucket.
+	DataBucket objstore.Bucket
+
 	Config   WorkerConfig   // Configuration for the worker.
 	Executor ExecutorConfig // Configuration for task execution.
 
@@ -144,9 +150,10 @@ func NewWorker(params WorkerParams, reg prometheus.Registerer) (*Worker, error) 
 	}
 
 	inner, err := worker.New(worker.Config{
-		Logger:    params.Logger,
-		Bucket:    params.Bucket,
-		Metastore: params.Metastore,
+		Logger:     params.Logger,
+		Bucket:     params.Bucket,
+		DataBucket: params.DataBucket,
+		Metastore:  params.Metastore,
 
 		Dialer:   dialer,
 		Listener: listener,

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -2448,8 +2448,12 @@ func (t *Loki) initDataObjCompactionWorker() (services.Service, error) {
 	ms := metastore.NewObjectMetastore(store, t.Cfg.DataObj.Metastore, logger, t.metastoreMetrics)
 
 	w, err := enginecompactor.NewWorker(enginecompactor.WorkerParams{
-		Config:       t.Cfg.DataObj.Compaction.Worker,
-		Bucket:       indexBucket,
+		Config: t.Cfg.DataObj.Compaction.Worker,
+		Bucket: indexBucket,
+		// Source log objects live at the unprefixed dataobj root, so the
+		// LogMerge executor reads them through the unprefixed store rather than
+		// the index-prefixed bucket used for index I/O and ToC.
+		DataBucket:   store,
 		Metastore:    ms,
 		ScratchStore: t.scratchStore,
 		IndexobjCfg:  t.Cfg.DataObj.Compaction.IndexobjBuilder,


### PR DESCRIPTION
Stacked on #23214.

Fixes the log-compaction path in the dataobj compactor so it reads source objects from the correct bucket and reports metrics for its own workflow.

## Changes

- **Read source log objects from the unprefixed data bucket.** The `LogMerge` executor's `collectLogSources` was reading source log objects through the index-prefixed bucket, prepending the index prefix (e.g. `dataobj/index/v0/`) and failing with "The specified key does not exist". This caused every `LogMerge` task to fail and zero tenants to compact. A separate, unprefixed `DataBucket` is now threaded through the compaction worker into the executor `Context` for source reads; index I/O, ToC, and compacted-output uploads stay on the prefixed bucket. `DataBucket` is optional and falls back to `Bucket` when unset.

- **Record index/task metrics for the log-compaction path.** `compactTenantLogs` swapped the ToC but `runTenantCycle` recorded an empty `compactionStats{}` for the `log_compacted` outcome, so `indexes_added_total`, `indexes_removed_total`, and `tasks_total` never moved for the primary compaction path. It now returns real stats from the ToC swap and dispatched task count.

- **Split tenant log-compaction into its own metric.** `tenant_cycles_total` mixed index- and log-compaction cycles on one series. Log-compaction now reports on a dedicated `tenant_log_cycles_total` metric with independent `compacted|converged|failed` outcomes.
