### PR TITLE
chore: Implement streaming reading of header and TOC

### DIFF
--- a/pkg/compactor/index_set.go
+++ b/pkg/compactor/index_set.go
@@ -317,6 +317,11 @@ func (is *indexSet) upload() error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err := idxReader.Close(); err != nil {
+			level.Error(util_log.Logger).Log("msg", "failed to close index reader", "path", idxPath, "err", err)
+		}
+	}()
 
 	_, err = idxReader.Seek(0, 0)
 	if err != nil {

--- a/pkg/compactor/testutil.go
+++ b/pkg/compactor/testutil.go
@@ -200,12 +200,8 @@ func (c compactedIndex) Close() error {
 	return c.indexFile.Close()
 }
 
-func (c compactedIndex) Reader() (io.ReadSeeker, error) {
-	_, err := c.indexFile.Seek(0, 0)
-	if err != nil {
-		return nil, err
-	}
-	return c.indexFile, nil
+func (c compactedIndex) Reader() (io.ReadSeekCloser, error) {
+	return os.Open(c.indexFile.Name())
 }
 
 type testIndexCompactor struct{}

--- a/pkg/storage/stores/shipper/indexshipper/downloads/table_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table_test.go
@@ -456,6 +456,7 @@ func verifyIndexForEach(t *testing.T, expectedIndexes []string, forEachFunc func
 		// get the reader for the index.
 		readSeeker, err := idx.Reader()
 		require.NoError(t, err)
+		defer func() { require.NoError(t, readSeeker.Close()) }()
 
 		// seek it to 0
 		_, err = readSeeker.Seek(0, 0)

--- a/pkg/storage/stores/shipper/indexshipper/downloads/testutil.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/testutil.go
@@ -28,8 +28,8 @@ func (m *mockIndex) Path() string {
 	return m.File.Name()
 }
 
-func (m *mockIndex) Reader() (io.ReadSeeker, error) {
-	return m.File, nil
+func (m *mockIndex) Reader() (io.ReadSeekCloser, error) {
+	return os.Open(m.File.Name())
 }
 
 func setupIndexesAtPath(t *testing.T, userID, path string, start, end int) []string {

--- a/pkg/storage/stores/shipper/indexshipper/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/index/index.go
@@ -6,7 +6,7 @@ type Index interface {
 	Name() string
 	Path() string
 	Close() error
-	Reader() (io.ReadSeeker, error)
+	Reader() (io.ReadSeekCloser, error)
 }
 
 // OpenIndexFileFunc opens an index file stored at the given path.

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1423,9 +1423,16 @@ func (r *ByteSliceReader) Version() int {
 	return r.version
 }
 
-func (r *ByteSliceReader) RawFileReader() (io.ReadSeeker, error) {
-	return bytes.NewReader(r.b.Range(0, r.b.Len())), nil
+func (r *ByteSliceReader) RawFileReader() (io.ReadSeekCloser, error) {
+	return nopCloserReadSeeker{bytes.NewReader(r.b.Range(0, r.b.Len()))}, nil
 }
+
+// nopCloserReadSeeker wraps an io.ReadSeeker with a no-op Close method so
+// callers can rely on a single io.ReadSeekCloser type regardless of whether
+// the underlying reader owns a real resource.
+type nopCloserReadSeeker struct{ io.ReadSeeker }
+
+func (nopCloserReadSeeker) Close() error { return nil }
 
 // Range marks a byte range.
 type Range struct {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/reader.go
@@ -13,8 +13,9 @@ type Reader interface {
 	Version() int
 
 	// RawFileReader exposes the underlying index file bytes as an
-	// io.ReadSeeker so the indexshipper can upload the raw file.
-	RawFileReader() (io.ReadSeeker, error)
+	// io.ReadSeekCloser so the indexshipper can upload the raw file.
+	// The caller owns the returned reader and must Close it.
+	RawFileReader() (io.ReadSeekCloser, error)
 
 	// PostingsRanges returns the byte range in the underlying index file for
 	// every posting list.

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
@@ -1,36 +1,159 @@
 package index
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"io"
+	"os"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc"
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/filepool"
 )
 
 // StreamReader is the file-streaming counterpart to ByteSliceReader.
 //
-// Currently, this is just scaffolding: StreamReader delegates all calls to a *ByteSliceReader.
+// Currently, StreamReader delegates some calls to a *ByteSliceReader.
 // Follow-up changes will progressively replace embedded calls with streaming implementations
 // backed by a file-handle pool.
 type StreamReader struct {
 	mmapReader *ByteSliceReader
+
+	factory *streamenc.FilePoolDecbufFactory
+	path    string
+	size    int64
+	version int
+	toc     *TOC
 }
 
 // NewStreamFileReader constructs a StreamReader against the given index file.
 func NewStreamFileReader(path string) (*StreamReader, error) {
-	mmapReader, err := NewMmapFileReader(path)
+	fileInfo, err := os.Stat(path)
 	if err != nil {
+		return nil, fmt.Errorf("stat index file: %w", err)
+	}
+	size := fileInfo.Size()
+
+	factory := streamenc.NewFilePoolDecbufFactory(path, 0, filepool.NewFilePoolMetrics(nil))
+
+	reader := &StreamReader{
+		factory: factory,
+		path:    path,
+		size:    size,
+	}
+
+	version, err := reader.readHeader()
+	if err != nil {
+		_ = factory.Close()
 		return nil, err
 	}
-	return &StreamReader{mmapReader: mmapReader}, nil
+	reader.version = version
+
+	toc, err := reader.readTOC()
+	if err != nil {
+		_ = factory.Close()
+		return nil, err
+	}
+	reader.toc = toc
+
+	// Fallback used by not-yet-ported methods
+	mmapReader, err := NewMmapFileReader(path)
+	if err != nil {
+		_ = factory.Close()
+		return nil, err
+	}
+	reader.mmapReader = mmapReader
+
+	return reader, nil
+}
+
+// readHeader validates the magic bytes and returns the on-disk format version.
+func (s StreamReader) readHeader() (int, error) {
+	// Validate header size
+	if s.size < int64(HeaderLen) {
+		return 0, fmt.Errorf("index header: %w", streamenc.ErrInvalidSize)
+	}
+	// Construct decbuf
+	decbuf := s.factory.NewRawDecbuf(context.Background())
+	if err := decbuf.Err(); err != nil {
+		return 0, fmt.Errorf("open header decbuf: %w", err)
+	}
+	defer func() { _ = decbuf.Close() }()
+	// Extract and validate magic
+	magic := decbuf.Be32()
+	if err := decbuf.Err(); err != nil {
+		return 0, fmt.Errorf("read header magic: %w", err)
+	}
+	if magic != MagicIndex {
+		return 0, fmt.Errorf("invalid magic number %x", magic)
+	}
+	// Extract and validate version
+	version := int(decbuf.Byte())
+	if err := decbuf.Err(); err != nil {
+		return 0, fmt.Errorf("read header version: %w", err)
+	}
+	if version != FormatV2 && version != FormatV3 && version != FormatV4 {
+		return 0, fmt.Errorf("unknown index file version %d", version)
+	}
+	return version, nil
+}
+
+// readTOC reads the fixed-size TOC record from the tail of
+// the file and validates its CRC32.
+func (s StreamReader) readTOC() (*TOC, error) {
+	// Validate size
+	if s.size < int64(indexTOCLen) {
+		return nil, fmt.Errorf("index toc: %w", streamenc.ErrInvalidSize)
+	}
+	// Create decbuf
+	decbuf := s.factory.NewRawDecbuf(context.Background())
+	if err := decbuf.Err(); err != nil {
+		return nil, fmt.Errorf("open toc decbuf: %w", err)
+	}
+	defer func() { _ = decbuf.Close() }()
+	// Validate CRC32
+	tocStart := int(s.size) - indexTOCLen
+	if decbuf.ResetAt(tocStart); decbuf.Err() != nil {
+		return nil, fmt.Errorf("go to start of toc for crc: %w", decbuf.Err())
+	}
+	if decbuf.CheckCrc32(castagnoliTable); decbuf.Err() != nil {
+		return nil, fmt.Errorf("check toc crc: %w", decbuf.Err())
+	}
+	// Read TOC
+	if decbuf.ResetAt(tocStart); decbuf.Err() != nil {
+		return nil, fmt.Errorf("go to start of toc to read it: %w", decbuf.Err())
+	}
+	toc := &TOC{
+		Symbols:            decbuf.Be64(),
+		Series:             decbuf.Be64(),
+		LabelIndices:       decbuf.Be64(),
+		LabelIndicesTable:  decbuf.Be64(),
+		Postings:           decbuf.Be64(),
+		PostingsTable:      decbuf.Be64(),
+		FingerprintOffsets: decbuf.Be64(),
+		Metadata: Metadata{
+			From:     int64(decbuf.Be64()),
+			Through:  int64(decbuf.Be64()),
+			Checksum: decbuf.Be32(),
+		},
+	}
+	if err := decbuf.Err(); err != nil {
+		return nil, fmt.Errorf("read toc: %w", err)
+	}
+	return toc, nil
 }
 
 func (s StreamReader) Version() int {
-	return s.mmapReader.Version()
+	return s.version
 }
 
-func (s StreamReader) RawFileReader() (io.ReadSeeker, error) {
-	return s.mmapReader.RawFileReader()
+// RawFileReader opens a fresh file handle over the index file.
+// The caller owns closing it.
+func (s StreamReader) RawFileReader() (io.ReadSeekCloser, error) {
+	return os.Open(s.path)
 }
 
 func (s StreamReader) PostingsRanges() (map[labels.Label]Range, error) {
@@ -38,11 +161,11 @@ func (s StreamReader) PostingsRanges() (map[labels.Label]Range, error) {
 }
 
 func (s StreamReader) Bounds() (int64, int64) {
-	return s.mmapReader.Bounds()
+	return s.toc.Metadata.From, s.toc.Metadata.Through
 }
 
 func (s StreamReader) Checksum() uint32 {
-	return s.mmapReader.Checksum()
+	return s.toc.Metadata.Checksum
 }
 
 func (s StreamReader) Symbols() StringIter {
@@ -82,9 +205,11 @@ func (s StreamReader) Postings(name string, fpFilter FingerprintFilter, values .
 }
 
 func (s StreamReader) Size() int64 {
-	return s.mmapReader.Size()
+	return s.size
 }
 
 func (s StreamReader) Close() error {
-	return s.mmapReader.Close()
+	mmapErr := s.mmapReader.Close()
+	factoryErr := s.factory.Close()
+	return errors.Join(mmapErr, factoryErr)
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
@@ -2,8 +2,12 @@ package index
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
+	"hash/crc32"
+	"io"
 	"math"
+	"os"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -13,6 +17,18 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/require"
 )
+
+type readerConstructor struct {
+	name string
+	open func(path string) (Reader, error)
+}
+
+func allReaderConstructors() []readerConstructor {
+	return []readerConstructor{
+		{name: "MmapReader", open: func(p string) (Reader, error) { return NewMmapFileReader(p) }},
+		{name: "StreamReader", open: func(p string) (Reader, error) { return NewStreamFileReader(p) }},
+	}
+}
 
 // writeCrossCheckFixture builds a small but non-trivial index used by
 // the cross-check tests: multiple label names, multiple values per
@@ -91,6 +107,137 @@ func TestReaders_CrossCheck(t *testing.T) {
 			requirePostingsRangesEqual(t, mmap, stream)
 		})
 	}
+}
+
+func TestReaders_RejectsBadMagic(t *testing.T) {
+	for _, rc := range allReaderConstructors() {
+		t.Run(rc.name, func(t *testing.T) {
+			path := writeCrossCheckFixture(t, FormatV3)
+			corruptFileBytes(t, path, func(b []byte) { b[0] ^= 0xFF })
+
+			_, err := rc.open(path)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid magic number")
+		})
+	}
+}
+
+func TestReaders_RejectsUnknownVersion(t *testing.T) {
+	for _, rc := range allReaderConstructors() {
+		t.Run(rc.name, func(t *testing.T) {
+			path := writeCrossCheckFixture(t, FormatV3)
+			// The version byte lives immediately after the 4-byte magic.
+			corruptFileBytes(t, path, func(b []byte) { b[4] = 0xFE })
+
+			_, err := rc.open(path)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "unknown index file version")
+		})
+	}
+}
+
+func TestReaders_RejectsTruncatedHeader(t *testing.T) {
+	for _, rc := range allReaderConstructors() {
+		t.Run(rc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "truncated.tsdb")
+			require.NoError(t, os.WriteFile(path, []byte{0xBA, 0xAA}, 0600))
+
+			_, err := rc.open(path)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid size")
+		})
+	}
+}
+
+func TestReaders_RejectsTruncatedTOC(t *testing.T) {
+	// Reject an index that has a valid header but is too short to contain the fixed-size TOC record.
+	for _, rc := range allReaderConstructors() {
+		t.Run(rc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "truncated.tsdb")
+			// Valid magic + version, then nothing.
+			buf := make([]byte, HeaderLen)
+			binary.BigEndian.PutUint32(buf[0:4], MagicIndex)
+			buf[4] = FormatV3
+			require.NoError(t, os.WriteFile(path, buf, 0600))
+
+			_, err := rc.open(path)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid size")
+		})
+	}
+}
+
+func TestReaders_RejectsCorruptTOCChecksum(t *testing.T) {
+	for _, rc := range allReaderConstructors() {
+		t.Run(rc.name, func(t *testing.T) {
+			path := writeCrossCheckFixture(t, FormatV3)
+			// The TOC lives in the last 72+4 bytes of the file.
+			// Flip byte at offset -8, which is in the content of the TOC,
+			// so changing it should make the checksum invalid.
+			corruptFileBytes(t, path, func(b []byte) {
+				off := len(b) - crc32.Size - 8
+				b[off] ^= 0x01
+			})
+
+			_, err := rc.open(path)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid checksum")
+		})
+	}
+}
+
+// TestReaders_RawFileReaderIndependence verifies that RawFileReader
+// returns an independent reader each call.
+func TestReaders_RawFileReaderIndependence(t *testing.T) {
+	for _, rc := range allReaderConstructors() {
+		t.Run(rc.name, func(t *testing.T) {
+			path := writeCrossCheckFixture(t, FormatV3)
+
+			r, err := rc.open(path)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, r.Close()) })
+
+			want, err := os.ReadFile(path)
+			require.NoError(t, err)
+
+			rf1, err := r.RawFileReader()
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, rf1.Close()) })
+			rf2, err := r.RawFileReader()
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, rf2.Close()) })
+
+			// Advancing rf1 must not consume from rf2 — they're
+			// independent cursors over the same file content.
+			half := len(want) / 2
+			buf := make([]byte, half)
+			n, err := io.ReadFull(rf1, buf)
+			require.NoError(t, err)
+			require.Equal(t, half, n)
+			require.Equal(t, want[:half], buf)
+
+			got2, err := io.ReadAll(rf2)
+			require.NoError(t, err)
+			require.Equal(t, want, got2)
+
+			// The reader itself must still work after the raw readers
+			// have been used — the underlying access path is separate.
+			require.Equal(t, FormatV3, r.Version())
+		})
+	}
+}
+
+// corruptFileBytes reads the whole file, hands the bytes to mutate, and
+// writes them back. Used to inject targeted corruption into fixture
+// files for the reject-* tests.
+func corruptFileBytes(t *testing.T, path string, mutate func(b []byte)) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	mutate(b)
+	require.NoError(t, os.WriteFile(path, b, 0600))
 }
 
 func requireSymbolsEqual(t *testing.T, mmap, stream Reader) {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding.go
@@ -6,7 +6,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Prometheus Authors.
 
-package encoding
+package streamenc
 
 import (
 	"encoding/binary"

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding.go
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/grafana/mimir/blob/main/pkg/storage/indexheader/encoding/encoding.go
+// Provenance-includes-license: AGPL-3.0-only
+// Provenance-includes-copyright: The Grafana Mimir Authors.
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/main/tsdb/encoding/encoding.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Prometheus Authors.
+
+package encoding
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+
+	"github.com/dennwc/varint"
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrInvalidSize     = errors.New("invalid size")
+	ErrInvalidChecksum = errors.New("invalid checksum")
+)
+
+// Decbuf provides safe methods to extract data from a big-endian binary data.
+// It the Prometheus encoding.Decbuf type, but for a generic BufReader rather than []byte.
+// Decbuf handles all necessary bounds checking and advancing of the underlying reader.
+// Consumers may extract multiple datums without checking for errors,
+// but the Err() must be checked before using the extracted data.
+// New Decbuf instances must be created via a DecbufFactory.
+type Decbuf struct {
+	r BufReader
+	E error
+}
+
+func (d *Decbuf) Uvarint() int { return int(d.Uvarint64()) }
+func (d *Decbuf) Be32int() int { return int(d.Be32()) }
+
+// CheckCrc32 checks the integrity of the contents of this Decbuf,
+// comparing the contents with the CRC32 checksum stored in the last four bytes.
+// CheckCrc32 consumes the contents of this Decbuf.
+func (d *Decbuf) CheckCrc32(castagnoliTable *crc32.Table) {
+	if d.r.Len() <= 4 {
+		d.E = ErrInvalidSize
+		return
+	}
+
+	hash := crc32.New(castagnoliTable)
+	bytesToRead := d.r.Len() - 4
+	maxChunkSize := 1024 * 1024
+	rawBuf := make([]byte, maxChunkSize)
+
+	for bytesToRead > 0 {
+		chunkSize := min(bytesToRead, maxChunkSize)
+		chunkBuf := rawBuf[0:chunkSize]
+
+		err := d.r.ReadInto(chunkBuf)
+		if err != nil {
+			d.E = errors.Wrap(err, "read contents for CRC32 calculation")
+			return
+		}
+
+		if n, err := hash.Write(chunkBuf); err != nil {
+			d.E = errors.Wrap(err, "write bytes to CRC32 calculation")
+			return
+		} else if n != len(chunkBuf) {
+			d.E = fmt.Errorf("CRC32 calculation only wrote %v bytes, expected to write %v bytes", n, len(chunkBuf))
+			return
+		}
+
+		bytesToRead -= len(chunkBuf)
+	}
+
+	actual := hash.Sum32()
+	expected := d.Be32()
+
+	if actual != expected {
+		d.E = ErrInvalidChecksum
+	}
+}
+
+// Skip advances the pointer of the underlying BufReader by the given number
+// of bytes. If E is non-nil, this method has no effect. Skip-ing beyond the
+// end of the underlying BufReader will set E to an error and not advance the
+// pointer of the BufReader.
+func (d *Decbuf) Skip(l int) {
+	if d.E != nil {
+		return
+	}
+
+	d.E = d.r.Skip(l)
+}
+
+// SkipUvarintBytes advances the pointer of the underlying BufReader past the
+// next varint-prefixed bytes. If E is non-nil, this method has no effect.
+func (d *Decbuf) SkipUvarintBytes() {
+	l := d.Uvarint64()
+	d.Skip(int(l))
+}
+
+// ResetAt sets the pointer of the underlying BufReader to the absolute
+// offset and discards any buffered data. If E is non-nil, this method has
+// no effect. ResetAt-ing beyond the end of the underlying BufReader will set
+// E to an error and not advance the pointer of BufReader.
+func (d *Decbuf) ResetAt(off int) {
+	if d.E != nil {
+		return
+	}
+
+	// If we are trying to reset at an offset which is already buffered,
+	// we can avoid resetting the BufReader and just discard some of the buffer instead.
+	if dist := off - d.Offset(); dist >= 0 && dist < d.r.Buffered() {
+		d.E = d.r.Skip(dist)
+		return
+	}
+
+	d.E = d.r.ResetAt(off)
+}
+
+// UvarintStr reads varint prefixed bytes into a string and consumes them. The string
+// returned allocates its own memory may be used after subsequent reads from the Decbuf.
+// If E is non-nil, this method returns an empty string.
+func (d *Decbuf) UvarintStr() string {
+	return string(d.UnsafeUvarintBytes())
+}
+
+// UnsafeUvarintBytes reads varint prefixed bytes into a byte slice consuming them but without
+// allocating. The bytes returned are NO LONGER VALID after subsequent reads from the Decbuf.
+// If E is non-nil, this method returns an empty byte slice.
+func (d *Decbuf) UnsafeUvarintBytes() []byte {
+	l := d.Uvarint64()
+	if d.E != nil {
+		return nil
+	}
+
+	// If the length of this uvarint slice is greater than the size of buffer used
+	// by our reader, we can't Peek() it. Instead, we have to use the Read() method
+	// which will allocate its own slice to hold the results. We prefer to use Peek()
+	// when possible for performance but can't rely on slices always being less than
+	// the size of our buffer.
+	if l > uint64(d.r.Size()) {
+		b, err := d.r.Read(int(l))
+		if err != nil {
+			d.E = err
+			return nil
+		}
+
+		return b
+	}
+
+	b, err := d.r.Peek(int(l))
+	if err != nil {
+		d.E = err
+		return nil
+	}
+
+	if len(b) != int(l) {
+		d.E = ErrInvalidSize
+		return nil
+	}
+
+	if b == nil {
+		return nil
+	}
+
+	err = d.r.Skip(len(b))
+	if err != nil {
+		d.E = err
+		return nil
+	}
+
+	return b
+}
+
+func (d *Decbuf) Uvarint64() uint64 {
+	if d.E != nil {
+		return 0
+	}
+	b, err := d.r.Peek(10)
+	if err != nil {
+		d.E = err
+		return 0
+	}
+
+	x, n := varint.Uvarint(b)
+	if n < 1 {
+		d.E = ErrInvalidSize
+		return 0
+	}
+
+	err = d.r.Skip(n)
+	if err != nil {
+		d.E = err
+		return 0
+	}
+
+	return x
+}
+
+func (d *Decbuf) Be64() uint64 {
+	if d.E != nil {
+		return 0
+	}
+
+	b, err := d.r.Peek(8)
+	if err != nil {
+		d.E = err
+		return 0
+	}
+
+	if len(b) != 8 {
+		d.E = ErrInvalidSize
+		return 0
+	}
+
+	v := binary.BigEndian.Uint64(b)
+	err = d.r.Skip(8)
+	if err != nil {
+		d.E = err
+		return 0
+	}
+
+	return v
+}
+
+func (d *Decbuf) Be32() uint32 {
+	if d.E != nil {
+		return 0
+	}
+
+	b, err := d.r.Peek(4)
+	if err != nil {
+		d.E = err
+		return 0
+	}
+
+	if len(b) != 4 {
+		d.E = ErrInvalidSize
+		return 0
+	}
+
+	v := binary.BigEndian.Uint32(b)
+	err = d.r.Skip(4)
+	if err != nil {
+		d.E = err
+		return 0
+	}
+
+	return v
+}
+
+func (d *Decbuf) Byte() byte {
+	if d.E != nil {
+		return 0
+	}
+
+	b, err := d.r.Peek(1)
+	if err != nil {
+		d.E = err
+		return 0
+	}
+
+	if len(b) != 1 {
+		d.E = ErrInvalidSize
+		return 0
+	}
+
+	v := b[0]
+	err = d.r.Skip(1)
+	if err != nil {
+		d.E = err
+		return 0
+	}
+
+	return v
+}
+
+func (d *Decbuf) Err() error { return d.E }
+
+// Len returns the remaining number of bytes in the underlying BufReader.
+func (d *Decbuf) Len() int { return d.r.Len() }
+
+// Offset returns the current offset of the underlying BufReader.
+// Calling d.ResetAt(d.Offset()) is effectively a no-op.
+func (d *Decbuf) Offset() int { return d.r.Offset() }
+
+func (d *Decbuf) Close() error {
+	if d.r != nil {
+		return d.r.Close()
+	}
+
+	return nil
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding_test.go
@@ -1,0 +1,870 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/grafana/mimir/blob/main/pkg/storage/indexheader/encoding/encoding_test.go
+// Provenance-includes-license: AGPL-3.0-only
+// Provenance-includes-copyright: The Grafana Mimir Authors.
+
+package encoding
+
+import (
+	"context"
+	"fmt"
+	"hash/crc32"
+	"os"
+	"path"
+	"strconv"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	promencoding "github.com/prometheus/prometheus/tsdb/encoding"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/objstore/providers/filesystem"
+
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/filepool"
+	"github.com/grafana/mimir/pkg/util/test"
+)
+
+func TestDecbuf_Be32HappyPath(t *testing.T) {
+	cases := []uint32{
+		0,
+		1,
+		0xFFFF_FFFF,
+	}
+
+	for _, c := range cases {
+		tb := test.NewTB(t)
+		caseName := strconv.FormatInt(int64(c), 10)
+
+		enc := promencoding.Encbuf{}
+		enc.PutBE32(c)
+
+		runAllBufReaderTypes(tb, caseName, enc.Get(), func(tb test.TB, dec Decbuf) {
+			require.Equal(t, 4, dec.Len())
+			require.Equal(t, 0, dec.Offset())
+
+			actual := dec.Be32()
+			require.NoError(t, dec.Err())
+			require.Equal(t, c, actual)
+			require.Equal(t, 0, dec.Len())
+			require.Equal(t, 4, dec.Offset())
+		})
+	}
+}
+
+func TestDecbuf_Be32InsufficientBuffer(t *testing.T) {
+	tb := test.NewTB(t)
+
+	enc := promencoding.Encbuf{}
+	enc.PutBE32(0xFFFF_FFFF)
+
+	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(tb test.TB, dec Decbuf) {
+		_ = dec.Be32()
+		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
+	})
+}
+
+func FuzzDecbuf_Be32(f *testing.F) {
+	f.Add(uint32(0))
+	f.Add(uint32(1))
+	f.Add(uint32(0xFFFF_FFFF))
+
+	f.Fuzz(func(t *testing.T, n uint32) {
+		tb := test.NewTB(t)
+
+		enc := promencoding.Encbuf{}
+		enc.PutBE32(n)
+
+		runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+			require.NoError(t, dec.Err())
+			require.Equal(t, 4, dec.Len())
+			require.Equal(t, 0, dec.Offset())
+
+			actual := dec.Be32()
+			require.NoError(t, dec.Err())
+			require.Equal(t, n, actual)
+			require.Equal(t, 0, dec.Len())
+			require.Equal(t, 4, dec.Offset())
+		})
+	})
+}
+
+func BenchmarkDecbuf_Be32(b *testing.B) {
+	tb := test.NewTB(b)
+
+	enc := promencoding.Encbuf{}
+	enc.PutBE32(uint32(0))
+	enc.PutBE32(uint32(1))
+	enc.PutBE32(uint32(0xFFFF_FFFF))
+
+	bytes := enc.Get()
+	bytesCopy := append([]byte(nil), bytes...)
+
+	runAllBufReaderTypes(tb, "", bytesCopy, func(tb test.TB, dec Decbuf) {
+		tb.ResetTimer()
+
+		for i := 0; i < tb.N(); i++ {
+			v1 := dec.Be32()
+			v2 := dec.Be32()
+			v3 := dec.Be32()
+
+			if err := dec.Err(); err != nil {
+				require.NoError(tb, err)
+			}
+
+			if v1 != 0 || v2 != 0 || v3 != 0xFFFF_FFFF {
+				require.Equal(tb, uint32(0), v1)
+				require.Equal(tb, uint32(1), v2)
+				require.Equal(tb, uint32(0xFFFF_FFFF), v3)
+			}
+
+			dec.ResetAt(0)
+		}
+	})
+}
+
+func TestDecbuf_Be32intHappyPath(t *testing.T) {
+	cases := []int{
+		0,
+		1,
+		0xFFFF_FFFF,
+	}
+
+	for _, c := range cases {
+		tb := test.NewTB(t)
+		caseName := strconv.FormatInt(int64(c), 10)
+
+		enc := promencoding.Encbuf{}
+		enc.PutBE32int(c)
+
+		runAllBufReaderTypes(tb, caseName, enc.Get(), func(tb test.TB, dec Decbuf) {
+			require.Equal(t, 4, dec.Len())
+			require.Equal(t, 0, dec.Offset())
+
+			actual := dec.Be32int()
+			require.NoError(t, dec.Err())
+			require.Equal(t, c, actual)
+			require.Equal(t, 0, dec.Len())
+			require.Equal(t, 4, dec.Offset())
+		})
+	}
+}
+
+func TestDecbuf_Be32intInsufficientBuffer(t *testing.T) {
+	tb := test.NewTB(t)
+
+	enc := promencoding.Encbuf{}
+	enc.PutBE32int(0xFFFF_FFFF)
+
+	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(tb test.TB, dec Decbuf) {
+		_ = dec.Be32int()
+		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
+	})
+}
+
+func FuzzDecbuf_Be32int(f *testing.F) {
+	f.Add(0)
+	f.Add(1)
+	f.Add(0xFFFF_FFFF)
+
+	f.Fuzz(func(t *testing.T, n int) {
+		if n < 0 || n > 0xFFFF_FFFF {
+			t.Skip()
+		}
+
+		tb := test.NewTB(t)
+		enc := promencoding.Encbuf{}
+		enc.PutBE32int(n)
+
+		runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+			require.NoError(t, dec.Err())
+			require.Equal(t, 4, dec.Len())
+			require.Equal(t, 0, dec.Offset())
+
+			actual := dec.Be32int()
+			require.NoError(t, dec.Err())
+			require.Equal(t, n, actual)
+			require.Equal(t, 0, dec.Len())
+			require.Equal(t, 4, dec.Offset())
+		})
+	})
+}
+
+func TestDecbuf_Be64HappyPath(t *testing.T) {
+	cases := []uint64{
+		0,
+		1,
+		0xFFFF_FFFF_FFFF_FFFF,
+	}
+
+	for _, c := range cases {
+		tb := test.NewTB(t)
+		caseName := strconv.FormatUint(c, 10)
+
+		enc := promencoding.Encbuf{}
+		enc.PutBE64(c)
+
+		runAllBufReaderTypes(tb, caseName, enc.Get(), func(tb test.TB, dec Decbuf) {
+			require.Equal(t, 8, dec.Len())
+			require.Equal(t, 0, dec.Offset())
+
+			actual := dec.Be64()
+			require.NoError(t, dec.Err())
+			require.Equal(t, c, actual)
+			require.Equal(t, 0, dec.Len())
+			require.Equal(t, 8, dec.Offset())
+		})
+	}
+}
+
+func TestDecbuf_Be64InsufficientBuffer(t *testing.T) {
+	tb := test.NewTB(t)
+	runAllBufReaderTypes(tb, "", []byte{0x01}, func(tb test.TB, dec Decbuf) {
+		_ = dec.Be64()
+		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
+	})
+}
+
+func FuzzDecbuf_Be64(f *testing.F) {
+	f.Add(uint64(0))
+	f.Add(uint64(1))
+	f.Add(uint64(0xFFFF_FFFF_FFFF_FFFF))
+
+	f.Fuzz(func(t *testing.T, n uint64) {
+		tb := test.NewTB(t)
+
+		enc := promencoding.Encbuf{}
+		enc.PutBE64(n)
+
+		runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+			require.NoError(t, dec.Err())
+			require.Equal(t, 8, dec.Len())
+			require.Equal(t, 0, dec.Offset())
+
+			actual := dec.Be64()
+			require.NoError(t, dec.Err())
+			require.Equal(t, n, actual)
+			require.Equal(t, 0, dec.Len())
+			require.Equal(t, 8, dec.Offset())
+		})
+	})
+}
+
+func BenchmarkDecbuf_Be64(t *testing.B) {
+	tb := test.NewTB(t)
+
+	enc := promencoding.Encbuf{}
+	enc.PutBE64(uint64(0))
+	enc.PutBE64(uint64(1))
+	enc.PutBE64(uint64(0xFFFF_FFFF_FFFF_FFFF))
+
+	b := enc.Get()
+	bCopy := append([]byte(nil), b...)
+
+	runAllBufReaderTypes(tb, "", bCopy, func(tb test.TB, dec Decbuf) {
+		t.ResetTimer()
+
+		for i := 0; i < t.N; i++ {
+			v1 := dec.Be64()
+			v2 := dec.Be64()
+			v3 := dec.Be64()
+
+			if err := dec.Err(); err != nil {
+				require.NoError(t, err)
+			}
+
+			if v1 != 0 || v2 != 0 || v3 != 0xFFFF_FFFF_FFFF_FFFF {
+				require.Equal(t, uint64(0), v1)
+				require.Equal(t, uint64(1), v2)
+				require.Equal(t, uint64(0xFFFF_FFFF_FFFF_FFFF), v3)
+			}
+
+			dec.ResetAt(0)
+		}
+	})
+}
+
+func TestDecbuf_SkipHappyPath(t *testing.T) {
+	tb := test.NewTB(t)
+
+	expected := uint32(0x12345678)
+
+	enc := promencoding.Encbuf{}
+	enc.PutBE32(0xFFFF_FFFF)
+	enc.PutBE32(expected)
+
+	runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+		require.Equal(t, 8, dec.Len())
+		require.Equal(t, 0, dec.Offset())
+
+		dec.Skip(4)
+		require.NoError(t, dec.Err())
+		require.Equal(t, 4, dec.Len())
+		require.Equal(t, 4, dec.Offset())
+
+		actual := dec.Be32()
+		require.NoError(t, dec.Err())
+		require.Equal(t, expected, actual)
+		require.Equal(t, 0, dec.Len())
+		require.Equal(t, 8, dec.Offset())
+	})
+}
+
+func TestDecbuf_SkipMultipleBufferReads(t *testing.T) {
+	tb := test.NewTB(t)
+
+	// The underlying FileReader buffers the file 4k bytes at a time. Ensure
+	// that we can skip multiple 4k chunks without ending up with a short read.
+	bytes := make([]byte, 4096*5)
+	for i := 0; i < len(bytes); i++ {
+		bytes[i] = 0x01
+	}
+
+	runAllBufReaderTypes(tb, "", bytes, func(tb test.TB, dec Decbuf) {
+		dec.Skip(4096 * 4)
+
+		require.NoError(t, dec.Err())
+		require.Equal(t, dec.Len(), 4096)
+		require.Equal(t, 4096*4, dec.Offset())
+		require.Equal(t, byte(0x01), dec.Byte())
+	})
+}
+
+func TestDecbuf_SkipInsufficientBuffer(t *testing.T) {
+	tb := test.NewTB(t)
+	runAllBufReaderTypes(tb, "", []byte{0x01}, func(tb test.TB, dec Decbuf) {
+		dec.Skip(2)
+		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
+	})
+}
+
+func TestDecbuf_SkipUvarintBytesHappyPath(t *testing.T) {
+	tb := test.NewTB(t)
+
+	expected := uint32(0x567890AB)
+	enc := promencoding.Encbuf{}
+	enc.PutUvarintBytes([]byte{0x12, 0x34})
+	enc.PutBE32(expected)
+
+	runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+		require.Equal(t, 7, dec.Len())
+		require.Equal(t, 0, dec.Offset())
+
+		dec.SkipUvarintBytes()
+		require.NoError(t, dec.Err())
+		require.Equal(t, 4, dec.Len())
+		require.Equal(t, 3, dec.Offset())
+
+		actual := dec.Be32()
+		require.NoError(t, dec.Err())
+		require.Equal(t, expected, actual)
+	})
+}
+
+func TestDecbuf_SkipUvarintBytesEndOfFile(t *testing.T) {
+	tb := test.NewTB(t)
+
+	enc := promencoding.Encbuf{}
+	enc.PutBE32(0x12345678)
+
+	runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+		dec.Be32()
+		require.NoError(t, dec.Err())
+		require.Equal(t, 0, dec.Len())
+		require.Equal(t, 4, dec.Offset())
+
+		dec.SkipUvarintBytes()
+		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
+	})
+}
+
+func TestDecbuf_SkipUvarintBytesOnlyHaveLength(t *testing.T) {
+	tb := test.NewTB(t)
+
+	enc := promencoding.Encbuf{}
+	enc.PutUvarintBytes([]byte{0x12, 0x34})
+
+	bytes := enc.Get()
+
+	runAllBufReaderTypes(tb, "", bytes[:len(bytes)-2], func(tb test.TB, dec Decbuf) {
+		require.Equal(t, 1, dec.Len())
+		require.Equal(t, 0, dec.Offset())
+
+		dec.SkipUvarintBytes()
+		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
+	})
+}
+
+func TestDecbuf_SkipUvarintBytesPartialValue(t *testing.T) {
+	tb := test.NewTB(t)
+
+	enc := promencoding.Encbuf{}
+	enc.PutUvarintBytes([]byte{0x12, 0x34})
+
+	bytes := enc.Get()
+
+	runAllBufReaderTypes(tb, "", bytes[:len(bytes)-1], func(tb test.TB, dec Decbuf) {
+		require.Equal(t, 2, dec.Len())
+		require.Equal(t, 0, dec.Offset())
+
+		dec.SkipUvarintBytes()
+		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
+	})
+}
+
+func TestDecbuf_UvarintHappyPath(t *testing.T) {
+	cases := []struct {
+		value int
+		bytes int
+	}{
+		{value: 0, bytes: 1},
+		{value: 1, bytes: 1},
+		{value: 127, bytes: 1},
+		{value: 128, bytes: 2},
+		{value: 0xFFFF_FFFF, bytes: 5},
+	}
+
+	for _, c := range cases {
+		tb := test.NewTB(t)
+		caseName := strconv.Itoa(c.value)
+
+		enc := promencoding.Encbuf{}
+		enc.PutUvarint(c.value)
+
+		runAllBufReaderTypes(tb, caseName, enc.Get(), func(tb test.TB, dec Decbuf) {
+			require.Equal(t, c.bytes, dec.Len())
+			require.Equal(t, 0, dec.Offset())
+
+			actual := dec.Uvarint()
+			require.NoError(t, dec.Err())
+			require.Equal(t, c.value, actual)
+			require.Equal(t, 0, dec.Len())
+			require.Equal(t, c.bytes, dec.Offset())
+		})
+	}
+}
+
+func TestDecbuf_UvarintInsufficientBuffer(t *testing.T) {
+	tb := test.NewTB(t)
+
+	enc := promencoding.Encbuf{}
+	enc.PutUvarint(0xFFFF_FFFF)
+
+	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(tb test.TB, dec Decbuf) {
+		_ = dec.Uvarint()
+		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
+	})
+}
+
+func FuzzDecbuf_Uvarint(f *testing.F) {
+	f.Add(0)
+	f.Add(1)
+	f.Add(0xFFFF_FFFF)
+
+	f.Fuzz(func(t *testing.T, n int) {
+		if n < 0 {
+			t.Skip()
+		}
+		tb := test.NewTB(t)
+
+		enc := promencoding.Encbuf{}
+		enc.PutUvarint(n)
+
+		runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+			require.NoError(t, dec.Err())
+			actual := dec.Uvarint()
+			require.NoError(t, dec.Err())
+			require.Equal(t, n, actual)
+			require.Equal(t, 0, dec.Len())
+		})
+	})
+}
+
+func TestDecbuf_Uvarint64HappyPath(t *testing.T) {
+	cases := []struct {
+		value uint64
+		bytes int
+	}{
+		{value: 0, bytes: 1},
+		{value: 1, bytes: 1},
+		{value: 127, bytes: 1},
+		{value: 128, bytes: 2},
+		{value: 0xFFFF_FFFF, bytes: 5},
+		{value: 0xFFFF_FFFF_FFFF_FFFF, bytes: 10},
+	}
+
+	for _, c := range cases {
+		tb := test.NewTB(t)
+		caseName := strconv.FormatUint(c.value, 10)
+
+		enc := promencoding.Encbuf{}
+		enc.PutUvarint64(c.value)
+
+		runAllBufReaderTypes(tb, caseName, enc.Get(), func(tb test.TB, dec Decbuf) {
+			require.Equal(t, c.bytes, dec.Len())
+			require.Equal(t, 0, dec.Offset())
+
+			actual := dec.Uvarint64()
+			require.NoError(t, dec.Err())
+			require.Equal(t, c.value, actual)
+			require.Equal(t, 0, dec.Len())
+			require.Equal(t, c.bytes, dec.Offset())
+		})
+	}
+}
+
+func TestDecbuf_Uvarint64InsufficientBuffer(t *testing.T) {
+	tb := test.NewTB(t)
+
+	enc := promencoding.Encbuf{}
+	enc.PutUvarint64(0xFFFF_FFFF)
+
+	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(tb test.TB, dec Decbuf) {
+		_ = dec.Uvarint64()
+		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
+	})
+}
+
+func FuzzDecbuf_Uvarint64(f *testing.F) {
+	f.Add(uint64(0))
+	f.Add(uint64(1))
+	f.Add(uint64(127))
+	f.Add(uint64(128))
+	f.Add(uint64(0xFFFF_FFFF))
+	f.Add(uint64(0xFFFF_FFFF_FFFF_FFFF))
+
+	f.Fuzz(func(t *testing.T, n uint64) {
+		tb := test.NewTB(t)
+
+		enc := promencoding.Encbuf{}
+		enc.PutUvarint64(n)
+
+		runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+			require.NoError(t, dec.Err())
+			actual := dec.Uvarint64()
+			require.NoError(t, dec.Err())
+			require.Equal(t, n, actual)
+			require.Equal(t, 0, dec.Len())
+		})
+	})
+}
+
+func TestDecbuf_UnsafeUvarintBytesHappyPath(t *testing.T) {
+	cases := []struct {
+		name              string
+		value             []byte
+		encodedSizeLength int
+	}{
+		{name: "nil slice", value: []byte(nil), encodedSizeLength: 1},
+		{name: "empty slice", value: []byte{}, encodedSizeLength: 1},
+		{name: "single byte", value: []byte{0x12}, encodedSizeLength: 1},
+		{name: "127 bytes", value: []byte("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567"), encodedSizeLength: 1},
+		{name: "128 bytes", value: []byte("12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678"), encodedSizeLength: 2},
+	}
+
+	for _, c := range cases {
+		tb := test.NewTB(t)
+
+		enc := promencoding.Encbuf{}
+		enc.PutUvarintBytes(c.value)
+
+		runAllBufReaderTypes(tb, c.name, enc.Get(), func(tb test.TB, dec Decbuf) {
+			size := c.encodedSizeLength + len(c.value)
+			require.Equal(t, size, dec.Len())
+			require.Equal(t, 0, dec.Offset())
+
+			actual := dec.UnsafeUvarintBytes()
+			require.NoError(t, dec.Err())
+			require.Condition(t, test.EqualSlices(c.value, actual), "%#v != %#v", c.value, actual)
+			require.Equal(t, 0, dec.Len())
+			require.Equal(t, size, dec.Offset())
+		})
+	}
+}
+
+func TestDecbuf_UnsafeUvarintBytesInsufficientBuffer(t *testing.T) {
+	tb := test.NewTB(t)
+
+	enc := promencoding.Encbuf{}
+	enc.PutUvarintBytes([]byte("123456"))
+
+	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(tb test.TB, dec Decbuf) {
+		_ = dec.UnsafeUvarintBytes()
+		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
+	})
+}
+
+func TestDecbuf_UnsafeUvarintBytesSkipDoesNotCauseBufferFill(t *testing.T) {
+	tb := test.NewTB(t)
+	const (
+		expectedSlices = 32
+		expectedBytes  = 983
+	)
+
+	// This test verifies that when bytes are read in UnsafeUvarintBytes, the Peek(n) and
+	// subsequent skip(len(b)) does not cause a read from disk that invalidates the slice
+	// returned. It does this by creating multiple uvarint byte slices in the encoding
+	// buffer each with different content _and_ by ensuring there are more bytes written
+	// in total than the size of the underlying buffer (currently 4k).
+
+	enc := promencoding.Encbuf{}
+	for base := 0; base < expectedSlices; base++ {
+		var bytes []byte
+		for i := 0; i < expectedBytes; i++ {
+			bytes = append(bytes, byte(base))
+		}
+
+		enc.PutUvarintBytes(bytes)
+	}
+
+	runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+		for base := 0; base < expectedSlices; base++ {
+			bytes := dec.UnsafeUvarintBytes()
+
+			require.NoError(t, dec.Err())
+			require.Len(t, bytes, expectedBytes)
+
+			for _, v := range bytes {
+				require.Equal(t, byte(base), v)
+			}
+		}
+	})
+}
+
+func FuzzDecbuf_UnsafeUvarintBytes(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{0x12})
+	f.Add([]byte("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567"))
+	f.Add([]byte("12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678"))
+
+	f.Fuzz(func(t *testing.T, b []byte) {
+		tb := test.NewTB(t)
+
+		enc := promencoding.Encbuf{}
+		enc.PutUvarintBytes(b)
+
+		runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+			require.NoError(t, dec.Err())
+			actual := dec.UnsafeUvarintBytes()
+			require.NoError(t, dec.Err())
+			require.Condition(t, test.EqualSlices(b, actual), "%#v != %#v", b, actual)
+			require.Equal(t, 0, dec.Len())
+		})
+	})
+}
+
+func BenchmarkDecbuf_UnsafeUvarintBytes(t *testing.B) {
+	tb := test.NewTB(t)
+
+	// 127 bytes, the varint size will be 1 byte.
+	val := []byte("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567")
+	enc := promencoding.Encbuf{}
+	enc.PutUvarintBytes(val)
+
+	bytes := enc.Get()
+	byteCopy := append([]byte(nil), bytes...)
+
+	runAllBufReaderTypes(tb, "", byteCopy, func(tb test.TB, dec Decbuf) {
+		t.ResetTimer()
+
+		for i := 0; i < t.N; i++ {
+			b := dec.UnsafeUvarintBytes()
+			if err := dec.Err(); err != nil {
+				require.NoError(t, err)
+			}
+
+			if len(b) != len(val) {
+				require.Len(t, b, len(val))
+			}
+
+			dec.ResetAt(0)
+			if err := dec.Err(); err != nil {
+				require.NoError(t, err)
+			}
+		}
+	})
+}
+
+func TestDecbuf_UvarintStrHappyPath(t *testing.T) {
+	cases := []struct {
+		name              string
+		value             string
+		encodedSizeLength int
+	}{
+		{name: "empty string", value: "", encodedSizeLength: 1},
+		{name: "single byte", value: "a", encodedSizeLength: 1},
+		{name: "127 bytes", value: "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567", encodedSizeLength: 1},
+		{name: "128 bytes", value: "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678", encodedSizeLength: 2},
+	}
+
+	for _, c := range cases {
+		tb := test.NewTB(t)
+
+		enc := promencoding.Encbuf{}
+		enc.PutUvarintStr(c.value)
+
+		runAllBufReaderTypes(tb, c.name, enc.Get(), func(tb test.TB, dec Decbuf) {
+			size := c.encodedSizeLength + len(c.value)
+			require.Equal(t, size, dec.Len())
+			require.Equal(t, 0, dec.Offset())
+
+			actual := dec.UvarintStr()
+			require.NoError(t, dec.Err())
+			require.Equal(t, c.value, actual)
+			require.Equal(t, 0, dec.Len())
+			require.Equal(t, size, dec.Offset())
+		})
+	}
+}
+
+func TestDecbuf_UvarintStrInsufficientBuffer(t *testing.T) {
+	tb := test.NewTB(t)
+
+	enc := promencoding.Encbuf{}
+	enc.PutUvarintStr("123456")
+
+	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(tb test.TB, dec Decbuf) {
+		_ = dec.UvarintStr()
+		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
+	})
+}
+
+func FuzzDecbuf_UvarintStr(f *testing.F) {
+	f.Add("")
+	f.Add("a")
+	f.Add("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567")
+	f.Add("12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		tb := test.NewTB(t)
+
+		enc := promencoding.Encbuf{}
+		enc.PutUvarintStr(s)
+
+		runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+			require.NoError(t, dec.Err())
+			actual := dec.UvarintStr()
+			require.NoError(t, dec.Err())
+			require.Equal(t, s, actual)
+			require.Equal(t, 0, dec.Len())
+		})
+	})
+}
+
+func TestDecbuf_Crc32(t *testing.T) {
+	table := crc32.MakeTable(crc32.Castagnoli)
+
+	t.Run("matches checksum (small buffer)", func(t *testing.T) {
+		tb := test.NewTB(t)
+		bytes := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x4f, 0x4d, 0xfb, 0xab}
+		runAllBufReaderTypes(tb, "", bytes, func(tb test.TB, dec Decbuf) {
+			dec.CheckCrc32(table)
+			require.NoError(t, dec.Err())
+		})
+	})
+
+	t.Run("matches checksum (buffer larger than single read)", func(t *testing.T) {
+		tb := test.NewTB(t)
+
+		bufferSize := 4*1024*1024 + 1
+		enc := promencoding.Encbuf{}
+
+		for enc.Len() < bufferSize {
+			enc.PutByte(0x01)
+		}
+		enc.PutHash(crc32.New(crc32.MakeTable(crc32.Castagnoli)))
+
+		runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+			dec.CheckCrc32(table)
+			require.NoError(t, dec.Err())
+		})
+	})
+
+	t.Run("does not match checksum (small buffer)", func(t *testing.T) {
+		tb := test.NewTB(t)
+
+		runAllBufReaderTypes(tb, "", []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x4f, 0x4d, 0xfb, 0xff}, func(tb test.TB, dec Decbuf) {
+			dec.CheckCrc32(table)
+			require.ErrorIs(t, dec.Err(), ErrInvalidChecksum)
+		})
+	})
+
+	t.Run("does not match checksum (buffer larger than single read)", func(t *testing.T) {
+		tb := test.NewTB(t)
+
+		bufferSize := 4*1024*1024 + 1
+		enc := promencoding.Encbuf{}
+
+		for enc.Len() < bufferSize {
+			enc.PutByte(0x01)
+		}
+
+		bytes := enc.Get()
+		bytes = append(bytes, 0x00, 0x01, 0x02, 0x03)
+
+		runAllBufReaderTypes(tb, "", bytes, func(tb test.TB, dec Decbuf) {
+			dec.CheckCrc32(table)
+			require.ErrorIs(t, dec.Err(), ErrInvalidChecksum)
+		})
+	})
+
+	t.Run("buffer only contains checksum", func(t *testing.T) {
+		tb := test.NewTB(t)
+
+		runAllBufReaderTypes(tb, "", []byte{0x4f, 0x4d, 0xfb, 0xab}, func(tb test.TB, dec Decbuf) {
+			dec.CheckCrc32(table)
+			require.ErrorIs(t, dec.Err(), ErrInvalidSize)
+		})
+	})
+
+	t.Run("buffer too short for checksum", func(t *testing.T) {
+		tb := test.NewTB(t)
+
+		runAllBufReaderTypes(tb, "", []byte{0x4f, 0x4d, 0xfb}, func(tb test.TB, dec Decbuf) {
+			dec.CheckCrc32(table)
+			require.ErrorIs(t, dec.Err(), ErrInvalidSize)
+		})
+	})
+}
+
+func runAllBufReaderTypes(tb test.TB, caseName string, bytes []byte, testFn func(tb test.TB, dec Decbuf)) {
+	dir := tb.TempDir()
+	fileName := "test-file"
+	filePath := path.Join(dir, fileName)
+	require.NoError(tb, os.WriteFile(filePath, bytes, 0700))
+
+	reg := prometheus.WrapRegistererWithPrefix("indexheader_", prometheus.NewPedanticRegistry())
+	diskFactory := NewFilePoolDecbufFactory(filePath, 0, filepool.NewFilePoolMetrics(reg))
+	tb.Cleanup(func() {
+		_ = diskFactory.Close()
+	})
+	diskDecBuf := diskFactory.NewRawDecbuf(context.Background())
+	require.NoError(tb, diskDecBuf.Err())
+
+	bkt, err := filesystem.NewBucket(dir)
+	require.NoError(tb, err)
+	instBkt := objstore.WithNoopInstr(bkt)
+	tb.Cleanup(func() {
+		require.NoError(tb, bkt.Close())
+	})
+	bucketFactory := NewBucketDecbufFactory(instBkt, fileName)
+	bucketDecBuf := bucketFactory.NewRawDecbuf(context.Background())
+	require.NoError(tb, bucketDecBuf.Err())
+
+	decbufs := map[string]Decbuf{
+		"disk":   diskDecBuf,
+		"bucket": bucketDecBuf,
+	}
+
+	for decbufName, decbuf := range decbufs {
+		name := caseName
+		if len(name) > 0 {
+			name += "/"
+		}
+		name += fmt.Sprintf("BufReader=%s", decbufName)
+
+		tb.Run(name, func(tb test.TB) {
+
+			testFn(tb, decbuf)
+		})
+	}
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding_test.go
@@ -3,9 +3,10 @@
 // Provenance-includes-license: AGPL-3.0-only
 // Provenance-includes-copyright: The Grafana Mimir Authors.
 
-package encoding
+package streamenc
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"hash/crc32"
@@ -17,11 +18,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	promencoding "github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/stretchr/testify/require"
-	"github.com/thanos-io/objstore"
-	"github.com/thanos-io/objstore/providers/filesystem"
 
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/filepool"
-	"github.com/grafana/mimir/pkg/util/test"
 )
 
 func TestDecbuf_Be32HappyPath(t *testing.T) {
@@ -32,13 +30,13 @@ func TestDecbuf_Be32HappyPath(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		tb := test.NewTB(t)
+		tb := t
 		caseName := strconv.FormatInt(int64(c), 10)
 
 		enc := promencoding.Encbuf{}
 		enc.PutBE32(c)
 
-		runAllBufReaderTypes(tb, caseName, enc.Get(), func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, caseName, enc.Get(), func(_ *testing.T, dec Decbuf) {
 			require.Equal(t, 4, dec.Len())
 			require.Equal(t, 0, dec.Offset())
 
@@ -52,12 +50,12 @@ func TestDecbuf_Be32HappyPath(t *testing.T) {
 }
 
 func TestDecbuf_Be32InsufficientBuffer(t *testing.T) {
-	tb := test.NewTB(t)
+	tb := t
 
 	enc := promencoding.Encbuf{}
 	enc.PutBE32(0xFFFF_FFFF)
 
-	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(tb test.TB, dec Decbuf) {
+	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(_ *testing.T, dec Decbuf) {
 		_ = dec.Be32()
 		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
 	})
@@ -69,12 +67,12 @@ func FuzzDecbuf_Be32(f *testing.F) {
 	f.Add(uint32(0xFFFF_FFFF))
 
 	f.Fuzz(func(t *testing.T, n uint32) {
-		tb := test.NewTB(t)
+		tb := t
 
 		enc := promencoding.Encbuf{}
 		enc.PutBE32(n)
 
-		runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, "", enc.Get(), func(_ *testing.T, dec Decbuf) {
 			require.NoError(t, dec.Err())
 			require.Equal(t, 4, dec.Len())
 			require.Equal(t, 0, dec.Offset())
@@ -88,40 +86,6 @@ func FuzzDecbuf_Be32(f *testing.F) {
 	})
 }
 
-func BenchmarkDecbuf_Be32(b *testing.B) {
-	tb := test.NewTB(b)
-
-	enc := promencoding.Encbuf{}
-	enc.PutBE32(uint32(0))
-	enc.PutBE32(uint32(1))
-	enc.PutBE32(uint32(0xFFFF_FFFF))
-
-	bytes := enc.Get()
-	bytesCopy := append([]byte(nil), bytes...)
-
-	runAllBufReaderTypes(tb, "", bytesCopy, func(tb test.TB, dec Decbuf) {
-		tb.ResetTimer()
-
-		for i := 0; i < tb.N(); i++ {
-			v1 := dec.Be32()
-			v2 := dec.Be32()
-			v3 := dec.Be32()
-
-			if err := dec.Err(); err != nil {
-				require.NoError(tb, err)
-			}
-
-			if v1 != 0 || v2 != 0 || v3 != 0xFFFF_FFFF {
-				require.Equal(tb, uint32(0), v1)
-				require.Equal(tb, uint32(1), v2)
-				require.Equal(tb, uint32(0xFFFF_FFFF), v3)
-			}
-
-			dec.ResetAt(0)
-		}
-	})
-}
-
 func TestDecbuf_Be32intHappyPath(t *testing.T) {
 	cases := []int{
 		0,
@@ -130,13 +94,13 @@ func TestDecbuf_Be32intHappyPath(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		tb := test.NewTB(t)
+		tb := t
 		caseName := strconv.FormatInt(int64(c), 10)
 
 		enc := promencoding.Encbuf{}
 		enc.PutBE32int(c)
 
-		runAllBufReaderTypes(tb, caseName, enc.Get(), func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, caseName, enc.Get(), func(_ *testing.T, dec Decbuf) {
 			require.Equal(t, 4, dec.Len())
 			require.Equal(t, 0, dec.Offset())
 
@@ -150,12 +114,12 @@ func TestDecbuf_Be32intHappyPath(t *testing.T) {
 }
 
 func TestDecbuf_Be32intInsufficientBuffer(t *testing.T) {
-	tb := test.NewTB(t)
+	tb := t
 
 	enc := promencoding.Encbuf{}
 	enc.PutBE32int(0xFFFF_FFFF)
 
-	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(tb test.TB, dec Decbuf) {
+	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(_ *testing.T, dec Decbuf) {
 		_ = dec.Be32int()
 		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
 	})
@@ -171,11 +135,11 @@ func FuzzDecbuf_Be32int(f *testing.F) {
 			t.Skip()
 		}
 
-		tb := test.NewTB(t)
+		tb := t
 		enc := promencoding.Encbuf{}
 		enc.PutBE32int(n)
 
-		runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, "", enc.Get(), func(_ *testing.T, dec Decbuf) {
 			require.NoError(t, dec.Err())
 			require.Equal(t, 4, dec.Len())
 			require.Equal(t, 0, dec.Offset())
@@ -197,13 +161,13 @@ func TestDecbuf_Be64HappyPath(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		tb := test.NewTB(t)
+		tb := t
 		caseName := strconv.FormatUint(c, 10)
 
 		enc := promencoding.Encbuf{}
 		enc.PutBE64(c)
 
-		runAllBufReaderTypes(tb, caseName, enc.Get(), func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, caseName, enc.Get(), func(_ *testing.T, dec Decbuf) {
 			require.Equal(t, 8, dec.Len())
 			require.Equal(t, 0, dec.Offset())
 
@@ -217,8 +181,8 @@ func TestDecbuf_Be64HappyPath(t *testing.T) {
 }
 
 func TestDecbuf_Be64InsufficientBuffer(t *testing.T) {
-	tb := test.NewTB(t)
-	runAllBufReaderTypes(tb, "", []byte{0x01}, func(tb test.TB, dec Decbuf) {
+	tb := t
+	runAllBufReaderTypes(tb, "", []byte{0x01}, func(_ *testing.T, dec Decbuf) {
 		_ = dec.Be64()
 		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
 	})
@@ -230,12 +194,12 @@ func FuzzDecbuf_Be64(f *testing.F) {
 	f.Add(uint64(0xFFFF_FFFF_FFFF_FFFF))
 
 	f.Fuzz(func(t *testing.T, n uint64) {
-		tb := test.NewTB(t)
+		tb := t
 
 		enc := promencoding.Encbuf{}
 		enc.PutBE64(n)
 
-		runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, "", enc.Get(), func(_ *testing.T, dec Decbuf) {
 			require.NoError(t, dec.Err())
 			require.Equal(t, 8, dec.Len())
 			require.Equal(t, 0, dec.Offset())
@@ -249,42 +213,8 @@ func FuzzDecbuf_Be64(f *testing.F) {
 	})
 }
 
-func BenchmarkDecbuf_Be64(t *testing.B) {
-	tb := test.NewTB(t)
-
-	enc := promencoding.Encbuf{}
-	enc.PutBE64(uint64(0))
-	enc.PutBE64(uint64(1))
-	enc.PutBE64(uint64(0xFFFF_FFFF_FFFF_FFFF))
-
-	b := enc.Get()
-	bCopy := append([]byte(nil), b...)
-
-	runAllBufReaderTypes(tb, "", bCopy, func(tb test.TB, dec Decbuf) {
-		t.ResetTimer()
-
-		for i := 0; i < t.N; i++ {
-			v1 := dec.Be64()
-			v2 := dec.Be64()
-			v3 := dec.Be64()
-
-			if err := dec.Err(); err != nil {
-				require.NoError(t, err)
-			}
-
-			if v1 != 0 || v2 != 0 || v3 != 0xFFFF_FFFF_FFFF_FFFF {
-				require.Equal(t, uint64(0), v1)
-				require.Equal(t, uint64(1), v2)
-				require.Equal(t, uint64(0xFFFF_FFFF_FFFF_FFFF), v3)
-			}
-
-			dec.ResetAt(0)
-		}
-	})
-}
-
 func TestDecbuf_SkipHappyPath(t *testing.T) {
-	tb := test.NewTB(t)
+	tb := t
 
 	expected := uint32(0x12345678)
 
@@ -292,7 +222,7 @@ func TestDecbuf_SkipHappyPath(t *testing.T) {
 	enc.PutBE32(0xFFFF_FFFF)
 	enc.PutBE32(expected)
 
-	runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+	runAllBufReaderTypes(tb, "", enc.Get(), func(_ *testing.T, dec Decbuf) {
 		require.Equal(t, 8, dec.Len())
 		require.Equal(t, 0, dec.Offset())
 
@@ -310,7 +240,7 @@ func TestDecbuf_SkipHappyPath(t *testing.T) {
 }
 
 func TestDecbuf_SkipMultipleBufferReads(t *testing.T) {
-	tb := test.NewTB(t)
+	tb := t
 
 	// The underlying FileReader buffers the file 4k bytes at a time. Ensure
 	// that we can skip multiple 4k chunks without ending up with a short read.
@@ -319,7 +249,7 @@ func TestDecbuf_SkipMultipleBufferReads(t *testing.T) {
 		bytes[i] = 0x01
 	}
 
-	runAllBufReaderTypes(tb, "", bytes, func(tb test.TB, dec Decbuf) {
+	runAllBufReaderTypes(tb, "", bytes, func(_ *testing.T, dec Decbuf) {
 		dec.Skip(4096 * 4)
 
 		require.NoError(t, dec.Err())
@@ -330,22 +260,22 @@ func TestDecbuf_SkipMultipleBufferReads(t *testing.T) {
 }
 
 func TestDecbuf_SkipInsufficientBuffer(t *testing.T) {
-	tb := test.NewTB(t)
-	runAllBufReaderTypes(tb, "", []byte{0x01}, func(tb test.TB, dec Decbuf) {
+	tb := t
+	runAllBufReaderTypes(tb, "", []byte{0x01}, func(_ *testing.T, dec Decbuf) {
 		dec.Skip(2)
 		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
 	})
 }
 
 func TestDecbuf_SkipUvarintBytesHappyPath(t *testing.T) {
-	tb := test.NewTB(t)
+	tb := t
 
 	expected := uint32(0x567890AB)
 	enc := promencoding.Encbuf{}
 	enc.PutUvarintBytes([]byte{0x12, 0x34})
 	enc.PutBE32(expected)
 
-	runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+	runAllBufReaderTypes(tb, "", enc.Get(), func(_ *testing.T, dec Decbuf) {
 		require.Equal(t, 7, dec.Len())
 		require.Equal(t, 0, dec.Offset())
 
@@ -361,12 +291,12 @@ func TestDecbuf_SkipUvarintBytesHappyPath(t *testing.T) {
 }
 
 func TestDecbuf_SkipUvarintBytesEndOfFile(t *testing.T) {
-	tb := test.NewTB(t)
+	tb := t
 
 	enc := promencoding.Encbuf{}
 	enc.PutBE32(0x12345678)
 
-	runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+	runAllBufReaderTypes(tb, "", enc.Get(), func(_ *testing.T, dec Decbuf) {
 		dec.Be32()
 		require.NoError(t, dec.Err())
 		require.Equal(t, 0, dec.Len())
@@ -378,14 +308,14 @@ func TestDecbuf_SkipUvarintBytesEndOfFile(t *testing.T) {
 }
 
 func TestDecbuf_SkipUvarintBytesOnlyHaveLength(t *testing.T) {
-	tb := test.NewTB(t)
+	tb := t
 
 	enc := promencoding.Encbuf{}
 	enc.PutUvarintBytes([]byte{0x12, 0x34})
 
 	bytes := enc.Get()
 
-	runAllBufReaderTypes(tb, "", bytes[:len(bytes)-2], func(tb test.TB, dec Decbuf) {
+	runAllBufReaderTypes(tb, "", bytes[:len(bytes)-2], func(_ *testing.T, dec Decbuf) {
 		require.Equal(t, 1, dec.Len())
 		require.Equal(t, 0, dec.Offset())
 
@@ -395,14 +325,14 @@ func TestDecbuf_SkipUvarintBytesOnlyHaveLength(t *testing.T) {
 }
 
 func TestDecbuf_SkipUvarintBytesPartialValue(t *testing.T) {
-	tb := test.NewTB(t)
+	tb := t
 
 	enc := promencoding.Encbuf{}
 	enc.PutUvarintBytes([]byte{0x12, 0x34})
 
 	bytes := enc.Get()
 
-	runAllBufReaderTypes(tb, "", bytes[:len(bytes)-1], func(tb test.TB, dec Decbuf) {
+	runAllBufReaderTypes(tb, "", bytes[:len(bytes)-1], func(_ *testing.T, dec Decbuf) {
 		require.Equal(t, 2, dec.Len())
 		require.Equal(t, 0, dec.Offset())
 
@@ -424,13 +354,13 @@ func TestDecbuf_UvarintHappyPath(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		tb := test.NewTB(t)
+		tb := t
 		caseName := strconv.Itoa(c.value)
 
 		enc := promencoding.Encbuf{}
 		enc.PutUvarint(c.value)
 
-		runAllBufReaderTypes(tb, caseName, enc.Get(), func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, caseName, enc.Get(), func(_ *testing.T, dec Decbuf) {
 			require.Equal(t, c.bytes, dec.Len())
 			require.Equal(t, 0, dec.Offset())
 
@@ -444,12 +374,12 @@ func TestDecbuf_UvarintHappyPath(t *testing.T) {
 }
 
 func TestDecbuf_UvarintInsufficientBuffer(t *testing.T) {
-	tb := test.NewTB(t)
+	tb := t
 
 	enc := promencoding.Encbuf{}
 	enc.PutUvarint(0xFFFF_FFFF)
 
-	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(tb test.TB, dec Decbuf) {
+	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(_ *testing.T, dec Decbuf) {
 		_ = dec.Uvarint()
 		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
 	})
@@ -464,12 +394,12 @@ func FuzzDecbuf_Uvarint(f *testing.F) {
 		if n < 0 {
 			t.Skip()
 		}
-		tb := test.NewTB(t)
+		tb := t
 
 		enc := promencoding.Encbuf{}
 		enc.PutUvarint(n)
 
-		runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, "", enc.Get(), func(_ *testing.T, dec Decbuf) {
 			require.NoError(t, dec.Err())
 			actual := dec.Uvarint()
 			require.NoError(t, dec.Err())
@@ -493,13 +423,13 @@ func TestDecbuf_Uvarint64HappyPath(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		tb := test.NewTB(t)
+		tb := t
 		caseName := strconv.FormatUint(c.value, 10)
 
 		enc := promencoding.Encbuf{}
 		enc.PutUvarint64(c.value)
 
-		runAllBufReaderTypes(tb, caseName, enc.Get(), func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, caseName, enc.Get(), func(_ *testing.T, dec Decbuf) {
 			require.Equal(t, c.bytes, dec.Len())
 			require.Equal(t, 0, dec.Offset())
 
@@ -513,12 +443,12 @@ func TestDecbuf_Uvarint64HappyPath(t *testing.T) {
 }
 
 func TestDecbuf_Uvarint64InsufficientBuffer(t *testing.T) {
-	tb := test.NewTB(t)
+	tb := t
 
 	enc := promencoding.Encbuf{}
 	enc.PutUvarint64(0xFFFF_FFFF)
 
-	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(tb test.TB, dec Decbuf) {
+	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(_ *testing.T, dec Decbuf) {
 		_ = dec.Uvarint64()
 		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
 	})
@@ -533,12 +463,12 @@ func FuzzDecbuf_Uvarint64(f *testing.F) {
 	f.Add(uint64(0xFFFF_FFFF_FFFF_FFFF))
 
 	f.Fuzz(func(t *testing.T, n uint64) {
-		tb := test.NewTB(t)
+		tb := t
 
 		enc := promencoding.Encbuf{}
 		enc.PutUvarint64(n)
 
-		runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, "", enc.Get(), func(_ *testing.T, dec Decbuf) {
 			require.NoError(t, dec.Err())
 			actual := dec.Uvarint64()
 			require.NoError(t, dec.Err())
@@ -562,19 +492,19 @@ func TestDecbuf_UnsafeUvarintBytesHappyPath(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		tb := test.NewTB(t)
+		tb := t
 
 		enc := promencoding.Encbuf{}
 		enc.PutUvarintBytes(c.value)
 
-		runAllBufReaderTypes(tb, c.name, enc.Get(), func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, c.name, enc.Get(), func(_ *testing.T, dec Decbuf) {
 			size := c.encodedSizeLength + len(c.value)
 			require.Equal(t, size, dec.Len())
 			require.Equal(t, 0, dec.Offset())
 
 			actual := dec.UnsafeUvarintBytes()
 			require.NoError(t, dec.Err())
-			require.Condition(t, test.EqualSlices(c.value, actual), "%#v != %#v", c.value, actual)
+			require.True(t, bytes.Equal(c.value, actual), "%#v != %#v", c.value, actual)
 			require.Equal(t, 0, dec.Len())
 			require.Equal(t, size, dec.Offset())
 		})
@@ -582,19 +512,19 @@ func TestDecbuf_UnsafeUvarintBytesHappyPath(t *testing.T) {
 }
 
 func TestDecbuf_UnsafeUvarintBytesInsufficientBuffer(t *testing.T) {
-	tb := test.NewTB(t)
+	tb := t
 
 	enc := promencoding.Encbuf{}
 	enc.PutUvarintBytes([]byte("123456"))
 
-	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(tb test.TB, dec Decbuf) {
+	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(_ *testing.T, dec Decbuf) {
 		_ = dec.UnsafeUvarintBytes()
 		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
 	})
 }
 
 func TestDecbuf_UnsafeUvarintBytesSkipDoesNotCauseBufferFill(t *testing.T) {
-	tb := test.NewTB(t)
+	tb := t
 	const (
 		expectedSlices = 32
 		expectedBytes  = 983
@@ -616,7 +546,7 @@ func TestDecbuf_UnsafeUvarintBytesSkipDoesNotCauseBufferFill(t *testing.T) {
 		enc.PutUvarintBytes(bytes)
 	}
 
-	runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+	runAllBufReaderTypes(tb, "", enc.Get(), func(_ *testing.T, dec Decbuf) {
 		for base := 0; base < expectedSlices; base++ {
 			bytes := dec.UnsafeUvarintBytes()
 
@@ -637,50 +567,18 @@ func FuzzDecbuf_UnsafeUvarintBytes(f *testing.F) {
 	f.Add([]byte("12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678"))
 
 	f.Fuzz(func(t *testing.T, b []byte) {
-		tb := test.NewTB(t)
+		tb := t
 
 		enc := promencoding.Encbuf{}
 		enc.PutUvarintBytes(b)
 
-		runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, "", enc.Get(), func(_ *testing.T, dec Decbuf) {
 			require.NoError(t, dec.Err())
 			actual := dec.UnsafeUvarintBytes()
 			require.NoError(t, dec.Err())
-			require.Condition(t, test.EqualSlices(b, actual), "%#v != %#v", b, actual)
+			require.True(t, bytes.Equal(b, actual), "%#v != %#v", b, actual)
 			require.Equal(t, 0, dec.Len())
 		})
-	})
-}
-
-func BenchmarkDecbuf_UnsafeUvarintBytes(t *testing.B) {
-	tb := test.NewTB(t)
-
-	// 127 bytes, the varint size will be 1 byte.
-	val := []byte("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567")
-	enc := promencoding.Encbuf{}
-	enc.PutUvarintBytes(val)
-
-	bytes := enc.Get()
-	byteCopy := append([]byte(nil), bytes...)
-
-	runAllBufReaderTypes(tb, "", byteCopy, func(tb test.TB, dec Decbuf) {
-		t.ResetTimer()
-
-		for i := 0; i < t.N; i++ {
-			b := dec.UnsafeUvarintBytes()
-			if err := dec.Err(); err != nil {
-				require.NoError(t, err)
-			}
-
-			if len(b) != len(val) {
-				require.Len(t, b, len(val))
-			}
-
-			dec.ResetAt(0)
-			if err := dec.Err(); err != nil {
-				require.NoError(t, err)
-			}
-		}
 	})
 }
 
@@ -697,12 +595,12 @@ func TestDecbuf_UvarintStrHappyPath(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		tb := test.NewTB(t)
+		tb := t
 
 		enc := promencoding.Encbuf{}
 		enc.PutUvarintStr(c.value)
 
-		runAllBufReaderTypes(tb, c.name, enc.Get(), func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, c.name, enc.Get(), func(_ *testing.T, dec Decbuf) {
 			size := c.encodedSizeLength + len(c.value)
 			require.Equal(t, size, dec.Len())
 			require.Equal(t, 0, dec.Offset())
@@ -717,12 +615,12 @@ func TestDecbuf_UvarintStrHappyPath(t *testing.T) {
 }
 
 func TestDecbuf_UvarintStrInsufficientBuffer(t *testing.T) {
-	tb := test.NewTB(t)
+	tb := t
 
 	enc := promencoding.Encbuf{}
 	enc.PutUvarintStr("123456")
 
-	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(tb test.TB, dec Decbuf) {
+	runAllBufReaderTypes(tb, "", enc.Get()[:2], func(_ *testing.T, dec Decbuf) {
 		_ = dec.UvarintStr()
 		require.ErrorIs(t, dec.Err(), ErrInvalidSize)
 	})
@@ -735,12 +633,12 @@ func FuzzDecbuf_UvarintStr(f *testing.F) {
 	f.Add("12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678")
 
 	f.Fuzz(func(t *testing.T, s string) {
-		tb := test.NewTB(t)
+		tb := t
 
 		enc := promencoding.Encbuf{}
 		enc.PutUvarintStr(s)
 
-		runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, "", enc.Get(), func(_ *testing.T, dec Decbuf) {
 			require.NoError(t, dec.Err())
 			actual := dec.UvarintStr()
 			require.NoError(t, dec.Err())
@@ -754,16 +652,16 @@ func TestDecbuf_Crc32(t *testing.T) {
 	table := crc32.MakeTable(crc32.Castagnoli)
 
 	t.Run("matches checksum (small buffer)", func(t *testing.T) {
-		tb := test.NewTB(t)
+		tb := t
 		bytes := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x4f, 0x4d, 0xfb, 0xab}
-		runAllBufReaderTypes(tb, "", bytes, func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, "", bytes, func(_ *testing.T, dec Decbuf) {
 			dec.CheckCrc32(table)
 			require.NoError(t, dec.Err())
 		})
 	})
 
 	t.Run("matches checksum (buffer larger than single read)", func(t *testing.T) {
-		tb := test.NewTB(t)
+		tb := t
 
 		bufferSize := 4*1024*1024 + 1
 		enc := promencoding.Encbuf{}
@@ -773,23 +671,23 @@ func TestDecbuf_Crc32(t *testing.T) {
 		}
 		enc.PutHash(crc32.New(crc32.MakeTable(crc32.Castagnoli)))
 
-		runAllBufReaderTypes(tb, "", enc.Get(), func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, "", enc.Get(), func(_ *testing.T, dec Decbuf) {
 			dec.CheckCrc32(table)
 			require.NoError(t, dec.Err())
 		})
 	})
 
 	t.Run("does not match checksum (small buffer)", func(t *testing.T) {
-		tb := test.NewTB(t)
+		tb := t
 
-		runAllBufReaderTypes(tb, "", []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x4f, 0x4d, 0xfb, 0xff}, func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, "", []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x4f, 0x4d, 0xfb, 0xff}, func(_ *testing.T, dec Decbuf) {
 			dec.CheckCrc32(table)
 			require.ErrorIs(t, dec.Err(), ErrInvalidChecksum)
 		})
 	})
 
 	t.Run("does not match checksum (buffer larger than single read)", func(t *testing.T) {
-		tb := test.NewTB(t)
+		tb := t
 
 		bufferSize := 4*1024*1024 + 1
 		enc := promencoding.Encbuf{}
@@ -801,70 +699,52 @@ func TestDecbuf_Crc32(t *testing.T) {
 		bytes := enc.Get()
 		bytes = append(bytes, 0x00, 0x01, 0x02, 0x03)
 
-		runAllBufReaderTypes(tb, "", bytes, func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, "", bytes, func(_ *testing.T, dec Decbuf) {
 			dec.CheckCrc32(table)
 			require.ErrorIs(t, dec.Err(), ErrInvalidChecksum)
 		})
 	})
 
 	t.Run("buffer only contains checksum", func(t *testing.T) {
-		tb := test.NewTB(t)
+		tb := t
 
-		runAllBufReaderTypes(tb, "", []byte{0x4f, 0x4d, 0xfb, 0xab}, func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, "", []byte{0x4f, 0x4d, 0xfb, 0xab}, func(_ *testing.T, dec Decbuf) {
 			dec.CheckCrc32(table)
 			require.ErrorIs(t, dec.Err(), ErrInvalidSize)
 		})
 	})
 
 	t.Run("buffer too short for checksum", func(t *testing.T) {
-		tb := test.NewTB(t)
+		tb := t
 
-		runAllBufReaderTypes(tb, "", []byte{0x4f, 0x4d, 0xfb}, func(tb test.TB, dec Decbuf) {
+		runAllBufReaderTypes(tb, "", []byte{0x4f, 0x4d, 0xfb}, func(_ *testing.T, dec Decbuf) {
 			dec.CheckCrc32(table)
 			require.ErrorIs(t, dec.Err(), ErrInvalidSize)
 		})
 	})
 }
 
-func runAllBufReaderTypes(tb test.TB, caseName string, bytes []byte, testFn func(tb test.TB, dec Decbuf)) {
-	dir := tb.TempDir()
+func runAllBufReaderTypes(t *testing.T, caseName string, bytes []byte, testFn func(t *testing.T, dec Decbuf)) {
+	dir := t.TempDir()
 	fileName := "test-file"
 	filePath := path.Join(dir, fileName)
-	require.NoError(tb, os.WriteFile(filePath, bytes, 0700))
+	require.NoError(t, os.WriteFile(filePath, bytes, 0700))
 
 	reg := prometheus.WrapRegistererWithPrefix("indexheader_", prometheus.NewPedanticRegistry())
 	diskFactory := NewFilePoolDecbufFactory(filePath, 0, filepool.NewFilePoolMetrics(reg))
-	tb.Cleanup(func() {
+	t.Cleanup(func() {
 		_ = diskFactory.Close()
 	})
 	diskDecBuf := diskFactory.NewRawDecbuf(context.Background())
-	require.NoError(tb, diskDecBuf.Err())
+	require.NoError(t, diskDecBuf.Err())
 
-	bkt, err := filesystem.NewBucket(dir)
-	require.NoError(tb, err)
-	instBkt := objstore.WithNoopInstr(bkt)
-	tb.Cleanup(func() {
-		require.NoError(tb, bkt.Close())
+	name := caseName
+	if len(name) > 0 {
+		name += "/"
+	}
+	name += fmt.Sprintf("BufReader=%s", "disk")
+
+	t.Run(name, func(t *testing.T) {
+		testFn(t, diskDecBuf)
 	})
-	bucketFactory := NewBucketDecbufFactory(instBkt, fileName)
-	bucketDecBuf := bucketFactory.NewRawDecbuf(context.Background())
-	require.NoError(tb, bucketDecBuf.Err())
-
-	decbufs := map[string]Decbuf{
-		"disk":   diskDecBuf,
-		"bucket": bucketDecBuf,
-	}
-
-	for decbufName, decbuf := range decbufs {
-		name := caseName
-		if len(name) > 0 {
-			name += "/"
-		}
-		name += fmt.Sprintf("BufReader=%s", decbufName)
-
-		tb.Run(name, func(tb test.TB) {
-
-			testFn(tb, decbuf)
-		})
-	}
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/factory.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/factory.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: AGPL-3.0-only
 // Provenance-includes-copyright: The Grafana Mimir Authors.
 
-package encoding
+package streamenc
 
 import (
 	"context"

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/factory.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/factory.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/grafana/mimir/blob/main/pkg/storage/indexheader/encoding/factory.go
+// Provenance-includes-license: AGPL-3.0-only
+// Provenance-includes-copyright: The Grafana Mimir Authors.
+
+package encoding
+
+import (
+	"context"
+	"hash/crc32"
+)
+
+const (
+	numLenBytes = 4 // Index sections use a 4-byte big-endian uint32 to mark the byte length of the section.
+)
+
+type DecbufFactory interface {
+	// NewDecbufAtChecked returns a new binary decoding reader positioned at offset + 4 bytes.
+	// It expects the first 4 bytes after offset to hold the big-endian-encoded content length,
+	// followed by the contents and the expected checksum.
+	// This method MUST check the CRC of the content and return an errored Decbuf if validation fails.
+	NewDecbufAtChecked(ctx context.Context, offset int, table *crc32.Table) Decbuf
+
+	// NewDecbufAtUnchecked returns a new binary decoding reader positioned at offset + 4 bytes.
+	// It expects the first 4 bytes after offset to hold the big endian encoded content length,
+	// followed by the contents and the expected checksum.
+	// This method MUST NOT validate or compute the CRC of the content.
+	// To check the CRC of the content, use NewDecbufAtChecked.
+	NewDecbufAtUnchecked(ctx context.Context, offset int) Decbuf
+
+	// NewRawDecbuf returns a new binary decoding reader positioned at the beginning of the underlying data,
+	// and spanning the entire length of the data segment.
+	// It MUST NOT make any assumptions about the layout of the underlying data w.r.t checksums, TOC, etc.
+	// and it MUST NOT validate or compute the CRC of the content.
+	// To create a binary decoding reader for some subset of the data or to perform integrity checks,
+	// use NewDecbufAtUnchecked or NewDecbufAtChecked.
+	NewRawDecbuf(ctx context.Context) Decbuf
+
+	// NewDecbufInSection returns a new binary decoding reader positioned at tableOffset + sectionStartOffset,
+	// spanning to tableOffset+sectionEndOffset or the end of the table, whichever comes first.
+	// Reading from a section of the table rather than the whole table allows the reader to leverage
+	// shorter read operations, which can improve read latency and cache efficiency (if caching these reads).
+	// It expects the first 4 bytes after tableOffset to hold the big-endian encoded content length.
+	// This method MUST NOT validate or compute the CRC of the content.
+	NewDecbufInSection(ctx context.Context, tableOffset, sectionStartOffset, sectionEndOffset int) Decbuf
+
+	Close() error
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/factory_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/factory_test.go
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/grafana/mimir/blob/main/pkg/storage/indexheader/encoding/factory_test.go
+// Provenance-includes-license: AGPL-3.0-only
+// Provenance-includes-copyright: The Grafana Mimir Authors.
+
+package encoding
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	promencoding "github.com/prometheus/prometheus/tsdb/encoding"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/objstore/providers/filesystem"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/filepool"
+)
+
+const testContentSize = 4096
+
+var table = crc32.MakeTable(crc32.Castagnoli)
+
+func BenchmarkDecbufFactory_NewDecbufAtUnchecked(b *testing.B) {
+	enc := createTestEncoder(testContentSize)
+	enc.PutHash(crc32.New(table))
+
+	diskFactory, bucketFactory := createDecbufFactoriesWithBytes(b, 1, testContentSize, enc)
+	factories := map[string]DecbufFactory{
+		"disk":   diskFactory,
+		"bucket": bucketFactory,
+	}
+	b.ResetTimer()
+
+	for factoryName, factory := range factories {
+		b.Run(fmt.Sprintf("DecbufFactory=%s", factoryName), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				d := factory.NewDecbufAtUnchecked(context.Background(), 0)
+
+				if err := d.Err(); err != nil {
+					require.NoError(b, err)
+				}
+
+				if err := d.Close(); err != nil {
+					require.NoError(b, err)
+				}
+			}
+		})
+	}
+}
+
+func TestDecbufFactory_NewDecbufAtChecked_InvalidCRC(t *testing.T) {
+	enc := createTestEncoder(testContentSize)
+	enc.PutBytes([]byte{0, 0, 0, 0})
+
+	testDecbufFactory(t, testContentSize, enc, true, true, func(t *testing.T, factory DecbufFactory) {
+		d := factory.NewDecbufAtChecked(context.Background(), 0, table)
+		t.Cleanup(func() {
+			require.NoError(t, d.Close())
+		})
+
+		require.ErrorIs(t, d.Err(), ErrInvalidChecksum)
+	})
+}
+
+func TestDecbufFactory_NewDecbufAtChecked_InvalidLength(t *testing.T) {
+	enc := createTestEncoder(testContentSize)
+	enc.PutHash(crc32.New(table))
+
+	testDecbufFactory(t, testContentSize+1000, enc, true, true, func(t *testing.T, factory DecbufFactory) {
+		d := factory.NewDecbufAtChecked(context.Background(), 0, table)
+		t.Cleanup(func() {
+			require.NoError(t, d.Close())
+		})
+
+		require.ErrorIs(t, d.Err(), ErrInvalidSize)
+	})
+}
+
+func TestDecbufFactory_NewDecbufAtChecked_HappyPath(t *testing.T) {
+	enc := createTestEncoder(testContentSize)
+	enc.PutHash(crc32.New(table))
+
+	testDecbufFactory(t, testContentSize, enc, true, true, func(t *testing.T, factory DecbufFactory) {
+		d := factory.NewDecbufAtChecked(context.Background(), 0, table)
+		t.Cleanup(func() {
+			require.NoError(t, d.Close())
+		})
+
+		require.NoError(t, d.Err())
+		require.Equal(t, testContentSize+crc32.Size, d.Len())
+	})
+}
+
+func TestDecbufFactory_NewDecbufAtChecked_MultipleInstances(t *testing.T) {
+	enc := createTestEncoder(testContentSize)
+	enc.PutHash(crc32.New(table))
+
+	// Note that we create the factory ourselves instead of using testDecbufFactory because
+	// we only want to test the case where file handles are pooled and hence will be reused
+	// between different Decbuf instances; bucket-based factory is also not tested here.
+	factory, _ := createDecbufFactoriesWithBytes(t, 1, testContentSize, enc)
+	t.Cleanup(func() {
+		_ = factory.Close()
+	})
+
+	d1 := factory.NewDecbufAtChecked(context.Background(), 0, table)
+	require.NoError(t, d1.Err())
+	fr1, ok := d1.r.(*FileReader)
+	require.True(t, ok, "expected FileReader")
+	fd1 := fr1.file.Fd()
+	require.NoError(t, d1.Close())
+
+	d2 := factory.NewDecbufAtChecked(context.Background(), 0, table)
+	require.NoError(t, d2.Err())
+	fr2, ok := d2.r.(*FileReader)
+	require.True(t, ok, "expected FileReader")
+	fd2 := fr2.file.Fd()
+	require.NoError(t, d2.Close())
+
+	require.Equal(t, fd1, fd2, "expected Decbuf instances to use the same file descriptor")
+}
+
+func TestDecbufFactory_NewDecbufAtChecked_Concurrent(t *testing.T) {
+	enc := createTestEncoder(testContentSize)
+	enc.PutHash(crc32.New(table))
+
+	const (
+		runs        = 100
+		concurrency = 10
+	)
+
+	testDecbufFactory(t, testContentSize, enc, true, true, func(t *testing.T, factory DecbufFactory) {
+		g, ctx := errgroup.WithContext(context.Background())
+
+		for i := 0; i < concurrency; i++ {
+			g.Go(func() error {
+				for run := 0; run < runs; run++ {
+					d := factory.NewDecbufAtChecked(ctx, 0, table)
+
+					if err := d.Err(); err != nil {
+						_ = d.Close()
+						return err
+					}
+
+					if err := d.Close(); err != nil {
+						return err
+					}
+				}
+
+				return nil
+			})
+		}
+
+		require.NoError(t, g.Wait())
+	})
+}
+
+func TestDecbufFactory_NewDecbufAtUnchecked_HappyPath(t *testing.T) {
+	enc := createTestEncoder(testContentSize)
+	enc.PutHash(crc32.New(table))
+
+	testDecbufFactory(t, testContentSize, enc, true, true, func(t *testing.T, factory DecbufFactory) {
+		d := factory.NewDecbufAtUnchecked(context.Background(), 0)
+		t.Cleanup(func() {
+			require.NoError(t, d.Close())
+		})
+
+		require.NoError(t, d.Err())
+		require.Equal(t, testContentSize+crc32.Size, d.Len())
+	})
+}
+
+func TestDecbufFactory_NewDecbufRaw_HappyPath(t *testing.T) {
+	enc := createTestEncoder(testContentSize)
+	enc.PutHash(crc32.New(table))
+
+	testDecbufFactory(t, testContentSize, enc, true, true, func(t *testing.T, factory DecbufFactory) {
+		d := factory.NewRawDecbuf(context.Background())
+		t.Cleanup(func() {
+			require.NoError(t, d.Close())
+		})
+
+		require.NoError(t, d.Err())
+		require.Equal(t, 4+testContentSize+crc32.Size, d.Len())
+	})
+}
+
+// TestDecbufFactory_NewDecbufInSection_HappyPath tests that creating a new Decbuf for a table section
+// starts the reader in the correct place by placing a test byte at the expected start offset.
+func TestDecbufFactory_NewDecbufInSection_HappyPath(t *testing.T) {
+	testByte := byte(0x02)
+	startOffset := 10
+	endOffset := 25
+	enc := createTestEncoderWithTestByte(testContentSize, startOffset-numLenBytes, testByte)
+	enc.PutHash(crc32.New(table))
+
+	testDisk := false // NewDecbufInSection is currently only implemented for BucketDecbufFactory
+	testDecbufFactory(t, testContentSize, enc, testDisk, true, func(t *testing.T, factory DecbufFactory) {
+		d := factory.NewDecbufInSection(context.Background(), 0, startOffset, endOffset)
+		t.Cleanup(func() {
+			require.NoError(t, d.Close())
+		})
+		require.NoError(t, d.Err())
+		require.Equal(t, endOffset-startOffset, d.Len())
+		// Make sure our start offset is placed where we expected by reading the first byte
+		require.Equal(t, testByte, d.Byte())
+	})
+}
+
+// TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeyondTableLength tests that calling NewDecbufInSection
+// with an end offset beyond the end of the table produces a Decbuf that ends at the end of the table.
+func TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeyondTableLength(t *testing.T) {
+	testByte := byte(0x02)
+	enc := createTestEncoderWithTestByte(testContentSize, 10-numLenBytes, testByte)
+	enc.PutHash(crc32.New(table))
+
+	testDisk := false // NewDecbufInSection is currently only implemented for BucketDecbufFactory
+	testDecbufFactory(t, testContentSize, enc, testDisk, true, func(t *testing.T, factory DecbufFactory) {
+		d := factory.NewDecbufInSection(context.Background(), 0, 10, testContentSize+1000)
+		t.Cleanup(func() {
+			require.NoError(t, d.Close())
+		})
+		require.NoError(t, d.Err())
+		require.Equal(t, testContentSize+numLenBytes-10, d.Len())
+		require.Equal(t, testByte, d.Byte())
+	})
+}
+
+// TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeforeStartOffset tests that attempting to call NewDecbufInSection
+// with an end offset before the start offset returns an error.
+func TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeforeStartOffset(t *testing.T) {
+	enc := createTestEncoder(testContentSize)
+	enc.PutHash(crc32.New(table))
+
+	testDisk := false // NewDecbufInSection is currently only implemented for BucketDecbufFactory
+	testDecbufFactory(t, testContentSize, enc, testDisk, true, func(t *testing.T, factory DecbufFactory) {
+		d := factory.NewDecbufInSection(context.Background(), 0, 2500, 30)
+		t.Cleanup(func() {
+			require.NoError(t, d.Close())
+		})
+		require.Error(t, d.Err())
+	})
+}
+
+func TestDecbufFactory_Stop(t *testing.T) {
+	enc := createTestEncoder(testContentSize)
+	enc.PutHash(crc32.New(table))
+
+	testBucket := false // bucket-based factory does not do anything on close and will not error
+	testDecbufFactory(t, testContentSize, enc, true, testBucket, func(t *testing.T, factory DecbufFactory) {
+		require.NoError(t, factory.Close())
+
+		d := factory.NewRawDecbuf(context.Background())
+		t.Cleanup(func() {
+			require.NoError(t, d.Close())
+		})
+
+		require.ErrorIs(t, d.Err(), filepool.ErrPoolStopped)
+	})
+}
+
+func testDecbufFactory(
+	t *testing.T,
+	len int,
+	enc promencoding.Encbuf,
+	testDisk bool,
+	testBucket bool,
+	test func(t *testing.T, factory DecbufFactory),
+) {
+	if testDisk {
+		t.Run("DecbufFactory=Disk-Pooled", func(t *testing.T) {
+			diskFactory, _ := createDecbufFactoriesWithBytes(t, 1, len, enc)
+			test(t, diskFactory)
+		})
+
+		t.Run("DecbufFactory=Disk-NoPool", func(t *testing.T) {
+			diskFactory, _ := createDecbufFactoriesWithBytes(t, 0, len, enc)
+			test(t, diskFactory)
+		})
+	}
+
+	if testBucket {
+		t.Run("DecbufFactory=Bucket", func(t *testing.T) {
+			_, bucketFactory := createDecbufFactoriesWithBytes(t, 0, len, enc)
+			test(t, bucketFactory)
+		})
+	}
+
+}
+
+func createTestEncoderWithTestByte(numBytes, testByteOffset int, testByte byte) promencoding.Encbuf {
+	enc := promencoding.Encbuf{}
+
+	for i := 0; i < testByteOffset; i++ {
+		enc.PutByte(0x01)
+	}
+	enc.PutByte(testByte)
+	for i := testByteOffset + 1; i < numBytes; i++ {
+		enc.PutByte(0x01)
+	}
+	return enc
+}
+
+func createTestEncoder(numBytes int) promencoding.Encbuf {
+	enc := promencoding.Encbuf{}
+
+	for i := 0; i < numBytes; i++ {
+		enc.PutByte(0x01)
+	}
+
+	return enc
+}
+
+func createDecbufFactoriesWithBytes(t testing.TB, filePoolSize uint, len int, enc promencoding.Encbuf) (*FilePoolDecbufFactory, *BucketDecbufFactory) {
+	// Prepend the contents of the buffer with the length of the content portion
+	// which does not include the trailing 4 bytes for a CRC 32.
+	lenBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(lenBytes, uint32(len))
+	bytes := append(lenBytes, enc.Get()...)
+
+	dir := t.TempDir()
+	fileName := "test-file"
+	filePath := path.Join(dir, fileName)
+	require.NoError(t, os.WriteFile(filePath, bytes, 0700))
+
+	reg := prometheus.NewPedanticRegistry()
+	diskFactory := NewFilePoolDecbufFactory(filePath, filePoolSize, filepool.NewFilePoolMetrics(reg))
+	t.Cleanup(func() {
+		_ = diskFactory.Close()
+	})
+
+	bkt, err := filesystem.NewBucket(dir)
+	require.NoError(t, err)
+	instBkt := objstore.WithNoopInstr(bkt)
+	t.Cleanup(func() {
+		require.NoError(t, bkt.Close())
+	})
+	bucketFactory := NewBucketDecbufFactory(instBkt, fileName)
+
+	return diskFactory, bucketFactory
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/factory_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/factory_test.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: AGPL-3.0-only
 // Provenance-includes-copyright: The Grafana Mimir Authors.
 
-package encoding
+package streamenc
 
 import (
 	"context"
@@ -17,8 +17,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	promencoding "github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/stretchr/testify/require"
-	"github.com/thanos-io/objstore"
-	"github.com/thanos-io/objstore/providers/filesystem"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/filepool"
@@ -32,10 +30,9 @@ func BenchmarkDecbufFactory_NewDecbufAtUnchecked(b *testing.B) {
 	enc := createTestEncoder(testContentSize)
 	enc.PutHash(crc32.New(table))
 
-	diskFactory, bucketFactory := createDecbufFactoriesWithBytes(b, 1, testContentSize, enc)
+	diskFactory := createDecbufFactoryWithBytes(b, 1, testContentSize, enc)
 	factories := map[string]DecbufFactory{
-		"disk":   diskFactory,
-		"bucket": bucketFactory,
+		"disk": diskFactory,
 	}
 	b.ResetTimer()
 
@@ -60,7 +57,7 @@ func TestDecbufFactory_NewDecbufAtChecked_InvalidCRC(t *testing.T) {
 	enc := createTestEncoder(testContentSize)
 	enc.PutBytes([]byte{0, 0, 0, 0})
 
-	testDecbufFactory(t, testContentSize, enc, true, true, func(t *testing.T, factory DecbufFactory) {
+	testDecbufFactory(t, testContentSize, enc, func(t *testing.T, factory DecbufFactory) {
 		d := factory.NewDecbufAtChecked(context.Background(), 0, table)
 		t.Cleanup(func() {
 			require.NoError(t, d.Close())
@@ -74,7 +71,7 @@ func TestDecbufFactory_NewDecbufAtChecked_InvalidLength(t *testing.T) {
 	enc := createTestEncoder(testContentSize)
 	enc.PutHash(crc32.New(table))
 
-	testDecbufFactory(t, testContentSize+1000, enc, true, true, func(t *testing.T, factory DecbufFactory) {
+	testDecbufFactory(t, testContentSize+1000, enc, func(t *testing.T, factory DecbufFactory) {
 		d := factory.NewDecbufAtChecked(context.Background(), 0, table)
 		t.Cleanup(func() {
 			require.NoError(t, d.Close())
@@ -88,7 +85,7 @@ func TestDecbufFactory_NewDecbufAtChecked_HappyPath(t *testing.T) {
 	enc := createTestEncoder(testContentSize)
 	enc.PutHash(crc32.New(table))
 
-	testDecbufFactory(t, testContentSize, enc, true, true, func(t *testing.T, factory DecbufFactory) {
+	testDecbufFactory(t, testContentSize, enc, func(t *testing.T, factory DecbufFactory) {
 		d := factory.NewDecbufAtChecked(context.Background(), 0, table)
 		t.Cleanup(func() {
 			require.NoError(t, d.Close())
@@ -105,8 +102,8 @@ func TestDecbufFactory_NewDecbufAtChecked_MultipleInstances(t *testing.T) {
 
 	// Note that we create the factory ourselves instead of using testDecbufFactory because
 	// we only want to test the case where file handles are pooled and hence will be reused
-	// between different Decbuf instances; bucket-based factory is also not tested here.
-	factory, _ := createDecbufFactoriesWithBytes(t, 1, testContentSize, enc)
+	// between different Decbuf instances.
+	factory := createDecbufFactoryWithBytes(t, 1, testContentSize, enc)
 	t.Cleanup(func() {
 		_ = factory.Close()
 	})
@@ -137,7 +134,7 @@ func TestDecbufFactory_NewDecbufAtChecked_Concurrent(t *testing.T) {
 		concurrency = 10
 	)
 
-	testDecbufFactory(t, testContentSize, enc, true, true, func(t *testing.T, factory DecbufFactory) {
+	testDecbufFactory(t, testContentSize, enc, func(t *testing.T, factory DecbufFactory) {
 		g, ctx := errgroup.WithContext(context.Background())
 
 		for i := 0; i < concurrency; i++ {
@@ -167,7 +164,7 @@ func TestDecbufFactory_NewDecbufAtUnchecked_HappyPath(t *testing.T) {
 	enc := createTestEncoder(testContentSize)
 	enc.PutHash(crc32.New(table))
 
-	testDecbufFactory(t, testContentSize, enc, true, true, func(t *testing.T, factory DecbufFactory) {
+	testDecbufFactory(t, testContentSize, enc, func(t *testing.T, factory DecbufFactory) {
 		d := factory.NewDecbufAtUnchecked(context.Background(), 0)
 		t.Cleanup(func() {
 			require.NoError(t, d.Close())
@@ -182,7 +179,7 @@ func TestDecbufFactory_NewDecbufRaw_HappyPath(t *testing.T) {
 	enc := createTestEncoder(testContentSize)
 	enc.PutHash(crc32.New(table))
 
-	testDecbufFactory(t, testContentSize, enc, true, true, func(t *testing.T, factory DecbufFactory) {
+	testDecbufFactory(t, testContentSize, enc, func(t *testing.T, factory DecbufFactory) {
 		d := factory.NewRawDecbuf(context.Background())
 		t.Cleanup(func() {
 			require.NoError(t, d.Close())
@@ -193,69 +190,11 @@ func TestDecbufFactory_NewDecbufRaw_HappyPath(t *testing.T) {
 	})
 }
 
-// TestDecbufFactory_NewDecbufInSection_HappyPath tests that creating a new Decbuf for a table section
-// starts the reader in the correct place by placing a test byte at the expected start offset.
-func TestDecbufFactory_NewDecbufInSection_HappyPath(t *testing.T) {
-	testByte := byte(0x02)
-	startOffset := 10
-	endOffset := 25
-	enc := createTestEncoderWithTestByte(testContentSize, startOffset-numLenBytes, testByte)
-	enc.PutHash(crc32.New(table))
-
-	testDisk := false // NewDecbufInSection is currently only implemented for BucketDecbufFactory
-	testDecbufFactory(t, testContentSize, enc, testDisk, true, func(t *testing.T, factory DecbufFactory) {
-		d := factory.NewDecbufInSection(context.Background(), 0, startOffset, endOffset)
-		t.Cleanup(func() {
-			require.NoError(t, d.Close())
-		})
-		require.NoError(t, d.Err())
-		require.Equal(t, endOffset-startOffset, d.Len())
-		// Make sure our start offset is placed where we expected by reading the first byte
-		require.Equal(t, testByte, d.Byte())
-	})
-}
-
-// TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeyondTableLength tests that calling NewDecbufInSection
-// with an end offset beyond the end of the table produces a Decbuf that ends at the end of the table.
-func TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeyondTableLength(t *testing.T) {
-	testByte := byte(0x02)
-	enc := createTestEncoderWithTestByte(testContentSize, 10-numLenBytes, testByte)
-	enc.PutHash(crc32.New(table))
-
-	testDisk := false // NewDecbufInSection is currently only implemented for BucketDecbufFactory
-	testDecbufFactory(t, testContentSize, enc, testDisk, true, func(t *testing.T, factory DecbufFactory) {
-		d := factory.NewDecbufInSection(context.Background(), 0, 10, testContentSize+1000)
-		t.Cleanup(func() {
-			require.NoError(t, d.Close())
-		})
-		require.NoError(t, d.Err())
-		require.Equal(t, testContentSize+numLenBytes-10, d.Len())
-		require.Equal(t, testByte, d.Byte())
-	})
-}
-
-// TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeforeStartOffset tests that attempting to call NewDecbufInSection
-// with an end offset before the start offset returns an error.
-func TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeforeStartOffset(t *testing.T) {
-	enc := createTestEncoder(testContentSize)
-	enc.PutHash(crc32.New(table))
-
-	testDisk := false // NewDecbufInSection is currently only implemented for BucketDecbufFactory
-	testDecbufFactory(t, testContentSize, enc, testDisk, true, func(t *testing.T, factory DecbufFactory) {
-		d := factory.NewDecbufInSection(context.Background(), 0, 2500, 30)
-		t.Cleanup(func() {
-			require.NoError(t, d.Close())
-		})
-		require.Error(t, d.Err())
-	})
-}
-
 func TestDecbufFactory_Stop(t *testing.T) {
 	enc := createTestEncoder(testContentSize)
 	enc.PutHash(crc32.New(table))
 
-	testBucket := false // bucket-based factory does not do anything on close and will not error
-	testDecbufFactory(t, testContentSize, enc, true, testBucket, func(t *testing.T, factory DecbufFactory) {
+	testDecbufFactory(t, testContentSize, enc, func(t *testing.T, factory DecbufFactory) {
 		require.NoError(t, factory.Close())
 
 		d := factory.NewRawDecbuf(context.Background())
@@ -269,44 +208,19 @@ func TestDecbufFactory_Stop(t *testing.T) {
 
 func testDecbufFactory(
 	t *testing.T,
-	len int,
+	length int,
 	enc promencoding.Encbuf,
-	testDisk bool,
-	testBucket bool,
 	test func(t *testing.T, factory DecbufFactory),
 ) {
-	if testDisk {
-		t.Run("DecbufFactory=Disk-Pooled", func(t *testing.T) {
-			diskFactory, _ := createDecbufFactoriesWithBytes(t, 1, len, enc)
-			test(t, diskFactory)
-		})
+	t.Run("DecbufFactory=Disk-Pooled", func(t *testing.T) {
+		diskFactory := createDecbufFactoryWithBytes(t, 1, length, enc)
+		test(t, diskFactory)
+	})
 
-		t.Run("DecbufFactory=Disk-NoPool", func(t *testing.T) {
-			diskFactory, _ := createDecbufFactoriesWithBytes(t, 0, len, enc)
-			test(t, diskFactory)
-		})
-	}
-
-	if testBucket {
-		t.Run("DecbufFactory=Bucket", func(t *testing.T) {
-			_, bucketFactory := createDecbufFactoriesWithBytes(t, 0, len, enc)
-			test(t, bucketFactory)
-		})
-	}
-
-}
-
-func createTestEncoderWithTestByte(numBytes, testByteOffset int, testByte byte) promencoding.Encbuf {
-	enc := promencoding.Encbuf{}
-
-	for i := 0; i < testByteOffset; i++ {
-		enc.PutByte(0x01)
-	}
-	enc.PutByte(testByte)
-	for i := testByteOffset + 1; i < numBytes; i++ {
-		enc.PutByte(0x01)
-	}
-	return enc
+	t.Run("DecbufFactory=Disk-NoPool", func(t *testing.T) {
+		diskFactory := createDecbufFactoryWithBytes(t, 0, length, enc)
+		test(t, diskFactory)
+	})
 }
 
 func createTestEncoder(numBytes int) promencoding.Encbuf {
@@ -319,11 +233,11 @@ func createTestEncoder(numBytes int) promencoding.Encbuf {
 	return enc
 }
 
-func createDecbufFactoriesWithBytes(t testing.TB, filePoolSize uint, len int, enc promencoding.Encbuf) (*FilePoolDecbufFactory, *BucketDecbufFactory) {
+func createDecbufFactoryWithBytes(t testing.TB, filePoolSize uint, length int, enc promencoding.Encbuf) *FilePoolDecbufFactory {
 	// Prepend the contents of the buffer with the length of the content portion
 	// which does not include the trailing 4 bytes for a CRC 32.
 	lenBytes := make([]byte, 4)
-	binary.BigEndian.PutUint32(lenBytes, uint32(len))
+	binary.BigEndian.PutUint32(lenBytes, uint32(length))
 	bytes := append(lenBytes, enc.Get()...)
 
 	dir := t.TempDir()
@@ -337,13 +251,5 @@ func createDecbufFactoriesWithBytes(t testing.TB, filePoolSize uint, len int, en
 		_ = diskFactory.Close()
 	})
 
-	bkt, err := filesystem.NewBucket(dir)
-	require.NoError(t, err)
-	instBkt := objstore.WithNoopInstr(bkt)
-	t.Cleanup(func() {
-		require.NoError(t, bkt.Close())
-	})
-	bucketFactory := NewBucketDecbufFactory(instBkt, fileName)
-
-	return diskFactory, bucketFactory
+	return diskFactory
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_factory.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_factory.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: AGPL-3.0-only
 // Provenance-includes-copyright: The Grafana Mimir Authors.
 
-package encoding
+package streamenc
 
 import (
 	"context"

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_factory.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_factory.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/grafana/mimir/blob/main/pkg/storage/indexheader/encoding/file_factory.go
+// Provenance-includes-license: AGPL-3.0-only
+// Provenance-includes-copyright: The Grafana Mimir Authors.
+
+package encoding
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+
+	"github.com/pkg/errors"
+
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/filepool"
+)
+
+// FilePoolDecbufFactory creates new file-backed Decbuf instances
+// for a specific index-header file on local disk.
+type FilePoolDecbufFactory struct {
+	files *filepool.FilePool
+}
+
+func NewFilePoolDecbufFactory(
+	path string,
+	maxIdleFileHandles uint,
+	metrics *filepool.FilePoolMetrics,
+) *FilePoolDecbufFactory {
+	return &FilePoolDecbufFactory{
+		files: filepool.NewFilePool(
+			path,
+			maxIdleFileHandles,
+			metrics,
+		),
+	}
+}
+
+func (df *FilePoolDecbufFactory) NewDecbufAtChecked(_ context.Context, offset int, table *crc32.Table) Decbuf {
+	f, err := df.files.Get()
+	if err != nil {
+		return Decbuf{E: errors.Wrap(err, "open file for decbuf")}
+	}
+
+	// If we return early and don't include a BufReader for our Decbuf, we are responsible
+	// for putting the file handle back in the pool.
+	closeFile := true
+	defer func() {
+		if closeFile {
+			_ = df.files.Put(f)
+		}
+	}()
+
+	// TODO: A particular index-header only has symbols and posting offsets. We should only need to read
+	//  the length of each of those a single time per index-header (DecbufFactory). Should the factory
+	//  cache the length? Should the table of contents be passed to the factory?
+	lengthBytes := make([]byte, numLenBytes)
+	n, err := f.ReadAt(lengthBytes, int64(offset))
+	if err != nil {
+		return Decbuf{E: err}
+	}
+	if n != numLenBytes {
+		return Decbuf{E: errors.Wrapf(ErrInvalidSize, "insufficient bytes read for size (got %d, wanted %d)", n, numLenBytes)}
+	}
+
+	contentLength := int(binary.BigEndian.Uint32(lengthBytes))
+	bufferLength := len(lengthBytes) + contentLength + crc32.Size
+	r, err := NewFileReader(f, offset, bufferLength, df.files)
+	if err != nil {
+		return Decbuf{E: errors.Wrap(err, "create file reader")}
+	}
+
+	closeFile = false
+	d := Decbuf{r: r}
+
+	if d.ResetAt(numLenBytes); d.Err() != nil {
+		return d
+	}
+
+	if table != nil {
+		if d.CheckCrc32(table); d.Err() != nil {
+			return d
+		}
+
+		// reset to the beginning of the content after reading it all for the CRC.
+		d.ResetAt(numLenBytes)
+	}
+
+	return d
+}
+
+func (df *FilePoolDecbufFactory) NewDecbufAtUnchecked(ctx context.Context, offset int) Decbuf {
+	return df.NewDecbufAtChecked(ctx, offset, nil)
+}
+
+func (df *FilePoolDecbufFactory) NewDecbufInSection(_ context.Context, _, _, _ int) Decbuf {
+	return Decbuf{E: fmt.Errorf("NewDecbufInSection not implemented for FilePoolDecbufFactory")}
+}
+
+func (df *FilePoolDecbufFactory) NewRawDecbuf(_ context.Context) Decbuf {
+	f, err := df.files.Get()
+	if err != nil {
+		return Decbuf{E: errors.Wrap(err, "open file for decbuf")}
+	}
+
+	// If we return early and don't include a BufReader for our Decbuf, we are responsible
+	// for putting the file handle back in the pool.
+	closeFile := true
+	defer func() {
+		if closeFile {
+			_ = df.files.Put(f)
+		}
+	}()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return Decbuf{E: errors.Wrap(err, "stat file for decbuf")}
+	}
+
+	fileSize := stat.Size()
+	reader, err := NewFileReader(f, 0, int(fileSize), df.files)
+	if err != nil {
+		return Decbuf{E: errors.Wrap(err, "file reader for decbuf")}
+	}
+
+	closeFile = false
+	return Decbuf{r: reader}
+}
+
+// Close cleans up resources associated with this DecbufFactory
+func (df *FilePoolDecbufFactory) Close() error {
+	df.files.Stop()
+	return nil
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_reader.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/grafana/mimir/blob/main/pkg/storage/indexheader/encoding/file_reader.go
+// Provenance-includes-license: AGPL-3.0-only
+// Provenance-includes-copyright: The Grafana Mimir Authors.
+
+package encoding
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/filepool"
+)
+
+// readerBufferSize is the size of the buffer used for reading index-header files. This
+// value is arbitrary and will likely change in the future based on profiling results.
+const readerBufferSize = 4096
+
+type FileReader struct {
+	file   *os.File
+	closer filepool.FilePoolCloser
+	buf    *bufio.Reader
+	base   int
+	length int
+	off    int
+}
+
+var bufferPool = sync.Pool{
+	New: func() any {
+		return bufio.NewReaderSize(nil, readerBufferSize)
+	},
+}
+
+// NewFileReader creates a new FileReader for the segment of file beginning at base bytes,
+// extending length bytes, and closing the handle with closer.
+func NewFileReader(file *os.File, base, length int, closer filepool.FilePoolCloser) (*FileReader, error) {
+	f := &FileReader{
+		file:   file,
+		closer: closer,
+		buf:    bufferPool.Get().(*bufio.Reader),
+		base:   base,
+		length: length,
+	}
+
+	err := f.Reset()
+	if err != nil {
+		return nil, err
+	}
+
+	return f, nil
+}
+
+func (f *FileReader) Reset() error {
+	return f.ResetAt(0)
+}
+
+func (f *FileReader) ResetAt(off int) error {
+	if off > f.length {
+		return ErrInvalidSize
+	}
+
+	_, err := f.file.Seek(int64(f.base+off), io.SeekStart)
+	if err != nil {
+		return err
+	}
+
+	f.buf.Reset(f.file)
+	f.off = off
+
+	return nil
+}
+
+func (f *FileReader) Skip(l int) error {
+	if l > f.Len() {
+		return ErrInvalidSize
+	}
+
+	n, err := f.buf.Discard(l)
+	if n > 0 {
+		f.off += n
+	}
+
+	return err
+}
+
+func (f *FileReader) Peek(n int) ([]byte, error) {
+	b, err := f.buf.Peek(n)
+	// bufio.Reader still returns what it Read when it hits EOF and callers
+	// expect to be able to peek past the end of a file.
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+
+	if len(b) > 0 {
+		return b, nil
+	}
+
+	return nil, nil
+}
+
+func (f *FileReader) Read(n int) ([]byte, error) {
+	b := make([]byte, n)
+
+	err := f.ReadInto(b)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+func (f *FileReader) ReadInto(b []byte) error {
+	r, err := io.ReadFull(f.buf, b)
+	if r > 0 {
+		f.off += r
+	}
+
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return fmt.Errorf("%w reading %d bytes: %s", ErrInvalidSize, len(b), err)
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (f *FileReader) Offset() int {
+	return f.off
+}
+
+func (f *FileReader) Len() int {
+	return f.length - f.off
+}
+
+func (f *FileReader) Size() int {
+	return f.buf.Size()
+}
+
+func (f *FileReader) Buffered() int {
+	return f.buf.Buffered()
+}
+
+// Close cleans up the underlying resources used by this FileReader.
+func (f *FileReader) Close() error {
+	// Note that we don't do anything to clean up the buffer before returning it to the pool here:
+	// we reset the buffer when we retrieve it from the pool instead.
+	bufferPool.Put(f.buf)
+	// File handles are pooled, so we don't actually close the handle here, just return it.
+	return f.closer.Put(f.file)
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_reader.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: AGPL-3.0-only
 // Provenance-includes-copyright: The Grafana Mimir Authors.
 
-package encoding
+package streamenc
 
 import (
 	"bufio"

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_reader_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_reader_test.go
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/grafana/mimir/blob/main/pkg/storage/indexheader/encoding/file_reader_test.go
+// Provenance-includes-license: AGPL-3.0-only
+// Provenance-includes-copyright: The Grafana Mimir Authors.
+
+package encoding
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/filepool"
+)
+
+func TestReaders_Read(t *testing.T) {
+	testReaders(t, func(t *testing.T, r *FileReader) {
+		firstRead, err := r.Read(5)
+		require.NoError(t, err)
+		require.Equal(t, []byte("abcde"), firstRead, "first read")
+
+		secondRead, err := r.Read(5)
+		require.NoError(t, err)
+		require.Equal(t, []byte("fghij"), secondRead, "second read")
+
+		readBeyondEnd, err := r.Read(12)
+		require.ErrorIs(t, err, ErrInvalidSize)
+		require.Empty(t, readBeyondEnd, "read beyond end")
+
+		readAfterEnd, err := r.Read(1)
+		require.ErrorIs(t, err, ErrInvalidSize)
+		require.Empty(t, readAfterEnd, "read after end")
+	})
+}
+
+func TestReaders_ReadInto(t *testing.T) {
+	testReaders(t, func(t *testing.T, r *FileReader) {
+		firstBuf := make([]byte, 5)
+		err := r.ReadInto(firstBuf)
+		require.NoError(t, err)
+		require.Equal(t, []byte("abcde"), firstBuf, "first read")
+
+		secondBuf := make([]byte, 5)
+		err = r.ReadInto(secondBuf)
+		require.NoError(t, err)
+		require.Equal(t, []byte("fghij"), secondBuf, "second read")
+
+		beyondEndBuf := make([]byte, 12)
+		err = r.ReadInto(beyondEndBuf)
+		require.ErrorIs(t, err, ErrInvalidSize)
+
+		afterEndBuf := make([]byte, 1)
+		err = r.ReadInto(afterEndBuf)
+		require.ErrorIs(t, err, ErrInvalidSize)
+	})
+}
+
+func TestReaders_Peek(t *testing.T) {
+	testReaders(t, func(t *testing.T, r *FileReader) {
+		firstPeek, err := r.Peek(5)
+		require.NoError(t, err)
+		require.Equal(t, []byte("abcde"), firstPeek, "peek (first call)")
+
+		secondPeek, err := r.Peek(5)
+		require.NoError(t, err)
+		require.Equal(t, []byte("abcde"), secondPeek, "peek (second call)")
+
+		readAfterPeek, err := r.Read(5)
+		require.NoError(t, err)
+		require.Equal(t, []byte("abcde"), readAfterPeek, "first read call")
+
+		peekAfterRead, err := r.Peek(5)
+		require.NoError(t, err)
+		require.Equal(t, []byte("fghij"), peekAfterRead, "peek after read")
+
+		peekBeyondEnd, err := r.Peek(20)
+		require.NoError(t, err)
+		require.Equal(t, []byte("fghij1234567890"), peekBeyondEnd, "peek beyond end")
+
+		_, err = r.Read(15)
+		require.NoError(t, err)
+
+		peekAfterEnd, err := r.Peek(1)
+		require.NoError(t, err)
+		require.Empty(t, peekAfterEnd, "peek after end")
+	})
+}
+
+func TestReaders_Reset(t *testing.T) {
+	testReaders(t, func(t *testing.T, r *FileReader) {
+		_, err := r.Read(5)
+		require.NoError(t, err)
+		require.NoError(t, r.Reset())
+
+		readAfterReset, err := r.Read(5)
+		require.NoError(t, err)
+		require.Equal(t, []byte("abcde"), readAfterReset)
+	})
+}
+
+func TestReaders_ResetAt(t *testing.T) {
+	testReaders(t, func(t *testing.T, r *FileReader) {
+		require.NoError(t, r.ResetAt(5))
+		readAfterReset, err := r.Read(5)
+		require.NoError(t, err)
+		require.Equal(t, []byte("fghij"), readAfterReset, "read after reset to non-zero offset")
+
+		require.NoError(t, r.ResetAt(0))
+		readAfterResetToBeginning, err := r.Read(5)
+		require.NoError(t, err)
+		require.Equal(t, []byte("abcde"), readAfterResetToBeginning, "read after reset to zero offset")
+
+		require.NoError(t, r.ResetAt(19))
+		readAfterResetToLastByte, err := r.Read(1)
+		require.NoError(t, err)
+		require.Equal(t, []byte("0"), readAfterResetToLastByte, "read after reset to last byte")
+
+		require.NoError(t, r.ResetAt(20))
+		require.ErrorIs(t, r.ResetAt(21), ErrInvalidSize)
+	})
+}
+
+func TestReaders_Skip(t *testing.T) {
+	testReaders(t, func(t *testing.T, r *FileReader) {
+		peek, err := r.Peek(5)
+		require.NoError(t, err)
+		require.Equal(t, []byte("abcde"), peek, "peek before skip")
+		require.Equal(t, 20, r.Len())
+
+		require.NoError(t, r.Skip(5))
+		readAfterSkip, err := r.Read(5)
+		require.NoError(t, err)
+		require.Equal(t, []byte("fghij"), readAfterSkip, "read after skip")
+		require.Equal(t, 10, r.Len())
+
+		require.NoError(t, r.Skip(5))
+		peekAfterSkip, err := r.Peek(5)
+		require.NoError(t, err)
+		require.Equal(t, []byte("67890"), peekAfterSkip, "peek after skip")
+		require.Equal(t, 5, r.Len())
+
+		// skip to exactly the end, then skip beyond it
+		require.NoError(t, r.Skip(5))
+		require.Equal(t, 0, r.Len())
+		require.ErrorIs(t, r.Skip(1), ErrInvalidSize)
+
+	})
+}
+
+func TestReaders_Len(t *testing.T) {
+	testReaders(t, func(t *testing.T, r *FileReader) {
+		require.Equal(t, 20, r.Len(), "initial length")
+
+		_, err := r.Read(5)
+		require.NoError(t, err)
+		require.Equal(t, 15, r.Len(), "after first read")
+
+		_, err = r.Read(2)
+		require.NoError(t, err)
+		require.Equal(t, 13, r.Len(), "after second read")
+
+		_, err = r.Peek(3)
+		require.NoError(t, err)
+		require.Equal(t, 13, r.Len(), "after peek")
+
+		_, err = r.Read(14)
+		require.ErrorIs(t, err, ErrInvalidSize)
+		require.Equal(t, 0, r.Len(), "after read beyond end")
+
+		require.NoError(t, r.Reset())
+		require.Equal(t, 20, r.Len(), "after reset to beginning")
+
+		require.NoError(t, r.ResetAt(3))
+		require.Equal(t, 17, r.Len(), "after reset to offset")
+	})
+}
+
+func TestReaders_Position(t *testing.T) {
+	testReaders(t, func(t *testing.T, r *FileReader) {
+		require.Equal(t, 0, r.Offset(), "initial offset")
+
+		_, err := r.Read(5)
+		require.NoError(t, err)
+		require.Equal(t, 5, r.Offset(), "after first read")
+
+		_, err = r.Read(2)
+		require.NoError(t, err)
+		require.Equal(t, 7, r.Offset(), "after second read")
+
+		_, err = r.Peek(3)
+		require.NoError(t, err)
+		require.Equal(t, 7, r.Offset(), "after peek")
+
+		_, err = r.Read(14)
+		require.ErrorIs(t, err, ErrInvalidSize)
+		require.Equal(t, 20, r.Offset(), "after read beyond end")
+
+		require.NoError(t, r.Reset())
+		require.Equal(t, 0, r.Offset(), "after reset to beginning")
+
+		require.NoError(t, r.ResetAt(3))
+		require.Equal(t, 3, r.Offset(), "after reset to offset")
+	})
+}
+
+func TestReaders_CreationWithEmptyContents(t *testing.T) {
+	t.Run("FileReader", func(t *testing.T) {
+		dir := t.TempDir()
+		filePath := path.Join(dir, "test-file")
+		require.NoError(t, os.WriteFile(filePath, nil, 0700))
+
+		f, err := os.Open(filePath)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, f.Close())
+		})
+
+		r, err := NewFileReader(f, 0, 0, &filepool.SingleFilePoolNoopCloser{})
+		require.NoError(t, err)
+		require.ErrorIs(t, r.Skip(1), ErrInvalidSize)
+		require.ErrorIs(t, r.ResetAt(1), ErrInvalidSize)
+	})
+}
+
+func testReaders(t *testing.T, test func(t *testing.T, r *FileReader)) {
+	testReaderContents := []byte("abcdefghij1234567890")
+
+	t.Run("FileReaderWithZeroOffset", func(t *testing.T) {
+		dir := t.TempDir()
+		filePath := path.Join(dir, "test-file")
+		require.NoError(t, os.WriteFile(filePath, testReaderContents, 0700))
+
+		f, err := os.Open(filePath)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, f.Close())
+		})
+
+		r, err := NewFileReader(f, 0, len(testReaderContents), &filepool.SingleFilePoolNoopCloser{})
+		require.NoError(t, err)
+
+		test(t, r)
+	})
+
+	t.Run("FileReaderWithNonZeroOffset", func(t *testing.T) {
+		offsetBytes := []byte("ABCDE")
+		fileBytes := append(offsetBytes, testReaderContents...)
+
+		dir := t.TempDir()
+		filePath := path.Join(dir, "test-file")
+		require.NoError(t, os.WriteFile(filePath, fileBytes, 0700))
+
+		f, err := os.Open(filePath)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, f.Close())
+		})
+
+		r, err := NewFileReader(f, len(offsetBytes), len(testReaderContents), &filepool.SingleFilePoolNoopCloser{})
+		require.NoError(t, err)
+
+		test(t, r)
+	})
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_reader_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_reader_test.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: AGPL-3.0-only
 // Provenance-includes-copyright: The Grafana Mimir Authors.
 
-package encoding
+package streamenc
 
 import (
 	"os"

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/filepool/filepool.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/filepool/filepool.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/grafana/mimir/blob/main/pkg/util/filepool/filepool.go
+// Provenance-includes-license: AGPL-3.0-only
+// Provenance-includes-copyright: The Grafana Mimir Authors.
+
+package filepool
+
+import (
+	"errors"
+	"os"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var ErrPoolStopped = errors.New("file handle pool is stopped")
+
+type FilePoolMetrics struct {
+	openCount        prometheus.Counter
+	pooledOpenCount  prometheus.Counter
+	closeCount       prometheus.Counter
+	pooledCloseCount prometheus.Counter
+}
+
+func NewFilePoolMetrics(reg prometheus.Registerer) *FilePoolMetrics {
+	return &FilePoolMetrics{
+		openCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "file_handle_unpooled_open_total",
+			Help: "Total number of times index-header file has been opened instead of using a pooled handle.",
+		}),
+		pooledOpenCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "file_handle_pooled_open_total",
+			Help: "Total number of times a pooled index-header file handle has been used instead of opened.",
+		}),
+		closeCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "file_handle_unpooled_close_total",
+			Help: "Total number of times index-header file has been closed instead of returning the handle to the pool.",
+		}),
+		pooledCloseCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "file_handle_pooled_close_total",
+			Help: "Total number of times pooled index-header file handle has been returned to the pool instead of closed.",
+		}),
+	}
+}
+
+type FilePoolCloser interface {
+	Put(*os.File) error
+}
+
+// SingleFilePoolNoopCloser implements FilePoolCloser without closing the file.
+// Some operations may call the pool closer on a file handle upon completion,
+// as they assume the file handle was originally retrieved from a FilePool.
+// This type allows calling those operations an unpooled file handle,
+// which can be closed manually according to its own lifecycle.
+type SingleFilePoolNoopCloser struct{}
+
+func (c SingleFilePoolNoopCloser) Put(_ *os.File) error {
+	return nil
+}
+
+// FilePool maintains a pool of file handles up to a maximum number, creating
+// new handles and closing them when required. Get and Put operations on this
+// pool never block. If there are no available file handles, one will be created
+// on Get. If the pool is full, the file handle is closed on Put.
+type FilePool struct {
+	path    string
+	handles chan *os.File
+	mtx     sync.RWMutex
+	stopped bool
+
+	metrics *FilePoolMetrics
+}
+
+// NewFilePool creates a new file pool for path with cap capacity. If cap is 0,
+// Get always opens new file handles and Put always closes them immediately.
+func NewFilePool(path string, cap uint, metrics *FilePoolMetrics) *FilePool {
+	return &FilePool{
+		path: path,
+		// We don't care if cap is 0 which means the channel will be unbuffered. Because
+		// we have default cases for reads and writes to the channel, we will always open
+		// new files and close file handles immediately if the channel is unbuffered.
+		handles: make(chan *os.File, cap),
+		metrics: metrics,
+	}
+}
+
+// Get returns a pooled file handle if available or opens a new one
+// are no pooled handles available. If this pool has been stopped, an error
+// is returned.
+func (p *FilePool) Get() (*os.File, error) {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	if p.stopped {
+		return nil, ErrPoolStopped
+	}
+
+	select {
+	case f := <-p.handles:
+		p.metrics.pooledOpenCount.Inc()
+		return f, nil
+	default:
+		p.metrics.openCount.Inc()
+		return os.Open(p.path)
+	}
+}
+
+// Put returns a file handle to the pool if there is space available or closes
+// the file handle if there is not. If this pool has been stopped, the file handle
+// is closed immediately.
+func (p *FilePool) Put(f *os.File) error {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	if p.stopped {
+		return f.Close()
+	}
+
+	select {
+	case p.handles <- f:
+		p.metrics.pooledCloseCount.Inc()
+		return nil
+	default:
+		p.metrics.closeCount.Inc()
+		return f.Close()
+	}
+}
+
+// Stop closes all pooled file handles. After this method is called, subsequent
+// Get calls will return an error and Put calls will immediately close the file
+// handle.
+func (p *FilePool) Stop() {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.stopped = true
+
+	for {
+		select {
+		case f := <-p.handles:
+			_ = f.Close()
+		default:
+			return
+		}
+	}
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/filepool/filepool.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/filepool/filepool.go
@@ -16,7 +16,7 @@ import (
 
 var ErrPoolStopped = errors.New("file handle pool is stopped")
 
-type FilePoolMetrics struct {
+type FilePoolMetrics struct { // nolint:revive
 	openCount        prometheus.Counter
 	pooledOpenCount  prometheus.Counter
 	closeCount       prometheus.Counter
@@ -26,25 +26,25 @@ type FilePoolMetrics struct {
 func NewFilePoolMetrics(reg prometheus.Registerer) *FilePoolMetrics {
 	return &FilePoolMetrics{
 		openCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "file_handle_unpooled_open_total",
-			Help: "Total number of times index-header file has been opened instead of using a pooled handle.",
+			Name: "loki_tsdb_index_file_handle_unpooled_open_total",
+			Help: "Total number of times a TSDB index file has been opened instead of using a pooled handle.",
 		}),
 		pooledOpenCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "file_handle_pooled_open_total",
-			Help: "Total number of times a pooled index-header file handle has been used instead of opened.",
+			Name: "loki_tsdb_index_file_handle_pooled_open_total",
+			Help: "Total number of times a pooled TSDB index file handle has been used instead of opened.",
 		}),
 		closeCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "file_handle_unpooled_close_total",
-			Help: "Total number of times index-header file has been closed instead of returning the handle to the pool.",
+			Name: "loki_tsdb_index_file_handle_unpooled_close_total",
+			Help: "Total number of times a TSDB index file has been closed instead of returning the handle to the pool.",
 		}),
 		pooledCloseCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "file_handle_pooled_close_total",
-			Help: "Total number of times pooled index-header file handle has been returned to the pool instead of closed.",
+			Name: "loki_tsdb_index_file_handle_pooled_close_total",
+			Help: "Total number of times a pooled TSDB index file handle has been returned to the pool instead of closed.",
 		}),
 	}
 }
 
-type FilePoolCloser interface {
+type FilePoolCloser interface { // nolint:revive
 	Put(*os.File) error
 }
 
@@ -72,15 +72,15 @@ type FilePool struct {
 	metrics *FilePoolMetrics
 }
 
-// NewFilePool creates a new file pool for path with cap capacity. If cap is 0,
+// NewFilePool creates a new file pool for path with capacity capacity. If capacity is 0,
 // Get always opens new file handles and Put always closes them immediately.
-func NewFilePool(path string, cap uint, metrics *FilePoolMetrics) *FilePool {
+func NewFilePool(path string, capacity uint, metrics *FilePoolMetrics) *FilePool {
 	return &FilePool{
 		path: path,
-		// We don't care if cap is 0 which means the channel will be unbuffered. Because
+		// We don't care if capacity is 0 which means the channel will be unbuffered. Because
 		// we have default cases for reads and writes to the channel, we will always open
 		// new files and close file handles immediately if the channel is unbuffered.
-		handles: make(chan *os.File, cap),
+		handles: make(chan *os.File, capacity),
 		metrics: metrics,
 	}
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/reader.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/grafana/mimir/blob/main/pkg/storage/indexheader/encoding/reader.go
+// Provenance-includes-license: AGPL-3.0-only
+// Provenance-includes-copyright: The Grafana Mimir Authors.
+
+package encoding
+
+// BufReader provides the low-level byte access interface for Decbuf's read operations
+type BufReader interface {
+	// Reset moves the cursor to the beginning of the data segment owned by the reader,
+	// at the base offset configured at reader initialization.
+	Reset() error
+
+	// ResetAt moves the cursor to the given offset in the data segment owned by the reader,
+	// relative to the base offset configured at reader initialization.
+	// CAUTION: This operation may be very expensive and result in the discard of buffered data.
+	// Use Skip to move forward to avoid unnecessary buffer discard.
+	// ResetAt should only be used to move backwards.
+	//
+	// Attempting to ResetAt to the end of the data segment is valid.
+	// Attempting to ResetAt _beyond_ the end of the data segment will return an error.
+	ResetAt(off int) error
+
+	// Skip advances the cursor by the given number of bytes in the data segment.
+	// Attempting to skip to the end of the data segment is valid.
+	// Attempting to skip _beyond_ the end of the data segment will return an error.
+	Skip(l int) error
+
+	// Peek returns at most the given number of bytes from the data segment, without consuming them.
+	// The byte slice returned becomes invalid at the next read.
+	// It is valid to Peek beyond the end of the data segment;
+	// in this case implementations MUST return the available bytes up to the end and a nil error.
+	Peek(n int) ([]byte, error)
+
+	// Read returns the given number of bytes from the data segment, consuming them.
+	// It is NOT valid to read beyond the end of the data segment;
+	// in this case implementations MUST return a nil byte slice and an ErrInvalidSize error,
+	// and the remaining bytes MUST be consumed.
+	Read(n int) ([]byte, error)
+
+	// ReadInto reads len(b) bytes from the data segment into b, consuming them.
+	// It is NOT valid to read beyond the end of the data segment;
+	// in this case implementations MUST return a nil byte slice and an ErrInvalidSize error,
+	// and the remaining bytes MUST be consumed.
+	ReadInto(b []byte) error
+
+	// Size returns the length of the underlying buffer in bytes.
+	Size() int
+
+	// Len returns the remaining number of bytes in the data segment owned by the reader,
+	// from the current offset to the length configured at reader initialization.
+	Len() int
+
+	// Offset returns the cursor offset in the data segment owned by the reader,
+	// relative to the base offset configured at reader initialization.
+	Offset() int
+
+	// Buffered returns the number of bytes that can be read from the reader which are already in memory.
+	Buffered() int
+
+	Close() error
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/reader.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: AGPL-3.0-only
 // Provenance-includes-copyright: The Grafana Mimir Authors.
 
-package encoding
+package streamenc
 
 // BufReader provides the low-level byte access interface for Decbuf's read operations
 type BufReader interface {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
@@ -26,8 +26,9 @@ import (
 
 var ErrAlreadyOnDesiredVersion = errors.New("tsdb file already on desired version")
 
-// GetRawFileReaderFunc returns an io.ReadSeeker for reading raw tsdb file from disk
-type GetRawFileReaderFunc func() (io.ReadSeeker, error)
+// GetRawFileReaderFunc returns an io.ReadSeekCloser for reading raw tsdb file from disk.
+// The caller owns the returned reader and must Close it.
+type GetRawFileReaderFunc func() (io.ReadSeekCloser, error)
 
 func OpenShippableTSDB(p string, mode indexshipper.IndexReaderMode) (shipperindex.Index, error) {
 	id, err := identifierFromPath(p)
@@ -112,7 +113,7 @@ func (f *TSDBFile) Close() error {
 	return f.Index.Close()
 }
 
-func (f *TSDBFile) Reader() (io.ReadSeeker, error) {
+func (f *TSDBFile) Reader() (io.ReadSeekCloser, error) {
 	return f.getRawFileReader()
 }
 
@@ -133,7 +134,7 @@ func NewTSDBIndexFromFile(location string, mode indexshipper.IndexReaderMode) (*
 		return nil, nil, err
 	}
 
-	return NewTSDBIndex(reader), func() (io.ReadSeeker, error) {
+	return NewTSDBIndex(reader), func() (io.ReadSeekCloser, error) {
 		return reader.RawFileReader()
 	}, nil
 }

--- a/pkg/storage/stores/shipper/indexshipper/uploads/index_set.go
+++ b/pkg/storage/stores/shipper/indexshipper/uploads/index_set.go
@@ -153,6 +153,11 @@ func (t *indexSet) uploadIndex(ctx context.Context, idx index.Index) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err := idxReader.Close(); err != nil {
+			level.Error(util_log.Logger).Log("msg", "failed to close index reader", "path", idxPath, "err", err)
+		}
+	}()
 
 	_, err = idxReader.Seek(0, 0)
 	if err != nil {

--- a/pkg/storage/stores/shipper/indexshipper/uploads/testutil.go
+++ b/pkg/storage/stores/shipper/indexshipper/uploads/testutil.go
@@ -28,8 +28,8 @@ func (m *mockIndex) Path() string {
 	return m.File.Name()
 }
 
-func (m *mockIndex) Reader() (io.ReadSeeker, error) {
-	return m.File, nil
+func (m *mockIndex) Reader() (io.ReadSeekCloser, error) {
+	return os.Open(m.File.Name())
 }
 
 func buildTestIndexes(t *testing.T, path string, numIndexes int) map[string]*mockIndex {


### PR DESCRIPTION
**What this PR does / why we need it**: Implement streaming reading of header and TOC as part of the process of moving away from mmap in the index gateway.
I have run this in a pre-production environment for a few minutes and not seen any noticeable changes in latency, resource usage, etc. 

**Special notes for your reviewer**: This PR is best reviewed commit-by-commit. The first commit copies across some files from mimir's equivalent. The second commit makes those files compile and pass linting rules within the context of loki. The third commit is "the actual change". Commit messages should be clear. 

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
