### PR TITLE
feat: Introduce tsdb.shipper.index-reader-mode feature flag

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -6859,6 +6859,12 @@ tsdb_shipper:
   # CLI flag: -tsdb.shipper.download-timeout
   [download_timeout: <duration> | default = 1m]
 
+  # Experimental. Implementation used to read TSDB index files off disk.
+  # Supported values: mmap (memory-map the file, the historical default) or
+  # stream (experimental, not yet fully implemented).
+  # CLI flag: -tsdb.shipper.index-reader-mode
+  [index_reader_mode: <string> | default = "mmap"]
+
   index_gateway_client:
     # The grpc_client block configures the gRPC client used to communicate
     # between a client and server component in Loki.

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -6870,6 +6870,12 @@ tsdb_shipper:
   # CLI flag: -tsdb.shipper.download-timeout
   [download_timeout: <duration> | default = 1m]
 
+  # Experimental. Implementation used to read TSDB index files off disk.
+  # Supported values: mmap (memory-map the file, the historical default) or
+  # stream (experimental, not yet fully implemented).
+  # CLI flag: -tsdb.shipper.index-reader-mode
+  [index_reader_mode: <string> | default = "mmap"]
+
   index_gateway_client:
     # The grpc_client block configures the gRPC client used to communicate
     # between a client and server component in Loki.

--- a/pkg/bloombuild/common/tsdb.go
+++ b/pkg/bloombuild/common/tsdb.go
@@ -114,7 +114,7 @@ func (b *BloomTSDBStore) LoadTSDB(
 		return nil, errors.Wrap(err, "failed to read file")
 	}
 
-	reader, err := index.NewReader(index.RealByteSlice(buf))
+	reader, err := index.NewByteSliceReader(index.RealByteSlice(buf))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create index reader")
 	}

--- a/pkg/logql/bench/discover/pkg/tsdb/reader.go
+++ b/pkg/logql/bench/discover/pkg/tsdb/reader.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 
 	lokitsdb "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
 	tsdbindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"

--- a/pkg/logql/bench/discover/pkg/tsdb/reader.go
+++ b/pkg/logql/bench/discover/pkg/tsdb/reader.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/prometheus/common/model"
 
 	lokitsdb "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
@@ -29,7 +30,7 @@ func OpenAndInspectIndexes(paths []string) ([]IndexReaderResult, error) {
 }
 
 func openAndInspectIndex(path string) (result IndexReaderResult, err error) {
-	reader, err := tsdbindex.NewFileReader(path)
+	reader, err := tsdbindex.NewMmapFileReader(path)
 	if err != nil {
 		return IndexReaderResult{}, fmt.Errorf("open tsdb index %q: %w", path, err)
 	}
@@ -53,7 +54,7 @@ func openAndInspectIndex(path string) (result IndexReaderResult, err error) {
 
 	// Full index handle for structural discovery (ForSeries traversal).
 	// This stays open — the caller must close it via result.Index.Close().
-	idx, _, err := lokitsdb.NewTSDBIndexFromFile(path)
+	idx, _, err := lokitsdb.NewTSDBIndexFromFile(path, indexshipper.IndexReaderModeMmap)
 	if err != nil {
 		return IndexReaderResult{}, fmt.Errorf("open TSDB index for discovery %q: %w", path, err)
 	}

--- a/pkg/logql/bench/discover/pkg/tsdb/structural_test.go
+++ b/pkg/logql/bench/discover/pkg/tsdb/structural_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 
 	"github.com/grafana/loki/v3/pkg/loghttp"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"

--- a/pkg/logql/bench/discover/pkg/tsdb/structural_test.go
+++ b/pkg/logql/bench/discover/pkg/tsdb/structural_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -156,7 +157,7 @@ func openStructuralIndexes(t *testing.T, paths ...string) []tsdb.Index {
 
 	res := make([]tsdb.Index, 0, len(paths))
 	for _, path := range paths {
-		idx, _, err := tsdb.NewTSDBIndexFromFile(path)
+		idx, _, err := tsdb.NewTSDBIndexFromFile(path, indexshipper.IndexReaderModeMmap)
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, idx.Close())

--- a/pkg/storage/stores/shipper/indexshipper/shipper.go
+++ b/pkg/storage/stores/shipper/indexshipper/shipper.go
@@ -46,6 +46,27 @@ const (
 	UploadInterval = 1 * time.Minute
 )
 
+// IndexReaderMode selects the implementation used to read TSDB index files from disk.
+type IndexReaderMode string
+
+const (
+	// IndexReaderModeMmap memory-maps the index file.
+	// This is the historical default.
+	// Mmap page faults are invisible to the Go runtime, which causes a
+	// thread to be locked for the duration of the page fault.
+	IndexReaderModeMmap IndexReaderMode = "mmap"
+	// IndexReaderModeStream serves reads via schedulable file I/O so the
+	// runtime can observe blocking.
+	// It is not yet fully implemented and currently delegates calls to a
+	// mmap reader under the hood.
+	// Over time its implementation will be fleshed out until it no longer
+	// depends on the mmap implementation.
+	IndexReaderModeStream IndexReaderMode = "stream"
+)
+
+// DefaultIndexReaderMode is the mode used when none is configured.
+const DefaultIndexReaderMode = IndexReaderModeMmap
+
 type Index interface {
 	Close() error
 }
@@ -75,6 +96,7 @@ type Config struct {
 	ResyncInterval           time.Duration             `yaml:"resync_interval"`
 	QueryReadyNumDays        int                       `yaml:"query_ready_num_days"`
 	DownloadTimeout          time.Duration             `yaml:"download_timeout"`
+	IndexReaderMode          IndexReaderMode           `yaml:"index_reader_mode" category:"experimental"`
 	IndexGatewayClientConfig indexgateway.ClientConfig `yaml:"index_gateway_client"`
 
 	// Temporary experimental feature
@@ -101,12 +123,20 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.IntVar(&cfg.QueryReadyNumDays, prefix+"shipper.query-ready-num-days", 0, "Number of days of common index to be kept downloaded for queries. For per tenant index query readiness, use limits overrides config.")
 	f.DurationVar(&cfg.DownloadTimeout, prefix+"shipper.download-timeout", time.Minute, "Timeout for downloading a table's initial set of index files from object storage when serving a query. "+
 		"Raise this for tenants with large indexes when slow object-storage responses cause downloads to hit the deadline; lower it to fail queries faster when storage is degraded.")
+	f.StringVar((*string)(&cfg.IndexReaderMode), prefix+"shipper.index-reader-mode", string(DefaultIndexReaderMode),
+		"Experimental. Implementation used to read TSDB index files off disk. Supported values: mmap (memory-map the file, the historical default) or stream (experimental, not yet fully implemented).")
 }
 
 func (cfg *Config) Validate() error {
 	// set the default value for mode
 	if cfg.Mode == "" {
 		cfg.Mode = ModeReadWrite
+	}
+
+	switch cfg.IndexReaderMode {
+	case IndexReaderModeMmap, IndexReaderModeStream:
+	default:
+		return fmt.Errorf("invalid shipper.index-reader-mode %q, must be one of mmap|stream", cfg.IndexReaderMode)
 	}
 
 	if cfg.DownloadTimeout <= 0 {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/builder.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/builder.go
@@ -134,7 +134,7 @@ func (b *Builder) Build(
 		return id, err
 	}
 
-	reader, err := index.NewFileReader(tmpPath)
+	reader, err := index.NewMmapFileReader(tmpPath)
 	if err != nil {
 		return id, err
 	}
@@ -245,7 +245,7 @@ func (b *Builder) BuildInMemory(
 		return nil, nil, err
 	}
 
-	reader, err := index.NewReader(index.RealByteSlice(data))
+	reader, err := index.NewByteSliceReader(index.RealByteSlice(data))
 	if err != nil {
 		return id, nil, err
 	}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/builder_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/builder_test.go
@@ -35,13 +35,13 @@ func Test_Build(t *testing.T) {
 		return context.Background(), builder, tmpDir
 	}
 
-	getReader := func(path string) *index.Reader {
+	getReader := func(path string) index.Reader {
 		indexPath := fakeIdentifierPathForBounds(path, 1, 6) //default step is 1
 		files, err := filepath.Glob(indexPath)
 		require.NoError(t, err)
 		require.Len(t, files, 1)
 
-		reader, err := index.NewFileReader(files[0])
+		reader, err := index.NewMmapFileReader(files[0])
 		require.NoError(t, err)
 		return reader
 	}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
@@ -11,9 +11,10 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
-	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 
 	"github.com/grafana/loki/v3/pkg/compactor"
 	"github.com/grafana/loki/v3/pkg/compactor/retention"

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -37,7 +38,7 @@ func (i indexProcessor) NewTableCompactor(ctx context.Context, commonIndexSet co
 }
 
 func (i indexProcessor) OpenCompactedIndexFile(ctx context.Context, path, tableName, userID, workingDir string, periodConfig config.PeriodConfig, logger log.Logger) (compactor.CompactedIndex, error) {
-	indexFile, err := OpenShippableTSDB(path)
+	indexFile, err := OpenShippableTSDB(path, indexshipper.IndexReaderModeMmap)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +108,7 @@ func (t *tableCompactor) CompactTable() error {
 		}
 
 		downloadPaths[job] = downloadedAt
-		idx, err := OpenShippableTSDB(downloadedAt)
+		idx, err := OpenShippableTSDB(downloadedAt, indexshipper.IndexReaderModeMmap)
 		if err != nil {
 			return err
 		}
@@ -231,7 +232,7 @@ func processSourceIndex(ctx context.Context, sourceIndex storage.IndexFile, sour
 		}
 	}()
 
-	indexFile, err := OpenShippableTSDB(path)
+	indexFile, err := OpenShippableTSDB(path, indexshipper.IndexReaderModeMmap)
 	if err != nil {
 		return err
 	}
@@ -480,7 +481,7 @@ func (c *compactedIndex) ToIndexFile() (shipperindex.Index, error) {
 		return nil, err
 	}
 
-	return NewShippableTSDBFile(id)
+	return NewShippableTSDBFile(id, indexshipper.IndexReaderModeMmap)
 }
 
 func getUnsafeBytes(s string) []byte {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1255,7 +1255,9 @@ type StringIter interface {
 	Err() error
 }
 
-type Reader struct {
+// ByteSliceReader is an implementation of Reader used for reading indexes from
+// a ByteSlice that has either been loaded into memory or memory-mapped.
+type ByteSliceReader struct {
 	b   ByteSlice
 	toc *TOC
 
@@ -1302,19 +1304,20 @@ func (b RealByteSlice) Sub(start, end int) ByteSlice {
 	return b[start:end]
 }
 
-// NewReader returns a new index reader on the given byte slice. It automatically
+// NewByteSliceReader returns a new index reader on the given byte slice. It automatically
 // handles different format versions.
-func NewReader(b ByteSlice) (*Reader, error) {
-	return newReader(b, io.NopCloser(nil))
+func NewByteSliceReader(b ByteSlice) (*ByteSliceReader, error) {
+	return newByteSliceReader(b, io.NopCloser(nil))
 }
 
-// NewFileReader returns a new index reader against the given index file.
-func NewFileReader(path string) (*Reader, error) {
+// NewMmapFileReader returns a new index reader against the given index file.
+// It uses mmap to read the file.
+func NewMmapFileReader(path string) (*ByteSliceReader, error) {
 	f, err := fileutil.OpenMmapFile(path)
 	if err != nil {
 		return nil, err
 	}
-	r, err := newReader(RealByteSlice(f.Bytes()), f)
+	r, err := newByteSliceReader(RealByteSlice(f.Bytes()), f)
 	if err != nil {
 		return nil, stderrors.Join(
 			err,
@@ -1325,8 +1328,8 @@ func NewFileReader(path string) (*Reader, error) {
 	return r, nil
 }
 
-func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
-	r := &Reader{
+func newByteSliceReader(b ByteSlice, c io.Closer) (*ByteSliceReader, error) {
+	r := &ByteSliceReader{
 		b:        b,
 		c:        c,
 		postings: map[string][]postingOffset{},
@@ -1416,11 +1419,11 @@ func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 }
 
 // Version returns the file format version of the underlying index.
-func (r *Reader) Version() int {
+func (r *ByteSliceReader) Version() int {
 	return r.version
 }
 
-func (r *Reader) RawFileReader() (io.ReadSeeker, error) {
+func (r *ByteSliceReader) RawFileReader() (io.ReadSeeker, error) {
 	return bytes.NewReader(r.b.Range(0, r.b.Len())), nil
 }
 
@@ -1431,7 +1434,7 @@ type Range struct {
 
 // PostingsRanges returns a new map of byte range in the underlying index file
 // for all postings lists.
-func (r *Reader) PostingsRanges() (map[labels.Label]Range, error) {
+func (r *ByteSliceReader) PostingsRanges() (map[labels.Label]Range, error) {
 	m := map[labels.Label]Range{}
 	if err := ReadOffsetTable(r.b, r.toc.PostingsTable, func(name, value []byte, off uint64, _ int) error {
 		d := encoding.DecWrap(tsdb_enc.NewDecbufAt(r.b, int(off), castagnoliTable))
@@ -1621,39 +1624,39 @@ func readFingerprintOffsetsTable(bs ByteSlice, off uint64) (FingerprintOffsets, 
 }
 
 // Close the reader and its underlying resources.
-func (r *Reader) Close() error {
+func (r *ByteSliceReader) Close() error {
 	return r.c.Close()
 }
 
-func (r *Reader) lookupSymbol(o uint32) (string, error) {
+func (r *ByteSliceReader) lookupSymbol(o uint32) (string, error) {
 	if s, ok := r.nameSymbols[o]; ok {
 		return s, nil
 	}
 	return r.symbols.Lookup(o)
 }
 
-func (r *Reader) Bounds() (int64, int64) {
+func (r *ByteSliceReader) Bounds() (int64, int64) {
 	return r.toc.Metadata.From, r.toc.Metadata.Through
 }
 
-func (r *Reader) Checksum() uint32 {
+func (r *ByteSliceReader) Checksum() uint32 {
 	return r.toc.Metadata.Checksum
 }
 
 // Symbols returns an iterator over the symbols that exist within the index.
-func (r *Reader) Symbols() StringIter {
+func (r *ByteSliceReader) Symbols() StringIter {
 	return r.symbols.Iter()
 }
 
 // SymbolTableSize returns the symbol table size in bytes.
-func (r *Reader) SymbolTableSize() uint64 {
+func (r *ByteSliceReader) SymbolTableSize() uint64 {
 	return uint64(r.symbols.Size())
 }
 
 // LabelValues returns value tuples that exist for the given label name.
 // The returned values should be copied if they need to be used beyond the current tsdb read operation, including sending back as response.
 // TODO(replay): Support filtering by matchers
-func (r *Reader) LabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
+func (r *ByteSliceReader) LabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
 	if len(matchers) > 0 {
 		return nil, errors.Errorf("matchers parameter is not implemented: %+v", matchers)
 	}
@@ -1698,7 +1701,7 @@ func (r *Reader) LabelValues(name string, matchers ...*labels.Matcher) ([]string
 
 // LabelNamesFor returns all the label names for the series referred to by IDs.
 // The names returned are sorted.
-func (r *Reader) LabelNamesFor(ids ...storage.SeriesRef) ([]string, error) {
+func (r *ByteSliceReader) LabelNamesFor(ids ...storage.SeriesRef) ([]string, error) {
 	// Gather offsetsMap the name offsetsMap in the symbol table first
 	offsetsMap := make(map[uint32]struct{})
 	for _, id := range ids {
@@ -1736,7 +1739,7 @@ func (r *Reader) LabelNamesFor(ids ...storage.SeriesRef) ([]string, error) {
 }
 
 // LabelValueFor returns label value for the given label name in the series referred to by ID.
-func (r *Reader) LabelValueFor(id storage.SeriesRef, label string) (string, error) {
+func (r *ByteSliceReader) LabelValueFor(id storage.SeriesRef, label string) (string, error) {
 	// Series IDs are 16-byte padded and ID is the multiple of 16 of the actual position
 	offset := id * 16
 	d := encoding.DecWrap(tsdb_enc.NewDecbufUvarintAt(r.b, int(offset), castagnoliTable))
@@ -1758,7 +1761,7 @@ func (r *Reader) LabelValueFor(id storage.SeriesRef, label string) (string, erro
 }
 
 // Series reads the series with the given ID and writes its labels and chunks into lbls and chks.
-func (r *Reader) Series(id storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]ChunkMeta) (uint64, error) {
+func (r *ByteSliceReader) Series(id storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]ChunkMeta) (uint64, error) {
 	// Series IDs are 16-byte padded and ID is the multiple of 16 of the actual position
 	offset := id * 16
 	d := encoding.DecWrap(tsdb_enc.NewDecbufUvarintAt(r.b, int(offset), castagnoliTable))
@@ -1773,7 +1776,7 @@ func (r *Reader) Series(id storage.SeriesRef, from int64, through int64, lbls *l
 	return fprint, nil
 }
 
-func (r *Reader) ChunkStats(id storage.SeriesRef, from, through int64, lbls *labels.Labels, by map[string]struct{}) (uint64, ChunkStats, error) {
+func (r *ByteSliceReader) ChunkStats(id storage.SeriesRef, from, through int64, lbls *labels.Labels, by map[string]struct{}) (uint64, ChunkStats, error) {
 	// Series IDs are 16-byte padded and ID is the multiple of 16 of the actual position
 	offset := id * 16
 	d := encoding.DecWrap(tsdb_enc.NewDecbufUvarintAt(r.b, int(offset), castagnoliTable))
@@ -1784,7 +1787,7 @@ func (r *Reader) ChunkStats(id storage.SeriesRef, from, through int64, lbls *lab
 	return r.dec.ChunkStats(r.version, d.Get(), id, from, through, lbls, by)
 }
 
-func (r *Reader) Postings(name string, fpFilter FingerprintFilter, values ...string) (Postings, error) {
+func (r *ByteSliceReader) Postings(name string, fpFilter FingerprintFilter, values ...string) (Postings, error) {
 	e, ok := r.postings[name]
 	if !ok {
 		return EmptyPostings(), nil
@@ -1868,13 +1871,13 @@ func (r *Reader) Postings(name string, fpFilter FingerprintFilter, values ...str
 }
 
 // Size returns the size of an index file.
-func (r *Reader) Size() int64 {
+func (r *ByteSliceReader) Size() int64 {
 	return int64(r.b.Len())
 }
 
 // LabelNames returns all the unique label names present in the index.
 // TODO(twilkie) implement support for matchers
-func (r *Reader) LabelNames(matchers ...*labels.Matcher) ([]string, error) {
+func (r *ByteSliceReader) LabelNames(matchers ...*labels.Matcher) ([]string, error) {
 	if len(matchers) > 0 {
 		return nil, errors.Errorf("matchers parameter is not implemented: %+v", matchers)
 	}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index_test.go
@@ -136,7 +136,7 @@ func TestIndexRW_Create_Open(t *testing.T) {
 	_, err = iw.Close(false)
 	require.NoError(t, err)
 
-	ir, err := NewFileReader(fn)
+	ir, err := NewMmapFileReader(fn)
 	require.NoError(t, err)
 	require.NoError(t, ir.Close())
 
@@ -147,7 +147,7 @@ func TestIndexRW_Create_Open(t *testing.T) {
 	require.NoError(t, err)
 	f.Close()
 
-	_, err = NewFileReader(dir)
+	_, err = NewMmapFileReader(dir)
 	require.Error(t, err)
 }
 
@@ -160,7 +160,7 @@ func TestIndexRW_Create_Open_V4(t *testing.T) {
 	_, err = iw.Close(false)
 	require.NoError(t, err)
 
-	ir, err := NewFileReader(fn)
+	ir, err := NewMmapFileReader(fn)
 	require.NoError(t, err)
 	require.Equal(t, FormatV4, ir.Version())
 	require.NoError(t, ir.Close())
@@ -198,7 +198,7 @@ func TestIndexRW_Postings(t *testing.T) {
 	_, err = iw.Close(false)
 	require.NoError(t, err)
 
-	ir, err := NewFileReader(fn)
+	ir, err := NewMmapFileReader(fn)
 	require.NoError(t, err)
 
 	p, err := ir.Postings("a", nil, "1")
@@ -287,7 +287,7 @@ func TestPostingsMany(t *testing.T) {
 	_, err = iw.Close(false)
 	require.NoError(t, err)
 
-	ir, err := NewFileReader(fn)
+	ir, err := NewMmapFileReader(fn)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, ir.Close()) }()
 
@@ -428,7 +428,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 	_, err = iw.Close(false)
 	require.NoError(t, err)
 
-	ir, err := NewFileReader(filepath.Join(dir, IndexFilename))
+	ir, err := NewMmapFileReader(filepath.Join(dir, IndexFilename))
 	require.NoError(t, err)
 
 	for p := range mi.postings {
@@ -501,7 +501,7 @@ func TestDecbufUvarintWithInvalidBuffer(t *testing.T) {
 func TestReaderWithInvalidBuffer(t *testing.T) {
 	b := RealByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
 
-	_, err := NewReader(b)
+	_, err := NewByteSliceReader(b)
 	require.Error(t, err)
 }
 
@@ -513,7 +513,7 @@ func TestNewFileReaderErrorNoOpenFiles(t *testing.T) {
 	err := os.WriteFile(idxName, []byte("corrupted contents"), 0o666)
 	require.NoError(t, err)
 
-	_, err = NewFileReader(idxName)
+	_, err = NewMmapFileReader(idxName)
 	require.Error(t, err)
 
 	// dir.Close will fail on Win if idxName fd is not closed on error path.
@@ -765,7 +765,7 @@ func TestDecoder_ChunkSamples(t *testing.T) {
 			_, err = iw.Close(false)
 			require.NoError(t, err)
 
-			ir, err := NewFileReader(filepath.Join(dir, name))
+			ir, err := NewMmapFileReader(filepath.Join(dir, name))
 			require.NoError(t, err)
 
 			postings, err := ir.Postings("fizz", nil, "buzz")
@@ -1027,7 +1027,7 @@ func BenchmarkInitReader_ReadOffsetTable(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		r, err := newReader(RealByteSlice(bs), io.NopCloser(nil))
+		r, err := newByteSliceReader(RealByteSlice(bs), io.NopCloser(nil))
 		require.NoError(b, err)
 		require.NoError(b, r.Close())
 	}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/reader.go
@@ -1,0 +1,66 @@
+package index
+
+import (
+	"io"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+)
+
+// Reader is the read-side interface implemented by every on-disk TSDB index reader.
+type Reader interface {
+	// Version returns the on-disk index format version.
+	Version() int
+
+	// RawFileReader exposes the underlying index file bytes as an
+	// io.ReadSeeker so the indexshipper can upload the raw file.
+	RawFileReader() (io.ReadSeeker, error)
+
+	// PostingsRanges returns the byte range in the underlying index file for
+	// every posting list.
+	PostingsRanges() (map[labels.Label]Range, error)
+
+	// Bounds returns the min/max time range covered by the index.
+	Bounds() (int64, int64)
+
+	// Checksum returns the CRC32 checksum recorded in the index TOC.
+	Checksum() uint32
+
+	// Symbols returns an iterator over the symbol table.
+	Symbols() StringIter
+
+	// SymbolTableSize returns the symbol table size in bytes.
+	SymbolTableSize() uint64
+
+	// LabelValues returns the possible label values for the given label name.
+	LabelValues(name string, matchers ...*labels.Matcher) ([]string, error)
+
+	// LabelNames returns the unique label names present in the index in
+	// sorted order.
+	LabelNames(matchers ...*labels.Matcher) ([]string, error)
+
+	// LabelValueFor returns the value of the given label name for the series
+	// referred to by id.
+	LabelValueFor(id storage.SeriesRef, label string) (string, error)
+
+	// LabelNamesFor returns the sorted label names for the series referred to
+	// by ids.
+	LabelNamesFor(ids ...storage.SeriesRef) ([]string, error)
+
+	// Series populates lbls and chks for the series identified by id.
+	Series(id storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]ChunkMeta) (uint64, error)
+
+	// ChunkStats returns aggregated chunk statistics for the series
+	// identified by id.
+	ChunkStats(id storage.SeriesRef, from, through int64, lbls *labels.Labels, by map[string]struct{}) (uint64, ChunkStats, error)
+
+	// Postings returns a postings iterator over the series matching the
+	// (name, value) pairs.
+	Postings(name string, fpFilter FingerprintFilter, values ...string) (Postings, error)
+
+	// Size returns the size of the underlying index in bytes.
+	Size() int64
+
+	// Close releases the underlying resources of the reader.
+	Close() error
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
@@ -1,0 +1,90 @@
+package index
+
+import (
+	"io"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+)
+
+// StreamReader is the file-streaming counterpart to ByteSliceReader.
+//
+// Currently, this is just scaffolding: StreamReader delegates all calls to a *ByteSliceReader.
+// Follow-up changes will progressively replace embedded calls with streaming implementations
+// backed by a file-handle pool.
+type StreamReader struct {
+	mmapReader *ByteSliceReader
+}
+
+// NewStreamFileReader constructs a StreamReader against the given index file.
+func NewStreamFileReader(path string) (*StreamReader, error) {
+	mmapReader, err := NewMmapFileReader(path)
+	if err != nil {
+		return nil, err
+	}
+	return &StreamReader{mmapReader: mmapReader}, nil
+}
+
+func (s StreamReader) Version() int {
+	return s.mmapReader.Version()
+}
+
+func (s StreamReader) RawFileReader() (io.ReadSeeker, error) {
+	return s.mmapReader.RawFileReader()
+}
+
+func (s StreamReader) PostingsRanges() (map[labels.Label]Range, error) {
+	return s.mmapReader.PostingsRanges()
+}
+
+func (s StreamReader) Bounds() (int64, int64) {
+	return s.mmapReader.Bounds()
+}
+
+func (s StreamReader) Checksum() uint32 {
+	return s.mmapReader.Checksum()
+}
+
+func (s StreamReader) Symbols() StringIter {
+	return s.mmapReader.Symbols()
+}
+
+func (s StreamReader) SymbolTableSize() uint64 {
+	return s.mmapReader.SymbolTableSize()
+}
+
+func (s StreamReader) LabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
+	return s.mmapReader.LabelValues(name, matchers...)
+}
+
+func (s StreamReader) LabelNames(matchers ...*labels.Matcher) ([]string, error) {
+	return s.mmapReader.LabelNames(matchers...)
+}
+
+func (s StreamReader) LabelValueFor(id storage.SeriesRef, label string) (string, error) {
+	return s.mmapReader.LabelValueFor(id, label)
+}
+
+func (s StreamReader) LabelNamesFor(ids ...storage.SeriesRef) ([]string, error) {
+	return s.mmapReader.LabelNamesFor(ids...)
+}
+
+func (s StreamReader) Series(id storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]ChunkMeta) (uint64, error) {
+	return s.mmapReader.Series(id, from, through, lbls, chks)
+}
+
+func (s StreamReader) ChunkStats(id storage.SeriesRef, from, through int64, lbls *labels.Labels, by map[string]struct{}) (uint64, ChunkStats, error) {
+	return s.mmapReader.ChunkStats(id, from, through, lbls, by)
+}
+
+func (s StreamReader) Postings(name string, fpFilter FingerprintFilter, values ...string) (Postings, error) {
+	return s.mmapReader.Postings(name, fpFilter, values...)
+}
+
+func (s StreamReader) Size() int64 {
+	return s.mmapReader.Size()
+}
+
+func (s StreamReader) Close() error {
+	return s.mmapReader.Close()
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
@@ -1,0 +1,226 @@
+package index
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// readerConstructor pairs a Reader implementation's name with a function
+// that opens an on-disk index using it. The cross-check tests iterate
+// over allReaderConstructors so every implementation is exercised the
+// same way against the ByteSliceReader baseline.
+type readerConstructor struct {
+	name string
+	open func(path string) (Reader, error)
+}
+
+func allReaderConstructors() []readerConstructor {
+	return []readerConstructor{
+		{name: "MmapReader", open: func(p string) (Reader, error) { return NewMmapFileReader(p) }},
+		{name: "StreamReader", open: func(p string) (Reader, error) { return NewStreamFileReader(p) }},
+	}
+}
+
+// writeCrossCheckFixture builds a small but non-trivial index used by
+// the cross-check tests: multiple label names, multiple values per
+// name, a couple of chunks per series.
+func writeCrossCheckFixture(t *testing.T, format int) string {
+	t.Helper()
+	dir := t.TempDir()
+	fileName := filepath.Join(dir, IndexFilename)
+
+	creator, err := NewWriter(context.Background(), format, fileName)
+	require.NoError(t, err)
+
+	symbols := []string{"1", "2", "3", "a", "b", "c", "svcA", "svcB"}
+	for _, s := range symbols {
+		require.NoError(t, creator.AddSymbol(s))
+	}
+
+	type entry struct {
+		ls     labels.Labels
+		chunks []ChunkMeta
+	}
+	entries := []entry{
+		{ls: labels.FromStrings("a", "1", "b", "1", "c", "svcA"), chunks: []ChunkMeta{{Checksum: 1, MinTime: 0, MaxTime: 10, KB: 1, Entries: 1}}},
+		{ls: labels.FromStrings("a", "1", "b", "2", "c", "svcA"), chunks: []ChunkMeta{{Checksum: 2, MinTime: 10, MaxTime: 20, KB: 1, Entries: 1}}},
+		{ls: labels.FromStrings("a", "2", "b", "3", "c", "svcB"), chunks: []ChunkMeta{{Checksum: 3, MinTime: 20, MaxTime: 30, KB: 1, Entries: 1}}},
+	}
+	// AddSeries requires ascending fingerprint order.
+	sort.Slice(entries, func(i, j int) bool {
+		return labels.StableHash(entries[i].ls) < labels.StableHash(entries[j].ls)
+	})
+	for i, e := range entries {
+		require.NoError(t, creator.AddSeries(
+			storage.SeriesRef(i+1),
+			e.ls,
+			model.Fingerprint(labels.StableHash(e.ls)),
+			e.chunks...,
+		))
+	}
+
+	_, err = creator.Close(false)
+	require.NoError(t, err)
+	return fileName
+}
+
+// TestReaders_CrossCheck opens the same fixture with every Reader
+// implementation and asserts each method returns identical results to
+// the ByteSliceReader baseline. Today StreamReader delegates to
+// ByteSliceReader so this passes trivially; the check exists to catch
+// regressions as StreamReader gains real, standalone implementations.
+func TestReaders_CrossCheck(t *testing.T) {
+	for _, format := range []int{FormatV3, FormatV4} {
+		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
+			fn := writeCrossCheckFixture(t, format)
+
+			mmap, err := NewMmapFileReader(fn)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, mmap.Close()) })
+
+			stream, err := NewStreamFileReader(fn)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, stream.Close()) })
+
+			require.Equal(t, mmap.Version(), stream.Version())
+			require.Equal(t, mmap.Checksum(), stream.Checksum())
+			require.Equal(t, mmap.SymbolTableSize(), stream.SymbolTableSize())
+			require.Equal(t, mmap.Size(), stream.Size())
+
+			baseMin, baseMax := mmap.Bounds()
+			rMin, rMax := stream.Bounds()
+			require.Equal(t, baseMin, rMin)
+			require.Equal(t, baseMax, rMax)
+
+			requireSymbolsEqual(t, mmap, stream)
+			requireLabelsEqual(t, mmap, stream)
+			requirePostingsSeriesEqual(t, mmap, stream)
+			requirePostingsRangesEqual(t, mmap, stream)
+		})
+	}
+}
+
+func requireSymbolsEqual(t *testing.T, mmap, stream Reader) {
+	t.Helper()
+	mmapSymbols := getSymbols(t, mmap)
+	streamSymbols := getSymbols(t, stream)
+	require.Equal(t, mmapSymbols, streamSymbols)
+}
+
+func getSymbols(t *testing.T, reader Reader) []string {
+	t.Helper()
+	var out []string
+	symbols := reader.Symbols()
+	for symbols.Next() {
+		out = append(out, symbols.At())
+	}
+	require.NoError(t, symbols.Err())
+	return out
+}
+
+func requireLabelsEqual(t *testing.T, mmap, stream Reader) {
+	t.Helper()
+	mmapLabelNames, err := mmap.LabelNames()
+	require.NoError(t, err)
+	streamLabelNames, err := stream.LabelNames()
+	require.NoError(t, err)
+	require.Equal(t, mmapLabelNames, streamLabelNames)
+
+	for _, labelName := range mmapLabelNames {
+		mmapLabelValues, err := mmap.LabelValues(labelName)
+		require.NoError(t, err)
+		streamLabelValues, err := stream.LabelValues(labelName)
+		require.NoError(t, err)
+		require.Equal(t, mmapLabelValues, streamLabelValues)
+	}
+}
+
+func requirePostingsSeriesEqual(t *testing.T, mmap, stream Reader) {
+	t.Helper()
+	labelNames, err := mmap.LabelNames()
+	require.NoError(t, err)
+	for _, labelName := range labelNames {
+		labelValues, err := mmap.LabelValues(labelName)
+		require.NoError(t, err)
+		for _, labelValue := range labelValues {
+			mmapSeriesRefs := getPostings(t, mmap, labelName, labelValue)
+			streamSeriesRefs := getPostings(t, stream, labelName, labelValue)
+			require.Equal(t, mmapSeriesRefs, streamSeriesRefs)
+
+			for _, seriesRef := range mmapSeriesRefs {
+				requireSeriesEqual(t, mmap, stream, seriesRef, labelName)
+			}
+		}
+	}
+}
+
+func getPostings(t *testing.T, reader Reader, labelName, labelValue string) []storage.SeriesRef {
+	t.Helper()
+	p, err := reader.Postings(labelName, nil, labelValue)
+	require.NoError(t, err)
+	var refs []storage.SeriesRef
+	for p.Next() {
+		refs = append(refs, p.At())
+	}
+	require.NoError(t, p.Err())
+	return refs
+}
+
+func requireSeriesEqual(t *testing.T, mmap, stream Reader, seriesRef storage.SeriesRef, labelName string) {
+	t.Helper()
+
+	var mmapLabels, streamLabels labels.Labels
+	var mmapChecksums, streamChecksums []ChunkMeta
+	mmapFingerprint, err := mmap.Series(seriesRef, 0, math.MaxInt64, &mmapLabels, &mmapChecksums)
+	require.NoError(t, err)
+	streamFingerprint, err := stream.Series(seriesRef, 0, math.MaxInt64, &streamLabels, &streamChecksums)
+	require.NoError(t, err)
+	require.Equal(t, mmapFingerprint, streamFingerprint)
+	require.Equal(t, mmapLabels, streamLabels)
+	require.Equal(t, mmapChecksums, streamChecksums)
+
+	mmapLabelValue, err := mmap.LabelValueFor(seriesRef, labelName)
+	require.NoError(t, err)
+	streamLabelValue, err := stream.LabelValueFor(seriesRef, labelName)
+	require.NoError(t, err)
+	require.Equal(t, mmapLabelValue, streamLabelValue)
+
+	mmapLabelNames, err := mmap.LabelNamesFor(seriesRef)
+	require.NoError(t, err)
+	streamLabelNames, err := stream.LabelNamesFor(seriesRef)
+	require.NoError(t, err)
+	require.Equal(t, mmapLabelNames, streamLabelNames)
+
+	requireChunkStatsEqual(t, mmap, stream, seriesRef, labelName)
+}
+
+func requireChunkStatsEqual(t *testing.T, mmap Reader, stream Reader, seriesRef storage.SeriesRef, labelName string) {
+	for _, by := range []map[string]struct{}{nil, {labelName: {}}} {
+		var mmapLabels, streamLabels labels.Labels
+		mmapFingerprints, mmapChunkStats, err := mmap.ChunkStats(seriesRef, 0, math.MaxInt64, &mmapLabels, by)
+		require.NoError(t, err)
+		streamFingerprints, streamChunkStats, err := stream.ChunkStats(seriesRef, 0, math.MaxInt64, &streamLabels, by)
+		require.NoError(t, err)
+		require.Equal(t, mmapFingerprints, streamFingerprints)
+		require.Equal(t, mmapChunkStats, streamChunkStats)
+		require.Equal(t, mmapLabels, streamLabels)
+	}
+}
+
+func requirePostingsRangesEqual(t *testing.T, base, other Reader) {
+	t.Helper()
+	baseRanges, err := base.PostingsRanges()
+	require.NoError(t, err)
+	otherRanges, err := other.PostingsRanges()
+	require.NoError(t, err)
+	require.Equal(t, baseRanges, otherRanges)
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
@@ -14,22 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// readerConstructor pairs a Reader implementation's name with a function
-// that opens an on-disk index using it. The cross-check tests iterate
-// over allReaderConstructors so every implementation is exercised the
-// same way against the ByteSliceReader baseline.
-type readerConstructor struct {
-	name string
-	open func(path string) (Reader, error)
-}
-
-func allReaderConstructors() []readerConstructor {
-	return []readerConstructor{
-		{name: "MmapReader", open: func(p string) (Reader, error) { return NewMmapFileReader(p) }},
-		{name: "StreamReader", open: func(p string) (Reader, error) { return NewStreamFileReader(p) }},
-	}
-}
-
 // writeCrossCheckFixture builds a small but non-trivial index used by
 // the cross-check tests: multiple label names, multiple values per
 // name, a couple of chunks per series.

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/manager.go
@@ -134,7 +134,7 @@ func (m *tsdbManager) Start() error {
 			indices++
 
 			prefixed := NewPrefixedIdentifier(id, filepath.Join(mulitenantDir, bucket), "")
-			loaded, err := NewShippableTSDBFile(prefixed)
+			loaded, err := NewShippableTSDBFile(prefixed, indexshipper.IndexReaderModeMmap)
 
 			if err != nil {
 				level.Warn(m.log).Log(
@@ -237,7 +237,7 @@ func (m *tsdbManager) buildFromHead(heads *tenantHeads, indexShipper indexshippe
 
 		level.Debug(m.log).Log("msg", "finished building tsdb for period", "pd", p, "dst", dst.Path(), "duration", time.Since(start))
 
-		loaded, err := NewShippableTSDBFile(dst)
+		loaded, err := NewShippableTSDBFile(dst, indexshipper.IndexReaderModeMmap)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/querier_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/querier_test.go
@@ -102,7 +102,7 @@ func TestQueryIndex(t *testing.T) {
 	})
 	require.Nil(t, err)
 
-	reader, err := index.NewFileReader(dst.Path())
+	reader, err := index.NewMmapFileReader(dst.Path())
 	require.Nil(t, err)
 
 	p, err := PostingsForMatchers(reader, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/stores/index/seriesvolume"
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	shipperindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/index"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 	"github.com/grafana/loki/v3/pkg/util"
@@ -28,17 +29,17 @@ var ErrAlreadyOnDesiredVersion = errors.New("tsdb file already on desired versio
 // GetRawFileReaderFunc returns an io.ReadSeeker for reading raw tsdb file from disk
 type GetRawFileReaderFunc func() (io.ReadSeeker, error)
 
-func OpenShippableTSDB(p string) (shipperindex.Index, error) {
+func OpenShippableTSDB(p string, mode indexshipper.IndexReaderMode) (shipperindex.Index, error) {
 	id, err := identifierFromPath(p)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewShippableTSDBFile(id)
+	return NewShippableTSDBFile(id, mode)
 }
 
 func RebuildWithVersion(ctx context.Context, path string, desiredVer int) (shipperindex.Index, error) {
-	indexFile, err := OpenShippableTSDB(path)
+	indexFile, err := OpenShippableTSDB(path, indexshipper.IndexReaderModeMmap)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +50,7 @@ func RebuildWithVersion(ctx context.Context, path string, desiredVer int) (shipp
 		}
 	}()
 
-	currVer := indexFile.(*TSDBFile).Index.(*TSDBIndex).reader.(*index.Reader).Version()
+	currVer := indexFile.(*TSDBFile).Index.(*TSDBIndex).reader.(index.Reader).Version()
 	if currVer == desiredVer {
 		return nil, ErrAlreadyOnDesiredVersion
 	}
@@ -78,7 +79,7 @@ func RebuildWithVersion(ctx context.Context, path string, desiredVer int) (shipp
 	if err != nil {
 		return nil, err
 	}
-	return NewShippableTSDBFile(id)
+	return NewShippableTSDBFile(id, indexshipper.IndexReaderModeMmap)
 }
 
 // nolint
@@ -94,8 +95,8 @@ type TSDBFile struct {
 	getRawFileReader GetRawFileReaderFunc
 }
 
-func NewShippableTSDBFile(id Identifier) (*TSDBFile, error) {
-	idx, getRawFileReader, err := NewTSDBIndexFromFile(id.Path())
+func NewShippableTSDBFile(id Identifier, mode indexshipper.IndexReaderMode) (*TSDBFile, error) {
+	idx, getRawFileReader, err := NewTSDBIndexFromFile(id.Path(), mode)
 	if err != nil {
 		return nil, err
 	}
@@ -126,8 +127,8 @@ type TSDBIndex struct {
 
 // Return the index as well as the underlying raw file reader which isn't exposed as an index
 // method but is helpful for building an io.reader for the index shipper
-func NewTSDBIndexFromFile(location string) (*TSDBIndex, GetRawFileReaderFunc, error) {
-	reader, err := index.NewFileReader(location)
+func NewTSDBIndexFromFile(location string, mode indexshipper.IndexReaderMode) (*TSDBIndex, GetRawFileReaderFunc, error) {
+	reader, err := openIndexFileReader(location, mode)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -135,6 +136,17 @@ func NewTSDBIndexFromFile(location string) (*TSDBIndex, GetRawFileReaderFunc, er
 	return NewTSDBIndex(reader), func() (io.ReadSeeker, error) {
 		return reader.RawFileReader()
 	}, nil
+}
+
+// openIndexFileReader constructs the configured index.Reader implementation
+// for the given file. An empty mode falls back to the default (mmap).
+func openIndexFileReader(location string, mode indexshipper.IndexReaderMode) (index.Reader, error) {
+	switch mode {
+	case indexshipper.IndexReaderModeStream:
+		return index.NewStreamFileReader(location)
+	default:
+		return index.NewMmapFileReader(location)
+	}
 }
 
 func NewTSDBIndex(reader IndexReader) *TSDBIndex {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/store.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/store.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/index"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads"
+	shipperindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/index"
 	tsdbindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 )
 
@@ -73,7 +74,9 @@ func (s *store) init(name, prefix string, indexShipperCfg indexshipper.Config, s
 		objectClient,
 		limits,
 		nil,
-		OpenShippableTSDB,
+		func(p string) (shipperindex.Index, error) {
+			return OpenShippableTSDB(p, indexShipperCfg.IndexReaderMode)
+		},
 		tableRange,
 		prometheus.WrapRegistererWithPrefix("loki_tsdb_shipper_", reg),
 		s.logger,

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/util_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/util_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -35,7 +36,7 @@ func BuildIndex(t testing.TB, dir string, cases []LoadableSeries) *TSDBFile {
 	})
 	require.Nil(t, err)
 
-	idx, err := NewShippableTSDBFile(dst)
+	idx, err := NewShippableTSDBFile(dst, indexshipper.IndexReaderModeMmap)
 	require.Nil(t, err)
 	return idx
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/util_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/util_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 )

--- a/tools/tsdb/index-analyzer/main.go
+++ b/tools/tsdb/index-analyzer/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/storage"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
+	shipperindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/index"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/tools/tsdb/helpers"
@@ -33,7 +34,9 @@ func main() {
 		objectClient,
 		overrides,
 		nil,
-		tsdb.OpenShippableTSDB,
+		func(p string) (shipperindex.Index, error) {
+			return tsdb.OpenShippableTSDB(p, conf.StorageConfig.TSDBShipperConfig.IndexReaderMode)
+		},
 		tableRange,
 		prometheus.WrapRegistererWithPrefix("loki_tsdb_shipper_", prometheus.DefaultRegisterer),
 		util_log.Logger,

--- a/tools/tsdb/migrate-versions/main_test.go
+++ b/tools/tsdb/migrate-versions/main_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -90,7 +91,7 @@ func TestMigrateTables(t *testing.T) {
 		require.NoError(t, err)
 
 		tableName := fmt.Sprintf("%s%d", indexPrefix, i)
-		idx, err := tsdb.NewShippableTSDBFile(id)
+		idx, err := tsdb.NewShippableTSDBFile(id, indexshipper.IndexReaderModeMmap)
 		require.NoError(t, err)
 
 		require.NoError(t, uploadFile(idx, indexStorageClient, tableName, userID))


### PR DESCRIPTION
- Default mode is mmap (existing implementation)
- New mode is stream
- New mode is not yet implemented - it delegates all calls to mmap implementation.
- Extract Reader interface, renaming existing implementation to ByteSliceReader and adding new StreamReader.
- This is a PR that doesn't do much because it's a lot of plumbing!

**What this PR does / why we need it**: First step of migrating away from mmap. Mmap can be problematic for the operational stability of index gateways.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
