### PR TITLE
test: Fix race in hedging test

### DIFF
--- a/pkg/storage/chunk/client/hedging/hedging_test.go
+++ b/pkg/storage/chunk/client/hedging/hedging_test.go
@@ -2,11 +2,9 @@ package hedging
 
 import (
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
@@ -18,17 +16,10 @@ func (fn RoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) 
 	return fn(req)
 }
 
-func resetMetrics() *prometheus.Registry {
-	//TODO: clean up this massive hack...
-	reg := prometheus.NewRegistry()
-	prometheus.DefaultRegisterer = reg
-	prometheus.DefaultGatherer = reg
-	initMetrics()
-	return reg
-}
-
 func TestHedging(t *testing.T) {
-	reg := resetMetrics()
+	beforeTotal := testutil.ToFloat64(totalHedgeRequests)
+	beforeLimited := testutil.ToFloat64(totalRateLimitedHedgeRequests)
+
 	cfg := &Config{
 		At:           time.Duration(1),
 		UpTo:         3,
@@ -43,27 +34,21 @@ func TestHedging(t *testing.T) {
 				StatusCode: http.StatusOK,
 			}, nil
 		}),
-	}, reg)
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	_, _ = client.Get("http://example.com")
 
 	require.Equal(t, int32(3), count.Load())
-	require.NoError(t, testutil.GatherAndCompare(reg,
-		strings.NewReader(`
-# HELP hedged_requests_rate_limited_total The total number of hedged requests rejected via rate limiting.
-# TYPE hedged_requests_rate_limited_total counter
-hedged_requests_rate_limited_total 0
-# HELP hedged_requests_total The total number of hedged requests.
-# TYPE hedged_requests_total counter
-hedged_requests_total 2
-`,
-		), "hedged_requests_total", "hedged_requests_rate_limited_total"))
+	require.Equal(t, 2.0, testutil.ToFloat64(totalHedgeRequests)-beforeTotal)
+	require.Equal(t, 0.0, testutil.ToFloat64(totalRateLimitedHedgeRequests)-beforeLimited)
 }
 
 func TestHedgingRateLimit(t *testing.T) {
-	reg := resetMetrics()
+	beforeTotal := testutil.ToFloat64(totalHedgeRequests)
+	beforeLimited := testutil.ToFloat64(totalRateLimitedHedgeRequests)
+
 	cfg := &Config{
 		At:           time.Duration(1),
 		UpTo:         20,
@@ -78,21 +63,13 @@ func TestHedgingRateLimit(t *testing.T) {
 				StatusCode: http.StatusOK,
 			}, nil
 		}),
-	}, reg)
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	_, _ = client.Get("http://example.com")
 
 	require.Equal(t, int32(2), count.Load())
-	require.NoError(t, testutil.GatherAndCompare(reg,
-		strings.NewReader(`
-# HELP hedged_requests_rate_limited_total The total number of hedged requests rejected via rate limiting.
-# TYPE hedged_requests_rate_limited_total counter
-hedged_requests_rate_limited_total 18
-# HELP hedged_requests_total The total number of hedged requests.
-# TYPE hedged_requests_total counter
-hedged_requests_total 1
-`,
-		), "hedged_requests_total", "hedged_requests_rate_limited_total"))
+	require.Equal(t, 1.0, testutil.ToFloat64(totalHedgeRequests)-beforeTotal)
+	require.Equal(t, 18.0, testutil.ToFloat64(totalRateLimitedHedgeRequests)-beforeLimited)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Addresses data race seen here:

```
WARNING: DATA RACE
Write at 0x0001050bb348 by goroutine 23:
  github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging.initMetrics()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/hedging/hedging.go:39 +0x27c
  github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging.resetMetrics()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/hedging/hedging_test.go:26 +0x1d4
  github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging.TestHedgingRateLimit()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/hedging/hedging_test.go:66 +0x28
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2101 +0x34

Previous read at 0x0001050bb348 by goroutine 17:
  github.com/grafana/loki/v3/pkg/storage/chunk/client/hedging.(*winnerTrackingRoundTripper).RoundTrip()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/storage/chunk/client/hedging/hedging.go:154 +0x94
  github.com/cristalhq/hedgedhttp.(*hedgedTransport).RoundTrip.func2()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/cristalhq/hedgedhttp/hedged.go:211 +0x8c
  github.com/cristalhq/hedgedhttp.runInPool.func1()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/cristalhq/hedgedhttp/hedged.go:305 +0x34
```

The approach was to remove the known and stated "hack".  Instead, the `RoundTripperWithRegisterer` registers the existing package-level metrics once. Since tests no longer replace those metrics or the default registry, registration remains valid and race-free. 

**Which issue(s) this PR fixes**:
In support of: https://github.com/grafana/loki/issues/8586

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
