### PR TITLE
fix(v2-engine): Preserve unwrap label when outer aggregation groups by it

### DIFF
--- a/pkg/engine/internal/planner/logical/planner.go
+++ b/pkg/engine/internal/planner/logical/planner.go
@@ -335,15 +335,23 @@ func walkRangeAggregation(e *syntax.RangeAggregationExpr, wc *walkContext) (Valu
 			return nil, unimplementedFeature(fmt.Sprintf("unwrap conversion operation %q", e.Left.Unwrap.Operation))
 		}
 
-		// Unwrap turns a column into numerical `value` column, and that original column should be dropped from the result.
-		builder = builder.
-			Cast(unwrapIdentifier, unwrapOperation).
-			ProjectDrop(&ColumnRef{
+		// Unwrap turns a column into numerical `value` column. By default we
+		// drop the source column from the label set since it's been consumed
+		// as the sample value. v1 makes an exception: if the immediately
+		// wrapping vector aggregation explicitly groups by the unwrap
+		// identifier (e.g. `sum by (totalSize) (... | unwrap totalSize ...)`),
+		// v1 preserves the column so the group-by actually produces per-value
+		// series. Match that behavior here — dropping unconditionally would
+		// silently collapse such queries to a single-value output.
+		builder = builder.Cast(unwrapIdentifier, unwrapOperation)
+		if !outerGroupingReferencesUnwrap(wc.outerVecGrouping, unwrapIdentifier) {
+			builder = builder.ProjectDrop(&ColumnRef{
 				Ref: types.ColumnRef{
 					Column: unwrapIdentifier,
 					Type:   types.ColumnTypeAmbiguous,
 				},
 			})
+		}
 
 		// Filter out rows with any errors because rows with errors have invalid numeric values.
 		builder = builder.Select(
@@ -404,6 +412,13 @@ func walkRangeAggregation(e *syntax.RangeAggregationExpr, wc *walkContext) (Valu
 }
 
 func walkVectorAggregation(e *syntax.VectorAggregationExpr, wc *walkContext) (Value, error) {
+	// Save-restore outerVecGrouping so a nested VectorAggregation restores
+	// its parent's grouping on exit. This lets a child RangeAggregation with
+	// unwrap see its DIRECT wrapping vector aggregation's grouping.
+	prev := wc.outerVecGrouping
+	wc.outerVecGrouping = e.Grouping
+	defer func() { wc.outerVecGrouping = prev }()
+
 	left, err := walk(e.Left, wc)
 	if err != nil {
 		return nil, err
@@ -469,10 +484,31 @@ func walkLiteral(e *syntax.LiteralExpr, _ *walkContext) (Value, error) {
 	return NewLiteral(e.Val), nil
 }
 
+// outerGroupingReferencesUnwrap reports whether the enclosing vector
+// aggregation's `by (...)` clause names the unwrap identifier — meaning the
+// user wants distinct series per unwrap-value and the source column must
+// therefore survive as a label. `without (...)` and bare aggregations return
+// false since neither preserves a specific label the user asked to group by.
+func outerGroupingReferencesUnwrap(g *syntax.Grouping, unwrapIdentifier string) bool {
+	if g == nil || g.Without {
+		return false
+	}
+	for _, name := range g.Groups {
+		if name == unwrapIdentifier {
+			return true
+		}
+	}
+	return false
+}
+
 type walkContext struct {
 	ctx     context.Context
 	params  logql.Params
 	deletes []*deletion.Request
+	// outerVecGrouping is the grouping of the immediate enclosing
+	// VectorAggregation expression, or nil if the range aggregation being
+	// walked is not directly wrapped by a vector aggregation.
+	outerVecGrouping *syntax.Grouping
 }
 
 func walk(e syntax.Expr, wc *walkContext) (Value, error) {

--- a/pkg/engine/internal/planner/logical/planner_test.go
+++ b/pkg/engine/internal/planner/logical/planner_test.go
@@ -1241,3 +1241,197 @@ func buildPlanFromPredicates(t *testing.T, predicates []Value, selector Value) s
 
 	return plan.String()
 }
+
+func TestOuterGroupingReferencesUnwrap(t *testing.T) {
+	tests := []struct {
+		name             string
+		grouping         *syntax.Grouping
+		unwrapIdentifier string
+		want             bool
+	}{
+		{
+			name:             "nil grouping (bare aggregation)",
+			grouping:         nil,
+			unwrapIdentifier: "foo",
+			want:             false,
+		},
+		{
+			name:             "by grouping names the unwrap identifier",
+			grouping:         &syntax.Grouping{Groups: []string{"foo"}},
+			unwrapIdentifier: "foo",
+			want:             true,
+		},
+		{
+			name:             "by grouping names the unwrap identifier among others",
+			grouping:         &syntax.Grouping{Groups: []string{"level", "foo"}},
+			unwrapIdentifier: "foo",
+			want:             true,
+		},
+		{
+			name:             "by grouping does not name the unwrap identifier",
+			grouping:         &syntax.Grouping{Groups: []string{"level"}},
+			unwrapIdentifier: "foo",
+			want:             false,
+		},
+		{
+			name:             "empty by grouping",
+			grouping:         &syntax.Grouping{Groups: []string{}},
+			unwrapIdentifier: "foo",
+			want:             false,
+		},
+		{
+			name:             "without grouping never preserves the column even if it names the identifier",
+			grouping:         &syntax.Grouping{Without: true, Groups: []string{"foo"}},
+			unwrapIdentifier: "foo",
+			want:             false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, outerGroupingReferencesUnwrap(tc.grouping, tc.unwrapIdentifier))
+		})
+	}
+}
+
+func TestPlannerPreservesUnwrapColumnWhenGroupedBy(t *testing.T) {
+	t.Run("by grouping on the unwrap identifier keeps the source column (no ProjectDrop)", func(t *testing.T) {
+		q := &query{
+			statement: `sum by (foo) (sum_over_time({app="api"} | unwrap foo [5m]))`,
+			start:     3600,
+			end:       7200,
+			interval:  5 * time.Minute,
+		}
+
+		plan, err := BuildPlan(context.Background(), q)
+		require.NoError(t, err)
+		t.Logf("\n%s\n", plan.String())
+
+		// Because the wrapping vector aggregation groups `by (foo)`, the
+		// source column is preserved: there is no `mode=*D` ProjectDrop of
+		// ambiguous.foo after the cast.
+		expected := `%1 = EQ label.app "api"
+%2 = MAKETABLE [selector=%1, predicates=[], shard=0_of_1]
+%3 = GTE builtin.timestamp 1970-01-01T00:55:00Z
+%4 = SELECT %2 [predicate=%3]
+%5 = LT builtin.timestamp 1970-01-01T02:00:00Z
+%6 = SELECT %4 [predicate=%5]
+%7 = CAST_FLOAT(ambiguous.foo)
+%8 = PROJECT %6 [mode=*E, expr=%7]
+%9 = EQ generated.__error__ ""
+%10 = EQ generated.__error_details__ ""
+%11 = AND %9 %10
+%12 = SELECT %8 [predicate=%11]
+%13 = RANGE_AGGREGATION %12 [operation=sum, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
+%14 = VECTOR_AGGREGATION %13 [operation=sum, group_by=(ambiguous.foo)]
+%15 = LOGQL_COMPAT %14
+RETURN %15
+`
+		require.Equal(t, expected, plan.String())
+	})
+
+	t.Run("without grouping on the unwrap identifier drops the source column", func(t *testing.T) {
+		q := &query{
+			statement: `sum without (foo) (sum_over_time({app="api"} | unwrap foo [5m]))`,
+			start:     3600,
+			end:       7200,
+			interval:  5 * time.Minute,
+		}
+
+		plan, err := BuildPlan(context.Background(), q)
+		require.NoError(t, err)
+		t.Logf("\n%s\n", plan.String())
+
+		// `without` does not preserve a specific label, so the source column is
+		// dropped as usual (the `%9 ... mode=*D` ProjectDrop is present).
+		expected := `%1 = EQ label.app "api"
+%2 = MAKETABLE [selector=%1, predicates=[], shard=0_of_1]
+%3 = GTE builtin.timestamp 1970-01-01T00:55:00Z
+%4 = SELECT %2 [predicate=%3]
+%5 = LT builtin.timestamp 1970-01-01T02:00:00Z
+%6 = SELECT %4 [predicate=%5]
+%7 = CAST_FLOAT(ambiguous.foo)
+%8 = PROJECT %6 [mode=*E, expr=%7]
+%9 = PROJECT %8 [mode=*D, expr=ambiguous.foo]
+%10 = EQ generated.__error__ ""
+%11 = EQ generated.__error_details__ ""
+%12 = AND %10 %11
+%13 = SELECT %9 [predicate=%12]
+%14 = RANGE_AGGREGATION %13 [operation=sum, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
+%15 = VECTOR_AGGREGATION %14 [operation=sum, group_without=(ambiguous.foo)]
+%16 = LOGQL_COMPAT %15
+RETURN %16
+`
+		require.Equal(t, expected, plan.String())
+	})
+
+	t.Run("bare aggregation drops the source column", func(t *testing.T) {
+		q := &query{
+			statement: `sum(sum_over_time({app="api"} | unwrap foo [5m]))`,
+			start:     3600,
+			end:       7200,
+			interval:  5 * time.Minute,
+		}
+
+		plan, err := BuildPlan(context.Background(), q)
+		require.NoError(t, err)
+		t.Logf("\n%s\n", plan.String())
+
+		expected := `%1 = EQ label.app "api"
+%2 = MAKETABLE [selector=%1, predicates=[], shard=0_of_1]
+%3 = GTE builtin.timestamp 1970-01-01T00:55:00Z
+%4 = SELECT %2 [predicate=%3]
+%5 = LT builtin.timestamp 1970-01-01T02:00:00Z
+%6 = SELECT %4 [predicate=%5]
+%7 = CAST_FLOAT(ambiguous.foo)
+%8 = PROJECT %6 [mode=*E, expr=%7]
+%9 = PROJECT %8 [mode=*D, expr=ambiguous.foo]
+%10 = EQ generated.__error__ ""
+%11 = EQ generated.__error_details__ ""
+%12 = AND %10 %11
+%13 = SELECT %9 [predicate=%12]
+%14 = RANGE_AGGREGATION %13 [operation=sum, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
+%15 = VECTOR_AGGREGATION %14 [operation=sum, group_by=()]
+%16 = LOGQL_COMPAT %15
+RETURN %16
+`
+		require.Equal(t, expected, plan.String())
+	})
+
+	t.Run("only the DIRECT wrapping aggregation's grouping is considered", func(t *testing.T) {
+		// The immediate wrapper groups `by (foo)` so the column is
+		// preserved, even though the outer `by (level)` does not reference it.
+		// This exercises the save/restore of outerVecGrouping across nested
+		// vector aggregations.
+		q := &query{
+			statement: `sum by (level) (sum by (foo) (sum_over_time({app="api"} | unwrap foo [5m])))`,
+			start:     3600,
+			end:       7200,
+			interval:  5 * time.Minute,
+		}
+
+		plan, err := BuildPlan(context.Background(), q)
+		require.NoError(t, err)
+		t.Logf("\n%s\n", plan.String())
+
+		expected := `%1 = EQ label.app "api"
+%2 = MAKETABLE [selector=%1, predicates=[], shard=0_of_1]
+%3 = GTE builtin.timestamp 1970-01-01T00:55:00Z
+%4 = SELECT %2 [predicate=%3]
+%5 = LT builtin.timestamp 1970-01-01T02:00:00Z
+%6 = SELECT %4 [predicate=%5]
+%7 = CAST_FLOAT(ambiguous.foo)
+%8 = PROJECT %6 [mode=*E, expr=%7]
+%9 = EQ generated.__error__ ""
+%10 = EQ generated.__error_details__ ""
+%11 = AND %9 %10
+%12 = SELECT %8 [predicate=%11]
+%13 = RANGE_AGGREGATION %12 [operation=sum, start_ts=1970-01-01T01:00:00Z, end_ts=1970-01-01T02:00:00Z, step=0s, range=5m0s]
+%14 = VECTOR_AGGREGATION %13 [operation=sum, group_by=(ambiguous.foo)]
+%15 = VECTOR_AGGREGATION %14 [operation=sum, group_by=(ambiguous.level)]
+%16 = LOGQL_COMPAT %15
+RETURN %16
+`
+		require.Equal(t, expected, plan.String())
+	})
+}

--- a/pkg/logql/bench/queries/regression/metric-queries.yaml
+++ b/pkg/logql/bench/queries/regression/metric-queries.yaml
@@ -463,3 +463,29 @@ queries:
       log_format: logfmt
       detected_fields:
         - msg
+  - description: sum by (unwrapped_field) preserves the unwrap identifier as a label
+    query: sum by (bytes) (sum_over_time(${SELECTOR} | logfmt | unwrap bytes [${RANGE}]))
+    kind: metric
+    time_range:
+      length: 24h
+      step: 1m
+    tags:
+      - sum_over_time
+      - logfmt
+      - unwrap
+      - grouping
+      - unwrapped-label-preserved
+    notes: >
+      Regression for the v2 conditional-unwrap-drop fix. Pre-fix v2
+      unconditionally dropped the unwrap identifier from the label set
+      after casting it to `value`, so `sum by (bytes) (... | unwrap bytes)`
+      grouped by a label that no longer existed and collapsed every
+      series into a single unlabelled sum. v1 preserves the source
+      column as a label whenever the immediately-enclosing vector
+      aggregation's `by (...)` names the unwrap identifier, so the
+      group-by produces one series per distinct bytes value.
+      The series label set and per-series counts must match v1.
+    requires:
+      log_format: logfmt
+      unwrappable_fields:
+        - bytes


### PR DESCRIPTION
**What this PR does / why we need it**:
The v2 engine unconditionally drops the unwrap identifier from the label set after casting it to the sample `value` column. That silently collapses queries like `sum by (bytes) (sum_over_time({selector} | logfmt | unwrap bytes [5m]))` into a single unlabelled series since the `by (bytes)` groups by a label that no longer exists.

v1 handles this case specially: when the immediately-wrapping vector aggregation's `by (...)` clause explicitly names the unwrap identifier, v1 preserves the source column as a label so the group-by produces per-value series. This PR matches that behaviour in v2.

Implementation:

- Added `outerVecGrouping *syntax.Grouping` to `walkContext`.
- `walkVectorAggregation` sets it to its own grouping before walking its subtree, restoring the previous value on exit. Nested aggregations, therefore, see their DIRECT parent's grouping, not the outermost one.
- `walkRangeAggregation` skips the `ProjectDrop` when a new helper `outerGroupingReferencesUnwrap(wc.outerVecGrouping, unwrapIdentifier)` returns true.
- Helper only returns true for `by(...)` that names the unwrap identifier. Bare aggregations, `without(...)`, and `by(other, …)` all remain unaffected.