### PR TITLE
fix(logql): Extract renamed logfmt labels when grouping by them in metric queries

### DIFF
--- a/pkg/logql/log/parser.go
+++ b/pkg/logql/log/parser.go
@@ -542,8 +542,13 @@ func (l *LogfmtExpressionParser) Process(_ int64, line []byte, lbs *LabelsBuilde
 	// Create a map of every renamed label and its original name
 	// in order to retrieve it later in the extraction phase
 	keys := make(map[string]string, len(l.expressions))
+	// sources holds the original logfmt keys read from the line so they can be
+	// remapped to their expression identifiers below.
+	sources := make(map[string]struct{}, len(l.expressions))
 	for id, paths := range l.expressions {
-		keys[id] = fmt.Sprintf("%v", paths...)
+		orig := fmt.Sprintf("%v", paths...)
+		keys[id] = orig
+		sources[orig] = struct{}{}
 		if !lbs.BaseHas(id) && !lbs.HasInCategory(id, StructuredMetadataLabel) {
 			lbs.Set(ParsedLabel, id, "")
 		}
@@ -552,8 +557,9 @@ func (l *LogfmtExpressionParser) Process(_ int64, line []byte, lbs *LabelsBuilde
 	// alwaysExtract checks whether a key should be extracted regardless of other
 	// conditions.
 	alwaysExtract := func(key string) bool {
-		// Any key in the expression list should always be extracted.
-		_, ok := keys[key]
+		// Keys read from the line are expression sources; they must always be
+		// extracted so renamed labels survive the parser hint gate.
+		_, ok := sources[key]
 		return ok
 	}
 

--- a/pkg/logql/log/parser_test.go
+++ b/pkg/logql/log/parser_test.go
@@ -1759,6 +1759,50 @@ func TestLogfmtExpressionParser(t *testing.T) {
 	}
 }
 
+func TestLogfmtExpressionParser_RenamedLabelWithGroupingHints(t *testing.T) {
+	// Reproduces metric queries that group by a renamed logfmt label, e.g.
+	// sum by (ip) (count_over_time({app="foo"} | logfmt ip=remote_addr [5m])).
+	// Grouping adds parser hints that only require the renamed identifier, so
+	// the parser must still read the original source key to remap it.
+	tests := []struct {
+		name        string
+		line        []byte
+		expressions []LabelExtractionExpr
+		groups      []string
+		want        labels.Labels
+	}{
+		{
+			name:        "renamed source is the first field",
+			line:        []byte(`remote_addr=1.2.3.4 status=200`),
+			expressions: []LabelExtractionExpr{NewLabelExtractionExpr("ip", "remote_addr")},
+			groups:      []string{"ip"},
+			want:        labels.FromStrings("ip", "1.2.3.4"),
+		},
+		{
+			name:        "renamed source follows a non-required field",
+			line:        []byte(`status=200 remote_addr=1.2.3.4`),
+			expressions: []LabelExtractionExpr{NewLabelExtractionExpr("ip", "remote_addr")},
+			groups:      []string{"ip"},
+			want:        labels.FromStrings("ip", "1.2.3.4"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l, err := NewLogfmtExpressionParser(tt.expressions, false)
+			require.NoError(t, err)
+
+			hints := NewParserHint(nil, tt.groups, false, false, "", nil)
+			b := NewBaseLabelsBuilderWithGrouping(tt.groups, hints, false, false).
+				ForLabels(labels.EmptyLabels(), 0)
+			b.Reset()
+
+			_, _ = l.Process(0, tt.line, b)
+			require.Equal(t, tt.want, b.LabelsResult().Labels())
+		})
+	}
+}
+
 func TestXExpressionParserFailures(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
**What this PR does / why we need it**:

Metric queries that group by a renamed logfmt label were returning an empty value for that label. For example, `sum by (ip) (count_over_time({app="x"} | logfmt ip=remote_addr [5m]))` gave `ip=""` on every log line instead of the real `remote_addr` values, so all series collapsed into one empty group.

The `LogfmtExpressionParser` keeps a map of each expression's identifier to its source key, and while scanning a line it decides whether to extract a key via `alwaysExtract`. That check looked the key up in the identifier map, but the keys read from a log line are the source names, not the identifiers. So for a renaming expression like `logfmt ip=remote_addr`, the source key `remote_addr` failed the check and got dropped by the parser hint gate before it could be renamed to `ip`.

Only metric queries hit this, because the hints that limit extraction come from the `by (...)` grouping. Instant and log queries have no hints, so the gate never runs for them, and non-renaming expressions work because the identifier and source are the same. That's why it went unnoticed.

The fix keeps a separate set of the source keys and checks against that, so a renamed label's source key passes the gate and gets renamed as expected. Nothing changes for the no-hints or non-renaming paths.

**Which issue(s) this PR fixes**:

No existing issue. Found while reading through the logfmt expression parser.

**Special notes for your reviewer**:

Added `TestLogfmtExpressionParser_RenamedLabelWithGroupingHints`, which covers the renamed source appearing first and appearing after another field. It fails before the change and passes after. `pkg/logql/log`, the wider `pkg/logql/...` packages, and `go vet` all pass.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.
