### PR TITLE
fix(index-gateway): Correctness fixes for broken indexSet handling + configurable download timeout

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -6854,7 +6854,7 @@ tsdb_shipper:
   [query_ready_num_days: <int> | default = 0]
 
   # Timeout for downloading a table's initial set of index files from object
-  # storage when serving a query.Raise this for tenants with large indexes when
+  # storage when serving a query. Raise this for tenants with large indexes when
   # slow object-storage responses cause downloads to hit the deadline; lower it
   # to fail queries faster when storage is degraded.
   # CLI flag: -tsdb.shipper.download-timeout

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -6853,6 +6853,13 @@ tsdb_shipper:
   # CLI flag: -tsdb.shipper.query-ready-num-days
   [query_ready_num_days: <int> | default = 0]
 
+  # Timeout for downloading a table's initial set of index files from object
+  # storage when serving a query.Raise this for tenants with large indexes when
+  # slow object-storage responses cause downloads to hit the deadline; lower it
+  # to fail queries faster when storage is degraded.
+  # CLI flag: -tsdb.shipper.download-timeout
+  [download_timeout: <duration> | default = 1m]
+
   index_gateway_client:
     # The grpc_client block configures the gRPC client used to communicate
     # between a client and server component in Loki.

--- a/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
@@ -183,6 +183,10 @@ func (t *indexSet) ForEach(ctx context.Context, callback index.ForEachIndexCallb
 	}
 	defer t.indexMtx.rUnlock()
 
+	if t.err != nil {
+		return t.err
+	}
+
 	logger := spanlogger.FromContext(ctx, t.logger)
 	level.Debug(logger).Log("index-files-count", len(t.index))
 
@@ -201,6 +205,10 @@ func (t *indexSet) ForEachConcurrent(ctx context.Context, callback index.ForEach
 		return err
 	}
 	defer t.indexMtx.rUnlock()
+
+	if t.err != nil {
+		return t.err
+	}
 
 	logger := spanlogger.FromContext(ctx, t.logger)
 	level.Debug(logger).Log("index-files-count", len(t.index))

--- a/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/index_set.go
@@ -52,6 +52,7 @@ type indexSet struct {
 	cacheLocation     string
 	logger            log.Logger
 	maxConcurrent     int
+	downloadTimeout   time.Duration
 
 	lastUsedAt time.Time
 	index      map[string]index.Index
@@ -61,7 +62,7 @@ type indexSet struct {
 	cancelFunc context.CancelFunc // helps with cancellation of initialization if we are asked to stop.
 }
 
-func NewIndexSet(tableName, userID, cacheLocation string, baseIndexSet storage.IndexSet, openIndexFileFunc index.OpenIndexFileFunc, logger log.Logger) (IndexSet, error) {
+func NewIndexSet(tableName, userID, cacheLocation string, baseIndexSet storage.IndexSet, openIndexFileFunc index.OpenIndexFileFunc, logger log.Logger, downloadTimeout time.Duration) (IndexSet, error) {
 	if baseIndexSet.IsUserBasedIndexSet() && userID == "" {
 		return nil, fmt.Errorf("userID must not be empty")
 	} else if !baseIndexSet.IsUserBasedIndexSet() && userID != "" {
@@ -83,6 +84,7 @@ func NewIndexSet(tableName, userID, cacheLocation string, baseIndexSet storage.I
 		cacheLocation:     cacheLocation,
 		logger:            logger,
 		maxConcurrent:     maxConcurrent,
+		downloadTimeout:   downloadTimeout,
 		lastUsedAt:        time.Now(),
 		index:             map[string]index.Index{},
 		indexMtx:          newMtxWithReadiness(),
@@ -97,7 +99,7 @@ func (t *indexSet) Init(forQuerying bool, logger log.Logger) (err error) {
 	// Using background context to avoid cancellation of download when request times out.
 	// We would anyways need the files for serving next requests.
 	ctx := context.Background()
-	ctx, t.cancelFunc = context.WithTimeout(ctx, downloadTimeout)
+	ctx, t.cancelFunc = context.WithTimeout(ctx, t.downloadTimeout)
 
 	defer func() {
 		if err != nil {

--- a/pkg/storage/stores/shipper/indexshipper/downloads/index_set_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/index_set_test.go
@@ -2,9 +2,11 @@ package downloads
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -152,4 +154,109 @@ func TestIndexSet_Sync(t *testing.T) {
 
 	// verify that table has got only compacted db
 	checkIndexSet()
+}
+
+func TestIndexSet_ForEach_ErrorPropagation(t *testing.T) {
+	initErr := errors.New("simulated init failure")
+
+	tests := []struct {
+		name         string
+		filesInStore int
+		callInit     bool
+		injectErr    error
+		wantErr      error
+	}{
+		{
+			// Init failed and cleanup successfully emptied t.index — the
+			// original bug shape: parked readers unblock to len(t.index) == 0.
+			name:         "empty index with init error propagates",
+			filesInStore: 0,
+			callInit:     false, // bypass Init to simulate the "post-defer, error set" state
+			injectErr:    initErr,
+			wantErr:      initErr,
+		},
+		{
+			// Init failed, cleanupDB failed (df.Close returned an error) so
+			// t.index still holds surviving orphan entries. Without the fix,
+			// ForEach would iterate them and silently return partial data.
+			name:         "populated index with init error propagates (orphan cleanup)",
+			filesInStore: 3,
+			callInit:     true, // Init populates t.index with 3 files
+			injectErr:    initErr,
+			wantErr:      initErr,
+		},
+		{
+			// Legitimate empty state — no files anywhere, Init succeeded,
+			// t.err stays nil. Regression guard against over-eager propagation.
+			name:         "empty index without error returns nil",
+			filesInStore: 0,
+			callInit:     true,
+			injectErr:    nil,
+			wantErr:      nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			if tc.filesInStore > 0 {
+				setupIndexesAtPath(t, userID, filepath.Join(tempDir, objectsStorageDirName, tableName, userID), 0, tc.filesInStore)
+			}
+
+			storageClient := buildTestStorageClient(t, tempDir)
+			cachePath := filepath.Join(tempDir, cacheDirName)
+			baseIndexSet := storage.NewIndexSet(storageClient, userID != "")
+
+			idxSet, err := NewIndexSet(tableName, userID, filepath.Join(cachePath, tableName, userID), baseIndexSet,
+				func(path string) (index.Index, error) {
+					return openMockIndexFile(t, path), nil
+				}, util_log.Logger)
+			require.NoError(t, err)
+			defer idxSet.Close()
+
+			is := idxSet.(*indexSet)
+
+			if tc.callInit {
+				require.NoError(t, idxSet.Init(false, util_log.Logger))
+			} else {
+				// Bypass Init to simulate the exact post-defer state where
+				// the readiness gate is open but t.err is set and t.index is
+				// empty. Init would normally handle this via its defer at
+				// index_set.go:114 (markReady).
+				is.indexMtx.markReady()
+			}
+
+			if tc.injectErr != nil {
+				is.err = tc.injectErr
+			}
+
+			require.Len(t, is.index, tc.filesInStore, "pre-condition: t.index size")
+
+			// Both entry points must behave identically.
+			for _, forEach := range []struct {
+				name string
+				fn   func(ctx context.Context, cb index.ForEachIndexCallback) error
+			}{
+				{"ForEach", idxSet.ForEach},
+				{"ForEachConcurrent", idxSet.ForEachConcurrent},
+			} {
+				t.Run(forEach.name, func(t *testing.T) {
+					var invocations atomic.Int32
+					err := forEach.fn(context.Background(), func(_ bool, _ index.Index) error {
+						invocations.Add(1)
+						return nil
+					})
+
+					if tc.wantErr != nil {
+						require.ErrorIs(t, err, tc.wantErr, "must propagate t.err")
+						require.Equal(t, int32(0), invocations.Load(), "callback must not fire when the indexSet is broken")
+					} else {
+						require.NoError(t, err)
+						require.Equal(t, int32(tc.filesInStore), invocations.Load(), "callback must fire once per index file")
+					}
+				})
+			}
+		})
+	}
 }

--- a/pkg/storage/stores/shipper/indexshipper/downloads/index_set_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/index_set_test.go
@@ -25,7 +25,7 @@ func buildTestIndexSet(t *testing.T, userID, path string) (*indexSet, stopFunc) 
 	idxSet, err := NewIndexSet(tableName, userID, filepath.Join(cachePath, tableName, userID), baseIndexSet,
 		func(path string) (index.Index, error) {
 			return openMockIndexFile(t, path), nil
-		}, util_log.Logger)
+		}, util_log.Logger, testDownloadTimeout)
 	require.NoError(t, err)
 
 	require.NoError(t, idxSet.Init(false, util_log.Logger))
@@ -211,7 +211,7 @@ func TestIndexSet_ForEach_ErrorPropagation(t *testing.T) {
 			idxSet, err := NewIndexSet(tableName, userID, filepath.Join(cachePath, tableName, userID), baseIndexSet,
 				func(path string) (index.Index, error) {
 					return openMockIndexFile(t, path), nil
-				}, util_log.Logger)
+				}, util_log.Logger, testDownloadTimeout)
 			require.NoError(t, err)
 			defer idxSet.Close()
 

--- a/pkg/storage/stores/shipper/indexshipper/downloads/index_set_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/index_set_test.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/util"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/index"

--- a/pkg/storage/stores/shipper/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table.go
@@ -181,7 +181,18 @@ func (t *table) ForEachConcurrent(ctx context.Context, userID string, callback i
 				return indexSet.Err()
 			}
 
-			return indexSet.ForEachConcurrent(ctx, callback)
+			err = indexSet.ForEachConcurrent(ctx, callback)
+
+			// The pre-check above races with Init's defer: if Init was still in
+			// flight when we checked Err(), we entered ForEachConcurrent with
+			// Err() == nil, parked on the readiness gate, and only saw the
+			// error once Init's defer marked it ready. In that case cleanup
+			// hasn't run yet — do it now so the next caller creates a fresh
+			// indexSet instead of hitting the same broken one.
+			if err != nil && indexSet.Err() != nil {
+				t.cleanupBrokenIndexSet(ctx, uid)
+			}
+			return err
 		})
 	}
 	return g.Wait()
@@ -202,6 +213,12 @@ func (t *table) ForEach(ctx context.Context, userID string, callback index.ForEa
 
 		err = indexSet.ForEach(ctx, callback)
 		if err != nil {
+			// See the comment in ForEachConcurrent above: the pre-check races
+			// with Init's defer, so an error surfaced here may reflect a broken
+			// indexSet that hasn't been cleaned up yet.
+			if indexSet.Err() != nil {
+				t.cleanupBrokenIndexSet(ctx, uid)
+			}
 			return err
 		}
 	}

--- a/pkg/storage/stores/shipper/indexshipper/downloads/table.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table.go
@@ -24,9 +24,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/spanlogger"
 )
 
-// timeout for downloading initial files for a table to avoid leaking resources by allowing it to take all the time.
 const (
-	downloadTimeout        = 1 * time.Minute
 	maxDownloadConcurrency = 50
 )
 
@@ -48,6 +46,7 @@ type table struct {
 	openIndexFileFunc index.OpenIndexFileFunc
 	metrics           *metrics
 	maxConcurrent     int
+	downloadTimeout   time.Duration
 
 	baseUserIndexSet, baseCommonIndexSet storage.IndexSet
 
@@ -58,7 +57,7 @@ type table struct {
 
 // NewTable just creates an instance of table without trying to load files from local storage or object store.
 // It is used for initializing table at query time.
-func NewTable(name, cacheLocation string, storageClient storage.Client, openIndexFileFunc index.OpenIndexFileFunc, metrics *metrics) Table {
+func NewTable(name, cacheLocation string, storageClient storage.Client, openIndexFileFunc index.OpenIndexFileFunc, metrics *metrics, downloadTimeout time.Duration) Table {
 	maxConcurrent := max(runtime.GOMAXPROCS(0)/2, 1)
 	return &table{
 		name:               name,
@@ -70,13 +69,14 @@ func NewTable(name, cacheLocation string, storageClient storage.Client, openInde
 		openIndexFileFunc:  openIndexFileFunc,
 		metrics:            metrics,
 		maxConcurrent:      maxConcurrent,
+		downloadTimeout:    downloadTimeout,
 		indexSets:          map[string]IndexSet{},
 	}
 }
 
 // LoadTable loads a table from local storage(syncs the table too if we have it locally) or downloads it from the shared store.
 // It is used for loading and initializing table at startup. It would initialize index sets which already had files locally.
-func LoadTable(name, cacheLocation string, storageClient storage.Client, openIndexFileFunc index.OpenIndexFileFunc, metrics *metrics) (Table, error) {
+func LoadTable(name, cacheLocation string, storageClient storage.Client, openIndexFileFunc index.OpenIndexFileFunc, metrics *metrics, downloadTimeout time.Duration) (Table, error) {
 	err := util.EnsureDirectory(cacheLocation)
 	if err != nil {
 		return nil, err
@@ -100,6 +100,7 @@ func LoadTable(name, cacheLocation string, storageClient storage.Client, openInd
 		openIndexFileFunc:  openIndexFileFunc,
 		metrics:            metrics,
 		maxConcurrent:      maxConcurrent,
+		downloadTimeout:    downloadTimeout,
 	}
 
 	level.Debug(table.logger).Log("msg", "opening locally present files for table", "table", name, "files", fmt.Sprint(dirEntries))
@@ -113,7 +114,7 @@ func LoadTable(name, cacheLocation string, storageClient storage.Client, openInd
 		userID := entry.Name()
 		logger := loggerWithUserID(table.logger, userID)
 		userIndexSet, err := NewIndexSet(name, userID, filepath.Join(cacheLocation, userID),
-			table.baseUserIndexSet, openIndexFileFunc, logger)
+			table.baseUserIndexSet, openIndexFileFunc, logger, table.downloadTimeout)
 		if err != nil {
 			return nil, err
 		}
@@ -127,7 +128,7 @@ func LoadTable(name, cacheLocation string, storageClient storage.Client, openInd
 	}
 
 	commonIndexSet, err := NewIndexSet(name, "", cacheLocation, table.baseCommonIndexSet,
-		openIndexFileFunc, table.logger)
+		openIndexFileFunc, table.logger, table.downloadTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +328,7 @@ func (t *table) getOrCreateIndexSet(ctx context.Context, id string, forQuerying 
 	}
 
 	// instantiate the index set, add it to the map
-	indexSet, err = NewIndexSet(t.name, id, filepath.Join(t.cacheLocation, id), baseIndexSet, t.openIndexFileFunc, loggerWithUserID(t.logger, id))
+	indexSet, err = NewIndexSet(t.name, id, filepath.Join(t.cacheLocation, id), baseIndexSet, t.openIndexFileFunc, loggerWithUserID(t.logger, id), t.downloadTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go
@@ -67,7 +67,10 @@ type Config struct {
 	SyncInterval      time.Duration
 	CacheTTL          time.Duration
 	QueryReadyNumDays int
-	Limits            Limits
+	// DownloadTimeout bounds how long an indexSet's Init may take to download
+	// its files from object storage.
+	DownloadTimeout time.Duration
+	Limits          Limits
 }
 
 type tableManager struct {
@@ -265,7 +268,7 @@ func (tm *tableManager) getOrCreateTable(tableName string) (Table, error) {
 				return nil, err
 			}
 
-			table = NewTable(tableName, filepath.Join(tm.cfg.CacheDir, tableName), tm.indexStorageClient, tm.openIndexFileFunc, tm.metrics)
+			table = NewTable(tableName, filepath.Join(tm.cfg.CacheDir, tableName), tm.indexStorageClient, tm.openIndexFileFunc, tm.metrics, tm.cfg.DownloadTimeout)
 			tm.tables[tableName] = table
 		}
 	}
@@ -511,7 +514,7 @@ func (tm *tableManager) loadLocalTables() error {
 		level.Info(tm.logger).Log("msg", fmt.Sprintf("loading local table %s", entry.Name()))
 
 		table, err := LoadTable(entry.Name(), filepath.Join(tm.cfg.CacheDir, entry.Name()),
-			tm.indexStorageClient, tm.openIndexFileFunc, tm.metrics)
+			tm.indexStorageClient, tm.openIndexFileFunc, tm.metrics, tm.cfg.DownloadTimeout)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/stores/shipper/indexshipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table_manager_test.go
@@ -41,10 +41,11 @@ func buildTestTableManager(t *testing.T, path string, tableRangeToHandle *config
 	cachePath := filepath.Join(path, cacheDirName)
 
 	cfg := Config{
-		CacheDir:     cachePath,
-		SyncInterval: time.Hour,
-		CacheTTL:     time.Hour,
-		Limits:       &mockLimits{},
+		CacheDir:        cachePath,
+		SyncInterval:    time.Hour,
+		CacheTTL:        time.Hour,
+		DownloadTimeout: 5 * time.Minute,
+		Limits:          &mockLimits{},
 	}
 
 	if tableRangeToHandle == nil {
@@ -135,8 +136,9 @@ func TestTableManager_ensureQueryReadiness(t *testing.T) {
 	}
 
 	cfg := Config{
-		SyncInterval: time.Hour,
-		CacheTTL:     time.Hour,
+		SyncInterval:    time.Hour,
+		CacheTTL:        time.Hour,
+		DownloadTimeout: 5 * time.Minute,
 	}
 
 	tableManager := &tableManager{

--- a/pkg/storage/stores/shipper/indexshipper/downloads/table_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table_test.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	userID    = "user-id"
-	tableName = "test"
+	userID              = "user-id"
+	tableName           = "test"
+	testDownloadTimeout = 5 * time.Minute
 )
 
 // storageClientWithFakeObjectsInList adds a fake object in the list call response which
@@ -66,7 +67,7 @@ func buildTestTable(t *testing.T, path string) (*table, stopFunc) {
 
 	table := NewTable(tableName, cachePath, storageClient, func(path string) (index.Index, error) {
 		return openMockIndexFile(t, path), nil
-	}, newMetrics(nil)).(*table)
+	}, newMetrics(nil), testDownloadTimeout).(*table)
 	_, usersWithIndex, err := table.storageClient.ListFiles(context.Background(), tableName, false)
 	require.NoError(t, err)
 	require.NoError(t, table.EnsureQueryReadiness(context.Background(), usersWithIndex))
@@ -258,7 +259,7 @@ func TestTable_EnsureQueryReadiness(t *testing.T) {
 			cachePath := t.TempDir()
 			table := NewTable(tableName, cachePath, storageClient, func(path string) (index.Index, error) {
 				return openMockIndexFile(t, path), nil
-			}, newMetrics(nil)).(*table)
+			}, newMetrics(nil), testDownloadTimeout).(*table)
 			defer func() {
 				table.Close()
 			}()
@@ -403,7 +404,7 @@ func TestLoadTable(t *testing.T) {
 	// try loading the table.
 	table, err := LoadTable(tableName, tablePathInCache, storageClient, func(path string) (index.Index, error) {
 		return openMockIndexFile(t, path), nil
-	}, newMetrics(nil))
+	}, newMetrics(nil), testDownloadTimeout)
 	require.NoError(t, err)
 	require.NotNil(t, table)
 
@@ -423,7 +424,7 @@ func TestLoadTable(t *testing.T) {
 	// try loading the table, it should skip loading corrupt file and reload it from storage.
 	table, err = LoadTable(tableName, tablePathInCache, storageClient, func(path string) (index.Index, error) {
 		return openMockIndexFile(t, path), nil
-	}, newMetrics(nil))
+	}, newMetrics(nil), testDownloadTimeout)
 	require.NoError(t, err)
 	require.NotNil(t, table)
 

--- a/pkg/storage/stores/shipper/indexshipper/shipper.go
+++ b/pkg/storage/stores/shipper/indexshipper/shipper.go
@@ -74,6 +74,7 @@ type Config struct {
 	CacheTTL                 time.Duration             `yaml:"cache_ttl"`
 	ResyncInterval           time.Duration             `yaml:"resync_interval"`
 	QueryReadyNumDays        int                       `yaml:"query_ready_num_days"`
+	DownloadTimeout          time.Duration             `yaml:"download_timeout"`
 	IndexGatewayClientConfig indexgateway.ClientConfig `yaml:"index_gateway_client"`
 
 	// Temporary experimental feature
@@ -98,12 +99,18 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.DurationVar(&cfg.CacheTTL, prefix+"shipper.cache-ttl", 24*time.Hour, "TTL for index files restored in cache for queries")
 	f.DurationVar(&cfg.ResyncInterval, prefix+"shipper.resync-interval", 5*time.Minute, "Resync downloaded files with the storage")
 	f.IntVar(&cfg.QueryReadyNumDays, prefix+"shipper.query-ready-num-days", 0, "Number of days of common index to be kept downloaded for queries. For per tenant index query readiness, use limits overrides config.")
+	f.DurationVar(&cfg.DownloadTimeout, prefix+"shipper.download-timeout", time.Minute, "Timeout for downloading a table's initial set of index files from object storage when serving a query."+
+		"Raise this for tenants with large indexes when slow object-storage responses cause downloads to hit the deadline; lower it to fail queries faster when storage is degraded.")
 }
 
 func (cfg *Config) Validate() error {
 	// set the default value for mode
 	if cfg.Mode == "" {
 		cfg.Mode = ModeReadWrite
+	}
+
+	if cfg.DownloadTimeout <= 0 {
+		return fmt.Errorf("shipper.download-timeout must be greater than zero, got %s", cfg.DownloadTimeout)
 	}
 
 	return nil
@@ -202,6 +209,7 @@ func (s *indexShipper) init(prefix string, storageClient client.ObjectClient, li
 			SyncInterval:      s.cfg.ResyncInterval,
 			CacheTTL:          s.cfg.CacheTTL,
 			QueryReadyNumDays: s.cfg.QueryReadyNumDays,
+			DownloadTimeout:   s.cfg.DownloadTimeout,
 			Limits:            limits,
 		}
 		downloadsManager, err := downloads.NewTableManager(cfg, s.openIndexFileFunc, indexStorageClient, tenantFilter, tableRangeToHandle, reg, s.logger)

--- a/pkg/storage/stores/shipper/indexshipper/shipper.go
+++ b/pkg/storage/stores/shipper/indexshipper/shipper.go
@@ -99,7 +99,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.DurationVar(&cfg.CacheTTL, prefix+"shipper.cache-ttl", 24*time.Hour, "TTL for index files restored in cache for queries")
 	f.DurationVar(&cfg.ResyncInterval, prefix+"shipper.resync-interval", 5*time.Minute, "Resync downloaded files with the storage")
 	f.IntVar(&cfg.QueryReadyNumDays, prefix+"shipper.query-ready-num-days", 0, "Number of days of common index to be kept downloaded for queries. For per tenant index query readiness, use limits overrides config.")
-	f.DurationVar(&cfg.DownloadTimeout, prefix+"shipper.download-timeout", time.Minute, "Timeout for downloading a table's initial set of index files from object storage when serving a query."+
+	f.DurationVar(&cfg.DownloadTimeout, prefix+"shipper.download-timeout", time.Minute, "Timeout for downloading a table's initial set of index files from object storage when serving a query. "+
 		"Raise this for tenants with large indexes when slow object-storage responses cause downloads to hit the deadline; lower it to fail queries faster when storage is degraded.")
 }
 


### PR DESCRIPTION
**What this PR does / why we need it:**

Fixes a set of correctness bugs in the index-gateway path that could silently return partial query results when a table's initial index-file download from object storage failed or timed out.

While debugging an issue, I found that when a query-time Init failed (typically on ctx-deadline), the failure was not surfaced to callers, i.e., parked readers unblocked into an empty state and quietly returned success with zero data. Downstream, this resulted in an empty response without any visible signs of a problem.

The fix is split into three commits to keep review scoped:

1. Return the error instead of partial results when the `indexSet` is broken

Core correctness fix at `pkg/storage/stores/shipper/indexshipper/downloads/index_set.go`. Both ForEach and ForEachConcurrent now check `t.err` immediately after acquiring the readiness-gated `rLock`, and propagate the error instead of falling through to iterate a possibly-wiped `t.index`.

2. Move the index download timeout to a config to make it configurable

Makes what was a compile-time constant configurable with a default value of 1 minute. The hard-coded 1-minute timeout for large deployments is insufficient, so making it configurable.

3. Clean up the broken `indexSet` when the queries waiting for it notice that it's broken

Closes the race between the pre-check at `table.go:178` and `Init`'s defer setting `t.err`. Before this commit, a reader could pass the pre-check with `Err() == nil` (`Init` still in-flight), park on the readiness gate, unblock when `Init` failed, and get the error from `indexSet.ForEach`, and the broken indexSet would remain in `t.indexSets` poisoning subsequent callers until another reader eventually caught the error on the pre-check path. Now both `ForEach` and `ForEachConcurrent` call `cleanupBrokenIndexSet` when the reader path itself surfaces an error against a still-broken `indexSet`.