### PR TITLE
chore(querier): Replace go.uber.org/atomic with stdlib sync/atomic 🤖🤖🤖

### DIFF
--- a/pkg/querier/ingester_querier_test.go
+++ b/pkg/querier/ingester_querier_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/ring/client"
 	"github.com/grafana/dskit/user"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 	grpc_metadata "google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -305,7 +305,7 @@ func TestIngesterQuerierFetchesResponsesFromPartitionIngesters(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
-		cnt := atomic.NewInt32(0)
+		var cnt atomic.Int32
 
 		t.Run(testName, func(t *testing.T) {
 			cnt.Store(0)
@@ -404,7 +404,7 @@ func TestIngesterQuerier_QueriesSameIngestersWithPartitionContext(t *testing.T) 
 	}
 
 	for testName, testData := range tests {
-		cnt := atomic.NewInt32(0)
+		var cnt atomic.Int32
 		ctx := NewPartitionContext(testCtx)
 
 		t.Run(testName, func(t *testing.T) {

--- a/pkg/querier/queryrange/downstreamer_test.go
+++ b/pkg/querier/queryrange/downstreamer_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,7 +17,6 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
@@ -568,7 +568,7 @@ func TestCancelWhileWaitingResponse(t *testing.T) {
 
 	// Launch the For call in a goroutine because it blocks and we need to be able to cancel the context
 	// to prove it will exit when the context is canceled.
-	b := atomic.NewBool(false)
+	var b atomic.Bool
 	go func() {
 		_, _ = in.For(ctx, queries, acc, func(_ logql.DownstreamQuery) (logqlmodel.Result, error) {
 			// Intended to keep the For method from returning unless the context is canceled.
@@ -625,11 +625,11 @@ func TestCancelDoesNotLeakGoroutines(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		acc := logql.NewBufferedAccumulator(len(queries))
 
-		started := atomic.NewInt32(0)
+		var started atomic.Int32
 		done := make(chan struct{})
 		go func() {
 			_, _ = in.For(ctx, queries, acc, func(_ logql.DownstreamQuery) (logqlmodel.Result, error) {
-				started.Inc()
+				started.Add(1)
 				// Block until context is canceled.
 				<-ctx.Done()
 				return logqlmodel.Result{}, ctx.Err()

--- a/pkg/querier/queryrange/limits_test.go
+++ b/pkg/querier/queryrange/limits_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"regexp"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"go.yaml.in/yaml/v4"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -566,11 +566,11 @@ func Test_MaxQueryParallelism(t *testing.T) {
 	var count atomic.Int32
 	var maxVal atomic.Int32
 	h := queryrangebase.HandlerFunc(func(_ context.Context, _ queryrangebase.Request) (queryrangebase.Response, error) {
-		cur := count.Inc()
+		cur := count.Add(1)
 		if cur > maxVal.Load() {
 			maxVal.Store(cur)
 		}
-		defer count.Dec()
+		defer count.Add(-1)
 		// simulate some work
 		time.Sleep(20 * time.Millisecond)
 		return queryrangebase.NewEmptyPrometheusResponse(model.ValMatrix), nil
@@ -1103,10 +1103,10 @@ func Test_MaxQuerySize_WithQueryLimitsContext(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			statsHits := atomic.NewInt32(0)
+			var statsHits atomic.Int32
 
 			statsHandler := queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
-				statsHits.Inc()
+				statsHits.Add(1)
 
 				bytes := tc.queryBytes
 				if req.GetQuery() == ctxSentinal {

--- a/pkg/querier/queryrange/queryrangebase/retry_test.go
+++ b/pkg/querier/queryrange/queryrangebase/retry_test.go
@@ -5,13 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-kit/log"
 	"github.com/gogo/status"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/loki/v3/pkg/util/constants"
@@ -30,7 +30,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "retry failures",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				if try.Inc() == 5 {
+				if try.Add(1) == 5 {
 					return &PrometheusResponse{Status: "Hello World"}, nil
 				}
 				return nil, fmt.Errorf("fail")
@@ -41,7 +41,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "don't retry 400s",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				try.Inc()
+				try.Add(1)
 				return nil, httpgrpc.Errorf(http.StatusBadRequest, "Bad Request")
 			}),
 			err:           httpgrpc.Errorf(http.StatusBadRequest, "Bad Request"),
@@ -50,7 +50,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "retry 500s",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				try.Inc()
+				try.Add(1)
 				return nil, httpgrpc.Errorf(http.StatusInternalServerError, "Internal Server Error")
 			}),
 			err:           httpgrpc.Errorf(http.StatusInternalServerError, "Internal Server Error"),
@@ -59,7 +59,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "last error",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				if try.Inc() == 5 {
+				if try.Add(1) == 5 {
 					return nil, httpgrpc.Errorf(http.StatusBadRequest, "Bad Request")
 				}
 				return nil, httpgrpc.Errorf(http.StatusInternalServerError, "Internal Server Error")
@@ -72,7 +72,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "protobuf enc don't retry 400s",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				try.Inc()
+				try.Add(1)
 				return nil, status.New(codes.Code(http.StatusBadRequest), "Bad Request").Err()
 			}),
 			err:           status.New(codes.Code(http.StatusBadRequest), "Bad Request").Err(),
@@ -81,7 +81,7 @@ func TestRetry(t *testing.T) {
 		{
 			name: "protobuf enc retry 500s",
 			handler: HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-				try.Inc()
+				try.Add(1)
 				return nil, status.New(codes.Code(http.StatusInternalServerError), "Internal Server Error").Err()
 			}),
 			err:           status.New(codes.Code(http.StatusInternalServerError), "Internal Server Error").Err(),
@@ -112,7 +112,7 @@ func Test_RetryMiddlewareCancel(t *testing.T) {
 	cancel()
 	_, err := NewRetryMiddleware(log.NewNopLogger(), 5, nil, constants.Loki).Wrap(
 		HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-			try.Inc()
+			try.Add(1)
 			return nil, ctx.Err()
 		}),
 	).Do(ctx, req)
@@ -122,7 +122,7 @@ func Test_RetryMiddlewareCancel(t *testing.T) {
 	ctx, cancel = context.WithCancel(context.Background())
 	_, err = NewRetryMiddleware(log.NewNopLogger(), 5, nil, constants.Loki).Wrap(
 		HandlerFunc(func(_ context.Context, _ Request) (Response, error) {
-			try.Inc()
+			try.Add(1)
 			cancel()
 			return nil, errors.New("failed")
 		}),

--- a/pkg/querier/tail/tail.go
+++ b/pkg/querier/tail/tail.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
-
-	"go.uber.org/atomic"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"

--- a/pkg/querier/worker/frontend_processor_test.go
+++ b/pkg/querier/worker/frontend_processor_test.go
@@ -3,13 +3,13 @@ package worker
 import (
 	"context"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
@@ -36,7 +36,7 @@ func TestRecvFailDoesntCancelProcess(t *testing.T) {
 
 	cfg := Config{}
 	mgr := newFrontendProcessor(cfg, nil, log.NewNopLogger(), queryrange.DefaultCodec)
-	running := atomic.NewBool(false)
+	var running atomic.Bool
 	go func() {
 		running.Store(true)
 		defer running.Store(false)

--- a/pkg/querier/worker/processor_manager.go
+++ b/pkg/querier/worker/processor_manager.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 )
 
@@ -29,16 +29,15 @@ type processorManager struct {
 	cancelsMu sync.Mutex
 	cancels   []context.CancelFunc
 
-	currentProcessors *atomic.Int32
+	currentProcessors atomic.Int32
 }
 
 func newProcessorManager(ctx context.Context, p processor, conn *grpc.ClientConn, address string) *processorManager {
 	return &processorManager{
-		p:                 p,
-		ctx:               ctx,
-		conn:              conn,
-		address:           address,
-		currentProcessors: atomic.NewInt32(0),
+		p:       p,
+		ctx:     ctx,
+		conn:    conn,
+		address: address,
 	}
 }
 
@@ -75,8 +74,8 @@ func (pm *processorManager) concurrency(n int) {
 		go func(workerID int) {
 			defer pm.wg.Done()
 
-			pm.currentProcessors.Inc()
-			defer pm.currentProcessors.Dec()
+			pm.currentProcessors.Add(1)
+			defer pm.currentProcessors.Add(-1)
 
 			pm.p.processQueriesOnSingleStream(ctx, pm.conn, pm.address, strconv.Itoa(workerID))
 		}(workerID)

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -21,7 +22,6 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 

--- a/pkg/querier/worker/scheduler_processor_test.go
+++ b/pkg/querier/worker/scheduler_processor_test.go
@@ -4,6 +4,7 @@ package worker
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -54,10 +54,10 @@ func TestSchedulerProcessor_processQueriesOnSingleStream(t *testing.T) {
 	t.Run("should wait until inflight query execution is completed before returning when worker context is canceled", func(t *testing.T) {
 		sp, loopClient, requestHandler := prepareSchedulerProcessor()
 
-		recvCount := atomic.NewInt64(0)
+		var recvCount atomic.Int64
 
 		loopClient.On("Recv").Return(func() (*schedulerpb.SchedulerToQuerier, error) {
-			switch recvCount.Inc() {
+			switch recvCount.Add(1) {
 			case 1:
 				return &schedulerpb.SchedulerToQuerier{
 					QueryID: 1,

--- a/pkg/querier/worker/util.go
+++ b/pkg/querier/worker/util.go
@@ -5,6 +5,7 @@ package worker
 import (
 	"context"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -12,7 +13,6 @@ import (
 	"github.com/gogo/status"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/pkg/errors"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/loki/v3/pkg/querier/queryrange"
@@ -35,7 +35,7 @@ import (
 // once the inflight query terminates and the response has been sent.
 func newExecutionContext(workerCtx context.Context, logger log.Logger) (execCtx context.Context, execCancel context.CancelCauseFunc, inflightQuery *atomic.Bool) {
 	execCtx, execCancel = context.WithCancelCause(context.Background())
-	inflightQuery = atomic.NewBool(false)
+	inflightQuery = new(atomic.Bool)
 
 	go func() {
 		// Wait until it's safe to cancel the execution context, which is when one of the following conditions happen:


### PR DESCRIPTION
Part of #20673. Migrates the querier package tree only; the rest of the codebase still uses go.uber.org/atomic so the dependency stays in go.mod for now.

**What this PR does / why we need it**:
Replaces go.uber.org/atomic with the standard library sync/atomic typed wrappers (atomic.Int32, atomic.Int64, atomic.Bool) across the pkg/querier package tree. Since Go 1.19, sync/atomic provides the same safety guarantees as the uber package without the external dependency. This PR only covers pkg/querier/**; the rest of the codebase still imports go.uber.org/atomic, so the module dependency stays in go.mod for now — will follow up with the remaining packages in separate, smaller PRs.

**Which issue(s) this PR fixes**:
Part of #20673

**Special notes for your reviewer**:

Mechanical change, no behavior change intended:
- atomic.NewXxx(v) → zero-value var x atomic.Xxx (or new(atomic.Xxx) where a pointer is required)
- .Inc() / .Dec() → .Add(1) / .Add(-1) (stdlib has no Inc/Dec)
- processorManager.currentProcessors changed from *atomic.Int32 to a value-typed atomic.Int32 field, since stdlib atomics are designed to be embedded by value
- go test ./pkg/querier/... passes; go build ./pkg/querier/... clean

**Checklist**
- [x] Reviewed the CONTRIBUTING.md (https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (required)
- [x] Documentation added — N/A, internal refactor only
- [x] Tests updated — N/A, existing tests migrated to the new API with no behavioral change
- [x] Title matches the required conventional commits format
- [x] Changes that require user attention or interaction to upgrade are documented — N/A, no user-facing change
- [x] Deprecated/removed config option checklist item — N/A
