### PR TITLE
feat(compaction): Compact a configurable lookback of older windows

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1630,6 +1630,13 @@ dataobj:
     # CLI flag: -dataobj.compaction.polling-interval
     [polling_interval: <duration> | default = 5m]
 
+    # Experimental: Number of older metastore windows to compact in addition to
+    # the current window. 0 compacts only the current window; 1 also compacts
+    # the previous window. Raise when the index-builder lags wall-clock so the
+    # current window's ToC may not exist yet.
+    # CLI flag: -dataobj.compaction.window-lookback
+    [window_lookback: <int> | default = 0]
+
     # Experimental: Maximum runs per IndexMerge task (K). Memory grows linearly
     # with K.
     # CLI flag: -dataobj.compaction.max-runs-per-task

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1632,8 +1632,7 @@ dataobj:
 
     # Experimental: Number of older metastore windows to compact in addition to
     # the current window. 0 compacts only the current window; 1 also compacts
-    # the previous window. Raise when the index-builder lags wall-clock so the
-    # current window's ToC may not exist yet.
+    # the previous window.
     # CLI flag: -dataobj.compaction.window-lookback
     [window_lookback: <int> | default = 0]
 

--- a/pkg/engine/compactor/config.go
+++ b/pkg/engine/compactor/config.go
@@ -187,7 +187,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.DurationVar(&cfg.PollingInterval, prefix+"polling-interval", defaultPollingInterval,
 		"Experimental: Coordinator main-loop cadence.")
 	f.IntVar(&cfg.WindowLookback, prefix+"window-lookback", defaultWindowLookback,
-		"Experimental: Number of older metastore windows to compact in addition to the current window. 0 compacts only the current window; 1 also compacts the previous window. Raise when the index-builder lags wall-clock so the current window's ToC may not exist yet.")
+		"Experimental: Number of older metastore windows to compact in addition to the current window. 0 compacts only the current window; 1 also compacts the previous window.")
 	f.IntVar(&cfg.MaxRunsPerTask, prefix+"max-runs-per-task", defaultMaxRunsPerTask,
 		"Experimental: Maximum runs per IndexMerge task (K). Memory grows linearly with K.")
 	f.IntVar(&cfg.LogMaxRunsPerTask, prefix+"logs.max-runs-per-task", defaultLogMaxRunsPerTask,

--- a/pkg/engine/compactor/config.go
+++ b/pkg/engine/compactor/config.go
@@ -39,6 +39,16 @@ type Config struct {
 	// tick reads the most-recent ToC and plans compaction per tenant.
 	PollingInterval time.Duration `yaml:"polling_interval"`
 
+	// WindowLookback is the number of older metastore windows the coordinator
+	// compacts in addition to the current window. Zero (the default) compacts
+	// only the current window; 1 also compacts the immediately-preceding
+	// window, and so on. Raise it when the index-builder lags behind wall-clock
+	// so a ToC for the current window may not exist yet: the preceding
+	// window(s) still have populated ToCs and would otherwise never be
+	// compacted. Each extra window is an independent per-pass read + plan, so
+	// cost scales linearly with the count.
+	WindowLookback int `yaml:"window_lookback"`
+
 	// MaxRunsPerTask (K in the K-way merge) is the maximum number of runs a
 	// single IndexMerge task may consume. Memory grows linearly with K.
 	MaxRunsPerTask int `yaml:"max_runs_per_task"`
@@ -150,6 +160,7 @@ const (
 	defaultEndpoint                     = "/api/v2/compaction-frame"
 
 	defaultPollingInterval       = 5 * time.Minute
+	defaultWindowLookback        = 0
 	defaultMaxRunsPerTask        = 8
 	defaultLogMaxRunsPerTask     = 3
 	defaultToCConsolidateTimeout = 30 * time.Second
@@ -175,6 +186,8 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 		"Experimental: Per-tenant-cycle cap on concurrent LogMerge tasks dispatched by the coordinator. 0 means unlimited.")
 	f.DurationVar(&cfg.PollingInterval, prefix+"polling-interval", defaultPollingInterval,
 		"Experimental: Coordinator main-loop cadence.")
+	f.IntVar(&cfg.WindowLookback, prefix+"window-lookback", defaultWindowLookback,
+		"Experimental: Number of older metastore windows to compact in addition to the current window. 0 compacts only the current window; 1 also compacts the previous window. Raise when the index-builder lags wall-clock so the current window's ToC may not exist yet.")
 	f.IntVar(&cfg.MaxRunsPerTask, prefix+"max-runs-per-task", defaultMaxRunsPerTask,
 		"Experimental: Maximum runs per IndexMerge task (K). Memory grows linearly with K.")
 	f.IntVar(&cfg.LogMaxRunsPerTask, prefix+"logs.max-runs-per-task", defaultLogMaxRunsPerTask,
@@ -235,6 +248,9 @@ func (cfg *Config) Validate() error {
 	if cfg.PollingInterval <= 0 {
 		return errInvalidPollingInterval
 	}
+	if cfg.WindowLookback < 0 {
+		return errInvalidWindowLookback
+	}
 	if cfg.ToCConsolidateTimeout <= 0 {
 		return errInvalidToCConsolidateTimeout
 	}
@@ -261,6 +277,7 @@ var (
 	errInvalidLogMaxRunningCompactionTasks = errors.New("dataobj.compaction.logs.max_running_compaction_tasks must be >= 0")
 	errEmptySchedulerEndpoint              = errors.New("dataobj.compaction.scheduler.endpoint must not be empty when compaction is enabled")
 	errInvalidPollingInterval              = errors.New("dataobj.compaction.polling_interval must be > 0 when compaction is enabled")
+	errInvalidWindowLookback               = errors.New("dataobj.compaction.window_lookback must be >= 0")
 	errInvalidToCConsolidateTimeout        = errors.New("dataobj.compaction.toc_consolidate_timeout must be > 0 when compaction is enabled")
 	errInvalidMaxRunsPerTask               = errors.New("dataobj.compaction.max_runs_per_task must be > 0 when compaction is enabled")
 	errInvalidLogMaxRunsPerTask            = errors.New("dataobj.compaction.logs.max_runs_per_task must be > 0 when compaction is enabled")

--- a/pkg/engine/compactor/config_test.go
+++ b/pkg/engine/compactor/config_test.go
@@ -23,6 +23,7 @@ func TestConfig_ValidateRejectsBadValues(t *testing.T) {
 		{"toc consolidate timeout zero", func(c *Config) { c.ToCConsolidateTimeout = 0 }, errInvalidToCConsolidateTimeout},
 		{"max runs zero", func(c *Config) { c.MaxRunsPerTask = 0 }, errInvalidMaxRunsPerTask},
 		{"max runs negative", func(c *Config) { c.MaxRunsPerTask = -1 }, errInvalidMaxRunsPerTask},
+		{"window lookback negative", func(c *Config) { c.WindowLookback = -1 }, errInvalidWindowLookback},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/engine/compactor/coordinator.go
+++ b/pkg/engine/compactor/coordinator.go
@@ -80,9 +80,9 @@ func newCoordinator(
 	}
 }
 
-// Run reconciles the set of per-tenant workers against the current-window ToC
-// and filtered by the per-tenant runtime config every PollingInterval until ctx
-// is cancelled, then drains all workers.
+// Run reconciles the set of per-tenant workers against the compacted windows'
+// ToCs and filtered by the per-tenant runtime config every PollingInterval
+// until ctx is cancelled, then drains all workers.
 func (c *coordinator) Run(ctx context.Context) error {
 	level.Info(c.logger).Log(
 		"msg", "starting dataobj compaction coordinator",
@@ -112,12 +112,24 @@ func (c *coordinator) Run(ctx context.Context) error {
 	}
 }
 
-// reconcile brings the live worker set in line with the current-window ToC and
-// the per-tenant enable override. workers is owned solely by the single Run
+// windows returns the metastore-aligned windows the coordinator compacts on
+// each pass, newest first: the current window followed by cfg.WindowLookback
+// older windows. With the default lookback of 0 this is exactly the current
+// window, preserving the original single-window behaviour.
+func (c *coordinator) windows() []time.Time {
+	current := c.clock().UTC().Truncate(metastore.MetastoreWindowSize)
+	out := make([]time.Time, 0, c.cfg.WindowLookback+1)
+	for i := 0; i <= c.cfg.WindowLookback; i++ {
+		out = append(out, current.Add(-time.Duration(i)*metastore.MetastoreWindowSize))
+	}
+	return out
+}
+
+// reconcile brings the live worker set in line with the compacted windows' ToCs
+// and the per-tenant enable override. workers is owned solely by the single Run
 // goroutine, so it needs no synchronization.
 func (c *coordinator) reconcile(ctx context.Context, workers map[string]context.CancelFunc, wg *sync.WaitGroup) {
-	window := c.clock().UTC().Truncate(metastore.MetastoreWindowSize)
-	discovered, ok := c.discover(ctx, window)
+	discovered, allOK := c.discoverAll(ctx)
 
 	// Per-tenant metric series are dropped by the worker goroutine on exit (see
 	// startWorker), not here, so a still-draining worker cannot resurrect a
@@ -131,10 +143,10 @@ func (c *coordinator) reconcile(ctx context.Context, workers map[string]context.
 		}
 	}
 
-	if !ok {
-		return
-	}
-
+	// Starting a worker for a discovered tenant is always safe, even when a
+	// window's ToC failed to load (allOK=false): a tenant present in any
+	// successfully-read window has real work. This is what lets a populated
+	// older window run while the current window's ToC does not yet exist.
 	for tenant := range discovered {
 		if _, running := workers[tenant]; running {
 			continue
@@ -143,6 +155,14 @@ func (c *coordinator) reconcile(ctx context.Context, workers map[string]context.
 			continue
 		}
 		c.startWorker(ctx, workers, wg, tenant)
+	}
+
+	// Absence-driven cancellation requires an authoritative picture: only when
+	// every window read cleanly is a tenant's absence from the union conclusive.
+	// A transient read failure on any window leaves the running set untouched so
+	// a tenant present only in the unread window is not spuriously cancelled.
+	if !allOK {
+		return
 	}
 
 	// Workers just started above are all in discovered, so this cancel-absent
@@ -154,6 +174,26 @@ func (c *coordinator) reconcile(ctx context.Context, workers map[string]context.
 			delete(workers, tenant)
 		}
 	}
+}
+
+// discoverAll unions the tenant sets of every compacted window's ToC. allOK is
+// true only when every window read cleanly (a missing ToC or transient error on
+// any window clears it); reconcile uses allOK to gate absence-driven
+// cancellation so an unread window never causes a spurious cancel.
+func (c *coordinator) discoverAll(ctx context.Context) (map[string]struct{}, bool) {
+	discovered := make(map[string]struct{})
+	allOK := true
+	for _, window := range c.windows() {
+		tenants, ok := c.discover(ctx, window)
+		if !ok {
+			allOK = false
+			continue
+		}
+		for tenant := range tenants {
+			discovered[tenant] = struct{}{}
+		}
+	}
+	return discovered, allOK
 }
 
 // startWorker launches a long-lived runTenantLoop goroutine for tenant and
@@ -168,10 +208,10 @@ func (c *coordinator) startWorker(ctx context.Context, workers map[string]contex
 	})
 }
 
-// discover reads the current-window ToC and returns the set of tenants it
-// references. ok is false on any read error (missing ToC or transient), which
-// tells reconcile to skip new-worker starts and absence-driven cancellation and
-// leave the running set untouched: only a successfully read ToC is authoritative
+// discover reads one window's ToC and returns the set of tenants it references.
+// ok is false on any read error (missing ToC or transient); discoverAll folds
+// that into its allOK result so reconcile can leave the running set untouched
+// when the picture is incomplete. Only a successfully read ToC is authoritative
 // enough to conclude a tenant was removed. Membership is by map key.
 func (c *coordinator) discover(ctx context.Context, window time.Time) (map[string]struct{}, bool) {
 	indexes, err := loadTenantIndexes(ctx, c.bucket, window)
@@ -702,7 +742,9 @@ func (c *coordinator) runLogMergePhase(ctx context.Context, tenant string, windo
 // is cancelled. It never returns an error and never sleeps: on error it retries
 // the same phase, otherwise it flips. It re-reads the per-tenant phase
 // enablement each iteration and skips the LogMerge phase when log compaction is
-// disabled, so an index-only tenant runs IndexMerge exclusively.
+// disabled, so an index-only tenant runs IndexMerge exclusively. Each phase runs
+// against every window returned by c.windows(); the phase flips only when no
+// window errored so a single failing window retries the whole phase.
 func (c *coordinator) runTenantLoop(ctx context.Context, tenant string) {
 	p := phaseIndexMerge
 	for {
@@ -718,7 +760,28 @@ func (c *coordinator) runTenantLoop(ctx context.Context, tenant string) {
 			continue
 		}
 
-		window := c.clock().UTC().Truncate(metastore.MetastoreWindowSize)
+		outcome := c.runPhaseAllWindows(ctx, tenant, p)
+		if ctx.Err() != nil {
+			return
+		}
+
+		if outcome != phaseOutcomeError {
+			p = p.flip()
+		}
+	}
+}
+
+// runPhaseAllWindows runs phase p for the tenant against each compacted window,
+// recording the worker-loop cycle metric per window, and returns the worst
+// outcome across them. Error dominates (the caller re-arms the same phase);
+// otherwise swapped (progress) outranks no-work. Windows are independent: a
+// window with no ToC no-ops while a populated one does real work.
+func (c *coordinator) runPhaseAllWindows(ctx context.Context, tenant string, p phase) phaseOutcome {
+	worst := phaseOutcomeNoWork
+	for _, window := range c.windows() {
+		if ctx.Err() != nil {
+			return worst
+		}
 
 		start := c.clock()
 		var outcome phaseOutcome
@@ -728,14 +791,22 @@ func (c *coordinator) runTenantLoop(ctx context.Context, tenant string) {
 		case phaseLogMerge:
 			outcome = c.runLogMergePhase(ctx, tenant, window)
 		}
-		if ctx.Err() != nil {
-			return
-		}
 		c.metrics.observeCycle(cycleOutcome(outcome), c.clock().Sub(start))
+		worst = worseOutcome(worst, outcome)
+	}
+	return worst
+}
 
-		if outcome != phaseOutcomeError {
-			p = p.flip()
-		}
+// worseOutcome ranks phase outcomes so the tenant loop retries on any error and
+// otherwise reports progress: error > swapped > no-work.
+func worseOutcome(a, b phaseOutcome) phaseOutcome {
+	switch {
+	case a == phaseOutcomeError || b == phaseOutcomeError:
+		return phaseOutcomeError
+	case a == phaseOutcomeSwapped || b == phaseOutcomeSwapped:
+		return phaseOutcomeSwapped
+	default:
+		return phaseOutcomeNoWork
 	}
 }
 

--- a/pkg/engine/compactor/coordinator.go
+++ b/pkg/engine/compactor/coordinator.go
@@ -114,8 +114,7 @@ func (c *coordinator) Run(ctx context.Context) error {
 
 // windows returns the metastore-aligned windows the coordinator compacts on
 // each pass, newest first: the current window followed by cfg.WindowLookback
-// older windows. With the default lookback of 0 this is exactly the current
-// window, preserving the original single-window behaviour.
+// older windows. With the default lookback of 0 this is the current window.
 func (c *coordinator) windows() []time.Time {
 	current := c.clock().UTC().Truncate(metastore.MetastoreWindowSize)
 	out := make([]time.Time, 0, c.cfg.WindowLookback+1)
@@ -129,7 +128,7 @@ func (c *coordinator) windows() []time.Time {
 // and the per-tenant enable override. workers is owned solely by the single Run
 // goroutine, so it needs no synchronization.
 func (c *coordinator) reconcile(ctx context.Context, workers map[string]context.CancelFunc, wg *sync.WaitGroup) {
-	discovered, allOK := c.discoverAll(ctx)
+	discovered, allOK := c.discoverUniqueTenants(ctx)
 
 	// Per-tenant metric series are dropped by the worker goroutine on exit (see
 	// startWorker), not here, so a still-draining worker cannot resurrect a
@@ -176,11 +175,11 @@ func (c *coordinator) reconcile(ctx context.Context, workers map[string]context.
 	}
 }
 
-// discoverAll unions the tenant sets of every compacted window's ToC. allOK is
+// discoverUniqueTenants unions the tenant sets of every compacted window's ToC. allOK is
 // true only when every window read cleanly (a missing ToC or transient error on
 // any window clears it); reconcile uses allOK to gate absence-driven
 // cancellation so an unread window never causes a spurious cancel.
-func (c *coordinator) discoverAll(ctx context.Context) (map[string]struct{}, bool) {
+func (c *coordinator) discoverUniqueTenants(ctx context.Context) (map[string]struct{}, bool) {
 	discovered := make(map[string]struct{})
 	allOK := true
 	for _, window := range c.windows() {
@@ -792,14 +791,14 @@ func (c *coordinator) runPhaseAllWindows(ctx context.Context, tenant string, p p
 			outcome = c.runLogMergePhase(ctx, tenant, window)
 		}
 		c.metrics.observeCycle(cycleOutcome(outcome), c.clock().Sub(start))
-		worst = worseOutcome(worst, outcome)
+		worst = worstOutcome(worst, outcome)
 	}
 	return worst
 }
 
-// worseOutcome ranks phase outcomes so the tenant loop retries on any error and
+// worstOutcome ranks phase outcomes so the tenant loop retries on any error and
 // otherwise reports progress: error > swapped > no-work.
-func worseOutcome(a, b phaseOutcome) phaseOutcome {
+func worstOutcome(a, b phaseOutcome) phaseOutcome {
 	switch {
 	case a == phaseOutcomeError || b == phaseOutcomeError:
 		return phaseOutcomeError

--- a/pkg/engine/compactor/coordinator_test.go
+++ b/pkg/engine/compactor/coordinator_test.go
@@ -1036,6 +1036,124 @@ func TestReconcile_StartAndCancelSameTick(t *testing.T) {
 	require.NotContains(t, workers, "acme")
 }
 
+// seedWindowToC writes a two-index ToC entry per tenant into bucket for the
+// given window, so multiple windows can coexist in one bucket. The window is
+// encoded into each path to keep paths distinct across windows.
+func seedWindowToC(ctx context.Context, t *testing.T, bucket objstore.Bucket, window time.Time, tenants ...string) {
+	t.Helper()
+	entries := map[string][]testIndex{}
+	for _, tn := range tenants {
+		prefix := "[REDACTED]" + window.Format("20060102T150405Z") + "/" + tn
+		buildOverlappingPostingsIndex(ctx, t, bucket, tn, prefix+"/0")
+		buildOverlappingPostingsIndex(ctx, t, bucket, tn, prefix+"/1")
+		entries[tn] = []testIndex{
+			{path: prefix + "/0", start: window.Add(time.Hour), end: window.Add(2 * time.Hour)},
+			{path: prefix + "/1", start: window.Add(time.Hour), end: window.Add(2 * time.Hour)},
+		}
+	}
+	writeToCWithIndexes(ctx, t, bucket, entries)
+}
+
+func keys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func TestWindows_LookbackCountsBackFromCurrent(t *testing.T) {
+	current := imWindow()
+	newC := func(lookback int) *coordinator {
+		return &coordinator{cfg: Config{WindowLookback: lookback}, clock: fixedClock(current.Add(time.Hour))}
+	}
+
+	require.Equal(t, []time.Time{current}, newC(0).windows(),
+		"lookback 0 compacts only the current window (original behaviour)")
+
+	require.Equal(t, []time.Time{
+		current,
+		current.Add(-metastore.MetastoreWindowSize),
+		current.Add(-2 * metastore.MetastoreWindowSize),
+	}, newC(2).windows(), "lookback N yields the current window plus N older ones, newest first")
+}
+
+func TestWorseOutcome(t *testing.T) {
+	require.Equal(t, phaseOutcomeError, worseOutcome(phaseOutcomeNoWork, phaseOutcomeError))
+	require.Equal(t, phaseOutcomeError, worseOutcome(phaseOutcomeSwapped, phaseOutcomeError))
+	require.Equal(t, phaseOutcomeSwapped, worseOutcome(phaseOutcomeNoWork, phaseOutcomeSwapped))
+	require.Equal(t, phaseOutcomeNoWork, worseOutcome(phaseOutcomeNoWork, phaseOutcomeNoWork))
+}
+
+func TestDiscoverAll_UnionsPopulatedWindows(t *testing.T) {
+	ctx := t.Context()
+	current := imWindow()
+	prev := current.Add(-metastore.MetastoreWindowSize)
+
+	bucket := objstore.NewInMemBucket()
+	seedWindowToC(ctx, t, bucket, current, "acme")
+	seedWindowToC(ctx, t, bucket, prev, "bravo")
+
+	c := newTestCoordinator(t, bucket, &fakeRunner{}, &fakeReplacer{}, fixedClock(current.Add(time.Hour)), newFakeLimits("acme", "bravo"))
+	c.cfg.WindowLookback = 1
+
+	discovered, allOK := c.discoverAll(ctx)
+	require.True(t, allOK, "both windows read cleanly")
+	require.ElementsMatch(t, []string{"acme", "bravo"}, keys(discovered))
+}
+
+// TestDiscoverAll_CurrentMissingPreviousPresent reproduces the index-builder-lag
+// scenario: the current window has no ToC yet, but the previous window does.
+// The previous window's tenant is still discovered, and allOK is false so
+// reconcile will start-but-not-cancel.
+func TestDiscoverAll_CurrentMissingPreviousPresent(t *testing.T) {
+	ctx := t.Context()
+	current := imWindow()
+	prev := current.Add(-metastore.MetastoreWindowSize)
+
+	bucket := objstore.NewInMemBucket()
+	seedWindowToC(ctx, t, bucket, prev, "bravo") // current window intentionally unwritten
+
+	c := newTestCoordinator(t, bucket, &fakeRunner{}, &fakeReplacer{}, fixedClock(current.Add(time.Hour)), newFakeLimits("bravo"))
+	c.cfg.WindowLookback = 1
+
+	discovered, allOK := c.discoverAll(ctx)
+	require.False(t, allOK, "the missing current-window ToC makes the picture non-authoritative")
+	require.ElementsMatch(t, []string{"bravo"}, keys(discovered),
+		"the populated previous window still yields its tenant")
+}
+
+// TestReconcile_PreviousWindowStartsWorker is the end-to-end unblock: with
+// lookback=1 and only the previous window populated, reconcile starts a worker
+// that does real compaction work, even though the current window has no ToC.
+func TestReconcile_PreviousWindowStartsWorker(t *testing.T) {
+	ctx := t.Context()
+	current := imWindow()
+	prev := current.Add(-metastore.MetastoreWindowSize)
+
+	bucket := objstore.NewInMemBucket()
+	seedWindowToC(ctx, t, bucket, prev, "bravo")
+
+	c, liveTenants := reconcileHarness(t, bucket, fixedClock(current.Add(time.Hour)), newFakeLimits("bravo"))
+	c.cfg.WindowLookback = 1
+
+	workers := map[string]context.CancelFunc{}
+	var wg sync.WaitGroup
+	defer func() {
+		for _, cf := range workers {
+			cf()
+		}
+		wg.Wait()
+	}()
+
+	c.reconcile(ctx, workers, &wg)
+
+	require.Eventually(t, func() bool {
+		return len(liveTenants()) == 1 && liveTenants()[0] == "bravo"
+	}, 2*time.Second, 5*time.Millisecond, "previous-window tenant is compacted while the current window has no ToC")
+	require.Contains(t, workers, "bravo")
+}
+
 // TestRunTenantLoop_ErrorRetries pins the flip-flop state machine: a failing
 // phase re-arms the same phase (it must never flip), while a successful phase
 // flips to the other one. The loop starts on IndexMerge.
@@ -1383,7 +1501,7 @@ func TestRunTenantLoop_IndexOnly(t *testing.T) {
 		mu.Lock()
 		phases = append(phases, opts.Actor[1])
 		mu.Unlock()
-		return nil, nil
+		return v2.BuildResultRecord(memory.DefaultAllocator, []v2.ResultArtifact{{Path: "indexes/aa/bb"}}), nil
 	}
 
 	done := make(chan struct{})
@@ -1427,7 +1545,7 @@ func TestRunTenantLoop_LogEnabledRunsBothPhases(t *testing.T) {
 			phases = append(phases, opts.Actor[1])
 		}
 		mu.Unlock()
-		return nil, nil
+		return v2.BuildResultRecord(memory.DefaultAllocator, []v2.ResultArtifact{{Path: "indexes/aa/bb"}}), nil
 	}
 
 	done := make(chan struct{})
@@ -1443,9 +1561,9 @@ func TestRunTenantLoop_LogEnabledRunsBothPhases(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
-	// runPlan returns nil (success) on every call, so the loop flips every
-	// cycle and the phase order is deterministic; the exact prefix is safe to
-	// assert. The loop starts on IndexMerge.
+	// runPlan reports a swapped artifact (success) on every call, so the loop
+	// flips every cycle and the phase order is deterministic; the exact prefix
+	// is safe to assert. The loop starts on IndexMerge.
 	require.Equal(t, []string{"index-merge", "log-merge", "index-merge"}, phases[:3],
 		"log-enabled tenant flips between index-merge and log-merge")
 }
@@ -1476,7 +1594,7 @@ func TestRunTenantLoop_DisablingLogMidRunStopsLogMerge(t *testing.T) {
 		if opts.Actor[1] == "log-merge" {
 			closeOnce.Do(func() { close(sawLog) })
 		}
-		return nil, nil
+		return v2.BuildResultRecord(memory.DefaultAllocator, []v2.ResultArtifact{{Path: "indexes/aa/bb"}}), nil
 	}
 
 	done := make(chan struct{})

--- a/pkg/engine/compactor/coordinator_test.go
+++ b/pkg/engine/compactor/coordinator_test.go
@@ -1079,10 +1079,10 @@ func TestWindows_LookbackCountsBackFromCurrent(t *testing.T) {
 }
 
 func TestWorseOutcome(t *testing.T) {
-	require.Equal(t, phaseOutcomeError, worseOutcome(phaseOutcomeNoWork, phaseOutcomeError))
-	require.Equal(t, phaseOutcomeError, worseOutcome(phaseOutcomeSwapped, phaseOutcomeError))
-	require.Equal(t, phaseOutcomeSwapped, worseOutcome(phaseOutcomeNoWork, phaseOutcomeSwapped))
-	require.Equal(t, phaseOutcomeNoWork, worseOutcome(phaseOutcomeNoWork, phaseOutcomeNoWork))
+	require.Equal(t, phaseOutcomeError, worstOutcome(phaseOutcomeNoWork, phaseOutcomeError))
+	require.Equal(t, phaseOutcomeError, worstOutcome(phaseOutcomeSwapped, phaseOutcomeError))
+	require.Equal(t, phaseOutcomeSwapped, worstOutcome(phaseOutcomeNoWork, phaseOutcomeSwapped))
+	require.Equal(t, phaseOutcomeNoWork, worstOutcome(phaseOutcomeNoWork, phaseOutcomeNoWork))
 }
 
 func TestDiscoverAll_UnionsPopulatedWindows(t *testing.T) {
@@ -1097,7 +1097,7 @@ func TestDiscoverAll_UnionsPopulatedWindows(t *testing.T) {
 	c := newTestCoordinator(t, bucket, &fakeRunner{}, &fakeReplacer{}, fixedClock(current.Add(time.Hour)), newFakeLimits("acme", "bravo"))
 	c.cfg.WindowLookback = 1
 
-	discovered, allOK := c.discoverAll(ctx)
+	discovered, allOK := c.discoverUniqueTenants(ctx)
 	require.True(t, allOK, "both windows read cleanly")
 	require.ElementsMatch(t, []string{"acme", "bravo"}, keys(discovered))
 }
@@ -1117,7 +1117,7 @@ func TestDiscoverAll_CurrentMissingPreviousPresent(t *testing.T) {
 	c := newTestCoordinator(t, bucket, &fakeRunner{}, &fakeReplacer{}, fixedClock(current.Add(time.Hour)), newFakeLimits("bravo"))
 	c.cfg.WindowLookback = 1
 
-	discovered, allOK := c.discoverAll(ctx)
+	discovered, allOK := c.discoverUniqueTenants(ctx)
 	require.False(t, allOK, "the missing current-window ToC makes the picture non-authoritative")
 	require.ElementsMatch(t, []string{"bravo"}, keys(discovered),
 		"the populated previous window still yields its tenant")


### PR DESCRIPTION
**What this PR does / why we need it**:

The dataobj compaction coordinator only ever compacted the *current* metastore window (`now.Truncate(12h)`). When the index-builder lags behind wall-clock, the current window's ToC does not exist yet, so the coordinator finds no tenants and dispatches no work — even though older windows have populated ToCs sitting ready to be compacted.

This PR adds a `dataobj.compaction.window-lookback` knob so the coordinator can also compact a configurable number of immediately-preceding windows:

- **Default `0` preserves existing behaviour** (current window only), so this is a no-op unless explicitly configured.
- Setting it to `N` compacts the current window plus the `N` windows immediately before it (`[T, T-1, … T-N]`, newest-first).
- Worker starts now proceed even when a given window's ToC is missing (the unblock), but **absence-driven cancellation is gated on every window reading cleanly**, so a transient or missing read never spuriously tears down a running worker.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Builds on the artifact-tracking work from #23364. The coordinator's per-tenant `runTenantLoop` now runs the chosen phase across all in-scope windows and only flips index<->log when no window errored.

**Checklist**

- [ ] Tests updated
