### PR TITLE
fix(ingester): Track per-policy stream counts separately only when the policy overrides the stream count limit

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -1785,7 +1785,7 @@ func TestUpdateOwnedStreams(t *testing.T) {
 	require.NoError(t, err)
 
 	// streams are pushed, let's check owned stream counts
-	ownedStreams := i.instances["test"].ownedStreamsSvc.getOwnedStreamCount()
+	ownedStreams := i.instances["test"].ownedStreamsSvc.getStreamCount(defaultStreamCountBucket)
 	require.Equal(t, 8, ownedStreams)
 }
 

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -271,9 +271,10 @@ func (i *instance) createStream(ctx context.Context, pushReqStream logproto.Stre
 
 	retentionHours := util.RetentionHours(i.tenantsRetention.RetentionPeriodFor(i.instanceID, labels))
 	policy := i.resolvePolicyForStream(ctx, labels)
+	bucket := i.limiter.streamCountBucket(i.instanceID, policy)
 
 	if record != nil {
-		err = i.streamCountLimiter.AssertNewStreamAllowed(i.instanceID, policy)
+		err = i.streamCountLimiter.AssertNewStreamAllowed(i.instanceID, bucket)
 	}
 
 	if err != nil {
@@ -290,6 +291,7 @@ func (i *instance) createStream(ctx context.Context, pushReqStream logproto.Stre
 	}
 
 	s := newStream(chunkfmt, headfmt, i.cfg, i.limiter.rateLimitStrategy, i.instanceID, fp, sortedLabels, i.streamRateCalculator, i.metrics, i.writeFailures, i.configs, retentionHours, policy)
+	s.streamCountBucket = bucket
 
 	// record will be nil when replaying the wal (we don't want to rewrite wal entries as we replay them).
 	if record != nil {
@@ -361,7 +363,7 @@ func (i *instance) onStreamCreated(s *stream) {
 	i.addTailersToNewStream(s)
 	streamsCountStats.Add(1)
 	// we count newly created stream as owned
-	i.ownedStreamsSvc.trackStreamOwnership(s.fp, true, s.policy)
+	i.ownedStreamsSvc.trackStreamOwnership(s.fp, true, s.streamCountBucket)
 	if i.configs.LogStreamCreation(i.instanceID) {
 		level.Debug(util_log.Logger).Log(
 			"msg", "successfully created stream",
@@ -384,6 +386,7 @@ func (i *instance) createStreamByFP(ctx context.Context, ls labels.Labels, fp mo
 	policy := i.resolvePolicyForStream(ctx, ls)
 
 	s := newStream(chunkfmt, headfmt, i.cfg, i.limiter.rateLimitStrategy, i.instanceID, fp, sortedLabels, i.streamRateCalculator, i.metrics, i.writeFailures, i.configs, retentionHours, policy)
+	s.streamCountBucket = i.limiter.streamCountBucket(i.instanceID, policy)
 
 	i.onStreamCreated(s)
 
@@ -429,7 +432,7 @@ func (i *instance) removeStream(s *stream) {
 		memoryStreams.WithLabelValues(i.instanceID).Dec()
 		memoryStreamsLabelsBytes.Sub(float64(len(s.labels.String())))
 		streamsCountStats.Add(-1)
-		i.ownedStreamsSvc.trackRemovedStream(s.fp, s.policy)
+		i.ownedStreamsSvc.trackRemovedStream(s.fp, s.streamCountBucket)
 	}
 }
 
@@ -1213,7 +1216,11 @@ func (i *instance) updateOwnedStreams(isOwnedStream func(*stream) (bool, error))
 				return false, err
 			}
 
-			i.ownedStreamsSvc.trackStreamOwnership(s.fp, ownedStream, s.policy)
+			// Re-resolve the bucket so that stream-count override changes made since the
+			// stream was created converge here (counts were just reset, so re-bucketing all
+			// streams is safe and keeps future trackRemovedStream calls symmetric).
+			s.streamCountBucket = i.limiter.streamCountBucket(i.instanceID, s.policy)
+			i.ownedStreamsSvc.trackStreamOwnership(s.fp, ownedStream, s.streamCountBucket)
 			return true, nil
 		})
 	})

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -1200,31 +1200,6 @@ func minTs(stream *logproto.Stream) model.Time {
 	return model.TimeFromUnixNano(streamMinTs)
 }
 
-// rebucketOwnedStreams re-resolves every stream's stream-count bucket from its (creation-time)
-// policy and moves the counts of streams whose bucket changed. This converges bucket membership
-// after a runtime change to policy stream-count overrides without waiting for a ring change.
-// Policies themselves stay fixed at creation: label-mapping changes and header-assigned policies
-// are deliberately not re-resolved here (see Limiter.streamCountBucket).
-func (i *instance) rebucketOwnedStreams() {
-	// The tenant is fixed for the whole pass, so the bucket only depends on the policy;
-	// memoize it to avoid re-reading the overrides for every stream.
-	buckets := make(map[string]string)
-	i.streams.WithRLock(func() {
-		_ = i.streams.ForEach(func(s *stream) (bool, error) {
-			bucket, ok := buckets[s.policy]
-			if !ok {
-				bucket = i.limiter.streamCountBucket(i.instanceID, s.policy)
-				buckets[s.policy] = bucket
-			}
-			if bucket != s.streamCountBucket {
-				i.ownedStreamsSvc.moveStreamBucket(s.fp, s.streamCountBucket, bucket)
-				s.streamCountBucket = bucket
-			}
-			return true, nil
-		})
-	})
-}
-
 // For each stream, we check if the stream is owned by the ingester or not and increment/decrement the owned stream count.
 func (i *instance) updateOwnedStreams(isOwnedStream func(*stream) (bool, error)) error {
 	start := time.Now()

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -1200,6 +1200,31 @@ func minTs(stream *logproto.Stream) model.Time {
 	return model.TimeFromUnixNano(streamMinTs)
 }
 
+// rebucketOwnedStreams re-resolves every stream's stream-count bucket from its (creation-time)
+// policy and moves the counts of streams whose bucket changed. This converges bucket membership
+// after a runtime change to policy stream-count overrides without waiting for a ring change.
+// Policies themselves stay fixed at creation: label-mapping changes and header-assigned policies
+// are deliberately not re-resolved here (see Limiter.streamCountBucket).
+func (i *instance) rebucketOwnedStreams() {
+	// The tenant is fixed for the whole pass, so the bucket only depends on the policy;
+	// memoize it to avoid re-reading the overrides for every stream.
+	buckets := make(map[string]string)
+	i.streams.WithRLock(func() {
+		_ = i.streams.ForEach(func(s *stream) (bool, error) {
+			bucket, ok := buckets[s.policy]
+			if !ok {
+				bucket = i.limiter.streamCountBucket(i.instanceID, s.policy)
+				buckets[s.policy] = bucket
+			}
+			if bucket != s.streamCountBucket {
+				i.ownedStreamsSvc.moveStreamBucket(s.fp, s.streamCountBucket, bucket)
+				s.streamCountBucket = bucket
+			}
+			return true, nil
+		})
+	})
+}
+
 // For each stream, we check if the stream is owned by the ingester or not and increment/decrement the owned stream count.
 func (i *instance) updateOwnedStreams(isOwnedStream func(*stream) (bool, error)) error {
 	start := time.Now()

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -1704,3 +1704,91 @@ func (m *mockUsageTracker) DiscardedBytesAdd(_ context.Context, _ string, _ stri
 // ReceivedBytesAdd implements push.UsageTracker.
 func (*mockUsageTracker) ReceivedBytesAdd(_ context.Context, _ string, _ time.Duration, _ labels.Labels, _ float64, _ string) {
 }
+
+// streamCountBucketsTestInstance builds an instance with a tenant stream limit of 5, a "replay"
+// policy with a stream-count override of 3, and a "mapped" policy with no stream-count override.
+func streamCountBucketsTestInstance(t *testing.T) (*instance, *validation.Overrides) {
+	l := defaultLimitsTestConfig()
+	l.MaxLocalStreamsPerUser = 0
+	l.MaxGlobalStreamsPerUser = 5
+	l.UseOwnedStreamCount = true
+	l.PolicyStreamMapping = validation.PolicyStreamMapping{
+		"replay": []*validation.PriorityStream{{Selector: `{job="replay"}`, Priority: 1}},
+		"mapped": []*validation.PriorityStream{{Selector: `{job="mapped"}`, Priority: 1}},
+	}
+	l.PolicyOverrideLimits = map[string]validation.PolicyOverridableLimits{
+		"replay": {MaxGlobalStreamsPerUser: ptr(3)},
+	}
+	// Validate populates the stream-selector matchers used by PolicyFor (the real config-load
+	// path does this); without it an empty matcher set would match every stream.
+	require.NoError(t, l.Validate())
+
+	limits, err := validation.NewOverrides(l, nil)
+	require.NoError(t, err)
+	// Single ingester and RF 1: adjusted global limits == configured global limits.
+	limiter := NewLimiter(limits, NilMetrics, newIngesterRingLimiterStrategy(&ringCountMock{count: 1}, 1), &TenantBasedStrategy{limits: limits})
+	tenantsRetention := retention.NewTenantsRetention(limits)
+
+	inst, err := newInstance(defaultConfig(), defaultPeriodConfigs, "test", limiter, loki_runtime.DefaultTenantConfigs(), noopWAL{}, NilMetrics, &OnceSwitch{}, nil, nil, nil, NewStreamRateCalculator(), nil, nil, tenantsRetention)
+	require.NoError(t, err)
+	return inst, limits
+}
+
+func TestInstance_StreamCountPolicyBuckets(t *testing.T) {
+	push := func(inst *instance, ls string) error {
+		return inst.Push(context.Background(), &logproto.PushRequest{Streams: []logproto.Stream{
+			{Labels: ls, Entries: entries(1, time.Now().Add(-5*time.Minute))},
+		}})
+	}
+
+	t.Run("policy bucket is isolated from the default bucket", func(t *testing.T) {
+		inst, _ := streamCountBucketsTestInstance(t)
+
+		// Fill the replay bucket to its override limit.
+		for n := range 3 {
+			require.NoError(t, push(inst, fmt.Sprintf(`{job="replay", n="%d"}`, n)))
+		}
+		require.Error(t, push(inst, `{job="replay", n="3"}`), "replay bucket must reject at its override limit")
+
+		// The default bucket still has its full tenant budget of 5.
+		for n := range 5 {
+			require.NoError(t, push(inst, fmt.Sprintf(`{job="app", n="%d"}`, n)))
+		}
+		require.Error(t, push(inst, `{job="app", n="5"}`), "default bucket must reject at the tenant limit")
+
+		// A policy without a stream-count override shares the default bucket: no phantom budget.
+		require.Error(t, push(inst, `{job="mapped", n="0"}`))
+
+		require.Equal(t, 5, inst.ownedStreamsSvc.getStreamCount(defaultStreamCountBucket))
+		require.Equal(t, 3, inst.ownedStreamsSvc.getStreamCount("replay"))
+	})
+
+	t.Run("totals are order-independent", func(t *testing.T) {
+		inst, _ := streamCountBucketsTestInstance(t)
+
+		// Reverse order from the subtest above; both buckets still get their full budget.
+		for n := range 5 {
+			require.NoError(t, push(inst, fmt.Sprintf(`{job="app", n="%d"}`, n)))
+		}
+		for n := range 3 {
+			require.NoError(t, push(inst, fmt.Sprintf(`{job="replay", n="%d"}`, n)))
+		}
+		require.Equal(t, 5, inst.ownedStreamsSvc.getStreamCount(defaultStreamCountBucket))
+		require.Equal(t, 3, inst.ownedStreamsSvc.getStreamCount("replay"))
+	})
+
+	t.Run("recalculation re-buckets streams after an override change", func(t *testing.T) {
+		inst, limits := streamCountBucketsTestInstance(t)
+
+		require.NoError(t, push(inst, `{job="replay", n="0"}`))
+		require.NoError(t, push(inst, `{job="app", n="0"}`))
+		require.Equal(t, 1, inst.ownedStreamsSvc.getStreamCount(defaultStreamCountBucket))
+		require.Equal(t, 1, inst.ownedStreamsSvc.getStreamCount("replay"))
+
+		// Drop the stream-count override: replay streams belong in the default bucket now.
+		limits.DefaultLimits().PolicyOverrideLimits = nil
+		require.NoError(t, inst.updateOwnedStreams(func(*stream) (bool, error) { return true, nil }))
+		require.Equal(t, 2, inst.ownedStreamsSvc.getStreamCount(defaultStreamCountBucket))
+		require.Equal(t, 0, inst.ownedStreamsSvc.getStreamCount("replay"))
+	})
+}

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -1777,7 +1777,7 @@ func TestInstance_StreamCountPolicyBuckets(t *testing.T) {
 		require.Equal(t, 3, inst.ownedStreamsSvc.getStreamCount("replay"))
 	})
 
-	t.Run("re-bucketing converges after an override is removed", func(t *testing.T) {
+	t.Run("recalculation re-buckets streams after an override change", func(t *testing.T) {
 		inst, limits := streamCountBucketsTestInstance(t)
 
 		require.NoError(t, push(inst, `{job="replay", n="0"}`))
@@ -1785,32 +1785,11 @@ func TestInstance_StreamCountPolicyBuckets(t *testing.T) {
 		require.Equal(t, 1, inst.ownedStreamsSvc.getStreamCount(defaultStreamCountBucket))
 		require.Equal(t, 1, inst.ownedStreamsSvc.getStreamCount("replay"))
 
-		// Drop the stream-count override: replay streams belong in the default bucket now.
+		// Drop the stream-count override: replay streams belong in the default bucket after
+		// the next ownership recalculation (ring change).
 		limits.DefaultLimits().PolicyOverrideLimits = nil
-		inst.rebucketOwnedStreams()
+		require.NoError(t, inst.updateOwnedStreams(func(*stream) (bool, error) { return true, nil }))
 		require.Equal(t, 2, inst.ownedStreamsSvc.getStreamCount(defaultStreamCountBucket))
 		require.Equal(t, 0, inst.ownedStreamsSvc.getStreamCount("replay"))
-	})
-
-	t.Run("re-bucketing converges after an override is added", func(t *testing.T) {
-		inst, limits := streamCountBucketsTestInstance(t)
-
-		// "mapped" has no stream-count override, so its streams start in the default bucket.
-		require.NoError(t, push(inst, `{job="mapped", n="0"}`))
-		require.NoError(t, push(inst, `{job="mapped", n="1"}`))
-		require.NoError(t, push(inst, `{job="app", n="0"}`))
-		require.Equal(t, 3, inst.ownedStreamsSvc.getStreamCount(defaultStreamCountBucket))
-		require.Equal(t, 0, inst.ownedStreamsSvc.getStreamCount("mapped"))
-
-		// Give "mapped" its own bucket: existing streams must move so the new limit sees them.
-		limits.DefaultLimits().PolicyOverrideLimits = map[string]validation.PolicyOverridableLimits{
-			"mapped": {MaxGlobalStreamsPerUser: ptr(2)},
-		}
-		inst.rebucketOwnedStreams()
-		require.Equal(t, 1, inst.ownedStreamsSvc.getStreamCount(defaultStreamCountBucket))
-		require.Equal(t, 2, inst.ownedStreamsSvc.getStreamCount("mapped"))
-
-		// The moved streams count against the new override immediately: bucket is full.
-		require.Error(t, push(inst, `{job="mapped", n="2"}`))
 	})
 }

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -1777,7 +1777,7 @@ func TestInstance_StreamCountPolicyBuckets(t *testing.T) {
 		require.Equal(t, 3, inst.ownedStreamsSvc.getStreamCount("replay"))
 	})
 
-	t.Run("recalculation re-buckets streams after an override change", func(t *testing.T) {
+	t.Run("re-bucketing converges after an override is removed", func(t *testing.T) {
 		inst, limits := streamCountBucketsTestInstance(t)
 
 		require.NoError(t, push(inst, `{job="replay", n="0"}`))
@@ -1787,8 +1787,30 @@ func TestInstance_StreamCountPolicyBuckets(t *testing.T) {
 
 		// Drop the stream-count override: replay streams belong in the default bucket now.
 		limits.DefaultLimits().PolicyOverrideLimits = nil
-		require.NoError(t, inst.updateOwnedStreams(func(*stream) (bool, error) { return true, nil }))
+		inst.rebucketOwnedStreams()
 		require.Equal(t, 2, inst.ownedStreamsSvc.getStreamCount(defaultStreamCountBucket))
 		require.Equal(t, 0, inst.ownedStreamsSvc.getStreamCount("replay"))
+	})
+
+	t.Run("re-bucketing converges after an override is added", func(t *testing.T) {
+		inst, limits := streamCountBucketsTestInstance(t)
+
+		// "mapped" has no stream-count override, so its streams start in the default bucket.
+		require.NoError(t, push(inst, `{job="mapped", n="0"}`))
+		require.NoError(t, push(inst, `{job="mapped", n="1"}`))
+		require.NoError(t, push(inst, `{job="app", n="0"}`))
+		require.Equal(t, 3, inst.ownedStreamsSvc.getStreamCount(defaultStreamCountBucket))
+		require.Equal(t, 0, inst.ownedStreamsSvc.getStreamCount("mapped"))
+
+		// Give "mapped" its own bucket: existing streams must move so the new limit sees them.
+		limits.DefaultLimits().PolicyOverrideLimits = map[string]validation.PolicyOverridableLimits{
+			"mapped": {MaxGlobalStreamsPerUser: ptr(2)},
+		}
+		inst.rebucketOwnedStreams()
+		require.Equal(t, 1, inst.ownedStreamsSvc.getStreamCount(defaultStreamCountBucket))
+		require.Equal(t, 2, inst.ownedStreamsSvc.getStreamCount("mapped"))
+
+		// The moved streams count against the new override immediately: bucket is full.
+		require.Error(t, push(inst, `{job="mapped", n="2"}`))
 	})
 }

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -112,6 +112,25 @@ func (l *Limiter) GetStreamCountLimit(tenantID string, policy string) (calculate
 	return
 }
 
+// streamCountBucket returns the bucket a stream's count is tracked under: the policy name when
+// the policy has a stream-count override (local or global) and owned-stream counting is enabled
+// for the tenant; otherwise defaultStreamCountBucket. Streams in a policy bucket are counted
+// and limited independently from the default bucket, mirroring the ingest-limits service (see
+// pkg/limits getPolicyBucketAndStreamsLimit). Without owned-stream counting there is no
+// per-policy count to check against, so per-policy stream-count overrides are ignored.
+func (l *Limiter) streamCountBucket(tenantID, policy string) string {
+	if policy == noPolicy || !l.limits.UseOwnedStreamCount(tenantID) {
+		return defaultStreamCountBucket
+	}
+	if _, ok := l.limits.PolicyMaxLocalStreamsPerUser(tenantID, policy); ok {
+		return policy
+	}
+	if _, ok := l.limits.PolicyMaxGlobalStreamsPerUser(tenantID, policy); ok {
+		return policy
+	}
+	return defaultStreamCountBucket
+}
+
 func (l *Limiter) minNonZero(first, second int) int {
 	if first == 0 || (second != 0 && first > second) {
 		return second
@@ -213,12 +232,16 @@ func newStreamCountLimiter(tenantID string, defaultStreamCountSupplier supplier[
 	}
 }
 
-func (l *streamCountLimiter) AssertNewStreamAllowed(tenantID string, policy string) error {
+// AssertNewStreamAllowed checks whether the tenant can create a new stream in the given
+// stream-count bucket (see Limiter.streamCountBucket). A policy bucket is checked against its
+// own stream count and the policy's limit; the default bucket is checked against the
+// tenant-wide count and limit.
+func (l *streamCountLimiter) AssertNewStreamAllowed(tenantID string, bucket string) error {
 	if l.delegateStreamLimits {
 		return nil
 	}
-	streamCountSupplier, fixedLimitSupplier := l.getSuppliers(tenantID, policy)
-	calculatedLimit, localLimit, globalLimit, adjustedGlobalLimit := l.getCurrentLimit(tenantID, policy, fixedLimitSupplier)
+	streamCountSupplier, fixedLimitSupplier := l.getSuppliers(tenantID, bucket)
+	calculatedLimit, localLimit, globalLimit, adjustedGlobalLimit := l.getCurrentLimit(tenantID, bucket, fixedLimitSupplier)
 	actualStreamsCount := streamCountSupplier()
 	if actualStreamsCount < calculatedLimit {
 		return nil
@@ -227,12 +250,12 @@ func (l *streamCountLimiter) AssertNewStreamAllowed(tenantID string, policy stri
 	return fmt.Errorf(errMaxStreamsPerUserLimitExceeded, tenantID, actualStreamsCount, calculatedLimit, localLimit, globalLimit, adjustedGlobalLimit)
 }
 
-func (l *streamCountLimiter) getCurrentLimit(tenantID, policy string, fixedLimitSupplier supplier[int]) (calculatedLimit, localLimit, globalLimit, adjustedGlobalLimit int) {
-	calculatedLimit, localLimit, globalLimit, adjustedGlobalLimit = l.limiter.GetStreamCountLimit(tenantID, policy)
+func (l *streamCountLimiter) getCurrentLimit(tenantID, bucket string, fixedLimitSupplier supplier[int]) (calculatedLimit, localLimit, globalLimit, adjustedGlobalLimit int) {
+	calculatedLimit, localLimit, globalLimit, adjustedGlobalLimit = l.limiter.GetStreamCountLimit(tenantID, bucket)
 
-	// Only apply fixed limit if no policy is specified
-	// Policy limits should take precedence over fixed limits
-	if policy == noPolicy {
+	// The fixed limit is a floor for the default bucket's limit only; policy buckets use
+	// their override limit as-is.
+	if bucket == defaultStreamCountBucket {
 		fixedLimit := fixedLimitSupplier()
 		if fixedLimit > calculatedLimit {
 			calculatedLimit = fixedLimit
@@ -242,15 +265,10 @@ func (l *streamCountLimiter) getCurrentLimit(tenantID, policy string, fixedLimit
 	return
 }
 
-func (l *streamCountLimiter) getSuppliers(tenant string, policy string) (streamCountSupplier, fixedLimitSupplier supplier[int]) {
+func (l *streamCountLimiter) getSuppliers(tenant string, bucket string) (streamCountSupplier, fixedLimitSupplier supplier[int]) {
 	if l.limiter.limits.UseOwnedStreamCount(tenant) {
 		streamCountSupplier := func() int {
-			return l.ownedStreamSvc.getOwnedStreamCount()
-		}
-		if policy != noPolicy {
-			streamCountSupplier = func() int {
-				return l.ownedStreamSvc.getPolicyStreamCount(policy)
-			}
+			return l.ownedStreamSvc.getStreamCount(bucket)
 		}
 		return streamCountSupplier, l.ownedStreamSvc.getFixedLimit
 	}

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/ring"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
@@ -130,8 +131,10 @@ func TestStreamCountLimiter_AssertNewStreamAllowed(t *testing.T) {
 			require.NoError(t, err)
 
 			ownedStreamSvc := &ownedStreamService{
-				fixedLimit:       atomic.NewInt32(testData.fixedLimit),
-				ownedStreamCount: atomic.NewInt64(int64(testData.ownedStreamCount)),
+				fixedLimit: atomic.NewInt32(testData.fixedLimit),
+				streamCounts: map[string]*atomic.Int64{
+					defaultStreamCountBucket: atomic.NewInt64(int64(testData.ownedStreamCount)),
+				},
 			}
 			strategy := &fixedStrategy{localLimit: testData.calculatedLocalLimit}
 			limiter := NewLimiter(limits, NilMetrics, strategy, &TenantBasedStrategy{limits: limits})
@@ -159,8 +162,8 @@ func TestStreamCountLimiter_DelegateStreamLimits(t *testing.T) {
 		return 200 // well above the limit
 	}
 	ownedStreamSvc := &ownedStreamService{
-		fixedLimit:       atomic.NewInt32(0),
-		ownedStreamCount: atomic.NewInt64(0),
+		fixedLimit:   atomic.NewInt32(0),
+		streamCounts: map[string]*atomic.Int64{},
 	}
 
 	scl := newStreamCountLimiter("test", defaultCountSupplier, limiter, ownedStreamSvc, true)
@@ -560,3 +563,72 @@ func (m *mockRingStrategy) convertGlobalToLocalLimit(globalLimit int, _ string) 
 }
 
 func ptr[T any](v T) *T { return &v }
+
+func TestLimiter_StreamCountBucket(t *testing.T) {
+	newLimiterWith := func(t *testing.T, useOwnedStreamCount bool) *Limiter {
+		limits, err := validation.NewOverrides(validation.Limits{
+			MaxGlobalStreamsPerUser: 1000,
+			UseOwnedStreamCount:     useOwnedStreamCount,
+			PolicyOverrideLimits: map[string]validation.PolicyOverridableLimits{
+				"local-only":  {MaxLocalStreamsPerUser: ptr(10)},
+				"global-only": {MaxGlobalStreamsPerUser: ptr(20)},
+				"both":        {MaxLocalStreamsPerUser: ptr(10), MaxGlobalStreamsPerUser: ptr(20)},
+				"rate-only":   {IngestionRateMB: ptr(10.0)},
+			},
+		}, nil)
+		require.NoError(t, err)
+		return NewLimiter(limits, NilMetrics, &fixedStrategy{localLimit: 100}, &TenantBasedStrategy{limits: limits})
+	}
+
+	limiter := newLimiterWith(t, true)
+	// A stream-count override (local or global) gives the policy its own bucket.
+	require.Equal(t, "local-only", limiter.streamCountBucket("test", "local-only"))
+	require.Equal(t, "global-only", limiter.streamCountBucket("test", "global-only"))
+	require.Equal(t, "both", limiter.streamCountBucket("test", "both"))
+	// Overriding other limits does not create a stream-count bucket.
+	require.Equal(t, defaultStreamCountBucket, limiter.streamCountBucket("test", "rate-only"))
+	// Policies without overrides and streams without a policy use the default bucket.
+	require.Equal(t, defaultStreamCountBucket, limiter.streamCountBucket("test", "unknown"))
+	require.Equal(t, defaultStreamCountBucket, limiter.streamCountBucket("test", noPolicy))
+
+	// Without owned-stream counting there is no per-policy count to check against, so
+	// stream-count overrides are ignored and everything lands in the default bucket.
+	limiter = newLimiterWith(t, false)
+	require.Equal(t, defaultStreamCountBucket, limiter.streamCountBucket("test", "both"))
+}
+
+func TestStreamCountLimiter_PolicyBucketIsolation(t *testing.T) {
+	limits, err := validation.NewOverrides(validation.Limits{
+		MaxGlobalStreamsPerUser: 5,
+		UseOwnedStreamCount:     true,
+		PolicyOverrideLimits: map[string]validation.PolicyOverridableLimits{
+			"replay": {MaxGlobalStreamsPerUser: ptr(3)},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	// Single healthy instance and RF 1: adjusted global limits == configured global limits.
+	limiter := NewLimiter(limits, NilMetrics, &mockRingStrategy{healthyInstances: 1, replicationFactor: 1}, &TenantBasedStrategy{limits: limits})
+	svc := newOwnedStreamService("test", limiter)
+	scl := newStreamCountLimiter("test", func() int { return 0 }, limiter, svc, false)
+
+	// Fill the default bucket: the tenant-wide limit is hit, the replay bucket is untouched.
+	for n := range 5 {
+		require.NoError(t, scl.AssertNewStreamAllowed("test", defaultStreamCountBucket))
+		svc.trackStreamOwnership(model.Fingerprint(n), true, defaultStreamCountBucket)
+	}
+	require.Error(t, scl.AssertNewStreamAllowed("test", defaultStreamCountBucket))
+	require.NoError(t, scl.AssertNewStreamAllowed("test", "replay"), "a full default bucket must not affect the replay bucket")
+
+	// Fill the replay bucket to its own limit.
+	for n := range 3 {
+		require.NoError(t, scl.AssertNewStreamAllowed("test", "replay"))
+		svc.trackStreamOwnership(model.Fingerprint(100+n), true, "replay")
+	}
+	require.Error(t, scl.AssertNewStreamAllowed("test", "replay"))
+
+	// Removing a default-bucket stream frees default capacity even though replay is full.
+	svc.trackRemovedStream(model.Fingerprint(0), defaultStreamCountBucket)
+	require.NoError(t, scl.AssertNewStreamAllowed("test", defaultStreamCountBucket))
+	require.Error(t, scl.AssertNewStreamAllowed("test", "replay"))
+}

--- a/pkg/ingester/owned_streams.go
+++ b/pkg/ingester/owned_streams.go
@@ -14,6 +14,12 @@ import (
 const (
 	// noPolicy represents the absence of a policy
 	noPolicy = ""
+
+	// defaultStreamCountBucket is the stream-count bucket for streams whose policy has no
+	// stream-count override, including streams with no policy at all (see
+	// Limiter.streamCountBucket). Named buckets exist only for policies with an override;
+	// every stream is counted in exactly one bucket.
+	defaultStreamCountBucket = noPolicy
 )
 
 var notOwnedStreamsMetric = promauto.NewGauge(prometheus.GaugeOpts{
@@ -23,59 +29,56 @@ var notOwnedStreamsMetric = promauto.NewGauge(prometheus.GaugeOpts{
 })
 
 type ownedStreamService struct {
-	tenantID         string
-	limiter          *Limiter
-	fixedLimit       *atomic.Int32
-	ownedStreamCount *atomic.Int64
-	lock             sync.RWMutex
-	notOwnedStreams  map[model.Fingerprint]any
+	tenantID   string
+	limiter    *Limiter
+	fixedLimit *atomic.Int32
 
-	// Track streams by policy for policy-specific limit enforcement
-	policyStreamCounts map[string]*atomic.Int64
-	policyLock         sync.RWMutex
+	lock            sync.RWMutex
+	notOwnedStreams map[model.Fingerprint]any
+	// streamCounts tracks owned streams per stream-count bucket. Buckets are created lazily
+	// and removed when their count reaches zero. The map is guarded by lock; the counters are
+	// atomics so existing buckets can be incremented under the read lock.
+	streamCounts map[string]*atomic.Int64
 }
 
 func newOwnedStreamService(tenantID string, limiter *Limiter) *ownedStreamService {
 	svc := &ownedStreamService{
-		tenantID:           tenantID,
-		limiter:            limiter,
-		fixedLimit:         atomic.NewInt32(0),
-		ownedStreamCount:   atomic.NewInt64(0),
-		notOwnedStreams:    make(map[model.Fingerprint]any),
-		policyStreamCounts: make(map[string]*atomic.Int64),
+		tenantID:        tenantID,
+		limiter:         limiter,
+		fixedLimit:      atomic.NewInt32(0),
+		notOwnedStreams: make(map[model.Fingerprint]any),
+		streamCounts:    make(map[string]*atomic.Int64),
 	}
 
 	svc.updateFixedLimit()
 	return svc
 }
 
-func (s *ownedStreamService) getOwnedStreamCount() int {
-	return int(s.ownedStreamCount.Load())
-}
+// getStreamCount returns the number of owned streams tracked in the given bucket.
+func (s *ownedStreamService) getStreamCount(bucket string) int {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 
-func (s *ownedStreamService) getPolicyStreamCount(policy string) int {
-	if policy == noPolicy {
-		return 0
-	}
-
-	s.policyLock.RLock()
-	defer s.policyLock.RUnlock()
-
-	if policyCount, exists := s.policyStreamCounts[policy]; exists {
-		return int(policyCount.Load())
+	if count, exists := s.streamCounts[bucket]; exists {
+		return int(count.Load())
 	}
 	return 0
 }
 
-// getActivePolicyCount returns the number of policies that currently have active streams
+// getActivePolicyCount returns the number of policy buckets that currently have active streams
 func (s *ownedStreamService) getActivePolicyCount() int {
-	s.policyLock.RLock()
-	defer s.policyLock.RUnlock()
-	return len(s.policyStreamCounts)
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	n := len(s.streamCounts)
+	if _, exists := s.streamCounts[defaultStreamCountBucket]; exists {
+		n--
+	}
+	return n
 }
 
 func (s *ownedStreamService) updateFixedLimit() (old, newVal int32) {
-	newLimit, _, _, _ := s.limiter.GetStreamCountLimit(s.tenantID, noPolicy)
+	newLimit, _, _, _ := s.limiter.GetStreamCountLimit(s.tenantID, defaultStreamCountBucket)
 	return s.fixedLimit.Swap(int32(newLimit)), int32(newLimit)
 }
 
@@ -83,20 +86,29 @@ func (s *ownedStreamService) getFixedLimit() int {
 	return int(s.fixedLimit.Load())
 }
 
-func (s *ownedStreamService) trackStreamOwnership(fp model.Fingerprint, owned bool, policy string) {
-	// only need to inc the owned count; can use sync atomics.
+// trackStreamOwnership counts an owned stream in exactly one bucket. The bucket must be the
+// stream's streamCountBucket so that the later trackRemovedStream call decrements the same
+// bucket.
+func (s *ownedStreamService) trackStreamOwnership(fp model.Fingerprint, owned bool, bucket string) {
 	if owned {
-		s.ownedStreamCount.Inc()
-
-		// Track policy-specific stream count if policy is specified
-		if policy != noPolicy {
-			s.policyLock.Lock()
-			if s.policyStreamCounts[policy] == nil {
-				s.policyStreamCounts[policy] = atomic.NewInt64(0)
-			}
-			s.policyStreamCounts[policy].Inc()
-			s.policyLock.Unlock()
+		// Fast path: the bucket usually exists already and its atomic counter can be
+		// incremented under the read lock.
+		s.lock.RLock()
+		count, exists := s.streamCounts[bucket]
+		if exists {
+			count.Inc()
 		}
+		s.lock.RUnlock()
+		if exists {
+			return
+		}
+
+		s.lock.Lock()
+		if s.streamCounts[bucket] == nil {
+			s.streamCounts[bucket] = atomic.NewInt64(0)
+		}
+		s.streamCounts[bucket].Inc()
+		s.lock.Unlock()
 		return
 	}
 
@@ -107,7 +119,7 @@ func (s *ownedStreamService) trackStreamOwnership(fp model.Fingerprint, owned bo
 	s.notOwnedStreams[fp] = nil
 }
 
-func (s *ownedStreamService) trackRemovedStream(fp model.Fingerprint, policy string) {
+func (s *ownedStreamService) trackRemovedStream(fp model.Fingerprint, bucket string) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -116,33 +128,22 @@ func (s *ownedStreamService) trackRemovedStream(fp model.Fingerprint, policy str
 		delete(s.notOwnedStreams, fp)
 		return
 	}
-	s.ownedStreamCount.Dec()
 
-	// Decrement policy-specific stream count if policy is specified
-	if policy != noPolicy {
-		s.policyLock.Lock()
-		if policyCount, exists := s.policyStreamCounts[policy]; exists {
-			policyCount.Dec()
-			// Clean up policy if count reaches zero to prevent unbounded map growth
-			if policyCount.Load() == 0 {
-				delete(s.policyStreamCounts, policy)
-			}
+	if count, exists := s.streamCounts[bucket]; exists {
+		count.Dec()
+		// Clean up the bucket if count reaches zero to prevent unbounded map growth
+		if count.Load() == 0 {
+			delete(s.streamCounts, bucket)
 		}
-		s.policyLock.Unlock()
 	}
 }
 
 func (s *ownedStreamService) resetStreamCounts() {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	s.ownedStreamCount.Store(0)
 	notOwnedStreamsMetric.Sub(float64(len(s.notOwnedStreams)))
 	s.notOwnedStreams = make(map[model.Fingerprint]any)
-
-	// Reset policy-specific stream counts and clean up the map
-	s.policyLock.Lock()
-	s.policyStreamCounts = make(map[string]*atomic.Int64)
-	s.policyLock.Unlock()
+	s.streamCounts = make(map[string]*atomic.Int64)
 }
 
 func (s *ownedStreamService) isStreamNotOwned(fp model.Fingerprint) bool {

--- a/pkg/ingester/owned_streams.go
+++ b/pkg/ingester/owned_streams.go
@@ -138,30 +138,6 @@ func (s *ownedStreamService) trackRemovedStream(fp model.Fingerprint, bucket str
 	}
 }
 
-// moveStreamBucket moves an owned stream's count from one bucket to another, used when a
-// runtime config change re-assigns the stream's bucket (see instance.rebucketOwnedStreams).
-// Streams currently tracked as not-owned are not counted in any bucket, so there is nothing to
-// move for them.
-func (s *ownedStreamService) moveStreamBucket(fp model.Fingerprint, from, to string) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	if _, notOwned := s.notOwnedStreams[fp]; notOwned {
-		return
-	}
-
-	if count, exists := s.streamCounts[from]; exists {
-		count.Dec()
-		if count.Load() == 0 {
-			delete(s.streamCounts, from)
-		}
-	}
-	if s.streamCounts[to] == nil {
-		s.streamCounts[to] = atomic.NewInt64(0)
-	}
-	s.streamCounts[to].Inc()
-}
-
 func (s *ownedStreamService) resetStreamCounts() {
 	s.lock.Lock()
 	defer s.lock.Unlock()

--- a/pkg/ingester/owned_streams.go
+++ b/pkg/ingester/owned_streams.go
@@ -138,6 +138,30 @@ func (s *ownedStreamService) trackRemovedStream(fp model.Fingerprint, bucket str
 	}
 }
 
+// moveStreamBucket moves an owned stream's count from one bucket to another, used when a
+// runtime config change re-assigns the stream's bucket (see instance.rebucketOwnedStreams).
+// Streams currently tracked as not-owned are not counted in any bucket, so there is nothing to
+// move for them.
+func (s *ownedStreamService) moveStreamBucket(fp model.Fingerprint, from, to string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if _, notOwned := s.notOwnedStreams[fp]; notOwned {
+		return
+	}
+
+	if count, exists := s.streamCounts[from]; exists {
+		count.Dec()
+		if count.Load() == 0 {
+			delete(s.streamCounts, from)
+		}
+	}
+	if s.streamCounts[to] == nil {
+		s.streamCounts[to] = atomic.NewInt64(0)
+	}
+	s.streamCounts[to].Inc()
+}
+
 func (s *ownedStreamService) resetStreamCounts() {
 	s.lock.Lock()
 	defer s.lock.Unlock()

--- a/pkg/ingester/owned_streams_test.go
+++ b/pkg/ingester/owned_streams_test.go
@@ -115,7 +115,7 @@ func Test_OwnedStreamService_PolicyStreamCounting(t *testing.T) {
 	require.Equal(t, 2, service.getStreamCount("finance"))     // finance policy streams
 	require.Equal(t, 1, service.getStreamCount("ops"))         // ops policy streams
 	require.Equal(t, 0, service.getStreamCount("nonexistent")) // non-existent policy
-	require.Equal(t, 2, service.getActivePolicyCount())              // finance and ops policies
+	require.Equal(t, 2, service.getActivePolicyCount())        // finance and ops policies
 
 	// Remove streams
 	service.trackRemovedStream(model.Fingerprint(1), "finance")
@@ -125,7 +125,7 @@ func Test_OwnedStreamService_PolicyStreamCounting(t *testing.T) {
 	require.Equal(t, 1, service.getStreamCount(defaultStreamCountBucket), "removing policy-bucketed streams must not change the tenant-wide bucket")
 	require.Equal(t, 1, service.getStreamCount("finance")) // finance policy streams
 	require.Equal(t, 0, service.getStreamCount("ops"))     // ops policy streams
-	require.Equal(t, 1, service.getActivePolicyCount())          // only finance policy remains
+	require.Equal(t, 1, service.getActivePolicyCount())    // only finance policy remains
 
 	// Remove the tenant-wide stream
 	service.trackRemovedStream(model.Fingerprint(4), noPolicy)

--- a/pkg/ingester/owned_streams_test.go
+++ b/pkg/ingester/owned_streams_test.go
@@ -139,6 +139,35 @@ func Test_OwnedStreamService_PolicyStreamCounting(t *testing.T) {
 	require.Equal(t, 0, service.getStreamCount("ops"))
 }
 
+func Test_OwnedStreamService_MoveStreamBucket(t *testing.T) {
+	limits, err := validation.NewOverrides(validation.Limits{
+		MaxGlobalStreamsPerUser: 100,
+	}, nil)
+	require.NoError(t, err)
+
+	ring := &ringCountMock{count: 30}
+	limiter := NewLimiter(limits, NilMetrics, newIngesterRingLimiterStrategy(ring, 3), &TenantBasedStrategy{limits: limits})
+
+	service := newOwnedStreamService("test", limiter)
+
+	service.trackStreamOwnership(model.Fingerprint(1), true, "replay")
+	service.trackStreamOwnership(model.Fingerprint(2), true, "replay")
+	service.trackStreamOwnership(model.Fingerprint(3), false, "replay") // not owned
+
+	// Owned stream moves buckets; the not-owned stream is not counted anywhere so moving it
+	// must not change any counter.
+	service.moveStreamBucket(model.Fingerprint(1), "replay", defaultStreamCountBucket)
+	service.moveStreamBucket(model.Fingerprint(3), "replay", defaultStreamCountBucket)
+	require.Equal(t, 1, service.getStreamCount(defaultStreamCountBucket))
+	require.Equal(t, 1, service.getStreamCount("replay"))
+
+	// Moving the last stream out of a bucket deletes the bucket (delete-at-zero).
+	service.moveStreamBucket(model.Fingerprint(2), "replay", defaultStreamCountBucket)
+	require.Equal(t, 2, service.getStreamCount(defaultStreamCountBucket))
+	require.Equal(t, 0, service.getStreamCount("replay"))
+	require.Equal(t, 0, service.getActivePolicyCount())
+}
+
 func Test_OwnedStreamService_PolicyCleanup(t *testing.T) {
 	limits, err := validation.NewOverrides(validation.Limits{
 		MaxGlobalStreamsPerUser: 100,

--- a/pkg/ingester/owned_streams_test.go
+++ b/pkg/ingester/owned_streams_test.go
@@ -20,7 +20,7 @@ func Test_OwnedStreamService(t *testing.T) {
 	limiter := NewLimiter(limits, NilMetrics, newIngesterRingLimiterStrategy(ring, 3), &TenantBasedStrategy{limits: limits})
 
 	service := newOwnedStreamService("test", limiter)
-	require.Equal(t, 0, service.getOwnedStreamCount())
+	require.Equal(t, 0, service.getStreamCount(defaultStreamCountBucket))
 	require.Equal(t, 10, service.getFixedLimit(), "fixed limit must be initialised during the instantiation")
 
 	limits.DefaultLimits().MaxGlobalStreamsPerUser = 1000
@@ -32,13 +32,13 @@ func Test_OwnedStreamService(t *testing.T) {
 	service.trackStreamOwnership(model.Fingerprint(1), true, noPolicy)
 	service.trackStreamOwnership(model.Fingerprint(2), true, noPolicy)
 	service.trackStreamOwnership(model.Fingerprint(3), true, noPolicy)
-	require.Equal(t, 3, service.getOwnedStreamCount())
+	require.Equal(t, 3, service.getStreamCount(defaultStreamCountBucket))
 	require.Len(t, service.notOwnedStreams, 0)
 
 	service.resetStreamCounts()
 	service.trackStreamOwnership(model.Fingerprint(3), true, noPolicy)
 	service.trackStreamOwnership(model.Fingerprint(3), false, noPolicy)
-	require.Equal(t, 1, service.getOwnedStreamCount(),
+	require.Equal(t, 1, service.getStreamCount(defaultStreamCountBucket),
 		"owned streams count must not be changed because not owned stream can be reported only by recalculate_owned_streams job that resets the counters before checking all the streams")
 	require.Len(t, service.notOwnedStreams, 1)
 	require.True(t, service.isStreamNotOwned(model.Fingerprint(3)))
@@ -49,11 +49,11 @@ func Test_OwnedStreamService(t *testing.T) {
 	service.trackStreamOwnership(model.Fingerprint(3), false, noPolicy)
 
 	service.trackRemovedStream(model.Fingerprint(3), noPolicy)
-	require.Equal(t, 2, service.getOwnedStreamCount(), "owned stream count must be decremented only when notOwnedStream does not contain this fingerprint")
+	require.Equal(t, 2, service.getStreamCount(defaultStreamCountBucket), "owned stream count must be decremented only when notOwnedStream does not contain this fingerprint")
 	require.Len(t, service.notOwnedStreams, 0)
 
 	service.trackRemovedStream(model.Fingerprint(2), noPolicy)
-	require.Equal(t, 1, service.getOwnedStreamCount())
+	require.Equal(t, 1, service.getStreamCount(defaultStreamCountBucket))
 	require.Len(t, service.notOwnedStreams, 0)
 
 	group := sync.WaitGroup{}
@@ -75,7 +75,7 @@ func Test_OwnedStreamService(t *testing.T) {
 	}
 	group.Wait()
 
-	require.Equal(t, 1, service.getOwnedStreamCount(), "owned stream count must not be changed")
+	require.Equal(t, 1, service.getStreamCount(defaultStreamCountBucket), "owned stream count must not be changed")
 
 	// simulate the effect from the recalculation job
 	service.trackStreamOwnership(model.Fingerprint(44), false, noPolicy)
@@ -83,7 +83,7 @@ func Test_OwnedStreamService(t *testing.T) {
 
 	service.resetStreamCounts()
 
-	require.Equal(t, 0, service.getOwnedStreamCount())
+	require.Equal(t, 0, service.getStreamCount(defaultStreamCountBucket))
 	require.Len(t, service.notOwnedStreams, 0)
 }
 
@@ -99,21 +99,22 @@ func Test_OwnedStreamService_PolicyStreamCounting(t *testing.T) {
 	service := newOwnedStreamService("test", limiter)
 
 	// Initially no streams
-	require.Equal(t, 0, service.getOwnedStreamCount())
-	require.Equal(t, 0, service.getPolicyStreamCount("finance"))
-	require.Equal(t, 0, service.getPolicyStreamCount("ops"))
+	require.Equal(t, 0, service.getStreamCount(defaultStreamCountBucket))
+	require.Equal(t, 0, service.getStreamCount("finance"))
+	require.Equal(t, 0, service.getStreamCount("ops"))
 
-	// Track streams with different policies
+	// Track streams under different buckets. Each stream is counted in exactly one bucket:
+	// its policy bucket, or the tenant-wide count for the noPolicy bucket.
 	service.trackStreamOwnership(model.Fingerprint(1), true, "finance")
 	service.trackStreamOwnership(model.Fingerprint(2), true, "finance")
 	service.trackStreamOwnership(model.Fingerprint(3), true, "ops")
-	service.trackStreamOwnership(model.Fingerprint(4), true, noPolicy) // no policy
+	service.trackStreamOwnership(model.Fingerprint(4), true, noPolicy) // tenant-wide bucket
 
 	// Verify counts
-	require.Equal(t, 4, service.getOwnedStreamCount())               // total streams
-	require.Equal(t, 2, service.getPolicyStreamCount("finance"))     // finance policy streams
-	require.Equal(t, 1, service.getPolicyStreamCount("ops"))         // ops policy streams
-	require.Equal(t, 0, service.getPolicyStreamCount("nonexistent")) // non-existent policy
+	require.Equal(t, 1, service.getStreamCount(defaultStreamCountBucket), "policy-bucketed streams must not count toward the tenant-wide bucket")
+	require.Equal(t, 2, service.getStreamCount("finance"))     // finance policy streams
+	require.Equal(t, 1, service.getStreamCount("ops"))         // ops policy streams
+	require.Equal(t, 0, service.getStreamCount("nonexistent")) // non-existent policy
 	require.Equal(t, 2, service.getActivePolicyCount())              // finance and ops policies
 
 	// Remove streams
@@ -121,16 +122,21 @@ func Test_OwnedStreamService_PolicyStreamCounting(t *testing.T) {
 	service.trackRemovedStream(model.Fingerprint(3), "ops")
 
 	// Verify updated counts
-	require.Equal(t, 2, service.getOwnedStreamCount())           // total streams
-	require.Equal(t, 1, service.getPolicyStreamCount("finance")) // finance policy streams
-	require.Equal(t, 0, service.getPolicyStreamCount("ops"))     // ops policy streams
+	require.Equal(t, 1, service.getStreamCount(defaultStreamCountBucket), "removing policy-bucketed streams must not change the tenant-wide bucket")
+	require.Equal(t, 1, service.getStreamCount("finance")) // finance policy streams
+	require.Equal(t, 0, service.getStreamCount("ops"))     // ops policy streams
 	require.Equal(t, 1, service.getActivePolicyCount())          // only finance policy remains
+
+	// Remove the tenant-wide stream
+	service.trackRemovedStream(model.Fingerprint(4), noPolicy)
+	require.Equal(t, 0, service.getStreamCount(defaultStreamCountBucket))
+	require.Equal(t, 1, service.getStreamCount("finance"))
 
 	// Reset and verify
 	service.resetStreamCounts()
-	require.Equal(t, 0, service.getOwnedStreamCount())
-	require.Equal(t, 0, service.getPolicyStreamCount("finance"))
-	require.Equal(t, 0, service.getPolicyStreamCount("ops"))
+	require.Equal(t, 0, service.getStreamCount(defaultStreamCountBucket))
+	require.Equal(t, 0, service.getStreamCount("finance"))
+	require.Equal(t, 0, service.getStreamCount("ops"))
 }
 
 func Test_OwnedStreamService_PolicyCleanup(t *testing.T) {
@@ -155,9 +161,9 @@ func Test_OwnedStreamService_PolicyCleanup(t *testing.T) {
 
 	// Verify we have 3 active policies
 	require.Equal(t, 3, service.getActivePolicyCount())
-	require.Equal(t, 2, service.getPolicyStreamCount("finance"))
-	require.Equal(t, 1, service.getPolicyStreamCount("ops"))
-	require.Equal(t, 1, service.getPolicyStreamCount("dev"))
+	require.Equal(t, 2, service.getStreamCount("finance"))
+	require.Equal(t, 1, service.getStreamCount("ops"))
+	require.Equal(t, 1, service.getStreamCount("dev"))
 
 	// Remove all finance streams - should clean up the policy
 	service.trackRemovedStream(model.Fingerprint(1), "finance")
@@ -165,25 +171,25 @@ func Test_OwnedStreamService_PolicyCleanup(t *testing.T) {
 
 	// Verify finance policy is cleaned up
 	require.Equal(t, 2, service.getActivePolicyCount()) // finance removed, ops and dev remain
-	require.Equal(t, 0, service.getPolicyStreamCount("finance"))
-	require.Equal(t, 1, service.getPolicyStreamCount("ops"))
-	require.Equal(t, 1, service.getPolicyStreamCount("dev"))
+	require.Equal(t, 0, service.getStreamCount("finance"))
+	require.Equal(t, 1, service.getStreamCount("ops"))
+	require.Equal(t, 1, service.getStreamCount("dev"))
 
 	// Remove ops stream - should clean up the policy
 	service.trackRemovedStream(model.Fingerprint(3), "ops")
 
 	// Verify ops policy is cleaned up
 	require.Equal(t, 1, service.getActivePolicyCount()) // only dev remains
-	require.Equal(t, 0, service.getPolicyStreamCount("ops"))
-	require.Equal(t, 1, service.getPolicyStreamCount("dev"))
+	require.Equal(t, 0, service.getStreamCount("ops"))
+	require.Equal(t, 1, service.getStreamCount("dev"))
 
 	// Remove dev stream - should clean up the policy
 	service.trackRemovedStream(model.Fingerprint(4), "dev")
 
 	// Verify dev policy is cleaned up
 	require.Equal(t, 0, service.getActivePolicyCount()) // no policies left
-	require.Equal(t, 0, service.getPolicyStreamCount("dev"))
+	require.Equal(t, 0, service.getStreamCount("dev"))
 
 	// Verify total stream count is correct
-	require.Equal(t, 0, service.getOwnedStreamCount())
+	require.Equal(t, 0, service.getStreamCount(defaultStreamCountBucket))
 }

--- a/pkg/ingester/owned_streams_test.go
+++ b/pkg/ingester/owned_streams_test.go
@@ -139,35 +139,6 @@ func Test_OwnedStreamService_PolicyStreamCounting(t *testing.T) {
 	require.Equal(t, 0, service.getStreamCount("ops"))
 }
 
-func Test_OwnedStreamService_MoveStreamBucket(t *testing.T) {
-	limits, err := validation.NewOverrides(validation.Limits{
-		MaxGlobalStreamsPerUser: 100,
-	}, nil)
-	require.NoError(t, err)
-
-	ring := &ringCountMock{count: 30}
-	limiter := NewLimiter(limits, NilMetrics, newIngesterRingLimiterStrategy(ring, 3), &TenantBasedStrategy{limits: limits})
-
-	service := newOwnedStreamService("test", limiter)
-
-	service.trackStreamOwnership(model.Fingerprint(1), true, "replay")
-	service.trackStreamOwnership(model.Fingerprint(2), true, "replay")
-	service.trackStreamOwnership(model.Fingerprint(3), false, "replay") // not owned
-
-	// Owned stream moves buckets; the not-owned stream is not counted anywhere so moving it
-	// must not change any counter.
-	service.moveStreamBucket(model.Fingerprint(1), "replay", defaultStreamCountBucket)
-	service.moveStreamBucket(model.Fingerprint(3), "replay", defaultStreamCountBucket)
-	require.Equal(t, 1, service.getStreamCount(defaultStreamCountBucket))
-	require.Equal(t, 1, service.getStreamCount("replay"))
-
-	// Moving the last stream out of a bucket deletes the bucket (delete-at-zero).
-	service.moveStreamBucket(model.Fingerprint(2), "replay", defaultStreamCountBucket)
-	require.Equal(t, 2, service.getStreamCount(defaultStreamCountBucket))
-	require.Equal(t, 0, service.getStreamCount("replay"))
-	require.Equal(t, 0, service.getActivePolicyCount())
-}
-
 func Test_OwnedStreamService_PolicyCleanup(t *testing.T) {
 	limits, err := validation.NewOverrides(validation.Limits{
 		MaxGlobalStreamsPerUser: 100,

--- a/pkg/ingester/recalculate_owned_streams.go
+++ b/pkg/ingester/recalculate_owned_streams.go
@@ -56,7 +56,17 @@ func (s *recalculateOwnedStreamsSvc) recalculate() {
 		return
 	}
 	if !ringChanged {
-		level.Debug(s.logger).Log("msg", "ring is not changed, skipping the job")
+		level.Debug(s.logger).Log("msg", "ring is not changed, only re-checking stream count buckets")
+		// Ownership is unaffected, but a runtime change to policy stream-count overrides can
+		// re-assign streams' buckets; converge membership here. Ring changes converge it via
+		// updateOwnedStreams below.
+		// NOTE: this runs on every tick; the per-stream work is a memoized map lookup plus a
+		// string compare, so it should be cheap even for large stream counts. If it ever shows
+		// up in profiles, cache each tenant's effective stream-count override set (the
+		// policy -> local/global limit pairs plus use_owned_stream_count) and skip the pass
+		// when it is unchanged since the previous tick — bucket membership can only change
+		// when that config changes.
+		s.rebucketStreamCounts()
 		return
 	}
 	level.Info(s.logger).Log("msg", "detected ring changes, re-evaluating streams ownership")
@@ -71,6 +81,15 @@ func (s *recalculateOwnedStreamsSvc) recalculate() {
 		if err != nil {
 			level.Error(s.logger).Log("msg", "failed to re-evaluate streams ownership", "tenant", instance.instanceID, "err", err)
 		}
+	}
+}
+
+func (s *recalculateOwnedStreamsSvc) rebucketStreamCounts() {
+	for _, instance := range s.instancesSupplier() {
+		if !instance.limiter.limits.UseOwnedStreamCount(instance.instanceID) {
+			continue
+		}
+		instance.rebucketOwnedStreams()
 	}
 }
 

--- a/pkg/ingester/recalculate_owned_streams.go
+++ b/pkg/ingester/recalculate_owned_streams.go
@@ -56,17 +56,7 @@ func (s *recalculateOwnedStreamsSvc) recalculate() {
 		return
 	}
 	if !ringChanged {
-		level.Debug(s.logger).Log("msg", "ring is not changed, only re-checking stream count buckets")
-		// Ownership is unaffected, but a runtime change to policy stream-count overrides can
-		// re-assign streams' buckets; converge membership here. Ring changes converge it via
-		// updateOwnedStreams below.
-		// NOTE: this runs on every tick; the per-stream work is a memoized map lookup plus a
-		// string compare, so it should be cheap even for large stream counts. If it ever shows
-		// up in profiles, cache each tenant's effective stream-count override set (the
-		// policy -> local/global limit pairs plus use_owned_stream_count) and skip the pass
-		// when it is unchanged since the previous tick — bucket membership can only change
-		// when that config changes.
-		s.rebucketStreamCounts()
+		level.Debug(s.logger).Log("msg", "ring is not changed, skipping the job")
 		return
 	}
 	level.Info(s.logger).Log("msg", "detected ring changes, re-evaluating streams ownership")
@@ -81,15 +71,6 @@ func (s *recalculateOwnedStreamsSvc) recalculate() {
 		if err != nil {
 			level.Error(s.logger).Log("msg", "failed to re-evaluate streams ownership", "tenant", instance.instanceID, "err", err)
 		}
-	}
-}
-
-func (s *recalculateOwnedStreamsSvc) rebucketStreamCounts() {
-	for _, instance := range s.instancesSupplier() {
-		if !instance.limiter.limits.UseOwnedStreamCount(instance.instanceID) {
-			continue
-		}
-		instance.rebucketOwnedStreams()
 	}
 }
 

--- a/pkg/ingester/recalculate_owned_streams_test.go
+++ b/pkg/ingester/recalculate_owned_streams_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/compactor/retention"
+	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/runtime"
 	lokiring "github.com/grafana/loki/v3/pkg/util/ring"
 	"github.com/grafana/loki/v3/pkg/validation"
@@ -267,4 +268,40 @@ type mockPartitionRingReader struct {
 
 func (m mockPartitionRingReader) PartitionRing() *ring.PartitionRing {
 	return m.ring
+}
+
+type mockOwnershipStrategy struct {
+	ringChanged bool
+}
+
+func (m *mockOwnershipStrategy) checkRingForChanges() (bool, error) { return m.ringChanged, nil }
+func (m *mockOwnershipStrategy) isOwnedStream(*stream) (bool, error) {
+	return true, nil
+}
+
+func Test_recalculateOwnedStreams_rebucketsWithoutRingChange(t *testing.T) {
+	inst, limits := streamCountBucketsTestInstance(t)
+
+	err := inst.Push(context.Background(), &logproto.PushRequest{Streams: []logproto.Stream{
+		{Labels: `{job="replay", n="0"}`, Entries: entries(1, time.Now().Add(-5*time.Minute))},
+		{Labels: `{job="app", n="0"}`, Entries: entries(1, time.Now().Add(-5*time.Minute))},
+	}})
+	require.NoError(t, err)
+	require.Equal(t, 1, inst.ownedStreamsSvc.getStreamCount(defaultStreamCountBucket))
+	require.Equal(t, 1, inst.ownedStreamsSvc.getStreamCount("replay"))
+
+	// Remove the override at runtime; the ring does NOT change, but the periodic job must
+	// still converge bucket membership.
+	limits.DefaultLimits().PolicyOverrideLimits = nil
+
+	service := newRecalculateOwnedStreamsSvc(
+		(&mockTenantsSuplier{tenants: []*instance{inst}}).get,
+		&mockOwnershipStrategy{ringChanged: false},
+		50*time.Millisecond,
+		log.NewNopLogger(),
+	)
+	service.recalculate()
+
+	require.Equal(t, 2, inst.ownedStreamsSvc.getStreamCount(defaultStreamCountBucket))
+	require.Equal(t, 0, inst.ownedStreamsSvc.getStreamCount("replay"))
 }

--- a/pkg/ingester/recalculate_owned_streams_test.go
+++ b/pkg/ingester/recalculate_owned_streams_test.go
@@ -104,7 +104,7 @@ func Test_recalculateOwnedStreams_recalculateWithIngesterStrategy(t *testing.T) 
 			mockRing.addMapping(createStream(t, tenant, 100), true)
 			mockRing.addMapping(createStream(t, tenant, 250), true)
 
-			require.Equal(t, int64(7), tenant.ownedStreamsSvc.ownedStreamCount.Load())
+			require.Equal(t, 7, tenant.ownedStreamsSvc.getStreamCount(defaultStreamCountBucket))
 			require.Len(t, tenant.ownedStreamsSvc.notOwnedStreams, 0)
 
 			mockTenantsSupplier := &mockTenantsSuplier{tenants: []*instance{tenant}}
@@ -119,7 +119,7 @@ func Test_recalculateOwnedStreams_recalculateWithIngesterStrategy(t *testing.T) 
 			if testData.featureEnabled {
 				require.Equal(t, 50, tenant.ownedStreamsSvc.getFixedLimit(), "fixed limit must be updated after recalculation")
 			}
-			require.Equal(t, testData.expectedOwnedStreamCount, tenant.ownedStreamsSvc.ownedStreamCount.Load())
+			require.Equal(t, testData.expectedOwnedStreamCount, int64(tenant.ownedStreamsSvc.getStreamCount(defaultStreamCountBucket)))
 			require.Len(t, tenant.ownedStreamsSvc.notOwnedStreams, testData.expectedNotOwnedStreamCount)
 		})
 	}

--- a/pkg/ingester/recalculate_owned_streams_test.go
+++ b/pkg/ingester/recalculate_owned_streams_test.go
@@ -268,4 +268,3 @@ type mockPartitionRingReader struct {
 func (m mockPartitionRingReader) PartitionRing() *ring.PartitionRing {
 	return m.ring
 }
-

--- a/pkg/ingester/recalculate_owned_streams_test.go
+++ b/pkg/ingester/recalculate_owned_streams_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/loki/v3/pkg/compactor/retention"
-	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/runtime"
 	lokiring "github.com/grafana/loki/v3/pkg/util/ring"
 	"github.com/grafana/loki/v3/pkg/validation"
@@ -270,38 +269,3 @@ func (m mockPartitionRingReader) PartitionRing() *ring.PartitionRing {
 	return m.ring
 }
 
-type mockOwnershipStrategy struct {
-	ringChanged bool
-}
-
-func (m *mockOwnershipStrategy) checkRingForChanges() (bool, error) { return m.ringChanged, nil }
-func (m *mockOwnershipStrategy) isOwnedStream(*stream) (bool, error) {
-	return true, nil
-}
-
-func Test_recalculateOwnedStreams_rebucketsWithoutRingChange(t *testing.T) {
-	inst, limits := streamCountBucketsTestInstance(t)
-
-	err := inst.Push(context.Background(), &logproto.PushRequest{Streams: []logproto.Stream{
-		{Labels: `{job="replay", n="0"}`, Entries: entries(1, time.Now().Add(-5*time.Minute))},
-		{Labels: `{job="app", n="0"}`, Entries: entries(1, time.Now().Add(-5*time.Minute))},
-	}})
-	require.NoError(t, err)
-	require.Equal(t, 1, inst.ownedStreamsSvc.getStreamCount(defaultStreamCountBucket))
-	require.Equal(t, 1, inst.ownedStreamsSvc.getStreamCount("replay"))
-
-	// Remove the override at runtime; the ring does NOT change, but the periodic job must
-	// still converge bucket membership.
-	limits.DefaultLimits().PolicyOverrideLimits = nil
-
-	service := newRecalculateOwnedStreamsSvc(
-		(&mockTenantsSuplier{tenants: []*instance{inst}}).get,
-		&mockOwnershipStrategy{ringChanged: false},
-		50*time.Millisecond,
-		log.NewNopLogger(),
-	)
-	service.recalculate()
-
-	require.Equal(t, 2, inst.ownedStreamsSvc.getStreamCount(defaultStreamCountBucket))
-	require.Equal(t, 0, inst.ownedStreamsSvc.getStreamCount("replay"))
-}

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -88,11 +88,10 @@ type stream struct {
 
 	retentionHours string
 	policy         string
-	// streamCountBucket is the bucket this stream's count is tracked under for stream-count
-	// limits (see Limiter.streamCountBucket): the policy name when the policy has a
-	// stream-count override, defaultStreamCountBucket otherwise. Kept separate from policy,
-	// which is still used for rate limits, enforced labels and reporting regardless of
-	// overrides.
+
+	// streamCountBucket is the name of the bucket used to track stream counts.
+	// If the policy overrides stream limits, then streamCountBucket is the policy name.
+	// Otherwise, streamCountBucket is defaultStreamCountBucket.
 	streamCountBucket string
 }
 

--- a/pkg/ingester/stream.go
+++ b/pkg/ingester/stream.go
@@ -88,6 +88,12 @@ type stream struct {
 
 	retentionHours string
 	policy         string
+	// streamCountBucket is the bucket this stream's count is tracked under for stream-count
+	// limits (see Limiter.streamCountBucket): the policy name when the policy has a
+	// stream-count override, defaultStreamCountBucket otherwise. Kept separate from policy,
+	// which is still used for rate limits, enforced labels and reporting regardless of
+	// overrides.
+	streamCountBucket string
 }
 
 type chunkDesc struct {

--- a/pkg/validation/ingestion_policies.go
+++ b/pkg/validation/ingestion_policies.go
@@ -387,7 +387,7 @@ func (o *PerPolicyConfigOverride) ApplyTo(base shardstreams.Config) shardstreams
 type PolicyOverridableLimits struct {
 	// MaxLocalStreamsPerUser and MaxGlobalStreamsPerUser give the policy its own stream-count
 	// bucket, tracked and limited independently from the tenant-wide count. They are enforced
-	// only with `use_owned_stream_count: true` (classic ingester path) or the delegated
+	// only with `use_owned_stream_count: true` (classic ingester path) or with the delegated
 	// ingest-limits service; otherwise they are ignored. An explicit 0 follows the same
 	// convention as the tenant-level limits: 0 disables that limit (it does NOT block new
 	// streams), so a policy with both set to 0 is unlimited.

--- a/pkg/validation/ingestion_policies.go
+++ b/pkg/validation/ingestion_policies.go
@@ -388,7 +388,9 @@ type PolicyOverridableLimits struct {
 	// MaxLocalStreamsPerUser and MaxGlobalStreamsPerUser give the policy its own stream-count
 	// bucket, tracked and limited independently from the tenant-wide count. They are enforced
 	// only with `use_owned_stream_count: true` (classic ingester path) or the delegated
-	// ingest-limits service; otherwise they are ignored.
+	// ingest-limits service; otherwise they are ignored. An explicit 0 follows the same
+	// convention as the tenant-level limits: 0 disables that limit (it does NOT block new
+	// streams), so a policy with both set to 0 is unlimited.
 	MaxLocalStreamsPerUser  *int                     `yaml:"max_streams_per_user" json:"max_streams_per_user" doc:"hidden"`
 	MaxGlobalStreamsPerUser *int                     `yaml:"max_global_streams_per_user" json:"max_global_streams_per_user" doc:"hidden"`
 	IngestionRateMB         *float64                 `yaml:"ingestion_rate_mb" json:"ingestion_rate_mb" doc:"hidden"`

--- a/pkg/validation/ingestion_policies.go
+++ b/pkg/validation/ingestion_policies.go
@@ -385,6 +385,10 @@ func (o *PerPolicyConfigOverride) ApplyTo(base shardstreams.Config) shardstreams
 // pointer: a nil field means "not overridden" (the tenant value is inherited); a non-nil field
 // overrides the tenant value for streams resolved to the policy.
 type PolicyOverridableLimits struct {
+	// MaxLocalStreamsPerUser and MaxGlobalStreamsPerUser give the policy its own stream-count
+	// bucket, tracked and limited independently from the tenant-wide count. They are enforced
+	// only with `use_owned_stream_count: true` (classic ingester path) or the delegated
+	// ingest-limits service; otherwise they are ignored.
 	MaxLocalStreamsPerUser  *int                     `yaml:"max_streams_per_user" json:"max_streams_per_user" doc:"hidden"`
 	MaxGlobalStreamsPerUser *int                     `yaml:"max_global_streams_per_user" json:"max_global_streams_per_user" doc:"hidden"`
 	IngestionRateMB         *float64                 `yaml:"ingestion_rate_mb" json:"ingestion_rate_mb" doc:"hidden"`


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes the classic ingester's per-policy stream-count accounting equivalent to the ingest-limits service (`pkg/limits`): a stream is tracked in a per-policy bucket **only when** its policy has a `max_streams_per_user` / `max_global_streams_per_user` override in `policy_override_limits`. Otherwise it counts in the default (tenant-wide) bucket. Each stream counts in exactly one bucket.

This fixes two bugs in the previous accounting:
- **Double counting**: policy streams incremented both the tenant-wide count and their policy count, so policy traffic consumed the tenant-wide stream budget (order-dependent limits; regular streams could be starved).
- **Phantom budgets**: any stream matching a policy in `policy_stream_mapping` was checked against its policy-only count while falling back to the tenant limit, so every mapped policy without an override got its own tenant-sized stream budget.

Implementation: `Limiter.streamCountBucket()` resolves the bucket at stream creation and stores it on the stream so add/remove stay symmetric. Bucket membership is re-converged on ring-change recalculation (`updateOwnedStreams`). `ownedStreamService` now tracks a single `streamCounts` bucket map instead of a tenant-wide counter plus a policy map.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
- Per-policy stream-count overrides now require `use_owned_stream_count: true` (or the delegated ingest-limits service). Without it there is no per-policy count, and the override was previously misapplied against the tenant-wide total.
- An explicit `0` in a policy stream-count override follows the tenant-level convention: it disables the limit (unlimited), it does not block new streams.
- In this PR, streams' policies and buckets stay fixed at creation and only re-converge on ring-change recalculation. Follow-up #23750 adds convergence on runtime policy-config changes: it re-resolves mapping-derived policies and moves stream-count buckets whenever `policy_stream_mapping`/`policy_override_limits` change (gated on a per-tenant config hash; header-assigned policies stay sticky).
- With independent buckets, an ingester can now hold up to `tenant_limit + sum(policy override limits)` streams (matching `pkg/limits`); tenants with existing overrides get a higher effective ceiling after upgrade.
- `trackRemovedStream` for an unknown bucket is now a no-op instead of unconditionally decrementing the tenant-wide counter.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
