### PR TITLE
chore(dataset/layout): Add Struct layout

### DIFF
--- a/pkg/columnar/scalar.go
+++ b/pkg/columnar/scalar.go
@@ -1,0 +1,66 @@
+package columnar
+
+import (
+	"fmt"
+
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// Broadcast returns an Array containing length copies of scalar.
+// Broadcast panics if length is negative.
+func Broadcast(alloc *memory.Allocator, scalar Scalar, length int) Array {
+	if length < 0 {
+		panic("length must be non-negative")
+	}
+
+	switch scalar := scalar.(type) {
+	case *NullScalar:
+		builder := NewNullBuilder(alloc)
+		builder.AppendNulls(length)
+		return builder.Build()
+
+	case *BoolScalar:
+		builder := NewBoolBuilder(alloc)
+		if scalar.Null {
+			builder.AppendNulls(length)
+		} else {
+			builder.AppendValueCount(scalar.Value, length)
+		}
+		return builder.Build()
+
+	case *NumberScalar[int32]:
+		return makeNumberArrayFromScalar(alloc, scalar, length)
+	case *NumberScalar[int64]:
+		return makeNumberArrayFromScalar(alloc, scalar, length)
+	case *NumberScalar[uint32]:
+		return makeNumberArrayFromScalar(alloc, scalar, length)
+	case *NumberScalar[uint64]:
+		return makeNumberArrayFromScalar(alloc, scalar, length)
+
+	case *UTF8Scalar:
+		builder := NewUTF8Builder(alloc)
+		if scalar.Null {
+			builder.AppendNulls(length)
+		} else {
+			builder.Grow(length)
+			builder.GrowData(len(scalar.Value) * length)
+			for range length {
+				builder.AppendValue(scalar.Value)
+			}
+		}
+		return builder.Build()
+
+	default:
+		panic(fmt.Sprintf("unexpected scalar type %T", scalar))
+	}
+}
+
+func makeNumberArrayFromScalar[T Numeric](alloc *memory.Allocator, scalar *NumberScalar[T], length int) *Number[T] {
+	builder := NewNumberBuilder[T](alloc)
+	if scalar.Null {
+		builder.AppendNulls(length)
+	} else {
+		builder.AppendValueCount(scalar.Value, length)
+	}
+	return builder.Build()
+}

--- a/pkg/columnar/scalar_test.go
+++ b/pkg/columnar/scalar_test.go
@@ -1,0 +1,42 @@
+package columnar_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestBroadcast(t *testing.T) {
+	var alloc memory.Allocator
+
+	tests := []struct {
+		name   string
+		scalar columnar.Scalar
+		expect columnar.Array
+	}{
+		{"null", &columnar.NullScalar{}, columnartest.Array(t, types.KindNull, &alloc, nil, nil, nil)},
+		{"bool", &columnar.BoolScalar{Value: true}, columnartest.Array(t, types.KindBool, &alloc, true, true, true)},
+		{"int32", &columnar.NumberScalar[int32]{Value: 1}, columnartest.Array(t, types.KindInt32, &alloc, int32(1), int32(1), int32(1))},
+		{"int64", &columnar.NumberScalar[int64]{Value: 2}, columnartest.Array(t, types.KindInt64, &alloc, int64(2), int64(2), int64(2))},
+		{"uint32", &columnar.NumberScalar[uint32]{Value: 3}, columnartest.Array(t, types.KindUint32, &alloc, uint32(3), uint32(3), uint32(3))},
+		{"uint64", &columnar.NumberScalar[uint64]{Value: 4}, columnartest.Array(t, types.KindUint64, &alloc, uint64(4), uint64(4), uint64(4))},
+		{"utf8", &columnar.UTF8Scalar{Value: []byte("value")}, columnartest.Array(t, types.KindUTF8, &alloc, "value", "value", "value")},
+		{"typed null", &columnar.NumberScalar[int64]{Null: true}, columnartest.Array(t, types.KindInt64, &alloc, nil, nil, nil)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := columnar.Broadcast(&alloc, test.scalar, 3)
+			columnartest.RequireArraysEqual(t, test.expect, actual, memory.Bitmap{})
+		})
+	}
+
+	t.Run("zero length", func(t *testing.T) {
+		actual := columnar.Broadcast(&alloc, &columnar.UTF8Scalar{Value: []byte("value")}, 0)
+		require.Zero(t, actual.Len())
+	})
+}

--- a/pkg/compute/nulls.go
+++ b/pkg/compute/nulls.go
@@ -1,0 +1,51 @@
+package compute
+
+import (
+	"fmt"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// PropagateNulls returns a shallow copy of input whose validity is intersected
+// with validity. Input must be an Array. The returned Array shares its value
+// buffers with input.
+func PropagateNulls(alloc *memory.Allocator, input columnar.Datum, validity memory.Bitmap) (columnar.Datum, error) {
+	arr, ok := input.(columnar.Array)
+	if !ok {
+		return nil, fmt.Errorf("PropagateNulls requires an Array input, got %T", input)
+	}
+	if validity.Len() != 0 && validity.Len() != arr.Len() {
+		return nil, fmt.Errorf("validity bitmap length mismatch: %d != %d", validity.Len(), arr.Len())
+	}
+
+	resultValidity, err := computeValidityAA(alloc, arr.Validity(), validity)
+	if err != nil {
+		return nil, err
+	}
+
+	switch input := arr.(type) {
+	case *columnar.Null:
+		return columnar.NewNull(resultValidity), nil
+	case *columnar.Bool:
+		return columnar.NewBool(input.Values(), resultValidity), nil
+	case *columnar.Number[int32]:
+		return columnar.NewNumber(input.Values(), resultValidity), nil
+	case *columnar.Number[int64]:
+		return columnar.NewNumber(input.Values(), resultValidity), nil
+	case *columnar.Number[uint32]:
+		return columnar.NewNumber(input.Values(), resultValidity), nil
+	case *columnar.Number[uint64]:
+		return columnar.NewNumber(input.Values(), resultValidity), nil
+	case *columnar.UTF8:
+		return columnar.NewUTF8(input.Data(), input.Offsets(), resultValidity), nil
+	case *columnar.Struct:
+		fields := make([]columnar.Array, input.NumFields())
+		for i := range fields {
+			fields[i] = input.Field(i)
+		}
+		return columnar.NewStruct(input.Schema(), fields, input.Len(), resultValidity), nil
+	default:
+		panic(fmt.Sprintf("unexpected Array type %T", input))
+	}
+}

--- a/pkg/compute/nulls_test.go
+++ b/pkg/compute/nulls_test.go
@@ -1,0 +1,34 @@
+package compute_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/compute"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestPropagateNulls(t *testing.T) {
+	var alloc memory.Allocator
+
+	input := columnartest.Array(t, types.KindInt64, &alloc, int64(1), nil, int64(3))
+	validity := memory.NewBitmap(&alloc, 3)
+	validity.AppendValues(true, true, false)
+
+	actual, err := compute.PropagateNulls(&alloc, input, validity)
+	require.NoError(t, err)
+	expect := columnartest.Array(t, types.KindInt64, &alloc, int64(1), nil, nil)
+	columnartest.RequireDatumsEqual(t, expect, actual, memory.Bitmap{})
+
+	invalid := memory.NewBitmap(&alloc, 2)
+	invalid.AppendValues(true, true)
+	_, err = compute.PropagateNulls(&alloc, columnar.NewNumber([]int64{1, 2, 3}, memory.Bitmap{}), invalid)
+	require.ErrorContains(t, err, "validity bitmap length mismatch")
+
+	_, err = compute.PropagateNulls(&alloc, &columnar.NumberScalar[int64]{Value: 1}, memory.Bitmap{})
+	require.ErrorContains(t, err, "requires an Array input")
+}

--- a/pkg/dataset/layout/codec.go
+++ b/pkg/dataset/layout/codec.go
@@ -43,6 +43,9 @@ func NewWriter(alloc *memory.Allocator, sink buffer.Sink, spec Spec, typ types.T
 	case KindChunked:
 		return newChunkedWriter(alloc, sink, spec, typ)
 
+	case KindStruct:
+		return newStructWriter(alloc, sink, spec, typ)
+
 	default:
 		return nil, fmt.Errorf("unsupported layout kind %q", spec.Kind())
 	}
@@ -123,6 +126,9 @@ func NewReader(alloc *memory.Allocator, layout Layout, source buffer.Source) (Re
 
 	case KindChunked:
 		return newChunkedReader(alloc, layout, source)
+
+	case KindStruct:
+		return newStructReader(alloc, layout, source)
 
 	default:
 		return nil, fmt.Errorf("unsupported layout kind %q", layout.Kind())

--- a/pkg/dataset/layout/codec_array_test.go
+++ b/pkg/dataset/layout/codec_array_test.go
@@ -48,6 +48,37 @@ func TestCodec_Array(t *testing.T) {
 	columnartest.RequireArraysEqual(t, expect, actual, memory.Bitmap{})
 }
 
+func TestCodec_Array_ConstantProjection(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	w, err := layout.NewWriter(&alloc, &store, &layout.SpecArray{
+		Spec: &array.SpecPlain{},
+	}, &types.Int64{})
+	require.NoError(t, err)
+	require.NoError(t, w.Append(t.Context(), columnartest.Array(t, types.KindInt64, &alloc,
+		int64(1), int64(2), int64(3),
+	)))
+	encoded, err := w.Flush(t.Context())
+	require.NoError(t, err)
+
+	r, err := layout.NewReader(&alloc, encoded, &store)
+	require.NoError(t, err)
+	defer r.Close()
+	_, err = r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+
+	actual, err := r.Project(t.Context(), &alloc, &expr.Constant{
+		Value: &columnar.NumberScalar[int64]{Value: 5},
+	}, memory.Bitmap{})
+	require.NoError(t, err)
+	columnartest.RequireArraysEqual(t,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(5), int64(5), int64(5)),
+		actual,
+		memory.Bitmap{},
+	)
+}
+
 func TestCodec_Array_Windowing(t *testing.T) {
 	var alloc memory.Allocator
 	var store buffer.MemoryStore

--- a/pkg/dataset/layout/codec_struct.go
+++ b/pkg/dataset/layout/codec_struct.go
@@ -1,0 +1,539 @@
+package layout
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/compute"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/expr"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// structWriter writes struct-typed data by delegating each field to a child Writer.
+type structWriter struct {
+	alloc    *memory.Allocator
+	typ      *types.Struct
+	fields   []Writer
+	validity Writer // nil when non-nullable.
+}
+
+func newStructWriter(alloc *memory.Allocator, sink buffer.Sink, spec Spec, typ types.Type) (*structWriter, error) {
+	if got, want := spec.Kind(), KindStruct; got != want {
+		return nil, fmt.Errorf("invalid spec kind for struct writer: got %s, want %s", got, want)
+	}
+
+	structSpec := spec.(*SpecStruct)
+	structType := typ.(*types.Struct)
+
+	if len(structSpec.Fields) != len(structType.Fields) {
+		return nil, fmt.Errorf("spec has %d fields, type has %d", len(structSpec.Fields), len(structType.Fields))
+	}
+
+	fields := make([]Writer, len(structSpec.Fields))
+	for i, fieldSpec := range structSpec.Fields {
+		w, err := NewWriter(alloc, sink, fieldSpec, structType.Fields[i].Type)
+		if err != nil {
+			return nil, fmt.Errorf("creating writer for field %q: %w", structType.Fields[i].Name, err)
+		}
+		fields[i] = w
+	}
+
+	var validity Writer
+	if structType.Nullable && structSpec.Validity != nil {
+		w, err := NewWriter(alloc, sink, structSpec.Validity, &types.Bool{})
+		if err != nil {
+			return nil, fmt.Errorf("creating validity writer: %w", err)
+		}
+		validity = w
+	}
+
+	return &structWriter{
+		alloc:    alloc,
+		typ:      structType,
+		fields:   fields,
+		validity: validity,
+	}, nil
+}
+
+func (w *structWriter) Append(ctx context.Context, arr columnar.Array) error {
+	s, ok := arr.(*columnar.Struct)
+	if !ok {
+		return fmt.Errorf("expected *columnar.Struct, got %T", arr)
+	}
+	validity := s.Validity()
+	if w.validity == nil && validity.Len() > 0 {
+		return fmt.Errorf("cannot append struct validity to a non-nullable writer")
+	}
+
+	for i, fw := range w.fields {
+		if err := fw.Append(ctx, s.Field(i)); err != nil {
+			return fmt.Errorf("appending field %q: %w", w.typ.Fields[i].Name, err)
+		}
+	}
+
+	// Write validity bitmap as a Bool array.
+	if w.validity != nil {
+		var boolArr *columnar.Bool
+		if validity.Len() == 0 {
+			// All valid: create an all-true Bool array.
+			builder := columnar.NewBoolBuilder(w.alloc)
+			builder.AppendValueCount(true, s.Len())
+			boolArr = builder.Build()
+		} else {
+			boolArr = columnar.NewBool(validity, memory.Bitmap{})
+		}
+		if err := w.validity.Append(ctx, boolArr); err != nil {
+			return fmt.Errorf("appending validity: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (w *structWriter) Flush(ctx context.Context) (Layout, error) {
+	fields := make([]Layout, len(w.fields))
+	for i, fw := range w.fields {
+		l, err := fw.Flush(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("flushing field %q: %w", w.typ.Fields[i].Name, err)
+		}
+		fields[i] = l
+	}
+
+	var validity Layout
+	if w.validity != nil {
+		l, err := w.validity.Flush(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("flushing validity: %w", err)
+		}
+		validity = l
+	}
+
+	return &Struct{
+		Type:     w.typ,
+		Fields:   fields,
+		Validity: validity,
+	}, nil
+}
+
+// structReader reads struct-typed data by delegating to child readers.
+type structReader struct {
+	typ      *types.Struct
+	fields   []Reader
+	validity Reader // nil when non-nullable.
+
+	totalRows int
+	offset    int
+	length    int
+}
+
+func newStructReader(alloc *memory.Allocator, layout Layout, source buffer.Source) (*structReader, error) {
+	if got, want := layout.Kind(), KindStruct; got != want {
+		return nil, fmt.Errorf("invalid layout kind for struct reader: got %s, want %s", got, want)
+	}
+
+	sl := layout.(*Struct)
+	st := sl.Type.(*types.Struct)
+
+	fields := make([]Reader, len(sl.Fields))
+	for i, fl := range sl.Fields {
+		r, err := NewReader(alloc, fl, source)
+		if err != nil {
+			return nil, fmt.Errorf("creating reader for field %q: %w", st.Fields[i].Name, err)
+		}
+		fields[i] = r
+	}
+
+	var validity Reader
+	if sl.Validity != nil {
+		r, err := NewReader(alloc, sl.Validity, source)
+		if err != nil {
+			return nil, fmt.Errorf("creating validity reader: %w", err)
+		}
+		validity = r
+	}
+
+	return &structReader{
+		typ:       st,
+		fields:    fields,
+		validity:  validity,
+		totalRows: sl.Len(),
+	}, nil
+}
+
+func (r *structReader) Next(ctx context.Context, batchSize int) (int, error) {
+	r.offset += r.length
+
+	if r.offset >= r.totalRows {
+		r.length = 0
+		return 0, io.EOF
+	}
+
+	r.length = min(batchSize, r.totalRows-r.offset)
+
+	for i, fr := range r.fields {
+		if _, err := fr.Next(ctx, r.length); err != nil {
+			return 0, fmt.Errorf("advancing field %q: %w", r.typ.Fields[i].Name, err)
+		}
+	}
+
+	if r.validity != nil {
+		if _, err := r.validity.Next(ctx, r.length); err != nil {
+			return 0, fmt.Errorf("advancing validity: %w", err)
+		}
+	}
+
+	return r.length, nil
+}
+
+func (r *structReader) AppendBuffers(buf []buffer.ID, filter expr.Expression, projection expr.Expression, mask memory.Bitmap) ([]buffer.ID, error) {
+	fieldNames := make([]string, len(r.typ.Fields))
+	for i, f := range r.typ.Fields {
+		fieldNames[i] = f.Name
+	}
+
+	// Build per-field projection sub-expressions from the simplified tree.
+	// After Simplify, the projection is a MakeStruct whose values are the
+	// sub-expressions for each referenced field.
+	simplified := simplifyProjection(projection, fieldNames)
+	childProj := make(map[string]expr.Expression)
+	if ms, ok := simplified.(*expr.MakeStruct); ok {
+		for i, name := range ms.Names {
+			childProj[name] = rewriteColumnsToIdentity(ms.Values[i], name)
+		}
+	}
+
+	// Simplify the filter so nested-struct shapes (Identity, Extract over
+	// MakeStruct, Include, Exclude) collapse into plain Column references.
+	// Without this, collectColumns below would miss the field references and
+	// under-count the buffers reachable through the filter.
+	filter = simplifyProjection(filter, fieldNames)
+
+	// Collect fields referenced by the filter.
+	filterCols := make(map[string]struct{})
+	if filter != nil {
+		filterCols = collectColumns(filter)
+	}
+
+	// Union of projection and filter field references.
+	needed := make(map[string]struct{})
+	for name := range childProj {
+		needed[name] = struct{}{}
+	}
+	for name := range collectColumns(simplified) {
+		needed[name] = struct{}{}
+	}
+	for name := range filterCols {
+		needed[name] = struct{}{}
+	}
+
+	// Iterate in struct field order so buffer collection is deterministic.
+	for i, f := range r.typ.Fields {
+		if _, ok := needed[f.Name]; !ok {
+			continue
+		}
+		proj, ok := childProj[f.Name]
+		if !ok {
+			// The expression could not be decomposed into a projection for this
+			// child. Use Identity to collect all of its buffers.
+			proj = &expr.Identity{}
+		}
+		var err error
+		buf, err = r.fields[i].AppendBuffers(buf, filter, proj, mask)
+		if err != nil {
+			return buf, fmt.Errorf("field %q: %w", f.Name, err)
+		}
+	}
+
+	if r.validity != nil {
+		var err error
+		buf, err = r.validity.AppendBuffers(buf, filter, &expr.Identity{}, mask)
+		if err != nil {
+			return buf, fmt.Errorf("validity: %w", err)
+		}
+	}
+
+	return buf, nil
+}
+
+func (r *structReader) Prune(ctx context.Context, alloc *memory.Allocator, e expr.Expression, mask memory.Bitmap) (memory.Bitmap, error) {
+	if mask.Len() != 0 && mask.Len() != r.length {
+		return memory.Bitmap{}, fmt.Errorf("mask length %d does not match row range %d", mask.Len(), r.length)
+	}
+	fieldNames := make([]string, len(r.typ.Fields))
+	for i, f := range r.typ.Fields {
+		fieldNames[i] = f.Name
+	}
+	simplified := simplifyProjection(e, fieldNames)
+	return r.walkFilter(ctx, alloc, simplified, mask, pruneOp)
+}
+
+func (r *structReader) Filter(ctx context.Context, alloc *memory.Allocator, e expr.Expression, mask memory.Bitmap) (memory.Bitmap, error) {
+	if mask.Len() != 0 && mask.Len() != r.length {
+		return memory.Bitmap{}, fmt.Errorf("mask length %d does not match row range %d", mask.Len(), r.length)
+	}
+
+	fieldNames := make([]string, len(r.typ.Fields))
+	for i, f := range r.typ.Fields {
+		fieldNames[i] = f.Name
+	}
+	simplified := simplifyProjection(e, fieldNames)
+
+	result, err := r.walkFilter(ctx, alloc, simplified, mask, filterOp)
+	if err != nil {
+		return memory.Bitmap{}, err
+	}
+
+	if r.validity != nil {
+		vArr, err := r.validity.Project(ctx, alloc, &expr.Identity{}, mask)
+		if err != nil {
+			return memory.Bitmap{}, fmt.Errorf("projecting validity for filter: %w", err)
+		}
+		vMask := vArr.(*columnar.Bool).Values()
+		if result.Len() == 0 {
+			result = vMask
+		} else {
+			result = intersectMasks(alloc, result, vMask)
+		}
+	}
+
+	return result, nil
+}
+
+func (r *structReader) walkFilter(ctx context.Context, alloc *memory.Allocator, e expr.Expression, mask memory.Bitmap, op decomposeOp) (memory.Bitmap, error) {
+	if e == nil {
+		return mask, nil
+	}
+
+	// AND/OR get special treatment for short-circuit evaluation.
+	if bin, ok := e.(*expr.Binary); ok {
+		switch bin.Op {
+		case expr.BinaryOpAND:
+			leftMask, err := r.walkFilter(ctx, alloc, bin.Left, mask, op)
+			if err != nil {
+				return memory.Bitmap{}, err
+			}
+			if leftMask.Len() > 0 && leftMask.SetCount() == 0 {
+				return leftMask, nil
+			}
+			return r.walkFilter(ctx, alloc, bin.Right, leftMask, op)
+
+		case expr.BinaryOpOR:
+			leftMask, err := r.walkFilter(ctx, alloc, bin.Left, mask, op)
+			if err != nil {
+				return memory.Bitmap{}, err
+			}
+			if leftMask.Len() > 0 && leftMask.SetCount() == leftMask.Len() {
+				return leftMask, nil
+			}
+			rightMask, err := r.walkFilter(ctx, alloc, bin.Right, mask, op)
+			if err != nil {
+				return memory.Bitmap{}, err
+			}
+			return unionMasks(alloc, leftMask, rightMask, r.length), nil
+		}
+	}
+
+	// Annotation-based push-down.
+	cols := collectColumns(e)
+	if len(cols) == 1 {
+		var colName string
+		for name := range cols {
+			colName = name
+		}
+		idx := r.fieldIndex(colName)
+		if idx < 0 {
+			// Unknown columns can't be pushed down.
+			goto Fallback
+		}
+		rewritten := rewriteColumnsToIdentity(e, colName)
+		return op.call(ctx, r.fields[idx], alloc, rewritten, mask)
+	}
+
+Fallback:
+	// Multi-column or zero-column expression that can't be decomposed
+	// into single-field sub-expressions (e.g., a + b < 5).
+	//
+	// Prune returns the mask unchanged here. Cross-column pruning would
+	// require aligned per-zone statistics across columns (zone maps) to
+	// reason about combined expressions. The current layout has
+	// independent per-column chunking with no alignment guarantee, so
+	// cross-column metadata reasoning is not possible at this level.
+	//
+	// Filter falls back to projecting the referenced columns and
+	// evaluating the full expression.
+	if op == pruneOp {
+		return mask, nil
+	}
+	return r.evalFallbackFilter(ctx, alloc, e, mask)
+}
+
+// decomposeOp selects whether decomposition delegates to Filter or Prune on
+// child readers.
+type decomposeOp int
+
+const (
+	filterOp decomposeOp = iota
+	pruneOp
+)
+
+func (op decomposeOp) call(ctx context.Context, r Reader, alloc *memory.Allocator, e expr.Expression, mask memory.Bitmap) (memory.Bitmap, error) {
+	switch op {
+	case filterOp:
+		return r.Filter(ctx, alloc, e, mask)
+	case pruneOp:
+		return r.Prune(ctx, alloc, e, mask)
+	default:
+		panic("unreachable")
+	}
+}
+
+func (r *structReader) evalFallbackFilter(ctx context.Context, alloc *memory.Allocator, e expr.Expression, mask memory.Bitmap) (memory.Bitmap, error) {
+	cols := collectColumns(e)
+
+	columns := make([]columnar.Column, 0, len(cols))
+	arrays := make([]columnar.Array, 0, len(cols))
+
+	for name := range cols {
+		idx := r.fieldIndex(name)
+		if idx < 0 {
+			continue
+		}
+		arr, err := r.fields[idx].Project(ctx, alloc, &expr.Identity{}, memory.Bitmap{})
+		if err != nil {
+			return memory.Bitmap{}, fmt.Errorf("projecting field %q for fallback: %w", name, err)
+		}
+		columns = append(columns, columnar.Column{Name: name})
+		arrays = append(arrays, arr)
+	}
+
+	input := columnar.NewStruct(columnar.NewSchema(columns), arrays, r.length, memory.Bitmap{})
+	result, err := expr.Evaluate(alloc, e, input, mask)
+	if err != nil {
+		return memory.Bitmap{}, fmt.Errorf("evaluating fallback expression: %w", err)
+	}
+
+	resultMask, err := datumToMask(alloc, result, r.length)
+	if err != nil {
+		return memory.Bitmap{}, fmt.Errorf("converting fallback result to mask: %w", err)
+	}
+	if mask.Len() > 0 {
+		resultMask = intersectMasks(alloc, resultMask, mask)
+	}
+	return resultMask, nil
+}
+
+func (r *structReader) fieldIndex(name string) int {
+	for i, f := range r.typ.Fields {
+		if f.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func (r *structReader) Project(ctx context.Context, alloc *memory.Allocator, projection expr.Expression, mask memory.Bitmap) (columnar.Array, error) {
+	fieldNames := make([]string, len(r.typ.Fields))
+	for i, f := range r.typ.Fields {
+		fieldNames[i] = f.Name
+	}
+
+	simplified := simplifyProjection(projection, fieldNames)
+
+	var validity memory.Bitmap
+	if r.validity != nil {
+		vArr, err := r.validity.Project(ctx, alloc, &expr.Identity{}, mask)
+		if err != nil {
+			return nil, fmt.Errorf("projecting struct validity: %w", err)
+		}
+		validity = vArr.(*columnar.Bool).Values()
+	}
+
+	result, err := r.walkProject(ctx, alloc, simplified, mask, validity)
+	if err != nil {
+		return nil, err
+	}
+
+	arr, ok := result.(columnar.Array)
+	if !ok {
+		return nil, fmt.Errorf("projection produced %T, expected Array", result)
+	}
+	return arr, nil
+}
+
+func (r *structReader) Reset() {
+	r.resetSelf()
+
+	for _, fr := range r.fields {
+		fr.Reset()
+	}
+	if r.validity != nil {
+		r.validity.Reset()
+	}
+}
+
+func (r *structReader) resetSelf() {
+	r.offset = 0
+	r.length = 0
+}
+
+func (r *structReader) Close() error {
+	r.resetSelf()
+
+	for _, fr := range r.fields {
+		fr.Close()
+	}
+	if r.validity != nil {
+		r.validity.Close()
+	}
+	return nil
+}
+
+func (r *structReader) walkProject(ctx context.Context, alloc *memory.Allocator, e expr.Expression, mask, validity memory.Bitmap) (columnar.Datum, error) {
+	if e == nil {
+		return nil, fmt.Errorf("nil projection expression is invalid")
+	}
+
+	cols := collectColumns(e)
+
+	switch len(cols) {
+	case 0: // No column references: evaluate directly (constants, etc.).
+		empty := columnar.NewStruct(columnar.NewSchema(nil), nil, r.length, memory.Bitmap{})
+		return expr.Evaluate(alloc, e, empty, mask)
+
+	case 1: // Single-field reference: scope-rewrite and push to child reader.
+		var colName string
+		for name := range cols {
+			colName = name
+		}
+		idx := r.fieldIndex(colName)
+		if idx < 0 {
+			empty := columnar.NewStruct(columnar.NewSchema(nil), nil, r.length, memory.Bitmap{})
+			return expr.Evaluate(alloc, e, empty, mask)
+		}
+		rewritten := rewriteColumnsToIdentity(e, colName)
+		projected, err := r.fields[idx].Project(ctx, alloc, rewritten, mask)
+		if err != nil {
+			return nil, err
+		}
+		if validity.Len() == 0 {
+			return projected, nil
+		}
+		return compute.PropagateNulls(alloc, projected, validity)
+
+	default:
+		// Multi-field reference: Reduce calls walkProject on each child.
+		// Each child gets categorized by its own column count — single-column
+		// sub-expressions get pushed to child readers, constants evaluate
+		// directly, and multi-column children recurse further.
+		// All children return full-window arrays; mask is forwarded as a
+		// selection hint so compute ops can skip unselected rows.
+		return expr.Reduce(alloc, e, func(child expr.Expression) (columnar.Datum, error) {
+			return r.walkProject(ctx, alloc, child, mask, validity)
+		}, mask)
+	}
+}

--- a/pkg/dataset/layout/codec_struct_test.go
+++ b/pkg/dataset/layout/codec_struct_test.go
@@ -1,0 +1,806 @@
+package layout_test
+
+import (
+	"io"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/compute"
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/dataset/layout"
+	"github.com/grafana/loki/v3/pkg/expr"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestCodec_Struct_WriteRead(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	typ := &types.Struct{
+		Fields: []types.StructField{
+			{Name: "x", Type: &types.Int64{}},
+			{Name: "y", Type: &types.UTF8{}},
+		},
+	}
+
+	spec := &layout.SpecStruct{
+		Fields: []layout.Spec{
+			&layout.SpecArray{Spec: &array.SpecPlain{}},
+			&layout.SpecArray{Spec: &array.SpecBinary{Offsets: &array.SpecPlain{}}},
+		},
+	}
+
+	w, err := layout.NewWriter(&alloc, &store, spec, typ)
+	require.NoError(t, err)
+
+	input := columnartest.Struct(t, &alloc,
+		columnartest.Field("x", types.KindInt64, int64(10), int64(20), int64(30)),
+		columnartest.Field("y", types.KindUTF8, "a", "b", "c"),
+	)
+	require.NoError(t, w.Append(t.Context(), input))
+
+	l, err := w.Flush(t.Context())
+	require.NoError(t, err)
+
+	r, err := layout.NewReader(&alloc, l, &store)
+	require.NoError(t, err)
+	defer r.Close()
+
+	n, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+
+	projection := &expr.Include{Names: []string{"x", "y"}, Value: &expr.Identity{}}
+	actual, err := r.Project(t.Context(), &alloc, projection, memory.Bitmap{})
+	require.NoError(t, err)
+	columnartest.RequireArraysEqual(t, input, actual, memory.Bitmap{})
+}
+
+func TestCodec_Struct_RejectsUnexpectedValidity(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	w, err := layout.NewWriter(&alloc, &store, &layout.SpecStruct{
+		Fields: []layout.Spec{&layout.SpecArray{Spec: &array.SpecPlain{}}},
+	}, &types.Struct{
+		Fields: []types.StructField{{Name: "x", Type: &types.Int64{}}},
+	})
+	require.NoError(t, err)
+
+	input := columnartest.StructWithValidity(t, &alloc, []bool{true, false},
+		columnartest.Field("x", types.KindInt64, int64(10), int64(20)),
+	)
+	require.Error(t, w.Append(t.Context(), input))
+}
+
+func TestCodec_Struct_ProjectionPreservesValidity(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	w, err := layout.NewWriter(&alloc, &store, &layout.SpecStruct{
+		Fields:   []layout.Spec{&layout.SpecArray{Spec: &array.SpecPlain{}}},
+		Validity: &layout.SpecArray{Spec: &array.SpecBool{}},
+	}, &types.Struct{
+		Fields:   []types.StructField{{Name: "x", Type: &types.Int64{}}},
+		Nullable: true,
+	})
+	require.NoError(t, err)
+
+	input := columnartest.StructWithValidity(t, &alloc, []bool{true, false, true},
+		columnartest.Field("x", types.KindInt64, int64(10), int64(20), int64(30)),
+	)
+	require.NoError(t, w.Append(t.Context(), input))
+	encoded, err := w.Flush(t.Context())
+	require.NoError(t, err)
+
+	r, err := layout.NewReader(&alloc, encoded, &store)
+	require.NoError(t, err)
+	defer r.Close()
+	_, err = r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+
+	actual, err := r.Project(t.Context(), &alloc, &expr.Include{
+		Names: []string{"x"},
+		Value: &expr.Identity{},
+	}, memory.Bitmap{})
+	require.NoError(t, err)
+	columnartest.RequireArraysEqual(t, input, actual, memory.Bitmap{})
+
+	field, err := r.Project(t.Context(), &alloc, &expr.Column{Name: "x"}, memory.Bitmap{})
+	require.NoError(t, err)
+	columnartest.RequireArraysEqual(t,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(10), nil, int64(30)),
+		field,
+		memory.Bitmap{},
+	)
+}
+
+func TestCodec_Struct_ConstantProjection(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	r := buildStructReaderXY(t, &alloc, &store,
+		[]int64{10, 20, 30},
+		[]string{"a", "b", "c"},
+	)
+	defer r.Close()
+	_, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+
+	actual, err := r.Project(t.Context(), &alloc, &expr.Constant{
+		Value: &columnar.NumberScalar[int64]{Value: 5},
+	}, memory.Bitmap{})
+	require.NoError(t, err)
+	columnartest.RequireArraysEqual(t,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(5), int64(5), int64(5)),
+		actual,
+		memory.Bitmap{},
+	)
+
+	actual, err = r.Project(t.Context(), &alloc, &expr.MakeStruct{
+		Names: []string{"x", "constant"},
+		Values: []expr.Expression{
+			&expr.Column{Name: "x"},
+			&expr.Constant{Value: &columnar.NumberScalar[int64]{Value: 5}},
+		},
+	}, memory.Bitmap{})
+	require.NoError(t, err)
+	columnartest.RequireArraysEqual(t,
+		columnartest.Struct(t, &alloc,
+			columnartest.Field("x", types.KindInt64, int64(10), int64(20), int64(30)),
+			columnartest.Field("constant", types.KindInt64, int64(5), int64(5), int64(5)),
+		),
+		actual,
+		memory.Bitmap{},
+	)
+}
+
+func TestCodec_Struct_Projection(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	typ := &types.Struct{
+		Fields: []types.StructField{
+			{Name: "x", Type: &types.Int64{}},
+			{Name: "y", Type: &types.UTF8{}},
+			{Name: "z", Type: &types.Int64{}},
+		},
+	}
+
+	spec := &layout.SpecStruct{
+		Fields: []layout.Spec{
+			&layout.SpecArray{Spec: &array.SpecPlain{}},
+			&layout.SpecArray{Spec: &array.SpecBinary{Offsets: &array.SpecPlain{}}},
+			&layout.SpecArray{Spec: &array.SpecPlain{}},
+		},
+	}
+
+	w, err := layout.NewWriter(&alloc, &store, spec, typ)
+	require.NoError(t, err)
+
+	input := columnartest.Struct(t, &alloc,
+		columnartest.Field("x", types.KindInt64, int64(1), int64(2)),
+		columnartest.Field("y", types.KindUTF8, "a", "b"),
+		columnartest.Field("z", types.KindInt64, int64(10), int64(20)),
+	)
+	require.NoError(t, w.Append(t.Context(), input))
+
+	l, err := w.Flush(t.Context())
+	require.NoError(t, err)
+
+	r, err := layout.NewReader(&alloc, l, &store)
+	require.NoError(t, err)
+	defer r.Close()
+
+	n, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+
+	projection := &expr.Include{Names: []string{"x", "z"}, Value: &expr.Identity{}}
+
+	actual, err := r.Project(t.Context(), &alloc, projection, memory.Bitmap{})
+	require.NoError(t, err)
+
+	expected := columnartest.Struct(t, &alloc,
+		columnartest.Field("x", types.KindInt64, int64(1), int64(2)),
+		columnartest.Field("z", types.KindInt64, int64(10), int64(20)),
+	)
+	columnartest.RequireArraysEqual(t, expected, actual, memory.Bitmap{})
+}
+
+func TestCodec_Struct_Windowing(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	typ := &types.Struct{
+		Fields: []types.StructField{
+			{Name: "x", Type: &types.Int64{}},
+		},
+	}
+
+	spec := &layout.SpecStruct{
+		Fields: []layout.Spec{
+			&layout.SpecArray{Spec: &array.SpecPlain{}},
+		},
+	}
+
+	w, err := layout.NewWriter(&alloc, &store, spec, typ)
+	require.NoError(t, err)
+
+	input := columnartest.Struct(t, &alloc,
+		columnartest.Field("x", types.KindInt64, int64(1), int64(2), int64(3), int64(4)),
+	)
+	require.NoError(t, w.Append(t.Context(), input))
+
+	l, err := w.Flush(t.Context())
+	require.NoError(t, err)
+
+	r, err := layout.NewReader(&alloc, l, &store)
+	require.NoError(t, err)
+	defer r.Close()
+
+	// Window 1
+	n, err := r.Next(t.Context(), 2)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+	projection := &expr.Include{Names: []string{"x"}, Value: &expr.Identity{}}
+	actual, err := r.Project(t.Context(), &alloc, projection, memory.Bitmap{})
+	require.NoError(t, err)
+	columnartest.RequireArraysEqual(t,
+		columnartest.Struct(t, &alloc, columnartest.Field("x", types.KindInt64, int64(1), int64(2))),
+		actual, memory.Bitmap{},
+	)
+
+	// Window 2
+	n, err = r.Next(t.Context(), 2)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+	actual, err = r.Project(t.Context(), &alloc, projection, memory.Bitmap{})
+	require.NoError(t, err)
+	columnartest.RequireArraysEqual(t,
+		columnartest.Struct(t, &alloc, columnartest.Field("x", types.KindInt64, int64(3), int64(4))),
+		actual, memory.Bitmap{},
+	)
+
+	// EOF
+	_, err = r.Next(t.Context(), 2)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestCodec_Struct_Filter(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	typ := &types.Struct{
+		Fields: []types.StructField{
+			{Name: "x", Type: &types.Int64{}},
+			{Name: "y", Type: &types.UTF8{}},
+		},
+	}
+
+	spec := &layout.SpecStruct{
+		Fields: []layout.Spec{
+			&layout.SpecArray{Spec: &array.SpecPlain{}},
+			&layout.SpecArray{Spec: &array.SpecBinary{Offsets: &array.SpecPlain{}}},
+		},
+	}
+
+	w, err := layout.NewWriter(&alloc, &store, spec, typ)
+	require.NoError(t, err)
+
+	input := columnartest.Struct(t, &alloc,
+		columnartest.Field("x", types.KindInt64, int64(10), int64(20), int64(30), int64(40)),
+		columnartest.Field("y", types.KindUTF8, "a", "b", "c", "d"),
+	)
+	require.NoError(t, w.Append(t.Context(), input))
+
+	l, err := w.Flush(t.Context())
+	require.NoError(t, err)
+
+	r, err := layout.NewReader(&alloc, l, &store)
+	require.NoError(t, err)
+	defer r.Close()
+
+	n, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+
+	filterExpr := &expr.Binary{
+		Left:  &expr.Column{Name: "x"},
+		Op:    expr.BinaryOpGT,
+		Right: &expr.Constant{Value: &columnar.NumberScalar[int64]{Value: 15}},
+	}
+
+	mask, err := r.Filter(t.Context(), &alloc, filterExpr, memory.Bitmap{})
+	require.NoError(t, err)
+
+	projection := &expr.Include{Names: []string{"x", "y"}, Value: &expr.Identity{}}
+	projected, err := r.Project(t.Context(), &alloc, projection, mask)
+	require.NoError(t, err)
+	filtered, err := compute.Filter(&alloc, projected, mask)
+	require.NoError(t, err)
+
+	expected := columnartest.Struct(t, &alloc,
+		columnartest.Field("x", types.KindInt64, int64(20), int64(30), int64(40)),
+		columnartest.Field("y", types.KindUTF8, "b", "c", "d"),
+	)
+	columnartest.RequireArraysEqual(t, expected, filtered.(columnar.Array), memory.Bitmap{})
+}
+
+func TestCodec_Struct_Filter_AND(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	typ := &types.Struct{
+		Fields: []types.StructField{
+			{Name: "x", Type: &types.Int64{}},
+			{Name: "y", Type: &types.Int64{}},
+		},
+	}
+
+	spec := &layout.SpecStruct{
+		Fields: []layout.Spec{
+			&layout.SpecArray{Spec: &array.SpecPlain{}},
+			&layout.SpecArray{Spec: &array.SpecPlain{}},
+		},
+	}
+
+	w, err := layout.NewWriter(&alloc, &store, spec, typ)
+	require.NoError(t, err)
+
+	input := columnartest.Struct(t, &alloc,
+		columnartest.Field("x", types.KindInt64, int64(1), int64(2), int64(3)),
+		columnartest.Field("y", types.KindInt64, int64(10), int64(20), int64(30)),
+	)
+	require.NoError(t, w.Append(t.Context(), input))
+
+	l, err := w.Flush(t.Context())
+	require.NoError(t, err)
+
+	r, err := layout.NewReader(&alloc, l, &store)
+	require.NoError(t, err)
+	defer r.Close()
+
+	n, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+
+	// x > 1 AND y > 15
+	filterExpr := &expr.Binary{
+		Left: &expr.Binary{
+			Left:  &expr.Column{Name: "x"},
+			Op:    expr.BinaryOpGT,
+			Right: &expr.Constant{Value: &columnar.NumberScalar[int64]{Value: 1}},
+		},
+		Op: expr.BinaryOpAND,
+		Right: &expr.Binary{
+			Left:  &expr.Column{Name: "y"},
+			Op:    expr.BinaryOpGT,
+			Right: &expr.Constant{Value: &columnar.NumberScalar[int64]{Value: 15}},
+		},
+	}
+
+	mask, err := r.Filter(t.Context(), &alloc, filterExpr, memory.Bitmap{})
+	require.NoError(t, err)
+
+	projection := &expr.Include{Names: []string{"x", "y"}, Value: &expr.Identity{}}
+	projected, err := r.Project(t.Context(), &alloc, projection, mask)
+	require.NoError(t, err)
+	filtered, err := compute.Filter(&alloc, projected, mask)
+	require.NoError(t, err)
+
+	expected := columnartest.Struct(t, &alloc,
+		columnartest.Field("x", types.KindInt64, int64(2), int64(3)),
+		columnartest.Field("y", types.KindInt64, int64(20), int64(30)),
+	)
+	columnartest.RequireArraysEqual(t, expected, filtered.(columnar.Array), memory.Bitmap{})
+}
+
+func TestCodec_Struct_Filter_OR(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	typ := &types.Struct{
+		Fields: []types.StructField{
+			{Name: "x", Type: &types.Int64{}},
+			{Name: "y", Type: &types.Int64{}},
+		},
+	}
+
+	spec := &layout.SpecStruct{
+		Fields: []layout.Spec{
+			&layout.SpecArray{Spec: &array.SpecPlain{}},
+			&layout.SpecArray{Spec: &array.SpecPlain{}},
+		},
+	}
+
+	w, err := layout.NewWriter(&alloc, &store, spec, typ)
+	require.NoError(t, err)
+
+	input := columnartest.Struct(t, &alloc,
+		columnartest.Field("x", types.KindInt64, int64(1), int64(2), int64(3)),
+		columnartest.Field("y", types.KindInt64, int64(30), int64(10), int64(10)),
+	)
+	require.NoError(t, w.Append(t.Context(), input))
+
+	l, err := w.Flush(t.Context())
+	require.NoError(t, err)
+
+	r, err := layout.NewReader(&alloc, l, &store)
+	require.NoError(t, err)
+	defer r.Close()
+
+	n, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+
+	// x == 1 OR y == 10
+	filterExpr := &expr.Binary{
+		Left: &expr.Binary{
+			Left:  &expr.Column{Name: "x"},
+			Op:    expr.BinaryOpEQ,
+			Right: &expr.Constant{Value: &columnar.NumberScalar[int64]{Value: 1}},
+		},
+		Op: expr.BinaryOpOR,
+		Right: &expr.Binary{
+			Left:  &expr.Column{Name: "y"},
+			Op:    expr.BinaryOpEQ,
+			Right: &expr.Constant{Value: &columnar.NumberScalar[int64]{Value: 10}},
+		},
+	}
+
+	mask, err := r.Filter(t.Context(), &alloc, filterExpr, memory.Bitmap{})
+	require.NoError(t, err)
+
+	projection := &expr.Include{Names: []string{"x", "y"}, Value: &expr.Identity{}}
+	projected, err := r.Project(t.Context(), &alloc, projection, mask)
+	require.NoError(t, err)
+	filtered, err := compute.Filter(&alloc, projected, mask)
+	require.NoError(t, err)
+
+	// All 3 rows match (row 0: x==1, row 1: y==10, row 2: y==10)
+	columnartest.RequireArraysEqual(t, input, filtered.(columnar.Array), memory.Bitmap{})
+}
+
+func TestCodec_Struct_ChunkedFields(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	typ := &types.Struct{
+		Fields: []types.StructField{
+			{Name: "x", Type: &types.Int64{}},
+			{Name: "y", Type: &types.UTF8{}},
+		},
+	}
+
+	spec := &layout.SpecStruct{
+		Fields: []layout.Spec{
+			&layout.SpecChunked{
+				MaxRowCount: 2,
+				Chunk:       &layout.SpecArray{Spec: &array.SpecPlain{}},
+			},
+			&layout.SpecChunked{
+				MaxRowCount: 2,
+				Chunk:       &layout.SpecArray{Spec: &array.SpecBinary{Offsets: &array.SpecPlain{}}},
+			},
+		},
+	}
+
+	w, err := layout.NewWriter(&alloc, &store, spec, typ)
+	require.NoError(t, err)
+
+	input := columnartest.Struct(t, &alloc,
+		columnartest.Field("x", types.KindInt64, int64(1), int64(2), int64(3), int64(4), int64(5)),
+		columnartest.Field("y", types.KindUTF8, "a", "b", "c", "d", "e"),
+	)
+	require.NoError(t, w.Append(t.Context(), input))
+
+	l, err := w.Flush(t.Context())
+	require.NoError(t, err)
+
+	r, err := layout.NewReader(&alloc, l, &store)
+	require.NoError(t, err)
+	defer r.Close()
+
+	n, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+
+	filterExpr := &expr.Binary{
+		Left:  &expr.Column{Name: "x"},
+		Op:    expr.BinaryOpGT,
+		Right: &expr.Constant{Value: &columnar.NumberScalar[int64]{Value: 2}},
+	}
+
+	mask, err := r.Filter(t.Context(), &alloc, filterExpr, memory.Bitmap{})
+	require.NoError(t, err)
+
+	projection := &expr.Include{Names: []string{"x", "y"}, Value: &expr.Identity{}}
+	projected, err := r.Project(t.Context(), &alloc, projection, mask)
+	require.NoError(t, err)
+	filtered, err := compute.Filter(&alloc, projected, mask)
+	require.NoError(t, err)
+
+	expected := columnartest.Struct(t, &alloc,
+		columnartest.Field("x", types.KindInt64, int64(3), int64(4), int64(5)),
+		columnartest.Field("y", types.KindUTF8, "c", "d", "e"),
+	)
+	columnartest.RequireArraysEqual(t, expected, filtered.(columnar.Array), memory.Bitmap{})
+}
+
+// TestStructReader_Filter_NestedStructExpression exercises the simplification
+// path inside structReader.Filter: an Extract{name, Identity{}} on a struct
+// boundary must fold to Column{name} so the filter pushes down to the child
+// reader. Pre-fix, the filter falls into evalFallbackFilter against an empty
+// input and produces a null-vs-utf8 type mismatch.
+func TestStructReader_Filter_NestedStructExpression(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	r := buildStructReaderXY(t, &alloc, &store,
+		[]int64{1, 2, 3, 4},
+		[]string{"alpha", "beta", "alpha", "gamma"},
+	)
+	defer r.Close()
+
+	n, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+
+	// Equivalent of: y == "alpha", expressed via Extract{Name, Identity}.
+	nestedFilter := &expr.Binary{
+		Left: &expr.Extract{
+			Name:  "y",
+			Value: &expr.Identity{},
+		},
+		Op:    expr.BinaryOpEQ,
+		Right: &expr.Constant{Value: &columnar.UTF8Scalar{Value: []byte("alpha")}},
+	}
+
+	gotMask, err := r.Filter(t.Context(), &alloc, nestedFilter, memory.Bitmap{})
+	require.NoError(t, err)
+
+	// Reference: same predicate written with a plain Column reference. After
+	// simplification the two forms must produce identical results.
+	plainFilter := &expr.Binary{
+		Left:  &expr.Column{Name: "y"},
+		Op:    expr.BinaryOpEQ,
+		Right: &expr.Constant{Value: &columnar.UTF8Scalar{Value: []byte("alpha")}},
+	}
+	wantMask, err := r.Filter(t.Context(), &alloc, plainFilter, memory.Bitmap{})
+	require.NoError(t, err)
+
+	require.Equal(t, wantMask.Len(), gotMask.Len())
+	for i := 0; i < gotMask.Len(); i++ {
+		require.Equal(t, wantMask.Get(i), gotMask.Get(i), "row %d mismatch", i)
+	}
+}
+
+// TestStructReader_Filter_ExtractWithInclude exercises the Include fold rule
+// in simplifyProjection. Pre-fix, Extract{y, Include{[y], Identity{}}} has
+// zero collected Column references so walkFilter routes it to
+// evalFallbackFilter, which builds an empty input struct and produces a Null
+// column: comparison with a UTF8 literal then fails with a kind mismatch.
+// Post-fix, the simplification folds Include{[y], Identity{}} to MakeStruct{y:
+// Column{y}}, then Extract{y, ...} folds to Column{y}, and the filter pushes
+// down to the y child reader.
+func TestStructReader_Filter_ExtractWithInclude(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	r := buildStructReaderXY(t, &alloc, &store,
+		[]int64{10, 20, 30, 40},
+		[]string{"a", "b", "c", "d"},
+	)
+	defer r.Close()
+
+	n, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+
+	// Equivalent of: y == "b", but expressed via Extract{y, Include{[y], Identity{}}}.
+	nestedFilter := &expr.Binary{
+		Left: &expr.Extract{
+			Name: "y",
+			Value: &expr.Include{
+				Names: []string{"y"},
+				Value: &expr.Identity{},
+			},
+		},
+		Op:    expr.BinaryOpEQ,
+		Right: &expr.Constant{Value: &columnar.UTF8Scalar{Value: []byte("b")}},
+	}
+
+	gotMask, err := r.Filter(t.Context(), &alloc, nestedFilter, memory.Bitmap{})
+	require.NoError(t, err)
+
+	plainFilter := &expr.Binary{
+		Left:  &expr.Column{Name: "y"},
+		Op:    expr.BinaryOpEQ,
+		Right: &expr.Constant{Value: &columnar.UTF8Scalar{Value: []byte("b")}},
+	}
+	wantMask, err := r.Filter(t.Context(), &alloc, plainFilter, memory.Bitmap{})
+	require.NoError(t, err)
+
+	require.Equal(t, wantMask.Len(), gotMask.Len())
+	for i := 0; i < gotMask.Len(); i++ {
+		require.Equal(t, wantMask.Get(i), gotMask.Get(i), "row %d mismatch", i)
+	}
+}
+
+func TestStructReader_MissingColumn(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	r := buildStructReaderXY(t, &alloc, &store,
+		[]int64{10, 20, 30, 40},
+		[]string{"alpha", "beta", "alpha", "gamma"},
+	)
+	defer r.Close()
+	_, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+
+	projected, err := r.Project(t.Context(), &alloc, &expr.Column{Name: "missing"}, memory.Bitmap{})
+	require.NoError(t, err)
+	require.Equal(t, types.KindNull, projected.Kind())
+	require.Equal(t, 4, projected.Len())
+
+	_, err = r.Filter(t.Context(), &alloc, &expr.Binary{
+		Left:  &expr.Column{Name: "missing"},
+		Op:    expr.BinaryOpEQ,
+		Right: &expr.Constant{Value: &columnar.UTF8Scalar{Value: []byte("value")}},
+	}, memory.Bitmap{})
+	require.Error(t, err)
+}
+
+func TestStructReader_EmptyProjectionPreservesLength(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	r := buildStructReaderXY(t, &alloc, &store,
+		[]int64{10, 20, 30, 40},
+		[]string{"alpha", "beta", "alpha", "gamma"},
+	)
+	defer r.Close()
+	_, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+
+	projected, err := r.Project(t.Context(), &alloc, &expr.Include{Value: &expr.Identity{}}, memory.Bitmap{})
+	require.NoError(t, err)
+	require.Equal(t, 4, projected.Len())
+	require.Equal(t, 0, projected.(*columnar.Struct).NumFields())
+}
+
+func TestStructReader_AppendBuffers_DirectProjection(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	r := buildStructReaderXY(t, &alloc, &store,
+		[]int64{10, 20, 30, 40},
+		[]string{"alpha", "beta", "alpha", "gamma"},
+	)
+	defer r.Close()
+
+	n, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+
+	directBufs, err := r.AppendBuffers(nil, nil, &expr.Column{Name: "x"}, memory.Bitmap{})
+	require.NoError(t, err)
+
+	includeBufs, err := r.AppendBuffers(nil, nil, &expr.Include{
+		Names: []string{"x"},
+		Value: &expr.Identity{},
+	}, memory.Bitmap{})
+	require.NoError(t, err)
+	require.NotEmpty(t, includeBufs)
+	require.ElementsMatch(t, includeBufs, directBufs)
+}
+
+// TestStructReader_AppendBuffers_FilterIdentityRoot exercises the
+// simplification of the filter argument inside AppendBuffers. Pre-fix, the
+// projection arg is simplified at line 196 but the filter arg is not, so a
+// filter like Extract{name, Identity{}} == "x" has zero collectColumns
+// matches and contributes no fields to the union: buffers for fields used
+// only by the filter are missed. The projection here deliberately omits the
+// filter field so the filter is the only path that should pull in that
+// field's buffers.
+func TestStructReader_AppendBuffers_FilterIdentityRoot(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	r := buildStructReaderXY(t, &alloc, &store,
+		[]int64{10, 20, 30, 40},
+		[]string{"alpha", "beta", "alpha", "gamma"},
+	)
+	defer r.Close()
+
+	n, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+
+	// Filter on y, project only x: y's buffers must be reached only via the
+	// filter argument's column references.
+	projection := &expr.Include{Names: []string{"x"}, Value: &expr.Identity{}}
+
+	nestedFilter := &expr.Binary{
+		Left: &expr.Extract{
+			Name:  "y",
+			Value: &expr.Identity{},
+		},
+		Op:    expr.BinaryOpEQ,
+		Right: &expr.Constant{Value: &columnar.UTF8Scalar{Value: []byte("alpha")}},
+	}
+	plainFilter := &expr.Binary{
+		Left:  &expr.Column{Name: "y"},
+		Op:    expr.BinaryOpEQ,
+		Right: &expr.Constant{Value: &columnar.UTF8Scalar{Value: []byte("alpha")}},
+	}
+
+	gotBufs, err := r.AppendBuffers(nil, nestedFilter, projection, memory.Bitmap{})
+	require.NoError(t, err)
+
+	wantBufs, err := r.AppendBuffers(nil, plainFilter, projection, memory.Bitmap{})
+	require.NoError(t, err)
+
+	// Sanity: the plain-Column form must reach more buffers than the
+	// projection alone would; otherwise the test wouldn't distinguish
+	// pre-fix from post-fix.
+	projOnlyBufs, err := r.AppendBuffers(nil, nil, projection, memory.Bitmap{})
+	require.NoError(t, err)
+	require.Greater(t, len(wantBufs), len(projOnlyBufs),
+		"plain-Column filter must reach buffers the projection alone misses")
+
+	require.ElementsMatch(t, wantBufs, gotBufs)
+}
+
+// buildStructReaderXY is a helper to build a struct reader with two fields
+// (x: Int64, y: UTF8) populated with the given parallel data.
+func buildStructReaderXY(t *testing.T, alloc *memory.Allocator, store *buffer.MemoryStore, xs []int64, ys []string) layout.Reader {
+	t.Helper()
+
+	typ := &types.Struct{
+		Fields: []types.StructField{
+			{Name: "x", Type: &types.Int64{}},
+			{Name: "y", Type: &types.UTF8{}},
+		},
+	}
+
+	spec := &layout.SpecStruct{
+		Fields: []layout.Spec{
+			&layout.SpecArray{Spec: &array.SpecPlain{}},
+			&layout.SpecArray{Spec: &array.SpecBinary{Offsets: &array.SpecPlain{}}},
+		},
+	}
+
+	w, err := layout.NewWriter(alloc, store, spec, typ)
+	require.NoError(t, err)
+
+	xVals := make([]any, len(xs))
+	for i, v := range xs {
+		xVals[i] = v
+	}
+	yVals := make([]any, len(ys))
+	for i, v := range ys {
+		yVals[i] = v
+	}
+
+	input := columnartest.Struct(t, alloc,
+		columnartest.Field("x", types.KindInt64, xVals...),
+		columnartest.Field("y", types.KindUTF8, yVals...),
+	)
+	require.NoError(t, w.Append(t.Context(), input))
+
+	l, err := w.Flush(t.Context())
+	require.NoError(t, err)
+
+	r, err := layout.NewReader(alloc, l, store)
+	require.NoError(t, err)
+	return r
+}

--- a/pkg/dataset/layout/codec_util.go
+++ b/pkg/dataset/layout/codec_util.go
@@ -34,6 +34,29 @@ func datumToMask(alloc *memory.Allocator, datum columnar.Datum, length int) (mem
 	}
 }
 
+// unionMasks returns a bitmap where bits set in either a or b are set.
+// An empty bitmap is treated as all-set for the given length.
+func unionMasks(alloc *memory.Allocator, a, b memory.Bitmap, length int) memory.Bitmap {
+	if a.Len() == 0 && b.Len() == 0 {
+		return memory.Bitmap{}
+	}
+	if a.Len() == 0 {
+		a = memory.NewBitmap(alloc, length)
+		a.AppendCount(true, length)
+	}
+	if b.Len() == 0 {
+		b = memory.NewBitmap(alloc, length)
+		b.AppendCount(true, length)
+	}
+	aArr := columnar.NewBool(a, memory.Bitmap{})
+	bArr := columnar.NewBool(b, memory.Bitmap{})
+	result, err := compute.Or(alloc, aArr, bArr, memory.Bitmap{})
+	if err != nil {
+		panic("unionMasks: " + err.Error())
+	}
+	return result.(*columnar.Bool).Values()
+}
+
 // intersectMasks returns a new mask where only bits set in both a and b are
 // set.
 func intersectMasks(alloc *memory.Allocator, a, b memory.Bitmap) memory.Bitmap {

--- a/pkg/dataset/layout/expr_helpers.go
+++ b/pkg/dataset/layout/expr_helpers.go
@@ -1,0 +1,120 @@
+package layout
+
+import "github.com/grafana/loki/v3/pkg/expr"
+
+// collectColumns returns the set of distinct Column names referenced by e.
+func collectColumns(e expr.Expression) map[string]struct{} {
+	cols := make(map[string]struct{})
+	expr.Walk(e, func(node expr.Expression) {
+		if col, ok := node.(*expr.Column); ok {
+			cols[col.Name] = struct{}{}
+		}
+	})
+	return cols
+}
+
+// rewriteColumnsToIdentity returns a copy of e with all Column nodes matching
+// name replaced by Identity. This is the scope-rewrite step: when the struct
+// reader pushes a sub-expression to a child reader, it replaces Column
+// references to that child's name with Identity so the expression operates in
+// the child's namespace.
+func rewriteColumnsToIdentity(e expr.Expression, name string) expr.Expression {
+	if e == nil {
+		return nil
+	}
+	if col, ok := e.(*expr.Column); ok && col.Name == name {
+		return &expr.Identity{}
+	}
+	return expr.Map(e, func(child expr.Expression) expr.Expression {
+		return rewriteColumnsToIdentity(child, name)
+	})
+}
+
+// simplifyProjection rewrites an expression tree so that all field references
+// appear as Column nodes. It applies the following rules bottom-up:
+//
+//   - Identity{} → MakeStruct{fields, [Column{f} for each f]}
+//   - Extract{name, MakeStruct{..., name: X, ...}} → X
+//   - Include{names, MakeStruct{...}} → MakeStruct with only named fields
+//   - Exclude{names, MakeStruct{...}} → MakeStruct with named fields removed
+//
+// The fields parameter provides the field names for expanding Identity at the
+// current struct level. It may be nil when no Identity nodes are expected.
+func simplifyProjection(e expr.Expression, fields []string) expr.Expression {
+	if e == nil {
+		return nil
+	}
+
+	if _, ok := e.(*expr.Identity); ok {
+		names := make([]string, len(fields))
+		copy(names, fields)
+		values := make([]expr.Expression, len(fields))
+		for i, f := range fields {
+			values[i] = &expr.Column{Name: f}
+		}
+		return &expr.MakeStruct{Names: names, Values: values}
+	}
+
+	e = expr.Map(e, func(child expr.Expression) expr.Expression {
+		return simplifyProjection(child, fields)
+	})
+
+	return simplifyFolds(e)
+}
+
+// simplifyFolds applies fold rules to an already-recursed expression node.
+func simplifyFolds(e expr.Expression) expr.Expression {
+	switch e := e.(type) {
+	case *expr.Extract:
+		if ms, ok := e.Value.(*expr.MakeStruct); ok {
+			for i, name := range ms.Names {
+				if name == e.Name {
+					return ms.Values[i]
+				}
+			}
+		}
+
+	case *expr.Include:
+		if ms, ok := e.Value.(*expr.MakeStruct); ok {
+			return includeMakeStruct(e.Names, ms)
+		}
+
+	case *expr.Exclude:
+		if ms, ok := e.Value.(*expr.MakeStruct); ok {
+			return excludeMakeStruct(e.Names, ms)
+		}
+	}
+
+	return e
+}
+
+func includeMakeStruct(names []string, ms *expr.MakeStruct) *expr.MakeStruct {
+	resultNames := make([]string, 0, len(names))
+	resultValues := make([]expr.Expression, 0, len(names))
+	for _, name := range names {
+		for i, msName := range ms.Names {
+			if msName == name {
+				resultNames = append(resultNames, name)
+				resultValues = append(resultValues, ms.Values[i])
+				break
+			}
+		}
+	}
+	return &expr.MakeStruct{Names: resultNames, Values: resultValues}
+}
+
+func excludeMakeStruct(names []string, ms *expr.MakeStruct) *expr.MakeStruct {
+	excludeSet := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		excludeSet[name] = struct{}{}
+	}
+	resultNames := make([]string, 0, len(ms.Names))
+	resultValues := make([]expr.Expression, 0, len(ms.Names))
+	for i, name := range ms.Names {
+		if _, excluded := excludeSet[name]; !excluded {
+			resultNames = append(resultNames, name)
+			resultValues = append(resultValues, ms.Values[i])
+		}
+	}
+	return &expr.MakeStruct{Names: resultNames, Values: resultValues}
+}

--- a/pkg/dataset/layout/kind.go
+++ b/pkg/dataset/layout/kind.go
@@ -11,12 +11,14 @@ const (
 
 	KindArray   // KindArray holds a single array.
 	KindChunked // KindChunked holds a set of layout chunks.
+	KindStruct  // KindStruct is a set of named layouts.
 )
 
 var kindNames = [...]string{
 	KindInvalid: "invalid",
 	KindArray:   "array",
 	KindChunked: "chunked",
+	KindStruct:  "struct",
 }
 
 // String returns the string representation of k.

--- a/pkg/dataset/layout/layout.go
+++ b/pkg/dataset/layout/layout.go
@@ -34,6 +34,13 @@ type (
 		Type   types.Type
 		Chunks []Layout
 	}
+
+	// Struct holds a layout per field of a struct type.
+	Struct struct {
+		Type     types.Type
+		Fields   []Layout
+		Validity Layout // Optional; nil if non-nullable.
+	}
 )
 
 // Kind returns [KindArray].
@@ -70,9 +77,33 @@ func (l *Chunked) Len() int {
 	return total
 }
 
+// Kind returns [KindStruct].
+func (l *Struct) Kind() Kind {
+	return KindStruct
+}
+
+// DataType returns the data type of the Struct layout.
+func (l *Struct) DataType() types.Type {
+	return l.Type
+}
+
+// Len returns the number of rows in the Struct. Returns 0 if there are no
+// fields and no validity layout.
+func (l *Struct) Len() int {
+	// All fields must have the same number of rows.
+	if len(l.Fields) > 0 {
+		return l.Fields[0].Len()
+	}
+	if l.Validity != nil {
+		return l.Validity.Len()
+	}
+	return 0
+}
+
 //
 // Sealed marker implementations.
 //
 
 func (l *Array) isLayout()   {}
 func (l *Chunked) isLayout() {}
+func (l *Struct) isLayout()  {}

--- a/pkg/dataset/layout/spec.go
+++ b/pkg/dataset/layout/spec.go
@@ -43,6 +43,12 @@ type (
 		// Chunk is the spec used for all chunks in the layout.
 		Chunk Spec
 	}
+
+	// SpecStruct specifies how to encode fields in a struct layout.
+	SpecStruct struct {
+		Fields   []Spec
+		Validity Spec // Optional; nil for non-nullable structs.
+	}
 )
 
 // Kind returns [KindArray].
@@ -55,9 +61,15 @@ func (spec *SpecChunked) Kind() Kind {
 	return KindChunked
 }
 
+// Kind returns [KindStruct].
+func (spec *SpecStruct) Kind() Kind {
+	return KindStruct
+}
+
 //
 // Sealed marker implementations.
 //
 
 func (spec *SpecArray) isSpec()   {}
 func (spec *SpecChunked) isSpec() {}
+func (spec *SpecStruct) isSpec()  {}

--- a/pkg/expr/evaluate.go
+++ b/pkg/expr/evaluate.go
@@ -24,9 +24,23 @@ import (
 //
 // The return type of Evaluate depends on the expression provided. See the
 // documentation for implementations of Expression for what they produce when
-// evaluated.
+// evaluated. Scalar results are broadcast to the length of an Array input.
 func Evaluate(alloc *memory.Allocator, expr Expression, input columnar.Datum, selection memory.Bitmap) (columnar.Datum, error) {
-	return evaluateWithSelection(alloc, expr, input, selection)
+	result, err := evaluateWithSelection(alloc, expr, input, selection)
+	if err != nil {
+		return nil, err
+	}
+
+	return materializeScalar(alloc, result, input), nil
+}
+
+func materializeScalar(alloc *memory.Allocator, result, input columnar.Datum) columnar.Datum {
+	scalar, isScalar := result.(columnar.Scalar)
+	inputArray, isArray := input.(columnar.Array)
+	if isScalar && isArray {
+		return columnar.Broadcast(alloc, scalar, inputArray.Len())
+	}
+	return result
 }
 
 // inputNumRows returns the number of rows for the given input datum.
@@ -180,6 +194,7 @@ func evaluateMakeStruct(alloc *memory.Allocator, expr *MakeStruct, input columna
 		if err != nil {
 			return nil, err
 		}
+		val = materializeScalar(alloc, val, input)
 		arr, ok := val.(columnar.Array)
 		if !ok {
 			return nil, fmt.Errorf("value %d (%q) must be an array, got %T", i, name, val)

--- a/pkg/expr/evaluate_test.go
+++ b/pkg/expr/evaluate_test.go
@@ -49,11 +49,22 @@ func TestEvaluate_Constant(t *testing.T) {
 
 	e := &expr.Constant{Value: columnartest.Scalar(t, types.KindUint64, 42)}
 
-	expect := columnartest.Scalar(t, types.KindUint64, 42)
+	t.Run("without input", func(t *testing.T) {
+		expect := columnartest.Scalar(t, types.KindUint64, 42)
 
-	result, err := expr.Evaluate(&alloc, e, nil, memory.Bitmap{})
-	require.NoError(t, err)
-	columnartest.RequireDatumsEqual(t, expect, result, memory.Bitmap{})
+		result, err := expr.Evaluate(&alloc, e, nil, memory.Bitmap{})
+		require.NoError(t, err)
+		columnartest.RequireDatumsEqual(t, expect, result, memory.Bitmap{})
+	})
+
+	t.Run("with array input", func(t *testing.T) {
+		input := columnartest.Array(t, types.KindInt64, &alloc, int64(1), int64(2), int64(3))
+		expect := columnartest.Array(t, types.KindUint64, &alloc, 42, 42, 42)
+
+		result, err := expr.Evaluate(&alloc, e, input, memory.Bitmap{})
+		require.NoError(t, err)
+		columnartest.RequireDatumsEqual(t, expect, result, memory.Bitmap{})
+	})
 }
 
 func TestEvaluate_Column(t *testing.T) {
@@ -277,6 +288,25 @@ func TestEvaluate_MakeStruct(t *testing.T) {
 		columnartest.RequireDatumsEqual(t, expect, result, memory.Bitmap{})
 	})
 
+	t.Run("broadcast scalar values", func(t *testing.T) {
+		e := &expr.MakeStruct{
+			Names: []string{"name", "constant"},
+			Values: []expr.Expression{
+				&expr.Column{Name: "name"},
+				&expr.Constant{Value: columnartest.Scalar(t, types.KindInt64, 5)},
+			},
+		}
+
+		expect := columnartest.Struct(t, &alloc,
+			columnartest.Field("name", types.KindUTF8, "Alice", "Bob", "Charlie"),
+			columnartest.Field("constant", types.KindInt64, int64(5), int64(5), int64(5)),
+		)
+
+		result, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
+		require.NoError(t, err)
+		columnartest.RequireDatumsEqual(t, expect, result, memory.Bitmap{})
+	})
+
 	t.Run("mismatched names and values", func(t *testing.T) {
 		e := &expr.MakeStruct{
 			Names:  []string{"a", "b"},
@@ -291,16 +321,6 @@ func TestEvaluate_MakeStruct(t *testing.T) {
 		e := &expr.MakeStruct{
 			Names:  []string{"x", "x"},
 			Values: []expr.Expression{&expr.Column{Name: "name"}, &expr.Column{Name: "age"}},
-		}
-
-		_, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})
-		require.Error(t, err)
-	})
-
-	t.Run("scalar value rejected", func(t *testing.T) {
-		e := &expr.MakeStruct{
-			Names:  []string{"x"},
-			Values: []expr.Expression{&expr.Constant{Value: columnartest.Scalar(t, types.KindUTF8, "hello")}},
 		}
 
 		_, err := expr.Evaluate(&alloc, e, record, memory.Bitmap{})

--- a/pkg/expr/expr.go
+++ b/pkg/expr/expr.go
@@ -16,8 +16,9 @@ type Expression interface{ isExpr() }
 
 // Types implementing [Expression].
 type (
-	// Constant is an [Expression] that produces a single scalar value when
-	// evaluated.
+	// Constant is an [Expression] that produces a scalar value. When a Constant
+	// is the final result evaluated against an Array, it is broadcast to the
+	// Array's length.
 	Constant struct{ Value columnar.Scalar }
 
 	// Column is an [Expression] that looks up the column by name in the record

--- a/pkg/expr/reduce.go
+++ b/pkg/expr/reduce.go
@@ -1,0 +1,244 @@
+package expr
+
+import (
+	"fmt"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/compute"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// Reduce evaluates e by calling fn to resolve each child expression into a
+// [columnar.Datum], then computing the parent operation on those results.
+//
+// Reduce is used when the caller wants to hook into evaluating sub-expressions.
+//
+// Leaf expressions (Constant, Identity, Column) have no children to reduce
+// and are evaluated directly via [Evaluate].
+func Reduce(alloc *memory.Allocator, e Expression, fn func(Expression) (columnar.Datum, error), selection memory.Bitmap) (columnar.Datum, error) {
+	switch e := e.(type) {
+	case *Binary:
+		return reduceBinary(alloc, e, fn, selection)
+	case *Unary:
+		return reduceUnary(alloc, e, fn, selection)
+	case *MakeStruct:
+		return reduceMakeStruct(alloc, e, fn)
+	case *Extract:
+		return reduceExtract(alloc, e, fn)
+	case *Include:
+		return reduceInclude(alloc, e, fn)
+	case *Exclude:
+		return reduceExclude(alloc, e, fn)
+	default:
+		panic(fmt.Sprintf("Reduce called on leaf expression %T; use fn to handle leaves", e))
+	}
+}
+
+func reduceBinary(alloc *memory.Allocator, e *Binary, fn func(Expression) (columnar.Datum, error), selection memory.Bitmap) (columnar.Datum, error) {
+	// Special operators where the right side is not evaluated to a Datum.
+	// This mirrors evaluateSpecialBinary in evaluate.go.
+	switch e.Op {
+	case BinaryOpMatchRegex:
+		left, err := fn(e.Left)
+		if err != nil {
+			return nil, err
+		}
+		right, ok := e.Right.(*Regexp)
+		if !ok {
+			return nil, fmt.Errorf("right-hand side of regex match must be a Regexp, got %T", e.Right)
+		}
+		return compute.RegexpMatch(alloc, left, right.Expression, selection)
+
+	case BinaryOpIn:
+		left, err := fn(e.Left)
+		if err != nil {
+			return nil, err
+		}
+		right, ok := e.Right.(*ValueSet)
+		if !ok {
+			return nil, fmt.Errorf("right-hand side of in must be a ValueSet, got %T", e.Right)
+		}
+		return compute.IsMember(alloc, left, right.Values, selection)
+	}
+
+	left, err := fn(e.Left)
+	if err != nil {
+		return nil, err
+	}
+	right, err := fn(e.Right)
+	if err != nil {
+		return nil, err
+	}
+
+	switch e.Op {
+	case BinaryOpEQ:
+		return compute.Equals(alloc, left, right, selection)
+	case BinaryOpNEQ:
+		return compute.NotEquals(alloc, left, right, selection)
+	case BinaryOpGT:
+		return compute.GreaterThan(alloc, left, right, selection)
+	case BinaryOpGTE:
+		return compute.GreaterOrEqual(alloc, left, right, selection)
+	case BinaryOpLT:
+		return compute.LessThan(alloc, left, right, selection)
+	case BinaryOpLTE:
+		return compute.LessOrEqual(alloc, left, right, selection)
+	case BinaryOpAND:
+		return compute.And(alloc, left, right, selection)
+	case BinaryOpOR:
+		return compute.Or(alloc, left, right, selection)
+	case BinaryOpHasSubstr:
+		return compute.Substr(alloc, left, right, selection)
+	case BinaryOpHasSubstrIgnoreCase:
+		return compute.SubstrInsensitive(alloc, left, right, selection)
+	default:
+		return nil, fmt.Errorf("unexpected binary operator %s", e.Op)
+	}
+}
+
+func reduceUnary(alloc *memory.Allocator, e *Unary, fn func(Expression) (columnar.Datum, error), selection memory.Bitmap) (columnar.Datum, error) {
+	value, err := fn(e.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	switch e.Op {
+	case UnaryOpNOT:
+		return compute.Not(alloc, value, selection)
+	default:
+		return nil, fmt.Errorf("unexpected unary operator %s", e.Op)
+	}
+}
+
+func reduceMakeStruct(_ *memory.Allocator, e *MakeStruct, fn func(Expression) (columnar.Datum, error)) (columnar.Datum, error) {
+	if len(e.Names) != len(e.Values) {
+		return nil, fmt.Errorf("MakeStruct: names and values count mismatch: %d != %d", len(e.Names), len(e.Values))
+	}
+	if err := validateUniqueNames(e.Names); err != nil {
+		return nil, fmt.Errorf("MakeStruct: %w", err)
+	}
+
+	columns := make([]columnar.Column, len(e.Names))
+	fields := make([]columnar.Array, len(e.Values))
+
+	for i, name := range e.Names {
+		val, err := fn(e.Values[i])
+		if err != nil {
+			return nil, fmt.Errorf("field %q: %w", name, err)
+		}
+		arr, ok := val.(columnar.Array)
+		if !ok {
+			return nil, fmt.Errorf("MakeStruct: field %q must be an array, got %T", name, val)
+		}
+		columns[i] = columnar.Column{Name: name}
+		fields[i] = arr
+	}
+
+	length := 0
+	if len(fields) > 0 {
+		length = fields[0].Len()
+	}
+
+	schema := columnar.NewSchema(columns)
+	return columnar.NewStruct(schema, fields, length, memory.Bitmap{}), nil
+}
+
+func reduceExtract(alloc *memory.Allocator, e *Extract, fn func(Expression) (columnar.Datum, error)) (columnar.Datum, error) {
+	value, err := fn(e.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	s, ok := value.(*columnar.Struct)
+	if !ok {
+		return nil, fmt.Errorf("Extract requires Struct, got %T", value)
+	}
+
+	columnIndex := -1
+	if schema := s.Schema(); schema != nil {
+		_, columnIndex = schema.ColumnIndex(e.Name)
+	}
+
+	if columnIndex == -1 {
+		validity := memory.NewBitmap(alloc, s.Len())
+		validity.AppendCount(false, s.Len())
+		return columnar.NewNull(validity), nil
+	}
+
+	return s.Field(columnIndex), nil
+}
+
+func reduceInclude(_ *memory.Allocator, e *Include, fn func(Expression) (columnar.Datum, error)) (columnar.Datum, error) {
+	value, err := fn(e.Value)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateUniqueNames(e.Names); err != nil {
+		return nil, fmt.Errorf("Include: %w", err)
+	}
+
+	s, ok := value.(*columnar.Struct)
+	if !ok {
+		return nil, fmt.Errorf("Include requires Struct, got %T", value)
+	}
+
+	var (
+		columns []columnar.Column
+		fields  []columnar.Array
+	)
+	for _, name := range e.Names {
+		_, idx := s.Schema().ColumnIndex(name)
+		if idx == -1 {
+			continue
+		}
+		columns = append(columns, columnar.Column{Name: name})
+		fields = append(fields, s.Field(idx))
+	}
+
+	schema := columnar.NewSchema(columns)
+	return columnar.NewStruct(schema, fields, s.Len(), s.Validity()), nil
+}
+
+func validateUniqueNames(names []string) error {
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if _, ok := seen[name]; ok {
+			return fmt.Errorf("duplicate field name %q", name)
+		}
+		seen[name] = struct{}{}
+	}
+	return nil
+}
+
+func reduceExclude(_ *memory.Allocator, e *Exclude, fn func(Expression) (columnar.Datum, error)) (columnar.Datum, error) {
+	value, err := fn(e.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	s, ok := value.(*columnar.Struct)
+	if !ok {
+		return nil, fmt.Errorf("Exclude requires Struct, got %T", value)
+	}
+
+	excludeSet := make(map[string]struct{}, len(e.Names))
+	for _, name := range e.Names {
+		excludeSet[name] = struct{}{}
+	}
+
+	var (
+		columns []columnar.Column
+		fields  []columnar.Array
+	)
+	for i := range s.NumFields() {
+		col := s.Schema().Column(i)
+		if _, excluded := excludeSet[col.Name]; excluded {
+			continue
+		}
+		columns = append(columns, col)
+		fields = append(fields, s.Field(i))
+	}
+
+	schema := columnar.NewSchema(columns)
+	return columnar.NewStruct(schema, fields, s.Len(), s.Validity()), nil
+}

--- a/pkg/expr/reduce_test.go
+++ b/pkg/expr/reduce_test.go
@@ -1,0 +1,34 @@
+package expr_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/expr"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestReduce_DuplicateFieldNames(t *testing.T) {
+	var alloc memory.Allocator
+
+	tests := map[string]expr.Expression{
+		"make struct": &expr.MakeStruct{
+			Names:  []string{"x", "x"},
+			Values: []expr.Expression{&expr.Identity{}, &expr.Identity{}},
+		},
+		"include": &expr.Include{
+			Names: []string{"x", "x"},
+			Value: &expr.Identity{},
+		},
+	}
+	for name, expression := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := expr.Reduce(&alloc, expression, func(expr.Expression) (columnar.Datum, error) {
+				return nil, nil
+			}, memory.Bitmap{})
+			require.ErrorContains(t, err, "duplicate field name")
+		})
+	}
+}

--- a/pkg/expr/walk.go
+++ b/pkg/expr/walk.go
@@ -1,0 +1,69 @@
+package expr
+
+import "fmt"
+
+// Walk calls fn on e and then recursively on every descendant expression in
+// pre-order. Nil expressions are silently skipped.
+func Walk(e Expression, fn func(Expression)) {
+	if e == nil {
+		return
+	}
+	fn(e)
+	ForEach(e, func(child Expression) {
+		Walk(child, fn)
+	})
+}
+
+// Map returns a shallow copy of e with each direct child expression replaced
+// by the result of fn. Leaf nodes (Column, Constant, Identity, Regexp,
+// ValueSet) have no children and are returned unchanged.
+func Map(e Expression, fn func(Expression) Expression) Expression {
+	switch e := e.(type) {
+	case *Column, *Constant, *Identity, *Regexp, *ValueSet:
+		return e
+	case *Binary:
+		return &Binary{Left: fn(e.Left), Op: e.Op, Right: fn(e.Right)}
+	case *Unary:
+		return &Unary{Op: e.Op, Value: fn(e.Value)}
+	case *Extract:
+		return &Extract{Name: e.Name, Value: fn(e.Value)}
+	case *Include:
+		return &Include{Names: e.Names, Value: fn(e.Value)}
+	case *Exclude:
+		return &Exclude{Names: e.Names, Value: fn(e.Value)}
+	case *MakeStruct:
+		values := make([]Expression, len(e.Values))
+		for i, v := range e.Values {
+			values[i] = fn(v)
+		}
+		return &MakeStruct{Names: e.Names, Values: values}
+	default:
+		panic(fmt.Sprintf("Map: unexpected expression type %T", e))
+	}
+}
+
+// ForEach calls fn on each direct child expression of e.
+// Leaf nodes have no children, so fn is never called for them.
+func ForEach(e Expression, fn func(Expression)) {
+	switch e := e.(type) {
+	case nil, *Column, *Constant, *Identity, *Regexp, *ValueSet:
+		// Leaf nodes have no children.
+	case *Binary:
+		fn(e.Left)
+		fn(e.Right)
+	case *Unary:
+		fn(e.Value)
+	case *Extract:
+		fn(e.Value)
+	case *Include:
+		fn(e.Value)
+	case *Exclude:
+		fn(e.Value)
+	case *MakeStruct:
+		for _, v := range e.Values {
+			fn(v)
+		}
+	default:
+		panic(fmt.Sprintf("ForEach: unexpected expression type %T", e))
+	}
+}


### PR DESCRIPTION
Introduce a Struct layout, which holds a sequence of child Layouts, one per struct field. Each child Layout may have its own data type.

A typical common hierarchy is

    Struct
      Chunked # column-a
        Array
        Array
        ...
      Chunked # column-b
        ...
      Chunked # column-c
        ...

This includes two things:

* A fix for `expr.Evaluate` where evaluating a scalar always resulted in a scalar regardless of the input: this was intended to be broadcast to an array. A `columnar.Broadcast` utility function is added to support this.

* A `compute.PropagateNulls` function to allow propagating parent nulls to a child datum. 
