### PR TITLE
fix: Reset shared calculator scratchpad on abort

### DIFF
--- a/pkg/dataobj/index/indexer.go
+++ b/pkg/dataobj/index/indexer.go
@@ -222,6 +222,13 @@ func (si *serialIndexer) processBuildRequest(req buildRequest) buildResult {
 
 	// Build the index using internal method
 	indexPath, processed, err := si.buildIndex(req.ctx, events, req.partition)
+	if err != nil {
+		// The calculator is shared across partitions on this serial indexer. Clear
+		// any partial state when a build fails or is cancelled (e.g. partition
+		// revoke) so the next request starts clean. Successful flushes already call
+		// Reset inside flushIndex.
+		si.calculator.Reset()
+	}
 
 	// Update metrics
 	buildTime := time.Since(start)

--- a/pkg/dataobj/index/indexer_test.go
+++ b/pkg/dataobj/index/indexer_test.go
@@ -420,6 +420,100 @@ func TestSerialIndexer_FlushOnBuilderFull(t *testing.T) {
 	require.Equal(t, float64(1), testutil.ToFloat64(indexerMetrics.totalBuilds))
 }
 
+func TestSerialIndexer_ResetsCalculatorOnCancel(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	bucket := objstore.NewInMemBucket()
+	buildLogObject(t, "loki", "test-path-0", bucket)
+
+	event := metastore.ObjectWrittenEvent{
+		ObjectPath: "test-path-0",
+		WriteTime:  time.Now().Format(time.RFC3339),
+	}
+	record := &kgo.Record{Partition: int32(0)}
+	eventBytes, err := event.Marshal()
+	require.NoError(t, err)
+	record.Value = eventBytes
+
+	mockCalc := &blockingMockCalculator{
+		entered: make(chan struct{}),
+	}
+	indexStorageBucket := objstore.NewInMemBucket()
+
+	reg := prometheus.NewRegistry()
+	builderMetrics := newBuilderMetrics()
+	require.NoError(t, builderMetrics.register(reg))
+	indexerMetrics := newIndexerMetrics()
+	require.NoError(t, indexerMetrics.register(reg))
+
+	indexer := newSerialIndexer(
+		mockCalc,
+		bucket,
+		indexStorageBucket,
+		builderMetrics,
+		indexerMetrics,
+		log.NewLogfmtLogger(os.Stderr),
+		indexerConfig{QueueSize: 10},
+	)
+
+	require.NoError(t, indexer.StartAsync(ctx))
+	require.NoError(t, indexer.AwaitRunning(ctx))
+	defer func() {
+		indexer.StopAsync()
+		require.NoError(t, indexer.AwaitTerminated(context.Background()))
+	}()
+
+	buildCtx, buildCancel := context.WithCancel(ctx)
+	defer buildCancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := indexer.submitBuild(buildCtx, []bufferedEvent{{
+			event:  event,
+			record: record,
+		}}, 0, triggerTypeAppend)
+		errCh <- err
+	}()
+
+	select {
+	case <-mockCalc.entered:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for Calculate to start")
+	}
+
+	buildCancel()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for submitBuild to return")
+	}
+
+	// submitBuild may return on ctx.Done before the worker finishes unwinding;
+	// wait for the deferred Reset from the cancelled buildIndex.
+	require.Eventually(t, func() bool {
+		return mockCalc.resetCallCount >= 1
+	}, 5*time.Second, 10*time.Millisecond, "calculator should be reset after cancelled build")
+	require.Equal(t, 0, mockCalc.flushCallCount, "cancelled build should not flush")
+}
+
+// blockingMockCalculator blocks inside Calculate until the context is cancelled.
+type blockingMockCalculator struct {
+	mockCalculator
+	entered chan struct{}
+}
+
+func (c *blockingMockCalculator) Calculate(ctx context.Context, _ log.Logger, object *dataobj.Object, _ string) error {
+	c.count++
+	c.object = object
+	close(c.entered)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
 func TestDownloadObject_Success(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
**What this PR does / why we need it**:
The calculator is a shared scratchpad. As objects are indexed, it accumulates streams, postings, stats, etc. `Reset()` empties that scratchpad so the next build starts clean.

There is one calculator for the whole serial indexer, reused across partitions. Success path already does Flush → upload → Reset(). The cancel/error path used to skip that.

Without `Reset()` on abort: Partition 1 gets revoked mid-build with half-written index state still in memory. Partition 2’s next build keeps appending on top of that leftover. You can end up with a polluted index (wrong tenants/streams/sections mixed in), or odd size/IsFull behavior from leftover estimate state — until something eventually flushes and resets.

So the new call is hygiene: aborted work must not contaminate the next build.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
