### PR TITLE
fix(queryrange): Preserve the query plan across the httpgrpc downstream hop

### DIFF
--- a/pkg/querier/queryrange/codec.go
+++ b/pkg/querier/queryrange/codec.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"container/heap"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -776,6 +777,9 @@ func (c Codec) EncodeRequest(ctx context.Context, r queryrangebase.Request) (*ht
 			}
 			params["storeChunks"] = []string{string(b)}
 		}
+		if err := encodeQueryPlan(params, request.Plan); err != nil {
+			return nil, err
+		}
 		u := &url.URL{
 			// the request could come /api/prom/query but we want to only use the new api.
 			Path:     "/loki/api/v1/query_range",
@@ -839,6 +843,9 @@ func (c Codec) EncodeRequest(ctx context.Context, r queryrangebase.Request) (*ht
 		}
 		if len(request.Shards) > 0 {
 			params["shards"] = request.Shards
+		}
+		if err := encodeQueryPlan(params, request.Plan); err != nil {
+			return nil, err
 		}
 		u := &url.URL{
 			// the request could come /api/prom/query but we want to only use the new api.
@@ -2263,13 +2270,54 @@ func mergeLokiResponse(responses ...queryrangebase.Response) *LokiResponse {
 	}
 }
 
+// planParam carries the serialized query plan across the httpgrpc hop between the
+// query-frontend and the querier. Downstream sub-queries produced by the shard mapper can
+// contain internal operators (e.g. __count_min_sketch__) that are not part of the public
+// LogQL grammar, so the querier must restore the AST from the plan rather than re-parsing
+// the query string.
+const planParam = "plan"
+
+func encodeQueryPlan(params url.Values, p *plan.QueryPlan) error {
+	if p == nil || p.AST == nil {
+		return nil
+	}
+	b, err := p.Marshal()
+	if err != nil {
+		return errors.Wrap(err, "marshaling query plan")
+	}
+	params[planParam] = []string{base64.StdEncoding.EncodeToString(b)}
+	return nil
+}
+
+// decodeQueryPlan returns the AST from the serialized plan when present, falling back to
+// parsing the query string otherwise (e.g. requests originating directly from a user).
+func decodeQueryPlan(r *http.Request, query string) (syntax.Expr, error) {
+	encoded := r.Form.Get(planParam)
+	if encoded == "" {
+		return syntax.ParseExpr(query)
+	}
+
+	b, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, errors.Wrap(err, "decoding query plan")
+	}
+	var p plan.QueryPlan
+	if err := p.Unmarshal(b); err != nil {
+		return nil, errors.Wrap(err, "unmarshaling query plan")
+	}
+	if p.AST == nil {
+		return syntax.ParseExpr(query)
+	}
+	return p.AST, nil
+}
+
 func parseRangeQuery(r *http.Request) (*LokiRequest, error) {
 	rangeQuery, err := loghttp.ParseRangeQuery(r)
 	if err != nil {
 		return nil, err
 	}
 
-	parsed, err := syntax.ParseExpr(rangeQuery.Query)
+	parsed, err := decodeQueryPlan(r, rangeQuery.Query)
 	if err != nil {
 		return nil, err
 	}
@@ -2302,7 +2350,7 @@ func parseInstantQuery(r *http.Request) (*LokiInstantRequest, error) {
 		return nil, err
 	}
 
-	parsed, err := syntax.ParseExpr(req.Query)
+	parsed, err := decodeQueryPlan(r, req.Query)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/querier/queryrange/codec_test.go
+++ b/pkg/querier/queryrange/codec_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/axiomhq/hyperloglog"
 	"github.com/gorilla/mux"
+	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -2876,4 +2877,52 @@ func generateSeries() (res []logproto.SeriesIdentifier) {
 		res = append(res, logproto.SeriesIdentifier{Labels: labels})
 	}
 	return res
+}
+
+// TestApproxTopkDownstreamHTTPGrpcRoundTrip is the queryrange-codec counterpart to
+// TestApproxTopkDownstreamRoundTrip (https://github.com/grafana/loki/issues/23150).
+//
+// When approx_topk is sharded, the shard mapper produces downstream
+// __count_min_sketch__ sub-queries whose AST is carried in LokiRequest.Plan. In a
+// microservices deployment the frontend dispatches each downstream to the querier via
+// httpgrpc: EncodeRequest -> DecodeHTTPGrpcRequest. If the plan is not carried across
+// that hop, the querier falls back to re-parsing the query string, which fails for the
+// internal __count_min_sketch__ operator with a 400 "unexpected IDENTIFIER".
+//
+// This asserts the AST survives the round-trip without depending on the query string
+// being parseable.
+func TestApproxTopkDownstreamHTTPGrpcRoundTrip(t *testing.T) {
+	ctx := user.InjectOrgID(context.Background(), "1")
+
+	// Build the __count_min_sketch__ downstream expr the way the shard mapper does.
+	inner := syntax.MustParseExpr(`approx_topk(3, sum by (ip)(rate({foo="bar"}[5m])))`).(*syntax.VectorAggregationExpr)
+	cms := syntax.MustClone(inner)
+	cms.Operation = syntax.OpTypeCountMinSketch
+	cms.Params = 0
+
+	req := &LokiRequest{
+		Query:     cms.String(),
+		Limit:     100,
+		StartTs:   start,
+		EndTs:     end,
+		Step:      30000,
+		Direction: logproto.FORWARD,
+		Path:      "/loki/api/v1/query_range",
+		Plan:      &plan.QueryPlan{AST: cms},
+	}
+
+	httpReq, err := DefaultCodec.EncodeRequest(ctx, req)
+	require.NoError(t, err)
+
+	grpcReq, err := httpgrpc.FromHTTPRequest(httpReq)
+	require.NoError(t, err)
+
+	got, _, err := DefaultCodec.DecodeHTTPGrpcRequest(ctx, grpcReq)
+	require.NoError(t, err, "querier must decode the sharded __count_min_sketch__ downstream without re-parsing the query string")
+
+	lokiReq, ok := got.(*LokiRequest)
+	require.True(t, ok)
+	require.NotNil(t, lokiReq.Plan)
+	require.NotNil(t, lokiReq.Plan.AST)
+	require.Equal(t, cms.String(), lokiReq.Plan.AST.String())
 }

--- a/pkg/querier/queryrange/codec_test.go
+++ b/pkg/querier/queryrange/codec_test.go
@@ -2879,50 +2879,96 @@ func generateSeries() (res []logproto.SeriesIdentifier) {
 	return res
 }
 
-// TestApproxTopkDownstreamHTTPGrpcRoundTrip is the queryrange-codec counterpart to
-// TestApproxTopkDownstreamRoundTrip (https://github.com/grafana/loki/issues/23150).
+// TestInternalOpDownstreamHTTPGrpcRoundTrip is the queryrange-codec regression test for
+// https://github.com/grafana/loki/issues/23150.
 //
-// When approx_topk is sharded, the shard mapper produces downstream
-// __count_min_sketch__ sub-queries whose AST is carried in LokiRequest.Plan. In a
-// microservices deployment the frontend dispatches each downstream to the querier via
-// httpgrpc: EncodeRequest -> DecodeHTTPGrpcRequest. If the plan is not carried across
-// that hop, the querier falls back to re-parsing the query string, which fails for the
-// internal __count_min_sketch__ operator with a 400 "unexpected IDENTIFIER".
+// The shard mapper (pkg/logql/shardmapper.go) rewrites shardable aggregations into
+// downstream sub-queries that use internal operators which are NOT part of the public
+// LogQL grammar, so their String() form is not parseable. In a microservices deployment
+// the frontend dispatches each downstream to the querier via httpgrpc:
+// EncodeRequest -> DecodeHTTPGrpcRequest. If the plan is not carried across that hop, the
+// querier falls back to re-parsing the query string and fails with a 400
+// "unexpected IDENTIFIER".
 //
-// This asserts the AST survives the round-trip without depending on the query string
-// being parseable.
-func TestApproxTopkDownstreamHTTPGrpcRoundTrip(t *testing.T) {
+// approx_topk (#23150) is the reported case, but the same failure applies to every
+// internal operator the shard mapper emits. Carrying the plan fixes them all, which this
+// asserts by round-tripping each without depending on the query string being parseable.
+func TestInternalOpDownstreamHTTPGrpcRoundTrip(t *testing.T) {
 	ctx := user.InjectOrgID(context.Background(), "1")
 
-	// Build the __count_min_sketch__ downstream expr the way the shard mapper does.
-	inner := syntax.MustParseExpr(`approx_topk(3, sum by (ip)(rate({foo="bar"}[5m])))`).(*syntax.VectorAggregationExpr)
-	cms := syntax.MustClone(inner)
-	cms.Operation = syntax.OpTypeCountMinSketch
-	cms.Params = 0
+	for _, tc := range []struct {
+		name string
+		expr syntax.SampleExpr
+	}{
+		{
+			// approx_topk sharding -> __count_min_sketch__
+			name: "count_min_sketch",
+			expr: func() syntax.SampleExpr {
+				e := syntax.MustClone(syntax.MustParseExpr(`approx_topk(3, sum by (ip)(rate({foo="bar"}[5m])))`).(*syntax.VectorAggregationExpr))
+				e.Operation = syntax.OpTypeCountMinSketch
+				e.Params = 0
+				return e
+			}(),
+		},
+		{
+			// quantile_over_time sharding -> __quantile_sketch_over_time__
+			name: "quantile_sketch_over_time",
+			expr: func() syntax.SampleExpr {
+				e := syntax.MustParseExpr(`quantile_over_time(0.5,{foo="bar"} | unwrap x [5m]) by (ip)`).(*syntax.RangeAggregationExpr)
+				e.Operation = syntax.OpRangeTypeQuantileSketch
+				return e
+			}(),
+		},
+		{
+			// first_over_time sharding -> __first_over_time_ts__
+			name: "first_over_time_ts",
+			expr: func() syntax.SampleExpr {
+				e := syntax.MustParseExpr(`first_over_time({foo="bar"} | unwrap x [5m]) by (ip)`).(*syntax.RangeAggregationExpr)
+				e.Operation = syntax.OpRangeTypeFirstWithTimestamp
+				return e
+			}(),
+		},
+		{
+			// last_over_time sharding -> __last_over_time_ts__
+			name: "last_over_time_ts",
+			expr: func() syntax.SampleExpr {
+				e := syntax.MustParseExpr(`last_over_time({foo="bar"} | unwrap x [5m]) by (ip)`).(*syntax.RangeAggregationExpr)
+				e.Operation = syntax.OpRangeTypeLastWithTimestamp
+				return e
+			}(),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Sanity: the serialized form really is unparseable, so a querier that
+			// re-parses the query string (rather than using the plan) would 400.
+			_, err := syntax.ParseExpr(tc.expr.String())
+			require.Errorf(t, err, "internal operator string unexpectedly parseable: %s", tc.expr.String())
 
-	req := &LokiRequest{
-		Query:     cms.String(),
-		Limit:     100,
-		StartTs:   start,
-		EndTs:     end,
-		Step:      30000,
-		Direction: logproto.FORWARD,
-		Path:      "/loki/api/v1/query_range",
-		Plan:      &plan.QueryPlan{AST: cms},
+			req := &LokiRequest{
+				Query:     tc.expr.String(),
+				Limit:     100,
+				StartTs:   start,
+				EndTs:     end,
+				Step:      30000,
+				Direction: logproto.FORWARD,
+				Path:      "/loki/api/v1/query_range",
+				Plan:      &plan.QueryPlan{AST: tc.expr},
+			}
+
+			httpReq, err := DefaultCodec.EncodeRequest(ctx, req)
+			require.NoError(t, err)
+
+			grpcReq, err := httpgrpc.FromHTTPRequest(httpReq)
+			require.NoError(t, err)
+
+			got, _, err := DefaultCodec.DecodeHTTPGrpcRequest(ctx, grpcReq)
+			require.NoError(t, err, "querier must decode the downstream sub-query via the plan, without re-parsing the query string")
+
+			lokiReq, ok := got.(*LokiRequest)
+			require.True(t, ok)
+			require.NotNil(t, lokiReq.Plan)
+			require.NotNil(t, lokiReq.Plan.AST)
+			require.Equal(t, tc.expr.String(), lokiReq.Plan.AST.String())
+		})
 	}
-
-	httpReq, err := DefaultCodec.EncodeRequest(ctx, req)
-	require.NoError(t, err)
-
-	grpcReq, err := httpgrpc.FromHTTPRequest(httpReq)
-	require.NoError(t, err)
-
-	got, _, err := DefaultCodec.DecodeHTTPGrpcRequest(ctx, grpcReq)
-	require.NoError(t, err, "querier must decode the sharded __count_min_sketch__ downstream without re-parsing the query string")
-
-	lokiReq, ok := got.(*LokiRequest)
-	require.True(t, ok)
-	require.NotNil(t, lokiReq.Plan)
-	require.NotNil(t, lokiReq.Plan.AST)
-	require.Equal(t, cms.String(), lokiReq.Plan.AST.String())
 }


### PR DESCRIPTION
> **Draft / alternative approach.** This is an alternative fix for #23150, offered for comparison with #23175. It targets the transport layer rather than the LogQL grammar. Not intended to merge as-is — see **Remaining gaps** below.

**What this PR does / why we need it**

`approx_topk` is sharded by rewriting it into downstream `__count_min_sketch__` sub-queries (`mapApproxTopk` in `pkg/logql/shardmapper.go`). In a microservices deployment the query-frontend dispatches each downstream to the querier over **httpgrpc**: `Codec.EncodeRequest` → `Codec.DecodeHTTPGrpcRequest`.

The root cause of the 400 is that `EncodeRequest` serialized only the query **string** (`query=__count_min_sketch__(...)`) into the httpgrpc request and **dropped `LokiRequest.Plan`**. The querier's `DecodeHTTPGrpcRequest` → `parseRangeQuery`/`parseInstantQuery` then rebuilt the expression with `syntax.ParseExpr` on that string. Because `__count_min_sketch__` is an internal operator that is not part of the public LogQL grammar, re-parsing fails:

```
parse error at line 1, col 1: syntax error: unexpected IDENTIFIER
```

which surfaces on the query-frontend as an HTTP 400 (exactly the log in #23150).

This PR carries the marshaled query plan across the hop (as a `plan` param, mirroring the existing `storeChunks` precedent) and restores the AST from it on the querier, falling back to `ParseExpr` only when no plan is present (requests originating directly from a user, which are always valid public LogQL).

**Which issue(s) this PR fixes**: alternative fix for #23150.

**How this differs from #23175**

| | #23175 — register the token | This PR — carry `Plan.AST` |
|---|---|---|
| Layer | LogQL lexer + grammar (regenerates `syntax.y.go`) | Transport codec (`pkg/querier/queryrange`) |
| Root cause | Symptom — makes the leaked internal string parseable | Root — stops the AST being dropped on the wire |
| User exposure | `__count_min_sketch__` becomes a user-typable operator | Stays internal |
| Scope | Fixes `approx_topk` only | Fixes every shard-mapper internal operator at once |

The internal operator was never meant to leave the frontend as a string; the AST it was built from is already available in `LokiRequest.Plan`. This approach transmits that AST instead of relying on the internal operator being re-parseable, so no internal operator needs to be added to the public grammar.

**This also fixes latent breakage for the other internal operators — verified.** The shard mapper emits `__quantile_sketch_over_time__`, `__first_over_time_ts__`, and `__last_over_time_ts__` the same way (`shardmapper.go`), and none of them is in the grammar either. On the httpgrpc transport their plan was dropped identically, so quantile/first/last sharding hit the same 400 — it simply wasn't exercised in the reporter's setup. The test below confirms all four fail without this change and are preserved with it, so the fix closes the whole class rather than just `approx_topk`.

**Aligned with the `protobuf` transport.** Loki already has a transport that carries the plan correctly: `-frontend.encoding=protobuf` wraps the whole `LokiRequest` (including `Plan`) in a typed `QueryRequest` proto, so the querier uses the AST and never re-parses — `QueryRequestUnwrap` calls `ParseExpr` only when `Plan == nil`. That path was introduced (#10956) explicitly to replace the HTTP/httpgrpc transcoding, but it is opt-in and `json`/httpgrpc is still the default, which is why the bug bites. This PR brings the default `json`/httpgrpc path to **parity** with what `protobuf` already does — carry the plan, prefer the AST, fall back to `ParseExpr` only when absent — rather than inventing new behaviour. (`frontend.encoding: protobuf` is therefore also a config-only workaround for #23150.)

**Tests**

`TestInternalOpDownstreamHTTPGrpcRoundTrip` reproduces the bug at the codec layer for **every** internal operator the shard mapper emits (`__count_min_sketch__`, `__quantile_sketch_over_time__`, `__first_over_time_ts__`, `__last_over_time_ts__`). For each it builds the downstream expr the shard mapper would, asserts its `String()` form is genuinely unparseable, then round-trips a `LokiRequest` through `EncodeRequest` → `DecodeHTTPGrpcRequest`. Without the change every case fails with the exact `rpc error: code = Code(400) ... unexpected IDENTIFIER` from the issue; with it, the AST is preserved and each request decodes cleanly.

**Remaining gaps (why this is a draft)**

- **Encoding efficiency (not a size limit).** The plan currently rides in the URL query params as base64 (mirroring the existing `storeChunks` pattern). On the scheduler/httpgrpc path this is **not** bounded by any URL-length limit — the request travels inside a gRPC message (bounded by `server.grpc-max-recv-msg-size-bytes`, default 4 MB), and the `protobuf` transport already ships the full AST on every request well within that. The only real downside of the current form is efficiency: base64 (~+33%) plus the textual URL make it ~40% larger than the equivalent protobuf message (633 B vs 442 B for a representative query). A merge-ready version should carry the plan in the request **body as raw bytes**, bringing it to parity with protobuf — the existing `storeChunks` handling has a `TODO` musing the same move. (A genuine URL-length limit only applies in `frontend.downstream-url` mode, where `EncodeRequest`'s request is sent as real HTTP.)
- **Other string-reparse sites.** `NewEmptyResponse` (`codec.go`) also re-parses `req.Query` and would still fail for an internal operator. It receives a `*LokiRequest` with a populated `Plan`, so it should prefer `req.Plan.AST`; not addressed here.
- **Transport coverage.** This fixes the `json`/httpgrpc path; the `protobuf` path already carries the plan. Both should be covered and tested together.
- This applies to all queries. That might be a good thing - or perhaps to broad and needs to be gated to only queries which need to know the AST. Note that `protobuf` already attaches the AST to every request, so unconditional is consistent with the intended-default transport rather than uniquely broad; scoping to only plan-dependent queries would make `json` diverge from `protobuf` for a marginal, encoding-driven saving.

**Checklist**
- [ ] Documentation added (n/a — internal operator, no user-facing surface)
- [x] Tests updated
- [x] Title matches conventional commits format

