### PR TITLE
fix: Advertise sticky balancers for dataobj index builders

### DIFF
--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -188,7 +188,10 @@ func NewIndexBuilder(
 		kgo.InstanceID(instanceID),
 		kgo.SessionTimeout(3*time.Minute),
 		kgo.ConsumerGroup(consumerGroup),
-		kgo.Balancers(kgo.RoundRobinBalancer()),
+		// Offer both cooperative-sticky and round-robin during migration from eager
+		// rebalancing (KIP-429). A follow-up change removes RoundRobin once every
+		// index-builder member advertises cooperative-sticky.
+		kgo.Balancers(kgo.CooperativeStickyBalancer(), kgo.RoundRobinBalancer()),
 		kgo.RebalanceTimeout(5*time.Minute),
 		kgo.DisableAutoCommit(),
 		kgo.OnPartitionsAssigned(s.handlePartitionsAssigned),


### PR DESCRIPTION
**What this PR does / why we need it**:
Phase 1.  Advertise sticky balancer for dataobj-index-builders.

This is so we can roll out and support both styles of balancers for now.  A subsequent PR will be along to remove the cooperative balancers.  According to the franz-go docs: once a group is fully cooperative it cannot safely mix with eager-only members; migrating needs two rolling deploys.

**Which issue(s) this PR fixes**:
This is being done as rollouts in a RoundRobin balancer cause a membership change, resulting in all partitions being revoked.  This aborts in-flight builds.  By moving to a sticky balancer, similar to the ingest limits service, only impacted partitions would be revoked, lessening the amount thrown away.

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
