### PR TITLE
chore(metrics): Extend `loki_index_gateway_requests_total` to cover `GetShards`

### DIFF
--- a/pkg/indexgateway/grpc.go
+++ b/pkg/indexgateway/grpc.go
@@ -12,8 +12,9 @@ import (
 )
 
 type ServerInterceptors struct {
-	reqCount              *prometheus.CounterVec
-	PerTenantRequestCount grpc.UnaryServerInterceptor
+	reqCount               *prometheus.CounterVec
+	PerTenantRequestCount  grpc.UnaryServerInterceptor
+	PerTenantStreamRequest grpc.StreamServerInterceptor
 }
 
 func NewServerInterceptors(r prometheus.Registerer) *ServerInterceptors {
@@ -24,24 +25,33 @@ func NewServerInterceptors(r prometheus.Registerer) *ServerInterceptors {
 		Help:      "Total amount of requests served by the index gateway",
 	}, []string{"operation", "status", "tenant"})
 
-	perTenantRequestCount := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
-		tenantID, err := tenant.TenantID(ctx)
-		if err != nil {
-			// ignore requests without tenantID
-			return handler(ctx, req)
+	recordMetric := func(ctx context.Context, method string, err error) {
+		tenantID, tenantErr := tenant.TenantID(ctx)
+		if tenantErr != nil {
+			return
 		}
-
-		resp, err = handler(ctx, req)
 		status := "success"
 		if err != nil {
 			status = "error"
 		}
-		requestCount.WithLabelValues(info.FullMethod, status, tenantID).Inc()
+		requestCount.WithLabelValues(method, status, tenantID).Inc()
+	}
+
+	perTenantRequestCount := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		resp, err = handler(ctx, req)
+		recordMetric(ctx, info.FullMethod, err)
 		return
 	}
 
+	perTenantStreamRequest := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		err := handler(srv, ss)
+		recordMetric(ss.Context(), info.FullMethod, err)
+		return err
+	}
+
 	return &ServerInterceptors{
-		reqCount:              requestCount,
-		PerTenantRequestCount: perTenantRequestCount,
+		reqCount:               requestCount,
+		PerTenantRequestCount:  perTenantRequestCount,
+		PerTenantStreamRequest: perTenantStreamRequest,
 	}
 }

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1958,6 +1958,7 @@ func (t *Loki) initIndexGatewayInterceptors() (services.Service, error) {
 	if t.Cfg.isTarget(IndexGateway) {
 		interceptors := indexgateway.NewServerInterceptors(prometheus.DefaultRegisterer)
 		t.Cfg.Server.GRPCMiddleware = append(t.Cfg.Server.GRPCMiddleware, interceptors.PerTenantRequestCount)
+		t.Cfg.Server.GRPCStreamMiddleware = append(t.Cfg.Server.GRPCStreamMiddleware, interceptors.PerTenantStreamRequest)
 	}
 	return nil, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Extends `loki_index_gateway_requests_total` metric to cover `GetShards`. This wasn't covered previously because this is a streaming request whilst other methods are non-streaming. 
Tested by running in a pre-production environment. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
