### PR TITLE
fix(dataobj-compaction): Plan index compaction from section runs 🤖🤖🤖

### DIFF
--- a/pkg/dataobj/compaction/v2/calculator.go
+++ b/pkg/dataobj/compaction/v2/calculator.go
@@ -1,153 +1,115 @@
 package compactionv2
 
 import (
-	"cmp"
-	"slices"
 	"sort"
 
 	compactionv2pb "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2/proto"
 )
 
-// run is one non-overlapping run of sections.
-//
-// topMaxKey + topMaxTimestamp hold the most recent appended section's upper
-// bound -- the composite (labels, timestamp) sort key.
-type run struct {
-	sections        []*compactionv2pb.SectionRef
-	topMaxKey       []string
-	topMaxTimestamp int64
+// run is one ordered sequence built by calculateRuns. topMax is the upper
+// bound of its final section.
+type run[K any] struct {
+	sections []*compactionv2pb.SectionRef
+	topMax   K
 }
 
-func (r *run) Sections() []*compactionv2pb.SectionRef { return r.sections }
+func (r *run[K]) Sections() []*compactionv2pb.SectionRef { return r.sections }
 
-func (r *run) Size() uint64 {
+func (r *run[K]) Size() uint64 {
 	var total uint64
-	for _, s := range r.sections {
-		total += uint64(s.UncompressedSize)
+	for _, section := range r.sections {
+		total += uint64(section.UncompressedSize)
 	}
 	return total
 }
 
-// cmpSortKey compares two composite (labels, timestamp) sort keys
-// lexicographically -- labels first, then timestamp.
-// Returns -1 if a < b, 0 if equal, +1 if a > b.
-func cmpSortKey(aLabels []string, aTs int64, bLabels []string, bTs int64) int {
-	if c := slices.Compare(aLabels, bLabels); c != 0 {
-		return c
+func sortSections[K any](sections []Section[K], compare CompareFunc[K]) {
+	for _, section := range sections {
+		if section.Ref == nil {
+			panic("nil section reference")
+		}
 	}
-	return cmp.Compare(aTs, bTs)
+
+	sort.Slice(sections, func(i, j int) bool {
+		a, b := sections[i], sections[j]
+		if n := compare(a.Min, b.Min); n != 0 {
+			return n < 0
+		}
+		if n := compare(a.Max, b.Max); n != 0 {
+			return n < 0
+		}
+		if a.Ref.ObjectPath != b.Ref.ObjectPath {
+			return a.Ref.ObjectPath < b.Ref.ObjectPath
+		}
+		return a.Ref.SectionIndex < b.Ref.SectionIndex
+	})
 }
 
-// calculateRuns sorts the provided [sections] in place and returns a set of
-// runs in creation order. A "run" is a sorted sequence of sections whose
-// ([MinKey, MinTimestamp], [MaxKey, MaxTimestamp]) bounds are pairwise
-// non-overlapping in sort-key space.
-//
-// The input slice is sorted in place; callers that need the original order must
-// copy beforehand. The contract requires non-nil SectionRef entries; nil
-// entries will panic.
-func calculateRuns(sections []*compactionv2pb.SectionRef) []*run {
+func calculateRuns[K any](sections []Section[K], compare CompareFunc[K]) []*run[K] {
 	if len(sections) == 0 {
 		return nil
 	}
+	sortSections(sections, compare)
 
-	// Step 1: sort sections by composite (MinKey, MinTimestamp) ASC, then
-	// composite (MaxKey, MaxTimestamp) ASC, then (ObjectPath, SectionIndex) as
-	// a stable tiebreaker.
-	sort.Slice(sections, func(i, j int) bool {
-		a, b := sections[i], sections[j]
-		if c := cmpSortKey(a.MinKey, a.MinTimestamp, b.MinKey, b.MinTimestamp); c != 0 {
-			return c < 0
-		}
-		if c := cmpSortKey(a.MaxKey, a.MaxTimestamp, b.MaxKey, b.MaxTimestamp); c != 0 {
-			return c < 0
-		}
-		if a.ObjectPath != b.ObjectPath {
-			return a.ObjectPath < b.ObjectPath
-		}
-		return a.SectionIndex < b.SectionIndex
-	})
-
-	// runs in creation order; this is what we return.
-	runs := make([]*run, 0)
-
-	// Iterate sorted sections and append to the existing run whose top_max_key is
-	// the largest value strictly less than the section's MinKey; if no such run
-	// exists, start a new one. Among runs tied on top_max_key, the OLDEST run
-	// (first seen) wins. Below is a demonstration of how this algorithm allows us
-	// to generate runs and make compaction decisions.
+	// Place each section in the run with the greatest upper bound that still
+	// ends before this section starts. If no run is eligible, start a new one.
+	// When two runs have the same upper bound, the oldest run wins.
 	//
-	// L0 sections come from the consumer/ingester. They are sorted by
-	// __timestamp__ (ingestion order), NOT by service_name, so services
-	// interleave inside each section. Each section's MinKey/MaxKey therefore
-	// spans the full service_name range:
+	// Consider three L0 sections sorted by timestamp rather than service_name.
+	// Services interleave inside each section, so every section spans much of the
+	// service_name keyspace:
 	//
-	//	Section A0 (Schema=[])             Section B0 (Schema=[])             Section C0 (Schema=[])
-	//	-----------------------            -----------------------            -----------------------
-	//	 auth     | T1 | "login"             billing  | T4 | "pay"              auth     | T7 | "refresh"
-	//	 billing  | T2 | "invoice"           auth     | T5 | "logout"           auth     | T8 | "login"
-	//	 cart     | T3 | "add"               cart     | T6 | "checkout"         billing  | T9 | "renew"
+	//	Section A0                         Section B0                         Section C0
+	//	----------                         ----------                         ----------
+	//	auth    | T1 | "login"            billing | T4 | "pay"              auth    | T7 | "refresh"
+	//	billing | T2 | "invoice"          auth    | T5 | "logout"           auth    | T8 | "login"
+	//	cart    | T3 | "add"              cart    | T6 | "checkout"         billing | T9 | "renew"
 	//
-	//	 MinKey = ["auth", T1]              MinKey = ["auth", T5]              MinKey = ["auth", T7]
-	//	 MaxKey = ["cart", T3]              MaxKey = ["cart", T6]              MaxKey = ["billing", T9]
+	//	Min = ["auth", T1]               Min = ["auth", T5]               Min = ["auth", T7]
+	//	Max = ["cart", T3]               Max = ["cart", T6]               Max = ["billing", T9]
 	//
-	// calculateRuns walks them in sorted order, looking for the run with the
-	// largest top_max_key strictly less than the section's MinKey (best-fit).
-	// Tuple compare proceeds element-wise; column 0 (service_name) dominates
-	// for every comparison below.
-	//   - A0 -> no runs exist -> new run #0 (top_max_key = ["cart", T3])
-	//   - B0 -> need top_max_key < ["auth", T5]. Run 0's top is ["cart", T3];
-	//     compare column 0: "cart" > "auth". Not eligible -> new run #1
-	//     (top_max_key = ["cart", T6])
-	//   - C0 -> need top_max_key < ["auth", T7]. Both existing runs have
-	//     ["cart", ...] tops, all > ["auth", ...] at column 0. Not eligible ->
-	//     new run #2 (top_max_key = ["billing", T9])
+	// Patience sorting considers them in lower-bound order:
+	//   - A0 has no predecessor, so it starts run 0 with top ["cart", T3].
+	//   - B0 starts run 1 because run 0's "cart" top cannot precede B0's
+	//     "auth" lower bound.
+	//   - C0 starts run 2 for the same reason.
 	//
-	// Result: P=3 runs, one section each. After compaction the new L1 sections
-	// ARE sorted:
+	// The result is three overlapping runs. A K-way merge can rewrite them into
+	// sections that are ordered by service_name:
 	//
-	//	Section X1 (Schema=[service_name])   Section Y1 (Schema=[service_name])   Section Z1 (Schema=[service_name])
-	//	-----------------------------------  -----------------------------------  -----------------------------------
-	//	 auth     | T1 | "login"               auth     | T8 | "login"              billing  | T9 | "renew"
-	//	 auth     | T5 | "logout"              billing  | T2 | "invoice"            cart     | T3 | "add"
-	//	 auth     | T7 | "refresh"             billing  | T4 | "pay"                cart     | T6 | "checkout"
+	//	Section X1                         Section Y1                         Section Z1
+	//	----------                         ----------                         ----------
+	//	auth | T1 | "login"               auth    | T8 | "login"            billing | T9 | "renew"
+	//	auth | T5 | "logout"              billing | T2 | "invoice"          cart    | T3 | "add"
+	//	auth | T7 | "refresh"             billing | T4 | "pay"              cart    | T6 | "checkout"
 	//
-	//	 MinKey = ["auth", T1]                MinKey = ["auth", T8]                MinKey = ["billing", T9]
-	//	 MaxKey = ["auth", T7]                MaxKey = ["billing", T4]             MaxKey = ["cart", T6]
+	//	Min = ["auth", T1]               Min = ["auth", T8]               Min = ["billing", T9]
+	//	Max = ["auth", T7]               Max = ["billing", T4]            Max = ["cart", T6]
 	//
-	// The MinKey/MaxKey ranges are now non-overlapping in sort-key space:
-	//
-	//	(["auth",T1]..["auth",T7])..(["auth",T8]..["billing",T4])..(["billing",T9]..["cart",T6])
-	//	           X1                            Y1                              Z1
-	//
-	// A subsequent L1 -> L2 run on {X1, Y1, Z1} would yield P=1 indicating strong
-	// data locality. Sections can be perfectly sorted by sort_schema and STILL
-	// overlap if each one covers the full sort_schema_value range. The size of P
-	// allows us to determine if compaction is necessary in these cases.
-	for _, s := range sections {
-		var best *run
-		for _, r := range runs {
-			if cmpSortKey(r.topMaxKey, r.topMaxTimestamp, s.MinKey, s.MinTimestamp) < 0 {
-				if best == nil || cmpSortKey(r.topMaxKey, r.topMaxTimestamp, best.topMaxKey, best.topMaxTimestamp) > 0 {
-					best = r
-				}
+	// A later calculation places X1, Y1, and Z1 in one run. This is why run count
+	// measures locality even when the number of physical sections does not
+	// change.
+	var runs []*run[K]
+	for _, section := range sections {
+		var best *run[K]
+		for _, candidate := range runs {
+			canFollow := compare(candidate.topMax, section.Min) < 0
+			isCloser := best == nil || compare(candidate.topMax, best.topMax) > 0
+			if canFollow && isCloser {
+				best = candidate
 			}
 		}
 
-		if best != nil {
-			best.sections = append(best.sections, s)
-			best.topMaxKey = s.MaxKey
-			best.topMaxTimestamp = s.MaxTimestamp
+		if best == nil {
+			runs = append(runs, &run[K]{
+				sections: []*compactionv2pb.SectionRef{section.Ref},
+				topMax:   section.Max,
+			})
 			continue
 		}
 
-		// No eligible pile: start a new one.
-		runs = append(runs, &run{
-			sections:        []*compactionv2pb.SectionRef{s},
-			topMaxKey:       s.MaxKey,
-			topMaxTimestamp: s.MaxTimestamp,
-		})
+		best.sections = append(best.sections, section.Ref)
+		best.topMax = section.Max
 	}
-
 	return runs
 }

--- a/pkg/dataobj/compaction/v2/calculator_test.go
+++ b/pkg/dataobj/compaction/v2/calculator_test.go
@@ -1,7 +1,10 @@
 package compactionv2
 
 import (
+	"cmp"
+	"fmt"
 	"math/rand"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,372 +12,184 @@ import (
 	compactionv2pb "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2/proto"
 )
 
-// Suppress unused import warning; math/rand is used in the shuffle determinism tests.
-var _ = rand.Float64
+type testKey struct {
+	labels    []string
+	timestamp int64
+}
 
-// sec is a small constructor for SectionRef test fixtures with single-column
-// MinKey/MaxKey values (the common case in existing tests).
-func sec(path string, idx int64, minKey, maxKey string) *compactionv2pb.SectionRef {
-	return &compactionv2pb.SectionRef{
-		ObjectPath:   path,
-		SectionIndex: idx,
-		MinKey:       []string{minKey},
-		MaxKey:       []string{maxKey},
+func compareTestKey(a, b testKey) int {
+	if n := slices.Compare(a.labels, b.labels); n != 0 {
+		return n
+	}
+	return cmp.Compare(a.timestamp, b.timestamp)
+}
+
+func testSection(path string, index int64, minKey, maxKey testKey) Section[testKey] {
+	return Section[testKey]{
+		Ref: &compactionv2pb.SectionRef{ObjectPath: path, SectionIndex: index},
+		Min: minKey,
+		Max: maxKey,
 	}
 }
 
-// secT is a constructor for SectionRef test fixtures with multi-column
-// MinKey/MaxKey tuples (for tests that exercise multi-column sort_schema
-// semantics).
-func secT(path string, idx int64, minKey, maxKey []string) *compactionv2pb.SectionRef {
-	return &compactionv2pb.SectionRef{
-		ObjectPath:   path,
-		SectionIndex: idx,
-		MinKey:       minKey,
-		MaxKey:       maxKey,
+func key(label string, timestamp int64) testKey {
+	return testKey{labels: []string{label}, timestamp: timestamp}
+}
+
+func TestCalculateRuns(t *testing.T) {
+	tests := []struct {
+		name     string
+		sections []Section[testKey]
+		want     [][]int64
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "non-overlapping",
+			sections: []Section[testKey]{
+				testSection("o", 2, key("e", 0), key("f", 0)),
+				testSection("o", 0, key("a", 0), key("b", 0)),
+				testSection("o", 1, key("c", 0), key("d", 0)),
+			},
+			want: [][]int64{{0, 1, 2}},
+		},
+		{
+			name: "touching",
+			sections: []Section[testKey]{
+				testSection("o", 0, key("a", 0), key("b", 0)),
+				testSection("o", 1, key("b", 0), key("c", 0)),
+			},
+			want: [][]int64{{0}, {1}},
+		},
+		{
+			name: "overlapping",
+			sections: []Section[testKey]{
+				testSection("o", 0, key("a", 0), key("d", 0)),
+				testSection("o", 1, key("b", 0), key("e", 0)),
+				testSection("o", 2, key("c", 0), key("f", 0)),
+			},
+			want: [][]int64{{0}, {1}, {2}},
+		},
+		{
+			name: "timestamp breaks label tie",
+			sections: []Section[testKey]{
+				testSection("o", 1, key("api", 30), key("api", 40)),
+				testSection("o", 0, key("api", 10), key("api", 20)),
+			},
+			want: [][]int64{{0, 1}},
+		},
+		{
+			name: "best fit",
+			sections: []Section[testKey]{
+				testSection("o", 0, key("00", 0), key("05", 0)),
+				testSection("o", 1, key("01", 0), key("10", 0)),
+				testSection("o", 2, key("12", 0), key("20", 0)),
+			},
+			want: [][]int64{{0}, {1, 2}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runs := CalculateRuns(test.sections, compareTestKey)
+			var got [][]int64
+			for _, run := range runs {
+				var indexes []int64
+				for _, section := range run.Sections() {
+					indexes = append(indexes, section.SectionIndex)
+				}
+				got = append(got, indexes)
+			}
+			require.Equal(t, test.want, got)
+		})
 	}
 }
 
-func TestPatienceSort_Empty(t *testing.T) {
-	require.Nil(t, calculateRuns(nil))
-	require.Nil(t, calculateRuns([]*compactionv2pb.SectionRef{}))
+func TestCalculateRuns_NilRefPanics(t *testing.T) {
+	require.PanicsWithValue(t, "nil section reference", func() {
+		CalculateRuns([]Section[int]{{Min: 1, Max: 2}}, cmp.Compare[int])
+	})
 }
 
-func TestPatienceSort_SingleSection(t *testing.T) {
-	s := sec("obj-1", 0, "a", "b")
-	got := calculateRuns([]*compactionv2pb.SectionRef{s})
-
-	require.Len(t, got, 1)
-	require.Equal(t, []*compactionv2pb.SectionRef{s}, got[0].sections)
-	require.Equal(t, []string{"b"}, got[0].topMaxKey)
-}
-
-func TestPatienceSort_AllNonOverlapping(t *testing.T) {
-	s1 := sec("o", 0, "a", "b")
-	s2 := sec("o", 1, "c", "d")
-	s3 := sec("o", 2, "e", "f")
-
-	got := calculateRuns([]*compactionv2pb.SectionRef{s1, s2, s3})
-
-	require.Len(t, got, 1, "all non-overlapping sections should form exactly one pile")
-	require.Equal(t, []*compactionv2pb.SectionRef{s1, s2, s3}, got[0].sections)
-	require.Equal(t, []string{"f"}, got[0].topMaxKey)
-}
-
-func TestPatienceSort_AllOverlapping(t *testing.T) {
-	// All three sections overlap pairwise; expect 3 piles each with 1 section.
-	s1 := sec("o", 0, "a", "m")
-	s2 := sec("o", 1, "b", "n")
-	s3 := sec("o", 2, "c", "o")
-
-	got := calculateRuns([]*compactionv2pb.SectionRef{s1, s2, s3})
-
-	require.Len(t, got, 3)
-	for _, p := range got {
-		require.Len(t, p.sections, 1, "each pile should hold exactly one overlapping section")
+func TestCalculateRuns_Deterministic(t *testing.T) {
+	sections := []Section[testKey]{
+		testSection("a", 0, key("a", 0), key("d", 0)),
+		testSection("b", 0, key("b", 0), key("e", 0)),
+		testSection("c", 0, key("f", 0), key("g", 0)),
+		testSection("d", 0, key("c", 0), key("h", 0)),
 	}
-}
+	want := CalculateRuns(append([]Section[testKey](nil), sections...), compareTestKey)
 
-func TestPatienceSort_BestFit(t *testing.T) {
-	// Seed two piles by feeding two overlapping sections first:
-	//   pile0: topMaxKey "05"
-	//   pile1: topMaxKey "10"
-	// Then a third section with MinKey="12" — best-fit is pile1 (largest topMaxKey < "12").
-	s1 := sec("o", 0, "00", "05") // creates pile0
-	s2 := sec("o", 1, "01", "10") // overlaps s1; creates pile1
-	s3 := sec("o", 2, "12", "20") // MinKey > both top_max_keys; pick pile1
-
-	got := calculateRuns([]*compactionv2pb.SectionRef{s1, s2, s3})
-
-	require.Len(t, got, 2, "expected 2 piles")
-	// pile1 (created second) should now contain s2 and s3.
-	require.Equal(t, []*compactionv2pb.SectionRef{s2, s3}, got[1].sections)
-	require.Equal(t, []string{"20"}, got[1].topMaxKey)
-	// pile0 should still hold only s1.
-	require.Equal(t, []*compactionv2pb.SectionRef{s1}, got[0].sections)
-	require.Equal(t, []string{"05"}, got[0].topMaxKey)
-}
-
-func TestPatienceSort_TiebreakerOnCreationOrder(t *testing.T) {
-	// Two piles will both end up with topMaxKey == "10":
-	//   s1 = ("00","10") — creates pile0
-	//   s2 = ("05","11") — overlaps s1 (MinKey "05" < pile0 topMaxKey "10"); creates pile1
-	//   s3 = ("06","10") — overlaps both ("06" < both "10"); creates pile2
-	// pile0 topMaxKey=10, pile1 topMaxKey=11, pile2 topMaxKey=10
-	//   s4 = ("11","20") — eligible for pile0 (topMaxKey "10" < "11") AND pile2 (topMaxKey "10" < "11").
-	//   pile1 topMaxKey "11" is NOT < "11"; not eligible.
-	//   Tiebreak: pick the OLDEST eligible pile -> pile0 (slice index 0).
-	s1 := sec("o", 0, "00", "10")
-	s2 := sec("o", 1, "05", "11")
-	s3 := sec("o", 2, "06", "10")
-	s4 := sec("o", 3, "11", "20")
-
-	got := calculateRuns([]*compactionv2pb.SectionRef{s1, s2, s3, s4})
-
-	require.Len(t, got, 3)
-	// pile0 (slice index 0, the oldest) should have received s4.
-	require.Equal(t, []*compactionv2pb.SectionRef{s1, s4}, got[0].sections,
-		"among piles with equal topMaxKey, append to the OLDEST")
-	// pile2 unchanged.
-	require.Equal(t, []*compactionv2pb.SectionRef{s3}, got[2].sections,
-		"newer pile is NOT chosen on tie")
-}
-
-func TestPatienceSort_StableIDTiebreaker(t *testing.T) {
-	// Two sections with identical (MinKey, MaxKey) — differentiated only by stable_id.
-	// Per step-1 sort: (ObjectPath ASC, SectionIndex ASC) breaks the tie deterministically.
-	// Both sections overlap each other (same range) so they end up in separate piles.
-	// The pile created first must contain the section with the smaller stable_id.
-	a := sec("aaa", 0, "k", "m")
-	b := sec("aaa", 1, "k", "m")
-	c := sec("bbb", 0, "k", "m")
-
-	// Feed in deliberately scrambled order — output must still be deterministic
-	// per the stable_id tiebreaker.
-	got := calculateRuns([]*compactionv2pb.SectionRef{c, b, a})
-
-	require.Len(t, got, 3)
-	require.Equal(t, a, got[0].sections[0], "pile0 expected to hold stable_id-smallest section")
-	require.Equal(t, b, got[1].sections[0])
-	require.Equal(t, c, got[2].sections[0])
-}
-
-func TestPatienceSort_Determinism_Shuffled(t *testing.T) {
-	// Build a non-trivial input — a few overlapping and non-overlapping sections.
-	base := []*compactionv2pb.SectionRef{
-		sec("o", 0, "01", "03"),
-		sec("o", 1, "02", "04"),
-		sec("o", 2, "05", "07"),
-		sec("o", 3, "06", "10"),
-		sec("o", 4, "11", "13"),
-		sec("o", 5, "12", "14"),
-		sec("o", 6, "15", "18"),
-		sec("p", 0, "02", "06"),
-	}
-
-	// Reference result: feed in input order.
-	want := calculateRuns(append([]*compactionv2pb.SectionRef(nil), base...))
-
-	// Try 10 different deterministic shuffles. Use a seeded math/rand so the
-	// test is reproducible.
-	r := rand.New(rand.NewSource(42))
-	for trial := 0; trial < 10; trial++ {
-		shuffled := append([]*compactionv2pb.SectionRef(nil), base...)
-		r.Shuffle(len(shuffled), func(i, j int) {
+	random := rand.New(rand.NewSource(42))
+	for range 10 {
+		shuffled := append([]Section[testKey](nil), sections...)
+		random.Shuffle(len(shuffled), func(i, j int) {
 			shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
 		})
-		got := calculateRuns(shuffled)
+		got := CalculateRuns(shuffled, compareTestKey)
+		require.Equal(t, runRefs(want), runRefs(got))
+	}
+}
 
-		require.Equal(t, len(want), len(got), "trial %d: pile count must match", trial)
-		for i := range want {
-			require.Equal(t, want[i].sections, got[i].sections, "trial %d: pile %d sections", trial, i)
-			require.Equal(t, want[i].topMaxKey, got[i].topMaxKey, "trial %d: pile %d topMaxKey", trial, i)
+func TestCalculateRuns_TiedBoundsUseReferenceOrder(t *testing.T) {
+	sections := []Section[testKey]{
+		testSection("b", 0, key("a", 0), key("b", 0)),
+		testSection("a", 1, key("a", 0), key("b", 0)),
+		testSection("a", 0, key("a", 0), key("b", 0)),
+	}
+
+	runs := CalculateRuns(sections, compareTestKey)
+	require.Equal(t, [][]string{{"a#0"}, {"a#1"}, {"b#0"}}, runRefs(runs))
+}
+
+func TestIsConverged(t *testing.T) {
+	tests := []struct {
+		name      string
+		sections  []Section[testKey]
+		converged bool
+	}{
+		{name: "empty", converged: true},
+		{
+			name: "strict run",
+			sections: []Section[testKey]{
+				testSection("o", 0, key("a", 0), key("b", 0)),
+				testSection("o", 1, key("c", 0), key("d", 0)),
+			},
+			converged: true,
+		},
+		{
+			name: "touching only",
+			sections: []Section[testKey]{
+				testSection("o", 0, key("a", 0), key("b", 0)),
+				testSection("o", 1, key("b", 0), key("c", 0)),
+			},
+			converged: true,
+		},
+		{
+			name: "true overlap",
+			sections: []Section[testKey]{
+				testSection("o", 0, key("a", 0), key("c", 0)),
+				testSection("o", 1, key("b", 0), key("d", 0)),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			original := append([]Section[testKey](nil), test.sections...)
+			require.Equal(t, test.converged, IsConverged(test.sections, compareTestKey))
+			require.Equal(t, original, test.sections)
+		})
+	}
+}
+
+func runRefs(runs []Run) [][]string {
+	refs := make([][]string, len(runs))
+	for i, run := range runs {
+		for _, section := range run.Sections() {
+			refs[i] = append(refs[i], fmt.Sprintf("%s#%d", section.ObjectPath, section.SectionIndex))
 		}
 	}
-}
-
-// The following tests pin the multi-column (tuple) compare semantics for
-// MinKey/MaxKey. They demonstrate cases that would fail under a naive
-// single-string concatenation of column values:
-//
-// Sort schema = [service_name, env] (two columns). Sections carry MinKey/MaxKey
-// as []string{service_name_value, env_value}. The calculator must compare these
-// element-wise (column 0 first, column 1 only if column 0 is equal). A
-// concatenated-string representation -- say, joined by some delimiter -- gets
-// these cases wrong because the delimiter byte intermixes with column-content
-// bytes at the boundary.
-
-// TestCalculateRuns_MultiColumn_PrefixOrder demonstrates the prefix case:
-// when one section's column-0 value is a strict prefix of another's, the
-// prefix is less. Concatenation with any printable separator (e.g. '|' at
-// 0x7C) reverses this whenever the next byte in the longer string is less
-// than the separator -- e.g. "api|*" vs "apiv2|*" hits '|' vs 'v' (0x7C vs
-// 0x76) and orders them backwards.
-func TestCalculateRuns_MultiColumn_PrefixOrder(t *testing.T) {
-	// Two sections, two columns each.
-	//   a: MinKey=("api","zoo")    MaxKey=("api","zzz")
-	//   b: MinKey=("apiv2","aaa")  MaxKey=("apiv2","aaa")
-	//
-	// Tuple compare on MinKey: column 0 "api" vs "apiv2" — prefix is less,
-	// so a < b. Column 1 ("zoo" vs "aaa") never inspected.
-	//
-	// a.MaxKey = ("api","zzz") < b.MinKey = ("apiv2","aaa") at column 0
-	// (same prefix logic), so the ranges do NOT overlap: one run with both
-	// sections in order.
-	a := secT("o", 0, []string{"api", "zoo"}, []string{"api", "zzz"})
-	b := secT("o", 1, []string{"apiv2", "aaa"}, []string{"apiv2", "aaa"})
-
-	got := calculateRuns([]*compactionv2pb.SectionRef{a, b})
-
-	require.Len(t, got, 1, "non-overlapping sections should form one run")
-	require.Equal(t, []*compactionv2pb.SectionRef{a, b}, got[0].sections,
-		"prefix on column 0 must place 'api' before 'apiv2' regardless of column 1")
-}
-
-// TestCalculateRuns_MultiColumn_SecondColumnDecides verifies that when
-// column 0 values tie, the comparison correctly proceeds to column 1.
-// Tests sort ordering AND non-overlapping run packing on column 1.
-func TestCalculateRuns_MultiColumn_SecondColumnDecides(t *testing.T) {
-	// All three sections share service_name="api"; they only differ on env.
-	//   a: ("api","prod")..("api","prod")     — env=prod
-	//   b: ("api","qa")..("api","qa")          — env=qa
-	//   c: ("api","staging")..("api","staging") — env=staging
-	//
-	// Lexicographic: prod < qa < staging. All three non-overlapping; one run.
-	a := secT("o", 0, []string{"api", "prod"}, []string{"api", "prod"})
-	b := secT("o", 1, []string{"api", "qa"}, []string{"api", "qa"})
-	c := secT("o", 2, []string{"api", "staging"}, []string{"api", "staging"})
-
-	// Feed in jumbled order; sort step must reorder by tuple compare.
-	got := calculateRuns([]*compactionv2pb.SectionRef{c, a, b})
-
-	require.Len(t, got, 1, "non-overlapping sections should form one run")
-	require.Equal(t, []*compactionv2pb.SectionRef{a, b, c}, got[0].sections,
-		"with equal column 0, column 1 must decide the order (prod < qa < staging)")
-}
-
-// TestCalculateRuns_MultiColumn_OverlapAcrossColumns demonstrates that
-// overlap detection works correctly across columns. The same input under a
-// single-concatenated-string MinKey/MaxKey could mistakenly treat these as
-// non-overlapping (and pack them into one run) because the byte order would
-// reverse at the column-0/column-1 boundary.
-func TestCalculateRuns_MultiColumn_OverlapAcrossColumns(t *testing.T) {
-	// a: MinKey=("api","prod")  MaxKey=("apiv2","aaa")
-	// b: MinKey=("api","zoo")   MaxKey=("api","zzz")
-	//
-	// Tuple compare sorts a < b on MinKey (col 0 prefix: "api" < "api"? equal;
-	// col 1 "prod" < "zoo"; so a.MinKey < b.MinKey).
-	//
-	// Does a contain b? a.MaxKey=("apiv2","aaa") vs b.MinKey=("api","zoo"):
-	// col 0 "apiv2" vs "api" — "api" is a prefix of "apiv2" → "api" < "apiv2"
-	// → a.MaxKey > b.MinKey. So b.MinKey falls INSIDE a's range. They overlap.
-	// Expected: 2 runs.
-	//
-	// Under a naive "join columns with '|'" encoding, a.MaxKey = "apiv2|aaa"
-	// vs b.MinKey = "api|zoo" — at position 3, 'v' (0x76) vs '|' (0x7C);
-	// 'v' < '|', so "apiv2|aaa" < "api|zoo". The encoder would conclude
-	// a.MaxKey < b.MinKey, treat them as non-overlapping, and pack them into
-	// a single run. This test pins the correct overlap detection.
-	a := secT("o", 0, []string{"api", "prod"}, []string{"apiv2", "aaa"})
-	b := secT("o", 1, []string{"api", "zoo"}, []string{"api", "zzz"})
-
-	got := calculateRuns([]*compactionv2pb.SectionRef{a, b})
-
-	require.Len(t, got, 2, "overlapping sections must produce separate runs")
-}
-
-// secTS is a constructor for SectionRef test fixtures with explicit
-// MinTimestamp/MaxTimestamp values (for tests that exercise the timestamp
-// component of the composite sort key). MinKey/MaxKey are still []string
-// tuples; pass single-element slices for the single-column case.
-func secTS(path string, idx int64, minKey, maxKey []string, minTs, maxTs int64) *compactionv2pb.SectionRef {
-	return &compactionv2pb.SectionRef{
-		ObjectPath:   path,
-		SectionIndex: idx,
-		MinKey:       minKey,
-		MaxKey:       maxKey,
-		MinTimestamp: minTs,
-		MaxTimestamp: maxTs,
-	}
-}
-
-// TestCalculateRuns_Timestamp_NonOverlap demonstrates that when two sections
-// share the same label tuple but have non-overlapping time slices, they
-// correctly pack into a single run. Without including the timestamp
-// component in the comparison, the algorithm would see equal label tuples
-// at the boundary (a.MaxKey == b.MinKey) and conclude they overlap.
-func TestCalculateRuns_Timestamp_NonOverlap(t *testing.T) {
-	// a: labels=["api"], ts=[100..200]
-	// b: labels=["api"], ts=[300..400]
-	//
-	// Composite compare on (a.MaxKey, a.MaxTimestamp) vs (b.MinKey, b.MinTimestamp):
-	// labels equal (["api"] == ["api"]); fall through to timestamp:
-	// 200 < 300 -> a's upper bound < b's lower bound -> NO overlap -> one run.
-	a := secTS("o", 0, []string{"api"}, []string{"api"}, 100, 200)
-	b := secTS("o", 1, []string{"api"}, []string{"api"}, 300, 400)
-
-	got := calculateRuns([]*compactionv2pb.SectionRef{b, a}) // jumbled
-
-	require.Len(t, got, 1, "same-label, non-overlapping time should form one run")
-	require.Equal(t, []*compactionv2pb.SectionRef{a, b}, got[0].sections,
-		"composite sort key must order by timestamp when labels tie: a (ts=100) before b (ts=300)")
-}
-
-// TestCalculateRuns_Timestamp_Overlap is the dual: same labels with
-// overlapping time slices must produce separate runs.
-func TestCalculateRuns_Timestamp_Overlap(t *testing.T) {
-	// a: labels=["api"], ts=[100..300]
-	// b: labels=["api"], ts=[200..400]   -- overlaps a in time
-	//
-	// Composite compare on (a.MaxKey, a.MaxTimestamp) vs (b.MinKey, b.MinTimestamp):
-	// labels equal; 300 > 200 -> a's upper bound > b's lower bound -> OVERLAP.
-	// Two runs.
-	a := secTS("o", 0, []string{"api"}, []string{"api"}, 100, 300)
-	b := secTS("o", 1, []string{"api"}, []string{"api"}, 200, 400)
-
-	got := calculateRuns([]*compactionv2pb.SectionRef{a, b})
-
-	require.Len(t, got, 2, "same-label, time-overlapping sections must form separate runs")
-}
-
-// TestCalculateRuns_Timestamp_NumericOrder verifies that timestamps compare
-// numerically as int64, not lexicographically as strings. A naive encoding
-// of timestamps as Sprintf("%d", ts) would order ts=9 > ts=10 (because '9'
-// (0x39) > '1' (0x31) under byte compare); the int64 field side-steps that
-// entirely.
-func TestCalculateRuns_Timestamp_NumericOrder(t *testing.T) {
-	// Same labels; widely-separated timestamps where decimal-string compare
-	// would give the wrong answer.
-	//   a: labels=["api"], ts=[9..9]
-	//   b: labels=["api"], ts=[10..10]
-	// Numeric order: a < b (9 < 10). String "9" > "10" under byte compare.
-	a := secTS("o", 0, []string{"api"}, []string{"api"}, 9, 9)
-	b := secTS("o", 1, []string{"api"}, []string{"api"}, 10, 10)
-
-	got := calculateRuns([]*compactionv2pb.SectionRef{b, a}) // jumbled
-
-	require.Len(t, got, 1, "non-overlapping (one timestamp each) -> one run")
-	require.Equal(t, []*compactionv2pb.SectionRef{a, b}, got[0].sections,
-		"timestamps must compare numerically: ts=9 < ts=10")
-}
-
-func TestCalculateRuns_CompositeKey_SameTupleTimeOverlapSplits(t *testing.T) {
-	sections := []*compactionv2pb.SectionRef{
-		secTS("log-0", 0, []string{"auth"}, []string{"auth"}, 10, 30),
-		secTS("log-1", 0, []string{"auth"}, []string{"auth"}, 20, 40),
-	}
-	require.Len(t, calculateRuns(sections), 2, "overlapping times, same tuple: two runs")
-}
-
-func TestCalculateRuns_CompositeKey_SameTupleTimeDisjointChains(t *testing.T) {
-	sections := []*compactionv2pb.SectionRef{
-		secTS("log-0", 0, []string{"auth"}, []string{"auth"}, 10, 20),
-		secTS("log-1", 0, []string{"auth"}, []string{"auth"}, 30, 40),
-	}
-	require.Len(t, calculateRuns(sections), 1, "disjoint ordered times, same tuple: one run")
-}
-
-func TestCalculateRuns_CompositeKey_MultiLabelDistinctTuplesChain(t *testing.T) {
-	sections := []*compactionv2pb.SectionRef{
-		secTS("log-0", 0, []string{"auth", "eu"}, []string{"auth", "eu"}, 10, 40),
-		secTS("log-1", 0, []string{"auth", "us"}, []string{"auth", "us"}, 20, 50),
-		secTS("log-2", 0, []string{"billing", "eu"}, []string{"billing", "eu"}, 15, 45),
-	}
-	require.Len(t, calculateRuns(sections), 1, "distinct multi-label tuples chain into one run")
-}
-
-func TestCalculateRuns_CompositeKey_MultiLabelSecondKeyDisambiguates(t *testing.T) {
-	sections := []*compactionv2pb.SectionRef{
-		secTS("log-0", 0, []string{"auth", "eu"}, []string{"auth", "eu"}, 10, 40),
-		secTS("log-1", 0, []string{"auth", "us"}, []string{"auth", "us"}, 10, 40),
-	}
-	require.Len(t, calculateRuns(sections), 1, "second sort key disambiguates equal first keys")
-}
-
-func TestCalculateRuns_CompositeKey_MultiLabelSameTupleTimeOverlapSplits(t *testing.T) {
-	sections := []*compactionv2pb.SectionRef{
-		secTS("log-0", 0, []string{"auth", "eu"}, []string{"auth", "eu"}, 10, 30),
-		secTS("log-1", 0, []string{"auth", "eu"}, []string{"auth", "eu"}, 20, 40),
-	}
-	require.Len(t, calculateRuns(sections), 2, "identical multi-label tuple, overlapping times: two runs")
+	return refs
 }

--- a/pkg/dataobj/compaction/v2/doc.go
+++ b/pkg/dataobj/compaction/v2/doc.go
@@ -1,6 +1,5 @@
-// Package compactionv2 implements a sorted run-based compaction planner.
-//
-// Given a set of sections with (min_key, max_key, stable_id) sort-key bounds, Plan
-// produces a deterministic list of sorted piles (runs of non-overlapping
-// sections) and groups them into ⌈P/K⌉ task batches for downstream K-way merges.
+// Package compactionv2 plans K-way compaction from sections with inclusive
+// ordering-key bounds. CalculateRuns forms strict merge inputs, while
+// IsConverged treats touching-only boundaries as a terminal fixed point. Plan
+// batches P runs into ceil(P/K) tasks that each produce one output sequence.
 package compactionv2

--- a/pkg/dataobj/compaction/v2/plan.go
+++ b/pkg/dataobj/compaction/v2/plan.go
@@ -6,7 +6,16 @@ import (
 	compactionv2pb "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2/proto"
 )
 
-// Run is one non-overlapping layer of sections over the sort key.
+// CompareFunc compares two ordering keys.
+type CompareFunc[K any] func(a, b K) int
+
+// Section associates a section reference with its inclusive ordering-key bounds.
+type Section[K any] struct {
+	Ref      *compactionv2pb.SectionRef
+	Min, Max K
+}
+
+// Run is one strictly ordered sequence of sections.
 type Run interface {
 	// Sections returns the run's sections in sorted order.
 	Sections() []*compactionv2pb.SectionRef
@@ -14,41 +23,55 @@ type Run interface {
 	Size() uint64
 }
 
-// CalculateRuns sorts [sections] in place and returns the resulting runs.
-func CalculateRuns(sections []*compactionv2pb.SectionRef) []Run {
-	calculated := calculateRuns(sections)
+// CalculateRuns sorts sections in place and groups them into strict runs. It panics if a section has a nil Ref.
+func CalculateRuns[K any](sections []Section[K], compare CompareFunc[K]) []Run {
+	calculated := calculateRuns(sections, compare)
 	runs := make([]Run, len(calculated))
-	for i, r := range calculated {
-		runs[i] = r
+	for i, run := range calculated {
+		runs[i] = run
 	}
 	return runs
 }
 
-// IsTerminal reports whether a converged window is already a single run (or
-// none), or when the total data across all runs is below minCompactionSize.
-func IsTerminal(runs []Run, minCompactionSize uint64) bool {
-	if len(runs) <= 1 {
+// IsConverged reports whether sections have no positive overlap. Touching
+// sections remain separate runs because their stable order is unknown, but
+// rewriting them cannot remove that ambiguity, so run count alone does not
+// prevent convergence. It does not mutate sections.
+func IsConverged[K any](sections []Section[K], compare CompareFunc[K]) bool {
+	sections = append([]Section[K](nil), sections...)
+	sortSections(sections, compare)
+	if len(sections) <= 1 {
 		return true
 	}
-	var total uint64
-	for _, r := range runs {
-		total += r.Size()
+
+	maxKey := sections[0].Max
+	for _, section := range sections[1:] {
+		if compare(maxKey, section.Min) > 0 {
+			return false
+		}
+		if compare(section.Max, maxKey) > 0 {
+			maxKey = section.Max
+		}
 	}
-	return total < minCompactionSize
+	return true
 }
 
-// Plan groups [runs] into ⌈P/K⌉ task batches: runs [0..K) -> task
+// BelowMinCompactionSize reports whether the runs' total size is below minSize.
+func BelowMinCompactionSize(runs []Run, minSize uint64) bool {
+	var total uint64
+	for _, run := range runs {
+		total += run.Size()
+	}
+	return total < minSize
+}
+
+// Plan groups [runs] into ceil(P/K) task batches: runs [0..K) -> task
 // 0, runs [K..2K) -> task 1, ... The output is deterministic for a given input.
 //
 // Special cases:
 //   - len(runs) == 0 -> returns nil (no tasks).
 //   - k >= P         -> returns a single TaskSpec containing all runs.
-func Plan(
-	runs []Run,
-	tenant string,
-	k int,
-	sortSchema []string,
-) []*compactionv2pb.TaskSpec {
+func Plan(runs []Run, tenant string, k int, sortSchema []string) []*compactionv2pb.TaskSpec {
 	if k <= 0 {
 		panic(fmt.Sprintf("k must be > 0, got %d", k))
 	}
@@ -57,8 +80,8 @@ func Plan(
 	}
 
 	refs := make([]*compactionv2pb.RunRef, len(runs))
-	for i, r := range runs {
-		refs[i] = &compactionv2pb.RunRef{Sections: r.Sections()}
+	for i, run := range runs {
+		refs[i] = &compactionv2pb.RunRef{Sections: run.Sections()}
 	}
 
 	numTasks := (len(refs) + k - 1) / k

--- a/pkg/dataobj/compaction/v2/plan_test.go
+++ b/pkg/dataobj/compaction/v2/plan_test.go
@@ -92,57 +92,56 @@ func TestRun_SizeAndSections(t *testing.T) {
 	s1 := &compactionv2pb.SectionRef{ObjectPath: "a", SectionIndex: 0, UncompressedSize: 100}
 	s2 := &compactionv2pb.SectionRef{ObjectPath: "a", SectionIndex: 1, UncompressedSize: 250}
 
-	var r Run = &run{sections: []*compactionv2pb.SectionRef{s1, s2}}
+	var r Run = &run[int]{sections: []*compactionv2pb.SectionRef{s1, s2}}
 
 	require.Equal(t, uint64(350), r.Size())
 	require.Equal(t, []*compactionv2pb.SectionRef{s1, s2}, r.Sections())
 }
 
 func TestRun_SizeEmpty(t *testing.T) {
-	var r Run = &run{sections: nil}
+	var r Run = &run[int]{sections: nil}
 	require.Equal(t, uint64(0), r.Size())
 	require.Empty(t, r.Sections())
 }
 
 func TestCalculateRuns_EmptyInput(t *testing.T) {
-	require.Empty(t, CalculateRuns(nil))
-	require.Empty(t, CalculateRuns([]*compactionv2pb.SectionRef{}))
+	require.Empty(t, CalculateRuns([]Section[int](nil), func(a, b int) int { return a - b }))
 }
 
 func TestCalculateRuns_WrapsRunsAndSortsInPlace(t *testing.T) {
-	// Two non-overlapping same-tuple sections (disjoint, ordered times) chain
-	// into one run; passed out of order to prove in-place sorting.
-	a := &compactionv2pb.SectionRef{ObjectPath: "a", SectionIndex: 0, MinKey: []string{"svc"}, MaxKey: []string{"svc"}, MinTimestamp: 10, MaxTimestamp: 20, UncompressedSize: 5}
-	b := &compactionv2pb.SectionRef{ObjectPath: "b", SectionIndex: 0, MinKey: []string{"svc"}, MaxKey: []string{"svc"}, MinTimestamp: 30, MaxTimestamp: 40, UncompressedSize: 7}
+	a := &compactionv2pb.SectionRef{ObjectPath: "a", SectionIndex: 0, UncompressedSize: 5}
+	b := &compactionv2pb.SectionRef{ObjectPath: "b", SectionIndex: 0, UncompressedSize: 7}
+	input := []Section[int]{
+		{Ref: b, Min: 30, Max: 40},
+		{Ref: a, Min: 10, Max: 20},
+	}
 
-	input := []*compactionv2pb.SectionRef{b, a}
-	runs := CalculateRuns(input)
+	runs := CalculateRuns(input, func(a, b int) int { return a - b })
 
 	require.Len(t, runs, 1)
 	require.Equal(t, uint64(12), runs[0].Size())
-	require.Equal(t, []*compactionv2pb.SectionRef{a, b}, input, "input sorted in place")
+	require.Equal(t, []Section[int]{{Ref: a, Min: 10, Max: 20}, {Ref: b, Min: 30, Max: 40}}, input)
 }
 
-func TestIsTerminal(t *testing.T) {
+func TestBelowMinCompactionSize(t *testing.T) {
 	const floor = uint64(100)
 	run := func(size uint64) Run { return fakeRun{size: size} }
 
 	tests := []struct {
-		name     string
-		runs     []Run
-		terminal bool
+		name  string
+		runs  []Run
+		below bool
 	}{
 		{"no runs", nil, true},
 		{"single run below floor", []Run{run(1)}, true},
-		{"single run above floor", []Run{run(500)}, true},
-		{"two runs total >= floor", []Run{run(60), run(60)}, false},
+		{"single run above floor", []Run{run(500)}, false},
+		{"two runs total above floor", []Run{run(60), run(60)}, false},
 		{"two runs total exactly floor", []Run{run(50), run(50)}, false},
 		{"two runs total below floor", []Run{run(10), run(20)}, true},
-		{"many tiny runs below floor (small tenant)", []Run{run(5), run(5), run(5)}, true},
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.terminal, IsTerminal(tc.runs, floor))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.below, BelowMinCompactionSize(test.runs, floor))
 		})
 	}
 }

--- a/pkg/dataobj/sections/postings/row.go
+++ b/pkg/dataobj/sections/postings/row.go
@@ -8,8 +8,9 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 )
 
-// CompareRows reports whether row [a] sorts before (<0), after (>0), or equal to
-// (0) row [b].
+// CompareRows defines the physical row order of a postings section and the
+// merge order across sections. It reports whether row [a] sorts before (<0),
+// after (>0), or equal to (0) row [b].
 func CompareRows(a, b Row) int {
 	return cmp.Or(
 		cmp.Compare(a.Kind, b.Kind),

--- a/pkg/engine/compactor/config.go
+++ b/pkg/engine/compactor/config.go
@@ -36,8 +36,7 @@ type Config struct {
 	LogMaxRunningCompactionTasks int `yaml:"logs_max_running_compaction_tasks"`
 
 	// PollingInterval is the cadence of the coordinator's main loop. Each
-	// tick reads the most-recent ToC and runs a compaction plan per tenant
-	// that has > 1 index in the window.
+	// tick reads the most-recent ToC and plans compaction per tenant.
 	PollingInterval time.Duration `yaml:"polling_interval"`
 
 	// MaxRunsPerTask (K in the K-way merge) is the maximum number of runs a

--- a/pkg/engine/compactor/coordinator.go
+++ b/pkg/engine/compactor/coordinator.go
@@ -212,8 +212,8 @@ func (c *coordinator) compactTenantLogs(
 		return compactionStats{}, fmt.Errorf("reading log section refs: %w", err)
 	}
 
-	runs := v2.CalculateRuns(sections)
-	if v2.IsTerminal(runs, uint64(c.cfg.LogMinCompactionSize)) {
+	runs := v2.CalculateRuns(sections, compareSortKey)
+	if v2.IsConverged(sections, compareSortKey) || v2.BelowMinCompactionSize(runs, uint64(c.cfg.LogMinCompactionSize)) {
 		level.Debug(c.logger).Log("msg", "log-compaction: window not worth compacting, skipping",
 			"tenant", tenant, "window", window)
 		return compactionStats{}, nil
@@ -318,7 +318,7 @@ func (c *coordinator) compactTenant(
 ) (compactionStats, error) {
 	// Plan.
 	sections := sectionRefsFor(entries)
-	runs := v2.CalculateRuns(sections)
+	runs := v2.CalculateRuns(sections, compareSortKey)
 	tasks := v2.Plan(runs, tenant, c.cfg.MaxRunsPerTask, nil)
 	if len(tasks) == 0 {
 		level.Debug(c.logger).Log("msg", "tenant cycle: planner produced no tasks",

--- a/pkg/engine/compactor/coordinator.go
+++ b/pkg/engine/compactor/coordinator.go
@@ -3,6 +3,7 @@ package compactor
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -308,32 +309,38 @@ func (c *coordinator) compactTenantLogs(
 	return stats, nil
 }
 
-// compactTenant performs the per-(tenant, window) IndexMerge. Stats are
-// zero-valued on any no-op success (no tasks planned or a race-loss swap).
-func (c *coordinator) compactTenant(
-	ctx context.Context,
-	tenant string,
-	window time.Time,
-	entries []indexEntry,
-) (compactionStats, error) {
-	// Plan.
-	sections := sectionRefsFor(entries)
-	runs := v2.CalculateRuns(sections, compareSortKey)
-	tasks := v2.Plan(runs, tenant, c.cfg.MaxRunsPerTask, nil)
-	if len(tasks) == 0 {
-		level.Debug(c.logger).Log("msg", "tenant cycle: planner produced no tasks",
-			"tenant", tenant, "window", window)
+// compactTenant performs one index-compaction pass for a tenant and window.
+func (c *coordinator) compactTenant(ctx context.Context, tenant string, window time.Time, entries []indexEntry) (compactionStats, error) {
+	sections, err := indexSectionRefsFor(ctx, c.bucket, tenant, entries)
+	if err != nil {
+		return compactionStats{}, fmt.Errorf("discover index section bounds: %w", err)
+	}
+
+	runs := v2.CalculateRuns(sections, compareIndexSortKey)
+	inputRuns := len(runs)
+	c.metrics.observeIndexInputRuns(inputRuns)
+	converged := v2.IsConverged(sections, compareIndexSortKey)
+	c.metrics.observeIndexConvergence(tenant, converged, inputRuns, entries, c.clock())
+	if converged {
+		level.Debug(c.logger).Log("msg", "index-compaction: window converged, skipping",
+			"tenant", tenant, "window", window, "input_runs", inputRuns)
 		return compactionStats{}, nil
 	}
 
-	resultEntries := make([]*metastore.TableOfContentsEntry, len(tasks))
+	tasks := v2.Plan(runs, tenant, c.cfg.MaxRunsPerTask, nil)
+	outputs := make([]string, len(tasks))
+
+	// IndexMerge opens each referenced object whole. Until it reads individual
+	// sections, one object may be repeated across task outputs and deduplicated
+	// by a later pass.
+	// TODO(rfratto): Preserve multiple log sort schemas in one IndexMerge output.
 	g, gctx := errgroup.WithContext(ctx)
 	if c.cfg.MaxRunningCompactionTasks > 0 {
 		g.SetLimit(c.cfg.MaxRunningCompactionTasks)
 	}
-	for i, ts := range tasks {
+	for i, task := range tasks {
 		g.Go(func() error {
-			plan := buildIndexMergePlan(tenant, window, ts)
+			plan := buildIndexMergePlan(tenant, window, task)
 			opts := workflow.Options{Tenant: tenant, Actor: []string{"compaction", "index-merge"}}
 			rec, err := c.runPlan(gctx, opts, plan)
 			if err != nil {
@@ -352,33 +359,30 @@ func (c *coordinator) compactTenant(
 			if len(artifacts) > 1 {
 				return fmt.Errorf("index-merge job produced %d artifacts, want 1", len(artifacts))
 			}
-			minTS, maxTS := taskBounds(ts)
-			resultEntries[i] = &metastore.TableOfContentsEntry{
-				Path:                 artifacts[0].Path,
-				StartTime:            time.Unix(0, minTS).UTC(),
-				EndTime:              time.Unix(0, maxTS).UTC(),
-				UncompressedLogsSize: taskUncompressedLogsSize(ts),
-			}
+			outputs[i] = artifacts[0].Path
 			return nil
 		})
 	}
 	if err := g.Wait(); err != nil {
-		return compactionStats{}, fmt.Errorf("failed to execute compaction tasks: %w", err)
+		return compactionStats{}, fmt.Errorf("execute index-compaction tasks: %w", err)
 	}
 
-	oldPaths := make([]string, len(entries))
-	for i, e := range entries {
-		oldPaths[i] = e.Path
-	}
-
-	newEntries := make([]metastore.TableOfContentsEntry, 0, len(resultEntries))
-	for _, e := range resultEntries {
-		if e != nil {
-			newEntries = append(newEntries, *e)
+	completedTasks := make([]*compactionv2pb.TaskSpec, 0, len(tasks))
+	completedOutputs := make([]string, 0, len(tasks))
+	for i, output := range outputs {
+		if output != "" {
+			completedTasks = append(completedTasks, tasks[i])
+			completedOutputs = append(completedOutputs, output)
 		}
 	}
-	if len(newEntries) == 0 {
+	if len(completedTasks) == 0 {
 		return compactionStats{}, nil
+	}
+
+	oldPaths := taskObjectPaths(completedTasks)
+	newEntries, err := makeIndexTocEntries(completedTasks, completedOutputs, entries)
+	if err != nil {
+		return compactionStats{}, fmt.Errorf("build index ToC entries: %w", err)
 	}
 
 	if c.cfg.DryRun {
@@ -391,13 +395,14 @@ func (c *coordinator) compactTenant(
 	defer cancel()
 	swapped, err := c.metastoreWriter.ReplaceIndexPointers(phase2Ctx, window, tenant, oldPaths, newEntries)
 	if err != nil {
-		return compactionStats{}, fmt.Errorf("failed to replace index pointers after compaction: %w", err)
+		return compactionStats{}, fmt.Errorf("replace index pointers after compaction: %w", err)
 	}
 	if !swapped {
-		level.Debug(c.logger).Log("msg", "ToC replace race-loss / already-converged",
+		level.Debug(c.logger).Log("msg", "index-compaction ToC replace race-loss",
 			"tenant", tenant, "window", window)
 		return compactionStats{}, nil
 	}
+
 	level.Info(c.logger).Log("msg", "tenant cycle complete",
 		"tenant", tenant, "window", window,
 		"removed_indexes", len(oldPaths),
@@ -446,6 +451,78 @@ func taskUncompressedLogsSize(task *compactionv2pb.TaskSpec) uint64 {
 		}
 	}
 	return total
+}
+
+func taskObjectPaths(tasks []*compactionv2pb.TaskSpec) []string {
+	seen := make(map[string]struct{})
+	for _, task := range tasks {
+		for _, run := range task.Runs {
+			for _, section := range run.Sections {
+				seen[section.ObjectPath] = struct{}{}
+			}
+		}
+	}
+
+	paths := make([]string, 0, len(seen))
+	for path := range seen {
+		paths = append(paths, path)
+	}
+	slices.Sort(paths)
+	return paths
+}
+
+// makeIndexTocEntries derives output metadata from each task's source indexes.
+func makeIndexTocEntries(tasks []*compactionv2pb.TaskSpec, outputs []string, inputs []indexEntry) ([]metastore.TableOfContentsEntry, error) {
+	byPath := make(map[string]indexEntry, len(inputs))
+	for _, input := range inputs {
+		byPath[input.Path] = input
+	}
+
+	entries := make([]metastore.TableOfContentsEntry, len(outputs))
+	for i, task := range tasks {
+		var (
+			start, end   time.Time
+			uncompressed uint64
+
+			first     = true
+			sizeKnown = true
+			seen      = make(map[string]struct{})
+		)
+		for _, run := range task.Runs {
+			for _, section := range run.Sections {
+				if _, ok := seen[section.ObjectPath]; ok {
+					continue
+				}
+				seen[section.ObjectPath] = struct{}{}
+
+				input, ok := byPath[section.ObjectPath]
+				if !ok {
+					return nil, fmt.Errorf("task references unknown index %q", section.ObjectPath)
+				}
+				if first || input.Start.Before(start) {
+					start = input.Start
+				}
+				if first || input.End.After(end) {
+					end = input.End
+				}
+				first = false
+				if input.UncompressedLogsSize == 0 {
+					sizeKnown = false
+				}
+				uncompressed += input.UncompressedLogsSize
+			}
+		}
+		if !sizeKnown {
+			uncompressed = 0
+		}
+		entries[i] = metastore.TableOfContentsEntry{
+			Path:                 outputs[i],
+			StartTime:            start.UTC(),
+			EndTime:              end.UTC(),
+			UncompressedLogsSize: uncompressed,
+		}
+	}
+	return entries, nil
 }
 
 // fileSizeStatConcurrency bounds concurrent bucket.Attributes calls when
@@ -515,12 +592,7 @@ func (c *coordinator) runIndexMergePhase(ctx context.Context, tenant string, win
 		return phaseOutcomeError
 	}
 
-	c.metrics.observeEntries(tenant, entries, c.clock())
-
-	if len(entries) <= 1 {
-		c.metrics.observeTenantCycle(tenant, "converged", c.clock().Sub(start), compactionStats{})
-		return phaseOutcomeNoWork
-	}
+	c.metrics.observeEntries(tenant, entries)
 
 	stats, err := c.compactTenant(ctx, tenant, window, entries)
 	dur := c.clock().Sub(start)

--- a/pkg/engine/compactor/coordinator_test.go
+++ b/pkg/engine/compactor/coordinator_test.go
@@ -23,6 +23,7 @@ import (
 	v2 "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2"
 	compactionv2pb "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2/proto"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
 	stats "github.com/grafana/loki/v3/pkg/dataobj/sections/stats"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
@@ -145,6 +146,14 @@ func newTestCoordinator(t *testing.T, bucket objstore.Bucket, runner *fakeRunner
 // fixedClock returns a clock function pinned to t.
 func fixedClock(t time.Time) func() time.Time { return func() time.Time { return t } }
 
+func buildOverlappingPostingsIndex(ctx context.Context, t *testing.T, bucket objstore.Bucket, tenant, path string) {
+	t.Helper()
+	buildIndexWithPostings(ctx, t, bucket, tenant, path, 1<<20, []postings.Row{
+		{Kind: postings.KindLabel, ObjectPath: path + ".log-0", ColumnName: "service_name", LabelValue: "a", MinTimestamp: 10, MaxTimestamp: 20},
+		{Kind: postings.KindLabel, ObjectPath: path + ".log-1", ColumnName: "service_name", LabelValue: "z", MinTimestamp: 30, MaxTimestamp: 40},
+	})
+}
+
 // TestRunTenantCycle_RaceLossIsSuccess verifies the (swapped=false, err=nil)
 // path is treated as success: the cycle returns nil and the next cycle
 // re-plans against the post-swap ToC.
@@ -152,6 +161,8 @@ func TestCompactTenant_RaceLossIsSuccess(t *testing.T) {
 	ctx := context.Background()
 	bucket := objstore.NewInMemBucket()
 	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
+	buildOverlappingPostingsIndex(ctx, t, bucket, "acme", "indexes/aa/src-0")
+	buildOverlappingPostingsIndex(ctx, t, bucket, "acme", "indexes/bb/src-1")
 
 	writeToCWithIndexes(ctx, t, bucket, map[string][]testIndex{
 		"acme": {
@@ -180,6 +191,8 @@ func TestCompactTenant_HardSwapErrorPropagates(t *testing.T) {
 	ctx := context.Background()
 	bucket := objstore.NewInMemBucket()
 	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
+	buildOverlappingPostingsIndex(ctx, t, bucket, "acme", "indexes/aa/src-0")
+	buildOverlappingPostingsIndex(ctx, t, bucket, "acme", "indexes/bb/src-1")
 
 	writeToCWithIndexes(ctx, t, bucket, map[string][]testIndex{
 		"acme": {
@@ -489,8 +502,9 @@ func TestRunIndexMergePhase_SingleIndexIsNoWork(t *testing.T) {
 	ctx := context.Background()
 	window := imWindow()
 	bucket := objstore.NewInMemBucket()
+	buildOverlappingPostingsIndex(ctx, t, bucket, "acme", "indexes/a")
 	writeToCWithIndexes(ctx, t, bucket, map[string][]testIndex{
-		"acme": {{path: "[REDACTED]", start: window.Add(time.Hour), end: window.Add(2 * time.Hour)}},
+		"acme": {{path: "indexes/a", start: window.Add(time.Hour), end: window.Add(2 * time.Hour)}},
 	})
 	runner := &fakeRunner{}
 	replacer := &fakeReplacer{swapped: true}
@@ -498,6 +512,104 @@ func TestRunIndexMergePhase_SingleIndexIsNoWork(t *testing.T) {
 
 	require.Equal(t, phaseOutcomeNoWork, c.runIndexMergePhase(ctx, "acme", window))
 	require.Empty(t, replacer.snapshot(), "no swap for a single-index window")
+}
+
+func TestRunIndexMergePhase_SingleIndexWithOverlappingSectionsSwaps(t *testing.T) {
+	ctx := context.Background()
+	window := imWindow()
+	bucket := objstore.NewInMemBucket()
+	path := "indexes/a"
+	buildIndexWithPostingsSections(ctx, t, bucket, "acme", path,
+		[]postings.Row{
+			{Kind: postings.KindLabel, ObjectPath: "logs/a", ColumnName: "service", LabelValue: "a", MinTimestamp: 10, MaxTimestamp: 20},
+			{Kind: postings.KindLabel, ObjectPath: "logs/b", ColumnName: "service", LabelValue: "z", MinTimestamp: 30, MaxTimestamp: 40},
+		},
+		[]postings.Row{
+			{Kind: postings.KindLabel, ObjectPath: "logs/c", ColumnName: "service", LabelValue: "b", MinTimestamp: 15, MaxTimestamp: 25},
+			{Kind: postings.KindLabel, ObjectPath: "logs/d", ColumnName: "service", LabelValue: "y", MinTimestamp: 25, MaxTimestamp: 35},
+		},
+	)
+	writeToCWithIndexes(ctx, t, bucket, map[string][]testIndex{
+		"acme": {{path: path, start: window.Add(time.Hour), end: window.Add(2 * time.Hour)}},
+	})
+
+	replacer := &fakeReplacer{swapped: true}
+	c := newTestCoordinator(t, bucket, &fakeRunner{}, replacer, fixedClock(window.Add(3*time.Hour)), newFakeLimits("acme"))
+
+	require.Equal(t, phaseOutcomeSwapped, c.runIndexMergePhase(ctx, "acme", window))
+	require.Len(t, replacer.snapshot(), 1)
+	require.Equal(t, 1.0, testutil.ToFloat64(c.metrics.unconsolidatedBacklog.WithLabelValues("acme")))
+	require.Equal(t, time.Hour.Seconds(), testutil.ToFloat64(c.metrics.oldestBacklogLogAgeSeconds.WithLabelValues("acme")))
+}
+
+func TestCompactTenant_TouchingSectionsAreConverged(t *testing.T) {
+	ctx := context.Background()
+	window := imWindow()
+	bucket := objstore.NewInMemBucket()
+	for _, path := range []string{"indexes/a", "indexes/b"} {
+		buildIndexWithPostings(ctx, t, bucket, "acme", path, 1<<20, []postings.Row{{
+			Kind: postings.KindLabel, ObjectPath: path + ".log", ColumnName: "service", LabelValue: "api", MinTimestamp: 10, MaxTimestamp: 20,
+		}})
+	}
+
+	runner := &fakeRunner{}
+	replacer := &fakeReplacer{swapped: true}
+	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
+	stats, err := c.compactTenant(ctx, "acme", window, []indexEntry{{Path: "indexes/a"}, {Path: "indexes/b"}})
+
+	require.NoError(t, err)
+	require.Equal(t, compactionStats{}, stats)
+	require.Empty(t, runner.snapshot())
+	require.Empty(t, replacer.snapshot())
+	require.Zero(t, testutil.ToFloat64(c.metrics.unconsolidatedBacklog.WithLabelValues("acme")))
+}
+
+func TestCompactTenant_PostingTimestampsDetectOverlap(t *testing.T) {
+	ctx := context.Background()
+	window := imWindow()
+	bucket := objstore.NewInMemBucket()
+	rowsByPath := map[string][]postings.Row{
+		"indexes/a": {
+			{Kind: postings.KindLabel, ObjectPath: "logs/a-0", ColumnName: "service", LabelValue: "api", MinTimestamp: 10, MaxTimestamp: 10},
+			{Kind: postings.KindLabel, ObjectPath: "logs/a-1", ColumnName: "service", LabelValue: "api", MinTimestamp: 30, MaxTimestamp: 30},
+		},
+		"indexes/b": {
+			{Kind: postings.KindLabel, ObjectPath: "logs/b-0", ColumnName: "service", LabelValue: "api", MinTimestamp: 20, MaxTimestamp: 20},
+			{Kind: postings.KindLabel, ObjectPath: "logs/b-1", ColumnName: "service", LabelValue: "api", MinTimestamp: 40, MaxTimestamp: 40},
+		},
+	}
+	for path, rows := range rowsByPath {
+		buildIndexWithPostings(ctx, t, bucket, "acme", path, 1<<20, rows)
+	}
+
+	runner := &fakeRunner{}
+	replacer := &fakeReplacer{swapped: true}
+	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
+	_, err := c.compactTenant(ctx, "acme", window, []indexEntry{
+		{Path: "indexes/a", Start: window, End: window.Add(time.Hour)},
+		{Path: "indexes/b", Start: window, End: window.Add(time.Hour)},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, runner.snapshot(), 1)
+	require.Len(t, replacer.snapshot(), 1)
+	require.Equal(t, 1.0, testutil.ToFloat64(c.metrics.unconsolidatedBacklog.WithLabelValues("acme")))
+}
+
+func TestCompactTenant_FailsOnIncompleteDiscovery(t *testing.T) {
+	ctx := context.Background()
+	window := imWindow()
+	bucket := objstore.NewInMemBucket()
+	buildOverlappingPostingsIndex(ctx, t, bucket, "acme", "indexes/a")
+
+	runner := &fakeRunner{}
+	replacer := &fakeReplacer{swapped: true}
+	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
+	_, err := c.compactTenant(ctx, "acme", window, []indexEntry{{Path: "indexes/a"}, {Path: "indexes/missing"}})
+
+	require.ErrorContains(t, err, "discover index section bounds")
+	require.Empty(t, runner.snapshot())
+	require.Empty(t, replacer.snapshot())
 }
 
 func TestRunIndexMergePhase_MissingToCIsNoWork(t *testing.T) {
@@ -513,10 +625,12 @@ func TestRunIndexMergePhase_MultiIndexSwaps(t *testing.T) {
 	ctx := context.Background()
 	window := imWindow()
 	bucket := objstore.NewInMemBucket()
+	buildOverlappingPostingsIndex(ctx, t, bucket, "acme", "indexes/a")
+	buildOverlappingPostingsIndex(ctx, t, bucket, "acme", "indexes/b")
 	writeToCWithIndexes(ctx, t, bucket, map[string][]testIndex{
 		"acme": {
-			{path: "[REDACTED]", start: window.Add(time.Hour), end: window.Add(2 * time.Hour)},
-			{path: "[REDACTED]", start: window.Add(time.Hour), end: window.Add(2 * time.Hour)},
+			{path: "indexes/a", start: window.Add(time.Hour), end: window.Add(2 * time.Hour)},
+			{path: "indexes/b", start: window.Add(time.Hour), end: window.Add(2 * time.Hour)},
 		},
 	})
 	runner := &fakeRunner{}
@@ -532,11 +646,20 @@ func logMergeBucket(ctx context.Context, t *testing.T, window time.Time, tenant 
 	bucket := objstore.NewInMemBucket()
 	entries := make([]testIndex, 0, len(paths))
 	for _, p := range paths {
-		buildIndexWithStats(ctx, t, bucket, tenant, p, []stats.Stat{
-			{ObjectPath: p + ".log-0", SectionIndex: 0, SortSchema: "label:service_name",
-				Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 30, RowCount: 1, UncompressedSize: 100},
-			{ObjectPath: p + ".log-1", SectionIndex: 0, SortSchema: "label:service_name",
-				Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 20, MaxTimestamp: 40, RowCount: 1, UncompressedSize: 100},
+		buildIndex(ctx, t, bucket, testIndexObject{
+			tenant:      tenant,
+			path:        p,
+			sectionSize: 1 << 20,
+			stats: []stats.Stat{
+				{ObjectPath: p + ".log-0", SectionIndex: 0, SortSchema: "label:service_name",
+					Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 30, RowCount: 1, UncompressedSize: 100},
+				{ObjectPath: p + ".log-1", SectionIndex: 0, SortSchema: "label:service_name",
+					Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 20, MaxTimestamp: 40, RowCount: 1, UncompressedSize: 100},
+			},
+			postings: []postings.Row{
+				{Kind: postings.KindLabel, ObjectPath: p + ".log-0", ColumnName: "service_name", LabelValue: "a", MinTimestamp: 10, MaxTimestamp: 20},
+				{Kind: postings.KindLabel, ObjectPath: p + ".log-1", ColumnName: "service_name", LabelValue: "z", MinTimestamp: 30, MaxTimestamp: 40},
+			},
 		})
 		entries = append(entries, testIndex{path: p, start: window.Add(time.Hour), end: window.Add(2 * time.Hour)})
 	}
@@ -583,13 +706,7 @@ func TestRunLogMergePhase_CancelledMidIterationStops(t *testing.T) {
 func TestRun_CancelDrainsGoroutines(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	window := imWindow()
-	bucket := objstore.NewInMemBucket()
-	writeToCWithIndexes(ctx, t, bucket, map[string][]testIndex{
-		"acme": {
-			{path: "indexes/acme/0", start: window.Add(time.Hour), end: window.Add(2 * time.Hour)},
-			{path: "indexes/acme/1", start: window.Add(time.Hour), end: window.Add(2 * time.Hour)},
-		},
-	})
+	bucket := seededToC(ctx, t, window, "acme")
 	runner := &fakeRunner{}
 	replacer := &fakeReplacer{swapped: true}
 
@@ -629,17 +746,7 @@ func TestRun_StartsOneWorkerPerTenant(t *testing.T) {
 	defer cancel()
 
 	window := imWindow()
-	bucket := objstore.NewInMemBucket()
-	writeToCWithIndexes(ctx, t, bucket, map[string][]testIndex{
-		"acme": {
-			{path: "indexes/acme/0", start: window.Add(time.Hour), end: window.Add(2 * time.Hour)},
-			{path: "indexes/acme/1", start: window.Add(time.Hour), end: window.Add(2 * time.Hour)},
-		},
-		"bravo": {
-			{path: "indexes/bravo/0", start: window.Add(time.Hour), end: window.Add(2 * time.Hour)},
-			{path: "indexes/bravo/1", start: window.Add(time.Hour), end: window.Add(2 * time.Hour)},
-		},
-	})
+	bucket := seededToC(ctx, t, window, "acme", "bravo")
 
 	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, &fakeRunner{}, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme", "bravo"))
@@ -713,10 +820,14 @@ func seededToC(ctx context.Context, t *testing.T, window time.Time, tenants ...s
 	t.Helper()
 	bucket := objstore.NewInMemBucket()
 	entries := map[string][]testIndex{}
-	for _, tn := range tenants {
-		entries[tn] = []testIndex{
-			{path: "indexes/" + tn + "/0", start: window.Add(time.Hour), end: window.Add(2 * time.Hour)},
-			{path: "indexes/" + tn + "/1", start: window.Add(time.Hour), end: window.Add(2 * time.Hour)},
+	for _, tenant := range tenants {
+		paths := []string{"indexes/" + tenant + "/0", "indexes/" + tenant + "/1"}
+		for _, path := range paths {
+			buildOverlappingPostingsIndex(ctx, t, bucket, tenant, path)
+		}
+		entries[tenant] = []testIndex{
+			{path: paths[0], start: window.Add(time.Hour), end: window.Add(2 * time.Hour)},
+			{path: paths[1], start: window.Add(time.Hour), end: window.Add(2 * time.Hour)},
 		}
 	}
 	writeToCWithIndexes(ctx, t, bucket, entries)
@@ -1168,6 +1279,49 @@ func TestTaskUncompressedLogsSize_UnknownSizePropagates(t *testing.T) {
 
 	require.Equal(t, uint64(0), taskUncompressedLogsSize(tasks[0]),
 		"an unknown (0) input section must propagate as unknown, not a misleading partial sum")
+}
+
+func TestMakeIndexTocEntries_UsesInputIndexes(t *testing.T) {
+	window := imWindow()
+	tasks := []*compactionv2pb.TaskSpec{{
+		Runs: []*compactionv2pb.RunRef{
+			{Sections: []*compactionv2pb.SectionRef{
+				{ObjectPath: "indexes/a", SectionIndex: 1},
+				{ObjectPath: "indexes/a", SectionIndex: 2},
+			}},
+			{Sections: []*compactionv2pb.SectionRef{{ObjectPath: "indexes/b", SectionIndex: 0}}},
+		},
+	}}
+	inputs := []indexEntry{
+		{Path: "indexes/a", Start: window.Add(time.Hour), End: window.Add(3 * time.Hour), UncompressedLogsSize: 100},
+		{Path: "indexes/b", Start: window.Add(2 * time.Hour), End: window.Add(4 * time.Hour), UncompressedLogsSize: 200},
+	}
+
+	entries, err := makeIndexTocEntries(tasks, []string{"indexes/output"}, inputs)
+	require.NoError(t, err)
+	require.Equal(t, []metastore.TableOfContentsEntry{{
+		Path:                 "indexes/output",
+		StartTime:            window.Add(time.Hour),
+		EndTime:              window.Add(4 * time.Hour),
+		UncompressedLogsSize: 300,
+	}}, entries)
+}
+
+func TestMakeIndexTocEntries_UnknownInputSizePropagates(t *testing.T) {
+	tasks := []*compactionv2pb.TaskSpec{{
+		Runs: []*compactionv2pb.RunRef{{Sections: []*compactionv2pb.SectionRef{
+			{ObjectPath: "indexes/a"},
+			{ObjectPath: "indexes/b"},
+		}}},
+	}}
+	inputs := []indexEntry{
+		{Path: "indexes/a", UncompressedLogsSize: 100},
+		{Path: "indexes/b", UncompressedLogsSize: 0},
+	}
+
+	entries, err := makeIndexTocEntries(tasks, []string{"indexes/output"}, inputs)
+	require.NoError(t, err)
+	require.Zero(t, entries[0].UncompressedLogsSize)
 }
 
 func TestFillFileSizes_StatsObjectAndSetsSize(t *testing.T) {

--- a/pkg/engine/compactor/coordinator_test.go
+++ b/pkg/engine/compactor/coordinator_test.go
@@ -292,6 +292,30 @@ func TestCompactTenantLogs_TerminalSingleRunSkips(t *testing.T) {
 	require.Empty(t, replacer.snapshot(), "terminal window performs no swap")
 }
 
+func TestCompactTenantLogs_TouchingRunsAreConverged(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
+	indexPath := "indexes/aa/converged"
+
+	buildIndexWithStats(ctx, t, bucket, "acme", indexPath, []stats.Stat{
+		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "label:service_name",
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 20, UncompressedSize: 100},
+		{ObjectPath: "logs/log-1", SectionIndex: 0, SortSchema: "label:service_name",
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 20, MaxTimestamp: 30, UncompressedSize: 100},
+	})
+
+	runner := &fakeRunner{}
+	replacer := &fakeReplacer{swapped: true}
+	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
+
+	stats, err := c.compactTenantLogs(ctx, "acme", window, indexEntry{Path: indexPath})
+	require.NoError(t, err)
+	require.Equal(t, compactionStats{}, stats)
+	require.Empty(t, runner.snapshot())
+	require.Empty(t, replacer.snapshot())
+}
+
 func TestCompactTenantLogs_TerminalBelowFloorSkips(t *testing.T) {
 	ctx := context.Background()
 	bucket := objstore.NewInMemBucket()
@@ -509,9 +533,9 @@ func logMergeBucket(ctx context.Context, t *testing.T, window time.Time, tenant 
 	entries := make([]testIndex, 0, len(paths))
 	for _, p := range paths {
 		buildIndexWithStats(ctx, t, bucket, tenant, p, []stats.Stat{
-			{ObjectPath: p + ".log", SectionIndex: 0, SortSchema: "service_name",
+			{ObjectPath: p + ".log-0", SectionIndex: 0, SortSchema: "label:service_name",
 				Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 30, RowCount: 1, UncompressedSize: 100},
-			{ObjectPath: p + ".log", SectionIndex: 0, SortSchema: "service_name",
+			{ObjectPath: p + ".log-1", SectionIndex: 0, SortSchema: "label:service_name",
 				Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 20, MaxTimestamp: 40, RowCount: 1, UncompressedSize: 100},
 		})
 		entries = append(entries, testIndex{path: p, start: window.Add(time.Hour), end: window.Add(2 * time.Hour)})
@@ -1039,6 +1063,33 @@ func TestCompactTenantLogs_KnownConvergedRowKeepsComputedSize(t *testing.T) {
 	require.Len(t, calls[0].newEntries, 1)
 	require.Equal(t, uint64(200), calls[0].newEntries[0].UncompressedLogsSize,
 		"a known converged row keeps the computed section sum (100+100)")
+}
+
+func TestCompactTenantLogs_PublishesGlobalTimeRange(t *testing.T) {
+	ctx := context.Background()
+	window := imWindow()
+	bucket := objstore.NewInMemBucket()
+	indexPath := "indexes/converged"
+	buildIndexWithStats(ctx, t, bucket, "acme", indexPath, []stats.Stat{
+		{ObjectPath: "logs/a", SectionIndex: 0, SortSchema: "label:service_name",
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 500, MaxTimestamp: 1000, UncompressedSize: 100},
+		{ObjectPath: "logs/a", SectionIndex: 0, SortSchema: "label:service_name",
+			Labels: map[string]string{"service_name": "billing"}, MinTimestamp: 100, MaxTimestamp: 900, UncompressedSize: 100},
+		{ObjectPath: "logs/b", SectionIndex: 0, SortSchema: "label:service_name",
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 550, MaxTimestamp: 950, UncompressedSize: 100},
+		{ObjectPath: "logs/b", SectionIndex: 0, SortSchema: "label:service_name",
+			Labels: map[string]string{"service_name": "billing"}, MinTimestamp: 200, MaxTimestamp: 800, UncompressedSize: 100},
+	})
+
+	replacer := &fakeReplacer{swapped: true}
+	c := newTestCoordinator(t, bucket, &fakeRunner{}, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
+	_, err := c.compactTenantLogs(ctx, "acme", window, indexEntry{Path: indexPath, UncompressedLogsSize: 400})
+	require.NoError(t, err)
+
+	calls := replacer.snapshot()
+	require.Len(t, calls, 1)
+	require.Equal(t, time.Unix(0, 100).UTC(), calls[0].newEntries[0].StartTime)
+	require.Equal(t, time.Unix(0, 1000).UTC(), calls[0].newEntries[0].EndTime)
 }
 
 func TestTaskBounds_AndUncompressedLogsSize(t *testing.T) {

--- a/pkg/engine/compactor/integration_test.go
+++ b/pkg/engine/compactor/integration_test.go
@@ -43,9 +43,7 @@ func TestCoordinator_EndToEnd(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
 	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
 
-	// Seed: 3 indexes for "acme" with overlapping timestamp ranges (forces >1 pile).
-	// Plus an "untouched" tenant with one index to verify cross-tenant
-	// isolation across the ToC swap.
+	// The acme postings ranges overlap; untouched verifies tenant-scoped ToC replacement.
 	seed := map[string][]testIndex{
 		"acme": {
 			{path: "indexes/aa/src-0", start: window.Add(1 * time.Hour), end: window.Add(5 * time.Hour)},
@@ -236,11 +234,7 @@ func pathsOf(entries []indexEntry) []string {
 	return out
 }
 
-// seedSourceIndexObject builds and uploads an index object at path, containing
-// one postings section and one stats section per tenant. Each section is tagged
-// with its tenant so classifyRuns can correctly filter by tenant. The single
-// observation/stat is timestamped at ts so it falls inside the entry's seeded
-// time range.
+// seedSourceIndexObject builds and uploads tenant-tagged postings and stats sections.
 func seedSourceIndexObject(ctx context.Context, t *testing.T, bucket objstore.Bucket, path string, ts time.Time, tenants ...string) {
 	t.Helper()
 
@@ -248,15 +242,17 @@ func seedSourceIndexObject(ctx context.Context, t *testing.T, bucket objstore.Bu
 	for _, tenant := range tenants {
 		postingsBuilder := postings.NewBuilder(nil, 0, 0, math.MaxInt)
 		postingsBuilder.SetTenant(tenant)
-		postingsBuilder.ObserveLabelPosting(postings.LabelObservation{
-			ObjectPath:       path,
-			SectionIndex:     0,
-			ColumnName:       "service",
-			LabelValue:       "api",
-			StreamID:         1,
-			Timestamp:        ts,
-			UncompressedSize: 100,
-		})
+		for streamID, value := range []string{"a", "z"} {
+			postingsBuilder.ObserveLabelPosting(postings.LabelObservation{
+				ObjectPath:       path,
+				SectionIndex:     0,
+				ColumnName:       "service",
+				LabelValue:       value,
+				StreamID:         int64(streamID),
+				Timestamp:        ts,
+				UncompressedSize: 100,
+			})
+		}
 		require.NoError(t, objBuilder.Append(postingsBuilder))
 
 		statsBuilder := stats.NewBuilder(nil, stats.ColumnarSectionEncoder(2048, 1000))
@@ -264,7 +260,7 @@ func seedSourceIndexObject(ctx context.Context, t *testing.T, bucket objstore.Bu
 		statsBuilder.Append(stats.Stat{
 			ObjectPath:       path,
 			SectionIndex:     0,
-			SortSchema:       "service",
+			SortSchema:       "label:service",
 			Labels:           map[string]string{"service": "api"},
 			MinTimestamp:     ts.UnixNano(),
 			MaxTimestamp:     ts.UnixNano() + 1000,

--- a/pkg/engine/compactor/metrics.go
+++ b/pkg/engine/compactor/metrics.go
@@ -56,6 +56,7 @@ type coordinatorMetrics struct {
 	// stats run concurrently before a ToC replace; the histogram surfaces
 	// per-call latency early so it can be caught before it dominates a cycle.
 	fileSizeStatDurationSeconds prometheus.Histogram
+	indexInputRuns              prometheus.Histogram
 }
 
 func newCoordinatorMetrics(reg prometheus.Registerer) *coordinatorMetrics {
@@ -63,7 +64,7 @@ func newCoordinatorMetrics(reg prometheus.Registerer) *coordinatorMetrics {
 	return &coordinatorMetrics{
 		unconsolidatedBacklog: f.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "loki_dataobj_compaction_unconsolidated_index_backlog",
-			Help: "Per-tenant count of indexes in the current + previous ToC windows whose max_timestamp is older than the consolidation SLO. Steady state: 0.",
+			Help: "Per-tenant count of nonterminal index runs beyond one. Steady state: 0.",
 		}, []string{labelTenant}),
 		oldestBacklogLogAgeSeconds: f.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "loki_dataobj_compaction_oldest_backlog_log_age_seconds",
@@ -81,11 +82,11 @@ func newCoordinatorMetrics(reg prometheus.Registerer) *coordinatorMetrics {
 		}, []string{labelOutcome}),
 		tenantCyclesTotal: f.NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_dataobj_compaction_tenant_cycles_total",
-			Help: "Per-tenant index-compaction cycle outcomes. compacted = ran index compaction successfully, converged = no index or single index (log-compaction path), failed = cycle returned error.",
+			Help: "Per-tenant index-compaction cycle outcomes. compacted = ToC swapped, converged = no true section overlap, failed = cycle returned error.",
 		}, []string{labelOutcome, labelTenant}),
 		tenantLogCyclesTotal: f.NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_dataobj_compaction_tenant_log_cycles_total",
-			Help: "Per-tenant log-compaction cycle outcomes. compacted = converged window dispatched log-merge tasks, converged = single index with no log-merge work, failed = cycle returned error.",
+			Help: "Per-tenant log-compaction cycle outcomes. compacted = ToC swapped, converged = no worthwhile section overlap, failed = cycle returned error.",
 		}, []string{labelOutcome, labelTenant}),
 		indexesRemovedTotal: f.NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_dataobj_compaction_indexes_removed_total",
@@ -114,25 +115,28 @@ func newCoordinatorMetrics(reg prometheus.Registerer) *coordinatorMetrics {
 			Help:    "Latency of a single object-storage Attributes call issued to fill in index file size before a ToC replace.",
 			Buckets: prometheus.ExponentialBuckets(0.001, 2, 14), // 1ms .. ~8s
 		}),
+		indexInputRuns: f.NewHistogram(prometheus.HistogramOpts{
+			Name:    "loki_dataobj_compaction_index_input_runs",
+			Help:    "Number of strict index runs offered to the task planner.",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 12),
+		}),
 	}
 }
 
-// observeEntries records metrics regarding the age and number of entries per
-// tenant and window.
-//   - unconsolidated_index_backlog = max(0, len(entries)-1) — indexes beyond
-//     the single converged target that still await consolidation.
-//   - oldest_backlog_log_age_seconds = now - min(End) over all entries when a
-//     backlog exists (len > 1), else 0.
-//   - indexes_per_tenant_window = len(entries).
-func (m *coordinatorMetrics) observeEntries(
-	tenant string,
-	entries []indexEntry,
-	now time.Time,
-) {
+func (m *coordinatorMetrics) observeIndexInputRuns(runs int) {
+	if m != nil {
+		m.indexInputRuns.Observe(float64(runs))
+	}
+}
+
+func (m *coordinatorMetrics) observeIndexConvergence(tenant string, converged bool, runs int, entries []indexEntry, now time.Time) {
 	if m == nil {
 		return
 	}
-	backlog := max(0, len(entries)-1)
+	backlog := max(0, runs-1)
+	if converged {
+		backlog = 0
+	}
 	m.unconsolidatedBacklog.WithLabelValues(tenant).Set(float64(backlog))
 
 	var oldestAge float64
@@ -143,8 +147,13 @@ func (m *coordinatorMetrics) observeEntries(
 		}
 	}
 	m.oldestBacklogLogAgeSeconds.WithLabelValues(tenant).Set(oldestAge)
+}
 
-	m.indexesPerTenantWindow.WithLabelValues(tenant).Set(float64(len(entries)))
+// observeEntries records the raw ToC index count before section discovery.
+func (m *coordinatorMetrics) observeEntries(tenant string, entries []indexEntry) {
+	if m != nil {
+		m.indexesPerTenantWindow.WithLabelValues(tenant).Set(float64(len(entries)))
+	}
 }
 
 // oldestEnd returns the minimum End timestamp across entries, or the zero

--- a/pkg/engine/compactor/sections.go
+++ b/pkg/engine/compactor/sections.go
@@ -225,96 +225,112 @@ func sectionRefsFor(indexes []indexEntry) []v2.Section[sortKey] {
 	return out
 }
 
-// logSectionRefsFor reads an index object's stats sections and
-// produces compactionv2pb.SectionRef values (one per stats row) plus the
-// tenant's sort schema.
+// logSectionRefsFor returns one bounded reference per log section indexed by idxPath.
 func logSectionRefsFor(ctx context.Context, bucket objstore.Bucket, tenant, idxPath string) ([]v2.Section[sortKey], []string, error) {
 	obj, err := dataobj.FromBucket(ctx, bucket, idxPath, 0)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open converged index tenant=%s index=%s: %w", tenant, idxPath, err)
 	}
 
-	var (
-		refs           []v2.Section[sortKey]
-		schema         []string
-		reader         stats.Reader
-		sortSchemaLbls []string
-		schemaDerived  bool
-	)
+	type sectionID struct {
+		path  string
+		index int64
+	}
 
+	var (
+		schema     []string
+		labelNames []string
+		schemaName string
+		reader     stats.Reader
+
+		bySection = make(map[sectionID]*v2.Section[sortKey])
+	)
 	defer reader.Close()
+
 	const batchSize = 1024
 	scratch := make([]stats.Stat, batchSize)
-
 	for _, section := range obj.Sections().Filter(stats.CheckSection) {
 		if section.Tenant != tenant {
 			continue
 		}
 
-		sec, err := stats.Open(ctx, section)
+		statsSection, err := stats.Open(ctx, section)
 		if err != nil {
 			return nil, nil, fmt.Errorf("open stats section tenant=%s index=%s: %w", tenant, idxPath, err)
 		}
 
-		reader.Reset(stats.ReaderOptions{Columns: sec.Columns()})
+		reader.Reset(stats.ReaderOptions{Columns: statsSection.Columns()})
 		if err := reader.Open(ctx); err != nil {
 			return nil, nil, fmt.Errorf("opening reader tenant=%s index=%s: %w", tenant, idxPath, err)
 		}
 
 		for {
-			rec, readErr := reader.Read(ctx, batchSize)
+			record, readErr := reader.Read(ctx, batchSize)
 			if readErr != nil && !errors.Is(readErr, io.EOF) {
 				return nil, nil, fmt.Errorf("reading batch tenant=%s index=%s: %w", tenant, idxPath, readErr)
 			}
-			numRows := int(rec.NumRows())
+			numRows := int(record.NumRows())
 			if numRows == 0 && errors.Is(readErr, io.EOF) {
 				break
 			}
 
-			dest := scratch[:numRows]
-			n, err := stats.FromRecordBatch(rec, dest)
+			rows := scratch[:numRows]
+			n, err := stats.FromRecordBatch(record, rows)
 			if err != nil {
 				return nil, nil, fmt.Errorf("decode stats batch tenant=%s index=%s: %w", tenant, idxPath, err)
 			}
 
-			for i := range n {
-				st := dest[i]
-
-				if !schemaDerived {
-					// SortSchema is stored fully-qualified ("label:<name>"),
-					for fqn := range strings.SplitSeq(st.SortSchema, ",") {
-						if fqn == "" {
-							continue
-						}
-						schema = append(schema, fqn)
-						typ, name, ok := strings.Cut(fqn, ":")
-						if ok && typ == "label" && name != "" {
-							sortSchemaLbls = append(sortSchemaLbls, name)
-						}
+			for _, stat := range rows[:n] {
+				if schemaName == "" && len(bySection) == 0 {
+					schemaName = stat.SortSchema
+					schema, labelNames, err = parseSortSchema(stat.SortSchema)
+					if err != nil {
+						return nil, nil, fmt.Errorf("parse log sort schema tenant=%s index=%s: %w", tenant, idxPath, err)
 					}
-					schemaDerived = true
+				} else if stat.SortSchema != schemaName {
+					return nil, nil, fmt.Errorf("index %s contains log sort schemas %q and %q", idxPath, schemaName, stat.SortSchema)
 				}
 
-				ref := &compactionv2pb.SectionRef{
-					ObjectPath:       st.ObjectPath,
-					SectionIndex:     st.SectionIndex,
-					MinTimestamp:     st.MinTimestamp,
-					MaxTimestamp:     st.MaxTimestamp,
-					UncompressedSize: st.UncompressedSize,
-				}
-				if len(sortSchemaLbls) > 0 {
-					minKey := make([]string, len(sortSchemaLbls))
-					for j, k := range sortSchemaLbls {
-						minKey[j] = st.Labels[k]
+				var labels []string
+				if len(labelNames) > 0 {
+					labels = make([]string, len(labelNames))
+					for i, name := range labelNames {
+						labels[i] = stat.Labels[name]
 					}
-					ref.MinKey = minKey
-					ref.MaxKey = slices.Clone(minKey)
 				}
-				refs = append(refs, v2.Section[sortKey]{
-					Ref: ref,
-					Min: sortKey{labels: ref.MinKey, timestamp: ref.MinTimestamp},
-					Max: sortKey{labels: ref.MaxKey, timestamp: ref.MaxTimestamp},
-				})
+				minKey := sortKey{labels: labels, timestamp: stat.MinTimestamp}
+				maxKey := sortKey{labels: labels, timestamp: stat.MaxTimestamp}
+
+				id := sectionID{path: stat.ObjectPath, index: stat.SectionIndex}
+				bounded, ok := bySection[id]
+				if !ok {
+					bySection[id] = &v2.Section[sortKey]{
+						Ref: &compactionv2pb.SectionRef{
+							ObjectPath:       stat.ObjectPath,
+							SectionIndex:     stat.SectionIndex,
+							MinKey:           minKey.labels,
+							MaxKey:           maxKey.labels,
+							MinTimestamp:     minKey.timestamp,
+							MaxTimestamp:     maxKey.timestamp,
+							UncompressedSize: stat.UncompressedSize,
+						},
+						Min: minKey,
+						Max: maxKey,
+					}
+					continue
+				}
+
+				if compareSortKey(minKey, bounded.Min) < 0 {
+					bounded.Min = minKey
+					bounded.Ref.MinKey = minKey.labels
+				}
+				if compareSortKey(maxKey, bounded.Max) > 0 {
+					bounded.Max = maxKey
+					bounded.Ref.MaxKey = maxKey.labels
+				}
+				bounded.Ref.MinTimestamp = min(bounded.Ref.MinTimestamp, stat.MinTimestamp)
+				bounded.Ref.MaxTimestamp = max(bounded.Ref.MaxTimestamp, stat.MaxTimestamp)
+				bounded.Ref.UncompressedSize += stat.UncompressedSize
 			}
 
 			if errors.Is(readErr, io.EOF) {
@@ -323,5 +339,30 @@ func logSectionRefsFor(ctx context.Context, bucket objstore.Bucket, tenant, idxP
 		}
 	}
 
+	refs := make([]v2.Section[sortKey], 0, len(bySection))
+	for _, ref := range bySection {
+		refs = append(refs, *ref)
+	}
+	slices.SortFunc(refs, func(a, b v2.Section[sortKey]) int {
+		if n := strings.Compare(a.Ref.ObjectPath, b.Ref.ObjectPath); n != 0 {
+			return n
+		}
+		return cmp.Compare(a.Ref.SectionIndex, b.Ref.SectionIndex)
+	})
 	return refs, schema, nil
+}
+
+func parseSortSchema(value string) (schema, labelNames []string, _ error) {
+	for entry := range strings.SplitSeq(value, ",") {
+		if entry == "" {
+			continue
+		}
+		typ, name, ok := strings.Cut(entry, ":")
+		if !ok || typ != "label" || name == "" {
+			return nil, nil, fmt.Errorf("invalid log sort key %q", entry)
+		}
+		schema = append(schema, entry)
+		labelNames = append(labelNames, name)
+	}
+	return schema, labelNames, nil
 }

--- a/pkg/engine/compactor/sections.go
+++ b/pkg/engine/compactor/sections.go
@@ -2,6 +2,7 @@ package compactor
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -14,6 +15,7 @@ import (
 	"github.com/thanos-io/objstore"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
+	v2 "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2"
 	compactionv2pb "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2/proto"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/indexpointers"
@@ -27,6 +29,18 @@ type indexEntry struct {
 	End                  time.Time
 	FileSize             uint64
 	UncompressedLogsSize uint64
+}
+
+type sortKey struct {
+	labels    []string
+	timestamp int64
+}
+
+func compareSortKey(a, b sortKey) int {
+	if n := slices.Compare(a.labels, b.labels); n != 0 {
+		return n
+	}
+	return cmp.Compare(a.timestamp, b.timestamp)
 }
 
 // tenantIndexes maps tenant ID → ordered list of indexes the ToC references
@@ -192,15 +206,20 @@ func readAllIndexPointers(ctx context.Context, reader *indexpointers.Reader, scr
 // bounds (empty MinKey/MaxKey); the planner's composite (MinKey, MinTimestamp)
 // sort key degrades to single-axis timestamp ordering, which is sufficient
 // for index-only compaction.
-func sectionRefsFor(indexes []indexEntry) []*compactionv2pb.SectionRef {
-	out := make([]*compactionv2pb.SectionRef, len(indexes))
-	for i, e := range indexes {
-		out[i] = &compactionv2pb.SectionRef{
-			ObjectPath:       e.Path,
+func sectionRefsFor(indexes []indexEntry) []v2.Section[sortKey] {
+	out := make([]v2.Section[sortKey], len(indexes))
+	for i, entry := range indexes {
+		ref := &compactionv2pb.SectionRef{
+			ObjectPath:       entry.Path,
 			SectionIndex:     0,
-			MinTimestamp:     e.Start.UnixNano(),
-			MaxTimestamp:     e.End.UnixNano(),
-			UncompressedSize: int64(e.UncompressedLogsSize),
+			MinTimestamp:     entry.Start.UnixNano(),
+			MaxTimestamp:     entry.End.UnixNano(),
+			UncompressedSize: int64(entry.UncompressedLogsSize),
+		}
+		out[i] = v2.Section[sortKey]{
+			Ref: ref,
+			Min: sortKey{timestamp: ref.MinTimestamp},
+			Max: sortKey{timestamp: ref.MaxTimestamp},
 		}
 	}
 	return out
@@ -209,14 +228,14 @@ func sectionRefsFor(indexes []indexEntry) []*compactionv2pb.SectionRef {
 // logSectionRefsFor reads an index object's stats sections and
 // produces compactionv2pb.SectionRef values (one per stats row) plus the
 // tenant's sort schema.
-func logSectionRefsFor(ctx context.Context, bucket objstore.Bucket, tenant, idxPath string) ([]*compactionv2pb.SectionRef, []string, error) {
+func logSectionRefsFor(ctx context.Context, bucket objstore.Bucket, tenant, idxPath string) ([]v2.Section[sortKey], []string, error) {
 	obj, err := dataobj.FromBucket(ctx, bucket, idxPath, 0)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open converged index tenant=%s index=%s: %w", tenant, idxPath, err)
 	}
 
 	var (
-		refs           []*compactionv2pb.SectionRef
+		refs           []v2.Section[sortKey]
 		schema         []string
 		reader         stats.Reader
 		sortSchemaLbls []string
@@ -291,7 +310,11 @@ func logSectionRefsFor(ctx context.Context, bucket objstore.Bucket, tenant, idxP
 					ref.MinKey = minKey
 					ref.MaxKey = slices.Clone(minKey)
 				}
-				refs = append(refs, ref)
+				refs = append(refs, v2.Section[sortKey]{
+					Ref: ref,
+					Min: sortKey{labels: ref.MinKey, timestamp: ref.MinTimestamp},
+					Max: sortKey{labels: ref.MaxKey, timestamp: ref.MaxTimestamp},
+				})
 			}
 
 			if errors.Is(readErr, io.EOF) {

--- a/pkg/engine/compactor/sections.go
+++ b/pkg/engine/compactor/sections.go
@@ -13,12 +13,14 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/thanos-io/objstore"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	v2 "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2"
 	compactionv2pb "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2/proto"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/indexpointers"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/stats"
 )
 
@@ -43,31 +45,39 @@ func compareSortKey(a, b sortKey) int {
 	return cmp.Compare(a.timestamp, b.timestamp)
 }
 
+type indexSortKey struct {
+	kind                       postings.PostingKind
+	columnName, labelValue     string
+	minTimestamp, maxTimestamp int64
+}
+
+func compareIndexSortKey(a, b indexSortKey) int {
+	return cmp.Or(
+		cmp.Compare(a.kind, b.kind),
+		strings.Compare(a.columnName, b.columnName),
+		strings.Compare(a.labelValue, b.labelValue),
+		cmp.Compare(a.minTimestamp, b.minTimestamp),
+		cmp.Compare(a.maxTimestamp, b.maxTimestamp),
+	)
+}
+
+func indexKey(row postings.Row) indexSortKey {
+	return indexSortKey{
+		kind:         row.Kind,
+		columnName:   row.ColumnName,
+		labelValue:   row.LabelValue,
+		minTimestamp: row.MinTimestamp,
+		maxTimestamp: row.MaxTimestamp,
+	}
+}
+
 // tenantIndexes maps tenant ID → ordered list of indexes the ToC references
 // for that tenant. Slice order reflects ToC enumeration order and is not
 // part of the contract — callers must not rely on it for correctness.
 type tenantIndexes map[string][]indexEntry
 
-// loadTenantIndexes reads the ToC for the given window-aligned time and
-// returns every (tenant, index entry) pair — each entry carries path, time
-// range, and the sizes recorded in the ToC row (zero for legacy rows written
-// before the size columns existed).
-//
-// This is the per-cycle planning input: the coordinator iterates the result
-// map and skips tenants whose index slice has length ≤ 1 (the convergence
-// gate). If the ToC does not exist for this window the call returns a
-// bucket.IsObjNotFoundErr-class error which the coordinator treats as
-// "nothing to do this cycle" — the next polling tick re-reads.
-//
-// Unlike pkg/dataobj/metastore.forEachIndexPointer, this helper does NOT
-// filter by user.ExtractOrgID — it walks every tenant's indexpointers
-// section and returns them grouped, which is what the coordinator's
-// per-tenant loop needs.
-func loadTenantIndexes(
-	ctx context.Context,
-	bucket objstore.Bucket,
-	window time.Time,
-) (tenantIndexes, error) {
+// loadTenantIndexes returns the window's ToC entries grouped by tenant.
+func loadTenantIndexes(ctx context.Context, bucket objstore.Bucket, window time.Time) (tenantIndexes, error) {
 	tocPath := metastore.TableOfContentsPath(window.UTC().Truncate(metastore.MetastoreWindowSize))
 
 	r, err := bucket.Get(ctx, tocPath)
@@ -201,28 +211,129 @@ func readAllIndexPointers(ctx context.Context, reader *indexpointers.Reader, scr
 	return out, nil
 }
 
-// sectionRefsFor converts a tenant's indexes into SectionRefs suitable for
-// compactionv2.Plan. Returns one SectionRef per index with timestamp-only
-// bounds (empty MinKey/MaxKey); the planner's composite (MinKey, MinTimestamp)
-// sort key degrades to single-axis timestamp ordering, which is sufficient
-// for index-only compaction.
-func sectionRefsFor(indexes []indexEntry) []v2.Section[sortKey] {
-	out := make([]v2.Section[sortKey], len(indexes))
-	for i, entry := range indexes {
-		ref := &compactionv2pb.SectionRef{
-			ObjectPath:       entry.Path,
-			SectionIndex:     0,
-			MinTimestamp:     entry.Start.UnixNano(),
-			MaxTimestamp:     entry.End.UnixNano(),
-			UncompressedSize: int64(entry.UncompressedLogsSize),
+const indexSectionReadConcurrency = 16
+
+func indexSectionRefsFor(ctx context.Context, bucket objstore.Bucket, tenant string, entries []indexEntry) ([]v2.Section[indexSortKey], error) {
+	type sectionRead struct {
+		objectPath   string
+		sectionIndex int64
+		section      *dataobj.Section
+	}
+
+	var reads []sectionRead
+	for _, entry := range entries {
+		obj, err := dataobj.FromBucket(ctx, bucket, entry.Path, 0)
+		if err != nil {
+			return nil, fmt.Errorf("open index tenant=%s index=%s: %w", tenant, entry.Path, err)
 		}
-		out[i] = v2.Section[sortKey]{
-			Ref: ref,
-			Min: sortKey{timestamp: ref.MinTimestamp},
-			Max: sortKey{timestamp: ref.MaxTimestamp},
+		for sectionIndex, section := range obj.Sections() {
+			if postings.CheckSection(section) && section.Tenant == tenant {
+				reads = append(reads, sectionRead{
+					objectPath:   entry.Path,
+					sectionIndex: int64(sectionIndex),
+					section:      section,
+				})
+			}
 		}
 	}
-	return out
+
+	results := make([]*v2.Section[indexSortKey], len(reads))
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(indexSectionReadConcurrency)
+	for i, read := range reads {
+		group.Go(func() error {
+			ref, err := indexSectionRef(groupCtx, read.objectPath, read.sectionIndex, read.section)
+			if err != nil {
+				return fmt.Errorf("read postings bounds tenant=%s index=%s section=%d: %w", tenant, read.objectPath, read.sectionIndex, err)
+			}
+			results[i] = ref
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+
+	refs := make([]v2.Section[indexSortKey], 0, len(results))
+	for _, ref := range results {
+		if ref != nil {
+			refs = append(refs, *ref)
+		}
+	}
+	return refs, nil
+}
+
+func indexSectionRef(ctx context.Context, objectPath string, sectionIndex int64, section *dataobj.Section) (*v2.Section[indexSortKey], error) {
+	postingsSection, err := postings.Open(ctx, section)
+	if err != nil {
+		return nil, fmt.Errorf("open postings section: %w", err)
+	}
+	columns, err := postingsBoundColumns(postingsSection)
+	if err != nil {
+		return nil, err
+	}
+
+	reader := postings.NewReader(postings.ReaderOptions{Columns: columns})
+	if err := reader.Open(ctx); err != nil {
+		return nil, fmt.Errorf("open postings reader: %w", err)
+	}
+	rows := postings.NewRowReader(ctx, reader)
+	defer rows.Close()
+
+	// Postings sections use CompareRows order. compareIndexSortKey is its prefix,
+	// so the first and last rows bound the section for run planning.
+	var first, last postings.Row
+	hasRows := rows.Next()
+	if hasRows {
+		first = rows.At()
+		last = first
+	}
+	for rows.Next() {
+		last = rows.At()
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read postings rows: %w", err)
+	}
+	if !hasRows {
+		return nil, nil
+	}
+
+	minKey, maxKey := indexKey(first), indexKey(last)
+	if compareIndexSortKey(minKey, maxKey) > 0 {
+		return nil, errors.New("postings section bounds are out of order")
+	}
+	return &v2.Section[indexSortKey]{
+		Ref: &compactionv2pb.SectionRef{
+			ObjectPath:   objectPath,
+			SectionIndex: sectionIndex,
+		},
+		Min: minKey,
+		Max: maxKey,
+	}, nil
+}
+
+func postingsBoundColumns(section *postings.Section) ([]*postings.Column, error) {
+	required := []postings.ColumnType{
+		postings.ColumnTypeKind,
+		postings.ColumnTypeColumnName,
+		postings.ColumnTypeLabelValue,
+		postings.ColumnTypeMinTimestamp,
+		postings.ColumnTypeMaxTimestamp,
+	}
+	byType := make(map[postings.ColumnType]*postings.Column, len(section.Columns()))
+	for _, column := range section.Columns() {
+		byType[column.Type] = column
+	}
+
+	columns := make([]*postings.Column, 0, len(required))
+	for _, columnType := range required {
+		column, ok := byType[columnType]
+		if !ok {
+			return nil, fmt.Errorf("postings section has no %s column", columnType)
+		}
+		columns = append(columns, column)
+	}
+	return columns, nil
 }
 
 // logSectionRefsFor returns one bounded reference per log section indexed by idxPath.

--- a/pkg/engine/compactor/sections_test.go
+++ b/pkg/engine/compactor/sections_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 
+	v2 "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2"
 	compactionv2pb "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2/proto"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
@@ -164,40 +165,36 @@ func buildIndexWithStats(ctx context.Context, t *testing.T, bucket objstore.Buck
 	require.NoError(t, bucket.Upload(ctx, path, io.NopCloser(bytes.NewReader(objBytes))))
 }
 
-func TestLogSectionRefsFor_OneRefPerStatRow(t *testing.T) {
+func TestLogSectionRefsFor_AggregatesStatsRows(t *testing.T) {
 	ctx := context.Background()
 	bucket := objstore.NewInMemBucket()
 	path := "indexes/aa/converged"
 
 	buildIndexWithStats(ctx, t, bucket, "acme", path, []stats.Stat{
 		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "label:service_name",
-			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 20, RowCount: 3, UncompressedSize: 300},
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 500, MaxTimestamp: 1000, RowCount: 3, UncompressedSize: 300},
 		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "label:service_name",
-			Labels: map[string]string{"service_name": "billing"}, MinTimestamp: 15, MaxTimestamp: 25, RowCount: 2, UncompressedSize: 200},
+			Labels: map[string]string{"service_name": "billing"}, MinTimestamp: 100, MaxTimestamp: 900, RowCount: 2, UncompressedSize: 200},
 	})
 
 	refs, schema, err := logSectionRefsFor(ctx, bucket, "acme", path)
 	require.NoError(t, err)
 	require.Equal(t, []string{"label:service_name"}, schema)
-	require.Len(t, refs, 2)
-
-	byKey := map[string]*compactionv2pb.SectionRef{}
-	for _, section := range refs {
-		byKey[section.Min.labels[0]] = section.Ref
-	}
-
-	auth := byKey["auth"]
-	require.NotNil(t, auth)
-	require.Equal(t, "logs/log-0", auth.ObjectPath)
-	require.Equal(t, []string{"auth"}, auth.MinKey)
-	require.Equal(t, []string{"auth"}, auth.MaxKey)
-	require.Equal(t, int64(300), auth.UncompressedSize)
-
-	require.Equal(t, int64(200), byKey["billing"].UncompressedSize)
-
-	// MaxKey must be a distinct slice from MinKey, not a shared backing array.
-	auth.MinKey[0] = "MUTATED"
-	require.Equal(t, "auth", auth.MaxKey[0], "MaxKey must be a distinct slice from MinKey")
+	require.Equal(t, []v2.Section[sortKey]{
+		{
+			Ref: &compactionv2pb.SectionRef{
+				ObjectPath:       "logs/log-0",
+				SectionIndex:     0,
+				MinKey:           []string{"auth"},
+				MaxKey:           []string{"billing"},
+				MinTimestamp:     100,
+				MaxTimestamp:     1000,
+				UncompressedSize: 500,
+			},
+			Min: sortKey{labels: []string{"auth"}, timestamp: 500},
+			Max: sortKey{labels: []string{"billing"}, timestamp: 900},
+		},
+	}, refs)
 }
 
 func TestLogSectionRefsFor_MultiKeySchemaOrdersValuesAndReturnsFQN(t *testing.T) {
@@ -213,8 +210,20 @@ func TestLogSectionRefsFor_MultiKeySchemaOrdersValuesAndReturnsFQN(t *testing.T)
 	refs, schema, err := logSectionRefsFor(ctx, bucket, "acme", path)
 	require.NoError(t, err)
 	require.Equal(t, []string{"label:service_name", "label:namespace"}, schema)
-	require.Len(t, refs, 1)
-	require.Equal(t, sortKey{labels: []string{"auth", "eu"}, timestamp: 10}, refs[0].Min)
+	require.Equal(t, []v2.Section[sortKey]{
+		{
+			Ref: &compactionv2pb.SectionRef{
+				ObjectPath:       "logs/log-0",
+				MinKey:           []string{"auth", "eu"},
+				MaxKey:           []string{"auth", "eu"},
+				MinTimestamp:     10,
+				MaxTimestamp:     20,
+				UncompressedSize: 100,
+			},
+			Min: sortKey{labels: []string{"auth", "eu"}, timestamp: 10},
+			Max: sortKey{labels: []string{"auth", "eu"}, timestamp: 20},
+		},
+	}, refs)
 }
 
 func TestLogSectionRefsFor_EmptySortSchema(t *testing.T) {
@@ -235,6 +244,22 @@ func TestLogSectionRefsFor_EmptySortSchema(t *testing.T) {
 	require.Equal(t, sortKey{timestamp: 20}, refs[0].Max)
 	require.Equal(t, "logs/log-0", refs[0].Ref.ObjectPath)
 	require.Equal(t, int64(100), refs[0].Ref.UncompressedSize)
+}
+
+func TestLogSectionRefsFor_RejectsMixedSchemas(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	path := "indexes/aa/mixed"
+
+	buildIndexWithStats(ctx, t, bucket, "acme", path, []stats.Stat{
+		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "label:service_name",
+			Labels: map[string]string{"service_name": "api"}, MinTimestamp: 10, MaxTimestamp: 20},
+		{ObjectPath: "logs/log-1", SectionIndex: 0, SortSchema: "label:namespace",
+			Labels: map[string]string{"namespace": "prod"}, MinTimestamp: 10, MaxTimestamp: 20},
+	})
+
+	_, _, err := logSectionRefsFor(ctx, bucket, "acme", path)
+	require.ErrorContains(t, err, `contains log sort schemas "label:service_name" and "label:namespace"`)
 }
 
 // TestLoadTenantIndexes_PopulatesSizeColumns verifies that loadTenantIndexes

--- a/pkg/engine/compactor/sections_test.go
+++ b/pkg/engine/compactor/sections_test.go
@@ -4,26 +4,26 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 
+	"github.com/grafana/loki/v3/pkg/dataobj"
 	v2 "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2"
 	compactionv2pb "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2/proto"
 	"github.com/grafana/loki/v3/pkg/dataobj/consumer/logsobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/stats"
 )
 
-// TestLoadTenantIndexes_GroupsByTenant verifies that loadTenantIndexes reads
-// a multi-tenant ToC and returns each tenant's index references separately.
-// This is the per-cycle planning input: the coordinator iterates the result
-// map and skips tenants whose index slice has length ≤ 1 (convergence gate).
 func TestLoadTenantIndexes_GroupsByTenant(t *testing.T) {
 	ctx := context.Background()
 	bucket := objstore.NewInMemBucket()
@@ -62,32 +62,6 @@ func TestLoadTenantIndexes_MissingToCReturnsNotFound(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, bucket.IsObjNotFoundErr(err),
 		"missing ToC must surface as IsObjNotFoundErr, got %v", err)
-}
-
-// TestSectionRefsFor_OneRefPerIndex verifies one SectionRef per index,
-// timestamp-only bounds, empty MinKey/MaxKey. The planner patience-sorts on the
-// composite (MinKey, MinTimestamp) key, so timestamp-only bounds remain a valid
-// (less granular) sort key.
-func TestSectionRefsFor_OneRefPerIndex(t *testing.T) {
-	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC)
-	indexes := []indexEntry{
-		{Path: "indexes/aa/idx-0", Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)},
-		{Path: "indexes/bb/idx-1", Start: window.Add(3 * time.Hour), End: window.Add(5 * time.Hour)},
-	}
-
-	got := sectionRefsFor(indexes)
-	require.Len(t, got, 2)
-
-	require.Equal(t, "indexes/aa/idx-0", got[0].Ref.ObjectPath)
-	require.Equal(t, int64(0), got[0].Ref.SectionIndex)
-	require.Empty(t, got[0].Ref.MinKey, "timestamp-only bounds")
-	require.Empty(t, got[0].Ref.MaxKey, "timestamp-only bounds")
-	require.Equal(t, sortKey{timestamp: window.Add(1 * time.Hour).UnixNano()}, got[0].Min)
-	require.Equal(t, sortKey{timestamp: window.Add(2 * time.Hour).UnixNano()}, got[0].Max)
-
-	require.Equal(t, "indexes/bb/idx-1", got[1].Ref.ObjectPath)
-	require.Equal(t, sortKey{timestamp: window.Add(3 * time.Hour).UnixNano()}, got[1].Min)
-	require.Equal(t, sortKey{timestamp: window.Add(5 * time.Hour).UnixNano()}, got[1].Max)
 }
 
 // testIndex captures one index pointer entry (path, time range, sizes) to seed a ToC fixture.
@@ -131,32 +105,77 @@ func requireIndexPaths(t *testing.T, got []indexEntry, want ...string) {
 	require.ElementsMatch(t, want, gotPaths)
 }
 
-// buildIndexWithStats writes an index object with one stats section for tenant
-// containing the supplied rows, and uploads it at path. At least one row is
-// required; an index with no sections cannot be flushed.
+type testIndexObject struct {
+	tenant, path string
+	sectionSize  flagext.Bytes
+	stats        []stats.Stat
+	postings     []postings.Row
+}
+
 func buildIndexWithStats(ctx context.Context, t *testing.T, bucket objstore.Bucket, tenant, path string, rows []stats.Stat) {
+	t.Helper()
+	buildIndex(ctx, t, bucket, testIndexObject{tenant: tenant, path: path, sectionSize: 1 << 21, stats: rows})
+}
+
+func buildIndexWithPostings(ctx context.Context, t *testing.T, bucket objstore.Bucket, tenant, path string, sectionSize flagext.Bytes, rows []postings.Row) {
+	t.Helper()
+	buildIndex(ctx, t, bucket, testIndexObject{tenant: tenant, path: path, sectionSize: sectionSize, postings: rows})
+}
+
+func buildIndex(ctx context.Context, t *testing.T, bucket objstore.Bucket, object testIndexObject) {
 	t.Helper()
 	cfg := logsobj.BuilderBaseConfig{
 		TargetPageSize:          2048,
 		MaxPageRows:             10000,
 		TargetObjectSize:        1 << 22,
-		TargetSectionSize:       1 << 21,
+		TargetSectionSize:       object.sectionSize,
 		BufferSize:              2048 * 8,
 		SectionStripeMergeLimit: 2,
 	}
-	b, err := indexobj.NewBuilder(cfg, nil)
+	builder, err := indexobj.NewMergeBuilder(cfg, nil)
 	require.NoError(t, err)
-	for _, r := range rows {
-		require.NoError(t, b.AppendStat(
-			tenant, r.ObjectPath, r.SectionIndex, r.SortSchema, r.Labels,
-			time.Unix(0, r.MinTimestamp), time.Unix(0, r.MaxTimestamp),
-			int(r.RowCount), r.UncompressedSize,
-		))
+	for _, stat := range object.stats {
+		require.NoError(t, builder.AppendStat(object.tenant, stat))
 	}
-	obj, closer, err := b.Flush()
+	for _, row := range object.postings {
+		switch row.Kind {
+		case postings.KindBloom:
+			require.NoError(t, builder.AppendPostingsBloomEntry(object.tenant, row.BloomEntry()))
+		case postings.KindLabel:
+			require.NoError(t, builder.AppendPostingsLabelEntry(object.tenant, row.LabelEntry()))
+		default:
+			t.Fatalf("unsupported posting kind %d", row.Kind)
+		}
+	}
+
+	obj, closer, err := builder.Flush()
 	require.NoError(t, err)
 	defer closer.Close()
 
+	reader, err := obj.Reader(ctx)
+	require.NoError(t, err)
+	defer reader.Close()
+	objBytes, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, bucket.Upload(ctx, object.path, io.NopCloser(bytes.NewReader(objBytes))))
+}
+
+func buildIndexWithPostingsSections(ctx context.Context, t *testing.T, bucket objstore.Bucket, tenant, path string, sections ...[]postings.Row) {
+	t.Helper()
+	builder := dataobj.NewBuilder(nil)
+	for _, rows := range sections {
+		postingsBuilder := postings.NewMergeBuilder(nil, 2048, 10000, math.MaxInt)
+		postingsBuilder.SetTenant(tenant)
+		for _, row := range rows {
+			require.Equal(t, postings.KindLabel, row.Kind)
+			require.NoError(t, postingsBuilder.AppendLabelEntry(row.LabelEntry()))
+		}
+		require.NoError(t, builder.Append(postingsBuilder))
+	}
+
+	obj, closer, err := builder.Flush()
+	require.NoError(t, err)
+	defer closer.Close()
 	reader, err := obj.Reader(ctx)
 	require.NoError(t, err)
 	defer reader.Close()
@@ -298,20 +317,77 @@ func TestLoadTenantIndexes_PopulatesSizeColumns(t *testing.T) {
 	require.Equal(t, uint64(4096), idx1.UncompressedLogsSize)
 }
 
-// TestSectionRefsFor_CopiesUncompressedSize verifies that sectionRefsFor
-// copies each entry's UncompressedLogsSize into the produced SectionRef.UncompressedSize.
-func TestSectionRefsFor_CopiesUncompressedSize(t *testing.T) {
-	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC)
-	indexes := []indexEntry{
-		{Path: "indexes/aa/idx-0", Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour),
-			FileSize: 1024, UncompressedLogsSize: 2048},
-		{Path: "indexes/bb/idx-1", Start: window.Add(3 * time.Hour), End: window.Add(5 * time.Hour),
-			FileSize: 512, UncompressedLogsSize: 4096},
+func TestCompareIndexSortKey(t *testing.T) {
+	base := indexSortKey{kind: postings.KindLabel, columnName: "service", labelValue: "api", minTimestamp: 10, maxTimestamp: 20}
+	tests := []indexSortKey{
+		{kind: postings.KindBloom, columnName: "z", labelValue: "z", minTimestamp: 99, maxTimestamp: 99},
+		{kind: postings.KindLabel, columnName: "namespace", labelValue: "z", minTimestamp: 99, maxTimestamp: 99},
+		{kind: postings.KindLabel, columnName: "service", labelValue: "aaa", minTimestamp: 99, maxTimestamp: 99},
+		{kind: postings.KindLabel, columnName: "service", labelValue: "api", minTimestamp: 9, maxTimestamp: 99},
+		{kind: postings.KindLabel, columnName: "service", labelValue: "api", minTimestamp: 10, maxTimestamp: 19},
 	}
+	for _, before := range tests {
+		require.Negative(t, compareIndexSortKey(before, base))
+		require.Positive(t, compareIndexSortKey(base, before))
+	}
+	require.Zero(t, compareIndexSortKey(base, base))
+}
 
-	got := sectionRefsFor(indexes)
-	require.Len(t, got, 2)
+func TestIndexSectionRefsFor_UsesFullPostingsBounds(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	path := "indexes/aa/idx-0"
+	buildIndexWithPostings(ctx, t, bucket, "acme", path, 1<<20, []postings.Row{
+		{Kind: postings.KindLabel, ObjectPath: "logs/b", ColumnName: "service_name", LabelValue: "api", MinTimestamp: 30, MaxTimestamp: 40},
+		{Kind: postings.KindLabel, ObjectPath: "logs/a", ColumnName: "service_name", LabelValue: "api", MinTimestamp: 10, MaxTimestamp: 20},
+		{Kind: postings.KindLabel, ObjectPath: "logs/c", ColumnName: "service_name", LabelValue: "web", MinTimestamp: 5, MaxTimestamp: 50},
+	})
 
-	require.Equal(t, int64(2048), got[0].Ref.UncompressedSize)
-	require.Equal(t, int64(4096), got[1].Ref.UncompressedSize)
+	refs, err := indexSectionRefsFor(ctx, bucket, "acme", []indexEntry{{Path: path}})
+	require.NoError(t, err)
+	require.Equal(t, []v2.Section[indexSortKey]{
+		{
+			Ref: &compactionv2pb.SectionRef{ObjectPath: path},
+			Min: indexSortKey{kind: postings.KindLabel, columnName: "service_name", labelValue: "api", minTimestamp: 10, maxTimestamp: 20},
+			Max: indexSortKey{kind: postings.KindLabel, columnName: "service_name", labelValue: "web", minTimestamp: 5, maxTimestamp: 50},
+		},
+	}, refs)
+}
+
+func TestIndexSectionRefsFor_UsesAbsoluteSectionIndexes(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	path := "indexes/aa/idx-0"
+	buildIndex(ctx, t, bucket, testIndexObject{
+		tenant:      "acme",
+		path:        path,
+		sectionSize: 1,
+		stats: []stats.Stat{{
+			ObjectPath: "logs/a", SortSchema: "label:service_name",
+			Labels: map[string]string{"service_name": "api"}, MinTimestamp: 1, MaxTimestamp: 2,
+		}},
+		postings: []postings.Row{
+			{Kind: postings.KindLabel, ObjectPath: "logs/a", ColumnName: "a", LabelValue: "1", MinTimestamp: 1, MaxTimestamp: 2},
+			{Kind: postings.KindLabel, ObjectPath: "logs/b", ColumnName: "b", LabelValue: "2", MinTimestamp: 3, MaxTimestamp: 4},
+		},
+	})
+
+	refs, err := indexSectionRefsFor(ctx, bucket, "acme", []indexEntry{{Path: path}})
+	require.NoError(t, err)
+	require.Len(t, refs, 2)
+	require.Equal(t, int64(1), refs[0].Ref.SectionIndex)
+	require.Equal(t, int64(2), refs[1].Ref.SectionIndex)
+}
+
+func TestIndexSectionRefsFor_FailsOnUnreadableObject(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	goodPath := "indexes/aa/good"
+	buildIndexWithPostings(ctx, t, bucket, "acme", goodPath, 1<<20, []postings.Row{{
+		Kind: postings.KindLabel, ObjectPath: "logs/a", ColumnName: "service_name", LabelValue: "api", MinTimestamp: 1, MaxTimestamp: 2,
+	}})
+
+	refs, err := indexSectionRefsFor(ctx, bucket, "acme", []indexEntry{{Path: goodPath}, {Path: "indexes/aa/missing"}})
+	require.Error(t, err)
+	require.Nil(t, refs)
 }

--- a/pkg/engine/compactor/sections_test.go
+++ b/pkg/engine/compactor/sections_test.go
@@ -77,16 +77,16 @@ func TestSectionRefsFor_OneRefPerIndex(t *testing.T) {
 	got := sectionRefsFor(indexes)
 	require.Len(t, got, 2)
 
-	require.Equal(t, "indexes/aa/idx-0", got[0].ObjectPath)
-	require.Equal(t, int64(0), got[0].SectionIndex)
-	require.Empty(t, got[0].MinKey, "timestamp-only bounds")
-	require.Empty(t, got[0].MaxKey, "timestamp-only bounds")
-	require.Equal(t, window.Add(1*time.Hour).UnixNano(), got[0].MinTimestamp)
-	require.Equal(t, window.Add(2*time.Hour).UnixNano(), got[0].MaxTimestamp)
+	require.Equal(t, "indexes/aa/idx-0", got[0].Ref.ObjectPath)
+	require.Equal(t, int64(0), got[0].Ref.SectionIndex)
+	require.Empty(t, got[0].Ref.MinKey, "timestamp-only bounds")
+	require.Empty(t, got[0].Ref.MaxKey, "timestamp-only bounds")
+	require.Equal(t, sortKey{timestamp: window.Add(1 * time.Hour).UnixNano()}, got[0].Min)
+	require.Equal(t, sortKey{timestamp: window.Add(2 * time.Hour).UnixNano()}, got[0].Max)
 
-	require.Equal(t, "indexes/bb/idx-1", got[1].ObjectPath)
-	require.Equal(t, window.Add(3*time.Hour).UnixNano(), got[1].MinTimestamp)
-	require.Equal(t, window.Add(5*time.Hour).UnixNano(), got[1].MaxTimestamp)
+	require.Equal(t, "indexes/bb/idx-1", got[1].Ref.ObjectPath)
+	require.Equal(t, sortKey{timestamp: window.Add(3 * time.Hour).UnixNano()}, got[1].Min)
+	require.Equal(t, sortKey{timestamp: window.Add(5 * time.Hour).UnixNano()}, got[1].Max)
 }
 
 // testIndex captures one index pointer entry (path, time range, sizes) to seed a ToC fixture.
@@ -182,8 +182,8 @@ func TestLogSectionRefsFor_OneRefPerStatRow(t *testing.T) {
 	require.Len(t, refs, 2)
 
 	byKey := map[string]*compactionv2pb.SectionRef{}
-	for _, r := range refs {
-		byKey[r.MinKey[0]] = r
+	for _, section := range refs {
+		byKey[section.Min.labels[0]] = section.Ref
 	}
 
 	auth := byKey["auth"]
@@ -214,7 +214,7 @@ func TestLogSectionRefsFor_MultiKeySchemaOrdersValuesAndReturnsFQN(t *testing.T)
 	require.NoError(t, err)
 	require.Equal(t, []string{"label:service_name", "label:namespace"}, schema)
 	require.Len(t, refs, 1)
-	require.Equal(t, []string{"auth", "eu"}, refs[0].MinKey, "values ordered by schema, not map order")
+	require.Equal(t, sortKey{labels: []string{"auth", "eu"}, timestamp: 10}, refs[0].Min)
 }
 
 func TestLogSectionRefsFor_EmptySortSchema(t *testing.T) {
@@ -223,7 +223,7 @@ func TestLogSectionRefsFor_EmptySortSchema(t *testing.T) {
 	path := "indexes/aa/emptyschema"
 
 	buildIndexWithStats(ctx, t, bucket, "acme", path, []stats.Stat{
-		{ObjectPath: "[REDACTED]", SectionIndex: 0, SortSchema: "",
+		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "",
 			Labels: map[string]string{}, MinTimestamp: 10, MaxTimestamp: 20, RowCount: 1, UncompressedSize: 100},
 	})
 
@@ -231,10 +231,10 @@ func TestLogSectionRefsFor_EmptySortSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, schema, "empty sort_schema yields no schema keys (not a bogus label: entry)")
 	require.Len(t, refs, 1)
-	require.Empty(t, refs[0].MinKey, "no sort keys -> empty MinKey")
-	require.Empty(t, refs[0].MaxKey)
-	require.Equal(t, "[REDACTED]", refs[0].ObjectPath)
-	require.Equal(t, int64(100), refs[0].UncompressedSize)
+	require.Equal(t, sortKey{timestamp: 10}, refs[0].Min)
+	require.Equal(t, sortKey{timestamp: 20}, refs[0].Max)
+	require.Equal(t, "logs/log-0", refs[0].Ref.ObjectPath)
+	require.Equal(t, int64(100), refs[0].Ref.UncompressedSize)
 }
 
 // TestLoadTenantIndexes_PopulatesSizeColumns verifies that loadTenantIndexes
@@ -287,6 +287,6 @@ func TestSectionRefsFor_CopiesUncompressedSize(t *testing.T) {
 	got := sectionRefsFor(indexes)
 	require.Len(t, got, 2)
 
-	require.Equal(t, int64(2048), got[0].UncompressedSize)
-	require.Equal(t, int64(4096), got[1].UncompressedSize)
+	require.Equal(t, int64(2048), got[0].Ref.UncompressedSize)
+	require.Equal(t, int64(4096), got[1].Ref.UncompressedSize)
 }


### PR DESCRIPTION
Index compaction currently treats each index file as a run, so file count doubles as its convergence signal. This change reads postings-section bounds, forms runs from the full postings ordering key, and plans bounded K-way merges only while true overlap remains. Log planning now aggregates stats rows into one bound per physical section, which lets the same generic run planner serve both paths. No on-disk formats or configuration change.
