### PR TITLE
fix(dataobj-compaction): Treat touching section bounds as one run 🤖🤖🤖

### DIFF
--- a/pkg/dataobj/compaction/v2/calculator.go
+++ b/pkg/dataobj/compaction/v2/calculator.go
@@ -8,7 +8,7 @@ import (
 	compactionv2pb "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2/proto"
 )
 
-// run is one non-overlapping run of sections.
+// run is the concrete [Run] built by calculateRuns.
 //
 // topMaxKey + topMaxTimestamp hold the most recent appended section's upper
 // bound -- the composite (labels, timestamp) sort key.
@@ -38,14 +38,8 @@ func cmpSortKey(aLabels []string, aTs int64, bLabels []string, bTs int64) int {
 	return cmp.Compare(aTs, bTs)
 }
 
-// calculateRuns sorts the provided [sections] in place and returns a set of
-// runs in creation order. A "run" is a sorted sequence of sections whose
-// ([MinKey, MinTimestamp], [MaxKey, MaxTimestamp]) bounds are pairwise
-// non-overlapping in sort-key space.
-//
-// The input slice is sorted in place; callers that need the original order must
-// copy beforehand. The contract requires non-nil SectionRef entries; nil
-// entries will panic.
+// calculateRuns sorts sections in place and returns the [Run]s in creation
+// order. Panics on a nil entry.
 func calculateRuns(sections []*compactionv2pb.SectionRef) []*run {
 	if len(sections) == 0 {
 		return nil
@@ -71,11 +65,12 @@ func calculateRuns(sections []*compactionv2pb.SectionRef) []*run {
 	// runs in creation order; this is what we return.
 	runs := make([]*run, 0)
 
-	// Iterate sorted sections and append to the existing run whose top_max_key is
-	// the largest value strictly less than the section's MinKey; if no such run
-	// exists, start a new one. Among runs tied on top_max_key, the OLDEST run
-	// (first seen) wins. Below is a demonstration of how this algorithm allows us
-	// to generate runs and make compaction decisions.
+	// Iterate sorted sections and append each to the existing run whose
+	// top_max_key is the largest value <= the section's MinKey (best-fit);
+	// touching bounds (equal) keep the section in that run. Start a new run when
+	// none is eligible. Among runs tied on top_max_key, the OLDEST run (first
+	// seen) wins. Below is a demonstration of how this algorithm allows us to
+	// generate runs and make compaction decisions.
 	//
 	// L0 sections come from the consumer/ingester. They are sorted by
 	// __timestamp__ (ingestion order), NOT by service_name, so services
@@ -92,14 +87,14 @@ func calculateRuns(sections []*compactionv2pb.SectionRef) []*run {
 	//	 MaxKey = ["cart", T3]              MaxKey = ["cart", T6]              MaxKey = ["billing", T9]
 	//
 	// calculateRuns walks them in sorted order, looking for the run with the
-	// largest top_max_key strictly less than the section's MinKey (best-fit).
+	// largest top_max_key less than or equal to the section's MinKey (best-fit).
 	// Tuple compare proceeds element-wise; column 0 (service_name) dominates
 	// for every comparison below.
 	//   - A0 -> no runs exist -> new run #0 (top_max_key = ["cart", T3])
-	//   - B0 -> need top_max_key < ["auth", T5]. Run 0's top is ["cart", T3];
+	//   - B0 -> need top_max_key <= ["auth", T5]. Run 0's top is ["cart", T3];
 	//     compare column 0: "cart" > "auth". Not eligible -> new run #1
 	//     (top_max_key = ["cart", T6])
-	//   - C0 -> need top_max_key < ["auth", T7]. Both existing runs have
+	//   - C0 -> need top_max_key <= ["auth", T7]. Both existing runs have
 	//     ["cart", ...] tops, all > ["auth", ...] at column 0. Not eligible ->
 	//     new run #2 (top_max_key = ["billing", T9])
 	//
@@ -127,7 +122,7 @@ func calculateRuns(sections []*compactionv2pb.SectionRef) []*run {
 	for _, s := range sections {
 		var best *run
 		for _, r := range runs {
-			if cmpSortKey(r.topMaxKey, r.topMaxTimestamp, s.MinKey, s.MinTimestamp) < 0 {
+			if cmpSortKey(r.topMaxKey, r.topMaxTimestamp, s.MinKey, s.MinTimestamp) <= 0 {
 				if best == nil || cmpSortKey(r.topMaxKey, r.topMaxTimestamp, best.topMaxKey, best.topMaxTimestamp) > 0 {
 					best = r
 				}

--- a/pkg/dataobj/compaction/v2/calculator_test.go
+++ b/pkg/dataobj/compaction/v2/calculator_test.go
@@ -1,6 +1,7 @@
 package compactionv2
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 
@@ -96,27 +97,25 @@ func TestPatienceSort_BestFit(t *testing.T) {
 }
 
 func TestPatienceSort_TiebreakerOnCreationOrder(t *testing.T) {
-	// Two piles will both end up with topMaxKey == "10":
-	//   s1 = ("00","10") — creates pile0
-	//   s2 = ("05","11") — overlaps s1 (MinKey "05" < pile0 topMaxKey "10"); creates pile1
-	//   s3 = ("06","10") — overlaps both ("06" < both "10"); creates pile2
-	// pile0 topMaxKey=10, pile1 topMaxKey=11, pile2 topMaxKey=10
-	//   s4 = ("11","20") — eligible for pile0 (topMaxKey "10" < "11") AND pile2 (topMaxKey "10" < "11").
-	//   pile1 topMaxKey "11" is NOT < "11"; not eligible.
-	//   Tiebreak: pick the OLDEST eligible pile -> pile0 (slice index 0).
+	// Build two piles that both end with topMaxKey == "10", then feed a section
+	// whose MinKey ("20") is strictly greater than "10", so both piles are
+	// unambiguously eligible regardless of the touching rule. Best-fit ties on
+	// topMaxKey, so the OLDEST pile (lowest slice index) must win.
+	//   s1 = ("00","10") — creates pile0 (topMaxKey "10")
+	//   s2 = ("05","10") — overlaps s1 (pile0 topMaxKey "10" is not <= "05"),
+	//                      so it creates pile1 (topMaxKey "10")
+	//   s3 = ("20","30") — eligible for pile0 and pile1 (both topMaxKey "10" <=
+	//                      "20"); tie on topMaxKey -> append to the oldest, pile0.
 	s1 := sec("o", 0, "00", "10")
-	s2 := sec("o", 1, "05", "11")
-	s3 := sec("o", 2, "06", "10")
-	s4 := sec("o", 3, "11", "20")
+	s2 := sec("o", 1, "05", "10")
+	s3 := sec("o", 2, "20", "30")
 
-	got := calculateRuns([]*compactionv2pb.SectionRef{s1, s2, s3, s4})
+	got := calculateRuns([]*compactionv2pb.SectionRef{s1, s2, s3})
 
-	require.Len(t, got, 3)
-	// pile0 (slice index 0, the oldest) should have received s4.
-	require.Equal(t, []*compactionv2pb.SectionRef{s1, s4}, got[0].sections,
+	require.Len(t, got, 2)
+	require.Equal(t, []*compactionv2pb.SectionRef{s1, s3}, got[0].sections,
 		"among piles with equal topMaxKey, append to the OLDEST")
-	// pile2 unchanged.
-	require.Equal(t, []*compactionv2pb.SectionRef{s3}, got[2].sections,
+	require.Equal(t, []*compactionv2pb.SectionRef{s2}, got[1].sections,
 		"newer pile is NOT chosen on tie")
 }
 
@@ -279,10 +278,9 @@ func secTS(path string, idx int64, minKey, maxKey []string, minTs, maxTs int64) 
 }
 
 // TestCalculateRuns_Timestamp_NonOverlap demonstrates that when two sections
-// share the same label tuple but have non-overlapping time slices, they
-// correctly pack into a single run. Without including the timestamp
-// component in the comparison, the algorithm would see equal label tuples
-// at the boundary (a.MaxKey == b.MinKey) and conclude they overlap.
+// share the same label tuple but have non-overlapping time slices, they order
+// by timestamp and pack into a single run. The timestamp component of the
+// composite key is what gives same-label sections a well-defined order.
 func TestCalculateRuns_Timestamp_NonOverlap(t *testing.T) {
 	// a: labels=["api"], ts=[100..200]
 	// b: labels=["api"], ts=[300..400]
@@ -338,43 +336,125 @@ func TestCalculateRuns_Timestamp_NumericOrder(t *testing.T) {
 		"timestamps must compare numerically: ts=9 < ts=10")
 }
 
-func TestCalculateRuns_CompositeKey_SameTupleTimeOverlapSplits(t *testing.T) {
-	sections := []*compactionv2pb.SectionRef{
-		secTS("log-0", 0, []string{"auth"}, []string{"auth"}, 10, 30),
-		secTS("log-1", 0, []string{"auth"}, []string{"auth"}, 20, 40),
+// TestCalculateRuns_RunGrouping checks that touching sections form one run and
+// overlapping sections split.
+func TestCalculateRuns_RunGrouping(t *testing.T) {
+	tests := []struct {
+		name     string
+		sections []*compactionv2pb.SectionRef
+		wantRuns int
+	}{
+		{
+			name:     "touching single-column key",
+			sections: []*compactionv2pb.SectionRef{sec("o", 1, "m", "z"), sec("o", 0, "a", "m")},
+			wantRuns: 1,
+		},
+		{
+			name:     "overlapping single-column key splits",
+			sections: []*compactionv2pb.SectionRef{sec("o", 0, "a", "m"), sec("o", 1, "k", "z")},
+			wantRuns: 2,
+		},
+		{
+			name: "touching timestamps, same label",
+			sections: []*compactionv2pb.SectionRef{
+				secTS("o", 1, []string{"api"}, []string{"api"}, 200, 300),
+				secTS("o", 0, []string{"api"}, []string{"api"}, 100, 200),
+			},
+			wantRuns: 1,
+		},
+		{
+			name: "disjoint timestamps, same label",
+			sections: []*compactionv2pb.SectionRef{
+				secTS("o", 0, []string{"auth"}, []string{"auth"}, 10, 20),
+				secTS("o", 1, []string{"auth"}, []string{"auth"}, 30, 40),
+			},
+			wantRuns: 1,
+		},
+		{
+			name: "overlapping timestamps, same label splits",
+			sections: []*compactionv2pb.SectionRef{
+				secTS("o", 0, []string{"auth"}, []string{"auth"}, 10, 30),
+				secTS("o", 1, []string{"auth"}, []string{"auth"}, 20, 40),
+			},
+			wantRuns: 2,
+		},
+		{
+			name: "touching multi-column tuple",
+			sections: []*compactionv2pb.SectionRef{
+				secT("o", 1, []string{"auth", "us"}, []string{"billing", "eu"}),
+				secT("o", 0, []string{"auth", "eu"}, []string{"auth", "us"}),
+			},
+			wantRuns: 1,
+		},
+		{
+			name: "touching full composite key",
+			sections: []*compactionv2pb.SectionRef{
+				secTS("o", 1, []string{"auth", "eu"}, []string{"auth", "eu"}, 40, 70),
+				secTS("o", 0, []string{"auth", "eu"}, []string{"auth", "eu"}, 10, 40),
+			},
+			wantRuns: 1,
+		},
+		{
+			name: "distinct multi-label tuples chain",
+			sections: []*compactionv2pb.SectionRef{
+				secTS("o", 0, []string{"auth", "eu"}, []string{"auth", "eu"}, 10, 40),
+				secTS("o", 1, []string{"auth", "us"}, []string{"auth", "us"}, 20, 50),
+				secTS("o", 2, []string{"billing", "eu"}, []string{"billing", "eu"}, 15, 45),
+			},
+			wantRuns: 1,
+		},
+		{
+			name: "equal first key, second key disambiguates",
+			sections: []*compactionv2pb.SectionRef{
+				secTS("o", 0, []string{"auth", "eu"}, []string{"auth", "eu"}, 10, 40),
+				secTS("o", 1, []string{"auth", "us"}, []string{"auth", "us"}, 10, 40),
+			},
+			wantRuns: 1,
+		},
+		{
+			name: "identical multi-label tuple, overlapping times splits",
+			sections: []*compactionv2pb.SectionRef{
+				secTS("o", 0, []string{"auth", "eu"}, []string{"auth", "eu"}, 10, 30),
+				secTS("o", 1, []string{"auth", "eu"}, []string{"auth", "eu"}, 20, 40),
+			},
+			wantRuns: 2,
+		},
 	}
-	require.Len(t, calculateRuns(sections), 2, "overlapping times, same tuple: two runs")
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Len(t, calculateRuns(tc.sections), tc.wantRuns)
+		})
+	}
 }
 
-func TestCalculateRuns_CompositeKey_SameTupleTimeDisjointChains(t *testing.T) {
-	sections := []*compactionv2pb.SectionRef{
-		secTS("log-0", 0, []string{"auth"}, []string{"auth"}, 10, 20),
-		secTS("log-1", 0, []string{"auth"}, []string{"auth"}, 30, 40),
-	}
-	require.Len(t, calculateRuns(sections), 1, "disjoint ordered times, same tuple: one run")
-}
+func runKey(v int) string { return fmt.Sprintf("%03d", v) }
 
-func TestCalculateRuns_CompositeKey_MultiLabelDistinctTuplesChain(t *testing.T) {
-	sections := []*compactionv2pb.SectionRef{
-		secTS("log-0", 0, []string{"auth", "eu"}, []string{"auth", "eu"}, 10, 40),
-		secTS("log-1", 0, []string{"auth", "us"}, []string{"auth", "us"}, 20, 50),
-		secTS("log-2", 0, []string{"billing", "eu"}, []string{"billing", "eu"}, 15, 45),
-	}
-	require.Len(t, calculateRuns(sections), 1, "distinct multi-label tuples chain into one run")
-}
+// TestCalculateRuns_ValidRunSurvivesArbitrarySectionCuts checks that cutting one
+// sorted run into many sections still yields exactly one run.
+func TestCalculateRuns_ValidRunSurvivesArbitrarySectionCuts(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+	for trial := 0; trial < 50; trial++ {
+		// Cut one sorted run into n sections; neighbours share a boundary key,
+		// and a zero-width step makes a single-key section.
+		n := 2 + r.Intn(12)
+		bounds := make([]int, n+1)
+		bounds[0] = r.Intn(3)
+		for i := 1; i <= n; i++ {
+			bounds[i] = bounds[i-1] + r.Intn(3)
+		}
 
-func TestCalculateRuns_CompositeKey_MultiLabelSecondKeyDisambiguates(t *testing.T) {
-	sections := []*compactionv2pb.SectionRef{
-		secTS("log-0", 0, []string{"auth", "eu"}, []string{"auth", "eu"}, 10, 40),
-		secTS("log-1", 0, []string{"auth", "us"}, []string{"auth", "us"}, 10, 40),
-	}
-	require.Len(t, calculateRuns(sections), 1, "second sort key disambiguates equal first keys")
-}
+		sections := make([]*compactionv2pb.SectionRef, n)
+		for i := 0; i < n; i++ {
+			sections[i] = sec("o", int64(i), runKey(bounds[i]), runKey(bounds[i+1]))
+		}
 
-func TestCalculateRuns_CompositeKey_MultiLabelSameTupleTimeOverlapSplits(t *testing.T) {
-	sections := []*compactionv2pb.SectionRef{
-		secTS("log-0", 0, []string{"auth", "eu"}, []string{"auth", "eu"}, 10, 30),
-		secTS("log-1", 0, []string{"auth", "eu"}, []string{"auth", "eu"}, 20, 40),
+		// Run formation must be independent of input order.
+		shuffled := append([]*compactionv2pb.SectionRef(nil), sections...)
+		r.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+
+		got := calculateRuns(shuffled)
+		require.Lenf(t, got, 1, "trial %d: a cut-up valid run must re-derive as one run (bounds=%v)", trial, bounds)
+		require.Equalf(t, sections, got[0].sections, "trial %d: sections must come back in sorted order", trial)
 	}
-	require.Len(t, calculateRuns(sections), 2, "identical multi-label tuple, overlapping times: two runs")
 }

--- a/pkg/dataobj/compaction/v2/doc.go
+++ b/pkg/dataobj/compaction/v2/doc.go
@@ -1,6 +1,5 @@
 // Package compactionv2 implements a sorted run-based compaction planner.
 //
-// Given a set of sections with (min_key, max_key, stable_id) sort-key bounds, Plan
-// produces a deterministic list of sorted piles (runs of non-overlapping
-// sections) and groups them into ⌈P/K⌉ task batches for downstream K-way merges.
+// [CalculateRuns] groups a set of sections into sorted [Run]s and [Plan]
+// batches those runs into ceil(P/K) tasks for downstream K-way merges.
 package compactionv2

--- a/pkg/dataobj/compaction/v2/plan.go
+++ b/pkg/dataobj/compaction/v2/plan.go
@@ -6,7 +6,11 @@ import (
 	compactionv2pb "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2/proto"
 )
 
-// Run is one non-overlapping layer of sections over the sort key.
+// Run is a sorted sequence of sections that a K-way merge consumes as one input.
+//
+// Section bounds are inclusive [min, max]. Within a run each section's max is <=
+// the next's min, so touching sections (max == min) stay in one run and
+// overlapping sections (max > min) split.
 type Run interface {
 	// Sections returns the run's sections in sorted order.
 	Sections() []*compactionv2pb.SectionRef
@@ -14,7 +18,8 @@ type Run interface {
 	Size() uint64
 }
 
-// CalculateRuns sorts [sections] in place and returns the resulting runs.
+// CalculateRuns sorts the provided sections in place and groups them into the
+// fewest [Run]s. The result is deterministic for a given input.
 func CalculateRuns(sections []*compactionv2pb.SectionRef) []Run {
 	calculated := calculateRuns(sections)
 	runs := make([]Run, len(calculated))
@@ -37,7 +42,7 @@ func IsTerminal(runs []Run, minCompactionSize uint64) bool {
 	return total < minCompactionSize
 }
 
-// Plan groups [runs] into ⌈P/K⌉ task batches: runs [0..K) -> task
+// Plan groups runs into ceil(P/K) task batches: runs [0..K) -> task
 // 0, runs [K..2K) -> task 1, ... The output is deterministic for a given input.
 //
 // Special cases:


### PR DESCRIPTION
Compaction groups sections into sorted runs by their sort-key bounds. calculateRuns compared a section's max against the next section's min with a strict `<`, so two sections that meet exactly at a boundary key were read as overlapping and split into separate runs, inflating the run count. This changes it to `<=`, documents the run contract in one place on the `Run` type, and adds tests.

Section bounds are used two ways:

- **Determining runs: inclusive on both ends.** A section joins a run when the previous section's max is `<=` its min, so sections that touch at a shared boundary key stay in one run.
- **Partitioning: half-open**, so partition ranges tile the key space with no gaps or double-counting. Future work, not in this change.
