### PR TITLE
test(logql): Add logqltest coverage for range-aggregation edge cases, parse errors, and grouping

### DIFF
--- a/pkg/logql/internal/logqltest/testdata/functions.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/functions.logqltest
@@ -11,6 +11,16 @@ eval instant at 60s vector(2)
 eval range from 60s to 180s step 30s vector(2)
   {} 2 2 2 2 2
 
+# vector accepts a decimal literal.
+eval instant at 60s vector(3.14)
+  {} 3.14
+eval range from 60s to 180s step 30s vector(3.14)
+  {} 3.14 3.14 3.14 3.14 3.14
+
+# vector(n) doesn't accept a nested query.
+eval instant at 60s vector(count_over_time({app="a"}[1m]))
+  expect fail regex: expecting NUMBER
+
 # label_replace().
 clear
 load

--- a/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
@@ -10,21 +10,6 @@ eval instant at 60s rate({app="foo"} |~".+bar" [1m])
 eval range from 60s to 120s step 60s rate({app="foo"} |~".+bar" [1m])
   {app="foo"} 0.1 0.1
 
-eval instant at 60s count_over_time({app="foo"} |~".+bar" [1m])
-  {app="foo"} 6
-eval range from 60s to 120s step 30s count_over_time({app="foo"} |~".+bar" [1m])
-  {app="foo"} 6 6 6
-
-eval instant at 300s count_over_time(({app="foo"} |~".+bar")[5m])
-  {app="foo"} 30
-eval range from 300s to 600s step 30s count_over_time(({app="foo"} |~".+bar")[5m])
-  {app="foo"} 30 30 30 30 30 30 30 30 30 30 30
-
-eval instant at 90s count_over_time({app="foo"} |~".+bar" [1m] offset 30s)
-  {app="foo"} 6
-eval range from 60s to 120s step 30s count_over_time({app="foo"} |~".+bar" [1m] offset 30s)
-  {app="foo"} 4 6 6
-
 eval instant at 60s rate(({app=~"foo|bar"} |~".+bar")[1m])
   {app="foo"} 0.1
   {app="bar"} 0.05
@@ -512,3 +497,343 @@ load
 # avg/2 and the threshold, so it does NOT shorten the 15s: 60 x (30+15)/30 / 90s = 1.
 eval instant at 210s rate_counter({app="a"} | logfmt | unwrap c [90s])
   {app="a"} 1
+
+# count_over_time()
+clear
+load
+  {app="a"} "keep"  @ 0s [repeat every 10s for 61]   # 0s..600s
+  {app="a"} "noise" @ 5s [repeat every 10s for 61]
+
+eval instant at 60s count_over_time({app="a"} |= "keep" [1m])
+  {app="a"} 6
+eval range from 60s to 120s step 30s count_over_time({app="a"} |= "keep" [1m]) # overlapping
+  {app="a"} 6 6 6
+eval range from 60s to 180s step 90s count_over_time({app="a"} |= "keep" [1m]) # non-overlapping
+  {app="a"} 6 6
+
+# The offset shifts the window back.
+eval instant at 90s count_over_time({app="a"} |= "keep" [1m] offset 30s)
+  {app="a"} 6
+eval range from 60s to 120s step 30s count_over_time({app="a"} |= "keep" [1m] offset 30s) # overlapping
+  {app="a"} 4 6 6
+
+# Longer range vector duration.
+eval instant at 300s count_over_time({app="a"} |= "keep" [5m])
+  {app="a"} 30
+eval range from 300s to 600s step 60s count_over_time({app="a"} |= "keep" [5m]) # overlapping
+  {app="a"} 30 30 30 30 30 30
+
+# count_over_time doesn't allow grouping.
+eval instant at 60s count_over_time({app="a"} |= "keep" [1m]) by (app)
+  expect fail msg: grouping not allowed for count_over_time aggregation
+
+# bytes_over_time()
+clear
+load
+  {app="a"} "a"   @ 20s   # 1 byte
+  {app="a"} "bb"  @ 30s   # 2 bytes
+  {app="a"} "ccc" @ 40s   # 3 bytes
+  {app="noise"} "noise" @ 20s [repeat every 10s for 3]
+
+eval instant at 60s bytes_over_time({app="a"}[1m])
+  {app="a"} 6
+eval range from 40s to 60s step 20s bytes_over_time({app="a"}[1m])  # overlapping
+  {app="a"} 6 6
+eval range from 60s to 130s step 70s bytes_over_time({app="a"}[1m]) # non-overlapping
+  {app="a"} 6 _
+
+# bytes_over_time doesn't allow grouping.
+eval instant at 60s bytes_over_time({app="a"}[1m]) by (app)
+  expect fail msg: grouping not allowed for bytes_over_time aggregation
+
+# rate()
+clear
+load
+  {app="a"} "keep"  @ 0s [repeat every 10s for 19]   # 0s..180s
+  {app="a"} "noise" @ 5s [repeat every 10s for 19]
+
+eval instant at 60s rate({app="a"} |= "keep" [1m])
+  {app="a"} 0.1
+eval range from 60s to 120s step 30s rate({app="a"} |= "keep" [1m]) # overlapping
+  {app="a"} 0.1 0.1 0.1
+eval range from 60s to 180s step 90s rate({app="a"} |= "keep" [1m]) # non-overlapping
+  {app="a"} 0.1 0.1
+
+eval instant at 90s rate({app="a"} |= "keep" [1m] offset 30s)
+  {app="a"} 0.1
+eval range from 90s to 150s step 30s rate({app="a"} |= "keep" [1m] offset 30s) # overlapping
+  {app="a"} 0.1 0.1 0.1
+eval range from 90s to 180s step 90s rate({app="a"} |= "keep" [1m] offset 30s) # non-overlapping
+  {app="a"} 0.1 0.1
+
+# rate doesn't allow grouping.
+eval instant at 60s rate({app="a"} |= "keep" [1m]) by (app)
+  expect fail msg: grouping not allowed for rate aggregation
+
+# rate over a sub-second [500ms] range divides the matching-line count by 0.5s.
+clear
+load
+  {app="b"} "keep"  @ 100ms [repeat every 200ms for 6]   # 100,300,500,700,900,1100 ms
+  {app="b"} "noise" @ 200ms [repeat every 200ms for 6]
+
+eval instant at 500ms rate({app="b"} |= "keep" [500ms])
+  {app="b"} 6
+eval range from 500ms to 900ms step 400ms rate({app="b"} |= "keep" [500ms])  # overlapping
+  {app="b"} 6 6
+eval range from 500ms to 1100ms step 600ms rate({app="b"} |= "keep" [500ms]) # non-overlapping
+  {app="b"} 6 6
+
+# avg_over_time edge cases:
+# - any NaN -> NaN
+# - +Inf absorbs a finite value
+# - +Inf with -Inf -> NaN
+clear
+load
+  {app="a", c="single"} "v=5"    @ 30s
+  {app="a", c="nan"}    "v=7"    @ 20s
+  {app="a", c="nan"}    "v=NaN"  @ 40s
+  {app="a", c="posinf"} "v=+Inf" @ 20s
+  {app="a", c="posinf"} "v=5"    @ 40s
+  {app="a", c="mixinf"} "v=+Inf" @ 20s
+  {app="a", c="mixinf"} "v=-Inf" @ 40s
+  {app="noise"} "noise" @ 20s [repeat every 10s for 3]
+
+eval instant at 60s avg_over_time({app="a"} | logfmt | unwrap v [1m])
+  {app="a", c="single"} 5
+  {app="a", c="nan"}    NaN
+  {app="a", c="posinf"} +Inf
+  {app="a", c="mixinf"} NaN
+eval range from 40s to 60s step 20s avg_over_time({app="a"} | logfmt | unwrap v [1m])  # overlapping
+  {app="a", c="single"} 5 5
+  {app="a", c="nan"}    NaN NaN
+  {app="a", c="posinf"} +Inf +Inf
+  {app="a", c="mixinf"} NaN NaN
+eval range from 60s to 130s step 70s avg_over_time({app="a"} | logfmt | unwrap v [1m]) # non-overlapping
+  {app="a", c="single"} 5 _
+  {app="a", c="nan"}    NaN _
+  {app="a", c="posinf"} +Inf _
+  {app="a", c="mixinf"} NaN _
+
+# avg_over_time with grouping: by/without combine the unwrapped samples ACROSS the streams in each
+# group and label the result with only the grouping keys. Two pods under app="a": pod=1 {2,4},
+# pod=2 {10,20}; by (app) folds all four into one group (mean 9), and without (pod) is equivalent.
+clear
+load
+  {app="a", pod="1"} "v=2"  @ 20s
+  {app="a", pod="1"} "v=4"  @ 30s
+  {app="a", pod="2"} "v=10" @ 40s
+  {app="a", pod="2"} "v=20" @ 50s
+  {app="a", pod="1"} "noise" @ 25s
+eval instant at 60s avg_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
+  {pod="1"} 3
+  {pod="2"} 15
+eval instant at 60s avg_over_time({app="a"} | logfmt | unwrap v [1m]) by (app)
+  {app="a"} 9
+eval instant at 60s avg_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
+  {app="a"} 9
+eval range from 60s to 70s step 10s avg_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
+  {pod="1"} 3 3
+  {pod="2"} 15 15
+
+# min/max_over_time edge cases:
+# - a leading NaN is ignored
+# - all NaN -> NaN
+clear
+load
+  {app="a", c="neg"}    "v=-5"  @ 20s
+  {app="a", c="neg"}    "v=-1"  @ 30s
+  {app="a", c="neg"}    "v=-10" @ 40s
+  {app="a", c="single"} "v=42"  @ 30s
+  {app="a", c="lead"}   "v=NaN" @ 20s
+  {app="a", c="lead"}   "v=7"   @ 30s
+  {app="a", c="lead"}   "v=13"  @ 40s
+  {app="a", c="allnan"} "v=NaN" @ 20s
+  {app="a", c="allnan"} "v=NaN" @ 40s
+  {app="noise"} "noise" @ 20s [repeat every 10s for 3]
+
+eval instant at 60s min_over_time({app="a"} | logfmt | unwrap v [1m])
+  {app="a", c="neg"}    -10
+  {app="a", c="single"} 42
+  {app="a", c="lead"}   7
+  {app="a", c="allnan"} NaN
+eval range from 40s to 60s step 20s min_over_time({app="a"} | logfmt | unwrap v [1m])  # overlapping
+  {app="a", c="neg"}    -10 -10
+  {app="a", c="single"} 42 42
+  {app="a", c="lead"}   7 7
+  {app="a", c="allnan"} NaN NaN
+eval range from 60s to 130s step 70s min_over_time({app="a"} | logfmt | unwrap v [1m]) # non-overlapping
+  {app="a", c="neg"}    -10 _
+  {app="a", c="single"} 42 _
+  {app="a", c="lead"}   7 _
+  {app="a", c="allnan"} NaN _
+
+eval instant at 60s max_over_time({app="a"} | logfmt | unwrap v [1m])
+  {app="a", c="neg"}    -1
+  {app="a", c="single"} 42
+  {app="a", c="lead"}   13
+  {app="a", c="allnan"} NaN
+eval range from 40s to 60s step 20s max_over_time({app="a"} | logfmt | unwrap v [1m])  # overlapping
+  {app="a", c="neg"}    -1 -1
+  {app="a", c="single"} 42 42
+  {app="a", c="lead"}   13 13
+  {app="a", c="allnan"} NaN NaN
+eval range from 60s to 130s step 70s max_over_time({app="a"} | logfmt | unwrap v [1m]) # non-overlapping
+  {app="a", c="neg"}    -1 _
+  {app="a", c="single"} 42 _
+  {app="a", c="lead"}   13 _
+  {app="a", c="allnan"} NaN _
+
+# min_over_time() / max_over_time() with grouping.
+clear
+load
+  {app="a", pod="1"} "v=2"  @ 20s
+  {app="a", pod="1"} "v=4"  @ 30s
+  {app="a", pod="2"} "v=10" @ 40s
+  {app="a", pod="2"} "v=20" @ 50s
+  {app="a", pod="1"} "noise" @ 25s
+
+eval instant at 60s min_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
+  {pod="1"} 2
+  {pod="2"} 10
+eval instant at 60s max_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
+  {pod="1"} 4
+  {pod="2"} 20
+eval instant at 60s min_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
+  {app="a"} 2
+eval instant at 60s max_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
+  {app="a"} 20
+
+# sum_over_time edge cases:
+# - mixed signs
+# - any NaN -> NaN
+# +Inf with -Inf -> NaN
+clear
+load
+  {app="a", c="mixed"} "v=-3"   @ 20s
+  {app="a", c="mixed"} "v=5"    @ 30s
+  {app="a", c="mixed"} "v=10"   @ 40s
+  {app="a", c="nan"}   "v=7"    @ 20s
+  {app="a", c="nan"}   "v=NaN"  @ 40s
+  {app="a", c="inf"}   "v=+Inf" @ 20s
+  {app="a", c="inf"}   "v=-Inf" @ 40s
+  {app="noise"} "noise" @ 20s [repeat every 10s for 3]
+
+eval instant at 60s sum_over_time({app="a"} | logfmt | unwrap v [1m])
+  {app="a", c="mixed"} 12
+  {app="a", c="nan"}   NaN
+  {app="a", c="inf"}   NaN
+eval range from 40s to 60s step 20s sum_over_time({app="a"} | logfmt | unwrap v [1m])  # overlapping
+  {app="a", c="mixed"} 12 12
+  {app="a", c="nan"}   NaN NaN
+  {app="a", c="inf"}   NaN NaN
+eval range from 60s to 130s step 70s sum_over_time({app="a"} | logfmt | unwrap v [1m]) # non-overlapping
+  {app="a", c="mixed"} 12 _
+  {app="a", c="nan"}   NaN _
+  {app="a", c="inf"}   NaN _
+
+# sum_over_time requires an unwrap.
+eval instant at 60s sum_over_time({app="a"}[1m])
+  expect fail msg: invalid aggregation sum_over_time without unwrap
+
+# sum_over_time doesn't allow grouping.
+eval instant at 60s sum_over_time({app="a"} | logfmt | unwrap v [1m]) by (app)
+  expect fail msg: grouping not allowed for sum_over_time aggregation
+
+# stddev_over_time() / stdvar_over_time()
+clear
+load
+  {app="a", c="single"}   "v=5" @ 30s
+  {app="a", c="constant"} "v=4" @ 20s
+  {app="a", c="constant"} "v=4" @ 30s
+  {app="a", c="constant"} "v=4" @ 40s
+  {app="a", c="vary"}     "v=2" @ 20s
+  {app="a", c="vary"}     "v=6" @ 40s
+  {app="a", c="nan"}      "v=5" @ 20s
+  {app="a", c="nan"}      "v=NaN" @ 40s
+  {app="noise"} "noise" @ 20s [repeat every 10s for 3]
+
+# A single sample and a constant window are both 0; any NaN in the window -> NaN.
+eval instant at 60s stdvar_over_time({app="a"} | logfmt | unwrap v [1m])
+  {app="a", c="single"}   0
+  {app="a", c="constant"} 0
+  {app="a", c="vary"}     4
+  {app="a", c="nan"}      NaN
+eval range from 40s to 60s step 20s stdvar_over_time({app="a"} | logfmt | unwrap v [1m])  # overlapping
+  {app="a", c="single"}   0 0
+  {app="a", c="constant"} 0 0
+  {app="a", c="vary"}     4 4
+  {app="a", c="nan"}      NaN NaN
+eval range from 60s to 130s step 70s stdvar_over_time({app="a"} | logfmt | unwrap v [1m]) # non-overlapping
+  {app="a", c="single"}   0 _
+  {app="a", c="constant"} 0 _
+  {app="a", c="vary"}     4 _
+  {app="a", c="nan"}      NaN _
+
+eval instant at 60s stddev_over_time({app="a"} | logfmt | unwrap v [1m])
+  {app="a", c="single"}   0
+  {app="a", c="constant"} 0
+  {app="a", c="vary"}     2
+  {app="a", c="nan"}      NaN
+eval range from 40s to 60s step 20s stddev_over_time({app="a"} | logfmt | unwrap v [1m])  # overlapping
+  {app="a", c="single"}   0 0
+  {app="a", c="constant"} 0 0
+  {app="a", c="vary"}     2 2
+  {app="a", c="nan"}      NaN NaN
+eval range from 60s to 130s step 70s stddev_over_time({app="a"} | logfmt | unwrap v [1m]) # non-overlapping
+  {app="a", c="single"}   0 _
+  {app="a", c="constant"} 0 _
+  {app="a", c="vary"}     2 _
+  {app="a", c="nan"}      NaN _
+
+# stddev_over_time() / stdvar_over_time() with grouping.
+clear
+load
+  {app="a", pod="1"} "v=2"  @ 20s
+  {app="a", pod="1"} "v=4"  @ 30s
+  {app="a", pod="2"} "v=10" @ 40s
+  {app="a", pod="2"} "v=20" @ 50s
+  {app="a", pod="1"} "noise" @ 25s
+
+eval instant at 60s stddev_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
+  {pod="1"} 1
+  {pod="2"} 5
+eval instant at 60s stdvar_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
+  {pod="1"} 1
+  {pod="2"} 25
+eval instant at 60s stdvar_over_time({app="a"} | logfmt | unwrap v [1m]) by (app)
+  {app="a"} 49
+eval instant at 60s stddev_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
+  {app="a"} 7
+eval instant at 60s stdvar_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
+  {app="a"} 49
+
+# absent_over_time()
+clear
+load
+  {job="x", env="prod"} "present" @ 0s
+  {app="noise"} "noise" @ 20s [repeat every 10s for 12]
+
+eval instant at 60s absent_over_time({job="x", env=~".+"}[1m])
+  {job="x"} 1
+eval range from 60s to 120s step 60s absent_over_time({job="x", env=~".+"}[1m]) # overlapping
+  {job="x"} 1 1
+eval range from 60s to 180s step 120s absent_over_time({job="x", env=~".+"}[1m]) # non-overlapping
+  {job="x"} 1 1
+
+# absent_over_time doesn't allow grouping.
+eval instant at 60s absent_over_time({job="x"}[1m]) by (job)
+  expect fail msg: grouping not allowed for absent_over_time aggregation
+
+# absent_over_time() unwrapped.
+clear
+load
+  {app="a"} "msg=hello" @ 20s [repeat every 10s for 5]   # 20s..60s; no `v` field
+  {app="noise"} "noise" @ 20s [repeat every 10s for 5]
+
+# The lines carry no `v`, so unwrap drops every sample and the window is empty.
+eval instant at 60s absent_over_time({app="a"} | logfmt | unwrap v [1m])
+  {app="a"} 1
+eval range from 60s to 120s step 60s absent_over_time({app="a"} | logfmt | unwrap v [1m])  # overlapping
+  {app="a"} 1 1
+eval range from 60s to 180s step 120s absent_over_time({app="a"} | logfmt | unwrap v [1m]) # non-overlapping
+  {app="a"} 1 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Continues broadening the declarative `logqltest` correctness suite for LogQL metric queries (building on the DSL foundation in #23506). This part fills the gaps around the range aggregations' edge cases and error handling, which were previously untested:

- NaN / ±Inf handling for `avg`/`min`/`max`/`sum`/`stddev`/`stdvar_over_time`.
- Grouping (`by`/`without`) for the aggregations that allow it, and the grouping / missing-unwrap parse errors for those that don't.
- Dedicated `bytes_over_time` and `bytes_rate` scenarios.
- `vector()` with a decimal literal, and rejection of a nested query.

**Which issue(s) this PR fixes**:
N/A — test-only.

**Special notes for your reviewer**:

Test-data-only change (`*.logqltest`); no production code is modified. Expected values are hand-computed and cross-checked against the engine.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
