### PR TITLE
docs: Explain structured metadata limits and large OTel attributes such as stack traces 🤖🤖🤖

### DIFF
--- a/docs/sources/get-started/labels/structured-metadata.md
+++ b/docs/sources/get-started/labels/structured-metadata.md
@@ -64,6 +64,8 @@ Along with that, there are separate limits on how much structured metadata can b
 [max_structured_metadata_entries_count: <int> | default = 128]
 ```
 
+Log lines that exceed either limit are rejected by the distributor with an HTTP 400 response, and the discarded entries are counted in the `loki_discarded_samples_total` metric with reason `structured_metadata_too_large` or `structured_metadata_too_many`.
+A large OpenTelemetry log attribute such as `exception.stacktrace` can be the cause — refer to [Handle large attributes such as stack traces](https://grafana.com/docs/loki/<LOKI_VERSION>/send-data/otel/#handle-large-attributes-such-as-stack-traces) for mitigations.
 {{< /admonition >}}
 
 ## Querying structured metadata

--- a/docs/sources/send-data/otel/_index.md
+++ b/docs/sources/send-data/otel/_index.md
@@ -79,3 +79,40 @@ With the example config, here is how various kinds of Attributes would be stored
 * Store remaining Resource Attributes as Structured Metadata.
 * Drop Scope Attribute named `method.name` and store all other Scope Attributes as Structured Metadata.
 * Store Log Attribute named `user.id` as Structured Metadata and drop all other Log Attributes.
+
+## Handle large attributes such as stack traces
+
+By default, Loki stores OpenTelemetry log attributes as [structured metadata](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/labels/structured-metadata/). Two per-line limits apply to them:
+
+- `max_structured_metadata_size`: the total size of structured metadata per log line, 64KB by default.
+- `max_structured_metadata_entries_count`: the number of structured metadata entries per log line, 128 by default.
+
+A large log attribute — for example `exception.stacktrace`, which some OpenTelemetry SDK log integrations attach when a log records an exception — can push a log line over these limits. The distributor rejects such entries with an HTTP 400 (non-retryable) response and counts them in the `loki_discarded_samples_total` metric with reason `structured_metadata_too_large` or `structured_metadata_too_many`; other valid entries in the same push request may still be ingested. For the exact error messages, refer to [Troubleshoot ingestion errors](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/troubleshooting/troubleshoot-ingest/#error-structured-metadata-too-large).
+
+If your stack traces are being rejected, use one of the following mitigations.
+
+### Move the stack trace into the log body
+
+Use the OpenTelemetry Collector [transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor) to append the stack trace to the log body and delete the attribute:
+
+```yaml
+processors:
+  transform/stacktrace:
+    log_statements:
+      - context: log
+        statements:
+          - set(body, Concat([body, attributes["exception.stacktrace"]], "\n")) where attributes["exception.stacktrace"] != nil
+          - delete_key(attributes, "exception.stacktrace") where attributes["exception.stacktrace"] != nil
+service:
+  pipelines:
+    logs:
+      processors: [transform/stacktrace] # append to your existing processors list
+```
+
+The `set` statement must come before `delete_key`. The stack trace then counts against the log line size limit instead: `max_line_size`, 256KB by default, with `max_line_size_truncate` available to truncate rather than reject oversized lines. If you collect logs with Grafana Alloy, the [otelcol.processor.transform](https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.processor.transform/) component applies the same statements.
+
+### Drop the attribute or adjust the limits
+
+- If you don't need stack traces in Loki, drop the attribute at ingest with a `log_attributes` rule using `action: drop` under `limits_config.otlp_config` (Example 3 above shows the pattern). Rules are applied first-match-wins, so place the specific attribute before any catch-all regex.
+- On self-managed Loki, you can raise `max_structured_metadata_size` or `max_structured_metadata_entries_count` for a tenant through runtime overrides.
+- On Grafana Cloud, contact support to discuss limit adjustments.


### PR DESCRIPTION
**What this PR does / why we need it**:

OpenTelemetry users hit a discoverability gap around large log attributes. Some SDK log integrations attach `exception.stacktrace` to logs recorded with an exception, Loki stores log attributes as structured metadata by default, and two per-line limits apply (`max_structured_metadata_size`, 64KB by default; `max_structured_metadata_entries_count`, 128 by default). The troubleshooting reference documents the resulting errors and generic resolutions (reduce, raise the limit), but nothing on the OTel ingestion path connects attributes → structured metadata → per-line limits, and no page explains preserving an oversized attribute by moving it into the log body — for a stack trace you'd rather keep without raising tenant limits.

This PR adds a **Handle large attributes such as stack traces** section to the OTel send-data page covering the rejection behavior (with a cross-link to the existing troubleshooting entries) and three mitigations: moving the stack trace into the log body with the OTel Collector transform processor (one worked OTTL example including pipeline activation, with the `max_line_size` trade-off stated and a pointer to Alloy's `otelcol.processor.transform`), dropping the attribute via `limits_config.otlp_config`, and adjusting per-tenant limits. It also extends the structured-metadata limits admonition with the consequence and a cross-link to the new section.

Behavior claims verified against code at this revision: defaults in `pkg/validation/limits.go` (`max_structured_metadata_size` 64KB, `max_structured_metadata_entries_count` 128, `max_line_size` 256KB), discard reasons in `pkg/validation/validate.go`.

**Which issue(s) this PR fixes**:
No open issue exists for this — it addresses a recurring user question routed through customer feedback channels.

**Special notes for your reviewer**:

- Deliberately does not touch `docs/sources/shared/otel.md` (it is included by the Grafana Cloud website docs); the new section lives only in the Loki-local page.
- If the docs team would rather have this as a standalone topic page, happy to restructure on request.
- If you want this published to the current release docs immediately, please add the `type/docs` and backport labels.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated — N/A, docs-only
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md` — N/A
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory — N/A

---

This PR implements a customer request from Grafana's Voice of Customer (VoC) program (ref IDEASVOC-I-7331). It was prepared with AI assistance as part of an internal VoC→PR pilot and human-reviewed before submission; I'm the accountable author and will handle review feedback.
