### PR TITLE
chore(dashboard): Add more metrics to `Loki / Read Resources`

### DIFF
--- a/production/loki-mixin-compiled/dashboards/loki-reads-resources.json
+++ b/production/loki-mixin-compiled/dashboards/loki-reads-resources.json
@@ -48,6 +48,100 @@
                         },
                         "unit": "short"
                      },
+                     "overrides": [ ]
+                  },
+                  "id": 1,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "count(up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"query-frontend\"})",
+                        "format": "time_series",
+                        "legendFormat": "pods",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Running Pods",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 2,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "sum(\n  increase(kube_pod_container_status_restarts_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"query-frontend\"}[$__rate_interval]) > 0\n  and on(pod)\n  kube_pod_container_status_last_terminated_reason{container=\"query-frontend\", reason=\"OOMKilled\"} == 1\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "OOMs",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "OOMs",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
                      "overrides": [
                         {
                            "matcher": {
@@ -89,7 +183,7 @@
                         }
                      ]
                   },
-                  "id": 1,
+                  "id": 3,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -190,7 +284,7 @@
                         }
                      ]
                   },
-                  "id": 2,
+                  "id": 4,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -201,7 +295,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 4,
+                  "span": 6,
                   "targets": [
                      {
                         "expr": "max by(pod) (container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"query-frontend\"})",
@@ -252,7 +346,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 3,
+                  "id": 5,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -263,7 +357,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 4,
+                  "span": 6,
                   "targets": [
                      {
                         "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/query-frontend\"})",
@@ -290,6 +384,100 @@
             "collapse": false,
             "height": "250px",
             "panels": [
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 6,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "count(up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"query-scheduler\"})",
+                        "format": "time_series",
+                        "legendFormat": "pods",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Running Pods",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 7,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "sum(\n  increase(kube_pod_container_status_restarts_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"query-scheduler\"}[$__rate_interval]) > 0\n  and on(pod)\n  kube_pod_container_status_last_terminated_reason{container=\"query-scheduler\", reason=\"OOMKilled\"} == 1\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "OOMs",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "OOMs",
+                  "type": "timeseries"
+               },
                {
                   "datasource": "$datasource",
                   "fieldConfig": {
@@ -353,7 +541,7 @@
                         }
                      ]
                   },
-                  "id": 4,
+                  "id": 8,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -454,7 +642,7 @@
                         }
                      ]
                   },
-                  "id": 5,
+                  "id": 9,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -465,7 +653,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 4,
+                  "span": 6,
                   "targets": [
                      {
                         "expr": "max by(pod) (container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"query-scheduler\"})",
@@ -516,7 +704,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 6,
+                  "id": 10,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -527,7 +715,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 4,
+                  "span": 6,
                   "targets": [
                      {
                         "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/query-scheduler\"})",
@@ -554,6 +742,100 @@
             "collapse": false,
             "height": "250px",
             "panels": [
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 11,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "count(up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"querier\"})",
+                        "format": "time_series",
+                        "legendFormat": "pods",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Running Pods",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 12,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "sum(\n  increase(kube_pod_container_status_restarts_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"querier\"}[$__rate_interval]) > 0\n  and on(pod)\n  kube_pod_container_status_last_terminated_reason{container=\"querier\", reason=\"OOMKilled\"} == 1\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "OOMs",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "OOMs",
+                  "type": "timeseries"
+               },
                {
                   "datasource": "$datasource",
                   "fieldConfig": {
@@ -617,7 +899,7 @@
                         }
                      ]
                   },
-                  "id": 7,
+                  "id": 13,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -628,7 +910,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "sum by(pod) (rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"querier\"}[$__rate_interval]))",
@@ -718,7 +1000,7 @@
                         }
                      ]
                   },
-                  "id": 8,
+                  "id": 14,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -729,7 +1011,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 6,
                   "targets": [
                      {
                         "expr": "max by(pod) (container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"querier\"})",
@@ -780,7 +1062,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 9,
+                  "id": 15,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -791,7 +1073,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 6,
                   "targets": [
                      {
                         "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/querier\"})",
@@ -830,7 +1112,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 10,
+                  "id": 16,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -841,10 +1123,10 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by(instance, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"querier\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
+                        "expr": "sum by(instance, pod, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"querier\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
                         "format": "time_series",
                         "legendFormat": "{{pod}} - {{device}}",
                         "legendLink": null
@@ -877,7 +1159,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 11,
+                  "id": 17,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -888,10 +1170,10 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by(instance,device) (rate(node_disk_read_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"querier\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
+                        "expr": "sum by(instance, pod, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"querier\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
                         "format": "time_series",
                         "legendFormat": "{{pod}} - {{device}}",
                         "legendLink": null
@@ -924,7 +1206,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 12,
+                  "id": 18,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -935,7 +1217,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*querier.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*querier.*\"})",
@@ -959,6 +1241,100 @@
             "collapse": false,
             "height": "250px",
             "panels": [
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 19,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "count(up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"index-gateway\"})",
+                        "format": "time_series",
+                        "legendFormat": "pods",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Running Pods",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 20,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "sum(\n  increase(kube_pod_container_status_restarts_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"index-gateway\"}[$__rate_interval]) > 0\n  and on(pod)\n  kube_pod_container_status_last_terminated_reason{container=\"index-gateway\", reason=\"OOMKilled\"} == 1\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "OOMs",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "OOMs",
+                  "type": "timeseries"
+               },
                {
                   "datasource": "$datasource",
                   "fieldConfig": {
@@ -1022,7 +1398,7 @@
                         }
                      ]
                   },
-                  "id": 13,
+                  "id": 21,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1033,7 +1409,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "sum by(pod) (rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"index-gateway\"}[$__rate_interval]))",
@@ -1123,7 +1499,7 @@
                         }
                      ]
                   },
-                  "id": 14,
+                  "id": 22,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1134,7 +1510,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 6,
                   "targets": [
                      {
                         "expr": "max by(pod) (container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"index-gateway\"})",
@@ -1185,7 +1561,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 15,
+                  "id": 23,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1196,7 +1572,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 6,
                   "targets": [
                      {
                         "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/index-gateway\"})",
@@ -1235,7 +1611,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 16,
+                  "id": 24,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1246,10 +1622,10 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by(instance, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"index-gateway\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
+                        "expr": "sum by(instance, pod, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"index-gateway\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
                         "format": "time_series",
                         "legendFormat": "{{pod}} - {{device}}",
                         "legendLink": null
@@ -1282,7 +1658,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 17,
+                  "id": 25,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1293,10 +1669,10 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by(instance, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"index-gateway\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
+                        "expr": "sum by(instance, pod, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"index-gateway\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
                         "format": "time_series",
                         "legendFormat": "{{pod}} - {{device}}",
                         "legendLink": null
@@ -1329,7 +1705,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 18,
+                  "id": 26,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1340,7 +1716,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*index-gateway.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*index-gateway.*\"})",
@@ -1364,6 +1740,100 @@
             "collapse": false,
             "height": "250px",
             "panels": [
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 27,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "count(up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"bloom-gateway\"})",
+                        "format": "time_series",
+                        "legendFormat": "pods",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Running Pods",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 28,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "sum(\n  increase(kube_pod_container_status_restarts_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"bloom-gateway\"}[$__rate_interval]) > 0\n  and on(pod)\n  kube_pod_container_status_last_terminated_reason{container=\"bloom-gateway\", reason=\"OOMKilled\"} == 1\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "OOMs",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "OOMs",
+                  "type": "timeseries"
+               },
                {
                   "datasource": "$datasource",
                   "fieldConfig": {
@@ -1427,7 +1897,7 @@
                         }
                      ]
                   },
-                  "id": 19,
+                  "id": 29,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1438,7 +1908,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "sum by(pod) (rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"bloom-gateway\"}[$__rate_interval]))",
@@ -1528,7 +1998,7 @@
                         }
                      ]
                   },
-                  "id": 20,
+                  "id": 30,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1539,7 +2009,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 6,
                   "targets": [
                      {
                         "expr": "max by(pod) (container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"bloom-gateway\"})",
@@ -1590,7 +2060,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 21,
+                  "id": 31,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1601,7 +2071,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 6,
                   "targets": [
                      {
                         "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/bloom-gateway\"})",
@@ -1640,7 +2110,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 22,
+                  "id": 32,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1651,10 +2121,10 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by(instance, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"bloom-gateway\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
+                        "expr": "sum by(instance, pod, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"bloom-gateway\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
                         "format": "time_series",
                         "legendFormat": "{{pod}} - {{device}}",
                         "legendLink": null
@@ -1687,7 +2157,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 23,
+                  "id": 33,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1698,10 +2168,10 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by(instance, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"bloom-gateway\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
+                        "expr": "sum by(instance, pod, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + ignoring(pod) group_right() (label_replace(count by(instance, pod, device) (container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"bloom-gateway\", device!~\".*sda.*\"}), \"device\", \"$1\", \"device\", \"/dev/(.*)\") * 0)\n",
                         "format": "time_series",
                         "legendFormat": "{{pod}} - {{device}}",
                         "legendLink": null
@@ -1734,7 +2204,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 24,
+                  "id": 34,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1745,7 +2215,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "max by(persistentvolumeclaim) (kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*bloom-gateway.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*bloom-gateway.*\"})",
@@ -1769,6 +2239,100 @@
             "collapse": false,
             "height": "250px",
             "panels": [
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 35,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "count(up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"ingester|partition-ingester\"})",
+                        "format": "time_series",
+                        "legendFormat": "pods",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Running Pods",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 36,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "sum(\n  increase(kube_pod_container_status_restarts_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"ingester|partition-ingester\"}[$__rate_interval]) > 0\n  and on(pod)\n  kube_pod_container_status_last_terminated_reason{container=~\"ingester|partition-ingester\", reason=\"OOMKilled\"} == 1\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "OOMs",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "OOMs",
+                  "type": "timeseries"
+               },
                {
                   "datasource": "$datasource",
                   "fieldConfig": {
@@ -1832,7 +2396,7 @@
                         }
                      ]
                   },
-                  "id": 25,
+                  "id": 37,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1933,7 +2497,7 @@
                         }
                      ]
                   },
-                  "id": 26,
+                  "id": 38,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1944,7 +2508,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 4,
+                  "span": 6,
                   "targets": [
                      {
                         "expr": "max by(pod) (container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"ingester|partition-ingester\"})",
@@ -1995,7 +2559,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 27,
+                  "id": 39,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2006,7 +2570,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 4,
+                  "span": 6,
                   "targets": [
                      {
                         "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/(.*ingester|partition-ingester).*\"})",
@@ -2057,7 +2621,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 28,
+                  "id": 40,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2068,16 +2632,63 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by(pod) (loki_prometheus_rule_group_rules{cluster=~\"$cluster\", job=~\"($namespace)/ruler\"}) or sum by(pod) (cortex_prometheus_rule_group_rules{cluster=~\"$cluster\", job=~\"($namespace)/ruler\"})",
+                        "expr": "count(up{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"ruler\"})",
                         "format": "time_series",
-                        "legendFormat": "{{pod}}",
+                        "legendFormat": "pods",
                         "legendLink": null
                      }
                   ],
-                  "title": "Rules",
+                  "title": "Running Pods",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 41,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "sum(\n  increase(kube_pod_container_status_restarts_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"ruler\"}[$__rate_interval]) > 0\n  and on(pod)\n  kube_pod_container_status_last_terminated_reason{container=\"ruler\", reason=\"OOMKilled\"} == 1\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "OOMs",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "OOMs",
                   "type": "timeseries"
                },
                {
@@ -2143,7 +2754,7 @@
                         }
                      ]
                   },
-                  "id": 29,
+                  "id": 42,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2154,7 +2765,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "sum by(pod) (rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"ruler\"}[$__rate_interval]))",
@@ -2244,7 +2855,7 @@
                         }
                      ]
                   },
-                  "id": 30,
+                  "id": 43,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2255,7 +2866,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 6,
                   "targets": [
                      {
                         "expr": "max by(pod) (container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"ruler\"})",
@@ -2306,7 +2917,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 31,
+                  "id": 44,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2317,7 +2928,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 6,
                   "targets": [
                      {
                         "expr": "sum by(pod) (go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", job=~\"($namespace)/ruler\"})",
@@ -2330,6 +2941,53 @@
                   "tooltip": {
                      "sort": 2
                   },
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 10,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 45,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 6,
+                  "targets": [
+                     {
+                        "expr": "sum by(pod) (loki_prometheus_rule_group_rules{cluster=~\"$cluster\", job=~\"($namespace)/ruler\"}) or sum by(pod) (cortex_prometheus_rule_group_rules{cluster=~\"$cluster\", job=~\"($namespace)/ruler\"})",
+                        "format": "time_series",
+                        "legendFormat": "{{pod}}",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Rules",
                   "type": "timeseries"
                }
             ],

--- a/production/loki-mixin/config.libsonnet
+++ b/production/loki-mixin/config.libsonnet
@@ -85,5 +85,23 @@
     meta_monitoring: {
       enabled: false,
     },
+
+    // Enable panels that depend on autoscaler metrics
+    // (loki_autoscaler_min_replicas / loki_autoscaler_max_replicas).
+    autoscaling_metrics: false,
+    // Per-component autoscaling status.
+    // Only consulted when autoscaling_metrics is true.
+    // If true, min and max replicas for the component are shown.
+    // If false, a panel that says "not autoscaled" is shown instead.
+    autoscaled: {
+      gateway: false,  // only when internal_components=true
+      query_frontend: false,
+      query_scheduler: false,
+      querier: false,
+      index_gateway: false,
+      bloom_gateway: false,
+      ingester: false,
+      ruler: false,
+    },
   },
 }

--- a/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
@@ -13,173 +13,275 @@
   then '(.*ingester.*|loki-single-binary)'
   else '(.*ingester|partition-ingester).*',
 
+  // Regex for the "type" label on the autoscaler metric, per component.
+  // Follows the naming convention emitted by the loki-autoscaler exporter.
+  local autoscaler_type = {
+    gateway: 'cortex_gateway(_internal)?',
+    query_frontend: 'query-frontend',
+    query_scheduler: 'query-scheduler',
+    querier: 'querier',
+    index_gateway: 'index-gateway',
+    bloom_gateway: 'bloom-gateway',
+    ingester: '(partition-)?ingester',
+    ruler: 'ruler',
+  },
+
+  local oomKilledPanel(matcher) =
+    $.newQueryPanel('OOMs') +
+    $.queryPanel(
+      |||
+        sum(
+          increase(kube_pod_container_status_restarts_total{%(ns)s, %(m)s}[$__rate_interval]) > 0
+          and on(pod)
+          kube_pod_container_status_last_terminated_reason{%(m)s, reason="OOMKilled"} == 1
+        )
+      ||| % { ns: $.namespaceMatcher(), m: matcher },
+      'OOMs'
+    ),
+
+  local runningPodsPanel(matcher) =
+    $.newQueryPanel('Running Pods') +
+    $.queryPanel(
+      'count(up{%s, %s})' % [$.namespaceMatcher(), matcher],
+      'pods'
+    ),
+
+  local minReplicasPanel(component) =
+    $.panel('Min Replicas') +
+    $.newStatPanel(
+      'sum(loki_autoscaler_min_replicas{%s, type=~"%s"})' % [$.namespaceMatcher(), autoscaler_type[component]],
+      unit='short',
+      decimals=0,
+    ),
+
+  local maxReplicasPanel(component) =
+    $.panel('Max Replicas') +
+    $.newStatPanel(
+      'sum(loki_autoscaler_max_replicas{%s, type=~"%s"})' % [$.namespaceMatcher(), autoscaler_type[component]],
+      unit='short',
+      decimals=0,
+    ),
+
+  local notAutoScaledPanel = {
+    type: 'text',
+    title: 'Autoscaling',
+    options: {
+      mode: 'markdown',
+      content: '### Not auto-scaled',
+    },
+  },
+
+  // Returns the leading panels + spans for a component's row:
+  // - Min/Max Replicas stats when autoscaling_metrics is enabled and the
+  //   component is flagged auto-scaled.
+  // - A "Not auto-scaled" text panel when autoscaling_metrics is enabled
+  //   but the component is flagged not auto-scaled.
+  // - Nothing when autoscaling_metrics is disabled.
+  local autoscalingPanels(component) =
+    if !$._config.autoscaling_metrics then { panels: [], spans: [] }
+    else if $._config.autoscaled[component] then {
+      panels: [minReplicasPanel(component), maxReplicasPanel(component)],
+      spans: [2, 2],
+    }
+    else { panels: [notAutoScaledPanel], spans: [4] },
+
+  local diskWritesPanel(matcher) =
+    $.newQueryPanel('Disk Writes', 'Bps') +
+    $.queryPanel(
+      'sum by(%s, %s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDisk(matcher)],
+      '{{%s}} - {{device}}' % $._config.per_instance_label
+    ) +
+    $.withStacking,
+
+  local diskReadsPanel(matcher) =
+    $.newQueryPanel('Disk Reads', 'Bps') +
+    $.queryPanel(
+      'sum by(%s, %s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $._config.per_instance_label, $.filterNodeDisk(matcher)],
+      '{{%s}} - {{device}}' % $._config.per_instance_label
+    ) +
+    $.withStacking,
+
+  // Override auto-distributed spans with an explicit list. Total span for
+  // each row is 12; sums > 12 wrap to a new visual line, letting a single
+  // (collapsible) row hold multiple visual lines of panels.
+  local withSpans(spans) = {
+    panels: [
+      super.panels[i] { span: spans[i] }
+      for i in std.range(0, std.length(spans) - 1)
+    ],
+  },
+
+  // addPanels chains .addPanel(p) for each panel in the list, returning
+  // the resulting row.
+  local addPanels(row, panels) =
+    std.foldl(function(r, p) r.addPanel(p), panels, row),
+
+  // componentRow builds a per-component row. Panels are packed onto
+  // 12-unit visual lines and wrap onto subsequent lines when the running
+  // total exceeds 12. Layouts:
+  //   autoscaling_metrics off (OSS default):
+  //     Line 1: [RunningPods=4, OOMs=4, CPU=4]
+  //     Line 2: [Memory ws=6, Memory heap=6]
+  //   autoscaling on, component auto-scaled:
+  //     Line 1: [MinReplicas=2, MaxReplicas=2, RunningPods=4, CPU=4]
+  //     Line 2: [OOMs=4, Memory ws=4, Memory heap=4]
+  //   autoscaling on, component not auto-scaled:
+  //     Line 1: [Not-auto-scaled=4, RunningPods=4, CPU=4]
+  //     Line 2: [OOMs=4, Memory ws=4, Memory heap=4]
+  // trailingPanels/trailingSpans are appended after the core panels
+  // (e.g. Disk Writes/Reads/Space, Rules).
+  local componentRow(title, cpuPanel, memoryPanel, goHeapPanel, runningPodsMatcher, oomMatcher, autoscalingComponent, trailingPanels=[], trailingSpans=[]) =
+    local as = autoscalingPanels(autoscalingComponent);
+    local hasAS = std.length(as.panels) > 0;
+    local corePanels =
+      if hasAS then
+        // Autoscaling-on layout: replicas/status on line 1 with RunningPods+CPU;
+        // OOMs + memory on line 2.
+        as.panels + [
+          runningPodsPanel(runningPodsMatcher),
+          cpuPanel,
+          oomKilledPanel(oomMatcher),
+          memoryPanel,
+          goHeapPanel,
+        ]
+      else
+        // Autoscaling-off layout: RunningPods/OOMs/CPU on line 1; memory on line 2.
+        [
+          runningPodsPanel(runningPodsMatcher),
+          oomKilledPanel(oomMatcher),
+          cpuPanel,
+          memoryPanel,
+          goHeapPanel,
+        ];
+    local coreSpans =
+      if hasAS then
+        as.spans + [4, 4, 4, 4, 4]
+      else
+        [4, 4, 4, 6, 6];
+    addPanels($.row(title), corePanels + trailingPanels) + withSpans(coreSpans + trailingSpans),
+
   grafanaDashboards+:: {
     'loki-reads-resources.json':
       ($.dashboard('Loki / Reads Resources', uid='reads-resources'))
       .addCluster()
       .addNamespace()
       .addTag()
+
+      // --- Gateway ---
       .addRowIf(
         $._config.internal_components,
-        $.row('Gateway')
-        .addPanel(
+        componentRow(
+          'Gateway',
           $.containerCPUUsagePanel('CPU', 'cortex-gw(-internal)?'),
-        )
-        .addPanel(
           $.containerMemoryWorkingSetPanel('Memory (workingset)', 'cortex-gw(-internal)?'),
-        )
-        .addPanel(
           $.goHeapInUsePanel('Memory (go heap inuse)', 'cortex-gw(-internal)?'),
+          'container=~"cortex-gw(-internal)?"',
+          'container=~"cortex-gw(-internal)?"',
+          'gateway'
         )
       )
-      .addRow(
-        $.row('Query Frontend')
-        .addPanel(
-          $.containerCPUUsagePanel('CPU', 'query-frontend'),
-        )
-        .addPanel(
-          $.containerMemoryWorkingSetPanel('Memory (workingset)', 'query-frontend'),
-        )
-        .addPanel(
-          $.goHeapInUsePanel('Memory (go heap inuse)', 'query-frontend'),
-        )
-      )
-      .addRow(
-        $.row('Query Scheduler')
-        .addPanel(
-          $.containerCPUUsagePanel('CPU', 'query-scheduler'),
-        )
-        .addPanel(
-          $.containerMemoryWorkingSetPanel('Memory (workingset)', 'query-scheduler'),
-        )
-        .addPanel(
-          $.goHeapInUsePanel('Memory (go heap inuse)', 'query-scheduler'),
-        )
-      )
-      .addRow(
-        $.row('Querier')
-        .addPanel(
-          $.containerCPUUsagePanel('CPU', 'querier'),
-        )
-        .addPanel(
-          $.containerMemoryWorkingSetPanel('Memory (workingset)', 'querier'),
-        )
-        .addPanel(
-          $.goHeapInUsePanel('Memory (go heap inuse)', 'querier'),
-        )
-        .addPanel(
-          $.newQueryPanel('Disk Writes', 'Bps') +
-          $.queryPanel(
-            'sum by(%s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $.filterNodeDiskContainer('querier')],
-            '{{%s}} - {{device}}' % $._config.per_instance_label
-          ) +
-          $.withStacking,
-        )
-        .addPanel(
-          $.newQueryPanel('Disk Reads', 'Bps') +
-          $.queryPanel(
-            'sum by(%s,device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $.filterNodeDiskContainer('querier')],
-            '{{%s}} - {{device}}' % $._config.per_instance_label
-          ) +
-          $.withStacking,
-        )
-        .addPanel(
+
+      // --- Query Frontend ---
+      .addRow(componentRow(
+        'Query Frontend',
+        $.containerCPUUsagePanel('CPU', 'query-frontend'),
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'query-frontend'),
+        $.goHeapInUsePanel('Memory (go heap inuse)', 'query-frontend'),
+        'container="query-frontend"',
+        'container="query-frontend"',
+        'query_frontend'
+      ))
+
+      // --- Query Scheduler ---
+      .addRow(componentRow(
+        'Query Scheduler',
+        $.containerCPUUsagePanel('CPU', 'query-scheduler'),
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'query-scheduler'),
+        $.goHeapInUsePanel('Memory (go heap inuse)', 'query-scheduler'),
+        'container="query-scheduler"',
+        'container="query-scheduler"',
+        'query_scheduler'
+      ))
+
+      // --- Querier ---
+      .addRow(componentRow(
+        'Querier',
+        $.containerCPUUsagePanel('CPU', 'querier'),
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'querier'),
+        $.goHeapInUsePanel('Memory (go heap inuse)', 'querier'),
+        'container="querier"',
+        'container="querier"',
+        'querier',
+        trailingPanels=[
+          diskWritesPanel('container="querier"'),
+          diskReadsPanel('container="querier"'),
           $.containerDiskSpaceUtilizationPanel('Disk Space Utilization', 'querier'),
-        )
-      )
-      // Otherwise we add the index gateway information
-      .addRow(
-        $.row('Index Gateway')
-        .addPanel(
-          $.CPUUsagePanel('CPU', index_gateway_pod_matcher),
-        )
-        .addPanel(
-          $.memoryWorkingSetPanel('Memory (workingset)', index_gateway_pod_matcher),
-        )
-        .addPanel(
-          $.goHeapInUsePanel('Memory (go heap inuse)', index_gateway_job_matcher),
-        )
-        .addPanel(
-          $.newQueryPanel('Disk Writes', 'Bps') +
-          $.queryPanel(
-            'sum by(%s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $.filterNodeDisk(index_gateway_pod_matcher)],
-            '{{%s}} - {{device}}' % $._config.per_instance_label
-          ) +
-          $.withStacking,
-        )
-        .addPanel(
-          $.newQueryPanel('Disk Reads', 'Bps') +
-          $.queryPanel(
-            'sum by(%s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $.filterNodeDisk(index_gateway_pod_matcher)],
-            '{{%s}} - {{device}}' % $._config.per_instance_label
-          ) +
-          $.withStacking,
-        )
-        .addPanel(
+        ],
+        trailingSpans=[4, 4, 4],
+      ))
+
+      // --- Index Gateway ---
+      .addRow(componentRow(
+        'Index Gateway',
+        $.CPUUsagePanel('CPU', index_gateway_pod_matcher),
+        $.memoryWorkingSetPanel('Memory (workingset)', index_gateway_pod_matcher),
+        $.goHeapInUsePanel('Memory (go heap inuse)', index_gateway_job_matcher),
+        index_gateway_pod_matcher,
+        index_gateway_pod_matcher,
+        'index_gateway',
+        trailingPanels=[
+          diskWritesPanel(index_gateway_pod_matcher),
+          diskReadsPanel(index_gateway_pod_matcher),
           $.containerDiskSpaceUtilizationPanel('Disk Space Utilization', index_gateway_job_matcher),
-        )
-      )
-      .addRow(
-        $.row('Bloom Gateway')
-        .addPanel(
-          $.containerCPUUsagePanel('CPU', 'bloom-gateway'),
-        )
-        .addPanel(
-          $.containerMemoryWorkingSetPanel('Memory (workingset)', 'bloom-gateway'),
-        )
-        .addPanel(
-          $.goHeapInUsePanel('Memory (go heap inuse)', 'bloom-gateway'),
-        )
-        .addPanel(
-          $.newQueryPanel('Disk Writes', 'Bps') +
-          $.queryPanel(
-            'sum by(%s, device) (rate(node_disk_written_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $.filterNodeDiskContainer('bloom-gateway')],
-            '{{%s}} - {{device}}' % $._config.per_instance_label
-          ) +
-          $.withStacking,
-        )
-        .addPanel(
-          $.newQueryPanel('Disk Reads', 'Bps') +
-          $.queryPanel(
-            'sum by(%s, device) (rate(node_disk_read_bytes_total[$__rate_interval])) + %s' % [$._config.per_node_label, $.filterNodeDiskContainer('bloom-gateway')],
-            '{{%s}} - {{device}}' % $._config.per_instance_label
-          ) +
-          $.withStacking,
-        )
-        .addPanel(
+        ],
+        trailingSpans=[4, 4, 4],
+      ))
+
+      // --- Bloom Gateway ---
+      .addRow(componentRow(
+        'Bloom Gateway',
+        $.containerCPUUsagePanel('CPU', 'bloom-gateway'),
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'bloom-gateway'),
+        $.goHeapInUsePanel('Memory (go heap inuse)', 'bloom-gateway'),
+        'container="bloom-gateway"',
+        'container="bloom-gateway"',
+        'bloom_gateway',
+        trailingPanels=[
+          diskWritesPanel('container="bloom-gateway"'),
+          diskReadsPanel('container="bloom-gateway"'),
           $.containerDiskSpaceUtilizationPanel('Disk Space Utilization', 'bloom-gateway'),
-        )
-      )
-      .addRow(
-        $.row('Ingester')
-        .addPanel(
-          $.CPUUsagePanel('CPU', ingester_pod_matcher),
-        )
-        .addPanel(
-          $.memoryWorkingSetPanel('Memory (workingset)', ingester_pod_matcher),
-        )
-        .addPanel(
-          $.goHeapInUsePanel('Memory (go heap inuse)', ingester_job_matcher),
-        )
-      )
-      .addRow(
-        $.row('Ruler')
-        .addPanel(
+        ],
+        trailingSpans=[4, 4, 4],
+      ))
+
+      // --- Ingester ---
+      .addRow(componentRow(
+        'Ingester',
+        $.CPUUsagePanel('CPU', ingester_pod_matcher),
+        $.memoryWorkingSetPanel('Memory (workingset)', ingester_pod_matcher),
+        $.goHeapInUsePanel('Memory (go heap inuse)', ingester_job_matcher),
+        ingester_pod_matcher,
+        ingester_pod_matcher,
+        'ingester'
+      ))
+
+      // --- Ruler ---
+      .addRow(componentRow(
+        'Ruler',
+        $.containerCPUUsagePanel('CPU', 'ruler'),
+        $.containerMemoryWorkingSetPanel('Memory (workingset)', 'ruler'),
+        $.goHeapInUsePanel('Memory (go heap inuse)', 'ruler'),
+        'container="ruler"',
+        'container="ruler"',
+        'ruler',
+        trailingPanels=[
           $.newQueryPanel('Rules') +
           $.queryPanel(
             'sum by(%(label)s) (loki_prometheus_rule_group_rules{%(matcher)s}) or sum by(%(label)s) (cortex_prometheus_rule_group_rules{%(matcher)s})' % { label: $._config.per_instance_label, matcher: $.jobMatcher('ruler') },
             '{{%s}}' % $._config.per_instance_label
           ),
-        )
-        .addPanel(
-          $.containerCPUUsagePanel('CPU', 'ruler'),
-        )
-        .addPanel(
-          $.containerMemoryWorkingSetPanel('Memory (workingset)', 'ruler'),
-        )
-        .addPanel(
-          $.goHeapInUsePanel('Memory (go heap inuse)', 'ruler'),
-        )
-      ),
+        ],
+        trailingSpans=[6],
+      )),
   },
 }


### PR DESCRIPTION
Relevant for all users:
- Number of pods per component
- Number of OOMs experienced by each component

Relevant for Grafana Cloud:
- Min/max replicas for each component

I have tested this locally with autoscaling_metrics set to both true and false. 

### Screenshots against a pre-production environment
- This is with internal_components: false and autoscaling_metrics: false

<img width="1263" height="573" alt="image" src="https://github.com/user-attachments/assets/8a955069-0986-4a6a-8da5-ed1dd64c03ee" />
<img width="1263" height="573" alt="image" src="https://github.com/user-attachments/assets/b97e3ac2-bc37-4786-80b4-1e134c47ac59" />
<img width="1263" height="844" alt="image" src="https://github.com/user-attachments/assets/f6db5da6-63c4-4c77-a3bf-f368848e49ca" />
<img width="1263" height="844" alt="image" src="https://github.com/user-attachments/assets/e1fbb472-193c-475d-b40c-8667757dfa9d" />
<img width="1263" height="844" alt="image" src="https://github.com/user-attachments/assets/99a4d029-8a39-44e3-a399-0b4cf1a66ce8" />
<img width="1263" height="570" alt="image" src="https://github.com/user-attachments/assets/ee22a4a7-f801-4a0a-9910-1d2b4bf3ebbc" />
<img width="1263" height="815" alt="image" src="https://github.com/user-attachments/assets/266a0fda-400a-455f-ad4d-2ad11eb19357" />


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
