### PR TITLE
chore: Remove the unused "cache_lookups_older_than" setting

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -81,6 +81,7 @@ As a result, the following have been removed:
 - The setting `-store.index-cache-write` (`chunk_store_config.write_dedupe_cache_config` block in the yaml file) has been removed as it was only used for legacy storage backends that have been removed as well.
 - The setting `-store.index-cache-read` (`storage_config.index_queries_cache_config` block in the yaml file) has been removed as it was only used for legacy storage backends (`boltdb-shipper`) that have been removed as well.
 - The setting `-store.index-cache-validity` (`storage_config.index_cache_validity` block in the yaml file) has been removed as it was only used in combination with the removed `-store.index-cache-read` setting.
+- The setting `-store.cache-lookups-older-than` (`chunk_store_config.cache_lookups_older_than` in the yaml file) has been removed as it was only used to cache index entries for legacy storage backends that have been removed as well. It has had no effect since the index read cache was removed.
 
 Use the `deprecated-config-checker` tool to validate your `config.yaml`.
 

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -81,7 +81,7 @@ As a result, the following have been removed:
 - The setting `-store.index-cache-write` (`chunk_store_config.write_dedupe_cache_config` block in the yaml file) has been removed as it was only used for legacy storage backends that have been removed as well.
 - The setting `-store.index-cache-read` (`storage_config.index_queries_cache_config` block in the yaml file) has been removed as it was only used for legacy storage backends (`boltdb-shipper`) that have been removed as well.
 - The setting `-store.index-cache-validity` (`storage_config.index_cache_validity` block in the yaml file) has been removed as it was only used in combination with the removed `-store.index-cache-read` setting.
-- The setting `-store.cache-lookups-older-than` (`chunk_store_config.cache_lookups_older_than` in the yaml file) has been removed as it was only used to cache index entries for legacy storage backends that have been removed as well. It has had no effect since the index read cache was removed.
+- The setting `-store.cache-lookups-older-than` (`chunk_store_config.cache_lookups_older_than` in the yaml file) has been removed as it was only used to cache index entries for legacy storage backends that have been removed as well.
 
 Use the `deprecated-config-checker` tool to validate your `config.yaml`.
 

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -2732,10 +2732,6 @@ The `chunk_store_config` block configures how chunks will be cached and how long
 # cache.
 # CLI flag: -store.chunks-cache-l2.handoff
 [l2_chunk_cache_handoff: <duration> | default = 0s]
-
-# Cache index entries older than this period. 0 to disable.
-# CLI flag: -store.cache-lookups-older-than
-[cache_lookups_older_than: <duration> | default = 0s]
 ```
 
 ### common

--- a/pkg/storage/config/store.go
+++ b/pkg/storage/config/store.go
@@ -4,8 +4,6 @@ import (
 	"flag"
 	"time"
 
-	"github.com/prometheus/common/model"
-
 	"github.com/grafana/loki/v3/pkg/storage/chunk/cache"
 )
 
@@ -14,8 +12,7 @@ type ChunkStoreConfig struct {
 	ChunkCacheConfigL2          cache.Config  `yaml:"chunk_cache_config_l2"`
 	SkipQueryWritebackOlderThan time.Duration `yaml:"skip_query_writeback_cache_older_than"`
 
-	L2ChunkCacheHandoff   time.Duration  `yaml:"l2_chunk_cache_handoff"`
-	CacheLookupsOlderThan model.Duration `yaml:"cache_lookups_older_than"`
+	L2ChunkCacheHandoff time.Duration `yaml:"l2_chunk_cache_handoff"`
 
 	// Not visible in yaml because the setting shouldn't be common between ingesters and queriers.
 	// This exists in case we don't want to cache all the chunks but still want to take advantage of
@@ -38,8 +35,6 @@ func (cfg *ChunkStoreConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.L2ChunkCacheHandoff, "store.chunks-cache-l2.handoff", 0, "Chunks will be handed off to the L2 cache after this duration. 0 to disable L2 cache.")
 	f.BoolVar(&cfg.chunkCacheStubs, "store.chunks-cache.cache-stubs", false, "If true, don't write the full chunk to cache, just a stub entry.")
 	f.DurationVar(&cfg.SkipQueryWritebackOlderThan, "store.skip-query-writeback-older-than", 0, "Chunks fetched from queriers before this duration will not be written to the cache. A value of 0 will write all chunks to the cache")
-
-	f.Var(&cfg.CacheLookupsOlderThan, "store.cache-lookups-older-than", "Cache index entries older than this period. 0 to disable.")
 }
 
 func (cfg *ChunkStoreConfig) Validate() error {

--- a/tools/deprecated-config-checker/checker/checker_test.go
+++ b/tools/deprecated-config-checker/checker/checker_test.go
@@ -37,6 +37,7 @@ var (
 		"compactor.shared_store",
 		"compactor.shared_store_key_prefix",
 		"chunk_store_config.write_dedupe_cache_config",
+		"chunk_store_config.cache_lookups_older_than",
 		"limits_config.unordered_writes",
 		"limits_config.enforce_metric_name",
 		"limits_config.ruler_evaluation_delay_duration",

--- a/tools/deprecated-config-checker/deleted-config.yaml
+++ b/tools/deprecated-config-checker/deleted-config.yaml
@@ -89,6 +89,7 @@ compactor:
 chunk_store_config:
   max_look_back_period: "Use global or per-tenant max_query_lookback configuration from limits_config."
   write_dedupe_cache_config: "Write dedupe cache is removed along with deprecated index types."
+  cache_lookups_older_than: "Index entry caching is removed along with deprecated index types."
 
 limits_config:
   unordered_writes: "This setting is removed."

--- a/tools/deprecated-config-checker/test-fixtures/config.yaml
+++ b/tools/deprecated-config-checker/test-fixtures/config.yaml
@@ -48,7 +48,7 @@ compactor:
   deletion_mode: "delete" # DELETED
 
 chunk_store_config:
-  cache_lookups_older_than: 1h
+  cache_lookups_older_than: 1h # DELETED
   write_dedupe_cache_config: # DEPRECATED
     default_validity: 30m
   max_look_back_period: 1m # DELETED


### PR DESCRIPTION
**What this PR does / why we need it**:

`-store.cache-lookups-older-than` configured caching of index entries. Its last read was deleted in #21986 along with the legacy index types, so the setting has been silently ignored ever since, while remaining registered as a flag and documented in the config reference.

#22066 removed the sibling index-cache settings (`-store.index-cache-read`, `-store.index-cache-validity`) a week later and gave them the `deleted-config.yaml` + upgrade-note treatment. This one was missed, so it gets the same treatment here.

**Special notes for your reviewer**:

N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory