### PR TITLE
fix(compaction): Stop using the default sort_schema in index compaction

### DIFF
--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -58,11 +58,11 @@ type logsCalculationContext struct {
 }
 
 // These steps are applied to all logs and are unique to a section
-func getLogsCalculationSteps() []logsIndexCalculation {
+func getLogsCalculationSteps(sortSchemaKeys []string) []logsIndexCalculation {
 	return []logsIndexCalculation{
 		&streamStatisticsCalculation{},
 		&columnValuesCalculation{},
-		&statsCalculation{sortSchemaKeys: defaultSortSchemaKeys},
+		&statsCalculation{sortSchemaKeys: sortSchemaKeys},
 		&labelPostingsCalculation{},
 	}
 }
@@ -226,6 +226,11 @@ func (c *Calculator) processLogsSection(ctx context.Context, sectionLogger log.L
 		return fmt.Errorf("failed to open logs section: %w", err)
 	}
 
+	schemaLabels, err := logsSection.SchemaLabels()
+	if err != nil {
+		return fmt.Errorf("failed to read logs section schema labels: %w", err)
+	}
+
 	tenantID := section.Tenant
 
 	// Fetch the column statistics in order to init the bloom filters for each column
@@ -250,7 +255,7 @@ func (c *Calculator) processLogsSection(ctx context.Context, sectionLogger log.L
 	lockFreeContext := *calculationContext
 	lockFreeContext.builder = nil
 
-	calculationSteps := getLogsCalculationSteps()
+	calculationSteps := getLogsCalculationSteps(schemaSortKeys(schemaLabels))
 
 	// Track cumulative duration per calculation step across all batches + flush.
 	stepDurations := make([]time.Duration, len(calculationSteps))

--- a/pkg/dataobj/index/sort_schema.go
+++ b/pkg/dataobj/index/sort_schema.go
@@ -1,5 +1,26 @@
 package index
 
+import "strings"
+
 // defaultSortSchemaKeys defines the label keys used for stats and postings
-// sections. Currently hardcoded; will become configurable per tenant.
+// sections when a logs section carries no schema sort of its own.
 var defaultSortSchemaKeys = []string{"service_name"}
+
+// schemaSortKeys converts a logs section's fully-qualified schema labels (e.g.
+// "label:service_name") into label keys
+func schemaSortKeys(fqns []string) []string {
+	if len(fqns) == 0 {
+		return defaultSortSchemaKeys
+	}
+	keys := make([]string, 0, len(fqns))
+	for _, fqn := range fqns {
+		// Only "label:<name>" keys are supported. Anything else means we cannot
+		// reproduce the sort key here, so fall back to the default.
+		typ, name, ok := strings.Cut(fqn, ":")
+		if !ok || typ != "label" || name == "" {
+			return defaultSortSchemaKeys
+		}
+		keys = append(keys, name)
+	}
+	return keys
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The index calculator hardcoded the stats section's SortSchema to defaultSortSchemaKeys = ["service_name"], ignoring how the logs section was actually sorted. 
Log-compaction later reads that stats SortSchema to tell the k-way merge what ordering to expect, which then compares it against each physical section's real SchemaLabels() — and rejects the whole merge on mismatch. So any tenant sorted by more than service_name never converged. 

This PR records the section's actual sort schema instead of the default.