### PR TITLE
perf(dataobj): Speed up index compaction (O(1) stats size, trim postings bitmaps)

### DIFF
--- a/pkg/dataobj/index/indexobj/merge_builder_test.go
+++ b/pkg/dataobj/index/indexobj/merge_builder_test.go
@@ -110,7 +110,7 @@ func TestMergeBuilder_AppendPostingsLabelEntry(t *testing.T) {
 	ts := int64(1000) // unix nanoseconds
 
 	// Create a valid label entry
-	bitmapBytes := []byte{0x01, 0x00}
+	bitmapBytes := []byte{0x01}
 	entry := postings.LabelEntry{
 		ObjectPath:       "/obj1",
 		SectionIndex:     0,
@@ -188,7 +188,7 @@ func TestMergeBuilder_AppendPostingsBloomEntry(t *testing.T) {
 
 	// Now create the entry
 	ts := int64(500) // unix nanoseconds
-	bitmapBytes := []byte{0x01, 0x00}
+	bitmapBytes := []byte{0x01}
 	entry := postings.BloomEntry{
 		ObjectPath:       "/obj2",
 		SectionIndex:     1,

--- a/pkg/dataobj/sections/postings/builder_test.go
+++ b/pkg/dataobj/sections/postings/builder_test.go
@@ -307,9 +307,12 @@ func TestBuilder_BitmapCorrectness(t *testing.T) {
 	require.True(t, checkBit(bitmaps[0], 7), "bit 7 should be set")
 }
 
-// TestBuilder_BitmapNormalization verifies that bitmaps of different sizes are
-// padded to the same length.
-func TestBuilder_BitmapNormalization(t *testing.T) {
+// TestBuilder_BitmapSizes verifies that each bitmap is stored at its natural
+// length (trailing zero bytes trimmed), not zero-padded to the section's
+// longest bitmap. Readers derive the bit count per row and zero-extend during
+// unions, so variable-length storage is correct and avoids padding every row to
+// the maximum length.
+func TestBuilder_BitmapSizes(t *testing.T) {
 	b := NewBuilder(nil, 0, 0, 1<<20)
 
 	ts := time.Unix(0, 0).UTC()
@@ -325,9 +328,12 @@ func TestBuilder_BitmapNormalization(t *testing.T) {
 	require.Len(t, rows, 2)
 
 	bitmaps := extractBinaryColumn(t, tbl, "stream_id_bitmap.binary")
-	// All bitmaps should be the same length (3 bytes, the maximum for stream ID 23).
-	require.Len(t, bitmaps[0], 3, "short bitmap should be padded to max length")
-	require.Len(t, bitmaps[1], 3, "long bitmap should remain at max length")
+	// Rows are sorted by (kind, column_name, label_value): "a" (stream 0) then
+	// "b" (stream 23). Each keeps its natural byte length.
+	require.Len(t, bitmaps[0], 1, "bitmap for stream ID 0 should be 1 byte")
+	require.Len(t, bitmaps[1], 3, "bitmap for stream ID 23 should be 3 bytes")
+	require.True(t, checkBit(bitmaps[0], 0), "bit 0 should be set for stream 0")
+	require.True(t, checkBit(bitmaps[1], 23), "bit 23 should be set for stream 23")
 }
 
 // TestBuilder_SectionSplitting verifies that a small targetSectionSize causes

--- a/pkg/dataobj/sections/postings/encode_columnar.go
+++ b/pkg/dataobj/sections/postings/encode_columnar.go
@@ -88,6 +88,24 @@ func labelEntrySize(e LabelEntry) int {
 	return 5*8 + len(e.ObjectPath) + len(e.ColumnName) + len(e.LabelValue) + len(e.StreamIDBitmap)
 }
 
+// trimTrailingZeros returns b with trailing zero bytes removed. Stream-ID
+// bitmaps are LSB-encoded, so trailing zero bytes contain no set bits and are
+// semantically insignificant: readers derive the bit count from each row's byte
+// length and zero-extend shorter operands during unions (see scanner.go).
+//
+// The stored column is variable-length BINARY, so trimming is safe and keeps
+// per-row bitmaps at their natural size. Previously every bitmap in a section
+// was zero-padded to the section's longest bitmap, which — when a single hot
+// label matched many streams — allocated and zeroed that maximum length for
+// every row, dominating both compaction CPU and index object size.
+func trimTrailingZeros(b []byte) []byte {
+	n := len(b)
+	for n > 0 && b[n-1] == 0 {
+		n--
+	}
+	return b[:n]
+}
+
 // writeSection encodes a single-kind section (blooms or labels) into a columnar
 // encoder, flushes to w, and returns bytes written. Encoder is reset on return.
 func (p *postingsEncoder) writeSection(w dataobj.SectionWriter, tenant string, blooms []BloomEntry, labels []LabelEntry) (int64, error) {
@@ -179,29 +197,6 @@ func (p *postingsEncoder) encodeColumns(bloomEntries []BloomEntry, labelEntries 
 		return fmt.Errorf("creating max_timestamp column: %w", err)
 	}
 
-	// Compute the max bitmap length across both bloom and label entries for normalization.
-	maxBitmapLen := 0
-	for _, e := range bloomEntries {
-		if len(e.StreamIDBitmap) > maxBitmapLen {
-			maxBitmapLen = len(e.StreamIDBitmap)
-		}
-	}
-	for _, e := range labelEntries {
-		if len(e.StreamIDBitmap) > maxBitmapLen {
-			maxBitmapLen = len(e.StreamIDBitmap)
-		}
-	}
-
-	// normalizeBitmap pads a bitmap to maxBitmapLen.
-	normalizeBitmap := func(b []byte) []byte {
-		if len(b) == maxBitmapLen {
-			return b
-		}
-		padded := make([]byte, maxBitmapLen)
-		copy(padded, b)
-		return padded
-	}
-
 	// Populate column builders: bloom entries first (Kind=0), then label entries (Kind=1).
 	rowIdx := 0
 
@@ -212,7 +207,7 @@ func (p *postingsEncoder) encodeColumns(bloomEntries []BloomEntry, labelEntries 
 		_ = columnNameBuilder.Append(rowIdx, dataset.BinaryValue([]byte(e.ColumnName)))
 		_ = labelValueBuilder.Append(rowIdx, dataset.Value{}) // null for bloom
 		_ = bloomFilterBuilder.Append(rowIdx, dataset.BinaryValue(e.BloomFilter))
-		_ = streamIDBitmapBuilder.Append(rowIdx, dataset.BinaryValue(normalizeBitmap(e.StreamIDBitmap)))
+		_ = streamIDBitmapBuilder.Append(rowIdx, dataset.BinaryValue(trimTrailingZeros(e.StreamIDBitmap)))
 		_ = uncompressedSizeBuilder.Append(rowIdx, dataset.Int64Value(e.UncompressedSize))
 		_ = minTimestampBuilder.Append(rowIdx, dataset.Int64Value(e.MinTimestamp))
 		_ = maxTimestampBuilder.Append(rowIdx, dataset.Int64Value(e.MaxTimestamp))
@@ -226,7 +221,7 @@ func (p *postingsEncoder) encodeColumns(bloomEntries []BloomEntry, labelEntries 
 		_ = columnNameBuilder.Append(rowIdx, dataset.BinaryValue([]byte(e.ColumnName)))
 		_ = labelValueBuilder.Append(rowIdx, dataset.BinaryValue([]byte(e.LabelValue)))
 		_ = bloomFilterBuilder.Append(rowIdx, dataset.Value{}) // null for label
-		_ = streamIDBitmapBuilder.Append(rowIdx, dataset.BinaryValue(normalizeBitmap(e.StreamIDBitmap)))
+		_ = streamIDBitmapBuilder.Append(rowIdx, dataset.BinaryValue(trimTrailingZeros(e.StreamIDBitmap)))
 		_ = uncompressedSizeBuilder.Append(rowIdx, dataset.Int64Value(e.UncompressedSize))
 		_ = minTimestampBuilder.Append(rowIdx, dataset.Int64Value(e.MinTimestamp))
 		_ = maxTimestampBuilder.Append(rowIdx, dataset.Int64Value(e.MaxTimestamp))

--- a/pkg/dataobj/sections/postings/encode_columnar_bench_test.go
+++ b/pkg/dataobj/sections/postings/encode_columnar_bench_test.go
@@ -1,0 +1,65 @@
+package postings
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+)
+
+// discardSectionWriter is a no-op [dataobj.SectionWriter] that counts bytes so
+// benchmarks measure encoding cost without an object builder or I/O.
+type discardSectionWriter struct{}
+
+func (discardSectionWriter) WriteSection(_ *dataobj.WriteSectionOptions, data, metadata []byte) (int64, error) {
+	return int64(len(data) + len(metadata)), nil
+}
+
+// BenchmarkEncodeLabelEntries encodes a section of label postings with a
+// realistic skew in stream-ID bitmap sizes: a few "hot" label values match many
+// streams (large bitmaps) while most match few (tiny bitmaps).
+//
+// The encoder used to zero-pad every row's bitmap to the section's longest
+// bitmap, so a single hot label forced an allocate-and-zero of that maximum
+// length for every row — dominating both compaction CPU (memclr) and index
+// object size. Bitmaps are now stored at their natural length. Run across
+// branches with benchstat; the win shows in both ns/op and B/op.
+func BenchmarkEncodeLabelEntries(b *testing.B) {
+	const (
+		numRows  = 20_000
+		hotEvery = 500 // one hot label per this many rows
+	)
+	hot := bytes.Repeat([]byte{0xFF}, 8<<10) // 8 KiB: a label present in many streams
+	cold := []byte{0x01}                     // a label present in a single stream
+
+	entries := make([]LabelEntry, numRows)
+	for i := range entries {
+		bitmap := cold
+		if i%hotEvery == 0 {
+			bitmap = hot
+		}
+		entries[i] = LabelEntry{
+			ObjectPath:       "logs/tenant/obj",
+			SectionIndex:     0,
+			ColumnName:       "service_name",
+			LabelValue:       fmt.Sprintf("svc-%06d", i),
+			StreamIDBitmap:   bitmap,
+			MinTimestamp:     int64(i),
+			MaxTimestamp:     int64(i) + 1,
+			UncompressedSize: 100,
+		}
+	}
+	sortLabelEntries(entries)
+
+	// Production-like page and section sizing (2KB pages, 2MB sections).
+	enc := newPostingsEncoder(2<<10, 0, 2<<20)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := enc.encodeLabelEntries(discardSectionWriter{}, "tenant", entries); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/dataobj/sections/stats/builder.go
+++ b/pkg/dataobj/sections/stats/builder.go
@@ -22,7 +22,8 @@ type Builder struct {
 	tenant  string
 	encode  SectionEncoder
 
-	rows []Stat
+	rows          []Stat
+	estimatedSize int
 }
 
 // NewBuilder creates a new Builder.
@@ -47,21 +48,24 @@ func (b *Builder) Type() dataobj.SectionType { return sectionType }
 // Append adds a [Stat] row to the builder.
 func (b *Builder) Append(stat Stat) {
 	b.rows = append(b.rows, stat)
+	b.estimatedSize += statSize(stat)
 }
 
 // EstimatedSize returns an estimate of the encoded size of the accumulated
-// rows in bytes. The estimate uses a per-row heuristic:
+// rows in bytes, maintained incrementally by [Builder.Append] (see statSize).
+func (b *Builder) EstimatedSize() int {
+	return b.estimatedSize
+}
+
+// statSize is the per-row size heuristic:
 //   - 5 int64 columns × 8 bytes = 40 bytes (SectionIndex, MinTimestamp, MaxTimestamp, RowCount, UncompressedSize)
 //   - len(ObjectPath) + len(SortSchema) bytes for fixed string columns
 //   - sum of len(k)+len(v) for all entries in Labels
-func (b *Builder) EstimatedSize() int {
-	var total int
-	for _, r := range b.rows {
-		total += 5 * 8 // int64 columns: SectionIndex, MinTimestamp, MaxTimestamp, RowCount, UncompressedSize
-		total += len(r.ObjectPath) + len(r.SortSchema)
-		for k, v := range r.Labels {
-			total += len(k) + len(v)
-		}
+func statSize(r Stat) int {
+	total := 5 * 8
+	total += len(r.ObjectPath) + len(r.SortSchema)
+	for k, v := range r.Labels {
+		total += len(k) + len(v)
 	}
 	return total
 }
@@ -69,6 +73,7 @@ func (b *Builder) EstimatedSize() int {
 // Reset clears all accumulated rows and resets the builder to a fresh state.
 func (b *Builder) Reset() {
 	b.rows = b.rows[:0]
+	b.estimatedSize = 0
 }
 
 // Compare reports the canonical sort order of two [Stat] rows. It returns a

--- a/pkg/dataobj/sections/stats/builder_bench_test.go
+++ b/pkg/dataobj/sections/stats/builder_bench_test.go
@@ -1,0 +1,65 @@
+package stats
+
+import (
+	"fmt"
+	"testing"
+)
+
+// sizeSink prevents the compiler from eliminating the EstimatedSize calls.
+var sizeSink int
+
+// BenchmarkBuilderAppend reproduces how index compaction drives the stats
+// builder. indexobj.MergeBuilder.AppendStat queries EstimatedSize before and
+// after every Append to decide when to cut a section, so the merge performs two
+// EstimatedSize calls per row.
+//
+// EstimatedSize used to recompute its result by walking every accumulated row
+// and every label in each row, making this loop O(n²) in the number of rows —
+// which is why merging a tenant with many stats rows "took ages". It is now
+// maintained incrementally in Append, so each call is O(1). Run across branches
+// with benchstat to see the difference; the per-row-count sub-benchmarks make
+// the quadratic-vs-linear scaling visible on its own.
+func BenchmarkBuilderAppend(b *testing.B) {
+	for _, n := range []int{1_000, 5_000, 20_000} {
+		rows := makeBenchStats(n)
+		b.Run(fmt.Sprintf("rows=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			var sink int
+			for range b.N {
+				bld := NewBuilder(nil, ColumnarSectionEncoder(2048, 0))
+				bld.SetTenant("tenant")
+				for _, r := range rows {
+					// Mirror indexobj.MergeBuilder.AppendStat's pre/post size checks.
+					sink += bld.EstimatedSize()
+					bld.Append(r)
+					sink += bld.EstimatedSize()
+				}
+			}
+			sizeSink = sink
+		})
+	}
+}
+
+// makeBenchStats builds n stats rows with a realistic multi-label sort schema so
+// EstimatedSize's per-row label walk is exercised at a representative width.
+func makeBenchStats(n int) []Stat {
+	rows := make([]Stat, n)
+	for i := range rows {
+		rows[i] = Stat{
+			ObjectPath:   fmt.Sprintf("logs/tenant/obj-%06d", i),
+			SectionIndex: int64(i % 8),
+			SortSchema:   "service_name,namespace,pod",
+			Labels: map[string]string{
+				"service_name": fmt.Sprintf("svc-%d", i%512),
+				"namespace":    fmt.Sprintf("ns-%d", i%32),
+				"pod":          fmt.Sprintf("pod-%d", i),
+			},
+			MinTimestamp:     int64(i),
+			MaxTimestamp:     int64(i) + 1,
+			RowCount:         int64(i),
+			UncompressedSize: int64(i) * 10,
+		}
+	}
+	return rows
+}


### PR DESCRIPTION
## What

Two fixes that make dataobj **index compaction** (`IndexMerge`) much faster. Both live in code shared by the ingester and compactor, so they help ingester indexing too.

## Fix 1: `stats.Builder.EstimatedSize` was O(n²)

`indexobj.MergeBuilder.AppendStat` calls `EstimatedSize` twice per row (to decide when to cut a section). `EstimatedSize` re-walked every accumulated row and label each call, so appending N stats rows was O(n²).

Now the size is tracked incrementally in `Append`/`Reset`, so each call is O(1). No behavior or allocation change.

## Fix 2: postings bitmaps were zero-padded

The postings encoder padded every row's stream-ID bitmap up to the longest bitmap in the section. One hot label with a large bitmap forced an allocate-and-zero of that size for every other row (often 1 byte). This was ~51% of merge CPU (`memclr`) and bloats index objects.

Now each bitmap is trimmed of trailing zero bytes and stored at its natural length.

Why it's safe:
- Trailing zero bytes hold no set bits, so trimming keeps the exact stream-ID set.
- The reader already reads variable-length bitmaps: it takes the bit count from each row's byte length and zero-extends before unions.
- The column is variable-length `BINARY` (same as `object_path`); padding was never required.
- The `stream_id_bitmap` column is only produced and read inside `pkg/dataobj/sections/postings`. Nothing assumes a fixed width.
- Old (padded) and new (trimmed) objects read correctly either way, including mixed in one merge.

## Benchmark comparison

Two self-contained benchmarks are included. Numbers from an Apple M-series.

**`BenchmarkBuilderAppend`** (`pkg/dataobj/sections/stats`) — append N rows with the merge's pre/post size checks:

| rows | before | after | speedup |
|---|--:|--:|--:|
| 1,000 | 40.7 ms | 0.117 ms | ~348× |
| 5,000 | 960.3 ms | 0.424 ms | ~2,260× |
| 20,000 | 14,400 ms | 1.412 ms | ~10,000× |

The `5×` rows → `~24×`/`~15×` time jumps show the O(n²); the fix scales ~linearly. Allocations unchanged.

**`BenchmarkEncodeLabelEntries`** (`pkg/dataobj/sections/postings`) — skewed bitmaps (a few 8 KiB, most 1 byte):

| metric | before | after | improvement |
|---|--:|--:|--:|
| time | 39.3 ms/op | 5.40 ms/op | ~7.3× |
| alloc | 177.9 MB/op | 2.0 MB/op | ~89× |

**End-to-end** (local, against captured tenant-29 indexes: ~278 MiB / 123 objects; not committed): a full `IndexMerge` went from **~191 s → ~33 s (~5.8×)**.

Reproduce:

```
go test ./pkg/dataobj/sections/stats -run '^$' -bench BenchmarkBuilderAppend -benchtime 100x
go test ./pkg/dataobj/sections/postings -run '^$' -bench BenchmarkEncodeLabelEntries -benchtime 50x
```

## Note for reviewers

Fix 2 changes the bytes written for postings sections (fewer trailing zeros). It's compatible both ways per the notes above, but worth a sanity check.

## Tests

`stats`, `postings`, `indexobj`, `executor` pass. `TestBuilder_BitmapNormalization` (asserted padding) becomes `TestBuilder_BitmapSizes` (asserts natural per-row length); two `indexobj` round-trip tests drop a trailing zero byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)