### PR TITLE
fix: Address stale metric when no flushes occur in the dataobj-index-builders

### DIFF
--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -105,7 +105,8 @@ type Builder struct {
 	flushTicker     *time.Ticker
 
 	// Only kafka commit functionality
-	metrics *builderMetrics
+	metrics        *builderMetrics
+	indexerMetrics *indexerMetrics
 
 	// Control and coordination
 	wg                 sync.WaitGroup
@@ -161,6 +162,7 @@ func NewIndexBuilder(
 		mCfg:               mCfg,
 		logger:             logger,
 		metrics:            builderMetrics,
+		indexerMetrics:     indexerMetrics,
 		partitionStates:    make(map[int32]*partitionState),
 		activeCalculations: make(map[int32]context.CancelCauseFunc),
 	}
@@ -430,11 +432,39 @@ func (p *Builder) checkAndFlushPartitions(ctx context.Context) {
 		// This is to avoid leaving partitions with no recent activity with high processing delay metrics.
 		p.metrics.setProcessingDelay(partition, recordTime)
 	}
+
+	// Update E2E processing time from the oldest buffered EarliestRecordTime (or
+	// now if no events are buffered) so the gauge does not stay stale between flushes.
+	p.indexerMetrics.setEndToEndProcessingTime(time.Since(oldestBufferedRecordTime(p.partitionStates, p.logger)))
+
 	p.partitionsMutex.Unlock()
 
 	for partition, triggerType := range partitionsToFlush {
 		p.flushPartition(ctx, partition, triggerType)
 	}
+}
+
+// oldestBufferedRecordTime returns the earliest EarliestRecordTime across all
+// buffered events. If no events are buffered, it returns time.Now() so the E2E
+// gauge resets to ~0.
+func oldestBufferedRecordTime(states map[int32]*partitionState, logger log.Logger) time.Time {
+	var earliest time.Time
+	for _, state := range states {
+		for _, ev := range state.events {
+			ts, err := time.Parse(time.RFC3339, ev.event.EarliestRecordTime)
+			if err != nil {
+				level.Warn(logger).Log("msg", "failed to parse earliest record time", "err", err)
+				continue
+			}
+			if earliest.IsZero() || ts.Before(earliest) {
+				earliest = ts
+			}
+		}
+	}
+	if earliest.IsZero() {
+		return time.Now()
+	}
+	return earliest
 }
 
 func (p *Builder) flushPartition(ctx context.Context, partition int32, triggerType triggerType) {

--- a/pkg/dataobj/index/builder_test.go
+++ b/pkg/dataobj/index/builder_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -446,6 +447,69 @@ func TestIndexBuilder_oldEvents(t *testing.T) {
 
 	require.Equal(t, 30, len(readAllSectionPointers(t, bucket)))
 	require.Equal(t, 0, readFirstPartitionStateEventsCount(p)) // Events should be gone now they've been processed
+}
+
+func TestIndexBuilder_endToEndProcessingTimeBetweenFlushes(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	bucket := objstore.NewInMemBucket()
+	buildLogObject(t, "loki", "test-path-0", bucket)
+
+	p, err := NewIndexBuilder(
+		Config{
+			BuilderBaseConfig: testBuilderConfig,
+			EventsPerIndex:    16, // high so append does not trigger a build
+			FlushInterval:     time.Hour,
+			MaxIdleTime:       time.Hour,
+			MaxAge:            time.Hour,
+		},
+		metastore.Config{},
+		kafka.Config{},
+		log.NewNopLogger(),
+		"instance-id",
+		bucket,
+		nil,
+		prometheus.NewRegistry(),
+	)
+	require.NoError(t, err)
+	p.client.Close()
+	p.client = &mockKafkaClient{}
+
+	p.handlePartitionsAssigned(ctx, nil, map[string][]int32{
+		"loki.metastore-events": {0},
+	})
+
+	oldRecordTime := time.Now().Add(-30 * time.Minute)
+	event := metastore.ObjectWrittenEvent{
+		ObjectPath:         "test-path-0",
+		WriteTime:          time.Now().Format(time.RFC3339),
+		EarliestRecordTime: oldRecordTime.Format(time.RFC3339),
+	}
+	eventBytes, err := event.Marshal()
+	require.NoError(t, err)
+
+	p.processRecord(ctx, &kgo.Record{
+		Value:     eventBytes,
+		Partition: 0,
+	})
+	require.Equal(t, 1, readFirstPartitionStateEventsCount(p))
+
+	// Tick flush check without flushing: E2E gauge should reflect buffered lag.
+	p.checkAndFlushPartitions(ctx)
+	require.Equal(t, 1, readFirstPartitionStateEventsCount(p))
+	e2e := testutil.ToFloat64(p.indexerMetrics.endToEndProcessingTime)
+	require.InDelta(t, (30 * time.Minute).Seconds(), e2e, 5)
+
+	// Empty the buffer and tick again: E2E gauge should reset to ~0.
+	p.partitionsMutex.Lock()
+	p.partitionStates[0].events = nil
+	p.partitionsMutex.Unlock()
+
+	p.checkAndFlushPartitions(ctx)
+	e2e = testutil.ToFloat64(p.indexerMetrics.endToEndProcessingTime)
+	require.Less(t, e2e, 1.0)
 }
 
 func readFirstPartitionStateEventsCount(p *Builder) int {


### PR DESCRIPTION
**What this PR does / why we need it**:

`loki_ingest_end_to_end_processing_time_seconds` is set only in `serialIndexer.updateMetrics()`, called at the end of every index build in `processBuildRequest()`.  As such, when there are no flushes, the metric becomes stale.

With this PR, the same gauge is also updated every `flush_interval` in `checkAndFlushPartitions()` from buffered events (or time.Now() if empty).

This is a similar pattern to `processing_delay` handling.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
