### PR TITLE
fix(compaction): Upload logs objects to correct path

### DIFF
--- a/pkg/engine/internal/executor/log_merge.go
+++ b/pkg/engine/internal/executor/log_merge.go
@@ -32,11 +32,12 @@ func (c *Context) executeLogMerge(node *physical.LogMerge) Pipeline {
 	}, nil)
 }
 
-// sourceBucket returns the bucket to read source log objects from. Source
-// objects are stored at the unprefixed dataobj root, so it prefers dataBucket
-// and falls back to bucket when dataBucket is unset (e.g. query-only workers or
-// tests that share a single bucket).
-func (c *Context) sourceBucket() objstore.Bucket {
+// dataObjectBucket returns the bucket for reading source log objects and writing
+// compacted log objects. Both live at the unprefixed dataobj root (the objects/
+// namespace), not under the index-storage prefix that c.bucket carries, so it
+// prefers dataBucket and falls back to bucket when dataBucket is unset (e.g.
+// query-only workers or tests that share a single bucket).
+func (c *Context) dataObjectBucket() objstore.Bucket {
 	if c.dataBucket != nil {
 		return c.dataBucket
 	}
@@ -113,7 +114,7 @@ func (c *Context) doLogObjectMerge(ctx context.Context, node *physical.LogMerge)
 		return fmt.Errorf("flushing index: %w", err)
 	}
 
-	_, err = c.uploadLogObject(ctx, node.OutputIndexPath, idxObj)
+	_, err = c.uploadObject(ctx, c.bucket, node.OutputIndexPath, idxObj)
 	if err != nil {
 		return errors.Join(fmt.Errorf("uploading index %q: %w", node.OutputIndexPath, err), idxCloser.Close())
 	}
@@ -178,10 +179,14 @@ func (c *Context) observeLogMerge(tenant string, stats logMergeObservedStats, du
 }
 
 // logMergeOutputPath derives the deterministic object-storage key for the i-th
-// compacted log object from the node's OutputIndexPath. It stays in the same
-// bucket
+// compacted log object from the node's OutputIndexPath. Compacted logs are data
+// objects, so they live in the objects/ namespace of the unprefixed data bucket
+// alongside ingested source objects — not under the indexes/ namespace where the
+// index object itself is written. Deriving the key from OutputIndexPath keeps it
+// deterministic and unique per merge task.
 func logMergeOutputPath(outputIndexPath string, i int) string {
-	return fmt.Sprintf("%s.compacted-log.%d", outputIndexPath, i)
+	objectPath := "objects/" + strings.TrimPrefix(outputIndexPath, "indexes/")
+	return fmt.Sprintf("%s.compacted-log.%d", objectPath, i)
 }
 
 type logSource struct {
@@ -211,9 +216,7 @@ func (c *Context) collectLogSources(ctx context.Context, node *physical.LogMerge
 			paths = append(paths, sec.ObjectPath)
 		}
 	}
-	// Source log objects live at the unprefixed dataobj root, not under the
-	// index-storage prefix that c.bucket carries, so read them via dataBucket.
-	srcBucket := c.sourceBucket()
+	srcBucket := c.dataObjectBucket()
 
 	// Gather log and streams sections
 	sources := make([]*logSource, 0, len(paths))
@@ -480,7 +483,7 @@ func (w *logObjectWriter) finalizeAndUpload(ctx context.Context) error {
 
 	path := logMergeOutputPath(w.node.OutputIndexPath, w.stats.OutputObjects)
 
-	size, upErr := w.c.uploadLogObject(ctx, path, obj)
+	size, upErr := w.c.uploadObject(ctx, w.c.dataObjectBucket(), path, obj)
 	if upErr != nil {
 		return errors.Join(fmt.Errorf("uploading %q: %w", path, upErr), closer.Close())
 	}
@@ -534,15 +537,17 @@ func logRecordSize(rec logs.Record) int {
 	return size
 }
 
-// uploadLogObject streams a built object to the bucket and returns its encoded size.
-func (c *Context) uploadLogObject(ctx context.Context, path string, obj *dataobj.Object) (int64, error) {
+// uploadObject streams a built object to the given bucket and returns its encoded
+// size. The index object goes to the index bucket; compacted log objects go to
+// the data bucket.
+func (c *Context) uploadObject(ctx context.Context, bucket objstore.Bucket, path string, obj *dataobj.Object) (int64, error) {
 	reader, err := obj.Reader(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("getting object reader: %w", err)
 	}
 	defer reader.Close()
 
-	if err := c.bucket.Upload(ctx, path, reader); err != nil {
+	if err := bucket.Upload(ctx, path, reader); err != nil {
 		return 0, err
 	}
 	return obj.Size(), nil

--- a/pkg/engine/internal/executor/log_merge_test.go
+++ b/pkg/engine/internal/executor/log_merge_test.go
@@ -232,6 +232,71 @@ func TestCollectLogSources_ReadsFromUnprefixedDataBucket(t *testing.T) {
 	require.Equal(t, "objects/09/abcdef", sources[0].path)
 }
 
+// TestDoLogObjectMerge_WritesCompactedLogsToDataBucket reproduces the bug where
+// compacted log objects were written next to the index (through the
+// index-prefixed bucket, under the indexes/ namespace) instead of to the objects/
+// namespace of the unprefixed data bucket. Because a query worker resolves object
+// paths recorded in an index against the unprefixed data bucket, a compacted log
+// written under the index prefix is unreadable at query time. Compacted logs must
+// land in the data bucket under objects/, and the index must reference that path.
+func TestDoLogObjectMerge_WritesCompactedLogsToDataBucket(t *testing.T) {
+	ctx := context.Background()
+
+	const tenant = "T"
+	sortSchema := []string{"label:app"}
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// root is the unprefixed data bucket; indexBucket is the index-prefixed view
+	// the compaction wiring hands the executor for index I/O.
+	root := objstore.NewInMemBucket()
+	indexBucket := objstore.NewPrefixedBucket(root, "dataobj/index/v0")
+
+	buildSourceLogObject(t, root, "objects/09/abcdef", sortSchema, map[string][]testStream{
+		tenant: {{labels: `{app="a"}`, entries: linesAt(base, 3)}},
+	})
+
+	c := newTestExecutorContext(t, indexBucket)
+	c.dataBucket = root
+
+	node := &physical.LogMerge{
+		Tenant:          tenant,
+		SortSchema:      sortSchema,
+		OutputIndexPath: "indexes/tenants/T/ab/cdef",
+		Runs: []*compactionv2pb.RunRef{
+			{Sections: []*compactionv2pb.SectionRef{{ObjectPath: "objects/09/abcdef"}}},
+		},
+	}
+
+	require.NoError(t, c.doLogObjectMerge(ctx, node))
+
+	compactedPath := logMergeOutputPath(node.OutputIndexPath, 0)
+	require.True(t, strings.HasPrefix(compactedPath, "objects/"),
+		"compacted log path must live in the objects/ namespace, got %q", compactedPath)
+	require.False(t, strings.HasPrefix(compactedPath, "indexes/"),
+		"compacted log path must not live in the indexes/ namespace, got %q", compactedPath)
+
+	// The compacted log object lands in the data bucket, alongside source objects.
+	ok, err := root.Exists(ctx, compactedPath)
+	require.NoError(t, err)
+	require.True(t, ok, "compacted log object must be written to the data bucket at %q", compactedPath)
+
+	// It must not leak into the index-prefixed bucket next to the index object.
+	ok, err = indexBucket.Exists(ctx, compactedPath)
+	require.NoError(t, err)
+	require.False(t, ok, "compacted log object must not be written through the index-prefixed bucket")
+
+	// The index object itself is still written to the index bucket.
+	ok, err = indexBucket.Exists(ctx, node.OutputIndexPath)
+	require.NoError(t, err)
+	require.True(t, ok, "index object must be written to the index bucket at OutputIndexPath")
+
+	// The index references the compacted log by its data-bucket path, so a query
+	// worker resolving that path against the unprefixed data bucket finds it.
+	_, postingsPaths := collectIndexSections(ctx, t, indexBucket, node)
+	require.Equal(t, map[string]bool{compactedPath: true}, postingsPaths,
+		"index postings must reference the compacted log's data-bucket path")
+}
+
 // newSmallObjectExecutorContext is like newTestExecutorContext but with a tiny
 // TargetObjectSize so the merge splits its output across multiple objects.
 func newSmallObjectExecutorContext(t *testing.T, bucket objstore.Bucket) *Context {


### PR DESCRIPTION
**What this PR does / why we need it**:

Compacted logs are currently uploaded to `dataobj/index/v0/indexes/tenant/TENANT_ID/aa/bbbb.compacted-log.c` but must be uploaded to `dataobj/objects/tenant/TENANT_ID/aa/bbbb.compacted-log.c` (otherwise the read path can't find them as it reads from `dataobj/objects`. I'm coupling the logs object path with index object path which is bad but works temporary given that we want to get rid of these paths anyway.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
