### PR TITLE
chore(renovate): Tidy the parent module after nested go.mod updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -191,6 +191,39 @@
         enabled: true,
       },
     },
+    {
+      // The operator module replaces github.com/grafana/loki/operator/api/loki with
+      // ./api/loki, so raising a requirement in the nested module also raises the
+      // operator module's own indirect requirements. 'gomodTidy' only tidies the module
+      // Renovate updated, which leaves operator/go.mod stale and fails the operator CI's
+      // 'make manager && git diff --exit-code' check, so tidy the parent as well.
+      matchManagers: ['gomod'],
+      matchFileNames: ['operator/api/loki/go.mod'],
+      postUpgradeTasks: {
+        commands: ['cd operator && go mod tidy'],
+        fileFilters: [
+          'operator/go.mod',
+          'operator/go.sum',
+        ],
+        executionMode: 'branch',
+      },
+    },
+    {
+      // Same nesting problem as above: the root module replaces
+      // github.com/grafana/loki/pkg/push with ./pkg/push. The root module is vendored, so
+      // the parent needs re-vendoring on top of the tidy.
+      matchManagers: ['gomod'],
+      matchFileNames: ['pkg/push/go.mod'],
+      postUpgradeTasks: {
+        commands: ['go mod tidy && go mod vendor'],
+        fileFilters: [
+          'go.mod',
+          'go.sum',
+          'vendor/**',
+        ],
+        executionMode: 'branch',
+      },
+    },
     //
     // Section 2: disable updates. These must all stay below section 1 — see the note above
     // 'packageRules'.


### PR DESCRIPTION
**What this PR does / why we need it**:

Renovate's `gomodTidy` only tidies the module it actually updated. Both nested modules in this repo are pulled into their parent through a `replace` directive:

- `operator/go.mod` → `replace github.com/grafana/loki/operator/api/loki => ./api/loki`
- `go.mod` → `replace github.com/grafana/loki/pkg/push => ./pkg/push`

So raising a requirement in the nested module also raises the parent's *indirect* requirements via MVS, but Renovate leaves the parent's `go.mod` untouched. The result is a PR whose parent `go.mod` is stale, which breaks package loading for the whole parent module — so `lint`, `build`, `docs` and both `Build` jobs fail at once, none of them pointing at the real cause.

This is not hypothetical: #23146 and #23390 both failed this way. Each needed nothing more than `go mod tidy` in `operator/`, which produced exactly the diff CI was asking for:

```
operator/go.mod:  golang.org/x/net v0.55.0 → v0.56.0   (+ go.sum)
```

Note the parent is never itself vulnerable in these cases, so Renovate has no dependency of its own to bump there and no amount of grouping or `packageRules` would catch it — the parent only moves as a consequence of the child. A post-update tidy is the only thing that closes the gap.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

- `postUpgradeTasks` requires the command to be allowlisted in the self-hosted Renovate bot's global config. Other repos in the org already rely on it (e.g. `grafana/k8s-monitoring-helm` runs `make clean build test` and its PRs do contain regenerated artifacts), so this should work — but if these two commands are not covered by the allowlist, Renovate will silently skip them and this change is inert rather than wrong. Worth a sanity check with #proj-renovate-self-hosted.
- The `pkg/push` rule is pre-emptive. `pkg/push/go.mod` updates are disabled today, but per the note already in this file, `vulnerabilityAlerts` merges after `packageRules`, so a security bump can still land there and would hit the same failure — with the added twist that the root module is vendored.
- Verified with `renovate-config-validator`: error count is unchanged from `main` (8 before, 8 after). The pre-existing errors are all the `matchBaseBranches`/`baseBranchPatterns` complaint and are untouched; the only delta is two index shifts (`packageRules[20],[21]` → `[22],[23]`) from inserting the new rules.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
