### PR TITLE
fix(build): Enable auto-detection of tty for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ define run_in_container
 		.
 
 	@if $(TTY_TEST); then INTERACTIVE_FLAGS='--tty --interactive'; else INTERACTIVE_FLAGS=''; fi; \
-	docker run --rm $$INTERACTIVE_FLAGS \
+	@docker run --rm $$INTERACTIVE_FLAGS \
 		-v $(shell pwd)/.pkg:/go/pkg$(MOUNT_FLAGS) \
 		-v $(shell pwd)/.cache:/go/cache$(MOUNT_FLAGS) \
 		-v $(shell pwd):/src/loki$(MOUNT_FLAGS) \

--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,11 @@ SHELL = /usr/bin/env bash -o pipefail
 # want to speed up development you can run make BUILD_IN_CONTAINER=false target
 # or you can override this with an environment variable.
 BUILD_IN_CONTAINER ?= true
+# Unless NONINTERACTIVE is set, docker will be run interactive if it has a TTY
+# attached at launch time.
 NONINTERACTIVE     ?= false
+TTY_TEST           := $(if $(filter true,$(NONINTERACTIVE)),false,[ -t 0 ])
 CI                 ?= false
-
-# Docker flags for container interaction
-ifeq ($(NONINTERACTIVE),true)
-DOCKER_INTERACTIVE_FLAGS :=
-else
-DOCKER_INTERACTIVE_FLAGS := --tty --interactive
-endif
 
 # Ensure you run `make update-go-version` after changing this
 GO_VERSION         := 1.26.5
@@ -118,7 +114,8 @@ define run_in_container
 		-t $(MAKEFILE_IMAGE) \
 		.
 
-	@docker run --rm $(DOCKER_INTERACTIVE_FLAGS) \
+	@if $(TTY_TEST); then INTERACTIVE_FLAGS='--tty --interactive'; else INTERACTIVE_FLAGS=''; fi; \
+	docker run --rm $$INTERACTIVE_FLAGS \
 		-v $(shell pwd)/.pkg:/go/pkg$(MOUNT_FLAGS) \
 		-v $(shell pwd)/.cache:/go/cache$(MOUNT_FLAGS) \
 		-v $(shell pwd):/src/loki$(MOUNT_FLAGS) \

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ define run_in_container
 		.
 
 	@if $(TTY_TEST); then INTERACTIVE_FLAGS='--tty --interactive'; else INTERACTIVE_FLAGS=''; fi; \
-	@docker run --rm $$INTERACTIVE_FLAGS \
+	docker run --rm $$INTERACTIVE_FLAGS \
 		-v $(shell pwd)/.pkg:/go/pkg$(MOUNT_FLAGS) \
 		-v $(shell pwd)/.cache:/go/cache$(MOUNT_FLAGS) \
 		-v $(shell pwd):/src/loki$(MOUNT_FLAGS) \


### PR DESCRIPTION
**What this PR does / why we need it**:

`docker run --tty` fails with `cannot attach stdin to a TTY-enabled container
because stdin is not a terminal` when stdin is not a terminal. Non-interactive callers like
CI and LLM tools could not run any containerised `make` target without
setting `NONINTERACTIVE=true`

This replaces the unconditional `--tty --interactive` flags on the
`run_in_container` docker invocation with a terminal test performed in the
recipe, immediately before `docker run`. `NONINTERACTIVE=true` still forces the
flags off.

The terminal test is also required for parallel (`-j`) builds where only one instance will receive stdin.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
