### PR TITLE
fix: treat scientific notation timestamps as nanoseconds in parseTimestamp

### DIFF
--- a/pkg/loghttp/params.go
+++ b/pkg/loghttp/params.go
@@ -180,6 +180,13 @@ func parseTimestamp(value string, def time.Time) (time.Time, error) {
 	if strings.Contains(value, ".") {
 		if t, err := strconv.ParseFloat(value, 64); err == nil {
 			s, ns := math.Modf(t)
+			// If the integer part is large (> 9999999999), it is a nanosecond
+			// timestamp expressed in scientific notation (e.g. "1.767610546875e+18")
+			// rather than a second timestamp with fractional sub-seconds.
+			// Treat the entire value as nanoseconds to match the integer path.
+			if s > 9999999999 {
+				return time.Unix(0, int64(t)), nil
+			}
 			ns = math.Round(ns*1000) / 1000
 			return time.Unix(int64(s), int64(ns*float64(time.Second))), nil
 		}

--- a/pkg/loghttp/params_test.go
+++ b/pkg/loghttp/params_test.go
@@ -362,6 +362,8 @@ func Test_parseTimestamp(t *testing.T) {
 		{"unix timestamp", "1571332130", now, time.Unix(1571332130, 0), false},
 		{"unix nano timestamp", "1571334162051000000", now, time.Unix(0, 1571334162051000000), false},
 		{"unix timestamp with subseconds", "1571332130.934", now, time.Unix(1571332130, 934*1e6), false},
+		{"unix nano timestamp in scientific notation", "1.767610546875e+18", now, time.Unix(0, 1767610546875000000), false},
+		{"small float seconds with subseconds", "1571332130.5", now, time.Unix(1571332130, 5e8), false},
 		{"RFC3339 format", "2002-10-02T15:00:00Z", now, time.Date(2002, 10, 02, 15, 0, 0, 0, time.UTC), false},
 		{"RFC3339nano format", "2009-11-10T23:00:00.000000001Z", now, time.Date(2009, 11, 10, 23, 0, 0, 1, time.UTC), false},
 		{"invalid", "we", now, time.Time{}, true},


### PR DESCRIPTION
## Description

Fixes #20293

When a `query_range` request passes a timestamp in scientific notation (e.g. `end=1.767610546875e+18`), `parseTimestamp` incorrectly interprets the integer part as **seconds** instead of **nanoseconds**, creating a time value billions of years in the future. This causes massive memory allocation and eventually OOM.

### Root Cause

In `pkg/loghttp/params.go`, `parseTimestamp()` checks for a `.` in the value and parses it as a float. For a value like `1.767610546875e+18`:

1. `strconv.ParseFloat` succeeds → `t = 1.767610546875e+18`
2. `math.Modf(t)` → `s = 1.767610546875e+18`, `ns = 0`
3. `time.Unix(int64(s), 0)` → treats `s` as **seconds** → ~55 billion years in the future

The integer path correctly handles this by checking `len(value) > 10` to detect nanosecond timestamps, but the float path had no such check.

### Fix

Added a check in the float branch: if the integer part (`s`) exceeds `9999999999` (> 10 digits), the entire float value is treated as nanoseconds rather than seconds with fractional sub-seconds.

```go
if s > 9999999999 {
    return time.Unix(0, int64(t)), nil
}
```

### Test Cases Added

- `"1.767610546875e+18"` → `time.Unix(0, 1767610546875000000)` (nanosecond scientific notation)
- `"1571332130.5"` → `time.Unix(1571332130, 5e8)` (small float seconds still work correctly)

### Behavior

| Input | Before | After |
|-------|--------|-------|
| `1.767610546875e+18` | `time.Unix(1767610546875000000, 0)` → year ~55 billion | `time.Unix(0, 1767610546875000000)` → 2025-01-05 |
| `1571332130.934` | `time.Unix(1571332130, 934000000)` → unchanged | Unchanged |
| `1571332130.5` | `time.Unix(1571332130, 500000000)` → unchanged | Unchanged |