### PR TITLE
test(logql): Expand logqltest coverage for quantile/first/last_over_time, bytes_rate, and label_replace

### DIFF
--- a/pkg/logql/internal/logqltest/testdata/functions.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/functions.logqltest
@@ -11,11 +11,100 @@ eval instant at 60s vector(2)
 eval range from 60s to 180s step 30s vector(2)
   {} 2 2 2 2 2
 
-# label_replace copies a capture from `app` into a new label; "bar" doesn't match "f(.*)".
-eval instant at 60s label_replace(sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (namespace,app), "new", "$1", "app", "f(.*)")
-  {app="foo", namespace="a", new="oo"} 6
-  {app="bar", namespace="b"} 6
+# label_replace().
+clear
+load
+  {app="foo", tier="1"}    "xbar"  @ 0s [repeat every 10s for 13]
+  {app="foo", tier="1"}    "noise" @ 5s [repeat every 10s for 13]
+  {app="foobar", tier="2"} "xbar"  @ 0s [repeat every 10s for 13]
+  {app="foobar", tier="2"} "noise" @ 5s [repeat every 10s for 13]
 
-eval range from 60s to 180s step 30s label_replace(avg by (app) ( sum by (app) (rate({app=~"foo|bar"} |~".+bar" [1m])) + sum by (app) (rate({app=~"foo|bar"} |~".+bar" [1m])) / sum by (app) (rate({app=~"foo|bar"} |~".+bar" [1m])) ) * 2, "new", "$1", "app", "f(.*)")
-  {app="foo", new="oo"} 2.2 2.2 2.2 2.2 2.2
-  {app="bar"} 2.2 2.2 2.2 2.2 2.2
+# Capture copy into a new label. The regex is anchored to the whole value, so "(fo)o" matches
+# "foo" (new="fo") but NOT "foobar" (left unchanged).
+eval instant at 60s label_replace(count_over_time({app=~"foo.*"} |~".+bar" [1m]), "new", "$1", "app", "(fo)o")
+  {app="foo", tier="1", new="fo"} 6
+  {app="foobar", tier="2"} 6
+eval range from 60s to 120s step 60s label_replace(count_over_time({app=~"foo.*"} |~".+bar" [1m]), "new", "$1", "app", "(fo)o")
+  {app="foo", tier="1", new="fo"} 6 6
+  {app="foobar", tier="2"} 6 6
+
+# Overwrite an existing dst label.
+eval instant at 60s label_replace(count_over_time({app=~"foo.*"} |~".+bar" [1m]), "tier", "gold", "app", "foo")
+  {app="foo", tier="gold"} 6
+  {app="foobar", tier="2"} 6
+
+# Empty replacement deletes dst label.
+eval instant at 60s label_replace(count_over_time({app=~"foo.*"} |~".+bar" [1m]), "tier", "", "app", "foo")
+  {app="foo"} 6
+  {app="foobar", tier="2"} 6
+
+# dst==src rewrites the label in place.
+eval instant at 60s label_replace(count_over_time({app=~"foo.*"} |~".+bar" [1m]), "app", "$1", "app", "f(.*)")
+  {app="oo", tier="1"} 6
+  {app="oobar", tier="2"} 6
+
+# An absent source label reads as "": a regex that matches the empty string still fires, so a
+# constant replacement adds the dst to every series (this is the idiomatic "add a label" use).
+eval instant at 60s label_replace(count_over_time({app=~"foo.*"} |~".+bar" [1m]), "region", "eu", "missing", ".*")
+  {app="foo", tier="1", region="eu"} 6
+  {app="foobar", tier="2", region="eu"} 6
+
+# Invalid regex returns a parse error.
+eval instant at 60s label_replace(count_over_time({app=~"foo.*"} |~".+bar" [1m]), "new", "$1", "app", "(")
+  expect fail
+
+# label_replace reads the final label set, the one left after structured metadata and parser
+# conflicts are resolved. The precedence order is: stream > structured metadata > parsed.
+# Each conflict loser keeps its value under a `<name>_extracted` label.
+# Structured metadata is present even without a parser stage.
+clear
+load
+  # Stream label conflicting with structured metadata.
+  {app="a", env="prod"} "msg" @ 20s [repeat every 20s for 3] [metadata region="eu" env="canary"]
+  {app="noise"} "noise" @ 30s
+
+# `region` exists only in structured metadata: label_replace copies it like any other label.
+eval instant at 60s label_replace(count_over_time({app="a"} [1m]), "out", "$1", "region", "(.*)")
+  {app="a", env="prod", env_extracted="canary", region="eu", out="eu"} 3
+
+# `env` is both a stream label and structured metadata.
+eval instant at 60s label_replace(count_over_time({app="a"} [1m]), "out", "$1", "env", "(.*)")
+  {app="a", env="prod", env_extracted="canary", region="eu", out="prod"} 3
+eval instant at 60s label_replace(count_over_time({app="a"} [1m]), "out", "$1", "env_extracted", "(.*)")
+  {app="a", env="prod", env_extracted="canary", region="eu", out="canary"} 3
+
+clear
+load
+  # Line fields conflict with stream labels or structured metadata.
+  {app="a", zone="s"} "svc=api zone=p tid=p" @ 20s [repeat every 20s for 3] [metadata tid="m"]
+  {app="noise"} "noise" @ 30s
+
+# `svc` has no conflict.
+eval instant at 60s label_replace(count_over_time({app="a"} | logfmt [1m]), "out", "$1", "svc", "(.*)")
+  {app="a", zone="s", zone_extracted="p", tid="m", tid_extracted="p", svc="api", out="api"} 3
+
+# `zone` line field conflicts with stream label.
+eval instant at 60s label_replace(count_over_time({app="a"} | logfmt [1m]), "out", "$1", "zone", "(.*)")
+  {app="a", zone="s", zone_extracted="p", tid="m", tid_extracted="p", svc="api", out="s"} 3
+eval instant at 60s label_replace(count_over_time({app="a"} | logfmt [1m]), "out", "$1", "zone_extracted", "(.*)")
+  {app="a", zone="s", zone_extracted="p", tid="m", tid_extracted="p", svc="api", out="p"} 3
+
+# `tid` line field conflicts with structured metadata.
+eval instant at 60s label_replace(count_over_time({app="a"} | logfmt [1m]), "out", "$1", "tid", "(.*)")
+  {app="a", zone="s", zone_extracted="p", tid="m", tid_extracted="p", svc="api", out="m"} 3
+eval instant at 60s label_replace(count_over_time({app="a"} | logfmt [1m]), "out", "$1", "tid_extracted", "(.*)")
+  {app="a", zone="s", zone_extracted="p", tid="m", tid_extracted="p", svc="api", out="p"} 3
+
+clear
+load
+  # A line field conflicts both with stream labels and structured metadata.
+  {app="a", k="s"} "k=p" @ 20s [repeat every 20s for 3] [metadata k="m"]
+  {app="noise"} "noise" @ 30s
+
+# `k` line field conflicts both with stream labels and structured metadata.
+eval instant at 60s label_replace(count_over_time({app="a"} | logfmt [1m]), "out", "$1", "k", "(.*)")
+  {app="a", k="s", k_extracted="p", out="s"} 3
+eval instant at 60s label_replace(count_over_time({app="a"} | logfmt [1m]), "out", "$1", "k_extracted", "(.*)")
+  {app="a", k="s", k_extracted="p", out="p"} 3
+eval instant at 60s label_replace(count_over_time({app="a"} [1m]), "out", "$1", "k_extracted", "(.*)")
+  {app="a", k="s", k_extracted="m", out="m"} 3

--- a/pkg/logql/internal/logqltest/testdata/functions.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/functions.logqltest
@@ -33,10 +33,15 @@ eval instant at 60s label_replace(count_over_time({app=~"foo.*"} |~".+bar" [1m])
   {app="foo", tier="gold"} 6
   {app="foobar", tier="2"} 6
 
-# Empty replacement deletes dst label.
+# Empty replacement – coming from empty dst value – deletes dst label.
 eval instant at 60s label_replace(count_over_time({app=~"foo.*"} |~".+bar" [1m]), "tier", "", "app", "foo")
   {app="foo"} 6
   {app="foobar", tier="2"} 6
+
+# Empty replacement – coming from regexp capture group – deletes dst label.
+eval instant at 60s label_replace(count_over_time({app=~"foo.*"} |~".+bar" [1m]), "app", "$1", "app", "foo(.*)")
+   {tier="1"} 6
+   {app="bar", tier="2"} 6
 
 # dst==src rewrites the label in place.
 eval instant at 60s label_replace(count_over_time({app=~"foo.*"} |~".+bar" [1m]), "app", "$1", "app", "f(.*)")

--- a/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
@@ -81,11 +81,6 @@ eval instant at 60s bytes_over_time({app="foo"}[30s])
 eval range from 60s to 120s step 15s bytes_over_time({app="foo"}[30s])
   {app="foo"} 12 12 12 12 12
 
-eval instant at 60s bytes_rate({app="foo"}[30s])
-  {app="foo"} 0.4
-eval range from 60s to 120s step 15s bytes_rate({app="foo"}[30s])
-  {app="foo"} 0.4 0.4 0.4 0.4 0.4
-
 # bytes_over_time compared against a scalar (12 bytes per [30s] window).
 eval instant at 60s bytes_over_time({app="foo"}[30s]) > 1
   {app="foo"} 12
@@ -108,6 +103,33 @@ eval instant at 60s 1 < bool bytes_over_time({app="foo"}[30s])
 eval range from 60s to 120s step 15s 1 < bool bytes_over_time({app="foo"}[30s])
   {app="foo"} 1 1 1 1 1
 
+# bytes_rate is computed as Σ(line bytes in window) / range seconds.
+clear
+load
+  {app="a"} "xbar"  @ 0s [repeat every 10s for 13]
+  {app="a"} "noise" @ 5s [repeat every 10s for 13]
+  {app="b"} "xxbar" @ 0s [repeat every 10s for 13]
+  {app="b"} "noise" @ 5s [repeat every 10s for 13]
+
+eval instant at 60s bytes_rate({app=~"a|b"} |~".+bar" [30s])
+  {app="a"} 0.4
+  {app="b"} 0.5
+
+# Overlapping range vector selectors (step < range).
+eval range from 60s to 120s step 15s bytes_rate({app=~"a|b"} |~".+bar" [30s])
+  {app="a"} 0.4 0.4 0.4 0.4 0.4
+  {app="b"} 0.5 0.5 0.5 0.5 0.5
+
+# Non-overlapping range vector selectors (step > range).
+eval range from 60s to 120s step 30s bytes_rate({app=~"a|b"} |~".+bar" [20s])
+  {app="a"} 0.4 0.4 0.4
+  {app="b"} 0.5 0.5 0.5
+
+# Output gap (past the last sample).
+eval range from 90s to 150s step 30s bytes_rate({app=~"a|b"} |~".+bar" [20s])
+  {app="a"} 0.4 0.4 _
+  {app="b"} 0.5 0.5 _
+
 # unwrap of a stream label `foo` (no parser stage).
 clear
 load
@@ -122,18 +144,105 @@ eval range from 60s to 120s step 15s rate({app="foo"} | unwrap foo [30s])
 # first_over_time / last_over_time over unwrapped values.
 clear
 load
-  {app="foo", foo="2"} "xbar"  @ 0s [repeat every 10s for 61]
-  {app="foo", foo="2"} "noise" @ 5s [repeat every 10s for 61]
+  {app="a"} "v=10"  @ 10s
+  {app="a"} "v=20"  @ 20s
+  {app="a"} "v=30"  @ 30s
+  {app="a"} "v=40"  @ 90s
+  {app="a"} "v=NaN" @ 100s
+  {app="a"} "noise" @ 15s
 
-eval instant at 60s first_over_time({app="foo"} |~".+bar" | unwrap foo [1m])
-  {app="foo"} 2
-eval range from 60s to 120s step 30s first_over_time({app="foo"} |~".+bar" | unwrap foo [1m])
-  {app="foo"} 2 2 2
+# Range vector selector spanning multiple samples.
+eval instant at 60s first_over_time({app="a"} | logfmt | unwrap v [1m])
+  {app="a"} 10
+eval instant at 60s last_over_time({app="a"} | logfmt | unwrap v [1m])
+  {app="a"} 30
 
-eval instant at 300s last_over_time(({app="foo"} |~".+bar" | unwrap foo)[5m])
-  {app="foo"} 2
-eval range from 300s to 600s step 30s last_over_time(({app="foo"} |~".+bar" | unwrap foo)[5m])
-  {app="foo"} 2 2 2 2 2 2 2 2 2 2 2
+# Range vector selector picking a single sample.
+eval instant at 40s first_over_time({app="a"} | logfmt | unwrap v [20s])
+  {app="a"} 30
+eval instant at 40s last_over_time({app="a"} | logfmt | unwrap v [20s])
+  {app="a"} 30
+
+# Overlapping range vector selectors (step < range).
+eval range from 20s to 40s step 10s first_over_time({app="a"} | logfmt | unwrap v [20s])
+  {app="a"} 10 20 30
+eval range from 20s to 40s step 10s last_over_time({app="a"} | logfmt | unwrap v [20s])
+  {app="a"} 20 30 30
+
+# Non-overlapping range vector selectors (step > range).
+eval range from 10s to 30s step 20s first_over_time({app="a"} | logfmt | unwrap v [10s])
+  {app="a"} 10 30
+eval range from 10s to 30s step 20s last_over_time({app="a"} | logfmt | unwrap v [10s])
+  {app="a"} 10 30
+
+# Output gaps.
+eval range from 30s to 90s step 30s first_over_time({app="a"} | logfmt | unwrap v [20s])
+  {app="a"} 20 _ 40
+eval range from 30s to 90s step 30s last_over_time({app="a"} | logfmt | unwrap v [20s])
+  {app="a"} 30 _ 40
+
+# first/last return the boundary sample verbatim, including NaN (they don't skip it).
+eval instant at 110s first_over_time({app="a"} | logfmt | unwrap v [30s])
+  {app="a"} 40
+eval instant at 110s last_over_time({app="a"} | logfmt | unwrap v [30s])
+  {app="a"} NaN
+eval instant at 125s first_over_time({app="a"} | logfmt | unwrap v [30s])
+  {app="a"} NaN
+
+# quantile_over_time.
+clear
+load
+  {app="a"} "v=1"   @ 10s
+  {app="a"} "v=2"   @ 20s
+  {app="a"} "v=3"   @ 30s
+  {app="a"} "v=4"   @ 40s
+  {app="a"} "v=5"   @ 50s
+  {app="a"} "v=6"   @ 110s
+  {app="a"} "noise" @ 25s
+
+# Linear interpolation between ranked samples.
+eval instant at 60s quantile_over_time(0, {app="a"} | logfmt | unwrap v [1m])
+  {app="a"} 1
+eval instant at 60s quantile_over_time(0.25, {app="a"} | logfmt | unwrap v [1m])
+  {app="a"} 2
+eval instant at 60s quantile_over_time(0.4, {app="a"} | logfmt | unwrap v [1m])
+  {app="a"} 2.6     # (0.4 x 2) + (0.6 x 3) = 2.6
+eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m])
+  {app="a"} 3
+eval instant at 60s quantile_over_time(1, {app="a"} | logfmt | unwrap v [1m])
+  {app="a"} 5
+
+# When q is > 1 it returns +Inf.
+eval instant at 60s quantile_over_time(1.5, {app="a"} | logfmt | unwrap v [1m])
+  {app="a"} +Inf
+
+# A negative quantile literal is a parse error.
+eval instant at 60s quantile_over_time(-0.1, {app="a"} | logfmt | unwrap v [1m])
+  expect fail msg: unexpected -
+
+# Single-sample window: any quantile returns that value.
+eval instant at 10s quantile_over_time(0, {app="a"} | logfmt | unwrap v [5s])
+  {app="a"} 1
+eval instant at 10s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [5s])
+  {app="a"} 1
+eval instant at 10s quantile_over_time(1, {app="a"} | logfmt | unwrap v [5s])
+  {app="a"} 1
+
+# Median interpolates midway between 2 values.
+eval instant at 50s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [15s])
+  {app="a"} 4.5     # (0.5 x 4) + (0.5 x 5) = 4.5
+
+# Overlapping range vector selectors (step < range).
+eval range from 30s to 60s step 30s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m])
+  {app="a"} 2 3     # (−30s,30s]={1,2,3}→2, (0s,60s]={1,2,3,4,5}→3
+
+# Non-overlapping range vector selectors (step > range).
+eval range from 20s to 50s step 30s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [15s])
+  {app="a"} 1.5 4.5 # (5s,20s]={1,2}→1.5, (35s,50s]={4,5}→4.5
+
+# Output gap.
+eval range from 50s to 110s step 30s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [15s])
+  {app="a"} 4.5 _ 6
 
 # unwrap of a stream label `bar`.
 clear

--- a/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
@@ -189,21 +189,26 @@ eval instant at 110s last_over_time({app="a"} | logfmt | unwrap v [30s])
 eval instant at 125s first_over_time({app="a"} | logfmt | unwrap v [30s])
   {app="a"} NaN
 
-# first/last_over_time with grouping (by pod; app dropped). Distinct timestamps keep first/last
-# deterministic: pod=1 {v=2@20s, v=4@30s}, pod=2 {v=10@40s, v=20@50s}.
+# first_over_time() / last_over_time() with grouping.
 clear
 load
   {app="a", pod="1"} "v=2"  @ 20s
   {app="a", pod="1"} "v=4"  @ 30s
   {app="a", pod="2"} "v=10" @ 40s
   {app="a", pod="2"} "v=20" @ 50s
-  {app="a", pod="1"} "noise" @ 25s   # no `v` -> dropped by unwrap
+  {app="a", pod="1"} "noise" @ 25s
+
 eval instant at 60s first_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
   {pod="1"} 2
   {pod="2"} 10
 eval instant at 60s last_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
   {pod="1"} 4
   {pod="2"} 20
+
+eval instant at 60s first_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
+  {app="a"} 2
+eval instant at 60s last_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
+  {app="a"} 20
 
 # quantile_over_time.
 clear
@@ -264,21 +269,26 @@ eval range from 20s to 50s step 30s quantile_over_time(0.5, {app="a"} | logfmt |
 eval range from 50s to 110s step 30s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [15s])
   {app="a"} 4.5 _ 6
 
-# quantile_over_time with grouping: by/without combine the unwrapped samples across the streams in
-# each group. Two pods under app="a": pod=1 {2,4}, pod=2 {10,20}; by (app) folds all four into one
-# group (median of {2,4,10,20} = 7).
+# quantile_over_time() with grouping.
 clear
 load
   {app="a", pod="1"} "v=2"  @ 20s
   {app="a", pod="1"} "v=4"  @ 30s
   {app="a", pod="2"} "v=10" @ 40s
   {app="a", pod="2"} "v=20" @ 50s
-  {app="a", pod="1"} "noise" @ 25s   # no `v` -> dropped by unwrap
+  {app="a", pod="1"} "noise" @ 25s
+
 eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) by (pod)
   {pod="1"} 3
   {pod="2"} 15
 eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) by (app)
   {app="a"} 7
+
+eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) without (pod)
+  {app="a"} 7
+eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) without (app)
+  {pod="1"} 3
+  {pod="2"} 15
 
 # unwrap of a stream label `bar`.
 clear

--- a/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
@@ -189,6 +189,22 @@ eval instant at 110s last_over_time({app="a"} | logfmt | unwrap v [30s])
 eval instant at 125s first_over_time({app="a"} | logfmt | unwrap v [30s])
   {app="a"} NaN
 
+# first/last_over_time with grouping (by pod; app dropped). Distinct timestamps keep first/last
+# deterministic: pod=1 {v=2@20s, v=4@30s}, pod=2 {v=10@40s, v=20@50s}.
+clear
+load
+  {app="a", pod="1"} "v=2"  @ 20s
+  {app="a", pod="1"} "v=4"  @ 30s
+  {app="a", pod="2"} "v=10" @ 40s
+  {app="a", pod="2"} "v=20" @ 50s
+  {app="a", pod="1"} "noise" @ 25s   # no `v` -> dropped by unwrap
+eval instant at 60s first_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
+  {pod="1"} 2
+  {pod="2"} 10
+eval instant at 60s last_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
+  {pod="1"} 4
+  {pod="2"} 20
+
 # quantile_over_time.
 clear
 load
@@ -220,6 +236,10 @@ eval instant at 60s quantile_over_time(1.5, {app="a"} | logfmt | unwrap v [1m])
 eval instant at 60s quantile_over_time(-0.1, {app="a"} | logfmt | unwrap v [1m])
   expect fail msg: unexpected -
 
+# quantile_over_time requires an unwrap.
+eval instant at 60s quantile_over_time(0.5, {app="a"}[1m])
+  expect fail msg: invalid aggregation quantile_over_time without unwrap
+
 # Single-sample window: any quantile returns that value.
 eval instant at 10s quantile_over_time(0, {app="a"} | logfmt | unwrap v [5s])
   {app="a"} 1
@@ -243,6 +263,22 @@ eval range from 20s to 50s step 30s quantile_over_time(0.5, {app="a"} | logfmt |
 # Output gap.
 eval range from 50s to 110s step 30s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [15s])
   {app="a"} 4.5 _ 6
+
+# quantile_over_time with grouping: by/without combine the unwrapped samples across the streams in
+# each group. Two pods under app="a": pod=1 {2,4}, pod=2 {10,20}; by (app) folds all four into one
+# group (median of {2,4,10,20} = 7).
+clear
+load
+  {app="a", pod="1"} "v=2"  @ 20s
+  {app="a", pod="1"} "v=4"  @ 30s
+  {app="a", pod="2"} "v=10" @ 40s
+  {app="a", pod="2"} "v=20" @ 50s
+  {app="a", pod="1"} "noise" @ 25s   # no `v` -> dropped by unwrap
+eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) by (pod)
+  {pod="1"} 3
+  {pod="2"} 15
+eval instant at 60s quantile_over_time(0.5, {app="a"} | logfmt | unwrap v [1m]) by (app)
+  {app="a"} 7
 
 # unwrap of a stream label `bar`.
 clear


### PR DESCRIPTION
**What this PR does / why we need it**:

Broadens the declarative `logqltest` correctness suite for LogQL metric queries, which had thin coverage for several functions. Adds cases for `quantile_over_time`, `first_over_time`, `last_over_time`, `bytes_rate`, and `label_replace`: overlapping vs non-overlapping window shapes, output gaps from empty windows, quantile interpolation and out-of-range saturation, and `label_replace` over structured metadata and parser/stream-label conflicts (the `_extracted` name resolution).

**Which issue(s) this PR fixes**:
N/A — test-only.

**Special notes for your reviewer**:

Test-data-only change (`*.logqltest`); no production code is modified. Expected values are hand-computed and cross-checked against the engine.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
