### PR TITLE
feat(otlp): Adds a reporter to view attributes expanded to structured metadata

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3440,6 +3440,18 @@ write_failures_logging:
   # CLI flag: -distributor.write-failures-logging.add-insights-label
   [add_insights_label: <boolean> | default = false]
 
+# Customize the logging of OTLP attribute expansion.
+otlp_attribute_logging:
+  # Number of attribute expansion reports to emit per second, per tenant. Each
+  # report is one summary line plus one line per attribute.
+  # CLI flag: -distributor.otlp-attribute-logging.rate
+  [rate: <float> | default = 1]
+
+  # Maximum number of attributes to log on their own line for a reported
+  # request. The remaining attributes are summarised on a single overflow line.
+  # CLI flag: -distributor.otlp-attribute-logging.max-attributes
+  [max_attributes: <int> | default = 20]
+
 otlp_config:
   # List of default otlp resource attributes to be picked as index labels
   # CLI flag: -distributor.otlp.default_resource_attributes_as_index_labels
@@ -5460,6 +5472,12 @@ These are values which allow you to control aspects of Loki's operation, most co
 # Log stream info for duplicate lines received
 # CLI flag: -operation-config.log-duplicate-stream-info
 [log_duplicate_stream_info: <boolean> | default = false]
+
+# Log which OTLP resource and scope attributes are expanded into structured
+# metadata, for a rate limited subset of push requests. Only attribute names and
+# sizes are logged, never values (recommend to enable via runtime config only).
+# CLI flag: -operation-config.log-otlp-attribute-expansion
+[log_otlp_attribute_expansion: <boolean> | default = false]
 
 # Log push errors with a rate limited logger, will show client push errors
 # without overly spamming logs.

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -5475,7 +5475,7 @@ These are values which allow you to control aspects of Loki's operation, most co
 
 # Log which OTLP resource and scope attributes are expanded into structured
 # metadata, for a rate limited subset of push requests. Only attribute names and
-# sizes are logged, never values (recommend to enable via runtime config only).
+# sizes are logged, never values.
 # CLI flag: -operation-config.log-otlp-attribute-expansion
 [log_otlp_attribute_expansion: <boolean> | default = false]
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -51,6 +51,7 @@ import (
 	limits_frontend "github.com/grafana/loki/v3/pkg/limits/frontend"
 	limits_frontend_client "github.com/grafana/loki/v3/pkg/limits/frontend/client"
 	"github.com/grafana/loki/v3/pkg/loghttp/push"
+	"github.com/grafana/loki/v3/pkg/loghttp/push/otlpattrs"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/runtime"
@@ -104,6 +105,10 @@ type Config struct {
 	// WriteFailuresLoggingCfg customizes write failures logging behavior.
 	WriteFailuresLogging writefailures.Cfg `yaml:"write_failures_logging" doc:"description=Customize the logging of write failures."`
 
+	// OTLPAttributeLogging configures the sampled logging of OTLP attribute expansion
+	// which is enabled per tenant with the log_otlp_attribute_expansion runtime config.
+	OTLPAttributeLogging otlpattrs.Cfg `yaml:"otlp_attribute_logging" doc:"description=Customize the logging of OTLP attribute expansion."`
+
 	OTLPConfig push.GlobalOTLPConfig `yaml:"otlp_config"`
 
 	// DefaultPolicyStreamMappings contains the default policy stream mappings that are merged with per-tenant mappings.
@@ -128,6 +133,7 @@ func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
 	cfg.CircuitBreaker.RegisterFlags(fs)
 	cfg.RateStore.RegisterFlagsWithPrefix("distributor.rate-store", fs)
 	cfg.WriteFailuresLogging.RegisterFlagsWithPrefix("distributor.write-failures-logging", fs)
+	cfg.OTLPAttributeLogging.RegisterFlagsWithPrefix("distributor.otlp-attribute-logging", fs)
 	fs.IntVar(&cfg.MaxRecvMsgSize, "distributor.max-recv-msg-size", 100<<20, "The maximum size of a received message.")
 	fs.Int64Var(&cfg.MaxDecompressedSize, "distributor.max-decompressed-size", 5000<<20, "The maximum size of a decompressed message. Defaults to 50x max-recv-msg-size.")
 	fs.IntVar(&cfg.MaxInflightBytes, "distributor.max-inflight-bytes", 0, "The maximum number of inflight bytes at a time. 0 means disabled.")
@@ -317,6 +323,9 @@ type Distributor struct {
 	// Push failures rate limiter.
 	writeFailuresManager *writefailures.Manager
 
+	// Rate limited reporter for OTLP resource and scope attribute expansion.
+	otlpAttrReporter *otlpattrs.Reporter
+
 	RequestParserWrapper push.RequestParserWrapper
 
 	usageTracker   push.UsageTracker
@@ -483,6 +492,7 @@ func New(
 		ingesterTasks:         make(chan pushIngesterTask),
 		m:                     newMetrics(registerer),
 		writeFailuresManager:  writefailures.NewManager(logger, registerer, cfg.WriteFailuresLogging, configs, "distributor"),
+		otlpAttrReporter:      otlpattrs.NewReporter(cfg.OTLPAttributeLogging, configs),
 		kafkaWriter:           kafkaWriter,
 		partitionRing:         partitionRing,
 		ingestLimits:          ingestLimits,

--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -132,6 +132,9 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 	// Gather information about the different types of push formats Loki receives
 	d.m.pushStatsCount.WithLabelValues(tenantID, pushStats.ContentType, pushStats.ContentEncoding, pushStats.ContentVersion, format).Inc()
 
+	// Only reported for tenants that have enabled log_otlp_attribute_expansion in their runtime config.
+	d.otlpAttrReporter.Report(logger, tenantID, pushStats.OTLPAttributes)
+
 	if logPushRequestStreams {
 		shouldLog := true
 		if len(filterPushRequestStreamsIPs) > 0 {

--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 
+	"github.com/grafana/loki/v3/pkg/loghttp/push/otlpattrs"
 	"github.com/grafana/loki/v3/pkg/loghttp/push/otlplabels"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 
@@ -151,9 +152,17 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 
 	logServiceNameDiscovery := false
 	logPushRequestStreams := false
+	logOTLPAttributeExpansion := false
 	if tenantConfigs != nil {
 		logServiceNameDiscovery = tenantConfigs.LogServiceNameDiscovery(userID)
 		logPushRequestStreams = tenantConfigs.LogPushRequestStreams(userID)
+		logOTLPAttributeExpansion = tenantConfigs.LogOTLPAttributeExpansion(userID)
+	}
+
+	var attrAccumulator *otlpattrs.Accumulator
+	if logOTLPAttributeExpansion {
+		attrAccumulator = otlpattrs.NewAccumulator()
+		stats.OTLPAttributes = attrAccumulator
 	}
 
 	// If this is a backfill push (X-Loki-Backfill-Shard header), every stream gets the internal
@@ -167,6 +176,7 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 		res := rls.At(i).Resource()
 		resAttrs := res.Attributes()
 
+		resourceRecords := 0
 		resResult, err := otlplabels.ResourceAttrsToStreamLabels(resAttrs, otlpConfig, discoverServiceName)
 		if err != nil {
 			return nil, err
@@ -257,6 +267,8 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 		for j := 0; j < sls.Len(); j++ {
 			logs := sls.At(j).LogRecords()
 
+			scopeRecords := 0
+
 			// it would be rare to have multiple scopes so if the entries slice is empty, pre-allocate it for the number of log entries
 			if cap(pushRequestsByStream[labelsStr].Entries) == 0 {
 				stream := pushRequestsByStream[labelsStr]
@@ -341,6 +353,7 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 				stream := pushRequestsByStream[entryLabelsStr]
 				stream.Entries = append(stream.Entries, entry)
 				pushRequestsByStream[entryLabelsStr] = stream
+				scopeRecords++
 
 				entryRetentionPeriod := streamResolver.RetentionPeriodFor(entryLbs)
 				entryPolicy := streamResolver.PolicyFor(ctx, entryLbs)
@@ -375,9 +388,19 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 				}
 			}
 
+			if attrAccumulator != nil {
+				attrAccumulator.IncRecords(scopeRecords)
+				attrAccumulator.Observe(otlpattrs.KindScope, scopeAttributesAsStructuredMetadata, scopeRecords)
+			}
+			resourceRecords += scopeRecords
+
 			if tracker != nil {
 				tracker.ReceivedBytesAdd(ctx, userID, retentionPeriodForUser, lbs, float64(totalBytesReceived), format)
 			}
+		}
+
+		if attrAccumulator != nil {
+			attrAccumulator.Observe(otlpattrs.KindResource, resourceAttributesAsStructuredMetadata, resourceRecords)
 		}
 	}
 

--- a/pkg/loghttp/push/otlp_test.go
+++ b/pkg/loghttp/push/otlp_test.go
@@ -20,6 +20,8 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/grafana/loki/v3/pkg/loghttp/push/otlpattrs"
+	"github.com/grafana/loki/v3/pkg/runtime"
 	"github.com/grafana/loki/v3/pkg/util"
 	"github.com/grafana/loki/v3/pkg/util/constants"
 
@@ -38,6 +40,12 @@ var defaultGlobalOTLPConfig = GlobalOTLPConfig{}
 
 func init() {
 	flagext.DefaultValues(&defaultGlobalOTLPConfig)
+}
+
+type otlpAttributeExpansionTenantConfigs struct{}
+
+func (otlpAttributeExpansionTenantConfigs) TenantConfig(_ string) *runtime.Config {
+	return &runtime.Config{LogOTLPAttributeExpansion: true}
 }
 
 func TestOTLPToLokiPushRequest(t *testing.T) {
@@ -681,6 +689,7 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 					expectedStats.TotalExpandedEntriesSize += int64(util.EntryTotalSize(&stream.Entries[i]))
 				}
 			}
+
 			require.Equal(t, expectedStats, *stats)
 
 			totalBytes := 0.0
@@ -695,6 +704,77 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 				}
 			}
 			require.Equal(t, totalBytes, tracker.Total(), "Total tracked bytes must equal total bytes of the stats.")
+		})
+	}
+}
+
+func TestOTLPToLokiPushRequestAttributeExpansionReport(t *testing.T) {
+	now := time.Unix(0, time.Now().UnixNano())
+	otlpConfig := DefaultOTLPConfig(GlobalOTLPConfig{
+		DefaultOTLPResourceAttributesAsIndexLabels: []string{"service.name"},
+	})
+	generateLogs := func() plog.Logs {
+		logs := plog.NewLogs()
+		resourceLogs := logs.ResourceLogs().AppendEmpty()
+		resourceLogs.Resource().Attributes().PutStr("service.name", "svc")
+		resourceLogs.Resource().Attributes().PutStr("cluster", "prod")
+		resourceLogs.Resource().Attributes().PutStr("cloud.region", "us-east-1")
+
+		scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+		scopeLogs.Scope().SetName("testlib")
+		for range 3 {
+			record := scopeLogs.LogRecords().AppendEmpty()
+			record.Body().SetStr("a log line")
+			record.SetTimestamp(pcommon.Timestamp(now.UnixNano()))
+		}
+		return logs
+	}
+
+	for _, tc := range []struct {
+		name           string
+		expectedReport *otlpattrs.Report
+	}{
+		{
+			name: "enabled",
+			expectedReport: &otlpattrs.Report{
+				Records:                3,
+				Attributes:             3, // service.name is promoted as label
+				AttributeExpandedBytes: 147,
+				Top: []otlpattrs.Attribute{
+					{Kind: otlpattrs.KindResource, Name: "cloud_region", Records: 3, ExpandedBytes: 63},
+					{Kind: otlpattrs.KindScope, Name: "scope_name", Records: 3, ExpandedBytes: 51},
+					{Kind: otlpattrs.KindResource, Name: "cluster", Records: 3, ExpandedBytes: 33},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tenantConfigs, err := runtime.NewTenantConfigs(otlpAttributeExpansionTenantConfigs{})
+			require.NoError(t, err)
+
+			stats := NewPushStats()
+			streamResolver := newMockStreamResolver("fake", &fakeLimits{})
+			streamResolver.policyForOverride = func(_ context.Context, _ labels.Labels) string {
+				return "test-policy"
+			}
+
+			_, err = otlpToLokiPushRequest(
+				context.Background(),
+				generateLogs(),
+				"test-user",
+				otlpConfig,
+				tenantConfigs,
+				[]string{},
+				NewMockTracker(),
+				stats,
+				log.NewNopLogger(),
+				streamResolver,
+				constants.OTLP,
+			)
+			require.NoError(t, err)
+
+			require.NotNil(t, stats.OTLPAttributes)
+			require.Equal(t, *tc.expectedReport, stats.OTLPAttributes.Report(0))
 		})
 	}
 }

--- a/pkg/loghttp/push/otlpattrs/accumulator.go
+++ b/pkg/loghttp/push/otlpattrs/accumulator.go
@@ -1,0 +1,193 @@
+// Package otlpattrs observes how much of an OTLP push request's ingested
+// volume comes from resource and scope attributes being expanded onto every
+// log record, and reports it as sampled structured logs.
+//
+// Only attribute names and byte counts are ever recorded. Attribute values are
+// never retained or logged, since they routinely contain user data.
+package otlpattrs
+
+import (
+	"cmp"
+	"slices"
+	"strings"
+
+	"github.com/grafana/loki/pkg/push"
+
+	"github.com/grafana/loki/v3/pkg/util"
+)
+
+// Kind identifies which part of the OTLP payload an attribute came from.
+type Kind string
+
+const (
+	// KindResource is an attribute defined on a ResourceLogs block.
+	KindResource Kind = "resource"
+	// KindScope is an attribute defined on a ScopeLogs block.
+	KindScope Kind = "scope"
+)
+
+type attrStat struct {
+	// records is the number of log records this attribute was copied onto.
+	records int64
+	// expandedBytes is the total bytes the attribute contributed across all
+	// of those records, including the repeated attribute name.
+	expandedBytes int64
+}
+
+// Accumulator collects per-attribute expansion counters for a single push
+// request. It is not safe for concurrent use; a request is parsed on one
+// goroutine, so it deliberately avoids any synchronisation.
+type Accumulator struct {
+	records       int64
+	resourceAttrs map[string]attrStat
+	scopeAttrs    map[string]attrStat
+}
+
+// NewAccumulator returns an Accumulator ready to observe a single push request.
+func NewAccumulator() *Accumulator {
+	return &Accumulator{
+		resourceAttrs: make(map[string]attrStat),
+		scopeAttrs:    make(map[string]attrStat),
+	}
+}
+
+// IncRecords adds to the request's total log record count.
+// Callers must add each record exactly once, so it is separate from Observe,
+// which is called once per resource and once per scope over the same records.
+func (a *Accumulator) IncRecords(records int) {
+	a.records += int64(records)
+}
+
+// IsEmpty reports whether the request expanded no attributes at all.
+func (a *Accumulator) IsEmpty() bool {
+	return len(a.resourceAttrs) == 0 && len(a.scopeAttrs) == 0
+}
+
+// Observe records that every attribute in attrs was copied onto records log
+// records.
+func (a *Accumulator) Observe(kind Kind, attrs push.LabelsAdapter, records int) {
+	if records <= 0 {
+		return
+	}
+
+	for _, attr := range attrs {
+		if slices.Contains(util.ExcludedStructuredMetadataLabels, attr.Name) {
+			continue
+		}
+
+		// Note that even though expandedBytes counts the attribute name and value
+		// once per record, these slices are not copied per record, so the actual
+		// memory cost in distributor is lower in practice.
+		//
+		// Where this cost does show up is in the kafka producer and on the ingester
+		// when we unmarshal the denormalised payload into memory.
+		expandedBytes := int64(records) * int64(len(attr.Name)+len(attr.Value))
+
+		switch kind {
+		case KindResource:
+			stat := a.resourceAttrs[attr.Name]
+			stat.records += int64(records)
+			stat.expandedBytes += expandedBytes
+			a.resourceAttrs[attr.Name] = stat
+		case KindScope:
+			stat := a.scopeAttrs[attr.Name]
+			stat.records += int64(records)
+			stat.expandedBytes += expandedBytes
+			a.scopeAttrs[attr.Name] = stat
+		default:
+			// audit only supports resource and scope attributes.
+			// silently ignore unknown kind.
+		}
+	}
+}
+
+// Attribute is a single attribute's contribution to a push request.
+type Attribute struct {
+	Kind Kind
+	Name string
+	// Records is the number of log records the attribute was copied onto.
+	Records int64
+	// ExpandedBytes is the total bytes the attribute contributed to the request.
+	ExpandedBytes int64
+}
+
+// Report is a ranked, truncated view of an Accumulator, safe to log.
+type Report struct {
+	Records int64
+
+	// Attributes is the total number of distinct attributes observed, whether
+	// or not they made the cut.
+	Attributes int
+	// AttributeExpandedBytes is how much of ExpandedBytes is attributable to
+	// resource and scope attributes being copied onto every record.
+	AttributeExpandedBytes int64
+
+	// Top holds the attributes that individually contributed the most bytes,
+	// ordered by descending contribution.
+	Top []Attribute
+
+	// Overflow summarises the attributes that did not make Top.
+	OverflowAttributes    int
+	OverflowExpandedBytes int64
+
+	// OverflowNames lists the names of the overflow attributes.
+	OverflowNames []string
+}
+
+// Report ranks the observed attributes by the bytes they contributed and keeps
+// the top limit of them, folding the rest into the overflow totals. A limit of
+// zero or less keeps everything.
+func (a *Accumulator) Report(limit int) Report {
+	report := Report{
+		Records:    a.records,
+		Attributes: len(a.resourceAttrs) + len(a.scopeAttrs),
+	}
+
+	ranked := make([]Attribute, 0, len(a.resourceAttrs)+len(a.scopeAttrs))
+	for name, stat := range a.resourceAttrs {
+		report.AttributeExpandedBytes += stat.expandedBytes
+		ranked = append(ranked, Attribute{
+			Kind:          KindResource,
+			Name:          name,
+			Records:       stat.records,
+			ExpandedBytes: stat.expandedBytes,
+		})
+	}
+
+	for name, stat := range a.scopeAttrs {
+		report.AttributeExpandedBytes += stat.expandedBytes
+		ranked = append(ranked, Attribute{
+			Kind:          KindScope,
+			Name:          name,
+			Records:       stat.records,
+			ExpandedBytes: stat.expandedBytes,
+		})
+	}
+
+	slices.SortFunc(ranked, func(x, y Attribute) int {
+		if c := cmp.Compare(y.ExpandedBytes, x.ExpandedBytes); c != 0 {
+			return c
+		}
+		if x.Kind != y.Kind {
+			return strings.Compare(string(x.Kind), string(y.Kind))
+		}
+		return strings.Compare(x.Name, y.Name)
+	})
+
+	if limit <= 0 || limit >= len(ranked) {
+		report.Top = ranked
+		return report
+	}
+
+	report.Top = ranked[:limit]
+
+	overflow := ranked[limit:]
+	report.OverflowAttributes = len(overflow)
+	report.OverflowNames = make([]string, 0, len(overflow))
+	for _, attr := range overflow {
+		report.OverflowExpandedBytes += attr.ExpandedBytes
+		report.OverflowNames = append(report.OverflowNames, attr.Name)
+	}
+
+	return report
+}

--- a/pkg/loghttp/push/otlpattrs/accumulator_test.go
+++ b/pkg/loghttp/push/otlpattrs/accumulator_test.go
@@ -1,0 +1,75 @@
+package otlpattrs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/pkg/push"
+)
+
+func attrs(kv ...string) push.LabelsAdapter {
+	adapter := make(push.LabelsAdapter, 0, len(kv)/2)
+	for i := 0; i < len(kv); i += 2 {
+		adapter = append(adapter, push.LabelAdapter{Name: kv[i], Value: kv[i+1]})
+	}
+	return adapter
+}
+
+func TestAccumulatorObserve(t *testing.T) {
+	acc := NewAccumulator()
+
+	// "cluster"+"prod" is 11 bytes on each of 3 records.
+	acc.Observe(KindResource, attrs("cluster", "prod"), 3)
+	// Same attribute again from a second resource block, with a longer value.
+	acc.Observe(KindResource, attrs("cluster", "staging"), 2)
+	acc.Observe(KindScope, attrs("scope_name", "otelcol"), 5)
+
+	report := acc.Report(0)
+	require.Equal(t, 2, report.Attributes)
+	require.Len(t, report.Top, 2)
+
+	byName := map[string]Attribute{}
+	for _, attr := range report.Top {
+		byName[string(attr.Kind)+"."+attr.Name] = attr
+	}
+
+	cluster := byName["resource.cluster"]
+	require.Equal(t, int64(5), cluster.Records)
+	require.Equal(t, int64(3*11+2*14), cluster.ExpandedBytes)
+
+	scope := byName["scope.scope_name"]
+	require.Equal(t, int64(5), scope.Records)
+	require.Equal(t, int64(5*17), scope.ExpandedBytes)
+}
+
+func TestReportRanksAndTruncates(t *testing.T) {
+	acc := NewAccumulator()
+	// Give each attribute a distinct value length so the ranking is unambiguous.
+	for i := range 10 {
+		acc.Observe(KindResource, attrs(fmt.Sprintf("attr_%02d", i), string(make([]byte, i))), 1)
+	}
+
+	report := acc.Report(3)
+	require.Equal(t, 10, report.Attributes)
+
+	require.Len(t, report.Top, 3)
+	require.Equal(t, []string{"attr_09", "attr_08", "attr_07"}, []string{report.Top[0].Name, report.Top[1].Name, report.Top[2].Name})
+	require.Greater(t, report.Top[0].ExpandedBytes, report.Top[1].ExpandedBytes)
+
+	require.Equal(t, 7, report.OverflowAttributes)
+	require.Equal(t, []string{"attr_06", "attr_05", "attr_04", "attr_03", "attr_02", "attr_01", "attr_00"},
+		report.OverflowNames)
+
+	// Every observed byte is accounted for, either individually or in the overflow.
+	var topBytes int64
+	for _, attr := range report.Top {
+		topBytes += attr.ExpandedBytes
+	}
+	var expectedTotal int64
+	for i := range 10 {
+		expectedTotal += int64(len("attr_00") + i)
+	}
+	require.Equal(t, expectedTotal, topBytes+report.OverflowExpandedBytes)
+}

--- a/pkg/loghttp/push/otlpattrs/reporter.go
+++ b/pkg/loghttp/push/otlpattrs/reporter.go
@@ -1,0 +1,90 @@
+package otlpattrs
+
+import (
+	"flag"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/limiter"
+
+	"github.com/grafana/loki/v3/pkg/runtime"
+)
+
+// Cfg shapes the attribute expansion reports for the tenants that have
+// log_otlp_attribute_expansion set in their runtime config.
+type Cfg struct {
+	Rate          float64 `yaml:"rate"`
+	MaxAttributes int     `yaml:"max_attributes"`
+}
+
+// RegisterFlagsWithPrefix registers the attribute expansion report flags.
+func (cfg *Cfg) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.Float64Var(&cfg.Rate, prefix+".rate", 1, "Number of attribute expansion reports to emit per second, per tenant. Each report is one summary line plus one line per attribute.")
+	f.IntVar(&cfg.MaxAttributes, prefix+".max-attributes", 20, "Maximum number of attributes to log on their own line for a reported request. The remaining attributes are summarised on a single overflow line.")
+}
+
+// Reporter emits rate limited reports of OTLP attribute expansion.
+type Reporter struct {
+	limiter       *limiter.RateLimiter
+	tenantCfgs    *runtime.TenantConfigs
+	maxAttributes int
+}
+
+// NewReporter returns a Reporter that emits at most cfg.Rate reports per second,
+// for each tenant that has log_otlp_attribute_expansion set in its runtime
+// config.
+func NewReporter(cfg Cfg, tenants *runtime.TenantConfigs) *Reporter {
+	burst := max(1, int(cfg.Rate))
+	return &Reporter{
+		limiter:       limiter.NewRateLimiter(newStrategy(burst, cfg.Rate), time.Hour),
+		tenantCfgs:    tenants,
+		maxAttributes: cfg.MaxAttributes,
+	}
+}
+
+// Report emits one summary line for the request followed by one line per
+// top-ranked attribute. Pass the request scoped logger so the report carries the
+// same org_id and traceID as the rest of the push request's logging.
+func (r *Reporter) Report(logger log.Logger, tenantID string, acc *Accumulator) {
+	if r == nil || acc == nil {
+		return
+	}
+
+	if !r.tenantCfgs.LogOTLPAttributeExpansion(tenantID) {
+		return
+	}
+
+	if acc.IsEmpty() {
+		// nothing to report
+		return
+	}
+
+	if !r.limiter.AllowN(time.Now(), tenantID, 1) {
+		return
+	}
+
+	report := acc.Report(r.maxAttributes)
+
+	level.Info(logger).Log(
+		"msg", "otlp attribute expansion",
+		"num_records", report.Records,
+		"num_attributes", report.Attributes,
+		"attribute_expanded_bytes", report.AttributeExpandedBytes,
+		"num_logged_attributes", len(report.Top),
+		"num_overflow_attributes", report.OverflowAttributes,
+		"overflow_expanded_bytes", report.OverflowExpandedBytes,
+		"overflow_names", strings.Join(report.OverflowNames, ","),
+	)
+
+	for _, attr := range report.Top {
+		level.Info(logger).Log(
+			"msg", "otlp attribute",
+			"kind", string(attr.Kind),
+			"attribute", attr.Name,
+			"records", attr.Records,
+			"expanded_bytes", attr.ExpandedBytes,
+		)
+	}
+}

--- a/pkg/loghttp/push/otlpattrs/strategy.go
+++ b/pkg/loghttp/push/otlpattrs/strategy.go
@@ -1,0 +1,21 @@
+package otlpattrs
+
+type strategy struct {
+	burst int
+	rate  float64
+}
+
+func newStrategy(burst int, rate float64) *strategy {
+	return &strategy{
+		burst: burst,
+		rate:  rate,
+	}
+}
+
+func (s *strategy) Burst(_ string) int {
+	return s.burst
+}
+
+func (s *strategy) Limit(_ string) float64 {
+	return s.rate
+}

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/analytics"
 	"github.com/grafana/loki/v3/pkg/loghttp"
+	"github.com/grafana/loki/v3/pkg/loghttp/push/otlpattrs"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/runtime"
@@ -188,6 +189,10 @@ type Stats struct {
 	// This is the actual size of data that is being ingested and stored in Loki.
 	// For non-OTLP requests, TotalExpandedEntriesSize should be the same as the total size of LogLinesBytes and StructuredMetadataBytes.
 	TotalExpandedEntriesSize int64
+
+	// OTLPAttributes breaks TotalExpandedEntriesSize down per resource and scope attribute.
+	// Is only populated for OTLP requests when logOTLPAttributeExpansion is true.
+	OTLPAttributes *otlpattrs.Accumulator
 }
 
 func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, maxDecompressedSize int64, r *http.Request, limits Limits, tenantConfigs *runtime.TenantConfigs, pushRequestParser RequestParser, tracker UsageTracker, streamResolver StreamResolver, presumedAgentIP, format string) (*logproto.PushRequest, *Stats, error) {

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	LogServiceNameDiscovery     bool     `yaml:"log_service_name_discovery"`
 	LogDuplicateMetrics         bool     `yaml:"log_duplicate_metrics"`
 	LogDuplicateStreamInfo      bool     `yaml:"log_duplicate_stream_info"`
+	LogOTLPAttributeExpansion   bool     `yaml:"log_otlp_attribute_expansion"`
 
 	// LimitedLogPushErrors is to be implemented and will allow logging push failures at a controlled pace.
 	LimitedLogPushErrors bool `yaml:"limited_log_push_errors"`
@@ -30,6 +31,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.LogServiceNameDiscovery, "operation-config.log-service-name-discovery", false, "Log service name discovery (very verbose, recommend to enable via runtime config only).")
 	f.BoolVar(&cfg.LogDuplicateMetrics, "operation-config.log-duplicate-metrics", false, "Log metrics for duplicate lines received.")
 	f.BoolVar(&cfg.LogDuplicateStreamInfo, "operation-config.log-duplicate-stream-info", false, "Log stream info for duplicate lines received")
+	f.BoolVar(&cfg.LogOTLPAttributeExpansion, "operation-config.log-otlp-attribute-expansion", false, "Log which OTLP resource and scope attributes are expanded into structured metadata, for a rate limited subset of push requests. Only attribute names and sizes are logged, never values.")
 	f.BoolVar(&cfg.LimitedLogPushErrors, "operation-config.limited-log-push-errors", true, "Log push errors with a rate limited logger, will show client push errors without overly spamming logs.")
 }
 
@@ -124,6 +126,10 @@ func (o *TenantConfigs) LogDuplicateMetrics(userID string) bool {
 
 func (o *TenantConfigs) LogDuplicateStreamInfo(userID string) bool {
 	return o.getOverridesForUser(userID).LogDuplicateStreamInfo
+}
+
+func (o *TenantConfigs) LogOTLPAttributeExpansion(userID string) bool {
+	return o.getOverridesForUser(userID).LogOTLPAttributeExpansion
 }
 
 func (o *TenantConfigs) LimitedLogPushErrors(userID string) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds functionality to report (and drilldown) how much of OTLP volume comes from expansion of resource and scope
attributes as structured metadata to records in the request.

It can enabled using the per-tenant runtime config `log_otlp_attribute_expansion`.

The reporter samples one request per second by default (configurable) which should be good enough to get a representative sample of the top attributes by size and count.

For each sampled request, it emits one summary line followed by one line per top-ranked attributes.
```
level=info org_id=tenant-a traceID=abc123 msg="otlp attribute expansion" records=500 attributes=3 attribute_expanded_bytes=56000 logged_attributes=2 overflow_attributes=1 overflow_expanded_bytes=14000 overflow_names=cloud_region
level=info org_id=tenant-a traceID=abc123 msg="otlp attribute" kind=resource attribute=k8s_pod_name records=500 expanded_bytes=24000
level=info org_id=tenant-a traceID=abc123 msg="otlp attribute" kind=scope attribute=scope_name records=500 expanded_bytes=18000
```

Following is an example query to get the top attributes by their expanded size for the query duration.
```
topk(20,
  sum by (kind, attribute) (
    sum_over_time(
      {job="loki-prod/distributor"}
        | logfmt
        | msg = "otlp attribute"
        | org_id="123"
        | unwrap expanded_bytes [$__auto]
    )
  )
)
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
