### PR TITLE
fix(dataobj): Skip unrecognized columns when iterating sections

### DIFF
--- a/pkg/dataobj/sections/indexpointers/iter.go
+++ b/pkg/dataobj/sections/indexpointers/iter.go
@@ -39,8 +39,7 @@ func Iter(ctx context.Context, obj *dataobj.Object) result.Seq[TenantIndexPointe
 
 func IterSection(ctx context.Context, section *Section) result.Seq[IndexPointer] {
 	return result.Iter(func(yield func(IndexPointer) bool) error {
-		columnarSection := section.inner
-		dset, err := columnar.MakeDataset(columnarSection, recognizedInnerColumns(section))
+		dset, err := section.makeDataset()
 		if err != nil {
 			return fmt.Errorf("creating columns dataset: %w", err)
 		}
@@ -86,22 +85,15 @@ func IterSection(ctx context.Context, section *Section) result.Seq[IndexPointer]
 	})
 }
 
-// recognizedInnerColumns returns the underlying columnar columns for the
-// columns the section recognizes, preserving their order.
-//
-// Datasets and row readers must be built from these rather than from every
-// physical column in the section: it keeps each row's values positionally
-// aligned with sec.Columns() during decoding and transparently skips columns
-// written by a newer version of Loki that this reader doesn't understand.
-// Reading unrecognized columns would otherwise misalign or overrun decodeRow's
-// positional lookups.
-func recognizedInnerColumns(sec *Section) []*columnar.Column {
-	recognized := sec.Columns()
+// makeDataset builds a dataset from only the recognized columns, so rows stay
+// aligned with Columns() and columns from a newer Loki are skipped, not decoded.
+func (s *Section) makeDataset() (*columnar.Dataset, error) {
+	recognized := s.Columns()
 	inner := make([]*columnar.Column, len(recognized))
 	for i, col := range recognized {
 		inner[i] = col.inner
 	}
-	return inner
+	return columnar.MakeDataset(s.inner, inner)
 }
 
 // decodeRow decodes an indexpointer from a [dataset.Row], using the provided columns to

--- a/pkg/dataobj/sections/indexpointers/iter.go
+++ b/pkg/dataobj/sections/indexpointers/iter.go
@@ -40,7 +40,7 @@ func Iter(ctx context.Context, obj *dataobj.Object) result.Seq[TenantIndexPointe
 func IterSection(ctx context.Context, section *Section) result.Seq[IndexPointer] {
 	return result.Iter(func(yield func(IndexPointer) bool) error {
 		columnarSection := section.inner
-		dset, err := columnar.MakeDataset(columnarSection, columnarSection.Columns())
+		dset, err := columnar.MakeDataset(columnarSection, recognizedInnerColumns(section))
 		if err != nil {
 			return fmt.Errorf("creating columns dataset: %w", err)
 		}
@@ -84,6 +84,24 @@ func IterSection(ctx context.Context, section *Section) result.Seq[IndexPointer]
 			}
 		}
 	})
+}
+
+// recognizedInnerColumns returns the underlying columnar columns for the
+// columns the section recognizes, preserving their order.
+//
+// Datasets and row readers must be built from these rather than from every
+// physical column in the section: it keeps each row's values positionally
+// aligned with sec.Columns() during decoding and transparently skips columns
+// written by a newer version of Loki that this reader doesn't understand.
+// Reading unrecognized columns would otherwise misalign or overrun decodeRow's
+// positional lookups.
+func recognizedInnerColumns(sec *Section) []*columnar.Column {
+	recognized := sec.Columns()
+	inner := make([]*columnar.Column, len(recognized))
+	for i, col := range recognized {
+		inner[i] = col.inner
+	}
+	return inner
 }
 
 // decodeRow decodes an indexpointer from a [dataset.Row], using the provided columns to

--- a/pkg/dataobj/sections/indexpointers/iter_forward_compat_test.go
+++ b/pkg/dataobj/sections/indexpointers/iter_forward_compat_test.go
@@ -1,0 +1,134 @@
+package indexpointers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/internal/columnar"
+)
+
+// TestIter_ForwardCompatUnknownColumn reproduces the panic that occurs when an
+// older reader iterates an indexpointers section written by a newer Loki that
+// added columns the reader doesn't recognize (e.g. file_size /
+// uncompressed_logs_size from PR #23331).
+//
+// The section is built with the three long-standing columns plus one extra
+// column carrying a logical type unknown to [ParseColumnType]. A reader that
+// predates the new column must skip it and still decode the known columns
+// rather than panicking with an index-out-of-range in decodeRow.
+func TestIter_ForwardCompatUnknownColumn(t *testing.T) {
+	pointers := []IndexPointer{
+		{Path: "path1", StartTs: unixTime(10), EndTs: unixTime(20)},
+		{Path: "path2", StartTs: unixTime(30), EndTs: unixTime(40)},
+	}
+
+	objBuilder := dataobj.NewBuilder(nil)
+	require.NoError(t, objBuilder.Append(&unknownColumnSectionBuilder{tenant: "tenant-1", pointers: pointers}))
+
+	obj, closer, err := objBuilder.Flush()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = closer.Close() })
+
+	sec, err := Open(t.Context(), obj.Sections()[0])
+	require.NoError(t, err)
+
+	// The physical section carries the unknown column, but the typed view drops
+	// it. This length mismatch is exactly what makes decodeRow's positional
+	// lookup run off the end of the recognized-columns slice.
+	require.Len(t, sec.inner.Columns(), 4, "physical section should carry the unknown column")
+	require.Len(t, sec.Columns(), 3, "unknown column should be dropped from the typed view")
+
+	var got []IndexPointer
+	for res := range Iter(t.Context(), obj) {
+		tip, err := res.Value()
+		require.NoError(t, err)
+		got = append(got, tip.IndexPointer)
+	}
+
+	require.Len(t, got, len(pointers))
+	for i, want := range pointers {
+		require.Equal(t, want.Path, got[i].Path)
+		require.Equal(t, want.StartTs.UnixNano(), got[i].StartTs.UnixNano())
+		require.Equal(t, want.EndTs.UnixNano(), got[i].EndTs.UnixNano())
+		require.Zero(t, got[i].FileSize)
+		require.Zero(t, got[i].UncompressedLogsSize)
+	}
+}
+
+// unknownColumnSectionBuilder is a test-only [dataobj.SectionBuilder] that
+// encodes an indexpointers section with the standard path/min/max columns plus
+// one extra column whose logical type is unknown to the current reader. It
+// stands in for a section written by a newer version of Loki.
+type unknownColumnSectionBuilder struct {
+	tenant   string
+	pointers []IndexPointer
+}
+
+func (b *unknownColumnSectionBuilder) Type() dataobj.SectionType { return sectionType }
+
+func (b *unknownColumnSectionBuilder) Reset() { b.pointers = nil }
+
+func (b *unknownColumnSectionBuilder) Flush(w dataobj.SectionWriter) (int64, error) {
+	var enc columnar.Encoder
+	defer enc.Reset()
+
+	int64Column := func(name, logical string) (*dataset.ColumnBuilder, error) {
+		return dataset.NewColumnBuilder(name, dataset.BuilderOptions{
+			PageMaxRowCount: 100,
+			Type:            dataset.ColumnType{Physical: datasetmd.PHYSICAL_TYPE_INT64, Logical: logical},
+			Encoding:        datasetmd.ENCODING_TYPE_DELTA,
+			Compression:     datasetmd.COMPRESSION_TYPE_NONE,
+		})
+	}
+
+	pathBuilder, err := dataset.NewColumnBuilder("path", dataset.BuilderOptions{
+		PageMaxRowCount: 100,
+		Type:            dataset.ColumnType{Physical: datasetmd.PHYSICAL_TYPE_BINARY, Logical: ColumnTypePath.String()},
+		Encoding:        datasetmd.ENCODING_TYPE_PLAIN,
+		Compression:     datasetmd.COMPRESSION_TYPE_ZSTD,
+	})
+	if err != nil {
+		return 0, err
+	}
+	minBuilder, err := int64Column("min_timestamp", ColumnTypeMinTimestamp.String())
+	if err != nil {
+		return 0, err
+	}
+	maxBuilder, err := int64Column("max_timestamp", ColumnTypeMaxTimestamp.String())
+	if err != nil {
+		return 0, err
+	}
+	// A column written by a newer Loki. Its logical type is not known to
+	// ParseColumnType, so an older reader drops it from Section.Columns().
+	futureBuilder, err := int64Column("future_field", "future_field")
+	if err != nil {
+		return 0, err
+	}
+
+	for i, p := range b.pointers {
+		_ = pathBuilder.Append(i, dataset.BinaryValue([]byte(p.Path)))
+		_ = minBuilder.Append(i, dataset.Int64Value(p.StartTs.UnixNano()))
+		_ = maxBuilder.Append(i, dataset.Int64Value(p.EndTs.UnixNano()))
+		_ = futureBuilder.Append(i, dataset.Int64Value(int64(i+1)))
+	}
+
+	// The unknown column is encoded last so it lands at a physical index beyond
+	// the recognized columns, reproducing "index out of range [3] with length 3".
+	errs := []error{
+		encodeColumn(&enc, ColumnTypePath, pathBuilder),
+		encodeColumn(&enc, ColumnTypeMinTimestamp, minBuilder),
+		encodeColumn(&enc, ColumnTypeMaxTimestamp, maxBuilder),
+		encodeColumn(&enc, ColumnTypeInvalid, futureBuilder),
+	}
+	if err := errors.Join(errs...); err != nil {
+		return 0, err
+	}
+
+	enc.SetTenant(b.tenant)
+	return enc.Flush(w)
+}

--- a/pkg/dataobj/sections/indexpointers/row_reader.go
+++ b/pkg/dataobj/sections/indexpointers/row_reader.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/slicegrow"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/symbolizer"
-	"github.com/grafana/loki/v3/pkg/dataobj/sections/internal/columnar"
 )
 
 // RowReader is a reader for index pointers in a data object.
@@ -102,7 +101,7 @@ func (r *RowReader) Read(ctx context.Context, s []IndexPointer) (int, error) {
 }
 
 func (r *RowReader) initReader(ctx context.Context) error {
-	dset, err := columnar.MakeDataset(r.sec.inner, recognizedInnerColumns(r.sec))
+	dset, err := r.sec.makeDataset()
 	if err != nil {
 		return fmt.Errorf("creating section dataset: %w", err)
 	}

--- a/pkg/dataobj/sections/indexpointers/row_reader.go
+++ b/pkg/dataobj/sections/indexpointers/row_reader.go
@@ -102,7 +102,7 @@ func (r *RowReader) Read(ctx context.Context, s []IndexPointer) (int, error) {
 }
 
 func (r *RowReader) initReader(ctx context.Context) error {
-	dset, err := columnar.MakeDataset(r.sec.inner, r.sec.inner.Columns())
+	dset, err := columnar.MakeDataset(r.sec.inner, recognizedInnerColumns(r.sec))
 	if err != nil {
 		return fmt.Errorf("creating section dataset: %w", err)
 	}

--- a/pkg/dataobj/sections/logs/dataset_forward_compat_test.go
+++ b/pkg/dataobj/sections/logs/dataset_forward_compat_test.go
@@ -1,0 +1,66 @@
+package logs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
+)
+
+// TestMakeColumnarDataset_ForwardCompatUnknownColumn guards the sortmerge path,
+// which lives in a package that can't import the internal columnar encoder and
+// so can't build a section carrying an unknown column itself.
+//
+// It reproduces sortmerge's exact composition — MakeColumnarDataset, then a row
+// reader feeding DecodeRow against Section.Columns() — over a section written
+// by a newer Loki. Before the funnel fix, MakeColumnarDataset built from every
+// physical column, so DecodeRow's positional lookup ran off the end of the
+// recognized columns and panicked.
+func TestMakeColumnarDataset_ForwardCompatUnknownColumn(t *testing.T) {
+	objBuilder := dataobj.NewBuilder(nil)
+	require.NoError(t, objBuilder.Append(&unknownColumnSectionBuilder{}))
+
+	obj, closer, err := objBuilder.Flush()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = closer.Close() })
+
+	sec, err := Open(t.Context(), obj.Sections()[0])
+	require.NoError(t, err)
+
+	require.Len(t, sec.inner.Columns(), 3, "physical section should carry the unknown column")
+	require.Len(t, sec.Columns(), 2, "unknown column should be dropped from the typed view")
+
+	dset, err := MakeColumnarDataset(sec)
+	require.NoError(t, err)
+
+	columns, err := result.Collect(dset.ListColumns(t.Context()))
+	require.NoError(t, err)
+
+	r := dataset.NewRowReader(dataset.RowReaderOptions{
+		Dataset:  dset,
+		Columns:  columns,
+		Prefetch: true,
+	})
+	defer r.Close()
+	require.NoError(t, r.Open(t.Context()))
+
+	var got []Record
+	seq := NewDatasetSequence(r, 128)
+	for seq.Next() {
+		row, err := seq.At().Value()
+		require.NoError(t, err)
+
+		var record Record
+		require.NoError(t, DecodeRow(sec.Columns(), row, &record, nil))
+		got = append(got, Record{StreamID: record.StreamID, Timestamp: record.Timestamp})
+	}
+
+	require.Len(t, got, 2)
+	require.Equal(t, int64(1), got[0].StreamID)
+	require.Equal(t, int64(2), got[1].StreamID)
+	require.Equal(t, int64(10), got[0].Timestamp.UnixNano())
+	require.Equal(t, int64(30), got[1].Timestamp.UnixNano())
+}

--- a/pkg/dataobj/sections/logs/iter.go
+++ b/pkg/dataobj/sections/logs/iter.go
@@ -41,7 +41,7 @@ func Iter(ctx context.Context, obj *dataobj.Object) result.Seq[Record] {
 
 func IterSection(ctx context.Context, section *Section) result.Seq[Record] {
 	return result.Iter(func(yield func(Record) bool) error {
-		dset, err := columnar.MakeDataset(section.inner, recognizedInnerColumns(section))
+		dset, err := section.makeDataset()
 		if err != nil {
 			return fmt.Errorf("creating columnar dataset: %w", err)
 		}
@@ -85,29 +85,21 @@ func IterSection(ctx context.Context, section *Section) result.Seq[Record] {
 // ColumnarDataset is the exported type alias of the internal [columnar.Dataset].
 type ColumnarDataset = columnar.Dataset
 
-// MakeColumnarDataset returns the dataset from a section and a set of columns.
-// It returns an error if not all columns are from the provided section.
-func MakeColumnarDataset(section *Section) (*ColumnarDataset, error) {
-	columnarSection := section.inner
-	return columnar.MakeDataset(columnarSection, columnarSection.Columns())
-}
-
-// recognizedInnerColumns returns the underlying columnar columns for the
-// columns the section recognizes, preserving their order.
-//
-// Datasets and row readers must be built from these rather than from every
-// physical column in the section: it keeps each row's values positionally
-// aligned with sec.Columns() during decoding and transparently skips columns
-// written by a newer version of Loki that this reader doesn't understand.
-// Reading unrecognized columns would otherwise misalign or overrun DecodeRow's
-// positional lookups.
-func recognizedInnerColumns(sec *Section) []*columnar.Column {
-	recognized := sec.Columns()
+// makeDataset builds a dataset from only the recognized columns, so rows stay
+// aligned with Columns() and columns from a newer Loki are skipped, not decoded.
+func (s *Section) makeDataset() (*columnar.Dataset, error) {
+	recognized := s.Columns()
 	inner := make([]*columnar.Column, len(recognized))
 	for i, col := range recognized {
 		inner[i] = col.inner
 	}
-	return inner
+	return columnar.MakeDataset(s.inner, inner)
+}
+
+// MakeColumnarDataset is the exported entry point for sortmerge, the only caller
+// outside this package; internal callers use makeDataset.
+func MakeColumnarDataset(section *Section) (*ColumnarDataset, error) {
+	return section.makeDataset()
 }
 
 // DecodeRow decodes a record from a [dataset.Row], using the provided columns

--- a/pkg/dataobj/sections/logs/iter.go
+++ b/pkg/dataobj/sections/logs/iter.go
@@ -41,7 +41,7 @@ func Iter(ctx context.Context, obj *dataobj.Object) result.Seq[Record] {
 
 func IterSection(ctx context.Context, section *Section) result.Seq[Record] {
 	return result.Iter(func(yield func(Record) bool) error {
-		dset, err := MakeColumnarDataset(section)
+		dset, err := columnar.MakeDataset(section.inner, recognizedInnerColumns(section))
 		if err != nil {
 			return fmt.Errorf("creating columnar dataset: %w", err)
 		}
@@ -90,6 +90,24 @@ type ColumnarDataset = columnar.Dataset
 func MakeColumnarDataset(section *Section) (*ColumnarDataset, error) {
 	columnarSection := section.inner
 	return columnar.MakeDataset(columnarSection, columnarSection.Columns())
+}
+
+// recognizedInnerColumns returns the underlying columnar columns for the
+// columns the section recognizes, preserving their order.
+//
+// Datasets and row readers must be built from these rather than from every
+// physical column in the section: it keeps each row's values positionally
+// aligned with sec.Columns() during decoding and transparently skips columns
+// written by a newer version of Loki that this reader doesn't understand.
+// Reading unrecognized columns would otherwise misalign or overrun DecodeRow's
+// positional lookups.
+func recognizedInnerColumns(sec *Section) []*columnar.Column {
+	recognized := sec.Columns()
+	inner := make([]*columnar.Column, len(recognized))
+	for i, col := range recognized {
+		inner[i] = col.inner
+	}
+	return inner
 }
 
 // DecodeRow decodes a record from a [dataset.Row], using the provided columns

--- a/pkg/dataobj/sections/logs/iter_forward_compat_test.go
+++ b/pkg/dataobj/sections/logs/iter_forward_compat_test.go
@@ -1,0 +1,117 @@
+package logs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/internal/columnar"
+)
+
+// TestIter_ForwardCompatUnknownColumn ensures an older reader can iterate a
+// logs section written by a newer Loki that added a column this reader doesn't
+// recognize, instead of panicking with an index-out-of-range in DecodeRow.
+func TestIter_ForwardCompatUnknownColumn(t *testing.T) {
+	objBuilder := dataobj.NewBuilder(nil)
+	require.NoError(t, objBuilder.Append(&unknownColumnSectionBuilder{}))
+
+	obj, closer, err := objBuilder.Flush()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = closer.Close() })
+
+	sec, err := Open(t.Context(), obj.Sections()[0])
+	require.NoError(t, err)
+
+	require.Len(t, sec.inner.Columns(), 3, "physical section should carry the unknown column")
+	require.Len(t, sec.Columns(), 2, "unknown column should be dropped from the typed view")
+
+	var got []Record
+	for res := range Iter(t.Context(), obj) {
+		r, err := res.Value()
+		require.NoError(t, err)
+		got = append(got, Record{StreamID: r.StreamID, Timestamp: r.Timestamp})
+	}
+
+	require.Len(t, got, 2)
+	require.Equal(t, int64(1), got[0].StreamID)
+	require.Equal(t, int64(2), got[1].StreamID)
+	require.Equal(t, int64(10), got[0].Timestamp.UnixNano())
+	require.Equal(t, int64(30), got[1].Timestamp.UnixNano())
+}
+
+// unknownColumnSectionBuilder is a test-only [dataobj.SectionBuilder] that
+// encodes a logs section with stream_id/timestamp columns plus one column whose
+// logical type is unknown to the current reader, standing in for a section
+// written by a newer version of Loki.
+type unknownColumnSectionBuilder struct{}
+
+func (b *unknownColumnSectionBuilder) Type() dataobj.SectionType { return sectionType }
+
+func (b *unknownColumnSectionBuilder) Reset() {}
+
+func (b *unknownColumnSectionBuilder) Flush(w dataobj.SectionWriter) (int64, error) {
+	var enc columnar.Encoder
+	defer enc.Reset()
+
+	streamIDs := []int64{1, 2}
+	timestamps := []int64{10, 30}
+
+	streamIDBuilder := newInt64ColumnBuilder("stream_id", ColumnTypeStreamID.String())
+	timestampBuilder := newInt64ColumnBuilder("timestamp", ColumnTypeTimestamp.String())
+	// A column written by a newer Loki. Its logical type is unknown to
+	// ParseColumnType, so an older reader drops it from Section.Columns().
+	futureBuilder := newInt64ColumnBuilder("future_field", "future_field")
+
+	for i := range streamIDs {
+		_ = streamIDBuilder.Append(i, dataset.Int64Value(streamIDs[i]))
+		_ = timestampBuilder.Append(i, dataset.Int64Value(timestamps[i]))
+		_ = futureBuilder.Append(i, dataset.Int64Value(int64(i+1)))
+	}
+
+	// The unknown column is encoded last so it lands at a physical index beyond
+	// the recognized columns, reproducing the index-out-of-range panic.
+	if err := encodeTestColumns(&enc, streamIDBuilder, timestampBuilder, futureBuilder); err != nil {
+		return 0, err
+	}
+
+	enc.SetTenant("tenant-1")
+	return enc.Flush(w)
+}
+
+func newInt64ColumnBuilder(name, logical string) *dataset.ColumnBuilder {
+	b, err := dataset.NewColumnBuilder(name, dataset.BuilderOptions{
+		PageMaxRowCount: 100,
+		Type:            dataset.ColumnType{Physical: datasetmd.PHYSICAL_TYPE_INT64, Logical: logical},
+		Encoding:        datasetmd.ENCODING_TYPE_DELTA,
+		Compression:     datasetmd.COMPRESSION_TYPE_NONE,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func encodeTestColumns(enc *columnar.Encoder, builders ...*dataset.ColumnBuilder) error {
+	for _, b := range builders {
+		column, err := b.Flush()
+		if err != nil {
+			return err
+		}
+		columnEnc, err := enc.OpenColumn(column.ColumnDesc())
+		if err != nil {
+			return err
+		}
+		for _, page := range column.Pages {
+			if err := columnEnc.AppendPage(page); err != nil {
+				return err
+			}
+		}
+		if err := columnEnc.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/dataobj/sections/logs/row_reader.go
+++ b/pkg/dataobj/sections/logs/row_reader.go
@@ -139,7 +139,7 @@ func unsafeString(data []byte) string {
 }
 
 func (r *RowReader) initReader(ctx context.Context) error {
-	dset, err := columnar.MakeDataset(r.sec.inner, r.sec.inner.Columns())
+	dset, err := columnar.MakeDataset(r.sec.inner, recognizedInnerColumns(r.sec))
 	if err != nil {
 		return fmt.Errorf("creating section dataset: %w", err)
 	}

--- a/pkg/dataobj/sections/logs/row_reader.go
+++ b/pkg/dataobj/sections/logs/row_reader.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/slicegrow"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/symbolizer"
-	"github.com/grafana/loki/v3/pkg/dataobj/sections/internal/columnar"
 )
 
 // RowReader reads the set of logs from an [Object].
@@ -139,7 +138,7 @@ func unsafeString(data []byte) string {
 }
 
 func (r *RowReader) initReader(ctx context.Context) error {
-	dset, err := columnar.MakeDataset(r.sec.inner, recognizedInnerColumns(r.sec))
+	dset, err := r.sec.makeDataset()
 	if err != nil {
 		return fmt.Errorf("creating section dataset: %w", err)
 	}

--- a/pkg/dataobj/sections/pointers/iter.go
+++ b/pkg/dataobj/sections/pointers/iter.go
@@ -40,8 +40,7 @@ func Iter(ctx context.Context, obj *dataobj.Object) result.Seq[SectionPointer] {
 
 func IterSection(ctx context.Context, section *Section) result.Seq[SectionPointer] {
 	return result.Iter(func(yield func(SectionPointer) bool) error {
-		columnarSection := section.inner
-		dset, err := columnar.MakeDataset(columnarSection, recognizedInnerColumns(section))
+		dset, err := section.makeDataset()
 		if err != nil {
 			return fmt.Errorf("creating columns dataset: %w", err)
 		}
@@ -87,22 +86,15 @@ func IterSection(ctx context.Context, section *Section) result.Seq[SectionPointe
 	})
 }
 
-// recognizedInnerColumns returns the underlying columnar columns for the
-// columns the section recognizes, preserving their order.
-//
-// Datasets and row readers must be built from these rather than from every
-// physical column in the section: it keeps each row's values positionally
-// aligned with sec.Columns() during decoding and transparently skips columns
-// written by a newer version of Loki that this reader doesn't understand.
-// Reading unrecognized columns would otherwise misalign or overrun decodeRow's
-// positional lookups.
-func recognizedInnerColumns(sec *Section) []*columnar.Column {
-	recognized := sec.Columns()
+// makeDataset builds a dataset from only the recognized columns, so rows stay
+// aligned with Columns() and columns from a newer Loki are skipped, not decoded.
+func (s *Section) makeDataset() (*columnar.Dataset, error) {
+	recognized := s.Columns()
 	inner := make([]*columnar.Column, len(recognized))
 	for i, col := range recognized {
 		inner[i] = col.inner
 	}
-	return inner
+	return columnar.MakeDataset(s.inner, inner)
 }
 
 // decodeRow decodes a stream from a [dataset.Row], using the provided columns to

--- a/pkg/dataobj/sections/pointers/iter.go
+++ b/pkg/dataobj/sections/pointers/iter.go
@@ -41,7 +41,7 @@ func Iter(ctx context.Context, obj *dataobj.Object) result.Seq[SectionPointer] {
 func IterSection(ctx context.Context, section *Section) result.Seq[SectionPointer] {
 	return result.Iter(func(yield func(SectionPointer) bool) error {
 		columnarSection := section.inner
-		dset, err := columnar.MakeDataset(columnarSection, columnarSection.Columns())
+		dset, err := columnar.MakeDataset(columnarSection, recognizedInnerColumns(section))
 		if err != nil {
 			return fmt.Errorf("creating columns dataset: %w", err)
 		}
@@ -85,6 +85,24 @@ func IterSection(ctx context.Context, section *Section) result.Seq[SectionPointe
 			}
 		}
 	})
+}
+
+// recognizedInnerColumns returns the underlying columnar columns for the
+// columns the section recognizes, preserving their order.
+//
+// Datasets and row readers must be built from these rather than from every
+// physical column in the section: it keeps each row's values positionally
+// aligned with sec.Columns() during decoding and transparently skips columns
+// written by a newer version of Loki that this reader doesn't understand.
+// Reading unrecognized columns would otherwise misalign or overrun decodeRow's
+// positional lookups.
+func recognizedInnerColumns(sec *Section) []*columnar.Column {
+	recognized := sec.Columns()
+	inner := make([]*columnar.Column, len(recognized))
+	for i, col := range recognized {
+		inner[i] = col.inner
+	}
+	return inner
 }
 
 // decodeRow decodes a stream from a [dataset.Row], using the provided columns to

--- a/pkg/dataobj/sections/pointers/iter_forward_compat_test.go
+++ b/pkg/dataobj/sections/pointers/iter_forward_compat_test.go
@@ -1,0 +1,123 @@
+package pointers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/internal/columnar"
+)
+
+// TestIter_ForwardCompatUnknownColumn ensures an older reader can iterate a
+// pointers section written by a newer Loki that added a column this reader
+// doesn't recognize, instead of panicking with an index-out-of-range in
+// decodeRow.
+func TestIter_ForwardCompatUnknownColumn(t *testing.T) {
+	objBuilder := dataobj.NewBuilder(nil)
+	require.NoError(t, objBuilder.Append(&unknownColumnSectionBuilder{}))
+
+	obj, closer, err := objBuilder.Flush()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = closer.Close() })
+
+	sec, err := Open(t.Context(), obj.Sections()[0])
+	require.NoError(t, err)
+
+	require.Len(t, sec.inner.Columns(), 3, "physical section should carry the unknown column")
+	require.Len(t, sec.Columns(), 2, "unknown column should be dropped from the typed view")
+
+	var got []SectionPointer
+	for res := range Iter(t.Context(), obj) {
+		p, err := res.Value()
+		require.NoError(t, err)
+		got = append(got, p)
+	}
+
+	require.Len(t, got, 2)
+	require.Equal(t, "path1", got[0].Path)
+	require.Equal(t, "path2", got[1].Path)
+	require.Equal(t, int64(1), got[0].StreamID)
+	require.Equal(t, int64(2), got[1].StreamID)
+}
+
+// unknownColumnSectionBuilder is a test-only [dataobj.SectionBuilder] that
+// encodes a pointers section with path/stream_id columns plus one column whose
+// logical type is unknown to the current reader, standing in for a section
+// written by a newer version of Loki.
+type unknownColumnSectionBuilder struct{}
+
+func (b *unknownColumnSectionBuilder) Type() dataobj.SectionType { return sectionType }
+
+func (b *unknownColumnSectionBuilder) Reset() {}
+
+func (b *unknownColumnSectionBuilder) Flush(w dataobj.SectionWriter) (int64, error) {
+	var enc columnar.Encoder
+	defer enc.Reset()
+
+	paths := []string{"path1", "path2"}
+	streamIDs := []int64{1, 2}
+
+	pathBuilder := newColumnBuilder("path", ColumnTypePath.String(), datasetmd.PHYSICAL_TYPE_BINARY)
+	streamIDBuilder := newColumnBuilder("stream_id", ColumnTypeStreamID.String(), datasetmd.PHYSICAL_TYPE_INT64)
+	// A column written by a newer Loki. Its logical type is unknown to
+	// ParseColumnType, so an older reader drops it from Section.Columns().
+	futureBuilder := newColumnBuilder("future_field", "future_field", datasetmd.PHYSICAL_TYPE_INT64)
+
+	for i := range paths {
+		_ = pathBuilder.Append(i, dataset.BinaryValue([]byte(paths[i])))
+		_ = streamIDBuilder.Append(i, dataset.Int64Value(streamIDs[i]))
+		_ = futureBuilder.Append(i, dataset.Int64Value(int64(i+1)))
+	}
+
+	// The unknown column is encoded last so it lands at a physical index beyond
+	// the recognized columns, reproducing the index-out-of-range panic.
+	if err := encodeTestColumns(&enc, pathBuilder, streamIDBuilder, futureBuilder); err != nil {
+		return 0, err
+	}
+
+	enc.SetTenant("tenant-1")
+	return enc.Flush(w)
+}
+
+func newColumnBuilder(name, logical string, physical datasetmd.PhysicalType) *dataset.ColumnBuilder {
+	// INT64 columns require DELTA encoding; binary columns use PLAIN.
+	encoding := datasetmd.ENCODING_TYPE_PLAIN
+	if physical == datasetmd.PHYSICAL_TYPE_INT64 {
+		encoding = datasetmd.ENCODING_TYPE_DELTA
+	}
+	b, err := dataset.NewColumnBuilder(name, dataset.BuilderOptions{
+		PageMaxRowCount: 100,
+		Type:            dataset.ColumnType{Physical: physical, Logical: logical},
+		Encoding:        encoding,
+		Compression:     datasetmd.COMPRESSION_TYPE_NONE,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func encodeTestColumns(enc *columnar.Encoder, builders ...*dataset.ColumnBuilder) error {
+	for _, b := range builders {
+		column, err := b.Flush()
+		if err != nil {
+			return err
+		}
+		columnEnc, err := enc.OpenColumn(column.ColumnDesc())
+		if err != nil {
+			return err
+		}
+		for _, page := range column.Pages {
+			if err := columnEnc.AppendPage(page); err != nil {
+				return err
+			}
+		}
+		if err := columnEnc.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/dataobj/sections/pointers/row_reader.go
+++ b/pkg/dataobj/sections/pointers/row_reader.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/slicegrow"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/symbolizer"
-	"github.com/grafana/loki/v3/pkg/dataobj/sections/internal/columnar"
 )
 
 // RowReader reads the set of streams from an [Object].
@@ -131,7 +130,7 @@ func (r *RowReader) Read(ctx context.Context, s []SectionPointer) (int, error) {
 }
 
 func (r *RowReader) initReader(ctx context.Context) error {
-	dset, err := columnar.MakeDataset(r.sec.inner, recognizedInnerColumns(r.sec))
+	dset, err := r.sec.makeDataset()
 	if err != nil {
 		return fmt.Errorf("creating section dataset: %w", err)
 	}

--- a/pkg/dataobj/sections/pointers/row_reader.go
+++ b/pkg/dataobj/sections/pointers/row_reader.go
@@ -131,7 +131,7 @@ func (r *RowReader) Read(ctx context.Context, s []SectionPointer) (int, error) {
 }
 
 func (r *RowReader) initReader(ctx context.Context) error {
-	dset, err := columnar.MakeDataset(r.sec.inner, r.sec.inner.Columns())
+	dset, err := columnar.MakeDataset(r.sec.inner, recognizedInnerColumns(r.sec))
 	if err != nil {
 		return fmt.Errorf("creating section dataset: %w", err)
 	}

--- a/pkg/dataobj/sections/streams/iter.go
+++ b/pkg/dataobj/sections/streams/iter.go
@@ -82,7 +82,7 @@ func IterSection(ctx context.Context, section *Section, opts ...IterOption) resu
 func iterSection(ctx context.Context, section *Section, cfg iterConfig) result.Seq[Stream] {
 	return result.Iter(func(yield func(Stream) bool) error {
 		columnarSection := section.inner
-		dset, err := columnar.MakeDataset(columnarSection, columnarSection.Columns())
+		dset, err := columnar.MakeDataset(columnarSection, recognizedInnerColumns(section))
 		if err != nil {
 			return fmt.Errorf("creating columns dataset: %w", err)
 		}
@@ -127,6 +127,24 @@ func iterSection(ctx context.Context, section *Section, cfg iterConfig) result.S
 			}
 		}
 	})
+}
+
+// recognizedInnerColumns returns the underlying columnar columns for the
+// columns the section recognizes, preserving their order.
+//
+// Datasets and row readers must be built from these rather than from every
+// physical column in the section: it keeps each row's values positionally
+// aligned with sec.Columns() during decoding and transparently skips columns
+// written by a newer version of Loki that this reader doesn't understand.
+// Reading unrecognized columns would otherwise misalign or overrun decodeRow's
+// positional lookups.
+func recognizedInnerColumns(sec *Section) []*columnar.Column {
+	recognized := sec.Columns()
+	inner := make([]*columnar.Column, len(recognized))
+	for i, col := range recognized {
+		inner[i] = col.inner
+	}
+	return inner
 }
 
 // decodeRow decodes a stream from a [dataset.Row], using the provided columns to

--- a/pkg/dataobj/sections/streams/iter.go
+++ b/pkg/dataobj/sections/streams/iter.go
@@ -81,8 +81,7 @@ func IterSection(ctx context.Context, section *Section, opts ...IterOption) resu
 
 func iterSection(ctx context.Context, section *Section, cfg iterConfig) result.Seq[Stream] {
 	return result.Iter(func(yield func(Stream) bool) error {
-		columnarSection := section.inner
-		dset, err := columnar.MakeDataset(columnarSection, recognizedInnerColumns(section))
+		dset, err := section.makeDataset()
 		if err != nil {
 			return fmt.Errorf("creating columns dataset: %w", err)
 		}
@@ -129,22 +128,15 @@ func iterSection(ctx context.Context, section *Section, cfg iterConfig) result.S
 	})
 }
 
-// recognizedInnerColumns returns the underlying columnar columns for the
-// columns the section recognizes, preserving their order.
-//
-// Datasets and row readers must be built from these rather than from every
-// physical column in the section: it keeps each row's values positionally
-// aligned with sec.Columns() during decoding and transparently skips columns
-// written by a newer version of Loki that this reader doesn't understand.
-// Reading unrecognized columns would otherwise misalign or overrun decodeRow's
-// positional lookups.
-func recognizedInnerColumns(sec *Section) []*columnar.Column {
-	recognized := sec.Columns()
+// makeDataset builds a dataset from only the recognized columns, so rows stay
+// aligned with Columns() and columns from a newer Loki are skipped, not decoded.
+func (s *Section) makeDataset() (*columnar.Dataset, error) {
+	recognized := s.Columns()
 	inner := make([]*columnar.Column, len(recognized))
 	for i, col := range recognized {
 		inner[i] = col.inner
 	}
-	return inner
+	return columnar.MakeDataset(s.inner, inner)
 }
 
 // decodeRow decodes a stream from a [dataset.Row], using the provided columns to

--- a/pkg/dataobj/sections/streams/iter_forward_compat_test.go
+++ b/pkg/dataobj/sections/streams/iter_forward_compat_test.go
@@ -1,0 +1,125 @@
+package streams
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/internal/columnar"
+)
+
+// TestIter_ForwardCompatUnknownColumn ensures an older reader can iterate a
+// streams section written by a newer Loki that added a column this reader
+// doesn't recognize, instead of panicking with an index-out-of-range in
+// decodeRow.
+func TestIter_ForwardCompatUnknownColumn(t *testing.T) {
+	obj := buildObjectWithUnknownColumn(t, &unknownColumnSectionBuilder{})
+
+	sec, err := Open(t.Context(), obj.Sections()[0])
+	require.NoError(t, err)
+
+	require.Len(t, sec.inner.Columns(), 3, "physical section should carry the unknown column")
+	require.Len(t, sec.Columns(), 2, "unknown column should be dropped from the typed view")
+
+	var got []Stream
+	for res := range Iter(t.Context(), obj) {
+		s, err := res.Value()
+		require.NoError(t, err)
+		got = append(got, s)
+	}
+
+	require.Len(t, got, 2)
+	require.Equal(t, int64(1), got[0].ID)
+	require.Equal(t, int64(2), got[1].ID)
+	require.Equal(t, int64(10), got[0].MinTimestamp.UnixNano())
+	require.Equal(t, int64(30), got[1].MinTimestamp.UnixNano())
+}
+
+func buildObjectWithUnknownColumn(t *testing.T, sb dataobj.SectionBuilder) *dataobj.Object {
+	t.Helper()
+
+	objBuilder := dataobj.NewBuilder(nil)
+	require.NoError(t, objBuilder.Append(sb))
+
+	obj, closer, err := objBuilder.Flush()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = closer.Close() })
+	return obj
+}
+
+// unknownColumnSectionBuilder is a test-only [dataobj.SectionBuilder] that
+// encodes a streams section with stream_id/min_timestamp columns plus one
+// column whose logical type is unknown to the current reader, standing in for
+// a section written by a newer version of Loki.
+type unknownColumnSectionBuilder struct{}
+
+func (b *unknownColumnSectionBuilder) Type() dataobj.SectionType { return sectionType }
+
+func (b *unknownColumnSectionBuilder) Reset() {}
+
+func (b *unknownColumnSectionBuilder) Flush(w dataobj.SectionWriter) (int64, error) {
+	var enc columnar.Encoder
+	defer enc.Reset()
+
+	streamIDs := []int64{1, 2}
+	minTimestamps := []int64{10, 30}
+
+	streamIDBuilder := newInt64ColumnBuilder("stream_id", ColumnTypeStreamID.String())
+	minTimestampBuilder := newInt64ColumnBuilder("min_timestamp", ColumnTypeMinTimestamp.String())
+	// A column written by a newer Loki. Its logical type is unknown to
+	// ParseColumnType, so an older reader drops it from Section.Columns().
+	futureBuilder := newInt64ColumnBuilder("future_field", "future_field")
+
+	for i := range streamIDs {
+		_ = streamIDBuilder.Append(i, dataset.Int64Value(streamIDs[i]))
+		_ = minTimestampBuilder.Append(i, dataset.Int64Value(minTimestamps[i]))
+		_ = futureBuilder.Append(i, dataset.Int64Value(int64(i+1)))
+	}
+
+	// The unknown column is encoded last so it lands at a physical index beyond
+	// the recognized columns, reproducing the index-out-of-range panic.
+	if err := encodeTestColumns(&enc, streamIDBuilder, minTimestampBuilder, futureBuilder); err != nil {
+		return 0, err
+	}
+
+	enc.SetTenant("tenant-1")
+	return enc.Flush(w)
+}
+
+func newInt64ColumnBuilder(name, logical string) *dataset.ColumnBuilder {
+	b, err := dataset.NewColumnBuilder(name, dataset.BuilderOptions{
+		PageMaxRowCount: 100,
+		Type:            dataset.ColumnType{Physical: datasetmd.PHYSICAL_TYPE_INT64, Logical: logical},
+		Encoding:        datasetmd.ENCODING_TYPE_DELTA,
+		Compression:     datasetmd.COMPRESSION_TYPE_NONE,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func encodeTestColumns(enc *columnar.Encoder, builders ...*dataset.ColumnBuilder) error {
+	for _, b := range builders {
+		column, err := b.Flush()
+		if err != nil {
+			return err
+		}
+		columnEnc, err := enc.OpenColumn(column.ColumnDesc())
+		if err != nil {
+			return err
+		}
+		for _, page := range column.Pages {
+			if err := columnEnc.AppendPage(page); err != nil {
+				return err
+			}
+		}
+		if err := columnEnc.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/dataobj/sections/streams/row_reader.go
+++ b/pkg/dataobj/sections/streams/row_reader.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/metadata/datasetmd"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/slicegrow"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/symbolizer"
-	"github.com/grafana/loki/v3/pkg/dataobj/sections/internal/columnar"
 )
 
 // RowReader reads the set of streams from an [Object].
@@ -105,7 +104,7 @@ func (r *RowReader) Read(ctx context.Context, s []Stream) (int, error) {
 }
 
 func (r *RowReader) initReader(ctx context.Context) error {
-	dset, err := columnar.MakeDataset(r.sec.inner, recognizedInnerColumns(r.sec))
+	dset, err := r.sec.makeDataset()
 	if err != nil {
 		return fmt.Errorf("creating section dataset: %w", err)
 	}

--- a/pkg/dataobj/sections/streams/row_reader.go
+++ b/pkg/dataobj/sections/streams/row_reader.go
@@ -105,7 +105,7 @@ func (r *RowReader) Read(ctx context.Context, s []Stream) (int, error) {
 }
 
 func (r *RowReader) initReader(ctx context.Context) error {
-	dset, err := columnar.MakeDataset(r.sec.inner, r.sec.inner.Columns())
+	dset, err := columnar.MakeDataset(r.sec.inner, recognizedInnerColumns(r.sec))
 	if err != nil {
 		return fmt.Errorf("creating section dataset: %w", err)
 	}


### PR DESCRIPTION
**What / why**

A newer Loki can add columns to a section; an older reader should skip the ones it doesn't know, but today it panics.

The reader builds each row from *all* stored columns, so a row has one value per stored column. To decode that row it walks the values by position and, for each one, looks up the matching column in its own list of *known* columns. If a row has more values than the reader has known columns, that lookup runs off the end.

**Example**

A newer Loki stored 4 columns; the old reader only knows 3 of them.

```
row read from data  : [path, min, max, new]   // 4 values, one per stored column
reader's known cols : [path, min, max]        // only 3

decode value[0] -> known[0]  ok
decode value[1] -> known[1]  ok
decode value[2] -> known[2]  ok
decode value[3] -> known[3]  panic: index out of range [3] with length 3
```

**Fix**

Build each row from only the known columns, so it has exactly as many values as there are known columns and the extra ones are skipped. Fixed in `iter.go`/`row_reader.go` of `indexpointers`, `streams`, `pointers`, `logs`, each with a test that iterates an unknown column: panics before, passes after.