### PR TITLE
chore(ci): Remove Renovate automerge and autoApprove overrides

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,6 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
     'github>grafana/grafana-renovate-config//presets/base',
-    'github>grafana/grafana-renovate-config//presets/automerge',
     'github>grafana/grafana-renovate-config//presets/labels',
     'github>grafana/grafana-renovate-config//presets/docker',
     'github>grafana/grafana-renovate-config//presets/github-actions',
@@ -41,7 +40,7 @@
       },
     },
     {
-      // Auto-merge the rest of the npm updates
+      // Keep npm updates enabled on main; tailwindcss is disabled below.
       matchManagers: [
         'npm',
       ],
@@ -52,11 +51,8 @@
         'main',
       ],
       enabled: true,
-      autoApprove: true,
-      automerge: true,
     },
     {
-      // Don't automatically merge GitHub Actions updates
       matchManagers: [
         'github-actions',
       ],
@@ -70,12 +66,9 @@
       digest: {
         enabled: true,
       },
-      autoApprove: false,
-      automerge: false,
     },
     {
       // Separate out Helm updates from other dependencies
-      // Don't automatically merge Helm updates
       // Updates to this require the docs to be updated
       matchManagers: [
         'helm-requirements',
@@ -90,31 +83,9 @@
       matchPackageNames: [
         '!grafana/loki',
       ],
-      autoApprove: false,
-      automerge: false,
     },
     {
-      // Auto-merge minor and patch Go module updates after 3 days
-      matchManagers: [
-        'gomod',
-      ],
-      matchFileNames: [
-        '!operator/go.mod',
-        '!operator/api/loki/go.mod',
-        '!pkg/push/go.mod',
-      ],
-      groupName: '{{packageName}}',
-      enabled: true,
-      matchUpdateTypes: [
-        'minor',
-        'patch',
-      ],
-      minimumReleaseAge: '3 days',
-      automerge: true,
-      autoApprove: true,
-    },
-    {
-      // Don't auto-merge major Go module updates, wait 3 days
+      // Wait 3 days before opening Go module updates
       matchManagers: [
         'gomod',
       ],
@@ -127,16 +98,16 @@
       enabled: true,
       matchUpdateTypes: [
         'major',
+        'minor',
+        'patch',
       ],
       minimumReleaseAge: '3 days',
-      automerge: false,
-      autoApprove: false,
     },
     {
       // Group the aws-sdk-go-v2 family into a single PR. The sub-modules version in
       // lockstep, so per-module PRs (via the '{{packageName}}' grouping above) conflict
       // against each other on the shared go.sum. This overrides only groupName, inheriting
-      // the enable/automerge/minimumReleaseAge behaviour from the gomod rules above.
+      // the enable/minimumReleaseAge behaviour from the gomod rule above.
       matchManagers: [
         'gomod',
       ],
@@ -244,23 +215,17 @@
         'operator/api/loki/go.mod',
       ],
       enabled: false,
-      autoApprove: false,
-      automerge: false,
     },
     {
       // Disable all updates for pkg/push/go.mod (deps of the submodule).
       matchFileNames: ['pkg/push/go.mod'],
       enabled: false,
-      autoApprove: false,
-      automerge: false,
     },
     {
       // Do not bump github.com/grafana/loki/pkg/push in any go.mod.
       matchManagers: ['gomod'],
       matchPackageNames: ['github.com/grafana/loki/pkg/push'],
       enabled: false,
-      autoApprove: false,
-      automerge: false,
     },
     {
       // Release branches take security updates only. 'vulnerabilityAlerts' is merged after
@@ -295,8 +260,6 @@
       'area/security',
       'severity:{{vulnerabilitySeverity}}',
     ],
-    automerge: false,
-    autoApprove: false,
   },
   osvVulnerabilityAlerts: true,
   prConcurrentLimit: 0,


### PR DESCRIPTION
**What this PR does / why we need it**:

A recent security policy change means we can no longer merge PRs without a human review, so the automerge setup this repository maintained on its own no longer applies.

Rather than replacing it with an explicit `automerge: false`, this drops the `presets/automerge` extend and every `automerge`/`autoApprove` override, so we simply follow the org-wide Renovate defaults instead of keeping a repository-local merge policy.

Notes:
- Nothing else in the repository was driving the merges: there is no automerge GitHub Action or workflow here, and nothing consumed the `automerge-patch` label. It was only a marker added by `presets/automerge`.
- The `automerge-patch` label is left in place so it stays on historical PRs. New PRs will no longer get it, and patch/pin/digest updates will now get the usual `dependencies` label instead (the preset used `labels`, which replaced it).
- `automerge-security-update` is applied by the org-wide self-hosted Renovate config and is not something this repository can change.
- With the `automerge`/`autoApprove` keys gone the two `gomod` rules only differed by `matchUpdateTypes`, so they collapse into one rule with the same 3-day wait.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

`renovate-config-validator` output is unchanged from `main` (the `baseBranchPatterns` error and the `matchBaseBranches` warnings are pre-existing, from the validator version not knowing that option).

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
