### PR TITLE
feat: Add label based access control LBAC [release-3.7.x]

### DIFF
--- a/docs/sources/operations/lbac.md
+++ b/docs/sources/operations/lbac.md
@@ -1,0 +1,94 @@
+---
+title: Use label-based access control with Loki
+menuTitle: Access control
+description: Describes how to use label-based access control to only query logs that meet specific label requirements.
+aliases:
+weight:
+---
+
+# Use label-based access control with Loki
+
+{{< admonition type="note" >}}
+This feature is experimental and available from v3.7.3. For the latest releases, refer to the [Release notes](https://grafana.com/docs/loki/<LOKI_VERSION>/release-notes/).
+{{< /admonition >}}
+
+Label-based access control (LBAC) restricts the logs a tenant can query to those that match one or more [Prometheus label selectors](https://prometheus.io/docs/prometheus/latest/querying/basics/#time-series-selectors). You associate a set of selectors with a tenant, and queries from that tenant only return data from log streams that match at least one of the selectors. Because the selectors are combined with OR, this corresponds to [disjunctive normal form](https://en.wikipedia.org/wiki/Disjunctive_normal_form), which lets you express any required policy.
+
+LBAC builds on Loki's multi-tenancy: policies are scoped per tenant, so you must run Loki in multi-tenant mode. For more information, refer to the [multi-tenancy](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/multi-tenancy/) documentation.
+
+## Security model
+
+Loki does not include its own authentication layer. Both the tenant (`X-Scope-OrgID`) and the label policy (`X-Prom-Label-Policy`) are read from trusted HTTP headers on incoming requests.
+
+{{< admonition type="warning" >}}
+Never expose the Loki API directly to clients. A client that can reach Loki can set the `X-Scope-OrgID` and `X-Prom-Label-Policy` headers itself and bypass label-based access control entirely. You must run an authentication gateway in front of Loki that authenticates the request, sets the tenant, and attaches the correct label policy.
+{{< /admonition >}}
+
+The gateway is responsible for stripping any user supplied `X-Scope-OrgID` and `X-Prom-Label-Policy` and replacing them with values it derives from the authenticated identity. One open-source gateway that sets these headers is [db-auth-gateway](https://github.com/grafana/db-auth-gateway/). For general guidance on putting an authenticating reverse proxy in front of Loki, refer to the [authentication](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/authentication/) documentation.
+
+## Enable label-based access control
+
+LBAC requires multi-tenant mode, which is the default. Ensure authentication is enabled so that requests carry a tenant:
+
+```yaml
+auth_enabled: true
+```
+
+Then enable LBAC:
+
+```yaml
+lbac:
+  enabled: true
+```
+
+This can also be set with the `-lbac.enabled` command-line flag. When enabled, Loki parses the `X-Prom-Label-Policy` header on incoming requests and enforces the policies it contains.
+
+## Setting up a label policy
+
+A label policy is conveyed to Loki in the `X-Prom-Label-Policy` request header. This header is set by your authentication gateway, not by clients. Each header value has the form:
+
+```
+<tenant>:<URL-encoded selector>
+```
+
+The selector is a standard label matcher set such as `{env="dev"}`, URL-encoded so that it is safe to carry in a header. For example, the policy `{env="dev"}` for tenant `tenant1` is encoded as:
+
+```
+X-Prom-Label-Policy: tenant1:%7Benv%3D%22dev%22%7D
+```
+
+To associate multiple selectors with a tenant, set multiple values. You can either repeat the header or separate the encoded policies with a comma. The selectors are combined with OR: a stream is returned if it matches any one of them.
+
+## Exclude a label
+
+One common use case for an LBAC policy is to exclude logs that have a specific label. For example, to exclude all log lines with the label `secret=true`, use a selector with `secret!="true"`:
+
+```
+{secret!="true"}
+```
+
+## Use multiple selectors
+
+To allow access to both the production and development environments while excluding logs with the label `secret=true` in the production environment, use multiple selectors:
+
+```
+{secret!="true", env="prod"}
+{env="dev"}
+```
+
+These selectors enforce the policy as follows:
+
+* `{secret!="true", env="prod"}` matches and returns log lines from the production environment that do not have the `secret: true` label.
+* `{env="dev"}` matches and returns log lines from the development environment, even if they have the `secret: true` label.
+
+## Label policy scope
+
+Label policies are only applied to the log stream selector of the Loki query. They do not apply to label filter expressions. For more information, refer to the [Log stream selector](https://grafana.com/docs/loki/<LOKI_VERSION>/query/log_queries/#log-stream-selector) and [Label filter expression](https://grafana.com/docs/loki/<LOKI_VERSION>/query/log_queries/#label-filter-expression) sections in the documentation about [Log queries](https://grafana.com/docs/loki/<LOKI_VERSION>/query/log_queries/).
+
+## Writing log lines
+
+Label-based access control is not enforced on write (push) requests. A tenant that is allowed to write can push log lines with any labels, regardless of the label policy that applies to its queries.
+
+## Alertmanager and ruler
+
+Label policies are not enforced by the Alertmanager and ruler. This means that the requests they serve contain everything for a particular tenant without applying label-based access control. For example, listing all rule groups in the ruler returns all rule groups for the tenant, even if a label selector in the policy would exclude some of the labels on the rules.

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -98,6 +98,11 @@ Pass the `-config.expand-env` flag at the command line to enable this way of set
 # CLI flag: -auth.enabled
 [auth_enabled: <boolean> | default = true]
 
+lbac:
+  # Enables label based access control through the X-Prom-Label-Policy header.
+  # CLI flag: -lbac.enabled
+  [enabled: <boolean> | default = false]
+
 # The amount of virtual memory in bytes to reserve as ballast in order to
 # optimize garbage collection. Larger ballasts result in fewer garbage
 # collection passes, reducing CPU overhead at the cost of heap size. The ballast

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -481,7 +481,7 @@ type Header struct {
 }
 
 // RunRangeQuery runs a 7d query and returns an error if anything went wrong
-// This function is kept to keep backwards copatibility of existing tests.
+// This function is kept to keep backwards compatibility of existing tests.
 // Better use (*Client).RunRangeQueryWithStartEnd()
 func (c *Client) RunRangeQuery(ctx context.Context, query string, extraHeaders ...Header) (*Response, error) {
 	end := c.Now.Add(time.Second)
@@ -645,6 +645,8 @@ func (c *Client) Series(ctx context.Context, matcher string) ([]map[string]strin
 
 	v := url.Values{}
 	v.Set("match[]", matcher)
+	v.Set("end", FormatTS(c.Now.Add(time.Second)))
+	v.Set("start", FormatTS(c.Now.Add(-7*24*time.Hour)))
 
 	u, err := url.Parse(c.baseURL)
 	if err != nil {

--- a/integration/labelaccess_test.go
+++ b/integration/labelaccess_test.go
@@ -1,0 +1,476 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/integration/client"
+	"github.com/grafana/loki/v3/integration/cluster"
+	"github.com/grafana/loki/v3/pkg/labelaccess"
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+	"github.com/grafana/loki/v3/pkg/util/constants"
+)
+
+const (
+	logsQuery           = `{job="varlog"} |= "line"`
+	metricsQuery        = "count_over_time(" + logsQuery + " [2h])"
+	aggregatedLogsQuery = `{__aggregated_metric__="varlog_service"} | logfmt`
+)
+
+func buildLBACPolicyHeaders(tenantID string, policies []types.LabelPolicy) []string {
+	headers := make([]string, len(policies))
+	for i := range policies {
+		matchers := make([]string, len(policies[i].Selector))
+		for j, selector := range policies[i].Selector {
+			matcher, err := types.LabelMatcherToPromLabel(selector)
+			if err != nil {
+				panic(err)
+			}
+			matchers[j] = matcher.String()
+		}
+		headers[i] = fmt.Sprintf("%s:%s", tenantID, url.PathEscape("{"+strings.Join(matchers, ", ")+"}"))
+	}
+	return headers
+}
+
+// newPolicy builds a LabelPolicy fixture from a selector string, panicking on
+// malformed input.
+func newPolicy(selector string) types.LabelPolicy {
+	matchers, err := parser.NewParser(parser.Options{}).ParseMetricSelector(selector)
+	if err != nil {
+		panic(err)
+	}
+	policy := types.LabelPolicy{Selector: make([]*types.LabelMatcher, len(matchers))}
+	for i, m := range matchers {
+		lm, err := types.LabelMatcherFromPromLabel(m)
+		if err != nil {
+			panic(err)
+		}
+		policy.Selector[i] = lm
+	}
+	return policy
+}
+
+var (
+	testCases = []*testQueryAndLabelResults{
+		{
+			name:          "no matches",
+			createCluster: clusterAllLBAC,
+			tenantID:      randStringRunes(),
+			now:           time.Now(),
+			labelPolicies: []types.LabelPolicy{newPolicy(`{not="existing"}`)},
+		},
+		{
+			name:          "disabled",
+			createCluster: clusterAll,
+			tenantID:      randStringRunes(),
+			now:           time.Now(),
+			labelPolicies: []types.LabelPolicy{
+				newPolicy(`{env="dev"}`),
+			},
+			labelValues: map[string][]string{
+				"classification": {"confidential", "secret"},
+				"env":            {"dev", "prod"},
+				"job":            {"varlog"},
+			},
+			lines: []string{"line1", "line2", "line3", "line4"},
+			streams: []map[string]string{
+				{
+					"classification": "confidential",
+					"env":            "dev",
+					"job":            "varlog",
+				},
+				{
+					"classification": "secret",
+					"env":            "prod",
+					"job":            "varlog",
+				},
+				{
+					"classification": "secret",
+					"env":            "dev",
+					"job":            "varlog",
+				},
+				{
+					"job": "varlog",
+				},
+			},
+		},
+		{
+			name:          "lbac enabled",
+			createCluster: clusterAllLBAC,
+			tenantID:      randStringRunes(),
+			now:           time.Now(),
+			labelPolicies: []types.LabelPolicy{
+				newPolicy(`{env="dev"}`),
+			},
+			labelValues: map[string][]string{
+				"classification": {"confidential", "secret"},
+				"env":            {"dev"},
+				"job":            {"varlog"},
+			},
+			lines: []string{"line1", "line3"},
+			streams: []map[string]string{
+				{
+					"classification": "confidential",
+					"env":            "dev",
+					"job":            "varlog",
+				},
+				{
+					"classification": "secret",
+					"env":            "dev",
+					"job":            "varlog",
+				},
+			},
+		},
+		{
+			name:          "multiple policies",
+			createCluster: clusterAllLBAC,
+			tenantID:      randStringRunes(),
+			now:           time.Now(),
+			labelPolicies: []types.LabelPolicy{
+				newPolicy(`{env="dev", classification!="secret"}`),
+				newPolicy(`{classification=~"secre.*"}`),
+			},
+			labelValues: map[string][]string{
+				"env":            {"dev", "prod"},
+				"classification": {"secret", "confidential"},
+				"job":            {"varlog"},
+			},
+			lines: []string{"line1", "line3", "line4"},
+			streams: []map[string]string{
+				{
+					"classification": "confidential",
+					"env":            "dev",
+					"job":            "varlog",
+				},
+				{
+					"classification": "secret",
+					"env":            "dev",
+					"job":            "varlog",
+				},
+				{
+					"classification": "secret",
+					"env":            "prod",
+					"job":            "varlog",
+				},
+			},
+		},
+	}
+)
+
+func clusterAll(t *testing.T) *cluster.Component {
+	clu := cluster.New(nil, cluster.SchemaWithTSDB, func(c *cluster.Cluster) {
+		c.SetSchemaVer("v13")
+	})
+	t.Cleanup(func() {
+		assert.NoError(t, clu.Cleanup())
+	})
+
+	tAll := clu.AddComponent("all", "-target=all")
+	require.NoError(t, clu.Run())
+
+	return tAll
+}
+
+func clusterAllLBAC(t *testing.T) *cluster.Component {
+	clu := cluster.New(nil, cluster.SchemaWithTSDB, func(c *cluster.Cluster) {
+		c.SetSchemaVer("v13")
+	})
+	t.Cleanup(func() {
+		assert.NoError(t, clu.Cleanup())
+	})
+
+	tAll := clu.AddComponent("all", "-target=all", "-lbac.enabled=true")
+	require.NoError(t, clu.Run())
+
+	return tAll
+}
+
+func clusterAllLBACAggregation(t *testing.T) *cluster.Component {
+	clu := cluster.New(nil, cluster.SchemaWithTSDB, func(c *cluster.Cluster) {
+		c.SetSchemaVer("v13")
+	})
+	t.Cleanup(func() {
+		assert.NoError(t, clu.Cleanup())
+	})
+
+	tAll := clu.AddComponent("all", "-target=all", "-lbac.enabled=true", "-limits.aggregation-enabled=true", "-pattern-ingester.enabled=true")
+	require.NoError(t, clu.Run())
+
+	return tAll
+}
+
+// TestLabelAccessDefault starts a Loki cluster and verifies
+// the query results are as expected as per the testCase configuration
+func TestLabelAccessTestCases(t *testing.T) {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.createCluster == nil {
+				panic("test case is missing createCluster function")
+			}
+			tAll := testCase.createCluster(t)
+			testCase.ingest(t, tAll)
+			cliQuery := testCase.cliQuery(t, tAll)
+
+			testCase.logsQuery(t, cliQuery)
+			testCase.labelValuesQuery(t, cliQuery)
+			testCase.seriesQuery(t, cliQuery)
+			testCase.metricsRangeQuery(t, cliQuery)
+			testCase.metricsQuery(t, cliQuery)
+
+			testCase.flush(t, tAll)
+			testCase.seriesQuery(t, cliQuery)
+		})
+	}
+}
+
+func TestAggregatedMetricsTestCases(t *testing.T) {
+	var aggregatedMetricsTestCases = []*testQueryAndLabelResults{
+		{
+			name:          "aggregated metrics",
+			createCluster: clusterAllLBACAggregation,
+			tenantID:      randStringRunes(),
+			now:           time.Now(),
+			labelPolicies: []types.LabelPolicy{
+				newPolicy(`{env!="dev", classification!="secret"}`),
+				newPolicy(`{classification!="secret"}`),
+			},
+			labelValues: map[string][]string{
+				"job": {"varlog"},
+			},
+			lines: []string{`ts=1 bytes=1024 count=10 job="varlog" service_name="varlog_service" env="dev" classification="confidential"`,
+				`ts=4 bytes=8192 count=40 job="varlog" service_name="varlog_service" env="prod" classification="notsecret"`},
+		},
+	}
+	for _, testCase := range aggregatedMetricsTestCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.createCluster == nil {
+				panic("test case is missing createCluster function")
+			}
+			tAll := testCase.createCluster(t)
+			testCase.ingestAggregatedMetrics(t, tAll)
+
+			cliQuery := testCase.cliQuery(t, tAll)
+
+			testCase.aggregatedMetricsQuery(t, cliQuery)
+			testCase.labelValuesQuery(t, cliQuery)
+		})
+	}
+}
+
+//
+//	// Query aggregated metrics
+
+//}
+
+type testQueryAndLabelResults struct {
+	name          string
+	createCluster func(t *testing.T) *cluster.Component
+	tenantID      string
+	now           time.Time
+	labelPolicies []types.LabelPolicy
+	labelValues   map[string][]string // expected label values that match the label policy
+	lines         []string            // expected lines that match the label policy
+	streams       []map[string]string // expected streams
+}
+
+func (tc *testQueryAndLabelResults) flush(t *testing.T, tAll *cluster.Component) {
+	cliWrite := client.New(tc.tenantID, "", tAll.HTTPURL())
+	require.NoError(t, cliWrite.Flush())
+}
+
+func (tc *testQueryAndLabelResults) ingest(t *testing.T, tAll *cluster.Component) *client.Client {
+	cliWrite := client.New(tc.tenantID, "", tAll.HTTPURL())
+	cliWrite.Now = tc.now
+
+	require.NoError(t, cliWrite.PushLogLine("line1", tc.now, nil, map[string]string{"env": "dev", "classification": "confidential"}))
+	require.NoError(t, cliWrite.PushLogLine("line2", tc.now.Add(time.Second), nil))
+	require.NoError(t, cliWrite.PushLogLine("line3", tc.now.Add(2*time.Second), nil, map[string]string{"classification": "secret", "env": "dev"}))
+	require.NoError(t, cliWrite.PushLogLine("line4", tc.now.Add(3*time.Second), nil, map[string]string{"classification": "secret", "env": "prod"}))
+	return cliWrite
+}
+
+func (tc *testQueryAndLabelResults) ingestAggregatedMetrics(t *testing.T, tAll *cluster.Component) {
+	cliWrite := client.New(tc.tenantID, "", tAll.HTTPURL())
+	cliWrite.Now = tc.now
+
+	aggMetricLabels := map[string]string{"__aggregated_metric__": "varlog_service"}
+
+	// Aggregated metrics for dev environment with confidential classification
+	require.NoError(t, cliWrite.PushLogLine(
+		`ts=1 bytes=1024 count=10 job="varlog" service_name="varlog_service" env="dev" classification="confidential"`,
+		tc.now,
+		nil,
+		aggMetricLabels,
+	))
+
+	// Aggregated metrics for dev environment with secret classification
+	require.NoError(t, cliWrite.PushLogLine(
+		`ts=2 bytes=2048 count=20 job="varlog" service_name="varlog_service" env="dev" classification="secret"`,
+		tc.now.Add(-time.Second),
+		nil,
+		aggMetricLabels,
+	))
+
+	// Aggregated metrics for prod environment with secret classification
+	require.NoError(t, cliWrite.PushLogLine(
+		`ts=3 bytes=4096 count=30 job="varlog" service_name="varlog_service" env="prod" classification="secret"`,
+		tc.now.Add(-2*time.Second),
+		nil,
+		aggMetricLabels,
+	))
+
+	// Aggregated metrics for prod environment with notsecret classification
+	require.NoError(t, cliWrite.PushLogLine(
+		`ts=4 bytes=8192 count=40 job="varlog" service_name="varlog_service" env="prod" classification="notsecret"`,
+		tc.now.Add(-3*time.Second),
+		nil,
+		aggMetricLabels,
+	))
+
+	require.NoError(t, cliWrite.Flush())
+}
+
+func (tc *testQueryAndLabelResults) aggregatedMetricsQuery(t *testing.T, qc *client.Client) {
+	t.Run("aggregated-metrics-query", func(t *testing.T) {
+
+		// query the available lines
+		output, err := qc.RunRangeQuery(context.Background(), aggregatedLogsQuery,
+			client.Header{Name: "X-Query-Tags", Value: "source=" + constants.LogsDrilldownAppName})
+		require.NoError(t, err)
+		assert.Equal(t, "success", output.Status)
+		assert.Equal(t, "streams", output.Data.ResultType)
+
+		var actualLines []string
+		for _, row := range output.Data.Stream {
+			for _, lines := range row.Values {
+				actualLines = append(actualLines, lines[1])
+			}
+		}
+		assert.ElementsMatch(t, tc.lines, actualLines)
+	})
+}
+
+func (tc *testQueryAndLabelResults) cliQuery(_ *testing.T, tAll *cluster.Component) *client.Client {
+	headers := buildLBACPolicyHeaders(tc.tenantID, tc.labelPolicies)
+
+	cliQuery := client.New(
+		tc.tenantID,
+		"",
+		tAll.HTTPURL(),
+		client.InjectHeadersOption{
+			labelaccess.HTTPHeaderKey: headers,
+		},
+	)
+	cliQuery.Now = tc.now.Add(4 * time.Second)
+	return cliQuery
+}
+
+func (tc *testQueryAndLabelResults) labelValuesQuery(t *testing.T, qc *client.Client) {
+	t.Run("label-values-query", func(t *testing.T) {
+		labelMap := make(map[string][]string)
+		labelNames, err := qc.LabelNames(context.Background())
+		require.NoError(t, err)
+		for _, label := range labelNames {
+			labelValues, err := qc.LabelValues(context.Background(), label)
+			require.NoError(t, err)
+			labelMap[label] = labelValues
+		}
+		require.NoError(t, err)
+
+		require.Equal(t, normalizeLabelsData(tc.labelValues), normalizeLabelsData(labelMap))
+	})
+}
+func (tc *testQueryAndLabelResults) logsQuery(t *testing.T, qc *client.Client) {
+	t.Run("logs-query", func(t *testing.T) {
+
+		// query the available lines
+		output, err := qc.RunRangeQuery(context.Background(), logsQuery)
+		require.NoError(t, err)
+		assert.Equal(t, "success", output.Status)
+		assert.Equal(t, "streams", output.Data.ResultType)
+
+		var actualLines []string
+		for _, row := range output.Data.Stream {
+			for _, lines := range row.Values {
+				actualLines = append(actualLines, lines[1])
+			}
+		}
+		assert.ElementsMatch(t, tc.lines, actualLines)
+	})
+}
+
+func (tc *testQueryAndLabelResults) seriesQuery(t *testing.T, qc *client.Client) {
+	t.Run("series-query", func(t *testing.T) {
+		seriesResult, err := qc.Series(context.Background(), "{}")
+		require.NoError(t, err)
+		require.ElementsMatch(t, tc.streams, seriesResult)
+	})
+}
+
+func (tc *testQueryAndLabelResults) metricsQuery(t *testing.T, qc *client.Client) {
+	t.Run("metrics-query", func(t *testing.T) {
+		output, err := qc.RunQuery(context.Background(), metricsQuery)
+		require.NoError(t, err)
+		assert.Equal(t, "success", output.Status)
+		assert.Equal(t, "vector", output.Data.ResultType)
+
+		var streams []map[string]string
+		for _, row := range output.Data.Vector {
+			streams = append(streams, labels.FromMap(row.Metric).Map())
+		}
+		assert.ElementsMatch(t, tc.streams, streams)
+	})
+}
+
+func (tc *testQueryAndLabelResults) metricsRangeQuery(t *testing.T, qc *client.Client) {
+	t.Run("metrics-range-query", func(t *testing.T) {
+		output, err := qc.RunRangeQuery(context.Background(), metricsQuery)
+		require.NoError(t, err)
+		require.Equal(t, "success", output.Status)
+		require.Equal(t, "matrix", output.Data.ResultType)
+		require.EqualValues(t, len(tc.lines), sumMatrixValues(t, output.Data.Matrix))
+	})
+}
+
+func sumMatrixValues(t *testing.T, matrix []client.MatrixValues) float64 {
+	t.Helper()
+
+	var total float64
+	for _, row := range matrix {
+		for _, sample := range row.Values {
+			require.Len(t, sample, 2)
+			value, ok := sample[1].(string)
+			require.True(t, ok)
+
+			parsed, err := strconv.ParseFloat(value, 64)
+			require.NoError(t, err)
+			total += parsed
+		}
+	}
+
+	return total
+}
+
+func normalizeLabelsData(labels map[string][]string) map[string][]string {
+	normalized := make(map[string][]string, len(labels))
+	for name, values := range labels {
+		sortedValues := append([]string(nil), values...)
+		sort.Strings(sortedValues)
+		normalized[name] = sortedValues
+	}
+	return normalized
+}

--- a/integration/multi_tenant_queries_test.go
+++ b/integration/multi_tenant_queries_test.go
@@ -16,10 +16,12 @@ import (
 
 func TestMultiTenantQuery(t *testing.T) {
 	t.Skip("This test is flaky on CI but it's hardly reproducible locally.")
-	clu := cluster.New(nil)
-	defer func() {
+	clu := cluster.New(nil, cluster.SchemaWithTSDB, func(c *cluster.Cluster) {
+		c.SetSchemaVer("v13")
+	})
+	t.Cleanup(func() {
 		assert.NoError(t, clu.Cleanup())
-	}()
+	})
 
 	var (
 		tAll = clu.AddComponent(

--- a/integration/shared_test.go
+++ b/integration/shared_test.go
@@ -7,11 +7,7 @@ import (
 	"time"
 )
 
-var randomGenerator *rand.Rand
-
-func init() {
-	randomGenerator = rand.New(rand.NewSource(time.Now().UnixNano()))
-}
+var randomGenerator = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 

--- a/pkg/labelaccess/aggregated_metrics.go
+++ b/pkg/labelaccess/aggregated_metrics.go
@@ -1,0 +1,278 @@
+package labelaccess
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+	logql_log "github.com/grafana/loki/v3/pkg/logql/log"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/util/constants"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+)
+
+// isQueryRequest checks if the request is a Loki query
+func isQueryRequest(r *http.Request) bool {
+	path := r.URL.Path
+	isQuery := strings.Contains(path, "/loki/api/v1/query") ||
+		strings.Contains(path, "/loki/api/v1/query_range")
+
+	return isQuery
+}
+
+// ModifyAggregatedMetricsQuery modifies Loki queries for aggregated metrics
+// to include label-based access control (LBAC) filters.
+//
+// For aggregated metrics, labels are stored inside the log content rather than
+// as stream labels, so we need to apply LBAC filters after parsing the log content
+// with the logfmt parser. This function:
+//  1. Identifies queries targeting aggregated metrics
+//  2. Extracts LBAC policies for the tenant
+//  3. Builds filter expressions combining all policies (ORed together)
+//  4. Injects a logfmt parser and label filter into the FRONT of query pipeline
+//  5. Updates the request URL with the modified query
+//
+// The resulting query will contain a pipeline that parses log lines with logfmt
+// and filters out lines that don't match the LBAC policies, ensuring that
+// users only see aggregated metrics they have permission to access.
+func ModifyAggregatedMetricsQuery(r *http.Request, matchers LabelPolicySet) error {
+	// Get the query parameter
+	query := r.URL.Query().Get("query")
+	if query == "" {
+		return nil
+	}
+
+	// Extract the OrgID from the request
+	orgID := r.Header.Get("X-Scope-OrgID")
+	if orgID == "" {
+		return nil
+	}
+
+	// Get the policies for this tenant
+	policies, exists := matchers[orgID]
+	if !exists || len(policies) == 0 {
+		return nil
+	}
+
+	// Build filter expressions for each policy
+	policyFilterer, err := buildPolicyFilter(policies)
+	if err != nil {
+		return err
+	}
+
+	logfmtParser := syntax.MultiStageExpr{
+		&syntax.LogfmtParserExpr{},
+		&syntax.LabelFilterExpr{
+			LabelFilterer: policyFilterer,
+		},
+	}
+
+	// Parse the original query using the LogQL parser
+	expr, err := syntax.ParseExpr(query)
+	if err != nil {
+		_ = level.Error(util_log.Logger).Log(
+			"msg", "failed to parse aggregated metrics query",
+			"query", query,
+			"error", err,
+		)
+		return err
+	}
+
+	// Check if this is a query for aggregated metrics streams
+	if !isAggregatedMetricQueryString(expr) {
+		return nil
+	}
+
+	var modifiedQuery string
+	switch e := expr.(type) {
+	case syntax.SampleExpr:
+		// For sample expressions (metric queries), we need to identify the log selector
+		// and add our filter to that part before any range operations
+		modifiedQuery, err = modifySampleExpr(e, logfmtParser)
+		if err != nil {
+			return err
+		}
+	case syntax.LogSelectorExpr:
+		modifiedQuery, err = modifyLogSelectorExpr(e, logfmtParser)
+		if err != nil {
+			return err
+		}
+	}
+
+	if modifiedQuery != "" && modifiedQuery != query {
+		// Update the query parameter
+		q := r.URL.Query()
+		q.Set("query", modifiedQuery)
+		r.URL.RawQuery = q.Encode()
+
+		_ = level.Info(util_log.Logger).Log(
+			"msg", "modified query for aggregated metrics to respect LBAC",
+			"original", query,
+			"modified", modifiedQuery,
+			"orgID", orgID,
+			"policyCount", len(policies),
+		)
+	}
+
+	return nil
+}
+
+func prependPipelineExpr(e *syntax.PipelineExpr, logfmtParser syntax.MultiStageExpr) (*syntax.PipelineExpr, error) {
+	e.MultiStages = append(logfmtParser, e.MultiStages...)
+	return e, nil
+}
+
+// findRangeAggregationExpr attempts to find a RangeAggregationExpr within a SampleExpr
+// This helps us locate where to insert our filter in complex metric queries
+func findRangeAggregationExpr(expr syntax.SampleExpr) (*syntax.RangeAggregationExpr, bool) {
+	switch e := expr.(type) {
+	case *syntax.RangeAggregationExpr:
+		return e, true
+	case *syntax.VectorAggregationExpr:
+		return findRangeAggregationExpr(e.Left)
+	default:
+		return nil, false
+	}
+}
+
+// isAggregatedMetricQueryString checks if a query string targets aggregated metrics
+func isAggregatedMetricQueryString(expr syntax.Expr) bool {
+	var matchers []*labels.Matcher
+	switch e := expr.(type) {
+	case syntax.SampleExpr:
+		selector, err := e.Selector()
+		if err != nil {
+			return false
+		}
+
+		matchers = selector.Matchers()
+	case syntax.LogSelectorExpr:
+		matchers = e.Matchers()
+	default:
+		return false
+	}
+
+	if len(matchers) == 0 {
+		return false
+	}
+
+	for _, matcher := range matchers {
+		if matcher.Name == constants.AggregatedMetricLabel {
+			return true
+		}
+	}
+
+	return false
+}
+
+// modifySampleExpr modifies a SampleExpr to add LBAC filtering via a logfmt parser
+// This is used for metric queries based on aggregated metrics
+func modifySampleExpr(expr syntax.SampleExpr, logfmtParser syntax.MultiStageExpr) (string, error) {
+	rangeExpr, ok := findRangeAggregationExpr(expr)
+	if !ok {
+		return "", fmt.Errorf("unsupported aggregated metric expression")
+	}
+
+	// Extract the log selector from the range expression
+	logSelector, err := rangeExpr.Selector()
+	if err != nil {
+		return "", err
+	}
+
+	// Create a new pipeline expression with our modified pipeline
+	var pipelineExpr *syntax.PipelineExpr
+
+	if existingPipeline, ok := logSelector.(*syntax.PipelineExpr); ok {
+		// If there's already a pipeline, prepend our stages
+		pipelineExpr, err = prependPipelineExpr(existingPipeline, logfmtParser)
+		if err != nil {
+			return "", err
+		}
+	} else if matchersExpr, ok := logSelector.(*syntax.MatchersExpr); ok {
+		// If it's just matchers, create a new pipeline
+		pipelineExpr = &syntax.PipelineExpr{
+			Left:        matchersExpr,
+			MultiStages: logfmtParser,
+		}
+	} else {
+		return "", fmt.Errorf("unsupported log selector type %T", logSelector)
+	}
+
+	// Update the log selector in the range expression
+	if pipelineExpr != nil {
+		rangeExpr.Left.Left = pipelineExpr
+	}
+
+	return expr.String(), nil
+}
+
+// modifyLogSelectorExpr modifies a LogSelectorExpr to add LBAC filtering via a logfmt parser
+// This is used for log queries of aggregated metrics
+func modifyLogSelectorExpr(expr syntax.LogSelectorExpr, logfmtParser syntax.MultiStageExpr) (string, error) {
+	var pipelineExpr syntax.LogSelectorExpr
+
+	switch e := expr.(type) {
+	case *syntax.MatchersExpr:
+		pipelineExpr = &syntax.PipelineExpr{
+			Left:        e,
+			MultiStages: logfmtParser,
+		}
+	case *syntax.PipelineExpr:
+		var err error
+		pipelineExpr, err = prependPipelineExpr(e, logfmtParser)
+		if err != nil {
+			return "", err
+		}
+	default:
+		_ = level.Error(util_log.Logger).Log(
+			"msg", "unexpected LogSelectorExpr type",
+			"type", fmt.Sprintf("%T", e),
+		)
+		return "", fmt.Errorf("unexpected LogSelectorExpr type %T", e)
+	}
+
+	return pipelineExpr.String(), nil
+}
+
+// buildPolicyFilter creates a LabelFilterer from a list of label policies
+// The filter will pass logs that match any of the policies (policies are ORed),
+// while conditions within a policy must all match (conditions are ANDed)
+func buildPolicyFilter(policies []*types.LabelPolicy) (logql_log.LabelFilterer, error) {
+	var policyFilterer logql_log.LabelFilterer
+
+	for _, policy := range policies {
+		var labelFilterer logql_log.LabelFilterer
+
+		for i := range policy.Selector {
+			matcher, err := types.LabelMatcherToPromLabel(policy.Selector[i])
+			if err != nil {
+				return nil, err
+			}
+
+			if labelFilterer == nil {
+				labelFilterer = logql_log.NewStringLabelFilter(matcher)
+			} else {
+				labelFilterer = logql_log.NewAndLabelFilter(labelFilterer, logql_log.NewStringLabelFilter(matcher))
+			}
+		}
+
+		if policyFilterer == nil {
+			policyFilterer = labelFilterer
+		} else {
+			policyFilterer = logql_log.NewOrLabelFilter(policyFilterer, labelFilterer)
+		}
+	}
+
+	// policyFilter can be nil if the customer's x-prom-label-policy is an empty label matcher (e.g. {})
+	// this condition may leave the policy.Selector array empty, which means we don't set the policyFilterer
+	if policyFilterer == nil {
+		return nil, errors.New("failed to parse policy filter from prometheus label matchers")
+	}
+
+	return policyFilterer, nil
+}

--- a/pkg/labelaccess/aggregated_metrics_test.go
+++ b/pkg/labelaccess/aggregated_metrics_test.go
@@ -1,0 +1,318 @@
+package labelaccess
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+)
+
+func TestModifyAggregatedMetricsQuery(t *testing.T) {
+	testCases := []struct {
+		name             string
+		query            string
+		policies         []*types.LabelPolicy
+		expectedModified bool
+		expectedQuery    string
+		expectedError    bool
+	}{
+		{
+			name:  "non-aggregated metric query is not modified",
+			query: `{job="varlog"} |= "line"`,
+			policies: []*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+					},
+				},
+			},
+			expectedModified: false,
+			expectedQuery:    `{job="varlog"} |= "line"`,
+		},
+		{
+			name:             "aggregated metric query with no policies is not modified",
+			query:            `{__aggregated_metric__="varlog_service"}`,
+			policies:         []*types.LabelPolicy{},
+			expectedModified: false,
+			expectedQuery:    `{__aggregated_metric__="varlog_service"}`,
+		},
+		{
+			name:  "aggregated metric query with env=dev policy is modified correctly",
+			query: `{__aggregated_metric__="varlog_service"}`,
+			policies: []*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+					},
+				},
+			},
+			expectedModified: true,
+			expectedQuery:    `{__aggregated_metric__="varlog_service"} | logfmt | env="dev"`,
+		},
+		{
+			name:  "aggregated metric query with multiple policies is modified correctly",
+			query: `{__aggregated_metric__="varlog_service"}`,
+			policies: []*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+						{Type: types.LABEL_MATCHER_TYPE_NEQ, Name: "classification", Value: "secret"},
+					},
+				},
+				{
+					Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_RE, Name: "classification", Value: "secre.*"},
+					},
+				},
+			},
+			expectedModified: true,
+			expectedQuery:    `{__aggregated_metric__="varlog_service"} | logfmt | ( ( env="dev" , classification!="secret" ) or classification=~"secre.*" )`,
+		},
+		{
+			name:  "aggregated metric query with existing filter gets lbac filter added before existing filter",
+			query: `{__aggregated_metric__="varlog_service"} |= "some text"`,
+			policies: []*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+					},
+				},
+			},
+			expectedModified: true,
+			expectedQuery:    `{__aggregated_metric__="varlog_service"} | logfmt | env="dev" |= "some text"`,
+		},
+		{
+			name:  "aggregated metric metric query gets modified correctly",
+			query: `sum by (job) (count_over_time({__aggregated_metric__="varlog_service"}[5m]))`,
+			policies: []*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+					},
+				},
+			},
+			expectedModified: true,
+			expectedQuery:    `sum by (job)(count_over_time({__aggregated_metric__="varlog_service"} | logfmt | env="dev"[5m]))`,
+		},
+		{
+			name: "complicated aggregated metrics queries with policies are rejected",
+			query: `sum(
+        sum by (job) (
+          count_over_time({__aggregated_metric__="varlog_service"}[5m])
+        ) / sum by (foo) (
+          count_over_time({__aggregated_metric__="varlog_service"}[5m])
+        )
+      )`,
+			policies: []*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+					},
+				},
+				{
+					Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "prod"},
+						{Type: types.LABEL_MATCHER_TYPE_NEQ, Name: "classification", Value: "secret"},
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name:  "complicated aggregated metrics query with empty policy label filter",
+			query: "sum by (detected_level) (sum_over_time({__aggregated_metric__=`fantastic-signals-campaign-service` } | logfmt | unwrap count [10s]))",
+			policies: []*types.LabelPolicy{
+				func() *types.LabelPolicy {
+					_, policy, err := policyFromHeaderValue("12345:{}")
+					require.NoError(t, err)
+
+					return policy
+				}(),
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a request with the query
+			req, err := http.NewRequest("GET", "/loki/api/v1/query_range", nil)
+			require.NoError(t, err)
+
+			// Set the orgID header that the function will look for
+			req.Header.Set("X-Scope-OrgID", "test_tenant")
+
+			q := url.Values{}
+			q.Add("query", tc.query)
+			req.URL.RawQuery = q.Encode()
+
+			// Convert policies to LabelPolicySet
+			policies := LabelPolicySet{}
+			policies["test_tenant"] = tc.policies
+
+			// Call the function
+			err = ModifyAggregatedMetricsQuery(req, policies)
+			if tc.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				// Check the result
+				resultQuery := req.URL.Query().Get("query")
+				if tc.expectedModified {
+					assert.Equal(t, tc.expectedQuery, resultQuery)
+				} else {
+					assert.Equal(t, tc.query, resultQuery)
+				}
+			}
+		})
+	}
+}
+
+func TestIsAggregatedMetricQueryString(t *testing.T) {
+	testCases := []struct {
+		name           string
+		query          string
+		expectedResult bool
+	}{
+		{
+			name:           "simple aggregated metric query",
+			query:          `{__aggregated_metric__="varlog_service"}`,
+			expectedResult: true,
+		},
+		{
+			name:           "complex aggregated metric query",
+			query:          `{__aggregated_metric__="varlog_service", job="metrics"}`,
+			expectedResult: true,
+		},
+		{
+			name:           "negated aggregated metric query",
+			query:          `{__aggregated_metric__!="something_else", level="info"}`,
+			expectedResult: true,
+		},
+		{
+			name:           "regex aggregated metric query",
+			query:          `{__aggregated_metric__=~"something_else"}`,
+			expectedResult: true,
+		},
+		{
+			name:           "negated regex aggregated metric query",
+			query:          `{__aggregated_metric__!~"something_else", level="info"}`,
+			expectedResult: true,
+		},
+		{
+			name:           "regular log query",
+			query:          `{job="varlog"}`,
+			expectedResult: false,
+		},
+		{
+			name:           "metric query",
+			query:          `rate({job="varlog"}[5m])`,
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := syntax.ParseExpr(tc.query)
+			require.NoError(t, err)
+			result := isAggregatedMetricQueryString(expr)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestPolicyFilters(t *testing.T) {
+	testCases := []struct {
+		name                      string
+		policy                    string
+		expectedExtractResult     bool
+		expectedBuildPolicyResult bool
+	}{
+		{
+			name:                      "basic filter",
+			policy:                    `test_tenant:{cluster="foo"}`,
+			expectedExtractResult:     true,
+			expectedBuildPolicyResult: true,
+		},
+		{
+			name:                      "negated filter",
+			policy:                    `test_tenant:{cluster!="foo"}`,
+			expectedExtractResult:     true,
+			expectedBuildPolicyResult: true,
+		},
+		{
+			name:                      "regex filter",
+			policy:                    `test_tenant:{cluster=~"(foo|bar)"}`,
+			expectedExtractResult:     true,
+			expectedBuildPolicyResult: true,
+		},
+		{
+			name:                      "complex regex filter",
+			policy:                    `test_tenant:{cluster=~"(foo|bar)[^f]ar.*?baz"}`,
+			expectedExtractResult:     true,
+			expectedBuildPolicyResult: true,
+		},
+		{
+			name:                      "negated regex filter",
+			policy:                    `test_tenant:{cluster!~"(foo|bar)"}`,
+			expectedExtractResult:     true,
+			expectedBuildPolicyResult: true,
+		},
+		{
+			name:                      "empty label filter",
+			policy:                    "test_tenant:{}",
+			expectedExtractResult:     true,
+			expectedBuildPolicyResult: false,
+		},
+		{
+			name:                  "empty header value",
+			policy:                "test_tenant:''",
+			expectedExtractResult: false,
+		},
+		{
+			name:                  "missing header value",
+			policy:                "test_tenant:",
+			expectedExtractResult: false,
+		},
+		{
+			name:                  "multi-label filter",
+			policy:                `test_tenant:{cluster="foo", namespace="bar"}`,
+			expectedExtractResult: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Create a request with the requisite headers for extracting the policy
+			req, err := http.NewRequest("GET", "/loki/api/v1/query_range", nil)
+			require.NoError(t, err)
+
+			req.Header.Set("X-Scope-OrgID", "test_tenant")
+			req.Header.Set("X-Prom-Label-Policy", testCase.policy)
+
+			matchers, err := ExtractLabelMatchersHTTP(req)
+
+			// if we expect extraction of the header to fail and it does, great, keep going with the test cases
+			if !testCase.expectedExtractResult {
+				require.Error(t, err)
+			} else {
+				// otherwise, move on to test the policy build process
+				require.NoError(t, err)
+
+				policy, err := buildPolicyFilter(matchers["test_tenant"])
+
+				if testCase.expectedBuildPolicyResult {
+					require.NoError(t, err)
+					require.NotNil(t, policy)
+				} else {
+					require.Error(t, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/labelaccess/codec.go
+++ b/pkg/labelaccess/codec.go
@@ -1,0 +1,141 @@
+package labelaccess
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/httpgrpc"
+
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+
+	"github.com/grafana/loki/v3/pkg/loki/codec"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+)
+
+type Codec struct {
+	codec.Codec
+}
+
+func NewCodec(original codec.Codec) *Codec {
+	return &Codec{
+		original,
+	}
+}
+
+func (c *Codec) DecodeHTTPGrpcRequest(ctx context.Context, r *httpgrpc.HTTPRequest) (queryrangebase.Request, context.Context, error) {
+	labelPolicySet, err := ExtractLabelMatchersGRPC(r)
+	if err != nil {
+		return nil, ctx, err
+	}
+	level.Debug(util_log.Logger).Log("msg", "extracted label policy from HTTP gRPC request", "label-policy", labelPolicySet)
+
+	ctx = InjectLabelMatchersContext(ctx, labelPolicySet)
+
+	return c.Codec.DecodeHTTPGrpcRequest(ctx, r)
+}
+
+func (c *Codec) EncodeRequest(ctx context.Context, req queryrangebase.Request) (*http.Request, error) {
+	httpReq, err := c.Codec.EncodeRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	labelPolicySet, err := ExtractLabelMatchersContext(ctx)
+	// This should never happen anyways because we have auth middleware before this.
+	if err != nil {
+		return nil, err
+	}
+
+	// If the instance policies are set on the query, ensure the user ID is decoded before leaving
+	// the middleware for the scheduler and the LBAC configs are reinjected into the HTTP request
+	// as headers.
+	if len(labelPolicySet) != 0 {
+		err = InjectLabelMatchersHTTP(httpReq, labelPolicySet)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return httpReq, nil
+}
+
+func (c *Codec) QueryRequestWrap(ctx context.Context, r queryrangebase.Request) (*queryrange.QueryRequest, error) {
+	wrapped, err := c.Codec.QueryRequestWrap(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	labelPolicySet, err := ExtractLabelMatchersContext(ctx)
+	// This should never happen anyways because we have auth middleware before this.
+	if err != nil {
+		return nil, err
+	}
+
+	// If the instance policies are set on the query, ensure the user ID is decoded before leaving
+	// the middleware for the scheduler and the LBAC configs are reinjected into the HTTP request
+	// as headers.
+	if len(labelPolicySet) != 0 {
+		marshalled, err := json.Marshal(labelPolicySet)
+		if err != nil {
+			return nil, err
+		}
+		wrapped.Metadata[HTTPHeaderKey] = string(marshalled)
+	}
+
+	return wrapped, nil
+}
+
+func (c *Codec) QueryRequestUnwrap(ctx context.Context, req *queryrange.QueryRequest) (queryrangebase.Request, context.Context, error) {
+	// The base codec returns newCtx (e.g. with tenant ID set); callers receive newCtx, so LBAC
+	// must be injected there. Injecting into ctx would be silently dropped.
+	unwrappedReq, newCtx, err := c.Codec.QueryRequestUnwrap(ctx, req)
+	if err != nil {
+		return nil, ctx, err
+	}
+
+	if policy, ok := req.Metadata[HTTPHeaderKey]; ok {
+		var labelPolicySet LabelPolicySet
+		if err := json.Unmarshal([]byte(policy), &labelPolicySet); err != nil {
+			return nil, ctx, err
+		}
+		newCtx = InjectLabelMatchersContext(newCtx, labelPolicySet)
+	}
+
+	return unwrappedReq, newCtx, nil
+}
+
+func ExtractLabelMatchersGRPC(r *httpgrpc.HTTPRequest) (LabelPolicySet, error) {
+
+	instancePolicyMap := LabelPolicySet{}
+
+	// Iterate through each set header value
+	for _, header := range r.Headers {
+		if header.Key != HTTPHeaderKey {
+			continue
+		}
+
+		for _, headerValue := range header.Values {
+			// Split the header value on a comma and iterate through each policy.
+			for _, v := range strings.Split(headerValue, ",") {
+				instanceName, policy, err := policyFromHeaderValue(v)
+				if err != nil {
+					return nil, err
+				}
+
+				currentPolicies, exists := instancePolicyMap[instanceName]
+				if exists {
+					instancePolicyMap[instanceName] = append(currentPolicies, policy)
+				} else {
+					instancePolicyMap[instanceName] = []*types.LabelPolicy{policy}
+				}
+			}
+		}
+	}
+
+	return instancePolicyMap, nil
+}

--- a/pkg/labelaccess/codec_test.go
+++ b/pkg/labelaccess/codec_test.go
@@ -1,0 +1,121 @@
+package labelaccess
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
+)
+
+// fakeInnerCodecTag is the query-tag enrichment the fake inner codec adds to its
+// returned context, used as a canary that the LabelAccess codec must preserve.
+const fakeInnerCodecTag = "Source=test"
+
+// fakeInnerCodec embeds queryrange.Codec so it satisfies loki.Codec, but
+// overrides QueryRequestUnwrap to return a context that does NOT inherit from
+// the input, yet carries an enrichment of its own (a query tag). This isolates
+// the contract under test in TestCodec_QueryRequestUnwrap_InjectsLBACIntoReturnedCtx:
+// the LabelAccess codec must chain LBAC onto the inner codec's *returned* context
+// — preserving its contents — rather than rebuilding from the discarded input ctx.
+type fakeInnerCodec struct {
+	queryrange.Codec
+}
+
+func (f *fakeInnerCodec) QueryRequestUnwrap(ctx context.Context, req *queryrange.QueryRequest) (queryrangebase.Request, context.Context, error) {
+	unwrapped, _, err := f.Codec.QueryRequestUnwrap(ctx, req)
+	return unwrapped, httpreq.InjectQueryTags(context.Background(), fakeInnerCodecTag), err
+}
+
+// TestCodec_QueryRequestUnwrap_InjectsLBACIntoReturnedCtx pins the regression
+// fixed in #5180. The buggy code injected LBAC into the input ctx and then
+// returned the inner codec's ctx unchanged; downstream handlers received the
+// inner ctx without LBAC, and Volume queries silently bypassed label-based
+// access control. The fix injects LBAC into the ctx returned by the inner
+// codec, which is what callers actually use.
+func TestCodec_QueryRequestUnwrap_InjectsLBACIntoReturnedCtx(t *testing.T) {
+	policySet := LabelPolicySet{
+		"test_tenant": []*types.LabelPolicy{
+			{Selector: []*types.LabelMatcher{
+				{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+			}},
+		},
+	}
+
+	encoded, err := json.Marshal(policySet)
+	require.NoError(t, err)
+
+	req := &queryrange.QueryRequest{
+		Metadata: map[string]string{
+			HTTPHeaderKey: string(encoded),
+		},
+		Request: &queryrange.QueryRequest_Series{
+			Series: &queryrange.LokiSeriesRequest{},
+		},
+	}
+
+	codec := NewCodec(&fakeInnerCodec{Codec: queryrange.Codec{}})
+
+	_, returnedCtx, err := codec.QueryRequestUnwrap(context.Background(), req)
+	require.NoError(t, err)
+
+	// The fix must inject LBAC into the inner codec's returned ctx; otherwise
+	// extraction here fails.
+	extracted, err := ExtractLabelMatchersContext(returnedCtx)
+	require.NoError(t, err, "LBAC must be reachable from the returned ctx — the codec injected into the wrong ctx")
+
+	require.Contains(t, extracted, "test_tenant")
+	require.Len(t, extracted["test_tenant"], 1)
+	require.Len(t, extracted["test_tenant"][0].Selector, 1)
+	assert.Equal(t, "env", extracted["test_tenant"][0].Selector[0].Name)
+	assert.Equal(t, "dev", extracted["test_tenant"][0].Selector[0].Value)
+
+	// The inner codec's own ctx enrichment (here, a query tag) must survive
+	// alongside LBAC. Rebuilding from the discarded input ctx drops it.
+	assert.Equal(t, fakeInnerCodecTag, httpreq.ExtractQueryTagsFromContext(returnedCtx),
+		"inner codec ctx enrichment must be preserved — LBAC was chained off the wrong ctx")
+}
+
+// TestCodec_QueryRequestUnwrap_NoMetadataIsPassthrough verifies that when no
+// LBAC metadata is present, QueryRequestUnwrap simply returns the inner
+// codec's ctx (with no LBAC injection that would mask the absence of policy).
+func TestCodec_QueryRequestUnwrap_NoMetadataIsPassthrough(t *testing.T) {
+	req := &queryrange.QueryRequest{
+		Request: &queryrange.QueryRequest_Series{
+			Series: &queryrange.LokiSeriesRequest{},
+		},
+	}
+
+	codec := NewCodec(&fakeInnerCodec{Codec: queryrange.Codec{}})
+
+	_, returnedCtx, err := codec.QueryRequestUnwrap(context.Background(), req)
+	require.NoError(t, err)
+
+	_, err = ExtractLabelMatchersContext(returnedCtx)
+	assert.ErrorIs(t, err, errNoMatcherSource, "no LBAC metadata should leave the ctx with no headers")
+}
+
+// TestCodec_QueryRequestUnwrap_InvalidMetadataReturnsError verifies that
+// malformed LBAC metadata is reported as an error rather than silently
+// ignored — a prerequisite for the fix's correctness.
+func TestCodec_QueryRequestUnwrap_InvalidMetadataReturnsError(t *testing.T) {
+	req := &queryrange.QueryRequest{
+		Metadata: map[string]string{
+			HTTPHeaderKey: "not-valid-json",
+		},
+		Request: &queryrange.QueryRequest_Series{
+			Series: &queryrange.LokiSeriesRequest{},
+		},
+	}
+
+	codec := NewCodec(&fakeInnerCodec{Codec: queryrange.Codec{}})
+
+	_, _, err := codec.QueryRequestUnwrap(context.Background(), req)
+	require.Error(t, err)
+}

--- a/pkg/labelaccess/config.go
+++ b/pkg/labelaccess/config.go
@@ -1,0 +1,17 @@
+package labelaccess
+
+import (
+	"flag"
+)
+
+// Config holds the configuration for label-based access control.
+type Config struct {
+	Enabled bool `yaml:"enabled" category:"experimental"`
+}
+
+// RegisterFlags adds the flags for LBAC to the given FlagSet.
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	f.BoolVar(&cfg.Enabled, "lbac.enabled", false,
+		"Enables label based access control through the X-Prom-Label-Policy header.",
+	)
+}

--- a/pkg/labelaccess/error.go
+++ b/pkg/labelaccess/error.go
@@ -1,0 +1,28 @@
+package labelaccess
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type ErrorAPI struct {
+	Status string `json:"status"`
+	Error  string `json:"error"`
+}
+
+func WritePromError(w http.ResponseWriter, errorMessage string, code int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(code)
+
+	defaultErrorMessage := `{"status": "error", "error": "` + errorMessage + `"}`
+	errorAPI := &ErrorAPI{
+		Status: "error",
+		Error:  errorMessage,
+	}
+	errorAPIBytes, err := json.Marshal(errorAPI)
+	if err != nil {
+		errorAPIBytes = []byte(defaultErrorMessage)
+	}
+	w.Write(errorAPIBytes) // nolint:errcheck
+}

--- a/pkg/labelaccess/grpc.go
+++ b/pkg/labelaccess/grpc.go
@@ -1,0 +1,144 @@
+package labelaccess
+
+import (
+	"context"
+	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+)
+
+const (
+	lowerLBACHeaderName = "x-prom-label-policy"
+)
+
+// injectIntoGRPCRequest takes the LBAC config from the context and puts it in the GRPC metadata
+func injectIntoGRPCRequest(ctx context.Context) (context.Context, error) {
+	labelPolicySet, err := ExtractLabelMatchersContext(ctx)
+	if err != nil {
+		return ctx, nil
+	}
+
+	if len(labelPolicySet) > 0 {
+		trace.SpanFromContext(ctx).SetAttributes(
+			attribute.String("inject x-prom-label-policy", labelPolicySet.String()),
+		)
+	}
+
+	// inject into GRPC metadata
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		md = metadata.New(map[string]string{})
+	}
+	md = md.Copy()
+	var headerValues []string
+	for instanceName, policies := range labelPolicySet {
+		for _, policy := range policies {
+			encoded, err := policyToHeaderValue(instanceName, policy)
+			if err != nil {
+				return ctx, err
+			}
+			headerValues = append(headerValues, encoded)
+		}
+	}
+	md.Set(lowerLBACHeaderName, headerValues...)
+	newCtx := metadata.NewOutgoingContext(ctx, md)
+
+	return newCtx, nil
+}
+
+// ClientLBACInterceptor propagates the LBAC headers from the context to gRPC metadata, which eventually ends up as a HTTP2 header.
+func ClientLBACInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	ctx, err := injectIntoGRPCRequest(ctx)
+	if err != nil {
+		return err
+	}
+
+	return invoker(ctx, method, req, reply, cc, opts...)
+}
+
+// StreamClientLBACInterceptor propagates the LBAC headers from the context to gRPC metadata, which eventually ends up as a HTTP2 header.
+// For streaming gRPC requests.
+func StreamClientLBACInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	ctx, err := injectIntoGRPCRequest(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return streamer(ctx, desc, cc, method, opts...)
+}
+
+// extractFromGRPCRequest takes the LBAC config from the GRPC metadata and puts it in the context
+func extractFromGRPCRequest(ctx context.Context) (context.Context, error) {
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		// No metadata, just return as is
+		return ctx, nil
+	}
+
+	headerValues, ok := md[lowerLBACHeaderName]
+	if !ok {
+		// No LBAC metadata found, just return context
+		return ctx, nil
+	}
+
+	instancePolicyMap := LabelPolicySet{}
+	for _, headerValue := range headerValues {
+		for _, v := range strings.Split(headerValue, ",") {
+			instanceName, policy, err := policyFromHeaderValue(v)
+			if err != nil {
+				return ctx, err
+			}
+
+			currentPolicies, exists := instancePolicyMap[instanceName]
+			if exists {
+				instancePolicyMap[instanceName] = append(currentPolicies, policy)
+			} else {
+				instancePolicyMap[instanceName] = []*types.LabelPolicy{policy}
+			}
+		}
+	}
+
+	trace.SpanFromContext(ctx).SetAttributes(
+		attribute.String("extracted x-prom-label-policy", instancePolicyMap.String()),
+	)
+
+	return InjectLabelMatchersContext(ctx, instancePolicyMap), nil
+}
+
+// ServerLBACInterceptor propagates the LBAC headers from the gRPC metadata back to our context.
+func ServerLBACInterceptor(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	ctx, err := extractFromGRPCRequest(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return handler(ctx, req)
+}
+
+// StreamServerLBACInterceptor propagates the LBAC headers from the gRPC metadata back to our context.
+func StreamServerLBACInterceptor(srv interface{}, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	ctx, err := extractFromGRPCRequest(ss.Context())
+	if err != nil {
+		return err
+	}
+
+	return handler(srv, serverStream{
+		ctx:          ctx,
+		ServerStream: ss,
+	})
+}
+
+type serverStream struct {
+	ctx context.Context
+	grpc.ServerStream
+}
+
+func (ss serverStream) Context() context.Context {
+	return ss.ctx
+}

--- a/pkg/labelaccess/ingester_wrapper.go
+++ b/pkg/labelaccess/ingester_wrapper.go
@@ -1,0 +1,98 @@
+package labelaccess
+
+import (
+	"context"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/v3/pkg/ingester"
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/util"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+)
+
+type IngesterWrapper struct{}
+
+func (iw *IngesterWrapper) Wrap(wrapped ingester.Interface) ingester.Interface {
+	w := WrappedIngester{
+		Interface: wrapped,
+	}
+
+	return &w
+}
+
+type WrappedIngester struct {
+	ingester.Interface
+}
+
+// Label overrides the existing Label method.
+// Label matchers in the context are applied to labels stored for the instance/org ID.
+func (i *WrappedIngester) Label(ctx context.Context, req *logproto.LabelRequest) (*logproto.LabelResponse, error) {
+	_ = level.Debug(util_log.Logger).Log("msg", "using ingester wrapper")
+	instancePolicyMap, err := ExtractLabelMatchersContext(ctx)
+	if err != nil {
+		_ = level.Debug(util_log.Logger).Log("msg", "unable to find instance policy map", "err", err)
+		if err == errNoMatcherSource {
+			// No lbac header, so return the given labelValues
+			return i.Interface.Label(ctx, req)
+		}
+		return nil, err
+	}
+
+	instanceName, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		_ = level.Debug(util_log.Logger).Log("msg", "unable to find instance name", "err", err)
+		return nil, err
+	}
+
+	policies, exist := instancePolicyMap[instanceName]
+	if !exist {
+		_ = level.Debug(util_log.Logger).Log("msg", "no policies are defined", "orgID", instanceName)
+		return i.Interface.Label(ctx, req)
+	}
+
+	instance, err := i.GetOrCreateInstance(instanceName)
+	if err != nil {
+		_ = level.Debug(util_log.Logger).Log("msg", "failed to get or create instance", "orgID", instanceName)
+		return nil, err
+	}
+
+	var queryMatchers []*labels.Matcher
+	if req.Query != "" {
+		queryMatchers, err = syntax.ParseMatchers(req.Query, true)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var result util.UniqueStrings
+	for _, p := range policies {
+		matchers := make([]*labels.Matcher, len(p.Selector))
+		for i, lm := range p.Selector {
+			matcher, err := types.LabelMatcherToPromLabel(lm)
+			matchers[i] = matcher
+			if err != nil {
+				// This shouldn't happen: log it and do not match
+				_ = level.Debug(util_log.Logger).Log("msg", "unable to encode matcher as Prometheus matcher", "orgID", instanceName, "err", err)
+				break
+			}
+		}
+		matchers = append(matchers, queryMatchers...)
+		_ = level.Debug(util_log.Logger).Log("msg", "fetching label values", "orgID", instanceName, "label", req.Name, "matchers", len(matchers))
+
+		resp, err := instance.Label(ctx, req, matchers...)
+		if err != nil {
+			return nil, err
+		}
+		_ = level.Debug(util_log.Logger).Log("msg", "fetched label values", "orgID", instanceName, "label", req.Name, "values", len(resp.Values))
+		result.Add(resp.Values...)
+	}
+
+	return &logproto.LabelResponse{
+		Values: result.Strings(),
+	}, nil
+}

--- a/pkg/labelaccess/ingester_wrapper_test.go
+++ b/pkg/labelaccess/ingester_wrapper_test.go
@@ -1,0 +1,207 @@
+package labelaccess
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/dskit/user"
+
+	"github.com/grafana/loki/v3/pkg/distributor/writefailures"
+	"github.com/grafana/loki/v3/pkg/ingester"
+	ingester_client "github.com/grafana/loki/v3/pkg/ingester/client"
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/runtime"
+	"github.com/grafana/loki/v3/pkg/storage/chunk"
+	"github.com/grafana/loki/v3/pkg/util/constants"
+	"github.com/grafana/loki/v3/pkg/validation"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func CreateLabelMatchers(input *types.LabelPolicy) error {
+	policyMatchers := make([]*labels.Matcher, len(input.Selector))
+	for i, lm := range input.Selector {
+		matcher, err := types.LabelMatcherToPromLabel(lm)
+		policyMatchers[i] = matcher
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func BenchmarkTwoLabelMatchersNoRegex(b *testing.B) {
+	b.ReportAllocs()
+
+	m1, _ := labels.NewMatcher(labels.MatchNotEqual, "risk_profile", "CRITICAL")
+	m2, _ := labels.NewMatcher(labels.MatchNotEqual, "risk_profile", "critical")
+	policy := &types.LabelPolicy{
+		Selector: make([]*types.LabelMatcher, 2),
+	}
+	policy.Selector[0], _ = types.LabelMatcherFromPromLabel(m1)
+	policy.Selector[1], _ = types.LabelMatcherFromPromLabel(m2)
+
+	for i := 0; i < b.N; i++ {
+		err := CreateLabelMatchers(policy)
+		if err != nil {
+			b.Errorf("Unexpected error in benchmark: %v", err)
+		}
+	}
+}
+
+func BenchmarkOneLabelMatcherWithRegex(b *testing.B) {
+	b.ReportAllocs()
+
+	m1, _ := labels.NewMatcher(labels.MatchRegexp, "risk_profile", "CRITICAL|critical")
+	policy := &types.LabelPolicy{
+		Selector: make([]*types.LabelMatcher, 1),
+	}
+	policy.Selector[0], _ = types.LabelMatcherFromPromLabel(m1)
+
+	for i := 0; i < b.N; i++ {
+		err := CreateLabelMatchers(policy)
+		if err != nil {
+			b.Errorf("Unexpected error in benchmark: %v", err)
+		}
+	}
+}
+
+func defaultLimitsTestConfig() validation.Limits {
+	limits := validation.Limits{}
+	flagext.DefaultValues(&limits)
+	return limits
+}
+
+// nolint
+func defaultIngesterTestConfig(t testing.TB) ingester.Config {
+	kvClient, err := kv.NewClient(kv.Config{Store: "inmemory"}, ring.GetCodec(), nil, log.NewNopLogger())
+	require.NoError(t, err)
+
+	cfg := ingester.Config{}
+	flagext.DefaultValues(&cfg)
+	cfg.FlushCheckPeriod = 99999 * time.Hour
+	cfg.MaxChunkIdle = 99999 * time.Hour
+	cfg.ConcurrentFlushes = 1
+	cfg.LifecyclerConfig.RingConfig.KVStore.Mock = kvClient
+	cfg.LifecyclerConfig.NumTokens = 1
+	cfg.LifecyclerConfig.ListenPort = 0
+	cfg.LifecyclerConfig.Addr = "localhost"
+	cfg.LifecyclerConfig.ID = "localhost"
+	cfg.LifecyclerConfig.FinalSleep = 0
+	cfg.LifecyclerConfig.MinReadyDuration = 0
+	cfg.BlockSize = 256 * 1024
+	cfg.TargetChunkSize = 1500 * 1024
+	cfg.WAL.Enabled = false
+	return cfg
+}
+
+func TestLabel(t *testing.T) {
+	ingesterConfig := defaultIngesterTestConfig(t)
+	limits, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
+	require.NoError(t, err)
+
+	store := &mockStore{
+		chunks: map[string][]chunk.Chunk{},
+	}
+
+	i, err := ingester.New(ingesterConfig, ingester_client.Config{}, store, limits, runtime.DefaultTenantConfigs(), nil, writefailures.Cfg{}, constants.Loki, log.NewNopLogger(), nil, nil, nil)
+	require.NoError(t, err)
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
+
+	tw := IngesterWrapper{}
+	wrapped := tw.Wrap(i)
+
+	instancePolicyMap := LabelPolicySet{}
+	// A policy with multiple label matchers: must match env="dev" or level="info"
+	m1 := labels.MustNewMatcher(labels.MatchEqual, "env", "dev")
+	m2 := labels.MustNewMatcher(labels.MatchNotEqual, "level", "info")
+	policy := &types.LabelPolicy{
+		Selector: make([]*types.LabelMatcher, 2),
+	}
+	policy.Selector[0], err = types.LabelMatcherFromPromLabel(m1)
+	require.Nil(t, err)
+	policy.Selector[1], err = types.LabelMatcherFromPromLabel(m2)
+	require.Nil(t, err)
+	instancePolicyMap["tenant1"] = []*types.LabelPolicy{policy}
+
+	ctx := context.Background()
+	ctx = InjectLabelMatchersContext(ctx, instancePolicyMap)
+	ctx = user.InjectOrgID(ctx, "tenant1")
+
+	req := logproto.PushRequest{
+		Streams: []logproto.Stream{
+			{
+				Labels: `{env="dev",foo="bar",bar="baz1"}`,
+			},
+			{
+				Labels: `{env="dev",foo="bar",bar="baz2"}`,
+			},
+			{
+				Labels: `{env="prod",foo="bar",bar="baz3"}`,
+			},
+		},
+	}
+	for i := 0; i < 10; i++ {
+		req.Streams[0].Entries = append(req.Streams[0].Entries, logproto.Entry{
+			Timestamp: time.Unix(0, 0),
+			Line:      fmt.Sprintf("line %d", i),
+		})
+		req.Streams[1].Entries = append(req.Streams[1].Entries, logproto.Entry{
+			Timestamp: time.Unix(0, 0),
+			Line:      fmt.Sprintf("line %d", i),
+		})
+		req.Streams[2].Entries = append(req.Streams[2].Entries, logproto.Entry{
+			Timestamp: time.Unix(0, 0),
+			Line:      fmt.Sprintf("line %d", i),
+		})
+	}
+
+	_, err = i.Push(ctx, &req)
+	require.NoError(t, err)
+
+	// Call Label() without a query : labels matching LBAC header are returned
+	start := time.Unix(0, 0)
+	res, err := wrapped.Label(ctx, &logproto.LabelRequest{
+		Start:  &start,
+		Name:   "bar",
+		Values: true,
+		Query:  ``,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"baz1", "baz2"}, res.Values)
+
+	// Call Label() with a query : labels matching LBAC header and query are returned
+	res, err = wrapped.Label(ctx, &logproto.LabelRequest{
+		Start:  &start,
+		Name:   "bar",
+		Values: true,
+		Query:  `{bar="baz2"}`,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"baz2"}, res.Values)
+
+	// Call Label() without an LBAC header and a query: all label values are returned
+	ctx = context.Background()
+	ctx = user.InjectOrgID(ctx, "tenant1")
+	res, err = wrapped.Label(ctx, &logproto.LabelRequest{
+		Start:  &start,
+		Name:   "bar",
+		Values: true,
+		Query:  ``,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"baz1", "baz2", "baz3"}, res.Values)
+}

--- a/pkg/labelaccess/middleware.go
+++ b/pkg/labelaccess/middleware.go
@@ -1,0 +1,156 @@
+package labelaccess
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/middleware"
+	"github.com/prometheus/prometheus/model/labels"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+)
+
+type labelAccessMiddleware struct {
+	logger log.Logger
+}
+
+// NewLabelAccessMiddleware returns a HTTP middleware that parses the X-Prom-Label-Policy header
+// and injects the parsed label selectors into the request context.
+func NewLabelAccessMiddleware(logger log.Logger) middleware.Interface {
+	return &labelAccessMiddleware{
+		logger: logger,
+	}
+}
+
+// Wrap implements the middleware interface
+func (l *labelAccessMiddleware) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		matchers, err := ExtractLabelMatchersHTTP(r)
+		if err != nil {
+			_ = level.Debug(util_log.Logger).Log("msg", "unable to find instance policy map in HTTP request", "err", err)
+			WritePromError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		r = r.Clone(InjectLabelMatchersContext(r.Context(), matchers))
+
+		if len(matchers) > 0 {
+			_ = level.Debug(util_log.Logger).Log("msg", "inject x-prom-label-policy", "matchers", matchers.String())
+
+			trace.SpanFromContext(r.Context()).SetAttributes(
+				attribute.String("inject x-prom-label-policy", matchers.String()),
+			)
+
+			// If this is a query request, check for aggregated metrics parameters
+			// and modify query if needed
+			if isQueryRequest(r) {
+				err := ModifyAggregatedMetricsQuery(r, matchers)
+				if err != nil {
+					_ = level.Error(util_log.Logger).Log("msg", "failed to modify aggregated metric query", "err", err)
+					WritePromError(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				_ = level.Debug(util_log.Logger).Log("msg", "request after modifying aggregated metric query", "request", fmt.Sprintf("%v", r))
+			}
+
+			// For volume requests, inject LBAC matchers into the stream selector
+			// so the index only returns streams matching the policies.
+			if isVolumeRequest(r) {
+				if err := modifyVolumeQuery(r, matchers); err != nil {
+					_ = level.Error(util_log.Logger).Log("msg", "lbac middleware: failed to modify volume query for LBAC", "err", err)
+					WritePromError(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+			}
+
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isVolumeRequest checks if the request is a Loki volume query.
+func isVolumeRequest(r *http.Request) bool {
+	return strings.Contains(r.URL.Path, "/loki/api/v1/index/volume")
+}
+
+// modifyVolumeQuery injects LBAC label matchers into the volume request's stream selector.
+// For a single policy, all its matchers are ANDed into the query parameter so the index
+// only returns streams the tenant is allowed to see. For multiple policies, query
+// modification is skipped (response-level filtering in the tripperware handles LBAC).
+func modifyVolumeQuery(r *http.Request, policySet LabelPolicySet) error {
+	orgID := r.Header.Get("X-Scope-OrgID")
+	if orgID == "" {
+		return nil
+	}
+
+	policies, exists := policySet[orgID]
+	if !exists || len(policies) == 0 {
+		return nil
+	}
+
+	query := r.URL.Query().Get("query")
+	if query == "" {
+		query = "{}"
+	}
+
+	existingMatchers, err := syntax.ParseMatchers(query, true)
+	if err != nil {
+		return fmt.Errorf("lbac middleware: failed to parse volume query %q: %w", query, err)
+	}
+
+	// For multiple policies, skip query modification — the response-level filter in the
+	// tripperware middleware handles LBAC with correct OR semantics across policies.
+	if len(policies) > 1 {
+		_ = level.Debug(util_log.Logger).Log(
+			"msg", "lbac middleware: multiple policies for volume query, skipping query-level modification",
+			"org_id", orgID,
+			"num_policies", len(policies),
+		)
+		return nil
+	}
+
+	policy := policies[0]
+	lbacMatchers := make([]*labels.Matcher, 0, len(policy.Selector))
+	for _, lm := range policy.Selector {
+		m, err := types.LabelMatcherToPromLabel(lm)
+		if err != nil {
+			return fmt.Errorf("lbac middleware: failed to convert label matcher for volume query: %w", err)
+		}
+		lbacMatchers = append(lbacMatchers, m)
+	}
+
+	if len(lbacMatchers) == 0 {
+		return nil
+	}
+
+	combined := make([]*labels.Matcher, 0, len(existingMatchers)+len(lbacMatchers))
+	combined = append(combined, existingMatchers...)
+	combined = append(combined, lbacMatchers...)
+	modifiedQuery := syntax.MatchersString(combined)
+
+	if modifiedQuery == query {
+		return nil
+	}
+
+	q := r.URL.Query()
+	q.Set("query", modifiedQuery)
+	r.URL.RawQuery = q.Encode()
+
+	_ = level.Info(util_log.Logger).Log(
+		"msg", "lbac middleware: modified volume query to enforce LBAC",
+		"original_query", query,
+		"modified_query", modifiedQuery,
+		"org_id", orgID,
+	)
+
+	return nil
+}

--- a/pkg/labelaccess/middleware_test.go
+++ b/pkg/labelaccess/middleware_test.go
@@ -1,0 +1,294 @@
+package labelaccess
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+)
+
+func TestLabelAccessMiddlewareWithAggregatedMetrics(t *testing.T) {
+	// Create a test HTTP handler that captures the request
+	var capturedRequest *http.Request
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequest = r.Clone(context.Background())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Create middleware with a logger
+	middleware := NewLabelAccessMiddleware(log.NewNopLogger())
+	wrappedHandler := middleware.Wrap(testHandler)
+
+	// Create a test request with an aggregated metrics query
+	reqURL, err := url.Parse("/loki/api/v1/query_range")
+	require.NoError(t, err)
+
+	q := url.Values{}
+	q.Add("query", `{__aggregated_metric__="varlog_service"}`)
+	reqURL.RawQuery = q.Encode()
+
+	req := httptest.NewRequest("GET", reqURL.String(), bytes.NewReader([]byte{}))
+	req.Header.Set("X-Scope-OrgID", "test_tenant")
+
+	// Add LBAC policy headers - each policy needs its own header
+	req.Header.Add(HTTPHeaderKey, "test_tenant:"+url.PathEscape(
+		`{env="dev",classification!="secret"}`,
+	))
+	req.Header.Add(HTTPHeaderKey, "test_tenant:"+url.PathEscape(
+		`{classification=~"secre.*"}`,
+	))
+
+	// Create a response recorder
+	recorder := httptest.NewRecorder()
+
+	// Call the wrapped handler
+	wrappedHandler.ServeHTTP(recorder, req)
+
+	// Verify the response
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	// Verify that the request was modified
+	require.NotNil(t, capturedRequest, "The request was not captured")
+
+	// Check that the query was modified with LBAC filters
+	modifiedQuery := capturedRequest.URL.Query().Get("query")
+	require.NotEqual(t, `{__aggregated_metric__="varlog_service"}`, modifiedQuery, "Query was not modified")
+
+	// Verify the expected filters were applied (this matches what we expect from the test in aggregated_metrics_test.go)
+	expectedQuery := `{__aggregated_metric__="varlog_service"} | logfmt | ( ( env="dev" , classification!="secret" ) or classification=~"secre.*" )`
+	assert.Equal(t, expectedQuery, modifiedQuery, "Query was not modified correctly")
+}
+
+func TestIsVolumeRequest(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/loki/api/v1/index/volume", true},
+		{"/loki/api/v1/index/volume_range", true}, // matched by Contains; tripperware-level filter handles correctness
+		{"/loki/api/v1/index/stats", false},
+		{"/loki/api/v1/query_range", false},
+		{"/loki/api/v1/labels", false},
+		{"/", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, tc.path, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, isVolumeRequest(req))
+		})
+	}
+}
+
+func TestModifyVolumeQuery(t *testing.T) {
+	const tenant = "test_tenant"
+
+	cases := []struct {
+		name          string
+		path          string
+		orgID         string
+		query         string
+		policies      LabelPolicySet
+		expectedQuery string // empty string means: assert query is unchanged
+		expectedErr   bool
+	}{
+		{
+			name:  "single policy is ANDed into existing selector",
+			path:  "/loki/api/v1/index/volume",
+			orgID: tenant,
+			query: `{job="varlog"}`,
+			policies: LabelPolicySet{
+				tenant: []*types.LabelPolicy{
+					{Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+						{Type: types.LABEL_MATCHER_TYPE_NEQ, Name: "classification", Value: "secret"},
+					}},
+				},
+			},
+			expectedQuery: `{job="varlog", env="dev", classification!="secret"}`,
+		},
+		{
+			name:  "regex matcher is preserved",
+			path:  "/loki/api/v1/index/volume",
+			orgID: tenant,
+			query: `{job="varlog"}`,
+			policies: LabelPolicySet{
+				tenant: []*types.LabelPolicy{
+					{Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_RE, Name: "namespace", Value: "team-.*"},
+					}},
+				},
+			},
+			expectedQuery: `{job="varlog", namespace=~"team-.*"}`,
+		},
+		{
+			name:  "multiple policies are NOT injected at the query level",
+			path:  "/loki/api/v1/index/volume",
+			orgID: tenant,
+			query: `{job="varlog"}`,
+			policies: LabelPolicySet{
+				tenant: []*types.LabelPolicy{
+					{Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+					}},
+					{Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "prod"},
+					}},
+				},
+			},
+			// query left untouched — response-level OR filter in the tripperware handles this case
+			expectedQuery: "",
+		},
+		{
+			name:  "missing X-Scope-OrgID is a no-op",
+			path:  "/loki/api/v1/index/volume",
+			orgID: "",
+			query: `{job="varlog"}`,
+			policies: LabelPolicySet{
+				tenant: []*types.LabelPolicy{
+					{Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+					}},
+				},
+			},
+			expectedQuery: "",
+		},
+		{
+			name:          "tenant has no policies — query untouched",
+			path:          "/loki/api/v1/index/volume",
+			orgID:         tenant,
+			query:         `{job="varlog"}`,
+			policies:      LabelPolicySet{tenant: []*types.LabelPolicy{}},
+			expectedQuery: "",
+		},
+		{
+			name:  "policy with empty selector — query untouched",
+			path:  "/loki/api/v1/index/volume",
+			orgID: tenant,
+			query: `{job="varlog"}`,
+			policies: LabelPolicySet{
+				tenant: []*types.LabelPolicy{
+					{Selector: []*types.LabelMatcher{}},
+				},
+			},
+			expectedQuery: "",
+		},
+		{
+			name:  "invalid existing query returns error",
+			path:  "/loki/api/v1/index/volume",
+			orgID: tenant,
+			query: "not a valid logql selector",
+			policies: LabelPolicySet{
+				tenant: []*types.LabelPolicy{
+					{Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+					}},
+				},
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reqURL, err := url.Parse(tc.path)
+			require.NoError(t, err)
+			if tc.query != "" {
+				q := url.Values{}
+				q.Set("query", tc.query)
+				reqURL.RawQuery = q.Encode()
+			}
+
+			req, err := http.NewRequest(http.MethodGet, reqURL.String(), nil)
+			require.NoError(t, err)
+			if tc.orgID != "" {
+				req.Header.Set("X-Scope-OrgID", tc.orgID)
+			}
+
+			err = modifyVolumeQuery(req, tc.policies)
+			if tc.expectedErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			got := req.URL.Query().Get("query")
+			if tc.expectedQuery == "" {
+				assert.Equal(t, tc.query, got, "query should be unchanged")
+			} else {
+				assert.Equal(t, tc.expectedQuery, got)
+			}
+		})
+	}
+}
+
+// TestLabelAccessMiddlewareWithVolumeRequest pins the end-to-end behavior of
+// the HTTP middleware for Volume requests: the X-Prom-Label-Policy header is
+// extracted, the policy is folded into the query parameter as additional
+// matchers, and the modified request is forwarded to the downstream handler.
+// This is the regression scenario from #5180.
+func TestLabelAccessMiddlewareWithVolumeRequest(t *testing.T) {
+	var capturedRequest *http.Request
+	testHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedRequest = r.Clone(context.Background())
+	})
+
+	mw := NewLabelAccessMiddleware(log.NewNopLogger())
+	wrapped := mw.Wrap(testHandler)
+
+	reqURL, err := url.Parse("/loki/api/v1/index/volume")
+	require.NoError(t, err)
+	q := url.Values{}
+	q.Set("query", `{job="varlog"}`)
+	reqURL.RawQuery = q.Encode()
+
+	req := httptest.NewRequest(http.MethodGet, reqURL.String(), bytes.NewReader(nil))
+	req.Header.Set("X-Scope-OrgID", "test_tenant")
+	req.Header.Add(HTTPHeaderKey, "test_tenant:"+url.PathEscape(`{env="dev"}`))
+
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, capturedRequest)
+
+	got := capturedRequest.URL.Query().Get("query")
+	assert.Equal(t, `{job="varlog", env="dev"}`, got, "volume request query should be modified to include LBAC matchers")
+}
+
+// TestLabelAccessMiddlewareWithVolumeRequest_NonVolumePathUnchanged guards the
+// Contains-based path check: stats requests share the /index/ prefix but must
+// not be modified.
+func TestLabelAccessMiddlewareWithVolumeRequest_NonVolumePathUnchanged(t *testing.T) {
+	var capturedRequest *http.Request
+	testHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedRequest = r.Clone(context.Background())
+	})
+
+	mw := NewLabelAccessMiddleware(log.NewNopLogger())
+	wrapped := mw.Wrap(testHandler)
+
+	reqURL, err := url.Parse("/loki/api/v1/index/stats")
+	require.NoError(t, err)
+	q := url.Values{}
+	q.Set("query", `{job="varlog"}`)
+	reqURL.RawQuery = q.Encode()
+
+	req := httptest.NewRequest(http.MethodGet, reqURL.String(), bytes.NewReader(nil))
+	req.Header.Set("X-Scope-OrgID", "test_tenant")
+	req.Header.Add(HTTPHeaderKey, "test_tenant:"+url.PathEscape(`{env="dev"}`))
+
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	require.NotNil(t, capturedRequest)
+	assert.Equal(t, `{job="varlog"}`, capturedRequest.URL.Query().Get("query"))
+}

--- a/pkg/labelaccess/mock_store_test.go
+++ b/pkg/labelaccess/mock_store_test.go
@@ -1,0 +1,134 @@
+package labelaccess
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/grafana/dskit/tenant"
+
+	"github.com/grafana/loki/v3/pkg/iter"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql"
+	"github.com/grafana/loki/v3/pkg/storage/chunk"
+	"github.com/grafana/loki/v3/pkg/storage/chunk/fetcher"
+	"github.com/grafana/loki/v3/pkg/storage/config"
+	"github.com/grafana/loki/v3/pkg/storage/stores/index/stats"
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/sharding"
+	"github.com/grafana/loki/v3/pkg/storage/types"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func MustParseDayTime(s string) config.DayTime {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return config.DayTime{Time: model.TimeFromUnix(t.Unix())}
+}
+
+var defaultPeriodConfigs = []config.PeriodConfig{
+	{
+		From:      MustParseDayTime("1900-01-01"),
+		IndexType: types.IndexTypeTSDB,
+		Schema:    "v13",
+	},
+}
+
+type mockStore struct {
+	mtx    sync.Mutex
+	chunks map[string][]chunk.Chunk
+}
+
+func (s *mockStore) Put(ctx context.Context, chunks []chunk.Chunk) error {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	userid, err := tenant.TenantID(ctx)
+	if err != nil {
+		return err
+	}
+
+	s.chunks[userid] = append(s.chunks[userid], chunks...)
+	return nil
+}
+
+func (s *mockStore) SelectLogs(_ context.Context, _ logql.SelectLogParams) (iter.EntryIterator, error) {
+	return nil, nil
+}
+
+func (s *mockStore) SelectSamples(_ context.Context, _ logql.SelectSampleParams) (iter.SampleIterator, error) {
+	return nil, nil
+}
+
+func (s *mockStore) SelectSeries(_ context.Context, _ logql.SelectLogParams) ([]logproto.SeriesIdentifier, error) {
+	return nil, nil
+}
+
+func (s *mockStore) GetSchemaConfigs() []config.PeriodConfig {
+	return defaultPeriodConfigs
+}
+
+func (s *mockStore) SetChunkFilterer(_ chunk.RequestChunkFilterer) {
+}
+
+// chunk.Store methods
+func (s *mockStore) PutOne(_ context.Context, _, _ model.Time, _ chunk.Chunk) error {
+	return nil
+}
+
+func (s *mockStore) GetChunks(_ context.Context, _ string, _, _ model.Time, _ chunk.Predicate, _ *logproto.ChunkRefGroup) ([][]chunk.Chunk, []*fetcher.Fetcher, error) {
+	return nil, nil, nil
+}
+
+func (s *mockStore) GetChunkRefsWithSizingInfo(_ context.Context, _ string, _, _ model.Time, _ chunk.Predicate) ([]logproto.ChunkRefWithSizingInfo, error) {
+	return nil, nil
+}
+
+func (s *mockStore) HasChunkSizingInfo(_, _ model.Time) bool {
+	return false
+}
+
+func (s *mockStore) LabelValuesForMetricName(_ context.Context, _ string, _, _ model.Time, _ string, _ string, _ ...*labels.Matcher) ([]string, error) {
+	return []string{"val1", "val2"}, nil
+}
+
+func (s *mockStore) LabelNamesForMetricName(_ context.Context, _ string, _, _ model.Time, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (s *mockStore) GetChunkFetcher(_ model.Time) *fetcher.Fetcher {
+	return nil
+}
+
+func (s *mockStore) Stats(_ context.Context, _ string, _, _ model.Time, _ ...*labels.Matcher) (*stats.Stats, error) {
+	return &stats.Stats{
+		Streams: 2,
+		Chunks:  5,
+		Bytes:   25,
+		Entries: 100,
+	}, nil
+}
+
+func (s *mockStore) GetShards(_ context.Context, _ string, _, _ model.Time, _ uint64, _ chunk.Predicate) (*logproto.ShardsResponse, error) {
+	return nil, nil
+}
+
+func (s *mockStore) HasForSeries(_, _ model.Time) (sharding.ForSeries, bool) {
+	return nil, false
+}
+
+func (s *mockStore) Volume(_ context.Context, _ string, _, _ model.Time, limit int32, _ []string, _ string, _ ...*labels.Matcher) (*logproto.VolumeResponse, error) {
+	return &logproto.VolumeResponse{
+		Volumes: []logproto.Volume{
+			{Name: `{foo="bar"}`, Volume: 38},
+		},
+		Limit: limit,
+	}, nil
+}
+
+func (s *mockStore) FlushIndexes(_ context.Context) error { return nil }
+
+func (s *mockStore) Stop() {}

--- a/pkg/labelaccess/mock_store_test.go
+++ b/pkg/labelaccess/mock_store_test.go
@@ -32,7 +32,7 @@ func MustParseDayTime(s string) config.DayTime {
 var defaultPeriodConfigs = []config.PeriodConfig{
 	{
 		From:      MustParseDayTime("1900-01-01"),
-		IndexType: types.IndexTypeTSDB,
+		IndexType: types.TSDBType,
 		Schema:    "v13",
 	},
 }

--- a/pkg/labelaccess/propagation.go
+++ b/pkg/labelaccess/propagation.go
@@ -1,0 +1,235 @@
+package labelaccess
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"net/http"
+	"net/url"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+)
+
+const (
+	// HTTPHeaderKey is used as the header to store label matcher values
+	HTTPHeaderKey = "X-Prom-Label-Policy"
+)
+
+var (
+	errNoMatcherSource     = errors.New("no label matcher source")
+	errInvalidHeaderParse  = errors.New("invalid label policy header value, unable to parse tenant and selector")
+	errInvalidHeaderEscape = errors.New("invalid label policy header value unable to url escape selector string")
+	errInvalidSelector     = errors.New("invalid label policy header value unable to parse selector string")
+)
+
+// LabelPolicySet is used
+type LabelPolicySet map[string][]*types.LabelPolicy
+
+// canonicalPolicies returns a tenant's policies sorted by their string
+// representation, with duplicates removed.
+func canonicalPolicies(policies []*types.LabelPolicy) []*types.LabelPolicy {
+	// LabelPolicy.String() allocates heavily, so We pre-compute so we can sort/dedup
+	// without multiple invocations
+	type keyed struct {
+		key    string
+		policy *types.LabelPolicy
+	}
+	decorated := make([]keyed, len(policies))
+	for i, p := range policies {
+		decorated[i] = keyed{key: p.String(), policy: p}
+	}
+	slices.SortFunc(decorated, func(a, b keyed) int {
+		return strings.Compare(a.key, b.key)
+	})
+	canonical := make([]*types.LabelPolicy, 0, len(decorated))
+	for i, d := range decorated {
+		if i > 0 && d.key == decorated[i-1].key {
+			continue
+		}
+		canonical = append(canonical, d.policy)
+	}
+	return canonical
+}
+
+// hash iterates through the tenant map in ascending order and returns a string
+// of an FNV-64a hash of all of the tenants. Each tenant's policies are hashed in
+// a canonical order so that the same access set always maps to the same key.
+func (l LabelPolicySet) hash() string {
+	tenants := make([]string, 0, len(l))
+	for t := range l {
+		tenants = append(tenants, t)
+	}
+	h := fnv.New64a()
+	sort.Strings(tenants)
+	for _, t := range tenants {
+		_, _ = h.Write([]byte(t))
+		for _, p := range canonicalPolicies(l[t]) {
+			_, _ = h.Write([]byte(p.String()))
+		}
+	}
+	return fmt.Sprintf("%d", h.Sum64())
+}
+
+func (l LabelPolicySet) String() string {
+	sb := strings.Builder{}
+
+	tenants := make([]string, 0, len(l))
+	for t := range l {
+		tenants = append(tenants, t)
+	}
+	sort.Strings(tenants)
+
+	for _, t := range tenants {
+		sb.Write([]byte(t))
+		sb.WriteString(":[")
+		for _, p := range canonicalPolicies(l[t]) {
+			sb.WriteString("{")
+			for _, lm := range p.Selector {
+				plm, err := types.LabelMatcherToPromLabel(lm)
+				if err != nil {
+					_ = level.Error(util_log.Logger).Log("msg", "unexpected error transforming LabelMatcher", "err", err)
+				}
+				sb.WriteString(plm.String())
+				sb.WriteString(",")
+			}
+			sb.WriteString("},")
+		}
+		sb.WriteString("] ")
+	}
+	return sb.String()
+}
+
+func policyToHeaderValue(instanceName string, policy *types.LabelPolicy) (string, error) {
+	matchers := make([]string, len(policy.Selector))
+
+	for i := range policy.Selector {
+		matcher, err := types.LabelMatcherToPromLabel(policy.Selector[i])
+		if err != nil {
+			return "", err
+		}
+		matchers[i] = matcher.String()
+	}
+
+	return instanceName + ":" + url.PathEscape("{"+strings.Join(matchers, ", ")+"}"), nil
+}
+
+func policyFromHeaderValue(headerString string) (string, *types.LabelPolicy, error) {
+	components := strings.SplitN(headerString, ":", 2)
+	if len(components) != 2 {
+		return "", nil, errInvalidHeaderParse
+	}
+	selectorString, err := url.PathUnescape(components[1])
+	if err != nil {
+		return "", nil, fmt.Errorf("%w, '%v'", errInvalidHeaderEscape, err)
+	}
+	matchers, err := parser.NewParser(parser.Options{}).ParseMetricSelector(selectorString)
+	if err != nil {
+		return "", nil, fmt.Errorf("%w '%s', error: '%v'", errInvalidSelector, selectorString, err)
+	}
+
+	policy := &types.LabelPolicy{
+		Selector: make([]*types.LabelMatcher, len(matchers)),
+	}
+	for i, matcher := range matchers {
+		policy.Selector[i], err = types.LabelMatcherFromPromLabel(matcher)
+		if err != nil {
+			return "", nil, err
+		}
+	}
+
+	return components[0], policy, nil
+}
+
+// InjectLabelMatchersHTTP takes the provided matcher protobufs and stores them as HTTP headers
+func InjectLabelMatchersHTTP(r *http.Request, instancePolicyMap LabelPolicySet) error {
+	_ = level.Debug(util_log.Logger).Log("msg", "injecting label policy into HTTP request")
+
+	// Ensure any existing policy sets are erased
+	r.Header.Del(HTTPHeaderKey)
+	for instanceName, policies := range instancePolicyMap {
+		for _, policy := range policies {
+			encodedPolicy, err := policyToHeaderValue(instanceName, policy)
+			if err != nil {
+				return err
+			}
+			r.Header.Add(HTTPHeaderKey, encodedPolicy)
+		}
+	}
+	return nil
+}
+
+// ExtractLabelMatchersHTTP takes the provided HTTP request and parses out label matcher protobufs
+func ExtractLabelMatchersHTTP(r *http.Request) (LabelPolicySet, error) {
+	return ExtractLabelMatchersFromHeaders(r.Header)
+}
+
+// ExtractLabelMatchersFromHeaders parses label matcher protobufs from the provided headers
+func ExtractLabelMatchersFromHeaders(headers http.Header) (LabelPolicySet, error) {
+	headerValues := headers.Values(HTTPHeaderKey)
+
+	instancePolicyMap := LabelPolicySet{}
+
+	// Iterate through each set header value
+	for _, headerValue := range headerValues {
+		// Split the header value on a comma and iterate through each policy.
+		for v := range strings.SplitSeq(headerValue, ",") {
+			instanceName, policy, err := policyFromHeaderValue(v)
+			if err != nil {
+				return nil, err
+			}
+
+			currentPolicies, exists := instancePolicyMap[instanceName]
+			if exists {
+				instancePolicyMap[instanceName] = append(currentPolicies, policy)
+			} else {
+				instancePolicyMap[instanceName] = []*types.LabelPolicy{policy}
+			}
+		}
+	}
+
+	return instancePolicyMap, nil
+}
+
+// ExtractLabelMatchersContext gets the embedded label matchers from the context.
+// It extracts headers stored by PropagateAllHeadersMiddleware or httpreq.InjectHeader.
+func ExtractLabelMatchersContext(ctx context.Context) (LabelPolicySet, error) {
+	headers := httpreq.ExtractAllHeaders(ctx)
+	if headers == nil {
+		return nil, errNoMatcherSource
+	}
+	return ExtractLabelMatchersFromHeaders(headers)
+}
+
+// InjectLabelMatchersContext injects label matchers into the context using httpreq.InjectHeader.
+// This ensures the headers are propagated through the V2 engine's scheduler/worker mechanism.
+func InjectLabelMatchersContext(ctx context.Context, matchers LabelPolicySet) context.Context {
+	// Collect all encoded policies first, then join with comma.
+	// httpreq.InjectHeader uses Set() which replaces, so we must inject all values at once.
+	var encodedPolicies []string
+	for instanceName, policies := range matchers {
+		for _, policy := range policies {
+			encoded, err := policyToHeaderValue(instanceName, policy)
+			if err != nil {
+				continue
+			}
+			encodedPolicies = append(encodedPolicies, encoded)
+		}
+	}
+
+	if len(encodedPolicies) > 0 {
+		combinedValue := strings.Join(encodedPolicies, ",")
+		ctx = httpreq.InjectHeader(ctx, HTTPHeaderKey, combinedValue)
+	}
+
+	return ctx
+}

--- a/pkg/labelaccess/propagation_test.go
+++ b/pkg/labelaccess/propagation_test.go
@@ -1,0 +1,224 @@
+package labelaccess
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+)
+
+func TestLabelPolicySetString(t *testing.T) {
+	instancePolicyMap := LabelPolicySet{}
+
+	// One tenant with multiple label matchers
+	m1, err := labels.NewMatcher(labels.MatchEqual, "env", "dev")
+	require.Nil(t, err)
+
+	m2, err := labels.NewMatcher(labels.MatchNotEqual, "level", "info")
+	require.Nil(t, err)
+
+	policy := &types.LabelPolicy{
+		Selector: make([]*types.LabelMatcher, 2),
+	}
+	policy.Selector[0], err = types.LabelMatcherFromPromLabel(m1)
+	require.Nil(t, err)
+	policy.Selector[1], err = types.LabelMatcherFromPromLabel(m2)
+	require.Nil(t, err)
+
+	instancePolicyMap["tenant1"] = []*types.LabelPolicy{policy}
+
+	require.Equal(t, "tenant1:[{env=\"dev\",level!=\"info\",},] ", instancePolicyMap.String())
+
+	// Add another tenant with one label matchers
+	m3, err := labels.NewMatcher(labels.MatchNotRegexp, "env", "p.*")
+	require.Nil(t, err)
+
+	policy2 := &types.LabelPolicy{
+		Selector: make([]*types.LabelMatcher, 1),
+	}
+	policy2.Selector[0], err = types.LabelMatcherFromPromLabel(m3)
+	require.Nil(t, err)
+
+	m4, err := labels.NewMatcher(labels.MatchRegexp, "blah", "p.*")
+	require.Nil(t, err)
+
+	policy3 := &types.LabelPolicy{
+		Selector: make([]*types.LabelMatcher, 1),
+	}
+	policy3.Selector[0], err = types.LabelMatcherFromPromLabel(m4)
+
+	require.Nil(t, err)
+
+	instancePolicyMap["tenant2"] = []*types.LabelPolicy{policy2, policy3}
+
+	require.Equal(t, "tenant1:[{env=\"dev\",level!=\"info\",},] tenant2:[{env!~\"p.*\",},{blah=~\"p.*\",},] ", instancePolicyMap.String())
+}
+
+// TestLabelPolicySetHashOrderIndependent guards against the cache-key
+// fragmentation bug in grafana/loki-private#2522: a multi-team user's policies
+// arrive in the X-Prom-Label-Policy header in an unstable order, and the same
+// logical access set must always produce the same hash (and String) so it maps
+// to a single results-cache bucket.
+func mustPolicy(t *testing.T, matchType labels.MatchType, name, value string) *types.LabelPolicy {
+	t.Helper()
+	m, err := labels.NewMatcher(matchType, name, value)
+	require.NoError(t, err)
+	lm, err := types.LabelMatcherFromPromLabel(m)
+	require.NoError(t, err)
+	return &types.LabelPolicy{Selector: []*types.LabelMatcher{lm}}
+}
+
+func TestLabelPolicySetHashOrderIndependent(t *testing.T) {
+	const tenant = "tenant1"
+
+	pA := mustPolicy(t, labels.MatchEqual, "team", "alpha")
+	pB := mustPolicy(t, labels.MatchEqual, "team", "bravo")
+	pC := mustPolicy(t, labels.MatchEqual, "team", "charlie")
+
+	permutations := [][]*types.LabelPolicy{
+		{pA, pB, pC},
+		{pA, pC, pB},
+		{pB, pA, pC},
+		{pB, pC, pA},
+		{pC, pA, pB},
+		{pC, pB, pA},
+	}
+
+	wantHash := LabelPolicySet{tenant: permutations[0]}.hash()
+	wantString := LabelPolicySet{tenant: permutations[0]}.String()
+
+	for i, perm := range permutations {
+		set := LabelPolicySet{tenant: perm}
+		require.Equalf(t, wantHash, set.hash(), "hash differs for permutation %d: %v", i, perm)
+		require.Equalf(t, wantString, set.String(), "String differs for permutation %d: %v", i, perm)
+	}
+}
+
+// TestLabelPolicySetHashDistinct asserts the hash actually discriminates:
+// different access sets must produce different keys, otherwise distinct
+// permissions would collide on a single cache bucket. It also exercises the
+// multi-tenant path (tenant sort + per-tenant canonicalization together), which
+// the single-tenant order-independence test does not.
+func TestLabelPolicySetHashDistinct(t *testing.T) {
+	pAlpha := mustPolicy(t, labels.MatchEqual, "team", "alpha")
+	pBravo := mustPolicy(t, labels.MatchEqual, "team", "bravo")
+	pCharlie := mustPolicy(t, labels.MatchEqual, "team", "charlie")
+
+	// Two tenants, two policies each, built in different orders. Both describe
+	// the same logical access set, so they must hash identically.
+	setAB := LabelPolicySet{
+		"tenant1": {pAlpha, pBravo},
+		"tenant2": {pAlpha, pBravo},
+	}
+	setBA := LabelPolicySet{
+		"tenant2": {pBravo, pAlpha},
+		"tenant1": {pBravo, pAlpha},
+	}
+	require.Equal(t, setAB.hash(), setBA.hash(), "same multi-tenant access set must hash identically regardless of order")
+
+	// Distinct sets must hash distinctly. Each differs from setAB in exactly one
+	// dimension: policy content, policy count, and which tenant holds them.
+	others := map[string]LabelPolicySet{
+		"different policy value": {
+			"tenant1": {pAlpha, pCharlie},
+			"tenant2": {pAlpha, pBravo},
+		},
+		"fewer policies": {
+			"tenant1": {pAlpha},
+			"tenant2": {pAlpha, pBravo},
+		},
+		"different tenant set": {
+			"tenant1": {pAlpha, pBravo},
+			"tenant3": {pAlpha, pBravo},
+		},
+	}
+	for name, other := range others {
+		require.NotEqualf(t, setAB.hash(), other.hash(), "expected distinct hash for %q", name)
+	}
+}
+
+// TestLabelPolicySetHashDeduplicates asserts a repeated selector does not change
+// the key: a user in multiple teams that contribute identical selectors must map
+// to the same cache bucket as if the selector appeared once.
+func TestLabelPolicySetHashDeduplicates(t *testing.T) {
+	pAlpha := mustPolicy(t, labels.MatchEqual, "team", "alpha")
+	pBravo := mustPolicy(t, labels.MatchEqual, "team", "bravo")
+
+	withDup := LabelPolicySet{"tenant1": {pAlpha, pBravo, pBravo}}
+	withoutDup := LabelPolicySet{"tenant1": {pAlpha, pBravo}}
+
+	require.Equal(t, withoutDup.hash(), withDup.hash(), "duplicate policy must not change the hash")
+	require.Equal(t, withoutDup.String(), withDup.String(), "duplicate policy must not change the String output")
+}
+
+func TestInjectAndExtractLabelMatchersContext(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		matchers    LabelPolicySet
+		expectedErr error
+	}{
+		{
+			name: "single policy is injected and extracted correctly",
+			matchers: LabelPolicySet{
+				"tenant1": {
+					{Selector: []*types.LabelMatcher{{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "prod"}}},
+				},
+			},
+		},
+		{
+			name: "multiple policies are injected and extracted correctly",
+			matchers: LabelPolicySet{
+				"tenant1": {
+					{Selector: []*types.LabelMatcher{{Type: types.LABEL_MATCHER_TYPE_RE, Name: "env", Value: ".*"}}},
+					{Selector: []*types.LabelMatcher{{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "classification", Value: "secret"}}},
+				},
+			},
+		},
+		{
+			name: "multiple tenants are injected and extracted correctly",
+			matchers: LabelPolicySet{
+				"tenant1": {
+					{Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+						{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "classification", Value: "secret"},
+					}},
+					{Selector: []*types.LabelMatcher{{Type: types.LABEL_MATCHER_TYPE_NEQ, Name: "classification", Value: "secret"}}},
+				},
+				"tenant2": {
+					{Selector: []*types.LabelMatcher{{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "level", Value: "info"}}},
+				},
+			},
+		},
+		{
+			name:        "empty matchers do not inject anything",
+			matchers:    LabelPolicySet{},
+			expectedErr: errNoMatcherSource,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			ctx = InjectLabelMatchersContext(ctx, tc.matchers)
+
+			extracted, err := ExtractLabelMatchersContext(ctx)
+
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+
+			require.Equal(t, len(tc.matchers), len(extracted))
+			for tenant, expectedPolicies := range tc.matchers {
+				require.ElementsMatch(t, expectedPolicies, extracted[tenant])
+			}
+		})
+	}
+
+	t.Run("extracting from empty context returns error", func(t *testing.T) {
+		_, err := ExtractLabelMatchersContext(t.Context())
+		require.ErrorIs(t, err, errNoMatcherSource)
+	})
+}

--- a/pkg/labelaccess/request_chunk_filterer.go
+++ b/pkg/labelaccess/request_chunk_filterer.go
@@ -1,0 +1,134 @@
+package labelaccess
+
+import (
+	"context"
+	"slices"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+	"github.com/grafana/loki/v3/pkg/storage/chunk"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+)
+
+type RequestChunkFilterer struct{}
+
+func (r *RequestChunkFilterer) ForRequest(ctx context.Context) chunk.Filterer {
+	f := filtererForRequest(ctx)
+	if f == nil {
+		// Return nil chunk.Filterer instead of (*ChunkFilterer)(nil)
+		// to avoid typed nil wrapped in interface issues.
+		return nil
+	}
+	return f
+}
+
+// filtererForRequest extracts LBAC policies from the context and returns a ChunkFilterer.
+// This is shared between RequestChunkFilterer (V1 engine) and RequestStreamFilterer (V2 engine).
+func filtererForRequest(ctx context.Context) *ChunkFilterer {
+	// Extract policies from context
+	instancePolicyMap, err := ExtractLabelMatchersContext(ctx)
+	if err != nil {
+		if err == errNoMatcherSource {
+			// No LBAC policies, return nil (no filtering)
+			return nil
+		}
+		_ = level.Debug(util_log.Logger).Log("msg", "unable to find instance policy map in context", "err", err)
+		return nil
+	}
+
+	instanceName, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		_ = level.Debug(util_log.Logger).Log("msg", "unable to find instance name", "err", err)
+		return nil
+	}
+
+	policies, exist := instancePolicyMap[instanceName]
+	if !exist {
+		return nil
+	}
+
+	// Store in ChunkFilterer
+	cf := ChunkFilterer{
+		policies: policies,
+	}
+	cf.loadMatchers()
+
+	return &cf
+}
+
+type ChunkFilterer struct {
+	policies []*types.LabelPolicy
+	matchers map[string]*labels.Matcher
+}
+
+func (c *ChunkFilterer) loadMatchers() {
+	matchers := make(map[string]*labels.Matcher)
+	for _, p := range c.policies {
+		for _, lm := range p.Selector {
+			matcher, err := types.LabelMatcherToPromLabel(lm)
+			if err != nil {
+				// This shouldn't happen: log it and do not match
+				_ = level.Debug(util_log.Logger).Log("msg", "unable to encode matcher as prometheus matcher", "err", err)
+				break
+			}
+
+			matchers[lm.GoString()] = matcher
+		}
+	}
+	c.matchers = matchers
+}
+
+func (c *ChunkFilterer) ShouldFilter(metric labels.Labels) bool {
+	if len(c.policies) == 0 {
+		return false
+	}
+
+	if len(c.matchers) == 0 {
+		c.loadMatchers()
+	}
+
+	for _, p := range c.policies {
+		// For one selector all must match
+		matching := true
+		for _, lm := range p.Selector {
+			labelValue := metric.Get(lm.Name)
+
+			matcher, ok := c.matchers[lm.GoString()]
+			if !ok {
+				// This shouldn't happen: log it and do not match
+				_ = level.Debug(util_log.Logger).Log("msg", "unable to find matcher as prometheus matcher", "name", lm.Name)
+				matching = false
+				break
+			}
+
+			if !matcher.Matches(labelValue) {
+				matching = false
+				break
+			}
+		}
+		// If any of the selectors match we should not filter
+		if matching {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *ChunkFilterer) RequiredLabelNames() []string {
+	labelNames := map[string]struct{}{}
+	for _, p := range c.policies {
+		for _, lm := range p.Selector {
+			labelNames[lm.Name] = struct{}{}
+		}
+	}
+
+	names := make([]string, 0, len(labelNames))
+	for k := range labelNames {
+		names = append(names, k)
+	}
+	slices.Sort(names)
+	return names
+}

--- a/pkg/labelaccess/request_chunk_filterer_test.go
+++ b/pkg/labelaccess/request_chunk_filterer_test.go
@@ -1,0 +1,377 @@
+package labelaccess
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+)
+
+func TestChunkFiltererShouldFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		policies []*types.LabelPolicy
+		metric   labels.Labels
+		want     bool
+	}{
+		{
+			"no selectors",
+			[]*types.LabelPolicy{},
+			labels.EmptyLabels(),
+			false,
+		},
+		{
+			"matching selector with 1 matcher",
+			[]*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{
+							Type:  types.LABEL_MATCHER_TYPE_EQ,
+							Name:  "env",
+							Value: "dev",
+						},
+					},
+				},
+			},
+			labels.FromStrings("host", "host1", "env", "dev"),
+			false,
+		},
+		{
+			"matching selector with 1 negative matcher",
+			[]*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{
+							Type:  types.LABEL_MATCHER_TYPE_NEQ,
+							Name:  "env",
+							Value: "dev",
+						},
+					},
+				},
+			},
+			labels.FromStrings("host", "host1", "env", "dev"),
+			true,
+		},
+		{
+			"non matching selector with multiple matchers",
+			[]*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{
+							Type:  types.LABEL_MATCHER_TYPE_EQ,
+							Name:  "env",
+							Value: "dev",
+						},
+						{
+							Type:  types.LABEL_MATCHER_TYPE_EQ,
+							Name:  "host",
+							Value: "host2",
+						},
+					},
+				},
+			},
+			labels.FromStrings("host", "host1", "env", "dev"),
+			true,
+		},
+		{
+			"one of multiple selectors matching",
+			[]*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{
+							Type:  types.LABEL_MATCHER_TYPE_NEQ,
+							Name:  "env",
+							Value: "prod",
+						},
+					},
+				},
+				{
+					Selector: []*types.LabelMatcher{
+						{
+							Type:  types.LABEL_MATCHER_TYPE_EQ,
+							Name:  "env",
+							Value: "dev",
+						},
+						{
+							Type:  types.LABEL_MATCHER_TYPE_EQ,
+							Name:  "host",
+							Value: "host1",
+						},
+					},
+				},
+			},
+			labels.FromStrings("host", "host3", "env", "dev"),
+			false,
+		},
+		{
+			"non matching selector",
+			[]*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{
+							Type:  types.LABEL_MATCHER_TYPE_EQ,
+							Name:  "env",
+							Value: "dev",
+						},
+					},
+				},
+			},
+			labels.FromStrings("host", "host1", "env", "prod"),
+			true,
+		},
+		{
+			"regex selector with no matching labels",
+			[]*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{
+							Type:  types.LABEL_MATCHER_TYPE_RE,
+							Name:  "environment",
+							Value: "dev.*",
+						},
+					},
+				},
+			},
+			labels.FromStrings("host", "host1", "env", "prod"),
+			true,
+		},
+		{
+			"negative regex selector without matching labels",
+			[]*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{
+							Type:  types.LABEL_MATCHER_TYPE_NRE,
+							Name:  "environment",
+							Value: "dev.*",
+						},
+					},
+				},
+			},
+			labels.FromStrings("host", "host1", "env", "prod"),
+			false,
+		},
+		{
+			"invalid label matcher type",
+			[]*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{
+							Type:  types.LabelMatcherType(1000),
+							Name:  "env",
+							Value: "prod",
+						},
+					},
+				},
+			},
+			labels.FromStrings("host", "host1", "env", "prod"),
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ChunkFilterer{
+				policies: tt.policies,
+			}
+			if got := c.ShouldFilter(tt.metric); got != tt.want {
+				t.Errorf("ChunkFilterer.ShouldFilter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkShouldFilter(b *testing.B) {
+	lps := make(LabelPolicySet)
+	lps["tenant"] = []*types.LabelPolicy{
+		{
+			Selector: []*types.LabelMatcher{
+				{
+					Type:  types.LABEL_MATCHER_TYPE_NRE,
+					Name:  "environment",
+					Value: "dev.*",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	ctx = InjectLabelMatchersContext(ctx, lps)
+	ctx = user.InjectOrgID(ctx, "tenant")
+
+	rcf := RequestChunkFilterer{}
+	cf := rcf.ForRequest(ctx)
+
+	lbls := labels.FromStrings("host", "host1", "env", "prod")
+
+	for n := 0; n < b.N; n++ {
+		_ = cf.ShouldFilter(lbls)
+	}
+}
+
+func TestChunkFilterer_RequiredLabelNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		policies []*types.LabelPolicy
+		metric   labels.Labels
+		want     []string
+	}{
+		{
+			"no selectors",
+			[]*types.LabelPolicy{},
+			labels.EmptyLabels(),
+			nil,
+		},
+		{
+			"policy with one selector",
+			[]*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{
+							Type:  types.LABEL_MATCHER_TYPE_EQ,
+							Name:  "env",
+							Value: "dev",
+						},
+					},
+				},
+			},
+			labels.FromStrings("host", "host1", "env", "dev"),
+			[]string{"env"},
+		},
+		{
+			"policy with multiple selectors",
+			[]*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{
+							Type:  types.LABEL_MATCHER_TYPE_EQ,
+							Name:  "env",
+							Value: "dev",
+						},
+						{
+							Type:  types.LABEL_MATCHER_TYPE_EQ,
+							Name:  "host",
+							Value: "host2",
+						},
+					},
+				},
+			},
+			labels.FromStrings("host", "host1", "env", "dev"),
+			[]string{"env", "host"},
+		},
+		{
+			"multiple policies",
+			[]*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{
+							Type:  types.LABEL_MATCHER_TYPE_NEQ,
+							Name:  "env",
+							Value: "prod",
+						},
+					},
+				},
+				{
+					Selector: []*types.LabelMatcher{
+						{
+							Type:  types.LABEL_MATCHER_TYPE_EQ,
+							Name:  "env",
+							Value: "dev",
+						},
+						{
+							Type:  types.LABEL_MATCHER_TYPE_EQ,
+							Name:  "host",
+							Value: "host1",
+						},
+					},
+				},
+			},
+			labels.FromStrings("host", "host3", "env", "dev"),
+			[]string{"env", "host"},
+		},
+		{
+			"invalid label matcher type",
+			[]*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{
+							Type:  types.LabelMatcherType(1000),
+							Name:  "env",
+							Value: "prod",
+						},
+					},
+				},
+			},
+			labels.FromStrings("host", "host1", "env", "prod"),
+			[]string{"env"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ChunkFilterer{
+				policies: tt.policies,
+			}
+			got := c.RequiredLabelNames()
+			require.ElementsMatch(t, got, tt.want)
+		})
+	}
+}
+
+// TestRequestChunkFilterer_ForRequest tests that ForRequest returns a proper nil interface
+// when no LBAC policies are present, and a non-nil filterer when policies exist.
+// The nil interface check is critical because a typed nil (*ChunkFilterer)(nil)
+// wrapped in an interface would cause `filterer != nil` checks to pass,
+// leading to nil pointer dereferences.
+func TestRequestChunkFilterer_ForRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		policies  LabelPolicySet
+		expectNil bool
+	}{
+		{
+			name:      "no LBAC policies returns nil interface",
+			policies:  nil,
+			expectNil: true,
+		},
+		{
+			name:      "empty LBAC policies returns nil interface",
+			policies:  LabelPolicySet{},
+			expectNil: true,
+		},
+		{
+			name: "with LBAC policies returns non-nil filterer",
+			policies: LabelPolicySet{
+				"test-tenant": {
+					{Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "prod"},
+					}},
+				},
+			},
+			expectNil: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &RequestChunkFilterer{}
+
+			ctx := t.Context()
+			if tc.policies != nil {
+				ctx = InjectLabelMatchersContext(ctx, tc.policies)
+			}
+			ctx = user.InjectOrgID(ctx, "test-tenant")
+
+			filterer := r.ForRequest(ctx)
+
+			if tc.expectNil {
+				// The interface itself must be nil, not just the underlying value.
+				// If we returned a typed nil, `filterer != nil` would be true
+				// but filterer.ShouldFilter() would panic.
+				require.True(t, filterer == nil, "ForRequest should return nil interface")
+			} else {
+				require.True(t, filterer != nil, "ForRequest should return non-nil filterer")
+			}
+		})
+	}
+}

--- a/pkg/labelaccess/request_stream_filterer.go
+++ b/pkg/labelaccess/request_stream_filterer.go
@@ -1,0 +1,34 @@
+package labelaccess
+
+import (
+	"context"
+
+	"github.com/grafana/loki/v3/pkg/engine"
+)
+
+// StreamFilterer is an alias for ChunkFilterer.
+// Both implement the same ShouldFilter(labels.Labels) bool method for LBAC filtering.
+// ChunkFilterer is used for the V1 engine (chunk-level filtering),
+// StreamFilterer is used for the V2 engine (stream-level filtering on the data object).
+type StreamFilterer = ChunkFilterer
+
+var _ engine.StreamFilterer = (*StreamFilterer)(nil)
+
+// RequestStreamFilterer implements engine.RequestStreamFilterer for LBAC enforcement
+// in the V2 query engine. It creates a StreamFilterer for each request based on the
+// LBAC policies in the request context.
+type RequestStreamFilterer struct{}
+
+var _ engine.RequestStreamFilterer = (*RequestStreamFilterer)(nil)
+
+// ForRequest extracts LBAC policies from the context and returns a StreamFilterer
+// that filters streams based on those policies.
+// It reuses the same logic as RequestChunkFilterer.ForRequest via filtererForRequest.
+func (r *RequestStreamFilterer) ForRequest(ctx context.Context) engine.StreamFilterer {
+	f := filtererForRequest(ctx)
+	if f == nil {
+		// Return nil engine.StreamFilterer instead of (*ChunkFilterer)(nil)
+		return nil
+	}
+	return f
+}

--- a/pkg/labelaccess/request_stream_filterer_test.go
+++ b/pkg/labelaccess/request_stream_filterer_test.go
@@ -1,0 +1,66 @@
+package labelaccess
+
+import (
+	"testing"
+
+	"github.com/grafana/dskit/user"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+)
+
+// TestRequestStreamFilterer_ForRequest tests that ForRequest returns a proper nil interface
+// when no LBAC policies are present, and a non-nil filterer when policies exist.
+// The nil interface check is critical because a typed nil (*ChunkFilterer)(nil)
+// wrapped in an interface would cause `filterer != nil` checks to pass,
+// leading to nil pointer dereferences.
+func TestRequestStreamFilterer_ForRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		policies  LabelPolicySet
+		expectNil bool
+	}{
+		{
+			name:      "no LBAC policies returns nil interface",
+			policies:  nil,
+			expectNil: true,
+		},
+		{
+			name:      "empty LBAC policies returns nil interface",
+			policies:  LabelPolicySet{},
+			expectNil: true,
+		},
+		{
+			name: "with LBAC policies returns non-nil filterer",
+			policies: LabelPolicySet{
+				"test-tenant": {
+					{Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "prod"},
+					}},
+				},
+			},
+			expectNil: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &RequestStreamFilterer{}
+
+			ctx := t.Context()
+			if tc.policies != nil {
+				ctx = InjectLabelMatchersContext(ctx, tc.policies)
+			}
+			ctx = user.InjectOrgID(ctx, "test-tenant")
+
+			filterer := r.ForRequest(ctx)
+
+			if tc.expectNil {
+				// The interface itself must be nil, not just the underlying value.
+				// If we returned a typed nil, `filterer != nil` would be true
+				// but filterer.ShouldFilter() would panic.
+				require.True(t, filterer == nil, "ForRequest should return nil interface")
+			} else {
+				require.True(t, filterer != nil, "ForRequest should return non-nil filterer")
+			}
+		})
+	}
+}

--- a/pkg/labelaccess/store_wrapper.go
+++ b/pkg/labelaccess/store_wrapper.go
@@ -1,0 +1,72 @@
+package labelaccess
+
+import (
+	"context"
+
+	"github.com/go-kit/log/level"
+
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+
+	//"github.com/grafana/backend-enterprise-libs/enterprise/admin/types"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/v3/pkg/storage"
+	"github.com/grafana/loki/v3/pkg/util"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+)
+
+func WrapStore(wrapped storage.Store) storage.Store {
+	w := StoreWrapper{
+		Store: wrapped,
+	}
+
+	return &w
+}
+
+type StoreWrapper struct {
+	storage.Store
+}
+
+func (w *StoreWrapper) LabelValuesForMetricName(ctx context.Context, orgID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error) {
+	_ = level.Debug(util_log.Logger).Log("msg", "using store wrapper")
+	instancePolicyMap, err := ExtractLabelMatchersContext(ctx)
+	if err != nil {
+		if err == errNoMatcherSource {
+			// No lbac header, so return the given labelValues
+			return w.Store.LabelValuesForMetricName(ctx, orgID, from, through, metricName, labelName, matchers...)
+		}
+		_ = level.Debug(util_log.Logger).Log("msg", "unable to find instance policy map in context", "err", err)
+		return nil, err
+	}
+
+	policies, exist := instancePolicyMap[orgID]
+	if !exist {
+		return w.Store.LabelValuesForMetricName(ctx, orgID, from, through, metricName, labelName, matchers...)
+	}
+
+	var result util.UniqueStrings
+	for _, p := range policies {
+		policyMatchers := make([]*labels.Matcher, len(p.Selector))
+		for i, lm := range p.Selector {
+			matcher, err := types.LabelMatcherToPromLabel(lm)
+			policyMatchers[i] = matcher
+			if err != nil {
+				// This shouldn't happen: log it and do not match
+				_ = level.Debug(util_log.Logger).Log("msg", "unable to encode matcher as Prometheus matcher", "label", labelName, "err", err)
+				break
+			}
+		}
+		policyMatchers = append(policyMatchers, matchers...)
+		_ = level.Debug(util_log.Logger).Log("msg", "fetching label values", "org_id", orgID, "label", labelName, "matchers", len(policyMatchers))
+
+		labelValues, err := w.Store.LabelValuesForMetricName(ctx, orgID, from, through, metricName, labelName, policyMatchers...)
+		if err != nil {
+			return nil, err
+		}
+		_ = level.Debug(util_log.Logger).Log("msg", "fetched label values", "org_id", orgID, "label", labelName, "labels", len(labelValues))
+		result.Add(labelValues...)
+	}
+
+	return result.Strings(), nil
+}

--- a/pkg/labelaccess/store_wrapper_test.go
+++ b/pkg/labelaccess/store_wrapper_test.go
@@ -1,0 +1,246 @@
+package labelaccess
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
+
+	"github.com/grafana/loki/v3/pkg/chunkenc"
+	"github.com/grafana/loki/v3/pkg/compression"
+	"github.com/grafana/loki/v3/pkg/ingester/client"
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/storage"
+	"github.com/grafana/loki/v3/pkg/storage/chunk"
+	chunk_local "github.com/grafana/loki/v3/pkg/storage/chunk/client/local"
+	storage_config "github.com/grafana/loki/v3/pkg/storage/config"
+	loki_types "github.com/grafana/loki/v3/pkg/storage/types"
+	loki_util "github.com/grafana/loki/v3/pkg/util"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+	"github.com/grafana/loki/v3/pkg/validation"
+)
+
+var (
+	start      = model.Time(0)
+	tenantName = "david"
+
+	// storage.NewClientMetrics registers Azure blob metrics on prometheus.DefaultRegisterer;
+	// reuse one instance so parallel tests, -count>1, or multiple helpers do not panic.
+	testStorageClientMetrics     storage.ClientMetrics
+	testStorageClientMetricsOnce sync.Once
+)
+
+func testStorageClientMetricsSingleton() storage.ClientMetrics {
+	testStorageClientMetricsOnce.Do(func() {
+		testStorageClientMetrics = storage.NewClientMetrics()
+	})
+	return testStorageClientMetrics
+}
+
+func TestWrapperLabelValuesForMetricName(t *testing.T) {
+	util_log.Logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	ctx := context.Background()
+
+	chunks := []chunk.Chunk{
+		newChunk(logproto.Stream{
+			Labels:  `{env="dev", classification="confidential"}`,
+			Entries: []logproto.Entry{{Timestamp: time.Unix(0, 1), Line: "1"}},
+		}),
+		newChunk(logproto.Stream{
+			Labels:  `{env="dev", classification="secret"}`,
+			Entries: []logproto.Entry{{Timestamp: time.Unix(0, 2), Line: "3"}},
+		}),
+		newChunk(logproto.Stream{
+			Labels:  `{env="prod", classification="secret"}`,
+			Entries: []logproto.Entry{{Timestamp: time.Unix(0, 2), Line: "4"}},
+		}),
+		newChunk(logproto.Stream{
+			Labels:  `{env="prod", classification="secret"}`,
+			Entries: []logproto.Entry{{Timestamp: time.Unix(0, 3), Line: "4"}},
+		}),
+		newChunk(logproto.Stream{
+			Labels:  `{env="prod", classification="notsecret"}`,
+			Entries: []logproto.Entry{{Timestamp: time.Unix(0, 3), Line: "5"}},
+		}),
+		newChunk(logproto.Stream{
+			Labels:  `{env="prod-confidential", classification="confidential"}`,
+			Entries: []logproto.Entry{{Timestamp: time.Unix(0, 3), Line: "6"}},
+		}),
+	}
+	m := getLocalStore(t)
+	err := m.Put(ctx, chunks)
+	require.NoError(t, err)
+	w := WrapStore(m)
+
+	for _, tc := range []struct {
+		name          string
+		labelPolicies []*types.LabelPolicy
+		labelValues   map[string][]string
+		extraMatchers []*labels.Matcher
+	}{
+		{
+			name: "dev-only",
+			labelPolicies: []*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{
+							Type:  types.LABEL_MATCHER_TYPE_EQ,
+							Name:  "env",
+							Value: "dev",
+						},
+					},
+				},
+			},
+			labelValues: map[string][]string{
+				"env":            {"dev"},
+				"classification": {"secret", "confidential"},
+			},
+		},
+		{
+			name: "not-confidential-not-secret",
+			labelPolicies: []*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{
+							Type:  types.LABEL_MATCHER_TYPE_NEQ,
+							Name:  "classification",
+							Value: "confidential",
+						},
+						{
+							Type:  types.LABEL_MATCHER_TYPE_NEQ,
+							Name:  "classification",
+							Value: "secret",
+						},
+					},
+				},
+			},
+			labelValues: map[string][]string{
+				"env":            {"prod"},
+				"classification": {"notsecret"},
+			},
+		},
+		{
+			name: "use all matchers",
+			labelPolicies: []*types.LabelPolicy{
+				{
+					Selector: []*types.LabelMatcher{
+						{
+							Type:  types.LABEL_MATCHER_TYPE_RE,
+							Name:  "env",
+							Value: ".*",
+						},
+					},
+				},
+			},
+			labelValues: map[string][]string{
+				"env": {"dev"},
+			},
+			extraMatchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "env", "dev"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			matchers := LabelPolicySet{}
+			matchers[tenantName] = tc.labelPolicies
+
+			ctx = InjectLabelMatchersContext(ctx, matchers)
+			ctx = user.InjectOrgID(ctx, tenantName)
+
+			from, through := loki_util.RoundToMilliseconds(time.Unix(0, 0), time.Unix(10, 0))
+
+			for labelName, expLabelValues := range tc.labelValues {
+				actualLabelValues, err := w.LabelValuesForMetricName(ctx, tenantName, from, through, "logs", labelName, tc.extraMatchers...)
+				require.NoError(t, err)
+				require.ElementsMatch(t, expLabelValues, actualLabelValues)
+			}
+		})
+	}
+}
+
+// helper methods from loki/pkg/storage
+func getLocalStore(t *testing.T) storage.Store {
+	limits, err := validation.NewOverrides(validation.Limits{
+		MaxQueryLength: model.Duration(6000 * time.Hour),
+	}, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	storeConfig := storage.Config{
+		FSConfig:          chunk_local.FSConfig{Directory: t.TempDir()},
+		MaxChunkBatchSize: 10,
+		TSDBShipperConfig: indexshipper.Config{
+			ActiveIndexDirectory: t.TempDir(),
+			CacheLocation:        t.TempDir(),
+			Mode:                 indexshipper.ModeReadWrite,
+			IngesterName:         "test-ingester",
+			ResyncInterval:       5 * time.Minute,
+			CacheTTL:             24 * time.Hour,
+		},
+	}
+
+	schemaConfig := storage_config.SchemaConfig{
+		Configs: []storage_config.PeriodConfig{
+			{
+				From:       storage_config.DayTime{Time: start},
+				IndexType:  loki_types.IndexTypeTSDB,
+				ObjectType: loki_types.StorageTypeFileSystem,
+				Schema:     "v13",
+				RowShards:  16,
+				IndexTables: storage_config.IndexPeriodicTableConfig{
+					PeriodicTableConfig: storage_config.PeriodicTableConfig{
+						Prefix: "index_",
+						Period: storage_config.ObjectStorageIndexRequiredPeriod,
+					}},
+			},
+		},
+	}
+
+	clientMetrics := testStorageClientMetricsSingleton()
+	store, err := storage.NewStore(
+		storeConfig,
+		storage_config.ChunkStoreConfig{},
+		schemaConfig, limits, clientMetrics, nil, util_log.Logger, "namespace")
+	if err != nil {
+		panic(err)
+	}
+
+	return store
+}
+
+func newChunk(stream logproto.Stream) chunk.Chunk {
+	lbs, err := syntax.ParseLabels(stream.Labels)
+	if err != nil {
+		panic(err)
+	}
+	if schema.NewMetadataFromLabels(lbs).Name == "" {
+		builder := labels.NewBuilder(lbs)
+		schema.Metadata{Name: "logs"}.SetToLabels(builder)
+		lbs = builder.Labels()
+	}
+	from, through := loki_util.RoundToMilliseconds(stream.Entries[0].Timestamp, stream.Entries[len(stream.Entries)-1].Timestamp)
+	chk := chunkenc.NewMemChunk(chunkenc.ChunkFormatV4, compression.GZIP, chunkenc.UnorderedWithStructuredMetadataHeadBlockFmt, 256*1024, 0)
+	for _, e := range stream.Entries {
+		_, _ = chk.Append(&e)
+	}
+	chk.Close()
+	c := chunk.NewChunk(tenantName, client.Fingerprint(lbs), lbs, chunkenc.NewFacade(chk, 0, 0), from, through)
+	// force the checksum creation
+	if err := c.Encode(); err != nil {
+		panic(err)
+	}
+	return c
+}

--- a/pkg/labelaccess/store_wrapper_test.go
+++ b/pkg/labelaccess/store_wrapper_test.go
@@ -196,7 +196,7 @@ func getLocalStore(t *testing.T) storage.Store {
 		Configs: []storage_config.PeriodConfig{
 			{
 				From:       storage_config.DayTime{Time: start},
-				IndexType:  loki_types.IndexTypeTSDB,
+				IndexType:  loki_types.TSDBType,
 				ObjectType: loki_types.StorageTypeFileSystem,
 				Schema:     "v13",
 				RowShards:  16,

--- a/pkg/labelaccess/tripperware.go
+++ b/pkg/labelaccess/tripperware.go
@@ -1,0 +1,127 @@
+package labelaccess
+
+import (
+	"context"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/user"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+)
+
+type contextKeyLabelPolicyHashType string
+
+const (
+	contextKeyLabelPolicyHash contextKeyLabelPolicyHashType = "lbac_hash"
+
+	tenantSeparator string = "!"
+)
+
+// Not used by GEM or GEL and supported by upstream
+
+// NewMiddleware wraps the existing middleware to make sure the LBAC headers are propagated
+func NewMiddleware() queryrangebase.Middleware {
+	return queryrangebase.MiddlewareFunc(func(next queryrangebase.Handler) queryrangebase.Handler {
+		return queryrangebase.HandlerFunc(func(ctx context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+			labelPolicySet, err := ExtractLabelMatchersContext(ctx)
+
+			// This should never happen anyways because we have auth middleware before this.
+			if err != nil {
+				return nil, err
+			}
+
+			// If the instance policies are set on the query, ensure the user ID is altered to respect
+			// them before being passed to the wrapped tripperware.
+			if len(labelPolicySet) != 0 {
+				ctx = context.WithValue(ctx, contextKeyLabelPolicyHash, labelPolicySet.hash())
+			}
+
+			resp, err := next.Do(ctx, req)
+			if err != nil {
+				return nil, err
+			}
+
+			// Filter volume responses to enforce LBAC as defense-in-depth.
+			// This catches any streams that slipped through upstream filtering,
+			// and correctly handles multi-policy OR semantics for series aggregation.
+			if len(labelPolicySet) > 0 {
+				resp = filterVolumeResponse(ctx, resp, labelPolicySet)
+			}
+
+			return resp, nil
+		})
+	})
+}
+
+// filterVolumeResponse filters out volume entries whose stream labels don't match
+// any LBAC policy. It mirrors ChunkFilterer.ShouldFilter semantics: within a policy
+// all matchers must match (AND), across policies any match passes (OR).
+//
+// For non-series aggregation modes, Volume.Name is a bare label name (e.g. "namespace")
+// rather than a full label set — those entries are passed through unchanged, since
+// query-level LBAC injection in the HTTP middleware already filtered upstream.
+func filterVolumeResponse(ctx context.Context, resp queryrangebase.Response, policySet LabelPolicySet) queryrangebase.Response {
+	volResp, ok := resp.(*queryrange.VolumeResponse)
+	if !ok || volResp.Response == nil {
+		return resp
+	}
+
+	orgID, _ := user.ExtractOrgID(ctx)
+	policies, exists := policySet[orgID]
+	if !exists || len(policies) == 0 {
+		return resp
+	}
+
+	cf := &ChunkFilterer{policies: policies}
+	cf.loadMatchers()
+
+	filtered := make([]logproto.Volume, 0, len(volResp.Response.Volumes))
+	filteredCount := 0
+	for _, v := range volResp.Response.Volumes {
+		ls, err := syntax.ParseLabels(v.Name)
+		if err != nil {
+			// Not a parseable label set (e.g. a bare label name from non-series aggregation).
+			// Pass through — query-level filtering handles this case.
+			filtered = append(filtered, v)
+			continue
+		}
+		if cf.ShouldFilter(ls) {
+			filteredCount++
+			continue
+		}
+		filtered = append(filtered, v)
+	}
+
+	if filteredCount == 0 {
+		return resp
+	}
+
+	level.Debug(util_log.Logger).Log(
+		"msg", "lbac tripperware: filtered volume response entries",
+		"org_id", orgID,
+		"total", len(volResp.Response.Volumes),
+		"filtered_out", filteredCount,
+		"remaining", len(filtered),
+	)
+
+	return &queryrange.VolumeResponse{
+		Response: &logproto.VolumeResponse{
+			Volumes: filtered,
+			Limit:   volResp.Response.Limit,
+		},
+		Headers: volResp.Headers,
+	}
+}
+
+// UserIDTransformer returns the changed userID if there is a LabelPolicy set in the context.
+// This is used in Loki in GenerateCacheKey so the cached results have the labelpolicy as part of the cache key.
+func UserIDTransformer(ctx context.Context, userID string) string {
+	if labelPolicyHash, _ := ctx.Value(contextKeyLabelPolicyHash).(string); len(labelPolicyHash) > 0 {
+		userID = userID + tenantSeparator + labelPolicyHash
+	}
+	return userID
+}

--- a/pkg/labelaccess/tripperware_test.go
+++ b/pkg/labelaccess/tripperware_test.go
@@ -1,0 +1,254 @@
+package labelaccess
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/dskit/user"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/labelaccess/types"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange"
+	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/util/httpreq"
+)
+
+func volume(name string, n uint64) logproto.Volume {
+	return logproto.Volume{Name: name, Volume: n}
+}
+
+func volumes(resp queryrangebase.Response) []logproto.Volume {
+	t, ok := resp.(*queryrange.VolumeResponse)
+	if !ok || t.Response == nil {
+		return nil
+	}
+	return t.Response.Volumes
+}
+
+// TestFilterVolumeResponse covers the response-level LBAC filter added in
+// #5180. Mirrors ChunkFilterer semantics: within a policy, all matchers must
+// match (AND); across policies, any matching policy passes (OR). Bare label
+// names (non-series aggregation responses) are not parseable as label sets and
+// must pass through — query-level injection in the HTTP middleware handles
+// those.
+func TestFilterVolumeResponse(t *testing.T) {
+	const tenant = "test_tenant"
+
+	policySingle := LabelPolicySet{
+		tenant: []*types.LabelPolicy{
+			{Selector: []*types.LabelMatcher{
+				{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+			}},
+		},
+	}
+
+	policyMulti := LabelPolicySet{
+		tenant: []*types.LabelPolicy{
+			{Selector: []*types.LabelMatcher{
+				{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+			}},
+			{Selector: []*types.LabelMatcher{
+				{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "team", Value: "platform"},
+			}},
+		},
+	}
+
+	cases := []struct {
+		name        string
+		orgID       string // "" means do not inject orgID
+		policies    LabelPolicySet
+		input       *queryrange.VolumeResponse
+		expectNames []string
+	}{
+		{
+			name:     "denied entries are filtered out",
+			orgID:    tenant,
+			policies: policySingle,
+			input: &queryrange.VolumeResponse{
+				Response: &logproto.VolumeResponse{
+					Volumes: []logproto.Volume{
+						volume(`{env="dev", job="a"}`, 10),
+						volume(`{env="prod", job="b"}`, 20),
+						volume(`{env="dev", job="c"}`, 30),
+					},
+				},
+			},
+			expectNames: []string{`{env="dev", job="a"}`, `{env="dev", job="c"}`},
+		},
+		{
+			name:     "multi-policy uses OR semantics across policies",
+			orgID:    tenant,
+			policies: policyMulti,
+			input: &queryrange.VolumeResponse{
+				Response: &logproto.VolumeResponse{
+					Volumes: []logproto.Volume{
+						volume(`{env="dev", team="other"}`, 1),     // matches policy 1
+						volume(`{env="prod", team="platform"}`, 2), // matches policy 2
+						volume(`{env="prod", team="other"}`, 3),    // matches neither
+					},
+				},
+			},
+			expectNames: []string{`{env="dev", team="other"}`, `{env="prod", team="platform"}`},
+		},
+		{
+			name:     "unparseable Volume.Name passes through unchanged",
+			orgID:    tenant,
+			policies: policySingle,
+			input: &queryrange.VolumeResponse{
+				Response: &logproto.VolumeResponse{
+					Volumes: []logproto.Volume{
+						volume("not a label set", 1), // ParseLabels rejects this
+						volume(`{env="prod"}`, 2),
+					},
+				},
+			},
+			expectNames: []string{"not a label set"},
+		},
+		{
+			name:     "no entries filtered returns the same response (no allocation churn)",
+			orgID:    tenant,
+			policies: policySingle,
+			input: &queryrange.VolumeResponse{
+				Response: &logproto.VolumeResponse{
+					Volumes: []logproto.Volume{
+						volume(`{env="dev"}`, 1),
+					},
+				},
+			},
+			expectNames: []string{`{env="dev"}`},
+		},
+		{
+			name:     "no orgID in ctx — response untouched",
+			orgID:    "",
+			policies: policySingle,
+			input: &queryrange.VolumeResponse{
+				Response: &logproto.VolumeResponse{
+					Volumes: []logproto.Volume{
+						volume(`{env="prod"}`, 1),
+					},
+				},
+			},
+			expectNames: []string{`{env="prod"}`},
+		},
+		{
+			name:  "tenant has no policies — response untouched",
+			orgID: tenant,
+			policies: LabelPolicySet{
+				"other_tenant": []*types.LabelPolicy{
+					{Selector: []*types.LabelMatcher{
+						{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+					}},
+				},
+			},
+			input: &queryrange.VolumeResponse{
+				Response: &logproto.VolumeResponse{
+					Volumes: []logproto.Volume{
+						volume(`{env="prod"}`, 1),
+					},
+				},
+			},
+			expectNames: []string{`{env="prod"}`},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.orgID != "" {
+				ctx = user.InjectOrgID(ctx, tc.orgID)
+			}
+
+			got := filterVolumeResponse(ctx, tc.input, tc.policies)
+			gotVols := volumes(got)
+
+			gotNames := make([]string, 0, len(gotVols))
+			for _, v := range gotVols {
+				gotNames = append(gotNames, v.Name)
+			}
+			assert.ElementsMatch(t, tc.expectNames, gotNames)
+		})
+	}
+}
+
+// TestFilterVolumeResponse_NonVolumeResponseIsUnchanged ensures we do not
+// accidentally reformat or wrap responses we don't recognize.
+func TestFilterVolumeResponse_NonVolumeResponseIsUnchanged(t *testing.T) {
+	ctx := user.InjectOrgID(context.Background(), "test_tenant")
+	policies := LabelPolicySet{
+		"test_tenant": []*types.LabelPolicy{
+			{Selector: []*types.LabelMatcher{
+				{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+			}},
+		},
+	}
+
+	resp := &queryrangebase.PrometheusResponse{Status: "success"}
+	got := filterVolumeResponse(ctx, resp, policies)
+	assert.Same(t, resp, got)
+}
+
+// TestNewMiddleware_FiltersVolumeResponse exercises the queryrange middleware
+// from #5180 end-to-end: when LBAC policies are present in the ctx, a
+// VolumeResponse returned by the downstream handler is filtered before being
+// returned to the caller.
+func TestNewMiddleware_FiltersVolumeResponse(t *testing.T) {
+	const tenant = "test_tenant"
+	policies := LabelPolicySet{
+		tenant: []*types.LabelPolicy{
+			{Selector: []*types.LabelMatcher{
+				{Type: types.LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+			}},
+		},
+	}
+
+	downstream := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		return &queryrange.VolumeResponse{
+			Response: &logproto.VolumeResponse{
+				Volumes: []logproto.Volume{
+					volume(`{env="dev"}`, 1),
+					volume(`{env="prod"}`, 2),
+				},
+			},
+		}, nil
+	})
+
+	handler := NewMiddleware().Wrap(downstream)
+
+	ctx := user.InjectOrgID(context.Background(), tenant)
+	ctx = InjectLabelMatchersContext(ctx, policies)
+
+	resp, err := handler.Do(ctx, &logproto.VolumeRequest{})
+	require.NoError(t, err)
+
+	got := volumes(resp)
+	require.Len(t, got, 1)
+	assert.Equal(t, `{env="dev"}`, got[0].Name)
+}
+
+// TestNewMiddleware_NoLBACDoesNotFilter ensures the middleware is transparent
+// when no LBAC policies are set on the context. Production requests always
+// reach this middleware via PropagateAllHeadersMiddleware, which seeds a
+// headers map; we replicate that here by injecting an unrelated header.
+func TestNewMiddleware_NoLBACDoesNotFilter(t *testing.T) {
+	downstream := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		return &queryrange.VolumeResponse{
+			Response: &logproto.VolumeResponse{
+				Volumes: []logproto.Volume{
+					volume(`{env="dev"}`, 1),
+					volume(`{env="prod"}`, 2),
+				},
+			},
+		}, nil
+	})
+
+	handler := NewMiddleware().Wrap(downstream)
+
+	ctx := httpreq.InjectHeader(context.Background(), "X-Some-Other-Header", "value")
+	resp, err := handler.Do(ctx, &logproto.VolumeRequest{})
+	require.NoError(t, err)
+
+	got := volumes(resp)
+	assert.Len(t, got, 2)
+}

--- a/pkg/labelaccess/types/label.go
+++ b/pkg/labelaccess/types/label.go
@@ -1,0 +1,88 @@
+package types
+
+import (
+	fmt "fmt"
+	strconv "strconv"
+	strings "strings"
+)
+
+type LabelMatcherType int32
+
+//nolint:revive // Converted from protobuf
+const (
+	LABEL_MATCHER_TYPE_UNSPECIFIED LabelMatcherType = 0
+	LABEL_MATCHER_TYPE_EQ          LabelMatcherType = 1
+	LABEL_MATCHER_TYPE_NEQ         LabelMatcherType = 2
+	LABEL_MATCHER_TYPE_RE          LabelMatcherType = 3
+	LABEL_MATCHER_TYPE_NRE         LabelMatcherType = 4
+)
+
+var LabelMatcherTypeName = map[int32]string{
+	0: "LABEL_MATCHER_TYPE_UNSPECIFIED",
+	1: "LABEL_MATCHER_TYPE_EQ",
+	2: "LABEL_MATCHER_TYPE_NEQ",
+	3: "LABEL_MATCHER_TYPE_RE",
+	4: "LABEL_MATCHER_TYPE_NRE",
+}
+
+// LabelMatcher is a simple representation of a label matcher, originally
+// matching a backend protobuf but now just a standalone struct
+// the format is similar to the prometheus type but the type numbers
+// are not the same
+type LabelMatcher struct {
+	Type  LabelMatcherType `json:"type,omitempty"`
+	Name  string           `json:"name,omitempty"`
+	Value string           `json:"value,omitempty"`
+}
+
+type LabelPolicy struct {
+	Selector []*LabelMatcher `json:"selector,omitempty"`
+}
+
+func (x LabelMatcherType) String() string {
+	s, ok := LabelMatcherTypeName[int32(x)]
+	if ok {
+		return s
+	}
+	return strconv.Itoa(int(x))
+}
+
+func (m *LabelMatcher) String() string {
+	if m == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&LabelMatcher{`,
+		`Type:` + fmt.Sprintf("%v", m.Type) + `,`,
+		`Name:` + fmt.Sprintf("%v", m.Name) + `,`,
+		`Value:` + fmt.Sprintf("%v", m.Value) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+
+func (m *LabelMatcher) GoString() string {
+	if m == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 7)
+	s = append(s, "&types.LabelMatcher{")
+	s = append(s, "Type: "+fmt.Sprintf("%#v", m.Type)+",\n")
+	s = append(s, "Name: "+fmt.Sprintf("%#v", m.Name)+",\n")
+	s = append(s, "Value: "+fmt.Sprintf("%#v", m.Value)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+
+func (p *LabelPolicy) String() string {
+	if p == nil {
+		return "nil"
+	}
+	var sb strings.Builder
+	sb.WriteString("&LabelPolicy{Selector:[]*LabelMatcher{")
+	for _, f := range p.Selector {
+		sb.WriteString(f.String())
+		sb.WriteByte(',')
+	}
+	sb.WriteString("},}")
+	return sb.String()
+}

--- a/pkg/labelaccess/types/label_test.go
+++ b/pkg/labelaccess/types/label_test.go
@@ -1,0 +1,45 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLabelPolicyString(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		policy *LabelPolicy
+		want   string
+	}{
+		{
+			name:   "nil policy",
+			policy: nil,
+			want:   "nil",
+		},
+		{
+			name:   "empty selector",
+			policy: &LabelPolicy{},
+			want:   "&LabelPolicy{Selector:[]*LabelMatcher{},}",
+		},
+		{
+			name: "single matcher",
+			policy: &LabelPolicy{Selector: []*LabelMatcher{
+				{Type: LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+			}},
+			want: "&LabelPolicy{Selector:[]*LabelMatcher{&LabelMatcher{Type:LABEL_MATCHER_TYPE_EQ,Name:env,Value:dev,},},}",
+		},
+		{
+			name: "multiple matchers preserve order and trailing comma",
+			policy: &LabelPolicy{Selector: []*LabelMatcher{
+				{Type: LABEL_MATCHER_TYPE_EQ, Name: "env", Value: "dev"},
+				{Type: LABEL_MATCHER_TYPE_NRE, Name: "class", Value: "secre.*"},
+			}},
+			want: "&LabelPolicy{Selector:[]*LabelMatcher{&LabelMatcher{Type:LABEL_MATCHER_TYPE_EQ,Name:env,Value:dev,},&LabelMatcher{Type:LABEL_MATCHER_TYPE_NRE,Name:class,Value:secre.*,},},}",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.policy.String())
+		})
+	}
+}

--- a/pkg/labelaccess/types/utils.go
+++ b/pkg/labelaccess/types/utils.go
@@ -1,0 +1,54 @@
+package types
+
+import (
+	"errors"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+var errInvalidMatchType = errors.New("unable to marshal unrecognized match type")
+
+// LabelMatcherToPromLabel transforms a simple label matcher to a upstream Prometheus label.Matcher
+func LabelMatcherToPromLabel(labelMatcherProto *LabelMatcher) (*labels.Matcher, error) {
+	var matchType labels.MatchType
+	switch labelMatcherProto.Type {
+	case LABEL_MATCHER_TYPE_EQ:
+		matchType = labels.MatchEqual
+	case LABEL_MATCHER_TYPE_NEQ:
+		matchType = labels.MatchNotEqual
+	case LABEL_MATCHER_TYPE_RE:
+		matchType = labels.MatchRegexp
+	case LABEL_MATCHER_TYPE_NRE:
+		matchType = labels.MatchNotRegexp
+	default:
+		return nil, errInvalidMatchType
+	}
+
+	matcher, err := labels.NewMatcher(matchType, labelMatcherProto.Name, labelMatcherProto.Value)
+	if err != nil {
+		return nil, err
+	}
+	return matcher, nil
+}
+
+// LabelMatcherFromPromLabel transforms a upstream Prometheus label.Matcher to a simple representation
+func LabelMatcherFromPromLabel(matcher *labels.Matcher) (*LabelMatcher, error) {
+	var matchType LabelMatcherType
+	switch matcher.Type {
+	case labels.MatchEqual:
+		matchType = LABEL_MATCHER_TYPE_EQ
+	case labels.MatchNotEqual:
+		matchType = LABEL_MATCHER_TYPE_NEQ
+	case labels.MatchRegexp:
+		matchType = LABEL_MATCHER_TYPE_RE
+	case labels.MatchNotRegexp:
+		matchType = LABEL_MATCHER_TYPE_NRE
+	default:
+		return nil, errInvalidMatchType
+	}
+	return &LabelMatcher{
+		Type:  matchType,
+		Name:  matcher.Name,
+		Value: matcher.Value,
+	}, nil
+}

--- a/pkg/loki/codec/codec.go
+++ b/pkg/loki/codec/codec.go
@@ -1,0 +1,12 @@
+package codec
+
+import (
+	"github.com/grafana/loki/v3/pkg/lokifrontend/frontend/transport"
+	"github.com/grafana/loki/v3/pkg/querier/worker"
+)
+
+// Codec defines methods to encode and decode requests from HTTP, httpgrpc and Protobuf.
+type Codec interface {
+	transport.Codec
+	worker.RequestCodec
+}

--- a/pkg/loki/labelaccess.go
+++ b/pkg/loki/labelaccess.go
@@ -1,0 +1,145 @@
+package loki
+
+import (
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/middleware"
+	"github.com/grafana/dskit/modules"
+	"github.com/grafana/dskit/services"
+
+	"github.com/grafana/loki/v3/pkg/labelaccess"
+
+	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	util_log "github.com/grafana/loki/v3/pkg/util/log"
+)
+
+func (l *Loki) setupLBAC() error {
+	l.Codec = labelaccess.NewCodec(l.Codec)
+
+	l.ModuleManager.RegisterModule(AuthMiddleware, l.initAuthMiddleware, modules.UserInvisibleModule)
+	l.ModuleManager.RegisterModule(LabelAccess, l.initStoreChunkFilterer)
+	l.ModuleManager.RegisterModule(LabelAccessStoreWrapper, l.initLabelAccessStoreWrapper, modules.UserInvisibleModule)
+	l.ModuleManager.RegisterModule(LabelAccessIngesterWrapper, l.initLabelAccessIngesterWrapper)
+	l.ModuleManager.RegisterModule(LabelAccessV2Engine, l.initLabelAccessV2Engine, modules.UserInvisibleModule)
+	l.ModuleManager.RegisterModule(LabelAccessInterceptors, l.initLabelAccessInterceptors, modules.UserInvisibleModule)
+	l.ModuleManager.RegisterModule(LabelAccessTripperware, l.initLabelAccessMiddleware, modules.UserInvisibleModule)
+	l.ModuleManager.RegisterModule(Filterers, l.initFilterers, modules.UserInvisibleModule)
+	l.ModuleManager.RegisterModule(LabelAccessUserIDTransformer, l.initLabelAccessUserIDTransformer, modules.UserInvisibleModule)
+	l.ModuleManager.RegisterModule(AuthTripperware, l.initAuthTripperware, modules.UserInvisibleModule)
+
+	lbacDeps := map[string][]string{
+		AuthMiddleware:          {Server},
+		AuthTripperware:         {QueryFrontendTripperware},
+		Compactor:               {AuthMiddleware},
+		Distributor:             {AuthMiddleware},
+		IndexGateway:            {LabelAccess},
+		Ingester:                {LabelAccessStoreWrapper, LabelAccessIngesterWrapper, Filterers},
+		LabelAccess:             {Store},
+		LabelAccessStoreWrapper: {Store},
+		LabelAccessTripperware:  {AuthTripperware},
+		Querier:                 {AuthMiddleware, LabelAccess, LabelAccessStoreWrapper},
+		QueryEngine:             {AuthMiddleware, LabelAccessV2Engine},
+		QueryFrontend:           {AuthMiddleware, LabelAccessTripperware},
+		Server:                  {LabelAccessInterceptors, LabelAccessUserIDTransformer},
+	}
+
+	for mod, targets := range lbacDeps {
+		if err := l.ModuleManager.AddDependency(mod, targets...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *Loki) initAuthMiddleware() (services.Service, error) {
+	_ = level.Debug(util_log.Logger).Log("msg", "initializing the auth middleware")
+
+	l.HTTPAuthMiddleware = middleware.Merge(
+		l.HTTPAuthMiddleware,
+		labelaccess.NewLabelAccessMiddleware(
+			log.With(util_log.Logger, "component", "label_access_middleware"),
+		),
+	)
+
+	return nil, nil
+}
+
+func (l *Loki) initLabelAccessIngesterWrapper() (services.Service, error) {
+	_ = level.Debug(util_log.Logger).Log("msg", "initializing ingester wrapper")
+	l.Cfg.Ingester.Wrapper = &labelaccess.IngesterWrapper{}
+
+	return nil, nil
+}
+
+func (l *Loki) initStoreChunkFilterer() (services.Service, error) {
+	_ = level.Debug(util_log.Logger).Log("msg", "initializing store chunk filterer")
+	filterer := labelaccess.RequestChunkFilterer{}
+	l.Store.SetChunkFilterer(&filterer)
+	return nil, nil
+}
+
+func (l *Loki) initLabelAccessInterceptors() (services.Service, error) {
+	_ = level.Debug(util_log.Logger).Log("msg", "initializing label access interceptors")
+	// Add server GRPC interceptors to the Ingester
+	l.Cfg.Server.GRPCMiddleware = append(l.Cfg.Server.GRPCMiddleware, labelaccess.ServerLBACInterceptor)
+	l.Cfg.Server.GRPCStreamMiddleware = append(l.Cfg.Server.GRPCStreamMiddleware, labelaccess.StreamServerLBACInterceptor)
+
+	// Add client GRPC interceptors to the IngesterClient
+	l.Cfg.IngesterClient.GRPCUnaryClientInterceptors = append(l.Cfg.IngesterClient.GRPCUnaryClientInterceptors, labelaccess.ClientLBACInterceptor)
+	l.Cfg.IngesterClient.GRCPStreamClientInterceptors = append(l.Cfg.IngesterClient.GRCPStreamClientInterceptors, labelaccess.StreamClientLBACInterceptor)
+
+	// Add client GRPC interceptors to the IndexGateway client
+	l.Cfg.StorageConfig.TSDBShipperConfig.IndexGatewayClientConfig.GRPCUnaryClientInterceptors = append(l.Cfg.StorageConfig.TSDBShipperConfig.IndexGatewayClientConfig.GRPCUnaryClientInterceptors, labelaccess.ClientLBACInterceptor)
+	l.Cfg.StorageConfig.TSDBShipperConfig.IndexGatewayClientConfig.GRCPStreamClientInterceptors = append(l.Cfg.StorageConfig.TSDBShipperConfig.IndexGatewayClientConfig.GRCPStreamClientInterceptors, labelaccess.StreamClientLBACInterceptor)
+
+	return nil, nil
+}
+
+func (l *Loki) initLabelAccessMiddleware() (services.Service, error) {
+	_ = level.Debug(util_log.Logger).Log("msg", "initializing label access middleware")
+	l.QueryFrontEndMiddleware = queryrangebase.MergeMiddlewares(
+		labelaccess.NewMiddleware(),
+		l.QueryFrontEndMiddleware,
+	)
+
+	return nil, nil
+}
+
+func (l *Loki) initLabelAccessStoreWrapper() (services.Service, error) {
+	_ = level.Debug(util_log.Logger).Log("msg", "initializing store wrapper")
+	l.Store = labelaccess.WrapStore(l.Store)
+
+	return nil, nil
+}
+
+func (l *Loki) initLabelAccessV2Engine() (services.Service, error) {
+	_ = level.Debug(util_log.Logger).Log("msg", "initializing LBAC support for V2 query engine")
+
+	// Set the StreamFilterer for filtering streams based on LBAC policies.
+	// LBAC policies are propagated via HTTP headers using PropagateAllHeadersMiddleware
+	// and httpreq.InjectHeader, then extracted at the worker via httpreq.ExtractAllHeaders.
+	streamFilterer := &labelaccess.RequestStreamFilterer{}
+	l.Cfg.QueryEngine.Executor.StreamFilterer = streamFilterer
+
+	return nil, nil
+}
+
+func (l *Loki) initFilterers() (services.Service, error) {
+	_ = level.Debug(util_log.Logger).Log("msg", "initializing label access filterers")
+	filterer := labelaccess.RequestChunkFilterer{}
+	l.Cfg.Ingester.ChunkFilterer = &filterer
+
+	return nil, nil
+}
+
+func (l *Loki) initLabelAccessUserIDTransformer() (services.Service, error) {
+	_ = level.Debug(util_log.Logger).Log("msg", "initializing label access id transformer")
+	l.Cfg.QueryRange.Transformer = labelaccess.UserIDTransformer
+
+	return nil, nil
+}
+
+func (l *Loki) initAuthTripperware() (services.Service, error) {
+	_ = level.Debug(util_log.Logger).Log("msg", "initializing auth tripperware")
+	return nil, nil
+}

--- a/pkg/loki/lbac_setup_test.go
+++ b/pkg/loki/lbac_setup_test.go
@@ -1,0 +1,107 @@
+package loki
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/grafana/dskit/flagext"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/labelaccess"
+)
+
+// TestLBACAuthMiddlewareRegisteredOnce drives both wiring steps that touch
+// HTTPAuthMiddleware: setupAuthMiddleware() (base auth, from New()) and the
+// AuthMiddleware module (initAuthMiddleware, which merges the LBAC middleware).
+// The LBAC middleware must be installed exactly once
+func TestLBACAuthMiddlewareRegisteredOnce(t *testing.T) {
+	l := &Loki{}
+	l.Cfg.AuthEnabled = false
+	l.Cfg.LBAC.Enabled = true
+
+	l.setupAuthMiddleware()
+	_, err := l.initAuthMiddleware()
+	require.NoError(t, err)
+
+	var seenQuery string
+	final := l.HTTPAuthMiddleware.Wrap(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seenQuery = r.URL.Query().Get("query")
+	}))
+
+	q := url.Values{}
+	q.Set("query", `{__aggregated_metric__="varlog_service"}`)
+	req := httptest.NewRequest("GET", "/loki/api/v1/query_range?"+q.Encode(), nil)
+	req.Header.Set("X-Scope-OrgID", "test_tenant")
+	req.Header.Add(labelaccess.HTTPHeaderKey, "test_tenant:"+url.PathEscape(`{env="dev"}`))
+
+	final.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.Equal(t, 1, strings.Count(seenQuery, "logfmt"),
+		"LBAC query modification must be applied exactly once; got query: %s", seenQuery)
+}
+
+// lbacModules are the modules setupLBAC registers.
+var lbacModules = []string{
+	AuthMiddleware,
+	LabelAccess,
+	LabelAccessStoreWrapper,
+	LabelAccessIngesterWrapper,
+	LabelAccessV2Engine,
+	LabelAccessInterceptors,
+	LabelAccessTripperware,
+	Filterers,
+	LabelAccessUserIDTransformer,
+	AuthTripperware,
+}
+
+// TestSetupLBACEnabled exercises setupLBAC through setupModuleManager.
+// It confirmed that all the registered modules exist without cycles
+func TestSetupLBACEnabled(t *testing.T) {
+	l := &Loki{}
+	l.Cfg.Target = flagext.StringSliceCSV{All}
+	l.Cfg.LBAC.Enabled = true
+
+	require.NoError(t, l.setupModuleManager())
+
+	for _, mod := range lbacModules {
+		require.True(t, l.ModuleManager.IsModuleRegistered(mod),
+			"module %s should be registered when LBAC is enabled", mod)
+	}
+
+	// DependenciesForModule returns transitive deps, so assert containment of
+	// the edges setupLBAC adds rather than exact equality.
+	edges := map[string][]string{
+		Querier:       {AuthMiddleware, LabelAccess, LabelAccessStoreWrapper},
+		QueryFrontend: {AuthMiddleware, LabelAccessTripperware},
+		QueryEngine:   {AuthMiddleware, LabelAccessV2Engine},
+		Ingester:      {LabelAccessStoreWrapper, LabelAccessIngesterWrapper, Filterers},
+		Server:        {LabelAccessInterceptors, LabelAccessUserIDTransformer},
+		IndexGateway:  {LabelAccess},
+	}
+	for mod, deps := range edges {
+		got := l.ModuleManager.DependenciesForModule(mod)
+		for _, dep := range deps {
+			require.Contains(t, got, dep,
+				"module %s should depend on %s under LBAC", mod, dep)
+		}
+	}
+}
+
+// TestSetupLBACDisabled confirms the LBAC modules are absent when LBAC is off,
+// so setupLBAC's wiring is gated on the feature flag.
+func TestSetupLBACDisabled(t *testing.T) {
+	l := &Loki{}
+	l.Cfg.Target = flagext.StringSliceCSV{All}
+	l.Cfg.LBAC.Enabled = false
+
+	require.NoError(t, l.setupModuleManager())
+
+	for _, mod := range lbacModules {
+		// AuthTripperware and AuthMiddleware names are unique to LBAC wiring.
+		require.False(t, l.ModuleManager.IsModuleRegistered(mod),
+			"module %s should not be registered when LBAC is disabled", mod)
+	}
+}

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -29,6 +29,8 @@ import (
 	"go.uber.org/atomic"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/grafana/loki/v3/pkg/labelaccess"
+
 	"github.com/grafana/loki/v3/pkg/analytics"
 	"github.com/grafana/loki/v3/pkg/bloombuild"
 	"github.com/grafana/loki/v3/pkg/bloomgateway"
@@ -49,9 +51,9 @@ import (
 	limits_frontend "github.com/grafana/loki/v3/pkg/limits/frontend"
 	limits_frontend_client "github.com/grafana/loki/v3/pkg/limits/frontend/client"
 	"github.com/grafana/loki/v3/pkg/loghttp/push"
+	"github.com/grafana/loki/v3/pkg/loki/codec"
 	"github.com/grafana/loki/v3/pkg/loki/common"
 	"github.com/grafana/loki/v3/pkg/lokifrontend"
-	"github.com/grafana/loki/v3/pkg/lokifrontend/frontend/transport"
 	"github.com/grafana/loki/v3/pkg/pattern"
 	"github.com/grafana/loki/v3/pkg/querier"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange"
@@ -74,6 +76,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/constants"
 	"github.com/grafana/loki/v3/pkg/util/fakeauth"
 	"github.com/grafana/loki/v3/pkg/util/limiter"
+
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	lokiring "github.com/grafana/loki/v3/pkg/util/ring"
 	serverutil "github.com/grafana/loki/v3/pkg/util/server"
@@ -84,6 +87,7 @@ import (
 type Config struct {
 	Target       flagext.StringSliceCSV `yaml:"target,omitempty"`
 	AuthEnabled  bool                   `yaml:"auth_enabled,omitempty"`
+	LBAC         labelaccess.Config     `yaml:"lbac,omitempty" category:"experimental"`
 	HTTPPrefix   string                 `yaml:"http_prefix" doc:"hidden"`
 	BallastBytes int                    `yaml:"ballast_bytes"`
 
@@ -160,6 +164,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 		"Enables authentication through the X-Scope-OrgID header, which must be present if true. "+
 			"If false, the OrgID will always be set to 'fake'.",
 	)
+	c.LBAC.RegisterFlags(f)
 	f.IntVar(&c.BallastBytes, "config.ballast-bytes", 0,
 		"The amount of virtual memory in bytes to reserve as ballast in order to optimize garbage collection. "+
 			"Larger ballasts result in fewer garbage collection passes, reducing CPU overhead at the cost of heap size. "+
@@ -393,12 +398,6 @@ type Frontend interface {
 	CheckReady(_ context.Context) error
 }
 
-// Codec defines methods to encode and decode requests from HTTP, httpgrpc and Protobuf.
-type Codec interface {
-	transport.Codec
-	worker.RequestCodec
-}
-
 // Loki is the root datastructure for Loki.
 type Loki struct {
 	Cfg Config
@@ -465,7 +464,7 @@ type Loki struct {
 	PushParserWrapper  push.RequestParserWrapper
 	HTTPAuthMiddleware middleware.Interface
 
-	Codec   Codec
+	Codec   codec.Codec
 	Metrics *server.Metrics
 
 	UsageTracker push.UsageTracker
@@ -485,11 +484,13 @@ func New(cfg Config) (*Loki, error) {
 	analytics.Edition("oss")
 	loki.setupAuthMiddleware()
 	loki.setupGRPCRecoveryMiddleware()
+
 	if err := loki.setupModuleManager(); err != nil {
 		return nil, err
 	}
 
 	return loki, nil
+
 }
 
 func (t *Loki) setupAuthMiddleware() {
@@ -951,6 +952,13 @@ func (t *Loki) setupModuleManager() error {
 
 	if t.isModuleActive(Ingester) {
 		if err := mm.AddDependency(Analytics, Ring); err != nil {
+			return err
+		}
+	}
+
+	if t.Cfg.LBAC.Enabled {
+		err := t.setupLBAC()
+		if err != nil {
 			return err
 		}
 	}

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -164,6 +164,16 @@ const (
 	Read                         = "read"
 	Write                        = "write"
 	Backend                      = "backend"
+	AuthMiddleware               = "auth-middleware"
+	LabelAccess                  = "label-access"
+	LabelAccessUserIDTransformer = "label-access-user-id-transformer"
+	LabelAccessInterceptors      = "label-access-interceptors"
+	LabelAccessStoreWrapper      = "label-access-store-wrapper"
+	LabelAccessIngesterWrapper   = "label-access-ingester-wrapper"
+	LabelAccessV2Engine          = "label-access-v2-engine"
+	LabelAccessTripperware       = "label-access-tripperware"
+	Filterers                    = "filterers"
+	AuthTripperware              = "auth-tripperware"
 )
 
 const (

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
@@ -110,6 +110,8 @@ type HeadManager struct {
 	shards                 int
 	activeHeads, prevHeads *tenantHeads
 
+	chunkFilter chunk.RequestChunkFilterer
+
 	Index
 
 	wg     sync.WaitGroup
@@ -143,7 +145,11 @@ func NewHeadManager(name string, logger log.Logger, dir string, metrics *Metrics
 			indices = append(indices, m.activeHeads)
 		}
 
-		return NewMultiIndex(IndexSlice(indices)), nil
+		idx := NewMultiIndex(IndexSlice(indices))
+		if m.chunkFilter != nil {
+			idx.SetChunkFilterer(m.chunkFilter)
+		}
+		return idx, nil
 	})
 
 	return m
@@ -246,6 +252,10 @@ func (m *HeadManager) Stop() error {
 	}
 
 	return m.buildTSDBFromHead(m.activeHeads)
+}
+
+func (m *HeadManager) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
+	m.chunkFilter = chunkFilter
 }
 
 func (m *HeadManager) Append(userID string, ls labels.Labels, fprint uint64, chks index.ChunkMetas) error {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
@@ -434,6 +434,42 @@ func Test_HeadManager_QueryAfterRotate(t *testing.T) {
 
 }
 
+func Test_HeadManager_ChunkFilterer(t *testing.T) {
+	now := time.Now()
+	dir := t.TempDir()
+	storeName := "store_2010-10-10"
+	mgr := NewHeadManager(storeName, log.NewNopLogger(), dir, NewMetrics(nil), newNoopTSDBManager(storeName, dir))
+	for _, d := range managerRequiredDirs(storeName, dir) {
+		require.Nil(t, util.EnsureDirectory(d))
+	}
+	require.Nil(t, mgr.Rotate(now))
+
+	user := "tenant1"
+	ls := mustParseLabels(`{foo="bar"}`)
+	chks := []index.ChunkMeta{{MinTime: 1, MaxTime: 10, Checksum: 1}}
+	require.Nil(t, mgr.Append(user, ls, labels.StableHash(ls), chks))
+
+	matchAll := labels.MustNewMatcher(labels.MatchRegexp, "foo", ".+")
+	nextPeriod := time.Now().Add(time.Duration(mgr.period))
+	mgr.tick(nextPeriod) // rotate so data moves to prevHeads, queryable via lazy index
+
+	// Confirm data is reachable via GetChunkRefs before testing Series.
+	refs, err := mgr.GetChunkRefs(context.Background(), user, 0, math.MaxInt64, nil, nil, matchAll)
+	require.Nil(t, err)
+	require.Len(t, refs, 1)
+
+	// Without a filterer, Series returns the appended series.
+	series, err := mgr.Series(context.Background(), user, 0, math.MaxInt64, nil, nil, matchAll)
+	require.Nil(t, err)
+	require.Len(t, series, 1)
+
+	// With a filterAll filterer, Series returns no results.
+	mgr.SetChunkFilterer(&filterAll{})
+	series, err = mgr.Series(context.Background(), user, 0, math.MaxInt64, nil, nil, matchAll)
+	require.Nil(t, err)
+	require.Len(t, series, 0)
+}
+
 // test mgr recover from multiple wals across multiple periods
 func Test_HeadManager_Lifecycle(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
Backport 976379a2d99962e1f55c35e4332b4b4de17ad35e from #21266

---

**What this PR does / why we need it**:

Adds **Label-Based Access Control (LBAC)** to OSS Loki, allowing fine-grained, per-tenant access control to logs based on stream labels. This brings a capability previously only available in GEM/GEL to upstream Loki.

Access policies are carried on read requests via the `X-Prom-Label-Policy` HTTP header. Each header value maps a tenant to a label selector (e.g. `tenant:{namespace="foo", cluster="bar"}`). A tenant may have multiple policies; within a policy all matchers must match (AND), and across policies any match passes (OR). The policies are parsed once at the edge and enforced consistently across the whole read path:

- **Auth middleware** parses the header, injects the policy set into the request context, and propagates it downstream (including over gRPC to ingesters and index gateways).
- **Chunk filterer** (V1 engine) and **stream filterer** (V2 engine) enforce policies in the querier, ingester, and index gateway so only permitted streams/chunks are returned.
- **Query frontend tripperware** mixes the policy-set hash into the cache key (via a user-ID transformer) so cached results never leak across differing access policies, and applies defense-in-depth response filtering for volume queries.
- **Volume queries** have LBAC matchers injected into the stream selector; **aggregated-metrics queries** get a logfmt parser + label filter injected into the query pipeline, since those labels live in the log content rather than as stream labels.

The feature is **experimental and off by default**, gated behind a single config flag:

```yaml
lbac:
  enabled: false   # -lbac.enabled
```

When disabled, none of the LBAC modules or middleware are wired in, so there is no impact on existing deployments.

**Special notes for your reviewer**:

- Covered by unit tests across the package and an end-to-end integration test (`integration/labelaccess_test.go`).

# Test results:
Testing was performed on `loki-dev-001` with logs generated by `send-logs-loki-dev` over 10 streams. and a set of CAPs with label selectors:

- READ_ALL (no label selector)
- READ_DEV `{env="dev"}`
- READ_PROD `{env="prod"}`
- READ_NONE `{env="prod",classification="none"}` `{env="dev"}`
- READ_NOT_PRIVATE `{classification!="private"}`
- READ_REGEX `{env=~"dev|prod"}`

For each CAP, the following queries were executed and the results tabulated

- `{env="dev"}`
- `{env="prod"}`
- `{env=~".+"}`
- `{env=~".+",classification="private"}`
- `{env=~".+",classification="none"}`

  ## Row counts per token × query

  | Token | `{env="dev"}` | `{env="prod"}` | `{env=~".+"}` | `+classification="private"` | `+classification="none"` |
  |---|--:|--:|--:|--:|--:|
  | READ_ALL | 500 | 1500 | 2100 | 900 | 1100 |
  | READ_DEV | 500 | 0 | 500 | 0 | 500 |
  | READ_PROD | 0 | 1500 | 1500 | 900 | 600 |
  | READ_NONE | 500 | 600 | 1100 | 0 | 1100 |
  | READ_NOT_PRIVATE | 500 | 600 | 1200 | 0 | 1100 |
  | READ_REGEX | 500 | 1500 | 2000 | 900 | 1100 |

  ## Breakdown of the `env=~".+"` column

  | Token | dev/none | prod/none | prod/private | staging/(no class) | total |
  |---|--:|--:|--:|--:|--:|
  | READ_ALL | 500 | 600 | 900 | 100 | 2100 |
  | READ_DEV | 500 | 0 | 0 | 0 | 500 |
  | READ_PROD | 0 | 600 | 900 | 0 | 1500 |
  | READ_NONE | 500 | 600 | 0 | 0 | 1100 |
  | READ_NOT_PRIVATE | 500 | 600 | 0 | 100 | 1200 |
  | READ_REGEX | 500 | 600 | 900 | 0 | 2000 |

These totals were all as expected based on the sample logs generated.

The raw log lines were also manually validated.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
