### PR TITLE
docs: Update RN for 3.6.13

### DIFF
--- a/docs/sources/release-notes/v3-6.md
+++ b/docs/sources/release-notes/v3-6.md
@@ -137,9 +137,9 @@ Other improvements include the following:
 * **operator:** Extend LokiStack authorization to support OTel Semantics ([#16031](https://github.com/grafana/loki/issues/16031))
 * **operator:** S3 validation reject endpoints that contain a URL path ([#19356](https://github.com/grafana/loki/issues/19356))
 * **operator:** Update Loki operand to v3.5.5 ([#19187](https://github.com/grafana/loki/issues/19187))
-* **policies:** Default ingestion policy mappings merged with per-tenant mappings ([#18926](https://github.com/grafana/loki/pull/18926))
 * **pattern ingester:** Pattern ingester pushes detected level as structured metadata ([#16924](https://github.com/grafana/loki/issues/16924)) ([66033bb](https://github.com/grafana/loki/commit/66033bb967ffbf0bbadb463b09e4509ce8c2242d))
 * **pattern ingester:** Implement volume-based pattern filtering ([#18838](https://github.com/grafana/loki/pull/18838))
+* **policies:** Default ingestion policy mappings merged with per-tenant mappings ([#18926](https://github.com/grafana/loki/pull/18926))
 * **thanos:** Allow dashes in storage_prefix config ([#16934](https://github.com/grafana/loki/issues/16934)) ([c01d9c7](https://github.com/grafana/loki/commit/c01d9c7512f5c29230278ad3142b82d3553bd792))
 
 ### 3.6.4 (2025-01-21)
@@ -148,7 +148,7 @@ Other improvements include the following:
 
 ### 3.6.5 (2025-02-05)
 
-* Add loki health command (backport release-3.6.x) ([#20590](https://github.com/grafana/loki/issues/20590)) ([dfdbe2a](https://github.com/grafana/loki/commit/dfdbe2a351dd0a203513ee66b6dd0b6b983332b0))
+* **loki:** Add loki health command (backport release-3.6.x) ([#20590](https://github.com/grafana/loki/issues/20590)) ([dfdbe2a](https://github.com/grafana/loki/commit/dfdbe2a351dd0a203513ee66b6dd0b6b983332b0))
 
 ## Deprecations
 
@@ -157,6 +157,7 @@ Other improvements include the following:
 - [Simple Scalable Deployment (SSD)](https://grafana.com/docs/loki/latest/get-started/deployment-modes/#simple-scalable) mode is being deprecated. The deprecation notice was posted in the CHANGELOG for Helm charts version 6.52.0. The timeline for the deprecation is to be determined (TBD), but will happen before Loki 4.0 is released.
 
 - Loki Helm charts deprecations: The following Community maintained Helm charts have been deprecated:
+
   - [LGTM-distributed](https://github.com/grafana/helm-charts/tree/main/charts/lgtm-distributed)
   - [loki-canary](https://github.com/grafana/helm-charts/tree/main/charts/loki-canary)
   - [loki-distributed](https://github.com/grafana/helm-charts/tree/main/charts/loki-distributed)
@@ -190,14 +191,24 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 
 ## Bug fixes
 
+### 3.6.13 (2026-07-23)
+
+* **ci:** Fix zizmor findings for operator-images in Loki 3.6 ([#22821](https://github.com/grafana/loki/issues/22821)) ([050f742](https://github.com/grafana/loki/commit/050f7422d671599830e9e59e89cca281039b6021))
+* **ci:** Helm CI warning fix ([#22606](https://github.com/grafana/loki/issues/22606)) ([4bc2586](https://github.com/grafana/loki/commit/4bc258651f36107086fc7028c4af1105618e67a4))
+* **deps:** Update objstore to include fix for GCS Exists ([#23381](https://github.com/grafana/loki/issues/23381)) ([87383d8](https://github.com/grafana/loki/commit/87383d801fa71a1cc7d3732b6e8a07372aee7558))
+* **security/CRITICAL/clients/cmd/fluentd/docker:** Update dependency fluentd to v1.19.3 (release-3.6.x) ([#22694](https://github.com/grafana/loki/issues/22694)) ([692f2b1](https://github.com/grafana/loki/commit/692f2b1183670b4e6df0436081a00b8dcc2d640a))
+* **security/HIGH/:** Bump Go to 1.26.5 to address CVE-2026-39822 and CVE-2026-42505 ([#23398](https://github.com/grafana/loki/issues/23398)) ([fc478e1](https://github.com/grafana/loki/commit/fc478e1d3491aea695080498d7ac3c0f065061c3))
+* **security/HIGH/:** Update golang.org/x/net, golang.org/x/text and google.golang.org/grpc ([70f75b7](https://github.com/grafana/loki/commit/70f75b7fbd0c6bab35a84700ac2ee531cfd483ed))
+* **security/HIGH/pkg/push:** Update module google.golang.org/grpc to v1.82.1 ([70f75b7](https://github.com/grafana/loki/commit/70f75b7fbd0c6bab35a84700ac2ee531cfd483ed))
+* **security/UNKNOWN/:** Update module github.com/containerd/containerd/v2 to v2.0.10 (release-3.6.x) ([#22479](https://github.com/grafana/loki/issues/22479)) ([697bd83](https://github.com/grafana/loki/commit/697bd835b91ae9a04c6476bb17d86975c624a642))
+* **security/UNKNOWN/cmd/chunks-inspect:** Update go toolchain directive to v1.25.12 (release-3.6.x) ([#23131](https://github.com/grafana/loki/issues/23131)) ([b327439](https://github.com/grafana/loki/commit/b3274394654e3f75996843924d54e3a8ea4c120f))
+* **security/UNKNOWN/pkg/push:** Update module golang.org/x/net to v0.56.0 ([70f75b7](https://github.com/grafana/loki/commit/70f75b7fbd0c6bab35a84700ac2ee531cfd483ed))
+* **security/UNKNOWN/pkg/push:** Update module golang.org/x/text to v0.39.0 ([70f75b7](https://github.com/grafana/loki/commit/70f75b7fbd0c6bab35a84700ac2ee531cfd483ed))
+* **security:** Backport security updates to release-3.6.x ([#23403](https://github.com/grafana/loki/issues/23403)) ([70f75b7](https://github.com/grafana/loki/commit/70f75b7fbd0c6bab35a84700ac2ee531cfd483ed))
+
 ### 3.6.12 (2026-06-24)
 
 * **deps:** Update `go.opentelemetry.io/otel/sdk` to v1.43.0 ([#21480](https://github.com/grafana/loki/issues/21480)) ([47fb29e](https://github.com/grafana/loki/commit/47fb29e)).
-* **security/HIGH:** Update `github.com/containerd/containerd/v2` to v2.0.9 ([#22204](https://github.com/grafana/loki/issues/22204)) ([ed38a68](https://github.com/grafana/loki/commit/ed38a68)).
-* **security/HIGH:** Update `github.com/prometheus/prometheus` to v0.311.3 in cmd/segment-inspect (release-3.6.x) ([#22205](https://github.com/grafana/loki/issues/22205)) ([bfd37e4](https://github.com/grafana/loki/commit/bfd37e4)).
-* **security/HIGH:** Update `go.opentelemetry.io/otel` to v1.41.0 in cmd/segment-inspect (release-3.6.x) ([#22206](https://github.com/grafana/loki/issues/22206)) ([0ed7bce](https://github.com/grafana/loki/commit/0ed7bce)).
-* **security/MEDIUM:** Update `github.com/grafana/loki/v3` to v3.6.4 in cmd/dataobj-inspect (release-3.6.x) ([#22209](https://github.com/grafana/loki/issues/22209)) ([d6117ed](https://github.com/grafana/loki/commit/d6117ed)).
-* **security/MEDIUM:** Update `github.com/grafana/loki/v3` to v3.6.4 in cmd/segment-inspect (release-3.6.x) ([#22210](https://github.com/grafana/loki/issues/22210)) ([186b9a9](https://github.com/grafana/loki/commit/186b9a9)).
 * **deps:** Update `golang.org/x/crypto` to v0.52.0 ([#22212](https://github.com/grafana/loki/issues/22212)) ([424e5ff](https://github.com/grafana/loki/commit/424e5ff)).
 * **deps:** Update `golang.org/x/net` to v0.55.0 ([#22213](https://github.com/grafana/loki/issues/22213)) ([90ae8f3](https://github.com/grafana/loki/commit/90ae8f3)).
 * **deps:** Update `golang.org/x/sys` to v0.44.0 ([#22214](https://github.com/grafana/loki/issues/22214)) ([49b9a22](https://github.com/grafana/loki/commit/49b9a22)).
@@ -208,10 +219,15 @@ For important upgrade guidance, refer to the [Upgrade Guide](https://grafana.com
 * **deps:** Update `golang.org/x/net` to v0.55.0 in pkg/push (release-3.6.x) ([#22224](https://github.com/grafana/loki/issues/22224)) ([0c53ce1](https://github.com/grafana/loki/commit/0c53ce1)).
 * **deps:** Update go toolchain to v1.25.11 in cmd/chunks-inspect (release-3.6.x) ([#22202](https://github.com/grafana/loki/issues/22202)) ([90e12c9](https://github.com/grafana/loki/commit/90e12c9)).
 * **deps:** Update go toolchain to v1.25.11 in cmd/segment-inspect (release-3.6.x) ([#22203](https://github.com/grafana/loki/issues/22203)) ([2c67a33](https://github.com/grafana/loki/commit/2c67a33)).
+* **security/HIGH:** Update `github.com/containerd/containerd/v2` to v2.0.9 ([#22204](https://github.com/grafana/loki/issues/22204)) ([ed38a68](https://github.com/grafana/loki/commit/ed38a68)).
+* **security/HIGH:** Update `github.com/prometheus/prometheus` to v0.311.3 in cmd/segment-inspect (release-3.6.x) ([#22205](https://github.com/grafana/loki/issues/22205)) ([bfd37e4](https://github.com/grafana/loki/commit/bfd37e4)).
+* **security/HIGH:** Update `go.opentelemetry.io/otel` to v1.41.0 in cmd/segment-inspect (release-3.6.x) ([#22206](https://github.com/grafana/loki/issues/22206)) ([0ed7bce](https://github.com/grafana/loki/commit/0ed7bce)).
+* **security/MEDIUM:** Update `github.com/grafana/loki/v3` to v3.6.4 in cmd/dataobj-inspect (release-3.6.x) ([#22209](https://github.com/grafana/loki/issues/22209)) ([d6117ed](https://github.com/grafana/loki/commit/d6117ed)).
+* **security/MEDIUM:** Update `github.com/grafana/loki/v3` to v3.6.4 in cmd/segment-inspect (release-3.6.x) ([#22210](https://github.com/grafana/loki/issues/22210)) ([186b9a9](https://github.com/grafana/loki/commit/186b9a9)).
 
 ### 3.6.11 (2025-05-13)
 
-* CVEs in release 3.7.x ([#21771](https://github.com/grafana/loki/issues/21771)) ([bb4c5d8](https://github.com/grafana/loki/commit/bb4c5d8758b8540cb742466683143a9ea93743c8))
+* **deps:** CVEs in release 3.7.x ([#21771](https://github.com/grafana/loki/issues/21771)) ([bb4c5d8](https://github.com/grafana/loki/commit/bb4c5d8758b8540cb742466683143a9ea93743c8))
 * **deps:** Update module github.com/aws/aws-sdk-go-v2/service/s3 to v1.97.3 ([#21457](https://github.com/grafana/loki/issues/21457)) ([7bc9450](https://github.com/grafana/loki/commit/7bc945082fd7ef7632a9bfd18cc22f23130ea64a)).
 * **ruler:** Fix ruler panic related to unset validation scheme ([#21401](https://github.com/grafana/loki/issues/21401)) ([cf65729](https://github.com/grafana/loki/commit/cf65729674b1f0be8011223c474df3e2e5253216)).
 * **storage:** Attach SHA-256 checksum on PutObject for Object Lock buckets ([#21849](https://github.com/grafana/loki/issues/21849)) ([7df13d9](https://github.com/grafana/loki/commit/7df13d9ad3993700c3aff23edf5dfa2966281416)).
@@ -249,14 +265,14 @@ This release does not exist. We triggered the release pipeline, but it decided t
 
 ### 3.6.4 (2025-01-21)
 
-* Backport gzip fix release 3.6.x ([#20514](https://github.com/grafana/loki/issues/20514)) ([d805266](https://github.com/grafana/loki/commit/d80526692af3bf28c35622a59a3231933b193bc2)).
 * **deps:** Update dskit to resolve Otel conflict ([#20368](https://github.com/grafana/loki/issues/20368)) ([fb05a36](https://github.com/grafana/loki/commit/fb05a368466e6b16ac70105f69e460871c0aa42e)).
+* **distributor:** Backport gzip fix release 3.6.x ([#20514](https://github.com/grafana/loki/issues/20514)) ([d805266](https://github.com/grafana/loki/commit/d80526692af3bf28c35622a59a3231933b193bc2)).
 
 ### 3.6.3 (2025-12-11)
 
 * **deps:** Update to Go 1.25 ([#20204](https://github.com/grafana/loki/issues/20204)).
-* Do not override S3 region if already specified in configuration chain (backport release-3.6.x) ([#20128](https://github.com/grafana/loki/issues/20128)) ([38582ac](https://github.com/grafana/loki/commit/38582ac8dcce1397580dddd1ecac51692bad7413)).
-* Fix regression in S3 client configuration (backport release-3.6.x) ([#20118](https://github.com/grafana/loki/issues/20118)) ([7d8176f](https://github.com/grafana/loki/commit/7d8176f4dd9c00ded84444360e31d7118abf66f0)).
+* **storage:** Do not override S3 region if already specified in configuration chain (backport release-3.6.x) ([#20128](https://github.com/grafana/loki/issues/20128)) ([38582ac](https://github.com/grafana/loki/commit/38582ac8dcce1397580dddd1ecac51692bad7413)).
+* **storage:** Fix regression in S3 client configuration (backport release-3.6.x) ([#20118](https://github.com/grafana/loki/issues/20118)) ([7d8176f](https://github.com/grafana/loki/commit/7d8176f4dd9c00ded84444360e31d7118abf66f0)).
 
 ### 3.6.2 (2025-11-25)
 
@@ -278,11 +294,11 @@ This release does not exist. We triggered the release pipeline, but it decided t
 * **build:** Remove UI from docker build ([#19425](https://github.com/grafana/loki/issues/19425))
 * **build:** RPM signature config ([#19476](https://github.com/grafana/loki/issues/19476))
 * **build:** Update ckit ([#18997](https://github.com/grafana/loki/issues/18997))
+* **chunkenc:** Avoid memory allocations when loading symbolizer from a flushed chunk ([#17953](https://github.com/grafana/loki/issues/17953))
 * **ci:** Fix deprecation errors from staticcheck linter ([#17210](https://github.com/grafana/loki/issues/17210)) ([cfe3675](https://github.com/grafana/loki/commit/cfe36752952cfa1aac6f59bb5804999e09ef1e41))
 * **ci:** Fix lambda-promtail image build ([#18443](https://github.com/grafana/loki/issues/18443)) ([8f0ba2e](https://github.com/grafana/loki/commit/8f0ba2eae6e01d96523d8a0d71fb0bf1ae29a224))
 * **ci:** Fix workflow timeout added in wrong format ([#18348](https://github.com/grafana/loki/issues/18348)) ([53ba9c7](https://github.com/grafana/loki/commit/53ba9c7fd63465209e9919ef1e5346dbeb66b2aa))
 * **ci:** Read releaseLibRef from jsonnet.json lockfile ([#18538](https://github.com/grafana/loki/issues/18538)) ([26417b5](https://github.com/grafana/loki/commit/26417b594593269339e440df2d3cfbdf6bb06541))
-* **chunkenc:** Avoid memory allocations when loading symbolizer from a flushed chunk ([#17953](https://github.com/grafana/loki/issues/17953))
 * **compactor:** Return request ID in response header ([#19444](https://github.com/grafana/loki/issues/19444))
 * **compactor:** Concurrent map access for processedSeries in delete requests manager ([#17469](https://github.com/grafana/loki/issues/17469)) ([32c5088](https://github.com/grafana/loki/commit/32c50888b04de299380895585dce1c77755c488c))
 * **compactor:** Fix timeout and series progress marker for same requests with different shards ([#17125](https://github.com/grafana/loki/issues/17125)) ([288ec8c](https://github.com/grafana/loki/commit/288ec8c64dca6457fb2287deed9ba841e70c61ae))
@@ -417,11 +433,9 @@ This release does not exist. We triggered the release pipeline, but it decided t
 * **distributor:** Extended detected level for debug and critical level ([#18370](https://github.com/grafana/loki/issues/18370))
 * **docs:** Update configuration.md ([#17269](https://github.com/grafana/loki/issues/17269)) ([70de523](https://github.com/grafana/loki/commit/70de5235b7c0e5a549f4bbc7cd127956d595badb))
 * **docs:** Added instructions for how to upgrade zone-aware ingesters ([#18658](https://github.com/grafana/loki/issues/18658)) ([aff2cb0](https://github.com/grafana/loki/commit/aff2cb0694cae99847b73da914ee4abd2432cdd0))
-
 * **engine:** Don't attempt to release batch reference on read for merge node ([#18913](https://github.com/grafana/loki/issues/18913))
 * **engine:** Fix bug in `SortMerge` which caused rows to be skipped due to incorrect sorting ([#18334](https://github.com/grafana/loki/issues/18334)) ([4fbe7c1](https://github.com/grafana/loki/commit/4fbe7c1a21a6443951bca3ad5e40712b24b4ef73))
 * **engine:** Fix out-of-bounds panic in SortMerge implementation ([#17967](https://github.com/grafana/loki/issues/17967))
-
 * **frontend:** Allow resolution of v6 addresses. ([#18251](https://github.com/grafana/loki/issues/18251)) ([8481b34](https://github.com/grafana/loki/commit/8481b34dd583d021e0dfa89d64298d2f36f75176))
 * **helm:** Add flush=true to preStop hook ([#16063](https://github.com/grafana/loki/issues/16063)) ([a375751](https://github.com/grafana/loki/commit/a375751e4dc126a27cd8784c802e07871803868d))
 * **helm:** Add init container configuration for backend, bloom builder, distributor, query-frontend, query-scheduler, read, write. ([#18709](https://github.com/grafana/loki/issues/18709))
@@ -472,22 +486,21 @@ This release does not exist. We triggered the release pipeline, but it decided t
 * **kafka:** Remove duplicated metric from Kafka producer ([#18614](https://github.com/grafana/loki/issues/18614)) ([a67a460](https://github.com/grafana/loki/commit/a67a460e9d7db43a793b180f2e73584fbe2497bb))
 * **kafka:** Disable defaults address defaults ([#17825](https://github.com/grafana/loki/issues/17825))
 * **kafka:** Use cooperative active sticky load balancer ([#19160](https://github.com/grafana/loki/issues/19160))
-
 * **limits:** Adapt defaults and expose evict interval ([#17808](https://github.com/grafana/loki/issues/17808))
 * **limits:** Fix ingest-limits eviction metric ([#17779](https://github.com/grafana/loki/issues/17779))
 * **limits:** Read the consumer group and topic from the ingest-limits config ([#17831](https://github.com/grafana/loki/issues/17831))
 * **limits:** Set ready when all partitions ready ([#18092](https://github.com/grafana/loki/issues/18092)) ([a07bee5](https://github.com/grafana/loki/commit/a07bee5dc2aae2c0618aba8d049630597b21b611))
 * **limits:** Counter variables should not have total at the end (([#17982](https://github.com/grafana/loki/issues/17982))
-
-* **loki:** Return defaults for non-existent tenants on applied limits endpoint ([#17942](https://github.com/grafana/loki/issues/17942))
 * **logql:** Fix inconsistency with parsed field short circuiting ([#17104](https://github.com/grafana/loki/issues/17104)) ([88beefb](https://github.com/grafana/loki/commit/88beefb02acca7651d57e69dd5118598d829a904))
 * **logql:** While validating logql expression, detect and validate expression in label_replace ([#18470](https://github.com/grafana/loki/issues/18470)) ([d379de5](https://github.com/grafana/loki/commit/d379de501f93be62cb0f72948794276e817d2599))
 * **logql:** Implement approx-topk function on querier ([#17816](https://github.com/grafana/loki/issues/17816))
 * **logql:** Reduce allocations for JSON and logfmt parser ([#18637](https://github.com/grafana/loki/issues/18637))
+* **loki:** Return defaults for non-existent tenants on applied limits endpoint ([#17942](https://github.com/grafana/loki/issues/17942))
 * **memberlist:** Allow resolution of advertise address from v6 interface ([#18250](https://github.com/grafana/loki/issues/18250)) ([8594d1c](https://github.com/grafana/loki/commit/8594d1ca282a9378091c122a2aa31d4b3af3f817))
-* **mixins:** Fix label generation for Loki logs dashboard ([#17412](https://github.com/grafana/loki/issues/17412)) ([da2b620](https://github.com/grafana/loki/commit/da2b620964e2b452598d2817107433e2e0092cc3))
 * **mixin:** Fix typo in Loki Reads dashboard TSDB row ([#18872](https://github.com/grafana/loki/issues/18872))
+* **mixins:** Fix label generation for Loki logs dashboard ([#17412](https://github.com/grafana/loki/issues/17412)) ([da2b620](https://github.com/grafana/loki/commit/da2b620964e2b452598d2817107433e2e0092cc3))
 * **objstore:** Ruler not starting and incorrect mkdir path when Thanos Store is enabled ([#16555](https://github.com/grafana/loki/issues/16555)) ([3da9f2c](https://github.com/grafana/loki/commit/3da9f2cae6cb6c01e185ef9a596cae8e3f782873))
+* **oltp:** Apply global otlp config to tenant config only when it is updated in the overrides ([#19213](https://github.com/grafana/loki/issues/19213))
 * **operator:** Fix type of maximum OpenShift version property ([#18066](https://github.com/grafana/loki/issues/18066)) ([f7c7dfa](https://github.com/grafana/loki/commit/f7c7dfa910d03e2ddc9c95c8d22fb3bff5c78e6b))
 * **operator:** Fix typo in docs regarding forcepathstyle ([#17725](https://github.com/grafana/loki/issues/17725))
 * **operator:** Update maximum OpenShift version ([#17954](https://github.com/grafana/loki/issues/17954))
@@ -499,19 +512,16 @@ This release does not exist. We triggered the release pipeline, but it decided t
 * **patterns:** Pattern persistence feature flag ([#18285](https://github.com/grafana/loki/issues/18285)) ([a206324](https://github.com/grafana/loki/commit/a206324ae3640d5f7615c2115fb3272256e95c6d))
 * **patterns:** Limit volume and frequency of persisted patterns ([#18362](https://github.com/grafana/loki/issues/18362)) ([c690827](https://github.com/grafana/loki/commit/c690827c6a655ada93806237d81643025ab53494))
 * **patterns:** Fix feature flag for enabling pattern persistence ([#18216](https://github.com/grafana/loki/issues/18216)) ([c167800](https://github.com/grafana/loki/commit/c167800b3f6e7edd7b3f06a9105245c98b7391dd))
-
 * **push:** Add guard clauses to prevent negative counter values ([#17056](https://github.com/grafana/loki/issues/17056)) ([9000de1](https://github.com/grafana/loki/commit/9000de1aa7a6508234ee58adb346549ac3df2648))
 * **push:** Fix guard clauses to prevent error spam in logs ([#17372](https://github.com/grafana/loki/issues/17372)) ([d70b20e](https://github.com/grafana/loki/commit/d70b20e37ffb788297bb42933aabc3fa5723f78c))
 * **push:** Fix push stats calculation ([#19319](https://github.com/grafana/loki/issues/19319))
-
-* **oltp:** Apply global otlp config to tenant config only when it is updated in the overrides ([#19213](https://github.com/grafana/loki/issues/19213))
 * **querier:** Fixes panic when filtering agg metrics from nil resp ([#17662](https://github.com/grafana/loki/issues/17662))
 * **querier:** Allow boolean numeric values in detected labels ([#16997](https://github.com/grafana/loki/issues/16997)) ([bfb935d](https://github.com/grafana/loki/commit/bfb935d893b6c3dec8d5fee539478c64d3012dd3))
 * **querier:** Fix integer overrun when calculating parallelism for very long time range queries ([#17428](https://github.com/grafana/loki/issues/17428)) ([82acbd5](https://github.com/grafana/loki/commit/82acbd58b22481df3999f34edcace200940ce79b))
 * **querier:** Better fix integer overrun when calculating parallelism for very long time range queries ([#17430](https://github.com/grafana/loki/issues/17430)) ([d660af3](https://github.com/grafana/loki/commit/d660af37fbc7dc9c7426999d14555c9bc688c565))
-* Revert "perf: Fix memory leak in cachedIterator ([#17628](https://github.com/grafana/loki/issues/17628))" ([#18687](https://github.com/grafana/loki/issues/18687)) ([0316740](https://github.com/grafana/loki/commit/03167408063088542d251a136d314471f09f33e9))
+* **querier:** Revert "perf: Fix memory leak in cachedIterator ([#17628](https://github.com/grafana/loki/issues/17628))" ([#18687](https://github.com/grafana/loki/issues/18687)) ([0316740](https://github.com/grafana/loki/commit/03167408063088542d251a136d314471f09f33e9))
 * **ruler:** Correct log level verbosity in rule evaluation ([#19519](https://github.com/grafana/loki/issues/19519))
-fix(ruler): Return StatusBadRequest on multiple org IDs (#17850)
+* **ruler:** Return StatusBadRequest on multiple org IDs ([#17850](https://github.com/grafana/loki/issues/17850))
 * **storage:** Fix nil pointer dereference in Volume method of the composite store ([#18064](https://github.com/grafana/loki/issues/18064)) ([fc7c018](https://github.com/grafana/loki/commit/fc7c0189c063d59d8933159faa9ab8f3e9df7f06))
 * **storage:** Use default config when building S3 client (backport k277) ([#19559](https://github.com/grafana/loki/issues/19559))
 * **stream-generator:** Split create/keep-alive streams routines ([#17815](https://github.com/grafana/loki/issues/17815))


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Release Notes for the 3.6.13 release.
I ran my release notes skill over the file, and it fixed some issues in the previous sections as well:
- added categories
- fixed alphabetizing errors
