### PR TITLE
fix(engine): Return errors instead of panicking in executor pipelines

### DIFF
--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"runtime"
 	"runtime/pprof"
 	gotrace "runtime/trace"
 	"sync"
@@ -473,8 +474,21 @@ func recordBatchBytes(rec arrow.RecordBatch) int64 {
 	return n
 }
 
-func (t *thread) drainPipeline(ctx context.Context, taskType taskType, slotPhase *slotPhaseTracker, pipeline executor.Pipeline, sinks []recordSink, logger log.Logger) (int, error) {
+func (t *thread) drainPipeline(ctx context.Context, taskType taskType, slotPhase *slotPhaseTracker, pipeline executor.Pipeline, sinks []recordSink, logger log.Logger) (totalRows int, retErr error) {
 	region := xcap.RegionFromContext(ctx)
+
+	// Draining runs on the worker thread's goroutine, which is not covered by any
+	// request-level recovery middleware. An unrecovered panic here (e.g. from a
+	// pipeline operator) would crash the entire worker process and abort every
+	// in-flight task. Convert it into a task error so only this task fails.
+	defer func() {
+		if p := recover(); p != nil {
+			stack := make([]byte, 8*1024)
+			stack = stack[:runtime.Stack(stack, false)]
+			level.Error(logger).Log("msg", "recovered from panic while draining pipeline", "panic", p, "stack", string(stack))
+			retErr = fmt.Errorf("panic while draining pipeline: %v", p)
+		}
+	}()
 
 	var (
 		openDuration  time.Duration
@@ -501,7 +515,6 @@ func (t *thread) drainPipeline(ctx context.Context, taskType taskType, slotPhase
 		return 0, openErr
 	}
 
-	var totalRows int
 	for {
 		startRead := time.Now()
 		rec, err := pipeline.Read(ctx)

--- a/pkg/engine/internal/worker/thread_test.go
+++ b/pkg/engine/internal/worker/thread_test.go
@@ -95,6 +95,25 @@ func (p failingPipeline) Open(context.Context) error                      { retu
 func (p failingPipeline) Read(context.Context) (arrow.RecordBatch, error) { return nil, p.readErr }
 func (p failingPipeline) Close()                                          {}
 
+// panicPipeline panics on Read to exercise drainPipeline's recovery.
+type panicPipeline struct{}
+
+func (panicPipeline) Open(context.Context) error                      { return nil }
+func (panicPipeline) Read(context.Context) (arrow.RecordBatch, error) { panic("boom from pipeline") }
+func (panicPipeline) Close()                                          {}
+
+func TestThread_drainPipeline_RecoversFromPanic(t *testing.T) {
+	th := &thread{Logger: log.NewNopLogger(), Metrics: newMetrics()}
+
+	// A panic while draining must be converted into an error rather than
+	// propagating and crashing the worker process.
+	totalRows, err := th.drainPipeline(t.Context(), taskTypeLeaf, nil, panicPipeline{}, nil, log.NewNopLogger())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "panic while draining pipeline")
+	require.ErrorContains(t, err, "boom from pipeline")
+	require.Equal(t, 0, totalRows)
+}
+
 func TestThread_drainPipeline_RecordsPhasesOnFailure(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Several executor pipeline operators panicked on unexpected plan/data shapes during Open/Read or pipeline construction. Because worker threads drain pipelines on bare goroutines (and merge prefetch reads run on their own goroutines), those panics are not covered by the request-level recovery middleware and crash the entire worker process.

Add a recover() in worker drainPipeline as a defence-in-depth backstop that turns any panic on the drain goroutine into a task error rather than a process crash.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
https://github.com/grafana/loki-private/issues/2632

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
