### PR TITLE
chore(deps): Group aws-sdk-go-v2 modules into a single Renovate PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -207,6 +207,25 @@
       autoApprove: false,
     },
     {
+      // Group the aws-sdk-go-v2 family into a single PR. The sub-modules version in
+      // lockstep, so per-module PRs (via the '{{packageName}}' grouping above) conflict
+      // against each other on the shared go.sum. This overrides only groupName, inheriting
+      // the enable/automerge/minimumReleaseAge behaviour from the gomod rules above.
+      matchManagers: [
+        'gomod',
+      ],
+      matchPackageNames: [
+        'github.com/aws/aws-sdk-go-v2',
+        'github.com/aws/aws-sdk-go-v2/**',
+      ],
+      matchFileNames: [
+        '!operator/go.mod',
+        '!operator/api/loki/go.mod',
+        '!pkg/push/go.mod',
+      ],
+      groupName: 'aws-sdk-go-v2',
+    },
+    {
       // Pin kprom to 1.2.x range, ignore 1.3.0+ updates due to a conflict with a metric introduced in this version.
       // Can be upgraded once adapative metrics and Mimir have upgraded.
       matchPackageNames: [


### PR DESCRIPTION
## What

Adds a `packageRule` to `.github/renovate.json5` that groups the entire `aws-sdk-go-v2` module family (`github.com/aws/aws-sdk-go-v2` and all sub-modules) under a single `groupName`, so they update together in one PR instead of ~40 separate ones.

## Why

The existing `gomod` rules group by `{{packageName}}`, which opens a separate PR per module. Because the aws-sdk-go-v2 sub-modules version in lockstep, those per-module PRs conflict against each other on the shared `go.sum` and never merge cleanly — currently ~10 of the open aws-sdk-go-v2 PRs on `main` are in a conflicting state. The volume also inflates the dependency dashboard (#19437) past GitHub's issue-body limit, so it renders truncated.

The new rule overrides only `groupName`; it inherits enable / automerge / `minimumReleaseAge: 3 days` from the `gomod` rules above it, and keeps the `operator/` and `pkg/push/go.mod` exclusions consistent with the surrounding rules.

## Validation

`renovate-config-validator` (run via the `renovate/renovate` Docker image) reports `Config validated successfully`.

Note: existing per-module aws-sdk-go-v2 PRs won't retroactively merge — after this lands, Renovate supersedes them with one grouped PR on its next run and closes the stragglers.