### PR TITLE
fix(mixin): Regenerate compiled dashboard and widen lint-jsonnet paths

### DIFF
--- a/.github/workflows/lint-jsonnet.yml
+++ b/.github/workflows/lint-jsonnet.yml
@@ -7,6 +7,8 @@ on:
       - "**/*.libsonnet"
       - "**/jsonnetfile.json"
       - "**/jsonnetfile.lock.json"
+      - "production/loki-mixin/**" # the mixin imports raw .json dashboards as source
+      - "production/loki-mixin-compiled/**"
       - ".github/workflows/lint-jsonnet.yml" # validate changes to the workflow itself
 
 permissions:

--- a/production/loki-mixin-compiled/dashboards/loki-operational.json
+++ b/production/loki-mixin-compiled/dashboards/loki-operational.json
@@ -772,17 +772,17 @@
             "steppedLine": false,
             "targets": [
                {
-                  "expr": "histogram_quantile(0.99, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"}))",
+                  "expr": "histogram_quantile(0.99, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\", route!~\"(debug_pprof|ready|metrics|usage_metrics)\"}))",
                   "legendFormat": ".99",
                   "refId": "A"
                },
                {
-                  "expr": "histogram_quantile(0.9, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"}))",
+                  "expr": "histogram_quantile(0.9, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\", route!~\"(debug_pprof|ready|metrics|usage_metrics)\"}))",
                   "legendFormat": ".9",
                   "refId": "B"
                },
                {
-                  "expr": "histogram_quantile(0.5, sum by (le) (cluster_job:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\"}))",
+                  "expr": "histogram_quantile(0.5, sum by (le) (cluster_job_route:loki_request_duration_seconds_bucket:sum_rate{job=~\"($namespace)/distributor\", cluster=~\"$cluster\", route!~\"(debug_pprof|ready|metrics|usage_metrics)\"}))",
                   "legendFormat": ".5",
                   "refId": "C"
                }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR regenerates the compiled `loki-operational` dashboard, which had drifted from
its jsonnet source, and widens the `lint-jsonnet` path filters so the same drift can't
sneak through again.

#23377 changed three distributor latency panel queries in
`production/loki-mixin/dashboards/dashboard-loki-operational.json` to use the
`cluster_job_route:loki_request_duration_seconds_bucket:sum_rate` recording rule and to
exclude the `debug_pprof|ready|metrics|usage_metrics` routes, but `make loki-mixin` was
never run, so `production/loki-mixin-compiled/` was left behind.

The reason nothing caught it is the interesting bit. The `lint-jsonnet` workflow only
watched `**/*.jsonnet`, `**/*.libsonnet` and `jsonnetfile*.json`, and the file that
changed is a plain `.json` — so the mixin check never ran on that pull request at all.
`gh pr checks 23377` confirms it: no jsonnet or mixin job in the list.

That's not a one-off. Five raw `.json` dashboards under
`production/loki-mixin/dashboards/` are genuine mixin source, imported straight into the
build by their `.libsonnet` wrappers:

```
production/loki-mixin/dashboards/loki-operational.libsonnet:1:
  local lokiOperational = (import './dashboard-loki-operational.json');
```

Any of them could have gone the same way, so the workflow now watches
`production/loki-mixin/**` and `production/loki-mixin-compiled/**`. The compiled
directory is included deliberately: it catches hand edits to generated output, and since
the job only regenerates and diffs (never commits), there's no re-trigger loop.

**Which issue(s) this PR fixes**:

None. Found while chasing a red `Check mixin jsonnet files` job on #23680, which is a
packaging change that happens to touch `.github/jsonnetfile.json` and so trips the
filter that #23377 slipped past.

**Special notes for your reviewer**:

The dashboard change is pure generated output — 3 lines, matching the diff CI was already
printing (blob `5c5f431b` → `8b7b63ff`). To avoid toolchain churn in the artefact I
installed the exact versions the workflow pins (`jsonnet` v0.20.0, `jb` v0.5.1,
`mixtool@16dc1661`) rather than using my system's newer ones, then ran
`make BUILD_IN_CONTAINER=false loki-mixin`. Both `lint-jsonnet` and `loki-mixin-check`
pass, and since the check regenerates before diffing, the output is idempotent.

One gap left knowingly open: `Makefile` isn't in the path filters, so a change to the
`loki-mixin` or `loki-mixin-check` recipes still won't trigger this workflow. Watching a
monolithic Makefile that half the repo touches seemed a poor trade for the benefit, and a
busted recipe would surface on the next PR that touches mixin content anyway. Happy to
add it if you'd rather.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
