### PR TITLE
Fix/pattern tee tenant configs nil

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -851,7 +851,7 @@ func (t *Loki) setupModuleManager() error {
 		BloomBuilder:                 {Server, BloomStore, Analytics, Store, UIRing},
 		BloomStore:                   {IndexGatewayRing, BloomGatewayClient},
 		PatternRingClient:            {Server, MemberlistKV, Analytics},
-		PatternIngesterTee:           {Server, Overrides, MemberlistKV, Analytics, PatternRingClient},
+		PatternIngesterTee:           {Server, Overrides, MemberlistKV, Analytics, PatternRingClient, TenantConfigs},
 		PatternIngester:              {Server, MemberlistKV, Analytics, PatternRingClient, PatternIngesterTee, Overrides, UIRing},
 		IngesterQuerier:              {Ring, PartitionRing, Overrides},
 		QuerySchedulerRing:           {Overrides, MemberlistKV},

--- a/pkg/pattern/tee_service.go
+++ b/pkg/pattern/tee_service.go
@@ -374,7 +374,7 @@ func (ts *TeeService) sendBatch(ctx context.Context, clientRequest clientRequest
 
 					// this is basically the same as logging push request streams,
 					// so put it behind the same flag
-					if ts.tenantCfgs.LogPushRequestStreams(clientRequest.tenant) {
+					if ts.tenantCfgs != nil && ts.tenantCfgs.LogPushRequestStreams(clientRequest.tenant) {
 						level.Debug(ts.logger).
 							Log(
 								"msg", "forwarded push request to pattern ingester",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR resolves an intermittent `SIGSEGV` nil-pointer panic in the distributor caused by a race condition during module initialization in the pattern-ingester tee path.

Previously, `PatternIngesterTee` did not list `TenantConfigs` as a dependency in the module manager. Depending on the non-deterministic initialization order, `ts.tenantCfgs` could be `nil` when the async `batchSender` goroutine attempted to call `ts.tenantCfgs.LogPushRequestStreams()`, crashing the distributor pod.

This PR introduces two fixes:
1. **Root Cause Fix:** Adds `TenantConfigs` to the `PatternIngesterTee` dependency list in `setupModuleManager` (`pkg/loki/loki.go`) to guarantee it is initialized before the tee is built.
2. **Defense in Depth:** Adds a defensive nil-guard in `TeeService` (`pkg/pattern/tee_service.go`) before dereferencing the pointer.

**Which issue(s) this PR fixes**:
Fixes #23076

**Special notes for your reviewer**:
* Added a regression test (`TestPatternTee_NilTenantConfigs`) to isolate and verify the defensive nil-guard in `TeeService` directly.
* Verified that adding this dependency does not introduce circular dependencies (both `TenantConfigs` and `Overrides` depend only on `RuntimeConfig`).

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)