### PR TITLE
chore: Update Helm chart for GEL 3.6.11

### DIFF
--- a/production/helm/loki/CHANGELOG.md
+++ b/production/helm/loki/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries should include a reference to the pull request that introduced the chang
 
 ## Unreleased
 
+## 7.2.0
+
+- [CHANGE] Changed version of Grafana Enterprise Logs to 3.6.11 (updated `enterprise.version`, and `enterprise.image.tag`).
+
 ## 7.1.0
 
 - [CHANGE] Changed version of Grafana Enterprise Logs to 3.6.8 (updated `enterprise.version`, and `enterprise.image.tag`).

--- a/production/helm/loki/Chart.yaml
+++ b/production/helm/loki/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: loki
 description: Helm chart for Grafana Enterprise Logs supporting monolithic, simple scalable, and microservices modes.
 type: application
-appVersion: 3.6.8
-version: 7.1.0
+appVersion: 3.6.11
+version: 7.2.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/production/helm/loki/README.md
+++ b/production/helm/loki/README.md
@@ -1,6 +1,6 @@
 # loki
 
-![Version: 7.1.0](https://img.shields.io/badge/Version-7.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.8](https://img.shields.io/badge/AppVersion-3.6.8-informational?style=flat-square)
+![Version: 7.2.0](https://img.shields.io/badge/Version-7.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.11](https://img.shields.io/badge/AppVersion-3.6.11-informational?style=flat-square)
 
 Helm chart for Grafana Enterprise Logs supporting monolithic, simple scalable, and microservices modes.
 

--- a/production/helm/loki/values.yaml
+++ b/production/helm/loki/values.yaml
@@ -88,7 +88,7 @@ loki:
     # -- Docker image repository
     repository: grafana/loki
     # -- Overrides the image tag whose default is the chart's appVersion
-    tag: 3.6.8
+    tag: 3.6.11
     # -- Overrides the image tag with an image digest
     digest: null
     # -- Docker image pull policy
@@ -634,7 +634,7 @@ enterprise:
   # `enterprise.license.contents` or `enterprise.useExternalLicense`/`enterprise.externalLicenseName`.
   enabled: false
   # Default version of GEL to deploy
-  version: 3.6.8
+  version: 3.6.11
   # -- Optional name of the GEL cluster, otherwise will use .Release.Name
   # The cluster name must match what is in your GEL license
   cluster_name: null
@@ -676,7 +676,7 @@ enterprise:
     # -- Docker image repository
     repository: grafana/enterprise-logs
     # -- Docker image tag
-    tag: 3.6.8
+    tag: 3.6.11
     # -- Overrides the image tag with an image digest
     digest: null
     # -- Docker image pull policy


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the GEL helm charts to use GEL 3.6.11

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
See also https://github.com/grafana/enterprise-logs/pull/6066, which should be merged after this PR.

