### PR TITLE
docs: Metric query result ordering is not guaranteed

### DIFF
--- a/docs/sources/query/metric_queries.md
+++ b/docs/sources/query/metric_queries.md
@@ -126,6 +126,12 @@ Like [PromQL](https://prometheus.io/docs/prometheus/latest/querying/operators/#a
 - `sort`: returns vector elements sorted by their sample values, in ascending order.
 - `sort_desc`: Same as sort, but sorts in descending order.
 
+{{< admonition type="note" >}}
+Metric query results are not guaranteed to be returned in any particular order, unless the query uses `sort` or `sort_desc`. Don't rely on the ordering of results in any other case.
+
+`sort` and `sort_desc` only affect the results of instant queries. The ordering of range query results is unspecified, even when the query uses `sort` or `sort_desc`.
+{{< /admonition >}}
+
 The aggregation operators can either be used to aggregate over all label values or a set of distinct label values by including a `without` or a `by` clause:
 
 ```logql

--- a/docs/sources/query/metric_queries.md
+++ b/docs/sources/query/metric_queries.md
@@ -126,12 +126,6 @@ Like [PromQL](https://prometheus.io/docs/prometheus/latest/querying/operators/#a
 - `sort`: returns vector elements sorted by their sample values, in ascending order.
 - `sort_desc`: Same as sort, but sorts in descending order.
 
-{{< admonition type="note" >}}
-Metric query results are not guaranteed to be returned in any particular order, unless the query uses `sort` or `sort_desc`. Don't rely on the ordering of results in any other case.
-
-`sort` and `sort_desc` only affect the results of instant queries. The ordering of range query results is unspecified, even when the query uses `sort` or `sort_desc`.
-{{< /admonition >}}
-
 The aggregation operators can either be used to aggregate over all label values or a set of distinct label values by including a `without` or a `by` clause:
 
 ```logql
@@ -194,6 +188,12 @@ topk(
 ```
 
 `__count_min_sketch__` is calculated for each shard and merged on the frontend. Then `eval_cms` iterates through the labels list and determines the count for each. Then `topk` selects the top items.
+
+## Result ordering
+
+Metric query results are not guaranteed to be returned in any particular order, unless the query uses `sort` or `sort_desc`, which order the elements by their sample value. Don't rely on the ordering of results in any other case.
+
+`sort` and `sort_desc` only affect the results of instant queries. The ordering of range query results is unspecified, even when the query uses `sort` or `sort_desc`.
 
 ## Further resources
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The LogQL docs don't say anything about the ordering of metric query results, so users end up depending on the order the engine happens to return. Today instant vectors are label-sorted (unless the query uses `sort`/`sort_desc`) and range results are label-sorted, but that's an implementation detail we shouldn't be locked into.

This PR documents the same contract Prometheus documents for PromQL: no ordering guarantee unless `sort`/`sort_desc` is used, and those only apply to instant queries.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

The statement about range queries is intentionally conservative ("unspecified" rather than Prometheus's "fixed output ordering"), since `sort`/`sort_desc` value ordering is dropped for matrix results anyway. Happy to promise more if we want range ordering to be part of the contract.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)