### PR TITLE
fix: Exclude debug routes from distributor panel on operational dashb…

### DIFF
--- a/production/loki-mixin/dashboards/dashboard-loki-operational.json
+++ b/production/loki-mixin/dashboards/dashboard-loki-operational.json
@@ -768,17 +768,17 @@
        "steppedLine": false,
        "targets": [
          {
-           "expr": "histogram_quantile(0.99, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"}))",
+           "expr": "histogram_quantile(0.99, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\", route!~\"(debug_pprof|ready|metrics|usage_metrics)\"}))",
            "legendFormat": ".99",
            "refId": "A"
          },
          {
-           "expr": "histogram_quantile(0.9, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"}))",
+           "expr": "histogram_quantile(0.9, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\", route!~\"(debug_pprof|ready|metrics|usage_metrics)\"}))",
            "legendFormat": ".9",
            "refId": "B"
          },
          {
-           "expr": "histogram_quantile(0.5, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"}))",
+           "expr": "histogram_quantile(0.5, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\", route!~\"(debug_pprof|ready|metrics|usage_metrics)\"}))",
            "legendFormat": ".5",
            "refId": "C"
          }


### PR DESCRIPTION
…oard

**What this PR does / why we need it**:
The "Distributor Latency" panel on the operational dashboard included all routes (debug_pprof, metrics, ready, usage_metrics). Most of these aren't a problem, but the debug_pprof endpoint takes a long time, as intended, and can dominate the p99 calculation if there isn't much other traffic.

This PR excludes the non-production traffic endpoints from the latency calculation so it more closely reflects the Push latency dashboard.