### PR TITLE
chore(ruler)!: Remove deprecated remote-write 'client' setting

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -75,6 +75,7 @@ As a result, the following have been removed:
 
 ### Breaking change: Removal of various deprecated configuration options
 
+- The single remote-write `client` setting (`ruler.remote_write.client` in the yaml file) has been removed in favor of the `clients` map (`ruler.remote_write.clients`), which allows configuring one or more remote-write clients keyed by an id. When upgrading, move your existing `client` configuration under `clients` with a chosen key.
 - The settings `-limits.per-user-override-config` (`limits_config.per_tenant_override_config`) and `-limits.per-user-override-period` (`limits_config.per_tenant_override_period`) have been removed in favor of `-runtime-config.file` (`runtime_config.file`) and `-runtime-config.reload-period` (`runtime_config.period`) respectively.
 - The per-tenant setting `unordered_writes` has been removed. Loki now always allows unordered writes.
 - The setting `-store.index-cache-write` (`chunk_store_config.write_dedupe_cache_config` block in the yaml file) has been removed as it was only used for legacy storage backends that have been removed as well.

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -6132,9 +6132,6 @@ wal_cleaner:
 # Remote-write configuration to send rule samples to a Prometheus remote-write
 # endpoint.
 remote_write:
-  # Deprecated: Use 'clients' instead. Configure remote write client.
-  [client: <RemoteWriteConfig>]
-
   # Configure remote write clients. A map with remote client id as key. For
   # details, see
   # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write

--- a/pkg/distributor/circuit_breaker.go
+++ b/pkg/distributor/circuit_breaker.go
@@ -177,7 +177,7 @@ func (b *trialCircuitBreaker) handleOpenErr(_ error) {
 		// A failure in the half-open state re-opens the circuit breaker. This is
 		// essential for correctness to avoid deadlocks in the half-open state where
 		// all trial requests have completed but neither threshold to close or re-open
-		// the circuit breaker was satisifed.
+		// the circuit breaker was satisfied.
 		b.open()
 	default:
 		// circuitBreakerOpen is unreachable: Allow() returns noopDoneFunc when open,

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -88,8 +88,10 @@ func TestInvalidRemoteWriteConfig(t *testing.T) {
 		Config: rulerbase.Config{},
 		RemoteWrite: RemoteWriteConfig{
 			Enabled: true,
-			Client: &config.RemoteWriteConfig{
-				URL: nil,
+			Clients: map[string]config.RemoteWriteConfig{
+				"default": config.RemoteWriteConfig{
+					URL: nil,
+				},
 			},
 		},
 	}

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -89,7 +89,7 @@ func TestInvalidRemoteWriteConfig(t *testing.T) {
 		RemoteWrite: RemoteWriteConfig{
 			Enabled: true,
 			Clients: map[string]config.RemoteWriteConfig{
-				"default": config.RemoteWriteConfig{
+				"default": {
 					URL: nil,
 				},
 			},

--- a/pkg/ruler/config.go
+++ b/pkg/ruler/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	promconfig "github.com/prometheus/prometheus/config"
 	"go.yaml.in/yaml/v4"
@@ -73,6 +74,8 @@ func (c *RemoteWriteConfig) Validate() error {
 				return fmt.Errorf("invalid remote write client for tenant %q: %w", id, err)
 			}
 		}
+	} else {
+		return errors.New("remote-write enabled but no clients are configured")
 	}
 
 	return nil

--- a/pkg/ruler/config.go
+++ b/pkg/ruler/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	promconfig "github.com/prometheus/prometheus/config"
 	"go.yaml.in/yaml/v4"
@@ -53,7 +52,6 @@ func (c *Config) Validate() error {
 }
 
 type RemoteWriteConfig struct {
-	Client              *promconfig.RemoteWriteConfig           `yaml:"client,omitempty" doc:"deprecated|description=Use 'clients' instead. Configure remote write client."`
 	Clients             map[string]promconfig.RemoteWriteConfig `yaml:"clients,omitempty" doc:"description=Configure remote write clients. A map with remote client id as key. For details, see https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write Specifying a header with key 'X-Scope-OrgID' under the 'headers' section of RemoteWriteConfig is not permitted. If specified, it will be dropped during config parsing."`
 	Enabled             bool                                    `yaml:"enabled"`
 	ConfigRefreshPeriod time.Duration                           `yaml:"config_refresh_period"`
@@ -63,16 +61,6 @@ type RemoteWriteConfig struct {
 func (c *RemoteWriteConfig) Validate() error {
 	if !c.Enabled {
 		return nil
-	}
-
-	if (c.Client == nil || c.Client.URL == nil) && len(c.Clients) == 0 {
-		return errors.New("remote-write enabled but no clients URL are configured")
-	}
-
-	if c.Client != nil {
-		if err := c.Client.Validate(model.UTF8Validation); err != nil {
-			return fmt.Errorf("invalid remote write client: %w", err)
-		}
 	}
 
 	if len(c.Clients) > 0 {
@@ -100,13 +88,6 @@ func (c *RemoteWriteConfig) Clone() (*RemoteWriteConfig, error) {
 	err = yaml.Unmarshal(out, &n)
 	if err != nil {
 		return nil, err
-	}
-
-	// BasicAuth.Password has a type of Secret (github.com/prometheus/common/config/config.go),
-	// so when its value is marshaled it is obfuscated as "<secret>".
-	// Here we copy the original password into the cloned config.
-	if n.Client != nil && n.Client.HTTPClientConfig.BasicAuth != nil {
-		n.Client.HTTPClientConfig.BasicAuth.Password = c.Client.HTTPClientConfig.BasicAuth.Password
 	}
 
 	for id := range n.Clients {

--- a/pkg/ruler/registry_test.go
+++ b/pkg/ruler/registry_test.go
@@ -57,30 +57,6 @@ var remoteURL, _ = url.Parse("http://remote-write")
 var backCompatCfg = Config{
 	RemoteWrite: RemoteWriteConfig{
 		AddOrgIDHeader: true,
-		Client: &promconfig.RemoteWriteConfig{
-			URL: &commonconfig.URL{URL: remoteURL},
-			QueueConfig: promconfig.QueueConfig{
-				Capacity: defaultCapacity,
-			},
-			HTTPClientConfig: commonconfig.HTTPClientConfig{
-				BasicAuth: &commonconfig.BasicAuth{
-					Password: "bar",
-					Username: "foo",
-				},
-			},
-			Headers: map[string]string{
-				"Base": "value",
-			},
-			WriteRelabelConfigs: []*relabel.Config{
-				{
-					SourceLabels: []model.LabelName{"__name__"},
-					Regex:        relabel.MustNewRegexp("ALERTS.*"),
-					Action:       "drop",
-					Separator:    ";",
-					Replacement:  "$1",
-				},
-			},
-		},
 		Clients: map[string]promconfig.RemoteWriteConfig{
 			"default": {
 				URL: &commonconfig.URL{URL: remoteURL},
@@ -1072,7 +1048,7 @@ func TestRelabelConfigOverridesNilWriteRelabels(t *testing.T) {
 	require.NoError(t, err)
 
 	// set NameValidationScheme on expected configs
-	expectedConfigs := reg.config.RemoteWrite.Client.WriteRelabelConfigs
+	expectedConfigs := reg.config.RemoteWrite.Clients["default"].WriteRelabelConfigs
 	for _, rc := range expectedConfigs {
 		rc.NameValidationScheme = model.UTF8Validation
 	}

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -2,9 +2,7 @@ package ruler
 
 import (
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/prometheus/config"
 	"go.opentelemetry.io/otel"
 
 	ruler "github.com/grafana/loki/v3/pkg/ruler/base"
@@ -14,20 +12,6 @@ import (
 var tracer = otel.Tracer("pkg/ruler")
 
 func NewRuler(cfg Config, evaluator Evaluator, reg prometheus.Registerer, logger log.Logger, ruleStore rulestore.RuleStore, limits RulesLimits, metricsNamespace string) (*ruler.Ruler, error) {
-	// For backward compatibility, client and clients are defined in the remote_write config.
-	// When both are present, an error is thrown.
-	if len(cfg.RemoteWrite.Clients) > 0 && cfg.RemoteWrite.Client != nil {
-		return nil, errors.New("ruler remote write config: both 'client' and 'clients' options are defined; 'client' is deprecated, please only use 'clients'")
-	}
-
-	if len(cfg.RemoteWrite.Clients) == 0 && cfg.RemoteWrite.Client != nil {
-		if cfg.RemoteWrite.Clients == nil {
-			cfg.RemoteWrite.Clients = make(map[string]config.RemoteWriteConfig)
-		}
-
-		cfg.RemoteWrite.Clients["default"] = *cfg.RemoteWrite.Client
-	}
-
 	mgr, err := ruler.NewDefaultMultiTenantManager(
 		cfg.Config,
 		MultiTenantRuleManager(cfg, evaluator, limits, logger, reg),

--- a/tools/deprecated-config-checker/checker/checker_test.go
+++ b/tools/deprecated-config-checker/checker/checker_test.go
@@ -24,6 +24,7 @@ var (
 		"frontend_worker.match_max_concurrent",
 		"common.storage.s3.sse_encryption",
 		"ruler.storage.s3.sse_encryption",
+		"ruler.remote_write.client",
 		"storage_config.boltdb_shipper.use_boltdb_shipper_as_backup",
 		"storage_config.aws.sse_encryption",
 		"storage_config.s3.sse_encryption",
@@ -69,7 +70,6 @@ var (
 	}
 
 	expectedConfigDeprecates = []string{
-		"ruler.remote_write.client",
 		"index_gateway.ring.replication_factor",
 		"limits_config.ruler_remote_write_url",
 		"limits_config.ruler_remote_write_timeout",

--- a/tools/deprecated-config-checker/deleted-config.yaml
+++ b/tools/deprecated-config-checker/deleted-config.yaml
@@ -27,6 +27,8 @@ common:
       admin_api_directory: "Removed in 3.5.0. This field is no longer supported or recognized by Loki."
 
 ruler:
+  remote_write:
+    client: "Use clients instead."
   storage:
     s3:
       sse_encryption: "Encryption for all S3 buckets is now SSE-S3. Configure .sse field instead."

--- a/tools/deprecated-config-checker/deprecated-config.yaml
+++ b/tools/deprecated-config-checker/deprecated-config.yaml
@@ -14,10 +14,6 @@
 #
 # Note that even though the configs in schema_config takes a list, here we specify the deprecated fields for each item in the list.
 
-ruler:
-  remote_write:
-    client: "Use clients instead."
-
 index_gateway:
   ring:
     replication_factor: "Use global or per-tenant index_gateway_shard_size configuration from limits_config."

--- a/tools/deprecated-config-checker/test-fixtures/config.yaml
+++ b/tools/deprecated-config-checker/test-fixtures/config.yaml
@@ -59,7 +59,7 @@ ruler:
     s3: *s3_cfg
   remote_write:
     enabled: true
-    client: # DEPRECATED
+    client: # DELETED
       url: "http://localhost:3100/api/prom/push"
 
 storage_config:


### PR DESCRIPTION
### Summary

The single 'client' remote-write option has been deprecated in favor of the 'clients' map. Removing it drops the backward-compatibility handling and simplifies config validation and cloning.
