### PR TITLE
chore(otlp): Remove unused structured metadata stats

### DIFF
--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -253,16 +253,10 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 			stats.StructuredMetadataBytes[policy] = make(map[time.Duration]int64)
 		}
 
-		if _, ok := stats.ResourceAndSourceMetadataLabels[policy]; !ok {
-			stats.ResourceAndSourceMetadataLabels[policy] = make(map[time.Duration]push.LabelsAdapter)
-		}
-
 		// We group by retention period to later be able to map bytes ingested to each retention period.
 		// Ex: 10GB ingested has 30d retention and 1GB has 365d retention.
 		stats.StructuredMetadataBytes[policy][retentionPeriodForUser] += resourceAttributesAsStructuredMetadataSize
 		totalBytesReceived += resourceAttributesAsStructuredMetadataSize
-
-		stats.ResourceAndSourceMetadataLabels[policy][retentionPeriodForUser] = append(stats.ResourceAndSourceMetadataLabels[policy][retentionPeriodForUser], resourceAttributesAsStructuredMetadata...)
 
 		for j := 0; j < sls.Len(); j++ {
 			logs := sls.At(j).LogRecords()
@@ -286,7 +280,6 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 			stats.StructuredMetadataBytes[policy][retentionPeriodForUser] += scopeAttributesAsStructuredMetadataSize
 			totalBytesReceived += scopeAttributesAsStructuredMetadataSize
 
-			stats.ResourceAndSourceMetadataLabels[policy][retentionPeriodForUser] = append(stats.ResourceAndSourceMetadataLabels[policy][retentionPeriodForUser], scopeAttributesAsStructuredMetadata...)
 			for k := 0; k < logs.Len(); k++ {
 				log := logs.At(k)
 

--- a/pkg/loghttp/push/otlp_test.go
+++ b/pkg/loghttp/push/otlp_test.go
@@ -131,11 +131,6 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 						time.Hour: 0,
 					},
 				},
-				ResourceAndSourceMetadataLabels: map[string]map[time.Duration]push.LabelsAdapter{
-					"service-1-policy": {
-						time.Hour: nil,
-					},
-				},
 				StreamLabelsSize:                  21,
 				MostRecentEntryTimestamp:          now,
 				StreamSizeBytes:                   map[string]int64{},
@@ -180,11 +175,6 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 						time.Hour: 0,
 					},
 				},
-				ResourceAndSourceMetadataLabels: map[string]map[time.Duration]push.LabelsAdapter{
-					"others": {
-						time.Hour: nil,
-					},
-				},
 				StreamLabelsSize:                  27,
 				MostRecentEntryTimestamp:          now,
 				StreamSizeBytes:                   map[string]int64{},
@@ -227,11 +217,6 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 				StructuredMetadataBytes: PolicyWithRetentionWithBytes{
 					"others": {
 						time.Hour: 0,
-					},
-				},
-				ResourceAndSourceMetadataLabels: map[string]map[time.Duration]push.LabelsAdapter{
-					"others": {
-						time.Hour: nil,
 					},
 				},
 				StreamLabelsSize:                  47,
@@ -279,11 +264,6 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 				StructuredMetadataBytes: PolicyWithRetentionWithBytes{
 					"others": {
 						time.Hour: 0,
-					},
-				},
-				ResourceAndSourceMetadataLabels: map[string]map[time.Duration]push.LabelsAdapter{
-					"others": {
-						time.Hour: nil,
 					},
 				},
 				StreamLabelsSize:                  41,
@@ -367,15 +347,6 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 				StructuredMetadataBytes: PolicyWithRetentionWithBytes{
 					"service-1-policy": {
 						time.Hour: 37,
-					},
-				},
-				ResourceAndSourceMetadataLabels: map[string]map[time.Duration]push.LabelsAdapter{
-					"service-1-policy": {
-						time.Hour: []push.LabelAdapter{
-							{Name: "service_image", Value: "loki"},
-							{Name: "op", Value: "buzz"},
-							{Name: "scope_name", Value: "fizz"},
-						},
 					},
 				},
 				StreamLabelsSize:                  21,
@@ -468,15 +439,6 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 				StructuredMetadataBytes: PolicyWithRetentionWithBytes{
 					"service-1-policy": {
 						time.Hour: 97,
-					},
-				},
-				ResourceAndSourceMetadataLabels: map[string]map[time.Duration]push.LabelsAdapter{
-					"service-1-policy": {
-						time.Hour: []push.LabelAdapter{
-							{Name: "resource_nested_foo", Value: "bar"},
-							{Name: "scope_nested_foo", Value: "bar"},
-							{Name: "scope_name", Value: "fizz"},
-						},
 					},
 				},
 				StreamLabelsSize:                  21,
@@ -629,16 +591,6 @@ func TestOTLPToLokiPushRequest(t *testing.T) {
 				StructuredMetadataBytes: PolicyWithRetentionWithBytes{
 					"service-1-policy": {
 						time.Hour: 113,
-					},
-				},
-				ResourceAndSourceMetadataLabels: map[string]map[time.Duration]push.LabelsAdapter{
-					"service-1-policy": {
-						time.Hour: []push.LabelAdapter{
-							{Name: "pod_ip", Value: "10.200.200.200"},
-							{Name: "resource_nested_foo", Value: "bar"},
-							{Name: "scope_nested_foo", Value: "bar"},
-							{Name: "scope_name", Value: "fizz"},
-						},
 					},
 				},
 				StreamLabelsSize:                  42,

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -15,8 +15,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 
-	"github.com/grafana/loki/pkg/push"
-
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 
@@ -143,7 +141,6 @@ func NewPushStats() *Stats {
 		LogLinesBytes:                     map[string]map[time.Duration]int64{},
 		StructuredMetadataBytes:           map[string]map[time.Duration]int64{},
 		PolicyNumLines:                    map[string]int64{},
-		ResourceAndSourceMetadataLabels:   map[string]map[time.Duration]push.LabelsAdapter{},
 		MostRecentEntryTimestampPerStream: map[string]time.Time{},
 		StreamSizeBytes:                   map[string]int64{},
 	}
@@ -159,9 +156,6 @@ type Stats struct {
 	// StructuredMetadataBytes holds the size of the original structured metadata (but after it was enriched by OLTP
 	// parser) per policy per retention. Used in billing.
 	StructuredMetadataBytes PolicyWithRetentionWithBytes
-
-	// ResourceAndSourceMetadataLabels holds structured metadata that was added by OLTP parser (scope and resource attributes)
-	ResourceAndSourceMetadataLabels map[string]map[time.Duration]push.LabelsAdapter
 
 	// StreamLabelsSize holds the total size of stream labels after sanitization (empty labels removed and
 	// non-meaningful whitespaces removed). Not used in billing.


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove unused `ResourceAndSourceMetadataLabels` stats field. 

This was added in https://github.com/grafana/loki/pull/12201 so these stats can be used by a wrapped parser.
Removing it now as it is no longer being consumed within Loki or by a wrapper parsed.


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
