### PR TITLE
fix(compaction): Store fully-qualified sort schema in stats sections

### DIFF
--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -58,11 +58,11 @@ type logsCalculationContext struct {
 }
 
 // These steps are applied to all logs and are unique to a section
-func getLogsCalculationSteps(sortSchemaKeys []string) []logsIndexCalculation {
+func getLogsCalculationSteps(sortSchema []string) []logsIndexCalculation {
 	return []logsIndexCalculation{
 		&streamStatisticsCalculation{},
 		&columnValuesCalculation{},
-		&statsCalculation{sortSchemaKeys: sortSchemaKeys},
+		&statsCalculation{schema: sortSchema},
 		&labelPostingsCalculation{},
 	}
 }
@@ -255,7 +255,7 @@ func (c *Calculator) processLogsSection(ctx context.Context, sectionLogger log.L
 	lockFreeContext := *calculationContext
 	lockFreeContext.builder = nil
 
-	calculationSteps := getLogsCalculationSteps(schemaSortKeys(schemaLabels))
+	calculationSteps := getLogsCalculationSteps(sectionSortSchema(schemaLabels))
 
 	// Track cumulative duration per calculation step across all batches + flush.
 	stepDurations := make([]time.Duration, len(calculationSteps))

--- a/pkg/dataobj/index/sort_schema.go
+++ b/pkg/dataobj/index/sort_schema.go
@@ -1,26 +1,35 @@
 package index
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
-// defaultSortSchemaKeys defines the label keys used for stats and postings
-// sections when a logs section carries no schema sort of its own.
-var defaultSortSchemaKeys = []string{"service_name"}
+// defaultSortSchema is the fully-qualified sort schema used for stats and
+// postings sections when a logs section carries no schema sort of its own.
+// It mirrors validation.DefaultSortSchema.
+var defaultSortSchema = []string{"label:service_name"}
 
-// schemaSortKeys converts a logs section's fully-qualified schema labels (e.g.
-// "label:service_name") into label keys
-func schemaSortKeys(fqns []string) []string {
+// sectionSortSchema returns the fully-qualified sort schema to record for a logs
+// section, falling back to the default when the section carries none.
+func sectionSortSchema(fqns []string) []string {
 	if len(fqns) == 0 {
-		return defaultSortSchemaKeys
+		return defaultSortSchema
 	}
-	keys := make([]string, 0, len(fqns))
+	return fqns
+}
+
+// schemaLabelNames converts fully-qualified sort keys ("label:<name>") into
+// their bare Prometheus label names. Only "label:<name>" keys are supported; any
+// other form is an error.
+func schemaLabelNames(fqns []string) ([]string, error) {
+	names := make([]string, 0, len(fqns))
 	for _, fqn := range fqns {
-		// Only "label:<name>" keys are supported. Anything else means we cannot
-		// reproduce the sort key here, so fall back to the default.
 		typ, name, ok := strings.Cut(fqn, ":")
 		if !ok || typ != "label" || name == "" {
-			return defaultSortSchemaKeys
+			return nil, fmt.Errorf("unsupported sort key %q — expected \"label:<name>\"", fqn)
 		}
-		keys = append(keys, name)
+		names = append(names, name)
 	}
-	return keys
+	return names, nil
 }

--- a/pkg/dataobj/index/stats_calculation.go
+++ b/pkg/dataobj/index/stats_calculation.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"cmp"
 	"context"
+	"fmt"
 	"hash/fnv"
 	"slices"
 	"strings"
@@ -15,8 +16,9 @@ import (
 
 // created for and scoped to each logs section
 type statsCalculation struct {
-	sortSchemaKeys []string                   // label keys to aggregate by
-	aggregates     map[uint64]*statsAggregate // keyed by hash of composite label values
+	schema     []string                   // schema is the fully-qualified sort schema ("label:<name>")
+	labelKeys  []string                   // labelKeys are the bare Prometheus label names derived from schema
+	aggregates map[uint64]*statsAggregate // keyed by hash of composite label values
 }
 
 type statsAggregate struct {
@@ -35,6 +37,11 @@ func (c *statsCalculation) Name() string { return "stats" }
 func (c *statsCalculation) ProcessBatchNeedsBuilderLock() bool { return false }
 
 func (c *statsCalculation) Prepare(_ context.Context, _ *logsCalculationContext, _ *dataobj.Section, _ logs.Stats) error {
+	labelKeys, err := schemaLabelNames(c.schema)
+	if err != nil {
+		return fmt.Errorf("stats calculation: %w", err)
+	}
+	c.labelKeys = labelKeys
 	c.aggregates = make(map[uint64]*statsAggregate)
 	return nil
 }
@@ -52,7 +59,7 @@ func (c *statsCalculation) ProcessBatch(_ context.Context, calcCtx *logsCalculat
 		// Build the composite key from all sort schema keys.
 		// Uses key=value pairs separated by \x00 to avoid ambiguity.
 		buf.Reset()
-		for i, key := range c.sortSchemaKeys {
+		for i, key := range c.labelKeys {
 			if i > 0 {
 				buf.WriteByte(0)
 			}
@@ -68,8 +75,8 @@ func (c *statsCalculation) ProcessBatch(_ context.Context, calcCtx *logsCalculat
 		agg, ok := c.aggregates[aggKey]
 		if !ok {
 			// Only allocate the labels map when creating a new aggregate.
-			labelMap := make(map[string]string, len(c.sortSchemaKeys))
-			for _, key := range c.sortSchemaKeys {
+			labelMap := make(map[string]string, len(c.labelKeys))
+			for _, key := range c.labelKeys {
 				labelMap[key] = streamLbls.Get(key)
 			}
 			agg = &statsAggregate{
@@ -103,7 +110,7 @@ func (c *statsCalculation) Flush(_ context.Context, calcCtx *logsCalculationCont
 		sorted = append(sorted, agg)
 	}
 	slices.SortFunc(sorted, func(a, b *statsAggregate) int {
-		for _, key := range c.sortSchemaKeys {
+		for _, key := range c.labelKeys {
 			if n := cmp.Compare(a.labels[key], b.labels[key]); n != 0 {
 				return n
 			}
@@ -111,7 +118,7 @@ func (c *statsCalculation) Flush(_ context.Context, calcCtx *logsCalculationCont
 		return 0
 	})
 
-	sortSchema := strings.Join(c.sortSchemaKeys, ",")
+	sortSchema := strings.Join(c.schema, ",")
 	for _, agg := range sorted {
 		err := calcCtx.builder.AppendStat(
 			calcCtx.tenantID,

--- a/pkg/dataobj/index/stats_calculation_test.go
+++ b/pkg/dataobj/index/stats_calculation_test.go
@@ -101,10 +101,50 @@ func readStatsTable(ctx context.Context, r *stats.Reader) (arrow.Table, error) {
 	return array.NewTableFromRecords(recs[0].Schema(), recs), nil
 }
 
+func TestStatsCalculation_StoresFullyQualifiedSchema(t *testing.T) {
+	builder := newTestIndexBuilder(t)
+	ctx := &logsCalculationContext{
+		tenantID:   "tenant-1",
+		objectPath: "test/path/obj1",
+		sectionIdx: 0,
+		streamLabels: map[int64]labels.Labels{
+			1: labels.FromStrings("service_name", "svcA", "cluster", "c1"),
+		},
+		builder: builder,
+	}
+	calc := &statsCalculation{schema: []string{"label:service_name", "label:cluster"}}
+
+	require.NoError(t, calc.Prepare(context.Background(), ctx, nil, logs.Stats{}))
+	require.NoError(t, calc.ProcessBatch(context.Background(), ctx, []logs.Record{
+		{StreamID: 1, Timestamp: time.Unix(100, 0).UTC(), Line: []byte("x")},
+	}))
+	require.NoError(t, calc.Flush(context.Background(), ctx))
+
+	actual := flushAndReadAllStatsTable(t, builder)
+	require.Len(t, actual, 1)
+
+	require.Equal(t, "label:service_name,label:cluster", actual[0]["sort_schema.utf8"],
+		"stats sort_schema must store the fully-qualified schema")
+	require.Equal(t, "svcA", actual[0]["service_name.label.utf8"],
+		"label columns must stay keyed by the bare Prometheus name")
+	require.Equal(t, "c1", actual[0]["cluster.label.utf8"],
+		"label columns must stay keyed by the bare Prometheus name")
+}
+
+func TestStatsCalculation_RejectsUnsupportedSortKey(t *testing.T) {
+	builder := newTestIndexBuilder(t)
+	ctx := makeTestCalcContext(builder)
+	calc := &statsCalculation{schema: []string{"metadata:trace_id"}}
+
+	err := calc.Prepare(context.Background(), ctx, nil, logs.Stats{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "metadata:trace_id")
+}
+
 func TestStatsCalculation_BasicAggregation(t *testing.T) {
 	builder := newTestIndexBuilder(t)
 	ctx := makeTestCalcContext(builder)
-	calc := &statsCalculation{sortSchemaKeys: defaultSortSchemaKeys}
+	calc := &statsCalculation{schema: defaultSortSchema}
 
 	require.NoError(t, calc.Prepare(context.Background(), ctx, nil, logs.Stats{}))
 
@@ -135,7 +175,7 @@ func TestStatsCalculation_BasicAggregation(t *testing.T) {
 	require.Equal(t, arrowtest.Row{
 		"object_path.utf8":        "test/path/obj1",
 		"section_index.int64":     int64(0),
-		"sort_schema.utf8":        "service_name",
+		"sort_schema.utf8":        "label:service_name",
 		"service_name.label.utf8": "",
 		"min_timestamp.timestamp": time.Unix(50, 0).UTC(),
 		"max_timestamp.timestamp": time.Unix(50, 0).UTC(),
@@ -146,7 +186,7 @@ func TestStatsCalculation_BasicAggregation(t *testing.T) {
 	require.Equal(t, arrowtest.Row{
 		"object_path.utf8":        "test/path/obj1",
 		"section_index.int64":     int64(0),
-		"sort_schema.utf8":        "service_name",
+		"sort_schema.utf8":        "label:service_name",
 		"service_name.label.utf8": "svcA",
 		"min_timestamp.timestamp": ts1,
 		"max_timestamp.timestamp": ts2,
@@ -157,7 +197,7 @@ func TestStatsCalculation_BasicAggregation(t *testing.T) {
 	require.Equal(t, arrowtest.Row{
 		"object_path.utf8":        "test/path/obj1",
 		"section_index.int64":     int64(0),
-		"sort_schema.utf8":        "service_name",
+		"sort_schema.utf8":        "label:service_name",
 		"service_name.label.utf8": "svcB",
 		"min_timestamp.timestamp": ts3,
 		"max_timestamp.timestamp": ts3,
@@ -169,7 +209,7 @@ func TestStatsCalculation_BasicAggregation(t *testing.T) {
 func TestStatsCalculation_MetadataFields(t *testing.T) {
 	builder := newTestIndexBuilder(t)
 	ctx := makeTestCalcContext(builder)
-	calc := &statsCalculation{sortSchemaKeys: defaultSortSchemaKeys}
+	calc := &statsCalculation{schema: defaultSortSchema}
 
 	require.NoError(t, calc.Prepare(context.Background(), ctx, nil, logs.Stats{}))
 
@@ -187,7 +227,7 @@ func TestStatsCalculation_MetadataFields(t *testing.T) {
 	require.Equal(t, arrowtest.Row{
 		"object_path.utf8":        "test/path/obj1",
 		"section_index.int64":     int64(0),
-		"sort_schema.utf8":        "service_name",
+		"sort_schema.utf8":        "label:service_name",
 		"service_name.label.utf8": "svcA",
 		"min_timestamp.timestamp": ts,
 		"max_timestamp.timestamp": ts,
@@ -199,7 +239,7 @@ func TestStatsCalculation_MetadataFields(t *testing.T) {
 func TestStatsCalculation_MissingServiceName(t *testing.T) {
 	builder := newTestIndexBuilder(t)
 	ctx := makeTestCalcContext(builder)
-	calc := &statsCalculation{sortSchemaKeys: defaultSortSchemaKeys}
+	calc := &statsCalculation{schema: defaultSortSchema}
 
 	require.NoError(t, calc.Prepare(context.Background(), ctx, nil, logs.Stats{}))
 
@@ -217,7 +257,7 @@ func TestStatsCalculation_MissingServiceName(t *testing.T) {
 func TestStatsCalculation_MultipleBatches(t *testing.T) {
 	builder := newTestIndexBuilder(t)
 	ctx := makeTestCalcContext(builder)
-	calc := &statsCalculation{sortSchemaKeys: defaultSortSchemaKeys}
+	calc := &statsCalculation{schema: defaultSortSchema}
 
 	require.NoError(t, calc.Prepare(context.Background(), ctx, nil, logs.Stats{}))
 
@@ -250,7 +290,7 @@ func TestStatsCalculation_MultipleBatches(t *testing.T) {
 func TestStatsCalculation_EmptyBatch(t *testing.T) {
 	builder := newTestIndexBuilder(t)
 	ctx := makeTestCalcContext(builder)
-	calc := &statsCalculation{sortSchemaKeys: defaultSortSchemaKeys}
+	calc := &statsCalculation{schema: defaultSortSchema}
 
 	require.NoError(t, calc.Prepare(context.Background(), ctx, nil, logs.Stats{}))
 	require.NoError(t, calc.ProcessBatch(context.Background(), ctx, nil))

--- a/pkg/dataobj/sections/stats/builder.go
+++ b/pkg/dataobj/sections/stats/builder.go
@@ -82,9 +82,11 @@ func (b *Builder) Reset() {
 //
 // Both rows must share the same SortSchema.
 func Compare(a, b Stat) int {
-	// Iterates the SortSchema with [strings.SplitSeq] so the function does not
-	// allocate per comparison; the flush sort invokes it O(n log n) times.
-	for key := range strings.SplitSeq(a.SortSchema, ",") {
+	for fqn := range strings.SplitSeq(a.SortSchema, ",") {
+		typ, key, ok := strings.Cut(fqn, ":")
+		if !ok || typ != "label" || key == "" {
+			continue
+		}
 		if va, vb := a.Labels[key], b.Labels[key]; va != vb {
 			return strings.Compare(va, vb)
 		}

--- a/pkg/dataobj/sections/stats/builder_bench_test.go
+++ b/pkg/dataobj/sections/stats/builder_bench_test.go
@@ -49,7 +49,7 @@ func makeBenchStats(n int) []Stat {
 		rows[i] = Stat{
 			ObjectPath:   fmt.Sprintf("logs/tenant/obj-%06d", i),
 			SectionIndex: int64(i % 8),
-			SortSchema:   "service_name,namespace,pod",
+			SortSchema:   "label:service_name,label:namespace,label:pod",
 			Labels: map[string]string{
 				"service_name": fmt.Sprintf("svc-%d", i%512),
 				"namespace":    fmt.Sprintf("ns-%d", i%32),

--- a/pkg/dataobj/sections/stats/builder_test.go
+++ b/pkg/dataobj/sections/stats/builder_test.go
@@ -99,7 +99,7 @@ func TestBuilder_RoundTrip(t *testing.T) {
 		{
 			ObjectPath:       "/tenant/abc/obj1",
 			SectionIndex:     0,
-			SortSchema:       "service_name",
+			SortSchema:       "label:service_name",
 			Labels:           map[string]string{"service_name": "foo"},
 			MinTimestamp:     1000,
 			MaxTimestamp:     2000,
@@ -109,7 +109,7 @@ func TestBuilder_RoundTrip(t *testing.T) {
 		{
 			ObjectPath:       "/tenant/abc/obj2",
 			SectionIndex:     1,
-			SortSchema:       "service_name",
+			SortSchema:       "label:service_name",
 			Labels:           map[string]string{"service_name": "bar"},
 			MinTimestamp:     500,
 			MaxTimestamp:     1500,
@@ -119,7 +119,7 @@ func TestBuilder_RoundTrip(t *testing.T) {
 		{
 			ObjectPath:       "/tenant/abc/obj3",
 			SectionIndex:     2,
-			SortSchema:       "service_name",
+			SortSchema:       "label:service_name",
 			Labels:           map[string]string{"service_name": "baz"},
 			MinTimestamp:     3000,
 			MaxTimestamp:     4000,
@@ -141,7 +141,7 @@ func TestBuilder_RoundTrip(t *testing.T) {
 		{
 			"object_path.utf8":        "/tenant/abc/obj2",
 			"section_index.int64":     int64(1),
-			"sort_schema.utf8":        "service_name",
+			"sort_schema.utf8":        "label:service_name",
 			"min_timestamp.timestamp": time.Unix(0, 500).UTC(),
 			"max_timestamp.timestamp": time.Unix(0, 1500).UTC(),
 			"row_count.int64":         int64(50),
@@ -151,7 +151,7 @@ func TestBuilder_RoundTrip(t *testing.T) {
 		{
 			"object_path.utf8":        "/tenant/abc/obj3",
 			"section_index.int64":     int64(2),
-			"sort_schema.utf8":        "service_name",
+			"sort_schema.utf8":        "label:service_name",
 			"min_timestamp.timestamp": time.Unix(0, 3000).UTC(),
 			"max_timestamp.timestamp": time.Unix(0, 4000).UTC(),
 			"row_count.int64":         int64(200),
@@ -161,7 +161,7 @@ func TestBuilder_RoundTrip(t *testing.T) {
 		{
 			"object_path.utf8":        "/tenant/abc/obj1",
 			"section_index.int64":     int64(0),
-			"sort_schema.utf8":        "service_name",
+			"sort_schema.utf8":        "label:service_name",
 			"min_timestamp.timestamp": time.Unix(0, 1000).UTC(),
 			"max_timestamp.timestamp": time.Unix(0, 2000).UTC(),
 			"row_count.int64":         int64(100),
@@ -178,11 +178,11 @@ func TestBuilder_SortOrder(t *testing.T) {
 	b := NewBuilder(nil, defaultEncoder)
 
 	// Intentionally appended out of order.
-	b.Append(Stat{SortSchema: "service_name", Labels: map[string]string{"service_name": "beta"}, MinTimestamp: 200})
-	b.Append(Stat{SortSchema: "service_name", Labels: map[string]string{"service_name": "alpha"}, MinTimestamp: 300})
-	b.Append(Stat{SortSchema: "service_name", Labels: map[string]string{"service_name": "alpha"}, MinTimestamp: 100})
-	b.Append(Stat{SortSchema: "service_name", Labels: map[string]string{"service_name": "gamma"}, MinTimestamp: 50})
-	b.Append(Stat{SortSchema: "service_name", Labels: map[string]string{"service_name": "alpha"}, MinTimestamp: 200})
+	b.Append(Stat{SortSchema: "label:service_name", Labels: map[string]string{"service_name": "beta"}, MinTimestamp: 200})
+	b.Append(Stat{SortSchema: "label:service_name", Labels: map[string]string{"service_name": "alpha"}, MinTimestamp: 300})
+	b.Append(Stat{SortSchema: "label:service_name", Labels: map[string]string{"service_name": "alpha"}, MinTimestamp: 100})
+	b.Append(Stat{SortSchema: "label:service_name", Labels: map[string]string{"service_name": "gamma"}, MinTimestamp: 50})
+	b.Append(Stat{SortSchema: "label:service_name", Labels: map[string]string{"service_name": "alpha"}, MinTimestamp: 200})
 
 	obj, closer := buildObject(t, b)
 	t.Cleanup(func() { _ = closer.Close() })
@@ -193,7 +193,7 @@ func TestBuilder_SortOrder(t *testing.T) {
 		{
 			"object_path.utf8":        "",
 			"section_index.int64":     int64(0),
-			"sort_schema.utf8":        "service_name",
+			"sort_schema.utf8":        "label:service_name",
 			"min_timestamp.timestamp": time.Unix(0, 100).UTC(),
 			"max_timestamp.timestamp": time.Unix(0, 0).UTC(),
 			"row_count.int64":         int64(0),
@@ -203,7 +203,7 @@ func TestBuilder_SortOrder(t *testing.T) {
 		{
 			"object_path.utf8":        "",
 			"section_index.int64":     int64(0),
-			"sort_schema.utf8":        "service_name",
+			"sort_schema.utf8":        "label:service_name",
 			"min_timestamp.timestamp": time.Unix(0, 200).UTC(),
 			"max_timestamp.timestamp": time.Unix(0, 0).UTC(),
 			"row_count.int64":         int64(0),
@@ -213,7 +213,7 @@ func TestBuilder_SortOrder(t *testing.T) {
 		{
 			"object_path.utf8":        "",
 			"section_index.int64":     int64(0),
-			"sort_schema.utf8":        "service_name",
+			"sort_schema.utf8":        "label:service_name",
 			"min_timestamp.timestamp": time.Unix(0, 300).UTC(),
 			"max_timestamp.timestamp": time.Unix(0, 0).UTC(),
 			"row_count.int64":         int64(0),
@@ -223,7 +223,7 @@ func TestBuilder_SortOrder(t *testing.T) {
 		{
 			"object_path.utf8":        "",
 			"section_index.int64":     int64(0),
-			"sort_schema.utf8":        "service_name",
+			"sort_schema.utf8":        "label:service_name",
 			"min_timestamp.timestamp": time.Unix(0, 200).UTC(),
 			"max_timestamp.timestamp": time.Unix(0, 0).UTC(),
 			"row_count.int64":         int64(0),
@@ -233,7 +233,7 @@ func TestBuilder_SortOrder(t *testing.T) {
 		{
 			"object_path.utf8":        "",
 			"section_index.int64":     int64(0),
-			"sort_schema.utf8":        "service_name",
+			"sort_schema.utf8":        "label:service_name",
 			"min_timestamp.timestamp": time.Unix(0, 50).UTC(),
 			"max_timestamp.timestamp": time.Unix(0, 0).UTC(),
 			"row_count.int64":         int64(0),
@@ -250,9 +250,9 @@ func TestBuilder_AllSameServiceName(t *testing.T) {
 	b := NewBuilder(nil, defaultEncoder)
 
 	// Multiple rows with the same service_name, different timestamps.
-	b.Append(Stat{SortSchema: "service_name", Labels: map[string]string{"service_name": "svc"}, MinTimestamp: 300, ObjectPath: "c"})
-	b.Append(Stat{SortSchema: "service_name", Labels: map[string]string{"service_name": "svc"}, MinTimestamp: 100, ObjectPath: "a"})
-	b.Append(Stat{SortSchema: "service_name", Labels: map[string]string{"service_name": "svc"}, MinTimestamp: 200, ObjectPath: "b"})
+	b.Append(Stat{SortSchema: "label:service_name", Labels: map[string]string{"service_name": "svc"}, MinTimestamp: 300, ObjectPath: "c"})
+	b.Append(Stat{SortSchema: "label:service_name", Labels: map[string]string{"service_name": "svc"}, MinTimestamp: 100, ObjectPath: "a"})
+	b.Append(Stat{SortSchema: "label:service_name", Labels: map[string]string{"service_name": "svc"}, MinTimestamp: 200, ObjectPath: "b"})
 
 	obj, closer := buildObject(t, b)
 	t.Cleanup(func() { _ = closer.Close() })
@@ -263,7 +263,7 @@ func TestBuilder_AllSameServiceName(t *testing.T) {
 		{
 			"object_path.utf8":        "a",
 			"section_index.int64":     int64(0),
-			"sort_schema.utf8":        "service_name",
+			"sort_schema.utf8":        "label:service_name",
 			"min_timestamp.timestamp": time.Unix(0, 100).UTC(),
 			"max_timestamp.timestamp": time.Unix(0, 0).UTC(),
 			"row_count.int64":         int64(0),
@@ -273,7 +273,7 @@ func TestBuilder_AllSameServiceName(t *testing.T) {
 		{
 			"object_path.utf8":        "b",
 			"section_index.int64":     int64(0),
-			"sort_schema.utf8":        "service_name",
+			"sort_schema.utf8":        "label:service_name",
 			"min_timestamp.timestamp": time.Unix(0, 200).UTC(),
 			"max_timestamp.timestamp": time.Unix(0, 0).UTC(),
 			"row_count.int64":         int64(0),
@@ -283,7 +283,7 @@ func TestBuilder_AllSameServiceName(t *testing.T) {
 		{
 			"object_path.utf8":        "c",
 			"section_index.int64":     int64(0),
-			"sort_schema.utf8":        "service_name",
+			"sort_schema.utf8":        "label:service_name",
 			"min_timestamp.timestamp": time.Unix(0, 300).UTC(),
 			"max_timestamp.timestamp": time.Unix(0, 0).UTC(),
 			"row_count.int64":         int64(0),
@@ -296,7 +296,7 @@ func TestBuilder_AllSameServiceName(t *testing.T) {
 
 // TestCompare_FullKeyOrder locks the canonical stats sort order
 func TestCompare_FullKeyOrder(t *testing.T) {
-	const schema = "service_name,namespace"
+	const schema = "label:service_name,label:namespace"
 	base := func() Stat {
 		return Stat{
 			SortSchema:   schema,
@@ -362,8 +362,8 @@ func TestBuilder_TieBreakOnObjectPathAndSectionIndex(t *testing.T) {
 	// All rows share the same (service_name, MinTimestamp, MaxTimestamp).
 	// They differ only in ObjectPath and SectionIndex, and are appended in an
 	// order that the coarse (labels, minT, maxT) sort would leave untouched.
-	const schema = "service_name"
-	labels := map[string]string{schema: "svc"}
+	const schema = "label:service_name"
+	labels := map[string]string{"service_name": "svc"}
 	b.Append(Stat{SortSchema: schema, Labels: labels, MinTimestamp: 100, MaxTimestamp: 200, ObjectPath: "objB", SectionIndex: 0})
 	b.Append(Stat{SortSchema: schema, Labels: labels, MinTimestamp: 100, MaxTimestamp: 200, ObjectPath: "objA", SectionIndex: 1})
 	b.Append(Stat{SortSchema: schema, Labels: labels, MinTimestamp: 100, MaxTimestamp: 200, ObjectPath: "objA", SectionIndex: 0})
@@ -412,8 +412,8 @@ func TestBuilder_TieBreakOnObjectPathAndSectionIndex(t *testing.T) {
 func TestBuilder_MissingServiceName(t *testing.T) {
 	b := NewBuilder(nil, defaultEncoder)
 
-	b.Append(Stat{SortSchema: "service_name", Labels: map[string]string{"service_name": ""}, ObjectPath: "obj1", MinTimestamp: 100})
-	b.Append(Stat{SortSchema: "service_name", Labels: map[string]string{"service_name": "svc"}, ObjectPath: "obj2", MinTimestamp: 200})
+	b.Append(Stat{SortSchema: "label:service_name", Labels: map[string]string{"service_name": ""}, ObjectPath: "obj1", MinTimestamp: 100})
+	b.Append(Stat{SortSchema: "label:service_name", Labels: map[string]string{"service_name": "svc"}, ObjectPath: "obj2", MinTimestamp: 200})
 
 	obj, closer := buildObject(t, b)
 	t.Cleanup(func() { _ = closer.Close() })
@@ -424,7 +424,7 @@ func TestBuilder_MissingServiceName(t *testing.T) {
 		{
 			"object_path.utf8":        "obj1",
 			"section_index.int64":     int64(0),
-			"sort_schema.utf8":        "service_name",
+			"sort_schema.utf8":        "label:service_name",
 			"min_timestamp.timestamp": time.Unix(0, 100).UTC(),
 			"max_timestamp.timestamp": time.Unix(0, 0).UTC(),
 			"row_count.int64":         int64(0),
@@ -434,7 +434,7 @@ func TestBuilder_MissingServiceName(t *testing.T) {
 		{
 			"object_path.utf8":        "obj2",
 			"section_index.int64":     int64(0),
-			"sort_schema.utf8":        "service_name",
+			"sort_schema.utf8":        "label:service_name",
 			"min_timestamp.timestamp": time.Unix(0, 200).UTC(),
 			"max_timestamp.timestamp": time.Unix(0, 0).UTC(),
 			"row_count.int64":         int64(0),
@@ -457,7 +457,7 @@ func TestBuilder_SectionSplitting(t *testing.T) {
 	for i := range 3 {
 		b.Append(Stat{
 			ObjectPath:   "x",
-			SortSchema:   "service_name",
+			SortSchema:   "label:service_name",
 			Labels:       map[string]string{"service_name": "svc"},
 			MinTimestamp: int64(i * 100),
 		})
@@ -472,7 +472,7 @@ func TestBuilder_SectionSplitting(t *testing.T) {
 	for i := range 3 {
 		b.Append(Stat{
 			ObjectPath:   "y",
-			SortSchema:   "service_name",
+			SortSchema:   "label:service_name",
 			Labels:       map[string]string{"service_name": "svc"},
 			MinTimestamp: int64((i + 3) * 100),
 		})
@@ -505,12 +505,13 @@ func TestBuilder_LargeValues(t *testing.T) {
 
 	longPath := "/" + strings.Repeat("a", 10000)
 	longLabel := strings.Repeat("b", 5000)
-	longSchema := strings.Repeat("c", 2000)
+	longName := strings.Repeat("c", 2000)
+	longSchema := "label:" + longName
 
 	b.Append(Stat{
 		ObjectPath:       longPath,
 		SortSchema:       longSchema,
-		Labels:           map[string]string{longSchema: longLabel},
+		Labels:           map[string]string{longName: longLabel},
 		SectionIndex:     99,
 		MinTimestamp:     1_000_000,
 		MaxTimestamp:     2_000_000,
@@ -525,7 +526,7 @@ func TestBuilder_LargeValues(t *testing.T) {
 	require.Len(t, actual, 1)
 
 	// Build the expected label column name dynamically
-	labelColName := longSchema + ".label.utf8"
+	labelColName := longName + ".label.utf8"
 	expected := arrowtest.Rows{
 		{
 			"object_path.utf8":        longPath,
@@ -546,7 +547,7 @@ func TestBuilder_ResetAndReuse(t *testing.T) {
 	b := NewBuilder(nil, defaultEncoder)
 	b.SetTenant("test-tenant")
 
-	b.Append(Stat{SortSchema: "service_name", Labels: map[string]string{"service_name": "first"}, MinTimestamp: 100})
+	b.Append(Stat{SortSchema: "label:service_name", Labels: map[string]string{"service_name": "first"}, MinTimestamp: 100})
 	b.Reset()
 
 	// After Reset, builder should be empty and produce no sections when flushed.
@@ -554,7 +555,7 @@ func TestBuilder_ResetAndReuse(t *testing.T) {
 	require.Zero(t, b.EstimatedSize(), "estimated size should be zero after reset")
 
 	// Add new data after reset and flush.
-	b.Append(Stat{SortSchema: "service_name", Labels: map[string]string{"service_name": "second"}, MinTimestamp: 200})
+	b.Append(Stat{SortSchema: "label:service_name", Labels: map[string]string{"service_name": "second"}, MinTimestamp: 200})
 
 	obj, closer := buildObject(t, b)
 	t.Cleanup(func() { _ = closer.Close() })
@@ -564,7 +565,7 @@ func TestBuilder_ResetAndReuse(t *testing.T) {
 		{
 			"object_path.utf8":        "",
 			"section_index.int64":     int64(0),
-			"sort_schema.utf8":        "service_name",
+			"sort_schema.utf8":        "label:service_name",
 			"min_timestamp.timestamp": time.Unix(0, 200).UTC(),
 			"max_timestamp.timestamp": time.Unix(0, 0).UTC(),
 			"row_count.int64":         int64(0),
@@ -595,7 +596,7 @@ func TestBuilder_EstimatedSize(t *testing.T) {
 // TestBuilder_FlushResetsBuilder verifies that a flush resets the builder state.
 func TestBuilder_FlushResetsBuilder(t *testing.T) {
 	b := NewBuilder(nil, defaultEncoder)
-	b.Append(Stat{SortSchema: "service_name", Labels: map[string]string{"service_name": "svc"}, MinTimestamp: 100})
+	b.Append(Stat{SortSchema: "label:service_name", Labels: map[string]string{"service_name": "svc"}, MinTimestamp: 100})
 
 	obj, closer := buildObject(t, b)
 	closer.Close()

--- a/pkg/dataobj/sections/stats/convert_test.go
+++ b/pkg/dataobj/sections/stats/convert_test.go
@@ -18,7 +18,7 @@ func TestFromRecordBatch_RoundTrip(t *testing.T) {
 	b.Append(stats.Stat{
 		ObjectPath:       "/obj1",
 		SectionIndex:     0,
-		SortSchema:       "service_name,job",
+		SortSchema:       "label:service_name,label:job",
 		Labels:           map[string]string{"service_name": "svc1", "job": "job1"},
 		MinTimestamp:     100,
 		MaxTimestamp:     200,
@@ -28,7 +28,7 @@ func TestFromRecordBatch_RoundTrip(t *testing.T) {
 	b.Append(stats.Stat{
 		ObjectPath:       "/obj2",
 		SectionIndex:     1,
-		SortSchema:       "service_name,job",
+		SortSchema:       "label:service_name,label:job",
 		Labels:           map[string]string{"service_name": "svc2", "job": "job2"},
 		MinTimestamp:     150,
 		MaxTimestamp:     250,
@@ -76,7 +76,7 @@ func TestFromRecordBatch_RoundTrip(t *testing.T) {
 	r1, ok := byPath["/obj1"]
 	require.True(t, ok, "expected a row for /obj1")
 	require.Equal(t, int64(0), r1.SectionIndex)
-	require.Equal(t, "service_name,job", r1.SortSchema)
+	require.Equal(t, "label:service_name,label:job", r1.SortSchema)
 	require.Equal(t, "svc1", r1.Labels["service_name"])
 	require.Equal(t, "job1", r1.Labels["job"])
 	require.Equal(t, int64(100), r1.MinTimestamp)
@@ -87,7 +87,7 @@ func TestFromRecordBatch_RoundTrip(t *testing.T) {
 	r2, ok := byPath["/obj2"]
 	require.True(t, ok, "expected a row for /obj2")
 	require.Equal(t, int64(1), r2.SectionIndex)
-	require.Equal(t, "service_name,job", r2.SortSchema)
+	require.Equal(t, "label:service_name,label:job", r2.SortSchema)
 	require.Equal(t, "svc2", r2.Labels["service_name"])
 	require.Equal(t, "job2", r2.Labels["job"])
 	require.Equal(t, int64(150), r2.MinTimestamp)
@@ -104,7 +104,7 @@ func TestFromRecordBatch_ParityWithDecodeRow(t *testing.T) {
 	b.Append(stats.Stat{
 		ObjectPath:       "/obj1",
 		SectionIndex:     0,
-		SortSchema:       "service_name,job",
+		SortSchema:       "label:service_name,label:job",
 		Labels:           map[string]string{"service_name": "svc1", "job": "job1"},
 		MinTimestamp:     100,
 		MaxTimestamp:     200,
@@ -114,7 +114,7 @@ func TestFromRecordBatch_ParityWithDecodeRow(t *testing.T) {
 	b.Append(stats.Stat{
 		ObjectPath:       "/obj2",
 		SectionIndex:     1,
-		SortSchema:       "service_name,job",
+		SortSchema:       "label:service_name,label:job",
 		Labels:           map[string]string{"service_name": "svc2", "job": "job2"},
 		MinTimestamp:     150,
 		MaxTimestamp:     250,
@@ -169,7 +169,7 @@ func TestFromRecordBatch_DestShorterThanBatch(t *testing.T) {
 	b.Append(stats.Stat{
 		ObjectPath:       "/obj1",
 		SectionIndex:     0,
-		SortSchema:       "service_name",
+		SortSchema:       "label:service_name",
 		Labels:           map[string]string{"service_name": "svc1"},
 		MinTimestamp:     100,
 		MaxTimestamp:     200,
@@ -179,7 +179,7 @@ func TestFromRecordBatch_DestShorterThanBatch(t *testing.T) {
 	b.Append(stats.Stat{
 		ObjectPath:       "/obj2",
 		SectionIndex:     1,
-		SortSchema:       "service_name",
+		SortSchema:       "label:service_name",
 		Labels:           map[string]string{"service_name": "svc2"},
 		MinTimestamp:     150,
 		MaxTimestamp:     250,
@@ -189,7 +189,7 @@ func TestFromRecordBatch_DestShorterThanBatch(t *testing.T) {
 	b.Append(stats.Stat{
 		ObjectPath:       "/obj3",
 		SectionIndex:     2,
-		SortSchema:       "service_name",
+		SortSchema:       "label:service_name",
 		Labels:           map[string]string{"service_name": "svc3"},
 		MinTimestamp:     160,
 		MaxTimestamp:     260,
@@ -240,7 +240,7 @@ func TestFromRecordBatch_ReusedDestNoStaleValues(t *testing.T) {
 	b.Append(stats.Stat{
 		ObjectPath:       "/obj1",
 		SectionIndex:     0,
-		SortSchema:       "service_name",
+		SortSchema:       "label:service_name",
 		Labels:           map[string]string{"service_name": "svc1"},
 		MinTimestamp:     100,
 		MaxTimestamp:     200,
@@ -292,7 +292,7 @@ func TestFromRecordBatch_ReusedDestNoStaleValues(t *testing.T) {
 	require.Equal(t, int64(200), dest[0].MaxTimestamp)
 	require.Equal(t, int64(5), dest[0].RowCount)
 	require.Equal(t, int64(50), dest[0].UncompressedSize)
-	require.Equal(t, "service_name", dest[0].SortSchema)
+	require.Equal(t, "label:service_name", dest[0].SortSchema)
 	require.Equal(t, "svc1", dest[0].Labels["service_name"])
 	require.NotContains(t, dest[0].Labels, "old")
 }

--- a/pkg/dataobj/sections/stats/encode_columnar.go
+++ b/pkg/dataobj/sections/stats/encode_columnar.go
@@ -3,7 +3,6 @@ package stats
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
@@ -30,16 +29,7 @@ func columnarEncode(rows []Stat, enc *columnar.Encoder, pageSizeHint, pageMaxRow
 	// Parse label keys from SortSchema. All rows within a section share the
 	// same SortSchema (guaranteed by the builder being per-tenant and the
 	// calculation pipeline producing rows with a config-driven schema).
-	sortSchema := rows[0].SortSchema
-	var labelKeys []string
-	if sortSchema != "" {
-		parts := strings.Split(sortSchema, ",")
-		for _, k := range parts {
-			if k != "" {
-				labelKeys = append(labelKeys, k)
-			}
-		}
-	}
+	labelKeys := schemaLabelNames(rows[0].SortSchema)
 
 	// Build fixed column builders (indices 0-6).
 	objectPathBuilder, err := binaryColumnBuilder(ColumnTypeObjectPath, pageSizeHint, pageMaxRowCount)

--- a/pkg/dataobj/sections/stats/reader_test.go
+++ b/pkg/dataobj/sections/stats/reader_test.go
@@ -31,7 +31,7 @@ func TestReader_RoundTrip(t *testing.T) {
 	b.Append(stats.Stat{
 		ObjectPath:       "/obj",
 		SectionIndex:     0,
-		SortSchema:       "service_name",
+		SortSchema:       "label:service_name",
 		Labels:           map[string]string{"service_name": "svc"},
 		MinTimestamp:     100,
 		MaxTimestamp:     200,
@@ -71,7 +71,7 @@ func TestReader_RoundTrip(t *testing.T) {
 	require.Len(t, actual, 1)
 	row := actual[0]
 	require.Equal(t, "/obj", row["object_path.utf8"])
-	require.Equal(t, "service_name", row["sort_schema.utf8"])
+	require.Equal(t, "label:service_name", row["sort_schema.utf8"])
 	require.Equal(t, int64(5), row["row_count.int64"])
 	require.Equal(t, int64(50), row["uncompressed_size.int64"])
 	require.Equal(t, "svc", row["service_name.label.utf8"])

--- a/pkg/dataobj/sections/stats/row_reader_test.go
+++ b/pkg/dataobj/sections/stats/row_reader_test.go
@@ -20,7 +20,7 @@ func TestRowReader_RoundTrip(t *testing.T) {
 	b.Append(stats.Stat{
 		ObjectPath:       "/obj1",
 		SectionIndex:     0,
-		SortSchema:       "service_name,job",
+		SortSchema:       "label:service_name,label:job",
 		Labels:           map[string]string{"service_name": "svc1", "job": "job1"},
 		MinTimestamp:     100,
 		MaxTimestamp:     200,
@@ -30,7 +30,7 @@ func TestRowReader_RoundTrip(t *testing.T) {
 	b.Append(stats.Stat{
 		ObjectPath:       "/obj2",
 		SectionIndex:     0,
-		SortSchema:       "service_name,job",
+		SortSchema:       "label:service_name,label:job",
 		Labels:           map[string]string{"service_name": "svc2", "job": "job2"},
 		MinTimestamp:     150,
 		MaxTimestamp:     250,
@@ -73,7 +73,7 @@ func TestRowReader_RoundTrip(t *testing.T) {
 
 	r1, ok := byPath["/obj1"]
 	require.True(t, ok, "expected a row for /obj1")
-	require.Equal(t, "service_name,job", r1.SortSchema)
+	require.Equal(t, "label:service_name,label:job", r1.SortSchema)
 	require.Equal(t, "svc1", r1.Labels["service_name"])
 	require.Equal(t, "job1", r1.Labels["job"])
 	require.Equal(t, int64(100), r1.MinTimestamp)
@@ -81,7 +81,7 @@ func TestRowReader_RoundTrip(t *testing.T) {
 
 	r2, ok := byPath["/obj2"]
 	require.True(t, ok, "expected a row for /obj2")
-	require.Equal(t, "service_name,job", r2.SortSchema)
+	require.Equal(t, "label:service_name,label:job", r2.SortSchema)
 	require.Equal(t, "svc2", r2.Labels["service_name"])
 	require.Equal(t, "job2", r2.Labels["job"])
 	require.Equal(t, int64(150), r2.MinTimestamp)
@@ -96,7 +96,7 @@ func TestRowReader_CloseIdempotent(t *testing.T) {
 	b.Append(stats.Stat{
 		ObjectPath:   "/obj1",
 		SectionIndex: 0,
-		SortSchema:   "service_name",
+		SortSchema:   "label:service_name",
 		Labels:       map[string]string{"service_name": "svc1"},
 		MinTimestamp: 100,
 		MaxTimestamp: 200,

--- a/pkg/dataobj/sections/stats/stats.go
+++ b/pkg/dataobj/sections/stats/stats.go
@@ -5,6 +5,7 @@ package stats
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/internal/columnar"
@@ -98,3 +99,23 @@ type Stat struct {
 
 // SectionEncoder encodes a batch of sorted Stat rows into a columnar encoder.
 type SectionEncoder func(rows []Stat, enc *columnar.Encoder) error
+
+// schemaLabelNames parses a comma-separated fully-qualified sort schema
+// ("label:svc,label:cluster") into its bare label names ("svc", "cluster").
+func schemaLabelNames(sortSchema string) []string {
+	if sortSchema == "" {
+		return nil
+	}
+	var names []string
+	for fqn := range strings.SplitSeq(sortSchema, ",") {
+		if fqn == "" {
+			continue
+		}
+		typ, name, ok := strings.Cut(fqn, ":")
+		if !ok || typ != "label" || name == "" {
+			continue
+		}
+		names = append(names, name)
+	}
+	return names
+}

--- a/pkg/engine/compactor/coordinator_test.go
+++ b/pkg/engine/compactor/coordinator_test.go
@@ -310,9 +310,9 @@ func TestCompactTenantLogs_DispatchesLogMergePlans(t *testing.T) {
 	// Same tuple, overlapping times -> 2 runs -> still dispatches after the
 	// terminal gate (total size 200 clears the test floor of 1).
 	buildIndexWithStats(ctx, t, bucket, "acme", convergedPath, []stats.Stat{
-		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "service_name",
+		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "label:service_name",
 			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 30, RowCount: 1, UncompressedSize: 100},
-		{ObjectPath: "logs/log-1", SectionIndex: 0, SortSchema: "service_name",
+		{ObjectPath: "logs/log-1", SectionIndex: 0, SortSchema: "label:service_name",
 			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 20, MaxTimestamp: 40, RowCount: 1, UncompressedSize: 100},
 	})
 
@@ -357,7 +357,7 @@ func TestCompactTenantLogs_NoStatsRowsForTenantIsConverged(t *testing.T) {
 	// Index has a stats section (so it flushes) but for a DIFFERENT tenant;
 	// "acme" gets zero refs -> no tasks -> converged.
 	buildIndexWithStats(ctx, t, bucket, "other", convergedPath, []stats.Stat{
-		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "service_name",
+		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "label:service_name",
 			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 20, RowCount: 1, UncompressedSize: 100},
 	})
 
@@ -379,9 +379,9 @@ func TestRunCycle_ConvergedTenantTriggersLogCompaction(t *testing.T) {
 	convergedPath := "indexes/aa/converged"
 
 	buildIndexWithStats(ctx, t, bucket, "solo", convergedPath, []stats.Stat{
-		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "service_name",
+		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "label:service_name",
 			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 30, RowCount: 1, UncompressedSize: 100},
-		{ObjectPath: "logs/log-0", SectionIndex: 1, SortSchema: "service_name",
+		{ObjectPath: "logs/log-0", SectionIndex: 1, SortSchema: "label:service_name",
 			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 20, MaxTimestamp: 40, RowCount: 1, UncompressedSize: 100},
 	})
 	writeToCWithIndexes(ctx, t, bucket, map[string][]testIndex{
@@ -406,7 +406,7 @@ func TestCompactTenantLogs_TerminalSingleRunSkips(t *testing.T) {
 
 	// Single stat row -> P=1 -> terminal regardless of size.
 	buildIndexWithStats(ctx, t, bucket, "acme", convergedPath, []stats.Stat{
-		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "service_name",
+		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "label:service_name",
 			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 20, RowCount: 1, UncompressedSize: 100},
 	})
 
@@ -431,9 +431,9 @@ func TestCompactTenantLogs_TerminalBelowFloorSkips(t *testing.T) {
 
 	// Two overlapping same-tuple rows -> P=2, total size 30, below the 1GiB floor.
 	buildIndexWithStats(ctx, t, bucket, "acme", convergedPath, []stats.Stat{
-		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "service_name",
+		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "label:service_name",
 			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 30, RowCount: 1, UncompressedSize: 10},
-		{ObjectPath: "logs/log-1", SectionIndex: 0, SortSchema: "service_name",
+		{ObjectPath: "logs/log-1", SectionIndex: 0, SortSchema: "label:service_name",
 			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 20, MaxTimestamp: 40, RowCount: 1, UncompressedSize: 20},
 	})
 
@@ -455,9 +455,9 @@ func twoRunConvergedBucket(ctx context.Context, t *testing.T, tenant, path strin
 	t.Helper()
 	bucket := objstore.NewInMemBucket()
 	buildIndexWithStats(ctx, t, bucket, tenant, path, []stats.Stat{
-		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "service_name",
+		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "label:service_name",
 			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 30, RowCount: 1, UncompressedSize: 100},
-		{ObjectPath: "logs/log-1", SectionIndex: 0, SortSchema: "service_name",
+		{ObjectPath: "logs/log-1", SectionIndex: 0, SortSchema: "label:service_name",
 			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 20, MaxTimestamp: 40, RowCount: 1, UncompressedSize: 100},
 	})
 	return bucket

--- a/pkg/engine/compactor/integration_test.go
+++ b/pkg/engine/compactor/integration_test.go
@@ -252,7 +252,7 @@ func seedSourceIndexObject(ctx context.Context, t *testing.T, bucket objstore.Bu
 	statsBuilder.Append(stats.Stat{
 		ObjectPath:       path,
 		SectionIndex:     0,
-		SortSchema:       "service",
+		SortSchema:       "label:service",
 		Labels:           map[string]string{"service": "api"},
 		MinTimestamp:     ts.UnixNano(),
 		MaxTimestamp:     ts.UnixNano() + 1000,

--- a/pkg/engine/compactor/sections.go
+++ b/pkg/engine/compactor/sections.go
@@ -240,14 +240,16 @@ func logSectionRefsFor(ctx context.Context, bucket objstore.Bucket, tenant, idxP
 				st := dest[i]
 
 				if !schemaDerived {
-					for k := range strings.SplitSeq(st.SortSchema, ",") {
-						if k != "" {
-							sortSchemaLbls = append(sortSchemaLbls, k)
+					// SortSchema is stored fully-qualified ("label:<name>"),
+					for fqn := range strings.SplitSeq(st.SortSchema, ",") {
+						if fqn == "" {
+							continue
 						}
-					}
-					schema = make([]string, len(sortSchemaLbls))
-					for j, k := range sortSchemaLbls {
-						schema[j] = "label:" + k
+						schema = append(schema, fqn)
+						typ, name, ok := strings.Cut(fqn, ":")
+						if ok && typ == "label" && name != "" {
+							sortSchemaLbls = append(sortSchemaLbls, name)
+						}
 					}
 					schemaDerived = true
 				}

--- a/pkg/engine/compactor/sections_test.go
+++ b/pkg/engine/compactor/sections_test.go
@@ -166,9 +166,9 @@ func TestLogSectionRefsFor_OneRefPerStatRow(t *testing.T) {
 	path := "indexes/aa/converged"
 
 	buildIndexWithStats(ctx, t, bucket, "acme", path, []stats.Stat{
-		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "service_name",
+		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "label:service_name",
 			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 20, RowCount: 3, UncompressedSize: 300},
-		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "service_name",
+		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "label:service_name",
 			Labels: map[string]string{"service_name": "billing"}, MinTimestamp: 15, MaxTimestamp: 25, RowCount: 2, UncompressedSize: 200},
 	})
 
@@ -202,7 +202,7 @@ func TestLogSectionRefsFor_MultiKeySchemaOrdersValuesAndReturnsFQN(t *testing.T)
 	path := "indexes/aa/multikey"
 
 	buildIndexWithStats(ctx, t, bucket, "acme", path, []stats.Stat{
-		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "service_name,namespace",
+		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "label:service_name,label:namespace",
 			Labels: map[string]string{"service_name": "auth", "namespace": "eu"}, MinTimestamp: 10, MaxTimestamp: 20, RowCount: 1, UncompressedSize: 100},
 	})
 

--- a/pkg/engine/internal/executor/index_merge_test.go
+++ b/pkg/engine/internal/executor/index_merge_test.go
@@ -579,7 +579,7 @@ func buildSourceWithLegacySections(t *testing.T, bucket objstore.Bucket, tenant,
 	require.NoError(t, err, "failed to observe log line")
 
 	// Append a stat to get a stats section.
-	err = builder.AppendStat(tenant, "log-A", 0, "service",
+	err = builder.AppendStat(tenant, "log-A", 0, "label:service",
 		map[string]string{"service": "api"},
 		ts, ts.Add(time.Second), 10, 1000)
 	require.NoError(t, err, "failed to append stat")
@@ -632,7 +632,7 @@ func buildSourceIndexWithBothKinds(t *testing.T, bucket objstore.Bucket, tenant,
 	statsBuilder.Append(stats.Stat{
 		ObjectPath:       "log-A",
 		SectionIndex:     0,
-		SortSchema:       "service,namespace",
+		SortSchema:       "label:service,label:namespace",
 		Labels:           map[string]string{"service": "api", "namespace": "default"},
 		MinTimestamp:     ts.UnixNano(),
 		MaxTimestamp:     ts.UnixNano() + 1000,
@@ -1126,7 +1126,7 @@ func TestExecuteIndexMerge_StatsDuplicateFirstWins(t *testing.T) {
 		{
 			ObjectPath:       "log-X",
 			SectionIndex:     0,
-			SortSchema:       "service",
+			SortSchema:       "label:service",
 			Labels:           map[string]string{"service": "api"},
 			MinTimestamp:     ts1, // identical to source B
 			MaxTimestamp:     ts2, // identical to source B
@@ -1140,7 +1140,7 @@ func TestExecuteIndexMerge_StatsDuplicateFirstWins(t *testing.T) {
 		{
 			ObjectPath:       "log-X",
 			SectionIndex:     0,
-			SortSchema:       "service",
+			SortSchema:       "label:service",
 			Labels:           map[string]string{"service": "api"},
 			MinTimestamp:     ts1, // identical to source A
 			MaxTimestamp:     ts2, // identical to source A
@@ -1176,7 +1176,7 @@ func TestExecuteIndexMerge_StatsDuplicateFirstWins(t *testing.T) {
 	row := rows[0]
 	require.Equal(t, "log-X", row.ObjectPath)
 	require.Equal(t, int64(0), row.SectionIndex)
-	require.Equal(t, "service", row.SortSchema)
+	require.Equal(t, "label:service", row.SortSchema)
 	require.Equal(t, map[string]string{"service": "api"}, row.Labels)
 
 	// Timestamps unchanged (both inputs match).
@@ -1214,7 +1214,7 @@ func TestExecuteIndexMerge_MixedKinds(t *testing.T) {
 		{
 			ObjectPath:       "log-A",
 			SectionIndex:     0,
-			SortSchema:       "service",
+			SortSchema:       "label:service",
 			Labels:           map[string]string{"service": "api"},
 			MinTimestamp:     100,
 			MaxTimestamp:     200,
@@ -1351,7 +1351,7 @@ func TestExecuteIndexMerge_StatsDuplicateFirstWinsMultiSource(t *testing.T) {
 			{
 				ObjectPath:       "log-X",
 				SectionIndex:     0,
-				SortSchema:       "service",
+				SortSchema:       "label:service",
 				Labels:           map[string]string{"service": "api"},
 				MinTimestamp:     ts1, // identical across all sources
 				MaxTimestamp:     ts2, // identical across all sources
@@ -1437,7 +1437,7 @@ func TestStatsRowReader_DottedLabelNames(t *testing.T) {
 	b.Append(stats.Stat{
 		ObjectPath:       "/obj1",
 		SectionIndex:     0,
-		SortSchema:       "my.svc",
+		SortSchema:       "label:my.svc",
 		Labels:           map[string]string{"my.svc": "api"},
 		MinTimestamp:     100,
 		MaxTimestamp:     200,
@@ -1477,7 +1477,7 @@ func TestStatsRowReader_DottedLabelNames(t *testing.T) {
 	}
 
 	// Verify the label name is NOT truncated: should be "my.svc", not "my"
-	require.Equal(t, "my.svc", row.SortSchema)
+	require.Equal(t, "label:my.svc", row.SortSchema)
 	require.Equal(t, map[string]string{"my.svc": "api"}, row.Labels)
 	require.Equal(t, "api", row.Labels["my.svc"])
 
@@ -1499,7 +1499,7 @@ func TestExecuteIndexMerge_StatsSortSchemaMismatch_FailsLoudly(t *testing.T) {
 		{
 			ObjectPath:       "log-X",
 			SectionIndex:     0,
-			SortSchema:       "service,job",
+			SortSchema:       "label:service,label:job",
 			Labels:           map[string]string{"service": "api", "job": "j1"},
 			MinTimestamp:     100,
 			MaxTimestamp:     200,
@@ -1513,7 +1513,7 @@ func TestExecuteIndexMerge_StatsSortSchemaMismatch_FailsLoudly(t *testing.T) {
 		{
 			ObjectPath:       "log-X",
 			SectionIndex:     0,
-			SortSchema:       "job,service", // Different SortSchema
+			SortSchema:       "label:job,label:service", // Different SortSchema
 			Labels:           map[string]string{"job": "j1", "service": "api"},
 			MinTimestamp:     100,
 			MaxTimestamp:     200,
@@ -1587,7 +1587,7 @@ func buildMultiTenantSourceObject(t *testing.T, bucket objstore.Bucket, path str
 			statsBuilder.Append(stats.Stat{
 				ObjectPath:       objectPath,
 				SectionIndex:     int64(i),
-				SortSchema:       "service_name",
+				SortSchema:       "label:service_name",
 				Labels:           map[string]string{"service_name": fmt.Sprintf("svc-%s-%s-%d", tr.tenant, path, i)},
 				MinTimestamp:     ts.UnixNano(),
 				MaxTimestamp:     ts.UnixNano() + 1000,


### PR DESCRIPTION
**What this PR does / why we need it**:

The stats section was the only component that stored the sort schema in bare form (`service_name`), while the logs section (`SortInfo.SchemaLabels`), tenant overrides (`SortSchemaLabels`), and `physical.LogMerge.SortSchema` all use the fully-qualified form (`label:service_name`).

Because the two conventions were reconciled in different places, the recorded stats schema could silently diverge from the data object it describes, surfacing as k-way log merge failures:

```
section schema [label:service_name label:cluster label:namespace label:job] does not match expected sort schema [label:service_name]
```

This PR makes the stats `sort_schema` field store the schema fully-qualified so it matches every other component, and derives the bare Prometheus label names locally only where a real label lookup is needed (aggregation, dynamic label columns, `Compare`). Unsupported sort keys now error instead of silently degrading to the default schema.

**Special notes for your reviewer**:

- Scope: this fixes the code so newly written indexes are self-consistent. It does **not** repair indexes written before #23285, which recorded a hardcoded `service_name` schema regardless of the log object's real schema — that historical data remains mismatched and is out of scope here.