### PR TITLE
chore(dev): Add Prometheus to the Kafka local dev environment

### DIFF
--- a/tools/dev/kafka/README.md
+++ b/tools/dev/kafka/README.md
@@ -33,11 +33,17 @@ This directory contains the development environment for testing Loki with Kafka 
 ### Grafana
 - Available at http://localhost:3000
 - Anonymous access enabled (Admin privileges)
-- Pre-configured with Loki data source
+- Pre-configured with Loki and Prometheus data sources
 - Features enabled:
   - Loki logs dataplane
   - Explore logs shard splitting
   - Loki explore app
+
+### Prometheus
+- Available at http://localhost:9090
+- Scrapes the host Loki's `/metrics` (`host.docker.internal:3100`, the single-binary `-target=all` process)
+- Query its metrics from Grafana via the pre-provisioned `gdev-prometheus` data source
+- Scrape target is defined in `prometheus.yaml`; add more `host:port`s there if you run multiple Loki processes
 
 ### Log Generator
 - Automatically sends sample logs to Loki

--- a/tools/dev/kafka/docker-compose.yaml
+++ b/tools/dev/kafka/docker-compose.yaml
@@ -14,6 +14,15 @@ services:
       - ./data/grafana/:/var/lib/grafana/
     extra_hosts:
       - "host.docker.internal:host-gateway"
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - 9090:9090/tcp
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yml
+    extra_hosts:
+      # Loki runs on the host, so Prometheus reaches its /metrics via host.docker.internal.
+      - "host.docker.internal:host-gateway"
   kafka-ui:
     image: provectuslabs/kafka-ui:latest
     ports:

--- a/tools/dev/kafka/prometheus.yaml
+++ b/tools/dev/kafka/prometheus.yaml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  # Loki runs on the host as a single-binary (-target=all), so there is one /metrics endpoint.
+  # If you run multiple Loki processes/containers, add their host:port here.
+  - job_name: loki
+    static_configs:
+      - targets: ["host.docker.internal:3100"]

--- a/tools/dev/kafka/provisioning/datasources/default.yml
+++ b/tools/dev/kafka/provisioning/datasources/default.yml
@@ -9,3 +9,9 @@ datasources:
     uid: gdev-loki
     access: proxy
     url: http://host.docker.internal:3100
+  - name: gdev-prometheus
+    type: prometheus
+    uid: gdev-prometheus
+    access: proxy
+    # Prometheus runs as a compose service, reachable by its service name on the shared network.
+    url: http://prometheus:9090


### PR DESCRIPTION
**What this PR does / why we need it**:

The Kafka local dev environment already lets you query Loki logs from Grafana, but not Loki's own metrics. That makes it awkward to look at ingestion, querier or ingest-limits behaviour while developing: you have to curl `/metrics` and read counters by hand, with no rates or history.

This adds a Prometheus service to the compose stack, scraping the host Loki process every 5s, and pre-provisions it as a Grafana data source. Loki metrics can then be explored and graphed in the same Grafana as the logs.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Dev-tooling only, no production code touched. Verified that Prometheus starts, loads the mounted config, and resolves the host Loki target through `host.docker.internal`.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
