### PR TITLE
chore!: Remove `row_shards` from the schema configuration

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -37,6 +37,10 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 ## Main / Unreleased
 
+### Breaking change: Removal of the `row_shards` schema setting
+
+The `row_shards` setting on a `schema_config` `period_config` has been removed. It configured a static query shard factor for legacy (non-TSDB) index types. TSDB, the only supported index type, resolves log and metric query sharding dynamically from index statistics and ignores `row_shards`; series queries continue to use the previous default factor of 16. Because schema config is parsed strictly, a leftover `row_shards:` key now fails config load. Remove the `row_shards` setting from every `period_config`; the `deprecated-config-checker` tool will flag it.
+
 ### TSDB schema v14
 
 Loki now supports the experimental TSDB storage schema `v14`. Schema v14 uses the

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -5514,9 +5514,6 @@ index:
 
   # Table period.
   [period: <duration>]
-
-# How many shards will be created. Only used if schema is v10 or greater.
-[row_shards: <int> | default = 16]
 ```
 
 ### profiling

--- a/integration/bloom_building_test.go
+++ b/integration/bloom_building_test.go
@@ -199,7 +199,6 @@ func createBloomStore(t *testing.T, sharedPath string) *bloomshipper.BloomStore 
 				IndexType:  types.IndexTypeTSDB,
 				ObjectType: types.StorageTypeFileSystem,
 				Schema:     "v13",
-				RowShards:  16,
 			},
 		},
 	}

--- a/pkg/bloombuild/builder/builder_test.go
+++ b/pkg/bloombuild/builder/builder_test.go
@@ -43,7 +43,6 @@ func setupBuilder(t *testing.T, plannerAddr string, limits Limits, logger log.Lo
 				IndexType:  types.IndexTypeTSDB,
 				ObjectType: types.StorageTypeFileSystem,
 				Schema:     "v13",
-				RowShards:  16,
 			},
 		},
 	}

--- a/pkg/bloombuild/planner/planner_test.go
+++ b/pkg/bloombuild/planner/planner_test.go
@@ -53,7 +53,6 @@ func createPlanner(
 				IndexType:  types.IndexTypeTSDB,
 				ObjectType: types.StorageTypeFileSystem,
 				Schema:     "v13",
-				RowShards:  16,
 			},
 		},
 	}

--- a/pkg/bloomgateway/bloomgateway_test.go
+++ b/pkg/bloomgateway/bloomgateway_test.go
@@ -79,7 +79,6 @@ func setupBloomStore(t *testing.T) *bloomshipper.BloomStore {
 		IndexType:  types.IndexTypeTSDB,
 		ObjectType: types.StorageTypeFileSystem,
 		Schema:     "v13",
-		RowShards:  16,
 	}
 	schemaCfg := config.SchemaConfig{
 		Configs: []config.PeriodConfig{p},

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -173,7 +173,6 @@ func Test_schemaPeriodForTable(t *testing.T) {
 					Prefix: indexTablePrefix,
 					Period: time.Hour * 24,
 				}},
-			RowShards: 16,
 		},
 		{
 			From:       dayFromTime(start.Add(25 * time.Hour)),
@@ -186,7 +185,6 @@ func Test_schemaPeriodForTable(t *testing.T) {
 					Prefix: indexTablePrefix,
 					Period: time.Hour * 24,
 				}},
-			RowShards: 16,
 		},
 		{
 			From:       dayFromTime(start.Add(73 * time.Hour)),
@@ -199,7 +197,6 @@ func Test_schemaPeriodForTable(t *testing.T) {
 					Prefix: tsdbIndexTablePrefix,
 					Period: time.Hour * 24,
 				}},
-			RowShards: 16,
 		},
 		{
 			From:       dayFromTime(start.Add(100 * time.Hour)),
@@ -212,7 +209,6 @@ func Test_schemaPeriodForTable(t *testing.T) {
 					Prefix: indexTablePrefix,
 					Period: time.Hour * 24,
 				}},
-			RowShards: 16,
 		},
 	}}
 	tests := []struct {

--- a/pkg/compactor/index_set_test.go
+++ b/pkg/compactor/index_set_test.go
@@ -152,7 +152,6 @@ func TestIndexSet_ApplyIndexUpdates(t *testing.T) {
 						Prefix: "index_",
 						Period: time.Hour * 24,
 					}},
-				RowShards: 16,
 			},
 		},
 	}

--- a/pkg/compactor/retention/util_test.go
+++ b/pkg/compactor/retention/util_test.go
@@ -50,7 +50,6 @@ var (
 						Prefix: "index_",
 						Period: time.Hour * 24,
 					}},
-				RowShards: 16,
 			},
 			{
 				From:       dayFromTime(start.Add(25 * time.Hour)),
@@ -62,7 +61,6 @@ var (
 						Prefix: "index_",
 						Period: time.Hour * 24,
 					}},
-				RowShards: 16,
 			},
 			{
 				From:       dayFromTime(start.Add(73 * time.Hour)),
@@ -74,7 +72,6 @@ var (
 						Prefix: "index_",
 						Period: time.Hour * 24,
 					}},
-				RowShards: 16,
 			},
 			{
 				From:       dayFromTime(start.Add(100 * time.Hour)),
@@ -86,7 +83,6 @@ var (
 						Prefix: "index_",
 						Period: time.Hour * 24,
 					}},
-				RowShards: 16,
 			},
 			{
 				From:       dayFromTime(start.Add(125 * time.Hour)),
@@ -98,7 +94,6 @@ var (
 						Prefix: "index_",
 						Period: time.Hour * 24,
 					}},
-				RowShards: 16,
 			},
 			{
 				From:       dayFromTime(start.Add(150 * time.Hour)),
@@ -110,7 +105,6 @@ var (
 						Prefix: "index_",
 						Period: time.Hour * 24,
 					}},
-				RowShards: 16,
 			},
 		},
 	}

--- a/pkg/compactor/table_test.go
+++ b/pkg/compactor/table_test.go
@@ -529,7 +529,6 @@ func TestTable_applyStorageUpdates(t *testing.T) {
 						Prefix: "index_",
 						Period: time.Hour * 24,
 					}},
-				RowShards: 16,
 			},
 		},
 	}

--- a/pkg/labelaccess/store_wrapper_test.go
+++ b/pkg/labelaccess/store_wrapper_test.go
@@ -199,7 +199,6 @@ func getLocalStore(t *testing.T) storage.Store {
 				IndexType:  loki_types.IndexTypeTSDB,
 				ObjectType: loki_types.StorageTypeFileSystem,
 				Schema:     "v13",
-				RowShards:  16,
 				IndexTables: storage_config.IndexPeriodicTableConfig{
 					PeriodicTableConfig: storage_config.PeriodicTableConfig{
 						Prefix: "index_",

--- a/pkg/logql/bench/store_chunk.go
+++ b/pkg/logql/bench/store_chunk.go
@@ -89,7 +89,6 @@ func NewChunkStoreWithRegisterer(dir, tenantID string, reg prometheus.Registerer
 				Period: time.Hour * 24,
 			},
 		},
-		RowShards: 16,
 	}
 	schemaCfg := config.SchemaConfig{
 		Configs: []config.PeriodConfig{

--- a/pkg/logql/internal/logqltest/store.go
+++ b/pkg/logql/internal/logqltest/store.go
@@ -61,7 +61,6 @@ func newTestingChunkStore(t *testing.T) *testingChunkStore {
 			PathPrefix:          "index/",
 			PeriodicTableConfig: config.PeriodicTableConfig{Prefix: "index_", Period: 24 * time.Hour},
 		},
-		RowShards: 16,
 	}
 	schemaCfg := config.SchemaConfig{Configs: []config.PeriodConfig{period}}
 

--- a/pkg/loki/config_compat.go
+++ b/pkg/loki/config_compat.go
@@ -2,7 +2,6 @@ package loki
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/grafana/loki/v3/pkg/ingester/index"
 	frontend "github.com/grafana/loki/v3/pkg/lokifrontend/frontend/v2"
@@ -24,23 +23,15 @@ func ValidateConfigCompatibility(c Config) []error {
 
 func ensureInvertedIndexShardingCompatibility(c Config) error {
 
-	for i, sc := range c.SchemaConfig.Configs {
-		switch sc.IndexType {
-		case types.IndexTypeTSDB:
-			if err := index.ValidateBitPrefixShardFactor(uint32(c.Ingester.IndexShards)); err != nil {
-				return err
-			}
-		default:
-			if sc.RowShards > 0 && c.Ingester.IndexShards%int(sc.RowShards) > 0 {
-				return fmt.Errorf(
-					"incompatible ingester index shards (%d) and period config row shard factor (%d) for period config at index (%d). The ingester factor must be evenly divisible by all period config factors",
-					c.Ingester.IndexShards,
-					sc.RowShards,
-					i,
-				)
-			}
+	// TSDB is the only supported index type; other types are rejected at store
+	// construction.
+	for _, sc := range c.SchemaConfig.Configs {
+		if sc.IndexType != types.IndexTypeTSDB {
+			continue
 		}
-
+		if err := index.ValidateBitPrefixShardFactor(uint32(c.Ingester.IndexShards)); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/loki/config_test.go
+++ b/pkg/loki/config_test.go
@@ -39,7 +39,6 @@ func TestCrossComponentValidation(t *testing.T) {
 									Period: 24 * time.Hour,
 								},
 							},
-							RowShards: 16,
 						},
 					},
 				},

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -276,8 +276,7 @@ func minimalWorkingConfig(t *testing.T, dir, target string, cfgTransformers ...f
 					PeriodicTableConfig: config.PeriodicTableConfig{
 						Period: time.Hour * 24,
 					}},
-				RowShards: 16,
-				Schema:    "v11",
+				Schema: "v11",
 				From: config.DayTime{
 					Time: model.Now(),
 				},

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -200,24 +200,20 @@ func (ast *astMapperware) Do(ctx context.Context, r queryrangebase.Request) (que
 		return ast.next.Do(ctx, r)
 	}
 
-	var strategy logql.ShardingStrategy
-
-	if conf.IndexType == types.IndexTypeTSDB {
-		v := ast.limits.TSDBShardingStrategy(ctx, tenants[0])
-		version, err := logql.ParseShardVersion(v)
-		if err != nil {
-			level.Warn(spLogger).Log(
-				"msg", "failed to parse shard version",
-				"fallback", version.String(),
-				"err", err.Error(),
-				"user", tenants[0],
-				"query", r.GetQuery(),
-			)
-		}
-		strategy = version.Strategy(resolver, uint64(ast.limits.TSDBMaxBytesPerShard(tenants[0])))
-	} else {
-		strategy = logql.NewPowerOfTwoStrategy(resolver)
+	// TSDB is the only supported index type, so the resolver is always dynamic
+	// and the sharding strategy is selected per-tenant.
+	v := ast.limits.TSDBShardingStrategy(ctx, tenants[0])
+	version, err := logql.ParseShardVersion(v)
+	if err != nil {
+		level.Warn(spLogger).Log(
+			"msg", "failed to parse shard version",
+			"fallback", version.String(),
+			"err", err.Error(),
+			"user", tenants[0],
+			"query", r.GetQuery(),
+		)
 	}
+	strategy := version.Strategy(resolver, uint64(ast.limits.TSDBMaxBytesPerShard(tenants[0])))
 
 	// Merge global shard aggregations and tenant overrides.
 	limitShardAggregation := validation.IntersectionPerTenant(tenants, func(tenant string) []string {
@@ -349,7 +345,7 @@ func (splitter *shardSplitter) Do(ctx context.Context, r queryrangebase.Request)
 
 func hasShards(confs ShardingConfigs) bool {
 	for _, conf := range confs {
-		if conf.RowShards > 0 || conf.IndexType == types.IndexTypeTSDB {
+		if conf.IndexType == types.IndexTypeTSDB {
 			return true
 		}
 	}
@@ -385,11 +381,6 @@ func (confs ShardingConfigs) GetConf(start, end int64) (config.PeriodConfig, err
 	// query exists across multiple sharding configs
 	if err != nil {
 		return conf, err
-	}
-
-	// query doesn't have shard factor, so don't try to do AST mapping.
-	if conf.RowShards < 2 && conf.IndexType != types.IndexTypeTSDB {
-		return conf, errors.Errorf("shard factor not high enough: [%d]", conf.RowShards)
 	}
 
 	return conf, nil

--- a/pkg/querier/queryrange/querysharding.go
+++ b/pkg/querier/queryrange/querysharding.go
@@ -429,9 +429,9 @@ type seriesShardingHandler struct {
 }
 
 func (ss *seriesShardingHandler) Do(ctx context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
-	conf, err := ss.confs.GetConf(r.GetStart().UnixMilli(), r.GetEnd().UnixMilli())
-	// cannot shard with this timerange
-	if err != nil {
+	// GetConf validates that the request fits within a single sharding config;
+	// the returned config is otherwise unused since the shard factor is fixed.
+	if _, err := ss.confs.GetConf(r.GetStart().UnixMilli(), r.GetEnd().UnixMilli()); err != nil {
 		level.Warn(ss.logger).Log("err", err.Error(), "msg", "skipped sharding for request")
 		return ss.next.Do(ctx, r)
 	}
@@ -442,14 +442,14 @@ func (ss *seriesShardingHandler) Do(ctx context.Context, r queryrangebase.Reques
 	}
 
 	ss.metrics.DownstreamQueries.WithLabelValues("series").Inc()
-	ss.metrics.DownstreamFactor.Observe(float64(conf.RowShards))
+	ss.metrics.DownstreamFactor.Observe(float64(config.DefaultRowShards))
 
-	requests := make([]queryrangebase.Request, 0, conf.RowShards)
-	for i := 0; i < int(conf.RowShards); i++ {
+	requests := make([]queryrangebase.Request, 0, config.DefaultRowShards)
+	for i := 0; i < config.DefaultRowShards; i++ {
 		shardedRequest := *req
 		shardedRequest.Shards = []string{astmapper.ShardAnnotation{
 			Shard: i,
-			Of:    int(conf.RowShards),
+			Of:    config.DefaultRowShards,
 		}.String()}
 		requests = append(requests, &shardedRequest)
 	}

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
-	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange/queryrangebase/definitions"
@@ -311,7 +310,6 @@ func Test_astMapper_QuerySizeLimits(t *testing.T) {
 			mware := newASTMapperware(
 				ShardingConfigs{
 					config.PeriodConfig{
-						RowShards: 2,
 						IndexType: types.IndexTypeTSDB,
 					},
 				},
@@ -417,7 +415,7 @@ func Test_ShardingByPass(t *testing.T) {
 	mware := newASTMapperware(
 		ShardingConfigs{
 			config.PeriodConfig{
-				RowShards: 2,
+				IndexType: types.IndexTypeTSDB,
 			},
 		},
 		testEngineOpts,
@@ -426,7 +424,7 @@ func Test_ShardingByPass(t *testing.T) {
 		nil,
 		log.NewNopLogger(),
 		nilShardingMetrics,
-		fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1},
+		fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1, tsdbMaxQueryParallelism: 1},
 		0,
 		[]string{},
 	)
@@ -573,7 +571,6 @@ func Test_InstantSharding(t *testing.T) {
 func Test_SeriesShardingHandler(t *testing.T) {
 	sharding := NewSeriesQueryShardMiddleware(log.NewNopLogger(), ShardingConfigs{
 		config.PeriodConfig{
-			RowShards: 3,
 			IndexType: types.IndexTypeTSDB,
 		},
 	},
@@ -615,37 +612,26 @@ func Test_SeriesShardingHandler(t *testing.T) {
 		Path:    "foo",
 	})
 
-	expected := &LokiSeriesResponse{
-		Statistics: stats.Result{Summary: stats.Summary{Splits: 3}},
-		Status:     "success",
-		Version:    1,
-		Data: []logproto.SeriesIdentifier{
-			{
-				Labels: []logproto.SeriesIdentifier_LabelsEntry{
-					{Key: "foo", Value: "bar"},
-				},
-			},
-			{
-				Labels: []logproto.SeriesIdentifier_LabelsEntry{
-					{Key: "shard", Value: "0_of_3"},
-				},
-			},
-			{
-				Labels: []logproto.SeriesIdentifier_LabelsEntry{
-					{Key: "shard", Value: "1_of_3"},
-				},
-			},
-			{
-				Labels: []logproto.SeriesIdentifier_LabelsEntry{
-					{Key: "shard", Value: "2_of_3"},
-				},
+	// Series queries fan out into config.DefaultRowShards shards.
+	expectedData := []logproto.SeriesIdentifier{
+		{
+			Labels: []logproto.SeriesIdentifier_LabelsEntry{
+				{Key: "foo", Value: "bar"},
 			},
 		},
 	}
+	for i := 0; i < config.DefaultRowShards; i++ {
+		expectedData = append(expectedData, logproto.SeriesIdentifier{
+			Labels: []logproto.SeriesIdentifier_LabelsEntry{
+				{Key: "shard", Value: fmt.Sprintf("%d_of_%d", i, config.DefaultRowShards)},
+			},
+		})
+	}
+
 	actual := response.(*LokiSeriesResponse)
 	require.NoError(t, err)
-	require.Equal(t, expected.Status, actual.Status)
-	require.ElementsMatch(t, expected.Data, actual.Data)
+	require.Equal(t, "success", actual.Status)
+	require.ElementsMatch(t, expectedData, actual.Data)
 }
 
 func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
@@ -653,12 +639,10 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 	confs := ShardingConfigs{
 		{
 			From:      config.DayTime{Time: now.Add(-30 * 24 * time.Hour)},
-			RowShards: 2,
 			IndexType: types.IndexTypeTSDB,
 		},
 		{
 			From:      config.DayTime{Time: now.Add(-24 * time.Hour)},
-			RowShards: 3,
 			IndexType: types.IndexTypeTSDB,
 		},
 	}
@@ -846,12 +830,10 @@ func TestShardingAcrossConfigs_SeriesSharding(t *testing.T) {
 	confs := ShardingConfigs{
 		{
 			From:      config.DayTime{Time: now.Add(-30 * 24 * time.Hour)},
-			RowShards: 2,
 			IndexType: types.IndexTypeTSDB,
 		},
 		{
 			From:      config.DayTime{Time: now.Add(-24 * time.Hour)},
-			RowShards: 3,
 			IndexType: types.IndexTypeTSDB,
 		},
 	}
@@ -869,7 +851,7 @@ func TestShardingAcrossConfigs_SeriesSharding(t *testing.T) {
 				EndTs:   now.Time(),
 				Path:    "foo",
 			},
-			numExpectedShards: 3,
+			numExpectedShards: 16,
 		},
 		{
 			name: "series query touching just the prev schema config",
@@ -879,7 +861,7 @@ func TestShardingAcrossConfigs_SeriesSharding(t *testing.T) {
 				EndTs:   confs[0].From.Time.Add(time.Hour).Time(),
 				Path:    "foo",
 			},
-			numExpectedShards: 2,
+			numExpectedShards: 16,
 		},
 		{
 			name: "series query covering both schemas",

--- a/pkg/querier/queryrange/querysharding_test.go
+++ b/pkg/querier/queryrange/querysharding_test.go
@@ -160,20 +160,29 @@ func Test_astMapper(t *testing.T) {
 		return resp, nil
 	})
 
+	// TSDB is the only index type; sharding is resolved dynamically from index
+	// stats. Return a large byte count and cap the factor via maxShards so the
+	// query deterministically shards into 2.
+	statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		return &IndexStatsResponse{
+			Response: &logproto.IndexStatsResponse{Bytes: 1 << 40},
+		}, nil
+	})
+
 	mware := newASTMapperware(
 		ShardingConfigs{
 			config.PeriodConfig{
-				RowShards: 2,
+				IndexType: types.IndexTypeTSDB,
 			},
 		},
 		testEngineOpts,
 		handler,
 		handler,
-		nil,
+		statsHandler,
 		log.NewNopLogger(),
 		nilShardingMetrics,
-		fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1, queryTimeout: time.Second},
-		0,
+		fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1, tsdbMaxQueryParallelism: 1, queryTimeout: time.Second},
+		2,
 		[]string{},
 	)
 
@@ -446,14 +455,14 @@ func Test_hasShards(t *testing.T) {
 		},
 		{
 			input: ShardingConfigs{
-				{RowShards: 16},
+				{IndexType: types.IndexTypeTSDB},
 			},
 			expected: true,
 		},
 		{
 			input: ShardingConfigs{
 				{},
-				{RowShards: 16},
+				{IndexType: types.IndexTypeTSDB},
 				{},
 			},
 			expected: true,
@@ -488,19 +497,28 @@ func Test_InstantSharding(t *testing.T) {
 	called := 0
 	shards := []string{}
 
-	cpyPeriodConf := testSchemas[0]
-	cpyPeriodConf.RowShards = 3
+	// TSDB is the only index type; sharding is resolved dynamically from index
+	// stats. Return a large byte count and cap the factor via maxShards so the
+	// query deterministically shards into 3.
+	statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+		return &IndexStatsResponse{
+			Response: &logproto.IndexStatsResponse{Bytes: 1 << 40},
+		}, nil
+	})
+
+	cpyPeriodConf := testSchemasTSDB[0]
 	sharding := NewQueryShardMiddleware(log.NewNopLogger(), ShardingConfigs{
 		cpyPeriodConf,
 	}, testEngineOpts, queryrangebase.NewInstrumentMiddlewareMetrics(nil, constants.Loki),
 		nilShardingMetrics,
 		fakeLimits{
-			maxSeries:           math.MaxInt32,
-			maxQueryParallelism: 10,
-			queryTimeout:        time.Second,
+			maxSeries:               math.MaxInt32,
+			maxQueryParallelism:     10,
+			tsdbMaxQueryParallelism: 10,
+			queryTimeout:            time.Second,
 		},
-		0,
-		nil,
+		3,
+		statsHandler,
 		nil,
 		[]string{},
 	)
@@ -556,12 +574,14 @@ func Test_SeriesShardingHandler(t *testing.T) {
 	sharding := NewSeriesQueryShardMiddleware(log.NewNopLogger(), ShardingConfigs{
 		config.PeriodConfig{
 			RowShards: 3,
+			IndexType: types.IndexTypeTSDB,
 		},
 	},
 		queryrangebase.NewInstrumentMiddlewareMetrics(nil, constants.Loki),
 		nilShardingMetrics,
 		fakeLimits{
-			maxQueryParallelism: 10,
+			maxQueryParallelism:     10,
+			tsdbMaxQueryParallelism: 10,
 		},
 		DefaultCodec,
 	)
@@ -634,10 +654,12 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 		{
 			From:      config.DayTime{Time: now.Add(-30 * 24 * time.Hour)},
 			RowShards: 2,
+			IndexType: types.IndexTypeTSDB,
 		},
 		{
 			From:      config.DayTime{Time: now.Add(-24 * time.Hour)},
 			RowShards: 3,
+			IndexType: types.IndexTypeTSDB,
 		},
 	}
 
@@ -656,7 +678,7 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 					{Name: "Header", Values: []string{"value"}},
 				},
 			},
-			numExpectedShards: 3,
+			numExpectedShards: 2,
 		},
 		{
 			name: "logs query touching just the prev schema config",
@@ -684,7 +706,7 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 					},
 				},
 			},
-			numExpectedShards: 3,
+			numExpectedShards: 2,
 		},
 		{
 			name: "metric query touching just the prev schema config",
@@ -777,16 +799,26 @@ func TestShardingAcrossConfigs_ASTMapper(t *testing.T) {
 				return tc.resp, nil
 			})
 
+			// TSDB is the only index type; sharding is resolved dynamically from
+			// index stats. Return a large byte count and cap the factor via
+			// maxShards so queries scoped to a single schema deterministically
+			// shard into 2, while queries spanning both schemas are not sharded.
+			statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+				return &IndexStatsResponse{
+					Response: &logproto.IndexStatsResponse{Bytes: 1 << 40},
+				}, nil
+			})
+
 			mware := newASTMapperware(
 				confs,
 				testEngineOpts,
 				handler,
 				handler,
-				nil,
+				statsHandler,
 				log.NewNopLogger(),
 				nilShardingMetrics,
-				fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1, queryTimeout: time.Second},
-				0,
+				fakeLimits{maxSeries: math.MaxInt32, maxQueryParallelism: 1, tsdbMaxQueryParallelism: 1, queryTimeout: time.Second},
+				2,
 				[]string{},
 			)
 
@@ -815,10 +847,12 @@ func TestShardingAcrossConfigs_SeriesSharding(t *testing.T) {
 		{
 			From:      config.DayTime{Time: now.Add(-30 * 24 * time.Hour)},
 			RowShards: 2,
+			IndexType: types.IndexTypeTSDB,
 		},
 		{
 			From:      config.DayTime{Time: now.Add(-24 * time.Hour)},
 			RowShards: 3,
+			IndexType: types.IndexTypeTSDB,
 		},
 	}
 
@@ -868,7 +902,8 @@ func TestShardingAcrossConfigs_SeriesSharding(t *testing.T) {
 				queryrangebase.NewInstrumentMiddlewareMetrics(nil, constants.Loki),
 				nilShardingMetrics,
 				fakeLimits{
-					maxQueryParallelism: 10,
+					maxQueryParallelism:     10,
+					tsdbMaxQueryParallelism: 10,
 				},
 				DefaultCodec,
 			)
@@ -931,69 +966,6 @@ func Test_ASTMapper_MaxLookBackPeriod(t *testing.T) {
 		Query:     q,
 		Limit:     1000,
 		TimeTs:    testTime,
-		Direction: logproto.FORWARD,
-		Path:      "/loki/api/v1/query",
-		Plan: &plan.QueryPlan{
-			AST: syntax.MustParseExpr(q),
-		},
-	}
-
-	ctx := user.InjectOrgID(context.Background(), "foo")
-	_, err := mware.Do(ctx, lokiReq)
-	require.NoError(t, err)
-}
-
-func Test_ConstantShardingDefaultIndexType(t *testing.T) {
-	engineOpts := testEngineOpts
-
-	queryHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
-		req.(*LokiInstantRequest).Plan.AST = syntax.MustParseExpr(`{cluster="dev-us-central-0"}`)
-		shards, _, err := logql.ParseShards(req.(*LokiInstantRequest).Shards)
-		require.NoError(t, err)
-		require.Equal(t, 1, len(shards))
-		require.Equal(t, logql.PowerOfTwoVersion, shards[0].Variant())
-		require.Equal(t, uint32(32), shards[0].PowerOfTwo.Of)
-		return &LokiResponse{}, nil
-	})
-
-	statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
-		// This is the actual check that we're testing.
-		require.Equal(t, testTime.Add(-engineOpts.MaxLookBackPeriod).UnixMilli(), req.GetStart().UnixMilli())
-
-		return &IndexStatsResponse{
-			Response: &logproto.IndexStatsResponse{
-				Bytes: 1 << 10,
-			},
-		}, nil
-	})
-	mware := newASTMapperware(
-		ShardingConfigs{
-			{
-				From:      config.DayTime{Time: model.Now().Add(-2 * 24 * time.Hour)},
-				RowShards: 2,
-				IndexType: "tsdb",
-			},
-			{
-				From:      config.DayTime{Time: model.Now().Add(-1 * 24 * time.Hour)},
-				RowShards: 32,
-			},
-		},
-		engineOpts,
-		queryHandler,
-		queryHandler,
-		statsHandler,
-		log.NewNopLogger(),
-		nilShardingMetrics,
-		fakeLimits{maxSeries: math.MaxInt32, tsdbMaxQueryParallelism: 1, queryTimeout: time.Second},
-		0,
-		[]string{},
-	)
-
-	q := `{cluster="dev-us-central-0"}`
-	lokiReq := &LokiInstantRequest{
-		Query:     q,
-		Limit:     1000,
-		TimeTs:    model.Now().Add(-1 * time.Hour).Time(),
 		Direction: logproto.FORWARD,
 		Path:      "/loki/api/v1/query",
 		Plan: &plan.QueryPlan{

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -1283,8 +1283,10 @@ func TestMetricsTripperware_SplitShardStats(t *testing.T) {
 
 	statsTestCfg := testConfig
 	statsTestCfg.ShardedQueries = true
-	statsSchemas := testSchemas
-	statsSchemas[0].RowShards = 4
+	// TSDB is the only index type; sharding is resolved dynamically from index
+	// stats. The downstream handler below returns a byte count of 4x the default
+	// max bytes per shard so every split deterministically shards into 4.
+	statsSchemas := testSchemasTSDB
 
 	for _, tc := range []struct {
 		name               string
@@ -1340,7 +1342,7 @@ func TestMetricsTripperware_SplitShardStats(t *testing.T) {
 				},
 			},
 			expectedSplitStats: 3,  // 2 hour range interval split based on the base hour + the remainder
-			expectedShardStats: 12, // 3 time splits * 4 row shards
+			expectedShardStats: 20, // range query with a [1h] range vector resolves shards over 5 sharded subqueries * 4 shards each
 		},
 		{
 			name: "range query not split",
@@ -1369,7 +1371,15 @@ func TestMetricsTripperware_SplitShardStats(t *testing.T) {
 
 			ctx := user.InjectOrgID(context.Background(), "1")
 
-			_, h := promqlResult(matrix)
+			_, promHandler := promqlResult(matrix)
+			h := base.HandlerFunc(func(ctx context.Context, r base.Request) (base.Response, error) {
+				if _, ok := r.(*logproto.IndexStatsRequest); ok {
+					return &IndexStatsResponse{
+						Response: &logproto.IndexStatsResponse{Bytes: 4 * 600 << 20},
+					}, nil
+				}
+				return promHandler.Do(ctx, r)
+			})
 			lokiResponse, err := tpw.Wrap(h).Do(ctx, tc.request)
 			require.NoError(t, err)
 

--- a/pkg/querier/queryrange/shard_resolver.go
+++ b/pkg/querier/queryrange/shard_resolver.go
@@ -39,25 +39,24 @@ func shardResolverForConf(
 	statsHandler, next, retryNext queryrangebase.Handler,
 	limits Limits,
 ) (logql.ShardResolver, bool) {
-	if conf.IndexType == types.IndexTypeTSDB {
-		return &dynamicShardResolver{
-			ctx:              ctx,
-			logger:           logger,
-			statsHandler:     statsHandler,
-			retryNextHandler: retryNext,
-			next:             next,
-			limits:           limits,
-			from:             model.Time(r.GetStart().UnixMilli()),
-			through:          model.Time(r.GetEnd().UnixMilli()),
-			maxParallelism:   maxParallelism,
-			maxShards:        maxShards,
-			defaultLookback:  defaultLookback,
-		}, true
-	}
-	if conf.RowShards < 2 {
+	// TSDB is the only supported index type; other types are rejected at store
+	// construction, so sharding is always resolved dynamically.
+	if conf.IndexType != types.IndexTypeTSDB {
 		return nil, false
 	}
-	return logql.ConstantShards(conf.RowShards), true
+	return &dynamicShardResolver{
+		ctx:              ctx,
+		logger:           logger,
+		statsHandler:     statsHandler,
+		retryNextHandler: retryNext,
+		next:             next,
+		limits:           limits,
+		from:             model.Time(r.GetStart().UnixMilli()),
+		through:          model.Time(r.GetEnd().UnixMilli()),
+		maxParallelism:   maxParallelism,
+		maxShards:        maxShards,
+		defaultLookback:  defaultLookback,
+	}, true
 }
 
 type dynamicShardResolver struct {

--- a/pkg/storage/async_store_test.go
+++ b/pkg/storage/async_store_test.go
@@ -80,8 +80,8 @@ func buildMockChunkRef(t *testing.T, num int) []chunk.Chunk {
 
 	periodConfig := config.PeriodConfig{
 
-		From:      config.DayTime{Time: 0},
-		Schema:    "v11",
+		From:   config.DayTime{Time: 0},
+		Schema: "v11",
 	}
 
 	s := config.SchemaConfig{
@@ -124,8 +124,8 @@ func TestAsyncStore_mergeIngesterAndStoreChunks(t *testing.T) {
 	s := config.SchemaConfig{
 		Configs: []config.PeriodConfig{
 			{
-				From:      config.DayTime{Time: 0},
-				Schema:    "v11",
+				From:   config.DayTime{Time: 0},
+				Schema: "v11",
 			},
 		},
 	}

--- a/pkg/storage/async_store_test.go
+++ b/pkg/storage/async_store_test.go
@@ -82,7 +82,6 @@ func buildMockChunkRef(t *testing.T, num int) []chunk.Chunk {
 
 		From:      config.DayTime{Time: 0},
 		Schema:    "v11",
-		RowShards: 16,
 	}
 
 	s := config.SchemaConfig{
@@ -127,7 +126,6 @@ func TestAsyncStore_mergeIngesterAndStoreChunks(t *testing.T) {
 			{
 				From:      config.DayTime{Time: 0},
 				Schema:    "v11",
-				RowShards: 16,
 			},
 		},
 	}

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -42,7 +42,6 @@ func Test_batchIterSafeStart(t *testing.T) {
 	periodConfig := config.PeriodConfig{
 		From:      config.DayTime{Time: 0},
 		Schema:    "v11",
-		RowShards: 16,
 	}
 
 	chunkfmt, headfmt, err := periodConfig.ChunkFormat()
@@ -75,17 +74,14 @@ func Test_newLogBatchChunkIterator(t *testing.T) {
 		{
 			From:      config.DayTime{Time: 0},
 			Schema:    "v11",
-			RowShards: 16,
 		},
 		{
 			From:      config.DayTime{Time: 0},
 			Schema:    "v12",
-			RowShards: 16,
 		},
 		{
 			From:      config.DayTime{Time: 0},
 			Schema:    "v13",
-			RowShards: 16,
 		},
 	}
 
@@ -1019,7 +1015,6 @@ func Test_newSampleBatchChunkIterator(t *testing.T) {
 	periodConfig := config.PeriodConfig{
 		From:      config.DayTime{Time: 0},
 		Schema:    "v11",
-		RowShards: 16,
 	}
 
 	chunkfmt, headfmt, err := periodConfig.ChunkFormat()
@@ -1409,7 +1404,6 @@ func Test_newSampleBatchChunkIterator(t *testing.T) {
 			{
 				From:      config.DayTime{Time: 0},
 				Schema:    "v11",
-				RowShards: 16,
 			},
 		},
 	}
@@ -1447,7 +1441,6 @@ func TestPartitionOverlappingchunks(t *testing.T) {
 	periodConfig := config.PeriodConfig{
 		From:      config.DayTime{Time: 0},
 		Schema:    "v11",
-		RowShards: 16,
 	}
 
 	chunkfmt, headfmt, err := periodConfig.ChunkFormat()
@@ -1538,7 +1531,6 @@ func TestBuildHeapIterator(t *testing.T) {
 	periodConfig := config.PeriodConfig{
 		From:      config.DayTime{Time: 0},
 		Schema:    "v11",
-		RowShards: 16,
 	}
 
 	chunkfmt, headfmt, err := periodConfig.ChunkFormat()
@@ -1711,7 +1703,6 @@ func TestBatchCancel(t *testing.T) {
 	periodConfig := config.PeriodConfig{
 		From:      config.DayTime{Time: 0},
 		Schema:    "v11",
-		RowShards: 16,
 	}
 
 	chunkfmt, headfmt, err := periodConfig.ChunkFormat()
@@ -1743,7 +1734,6 @@ func TestBatchCancel(t *testing.T) {
 			{
 				From:      config.DayTime{Time: 0},
 				Schema:    "v11",
-				RowShards: 16,
 			},
 		},
 	}
@@ -1763,7 +1753,6 @@ func Benchmark_store_OverlappingChunks(b *testing.B) {
 	periodConfig := config.PeriodConfig{
 		From:      config.DayTime{Time: 0},
 		Schema:    "v11",
-		RowShards: 16,
 	}
 
 	chunkfmt, headfmt, err := periodConfig.ChunkFormat()

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -40,8 +40,8 @@ func Test_batchIterSafeStart(t *testing.T) {
 		},
 	}
 	periodConfig := config.PeriodConfig{
-		From:      config.DayTime{Time: 0},
-		Schema:    "v11",
+		From:   config.DayTime{Time: 0},
+		Schema: "v11",
 	}
 
 	chunkfmt, headfmt, err := periodConfig.ChunkFormat()
@@ -72,16 +72,16 @@ func Test_batchIterSafeStart(t *testing.T) {
 func Test_newLogBatchChunkIterator(t *testing.T) {
 	periodConfigs := []config.PeriodConfig{
 		{
-			From:      config.DayTime{Time: 0},
-			Schema:    "v11",
+			From:   config.DayTime{Time: 0},
+			Schema: "v11",
 		},
 		{
-			From:      config.DayTime{Time: 0},
-			Schema:    "v12",
+			From:   config.DayTime{Time: 0},
+			Schema: "v12",
 		},
 		{
-			From:      config.DayTime{Time: 0},
-			Schema:    "v13",
+			From:   config.DayTime{Time: 0},
+			Schema: "v13",
 		},
 	}
 
@@ -1013,8 +1013,8 @@ func Test_newLogBatchChunkIterator(t *testing.T) {
 
 func Test_newSampleBatchChunkIterator(t *testing.T) {
 	periodConfig := config.PeriodConfig{
-		From:      config.DayTime{Time: 0},
-		Schema:    "v11",
+		From:   config.DayTime{Time: 0},
+		Schema: "v11",
 	}
 
 	chunkfmt, headfmt, err := periodConfig.ChunkFormat()
@@ -1402,8 +1402,8 @@ func Test_newSampleBatchChunkIterator(t *testing.T) {
 	s := config.SchemaConfig{
 		Configs: []config.PeriodConfig{
 			{
-				From:      config.DayTime{Time: 0},
-				Schema:    "v11",
+				From:   config.DayTime{Time: 0},
+				Schema: "v11",
 			},
 		},
 	}
@@ -1439,8 +1439,8 @@ func Test_newSampleBatchChunkIterator(t *testing.T) {
 
 func TestPartitionOverlappingchunks(t *testing.T) {
 	periodConfig := config.PeriodConfig{
-		From:      config.DayTime{Time: 0},
-		Schema:    "v11",
+		From:   config.DayTime{Time: 0},
+		Schema: "v11",
 	}
 
 	chunkfmt, headfmt, err := periodConfig.ChunkFormat()
@@ -1529,8 +1529,8 @@ func TestPartitionOverlappingchunks(t *testing.T) {
 func TestBuildHeapIterator(t *testing.T) {
 
 	periodConfig := config.PeriodConfig{
-		From:      config.DayTime{Time: 0},
-		Schema:    "v11",
+		From:   config.DayTime{Time: 0},
+		Schema: "v11",
 	}
 
 	chunkfmt, headfmt, err := periodConfig.ChunkFormat()
@@ -1701,8 +1701,8 @@ func Test_IsInvalidChunkError(t *testing.T) {
 
 func TestBatchCancel(t *testing.T) {
 	periodConfig := config.PeriodConfig{
-		From:      config.DayTime{Time: 0},
-		Schema:    "v11",
+		From:   config.DayTime{Time: 0},
+		Schema: "v11",
 	}
 
 	chunkfmt, headfmt, err := periodConfig.ChunkFormat()
@@ -1732,8 +1732,8 @@ func TestBatchCancel(t *testing.T) {
 	s := config.SchemaConfig{
 		Configs: []config.PeriodConfig{
 			{
-				From:      config.DayTime{Time: 0},
-				Schema:    "v11",
+				From:   config.DayTime{Time: 0},
+				Schema: "v11",
 			},
 		},
 	}
@@ -1751,8 +1751,8 @@ var entry logproto.Entry
 
 func Benchmark_store_OverlappingChunks(b *testing.B) {
 	periodConfig := config.PeriodConfig{
-		From:      config.DayTime{Time: 0},
-		Schema:    "v11",
+		From:   config.DayTime{Time: 0},
+		Schema: "v11",
 	}
 
 	chunkfmt, headfmt, err := periodConfig.ChunkFormat()

--- a/pkg/storage/chunk/cache/background_test.go
+++ b/pkg/storage/chunk/cache/background_test.go
@@ -27,8 +27,8 @@ func TestBackground(t *testing.T) {
 	s := config.SchemaConfig{
 		Configs: []config.PeriodConfig{
 			{
-				From:      config.DayTime{Time: 0},
-				Schema:    "v11",
+				From:   config.DayTime{Time: 0},
+				Schema: "v11",
 			},
 		},
 	}

--- a/pkg/storage/chunk/cache/background_test.go
+++ b/pkg/storage/chunk/cache/background_test.go
@@ -29,7 +29,6 @@ func TestBackground(t *testing.T) {
 			{
 				From:      config.DayTime{Time: 0},
 				Schema:    "v11",
-				RowShards: 16,
 			},
 		},
 	}

--- a/pkg/storage/chunk/cache/cache_test.go
+++ b/pkg/storage/chunk/cache/cache_test.go
@@ -125,8 +125,8 @@ func testChunkFetcher(t *testing.T, c cache.Cache, chunks []chunk.Chunk) {
 	s := config.SchemaConfig{
 		Configs: []config.PeriodConfig{
 			{
-				From:      config.DayTime{Time: 0},
-				Schema:    "v11",
+				From:   config.DayTime{Time: 0},
+				Schema: "v11",
 			},
 		},
 	}
@@ -167,8 +167,8 @@ func testCache(t *testing.T, cache cache.Cache) {
 	s := config.SchemaConfig{
 		Configs: []config.PeriodConfig{
 			{
-				From:      config.DayTime{Time: 0},
-				Schema:    "v11",
+				From:   config.DayTime{Time: 0},
+				Schema: "v11",
 			},
 		},
 	}

--- a/pkg/storage/chunk/cache/cache_test.go
+++ b/pkg/storage/chunk/cache/cache_test.go
@@ -127,7 +127,6 @@ func testChunkFetcher(t *testing.T, c cache.Cache, chunks []chunk.Chunk) {
 			{
 				From:      config.DayTime{Time: 0},
 				Schema:    "v11",
-				RowShards: 16,
 			},
 		},
 	}
@@ -170,7 +169,6 @@ func testCache(t *testing.T, cache cache.Cache) {
 			{
 				From:      config.DayTime{Time: 0},
 				Schema:    "v11",
-				RowShards: 16,
 			},
 		},
 	}

--- a/pkg/storage/chunk/client/testutils/inmemory_storage_client.go
+++ b/pkg/storage/chunk/client/testutils/inmemory_storage_client.go
@@ -70,9 +70,8 @@ func NewMockStorage() *MockStorage {
 			schemaCfg: config.SchemaConfig{
 				Configs: []config.PeriodConfig{
 					{
-						From:      config.DayTime{Time: 0},
-						Schema:    "v11",
-						RowShards: 16,
+						From:   config.DayTime{Time: 0},
+						Schema: "v11",
 					},
 				},
 			},

--- a/pkg/storage/config/schema_config.go
+++ b/pkg/storage/config/schema_config.go
@@ -27,6 +27,12 @@ const (
 	// ObjectStorageIndexRequiredPeriod defines the required index period for object storage based index stores (tsdb)
 	ObjectStorageIndexRequiredPeriod = 24 * time.Hour
 
+	// DefaultRowShards is the fixed number of row shards used to fan out series
+	// queries. It was previously the row_shards schema setting, which was always
+	// left at its default; TSDB (the only index type) resolves log and metric
+	// query sharding dynamically and ignores it.
+	DefaultRowShards = 16
+
 	pathPrefixDelimiter = "/"
 )
 
@@ -115,7 +121,6 @@ type PeriodConfig struct {
 	ObjectType  string                   `yaml:"object_store" doc:"description=Which store to use for the chunks. Either aws (alias s3), azure, gcs, alibabacloud, bos, cos, swift, filesystem, or a named_store (refer to named_stores_config)."`
 	Schema      string                   `yaml:"schema" doc:"description=The schema version to use, current recommended schema is v13."`
 	IndexTables IndexPeriodicTableConfig `yaml:"index" doc:"description=Configures how the index is updated and stored."`
-	RowShards   uint32                   `yaml:"row_shards" doc:"default=16|description=How many shards will be created. Only used if schema is v10 or greater."`
 
 	// Integer representation of schema used for hot path calculation. Populated on unmarshaling.
 	schemaInt *int `yaml:"-"`
@@ -335,15 +340,6 @@ func UsingObjectStorageIndex(configs []PeriodConfig) bool {
 	return usingForPeriodConfigs(configs, IsObjectStorageIndex)
 }
 
-func defaultRowShards(schema string) uint32 {
-	switch schema {
-	case "v9":
-		return 0
-	default:
-		return 16
-	}
-}
-
 // ForEachAfter will call f() on every entry after t, splitting
 // entries if necessary so there is an entry starting at t
 func (cfg *SchemaConfig) ForEachAfter(t model.Time, f func(config *PeriodConfig)) {
@@ -363,10 +359,6 @@ func (cfg *SchemaConfig) ForEachAfter(t model.Time, f func(config *PeriodConfig)
 func (cfg *PeriodConfig) applyDefaults() {
 	if cfg.IndexTables.PathPrefix == "" {
 		cfg.IndexTables.PathPrefix = "index/"
-	}
-
-	if cfg.RowShards == 0 {
-		cfg.RowShards = defaultRowShards(cfg.Schema)
 	}
 }
 
@@ -430,16 +422,11 @@ func (cfg PeriodConfig) validate() error {
 	}
 
 	switch v {
-	case 10, 11, 12, 13, 14:
-		if cfg.RowShards == 0 {
-			return fmt.Errorf("must have row_shards > 0 (current: %d) for schema (%s)", cfg.RowShards, cfg.Schema)
-		}
-	case 9:
+	case 9, 10, 11, 12, 13, 14:
 		return nil
 	default:
 		return errInvalidSchemaVersion
 	}
-	return nil
 }
 
 // Load the yaml file, or build the config from legacy command-line flags

--- a/pkg/storage/config/schema_config_test.go
+++ b/pkg/storage/config/schema_config_test.go
@@ -53,8 +53,7 @@ func TestSchemaConfig_Validate(t *testing.T) {
 			expected: &SchemaConfig{
 				Configs: []PeriodConfig{
 					{
-						Schema:    "v10",
-						RowShards: 16,
+						Schema: "v10",
 						IndexTables: IndexPeriodicTableConfig{
 							PathPrefix:          "index/",
 							PeriodicTableConfig: PeriodicTableConfig{Period: 24 * time.Hour},
@@ -77,54 +76,10 @@ func TestSchemaConfig_Validate(t *testing.T) {
 			expected: &SchemaConfig{
 				Configs: []PeriodConfig{
 					{
-						Schema:    "v10",
-						RowShards: 16,
+						Schema: "v10",
 						IndexTables: IndexPeriodicTableConfig{
 							PathPrefix:          "index/",
 							PeriodicTableConfig: PeriodicTableConfig{Period: 0},
-						},
-					},
-				},
-			},
-			err: nil,
-		},
-		"should set shard factor defaults": {
-			config: &SchemaConfig{
-				Configs: []PeriodConfig{
-					{
-						Schema: "v10",
-					},
-				},
-			},
-			expected: &SchemaConfig{
-				Configs: []PeriodConfig{
-					{
-						Schema:    "v10",
-						RowShards: 16,
-						IndexTables: IndexPeriodicTableConfig{
-							PathPrefix: "index/",
-						},
-					},
-				},
-			},
-			err: nil,
-		},
-		"should not override explicit shard factor": {
-			config: &SchemaConfig{
-				Configs: []PeriodConfig{
-					{
-						Schema:    "v11",
-						RowShards: 6,
-					},
-				},
-			},
-			expected: &SchemaConfig{
-				Configs: []PeriodConfig{
-					{
-						Schema:    "v11",
-						RowShards: 6,
-						IndexTables: IndexPeriodicTableConfig{
-							PathPrefix: "index/",
 						},
 					},
 				},
@@ -216,29 +171,7 @@ func TestPeriodConfig_Validate(t *testing.T) {
 			err: "invalid schema version",
 		},
 		{
-			desc: "v10 with shard factor",
-			in: PeriodConfig{
-				Schema:    "v10",
-				RowShards: 16,
-				IndexTables: IndexPeriodicTableConfig{
-					PathPrefix:          "index/",
-					PeriodicTableConfig: PeriodicTableConfig{Period: 0},
-				},
-			},
-		},
-		{
-			desc: "v11 with shard factor",
-			in: PeriodConfig{
-				Schema:    "v11",
-				RowShards: 16,
-				IndexTables: IndexPeriodicTableConfig{
-					PathPrefix:          "index/",
-					PeriodicTableConfig: PeriodicTableConfig{Period: 0},
-				},
-			},
-		},
-		{
-			desc: "error v10 no specified shard factor",
+			desc: "v10",
 			in: PeriodConfig{
 				Schema: "v10",
 				IndexTables: IndexPeriodicTableConfig{
@@ -246,13 +179,21 @@ func TestPeriodConfig_Validate(t *testing.T) {
 					PeriodicTableConfig: PeriodicTableConfig{Period: 0},
 				},
 			},
-			err: "must have row_shards > 0 (current: 0) for schema (v10)",
+		},
+		{
+			desc: "v11",
+			in: PeriodConfig{
+				Schema: "v11",
+				IndexTables: IndexPeriodicTableConfig{
+					PathPrefix:          "index/",
+					PeriodicTableConfig: PeriodicTableConfig{Period: 0},
+				},
+			},
 		},
 		{
 			desc: "v12",
 			in: PeriodConfig{
-				Schema:    "v12",
-				RowShards: 16,
+				Schema: "v12",
 				IndexTables: IndexPeriodicTableConfig{
 					PathPrefix:          "index/",
 					PeriodicTableConfig: PeriodicTableConfig{Period: 0},
@@ -262,8 +203,7 @@ func TestPeriodConfig_Validate(t *testing.T) {
 		{
 			desc: "v13",
 			in: PeriodConfig{
-				Schema:    "v13",
-				RowShards: 16,
+				Schema: "v13",
 				IndexTables: IndexPeriodicTableConfig{
 					PathPrefix:          "index/",
 					PeriodicTableConfig: PeriodicTableConfig{Period: 0},
@@ -273,8 +213,7 @@ func TestPeriodConfig_Validate(t *testing.T) {
 		{
 			desc: "v14",
 			in: PeriodConfig{
-				Schema:    "v14",
-				RowShards: 16,
+				Schema: "v14",
 				IndexTables: IndexPeriodicTableConfig{
 					PathPrefix:          "index/",
 					PeriodicTableConfig: PeriodicTableConfig{Period: 0},
@@ -386,7 +325,6 @@ func TestSchemaForTime(t *testing.T) {
 					Prefix: "index_",
 					Period: 604800000000000,
 				}},
-			RowShards: 16,
 		},
 		{
 			From:       DayTime{Time: 1564444800000},
@@ -398,7 +336,6 @@ func TestSchemaForTime(t *testing.T) {
 					Prefix: "index_",
 					Period: 604800000000000,
 				}},
-			RowShards: 32,
 		},
 	}}
 
@@ -448,9 +385,8 @@ func TestVersionAsInt(t *testing.T) {
 			schemaCfg: SchemaConfig{
 				Configs: []PeriodConfig{
 					{
-						From:      DayTime{Time: 0},
-						Schema:    "v12",
-						RowShards: 16,
+						From:   DayTime{Time: 0},
+						Schema: "v12",
 					},
 				},
 			},
@@ -461,9 +397,8 @@ func TestVersionAsInt(t *testing.T) {
 			schemaCfg: SchemaConfig{
 				Configs: []PeriodConfig{
 					{
-						From:      DayTime{Time: 0},
-						Schema:    "v13",
-						RowShards: 16,
+						From:   DayTime{Time: 0},
+						Schema: "v13",
 					},
 				},
 			},
@@ -474,9 +409,8 @@ func TestVersionAsInt(t *testing.T) {
 			schemaCfg: SchemaConfig{
 				Configs: []PeriodConfig{
 					{
-						From:      DayTime{Time: 0},
-						Schema:    "v14",
-						RowShards: 16,
+						From:   DayTime{Time: 0},
+						Schema: "v14",
 					},
 				},
 			},
@@ -533,7 +467,7 @@ func TestPeriodConfigFormatMappings(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := PeriodConfig{Schema: tc.schema, RowShards: 16}
+			cfg := PeriodConfig{Schema: tc.schema}
 
 			chunkFmt, headFmt, err := cfg.ChunkFormat()
 			require.NoError(t, err)
@@ -704,7 +638,6 @@ func TestGetIndexStoreTableRanges(t *testing.T) {
 						Prefix: "index_",
 						Period: time.Hour * 24,
 					}},
-				RowShards: 2,
 			},
 			{
 				From:       DayTime{Time: now.Add(5 * 24 * time.Hour)},
@@ -716,7 +649,6 @@ func TestGetIndexStoreTableRanges(t *testing.T) {
 						Prefix: "index_",
 						Period: time.Hour * 24,
 					}},
-				RowShards: 2,
 			},
 		},
 	}
@@ -758,9 +690,8 @@ func TestChunkKeys(t *testing.T) {
 			schemaCfg: SchemaConfig{
 				Configs: []PeriodConfig{
 					{
-						From:      DayTime{Time: 0},
-						Schema:    "v11",
-						RowShards: 16,
+						From:   DayTime{Time: 0},
+						Schema: "v11",
 					},
 				},
 			},
@@ -779,9 +710,8 @@ func TestChunkKeys(t *testing.T) {
 			schemaCfg: SchemaConfig{
 				Configs: []PeriodConfig{
 					{
-						From:      DayTime{Time: 0},
-						Schema:    "v12",
-						RowShards: 16,
+						From:   DayTime{Time: 0},
+						Schema: "v12",
 					},
 				},
 			},

--- a/pkg/storage/lazy_chunk_test.go
+++ b/pkg/storage/lazy_chunk_test.go
@@ -23,17 +23,14 @@ func TestLazyChunkIterator(t *testing.T) {
 		{
 			From:      config.DayTime{Time: 0},
 			Schema:    "v11",
-			RowShards: 16,
 		},
 		{
 			From:      config.DayTime{Time: 0},
 			Schema:    "v12",
-			RowShards: 16,
 		},
 		{
 			From:      config.DayTime{Time: 0},
 			Schema:    "v13",
-			RowShards: 16,
 		},
 	}
 

--- a/pkg/storage/lazy_chunk_test.go
+++ b/pkg/storage/lazy_chunk_test.go
@@ -21,16 +21,16 @@ import (
 func TestLazyChunkIterator(t *testing.T) {
 	periodConfigs := []config.PeriodConfig{
 		{
-			From:      config.DayTime{Time: 0},
-			Schema:    "v11",
+			From:   config.DayTime{Time: 0},
+			Schema: "v11",
 		},
 		{
-			From:      config.DayTime{Time: 0},
-			Schema:    "v12",
+			From:   config.DayTime{Time: 0},
+			Schema: "v12",
 		},
 		{
-			From:      config.DayTime{Time: 0},
-			Schema:    "v13",
+			From:   config.DayTime{Time: 0},
+			Schema: "v13",
 		},
 	}
 

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -86,7 +86,6 @@ func getLocalStore(path string, cm ClientMetrics) Store {
 						Prefix: "index_",
 						Period: time.Hour * 24,
 					}},
-				RowShards: 16,
 			},
 		},
 	}
@@ -1237,7 +1236,6 @@ func TestStore_indexPrefixChange(t *testing.T) {
 				Prefix: "index_tsdb_",
 				Period: time.Hour * 24,
 			}},
-		RowShards: 2,
 	}
 	schemaConfig.Configs = append(schemaConfig.Configs, periodConfig2)
 
@@ -1351,7 +1349,6 @@ func TestStore_MultiPeriod(t *testing.T) {
 						Prefix: "index_",
 						Period: time.Hour * 24,
 					}},
-				RowShards: 2,
 			}
 
 			schemaConfig := config.SchemaConfig{
@@ -1676,7 +1673,6 @@ func TestStore_BoltdbTsdbSameIndexPrefix(t *testing.T) {
 						Prefix: "index_",
 						Period: time.Hour * 24,
 					}},
-				RowShards: 2,
 			},
 			{
 				From:       config.DayTime{Time: timeToModelTime(newStartDate)},
@@ -1816,7 +1812,6 @@ func TestStore_SyncStopInteraction(t *testing.T) {
 						Prefix: "index_",
 						Period: time.Hour * 24,
 					}},
-				RowShards: 2,
 			},
 			{
 				From:       config.DayTime{Time: timeToModelTime(newStartDate)},

--- a/pkg/storage/stores/shipper/bloomshipper/fetcher_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/fetcher_test.go
@@ -62,7 +62,6 @@ func TestMetasFetcher(t *testing.T) {
 						Period: 24 * time.Hour,
 					},
 				},
-				RowShards: 16,
 			},
 		},
 	}

--- a/tools/deprecated-config-checker/checker/checker_test.go
+++ b/tools/deprecated-config-checker/checker/checker_test.go
@@ -53,6 +53,7 @@ var (
 		"storage_config.index_queries_cache_config",
 		"storage_config.index_cache_validity",
 		"storage_config.disable_broad_index_queries",
+		"schema_config.configs.[0].row_shards",
 		"schema_config.configs.[0].chunks",
 		"schema_config.configs.[0].index.tags",
 		"schema_config.configs.[1].store",

--- a/tools/deprecated-config-checker/deleted-config.yaml
+++ b/tools/deprecated-config-checker/deleted-config.yaml
@@ -63,6 +63,7 @@ schema_config:
     chunks: "The chunks block is removed as it only configured chunk tables for removed legacy storage backends. TSDB stores chunks directly in object storage."
     index:
       tags: "The tags setting is removed as it only applied to managed tables of removed legacy storage backends."
+    row_shards: "The row_shards setting is removed. It configured a static query shard factor for removed legacy index types; TSDB resolves query sharding dynamically."
 
 storage_config:
   bigtable: "Support for Bigtable is removed."

--- a/tools/deprecated-config-checker/test-fixtures/config.yaml
+++ b/tools/deprecated-config-checker/test-fixtures/config.yaml
@@ -95,6 +95,7 @@ schema_config:
     - from: 2020-10-10
       store: tsdb
       object_store: aws
+      row_shards: 16 # DELETED
       chunks: # DELETED
         prefix: chunks_
         period: 24h

--- a/tools/dev/loki-tsdb-storage-s3/config/loki.yaml
+++ b/tools/dev/loki-tsdb-storage-s3/config/loki.yaml
@@ -110,7 +110,6 @@ schema_config:
       object_store: s3
       schema: v13
       store: tsdb
-      row_shards: 4
 server:
   graceful_shutdown_timeout: 5s
   grpc_server_max_concurrent_streams: 1000


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the `row_shards` setting from `schema_config` `period_config` and deletes the dead non-TSDB query-sharding code it fed into.

**Why:**

TSDB is the only supported index type, that makes `row_shards` and the surrounding "constant shards" machinery effectively unnecessary:

- For **log and metric queries**, TSDB resolves the shard factor dynamically from index statistics (`dynamicShardResolver`) and never reads `row_shards`.
- The only remaining consumer was **series queries**, which fanned out into exactly `row_shards` shards. In practice this value is universally left at its default of `16`.
- The `ConstantShards(row_shards)` fallback in the shard resolver, the `row_shards` branches in `hasShards`/`GetConf` and the astmapper strategy selection, and the non-TSDB `row_shards` compatibility check in `config_compat` were only reachable for index types that can no longer be configured.

Keeping a config knob that silently does nothing (and dead branches guarding for an impossible index type) is a maintenance and usability cost. Promoting the value to a constant removes the config surface while keeping behavior identical.

**What changed:**

The work is split into two commits:

1. `refactor(querier): remove dead non-TSDB query-sharding branches` — pure dead-code cleanup with the field still present, so it builds standalone. Removes the `ConstantShards` fallback in the shard resolver, the non-TSDB guards in `hasShards`/`GetConf`, the non-TSDB astmapper strategy branch, and the non-TSDB `config_compat` check. Query-sharding tests that used `boltdb-shipper` + `row_shards` as a deterministic sharding shortcut are converted to TSDB dynamic sharding, preserving their invariants.
2. `refactor(config): replace row_shards setting with a constant` — introduces `config.DefaultRowShards = 16`, points the series sharding handler at it, and removes the `RowShards` field, its defaulting (`defaultRowShards`/`applyDefaults`), and its validation.

**Special notes for your reviewer**:

- **No behavioral change** for any supported (TSDB) configuration: log/metric sharding was already dynamic, and series sharding keeps the previous factor of 16.
- **Breaking config change**: `row_shards` lives on `PeriodConfig`, which is parsed strictly (`WithKnownFields(true)`), so a leftover `row_shards:` key now fails config load. This is the intended fail-fast behavior; it is documented in the upgrade guide and flagged by the `deprecated-config-checker` (fixture + test added).
- `TestMetricsTripperware_SplitShardStats`: the range-query-with-range-vector case legitimately resolves 5 sharded subqueries under TSDB dynamic sharding, so its expected shard count is updated from 12 to 20. The old test masked this by using `boltdb-shipper`/`ConstantShards`; the TSDB behavior itself is unchanged by this PR.
- Config reference docs are regenerated via `make doc` (the `row_shards` entry is gone).

**Checklist**
- [x] Reviewed the `CONTRIBUTING.md` guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] Deprecated/removed config option recorded in `tools/deprecated-config-checker`