### PR TITLE
ci: Bump helm-release to a commit that uses output.token

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   call-update-helm-repo:
-    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@d2a579570e204ebc7d36c9be654159be01abff17
+    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@0cb44b98b41df1bc345376ac40897453fa88df93
     permissions:
       contents: "write"
       id-token: "write"


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps the workflow to a version that uses `output.token`.


**Which issue(s) this PR fixes**:
Failing [run](https://github.com/grafana/loki/actions/runs/29422403306/job/87380048648)

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
