### PR TITLE
chore: Implement streaming reading of symbols section

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/builder_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/builder_test.go
@@ -35,7 +35,7 @@ func Test_Build(t *testing.T) {
 		return context.Background(), builder, tmpDir
 	}
 
-	getReader := func(path string) index.Reader {
+	getReader := func(path string) *index.ByteSliceReader {
 		indexPath := fakeIdentifierPathForBounds(path, 1, 6) //default step is 1
 		files, err := filepath.Glob(indexPath)
 		require.NoError(t, err)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_read.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_read.go
@@ -52,10 +52,6 @@ func (h *headIndexReader) Close() error {
 	return nil
 }
 
-func (h *headIndexReader) Symbols() index.StringIter {
-	return h.head.postings.Symbols()
-}
-
 // LabelValues returns label values present in the head for the
 // specific label name that are within the time range mint to maxt.
 // If matchers are specified the returned result set is reduced

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1651,13 +1651,9 @@ func (r *ByteSliceReader) Checksum() uint32 {
 }
 
 // Symbols returns an iterator over the symbols that exist within the index.
+// Only used in tests.
 func (r *ByteSliceReader) Symbols() StringIter {
 	return r.symbols.Iter()
-}
-
-// SymbolTableSize returns the symbol table size in bytes.
-func (r *ByteSliceReader) SymbolTableSize() uint64 {
-	return uint64(r.symbols.Size())
 }
 
 // LabelValues returns value tuples that exist for the given label name.

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/reader.go
@@ -27,12 +27,6 @@ type Reader interface {
 	// Checksum returns the CRC32 checksum recorded in the index TOC.
 	Checksum() uint32
 
-	// Symbols returns an iterator over the symbol table.
-	Symbols() StringIter
-
-	// SymbolTableSize returns the symbol table size in bytes.
-	SymbolTableSize() uint64
-
 	// LabelValues returns the possible label values for the given label name.
 	LabelValues(name string, matchers ...*labels.Matcher) ([]string, error)
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
@@ -27,6 +27,8 @@ type StreamReader struct {
 	size    int64
 	version int
 	toc     *TOC
+
+	symbols *streamSymbols
 }
 
 // NewStreamFileReader constructs a StreamReader against the given index file.
@@ -58,6 +60,12 @@ func NewStreamFileReader(path string) (*StreamReader, error) {
 		return nil, err
 	}
 	reader.toc = toc
+
+	reader.symbols, err = newStreamSymbols(context.Background(), factory, int(toc.Symbols))
+	if err != nil {
+		_ = factory.Close()
+		return nil, err
+	}
 
 	// Fallback used by not-yet-ported methods
 	mmapReader, err := NewMmapFileReader(path)
@@ -166,14 +174,6 @@ func (s StreamReader) Bounds() (int64, int64) {
 
 func (s StreamReader) Checksum() uint32 {
 	return s.toc.Metadata.Checksum
-}
-
-func (s StreamReader) Symbols() StringIter {
-	return s.mmapReader.Symbols()
-}
-
-func (s StreamReader) SymbolTableSize() uint64 {
-	return s.mmapReader.SymbolTableSize()
 }
 
 func (s StreamReader) LabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
@@ -93,7 +93,6 @@ func TestReaders_CrossCheck(t *testing.T) {
 
 			require.Equal(t, mmap.Version(), stream.Version())
 			require.Equal(t, mmap.Checksum(), stream.Checksum())
-			require.Equal(t, mmap.SymbolTableSize(), stream.SymbolTableSize())
 			require.Equal(t, mmap.Size(), stream.Size())
 
 			baseMin, baseMax := mmap.Bounds()
@@ -101,7 +100,6 @@ func TestReaders_CrossCheck(t *testing.T) {
 			require.Equal(t, baseMin, rMin)
 			require.Equal(t, baseMax, rMax)
 
-			requireSymbolsEqual(t, mmap, stream)
 			requireLabelsEqual(t, mmap, stream)
 			requirePostingsSeriesEqual(t, mmap, stream)
 			requirePostingsRangesEqual(t, mmap, stream)
@@ -188,6 +186,30 @@ func TestReaders_RejectsCorruptTOCChecksum(t *testing.T) {
 	}
 }
 
+func TestReaders_RejectsCorruptSymbolsChecksum(t *testing.T) {
+	for _, rc := range allReaderConstructors() {
+		t.Run(rc.name, func(t *testing.T) {
+			path := writeCrossCheckFixture(t, FormatV3)
+
+			// Locate the symbols section from the TOC
+			reader, err := NewStreamFileReader(path)
+			require.NoError(t, err)
+			symbolsOffset := int(reader.toc.Symbols)
+			require.NoError(t, reader.Close())
+
+			corruptFileBytes(t, path, func(b []byte) {
+				// Flip the first byte of the section's content (skipping the first 4 bytes,
+				// which is the size of the section).
+				b[symbolsOffset+4] ^= 0x01
+			})
+
+			_, err = rc.open(path)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid checksum")
+		})
+	}
+}
+
 // TestReaders_RawFileReaderIndependence verifies that RawFileReader
 // returns an independent reader each call.
 func TestReaders_RawFileReaderIndependence(t *testing.T) {
@@ -238,24 +260,6 @@ func corruptFileBytes(t *testing.T, path string, mutate func(b []byte)) {
 	require.NoError(t, err)
 	mutate(b)
 	require.NoError(t, os.WriteFile(path, b, 0600))
-}
-
-func requireSymbolsEqual(t *testing.T, mmap, stream Reader) {
-	t.Helper()
-	mmapSymbols := getSymbols(t, mmap)
-	streamSymbols := getSymbols(t, stream)
-	require.Equal(t, mmapSymbols, streamSymbols)
-}
-
-func getSymbols(t *testing.T, reader Reader) []string {
-	t.Helper()
-	var out []string
-	symbols := reader.Symbols()
-	for symbols.Next() {
-		out = append(out, symbols.At())
-	}
-	require.NoError(t, symbols.Err())
-	return out
 }
 
 func requireLabelsEqual(t *testing.T, mmap, stream Reader) {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols.go
@@ -1,0 +1,83 @@
+package index
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc"
+)
+
+// streamSymbols is StreamReader's equivalent of Symbols.
+//
+// It is used to read the symbols section of an index.
+// On creation builds a sparse offset table capturing the position of every
+// symbolFactor-th symbol.
+// A symbol look-up then skips to a location specified by the sparse offset table
+// and walks from there through up to symbolFactor symbols to the target symbol.
+type streamSymbols struct {
+	factory *streamenc.FilePoolDecbufFactory
+	// off is the absolute file offset of the symbols section.
+	off int
+	// offsets contains the offset of each of every symbolFactor-th symbol relative to off.
+	offsets []int
+	// size is the total number of symbols in the section.
+	size int
+}
+
+// newStreamSymbols scans the symbol section once, validating its CRC and
+// capturing the sparse offset table.
+func newStreamSymbols(ctx context.Context, factory *streamenc.FilePoolDecbufFactory, off int) (*streamSymbols, error) {
+	decbuf := factory.NewDecbufAtChecked(ctx, off, castagnoliTable)
+	if err := decbuf.Err(); err != nil {
+		_ = decbuf.Close()
+		return nil, err
+	}
+	defer func() { _ = decbuf.Close() }()
+
+	size := decbuf.Be32int()
+	if err := decbuf.Err(); err != nil {
+		return nil, err
+	}
+	// Construct the sparse offset table
+	s := &streamSymbols{
+		factory: factory,
+		off:     off,
+		size:    size,
+		offsets: make([]int, 0, 1+size/symbolFactor),
+	}
+	for i := 0; decbuf.Err() == nil && i < size; i++ {
+		if i%symbolFactor == 0 {
+			s.offsets = append(s.offsets, decbuf.Offset())
+		}
+		decbuf.SkipUvarintBytes()
+	}
+	if err := decbuf.Err(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *streamSymbols) Lookup(n uint32) (string, error) {
+	if int(n) >= s.size {
+		return "", fmt.Errorf("unknown symbol offset %d", n)
+	}
+
+	decbuf := s.factory.NewDecbufAtUnchecked(context.Background(), s.off)
+	if err := decbuf.Err(); err != nil {
+		return "", err
+	}
+	defer func() { _ = decbuf.Close() }()
+
+	// Use sparse offset table to jump right to the start of the bucket the symbol is in.
+	decbuf.ResetAt(s.offsets[int(n/symbolFactor)])
+	// Walk until we find the one we want.
+	for i := n - (n / symbolFactor * symbolFactor); i > 0; i-- {
+		decbuf.SkipUvarintBytes()
+	}
+
+	symbol := decbuf.UvarintStr()
+	if err := decbuf.Err(); err != nil {
+		return "", err
+	}
+	return symbol, nil
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols_test.go
@@ -1,0 +1,114 @@
+package index
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// writeManySymbolsFixture builds an index with well over symbolFactor
+// symbols so the sparse offset table has multiple entries and a lookup must
+// walk forward within a sparse block. Each series gets a unique zero-padded
+// "id" value; symbols are the sorted union of the label name and every value.
+func writeManySymbolsFixture(t *testing.T, format int) string {
+	t.Helper()
+	dir := t.TempDir()
+	fileName := filepath.Join(dir, IndexFilename)
+
+	creator, err := NewWriter(context.Background(), format, fileName)
+	require.NoError(t, err)
+
+	const numSeries = symbolFactor*4 + 5 // 133: several full sparse blocks plus a remainder.
+
+	// Collect the sorted, de-duplicated symbol set (label name + all values).
+	symbolSet := map[string]struct{}{"id": {}}
+	values := make([]string, 0, numSeries)
+	for i := range numSeries {
+		v := fmt.Sprintf("v%04d", i)
+		values = append(values, v)
+		symbolSet[v] = struct{}{}
+	}
+	symbols := make([]string, 0, len(symbolSet))
+	for s := range symbolSet {
+		symbols = append(symbols, s)
+	}
+	sort.Strings(symbols)
+	for _, s := range symbols {
+		require.NoError(t, creator.AddSymbol(s))
+	}
+
+	type entry struct {
+		ls     labels.Labels
+		chunks []ChunkMeta
+	}
+	entries := make([]entry, 0, numSeries)
+	for _, v := range values {
+		entries = append(entries, entry{
+			ls:     labels.FromStrings("id", v),
+			chunks: []ChunkMeta{{Checksum: 1, MinTime: 0, MaxTime: 10, KB: 1, Entries: 1}},
+		})
+	}
+	// AddSeries requires ascending fingerprint order.
+	sort.Slice(entries, func(i, j int) bool {
+		return labels.StableHash(entries[i].ls) < labels.StableHash(entries[j].ls)
+	})
+	for i, e := range entries {
+		require.NoError(t, creator.AddSeries(
+			storage.SeriesRef(i+1),
+			e.ls,
+			model.Fingerprint(labels.StableHash(e.ls)),
+			e.chunks...,
+		))
+	}
+
+	_, err = creator.Close(false)
+	require.NoError(t, err)
+	return fileName
+}
+
+// TestStreamSymbols_LookupMatchesMmap asserts that streamSymbols.Lookup and
+// Symbols.Lookup have matching behavior.
+func TestStreamSymbols_LookupMatchesMmap(t *testing.T) {
+	for _, format := range []int{FormatV3, FormatV4} {
+		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
+			fn := writeManySymbolsFixture(t, format)
+
+			mmap, err := NewMmapFileReader(fn)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, mmap.Close()) })
+
+			stream, err := NewStreamFileReader(fn)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, stream.Close()) })
+
+			// Both symbol tables must agree on how many symbols exist.
+			require.Equal(t, mmap.symbols.seen, stream.symbols.size)
+			count := stream.symbols.size
+
+			// Every in-range ordinal resolves to the same symbol in both readers.
+			for i := range count {
+				mmapSymbol, err := mmap.symbols.Lookup(uint32(i))
+				require.NoError(t, err)
+				streamSymbol, err := stream.symbols.Lookup(uint32(i))
+				require.NoError(t, err)
+				require.Equal(t, mmapSymbol, streamSymbol)
+			}
+
+			// Out-of-range ordinals are rejected identically by both.
+			for _, n := range []uint32{uint32(count), uint32(count) + 1, uint32(count) + 100} {
+				_, mmapErr := mmap.symbols.Lookup(n)
+				_, streamErr := stream.symbols.Lookup(n)
+				require.Error(t, mmapErr)
+				require.Error(t, streamErr)
+				require.Equal(t, mmapErr.Error(), streamErr.Error())
+			}
+		})
+	}
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/querier.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/querier.go
@@ -46,11 +46,6 @@ type IndexReader interface {
 
 	Checksum() uint32
 
-	// Symbols return an iterator over sorted string symbols that may occur in
-	// series' labels and indices. It is not safe to use the returned strings
-	// beyond the lifetime of the index reader.
-	Symbols() index.StringIter
-
 	// LabelValues returns possible label values which may not be sorted.
 	LabelValues(name string, matchers ...*labels.Matcher) ([]string, error)
 


### PR DESCRIPTION
- Remove Symbols() and SymbolTableSize() from Reader interface as it's not actually used
- Implement streamSymbols
- Test that it behaves the same as Symbols in index.go

**What this PR does / why we need it**: Part of our effort to move away from mmap in index gateways. 

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**: This is a reimplementation of index.go's Symbols, so might be useful to compare to that. 

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
