### PR TITLE
feat(indexgateway): Add scheduler-backlog based saturation limiter

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3975,22 +3975,25 @@ ring:
   # CLI flag: -index-gateway.ring.instance-enable-ipv6
   [instance_enable_ipv6: <boolean> | default = false]
 
-# Experimental: CPU utilization, in cores, above which the index gateway starts
-# rejecting requests. The utilization is computed as a moving average over a 60s
-# sliding window, and limiting only starts after a 60s warmup on startup. 0 to
-# disable.
-# CLI flag: -index-gateway.cpu-utilization-limit
-[cpu_utilization_limit: <float> | default = 0]
+# Experimental: Configures the rejection of requests when the index gateway is
+# saturated.
+saturation_control:
+  # Experimental: CPU utilization, in cores, above which the index gateway
+  # starts rejecting requests. The utilization is computed as a moving average
+  # over a 60s sliding window, and limiting only starts after a 60s warmup on
+  # startup. 0 to disable.
+  # CLI flag: -index-gateway.saturation-control.cpu-utilization-limit
+  [cpu_utilization_limit: <float> | default = 0]
 
-# Experimental: Go heap size above which the index gateway starts rejecting
-# requests, e.g. 24GiB. 0 to disable.
-# CLI flag: -index-gateway.memory-utilization-limit
-[memory_utilization_limit: <int> | default = 0B]
+  # Experimental: Go heap size above which the index gateway starts rejecting
+  # requests, e.g. 24GiB. 0 to disable.
+  # CLI flag: -index-gateway.saturation-control.memory-utilization-limit
+  [memory_utilization_limit: <int> | default = 0B]
 
-# Experimental: Log the CPU utilization samples backing the utilization based
-# limiter's moving average when limiting starts or stops.
-# CLI flag: -index-gateway.log-utilization-samples
-[log_utilization_samples: <boolean> | default = false]
+  # Experimental: Log the CPU utilization samples backing the utilization based
+  # limiter's moving average when limiting starts or stops.
+  # CLI flag: -index-gateway.saturation-control.log-utilization-samples
+  [log_utilization_samples: <boolean> | default = false]
 ```
 
 ### ingester

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3994,6 +3994,17 @@ saturation_control:
   # limiter's moving average when limiting starts or stops.
   # CLI flag: -index-gateway.saturation-control.log-utilization-samples
   [log_utilization_samples: <boolean> | default = false]
+
+  # Experimental: Go scheduler backlog per core above which the index gateway
+  # starts rejecting requests. The backlog is the average number of runnable
+  # goroutines waiting to run per core (GOMAXPROCS), computed from the Go
+  # scheduler latency histogram as a moving average over a 60s sliding window,
+  # with limiting starting only after a 60s warmup. It approaches 0 on a healthy
+  # instance and exceeds 1 when saturated, including saturation caused by
+  # memory-mapped file page faults that CPU utilization does not capture. A
+  # recommended value is around 1.0. 0 to disable.
+  # CLI flag: -index-gateway.saturation-control.scheduler-backlog-limit
+  [scheduler_backlog_limit: <float> | default = 0]
 ```
 
 ### ingester

--- a/pkg/indexgateway/config.go
+++ b/pkg/indexgateway/config.go
@@ -84,6 +84,11 @@ type SaturationControlConfig struct {
 	// LogUtilizationSamples enables logging of the CPU samples backing the utilization
 	// moving average when limiting kicks in or stops.
 	LogUtilizationSamples bool `yaml:"log_utilization_samples" category:"experimental"`
+
+	// SchedulerBacklogLimit is the Go scheduler backlog per core (average number of
+	// runnable goroutines waiting per GOMAXPROCS) above which the index gateway
+	// rejects requests. 0 disables scheduler backlog based limiting.
+	SchedulerBacklogLimit float64 `yaml:"scheduler_backlog_limit" category:"experimental"`
 }
 
 // RegisterFlagsWithPrefix registers the saturation control flags with the given prefix.
@@ -91,11 +96,17 @@ func (cfg *SaturationControlConfig) RegisterFlagsWithPrefix(prefix string, f *fl
 	f.Float64Var(&cfg.CPUUtilizationLimit, prefix+"cpu-utilization-limit", 0, "Experimental: CPU utilization, in cores, above which the index gateway starts rejecting requests. The utilization is computed as a moving average over a 60s sliding window, and limiting only starts after a 60s warmup on startup. 0 to disable.")
 	f.Var(&cfg.MemoryUtilizationLimit, prefix+"memory-utilization-limit", "Experimental: Go heap size above which the index gateway starts rejecting requests, e.g. 24GiB. 0 to disable.")
 	f.BoolVar(&cfg.LogUtilizationSamples, prefix+"log-utilization-samples", false, "Experimental: Log the CPU utilization samples backing the utilization based limiter's moving average when limiting starts or stops.")
+	f.Float64Var(&cfg.SchedulerBacklogLimit, prefix+"scheduler-backlog-limit", 0, "Experimental: Go scheduler backlog per core above which the index gateway starts rejecting requests. The backlog is the average number of runnable goroutines waiting to run per core (GOMAXPROCS), computed from the Go scheduler latency histogram as a moving average over a 60s sliding window, with limiting starting only after a 60s warmup. It approaches 0 on a healthy instance and exceeds 1 when saturated, including saturation caused by memory-mapped file page faults that CPU utilization does not capture. A recommended value is around 1.0. 0 to disable.")
 }
 
 // UtilizationLimiterEnabled returns whether requests should be rejected based on resource utilization.
 func (cfg *SaturationControlConfig) UtilizationLimiterEnabled() bool {
 	return cfg.CPUUtilizationLimit > 0 || cfg.MemoryUtilizationLimit > 0
+}
+
+// SchedulerLimiterEnabled returns whether requests should be rejected based on the Go scheduler backlog.
+func (cfg *SaturationControlConfig) SchedulerLimiterEnabled() bool {
+	return cfg.SchedulerBacklogLimit > 0
 }
 
 func (cfg *SaturationControlConfig) Validate() error {
@@ -106,6 +117,9 @@ func (cfg *SaturationControlConfig) Validate() error {
 	// values that would silently never trigger limiting.
 	if uint64(cfg.MemoryUtilizationLimit) > math.MaxInt64 {
 		return errors.New("index gateway memory utilization limit must not be negative")
+	}
+	if cfg.SchedulerBacklogLimit < 0 {
+		return errors.New("index gateway scheduler backlog limit must not be negative")
 	}
 	return nil
 }

--- a/pkg/indexgateway/config.go
+++ b/pkg/indexgateway/config.go
@@ -67,6 +67,12 @@ type Config struct {
 	// section and the ingester configuration by default).
 	Ring ring.RingConfig `yaml:"ring,omitempty" doc:"description=Defines the ring to be used by the index gateway servers and clients in case the servers are configured to run in 'ring' mode. In case this isn't configured, this block supports inheriting configuration from the common ring section."`
 
+	// SaturationControl configures the rejection of requests when the index gateway is saturated.
+	SaturationControl SaturationControlConfig `yaml:"saturation_control" category:"experimental" doc:"description=Experimental: Configures the rejection of requests when the index gateway is saturated."`
+}
+
+// SaturationControlConfig configures the rejection of requests when the index gateway is saturated.
+type SaturationControlConfig struct {
 	// CPUUtilizationLimit is the CPU utilization, in cores, above which the index gateway
 	// starts rejecting requests. 0 disables CPU utilization based limiting.
 	CPUUtilizationLimit float64 `yaml:"cpu_utilization_limit" category:"experimental"`
@@ -78,6 +84,30 @@ type Config struct {
 	// LogUtilizationSamples enables logging of the CPU samples backing the utilization
 	// moving average when limiting kicks in or stops.
 	LogUtilizationSamples bool `yaml:"log_utilization_samples" category:"experimental"`
+}
+
+// RegisterFlagsWithPrefix registers the saturation control flags with the given prefix.
+func (cfg *SaturationControlConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.Float64Var(&cfg.CPUUtilizationLimit, prefix+"cpu-utilization-limit", 0, "Experimental: CPU utilization, in cores, above which the index gateway starts rejecting requests. The utilization is computed as a moving average over a 60s sliding window, and limiting only starts after a 60s warmup on startup. 0 to disable.")
+	f.Var(&cfg.MemoryUtilizationLimit, prefix+"memory-utilization-limit", "Experimental: Go heap size above which the index gateway starts rejecting requests, e.g. 24GiB. 0 to disable.")
+	f.BoolVar(&cfg.LogUtilizationSamples, prefix+"log-utilization-samples", false, "Experimental: Log the CPU utilization samples backing the utilization based limiter's moving average when limiting starts or stops.")
+}
+
+// UtilizationLimiterEnabled returns whether requests should be rejected based on resource utilization.
+func (cfg *SaturationControlConfig) UtilizationLimiterEnabled() bool {
+	return cfg.CPUUtilizationLimit > 0 || cfg.MemoryUtilizationLimit > 0
+}
+
+func (cfg *SaturationControlConfig) Validate() error {
+	if cfg.CPUUtilizationLimit < 0 {
+		return errors.New("index gateway CPU utilization limit must not be negative")
+	}
+	// flagext.Bytes accepts negative inputs (e.g. -1GiB) and wraps them around to huge
+	// values that would silently never trigger limiting.
+	if uint64(cfg.MemoryUtilizationLimit) > math.MaxInt64 {
+		return errors.New("index gateway memory utilization limit must not be negative")
+	}
+	return nil
 }
 
 // RegisterFlags register all IndexGatewayClientConfig flags and all the flags of its subconfigs but with a prefix (ex: shipper).
@@ -98,27 +128,12 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	// reasons (this is assured by the spikey behavior of Index Gateway latencies).
 	f.IntVar(&cfg.Ring.ReplicationFactor, "replication-factor", ReplicationFactor, "Deprecated: How many index gateway instances are assigned to each tenant. Use -index-gateway.shard-size instead. The shard size is also a per-tenant setting.")
 
-	f.Float64Var(&cfg.CPUUtilizationLimit, "index-gateway.cpu-utilization-limit", 0, "Experimental: CPU utilization, in cores, above which the index gateway starts rejecting requests. The utilization is computed as a moving average over a 60s sliding window, and limiting only starts after a 60s warmup on startup. 0 to disable.")
-	f.Var(&cfg.MemoryUtilizationLimit, "index-gateway.memory-utilization-limit", "Experimental: Go heap size above which the index gateway starts rejecting requests, e.g. 24GiB. 0 to disable.")
-	f.BoolVar(&cfg.LogUtilizationSamples, "index-gateway.log-utilization-samples", false, "Experimental: Log the CPU utilization samples backing the utilization based limiter's moving average when limiting starts or stops.")
-}
-
-// UtilizationLimiterEnabled returns whether requests should be rejected based on resource utilization.
-func (cfg *Config) UtilizationLimiterEnabled() bool {
-	return cfg.CPUUtilizationLimit > 0 || cfg.MemoryUtilizationLimit > 0
+	cfg.SaturationControl.RegisterFlagsWithPrefix("index-gateway.saturation-control.", f)
 }
 
 func (cfg *Config) Validate() error {
 	if cfg.Ring.NumTokens != NumTokens {
 		return errors.New("Num tokens must not be changed as it will not take effect")
 	}
-	if cfg.CPUUtilizationLimit < 0 {
-		return errors.New("index gateway CPU utilization limit must not be negative")
-	}
-	// flagext.Bytes accepts negative inputs (e.g. -1GiB) and wraps them around to huge
-	// values that would silently never trigger limiting.
-	if uint64(cfg.MemoryUtilizationLimit) > math.MaxInt64 {
-		return errors.New("index gateway memory utilization limit must not be negative")
-	}
-	return nil
+	return cfg.SaturationControl.Validate()
 }

--- a/pkg/indexgateway/config_test.go
+++ b/pkg/indexgateway/config_test.go
@@ -1,0 +1,87 @@
+package indexgateway
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/grafana/dskit/flagext"
+	"github.com/stretchr/testify/require"
+)
+
+func defaultTestConfig(t *testing.T) Config {
+	t.Helper()
+	var cfg Config
+	fs := flag.NewFlagSet(t.Name(), flag.PanicOnError)
+	cfg.RegisterFlags(fs)
+	require.NoError(t, fs.Parse(nil))
+	return cfg
+}
+
+func TestConfig_Validate(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		mutate      func(*Config)
+		expectedErr string
+	}{
+		{
+			name:   "defaults are valid",
+			mutate: func(*Config) {},
+		},
+		{
+			name: "positive limits are valid",
+			mutate: func(cfg *Config) {
+				cfg.SaturationControl.CPUUtilizationLimit = 0.8
+				cfg.SaturationControl.SchedulerBacklogLimit = 1.0
+			},
+		},
+		{
+			name:        "negative CPU utilization limit is rejected",
+			mutate:      func(cfg *Config) { cfg.SaturationControl.CPUUtilizationLimit = -1 },
+			expectedErr: "CPU utilization limit",
+		},
+		{
+			name: "negative memory utilization limit is rejected",
+			mutate: func(cfg *Config) {
+				var b flagext.Bytes
+				require.NoError(t, b.Set("-1GiB"))
+				cfg.SaturationControl.MemoryUtilizationLimit = b
+			},
+			expectedErr: "memory utilization limit",
+		},
+		{
+			name:        "negative scheduler backlog limit is rejected",
+			mutate:      func(cfg *Config) { cfg.SaturationControl.SchedulerBacklogLimit = -1 },
+			expectedErr: "scheduler backlog limit",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := defaultTestConfig(t)
+			tc.mutate(&cfg)
+			err := cfg.Validate()
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.expectedErr)
+			}
+		})
+	}
+}
+
+func TestConfig_LimiterEnabledHelpers(t *testing.T) {
+	cfg := defaultTestConfig(t)
+	require.False(t, cfg.SaturationControl.UtilizationLimiterEnabled())
+	require.False(t, cfg.SaturationControl.SchedulerLimiterEnabled())
+
+	cfg.SaturationControl.CPUUtilizationLimit = 0.8
+	require.True(t, cfg.SaturationControl.UtilizationLimiterEnabled())
+	require.False(t, cfg.SaturationControl.SchedulerLimiterEnabled())
+
+	cfg.SaturationControl.CPUUtilizationLimit = 0
+	require.NoError(t, cfg.SaturationControl.MemoryUtilizationLimit.Set("1GiB"))
+	require.True(t, cfg.SaturationControl.UtilizationLimiterEnabled())
+
+	cfg.SaturationControl.MemoryUtilizationLimit = 0
+	cfg.SaturationControl.SchedulerBacklogLimit = 1.0
+	require.False(t, cfg.SaturationControl.UtilizationLimiterEnabled())
+	require.True(t, cfg.SaturationControl.SchedulerLimiterEnabled())
+}

--- a/pkg/indexgateway/grpc.go
+++ b/pkg/indexgateway/grpc.go
@@ -17,15 +17,17 @@ import (
 // the same gRPC server (e.g. in single-binary mode) are unaffected.
 const indexGatewayServicePrefix = "/indexgatewaypb.IndexGateway/"
 
-// utilizationChecker is satisfied by limiter.UtilizationBasedLimiter.
-type utilizationChecker interface {
+// UtilizationChecker is satisfied by the limiters in pkg/util/limiter, e.g.
+// limiter.UtilizationBasedLimiter and limiter.SchedulerBacklogLimiter.
+type UtilizationChecker interface {
 	// LimitingReason returns a non-empty reason when requests should be rejected.
 	LimitingReason() string
 }
 
 // NewSaturationCheckInterceptors returns gRPC interceptors that reject IndexGateway
-// requests with a saturation error while checker reports a limiting reason.
-func NewSaturationCheckInterceptors(r prometheus.Registerer, checker utilizationChecker) (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor) {
+// requests with a saturation error while any checker reports a limiting reason. The
+// first non-empty reason wins.
+func NewSaturationCheckInterceptors(r prometheus.Registerer, checkers ...UtilizationChecker) (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor) {
 	limitedRequests := promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 		Namespace: constants.Loki,
 		Subsystem: "index_gateway",
@@ -37,12 +39,13 @@ func NewSaturationCheckInterceptors(r prometheus.Registerer, checker utilization
 		if !strings.HasPrefix(fullMethod, indexGatewayServicePrefix) {
 			return nil
 		}
-		reason := checker.LimitingReason()
-		if reason == "" {
-			return nil
+		for _, checker := range checkers {
+			if reason := checker.LimitingReason(); reason != "" {
+				limitedRequests.WithLabelValues(reason).Inc()
+				return newSaturatedError(reason)
+			}
 		}
-		limitedRequests.WithLabelValues(reason).Inc()
-		return newSaturatedError(reason)
+		return nil
 	}
 
 	unary := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {

--- a/pkg/indexgateway/grpc_test.go
+++ b/pkg/indexgateway/grpc_test.go
@@ -27,9 +27,13 @@ func TestSaturationCheckInterceptors(t *testing.T) {
 		externalMethod = "/logproto.Querier/Query"
 	)
 
-	setup := func(reason string) (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor, prometheus.Gatherer) {
+	setup := func(reasons ...string) (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor, prometheus.Gatherer) {
 		reg := prometheus.NewPedanticRegistry()
-		unary, stream := NewSaturationCheckInterceptors(reg, &fakeUtilizationChecker{reason: reason})
+		checkers := make([]UtilizationChecker, 0, len(reasons))
+		for _, reason := range reasons {
+			checkers = append(checkers, &fakeUtilizationChecker{reason: reason})
+		}
+		unary, stream := NewSaturationCheckInterceptors(reg, checkers...)
 		return unary, stream, reg
 	}
 
@@ -99,6 +103,54 @@ func TestSaturationCheckInterceptors(t *testing.T) {
 			# TYPE loki_index_gateway_utilization_limited_requests_total counter
 			loki_index_gateway_utilization_limited_requests_total{reason="memory"} 1
 		`)
+	})
+
+	t.Run("the first non-empty reason wins with multiple checkers", func(t *testing.T) {
+		unary, _, reg := setup("cpu", "scheduler")
+
+		_, err := unary(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: unaryMethod},
+			func(context.Context, any) (any, error) {
+				t.Fatal("handler should not be invoked")
+				return nil, nil
+			})
+		require.True(t, IsSaturatedError(err))
+
+		requireLimitedRequests(t, reg, `
+			# HELP loki_index_gateway_utilization_limited_requests_total Total number of requests rejected by the index gateway because of resource utilization based limiting.
+			# TYPE loki_index_gateway_utilization_limited_requests_total counter
+			loki_index_gateway_utilization_limited_requests_total{reason="cpu"} 1
+		`)
+	})
+
+	t.Run("later checkers are consulted when earlier ones report no reason", func(t *testing.T) {
+		unary, _, reg := setup("", "scheduler")
+
+		_, err := unary(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: unaryMethod},
+			func(context.Context, any) (any, error) {
+				t.Fatal("handler should not be invoked")
+				return nil, nil
+			})
+		require.True(t, IsSaturatedError(err))
+
+		requireLimitedRequests(t, reg, `
+			# HELP loki_index_gateway_utilization_limited_requests_total Total number of requests rejected by the index gateway because of resource utilization based limiting.
+			# TYPE loki_index_gateway_utilization_limited_requests_total counter
+			loki_index_gateway_utilization_limited_requests_total{reason="scheduler"} 1
+		`)
+	})
+
+	t.Run("requests pass through when no checker reports a reason", func(t *testing.T) {
+		unary, _, reg := setup("", "")
+
+		called := false
+		_, err := unary(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: unaryMethod},
+			func(context.Context, any) (any, error) {
+				called = true
+				return nil, nil
+			})
+		require.NoError(t, err)
+		require.True(t, called)
+		requireLimitedRequests(t, reg, "")
 	})
 
 	t.Run("other services are not affected by limiting", func(t *testing.T) {

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1962,7 +1962,7 @@ func (t *Loki) initIndexGatewayInterceptors() (services.Service, error) {
 	interceptors := indexgateway.NewServerInterceptors(prometheus.DefaultRegisterer)
 	t.Cfg.Server.GRPCMiddleware = append(t.Cfg.Server.GRPCMiddleware, interceptors.PerTenantRequestCount)
 
-	if !t.Cfg.IndexGateway.UtilizationLimiterEnabled() {
+	if !t.Cfg.IndexGateway.SaturationControl.UtilizationLimiterEnabled() {
 		return nil, nil
 	}
 
@@ -1970,9 +1970,9 @@ func (t *Loki) initIndexGatewayInterceptors() (services.Service, error) {
 	// for the process lifetime. Until it is running (and during its warmup window),
 	// LimitingReason returns an empty string, so the interceptors fail open.
 	utilizationLimiter := limiter.NewUtilizationBasedLimiter(
-		t.Cfg.IndexGateway.CPUUtilizationLimit,
-		uint64(t.Cfg.IndexGateway.MemoryUtilizationLimit),
-		t.Cfg.IndexGateway.LogUtilizationSamples,
+		t.Cfg.IndexGateway.SaturationControl.CPUUtilizationLimit,
+		uint64(t.Cfg.IndexGateway.SaturationControl.MemoryUtilizationLimit),
+		t.Cfg.IndexGateway.SaturationControl.LogUtilizationSamples,
 		log.With(util_log.Logger, "component", "index-gateway"),
 		// The limiter registers its gauges without any prefix, prepend the component one.
 		prometheus.WrapRegistererWithPrefix(constants.Loki+"_index_gateway_", prometheus.DefaultRegisterer),

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1962,25 +1962,66 @@ func (t *Loki) initIndexGatewayInterceptors() (services.Service, error) {
 	interceptors := indexgateway.NewServerInterceptors(prometheus.DefaultRegisterer)
 	t.Cfg.Server.GRPCMiddleware = append(t.Cfg.Server.GRPCMiddleware, interceptors.PerTenantRequestCount)
 
-	if !t.Cfg.IndexGateway.SaturationControl.UtilizationLimiterEnabled() {
+	if !t.Cfg.IndexGateway.SaturationControl.UtilizationLimiterEnabled() && !t.Cfg.IndexGateway.SaturationControl.SchedulerLimiterEnabled() {
 		return nil, nil
 	}
 
-	// The limiter is returned as this module's service so its utilization sampling runs
-	// for the process lifetime. Until it is running (and during its warmup window),
+	// The limiters are returned as this module's service so their sampling runs for
+	// the process lifetime. Until they are running (and during their warmup window),
 	// LimitingReason returns an empty string, so the interceptors fail open.
-	utilizationLimiter := limiter.NewUtilizationBasedLimiter(
-		t.Cfg.IndexGateway.SaturationControl.CPUUtilizationLimit,
-		uint64(t.Cfg.IndexGateway.SaturationControl.MemoryUtilizationLimit),
-		t.Cfg.IndexGateway.SaturationControl.LogUtilizationSamples,
-		log.With(util_log.Logger, "component", "index-gateway"),
-		// The limiter registers its gauges without any prefix, prepend the component one.
-		prometheus.WrapRegistererWithPrefix(constants.Loki+"_index_gateway_", prometheus.DefaultRegisterer),
+	logger := log.With(util_log.Logger, "component", "index-gateway")
+	// The limiters register their gauges without any prefix, prepend the component one.
+	limiterReg := prometheus.WrapRegistererWithPrefix(constants.Loki+"_index_gateway_", prometheus.DefaultRegisterer)
+
+	var (
+		limiterServices []services.Service
+		checkers        []indexgateway.UtilizationChecker
 	)
-	unary, stream := indexgateway.NewSaturationCheckInterceptors(prometheus.DefaultRegisterer, utilizationLimiter)
+	if t.Cfg.IndexGateway.SaturationControl.UtilizationLimiterEnabled() {
+		utilizationLimiter := limiter.NewUtilizationBasedLimiter(
+			t.Cfg.IndexGateway.SaturationControl.CPUUtilizationLimit,
+			uint64(t.Cfg.IndexGateway.SaturationControl.MemoryUtilizationLimit),
+			t.Cfg.IndexGateway.SaturationControl.LogUtilizationSamples,
+			logger,
+			limiterReg,
+		)
+		limiterServices = append(limiterServices, utilizationLimiter)
+		checkers = append(checkers, utilizationLimiter)
+	}
+	if t.Cfg.IndexGateway.SaturationControl.SchedulerLimiterEnabled() {
+		schedulerLimiter := limiter.NewSchedulerBacklogLimiter(t.Cfg.IndexGateway.SaturationControl.SchedulerBacklogLimit, logger, limiterReg)
+		limiterServices = append(limiterServices, schedulerLimiter)
+		checkers = append(checkers, schedulerLimiter)
+	}
+
+	unary, stream := indexgateway.NewSaturationCheckInterceptors(prometheus.DefaultRegisterer, checkers...)
 	t.Cfg.Server.GRPCMiddleware = append(t.Cfg.Server.GRPCMiddleware, unary)
 	t.Cfg.Server.GRPCStreamMiddleware = append(t.Cfg.Server.GRPCStreamMiddleware, stream)
-	return utilizationLimiter, nil
+
+	if len(limiterServices) == 1 {
+		return limiterServices[0], nil
+	}
+
+	// Combine the limiters into a single module service. A failed limiter fails the
+	// module instead of silently leaving the gateway unlimited.
+	mgr, err := services.NewManager(limiterServices...)
+	if err != nil {
+		return nil, err
+	}
+	watcher := services.NewFailureWatcher()
+	watcher.WatchManager(mgr)
+	return services.NewBasicService(
+		func(ctx context.Context) error { return services.StartManagerAndAwaitHealthy(ctx, mgr) },
+		func(ctx context.Context) error {
+			select {
+			case <-ctx.Done():
+				return nil
+			case err := <-watcher.Chan():
+				return fmt.Errorf("index gateway saturation limiter subservice failed: %w", err)
+			}
+		},
+		func(_ error) error { return services.StopManagerAndAwaitStopped(context.Background(), mgr) },
+	), nil
 }
 
 func (t *Loki) initBloomPlanner() (services.Service, error) {

--- a/pkg/util/limiter/sched_latency.go
+++ b/pkg/util/limiter/sched_latency.go
@@ -1,0 +1,227 @@
+package limiter
+
+import (
+	"context"
+	"fmt"
+	gomath "math"
+	"runtime"
+	"runtime/metrics"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/atomic"
+
+	"github.com/grafana/loki/v3/pkg/util/math"
+)
+
+const schedLatenciesMetricName = "/sched/latencies:seconds"
+
+type schedLatencyScanner interface {
+	// Scan returns the cumulative time, in seconds, that goroutines have spent
+	// runnable waiting for a processor since process start, or an error.
+	Scan() (float64, error)
+}
+
+// runtimeSchedLatencyScanner sums the Go runtime's scheduler latency histogram.
+type runtimeSchedLatencyScanner struct {
+	sample []metrics.Sample
+	// bucketValues holds the lower bound of each histogram bucket. Bucket
+	// boundaries are guaranteed constant for the process lifetime, so they are
+	// computed once.
+	bucketValues []float64
+}
+
+func newRuntimeSchedLatencyScanner() (*runtimeSchedLatencyScanner, error) {
+	sample := []metrics.Sample{{Name: schedLatenciesMetricName}}
+	metrics.Read(sample)
+	if sample[0].Value.Kind() != metrics.KindFloat64Histogram {
+		return nil, fmt.Errorf("runtime metric %s is not a histogram", schedLatenciesMetricName)
+	}
+
+	h := sample[0].Value.Float64Histogram()
+	bucketValues := make([]float64, len(h.Counts))
+	for i := range h.Counts {
+		lb := h.Buckets[i]
+		if gomath.IsInf(lb, -1) {
+			// A latency cannot be negative, count the first bucket as zero.
+			lb = 0
+		}
+		bucketValues[i] = lb
+	}
+
+	return &runtimeSchedLatencyScanner{
+		sample:       sample,
+		bucketValues: bucketValues,
+	}, nil
+}
+
+func (s *runtimeSchedLatencyScanner) Scan() (float64, error) {
+	metrics.Read(s.sample)
+	h := s.sample[0].Value.Float64Histogram()
+
+	// Estimate the total wait time from the buckets' lower bounds, the same
+	// (slightly underestimating) approach the Prometheus Go collector uses for
+	// go_sched_latencies_seconds, so this value can be cross-checked against
+	// rate(go_sched_latencies_seconds_sum[1m]) on dashboards.
+	var total float64
+	for i, c := range h.Counts {
+		if c != 0 {
+			total += s.bucketValues[i] * float64(c)
+		}
+	}
+	return total, nil
+}
+
+// SchedulerBacklogLimiter is a Service offering limiting based on the Go scheduler
+// backlog: the average number of runnable goroutines waiting for a processor, per
+// processor (GOMAXPROCS). It is derived from the scheduler latency histogram via
+// Little's law: wait-seconds accumulated per second equals the average number of
+// goroutines waiting at any instant.
+//
+// The backlog is close to 0 on a healthy instance and exceeds 1 when there is more
+// runnable work than processors. Unlike CPU utilization, it also captures
+// saturation from memory-mapped file page faults, which block processors without
+// consuming CPU.
+type SchedulerBacklogLimiter struct {
+	services.Service
+
+	logger  log.Logger
+	scanner schedLatencyScanner
+
+	// Backlog limit in waiting goroutines per GOMAXPROCS. The limit is enabled if the value is > 0.
+	backlogLimit float64
+	// Number of processors used to normalize the backlog.
+	gomaxprocs int
+	// Last cumulative scheduler wait time counter, in seconds.
+	lastTotalWait float64
+	// The time of the first update.
+	firstUpdate time.Time
+	// The time of the last update.
+	lastUpdate       time.Time
+	backlogMovingAvg *math.EwmaRate
+	limitingReason   atomic.String
+	currBacklog      atomic.Float64
+}
+
+// NewSchedulerBacklogLimiter returns a SchedulerBacklogLimiter configured with backlogLimit.
+func NewSchedulerBacklogLimiter(backlogLimit float64, logger log.Logger, reg prometheus.Registerer) *SchedulerBacklogLimiter {
+	// Calculate alpha for a minute long window, same as the utilization based limiter.
+	alpha := 2 / (resourceUtilizationSlidingWindow.Seconds()/resourceUtilizationUpdateInterval.Seconds() + 1)
+	l := &SchedulerBacklogLimiter{
+		logger:           logger,
+		backlogLimit:     backlogLimit,
+		gomaxprocs:       runtime.GOMAXPROCS(0),
+		backlogMovingAvg: math.NewEWMARate(alpha, resourceUtilizationUpdateInterval),
+	}
+	l.Service = services.NewTimerService(resourceUtilizationUpdateInterval, l.starting, l.update, nil)
+
+	if reg != nil {
+		promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "utilization_limiter_current_scheduler_backlog",
+			Help: "Current average scheduler backlog (runnable goroutines waiting per GOMAXPROCS) calculated by the scheduler backlog limiter.",
+		}, func() float64 {
+			return l.currBacklog.Load()
+		})
+	}
+
+	return l
+}
+
+// LimitingReason returns the current reason for limiting, if any.
+// If an empty string is returned, limiting is disabled.
+func (l *SchedulerBacklogLimiter) LimitingReason() string {
+	return l.limitingReason.Load()
+}
+
+func (l *SchedulerBacklogLimiter) starting(_ context.Context) error {
+	var err error
+	l.scanner, err = newRuntimeSchedLatencyScanner()
+	if err != nil {
+		return fmt.Errorf("unable to read Go scheduler latency metrics. Please disable scheduler backlog based limiting: %w", err)
+	}
+
+	return nil
+}
+
+func (l *SchedulerBacklogLimiter) update(_ context.Context) error {
+	l.compute(time.Now)
+	return nil
+}
+
+// compute and return the current scheduler backlog per processor.
+// This function must be called at a regular interval (resourceUtilizationUpdateInterval) to get a predictable behaviour.
+func (l *SchedulerBacklogLimiter) compute(nowFn func() time.Time) (currBacklog float64) {
+	totalWait, err := l.scanner.Scan()
+	if err != nil {
+		level.Warn(l.logger).Log("msg", "failed to get scheduler latency stats", "err", err.Error())
+		// Disable any limiting, since we can't tell the scheduler backlog
+		l.limitingReason.Store("")
+		return
+	}
+
+	// Get wall time after the scan, in case there's a delay before the value is
+	// returned, which would cause us to compute too high of a backlog.
+	now := nowFn()
+
+	// Add the instant backlog to the moving average. It can only be computed
+	// starting from the 2nd tick.
+	if prevUpdate, prevTotalWait := l.lastUpdate, l.lastTotalWait; !prevUpdate.IsZero() {
+		timeSincePrevUpdate := now.Sub(prevUpdate)
+
+		// Skip updates elapsing less than half the expected interval, e.g. two
+		// consecutive ticks on an overloaded process. See the equivalent guard in
+		// UtilizationBasedLimiter.compute.
+		if timeSincePrevUpdate > resourceUtilizationUpdateInterval/2 {
+			// Little's law: wait-seconds accumulated per second equals the average
+			// number of goroutines waiting at any instant. Normalize by GOMAXPROCS
+			// to get a per-processor backlog comparable across pod sizes.
+			instBacklog := (totalWait - prevTotalWait) / timeSincePrevUpdate.Seconds() / float64(l.gomaxprocs)
+			l.backlogMovingAvg.Add(int64(instBacklog * 100))
+			l.backlogMovingAvg.Tick()
+
+			l.lastUpdate = now
+			l.lastTotalWait = totalWait
+		}
+	} else {
+		// First time we read the scheduler latency.
+		l.lastUpdate = now
+		l.lastTotalWait = totalWait
+	}
+
+	// The moving average requires a warmup period before getting stable results,
+	// during which the reported backlog will be 0. Same approach as the
+	// utilization based limiter.
+	if l.firstUpdate.IsZero() {
+		l.firstUpdate = now
+	} else if now.Sub(l.firstUpdate) >= resourceUtilizationSlidingWindow {
+		currBacklog = l.backlogMovingAvg.Rate() / 100
+		l.currBacklog.Store(currBacklog)
+	}
+
+	var reason string
+	if l.backlogLimit > 0 && currBacklog >= l.backlogLimit {
+		reason = "scheduler"
+	}
+
+	enable := reason != ""
+	prevEnable := l.limitingReason.Load() != ""
+	if enable == prevEnable {
+		// No change
+		return
+	}
+
+	if enable {
+		level.Info(l.logger).Log("msg", "enabling scheduler backlog based limiting",
+			"backlog_limit", formatCPU(l.backlogLimit), "scheduler_backlog", formatCPU(currBacklog))
+	} else {
+		level.Info(l.logger).Log("msg", "disabling scheduler backlog based limiting",
+			"backlog_limit", formatCPU(l.backlogLimit), "scheduler_backlog", formatCPU(currBacklog))
+	}
+
+	l.limitingReason.Store(reason)
+	return
+}

--- a/pkg/util/limiter/sched_latency_test.go
+++ b/pkg/util/limiter/sched_latency_test.go
@@ -1,0 +1,215 @@
+package limiter
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// preRecordedSchedLatencyScanner replays instantaneous wait-seconds values,
+// accumulating them into the cumulative counter Scan returns.
+type preRecordedSchedLatencyScanner struct {
+	instantWaitSeconds []float64
+	totalWaitSeconds   float64
+	err                error
+}
+
+func (s *preRecordedSchedLatencyScanner) Scan() (float64, error) {
+	if s.err != nil {
+		return 0, s.err
+	}
+	if len(s.instantWaitSeconds) > 0 {
+		s.totalWaitSeconds += s.instantWaitSeconds[0]
+		s.instantWaitSeconds = s.instantWaitSeconds[1:]
+	}
+	return s.totalWaitSeconds, nil
+}
+
+func TestSchedulerBacklogLimiter(t *testing.T) {
+	setup := func(t *testing.T, backlogLimit float64, gomaxprocs int, instantWaitSeconds []float64) (*SchedulerBacklogLimiter, *preRecordedSchedLatencyScanner, prometheus.Gatherer) {
+		scanner := &preRecordedSchedLatencyScanner{instantWaitSeconds: instantWaitSeconds}
+		reg := prometheus.NewPedanticRegistry()
+		lim := NewSchedulerBacklogLimiter(backlogLimit, log.NewNopLogger(), reg)
+		lim.scanner = scanner
+		lim.gomaxprocs = gomaxprocs
+		require.Empty(t, lim.LimitingReason(), "Limiting should initially be disabled")
+
+		return lim, scanner, reg
+	}
+
+	warmup := func(lim *SchedulerBacklogLimiter, tim *time.Time) {
+		for i := 0; i < int(resourceUtilizationSlidingWindow.Seconds()); i++ {
+			lim.compute(func() time.Time { return *tim })
+			*tim = tim.Add(resourceUtilizationUpdateInterval)
+		}
+	}
+
+	t.Run("no limiting during the warmup period despite high backlog", func(t *testing.T) {
+		// 4 goroutine-seconds of waiting per second on 2 procs = backlog 2 per proc.
+		lim, _, _ := setup(t, 1, 2, generateConstCPUUtilization(120, 4))
+
+		tim := time.Now()
+		for i := 0; i < int(resourceUtilizationSlidingWindow.Seconds()); i++ {
+			backlog := lim.compute(func() time.Time { return tim })
+			tim = tim.Add(resourceUtilizationUpdateInterval)
+			require.Zero(t, backlog, "Backlog should be 0 during warmup")
+			require.Empty(t, lim.LimitingReason(), "Limiting should be disabled during warmup")
+		}
+
+		lim.compute(func() time.Time { return tim })
+		require.Equal(t, "scheduler", lim.LimitingReason(), "Limiting should be enabled after warmup")
+	})
+
+	t.Run("limiting is enabled above the limit and disabled when backlog drops", func(t *testing.T) {
+		// Backlog 2 per proc until just past the warmup, then idle.
+		values := generateConstCPUUtilization(61, 4)
+		values = append(values, generateConstCPUUtilization(120, 0)...)
+		lim, _, reg := setup(t, 1, 2, values)
+
+		tim := time.Now()
+		warmup(lim, &tim)
+
+		lim.compute(func() time.Time { return tim })
+		tim = tim.Add(resourceUtilizationUpdateInterval)
+		require.Equal(t, "scheduler", lim.LimitingReason(), "Limiting should be enabled due to scheduler backlog")
+
+		// The pre-recorded backlog drops to 0, the moving average decays below the limit.
+		for i := 0; i < 60; i++ {
+			lim.compute(func() time.Time { return tim })
+			tim = tim.Add(resourceUtilizationUpdateInterval)
+		}
+		require.Empty(t, lim.LimitingReason(), "Limiting should be disabled again")
+
+		count, err := testutil.GatherAndCount(reg, "utilization_limiter_current_scheduler_backlog")
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+	})
+
+	t.Run("limiting is disabled when the limit is 0", func(t *testing.T) {
+		lim, _, _ := setup(t, 0, 2, generateConstCPUUtilization(180, 100))
+
+		tim := time.Now()
+		warmup(lim, &tim)
+
+		for i := 0; i < 60; i++ {
+			lim.compute(func() time.Time { return tim })
+			tim = tim.Add(resourceUtilizationUpdateInterval)
+			require.Empty(t, lim.LimitingReason(), "Limiting should be disabled")
+		}
+	})
+
+	t.Run("scan errors clear an active limiting reason", func(t *testing.T) {
+		lim, scanner, _ := setup(t, 1, 2, generateConstCPUUtilization(180, 4))
+
+		tim := time.Now()
+		warmup(lim, &tim)
+		lim.compute(func() time.Time { return tim })
+		require.Equal(t, "scheduler", lim.LimitingReason())
+
+		scanner.err = errors.New("boom")
+		lim.compute(func() time.Time { return tim })
+		require.Empty(t, lim.LimitingReason(), "Limiting should fail open on scan errors")
+	})
+
+	t.Run("updates elapsing less than half the interval are skipped", func(t *testing.T) {
+		lim, _, _ := setup(t, 1, 2, generateConstCPUUtilization(10, 1))
+
+		tim := time.Now()
+		lim.compute(func() time.Time { return tim })
+		require.InDelta(t, 1, lim.lastTotalWait, 0.0001)
+
+		for expected := 2; expected <= 5; expected++ {
+			tim = tim.Add(resourceUtilizationUpdateInterval)
+			lim.compute(func() time.Time { return tim })
+			require.InDelta(t, float64(expected), lim.lastTotalWait, 0.0001)
+		}
+
+		// Consecutive computations at a very short interval do not update the counter.
+		for i := 0; i < 5; i++ {
+			tim = tim.Add(resourceUtilizationUpdateInterval / 10)
+			lim.compute(func() time.Time { return tim })
+			require.InDelta(t, float64(5), lim.lastTotalWait, 0.0001)
+		}
+
+		// One more short tick crosses the half-interval mark and is tracked.
+		tim = tim.Add(resourceUtilizationUpdateInterval / 10)
+		lim.compute(func() time.Time { return tim })
+		require.InDelta(t, float64(10), lim.lastTotalWait, 0.0001)
+	})
+
+	t.Run("backlog is normalized by GOMAXPROCS", func(t *testing.T) {
+		// Same wait input: 4 goroutine-seconds of waiting per second.
+		limSingle, _, _ := setup(t, 0, 1, generateConstCPUUtilization(180, 4))
+		limQuad, _, _ := setup(t, 0, 4, generateConstCPUUtilization(180, 4))
+
+		tim1, tim4 := time.Now(), time.Now()
+		warmup(limSingle, &tim1)
+		warmup(limQuad, &tim4)
+
+		var backlogSingle, backlogQuad float64
+		for i := 0; i < 60; i++ {
+			backlogSingle = limSingle.compute(func() time.Time { return tim1 })
+			tim1 = tim1.Add(resourceUtilizationUpdateInterval)
+			backlogQuad = limQuad.compute(func() time.Time { return tim4 })
+			tim4 = tim4.Add(resourceUtilizationUpdateInterval)
+		}
+
+		assert.InDelta(t, 4, backlogSingle, 0.1)
+		assert.InDelta(t, 1, backlogQuad, 0.1)
+		assert.InDelta(t, backlogSingle/4, backlogQuad, 0.01)
+	})
+
+	t.Run("gauge reports the current backlog", func(t *testing.T) {
+		// Constant backlog of 1 per proc: 2 wait-seconds per second on 2 procs.
+		lim, _, reg := setup(t, 0, 2, generateConstCPUUtilization(180, 2))
+
+		tim := time.Now()
+		warmup(lim, &tim)
+		var backlog float64
+		for i := 0; i < 60; i++ {
+			backlog = lim.compute(func() time.Time { return tim })
+			tim = tim.Add(resourceUtilizationUpdateInterval)
+		}
+
+		// The moving average asymptotically approaches the constant input.
+		assert.InDelta(t, 1, backlog, 0.05)
+
+		mfs, err := reg.Gather()
+		require.NoError(t, err)
+		require.Len(t, mfs, 1)
+		require.Equal(t, "utilization_limiter_current_scheduler_backlog", mfs[0].GetName())
+		require.Len(t, mfs[0].GetMetric(), 1)
+		assert.Equal(t, backlog, mfs[0].GetMetric()[0].GetGauge().GetValue())
+	})
+}
+
+func TestRuntimeSchedLatencyScanner(t *testing.T) {
+	scanner, err := newRuntimeSchedLatencyScanner()
+	require.NoError(t, err)
+
+	first, err := scanner.Scan()
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, first, 0.0)
+
+	// Churn some goroutines to generate scheduling events.
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(time.Millisecond)
+		}()
+	}
+	wg.Wait()
+
+	second, err := scanner.Scan()
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, second, first, "cumulative wait time must be monotonic")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Stacked on #23460. Index gateways also saturate on disk I/O through mmap page faults: faulting threads hold Go processors hostage in the kernel without consuming CPU, so the CPU-based limiter from #23460 cannot see it.

This adds a second limiting signal: **scheduler backlog per core** — the average number of runnable goroutines waiting per GOMAXPROCS, derived from the Go runtime's `/sched/latencies:seconds` histogram via Little's law (wait-seconds accumulated per second = average goroutines waiting). It approaches 0 on a healthy instance and exceeds 1 when saturated, regardless of whether the cause is CPU or page-fault stalls. Same 60s EWMA smoothing and warmup as the CPU signal.

- New experimental flag `-index-gateway.scheduler-backlog-limit` (0 disables; ~1.0 recommended). Rejections use the existing saturation error and counter with `reason="scheduler"`.
- The saturation interceptors now accept multiple checkers (first non-empty reason wins); both limiters can run together as one module service.
- The histogram sum uses the same lower-bound estimator as client_golang's `go_sched_latencies_seconds`, so the exposed gauge cross-checks against `rate(go_sched_latencies_seconds_sum[1m]) / GOMAXPROCS` on dashboards.

**Which issue(s) this PR fixes**:
N/A (follow-up to #23460)

**Special notes for your reviewer**:
`pkg/util/limiter/utilization.go` (the Mimir copy) is untouched; the new limiter is a Loki-native sibling in the same package.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)