### PR TITLE
chore(ci): Replace non-breaking space in workflow pin comments

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -9,6 +9,6 @@ jobs:
       id-token: "write"
       pull-requests: "write"
     steps:
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/operator-release-please.yml
+++ b/.github/workflows/operator-release-please.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           github_app: loki-gh-app
 
-      - uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c # v4.3.0
+      - uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c # v4.3.0
         id: release
         with:
           path: operator


### PR DESCRIPTION
The pin comments after two action `uses:` SHAs contained a `U+00A0` non-breaking space instead of a regular ASCII space:

- `.github/workflows/conventional-commits.yml` (`amannn/action-semantic-pull-request` pin)
- `.github/workflows/operator-release-please.yml` (`googleapis/release-please-action` pin)

Self-hosted Renovate flags these as hidden Unicode ("could be an attempt to smuggle text into your codebase, or used to confuse tools like Renovate or LLMs"), which shows up in the repository problems / dependency dashboard for this release branch. `main` is unaffected. This replaces the `U+00A0` with an ASCII space; no functional change.