### PR TITLE
fix: Dispatch binop legs separately when sharding sum/count

### DIFF
--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -263,6 +263,14 @@ func (m ShardMapper) mapVectorAggregationExpr(expr *syntax.VectorAggregationExpr
 			if syntax.ReducesLabels(expr.Left) && syntax.HasNonAdditiveAggr(expr.Left) {
 				break
 			}
+			// A binary operation contributes one matcher group per leg (even
+			// when both legs share a selector), so it cannot be pushed down as a
+			// single sharded leaf: shard resolution (GetShards) only supports a
+			// single matcher group. Fall through to child mapping so mapBinOpExpr
+			// dispatches each leg separately.
+			if spansMultipleMatcherGroups(expr.Left) {
+				break
+			}
 			return m.wrappedShardedVectorAggr(expr, r)
 
 		case syntax.OpTypeMin, syntax.OpTypeMax:
@@ -298,6 +306,12 @@ func (m ShardMapper) mapVectorAggregationExpr(expr *syntax.VectorAggregationExpr
 				// skip sharding optimizations at this level. If labels are reduced,
 				// the same series may exist on multiple shards and must be aggregated
 				// together before a count is applied
+				break
+			}
+			// see the OpTypeSum case: a binary operation spans multiple matcher
+			// groups and cannot be pushed down as a single sharded leaf. Fall
+			// through so mapBinOpExpr dispatches each leg separately.
+			if spansMultipleMatcherGroups(expr.Left) {
 				break
 			}
 
@@ -693,4 +707,15 @@ func isLiteralOrVector(e syntax.Expr) bool {
 
 func badASTMapping(got syntax.Expr) error {
 	return fmt.Errorf("bad AST mapping: expected SampleExpr, but got (%T)", got)
+}
+
+// spansMultipleMatcherGroups reports whether e selects more than one stream
+// matcher group. Any binary operation does, since MatcherGroups counts one group
+// per leg. Returns false on parse errors, deferring them to downstream handling.
+func spansMultipleMatcherGroups(e syntax.Expr) bool {
+	groups, err := syntax.MatcherGroups(e)
+	if err != nil {
+		return false
+	}
+	return len(groups) > 1
 }

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -558,10 +558,30 @@ func TestMappingStrings(t *testing.T) {
 			out: `sum((downstream<count_over_time({a=~".+"}[1s]),shard=0_of_2>++downstream<count_over_time({a=~".+"}[1s]),shard=1_of_2>*ignoring(foo)downstream<count_over_time({a=~".+"}[1s]),shard=0_of_2>++downstream<count_over_time({a=~".+"}[1s]),shard=1_of_2>))`,
 		},
 		{
-			// ignoring () doesn't mutate labels and therefore can be shardable
-			// as long as the operation is shardable
+			// ignoring () doesn't mutate labels, but the binary operation still
+			// spans multiple matcher groups, so it must not be pushed down as a
+			// single sharded leaf (GetShards rejects >1 matcher group). Each leg
+			// is dispatched separately instead.
 			in:  `sum(count_over_time({a=~".+"}[1s]) * ignoring () count_over_time({a=~".+"}[1s]))`,
-			out: `sum(downstream<sum((count_over_time({a=~".+"}[1s])*count_over_time({a=~".+"}[1s]))),shard=0_of_2>++downstream<sum((count_over_time({a=~".+"}[1s])*count_over_time({a=~".+"}[1s]))),shard=1_of_2>)`,
+			out: `sum((downstream<count_over_time({a=~".+"}[1s]),shard=0_of_2>++downstream<count_over_time({a=~".+"}[1s]),shard=1_of_2>*downstream<count_over_time({a=~".+"}[1s]),shard=0_of_2>++downstream<count_over_time({a=~".+"}[1s]),shard=1_of_2>))`,
+		},
+		{
+			// binary operation under an outer sum: each leg is dispatched
+			// separately so no single sharded leaf spans multiple matcher groups.
+			in:  `sum by (cluster) (count_over_time({job="foo"}[5m]) + count_over_time({job="bar"}[5m]))`,
+			out: `sumby(cluster)((downstream<count_over_time({job="foo"}[5m]),shard=0_of_2>++downstream<count_over_time({job="foo"}[5m]),shard=1_of_2>+downstream<count_over_time({job="bar"}[5m]),shard=0_of_2>++downstream<count_over_time({job="bar"}[5m]),shard=1_of_2>))`,
+		},
+		{
+			// same as above but with an outer count.
+			in:  `count(count_over_time({job="foo"}[5m]) + count_over_time({job="bar"}[5m]))`,
+			out: `count((downstream<count_over_time({job="foo"}[5m]),shard=0_of_2>++downstream<count_over_time({job="foo"}[5m]),shard=1_of_2>+downstream<count_over_time({job="bar"}[5m]),shard=0_of_2>++downstream<count_over_time({job="bar"}[5m]),shard=1_of_2>))`,
+		},
+		{
+			// identical selectors on both legs still contribute one matcher
+			// group each, so the binop must still be split — it is not special
+			// cased to different selectors.
+			in:  `count by (cluster) (count_over_time({job="foo"}[5m]) + count_over_time({job="foo"}[5m]))`,
+			out: `countby(cluster)((downstream<count_over_time({job="foo"}[5m]),shard=0_of_2>++downstream<count_over_time({job="foo"}[5m]),shard=1_of_2>+downstream<count_over_time({job="foo"}[5m]),shard=0_of_2>++downstream<count_over_time({job="foo"}[5m]),shard=1_of_2>))`,
 		},
 		{
 			// shard the count since there is no label reduction in children
@@ -582,6 +602,65 @@ func TestMappingStrings(t *testing.T) {
 			require.Nil(t, err)
 
 			require.Equal(t, removeWhiteSpace(tc.out), removeWhiteSpace(mapped.String()))
+		})
+	}
+}
+
+// TestShardedLeavesHaveSingleMatcherGroup asserts the invariant that the shard
+// mapper never collapses an expression spanning multiple stream matcher groups
+// into a single sharded leaf. Such a leaf is passed to the resolver's Shards
+// (GetShards under bounded sharding), which only supports a single matcher group
+// and errors otherwise. A binary operation contributes one matcher group per
+// leg, so its legs must be dispatched separately rather than pushed down whole.
+//
+// This is a structural check on any aggregation that pushes down via the sharded
+// (ConcatSampleExpr) path, so it also guards operations not exercised by
+// TestMappingStrings and any added later.
+func TestShardedLeavesHaveSingleMatcherGroup(t *testing.T) {
+	strategy := NewPowerOfTwoStrategy(ConstantShards(2))
+	m := NewShardMapper(strategy, nilShardMetrics, []string{ShardQuantileOverTime, SupportApproxTopk})
+
+	for _, q := range []string{
+		// bare binops and non-pushdown aggregations already split via mapBinOpExpr
+		`count_over_time({job="foo"}[5m]) + count_over_time({job="bar"}[5m])`,
+		`rate({app="x"} |= "err" [5m]) / rate({app="x"}[5m])`,
+		`min(count_over_time({job="foo"}[5m]) + count_over_time({job="bar"}[5m]))`,
+		`max(count_over_time({job="foo"}[5m]) + count_over_time({job="bar"}[5m]))`,
+		`topk(3, count_over_time({job="foo"}[5m]) + count_over_time({job="bar"}[5m]))`,
+		`bottomk(3, count_over_time({job="foo"}[5m]) + count_over_time({job="bar"}[5m]))`,
+		// aggregations that push down via ConcatSampleExpr and previously
+		// collapsed the binop into a single multi-matcher-group leaf
+		`sum(count_over_time({job="foo"}[5m]) + count_over_time({job="bar"}[5m]))`,
+		`sum by (cluster) (count_over_time({job="foo"}[5m]) + count_over_time({job="bar"}[5m]))`,
+		`sum(count_over_time({job="foo"}[5m]) + count_over_time({job="foo"}[5m]))`,
+		`count(count_over_time({job="foo"}[5m]) + count_over_time({job="bar"}[5m]))`,
+		`avg(count_over_time({job="foo"}[5m]) + count_over_time({job="bar"}[5m]))`,
+		`sum(rate({app="a"}[5m]) + rate({app="b"}[5m]) + rate({app="c"}[5m]))`,
+		`sum(rate({app="a"}[5m])) / sum(rate({app="b"}[5m]))`,
+		// approx_topk resolves shards via GetStats + power-of-two shards (not
+		// GetShards), so its count-min-sketch leaf is not a ConcatSampleExpr and
+		// is exempt; included here to document that it does not regress.
+		`approx_topk(3, count_over_time({job="foo"}[5m]) + count_over_time({job="bar"}[5m]))`,
+	} {
+		t.Run(q, func(t *testing.T) {
+			ast, err := syntax.ParseExpr(q)
+			require.NoError(t, err)
+
+			mapped, _, err := m.Map(ast, nilShardMetrics.downstreamRecorder(), true)
+			require.NoError(t, err)
+
+			mapped.Walk(func(e syntax.Expr) bool {
+				concat, ok := e.(*ConcatSampleExpr)
+				if !ok {
+					return true
+				}
+				groups, err := syntax.MatcherGroups(concat.SampleExpr)
+				require.NoError(t, err)
+				require.LessOrEqualf(t, len(groups), 1,
+					"sharded leaf spans %d matcher groups and would fail shard resolution; its legs must be dispatched separately: %s",
+					len(groups), concat.SampleExpr.String())
+				return true
+			})
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The shard mapper's `sum(...)` and `count(...)` fast paths push the whole aggregation down as a single sharded leaf. When the aggregation wraps a binary operation (e.g. `sum by (cluster) (count_over_time({job="foo"}[5m]) + count_over_time({job="bar"}[5m]))`), that leaf carries more than one stream matcher group, i.e one per binop leg. Under
bounded/dynamic sharding, this leaf is resolved via the index gateway's `GetShards`, which only supports a single matcher group and fails with: `multiple matcher groups are not supported in GetShards. This is likely an internal bug as binary operations should be dispatched separately in planning`

This affects any binary operation under `sum`/`count`, regardless of whether the legs share a selector: `BinOpExpr.MatcherGroups` appends both legs without deduping, so `cot({a}) + cot({a})` also spans two groups. It only manifests under `DynamicBoundsStrategy` (`GetShards`); `PowerOfTwoStrategy` resolves shards via `GetStats`, which already sums across matcher groups.

The fix adds a `spansMultipleMatcherGroups` check to the `sum` and `count` shardable paths. When the child spans multiple matcher groups, the mapper falls through to child mapping, so `mapBinOpExpr` dispatches each leg separately; each resulting sharded leaf then carries a single matcher group. This matches the invariant the `GetShards` guard already assumes and is what shape-bounded sharding requires. There is no data-path cost: the query engine evaluates each
binop leg with its own step evaluator regardless, so the change only affects how leaves are grouped for shard resolution.

**Special notes for your reviewer**:

- `min`/`max` are unaffected (their `Shardable` requires a range-aggregation child, never a binop); `avg` is covered transitively via its `sum`/`count` decomposition. Bare binops and non-pushdown aggregations (`max`/`topk` over a binop) already dispatch legs separately via `mapBinOpExpr` and were never affected.
- `approx_topk(<binop>)` also produces a multi-matcher-group leaf (`__count_min_sketch__(...)`), but it is intentionally **not** covered here: it resolves shards via `Resolver().Shards` (`GetStats`, which handles multiple matcher groups) and emits power-of-two shard annotations, so it never reaches `GetShards`. If bounded sharding is later integrated with `approx_topk` (see the TODO in `mapApproxTopk`), that path will need the same leg-splitting.
- I have added a test function to catch regressions if any of the aggregation types tries to push the whole aggregation down as a single sharded leaf.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
