### PR TITLE
feat(logql): Add per-tenant query bytes counter metric

### DIFF
--- a/docs/sources/shared/troubleshoot-query.md
+++ b/docs/sources/shared/troubleshoot-query.md
@@ -28,6 +28,7 @@ Query errors can be observed using these Prometheus metrics:
 
 - `loki_request_duration_seconds` - Query latency by route and status code
 - `loki_logql_querystats_bytes_processed_per_seconds` - Bytes processed during queries
+- `loki_logql_querystats_bytes_processed_total` - Total bytes processed by queries, broken down by `tenant`. This is the metric equivalent of the `total_bytes` field in the `caller=metrics.go` query log line and lets you track per-tenant query bytes without parsing logs.
 - `loki_frontend_query_range_duration_seconds_bucket` - Frontend query latency
 
 You can set up alerts on 4xx and 5xx status codes to detect query problems early. This can be helpful when tuning limits configurations.

--- a/pkg/logql/metrics.go
+++ b/pkg/logql/metrics.go
@@ -10,6 +10,7 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/tenant"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/model/labels"
@@ -70,6 +71,11 @@ var (
 		// 50MB 100MB 200MB 400MB 600MB 800MB 1GB 2GB 3GB 4GB 5GB 6GB 7GB 8GB 9GB 10GB 15GB 20GB 30GB, 40GB 50GB 60GB
 		Buckets: []float64{50 * 1e6, 100 * 1e6, 400 * 1e6, 600 * 1e6, 800 * 1e6, 1 * 1e9, 2 * 1e9, 3 * 1e9, 4 * 1e9, 5 * 1e9, 6 * 1e9, 7 * 1e9, 8 * 1e9, 9 * 1e9, 10 * 1e9, 15 * 1e9, 20 * 1e9, 30 * 1e9, 40 * 1e9, 50 * 1e9, 60 * 1e9},
 	}, []string{"status_code", "type", "range", "latency_type", "sharded"})
+	bytesProcessedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: constants.Loki,
+		Name:      "logql_querystats_bytes_processed_total",
+		Help:      "Total number of bytes processed by LogQL queries, partitioned by tenant.",
+	}, []string{"tenant"})
 	execLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: constants.Loki,
 		Name:      "logql_querystats_latency_seconds",
@@ -308,6 +314,16 @@ func RecordRangeAndInstantQueryMetrics(
 
 	bytesPerSecond.WithLabelValues(status, queryType, rt, latencyType, sharded).
 		Observe(float64(stats.Summary.BytesProcessedPerSecond))
+	// Record per-tenant query bytes. For federated multi-tenant queries the aggregated
+	// byte total is divided evenly across the tenants in the request, since the stats are
+	// not broken down per tenant. This keeps the sum across tenants equal to the actual
+	// bytes processed. TenantIDs returns a normalized (sorted, de-duplicated) list.
+	if tenantIDs, err := tenant.TenantIDs(ctx); err == nil && len(tenantIDs) > 0 {
+		bytesPerTenant := float64(stats.Summary.TotalBytesProcessed) / float64(len(tenantIDs))
+		for _, tenantID := range tenantIDs {
+			bytesProcessedTotal.WithLabelValues(tenantID).Add(bytesPerTenant)
+		}
+	}
 	execLatency.WithLabelValues(status, queryType, rt).
 		Observe(stats.Summary.ExecTime)
 	chunkDownloadLatency.WithLabelValues(status, queryType, rt).

--- a/pkg/logql/metrics_test.go
+++ b/pkg/logql/metrics_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/user"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
@@ -87,6 +88,48 @@ func TestLogSlowQuery(t *testing.T) {
 		)),
 		buf.String())
 	util_log.Logger = log.NewNopLogger()
+}
+
+func TestRecordBytesProcessedTotal(t *testing.T) {
+	util_log.Logger = log.NewNopLogger()
+
+	params := LiteralParams{
+		queryString: `{foo="bar"} |= "buzz"`,
+		direction:   logproto.BACKWARD,
+		limit:       1000,
+		step:        time.Minute,
+		queryExpr:   syntax.MustParseExpr(`{foo="bar"} |= "buzz"`),
+	}
+	result := stats.Result{Summary: stats.Summary{TotalBytesProcessed: 100000}}
+
+	// Use a tenant unique to this test so we do not collide with the shared,
+	// package-level counter incremented by other tests.
+	const tenantID = "record-bytes-tenant"
+	ctx := user.InjectOrgID(context.Background(), tenantID)
+
+	now := time.Now()
+	params.start, params.end = now.Add(-1*time.Hour), now
+
+	counter := bytesProcessedTotal.WithLabelValues(tenantID)
+
+	RecordRangeAndInstantQueryMetrics(ctx, util_log.Logger, params, "200", result, nil)
+	require.Equal(t, float64(100000), testutil.ToFloat64(counter))
+
+	// A second query for the same tenant accumulates.
+	RecordRangeAndInstantQueryMetrics(ctx, util_log.Logger, params, "200", result, nil)
+	require.Equal(t, float64(200000), testutil.ToFloat64(counter))
+
+	// Federated multi-tenant queries divide the byte total evenly across tenants.
+	fedA, fedB := "record-bytes-fed-a", "record-bytes-fed-b"
+	fedCtx := user.InjectOrgID(context.Background(), fmt.Sprintf("%s|%s", fedA, fedB))
+	RecordRangeAndInstantQueryMetrics(fedCtx, util_log.Logger, params, "200", result, nil)
+	require.Equal(t, float64(50000), testutil.ToFloat64(bytesProcessedTotal.WithLabelValues(fedA)))
+	require.Equal(t, float64(50000), testutil.ToFloat64(bytesProcessedTotal.WithLabelValues(fedB)))
+
+	// When no tenant can be resolved from the context the metric is skipped rather
+	// than recorded under an empty tenant label (and must not panic).
+	RecordRangeAndInstantQueryMetrics(context.Background(), util_log.Logger, params, "200", result, nil)
+	require.Equal(t, float64(0), testutil.ToFloat64(bytesProcessedTotal.WithLabelValues("")))
 }
 
 func TestLogLabelsQuery(t *testing.T) {


### PR DESCRIPTION
Add a new metric `loki_logql_querystats_bytes_processed_total` that records the per tenant number of bytes processed while executing logql queries. "bytes processed" is the number of bytes of chunk data accessed while running the query.

Note that for multi tenant queries there is no clear way to perfectly attribute bytes processed per tenant. In these cases we evenly attribute the bytes processed to all tenants.