### PR TITLE
chore(dataset): Add top-level dataset API

### DIFF
--- a/pkg/dataset/dataset.go
+++ b/pkg/dataset/dataset.go
@@ -1,0 +1,12 @@
+package dataset
+
+import (
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/layout"
+)
+
+// A Dataset holds a collection of rows with a fixed schema.
+type Dataset struct {
+	Type   types.Type
+	Layout layout.Layout
+}

--- a/pkg/dataset/dataset_test.go
+++ b/pkg/dataset/dataset_test.go
@@ -1,0 +1,209 @@
+package dataset_test
+
+import (
+	"context"
+	"errors"
+	"math"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset"
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/dataset/layout"
+	"github.com/grafana/loki/v3/pkg/expr"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func Test(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	type Record struct {
+		Timestamp int64
+		Metadata  map[string]string
+		Line      string
+	}
+
+	spec := testSpec()
+
+	records := []Record{
+		{Timestamp: 1000, Metadata: map[string]string{"service": "web", "env": "prod"}, Line: "hello world"},
+		{Timestamp: 2000, Metadata: map[string]string{"service": "api"}, Line: "request started"},
+		{Timestamp: 3000, Metadata: map[string]string{"env": "dev"}, Line: "debug info"},
+		{Timestamp: 4000, Metadata: map[string]string{}, Line: "no metadata"},
+		{Timestamp: 5000, Metadata: map[string]string{"service": "db", "env": "staging"}, Line: "query executed"},
+	}
+
+	w, err := dataset.NewWriter(&alloc, &store, spec)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	for _, record := range records {
+		rec := buildRecord(t, &alloc, record.Timestamp, record.Metadata, record.Line)
+		err := w.Append(ctx, rec)
+		require.NoError(t, err)
+	}
+
+	dset, err := w.Flush(ctx)
+	require.NoError(t, err)
+
+	r, err := dataset.NewReader(&alloc, &store, dataset.ReaderOptions{
+		Dataset: dset,
+
+		Projection: &expr.Include{
+			Names: []string{"timestamp", "metadata", "line"},
+			Value: &expr.Identity{},
+		},
+
+		Filter: &expr.Binary{
+			Left:  &expr.Column{Name: "timestamp"},
+			Op:    expr.BinaryOpGTE,
+			Right: &expr.Constant{Value: &columnar.NumberScalar[int64]{Value: 2000}},
+		},
+
+		Mask: memory.Bitmap{}, // No initial mask.
+	})
+	require.NoError(t, err)
+
+	err = r.Open(ctx)
+	require.NoError(t, err)
+	defer r.Close()
+
+	actual, err := r.Read(ctx, &alloc, math.MaxInt)
+	require.NoError(t, err)
+
+	// After filtering timestamp >= 2000, we expect records 2-5.
+	// Dynamic metadata keys are [env, service] (sorted). Missing keys are NULL.
+	expected := columnartest.Struct(t, &alloc,
+		columnartest.Field("timestamp", types.KindInt64, int64(2000), int64(3000), int64(4000), int64(5000)),
+		columnartest.Field("metadata", types.KindStruct,
+			columnartest.Struct(t, &alloc,
+				columnartest.Field("env", types.KindUTF8, nil, "dev", nil, "staging"),
+				columnartest.Field("service", types.KindUTF8, "api", nil, nil, "db"),
+			),
+		),
+		columnartest.Field("line", types.KindUTF8, "request started", "debug info", "no metadata", "query executed"),
+	)
+
+	columnartest.RequireArraysEqual(t, expected, actual, memory.Bitmap{})
+}
+
+func buildRecord(t *testing.T, alloc *memory.Allocator, ts int64, metadata map[string]string, line string) *columnar.Struct {
+	t.Helper()
+
+	tsBuilder := columnar.NewNumberBuilder[int64](alloc)
+	tsBuilder.AppendValue(ts)
+
+	lineBuilder := columnar.NewUTF8Builder(alloc)
+	lineBuilder.AppendValue([]byte(line))
+
+	outerSchema := columnar.NewSchema([]columnar.Column{
+		{Name: "timestamp"},
+		{Name: "metadata"},
+		{Name: "line"},
+	})
+	return columnar.NewStruct(outerSchema, []columnar.Array{
+		tsBuilder.Build(),
+		buildMetadata(t, alloc, metadata),
+		lineBuilder.Build(),
+	}, 1, memory.Bitmap{})
+}
+func testSpec() dataset.Spec {
+	return dataset.Spec{
+		Fields: []dataset.FieldSpec{
+			&dataset.StaticFieldSpec{
+				Name: "timestamp",
+				Type: &types.Int64{Nullable: false},
+				Spec: &layout.SpecChunked{
+					MaxRowCount: 2,
+					Chunk: &layout.SpecArray{
+						Spec: &array.SpecPlain{},
+					},
+				},
+			},
+			&dataset.DynamicFieldSpec{
+				Name: "metadata",
+				GetSpec: func(_ string, _ types.Type) layout.Spec {
+					return &layout.SpecChunked{
+						MaxRowCount: 2,
+						Chunk: &layout.SpecArray{
+							Spec: &array.SpecBinary{
+								Validity: &array.SpecBool{},
+								Offsets:  &array.SpecPlain{},
+							},
+						},
+					}
+				},
+			},
+			&dataset.StaticFieldSpec{
+				Name: "line",
+				Type: &types.UTF8{Nullable: false},
+				Spec: &layout.SpecChunked{
+					MaxRowCount: 2,
+					Chunk: &layout.SpecArray{
+						Spec: &array.SpecBinary{
+							Offsets: &array.SpecPlain{},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func writeDataset(t *testing.T, alloc *memory.Allocator, sink buffer.Sink, rows ...columnar.Array) dataset.Dataset {
+	t.Helper()
+
+	w, err := dataset.NewWriter(alloc, sink, testSpec())
+	require.NoError(t, err)
+	for _, row := range rows {
+		require.NoError(t, w.Append(t.Context(), row))
+	}
+	dset, err := w.Flush(t.Context())
+	require.NoError(t, err)
+	return dset
+}
+
+func readDataset(t *testing.T, alloc *memory.Allocator, source buffer.Source, options dataset.ReaderOptions) (columnar.Array, error) {
+	t.Helper()
+
+	r, err := dataset.NewReader(alloc, source, options)
+	require.NoError(t, err)
+	require.NoError(t, r.Open(t.Context()))
+	t.Cleanup(func() { require.NoError(t, r.Close()) })
+	return r.Read(t.Context(), alloc, math.MaxInt)
+}
+
+func buildMetadata(t *testing.T, alloc *memory.Allocator, metadata map[string]string) *columnar.Struct {
+	t.Helper()
+
+	keys := slices.Sorted(func(yield func(string) bool) {
+		for key := range metadata {
+			if !yield(key) {
+				return
+			}
+		}
+	})
+
+	columns := make([]columnar.Column, len(keys))
+	fields := make([]columnar.Array, len(keys))
+	for i, key := range keys {
+		columns[i] = columnar.Column{Name: key}
+		builder := columnar.NewUTF8Builder(alloc)
+		builder.AppendValue([]byte(metadata[key]))
+		fields[i] = builder.Build()
+	}
+	return columnar.NewStruct(columnar.NewSchema(columns), fields, 1, memory.Bitmap{})
+}
+
+type errorSink struct{}
+
+func (errorSink) WriteBuffers(context.Context, []buffer.Data) ([]buffer.ID, error) {
+	return nil, errors.New("writing buffers")
+}

--- a/pkg/dataset/reader.go
+++ b/pkg/dataset/reader.go
@@ -1,0 +1,197 @@
+package dataset
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/compute"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/dataset/layout"
+	"github.com/grafana/loki/v3/pkg/expr"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// A Reader reads rows from a [Dataset], applying filtering and projection.
+//
+// Callers must call [Reader.Open] before calling [Reader.Read].
+type Reader struct {
+	alloc  *memory.Allocator
+	source buffer.Source
+	opts   ReaderOptions
+
+	opened    bool
+	pruneMask memory.Bitmap
+	inner     layout.Reader
+	offset    int // Offset into the dataset.
+}
+
+// ReaderOptions configures a [Reader].
+type ReaderOptions struct {
+	// Dataset to read.
+	Dataset Dataset
+
+	// Projection is the expression describing which columns to materialize.
+	Projection expr.Expression
+
+	// Filter is the expression to filter rows by.
+	Filter expr.Expression
+
+	// Mask is an optional bitmap to start with for filtering. If defined, it
+	// must be the same length as the dataset.
+	Mask memory.Bitmap
+}
+
+// NewReader creates a [Reader] for reading rows from a [Dataset].
+//
+// NewReader returns an error if the provided Mask length does not match the
+// dataset length.
+func NewReader(alloc *memory.Allocator, source buffer.Source, options ReaderOptions) (*Reader, error) {
+	if maskLen, datasetLen := options.Mask.Len(), options.Dataset.Layout.Len(); maskLen > 0 && maskLen != datasetLen {
+		return nil, fmt.Errorf("mask length %d does not match dataset length %d", maskLen, datasetLen)
+	}
+
+	return &Reader{
+		alloc:  alloc,
+		source: source,
+		opts:   options,
+
+		pruneMask: options.Mask,
+	}, nil
+}
+
+// Open prepares the reader for reading. It must be called before Read.
+func (r *Reader) Open(ctx context.Context) error {
+	fullMask, err := r.prune(ctx)
+	if err != nil {
+		return err
+	}
+	r.pruneMask = fullMask
+
+	// TODO(rfratto): This is where we would do prefetching after pruning, then
+	// we would give some kind of cached buffer.Source to the reader below.
+
+	inner, err := layout.NewReader(r.alloc, r.opts.Dataset.Layout, r.source)
+	if err != nil {
+		return err
+	}
+	r.inner = inner
+	r.opened = true
+	return nil
+}
+
+func (r *Reader) prune(ctx context.Context) (memory.Bitmap, error) {
+	pruneAlloc := memory.NewAllocator(r.alloc)
+	defer pruneAlloc.Free()
+
+	inner, err := layout.NewReader(pruneAlloc, r.opts.Dataset.Layout, r.source)
+	if err != nil {
+		return memory.Bitmap{}, err
+	}
+	defer inner.Close()
+
+	rows, err := inner.Next(ctx, math.MaxInt32)
+	if errors.Is(err, io.EOF) {
+		return r.pruneMask, nil
+	} else if err != nil {
+		return memory.Bitmap{}, err
+	} else if rows == 0 {
+		return r.pruneMask, nil
+	}
+
+	// NOTE(rfratto): The prune mask survives for the lifetime of the reader so
+	// we allocate it with r.alloc.
+	return inner.Prune(ctx, r.alloc, r.opts.Filter, r.pruneMask)
+}
+
+// Read returns up to count rows of selected fields that match the reader's
+// filter. At the end of the data, Read returns nil, io.EOF.
+//
+// If there was an error reading the Dataset, Read returns the error with no
+// array.
+//
+// The returned Array is allocated with alloc and is bound to its lifetime.
+func (r *Reader) Read(ctx context.Context, alloc *memory.Allocator, count int) (columnar.Array, error) {
+	if !r.opened {
+		return nil, fmt.Errorf("Reader must be opened before reading")
+	}
+
+	wantRows := count
+
+	chunkAlloc := memory.NewAllocator(alloc)
+	defer chunkAlloc.Free()
+
+	var chunks []columnar.Array
+	for wantRows > 0 {
+		chunk, err := r.readNext(ctx, chunkAlloc, wantRows)
+		if err != nil && errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+
+		if chunk != nil {
+			chunks = append(chunks, chunk)
+			wantRows -= chunk.Len()
+		}
+	}
+
+	if len(chunks) == 0 {
+		return nil, io.EOF
+	}
+	return columnar.Concat(alloc, chunks)
+}
+
+func (r *Reader) readNext(ctx context.Context, alloc *memory.Allocator, count int) (columnar.Array, error) {
+	rows, err := r.inner.Next(ctx, count)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		r.offset += rows
+	}()
+
+	var mask memory.Bitmap
+	if r.pruneMask.Len() > 0 {
+		mask = *r.pruneMask.Slice(r.offset, r.offset+rows)
+	}
+
+	filterMask := mask
+	if r.opts.Filter != nil {
+		// The returned filterMask doesn't survive the lifetime of readNext, so we
+		// use a temporary allocator.
+		maskAlloc := memory.NewAllocator(alloc)
+		defer maskAlloc.Free()
+
+		filterMask, err = r.inner.Filter(ctx, maskAlloc, r.opts.Filter, mask)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if filterMask.Len() > 0 && filterMask.SetCount() == 0 {
+		return nil, nil
+	}
+
+	projected, err := r.inner.Project(ctx, alloc, r.opts.Projection, filterMask)
+	if err != nil {
+		return nil, err
+	}
+	filtered, err := compute.Filter(alloc, projected, filterMask)
+	if err != nil {
+		return nil, fmt.Errorf("filtering projected data: %w", err)
+	}
+	return filtered.(columnar.Array), nil
+}
+
+// Close releases resources held by the Reader.
+func (r *Reader) Close() error {
+	if !r.opened {
+		return nil
+	}
+
+	r.opened = false
+	return r.inner.Close()
+}

--- a/pkg/dataset/reader_test.go
+++ b/pkg/dataset/reader_test.go
@@ -1,0 +1,58 @@
+package dataset_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/expr"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestReader(t *testing.T) {
+	t.Run("reads without a filter", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+
+		dset := writeDataset(t, &alloc, &store,
+			buildRecord(t, &alloc, 1000, map[string]string{"env": "prod", "service": "web"}, "first"),
+			buildRecord(t, &alloc, 2000, map[string]string{"env": "dev", "service": "api"}, "second"),
+		)
+
+		actual, err := readDataset(t, &alloc, &store, dataset.ReaderOptions{
+			Dataset:    dset,
+			Projection: &expr.Identity{},
+		})
+		require.NoError(t, err)
+
+		expected := columnartest.Struct(t, &alloc,
+			columnartest.Field("timestamp", types.KindInt64, int64(1000), int64(2000)),
+			columnartest.Field("metadata", types.KindStruct,
+				columnartest.Struct(t, &alloc,
+					columnartest.Field("env", types.KindUTF8, "prod", "dev"),
+					columnartest.Field("service", types.KindUTF8, "web", "api"),
+				),
+			),
+			columnartest.Field("line", types.KindUTF8, "first", "second"),
+		)
+		columnartest.RequireArraysEqual(t, expected, actual, memory.Bitmap{})
+	})
+
+	t.Run("returns EOF for an empty dataset", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+
+		dset := writeDataset(t, &alloc, &store)
+
+		_, err := readDataset(t, &alloc, &store, dataset.ReaderOptions{
+			Dataset:    dset,
+			Projection: &expr.Identity{},
+		})
+		require.ErrorIs(t, err, io.EOF)
+	})
+}

--- a/pkg/dataset/writer.go
+++ b/pkg/dataset/writer.go
@@ -1,0 +1,301 @@
+package dataset
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/dataset/layout"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// A Writer accumulates rows and flushes them into a [Dataset].
+type Writer struct {
+	alloc *memory.Allocator
+	sink  buffer.Sink
+	spec  Spec
+
+	fields map[string]layout.Writer
+}
+
+// NewWriter creates a [Writer] for constructing a [Dataset] from the given
+// [Spec].
+//
+// The provided alloc may be used to allocate memory across the entire Writer's
+// lifetime. Callers must ensure that the allocator is valid for the entire
+// lifetime of the Writer.
+//
+// Dynamic fields must be Struct arrays containing only UTF8 fields.
+//
+// NewWriter returns an error if spec contains duplicate field names.
+func NewWriter(alloc *memory.Allocator, sink buffer.Sink, spec Spec) (*Writer, error) {
+	fields := make(map[string]layout.Writer, len(spec.Fields))
+
+	for _, field := range spec.Fields {
+		if _, exist := fields[field.FieldName()]; exist {
+			return nil, fmt.Errorf("duplicate field name: %s", field.FieldName())
+		}
+
+		switch f := field.(type) {
+		case *StaticFieldSpec:
+			w, err := layout.NewWriter(alloc, sink, f.Spec, f.Type)
+			if err != nil {
+				return nil, err
+			}
+			fields[f.Name] = w
+
+		case *DynamicFieldSpec:
+			fields[f.Name] = newDynamicWriter(alloc, sink, f)
+		}
+	}
+
+	return &Writer{
+		alloc: alloc,
+		sink:  sink,
+		spec:  spec,
+
+		fields: fields,
+	}, nil
+}
+
+// Append appends the rows in arr to the Writer. arr must be a struct array
+// whose fields match the Writer's [Spec].
+func (w *Writer) Append(ctx context.Context, arr columnar.Array) error {
+	if got, want := arr.Kind(), types.KindStruct; got != want {
+		return fmt.Errorf("got %s kind, wanted %s", got, want)
+	}
+
+	structArr := arr.(*columnar.Struct)
+	structSchema := structArr.Schema()
+
+	if err := w.validate(structSchema); err != nil {
+		return err
+	}
+
+	var errs []error
+	for fieldIdx := range structArr.NumFields() {
+		field := structSchema.Column(fieldIdx)
+		fieldArr := structArr.Field(fieldIdx)
+
+		inner := w.fields[field.Name]
+		if err := inner.Append(ctx, fieldArr); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (w *Writer) validate(s *columnar.Schema) error {
+	var errs []error
+
+	// We do top-level validation only; inner fields are validated by the field
+	// writers.
+
+	schemaFields := make(map[string]struct{}, s.NumColumns())
+	for i := range s.NumColumns() {
+		col := s.Column(i)
+		schemaFields[col.Name] = struct{}{}
+
+		// Check to make sure the field exists in w.
+		if _, found := w.fields[col.Name]; !found {
+			errs = append(errs, fmt.Errorf("struct field %s not found in dataset spec", col.Name))
+		}
+	}
+
+	// Now check to make sure all the required fields were present.
+	for _, reqField := range w.spec.Fields {
+		reqName := reqField.FieldName()
+
+		_, exist := schemaFields[reqName]
+		if !exist {
+			// This usually indicates a bug in application code where the
+			// payload didn't have any keys for a dynamic field, and the caller
+			// forgot to construct a struct{} (no fields) with the appropriate
+			// length.
+			errs = append(errs, fmt.Errorf("required field %s not found in input", reqName))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// Flush flushes buffered data and returns a [Dataset] representing the
+// encoded data.
+func (w *Writer) Flush(ctx context.Context) (Dataset, error) {
+	// The overall dataset is not nullable.
+	var typ types.Struct
+	var structLayout layout.Struct
+
+	var errs []error
+
+	// Flush all fields.
+	for _, field := range w.spec.Fields {
+		name := field.FieldName()
+
+		fw, ok := w.fields[name]
+		if !ok {
+			errs = append(errs, fmt.Errorf("field %s not found in dataset spec", name))
+			continue
+		}
+		fieldLayout, err := fw.Flush(ctx)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		structLayout.Fields = append(structLayout.Fields, fieldLayout)
+
+		typ.Fields = append(typ.Fields, types.StructField{
+			Name: name,
+			Type: fieldLayout.DataType(),
+		})
+	}
+
+	if len(errs) > 0 {
+		return Dataset{}, errors.Join(errs...)
+	}
+
+	structLayout.Type = &typ
+	return Dataset{Type: &typ, Layout: &structLayout}, nil
+}
+
+type dynamicWriter struct {
+	alloc  *memory.Allocator
+	spec   *DynamicFieldSpec
+	sink   buffer.Sink
+	fields map[string]layout.Writer
+	rows   int
+}
+
+var _ layout.Writer = (*dynamicWriter)(nil)
+
+func newDynamicWriter(alloc *memory.Allocator, sink buffer.Sink, spec *DynamicFieldSpec) *dynamicWriter {
+	return &dynamicWriter{
+		alloc:  alloc,
+		spec:   spec,
+		sink:   sink,
+		fields: make(map[string]layout.Writer),
+	}
+}
+
+func (dw *dynamicWriter) Append(ctx context.Context, arr columnar.Array) error {
+	if got, want := arr.Kind(), types.KindStruct; got != want {
+		return fmt.Errorf("dynamic field %s must be %s, got %s", dw.spec.Name, want, got)
+	}
+
+	structArr := arr.(*columnar.Struct)
+	structSchema := structArr.Schema()
+	defer func() { dw.rows += arr.Len() }()
+
+	nullAlloc := memory.NewAllocator(dw.alloc)
+	defer nullAlloc.Free()
+
+	var errs []error
+	gotFields := make(map[string]struct{}, structArr.NumFields())
+	for fieldIndex := range structArr.NumFields() {
+		field := structSchema.Column(fieldIndex)
+		fieldArr := structArr.Field(fieldIndex)
+
+		if got, want := fieldArr.Kind(), types.KindUTF8; got != want {
+			errs = append(errs, fmt.Errorf("dynamic field %s.%s must be %s, got %s", dw.spec.Name, field.Name, want, got))
+			continue
+		}
+
+		if _, ok := dw.fields[field.Name]; !ok {
+			typ := fieldArr.Type()
+			spec := dw.spec.GetSpec(field.Name, typ)
+			if spec == nil {
+				errs = append(errs, fmt.Errorf("GetSpec returned nil for dynamic field %s.%s", dw.spec.Name, field.Name))
+				continue
+			}
+			l, err := layout.NewWriter(dw.alloc, dw.sink, spec, typ)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			if dw.rows > 0 {
+				if err := l.Append(ctx, newNullUTF8(nullAlloc, dw.rows)); err != nil {
+					errs = append(errs, err)
+					continue
+				}
+			}
+			dw.fields[field.Name] = l
+		}
+
+		gotFields[field.Name] = struct{}{}
+
+		inner := dw.fields[field.Name]
+		if err := inner.Append(ctx, fieldArr); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(gotFields) == len(dw.fields) {
+		// We appended all the known fields, so we can stop early.
+		return errors.Join(errs...)
+	}
+
+	// There are some fields which weren't seen in the incoming array, so we
+	// have to pad them with NULLs.
+	//
+	// TODO(rfratto): Since we require all dynamic fields to be strings, we can
+	// use a UTF8Builder to construct the null array. This should ideally be a
+	// columnar.Null, but this would require updating all of the layout.Writer
+	// and array.Writer implementations to support type coersion first.
+	nullArr := newNullUTF8(nullAlloc, arr.Len())
+
+	for fieldName := range dw.fields {
+		if _, ok := gotFields[fieldName]; ok {
+			continue
+		}
+		if err := dw.fields[fieldName].Append(ctx, nullArr); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func newNullUTF8(alloc *memory.Allocator, rows int) *columnar.UTF8 {
+	builder := columnar.NewUTF8Builder(alloc)
+	builder.AppendNulls(rows)
+	return builder.Build()
+}
+
+func (dw *dynamicWriter) Flush(ctx context.Context) (layout.Layout, error) {
+	if len(dw.fields) == 0 && dw.rows > 0 {
+		return nil, fmt.Errorf("dynamic field %s has %d rows but no fields", dw.spec.Name, dw.rows)
+	}
+
+	names := slices.Collect(maps.Keys(dw.fields))
+	slices.Sort(names)
+
+	var (
+		typ types.Struct
+		l   layout.Struct
+	)
+
+	var errs []error
+	for _, name := range names {
+		fieldLayout, err := dw.fields[name].Flush(ctx)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		typ.Fields = append(typ.Fields, types.StructField{
+			Name: name,
+			Type: &types.UTF8{Nullable: true},
+		})
+		l.Fields = append(l.Fields, fieldLayout)
+	}
+
+	l.Type = &typ
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+	return &l, nil
+}

--- a/pkg/dataset/writer_spec.go
+++ b/pkg/dataset/writer_spec.go
@@ -1,0 +1,60 @@
+package dataset
+
+import (
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/layout"
+)
+
+// Spec holds the specification for how to build a dataset with a set of static
+// and dynamic fields.
+//
+// The names of fields across a Spec must be unique.
+type Spec struct {
+	Fields []FieldSpec
+}
+
+type (
+	// FieldSpec represents one field of a struct.
+	FieldSpec interface {
+		isFieldSpec() // Sealed interface.
+
+		FieldName() string
+	}
+
+	// A StaticFieldSpec specifies a field with a known type.
+	StaticFieldSpec struct {
+		Name string      // Field name.
+		Spec layout.Spec // Field encoding specification.
+		Type types.Type  // Field type.
+	}
+
+	// A DynamicFieldSpec specifies a struct field whose full set of keys are not
+	// yet known at spec construction. Common use cases are for stream labels or
+	// structured metadata.
+	//
+	// Keys on the dynamic struct type are discovered as callers append values to
+	// the field.
+	//
+	// All keys for a dynamic field are nullable. If an append does not provide a
+	// value for a previously discovered key, it is backfilled with null values.
+	//
+	// When a dataset is flushed, the dynamic field is resolved to the full struct
+	// type with all discovered keys.
+	DynamicFieldSpec struct {
+		// Name holds the name of the dynamic field.
+		Name string
+
+		// GetSpec returns the layout spec for a newly discovered (key, typ) pair.
+		// It is called once per discovered pair and must not return nil.
+		GetSpec func(key string, typ types.Type) layout.Spec
+	}
+)
+
+// FieldName returns the name of the field.
+func (s *StaticFieldSpec) FieldName() string { return s.Name }
+
+// FieldName returns the name of the dynamic field.
+func (s *DynamicFieldSpec) FieldName() string { return s.Name }
+
+func (s *StaticFieldSpec) isFieldSpec()  {}
+func (s *DynamicFieldSpec) isFieldSpec() {}

--- a/pkg/dataset/writer_test.go
+++ b/pkg/dataset/writer_test.go
@@ -1,0 +1,107 @@
+package dataset_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/dataset/layout"
+	"github.com/grafana/loki/v3/pkg/expr"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestWriter(t *testing.T) {
+	t.Run("backfills newly discovered dynamic fields", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+
+		dset := writeDataset(t, &alloc, &store,
+			buildRecord(t, &alloc, 1000, map[string]string{"service": "web"}, "first"),
+			buildRecord(t, &alloc, 2000, map[string]string{"env": "prod"}, "second"),
+		)
+
+		actual, err := readDataset(t, &alloc, &store, dataset.ReaderOptions{
+			Dataset:    dset,
+			Projection: &expr.Identity{},
+		})
+		require.NoError(t, err)
+
+		expected := columnartest.Struct(t, &alloc,
+			columnartest.Field("timestamp", types.KindInt64, int64(1000), int64(2000)),
+			columnartest.Field("metadata", types.KindStruct,
+				columnartest.Struct(t, &alloc,
+					columnartest.Field("env", types.KindUTF8, nil, "prod"),
+					columnartest.Field("service", types.KindUTF8, "web", nil),
+				),
+			),
+			columnartest.Field("line", types.KindUTF8, "first", "second"),
+		)
+		columnartest.RequireArraysEqual(t, expected, actual, memory.Bitmap{})
+	})
+
+	t.Run("rejects dynamic rows without keys", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+
+		w, err := dataset.NewWriter(&alloc, &store, testSpec())
+		require.NoError(t, err)
+		require.NoError(t, w.Append(t.Context(), buildRecord(t, &alloc, 1000, map[string]string{}, "line")))
+
+		_, err = w.Flush(t.Context())
+		require.ErrorContains(t, err, "dynamic field metadata has 1 rows but no fields")
+	})
+
+	t.Run("returns flush errors", func(t *testing.T) {
+		var alloc memory.Allocator
+		var sink errorSink
+
+		w, err := dataset.NewWriter(&alloc, sink, testSpec())
+		require.NoError(t, err)
+		require.NoError(t, w.Append(t.Context(), buildRecord(t, &alloc, 1000, map[string]string{"service": "web"}, "first")))
+
+		_, err = w.Flush(t.Context())
+		require.ErrorContains(t, err, "writing buffers")
+	})
+
+	t.Run("rejects nil dynamic field specs", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+
+		w, err := dataset.NewWriter(&alloc, &store, dataset.Spec{
+			Fields: []dataset.FieldSpec{&dataset.DynamicFieldSpec{
+				Name:    "metadata",
+				GetSpec: func(string, types.Type) layout.Spec { return nil },
+			}},
+		})
+		require.NoError(t, err)
+		input := columnartest.Struct(t, &alloc,
+			columnartest.Field("metadata", types.KindStruct,
+				buildMetadata(t, &alloc, map[string]string{"service": "web"}),
+			),
+		)
+
+		err = w.Append(t.Context(), input)
+		require.ErrorContains(t, err, "GetSpec returned nil")
+	})
+
+	t.Run("rejects missing required fields", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+
+		w, err := dataset.NewWriter(&alloc, &store, testSpec())
+		require.NoError(t, err)
+		input := columnartest.Struct(t, &alloc,
+			columnartest.Field("timestamp", types.KindInt64, int64(1000)),
+			columnartest.Field("metadata", types.KindStruct,
+				buildMetadata(t, &alloc, map[string]string{}),
+			),
+		)
+
+		err = w.Append(t.Context(), input)
+		require.ErrorContains(t, err, "required field line not found in input")
+	})
+}


### PR DESCRIPTION
Add a top-level dataset API which ties together the layout and array packages. 

This includes the ability to define a "dynamic" struct column which has a dynamically determined set of fields that can be appended to as data streams in. 