### PR TITLE
chore: Move stream resolves back to read phase

### DIFF
--- a/pkg/dataobj/metastore/postings_index_sections_reader.go
+++ b/pkg/dataobj/metastore/postings_index_sections_reader.go
@@ -74,6 +74,8 @@ type postingsIndexSectionsReader struct {
 	batchSize  int
 
 	initialized bool
+	resolved    bool
+	selector    *streamSelector
 
 	rows   []resolvedRow
 	offset int
@@ -111,6 +113,7 @@ func (r *postingsIndexSectionsReader) Open(ctx context.Context) error {
 	}
 	if len(r.matchers) == 0 {
 		r.initialized = true
+		r.resolved = true
 		return nil
 	}
 
@@ -152,13 +155,7 @@ func (r *postingsIndexSectionsReader) Open(ctx context.Context) error {
 	if err := selector.open(ctx, opened, maxConcurrentSectionOpens); err != nil {
 		return fmt.Errorf("opening postings readers: %w", err)
 	}
-	defer selector.close()
-
-	// Eagerly resolve the stream selector, caching the result as part of the reader
-	err = r.resolveStreamsFromSelector(ctx, selector)
-	if err != nil {
-		return err
-	}
+	r.selector = selector
 
 	r.initialized = true
 	return nil
@@ -170,6 +167,12 @@ func (r *postingsIndexSectionsReader) Read(ctx context.Context) (arrow.RecordBat
 	}
 	if r.readSpan == nil {
 		_, r.readSpan = xcap.StartSpan(ctx, tracer, "metastore.postingsIndexSectionsReader.Read")
+	}
+
+	// Lazily resolve the stream selector on first Read, caching the result on the reader
+	err := r.resolveStreamsFromSelector(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolving streams from selector: %w", err)
 	}
 
 	if r.offset >= len(r.rows) {
@@ -185,7 +188,11 @@ func (r *postingsIndexSectionsReader) Read(ctx context.Context) (arrow.RecordBat
 	return sectionResultsToRecordBatch(batch), nil
 }
 
-func (r *postingsIndexSectionsReader) resolveStreamsFromSelector(ctx context.Context, selector *streamSelector) error {
+func (r *postingsIndexSectionsReader) resolveStreamsFromSelector(ctx context.Context) error {
+	if r.resolved {
+		return nil
+	}
+
 	region := xcap.RegionFromContext(ctx)
 	startTime := time.Now()
 	defer func() {
@@ -193,12 +200,17 @@ func (r *postingsIndexSectionsReader) resolveStreamsFromSelector(ctx context.Con
 		r.readSpan.Record(StatMetastoreSectionPointersReadTime.Observe(time.Since(startTime).Seconds()))
 	}()
 
-	results, err := selector.selectStreams(ctx)
+	results, err := r.selector.selectStreams(ctx)
+	defer func() {
+		_ = r.selector.close()
+	}()
 	if err != nil {
 		return fmt.Errorf("resolving postings sections: %w", err)
 	}
+
 	r.rows = expandResults(results)
 	r.resolvedRefs = uint64(len(r.rows))
+	r.resolved = true
 
 	region.Record(StatMetastoreStreamsRead.Observe(int64(len(r.rows))))
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves the stream resolution step back to the reader in order to maintain the Open/Read split we use in our dashboards.

With the previous setup, I couldn't tell if the Open phase was slow due to object storage, or slow due to the Resolve step. This moves it back to Read so it will become clear.