### PR TITLE
fix: Separate cortex-gw and cortex-gw-internal in Loki / Reads Resources

### DIFF
--- a/production/loki-mixin-compiled/dashboards/loki-operational.json
+++ b/production/loki-mixin-compiled/dashboards/loki-operational.json
@@ -772,17 +772,17 @@
             "steppedLine": false,
             "targets": [
                {
-                  "expr": "histogram_quantile(0.99, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"}))",
+                  "expr": "histogram_quantile(0.99, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\", route!~\"(debug_pprof|ready|metrics|usage_metrics)\"}))",
                   "legendFormat": ".99",
                   "refId": "A"
                },
                {
-                  "expr": "histogram_quantile(0.9, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"}))",
+                  "expr": "histogram_quantile(0.9, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\", route!~\"(debug_pprof|ready|metrics|usage_metrics)\"}))",
                   "legendFormat": ".9",
                   "refId": "B"
                },
                {
-                  "expr": "histogram_quantile(0.5, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"}))",
+                  "expr": "histogram_quantile(0.5, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\", route!~\"(debug_pprof|ready|metrics|usage_metrics)\"}))",
                   "legendFormat": ".5",
                   "refId": "C"
                }

--- a/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
+++ b/production/loki-mixin/dashboards/loki-reads-resources.libsonnet
@@ -16,7 +16,8 @@
   // Regex for the "type" label on the autoscaler metric, per component.
   // Follows the naming convention emitted by the loki-autoscaler exporter.
   local autoscaler_type = {
-    gateway: 'cortex_gateway(_internal)?',
+    cortex_gateway: 'cortex_gateway',
+    cortex_gateway_internal: 'cortex_gateway_internal',
     query_frontend: 'query-frontend',
     query_scheduler: 'query-scheduler',
     querier: 'querier',
@@ -167,17 +168,31 @@
       .addNamespace()
       .addTag()
 
-      // --- Gateway ---
+      // --- Cortex Gateway ---
       .addRowIf(
         $._config.internal_components,
         componentRow(
-          'Gateway',
-          $.containerCPUUsagePanel('CPU', 'cortex-gw(-internal)?'),
-          $.containerMemoryWorkingSetPanel('Memory (workingset)', 'cortex-gw(-internal)?'),
-          $.goHeapInUsePanel('Memory (go heap inuse)', 'cortex-gw(-internal)?'),
-          'container=~"cortex-gw(-internal)?"',
-          'container=~"cortex-gw(-internal)?"',
-          'gateway'
+          'Cortex Gateway',
+          $.containerCPUUsagePanel('CPU', 'cortex-gw'),
+          $.containerMemoryWorkingSetPanel('Memory (workingset)', 'cortex-gw'),
+          $.goHeapInUsePanel('Memory (go heap inuse)', 'cortex-gw'),
+          'container="cortex-gw"',
+          'container="cortex-gw"',
+          'cortex_gateway'
+        )
+      )
+
+      // --- Cortex Gateway Internal ---
+      .addRowIf(
+        $._config.internal_components,
+        componentRow(
+          'Cortex Gateway (Internal)',
+          $.containerCPUUsagePanel('CPU', 'cortex-gw-internal'),
+          $.containerMemoryWorkingSetPanel('Memory (workingset)', 'cortex-gw-internal'),
+          $.goHeapInUsePanel('Memory (go heap inuse)', 'cortex-gw-internal'),
+          'container="cortex-gw-internal"',
+          'container="cortex-gw-internal"',
+          'cortex_gateway_internal'
         )
       )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request separates cortex-gw and cortex-gw-internal into separate rows, allowing them to be monitored independently.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
