### PR TITLE
test: Fix data races in the integration test harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,7 @@ test: all ## run the unit tests
 
 
 test-integration:
-	$(GOTEST) -count=1 -v -tags=integration -timeout 15m ./integration
+	$(GOTEST) -count=1 -v -race -tags=integration -timeout 15m ./integration
 
 compare-coverage:
 	./tools/diff_coverage.sh $(old) $(new) $(packages)

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -11,7 +11,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"text/template"
 	"time"
@@ -36,8 +35,8 @@ var configTemplate = template.Must(template.New("").Parse(`
 auth_enabled: true
 
 server:
-  http_listen_port: 0
-  grpc_listen_port: 0
+  http_listen_port: {{.httpPort}}
+  grpc_listen_port: {{.grpcPort}}
   grpc_server_max_recv_msg_size: 110485813
   grpc_server_max_send_msg_size: 110485813
 
@@ -304,6 +303,10 @@ type Component struct {
 	overridesFile string
 	dataPath      string
 
+	// HTTP and gRPC ports where the component is listening to.
+	httpPort int
+	grpcPort int
+
 	running bool
 	wg      sync.WaitGroup
 }
@@ -320,11 +323,11 @@ func (c *Component) AddFlags(flags ...string) {
 }
 
 func (c *Component) HTTPURL() string {
-	return fmt.Sprintf("http://localhost:%s", port(c.loki.Server.HTTPListenAddr().String()))
+	return fmt.Sprintf("http://localhost:%d", c.httpPort)
 }
 
 func (c *Component) GRPCURL() string {
-	return fmt.Sprintf("localhost:%s", port(c.loki.Server.GRPCListenAddr().String()))
+	return fmt.Sprintf("localhost:%d", c.grpcPort)
 }
 
 func (c *Component) WithExtraConfig(cfg string) {
@@ -335,17 +338,22 @@ func (c *Component) WithExtraConfig(cfg string) {
 	c.extraConfigs = append(c.extraConfigs, cfg)
 }
 
-func port(addr string) string {
-	parts := strings.Split(addr, ":")
-	return parts[len(parts)-1]
-}
-
 func (c *Component) writeConfig() error {
 	var err error
 
 	configFile, err := os.CreateTemp("", fmt.Sprintf("loki-%s-config-*.yaml", c.name))
 	if err != nil {
 		return fmt.Errorf("error creating config file: %w", err)
+	}
+
+	// Listen ports are picked by the harness rather than by the server, so that
+	// the harness can probe readiness over the network.
+	if c.httpPort, err = freePort(); err != nil {
+		return fmt.Errorf("error allocating http port: %w", err)
+	}
+
+	if c.grpcPort, err = freePort(); err != nil {
+		return fmt.Errorf("error allocating grpc port: %w", err)
 	}
 
 	c.dataPath, err = os.MkdirTemp("", fmt.Sprintf("loki-%s-data-", c.name))
@@ -379,6 +387,8 @@ func (c *Component) MergedConfig() ([]byte, error) {
 	if err := configTemplate.Execute(&sb, map[string]interface{}{
 		"dataPath":       c.dataPath,
 		"sharedDataPath": c.cluster.sharedPath,
+		"httpPort":       c.httpPort,
+		"grpcPort":       c.grpcPort,
 	}); err != nil {
 		return nil, fmt.Errorf("error writing config file: %w", err)
 	}
@@ -455,18 +465,26 @@ func (c *Component) run() error {
 		errCh   = make(chan error, 1)
 	)
 
+	// Probe readiness over the network to guarantee the component is ready before
+	// the test proceeds.
+	//
+	// We don't check readiness by calling ServeHTTP on the router directly because
+	// the component may still initialize even if the readiness check passes
+	// (e.g. the server only accepts connections once initialization has completed,
+	// while directly calling ServeHTTP may pass the readiness probe even if the
+	// initialization has not completed yet).
+	readyURL := fmt.Sprintf("%s/ready", c.HTTPURL())
 	go func() {
 		for {
 			time.Sleep(time.Millisecond * 200)
-			if c.loki == nil || c.loki.Server == nil || c.loki.Server.HTTP == nil {
+
+			resp, err := http.Get(readyURL) // #nosec G107 -- local test server
+			if err != nil {
 				continue
 			}
+			_ = resp.Body.Close()
 
-			req := httptest.NewRequest("GET", "http://localhost/ready", nil)
-			w := httptest.NewRecorder()
-			c.loki.Server.HTTP.ServeHTTP(w, req)
-
-			if w.Code == 200 {
+			if resp.StatusCode == http.StatusOK {
 				close(readyCh)
 				return
 			}
@@ -558,4 +576,17 @@ func NewRemoteWriteServer(handler *http.HandlerFunc) *httptest.Server {
 	server.Start()
 
 	return server
+}
+
+// freePort asks the kernel for an unused port. There is an inherent gap between
+// releasing it here and the server binding it, but the integration tests start
+// components one at a time, so nothing else in the suite should compete for it.
+func freePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+
+	return l.Addr().(*net.TCPAddr).Port, nil
 }

--- a/integration/loki_rule_eval_test.go
+++ b/integration/loki_rule_eval_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/integration/client"
 	"github.com/grafana/loki/v3/integration/cluster"
@@ -120,7 +121,7 @@ func testRuleEval(t *testing.T, mode string, useThanosObjstore bool) {
 		fmt.Sprintf("-use-thanos-objstore=%v", useThanosObjstore),
 	)
 
-	rwHandler := func(called *bool, test func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	rwHandler := func(called *atomic.Bool, test func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
 		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path != "/api/v1/write" {
 				t.Errorf("Expected to request '/api/v1/write', got: %s", r.URL.Path)
@@ -128,7 +129,7 @@ func testRuleEval(t *testing.T, mode string, useThanosObjstore bool) {
 
 			test(w, r)
 
-			*called = true
+			called.Store(true)
 
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -148,7 +149,7 @@ func testRuleEval(t *testing.T, mode string, useThanosObjstore bool) {
 		require.Equal(t, wr.Timeseries[len(wr.Timeseries)-1].Samples[0].Value, float64(2))
 	}
 
-	var called bool
+	var called atomic.Bool
 	server1 := rwHandler(&called, expectedResults)
 	defer server1.Close()
 
@@ -207,6 +208,6 @@ groups:
 
 	// ensure that the remote-write receiver was called with the expected data
 	require.Eventually(t, func() bool {
-		return assert.ObjectsAreEqualValues(true, called)
+		return called.Load()
 	}, 30*time.Second, 100*time.Millisecond, "remote-write was not called")
 }

--- a/integration/loki_rule_eval_test.go
+++ b/integration/loki_rule_eval_test.go
@@ -39,6 +39,43 @@ func TestRuleEval(t *testing.T) {
 // In this test we stub out a remote-write receiver and check that the expected data is sent to it.
 // Both the local and the remote rule evaluation modes should produce the same result.
 func testRuleEval(t *testing.T, mode string, useThanosObjstore bool) {
+	rwHandler := func(called *atomic.Bool, test func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/v1/write" {
+				t.Errorf("Expected to request '/api/v1/write', got: %s", r.URL.Path)
+			}
+
+			test(w, r)
+
+			called.Store(true)
+
+			w.WriteHeader(http.StatusOK)
+		}))
+	}
+
+	// this is the function that will be called when the remote-write receiver receives a request.
+	// it tests that the expected payload is received.
+	expectedResults := func(_ http.ResponseWriter, r *http.Request) {
+		wr, err := remote.DecodeWriteRequest(r.Body)
+		require.NoError(t, err)
+
+		// depending on the rule interval, we may get multiple timeseries before remote-write is triggered,
+		// so we just check that we have at least one that matches our requirements.
+		require.GreaterOrEqual(t, len(wr.Timeseries), 1)
+
+		// we expect to see two GET lines from the aggregation in the recording rule
+		require.Equal(t, wr.Timeseries[len(wr.Timeseries)-1].Samples[0].Value, float64(2))
+	}
+
+	var called atomic.Bool
+	server1 := rwHandler(&called, expectedResults)
+
+	// Registered before the cluster cleanup so that it runs after it (t.Cleanup runs in
+	// LIFO order): the ruler flushes its remote-write queue while stopping, and that flush
+	// needs a live receiver, or it retries against a dead connection until it hits its
+	// flush deadline.
+	t.Cleanup(server1.Close)
+
 	clu := cluster.New(nil, cluster.SchemaWithTSDB, func(c *cluster.Cluster) {
 		c.SetSchemaVer("v13")
 	})
@@ -120,38 +157,6 @@ func testRuleEval(t *testing.T, mode string, useThanosObjstore bool) {
 		"-common.compactor-address="+tCompactor.HTTPURL(),
 		fmt.Sprintf("-use-thanos-objstore=%v", useThanosObjstore),
 	)
-
-	rwHandler := func(called *atomic.Bool, test func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
-		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path != "/api/v1/write" {
-				t.Errorf("Expected to request '/api/v1/write', got: %s", r.URL.Path)
-			}
-
-			test(w, r)
-
-			called.Store(true)
-
-			w.WriteHeader(http.StatusOK)
-		}))
-	}
-
-	// this is the function that will be called when the remote-write receiver receives a request.
-	// it tests that the expected payload is received.
-	expectedResults := func(_ http.ResponseWriter, r *http.Request) {
-		wr, err := remote.DecodeWriteRequest(r.Body)
-		require.NoError(t, err)
-
-		// depending on the rule interval, we may get multiple timeseries before remote-write is triggered,
-		// so we just check that we have at least one that matches our requirements.
-		require.GreaterOrEqual(t, len(wr.Timeseries), 1)
-
-		// we expect to see two GET lines from the aggregation in the recording rule
-		require.Equal(t, wr.Timeseries[len(wr.Timeseries)-1].Samples[0].Value, float64(2))
-	}
-
-	var called atomic.Bool
-	server1 := rwHandler(&called, expectedResults)
-	defer server1.Close()
 
 	tRuler.WithRulerRemoteWrite("target1", server1.URL)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix two data races in the integration test harness, found by running the suite locally with `-race`.

The readiness probe called `ServeHTTP` directly on the gorilla/mux router every 200ms as soon as `Server.HTTP` was non nil, while `Loki.Run()` was still registering routes on that same router. `mux.Router` does not support concurrent route registration and matching. The harness now picks the listen ports itself and probes readiness over the network instead, which can only succeed once the server accepts connections, i.e. after route registration has finished. As a side effect `HTTPURL()`/`GRPCURL()` no longer read into a partially initialised `Loki`.

The other fix is `TestRuleEval`, where the remote write handler set a plain `bool` from the server goroutine while `require.Eventually` read it.

This PR does not enable `-race` in CI: a few races outside the integration tests still need to land first.

**Which issue(s) this PR fixes**:

Related to #8586

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
