### PR TITLE
chore!: Remove the disable_broad_index_queries setting

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -82,6 +82,7 @@ As a result, the following have been removed:
 - The setting `-store.index-cache-read` (`storage_config.index_queries_cache_config` block in the yaml file) has been removed as it was only used for legacy storage backends (`boltdb-shipper`) that have been removed as well.
 - The setting `-store.index-cache-validity` (`storage_config.index_cache_validity` block in the yaml file) has been removed as it was only used in combination with the removed `-store.index-cache-read` setting.
 - The setting `-store.cache-lookups-older-than` (`chunk_store_config.cache_lookups_older_than` in the yaml file) has been removed as it was only used to cache index entries for legacy storage backends that have been removed as well.
+- The setting `-store.disable-broad-index-queries` (`storage_config.disable_broad_index_queries` in the yaml file) has been removed as it was only used for legacy storage backends that have been removed as well.
 - The `chunks` block (`chunks:` under a `schema_config` `period_config` in the yaml file) has been removed as it only configured chunk tables for legacy storage backends that have been removed as well. TSDB stores chunks directly in object storage. Remove the `chunks` block from every `period_config`.
 - The `tags` setting (`tags:` under the `index` block of a `schema_config` `period_config` in the yaml file) has been removed as it only applied to managed tables of legacy storage backends that have been removed as well. Remove the `tags` setting from every `period_config`.
 

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -6794,11 +6794,6 @@ congestion_control:
 # CLI flag: -store.object-prefix
 [object_prefix: <string> | default = ""]
 
-# Disable broad index queries which results in reduced cache usage and faster
-# query performance at the expense of somewhat higher QPS on the index store.
-# CLI flag: -store.disable-broad-index-queries
-[disable_broad_index_queries: <boolean> | default = false]
-
 # Maximum number of parallel chunk reads.
 # CLI flag: -store.max-parallel-get-chunk
 [max_parallel_get_chunk: <int> | default = 150]

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -270,8 +270,7 @@ type Config struct {
 	CongestionControl    congestion.Config         `yaml:"congestion_control,omitempty"`
 	ObjectPrefix         string                    `yaml:"object_prefix" doc:"description=Experimental. Sets a constant prefix for all keys inserted into object storage. Example: loki/"`
 
-	DisableBroadIndexQueries bool `yaml:"disable_broad_index_queries"`
-	MaxParallelGetChunk      int  `yaml:"max_parallel_get_chunk"`
+	MaxParallelGetChunk int `yaml:"max_parallel_get_chunk"`
 
 	UseThanosObjstore bool                         `yaml:"use_thanos_objstore"`
 	ObjectStore       bucket.ConfigWithNamedStores `yaml:"object_store"`
@@ -308,7 +307,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.ObjectStore.RegisterFlagsWithPrefix("object-store.", f)
 
 	f.StringVar(&cfg.ObjectPrefix, "store.object-prefix", "", "The prefix to all keys inserted in object storage. Example: loki-instances/west/")
-	f.BoolVar(&cfg.DisableBroadIndexQueries, "store.disable-broad-index-queries", false, "Disable broad index queries which results in reduced cache usage and faster query performance at the expense of somewhat higher QPS on the index store.")
 	f.IntVar(&cfg.MaxParallelGetChunk, "store.max-parallel-get-chunk", 150, "Maximum number of parallel chunk reads.")
 
 	f.IntVar(&cfg.MaxChunkBatchSize, "store.max-chunk-batch-size", 50, "The maximum number of chunks to fetch per batch.")

--- a/tools/deprecated-config-checker/checker/checker_test.go
+++ b/tools/deprecated-config-checker/checker/checker_test.go
@@ -52,6 +52,7 @@ var (
 		"storage_config.aws.dynamodb",
 		"storage_config.index_queries_cache_config",
 		"storage_config.index_cache_validity",
+		"storage_config.disable_broad_index_queries",
 		"schema_config.configs.[0].chunks",
 		"schema_config.configs.[0].index.tags",
 		"schema_config.configs.[1].store",

--- a/tools/deprecated-config-checker/deleted-config.yaml
+++ b/tools/deprecated-config-checker/deleted-config.yaml
@@ -71,6 +71,7 @@ storage_config:
   grpc_store: "Support for gRPC store is removed."
   index_queries_cache_config: "Index read cache configuration is removed."
   index_cache_validity: "Index cache validity is removed."
+  disable_broad_index_queries: "Broad index queries are removed along with the legacy index types."
   boltdb_shipper:
     shared_store: "object_store setting in the period_config will be used to configure the store for the index."
     shared_store_key_prefix: "Path prefix for storing the index can now be configured by setting path_prefix under index key in period_config."

--- a/tools/deprecated-config-checker/test-fixtures/config.yaml
+++ b/tools/deprecated-config-checker/test-fixtures/config.yaml
@@ -63,6 +63,7 @@ ruler:
       url: "http://localhost:3100/api/prom/push"
 
 storage_config:
+  disable_broad_index_queries: true # DELETED
   bigtable: # DEPRECATED
     project: "my-project"
   cassandra: # DEPRECATED


### PR DESCRIPTION
**What this PR does / why we need it**:

`-store.disable-broad-index-queries` (`storage_config.disable_broad_index_queries`) disabled broad index queries for the legacy index types. Its last read was deleted in #21986 along with those index types, so **the setting has been silently ignored ever since** while remaining registered and documented. I'm removing it in this PR.

Note: this is the direct sibling of `cache_lookups_older_than`: #21986 orphaned both, and only the latter was cleaned up in #23662.

**Special notes for your reviewer**:

N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory