### PR TITLE
fix(dataobj-compaction): Bound LogMerge reader memory and stop log failures starving index compaction

### DIFF
--- a/pkg/dataobj/internal/dataset/row_reader.go
+++ b/pkg/dataobj/internal/dataset/row_reader.go
@@ -38,6 +38,18 @@ type RowReaderOptions struct {
 	// the entire Dataset is already held in memory.
 	Prefetch bool
 
+	// TargetCacheSize is the target maximum bytes of compressed page data the
+	// bulk downloader keeps cached at once when Prefetch is enabled. Pages
+	// needed by the current read range are always downloaded regardless of the
+	// target; the target only bounds opportunistic lookahead, including the
+	// initial prefetch batch. 0 means no limit: all lookahead pages are
+	// downloaded eagerly.
+	//
+	// Set this for long sequential scans over datasets much larger than
+	// memory (e.g. compaction merges) so resident page data stays bounded
+	// while consumed pages are garbage collected as the read advances.
+	TargetCacheSize int
+
 	// StatsTracker keeps track of the various reader internal stats.
 	StatsTracker RowReaderStatsTracker
 }
@@ -588,6 +600,7 @@ func (r *RowReader) initDownloader(ctx context.Context) error {
 	} else {
 		r.dl.Reset(r.opts.Dataset)
 	}
+	r.dl.targetCacheSize = r.opts.TargetCacheSize
 
 	mask := bitmask.New(len(r.opts.Columns))
 	r.fillPrimaryMask(mask)

--- a/pkg/dataobj/internal/dataset/row_reader_downloader.go
+++ b/pkg/dataobj/internal/dataset/row_reader_downloader.go
@@ -46,13 +46,16 @@ import (
 //     This excludes any page that is outside of the dataset ranges passed to
 //     [newReaderDownloader] and [rowReaderDownloader.Reset].
 //
-// The rowReaderDownloader targets a configurable batch size, which is the target
-// size of pages to cache in memory at once.
+// The rowReaderDownloader targets a configurable batch size
+// ([RowReaderOptions.TargetCacheSize]), which is the target size of pages to
+// cache in memory at once. When no target is configured, every batch
+// downloads all candidate pages eagerly.
 //
 // Batches of pages to download are built in four steps:
 //
-//  1. Adding every uncached P1 page to the batch, even if this would exceed the
-//     target size.
+//  1. Adding every uncached P1 page to the batch, even if this would exceed
+//     the target size. (During a prefetch there is no pending read, so P1
+//     pages are bounded by the target size like lookahead pages.)
 //
 //  2. Continually add one P2 page across each column. Iteration stops if the
 //     target size would be exceeded by a P2 page.
@@ -96,6 +99,12 @@ type rowReaderDownloader struct {
 
 	readRange rangeset.Range // Current range being read.
 	rangeMask rangeset.Set   // Inverse of dsetRanges: ranges to _exclude_ from download.
+
+	// targetCacheSize is the target maximum bytes of compressed page data to
+	// keep cached at once. Pages overlapping the current read range are
+	// always downloaded regardless of the target; only lookahead pages (and
+	// the initial prefetch batch) are bounded by it. 0 disables the limit.
+	targetCacheSize int
 }
 
 // newReaderDataset creates a new readerDataset wrapping around an inner
@@ -132,7 +141,9 @@ func newRowReaderDownloader(dset Dataset) *rowReaderDownloader {
 	return &rd
 }
 
-// Prefetch will download an initial batch of pages.
+// Prefetch will download an initial batch of pages. When a target cache size
+// is configured, the initial batch is bounded by it; otherwise every page in
+// the dataset ranges is downloaded.
 func (dl *rowReaderDownloader) Prefetch(ctx context.Context) error {
 	oldReadRange := dl.readRange
 	defer func() { dl.readRange = oldReadRange }()
@@ -290,6 +301,13 @@ func (dl *rowReaderDownloader) buildDownloadBatch(ctx context.Context, requestor
 	// Always add the requestor page to the batch if it's uncached.
 	if requestor != nil && len(requestor.data) == 0 {
 		pageBatch = append(pageBatch, requestor)
+		batchSize += requestor.inner.PageDesc().CompressedSize
+	}
+
+	// exceedsTarget reports whether adding page would push the batch past the
+	// configured target cache size. Always false when no target is set.
+	exceedsTarget := func(page *readerPage) bool {
+		return dl.targetCacheSize > 0 && batchSize+page.inner.PageDesc().CompressedSize > dl.targetCacheSize
 	}
 
 	// If we're not calling buildDownloadBatch due to a page read, we'll assume
@@ -299,8 +317,11 @@ func (dl *rowReaderDownloader) buildDownloadBatch(ctx context.Context, requestor
 		isPrimary = requestor.column.primary
 	}
 
-	// Add uncached P1 pages to the batch. We add all P1 pages, even if it would
-	// exceed the target size.
+	// Add uncached P1 pages to the batch. When serving a page read (requestor
+	// != nil), all P1 pages are added even if the target size is exceeded:
+	// they overlap the current read range and will be needed immediately. For
+	// a prefetch (requestor == nil) there is no pending read, so the initial
+	// batch is bounded by the target size like any other lookahead.
 	for result := range dl.iterP1Pages(ctx, isPrimary) {
 		page, err := result.Value()
 		if err != nil {
@@ -311,7 +332,11 @@ func (dl *rowReaderDownloader) buildDownloadBatch(ctx context.Context, requestor
 			continue // Already added.
 		}
 
+		if requestor == nil && exceedsTarget(page) {
+			return pageBatch, nil
+		}
 		pageBatch = append(pageBatch, page)
+		batchSize += page.inner.PageDesc().CompressedSize
 	}
 
 	// Now we add P2 and P3 pages. We ignore pages that would have us exceed the
@@ -335,7 +360,12 @@ func (dl *rowReaderDownloader) buildDownloadBatch(ctx context.Context, requestor
 			continue // Already added.
 		}
 
+		if exceedsTarget(page) {
+			targetReached = true
+			break
+		}
 		pageBatch = append(pageBatch, page)
+		batchSize += page.inner.PageDesc().CompressedSize
 	}
 	if targetReached {
 		return pageBatch, nil
@@ -351,7 +381,11 @@ func (dl *rowReaderDownloader) buildDownloadBatch(ctx context.Context, requestor
 			continue // Already added.
 		}
 
+		if exceedsTarget(page) {
+			break
+		}
 		pageBatch = append(pageBatch, page)
+		batchSize += page.inner.PageDesc().CompressedSize
 	}
 
 	return pageBatch, nil

--- a/pkg/dataobj/internal/dataset/row_reader_test.go
+++ b/pkg/dataobj/internal/dataset/row_reader_test.go
@@ -40,6 +40,35 @@ func Test_RowReader_Open_Prefetch(t *testing.T) {
 	}
 }
 
+// Test_RowReader_Open_Prefetch_TargetCacheSize verifies that a configured
+// target cache size bounds the initial prefetch batch instead of eagerly
+// downloading every page, while reads still return the complete dataset by
+// downloading pages on demand.
+func Test_RowReader_Open_Prefetch_TargetCacheSize(t *testing.T) {
+	dset, columns := buildTestDataset(t)
+	r := NewRowReader(RowReaderOptions{Dataset: dset, Columns: columns, Prefetch: true, TargetCacheSize: 1})
+	defer r.Close()
+
+	require.NoError(t, r.Open(t.Context()))
+
+	var cached, total int
+	for _, col := range r.dl.allColumns {
+		rc := col.(*readerColumn)
+		for _, page := range rc.pages {
+			total++
+			if page.data != nil {
+				cached++
+			}
+		}
+	}
+	require.NotEqual(t, 0, total, "expected at least one page")
+	require.Less(t, cached, total, "a tiny target cache size must prevent prefetching every page")
+
+	actualRows, err := readDataset(r, 3)
+	require.NoError(t, err)
+	require.Equal(t, basicReaderTestData, convertToTestPersons(actualRows))
+}
+
 func Test_Reader_ReadAll(t *testing.T) {
 	dset, columns := buildTestDataset(t)
 	r := NewRowReader(RowReaderOptions{Dataset: dset, Columns: columns})

--- a/pkg/dataobj/sortmerge/sortmerge.go
+++ b/pkg/dataobj/sortmerge/sortmerge.go
@@ -22,6 +22,15 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/loser"
 )
 
+// readerTargetCacheSize bounds the compressed page data each section reader
+// keeps resident at once. The k-way merge holds one open reader per input
+// section, and all of them advance roughly in lockstep, so without a bound a
+// merge over hundreds of sections downloads every section's pages up front
+// and holds the whole task's data in memory (the dataobj-compaction-worker
+// OOM mode). With the bound, each reader prefetches up to this many bytes,
+// and consumed pages are garbage collected as the merge advances.
+const readerTargetCacheSize = 8 << 20 // 8 MiB
+
 // Iterator returns an iterator that performs a k-way merge of records from
 // multiple logs sections. It requires that the input sections are sorted
 // according to sort.
@@ -102,6 +111,10 @@ func iterator(
 			Dataset:  ds,
 			Columns:  columns,
 			Prefetch: true,
+			// Bound each reader's resident page data: the merge keeps every
+			// section's reader open at once, so unbounded prefetch holds the
+			// entire task's data in memory.
+			TargetCacheSize: readerTargetCacheSize,
 		})
 		if err := r.Open(ctx); err != nil {
 			return nil, fmt.Errorf("opening dataset row reader: %w", err)

--- a/pkg/dataobj/sortmerge/sortmerge_test.go
+++ b/pkg/dataobj/sortmerge/sortmerge_test.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -304,4 +305,62 @@ func recOrder(a, b logs.Record) int {
 		return r
 	}
 	return cmp.Compare(b.Timestamp.UnixNano(), a.Timestamp.UnixNano())
+}
+
+// TestIteratorWithStreamRemap_MultiSectionObjects forces each source object to
+// span multiple logs sections and verifies the merge still emits every record
+// exactly once in global order. This exercises the bounded-cache read path
+// (each section reader prefetches at most readerTargetCacheSize of page data)
+// over many concurrent section readers.
+func TestIteratorWithStreamRemap_MultiSectionObjects(t *testing.T) {
+	ctx := context.Background()
+	sortSchema := []string{"label:app"}
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Long lines against the 8 KiB TargetSectionSize force several sections
+	// per object.
+	ent := func(base time.Time, n int) []push.Entry {
+		out := make([]push.Entry, 0, n)
+		for i := range n {
+			out = append(out, push.Entry{
+				Timestamp: base.Add(time.Duration(i) * time.Second).UTC(),
+				Line:      strings.Repeat("x", 512),
+			})
+		}
+		return out
+	}
+
+	objA, closeA := buildSchemaObject(t, sortSchema, map[string][]push.Entry{
+		`{app="b"}`: ent(t0, 60),
+		`{app="a"}`: ent(t0, 60),
+	})
+	defer closeA()
+	objB, closeB := buildSchemaObject(t, sortSchema, map[string][]push.Entry{
+		`{app="a"}`: ent(t0.Add(time.Hour), 60),
+		`{app="c"}`: ent(t0.Add(time.Hour), 60),
+	})
+	defer closeB()
+
+	sections, remaps, globalSortKeys := planGlobalStreams(ctx, t, []*dataobj.Object{objA, objB}, sortSchema)
+	require.Greater(t, len(sections), 2, "objects must span multiple sections for this test to be meaningful")
+
+	iter, err := sortmerge.IteratorWithStreamRemap(ctx, sections, remaps, globalSortKeys, sortSchema)
+	require.NoError(t, err)
+
+	var (
+		count int
+		prev  logs.Record
+		first = true
+	)
+	for res := range iter {
+		rec, err := res.Value()
+		require.NoError(t, err)
+		if !first {
+			require.LessOrEqual(t, recOrder(prev, rec), 0,
+				"output must be globally sorted by [sortKey, globalStreamID, ts DESC]")
+		}
+		prev, first = rec, false
+		count++
+	}
+	require.Equal(t, 240, count, "expected merged record count to equal sum of inputs")
 }

--- a/pkg/engine/compactor/coordinator.go
+++ b/pkg/engine/compactor/coordinator.go
@@ -698,13 +698,60 @@ func (c *coordinator) runLogMergePhase(ctx context.Context, tenant string, windo
 	}
 }
 
+// Log-phase failure backoff. A failing LogMerge phase is usually failing for
+// a persistent reason (e.g. workers OOMing on an oversized merge), so after
+// each consecutive failure the phase is skipped for an exponentially growing
+// cooldown instead of re-dispatching the same doomed tasks.
+const (
+	logFailureBackoffBase = 5 * time.Minute
+	logFailureBackoffMax  = time.Hour
+)
+
+// logFailureBackoff returns the cooldown applied after n consecutive
+// log-phase failures (n >= 1), doubling from logFailureBackoffBase up to
+// logFailureBackoffMax.
+func logFailureBackoff(n int) time.Duration {
+	if n < 1 {
+		return 0
+	}
+	backoff := logFailureBackoffBase
+	for i := 1; i < n; i++ {
+		backoff *= 2
+		if backoff >= logFailureBackoffMax {
+			return logFailureBackoffMax
+		}
+	}
+	return backoff
+}
+
 // runTenantLoop runs the IndexMerge<->LogMerge cycle for one tenant until ctx
-// is cancelled. It never returns an error and never sleeps: on error it retries
-// the same phase, otherwise it flips. It re-reads the per-tenant phase
-// enablement each iteration and skips the LogMerge phase when log compaction is
-// disabled, so an index-only tenant runs IndexMerge exclusively.
+// is cancelled. It never returns an error. It re-reads the per-tenant phase
+// enablement each iteration and skips the LogMerge phase when log compaction
+// is disabled, so an index-only tenant runs IndexMerge exclusively.
+//
+// The two phases are deliberately asymmetric:
+//
+//   - IndexMerge re-arms on error: it must converge, retries against
+//     already-merged inputs are cheap no-ops, and query performance depends
+//     on it staying current.
+//
+//   - LogMerge runs only after the window's index side has converged (an
+//     unconverged window means one LogMerge sub-pass per raw index — the
+//     work grows with exactly the backlog IndexMerge exists to remove), and
+//     on error it hands the turn back to IndexMerge instead of re-arming,
+//     with an exponential per-tenant backoff before the next attempt.
+//     LogMerge is a locality optimization; it must never starve IndexMerge.
+//
+// When a full revolution finds no work (index converged, nothing dispatched),
+// the loop sleeps for PollingInterval so converged tenants do not spin on ToC
+// reads.
 func (c *coordinator) runTenantLoop(ctx context.Context, tenant string) {
 	p := phaseIndexMerge
+	var (
+		indexConverged  bool      // last IndexMerge phase found nothing to merge
+		logFailures     int       // consecutive LogMerge phase failures
+		logBackoffUntil time.Time // LogMerge turns are skipped until this instant
+	)
 	for {
 		if ctx.Err() != nil {
 			return
@@ -713,9 +760,34 @@ func (c *coordinator) runTenantLoop(ctx context.Context, tenant string) {
 		if !runIndex && !runLog {
 			return
 		}
-		if p == phaseLogMerge && !runLog {
-			p = p.flip()
-			continue
+		if p == phaseLogMerge {
+			var skipReason string
+			switch {
+			case !runLog:
+				// Disabled tenants skip silently: no metric series for
+				// tenants that never opted into log compaction.
+			case !indexConverged:
+				skipReason = "index_unconverged"
+			case c.clock().Before(logBackoffUntil):
+				skipReason = "backoff"
+			default:
+				skipReason = "-" // sentinel: run the phase
+			}
+			if skipReason != "-" {
+				if skipReason != "" {
+					c.metrics.observeLogPhaseSkip(tenant, skipReason)
+				}
+				// A skipped log turn on a converged window means the whole
+				// revolution had no work; pace the loop before the next
+				// IndexMerge pass so converged tenants do not spin.
+				if indexConverged {
+					if !sleepCtx(ctx, c.cfg.PollingInterval) {
+						return
+					}
+				}
+				p = p.flip()
+				continue
+			}
 		}
 
 		window := c.clock().UTC().Truncate(metastore.MetastoreWindowSize)
@@ -725,17 +797,53 @@ func (c *coordinator) runTenantLoop(ctx context.Context, tenant string) {
 		switch p {
 		case phaseIndexMerge:
 			outcome = c.runIndexMergePhase(ctx, tenant, window)
+			indexConverged = outcome == phaseOutcomeNoWork
 		case phaseLogMerge:
 			outcome = c.runLogMergePhase(ctx, tenant, window)
+			if outcome == phaseOutcomeError {
+				logFailures++
+				cooldown := logFailureBackoff(logFailures)
+				logBackoffUntil = c.clock().Add(cooldown)
+				level.Warn(c.logger).Log("msg", "log-merge phase failed; backing off",
+					"tenant", tenant, "consecutive_failures", logFailures, "cooldown", cooldown)
+			} else {
+				logFailures = 0
+				logBackoffUntil = time.Time{}
+			}
+			// A no-work log turn on a converged window closes an idle
+			// revolution; pace the loop before the next IndexMerge pass.
+			if outcome == phaseOutcomeNoWork && indexConverged {
+				if !sleepCtx(ctx, c.cfg.PollingInterval) {
+					return
+				}
+			}
 		}
 		if ctx.Err() != nil {
 			return
 		}
 		c.metrics.observeCycle(cycleOutcome(outcome), c.clock().Sub(start))
 
-		if outcome != phaseOutcomeError {
+		// IndexMerge re-arms on error; LogMerge always hands the turn back
+		// (see the phase-policy comment above).
+		if outcome != phaseOutcomeError || p == phaseLogMerge {
 			p = p.flip()
 		}
+	}
+}
+
+// sleepCtx sleeps for d or until ctx is cancelled, returning false on
+// cancellation.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
 	}
 }
 

--- a/pkg/engine/compactor/coordinator_test.go
+++ b/pkg/engine/compactor/coordinator_test.go
@@ -23,6 +23,7 @@ import (
 	v2 "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2"
 	compactionv2pb "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2/proto"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
+	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
 	stats "github.com/grafana/loki/v3/pkg/dataobj/sections/stats"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
@@ -70,12 +71,15 @@ func (f *fakeRunner) snapshot() []runCall {
 }
 
 // fakeReplacer records each ReplaceIndexPointers invocation and returns
-// configurable (swapped, err) tuples.
+// configurable (swapped, err) tuples. When onReplace is set it runs (under
+// the lock) for every call, letting tests mutate the backing ToC so a swap
+// becomes visible to subsequent reads.
 type fakeReplacer struct {
-	mu      sync.Mutex
-	calls   []replaceCall
-	swapped bool
-	err     error
+	mu        sync.Mutex
+	calls     []replaceCall
+	swapped   bool
+	err       error
+	onReplace func(replaceCall)
 }
 
 type replaceCall struct {
@@ -92,8 +96,12 @@ func (f *fakeReplacer) ReplaceIndexPointers(
 	oldPaths []string,
 	newEntries []metastore.TableOfContentsEntry,
 ) (bool, error) {
+	call := replaceCall{window, tenant, append([]string(nil), oldPaths...), append([]metastore.TableOfContentsEntry(nil), newEntries...)}
 	f.mu.Lock()
-	f.calls = append(f.calls, replaceCall{window, tenant, append([]string(nil), oldPaths...), append([]metastore.TableOfContentsEntry(nil), newEntries...)})
+	f.calls = append(f.calls, call)
+	if f.onReplace != nil {
+		f.onReplace(call)
+	}
 	f.mu.Unlock()
 	return f.swapped, f.err
 }
@@ -487,6 +495,15 @@ func TestCompactTenantLogs_DeterministicOutputPaths(t *testing.T) {
 	for i := range first {
 		require.Equal(t, first[i].Path, second[i].Path, "output index paths must be deterministic across cycles")
 	}
+}
+
+func TestLogFailureBackoff(t *testing.T) {
+	require.Equal(t, time.Duration(0), logFailureBackoff(0))
+	require.Equal(t, logFailureBackoffBase, logFailureBackoff(1))
+	require.Equal(t, 2*logFailureBackoffBase, logFailureBackoff(2))
+	require.Equal(t, 4*logFailureBackoffBase, logFailureBackoff(3))
+	require.Equal(t, logFailureBackoffMax, logFailureBackoff(5))
+	require.Equal(t, logFailureBackoffMax, logFailureBackoff(1000), "backoff must cap, not overflow")
 }
 
 func TestPhaseFlip(t *testing.T) {
@@ -1079,15 +1096,31 @@ func TestRunTenantLoop_ErrorRetries(t *testing.T) {
 		require.Empty(t, replacer.snapshot(), "a failing phase never swaps the ToC")
 	})
 
-	t.Run("a successful phase flips index-merge <-> log-merge", func(t *testing.T) {
+	t.Run("log-merge runs once the index side converges", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
 		bucket := logMergeBucket(ctx, t, window, "acme", []string{"indexes/a", "indexes/b"})
 		replacer := &fakeReplacer{swapped: true}
+		// Make the first index-merge swap visible: rewrite the ToC down to a
+		// single index so the next IndexMerge pass reports converged and the
+		// LogMerge phase becomes eligible. The hook runs on the tenant-loop
+		// goroutine, possibly after the test cancels ctx, so it must use a
+		// background context and must not fail the test (no require).
+		replacer.onReplace = func(replaceCall) {
+			bg := context.Background()
+			_ = bucket.Delete(bg, metastore.TableOfContentsPath(window))
+			w := metastore.NewTableOfContentsWriter(bucket, log.NewNopLogger())
+			_ = w.WriteEntry(bg, "indexes/a", []multitenancy.TimeRange{{
+				Tenant:  "acme",
+				MinTime: window.Add(time.Hour),
+				MaxTime: window.Add(2 * time.Hour),
+			}})
+		}
 		limits := newFakeLimits("acme")
 		limits.setLog("acme", true) // both phases enabled so the flip is exercised
 		c := newTestCoordinator(t, bucket, &fakeRunner{}, replacer, fixedClock(window.Add(time.Hour)), limits)
+		c.cfg.PollingInterval = time.Millisecond // fast idle-revolution pacing for the test
 
 		var mu sync.Mutex
 		var phases []string
@@ -1108,15 +1141,90 @@ func TestRunTenantLoop_ErrorRetries(t *testing.T) {
 		require.Eventually(t, func() bool {
 			mu.Lock()
 			defer mu.Unlock()
-			return len(phases) >= 3
+			return len(phases) >= 2
 		}, 2*time.Second, 5*time.Millisecond)
 		cancel()
 		<-done
 
 		mu.Lock()
 		defer mu.Unlock()
-		require.Equal(t, []string{"index-merge", "log-merge", "index-merge"}, phases[:3],
-			"successful phases flip between index-merge and log-merge")
+		require.Equal(t, []string{"index-merge", "log-merge"}, phases[:2],
+			"log-merge must only dispatch after the window's index side has converged")
+	})
+
+	t.Run("log-merge never dispatches while the index side is unconverged", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Static two-index ToC with a fake swap: every IndexMerge pass reports
+		// compacted but the ToC never shrinks, so the window never converges.
+		bucket := logMergeBucket(ctx, t, window, "acme", []string{"indexes/a", "indexes/b"})
+		replacer := &fakeReplacer{swapped: true}
+		limits := newFakeLimits("acme")
+		limits.setLog("acme", true)
+		c := newTestCoordinator(t, bucket, &fakeRunner{}, replacer, fixedClock(window.Add(time.Hour)), limits)
+		c.cfg.PollingInterval = time.Millisecond
+
+		var mu sync.Mutex
+		var phases []string
+		c.runPlan = func(_ context.Context, opts workflow.Options, _ *physical.Plan) (arrow.RecordBatch, error) {
+			mu.Lock()
+			phases = append(phases, opts.Actor[1])
+			mu.Unlock()
+			return v2.BuildResultRecord(memory.DefaultAllocator, []v2.ResultArtifact{{Path: "indexes/tenants/acme/aa/x"}}), nil
+		}
+
+		done := make(chan struct{})
+		go func() { c.runTenantLoop(ctx, "acme"); close(done) }()
+
+		require.Eventually(t, func() bool {
+			return testutil.ToFloat64(c.metrics.logPhaseSkipsTotal.WithLabelValues("index_unconverged", "acme")) >= 3
+		}, 2*time.Second, 5*time.Millisecond, "log turns must be skipped while unconverged")
+		cancel()
+		<-done
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.NotEmpty(t, phases)
+		for _, p := range phases {
+			require.Equal(t, "index-merge", p, "no log-merge may dispatch while the index side is unconverged")
+		}
+	})
+
+	t.Run("a failing log-merge hands the turn back and backs off", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Single-index ToC: the index side is converged from the start, so the
+		// log phase is eligible immediately.
+		bucket := logMergeBucket(ctx, t, window, "acme", []string{"indexes/a"})
+		replacer := &fakeReplacer{swapped: true}
+		limits := newFakeLimits("acme")
+		limits.setLog("acme", true)
+		// The clock is fixed, so the backoff armed by the first failure never
+		// expires: exactly one log-merge attempt can ever be dispatched.
+		c := newTestCoordinator(t, bucket, &fakeRunner{}, replacer, fixedClock(window.Add(time.Hour)), limits)
+		c.cfg.PollingInterval = time.Millisecond
+
+		c.runPlan = func(_ context.Context, opts workflow.Options, _ *physical.Plan) (arrow.RecordBatch, error) {
+			require.Equal(t, "log-merge", opts.Actor[1], "a converged index phase must not dispatch")
+			return nil, errors.New("log dispatch boom")
+		}
+
+		done := make(chan struct{})
+		go func() { c.runTenantLoop(ctx, "acme"); close(done) }()
+
+		require.Eventually(t, func() bool {
+			return testutil.ToFloat64(c.metrics.logPhaseSkipsTotal.WithLabelValues("backoff", "acme")) >= 3 &&
+				testutil.ToFloat64(c.metrics.cyclesTotal.WithLabelValues("converged")) >= 2
+		}, 2*time.Second, 5*time.Millisecond,
+			"after a log failure the loop must keep cycling the index phase and skip log turns via backoff")
+		cancel()
+		<-done
+
+		require.Equal(t, float64(1), testutil.ToFloat64(c.metrics.cyclesTotal.WithLabelValues("failed")),
+			"a failing log phase must not re-arm: exactly one failed cycle")
+		require.Equal(t, float64(1), testutil.ToFloat64(c.metrics.tenantLogCyclesTotal.WithLabelValues("failed", "acme")))
 	})
 }
 
@@ -1376,6 +1484,7 @@ func TestRunTenantLoop_IndexOnly(t *testing.T) {
 	bucket := logMergeBucket(ctx, t, window, "acme", []string{"a", "b"})
 	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, &fakeRunner{}, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
+	c.cfg.PollingInterval = time.Millisecond // fast idle-revolution pacing for the test
 
 	var mu sync.Mutex
 	var phases []string
@@ -1406,8 +1515,8 @@ func TestRunTenantLoop_IndexOnly(t *testing.T) {
 }
 
 // TestRunTenantLoop_LogEnabledRunsBothPhases verifies that enabling log
-// compaction (which implies index) restores the flip-flop: dispatches
-// alternate index-merge <-> log-merge.
+// compaction (which implies index) runs both phases: index-merge dispatches
+// first, and log-merge dispatches once the window's index side converges.
 func TestRunTenantLoop_LogEnabledRunsBothPhases(t *testing.T) {
 	window := imWindow()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1415,9 +1524,23 @@ func TestRunTenantLoop_LogEnabledRunsBothPhases(t *testing.T) {
 
 	bucket := logMergeBucket(ctx, t, window, "acme", []string{"a", "b"})
 	replacer := &fakeReplacer{swapped: true}
+	// Converge the ToC on the first swap so the log phase becomes eligible.
+	// Runs on the tenant-loop goroutine, possibly after ctx is cancelled, so
+	// it uses a background context and must not fail the test.
+	replacer.onReplace = func(replaceCall) {
+		bg := context.Background()
+		_ = bucket.Delete(bg, metastore.TableOfContentsPath(window))
+		w := metastore.NewTableOfContentsWriter(bucket, log.NewNopLogger())
+		_ = w.WriteEntry(bg, "a", []multitenancy.TimeRange{{
+			Tenant:  "acme",
+			MinTime: window.Add(time.Hour),
+			MaxTime: window.Add(2 * time.Hour),
+		}})
+	}
 	limits := newFakeLimits("acme")
 	limits.setLog("acme", true)
 	c := newTestCoordinator(t, bucket, &fakeRunner{}, replacer, fixedClock(window.Add(time.Hour)), limits)
+	c.cfg.PollingInterval = time.Millisecond
 
 	var mu sync.Mutex
 	var phases []string
@@ -1436,18 +1559,15 @@ func TestRunTenantLoop_LogEnabledRunsBothPhases(t *testing.T) {
 	require.Eventually(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(phases) >= 3
+		return len(phases) >= 2
 	}, 2*time.Second, 5*time.Millisecond)
 	cancel()
 	<-done
 
 	mu.Lock()
 	defer mu.Unlock()
-	// runPlan returns nil (success) on every call, so the loop flips every
-	// cycle and the phase order is deterministic; the exact prefix is safe to
-	// assert. The loop starts on IndexMerge.
-	require.Equal(t, []string{"index-merge", "log-merge", "index-merge"}, phases[:3],
-		"log-enabled tenant flips between index-merge and log-merge")
+	require.Equal(t, []string{"index-merge", "log-merge"}, phases[:2],
+		"log-enabled tenant dispatches index-merge first, then log-merge once converged")
 }
 
 // TestRunTenantLoop_DisablingLogMidRunStopsLogMerge verifies that turning off
@@ -1459,11 +1579,14 @@ func TestRunTenantLoop_DisablingLogMidRunStopsLogMerge(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	bucket := logMergeBucket(ctx, t, window, "acme", []string{"a", "b"})
+	// Single-index ToC: converged from the start, so log-merge dispatches
+	// immediately (index-merge has nothing to do and dispatches nothing).
+	bucket := logMergeBucket(ctx, t, window, "acme", []string{"a"})
 	replacer := &fakeReplacer{swapped: true}
 	limits := newFakeLimits("acme")
 	limits.setLog("acme", true)
 	c := newTestCoordinator(t, bucket, &fakeRunner{}, replacer, fixedClock(window.Add(time.Hour)), limits)
+	c.cfg.PollingInterval = time.Millisecond
 
 	var mu sync.Mutex
 	var phases []string
@@ -1490,27 +1613,29 @@ func TestRunTenantLoop_DisablingLogMidRunStopsLogMerge(t *testing.T) {
 	}
 	limits.setLog("acme", false)
 
-	// Record how many phases exist at the cutoff, then let the loop run more.
+	// The mid-run disable is not instantaneous: the in-flight log-merge cycle
+	// may still complete. Wait for several full index revolutions after the
+	// disable (converged index cycles keep incrementing), note the dispatch
+	// count, then confirm it stays flat over several more revolutions.
+	converged := func() float64 {
+		return testutil.ToFloat64(c.metrics.cyclesTotal.WithLabelValues("converged"))
+	}
+	base := converged()
+	require.Eventually(t, func() bool { return converged() >= base+3 },
+		2*time.Second, time.Millisecond, "index revolutions must continue after disabling log")
+
 	mu.Lock()
-	cutoff := len(phases)
+	settled := len(phases)
 	mu.Unlock()
 
-	require.Eventually(t, func() bool {
-		mu.Lock()
-		defer mu.Unlock()
-		return len(phases) >= cutoff+4 // several more cycles after disabling
-	}, 2*time.Second, 5*time.Millisecond)
+	base = converged()
+	require.Eventually(t, func() bool { return converged() >= base+3 },
+		2*time.Second, time.Millisecond)
 	cancel()
 	<-done
 
 	mu.Lock()
 	defer mu.Unlock()
-	// The mid-run disable is not instantaneous: an in-flight log-merge cycle
-	// may still complete. Assert that dispatches eventually settle to
-	// index-merge only — i.e. the tail after the cutoff contains no log-merge.
-	tail := phases[cutoff:]
-	require.NotEmpty(t, tail)
-	for _, p := range tail[len(tail)-4:] {
-		require.Equal(t, "index-merge", p, "no log-merge after log compaction is disabled")
-	}
+	require.Equal(t, settled, len(phases),
+		"no further dispatches (log-merge or otherwise) after log compaction is disabled on a converged window")
 }

--- a/pkg/engine/compactor/metrics.go
+++ b/pkg/engine/compactor/metrics.go
@@ -32,6 +32,10 @@ type coordinatorMetrics struct {
 	// tenantLogCyclesTotal counts per-tenant log-compaction cycle outcomes.
 	tenantLogCyclesTotal *prometheus.CounterVec // outcome=compacted|converged|failed, tenant
 
+	// logPhaseSkipsTotal counts log-phase turns the worker loop skipped
+	// without dispatching, by reason.
+	logPhaseSkipsTotal *prometheus.CounterVec // reason=index_unconverged|backoff, tenant
+
 	// indexesRemovedTotal counts source indexes removed by compaction
 	// (cumulative). Use with indexesAddedTotal to compute net reduction:
 	// removed - added = net_reduction.
@@ -88,6 +92,10 @@ func newCoordinatorMetrics(reg prometheus.Registerer) *coordinatorMetrics {
 			Name: "loki_dataobj_compaction_tenant_log_cycles_total",
 			Help: "Per-tenant log-compaction cycle outcomes. compacted = ToC swapped, converged = no worthwhile section overlap, failed = cycle returned error.",
 		}, []string{labelOutcome, labelTenant}),
+		logPhaseSkipsTotal: f.NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_dataobj_compaction_log_phase_skips_total",
+			Help: "Per-tenant count of log-compaction phase turns skipped without dispatching. reason=index_unconverged (window's index side has not converged yet) or backoff (cooling down after consecutive log-phase failures).",
+		}, []string{"reason", labelTenant}),
 		indexesRemovedTotal: f.NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_dataobj_compaction_indexes_removed_total",
 			Help: "Cumulative count of source index pointers removed from the ToC by successful tenant cycles.",
@@ -248,6 +256,15 @@ func (m *coordinatorMetrics) deleteTenant(tenant string) {
 	m.tasksTotal.DeleteLabelValues(tenant)
 	m.tenantCyclesTotal.DeletePartialMatch(prometheus.Labels{labelTenant: tenant})
 	m.tenantLogCyclesTotal.DeletePartialMatch(prometheus.Labels{labelTenant: tenant})
+	m.logPhaseSkipsTotal.DeletePartialMatch(prometheus.Labels{labelTenant: tenant})
+}
+
+// observeLogPhaseSkip records one skipped log-phase turn for the tenant.
+func (m *coordinatorMetrics) observeLogPhaseSkip(tenant, reason string) {
+	if m == nil {
+		return
+	}
+	m.logPhaseSkipsTotal.WithLabelValues(reason, tenant).Inc()
 }
 
 // observeFileSizeStat records the latency of a single bucket.Attributes call.


### PR DESCRIPTION
**What this PR does / why we need it**:

Two fixes for the dataobj-compaction-worker OOMs (single LogMerge tasks exceeding 60 GiB) and the resulting index-compaction starvation, split into three commits:

1. **Bounded reader memory** (`pkg/dataobj/internal/dataset`). The `rowReaderDownloader` documented a target batch size but never implemented it: `targetReached` was dead code, P3 pages (everything after the current read range) were added to every download batch unconditionally, and `Prefetch()` marked the whole dataset as P1. Every section reader therefore downloaded its entire section at Open. This PR adds `RowReaderOptions.TargetCacheSize` which implements the documented bounding: pages overlapping the current read range always download, lookahead and the initial prefetch batch stop at the target, and consumed pages keep getting GC'd. Zero is the default and preserves the old behavior for all existing callers.

2. **Sortmerge cap** (`pkg/dataobj/sortmerge`). A k-way merge holds one section reader per source section, so with unbounded readers the whole task's data stayed resident. The merge now sets 8 MiB per reader, so peak memory becomes ~sections × 8 MiB instead of the total task size.

3. **Coordinator phase policy** (`pkg/engine/compactor`). The per-tenant IndexMerge↔LogMerge loop re-armed a failing phase forever, so persistent LogMerge failures (worker OOMs) pinned the loop and starved IndexMerge for hours. The phases are now asymmetric: LogMerge only runs after the window's index side has converged (an unconverged window means one LogMerge sub-pass per raw index, work that grows with exactly the backlog IndexMerge exists to remove), and on error it hands the turn back to IndexMerge with an exponential per-tenant backoff (5m doubling to 1h) instead of re-arming. IndexMerge keeps re-arming on error as before. Skipped log turns are observable via `loki_dataobj_compaction_log_phase_skips_total{reason}`. Idle revolutions now sleep for `PollingInterval`, fixing a latent busy-spin where a fully converged tenant hammered ToC reads in a tight loop.

**Special notes for your reviewer**:

- A per-object section-concatenation port (the index-merge `sectionConcatSeq` approach) was investigated and rejected: a log object's sections are not cross-section ordered under the merge comparator, so concatenating them would produce misordered output.
- The unbounded-P3 download behavior also affects the query read path; bounding it there is a candidate follow-up.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)