### PR TITLE
test: Fix flaky dataobj builder test

### DIFF
--- a/pkg/dataobj/index/builder_test.go
+++ b/pkg/dataobj/index/builder_test.go
@@ -52,7 +52,7 @@ func TestIndexBuilder_CleanShutdown(t *testing.T) {
 	require.NoError(t, err)
 
 	var logBuf bytes.Buffer
-	logger := log.NewLogfmtLogger(&logBuf)
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(&logBuf))
 
 	builder, err := NewIndexBuilder(
 		Config{


### PR DESCRIPTION
**What this PR does / why we need it**:
Addresses this data race:
```

WARNING: DATA RACE
Write at 0x00c0082ed340 by goroutine 3710:
  bytes.(*Buffer).Write()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/bytes/buffer.go:194 +0x38
  github.com/go-kit/log.logfmtLogger.Log()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/go-kit/log/logfmt_logger.go:58 +0x258
  github.com/go-kit/log.(*logfmtLogger).Log()
      <autogenerated>:1 +0x50
  github.com/go-kit/log.(*context).Log()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/go-kit/log/log.go:168 +0x3e4
  github.com/grafana/loki/v3/pkg/kafka/client.(*logger).Log()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/kafka/client/logger.go:34 +0x4b8
  github.com/twmb/franz-go/pkg/kgo.(*wrappedLogger).Log()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/twmb/franz-go/pkg/kgo/logger.go:125 +0xc8
  github.com/twmb/franz-go/pkg/kgo.(*consumer).assignPartitions()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/twmb/franz-go/pkg/kgo/consumer.go:1062 +0x294
  github.com/twmb/franz-go/pkg/kgo.(*Client).LeaveGroupContext.func1()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/twmb/franz-go/pkg/kgo/consumer_group.go:282 +0x7c

Previous write at 0x00c0082ed340 by goroutine 3611:
  bytes.(*Buffer).Write()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/bytes/buffer.go:194 +0x38
  github.com/go-kit/log.logfmtLogger.Log()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/go-kit/log/logfmt_logger.go:58 +0x258
  github.com/go-kit/log.(*logfmtLogger).Log()
      <autogenerated>:1 +0x50
  github.com/go-kit/log.(*context).Log()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/go-kit/log/log.go:168 +0x3e4
  github.com/grafana/loki/v3/pkg/kafka/client.(*logger).Log()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/kafka/client/logger.go:34 +0x4b8
  github.com/twmb/franz-go/pkg/kgo.(*wrappedLogger).Log()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/twmb/franz-go/pkg/kgo/logger.go:125 +0xc8
  github.com/twmb/franz-go/pkg/kgo.(*Client).updateMetadataLoop()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/twmb/franz-go/pkg/kgo/metadata.go:204 +0x458
  github.com/twmb/franz-go/pkg/kgo.NewClient.gowrap1()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/twmb/franz-go/pkg/kgo/client.go:593 +0x2c
```

This is done by wrapping the shared `*bytes.Buffer` with a synchronization mechanism. `log.NewSyncWriter` is a go-kit helper that wraps an `io.Writer` with a mutex so concurrent `Write` calls are serialized.

**Which issue(s) this PR fixes**:
In support of: https://github.com/grafana/loki/issues/8586

**Special notes for your reviewer**:
```
 % go test -race -count=200 -run TestIndexBuilder_CleanShutdown ./pkg/dataobj/index/
ok  	github.com/grafana/loki/v3/pkg/dataobj/index	2.842s
```

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
