### PR TITLE
fix(storage): Hedged client should respect HTTP configuration

### DIFF
--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -2521,7 +2521,7 @@ func (t *Loki) getDataObjBucket(clientName string) (objstore.Bucket, error) {
 	}
 
 	var objstoreBucket objstore.Bucket
-	objstoreBucket, err = bucket.NewClient(context.Background(), backend, cfg.Config, clientName, util_log.Logger)
+	objstoreBucket, err = bucket.NewClient(context.Background(), backend, cfg.Config, clientName, util_log.Logger, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/querytee/goldfish/result_store.go
+++ b/pkg/querytee/goldfish/result_store.go
@@ -55,7 +55,7 @@ type bucketResultStore struct {
 
 // NewResultStore creates a ResultStore based on configuration.
 func NewResultStore(ctx context.Context, cfg ResultsStorageConfig, logger log.Logger) (ResultStore, error) {
-	bucketClient, err := bucketclient.NewClient(ctx, cfg.Backend, cfg.Bucket, "goldfish-results", logger)
+	bucketClient, err := bucketclient.NewClient(ctx, cfg.Backend, cfg.Bucket, "goldfish-results", logger, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create bucket client: %w", err)
 	}

--- a/pkg/ruler/base/storage.go
+++ b/pkg/ruler/base/storage.go
@@ -132,7 +132,7 @@ func NewRuleStore(ctx context.Context, cfg rulestore.Config, cfgProvider bucket.
 		return local.NewLocalRulesClient(cfg.Local, loader)
 	}
 
-	bucketClient, err := bucket.NewClient(ctx, cfg.Backend, cfg.Config, "ruler-storage", logger)
+	bucketClient, err := bucket.NewClient(ctx, cfg.Backend, cfg.Config, "ruler-storage", logger, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/bucket/client.go
+++ b/pkg/storage/bucket/client.go
@@ -184,31 +184,21 @@ func (cfg *Config) disableRetries(backend string) error {
 	return nil
 }
 
-func (cfg *Config) configureTransport(backend string, rt http.RoundTripper) error {
-	switch backend {
-	case S3:
-		cfg.S3.HTTP.Transport = rt
-	case GCS:
-		cfg.GCS.Transport = rt
-	case Azure:
-		cfg.Azure.Transport = rt
-	case Swift:
-		cfg.Swift.HTTP.Transport = rt
-	case Filesystem, Alibaba, BOS:
-		// do nothing
-	default:
-		return fmt.Errorf("cannot configure transport for backend: %s", backend)
-	}
-
-	return nil
-}
-
 // NewClient creates a new bucket client based on the configured backend
-func NewClient(ctx context.Context, backend string, cfg Config, name string, logger log.Logger) (objstore.InstrumentedBucket, error) {
+func NewClient(ctx context.Context, backend string, cfg Config, name string, logger log.Logger, wrapRT func(http.RoundTripper) http.RoundTripper) (objstore.InstrumentedBucket, error) {
 	var (
 		client objstore.Bucket
 		err    error
 	)
+
+	instrumentTransport := func() func(http.RoundTripper) http.RoundTripper {
+		return func(rt http.RoundTripper) http.RoundTripper {
+			if wrapRT != nil {
+				rt = wrapRT(rt)
+			}
+			return &instrumentedRoundTripper{next: rt}
+		}
+	}
 
 	// TODO: add support for other backends that loki already supports
 	switch backend {
@@ -255,12 +245,6 @@ func NewClient(ctx context.Context, backend string, cfg Config, name string, log
 
 type instrumentedRoundTripper struct {
 	next http.RoundTripper
-}
-
-func instrumentTransport() func(http.RoundTripper) http.RoundTripper {
-	return func(rt http.RoundTripper) http.RoundTripper {
-		return &instrumentedRoundTripper{next: rt}
-	}
 }
 
 func (i *instrumentedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/pkg/storage/bucket/client_test.go
+++ b/pkg/storage/bucket/client_test.go
@@ -81,7 +81,7 @@ func TestNewClient(t *testing.T) {
 			}
 
 			// Instance a new bucket client from the config
-			bucketClient, err := NewClient(context.Background(), testData.backend, cfg, "test", util_log.Logger)
+			bucketClient, err := NewClient(context.Background(), testData.backend, cfg, "test", util_log.Logger, nil)
 			require.Equal(t, testData.expectedErr, err)
 
 			if testData.expectedErr == nil {

--- a/pkg/storage/bucket/object_client_adapter.go
+++ b/pkg/storage/bucket/object_client_adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"slices"
 	"strings"
 
@@ -49,25 +50,32 @@ func NewObjectClient(ctx context.Context, backend string, cfg ConfigWithNamedSto
 		}
 	}
 
-	bucket, err := NewClient(ctx, storeType, storeCfg, component, logger)
+	bucket, err := NewClient(ctx, storeType, storeCfg, component, logger, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create bucket: %w", err)
 	}
 
 	hedgedBucket := bucket
 	if hedgingCfg.At != 0 {
-		hedgedTrasport, err := hedgingCfg.RoundTripperWithRegisterer(nil, prometheus.WrapRegistererWithPrefix("loki_", prometheus.DefaultRegisterer))
-		if err != nil {
-			return nil, fmt.Errorf("create hedged transport: %w", err)
+		// The library we use for hedging can return an error from NewRoundTripper,
+		// but our wrapper functions don't have an error return. So we assume this
+		// wrapper is called before NewClient returns, and we can stash the error here.
+		var hedgeErr error
+		wrapHedged := func(rt http.RoundTripper) http.RoundTripper {
+			hedgedRT, err := hedgingCfg.RoundTripperWithRegisterer(rt, prometheus.WrapRegistererWithPrefix("loki_", prometheus.DefaultRegisterer))
+			if err != nil {
+				hedgeErr = err
+				return rt
+			}
+			return hedgedRT
 		}
 
-		if err := storeCfg.configureTransport(storeType, hedgedTrasport); err != nil {
-			return nil, fmt.Errorf("create hedged bucket: %w", err)
-		}
-
-		hedgedBucket, err = NewClient(ctx, storeType, storeCfg, component, logger)
+		hedgedBucket, err = NewClient(ctx, storeType, storeCfg, component, logger, wrapHedged)
 		if err != nil {
 			return nil, fmt.Errorf("create hedged bucket: %w", err)
+		}
+		if hedgeErr != nil {
+			return nil, fmt.Errorf("create hedged transport: %w", hedgeErr)
 		}
 	}
 

--- a/pkg/storage/bucket/object_client_adapter_test.go
+++ b/pkg/storage/bucket/object_client_adapter_test.go
@@ -3,11 +3,22 @@ package bucket
 import (
 	"bytes"
 	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"sort"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/storage/bucket/filesystem"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
@@ -142,4 +153,76 @@ func TestObjectClientAdapter_IsBackendFilesystem(t *testing.T) {
 	// Non-filesystem backends must report false.
 	require.False(t, (&ObjectClientAdapter{storeType: S3}).IsBackendFilesystem())
 	require.False(t, (&ObjectClientAdapter{storeType: GCS}).IsBackendFilesystem())
+}
+
+func TestObjectClientAdapter_ClientReusesConnections(t *testing.T) {
+	// We are going to make multiple rounds of calls to a fake S3, and expect that
+	// connections opened by the first round should be reused by every later round.
+	const (
+		concurrency = 8
+		rounds      = 6
+	)
+
+	// Fake S3 responses
+	payload := []byte("some-object-contents")
+	var newConns atomic.Int64
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+		w.Header().Set("ETag", `"d0be2dc421be4fcd0172e5afceea3970"`)
+		w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+		w.WriteHeader(http.StatusOK)
+		if r.Method != http.MethodHead {
+			_, _ = w.Write(payload)
+		}
+	}))
+	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConns.Add(1)
+		}
+	}
+	srv.Start()
+	t.Cleanup(srv.Close)
+
+	var cfg Config
+	flagext.DefaultValues(&cfg)
+	cfg.S3.Endpoint = strings.TrimPrefix(srv.URL, "http://")
+	cfg.S3.BucketName = "test-bucket"
+	cfg.S3.Region = "us-east-1"
+	cfg.S3.AccessKeyID = "access-key"
+	cfg.S3.SecretAccessKey = flagext.SecretWithValue("secret-key")
+	cfg.S3.Insecure = true
+	cfg.S3.MaxRetries = 1
+
+	require.GreaterOrEqual(t, cfg.S3.HTTP.MaxIdleConnsPerHost, concurrency,
+		"test is only meaningful if the configured pool can hold every connection we open")
+
+	// Configure hedging on, since the bug where this went wrong only happened when hedging was enabled.
+	// However we don't actually want any hedged requests so use At=time.Hour.
+	client, err := NewObjectClient(context.Background(), S3, ConfigWithNamedStores{Config: cfg}, "test",
+		hedging.Config{At: time.Hour, UpTo: 2, MaxPerSecond: 100}, false, log.NewNopLogger())
+	require.NoError(t, err)
+
+	for range rounds {
+		var wg sync.WaitGroup
+		for range concurrency {
+			wg.Go(func() {
+				rc, _, err := client.GetObject(context.Background(), "some-key")
+				if !assert.NoError(t, err) {
+					return
+				}
+				defer rc.Close()
+
+				// Must read the whole body to enable connection pooling.
+				got, err := io.ReadAll(rc)
+				assert.NoError(t, err)
+				assert.Equal(t, payload, got)
+			})
+		}
+		wg.Wait()
+	}
+
+	// Allow some leeway, up to 2x what should be needed.
+	require.Lessf(t, newConns.Load(), int64(concurrency*2),
+		"opened %d connections to serve %d requests: the client is not reusing connections",
+		newConns.Load(), concurrency*rounds)
 }

--- a/pkg/ui/service.go
+++ b/pkg/ui/service.go
@@ -189,7 +189,7 @@ func (s *Service) initGoldfishDB() error {
 
 	// Initialize bucket client if results backend is configured
 	if s.cfg.Goldfish.ResultsBackend != "" {
-		bucketClient, err := bucket.NewClient(context.Background(), s.cfg.Goldfish.ResultsBackend, s.cfg.Goldfish.ResultsBucket, "goldfish-ui-results", s.logger)
+		bucketClient, err := bucket.NewClient(context.Background(), s.cfg.Goldfish.ResultsBackend, s.cfg.Goldfish.ResultsBucket, "goldfish-ui-results", s.logger, nil)
 		if err != nil {
 			level.Warn(s.logger).Log("msg", "failed to create goldfish bucket client, result fetching will be disabled", "err", err)
 		} else {

--- a/tools/dataobj-locality/source.go
+++ b/tools/dataobj-locality/source.go
@@ -163,7 +163,7 @@ func buildBucketFromLokiConfig(ctx context.Context, configFile string, expandEnv
 		"index_prefix", mCfg.IndexStoragePrefix,
 	)
 
-	ib, err := bucket.NewClient(ctx, backend, objCfg.Config, "dataobj-locality", logger)
+	ib, err := bucket.NewClient(ctx, backend, objCfg.Config, "dataobj-locality", logger, nil)
 	if err != nil {
 		return nil, metastore.Config{}, fmt.Errorf("creating bucket client: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, the call to `RoundTripperWithRegisterer(nil, ...)` would use `http.DefaultTransport`, which ignores config settings such as `MaxIdleConnsPerHost`. The observable effect is that connections are not reused.

Take out the code which let us overwrite the transport, and replace with an extra wrapper so we can put the hedging wrapper in.

Note that requests did not need to be hedged to suffer from the problem - the code routes all `GetObject`, `GetObjectRange`, and `GetAttributes` operations through the `hedgedClient`.

Add a test to check that this is now re-using connections.  Test was largely written by Claude.

**Which issue(s) this PR fixes**:
I can't find this reported anywhere.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- NA If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
