### PR TITLE
fix(compactor): Delete chunks marked for deletion when compactor leadership changes

### DIFF
--- a/docs/sources/operations/storage/retention.md
+++ b/docs/sources/operations/storage/retention.md
@@ -54,6 +54,11 @@ Marker files should be stored on a persistent disk to ensure that the chunks pen
 Grafana Labs recommends running Compactor as a stateful deployment (StatefulSet when using Kubernetes) with a persistent storage for storing marker files.
 {{< /admonition >}}
 
+Alternatively, set `-compactor.deletion-marker-object-store-prefix` to store the marker files under the
+given prefix in object storage instead of on the local disk. Marker files in object storage are visible
+to every Compactor instance, so the instance that deletes the chunks does not have to be the one that
+marked them. Any marker files found on the local disk are copied to object storage on startup.
+
 ### Retention Configuration
 
 This Compactor configuration example activates retention.

--- a/docs/sources/operations/storage/retention.md
+++ b/docs/sources/operations/storage/retention.md
@@ -59,7 +59,7 @@ By default, marker files are written to local disk, under `<working_directory>/r
 Grafana Labs recommends running Compactor as a stateful deployment (StatefulSet when using Kubernetes) with a persistent storage for storing marker files.
 {{< /admonition >}}
 
-Alternatively, you can configure the Compactor to store marker files in object storage instead of local disk, by setting `compactor.deletion-marker-object-store-prefix` (`deletion_marker_object_store_prefix`) to a prefix that ends with `/`. When set, the Compactor writes marker files to the same per-period object store bucket used for chunks, under that prefix. On startup it also copies any existing marker files from local disk to that prefix, then removes the local copies. This lets you run the Compactor without a persistent volume for marker files. Leave this setting empty to keep using local disk.
+Alternatively, you can configure the Compactor to store marker files in object storage instead of local disk, by setting `compactor.deletion-marker-object-store-prefix` (`deletion_marker_object_store_prefix`) to a prefix that ends with `/`. When set, the Compactor writes marker files to the same per-period object store bucket used for chunks, under that prefix. On startup it also copies any existing marker files from local disk to that prefix, then removes the local copies. This lets you run the Compactor without a persistent volume for marker files. Marker files in object storage are visible to every Compactor instance, so the instance that deletes the chunks does not have to be the one that marked them. Leave this setting empty to keep using local disk.
 
 ### Retention Configuration
 

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -464,6 +464,22 @@ func (c *Compactor) loop(ctx context.Context) error {
 	var runningCtx context.Context
 	var runningCancel context.CancelFunc
 	var wg sync.WaitGroup
+	var sweepersWG sync.WaitGroup
+
+	if c.cfg.RetentionEnabled && c.cfg.markersOnLocalDisk() {
+		// Chunk deletion markers are written to the local disk of whichever instance is
+		// running the compactor, and they are only processed after
+		// retention_delete_delay has elapsed. Since leadership can move to another
+		// instance within that window, and local markers are not visible to the other
+		// instances, every instance sweeps its own markers no matter whether it
+		// currently owns the compaction. Otherwise the chunks marked by a former leader
+		// would never be deleted from the object store.
+		sweepersWG.Add(1)
+		go func() {
+			defer sweepersWG.Done()
+			c.tablesManager.startChunkSweepers(ctx)
+		}()
+	}
 
 	for {
 		select {
@@ -472,6 +488,7 @@ func (c *Compactor) loop(ctx context.Context) error {
 				runningCancel()
 			}
 			wg.Wait()
+			sweepersWG.Wait()
 			level.Info(util_log.Logger).Log("msg", "compactor exiting")
 			return nil
 		case <-syncTicker.C:

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/compactor/retention"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/local"
 	"github.com/grafana/loki/v3/pkg/storage/config"
@@ -39,7 +42,7 @@ var (
 	start = model.Now().Add(-30 * 24 * time.Hour)
 )
 
-func setupTestCompactor(t *testing.T, objectClients map[config.DayTime]client.ObjectClient, periodConfigs []config.PeriodConfig, tempDir string) *Compactor {
+func setupTestCompactor(t *testing.T, objectClients map[config.DayTime]client.ObjectClient, periodConfigs []config.PeriodConfig, tempDir string, cfgOpts ...func(*Config)) *Compactor {
 	cfg := Config{}
 	flagext.DefaultValues(&cfg)
 	cfg.WorkingDirectory = filepath.Join(tempDir, workingDirName)
@@ -49,6 +52,10 @@ func setupTestCompactor(t *testing.T, objectClients map[config.DayTime]client.Ob
 
 	if loopbackIFace, err := loki_net.LoopbackInterfaceName(); err == nil {
 		cfg.CompactorRing.InstanceInterfaceNames = append(cfg.CompactorRing.InstanceInterfaceNames, loopbackIFace)
+	}
+
+	for _, opt := range cfgOpts {
+		opt(&cfg)
 	}
 
 	require.NoError(t, cfg.Validate())
@@ -154,6 +161,84 @@ func TestCompactor_RunCompactionMultipleStores(t *testing.T) {
 
 		verifyCompactedIndexTable(t, commonDBsConfig, perUserDBsConfig, filepath.Join(periodTwoPath, "index", name))
 	}
+}
+
+// TestCompactor_SweepsOwnMarkersWithoutLeadership verifies that a compactor keeps
+// processing the chunk deletion markers it wrote to its local disk even while it does
+// not own the compaction. Leadership can move to another instance within the
+// retention_delete_delay window, and markers on local disk are not visible to the other
+// instances, so the chunks would otherwise never be deleted from the object store.
+func TestCompactor_SweepsOwnMarkersWithoutLeadership(t *testing.T) {
+	tempDir := t.TempDir()
+	storePath := filepath.Join(tempDir, "store")
+
+	periodConfig := config.PeriodConfig{
+		From:       config.DayTime{Time: model.Time(0)},
+		IndexType:  "dummy",
+		ObjectType: "filesystem",
+		Schema:     "v13",
+		IndexTables: config.IndexPeriodicTableConfig{
+			PathPrefix: "index/",
+			PeriodicTableConfig: config.PeriodicTableConfig{
+				Prefix: indexTablePrefix,
+				Period: config.ObjectStorageIndexRequiredPeriod,
+			}},
+		RowShards: 16,
+	}
+	schemaConfig := config.SchemaConfig{Configs: []config.PeriodConfig{periodConfig}}
+
+	objectClient, err := local.NewFSObjectClient(local.FSConfig{Directory: storePath})
+	require.NoError(t, err)
+
+	compactor := setupTestCompactor(t, map[config.DayTime]client.ObjectClient{periodConfig.From: objectClient},
+		[]config.PeriodConfig{periodConfig}, tempDir, func(cfg *Config) {
+			// markers become eligible for processing right away.
+			cfg.RetentionDeleteDelay = 0
+		})
+	require.True(t, compactor.cfg.markersOnLocalDisk())
+
+	// store a chunk and mark it for deletion the same way the compaction would.
+	chunkRef := logproto.ChunkRef{
+		UserID:      "user1",
+		Fingerprint: 1,
+		From:        start,
+		Through:     start.Add(time.Hour),
+		Checksum:    1,
+	}
+	chunkID := schemaConfig.ExternalKey(chunkRef)
+	chunkKey := client.FSEncoder(schemaConfig, chunk.Chunk{ChunkRef: chunkRef})
+	require.NoError(t, objectClient.PutObject(context.Background(), chunkKey, strings.NewReader("chunk")))
+
+	markersClient, err := local.NewFSObjectClient(local.FSConfig{Directory: filepath.Join(
+		compactor.cfg.WorkingDirectory, "retention", fmt.Sprintf("%s_%s", periodConfig.ObjectType, periodConfig.From.String()), MarkersFolder,
+	)})
+	require.NoError(t, err)
+
+	markerWriter, err := retention.NewMarkerWriter(markersClient)
+	require.NoError(t, err)
+	require.NoError(t, markerWriter.Put([]byte(chunkID)))
+	require.NoError(t, markerWriter.Close())
+
+	// The ring is not running, so this instance never gets elected to run the compaction.
+	// Even if it did, the compaction only starts after one compaction interval, so the
+	// marker below can only be processed by a sweeper that does not depend on leadership.
+	ctx, cancel := context.WithCancel(context.Background())
+	loopStopped := make(chan struct{})
+	var loopErr error
+	go func() {
+		defer close(loopStopped)
+		loopErr = compactor.loop(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-loopStopped
+		require.NoError(t, loopErr)
+	})
+
+	require.Eventually(t, func() bool {
+		exists, err := objectClient.ObjectExists(context.Background(), chunkKey)
+		return err == nil && !exists
+	}, 30*time.Second, 100*time.Millisecond, "chunk marked for deletion was not swept")
 }
 
 func Test_schemaPeriodForTable(t *testing.T) {

--- a/pkg/compactor/config.go
+++ b/pkg/compactor/config.go
@@ -134,6 +134,12 @@ func (cfg *Config) Validate() error {
 	return cfg.WorkerConfig.Validate()
 }
 
+// markersOnLocalDisk returns true when chunk deletion markers are stored on the local
+// disk of each compactor instance rather than in a shared object store prefix.
+func (cfg *Config) markersOnLocalDisk() bool {
+	return cfg.DeletionMarkerObjectStorePrefix == ""
+}
+
 type JobsConfig struct {
 	Deletion DeletionJobsConfig `yaml:"deletion"`
 }

--- a/pkg/compactor/retention/marker.go
+++ b/pkg/compactor/retention/marker.go
@@ -179,6 +179,11 @@ func newMarkerReader(markerStorageClient client.ObjectClient, maxParallelism int
 func (r *markerProcessor) Start(deleteFunc func(ctx context.Context, chunkId []byte) error) {
 	level.Info(util_log.Logger).Log("msg", "mark processor started", "workers", r.maxParallelism, "delay", r.minAgeFile)
 	r.wg.Wait() // only one start at a time.
+	// Stop cancels the context shared by the goroutines below, so a fresh one is
+	// required here to make the processor restartable. Compactors stop the marker
+	// processor when they lose the compactor leader election and start it again if
+	// they win it back.
+	r.ctx, r.cancel = context.WithCancel(context.Background())
 	r.wg.Add(1)
 	go func() {
 		defer r.wg.Done()

--- a/pkg/compactor/retention/marker_test.go
+++ b/pkg/compactor/retention/marker_test.go
@@ -128,6 +128,54 @@ func Test_markerProcessor_StartDeleteOnSuccess(t *testing.T) {
 	}, 10*time.Second, 100*time.Microsecond)
 }
 
+func Test_markerProcessor_Restart(t *testing.T) {
+	minListMarkDelay = time.Second
+	dir := t.TempDir()
+
+	markerStorageClient, err := local.NewFSObjectClient(local.FSConfig{Directory: dir})
+	require.NoError(t, err)
+
+	p, err := newMarkerReader(markerStorageClient, 5, 0, sweepMetrics)
+	require.NoError(t, err)
+
+	seen := map[string]struct{}{}
+	l := sync.Mutex{}
+	deleteFunc := func(_ context.Context, id []byte) error {
+		l.Lock()
+		defer l.Unlock()
+		seen[string(id)] = struct{}{}
+		return nil
+	}
+	sawKey := func(key string) func() bool {
+		return func() bool {
+			l.Lock()
+			defer l.Unlock()
+			_, ok := seen[key]
+			return ok
+		}
+	}
+
+	putMark := func(chunkID string) {
+		w, err := NewMarkerWriter(markerStorageClient)
+		require.NoError(t, err)
+		require.NoError(t, w.Put([]byte(chunkID)))
+		require.NoError(t, w.Close())
+	}
+
+	putMark("1")
+	p.Start(deleteFunc)
+	require.Eventually(t, sawKey("1"), 10*time.Second, 10*time.Millisecond)
+
+	// Compactors stop the marker processor when they lose the leader election and
+	// start it again if they win it back. The processor must resume processing marks.
+	p.Stop()
+
+	putMark("2")
+	p.Start(deleteFunc)
+	defer p.Stop()
+	require.Eventually(t, sawKey("2"), 10*time.Second, 10*time.Millisecond)
+}
+
 func Test_markerProcessor_availablePath(t *testing.T) {
 	now := time.Now()
 	for _, tt := range []struct {

--- a/pkg/compactor/tables_manager.go
+++ b/pkg/compactor/tables_manager.go
@@ -128,23 +128,41 @@ func (c *tablesManager) start(ctx context.Context) {
 			}
 		}()
 
-		for _, container := range c.storeContainers {
-			if container.sweeper == nil {
-				continue
-			}
+		// Markers stored in the object store are visible to every compactor instance, so
+		// only the instance running the compaction needs to sweep them. Markers kept on
+		// local disk are swept by the instance owning them, see Compactor.loop.
+		if !c.cfg.markersOnLocalDisk() {
 			wg.Add(1)
-			go func(sc storeContainer) {
-				// starts the chunk sweeper
-				defer func() {
-					sc.sweeper.Stop()
-					wg.Done()
-				}()
-				sc.sweeper.Start()
-				<-ctx.Done()
-			}(container)
+			go func() {
+				defer wg.Done()
+				c.startChunkSweepers(ctx)
+			}()
 		}
 	}
 	level.Info(util_log.Logger).Log("msg", "compactor started")
+
+	wg.Wait()
+}
+
+// startChunkSweepers starts the chunk sweeper of each store container and blocks until
+// ctx is cancelled, at which point the sweepers are stopped.
+func (c *tablesManager) startChunkSweepers(ctx context.Context) {
+	wg := sync.WaitGroup{}
+	for _, container := range c.storeContainers {
+		if container.sweeper == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(sc storeContainer) {
+			// starts the chunk sweeper
+			defer func() {
+				sc.sweeper.Stop()
+				wg.Done()
+			}()
+			sc.sweeper.Start()
+			<-ctx.Done()
+		}(container)
+	}
 
 	wg.Wait()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Retention and delete requests are applied in two phases. The compaction removes the chunk references from the index and records them in a marker file; a sweeper then deletes those chunks from the object store once `retention_delete_delay` (2 hours by default) has elapsed.

Marker files are written to the local disk of whichever instance currently wins the compactor ring leader election, and only the elected instance runs the sweeper (`tablesManager.start` is called only from the leader branch of `Compactor.loop`). In SSD mode the leadership can move to another instance inside the delay window, and markers on local disk are not visible to the other instances, so the chunks they reference are never deleted from the object store.

As @slim-bean notes in #11119, this is not only wasted object storage. Chunks marked because of a delete request are dropped from the index but never removed from storage, so a delete request submitted through the delete API silently fails to delete the data even though the API reported success — which matters for anyone relying on the API to satisfy a data deletion obligation. @Perdjesk's comment on the issue reports the same failure mode reachable from the default Helm SSD values.

While digging into this I also found a second, sharper failure: the marker processor cannot be restarted. `newMarkerReader` creates one context per processor and `Stop` cancels it, so once an instance has lost the leader election a later `Start` returns immediately (`r.ctx.Err() != nil`) and that instance never sweeps again for the rest of the process lifetime — not even while it is the elected leader. This makes the "unless that node becomes the leader elected compactor again" escape hatch mentioned in the issue ineffective, and it fits @duj4's observation on the issue of a compactor service starting again after a stop.

**Which issue(s) this PR fixes**:
Fixes #11119

**Solution and trade-offs**:

The issue lists two solutions:

1. marker files should go to object storage
2. all compactors could run sweepers to make sure they cleanup any marker files they have even if they aren't the elected leader

Option 1 already landed in #19689: `-compactor.deletion-marker-object-store-prefix` stores markers under an object storage prefix, and existing local markers are copied over on startup. It is opt-in and empty by default, so the default configuration — including the default Helm SSD values, where `backend` runs the compactor with 3 replicas — is still affected.

This PR implements option 2 for that default. Each instance now runs the chunk sweeper for the markers on its own disk regardless of whether it currently owns the compaction, so a former leader finishes deleting the chunks it marked.

Deliberately, this applies only when markers are on local disk. When `deletion_marker_object_store_prefix` is set the markers live in one shared prefix that every instance can already see, so sweeping continues to run on the elected instance only. Sweeping a shared prefix from every instance would duplicate the object storage deletes and let two instances race over the same marker file, whereas local markers are private to their instance by construction, so there is no contention.

I did not change the default of `deletion_marker_object_store_prefix`. Flipping it would change the storage layout and the object storage request profile of every existing deployment, which seems like a maintainer call rather than something to slip into a bug fix. Happy to follow up separately if you would like that instead.

`retention_delete_delay` semantics are unchanged: eligibility is still decided by `markerProcessor.availableFiles` from the marker file timestamp, so the window that lets index gateways refresh their index copies before chunks disappear is preserved. The sweep just happens on the instance holding the marker instead of nowhere.

**Backwards compatibility / upgrade**:

* No configuration change, no new option, no default value change.
* Marker file format and on-disk layout are untouched, so a downgrade is safe: markers written before or after this change are read identically by either version.
* Markers already sitting on the local disk of a former leader when the new version starts are picked up on startup. That backlog is exactly what the fix drains, so no migration step is needed. The pre-existing `retention.CopyMarkers` migration from the legacy `retention/markers` and `retention/<store>/markers` directories into the period-specific directories is left as is.
* Deployments already using `deletion_marker_object_store_prefix` keep their current behaviour, minus the restart bug.
* No upgrade guide entry, since no operator action is required. Happy to add one if you would rather call the behaviour change out explicitly.
* One consequence worth flagging: instances that are not the leader now emit the existing `no marks file found` sweeper log line once a minute per period. It is a local directory listing, so the cost is negligible, but the line was previously logged only by the leader. Let me know if you would prefer it downgraded to debug.

**Special notes for your reviewer**:

Two tests, both verified to fail before the change:

* `Test_markerProcessor_Restart` — processes a mark, stops the processor the way a lost leader election does, writes another mark and starts it again. Before the fix the second mark is never processed (`Condition never satisfied`).
* `TestCompactor_SweepsOwnMarkersWithoutLeadership` — writes a chunk and a marker for it, then runs `Compactor.loop` with a ring that never elects this instance, and asserts the chunk is removed from the object store. Before the fix the chunk survives (`chunk marked for deletion was not swept`).

Verification: `go test ./pkg/compactor/... -count=1` passes, as does `-race` on `./pkg/compactor/ ./pkg/compactor/retention/`; `go build ./cmd/loki` and `gofmt` are clean.

The docs change mentions `-compactor.deletion-marker-object-store-prefix` on the retention page next to the existing persistent-disk recommendation, since that option was not referenced there at all.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md` — n/a, no operator action required
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory — n/a
