### PR TITLE
feat(distributor): Generalize backfill day to opaque shard and disable Loki time sharding for backfill

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -650,7 +650,10 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 	}
 
 	maybeShardStreams := func(stream logproto.Stream, labels labels.Labels, pushSize int, policy string, shardStreamsCfg shardstreams.Config) {
-		if !shardStreamsCfg.TimeShardingEnabled {
+		// Backfill streams implement time sharding on the client side (via the
+		// constants.BackfillShardLabel), so Loki's own time sharding is disabled for them to avoid
+		// exploding stream cardinality. Rate-based sharding still applies.
+		if !shardStreamsCfg.TimeShardingEnabled || labels.Has(constants.BackfillLabel) {
 			maybeShardByRate(stream, pushSize, policy, shardStreamsCfg)
 			return
 		}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1952,6 +1952,79 @@ func TestDistributor_PushShardStreamsPolicyOverride(t *testing.T) {
 	require.False(t, otherSharded, "non-foo stream should not be time-sharded (tenant default off)")
 }
 
+// TestDistributor_PushBackfillDisablesTimeSharding verifies that streams carrying the internal
+// backfill label are not time-sharded by Loki even when time sharding is enabled, because backfill
+// workers implement time sharding on the client side (via constants.BackfillShardLabel). A regular
+// old stream on the same tenant is still time-sharded.
+func TestDistributor_PushBackfillDisablesTimeSharding(t *testing.T) {
+	limits := &validation.Limits{}
+	flagext.DefaultValues(limits)
+	limits.RejectOldSamples = false // we push intentionally old logs to trigger time sharding
+	limits.ShardStreams.TimeShardingEnabled = true
+	require.NoError(t, limits.Validate())
+
+	// prepare() builds distributors with ingester MaxChunkAge=2h → time-shard length 1h.
+	distributors, ingesters := prepare(t, 1, 3, limits, nil)
+
+	// Logs older than time_sharding_ignore_recent (40m default), spanning two 1h buckets.
+	old := time.Now().Add(-3 * time.Hour)
+	mkReq := func(lbls string) *logproto.PushRequest {
+		return &logproto.PushRequest{Streams: []logproto.Stream{{
+			Labels: lbls,
+			Entries: []logproto.Entry{
+				{Timestamp: old, Line: "a"},
+				{Timestamp: old.Add(time.Hour + time.Minute), Line: "b"},
+			},
+		}}}
+	}
+
+	// A regular old stream (should be time-sharded) and a backfill stream (should not).
+	_, err := distributors[0].Push(ctx, mkReq(`{app="regular"}`))
+	require.NoError(t, err)
+	_, err = distributors[0].Push(ctx, mkReq(fmt.Sprintf(`{app="backfilled", %s="true", %s="shard-1"}`, constants.BackfillLabel, constants.BackfillShardLabel)))
+	require.NoError(t, err)
+
+	streamPushed := func(app string) bool {
+		for i := range ingesters {
+			ingesters[i].mu.Lock()
+			for _, pr := range ingesters[i].pushed {
+				for _, st := range pr.Streams {
+					if strings.Contains(st.Labels, `app="`+app+`"`) {
+						ingesters[i].mu.Unlock()
+						return true
+					}
+				}
+			}
+			ingesters[i].mu.Unlock()
+		}
+		return false
+	}
+	require.Eventually(t, func() bool {
+		return streamPushed("regular") && streamPushed("backfilled")
+	}, time.Second, 10*time.Millisecond, "expected both streams to reach the ingesters")
+
+	regularSharded, backfilledSharded := false, false
+	for i := range ingesters {
+		ingesters[i].mu.Lock()
+		for _, pr := range ingesters[i].pushed {
+			for _, st := range pr.Streams {
+				if !strings.Contains(st.Labels, "__time_shard__") {
+					continue
+				}
+				if strings.Contains(st.Labels, `app="regular"`) {
+					regularSharded = true
+				}
+				if strings.Contains(st.Labels, `app="backfilled"`) {
+					backfilledSharded = true
+				}
+			}
+		}
+		ingesters[i].mu.Unlock()
+	}
+	require.True(t, regularSharded, "regular old stream should be time-sharded")
+	require.False(t, backfilledSharded, "backfill stream should not be time-sharded by Loki")
+}
+
 func TestDistributor_PushIngestionBlocked(t *testing.T) {
 	for _, tc := range []struct {
 		name               string

--- a/pkg/loghttp/push/backfill.go
+++ b/pkg/loghttp/push/backfill.go
@@ -4,46 +4,57 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
+
+	"github.com/prometheus/common/model"
 )
 
-// HTTPHeaderBackfillDayKey is the HTTP header set by a backfill worker to mark a push as backfill
-// data for a given day. When present and valid, Loki adds the internal labels constants.BackfillLabel
-// and constants.BackfillDayLabel to every stream in the request.
-const HTTPHeaderBackfillDayKey = "X-Loki-Backfill-Day"
+// HTTPHeaderBackfillShardKey is the HTTP header set by a backfill worker to mark a push as backfill
+// data. When present and valid, Loki adds the internal labels constants.BackfillLabel and
+// constants.BackfillShardLabel to every stream in the request.
+//
+// The value is opaque to Loki: it may be a uuid, a hash, a time bucket (e.g. "2026-06-10") or any
+// other identifier. Its only purpose is to implement time sharding on the client side by producing
+// an independent stream per value. The client must guarantee that, within a single shard value, all
+// data is at most MaxChunkAge/2 older than the highest log-line timestamp already ingested for that
+// value (otherwise entries are rejected as too far behind).
+const HTTPHeaderBackfillShardKey = "X-Loki-Backfill-Shard"
 
-// backfillDayLayout is the required format for the X-Loki-Backfill-Day header value.
-const backfillDayLayout = "2006-01-02"
+// maxBackfillShardLen bounds the header value so it stays a reasonable stream label value.
+const maxBackfillShardLen = 128
 
-// backfillDayContextKey is used as a key for context values to avoid collisions.
-type backfillDayContextKey int
+// backfillShardContextKey is used as a key for context values to avoid collisions.
+type backfillShardContextKey int
 
-const backfillDayKey backfillDayContextKey = 1
+const backfillShardKey backfillShardContextKey = 1
 
-// ExtractAndValidateBackfillDay reads the X-Loki-Backfill-Day header from r.
+// ExtractAndValidateBackfillShard reads the X-Loki-Backfill-Shard header from r.
 // It returns ("", false, nil) when the header is absent or empty. When the header is set it must be
-// a valid YYYY-MM-DD date; otherwise it returns an error so the push is rejected with HTTP 400.
-func ExtractAndValidateBackfillDay(r *http.Request) (string, bool, error) {
-	day := r.Header.Get(HTTPHeaderBackfillDayKey)
-	if day == "" {
+// a valid, bounded-length Prometheus label value; otherwise it returns an error so the push is
+// rejected with HTTP 400.
+func ExtractAndValidateBackfillShard(r *http.Request) (string, bool, error) {
+	shard := r.Header.Get(HTTPHeaderBackfillShardKey)
+	if shard == "" {
 		return "", false, nil
 	}
-	if _, err := time.Parse(backfillDayLayout, day); err != nil {
-		return "", false, fmt.Errorf("invalid %s header %q: must be a date in YYYY-MM-DD format", HTTPHeaderBackfillDayKey, day)
+	if len(shard) > maxBackfillShardLen {
+		return "", false, fmt.Errorf("invalid %s header: value length %d exceeds limit of %d", HTTPHeaderBackfillShardKey, len(shard), maxBackfillShardLen)
 	}
-	return day, true, nil
+	if !model.LabelValue(shard).IsValid() {
+		return "", false, fmt.Errorf("invalid %s header %q: must be a valid label value", HTTPHeaderBackfillShardKey, shard)
+	}
+	return shard, true, nil
 }
 
-// InjectBackfillDayContext returns a derived context carrying the validated backfill day.
-func InjectBackfillDayContext(ctx context.Context, day string) context.Context {
-	return context.WithValue(ctx, backfillDayKey, day)
+// InjectBackfillShardContext returns a derived context carrying the validated backfill shard.
+func InjectBackfillShardContext(ctx context.Context, shard string) context.Context {
+	return context.WithValue(ctx, backfillShardKey, shard)
 }
 
-// ExtractBackfillDayContext returns the backfill day stored in ctx, or "" if none is set.
-func ExtractBackfillDayContext(ctx context.Context) string {
-	day, ok := ctx.Value(backfillDayKey).(string)
+// ExtractBackfillShardContext returns the backfill shard stored in ctx, or "" if none is set.
+func ExtractBackfillShardContext(ctx context.Context) string {
+	shard, ok := ctx.Value(backfillShardKey).(string)
 	if !ok {
 		return ""
 	}
-	return day
+	return shard
 }

--- a/pkg/loghttp/push/backfill_test.go
+++ b/pkg/loghttp/push/backfill_test.go
@@ -20,54 +20,54 @@ import (
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
 
-const testBackfillDay = "2026-06-10"
+const testBackfillShard = "3f8b1c9a-uuid"
 
-func TestExtractAndValidateBackfillDay(t *testing.T) {
+func TestExtractAndValidateBackfillShard(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
 		setHeader bool
 		value     string
-		wantDay   string
+		wantShard string
 		wantOK    bool
 		wantErr   bool
 	}{
 		{name: "no header"},
 		{name: "empty header", setHeader: true, value: ""},
-		{name: "valid", setHeader: true, value: "2026-06-10", wantDay: "2026-06-10", wantOK: true},
-		{name: "wrong separators", setHeader: true, value: "2026/06/10", wantErr: true},
-		{name: "not a date", setHeader: true, value: "yesterday", wantErr: true},
-		{name: "out of range", setHeader: true, value: "2026-13-40", wantErr: true},
-		{name: "has time component", setHeader: true, value: "2026-06-10T00:00:00Z", wantErr: true},
+		{name: "uuid", setHeader: true, value: "3f8b1c9a-uuid", wantShard: "3f8b1c9a-uuid", wantOK: true},
+		{name: "date bucket", setHeader: true, value: "2026-06-10", wantShard: "2026-06-10", wantOK: true},
+		{name: "arbitrary opaque", setHeader: true, value: "worker-7/bucket=1h", wantShard: "worker-7/bucket=1h", wantOK: true},
+		{name: "too long", setHeader: true, value: strings.Repeat("a", maxBackfillShardLen+1), wantErr: true},
+		{name: "invalid label value", setHeader: true, value: "bad\xffvalue", wantErr: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			r := httptest.NewRequest(http.MethodPost, "/loki/api/v1/push", nil)
 			if tc.setHeader {
-				r.Header.Set(HTTPHeaderBackfillDayKey, tc.value)
+				r.Header.Set(HTTPHeaderBackfillShardKey, tc.value)
 			}
 
-			day, ok, err := ExtractAndValidateBackfillDay(r)
+			shard, ok, err := ExtractAndValidateBackfillShard(r)
 			if tc.wantErr {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), HTTPHeaderBackfillDayKey)
+				require.Contains(t, err.Error(), HTTPHeaderBackfillShardKey)
 				require.False(t, ok)
-				require.Empty(t, day)
+				require.Empty(t, shard)
 				return
 			}
 			require.NoError(t, err)
 			require.Equal(t, tc.wantOK, ok)
-			require.Equal(t, tc.wantDay, day)
+			require.Equal(t, tc.wantShard, shard)
 		})
 	}
 }
 
-func TestBackfillDayContext(t *testing.T) {
-	require.Empty(t, ExtractBackfillDayContext(context.Background()))
+func TestBackfillShardContext(t *testing.T) {
+	require.Empty(t, ExtractBackfillShardContext(context.Background()))
 
-	ctx := InjectBackfillDayContext(context.Background(), testBackfillDay)
-	require.Equal(t, testBackfillDay, ExtractBackfillDayContext(ctx))
+	ctx := InjectBackfillShardContext(context.Background(), testBackfillShard)
+	require.Equal(t, testBackfillShard, ExtractBackfillShardContext(ctx))
 }
 
-func TestParseRequest_BackfillDay(t *testing.T) {
+func TestParseRequest_BackfillShard(t *testing.T) {
 	const lokiBody = `{"streams":[{"stream":{"foo":"bar"},"values":[["1570818238000000000","fizzbuzz"]]}]}`
 
 	parse := func(r *http.Request, parser RequestParser, limits *fakeLimits) (*logproto.PushRequest, error) {
@@ -77,7 +77,7 @@ func TestParseRequest_BackfillDay(t *testing.T) {
 	}
 
 	t.Run("loki: header adds backfill labels to every stream", func(t *testing.T) {
-		req, err := parse(newBackfillLokiRequest(lokiBody, testBackfillDay), ParseLokiRequest, &fakeLimits{enabled: true, labels: []string{"foo"}})
+		req, err := parse(newBackfillLokiRequest(lokiBody, testBackfillShard), ParseLokiRequest, &fakeLimits{enabled: true, labels: []string{"foo"}})
 		require.NoError(t, err)
 		require.Len(t, req.Streams, 1)
 		requireBackfillLabels(t, req.Streams[0].Labels)
@@ -95,14 +95,14 @@ func TestParseRequest_BackfillDay(t *testing.T) {
 	})
 
 	t.Run("malformed header rejects the whole push", func(t *testing.T) {
-		req, err := parse(newBackfillLokiRequest(lokiBody, "06-10-2026"), ParseLokiRequest, &fakeLimits{enabled: true})
+		req, err := parse(newBackfillLokiRequest(lokiBody, "bad\xffvalue"), ParseLokiRequest, &fakeLimits{enabled: true})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), HTTPHeaderBackfillDayKey)
+		require.Contains(t, err.Error(), HTTPHeaderBackfillShardKey)
 		require.Nil(t, req)
 	})
 
 	t.Run("otlp: header adds backfill labels", func(t *testing.T) {
-		req, err := parse(newBackfillOTLPRequest(t, singleResourceLogs("service.name", "service-1"), testBackfillDay), ParseOTLPRequest, &fakeLimits{enabled: true})
+		req, err := parse(newBackfillOTLPRequest(t, singleResourceLogs("service.name", "service-1"), testBackfillShard), ParseOTLPRequest, &fakeLimits{enabled: true})
 		require.NoError(t, err)
 		require.Len(t, req.Streams, 1)
 		requireBackfillLabels(t, req.Streams[0].Labels)
@@ -111,7 +111,7 @@ func TestParseRequest_BackfillDay(t *testing.T) {
 	t.Run("otlp: restrictive tenant config cannot drop backfill labels", func(t *testing.T) {
 		// Service-name discovery is off and the only indexed attribute does not match the resource,
 		// so without injection this stream would carry no index labels at all.
-		req, err := parse(newBackfillOTLPRequest(t, singleResourceLogs("service.name", "service-1"), testBackfillDay), ParseOTLPRequest, &fakeLimits{enabled: false, indexAttributes: []string{"nonexistent"}})
+		req, err := parse(newBackfillOTLPRequest(t, singleResourceLogs("service.name", "service-1"), testBackfillShard), ParseOTLPRequest, &fakeLimits{enabled: false, indexAttributes: []string{"nonexistent"}})
 		require.NoError(t, err)
 		require.Len(t, req.Streams, 1)
 		requireBackfillLabels(t, req.Streams[0].Labels)
@@ -137,7 +137,7 @@ func TestOTLPBackfillLabelsOnCombinedStreams(t *testing.T) {
 
 	stats := NewPushStats()
 	streamResolver := newMockStreamResolver("fake", &fakeLimits{})
-	ctx := InjectBackfillDayContext(context.Background(), testBackfillDay)
+	ctx := InjectBackfillShardContext(context.Background(), testBackfillShard)
 
 	pushReq, err := otlpToLokiPushRequest(ctx, ld, "fake", cfg, nil, []string{}, NewMockTracker(), stats, gokitlog.NewNopLogger(), streamResolver, constants.OTLP)
 	require.NoError(t, err)
@@ -154,23 +154,23 @@ func TestOTLPBackfillLabelsOnCombinedStreams(t *testing.T) {
 	require.Equal(t, 1, nonEmpty, "expected one combined stream carrying the indexed log attribute")
 }
 
-func newBackfillLokiRequest(body, backfillDay string) *http.Request {
+func newBackfillLokiRequest(body, backfillShard string) *http.Request {
 	r := httptest.NewRequest(http.MethodPost, "/loki/api/v1/push", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
-	if backfillDay != "" {
-		r.Header.Set(HTTPHeaderBackfillDayKey, backfillDay)
+	if backfillShard != "" {
+		r.Header.Set(HTTPHeaderBackfillShardKey, backfillShard)
 	}
 	return r
 }
 
-func newBackfillOTLPRequest(t *testing.T, ld plog.Logs, backfillDay string) *http.Request {
+func newBackfillOTLPRequest(t *testing.T, ld plog.Logs, backfillShard string) *http.Request {
 	t.Helper()
 	body, err := (&plog.JSONMarshaler{}).MarshalLogs(ld)
 	require.NoError(t, err)
 	r := httptest.NewRequest(http.MethodPost, "/otlp/v1/logs", bytes.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
-	if backfillDay != "" {
-		r.Header.Set(HTTPHeaderBackfillDayKey, backfillDay)
+	if backfillShard != "" {
+		r.Header.Set(HTTPHeaderBackfillShardKey, backfillShard)
 	}
 	return r
 }
@@ -192,7 +192,7 @@ func requireBackfillLabels(t *testing.T, labelsStr string) {
 	lbs, err := syntax.ParseLabels(labelsStr)
 	require.NoError(t, err, "labels=%s", labelsStr)
 	require.Equal(t, "true", lbs.Get(constants.BackfillLabel), "labels=%s", labelsStr)
-	require.Equal(t, testBackfillDay, lbs.Get(constants.BackfillDayLabel), "labels=%s", labelsStr)
+	require.Equal(t, testBackfillShard, lbs.Get(constants.BackfillShardLabel), "labels=%s", labelsStr)
 }
 
 func requireNoBackfillLabels(t *testing.T, labelsStr string) {
@@ -200,5 +200,5 @@ func requireNoBackfillLabels(t *testing.T, labelsStr string) {
 	lbs, err := syntax.ParseLabels(labelsStr)
 	require.NoError(t, err, "labels=%s", labelsStr)
 	require.False(t, lbs.Has(constants.BackfillLabel), "labels=%s", labelsStr)
-	require.False(t, lbs.Has(constants.BackfillDayLabel), "labels=%s", labelsStr)
+	require.False(t, lbs.Has(constants.BackfillShardLabel), "labels=%s", labelsStr)
 }

--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -156,10 +156,10 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 		logPushRequestStreams = tenantConfigs.LogPushRequestStreams(userID)
 	}
 
-	// If this is a backfill push (X-Loki-Backfill-Day header), every stream gets the internal
+	// If this is a backfill push (X-Loki-Backfill-Shard header), every stream gets the internal
 	// backfill labels added below. Done here (not via OTLP attribute promotion) so a tenant's OTLP
 	// config cannot drop them.
-	backfillDay := ExtractBackfillDayContext(ctx)
+	backfillShard := ExtractBackfillShardContext(ctx)
 
 	mostRecentEntryTimestamp := time.Time{}
 	for i := 0; i < rls.Len(); i++ {
@@ -175,9 +175,9 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 		resourceAttributesAsStructuredMetadata := resResult.StructuredMetadata
 		streamLabels := resResult.StreamLabels
 
-		if backfillDay != "" {
+		if backfillShard != "" {
 			streamLabels[constants.BackfillLabel] = "true"
-			streamLabels[constants.BackfillDayLabel] = model.LabelValue(backfillDay)
+			streamLabels[constants.BackfillShardLabel] = model.LabelValue(backfillShard)
 		}
 
 		var pushedLabels model.LabelSet

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -179,12 +179,12 @@ type Stats struct {
 }
 
 func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, maxDecompressedSize int64, r *http.Request, limits Limits, tenantConfigs *runtime.TenantConfigs, pushRequestParser RequestParser, tracker UsageTracker, streamResolver StreamResolver, presumedAgentIP, format string) (*logproto.PushRequest, *Stats, error) {
-	// If the X-Loki-Backfill-Day header is set, validate it and stash the day in the request context
-	// so the format parsers (Loki and OTLP) add the internal backfill labels to every stream.
-	if day, ok, err := ExtractAndValidateBackfillDay(r); err != nil {
+	// If the X-Loki-Backfill-Shard header is set, validate it and stash the shard in the request
+	// context so the format parsers (Loki and OTLP) add the internal backfill labels to every stream.
+	if shard, ok, err := ExtractAndValidateBackfillShard(r); err != nil {
 		return nil, nil, err
 	} else if ok {
-		r = r.Clone(InjectBackfillDayContext(r.Context(), day))
+		r = r.Clone(InjectBackfillShardContext(r.Context(), shard))
 	}
 
 	req, pushStats, err := pushRequestParser(userID, r, limits, tenantConfigs, maxRecvMsgSize, maxDecompressedSize, tracker, streamResolver, logger)
@@ -426,9 +426,9 @@ func ParseLokiRequest(userID string, r *http.Request, limits Limits, tenantConfi
 		logServiceNameDiscovery = tenantConfigs.LogServiceNameDiscovery(userID)
 	}
 
-	// If this is a backfill push (X-Loki-Backfill-Day header), every stream gets the internal
+	// If this is a backfill push (X-Loki-Backfill-Shard header), every stream gets the internal
 	// backfill labels added below.
-	backfillDay := ExtractBackfillDayContext(r.Context())
+	backfillShard := ExtractBackfillShardContext(r.Context())
 
 	for i := range req.Streams {
 		s := req.Streams[i]
@@ -467,10 +467,10 @@ func ParseLokiRequest(userID string, r *http.Request, limits Limits, tenantConfi
 			lbs = lb.Set(LabelServiceName, serviceName).Labels()
 		}
 
-		if backfillDay != "" {
+		if backfillShard != "" {
 			lbs = labels.NewBuilder(lbs).
 				Set(constants.BackfillLabel, "true").
-				Set(constants.BackfillDayLabel, backfillDay).
+				Set(constants.BackfillShardLabel, backfillShard).
 				Labels()
 		}
 

--- a/pkg/util/constants/internal_streams.go
+++ b/pkg/util/constants/internal_streams.go
@@ -5,10 +5,11 @@ const (
 	AggregatedMetricLabel = "__aggregated_metric__"
 	// PatternLabel is the label added to streams containing detected patterns
 	PatternLabel = "__pattern__"
-	// BackfillLabel marks streams ingested via the backfill path (X-Loki-Backfill-Day header).
+	// BackfillLabel marks streams ingested via the backfill path (X-Loki-Backfill-Shard header).
 	BackfillLabel = "__backfill__"
-	// BackfillDayLabel partitions backfilled streams by the backfill day (YYYY-MM-DD).
-	BackfillDayLabel = "__backfill_day__"
+	// BackfillShardLabel partitions backfilled streams by an arbitrary shard value set by the
+	// client. It implements time sharding on the client side.
+	BackfillShardLabel = "__backfill_shard__"
 	// LogsDrilldownAppName is the app name used to identify requests from Logs Drilldown
 	LogsDrilldownAppName = "grafana-lokiexplore-app"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Generalizes the backfill day into an opaque shard so replay workers own time sharding:
- `X-Loki-Backfill-Day` → `X-Loki-Backfill-Shard`; value is any bounded-length (≤128) label value (uuid/hash/bucket), no longer forced to `YYYY-MM-DD`. Label `__backfill_day__` → `__backfill_shard__`.
- Disables Loki's server-side time sharding for streams carrying `__backfill__`, so client-side bucketing is authoritative and stream cardinality doesn't explode on replay.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.
