### PR TITLE
fix(chunks): Return storage error instead of silent partial results in FetchChunks

### DIFF
--- a/pkg/storage/chunk/fetcher/fetcher.go
+++ b/pkg/storage/chunk/fetcher/fetcher.go
@@ -199,9 +199,12 @@ func (c *Fetcher) FetchChunks(ctx context.Context, chunks []chunk.Chunk) ([]chun
 	}
 
 	// Fetch missing from storage
-	var fromStorage []chunk.Chunk
+	var (
+		fromStorage []chunk.Chunk
+		storageErr  error
+	)
 	if len(missing) > 0 {
-		fromStorage, err = c.storage.GetChunks(ctx, missing)
+		fromStorage, storageErr = c.storage.GetChunks(ctx, missing)
 	}
 
 	// normally these stats would be collected by the cache.statsCollector wrapper, but chunks are written back
@@ -224,8 +227,9 @@ func (c *Fetcher) FetchChunks(ctx context.Context, chunks []chunk.Chunk) ([]chun
 		level.Warn(log).Log("msg", "could not store chunks in chunk cache", "err", cacheErr)
 	}
 
-	if err != nil {
-		level.Error(log).Log("msg", "failed downloading chunks", "err", err)
+	if storageErr != nil {
+		level.Error(log).Log("msg", "failed downloading chunks", "err", storageErr)
+		return nil, storageErr
 	}
 
 	allChunks := append(fromCache, fromStorage...)


### PR DESCRIPTION
**What this PR does / why we need it**:
`Fetcher.FetchChunks` fetches chunks from cache first, then falls back to object storage for the ones the cache missed. When the storage fetch failed, the error was logged but not returned. Callers received the cached subset plus whatever chunks the storage client happened to return before failing and treated it as a complete result.

This PR isolates the storage error into a dedicated variable and short-circuits with `return nil, storageErr` when the storage fetch fails. Cache-writeback failures continue to be logged as warnings without failing the query, since the chunks we already have are still usable and the cache continues to be treated as a best-effort service.

Since most object storage clients are by default configured to retry failed requests, queries should not suddenly start failing with this change as long as the storage service is not having major issues. In any case, it doesn't make sense to respond with partial results if we can't fetch all the chunks required for a query.