### PR TITLE
fix(compaction): Improve memory utilization for index compaction workers

### DIFF
--- a/pkg/dataobj/index/indexobj/merge_builder.go
+++ b/pkg/dataobj/index/indexobj/merge_builder.go
@@ -127,7 +127,14 @@ func (b *MergeBuilder) AppendPostingsLabelEntry(tenantID string, entry postings.
 
 	postSize := tenantPostings.EstimatedSize()
 	b.unflushedSizeEstimate += postSize - preSize
-	b.currentSizeEstimate += postSize - preSize
+
+	if postSize > int(b.cfg.TargetSectionSize) {
+		if err := b.builder.Append(tenantPostings); err != nil {
+			return err
+		}
+	}
+
+	b.currentSizeEstimate = b.estimatedSize()
 	b.state = builderStateDirty
 	if b.currentSizeEstimate > int(b.cfg.TargetObjectSize) {
 		b.builderFull = true
@@ -149,7 +156,15 @@ func (b *MergeBuilder) AppendPostingsBloomEntry(tenantID string, entry postings.
 
 	postSize := tenantPostings.EstimatedSize()
 	b.unflushedSizeEstimate += postSize - preSize
-	b.currentSizeEstimate += postSize - preSize
+
+	// Cut a section at the target size; see AppendPostingsLabelEntry.
+	if postSize > int(b.cfg.TargetSectionSize) {
+		if err := b.builder.Append(tenantPostings); err != nil {
+			return err
+		}
+	}
+
+	b.currentSizeEstimate = b.estimatedSize()
 	b.state = builderStateDirty
 	if b.currentSizeEstimate > int(b.cfg.TargetObjectSize) {
 		b.builderFull = true

--- a/pkg/dataobj/index/indexobj/merge_builder_test.go
+++ b/pkg/dataobj/index/indexobj/merge_builder_test.go
@@ -3,6 +3,7 @@ package indexobj
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -230,6 +231,71 @@ func TestMergeBuilder_AppendPostingsBloomEntry(t *testing.T) {
 	require.Equal(t, entry.ColumnName, row.ColumnName)
 	require.Equal(t, entry.BloomFilter, row.BloomFilter)
 	require.Equal(t, entry.StreamIDBitmap, row.StreamIDBitmap)
+}
+
+// TestMergeBuilder_PostingsSpillSectionsAtTargetSize verifies that postings are
+// cut into sections mid-stream once accumulation reaches TargetSectionSize, so
+// the builder never buffers the whole merged output in memory, and that every
+// appended row survives the round-trip across the resulting multiple sections.
+func TestMergeBuilder_PostingsSpillSectionsAtTargetSize(t *testing.T) {
+	b, err := NewMergeBuilder(logsobj.BuilderBaseConfig{
+		TargetPageSize:          2048,
+		MaxPageRows:             10000,
+		TargetObjectSize:        1 << 30, // large: isolate section-cutting from IsFull
+		TargetSectionSize:       1 << 12, // 4 KiB
+		BufferSize:              2048 * 8,
+		SectionStripeMergeLimit: 2,
+	}, nil)
+	require.NoError(t, err)
+
+	// Each entry is ~300 bytes (256-byte bitmap + keys), so 100 entries far
+	// exceed a 4 KiB section and force several mid-stream cuts.
+	const numEntries = 100
+	bitmap := make([]byte, 256)
+	want := make(map[string]struct{}, numEntries)
+	for i := range numEntries {
+		val := fmt.Sprintf("value-%05d", i)
+		want[val] = struct{}{}
+		require.NoError(t, b.AppendPostingsLabelEntry("tenant-1", postings.LabelEntry{
+			ObjectPath:     "/obj",
+			SectionIndex:   0,
+			ColumnName:     "env",
+			LabelValue:     val,
+			StreamIDBitmap: bitmap,
+			MinTimestamp:   int64(i),
+			MaxTimestamp:   int64(i),
+		}))
+	}
+
+	// A section must have been cut before Flush — proof that the builder is not
+	// holding the whole output in memory.
+	require.Greater(t, b.builder.Bytes(), 0, "expected a section to be cut mid-stream")
+
+	obj, closer, err := b.Flush()
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	defer closer.Close()
+
+	// The output spans multiple postings sections...
+	sections := obj.Sections()
+	require.Greater(t, len(sections), 1, "expected multiple postings sections")
+
+	// ...and every appended row survives across them, none lost or duplicated at
+	// the section boundaries.
+	ctx := context.Background()
+	got := make(map[string]struct{}, numEntries)
+	for _, sec := range sections {
+		require.True(t, postings.CheckSection(sec))
+		ps, err := postings.Open(ctx, sec)
+		require.NoError(t, err)
+		for _, row := range readAllPostingsRows(ctx, t, ps) {
+			require.Equal(t, postings.KindLabel, row.Kind)
+			_, dup := got[row.LabelValue]
+			require.False(t, dup, "duplicate row across sections: %s", row.LabelValue)
+			got[row.LabelValue] = struct{}{}
+		}
+	}
+	require.Equal(t, want, got)
 }
 
 // TestMergeBuilder_MultiTenant verifies that the merge builder handles multiple tenants.

--- a/pkg/engine/internal/executor/index_merge.go
+++ b/pkg/engine/internal/executor/index_merge.go
@@ -54,8 +54,8 @@ func (c *Context) doIndexMerge(ctx context.Context, node *physical.IndexMerge) e
 		return nil
 	}
 
-	// Classify sections from all runs
-	postingsSections, statsSections, err := c.classifyRuns(ctx, node)
+	// Classify sections from all runs, grouped by source object.
+	objects, err := c.classifyRuns(ctx, node)
 	if err != nil {
 		return fmt.Errorf("classifying runs: %w", err)
 	}
@@ -67,12 +67,12 @@ func (c *Context) doIndexMerge(ctx context.Context, node *physical.IndexMerge) e
 	}
 
 	// Merge postings sections
-	if err := c.mergePostingsIntoBuilder(ctx, node.Tenant, postingsSections, builder); err != nil {
+	if err := c.mergePostingsIntoBuilder(ctx, node.Tenant, objects, builder); err != nil {
 		return fmt.Errorf("merging postings: %w", err)
 	}
 
 	// Merge stats sections
-	if err := c.mergeStatsIntoBuilder(ctx, node.Tenant, statsSections, builder); err != nil {
+	if err := c.mergeStatsIntoBuilder(ctx, node.Tenant, objects, builder); err != nil {
 		return fmt.Errorf("merging stats: %w", err)
 	}
 
@@ -128,54 +128,48 @@ func (c *Context) outputExists(ctx context.Context, path string) (bool, error) {
 	return true, nil
 }
 
-// classifyRuns scans all sections of each referenced source object and
-// classifies them as postings or stats. Non-mergable section types (streams,
-// pointers, indexPointers) are silently ignored. Validates that all stats
-// sections share the same SortSchema.
-func (c *Context) classifyRuns(ctx context.Context, node *physical.IndexMerge) (
-	postingsSections []runSection,
-	statsSections []runSection,
-	err error,
-) {
+// classifyRuns opens each unique source object once and groups its mergable
+// sections by type (postings, stats), preserving section order within each
+// object. Non-mergable section types (streams, pointers, indexPointers) are
+// silently ignored. It validates that all stats sections share the same SortSchema
+func (c *Context) classifyRuns(ctx context.Context, node *physical.IndexMerge) ([]objectSections, error) {
 	// Deduplicate source objects by path. One object may be referenced by
 	// multiple SectionRefs in the same or different runs; we open and scan it
 	// exactly once.
-	type objectEntry struct {
-		obj    *dataobj.Object
-		runIdx int // first run that referenced this object
-	}
-	objects := make(map[string]*objectEntry)
+	objects := make(map[string]*dataobj.Object)
 
-	for runIdx, runRef := range node.Runs {
+	for _, runRef := range node.Runs {
 		for _, sectionRef := range runRef.Sections {
 			if _, seen := objects[sectionRef.ObjectPath]; seen {
 				continue
 			}
 			obj, openErr := dataobj.FromBucket(ctx, c.bucket, sectionRef.ObjectPath, 0)
 			if openErr != nil {
-				return nil, nil, fmt.Errorf("opening object %q: %w", sectionRef.ObjectPath, openErr)
+				return nil, fmt.Errorf("opening object %q: %w", sectionRef.ObjectPath, openErr)
 			}
-			objects[sectionRef.ObjectPath] = &objectEntry{obj: obj, runIdx: runIdx}
+			objects[sectionRef.ObjectPath] = obj
 		}
 	}
 
-	// For each unique source object, scan all of its sections and classify by
-	// type. Unknown section types (streams, pointers, indexPointers) are
-	// skipped silently — they're not applicable to an index merge.
-	// Iterate in sorted order for deterministic section ordering.
+	// Iterate objects in sorted path order for deterministic output.
 	paths := make([]string, 0, len(objects))
 	for path := range objects {
 		paths = append(paths, path)
 	}
 	sort.Strings(paths)
 
-	// Make sure all stats section have the same sort schema by checking the sort
-	// schema from the first row of each section. Catches misconfigured
-	// cross-tenant merges or upstream schema-evolution bugs.
+	// For each unique source object, scan its sections and classify by type,
+	// preserving section order. Unknown section types (streams, pointers,
+	// indexPointers) are skipped silently. Make sure all stats sections share
+	// the same sort schema (checked from the first row of each). statsSeen
+	// counts stats sections across all objects, for stable error messages.
+	grouped := make([]objectSections, 0, len(paths))
 	var firstSortSchema string
+	statsSeen := 0
 	for _, path := range paths {
-		entry := objects[path]
-		for _, sec := range entry.obj.Sections() {
+		obj := objects[path]
+		group := objectSections{path: path}
+		for _, sec := range obj.Sections() {
 			// Index objects are multi-tenant; only merge sections for the tenant
 			// being compacted, or other tenants' rows leak into this output.
 			if sec.Tenant != node.Tenant {
@@ -183,33 +177,31 @@ func (c *Context) classifyRuns(ctx context.Context, node *physical.IndexMerge) (
 			}
 			switch {
 			case postings.CheckSection(sec):
-				postingsSections = append(postingsSections, runSection{
-					section: sec,
-					runIdx:  entry.runIdx,
-				})
+				group.postings = append(group.postings, sec)
 			case stats.CheckSection(sec):
 				sortSchema, readErr := readStatsSortSchema(ctx, sec)
 				if readErr != nil {
-					return nil, nil, fmt.Errorf("reading stats section %d SortSchema: %w", len(statsSections), readErr)
+					return nil, fmt.Errorf("reading stats section %d SortSchema: %w", statsSeen, readErr)
 				}
-				if len(statsSections) == 0 {
+				if statsSeen == 0 {
 					firstSortSchema = sortSchema
 				} else if sortSchema != firstSortSchema {
-					return nil, nil, fmt.Errorf(
+					return nil, fmt.Errorf(
 						"stats sections have mismatched SortSchema: section 0 has %q, section %d has %q",
-						firstSortSchema, len(statsSections), sortSchema,
+						firstSortSchema, statsSeen, sortSchema,
 					)
 				}
-				statsSections = append(statsSections, runSection{
-					section: sec,
-					runIdx:  entry.runIdx,
-				})
+				statsSeen++
+				group.stats = append(group.stats, sec)
 				// default: skip silently (streams/pointers/indexPointers etc.)
 			}
 		}
+		if len(group.postings) > 0 || len(group.stats) > 0 {
+			grouped = append(grouped, group)
+		}
 	}
 
-	return postingsSections, statsSections, nil
+	return grouped, nil
 }
 
 // readStatsSortSchema opens a stats section and returns the SortSchema from
@@ -231,34 +223,38 @@ func readStatsSortSchema(ctx context.Context, sec *dataobj.Section) (string, err
 	return row.SortSchema, nil
 }
 
-type runSection struct {
-	section *dataobj.Section
-	runIdx  int
+// objectSections holds one source object's mergable sections, split by type and
+// kept in section order. A single object's same-type sections are contiguous,
+// non-overlapping slices of that object's sorted row stream (the section
+// encoders sort every row, then split into sections at size boundaries), so
+// they can be concatenated in section order — see [sectionConcatSeq].
+type objectSections struct {
+	path     string
+	postings []*dataobj.Section
+	stats    []*dataobj.Section
 }
 
-// mergePostingsIntoBuilder merges postings sections using a K-way merge heap and
-// feeds results into the builder.
-func (c *Context) mergePostingsIntoBuilder(ctx context.Context, tenant string, sections []runSection, builder *indexobj.MergeBuilder) error {
-	if len(sections) == 0 {
+// mergePostingsIntoBuilder merges the postings sections of all source objects
+// with a K-way loser-tree merge and feeds the result into the builder.
+func (c *Context) mergePostingsIntoBuilder(ctx context.Context, tenant string, objects []objectSections, builder *indexobj.MergeBuilder) error {
+	readers := make([]sequence[postings.Row], 0, len(objects))
+	for _, obj := range objects {
+		if len(obj.postings) == 0 {
+			continue
+		}
+		readers = append(readers, &sectionConcatSeq[postings.Row]{
+			ctx:        ctx,
+			objectPath: obj.path,
+			sections:   obj.postings,
+			seqIdx:     len(readers),
+			open:       openPostingsReader,
+		})
+	}
+	if len(readers) == 0 {
 		return nil
 	}
 
-	// Open all postings sections and create readers.
-	readers := make([]sequence[postings.Row], 0, len(sections))
-
-	for i, rs := range sections {
-		sec, err := postings.Open(ctx, rs.section)
-		if err != nil {
-			return fmt.Errorf("opening postings section from run %d: %w", rs.runIdx, err)
-		}
-
-		readers = append(readers, indexedSeq[postings.Row]{
-			CloseIterator: postings.NewRowReader(ctx, sec, nil),
-			idx:           i,
-		})
-	}
-
-	// Drive a K-way merge over the readers via a loser tree.
+	// Drive a K-way merge over the per-object sequences via a loser tree.
 	tree := loser.New(
 		readers,
 		heapVal[postings.Row]{isMax: true},
@@ -275,12 +271,12 @@ func (c *Context) mergePostingsIntoBuilder(ctx context.Context, tenant string, s
 
 		row := tree.Winner().At()
 
-		// A collision on the full sort key (Kind, ObjectPath, SectionIndex,
+		// A collision on the identity key (Kind, ObjectPath, SectionIndex,
 		// ColumnName, LabelValue) means two source indexes reference the same
 		// physical section/column/label — this shouldn't happen so log a warning
 		// and emit a metric for tracking. The data is logically equivalent, so
 		// keep the first row and drop the later duplicate.
-		if last != nil && comparePostingsRow(*last, row) == 0 {
+		if last != nil && samePostingsKey(*last, row) {
 			if region := xcap.RegionFromContext(ctx); region != nil {
 				region.Record(statIndexMergeDuplicatePostings.Observe(1))
 			}
@@ -322,29 +318,28 @@ func (c *Context) writePostingsRow(builder *indexobj.MergeBuilder, tenant string
 	}
 }
 
-// mergeStatsIntoBuilder merges stats sections using a K-way merge heap and
-// feeds results into the builder. Uses D3 aggregation with schema/label validation.
-func (c *Context) mergeStatsIntoBuilder(ctx context.Context, tenant string, sections []runSection, builder *indexobj.MergeBuilder) error {
-	if len(sections) == 0 {
+// mergeStatsIntoBuilder merges the stats sections of all source objects with a
+// K-way loser-tree merge and feeds the result into the builder. Uses D3
+// aggregation with schema/label validation.
+func (c *Context) mergeStatsIntoBuilder(ctx context.Context, tenant string, objects []objectSections, builder *indexobj.MergeBuilder) error {
+	readers := make([]sequence[stats.Stat], 0, len(objects))
+	for _, obj := range objects {
+		if len(obj.stats) == 0 {
+			continue
+		}
+		readers = append(readers, &sectionConcatSeq[stats.Stat]{
+			ctx:        ctx,
+			objectPath: obj.path,
+			sections:   obj.stats,
+			seqIdx:     len(readers),
+			open:       openStatsReader,
+		})
+	}
+	if len(readers) == 0 {
 		return nil
 	}
 
-	// Open all stats sections and create readers.
-	readers := make([]sequence[stats.Stat], 0, len(sections))
-
-	for i, rs := range sections {
-		sec, err := stats.Open(ctx, rs.section)
-		if err != nil {
-			return fmt.Errorf("opening stats section from run %d: %w", rs.runIdx, err)
-		}
-
-		readers = append(readers, indexedSeq[stats.Stat]{
-			CloseIterator: stats.NewRowReader(ctx, sec),
-			idx:           i,
-		})
-	}
-
-	// Drive a K-way merge over the readers via a loser tree.
+	// Drive a K-way merge over the per-object sequences via a loser tree.
 	tree := loser.New(
 		readers,
 		heapVal[stats.Stat]{isMax: true},
@@ -398,20 +393,96 @@ func (c *Context) mergeStatsIntoBuilder(ctx context.Context, tenant string, sect
 	return nil
 }
 
-// indexedSeq attaches a stable index to an [iter.CloseIterator] so the
-// loser tree can break ties deterministically. The index must be readable when
-// the tree snapshots each sequence so it travels with
-// the sequence rather than being derived at yield time.
-//
-// indexedSeq satisfies sequence[R] via the embedded iterator (promoting
-// Next/At/Err/Close) plus Index.
-type indexedSeq[R any] struct {
-	iter.CloseIterator[R] // promotes Next/At/Err/Close
-	idx                   int
+// sectionConcatSeq lazily concatenates the row readers of one source object's
+// same-type sections, read in section order, exposing them to the K-way merge
+// as a single sequence[R]. Only one section reader is open at a time, so K such
+// sequences hold K Arrow batches concurrently instead of one batch per section
+// across the whole task — the core of the index-merge memory reduction.
+// sectionConcatSeq satisfies sequence[R] (iter.CloseIterator[R] plus Index).
+type sectionConcatSeq[R any] struct {
+	ctx        context.Context
+	objectPath string // source object path, for error context
+	sections   []*dataobj.Section
+	open       func(context.Context, *dataobj.Section) (iter.CloseIterator[R], error)
+	seqIdx     int
+
+	idx int                   // index of the section currently being read
+	cur iter.CloseIterator[R] // reader for sections[idx-1]; nil until first Next / between sections
+	row R                     // current row, valid after Next returns true
+	err error
 }
 
-// Index returns the iterators index in the merge. Used for stable tiebreak ordering.
-func (s indexedSeq[R]) Index() int { return s.idx }
+// Index returns this sequence's stable index in the merge, for tiebreak ordering.
+func (s *sectionConcatSeq[R]) Index() int { return s.seqIdx }
+
+// At returns the current row. Valid only after Next returns true.
+func (s *sectionConcatSeq[R]) At() R { return s.row }
+
+// Err returns the first error encountered, if any.
+func (s *sectionConcatSeq[R]) Err() error { return s.err }
+
+// Next advances to the next row, transparently opening the next section once the
+// current one is drained. It keeps at most one section reader open at a time.
+// Returns false on exhaustion or on the first error.
+func (s *sectionConcatSeq[R]) Next() bool {
+	for {
+		if s.err != nil {
+			return false
+		}
+		if s.cur == nil {
+			if s.idx >= len(s.sections) {
+				return false
+			}
+			it, err := s.open(s.ctx, s.sections[s.idx])
+			if err != nil {
+				s.err = fmt.Errorf("opening section %d/%d of object %q: %w", s.idx, len(s.sections), s.objectPath, err)
+				return false
+			}
+			s.cur = it
+		}
+		if s.cur.Next() {
+			s.row = s.cur.At()
+			return true
+		}
+		// Current section drained or errored: capture any error, close, advance.
+		err := s.cur.Err()
+		_ = s.cur.Close()
+		s.cur = nil
+		if err != nil {
+			s.err = err
+			return false
+		}
+		s.idx++
+	}
+}
+
+// Close releases the currently open section reader, if any.
+func (s *sectionConcatSeq[R]) Close() error {
+	if s.cur != nil {
+		err := s.cur.Close()
+		s.cur = nil
+		return err
+	}
+	return nil
+}
+
+// openPostingsReader opens a postings section and returns a row iterator over it.
+func openPostingsReader(ctx context.Context, sec *dataobj.Section) (iter.CloseIterator[postings.Row], error) {
+	ps, err := postings.Open(ctx, sec)
+	if err != nil {
+		return nil, err
+	}
+	return postings.NewRowReader(ctx, ps, nil), nil
+}
+
+// openStatsReader opens a stats section and returns a row iterator over it.
+func openStatsReader(ctx context.Context, sec *dataobj.Section) (iter.CloseIterator[stats.Stat], error) {
+	ss, err := stats.Open(ctx, sec)
+	if err != nil {
+		return nil, err
+	}
+	return stats.NewRowReader(ctx, ss), nil
+}
 
 // sequence[R] is one group cursor for the K-way merge. It is an
 // [iter.CloseIterator] (Next/At/Err/Close) extended with Index for stable

--- a/pkg/engine/internal/executor/index_merge_postings.go
+++ b/pkg/engine/internal/executor/index_merge_postings.go
@@ -4,23 +4,13 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
 )
 
-// comparePostingsRow compares two postings rows using the sort order:
-// (Kind, ObjectPath, SectionIndex, ColumnName, LabelValue).
+// comparePostingsRow orders two postings rows in the order they are physically
+// written into, and read back from, a postings section:
+// (Kind, ColumnName, LabelValue, MinTimestamp, MaxTimestamp, ObjectPath,
+// SectionIndex).
 func comparePostingsRow(a, b postings.Row) int {
 	if a.Kind != b.Kind {
 		if a.Kind < b.Kind {
-			return -1
-		}
-		return 1
-	}
-	if a.ObjectPath != b.ObjectPath {
-		if a.ObjectPath < b.ObjectPath {
-			return -1
-		}
-		return 1
-	}
-	if a.SectionIndex != b.SectionIndex {
-		if a.SectionIndex < b.SectionIndex {
 			return -1
 		}
 		return 1
@@ -37,5 +27,45 @@ func comparePostingsRow(a, b postings.Row) int {
 		}
 		return 1
 	}
+	if a.MinTimestamp != b.MinTimestamp {
+		if a.MinTimestamp < b.MinTimestamp {
+			return -1
+		}
+		return 1
+	}
+	if a.MaxTimestamp != b.MaxTimestamp {
+		if a.MaxTimestamp < b.MaxTimestamp {
+			return -1
+		}
+		return 1
+	}
+	if a.ObjectPath != b.ObjectPath {
+		if a.ObjectPath < b.ObjectPath {
+			return -1
+		}
+		return 1
+	}
+	if a.SectionIndex != b.SectionIndex {
+		if a.SectionIndex < b.SectionIndex {
+			return -1
+		}
+		return 1
+	}
 	return 0
+}
+
+// samePostingsKey reports whether two rows share the postings builder's identity
+// key (Kind, ObjectPath, SectionIndex, ColumnName, LabelValue) — the key the
+// index-merge dedup collapses on. It deliberately ignores timestamps and
+// bitmaps: two source objects referencing the same physical section/column/label
+// are the same posting even if those non-key fields differ, and the builder's
+// map is keyed on exactly these fields, so a match here is what would collide.
+// This is separate from comparePostingsRow's ordering because ordering must
+// track physical (timestamp-bearing) storage order while dedup must not.
+func samePostingsKey(a, b postings.Row) bool {
+	return a.Kind == b.Kind &&
+		a.ObjectPath == b.ObjectPath &&
+		a.SectionIndex == b.SectionIndex &&
+		a.ColumnName == b.ColumnName &&
+		a.LabelValue == b.LabelValue
 }

--- a/pkg/engine/internal/executor/index_merge_test.go
+++ b/pkg/engine/internal/executor/index_merge_test.go
@@ -704,9 +704,18 @@ func newTestExecutorContext(t *testing.T, bucket objstore.Bucket) *Context {
 // with the given label observations, then uploads it to the bucket.
 func buildSourcePostingsObject(t *testing.T, bucket objstore.Bucket, tenant, path string, observations []postings.LabelObservation) {
 	t.Helper()
+	buildSourcePostingsObjectSized(t, bucket, tenant, path, math.MaxInt, observations)
+}
+
+// buildSourcePostingsObjectSized is buildSourcePostingsObject with a caller-chosen
+// target section size. A small size splits the postings into multiple sections
+// within the object, which exercises the per-object section concatenation in the
+// merge readers.
+func buildSourcePostingsObjectSized(t *testing.T, bucket objstore.Bucket, tenant, path string, targetSectionSize int, observations []postings.LabelObservation) {
+	t.Helper()
 	ctx := context.Background()
 
-	postingsBuilder := postings.NewBuilder(nil, 0, 0, math.MaxInt)
+	postingsBuilder := postings.NewBuilder(nil, 0, 0, targetSectionSize)
 	postingsBuilder.SetTenant(tenant)
 	for _, obs := range observations {
 		postingsBuilder.ObserveLabelPosting(obs)
@@ -776,6 +785,88 @@ func readPostingsRowsFromBucket(ctx context.Context, t *testing.T, bucket objsto
 	}
 
 	return rows
+}
+
+// readAllPostingsRowsFromBucket reads rows from ALL postings sections of the
+// object, in section order (unlike readPostingsRowsFromBucket, which reads only
+// the first section). Merge output can span multiple postings sections.
+func readAllPostingsRowsFromBucket(ctx context.Context, t *testing.T, bucket objstore.Bucket, path string) []postings.Row {
+	t.Helper()
+
+	obj := openObjectFromBucket(ctx, t, bucket, path)
+
+	var rows []postings.Row
+	for _, s := range obj.Sections() {
+		if !postings.CheckSection(s) {
+			continue
+		}
+		sec, err := postings.Open(ctx, s)
+		require.NoError(t, err)
+		reader := postings.NewRowReader(ctx, sec, nil)
+		for reader.Next() {
+			rows = append(rows, reader.At())
+		}
+		require.NoError(t, reader.Err())
+		require.NoError(t, reader.Close())
+	}
+	return rows
+}
+
+// TestExecuteIndexMerge_StorageOrderConcat verifies that the postings merge
+// orders rows by physical storage order (ColumnName-primary), not by the
+// identity-key order (ObjectPath-primary), and that per-object section
+// concatenation is correct.
+func TestExecuteIndexMerge_StorageOrderConcat(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	ts := time.Unix(0, 100)
+
+	buildSourcePostingsObjectSized(t, bucket, "tenant", "src/a", 1, []postings.LabelObservation{
+		{ObjectPath: "log-B", SectionIndex: 0, ColumnName: "svc", LabelValue: "api", StreamID: 1, Timestamp: ts, UncompressedSize: 10},
+		{ObjectPath: "log-A", SectionIndex: 0, ColumnName: "zone", LabelValue: "us", StreamID: 2, Timestamp: ts, UncompressedSize: 20},
+	})
+	buildSourcePostingsObjectSized(t, bucket, "tenant", "src/b", 1, []postings.LabelObservation{
+		// (log-B, 0, svc, api) duplicates src/a's first row exactly (same ts).
+		{ObjectPath: "log-B", SectionIndex: 0, ColumnName: "svc", LabelValue: "api", StreamID: 1, Timestamp: ts, UncompressedSize: 10},
+		{ObjectPath: "log-A", SectionIndex: 0, ColumnName: "zone", LabelValue: "eu", StreamID: 3, Timestamp: ts, UncompressedSize: 30},
+	})
+
+	outputPath := "output/merged.dat"
+	node := &physical.IndexMerge{
+		NodeID:          ulid.Make(),
+		Tenant:          "tenant",
+		OutputIndexPath: outputPath,
+		Runs: []*compactionv2pb.RunRef{
+			{Sections: []*compactionv2pb.SectionRef{{ObjectPath: "src/a", SectionIndex: 0}}},
+			{Sections: []*compactionv2pb.SectionRef{{ObjectPath: "src/b", SectionIndex: 0}}},
+		},
+	}
+
+	execCtx := newTestExecutorContext(t, bucket)
+	require.NoError(t, execCtx.doIndexMerge(ctx, node))
+
+	rows := readAllPostingsRowsFromBucket(ctx, t, bucket, outputPath)
+
+	// Three unique identity keys; the (log-B, svc, api) duplicate collapsed.
+	require.Len(t, rows, 3)
+
+	// Output is in physical storage order (ColumnName-primary).
+	for i := range len(rows) - 1 {
+		require.Negative(t, comparePostingsRow(rows[i], rows[i+1]),
+			"rows not in storage order at %d: %+v vs %+v", i, rows[i], rows[i+1])
+	}
+
+	// Every expected identity key is present exactly once.
+	type key struct{ obj, col, val string }
+	got := map[key]int{}
+	for _, r := range rows {
+		got[key{r.ObjectPath, r.ColumnName, r.LabelValue}]++
+	}
+	require.Equal(t, map[key]int{
+		{"log-B", "svc", "api"}: 1,
+		{"log-A", "zone", "us"}: 1,
+		{"log-A", "zone", "eu"}: 1,
+	}, got)
 }
 
 // readStatsRowsFromBucket downloads an object from the bucket, finds its


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fixes memory on the dataobj-compaction-workers by reading each index object sections one at a time and merge per-object. 
- Also aligns the merge comparator to the order postings sections are physically stored to fix deduplication problems.
- Postings are cut into sections as per TargetSectionSize on write path