### PR TITLE
feat(engine): Add configurable v1-only stream selector routing

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -417,6 +417,13 @@ query_engine:
   # CLI flag: -query-engine.storage-retention-days
   [storage_retention_days: <int> | default = 0]
 
+  # Experimental: LogQL stream selector, e.g. '{app="foo"}'. Queries whose
+  # stream selector contains all of these matchers are always executed by the v1
+  # (chunks) engine. Only equality matchers are allowed, and only queries using
+  # the exact same equality matchers are detected. Empty disables the feature.
+  # CLI flag: -query-engine.v1-only-stream-selector
+  [v1_only_stream_selector: <string> | default = ""]
+
   # Enable routing of query splits in the query frontend to the next generation
   # engine when they fall within the configured time range.
   # CLI flag: -query-engine.enable-engine-router

--- a/pkg/engine/config.go
+++ b/pkg/engine/config.go
@@ -9,7 +9,10 @@ import (
 
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/netutil"
+	"github.com/prometheus/prometheus/model/labels"
 
+	"github.com/grafana/loki/v3/pkg/logql"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/cache/resultscache"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
@@ -32,6 +35,13 @@ type Config struct {
 	StorageLag           time.Duration `yaml:"storage_lag" category:"experimental"`
 	StorageStartDate     flagext.Time  `yaml:"storage_start_date" category:"experimental"`
 	StorageRetentionDays int64         `yaml:"storage_retention_days" category:"experimental"`
+
+	// V1OnlyStreamSelector is a LogQL stream selector. Queries whose stream
+	// selector contains all of its matchers are always executed by the v1
+	// (chunks) engine, regardless of the configured storage time range.
+	V1OnlyStreamSelector string `yaml:"v1_only_stream_selector" category:"experimental"`
+	// V1OnlyMatchers is parsed from V1OnlyStreamSelector during validation.
+	V1OnlyMatchers []*labels.Matcher `yaml:"-" json:"-"`
 
 	EnableEngineRouter       bool   `yaml:"enable_engine_router" category:"experimental"`
 	DownstreamAddress        string `yaml:"downstream_address" category:"experimental"`
@@ -65,6 +75,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.DurationVar(&cfg.StorageLag, prefix+"storage-lag", 1*time.Hour, "Amount of time until data objects are available.")
 	f.Var(&cfg.StorageStartDate, prefix+"storage-start-date", "Initial date when data objects became available. Format YYYY-MM-DD. If not set, assume data objects are always available no matter how far back.")
 	f.Int64Var(&cfg.StorageRetentionDays, prefix+"storage-retention-days", 0, "Lifecycle of data objects in days. If set, queries falling outside of the retention period will not be supported. When both storage-start-date and storage-retention-days are set, the more restrictive of the two will apply.")
+	f.StringVar(&cfg.V1OnlyStreamSelector, prefix+"v1-only-stream-selector", "", "Experimental: LogQL stream selector, e.g. '{app=\"foo\"}'. Queries whose stream selector contains all of these matchers are always executed by the v1 (chunks) engine. Only equality matchers are allowed, and only queries using the exact same equality matchers are detected. Empty disables the feature.")
 
 	f.BoolVar(&cfg.EnableEngineRouter, prefix+"enable-engine-router", false, "Enable routing of query splits in the query frontend to the next generation engine when they fall within the configured time range.")
 	f.StringVar(&cfg.DownstreamAddress, prefix+"downstream-address", "", "Downstream address to send query splits to. This is the HTTP handler address of the query engine scheduler.")
@@ -73,6 +84,83 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&cfg.AlignQueriesWithStep, prefix+"align-queries-with-step", false, "Mutate incoming queries to align their start and end with their step.")
 	f.BoolVar(&cfg.EnforceQuerySeriesLimit, prefix+"enforce-max-query-series-limit", false, "Experimental: When enabled, the tenant's MaxQuerySeries limit is applied. Otherwise, no limit is enforced.")
 	cfg.ResultsCache.RegisterFlagsWithPrefix(f, prefix+"results-cache.")
+}
+
+// Validate validates the config and populates derived fields such as
+// V1OnlyMatchers. It is idempotent.
+func (cfg *Config) Validate() error {
+	if cfg.V1OnlyStreamSelector == "" {
+		cfg.V1OnlyMatchers = nil
+		return nil
+	}
+
+	matchers, err := ParseV1OnlySelector(cfg.V1OnlyStreamSelector)
+	if err != nil {
+		return err
+	}
+	cfg.V1OnlyMatchers = matchers
+	return nil
+}
+
+// ParseV1OnlySelector parses a v1-only stream selector into label matchers.
+// Only equality matchers are allowed: matching against queries is done by
+// exact matcher equality, so a regex or negative matcher in the selector
+// would silently never match.
+func ParseV1OnlySelector(selector string) ([]*labels.Matcher, error) {
+	matchers, err := syntax.ParseMatchers(selector, true)
+	if err != nil {
+		return nil, fmt.Errorf("invalid v1-only stream selector %q: %w", selector, err)
+	}
+	for _, m := range matchers {
+		if m.Type != labels.MatchEqual {
+			return nil, fmt.Errorf("v1-only stream selector must contain only equality matchers, got %s", m)
+		}
+	}
+	return matchers, nil
+}
+
+// MatchesV1OnlySelector returns true if any of the query's matcher groups
+// contains all of the configured V1OnlyMatchers, compared by exact matcher
+// equality. Such queries must be executed by the v1 (chunks) engine.
+func (cfg *Config) MatchesV1OnlySelector(params logql.Params) bool {
+	if len(cfg.V1OnlyMatchers) == 0 {
+		return false
+	}
+
+	expr := params.GetExpression()
+	if expr == nil {
+		return false
+	}
+
+	groups, err := syntax.MatcherGroups(expr)
+	if err != nil {
+		return false
+	}
+
+	for _, group := range groups {
+		if containsAllMatchers(group.Matchers, cfg.V1OnlyMatchers) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsAllMatchers returns true if every matcher in required has an exact
+// equal (name, type, value) in group.
+func containsAllMatchers(group, required []*labels.Matcher) bool {
+	for _, req := range required {
+		found := false
+		for _, m := range group {
+			if m.Type == req.Type && m.Name == req.Name && m.Value == req.Value {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 func (cfg *Config) ValidQueryRange() (time.Time, time.Time) {

--- a/pkg/engine/config_test.go
+++ b/pkg/engine/config_test.go
@@ -1,0 +1,168 @@
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql"
+)
+
+func TestConfig_Validate_V1OnlyStreamSelector(t *testing.T) {
+	tests := []struct {
+		name             string
+		selector         string
+		expectedErr      string
+		expectedMatchers []*labels.Matcher
+	}{
+		{
+			name: "empty selector disables the feature",
+		},
+		{
+			name:     "valid equality selector",
+			selector: `{app="foo"}`,
+			expectedMatchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "app", "foo"),
+			},
+		},
+		{
+			name:     "multiple equality matchers",
+			selector: `{app="foo", env="prod"}`,
+			expectedMatchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "app", "foo"),
+				labels.MustNewMatcher(labels.MatchEqual, "env", "prod"),
+			},
+		},
+		{
+			name:        "invalid LogQL selector",
+			selector:    `{app=}`,
+			expectedErr: "invalid v1-only stream selector",
+		},
+		{
+			name:        "regex matcher rejected even alongside an equality matcher",
+			selector:    `{app="foo", env=~"prod.*"}`,
+			expectedErr: "must contain only equality matchers",
+		},
+		{
+			name:        "negative matcher rejected",
+			selector:    `{app="foo", env!="dev"}`,
+			expectedErr: "must contain only equality matchers",
+		},
+		{
+			name:        "negative regex matcher rejected",
+			selector:    `{app="foo", env!~"dev.*"}`,
+			expectedErr: "must contain only equality matchers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{V1OnlyStreamSelector: tt.selector}
+			err := cfg.Validate()
+
+			if tt.expectedErr != "" {
+				require.ErrorContains(t, err, tt.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.ElementsMatch(t, tt.expectedMatchers, cfg.V1OnlyMatchers)
+		})
+	}
+}
+
+func TestConfig_MatchesV1OnlySelector(t *testing.T) {
+	newParams := func(t *testing.T, query string) logql.Params {
+		t.Helper()
+		now := time.Now()
+		params, err := logql.NewLiteralParams(query, now.Add(-time.Hour), now, 0, 0, logproto.BACKWARD, 100, nil, nil)
+		require.NoError(t, err)
+		return params
+	}
+
+	tests := []struct {
+		name     string
+		selector string
+		query    string
+		expected bool
+	}{
+		{
+			name:     "exact match",
+			selector: `{app="foo"}`,
+			query:    `{app="foo"}`,
+			expected: true,
+		},
+		{
+			name:     "query group with extra matchers matches",
+			selector: `{app="foo"}`,
+			query:    `{app="foo", env="prod"}`,
+			expected: true,
+		},
+		{
+			name:     "different value does not match",
+			selector: `{app="foo"}`,
+			query:    `{app="bar"}`,
+			expected: false,
+		},
+		{
+			name:     "regex matcher in query does not match",
+			selector: `{app="foo"}`,
+			query:    `{app=~"foo"}`,
+			expected: false,
+		},
+		{
+			name:     "multi-matcher selector requires all matchers",
+			selector: `{app="foo", env="prod"}`,
+			query:    `{app="foo", cluster="us"}`,
+			expected: false,
+		},
+		{
+			name:     "multi-matcher selector with all matchers present",
+			selector: `{app="foo", env="prod"}`,
+			query:    `{env="prod", cluster="us", app="foo"}`,
+			expected: true,
+		},
+		{
+			name:     "metric query wrapping a matching selector",
+			selector: `{app="foo"}`,
+			query:    `count_over_time({app="foo"}[5m])`,
+			expected: true,
+		},
+		{
+			name:     "binary op with one matching leg",
+			selector: `{app="foo"}`,
+			query:    `sum(rate({app="foo"}[5m])) + sum(rate({app="bar"}[5m]))`,
+			expected: true,
+		},
+		{
+			name:     "binary op with no matching leg",
+			selector: `{app="foo"}`,
+			query:    `sum(rate({app="bar"}[5m])) + sum(rate({app="baz"}[5m]))`,
+			expected: false,
+		},
+		{
+			name:     "query without stream selector",
+			selector: `{app="foo"}`,
+			query:    `vector(0)`,
+			expected: false,
+		},
+		{
+			name:     "no selector configured",
+			selector: "",
+			query:    `{app="foo"}`,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{V1OnlyStreamSelector: tt.selector}
+			require.NoError(t, cfg.Validate())
+
+			require.Equal(t, tt.expected, cfg.MatchesV1OnlySelector(newParams(t, tt.query)))
+		})
+	}
+}

--- a/pkg/engine/handler.go
+++ b/pkg/engine/handler.go
@@ -75,6 +75,12 @@ func executorHandler(
 	limits Limits,
 	reg prometheus.Registerer,
 ) (http.Handler, error) {
+	// Populate derived config fields (e.g. V1OnlyMatchers) in case the config
+	// was not validated upfront. Validate is idempotent.
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
 	var h queryrangebase.Handler = &queryHandler{
 		cfg:    cfg,
 		logger: logger,
@@ -545,6 +551,11 @@ func (h *queryHandler) validateMatcherGroup(matchers []*labels.Matcher, required
 }
 
 func (h *queryHandler) execute(ctx context.Context, logger log.Logger, params logql.Params) (logqlmodel.Result, error) {
+	if h.cfg.MatchesV1OnlySelector(params) {
+		return logqlmodel.Result{}, httpgrpc.Error(http.StatusNotImplemented,
+			"query matches the configured v1-only stream selector and must be executed by the v1 engine")
+	}
+
 	if err := h.validateTimeRange(params); err != nil {
 		return logqlmodel.Result{}, httpgrpc.Error(http.StatusNotImplemented, err.Error())
 	}

--- a/pkg/engine/handler_test.go
+++ b/pkg/engine/handler_test.go
@@ -516,6 +516,97 @@ func TestQueryHandler_ValidTimeRange(t *testing.T) {
 	}
 }
 
+func TestQueryHandler_V1OnlyStreamSelector(t *testing.T) {
+	now := time.Now()
+
+	cfg := Config{
+		StorageLag:           time.Hour,
+		V1OnlyStreamSelector: `{app="foo"}`,
+	}
+	require.NoError(t, cfg.Validate())
+
+	newHandler := func(executed *bool) queryrangebase.Handler {
+		eng := &mockEngine{
+			executeFunc: func(_ context.Context, _ logql.Params) (logqlmodel.Result, error) {
+				*executed = true
+				return logqlmodel.Result{Data: logqlmodel.Streams{}}, nil
+			},
+		}
+		return newTestHandler(cfg, eng, &querytest.MockLimits{MaxEntriesLimitPerQueryVal: 1000})
+	}
+
+	requireV1OnlyError := func(t *testing.T, err error) {
+		t.Helper()
+		require.Error(t, err)
+		httpErr, ok := httpgrpc.HTTPResponseFromError(err)
+		require.True(t, ok)
+		require.Equal(t, int32(http.StatusNotImplemented), httpErr.Code)
+		require.Contains(t, string(httpErr.Body), "v1-only stream selector")
+	}
+
+	t.Run("matching range query returns 501", func(t *testing.T) {
+		var executed bool
+		handler := newHandler(&executed)
+
+		query := `{app="foo", env="prod"}`
+		req := &queryrange.LokiRequest{
+			Query:   query,
+			Limit:   100,
+			StartTs: now.Add(-4 * time.Hour),
+			EndTs:   now.Add(-2 * time.Hour),
+			Plan: &plan.QueryPlan{
+				AST: syntax.MustParseExpr(query),
+			},
+		}
+
+		ctx := user.InjectOrgID(context.Background(), "fake")
+		_, err := handler.Do(ctx, req)
+		requireV1OnlyError(t, err)
+		require.False(t, executed)
+	})
+
+	t.Run("matching instant query returns 501", func(t *testing.T) {
+		var executed bool
+		handler := newHandler(&executed)
+
+		query := `count_over_time({app="foo"}[5m])`
+		req := &queryrange.LokiInstantRequest{
+			Query:  query,
+			Limit:  100,
+			TimeTs: now.Add(-2 * time.Hour),
+			Plan: &plan.QueryPlan{
+				AST: syntax.MustParseExpr(query),
+			},
+		}
+
+		ctx := user.InjectOrgID(context.Background(), "fake")
+		_, err := handler.Do(ctx, req)
+		requireV1OnlyError(t, err)
+		require.False(t, executed)
+	})
+
+	t.Run("non-matching query executes normally", func(t *testing.T) {
+		var executed bool
+		handler := newHandler(&executed)
+
+		query := `{app="test"}`
+		req := &queryrange.LokiRequest{
+			Query:   query,
+			Limit:   100,
+			StartTs: now.Add(-4 * time.Hour),
+			EndTs:   now.Add(-2 * time.Hour),
+			Plan: &plan.QueryPlan{
+				AST: syntax.MustParseExpr(query),
+			},
+		}
+
+		ctx := user.InjectOrgID(context.Background(), "fake")
+		_, err := handler.Do(ctx, req)
+		require.NoError(t, err)
+		require.True(t, executed)
+	})
+}
+
 func TestQueryHandler_ValidateMaxEntriesLimits(t *testing.T) {
 	now := time.Now()
 	startTime := now.Add(-1 * time.Hour)

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -296,6 +296,9 @@ func (c *Config) Validate() error {
 	if err := c.QueryRange.Validate(); err != nil {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid query_range config"))
 	}
+	if err := c.QueryEngine.Validate(); err != nil {
+		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid query_engine config"))
+	}
 	if err := c.Querier.Validate(); err != nil {
 		errs = append(errs, errors.Wrap(err, "CONFIG ERROR: invalid querier config"))
 	}

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -1110,6 +1110,7 @@ func (t *Loki) initQueryFrontendMiddleware() (_ services.Service, err error) {
 			Enabled:  true,
 			V2Range:  t.Cfg.QueryEngine.ValidQueryRange,
 			Validate: engine_v2.IsQuerySupported,
+			ForceV1:  t.Cfg.QueryEngine.MatchesV1OnlySelector,
 			Handler:  handler,
 		}
 	}

--- a/pkg/querier/queryrange/engine_router.go
+++ b/pkg/querier/queryrange/engine_router.go
@@ -28,6 +28,10 @@ type RouterConfig struct {
 	// Validate function to check if the query is supported by the engine.
 	Validate func(params logql.Params) bool
 
+	// ForceV1 is an optional function that, when it returns true, forces the
+	// whole query to be executed by the v1 engine without splitting.
+	ForceV1 func(params logql.Params) bool
+
 	// Handler to execute queries against the engine.
 	Handler queryrangebase.Handler
 }
@@ -47,6 +51,7 @@ type engineRouter struct {
 
 	v2Range      func() (start, end time.Time)
 	validV2Query func(params logql.Params) bool
+	forceV1      func(params logql.Params) bool
 
 	merger queryrangebase.Merger
 
@@ -72,6 +77,7 @@ func NewEngineRouterMiddleware(
 			v1Next:         queryrangebase.MergeMiddlewares(v1Chain...).Wrap(next),
 			v2Next:         v2RouterConfig.Handler,
 			validV2Query:   v2RouterConfig.Validate,
+			forceV1:        v2RouterConfig.ForceV1,
 			merger:         merger,
 			logger:         logger,
 			forMetricQuery: metricQuery,
@@ -90,6 +96,12 @@ func (e *engineRouter) Do(ctx context.Context, r queryrangebase.Request) (queryr
 	params, err := ParamsFromRequest(r)
 	if err != nil {
 		return nil, err
+	}
+
+	// Queries matching the configured v1-only stream selector must be entirely
+	// executed by chunks.
+	if e.forceV1 != nil && e.forceV1(params) {
+		return e.v1Next.Do(ctx, r)
 	}
 
 	// Unsupported queries should be entirely executed by chunks.

--- a/pkg/querier/queryrange/engine_router_test.go
+++ b/pkg/querier/queryrange/engine_router_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -371,6 +373,82 @@ func Test_engineRouter_Do(t *testing.T) {
 			require.Equal(t, tt.want, res)
 		})
 	}
+}
+
+func Test_engineRouter_Do_ForceV1(t *testing.T) {
+	var mtx sync.Mutex
+	var v1Reqs, v2Reqs []queryrangebase.Request
+
+	record := func(reqs *[]queryrangebase.Request) queryrangebase.HandlerFunc {
+		return func(_ context.Context, r queryrangebase.Request) (queryrangebase.Response, error) {
+			mtx.Lock()
+			defer mtx.Unlock()
+			*reqs = append(*reqs, r)
+			return &LokiResponse{
+				Status:    loghttp.QueryStatusSuccess,
+				Direction: r.(*LokiRequest).Direction,
+				Limit:     r.(*LokiRequest).Limit,
+				Version:   uint32(loghttp.VersionV1),
+				Data:      LokiData{ResultType: loghttp.ResultTypeStream},
+			}, nil
+		}
+	}
+
+	now := time.Now().Truncate(time.Second)
+	router := NewEngineRouterMiddleware(
+		RouterConfig{
+			V2Range: func() (time.Time, time.Time) {
+				return now.Add(-24 * time.Hour), now.Add(-time.Hour)
+			},
+			Validate: func(_ logql.Params) bool { return true },
+			ForceV1: func(params logql.Params) bool {
+				return strings.Contains(params.QueryString(), `app="foo"`)
+			},
+			Handler: record(&v2Reqs),
+		},
+		nil,
+		DefaultCodec,
+		false,
+		log.NewNopLogger(),
+	).Wrap(record(&v1Reqs))
+
+	buildReq := func(query string) *LokiRequest {
+		return &LokiRequest{
+			StartTs:   now.Add(-30 * time.Hour),
+			EndTs:     now,
+			Query:     query,
+			Limit:     1000,
+			Step:      1000,
+			Direction: logproto.BACKWARD,
+			Path:      "/api/prom/query_range",
+			Plan: &plan.QueryPlan{
+				AST: syntax.MustParseExpr(query),
+			},
+		}
+	}
+
+	t.Run("matching query goes entirely to v1 without splitting", func(t *testing.T) {
+		v1Reqs, v2Reqs = nil, nil
+
+		req := buildReq(`{app="foo"}`)
+		_, err := router.Do(context.Background(), req)
+		require.NoError(t, err)
+
+		require.Empty(t, v2Reqs)
+		require.Len(t, v1Reqs, 1)
+		require.Equal(t, req.GetStart(), v1Reqs[0].GetStart())
+		require.Equal(t, req.GetEnd(), v1Reqs[0].GetEnd())
+	})
+
+	t.Run("non-matching query is split between v1 and v2", func(t *testing.T) {
+		v1Reqs, v2Reqs = nil, nil
+
+		_, err := router.Do(context.Background(), buildReq(`{foo="bar"}`))
+		require.NoError(t, err)
+
+		require.Len(t, v2Reqs, 1)
+		require.Len(t, v1Reqs, 2)
+	})
 }
 
 func newEntrySuffixTestMiddleware(suffix string) queryrangebase.Middleware {

--- a/pkg/querytee/handler_factory.go
+++ b/pkg/querytee/handler_factory.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/flagext"
+	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/dskit/middleware"
 
@@ -31,6 +32,7 @@ type HandlerFactory struct {
 	splitLag                      time.Duration
 	splitRetentionDays            int64
 	addRoutingDecisionsToWarnings bool
+	v1OnlyMatchers                []*labels.Matcher
 }
 
 // HandlerFactoryConfig holds configuration for creating a HandlerFactory.
@@ -48,6 +50,7 @@ type HandlerFactoryConfig struct {
 	SplitLag                      time.Duration
 	SplitRetentionDays            int64
 	AddRoutingDecisionsToWarnings bool
+	V1OnlyMatchers                []*labels.Matcher
 }
 
 // NewHandlerFactory creates a new HandlerFactory.
@@ -66,6 +69,7 @@ func NewHandlerFactory(cfg HandlerFactoryConfig) *HandlerFactory {
 		splitLag:                      cfg.SplitLag,
 		splitRetentionDays:            cfg.SplitRetentionDays,
 		addRoutingDecisionsToWarnings: cfg.AddRoutingDecisionsToWarnings,
+		v1OnlyMatchers:                cfg.V1OnlyMatchers,
 	}
 }
 
@@ -109,6 +113,7 @@ func (f *HandlerFactory) CreateHandler(routeName string, comp comparator.Respons
 		SplitLag:                      f.splitLag,
 		SplitRetentionDays:            f.splitRetentionDays,
 		AddRoutingDecisionsToWarnings: f.addRoutingDecisionsToWarnings,
+		V1OnlyMatchers:                f.v1OnlyMatchers,
 	}, f.logger)
 
 	if err != nil {

--- a/pkg/querytee/proxy.go
+++ b/pkg/querytee/proxy.go
@@ -22,7 +22,9 @@ import (
 	"github.com/grafana/dskit/middleware"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
 
+	"github.com/grafana/loki/v3/pkg/engine"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange"
 	"github.com/grafana/loki/v3/pkg/querytee/comparator"
 	"github.com/grafana/loki/v3/pkg/querytee/goldfish"
@@ -70,6 +72,13 @@ type RoutingConfig struct {
 	// as warnings to query responses. When enabled, responses will include
 	// warnings indicating which backend handled the query and how it was routed.
 	AddRoutingDecisionsToWarnings bool
+
+	// V1OnlySelector is a LogQL stream selector. Queries whose stream selector
+	// contains all of its matchers are always routed to the v1 backend only.
+	V1OnlySelector string
+
+	// V1OnlyMatchers is parsed from V1OnlySelector during validation.
+	V1OnlyMatchers []*labels.Matcher
 }
 
 func (cfg *RoutingConfig) RegisterFlags(f *flag.FlagSet) {
@@ -81,6 +90,7 @@ func (cfg *RoutingConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.SplitLag, "routing.split-lag", 0, "Minimum age of data to route to v2. Data newer than this goes only to v1. When 0 (default), splitting is disabled.")
 	f.Int64Var(&cfg.SplitRetentionDays, "routing.split-retention-days", 0, "Lifecycle of data objects in days. If set, data outside of retention period will not be available in v2 storage. When both split-start and split-retention-days are set, the more restrictive of the two will apply.")
 	f.BoolVar(&cfg.AddRoutingDecisionsToWarnings, "routing.add-routing-decisions-to-warnings", false, "Add routing decisions as warnings to query responses.")
+	f.StringVar(&cfg.V1OnlySelector, "routing.v1-only-selector", "", "LogQL stream selector, e.g. '{app=\"foo\"}'. Queries whose stream selector contains all of these matchers are always routed to the v1 backend only. Only equality matchers are allowed, and only queries using the exact same equality matchers are detected. Empty disables the feature.")
 }
 
 func (cfg *RoutingConfig) Validate() error {
@@ -92,6 +102,14 @@ func (cfg *RoutingConfig) Validate() error {
 
 	if cfg.SplitLag < 0 {
 		return fmt.Errorf("split lag must be >= 0")
+	}
+
+	if cfg.V1OnlySelector != "" {
+		matchers, err := engine.ParseV1OnlySelector(cfg.V1OnlySelector)
+		if err != nil {
+			return err
+		}
+		cfg.V1OnlyMatchers = matchers
 	}
 
 	return nil
@@ -393,6 +411,7 @@ func (p *Proxy) Start() error {
 			SplitLag:                      p.cfg.Routing.SplitLag,
 			SplitRetentionDays:            p.cfg.Routing.SplitRetentionDays,
 			AddRoutingDecisionsToWarnings: p.cfg.Routing.AddRoutingDecisionsToWarnings,
+			V1OnlyMatchers:                p.cfg.Routing.V1OnlyMatchers,
 		})
 		queryHandler, err := routeHandlerFactory.CreateHandler(route.RouteName, comp)
 		if err != nil {

--- a/pkg/querytee/proxy_test.go
+++ b/pkg/querytee/proxy_test.go
@@ -44,6 +44,51 @@ func Test_NewProxy(t *testing.T) {
 	assert.Nil(t, p)
 }
 
+func TestRoutingConfig_Validate_V1OnlySelector(t *testing.T) {
+	tests := []struct {
+		name             string
+		selector         string
+		expectedErr      string
+		expectedMatchers int
+	}{
+		{
+			name: "empty selector is valid",
+		},
+		{
+			name:             "valid equality selector",
+			selector:         `{app="foo"}`,
+			expectedMatchers: 1,
+		},
+		{
+			name:        "invalid selector is rejected",
+			selector:    `{app=}`,
+			expectedErr: "invalid v1-only stream selector",
+		},
+		{
+			name:        "non-equality matchers are rejected",
+			selector:    `{app="foo", env=~"prod.*"}`,
+			expectedErr: "must contain only equality matchers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := RoutingConfig{
+				Mode:           RoutingModeV1Preferred,
+				V1OnlySelector: tt.selector,
+			}
+			err := cfg.Validate()
+
+			if tt.expectedErr != "" {
+				require.ErrorContains(t, err, tt.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, cfg.V1OnlyMatchers, tt.expectedMatchers)
+		})
+	}
+}
+
 func Test_Proxy_RequestsForwarding(t *testing.T) {
 	const (
 		querySingleMetric1 = `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"cortex_build_info"},"value":[1583320883,"1"]}]}}`

--- a/pkg/querytee/splitting_handler.go
+++ b/pkg/querytee/splitting_handler.go
@@ -13,8 +13,10 @@ import (
 	"github.com/grafana/dskit/tenant"
 	"github.com/grafana/dskit/user"
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/loki/v3/pkg/engine"
+	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/lokifrontend/frontend"
 	"github.com/grafana/loki/v3/pkg/querier/queryrange"
@@ -35,6 +37,7 @@ type SplittingHandlerConfig struct {
 	SplitLag                      time.Duration
 	SplitRetentionDays            int64
 	AddRoutingDecisionsToWarnings bool
+	V1OnlyMatchers                []*labels.Matcher
 }
 
 type SplittingHandler struct {
@@ -49,6 +52,7 @@ type SplittingHandler struct {
 	metricsQueryHandler           queryrangebase.Handler
 	v1Handler                     queryrangebase.Handler
 	addRoutingDecisionsToWarnings bool
+	forceV1                       func(params logql.Params) bool
 }
 
 // isMultiTenant returns true if the request contains multiple tenant IDs.
@@ -58,6 +62,9 @@ func isMultiTenant(tenants []string) bool {
 
 func NewSplittingHandler(cfg SplittingHandlerConfig, logger log.Logger) (http.Handler, error) {
 	if cfg.V1Backend == nil {
+		if len(cfg.V1OnlyMatchers) > 0 {
+			level.Warn(logger).Log("msg", "a v1-only selector is configured but there is no v1 backend to route matching queries to")
+		}
 		return tenantHandler(queryrange.NewSerializeHTTPHandler(cfg.FanOutHandler, cfg.Codec), logger), nil
 	}
 
@@ -68,6 +75,7 @@ func NewSplittingHandler(cfg SplittingHandlerConfig, logger log.Logger) (http.Ha
 		splitStart:         cfg.SplitStart,
 		splitLag:           cfg.SplitLag,
 		splitRetentionDays: cfg.SplitRetentionDays,
+		v1OnlyMatchers:     cfg.V1OnlyMatchers,
 	}
 	v1RoundTrip, err := frontend.NewDownstreamRoundTripper(
 		cfg.V1Backend.endpoint.String(),
@@ -83,6 +91,7 @@ func NewSplittingHandler(cfg SplittingHandlerConfig, logger log.Logger) (http.Ha
 	metricsQueryHandler := splitHandlerFactory.createSplittingHandler(true, v1RoundTrip)
 	logsQueryHandler := splitHandlerFactory.createSplittingHandler(false, v1RoundTrip)
 
+	v1OnlyCfg := engine.Config{V1OnlyMatchers: cfg.V1OnlyMatchers}
 	splittingHandler := &SplittingHandler{
 		codec:                         cfg.Codec,
 		fanOutHandler:                 cfg.FanOutHandler,
@@ -95,6 +104,7 @@ func NewSplittingHandler(cfg SplittingHandlerConfig, logger log.Logger) (http.Ha
 		routingMode:                   cfg.RoutingMode,
 		splitLag:                      cfg.SplitLag,
 		addRoutingDecisionsToWarnings: cfg.AddRoutingDecisionsToWarnings,
+		forceV1:                       v1OnlyCfg.MatchesV1OnlySelector,
 	}
 
 	return tenantHandler(splittingHandler, logger), nil
@@ -124,6 +134,7 @@ type splitHandlerFactory struct {
 	splitStart         time.Time
 	splitLag           time.Duration
 	splitRetentionDays int64
+	v1OnlyMatchers     []*labels.Matcher
 }
 
 func (f *splitHandlerFactory) createSplittingHandler(forMetricQuery bool, v1Handler queryrangebase.Handler) queryrangebase.Handler {
@@ -131,11 +142,13 @@ func (f *splitHandlerFactory) createSplittingHandler(forMetricQuery bool, v1Hand
 		StorageLag:           f.splitLag,
 		StorageStartDate:     flagext.Time(f.splitStart),
 		StorageRetentionDays: f.splitRetentionDays,
+		V1OnlyMatchers:       f.v1OnlyMatchers,
 	}
 
 	routerConfig := queryrange.RouterConfig{
 		Enabled:  true,
 		Validate: engine.IsQuerySupported,
+		ForceV1:  v2Cfg.MatchesV1OnlySelector,
 		Handler:  f.fanOutHandler, // v2Next: fan-out to all backends for comparison
 		V2Range:  v2Cfg.ValidQueryRange,
 	}
@@ -202,6 +215,19 @@ func (f *SplittingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		resp, err = f.v1Handler.Do(ctx, req)
 		if resp != nil && f.addRoutingDecisionsToWarnings {
 			addWarningToResponse(resp, "multi-tenant query routed to v1 backend only (v2 does not support multi-tenant)")
+		}
+		f.writeResponse(ctx, r, w, resp, err)
+		return
+	}
+
+	// Queries matching the configured v1-only stream selector must be answered by
+	// the v1 backend only: v2 does not have the data, so fanning out (or sampling
+	// for goldfish comparison) is meaningless.
+	if f.matchesV1Only(req) {
+		level.Info(f.logger).Log("msg", "query matches v1-only selector, routing to v1 only", "query", req.GetQuery())
+		resp, err = f.v1Handler.Do(ctx, req)
+		if resp != nil && f.addRoutingDecisionsToWarnings {
+			addWarningToResponse(resp, "query matches the v1-only stream selector and was routed to the v1 backend only")
 		}
 		f.writeResponse(ctx, r, w, resp, err)
 		return
@@ -303,6 +329,35 @@ func (f *SplittingHandler) writeResponse(ctx context.Context, r *http.Request, w
 	if _, err := io.Copy(w, httpResp.Body); err != nil {
 		level.Warn(f.logger).Log("msg", "unable to write response body", "err", err)
 	}
+}
+
+// matchesV1Only returns true if the request is a query whose stream selector
+// matches the configured v1-only matchers.
+func (f *SplittingHandler) matchesV1Only(req queryrangebase.Request) bool {
+	if f.forceV1 == nil {
+		return false
+	}
+
+	// Only query and query_range requests carry a query plan with a stream
+	// selector to match against.
+	switch typed := req.(type) {
+	case *queryrange.LokiRequest:
+		if typed.Plan == nil {
+			return false
+		}
+	case *queryrange.LokiInstantRequest:
+		if typed.Plan == nil {
+			return false
+		}
+	default:
+		return false
+	}
+
+	params, err := queryrange.ParamsFromRequest(req)
+	if err != nil {
+		return false
+	}
+	return f.forceV1(params)
 }
 
 // shouldSample determines if a query should be sampled for goldfish comparison.

--- a/pkg/querytee/splitting_handler_test.go
+++ b/pkg/querytee/splitting_handler_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/user"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
@@ -917,6 +918,129 @@ func TestSplittingHandler_MultiTenantQuery_RoutesToV1Only(t *testing.T) {
 			require.False(t, fanOutHandlerCalled, "multi-tenant query should NOT use fanout handler in %s mode (would route to v2)", routingMode)
 			require.Equal(t, "tenant1|tenant2", capturedTenantID, "tenant ID should be preserved when routing to v1")
 		})
+	}
+}
+
+// TestSplittingHandler_V1OnlySelector_RoutesToV1Only tests that queries whose stream
+// selector matches the configured v1-only matchers are routed exclusively to v1,
+// regardless of routing mode and whether splitting is enabled, and are never
+// sampled for goldfish comparison.
+func TestSplittingHandler_V1OnlySelector_RoutesToV1Only(t *testing.T) {
+	v1OnlyMatchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, "app", "foo"),
+	}
+
+	newLokiReq := func(t *testing.T, query string) *queryrange.LokiRequest {
+		t.Helper()
+		expr, err := syntax.ParseExpr(query)
+		require.NoError(t, err)
+
+		now := time.Now()
+		return &queryrange.LokiRequest{
+			Query:   query,
+			StartTs: now.Add(-2 * time.Hour),
+			EndTs:   now,
+			Step:    60000,
+			Limit:   100,
+			Path:    constants.PathLokiQueryRange,
+			Plan: &plan.QueryPlan{
+				AST: expr,
+			},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		query           string
+		splitLag        time.Duration
+		expectV1Only    bool
+		expectedWarning string
+	}{
+		{
+			name:         "matching query with splitting enabled",
+			query:        `{app="foo", env="prod"}`,
+			splitLag:     1 * time.Hour,
+			expectV1Only: true,
+		},
+		{
+			name:         "matching metric query with splitting disabled (fanout path)",
+			query:        `sum(rate({app="foo"}[5m]))`,
+			splitLag:     0,
+			expectV1Only: true,
+		},
+		{
+			name:         "non-matching query with splitting disabled uses fanout",
+			query:        `{app="test"}`,
+			splitLag:     0,
+			expectV1Only: false,
+		},
+	}
+
+	for _, tt := range tests {
+		for _, routingMode := range []RoutingMode{RoutingModeV1Preferred, RoutingModeV2Preferred, RoutingModeRace} {
+			t.Run(tt.name+"/"+string(routingMode), func(t *testing.T) {
+				v1BackendCalled := false
+				fanOutHandlerCalled := false
+
+				v1Backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					v1BackendCalled = true
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"streams","result":[]}}`))
+				}))
+				defer v1Backend.Close()
+
+				v1BackendURL, err := url.Parse(v1Backend.URL)
+				require.NoError(t, err)
+
+				v1ProxyBackend, err := NewProxyBackend("v1", v1BackendURL, 5*time.Second, true, false)
+				require.NoError(t, err)
+
+				mockFanOutHandler := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
+					fanOutHandlerCalled = true
+					return &queryrange.LokiResponse{
+						Status: "success",
+						Data:   queryrange.LokiData{ResultType: "streams"},
+					}, nil
+				})
+
+				goldfishManager := &mockGoldfishManager{
+					shouldSampleResult:  true, // Enable sampling to verify matching queries are not sampled.
+					correlationIDResult: "test-correlation-id",
+				}
+
+				handler, err := NewSplittingHandler(SplittingHandlerConfig{
+					Codec:                     queryrange.DefaultCodec,
+					FanOutHandler:             mockFanOutHandler,
+					GoldfishManager:           goldfishManager,
+					V1Backend:                 v1ProxyBackend,
+					SkipFanoutWhenNotSampling: false,
+					RoutingMode:               routingMode,
+					SplitStart:                time.Time{},
+					SplitLag:                  tt.splitLag,
+					V1OnlyMatchers:            v1OnlyMatchers,
+				}, log.NewNopLogger())
+				require.NoError(t, err)
+
+				ctx := user.InjectOrgID(context.Background(), "tenant1")
+				httpReq, err := queryrange.DefaultCodec.EncodeRequest(ctx, newLokiReq(t, tt.query))
+				require.NoError(t, err)
+
+				recorder := httptest.NewRecorder()
+				handler.ServeHTTP(recorder, httpReq)
+
+				require.Equal(t, http.StatusOK, recorder.Code)
+				if tt.expectV1Only {
+					require.True(t, v1BackendCalled, "matching query should be routed to v1 backend in %s mode", routingMode)
+					require.False(t, fanOutHandlerCalled, "matching query should NOT use fanout handler in %s mode", routingMode)
+					require.Empty(t, recorder.Header().Get(goldfish.GoldfishCorrelationIDHeader),
+						"matching query should not be sampled for goldfish comparison")
+				} else {
+					require.True(t, fanOutHandlerCalled, "non-matching query should use fanout handler in %s mode", routingMode)
+					require.False(t, v1BackendCalled, "non-matching query should not go directly to v1 backend in %s mode", routingMode)
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a configurable stream selector that forces matching queries to be executed by the v1 (chunks) engine:

- New `-query-engine.v1-only-stream-selector` option: queries whose stream selector contains all of the configured matchers are sent whole to v1 by the engine router, both in the query frontend and in the querytee (new `-routing.v1-only-selector` flag).
- As defense in depth, the v2 engine handler returns `501 Not Implemented` for matching queries, so direct hits fall back to v1 via the router's existing 501 fallback.
- In the querytee, matching queries go straight to the v1 backend and are never sampled for goldfish comparison.

Only equality matchers are allowed in the selector, and detection is by exact matcher equality.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

Queries referencing the selector's labels with regex or negative matchers are not detected and will be routed normally.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
