### PR TITLE
feat(indexgateway): Reject requests under CPU/memory saturation and back off client retries

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3974,6 +3974,23 @@ ring:
   # Enable using a IPv6 instance address.
   # CLI flag: -index-gateway.ring.instance-enable-ipv6
   [instance_enable_ipv6: <boolean> | default = false]
+
+# Experimental: CPU utilization, in cores, above which the index gateway starts
+# rejecting requests. The utilization is computed as a moving average over a 60s
+# sliding window, and limiting only starts after a 60s warmup on startup. 0 to
+# disable.
+# CLI flag: -index-gateway.cpu-utilization-limit
+[cpu_utilization_limit: <float> | default = 0]
+
+# Experimental: Go heap size above which the index gateway starts rejecting
+# requests, e.g. 24GiB. 0 to disable.
+# CLI flag: -index-gateway.memory-utilization-limit
+[memory_utilization_limit: <int> | default = 0B]
+
+# Experimental: Log the CPU utilization samples backing the utilization based
+# limiter's moving average when limiting starts or stops.
+# CLI flag: -index-gateway.log-utilization-samples
+[log_utilization_samples: <boolean> | default = false]
 ```
 
 ### ingester
@@ -6902,6 +6919,18 @@ tsdb_shipper:
     # Only applies to simple mode.
     # CLI flag: -tsdb.shipper.index-gateway-client.min-shuffle-shard-size
     [min_shuffle_shard_size: <int> | default = 3]
+
+    # Experimental: Minimum delay before retrying on another index gateway after
+    # a request was rejected because the gateway is saturated. The delay grows
+    # exponentially, with jitter, up to the max period. Requests rejected for
+    # other reasons are retried on another gateway without delay.
+    # CLI flag: -tsdb.shipper.index-gateway-client.saturation-backoff-min-period
+    [saturation_backoff_min_period: <duration> | default = 250ms]
+
+    # Experimental: Maximum delay before retrying on another index gateway after
+    # a request was rejected because the gateway is saturated.
+    # CLI flag: -tsdb.shipper.index-gateway-client.saturation-backoff-max-period
+    [saturation_backoff_max_period: <duration> | default = 2s]
 
   [ingestername: <string> | default = ""]
 

--- a/go.mod
+++ b/go.mod
@@ -392,7 +392,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/exporter-toolkit v0.17.1 // indirect
-	github.com/prometheus/procfs v0.21.0 // indirect
+	github.com/prometheus/procfs v0.21.0
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect

--- a/pkg/indexgateway/client.go
+++ b/pkg/indexgateway/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cespare/xxhash/v2"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/instrument"
@@ -80,6 +81,14 @@ type ClientConfig struct {
 	// MinShuffleShardSize is the minimum number of index gateway instances included in the
 	// shuffle shard, regardless of the max-capacity setting. Only applies to simple mode.
 	MinShuffleShardSize int `yaml:"min_shuffle_shard_size"`
+
+	// SaturationBackoffMinPeriod is the minimum delay before retrying on another index
+	// gateway after a request was rejected because the gateway is saturated.
+	SaturationBackoffMinPeriod time.Duration `yaml:"saturation_backoff_min_period" category:"experimental"`
+
+	// SaturationBackoffMaxPeriod is the maximum delay before retrying on another index
+	// gateway after a request was rejected because the gateway is saturated.
+	SaturationBackoffMaxPeriod time.Duration `yaml:"saturation_backoff_max_period" category:"experimental"`
 }
 
 // RegisterFlagsWithPrefix register client-specific flags with the given prefix.
@@ -97,6 +106,8 @@ func (i *ClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 		"Experimental: Defines buckets for time-based sharding. Time based sharding only takes affect when index gateways run in simple mode. To enable client side time-based sharding of queries across index gateway instances set at least one bucket in the format of a string representation of a time.Duration, e.g. ['168h', '336h', '504h']",
 	)
 	f.IntVar(&i.MinShuffleShardSize, prefix+".min-shuffle-shard-size", 3, "Minimum number of index gateway instances included in the shuffle shard, regardless of the max-capacity setting. A value of 0 disables the minimum. Only applies to simple mode.")
+	f.DurationVar(&i.SaturationBackoffMinPeriod, prefix+".saturation-backoff-min-period", 250*time.Millisecond, "Experimental: Minimum delay before retrying on another index gateway after a request was rejected because the gateway is saturated. The delay grows exponentially, with jitter, up to the max period. Requests rejected for other reasons are retried on another gateway without delay.")
+	f.DurationVar(&i.SaturationBackoffMaxPeriod, prefix+".saturation-backoff-max-period", 2*time.Second, "Experimental: Maximum delay before retrying on another index gateway after a request was rejected because the gateway is saturated.")
 }
 
 func (i *ClientConfig) RegisterFlags(f *flag.FlagSet) {
@@ -412,6 +423,16 @@ func (s *GatewayClient) poolDo(
 		addrs[i], addrs[j] = addrs[j], addrs[i]
 	})
 
+	// Saturation rejections back off before retrying on another gateway: the other
+	// gateways are likely under pressure too, and pacing retries avoids a retry storm
+	// while the autoscaler adds replicas. Other errors keep retrying immediately.
+	// MaxRetries is left 0 (unlimited) as attempts are already bounded by the address
+	// list and maxRetries.
+	saturationBackoff := backoff.New(ctx, backoff.Config{
+		MinBackoff: s.cfg.SaturationBackoffMinPeriod,
+		MaxBackoff: s.cfg.SaturationBackoffMaxPeriod,
+	})
+
 	errCount := 0
 	var lastErr error
 	for _, addr := range addrs {
@@ -434,6 +455,13 @@ func (s *GatewayClient) poolDo(
 			if maxRetries >= 0 && errCount > maxRetries {
 				s.retriesHistogram.WithLabelValues("failure").Observe(float64(errCount))
 				return err
+			}
+			if IsSaturatedError(err) {
+				saturationBackoff.Wait()
+				if saturationBackoff.Err() != nil {
+					s.retriesHistogram.WithLabelValues("failure").Observe(float64(errCount))
+					return lastErr
+				}
 			}
 			continue
 		}

--- a/pkg/indexgateway/client.go
+++ b/pkg/indexgateway/client.go
@@ -3,6 +3,7 @@ package indexgateway
 import (
 	"cmp"
 	"context"
+	stderrors "errors"
 	"flag"
 	"fmt"
 	"io"
@@ -458,9 +459,11 @@ func (s *GatewayClient) poolDo(
 			}
 			if IsSaturatedError(err) {
 				saturationBackoff.Wait()
-				if saturationBackoff.Err() != nil {
+				if backoffErr := saturationBackoff.Err(); backoffErr != nil {
 					s.retriesHistogram.WithLabelValues("failure").Observe(float64(errCount))
-					return lastErr
+					// Return both errors so callers can still tell the request was
+					// aborted by its context rather than by gateway saturation alone.
+					return stderrors.Join(lastErr, backoffErr)
 				}
 			}
 			continue

--- a/pkg/indexgateway/client.go
+++ b/pkg/indexgateway/client.go
@@ -3,7 +3,6 @@ package indexgateway
 import (
 	"cmp"
 	"context"
-	stderrors "errors"
 	"flag"
 	"fmt"
 	"io"
@@ -461,9 +460,9 @@ func (s *GatewayClient) poolDo(
 				saturationBackoff.Wait()
 				if backoffErr := saturationBackoff.Err(); backoffErr != nil {
 					s.retriesHistogram.WithLabelValues("failure").Observe(float64(errCount))
-					// Return both errors so callers can still tell the request was
-					// aborted by its context rather than by gateway saturation alone.
-					return stderrors.Join(lastErr, backoffErr)
+					// The request context ended during the wait: report that instead of
+					// the saturation, which is already logged above per attempt.
+					return backoffErr
 				}
 			}
 			continue

--- a/pkg/indexgateway/client_test.go
+++ b/pkg/indexgateway/client_test.go
@@ -347,8 +347,8 @@ func TestGatewayClient_SaturationBackoff(t *testing.T) {
 	t.Run("respects context cancellation while backing off", func(t *testing.T) {
 		// Backoff periods well past the context deadline so the wait is always
 		// interrupted by the deadline rather than completing.
-		client.cfg.SaturationBackoffMinPeriod = 100 * time.Millisecond
-		client.cfg.SaturationBackoffMaxPeriod = time.Second
+		client.cfg.SaturationBackoffMinPeriod = time.Second
+		client.cfg.SaturationBackoffMaxPeriod = 2 * time.Second
 		configurePoolWithError(t, client, logger, 10, newSaturatedError("cpu"))
 		ctx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
 		defer cancel()
@@ -359,8 +359,9 @@ func TestGatewayClient_SaturationBackoff(t *testing.T) {
 		// The context error is preserved so callers can tell the request was aborted
 		// by its deadline rather than by saturation alone.
 		require.ErrorIs(t, err, context.DeadlineExceeded)
-		// Returns promptly after the context deadline instead of walking the full backoff ladder.
-		require.Less(t, time.Since(start), time.Second)
+		// Finishing before a single backoff period could elapse proves the deadline
+		// interrupted the wait instead of it running to completion.
+		require.Less(t, time.Since(start), client.cfg.SaturationBackoffMinPeriod)
 	})
 }
 

--- a/pkg/indexgateway/client_test.go
+++ b/pkg/indexgateway/client_test.go
@@ -347,6 +347,9 @@ func TestGatewayClient_SaturationBackoff(t *testing.T) {
 		_, err := client.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
 		require.Error(t, err)
 		require.True(t, IsSaturatedError(err))
+		// The context error is preserved so callers can tell the request was aborted
+		// by its deadline rather than by saturation alone.
+		require.ErrorIs(t, err, context.DeadlineExceeded)
 		// Returns promptly after the context deadline instead of walking the full backoff ladder.
 		require.Less(t, time.Since(start), time.Second)
 	})

--- a/pkg/indexgateway/client_test.go
+++ b/pkg/indexgateway/client_test.go
@@ -354,10 +354,8 @@ func TestGatewayClient_SaturationBackoff(t *testing.T) {
 		defer cancel()
 		start := time.Now()
 		_, err := client.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
-		require.Error(t, err)
-		require.True(t, IsSaturatedError(err))
-		// The context error is preserved so callers can tell the request was aborted
-		// by its deadline rather than by saturation alone.
+		// The deadline ended the request, so that is what gets reported; the
+		// saturation is an internal retry-pacing detail.
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 		// Finishing before a single backoff period could elapse proves the deadline
 		// interrupted the wait instead of it running to completion.

--- a/pkg/indexgateway/client_test.go
+++ b/pkg/indexgateway/client_test.go
@@ -58,18 +58,26 @@ type mockGatewayConn struct {
 	logproto.IndexGatewayClient
 	grpc_health_v1.HealthClient
 	returnErrors bool
+	err          error
+}
+
+func (m *mockGatewayConn) callErr() error {
+	if m.err != nil {
+		return m.err
+	}
+	return errors.New("mock error")
 }
 
 func (m *mockGatewayConn) GetChunkRef(context.Context, *logproto.GetChunkRefRequest, ...grpc.CallOption) (*logproto.GetChunkRefResponse, error) {
 	if m.returnErrors {
-		return nil, errors.New("mock error")
+		return nil, m.callErr()
 	}
 	return &logproto.GetChunkRefResponse{}, nil
 }
 
 func (m *mockGatewayConn) GetShards(_ context.Context, _ *logproto.ShardsRequest, _ ...grpc.CallOption) (logproto.IndexGateway_GetShardsClient, error) {
 	if m.returnErrors {
-		return nil, errors.New("mock error")
+		return nil, m.callErr()
 	}
 	return &mockShardsClient{}, nil
 }
@@ -240,6 +248,10 @@ func createSimpleGatewayClient(t *testing.T, addrs []string) (log.Logger, *dskit
 }
 
 func configurePool(t *testing.T, client *GatewayClient, logger log.Logger, numErrorsToReturn int) *dskitclient.Pool {
+	return configurePoolWithError(t, client, logger, numErrorsToReturn, nil)
+}
+
+func configurePoolWithError(t *testing.T, client *GatewayClient, logger log.Logger, numErrorsToReturn int, errToReturn error) *dskitclient.Pool {
 	pool := dskitclient.NewPool(
 		"test",
 		dskitclient.PoolConfig{CheckInterval: time.Hour},
@@ -252,7 +264,7 @@ func configurePool(t *testing.T, client *GatewayClient, logger log.Logger, numEr
 			} else {
 				returnErrors = false
 			}
-			return &mockGatewayConn{returnErrors: returnErrors}, nil
+			return &mockGatewayConn{returnErrors: returnErrors, err: errToReturn}, nil
 		}),
 		nil, logger,
 	)
@@ -299,6 +311,45 @@ func TestGatewayClient_SimpleMode_OtherMethods(t *testing.T) {
 	configurePool(t, client, logger, 10)
 	_, err := client.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
 	require.Error(t, err)
+}
+
+func TestGatewayClient_SaturationBackoff(t *testing.T) {
+	logger, _, client := createSimpleGatewayClient(t, []string{
+		"0.0.0.0", "1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4",
+		"5.5.5.5", "6.6.6.6", "7.7.7.7", "8.8.8.8", "9.9.9.9",
+	})
+	client.cfg.SaturationBackoffMinPeriod = 50 * time.Millisecond
+	client.cfg.SaturationBackoffMaxPeriod = 100 * time.Millisecond
+	ctx := user.InjectOrgID(context.Background(), "tenant-123")
+
+	t.Run("waits between attempts on saturated gateways", func(t *testing.T) {
+		configurePoolWithError(t, client, logger, 2, newSaturatedError("cpu"))
+		start := time.Now()
+		_, err := client.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
+		require.NoError(t, err)
+		// Each of the two saturated attempts waits at least the min backoff period.
+		require.GreaterOrEqual(t, time.Since(start), 2*client.cfg.SaturationBackoffMinPeriod)
+	})
+
+	t.Run("non-saturation errors keep immediate failover", func(t *testing.T) {
+		configurePool(t, client, logger, 5)
+		start := time.Now()
+		_, err := client.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
+		require.NoError(t, err)
+		require.Less(t, time.Since(start), client.cfg.SaturationBackoffMinPeriod)
+	})
+
+	t.Run("respects context cancellation while backing off", func(t *testing.T) {
+		configurePoolWithError(t, client, logger, 10, newSaturatedError("cpu"))
+		ctx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+		defer cancel()
+		start := time.Now()
+		_, err := client.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
+		require.Error(t, err)
+		require.True(t, IsSaturatedError(err))
+		// Returns promptly after the context deadline instead of walking the full backoff ladder.
+		require.Less(t, time.Since(start), time.Second)
+	})
 }
 
 func TestGatewayClient_SimpleMode_ShuffleSharding(t *testing.T) {

--- a/pkg/indexgateway/client_test.go
+++ b/pkg/indexgateway/client_test.go
@@ -318,11 +318,11 @@ func TestGatewayClient_SaturationBackoff(t *testing.T) {
 		"0.0.0.0", "1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4",
 		"5.5.5.5", "6.6.6.6", "7.7.7.7", "8.8.8.8", "9.9.9.9",
 	})
-	client.cfg.SaturationBackoffMinPeriod = 50 * time.Millisecond
-	client.cfg.SaturationBackoffMaxPeriod = 100 * time.Millisecond
 	ctx := user.InjectOrgID(context.Background(), "tenant-123")
 
 	t.Run("waits between attempts on saturated gateways", func(t *testing.T) {
+		client.cfg.SaturationBackoffMinPeriod = 50 * time.Millisecond
+		client.cfg.SaturationBackoffMaxPeriod = 100 * time.Millisecond
 		configurePoolWithError(t, client, logger, 2, newSaturatedError("cpu"))
 		start := time.Now()
 		_, err := client.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
@@ -332,6 +332,11 @@ func TestGatewayClient_SaturationBackoff(t *testing.T) {
 	})
 
 	t.Run("non-saturation errors keep immediate failover", func(t *testing.T) {
+		// Generous periods so the fast-path upper-bound assertion below is not
+		// sensitive to CI scheduling jitter. The fast path never sleeps, so this
+		// does not slow down the test.
+		client.cfg.SaturationBackoffMinPeriod = 500 * time.Millisecond
+		client.cfg.SaturationBackoffMaxPeriod = time.Second
 		configurePool(t, client, logger, 5)
 		start := time.Now()
 		_, err := client.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
@@ -340,6 +345,10 @@ func TestGatewayClient_SaturationBackoff(t *testing.T) {
 	})
 
 	t.Run("respects context cancellation while backing off", func(t *testing.T) {
+		// Backoff periods well past the context deadline so the wait is always
+		// interrupted by the deadline rather than completing.
+		client.cfg.SaturationBackoffMinPeriod = 100 * time.Millisecond
+		client.cfg.SaturationBackoffMaxPeriod = time.Second
 		configurePoolWithError(t, client, logger, 10, newSaturatedError("cpu"))
 		ctx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
 		defer cancel()

--- a/pkg/indexgateway/config.go
+++ b/pkg/indexgateway/config.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/grafana/dskit/flagext"
 	"github.com/pkg/errors"
 
 	"github.com/grafana/loki/v3/pkg/util/ring"
@@ -64,6 +65,18 @@ type Config struct {
 	// In case it isn't explicitly set, it follows the same behavior of the other rings (ex: using the common configuration
 	// section and the ingester configuration by default).
 	Ring ring.RingConfig `yaml:"ring,omitempty" doc:"description=Defines the ring to be used by the index gateway servers and clients in case the servers are configured to run in 'ring' mode. In case this isn't configured, this block supports inheriting configuration from the common ring section."`
+
+	// CPUUtilizationLimit is the CPU utilization, in cores, above which the index gateway
+	// starts rejecting requests. 0 disables CPU utilization based limiting.
+	CPUUtilizationLimit float64 `yaml:"cpu_utilization_limit" category:"experimental"`
+
+	// MemoryUtilizationLimit is the Go heap size, in bytes, above which the index gateway
+	// starts rejecting requests. 0 disables memory utilization based limiting.
+	MemoryUtilizationLimit flagext.Bytes `yaml:"memory_utilization_limit" category:"experimental"`
+
+	// LogUtilizationSamples enables logging of the CPU samples backing the utilization
+	// moving average when limiting kicks in or stops.
+	LogUtilizationSamples bool `yaml:"log_utilization_samples" category:"experimental"`
 }
 
 // RegisterFlags register all IndexGatewayClientConfig flags and all the flags of its subconfigs but with a prefix (ex: shipper).
@@ -83,11 +96,23 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	// multiple Index Gateway instances are expected to be returned as Index Gateway might be busy/locked for specific
 	// reasons (this is assured by the spikey behavior of Index Gateway latencies).
 	f.IntVar(&cfg.Ring.ReplicationFactor, "replication-factor", ReplicationFactor, "Deprecated: How many index gateway instances are assigned to each tenant. Use -index-gateway.shard-size instead. The shard size is also a per-tenant setting.")
+
+	f.Float64Var(&cfg.CPUUtilizationLimit, "index-gateway.cpu-utilization-limit", 0, "Experimental: CPU utilization, in cores, above which the index gateway starts rejecting requests. The utilization is computed as a moving average over a 60s sliding window, and limiting only starts after a 60s warmup on startup. 0 to disable.")
+	f.Var(&cfg.MemoryUtilizationLimit, "index-gateway.memory-utilization-limit", "Experimental: Go heap size above which the index gateway starts rejecting requests, e.g. 24GiB. 0 to disable.")
+	f.BoolVar(&cfg.LogUtilizationSamples, "index-gateway.log-utilization-samples", false, "Experimental: Log the CPU utilization samples backing the utilization based limiter's moving average when limiting starts or stops.")
+}
+
+// UtilizationLimiterEnabled returns whether requests should be rejected based on resource utilization.
+func (cfg *Config) UtilizationLimiterEnabled() bool {
+	return cfg.CPUUtilizationLimit > 0 || cfg.MemoryUtilizationLimit > 0
 }
 
 func (cfg *Config) Validate() error {
 	if cfg.Ring.NumTokens != NumTokens {
 		return errors.New("Num tokens must not be changed as it will not take effect")
+	}
+	if cfg.CPUUtilizationLimit < 0 {
+		return errors.New("index gateway CPU utilization limit must not be negative")
 	}
 	return nil
 }

--- a/pkg/indexgateway/config.go
+++ b/pkg/indexgateway/config.go
@@ -3,6 +3,7 @@ package indexgateway
 import (
 	"flag"
 	"fmt"
+	"math"
 
 	"github.com/grafana/dskit/flagext"
 	"github.com/pkg/errors"
@@ -113,6 +114,11 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.CPUUtilizationLimit < 0 {
 		return errors.New("index gateway CPU utilization limit must not be negative")
+	}
+	// flagext.Bytes accepts negative inputs (e.g. -1GiB) and wraps them around to huge
+	// values that would silently never trigger limiting.
+	if uint64(cfg.MemoryUtilizationLimit) > math.MaxInt64 {
+		return errors.New("index gateway memory utilization limit must not be negative")
 	}
 	return nil
 }

--- a/pkg/indexgateway/grpc.go
+++ b/pkg/indexgateway/grpc.go
@@ -2,6 +2,7 @@ package indexgateway
 
 import (
 	"context"
+	"strings"
 
 	"github.com/grafana/dskit/tenant"
 	"github.com/prometheus/client_golang/prometheus"
@@ -10,6 +11,56 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/util/constants"
 )
+
+// indexGatewayServicePrefix is the gRPC method prefix of the IndexGateway service. The
+// saturation check interceptors only apply to these methods, so other services sharing
+// the same gRPC server (e.g. in single-binary mode) are unaffected.
+const indexGatewayServicePrefix = "/indexgatewaypb.IndexGateway/"
+
+// utilizationChecker is satisfied by limiter.UtilizationBasedLimiter.
+type utilizationChecker interface {
+	// LimitingReason returns a non-empty reason when requests should be rejected.
+	LimitingReason() string
+}
+
+// NewSaturationCheckInterceptors returns gRPC interceptors that reject IndexGateway
+// requests with a saturation error while checker reports a limiting reason.
+func NewSaturationCheckInterceptors(r prometheus.Registerer, checker utilizationChecker) (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor) {
+	limitedRequests := promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		Namespace: constants.Loki,
+		Subsystem: "index_gateway",
+		Name:      "utilization_limited_requests_total",
+		Help:      "Total number of requests rejected by the index gateway because of resource utilization based limiting.",
+	}, []string{"reason"})
+
+	check := func(fullMethod string) error {
+		if !strings.HasPrefix(fullMethod, indexGatewayServicePrefix) {
+			return nil
+		}
+		reason := checker.LimitingReason()
+		if reason == "" {
+			return nil
+		}
+		limitedRequests.WithLabelValues(reason).Inc()
+		return newSaturatedError(reason)
+	}
+
+	unary := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if err := check(info.FullMethod); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+
+	stream := func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := check(info.FullMethod); err != nil {
+			return err
+		}
+		return handler(srv, ss)
+	}
+
+	return unary, stream
+}
 
 type ServerInterceptors struct {
 	reqCount              *prometheus.CounterVec
@@ -24,7 +75,7 @@ func NewServerInterceptors(r prometheus.Registerer) *ServerInterceptors {
 		Help:      "Total amount of requests served by the index gateway",
 	}, []string{"operation", "status", "tenant"})
 
-	perTenantRequestCount := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	perTenantRequestCount := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 		tenantID, err := tenant.TenantID(ctx)
 		if err != nil {
 			// ignore requests without tenantID

--- a/pkg/indexgateway/grpc_test.go
+++ b/pkg/indexgateway/grpc_test.go
@@ -1,0 +1,127 @@
+package indexgateway
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+)
+
+type fakeUtilizationChecker struct {
+	reason string
+}
+
+func (c *fakeUtilizationChecker) LimitingReason() string {
+	return c.reason
+}
+
+func TestSaturationCheckInterceptors(t *testing.T) {
+	const (
+		unaryMethod    = "/indexgatewaypb.IndexGateway/GetChunkRef"
+		streamMethod   = "/indexgatewaypb.IndexGateway/GetShards"
+		externalMethod = "/logproto.Querier/Query"
+	)
+
+	setup := func(reason string) (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor, prometheus.Gatherer) {
+		reg := prometheus.NewPedanticRegistry()
+		unary, stream := NewSaturationCheckInterceptors(reg, &fakeUtilizationChecker{reason: reason})
+		return unary, stream, reg
+	}
+
+	requireLimitedRequests := func(t *testing.T, reg prometheus.Gatherer, expected string) {
+		t.Helper()
+		require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(expected),
+			"loki_index_gateway_utilization_limited_requests_total"))
+	}
+
+	t.Run("requests pass through when not limiting", func(t *testing.T) {
+		unary, stream, reg := setup("")
+
+		unaryCalled := false
+		resp, err := unary(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: unaryMethod},
+			func(context.Context, any) (any, error) {
+				unaryCalled = true
+				return "response", nil
+			})
+		require.NoError(t, err)
+		require.Equal(t, "response", resp)
+		require.True(t, unaryCalled)
+
+		streamCalled := false
+		err = stream(nil, nil, &grpc.StreamServerInfo{FullMethod: streamMethod},
+			func(any, grpc.ServerStream) error {
+				streamCalled = true
+				return nil
+			})
+		require.NoError(t, err)
+		require.True(t, streamCalled)
+
+		requireLimitedRequests(t, reg, "")
+	})
+
+	t.Run("unary requests are rejected when limiting", func(t *testing.T) {
+		unary, _, reg := setup("cpu")
+
+		resp, err := unary(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: unaryMethod},
+			func(context.Context, any) (any, error) {
+				t.Fatal("handler should not be invoked")
+				return nil, nil
+			})
+		require.Nil(t, resp)
+		require.True(t, IsSaturatedError(err))
+		require.Equal(t, saturationStatusCode, status.Code(err))
+
+		requireLimitedRequests(t, reg, `
+			# HELP loki_index_gateway_utilization_limited_requests_total Total number of requests rejected by the index gateway because of resource utilization based limiting.
+			# TYPE loki_index_gateway_utilization_limited_requests_total counter
+			loki_index_gateway_utilization_limited_requests_total{reason="cpu"} 1
+		`)
+	})
+
+	t.Run("stream requests are rejected when limiting", func(t *testing.T) {
+		_, stream, reg := setup("memory")
+
+		err := stream(nil, nil, &grpc.StreamServerInfo{FullMethod: streamMethod},
+			func(any, grpc.ServerStream) error {
+				t.Fatal("handler should not be invoked")
+				return nil
+			})
+		require.True(t, IsSaturatedError(err))
+		require.Equal(t, saturationStatusCode, status.Code(err))
+
+		requireLimitedRequests(t, reg, `
+			# HELP loki_index_gateway_utilization_limited_requests_total Total number of requests rejected by the index gateway because of resource utilization based limiting.
+			# TYPE loki_index_gateway_utilization_limited_requests_total counter
+			loki_index_gateway_utilization_limited_requests_total{reason="memory"} 1
+		`)
+	})
+
+	t.Run("other services are not affected by limiting", func(t *testing.T) {
+		unary, stream, reg := setup("cpu")
+
+		unaryCalled := false
+		_, err := unary(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: externalMethod},
+			func(context.Context, any) (any, error) {
+				unaryCalled = true
+				return nil, nil
+			})
+		require.NoError(t, err)
+		require.True(t, unaryCalled)
+
+		streamCalled := false
+		err = stream(nil, nil, &grpc.StreamServerInfo{FullMethod: externalMethod},
+			func(any, grpc.ServerStream) error {
+				streamCalled = true
+				return nil
+			})
+		require.NoError(t, err)
+		require.True(t, streamCalled)
+
+		requireLimitedRequests(t, reg, "")
+	})
+}

--- a/pkg/indexgateway/saturation.go
+++ b/pkg/indexgateway/saturation.go
@@ -12,9 +12,10 @@ import (
 // problem, not the client's fault, and the request is safe to retry elsewhere.
 const saturationStatusCode = codes.Unavailable
 
-// saturatedErrMessage identifies saturation rejections. Clients match on the message
-// rather than the status code, since Unavailable is also returned for connection-level
-// failures.
+// saturatedErrMessage identifies saturation rejections. Clients match on both the
+// status code and the message: Unavailable alone is ambiguous since it is also
+// returned for connection-level failures, and the message alone could collide with
+// unrelated errors that happen to contain it.
 const saturatedErrMessage = "index gateway is saturated"
 
 func newSaturatedError(reason string) error {
@@ -25,5 +26,5 @@ func newSaturatedError(reason string) error {
 // saturated index gateway.
 func IsSaturatedError(err error) bool {
 	s, ok := status.FromError(err)
-	return ok && strings.Contains(s.Message(), saturatedErrMessage)
+	return ok && s.Code() == saturationStatusCode && strings.Contains(s.Message(), saturatedErrMessage)
 }

--- a/pkg/indexgateway/saturation.go
+++ b/pkg/indexgateway/saturation.go
@@ -1,0 +1,29 @@
+package indexgateway
+
+import (
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// saturationStatusCode is returned when the gateway rejects a request because it is
+// saturated. Unavailable carries 503 semantics: the rejection is the server's capacity
+// problem, not the client's fault, and the request is safe to retry elsewhere.
+const saturationStatusCode = codes.Unavailable
+
+// saturatedErrMessage identifies saturation rejections. Clients match on the message
+// rather than the status code, since Unavailable is also returned for connection-level
+// failures.
+const saturatedErrMessage = "index gateway is saturated"
+
+func newSaturatedError(reason string) error {
+	return status.Errorf(saturationStatusCode, "%s (limiting reason: %s), please retry on another instance", saturatedErrMessage, reason)
+}
+
+// IsSaturatedError reports whether err (possibly wrapped) is a rejection from a
+// saturated index gateway.
+func IsSaturatedError(err error) bool {
+	s, ok := status.FromError(err)
+	return ok && strings.Contains(s.Message(), saturatedErrMessage)
+}

--- a/pkg/indexgateway/saturation_test.go
+++ b/pkg/indexgateway/saturation_test.go
@@ -44,7 +44,7 @@ func TestIsSaturatedError(t *testing.T) {
 		{
 			name:     "different status code, same message",
 			err:      status.Error(codes.ResourceExhausted, saturatedErrMessage),
-			expected: true,
+			expected: false,
 		},
 		{
 			name:     "context canceled",

--- a/pkg/indexgateway/saturation_test.go
+++ b/pkg/indexgateway/saturation_test.go
@@ -1,0 +1,64 @@
+package indexgateway
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsSaturatedError(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "saturated error",
+			err:      newSaturatedError("cpu"),
+			expected: true,
+		},
+		{
+			name:     "wrapped saturated error",
+			err:      errors.Wrap(newSaturatedError("cpu"), "get shards"),
+			expected: true,
+		},
+		{
+			name:     "saturated error with stack",
+			err:      errors.WithStack(newSaturatedError("memory")),
+			expected: true,
+		},
+		{
+			name:     "plain error",
+			err:      errors.New("mock error"),
+			expected: false,
+		},
+		{
+			name:     "same status code, different message",
+			err:      status.Error(saturationStatusCode, "connection refused"),
+			expected: false,
+		},
+		{
+			name:     "different status code, same message",
+			err:      status.Error(codes.ResourceExhausted, saturatedErrMessage),
+			expected: true,
+		},
+		{
+			name:     "context canceled",
+			err:      context.Canceled,
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, IsSaturatedError(tc.err))
+		})
+	}
+}

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1955,11 +1955,31 @@ func (t *Loki) initIndexGatewayRing() (_ services.Service, err error) {
 
 func (t *Loki) initIndexGatewayInterceptors() (services.Service, error) {
 	// Only expose per-tenant metric if index gateway runs as standalone service
-	if t.Cfg.isTarget(IndexGateway) {
-		interceptors := indexgateway.NewServerInterceptors(prometheus.DefaultRegisterer)
-		t.Cfg.Server.GRPCMiddleware = append(t.Cfg.Server.GRPCMiddleware, interceptors.PerTenantRequestCount)
+	if !t.Cfg.isTarget(IndexGateway) {
+		return nil, nil
 	}
-	return nil, nil
+
+	interceptors := indexgateway.NewServerInterceptors(prometheus.DefaultRegisterer)
+	t.Cfg.Server.GRPCMiddleware = append(t.Cfg.Server.GRPCMiddleware, interceptors.PerTenantRequestCount)
+
+	if !t.Cfg.IndexGateway.UtilizationLimiterEnabled() {
+		return nil, nil
+	}
+
+	// The limiter is returned as this module's service so its utilization sampling runs
+	// for the process lifetime. Until it is running (and during its warmup window),
+	// LimitingReason returns an empty string, so the interceptors fail open.
+	utilizationLimiter := limiter.NewUtilizationBasedLimiter(
+		t.Cfg.IndexGateway.CPUUtilizationLimit,
+		uint64(t.Cfg.IndexGateway.MemoryUtilizationLimit),
+		t.Cfg.IndexGateway.LogUtilizationSamples,
+		log.With(util_log.Logger, "component", "index-gateway"),
+		prometheus.DefaultRegisterer,
+	)
+	unary, stream := indexgateway.NewSaturationCheckInterceptors(prometheus.DefaultRegisterer, utilizationLimiter)
+	t.Cfg.Server.GRPCMiddleware = append(t.Cfg.Server.GRPCMiddleware, unary)
+	t.Cfg.Server.GRPCStreamMiddleware = append(t.Cfg.Server.GRPCStreamMiddleware, stream)
+	return utilizationLimiter, nil
 }
 
 func (t *Loki) initBloomPlanner() (services.Service, error) {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1974,7 +1974,8 @@ func (t *Loki) initIndexGatewayInterceptors() (services.Service, error) {
 		uint64(t.Cfg.IndexGateway.MemoryUtilizationLimit),
 		t.Cfg.IndexGateway.LogUtilizationSamples,
 		log.With(util_log.Logger, "component", "index-gateway"),
-		prometheus.DefaultRegisterer,
+		// The limiter registers its gauges without any prefix, prepend the component one.
+		prometheus.WrapRegistererWithPrefix(constants.Loki+"_index_gateway_", prometheus.DefaultRegisterer),
 	)
 	unary, stream := indexgateway.NewSaturationCheckInterceptors(prometheus.DefaultRegisterer, utilizationLimiter)
 	t.Cfg.Server.GRPCMiddleware = append(t.Cfg.Server.GRPCMiddleware, unary)

--- a/pkg/util/limiter/utilization.go
+++ b/pkg/util/limiter/utilization.go
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/grafana/mimir/blob/main/pkg/util/limiter/utilization.go
+// Provenance-includes-license: AGPL-3.0-only
+// Provenance-includes-copyright: The Mimir Authors.
+
+package limiter
+
+import (
+	"context"
+	"fmt"
+	"runtime/metrics"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/procfs"
+	"go.uber.org/atomic"
+
+	"github.com/grafana/loki/v3/pkg/util/math"
+)
+
+const (
+	// Interval for updating resource (CPU/memory) utilization.
+	resourceUtilizationUpdateInterval = time.Second
+
+	// How long is the sliding window used to compute the moving average.
+	resourceUtilizationSlidingWindow = 60 * time.Second
+)
+
+type utilizationScanner interface {
+	// Scan returns CPU time in seconds and Go heap size in bytes, or an error.
+	Scan() (float64, uint64, error)
+}
+
+// combinedScanner scans /proc for CPU utilization and Go runtime for heap size.
+type combinedScanner struct {
+	proc              procfs.Proc
+	memoryTotalSample []metrics.Sample
+}
+
+func (s combinedScanner) Scan() (float64, uint64, error) {
+	ps, err := s.proc.Stat()
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get process stats: %w", err)
+	}
+
+	metrics.Read(s.memoryTotalSample)
+
+	return ps.CPUTime(), s.memoryTotalSample[0].Value.Uint64(), nil
+}
+
+func newCombinedScanner() (combinedScanner, error) {
+	p, err := procfs.Self()
+	return combinedScanner{
+		proc:              p,
+		memoryTotalSample: []metrics.Sample{{Name: "/memory/classes/heap/objects:bytes"}},
+	}, err
+}
+
+// UtilizationBasedLimiter is a Service offering limiting based on CPU and memory utilization.
+//
+// The respective CPU and memory utilization limits are configurable.
+type UtilizationBasedLimiter struct {
+	services.Service
+
+	logger             log.Logger
+	utilizationScanner utilizationScanner
+
+	// Memory limit in bytes. The limit is enabled if the value is > 0.
+	memoryLimit uint64
+	// CPU limit in cores. The limit is enabled if the value is > 0.
+	cpuLimit float64
+	// Last CPU utilization time counter.
+	lastCPUTime float64
+	// The time of the first CPU update.
+	firstCPUUpdate time.Time
+	// The time of the last CPU update.
+	lastCPUUpdate  time.Time
+	cpuMovingAvg   *math.EwmaRate
+	limitingReason atomic.String
+	currCPUUtil    atomic.Float64
+	currHeapSize   atomic.Uint64
+	// For logging of input to CPU load EWMA calculation, keep window of source samples
+	cpuSamples *cpuSampleBuffer
+}
+
+// NewUtilizationBasedLimiter returns a UtilizationBasedLimiter configured with cpuLimit and memoryLimit.
+func NewUtilizationBasedLimiter(cpuLimit float64, memoryLimit uint64, logCPUSamples bool, logger log.Logger,
+	reg prometheus.Registerer) *UtilizationBasedLimiter {
+	// Calculate alpha for a minute long window
+	// https://github.com/VividCortex/ewma#choosing-alpha
+	alpha := 2 / (resourceUtilizationSlidingWindow.Seconds()/resourceUtilizationUpdateInterval.Seconds() + 1)
+	var cpuSamples *cpuSampleBuffer
+	if logCPUSamples {
+		cpuSamples = newCPUSampleBuffer(int(resourceUtilizationSlidingWindow.Seconds()))
+	}
+	l := &UtilizationBasedLimiter{
+		logger:      logger,
+		cpuLimit:    cpuLimit,
+		memoryLimit: memoryLimit,
+		// Use a minute long window, each sample being a second apart
+		cpuMovingAvg: math.NewEWMARate(alpha, resourceUtilizationUpdateInterval),
+		cpuSamples:   cpuSamples,
+	}
+	l.Service = services.NewTimerService(resourceUtilizationUpdateInterval, l.starting, l.update, nil)
+
+	if reg != nil {
+		promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "utilization_limiter_current_cpu_load",
+			Help: "Current average CPU load calculated by utilization based limiter.",
+		}, func() float64 {
+			return l.currCPUUtil.Load()
+		})
+		promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "utilization_limiter_current_memory_usage_bytes",
+			Help: "Current memory usage calculated by utilization based limiter.",
+		}, func() float64 {
+			return float64(l.currHeapSize.Load())
+		})
+	}
+
+	return l
+}
+
+// LimitingReason returns the current reason for limiting, if any.
+// If an empty string is returned, limiting is disabled.
+func (l *UtilizationBasedLimiter) LimitingReason() string {
+	return l.limitingReason.Load()
+}
+
+func (l *UtilizationBasedLimiter) starting(_ context.Context) error {
+	var err error
+	l.utilizationScanner, err = newCombinedScanner()
+	if err != nil {
+		return fmt.Errorf("unable to detect CPU/memory utilization, unsupported platform. Please disable utilization based limiting: %w", err)
+	}
+
+	return nil
+}
+
+func (l *UtilizationBasedLimiter) update(_ context.Context) error {
+	l.compute(time.Now)
+	return nil
+}
+
+// compute and return the current CPU and memory utilization.
+// This function must be called at a regular interval (resourceUtilizationUpdateInterval) to get a predictable behaviour.
+func (l *UtilizationBasedLimiter) compute(nowFn func() time.Time) (currCPUUtil float64, currMemoryUtil uint64) {
+	cpuTime, currHeapSize, err := l.utilizationScanner.Scan()
+	if err != nil {
+		level.Warn(l.logger).Log("msg", "failed to get CPU and memory stats", "err", err.Error())
+		// Disable any limiting, since we can't tell resource utilization
+		l.limitingReason.Store("")
+		return
+	}
+
+	// Get wall time after CPU time, in case there's a delay before CPU time is returned,
+	// which would cause us to compute too high of a CPU load
+	now := nowFn()
+	l.currHeapSize.Store(currHeapSize)
+
+	// Add the instant CPU utilization to the moving average. The instant CPU
+	// utilization can only be computed starting from the 2nd tick.
+	if prevUpdate, prevCPUTime := l.lastCPUUpdate, l.lastCPUTime; !prevUpdate.IsZero() {
+		// Provided that nowFn returns a Time with monotonic clock reading (like time.Now()), time.Sub is robust
+		// against wall clock changes, since it's based on the monotonic clock:
+		// https://pkg.go.dev/time#hdr-Monotonic_Clocks
+		timeSincePrevUpdate := now.Sub(prevUpdate)
+
+		// We expect the CPU utilization to be updated at a regular interval (resourceUtilizationUpdateInterval).
+		// Under some edge conditions (e.g. overloaded process / node), the time.Ticker used to periodically call
+		// the UtilizationBasedLimiter.compute() function, may call compute() two times consecutively (or with a very
+		// short delay). We detect these cases and skip the update (it will be updated during the next regular tick).
+		if timeSincePrevUpdate > resourceUtilizationUpdateInterval/2 {
+			cpuUtil := (cpuTime - prevCPUTime) / timeSincePrevUpdate.Seconds()
+			l.cpuMovingAvg.Add(int64(cpuUtil * 100))
+			l.cpuMovingAvg.Tick()
+			if l.cpuSamples != nil {
+				l.cpuSamples.Add(cpuUtil)
+			}
+
+			l.lastCPUUpdate = now
+			l.lastCPUTime = cpuTime
+		}
+	} else {
+		// First time we read the CPU utilization.
+		l.lastCPUUpdate = now
+		l.lastCPUTime = cpuTime
+	}
+
+	// The CPU utilization moving average requires a warmup period before getting
+	// stable results. In this implementation we use a warmup period equal to the
+	// sliding window. During the warmup, the reported CPU utilization will be 0.
+	if l.firstCPUUpdate.IsZero() {
+		l.firstCPUUpdate = now
+	} else if now.Sub(l.firstCPUUpdate) >= resourceUtilizationSlidingWindow {
+		currCPUUtil = l.cpuMovingAvg.Rate() / 100
+		l.currCPUUtil.Store(currCPUUtil)
+	}
+
+	var reason string
+	if l.memoryLimit > 0 && currHeapSize >= l.memoryLimit {
+		reason = "memory"
+	} else if l.cpuLimit > 0 && currCPUUtil >= l.cpuLimit {
+		reason = "cpu"
+	}
+
+	enable := reason != ""
+	prevEnable := l.limitingReason.Load() != ""
+	if enable == prevEnable {
+		// No change
+		return
+	}
+
+	logger := l.logger
+	if l.cpuSamples != nil {
+		// Log also the CPU samples the CPU load EWMA is based on
+		logger = log.WithSuffix(logger, "source_samples", l.cpuSamples.String())
+	}
+	if enable {
+		level.Info(logger).Log("msg", "enabling resource utilization based limiting",
+			"reason", reason, "memory_limit", formatMemoryLimit(l.memoryLimit), "memory_utilization", formatMemory(currHeapSize),
+			"cpu_limit", formatCPULimit(l.cpuLimit), "cpu_utilization", formatCPU(currCPUUtil))
+	} else {
+		level.Info(l.logger).Log("msg", "disabling resource utilization based limiting",
+			"memory_limit", formatMemoryLimit(l.memoryLimit), "memory_utilization", formatMemory(currHeapSize),
+			"cpu_limit", formatCPULimit(l.cpuLimit), "cpu_utilization", formatCPU(currCPUUtil))
+	}
+
+	l.limitingReason.Store(reason)
+	return
+}
+
+func formatCPU(value float64) string {
+	return fmt.Sprintf("%.2f", value)
+}
+
+func formatCPULimit(limit float64) string {
+	if limit == 0 {
+		return "disabled"
+	}
+	return formatCPU(limit)
+}
+
+func formatMemory(value uint64) string {
+	// We're not using a nicer format like units.Base2Bytes() because the actual value
+	// is harder to read and compare when not a multiple of a unit (e.g. not a multiple of GB).
+	return fmt.Sprintf("%d", value)
+}
+
+func formatMemoryLimit(limit uint64) string {
+	if limit == 0 {
+		return "disabled"
+	}
+	return formatMemory(limit)
+}
+
+// cpuSampleBuffer is a circular buffer of CPU samples.
+type cpuSampleBuffer struct {
+	samples []float64
+	head    int
+}
+
+func newCPUSampleBuffer(size int) *cpuSampleBuffer {
+	return &cpuSampleBuffer{
+		samples: make([]float64, size),
+	}
+}
+
+// Add adds a sample to the buffer.
+func (b *cpuSampleBuffer) Add(sample float64) {
+	b.samples[b.head] = sample
+	b.head = (b.head + 1) % len(b.samples)
+}
+
+// String returns a comma-separated string representation of the buffer.
+func (b *cpuSampleBuffer) String() string {
+	var sb strings.Builder
+	for i := range b.samples {
+		s := b.samples[(b.head+i)%len(b.samples)]
+		fmt.Fprintf(&sb, "%.2f", s)
+		if i < len(b.samples)-1 {
+			sb.WriteByte(',')
+		}
+	}
+
+	return sb.String()
+}

--- a/pkg/util/limiter/utilization.go
+++ b/pkg/util/limiter/utilization.go
@@ -161,6 +161,7 @@ func (l *UtilizationBasedLimiter) compute(nowFn func() time.Time) (currCPUUtil f
 	// Get wall time after CPU time, in case there's a delay before CPU time is returned,
 	// which would cause us to compute too high of a CPU load
 	now := nowFn()
+	currMemoryUtil = currHeapSize
 	l.currHeapSize.Store(currHeapSize)
 
 	// Add the instant CPU utilization to the moving average. The instant CPU

--- a/pkg/util/limiter/utilization_test.go
+++ b/pkg/util/limiter/utilization_test.go
@@ -1,0 +1,455 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/grafana/mimir/blob/main/pkg/util/limiter/utilization_test.go
+// Provenance-includes-license: AGPL-3.0-only
+// Provenance-includes-copyright: The Mimir Authors.
+
+package limiter
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUtilizationBasedLimiter(t *testing.T) {
+	const gigabyte = 1024 * 1024 * 1024
+
+	setup := func(t *testing.T, cpuLimit float64, memoryLimit uint64, enableLogging bool) (*UtilizationBasedLimiter,
+		*fakeUtilizationScanner, prometheus.Gatherer) {
+		fakeScanner := &fakeUtilizationScanner{}
+		reg := prometheus.NewPedanticRegistry()
+		lim := NewUtilizationBasedLimiter(cpuLimit, memoryLimit, enableLogging, log.NewNopLogger(), reg)
+		lim.utilizationScanner = fakeScanner
+		require.Empty(t, lim.LimitingReason(), "Limiting should initially be disabled")
+
+		return lim, fakeScanner, reg
+	}
+
+	tim := time.Now()
+	nowFn := func() time.Time {
+		return tim
+	}
+
+	t.Run("CPU based limiting should be enabled if set to a value greater than 0", func(t *testing.T) {
+		lim, _, reg := setup(t, 0.11, gigabyte, true)
+
+		// Warmup the CPU utilization.
+		for i := 0; i < int(resourceUtilizationSlidingWindow.Seconds()); i++ {
+			lim.compute(nowFn)
+			tim = tim.Add(resourceUtilizationUpdateInterval)
+		}
+
+		// The fake utilization scanner linearly increases CPU usage for a minute
+		for i := 0; i < 59; i++ {
+			lim.compute(nowFn)
+			tim = tim.Add(resourceUtilizationUpdateInterval)
+			require.Empty(t, lim.LimitingReason(), "Limiting should be disabled")
+		}
+		lim.compute(nowFn)
+		tim = tim.Add(resourceUtilizationUpdateInterval)
+		require.Equal(t, "cpu", lim.LimitingReason(), "Limiting should be enabled due to CPU")
+
+		// The fake utilization scanner drops CPU usage again after a minute, so we expect
+		// limiting to be disabled shortly.
+		for i := 0; i < 5; i++ {
+			lim.compute(nowFn)
+			tim = tim.Add(resourceUtilizationUpdateInterval)
+		}
+		require.Empty(t, lim.LimitingReason(), "Limiting should be disabled again")
+
+		assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+                                # HELP utilization_limiter_current_cpu_load Current average CPU load calculated by utilization based limiter.
+                                # TYPE utilization_limiter_current_cpu_load gauge
+            	           	utilization_limiter_current_cpu_load 0.10803555562923002
+            	           	# HELP utilization_limiter_current_memory_usage_bytes Current memory usage calculated by utilization based limiter.
+            	           	# TYPE utilization_limiter_current_memory_usage_bytes gauge
+            	           	utilization_limiter_current_memory_usage_bytes 0
+	`)))
+	})
+
+	t.Run("CPU based limiting should be disabled if set to 0", func(t *testing.T) {
+		lim, _, reg := setup(t, 0, gigabyte, true)
+
+		// Warmup the CPU utilization.
+		for i := 0; i < int(resourceUtilizationSlidingWindow.Seconds()); i++ {
+			lim.compute(nowFn)
+			tim = tim.Add(resourceUtilizationUpdateInterval)
+		}
+
+		for i := 0; i < 60; i++ {
+			lim.compute(nowFn)
+			tim = tim.Add(resourceUtilizationUpdateInterval)
+			require.Empty(t, lim.LimitingReason(), "Limiting should be disabled")
+		}
+
+		assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+                                # HELP utilization_limiter_current_cpu_load Current average CPU load calculated by utilization based limiter.
+            	           	# TYPE utilization_limiter_current_cpu_load gauge
+            	           	utilization_limiter_current_cpu_load  0.12581711205891943
+            	           	# HELP utilization_limiter_current_memory_usage_bytes Current memory usage calculated by utilization based limiter.
+            	           	# TYPE utilization_limiter_current_memory_usage_bytes gauge
+            	           	utilization_limiter_current_memory_usage_bytes 0
+		`)))
+	})
+
+	t.Run("memory based limiting should be enabled if set to a value greater than 0", func(t *testing.T) {
+		lim, fakeScanner, reg := setup(t, 0.11, gigabyte, true)
+
+		// Compute the utilization a first time to warm up the limiter.
+		lim.compute(nowFn)
+
+		fakeScanner.memoryUtilization = gigabyte
+		lim.compute(nowFn)
+		tim = tim.Add(resourceUtilizationUpdateInterval)
+		require.Equal(t, "memory", lim.LimitingReason(), "Limiting should be enabled due to memory")
+
+		fakeScanner.memoryUtilization = gigabyte - 1
+		lim.compute(nowFn)
+		require.Empty(t, lim.LimitingReason(), "Limiting should be disabled again")
+
+		assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+                                # HELP utilization_limiter_current_cpu_load Current average CPU load calculated by utilization based limiter.
+            	           	# TYPE utilization_limiter_current_cpu_load gauge
+            	           	utilization_limiter_current_cpu_load 0
+            	           	# HELP utilization_limiter_current_memory_usage_bytes Current memory usage calculated by utilization based limiter.
+            	           	# TYPE utilization_limiter_current_memory_usage_bytes gauge
+            	           	utilization_limiter_current_memory_usage_bytes 1.073741823e+09
+		`)))
+	})
+
+	t.Run("memory based limiting should be disabled if set to 0", func(t *testing.T) {
+		lim, fakeScanner, reg := setup(t, 0.11, 0, true)
+
+		// Compute the utilization a first time to warm up the limiter.
+		lim.compute(nowFn)
+
+		fakeScanner.memoryUtilization = gigabyte
+		lim.compute(nowFn)
+		tim = tim.Add(resourceUtilizationUpdateInterval)
+		require.Empty(t, lim.LimitingReason(), "Limiting should be disabled")
+
+		assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+                                # HELP utilization_limiter_current_cpu_load Current average CPU load calculated by utilization based limiter.
+            	           	# TYPE utilization_limiter_current_cpu_load gauge
+            	           	utilization_limiter_current_cpu_load 0
+            	           	# HELP utilization_limiter_current_memory_usage_bytes Current memory usage calculated by utilization based limiter.
+            	           	# TYPE utilization_limiter_current_memory_usage_bytes gauge
+            	           	utilization_limiter_current_memory_usage_bytes 1.073741824e+09
+		`)))
+	})
+
+	t.Run("limiting should work without CPU samples logging", func(t *testing.T) {
+		lim, _, _ := setup(t, 0.11, gigabyte, false)
+
+		// Warmup the CPU utilization.
+		for i := 0; i < int(resourceUtilizationSlidingWindow.Seconds()); i++ {
+			lim.compute(nowFn)
+			tim = tim.Add(resourceUtilizationUpdateInterval)
+		}
+
+		// The fake utilization scanner linearly increases CPU usage for a minute
+		for i := 0; i < 59; i++ {
+			lim.compute(nowFn)
+			tim = tim.Add(resourceUtilizationUpdateInterval)
+			require.Empty(t, lim.LimitingReason(), "Limiting should be disabled")
+		}
+		lim.compute(nowFn)
+		tim = tim.Add(resourceUtilizationUpdateInterval)
+		require.Equal(t, "cpu", lim.LimitingReason(), "Limiting should be enabled due to CPU")
+		require.Nil(t, lim.cpuSamples)
+	})
+
+	t.Run("the limiter should collect the last 60 CPU samples", func(t *testing.T) {
+		var instValues []float64
+		for i := 1; i <= 62; i++ {
+			instValues = append(instValues, float64(i))
+		}
+		scanner := &preRecordedUtilizationScanner{instantCPUValues: instValues}
+		lim := NewUtilizationBasedLimiter(1, 0, true, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+		lim.utilizationScanner = scanner
+
+		for i, ts := 0, time.Now(); i < len(instValues); i++ {
+			lim.compute(func() time.Time {
+				return ts
+			})
+			ts = ts.Add(resourceUtilizationUpdateInterval)
+		}
+
+		var sampleStrs []string
+		for i := 2; i < 62; i++ {
+			sampleStrs = append(sampleStrs, fmt.Sprintf("%.2f", instValues[i]))
+		}
+		exp := strings.Join(sampleStrs, ",")
+		assert.Equal(t, exp, lim.cpuSamples.String())
+	})
+}
+
+func TestFormatCPU(t *testing.T) {
+	assert.Equal(t, "0.00", formatCPU(0))
+	assert.Equal(t, "0.11", formatCPU(0.11))
+	assert.Equal(t, "0.11", formatCPU(0.111))
+	assert.Equal(t, "0.12", formatCPU(0.115))
+	assert.Equal(t, "2.10", formatCPU(2.1))
+}
+
+func TestFormatCPULimit(t *testing.T) {
+	assert.Equal(t, "disabled", formatCPULimit(0))
+	assert.Equal(t, "0.11", formatCPULimit(0.111))
+	assert.Equal(t, "0.12", formatCPULimit(0.115))
+}
+
+func TestFormatMemory(t *testing.T) {
+	assert.Equal(t, "0", formatMemory(0))
+	assert.Equal(t, "1073741824", formatMemory(1024*1024*1024))
+	assert.Equal(t, "1073741825", formatMemory((1024*1024*1024)+1))
+}
+
+func TestFormatMemoryLimit(t *testing.T) {
+	assert.Equal(t, "disabled", formatMemoryLimit(0))
+	assert.Equal(t, "1073741824", formatMemoryLimit(1024*1024*1024))
+	assert.Equal(t, "1073741825", formatMemoryLimit((1024*1024*1024)+1))
+}
+
+func TestUtilizationBasedLimiter_CPUUtilizationSensitivity(t *testing.T) {
+	tests := map[string]struct {
+		instantCPUValues          []float64
+		expectedMaxCPUUtilization float64
+	}{
+		"2 minutes idle": {
+			instantCPUValues:          generateConstCPUUtilization(120, 0),
+			expectedMaxCPUUtilization: 0,
+		},
+		"2 minutes at constant utilization": {
+			instantCPUValues:          generateConstCPUUtilization(120, 2.00),
+			expectedMaxCPUUtilization: 2,
+		},
+		"1 minute idle + 10 seconds spike + 50 seconds idle": {
+			instantCPUValues: func() []float64 {
+				values := generateConstCPUUtilization(60, 0)
+				values = append(values, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+				values = append(values, generateConstCPUUtilization(50, 0)...)
+				return values
+			}(),
+			expectedMaxCPUUtilization: 1.49,
+		},
+		"10 seconds spike + 110 seconds idle (moving average warms up the first 60 seconds)": {
+			instantCPUValues: func() []float64 {
+				values := []float64{10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
+				values = append(values, generateConstCPUUtilization(110, 0)...)
+				return values
+			}(),
+			expectedMaxCPUUtilization: 1.44,
+		},
+		"1 minute base utilization + 10 seconds spike + 50 seconds base utilization": {
+			instantCPUValues: func() []float64 {
+				values := generateConstCPUUtilization(60, 1.0)
+				values = append(values, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+				values = append(values, generateConstCPUUtilization(50, 1.0)...)
+				return values
+			}(),
+			expectedMaxCPUUtilization: 2.25,
+		},
+		"1 minute base utilization + 10 seconds steady spike + 50 seconds base utilization": {
+			instantCPUValues: func() []float64 {
+				values := generateConstCPUUtilization(60, 1.0)
+				values = append(values, generateConstCPUUtilization(10, 10.0)...)
+				values = append(values, generateConstCPUUtilization(50, 1.0)...)
+				return values
+			}(),
+			expectedMaxCPUUtilization: 3.55,
+		},
+		"1 minute base utilization + 30 seconds steady spike + 30 seconds base utilization": {
+			instantCPUValues: func() []float64 {
+				values := generateConstCPUUtilization(60, 1.0)
+				values = append(values, generateConstCPUUtilization(30, 10.0)...)
+				values = append(values, generateConstCPUUtilization(30, 1.0)...)
+				return values
+			}(),
+			expectedMaxCPUUtilization: 6.69,
+		},
+		"linear increase and then linear decrease utilization": {
+			instantCPUValues: func() []float64 {
+				values := generateLinearStepCPUUtilization(60, 0, 0.1)
+				values = append(values, generateLinearStepCPUUtilization(60, 60*0.1, -0.1)...)
+				return values
+			}(),
+			expectedMaxCPUUtilization: 4.13,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			scanner := &preRecordedUtilizationScanner{instantCPUValues: testData.instantCPUValues}
+
+			lim := NewUtilizationBasedLimiter(1, 0, true, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+			lim.utilizationScanner = scanner
+
+			minCPUUtilization := float64(math.MaxInt64)
+			maxCPUUtilization := float64(math.MinInt64)
+
+			for i, ts := 0, time.Now(); i < len(testData.instantCPUValues); i++ {
+				currCPUUtilization, _ := lim.compute(func() time.Time {
+					return ts
+				})
+				ts = ts.Add(resourceUtilizationUpdateInterval)
+
+				// Keep track of the max CPU utilization as computed by the limiter.
+				if currCPUUtilization < minCPUUtilization {
+					minCPUUtilization = currCPUUtilization
+				}
+				if currCPUUtilization > maxCPUUtilization {
+					maxCPUUtilization = currCPUUtilization
+				}
+			}
+
+			assert.InDelta(t, 0, minCPUUtilization, 0.01) // The minimum should always be 0 because of the warmup period.
+			assert.InDelta(t, testData.expectedMaxCPUUtilization, maxCPUUtilization, 0.01)
+		})
+	}
+}
+
+func TestUtilizationBasedLimiter_ShouldNotUpdateCPUIfElapsedVeryShortTimeSincePreviousUpdate(t *testing.T) {
+	now := time.Now()
+	nowFn := func() time.Time {
+		return now
+	}
+
+	scanner := &preRecordedUtilizationScanner{instantCPUValues: generateConstCPUUtilization(10, 1)}
+
+	lim := NewUtilizationBasedLimiter(1, 0, true, log.NewNopLogger(), nil)
+	lim.utilizationScanner = scanner
+
+	// CPU utilization tracking gets initialised.
+	lim.compute(nowFn)
+	assert.InDelta(t, 1, lim.lastCPUTime, 0.0001)
+
+	// Track the CPU utilization few times.
+	for expected := 2; expected <= 5; expected++ {
+		now = now.Add(resourceUtilizationUpdateInterval)
+		lim.compute(nowFn)
+		assert.InDelta(t, float64(expected), lim.lastCPUTime, 0.0001)
+	}
+
+	// Track the CPU utilization few consecutive times, at a very short interval.
+	for i := 0; i < 5; i++ {
+		now = now.Add(resourceUtilizationUpdateInterval / 10)
+		lim.compute(nowFn)
+		assert.InDelta(t, float64(5), lim.lastCPUTime, 0.0001)
+	}
+
+	// Track one more time with a short interval and now it should be tracked because
+	// it elapsed more than 50% of the expected update interval.
+	now = now.Add(resourceUtilizationUpdateInterval / 10)
+	lim.compute(nowFn)
+	assert.InDelta(t, float64(10), lim.lastCPUTime, 0.0001)
+}
+
+type fakeUtilizationScanner struct {
+	totalTime         float64
+	counter           int
+	memoryUtilization uint64
+}
+
+func (s *fakeUtilizationScanner) Scan() (float64, uint64, error) {
+	s.totalTime += float64(1) / float64(60-s.counter)
+	s.counter++
+	s.counter %= 60
+	return s.totalTime, s.memoryUtilization, nil
+}
+
+func (s *fakeUtilizationScanner) String() string {
+	return "fake"
+}
+
+// preRecordedUtilizationScanner allows to replay CPU values.
+type preRecordedUtilizationScanner struct {
+	instantCPUValues []float64
+
+	// Keeps track of the accumulated CPU utilization.
+	totalCPUUtilization float64
+}
+
+func (s *preRecordedUtilizationScanner) Scan() (float64, uint64, error) {
+	if len(s.instantCPUValues) == 0 {
+		return s.totalCPUUtilization, 0, nil
+	}
+
+	s.totalCPUUtilization += s.instantCPUValues[0]
+	s.instantCPUValues = s.instantCPUValues[1:]
+	return s.totalCPUUtilization, 0, nil
+}
+
+func (s *preRecordedUtilizationScanner) String() string {
+	return ""
+}
+
+func generateConstCPUUtilization(count int, value float64) []float64 {
+	values := make([]float64, 0, count)
+	for i := 0; i < count; i++ {
+		values = append(values, value)
+	}
+	return values
+}
+
+func generateLinearStepCPUUtilization(count int, from, step float64) []float64 {
+	values := make([]float64, 0, count)
+	for i := 0; i < count; i++ {
+		values = append(values, from+(float64(i)*step))
+	}
+	return values
+}
+
+func BenchmarkUtilizationBasedLimiter(b *testing.B) {
+	const gigabyte = 1024 * 1024 * 1024
+
+	setup := func(cpuLimit float64, memoryLimit uint64) *UtilizationBasedLimiter {
+		lim := NewUtilizationBasedLimiter(cpuLimit, memoryLimit, false, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+		s, err := newCombinedScanner()
+		require.NoError(b, err)
+		lim.utilizationScanner = s
+		require.Empty(b, lim.LimitingReason(), "Limiting should initially be disabled")
+
+		return lim
+	}
+
+	tim := time.Now()
+	nowFn := func() time.Time {
+		return tim
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		lim := setup(0.11, gigabyte)
+
+		// Warm up the CPU utilization.
+		for i := 0; i < int(resourceUtilizationSlidingWindow.Seconds()); i++ {
+			lim.compute(nowFn)
+			tim = tim.Add(resourceUtilizationUpdateInterval)
+		}
+
+		lim.compute(nowFn)
+		tim = tim.Add(resourceUtilizationUpdateInterval)
+	}
+}
+
+func BenchmarkCombinedScanner(b *testing.B) {
+	s, err := newCombinedScanner()
+	require.NoError(b, err)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _, err := s.Scan()
+		require.NoError(b, err)
+	}
+}

--- a/pkg/util/math/rate.go
+++ b/pkg/util/math/rate.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/grafana/mimir/blob/main/pkg/util/math/rate.go
+// Provenance-includes-license: AGPL-3.0-only
+// Provenance-includes-copyright: The Mimir Authors.
+// Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/pkg/util/math/rate.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Cortex Authors.
+
+package math
+
+import (
+	"sync"
+	"time"
+
+	"go.uber.org/atomic"
+)
+
+// EwmaRate tracks an exponentially weighted moving average of a per-second rate.
+type EwmaRate struct {
+	newEvents atomic.Int64
+
+	alpha    float64
+	interval time.Duration
+
+	mutex    sync.RWMutex
+	lastRate float64
+	init     bool
+}
+
+func NewEWMARate(alpha float64, interval time.Duration) *EwmaRate {
+	return &EwmaRate{
+		alpha:    alpha,
+		interval: interval,
+	}
+}
+
+// Rate returns the per-second rate.
+func (r *EwmaRate) Rate() float64 {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	return r.lastRate
+}
+
+// Tick assumes to be called every r.interval.
+func (r *EwmaRate) Tick() {
+	newEvents := r.newEvents.Swap(0)
+	instantRate := float64(newEvents) / r.interval.Seconds()
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if r.init {
+		r.lastRate += r.alpha * (instantRate - r.lastRate)
+	} else {
+		r.init = true
+		r.lastRate = instantRate
+	}
+}
+
+// Inc counts one event.
+func (r *EwmaRate) Inc() {
+	r.newEvents.Inc()
+}
+
+func (r *EwmaRate) Add(delta int64) {
+	r.newEvents.Add(delta)
+}

--- a/pkg/util/math/rate_test.go
+++ b/pkg/util/math/rate_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/grafana/mimir/blob/main/pkg/util/math/rate_test.go
+// Provenance-includes-license: AGPL-3.0-only
+// Provenance-includes-copyright: The Mimir Authors.
+// Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/pkg/util/math/rate_test.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Cortex Authors.
+
+package math
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRate(t *testing.T) {
+	ticks := []struct {
+		events int
+		want   float64
+	}{
+		{60, 1},
+		{30, 0.9},
+		{0, 0.72},
+		{60, 0.776},
+		{0, 0.6208},
+		{0, 0.49664},
+		{0, 0.397312},
+		{0, 0.3178496},
+		{0, 0.25427968},
+		{0, 0.203423744},
+		{0, 0.1627389952},
+	}
+	r := NewEWMARate(0.2, time.Minute)
+
+	for _, tick := range ticks {
+		for e := 0; e < tick.events; e++ {
+			r.Inc()
+		}
+		r.Tick()
+		// We cannot do double comparison, because double operations on different
+		// platforms may actually produce results that differ slightly.
+		// There are multiple issues about this in Go's github, eg: 18354 or 20319.
+		require.InDelta(t, tick.want, r.Rate(), 0.0000000001, "unexpected rate")
+	}
+
+	r = NewEWMARate(0.2, time.Minute)
+
+	for _, tick := range ticks {
+		r.Add(int64(tick.events))
+		r.Tick()
+		require.InDelta(t, tick.want, r.Rate(), 0.0000000001, "unexpected rate")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Index gateways have no admission control: a query spike can saturate their CPU, taking down the read path. This PR:
- Copies Mimir's utilization-based limiter into `pkg/util/limiter` (with provenance headers), plus its `EwmaRate` dependency into `pkg/util/math`.
- Adds experimental `-index-gateway.cpu-utilization-limit` and `-index-gateway.memory-utilization-limit` flags. When exceeded, gRPC interceptors reject IndexGateway requests with `Unavailable` before the handler runs, and `loki_index_gateway_utilization_limited_requests_total` is incremented.
- Makes index gateway clients back off (jittered, exponential) before retrying on another gateway, only for saturation rejections. Other errors keep failing over immediately. Configurable via `-index-gateway-client.saturation-backoff-{min,max}-period`.

Everything is disabled by default.

**Which issue(s) this PR fixes**:
N/A (follow-up to an internal incident review)

**Special notes for your reviewer**:
The limiter is copied, not imported, from Mimir so Loki does not depend on the Mimir module. `utilization.go` is kept line-diffable with the upstream file.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)