### PR TITLE
fix: Revert "fix: Advertise sticky balancers for dataobj index builders"

### DIFF
--- a/pkg/dataobj/index/builder.go
+++ b/pkg/dataobj/index/builder.go
@@ -193,10 +193,7 @@ func NewIndexBuilder(
 		kgo.InstanceID(instanceID),
 		kgo.SessionTimeout(3*time.Minute),
 		kgo.ConsumerGroup(consumerGroup),
-		// Offer both cooperative-sticky and round-robin during migration from eager
-		// rebalancing (KIP-429). A follow-up change removes RoundRobin once every
-		// index-builder member advertises cooperative-sticky.
-		kgo.Balancers(kgo.CooperativeStickyBalancer(), kgo.RoundRobinBalancer()),
+		kgo.Balancers(kgo.RoundRobinBalancer()),
 		kgo.RebalanceTimeout(5*time.Minute),
 		kgo.DisableAutoCommit(),
 		kgo.OnPartitionsAssigned(s.handlePartitionsAssigned),


### PR DESCRIPTION
Reverts grafana/loki#23304