### PR TITLE
fix(engine): Remove redundant line format compatibility 🤖🤖🤖

### DIFF
--- a/pkg/engine/internal/planner/physical/planner.go
+++ b/pkg/engine/internal/planner/physical/planner.go
@@ -780,6 +780,7 @@ func (p *Planner) Optimize(plan *Plan) (*Plan, error) {
 			// Perform cleanups at the very end.
 			newOptimization("Cleanup", plan).withRules(
 				&removeNoopFilter{plan: plan},
+				&removeNoopCompat{plan: plan},
 			),
 		}
 		optimizer := NewOptimizer(plan, optimizations)

--- a/pkg/engine/internal/planner/physical/rule_remove_noop_compat.go
+++ b/pkg/engine/internal/planner/physical/rule_remove_noop_compat.go
@@ -1,0 +1,45 @@
+package physical
+
+import "github.com/grafana/loki/v3/pkg/engine/internal/types"
+
+var _ rule = (*removeNoopCompat)(nil)
+
+// removeNoopCompat removes parsed compatibility after line_format projections.
+// line_format does not produce parsed columns, so the compatibility node would
+// only reprocess columns normalized by earlier parser stages.
+type removeNoopCompat struct {
+	plan *Plan
+}
+
+// apply implements rule.
+func (r *removeNoopCompat) apply(_ Node) bool {
+	// Parallel pushdown may replace the root before cleanup runs, so inspect the
+	// current graph instead of walking from the original root.
+	var nodes []Node
+	for node := range r.plan.graph.Nodes() {
+		compat, ok := node.(*ColumnCompat)
+		if !ok || compat.Source != types.ColumnTypeParsed {
+			continue
+		}
+
+		children := r.plan.Children(compat)
+		if len(children) != 1 {
+			continue
+		}
+
+		projection, ok := children[0].(*Projection)
+		if !ok || len(projection.Expressions) != 1 {
+			continue
+		}
+
+		expr, ok := projection.Expressions[0].(*VariadicExpr)
+		if ok && expr.Op == types.VariadicOpParseLinefmt {
+			nodes = append(nodes, node)
+		}
+	}
+
+	for _, node := range nodes {
+		r.plan.graph.Eliminate(node)
+	}
+	return len(nodes) > 0
+}

--- a/pkg/engine/internal/planner/physical/rule_remove_noop_compat_test.go
+++ b/pkg/engine/internal/planner/physical/rule_remove_noop_compat_test.go
@@ -1,0 +1,102 @@
+package physical
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/engine/internal/planner/logical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/types"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql"
+)
+
+func TestRemoveNoopCompat(t *testing.T) {
+	start := time.Unix(0, 0)
+	end := start.Add(time.Hour)
+
+	tests := []struct {
+		name          string
+		query         string
+		formatOp      types.VariadicOp
+		wantCompatOps []types.VariadicOp
+	}{
+		{
+			name:          "line format",
+			query:         `{app="loki"} | json | line_format "{{.level}}"`,
+			formatOp:      types.VariadicOpParseLinefmt,
+			wantCompatOps: []types.VariadicOp{types.VariadicOpParseJSON},
+		},
+		{
+			name:     "label format",
+			query:    `{app="loki"} | json | label_format severity=level`,
+			formatOp: types.VariadicOpParseLabelfmt,
+			wantCompatOps: []types.VariadicOp{
+				types.VariadicOpParseJSON,
+				types.VariadicOpParseLabelfmt,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params, err := logql.NewLiteralParams(
+				tt.query,
+				start, end,
+				0, 0,
+				logproto.BACKWARD,
+				100,
+				[]string{"0_of_1"},
+				nil,
+			)
+			require.NoError(t, err)
+			logicalPlan, err := logical.BuildPlan(context.Background(), params)
+			require.NoError(t, err)
+
+			planner := NewPlanner(NewContext(start, end), &catalog{
+				sectionDescriptors: []*metastore.DataobjSectionDescriptor{
+					{Start: start, End: end},
+				},
+			})
+			plan, err := planner.Build(logicalPlan)
+			require.NoError(t, err)
+			requireCompatProjections(t, plan, 3, types.VariadicOpParseJSON, tt.formatOp)
+
+			plan, err = planner.Optimize(plan)
+			require.NoError(t, err)
+			requireCompatProjections(t, plan, len(tt.wantCompatOps)+1, tt.wantCompatOps...)
+		})
+	}
+}
+
+func requireCompatProjections(t *testing.T, plan *Plan, wantCount int, wantOps ...types.VariadicOp) {
+	t.Helper()
+
+	root, err := plan.Root()
+	require.NoError(t, err)
+	compatNodes := findMatchingNodes(plan, root, func(node Node) bool {
+		_, ok := node.(*ColumnCompat)
+		return ok
+	})
+	require.Len(t, compatNodes, wantCount)
+
+	var compatOps []types.VariadicOp
+	for _, node := range compatNodes {
+		children := plan.Children(node)
+		if len(children) != 1 {
+			continue
+		}
+		projection, ok := children[0].(*Projection)
+		if !ok || len(projection.Expressions) != 1 {
+			continue
+		}
+		expr, ok := projection.Expressions[0].(*VariadicExpr)
+		if ok {
+			compatOps = append(compatOps, expr.Op)
+		}
+	}
+	require.ElementsMatch(t, wantOps, compatOps)
+}


### PR DESCRIPTION
The physical planner adds parsed column compatibility after `line_format`, even though that stage has no new parsed fields to reconcile. The extra compatibility pass only reprocesses collision output from earlier parser stages. When generated `_extracted` fields overlap with literal parsed fields, it can treat the same column as both a destination and a source, panic, and terminate the worker.

Remove the redundant compatibility node during physical plan cleanup. This removes a planner-generated path that has caused worker panics for `| json | line_format` queries with colliding fields, without changing LogQL collision behavior. Compatibility remains in place after parsers, `label_format`, and stored metadata.
