### PR TITLE
chore(dataset): Add end-to-end encoding

### DIFF
--- a/pkg/dataset/build.go
+++ b/pkg/dataset/build.go
@@ -1,0 +1,136 @@
+package dataset
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec"
+	"github.com/grafana/loki/v3/pkg/dataset/layout"
+	"github.com/grafana/loki/v3/pkg/expr"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// Build serializes a [Dataset] into a [File] using the canonical encoding
+// format. Build writes encoding metadata to store, and the returned File reads
+// all dataset and metadata buffers lazily from store. Callers must keep store
+// and those buffers available and unchanged for the lifetime of the File.
+func Build(ctx context.Context, ds Dataset, store buffer.Store) (*File, error) {
+	var alloc memory.Allocator
+
+	dataBuffers, err := collectDataBuffers(ctx, &alloc, ds.Layout, store)
+	if err != nil {
+		return nil, fmt.Errorf("dataset.Build: %w", err)
+	}
+
+	tracker := &trackingSink{inner: store}
+	manifest, err := wirecodec.Build(ctx, ds.Layout, tracker)
+	if err != nil {
+		return nil, fmt.Errorf("dataset.Build: building manifest: %w", err)
+	}
+
+	buffers := deduplicateBuffers(dataBuffers, tracker.written)
+	sizes, err := store.BufferSizes(ctx, &alloc, buffers)
+	if err != nil {
+		return nil, fmt.Errorf("dataset.Build: getting buffer sizes: %w", err)
+	}
+
+	postings := buildBufferPostings(buffers, sizes)
+	indexBytes, err := encoding.BuildBufferIndex(ctx, &alloc, postings)
+	if err != nil {
+		return nil, fmt.Errorf("dataset.Build: building buffer index: %w", err)
+	}
+
+	metadataBytes, err := manifest.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("dataset.Build: marshaling metadata: %w", err)
+	}
+
+	header, err := marshalFileHeader(fileHeader{metadata: metadataBytes, index: indexBytes})
+	if err != nil {
+		return nil, fmt.Errorf("dataset.Build: marshaling file header: %w", err)
+	}
+
+	file, err := newFile(header, postings, store)
+	if err != nil {
+		return nil, fmt.Errorf("dataset.Build: constructing file: %w", err)
+	}
+	return file, nil
+}
+
+func collectDataBuffers(ctx context.Context, alloc *memory.Allocator, root layout.Layout, source buffer.Source) ([]buffer.ID, error) {
+	r, err := layout.NewReader(alloc, root, source)
+	if err != nil {
+		return nil, fmt.Errorf("creating reader: %w", err)
+	}
+	defer r.Close()
+
+	if _, err := r.Next(ctx, math.MaxInt); err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("reading layout: %w", err)
+	}
+	buffers, err := r.AppendBuffers(nil, nil, &expr.Identity{}, memory.Bitmap{})
+	if err != nil {
+		return nil, fmt.Errorf("collecting buffers: %w", err)
+	}
+	return buffers, nil
+}
+
+func deduplicateBuffers(groups ...[]buffer.ID) []buffer.ID {
+	var size int
+	for _, group := range groups {
+		size += len(group)
+	}
+
+	var (
+		result = make([]buffer.ID, 0, size)
+		seen   = make(map[buffer.ID]struct{}, size)
+	)
+
+	for _, group := range groups {
+		for _, id := range group {
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			result = append(result, id)
+		}
+	}
+	return result
+}
+
+func buildBufferPostings(buffers []buffer.ID, sizes []int64) []encoding.BufferPosting {
+	var (
+		postings = make([]encoding.BufferPosting, len(buffers))
+		offset   int64
+	)
+
+	for i, id := range buffers {
+		postings[i] = encoding.BufferPosting{
+			BufferID: id,
+			Offset:   offset,
+			Length:   sizes[i],
+		}
+		offset += sizes[i]
+	}
+	return postings
+}
+
+// trackingSink records every buffer ID written to its inner sink. This includes
+// intermediate layout metadata buffers that are not exposed by the manifest.
+type trackingSink struct {
+	inner   buffer.Sink
+	written []buffer.ID
+}
+
+func (t *trackingSink) WriteBuffers(ctx context.Context, data []buffer.Data) ([]buffer.ID, error) {
+	buffers, err := t.inner.WriteBuffers(ctx, data)
+	if err != nil {
+		return buffers, err
+	}
+	t.written = append(t.written, buffers...)
+	return buffers, nil
+}

--- a/pkg/dataset/encoding/encoding.go
+++ b/pkg/dataset/encoding/encoding.go
@@ -1,7 +1,21 @@
 // Package encoding defines shared types for dataset serialization formats.
 package encoding
 
-import "github.com/grafana/loki/v3/pkg/dataset/buffer"
+import (
+	"context"
+
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+)
+
+// RangeReader reads ranges of bytes from a resource. It is similar to
+// io.ReaderAt but accepts a context and carries its own length.
+type RangeReader interface {
+	// ReadRange reads len(p) bytes starting at byte offset off.
+	ReadRange(ctx context.Context, p []byte, off int64) (n int, err error)
+
+	// Len returns the total size in bytes.
+	Len() int64
+}
 
 // BufferPosting describes a buffer's location within a contiguous byte range.
 type BufferPosting struct {

--- a/pkg/dataset/file.go
+++ b/pkg/dataset/file.go
@@ -1,0 +1,167 @@
+package dataset
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"sort"
+
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// File is a region-based virtual reader over a serialized dataset.
+type File struct {
+	regions []fileRegion
+	size    int64
+}
+
+var (
+	_ encoding.RangeReader = (*File)(nil)
+	_ io.ReaderAt          = (*File)(nil)
+)
+
+type fileRegion struct {
+	offset int64
+	length int64
+	read   func(ctx context.Context, p []byte, off int64) (int, error)
+}
+
+func newFile(header []byte, postings []encoding.BufferPosting, source buffer.Source) (*File, error) {
+	var (
+		headerLength = int64(len(header))
+		regions      = make([]fileRegion, 0, len(postings)+2)
+	)
+
+	regions = append(regions, fileRegion{
+		offset: 0,
+		length: headerLength,
+		read:   bytesRegionReader(header),
+	})
+
+	var bodyLength int64
+	for _, posting := range postings {
+		if posting.Offset != bodyLength {
+			return nil, fmt.Errorf("buffer %d has offset %d, expected %d", posting.BufferID, posting.Offset, bodyLength)
+		}
+		if posting.Length < 0 || posting.Offset > math.MaxInt64-posting.Length {
+			return nil, fmt.Errorf("buffer %d has invalid offset %d and length %d", posting.BufferID, posting.Offset, posting.Length)
+		}
+		bodyLength += posting.Length
+		if posting.Length == 0 {
+			continue
+		}
+		if headerLength > math.MaxInt64-posting.Offset {
+			return nil, fmt.Errorf("buffer %d file offset overflows int64", posting.BufferID)
+		}
+		regions = append(regions, fileRegion{
+			offset: headerLength + posting.Offset,
+			length: posting.Length,
+			read:   bufferRegionReader(source, posting.BufferID),
+		})
+	}
+
+	if headerLength > math.MaxInt64-bodyLength-fileTrailerSize {
+		return nil, fmt.Errorf("file size overflows int64")
+	}
+	trailerOffset := headerLength + bodyLength
+	regions = append(regions, fileRegion{
+		offset: trailerOffset,
+		length: fileTrailerSize,
+		read:   bytesRegionReader(fileMagic[:]),
+	})
+
+	return &File{
+		regions: regions,
+		size:    trailerOffset + fileTrailerSize,
+	}, nil
+}
+
+// ReadRange reads len(p) bytes starting at byte offset off.
+func (f *File) ReadRange(ctx context.Context, p []byte, off int64) (n int, err error) {
+	if off < 0 {
+		return 0, fmt.Errorf("dataset: invalid offset: %d", off)
+	}
+	if len(p) > 0 && off >= f.size {
+		return 0, io.EOF
+	}
+
+	for len(p) > 0 {
+		var (
+			absoluteOffset = off + int64(n)
+			regionIndex    = sort.Search(len(f.regions), func(i int) bool {
+				return f.regions[i].offset+f.regions[i].length > absoluteOffset
+			})
+		)
+
+		if regionIndex == len(f.regions) {
+			return n, io.EOF
+		}
+
+		region := f.regions[regionIndex]
+		if absoluteOffset < region.offset {
+			return n, fmt.Errorf("dataset: no file region at offset %d", absoluteOffset)
+		}
+
+		var (
+			localOffset = absoluteOffset - region.offset
+			readSize    = min(int64(len(p)), region.length-localOffset)
+		)
+
+		nn, err := region.read(ctx, p[:readSize], localOffset)
+		if nn < 0 || int64(nn) > readSize {
+			return n, fmt.Errorf("dataset: invalid read count %d for region read of %d bytes", nn, readSize)
+		}
+		n += nn
+		p = p[nn:]
+		if err != nil {
+			return n, err
+		}
+		if nn == 0 {
+			return n, io.ErrNoProgress
+		}
+	}
+	return n, nil
+}
+
+// ReadAt implements [io.ReaderAt].
+func (f *File) ReadAt(p []byte, off int64) (int, error) {
+	return f.ReadRange(context.Background(), p, off)
+}
+
+// Len returns the total size of the file in bytes.
+func (f *File) Len() int64 { return f.size }
+
+func bytesRegionReader(data []byte) func(context.Context, []byte, int64) (int, error) {
+	return func(_ context.Context, p []byte, off int64) (int, error) {
+		if off < 0 {
+			return 0, fmt.Errorf("invalid offset: %d", off)
+		}
+		if off >= int64(len(data)) {
+			return 0, io.EOF
+		}
+		n := copy(p, data[off:])
+		if n < len(p) {
+			return n, io.EOF
+		}
+		return n, nil
+	}
+}
+
+func bufferRegionReader(source buffer.Source, id buffer.ID) func(context.Context, []byte, int64) (int, error) {
+	return func(ctx context.Context, p []byte, off int64) (int, error) {
+		var alloc memory.Allocator
+		defer alloc.Free()
+
+		data, err := source.ReadBuffers(ctx, &alloc, []buffer.ID{id})
+		if err != nil {
+			return 0, err
+		}
+		if len(data) != 1 {
+			return 0, fmt.Errorf("reading buffer %d returned %d buffers", id, len(data))
+		}
+		return bytesRegionReader(data[0])(ctx, p, off)
+	}
+}

--- a/pkg/dataset/file_header.go
+++ b/pkg/dataset/file_header.go
@@ -1,0 +1,152 @@
+package dataset
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/grafana/loki/v3/pkg/dataset/encoding"
+)
+
+const (
+	fileMagicSize    = 4
+	fileVersion      = byte(0x01)
+	fileLengthSize   = 4
+	fileTrailerSize  = fileMagicSize
+	fileMinimumSize  = fileMagicSize + 1 + fileLengthSize + fileLengthSize + fileTrailerSize
+	fileHeaderPrefix = fileMagicSize + 1
+)
+
+var fileMagic = [fileMagicSize]byte{'D', 'S', 'E', 'T'}
+
+type fileHeader struct {
+	metadata []byte
+	index    []byte
+}
+
+func marshalFileHeader(header fileHeader) ([]byte, error) {
+	var (
+		buf bytes.Buffer
+
+		metadataSize = len(header.metadata)
+		indexSize    = len(header.index)
+		size         = fileHeaderPrefix + fileLengthSize
+	)
+
+	if uint64(metadataSize) > math.MaxUint32 {
+		return nil, fmt.Errorf("metadata is too large: %d bytes", metadataSize)
+	} else if uint64(indexSize) > math.MaxUint32 {
+		return nil, fmt.Errorf("buffer index is too large: %d bytes", indexSize)
+	}
+
+	if metadataSize > math.MaxInt-size-fileLengthSize {
+		return nil, fmt.Errorf("file header size overflows int")
+	}
+	size += metadataSize + fileLengthSize
+
+	if indexSize > math.MaxInt-size {
+		return nil, fmt.Errorf("file header size overflows int")
+	}
+	size += indexSize
+
+	buf.Grow(size)
+
+	_, _ = buf.Write(fileMagic[:])
+	_ = buf.WriteByte(fileVersion)
+
+	if err := binary.Write(&buf, binary.LittleEndian, uint32(metadataSize)); err != nil {
+		return nil, fmt.Errorf("writing metadata size: %w", err)
+	}
+	_, _ = buf.Write(header.metadata)
+
+	if err := binary.Write(&buf, binary.LittleEndian, uint32(indexSize)); err != nil {
+		return nil, fmt.Errorf("writing buffer index size: %w", err)
+	}
+	_, _ = buf.Write(header.index)
+
+	return buf.Bytes(), nil
+}
+
+func readFileHeader(ctx context.Context, r encoding.RangeReader) (header fileHeader, bodyOffset, bodyLength int64, err error) {
+	size := r.Len()
+	if size < fileMinimumSize {
+		return fileHeader{}, 0, 0, fmt.Errorf("file too small: %d bytes", size)
+	}
+
+	var trailer [fileTrailerSize]byte
+	if err := readFullRange(ctx, r, trailer[:], size-fileTrailerSize); err != nil {
+		return fileHeader{}, 0, 0, fmt.Errorf("reading trailing magic: %w", err)
+	}
+	if trailer != fileMagic {
+		return fileHeader{}, 0, 0, fmt.Errorf("invalid trailing magic: %x", trailer)
+	}
+
+	var prefix [fileHeaderPrefix]byte
+	if err := readFullRange(ctx, r, prefix[:], 0); err != nil {
+		return fileHeader{}, 0, 0, fmt.Errorf("reading leading magic and version: %w", err)
+	}
+	if [len(fileMagic)]byte(prefix[:len(fileMagic)]) != fileMagic {
+		return fileHeader{}, 0, 0, fmt.Errorf("invalid leading magic: %x", prefix[:len(fileMagic)])
+	}
+	if prefix[len(fileMagic)] != fileVersion {
+		return fileHeader{}, 0, 0, fmt.Errorf("unsupported version: %d", prefix[len(fileMagic)])
+	}
+
+	var (
+		bodyEnd = size - fileTrailerSize
+		off     = int64(fileHeaderPrefix)
+	)
+
+	metadata, off, err := readFileHeaderBlock(ctx, r, off, bodyEnd, fileLengthSize, "metadata")
+	if err != nil {
+		return fileHeader{}, 0, 0, err
+	}
+
+	index, off, err := readFileHeaderBlock(ctx, r, off, bodyEnd, 0, "buffer index")
+	if err != nil {
+		return fileHeader{}, 0, 0, err
+	}
+
+	return fileHeader{metadata: metadata, index: index}, off, bodyEnd - off, nil
+}
+
+func readFileHeaderBlock(ctx context.Context, r encoding.RangeReader, off, limit, reserved int64, name string) ([]byte, int64, error) {
+	if off > limit || limit-off < fileLengthSize+reserved {
+		return nil, 0, fmt.Errorf("reading %s size: file is truncated", name)
+	}
+
+	var sizeBytes [fileLengthSize]byte
+	if err := readFullRange(ctx, r, sizeBytes[:], off); err != nil {
+		return nil, 0, fmt.Errorf("reading %s size: %w", name, err)
+	}
+	off += fileLengthSize
+
+	size := int64(binary.LittleEndian.Uint32(sizeBytes[:]))
+	if size > limit-off-reserved {
+		return nil, 0, fmt.Errorf("%s size %d exceeds remaining file size %d", name, size, limit-off-reserved)
+	}
+	if size > int64(math.MaxInt) {
+		return nil, 0, fmt.Errorf("%s is too large to read: %d bytes", name, size)
+	}
+
+	data := make([]byte, int(size))
+	if err := readFullRange(ctx, r, data, off); err != nil {
+		return nil, 0, fmt.Errorf("reading %s: %w", name, err)
+	}
+	return data, off + size, nil
+}
+
+func readFullRange(ctx context.Context, r encoding.RangeReader, p []byte, off int64) error {
+	n, err := r.ReadRange(ctx, p, off)
+	if err != nil && (!errors.Is(err, io.EOF) || n != len(p)) {
+		return err
+	}
+	if n != len(p) {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}

--- a/pkg/dataset/file_test.go
+++ b/pkg/dataset/file_test.go
@@ -1,0 +1,396 @@
+package dataset_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/columnar"
+	"github.com/grafana/loki/v3/pkg/columnar/columnartest"
+	"github.com/grafana/loki/v3/pkg/columnar/types"
+	"github.com/grafana/loki/v3/pkg/dataset"
+	"github.com/grafana/loki/v3/pkg/dataset/array"
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	datasetencoding "github.com/grafana/loki/v3/pkg/dataset/encoding"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec"
+	"github.com/grafana/loki/v3/pkg/dataset/layout"
+	"github.com/grafana/loki/v3/pkg/expr"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+func TestBuildOpen(t *testing.T) {
+	t.Run("round trips a dataset", func(t *testing.T) {
+		var (
+			alloc memory.Allocator
+			store buffer.MemoryStore
+		)
+
+		rows := []columnar.Array{
+			buildRecord(t, &alloc, 1000, map[string]string{"service": "web", "env": "prod"}, "hello world"),
+			buildRecord(t, &alloc, 2000, map[string]string{"service": "api"}, "request started"),
+			buildRecord(t, &alloc, 3000, map[string]string{"env": "dev"}, "debug info"),
+		}
+		dset := writeDataset(t, &alloc, &store, rows...)
+		expected := readAllDataset(t, &alloc, &store, dset)
+
+		actual := roundTripDataset(t, &alloc, &store, dset)
+
+		columnartest.RequireArraysEqual(t, expected, actual, memory.Bitmap{})
+	})
+
+	t.Run("round trips an empty dataset", func(t *testing.T) {
+		var (
+			alloc memory.Allocator
+			store buffer.MemoryStore
+		)
+
+		dset := writeDataset(t, &alloc, &store)
+
+		actual, _ := reopenDataset(t, &store, dset)
+
+		require.Equal(t, 0, actual.Layout.Len())
+		require.Equal(t, dset.Type.Kind(), actual.Type.Kind())
+	})
+
+	t.Run("deduplicates shared buffers", func(t *testing.T) {
+		var (
+			alloc memory.Allocator
+			store buffer.MemoryStore
+		)
+
+		dset, expected := buildSharedBufferDataset(t, &alloc, &store)
+
+		actual := roundTripDataset(t, &alloc, &store, dset)
+
+		columnartest.RequireArraysEqual(t, expected, actual, memory.Bitmap{})
+	})
+}
+
+func TestFile_ReadRange(t *testing.T) {
+	var (
+		file = buildTestFile(t)
+		raw  = readFile(t, file)
+	)
+
+	t.Run("reads across regions", func(t *testing.T) {
+		bodyOffset := fileBodyOffset(t, raw)
+		trailerOffset := len(raw) - len("DSET")
+		tests := []struct {
+			name   string
+			offset int
+			length int
+		}{
+			{name: "header", offset: 0, length: 5},
+			{name: "header to body", offset: bodyOffset - 2, length: 4},
+			{name: "body to trailer", offset: trailerOffset - 2, length: 4},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				actual := make([]byte, tt.length)
+
+				n, err := file.ReadRange(t.Context(), actual, int64(tt.offset))
+
+				require.NoError(t, err)
+				require.Equal(t, tt.length, n)
+				require.Equal(t, raw[tt.offset:tt.offset+tt.length], actual)
+			})
+		}
+	})
+
+	t.Run("returns a partial read at EOF", func(t *testing.T) {
+		actual := make([]byte, 4)
+
+		n, err := file.ReadRange(t.Context(), actual, file.Len()-2)
+
+		require.ErrorIs(t, err, io.EOF)
+		require.Equal(t, 2, n)
+		require.Equal(t, raw[len(raw)-2:], actual[:n])
+	})
+
+	t.Run("returns EOF at the end", func(t *testing.T) {
+		actual := make([]byte, 4)
+
+		n, err := file.ReadRange(t.Context(), actual, file.Len())
+
+		require.ErrorIs(t, err, io.EOF)
+		require.Zero(t, n)
+	})
+
+	t.Run("rejects a negative offset", func(t *testing.T) {
+		_, err := file.ReadRange(t.Context(), make([]byte, 4), -1)
+
+		require.ErrorContains(t, err, "invalid offset")
+	})
+}
+
+func TestOpen_RejectsMalformedHeaders(t *testing.T) {
+	raw := readFile(t, buildTestFile(t))
+	tests := []struct {
+		name   string
+		mutate func([]byte) []byte
+		err    string
+	}{
+		{
+			name: "truncated file",
+			mutate: func(data []byte) []byte {
+				return data[:12]
+			},
+			err: "file too small",
+		},
+		{
+			name: "invalid leading magic",
+			mutate: func(data []byte) []byte {
+				data[0] = 'X'
+				return data
+			},
+			err: "invalid leading magic",
+		},
+		{
+			name: "invalid trailing magic",
+			mutate: func(data []byte) []byte {
+				data[len(data)-1] = 'X'
+				return data
+			},
+			err: "invalid trailing magic",
+		},
+		{
+			name: "unsupported version",
+			mutate: func(data []byte) []byte {
+				data[4] = 0xff
+				return data
+			},
+			err: "unsupported version",
+		},
+		{
+			name: "oversized metadata",
+			mutate: func(data []byte) []byte {
+				binary.LittleEndian.PutUint32(data[5:9], ^uint32(0))
+				return data
+			},
+			err: "metadata size 4294967295 exceeds remaining file size",
+		},
+		{
+			name: "oversized buffer index",
+			mutate: func(data []byte) []byte {
+				indexSizeOffset := 9 + int(binary.LittleEndian.Uint32(data[5:9]))
+				binary.LittleEndian.PutUint32(data[indexSizeOffset:indexSizeOffset+4], ^uint32(0))
+				return data
+			},
+			err: "buffer index size 4294967295 exceeds remaining file size",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			corrupted := tt.mutate(bytes.Clone(raw))
+
+			_, _, err := dataset.Open(t.Context(), newRangeReader(corrupted))
+
+			require.ErrorContains(t, err, tt.err)
+		})
+	}
+}
+
+func TestOpen_RejectsBufferOutsideBody(t *testing.T) {
+	corrupted := fileWithBufferOutsideBody(t)
+
+	_, _, err := dataset.Open(t.Context(), newRangeReader(corrupted))
+
+	require.ErrorContains(t, err, "exceeds body size")
+}
+
+func fileWithBufferOutsideBody(t *testing.T) []byte {
+	t.Helper()
+
+	raw := readFile(t, buildTestFile(t))
+	metadata, _, body := splitFile(t, raw)
+
+	var manifest wirecodec.Manifest
+	require.NoError(t, manifest.UnmarshalBinary(metadata))
+
+	bodyLength := int64(len(body) - len("DSET"))
+	postings := []datasetencoding.BufferPosting{
+		{BufferID: manifest.DictionaryBuffer, Offset: bodyLength, Length: 1},
+		{BufferID: manifest.TypeBuffer, Offset: bodyLength, Length: 1},
+		{BufferID: manifest.LayoutBuffer, Offset: bodyLength, Length: 1},
+	}
+
+	var alloc memory.Allocator
+	index, err := datasetencoding.BuildBufferIndex(t.Context(), &alloc, postings)
+	require.NoError(t, err)
+	return encodeFile(t, metadata, index, body)
+}
+
+func readAllDataset(t *testing.T, alloc *memory.Allocator, source buffer.Source, dset dataset.Dataset) columnar.Array {
+	t.Helper()
+
+	result, err := readDataset(t, alloc, source, dataset.ReaderOptions{
+		Dataset:    dset,
+		Projection: &expr.Identity{},
+	})
+	require.NoError(t, err)
+	return result
+}
+
+func roundTripDataset(t *testing.T, alloc *memory.Allocator, store buffer.Store, dset dataset.Dataset) columnar.Array {
+	t.Helper()
+
+	reopened, source := reopenDataset(t, store, dset)
+	return readAllDataset(t, alloc, source, reopened)
+}
+
+func reopenDataset(t *testing.T, store buffer.Store, dset dataset.Dataset) (dataset.Dataset, buffer.Source) {
+	t.Helper()
+
+	file, err := dataset.Build(t.Context(), dset, store)
+	require.NoError(t, err)
+
+	reopened, source, err := dataset.Open(t.Context(), newRangeReader(readFile(t, file)))
+	require.NoError(t, err)
+	return reopened, source
+}
+
+func buildSharedBufferDataset(t *testing.T, alloc *memory.Allocator, store buffer.Store) (dataset.Dataset, columnar.Array) {
+	t.Helper()
+
+	writer, err := layout.NewWriter(
+		alloc,
+		store,
+		&layout.SpecArray{Spec: &array.SpecPlain{}},
+		&types.Int64{},
+	)
+	require.NoError(t, err)
+
+	values := columnartest.Array(t, types.KindInt64, alloc, int64(1), int64(2), int64(3))
+	require.NoError(t, writer.Append(t.Context(), values))
+	shared, err := writer.Flush(t.Context())
+	require.NoError(t, err)
+
+	typ := &types.Struct{Fields: []types.StructField{
+		{Name: "left", Type: &types.Int64{}},
+		{Name: "right", Type: &types.Int64{}},
+	}}
+	dset := dataset.Dataset{
+		Type: typ,
+		Layout: &layout.Struct{
+			Type:   typ,
+			Fields: []layout.Layout{shared, shared},
+		},
+	}
+	expected := columnar.NewStruct(
+		columnar.NewSchema([]columnar.Column{{Name: "left"}, {Name: "right"}}),
+		[]columnar.Array{values, values},
+		values.Len(),
+		memory.Bitmap{},
+	)
+	return dset, expected
+}
+
+func buildTestFile(t *testing.T) *dataset.File {
+	t.Helper()
+
+	var (
+		alloc memory.Allocator
+		store buffer.MemoryStore
+	)
+
+	dset := writeDataset(t, &alloc, &store,
+		buildRecord(t, &alloc, 1000, map[string]string{"service": "web"}, "hello"),
+		buildRecord(t, &alloc, 2000, map[string]string{"service": "api"}, "world"),
+	)
+	file, err := dataset.Build(t.Context(), dset, &store)
+	require.NoError(t, err)
+	return file
+}
+
+func readFile(t *testing.T, file *dataset.File) []byte {
+	t.Helper()
+
+	data := make([]byte, file.Len())
+	n, err := file.ReadAt(data, 0)
+	require.NoError(t, err)
+	require.Equal(t, len(data), n)
+	return data
+}
+
+func fileBodyOffset(t *testing.T, data []byte) int {
+	t.Helper()
+
+	var (
+		metadataSize    = int(binary.LittleEndian.Uint32(data[5:9]))
+		indexSizeOffset = 9 + metadataSize
+		indexSize       = int(binary.LittleEndian.Uint32(data[indexSizeOffset : indexSizeOffset+4]))
+	)
+	return indexSizeOffset + 4 + indexSize
+}
+
+func splitFile(t *testing.T, data []byte) (metadata, index, body []byte) {
+	t.Helper()
+
+	var (
+		metadataSize    = int(binary.LittleEndian.Uint32(data[5:9]))
+		indexSizeOffset = 9 + metadataSize
+		indexSize       = int(binary.LittleEndian.Uint32(data[indexSizeOffset : indexSizeOffset+4]))
+	)
+
+	metadata = data[9 : 9+metadataSize]
+	index = data[indexSizeOffset+4 : indexSizeOffset+4+indexSize]
+	body = data[indexSizeOffset+4+indexSize:]
+	return metadata, index, body
+}
+
+func encodeFile(t *testing.T, metadata, index, body []byte) []byte {
+	t.Helper()
+
+	var result bytes.Buffer
+
+	_, _ = result.WriteString("DSET")
+	_ = result.WriteByte(0x01)
+
+	require.NoError(t, binary.Write(&result, binary.LittleEndian, uint32(len(metadata))))
+	_, _ = result.Write(metadata)
+
+	require.NoError(t, binary.Write(&result, binary.LittleEndian, uint32(len(index))))
+	_, _ = result.Write(index)
+
+	_, _ = result.Write(body)
+
+	return result.Bytes()
+}
+
+type rangeReader struct {
+	data []byte
+}
+
+func newRangeReader(data []byte) *rangeReader {
+	return &rangeReader{data: data}
+}
+
+func (r *rangeReader) ReadRange(_ context.Context, p []byte, off int64) (int, error) {
+	if off < 0 {
+		return 0, fmt.Errorf("invalid offset: %d", off)
+	}
+	if off >= int64(len(r.data)) {
+		if len(p) == 0 {
+			return 0, nil
+		}
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (r *rangeReader) Len() int64 {
+	return int64(len(r.data))
+}
+
+var _ datasetencoding.RangeReader = (*rangeReader)(nil)

--- a/pkg/dataset/open.go
+++ b/pkg/dataset/open.go
@@ -1,0 +1,126 @@
+package dataset
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/grafana/loki/v3/pkg/dataset/buffer"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding"
+	"github.com/grafana/loki/v3/pkg/dataset/encoding/wirecodec"
+	"github.com/grafana/loki/v3/pkg/memory"
+)
+
+// Open reads a serialized dataset from r and returns the reconstructed
+// [Dataset] along with a [buffer.Source] for reading its buffer data.
+func Open(ctx context.Context, r encoding.RangeReader) (Dataset, buffer.Source, error) {
+	header, bodyOffset, bodyLength, err := readFileHeader(ctx, r)
+	if err != nil {
+		return Dataset{}, nil, fmt.Errorf("dataset.Open: reading file header: %w", err)
+	}
+
+	var manifest wirecodec.Manifest
+	if err := manifest.UnmarshalBinary(header.metadata); err != nil {
+		return Dataset{}, nil, fmt.Errorf("dataset.Open: unmarshaling metadata: %w", err)
+	}
+
+	var alloc memory.Allocator
+	index, err := encoding.OpenBufferIndex(ctx, &alloc, header.index)
+	if err != nil {
+		return Dataset{}, nil, fmt.Errorf("dataset.Open: opening buffer index: %w", err)
+	}
+
+	source := &fileSource{
+		reader:     r,
+		index:      index,
+		bodyOffset: bodyOffset,
+		bodyLength: bodyLength,
+	}
+	root, err := manifest.Load(ctx, source)
+	if err != nil {
+		return Dataset{}, nil, fmt.Errorf("dataset.Open: loading layout: %w", err)
+	}
+
+	return Dataset{
+		Type:   root.DataType(),
+		Layout: root,
+	}, source, nil
+}
+
+// fileSource is a [buffer.Source] backed by a RangeReader and buffer index.
+type fileSource struct {
+	reader     encoding.RangeReader
+	index      *encoding.BufferIndex
+	bodyOffset int64
+	bodyLength int64
+}
+
+func (s *fileSource) ReadBuffers(ctx context.Context, _ *memory.Allocator, buffers []buffer.ID) ([]buffer.Data, error) {
+	var (
+		result = make([]buffer.Data, len(buffers))
+		errs   []error
+	)
+
+	for i, id := range buffers {
+		posting, err := s.lookup(id)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if posting.Length > int64(math.MaxInt) {
+			errs = append(errs, fmt.Errorf("buffer %d is too large to read: %d bytes", id, posting.Length))
+			continue
+		}
+
+		data := make([]byte, int(posting.Length))
+		if err := readFullRange(ctx, s.reader, data, s.bodyOffset+posting.Offset); err != nil {
+			errs = append(errs, fmt.Errorf("reading buffer %d: %w", id, err))
+			continue
+		}
+		result[i] = data
+	}
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+	return result, nil
+}
+
+func (s *fileSource) BufferSizes(_ context.Context, _ *memory.Allocator, buffers []buffer.ID) ([]int64, error) {
+	var (
+		sizes = make([]int64, len(buffers))
+		errs  []error
+	)
+
+	for i, id := range buffers {
+		posting, err := s.lookup(id)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		sizes[i] = posting.Length
+	}
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+	return sizes, nil
+}
+
+func (s *fileSource) lookup(id buffer.ID) (encoding.BufferPosting, error) {
+	posting, ok := s.index.Lookup(id)
+	if !ok {
+		return encoding.BufferPosting{}, fmt.Errorf("buffer %d not found in index", id)
+	}
+	if posting.Offset < 0 || posting.Length < 0 || posting.Offset > s.bodyLength || posting.Length > s.bodyLength-posting.Offset {
+		return encoding.BufferPosting{}, fmt.Errorf(
+			"buffer %d range [%d, %d) exceeds body size %d",
+			id,
+			posting.Offset,
+			posting.Offset+posting.Length,
+			s.bodyLength,
+		)
+	}
+	return posting, nil
+}
+
+var _ buffer.Source = (*fileSource)(nil)


### PR DESCRIPTION
Adds an API to dataset to allow encoding datasets end-to-end. A dataobj-like "canonical" representation is used for isolated use or in tests. 

Encoding within pkg/dataobj will require a slightly different approach due to dataobj's separation of metadata and data. 