### PR TITLE
docs: Fix broken links

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -568,7 +568,7 @@ All of these are cached to the `results_cache` which is configured in the `query
 
 #### Write dedupe cache is deprecated
 
-Write dedupe cache is deprecated because it not required by the newer single store indexes ([TSDB](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/tsdb/) and [boltdb-shipper](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/boltdb-shipper/)).
+Write dedupe cache is deprecated because it not required by the newer single store indexes ([TSDB](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/tsdb/) and boltdb-shipper).
 If you using a [legacy index type](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/storage/#index-storage), consider migrating to TSDB (recommended).
 
 #### Embedded cache metric changes
@@ -1060,8 +1060,6 @@ Meanwhile, the legacy format is a string in the following format:
 This histogram reports the distribution of log line sizes by file. It has 8 buckets for every file being tailed.
 
 This creates a lot of series and we don't think this metric has enough value to offset the amount of series generated so we are removing it.
-
-While this isn't a direct replacement, two metrics we find more useful are size and line counters configured via pipeline stages, an example of how to configure these metrics can be found in the [metrics pipeline stage docs](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/promtail/stages/metrics/#counter).
 
 #### `added Docker target` log message has been demoted from level=error to level=info
 
@@ -1589,7 +1587,7 @@ If you happen to have `results_cache.max_freshness` set, use `limits_config.max_
 
 ### Promtail config removed
 
-The long deprecated `entry_parser` config in Promtail has been removed, use [pipeline_stages](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/promtail/configuration/#pipeline_stages) instead.
+The long deprecated `entry_parser` config in Promtail has been removed.
 
 ### Upgrading schema to use boltdb-shipper and/or v11 schema
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes broken links flagged in https://github.com/grafana/loki/pull/23273, caused by removed content in preparation for Loki 4.0. Fixed as a separate PR to update `main` only, it should not be backported/published to the 3.7.x branch.

