### PR TITLE
fix(logql): Extend label-reduction optimization to max, min, and avg vector aggregations

### DIFF
--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -322,7 +322,7 @@ func TestEngine_InstantQuery(t *testing.T) {
 				},
 			},
 			[]SelectSampleParams{
-				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(60, 0), Selector: `count_over_time({app=~"foo|bar"}|~".+bar"[1m])`}},
+				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(60, 0), Selector: `avg(count_over_time({app=~"foo|bar"}|~".+bar"[1m]))`}},
 			},
 			promql.Vector{
 				promql.Sample{T: 60 * 1000, F: 6, Metric: labels.EmptyLabels()},
@@ -334,7 +334,7 @@ func TestEngine_InstantQuery(t *testing.T) {
 				{newSeries(testSize, factor(10, identity), `{app="foo"}`), newSeries(testSize, factor(10, identity), `{app="bar"}`)},
 			},
 			[]SelectSampleParams{
-				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(60, 0), Selector: `rate({app=~"foo|bar"}|~".+bar"[1m])`}},
+				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(60, 0), Selector: `min(rate({app=~"foo|bar"}|~".+bar"[1m]))`}},
 			},
 			promql.Vector{
 				promql.Sample{T: 60 * 1000, F: 0.1, Metric: labels.EmptyLabels()},
@@ -346,7 +346,7 @@ func TestEngine_InstantQuery(t *testing.T) {
 				{newSeries(testSize, factor(10, identity), `{app="foo"}`), newSeries(testSize, factor(5, identity), `{app="bar"}`)},
 			},
 			[]SelectSampleParams{
-				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(60, 0), Selector: `rate({app=~"foo|bar"}|~".+bar"[1m])`}},
+				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(60, 0), Selector: `max by (app) (rate({app=~"foo|bar"}|~".+bar"[1m]))`}},
 			},
 			promql.Vector{
 				promql.Sample{T: 60 * 1000, F: 0.2, Metric: labels.FromStrings("app", "bar")},
@@ -359,7 +359,7 @@ func TestEngine_InstantQuery(t *testing.T) {
 				{newSeries(testSize, factor(10, identity), `{app="foo"}`), newSeries(testSize, factor(5, identity), `{app="bar"}`)},
 			},
 			[]SelectSampleParams{
-				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(60, 0), Selector: `rate({app=~"foo|bar"}|~".+bar"[1m])`}},
+				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(60, 0), Selector: `max(rate({app=~"foo|bar"}|~".+bar"[1m]))`}},
 			},
 			promql.Vector{
 				promql.Sample{T: 60 * 1000, F: 0.2, Metric: labels.EmptyLabels()},
@@ -375,6 +375,58 @@ func TestEngine_InstantQuery(t *testing.T) {
 			},
 			promql.Vector{
 				promql.Sample{T: 60 * 1000, F: 0.4, Metric: labels.EmptyLabels()},
+			},
+		},
+		{
+			// max(max_over_time(...)) without by
+			`max(max_over_time({app="foo"} | unwrap foo [1m]))`, time.Unix(60, 0), logproto.FORWARD, 100,
+			[][]logproto.Series{
+				{newSeries(testSize, identity, `{app="foo"}`)},
+			},
+			[]SelectSampleParams{
+				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(60, 0), Selector: `max(max_over_time({app="foo"} | unwrap foo [1m]))`}},
+			},
+			promql.Vector{
+				promql.Sample{T: 60 * 1000, F: 1, Metric: labels.EmptyLabels()},
+			},
+		},
+		{
+			// min(min_over_time(...)) without by
+			`min(min_over_time({app="foo"} | unwrap foo [1m]))`, time.Unix(60, 0), logproto.FORWARD, 100,
+			[][]logproto.Series{
+				{newSeries(testSize, identity, `{app="foo"}`)},
+			},
+			[]SelectSampleParams{
+				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(60, 0), Selector: `min(min_over_time({app="foo"} | unwrap foo [1m]))`}},
+			},
+			promql.Vector{
+				promql.Sample{T: 60 * 1000, F: 1, Metric: labels.EmptyLabels()},
+			},
+		},
+		{
+			// avg(avg_over_time(...)) without by
+			`avg(avg_over_time({app="foo"} | unwrap foo [1m]))`, time.Unix(60, 0), logproto.FORWARD, 100,
+			[][]logproto.Series{
+				{newSeries(testSize, identity, `{app="foo"}`)},
+			},
+			[]SelectSampleParams{
+				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(60, 0), Selector: `avg(avg_over_time({app="foo"} | unwrap foo [1m]))`}},
+			},
+			promql.Vector{
+				promql.Sample{T: 60 * 1000, F: 1, Metric: labels.EmptyLabels()},
+			},
+		},
+		{
+			// max(max_over_time(...)) multiple series
+			`max(max_over_time({app=~"foo|bar"} | unwrap foo [1m]))`, time.Unix(60, 0), logproto.FORWARD, 100,
+			[][]logproto.Series{
+				{newSeries(testSize, identity, `{app="foo"}`), newSeries(testSize, constantValue(2), `{app="bar"}`)},
+			},
+			[]SelectSampleParams{
+				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(60, 0), Selector: `max(max_over_time({app=~"foo|bar"} | unwrap foo [1m]))`}},
+			},
+			promql.Vector{
+				promql.Sample{T: 60 * 1000, F: 2, Metric: labels.EmptyLabels()},
 			},
 		},
 		{
@@ -1186,7 +1238,7 @@ func TestEngine_RangeQuery(t *testing.T) {
 				{newSeries(testSize, factor(10, identity), `{app="foo"}`), newSeries(testSize, factor(10, identity), `{app="bar"}`)},
 			},
 			[]SelectSampleParams{
-				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(180, 0), Selector: `count_over_time({app=~"foo|bar"}|~".+bar"[1m])`}},
+				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(180, 0), Selector: `avg(count_over_time({app=~"foo|bar"}|~".+bar"[1m]))`}},
 			},
 			promql.Matrix{
 				promql.Series{
@@ -1201,7 +1253,7 @@ func TestEngine_RangeQuery(t *testing.T) {
 				{newSeries(testSize, factor(10, identity), `{app="foo"}`), newSeries(testSize, factor(10, identity), `{app="bar"}`)},
 			},
 			[]SelectSampleParams{
-				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(180, 0), Selector: `rate({app=~"foo|bar"}|~".+bar"[1m])`}},
+				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(180, 0), Selector: `min(rate({app=~"foo|bar"}|~".+bar"[1m]))`}},
 			},
 			promql.Matrix{
 				promql.Series{
@@ -1216,7 +1268,7 @@ func TestEngine_RangeQuery(t *testing.T) {
 				{newSeries(testSize, factor(10, identity), `{app="foo"}`), newSeries(testSize, factor(5, identity), `{app="bar"}`)},
 			},
 			[]SelectSampleParams{
-				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(180, 0), Selector: `rate({app=~"foo|bar"}|~".+bar"[1m])`}},
+				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(180, 0), Selector: `max by (app) (rate({app=~"foo|bar"}|~".+bar"[1m]))`}},
 			},
 			promql.Matrix{
 				promql.Series{
@@ -1235,7 +1287,7 @@ func TestEngine_RangeQuery(t *testing.T) {
 				{newSeries(testSize, factor(10, identity), `{app="foo"}`), newSeries(testSize, factor(5, identity), `{app="bar"}`)},
 			},
 			[]SelectSampleParams{
-				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(180, 0), Selector: `rate({app=~"foo|bar"}|~".+bar"[1m])`}},
+				{&logproto.SampleQueryRequest{Start: time.Unix(0, 0), End: time.Unix(180, 0), Selector: `max(rate({app=~"foo|bar"}|~".+bar"[1m]))`}},
 			},
 			promql.Matrix{
 				promql.Series{

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -334,7 +334,7 @@ func (ev *DefaultEvaluator) NewStepEvaluator(
 ) (StepEvaluator, error) {
 	switch e := expr.(type) {
 	case *syntax.VectorAggregationExpr:
-		if rangExpr, ok := e.Left.(*syntax.RangeAggregationExpr); ok && e.Operation == syntax.OpTypeSum {
+		if rangExpr, ok := e.Left.(*syntax.RangeAggregationExpr); ok && (e.Operation == syntax.OpTypeSum || e.Operation == syntax.OpTypeMax || e.Operation == syntax.OpTypeMin || e.Operation == syntax.OpTypeAvg) {
 			// if range expression is wrapped with a vector expression
 			// we should send the vector expression for allowing reducing labels at the source.
 			nextEvFactory = SampleEvaluatorFunc(func(ctx context.Context, _ SampleEvaluatorFactory, _ syntax.SampleExpr, _ Params) (StepEvaluator, error) {


### PR DESCRIPTION
## Description

When a vector aggregation like `max()`, `min()`, or `avg()` wraps a range aggregation (e.g. `max_over_time`) **without a `by` clause**, the inner range aggregation was evaluated with all stream labels preserved, causing high cardinality and query timeouts. The existing optimization that sends the full vector expression to `SelectSamples` for label reduction at the source only applied to `sum()`. This extends it to `max`, `min`, and `avg` as well.

Fixes the hang in `max(max_over_time(...))` queries described in #23474.

**What this PR does / why we need it**:

In `pkg/logql/evaluator.go`, `DefaultEvaluator.NewStepEvaluator` has an optimization (line 337) that sends the full vector aggregation expression to `SelectSamples` so the querier can reduce labels at the source. This optimization only applied to `OpTypeSum`. When `max()`, `min()`, or `avg()` wrap a `RangeAggregationExpr` (e.g. `max_over_time`, `rate` with unwrap, `count_over_time`) without a `by` clause, the inner range aggregation preserved all stream labels — producing extreme cardinality that caused the frontend's `batchRangeVectorIterator` and `VectorAggEvaluator` to hang and eventually timeout with a 502.

This PR extends the condition to also cover `OpTypeMax`, `OpTypeMin`, and `OpTypeAvg`, so they benefit from the same source-level label reduction that `sum()` already used. The change is a one-line condition expansion that reuses existing infrastructure with zero new logic.

**Which issue(s) this PR fixes**:
Fixes #23474

**Special notes for the reviewer**:

The fix is in `pkg/logql/evaluator.go:337` — a single condition change. The optimization body (lines 340–360) is unchanged; it already sends `e.String()` (the full vector expression) and `expr` (the full `VectorAggregationExpr`) to `SelectSamples`. Extending the condition simply allows `max`, `min`, and `avg` to enter this path.

Tests added:
- 4 new test cases in `TestEngine_InstantQuery` for `max(max_over_time)`, `min(min_over_time)`, `avg(avg_over_time)` — both single-stream and multi-stream ("foo|bar") without `by`
- 8 existing test `SelectSampleParams` Selector expectations updated (4 in `TestEngine_InstantQuery` + 4 in `TestEngine_RangeQuery`) for `avg(count_over_time)`, `min(rate)`, `max by (app)(rate)`, `max(rate)` — these now correctly expect the full vector aggregation string

Full `pkg/logql` test suite passes with no regressions.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)