### PR TITLE
chore: Fix stats row reader dropping rows after empty batches

### DIFF
--- a/pkg/dataobj/sections/stats/row_reader.go
+++ b/pkg/dataobj/sections/stats/row_reader.go
@@ -12,6 +12,15 @@ import (
 	iter "github.com/grafana/loki/v3/pkg/iter/v2"
 )
 
+// batchReader is the batch-level reader consumed by [RowReader]. [*Reader]
+// implements it; tests substitute a fake to exercise batch-boundary handling
+// (e.g. empty, non-EOF batches).
+type batchReader interface {
+	Open(ctx context.Context) error
+	Read(ctx context.Context, batchSize int) (arrow.RecordBatch, error)
+	Close() error
+}
+
 // RowReader reads [Stat] records from a stats [Section] one row at a time, in
 // section order. It is a row-level cursor over the batch-level [Reader].
 // It implements [iter.CloseIterator] over [Stat].
@@ -19,7 +28,7 @@ import (
 // A RowReader is not safe for concurrent use.
 type RowReader struct {
 	ctx     context.Context
-	reader  *Reader
+	reader  batchReader
 	batch   arrow.RecordBatch
 	index   int
 	columns ColumnIndex
@@ -80,26 +89,33 @@ func (r *RowReader) next() (Stat, error) {
 			r.batch = nil
 		}
 
-		batch, err := r.reader.Read(r.ctx, 8192)
-		if errors.Is(err, io.EOF) && batch == nil {
-			return Stat{}, io.EOF
-		}
-		if err != nil && !errors.Is(err, io.EOF) {
-			return Stat{}, fmt.Errorf("reading batch: %w", err)
-		}
-
-		if batch != nil && batch.NumRows() > 0 {
-			r.batch = batch
-			r.index = 0
-			if r.columns == nil {
-				r.columns = BuildColumnIndex(batch.Schema())
+		// Read batches until one contains rows or the reader reaches EOF. The
+		// underlying reader may return an empty (0-row) batch without io.EOF
+		// when a read window is fully filtered out; that means "keep reading",
+		// not "end of section". Treating an empty non-EOF batch as EOF would
+		// silently drop every row after the first fully-filtered batch.
+		for r.batch == nil {
+			batch, err := r.reader.Read(r.ctx, 8192)
+			if err != nil && !errors.Is(err, io.EOF) {
+				return Stat{}, fmt.Errorf("reading batch: %w", err)
 			}
-		} else if batch != nil {
-			batch.Release()
-			return Stat{}, io.EOF
-		} else {
-			// Nil batch with no error: treat as end of section.
-			return Stat{}, io.EOF
+
+			if batch != nil && batch.NumRows() > 0 {
+				r.batch = batch
+				r.index = 0
+				if r.columns == nil {
+					r.columns = BuildColumnIndex(batch.Schema())
+				}
+				break
+			}
+
+			// Empty or nil batch: release it (if any). Stop only on EOF.
+			if batch != nil {
+				batch.Release()
+			}
+			if errors.Is(err, io.EOF) {
+				return Stat{}, io.EOF
+			}
 		}
 	}
 

--- a/pkg/dataobj/sections/stats/row_reader_internal_test.go
+++ b/pkg/dataobj/sections/stats/row_reader_internal_test.go
@@ -1,0 +1,88 @@
+package stats
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/require"
+)
+
+// scriptedReader is a batchReader that returns a fixed sequence of batches, then
+// io.EOF. It lets us exercise batch-boundary handling that the real reader can't
+// currently produce (empty, non-EOF batches only arise from predicate filtering,
+// which the stats reader does not use today).
+type scriptedReader struct {
+	batches []arrow.RecordBatch
+	i       int
+}
+
+func (s *scriptedReader) Open(context.Context) error { return nil }
+func (s *scriptedReader) Close() error               { return nil }
+
+func (s *scriptedReader) Read(context.Context, int) (arrow.RecordBatch, error) {
+	if s.i >= len(s.batches) {
+		return nil, io.EOF
+	}
+	b := s.batches[s.i]
+	s.i++
+	return b, nil
+}
+
+// pathBatch builds a stats-schema record batch carrying one object_path per
+// argument (zero args => a valid empty, 0-row batch).
+func pathBatch(paths ...string) arrow.RecordBatch {
+	schema := arrow.NewSchema([]arrow.Field{{Name: "object_path.utf8", Type: arrow.BinaryTypes.String}}, nil)
+	bld := array.NewStringBuilder(memory.DefaultAllocator)
+	defer bld.Release()
+	for _, p := range paths {
+		bld.Append(p)
+	}
+	arr := bld.NewArray()
+	defer arr.Release()
+	return array.NewRecordBatch(schema, []arrow.Array{arr}, int64(len(paths)))
+}
+
+// TestRowReader_SkipsEmptyNonEOFBatches guards against the reader treating an
+// empty (0-row) batch without io.EOF as end-of-section. The underlying reader
+// may return such a batch when a read window is fully filtered out; the rows in
+// later batches must still be returned rather than silently dropped.
+func TestRowReader_SkipsEmptyNonEOFBatches(t *testing.T) {
+	fake := &scriptedReader{batches: []arrow.RecordBatch{
+		pathBatch(),           // empty, non-EOF
+		pathBatch(),           // empty, non-EOF
+		pathBatch("/a", "/b"), // real rows after the empty batches
+	}}
+
+	rr := &RowReader{ctx: context.Background(), reader: fake}
+	defer func() { require.NoError(t, rr.Close()) }()
+
+	var paths []string
+	for rr.Next() {
+		paths = append(paths, rr.At().ObjectPath)
+	}
+	require.NoError(t, rr.Err())
+	require.Equal(t, []string{"/a", "/b"}, paths,
+		"rows after leading empty (non-EOF) batches must not be dropped")
+}
+
+// TestRowReader_NonEmptyBatchWithEOF ensures a batch that arrives together with
+// io.EOF is still fully consumed before iteration ends.
+func TestRowReader_NonEmptyBatchWithEOF(t *testing.T) {
+	fake := &scriptedReader{batches: []arrow.RecordBatch{
+		pathBatch("/a", "/b"),
+	}}
+
+	rr := &RowReader{ctx: context.Background(), reader: fake}
+	defer func() { require.NoError(t, rr.Close()) }()
+
+	var paths []string
+	for rr.Next() {
+		paths = append(paths, rr.At().ObjectPath)
+	}
+	require.NoError(t, rr.Err())
+	require.Equal(t, []string{"/a", "/b"}, paths)
+}

--- a/pkg/dataobj/sections/stats/row_reader_internal_test.go
+++ b/pkg/dataobj/sections/stats/row_reader_internal_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
-	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/util/arrowtest"
 )
 
 // scriptedReader is a batchReader that returns a fixed sequence of batches, then
@@ -32,18 +33,14 @@ func (s *scriptedReader) Read(context.Context, int) (arrow.RecordBatch, error) {
 	return b, nil
 }
 
-// pathBatch builds a stats-schema record batch carrying one object_path per
-// argument (zero args => a valid empty, 0-row batch).
-func pathBatch(paths ...string) arrow.RecordBatch {
-	schema := arrow.NewSchema([]arrow.Field{{Name: "object_path.utf8", Type: arrow.BinaryTypes.String}}, nil)
-	bld := array.NewStringBuilder(memory.DefaultAllocator)
-	defer bld.Release()
+// pathRows builds stats rows carrying one object_path per argument (zero args =>
+// an empty, 0-row batch once rendered via [arrowtest.Rows.Record]).
+func pathRows(paths ...string) arrowtest.Rows {
+	rows := make(arrowtest.Rows, 0, len(paths))
 	for _, p := range paths {
-		bld.Append(p)
+		rows = append(rows, arrowtest.Row{"object_path.utf8": p})
 	}
-	arr := bld.NewArray()
-	defer arr.Release()
-	return array.NewRecordBatch(schema, []arrow.Array{arr}, int64(len(paths)))
+	return rows
 }
 
 // TestRowReader_SkipsEmptyNonEOFBatches guards against the reader treating an
@@ -51,10 +48,12 @@ func pathBatch(paths ...string) arrow.RecordBatch {
 // may return such a batch when a read window is fully filtered out; the rows in
 // later batches must still be returned rather than silently dropped.
 func TestRowReader_SkipsEmptyNonEOFBatches(t *testing.T) {
+	alloc := memory.DefaultAllocator
+	schema := pathRows("/a", "/b").Schema()
 	fake := &scriptedReader{batches: []arrow.RecordBatch{
-		pathBatch(),           // empty, non-EOF
-		pathBatch(),           // empty, non-EOF
-		pathBatch("/a", "/b"), // real rows after the empty batches
+		pathRows().Record(alloc, schema),           // empty, non-EOF
+		pathRows().Record(alloc, schema),           // empty, non-EOF
+		pathRows("/a", "/b").Record(alloc, schema), // real rows after the empty batches
 	}}
 
 	rr := &RowReader{ctx: context.Background(), reader: fake}
@@ -72,8 +71,9 @@ func TestRowReader_SkipsEmptyNonEOFBatches(t *testing.T) {
 // TestRowReader_NonEmptyBatchWithEOF ensures a batch that arrives together with
 // io.EOF is still fully consumed before iteration ends.
 func TestRowReader_NonEmptyBatchWithEOF(t *testing.T) {
+	rows := pathRows("/a", "/b")
 	fake := &scriptedReader{batches: []arrow.RecordBatch{
-		pathBatch("/a", "/b"),
+		rows.Record(memory.DefaultAllocator, rows.Schema()),
 	}}
 
 	rr := &RowReader{ctx: context.Background(), reader: fake}


### PR DESCRIPTION
**What this PR does / why we need it**:

The stats section `RowReader` treats an empty (0-row) batch that is *not* accompanied by `io.EOF` as end-of-section. This is the same bug that was fixed for the postings reader in #23290: the underlying dataset reader can legitimately return an empty, non-EOF batch when a read window is fully filtered out (its own docs say so), and treating that as EOF silently drops every row that comes after the first fully-filtered batch.

This path is **not reachable today** — the stats reader applies no predicates, so it never produces empty non-EOF batches — but the identical latent bug is a footgun that would activate the moment stats reads gain any filtering. Fixing it now keeps the two sibling readers consistent and prevents a future silent-data-loss regression.

The fix loops past empty non-EOF batches (mirroring #23290) and only stops on a real EOF, while preserving the reader's existing batch-release discipline.

**Which issue(s) this PR fixes**:

Follow-up to #23290 (applies the same fix to the stats reader). No separate issue.

**Special notes for your reviewer**:

- To make the empty-batch handling testable (the real reader can't currently produce empty non-EOF batches), the `RowReader.reader` field is now a small unexported `batchReader` interface that `*Reader` already satisfies; the public API is unchanged.
- Added an internal unit test with a scripted fake reader that emits empty → empty → non-empty batches; it fails on the old logic (returns nothing) and passes with the fix.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.
