### PR TITLE
fix(engine): Close task streams when workers disconnect 🤖🤖🤖

### DIFF
--- a/pkg/engine/internal/scheduler/scheduler.go
+++ b/pkg/engine/internal/scheduler/scheduler.go
@@ -418,12 +418,16 @@ func (s *Scheduler) changeStreamState(ctx context.Context, n *notifier, target *
 // - Aborts all tasks assigned to the given worker.
 // - Removes the worker from the ready list.
 //
-// If reason is non-nil, tasks that were running normally on the worker are
-// marked as failed with the provided reason.
-//
-// If reason is nil, all tasks are marked as cancelled. Tasks which were pending
-// cancellation will be marked as Canceled regardless of reason.
+// If reason is non-nil, assigned tasks without a cancellation request produce
+// a failed result with the provided reason. If reason is nil, they produce a
+// cancelled result. Tasks with a cancellation request produce a cancelled
+// result regardless of reason.
 func (s *Scheduler) removeWorker(ctx context.Context, worker *workerConn, reason error) {
+	// MarkClosed is synchronized with Assign. Any assignment accepted before
+	// this point is included in assigned; later ownership attempts are refused
+	// and handled by finalizeAssignment.
+	assigned := worker.MarkClosed(reason)
+
 	var n notifier
 	defer n.Notify(ctx)
 
@@ -433,59 +437,67 @@ func (s *Scheduler) removeWorker(ctx context.Context, worker *workerConn, reason
 	assignGuard := s.assignMut.Lock("remove_worker")
 	defer assignGuard.Unlock()
 
-	for _, task := range worker.Assigned() {
-		pendingCancel := task.PendingCancel()
-		worker.Unassign(task)
-
-		// Even though the worker disconnected we still have some stats about
-		// the task that the handler may be interested in.
-		result := workflow.TaskResult{Capture: task.capture}
-		switch {
-		case pendingCancel:
-			// Cancellation had already been requested for this task. Honor that
-			// intent regardless of whether the worker disconnected cleanly or
-			// with an error.
-			result.Outcome = workflow.TaskOutcomeCancelled
-		case reason != nil:
-			result.Outcome = workflow.TaskOutcomeFailed
-			result.Error = reason
-		default:
-			result.Outcome = workflow.TaskOutcomeCancelled
-		}
-
-		if changed, _ := task.SetResult(s.metrics, result); !changed {
-			continue
-		}
-
-		switch result.Outcome {
-		case workflow.TaskOutcomeCancelled:
-			if pendingCancel {
-				// The worker disconnected before confirming a cancellation we
-				// had requested. Record it against the assigned-cancellation
-				// stat to match the disposition that [Scheduler.Cancel] would
-				// have produced had the worker survived long enough to confirm.
-				task.wfRegion.Record(StatCanceledAssignedTasks.Observe(1))
-			}
-			// Otherwise the worker disconnected cleanly with no pending
-			// cancellation request; we have no specific stat for that category
-			// today.
-		case workflow.TaskOutcomeFailed:
-			task.wfRegion.Record(StatFailedTasks.Observe(1))
-		}
-
-		task.RecordTerminalObservations(time.Now())
-
-		// We only need to inform the handler about the result. There's nothing
-		// to send to the owner of the task since the worker has disconnected.
-		n.AddTaskEvent(taskNotification{
-			Handler: task.handler,
-			Task:    task.inner,
-			Result:  result,
-		})
+	for _, task := range assigned {
+		s.recordDisconnectedTaskResult(ctx, &n, worker, task, reason)
 	}
 
 	// Remove the worker from the ready list, if it exists.
 	delete(s.connectedWorkers, worker)
+}
+
+// recordDisconnectedTaskResult records the result of a task whose worker
+// disconnected and closes its sink streams. It must be called while
+// resourcesMut is held.
+func (s *Scheduler) recordDisconnectedTaskResult(ctx context.Context, n *notifier, worker *workerConn, task *task, reason error) {
+	pendingCancel := task.PendingCancel()
+	worker.Unassign(task)
+
+	// Even though the worker disconnected we still have some stats about the
+	// task that the handler may be interested in.
+	result := workflow.TaskResult{Capture: task.capture}
+	switch {
+	case pendingCancel:
+		// Cancellation had already been requested for this task. Honor that
+		// intent regardless of whether the worker disconnected cleanly or
+		// with an error.
+		result.Outcome = workflow.TaskOutcomeCancelled
+	case reason != nil:
+		result.Outcome = workflow.TaskOutcomeFailed
+		result.Error = reason
+	default:
+		result.Outcome = workflow.TaskOutcomeCancelled
+	}
+
+	changed, _ := task.SetResult(s.metrics, result)
+	if !changed {
+		return
+	}
+	s.closeTaskSinks(ctx, n, task)
+
+	switch result.Outcome {
+	case workflow.TaskOutcomeCancelled:
+		if pendingCancel {
+			// The worker disconnected before confirming a cancellation we
+			// had requested. Record it against the assigned-cancellation
+			// stat to match the disposition that [Scheduler.Cancel] would
+			// have produced had the worker survived long enough to confirm.
+			task.wfRegion.Record(StatCanceledAssignedTasks.Observe(1))
+		}
+		// Otherwise the worker disconnected cleanly with no pending
+		// cancellation request; we have no specific stat for that category
+		// today.
+	case workflow.TaskOutcomeFailed:
+		task.wfRegion.Record(StatFailedTasks.Observe(1))
+	}
+
+	task.RecordTerminalObservations(time.Now())
+
+	// The worker is disconnected, so only the workflow handler is notified.
+	n.AddTaskEvent(taskNotification{
+		Handler: task.handler,
+		Task:    task.inner,
+		Result:  result,
+	})
 }
 
 func (s *Scheduler) runAssignLoop(ctx context.Context) error {
@@ -716,7 +728,11 @@ type pendingMessage struct {
 // finalizeAssignment completes the assignment of the task to the worker.
 func (s *Scheduler) finalizeAssignment(ctx context.Context, t *task, worker *workerConn, sentStates map[ulid.ULID]workflow.StreamState) {
 	hop := s.metrics.startAssignmentHop("finalize_assignment")
-	var pendingMsgs []pendingMessage
+	var (
+		n           notifier
+		pendingMsgs []pendingMessage
+	)
+	defer n.Notify(ctx)
 
 	// Collect bookkeeping and messages under lock.
 	func() {
@@ -734,7 +750,10 @@ func (s *Scheduler) finalizeAssignment(ctx context.Context, t *task, worker *wor
 			return
 		}
 
-		worker.Assign(t)
+		if !worker.Assign(t) {
+			s.recordDisconnectedTaskResult(ctx, &n, worker, t, worker.CloseReason())
+			return
+		}
 		s.metrics.tasksAssignedTotal.Inc()
 
 		if t.wfRegion != nil {

--- a/pkg/engine/internal/scheduler/scheduler_test.go
+++ b/pkg/engine/internal/scheduler/scheduler_test.go
@@ -650,15 +650,20 @@ func TestScheduler_worker(t *testing.T) {
 		}
 	})
 
-	t.Run("Owned tasks are canceled upon connection loss", func(t *testing.T) {
+	t.Run("Owned tasks and their sinks terminate upon connection loss", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			var taskResult atomic.Pointer[workflow.TaskResult]
-			handler := func(_ context.Context, _ *workflow.Task, result workflow.TaskResult) {
-				taskResult.Store(&result)
+			taskResults := make(chan workflow.TaskResult, 1)
+			streamClosed := make(chan struct{}, 1)
+			taskHandler := func(_ context.Context, _ *workflow.Task, result workflow.TaskResult) {
+				taskResults <- result
+			}
+			streamHandler := func(_ context.Context, _ *workflow.Stream, state workflow.StreamState) {
+				if state == workflow.StreamStateClosed {
+					streamClosed <- struct{}{}
+				}
 			}
 
 			sched := newTestScheduler(t)
-
 			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 			defer cancel()
 
@@ -666,7 +671,6 @@ func TestScheduler_worker(t *testing.T) {
 			require.NoError(t, err)
 
 			messages := make(chan wire.Message, 10)
-
 			peer := wire.Peer{
 				Logger:  log.NewNopLogger(),
 				Metrics: wire.NewMetrics(),
@@ -681,47 +685,57 @@ func TestScheduler_worker(t *testing.T) {
 			}
 			go func() { _ = peer.Serve(ctx) }()
 
-			// Send a ready message so we get a task as soon as we create one.
-			require.NoError(t, peer.SendMessage(ctx, wire.WorkerHelloMessage{Threads: 1}), "Scheduler should accept hello message")
-			require.NoError(t, peer.SendMessage(ctx, wire.WorkerReadyMessage{}), "Scheduler should accept ready message")
+			require.NoError(t, peer.SendMessage(ctx, wire.WorkerHelloMessage{Threads: 1}))
+			require.NoError(t, peer.SendMessage(ctx, wire.WorkerReadyMessage{}))
 
-			var (
-				exampleTask = &workflow.Task{ULID: ulid.Make()}
-				manifest    = &workflow.Manifest{
-					Tasks:              []*workflow.Task{exampleTask},
-					StreamEventHandler: nopStreamHandler,
-					TaskResultHandler:  handler,
-				}
-			)
-			require.NoError(t, sched.RegisterManifest(t.Context(), manifest), "Scheduler should accept valid manifest")
-			require.NoError(t, sched.Start(t.Context(), exampleTask), "Scheduler should start registered task")
+			stream := &workflow.Stream{ULID: ulid.Make()}
+			exampleTask := &workflow.Task{
+				ULID:  ulid.Make(),
+				Sinks: map[physical.Node][]*workflow.Stream{nil: {stream}},
+			}
+			manifest := &workflow.Manifest{
+				Streams:            []*workflow.Stream{stream},
+				Tasks:              []*workflow.Task{exampleTask},
+				StreamEventHandler: streamHandler,
+				TaskResultHandler:  taskHandler,
+			}
+			require.NoError(t, sched.RegisterManifest(t.Context(), manifest))
+			require.NoError(t, sched.Start(t.Context(), exampleTask))
 
-			// Wait for assignment.
 		WaitAssign:
 			for {
 				select {
 				case <-ctx.Done():
-					require.Fail(t, "time out before receiving expected message")
+					t.Fatal("timed out waiting for assignment")
 				case msg := <-messages:
-					switch msg := msg.(type) {
+					switch msg.(type) {
 					case wire.WorkerSubscribeMessage:
-						continue // Ignore; we already sent WorkerReady
+						continue
 					case wire.TaskAssignMessage:
 						break WaitAssign
 					default:
-						require.Fail(t, "Unexpected message type", "Unexpected message type %T", msg)
+						t.Fatalf("unexpected message type %T", msg)
 					}
 				}
 			}
 
 			synctest.Wait()
 			guard := sched.resourcesMut.RLock("test_wait_assignment_owner")
-			require.NotNil(t, sched.tasks[exampleTask.ULID].owner, "assignment ownership should be installed after ACK")
+			require.NotNil(t, sched.tasks[exampleTask.ULID].owner)
 			guard.RUnlock()
 
-			require.NoError(t, conn.Close(), "Closing connection should succeed")
-			synctest.Wait()
-			require.True(t, taskResult.Load().Outcome.Valid(), "owned task should produce a terminal result")
+			require.NoError(t, conn.Close())
+			select {
+			case <-ctx.Done():
+				t.Fatal("timed out waiting for disconnected task result")
+			case result := <-taskResults:
+				require.True(t, result.Outcome.Valid())
+			}
+			select {
+			case <-ctx.Done():
+				t.Fatal("timed out waiting for disconnected task sink closure")
+			case <-streamClosed:
+			}
 		})
 	})
 
@@ -1397,6 +1411,49 @@ func TestScheduler_worker(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestScheduler_DisconnectAfterAssignmentAckBeforeFinalize(t *testing.T) {
+	var (
+		result       workflow.TaskResult
+		streamClosed bool
+	)
+	taskHandler := func(_ context.Context, _ *workflow.Task, taskResult workflow.TaskResult) {
+		result = taskResult
+	}
+	streamHandler := func(_ context.Context, _ *workflow.Stream, state workflow.StreamState) {
+		streamClosed = state == workflow.StreamStateClosed
+	}
+
+	sched := newTestScheduler(t)
+	stream := &workflow.Stream{ULID: ulid.Make()}
+	workflowTask := &workflow.Task{
+		ULID:  ulid.Make(),
+		Sinks: map[physical.Node][]*workflow.Stream{nil: {stream}},
+	}
+	manifest := &workflow.Manifest{
+		Streams:            []*workflow.Stream{stream},
+		Tasks:              []*workflow.Task{workflowTask},
+		StreamEventHandler: streamHandler,
+		TaskResultHandler:  taskHandler,
+	}
+	require.NoError(t, sched.RegisterManifest(t.Context(), manifest))
+	require.NoError(t, sched.Start(t.Context(), workflowTask))
+
+	tracked, err := sched.findTasks([]*workflow.Task{workflowTask})
+	require.NoError(t, err)
+	require.NoError(t, tracked[0].TryAssign(func() error { return nil }), "worker should accept assignment")
+
+	// The connection closes after the assignment ACK records assignTime, but
+	// before finalizeAssignment can install ownership.
+	var worker workerConn
+	worker.MarkClosed(context.Canceled)
+	sched.finalizeAssignment(t.Context(), tracked[0], &worker, nil)
+
+	require.Equal(t, workflow.TaskOutcomeFailed, result.Outcome)
+	require.ErrorIs(t, result.Error, context.Canceled)
+	require.True(t, streamClosed, "task sinks should close when finalization observes a disconnected worker")
+	require.Nil(t, tracked[0].owner, "disconnected worker must not gain task ownership")
 }
 
 func TestScheduler_assignmentMetricsUseBoundedLabels(t *testing.T) {

--- a/pkg/engine/internal/scheduler/worker_conn.go
+++ b/pkg/engine/internal/scheduler/worker_conn.go
@@ -72,6 +72,12 @@ type workerConn struct {
 	// tasks hold the collection of tasks currently assigned to the worker.
 	tasks map[*task]struct{}
 
+	// closed prevents accepted tasks from being assigned after removeWorker has
+	// snapshotted this connection's tasks. closeReason is the connection error,
+	// if any.
+	closed      bool
+	closeReason error
+
 	// done is closed when the worker connection is closed. It is used to signal
 	// worker goroutines to exit.
 	done chan struct{}
@@ -140,18 +146,38 @@ func (wc *workerConn) MarkDataPlane() error {
 	return nil
 }
 
-// Assigned returns a copy of the assigned tasks in an undefined order.
-func (wc *workerConn) Assigned() []*task {
-	wc.mut.RLock()
-	defer wc.mut.RUnlock()
+// MarkClosed marks the worker connection closed and returns a snapshot of its
+// assigned tasks. Assign and MarkClosed share the same mutex: either Assign
+// installs ownership before this snapshot, or it observes the closed fact and
+// refuses ownership.
+func (wc *workerConn) MarkClosed(reason error) []*task {
+	wc.mut.Lock()
+	defer wc.mut.Unlock()
 
+	if !wc.closed {
+		wc.closed = true
+		wc.closeReason = reason
+	}
 	return slices.Collect(maps.Keys(wc.tasks))
 }
 
-// Assign assigns a task to the worker.
-func (wc *workerConn) Assign(assigned *task) {
+// CloseReason returns the reason the worker connection closed, if any.
+func (wc *workerConn) CloseReason() error {
+	wc.mut.RLock()
+	defer wc.mut.RUnlock()
+
+	return wc.closeReason
+}
+
+// Assign assigns a task to the worker. It returns false if the worker connection
+// has already closed.
+func (wc *workerConn) Assign(assigned *task) bool {
 	wc.mut.Lock()
 	defer wc.mut.Unlock()
+
+	if wc.closed {
+		return false
+	}
 
 	assigned.owner = wc
 
@@ -159,6 +185,7 @@ func (wc *workerConn) Assign(assigned *task) {
 		wc.tasks = make(map[*task]struct{})
 	}
 	wc.tasks[assigned] = struct{}{}
+	return true
 }
 
 // Unassign removes a task from the worker.


### PR DESCRIPTION
When a worker disconnects, the scheduler records terminal task results but can leave the task's sink streams open, which can strand receivers waiting for input. This closes those sinks as part of disconnect cleanup. It also makes assignment and connection closure atomic at the worker boundary, so a task accepted just before disconnect is either included in cleanup or rejected during finalization.
