### PR TITLE
fix: Clean shutdown support for dataobj-index-builder

### DIFF
--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -25,7 +25,10 @@ import (
 	"github.com/grafana/loki/v3/pkg/scratch"
 )
 
-var ErrPartitionRevoked = errors.New("partition revoked")
+var (
+	ErrPartitionRevoked  = errors.New("partition revoked")
+	ErrIndexerNotRunning = errors.New("indexer service is not running")
+)
 
 type triggerType string
 
@@ -277,14 +280,17 @@ func (p *Builder) running(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			// Do not return ctx.Err(): a non-nil RunningFn error marks the
+			// dskit service Failed, which Loki surfaces as "failed services"
+			// on normal shutdown.
+			return nil
 		default:
 		}
 
 		fetches := p.client.PollRecords(ctx, -1)
 		if err := fetches.Err0(); err != nil {
 			if errors.Is(err, kgo.ErrClientClosed) || errors.Is(err, context.Canceled) {
-				return err
+				return nil
 			}
 			// Some other error occurred. We will check it in
 			// [processFetchTopicPartition] instead.
@@ -305,17 +311,27 @@ func (p *Builder) running(ctx context.Context) error {
 }
 
 func (p *Builder) stopping(failureCase error) error {
-	// Stop indexer service first - this handles calculation cleanup via context cancelation.
+	// Stop accepting new timed flushes first, then drain in-flight flush
+	// workers while the indexer is still Running so they can finish or abort
+	// cleanly instead of racing Stopping.
+	if p.flushTicker != nil {
+		p.flushTicker.Stop()
+	}
+
+	p.partitionsMutex.Lock()
+	for partition, cancel := range p.activeCalculations {
+		cancel(nil)
+		delete(p.activeCalculations, partition)
+	}
+	p.partitionsMutex.Unlock()
+
+	p.wg.Wait()
+
 	ctx := context.TODO()
 	if err := services.StopAndAwaitTerminated(ctx, p.indexer); err != nil {
 		level.Error(p.logger).Log("msg", "failed to stop indexer", "err", err)
 	}
 
-	// Stop other components
-	if p.flushTicker != nil {
-		p.flushTicker.Stop()
-	}
-	p.wg.Wait()
 	p.client.Close()
 	return failureCase
 }
@@ -440,8 +456,8 @@ func (p *Builder) buildAndCommitIndex(ctx context.Context, events []bufferedEven
 	// Submit to indexer service and wait for completion
 	records, err := p.indexer.submitBuild(ctx, events, partition, triggerType)
 	if err != nil {
-		if errors.Is(context.Cause(ctx), ErrPartitionRevoked) {
-			level.Debug(p.logger).Log("msg", "partition revoked, aborting index build", "partition", partition, "trigger", triggerType)
+		if isExpectedBuildAbort(ctx, err) {
+			level.Debug(p.logger).Log("msg", "index build aborted", "partition", partition, "err", err, "trigger", triggerType)
 			return
 		}
 		level.Error(p.logger).Log("msg", "failed to build index", "partition", partition, "err", err, "trigger", triggerType)
@@ -450,8 +466,8 @@ func (p *Builder) buildAndCommitIndex(ctx context.Context, events []bufferedEven
 
 	// Commit the records
 	if err := p.commitRecords(ctx, records); err != nil {
-		if errors.Is(context.Cause(ctx), ErrPartitionRevoked) {
-			level.Debug(p.logger).Log("msg", "partition revoked, aborting index commit", "partition", partition, "trigger", triggerType)
+		if isExpectedBuildAbort(ctx, err) {
+			level.Debug(p.logger).Log("msg", "index commit aborted", "partition", partition, "err", err, "trigger", triggerType)
 			return
 		}
 		level.Error(p.logger).Log("msg", "failed to commit records", "partition", partition, "err", err, "trigger", triggerType)
@@ -459,6 +475,14 @@ func (p *Builder) buildAndCommitIndex(ctx context.Context, events []bufferedEven
 	}
 
 	p.markEventsCompleted(partition, len(records))
+}
+
+// isExpectedBuildAbort reports whether err is an expected abort from partition
+// revocation or service shutdown, not a real build failure.
+func isExpectedBuildAbort(ctx context.Context, err error) bool {
+	return errors.Is(context.Cause(ctx), ErrPartitionRevoked) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, ErrIndexerNotRunning)
 }
 
 // bufferAndTryProcess is the unified method that handles both buffering and processing decisions

--- a/pkg/dataobj/index/builder_test.go
+++ b/pkg/dataobj/index/builder_test.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
@@ -18,6 +20,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/pointers"
 	"github.com/grafana/loki/v3/pkg/kafka"
 	"github.com/grafana/loki/v3/pkg/kafka/testkafka"
@@ -32,6 +35,76 @@ var testBuilderConfig = logsobj.BuilderBaseConfig{
 	BufferSize: 4 * 1024 * 1024,
 
 	SectionStripeMergeLimit: 2,
+}
+
+func TestIndexBuilder_CleanShutdown(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	bucket := objstore.NewInMemBucket()
+	buildLogObject(t, "loki", "test-path-0", bucket)
+	event := metastore.ObjectWrittenEvent{
+		ObjectPath: "test-path-0",
+		WriteTime:  time.Now().Format(time.RFC3339),
+	}
+	eventBytes, err := event.Marshal()
+	require.NoError(t, err)
+
+	var logBuf bytes.Buffer
+	logger := log.NewLogfmtLogger(&logBuf)
+
+	builder, err := NewIndexBuilder(
+		Config{
+			BuilderBaseConfig: testBuilderConfig,
+			EventsPerIndex:    16, // high so append does not trigger a build
+			FlushInterval:     time.Millisecond,
+			MaxIdleTime:       0, // flush immediately once buffered
+			MaxAge:            time.Hour,
+		},
+		metastore.Config{},
+		kafka.Config{},
+		logger,
+		"instance-id",
+		bucket,
+		nil,
+		prometheus.NewRegistry(),
+	)
+	require.NoError(t, err)
+	builder.client.Close()
+	builder.client = &mockKafkaClient{}
+
+	blocking := &blockingCalculator{
+		started: make(chan struct{}),
+	}
+	builder.indexer.(*serialIndexer).calculator = blocking
+
+	require.NoError(t, builder.StartAsync(ctx))
+	require.NoError(t, builder.AwaitRunning(ctx))
+
+	builder.handlePartitionsAssigned(ctx, nil, map[string][]int32{
+		"loki.metastore-events": {0},
+	})
+
+	// Buffer an event; the idle flush worker will start a build that blocks in Calculate.
+	builder.processRecord(context.Background(), &kgo.Record{
+		Value:     eventBytes,
+		Partition: 0,
+	})
+
+	select {
+	case <-blocking.started:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for in-flight index build to start")
+	}
+
+	builder.StopAsync()
+	require.NoError(t, builder.AwaitTerminated(context.Background()))
+	require.Equal(t, services.Terminated, builder.State())
+	require.Nil(t, builder.FailureCase())
+
+	logs := logBuf.String()
+	require.NotContains(t, logs, "failed to build index")
 }
 
 func TestIndexBuilder_PartitionRevocation(t *testing.T) {
@@ -441,11 +514,36 @@ func (m *mockKafkaClient) CommitRecords(_ context.Context, _ ...*kgo.Record) err
 	return nil
 }
 
-func (m *mockKafkaClient) PollRecords(_ context.Context, _ int) kgo.Fetches {
+func (m *mockKafkaClient) PollRecords(ctx context.Context, _ int) kgo.Fetches {
+	<-ctx.Done()
 	return nil
 }
 
 func (m *mockKafkaClient) Close() {}
+
+// blockingCalculator blocks in Calculate until the request context is cancelled.
+type blockingCalculator struct {
+	startedOnce sync.Once
+	started     chan struct{}
+}
+
+func (c *blockingCalculator) Calculate(ctx context.Context, _ log.Logger, _ *dataobj.Object, _ string) error {
+	c.startedOnce.Do(func() { close(c.started) })
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (c *blockingCalculator) Flush() (*dataobj.Object, io.Closer, error) {
+	return nil, nil, fmt.Errorf("unexpected flush")
+}
+
+func (c *blockingCalculator) TimeRanges() []multitenancy.TimeRange {
+	return nil
+}
+
+func (c *blockingCalculator) Reset() {}
+
+func (c *blockingCalculator) IsFull() bool { return false }
 
 func buildLogObject(t *testing.T, app string, path string, bucket objstore.Bucket) {
 	candidate, err := logsobj.NewBuilder(logsobj.BuilderConfig{

--- a/pkg/dataobj/index/indexer.go
+++ b/pkg/dataobj/index/indexer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -135,7 +136,7 @@ func (si *serialIndexer) stopping(_ error) error {
 func (si *serialIndexer) submitBuild(ctx context.Context, events []bufferedEvent, partition int32, trigger triggerType) ([]*kgo.Record, error) {
 	// Check if service is running
 	if si.State() != services.Running {
-		return nil, fmt.Errorf("indexer service is not running (state: %s)", si.State())
+		return nil, fmt.Errorf("%w (state: %s)", ErrIndexerNotRunning, si.State())
 	}
 
 	resultChan := make(chan buildResult, 1)
@@ -162,8 +163,13 @@ func (si *serialIndexer) submitBuild(ctx context.Context, events []bufferedEvent
 	select {
 	case result := <-resultChan:
 		if result.err != nil {
-			level.Error(si.logger).Log("msg", "build request failed",
-				"partition", partition, "err", result.err)
+			if errors.Is(result.err, context.Canceled) {
+				level.Debug(si.logger).Log("msg", "build request cancelled",
+					"partition", partition, "err", result.err)
+			} else {
+				level.Error(si.logger).Log("msg", "build request failed",
+					"partition", partition, "err", result.err)
+			}
 		} else {
 			level.Debug(si.logger).Log("msg", "build request completed",
 				"partition", partition, "index_path", result.indexPath)
@@ -228,8 +234,13 @@ func (si *serialIndexer) processBuildRequest(req buildRequest) buildResult {
 	si.updateMetrics(buildTime, getEarliestIndexedRecord(si.logger, events[:processed]))
 
 	if err != nil {
-		level.Error(si.logger).Log("msg", "failed to build index",
-			"partition", req.partition, "err", err, "duration", buildTime, "processed", processed)
+		if errors.Is(err, context.Canceled) {
+			level.Debug(si.logger).Log("msg", "index build cancelled",
+				"partition", req.partition, "err", err, "duration", buildTime, "processed", processed)
+		} else {
+			level.Error(si.logger).Log("msg", "failed to build index",
+				"partition", req.partition, "err", err, "duration", buildTime, "processed", processed)
+		}
 		return buildResult{err: err}
 	}
 

--- a/pkg/dataobj/index/indexer_test.go
+++ b/pkg/dataobj/index/indexer_test.go
@@ -204,7 +204,7 @@ func TestSerialIndexer_ServiceNotRunning(t *testing.T) {
 
 	_, err := indexer.submitBuild(ctx, []bufferedEvent{bufferedEvt}, 0, triggerTypeAppend)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "indexer service is not running")
+	require.ErrorIs(t, err, ErrIndexerNotRunning)
 }
 
 func TestSerialIndexer_ConcurrentBuilds(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Index builders were exiting uncleanly on normal stop: `Builder.running()` returned `context.Canceled`, which dskit marks as `Failed` and Loki surfaces as `failed services`. In-flight flushes also raced the indexer `Stopping` state and logged expected cancel/Stopping errors at Error level.
This matches the dataobj consumer pattern (return `nil` on cancel), drains flush work before stopping the indexer, and demotes expected shutdown aborts to Debug.

## Changes
- Return `nil` from `Builder.running()` on context cancel / Kafka client closed
- Reorder `stopping()`: stop flush ticker → cancel active builds → wait for flush workers → stop indexer → close Kafka
- Treat `context.Canceled` and typed `ErrIndexerNotRunning` as expected aborts (Debug, not Error)
- Add `TestIndexBuilder_CleanShutdown` asserting `Terminated`, nil `FailureCase`, and no `"failed to build index"` error logs mid-build

## Test plan
- [x] `go test ./pkg/dataobj/index/`
- [x] Delete a `dataobj-index-builder` pod while following logs; confirm clean `Loki stopped` / no `failed services`

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
