### PR TITLE
fix(logql): Correct rate_counter extrapolation broken by nanosecond/millisecond unit mismatch

### DIFF
--- a/pkg/logql/engine_test.go
+++ b/pkg/logql/engine_test.go
@@ -183,9 +183,13 @@ func TestEngine_LogsRateUnwrap(t *testing.T) {
 			[]SelectSampleParams{
 				{&logproto.SampleQueryRequest{Start: time.Unix(30, 0), End: time.Unix(60, 0), Selector: `rate_counter({app="foo"} | unwrap foo[30s])`}},
 			},
-			// there are 15 samples (from 47 to 61) matched from the generated series
-			// (61 - 47) / 30 = 0.4666
-			promql.Vector{promql.Sample{T: 60 * 1000, F: 0.46666766666666665, Metric: labels.FromStrings("app", "foo")}},
+			// 15 samples match the window (30s, 60s]: t=46..60 with values 47..61, so the
+			// counter increases by 14 over a 14s sampled interval (avg 1s between samples).
+			// The first sample is 16s past the window start (>> the sample spacing), so the
+			// counter start is extrapolated by half an average interval (0.5s); the last
+			// sample sits at the window end, so there is no extrapolation there.
+			// rate = 14 * (14 + 0.5) / 14 / 30 = 14.5 / 30 = 0.4833
+			promql.Vector{promql.Sample{T: 60 * 1000, F: 0.4833333333333334, Metric: labels.FromStrings("app", "foo")}},
 		},
 	} {
 		t.Run(fmt.Sprintf("%s %s", test.qs, test.direction), func(t *testing.T) {

--- a/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
@@ -497,3 +497,18 @@ eval range from 180s to 210s step 30s rate_counter({app="a"} | logfmt | unwrap c
   {app="a"} 1 2
 eval instant at 240s rate_counter({app="a"} | logfmt | unwrap c [150s])
   {app="a"} 0.8
+
+# Order of the two caps matters (Prometheus applies the threshold cap BEFORE the zero-point cap): a
+# far first sample is clamped to +half an interval first, and the zero point can then only shorten it
+# further — it cannot pull the extrapolation back past that clamp. Here the counter is 0 at 160s and
+# climbs by 2/s (c=40 at 180s, so its zero point is only 20s back). Window (120,210]: the first sample
+# (180s) is 60s from the lower edge (> the 33s threshold) → clamped to +15s (avg/2); the zero point
+# 20s back sits between avg/2 and the threshold, so it does NOT shorten the 15s. Increase 60 over 30s:
+# 60 x (30+15)/30 / 90s = 1. (Applying the zero point first would extrapolate to 20s → 100/90.)
+clear
+load
+  {app="a"} "c=40"  @ 180s
+  {app="a"} "c=100" @ 210s
+  {app="a"} "noise" @ 150s
+eval instant at 210s rate_counter({app="a"} | logfmt | unwrap c [90s])
+  {app="a"} 1

--- a/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
@@ -376,3 +376,124 @@ eval instant at 120s sum_over_time({app="a"} | logfmt | unwrap bytes(b) [1m])
   {app="a"} 6000
 eval range from 90s to 120s step 30s sum_over_time({app="a"} | logfmt | unwrap bytes(b) [1m])
   {app="a"} 3000 6000
+
+# rate_counter treats the unwrapped value as a counter: the per-second increase over the range with
+# counter resets added back, using Prometheus-style boundary extrapolation.
+#
+# The fixtures in this scenario contain:
+#   (0, 60]     c=<none>     empty
+#   (60, 120]   c=100, 130   increase 30
+#   (120, 180]  c=160, 250   increase 90
+#   (180, 240]  c=280, 340   increase 60
+#   (240, 300]  c=<none>     empty
+#   (300, 360]  c=400, 430   increase 30
+#   (360, 420]  c=460, 550   increase 90
+#   (420, 480]  c=580, 640   increase 60
+#   (480, 540]  c=<none>     empty
+clear
+load
+  {app="a"} "c=100" @ 90s
+  {app="a"} "c=130" @ 120s
+  {app="a"} "c=160" @ 150s
+  {app="a"} "c=250" @ 180s
+  {app="a"} "c=280" @ 210s
+  {app="a"} "c=340" @ 240s
+  {app="a"} "c=400" @ 330s
+  {app="a"} "c=430" @ 360s
+  {app="a"} "c=460" @ 390s
+  {app="a"} "c=550" @ 420s
+  {app="a"} "c=580" @ 450s
+  {app="a"} "c=640" @ 480s
+  {app="a"} "noise" @ 15s [repeat every 30s for 18]
+
+# Non-overlapping range vector selectors.
+#
+# In the fixtures we use, a [1m] window extrapolates the 30s to its lower edge, so:
+# rate = increase/30 (30->1, 60->2, 90->3).
+eval instant at 480s rate_counter({app="a"} | logfmt | unwrap c [1m])
+  {app="a"} 2
+eval range from 60s to 540s step 60s rate_counter({app="a"} | logfmt | unwrap c [1m])
+  {app="a"} _ 1 3 2 _ 1 3 2 _
+eval range from 60s to 180s step 60s rate_counter({app="a"} | logfmt | unwrap c [1m])
+  {app="a"} _ 1 3
+eval range from 240s to 360s step 60s rate_counter({app="a"} | logfmt | unwrap c [1m])
+  {app="a"} 2 _ 1
+eval range from 420s to 540s step 60s rate_counter({app="a"} | logfmt | unwrap c [1m])
+  {app="a"} 3 2 _
+
+# Overlapping range vector selectors (a sample falls in more than 1 step):
+#  (60,240]  sees +240 over 150s, extrapolated to 180s: 240 x (180/150) / 180s = 1.6
+#  (120,300] sees +180 over 90s,  extrapolated to 135s: 180 x (135/90)  / 180s = 1.5
+#  (180,360] sees +150 over 150s, extrapolated to 180s: 150 x (180/150) / 180s = 1
+eval instant at 360s rate_counter({app="a"} | logfmt | unwrap c [3m])
+  {app="a"} 1
+eval range from 240s to 360s step 60s rate_counter({app="a"} | logfmt | unwrap c [3m])
+  {app="a"} 1.6 1.5 1
+
+# Single sample in the window returns 0 (a rate needs at least 2 points).
+eval instant at 90s rate_counter({app="a"} | logfmt | unwrap c [10s])
+  {app="a"} 0
+
+# No samples in the window returns an empty result.
+eval instant at 300s rate_counter({app="a"} | logfmt | unwrap c [10s])
+  expect empty
+
+# rate_counter requires unwrap.
+eval instant at 60s rate_counter({app="a"}[1m])
+  expect fail msg: invalid aggregation rate_counter without unwrap
+
+# rate_counter treats any decrease as a counter reset and adds the pre-drop value back, so the rate
+# stays positive instead of going negative.:
+#  (30,150] sees +90 (60,90,30,60) over 90s, extrapolated to 120s: 90 x (120/90) / 120s = 1
+#  (60,120] sees +30 (90,30)       over 30s, extrapolated to 60s:  30 x (60/30) / 60s = 1
+clear
+load
+  {app="a"} "c=30" @ 30s
+  {app="a"} "c=60" @ 60s
+  {app="a"} "c=90" @ 90s
+  {app="a"} "c=30" @ 120s      # reset: 90 -> 30
+  {app="a"} "c=60" @ 150s
+  {app="a"} "noise" @ 15s [repeat every 30s for 6]
+eval instant at 150s rate_counter({app="a"} | logfmt | unwrap c [2m])
+  {app="a"} 1
+eval instant at 120s rate_counter({app="a"} | logfmt | unwrap c [1m])
+  {app="a"} 1
+
+# rate_counter never extrapolates a counter below zero. If extrapolating back to a window's lower
+# edge would cross the counter's zero point, back-extrapolation stops at the zero point instead.
+#
+# In this test fixtures, the zero point is at timestamp 60s (simulate a counter that is 0 at 60s
+# and then climbs by 60 every 30s), so:
+#  (45,105] sees +60 (30, 90)  over 30s, extrapolated to 45s (zero point is at 60s > range start at 45s): 60 x (45/30) / 60s = 1.5
+#  (75,135] sees +60 (90, 150) over 30s, extrapolated to 60s (zero point is at 60s < range start at 75s): 60 x (60/30) / 60s = 2
+clear
+load
+  {app="a"} "c=30"  @ 75s
+  {app="a"} "c=90"  @ 105s
+  {app="a"} "c=150" @ 135s
+  {app="a"} "noise" @ 60s [repeat every 30s for 4]
+eval instant at 105s rate_counter({app="a"} | logfmt | unwrap c [1m])
+  {app="a"} 1.5
+eval instant at 135s rate_counter({app="a"} | logfmt | unwrap c [1m])
+  {app="a"} 2
+
+# rate_counter extrapolates each side of the window to its edge, but caps that extrapolation at half
+# an average sampling interval when the nearest sample sits farther from the edge than ~1.1x the
+# average interval.
+#
+# In this test fixtures, the counter climbs by 60 every 30s (using large values so the zero point logic
+# never triggers), with samples only at 150s and 180s (average interval 30s, threshold ~33s), so:
+#  (90,180]  sees +60 (600, 660) over 30s, extrapolated to 45s (first sample 150s is 60s from range start 90s > 33s, so gets LEFT capped +15s): 60 x (45/30) / 90s = 1
+#  (120,210] sees +60 (600, 660) over 30s, extrapolated to 90s (both samples within 33s of the edges, no cap): 60 x (90/30) / 90s = 2
+#  (90,240]  sees +60 (600, 660) over 30s, extrapolated to 60s (first sample 150s is 60s from range start 90s AND last sample 180s is 60s from range end 240s, both > 33s, so BOTH sides capped +15s): 60 x (60/30) / 150s = 0.8
+clear
+load
+  {app="a"} "c=600" @ 150s
+  {app="a"} "c=660" @ 180s
+  {app="a"} "noise" @ 15s [repeat every 30s for 8]
+eval instant at 180s rate_counter({app="a"} | logfmt | unwrap c [90s])
+  {app="a"} 1
+eval range from 180s to 210s step 30s rate_counter({app="a"} | logfmt | unwrap c [90s])
+  {app="a"} 1 2
+eval instant at 240s rate_counter({app="a"} | logfmt | unwrap c [150s])
+  {app="a"} 0.8

--- a/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
@@ -498,17 +498,17 @@ eval range from 180s to 210s step 30s rate_counter({app="a"} | logfmt | unwrap c
 eval instant at 240s rate_counter({app="a"} | logfmt | unwrap c [150s])
   {app="a"} 0.8
 
-# Order of the two caps matters (Prometheus applies the threshold cap BEFORE the zero-point cap): a
+# rate_counter's order of the two caps matters (the threshold cap should be before the zero-point cap): a
 # far first sample is clamped to +half an interval first, and the zero point can then only shorten it
-# further — it cannot pull the extrapolation back past that clamp. Here the counter is 0 at 160s and
-# climbs by 2/s (c=40 at 180s, so its zero point is only 20s back). Window (120,210]: the first sample
-# (180s) is 60s from the lower edge (> the 33s threshold) → clamped to +15s (avg/2); the zero point
-# 20s back sits between avg/2 and the threshold, so it does NOT shorten the 15s. Increase 60 over 30s:
-# 60 x (30+15)/30 / 90s = 1. (Applying the zero point first would extrapolate to 20s → 100/90.)
+# further — it cannot pull the extrapolation back past that clamp.
 clear
 load
   {app="a"} "c=40"  @ 180s
   {app="a"} "c=100" @ 210s
   {app="a"} "noise" @ 150s
+
+# The counter is 0 at 160s and increases by 2/s. Window (120,210]: the first sample (180s) is 60s from
+# the lower edge (> the 33s threshold) → clamped to +15s (avg/2); the zero point 20s back sits between
+# avg/2 and the threshold, so it does NOT shorten the 15s: 60 x (30+15)/30 / 90s = 1.
 eval instant at 210s rate_counter({app="a"} | logfmt | unwrap c [90s])
   {app="a"} 1

--- a/pkg/logql/range_vector.go
+++ b/pkg/logql/range_vector.go
@@ -16,10 +16,9 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/vector"
 )
 
-// BatchRangeVectorAggregator aggregates samples for a given range of samples.
-// It receives the current milliseconds timestamp and the list of point within
-// the range.
-type BatchRangeVectorAggregator func([]promql.FPoint) float64
+// BatchRangeVectorAggregator aggregates the samples within a range window. It
+// receives the samples in the window and the window end timestamp in nanoseconds.
+type BatchRangeVectorAggregator func(samples []promql.FPoint, rangeEnd int64) float64
 
 // RangeStreamingAgg streaming aggregates sample for each sample
 type RangeStreamingAgg interface {
@@ -56,7 +55,7 @@ func newRangeVectorIterator(
 		overlap = true
 	}
 	if !overlap {
-		_, err := streamingAggregator(expr)
+		_, err := streamingAggregator(expr, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -195,7 +194,7 @@ func (r *batchRangeVectorIterator) At() (int64, StepResult) {
 	ts := r.current/1e+6 + r.offset/1e+6
 	for _, series := range r.window {
 		r.at = append(r.at, promql.Sample{
-			F:      r.agg(series.Floats),
+			F:      r.agg(series.Floats, r.current),
 			T:      ts,
 			Metric: series.Metric,
 		})
@@ -257,8 +256,8 @@ func aggregator(r *syntax.RangeAggregationExpr) (BatchRangeVectorAggregator, err
 
 // rateLogs calculates the per-second rate of log lines or values extracted
 // from log lines
-func rateLogs(selRange time.Duration, computeValues bool) func(samples []promql.FPoint) float64 {
-	return func(samples []promql.FPoint) float64 {
+func rateLogs(selRange time.Duration, computeValues bool) func(samples []promql.FPoint, _ int64) float64 {
+	return func(samples []promql.FPoint, _ int64) float64 {
 		if !computeValues {
 			return float64(len(samples)) / selRange.Seconds()
 		}
@@ -272,27 +271,27 @@ func rateLogs(selRange time.Duration, computeValues bool) func(samples []promql.
 
 // rateCounter calculates the per-second rate of values extracted from log lines
 // and treat them like a "counter" metric.
-func rateCounter(selRange time.Duration) func(samples []promql.FPoint) float64 {
-	return func(samples []promql.FPoint) float64 {
-		return extrapolatedRate(samples, selRange, true, true)
+func rateCounter(selRange time.Duration) func(samples []promql.FPoint, rangeEnd int64) float64 {
+	return func(samples []promql.FPoint, rangeEnd int64) float64 {
+		return extrapolatedRate(samples, selRange, rangeEnd, true, true)
 	}
 }
 
-// extrapolatedRate function is taken from prometheus code promql/functions.go:59
-// extrapolatedRate is a utility function for rate/increase/delta.
-// It calculates the rate (allowing for counter resets if isCounter is true),
-// extrapolates if the first/last sample is close to the boundary, and returns
-// the result as either per-second (if isRate is true) or overall.
-func extrapolatedRate(samples []promql.FPoint, selRange time.Duration, isCounter, isRate bool) float64 {
+// extrapolatedRate is adapted from Prometheus. It calculates the rate (allowing for counter
+// resets if isCounter is true), extrapolates if the first/last sample is close to the
+// boundary, and returns the result as either per-second (if isRate is true) or overall.
+//
+// Two differences from Prometheus:
+//  1. Sample timestamps and rangeEnd are nanoseconds (not milliseconds)
+//  2. The range boundaries come from the query window (rangeEnd and rangeEnd-selRange)
+//     rather than being approximated from the first/last sample.
+func extrapolatedRate(samples []promql.FPoint, selRange time.Duration, rangeEnd int64, isCounter, isRate bool) float64 {
 	// No sense in trying to compute a rate without at least two points. Drop
 	// this Vector element.
 	if len(samples) < 2 {
 		return 0
 	}
-	var (
-		rangeStart = samples[0].T - durationMilliseconds(selRange)
-		rangeEnd   = samples[len(samples)-1].T
-	)
+	rangeStart := rangeEnd - selRange.Nanoseconds()
 
 	resultValue := samples[len(samples)-1].F - samples[0].F
 	if isCounter {
@@ -305,11 +304,12 @@ func extrapolatedRate(samples []promql.FPoint, selRange time.Duration, isCounter
 		}
 	}
 
-	// Duration between first/last samples and boundary of range.
-	durationToStart := float64(samples[0].T-rangeStart) / 1000
-	durationToEnd := float64(rangeEnd-samples[len(samples)-1].T) / 1000
+	// Duration between first/last samples and boundary of range, in seconds
+	// (timestamps are nanoseconds).
+	durationToStart := float64(samples[0].T-rangeStart) / 1e9
+	durationToEnd := float64(rangeEnd-samples[len(samples)-1].T) / 1e9
 
-	sampledInterval := float64(samples[len(samples)-1].T-samples[0].T) / 1000
+	sampledInterval := float64(samples[len(samples)-1].T-samples[0].T) / 1e9
 	averageDurationBetweenSamples := sampledInterval / float64(len(samples)-1)
 
 	if isCounter && resultValue > 0 && samples[0].F >= 0 {
@@ -352,23 +352,19 @@ func extrapolatedRate(samples []promql.FPoint, selRange time.Duration, isCounter
 	return resultValue
 }
 
-func durationMilliseconds(d time.Duration) int64 {
-	return int64(d / (time.Millisecond / time.Nanosecond))
-}
-
 // rateLogBytes calculates the per-second rate of log bytes.
-func rateLogBytes(selRange time.Duration) func(samples []promql.FPoint) float64 {
-	return func(samples []promql.FPoint) float64 {
-		return sumOverTime(samples) / selRange.Seconds()
+func rateLogBytes(selRange time.Duration) func(samples []promql.FPoint, _ int64) float64 {
+	return func(samples []promql.FPoint, _ int64) float64 {
+		return sumOverTime(samples, 0) / selRange.Seconds()
 	}
 }
 
 // countOverTime counts the amount of log lines.
-func countOverTime(samples []promql.FPoint) float64 {
+func countOverTime(samples []promql.FPoint, _ int64) float64 {
 	return float64(len(samples))
 }
 
-func sumOverTime(samples []promql.FPoint) float64 {
+func sumOverTime(samples []promql.FPoint, _ int64) float64 {
 	var sum float64
 	for _, v := range samples {
 		sum += v.F
@@ -376,7 +372,7 @@ func sumOverTime(samples []promql.FPoint) float64 {
 	return sum
 }
 
-func avgOverTime(samples []promql.FPoint) float64 {
+func avgOverTime(samples []promql.FPoint, _ int64) float64 {
 	var mean, count float64
 	for _, v := range samples {
 		count++
@@ -402,7 +398,7 @@ func avgOverTime(samples []promql.FPoint) float64 {
 	return mean
 }
 
-func maxOverTime(samples []promql.FPoint) float64 {
+func maxOverTime(samples []promql.FPoint, _ int64) float64 {
 	maxVal := samples[0].F
 	for _, v := range samples {
 		if v.F > maxVal || math.IsNaN(maxVal) {
@@ -412,7 +408,7 @@ func maxOverTime(samples []promql.FPoint) float64 {
 	return maxVal
 }
 
-func minOverTime(samples []promql.FPoint) float64 {
+func minOverTime(samples []promql.FPoint, _ int64) float64 {
 	minVal := samples[0].F
 	for _, v := range samples {
 		if v.F < minVal || math.IsNaN(minVal) {
@@ -424,7 +420,7 @@ func minOverTime(samples []promql.FPoint) float64 {
 
 // stdvarOverTime calculates the variance using Welford's online algorithm.
 // See https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
-func stdvarOverTime(samples []promql.FPoint) float64 {
+func stdvarOverTime(samples []promql.FPoint, _ int64) float64 {
 	var aux, count, mean float64
 	for _, v := range samples {
 		count++
@@ -435,7 +431,7 @@ func stdvarOverTime(samples []promql.FPoint) float64 {
 	return aux / count
 }
 
-func stddevOverTime(samples []promql.FPoint) float64 {
+func stddevOverTime(samples []promql.FPoint, _ int64) float64 {
 	var aux, count, mean float64
 	for _, v := range samples {
 		count++
@@ -446,8 +442,8 @@ func stddevOverTime(samples []promql.FPoint) float64 {
 	return math.Sqrt(aux / count)
 }
 
-func quantileOverTime(q float64) func(samples []promql.FPoint) float64 {
-	return func(samples []promql.FPoint) float64 {
+func quantileOverTime(q float64) func(samples []promql.FPoint, _ int64) float64 {
+	return func(samples []promql.FPoint, _ int64) float64 {
 		values := make(vector.HeapByMaxValue, 0, len(samples))
 		for _, v := range samples {
 			values = append(values, promql.Sample{F: v.F})
@@ -486,21 +482,21 @@ func Quantile(q float64, values vector.HeapByMaxValue) float64 {
 	return values[int(lowerIndex)].F*(1-weight) + values[int(upperIndex)].F*weight
 }
 
-func first(samples []promql.FPoint) float64 {
+func first(samples []promql.FPoint, _ int64) float64 {
 	if len(samples) == 0 {
 		return math.NaN()
 	}
 	return samples[0].F
 }
 
-func last(samples []promql.FPoint) float64 {
+func last(samples []promql.FPoint, _ int64) float64 {
 	if len(samples) == 0 {
 		return math.NaN()
 	}
 	return samples[len(samples)-1].F
 }
 
-func one(_ []promql.FPoint) float64 {
+func one(_ []promql.FPoint, _ int64) float64 {
 	return 1.0
 }
 
@@ -567,7 +563,7 @@ func (r *streamRangeVectorIterator) load(start, end int64) {
 			}
 
 			// never err here ,we have check error at evaluator.go rangeAggEvaluator() func
-			rangeAgg, _ = streamingAggregator(r.r)
+			rangeAgg, _ = streamingAggregator(r.r, end)
 			r.windowRangeAgg[lbs] = rangeAgg
 		}
 		p := promql.FPoint{
@@ -596,12 +592,12 @@ func (r *streamRangeVectorIterator) At() (int64, StepResult) {
 	return ts, SampleVector(r.at)
 }
 
-func streamingAggregator(r *syntax.RangeAggregationExpr) (RangeStreamingAgg, error) {
+func streamingAggregator(r *syntax.RangeAggregationExpr, rangeEnd int64) (RangeStreamingAgg, error) {
 	switch r.Operation {
 	case syntax.OpRangeTypeRate:
 		return newRateLogs(r.Left.Interval, r.Left.Unwrap != nil), nil
 	case syntax.OpRangeTypeRateCounter:
-		return &RateCounterOverTime{selRange: r.Left.Interval, samples: make([]promql.FPoint, 0)}, nil
+		return &RateCounterOverTime{selRange: r.Left.Interval, rangeEnd: rangeEnd, samples: make([]promql.FPoint, 0)}, nil
 	case syntax.OpRangeTypeCount:
 		return &CountOverTime{}, nil
 	case syntax.OpRangeTypeBytesRate:
@@ -664,6 +660,7 @@ func (a *RateLogsOverTime) at() float64 {
 type RateCounterOverTime struct {
 	samples  []promql.FPoint
 	selRange time.Duration
+	rangeEnd int64
 }
 
 func (a *RateCounterOverTime) agg(sample promql.FPoint) {
@@ -671,7 +668,7 @@ func (a *RateCounterOverTime) agg(sample promql.FPoint) {
 }
 
 func (a *RateCounterOverTime) at() float64 {
-	return extrapolatedRate(a.samples, a.selRange, true, true)
+	return extrapolatedRate(a.samples, a.selRange, a.rangeEnd, true, true)
 }
 
 // rateLogBytes calculates the per-second rate of log bytes.

--- a/pkg/logql/range_vector.go
+++ b/pkg/logql/range_vector.go
@@ -256,7 +256,7 @@ func aggregator(r *syntax.RangeAggregationExpr) (BatchRangeVectorAggregator, err
 
 // rateLogs calculates the per-second rate of log lines or values extracted
 // from log lines
-func rateLogs(selRange time.Duration, computeValues bool) func(samples []promql.FPoint, _ int64) float64 {
+func rateLogs(selRange time.Duration, computeValues bool) BatchRangeVectorAggregator {
 	return func(samples []promql.FPoint, _ int64) float64 {
 		if !computeValues {
 			return float64(len(samples)) / selRange.Seconds()
@@ -271,7 +271,7 @@ func rateLogs(selRange time.Duration, computeValues bool) func(samples []promql.
 
 // rateCounter calculates the per-second rate of values extracted from log lines
 // and treat them like a "counter" metric.
-func rateCounter(selRange time.Duration) func(samples []promql.FPoint, rangeEnd int64) float64 {
+func rateCounter(selRange time.Duration) BatchRangeVectorAggregator {
 	return func(samples []promql.FPoint, rangeEnd int64) float64 {
 		return extrapolatedRate(samples, selRange, rangeEnd, true, true)
 	}
@@ -311,17 +311,10 @@ func extrapolatedRate(samples []promql.FPoint, selRange time.Duration, rangeEnd 
 	sampledInterval := float64(samples[len(samples)-1].T-samples[0].T) / 1e9
 	averageDurationBetweenSamples := sampledInterval / float64(len(samples)-1)
 
-	// If samples are close enough to the (lower or upper) boundary of the
-	// range, we extrapolate the rate all the way to the boundary in
-	// question. "Close enough" is defined as "up to 10% more than the
-	// average duration between samples within the range", see
-	// extrapolationThreshold below. Essentially, we are assuming a more or
-	// less regular spacing between samples, and if we don't see a sample
-	// where we would expect one, we assume the series does not cover the
-	// whole range, but starts and/or ends within the range. We still
-	// extrapolate the rate in this case, but not all the way to the
-	// boundary, but only by half of the average duration between samples
-	// (which is our guess for where the series actually starts or ends).
+	// If the first/last samples are close to the boundaries of the range,
+	// extrapolate the result. This is as we expect that another sample
+	// will exist given the spacing between samples we've seen thus far,
+	// with an allowance for noise.
 	extrapolationThreshold := averageDurationBetweenSamples * 1.1
 	if durationToStart >= extrapolationThreshold {
 		durationToStart = averageDurationBetweenSamples / 2
@@ -356,7 +349,7 @@ func extrapolatedRate(samples []promql.FPoint, selRange time.Duration, rangeEnd 
 }
 
 // rateLogBytes calculates the per-second rate of log bytes.
-func rateLogBytes(selRange time.Duration) func(samples []promql.FPoint, _ int64) float64 {
+func rateLogBytes(selRange time.Duration) BatchRangeVectorAggregator {
 	return func(samples []promql.FPoint, _ int64) float64 {
 		return sumOverTime(samples, 0) / selRange.Seconds()
 	}
@@ -445,7 +438,7 @@ func stddevOverTime(samples []promql.FPoint, _ int64) float64 {
 	return math.Sqrt(aux / count)
 }
 
-func quantileOverTime(q float64) func(samples []promql.FPoint, _ int64) float64 {
+func quantileOverTime(q float64) BatchRangeVectorAggregator {
 	return func(samples []promql.FPoint, _ int64) float64 {
 		values := make(vector.HeapByMaxValue, 0, len(samples))
 		for _, v := range samples {

--- a/pkg/logql/range_vector.go
+++ b/pkg/logql/range_vector.go
@@ -304,45 +304,48 @@ func extrapolatedRate(samples []promql.FPoint, selRange time.Duration, rangeEnd 
 		}
 	}
 
-	// Duration between first/last samples and boundary of range, in seconds
-	// (timestamps are nanoseconds).
+	// Duration between first/last samples and boundary of range.
 	durationToStart := float64(samples[0].T-rangeStart) / 1e9
 	durationToEnd := float64(rangeEnd-samples[len(samples)-1].T) / 1e9
 
 	sampledInterval := float64(samples[len(samples)-1].T-samples[0].T) / 1e9
 	averageDurationBetweenSamples := sampledInterval / float64(len(samples)-1)
 
-	if isCounter && resultValue > 0 && samples[0].F >= 0 {
-		// Counters cannot be negative. If we have any slope at
-		// all (i.e. resultValue went up), we can extrapolate
-		// the zero point of the counter. If the duration to the
-		// zero point is shorter than the durationToStart, we
-		// take the zero point as the start of the series,
-		// thereby avoiding extrapolation to negative counter
-		// values.
-		durationToZero := sampledInterval * (samples[0].F / resultValue)
+	// If samples are close enough to the (lower or upper) boundary of the
+	// range, we extrapolate the rate all the way to the boundary in
+	// question. "Close enough" is defined as "up to 10% more than the
+	// average duration between samples within the range", see
+	// extrapolationThreshold below. Essentially, we are assuming a more or
+	// less regular spacing between samples, and if we don't see a sample
+	// where we would expect one, we assume the series does not cover the
+	// whole range, but starts and/or ends within the range. We still
+	// extrapolate the rate in this case, but not all the way to the
+	// boundary, but only by half of the average duration between samples
+	// (which is our guess for where the series actually starts or ends).
+	extrapolationThreshold := averageDurationBetweenSamples * 1.1
+	if durationToStart >= extrapolationThreshold {
+		durationToStart = averageDurationBetweenSamples / 2
+	}
+	if isCounter {
+		// Counters cannot be negative. If we have any slope at all
+		// (i.e. resultValue went up), we can extrapolate the zero point
+		// of the counter. If the duration to the zero point is shorter
+		// than the durationToStart, we take the zero point as the start
+		// of the series, thereby avoiding extrapolation to negative
+		// counter values.
+		durationToZero := durationToStart
+		if resultValue > 0 && samples[0].F >= 0 {
+			durationToZero = sampledInterval * (samples[0].F / resultValue)
+		}
 		if durationToZero < durationToStart {
 			durationToStart = durationToZero
 		}
 	}
-
-	// If the first/last samples are close to the boundaries of the range,
-	// extrapolate the result. This is as we expect that another sample
-	// will exist given the spacing between samples we've seen thus far,
-	// with an allowance for noise.
-	extrapolationThreshold := averageDurationBetweenSamples * 1.1
-	extrapolateToInterval := sampledInterval
-
-	if durationToStart < extrapolationThreshold {
-		extrapolateToInterval += durationToStart
-	} else {
-		extrapolateToInterval += averageDurationBetweenSamples / 2
+	if durationToEnd >= extrapolationThreshold {
+		durationToEnd = averageDurationBetweenSamples / 2
 	}
-	if durationToEnd < extrapolationThreshold {
-		extrapolateToInterval += durationToEnd
-	} else {
-		extrapolateToInterval += averageDurationBetweenSamples / 2
-	}
+
+	extrapolateToInterval := sampledInterval + durationToStart + durationToEnd
 	resultValue = resultValue * (extrapolateToInterval / sampledInterval)
 	if isRate {
 		seconds := selRange.Seconds()


### PR DESCRIPTION
**What this PR does / why we need it**:

`rate_counter`'s boundary extrapolation assumed millisecond sample timestamps (Prometheus' convention), but Loki's timestamps are nanoseconds — so durations were scaled ~1e6x too small and the extrapolation collapsed, making `rate_counter` return near-zero (~1e-6) values instead of the real per-second rate. It also took the range boundaries from the first/last sample rather than the query window, so it never extrapolated to the window edges.

The fix threads the query window end through the range aggregators, derives the extrapolation boundaries from it, and scales nanosecond durations correctly, matching Prometheus' `rate`/`increase` extrapolation. It also adds declarative DSL coverage for the corrected behavior (reset compensation, the counter zero-point cap, and the left/right half-interval edge caps), which had no meaningful unit tests before.

**Which issue(s) this PR fixes**:
Fixes #23670

**Special notes for your reviewer**:

N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
