### PR TITLE
fix(v2-engine): Stop double-underscoring nested keys with digit start in json parser

### DIFF
--- a/pkg/engine/internal/executor/parse_json.go
+++ b/pkg/engine/internal/executor/parse_json.go
@@ -243,8 +243,11 @@ func appendSanitized(to, key []byte) []byte {
 		return to
 	}
 
-	// Add prefix underscore for digit-starting keys (both top-level and nested)
-	if key[0] >= '0' && key[0] <= '9' {
+	// Prepend an underscore only for digit-starting top-level keys — nested keys
+	// already have the parent-separator `_` in `to` from buildSanitizedPrefixFromBuffer,
+	// so adding another underscore here would produce `parent__0` instead of `parent_0`
+	// and diverge from v1's flatten format (see pkg/logql/log/util.go:49).
+	if len(to) == 0 && key[0] >= '0' && key[0] <= '9' {
 		to = append(to, '_')
 	}
 

--- a/pkg/engine/internal/executor/parse_json_test.go
+++ b/pkg/engine/internal/executor/parse_json_test.go
@@ -145,7 +145,17 @@ func TestJSONParser_Process(t *testing.T) {
 			"nested number keys",
 			[]byte(`{"parent": {"456child": "value"}}`),
 			nil,
-			map[string]string{"parent__456child": "value"},
+			map[string]string{"parent_456child": "value"},
+		},
+		{
+			"deeply nested digit-start keys use single underscore per level",
+			[]byte(`{"statistics":{"file_count_per_level":{"0":5,"1":7},"kv_store_statistics":{"11":{"kv_store_bytes":100}}}}`),
+			nil,
+			map[string]string{
+				"statistics_file_count_per_level_0":                "5",
+				"statistics_file_count_per_level_1":                "7",
+				"statistics_kv_store_statistics_11_kv_store_bytes": "100",
+			},
 		},
 		{
 			"nested bad key replaced",


### PR DESCRIPTION
**What this PR does / why we need it**:

The v2 engine's `json` parser erroneously flattens nested keys with an extra leading underscore when the nested segment starts with a digit. Root cause is in `appendSanitized` (`pkg/engine/internal/executor/parse_json.go`): the digit-prefix underscore is always prepended, even when appending after a parent path that already contributed the `_` separator. The [v1 helper](https://github.com/grafana/loki/blob/da1efe2a0151a08f58bef9fb306bf57cccf49de2/pkg/logql/log/util.go#L49) gates the same prepend on `len(to) == 0` to add `_` only at the top level. This PR mirrors that gate in v2.

The digit-prefix rule exists so a top-level key like `123key` becomes `_123key` (Prometheus label names can't start with a digit). At nested positions, the leading character is never a digit. It's the parent-separator `_`, so the prepend is redundant and results in the observed double underscore.