### PR TITLE
fix(tsdb): Give indices their chunk filterer at construction

### DIFF
--- a/pkg/bloombuild/common/tsdb.go
+++ b/pkg/bloombuild/common/tsdb.go
@@ -119,7 +119,8 @@ func (b *BloomTSDBStore) LoadTSDB(
 		return nil, errors.Wrap(err, "failed to create index reader")
 	}
 
-	idx := tsdb.NewTSDBIndex(reader)
+	// Bloom building reads the whole index; no LBAC filtering applies.
+	idx := tsdb.NewTSDBIndex(reader, nil)
 
 	return idx, nil
 }

--- a/pkg/ingester/flush_test.go
+++ b/pkg/ingester/flush_test.go
@@ -697,8 +697,6 @@ func (s *testStore) GetSchemaConfigs() []config.PeriodConfig {
 
 func (s *testStore) Stop() {}
 
-func (s *testStore) SetChunkFilterer(_ chunk.RequestChunkFilterer) {}
-
 func (s *testStore) Stats(_ context.Context, _ string, _, _ model.Time, _ ...*labels.Matcher) (*stats.Stats, error) {
 	return &stats.Stats{}, nil
 }

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -478,9 +478,6 @@ func (s *mockStore) GetSchemaConfigs() []config.PeriodConfig {
 	return defaultPeriodConfigs
 }
 
-func (s *mockStore) SetChunkFilterer(_ chunk.RequestChunkFilterer) {
-}
-
 // chunk.Store methods
 func (s *mockStore) PutOne(_ context.Context, _, _ model.Time, _ chunk.Chunk) error {
 	return nil

--- a/pkg/labelaccess/mock_store_test.go
+++ b/pkg/labelaccess/mock_store_test.go
@@ -71,9 +71,6 @@ func (s *mockStore) GetSchemaConfigs() []config.PeriodConfig {
 	return defaultPeriodConfigs
 }
 
-func (s *mockStore) SetChunkFilterer(_ chunk.RequestChunkFilterer) {
-}
-
 // chunk.Store methods
 func (s *mockStore) PutOne(_ context.Context, _, _ model.Time, _ chunk.Chunk) error {
 	return nil

--- a/pkg/loki/labelaccess.go
+++ b/pkg/loki/labelaccess.go
@@ -34,7 +34,7 @@ func (l *Loki) setupLBAC() error {
 		Distributor:             {AuthMiddleware},
 		IndexGateway:            {LabelAccess},
 		Ingester:                {LabelAccessStoreWrapper, LabelAccessIngesterWrapper, Filterers},
-		LabelAccess:             {Store},
+		Store:                   {LabelAccess},
 		LabelAccessStoreWrapper: {Store},
 		LabelAccessTripperware:  {AuthTripperware},
 		Querier:                 {AuthMiddleware, LabelAccess, LabelAccessStoreWrapper},
@@ -71,10 +71,12 @@ func (l *Loki) initLabelAccessIngesterWrapper() (services.Service, error) {
 	return nil, nil
 }
 
+// initStoreChunkFilterer puts the chunk filterer on the storage config, so the
+// store and the index implementations underneath it are built with it. It must run
+// before Store, which is why Store depends on it.
 func (l *Loki) initStoreChunkFilterer() (services.Service, error) {
 	_ = level.Debug(util_log.Logger).Log("msg", "initializing store chunk filterer")
-	filterer := labelaccess.RequestChunkFilterer{}
-	l.Store.SetChunkFilterer(&filterer)
+	l.Cfg.StorageConfig.ChunkFilterer = &labelaccess.RequestChunkFilterer{}
 	return nil, nil
 }
 

--- a/pkg/querier/querier_mock_test.go
+++ b/pkg/querier/querier_mock_test.go
@@ -270,7 +270,6 @@ type storeMock struct {
 func newStoreMock() *storeMock {
 	return &storeMock{}
 }
-func (s *storeMock) SetChunkFilterer(chunk.RequestChunkFilterer)    {}
 func (s *storeMock) SetExtractorWrapper(log.SampleExtractorWrapper) {}
 func (s *storeMock) SetPipelineWrapper(log.PipelineWrapper)         {}
 

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -1775,7 +1775,7 @@ func Benchmark_store_OverlappingChunks(b *testing.B) {
 		cfg: Config{
 			MaxChunkBatchSize: 50,
 		},
-		Store: newMockChunkStore(chunkfmt, headfmt, newOverlappingStreams(200, 200)),
+		Store: newMockChunkStore(chunkfmt, headfmt, nil, newOverlappingStreams(200, 200)),
 	}
 	b.ResetTimer()
 	statsCtx, ctx := stats.NewContext(user.InjectOrgID(context.Background(), "fake"))

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/indexgateway"
 	"github.com/grafana/loki/v3/pkg/storage/bucket"
+	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/alibaba"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/aws"
@@ -289,6 +290,10 @@ type Config struct {
 	// ObjectClientDecorator, if set, wraps every ObjectClient after creation.
 	// This is intended for testing (e.g. injecting latency simulation).
 	ObjectClientDecorator func(client.ObjectClient) client.ObjectClient `yaml:"-"`
+
+	// ChunkFilterer, if set, filters the chunks and series returned by the store.
+	// It is handed to the index implementations when they are built.
+	ChunkFilterer chunk.RequestChunkFilterer `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to configure this flag set.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -184,6 +184,8 @@ func NewStore(cfg Config, storeCfg config.ChunkStoreConfig, schemaCfg config.Sch
 		logger: logger,
 		limits: limits,
 
+		chunkFilterer: cfg.ChunkFilterer,
+
 		metricsNamespace: metricsNamespace,
 	}
 	if err := s.init(); err != nil {
@@ -352,7 +354,7 @@ func (s *LokiStore) storeForPeriod(p config.PeriodConfig, tableRange config.Tabl
 	}
 
 	name := fmt.Sprintf("%s_%s", p.ObjectType, p.From.String())
-	indexReaderWriter, stopTSDBStoreFunc, err := tsdb.NewStore(name, p.IndexTables.PathPrefix, s.cfg.TSDBShipperConfig, s.schemaCfg, f, objectClient, s.limits, tableRange, indexClientReg, indexClientLogger)
+	indexReaderWriter, stopTSDBStoreFunc, err := tsdb.NewStore(name, p.IndexTables.PathPrefix, s.cfg.TSDBShipperConfig, s.schemaCfg, f, objectClient, s.limits, tableRange, s.cfg.ChunkFilterer, indexClientReg, indexClientLogger)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -433,11 +435,6 @@ func injectShardLabel(shards []string, matchers []*labels.Matcher) ([]*labels.Ma
 		}
 	}
 	return matchers, nil
-}
-
-func (s *LokiStore) SetChunkFilterer(chunkFilterer chunk.RequestChunkFilterer) {
-	s.chunkFilterer = chunkFilterer
-	s.Store.SetChunkFilterer(chunkFilterer)
 }
 
 func (s *LokiStore) SetExtractorWrapper(wrapper lokilog.SampleExtractorWrapper) {

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -363,7 +363,7 @@ func Test_store_SelectLogs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &LokiStore{
-				Store: storeFixture,
+				Store: newMockChunkStore(chunkenc.ChunkFormatV3, chunkenc.UnorderedWithStructuredMetadataHeadBlockFmt, nil, streamsFixture),
 				cfg: Config{
 					MaxChunkBatchSize: 10,
 				},
@@ -694,7 +694,7 @@ func Test_store_SelectSample(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &LokiStore{
-				Store: storeFixture,
+				Store: newMockChunkStore(chunkenc.ChunkFormatV3, chunkenc.UnorderedWithStructuredMetadataHeadBlockFmt, nil, streamsFixture),
 				cfg: Config{
 					MaxChunkBatchSize: 10,
 				},
@@ -738,13 +738,13 @@ func (f fakeChunkFilterer) RequiredLabelNames() []string {
 
 func Test_ChunkFilterer(t *testing.T) {
 	s := &LokiStore{
-		Store: storeFixture,
+		Store: newMockChunkStore(chunkenc.ChunkFormatV3, chunkenc.UnorderedWithStructuredMetadataHeadBlockFmt, &fakeChunkFilterer{}, streamsFixture),
 		cfg: Config{
 			MaxChunkBatchSize: 10,
 		},
-		chunkMetrics: NilMetrics,
+		chunkMetrics:  NilMetrics,
+		chunkFilterer: &fakeChunkFilterer{},
 	}
-	s.SetChunkFilterer(&fakeChunkFilterer{})
 	ctx = user.InjectOrgID(context.Background(), "test-user")
 	it, err := s.SelectSamples(ctx, logql.SelectSampleParams{SampleQueryRequest: newSampleQuery("count_over_time({foo=~\"ba.*\"}[1s])", from, from.Add(1*time.Hour), nil, nil)})
 	if err != nil {
@@ -778,7 +778,7 @@ func Test_ChunkFilterer(t *testing.T) {
 
 func Test_PipelineWrapper(t *testing.T) {
 	s := &LokiStore{
-		Store: storeFixture,
+		Store: newMockChunkStore(chunkenc.ChunkFormatV3, chunkenc.UnorderedWithStructuredMetadataHeadBlockFmt, nil, streamsFixture),
 		cfg: Config{
 			MaxChunkBatchSize: 10,
 		},
@@ -808,7 +808,7 @@ func Test_PipelineWrapper(t *testing.T) {
 
 func Test_PipelineWrapper_disabled(t *testing.T) {
 	s := &LokiStore{
-		Store: storeFixture,
+		Store: newMockChunkStore(chunkenc.ChunkFormatV3, chunkenc.UnorderedWithStructuredMetadataHeadBlockFmt, nil, streamsFixture),
 		cfg: Config{
 			MaxChunkBatchSize: 10,
 		},
@@ -895,7 +895,7 @@ func (p *mockStreamPipeline) ProcessString(ts int64, line string, lbs labels.Lab
 
 func Test_SampleWrapper(t *testing.T) {
 	s := &LokiStore{
-		Store: storeFixture,
+		Store: newMockChunkStore(chunkenc.ChunkFormatV3, chunkenc.UnorderedWithStructuredMetadataHeadBlockFmt, nil, streamsFixture),
 		cfg: Config{
 			MaxChunkBatchSize: 10,
 		},
@@ -924,7 +924,7 @@ func Test_SampleWrapper(t *testing.T) {
 
 func Test_SampleWrapper_disabled(t *testing.T) {
 	s := &LokiStore{
-		Store: storeFixture,
+		Store: newMockChunkStore(chunkenc.ChunkFormatV3, chunkenc.UnorderedWithStructuredMetadataHeadBlockFmt, nil, streamsFixture),
 		cfg: Config{
 			MaxChunkBatchSize: 10,
 		},
@@ -1061,7 +1061,7 @@ func Test_store_GetSeries(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &LokiStore{
-				Store: newMockChunkStore(chunkfmt, headfmt, streamsFixture),
+				Store: newMockChunkStore(chunkfmt, headfmt, nil, streamsFixture),
 				cfg: Config{
 					MaxChunkBatchSize: tt.batchSize,
 				},
@@ -1535,7 +1535,7 @@ func Test_GetSeries(t *testing.T) {
 
 	var (
 		store = &LokiStore{
-			Store: newMockChunkStore(chunkfmt, headfmt, []*logproto.Stream{
+			Store: newMockChunkStore(chunkfmt, headfmt, nil, []*logproto.Stream{
 				{
 					Labels: `{foo="bar",buzz="boo"}`,
 					Entries: []logproto.Entry{

--- a/pkg/storage/stores/composite_store.go
+++ b/pkg/storage/stores/composite_store.go
@@ -41,7 +41,6 @@ type ChunkFetcher interface {
 type Store interface {
 	index.BaseReader
 	index.StatsReader
-	index.Filterable
 	ChunkWriter
 	ChunkFetcher
 	ChunkFetcherProvider
@@ -104,12 +103,6 @@ func (c CompositeStore) PutOne(ctx context.Context, from, through model.Time, ch
 	return c.forStores(ctx, from, through, func(innerCtx context.Context, from, through model.Time, store Store) error {
 		return store.PutOne(innerCtx, from, through, chunk)
 	})
-}
-
-func (c CompositeStore) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
-	for _, store := range c.stores {
-		store.SetChunkFilterer(chunkFilter)
-	}
 }
 
 func (c CompositeStore) GetSeries(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]labels.Labels, error) {

--- a/pkg/storage/stores/composite_store_entry.go
+++ b/pkg/storage/stores/composite_store_entry.go
@@ -107,10 +107,6 @@ func (c *storeEntry) GetSeries(ctx context.Context, userID string, from, through
 	return c.indexReader.GetSeries(ctx, userID, from, through, matchers...)
 }
 
-func (c *storeEntry) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
-	c.indexReader.SetChunkFilterer(chunkFilter)
-}
-
 // LabelNamesForMetricName retrieves all label names for a metric name.
 func (c *storeEntry) LabelNamesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, matchers ...*labels.Matcher) ([]string, error) {
 	ctx, sp := tracer.Start(ctx, "SeriesStore.LabelNamesForMetricName", trace.WithAttributes(

--- a/pkg/storage/stores/composite_store_test.go
+++ b/pkg/storage/stores/composite_store_test.go
@@ -35,8 +35,6 @@ func (m mockStore) LabelValuesForMetricName(_ context.Context, _ string, _, _ mo
 	return nil, nil
 }
 
-func (m mockStore) SetChunkFilterer(_ chunk.RequestChunkFilterer) {}
-
 func (m mockStore) GetChunks(_ context.Context, _ string, _, _ model.Time, _ chunk.Predicate, _ *logproto.ChunkRefGroup) ([][]chunk.Chunk, []*fetcher.Fetcher, error) {
 	return nil, nil, nil
 }

--- a/pkg/storage/stores/index/index.go
+++ b/pkg/storage/stores/index/index.go
@@ -18,11 +18,6 @@ import (
 	loki_instrument "github.com/grafana/loki/v3/pkg/util/instrument"
 )
 
-type Filterable interface {
-	// SetChunkFilterer sets a chunk filter to be used when retrieving chunks.
-	SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer)
-}
-
 type BaseReader interface {
 	GetSeries(ctx context.Context, userID string, from, through model.Time, matchers ...*labels.Matcher) ([]labels.Labels, error)
 	LabelValuesForMetricName(ctx context.Context, userID string, from, through model.Time, metricName string, labelName string, matchers ...*labels.Matcher) ([]string, error)
@@ -53,7 +48,6 @@ type StatsReader interface {
 type Reader interface {
 	BaseReader
 	StatsReader
-	Filterable
 	GetChunkRefs(ctx context.Context, userID string, from, through model.Time, predicate chunk.Predicate) ([]logproto.ChunkRef, error)
 }
 
@@ -270,10 +264,6 @@ func (m MonitoredReaderWriter) GetShards(
 		return nil, err
 	}
 	return shards, nil
-}
-
-func (m MonitoredReaderWriter) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
-	m.rw.SetChunkFilterer(chunkFilter)
 }
 
 func (m MonitoredReaderWriter) IndexChunk(ctx context.Context, from, through model.Time, chk chunk.Chunk) error {

--- a/pkg/storage/stores/series/series_index_gateway_store.go
+++ b/pkg/storage/stores/series/series_index_gateway_store.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -141,10 +140,6 @@ func (c *IndexGatewayClientStore) GetShards(ctx context.Context, _ string, from,
 		Query:               predicate.Plan().AST.String(),
 		TargetBytesPerShard: targetBytesPerShard,
 	})
-}
-
-func (c *IndexGatewayClientStore) SetChunkFilterer(_ chunk.RequestChunkFilterer) {
-	level.Warn(c.logger).Log("msg", "SetChunkFilterer called on index gateway client store, but it does not support it")
 }
 
 func (c *IndexGatewayClientStore) IndexChunk(_ context.Context, _, _ model.Time, _ chunk.Chunk) error {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
@@ -37,7 +37,7 @@ func (i indexProcessor) NewTableCompactor(ctx context.Context, commonIndexSet co
 }
 
 func (i indexProcessor) OpenCompactedIndexFile(ctx context.Context, path, tableName, userID, workingDir string, periodConfig config.PeriodConfig, logger log.Logger) (compactor.CompactedIndex, error) {
-	indexFile, err := OpenShippableTSDB(path, nil)
+	indexFile, err := OpenShippableTSDB(path)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (t *tableCompactor) CompactTable() error {
 		}
 
 		downloadPaths[job] = downloadedAt
-		idx, err := OpenShippableTSDB(downloadedAt, nil)
+		idx, err := OpenShippableTSDB(downloadedAt)
 		if err != nil {
 			return err
 		}
@@ -231,7 +231,7 @@ func processSourceIndex(ctx context.Context, sourceIndex storage.IndexFile, sour
 		}
 	}()
 
-	indexFile, err := OpenShippableTSDB(path, nil)
+	indexFile, err := OpenShippableTSDB(path)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
@@ -37,7 +37,7 @@ func (i indexProcessor) NewTableCompactor(ctx context.Context, commonIndexSet co
 }
 
 func (i indexProcessor) OpenCompactedIndexFile(ctx context.Context, path, tableName, userID, workingDir string, periodConfig config.PeriodConfig, logger log.Logger) (compactor.CompactedIndex, error) {
-	indexFile, err := OpenShippableTSDB(path)
+	indexFile, err := OpenShippableTSDB(path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (t *tableCompactor) CompactTable() error {
 		}
 
 		downloadPaths[job] = downloadedAt
-		idx, err := OpenShippableTSDB(downloadedAt)
+		idx, err := OpenShippableTSDB(downloadedAt, nil)
 		if err != nil {
 			return err
 		}
@@ -231,7 +231,7 @@ func processSourceIndex(ctx context.Context, sourceIndex storage.IndexFile, sour
 		}
 	}()
 
-	indexFile, err := OpenShippableTSDB(path)
+	indexFile, err := OpenShippableTSDB(path, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
@@ -121,7 +121,10 @@ type HeadManager struct {
 	flush chan chan error
 }
 
-func NewHeadManager(name string, logger log.Logger, dir string, metrics *Metrics, tsdbManager TSDBManager) *HeadManager {
+// NewHeadManager builds a head manager. chunkFilter may be nil, in which case no
+// filtering is applied. It is handed to every tenantHeads the manager creates, so
+// it never has to be set on an index that queries are already reading.
+func NewHeadManager(name string, chunkFilter chunk.RequestChunkFilterer, logger log.Logger, dir string, metrics *Metrics, tsdbManager TSDBManager) *HeadManager {
 	shards := defaultHeadManagerStripeSize
 	m := &HeadManager{
 		name:        name,
@@ -129,6 +132,7 @@ func NewHeadManager(name string, logger log.Logger, dir string, metrics *Metrics
 		dir:         dir,
 		metrics:     metrics,
 		tsdbManager: tsdbManager,
+		chunkFilter: chunkFilter,
 
 		period: defaultRotationPeriod,
 		shards: shards,
@@ -149,11 +153,7 @@ func NewHeadManager(name string, logger log.Logger, dir string, metrics *Metrics
 			indices = append(indices, m.activeHeads)
 		}
 
-		idx := NewMultiIndex(IndexSlice(indices))
-		if m.chunkFilter != nil {
-			idx.SetChunkFilterer(m.chunkFilter)
-		}
-		return idx, nil
+		return NewMultiIndex(IndexSlice(indices)), nil
 	})
 
 	return m
@@ -280,10 +280,6 @@ func (m *HeadManager) Stop() error {
 	}
 
 	return m.buildTSDBFromHead(m.activeHeads)
-}
-
-func (m *HeadManager) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
-	m.chunkFilter = chunkFilter
 }
 
 func (m *HeadManager) Append(userID string, ls labels.Labels, fprint uint64, chks index.ChunkMetas) error {
@@ -419,7 +415,7 @@ func (m *HeadManager) Rotate(t time.Time) (err error) {
 	}
 
 	// create new tenant heads
-	nextHeads := newTenantHeads(t, m.shards, m.metrics, m.log)
+	nextHeads := newTenantHeads(t, m.shards, m.metrics, m.chunkFilter, m.log)
 
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
@@ -701,14 +697,15 @@ type tenantHeads struct {
 	metrics     *Metrics
 }
 
-func newTenantHeads(start time.Time, shards int, metrics *Metrics, logger log.Logger) *tenantHeads {
+func newTenantHeads(start time.Time, shards int, metrics *Metrics, chunkFilter chunk.RequestChunkFilterer, logger log.Logger) *tenantHeads {
 	res := &tenantHeads{
-		start:   start,
-		shards:  shards,
-		locks:   make([]sync.RWMutex, shards),
-		tenants: make([]map[string]*Head, shards),
-		log:     log.With(logger, "component", "tenant-heads"),
-		metrics: metrics,
+		start:       start,
+		shards:      shards,
+		locks:       make([]sync.RWMutex, shards),
+		tenants:     make([]map[string]*Head, shards),
+		chunkFilter: chunkFilter,
+		log:         log.With(logger, "component", "tenant-heads"),
+		metrics:     metrics,
 	}
 	for i := range res.tenants {
 		res.tenants[i] = make(map[string]*Head)
@@ -783,10 +780,6 @@ func (t *tenantHeads) shardForTenant(userID string) uint64 {
 
 func (t *tenantHeads) Close() error { return nil }
 
-func (t *tenantHeads) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
-	t.chunkFilter = chunkFilter
-}
-
 func (t *tenantHeads) Bounds() (model.Time, model.Time) {
 	return model.Time(t.mint.Load()), model.Time(t.maxt.Load())
 }
@@ -800,11 +793,7 @@ func (t *tenantHeads) tenantIndex(userID string, from, through model.Time) (idx 
 		return
 	}
 
-	idx = NewTSDBIndex(tenant.indexRange(int64(from), int64(through)))
-	if t.chunkFilter != nil {
-		idx.SetChunkFilterer(t.chunkFilter)
-	}
-	return idx, true
+	return NewTSDBIndex(tenant.indexRange(int64(from), int64(through)), t.chunkFilter), true
 
 }
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager_test.go
@@ -40,7 +40,7 @@ func newNoopTSDBManager(name, dir string) noopTSDBManager {
 	return noopTSDBManager{
 		name:        name,
 		dir:         dir,
-		tenantHeads: newTenantHeads(time.Now(), defaultHeadManagerStripeSize, NewMetrics(nil), log.NewNopLogger()),
+		tenantHeads: newTenantHeads(time.Now(), defaultHeadManagerStripeSize, NewMetrics(nil), nil, log.NewNopLogger()),
 	}
 }
 
@@ -118,7 +118,7 @@ func chunkMetasToLogProtoChunkRefs(user string, fp uint64, xs index.ChunkMetas) 
 
 // Test append
 func Test_TenantHeads_Append(t *testing.T) {
-	h := newTenantHeads(time.Now(), defaultHeadManagerStripeSize, NewMetrics(nil), log.NewNopLogger())
+	h := newTenantHeads(time.Now(), defaultHeadManagerStripeSize, NewMetrics(nil), nil, log.NewNopLogger())
 	ls := mustParseLabels(`{foo="bar"}`)
 	chks := []index.ChunkMeta{
 		{
@@ -146,7 +146,7 @@ func Test_TenantHeads_Append(t *testing.T) {
 
 // Test multitenant reads
 func Test_TenantHeads_MultiRead(t *testing.T) {
-	h := newTenantHeads(time.Now(), defaultHeadManagerStripeSize, NewMetrics(nil), log.NewNopLogger())
+	h := newTenantHeads(time.Now(), defaultHeadManagerStripeSize, NewMetrics(nil), nil, log.NewNopLogger())
 	ls := mustParseLabels(`{foo="bar"}`)
 	chks := []index.ChunkMeta{
 		{
@@ -231,7 +231,7 @@ func Test_HeadManager_RecoverHead(t *testing.T) {
 	}
 
 	storeName := "store_2010-10-10"
-	mgr := NewHeadManager(storeName, log.NewNopLogger(), dir, NewMetrics(nil), newNoopTSDBManager(storeName, dir))
+	mgr := NewHeadManager(storeName, nil, log.NewNopLogger(), dir, NewMetrics(nil), newNoopTSDBManager(storeName, dir))
 	// This bit is normally handled by the Start() fn, but we're testing a smaller surface area
 	// so ensure our dirs exist
 	for _, d := range managerRequiredDirs(storeName, dir) {
@@ -364,7 +364,7 @@ func Test_HeadManager_RecoverHead_CorruptedWAL(t *testing.T) {
 			now := time.Now()
 
 			storeName := "store_2010-10-10"
-			mgr := NewHeadManager(storeName, log.NewNopLogger(), dir, NewMetrics(nil), newNoopTSDBManager(storeName, dir))
+			mgr := NewHeadManager(storeName, nil, log.NewNopLogger(), dir, NewMetrics(nil), newNoopTSDBManager(storeName, dir))
 			// This bit is normally handled by the Start() fn, but we're testing a smaller surface area
 			// so ensure our dirs exist
 			for _, d := range managerRequiredDirs(storeName, dir) {
@@ -420,7 +420,7 @@ func Test_HeadManager_QueryAfterRotate(t *testing.T) {
 	}
 
 	storeName := "store_2010-10-10"
-	mgr := NewHeadManager(storeName, log.NewNopLogger(), dir, NewMetrics(nil), newNoopTSDBManager(storeName, dir))
+	mgr := NewHeadManager(storeName, nil, log.NewNopLogger(), dir, NewMetrics(nil), newNoopTSDBManager(storeName, dir))
 	// This bit is normally handled by the Start() fn, but we're testing a smaller surface area
 	// so ensure our dirs exist
 	for _, d := range managerRequiredDirs(storeName, dir) {
@@ -468,7 +468,7 @@ func Test_HeadManager_RotateAndBuild(t *testing.T) {
 
 	storeName := "store_2010-10-10"
 	mgr := newRecordingTSDBManager(storeName, dir)
-	hm := NewHeadManager(storeName, log.NewNopLogger(), dir, NewMetrics(nil), mgr)
+	hm := NewHeadManager(storeName, nil, log.NewNopLogger(), dir, NewMetrics(nil), mgr)
 	for _, d := range managerRequiredDirs(storeName, dir) {
 		require.NoError(t, util.EnsureDirectory(d))
 	}
@@ -504,7 +504,7 @@ func Test_HeadManager_Flush(t *testing.T) {
 	dir := t.TempDir()
 	storeName := "store_2010-10-10"
 	mgr := newRecordingTSDBManager(storeName, dir)
-	hm := NewHeadManager(storeName, log.NewNopLogger(), dir, NewMetrics(nil), mgr)
+	hm := NewHeadManager(storeName, nil, log.NewNopLogger(), dir, NewMetrics(nil), mgr)
 	for _, d := range managerRequiredDirs(storeName, dir) {
 		require.NoError(t, util.EnsureDirectory(d))
 	}
@@ -523,39 +523,50 @@ func Test_HeadManager_Flush(t *testing.T) {
 }
 
 func Test_HeadManager_ChunkFilterer(t *testing.T) {
-	now := time.Now()
-	dir := t.TempDir()
-	storeName := "store_2010-10-10"
-	mgr := NewHeadManager(storeName, log.NewNopLogger(), dir, NewMetrics(nil), newNoopTSDBManager(storeName, dir))
-	for _, d := range managerRequiredDirs(storeName, dir) {
-		require.Nil(t, util.EnsureDirectory(d))
-	}
-	require.Nil(t, mgr.Rotate(now))
-
+	// The filterer is given to the manager at construction, so each case builds its
+	// own. Appending and rotating before querying means the series is read back
+	// through prevHeads, i.e. through a tenantHeads the manager created itself.
 	user := "tenant1"
 	ls := mustParseLabels(`{foo="bar"}`)
-	chks := []index.ChunkMeta{{MinTime: 1, MaxTime: 10, Checksum: 1}}
-	require.Nil(t, mgr.Append(user, ls, labels.StableHash(ls), chks))
-
 	matchAll := labels.MustNewMatcher(labels.MatchRegexp, "foo", ".+")
-	nextPeriod := time.Now().Add(time.Duration(mgr.period))
-	mgr.tick(nextPeriod) // rotate so data moves to prevHeads, queryable via lazy index
 
-	// Confirm data is reachable via GetChunkRefs before testing Series.
-	refs, err := mgr.GetChunkRefs(context.Background(), user, 0, math.MaxInt64, nil, nil, matchAll)
-	require.Nil(t, err)
-	require.Len(t, refs, 1)
+	newManagerWithSeries := func(t *testing.T, chunkFilter chunk.RequestChunkFilterer) *HeadManager {
+		dir := t.TempDir()
+		storeName := "store_2010-10-10"
+		mgr := NewHeadManager(storeName, chunkFilter, log.NewNopLogger(), dir, NewMetrics(nil), newNoopTSDBManager(storeName, dir))
+		for _, d := range managerRequiredDirs(storeName, dir) {
+			require.Nil(t, util.EnsureDirectory(d))
+		}
+		require.Nil(t, mgr.Rotate(time.Now()))
 
-	// Without a filterer, Series returns the appended series.
-	series, err := mgr.Series(context.Background(), user, 0, math.MaxInt64, nil, nil, matchAll)
-	require.Nil(t, err)
-	require.Len(t, series, 1)
+		chks := []index.ChunkMeta{{MinTime: 1, MaxTime: 10, Checksum: 1}}
+		require.Nil(t, mgr.Append(user, ls, labels.StableHash(ls), chks))
 
-	// With a filterAll filterer, Series returns no results.
-	mgr.SetChunkFilterer(&filterAll{})
-	series, err = mgr.Series(context.Background(), user, 0, math.MaxInt64, nil, nil, matchAll)
-	require.Nil(t, err)
-	require.Len(t, series, 0)
+		// rotate so data moves to prevHeads, queryable via lazy index
+		mgr.tick(time.Now().Add(time.Duration(mgr.period)))
+		return mgr
+	}
+
+	t.Run("without a filterer the appended series is returned", func(t *testing.T) {
+		mgr := newManagerWithSeries(t, nil)
+
+		// Confirm data is reachable via GetChunkRefs before testing Series.
+		refs, err := mgr.GetChunkRefs(context.Background(), user, 0, math.MaxInt64, nil, nil, matchAll)
+		require.Nil(t, err)
+		require.Len(t, refs, 1)
+
+		series, err := mgr.Series(context.Background(), user, 0, math.MaxInt64, nil, nil, matchAll)
+		require.Nil(t, err)
+		require.Len(t, series, 1)
+	})
+
+	t.Run("a filterAll filterer filters the series out", func(t *testing.T) {
+		mgr := newManagerWithSeries(t, &filterAll{})
+
+		series, err := mgr.Series(context.Background(), user, 0, math.MaxInt64, nil, nil, matchAll)
+		require.Nil(t, err)
+		require.Len(t, series, 0)
+	})
 }
 
 // test mgr recover from multiple wals across multiple periods
@@ -592,7 +603,7 @@ func Test_HeadManager_Lifecycle(t *testing.T) {
 	}
 
 	storeName := "store_2010-10-10"
-	mgr := NewHeadManager(storeName, log.NewNopLogger(), dir, NewMetrics(nil), newNoopTSDBManager(storeName, dir))
+	mgr := NewHeadManager(storeName, nil, log.NewNopLogger(), dir, NewMetrics(nil), newNoopTSDBManager(storeName, dir))
 	w, err := newHeadWAL(log.NewNopLogger(), walPath(mgr.name, mgr.dir, curPeriod), curPeriod)
 	require.Nil(t, err)
 
@@ -828,7 +839,7 @@ func TestBuildLegacyWALs(t *testing.T) {
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
-				store, stop, err := NewStore(tc.store, "index/", shipperCfg, schemaCfg, nil, fsObjectClient, &zeroValueLimits{}, tc.tableRange, nil, log.NewNopLogger())
+				store, stop, err := NewStore(tc.store, "index/", shipperCfg, schemaCfg, nil, fsObjectClient, &zeroValueLimits{}, tc.tableRange, nil, nil, log.NewNopLogger())
 				require.Nil(t, err)
 				refs, err := store.GetChunkRefs(
 					context.Background(),
@@ -872,7 +883,7 @@ func BenchmarkTenantHeads(b *testing.B) {
 		},
 	} {
 		b.Run(fmt.Sprintf("%d", tc.readers), func(b *testing.B) {
-			heads := newTenantHeads(time.Now(), defaultHeadManagerStripeSize, NewMetrics(nil), log.NewNopLogger())
+			heads := newTenantHeads(time.Now(), defaultHeadManagerStripeSize, NewMetrics(nil), nil, log.NewNopLogger())
 			// 1000 series across 100 tenants
 			nTenants := 10
 			for i := 0; i < 1000; i++ {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index.go
@@ -7,7 +7,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
-	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/sharding"
 )
@@ -21,7 +20,6 @@ type shouldIncludeChunk func(index.ChunkMeta) bool
 
 type Index interface {
 	Bounded
-	SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer)
 	Close() error
 	sharding.ForSeries
 	// GetChunkRefs accepts an optional []ChunkRef argument.
@@ -65,8 +63,6 @@ func (NoopIndex) LabelValues(_ context.Context, _ string, _, _ model.Time, _ str
 func (NoopIndex) Stats(_ context.Context, _ string, _, _ model.Time, _ IndexStatsAccumulator, _ index.FingerprintFilter, _ shouldIncludeChunk, _ ...*labels.Matcher) error {
 	return nil
 }
-
-func (NoopIndex) SetChunkFilterer(_ chunk.RequestChunkFilterer) {}
 
 func (NoopIndex) Volume(_ context.Context, _ string, _, _ model.Time, _ VolumeAccumulator, _ index.FingerprintFilter, _ shouldIncludeChunk, _ []string, _ string, _ ...*labels.Matcher) error {
 	return nil

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index_client.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index_client.go
@@ -333,13 +333,6 @@ func (c *IndexClient) GetShards(ctx context.Context, userID string, from, throug
 	return resp, nil
 }
 
-// SetChunkFilterer sets a chunk filter to be used when retrieving chunks.
-// This is only used for GetSeries implementation.
-// Todo we might want to pass it as a parameter to GetSeries instead.
-func (c *IndexClient) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
-	c.idx.SetChunkFilterer(chunkFilter)
-}
-
 // TODO(owen-d): in the future, handle this by preventing passing the __name__="logs" label
 // to TSDB indices at all.
 func withoutNameLabel(matchers []*labels.Matcher) []*labels.Matcher {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index_client_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index_client_test.go
@@ -54,7 +54,7 @@ func BenchmarkIndexClient_Stats(b *testing.B) {
 
 	tables := map[string][]*TSDBFile{
 		tableRange.PeriodConfig.IndexTables.TableFor(indexStartToday): {
-			BuildIndex(b, tempDir, []LoadableSeries{
+			BuildIndex(b, tempDir, nil, []LoadableSeries{
 				{
 					Labels: mustParseLabels(`{foo="bar"}`),
 					Chunks: buildChunkMetas(int64(indexStartToday), int64(indexStartToday+99)),
@@ -63,7 +63,7 @@ func BenchmarkIndexClient_Stats(b *testing.B) {
 		},
 
 		tableRange.PeriodConfig.IndexTables.TableFor(indexStartYesterday): {
-			BuildIndex(b, tempDir, []LoadableSeries{
+			BuildIndex(b, tempDir, nil, []LoadableSeries{
 				{
 					Labels: mustParseLabels(`{foo="bar"}`),
 					Chunks: buildChunkMetas(int64(indexStartYesterday), int64(indexStartYesterday+99)),
@@ -109,7 +109,7 @@ func TestIndexClient_Stats(t *testing.T) {
 
 	tables := map[string][]*TSDBFile{
 		tableRange.PeriodConfig.IndexTables.TableFor(indexStartToday): {
-			BuildIndex(t, tempDir, []LoadableSeries{
+			BuildIndex(t, tempDir, nil, []LoadableSeries{
 				{
 					Labels: mustParseLabels(`{foo="bar"}`),
 					Chunks: buildChunkMetas(int64(indexStartToday), int64(indexStartToday+99), 10),
@@ -122,7 +122,7 @@ func TestIndexClient_Stats(t *testing.T) {
 		},
 
 		tableRange.PeriodConfig.IndexTables.TableFor(indexStartYesterday): {
-			BuildIndex(t, tempDir, []LoadableSeries{
+			BuildIndex(t, tempDir, nil, []LoadableSeries{
 				{
 					Labels: mustParseLabels(`{foo="bar"}`),
 					Chunks: buildChunkMetas(int64(indexStartYesterday), int64(indexStartYesterday+99), 10),
@@ -238,7 +238,7 @@ func TestIndexClient_Volume(t *testing.T) {
 
 	tables := map[string][]*TSDBFile{
 		tableRange.PeriodConfig.IndexTables.TableFor(indexStartToday): {
-			BuildIndex(t, tempDir, []LoadableSeries{
+			BuildIndex(t, tempDir, nil, []LoadableSeries{
 				{
 					Labels: mustParseLabels(`{foo="bar"}`),
 					Chunks: buildChunkMetas(int64(indexStartToday), int64(indexStartToday+99), 10),
@@ -251,7 +251,7 @@ func TestIndexClient_Volume(t *testing.T) {
 		},
 
 		tableRange.PeriodConfig.IndexTables.TableFor(indexStartYesterday): {
-			BuildIndex(t, tempDir, []LoadableSeries{
+			BuildIndex(t, tempDir, nil, []LoadableSeries{
 				{
 					Labels: mustParseLabels(`{foo="bar"}`),
 					Chunks: buildChunkMetas(int64(indexStartYesterday), int64(indexStartYesterday+99), 10),

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index_client_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index_client_test.go
@@ -76,7 +76,7 @@ func BenchmarkIndexClient_Stats(b *testing.B) {
 		Start:        0,
 		End:          math.MaxInt64,
 		PeriodConfig: &config.PeriodConfig{},
-	})
+	}, nil)
 
 	indexClient := NewIndexClient(idx, IndexClientOptions{UseBloomFilters: true}, &fakeLimits{})
 
@@ -143,7 +143,7 @@ func TestIndexClient_Stats(t *testing.T) {
 		Start:        0,
 		End:          math.MaxInt64,
 		PeriodConfig: &config.PeriodConfig{},
-	})
+	}, nil)
 
 	indexClient := NewIndexClient(idx, IndexClientOptions{UseBloomFilters: true}, &fakeLimits{})
 
@@ -272,7 +272,7 @@ func TestIndexClient_Volume(t *testing.T) {
 		Start:        0,
 		End:          math.MaxInt64,
 		PeriodConfig: &config.PeriodConfig{},
-	})
+	}, nil)
 
 	limits := &fakeLimits{volumeMaxSeries: 5}
 	indexClient := NewIndexClient(idx, IndexClientOptions{UseBloomFilters: true}, limits)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index_shipper_querier.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index_shipper_querier.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
-	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	shipperindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/index"
 	tsdbindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
@@ -23,9 +22,8 @@ type indexShipperIterator interface {
 
 // indexShipperQuerier is used for querying index from the shipper.
 type indexShipperQuerier struct {
-	shipper     indexShipperIterator
-	chunkFilter chunk.RequestChunkFilterer
-	tableRange  config.TableRange
+	shipper    indexShipperIterator
+	tableRange config.TableRange
 }
 
 func newIndexShipperQuerier(shipper indexShipperIterator, tableRange config.TableRange) Index {
@@ -60,12 +58,7 @@ func (i *indexShipperQuerier) indices(ctx context.Context, from, through model.T
 		return nil
 	})
 
-	idx := NewMultiIndex(itr)
-
-	if i.chunkFilter != nil {
-		idx.SetChunkFilterer(i.chunkFilter)
-	}
-	return idx, nil
+	return NewMultiIndex(itr), nil
 }
 
 // TODO(owen-d): how to better implement this?
@@ -73,10 +66,6 @@ func (i *indexShipperQuerier) indices(ctx context.Context, from, through model.T
 // underlying tsdbs, which is safe, but can we optimize this?
 func (i *indexShipperQuerier) Bounds() (model.Time, model.Time) {
 	return 0, math.MaxInt64
-}
-
-func (i *indexShipperQuerier) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
-	i.chunkFilter = chunkFilter
 }
 
 // Close implements Index.Close, but we offload this responsibility

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index_shipper_querier.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index_shipper_querier.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	shipperindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/index"
 	tsdbindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
@@ -22,12 +23,20 @@ type indexShipperIterator interface {
 
 // indexShipperQuerier is used for querying index from the shipper.
 type indexShipperQuerier struct {
-	shipper    indexShipperIterator
-	tableRange config.TableRange
+	shipper     indexShipperIterator
+	tableRange  config.TableRange
+	chunkFilter chunk.RequestChunkFilterer
 }
 
-func newIndexShipperQuerier(shipper indexShipperIterator, tableRange config.TableRange) Index {
-	return &indexShipperQuerier{shipper: shipper, tableRange: tableRange}
+func newIndexShipperQuerier(shipper indexShipperIterator, tableRange config.TableRange, chunkFilter chunk.RequestChunkFilterer) Index {
+	return &indexShipperQuerier{shipper: shipper, tableRange: tableRange, chunkFilter: chunkFilter}
+}
+
+// chunkFiltererBinder is an Index that can return a copy of itself bound to a chunk
+// filterer. Binding returns a copy rather than mutating the receiver because the
+// indices the shipper hands out are cached and shared between concurrent queries.
+type chunkFiltererBinder interface {
+	withChunkFilterer(chunk.RequestChunkFilterer) (Index, error)
 }
 
 type indexIterFunc func(func(context.Context, Index) error) error
@@ -46,6 +55,21 @@ func (i *indexShipperQuerier) indices(ctx context.Context, from, through model.T
 				if !ok {
 					return fmt.Errorf("unexpected shipper index type: %T", idx)
 				}
+
+				// Bind the filterer here rather than where each index is built: this
+				// is the single point where indices the shipper owns enter the read path.
+				if i.chunkFilter != nil {
+					binder, ok := impl.(chunkFiltererBinder)
+					if !ok {
+						return fmt.Errorf("shipper index %T cannot apply a chunk filterer", idx)
+					}
+					filtered, err := binder.withChunkFilterer(i.chunkFilter)
+					if err != nil {
+						return err
+					}
+					impl = filtered
+				}
+
 				if multitenant {
 					impl = NewMultiTenantIndex(impl)
 				}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index_shipper_querier_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index_shipper_querier_test.go
@@ -1,0 +1,63 @@
+package tsdb
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/storage/chunk"
+	"github.com/grafana/loki/v3/pkg/storage/config"
+)
+
+// Test_IndexShipperQuerier_BindsChunkFilterer checks that the filterer is bound
+// where indices enter the read path, not where they are built. The shipper hands out
+// indices from two places -- ones it downloaded and ones built locally and added by
+// the tsdb manager -- and the locally built ones are constructed without a filterer,
+// so binding has to happen here or LBAC filtered series would be served.
+func Test_IndexShipperQuerier_BindsChunkFilterer(t *testing.T) {
+	tableRange := config.TableRange{
+		Start: 0,
+		End:   math.MaxInt64,
+		PeriodConfig: &config.PeriodConfig{
+			IndexTables: config.IndexPeriodicTableConfig{
+				PeriodicTableConfig: config.PeriodicTableConfig{
+					Period: config.ObjectStorageIndexRequiredPeriod,
+				}},
+		},
+	}
+	indexStart := model.TimeFromUnixNano(time.Now().Truncate(config.ObjectStorageIndexRequiredPeriod).UnixNano())
+	matchAll := labels.MustNewMatcher(labels.MatchRegexp, "foo", ".+")
+
+	querySeries := func(t *testing.T, chunkFilter chunk.RequestChunkFilterer) []Series {
+		// Built with no filterer of its own, exactly as the tsdb manager builds the
+		// indices it hands to the shipper.
+		idx := BuildIndex(t, t.TempDir(), nil, []LoadableSeries{
+			{
+				Labels: mustParseLabels(`{foo="bar"}`),
+				Chunks: buildChunkMetas(int64(indexStart), int64(indexStart+99)),
+			},
+		})
+
+		shipper := mockIndexShipperIndexIterator{tables: map[string][]*TSDBFile{
+			tableRange.PeriodConfig.IndexTables.TableFor(indexStart): {idx},
+		}}
+		querier := newIndexShipperQuerier(shipper, tableRange, chunkFilter)
+
+		got, err := querier.Series(context.Background(), "fake", indexStart, indexStart+100, nil, nil, matchAll)
+		require.Nil(t, err)
+		return got
+	}
+
+	t.Run("without a filterer the series is returned", func(t *testing.T) {
+		require.Len(t, querySeries(t, nil), 1)
+	})
+
+	t.Run("a filterAll filterer filters the series out", func(t *testing.T) {
+		require.Len(t, querySeries(t, &filterAll{}), 0)
+	})
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/lazy_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/lazy_index.go
@@ -7,7 +7,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
-	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 )
 
@@ -20,13 +19,6 @@ func (f LazyIndex) Bounds() (model.Time, model.Time) {
 		return 0, 0
 	}
 	return i.Bounds()
-}
-
-func (f LazyIndex) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
-	i, err := f()
-	if err == nil {
-		i.SetChunkFilterer(chunkFilter)
-	}
 }
 
 func (f LazyIndex) Close() error {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/manager.go
@@ -292,7 +292,7 @@ func (m *tsdbManager) BuildFromWALs(t time.Time, ids []WALIdentifier, legacy boo
 
 	level.Debug(m.log).Log("msg", "recovering tenant heads")
 	for _, id := range ids {
-		tmp := newTenantHeads(id.ts, defaultHeadManagerStripeSize, m.metrics, m.log)
+		tmp := newTenantHeads(id.ts, defaultHeadManagerStripeSize, m.metrics, nil, m.log)
 		if err = recoverHead(m.name, m.dir, tmp, []WALIdentifier{id}, legacy, m.log, m.metrics.walCorruptionsRepairs); err != nil {
 			return errors.Wrap(err, "building TSDB from WALs")
 		}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index.go
@@ -12,13 +12,11 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
-	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 )
 
 type MultiIndex struct {
 	iter        IndexIter
-	filterer    chunk.RequestChunkFilterer
 	maxParallel int
 }
 
@@ -98,10 +96,6 @@ func (i *MultiIndex) Bounds() (model.Time, model.Time) {
 	return lowest, highest
 }
 
-func (i *MultiIndex) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
-	i.filterer = chunkFilter
-}
-
 func (i *MultiIndex) Close() error {
 	return i.forMatchingIndices(
 		context.Background(),
@@ -117,15 +111,6 @@ func (i *MultiIndex) forMatchingIndices(ctx context.Context, from, through model
 
 	return i.iter.For(ctx, i.maxParallel, func(ctx context.Context, idx Index) error {
 		if Overlap(idx, queryBounds) {
-
-			if i.filterer != nil {
-				// TODO(owen-d): Find a nicer way
-				// to handle filterer passing. Doing it
-				// in the read path rather than during instantiation
-				// feels bad :(
-				idx.SetChunkFilterer(i.filterer)
-			}
-
 			return f(ctx, idx)
 		}
 		return nil

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/multi_file_index_test.go
@@ -62,7 +62,7 @@ func TestMultiIndex(t *testing.T) {
 	var indices []Index
 	dir := t.TempDir()
 	for i := 0; i < n; i++ {
-		indices = append(indices, BuildIndex(t, dir, cases))
+		indices = append(indices, BuildIndex(t, dir, nil, cases))
 	}
 
 	idx := NewMultiIndex(IndexSlice(indices))

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/multitenant.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/multitenant.go
@@ -8,7 +8,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
-	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 )
 
@@ -39,10 +38,6 @@ func withoutTenantLabel(ls labels.Labels) labels.Labels {
 }
 
 func (m *MultiTenantIndex) Bounds() (model.Time, model.Time) { return m.idx.Bounds() }
-
-func (m *MultiTenantIndex) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
-	m.idx.SetChunkFilterer(chunkFilter)
-}
 
 func (m *MultiTenantIndex) Close() error { return m.idx.Close() }
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
@@ -28,20 +28,17 @@ var ErrAlreadyOnDesiredVersion = errors.New("tsdb file already on desired versio
 // GetRawFileReaderFunc returns an io.ReadSeeker for reading raw tsdb file from disk
 type GetRawFileReaderFunc func() (io.ReadSeeker, error)
 
-// OpenShippableTSDB opens the index stored at p. chunkFilter, which may be nil,
-// is handed to the index so that it is construction data rather than something set
-// on a shared index while queries are reading it.
-func OpenShippableTSDB(p string, chunkFilter chunk.RequestChunkFilterer) (shipperindex.Index, error) {
+func OpenShippableTSDB(p string) (shipperindex.Index, error) {
 	id, err := identifierFromPath(p)
 	if err != nil {
 		return nil, err
 	}
 
-	return newShippableTSDBFile(id, chunkFilter)
+	return NewShippableTSDBFile(id)
 }
 
 func RebuildWithVersion(ctx context.Context, path string, desiredVer int) (shipperindex.Index, error) {
-	indexFile, err := OpenShippableTSDB(path, nil)
+	indexFile, err := OpenShippableTSDB(path)
 	if err != nil {
 		return nil, err
 	}
@@ -98,11 +95,7 @@ type TSDBFile struct {
 }
 
 func NewShippableTSDBFile(id Identifier) (*TSDBFile, error) {
-	return newShippableTSDBFile(id, nil)
-}
-
-func newShippableTSDBFile(id Identifier, chunkFilter chunk.RequestChunkFilterer) (*TSDBFile, error) {
-	idx, getRawFileReader, err := newTSDBIndexFromFile(id.Path(), chunkFilter)
+	idx, getRawFileReader, err := NewTSDBIndexFromFile(id.Path())
 	if err != nil {
 		return nil, err
 	}
@@ -112,6 +105,18 @@ func newShippableTSDBFile(id Identifier, chunkFilter chunk.RequestChunkFilterer)
 		Index:            idx,
 		getRawFileReader: getRawFileReader,
 	}, err
+}
+
+// withChunkFilterer binds the filterer to the underlying index. A TSDBFile always
+// wraps a TSDBIndex, so failing to bind means the wrapped index would answer
+// queries unfiltered, which for LBAC would leak data; report it rather than
+// silently skipping the filter.
+func (f *TSDBFile) withChunkFilterer(chunkFilter chunk.RequestChunkFilterer) (Index, error) {
+	binder, ok := f.Index.(chunkFiltererBinder)
+	if !ok {
+		return nil, fmt.Errorf("index %T wrapped by TSDBFile cannot apply a chunk filterer", f.Index)
+	}
+	return binder.withChunkFilterer(chunkFilter)
 }
 
 func (f *TSDBFile) Close() error {
@@ -134,16 +139,12 @@ type TSDBIndex struct {
 // Return the index as well as the underlying raw file reader which isn't exposed as an index
 // method but is helpful for building an io.reader for the index shipper
 func NewTSDBIndexFromFile(location string) (*TSDBIndex, GetRawFileReaderFunc, error) {
-	return newTSDBIndexFromFile(location, nil)
-}
-
-func newTSDBIndexFromFile(location string, chunkFilter chunk.RequestChunkFilterer) (*TSDBIndex, GetRawFileReaderFunc, error) {
 	reader, err := index.NewFileReader(location)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return NewTSDBIndex(reader, chunkFilter), func() (io.ReadSeeker, error) {
+	return NewTSDBIndex(reader, nil), func() (io.ReadSeeker, error) {
 		return reader.RawFileReader()
 	}, nil
 }
@@ -155,6 +156,15 @@ func NewTSDBIndex(reader IndexReader, chunkFilter chunk.RequestChunkFilterer) *T
 		reader:      reader,
 		chunkFilter: chunkFilter,
 	}
+}
+
+// withChunkFilterer returns a copy of the index bound to chunkFilter, sharing the
+// same reader. Indices are cached and shared between concurrent queries, so a
+// filterer is bound by copying rather than by mutating the shared index.
+func (i *TSDBIndex) withChunkFilterer(chunkFilter chunk.RequestChunkFilterer) (Index, error) {
+	cpy := *i
+	cpy.chunkFilter = chunkFilter
+	return &cpy, nil
 }
 
 func (i *TSDBIndex) Close() error {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
@@ -28,17 +28,20 @@ var ErrAlreadyOnDesiredVersion = errors.New("tsdb file already on desired versio
 // GetRawFileReaderFunc returns an io.ReadSeeker for reading raw tsdb file from disk
 type GetRawFileReaderFunc func() (io.ReadSeeker, error)
 
-func OpenShippableTSDB(p string) (shipperindex.Index, error) {
+// OpenShippableTSDB opens the index stored at p. chunkFilter, which may be nil,
+// is handed to the index so that it is construction data rather than something set
+// on a shared index while queries are reading it.
+func OpenShippableTSDB(p string, chunkFilter chunk.RequestChunkFilterer) (shipperindex.Index, error) {
 	id, err := identifierFromPath(p)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewShippableTSDBFile(id)
+	return newShippableTSDBFile(id, chunkFilter)
 }
 
 func RebuildWithVersion(ctx context.Context, path string, desiredVer int) (shipperindex.Index, error) {
-	indexFile, err := OpenShippableTSDB(path)
+	indexFile, err := OpenShippableTSDB(path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +98,11 @@ type TSDBFile struct {
 }
 
 func NewShippableTSDBFile(id Identifier) (*TSDBFile, error) {
-	idx, getRawFileReader, err := NewTSDBIndexFromFile(id.Path())
+	return newShippableTSDBFile(id, nil)
+}
+
+func newShippableTSDBFile(id Identifier, chunkFilter chunk.RequestChunkFilterer) (*TSDBFile, error) {
+	idx, getRawFileReader, err := newTSDBIndexFromFile(id.Path(), chunkFilter)
 	if err != nil {
 		return nil, err
 	}
@@ -127,19 +134,26 @@ type TSDBIndex struct {
 // Return the index as well as the underlying raw file reader which isn't exposed as an index
 // method but is helpful for building an io.reader for the index shipper
 func NewTSDBIndexFromFile(location string) (*TSDBIndex, GetRawFileReaderFunc, error) {
+	return newTSDBIndexFromFile(location, nil)
+}
+
+func newTSDBIndexFromFile(location string, chunkFilter chunk.RequestChunkFilterer) (*TSDBIndex, GetRawFileReaderFunc, error) {
 	reader, err := index.NewFileReader(location)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return NewTSDBIndex(reader), func() (io.ReadSeeker, error) {
+	return NewTSDBIndex(reader, chunkFilter), func() (io.ReadSeeker, error) {
 		return reader.RawFileReader()
 	}, nil
 }
 
-func NewTSDBIndex(reader IndexReader) *TSDBIndex {
+// NewTSDBIndex builds an index over reader. chunkFilter may be nil, in which case
+// no filtering is applied.
+func NewTSDBIndex(reader IndexReader, chunkFilter chunk.RequestChunkFilterer) *TSDBIndex {
 	return &TSDBIndex{
-		reader: reader,
+		reader:      reader,
+		chunkFilter: chunkFilter,
 	}
 }
 
@@ -152,8 +166,13 @@ func (i *TSDBIndex) Bounds() (model.Time, model.Time) {
 	return model.Time(from), model.Time(through)
 }
 
-func (i *TSDBIndex) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
-	i.chunkFilter = chunkFilter
+// filtererForRequest resolves the index's filterer for this request, or nil if
+// there is nothing to filter by.
+func (i *TSDBIndex) filtererForRequest(ctx context.Context) chunk.Filterer {
+	if i.chunkFilter == nil {
+		return nil
+	}
+	return i.chunkFilter.ForRequest(ctx)
 }
 
 // fn must NOT capture it's arguments. They're reused across series iterations and returned to
@@ -162,10 +181,7 @@ func (i *TSDBIndex) SetChunkFilterer(chunkFilter chunk.RequestChunkFilterer) {
 // Accepts a userID argument in order to implement `Index` interface, but since this is a single tenant index,
 // it is ignored (it's enforced elsewhere in index selection)
 func (i *TSDBIndex) ForSeries(ctx context.Context, _ string, fpFilter index.FingerprintFilter, from model.Time, through model.Time, fn func(labels.Labels, model.Fingerprint, []index.ChunkMeta) (stop bool), matchers ...*labels.Matcher) error {
-	var filterer chunk.Filterer
-	if i.chunkFilter != nil {
-		filterer = i.chunkFilter.ForRequest(ctx)
-	}
+	filterer := i.filtererForRequest(ctx)
 	return i.forSeriesAndLabels(ctx, fpFilter, filterer, from, through, fn, matchers...)
 }
 
@@ -263,10 +279,7 @@ func (i *TSDBIndex) GetChunkRefs(ctx context.Context, userID string, from, throu
 		return false
 	}
 
-	var filterer chunk.Filterer
-	if i.chunkFilter != nil {
-		filterer = i.chunkFilter.ForRequest(ctx)
-	}
+	filterer := i.filtererForRequest(ctx)
 	var err error
 	if filterer != nil {
 		// We need to fetch labels to pass to the filterer, even though we don't look at them in the callback.
@@ -341,14 +354,11 @@ func (i *TSDBIndex) Stats(ctx context.Context, _ string, from, through model.Tim
 	return i.forPostings(ctx, fpFilter, from, through, matchers, func(p index.Postings) error {
 		// TODO(owen-d): use pool
 		var ls labels.Labels
-		var filterer chunk.Filterer
 		by := make(map[string]struct{})
-		if i.chunkFilter != nil {
-			filterer = i.chunkFilter.ForRequest(ctx)
-			if filterer != nil {
-				for _, k := range filterer.RequiredLabelNames() {
-					by[k] = struct{}{}
-				}
+		filterer := i.filtererForRequest(ctx)
+		if filterer != nil {
+			for _, k := range filterer.RequiredLabelNames() {
+				by[k] = struct{}{}
 			}
 		}
 
@@ -418,10 +428,7 @@ func (i *TSDBIndex) Volume(
 
 	aggregateBySeries := seriesvolume.AggregateBySeries(aggregateBy) || aggregateBy == ""
 	var by map[string]struct{}
-	var filterer chunk.Filterer
-	if i.chunkFilter != nil {
-		filterer = i.chunkFilter.ForRequest(ctx)
-	}
+	filterer := i.filtererForRequest(ctx)
 	if !includeAll && (aggregateBySeries || len(targetLabels) > 0) {
 		by = make(map[string]struct{}, len(labelsToMatch))
 		for k := range labelsToMatch {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index_test.go
@@ -71,7 +71,7 @@ func TestSingleIdx(t *testing.T) {
 		{
 			desc: "file",
 			fn: func() Index {
-				return BuildIndex(t, t.TempDir(), cases)
+				return BuildIndex(t, t.TempDir(), nil, cases)
 			},
 		},
 		{
@@ -82,7 +82,7 @@ func TestSingleIdx(t *testing.T) {
 					_, _ = head.Append(x.Labels, labels.StableHash(x.Labels), x.Chunks)
 				}
 				reader := head.Index()
-				return NewTSDBIndex(reader)
+				return NewTSDBIndex(reader, nil)
 			},
 		},
 	} {
@@ -243,7 +243,7 @@ func BenchmarkTSDBIndex_GetChunkRefs(b *testing.B) {
 	}
 
 	tempDir := b.TempDir()
-	tsdbIndex := BuildIndex(b, tempDir, []LoadableSeries{
+	tsdbIndex := BuildIndex(b, tempDir, nil, []LoadableSeries{
 		{
 			Labels: mustParseLabels(`{foo="bar", fizz="buzz"}`),
 			Chunks: chunkMetas,
@@ -312,7 +312,7 @@ func TestTSDBIndex_Stats(t *testing.T) {
 
 	// Create the TSDB index
 	tempDir := t.TempDir()
-	tsdbIndex := BuildIndex(t, tempDir, series)
+	tsdbIndex := BuildIndex(t, tempDir, nil, series)
 
 	// Create the test cases
 	testCases := []struct {
@@ -446,7 +446,7 @@ func TestTSDBIndex_Volume(t *testing.T) {
 
 	// Create the TSDB index
 	tempDir := t.TempDir()
-	tsdbIndex := BuildIndex(t, tempDir, series)
+	tsdbIndex := BuildIndex(t, tempDir, nil, series)
 
 	from := model.TimeFromUnixNano(t1.UnixNano())
 	through := model.TimeFromUnixNano(t2.UnixNano())
@@ -526,8 +526,7 @@ func TestTSDBIndex_Volume(t *testing.T) {
 		})
 
 		t.Run("it can filter chunks", func(t *testing.T) {
-			tsdbIndex.SetChunkFilterer(&filterAll{})
-			defer tsdbIndex.SetChunkFilterer(nil)
+			tsdbIndex := BuildIndex(t, t.TempDir(), &filterAll{}, series)
 
 			matcher := labels.MustNewMatcher(labels.MatchEqual, "", "")
 			acc := seriesvolume.NewAccumulator(10, 10)
@@ -683,8 +682,7 @@ func TestTSDBIndex_Volume(t *testing.T) {
 		})
 
 		t.Run("it can filter chunks", func(t *testing.T) {
-			tsdbIndex.SetChunkFilterer(&filterAll{})
-			defer tsdbIndex.SetChunkFilterer(nil)
+			tsdbIndex := BuildIndex(t, t.TempDir(), &filterAll{}, series)
 
 			matcher := labels.MustNewMatcher(labels.MatchEqual, "", "")
 			acc := seriesvolume.NewAccumulator(10, 10)
@@ -785,7 +783,7 @@ func BenchmarkTSDBIndex_Volume(b *testing.B) {
 	through := model.Latest
 	// Create the TSDB index
 	tempDir := b.TempDir()
-	tsdbIndex := BuildIndex(b, tempDir, series)
+	tsdbIndex := BuildIndex(b, tempDir, nil, series)
 
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/store.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/store.go
@@ -20,7 +20,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/index"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads"
-	shipperindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/index"
 	tsdbindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 )
 
@@ -75,9 +74,7 @@ func (s *store) init(name, prefix string, indexShipperCfg indexshipper.Config, s
 		objectClient,
 		limits,
 		nil,
-		func(p string) (shipperindex.Index, error) {
-			return OpenShippableTSDB(p, chunkFilter)
-		},
+		OpenShippableTSDB,
 		tableRange,
 		prometheus.WrapRegistererWithPrefix("loki_tsdb_shipper_", reg),
 		s.logger,
@@ -142,7 +139,7 @@ func (s *store) init(name, prefix string, indexShipperCfg indexshipper.Config, s
 		s.indexWriter = failingIndexWriter{}
 	}
 
-	indices = append(indices, newIndexShipperQuerier(s.indexShipper, tableRange))
+	indices = append(indices, newIndexShipperQuerier(s.indexShipper, tableRange, chunkFilter))
 	multiIndex := NewMultiIndex(IndexSlice(indices))
 
 	s.Reader = NewIndexClient(multiIndex, opts, limits)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/store.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/store.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/index"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads"
+	shipperindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/index"
 	tsdbindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 )
 
@@ -44,6 +45,7 @@ func NewStore(
 	objectClient client.ObjectClient,
 	limits downloads.Limits,
 	tableRange config.TableRange,
+	chunkFilter chunk.RequestChunkFilterer,
 	reg prometheus.Registerer,
 	logger log.Logger,
 ) (
@@ -56,7 +58,7 @@ func NewStore(
 		logger: logger,
 	}
 
-	if err := storeInstance.init(name, prefix, indexShipperCfg, schemaCfg, objectClient, limits, tableRange, reg); err != nil {
+	if err := storeInstance.init(name, prefix, indexShipperCfg, schemaCfg, objectClient, limits, tableRange, chunkFilter, reg); err != nil {
 		return nil, nil, err
 	}
 
@@ -64,7 +66,7 @@ func NewStore(
 }
 
 func (s *store) init(name, prefix string, indexShipperCfg indexshipper.Config, schemaCfg config.SchemaConfig, objectClient client.ObjectClient,
-	limits downloads.Limits, tableRange config.TableRange, reg prometheus.Registerer) error {
+	limits downloads.Limits, tableRange config.TableRange, chunkFilter chunk.RequestChunkFilterer, reg prometheus.Registerer) error {
 
 	var err error
 	s.indexShipper, err = indexshipper.NewIndexShipper(
@@ -73,7 +75,9 @@ func (s *store) init(name, prefix string, indexShipperCfg indexshipper.Config, s
 		objectClient,
 		limits,
 		nil,
-		OpenShippableTSDB,
+		func(p string) (shipperindex.Index, error) {
+			return OpenShippableTSDB(p, chunkFilter)
+		},
 		tableRange,
 		prometheus.WrapRegistererWithPrefix("loki_tsdb_shipper_", reg),
 		s.logger,
@@ -122,6 +126,7 @@ func (s *store) init(name, prefix string, indexShipperCfg indexshipper.Config, s
 
 		headManager := NewHeadManager(
 			name,
+			chunkFilter,
 			s.logger,
 			indexShipperCfg.ActiveIndexDirectory,
 			tsdbMetrics,

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/util_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/util_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 )
 
@@ -17,7 +18,9 @@ type LoadableSeries struct {
 	Chunks index.ChunkMetas
 }
 
-func BuildIndex(t testing.TB, dir string, cases []LoadableSeries) *TSDBFile {
+// BuildIndex builds an index over cases. chunkFilter may be nil, in which case the
+// index applies no filtering.
+func BuildIndex(t testing.TB, dir string, chunkFilter chunk.RequestChunkFilterer, cases []LoadableSeries) *TSDBFile {
 	b := NewBuilder(index.FormatV3)
 
 	for _, s := range cases {
@@ -35,7 +38,7 @@ func BuildIndex(t testing.TB, dir string, cases []LoadableSeries) *TSDBFile {
 	})
 	require.Nil(t, err)
 
-	idx, err := NewShippableTSDBFile(dst)
+	idx, err := newShippableTSDBFile(dst, chunkFilter)
 	require.Nil(t, err)
 	return idx
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/util_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/util_test.go
@@ -38,7 +38,12 @@ func BuildIndex(t testing.TB, dir string, chunkFilter chunk.RequestChunkFilterer
 	})
 	require.Nil(t, err)
 
-	idx, err := newShippableTSDBFile(dst, chunkFilter)
+	idx, err := NewShippableTSDBFile(dst)
 	require.Nil(t, err)
+	if chunkFilter != nil {
+		bound, err := idx.withChunkFilterer(chunkFilter)
+		require.Nil(t, err)
+		idx.Index = bound
+	}
 	return idx
 }

--- a/pkg/storage/util_test.go
+++ b/pkg/storage/util_test.go
@@ -165,10 +165,10 @@ func newSampleQuery(query string, start, end time.Time, shards []astmapper.Shard
 }
 
 type mockChunkStore struct {
-	schemas config.SchemaConfig
-	chunks  []chunk.Chunk
-	client  *mockChunkStoreClient
-	f       chunk.RequestChunkFilterer
+	schemas       config.SchemaConfig
+	chunks        []chunk.Chunk
+	client        *mockChunkStoreClient
+	chunkFilterer chunk.RequestChunkFilterer
 }
 
 // mockChunkStore cannot implement both chunk.Store and chunk.Client,
@@ -178,12 +178,12 @@ var (
 	_ chunkclient.Client = &mockChunkStoreClient{}
 )
 
-func newMockChunkStore(chunkFormat byte, headfmt chunkenc.HeadBlockFmt, streams []*logproto.Stream) *mockChunkStore {
+func newMockChunkStore(chunkFormat byte, headfmt chunkenc.HeadBlockFmt, chunkFilterer chunk.RequestChunkFilterer, streams []*logproto.Stream) *mockChunkStore {
 	chunks := make([]chunk.Chunk, 0, len(streams))
 	for _, s := range streams {
 		chunks = append(chunks, newChunk(chunkFormat, headfmt, *s))
 	}
-	return &mockChunkStore{schemas: config.SchemaConfig{}, chunks: chunks, client: &mockChunkStoreClient{chunks: chunks, scfg: config.SchemaConfig{}}}
+	return &mockChunkStore{schemas: config.SchemaConfig{}, chunks: chunks, chunkFilterer: chunkFilterer, client: &mockChunkStoreClient{chunks: chunks, scfg: config.SchemaConfig{}}}
 }
 
 func (m *mockChunkStore) Put(_ context.Context, _ []chunk.Chunk) error { return nil }
@@ -203,8 +203,8 @@ Outer:
 				}
 			}
 			l := labels.NewBuilder(c.Metric).Del(model.MetricNameLabel).Labels()
-			if m.f != nil {
-				if m.f.ForRequest(ctx).ShouldFilter(l) {
+			if m.chunkFilterer != nil {
+				if m.chunkFilterer.ForRequest(ctx).ShouldFilter(l) {
 					continue
 				}
 			}
@@ -223,10 +223,6 @@ func (m *mockChunkStore) LabelValuesForMetricName(_ context.Context, _ string, _
 
 func (m *mockChunkStore) LabelNamesForMetricName(_ context.Context, _ string, _, _ model.Time, _ string, _ ...*labels.Matcher) ([]string, error) {
 	return nil, nil
-}
-
-func (m *mockChunkStore) SetChunkFilterer(f chunk.RequestChunkFilterer) {
-	m.f = f
 }
 
 func (m *mockChunkStore) DeleteChunk(_ context.Context, _, _ model.Time, _, _ string, _ labels.Labels, _ *model.Interval) error {
@@ -412,4 +408,3 @@ var streamsFixture = []*logproto.Stream{
 		},
 	},
 }
-var storeFixture = newMockChunkStore(chunkenc.ChunkFormatV3, chunkenc.UnorderedWithStructuredMetadataHeadBlockFmt, streamsFixture)

--- a/tools/tsdb/index-analyzer/main.go
+++ b/tools/tsdb/index-analyzer/main.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/storage"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
-	shipperindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/index"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/tools/tsdb/helpers"
@@ -34,9 +33,7 @@ func main() {
 		objectClient,
 		overrides,
 		nil,
-		func(p string) (shipperindex.Index, error) {
-			return tsdb.OpenShippableTSDB(p, nil)
-		},
+		tsdb.OpenShippableTSDB,
 		tableRange,
 		prometheus.WrapRegistererWithPrefix("loki_tsdb_shipper_", prometheus.DefaultRegisterer),
 		util_log.Logger,

--- a/tools/tsdb/index-analyzer/main.go
+++ b/tools/tsdb/index-analyzer/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/storage"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
+	shipperindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/index"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/tools/tsdb/helpers"
@@ -33,7 +34,9 @@ func main() {
 		objectClient,
 		overrides,
 		nil,
-		tsdb.OpenShippableTSDB,
+		func(p string) (shipperindex.Index, error) {
+			return tsdb.OpenShippableTSDB(p, nil)
+		},
 		tableRange,
 		prometheus.WrapRegistererWithPrefix("loki_tsdb_shipper_", prometheus.DefaultRegisterer),
 		util_log.Logger,


### PR DESCRIPTION
**What this PR does / why we need it**:

`MultiIndex.forMatchingIndices` set the chunk filterer on every index it iterated, from inside parallel errgroup goroutines:

```go
if i.filterer != nil {
    // TODO(owen-d): Find a nicer way
    // to handle filterer passing. Doing it
    // in the read path rather than during instantiation
    // feels bad :(
    idx.SetChunkFilterer(i.filterer)
}
```

Those indices are long lived and shared between concurrent queries, so that write raced with readers. The integration suite under `-race` reported it 16 times, against `indexShipperQuerier`, `tenantHeads` and `HeadManager`.

The filterer is a process-wide singleton: `initStoreChunkFilterer` builds one stateless `labelaccess.RequestChunkFilterer{}` and all per-request behaviour comes from `ForRequest(ctx)`, which reads LBAC state out of the context. So re-broadcasting it on every read carried no information. It only existed because the leaf indices are created lazily, and every one of those creation sites already has the filterer in hand. It is now passed down from the store as construction data, and the read-path broadcast is deleted rather than made safe.

That removes the need for a mutable setter, so `SetChunkFilterer` is gone from the tsdb `Index` interface, from the index side `Filterable` chain, and from `LokiStore` — whose own chunk level filterer now comes from `Config.ChunkFilterer`. Net effect is a deletion: +163/-227.

It also closes a second hazard of the same family: `headManager.Start()` runs before the filterer used to be set, so the rotation loop creating a `tenantHeads` could race that write too. As construction data that is now impossible rather than needing a lock.

**Which issue(s) this PR fixes**:

Related to #8586

This is the last data race blocking #23653, which enables `-race` for the integration tests. #23654 and #23644 are the other two.

**Special notes for your reviewer**:

**This needs a small coordinated change in enterprise-logs.** GEL keeps its own LBAC copy and calls the removed method in `pkg/enterprise/loki/init`:

```go
// added_modules.go — set it on the config instead of on the store
func (l *LokiEnterprise) initStoreChunkFilterer() (services.Service, error) {
	_ = level.Debug(util_log.Logger).Log("msg", "initializing store chunk filterer")
	l.Loki.Cfg.StorageConfig.ChunkFilterer = &labelaccess.RequestChunkFilterer{}
	return nil, nil
}

// loki.go — Store must now be built after the filterer is on the config
err := l.Loki.ModuleManager.AddDependency(loki.Store, LabelAccess)
```

I verified those two changes locally: GEL builds against this branch and its `pkg/enterprise/loki/labelaccess` and `pkg/enterprise/loki/init` tests pass.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)