### PR TITLE
feat(distributor): Skip reject_old_samples validation for backfill streams

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -807,9 +807,18 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 			prevTs := stream.Entries[0].Timestamp
 			streamEntriesSize := 0
 
+			// Backfilled data is expected to be older than reject_old_samples_max_age. The backfill
+			// label is reserved: the push parsers reject streams that already carry it, so it can
+			// only originate from the X-Loki-Backfill-Shard header and cannot be spoofed to bypass
+			// validation. Entries too far in the future are still rejected.
+			entryValidationContext := validationContext
+			if lbs.Has(constants.BackfillLabel) {
+				entryValidationContext.rejectOldSample = false
+			}
+
 			labelNamer := otlptranslator.LabelNamer{}
 			for _, entry := range stream.Entries {
-				if err := d.validator.ValidateEntry(ctx, validationContext, lbs, entry, retentionHours, policy, format); err != nil {
+				if err := d.validator.ValidateEntry(ctx, entryValidationContext, lbs, entry, retentionHours, policy, format); err != nil {
 					d.writeFailuresManager.Log(tenantID, err)
 					validationErrors.Add(err)
 					continue

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1952,6 +1952,58 @@ func TestDistributor_PushShardStreamsPolicyOverride(t *testing.T) {
 	require.False(t, otherSharded, "non-foo stream should not be time-sharded (tenant default off)")
 }
 
+// TestDistributor_PushBackfillBypassesRejectOldSamples verifies that streams carrying the internal
+// backfill label skip the reject_old_samples validation (backfill data is old by definition), while
+// regular streams on the same tenant are still subject to it and the too-far-in-future check stays
+// in force for backfill streams.
+func TestDistributor_PushBackfillBypassesRejectOldSamples(t *testing.T) {
+	limits := &validation.Limits{}
+	flagext.DefaultValues(limits)
+	limits.RejectOldSamples = true
+	require.NoError(t, limits.RejectOldSamplesMaxAge.Set("24h"))
+	require.NoError(t, limits.Validate())
+
+	distributors, ingesters := prepare(t, 1, 3, limits, nil)
+
+	old := time.Now().Add(-48 * time.Hour)
+	backfillLbls := fmt.Sprintf(`{app="backfilled", %s="true", %s="shard-1"}`, constants.BackfillLabel, constants.BackfillShardLabel)
+	mkReq := func(lbls string, ts time.Time) *logproto.PushRequest {
+		return &logproto.PushRequest{Streams: []logproto.Stream{{
+			Labels:  lbls,
+			Entries: []logproto.Entry{{Timestamp: ts, Line: "a"}},
+		}}}
+	}
+
+	// A regular stream with an entry older than reject_old_samples_max_age is rejected.
+	_, err := distributors[0].Push(ctx, mkReq(`{app="regular"}`, old))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timestamp too old")
+
+	// A backfill stream with an entry too far in the future is still rejected.
+	_, err = distributors[0].Push(ctx, mkReq(backfillLbls, time.Now().Add(time.Hour)))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timestamp too new")
+
+	// The same old entry on a backfill stream is accepted and reaches the ingesters.
+	_, err = distributors[0].Push(ctx, mkReq(backfillLbls, old))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		for i := range ingesters {
+			ingesters[i].mu.Lock()
+			for _, pr := range ingesters[i].pushed {
+				for _, st := range pr.Streams {
+					if strings.Contains(st.Labels, `app="backfilled"`) {
+						ingesters[i].mu.Unlock()
+						return true
+					}
+				}
+			}
+			ingesters[i].mu.Unlock()
+		}
+		return false
+	}, time.Second, 10*time.Millisecond, "expected the backfill stream to reach the ingesters")
+}
+
 // TestDistributor_PushBackfillDisablesTimeSharding verifies that streams carrying the internal
 // backfill label are not time-sharded by Loki even when time sharding is enabled, because backfill
 // workers implement time sharding on the client side (via constants.BackfillShardLabel). A regular

--- a/pkg/loghttp/push/backfill.go
+++ b/pkg/loghttp/push/backfill.go
@@ -69,3 +69,10 @@ func ExtractBackfillShardContext(ctx context.Context) string {
 func errReservedBackfillLabels() error {
 	return fmt.Errorf("streams must not contain the reserved labels %s or %s; set the %s header to mark a push as backfill data", constants.BackfillLabel, constants.BackfillShardLabel, HTTPHeaderBackfillShardKey)
 }
+
+// hasReservedBackfillLabels reports whether ls carries either internal backfill label.
+func hasReservedBackfillLabels(ls model.LabelSet) bool {
+	_, hasBackfillLabel := ls[constants.BackfillLabel]
+	_, hasBackfillShardLabel := ls[constants.BackfillShardLabel]
+	return hasBackfillLabel || hasBackfillShardLabel
+}

--- a/pkg/loghttp/push/backfill.go
+++ b/pkg/loghttp/push/backfill.go
@@ -6,11 +6,15 @@ import (
 	"net/http"
 
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/loki/v3/pkg/util/constants"
 )
 
 // HTTPHeaderBackfillShardKey is the HTTP header set by a backfill worker to mark a push as backfill
 // data. When present and valid, Loki adds the internal labels constants.BackfillLabel and
-// constants.BackfillShardLabel to every stream in the request.
+// constants.BackfillShardLabel to every stream in the request. Those labels are reserved: pushes
+// whose streams already carry them are rejected, so this header is the only way to produce them and
+// the distributor can safely relax validation (reject_old_samples) for streams carrying them.
 //
 // The value is opaque to Loki: it may be a uuid, a hash, a time bucket (e.g. "2026-06-10") or any
 // other identifier. Its only purpose is to implement time sharding on the client side by producing
@@ -57,4 +61,11 @@ func ExtractBackfillShardContext(ctx context.Context) string {
 		return ""
 	}
 	return shard
+}
+
+// errReservedBackfillLabels rejects streams that already carry the internal backfill labels.
+// They are reserved: only Loki itself may add them (from the X-Loki-Backfill-Shard header),
+// since the distributor relaxes validation (e.g. reject_old_samples) for streams carrying them.
+func errReservedBackfillLabels() error {
+	return fmt.Errorf("streams must not contain the reserved labels %s or %s; set the %s header to mark a push as backfill data", constants.BackfillLabel, constants.BackfillShardLabel, HTTPHeaderBackfillShardKey)
 }

--- a/pkg/loghttp/push/backfill_test.go
+++ b/pkg/loghttp/push/backfill_test.go
@@ -137,6 +137,22 @@ func TestParseRequest_BackfillShard(t *testing.T) {
 		require.Nil(t, req)
 	})
 
+	t.Run("otlp: reserved backfill label via indexed log attribute is rejected", func(t *testing.T) {
+		// Log attributes promoted to index labels are merged into the stream labels after the
+		// resource-attribute check, so they must be checked as well.
+		ld := singleResourceLogs("service.name", "service-1")
+		ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().PutStr(constants.BackfillLabel, "true")
+
+		cfg := DefaultOTLPConfig(GlobalOTLPConfig{DefaultOTLPResourceAttributesAsIndexLabels: []string{"service.name"}})
+		cfg.LogAttributes = []AttributesConfig{{Action: IndexLabel, Attributes: []string{constants.BackfillLabel}}}
+
+		stats := NewPushStats()
+		streamResolver := newMockStreamResolver("fake", &fakeLimits{})
+		_, err := otlpToLokiPushRequest(context.Background(), ld, "fake", cfg, nil, []string{}, NewMockTracker(), stats, gokitlog.NewNopLogger(), streamResolver, constants.OTLP)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "reserved")
+	})
+
 	t.Run("otlp: restrictive tenant config cannot drop backfill labels", func(t *testing.T) {
 		// Service-name discovery is off and the only indexed attribute does not match the resource,
 		// so without injection this stream would carry no index labels at all.

--- a/pkg/loghttp/push/backfill_test.go
+++ b/pkg/loghttp/push/backfill_test.go
@@ -108,6 +108,35 @@ func TestParseRequest_BackfillShard(t *testing.T) {
 		requireBackfillLabels(t, req.Streams[0].Labels)
 	})
 
+	t.Run("loki: reserved backfill label in body is rejected", func(t *testing.T) {
+		body := `{"streams":[{"stream":{"foo":"bar","` + constants.BackfillLabel + `":"true"},"values":[["1570818238000000000","fizzbuzz"]]}]}`
+		req, err := parse(newBackfillLokiRequest(body, ""), ParseLokiRequest, &fakeLimits{enabled: true, labels: []string{"foo"}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "reserved")
+		require.Nil(t, req)
+	})
+
+	t.Run("loki: reserved backfill shard label in body is rejected even with the header set", func(t *testing.T) {
+		body := `{"streams":[{"stream":{"foo":"bar","` + constants.BackfillShardLabel + `":"spoofed"},"values":[["1570818238000000000","fizzbuzz"]]}]}`
+		req, err := parse(newBackfillLokiRequest(body, testBackfillShard), ParseLokiRequest, &fakeLimits{enabled: true, labels: []string{"foo"}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "reserved")
+		require.Nil(t, req)
+	})
+
+	t.Run("otlp: reserved backfill label via indexed resource attribute is rejected", func(t *testing.T) {
+		// The OTLP label namer keeps __backfill__ as-is, so a resource attribute promoted to an
+		// index label could smuggle it in without this check.
+		req, err := parse(
+			newBackfillOTLPRequest(t, singleResourceLogs("service.name", "service-1", constants.BackfillLabel, "true"), ""),
+			ParseOTLPRequest,
+			&fakeLimits{enabled: true, indexAttributes: []string{constants.BackfillLabel}},
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "reserved")
+		require.Nil(t, req)
+	})
+
 	t.Run("otlp: restrictive tenant config cannot drop backfill labels", func(t *testing.T) {
 		// Service-name discovery is off and the only indexed attribute does not match the resource,
 		// so without injection this stream would carry no index labels at all.

--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -185,6 +185,14 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 		resourceAttributesAsStructuredMetadata := resResult.StructuredMetadata
 		streamLabels := resResult.StreamLabels
 
+		// The backfill labels are reserved for Loki: they may only be added below, from the
+		// X-Loki-Backfill-Shard header, so clients cannot spoof them to bypass validation.
+		_, hasBackfillLabel := streamLabels[constants.BackfillLabel]
+		_, hasBackfillShardLabel := streamLabels[constants.BackfillShardLabel]
+		if hasBackfillLabel || hasBackfillShardLabel {
+			return nil, errReservedBackfillLabels()
+		}
+
 		if backfillShard != "" {
 			streamLabels[constants.BackfillLabel] = "true"
 			streamLabels[constants.BackfillShardLabel] = model.LabelValue(backfillShard)

--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -187,9 +187,7 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 
 		// The backfill labels are reserved for Loki: they may only be added below, from the
 		// X-Loki-Backfill-Shard header, so clients cannot spoof them to bypass validation.
-		_, hasBackfillLabel := streamLabels[constants.BackfillLabel]
-		_, hasBackfillShardLabel := streamLabels[constants.BackfillShardLabel]
-		if hasBackfillLabel || hasBackfillShardLabel {
+		if hasReservedBackfillLabels(streamLabels) {
 			return nil, errReservedBackfillLabels()
 		}
 
@@ -305,6 +303,12 @@ func otlpToLokiPushRequest(ctx context.Context, ld plog.Logs, userID string, otl
 				var entryLbs labels.Labels
 
 				if len(logLabels) > 0 {
+					// Log attributes promoted to index labels must not smuggle in the reserved
+					// backfill labels either (they would overwrite the header-injected ones).
+					if hasReservedBackfillLabels(logLabels) {
+						return nil, errReservedBackfillLabels()
+					}
+
 					// Combine resource labels with log attributes
 					combinedLabels := make(model.LabelSet, len(streamLabels)+len(logLabels))
 					for k, v := range streamLabels {

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -456,6 +456,12 @@ func ParseLokiRequest(userID string, r *http.Request, limits Limits, tenantConfi
 			return nil, nil, fmt.Errorf("couldn't parse labels: %w", err)
 		}
 
+		// The backfill labels are reserved for Loki: they may only be added below, from the
+		// X-Loki-Backfill-Shard header, so clients cannot spoof them to bypass validation.
+		if lbs.Has(constants.BackfillLabel) || lbs.Has(constants.BackfillShardLabel) {
+			return nil, nil, errReservedBackfillLabels()
+		}
+
 		// Check if this is an aggregated metric or pattern stream
 		isInternalStream := false
 		if lbs.Has(constants.AggregatedMetricLabel) || lbs.Has(constants.PatternLabel) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Skips the `reject_old_samples` validation in the distributor for streams carrying the internal `__backfill__` label (added from the `X-Loki-Backfill-Shard` header, #23248) — backfill data is old by definition.

To make this safe, the backfill labels are now reserved: the Loki and OTLP push parsers reject requests whose streams already carry them, so the labels can only originate from the header and cannot be spoofed to bypass validation. The `creation_grace_period` (too far in future) check remains in force for backfill streams.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

Verified end-to-end against a local single-binary Loki with `reject_old_samples_max_age: 1h`: a 2-day-old push is rejected without the header, accepted with it (and queryable after flush), and pushes spoofing the reserved labels in the body are rejected with 400.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)