### PR TITLE
chore(storage): Warn when object storage config is blank

### DIFF
--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -451,9 +451,10 @@ func NewObjectClient(name, component string, cfg Config, clientMetrics ClientMet
 		c, err := bucket.NewObjectClient(context.Background(), name, cfg.ObjectStore, component, cfg.Hedging, false, util_log.Logger)
 		if err != nil {
 			// See if the admin has forgotten to set up any config, e.g. because they didn't realize the default changed.
-			var blankConfig bucket.Config
+			var blankConfig bucket.ConfigWithNamedStores
 			blankConfig.RegisterFlags(&flag.FlagSet{}) // Get defaults
-			if reflect.DeepEqual(&cfg.ObjectStore.Config, &blankConfig) {
+			blankConfig.NamedStores.Validate()         // Set `storeType` to empty map.
+			if reflect.DeepEqual(&cfg.ObjectStore, &blankConfig) {
 				return nil, fmt.Errorf("when use_thanos_objstore is true, config must be specified in the object_store section: %w", err)
 			}
 		}

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -447,7 +448,16 @@ func (c *ClientMetrics) Unregister() {
 // NewObjectClient makes a new StorageClient with the prefix in the front.
 func NewObjectClient(name, component string, cfg Config, clientMetrics ClientMetrics) (client.ObjectClient, error) {
 	if cfg.UseThanosObjstore {
-		return bucket.NewObjectClient(context.Background(), name, cfg.ObjectStore, component, cfg.Hedging, false, util_log.Logger)
+		c, err := bucket.NewObjectClient(context.Background(), name, cfg.ObjectStore, component, cfg.Hedging, false, util_log.Logger)
+		if err != nil {
+			// See if the admin has forgotten to set up any config, e.g. because they didn't realize the default changed.
+			var blankConfig bucket.Config
+			blankConfig.RegisterFlags(&flag.FlagSet{}) // Get defaults
+			if reflect.DeepEqual(&cfg.ObjectStore.Config, &blankConfig) {
+				return nil, fmt.Errorf("when use_thanos_objstore is true, config must be specified in the object_store section: %w", err)
+			}
+		}
+		return c, err
 	}
 
 	actual, err := internalNewObjectClient(name, cfg, clientMetrics)


### PR DESCRIPTION
**What this PR does / why we need it**:

To streamline troubleshooting for people who didn't edit their config when [the default changed](https://github.com/grafana/loki/pull/22676) to `use_thanos_objstore: true`.

Example message after this change:
```
% ./logcli query [...]
2026/08/03 16:40:49 Query failed: when use_thanos_objstore is true, config must be specified in the object_store section: create bucket: no s3 endpoint in config file
error creating object client
```

**Which issue(s) this PR fixes**:
Fixes #23729 

**Special notes for your reviewer**:

The error message is still passed on in case we misdiagnose the cause.

Using `reflect.DeepEqual` because the struct has some slices in it which can't be compared via `==`.
The code does look a little untidy to me, but the only neat alternative I found was a `switch` on storage type which would need editing every time we added another storage.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- NA Documentation added
- NA Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- NA Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- NA If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
