### PR TITLE
refactor(lbac): add LBAC initialization hooks

### DIFF
--- a/docs/sources/operations/lbac.md
+++ b/docs/sources/operations/lbac.md
@@ -9,7 +9,7 @@ weight:
 # Use label-based access control with Loki
 
 {{< admonition type="note" >}}
-This feature is experimental and available from v3.7.3. For the latest releases, refer to the [Release notes](https://grafana.com/docs/loki/<LOKI_VERSION>/release-notes/).
+This feature is experimental and available from v4.0. For the latest releases, refer to the [Release notes](https://grafana.com/docs/loki/<LOKI_VERSION>/release-notes/).
 {{< /admonition >}}
 
 Label-based access control (LBAC) restricts the logs a tenant can query to those that match one or more [Prometheus label selectors](https://prometheus.io/docs/prometheus/latest/querying/basics/#time-series-selectors). You associate a set of selectors with a tenant, and queries from that tenant only return data from log streams that match at least one of the selectors. Because the selectors are combined with OR, this corresponds to [disjunctive normal form](https://en.wikipedia.org/wiki/Disjunctive_normal_form), which lets you express any required policy.

--- a/docs/sources/operations/troubleshooting/troubleshoot-operations.md
+++ b/docs/sources/operations/troubleshooting/troubleshoot-operations.md
@@ -325,6 +325,40 @@ The compactor requires a working directory for index compaction, but none is con
 - HTTP status: N/A (startup failure)
 - Configurable per tenant: No
 
+### Error: LBAC requires authentication
+
+**Error message:**
+
+```text
+CONFIG ERROR: auth_enabled must be true when lbac.enabled is true
+```
+
+**Cause:**
+
+Label-based access control (`lbac.enabled: true`) relies on per-tenant authentication to determine which access policies to apply, but `auth_enabled` is set to `false`.
+
+**Resolution:**
+
+- **Enable authentication**:
+
+  ```yaml
+  auth_enabled: true
+  ```
+
+- **Or disable LBAC**:
+
+  ```yaml
+  lbac:
+    enabled: false
+  ```
+
+**Properties:**
+
+- Enforced by: Configuration validation
+- Retryable: No (configuration must be fixed)
+- HTTP status: N/A (startup failure)
+- Configurable per tenant: No
+
 ### Error: Unrecognized index or store type
 
 **Error message:**

--- a/pkg/loki/labelaccess.go
+++ b/pkg/loki/labelaccess.go
@@ -15,6 +15,9 @@ import (
 
 func (l *Loki) setupLBAC() error {
 	l.Codec = labelaccess.NewCodec(l.Codec)
+	if l.CodecWrapper != nil {
+		l.Codec = l.CodecWrapper(l.Codec)
+	}
 
 	l.ModuleManager.RegisterModule(AuthMiddleware, l.initAuthMiddleware, modules.UserInvisibleModule)
 	l.ModuleManager.RegisterModule(LabelAccess, l.initStoreChunkFilterer)
@@ -60,6 +63,12 @@ func (l *Loki) initAuthMiddleware() (services.Service, error) {
 			log.With(util_log.Logger, "component", "label_access_middleware"),
 		),
 	)
+
+	if l.AuthMiddlewareSetupFn != nil {
+		if err := l.AuthMiddlewareSetupFn(); err != nil {
+			return nil, err
+		}
+	}
 
 	return nil, nil
 }

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -366,6 +366,9 @@ func (c *Config) Validate() error {
 	if err := c.validateNoAuthTenant(); err != nil {
 		errs = append(errs, err)
 	}
+	if err := c.validateLBAC(); err != nil {
+		errs = append(errs, err)
+	}
 
 	errs = append(errs, validateSchemaValues(c)...)
 	errs = append(errs, ValidateConfigCompatibility(*c)...)
@@ -390,6 +393,13 @@ func (c *Config) isTarget(m string) bool {
 func (c *Config) validateNoAuthTenant() error {
 	if !c.AuthEnabled && strings.TrimSpace(c.NoAuthTenant) == "" {
 		return errors.New("CONFIG ERROR: no_auth_tenant cannot be empty when auth_enabled is false")
+	}
+	return nil
+}
+
+func (c *Config) validateLBAC() error {
+	if c.LBAC.Enabled && !c.AuthEnabled {
+		return errors.New("CONFIG ERROR: auth_enabled must be true when lbac.enabled is true")
 	}
 	return nil
 }

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -463,12 +463,14 @@ type Loki struct {
 	ClientMetrics       storage.ClientMetrics
 	deleteClientMetrics *deletion.DeleteRequestClientMetrics
 
-	Tee                distributor.Tee
-	PushParserWrapper  push.RequestParserWrapper
-	HTTPAuthMiddleware middleware.Interface
+	Tee                   distributor.Tee
+	PushParserWrapper     push.RequestParserWrapper
+	HTTPAuthMiddleware    middleware.Interface
+	AuthMiddlewareSetupFn func() error
 
-	Codec   codec.Codec
-	Metrics *server.Metrics
+	Codec        codec.Codec
+	CodecWrapper func(codec.Codec) codec.Codec
+	Metrics      *server.Metrics
 
 	UsageTracker push.UsageTracker
 

--- a/pkg/loki/loki_test.go
+++ b/pkg/loki/loki_test.go
@@ -406,3 +406,55 @@ func TestNoAuthTenantValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestLBACValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		lbacEnabled bool
+		authEnabled bool
+		wantErr     bool
+	}{
+		{
+			name:        "lbac enabled with auth enabled",
+			lbacEnabled: true,
+			authEnabled: true,
+			wantErr:     false,
+		},
+		{
+			name:        "lbac enabled with auth disabled",
+			lbacEnabled: true,
+			authEnabled: false,
+			wantErr:     true,
+		},
+		{
+			name:        "lbac disabled with auth enabled",
+			lbacEnabled: false,
+			authEnabled: true,
+			wantErr:     false,
+		},
+		{
+			name:        "lbac disabled with auth disabled",
+			lbacEnabled: false,
+			authEnabled: false,
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{}
+			f := flag.NewFlagSet("test", flag.PanicOnError)
+			cfg.RegisterFlags(f)
+			cfg.LBAC.Enabled = tt.lbacEnabled
+			cfg.AuthEnabled = tt.authEnabled
+
+			err := cfg.validateLBAC()
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "lbac.enabled")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds two nil-checked injection hooks on the `Loki` struct, applied in `setupLBAC` — pure additive seams with no behaviour change when unset:

- `CodecWrapper func(codec.Codec) codec.Codec` — grouped with `Codec`, applied right after `labelaccess.NewCodec` so a downstream codec stays outermost. Follows the `PushParserWrapper` idiom.
- `AuthMiddlewareSetupFn func() error` — grouped with `HTTPAuthMiddleware`, invoked at the end of `initAuthMiddleware`. Follows the `...Fn` naming convention.

These let a downstream wrapper (Grafana Enterprise Logs) reuse the same `setupLBAC` wiring — codec, module registration, and dependencies — instead of duplicating it, while still layering its own auth-forwarding codec and enterprise auth on top.

It also requires `auth_enabled` when `lbac.enabled` is set: LBAC derives access policies from the authenticated tenant, so it cannot function with `auth_enabled: false`. That combination is now rejected at config validation time, with the resulting startup error documented.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
The hooks are to be consumed by Grafana Enterprise Logs, which will delegate its LBAC setup to `setupLBAC` rather than re-registering the label-access modules itself.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
