### PR TITLE
fix(compaction): Use a dedicated builder config for compacted log objects

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1737,6 +1737,45 @@ dataobj:
       # CLI flag: -dataobj.compaction.indexobj-builder.estimated-compression-ratio
       [estimated_compression_ratio: <int> | default = 8]
 
+    logsobj_builder:
+      # The target maximum amount of uncompressed data to hold in data pages
+      # (for columnar sections). Uncompressed size is used for consistent I/O
+      # and planning.
+      # CLI flag: -dataobj.compaction.logsobj-builder.target-page-size
+      [target_page_size: <int> | default = 2MiB]
+
+      # The maximum row count for pages to use for the data object builder. A
+      # value of 0 means no limit.
+      # CLI flag: -dataobj.compaction.logsobj-builder.max-page-rows
+      [max_page_rows: <int> | default = 0]
+
+      # The target maximum size of the encoded object and all of its encoded
+      # sections (after compression), to limit memory usage of a builder.
+      # CLI flag: -dataobj.compaction.logsobj-builder.target-builder-memory-limit
+      [target_object_size: <int> | default = 1GiB]
+
+      # The target maximum amount of uncompressed data to hold in sections, for
+      # sections that support being limited by size. Uncompressed size is used
+      # for consistent I/O and planning.
+      # CLI flag: -dataobj.compaction.logsobj-builder.target-section-size
+      [target_section_size: <int> | default = 128MiB]
+
+      # The size of logs to buffer in memory before adding into columnar
+      # builders, used to reduce CPU load of sorting.
+      # CLI flag: -dataobj.compaction.logsobj-builder.buffer-size
+      [buffer_size: <int> | default = 16MiB]
+
+      # The maximum number of dataobj section stripes to merge into a section at
+      # once. Must be greater than 1.
+      # CLI flag: -dataobj.compaction.logsobj-builder.section-stripe-merge-limit
+      [section_stripe_merge_limit: <int> | default = 2]
+
+      # Expected compression ratio for log data, used to estimate compressed
+      # output size from uncompressed buffered records. Only takes effect with
+      # ordered append. Set to 0 or 1 to disable.
+      # CLI flag: -dataobj.compaction.logsobj-builder.estimated-compression-ratio
+      [estimated_compression_ratio: <int> | default = 8]
+
   # The prefix to use for the storage bucket.
   # CLI flag: -dataobj-storage-bucket-prefix
   [storage_bucket_prefix: <string> | default = "dataobj/"]

--- a/pkg/engine/compactor/config.go
+++ b/pkg/engine/compactor/config.go
@@ -86,6 +86,14 @@ type Config struct {
 	// target object/section sizes, etc.) used by the compactor worker when
 	// merging postings + stats sections into a new index object.
 	IndexobjBuilder logsobj.BuilderBaseConfig `yaml:"indexobj_builder" category:"experimental"`
+
+	// LogsobjBuilder controls the construction of the compacted *data* (log)
+	// objects that LogMerge writes. It is deliberately separate from
+	// IndexobjBuilder: index objects are small and finely sectioned, while the
+	// merged log objects must use data-object-scale sections (like the ingester's
+	// ~128MB) — reusing the small index-object section size over-sections the
+	// merged objects and balloons the index rebuilt over them.
+	LogsobjBuilder logsobj.BuilderBaseConfig `yaml:"logsobj_builder" category:"experimental"`
 }
 
 // SchedulerConfig holds the scheduler-side parameters that get passed
@@ -200,6 +208,15 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	_ = cfg.IndexobjBuilder.TargetSectionSize.Set("2MB")
 	_ = cfg.IndexobjBuilder.BufferSize.Set("16KB")
 	cfg.IndexobjBuilder.RegisterFlagsWithPrefix(prefix+"indexobj-builder.", f)
+
+	// The compacted log objects are data objects; default them to the ingester's
+	// data-object sizes (not the small index-object sizes above) so LogMerge does
+	// not over-section them and inflate the index built over them.
+	_ = cfg.LogsobjBuilder.TargetPageSize.Set("2MB")
+	_ = cfg.LogsobjBuilder.TargetObjectSize.Set("1GB")
+	_ = cfg.LogsobjBuilder.TargetSectionSize.Set("128MB")
+	_ = cfg.LogsobjBuilder.BufferSize.Set("16MB")
+	cfg.LogsobjBuilder.RegisterFlagsWithPrefix(prefix+"logsobj-builder.", f)
 }
 
 // RegisterFlagsWithPrefix registers the worker config flags using prefix
@@ -251,6 +268,9 @@ func (cfg *Config) Validate() error {
 
 	if err := cfg.IndexobjBuilder.Validate(); err != nil {
 		return fmt.Errorf("invalid indexobj builder config: %w", err)
+	}
+	if err := cfg.LogsobjBuilder.Validate(); err != nil {
+		return fmt.Errorf("invalid logsobj builder config: %w", err)
 	}
 	return nil
 }

--- a/pkg/engine/compactor/config_test.go
+++ b/pkg/engine/compactor/config_test.go
@@ -37,6 +37,33 @@ func TestConfig_ValidateRejectsBadValues(t *testing.T) {
 	}
 }
 
+// TestConfig_LogsobjBuilderIsIndependentOfIndexobjBuilder guards the split of
+// the compacted log (data) object builder config from the index object builder
+// config: the log objects must default to data-object-scale sections (unlike
+// the deliberately small index-object sections), and tuning one builder must
+// not resize the other. Coupling them caused LogMerge to over-section its data
+// objects and balloon the index rebuilt over them.
+func TestConfig_LogsobjBuilderIsIndependentOfIndexobjBuilder(t *testing.T) {
+	const mib = 1024 * 1024
+
+	t.Run("defaults differ by scale", func(t *testing.T) {
+		var cfg Config
+		cfg.RegisterFlags(flag.NewFlagSet("test", flag.PanicOnError))
+		require.Equal(t, flagext.Bytes(128*mib), cfg.LogsobjBuilder.TargetSectionSize)
+		require.Equal(t, flagext.Bytes(1024*mib), cfg.LogsobjBuilder.TargetObjectSize)
+		require.Equal(t, flagext.Bytes(2*mib), cfg.IndexobjBuilder.TargetSectionSize)
+	})
+
+	t.Run("tuning the index builder does not resize log objects", func(t *testing.T) {
+		var cfg Config
+		fs := flag.NewFlagSet("test", flag.PanicOnError)
+		cfg.RegisterFlagsWithPrefix("dataobj.compaction.", fs)
+		require.NoError(t, fs.Parse([]string{"--dataobj.compaction.indexobj-builder.target-section-size=4MB"}))
+		require.Equal(t, flagext.Bytes(4*mib), cfg.IndexobjBuilder.TargetSectionSize)
+		require.Equal(t, flagext.Bytes(128*mib), cfg.LogsobjBuilder.TargetSectionSize)
+	})
+}
+
 func TestConfig_LogMinCompactionSizeValidation(t *testing.T) {
 	// Build a valid enabled config, driving LogMinCompactionSize through the flag
 	// parser so this one test covers both parsing and validation.

--- a/pkg/engine/compactor/worker.go
+++ b/pkg/engine/compactor/worker.go
@@ -30,6 +30,11 @@ type WorkerParams struct {
 
 	// IndexobjCfg controls index object construction parameters.
 	IndexobjCfg logsobj.BuilderBaseConfig
+
+	// LogsobjCfg controls the compacted log (data) object construction
+	// parameters used by LogMerge. Separate from IndexobjCfg so the merged log
+	// objects use data-object-scale sections rather than index-object sizes.
+	LogsobjCfg logsobj.BuilderBaseConfig
 }
 
 // Worker is the dataobj-compaction-worker target service. It wraps an
@@ -102,6 +107,7 @@ func NewWorker(params WorkerParams) (*Worker, error) {
 		// LocalScheduler left nil: the compaction worker only ever
 		// connects to remote schedulers via DNS-SRV.
 		IndexobjCfg:        params.IndexobjCfg,
+		LogsobjCfg:         params.LogsobjCfg,
 		IndexMergeObserver: wm,
 		LogMergeObserver:   wm,
 	}, registerer)

--- a/pkg/engine/internal/executor/executor.go
+++ b/pkg/engine/internal/executor/executor.go
@@ -50,6 +50,9 @@ type Config struct {
 	ScratchStore scratch.Store
 	// IndexobjCfg is the builder config for index objects.
 	IndexobjCfg logsobj.BuilderBaseConfig
+	// LogsobjCfg is the builder config for the compacted log (data) objects that
+	// LogMerge writes. Separate from IndexobjCfg.
+	LogsobjCfg logsobj.BuilderBaseConfig
 
 	// IndexMergeObserver is used  by compaction to populate output-size
 	// histograms. Optional; nil disables observation.
@@ -108,6 +111,7 @@ func Run(ctx context.Context, cfg Config, plan *physical.Plan, logger log.Logger
 		taskCaches:         cfg.TaskCaches,
 		scratchStore:       cfg.ScratchStore,
 		indexobjCfg:        cfg.IndexobjCfg,
+		logsobjCfg:         cfg.LogsobjCfg,
 		indexMergeObserver: cfg.IndexMergeObserver,
 		logMergeObserver:   cfg.LogMergeObserver,
 	}
@@ -143,6 +147,7 @@ type Context struct {
 
 	scratchStore scratch.Store
 	indexobjCfg  logsobj.BuilderBaseConfig
+	logsobjCfg   logsobj.BuilderBaseConfig
 
 	indexMergeObserver IndexMergeObserver
 	logMergeObserver   LogMergeObserver

--- a/pkg/engine/internal/executor/index_merge_test.go
+++ b/pkg/engine/internal/executor/index_merge_test.go
@@ -696,6 +696,14 @@ func newTestExecutorContext(t *testing.T, bucket objstore.Bucket) *Context {
 			BufferSize:              2048 * 8,
 			SectionStripeMergeLimit: 2,
 		},
+		logsobjCfg: logsobj.BuilderBaseConfig{
+			TargetPageSize:          2048,
+			MaxPageRows:             10000,
+			TargetObjectSize:        1 << 22, // 4 MiB
+			TargetSectionSize:       1 << 21, // 2 MiB
+			BufferSize:              2048 * 8,
+			SectionStripeMergeLimit: 2,
+		},
 		logger: log.NewNopLogger(),
 	}
 }

--- a/pkg/engine/internal/executor/log_merge.go
+++ b/pkg/engine/internal/executor/log_merge.go
@@ -401,8 +401,8 @@ func (c *Context) newLogObjectWriter(node *physical.LogMerge, table *globalStrea
 		calc:           calc,
 		logsMetrics:    logs.NewMetrics(),
 		streamsMetrics: streams.NewMetrics(),
-		targetObject:   int(c.indexobjCfg.TargetObjectSize),
-		targetSection:  int(c.indexobjCfg.TargetSectionSize),
+		targetObject:   int(c.logsobjCfg.TargetObjectSize),
+		targetSection:  int(c.logsobjCfg.TargetSectionSize),
 	}
 	w.startObject()
 	return w
@@ -412,7 +412,7 @@ func (w *logObjectWriter) startObject() {
 	w.builder = dataobj.NewBuilder(w.c.scratchStore)
 	w.lb = logs.NewBuilder(w.logsMetrics, w.c.logsBuilderOptions(w.node.SortSchema))
 	w.lb.SetTenant(w.node.Tenant)
-	w.sb = streams.NewBuilder(w.streamsMetrics, int(w.c.indexobjCfg.TargetPageSize), w.c.indexobjCfg.MaxPageRows)
+	w.sb = streams.NewBuilder(w.streamsMetrics, int(w.c.logsobjCfg.TargetPageSize), w.c.logsobjCfg.MaxPageRows)
 	w.sb.SetTenant(w.node.Tenant)
 	w.objSize, w.objStreams, w.objRecords = 0, 0, 0
 	w.curGlobalID, w.curObjLocalID = 0, 0
@@ -514,13 +514,14 @@ func (w *logObjectWriter) finalizeAndUpload(ctx context.Context) error {
 }
 
 // logsBuilderOptions builds the logs section options for a schema-sorted output,
-// sized from the executor's shared builder config.
+// sized from the compacted-log-object builder config (not the index-object one),
+// so merged log objects use data-object-scale sections.
 func (c *Context) logsBuilderOptions(sortSchema []string) logs.BuilderOptions {
 	return logs.BuilderOptions{
-		PageSizeHint:     int(c.indexobjCfg.TargetPageSize),
-		PageMaxRowCount:  c.indexobjCfg.MaxPageRows,
-		BufferSize:       int(c.indexobjCfg.BufferSize),
-		StripeMergeLimit: c.indexobjCfg.SectionStripeMergeLimit,
+		PageSizeHint:     int(c.logsobjCfg.TargetPageSize),
+		PageMaxRowCount:  c.logsobjCfg.MaxPageRows,
+		BufferSize:       int(c.logsobjCfg.BufferSize),
+		StripeMergeLimit: c.logsobjCfg.SectionStripeMergeLimit,
 		AppendStrategy:   logs.AppendOrdered,
 		SortOrder:        logs.SortSchemaASC,
 		SchemaLabels:     sortSchema,

--- a/pkg/engine/internal/executor/log_merge_test.go
+++ b/pkg/engine/internal/executor/log_merge_test.go
@@ -298,13 +298,14 @@ func TestDoLogObjectMerge_WritesCompactedLogsToDataBucket(t *testing.T) {
 }
 
 // newSmallObjectExecutorContext is like newTestExecutorContext but with a tiny
-// TargetObjectSize so the merge splits its output across multiple objects.
+// log-object TargetObjectSize so the merge splits its output across multiple
+// compacted log objects. The output data objects are sized by logsobjCfg.
 func newSmallObjectExecutorContext(t *testing.T, bucket objstore.Bucket) *Context {
 	t.Helper()
 	c := newTestExecutorContext(t, bucket)
-	c.indexobjCfg.TargetPageSize = 512
-	c.indexobjCfg.TargetObjectSize = 1000 // bytes; forces splitting
-	c.indexobjCfg.TargetSectionSize = 800
+	c.logsobjCfg.TargetPageSize = 512
+	c.logsobjCfg.TargetObjectSize = 1000 // bytes; forces splitting
+	c.logsobjCfg.TargetSectionSize = 800
 	return c
 }
 

--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -97,6 +97,7 @@ type thread struct {
 	TaskCaches     executor.TaskCacheRegistry
 	ScratchStore   scratch.Store
 	IndexobjCfg    logsobj.BuilderBaseConfig
+	LogsobjCfg     logsobj.BuilderBaseConfig
 
 	// IndexMergeObserver is optional; nil for query-only workers.
 	IndexMergeObserver executor.IndexMergeObserver
@@ -225,6 +226,7 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 		TaskCaches:     t.TaskCaches,
 		ScratchStore:   t.ScratchStore,
 		IndexobjCfg:    t.IndexobjCfg,
+		LogsobjCfg:     t.LogsobjCfg,
 
 		IndexMergeObserver: t.IndexMergeObserver,
 		LogMergeObserver:   t.LogMergeObserver,

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -106,6 +106,10 @@ type Config struct {
 	// Required for compaction tasks; may be nil for query-only workers.
 	IndexobjCfg logsobj.BuilderBaseConfig
 
+	// LogsobjCfg is the builder config for the compacted log (data) objects that
+	// LogMerge writes. Separate from IndexobjCfg; may be nil for query-only workers.
+	LogsobjCfg logsobj.BuilderBaseConfig
+
 	// IndexMergeObserver is used  by compaction to populate output-size
 	// histograms. Optional; nil disables observation.
 	IndexMergeObserver executor.IndexMergeObserver
@@ -215,6 +219,7 @@ func (w *Worker) run(ctx context.Context) error {
 			TaskCaches:     w.taskCaches,
 			ScratchStore:   w.config.ScratchStore,
 			IndexobjCfg:    w.config.IndexobjCfg,
+			LogsobjCfg:     w.config.LogsobjCfg,
 
 			IndexMergeObserver: w.config.IndexMergeObserver,
 			LogMergeObserver:   w.config.LogMergeObserver,

--- a/pkg/engine/worker.go
+++ b/pkg/engine/worker.go
@@ -78,6 +78,10 @@ type WorkerParams struct {
 	// Required for compaction tasks; may be nil for query-only workers.
 	IndexobjCfg logsobj.BuilderBaseConfig
 
+	// LogsobjCfg is the builder config for the compacted log (data) objects that
+	// LogMerge writes. Separate from IndexobjCfg; may be nil for query-only workers.
+	LogsobjCfg logsobj.BuilderBaseConfig
+
 	// IndexMergeObserver is used  by compaction to populate output-size
 	// histograms. Optional; nil for query-only workers.
 	IndexMergeObserver executor.IndexMergeObserver
@@ -173,6 +177,7 @@ func NewWorker(params WorkerParams, reg prometheus.Registerer) (*Worker, error) 
 		TaskCaches:     taskCaches,
 		ScratchStore:   params.ScratchStore,
 		IndexobjCfg:    params.IndexobjCfg,
+		LogsobjCfg:     params.LogsobjCfg,
 
 		IndexMergeObserver: params.IndexMergeObserver,
 		LogMergeObserver:   params.LogMergeObserver,

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -2462,6 +2462,7 @@ func (t *Loki) initDataObjCompactionWorker() (services.Service, error) {
 		Metastore:    ms,
 		ScratchStore: t.scratchStore,
 		IndexobjCfg:  t.Cfg.DataObj.Compaction.IndexobjBuilder,
+		LogsobjCfg:   t.Cfg.DataObj.Compaction.LogsobjBuilder,
 		Logger:       logger,
 		Registerer:   prometheus.DefaultRegisterer,
 	})


### PR DESCRIPTION
## What

Adds a dedicated builder config for the compacted **log (data) objects** that LogMerge produces: `Config.LogsobjBuilder` (flag prefix `dataobj.compaction.logsobj-builder.`), separate from the existing `IndexobjBuilder`.

## Why

`LogMerge`'s data-object writer sized its objects/sections from the *index* object builder config (`IndexobjBuilder`), so the section size of the compacted log objects was tied to the index objects'. These are different concerns and should be configurable independently: index objects are built small, while the merged log objects want data-object-scale sections. Coupling them meant the merged log objects inherited the index-object section size, which over-sections them and inflates the index that is rebuilt inline over them.

This only surfaces after **log** compaction; index-only compaction never rewrites data objects and was unaffected.

## How

- New `LogsobjBuilder logsobj.BuilderBaseConfig` on the compaction `Config`, defaulting to the ingester's data-object builder sizes.
- Threaded through the worker → engine worker → executor chain alongside `IndexobjCfg` as `LogsobjCfg`.
- The log-object writer and its logs/streams builders now size from `LogsobjCfg`; the inline index builder and `IndexMerge` keep using `IndexobjCfg`.
- Regenerated config docs; added/updated tests (config independence + the log-merge split tests now drive splitting via the log-object config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)