### PR TITLE
fix(validation): Make the default limits global safe for concurrent access

### DIFF
--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/sigv4"
+	"go.uber.org/atomic"
 	yaml "go.yaml.in/yaml/v4"
 	"golang.org/x/time/rate"
 
@@ -594,6 +595,8 @@ func (l *Limits) UnmarshalYAML(value *yaml.Node) error {
 	// again, we have to hide it using a type indirection.  See prometheus/config.
 	type plain Limits
 
+	defaultLimits := defaultLimits.Load()
+
 	// During startup we wont have a default value so we don't want to overwrite them
 	if defaultLimits != nil {
 		b, err := yaml.Marshal(defaultLimits)
@@ -706,13 +709,16 @@ func (l *Limits) Validate() error {
 // to default to any values specified on the command line, not default
 // command line values.  This global contains those values.  I (Tom) cannot
 // find a nicer way I'm afraid.
-var defaultLimits *Limits
+// Atomic because a process running more than one Loki instance, as the
+// integration tests do, sets it while another instance is reloading its runtime
+// config. Only ever replaced as a whole, never mutated once published.
+var defaultLimits atomic.Pointer[Limits]
 
 // SetDefaultLimitsForYAMLUnmarshalling sets global default limits, used when loading
 // Limits from YAML files. This is used to ensure per-tenant limits are defaulted to
 // those values.
 func SetDefaultLimitsForYAMLUnmarshalling(defaults Limits) {
-	defaultLimits = &defaults
+	defaultLimits.Store(&defaults)
 }
 
 type TenantLimits interface {

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -174,9 +174,9 @@ func TestOverwriteMarshalingStringMapYAML(t *testing.T) {
 }
 
 func TestLimitsDoesNotMutate(t *testing.T) {
-	initialDefault := defaultLimits
+	initialDefault := defaultLimits.Load()
 	defer func() {
-		defaultLimits = initialDefault
+		defaultLimits.Store(initialDefault)
 	}()
 
 	defaultOTLPConfig := push.OTLPConfig{
@@ -799,9 +799,9 @@ func TestPolicyShardStreams(t *testing.T) {
 }
 
 func TestOTLPConfig(t *testing.T) {
-	initialDefault := defaultLimits
+	initialDefault := defaultLimits.Load()
 	defer func() {
-		defaultLimits = initialDefault
+		defaultLimits.Store(initialDefault)
 	}()
 
 	for _, tc := range []struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

`validation.SetDefaultLimitsForYAMLUnmarshalling` writes the `defaultLimits` global, and `Limits.UnmarshalYAML` reads it every time a runtime config is loaded. A single Loki instance sets it in `initRuntimeConfig` before the runtime config loader starts, so there is no concurrency there. A process running more than one instance is a different story: one instance's startup writes the global while another instance's runtime config manager is reloading, and the race detector reports it.

That is exactly what the integration tests do, since they run all components in one process. This is one of the data races blocking #23653, which enables `-race` for integration tests.

In this PR I propose to store `defaultLimits` in an `atomic.Pointer`. This should be enough: the global limits are only ever replaced as a whole and never mutated once published.

**Which issue(s) this PR fixes**:

Related to #8586

**Special notes for your reviewer**:

Verified with `go test -race ./pkg/validation/`, and by running the integration test suite under `-race` with #23653 applied.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)