### PR TITLE
fix(logql): Do not push vector aggregation past label_replace when splitting by range

### DIFF
--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -707,6 +707,13 @@ func TestRangeMappingEquivalence(t *testing.T) {
 		// label_replace
 		{`label_replace(sum by (a) (count_over_time({a=~".+"}[3s])), "", "", "", "")`, time.Second},
 		{`label_replace(sum by (a) (count_over_time({a=~".+"}[3s])), "foo", "$1", "a", "(.*)")`, time.Second},
+
+		// label_replace nested inside the vector aggregation
+		{`sum by (foo) (label_replace(count_over_time({a=~".+"}[3s]), "foo", "other", "a", ".*"))`, time.Second},
+		{`sum by (foo) (label_replace(label_replace(count_over_time({a=~".+"}[3s]), "foo", "other", "a", ".*"), "foo", "matched", "a", "1"))`, time.Second},
+		{`sum by (foo, a) (label_replace(label_replace(count_over_time({a=~".+"}[3s]), "foo", "other", "a", ".*"), "foo", "matched", "a", "1"))`, time.Second},
+		{`sum (label_replace(count_over_time({a=~".+"}[3s]), "foo", "other", "a", ".*"))`, time.Second},
+		{`sum by (foo) (label_replace(rate({a=~".+"}[3s]), "foo", "other", "a", ".*"))`, time.Second},
 	} {
 		q := NewMockQuerier(
 			shards,

--- a/pkg/logql/rangemapper.go
+++ b/pkg/logql/rangemapper.go
@@ -169,7 +169,12 @@ func (m RangeMapper) Map(expr syntax.SampleExpr, vectorAggrPushdown *syntax.Vect
 		e.RHS = rhsMapped
 		return e, nil
 	case *syntax.LabelReplaceExpr:
-		lhsMapped, err := m.Map(e.Left, vectorAggrPushdown, recorder)
+		// Do not push the outer vector aggregation past a label_replace. The
+		// pushdown would evaluate the grouping on the wrong side of the label
+		// mutation, and the label_replace kept on the merged result would be
+		// evaluated a second time on a label set the pushed down aggregation
+		// already reduced, silently rewriting labels whose source label is gone.
+		lhsMapped, err := m.Map(e.Left, nil, recorder)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/logql/rangemapper_test.go
+++ b/pkg/logql/rangemapper_test.go
@@ -1809,6 +1809,40 @@ func Test_SplitRangeVectorMapping(t *testing.T) {
 			)`,
 			3,
 		},
+		// The vector aggregation must not be pushed down into the downstream
+		// queries when a label_replace sits in between: the label_replace has to
+		// be evaluated exactly once, on a label set that still holds its source
+		// label.
+		{
+			`sum by (x) (label_replace(count_over_time({app="foo"}[3m]), "x", "$1", "a", "(.*)"))`,
+			`sum by (x) (
+				label_replace(
+					sum without () (
+						downstream<count_over_time({app="foo"} [1m] offset 2m0s), shard=<nil>>
+						++ downstream<count_over_time({app="foo"} [1m] offset 1m0s), shard=<nil>>
+						++ downstream<count_over_time({app="foo"} [1m]), shard=<nil>>
+					),
+					"x", "$1", "a", "(.*)"
+				)
+			)`,
+			3,
+		},
+		{
+			`sum by (x) (label_replace(rate({app="foo"}[3m]), "x", "$1", "a", "(.*)"))`,
+			`sum by (x) (
+				label_replace(
+					(
+						sum without () (
+							downstream<count_over_time({app="foo"} [1m] offset 2m0s), shard=<nil>>
+							++ downstream<count_over_time({app="foo"} [1m] offset 1m0s), shard=<nil>>
+							++ downstream<count_over_time({app="foo"} [1m]), shard=<nil>>
+						)
+					/ 180),
+					"x", "$1", "a", "(.*)"
+				)
+			)`,
+			3,
+		},
 	} {
 		t.Run(tc.expr, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
## What this PR does / why we need it

`sum by (...)` over a nested `label_replace` chain silently loses groups once the query range exceeds the instant metric query split interval.

Reported query (from #20314):

```logql
sum by (component) (
  label_replace(
    label_replace(
      count_over_time({app="alloy"} | logfmt component_id="component_id" [$__range]),
      "component", "Other", "component_id", ".*"),
    "component", "Prometheus", "component_id", "prometheus.*"))
```

| `$__range` | Result |
| --- | --- |
| `<= 60m` | two groups, `{component="Other"}` and `{component="Prometheus"}` — correct |
| `>= 61m` | one group, `{component="Other"}`, holding the **sum of both** |
| `>= 61m`, changed to `sum by (component, component_id)` | correct again |

`split_instant_metric_queries_by_interval` defaults to `1h`, which is exactly the 60m/61m boundary: at 61m `RangeMapper` starts splitting, and the split rewrite is what breaks the result.

### Root cause

When `RangeMapper` splits a metric query by range it pushes the outer vector aggregation into every downstream subquery, to reduce the number of series each subquery returns. `Map` forwarded that pushdown straight through `*syntax.LabelReplaceExpr`:

```go
case *syntax.LabelReplaceExpr:
	lhsMapped, err := m.Map(e.Left, vectorAggrPushdown, recorder)
```

The pushdown is the whole ancestor aggregation, `label_replace` chain included, so the chain ends up **both** inside every subquery **and** on the merged result. Today the query above maps to (split `30m`, abbreviated):

```
sum by (component) (
  label_replace(label_replace(
    sum without () (
      downstream<sum by (component) (label_replace(label_replace(count_over_time(...[30m]))))>
      ++ ...),
    "component","Other","component_id",".*"),
  "component","Prometheus","component_id","prometheus.*"))
```

Each subquery has already reduced its output to `by (component)`, so the second, outer evaluation of the chain no longer sees `component_id`. `label_replace` treats a missing source label as the empty string, `.*` matches the empty string, and so **every** series is rewritten to `component="Other"`; the final `sum by (component)` then folds the two distinct groups into one. That is precisely the reported symptom, and it also explains why `sum by (component, component_id)` works around it: the source label survives the pushdown, so the second evaluation is idempotent.

The same reordering breaks `rate`/`bytes_rate` through a different path — `sumOverFullRange` pushes down only the grouping and operation, so the grouping is applied to the raw series *before* `label_replace` has created the label being grouped on.

### The fix

Map the inner expression without the pushdown, so `label_replace` is evaluated exactly once, on a label set that still holds its source labels:

```
sum by (component) (
  label_replace(label_replace(
    sum without () (
      downstream<count_over_time({app="alloy"} | logfmt component_id="component_id" [30m])>
      ++ ...),
    "component","Other","component_id",".*"),
  "component","Prometheus","component_id","prometheus.*"))
```

This mirrors what `mapVectorAggregationExpr` already does for `BinOpExpr`, which likewise refuses to push the aggregation into a subtree where it would not be sound.

**Why this is equivalent to the unsplit query, not a behaviour change.** `count_over_time` over the full range equals the sum of `count_over_time` over the split subranges for each stream, and `sum without ()` merges the concatenated subqueries by the full label set, so the merge reproduces exactly the per-stream full-range values the unsplit query computes. `label_replace` is a per-series label function that does not depend on the sample value, and the following `sum by (...)` is applied to the same label sets as in the unsplit query. So the mapped expression and the original evaluate to the same result — which is the definition this PR restores. No query that returns correct results today changes its output; the only outputs that change are the wrong ones.

**Trade-off.** The per-subquery aggregation pushdown is given up for queries with a `label_replace` between the vector aggregation and the range aggregation, so those subqueries return more series than before. The query is still split by range. For the subset that also uses a series-exploding label extractor (`| json`, bare `| logfmt`), the pre-existing guard in `mapRangeAggregationExpr` — which declines to split when there is no pushdown and a label extractor is present — makes the query fall back to being executed unsplit, i.e. the same path a `<= 60m` range already takes today. I chose correctness over keeping the optimisation here; the pushdown could be restored later by dropping the now-redundant outer `label_replace` when the pushdown is known to have been consumed, but that needs a "was the pushdown used" signal threaded through `Map` and is a larger change than a correctness fix warrants.

### Relationship to #16920

Worth noting since both involve `label_replace` subtrees: **they are not the same bug.** `LabelReplaceExpr.Walk` does descend into `e.Left`, so `appendDownstream`, `getRangeInterval` and `hasLabelExtractionStage` all traverse correctly, and `RangeMapper` never uses the `DepthFirstTraversal` visitor from #16920. The visitor gap reported in #16920 is real but independent, and this PR does not address it.

## Which issue(s) this PR fixes

Fixes #20314

## Special notes for your reviewer

The functional change is one argument, `vectorAggrPushdown` → `nil`, in `RangeMapper.Map`. Everything else is tests.

Tests added:

- `TestRangeMappingEquivalence` (`pkg/logql/downstream_test.go`) — five cases with `label_replace` nested *inside* the vector aggregation. The existing `label_replace` cases only placed it outside, where the pushdown never reaches it, which is why this went uncaught. This test asserts the split-by-range result equals the unsplit result over the same data, so it pins the equivalence argument above rather than just the AST shape. It includes the reported group-collapse case, the `sum by (foo, a)` workaround, the no-grouping `sum(...)` case, and the `rate` variant.
- `Test_SplitRangeVectorMapping` (`pkg/logql/rangemapper_test.go`) — two cases locking in the mapped AST for `count_over_time` and `rate`, asserting the aggregation is no longer pushed into the subqueries and that the query is still split into 3.

Before the fix, 4 of these cases fail; the `TestRangeMappingEquivalence` group-collapse case fails as:

```
expected: {foo="matched"} => 21 @[1000], {foo="other"} => 39 @[1000]
actual  : {foo="other"}   => 60 @[1000]
```

which is the reported bug: one group instead of two, carrying the combined total. After the fix all pass.

Verified:

- `go test ./pkg/logql/... -count=1` — all pass, no existing expectations needed updating
- `go test ./pkg/querier/queryrange/... -count=1` — all pass
- `go build ./cmd/loki`, `gofmt -l` clean on the touched files

No CHANGELOG entry: this repo generates `CHANGELOG.md` with release-please from the commit title.
