### PR TITLE
feat(config): Add option for non-strict config parsing

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -56,7 +56,8 @@ func main() {
 		fmt.Println(version.Print("loki"))
 		os.Exit(0)
 	}
-	if err := cfg.DynamicUnmarshal(&config, os.Args[1:], flag.CommandLine); err != nil {
+	unknownFields, err := cfg.DynamicUnmarshal(&config, os.Args[1:], flag.CommandLine)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed parsing config: %v\n", err)
 		os.Exit(1)
 	}
@@ -81,6 +82,11 @@ func main() {
 	}
 	serverCfg := &config.Server
 	serverCfg.Log = util_log.InitLogger(serverCfg, prometheus.DefaultRegisterer, false)
+
+	// Report unknown configuration options now that the logger is initialized.
+	// Strict parsing already failed above, so any entries here mean non-strict
+	// parsing was requested.
+	unknownFields.Report(util_log.Logger)
 
 	if config.InternalServer.Enable {
 		config.InternalServer.Log = serverCfg.Log

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -64,14 +64,14 @@ func main() {
 
 	var sourceConfig loki.ConfigWrapper
 	srcArgs := []string{"-config.file=" + *sf}
-	if err := cfg.DynamicUnmarshal(&sourceConfig, srcArgs, flag.NewFlagSet("config-file-loader", flag.ContinueOnError)); err != nil {
+	if _, err := cfg.DynamicUnmarshal(&sourceConfig, srcArgs, flag.NewFlagSet("config-file-loader", flag.ContinueOnError)); err != nil {
 		fmt.Fprintf(os.Stderr, "failed parsing config: %v\n", err)
 		os.Exit(1)
 	}
 
 	var destConfig loki.ConfigWrapper
 	destArgs := []string{"-config.file=" + *df}
-	if err := cfg.DynamicUnmarshal(&destConfig, destArgs, flag.NewFlagSet("config-file-loader", flag.ContinueOnError)); err != nil {
+	if _, err := cfg.DynamicUnmarshal(&destConfig, destArgs, flag.NewFlagSet("config-file-loader", flag.ContinueOnError)); err != nil {
 		fmt.Fprintf(os.Stderr, "failed parsing config: %v\n", err)
 		os.Exit(1)
 	}

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -37,6 +37,15 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 ## Main / Unreleased
 
+### Non-strict configuration parsing
+
+Loki now accepts a `-config.strict` flag (default `true`). Strict parsing is
+unchanged from previous releases: unknown command-line flags and unknown YAML
+configuration fields still fail startup. Set `-config.strict=false` to instead
+log unknown options at the `WARN` level, count them in the new
+`loki_unknown_config_total` metric, and continue startup. This eases sharing a
+single configuration set between Grafana Enterprise Logs and OSS Loki.
+
 ### Breaking change: Removal of the `row_shards` schema setting
 
 The `row_shards` setting on a `schema_config` `period_config` has been removed. It configured a static query shard factor for legacy (non-TSDB) index types. TSDB, the only supported index type, resolves log and metric query sharding dynamically from index statistics and ignores `row_shards`; series queries continue to use the previous default factor of 16. Because schema config is parsed strictly, a leftover `row_shards:` key now fails config load. Remove the `row_shards` setting from every `period_config`; the `deprecated-config-checker` tool will flag it.

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -37,6 +37,18 @@ format](https://en.wikipedia.org/wiki/YAML), defined by the scheme below.
 Brackets indicate that a parameter is optional. For non-list parameters the
 value is set to the specified default.
 
+### Strict configuration parsing
+
+By default, Loki parses configuration strictly: an unknown command-line flag or
+an unknown YAML configuration field causes Loki to fail at startup. This helps
+catch typos and misconfiguration.
+
+Set `-config.strict=false` to relax this behavior. Unknown flags and fields are
+then logged at the `WARN` level and ignored instead of aborting startup, and the
+`loki_unknown_config_total` metric counts how many unknown options were seen.
+This is useful when sharing a single configuration set between Grafana
+Enterprise Logs and OSS Loki, where each recognizes options the other does not.
+
 ### Use environment variables in the configuration
 
 > **Note:** This feature is only available in Loki 2.1+.

--- a/docs/templates/configuration.template
+++ b/docs/templates/configuration.template
@@ -37,6 +37,18 @@ format](https://en.wikipedia.org/wiki/YAML), defined by the scheme below.
 Brackets indicate that a parameter is optional. For non-list parameters the
 value is set to the specified default.
 
+### Strict configuration parsing
+
+By default, Loki parses configuration strictly: an unknown command-line flag or
+an unknown YAML configuration field causes Loki to fail at startup. This helps
+catch typos and misconfiguration.
+
+Set `-config.strict=false` to relax this behavior. Unknown flags and fields are
+then logged at the `WARN` level and ignored instead of aborting startup, and the
+`loki_unknown_config_total` metric counts how many unknown options were seen.
+This is useful when sharing a single configuration set between Grafana
+Enterprise Logs and OSS Loki, where each recognizes options the other does not.
+
 ### Use environment variables in the configuration
 
 > **Note:** This feature is only available in Loki 2.1+.

--- a/integration/cluster/cluster.go
+++ b/integration/cluster/cluster.go
@@ -427,7 +427,7 @@ func (c *Component) run() error {
 
 	flagset := flag.NewFlagSet("test-flags", flag.ExitOnError)
 
-	if err := cfg.DynamicUnmarshal(&config, append(
+	if _, err := cfg.DynamicUnmarshal(&config, append(
 		c.flags,
 		"-config.file", c.configFile,
 		"-runtime-config.file", c.overridesFile,

--- a/pkg/logcli/query/query.go
+++ b/pkg/logcli/query/query.go
@@ -438,7 +438,7 @@ func (q *Query) DoLocalQuery(out output.LogOutput, statistics bool, orgID string
 	if q.LocalConfig == "" {
 		return errors.New("no supplied config file")
 	}
-	if err := cfg.YAML(q.LocalConfig, false, true)(&conf); err != nil {
+	if err := cfg.YAML(q.LocalConfig, false, true, nil)(&conf); err != nil {
 		return err
 	}
 

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -31,14 +31,14 @@ const versionFlag = "version"
 // on the logic in ApplyDynamicConfig, which receives values set in config file
 type ConfigWrapper struct {
 	Config          `yaml:",inline"`
-	printVersion    bool
-	VerifyConfig    bool
-	PrintConfig     bool
-	ListTargets     bool
-	LogConfig       bool
-	ConfigFile      string
-	ConfigExpandEnv bool
-	Strict          bool
+	printVersion    bool   `yaml:"-"`
+	VerifyConfig    bool   `yaml:"-"`
+	PrintConfig     bool   `yaml:"-"`
+	ListTargets     bool   `yaml:"-"`
+	LogConfig       bool   `yaml:"-"`
+	ConfigFile      string `yaml:"-"`
+	ConfigExpandEnv bool   `yaml:"-"`
+	Strict          bool   `yaml:"-"`
 }
 
 func PrintVersion(args []string) bool {

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -38,6 +38,7 @@ type ConfigWrapper struct {
 	LogConfig       bool
 	ConfigFile      string
 	ConfigExpandEnv bool
+	Strict          bool
 }
 
 func PrintVersion(args []string) bool {
@@ -59,7 +60,13 @@ func (c *ConfigWrapper) RegisterFlags(f *flag.FlagSet) {
 		"level with the order reversed, reversing the order makes viewing the entries easier in Grafana.")
 	f.StringVar(&c.ConfigFile, "config.file", "config.yaml,config/config.yaml", "configuration file to load, can be a comma separated list of paths, first existing file will be used")
 	f.BoolVar(&c.ConfigExpandEnv, "config.expand-env", false, "Expands ${var} in config according to the values of the environment variables.")
+	f.BoolVar(&c.Strict, "config.strict", true, "When true, unknown CLI flags and YAML config fields cause Loki to fail at startup. When false, they are logged at WARN, counted in loki_unknown_config_total, and ignored.")
 	c.Config.RegisterFlags(f)
+}
+
+// StrictConfig reports whether unknown configuration options are fatal.
+func (c *ConfigWrapper) StrictConfig() bool {
+	return c.Strict
 }
 
 // Clone takes advantage of pass-by-value semantics to return a distinct *Config.

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -61,7 +61,7 @@ func configWrapperFromYAML(t *testing.T, configFileString string, args []string)
 	} else {
 		args = append(args, configFileArgs...)
 	}
-	err = cfg.DynamicUnmarshal(&config, args, fs)
+	_, err = cfg.DynamicUnmarshal(&config, args, fs)
 	if err != nil {
 		return ConfigWrapper{}, ConfigWrapper{}, err
 	}

--- a/pkg/util/cfg/cfg.go
+++ b/pkg/util/cfg/cfg.go
@@ -47,7 +47,7 @@ func Unmarshal(dst Cloneable, sources ...Source) error {
 func DefaultUnmarshal(dst Cloneable, args []string, fs *flag.FlagSet) error {
 	return Unmarshal(dst,
 		Defaults(fs),
-		ConfigFileLoader(args, "config.file", true),
+		ConfigFileLoader(args, "config.file", true, nil),
 		Flags(args, fs),
 	)
 }

--- a/pkg/util/cfg/cfg_test.go
+++ b/pkg/util/cfg/cfg_test.go
@@ -18,7 +18,7 @@ server:
   timeout: 60h
 tls:
   key: YAML
-`), true)
+`), true, nil)
 
 	fs := flag.NewFlagSet(t.Name(), flag.PanicOnError)
 	flagSource := dFlags(fs, []string{"-verbose", "-server.port=21"})
@@ -51,7 +51,7 @@ servers:
   timeoutz: 60h
 tls:
   keey: YAML
-`), true)
+`), true, nil)
 
 	fs := flag.NewFlagSet(t.Name(), flag.PanicOnError)
 	flagSource := dFlags(fs, []string{"-verbose", "-server.port=21"})

--- a/pkg/util/cfg/dynamic.go
+++ b/pkg/util/cfg/dynamic.go
@@ -2,6 +2,8 @@ package cfg
 
 import (
 	"flag"
+	"fmt"
+	"strings"
 )
 
 // DynamicCloneable must be implemented by config structs that can be dynamically unmarshalled
@@ -10,19 +12,32 @@ type DynamicCloneable interface {
 	ApplyDynamicConfig() Source
 }
 
+// StrictParser is implemented by config types that can toggle strict parsing.
+// When StrictConfig reports true, unknown configuration options are treated as
+// a fatal error; otherwise they are collected for non-strict reporting.
+type StrictParser interface {
+	StrictConfig() bool
+}
+
 // DynamicUnmarshal handles populating a config based on the following precedence:
 // 1. Defaults provided by the `RegisterFlags` interface
 // 2. Sections populated by dynamic logic. Configs passed to this function must implement ApplyDynamicConfig()
 // 3. Any config options specified directly in the config file
 // 4. Any config options specified on the command line.
-func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet) error {
-	return Unmarshal(dst,
+//
+// Unknown configuration options are always collected. When dst implements
+// StrictParser and requests strict parsing, their presence is a fatal error;
+// otherwise the returned UnknownFields lets the caller report them once the
+// logger and metrics registry are initialized.
+func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet) (*UnknownFields, error) {
+	unknown := &UnknownFields{}
+	err := Unmarshal(dst,
 		// First populate the config with defaults including flags from the command line
 		Defaults(fs),
 		// Next populate the config from the config file, we do this to populate the `common`
 		// section of the config file by taking advantage of the code in ConfigFileLoader which will load
 		// and process the config file.
-		ConfigFileLoader(args, "config.file", true),
+		ConfigFileLoader(args, "config.file", true, unknown),
 		// Now load the flags again, this will supersede anything set from config file with flags from the command line.
 		Flags(args, fs),
 		// Apply any dynamic logic to set other defaults in the config. This function is called after parsing the
@@ -34,9 +49,20 @@ func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet) err
 		// By loading the config file twice and unmarshaling it into the same object,
 		// using strict yaml unmarshal causes an `already set in map` error with the `Clients` config,
 		// because it's a map that already has the keys we are trying to unmarshal into it.
-		// That is why we don't use strict for the second marshaling.
-		ConfigFileLoader(args, "config.file", false),
+		// That is why we don't use strict for the second marshaling. Unknown fields were already
+		// collected on the first pass, so we pass a nil collector here to avoid double counting.
+		ConfigFileLoader(args, "config.file", false, nil),
 		// Load the flags again, this will supersede anything set from config file with flags from the command line.
 		Flags(args, fs),
 	)
+	if err != nil {
+		return unknown, err
+	}
+
+	// Enforce strictness only after the full config is resolved, since the
+	// strict toggle is itself a configuration option.
+	if sp, ok := dst.(StrictParser); ok && sp.StrictConfig() && unknown.Len() > 0 {
+		return unknown, fmt.Errorf("found %d unknown configuration option(s): %s", unknown.Len(), strings.Join(unknown.List(), ", "))
+	}
+	return unknown, nil
 }

--- a/pkg/util/cfg/dynamic.go
+++ b/pkg/util/cfg/dynamic.go
@@ -31,6 +31,15 @@ type StrictParser interface {
 // logger and metrics registry are initialized.
 func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet) (*UnknownFields, error) {
 	unknown := &UnknownFields{}
+
+	// Discover the defined flags on a throwaway flagset so unknown CLI flags can
+	// be filtered out before any parsing. This mirrors how ConfigFileLoader
+	// enumerates flags and prevents the flag package from aborting on unknown
+	// flags; strictness is enforced centrally once the config is resolved.
+	known := flag.NewFlagSet("known-flags", flag.ContinueOnError)
+	dst.Clone().RegisterFlags(known)
+	args = filterUnknownFlags(known, args, unknown)
+
 	err := Unmarshal(dst,
 		// First populate the config with defaults including flags from the command line
 		Defaults(fs),

--- a/pkg/util/cfg/dynamic.go
+++ b/pkg/util/cfg/dynamic.go
@@ -3,6 +3,7 @@ package cfg
 import (
 	"flag"
 	"fmt"
+	"io"
 	"strings"
 )
 
@@ -25,20 +26,42 @@ type StrictParser interface {
 // 3. Any config options specified directly in the config file
 // 4. Any config options specified on the command line.
 //
-// Unknown configuration options are always collected. When dst implements
-// StrictParser and requests strict parsing, their presence is a fatal error;
-// otherwise the returned UnknownFields lets the caller report them once the
-// logger and metrics registry are initialized.
+// Strictness is resolved up front from the CLI flags. In strict mode (the
+// default) an unknown YAML field fails fast with the decoder's native error,
+// which includes the config file path, line number, and parent type, and an
+// unknown CLI flag is reported after parsing. In non-strict mode unknown fields
+// and flags are collected into the returned UnknownFields so the caller can
+// report them once the logger and metrics registry are initialized.
 func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet) (*UnknownFields, error) {
 	unknown := &UnknownFields{}
 
-	// Discover the defined flags on a throwaway flagset so unknown CLI flags can
-	// be filtered out before any parsing. This mirrors how ConfigFileLoader
-	// enumerates flags and prevents the flag package from aborting on unknown
-	// flags; strictness is enforced centrally once the config is resolved.
+	// Discover the defined flags on a throwaway config clone so unknown CLI
+	// flags can be filtered out before any parsing. This mirrors how
+	// ConfigFileLoader enumerates flags and prevents the flag package from
+	// aborting on unknown flags.
+	clone := dst.Clone()
 	known := flag.NewFlagSet("known-flags", flag.ContinueOnError)
-	dst.Clone().RegisterFlags(known)
+	known.SetOutput(io.Discard)
+	clone.RegisterFlags(known)
 	args = filterUnknownFlags(known, args, unknown)
+
+	// Resolve the effective strict setting from the (filtered) CLI flags before
+	// deciding how to parse the config file.
+	strict := true
+	if sp, ok := clone.(StrictParser); ok {
+		// args no longer contain unknown flags, so parsing only fails on
+		// -h/-help, which is handled later by ConfigFileLoader; ignore it here.
+		_ = known.Parse(args)
+		strict = sp.StrictConfig()
+	}
+
+	// In strict mode unknown YAML fields must fail fast with the decoder's
+	// native, fully contextual error, so no collector is passed to the YAML
+	// loader. In non-strict mode they are collected for deferred reporting.
+	var yamlUnknown *UnknownFields
+	if !strict {
+		yamlUnknown = unknown
+	}
 
 	err := Unmarshal(dst,
 		// First populate the config with defaults including flags from the command line
@@ -46,7 +69,7 @@ func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet) (*U
 		// Next populate the config from the config file, we do this to populate the `common`
 		// section of the config file by taking advantage of the code in ConfigFileLoader which will load
 		// and process the config file.
-		ConfigFileLoader(args, "config.file", true, unknown),
+		ConfigFileLoader(args, "config.file", strict, yamlUnknown),
 		// Now load the flags again, this will supersede anything set from config file with flags from the command line.
 		Flags(args, fs),
 		// Apply any dynamic logic to set other defaults in the config. This function is called after parsing the
@@ -58,8 +81,7 @@ func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet) (*U
 		// By loading the config file twice and unmarshaling it into the same object,
 		// using strict yaml unmarshal causes an `already set in map` error with the `Clients` config,
 		// because it's a map that already has the keys we are trying to unmarshal into it.
-		// That is why we don't use strict for the second marshaling. Unknown fields were already
-		// collected on the first pass, so we pass a nil collector here to avoid double counting.
+		// That is why we don't use strict for the second marshaling.
 		ConfigFileLoader(args, "config.file", false, nil),
 		// Load the flags again, this will supersede anything set from config file with flags from the command line.
 		Flags(args, fs),
@@ -68,10 +90,10 @@ func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet) (*U
 		return unknown, err
 	}
 
-	// Enforce strictness only after the full config is resolved, since the
-	// strict toggle is itself a configuration option.
-	if sp, ok := dst.(StrictParser); ok && sp.StrictConfig() && unknown.Len() > 0 {
-		return unknown, fmt.Errorf("found %d unknown configuration option(s): %s", unknown.Len(), strings.Join(unknown.List(), ", "))
+	// Unknown YAML fields already failed fast above in strict mode. Unknown CLI
+	// flags are filtered before parsing, so their strictness is enforced here.
+	if strict && unknown.Len() > 0 {
+		return unknown, fmt.Errorf("found %d unknown CLI flag(s): %s", unknown.Len(), strings.Join(unknown.List(), ", "))
 	}
 	return unknown, nil
 }

--- a/pkg/util/cfg/dynamic_test.go
+++ b/pkg/util/cfg/dynamic_test.go
@@ -34,7 +34,7 @@ server:
 			args = append(args, configFileArgs...)
 		}
 
-		err = DynamicUnmarshal(&data, args, fs)
+		_, err = DynamicUnmarshal(&data, args, fs)
 		require.NoError(t, err)
 		return data
 	}

--- a/pkg/util/cfg/files.go
+++ b/pkg/util/cfg/files.go
@@ -43,7 +43,8 @@ func dJSON(y []byte) Source {
 // YAML returns a Source that opens the supplied `.yaml` file and loads it.
 // When expandEnvVars is true, variables in the supplied '.yaml\ file are expanded
 // using https://pkg.go.dev/github.com/drone/envsubst?tab=overview
-func YAML(f string, expandEnvVars bool, strict bool) Source {
+// When u is non-nil, unknown fields are collected into it instead of failing.
+func YAML(f string, expandEnvVars bool, strict bool, u *UnknownFields) Source {
 	return func(dst Cloneable) error {
 		y, err := os.ReadFile(f)
 		if err != nil {
@@ -56,25 +57,34 @@ func YAML(f string, expandEnvVars bool, strict bool) Source {
 			}
 			y = []byte(s)
 		}
-		err = dYAML(y, strict)(dst)
+		err = dYAML(y, strict, u)(dst)
 		return errors.Wrap(err, f)
 	}
 }
 
-// dYAMLStrict returns a YAML source and allows dependency injection
-// argument `strict` defines whether unknown fields should be treated as error
-func dYAML(y []byte, strict bool) Source {
+// dYAML returns a YAML source and allows dependency injection.
+// argument `strict` defines whether unknown fields should be treated as error.
+// When u is non-nil, unknown fields are recorded for deferred reporting rather
+// than failing here; strictness is then enforced centrally after the full
+// config is resolved.
+func dYAML(y []byte, strict bool, u *UnknownFields) Source {
 	return func(dst Cloneable) error {
 		dec := yaml.NewDecoder(bytes.NewReader(y))
-		dec.KnownFields(strict)
-		if err := dec.Decode(dst); err != nil && err != io.EOF {
+		// Enable field checking whenever we enforce strictness or want to collect
+		// unknown fields for non-strict reporting.
+		dec.KnownFields(strict || u != nil)
+		err := dec.Decode(dst)
+		if err != nil && err != io.EOF {
+			if u != nil {
+				return u.collectYAML(err)
+			}
 			return err
 		}
 		return nil
 	}
 }
 
-func ConfigFileLoader(args []string, name string, strict bool) Source {
+func ConfigFileLoader(args []string, name string, strict bool, u *UnknownFields) Source {
 	return func(dst Cloneable) error {
 		freshFlags := flag.NewFlagSet("config-file-loader", flag.ContinueOnError)
 
@@ -109,7 +119,7 @@ func ConfigFileLoader(args []string, name string, strict bool) Source {
 				expandEnv, _ = strconv.ParseBool(expandEnvFlag.Value.String()) // Can ignore error as false returned
 			}
 			if _, err := os.Stat(val); err == nil {
-				err := YAML(val, expandEnv, strict)(dst)
+				err := YAML(val, expandEnv, strict, u)(dst)
 				if err != nil && !expandEnv {
 					err = fmt.Errorf("%w. Use `-config.expand-env=true` flag if you want to expand environment variables in your config file", err)
 				}

--- a/pkg/util/cfg/files.go
+++ b/pkg/util/cfg/files.go
@@ -65,8 +65,9 @@ func YAML(f string, expandEnvVars bool, strict bool, u *UnknownFields) Source {
 // dYAML returns a YAML source and allows dependency injection.
 // argument `strict` defines whether unknown fields should be treated as error.
 // When u is non-nil, unknown fields are recorded for deferred reporting rather
-// than failing here; strictness is then enforced centrally after the full
-// config is resolved.
+// than failing here. Callers select the mode: strict parsing passes a nil
+// collector so unknown fields fail fast with the decoder's native error, while
+// non-strict parsing passes a collector to gather them instead.
 func dYAML(y []byte, strict bool, u *UnknownFields) Source {
 	return func(dst Cloneable) error {
 		dec := yaml.NewDecoder(bytes.NewReader(y))

--- a/pkg/util/cfg/files_test.go
+++ b/pkg/util/cfg/files_test.go
@@ -24,7 +24,7 @@ func (cfg *testCfg) Clone() flagext.Registerer {
 
 func TestConfigFileLoaderDoesNotMutate(t *testing.T) {
 	cfg := &testCfg{}
-	err := ConfigFileLoader(nil, "something", true)(cfg)
+	err := ConfigFileLoader(nil, "something", true, nil)(cfg)
 	require.Nil(t, err)
 	require.Equal(t, 0, cfg.v)
 

--- a/pkg/util/cfg/flag.go
+++ b/pkg/util/cfg/flag.go
@@ -61,6 +61,13 @@ func filterUnknownFlags(fs *flag.FlagSet, args []string, u *UnknownFields) []str
 			continue
 		}
 
+		// The flag package handles -h/-help itself (returning ErrHelp when they are
+		// not registered), so keep them to preserve usage output.
+		if name == "h" || name == "help" {
+			out = append(out, arg)
+			continue
+		}
+
 		hasValue := strings.ContainsRune(arg, '=')
 		if f := fs.Lookup(name); f != nil {
 			out = append(out, arg)

--- a/pkg/util/cfg/flag.go
+++ b/pkg/util/cfg/flag.go
@@ -42,6 +42,74 @@ func dFlags(fs *flag.FlagSet, args []string) Source {
 	}
 }
 
+// filterUnknownFlags returns args with any flags not defined in fs removed,
+// recording each removed flag name in u. It lets non-strict parsing tolerate
+// unknown CLI flags instead of letting the flag package abort. A space-
+// separated value of an unknown flag is dropped too, since Loki takes no
+// positional arguments and leaving a stray token would terminate flag parsing.
+func filterUnknownFlags(fs *flag.FlagSet, args []string, u *UnknownFields) []string {
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			return append(out, args[i:]...)
+		}
+
+		name, ok := flagName(arg)
+		if !ok {
+			out = append(out, arg)
+			continue
+		}
+
+		hasValue := strings.ContainsRune(arg, '=')
+		if f := fs.Lookup(name); f != nil {
+			out = append(out, arg)
+			// A known non-boolean flag in `-name value` form consumes the next
+			// token as its value; keep them together so filtering an adjacent
+			// unknown flag cannot separate them.
+			if !hasValue && !isBoolFlag(f) && i+1 < len(args) {
+				out = append(out, args[i+1])
+				i++
+			}
+			continue
+		}
+
+		u.add(name)
+		if !hasValue && i+1 < len(args) {
+			if _, isFlag := flagName(args[i+1]); !isFlag && args[i+1] != "--" {
+				i++
+			}
+		}
+	}
+	return out
+}
+
+// flagName extracts the flag name from a CLI token, mirroring the flag
+// package's own parsing of `-name`, `--name`, and `-name=value` forms. It
+// returns false for non-flag tokens and the `--` terminator.
+func flagName(arg string) (string, bool) {
+	if len(arg) < 2 || arg[0] != '-' {
+		return "", false
+	}
+	numMinus := 1
+	if arg[1] == '-' {
+		numMinus = 2
+	}
+	name := arg[numMinus:]
+	if len(name) == 0 || name[0] == '-' || name[0] == '=' {
+		return "", false
+	}
+	if eq := strings.IndexByte(name, '='); eq >= 0 {
+		name = name[:eq]
+	}
+	return name, true
+}
+
+func isBoolFlag(f *flag.Flag) bool {
+	bf, ok := f.Value.(interface{ IsBoolFlag() bool })
+	return ok && bf.IsBoolFlag()
+}
+
 func categorizedUsage(fs *flag.FlagSet) func() {
 	categories := make(map[string][]string)
 	return func() {

--- a/pkg/util/cfg/precedence_test.go
+++ b/pkg/util/cfg/precedence_test.go
@@ -28,7 +28,7 @@ func TestYAMLOverDefaults(t *testing.T) {
 	fs := flag.NewFlagSet(t.Name(), flag.PanicOnError)
 	err := Unmarshal(&data,
 		Defaults(fs),
-		dYAML([]byte(y), true),
+		dYAML([]byte(y), true, nil),
 	)
 
 	require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestFlagOverYAML(t *testing.T) {
 
 	err := Unmarshal(&data,
 		Defaults(fs),
-		dYAML([]byte(y), true),
+		dYAML([]byte(y), true, nil),
 		dFlags(fs, []string{"-verbose=false", "-tls.cert=CLI"}),
 	)
 

--- a/pkg/util/cfg/unknown.go
+++ b/pkg/util/cfg/unknown.go
@@ -23,9 +23,10 @@ var unknownConfigTotal = promauto.NewCounter(prometheus.CounterOpts{
 })
 
 // UnknownFields collects configuration fields and CLI flags that are not
-// recognized during parsing. Reporting is deferred to the caller because the
-// logger and metrics registry are not yet initialized while the config is
-// parsed.
+// recognized during non-strict parsing. Reporting is deferred to the caller
+// because the logger and metrics registry are not yet initialized while the
+// config is parsed. In strict mode unknown fields fail fast with the decoder's
+// native error instead of being collected here.
 type UnknownFields struct {
 	fields []string
 }

--- a/pkg/util/cfg/unknown.go
+++ b/pkg/util/cfg/unknown.go
@@ -1,0 +1,105 @@
+package cfg
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	yaml "go.yaml.in/yaml/v4"
+
+	"github.com/grafana/loki/v3/pkg/util/constants"
+)
+
+// unknownConfigTotal counts configuration fields and CLI flags that were not
+// recognized while parsing with non-strict mode enabled. A nested unknown
+// object is reported by the decoder as a single field and thus counts once.
+var unknownConfigTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Namespace: constants.Loki,
+	Name:      "unknown_config_total",
+	Help:      "Total number of unknown configuration fields and CLI flags encountered during non-strict config parsing.",
+})
+
+// UnknownFields collects configuration fields and CLI flags that are not
+// recognized during parsing. Reporting is deferred to the caller because the
+// logger and metrics registry are not yet initialized while the config is
+// parsed.
+type UnknownFields struct {
+	fields []string
+}
+
+func (u *UnknownFields) add(name string) {
+	if u == nil {
+		return
+	}
+	u.fields = append(u.fields, name)
+}
+
+// List returns the collected unknown field and flag names in encounter order.
+func (u *UnknownFields) List() []string {
+	if u == nil {
+		return nil
+	}
+	return u.fields
+}
+
+// Len returns the number of collected unknown fields and flags.
+func (u *UnknownFields) Len() int {
+	if u == nil {
+		return 0
+	}
+	return len(u.fields)
+}
+
+// Report logs every collected unknown field at WARN and increments the
+// loki_unknown_config_total metric. Call once the logger is initialized and
+// only when strict parsing is disabled.
+func (u *UnknownFields) Report(logger log.Logger) {
+	for _, f := range u.List() {
+		level.Warn(logger).Log("msg", "ignoring unknown configuration option", "name", f)
+		unknownConfigTotal.Inc()
+	}
+}
+
+// collectYAML routes unknown-field decode errors to the collector and returns
+// any remaining (real) decode errors so they still fail parsing.
+func (u *UnknownFields) collectYAML(err error) error {
+	var loadErrs *yaml.LoadErrors
+	if !errors.As(err, &loadErrs) {
+		return err
+	}
+
+	var remaining []*yaml.LoadError
+	for _, le := range loadErrs.Errors {
+		if name, ok := unknownFieldName(le.Message); ok {
+			u.add(name)
+			continue
+		}
+		remaining = append(remaining, le)
+	}
+
+	if len(remaining) > 0 {
+		return &yaml.LoadErrors{Errors: remaining}
+	}
+	return nil
+}
+
+const (
+	yamlUnknownFieldPrefix = "field "
+	yamlUnknownFieldSuffix = " not found in type "
+)
+
+// unknownFieldName extracts the field name from a go-yaml "field X not found in
+// type Y" decode error message, reported for keys absent from the target type.
+func unknownFieldName(msg string) (string, bool) {
+	if !strings.HasPrefix(msg, yamlUnknownFieldPrefix) {
+		return "", false
+	}
+	idx := strings.Index(msg, yamlUnknownFieldSuffix)
+	if idx < len(yamlUnknownFieldPrefix) {
+		return "", false
+	}
+	return msg[len(yamlUnknownFieldPrefix):idx], true
+}

--- a/pkg/util/cfg/unknown_test.go
+++ b/pkg/util/cfg/unknown_test.go
@@ -1,0 +1,150 @@
+package cfg
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/grafana/dskit/flagext"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNonStrictYAMLIgnoresUnknownFields(t *testing.T) {
+	y := []byte(`
+verbose: true
+server:
+  port: 8080
+typo_field: value
+`)
+
+	var data Data
+	u := &UnknownFields{}
+	err := dYAML(y, false, u)(&data)
+
+	require.NoError(t, err)
+	require.True(t, data.Verbose)
+	require.Equal(t, 8080, data.Server.Port)
+	require.Equal(t, []string{"typo_field"}, u.List())
+}
+
+func TestDYAMLCollectsUnknownFields(t *testing.T) {
+	y := []byte(`
+verbose: true
+server:
+  port: 2000
+  bogus: 1
+unknown_top:
+  nested_a: 1
+  nested_b: 2
+`)
+
+	t.Run("non-strict collects unknown fields and does not fail", func(t *testing.T) {
+		var data Data
+		u := &UnknownFields{}
+		err := dYAML(y, false, u)(&data)
+		require.NoError(t, err)
+
+		// Known fields are still applied.
+		require.True(t, data.Verbose)
+		require.Equal(t, 2000, data.Server.Port)
+
+		// A nested unknown object counts once (unknown_top), plus the scalar bogus.
+		require.ElementsMatch(t, []string{"bogus", "unknown_top"}, u.List())
+		require.Equal(t, 2, u.Len())
+	})
+
+	t.Run("strict with collector defers error and still collects", func(t *testing.T) {
+		var data Data
+		u := &UnknownFields{}
+		// With a collector present, unknown fields are recorded rather than
+		// returned; strictness is enforced centrally by DynamicUnmarshal.
+		err := dYAML(y, true, u)(&data)
+		require.NoError(t, err)
+		require.Equal(t, 2, u.Len())
+	})
+
+	t.Run("real type errors still fail even with collector", func(t *testing.T) {
+		var data Data
+		u := &UnknownFields{}
+		bad := []byte(`
+server:
+  port: not-a-number
+`)
+		err := dYAML(bad, false, u)(&data)
+		require.Error(t, err)
+		require.Equal(t, 0, u.Len())
+	})
+}
+
+func TestUnknownFieldName(t *testing.T) {
+	for _, tc := range []struct {
+		msg  string
+		want string
+		ok   bool
+	}{
+		{"field bogus not found in type cfg.Server", "bogus", true},
+		{"field unknown_top not found in type cfg.Data", "unknown_top", true},
+		{"cannot unmarshal !!str into int", "", false},
+		{"field already set in type cfg.Data", "", false},
+	} {
+		name, ok := unknownFieldName(tc.msg)
+		require.Equal(t, tc.ok, ok, tc.msg)
+		require.Equal(t, tc.want, name, tc.msg)
+	}
+}
+
+// strictData wraps Data with a toggleable strict flag to exercise the
+// StrictParser enforcement path in DynamicUnmarshal.
+type strictData struct {
+	Data       `yaml:",inline"`
+	ConfigFile string
+	Strict     bool
+}
+
+func (d *strictData) Clone() flagext.Registerer {
+	return func(d strictData) *strictData { return &d }(*d)
+}
+
+func (d *strictData) RegisterFlags(fs *flag.FlagSet) {
+	d.Data.RegisterFlags(fs)
+	fs.StringVar(&d.ConfigFile, "config.file", "", "")
+	fs.BoolVar(&d.Strict, "config.strict", true, "")
+}
+
+func (d *strictData) StrictConfig() bool         { return d.Strict }
+func (d *strictData) ApplyDynamicConfig() Source { return func(_ Cloneable) error { return nil } }
+
+func TestDynamicUnmarshalStrictEnforcement(t *testing.T) {
+	config := `
+verbose: true
+bogus_field: 1
+`
+	writeConfig := func(t *testing.T) string {
+		f, err := os.CreateTemp(t.TempDir(), "config.yaml")
+		require.NoError(t, err)
+		_, err = f.WriteString(config)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+		return f.Name()
+	}
+
+	t.Run("strict makes unknown fields fatal", func(t *testing.T) {
+		var d strictData
+		fs := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+		args := []string{"-config.file", writeConfig(t), "-config.strict=true"}
+		u, err := DynamicUnmarshal(&d, args, fs)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bogus_field")
+		require.Equal(t, 1, u.Len())
+	})
+
+	t.Run("non-strict collects unknown fields without error", func(t *testing.T) {
+		var d strictData
+		fs := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+		args := []string{"-config.file", writeConfig(t), "-config.strict=false"}
+		u, err := DynamicUnmarshal(&d, args, fs)
+		require.NoError(t, err)
+		require.Equal(t, []string{"bogus_field"}, u.List())
+		require.True(t, d.Verbose)
+	})
+}

--- a/pkg/util/cfg/unknown_test.go
+++ b/pkg/util/cfg/unknown_test.go
@@ -119,6 +119,13 @@ func TestFilterUnknownFlags(t *testing.T) {
 			wantOut: []string{"-server.port", "9090"},
 			wantUnk: []string{"unknown"},
 		},
+		{
+			// -h/-help are handled by the flag package (ErrHelp) and must not be
+			// stripped or counted even though they are not registered.
+			name:    "help flags preserved",
+			args:    []string{"-help", "-h", "--help"},
+			wantOut: []string{"-help", "-h", "--help"},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			u := &UnknownFields{}

--- a/pkg/util/cfg/unknown_test.go
+++ b/pkg/util/cfg/unknown_test.go
@@ -76,6 +76,59 @@ server:
 	})
 }
 
+func TestFilterUnknownFlags(t *testing.T) {
+	newFS := func() *flag.FlagSet {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		fs.Bool("verbose", false, "")
+		fs.Int("server.port", 0, "")
+		return fs
+	}
+
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		wantOut []string
+		wantUnk []string
+	}{
+		{
+			name:    "all known preserved",
+			args:    []string{"-verbose", "-server.port", "8080"},
+			wantOut: []string{"-verbose", "-server.port", "8080"},
+		},
+		{
+			name:    "unknown with equals",
+			args:    []string{"-server.port=8080", "-foo.bar=baz"},
+			wantOut: []string{"-server.port=8080"},
+			wantUnk: []string{"foo.bar"},
+		},
+		{
+			name:    "unknown with space-separated value",
+			args:    []string{"--foo.bar", "value", "-verbose"},
+			wantOut: []string{"-verbose"},
+			wantUnk: []string{"foo.bar"},
+		},
+		{
+			name:    "unknown standalone before known flag",
+			args:    []string{"-foo", "-verbose"},
+			wantOut: []string{"-verbose"},
+			wantUnk: []string{"foo"},
+		},
+		{
+			name:    "known non-bool value kept together",
+			args:    []string{"-server.port", "9090", "-unknown", "x"},
+			wantOut: []string{"-server.port", "9090"},
+			wantUnk: []string{"unknown"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			u := &UnknownFields{}
+			out := filterUnknownFlags(newFS(), tc.args, u)
+			require.Equal(t, tc.wantOut, out)
+			require.Equal(t, tc.wantUnk, u.List())
+		})
+	}
+}
+
 func TestUnknownFieldName(t *testing.T) {
 	for _, tc := range []struct {
 		msg  string
@@ -146,5 +199,24 @@ bogus_field: 1
 		require.NoError(t, err)
 		require.Equal(t, []string{"bogus_field"}, u.List())
 		require.True(t, d.Verbose)
+	})
+
+	t.Run("non-strict tolerates unknown CLI flag", func(t *testing.T) {
+		var d strictData
+		fs := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+		args := []string{"-config.file", writeConfig(t), "-config.strict=false", "-server.port=7070", "-made.up=1"}
+		u, err := DynamicUnmarshal(&d, args, fs)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"bogus_field", "made.up"}, u.List())
+		require.Equal(t, 7070, d.Server.Port)
+	})
+
+	t.Run("strict makes unknown CLI flag fatal", func(t *testing.T) {
+		var d strictData
+		fs := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+		args := []string{"-config.file", writeConfig(t), "-config.strict=true", "-made.up=1"}
+		_, err := DynamicUnmarshal(&d, args, fs)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "made.up")
 	})
 }

--- a/pkg/util/cfg/unknown_test.go
+++ b/pkg/util/cfg/unknown_test.go
@@ -187,15 +187,28 @@ bogus_field: 1
 		require.NoError(t, f.Close())
 		return f.Name()
 	}
+	writeConfigContent := func(t *testing.T, content string) string {
+		f, err := os.CreateTemp(t.TempDir(), "config.yaml")
+		require.NoError(t, err)
+		_, err = f.WriteString(content)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+		return f.Name()
+	}
 
 	t.Run("strict makes unknown fields fatal", func(t *testing.T) {
 		var d strictData
 		fs := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
-		args := []string{"-config.file", writeConfig(t), "-config.strict=true"}
+		configPath := writeConfig(t)
+		args := []string{"-config.file", configPath, "-config.strict=true"}
 		u, err := DynamicUnmarshal(&d, args, fs)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "bogus_field")
-		require.Equal(t, 1, u.Len())
+		// Strict mode fails fast with the decoder's native error, which preserves
+		// the config file path, line number, and parent type so nested typos can
+		// be located. Unknown fields are not collected in this path.
+		require.Contains(t, err.Error(), configPath)
+		require.Contains(t, err.Error(), "line 3: field bogus_field not found in type cfg.strictData")
+		require.Equal(t, 0, u.Len())
 	})
 
 	t.Run("non-strict collects unknown fields without error", func(t *testing.T) {
@@ -221,9 +234,13 @@ bogus_field: 1
 	t.Run("strict makes unknown CLI flag fatal", func(t *testing.T) {
 		var d strictData
 		fs := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
-		args := []string{"-config.file", writeConfig(t), "-config.strict=true", "-made.up=1"}
-		_, err := DynamicUnmarshal(&d, args, fs)
+		// Use a config without unknown YAML fields so the unknown flag, rather
+		// than a fail-fast YAML error, is what makes parsing fatal.
+		cleanConfig := writeConfigContent(t, "verbose: true\n")
+		args := []string{"-config.file", cleanConfig, "-config.strict=true", "-made.up=1"}
+		u, err := DynamicUnmarshal(&d, args, fs)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "made.up")
+		require.Equal(t, []string{"made.up"}, u.List())
 	})
 }

--- a/tools/dataobj-locality/source.go
+++ b/tools/dataobj-locality/source.go
@@ -135,7 +135,7 @@ func buildBucketFromLokiConfig(ctx context.Context, configFile string, expandEnv
 		args = append(args, "-config.expand-env=true")
 	}
 	var c loki.ConfigWrapper
-	if err := lokicfg.DynamicUnmarshal(&c, args, flag.NewFlagSet("loki-config", flag.ContinueOnError)); err != nil {
+	if _, err := lokicfg.DynamicUnmarshal(&c, args, flag.NewFlagSet("loki-config", flag.ContinueOnError)); err != nil {
 		return nil, metastore.Config{}, fmt.Errorf("loading loki config %s: %w", configFile, err)
 	}
 

--- a/tools/tsdb/helpers/setup.go
+++ b/tools/tsdb/helpers/setup.go
@@ -24,7 +24,7 @@ import (
 
 func Setup() (loki.Config, services.Service, string, error) {
 	var c loki.ConfigWrapper
-	if err := cfg.DynamicUnmarshal(&c, os.Args[1:], flag.CommandLine); err != nil {
+	if _, err := cfg.DynamicUnmarshal(&c, os.Args[1:], flag.CommandLine); err != nil {
 		fmt.Fprintf(os.Stderr, "failed parsing config: %v\n", err)
 		os.Exit(1)
 	}

--- a/tools/tsdb/migrate-versions/main.go
+++ b/tools/tsdb/migrate-versions/main.go
@@ -295,7 +295,7 @@ func uploadFile(idx shipperindex.Index, indexStorageClient shipperstorage.Client
 
 func setup() loki.Config {
 	var c loki.ConfigWrapper
-	if err := cfg.DynamicUnmarshal(&c, os.Args[1:], flag.CommandLine); err != nil {
+	if _, err := cfg.DynamicUnmarshal(&c, os.Args[1:], flag.CommandLine); err != nil {
 		fmt.Fprintf(os.Stderr, "failed parsing config: %v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
### Summary

This PR sdds a `-config.strict` flag (default `true`) that controls how Loki reacts to unrecognized configuration. With the default, behavior is unchanged: an unknown command-line flag or an unknown YAML field fails startup, which is valuable for catching typos. When set to `false`, unknown flags and fields are instead logged at `WARN`, counted in a new `loki_unknown_config_total` metric, and ignored so Loki starts normally.

### Why

Running Grafana Enterprise Logs and OSS Loki side by side means maintaining two configuration sets, because each recognizes options the other does not and strict parsing rejects the foreign keys. Non-strict parsing lets a single shared config set be used across both, while still surfacing what was ignored through logs and a metric.
