### PR TITLE
test: Fix flaky dataobj indexer test

### DIFF
--- a/pkg/dataobj/index/indexer_test.go
+++ b/pkg/dataobj/index/indexer_test.go
@@ -439,6 +439,7 @@ func TestSerialIndexer_ResetsCalculatorOnCancel(t *testing.T) {
 
 	mockCalc := &blockingMockCalculator{
 		entered: make(chan struct{}),
+		reset:   make(chan struct{}),
 	}
 	indexStorageBucket := objstore.NewInMemBucket()
 
@@ -493,10 +494,12 @@ func TestSerialIndexer_ResetsCalculatorOnCancel(t *testing.T) {
 	}
 
 	// submitBuild may return on ctx.Done before the worker finishes unwinding;
-	// wait for the deferred Reset from the cancelled buildIndex.
-	require.Eventually(t, func() bool {
-		return mockCalc.resetCallCount >= 1
-	}, 5*time.Second, 10*time.Millisecond, "calculator should be reset after cancelled build")
+	// wait for Reset from the cancelled processBuildRequest.
+	select {
+	case <-mockCalc.reset:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for calculator Reset after cancelled build")
+	}
 	require.Equal(t, 0, mockCalc.flushCallCount, "cancelled build should not flush")
 }
 
@@ -504,6 +507,7 @@ func TestSerialIndexer_ResetsCalculatorOnCancel(t *testing.T) {
 type blockingMockCalculator struct {
 	mockCalculator
 	entered chan struct{}
+	reset   chan struct{}
 }
 
 func (c *blockingMockCalculator) Calculate(ctx context.Context, _ log.Logger, object *dataobj.Object, _ string) error {
@@ -512,6 +516,11 @@ func (c *blockingMockCalculator) Calculate(ctx context.Context, _ log.Logger, ob
 	close(c.entered)
 	<-ctx.Done()
 	return ctx.Err()
+}
+
+func (c *blockingMockCalculator) Reset() {
+	c.mockCalculator.Reset()
+	close(c.reset)
 }
 
 func TestDownloadObject_Success(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
To address a data race:
```
WARNING: DATA RACE
Read at 0x00c008cb2f58 by goroutine 2972:
  github.com/grafana/loki/v3/pkg/dataobj/index.TestSerialIndexer_ResetsCalculatorOnCancel.func3()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/dataobj/index/indexer_test.go:498 +0x34
  github.com/stretchr/testify/assert.Eventually.func1()
      /Users/progers/dev/src/github.com/grafana/loki/vendor/github.com/stretchr/testify/assert/assertions.go:1994 +0x34

Previous write at 0x00c008cb2f58 by goroutine 2875:
  github.com/grafana/loki/v3/pkg/dataobj/index.(*mockCalculator).Reset()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/dataobj/index/indexer_test.go:339 +0x50
  github.com/grafana/loki/v3/pkg/dataobj/index.(*blockingMockCalculator).Reset()
      <autogenerated>:1 +0x18
  github.com/grafana/loki/v3/pkg/dataobj/index.(*serialIndexer).processBuildRequest()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/dataobj/index/indexer.go:237 +0x4e0
  github.com/grafana/loki/v3/pkg/dataobj/index.(*serialIndexer).buildWorker()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/dataobj/index/indexer.go:197 +0x3fc
  github.com/grafana/loki/v3/pkg/dataobj/index.(*serialIndexer).starting.func1()
      /Users/progers/dev/src/github.com/grafana/loki/pkg/dataobj/index/indexer.go:108 +0x40
```
**Which issue(s) this PR fixes**:
In support of: https://github.com/grafana/loki/issues/8586

**Special notes for your reviewer**:
```
 % go test -race -count=1000 -run 'TestSerialIndexer_ResetsCalculatorOnCancel' ./pkg/dataobj/index/
ok  	github.com/grafana/loki/v3/pkg/dataobj/index	3.473s
```
**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
