### PR TITLE
feat: Replace `mmap` index access in index gateways with Mimir's pread+bufferpool implementation

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3988,11 +3988,19 @@ ring:
   [instance_enable_ipv6: <boolean> | default = false]
 
 # Maximum number of idle file handles the index gateway keeps open for each TSDB
-# index file. Index files are read on demand via pread(2) instead of being
-# memory-mapped; a small pool of handles per file avoids reopening the file on
-# every read while keeping the number of open file descriptors bounded.
+# index file. Only used when -index-gateway.index-reader-impl is 'pread'. A
+# small pool of handles per file avoids reopening the file on every read while
+# keeping the number of open file descriptors bounded.
 # CLI flag: -index-gateway.max-idle-file-handles
 [max_idle_file_handles: <int> | default = 4]
+
+# How TSDB index files are read. 'pread' reads index sections on demand via
+# pread(2) from a bounded pool of file handles, keeping memory usage
+# predictable. 'mmap' memory-maps the whole index file, which is faster while
+# the file stays resident in the page cache but can stall on major page faults
+# under memory pressure.
+# CLI flag: -index-gateway.index-reader-impl
+[index_reader_impl: <string> | default = "pread"]
 ```
 
 ### ingester
@@ -6932,6 +6940,8 @@ tsdb_shipper:
   [ingesterdbretainperiod: <duration>]
 
   [maxidlefilehandles: <int>]
+
+  [indexreaderimpl: <string> | default = ""]
 
 # Experimental: Configures the bloom shipper component, which contains the store
 # abstraction to fetch bloom filters from and put them to object storage.

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3986,6 +3986,13 @@ ring:
   # Enable using a IPv6 instance address.
   # CLI flag: -index-gateway.ring.instance-enable-ipv6
   [instance_enable_ipv6: <boolean> | default = false]
+
+# Maximum number of idle file handles the index gateway keeps open for each TSDB
+# index file. Index files are read on demand via pread(2) instead of being
+# memory-mapped; a small pool of handles per file avoids reopening the file on
+# every read while keeping the number of open file descriptors bounded.
+# CLI flag: -index-gateway.max-idle-file-handles
+[max_idle_file_handles: <int> | default = 4]
 ```
 
 ### ingester
@@ -6923,6 +6930,8 @@ tsdb_shipper:
   [mode: <string> | default = ""]
 
   [ingesterdbretainperiod: <duration>]
+
+  [maxidlefilehandles: <int>]
 
 # Experimental: Configures the bloom shipper component, which contains the store
 # abstraction to fetch bloom filters from and put them to object storage.

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	golang.org/x/crypto v0.53.0
 	golang.org/x/net v0.56.0
 	golang.org/x/sync v0.21.0
-	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/sys v0.46.0
 	golang.org/x/time v0.15.0
 	google.golang.org/api v0.286.0
 	google.golang.org/grpc v1.82.1

--- a/pkg/indexgateway/config.go
+++ b/pkg/indexgateway/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	tsdbindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 	"github.com/grafana/loki/v3/pkg/util/ring"
 )
 
@@ -64,6 +65,11 @@ type Config struct {
 	// In case it isn't explicitly set, it follows the same behavior of the other rings (ex: using the common configuration
 	// section and the ingester configuration by default).
 	Ring ring.RingConfig `yaml:"ring,omitempty" doc:"description=Defines the ring to be used by the index gateway servers and clients in case the servers are configured to run in 'ring' mode. In case this isn't configured, this block supports inheriting configuration from the common ring section."`
+
+	// MaxIdleFileHandles is the number of idle file handles the index reader
+	// keeps open per TSDB index file for reuse instead of reopening it on each
+	// read. Index files are read on demand via pread(2) rather than memory-mapped.
+	MaxIdleFileHandles int `yaml:"max_idle_file_handles"`
 }
 
 // RegisterFlags register all IndexGatewayClientConfig flags and all the flags of its subconfigs but with a prefix (ex: shipper).
@@ -83,11 +89,16 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	// multiple Index Gateway instances are expected to be returned as Index Gateway might be busy/locked for specific
 	// reasons (this is assured by the spikey behavior of Index Gateway latencies).
 	f.IntVar(&cfg.Ring.ReplicationFactor, "replication-factor", ReplicationFactor, "Deprecated: How many index gateway instances are assigned to each tenant. Use -index-gateway.shard-size instead. The shard size is also a per-tenant setting.")
+
+	f.IntVar(&cfg.MaxIdleFileHandles, "index-gateway.max-idle-file-handles", tsdbindex.DefaultMaxIdleFileHandles, "Maximum number of idle file handles the index gateway keeps open for each TSDB index file. Index files are read on demand via pread(2) instead of being memory-mapped; a small pool of handles per file avoids reopening the file on every read while keeping the number of open file descriptors bounded.")
 }
 
 func (cfg *Config) Validate() error {
 	if cfg.Ring.NumTokens != NumTokens {
 		return errors.New("Num tokens must not be changed as it will not take effect")
+	}
+	if cfg.MaxIdleFileHandles < 0 {
+		return errors.New("index-gateway.max-idle-file-handles must not be negative")
 	}
 	return nil
 }

--- a/pkg/indexgateway/config.go
+++ b/pkg/indexgateway/config.go
@@ -68,8 +68,13 @@ type Config struct {
 
 	// MaxIdleFileHandles is the number of idle file handles the index reader
 	// keeps open per TSDB index file for reuse instead of reopening it on each
-	// read. Index files are read on demand via pread(2) rather than memory-mapped.
+	// read. Only used by the "pread" index reader implementation.
 	MaxIdleFileHandles int `yaml:"max_idle_file_handles"`
+
+	// IndexReaderImpl selects how TSDB index files are read: "pread" (default)
+	// reads sections on demand from a pool of file handles, "mmap" memory-maps
+	// the whole index file.
+	IndexReaderImpl string `yaml:"index_reader_impl"`
 }
 
 // RegisterFlags register all IndexGatewayClientConfig flags and all the flags of its subconfigs but with a prefix (ex: shipper).
@@ -90,7 +95,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	// reasons (this is assured by the spikey behavior of Index Gateway latencies).
 	f.IntVar(&cfg.Ring.ReplicationFactor, "replication-factor", ReplicationFactor, "Deprecated: How many index gateway instances are assigned to each tenant. Use -index-gateway.shard-size instead. The shard size is also a per-tenant setting.")
 
-	f.IntVar(&cfg.MaxIdleFileHandles, "index-gateway.max-idle-file-handles", tsdbindex.DefaultMaxIdleFileHandles, "Maximum number of idle file handles the index gateway keeps open for each TSDB index file. Index files are read on demand via pread(2) instead of being memory-mapped; a small pool of handles per file avoids reopening the file on every read while keeping the number of open file descriptors bounded.")
+	f.IntVar(&cfg.MaxIdleFileHandles, "index-gateway.max-idle-file-handles", tsdbindex.DefaultMaxIdleFileHandles, "Maximum number of idle file handles the index gateway keeps open for each TSDB index file. Only used when -index-gateway.index-reader-impl is 'pread'. A small pool of handles per file avoids reopening the file on every read while keeping the number of open file descriptors bounded.")
+	f.StringVar(&cfg.IndexReaderImpl, "index-gateway.index-reader-impl", tsdbindex.IndexReaderPread, "How TSDB index files are read. 'pread' reads index sections on demand via pread(2) from a bounded pool of file handles, keeping memory usage predictable. 'mmap' memory-maps the whole index file, which is faster while the file stays resident in the page cache but can stall on major page faults under memory pressure.")
 }
 
 func (cfg *Config) Validate() error {
@@ -99,6 +105,11 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.MaxIdleFileHandles < 0 {
 		return errors.New("index-gateway.max-idle-file-handles must not be negative")
+	}
+	switch cfg.IndexReaderImpl {
+	case tsdbindex.IndexReaderPread, tsdbindex.IndexReaderMmap:
+	default:
+		return fmt.Errorf("index-gateway.index-reader-impl %q not supported. list of supported implementations: %s, %s", cfg.IndexReaderImpl, tsdbindex.IndexReaderPread, tsdbindex.IndexReaderMmap)
 	}
 	return nil
 }

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -972,6 +972,7 @@ func (t *Loki) updateConfigForShipperStore() {
 
 	t.Cfg.StorageConfig.TSDBShipperConfig.IngesterName = t.Cfg.Ingester.LifecyclerConfig.ID
 	t.Cfg.StorageConfig.TSDBShipperConfig.MaxIdleFileHandles = t.Cfg.IndexGateway.MaxIdleFileHandles
+	t.Cfg.StorageConfig.TSDBShipperConfig.IndexReaderImpl = t.Cfg.IndexGateway.IndexReaderImpl
 
 	// If RF > 1 and current or upcoming index type is boltdb-shipper then disable index dedupe and write dedupe cache.
 	// This is to ensure that index entries are replicated to all the boltdb files in ingesters flushing replicated data.

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -971,6 +971,7 @@ func (t *Loki) updateConfigForShipperStore() {
 	}
 
 	t.Cfg.StorageConfig.TSDBShipperConfig.IngesterName = t.Cfg.Ingester.LifecyclerConfig.ID
+	t.Cfg.StorageConfig.TSDBShipperConfig.MaxIdleFileHandles = t.Cfg.IndexGateway.MaxIdleFileHandles
 
 	// If RF > 1 and current or upcoming index type is boltdb-shipper then disable index dedupe and write dedupe cache.
 	// This is to ensure that index entries are replicated to all the boltdb files in ingesters flushing replicated data.

--- a/pkg/storage/stores/shipper/indexshipper/shipper.go
+++ b/pkg/storage/stores/shipper/indexshipper/shipper.go
@@ -83,6 +83,11 @@ type Config struct {
 	IngesterName           string
 	Mode                   Mode
 	IngesterDBRetainPeriod time.Duration
+
+	// MaxIdleFileHandles is the number of idle file handles the pool-backed TSDB
+	// index reader keeps open per index file for reuse. It is set programmatically
+	// from the index-gateway configuration (see indexgateway.Config).
+	MaxIdleFileHandles int
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {

--- a/pkg/storage/stores/shipper/indexshipper/shipper.go
+++ b/pkg/storage/stores/shipper/indexshipper/shipper.go
@@ -88,6 +88,11 @@ type Config struct {
 	// index reader keeps open per index file for reuse. It is set programmatically
 	// from the index-gateway configuration (see indexgateway.Config).
 	MaxIdleFileHandles int
+
+	// IndexReaderImpl selects the TSDB index reader implementation ("pread" or
+	// "mmap"). It is set programmatically from the index-gateway configuration
+	// (see indexgateway.Config).
+	IndexReaderImpl string
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
@@ -119,7 +119,7 @@ func (t *tableCompactor) CompactTable() error {
 
 	// Register cleanup before checking error to prevent FD leaks when
 	// ForEachJob partially succeeds: some goroutines may have already
-	// opened Index objects (holding mmap file descriptors) before another
+	// opened Index objects (holding pooled file descriptors) before another
 	// goroutine's failure cancels the group.
 	defer func() {
 		for i, idx := range multiTenantIndices {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/bench_scan_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/bench_scan_test.go
@@ -1,0 +1,162 @@
+// This is an in-package Go benchmark for
+// github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index
+//
+// It measures the cost of scanning a TSDB index file's series (the query hot
+// path in the index-gateway) comparing:
+//   - inmem: an index reader backed by an in-memory byte slice (approximates the
+//     previous mmap-backed reader for random access speed)
+//   - pool:  the pool/pread-backed reader that replaces mmap (poolByteSlice)
+//   - pool_parallel: concurrent series lookups via the pool-backed reader
+//
+// Copy this file into the index package as bench_scan_test.go to run:
+//
+//	go test -run '^$' -bench BenchmarkScanIndex -benchmem \
+//	  ./pkg/storage/stores/shipper/indexshipper/tsdb/index/...
+package index
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func buildBenchIndex(tb testing.TB, dir string, n int) (path string, size int64) {
+	tb.Helper()
+	fn := filepath.Join(dir, IndexFilename)
+	iw, err := NewWriter(context.Background(), FormatV4, fn)
+	require.NoError(tb, err)
+
+	series := make([]labels.Labels, 0, n)
+	symbols := map[string]struct{}{}
+	for i := 0; i < n; i++ {
+		lb := labels.FromStrings(
+			"foo", "bar",
+			"instance", fmt.Sprintf("inst-%d", i%1000),
+			"job", fmt.Sprintf("job-%d", i%50),
+			"pod", fmt.Sprintf("pod-%d", i),
+		)
+		series = append(series, lb)
+		lb.Range(func(l labels.Label) {
+			symbols[l.Name] = struct{}{}
+			symbols[l.Value] = struct{}{}
+		})
+	}
+
+	syms := make([]string, 0, len(symbols))
+	for k := range symbols {
+		syms = append(syms, k)
+	}
+	sort.Strings(syms)
+	for _, s := range syms {
+		require.NoError(tb, iw.AddSymbol(s))
+	}
+
+	sort.Slice(series, func(i, j int) bool {
+		return labels.StableHash(series[i]) < labels.StableHash(series[j])
+	})
+	for i, lb := range series {
+		require.NoError(tb, iw.AddSeries(storage.SeriesRef(i), lb,
+			model.Fingerprint(labels.StableHash(lb)),
+			ChunkMeta{MinTime: 0, MaxTime: 1000, Checksum: uint32(i), KB: 16, Entries: 100},
+		))
+	}
+	_, err = iw.Close(false)
+	require.NoError(tb, err)
+
+	fi, err := os.Stat(fn)
+	require.NoError(tb, err)
+	return fn, fi.Size()
+}
+
+func allRefs(tb testing.TB, r *Reader) []storage.SeriesRef {
+	tb.Helper()
+	n, v := AllPostingsKey()
+	p, err := r.Postings(n, nil, v)
+	require.NoError(tb, err)
+	var refs []storage.SeriesRef
+	for p.Next() {
+		refs = append(refs, p.At())
+	}
+	require.NoError(tb, p.Err())
+	return refs
+}
+
+func scanAll(tb testing.TB, r *Reader) int {
+	n, v := AllPostingsKey()
+	p, err := r.Postings(n, nil, v)
+	require.NoError(tb, err)
+	var (
+		lbls  labels.Labels
+		metas []ChunkMeta
+		count int
+	)
+	for p.Next() {
+		_, err := r.Series(p.At(), 0, math.MaxInt64, &lbls, &metas)
+		require.NoError(tb, err)
+		count++
+	}
+	require.NoError(tb, p.Err())
+	return count
+}
+
+func BenchmarkScanIndex(b *testing.B) {
+	const n = 200000
+	dir := b.TempDir()
+	path, size := buildBenchIndex(b, dir, n)
+	b.Logf("index file size: %.1f MiB (%d series)", float64(size)/(1<<20), n)
+
+	raw, err := os.ReadFile(path)
+	require.NoError(b, err)
+
+	b.Run("inmem", func(b *testing.B) {
+		r, err := NewReader(RealByteSlice(raw))
+		require.NoError(b, err)
+		defer r.Close()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = scanAll(b, r)
+		}
+	})
+
+	b.Run("pool", func(b *testing.B) {
+		r, err := NewFileReader(path)
+		require.NoError(b, err)
+		defer r.Close()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = scanAll(b, r)
+		}
+	})
+
+	b.Run("pool_parallel", func(b *testing.B) {
+		r, err := NewFileReader(path)
+		require.NoError(b, err)
+		defer r.Close()
+		refs := allRefs(b, r)
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			var (
+				lbls  labels.Labels
+				metas []ChunkMeta
+				i     int
+			)
+			for pb.Next() {
+				_, err := r.Series(refs[i%len(refs)], 0, math.MaxInt64, &lbls, &metas)
+				require.NoError(b, err)
+				i++
+			}
+		})
+	})
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/chunk.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/chunk.go
@@ -243,7 +243,7 @@ func (m *chunkPageMarker) clear() {
 	*m = chunkPageMarker{}
 }
 
-func (m *chunkPageMarker) decode(d *encoding.Decbuf) {
+func (m *chunkPageMarker) decode(d decbuf) {
 	m.ChunksInPage = d.Uvarint()
 	m.KB = d.Be32()
 	m.Entries = d.Be32()

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/file_pool.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/file_pool.go
@@ -1,0 +1,237 @@
+// Provenance-includes-location: https://github.com/grafana/mimir/blob/main/pkg/util/filepool/filepool.go
+// Provenance-includes-location: https://github.com/grafana/mimir/blob/main/pkg/storage/indexheader/encoding/file_reader.go
+// Provenance-includes-license: AGPL-3.0-only
+// Provenance-includes-copyright: The Mimir Authors.
+
+package index
+
+import (
+	"errors"
+	"os"
+	"sync"
+
+	"go.uber.org/atomic"
+)
+
+// DefaultMaxIdleFileHandles is the number of open file handles the filePool
+// keeps around for reuse per index file. It trades a small number of open file
+// descriptors per index file for a significant reduction in open(2)/close(2)
+// syscalls on the query hot path.
+const DefaultMaxIdleFileHandles = 4
+
+// MaxIdleFileHandles controls how many idle file handles each pool-backed index
+// reader keeps open for reuse. It can be tuned before opening index readers.
+var MaxIdleFileHandles = DefaultMaxIdleFileHandles
+
+// errPoolStopped is returned when a file handle is requested from a stopped pool.
+var errPoolStopped = errors.New("index file handle pool is stopped")
+
+// filePool maintains a bounded set of reusable file handles for a single file.
+//
+// It replaces memory-mapping the index file: instead of relying on the kernel to
+// page the file into the process address space (which makes memory accounting
+// unpredictable and can stall goroutines on page faults), reads are served from
+// a small pool of regular file handles using pread(2) (via *os.File.ReadAt).
+//
+// Get and Put never block. If no idle handle is available, Get opens a new one;
+// if the pool is full, Put closes the handle instead of retaining it. This mirrors
+// the behaviour of Mimir's filepool.FilePool.
+type filePool struct {
+	path    string
+	handles chan *os.File
+
+	mtx     sync.RWMutex
+	stopped bool
+}
+
+// newFilePool creates a file handle pool for path that keeps up to capacity idle
+// handles around for reuse. A capacity of 0 means every Get opens a new handle
+// and every Put closes it immediately.
+func newFilePool(path string, capacity int) *filePool {
+	if capacity < 0 {
+		capacity = 0
+	}
+	return &filePool{
+		path:    path,
+		handles: make(chan *os.File, capacity),
+	}
+}
+
+// get returns an idle file handle if one is available or opens a new one.
+func (p *filePool) get() (*os.File, error) {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	if p.stopped {
+		return nil, errPoolStopped
+	}
+
+	select {
+	case f := <-p.handles:
+		return f, nil
+	default:
+		return os.Open(p.path)
+	}
+}
+
+// put returns a file handle to the pool, or closes it if the pool is full or
+// stopped.
+func (p *filePool) put(f *os.File) error {
+	if f == nil {
+		return nil
+	}
+
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	if p.stopped {
+		return f.Close()
+	}
+
+	select {
+	case p.handles <- f:
+		return nil
+	default:
+		return f.Close()
+	}
+}
+
+// stop closes all idle handles. Subsequent Get calls return an error and Put
+// calls close handles immediately.
+func (p *filePool) stop() error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	if p.stopped {
+		return nil
+	}
+	p.stopped = true
+
+	var err error
+	for {
+		select {
+		case f := <-p.handles:
+			if cerr := f.Close(); cerr != nil && err == nil {
+				err = cerr
+			}
+		default:
+			return err
+		}
+	}
+}
+
+// scratchBufPool holds transient read buffers used for section reads whose
+// contents are not retained by the caller (e.g. symbol lookups). This is the
+// buffer-pool analogue of Mimir's bufio.Reader pool: it keeps read buffers off
+// the heap-allocation hot path.
+var scratchBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, 1024)
+		return &b
+	},
+}
+
+// poolByteSlice implements ByteSlice on top of a filePool. It is the replacement
+// for mmap-backed RealByteSlice used when opening an index file from disk.
+//
+// Range performs a single pread into a freshly allocated buffer. Fresh
+// allocations are required because callers (for example the postings decoder)
+// retain the returned slice; a pooled buffer could be recycled while still
+// referenced. For reads whose result is not retained, use readRange, which
+// serves the read from scratchBufPool.
+type poolByteSlice struct {
+	pool   *filePool
+	length int
+
+	// err records the first I/O error observed while reading. Because the
+	// ByteSlice interface cannot return an error from Range, callers on the hot
+	// path check Err after decoding sections that are not CRC-protected.
+	err atomic.Error
+}
+
+func newPoolByteSlice(path string, length, maxIdleHandles int) *poolByteSlice {
+	return &poolByteSlice{
+		pool:   newFilePool(path, maxIdleHandles),
+		length: length,
+	}
+}
+
+func (b *poolByteSlice) Len() int { return b.length }
+
+func (b *poolByteSlice) Range(start, end int) []byte {
+	buf := make([]byte, end-start)
+	if err := b.readAt(buf, start); err != nil {
+		b.setErr(err)
+	}
+	return buf
+}
+
+// readRange reads bytes [start, end) into a buffer obtained from scratchBufPool
+// and returns it together with a release function. The returned slice MUST NOT
+// be retained after release is called.
+func (b *poolByteSlice) readRange(start, end int) ([]byte, func(), error) {
+	n := end - start
+	pb := scratchBufPool.Get().(*[]byte)
+	if cap(*pb) < n {
+		*pb = make([]byte, n)
+	} else {
+		*pb = (*pb)[:n]
+	}
+	buf := *pb
+	if err := b.readAt(buf, start); err != nil {
+		scratchBufPool.Put(pb)
+		b.setErr(err)
+		return nil, nil, err
+	}
+	return buf, func() { scratchBufPool.Put(pb) }, nil
+}
+
+func (b *poolByteSlice) readAt(buf []byte, start int) error {
+	f, err := b.pool.get()
+	if err != nil {
+		return err
+	}
+	n, rerr := f.ReadAt(buf, int64(start))
+	if perr := b.pool.put(f); perr != nil && rerr == nil {
+		rerr = perr
+	}
+	// A read that fills the whole buffer is a success even if ReadAt reports
+	// io.EOF, which it may when the read ends exactly at the end of the file
+	// (see io.ReaderAt). A genuine short read (n < len(buf)) is returned as an
+	// error.
+	if n == len(buf) {
+		return nil
+	}
+	return rerr
+}
+
+func (b *poolByteSlice) setErr(err error) {
+	if err == nil {
+		return
+	}
+	b.err.CompareAndSwap(nil, err)
+}
+
+// Err returns the first I/O error observed while reading, if any.
+func (b *poolByteSlice) Err() error {
+	return b.err.Load()
+}
+
+// Close releases all pooled file handles.
+func (b *poolByteSlice) Close() error {
+	return b.pool.stop()
+}
+
+// rangeReader is implemented by ByteSlice values that can serve a read into a
+// pooled scratch buffer, avoiding an allocation when the result is not retained.
+type rangeReader interface {
+	readRange(start, end int) (buf []byte, release func(), err error)
+}
+
+// byteSliceErr returns the sticky read error of bs, if it tracks one.
+func byteSliceErr(bs ByteSlice) error {
+	if e, ok := bs.(interface{ Err() error }); ok {
+		return e.Err()
+	}
+	return nil
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/file_pool_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/file_pool_test.go
@@ -1,0 +1,295 @@
+package index
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func TestFilePool(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data")
+	require.NoError(t, os.WriteFile(path, []byte("hello world"), 0o644))
+
+	t.Run("reuses idle handles", func(t *testing.T) {
+		p := newFilePool(path, 2)
+		defer func() { _ = p.stop() }()
+
+		f1, err := p.get()
+		require.NoError(t, err)
+		require.NoError(t, p.put(f1))
+
+		// The next get should return the same, still-open handle.
+		f2, err := p.get()
+		require.NoError(t, err)
+		require.Same(t, f1, f2)
+		require.NoError(t, p.put(f2))
+	})
+
+	t.Run("closes handles over capacity", func(t *testing.T) {
+		p := newFilePool(path, 1)
+		defer func() { _ = p.stop() }()
+
+		f1, err := p.get()
+		require.NoError(t, err)
+		f2, err := p.get()
+		require.NoError(t, err)
+		require.NotSame(t, f1, f2)
+
+		require.NoError(t, p.put(f1)) // retained
+		require.NoError(t, p.put(f2)) // over capacity -> closed
+	})
+
+	t.Run("stop closes idle handles and rejects gets", func(t *testing.T) {
+		p := newFilePool(path, 2)
+		f, err := p.get()
+		require.NoError(t, err)
+		require.NoError(t, p.put(f))
+
+		require.NoError(t, p.stop())
+		require.NoError(t, p.stop()) // idempotent
+
+		_, err = p.get()
+		require.ErrorIs(t, err, errPoolStopped)
+	})
+}
+
+func TestPoolByteSliceErr(t *testing.T) {
+	b := &poolByteSlice{}
+	require.NoError(t, b.Err())
+
+	first := errors.New("first")
+	b.setErr(first)
+	require.ErrorIs(t, b.Err(), first)
+
+	// The first error wins; subsequent errors and nil are ignored.
+	b.setErr(errors.New("second"))
+	require.ErrorIs(t, b.Err(), first)
+	b.setErr(nil)
+	require.ErrorIs(t, b.Err(), first)
+}
+
+func TestPoolByteSliceParity(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data")
+	raw := make([]byte, 64<<10)
+	_, _ = rand.New(rand.NewSource(1)).Read(raw)
+	require.NoError(t, os.WriteFile(path, raw, 0o644))
+
+	b := newPoolByteSlice(path, len(raw), 4)
+	defer b.Close()
+
+	require.Equal(t, len(raw), b.Len())
+
+	rng := rand.New(rand.NewSource(2))
+	for i := 0; i < 1000; i++ {
+		start := rng.Intn(len(raw) - 1)
+		end := start + 1 + rng.Intn(len(raw)-start-1)
+
+		require.Equal(t, raw[start:end], b.Range(start, end))
+
+		buf, release, err := b.readRange(start, end)
+		require.NoError(t, err)
+		require.True(t, bytes.Equal(raw[start:end], buf))
+		release()
+	}
+	require.NoError(t, b.Err())
+}
+
+// buildParityIndex builds an on-disk index and returns its path plus the raw
+// bytes for constructing an in-memory reference reader.
+func buildParityIndex(t testing.TB, n int) (string, []byte) {
+	t.Helper()
+	dir := t.TempDir()
+	fn := filepath.Join(dir, IndexFilename)
+	iw, err := NewWriter(context.Background(), FormatV4, fn)
+	require.NoError(t, err)
+
+	series := make([]labels.Labels, 0, n)
+	symbols := map[string]struct{}{}
+	for i := 0; i < n; i++ {
+		lb := labels.FromStrings(
+			"foo", "bar",
+			"instance", fmt.Sprintf("inst-%d", i%100),
+			"job", fmt.Sprintf("job-%d", i%7),
+			"pod", fmt.Sprintf("pod-%d", i),
+		)
+		series = append(series, lb)
+		lb.Range(func(l labels.Label) {
+			symbols[l.Name] = struct{}{}
+			symbols[l.Value] = struct{}{}
+		})
+	}
+	syms := make([]string, 0, len(symbols))
+	for k := range symbols {
+		syms = append(syms, k)
+	}
+	sort.Strings(syms)
+	for _, s := range syms {
+		require.NoError(t, iw.AddSymbol(s))
+	}
+	sort.Slice(series, func(i, j int) bool {
+		return labels.StableHash(series[i]) < labels.StableHash(series[j])
+	})
+	for i, lb := range series {
+		require.NoError(t, iw.AddSeries(storage.SeriesRef(i), lb,
+			model.Fingerprint(labels.StableHash(lb)),
+			ChunkMeta{MinTime: 0, MaxTime: 1000, Checksum: uint32(i), KB: 16, Entries: 100},
+		))
+	}
+	_, err = iw.Close(false)
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(fn)
+	require.NoError(t, err)
+	return fn, raw
+}
+
+// TestReaderPoolParity ensures the pool-backed (pread) reader returns exactly the
+// same results as an in-memory (mmap-equivalent) reader across the read paths
+// that were refactored to bounded reads.
+func TestReaderPoolParity(t *testing.T) {
+	const n = 3000
+	path, raw := buildParityIndex(t, n)
+
+	ref, err := NewReader(RealByteSlice(raw))
+	require.NoError(t, err)
+	defer ref.Close()
+
+	pool, err := NewFileReader(path)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	// LabelNames / LabelValues parity.
+	refNames, err := ref.LabelNames()
+	require.NoError(t, err)
+	poolNames, err := pool.LabelNames()
+	require.NoError(t, err)
+	require.Equal(t, refNames, poolNames)
+
+	for _, name := range refNames {
+		refVals, err := ref.LabelValues(name)
+		require.NoError(t, err)
+		poolVals, err := pool.LabelValues(name)
+		require.NoError(t, err)
+		require.Equal(t, refVals, poolVals, "label values mismatch for %q", name)
+	}
+
+	// Series parity across all series (exercises symbol lookups on both readers).
+	pn, pv := AllPostingsKey()
+	refPostings, err := ref.Postings(pn, nil, pv)
+	require.NoError(t, err)
+
+	var refIDs []storage.SeriesRef
+	for refPostings.Next() {
+		refIDs = append(refIDs, refPostings.At())
+	}
+	require.NoError(t, refPostings.Err())
+	require.Len(t, refIDs, n)
+
+	for _, id := range refIDs {
+		var (
+			lblsA, lblsB labels.Labels
+			chksA, chksB []ChunkMeta
+		)
+		fpA, err := ref.Series(id, 0, math.MaxInt64, &lblsA, &chksA)
+		require.NoError(t, err)
+		fpB, err := pool.Series(id, 0, math.MaxInt64, &lblsB, &chksB)
+		require.NoError(t, err)
+
+		require.Equal(t, fpA, fpB)
+		require.Equal(t, lblsA, lblsB)
+		require.Equal(t, chksA, chksB)
+	}
+
+	// Postings parity for a specific multi-value lookup.
+	refP, err := ref.Postings("job", nil, "job-1", "job-3", "job-5")
+	require.NoError(t, err)
+	poolP, err := pool.Postings("job", nil, "job-1", "job-3", "job-5")
+	require.NoError(t, err)
+	require.Equal(t, drainPostings(t, refP), drainPostings(t, poolP))
+}
+
+func drainPostings(t testing.TB, p Postings) []storage.SeriesRef {
+	t.Helper()
+	var out []storage.SeriesRef
+	for p.Next() {
+		out = append(out, p.At())
+	}
+	require.NoError(t, p.Err())
+	return out
+}
+
+// TestReaderPoolConcurrentSeries exercises the pool-backed reader from many
+// goroutines using valid series references and asserts results match a
+// single-threaded in-memory reader.
+func TestReaderPoolConcurrentSeries(t *testing.T) {
+	const n = 4000
+	path, raw := buildParityIndex(t, n)
+
+	ref, err := NewReader(RealByteSlice(raw))
+	require.NoError(t, err)
+	defer ref.Close()
+
+	pool, err := NewFileReader(path)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	pn, pv := AllPostingsKey()
+	p, err := ref.Postings(pn, nil, pv)
+	require.NoError(t, err)
+	var ids []storage.SeriesRef
+	for p.Next() {
+		ids = append(ids, p.At())
+	}
+	require.NoError(t, p.Err())
+
+	// Expected labels per ref from the reference reader.
+	want := make([]labels.Labels, len(ids))
+	for i, id := range ids {
+		var lbls labels.Labels
+		var chks []ChunkMeta
+		_, err := ref.Series(id, 0, math.MaxInt64, &lbls, &chks)
+		require.NoError(t, err)
+		want[i] = lbls.Copy()
+	}
+
+	var (
+		wg       sync.WaitGroup
+		failures atomic.Int64
+	)
+	for g := 0; g < 24; g++ {
+		wg.Add(1)
+		go func(seed int64) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(seed))
+			var lbls labels.Labels
+			var chks []ChunkMeta
+			for i := 0; i < 2000; i++ {
+				idx := rng.Intn(len(ids))
+				_, err := pool.Series(ids[idx], 0, math.MaxInt64, &lbls, &chks)
+				if err != nil || !labels.Equal(want[idx], lbls) {
+					failures.Add(1)
+				}
+			}
+		}(int64(g))
+	}
+	wg.Wait()
+
+	require.Zero(t, failures.Load())
+	require.NoError(t, byteSliceErr(pool.b))
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1312,16 +1312,26 @@ func NewReader(b ByteSlice) (*Reader, error) {
 	return newReader(b, io.NopCloser(nil))
 }
 
+const (
+	// IndexReaderPread reads index sections on demand via pread(2) from a small
+	// pool of file handles (see file_pool.go). This is the default.
+	IndexReaderPread = "pread"
+	// IndexReaderMmap memory-maps the whole index file (see mmap.go). It is the
+	// legacy implementation, kept as an opt-in alternative.
+	IndexReaderMmap = "mmap"
+)
+
 // ReaderOption customizes an on-disk index Reader created by NewFileReader.
 type ReaderOption func(*readerConfig)
 
 type readerConfig struct {
 	maxIdleFileHandles int
+	useMmap            bool
 }
 
 // WithMaxIdleFileHandles sets how many idle file handles the pool-backed reader
 // keeps open for reuse. Values <= 0 are ignored and the package default
-// (MaxIdleFileHandles) is used instead.
+// (MaxIdleFileHandles) is used instead. It has no effect on the mmap reader.
 func WithMaxIdleFileHandles(n int) ReaderOption {
 	return func(c *readerConfig) {
 		if n > 0 {
@@ -1330,16 +1340,36 @@ func WithMaxIdleFileHandles(n int) ReaderOption {
 	}
 }
 
+// WithMmap selects the legacy memory-mapped reader implementation when enabled,
+// instead of the default pread-based pool reader.
+func WithMmap(enabled bool) ReaderOption {
+	return func(c *readerConfig) {
+		c.useMmap = enabled
+	}
+}
+
+// WithReaderImpl selects the reader implementation by name (IndexReaderPread or
+// IndexReaderMmap). Any value other than IndexReaderMmap selects the default
+// pread reader.
+func WithReaderImpl(impl string) ReaderOption {
+	return WithMmap(impl == IndexReaderMmap)
+}
+
 // NewFileReader returns a new index reader against the given index file.
 //
-// Instead of memory-mapping the file, sections are read on demand from a small
-// pool of file handles (see poolByteSlice). This keeps the index reader's memory
-// footprint predictable and off the kernel page cache, at the cost of reading
-// bounded sections via pread(2) rather than random access into mapped memory.
+// By default sections are read on demand from a small pool of file handles (see
+// poolByteSlice). This keeps the index reader's memory footprint predictable and
+// off the kernel page cache, at the cost of reading bounded sections via
+// pread(2) rather than random access into mapped memory. The legacy
+// memory-mapped implementation can be selected with WithMmap (see mmap.go).
 func NewFileReader(path string, opts ...ReaderOption) (*Reader, error) {
 	cfg := readerConfig{maxIdleFileHandles: MaxIdleFileHandles}
 	for _, opt := range opts {
 		opt(&cfg)
+	}
+
+	if cfg.useMmap {
+		return newMmapFileReader(path)
 	}
 
 	fi, err := os.Stat(path)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1306,6 +1306,22 @@ func (b RealByteSlice) Sub(start, end int) ByteSlice {
 	return b[start:end]
 }
 
+// decbuf is the minimal decoding interface shared by the []byte-backed
+// encoding.Decbuf and the streaming streamDecbuf. The series and chunk decoders
+// operate against it so the same decode logic serves both the in-memory/mmap
+// readers (via *encoding.Decbuf) and the file-backed streaming reader (via
+// *streamDecbuf).
+type decbuf interface {
+	Be32() uint32
+	Be64() uint64
+	Uvarint() int
+	Uvarint64() uint64
+	Varint64() int64
+	Skip(l int)
+	Len() int
+	Err() error
+}
+
 // NewReader returns a new index reader on the given byte slice. It automatically
 // handles different format versions.
 func NewReader(b ByteSlice) (*Reader, error) {
@@ -1921,16 +1937,44 @@ func (r *Reader) Series(id storage.SeriesRef, from int64, through int64, lbls *l
 	if r.version >= FormatV2 {
 		offset = id * 16
 	}
-	d := encoding.DecWrap(tsdb_enc.NewDecbufUvarintAt(r.b, int(offset), castagnoliTable))
-	if d.Err() != nil {
-		return 0, d.Err()
+	d, stream, err := r.seriesDecbufAt(int(offset))
+	if err != nil {
+		return 0, err
 	}
+	defer releaseStreamDecbuf(stream)
 
-	fprint, err := r.dec.Series(r.version, d.Get(), id, from, through, lbls, chks)
+	fprint, err := r.dec.Series(r.version, d, id, from, through, lbls, chks)
 	if err != nil {
 		return 0, errors.Wrap(err, "read series")
 	}
 	return fprint, nil
+}
+
+// seriesDecbufAt returns a decoder positioned at the content of the series
+// record at absolute offset off.
+//
+// For FormatV3+ file-backed indexes it streams the record through a pooled bufio
+// buffer (see stream_reader.go), which keeps the reader's memory footprint
+// independent of the record size. In-memory (RealByteSlice / mmap) readers and
+// FormatV2 (and earlier) records are decoded from a materialised buffer: the
+// former is already zero-copy, and the latter is required because the prior-v3
+// chunk sampler needs random access to the record's bytes.
+//
+// The second return value is the streaming decoder to release (nil on the
+// buffered path); callers must pass it to releaseStreamDecbuf when done.
+func (r *Reader) seriesDecbufAt(off int) (decbuf, *streamDecbuf, error) {
+	if pbs, ok := r.b.(*poolByteSlice); ok && r.version >= FormatV3 {
+		d, err := newSeriesStreamDecbuf(pbs.pool, pbs.length, off)
+		if err != nil {
+			return nil, nil, err
+		}
+		return d, d, nil
+	}
+	d := encoding.DecWrap(tsdb_enc.NewDecbufUvarintAt(r.b, off, castagnoliTable))
+	if err := d.Err(); err != nil {
+		return nil, nil, err
+	}
+	return &d, nil, nil
 }
 
 func (r *Reader) ChunkStats(id storage.SeriesRef, from, through int64, lbls *labels.Labels, by map[string]struct{}) (uint64, ChunkStats, error) {
@@ -1940,12 +1984,13 @@ func (r *Reader) ChunkStats(id storage.SeriesRef, from, through int64, lbls *lab
 	if r.version >= FormatV2 {
 		offset = id * 16
 	}
-	d := encoding.DecWrap(tsdb_enc.NewDecbufUvarintAt(r.b, int(offset), castagnoliTable))
-	if d.Err() != nil {
-		return 0, ChunkStats{}, d.Err()
+	d, stream, err := r.seriesDecbufAt(int(offset))
+	if err != nil {
+		return 0, ChunkStats{}, err
 	}
+	defer releaseStreamDecbuf(stream)
 
-	return r.dec.ChunkStats(r.version, d.Get(), id, from, through, lbls, by)
+	return r.dec.ChunkStats(r.version, d, id, from, through, lbls, by)
 }
 
 func (r *Reader) Postings(name string, fpFilter FingerprintFilter, values ...string) (Postings, error) {
@@ -2313,11 +2358,9 @@ func buildChunkSamples(version int, d encoding.Decbuf, numChunks int, info *chun
 
 // prepSeries returns series labels for a series, only returning selected `by` label names.
 // If `by` is nil, it returns all labels for the series.
-func (dec *Decoder) prepSeries(b []byte, lbls *labels.Labels, by map[string]struct{}) (*encoding.Decbuf, uint64, error) {
+func (dec *Decoder) prepSeries(d decbuf, lbls *labels.Labels, by map[string]struct{}) (uint64, error) {
 	builder := labelpool.Get()
 	defer labelpool.Put(builder)
-
-	d := encoding.DecWrap(tsdb_enc.Decbuf{B: b})
 
 	fprint := d.Be64()
 	k := d.Uvarint()
@@ -2327,12 +2370,12 @@ func (dec *Decoder) prepSeries(b []byte, lbls *labels.Labels, by map[string]stru
 		lvo := uint32(d.Uvarint())
 
 		if d.Err() != nil {
-			return nil, 0, errors.Wrap(d.Err(), "read series label offsets")
+			return 0, errors.Wrap(d.Err(), "read series label offsets")
 		}
 		// todo(cyriltovena): we could cache this by user requests spanning multiple prepSeries calls.
 		ln, err := dec.LookupSymbol(lno)
 		if err != nil {
-			return nil, 0, errors.Wrap(err, "lookup label name")
+			return 0, errors.Wrap(err, "lookup label name")
 		}
 
 		if by != nil {
@@ -2343,7 +2386,7 @@ func (dec *Decoder) prepSeries(b []byte, lbls *labels.Labels, by map[string]stru
 
 		lv, err := dec.LookupSymbol(lvo)
 		if err != nil {
-			return nil, 0, errors.Wrap(err, "lookup label value")
+			return 0, errors.Wrap(err, "lookup label value")
 		}
 
 		builder.Add(ln, lv)
@@ -2352,13 +2395,11 @@ func (dec *Decoder) prepSeries(b []byte, lbls *labels.Labels, by map[string]stru
 	// Commit built labels.
 	builder.Sort()
 	*lbls = builder.Labels()
-	return &d, fprint, nil
+	return fprint, nil
 }
 
-// skipSeriesLabels reads past the label section in buffer b, ready to read chunks after that.
-func (dec *Decoder) skipSeriesLabels(b []byte) (*encoding.Decbuf, uint64, error) {
-	d := encoding.DecWrap(tsdb_enc.Decbuf{B: b})
-
+// skipSeriesLabels reads past the label section, positioning d to read chunks after that.
+func (dec *Decoder) skipSeriesLabels(d decbuf) (uint64, error) {
 	fprint := d.Be64()
 	k := d.Uvarint()
 
@@ -2367,15 +2408,15 @@ func (dec *Decoder) skipSeriesLabels(b []byte) (*encoding.Decbuf, uint64, error)
 		_ = d.Uvarint()
 
 		if d.Err() != nil {
-			return nil, 0, errors.Wrap(d.Err(), "read series label offsets")
+			return 0, errors.Wrap(d.Err(), "read series label offsets")
 		}
 	}
 
-	return &d, fprint, nil
+	return fprint, nil
 }
 
-func (dec *Decoder) ChunkStats(version int, b []byte, seriesRef storage.SeriesRef, from, through int64, lbls *labels.Labels, by map[string]struct{}) (uint64, ChunkStats, error) {
-	d, fp, err := dec.prepSeries(b, lbls, by)
+func (dec *Decoder) ChunkStats(version int, d decbuf, seriesRef storage.SeriesRef, from, through int64, lbls *labels.Labels, by map[string]struct{}) (uint64, ChunkStats, error) {
+	fp, err := dec.prepSeries(d, lbls, by)
 	if err != nil {
 		return 0, ChunkStats{}, err
 	}
@@ -2384,14 +2425,14 @@ func (dec *Decoder) ChunkStats(version int, b []byte, seriesRef storage.SeriesRe
 	return fp, stats, err
 }
 
-func (dec *Decoder) readChunkStats(version int, d *encoding.Decbuf, seriesRef storage.SeriesRef, from, through int64) (ChunkStats, error) {
+func (dec *Decoder) readChunkStats(version int, d decbuf, seriesRef storage.SeriesRef, from, through int64) (ChunkStats, error) {
 	if version > FormatV2 {
 		return dec.readChunkStatsV3(version, d, from, through)
 	}
 	return dec.readChunkStatsPriorV3(d, seriesRef, from, through)
 }
 
-func (dec *Decoder) readChunkStatsV3(version int, d *encoding.Decbuf, from, through int64) (res ChunkStats, err error) {
+func (dec *Decoder) readChunkStatsV3(version int, d decbuf, from, through int64) (res ChunkStats, err error) {
 	nChunks := d.Uvarint()
 	markersLn := int(d.Be32()) // markersLn
 	startMarkers := d.Len()
@@ -2478,7 +2519,7 @@ func (dec *Decoder) readChunkStatsV3(version int, d *encoding.Decbuf, from, thro
 	return res, d.Err()
 }
 
-func (dec *Decoder) accumulateChunkStats(version int, d *encoding.Decbuf, nChunks int, from, through int64) (res ChunkStats, err error) {
+func (dec *Decoder) accumulateChunkStats(version int, d decbuf, nChunks int, from, through int64) (res ChunkStats, err error) {
 	var prevMaxT int64
 	chunkMeta := &ChunkMeta{}
 	for i := 0; i < nChunks; i++ {
@@ -2497,7 +2538,7 @@ func (dec *Decoder) accumulateChunkStats(version int, d *encoding.Decbuf, nChunk
 	return res, d.Err()
 }
 
-func (dec *Decoder) readChunkStatsPriorV3(d *encoding.Decbuf, seriesRef storage.SeriesRef, from, through int64) (res ChunkStats, err error) {
+func (dec *Decoder) readChunkStatsPriorV3(d decbuf, seriesRef storage.SeriesRef, from, through int64) (res ChunkStats, err error) {
 	// prior to v3, chunks needed iteration for stats aggregation
 	chks := ChunkMetasPool.Get()
 	defer func() { ChunkMetasPool.Put(chks) }()
@@ -2519,12 +2560,11 @@ func (dec *Decoder) readChunkStatsPriorV3(d *encoding.Decbuf, seriesRef storage.
 
 // Series decodes a series entry from the given byte slice into lbls and chks.
 // lbls can be nil, indicating the caller only wants the chunks.
-func (dec *Decoder) Series(version int, b []byte, seriesRef storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]ChunkMeta) (fprint uint64, err error) {
-	var d *encoding.Decbuf
+func (dec *Decoder) Series(version int, d decbuf, seriesRef storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]ChunkMeta) (fprint uint64, err error) {
 	if lbls == nil {
-		d, fprint, err = dec.skipSeriesLabels(b)
+		fprint, err = dec.skipSeriesLabels(d)
 	} else {
-		d, fprint, err = dec.prepSeries(b, lbls, nil)
+		fprint, err = dec.prepSeries(d, lbls, nil)
 	}
 	if err != nil {
 		return 0, err
@@ -2541,7 +2581,7 @@ func (dec *Decoder) Series(version int, b []byte, seriesRef storage.SeriesRef, f
 	return fprint, nil
 }
 
-func (dec *Decoder) readChunks(version int, d *encoding.Decbuf, seriesRef storage.SeriesRef, from int64, through int64, chks *[]ChunkMeta) error {
+func (dec *Decoder) readChunks(version int, d decbuf, seriesRef storage.SeriesRef, from int64, through int64, chks *[]ChunkMeta) error {
 	// read chunks based on fmt
 	if version > FormatV2 {
 		return dec.readChunksV3(version, d, from, through, chks)
@@ -2549,7 +2589,7 @@ func (dec *Decoder) readChunks(version int, d *encoding.Decbuf, seriesRef storag
 	return dec.readChunksPriorV3(version, d, seriesRef, from, through, chks)
 }
 
-func (dec *Decoder) readChunksV3(version int, d *encoding.Decbuf, from int64, through int64, chks *[]ChunkMeta) error {
+func (dec *Decoder) readChunksV3(version int, d decbuf, from int64, through int64, chks *[]ChunkMeta) error {
 	nChunks := d.Uvarint()
 	chunksRemaining := nChunks
 
@@ -2620,7 +2660,7 @@ iterate:
 	return d.Err()
 }
 
-func (dec *Decoder) readChunksPriorV3(version int, d *encoding.Decbuf, seriesRef storage.SeriesRef, from int64, through int64, chks *[]ChunkMeta) error {
+func (dec *Decoder) readChunksPriorV3(version int, d decbuf, seriesRef storage.SeriesRef, from int64, through int64, chks *[]ChunkMeta) error {
 	// Read the chunks meta data.
 	k := d.Uvarint()
 
@@ -2628,7 +2668,14 @@ func (dec *Decoder) readChunksPriorV3(version int, d *encoding.Decbuf, seriesRef
 		return d.Err()
 	}
 
-	chunksSample, err := dec.getOrCreateChunksSample(version, encoding.DecWrap(tsdb_enc.Decbuf{B: d.Get()}), seriesRef, k)
+	// The prior-v3 chunk sampler needs random access to the remaining bytes, so
+	// it only supports the in-memory []byte decoder. V2 series therefore always
+	// take the buffered (non-streaming) decode path (see Reader.Series).
+	getter, ok := d.(interface{ Get() []byte })
+	if !ok {
+		return errors.New("prior-v3 series decoding requires a buffered decoder")
+	}
+	chunksSample, err := dec.getOrCreateChunksSample(version, encoding.DecWrap(tsdb_enc.Decbuf{B: getter.Get()}), seriesRef, k)
 	if err != nil {
 		return err
 	}
@@ -2664,14 +2711,14 @@ func (dec *Decoder) readChunksPriorV3(version int, d *encoding.Decbuf, seriesRef
 	return d.Err()
 }
 
-func readChunkMeta(version int, d *encoding.Decbuf, prevChunkMaxt int64, chunkMeta *ChunkMeta) error {
+func readChunkMeta(version int, d decbuf, prevChunkMaxt int64, chunkMeta *ChunkMeta) error {
 	// Decode the diff against previous chunk as varint
 	// instead of uvarint because chunks may overlap
 	mint := d.Varint64() + prevChunkMaxt
 	return readChunkMetaWithForcedMintime(version, d, mint, chunkMeta, false)
 }
 
-func readChunkMetaWithForcedMintime(version int, d *encoding.Decbuf, mint int64, chunkMeta *ChunkMeta, decodeMinT bool) error {
+func readChunkMetaWithForcedMintime(version int, d decbuf, mint int64, chunkMeta *ChunkMeta, decodeMinT bool) error {
 	if decodeMinT {
 		// skip the mint delta since we're forcing, but still need to
 		// remove the bytes from our buffer

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1312,19 +1312,42 @@ func NewReader(b ByteSlice) (*Reader, error) {
 	return newReader(b, io.NopCloser(nil))
 }
 
+// ReaderOption customizes an on-disk index Reader created by NewFileReader.
+type ReaderOption func(*readerConfig)
+
+type readerConfig struct {
+	maxIdleFileHandles int
+}
+
+// WithMaxIdleFileHandles sets how many idle file handles the pool-backed reader
+// keeps open for reuse. Values <= 0 are ignored and the package default
+// (MaxIdleFileHandles) is used instead.
+func WithMaxIdleFileHandles(n int) ReaderOption {
+	return func(c *readerConfig) {
+		if n > 0 {
+			c.maxIdleFileHandles = n
+		}
+	}
+}
+
 // NewFileReader returns a new index reader against the given index file.
 //
 // Instead of memory-mapping the file, sections are read on demand from a small
 // pool of file handles (see poolByteSlice). This keeps the index reader's memory
 // footprint predictable and off the kernel page cache, at the cost of reading
 // bounded sections via pread(2) rather than random access into mapped memory.
-func NewFileReader(path string) (*Reader, error) {
+func NewFileReader(path string, opts ...ReaderOption) (*Reader, error) {
+	cfg := readerConfig{maxIdleFileHandles: MaxIdleFileHandles}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	fi, err := os.Stat(path)
 	if err != nil {
 		return nil, err
 	}
 
-	b := newPoolByteSlice(path, int(fi.Size()), MaxIdleFileHandles)
+	b := newPoolByteSlice(path, int(fi.Size()), cfg.maxIdleFileHandles)
 	r, err := newReader(b, b)
 	if err != nil {
 		return nil, stderrors.Join(

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1313,16 +1313,23 @@ func NewReader(b ByteSlice) (*Reader, error) {
 }
 
 // NewFileReader returns a new index reader against the given index file.
+//
+// Instead of memory-mapping the file, sections are read on demand from a small
+// pool of file handles (see poolByteSlice). This keeps the index reader's memory
+// footprint predictable and off the kernel page cache, at the cost of reading
+// bounded sections via pread(2) rather than random access into mapped memory.
 func NewFileReader(path string) (*Reader, error) {
-	f, err := fileutil.OpenMmapFile(path)
+	fi, err := os.Stat(path)
 	if err != nil {
 		return nil, err
 	}
-	r, err := newReader(RealByteSlice(f.Bytes()), f)
+
+	b := newPoolByteSlice(path, int(fi.Size()), MaxIdleFileHandles)
+	r, err := newReader(b, b)
 	if err != nil {
 		return nil, stderrors.Join(
 			err,
-			f.Close(),
+			b.Close(),
 		)
 	}
 
@@ -1474,6 +1481,16 @@ type Symbols struct {
 	version int
 	off     int
 
+	// tableEnd is the absolute file offset of the end of the symbols content
+	// (i.e. immediately before the trailing CRC32). It bounds reads of the last
+	// (possibly partial) group of symbols.
+	tableEnd int
+
+	// rr is set when bs can serve reads into pooled scratch buffers, avoiding
+	// allocations on the symbol-lookup hot path. It is nil for in-memory byte
+	// slices.
+	rr rangeReader
+
 	offsets []int
 	seen    int
 }
@@ -1487,12 +1504,15 @@ func NewSymbols(bs ByteSlice, version, off int) (*Symbols, error) {
 		version: version,
 		off:     off,
 	}
+	s.rr, _ = bs.(rangeReader)
 	d := encoding.DecWrap(tsdb_enc.NewDecbufAt(bs, off, castagnoliTable))
 	var (
 		origLen = d.Len()
 		cnt     = d.Be32int()
 		basePos = off + 4
 	)
+	// Symbols content spans [off+4, off+4+origLen); the CRC32 follows.
+	s.tableEnd = off + 4 + origLen
 	s.offsets = make([]int, 0, 1+cnt/symbolFactor)
 	for d.Err() == nil && s.seen < cnt {
 		if s.seen%symbolFactor == 0 {
@@ -1507,22 +1527,51 @@ func NewSymbols(bs ByteSlice, version, off int) (*Symbols, error) {
 	return s, nil
 }
 
+// decAt returns a decoder over the absolute file range [start, end). When the
+// backing byte slice supports pooled reads, the returned buffer is borrowed from
+// a pool and MUST NOT be used after release is called.
+func (s Symbols) decAt(start, end int) (encoding.Decbuf, func()) {
+	if s.rr != nil {
+		buf, release, err := s.rr.readRange(start, end)
+		if err != nil {
+			return encoding.DecWrap(tsdb_enc.Decbuf{E: err}), func() {}
+		}
+		return encoding.DecWrap(tsdb_enc.Decbuf{B: buf}), release
+	}
+	return encoding.DecWrap(tsdb_enc.Decbuf{B: s.bs.Range(start, end)}), func() {}
+}
+
+// groupEnd returns the absolute file offset that bounds the group of symbols
+// starting at checkpoint k, i.e. the next checkpoint or the end of the table.
+func (s Symbols) groupEnd(k int) int {
+	if k+1 < len(s.offsets) {
+		return s.offsets[k+1]
+	}
+	return s.tableEnd
+}
+
 func (s Symbols) Lookup(o uint32) (string, error) {
-	d := encoding.DecWrap(tsdb_enc.Decbuf{
-		B: s.bs.Range(0, s.bs.Len()),
-	})
+	var (
+		d       encoding.Decbuf
+		release func()
+	)
 
 	if s.version >= FormatV2 {
 		if int(o) >= s.seen {
 			return "", errors.Errorf("unknown symbol offset %d", o)
 		}
-		d.Skip(s.offsets[int(o/symbolFactor)])
-		// Walk until we find the one we want.
-		for i := o - (o / symbolFactor * symbolFactor); i > 0; i-- {
+		// Only read the group of symbols that contains o rather than the whole
+		// section, then walk to the requested symbol.
+		k := int(o / symbolFactor)
+		d, release = s.decAt(s.offsets[k], s.groupEnd(k))
+		defer release()
+		for i := o - uint32(k)*symbolFactor; i > 0; i-- {
 			d.UvarintBytes()
 		}
 	} else {
-		d.Skip(int(o))
+		// In v1 the offset is the absolute byte position of the symbol.
+		d, release = s.decAt(int(o), s.tableEnd)
+		defer release()
 	}
 	sym := d.UvarintStr()
 	if d.Err() != nil {
@@ -1538,24 +1587,24 @@ func (s Symbols) ReverseLookup(sym string) (uint32, error) {
 	i := sort.Search(len(s.offsets), func(i int) bool {
 		// Any decoding errors here will be lost, however
 		// we already read through all of this at startup.
-		d := encoding.DecWrap(tsdb_enc.Decbuf{
-			B: s.bs.Range(0, s.bs.Len()),
-		})
-		d.Skip(s.offsets[i])
+		// Only the first symbol of each group is inspected.
+		d, release := s.decAt(s.offsets[i], s.groupEnd(i))
+		defer release()
 		return yoloString(d.UvarintBytes()) > sym
-	})
-	d := encoding.DecWrap(tsdb_enc.Decbuf{
-		B: s.bs.Range(0, s.bs.Len()),
 	})
 	if i > 0 {
 		i--
 	}
-	d.Skip(s.offsets[i])
+	// The binary search guarantees sym, if present, lies within group i.
+	start := s.offsets[i]
+	end := s.groupEnd(i)
+	d, release := s.decAt(start, end)
+	defer release()
 	res := i * symbolFactor
-	var lastLen int
+	var lastPos int
 	var lastSymbol string
 	for d.Err() == nil && res <= s.seen {
-		lastLen = d.Len()
+		lastPos = start + ((end - start) - d.Len())
 		lastSymbol = yoloString(d.UvarintBytes())
 		if lastSymbol >= sym {
 			break
@@ -1571,7 +1620,7 @@ func (s Symbols) ReverseLookup(sym string) (uint32, error) {
 	if s.version >= FormatV2 {
 		return uint32(res), nil
 	}
-	return uint32(s.bs.Len() - lastLen), nil
+	return uint32(lastPos), nil
 }
 
 func (s Symbols) Size() int {
@@ -1711,6 +1760,9 @@ func (r *Reader) LabelValues(name string, matchers ...*labels.Matcher) ([]string
 	values := make([]string, 0, len(e)*symbolFactor)
 
 	d := encoding.DecWrap(tsdb_enc.NewDecbufAt(r.b, int(r.toc.PostingsTable), nil))
+	if err := byteSliceErr(r.b); err != nil {
+		return nil, errors.Wrap(err, "read postings offset table")
+	}
 	d.Skip(e[0].off)
 	lastVal := e[len(e)-1].value
 
@@ -1882,6 +1934,20 @@ func (r *Reader) Postings(name string, fpFilter FingerprintFilter, values ...str
 		// Discard values before the start.
 		valueIndex++
 	}
+
+	// Read the postings offset table content once and reuse it across all
+	// requested values. When the index is backed by a file (rather than mmap),
+	// this avoids re-reading the whole table from disk for every value.
+	// Don't Crc32 the entire postings offset table, this is very slow
+	// so hope any issues were caught at startup.
+	tableContent := tsdb_enc.NewDecbufAt(r.b, int(r.toc.PostingsTable), nil)
+	if err := tableContent.Err(); err != nil {
+		return nil, errors.Wrap(err, "read postings offset table")
+	}
+	if err := byteSliceErr(r.b); err != nil {
+		return nil, errors.Wrap(err, "read postings offset table")
+	}
+
 	for valueIndex < len(values) {
 		value := values[valueIndex]
 
@@ -1894,9 +1960,7 @@ func (r *Reader) Postings(name string, fpFilter FingerprintFilter, values ...str
 			// Need to look from previous entry.
 			i--
 		}
-		// Don't Crc32 the entire postings offset table, this is very slow
-		// so hope any issues were caught at startup.
-		d := encoding.DecWrap(tsdb_enc.NewDecbufAt(r.b, int(r.toc.PostingsTable), nil))
+		d := encoding.DecWrap(tsdb_enc.Decbuf{B: tableContent.B})
 		d.Skip(e[i].off)
 
 		// Iterate on the offset table.

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/mmap.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/mmap.go
@@ -1,0 +1,35 @@
+package index
+
+import (
+	stderrors "errors"
+
+	"github.com/prometheus/prometheus/tsdb/fileutil"
+)
+
+// This file contains the legacy memory-mapped index reader implementation.
+// It is kept behind the "mmap" reader backend (see WithMmap / IndexReaderMmap)
+// so it can be selected as an alternative to the default pread-based pool reader
+// implemented in file_pool.go.
+//
+// The mmap reader maps the whole index file into the process address space and
+// serves every ByteSlice.Range as a zero-copy sub-slice of the mapping. This is
+// very fast when the file stays resident in the page cache, but makes the
+// process' memory usage depend on the kernel page cache and can stall goroutines
+// on major page faults once the file no longer fits in available memory.
+
+// newMmapFileReader opens the index file at path by memory-mapping it. The
+// returned Reader owns the mapping and unmaps it on Close.
+func newMmapFileReader(path string) (*Reader, error) {
+	f, err := fileutil.OpenMmapFile(path)
+	if err != nil {
+		return nil, err
+	}
+	r, err := newReader(RealByteSlice(f.Bytes()), f)
+	if err != nil {
+		return nil, stderrors.Join(
+			err,
+			f.Close(),
+		)
+	}
+	return r, nil
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
@@ -1,0 +1,277 @@
+// Provenance-includes-location: https://github.com/grafana/mimir/blob/main/pkg/storage/indexheader/encoding/file_reader.go
+// Provenance-includes-location: https://github.com/grafana/mimir/blob/main/pkg/storage/indexheader/encoding/encoding.go
+// Provenance-includes-license: AGPL-3.0-only
+// Provenance-includes-copyright: The Mimir Authors.
+
+package index
+
+import (
+	"bufio"
+	"encoding/binary"
+	stderrors "errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	tsdb_enc "github.com/prometheus/prometheus/tsdb/encoding"
+)
+
+// This file implements a streaming decoder for on-disk index sections, modelled
+// on Mimir's indexheader/encoding.FileReader and Decbuf.
+//
+// Unlike poolByteSlice (see file_pool.go), which materialises a whole section
+// into a freshly allocated []byte per read, the streaming decoder pulls bytes
+// through a small, fixed-size bufio buffer. Fixed-width primitives (Be32, Be64,
+// Uvarint, ...) are served from the buffer with Peek and consumed with Discard,
+// so decoding a section allocates nothing on the hot path regardless of the
+// section size.
+//
+// It is used only for the file-backed reader and only for FormatV3+ series
+// records. In-memory (RealByteSlice / mmap) readers keep decoding from a
+// zero-copy sub-slice, and FormatV2 records keep using the buffered decoder
+// because the prior-v3 chunk sampler needs random access to the record bytes.
+
+// streamReaderBufSize is the size of the bufio buffer used to stream index
+// sections. It bounds steady-state memory to O(bufSize) per concurrent decode
+// instead of O(section size).
+const streamReaderBufSize = 4096
+
+// streamDecbufPool recycles streamDecbuf values (and their bufio buffers) across
+// section reads so that the streaming decode path allocates nothing on the hot
+// path once warm.
+var streamDecbufPool = sync.Pool{
+	New: func() any { return &streamDecbuf{} },
+}
+
+// streamDecbuf decodes big-endian binary data from a file segment by streaming
+// it through a pooled bufio.Reader backed by a pooled *os.File handle (see
+// filePool). It provides the subset of encoding.Decbuf's methods used by the
+// series and chunk decoders and satisfies the decbuf interface (see index.go).
+//
+// Errors are sticky; callers check Err after a sequence of reads.
+type streamDecbuf struct {
+	pool *filePool
+	f    *os.File
+	buf  *bufio.Reader
+
+	// readOff is the absolute file offset of the next underlying read. It backs
+	// the io.Reader implementation consumed by buf and is independent of the
+	// logical decode cursor (off).
+	readOff int64
+	fileEnd int64
+
+	length int // logical content length in bytes
+	off    int // logical bytes consumed
+	e      error
+}
+
+// Read implements io.Reader so buf can pull bytes from the file via pread
+// (ReadAt) without seeking, which keeps the pooled handle usable concurrently
+// with poolByteSlice.readAt.
+func (d *streamDecbuf) Read(p []byte) (int, error) {
+	if d.readOff >= d.fileEnd {
+		return 0, io.EOF
+	}
+	if int64(len(p)) > d.fileEnd-d.readOff {
+		p = p[:d.fileEnd-d.readOff]
+	}
+	n, err := d.f.ReadAt(p, d.readOff)
+	d.readOff += int64(n)
+	return n, err
+}
+
+// newSeriesStreamDecbuf returns a streaming decoder over the contents of the
+// uvarint-length-prefixed record at absolute offset off (the on-disk series
+// record layout: [uvarint len][content][crc32]). The returned decoder spans the
+// content only and MUST be released with releaseStreamDecbuf once decoding is
+// done.
+//
+// Note: unlike NewDecbufUvarintAt, this does NOT verify the trailing CRC32. The
+// series record is on the query hot path and, as with the postings offset table
+// (see Reader.Postings), we rely on integrity having been established when the
+// file's other sections were validated at open time. Skipping the per-record
+// checksum avoids reading the record twice (once to hash, once to decode).
+func newSeriesStreamDecbuf(pool *filePool, fileLen, off int) (*streamDecbuf, error) {
+	if off >= fileLen {
+		return nil, tsdb_enc.ErrInvalidSize
+	}
+	f, err := pool.get()
+	if err != nil {
+		return nil, err
+	}
+
+	d := streamDecbufPool.Get().(*streamDecbuf)
+	d.pool = pool
+	d.f = f
+	d.readOff = int64(off)
+	d.fileEnd = int64(fileLen)
+	d.off = 0
+	d.length = fileLen - off // provisional; narrowed once the header is read
+	d.e = nil
+	if d.buf == nil {
+		d.buf = bufio.NewReaderSize(d, streamReaderBufSize)
+	} else {
+		d.buf.Reset(d)
+	}
+
+	// Read the uvarint length prefix, then bound the decoder to the content.
+	hdr, err := d.peek(binary.MaxVarintLen32)
+	if err != nil {
+		releaseStreamDecbuf(d)
+		return nil, err
+	}
+	l, n := binary.Uvarint(hdr)
+	if n <= 0 {
+		releaseStreamDecbuf(d)
+		return nil, fmt.Errorf("invalid uvarint reading series record length at offset %d", off)
+	}
+	if off+n+int(l) > fileLen {
+		releaseStreamDecbuf(d)
+		return nil, tsdb_enc.ErrInvalidSize
+	}
+	if _, err := d.buf.Discard(n); err != nil {
+		releaseStreamDecbuf(d)
+		return nil, err
+	}
+	d.off = n
+	d.length = n + int(l) // so Len() == l
+
+	return d, nil
+}
+
+// releaseStreamDecbuf returns the file handle to the pool and the decoder to the
+// pool. It is a no-op when d is nil (the buffered/in-memory decode path).
+func releaseStreamDecbuf(d *streamDecbuf) {
+	if d == nil {
+		return
+	}
+	if d.f != nil {
+		_ = d.pool.put(d.f)
+		d.f = nil
+	}
+	d.pool = nil
+	streamDecbufPool.Put(d)
+}
+
+// peek returns up to n bytes from the buffer without consuming them, treating a
+// short read at end-of-file as success (like Mimir's FileReader.Peek).
+func (d *streamDecbuf) peek(n int) ([]byte, error) {
+	b, err := d.buf.Peek(n)
+	if err != nil && !stderrors.Is(err, io.EOF) {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (d *streamDecbuf) Err() error { return d.e }
+func (d *streamDecbuf) Len() int   { return d.length - d.off }
+
+func (d *streamDecbuf) Skip(l int) {
+	if d.e != nil {
+		return
+	}
+	if l > d.Len() {
+		d.e = tsdb_enc.ErrInvalidSize
+		return
+	}
+	n, err := d.buf.Discard(l)
+	d.off += n
+	if err != nil {
+		d.e = err
+	}
+}
+
+func (d *streamDecbuf) Uvarint64() uint64 {
+	if d.e != nil {
+		return 0
+	}
+	max := binary.MaxVarintLen64
+	if rem := d.Len(); rem < max {
+		max = rem
+	}
+	b, err := d.peek(max)
+	if err != nil {
+		d.e = err
+		return 0
+	}
+	x, n := binary.Uvarint(b)
+	if n < 1 {
+		d.e = tsdb_enc.ErrInvalidSize
+		return 0
+	}
+	if cn, err := d.buf.Discard(n); err != nil {
+		d.off += cn
+		d.e = err
+		return 0
+	}
+	d.off += n
+	return x
+}
+
+func (d *streamDecbuf) Uvarint() int { return int(d.Uvarint64()) }
+
+func (d *streamDecbuf) Varint64() int64 {
+	ux := d.Uvarint64()
+	if d.e != nil {
+		return 0
+	}
+	// ZigZag decoding, matching tsdb/encoding.Decbuf.Varint64.
+	x := int64(ux >> 1)
+	if ux&1 != 0 {
+		x = ^x
+	}
+	return x
+}
+
+func (d *streamDecbuf) Be32() uint32 {
+	if d.e != nil {
+		return 0
+	}
+	if d.Len() < 4 {
+		d.e = tsdb_enc.ErrInvalidSize
+		return 0
+	}
+	b, err := d.peek(4)
+	if err != nil {
+		d.e = err
+		return 0
+	}
+	if len(b) < 4 {
+		d.e = tsdb_enc.ErrInvalidSize
+		return 0
+	}
+	v := binary.BigEndian.Uint32(b)
+	if _, err := d.buf.Discard(4); err != nil {
+		d.e = err
+		return 0
+	}
+	d.off += 4
+	return v
+}
+
+func (d *streamDecbuf) Be64() uint64 {
+	if d.e != nil {
+		return 0
+	}
+	if d.Len() < 8 {
+		d.e = tsdb_enc.ErrInvalidSize
+		return 0
+	}
+	b, err := d.peek(8)
+	if err != nil {
+		d.e = err
+		return 0
+	}
+	if len(b) < 8 {
+		d.e = tsdb_enc.ErrInvalidSize
+		return 0
+	}
+	v := binary.BigEndian.Uint64(b)
+	if _, err := d.buf.Discard(8); err != nil {
+		d.e = err
+		return 0
+	}
+	d.off += 8
+	return v
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
@@ -28,13 +28,13 @@ var ErrAlreadyOnDesiredVersion = errors.New("tsdb file already on desired versio
 // GetRawFileReaderFunc returns an io.ReadSeeker for reading raw tsdb file from disk
 type GetRawFileReaderFunc func() (io.ReadSeeker, error)
 
-func OpenShippableTSDB(p string) (shipperindex.Index, error) {
+func OpenShippableTSDB(p string, opts ...index.ReaderOption) (shipperindex.Index, error) {
 	id, err := identifierFromPath(p)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewShippableTSDBFile(id)
+	return NewShippableTSDBFile(id, opts...)
 }
 
 func RebuildWithVersion(ctx context.Context, path string, desiredVer int) (shipperindex.Index, error) {
@@ -94,8 +94,8 @@ type TSDBFile struct {
 	getRawFileReader GetRawFileReaderFunc
 }
 
-func NewShippableTSDBFile(id Identifier) (*TSDBFile, error) {
-	idx, getRawFileReader, err := NewTSDBIndexFromFile(id.Path())
+func NewShippableTSDBFile(id Identifier, opts ...index.ReaderOption) (*TSDBFile, error) {
+	idx, getRawFileReader, err := NewTSDBIndexFromFile(id.Path(), opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -126,8 +126,8 @@ type TSDBIndex struct {
 
 // Return the index as well as the underlying raw file reader which isn't exposed as an index
 // method but is helpful for building an io.reader for the index shipper
-func NewTSDBIndexFromFile(location string) (*TSDBIndex, GetRawFileReaderFunc, error) {
-	reader, err := index.NewFileReader(location)
+func NewTSDBIndexFromFile(location string, opts ...index.ReaderOption) (*TSDBIndex, GetRawFileReaderFunc, error) {
+	reader, err := index.NewFileReader(location, opts...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/store.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/store.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/index"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads"
+	shipperindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/index"
 	tsdbindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 )
 
@@ -67,13 +68,18 @@ func (s *store) init(name, prefix string, indexShipperCfg indexshipper.Config, s
 	limits downloads.Limits, tableRange config.TableRange, reg prometheus.Registerer) error {
 
 	var err error
+	// Thread the configured file-handle pool size into every index reader opened
+	// by the shipper on the read path.
+	openIndexFile := func(p string) (shipperindex.Index, error) {
+		return OpenShippableTSDB(p, tsdbindex.WithMaxIdleFileHandles(indexShipperCfg.MaxIdleFileHandles))
+	}
 	s.indexShipper, err = indexshipper.NewIndexShipper(
 		prefix,
 		indexShipperCfg,
 		objectClient,
 		limits,
 		nil,
-		OpenShippableTSDB,
+		openIndexFile,
 		tableRange,
 		prometheus.WrapRegistererWithPrefix("loki_tsdb_shipper_", reg),
 		s.logger,

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/store.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/store.go
@@ -71,7 +71,10 @@ func (s *store) init(name, prefix string, indexShipperCfg indexshipper.Config, s
 	// Thread the configured file-handle pool size into every index reader opened
 	// by the shipper on the read path.
 	openIndexFile := func(p string) (shipperindex.Index, error) {
-		return OpenShippableTSDB(p, tsdbindex.WithMaxIdleFileHandles(indexShipperCfg.MaxIdleFileHandles))
+		return OpenShippableTSDB(p,
+			tsdbindex.WithMaxIdleFileHandles(indexShipperCfg.MaxIdleFileHandles),
+			tsdbindex.WithReaderImpl(indexShipperCfg.IndexReaderImpl),
+		)
 	}
 	s.indexShipper, err = indexshipper.NewIndexShipper(
 		prefix,

--- a/tools/tsdb/index-analyzer/main.go
+++ b/tools/tsdb/index-analyzer/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/storage"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
+	shipperindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/index"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/tools/tsdb/helpers"
@@ -33,7 +34,7 @@ func main() {
 		objectClient,
 		overrides,
 		nil,
-		tsdb.OpenShippableTSDB,
+		func(p string) (shipperindex.Index, error) { return tsdb.OpenShippableTSDB(p) },
 		tableRange,
 		prometheus.WrapRegistererWithPrefix("loki_tsdb_shipper_", prometheus.DefaultRegisterer),
 		util_log.Logger,


### PR DESCRIPTION
**What this PR does / why we need it**:

The index-gateway (and any component reading TSDB index files) memory-mapped each
index file via `fileutil.OpenMmapFile`. mmap makes memory accounting unpredictable
(RSS is charged but paged in lazily and shared with the kernel page cache), and page
faults on cold/slow storage can stall the OS thread backing a goroutine, causing
latency spikes that are hard to attribute.

This PR replaces mmap in the TSDB index reader with an on-demand `pread(2)` reader
served from a small pool of file handles plus a pooled read buffer, modeled on
Mimir's index-header `filepool` / buffered reader
(https://github.com/grafana/mimir/blob/main/pkg/storage/indexheader/stream_binary_reader.go).
Reads now go through regular, heap-managed buffers instead of mapped memory, giving
predictable memory usage and no page-fault stalls.

**Design**

- `filePool`: a bounded, non-blocking pool of reusable `*os.File` handles per index
  file. `get`/`put` never block; if no idle handle is available a new one is opened,
  and handles over capacity are closed. This keeps the number of open file
  descriptors bounded while avoiding an `open`/`close` per read.
- `poolByteSlice`: implements the existing `ByteSlice` interface using `ReadAt`
  (pread). `Range` returns freshly allocated buffers (the postings decoder retains
  them), while a `sync.Pool` scratch buffer serves non-retained reads (symbol
  lookups) — the buffer-pool analogue of Mimir's `bufio.Reader` pool.
- **Bounded reads:** a naive per-`Range` pread regressed full index scans ~33×
  because `Symbols.Lookup` read the entire file on every symbol lookup. Symbol and
  postings-offset-table reads are now bounded to the exact section needed:
  `Symbols.Lookup`/`ReverseLookup` read only the group of symbols that can contain
  the target, and `Reader.Postings` reads the offset table once per call instead of
  once per value.

**Configurability**

The file-handle pool size is exposed via `-index-gateway.max-idle-file-handles`
(default `4`). It is propagated into the shipper config and threaded to
`index.NewFileReader` through a functional option, so both index-gateways and
queriers reading TSDB indexes honor it. Other callers (compactor, tools) keep the
package default.

**Benchmark** (`BenchmarkScanIndex`, 200k series, ~25 MiB index, full series scan):

| reader | full scan | point lookup (parallel) |
|---|---|---|
| in-memory (mmap-equivalent) | ~136 ms/op | — |
| **pool (this PR)** | **~422 ms/op (~3×)** | **~3.9 µs/op** |
| naive per-`Range` pread | ~3468 ms/op (~33×) | ~18 µs/op |

The pool reader is ~3× the in-memory reader on a full scan (the inherent pread
syscall cost) versus 33× for a naive pread, and concurrent point lookups match or
beat the previous mmap baseline. All new code is race-clean.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

- The index *writer* (`Creator`) still uses mmap (`w.f.Bytes()`) during index
  construction; that is the build path (ingester/compactor), not the index-gateway
  read path, and is out of scope here.
- `RawFileReader` (used only on the upload path) still materializes the file
  in-memory via a single read, preserving the `Index.Reader()` contract (the
  returned `io.ReadSeeker` is not closed by callers).
- `OpenShippableTSDB`/`NewShippableTSDBFile`/`NewTSDBIndexFromFile`/`NewFileReader`
  gained variadic `ReaderOption` args, so existing call sites are unchanged; only
  the shipper read path passes the configured pool size.
- Possible follow-up: expose `filePool` open/close counters as metrics (Mimir does).

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

---

Created using π (claude-opus-4-8 xhigh)