### PR TITLE
chore(build): Build the make container user with the host UID/GID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ define run_in_container
 			fi; \
 		fi))
 
-	@docker build --rm $(OCI_BUILD_ARGS) --build-arg "USER=$(shell whoami)" --build-arg "SRC_DIR=/src/loki" --build-arg "INSTALL_WORKFLOW_DEPS_ARGS=$(INSTALL_WORKFLOW_DEPS_ARGS)" \
+	@docker build --rm $(OCI_BUILD_ARGS) --build-arg "USER=$(shell whoami)" --build-arg "USER_UID=$(shell id -u)" --build-arg "USER_GID=$(shell id -g)" --build-arg "SRC_DIR=/src/loki" --build-arg "INSTALL_WORKFLOW_DEPS_ARGS=$(INSTALL_WORKFLOW_DEPS_ARGS)" \
 		-f loki-build-image/Dockerfile \
 		-t $(MAKEFILE_IMAGE) \
 		.

--- a/loki-build-image/Dockerfile
+++ b/loki-build-image/Dockerfile
@@ -6,6 +6,8 @@ FROM $BUILD_IMAGE
 ARG SRC_DIR=/src/loki
 ARG INSTALL_WORKFLOW_DEPS_ARGS
 ARG USER=loki
+ARG USER_UID=1000
+ARG USER_GID=1000
 
 COPY .github $SRC_DIR/.github
 
@@ -13,7 +15,8 @@ RUN git config --global --add safe.directory $SRC_DIR
 RUN echo "Install dependencies ..."
 RUN $SRC_DIR/.github/vendor/github.com/grafana/loki-release/workflows/install_workflow_dependencies.sh $INSTALL_WORKFLOW_DEPS_ARGS
 
-RUN useradd -ms /bin/bash $USER
+RUN groupadd -o -g $USER_GID $USER \
+ && useradd -o -m -u $USER_UID -g $USER_GID -s /bin/bash $USER
 USER $USER
 
 WORKDIR $SRC_DIR


### PR DESCRIPTION
**What this PR does / why we need it**:

`make` targets that run in the build container (`run_in_container`) run the container as the host user *by name* (`--user $(shell whoami)`), but `loki-build-image` creates that user with `useradd`'s default UID `1000`. On any host where the invoking user's UID isn't `1000`, the container process runs as a UID that doesn't own the bind-mounted source tree and Go caches, so writes fail, e.g.:

```
failed to initialize build cache at /go/cache: mkdir /go/cache/00: permission denied
```

This passes the host UID/GID into the image as build args and creates the build user with them, so the container user matches the host user on any machine. Both args default to `1000`, so the published build image is unchanged.

> **Note:** this only manifests on Linux hosts. On macOS, Docker bind mounts go through the Docker Desktop VM, which maps host file ownership onto the container user rather than enforcing the host UID, so the mismatch is invisible there.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Verified on a Linux host with a non-1000 UID: rebuilt the image with the host UID/GID, then ran a `go build` in the container (mounting source + host-owned Go caches) as `--user $(whoami)` — the build succeeds and cache files are written as the host UID. Default build (no UID args) still produces a user with UID 1000.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`