### PR TITLE
chore(ruler): Add support for adding a wrapper  for rule evaluator

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -435,6 +435,7 @@ type Loki struct {
 	frontend                            Frontend
 	ruler                               *base_ruler.Ruler
 	ruleEvaluator                       ruler.Evaluator
+	RulerEvaluatorWrapper               func(ruler.Evaluator) ruler.Evaluator
 	RulerStorage                        rulestore.RuleStore
 	rulerAPI                            *base_ruler.API
 	stopper                             queryrange.Stopper

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1681,6 +1681,10 @@ func (t *Loki) initRuleEvaluator() (services.Service, error) {
 
 	t.ruleEvaluator = ruler.NewEvaluatorWithJitter(evaluator, t.Cfg.Ruler.Evaluation.MaxJitter, fnv.New32a(), logger)
 
+	if t.RulerEvaluatorWrapper != nil {
+		t.ruleEvaluator = t.RulerEvaluatorWrapper(t.ruleEvaluator)
+	}
+
 	return svc, nil
 }
 

--- a/pkg/ruler/evaluator_local.go
+++ b/pkg/ruler/evaluator_local.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/user"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/grafana/loki/v3/pkg/util"
-	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
 
 const EvalModeLocal = "local"
@@ -20,11 +20,6 @@ const EvalModeLocal = "local"
 type LocalEvaluator struct {
 	engine *logql.QueryEngine
 	logger log.Logger
-
-	// we don't want/need to log all the additional context, such as
-	// caller=spanlogger.go:116 component=ruler evaluation_mode=remote method=ruler.remoteEvaluation.Query
-	// in insights logs, so create a new logger
-	insightsLogger log.Logger
 }
 
 func NewLocalEvaluator(engine *logql.QueryEngine, logger log.Logger) (*LocalEvaluator, error) {
@@ -33,9 +28,8 @@ func NewLocalEvaluator(engine *logql.QueryEngine, logger log.Logger) (*LocalEval
 	}
 
 	return &LocalEvaluator{
-		engine:         engine,
-		logger:         logger,
-		insightsLogger: log.With(util_log.Logger, "msg", "request timings", "insight", "true", "source", "loki_ruler"),
+		engine: engine,
+		logger: logger,
 	}, nil
 }
 
@@ -63,7 +57,8 @@ func (l *LocalEvaluator) Eval(ctx context.Context, qs string, now time.Time) (*l
 
 	// Retrieve rule details from context
 	ruleName, ruleType := GetRuleDetailsFromContext(ctx)
+	orgID, _ := user.ExtractOrgID(ctx)
 
-	level.Info(l.insightsLogger).Log("rule_name", ruleName, "rule_type", ruleType, "total", res.Statistics.Summary.ExecTime, "total_bytes", res.Statistics.Summary.TotalBytesProcessed, "query_hash", util.HashedQuery(qs))
+	level.Info(l.logger).Log("msg", "rule evaluation succeeded", "tenant_id", orgID, "rule_name", ruleName, "rule_type", ruleType, "total", res.Statistics.Summary.ExecTime, "total_bytes", res.Statistics.Summary.TotalBytesProcessed, "query_hash", util.HashedQuery(qs))
 	return &res, nil
 }

--- a/pkg/ruler/evaluator_remote.go
+++ b/pkg/ruler/evaluator_remote.go
@@ -39,7 +39,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/build"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
-	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 )
 
@@ -70,21 +69,15 @@ type RemoteEvaluator struct {
 	overrides RulesLimits
 	logger    log.Logger
 
-	// we don't want/need to log all the additional context, such as
-	// caller=spanlogger.go:116 component=ruler evaluation_mode=remote method=ruler.remoteEvaluation.Query
-	// in insights logs, so create a new logger
-	insightsLogger log.Logger
-
 	metrics *metrics
 }
 
 func NewRemoteEvaluator(client httpgrpc.HTTPClient, overrides RulesLimits, logger log.Logger, registerer prometheus.Registerer) (*RemoteEvaluator, error) {
 	return &RemoteEvaluator{
-		client:         client,
-		overrides:      overrides,
-		logger:         logger,
-		insightsLogger: log.With(util_log.Logger, "msg", "request timings", "insight", "true", "source", "loki_ruler"),
-		metrics:        newMetrics(registerer),
+		client:    client,
+		overrides: overrides,
+		logger:    logger,
+		metrics:   newMetrics(registerer),
 	}, nil
 }
 
@@ -281,14 +274,14 @@ func (r *RemoteEvaluator) query(ctx context.Context, orgID, query string, ts tim
 		return nil, fmt.Errorf("%d bytes exceeds response size limit of %d (defined by ruler_remote_evaluation_max_response_size)", len(resp.Body), maxSize)
 	}
 
-	level.Debug(logger).Log("msg", "rule evaluation succeeded")
 	r.metrics.successfulEvals.WithLabelValues(orgID).Inc()
 
 	dr, err := r.decodeResponse(ctx, resp, orgID)
 	if err != nil {
 		return nil, err
 	}
-	level.Info(r.insightsLogger).Log("rule_name", ruleName, "rule_type", ruleType, "total", dr.Statistics.Summary.ExecTime, "total_bytes", dr.Statistics.Summary.TotalBytesProcessed, "query_hash", util.HashedQuery(query))
+
+	level.Info(logger).Log("msg", "rule evaluation succeeded", "rule_name", ruleName, "rule_type", ruleType, "total", dr.Statistics.Summary.ExecTime, "total_bytes", dr.Statistics.Summary.TotalBytesProcessed)
 	return dr, err
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Two small, self-contained changes to the ruler:

1. **Add `Loki.RulerEvaluatorWrapper`** — an optional hook, applied at the end of `initRuleEvaluator`, that lets an embedding application decorate the `ruler.Evaluator` (e.g. to add extra behaviour around rule evaluation). It defaults to `nil`, so the default behaviour should stay unchanged.

2. **Improve the ruler's per-evaluation logging** — the existing `request timings` log event did not have the tenant ID in it, so there was no way to tell which tenant the log belonged to. I have removed it and merged it with the existing `rule evaluation succeeded` log event.