### PR TITLE
ci: Add Workflow to Generate and Attach SBOM on Release

### DIFF
--- a/.github/workflows/sbom-on-release.yml
+++ b/.github/workflows/sbom-on-release.yml
@@ -1,0 +1,39 @@
+name: "SBOM on Release"
+
+on:
+  release:
+    types:
+      - published
+
+permissions: {}
+
+jobs:
+  export-sbom:
+    name: "Export SBOM and attach to release"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to upload the SBOM as a release asset
+      id-token: write # to authenticate to Vault
+    steps:
+      - name: "Get Socket API token from Vault"
+        id: vault-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@e46fe1e9a2bf9e618bcf8d8d32f3a7381b45c06d # get-vault-secrets/v2.0.0
+        with:
+          common_secrets: |
+            SOCKET_API_TOKEN=socket:SOCKET_API_KEY
+
+      - name: "Export SPDX SBOM from Socket"
+        id: export-sbom
+        uses: grafana/shared-workflows/actions/socket-export-sbom@ff9aaa53f25716fcd6dde39f6d4e41c4e16fb5e1 # socket-export-sbom/v0.1.2
+        with:
+          socket_api_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).SOCKET_API_TOKEN }}
+          socket_org: grafana
+          output_file: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.spdx.json
+
+      - name: "Upload SBOM to release"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+          SBOM_PATH: ${{ steps.export-sbom.outputs.path }}
+        run: gh release upload "$TAG" "$SBOM_PATH" --clobber

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,7 @@
 # Loki operator
 /operator/ @grafana/loki-team @periklis @xperimental @JoaoBraveCoding
 /.github/workflows/operator* @grafana/loki-team @periklis @xperimental @JoaoBraveCoding
+/.github/workflows/sbom-on-release.yml @grafana/security
 
 # Logql grammar
 # The OSS big tent team is listed as co-codeowner for grammar file. This is to receive notifications about updates, so these can be implemented in https://github.com/grafana/lezer-logql


### PR DESCRIPTION
**What this PR does / why we need it**:
CI workflow for generating an SBOM on release, which is added to the release assets. SBOMs are generated using the socket.dev API.

**Which issue(s) this PR fixes**:
The GRC team semi-frequently gets requests for Software Bill of Materials (SBOMs) from contracted customers and prospects. Grafana's Open Source repos are enrolled in and scanned for dependencies by socket.dev, which also generates SBOMs. Currently, the GRC team generates SBOMs ad-hoc using Socket's API. Adding a standardized workflow for SBOM generation reduces the burden for the GRC team and also makes SBOMs available for consumption by members of our OSS community.

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
