### PR TITLE
chore(dataset): Implement wirecodec marshal/unmarshal

### DIFF
--- a/pkg/dataset/encoding/wirecodec/dictionary.go
+++ b/pkg/dataset/encoding/wirecodec/dictionary.go
@@ -1,0 +1,46 @@
+package wirecodec
+
+import "fmt"
+
+// dictionary accumulates strings and assigns monotonically increasing indices.
+// It is used during marshaling (add) and unmarshaling (lookup).
+type dictionary struct {
+	keys    []string
+	indices map[string]uint64
+}
+
+// newDictionary creates a dictionary pre-populated with the given keys.
+func newDictionary(keys []string) *dictionary {
+	d := &dictionary{
+		keys:    keys,
+		indices: make(map[string]uint64, len(keys)),
+	}
+	for i, k := range keys {
+		d.indices[k] = uint64(i)
+	}
+	return d
+}
+
+// add inserts a string into the dictionary if not already present and returns
+// its index.
+func (d *dictionary) add(s string) uint64 {
+	if idx, ok := d.indices[s]; ok {
+		return idx
+	}
+	idx := uint64(len(d.keys))
+	d.keys = append(d.keys, s)
+	if d.indices == nil {
+		d.indices = make(map[string]uint64)
+	}
+	d.indices[s] = idx
+	return idx
+}
+
+// lookup returns the string at the given index. Returns an error if the index
+// is out of bounds.
+func (d *dictionary) lookup(i uint64) (string, error) {
+	if i >= uint64(len(d.keys)) {
+		return "", fmt.Errorf("wirecodec: dictionary index %d out of range (size %d)", i, len(d.keys))
+	}
+	return d.keys[i], nil
+}

--- a/pkg/dataset/encoding/wirecodec/dictionary_test.go
+++ b/pkg/dataset/encoding/wirecodec/dictionary_test.go
@@ -1,0 +1,41 @@
+package wirecodec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDictionary(t *testing.T) {
+	t.Run("assigns stable indices", func(t *testing.T) {
+		var dict dictionary
+
+		require.Equal(t, uint64(0), dict.add("dataset.array"))
+		require.Equal(t, uint64(0), dict.add("dataset.array"))
+		require.Equal(t, uint64(1), dict.add("dataset.chunked"))
+
+		require.Equal(t, []string{"dataset.array", "dataset.chunked"}, dict.keys)
+	})
+
+	t.Run("loads existing keys", func(t *testing.T) {
+		dict := newDictionary([]string{"dataset.array", "dataset.chunked"})
+
+		require.Equal(t, uint64(0), dict.add("dataset.array"))
+		require.Equal(t, uint64(1), dict.add("dataset.chunked"))
+		first, err := dict.lookup(0)
+		require.NoError(t, err)
+		second, err := dict.lookup(1)
+		require.NoError(t, err)
+
+		require.Equal(t, "dataset.array", first)
+		require.Equal(t, "dataset.chunked", second)
+	})
+
+	t.Run("rejects out-of-range indices", func(t *testing.T) {
+		dict := newDictionary([]string{"dataset.array"})
+
+		_, err := dict.lookup(99)
+
+		require.Error(t, err)
+	})
+}

--- a/pkg/dataset/encoding/wirecodec/inline.go
+++ b/pkg/dataset/encoding/wirecodec/inline.go
@@ -1,0 +1,164 @@
+package wirecodec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"slices"
+
+	"github.com/gogo/protobuf/proto"
+
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec/internal/inlinemd"
+	"github.com/grafana/loki/v3/pkg/dataset/layout"
+	"github.com/grafana/loki/v3/pkg/expr"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// MarshalInline marshals a layout and all of its data into a single byte slice.
+// MarshalInline should only be used for very small data sets, as unmarshaling
+// it requires reading the entire slice back into memory.
+func MarshalInline(ctx context.Context, root layout.Layout, source buffer.Source) ([]byte, error) {
+	var alloc memory.Allocator
+
+	r, err := layout.NewReader(&alloc, root, source)
+	if err != nil {
+		return nil, fmt.Errorf("creating reader: %w", err)
+	}
+	defer r.Close()
+
+	if _, err := r.Next(ctx, math.MaxInt); err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("reading buffers: %w", err)
+	}
+	bufs, err := r.AppendBuffers(nil, nil, &expr.Identity{}, memory.Bitmap{})
+	if err != nil {
+		return nil, fmt.Errorf("appending buffers: %w", err)
+	}
+
+	s := inlineSink{
+		// We start at maxBufferID + 1 so we don't overwrite any existing
+		// buffers.
+		nextID: maxBufferID(bufs) + 1,
+	}
+
+	md, err := marshalMetadata(ctx, root, &s)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling layout: %w", err)
+	}
+
+	inlineBufs := make([]*inlinemd.Buffer, 0, len(bufs)+len(s.bufs))
+
+	bufData, err := source.ReadBuffers(ctx, &alloc, bufs)
+	if err != nil {
+		return nil, fmt.Errorf("reading buffers: %w", err)
+	}
+	for i := range len(bufs) {
+		inlineBufs = append(inlineBufs, &inlinemd.Buffer{
+			Id:   uint64(bufs[i]),
+			Data: []byte(bufData[i]),
+		})
+	}
+	inlineBufs = append(inlineBufs, s.bufs...)
+
+	return proto.Marshal(&inlinemd.Inline{Metadata: md, Buffers: inlineBufs})
+}
+
+type inlineSink struct {
+	nextID uint64
+	bufs   []*inlinemd.Buffer
+}
+
+func (s *inlineSink) WriteBuffers(_ context.Context, data []buffer.Data) ([]buffer.ID, error) {
+	res := make([]buffer.ID, len(data))
+	for i, bd := range data {
+		id := s.nextID
+		if id == 0 {
+			id = 1
+		}
+
+		s.bufs = append(s.bufs, &inlinemd.Buffer{Id: id, Data: slices.Clone(bd)})
+		res[i] = buffer.ID(id)
+
+		s.nextID = id + 1
+	}
+	return res, nil
+}
+
+func maxBufferID(bufs []buffer.ID) uint64 {
+	var maxID uint64
+	for _, buf := range bufs {
+		if uint64(buf) > maxID {
+			maxID = uint64(buf)
+		}
+	}
+	return maxID
+}
+
+// UnmarshalInline unmarshals an inlined layout. The returned [buffer.Source]
+// refers to data within the input data slice; the caller must not modify the
+// data slice after calling this function.
+func UnmarshalInline(ctx context.Context, data []byte) (layout.Layout, buffer.Source, error) {
+	if len(data) == 0 {
+		return nil, nil, errors.New("cannot unmarshal empty inline dataset")
+	}
+
+	var inline inlinemd.Inline
+	if err := proto.Unmarshal(data, &inline); err != nil {
+		return nil, nil, err
+	}
+
+	src := inlineSource{
+		buffers: make(map[uint64]*inlinemd.Buffer, len(inline.Buffers)),
+	}
+	for _, buf := range inline.Buffers {
+		src.buffers[buf.Id] = buf
+	}
+
+	layout, err := unmarshalMetadata(ctx, inline.Metadata, &src)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading inline metadata: %w", err)
+	}
+	return layout, &src, nil
+}
+
+type inlineSource struct {
+	buffers map[uint64]*inlinemd.Buffer
+}
+
+func (s *inlineSource) ReadBuffers(_ context.Context, _ *memory.Allocator, bufs []buffer.ID) ([]buffer.Data, error) {
+	res := make([]buffer.Data, len(bufs))
+
+	var errs []error
+	for i, buf := range bufs {
+		bufData, ok := s.buffers[uint64(buf)]
+		if !ok {
+			errs = append(errs, fmt.Errorf("buffer not found: %d", buf))
+			continue
+		}
+		res[i] = bufData.Data
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+	return res, nil
+}
+
+func (s *inlineSource) BufferSizes(_ context.Context, _ *memory.Allocator, bufs []buffer.ID) ([]int64, error) {
+	sizes := make([]int64, len(bufs))
+	var errs []error
+	for i, buf := range bufs {
+		bufData, ok := s.buffers[uint64(buf)]
+		if !ok {
+			errs = append(errs, fmt.Errorf("buffer not found: %d", buf))
+			continue
+		}
+		sizes[i] = int64(len(bufData.Data))
+	}
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+	return sizes, nil
+}

--- a/pkg/dataset/encoding/wirecodec/inline_test.go
+++ b/pkg/dataset/encoding/wirecodec/inline_test.go
@@ -1,0 +1,45 @@
+package wirecodec_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestInline(t *testing.T) {
+	t.Run("round trips complete values", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+		root, expected := writeTestStruct(t, &alloc, &store)
+
+		data, err := wirecodec.MarshalInline(t.Context(), root, &store)
+		require.NoError(t, err)
+		actualLayout, source, err := wirecodec.UnmarshalInline(t.Context(), data)
+		require.NoError(t, err)
+		actual := readAll(t, &alloc, actualLayout, source)
+
+		columnartest.RequireArraysEqual(t, expected, actual, memory.Bitmap{})
+	})
+
+	t.Run("rejects invalid data", func(t *testing.T) {
+		tests := []struct {
+			name string
+			data []byte
+		}{
+			{name: "empty", data: []byte{}},
+			{name: "invalid protobuf", data: []byte("not a protobuf")},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				_, _, err := wirecodec.UnmarshalInline(t.Context(), tc.data)
+				require.Error(t, err)
+			})
+		}
+	})
+}

--- a/pkg/dataset/encoding/wirecodec/internal/arraymd/arraymd.pb.go
+++ b/pkg/dataset/encoding/wirecodec/internal/arraymd/arraymd.pb.go
@@ -155,9 +155,99 @@ func (m *Stats) GetNullCount() int64 {
 	return 0
 }
 
+// BitpackedMetadata holds encoding-specific metadata for bitpacked arrays.
+type BitpackedMetadata struct {
+	BlockSize uint64 `protobuf:"varint,1,opt,name=block_size,json=blockSize,proto3" json:"block_size,omitempty"`
+}
+
+func (m *BitpackedMetadata) Reset()      { *m = BitpackedMetadata{} }
+func (*BitpackedMetadata) ProtoMessage() {}
+func (*BitpackedMetadata) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0b0a12943a3691e3, []int{2}
+}
+func (m *BitpackedMetadata) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *BitpackedMetadata) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_BitpackedMetadata.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *BitpackedMetadata) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BitpackedMetadata.Merge(m, src)
+}
+func (m *BitpackedMetadata) XXX_Size() int {
+	return m.Size()
+}
+func (m *BitpackedMetadata) XXX_DiscardUnknown() {
+	xxx_messageInfo_BitpackedMetadata.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_BitpackedMetadata proto.InternalMessageInfo
+
+func (m *BitpackedMetadata) GetBlockSize() uint64 {
+	if m != nil {
+		return m.BlockSize
+	}
+	return 0
+}
+
+// ZstdMetadata holds encoding-specific metadata for zstd-compressed arrays.
+type ZstdMetadata struct {
+	UncompressedSize uint64 `protobuf:"varint,1,opt,name=uncompressed_size,json=uncompressedSize,proto3" json:"uncompressed_size,omitempty"`
+}
+
+func (m *ZstdMetadata) Reset()      { *m = ZstdMetadata{} }
+func (*ZstdMetadata) ProtoMessage() {}
+func (*ZstdMetadata) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0b0a12943a3691e3, []int{3}
+}
+func (m *ZstdMetadata) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ZstdMetadata) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_ZstdMetadata.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *ZstdMetadata) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ZstdMetadata.Merge(m, src)
+}
+func (m *ZstdMetadata) XXX_Size() int {
+	return m.Size()
+}
+func (m *ZstdMetadata) XXX_DiscardUnknown() {
+	xxx_messageInfo_ZstdMetadata.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ZstdMetadata proto.InternalMessageInfo
+
+func (m *ZstdMetadata) GetUncompressedSize() uint64 {
+	if m != nil {
+		return m.UncompressedSize
+	}
+	return 0
+}
+
 func init() {
 	proto.RegisterType((*Array)(nil), "grafana.dataset.array.v1.Array")
 	proto.RegisterType((*Stats)(nil), "grafana.dataset.array.v1.Stats")
+	proto.RegisterType((*BitpackedMetadata)(nil), "grafana.dataset.array.v1.BitpackedMetadata")
+	proto.RegisterType((*ZstdMetadata)(nil), "grafana.dataset.array.v1.ZstdMetadata")
 }
 
 func init() {
@@ -165,29 +255,33 @@ func init() {
 }
 
 var fileDescriptor_0b0a12943a3691e3 = []byte{
-	// 344 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x91, 0xb1, 0x4e, 0xeb, 0x30,
-	0x18, 0x85, 0xe3, 0x9b, 0xe6, 0xea, 0xd6, 0xed, 0x70, 0x6f, 0xa6, 0x2c, 0xd7, 0x84, 0x0e, 0x28,
-	0x12, 0x52, 0x2c, 0xa8, 0x98, 0x10, 0x03, 0x30, 0x81, 0xc4, 0x62, 0x36, 0x96, 0xca, 0x8d, 0x9d,
-	0xd4, 0x6a, 0x6a, 0x57, 0x8e, 0x53, 0xc4, 0xd6, 0x47, 0xe0, 0x31, 0x78, 0x14, 0xc6, 0x8e, 0x1d,
-	0xa9, 0xbb, 0x20, 0xa6, 0x3e, 0x02, 0x4a, 0xda, 0x74, 0x03, 0x89, 0xc9, 0xfa, 0xbf, 0xff, 0xfc,
-	0x47, 0xc7, 0x3a, 0xf0, 0x62, 0x3a, 0xce, 0x30, 0xa3, 0x86, 0x16, 0xdc, 0x60, 0x2e, 0x13, 0xc5,
-	0x84, 0xcc, 0xf0, 0xa3, 0xd0, 0x3c, 0x51, 0x8c, 0x27, 0x58, 0x48, 0xc3, 0xb5, 0xa4, 0x39, 0xa6,
-	0x5a, 0xd3, 0xa7, 0x09, 0x6b, 0xde, 0x78, 0xaa, 0x95, 0x51, 0x7e, 0x90, 0x69, 0x9a, 0x52, 0x49,
-	0xe3, 0x9d, 0x45, 0x5c, 0xaf, 0xe3, 0xd9, 0x49, 0xef, 0x03, 0x40, 0xef, 0xb2, 0x1a, 0xfc, 0x43,
-	0xd8, 0x6d, 0x8c, 0x07, 0x9a, 0xa7, 0x01, 0x08, 0x41, 0xd4, 0x22, 0x9d, 0x86, 0x11, 0x9e, 0xfa,
-	0xc7, 0xf0, 0xdf, 0x5e, 0x32, 0xe1, 0x86, 0x56, 0x6e, 0xc1, 0xaf, 0x10, 0x44, 0x5d, 0xf2, 0xb7,
-	0x59, 0xdc, 0xed, 0xb8, 0xff, 0x1f, 0xc2, 0x61, 0x99, 0xa6, 0x5c, 0x0f, 0x04, 0x2b, 0x02, 0x37,
-	0x74, 0xa3, 0x16, 0x69, 0x6f, 0xc9, 0x0d, 0x2b, 0xfc, 0x73, 0xf8, 0x27, 0x19, 0x89, 0x9c, 0x69,
-	0x2e, 0x83, 0x56, 0xe8, 0x46, 0x9d, 0xd3, 0x83, 0xf8, 0xab, 0x94, 0x71, 0x9d, 0x90, 0xec, 0x0f,
-	0xfc, 0x33, 0xe8, 0x15, 0x86, 0x9a, 0x22, 0xf0, 0x42, 0xf0, 0xfd, 0xe5, 0x7d, 0x25, 0x23, 0x5b,
-	0x75, 0xef, 0x08, 0x7a, 0xf5, 0x5c, 0x65, 0x93, 0x65, 0x9e, 0x0f, 0x12, 0x55, 0x4a, 0x53, 0xff,
-	0xd4, 0x25, 0xed, 0x8a, 0x5c, 0x57, 0xe0, 0x6a, 0x0e, 0x16, 0x2b, 0xe4, 0x2c, 0x57, 0xc8, 0xd9,
-	0xac, 0x10, 0x98, 0x5b, 0x04, 0x5e, 0x2c, 0x02, 0xaf, 0x16, 0x81, 0x85, 0x45, 0xe0, 0xcd, 0x22,
-	0xf0, 0x6e, 0x91, 0xb3, 0xb1, 0x08, 0x3c, 0xaf, 0x91, 0xb3, 0x58, 0x23, 0x67, 0xb9, 0x46, 0xce,
-	0xc3, 0x6d, 0x26, 0xcc, 0xa8, 0x1c, 0xc6, 0x89, 0x9a, 0xe0, 0x5d, 0x20, 0x9c, 0xab, 0xb1, 0xc0,
-	0xb3, 0x3e, 0xfe, 0x61, 0x7f, 0xc3, 0xdf, 0x75, 0x71, 0xfd, 0xcf, 0x00, 0x00, 0x00, 0xff, 0xff,
-	0xb8, 0xb0, 0xa5, 0xd9, 0xf9, 0x01, 0x00, 0x00,
+	// 401 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x92, 0x31, 0x6f, 0xd4, 0x30,
+	0x14, 0xc7, 0x63, 0x72, 0x41, 0x9c, 0x7b, 0x43, 0x2f, 0x53, 0x16, 0x4c, 0xc8, 0x80, 0x22, 0x55,
+	0x8a, 0x45, 0x2b, 0xa6, 0x8a, 0x81, 0x32, 0x81, 0xc4, 0x92, 0x6e, 0x5d, 0x22, 0x9f, 0xed, 0xa4,
+	0x56, 0x12, 0x3b, 0xb2, 0x9d, 0x22, 0x3a, 0xf5, 0x23, 0xf0, 0x31, 0xf8, 0x28, 0x8c, 0x37, 0x76,
+	0xe4, 0x72, 0x0b, 0x62, 0xea, 0x47, 0x40, 0xc9, 0x25, 0xc7, 0x31, 0x80, 0xd4, 0xc9, 0xf2, 0xef,
+	0xfd, 0xff, 0x4f, 0xff, 0xf7, 0xf4, 0xe0, 0xdb, 0xa6, 0x2c, 0x30, 0x23, 0x96, 0x18, 0x6e, 0x31,
+	0x97, 0x54, 0x31, 0x21, 0x0b, 0xfc, 0x59, 0x68, 0x4e, 0x15, 0xe3, 0x14, 0x0b, 0x69, 0xb9, 0x96,
+	0xa4, 0xc2, 0x44, 0x6b, 0xf2, 0xa5, 0x66, 0xd3, 0x9b, 0x34, 0x5a, 0x59, 0xe5, 0x07, 0x85, 0x26,
+	0x39, 0x91, 0x24, 0x19, 0x5b, 0x24, 0x43, 0x39, 0xb9, 0x79, 0x1d, 0xfd, 0x02, 0xd0, 0x7b, 0xd7,
+	0x7f, 0xfc, 0x97, 0x70, 0x31, 0x35, 0xce, 0x34, 0xcf, 0x03, 0x10, 0x82, 0x78, 0x96, 0x1e, 0x4d,
+	0x2c, 0xe5, 0xb9, 0x7f, 0x02, 0x97, 0x7b, 0x49, 0xcd, 0x2d, 0xe9, 0xbb, 0x05, 0x4f, 0x42, 0x10,
+	0x2f, 0xd2, 0xe3, 0xa9, 0xf0, 0x69, 0xe4, 0xfe, 0x73, 0x08, 0x57, 0x6d, 0x9e, 0x73, 0x9d, 0x09,
+	0x66, 0x02, 0x37, 0x74, 0xe3, 0x59, 0x3a, 0xdf, 0x91, 0x0f, 0xcc, 0xf8, 0xe7, 0xf0, 0x19, 0xbd,
+	0x16, 0x15, 0xd3, 0x5c, 0x06, 0xb3, 0xd0, 0x8d, 0x8f, 0x4e, 0x5f, 0x24, 0xff, 0x4a, 0x99, 0x0c,
+	0x09, 0xd3, 0xbd, 0xc1, 0x7f, 0x03, 0x3d, 0x63, 0x89, 0x35, 0x81, 0x17, 0x82, 0xff, 0x3b, 0x2f,
+	0x7b, 0x59, 0xba, 0x53, 0x47, 0xaf, 0xa0, 0x37, 0xfc, 0xfb, 0x6c, 0xb2, 0xad, 0xaa, 0x8c, 0xaa,
+	0x56, 0xda, 0x61, 0x52, 0x37, 0x9d, 0xf7, 0xe4, 0x7d, 0x0f, 0xa2, 0x53, 0xb8, 0xbc, 0x10, 0xb6,
+	0x21, 0xb4, 0xe4, 0xec, 0xaf, 0x79, 0x2a, 0x45, 0xcb, 0xcc, 0x88, 0x5b, 0x3e, 0x6e, 0x67, 0x3e,
+	0x90, 0x4b, 0x71, 0xcb, 0xa3, 0x73, 0xb8, 0xb8, 0x32, 0xf6, 0x8f, 0xfc, 0x04, 0x2e, 0x5b, 0x49,
+	0x55, 0xdd, 0x68, 0x6e, 0x0c, 0x67, 0x87, 0xae, 0xe3, 0xc3, 0x42, 0x6f, 0xbe, 0xb8, 0x03, 0xeb,
+	0x0d, 0x72, 0xee, 0x37, 0xc8, 0x79, 0xd8, 0x20, 0x70, 0xd7, 0x21, 0xf0, 0xad, 0x43, 0xe0, 0x7b,
+	0x87, 0xc0, 0xba, 0x43, 0xe0, 0x47, 0x87, 0xc0, 0xcf, 0x0e, 0x39, 0x0f, 0x1d, 0x02, 0x5f, 0xb7,
+	0xc8, 0x59, 0x6f, 0x91, 0x73, 0xbf, 0x45, 0xce, 0xd5, 0xc7, 0x42, 0xd8, 0xeb, 0x76, 0x95, 0x50,
+	0x55, 0xe3, 0x71, 0x03, 0xb8, 0x52, 0xa5, 0xc0, 0x37, 0x67, 0xf8, 0x91, 0x07, 0xb3, 0x7a, 0x3a,
+	0x5c, 0xca, 0xd9, 0xef, 0x00, 0x00, 0x00, 0xff, 0xff, 0xda, 0x91, 0x9f, 0x8b, 0x6a, 0x02, 0x00,
+	0x00,
 }
 
 func (this *Array) Equal(that interface{}) bool {
@@ -260,6 +354,54 @@ func (this *Stats) Equal(that interface{}) bool {
 	}
 	return true
 }
+func (this *BitpackedMetadata) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*BitpackedMetadata)
+	if !ok {
+		that2, ok := that.(BitpackedMetadata)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.BlockSize != that1.BlockSize {
+		return false
+	}
+	return true
+}
+func (this *ZstdMetadata) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ZstdMetadata)
+	if !ok {
+		that2, ok := that.(ZstdMetadata)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.UncompressedSize != that1.UncompressedSize {
+		return false
+	}
+	return true
+}
 func (this *Array) GoString() string {
 	if this == nil {
 		return "nil"
@@ -285,6 +427,26 @@ func (this *Stats) GoString() string {
 	s := make([]string, 0, 5)
 	s = append(s, "&arraymd.Stats{")
 	s = append(s, "NullCount: "+fmt.Sprintf("%#v", this.NullCount)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *BitpackedMetadata) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&arraymd.BitpackedMetadata{")
+	s = append(s, "BlockSize: "+fmt.Sprintf("%#v", this.BlockSize)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *ZstdMetadata) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&arraymd.ZstdMetadata{")
+	s = append(s, "UncompressedSize: "+fmt.Sprintf("%#v", this.UncompressedSize)+",\n")
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
@@ -403,6 +565,62 @@ func (m *Stats) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *BitpackedMetadata) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BitpackedMetadata) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *BitpackedMetadata) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.BlockSize != 0 {
+		i = encodeVarintArraymd(dAtA, i, uint64(m.BlockSize))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ZstdMetadata) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ZstdMetadata) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ZstdMetadata) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.UncompressedSize != 0 {
+		i = encodeVarintArraymd(dAtA, i, uint64(m.UncompressedSize))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintArraymd(dAtA []byte, offset int, v uint64) int {
 	offset -= sovArraymd(v)
 	base := offset
@@ -459,6 +677,30 @@ func (m *Stats) Size() (n int) {
 	return n
 }
 
+func (m *BitpackedMetadata) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.BlockSize != 0 {
+		n += 1 + sovArraymd(uint64(m.BlockSize))
+	}
+	return n
+}
+
+func (m *ZstdMetadata) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.UncompressedSize != 0 {
+		n += 1 + sovArraymd(uint64(m.UncompressedSize))
+	}
+	return n
+}
+
 func sovArraymd(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
@@ -490,6 +732,26 @@ func (this *Stats) String() string {
 	}
 	s := strings.Join([]string{`&Stats{`,
 		`NullCount:` + fmt.Sprintf("%v", this.NullCount) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *BitpackedMetadata) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&BitpackedMetadata{`,
+		`BlockSize:` + fmt.Sprintf("%v", this.BlockSize) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ZstdMetadata) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ZstdMetadata{`,
+		`UncompressedSize:` + fmt.Sprintf("%v", this.UncompressedSize) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -798,6 +1060,150 @@ func (m *Stats) Unmarshal(dAtA []byte) error {
 				b := dAtA[iNdEx]
 				iNdEx++
 				m.NullCount |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipArraymd(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthArraymd
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthArraymd
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *BitpackedMetadata) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowArraymd
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: BitpackedMetadata: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: BitpackedMetadata: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BlockSize", wireType)
+			}
+			m.BlockSize = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowArraymd
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BlockSize |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipArraymd(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthArraymd
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthArraymd
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ZstdMetadata) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowArraymd
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ZstdMetadata: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ZstdMetadata: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UncompressedSize", wireType)
+			}
+			m.UncompressedSize = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowArraymd
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.UncompressedSize |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/pkg/dataset/encoding/wirecodec/internal/arraymd/arraymd.proto
+++ b/pkg/dataset/encoding/wirecodec/internal/arraymd/arraymd.proto
@@ -31,3 +31,13 @@ message Array {
 message Stats {
   int64 null_count = 1;
 }
+
+// BitpackedMetadata holds encoding-specific metadata for bitpacked arrays.
+message BitpackedMetadata {
+  uint64 block_size = 1;
+}
+
+// ZstdMetadata holds encoding-specific metadata for zstd-compressed arrays.
+message ZstdMetadata {
+  uint64 uncompressed_size = 1;
+}

--- a/pkg/dataset/encoding/wirecodec/manifest_test.go
+++ b/pkg/dataset/encoding/wirecodec/manifest_test.go
@@ -1,0 +1,127 @@
+package wirecodec_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestManifest(t *testing.T) {
+	t.Run("round trips its binary representation", func(t *testing.T) {
+		expected := wirecodec.Manifest{
+			TypeBuffer:       1,
+			LayoutBuffer:     2,
+			FileStatsBuffer:  3,
+			DictionaryBuffer: 4,
+		}
+
+		data, err := expected.MarshalBinary()
+		require.NoError(t, err)
+		var actual wirecodec.Manifest
+		require.NoError(t, actual.UnmarshalBinary(data))
+
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("exposes layout and array metadata", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+		root, _ := writeTestStruct(t, &alloc, &store)
+		manifest, err := wirecodec.Build(t.Context(), root, &store)
+		require.NoError(t, err)
+
+		metadata, err := manifest.LayoutMetadata(t.Context(), &store, manifest.LayoutBuffer)
+		require.NoError(t, err)
+
+		require.Equal(t, "dataset.struct", metadata.Encoding)
+		require.Equal(t, uint64(4), metadata.Rows)
+		require.Empty(t, metadata.Buffers)
+		require.Len(t, metadata.Children, 3)
+
+		idField := metadata.Children[0]
+		require.Equal(t, "dataset.chunked", idField.Encoding)
+		require.Equal(t, uint64(4), idField.Rows)
+		require.Len(t, idField.Children, 2)
+
+		messageField := metadata.Children[1]
+		require.Equal(t, "dataset.chunked", messageField.Encoding)
+		require.Equal(t, uint64(4), messageField.Rows)
+		require.Len(t, messageField.Children, 2)
+
+		validity := metadata.Children[2]
+		require.Equal(t, "dataset.array", validity.Encoding)
+		require.Equal(t, uint64(4), validity.Rows)
+		require.Len(t, validity.Buffers, 1)
+
+		firstMessageChunk := messageField.Children[0]
+		require.Equal(t, "dataset.array", firstMessageChunk.Encoding)
+		require.Len(t, firstMessageChunk.Buffers, 1)
+		messageArray, err := manifest.ArrayMetadata(t.Context(), &store, firstMessageChunk.Buffers[0])
+		require.NoError(t, err)
+
+		require.Equal(t, "dataset.binary", messageArray.Encoding)
+		require.Len(t, messageArray.Buffers, 1)
+		require.Equal(t, &array.Stats{NullCount: 1}, messageArray.Stats)
+		require.Len(t, messageArray.Children, 2)
+		require.Equal(t, "dataset.plain", messageArray.Children[0].Encoding)
+		require.Equal(t, "dataset.bool", messageArray.Children[1].Encoding)
+	})
+
+	t.Run("discovers every buffer", func(t *testing.T) {
+		var alloc memory.Allocator
+		var store buffer.MemoryStore
+		root, _ := writeTestStruct(t, &alloc, &store)
+		manifest, err := wirecodec.Build(t.Context(), root, &store)
+		require.NoError(t, err)
+
+		metadataBuffers := map[buffer.ID]struct{}{
+			manifest.TypeBuffer:       {},
+			manifest.LayoutBuffer:     {},
+			manifest.DictionaryBuffer: {},
+		}
+		dataBuffers := map[buffer.ID]struct{}{}
+
+		rootMetadata, err := manifest.LayoutMetadata(t.Context(), &store, manifest.LayoutBuffer)
+		require.NoError(t, err)
+		collectManifestBuffers(t, manifest, &store, rootMetadata, metadataBuffers, dataBuffers)
+
+		for i := range store.Len() {
+			id := buffer.ID(i + 1)
+			_, isMetadata := metadataBuffers[id]
+			_, isData := dataBuffers[id]
+			require.True(t, isMetadata || isData, "buffer ID %d was not discovered", id)
+			require.False(t, isMetadata && isData, "buffer ID %d is both metadata and data", id)
+		}
+	})
+}
+
+func collectManifestBuffers(t *testing.T, manifest wirecodec.Manifest, source buffer.Source, root wirecodec.Layout, metadataBuffers, dataBuffers map[buffer.ID]struct{}) {
+	t.Helper()
+
+	for _, id := range root.Buffers {
+		metadataBuffers[id] = struct{}{}
+	}
+	if root.Encoding == "dataset.array" {
+		require.Len(t, root.Buffers, 1)
+		metadata, err := manifest.ArrayMetadata(t.Context(), source, root.Buffers[0])
+		require.NoError(t, err)
+		collectArrayBuffers(metadata, dataBuffers)
+	}
+	for _, child := range root.Children {
+		collectManifestBuffers(t, manifest, source, child, metadataBuffers, dataBuffers)
+	}
+}
+
+func collectArrayBuffers(root wirecodec.Array, buffers map[buffer.ID]struct{}) {
+	for _, id := range root.Buffers {
+		buffers[id] = struct{}{}
+	}
+	for _, child := range root.Children {
+		collectArrayBuffers(child, buffers)
+	}
+}

--- a/pkg/dataset/encoding/wirecodec/marshal.go
+++ b/pkg/dataset/encoding/wirecodec/marshal.go
@@ -1,0 +1,217 @@
+package wirecodec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gogo/protobuf/proto"
+
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec/internal/arraymd"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec/internal/datasetmd"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec/internal/layoutmd"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec/internal/typemd"
+	"github.com/grafana/loki/v3/pkg/dataset/layout"
+)
+
+type layoutEncoder struct {
+	dict *dictionary
+	sink buffer.Sink
+}
+
+func (e *layoutEncoder) encodeType(t types.Type) *typemd.Type {
+	switch t := t.(type) {
+	case *types.Null:
+		return &typemd.Type{Kind: &typemd.Type_Null{Null: &typemd.Null{}}}
+	case *types.Uint32:
+		return &typemd.Type{Kind: &typemd.Type_Uint32{Uint32: &typemd.Uint32{Nullable: t.Nullable}}}
+	case *types.Uint64:
+		return &typemd.Type{Kind: &typemd.Type_Uint64{Uint64: &typemd.Uint64{Nullable: t.Nullable}}}
+	case *types.Int32:
+		return &typemd.Type{Kind: &typemd.Type_Int32{Int32: &typemd.Int32{Nullable: t.Nullable}}}
+	case *types.Int64:
+		return &typemd.Type{Kind: &typemd.Type_Int64{Int64: &typemd.Int64{Nullable: t.Nullable}}}
+	case *types.Bool:
+		return &typemd.Type{Kind: &typemd.Type_Bool{Bool: &typemd.Bool{Nullable: t.Nullable}}}
+	case *types.UTF8:
+		return &typemd.Type{Kind: &typemd.Type_Utf8{Utf8: &typemd.UTF8{Nullable: t.Nullable}}}
+	case *types.Struct:
+		fields := make([]*typemd.Struct_Field, len(t.Fields))
+		for i, f := range t.Fields {
+			fields[i] = &typemd.Struct_Field{
+				NameRef: e.dict.add(f.Name),
+				Type:    e.encodeType(f.Type),
+			}
+		}
+		return &typemd.Type{Kind: &typemd.Type_Struct{Struct: &typemd.Struct{
+			Fields:   fields,
+			Nullable: t.Nullable,
+		}}}
+	case *types.List:
+		return &typemd.Type{Kind: &typemd.Type_List{List: &typemd.List{
+			Element:  e.encodeType(t.Element),
+			Nullable: t.Nullable,
+		}}}
+	default:
+		panic(fmt.Sprintf("wirecodec: unsupported type %T", t))
+	}
+}
+
+func (e *layoutEncoder) encodeArray(a array.Array) (*arraymd.Array, error) {
+	bufIDs := make([]uint64, len(a.Buffers))
+	for i, buf := range a.Buffers {
+		bufIDs[i] = uint64(buf)
+	}
+
+	var children []*arraymd.Array
+	for i, child := range a.Children {
+		c, err := e.encodeArray(child)
+		if err != nil {
+			return nil, fmt.Errorf("encoding child array %d: %w", i, err)
+		}
+		children = append(children, c)
+	}
+
+	encMeta, err := e.encodeEncodingMetadata(a.Encoding)
+	if err != nil {
+		return nil, fmt.Errorf("encoding metadata for %s: %w", a.Encoding.Kind(), err)
+	}
+
+	return &arraymd.Array{
+		EncodingRef:      e.dict.add("dataset." + a.Encoding.Kind().String()),
+		EncodingMetadata: encMeta,
+		BufferIds:        bufIDs,
+		Children:         children,
+		Stats:            &arraymd.Stats{NullCount: int64(a.Stats.NullCount)},
+	}, nil
+}
+
+func (e *layoutEncoder) encodeEncodingMetadata(enc array.Encoding) ([]byte, error) {
+	switch enc := enc.(type) {
+	case *array.EncodingBitpacked:
+		data, err := proto.Marshal(&arraymd.BitpackedMetadata{
+			BlockSize: uint64(enc.BlockSize),
+		})
+		return data, err
+	case *array.EncodingZstd:
+		data, err := proto.Marshal(&arraymd.ZstdMetadata{
+			UncompressedSize: uint64(enc.UncompressedSize),
+		})
+		return data, err
+	default:
+		return nil, nil
+	}
+}
+
+func marshalMetadata(ctx context.Context, root layout.Layout, sink buffer.Sink) (*datasetmd.Metadata, error) {
+	enc := &layoutEncoder{
+		dict: &dictionary{},
+		sink: sink,
+	}
+
+	// Encode the root type (called once for the whole dataset).
+	typeProto := enc.encodeType(root.DataType())
+	typeData, err := proto.Marshal(typeProto)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling type: %w", err)
+	}
+	typeBufs, err := sink.WriteBuffers(ctx, []buffer.Data{typeData})
+	if err != nil {
+		return nil, fmt.Errorf("writing type buffer: %w", err)
+	}
+
+	// Encode the layout tree.
+	layoutProto, err := enc.encodeLayout(ctx, root)
+	if err != nil {
+		return nil, fmt.Errorf("encoding layout: %w", err)
+	}
+	layoutData, err := proto.Marshal(layoutProto)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling layout: %w", err)
+	}
+	layoutBufs, err := sink.WriteBuffers(ctx, []buffer.Data{layoutData})
+	if err != nil {
+		return nil, fmt.Errorf("writing layout buffer: %w", err)
+	}
+
+	// Encode the dictionary (must happen last since earlier steps add entries).
+	dictData, err := proto.Marshal(&datasetmd.Dictionary{Keys: enc.dict.keys})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling dictionary: %w", err)
+	}
+	dictBufs, err := sink.WriteBuffers(ctx, []buffer.Data{dictData})
+	if err != nil {
+		return nil, fmt.Errorf("writing dictionary buffer: %w", err)
+	}
+
+	return &datasetmd.Metadata{
+		TypeBufferId:       uint64(typeBufs[0]),
+		LayoutBufferId:     uint64(layoutBufs[0]),
+		DictionaryBufferId: uint64(dictBufs[0]),
+	}, nil
+}
+
+func (e *layoutEncoder) encodeLayout(ctx context.Context, l layout.Layout) (*layoutmd.Layout, error) {
+	switch l := l.(type) {
+	case *layout.Array:
+		arrayProto, err := e.encodeArray(l.Metadata)
+		if err != nil {
+			return nil, fmt.Errorf("encoding array: %w", err)
+		}
+		arrayData, err := proto.Marshal(arrayProto)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling array: %w", err)
+		}
+		bufs, err := e.sink.WriteBuffers(ctx, []buffer.Data{arrayData})
+		if err != nil {
+			return nil, fmt.Errorf("writing array buffer: %w", err)
+		}
+		return &layoutmd.Layout{
+			EncodingRef: e.dict.add("dataset.array"),
+			RowCount:    uint64(l.Len()),
+			BufferIds:   []uint64{uint64(bufs[0])},
+		}, nil
+
+	case *layout.Chunked:
+		children := make([]*layoutmd.Layout, len(l.Chunks))
+		for i, chunk := range l.Chunks {
+			child, err := e.encodeLayout(ctx, chunk)
+			if err != nil {
+				return nil, fmt.Errorf("encoding chunk %d: %w", i, err)
+			}
+			children[i] = child
+		}
+		return &layoutmd.Layout{
+			EncodingRef: e.dict.add("dataset.chunked"),
+			RowCount:    uint64(l.Len()),
+			Children:    children,
+		}, nil
+
+	case *layout.Struct:
+		children := make([]*layoutmd.Layout, 0, len(l.Fields)+1)
+		for i, field := range l.Fields {
+			child, err := e.encodeLayout(ctx, field)
+			if err != nil {
+				return nil, fmt.Errorf("encoding field %d: %w", i, err)
+			}
+			children = append(children, child)
+		}
+		if l.Validity != nil {
+			validity, err := e.encodeLayout(ctx, l.Validity)
+			if err != nil {
+				return nil, fmt.Errorf("encoding validity: %w", err)
+			}
+			children = append(children, validity)
+		}
+		return &layoutmd.Layout{
+			EncodingRef: e.dict.add("dataset.struct"),
+			RowCount:    uint64(l.Len()),
+			Children:    children,
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("wirecodec: unsupported layout %T", l)
+	}
+}

--- a/pkg/dataset/encoding/wirecodec/schema_test.go
+++ b/pkg/dataset/encoding/wirecodec/schema_test.go
@@ -1,0 +1,116 @@
+package wirecodec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec/internal/typemd"
+)
+
+func TestTypeCodec(t *testing.T) {
+	t.Run("scalars", func(t *testing.T) {
+		tests := []struct {
+			name string
+			typ  types.Type
+			want *typemd.Type
+		}{
+			{
+				name: "null",
+				typ:  &types.Null{},
+				want: &typemd.Type{Kind: &typemd.Type_Null{Null: &typemd.Null{}}},
+			},
+			{
+				name: "uint32",
+				typ:  &types.Uint32{Nullable: true},
+				want: &typemd.Type{Kind: &typemd.Type_Uint32{Uint32: &typemd.Uint32{Nullable: true}}},
+			},
+			{
+				name: "uint64",
+				typ:  &types.Uint64{Nullable: true},
+				want: &typemd.Type{Kind: &typemd.Type_Uint64{Uint64: &typemd.Uint64{Nullable: true}}},
+			},
+			{
+				name: "int32",
+				typ:  &types.Int32{Nullable: true},
+				want: &typemd.Type{Kind: &typemd.Type_Int32{Int32: &typemd.Int32{Nullable: true}}},
+			},
+			{
+				name: "int64",
+				typ:  &types.Int64{Nullable: true},
+				want: &typemd.Type{Kind: &typemd.Type_Int64{Int64: &typemd.Int64{Nullable: true}}},
+			},
+			{
+				name: "bool",
+				typ:  &types.Bool{Nullable: true},
+				want: &typemd.Type{Kind: &typemd.Type_Bool{Bool: &typemd.Bool{Nullable: true}}},
+			},
+			{
+				name: "utf8",
+				typ:  &types.UTF8{Nullable: true},
+				want: &typemd.Type{Kind: &typemd.Type_Utf8{Utf8: &typemd.UTF8{Nullable: true}}},
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				var dict dictionary
+				enc := &layoutEncoder{dict: &dict}
+
+				encoded := enc.encodeType(tc.typ)
+				decoded, err := (&layoutDecoder{dict: &dict}).decodeType(encoded)
+				require.NoError(t, err)
+
+				require.Equal(t, tc.want, encoded)
+				require.Equal(t, tc.typ, decoded)
+			})
+		}
+	})
+
+	t.Run("struct", func(t *testing.T) {
+		var dict dictionary
+		enc := &layoutEncoder{dict: &dict}
+		typ := &types.Struct{
+			Fields: []types.StructField{
+				{Name: "name", Type: &types.UTF8{}},
+				{Name: "age", Type: &types.Int32{Nullable: true}},
+			},
+			Nullable: true,
+		}
+
+		encoded := enc.encodeType(typ)
+		decoded, err := (&layoutDecoder{dict: &dict}).decodeType(encoded)
+		require.NoError(t, err)
+
+		require.Equal(t, &typemd.Type{
+			Kind: &typemd.Type_Struct{Struct: &typemd.Struct{
+				Fields: []*typemd.Struct_Field{
+					{NameRef: 0, Type: &typemd.Type{Kind: &typemd.Type_Utf8{Utf8: &typemd.UTF8{}}}},
+					{NameRef: 1, Type: &typemd.Type{Kind: &typemd.Type_Int32{Int32: &typemd.Int32{Nullable: true}}}},
+				},
+				Nullable: true,
+			}},
+		}, encoded)
+		require.Equal(t, []string{"name", "age"}, dict.keys)
+		require.Equal(t, typ, decoded)
+	})
+
+	t.Run("list", func(t *testing.T) {
+		var dict dictionary
+		enc := &layoutEncoder{dict: &dict}
+		typ := &types.List{Element: &types.UTF8{}, Nullable: true}
+
+		encoded := enc.encodeType(typ)
+		decoded, err := (&layoutDecoder{dict: &dict}).decodeType(encoded)
+		require.NoError(t, err)
+
+		require.Equal(t, &typemd.Type{
+			Kind: &typemd.Type_List{List: &typemd.List{
+				Element:  &typemd.Type{Kind: &typemd.Type_Utf8{Utf8: &typemd.UTF8{}}},
+				Nullable: true,
+			}},
+		}, encoded)
+		require.Equal(t, typ, decoded)
+	})
+}

--- a/pkg/dataset/encoding/wirecodec/unmarshal.go
+++ b/pkg/dataset/encoding/wirecodec/unmarshal.go
@@ -1,0 +1,349 @@
+package wirecodec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gogo/protobuf/proto"
+
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec/internal/arraymd"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec/internal/datasetmd"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec/internal/layoutmd"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec/internal/typemd"
+	"github.com/grafana/loki/v3/pkg/dataset/layout"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+type layoutDecoder struct {
+	dict   *dictionary
+	source buffer.Source
+	alloc  *memory.Allocator
+}
+
+func (d *layoutDecoder) decodeType(pb *typemd.Type) (types.Type, error) {
+	switch k := pb.GetKind().(type) {
+	case *typemd.Type_Null:
+		return &types.Null{}, nil
+	case *typemd.Type_Uint32:
+		return &types.Uint32{Nullable: k.Uint32.Nullable}, nil
+	case *typemd.Type_Uint64:
+		return &types.Uint64{Nullable: k.Uint64.Nullable}, nil
+	case *typemd.Type_Int32:
+		return &types.Int32{Nullable: k.Int32.Nullable}, nil
+	case *typemd.Type_Int64:
+		return &types.Int64{Nullable: k.Int64.Nullable}, nil
+	case *typemd.Type_Bool:
+		return &types.Bool{Nullable: k.Bool.Nullable}, nil
+	case *typemd.Type_Utf8:
+		return &types.UTF8{Nullable: k.Utf8.Nullable}, nil
+	case *typemd.Type_Struct:
+		fields := make([]types.StructField, len(k.Struct.Fields))
+		for i, f := range k.Struct.Fields {
+			ft, err := d.decodeType(f.Type)
+			if err != nil {
+				return nil, fmt.Errorf("decoding struct field %d: %w", i, err)
+			}
+			name, err := d.dict.lookup(f.NameRef)
+			if err != nil {
+				return nil, fmt.Errorf("decoding struct field %d name: %w", i, err)
+			}
+			fields[i] = types.StructField{
+				Name: name,
+				Type: ft,
+			}
+		}
+		return &types.Struct{Fields: fields, Nullable: k.Struct.Nullable}, nil
+	case *typemd.Type_List:
+		elem, err := d.decodeType(k.List.Element)
+		if err != nil {
+			return nil, fmt.Errorf("decoding list element: %w", err)
+		}
+		return &types.List{Element: elem, Nullable: k.List.Nullable}, nil
+	default:
+		return nil, fmt.Errorf("wirecodec: unsupported type kind %T", k)
+	}
+}
+
+func unmarshalMetadata(ctx context.Context, md *datasetmd.Metadata, source buffer.Source) (layout.Layout, error) {
+	var alloc memory.Allocator
+
+	// Read the dictionary.
+	dictBufs, err := source.ReadBuffers(ctx, &alloc, []buffer.ID{
+		buffer.ID(md.DictionaryBufferId),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reading dictionary buffer: %w", err)
+	}
+	var dictProto datasetmd.Dictionary
+	if err := proto.Unmarshal(dictBufs[0], &dictProto); err != nil {
+		return nil, fmt.Errorf("unmarshaling dictionary: %w", err)
+	}
+	dict := newDictionary(dictProto.Keys)
+
+	dec := &layoutDecoder{
+		dict:   dict,
+		source: source,
+		alloc:  &alloc,
+	}
+
+	// Read and decode the type.
+	typeBufs, err := source.ReadBuffers(ctx, &alloc, []buffer.ID{
+		buffer.ID(md.TypeBufferId),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reading type buffer: %w", err)
+	}
+	var typeProto typemd.Type
+	if err := proto.Unmarshal(typeBufs[0], &typeProto); err != nil {
+		return nil, fmt.Errorf("unmarshaling type: %w", err)
+	}
+	typ, err := dec.decodeType(&typeProto)
+	if err != nil {
+		return nil, fmt.Errorf("decoding type: %w", err)
+	}
+
+	// Read and decode the layout.
+	layoutBufs, err := source.ReadBuffers(ctx, &alloc, []buffer.ID{
+		buffer.ID(md.LayoutBufferId),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reading layout buffer: %w", err)
+	}
+	var layoutProto layoutmd.Layout
+	if err := proto.Unmarshal(layoutBufs[0], &layoutProto); err != nil {
+		return nil, fmt.Errorf("unmarshaling layout: %w", err)
+	}
+
+	return dec.decodeLayout(ctx, &layoutProto, typ)
+}
+
+func (d *layoutDecoder) decodeLayout(ctx context.Context, pb *layoutmd.Layout, typ types.Type) (layout.Layout, error) {
+	ref, err := d.dict.lookup(pb.EncodingRef)
+	if err != nil {
+		return nil, fmt.Errorf("decoding layout encoding ref: %w", err)
+	}
+
+	switch ref {
+	case "dataset.array":
+		if len(pb.BufferIds) < 1 {
+			return nil, fmt.Errorf("wirecodec: array layout has no buffer_ids")
+		}
+		arrayBufs, err := d.source.ReadBuffers(ctx, d.alloc, []buffer.ID{
+			buffer.ID(pb.BufferIds[0]),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("reading array buffer: %w", err)
+		}
+		var arrayProto arraymd.Array
+		if err := proto.Unmarshal(arrayBufs[0], &arrayProto); err != nil {
+			return nil, fmt.Errorf("unmarshaling array: %w", err)
+		}
+		arr, err := d.decodeArray(&arrayProto, int(pb.RowCount), typ)
+		if err != nil {
+			return nil, err
+		}
+		return &layout.Array{Metadata: arr}, nil
+
+	case "dataset.chunked":
+		chunks := make([]layout.Layout, len(pb.Children))
+		for i, child := range pb.Children {
+			c, err := d.decodeLayout(ctx, child, typ)
+			if err != nil {
+				return nil, fmt.Errorf("decoding chunk %d: %w", i, err)
+			}
+			chunks[i] = c
+		}
+		return &layout.Chunked{Type: typ, Chunks: chunks}, nil
+
+	case "dataset.struct":
+		st, ok := typ.(*types.Struct)
+		if !ok {
+			return nil, fmt.Errorf("wirecodec: struct layout but type is %T", typ)
+		}
+
+		fieldCount := len(st.Fields)
+		expectChildren := fieldCount
+		if st.Nullable {
+			expectChildren++
+		}
+		if len(pb.Children) != expectChildren {
+			return nil, fmt.Errorf("wirecodec: struct has %d children, expected %d", len(pb.Children), expectChildren)
+		}
+
+		fields := make([]layout.Layout, fieldCount)
+		for i := range fieldCount {
+			f, err := d.decodeLayout(ctx, pb.Children[i], st.Fields[i].Type)
+			if err != nil {
+				return nil, fmt.Errorf("decoding field %d: %w", i, err)
+			}
+			fields[i] = f
+		}
+
+		var validity layout.Layout
+		if st.Nullable {
+			v, err := d.decodeLayout(ctx, pb.Children[fieldCount], &types.Bool{})
+			if err != nil {
+				return nil, fmt.Errorf("decoding validity: %w", err)
+			}
+			validity = v
+		}
+
+		return &layout.Struct{
+			Type:     typ,
+			Fields:   fields,
+			Validity: validity,
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("wirecodec: unknown layout encoding ref %q", ref)
+	}
+}
+
+func (d *layoutDecoder) decodeArray(pb *arraymd.Array, rowCount int, typ types.Type) (array.Array, error) {
+	enc, err := d.decodeEncoding(pb)
+	if err != nil {
+		return array.Array{}, err
+	}
+
+	bufs := make([]buffer.ID, len(pb.BufferIds))
+	for i, id := range pb.BufferIds {
+		bufs[i] = buffer.ID(id)
+	}
+
+	var children []array.Array
+	if len(pb.Children) > 0 {
+		childTypes, childRowCounts := childArrayInfo(enc, typ, rowCount)
+		children = make([]array.Array, len(pb.Children))
+		for i, child := range pb.Children {
+			ct, cr := typ, 0
+			if i < len(childTypes) {
+				ct, cr = childTypes[i], childRowCounts[i]
+			}
+			c, err := d.decodeArray(child, cr, ct)
+			if err != nil {
+				return array.Array{}, fmt.Errorf("decoding child array %d: %w", i, err)
+			}
+			children[i] = c
+		}
+	}
+
+	var stats array.Stats
+	if pb.Stats != nil {
+		stats.NullCount = int(pb.Stats.NullCount)
+	}
+
+	return array.Array{
+		Encoding: enc,
+		Type:     typ,
+		Buffers:  bufs,
+		RowCount: rowCount,
+		Stats:    stats,
+		Children: children,
+	}, nil
+}
+
+// childArrayInfo returns the expected types and row counts for the children of
+// an array with the given encoding, parent type, and parent row count. Each
+// encoding defines its own child structure:
+//
+//   - bool/plain: optional validity child (Bool, same row count)
+//   - binary/zstd: offsets child (Int32, rowCount+1), optional validity child
+//   - bitpacked: widths child (Uint32, ceil(rowCount/blockSize)), optional validity child
+//   - zigzag: data child (unsigned variant of parent type, same row count)
+//   - delta: data child (same type, same row count)
+func childArrayInfo(enc array.Encoding, parentType types.Type, parentRowCount int) (childTypes []types.Type, childRowCounts []int) {
+	// Validity, offsets, and widths are structural children: they always have a
+	// value for each expected position and are therefore non-nullable. Data
+	// children preserve the parent type's nullability.
+	boolType := &types.Bool{Nullable: false}
+
+	switch enc := enc.(type) {
+	case *array.EncodingBool, *array.EncodingPlain:
+		// Optional validity child.
+		return []types.Type{boolType}, []int{parentRowCount}
+
+	case *array.EncodingBinary, *array.EncodingZstd:
+		// Offsets (Int32, N+1 rows) + optional validity.
+		return []types.Type{
+				&types.Int32{Nullable: false},
+				boolType,
+			}, []int{
+				parentRowCount + 1,
+				parentRowCount,
+			}
+
+	case *array.EncodingBitpacked:
+		// Widths (Uint32, one per block) + optional validity.
+		numBlocks := 0
+		if enc.BlockSize > 0 && parentRowCount > 0 {
+			numBlocks = (parentRowCount + enc.BlockSize - 1) / enc.BlockSize
+		}
+		return []types.Type{
+				&types.Uint32{Nullable: false},
+				boolType,
+			}, []int{
+				numBlocks,
+				parentRowCount,
+			}
+
+	case *array.EncodingZigZag:
+		// Data child is the unsigned variant of the parent type.
+		return []types.Type{unsignedVariant(parentType)}, []int{parentRowCount}
+
+	case *array.EncodingDelta:
+		// Data child has the same type.
+		return []types.Type{parentType}, []int{parentRowCount}
+
+	default:
+		return nil, nil
+	}
+}
+
+// unsignedVariant returns the unsigned counterpart of a signed integer type.
+func unsignedVariant(typ types.Type) types.Type {
+	switch typ := typ.(type) {
+	case *types.Int32:
+		return &types.Uint32{Nullable: typ.Nullable}
+	case *types.Int64:
+		return &types.Uint64{Nullable: typ.Nullable}
+	default:
+		return typ
+	}
+}
+
+func (d *layoutDecoder) decodeEncoding(pb *arraymd.Array) (array.Encoding, error) {
+	ref, err := d.dict.lookup(pb.EncodingRef)
+	if err != nil {
+		return nil, fmt.Errorf("decoding array encoding ref: %w", err)
+	}
+
+	switch ref {
+	case "dataset.bool":
+		return &array.EncodingBool{}, nil
+	case "dataset.plain":
+		return &array.EncodingPlain{}, nil
+	case "dataset.binary":
+		return &array.EncodingBinary{}, nil
+	case "dataset.bitpacked":
+		var md arraymd.BitpackedMetadata
+		if err := proto.Unmarshal(pb.EncodingMetadata, &md); err != nil {
+			return nil, fmt.Errorf("unmarshaling bitpacked metadata: %w", err)
+		}
+		return &array.EncodingBitpacked{BlockSize: int(md.BlockSize)}, nil
+	case "dataset.zigzag":
+		return &array.EncodingZigZag{}, nil
+	case "dataset.delta":
+		return &array.EncodingDelta{}, nil
+	case "dataset.zstd":
+		var md arraymd.ZstdMetadata
+		if err := proto.Unmarshal(pb.EncodingMetadata, &md); err != nil {
+			return nil, fmt.Errorf("unmarshaling zstd metadata: %w", err)
+		}
+		return &array.EncodingZstd{UncompressedSize: int(md.UncompressedSize)}, nil
+	default:
+		return nil, fmt.Errorf("wirecodec: unknown encoding ref %q", ref)
+	}
+}

--- a/pkg/dataset/encoding/wirecodec/wirecodec.go
+++ b/pkg/dataset/encoding/wirecodec/wirecodec.go
@@ -1,0 +1,248 @@
+// Package wirecodec defines the wire format for datasets. This package is used
+// for low-level operations to have full control over how data is stored and
+// accessed.
+//
+// For higher-level operations, use [dataset.Build] and [dataset.Open].
+package wirecodec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gogo/protobuf/proto"
+
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec/internal/arraymd"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec/internal/datasetmd"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec/internal/layoutmd"
+	"github.com/grafana/loki/v3/pkg/dataset/layout"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// Manifest holds buffer IDs for root information about a dataset. Callers can
+// inspect individual buffer IDs for ordering or prefetching decisions.
+type Manifest struct {
+	TypeBuffer       buffer.ID
+	LayoutBuffer     buffer.ID
+	FileStatsBuffer  buffer.ID // Not yet populated; will be zero (absent).
+	DictionaryBuffer buffer.ID
+}
+
+// Build traverses the root layout and serializes information about it to the
+// provided sink. It returns a Manifest with the buffer IDs that were flushed.
+func Build(ctx context.Context, root layout.Layout, sink buffer.Sink) (Manifest, error) {
+	md, err := marshalMetadata(ctx, root, sink)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("building dataset: %w", err)
+	}
+	return Manifest{
+		TypeBuffer:       buffer.ID(md.TypeBufferId),
+		LayoutBuffer:     buffer.ID(md.LayoutBufferId),
+		FileStatsBuffer:  buffer.ID(md.FileStatsId),
+		DictionaryBuffer: buffer.ID(md.DictionaryBufferId),
+	}, nil
+}
+
+// Load reconstructs the layout from the buffers referenced by the Manifest.
+func (m *Manifest) Load(ctx context.Context, source buffer.Source) (layout.Layout, error) {
+	md := &datasetmd.Metadata{
+		TypeBufferId:       uint64(m.TypeBuffer),
+		LayoutBufferId:     uint64(m.LayoutBuffer),
+		FileStatsId:        uint64(m.FileStatsBuffer),
+		DictionaryBufferId: uint64(m.DictionaryBuffer),
+	}
+	return unmarshalMetadata(ctx, md, source)
+}
+
+// MarshalBinary serializes the buffer IDs in the Manifest to a byte slice.
+func (m *Manifest) MarshalBinary() ([]byte, error) {
+	return proto.Marshal(&datasetmd.Metadata{
+		TypeBufferId:       uint64(m.TypeBuffer),
+		LayoutBufferId:     uint64(m.LayoutBuffer),
+		FileStatsId:        uint64(m.FileStatsBuffer),
+		DictionaryBufferId: uint64(m.DictionaryBuffer),
+	})
+}
+
+// UnmarshalBinary reads the manifest from the provided data and populates the
+// buffer IDs in the Manifest.
+func (m *Manifest) UnmarshalBinary(data []byte) error {
+	var md datasetmd.Metadata
+	if err := proto.Unmarshal(data, &md); err != nil {
+		return err
+	}
+	m.TypeBuffer = buffer.ID(md.TypeBufferId)
+	m.LayoutBuffer = buffer.ID(md.LayoutBufferId)
+	m.FileStatsBuffer = buffer.ID(md.FileStatsId)
+	m.DictionaryBuffer = buffer.ID(md.DictionaryBufferId)
+	return nil
+}
+
+// Layout describes the wire-format metadata for a layout node. It provides
+// structured access to the serialized layout tree without converting to
+// runtime layout types.
+type Layout struct {
+	// Encoding is the resolved encoding name (e.g., "dataset.array",
+	// "dataset.struct", "dataset.chunked").
+	Encoding string
+
+	// Metadata holds encoding-specific metadata bytes. Currently unused;
+	// reserved for future layout-level metadata.
+	Metadata []byte
+
+	// Rows is the row count for this layout node.
+	Rows uint64
+
+	// Buffers holds buffer references for this node. For array-encoded
+	// layouts, Buffers[0] is the buffer ID of the serialized array proto,
+	// loadable via [Manifest.ArrayMetadata].
+	Buffers []buffer.ID
+
+	// Children holds child layout nodes.
+	Children []Layout
+}
+
+// Array describes the wire-format metadata for an encoded array. It
+// provides structured access to the serialized array metadata without
+// converting to runtime array types.
+type Array struct {
+	// Encoding is the resolved encoding name (e.g., "dataset.plain",
+	// "dataset.bitpacked", "dataset.binary").
+	Encoding string
+
+	// Metadata holds encoding-specific metadata (e.g., bitpacked block size,
+	// zstd uncompressed size). Nil for encodings with no extra metadata.
+	Metadata []byte
+
+	// Buffers holds the data buffer references for this array.
+	Buffers []buffer.ID
+
+	// Children holds child arrays (e.g., validity bitmaps, offset arrays).
+	Children []Array
+
+	// Stats holds optional statistics. Nil when no stats are present.
+	Stats *array.Stats
+}
+
+// LayoutMetadata reads and deserializes a layout metadata tree from the given
+// buffer. Callers typically pass m.LayoutBuffer; the parameter is explicit for
+// call-pattern consistency with [Manifest.ArrayMetadata].
+func (m *Manifest) LayoutMetadata(ctx context.Context, source buffer.Source, buf buffer.ID) (Layout, error) {
+	dict, err := m.loadDictionary(ctx, source)
+	if err != nil {
+		return Layout{}, fmt.Errorf("wirecodec: loading dictionary: %w", err)
+	}
+
+	var alloc memory.Allocator
+	bufs, err := source.ReadBuffers(ctx, &alloc, []buffer.ID{buf})
+	if err != nil {
+		return Layout{}, fmt.Errorf("wirecodec: reading layout buffer: %w", err)
+	}
+
+	var pb layoutmd.Layout
+	if err := proto.Unmarshal(bufs[0], &pb); err != nil {
+		return Layout{}, fmt.Errorf("wirecodec: unmarshaling layout: %w", err)
+	}
+
+	return convertLayout(&pb, dict)
+}
+
+// ArrayMetadata reads and deserializes array metadata from the given buffer.
+// Callers pass a [Layout.Buffers] entry from a layout node whose Encoding
+// is "dataset.array".
+func (m *Manifest) ArrayMetadata(ctx context.Context, source buffer.Source, buf buffer.ID) (Array, error) {
+	dict, err := m.loadDictionary(ctx, source)
+	if err != nil {
+		return Array{}, fmt.Errorf("wirecodec: loading dictionary: %w", err)
+	}
+
+	var alloc memory.Allocator
+	bufs, err := source.ReadBuffers(ctx, &alloc, []buffer.ID{buf})
+	if err != nil {
+		return Array{}, fmt.Errorf("wirecodec: reading array buffer: %w", err)
+	}
+
+	var pb arraymd.Array
+	if err := proto.Unmarshal(bufs[0], &pb); err != nil {
+		return Array{}, fmt.Errorf("wirecodec: unmarshaling array: %w", err)
+	}
+
+	return convertArray(&pb, dict)
+}
+
+func (m *Manifest) loadDictionary(ctx context.Context, source buffer.Source) (*dictionary, error) {
+	var alloc memory.Allocator
+	bufs, err := source.ReadBuffers(ctx, &alloc, []buffer.ID{m.DictionaryBuffer})
+	if err != nil {
+		return nil, fmt.Errorf("reading dictionary buffer: %w", err)
+	}
+	var dictProto datasetmd.Dictionary
+	if err := proto.Unmarshal(bufs[0], &dictProto); err != nil {
+		return nil, fmt.Errorf("unmarshaling dictionary: %w", err)
+	}
+	return newDictionary(dictProto.Keys), nil
+}
+
+func convertLayout(pb *layoutmd.Layout, dict *dictionary) (Layout, error) {
+	encoding, err := dict.lookup(pb.EncodingRef)
+	if err != nil {
+		return Layout{}, fmt.Errorf("decoding layout encoding ref: %w", err)
+	}
+
+	children := make([]Layout, len(pb.Children))
+	for i, child := range pb.Children {
+		c, err := convertLayout(child, dict)
+		if err != nil {
+			return Layout{}, fmt.Errorf("converting child layout %d: %w", i, err)
+		}
+		children[i] = c
+	}
+
+	buffers := make([]buffer.ID, len(pb.BufferIds))
+	for i, id := range pb.BufferIds {
+		buffers[i] = buffer.ID(id)
+	}
+
+	return Layout{
+		Encoding: encoding,
+		Metadata: pb.EncodingMetadata,
+		Rows:     pb.RowCount,
+		Buffers:  buffers,
+		Children: children,
+	}, nil
+}
+
+func convertArray(pb *arraymd.Array, dict *dictionary) (Array, error) {
+	encoding, err := dict.lookup(pb.EncodingRef)
+	if err != nil {
+		return Array{}, fmt.Errorf("decoding array encoding ref: %w", err)
+	}
+
+	buffers := make([]buffer.ID, len(pb.BufferIds))
+	for i, id := range pb.BufferIds {
+		buffers[i] = buffer.ID(id)
+	}
+
+	children := make([]Array, len(pb.Children))
+	for i, child := range pb.Children {
+		c, err := convertArray(child, dict)
+		if err != nil {
+			return Array{}, fmt.Errorf("converting child array %d: %w", i, err)
+		}
+		children[i] = c
+	}
+
+	var stats *array.Stats
+	if pb.Stats != nil {
+		stats = &array.Stats{NullCount: int(pb.Stats.NullCount)}
+	}
+
+	return Array{
+		Encoding: encoding,
+		Metadata: pb.EncodingMetadata,
+		Buffers:  buffers,
+		Children: children,
+		Stats:    stats,
+	}, nil
+}

--- a/pkg/dataset/encoding/wirecodec/wirecodec_test.go
+++ b/pkg/dataset/encoding/wirecodec/wirecodec_test.go
@@ -1,0 +1,199 @@
+package wirecodec_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec"
+	"github.com/grafana/loki/v3/pkg/dataset/layout"
+	"github.com/grafana/loki/v3/pkg/expr"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func Test(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	root, expected := writeTestStruct(t, &alloc, &store)
+
+	actualLayout := roundTrip(t, root, &store)
+	actual := readAll(t, &alloc, actualLayout, &store)
+
+	require.Equal(t, root.DataType(), actualLayout.DataType())
+	require.Equal(t, root.Len(), actualLayout.Len())
+	columnartest.RequireArraysEqual(t, expected, actual, memory.Bitmap{})
+}
+
+func TestEncodings(t *testing.T) {
+	tests := []struct {
+		name  string
+		spec  array.Spec
+		typ   types.Type
+		input func(*testing.T, *memory.Allocator) columnar.Array
+	}{
+		{
+			name: "bool",
+			spec: &array.SpecBool{},
+			typ:  &types.Bool{},
+			input: func(t *testing.T, alloc *memory.Allocator) columnar.Array {
+				return columnartest.Array(t, types.KindBool, alloc, true, false, true)
+			},
+		},
+		{
+			name: "plain",
+			spec: &array.SpecPlain{},
+			typ:  &types.Int64{},
+			input: func(t *testing.T, alloc *memory.Allocator) columnar.Array {
+				return columnartest.Array(t, types.KindInt64, alloc, int64(-10), int64(0), int64(20))
+			},
+		},
+		{
+			name: "binary",
+			spec: &array.SpecBinary{Offsets: &array.SpecPlain{}},
+			typ:  &types.UTF8{},
+			input: func(t *testing.T, alloc *memory.Allocator) columnar.Array {
+				return columnartest.Array(t, types.KindUTF8, alloc, "first", "second", "third")
+			},
+		},
+		{
+			name: "bitpacked",
+			spec: &array.SpecBitpacked{BlockSize: 8, Widths: &array.SpecPlain{}},
+			typ:  &types.Uint64{},
+			input: func(t *testing.T, alloc *memory.Allocator) columnar.Array {
+				return columnartest.Array(t, types.KindUint64, alloc, uint64(1), uint64(2), uint64(7))
+			},
+		},
+		{
+			name: "zigzag int32",
+			spec: &array.SpecZigZag{Data: &array.SpecPlain{}},
+			typ:  &types.Int32{},
+			input: func(t *testing.T, alloc *memory.Allocator) columnar.Array {
+				return columnartest.Array(t, types.KindInt32, alloc, int32(-10), int32(0), int32(20))
+			},
+		},
+		{
+			name: "nullable zigzag int64",
+			spec: &array.SpecZigZag{Data: &array.SpecPlain{Validity: &array.SpecBool{}}},
+			typ:  &types.Int64{Nullable: true},
+			input: func(t *testing.T, alloc *memory.Allocator) columnar.Array {
+				return columnartest.Array(t, types.KindInt64, alloc, int64(-10), nil, int64(20))
+			},
+		},
+		{
+			name: "delta",
+			spec: &array.SpecDelta{Data: &array.SpecPlain{}},
+			typ:  &types.Int64{},
+			input: func(t *testing.T, alloc *memory.Allocator) columnar.Array {
+				return columnartest.Array(t, types.KindInt64, alloc, int64(10), int64(11), int64(15))
+			},
+		},
+		{
+			name: "zstd",
+			spec: &array.SpecZstd{Offsets: &array.SpecPlain{}},
+			typ:  &types.UTF8{},
+			input: func(t *testing.T, alloc *memory.Allocator) columnar.Array {
+				return columnartest.Array(t, types.KindUTF8, alloc, "repeated", "repeated", "different")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var alloc memory.Allocator
+			var store buffer.MemoryStore
+
+			expected := tc.input(t, &alloc)
+			root := writeLayout(t, &alloc, &store, &layout.SpecArray{Spec: tc.spec}, tc.typ, expected)
+
+			actualLayout := roundTrip(t, root, &store)
+			actual := readAll(t, &alloc, actualLayout, &store)
+
+			expectedMetadata := root.(*layout.Array).Metadata
+			actualMetadata := actualLayout.(*layout.Array).Metadata
+			require.Equal(t, expectedMetadata.Encoding, actualMetadata.Encoding)
+			require.Equal(t, expectedMetadata.Stats, actualMetadata.Stats)
+			columnartest.RequireArraysEqual(t, expected, actual, memory.Bitmap{})
+		})
+	}
+}
+
+func writeTestStruct(t *testing.T, alloc *memory.Allocator, store buffer.Store) (layout.Layout, columnar.Array) {
+	t.Helper()
+
+	typ := &types.Struct{
+		Fields: []types.StructField{
+			{Name: "id", Type: &types.Int64{}},
+			{Name: "message", Type: &types.UTF8{Nullable: true}},
+		},
+		Nullable: true,
+	}
+	spec := &layout.SpecStruct{
+		Fields: []layout.Spec{
+			&layout.SpecChunked{
+				MaxRowCount: 2,
+				Chunk:       &layout.SpecArray{Spec: &array.SpecPlain{}},
+			},
+			&layout.SpecChunked{
+				MaxRowCount: 2,
+				Chunk: &layout.SpecArray{Spec: &array.SpecBinary{
+					Offsets:  &array.SpecPlain{},
+					Validity: &array.SpecBool{},
+				}},
+			},
+		},
+		Validity: &layout.SpecArray{Spec: &array.SpecBool{}},
+	}
+	input := columnartest.StructWithValidity(t, alloc, []bool{true, false, true, true},
+		columnartest.Field("id", types.KindInt64, int64(1), int64(2), int64(3), int64(4)),
+		columnartest.Field("message", types.KindUTF8, "first", nil, "third", "fourth"),
+	)
+
+	return writeLayout(t, alloc, store, spec, typ, input), input
+}
+
+func writeLayout(t *testing.T, alloc *memory.Allocator, sink buffer.Sink, spec layout.Spec, typ types.Type, inputs ...columnar.Array) layout.Layout {
+	t.Helper()
+
+	w, err := layout.NewWriter(alloc, sink, spec, typ)
+	require.NoError(t, err)
+	for _, input := range inputs {
+		require.NoError(t, w.Append(t.Context(), input))
+	}
+
+	root, err := w.Flush(t.Context())
+	require.NoError(t, err)
+	return root
+}
+
+func roundTrip(t *testing.T, root layout.Layout, store buffer.Store) layout.Layout {
+	t.Helper()
+
+	manifest, err := wirecodec.Build(t.Context(), root, store)
+	require.NoError(t, err)
+
+	actual, err := manifest.Load(t.Context(), store)
+	require.NoError(t, err)
+	return actual
+}
+
+func readAll(t *testing.T, alloc *memory.Allocator, root layout.Layout, source buffer.Source) columnar.Array {
+	t.Helper()
+
+	r, err := layout.NewReader(alloc, root, source)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, r.Close()) })
+
+	_, err = r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+
+	actual, err := r.Project(t.Context(), alloc, &expr.Identity{}, memory.Bitmap{})
+	require.NoError(t, err)
+	return actual
+}

--- a/pkg/dataset/layout/codec_struct.go
+++ b/pkg/dataset/layout/codec_struct.go
@@ -33,6 +33,11 @@ func newStructWriter(alloc *memory.Allocator, sink buffer.Sink, spec Spec, typ t
 		return nil, fmt.Errorf("spec has %d fields, type has %d", len(structSpec.Fields), len(structType.Fields))
 	}
 
+	hasValidity := structSpec.Validity != nil
+	if structType.Nullable != hasValidity {
+		return nil, fmt.Errorf("expected %s to have validity %t, got %t", structType, structType.Nullable, hasValidity)
+	}
+
 	fields := make([]Writer, len(structSpec.Fields))
 	for i, fieldSpec := range structSpec.Fields {
 		w, err := NewWriter(alloc, sink, fieldSpec, structType.Fields[i].Type)
@@ -43,7 +48,7 @@ func newStructWriter(alloc *memory.Allocator, sink buffer.Sink, spec Spec, typ t
 	}
 
 	var validity Writer
-	if structType.Nullable && structSpec.Validity != nil {
+	if hasValidity {
 		w, err := NewWriter(alloc, sink, structSpec.Validity, &types.Bool{})
 		if err != nil {
 			return nil, fmt.Errorf("creating validity writer: %w", err)
@@ -437,12 +442,19 @@ func (r *structReader) fieldIndex(name string) int {
 }
 
 func (r *structReader) Project(ctx context.Context, alloc *memory.Allocator, projection expr.Expression, mask memory.Bitmap) (columnar.Array, error) {
-	fieldNames := make([]string, len(r.typ.Fields))
-	for i, f := range r.typ.Fields {
-		fieldNames[i] = f.Name
+	if projection == nil {
+		return nil, fmt.Errorf("nil projection expression is invalid")
 	}
 
-	simplified := simplifyProjection(projection, fieldNames)
+	fieldNames := make([]string, len(r.typ.Fields))
+	for i, field := range r.typ.Fields {
+		fieldNames[i] = field.Name
+	}
+
+	var (
+		simplified       = simplifyProjection(projection, fieldNames)
+		preserveValidity = preservesInputStruct(projection)
+	)
 
 	var validity memory.Bitmap
 	if r.validity != nil {
@@ -453,9 +465,19 @@ func (r *structReader) Project(ctx context.Context, alloc *memory.Allocator, pro
 		validity = vArr.(*columnar.Bool).Values()
 	}
 
-	result, err := r.walkProject(ctx, alloc, simplified, mask, validity)
+	projectValidity := validity
+	if preserveValidity {
+		projectValidity = memory.Bitmap{}
+	}
+	result, err := r.walkProject(ctx, alloc, simplified, mask, projectValidity)
 	if err != nil {
 		return nil, err
+	}
+	if preserveValidity && validity.Len() > 0 {
+		result, err = compute.PropagateNulls(alloc, result, validity)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	arr, ok := result.(columnar.Array)
@@ -463,6 +485,81 @@ func (r *structReader) Project(ctx context.Context, alloc *memory.Allocator, pro
 		return nil, fmt.Errorf("projection produced %T, expected Array", result)
 	}
 	return arr, nil
+}
+
+func preservesInputStruct(e expr.Expression) bool {
+	switch e := e.(type) {
+	case *expr.Identity, *expr.Column:
+		return true
+	case *expr.Include:
+		return preservesInputStruct(e.Value)
+	case *expr.Exclude:
+		return preservesInputStruct(e.Value)
+	default:
+		return false
+	}
+}
+
+func (r *structReader) walkProject(ctx context.Context, alloc *memory.Allocator, e expr.Expression, mask, validity memory.Bitmap) (columnar.Datum, error) {
+	if e == nil {
+		return nil, fmt.Errorf("nil projection expression is invalid")
+	}
+
+	switch e := e.(type) {
+	case *expr.Constant:
+		empty := columnar.NewStruct(columnar.NewSchema(nil), nil, r.length, memory.Bitmap{})
+		return expr.Evaluate(alloc, e, empty, mask)
+
+	case *expr.Identity:
+		return r.projectIdentity(ctx, alloc, mask, validity)
+
+	case *expr.Column:
+		return r.projectField(ctx, alloc, e.Name, mask, validity)
+
+	case *expr.MakeStruct:
+		if len(e.Values) == 0 {
+			empty := columnar.NewStruct(columnar.NewSchema(nil), nil, r.length, memory.Bitmap{})
+			return expr.Evaluate(alloc, e, empty, mask)
+		}
+	}
+
+	return expr.Reduce(alloc, e, func(child expr.Expression) (columnar.Datum, error) {
+		return r.walkProject(ctx, alloc, child, mask, validity)
+	}, mask)
+}
+
+func (r *structReader) projectIdentity(ctx context.Context, alloc *memory.Allocator, mask, validity memory.Bitmap) (columnar.Datum, error) {
+	var (
+		columns = make([]columnar.Column, len(r.typ.Fields))
+		fields  = make([]columnar.Array, len(r.typ.Fields))
+	)
+	for i, fieldType := range r.typ.Fields {
+		field, err := r.fields[i].Project(ctx, alloc, &expr.Identity{}, mask)
+		if err != nil {
+			return nil, fmt.Errorf("projecting field %q: %w", fieldType.Name, err)
+		}
+		columns[i] = columnar.Column{Name: fieldType.Name}
+		fields[i] = field
+	}
+	return columnar.NewStruct(columnar.NewSchema(columns), fields, r.length, validity), nil
+}
+
+func (r *structReader) projectField(ctx context.Context, alloc *memory.Allocator, name string, mask, validity memory.Bitmap) (columnar.Datum, error) {
+	idx := r.fieldIndex(name)
+	if idx < 0 {
+		missing := memory.NewBitmap(alloc, r.length)
+		missing.AppendCount(false, r.length)
+		return columnar.NewNull(missing), nil
+	}
+
+	field, err := r.fields[idx].Project(ctx, alloc, &expr.Identity{}, mask)
+	if err != nil {
+		return nil, fmt.Errorf("projecting field %q: %w", name, err)
+	}
+	if validity.Len() == 0 {
+		return field, nil
+	}
+	return compute.PropagateNulls(alloc, field, validity)
 }
 
 func (r *structReader) Reset() {
@@ -491,49 +588,4 @@ func (r *structReader) Close() error {
 		r.validity.Close()
 	}
 	return nil
-}
-
-func (r *structReader) walkProject(ctx context.Context, alloc *memory.Allocator, e expr.Expression, mask, validity memory.Bitmap) (columnar.Datum, error) {
-	if e == nil {
-		return nil, fmt.Errorf("nil projection expression is invalid")
-	}
-
-	cols := collectColumns(e)
-
-	switch len(cols) {
-	case 0: // No column references: evaluate directly (constants, etc.).
-		empty := columnar.NewStruct(columnar.NewSchema(nil), nil, r.length, memory.Bitmap{})
-		return expr.Evaluate(alloc, e, empty, mask)
-
-	case 1: // Single-field reference: scope-rewrite and push to child reader.
-		var colName string
-		for name := range cols {
-			colName = name
-		}
-		idx := r.fieldIndex(colName)
-		if idx < 0 {
-			empty := columnar.NewStruct(columnar.NewSchema(nil), nil, r.length, memory.Bitmap{})
-			return expr.Evaluate(alloc, e, empty, mask)
-		}
-		rewritten := rewriteColumnsToIdentity(e, colName)
-		projected, err := r.fields[idx].Project(ctx, alloc, rewritten, mask)
-		if err != nil {
-			return nil, err
-		}
-		if validity.Len() == 0 {
-			return projected, nil
-		}
-		return compute.PropagateNulls(alloc, projected, validity)
-
-	default:
-		// Multi-field reference: Reduce calls walkProject on each child.
-		// Each child gets categorized by its own column count — single-column
-		// sub-expressions get pushed to child readers, constants evaluate
-		// directly, and multi-column children recurse further.
-		// All children return full-window arrays; mask is forwarded as a
-		// selection hint so compute ops can skip unselected rows.
-		return expr.Reduce(alloc, e, func(child expr.Expression) (columnar.Datum, error) {
-			return r.walkProject(ctx, alloc, child, mask, validity)
-		}, mask)
-	}
 }

--- a/pkg/dataset/layout/codec_struct_test.go
+++ b/pkg/dataset/layout/codec_struct_test.go
@@ -62,6 +62,39 @@ func TestCodec_Struct_WriteRead(t *testing.T) {
 	columnartest.RequireArraysEqual(t, input, actual, memory.Bitmap{})
 }
 
+func TestCodec_Struct_RejectsValidityMismatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		nullable bool
+		validity layout.Spec
+	}{
+		{
+			name:     "nullable type without validity spec",
+			nullable: true,
+		},
+		{
+			name:     "non-nullable type with validity spec",
+			validity: &layout.SpecArray{Spec: &array.SpecBool{}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var alloc memory.Allocator
+			var store buffer.MemoryStore
+
+			_, err := layout.NewWriter(&alloc, &store, &layout.SpecStruct{
+				Fields:   []layout.Spec{&layout.SpecArray{Spec: &array.SpecPlain{}}},
+				Validity: tc.validity,
+			}, &types.Struct{
+				Fields:   []types.StructField{{Name: "x", Type: &types.Int64{}}},
+				Nullable: tc.nullable,
+			})
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestCodec_Struct_RejectsUnexpectedValidity(t *testing.T) {
 	var alloc memory.Allocator
 	var store buffer.MemoryStore
@@ -79,21 +112,28 @@ func TestCodec_Struct_RejectsUnexpectedValidity(t *testing.T) {
 	require.Error(t, w.Append(t.Context(), input))
 }
 
-func TestCodec_Struct_ProjectionPreservesValidity(t *testing.T) {
+func TestCodec_Struct_ProjectionValidity(t *testing.T) {
 	var alloc memory.Allocator
 	var store buffer.MemoryStore
 
 	w, err := layout.NewWriter(&alloc, &store, &layout.SpecStruct{
-		Fields:   []layout.Spec{&layout.SpecArray{Spec: &array.SpecPlain{}}},
+		Fields: []layout.Spec{
+			&layout.SpecArray{Spec: &array.SpecPlain{}},
+			&layout.SpecArray{Spec: &array.SpecPlain{}},
+		},
 		Validity: &layout.SpecArray{Spec: &array.SpecBool{}},
 	}, &types.Struct{
-		Fields:   []types.StructField{{Name: "x", Type: &types.Int64{}}},
+		Fields: []types.StructField{
+			{Name: "x", Type: &types.Int64{}},
+			{Name: "y", Type: &types.Int64{}},
+		},
 		Nullable: true,
 	})
 	require.NoError(t, err)
 
 	input := columnartest.StructWithValidity(t, &alloc, []bool{true, false, true},
 		columnartest.Field("x", types.KindInt64, int64(10), int64(20), int64(30)),
+		columnartest.Field("y", types.KindInt64, int64(40), int64(50), int64(60)),
 	)
 	require.NoError(t, w.Append(t.Context(), input))
 	encoded, err := w.Flush(t.Context())
@@ -105,18 +145,126 @@ func TestCodec_Struct_ProjectionPreservesValidity(t *testing.T) {
 	_, err = r.Next(t.Context(), math.MaxInt)
 	require.NoError(t, err)
 
-	actual, err := r.Project(t.Context(), &alloc, &expr.Include{
-		Names: []string{"x"},
-		Value: &expr.Identity{},
+	makeStructProjection := func() *expr.MakeStruct {
+		return &expr.MakeStruct{
+			Names: []string{"constant", "x"},
+			Values: []expr.Expression{
+				&expr.Constant{Value: &columnar.NumberScalar[int64]{Value: 5}},
+				&expr.Column{Name: "x"},
+			},
+		}
+	}
+
+	t.Run("Identity preserves struct validity", func(t *testing.T) {
+		actual, err := r.Project(t.Context(), &alloc, &expr.Identity{}, memory.Bitmap{})
+		require.NoError(t, err)
+
+		columnartest.RequireArraysEqual(t, input, actual, memory.Bitmap{})
+	})
+
+	t.Run("Include preserves struct validity", func(t *testing.T) {
+		actual, err := r.Project(t.Context(), &alloc, &expr.Include{
+			Names: []string{"x", "y"},
+			Value: &expr.Identity{},
+		}, memory.Bitmap{})
+		require.NoError(t, err)
+
+		columnartest.RequireArraysEqual(t, input, actual, memory.Bitmap{})
+	})
+
+	t.Run("Exclude preserves struct validity", func(t *testing.T) {
+		actual, err := r.Project(t.Context(), &alloc, &expr.Exclude{
+			Names: nil,
+			Value: &expr.Identity{},
+		}, memory.Bitmap{})
+		require.NoError(t, err)
+
+		columnartest.RequireArraysEqual(t, input, actual, memory.Bitmap{})
+	})
+
+	t.Run("propagates validity to a field", func(t *testing.T) {
+		actual, err := r.Project(t.Context(), &alloc, &expr.Column{Name: "x"}, memory.Bitmap{})
+		require.NoError(t, err)
+
+		columnartest.RequireArraysEqual(t,
+			columnartest.Array(t, types.KindInt64, &alloc, int64(10), nil, int64(30)),
+			actual,
+			memory.Bitmap{},
+		)
+	})
+
+	t.Run("propagates validity per MakeStruct field", func(t *testing.T) {
+		actual, err := r.Project(t.Context(), &alloc, makeStructProjection(), memory.Bitmap{})
+		require.NoError(t, err)
+
+		columnartest.RequireArraysEqual(t,
+			columnartest.Struct(t, &alloc,
+				columnartest.Field("constant", types.KindInt64, int64(5), int64(5), int64(5)),
+				columnartest.Field("x", types.KindInt64, int64(10), nil, int64(30)),
+			),
+			actual,
+			memory.Bitmap{},
+		)
+	})
+
+	t.Run("preserves MakeStruct validity through Include", func(t *testing.T) {
+		expected, err := r.Project(t.Context(), &alloc, makeStructProjection(), memory.Bitmap{})
+		require.NoError(t, err)
+		actual, err := r.Project(t.Context(), &alloc, &expr.Include{
+			Names: []string{"constant", "x"},
+			Value: makeStructProjection(),
+		}, memory.Bitmap{})
+		require.NoError(t, err)
+
+		columnartest.RequireArraysEqual(t, expected, actual, memory.Bitmap{})
+	})
+}
+
+func TestCodec_Struct_NestedProjectionValidity(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	nestedType := &types.Struct{
+		Fields:   []types.StructField{{Name: "value", Type: &types.Int64{}}},
+		Nullable: true,
+	}
+	w, err := layout.NewWriter(&alloc, &store, &layout.SpecStruct{
+		Fields: []layout.Spec{&layout.SpecStruct{
+			Fields:   []layout.Spec{&layout.SpecArray{Spec: &array.SpecPlain{}}},
+			Validity: &layout.SpecArray{Spec: &array.SpecBool{}},
+		}},
+		Validity: &layout.SpecArray{Spec: &array.SpecBool{}},
+	}, &types.Struct{
+		Fields:   []types.StructField{{Name: "nested", Type: nestedType}},
+		Nullable: true,
+	})
+	require.NoError(t, err)
+
+	nested := columnartest.StructWithValidity(t, &alloc, []bool{true, true, false, true},
+		columnartest.Field("value", types.KindInt64, int64(10), int64(20), int64(30), int64(40)),
+	)
+	input := columnartest.StructWithValidity(t, &alloc, []bool{true, false, true, true},
+		columnartest.Field("nested", types.KindStruct, nested),
+	)
+	require.NoError(t, w.Append(t.Context(), input))
+	encoded, err := w.Flush(t.Context())
+	require.NoError(t, err)
+
+	r, err := layout.NewReader(&alloc, encoded, &store)
+	require.NoError(t, err)
+	defer r.Close()
+	_, err = r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+
+	actual, err := r.Project(t.Context(), &alloc, &expr.Extract{
+		Name:  "value",
+		Value: &expr.Column{Name: "nested"},
 	}, memory.Bitmap{})
 	require.NoError(t, err)
-	columnartest.RequireArraysEqual(t, input, actual, memory.Bitmap{})
 
-	field, err := r.Project(t.Context(), &alloc, &expr.Column{Name: "x"}, memory.Bitmap{})
-	require.NoError(t, err)
 	columnartest.RequireArraysEqual(t,
-		columnartest.Array(t, types.KindInt64, &alloc, int64(10), nil, int64(30)),
-		field,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(10), nil, nil, int64(40)),
+		actual,
 		memory.Bitmap{},
 	)
 }
@@ -154,6 +302,64 @@ func TestCodec_Struct_ConstantProjection(t *testing.T) {
 	columnartest.RequireArraysEqual(t,
 		columnartest.Struct(t, &alloc,
 			columnartest.Field("x", types.KindInt64, int64(10), int64(20), int64(30)),
+			columnartest.Field("constant", types.KindInt64, int64(5), int64(5), int64(5)),
+		),
+		actual,
+		memory.Bitmap{},
+	)
+}
+
+func TestCodec_Struct_EmptyMakeStructProjection(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	r := buildStructReaderXY(t, &alloc, &store,
+		[]int64{10, 20, 30},
+		[]string{"a", "b", "c"},
+	)
+	defer r.Close()
+	_, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+
+	actual, err := r.Project(t.Context(), &alloc, &expr.MakeStruct{}, memory.Bitmap{})
+	require.NoError(t, err)
+
+	result := actual.(*columnar.Struct)
+	require.Equal(t, 3, result.Len())
+	require.Equal(t, 0, result.NumFields())
+}
+
+func TestCodec_Struct_PrunesExcludedMakeStructFields(t *testing.T) {
+	var alloc memory.Allocator
+	var store buffer.MemoryStore
+
+	r := buildStructReaderXY(t, &alloc, &store,
+		[]int64{10, 20, 30},
+		[]string{"a", "b", "c"},
+	)
+	defer r.Close()
+	_, err := r.Next(t.Context(), math.MaxInt)
+	require.NoError(t, err)
+
+	projection := &expr.Include{
+		Names: []string{"constant"},
+		Value: &expr.MakeStruct{
+			Names: []string{"constant", "unused"},
+			Values: []expr.Expression{
+				&expr.Constant{Value: &columnar.NumberScalar[int64]{Value: 5}},
+				&expr.Unary{Op: expr.UnaryOpInvalid, Value: &expr.Column{Name: "x"}},
+			},
+		},
+	}
+
+	bufs, err := r.AppendBuffers(nil, nil, projection, memory.Bitmap{})
+	require.NoError(t, err)
+	require.Empty(t, bufs)
+	actual, err := r.Project(t.Context(), &alloc, projection, memory.Bitmap{})
+	require.NoError(t, err)
+
+	columnartest.RequireArraysEqual(t,
+		columnartest.Struct(t, &alloc,
 			columnartest.Field("constant", types.KindInt64, int64(5), int64(5), int64(5)),
 		),
 		actual,

--- a/pkg/expr/evaluate.go
+++ b/pkg/expr/evaluate.go
@@ -85,7 +85,7 @@ func evaluateWithSelection(alloc *memory.Allocator, expr Expression, input colum
 			return columnar.NewNull(validity), nil
 		}
 
-		return s.Field(columnIndex), nil
+		return projectStructField(alloc, s, columnIndex)
 
 	case *Extract:
 		return evaluateExtract(alloc, expr, input, selection)
@@ -131,7 +131,23 @@ func evaluateExtract(alloc *memory.Allocator, expr *Extract, input columnar.Datu
 		return columnar.NewNull(validity), nil
 	}
 
-	return s.Field(columnIndex), nil
+	return projectStructField(alloc, s, columnIndex)
+}
+
+func projectStructField(alloc *memory.Allocator, s *columnar.Struct, index int) (columnar.Array, error) {
+	var (
+		field    = s.Field(index)
+		validity = s.Validity()
+	)
+	if validity.Len() == 0 {
+		return field, nil
+	}
+
+	projected, err := compute.PropagateNulls(alloc, field, validity)
+	if err != nil {
+		return nil, err
+	}
+	return projected.(columnar.Array), nil
 }
 
 func evaluateInclude(alloc *memory.Allocator, expr *Include, input columnar.Datum, selection memory.Bitmap) (columnar.Datum, error) {

--- a/pkg/expr/evaluate_test.go
+++ b/pkg/expr/evaluate_test.go
@@ -328,6 +328,113 @@ func TestEvaluate_MakeStruct(t *testing.T) {
 	})
 }
 
+func TestEvaluate_NullableStruct(t *testing.T) {
+	var alloc memory.Allocator
+
+	input := columnartest.StructWithValidity(t, &alloc, []bool{true, false, true},
+		columnartest.Field("foo", types.KindInt64, int64(10), int64(20), int64(30)),
+		columnartest.Field("bar", types.KindInt64, int64(40), int64(50), int64(60)),
+	)
+
+	t.Run("identity preserves struct validity", func(t *testing.T) {
+		actual, err := expr.Evaluate(&alloc, &expr.Identity{}, input, memory.Bitmap{})
+		require.NoError(t, err)
+
+		columnartest.RequireDatumsEqual(t, input, actual, memory.Bitmap{})
+	})
+
+	t.Run("column propagates struct validity", func(t *testing.T) {
+		actual, err := expr.Evaluate(&alloc, &expr.Column{Name: "foo"}, input, memory.Bitmap{})
+		require.NoError(t, err)
+
+		columnartest.RequireDatumsEqual(t,
+			columnartest.Array(t, types.KindInt64, &alloc, int64(10), nil, int64(30)),
+			actual,
+			memory.Bitmap{},
+		)
+	})
+
+	t.Run("extract propagates struct validity", func(t *testing.T) {
+		actual, err := expr.Evaluate(&alloc, &expr.Extract{
+			Name:  "foo",
+			Value: &expr.Identity{},
+		}, input, memory.Bitmap{})
+		require.NoError(t, err)
+
+		columnartest.RequireDatumsEqual(t,
+			columnartest.Array(t, types.KindInt64, &alloc, int64(10), nil, int64(30)),
+			actual,
+			memory.Bitmap{},
+		)
+	})
+
+	t.Run("include preserves struct validity", func(t *testing.T) {
+		actual, err := expr.Evaluate(&alloc, &expr.Include{
+			Names: []string{"foo"},
+			Value: &expr.Identity{},
+		}, input, memory.Bitmap{})
+		require.NoError(t, err)
+
+		columnartest.RequireDatumsEqual(t,
+			columnartest.StructWithValidity(t, &alloc, []bool{true, false, true},
+				columnartest.Field("foo", types.KindInt64, int64(10), int64(20), int64(30)),
+			),
+			actual,
+			memory.Bitmap{},
+		)
+	})
+
+	makeStruct := &expr.MakeStruct{
+		Names: []string{"constant", "foo"},
+		Values: []expr.Expression{
+			&expr.Constant{Value: &columnar.NumberScalar[int64]{Value: 5}},
+			&expr.Column{Name: "foo"},
+		},
+	}
+	expectedStruct := columnartest.Struct(t, &alloc,
+		columnartest.Field("constant", types.KindInt64, int64(5), int64(5), int64(5)),
+		columnartest.Field("foo", types.KindInt64, int64(10), nil, int64(30)),
+	)
+
+	t.Run("MakeStruct propagates validity per field", func(t *testing.T) {
+		actual, err := expr.Evaluate(&alloc, makeStruct, input, memory.Bitmap{})
+		require.NoError(t, err)
+
+		columnartest.RequireDatumsEqual(t, expectedStruct, actual, memory.Bitmap{})
+	})
+
+	t.Run("include preserves MakeStruct validity", func(t *testing.T) {
+		actual, err := expr.Evaluate(&alloc, &expr.Include{
+			Names: []string{"constant", "foo"},
+			Value: makeStruct,
+		}, input, memory.Bitmap{})
+		require.NoError(t, err)
+
+		columnartest.RequireDatumsEqual(t, expectedStruct, actual, memory.Bitmap{})
+	})
+
+	t.Run("nested extract propagates every struct validity", func(t *testing.T) {
+		nested := columnartest.StructWithValidity(t, &alloc, []bool{true, true, false},
+			columnartest.Field("value", types.KindInt64, int64(1), int64(2), int64(3)),
+		)
+		outer := columnartest.StructWithValidity(t, &alloc, []bool{true, false, true},
+			columnartest.Field("nested", types.KindStruct, nested),
+		)
+
+		actual, err := expr.Evaluate(&alloc, &expr.Extract{
+			Name:  "value",
+			Value: &expr.Column{Name: "nested"},
+		}, outer, memory.Bitmap{})
+		require.NoError(t, err)
+
+		columnartest.RequireDatumsEqual(t,
+			columnartest.Array(t, types.KindInt64, &alloc, int64(1), nil, nil),
+			actual,
+			memory.Bitmap{},
+		)
+	})
+}
+
 func TestEvaluate_Unary(t *testing.T) {
 	var alloc memory.Allocator
 

--- a/pkg/expr/reduce.go
+++ b/pkg/expr/reduce.go
@@ -14,9 +14,11 @@ import (
 // Reduce is used when the caller wants to hook into evaluating sub-expressions.
 //
 // Leaf expressions (Constant, Identity, Column) have no children to reduce
-// and are evaluated directly via [Evaluate].
+// and are delegated directly to fn.
 func Reduce(alloc *memory.Allocator, e Expression, fn func(Expression) (columnar.Datum, error), selection memory.Bitmap) (columnar.Datum, error) {
 	switch e := e.(type) {
+	case *Constant, *Identity, *Column:
+		return fn(e)
 	case *Binary:
 		return reduceBinary(alloc, e, fn, selection)
 	case *Unary:
@@ -165,7 +167,7 @@ func reduceExtract(alloc *memory.Allocator, e *Extract, fn func(Expression) (col
 		return columnar.NewNull(validity), nil
 	}
 
-	return s.Field(columnIndex), nil
+	return projectStructField(alloc, s, columnIndex)
 }
 
 func reduceInclude(_ *memory.Allocator, e *Include, fn func(Expression) (columnar.Datum, error)) (columnar.Datum, error) {

--- a/pkg/expr/reduce_test.go
+++ b/pkg/expr/reduce_test.go
@@ -6,9 +6,58 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
 	"github.com/grafana/loki/v3/pkg/expr"
 	"github.com/grafana/loki/v3/pkg/memory"
 )
+
+func TestReduce_Leaf(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression expr.Expression
+	}{
+		{name: "constant", expression: &expr.Constant{}},
+		{name: "identity", expression: &expr.Identity{}},
+		{name: "column", expression: &expr.Column{Name: "foo"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			expected := &columnar.NumberScalar[int64]{Value: 5}
+
+			actual, err := expr.Reduce(nil, tc.expression, func(got expr.Expression) (columnar.Datum, error) {
+				require.Same(t, tc.expression, got)
+				return expected, nil
+			}, memory.Bitmap{})
+			require.NoError(t, err)
+
+			require.Same(t, expected, actual)
+		})
+	}
+}
+
+func TestReduce_ExtractPropagatesStructValidity(t *testing.T) {
+	var alloc memory.Allocator
+	input := columnartest.StructWithValidity(t, &alloc, []bool{true, false, true},
+		columnartest.Field("foo", types.KindInt64, int64(10), int64(20), int64(30)),
+	)
+
+	actual, err := expr.Reduce(&alloc, &expr.Extract{
+		Name:  "foo",
+		Value: &expr.Identity{},
+	}, func(e expr.Expression) (columnar.Datum, error) {
+		require.IsType(t, &expr.Identity{}, e)
+		return input, nil
+	}, memory.Bitmap{})
+	require.NoError(t, err)
+
+	columnartest.RequireDatumsEqual(t,
+		columnartest.Array(t, types.KindInt64, &alloc, int64(10), nil, int64(30)),
+		actual,
+		memory.Bitmap{},
+	)
+}
 
 func TestReduce_DuplicateFieldNames(t *testing.T) {
 	var alloc memory.Allocator


### PR DESCRIPTION
Implement marshaling and unmarshaling datasets, built on top of #23302. It does not yet provide a mechanism to produce a usable full section. 