### PR TITLE
fix(queryrange): Preserve sketch in MergeLabels

### DIFF
--- a/pkg/querier/queryrange/codec_test.go
+++ b/pkg/querier/queryrange/codec_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
+	"github.com/grafana/loki/v3/pkg/storage/detected"
 	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/httpreq"
 )
@@ -1961,6 +1962,46 @@ func Test_codec_MergeResponse_DetectedFieldsResponse(t *testing.T) {
 
 		require.Nil(t, baz)
 	})
+}
+
+// Test_codec_MergeResponse_DetectedLabelsResponse is a regression test for
+// https://github.com/grafana/loki/issues/16315: a multi-tenant detected_labels query 500s with
+// "too short binary".
+func Test_codec_MergeResponse_DetectedLabelsResponse(t *testing.T) {
+	// Build a response as MultiTenantQuerier.DetectedLabels would: per-tenant
+	// labels merged through detected.MergeLabels.
+	buildTenantMergedResponse := func(label string, cardinality int) *DetectedLabelsResponse {
+		var perTenant []*logproto.DetectedLabel
+		for tenant := 0; tenant < 2; tenant++ {
+			sketch := hyperloglog.New()
+			for i := 0; i < cardinality; i++ {
+				sketch.Insert([]byte(fmt.Sprintf("tenant-%d-value-%d", tenant, i)))
+			}
+			marshalled, err := sketch.MarshalBinary()
+			require.NoError(t, err)
+			perTenant = append(perTenant, &logproto.DetectedLabel{Label: label, Sketch: marshalled})
+		}
+
+		merged, err := detected.MergeLabels(perTenant)
+		require.NoError(t, err)
+
+		return &DetectedLabelsResponse{
+			Response: &logproto.DetectedLabelsResponse{DetectedLabels: merged},
+		}
+	}
+
+	// Two split-interval responses, each already merged across tenants.
+	responses := []queryrangebase.Response{
+		buildTenantMergedResponse("foo", 5),
+		buildTenantMergedResponse("foo", 7),
+	}
+
+	got, err := DefaultCodec.MergeResponse(responses...)
+	require.NoError(t, err)
+
+	response := got.(*DetectedLabelsResponse).Response
+	require.Len(t, response.DetectedLabels, 1)
+	require.Equal(t, "foo", response.DetectedLabels[0].Label)
 }
 
 type badResponse struct{}

--- a/pkg/storage/detected/labels.go
+++ b/pkg/storage/detected/labels.go
@@ -51,10 +51,18 @@ func MergeLabels(labels []*logproto.DetectedLabel) (result []*logproto.DetectedL
 	}
 
 	for _, label := range mergedLabels {
+		// Keep the marshalled sketch so the result can be merged again, e.g. when
+		// the query frontend merges responses that MultiTenantQuerier already
+		// merged across tenants.
+		sketch, err := label.Sketch.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+
 		detectedLabel := &logproto.DetectedLabel{
 			Label:       label.Label,
 			Cardinality: label.Sketch.Estimate(),
-			Sketch:      nil,
+			Sketch:      sketch,
 		}
 
 		result = append(result, detectedLabel)

--- a/pkg/storage/detected/labels_test.go
+++ b/pkg/storage/detected/labels_test.go
@@ -271,4 +271,35 @@ func TestMergeLabels(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result, 2) // Should treat App and app as different labels
 	})
+
+	// Reproduces grafana/loki#16315: a multi-tenant detected_labels query 500s
+	// with "too short binary".
+	//
+	// MergeLabels runs twice on the same response: first in
+	// MultiTenantQuerier.DetectedLabels, which merges the per-tenant sketches,
+	// and again in the query frontend when the request is split across time
+	// intervals. The first merge drops the sketch (Sketch: nil), so the second
+	// merge feeds nil into hyperloglog.UnmarshalBinary, which rejects it.
+	t.Run("re-merging a merged result must not fail", func(t *testing.T) {
+		var labels []*logproto.DetectedLabel
+		for _, name := range []string{"app", "env", "service"} {
+			sketch := hyperloglog.New()
+			for i := 0; i < 100; i++ {
+				sketch.Insert([]byte(name + "-value-" + string(rune(i))))
+			}
+			sketchData, err := sketch.MarshalBinary()
+			require.NoError(t, err)
+			labels = append(labels, &logproto.DetectedLabel{Label: name, Sketch: sketchData})
+		}
+
+		// First merge: MultiTenantQuerier.DetectedLabels merging tenant responses.
+		merged, err := MergeLabels(labels)
+		require.NoError(t, err)
+		require.Len(t, merged, 3)
+
+		// Second merge: query frontend merging split-interval responses.
+		remerged, err := MergeLabels(merged)
+		require.NoError(t, err)
+		require.Len(t, remerged, 3)
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When querying multi tenant querier (and there are multiple splits) we merge the results twice (once because of a split-by-interval, second time because of multi-tenant query). As a result we return an error "too short binary" (sketch is `nil`).

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/loki/issues/16315

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)