### PR TITLE
test(logql): Add logqltest coverage for parsers

### DIFF
--- a/pkg/logql/internal/logqltest/README.md
+++ b/pkg/logql/internal/logqltest/README.md
@@ -31,7 +31,8 @@ load
 ```
 
 - `<stream-selector>` — a LogQL stream selector, e.g. `{app="foo", env="prod"}`.
-- `"<line>"` — the log line (double-quoted).
+- `"<line>"` — the log line. Use double quotes, or backticks (`` `<line>` ``) for a raw line that
+  itself contains `"`, e.g. a JSON object for the `json` / `unpack` parsers. Neither form unescapes.
 - `@ <start>` — **required** timestamp of the entry, as a Go duration offset from the script
   epoch (`t=0`), e.g. `@ 0s`, `@ 90s`, `@ 1m30s`. Repeat the selector on multiple lines to
   place entries at arbitrary different times.
@@ -80,6 +81,10 @@ Point syntax (from promqltest):
 Label sets are compared as sets (order-independent). Note that Loki promotes **structured
 metadata into the result label set**, so a stream loaded with `[metadata detected_level="info"]`
 produces series labelled `{…, detected_level="info"}`.
+
+An **empty-value label is significant**: `{app="a", age=""}` asserts that `age` is present with an
+empty value (e.g. from a `json` expression whose path is missing, or `logfmt --keep-empty`), which is
+distinct from omitting `age` entirely.
 
 Every `eval` must assert exactly one kind of result — series, a scalar, `expect empty`, or
 `expect fail`; otherwise the harness errors (a forgotten expected block would otherwise pass

--- a/pkg/logql/internal/logqltest/parser.go
+++ b/pkg/logql/internal/logqltest/parser.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
+	promql_parser "github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/loki/pkg/push"
 
@@ -147,13 +148,16 @@ func splitStreamLabels(line string) (streamLabels, rest string, err error) {
 	return line[:end+1], line[end+1:], nil
 }
 
-// splitQuoted returns the first double-quoted string in s and the remainder after it.
+// splitQuoted returns the first quoted log line in s and the remainder after it. The line may be
+// delimited by double quotes ("...") or by backticks (`...`). Backticks are raw and let the line
+// hold double quotes, e.g. a JSON object. Neither form processes escape sequences.
 func splitQuoted(s string) (text, rest string, err error) {
-	start := strings.IndexByte(s, '"')
+	start := strings.IndexAny(s, "\"`")
 	if start < 0 {
 		return "", "", fmt.Errorf("missing quoted log line")
 	}
-	end := strings.IndexByte(s[start+1:], '"')
+	quote := s[start]
+	end := strings.IndexByte(s[start+1:], quote)
 	if end < 0 {
 		return "", "", fmt.Errorf("unterminated quoted log line")
 	}
@@ -394,7 +398,11 @@ func parseSeriesLabels(s string) (labels.Labels, error) {
 	if strings.TrimSpace(s) == "{}" {
 		return labels.EmptyLabels(), nil
 	}
-	return syntax.ParseLabels(s)
+	// Unlike syntax.ParseLabels, keep empty-value labels instead of dropping them with WithoutEmpty().
+	// That normalization exists for write-path hash stability, but a query result can carry a label
+	// with an empty value (e.g. a json expression whose path is missing sets `age=""`), and a test
+	// must assert `{age=""}` as distinct from an absent `age`.
+	return promql_parser.NewParser(promql_parser.Options{}).ParseMetric(s)
 }
 
 // parseSamples expands a series of tokens (`5`, `_`, `NaN`, `2+3x4`, `2-1x4`, `2x4`) into samples.

--- a/pkg/logql/internal/logqltest/parser_test.go
+++ b/pkg/logql/internal/logqltest/parser_test.go
@@ -44,6 +44,17 @@ func TestStreamsParser(t *testing.T) {
 		require.Equal(t, `{app="foo", env="prod"}`, streams[0].Labels)
 		require.Len(t, streams[0].Entries, 2)
 	})
+
+	t.Run("a backtick raw log line keeps its double quotes", func(t *testing.T) {
+		bt := "`"
+		s := newStreamsParser()
+		require.NoError(t, s.parse(`{app="foo"} `+bt+`{"level":"info","n":1}`+bt+` @ 0s`))
+
+		streams := s.get()
+		require.Len(t, streams, 1)
+		require.Len(t, streams[0].Entries, 1)
+		require.Equal(t, `{"level":"info","n":1}`, streams[0].Entries[0].Line)
+	})
 }
 
 func TestSplitStreamLabels(t *testing.T) {
@@ -60,16 +71,34 @@ func TestSplitStreamLabels(t *testing.T) {
 }
 
 func TestSplitQuoted(t *testing.T) {
-	text, rest, err := splitQuoted(` "hello world" @ 0s`)
-	require.NoError(t, err)
-	require.Equal(t, `hello world`, text)
-	require.Equal(t, ` @ 0s`, rest)
-
-	_, _, err = splitQuoted(` no quote here`)
-	require.Error(t, err)
-
-	_, _, err = splitQuoted(` "unterminated`)
-	require.Error(t, err)
+	bt := "`" // a backtick, awkward to embed in Go string literals
+	for name, tc := range map[string]struct {
+		in       string
+		wantText string
+		wantRest string
+		wantErr  bool
+	}{
+		"double quoted":                     {in: ` "hello world" @ 0s`, wantText: "hello world", wantRest: " @ 0s"},
+		"backtick raw":                      {in: " " + bt + "raw line" + bt + " @ 0s", wantText: "raw line", wantRest: " @ 0s"},
+		"backtick keeps double quotes":      {in: " " + bt + `{"a":"b"}` + bt + " @ 0s", wantText: `{"a":"b"}`, wantRest: " @ 0s"},
+		"double quotes stop at inner quote": {in: ` "a"b`, wantText: "a", wantRest: "b"},
+		"double quotes keep a backtick":     {in: ` "a` + bt + `b" @ 0s`, wantText: "a" + bt + "b", wantRest: " @ 0s"},
+		"first delimiter wins":              {in: ` "x" ` + bt + "y" + bt, wantText: "x", wantRest: " " + bt + "y" + bt},
+		"missing quote":                     {in: ` no quote here`, wantErr: true},
+		"unterminated double quote":         {in: ` "unterminated`, wantErr: true},
+		"unterminated backtick":             {in: " " + bt + "unterminated", wantErr: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			text, rest, err := splitQuoted(tc.in)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantText, text)
+			require.Equal(t, tc.wantRest, rest)
+		})
+	}
 }
 
 func TestParseMetadata(t *testing.T) {
@@ -235,6 +264,23 @@ func TestExpectationsValidate(t *testing.T) {
 	require.Error(t, expectations{ordered: true}.validate())
 	require.Error(t, expectations{ordered: true, scalar: &scalar}.validate()) // ordered needs series
 	require.Error(t, expectations{failKind: failMsg}.validate())              // qualifier without fail
+}
+
+func TestParseSeriesLabels(t *testing.T) {
+	// An empty-value label is preserved, so a test can assert a present-but-empty label distinctly
+	// from an absent one (unlike stream labels, which syntax.ParseLabels normalizes with WithoutEmpty).
+	present, err := parseSeriesLabels(`{app="a", age=""}`)
+	require.NoError(t, err)
+	require.Equal(t, `{age="", app="a"}`, present.String())
+
+	absent, err := parseSeriesLabels(`{app="a"}`)
+	require.NoError(t, err)
+	require.Equal(t, `{app="a"}`, absent.String())
+	require.NotEqual(t, present.String(), absent.String())
+
+	empty, err := parseSeriesLabels(`{}`)
+	require.NoError(t, err)
+	require.Equal(t, `{}`, empty.String())
 }
 
 func TestParseSeriesLine(t *testing.T) {

--- a/pkg/logql/internal/logqltest/testdata/parsers.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/parsers.logqltest
@@ -13,6 +13,7 @@ eval range from 60s to 180s step 120s count_over_time({app="a"} | logfmt [1m]) #
 
 # logfmt() edge cases:
 # - Keys sanitize non-word characters to `_`.
+# - A key that starts with a non-letter gets a leading `_` (9x becomes _9x).
 # - Empty values are kept only when --keep-empty is specified.
 # - A duplicate key keeps the first.
 # - A quoted value holds spaces.
@@ -213,7 +214,8 @@ eval range from 40s to 60s step 20s count_over_time({app="a"} | pattern `<method
 eval instant at 60s count_over_time({app="a"} | pattern `no captures here` [1m])
   expect fail msg: at least one capture is required
 
-# unpack() promotes to labels the string fields of a json line.
+# unpack() promotes the string fields of a json line to labels. It skips a non-string field (num) and
+# the reserved `_entry` key, whose value replaces the log line instead of becoming a label.
 clear
 load
   {app="a"} `{"lvl":"info","cluster":"eu","num":5,"_entry":"real message"}` @ 20s [repeat every 20s for 4]

--- a/pkg/logql/internal/logqltest/testdata/parsers.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/parsers.logqltest
@@ -1,0 +1,253 @@
+# logfmt()
+clear
+load
+  {app="a"}     "level=info status=200" @ 20s [repeat every 20s for 4]
+  {app="noise"} "level=info status=200" @ 20s [repeat every 20s for 4]
+
+eval instant at 60s count_over_time({app="a"} | logfmt [1m])
+  {app="a", level="info", status="200"} 3
+eval range from 40s to 80s step 20s count_over_time({app="a"} | logfmt [1m])   # overlapping
+  {app="a", level="info", status="200"} 2 3 3
+eval range from 60s to 180s step 120s count_over_time({app="a"} | logfmt [1m]) # non-overlapping
+  {app="a", level="info", status="200"} 3 _
+
+# logfmt() edge cases:
+# - Keys sanitize non-word characters to `_`.
+# - Empty values are kept only when --keep-empty is specified.
+# - A duplicate key keeps the first.
+# - A quoted value holds spaces.
+clear
+load
+  {app="a"} `a-b=1 9x=2 dup=first dup=second msg="hi there" empty=` @ 20s [repeat every 20s for 3]
+  {app="noise"} "z=1" @ 20s [repeat every 20s for 3]
+
+eval instant at 60s count_over_time({app="a"} | logfmt [1m])
+  {app="a", a_b="1", _9x="2", dup="first", msg="hi there"} 3
+eval instant at 60s count_over_time({app="a"} | logfmt --keep-empty [1m])
+  {app="a", a_b="1", _9x="2", dup="first", msg="hi there", empty=""} 3
+
+eval range from 40s to 60s step 20s count_over_time({app="a"} | logfmt [1m])
+  {app="a", a_b="1", _9x="2", dup="first", msg="hi there"} 2 3
+eval range from 40s to 60s step 20s count_over_time({app="a"} | logfmt --keep-empty [1m])
+  {app="a", a_b="1", _9x="2", dup="first", msg="hi there", empty=""} 2 3
+
+# logfmt() clashing labels keep the loser under `<name>_extracted`, following the base-name
+# precedence stream > metadata > parsed (the same for every parser).
+clear
+load
+  {app="a", sl="s", sm="s", tri="s"} `sl=p md=p tri=p` @ 20s [repeat every 20s for 3] [metadata md="m" sm="m" tri="m"]
+  {app="noise"} "z=1" @ 20s [repeat every 20s for 3]
+
+eval instant at 60s count_over_time({app="a"} | logfmt [1m])
+  {app="a", sl="s", sl_extracted="p", md="m", md_extracted="p", sm="s", sm_extracted="m", tri="s", tri_extracted="p"} 3
+eval range from 40s to 60s step 20s count_over_time({app="a"} | logfmt [1m])
+  {app="a", sl="s", sl_extracted="p", md="m", md_extracted="p", sm="s", sm_extracted="m", tri="s", tri_extracted="p"} 2 3
+
+# logfmt() partially malformed line: the parser keeps the valid pairs and drops the bad one, or
+# fails the whole line under --strict.
+clear
+load
+  {app="a"} `good=1 bad="unterminated` @ 20s [repeat every 20s for 3]
+  {app="noise"} "z=1" @ 20s [repeat every 20s for 3]
+
+eval instant at 60s count_over_time({app="a"} | logfmt [1m])
+  {app="a", good="1"} 3
+eval instant at 60s count_over_time({app="a"} | logfmt --strict [1m])
+  expect fail msg: LogfmtParserErr
+# A __error__ filter drops the failing line.
+eval instant at 60s count_over_time({app="a"} | logfmt --strict | __error__="" [1m])
+  expect empty
+
+# logfmt() with label expressions.
+clear
+load
+  {app="a"} "level=info status=200 msg=hi" @ 20s [repeat every 20s for 4]
+  {app="noise"} "x=1" @ 20s [repeat every 20s for 4]
+
+eval instant at 60s count_over_time({app="a"} | logfmt level, code="status" [1m])
+  {app="a", level="info", code="200"} 3
+eval range from 40s to 80s step 20s count_over_time({app="a"} | logfmt level, code="status" [1m])   # overlapping
+  {app="a", level="info", code="200"} 2 3 3
+eval range from 60s to 180s step 120s count_over_time({app="a"} | logfmt level, code="status" [1m]) # non-overlapping
+  {app="a", level="info", code="200"} 3 _
+
+# json()
+clear
+load
+  {app="a"} `{"level":"info","status":200}` @ 20s [repeat every 20s for 4]
+  {app="noise"} `{"level":"info"}` @ 20s [repeat every 20s for 4]
+
+eval instant at 60s count_over_time({app="a"} | json [1m])
+  {app="a", level="info", status="200"} 3
+eval range from 40s to 80s step 20s count_over_time({app="a"} | json [1m])  # overlapping
+  {app="a", level="info", status="200"} 2 3 3
+eval range from 60s to 180s step 120s count_over_time({app="a"} | json [1m]) # non-overlapping
+  {app="a", level="info", status="200"} 3 _
+
+# json() edge cases:
+# - Nested objects flatten with `_`.
+# - Numbers and booleans become strings.
+# - Null and arrays drop.
+clear
+load
+  {app="a"} `{"lvl":"warn","obj":{"x":1,"y":{"z":2}},"ok":true,"no":false,"nil":null,"arr":[1,2],"f":1.5}` @ 20s [repeat every 20s for 3]
+  {app="noise"} `{"a":1}` @ 20s [repeat every 20s for 3]
+
+eval instant at 60s count_over_time({app="a"} | json [1m])
+  {app="a", lvl="warn", obj_x="1", obj_y_z="2", ok="true", no="false", f="1.5"} 3
+eval range from 40s to 60s step 20s count_over_time({app="a"} | json [1m])  # overlapping
+  {app="a", lvl="warn", obj_x="1", obj_y_z="2", ok="true", no="false", f="1.5"} 2 3
+
+# json() edge cases:
+# - A dotted key sanitizes to `_`.
+# - A clashing name gets `_extracted`.
+# - A duplicate key keeps the first.
+clear
+load
+  {app="a", level="stream"} `{"level":"parsed","a.b":1,"dup":"first","dup":"second"}` @ 20s [repeat every 20s for 3]
+  {app="noise"} `{"x":1}` @ 20s [repeat every 20s for 3]
+
+eval instant at 60s count_over_time({app="a"} | json [1m])
+  {app="a", level="stream", level_extracted="parsed", a_b="1", dup="first"} 3
+eval range from 40s to 60s step 20s count_over_time({app="a"} | json [1m])  # overlapping
+  {app="a", level="stream", level_extracted="parsed", a_b="1", dup="first"} 2 3
+
+# json() malformed line: the query fails, unless a __error__ filter drops the bad line.
+clear
+load
+  {app="a"} `{"ok":1}` @ 20s
+  {app="a"} `broken`   @ 40s
+  {app="a"} `{"ok":1}` @ 60s
+  {app="noise"} `{"z":1}` @ 20s
+
+eval instant at 60s count_over_time({app="a"} | json [1m])
+  expect fail msg: JSONParserErr
+eval instant at 60s count_over_time({app="a"} | json | __error__="" [1m])
+  {app="a", ok="1"} 2
+
+# json() with label expressions:
+# - `user.id` reads a nested field.
+# - `tags[0]` indexes an array.
+# - A path with no match adds an empty-value label.
+# - An invalid expression fails at parse time.
+clear
+load
+  {app="a"} `{"user":{"id":"u1","name":"alice"},"tags":["x","y"]}` @ 20s [repeat every 20s for 4]
+  {app="noise"} `{"a":1}` @ 20s [repeat every 20s for 4]
+
+eval instant at 60s count_over_time({app="a"} | json who="user.id", tag="tags[0]" [1m])
+  {app="a", who="u1", tag="x"} 3
+eval range from 40s to 80s step 20s count_over_time({app="a"} | json who="user.id", tag="tags[0]" [1m])  # overlapping
+  {app="a", who="u1", tag="x"} 2 3 3
+eval range from 60s to 180s step 120s count_over_time({app="a"} | json who="user.id", tag="tags[0]" [1m]) # non-overlapping
+  {app="a", who="u1", tag="x"} 3 _
+eval instant at 60s count_over_time({app="a"} | json age="user.age" [1m])
+  {app="a", age=""} 3
+eval instant at 60s count_over_time({app="a"} | json bad="user[" [1m])
+  expect fail msg: cannot parse expression
+
+# regexp()
+clear
+load
+  {app="a"} "GET /home 200" @ 20s [repeat every 20s for 4]
+  {app="noise"} "GET /home 200" @ 20s [repeat every 20s for 4]
+
+eval instant at 60s count_over_time({app="a"} | regexp `(?P<method>\w+) (?P<path>\S+) (?P<status>\d+)` [1m])
+  {app="a", method="GET", path="/home", status="200"} 3
+eval range from 40s to 80s step 20s count_over_time({app="a"} | regexp `(?P<method>\w+) (?P<path>\S+) (?P<status>\d+)` [1m])  # overlapping
+  {app="a", method="GET", path="/home", status="200"} 2 3 3
+eval range from 60s to 180s step 120s count_over_time({app="a"} | regexp `(?P<method>\w+) (?P<path>\S+) (?P<status>\d+)` [1m]) # non-overlapping
+  {app="a", method="GET", path="/home", status="200"} 3 _
+
+# regexp() edge cases:
+# - A non-match extracts nothing and keeps the line.
+# - A clashing name gets `_extracted`.
+# - An invalid regexp fails at parse time (no capture, duplicate name, or bad syntax).
+clear
+load
+  {app="a", method="stream"} "PUT /x" @ 20s [repeat every 20s for 3]
+  {app="noise"} "y" @ 20s [repeat every 20s for 3]
+
+eval instant at 60s count_over_time({app="a"} | regexp `(?P<num>\d+)` [1m])
+  {app="a", method="stream"} 3
+eval instant at 60s count_over_time({app="a"} | regexp `(?P<method>\w+) (?P<path>\S+)` [1m])
+  {app="a", method="stream", method_extracted="PUT", path="/x"} 3
+eval range from 40s to 60s step 20s count_over_time({app="a"} | regexp `(?P<method>\w+) (?P<path>\S+)` [1m])  # overlapping
+  {app="a", method="stream", method_extracted="PUT", path="/x"} 2 3
+eval instant at 60s count_over_time({app="a"} | regexp `nocapture` [1m])
+  expect fail msg: at least one named capture must be supplied
+eval instant at 60s count_over_time({app="a"} | regexp `(?P<x>.)(?P<x>.)` [1m])
+  expect fail msg: duplicate extracted label name
+eval instant at 60s count_over_time({app="a"} | regexp `(` [1m])
+  expect fail msg: error parsing regexp
+
+# pattern()
+clear
+load
+  {app="a"} "GET /home 200" @ 20s [repeat every 20s for 4]
+  {app="noise"} "GET /home 200" @ 20s [repeat every 20s for 4]
+
+eval instant at 60s count_over_time({app="a"} | pattern `<method> <path> <status>` [1m])
+  {app="a", method="GET", path="/home", status="200"} 3
+eval range from 40s to 80s step 20s count_over_time({app="a"} | pattern `<method> <path> <status>` [1m])  # overlapping
+  {app="a", method="GET", path="/home", status="200"} 2 3 3
+eval range from 60s to 180s step 120s count_over_time({app="a"} | pattern `<method> <path> <status>` [1m]) # non-overlapping
+  {app="a", method="GET", path="/home", status="200"} 3 _
+# `<_>` skips a field.
+eval instant at 60s count_over_time({app="a"} | pattern `<method> <_> <status>` [1m])
+  {app="a", method="GET", status="200"} 3
+
+# pattern() edge cases:
+# - A short line fills only the leading captures.
+# - A clashing name gets `_extracted`.
+# - A pattern with no capture fails at parse time.
+clear
+load
+  {app="a", method="stream"} "POST" @ 20s [repeat every 20s for 3]
+  {app="noise"} "y" @ 20s [repeat every 20s for 3]
+
+eval instant at 60s count_over_time({app="a"} | pattern `<method> <path>` [1m])
+  {app="a", method="stream", method_extracted="POST"} 3
+eval range from 40s to 60s step 20s count_over_time({app="a"} | pattern `<method> <path>` [1m])  # overlapping
+  {app="a", method="stream", method_extracted="POST"} 2 3
+eval instant at 60s count_over_time({app="a"} | pattern `no captures here` [1m])
+  expect fail msg: at least one capture is required
+
+# unpack() promotes to labels the string fields of a json line.
+clear
+load
+  {app="a"} `{"lvl":"info","cluster":"eu","num":5,"_entry":"real message"}` @ 20s [repeat every 20s for 4]
+  {app="noise"} `{"a":"b","_entry":"x"}` @ 20s [repeat every 20s for 4]
+
+eval instant at 60s count_over_time({app="a"} | unpack [1m])
+  {app="a", lvl="info", cluster="eu"} 3
+eval range from 40s to 80s step 20s count_over_time({app="a"} | unpack [1m])  # overlapping
+  {app="a", lvl="info", cluster="eu"} 2 3 3
+eval range from 60s to 180s step 120s count_over_time({app="a"} | unpack [1m]) # non-overlapping
+  {app="a", lvl="info", cluster="eu"} 3 _
+
+# unpack() edge cases:
+# - A clashing name gets `_extracted`.
+# - The promoted `_entry` line feeds a following parser.
+clear
+load
+  {app="a", lvl="stream"} `{"lvl":"packed","_entry":"code=42"}` @ 20s [repeat every 20s for 3]
+  {app="noise"} `{"_entry":"x"}` @ 20s [repeat every 20s for 3]
+
+eval instant at 60s count_over_time({app="a"} | unpack [1m])
+  {app="a", lvl="stream", lvl_extracted="packed"} 3
+eval instant at 60s count_over_time({app="a"} | unpack | logfmt [1m])
+  {app="a", lvl="stream", lvl_extracted="packed", code="42"} 3
+eval range from 40s to 60s step 20s count_over_time({app="a"} | unpack | logfmt [1m])  # overlapping
+  {app="a", lvl="stream", lvl_extracted="packed", code="42"} 2 3
+
+# unpack() fails on a non-json line; a __error__ filter drops it.
+clear
+load
+  {app="a"} "not json" @ 20s [repeat every 20s for 3]
+  {app="noise"} `{"_entry":"x"}` @ 20s [repeat every 20s for 3]
+
+eval instant at 60s count_over_time({app="a"} | unpack [1m])
+  expect fail msg: JSONParserErr
+eval instant at 60s count_over_time({app="a"} | unpack | __error__="" [1m])
+  expect empty


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `parsers.logqltest` suite to the declarative `logqltest` corpus, covering the LogQL parsers that had no dedicated coverage: `logfmt`, `json`, `regexp`, `pattern`, and `unpack`. Each scenario checks label extraction plus the edge cases: key sanitization, clashes resolved with `_extracted` (across stream labels, structured metadata, and parsed fields — all combinations), duplicate keys, quoted values, nested/flattened json, null/array handling, malformed input, and parse errors.

Two small `logqltest` DSL/harness improvements were needed to write these tests:
- The `load` line now accepts a **backtick raw log line** so a line can contain `"` (required for JSON bodies).
- Expected results now **preserve empty-value labels**, so a test can assert `{a=""}` distinctly from an absent label.

**Which issue(s) this PR fixes**:
N/A — test and test-harness only.

**Special notes for your reviewer**:

No production code is changed — only the `logqltest` harness (`internal/logqltest/`) and its test data. Expected values are hand-computed and cross-checked against the engine.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
