### PR TITLE
fix: Backport WAL replay hang fix to release-3.6.x (#21176)

### DIFF
--- a/pkg/ingester/replay_controller.go
+++ b/pkg/ingester/replay_controller.go
@@ -1,6 +1,8 @@
 package ingester
 
 import (
+	"fmt"
+
 	"github.com/dustin/go-humanize"
 	"github.com/go-kit/log/level"
 	"go.uber.org/atomic"
@@ -45,9 +47,10 @@ type replayController struct {
 	// > 64-bit alignment of 64-bit words accessed atomically. The first word in a
 	// > variable or in an allocated struct, array, or slice can be relied upon to
 	// > be 64-bit aligned.
-	currentBytes atomic.Int64
-	cfg          WALConfig
-	metrics      *ingesterMetrics
+	currentBytes    atomic.Int64
+	totalSubtracted atomic.Int64 // monotonically increasing; used to detect flush no-progress without being affected by concurrent Add calls
+	cfg             WALConfig
+	metrics         *ingesterMetrics
 
 	flusher Flusher
 	flushSF singleflight.Group
@@ -68,8 +71,8 @@ func (c *replayController) Add(x int64) {
 }
 
 func (c *replayController) Sub(x int64) {
+	c.totalSubtracted.Add(x)
 	c.metrics.setRecoveryBytesInUse(c.currentBytes.Sub(x))
-
 }
 
 func (c *replayController) Cur() int {
@@ -107,10 +110,21 @@ func (c *replayController) flush() {
 // It will call the function as long as there is expected room before the memory cap and will then flush data intermittently
 // when needed.
 func (c *replayController) WithBackPressure(fn func() error) error {
+	ceiling := int(c.cfg.ReplayMemoryCeiling) * 9 / 10
+	if ceiling <= 0 {
+		return fn()
+	}
 	// use 90% as a threshold since we'll be adding to it.
-	for c.Cur() > int(c.cfg.ReplayMemoryCeiling)*9/10 {
+	for c.Cur() > ceiling {
+		subtractedBefore := c.totalSubtracted.Load()
 		// too much backpressure, flush
 		c.Flush()
+		if c.totalSubtracted.Load() == subtractedBefore {
+			return fmt.Errorf("WAL replay flush made no progress: %s in use, ceiling %s; cannot recover",
+				humanize.Bytes(uint64(c.currentBytes.Load())),
+				humanize.Bytes(uint64(ceiling)),
+			)
+		}
 	}
 
 	return fn()

--- a/pkg/ingester/replay_controller.go
+++ b/pkg/ingester/replay_controller.go
@@ -79,16 +79,27 @@ func (c *replayController) Cur() int {
 	return int(c.currentBytes.Load())
 }
 
-func (c *replayController) Flush() {
+// Flush runs (or joins) a single in-flight flush and returns the number of
+// bytes that flush subtracted. The returned value is shared with every caller
+// coalesced into the same flush, so each caller observes the progress made by
+// the flush it actually participated in rather than comparing against a
+// snapshot taken outside the flush (which can miss progress made by an already
+// in-flight flush before the snapshot was taken).
+func (c *replayController) Flush() int64 {
 	// Use singleflight to ensure only one flush happens at a time
-	_, _, _ = c.flushSF.Do("flush", func() (interface{}, error) {
-		c.flush()
-		return nil, nil
+	subtracted, _, _ := c.flushSF.Do("flush", func() (interface{}, error) {
+		return c.flush(), nil
 	})
+	return subtracted.(int64)
 }
 
-func (c *replayController) flush() {
+// flush performs a single flush and returns how many bytes it subtracted.
+// Because singleflight guarantees only one flush runs at a time and Sub is only
+// called from within a flush, the delta of totalSubtracted across this call is
+// exactly the progress attributable to this flush.
+func (c *replayController) flush() int64 {
 	c.metrics.recoveryIsFlushing.Set(1)
+	subtractedBefore := c.totalSubtracted.Load()
 	prior := c.currentBytes.Load()
 	level.Debug(util_log.Logger).Log(
 		"msg", "replay flusher pre-flush",
@@ -104,6 +115,7 @@ func (c *replayController) flush() {
 	)
 
 	c.metrics.recoveryIsFlushing.Set(0)
+	return c.totalSubtracted.Load() - subtractedBefore
 }
 
 // WithBackPressure is expected to call replayController.Add in the passed function to increase the managed byte count.
@@ -116,10 +128,16 @@ func (c *replayController) WithBackPressure(fn func() error) error {
 	}
 	// use 90% as a threshold since we'll be adding to it.
 	for c.Cur() > ceiling {
-		subtractedBefore := c.totalSubtracted.Load()
-		// too much backpressure, flush
-		c.Flush()
-		if c.totalSubtracted.Load() == subtractedBefore {
+		// too much backpressure, flush. Flush reports how many bytes the flush
+		// we participated in subtracted, so a caller coalesced into an already
+		// in-flight flush still observes that flush's progress.
+		//
+		// Only treat a zero-progress flush as fatal if we are *still* over the
+		// ceiling afterwards. A concurrent worker's flush may have drained memory
+		// below the ceiling between our loop guard and this call, in which case
+		// our own flush legitimately has nothing to do and we should simply exit
+		// the loop rather than report a spurious no-progress error.
+		if c.Flush() == 0 && c.Cur() > ceiling {
 			return fmt.Errorf("WAL replay flush made no progress: %s in use, ceiling %s; cannot recover",
 				humanize.Bytes(uint64(c.currentBytes.Load())),
 				humanize.Bytes(uint64(ceiling)),

--- a/pkg/ingester/replay_controller_test.go
+++ b/pkg/ingester/replay_controller_test.go
@@ -78,6 +78,105 @@ func TestReplayController(t *testing.T) {
 	require.Equal(t, expected, ops)
 }
 
+// Test that WithBackPressure skips backpressure entirely when ReplayMemoryCeiling is zero.
+func TestReplayControllerZeroCeiling(t *testing.T) {
+	var flushed bool
+	flusher := newDumbFlusher(func() {
+		flushed = true
+	})
+	rc := newReplayController(nilMetrics(), WALConfig{ReplayMemoryCeiling: 0}, flusher)
+
+	// Add a large amount of data — with a zero ceiling this should not trigger flushing.
+	rc.Add(1 << 30) // 1GB
+
+	err := rc.WithBackPressure(func() error {
+		rc.Add(1 << 30)
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.False(t, flushed, "flusher should not be called when ReplayMemoryCeiling is zero")
+}
+
+// Test that WithBackPressure returns an error when a flush makes no progress reducing memory.
+func TestReplayControllerNoProgressFlush(t *testing.T) {
+	flusher := newDumbFlusher(nil) // no-op: never calls rc.Sub, so bytes never decrease
+	rc := newReplayController(nilMetrics(), WALConfig{ReplayMemoryCeiling: 100}, flusher)
+
+	// Exceed 90% threshold (ceiling = 90).
+	rc.Add(95)
+
+	err := rc.WithBackPressure(func() error {
+		return nil
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WAL replay flush made no progress")
+}
+
+// Test that WithBackPressure returns an error when flush makes partial progress but then stalls,
+// i.e. subsequent flushes no longer reduce memory below the ceiling.
+func TestReplayControllerPartialProgressFlush(t *testing.T) {
+	var rc *replayController
+	flushCount := 0
+	flusher := newDumbFlusher(func() {
+		flushCount++
+		if flushCount == 1 {
+			// First flush makes partial progress: drops from 200 to 95, still above 90% ceiling.
+			rc.Sub(105)
+		}
+		// Subsequent flushes are no-ops: bytes stay at 95, no further progress.
+	})
+	rc = newReplayController(nilMetrics(), WALConfig{ReplayMemoryCeiling: 100}, flusher)
+
+	rc.Add(200) // well above the 90-byte ceiling
+
+	err := rc.WithBackPressure(func() error {
+		return nil
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WAL replay flush made no progress")
+	require.Equal(t, 2, flushCount, "should have flushed twice: once with progress, once stalled")
+}
+
+// Test that WithBackPressure does not spuriously error when concurrent workers refill currentBytes
+// during a flush. The flush made real progress (Sub was called), so no error should be returned
+// even though currentBytes ends up higher than the pre-flush snapshot due to concurrent Add calls.
+//
+// Sequence:
+//  1. bytes=95 > ceiling=90, enter loop; old code snapshots before=95
+//  2. Flush runs: Sub(80) → bytes=15; concurrent goroutine adds 85 → bytes=100
+//  3. Old check: currentBytes(100) >= before(95) → spurious error
+//  4. New check: totalSubtracted increased → no error, loop continues and drains on next flush
+func TestReplayControllerNoSpuriousErrorOnConcurrentAdd(t *testing.T) {
+	var rc *replayController
+	var once sync.Once
+	flushed := make(chan struct{})
+	flusher := newDumbFlusher(func() {
+		rc.Sub(80)                         // genuine progress each flush
+		once.Do(func() { close(flushed) }) // signal the concurrent goroutine only on first flush
+	})
+	rc = newReplayController(nilMetrics(), WALConfig{ReplayMemoryCeiling: 100}, flusher)
+	rc.Add(95) // above 90% ceiling
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Simulate a concurrent worker adding bytes while the first flush is running,
+		// pushing currentBytes back above the pre-flush snapshot (100 > before=95).
+		// The loop will flush again and drain normally; no error should be returned.
+		<-flushed
+		rc.Add(85) // 15 + 85 = 100, above the original before=95
+	}()
+
+	err := rc.WithBackPressure(func() error { return nil })
+	wg.Wait()
+
+	require.NoError(t, err, "concurrent Add during flush should not cause a spurious no-progress error")
+}
+
 // Test to ensure only one flush happens at a time when multiple goroutines call WithBackPressure
 func TestReplayControllerConcurrentFlushes(t *testing.T) {
 	t.Run("multiple goroutines wait for single flush", func(t *testing.T) {

--- a/pkg/ingester/replay_controller_test.go
+++ b/pkg/ingester/replay_controller_test.go
@@ -177,6 +177,87 @@ func TestReplayControllerNoSpuriousErrorOnConcurrentAdd(t *testing.T) {
 	require.NoError(t, err, "concurrent Add during flush should not cause a spurious no-progress error")
 }
 
+// Regression test: a caller that snapshots progress and then coalesces into an
+// already in-flight flush — whose Sub happened before the caller's snapshot —
+// must still observe that flush's progress and not return a spurious
+// no-progress error.
+//
+// Sequence:
+//  1. Goroutine A triggers flush F1, which Subs 50 (200 -> 150, still above the
+//     90-byte ceiling) and then parks in-flight.
+//  2. B enters WithBackPressure and takes its snapshot *after* F1's Sub, then
+//     coalesces into F1 via singleflight. The old code compared totalSubtracted
+//     against that post-Sub snapshot, saw no change, and errored out even though
+//     F1 freed memory.
+//  3. F2 (triggered by B's next loop iteration) drains below the ceiling.
+func TestReplayControllerJoinInFlightFlushObservesProgress(t *testing.T) {
+	var rc *replayController
+	release := make(chan struct{})
+	subDone := make(chan struct{})
+	var flushes atomic.Int32
+	flusher := newDumbFlusher(func() {
+		if flushes.Add(1) == 1 {
+			// First flush: make progress, then stay in-flight so a second
+			// caller coalesces into this same flush.
+			rc.Sub(50) // 200 -> 150, still above the 90-byte ceiling
+			close(subDone)
+			<-release
+		} else {
+			rc.Sub(100) // subsequent flushes drain the rest
+		}
+	})
+	rc = newReplayController(nilMetrics(), WALConfig{ReplayMemoryCeiling: 100}, flusher)
+	rc.Add(200)
+
+	// Goroutine A keeps F1 in-flight (blocked in the flusher) after its Sub.
+	var wgA sync.WaitGroup
+	wgA.Add(1)
+	go func() {
+		defer wgA.Done()
+		rc.Flush()
+	}()
+
+	// Only after F1 has already subtracted does B take its snapshot.
+	<-subDone
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- rc.WithBackPressure(func() error { return nil })
+	}()
+
+	// Give B time to enter Flush and coalesce into F1, then release it.
+	time.Sleep(20 * time.Millisecond)
+	close(release)
+
+	wgA.Wait()
+	require.NoError(t, <-errCh, "caller joining an in-flight flush must observe its progress")
+}
+
+// Regression test: a caller must not report a spurious no-progress error when a
+// concurrent worker's flush already drained memory below the ceiling between the
+// caller's loop guard and its own (now no-op) flush.
+//
+// The caller passes the Cur() > ceiling guard, then another worker's flush
+// completes and drains memory below the ceiling. The caller's own flush now has
+// nothing to do and returns zero, but memory is already fine, so it must exit
+// the loop cleanly instead of erroring.
+func TestReplayControllerNoErrorWhenDrainedBelowCeiling(t *testing.T) {
+	var rc *replayController
+	flusher := newDumbFlusher(func() {
+		// This flush frees nothing itself (so Flush() reports zero progress), but
+		// simulate that a concurrent worker's already-completed flush drained
+		// memory below the ceiling. currentBytes is reduced directly — as if by
+		// another flush's accounting — without advancing totalSubtracted for this
+		// flush, exactly mirroring a fresh flush that finds nothing left to do.
+		rc.currentBytes.Store(45) // below the 90-byte ceiling
+	})
+	rc = newReplayController(nilMetrics(), WALConfig{ReplayMemoryCeiling: 100}, flusher)
+	rc.Add(95) // above the 90-byte ceiling → enter the loop
+
+	err := rc.WithBackPressure(func() error { return nil })
+	require.NoError(t, err, "a no-progress flush must not error once memory is already under the ceiling")
+}
+
 // Test to ensure only one flush happens at a time when multiple goroutines call WithBackPressure
 func TestReplayControllerConcurrentFlushes(t *testing.T) {
 	t.Run("multiple goroutines wait for single flush", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports the WAL replay no-progress fix to `release-3.6.x` so it can be picked up by GEL 3.6 (which vendors this branch).

On 3.6.x, `replayController.WithBackPressure` has no exit condition: if a replay-triggered flush does not reduce in-memory bytes below 90% of `replay_memory_ceiling` (slow/unavailable storage backend, `chunk_retain_period` holding freshly flushed chunks, failed immediate flush ops being re-enqueued forever), the ingester spins in the backpressure loop indefinitely. It never finishes replay, never becomes ready, gets killed by the startup probe, and replays the same WAL again on the next start — an unrecoverable crash loop that only clearing the WAL breaks. We hit exactly this with a customer running GEL 3.6.10 (grafana/support-escalations#23469).

Two cherry-picks, in order:

- 347f2f7025 refactor(ingestor): WAL Replay controller: Use singleflight to ensure only one inflight flush is happening (#19831)
- fb58ab8c21 fix: WAL replay hang when flush doesn't progress (#21176)

The refactor is included because #21176 was written on top of it; taking both keeps `replay_controller.go` identical to `main` (both cherry-picks applied cleanly, no conflicts) instead of hand-porting the progress-detection logic onto the old `sync.Cond` implementation.

With this fix, a no-progress flush fails recovery with an explicit error (`WAL replay flush made no progress: ... cannot recover`) instead of hanging silently, and a zero `replay_memory_ceiling` no longer triggers backpressure on every record.

**Special notes for your reviewer**:

`go test ./pkg/ingester/ -run TestReplayController` passes on this branch, including the four tests added by #21176.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)