### PR TITLE
fix: return all tenant limits by default from limits API

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -41,6 +41,12 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 The `row_shards` setting on a `schema_config` `period_config` has been removed. It configured a static query shard factor for legacy (non-TSDB) index types. TSDB, the only supported index type, resolves log and metric query sharding dynamically from index statistics and ignores `row_shards`; series queries continue to use the previous default factor of 16. Because schema config is parsed strictly, a leftover `row_shards:` key now fails config load. Remove the `row_shards` setting from every `period_config`; the `deprecated-config-checker` tool will flag it.
 
+### Tenant limits endpoint returns all fields by default
+
+The default value of `tenant_limits_allow_publish` (`-limits.tenant-limits-allow-publish`) is now empty, so `/config/tenant/v1/limits` and `/loki/api/v1/drilldown-limits` return the full effective per-tenant limits (including runtime overrides such as `ingestion_rate_mb`).
+
+Previously only a small allowlist of fields was published by default, which made the response look incomplete. To restore the previous restricted set of fields, set `tenant_limits_allow_publish` explicitly.
+
 ### TSDB schema v14
 
 Loki now supports the experimental TSDB storage schema `v14`. Schema v14 uses the

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -2156,7 +2156,7 @@ ingest_limits_frontend_client:
 # fields are returned. Use YAML field names (e.g., 'retention_period',
 # 'max_query_series').
 # CLI flag: -limits.tenant-limits-allow-publish
-[tenant_limits_allow_publish: <list of strings> | default = [discover_log_levels discover_service_name log_level_fields max_entries_limit_per_query max_line_size_truncate max_query_bytes_read max_query_length max_query_lookback max_query_range max_query_series metric_aggregation_enabled otlp_config pattern_persistence_enabled query_timeout retention_period retention_stream volume_enabled volume_max_series]]
+[tenant_limits_allow_publish: <list of strings> | default = []]
 
 # Common configuration to be shared between multiple modules. If a more specific
 # configuration is given in other sections, the related configuration within

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -134,7 +134,8 @@ type Config struct {
 	Profiling         ProfilingConfig      `yaml:"profiling,omitempty"`
 
 	// TenantLimitsAllowPublish specifies which limit fields to return from the tenant limits endpoint.
-	// If empty, all fields are returned. This allows filtering of sensitive or unwanted configuration.
+	// If empty (the default), all fields are returned, including runtime overrides.
+	// Operators can set this to filter sensitive or unwanted configuration.
 	TenantLimitsAllowPublish []string `yaml:"tenant_limits_allow_publish" json:"tenant_limits_allowlist_fields"`
 
 	Common common.Config `yaml:"common,omitempty"`
@@ -178,26 +179,10 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 
 	f.StringVar(&c.MetricsNamespace, "metrics-namespace", constants.Loki, "Namespace of the metrics that in previous releases had cortex as namespace. This setting is deprecated and will be removed in the next minor release.")
 
-	c.TenantLimitsAllowPublish = []string{
-		"discover_log_levels",
-		"discover_service_name",
-		"log_level_fields",
-		"max_entries_limit_per_query",
-		"max_line_size_truncate",
-		"max_query_bytes_read",
-		"max_query_length",
-		"max_query_lookback",
-		"max_query_range",
-		"max_query_series",
-		"metric_aggregation_enabled",
-		"otlp_config",
-		"pattern_persistence_enabled",
-		"query_timeout",
-		"retention_period",
-		"retention_stream",
-		"volume_enabled",
-		"volume_max_series",
-	}
+	// Empty by default so /config/tenant/v1/limits returns the full effective per-tenant
+	// limits (including runtime overrides such as ingestion_rate_mb). Operators can
+	// restrict the published fields via -limits.tenant-limits-allow-publish.
+	c.TenantLimitsAllowPublish = nil
 	f.Var(
 		(*flagext.StringSlice)(&c.TenantLimitsAllowPublish),
 		"limits.tenant-limits-allow-publish",

--- a/pkg/loki/tenant_limits_handler_test.go
+++ b/pkg/loki/tenant_limits_handler_test.go
@@ -140,3 +140,48 @@ func TestTenantLimitsHandlerWithAllowlist(t *testing.T) {
 		})
 	}
 }
+
+// TestTenantLimitsHandlerDefaultAllowPublishReturnsAllFields verifies that with
+// the default (empty) tenant_limits_allow_publish setting, the tenant limits
+// endpoint returns runtime override fields such as ingestion_rate_mb.
+// Regression for https://github.com/grafana/loki/issues/22426.
+func TestTenantLimitsHandlerDefaultAllowPublishReturnsAllFields(t *testing.T) {
+	limits := &validation.Limits{
+		IngestionRateMB:        120.0,
+		IngestionBurstSizeMB:   140.0,
+		MaxQuerySeries:         1000,
+		MaxLocalStreamsPerUser: 500,
+		RejectOldSamples:       true,
+	}
+
+	// Zero-value Config matches the RegisterFlags default (empty allowlist).
+	loki := &Loki{
+		TenantLimits: &mockTenantLimits{limits: limits},
+		Cfg:          Config{},
+	}
+	require.Empty(t, loki.Cfg.TenantLimitsAllowPublish)
+
+	req := httptest.NewRequest("GET", "/config/tenant/v1/limits", nil)
+	req.Header.Set("X-Scope-OrgID", "foo")
+
+	w := httptest.NewRecorder()
+	loki.tenantLimitsHandler(false)(w, req)
+
+	resp := w.Result()
+	require.Equal(t, 200, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var response map[string]any
+	require.NoError(t, yaml.Unmarshal(body, &response))
+
+	// Runtime override fields that were previously missing from the default allowlist.
+	assert.Contains(t, response, "ingestion_rate_mb")
+	assert.Equal(t, 120, response["ingestion_rate_mb"])
+	assert.Contains(t, response, "ingestion_burst_size_mb")
+	assert.Equal(t, 140, response["ingestion_burst_size_mb"])
+	assert.Contains(t, response, "max_streams_per_user")
+	assert.Contains(t, response, "reject_old_samples")
+	assert.Contains(t, response, "max_query_series")
+}


### PR DESCRIPTION
## What this PR does

`GET /config/tenant/v1/limits` was only returning a small subset of limit fields. With a runtime override like:

```yaml
overrides:
  foo:
    ingestion_rate_mb: 120
```

the response never included `ingestion_rate_mb` (or most other ingestion/stream limits).

Root cause: `tenant_limits_allow_publish` defaulted to a short allowlist originally added for Logs Drilldown. Anything outside that list was filtered out.

## Fix

- Default `tenant_limits_allow_publish` to empty → all effective per-tenant limits are published
- Operators who want the old restricted set can still set the flag/config explicitly
- Docs + upgrade note updated

## Test plan

- [x] `go test ./pkg/loki/ -run 'TestTenantLimits|TestDrilldown|TestFilterLimit|TestConfig'`
- [x] New regression test asserts default config returns `ingestion_rate_mb` / related override fields

Fixes #22426