### PR TITLE
perf: Allocate capacity for fewer pattern samples up front

### DIFF
--- a/pkg/pattern/drain/chunk.go
+++ b/pkg/pattern/drain/chunk.go
@@ -22,7 +22,7 @@ type Chunk struct {
 
 func newChunk(ts model.Time, maxChunkAge time.Duration, sampleInterval time.Duration) Chunk {
 	maxSize := int(maxChunkAge.Nanoseconds()/sampleInterval.Nanoseconds()) + 1
-	v := Chunk{Samples: make([]logproto.PatternSample, 1, maxSize)}
+	v := Chunk{Samples: make([]logproto.PatternSample, 1, maxSize/8)} // Allocate 1/8 total size so sparse chunks don't waste memory
 	v.Samples[0] = logproto.PatternSample{
 		Timestamp: ts,
 		Value:     1,

--- a/pkg/pattern/drain/chunk_test.go
+++ b/pkg/pattern/drain/chunk_test.go
@@ -529,6 +529,7 @@ func TestConfigurableChunkCreation(t *testing.T) {
 
 		// Calculate expected capacity based on custom parameters
 		expectedCapacity := 12*30 + 1 // 5 second samples, 12 per minute, 30 minutes, plus 1
+		expectedCapacity /= 8         // Optimization: Only allocate 1/8 total size up front
 
 		require.Equal(t, expectedCapacity, cap(chunk.Samples), "chunk capacity should be calculated using configurable parameters")
 		require.Equal(t, 1, len(chunk.Samples), "chunk should have one initial sample")


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduces the initial allocation for pattern chunk's samples from the full range (by default, 360 samples from 1 hour of 10 second samples) to 1/8 of that.
* This is based on the assumption that many patterns are sparse and see a few samples each hour. 
* I verified this was the case from a set of 300 patterns from a live cell, where only 8/300 had more than 90% utilisation of their slices, and 50% had a single sample.
* Instead of adding a metric and verifying this more formally, I'm testing this PR empirically because its a 1 line change. It appears to reduce max memory usage by ~30%, although I need to wait the full 3h for final results. So far, stored samples are now 10% of the inuse_memory vs 50% previously. 
* An increase in allocations do not show up on the CPU profile. This was a potential side effect.

Before
<img width="914" height="748" alt="image" src="https://github.com/user-attachments/assets/a89635ea-2161-4cfe-ac0b-3430210ef37c" />

After
<img width="909" height="547" alt="image" src="https://github.com/user-attachments/assets/e0a02906-4e25-4de5-87b7-22ea8e90b0f0" />
