### PR TITLE
feat(dataobj): Split per-tenant compaction into index and log toggles

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -4930,9 +4930,15 @@ shard_streams:
 # CLI flag: -bloom-build.enable
 [bloom_creation_enabled: <boolean> | default = false]
 
-# Experimental. Whether dataobj compaction runs for the tenant.
-# CLI flag: -dataobj-compaction.enable
-[dataobj_compaction_enabled: <boolean> | default = false]
+# Experimental. Whether dataobj index compaction runs for the tenant.
+# CLI flag: -dataobj-compaction.index.enable
+[dataobj_index_compaction_enabled: <boolean> | default = false]
+
+# Experimental. Whether dataobj log compaction runs for the tenant. Log
+# compaction implies index compaction; enabling log compaction without index
+# compaction is a configuration error.
+# CLI flag: -dataobj-compaction.log.enable
+[dataobj_log_compaction_enabled: <boolean> | default = false]
 
 # Experimental. Bloom planning strategy to use in bloom creation. Can be one of:
 # 'split_keyspace_by_factor', 'split_by_series_chunks_size'

--- a/pkg/engine/compactor/compactor_test.go
+++ b/pkg/engine/compactor/compactor_test.go
@@ -16,31 +16,40 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 )
 
-// fakeLimits reports per-tenant compaction enablement from a set. A tenant is
-// enabled iff it is present in `enabled`. The zero value enables nothing.
+// fakeLimits reports per-tenant compaction phase enablement. newFakeLimits
+// enables index-only compaction for the listed tenants (log stays off). Use
+// setLog / setIndex to adjust a tenant at runtime. The zero value enables
+// nothing.
 type fakeLimits struct {
-	mu      sync.Mutex
-	enabled map[string]bool
+	mu    sync.Mutex
+	index map[string]bool
+	log   map[string]bool
 }
 
-func newFakeLimits(tenants ...string) *fakeLimits {
-	m := make(map[string]bool, len(tenants))
-	for _, t := range tenants {
-		m[t] = true
+func newFakeLimits(indexTenants ...string) *fakeLimits {
+	idx := make(map[string]bool, len(indexTenants))
+	for _, t := range indexTenants {
+		idx[t] = true
 	}
-	return &fakeLimits{enabled: m}
+	return &fakeLimits{index: idx, log: map[string]bool{}}
 }
 
-func (f *fakeLimits) DataObjCompactionEnabled(userID string) bool {
+func (f *fakeLimits) CompactionPhases(userID string) (runIndex, runLog bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.enabled[userID]
+	return f.index[userID] || f.log[userID], f.log[userID]
 }
 
-func (f *fakeLimits) set(userID string, on bool) {
+func (f *fakeLimits) setIndex(userID string, on bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.enabled[userID] = on
+	f.index[userID] = on
+}
+
+func (f *fakeLimits) setLog(userID string, on bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.log[userID] = on
 }
 
 // TestPlanner_BootShutdown boots the scaffold with an in-process-only

--- a/pkg/engine/compactor/coordinator.go
+++ b/pkg/engine/compactor/coordinator.go
@@ -664,13 +664,24 @@ func (c *coordinator) runLogMergePhase(ctx context.Context, tenant string, windo
 
 // runTenantLoop runs the IndexMerge<->LogMerge cycle for one tenant until ctx
 // is cancelled. It never returns an error and never sleeps: on error it retries
-// the same phase, otherwise it flips.
+// the same phase, otherwise it flips. It re-reads the per-tenant phase
+// enablement each iteration and skips the LogMerge phase when log compaction is
+// disabled, so an index-only tenant runs IndexMerge exclusively.
 func (c *coordinator) runTenantLoop(ctx context.Context, tenant string) {
 	p := phaseIndexMerge
 	for {
 		if ctx.Err() != nil {
 			return
 		}
+		runIndex, runLog := c.limits.CompactionPhases(tenant)
+		if !runIndex && !runLog {
+			return
+		}
+		if p == phaseLogMerge && !runLog {
+			p = p.flip()
+			continue
+		}
+
 		window := c.clock().UTC().Truncate(metastore.MetastoreWindowSize)
 
 		start := c.clock()

--- a/pkg/engine/compactor/coordinator.go
+++ b/pkg/engine/compactor/coordinator.go
@@ -124,7 +124,9 @@ func (c *coordinator) reconcile(ctx context.Context, workers map[string]context.
 	// startWorker), not here, so a still-draining worker cannot resurrect a
 	// series after this cancel.
 	for tenant, cancel := range workers {
-		if !c.limits.DataObjCompactionEnabled(tenant) {
+		// A worker stays alive whenever any phase runs; runLog is irrelevant to
+		// liveness because it implies runIndex.
+		if runIndex, _ := c.limits.CompactionPhases(tenant); !runIndex {
 			cancel()
 			delete(workers, tenant)
 		}
@@ -138,7 +140,7 @@ func (c *coordinator) reconcile(ctx context.Context, workers map[string]context.
 		if _, running := workers[tenant]; running {
 			continue
 		}
-		if !c.limits.DataObjCompactionEnabled(tenant) {
+		if runIndex, _ := c.limits.CompactionPhases(tenant); !runIndex {
 			continue
 		}
 		c.startWorker(ctx, workers, wg, tenant)

--- a/pkg/engine/compactor/coordinator_test.go
+++ b/pkg/engine/compactor/coordinator_test.go
@@ -945,7 +945,9 @@ func TestRunTenantLoop_ErrorRetries(t *testing.T) {
 
 		bucket := logMergeBucket(ctx, t, window, "acme", []string{"indexes/a", "indexes/b"})
 		replacer := &fakeReplacer{swapped: true}
-		c := newTestCoordinator(t, bucket, &fakeRunner{}, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
+		limits := newFakeLimits("acme")
+		limits.setLog("acme", true) // both phases enabled so the flip is exercised
+		c := newTestCoordinator(t, bucket, &fakeRunner{}, replacer, fixedClock(window.Add(time.Hour)), limits)
 
 		var mu sync.Mutex
 		var phases []string

--- a/pkg/engine/compactor/coordinator_test.go
+++ b/pkg/engine/compactor/coordinator_test.go
@@ -792,7 +792,7 @@ func TestReconcile_DisabledDuringToCReadFailure_CancelsWorker(t *testing.T) {
 		"the running worker must have emitted a per-tenant series")
 
 	// Disable the tenant AND make the ToC read fail. Disable must still apply.
-	limits.set("acme", false)
+	limits.setIndex("acme", false)
 	c.bucket = errBucket{objstore.NewInMemBucket()} // Get returns a non-not-found error
 
 	c.reconcile(ctx, workers, &wg)
@@ -1158,4 +1158,154 @@ func TestFillFileSizes_MissingObjectZeroSize(t *testing.T) {
 	c.fillFileSizes(ctx, entries)
 
 	require.Equal(t, uint64(0), entries[0].FileSize, "missing object should leave FileSize as zero")
+}
+
+// TestRunTenantLoop_IndexOnly verifies that a tenant with only index
+// compaction enabled runs IndexMerge cycles and never dispatches a LogMerge
+// task, because runTenantLoop skips the LogMerge phase when runLog is false.
+func TestRunTenantLoop_IndexOnly(t *testing.T) {
+	window := imWindow()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bucket := logMergeBucket(ctx, t, window, "acme", []string{"a", "b"})
+	replacer := &fakeReplacer{swapped: true}
+	c := newTestCoordinator(t, bucket, &fakeRunner{}, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
+
+	var mu sync.Mutex
+	var phases []string
+	c.runPlan = func(_ context.Context, opts workflow.Options, _ *physical.Plan) error {
+		mu.Lock()
+		phases = append(phases, opts.Actor[1])
+		mu.Unlock()
+		return nil
+	}
+
+	done := make(chan struct{})
+	go func() { c.runTenantLoop(ctx, "acme"); close(done) }()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(phases) >= 3
+	}, 2*time.Second, 5*time.Millisecond)
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, phases)
+	for _, p := range phases {
+		require.Equal(t, "index-merge", p, "index-only tenant must never dispatch a log-merge task")
+	}
+}
+
+// TestRunTenantLoop_LogEnabledRunsBothPhases verifies that enabling log
+// compaction (which implies index) restores the flip-flop: dispatches
+// alternate index-merge <-> log-merge.
+func TestRunTenantLoop_LogEnabledRunsBothPhases(t *testing.T) {
+	window := imWindow()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bucket := logMergeBucket(ctx, t, window, "acme", []string{"a", "b"})
+	replacer := &fakeReplacer{swapped: true}
+	limits := newFakeLimits("acme")
+	limits.setLog("acme", true)
+	c := newTestCoordinator(t, bucket, &fakeRunner{}, replacer, fixedClock(window.Add(time.Hour)), limits)
+
+	var mu sync.Mutex
+	var phases []string
+	c.runPlan = func(_ context.Context, opts workflow.Options, _ *physical.Plan) error {
+		mu.Lock()
+		if len(phases) == 0 || phases[len(phases)-1] != opts.Actor[1] {
+			phases = append(phases, opts.Actor[1])
+		}
+		mu.Unlock()
+		return nil
+	}
+
+	done := make(chan struct{})
+	go func() { c.runTenantLoop(ctx, "acme"); close(done) }()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(phases) >= 3
+	}, 2*time.Second, 5*time.Millisecond)
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	// runPlan returns nil (success) on every call, so the loop flips every
+	// cycle and the phase order is deterministic; the exact prefix is safe to
+	// assert. The loop starts on IndexMerge.
+	require.Equal(t, []string{"index-merge", "log-merge", "index-merge"}, phases[:3],
+		"log-enabled tenant flips between index-merge and log-merge")
+}
+
+// TestRunTenantLoop_DisablingLogMidRunStopsLogMerge verifies that turning off
+// log compaction while the loop runs stops further log-merge dispatches on the
+// next iteration while index-merge continues, because runTenantLoop re-reads
+// CompactionPhases every cycle.
+func TestRunTenantLoop_DisablingLogMidRunStopsLogMerge(t *testing.T) {
+	window := imWindow()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bucket := logMergeBucket(ctx, t, window, "acme", []string{"a", "b"})
+	replacer := &fakeReplacer{swapped: true}
+	limits := newFakeLimits("acme")
+	limits.setLog("acme", true)
+	c := newTestCoordinator(t, bucket, &fakeRunner{}, replacer, fixedClock(window.Add(time.Hour)), limits)
+
+	var mu sync.Mutex
+	var phases []string
+	sawLog := make(chan struct{})
+	var closeOnce sync.Once
+	c.runPlan = func(_ context.Context, opts workflow.Options, _ *physical.Plan) error {
+		mu.Lock()
+		phases = append(phases, opts.Actor[1])
+		mu.Unlock()
+		if opts.Actor[1] == "log-merge" {
+			closeOnce.Do(func() { close(sawLog) })
+		}
+		return nil
+	}
+
+	done := make(chan struct{})
+	go func() { c.runTenantLoop(ctx, "acme"); close(done) }()
+
+	// Wait for at least one log-merge, then disable log compaction.
+	select {
+	case <-sawLog:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected at least one log-merge dispatch before disabling")
+	}
+	limits.setLog("acme", false)
+
+	// Record how many phases exist at the cutoff, then let the loop run more.
+	mu.Lock()
+	cutoff := len(phases)
+	mu.Unlock()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(phases) >= cutoff+4 // several more cycles after disabling
+	}, 2*time.Second, 5*time.Millisecond)
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	// The mid-run disable is not instantaneous: an in-flight log-merge cycle
+	// may still complete. Assert that dispatches eventually settle to
+	// index-merge only — i.e. the tail after the cutoff contains no log-merge.
+	tail := phases[cutoff:]
+	require.NotEmpty(t, tail)
+	for _, p := range tail[len(tail)-4:] {
+		require.Equal(t, "index-merge", p, "no log-merge after log compaction is disabled")
+	}
 }

--- a/pkg/engine/compactor/limits.go
+++ b/pkg/engine/compactor/limits.go
@@ -3,7 +3,9 @@ package compactor
 // Limits is the per-tenant configuration the compaction coordinator consults.
 // *github.com/grafana/loki/v3/pkg/validation.Overrides satisfies it.
 type Limits interface {
-	// DataObjCompactionEnabled reports whether compaction should run for the
-	// given tenant.
-	DataObjCompactionEnabled(userID string) bool
+	// CompactionPhases reports which compaction phases run for the tenant.
+	// runIndex is true when either index or log compaction is enabled; runLog
+	// is true only when log compaction is enabled. The invalid combination
+	// (log without index) is rejected at config validation.
+	CompactionPhases(userID string) (runIndex, runLog bool)
 }

--- a/pkg/util/limiter/combined_limits.go
+++ b/pkg/util/limiter/combined_limits.go
@@ -33,5 +33,5 @@ type CombinedLimits interface {
 	pattern.Limits
 	bucket.SSEConfigProvider
 	SortSchemaLabels(userID string) []string
-	DataObjCompactionEnabled(userID string) bool
+	CompactionPhases(userID string) (runIndex, runLog bool)
 }

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -83,6 +83,8 @@ var (
 		"Severity_Text",
 		"SEVERITY_TEXT",
 	}
+
+	errLogCompactionRequiresIndex = errors.New("dataobj_log_compaction_enabled requires dataobj_index_compaction_enabled")
 )
 
 // Limits describe all the limits for users; can be used to describe global default
@@ -230,7 +232,8 @@ type Limits struct {
 	BloomBuilderResponseTimeout time.Duration `yaml:"bloom_build_builder_response_timeout" json:"bloom_build_builder_response_timeout" category:"experimental"`
 
 	BloomCreationEnabled           bool             `yaml:"bloom_creation_enabled" json:"bloom_creation_enabled" category:"experimental"`
-	DataObjCompactionEnabled       bool             `yaml:"dataobj_compaction_enabled" json:"dataobj_compaction_enabled" category:"experimental"`
+	DataObjIndexCompactionEnabled  bool             `yaml:"dataobj_index_compaction_enabled" json:"dataobj_index_compaction_enabled" category:"experimental"`
+	DataObjLogCompactionEnabled    bool             `yaml:"dataobj_log_compaction_enabled" json:"dataobj_log_compaction_enabled" category:"experimental"`
 	BloomPlanningStrategy          string           `yaml:"bloom_planning_strategy" json:"bloom_planning_strategy" category:"experimental"`
 	BloomSplitSeriesKeyspaceBy     int              `yaml:"bloom_split_series_keyspace_by" json:"bloom_split_series_keyspace_by" category:"experimental"`
 	BloomTaskTargetSeriesChunkSize flagext.ByteSize `yaml:"bloom_task_target_series_chunk_size" json:"bloom_task_target_series_chunk_size" category:"experimental"`
@@ -497,7 +500,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	)
 
 	f.BoolVar(&l.BloomCreationEnabled, "bloom-build.enable", false, "Experimental. Whether to create blooms for the tenant.")
-	f.BoolVar(&l.DataObjCompactionEnabled, "dataobj-compaction.enable", false, "Experimental. Whether dataobj compaction runs for the tenant.")
+	f.BoolVar(&l.DataObjIndexCompactionEnabled, "dataobj-compaction.index.enable", false, "Experimental. Whether dataobj index compaction runs for the tenant.")
+	f.BoolVar(&l.DataObjLogCompactionEnabled, "dataobj-compaction.log.enable", false, "Experimental. Whether dataobj log compaction runs for the tenant. Log compaction implies index compaction; enabling log compaction without index compaction is a configuration error.")
 	f.StringVar(&l.BloomPlanningStrategy, "bloom-build.planning-strategy", "split_keyspace_by_factor", "Experimental. Bloom planning strategy to use in bloom creation. Can be one of: 'split_keyspace_by_factor', 'split_by_series_chunks_size'")
 	f.IntVar(&l.BloomSplitSeriesKeyspaceBy, "bloom-build.split-keyspace-by", 256, "Experimental. Only if `bloom-build.planning-strategy` is 'split'. Number of splits to create for the series keyspace when building blooms. The series keyspace is split into this many parts to parallelize bloom creation.")
 	_ = l.BloomTaskTargetSeriesChunkSize.Set(defaultBloomTaskTargetChunkSize)
@@ -689,6 +693,10 @@ func (l *Limits) Validate() error {
 
 	if err := l.SortSchema.Validate(); err != nil {
 		return fmt.Errorf("sort_schema: %w", err)
+	}
+
+	if l.DataObjLogCompactionEnabled && !l.DataObjIndexCompactionEnabled {
+		return errLogCompactionRequiresIndex
 	}
 
 	return nil
@@ -1199,10 +1207,15 @@ func (o *Overrides) BloomCreationEnabled(userID string) bool {
 	return o.getOverridesForUser(userID).BloomCreationEnabled
 }
 
-// DataObjCompactionEnabled returns whether dataobj compaction is enabled for
-// the given tenant.
-func (o *Overrides) DataObjCompactionEnabled(userID string) bool {
-	return o.getOverridesForUser(userID).DataObjCompactionEnabled
+// CompactionPhases returns which dataobj compaction phases run for the tenant.
+// runIndex is true when either index or log compaction is enabled; runLog is
+// true only when log compaction is enabled.
+func (o *Overrides) CompactionPhases(userID string) (runIndex, runLog bool) {
+	l := o.getOverridesForUser(userID)
+	// runIndex stays correct (index || log) even if Validate's log-implies-index
+	// rule is ever bypassed, e.g. by an unvalidated runtime override.
+	return l.DataObjIndexCompactionEnabled || l.DataObjLogCompactionEnabled,
+		l.DataObjLogCompactionEnabled
 }
 
 func (o *Overrides) BloomPlanningStrategy(userID string) string {

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -1100,25 +1100,80 @@ otlp_config:
 	}
 }
 
-func TestDataObjCompactionEnabled_DefaultsFalse(t *testing.T) {
+func TestDataObjCompaction_DefaultsFalse(t *testing.T) {
 	var defaults Limits
 	defaults.RegisterFlags(flag.NewFlagSet("test", flag.PanicOnError))
 
 	ov, err := NewOverrides(defaults, nil)
 	require.NoError(t, err)
-	require.False(t, ov.DataObjCompactionEnabled("tenant-29"))
+
+	runIndex, runLog := ov.CompactionPhases("tenant-29")
+	require.False(t, runIndex)
+	require.False(t, runLog)
 }
 
-func TestDataObjCompactionEnabled_PerTenantOverride(t *testing.T) {
+func TestDataObjCompaction_IndexOnlyOverride(t *testing.T) {
 	var defaults Limits
 	defaults.RegisterFlags(flag.NewFlagSet("test", flag.PanicOnError))
 
 	tenantLimits := map[string]*Limits{
-		"tenant-29": {DataObjCompactionEnabled: true},
+		"tenant-29": {DataObjIndexCompactionEnabled: true},
 	}
 	ov, err := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
 	require.NoError(t, err)
 
-	require.True(t, ov.DataObjCompactionEnabled("tenant-29"))
-	require.False(t, ov.DataObjCompactionEnabled("tenant-1"))
+	runIndex, runLog := ov.CompactionPhases("tenant-29")
+	require.True(t, runIndex, "index compaction runs")
+	require.False(t, runLog, "log compaction does not run when only index is enabled")
+
+	runIndex, runLog = ov.CompactionPhases("tenant-1")
+	require.False(t, runIndex)
+	require.False(t, runLog)
+}
+
+func TestDataObjCompaction_LogImpliesIndex(t *testing.T) {
+	var defaults Limits
+	defaults.RegisterFlags(flag.NewFlagSet("test", flag.PanicOnError))
+
+	tenantLimits := map[string]*Limits{
+		"tenant-29": {
+			DataObjIndexCompactionEnabled: true,
+			DataObjLogCompactionEnabled:   true,
+		},
+	}
+	ov, err := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
+	require.NoError(t, err)
+
+	runIndex, runLog := ov.CompactionPhases("tenant-29")
+	require.True(t, runIndex, "log compaction implies index compaction")
+	require.True(t, runLog, "log compaction runs")
+}
+
+func TestDataObjCompaction_ValidateRejectsLogWithoutIndex(t *testing.T) {
+	var l Limits
+	l.RegisterFlags(flag.NewFlagSet("test", flag.PanicOnError))
+	l.DataObjLogCompactionEnabled = true
+	l.DataObjIndexCompactionEnabled = false
+	require.ErrorIs(t, l.Validate(), errLogCompactionRequiresIndex)
+}
+
+func TestDataObjCompaction_ValidateAcceptsValidCombinations(t *testing.T) {
+	// Build from RegisterFlags defaults so the other required Validate() fields
+	// (TSDBMaxBytesPerShard, EngineResultsCacheTimeBucketInterval, etc.) are
+	// already satisfied; toggle only the two compaction booleans.
+	combos := []struct{ index, log bool }{
+		{false, false},
+		{true, false},
+		{true, true},
+	}
+	for _, c := range combos {
+		t.Run(fmt.Sprintf("index=%v_log=%v", c.index, c.log), func(t *testing.T) {
+			var l Limits
+			l.RegisterFlags(flag.NewFlagSet("test", flag.PanicOnError))
+			l.DataObjIndexCompactionEnabled = c.index
+			l.DataObjLogCompactionEnabled = c.log
+			require.NotErrorIs(t, l.Validate(), errLogCompactionRequiresIndex,
+				"index=%v log=%v is a valid combination", c.index, c.log)
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Splits the single per-tenant `dataobj_compaction_enabled` override into two independent toggles so operators can run index compaction without log compaction:

- `dataobj_log_compaction_enabled` — runs **both** IndexMerge and LogMerge (log compaction implies index compaction).
- `dataobj_index_compaction_enabled` (log disabled) — runs **only** IndexMerge.
- log enabled + index disabled — rejected at config validation.
- both disabled — no compaction worker runs for the tenant.

The "log implies index" rule and the invalid-combination check are centralized behind a single `Overrides.CompactionPhases(userID) (runIndex, runLog bool)` accessor, so the compaction coordinator never reasons about the implication rule directly. `runTenantLoop` re-reads the per-tenant phase enablement each cycle and skips the LogMerge phase when log compaction is disabled, so an index-only tenant runs IndexMerge exclusively and picks up override changes without a restart.
