### PR TITLE
chore(dataset): Fix benchmarkBitmapEncoder

### DIFF
--- a/pkg/dataobj/internal/dataset/value_encoding_bitmap.go
+++ b/pkg/dataobj/internal/dataset/value_encoding_bitmap.go
@@ -14,10 +14,7 @@ import (
 
 const maxRunLength uint64 = 1<<63 - 1 // 2^63-1
 
-// bitmapEncoder encodes and decodes bitmaps of unsigned numbers up to 64 bits
-// wide. To use bitmap with signed integers, callers should first encode the
-// integers using zig-zag encoding to minimize the number of bits needed for
-// negative values.
+// bitmapEncoder encodes and decodes bitmaps (one bit per value).
 //
 // Data is encoded with a hybrid of run-length encoding and bitpacking. Longer
 // sequences of the same value are encoded with run-length encoding, while

--- a/pkg/dataobj/internal/dataset/value_encoding_bitmap_test.go
+++ b/pkg/dataobj/internal/dataset/value_encoding_bitmap_test.go
@@ -220,47 +220,25 @@ func Benchmark_bitmapEncoder(b *testing.B) {
 }
 
 func benchmarkBitmapEncoder(b *testing.B, width int) {
-	b.Run("variance=none", func(b *testing.B) {
-		var cw countingWriter
-		enc := newBitmapEncoder(&cw)
+	runBenchmark := func(b *testing.B, name string, width int, m func(i, width int) uint64) {
+		b.Run(name, func(b *testing.B) {
+			var cw countingWriter
+			enc := newBitmapEncoder(&cw)
 
-		b.ResetTimer()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = enc.Encode(Uint64Value(m(i, width)))
+			}
+			_ = enc.Flush()
 
-		for i := 0; i < b.N; i++ {
-			_ = enc.Encode(Uint64Value(1))
-		}
-		_ = enc.Flush()
+			b.ReportMetric(float64(cw.n), "encoded_bytes")
+		})
+	}
 
-		b.ReportMetric(float64(cw.n), "encoded_bytes")
-	})
-
-	b.Run("variance=alternating", func(b *testing.B) {
-		var cw countingWriter
-		enc := newBitmapEncoder(&cw)
-
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			_ = enc.Encode(Uint64Value(uint64(i % width)))
-		}
-		_ = enc.Flush()
-
-		b.ReportMetric(float64(cw.n), "encoded_bytes")
-	})
-
-	b.Run("variance=random", func(b *testing.B) {
-		rnd := rand.New(rand.NewSource(0))
-
-		var cw countingWriter
-		enc := newBitmapEncoder(&cw)
-
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			_ = enc.Encode(Uint64Value(uint64(rnd.Int63()) % uint64(width)))
-		}
-		_ = enc.Flush()
-
-		b.ReportMetric(float64(cw.n), "encoded_bytes")
-	})
+	runBenchmark(b, "variance=none", width, func(i, width int) uint64 { return 1 })
+	runBenchmark(b, "variance=alternating", width, func(i, width int) uint64 { return uint64(i % width) })
+	rnd := rand.New(rand.NewSource(0))
+	runBenchmark(b, "variance=random", width, func(i, width int) uint64 { return uint64(rnd.Int63()) % uint64(width) })
 }
 
 func Benchmark_bitmapDecoder_DecodeBatches(b *testing.B) {

--- a/pkg/dataobj/internal/dataset/value_encoding_bitmap_test.go
+++ b/pkg/dataobj/internal/dataset/value_encoding_bitmap_test.go
@@ -243,9 +243,9 @@ func benchmarkBitmapEncoder(b *testing.B, width int) {
 	}
 
 	runBenchmark(b, "variance=none", width, func(i, width int) uint64 { return 1 })
-	runBenchmark(b, "variance=alternating", width, func(i, width int) uint64 { return uint64(i % width) })
+	runBenchmark(b, "variance=alternating", width, func(i, width int) uint64 { return uint64(i % (1 << width)) })
 	rnd := rand.New(rand.NewSource(0))
-	runBenchmark(b, "variance=random", width, func(i, width int) uint64 { return uint64(rnd.Int63()) % uint64(width) })
+	runBenchmark(b, "variance=random", width, func(i, width int) uint64 { return uint64(rnd.Int63()) % uint64(1<<width) })
 }
 
 func Benchmark_bitmapDecoder_DecodeBatches(b *testing.B) {

--- a/pkg/dataobj/internal/dataset/value_encoding_bitmap_test.go
+++ b/pkg/dataobj/internal/dataset/value_encoding_bitmap_test.go
@@ -222,12 +222,19 @@ func Benchmark_bitmapEncoder(b *testing.B) {
 func benchmarkBitmapEncoder(b *testing.B, width int) {
 	runBenchmark := func(b *testing.B, name string, width int, m func(i, width int) uint64) {
 		b.Run(name, func(b *testing.B) {
+			// Pre-compute values so we're not benchmarking generation or conversion to Value type.
+			const numValues = 32768 // Enough to defeat the CPU branch predictor
+			values := make([]Value, numValues)
+			for i := range values {
+				values[i] = Uint64Value(m(i, width))
+			}
+
 			var cw countingWriter
 			enc := newBitmapEncoder(&cw)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_ = enc.Encode(Uint64Value(m(i, width)))
+				_ = enc.Encode(values[i%numValues])
 			}
 			_ = enc.Flush()
 

--- a/pkg/dataobj/internal/dataset/value_encoding_bitmap_test.go
+++ b/pkg/dataobj/internal/dataset/value_encoding_bitmap_test.go
@@ -212,11 +212,6 @@ func Fuzz_bitmap_EncodeN(f *testing.F) {
 
 func Benchmark_bitmapEncoder(b *testing.B) {
 	b.Run("width=1", func(b *testing.B) { benchmarkBitmapEncoder(b, 1) })
-	b.Run("width=3", func(b *testing.B) { benchmarkBitmapEncoder(b, 3) })
-	b.Run("width=5", func(b *testing.B) { benchmarkBitmapEncoder(b, 5) })
-	b.Run("width=8", func(b *testing.B) { benchmarkBitmapEncoder(b, 8) })
-	b.Run("width=32", func(b *testing.B) { benchmarkBitmapEncoder(b, 32) })
-	b.Run("width=64", func(b *testing.B) { benchmarkBitmapEncoder(b, 64) })
 }
 
 func benchmarkBitmapEncoder(b *testing.B, width int) {

--- a/pkg/dataobj/internal/dataset/value_encoding_bitmap_test.go
+++ b/pkg/dataobj/internal/dataset/value_encoding_bitmap_test.go
@@ -237,10 +237,10 @@ func benchmarkBitmapEncoder(b *testing.B, width int) {
 		})
 	}
 
-	runBenchmark(b, "variance=none", width, func(i, width int) uint64 { return 1 })
+	runBenchmark(b, "variance=none", width, func(_, _ int) uint64 { return 1 })
 	runBenchmark(b, "variance=alternating", width, func(i, width int) uint64 { return uint64(i % (1 << width)) })
 	rnd := rand.New(rand.NewSource(0))
-	runBenchmark(b, "variance=random", width, func(i, width int) uint64 { return uint64(rnd.Int63()) % uint64(1<<width) })
+	runBenchmark(b, "variance=random", width, func(_, width int) uint64 { return uint64(rnd.Int63()) % uint64(1<<width) })
 }
 
 func Benchmark_bitmapDecoder_DecodeBatches(b *testing.B) {


### PR DESCRIPTION
**What this PR does / why we need it**:

The big change is that bitmapEncoder only supports 1-bit width since #20467, so we can remove the benchmark cases testing 3, 5, 8, 32, 64 bits.

However all the cases were using that parameter as a modulus not a bit-width, so were a bit misleading. 

`benchmarkBitmapEncoder` now precomputes values, because both random-number generation and conversion to `Value`` type are significant costs that we don't want to include in the benchmark measurements.

Clarify in doc comment that bitmapEncoder only supports 1-bit values.

Previously all 1-bit cases encoded 6 bytes, because they all tested a run of 0s:
```
Benchmark_bitmapEncoder/width=1/variance=none-28                914791410                1.283 ns/op             6.000 encoded_bytes
Benchmark_bitmapEncoder/width=1/variance=alternating-28         671399454                1.786 ns/op             6.000 encoded_bytes
Benchmark_bitmapEncoder/width=1/variance=random-28              469341307                2.572 ns/op             6.000 encoded_bytes
```

Now:
```
Benchmark_bitmapEncoder/width=1/variance=none-28                772993138                1.476 ns/op             6.000 encoded_bytes
Benchmark_bitmapEncoder/width=1/variance=alternating-28         334286320                3.629 ns/op      41816396 encoded_bytes
Benchmark_bitmapEncoder/width=1/variance=random-28              155243233                7.722 ns/op      19879145 encoded_bytes
```

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
