### PR TITLE
fix(engine): Handle layered ColumnCompat `_extracted` collisions

### DIFF
--- a/pkg/engine/internal/executor/compat.go
+++ b/pkg/engine/internal/executor/compat.go
@@ -87,6 +87,16 @@ func newColumnCompatibilityPipeline(compat *physical.ColumnCompat, input Pipelin
 			return cmp.Compare(a.name, b.name)
 		})
 
+		// Names of all colliding source columns. Used below to recognise a source
+		// column that is itself the _extracted destination of a lower-named
+		// duplicate (e.g. a parsed "foo_extracted" column present when parsed "foo"
+		// also collides). Such a column cannot simply be merged into the recreated
+		// destination; its value must cascade up another _extracted level.
+		dupNames := make(map[string]bool, len(duplicates))
+		for i := range duplicates {
+			dupNames[duplicates[i].name] = true
+		}
+
 		// Next, update the schema with the new columns that have the _extracted suffix.
 		oldSchema := batch.Schema()
 
@@ -110,6 +120,15 @@ func newColumnCompatibilityPipeline(compat *physical.ColumnCompat, input Pipelin
 
 			if destinationNames[ident.ShortName()] {
 				if ident.ColumnType() == compat.Destination {
+					if dupNames[ident.ShortName()] {
+						// This _extracted column is itself a colliding source (it has its
+						// own duplicate). Its slot is taken over by the lower-named
+						// duplicate's destination, and its value cascades to
+						// <name>_extracted (processed as a "cascading source" below).
+						// Skip it here WITHOUT recording it as an existing destination to
+						// merge, so the lower-named duplicate recreates a fresh column.
+						continue
+					}
 					// Skip existing _extracted columns that we're going to recreate
 					// But save a reference to their data so we can preserve values
 					existingDestCols[ident.ShortName()] = batch.Column(oldIdx).(*array.String)
@@ -186,10 +205,26 @@ func newColumnCompatibilityPipeline(compat *physical.ColumnCompat, input Pipelin
 				collisionCols[i] = batch.Column(collIdx)
 			}
 
-			// Get the new index for this source field
-			sourceNewIdx, ok := oldFieldToNewIdx[oldIdx]
-			if !ok {
-				panic("sourceNewIdx not foud")
+			// Get the new index for this source field.
+			sourceNewIdx, hasSourceSlot := oldFieldToNewIdx[oldIdx]
+			if !hasSourceSlot {
+				// Cascading source: this column's original slot was taken over by a
+				// lower-named duplicate's destination (e.g. parsed.foo_extracted's slot
+				// is reused by parsed.foo's destination). Its value moves up one
+				// _extracted level into its own destination, matching the classic engine
+				// which appends an additional _extracted suffix on repeated collisions.
+				// There is no source slot left to clear.
+				srcCol := col.(*array.String)
+				destinationFieldBuilder := builder.Field(duplicate.destinationIdx).(*array.StringBuilder)
+				for i := range int(batch.NumRows()) {
+					if srcCol.IsNull(i) || !srcCol.IsValid(i) {
+						destinationFieldBuilder.AppendNull()
+					} else {
+						destinationFieldBuilder.Append(srcCol.Value(i))
+					}
+				}
+				newSchemaColumns[duplicate.destinationIdx] = destinationFieldBuilder.NewArray()
+				continue
 			}
 
 			switch sourceFieldBuilder := builder.Field(sourceNewIdx).(type) {

--- a/pkg/engine/internal/executor/compat_test.go
+++ b/pkg/engine/internal/executor/compat_test.go
@@ -721,3 +721,38 @@ func TestMultipleColumnCompatPreservesValues(t *testing.T) {
 		})
 	}
 }
+
+func TestNewColumnCompatibilityPipeline_LiteralExtractedCollision(t *testing.T) {
+	schema := arrow.NewSchema([]arrow.Field{
+		semconv.FieldFromFQN("utf8.label.foo", true),
+		semconv.FieldFromFQN("utf8.label.foo_extracted", true),
+		semconv.FieldFromFQN("utf8.parsed.foo", true),
+		semconv.FieldFromFQN("utf8.parsed.foo_extracted", true),
+	}, nil)
+	input := NewArrowtestPipeline(schema, arrowtest.Rows{{
+		"utf8.label.foo":            "L",
+		"utf8.label.foo_extracted":  "L2",
+		"utf8.parsed.foo":           "P",
+		"utf8.parsed.foo_extracted": "Q",
+	}})
+	pipeline := newColumnCompatibilityPipeline(&physical.ColumnCompat{
+		Source:      types.ColumnTypeParsed,
+		Destination: types.ColumnTypeParsed,
+		Collisions:  []types.ColumnType{types.ColumnTypeLabel, types.ColumnTypeMetadata},
+	}, input)
+	t.Cleanup(pipeline.Close)
+
+	record, err := pipeline.Read(t.Context())
+	require.NoError(t, err)
+	actual, err := arrowtest.RecordRows(record)
+	require.NoError(t, err)
+
+	expect := arrowtest.Rows{{
+		"utf8.label.foo":                      "L",
+		"utf8.label.foo_extracted":            nil,
+		"utf8.parsed.foo":                     nil,
+		"utf8.parsed.foo_extracted":           "P",
+		"utf8.parsed.foo_extracted_extracted": "Q",
+	}}
+	require.Equal(t, expect, actual)
+}


### PR DESCRIPTION
When Source == Destination (the normal case for parser stages), a source column can share the "<name>_extracted" name with an existing destination column - either carried over from an earlier stage, or a literal field a parser emitted (e.g. a line with both `foo` and `foo_extracted`). The old code classified it as both a fresh source and a to-be-recreated destination, leaving its original slot out of the rebuilt schema and panicking with "sourceNewIdx not foud" for an otherwise valid query.

Align with the classic engine: a colliding column whose name is already an _extracted destination cascades up one more level. Its slot is taken over by the lower-named duplicate's freshly recreated destination, and its own value moves to "<name>_extracted_extracted". Such cascading sources are skipped in the rebuild loop without being folded into the merge set, and get a dedicated row-processing path that writes only their destination.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
https://github.com/grafana/loki-private/issues/2632

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
