### PR TITLE
fix: scope boltdb RemoveChunk to current index table period

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/iterator.go
+++ b/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/iterator.go
@@ -75,6 +75,7 @@ func ForEachSeries(ctx context.Context, bucket *bbolt.Bucket, config config.Peri
 }
 
 type seriesCleaner struct {
+	tableName     string
 	tableInterval model.Interval
 	shards        map[uint32]string
 	bucket        *bbolt.Bucket
@@ -97,6 +98,7 @@ func newSeriesCleaner(bucket *bbolt.Bucket, periodConfig config.PeriodConfig, ta
 	}
 
 	return &seriesCleaner{
+		tableName:     tableName,
 		tableInterval: retention.ExtractIntervalFromTableName(tableName),
 		schema:        schema,
 		bucket:        bucket,
@@ -137,6 +139,22 @@ func (s *seriesCleaner) CleanupSeries(userID []byte, lbls labels.Labels) error {
 	return nil
 }
 
+// entriesForTable returns the subset of index entries that belong to the table
+// this cleaner is processing. GetChunkWriteEntries recomputes keys for every
+// period a chunk overlaps; each boltdb table only stores its own period's keys.
+func (s *seriesCleaner) entriesForTable(indexEntries []series_index.Entry) []series_index.Entry {
+	if len(indexEntries) == 0 {
+		return indexEntries
+	}
+	filtered := indexEntries[:0]
+	for _, indexEntry := range indexEntries {
+		if indexEntry.TableName == s.tableName {
+			filtered = append(filtered, indexEntry)
+		}
+	}
+	return filtered
+}
+
 func (s *seriesCleaner) RemoveChunk(from, through model.Time, userID []byte, lbls labels.Labels, chunkID string) (bool, error) {
 	// We need to add metric name label as well if it is missing since the series ids are calculated including that.
 	builder := labels.NewBuilder(lbls)
@@ -145,10 +163,17 @@ func (s *seriesCleaner) RemoveChunk(from, through model.Time, userID []byte, lbl
 	}
 	lbls = builder.Labels()
 
+	// Keep the full [from, through] so range keys (relative through offsets) stay
+	// correct, but only validate/delete entries for this table (#23358).
 	indexEntries, err := s.schema.GetChunkWriteEntries(from, through, string(userID), logMetricName, lbls, chunkID)
 	if err != nil {
 		return false, err
 	}
+	indexEntries = s.entriesForTable(indexEntries)
+	if len(indexEntries) == 0 {
+		return false, nil
+	}
+
 	keys := make([][]byte, 0, len(indexEntries))
 	for _, indexEntry := range indexEntries {
 		key := make([]byte, 0, len(indexEntry.HashValue)+len(separator)+len(indexEntry.RangeValue))
@@ -193,6 +218,11 @@ func (s *seriesCleaner) ChunkExists(userID []byte, lbls labels.Labels, chunkRef 
 	if err != nil {
 		return false, err
 	}
+	indexEntries = s.entriesForTable(indexEntries)
+	if len(indexEntries) == 0 {
+		return false, nil
+	}
+
 	for _, indexEntry := range indexEntries {
 		key := make([]byte, 0, len(indexEntry.HashValue)+len(separator)+len(indexEntry.RangeValue))
 		key = append(key, []byte(indexEntry.HashValue)...)

--- a/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/iterator_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/boltdb/compactor/iterator_test.go
@@ -113,6 +113,63 @@ func Test_ChunkIteratorContextCancelation(t *testing.T) {
 	require.Len(t, actual, 1)
 }
 
+// Test_RemoveChunk_SpansIndexPeriodBoundary reproduces #23358: a chunk that
+// spans an index-period (day) boundary is indexed in two tables. RemoveChunk
+// must only require/delete the entries that belong to the table currently
+// being processed; keys for the adjacent period are legitimately absent.
+func Test_RemoveChunk_SpansIndexPeriodBoundary(t *testing.T) {
+	// v12 covers a long window in the shared schemaCfg; pick a midnight fully
+	// inside that period so Put writes entries into two daily tables.
+	tt := allSchemas[3]
+	cm := storage.NewClientMetrics()
+	defer cm.Unregister()
+	store := newTestStore(t, cm)
+	chunkfmt, headfmt, err := tt.config.ChunkFormat()
+	require.NoError(t, err)
+
+	// First midnight at least one full day after the schema period starts.
+	dayBoundary := model.TimeFromUnix((tt.from.Unix()/86400 + 2) * 86400)
+	chunkFrom := dayBoundary.Add(-2 * time.Hour)
+	chunkThrough := dayBoundary.Add(2 * time.Hour)
+
+	lbs := labels.New(labels.Label{Name: "foo", Value: "span"})
+	c := createChunk(t, chunkfmt, headfmt, "fake", lbs, chunkFrom, chunkThrough)
+	require.NoError(t, store.Put(context.TODO(), []chunk.Chunk{c}))
+	store.Stop()
+
+	chunkID := store.schemaCfg.ExternalKey(c.ChunkRef)
+	tables := store.indexTables()
+
+	tablesWithChunk := 0
+	for _, tbl := range tables {
+		err := tbl.Update(func(tx *bbolt.Tx) error {
+			bucket := tx.Bucket(local.IndexBucketName)
+			cleaner := newSeriesCleaner(bucket, tt.config, tbl.name)
+			return ForEachSeries(context.Background(), bucket, tt.config, func(series retention.Series) error {
+				for _, chk := range series.Chunks() {
+					if chk.ChunkID != chunkID {
+						continue
+					}
+					tablesWithChunk++
+					// Full chunk time range, as markForDelete does — must not fail
+					// because adjacent-period keys are missing from this table.
+					existed, err := cleaner.RemoveChunk(chk.From, chk.Through, series.UserID(), series.Labels(), chk.ChunkID)
+					require.NoError(t, err)
+					require.True(t, existed, "table %s should remove its entry for spanning chunk", tbl.name)
+
+					// Entry should already be gone on a second pass.
+					removedAgain, err := cleaner.RemoveChunk(chk.From, chk.Through, series.UserID(), series.Labels(), chk.ChunkID)
+					require.NoError(t, err)
+					require.False(t, removedAgain, "table %s entry should already be deleted", tbl.name)
+				}
+				return nil
+			})
+		})
+		require.NoError(t, err)
+	}
+	require.GreaterOrEqual(t, tablesWithChunk, 2, "chunk spanning a day boundary should be indexed in at least two tables")
+}
+
 func Test_SeriesCleaner(t *testing.T) {
 	for _, tt := range allSchemas {
 		t.Run(tt.schema, func(t *testing.T) {


### PR DESCRIPTION
## What this PR does / why we need it

Since v3.6.0 (#19093), boltdb-shipper retention fails for any chunk whose time range spans an index-period (day) boundary with:

```
could not find entry of chunk <id> to remove it
```

That error aborts `RunCompaction(applyRetention=true)`, so
`loki_compactor_apply_retention_last_successful_run_timestamp_seconds` stays at 0 and nothing is deleted.

**Root cause:** `seriesCleaner.RemoveChunk` calls `GetChunkWriteEntries(from, through, ...)`, which returns index keys for **every** period the chunk overlaps. After #19093, every key must exist in the current table before delete. Adjacent-period keys live in adjacent tables, so they are legitimately missing and retention hard-fails. Before #19093, `bucket.Delete` on a missing key was a no-op.

This is expected data: ingesters do not cut chunks on day boundaries, and the write path deliberately indexes multi-period chunks in every overlapping table.

## Fix

- Keep the full chunk `[from, through]` when recomputing keys (range keys encode relative through offsets that must match the write path).
- Filter recomputed entries to those whose `TableName` matches the table currently being compacted.
- Only validate (`Get`) and delete keys for that table.
- Apply the same scoping to `ChunkExists`.

## Target branch

`release-3.7.x` — boltdb-shipper was removed from `main` in #21678; this regression still affects all 3.6.x / 3.7.x users mid-migration who retain boltdb-shipper data.

## Test plan

- [x] `go test ./pkg/storage/stores/shipper/indexshipper/boltdb/compactor/`
- [x] New regression test `Test_RemoveChunk_SpansIndexPeriodBoundary` writes a chunk across midnight, asserts it is indexed in ≥2 tables, and that `RemoveChunk` with the full chunk range succeeds on each table.

Fixes #23358