### PR TITLE
chore: Run lint in docker [release-3.7.x]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,6 +342,9 @@ LINT_FLAGS=--timeout=15m
 GOFLAGS=""
 endif
 lint: ## run linters
+ifeq ($(BUILD_IN_CONTAINER),true)
+	$(run_in_container)
+else
 	go version
 	golangci-lint version
 	golangci-lint run -v $(LINT_FLAGS)
@@ -358,6 +361,7 @@ lint: ## run linters
 	faillint -paths \
 		"github.com/opentracing/opentracing-go,github.com/opentracing/opentracing-go/log,github.com/uber/jaeger-client-go,github.com/opentracing-contrib/go-stdlib/nethttp" \
 		./...
+endif
 
 ########
 # Test #

--- a/pkg/logql/bench/k6_types.go
+++ b/pkg/logql/bench/k6_types.go
@@ -35,7 +35,7 @@ func ConvertTestCaseToK6(tc TestCase, tenantID int, length time.Duration, buffer
 	if tc.QueryDesc != "" {
 		name = fmt.Sprintf("%s - %s", tc.Source, tc.QueryDesc)
 	}
-	if kind == "log" {
+	if kind == kindLog {
 		name = fmt.Sprintf("%s [%s]", name, directionLabel(tc.Direction))
 	}
 

--- a/pkg/logql/bench/query_registry.go
+++ b/pkg/logql/bench/query_registry.go
@@ -204,12 +204,12 @@ func (r *QueryRegistry) loadFile(filePath string, suite Suite, fileName string) 
 		q.Source = fmt.Sprintf("%s/%s:%d", suite, fileName, lineNum)
 
 		// Default directions to "both" for log queries
-		if q.Directions == "" && q.Kind == "log" {
+		if q.Directions == "" && q.Kind == kindLog {
 			q.Directions = DirectionBoth
 		}
 
-		if q.Kind == "" || (q.Kind != "metric" && q.Kind != "log") {
-			q.Kind = "log"
+		if q.Kind == "" || (q.Kind != kindMetric && q.Kind != kindLog) {
+			q.Kind = kindLog
 		}
 
 		// Validate time range
@@ -325,7 +325,7 @@ func (r *QueryRegistry) ExpandQuery(def QueryDefinition, resolver VariableResolv
 	// Create test cases based on query kind and directions
 	var cases []TestCase
 
-	if def.Kind == "metric" {
+	if def.Kind == kindMetric {
 		// Metric queries only run in forward direction
 		tc := TestCase{
 			Query:     resolvedQuery,

--- a/pkg/logql/bench/testcase.go
+++ b/pkg/logql/bench/testcase.go
@@ -10,6 +10,11 @@ import (
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 )
 
+const (
+	kindLog    = "log"
+	kindMetric = "metric"
+)
+
 // TestCase represents a LogQL test case for benchmarking and testing
 type TestCase struct {
 	Query     string
@@ -53,9 +58,9 @@ func (c TestCase) Kind() string {
 		return "invalid"
 	}
 	if _, ok := expr.(syntax.SampleExpr); ok {
-		return "metric"
+		return kindMetric
 	}
-	return "log"
+	return kindLog
 }
 
 // Description returns a detailed description of the test case including time range


### PR DESCRIPTION
## What

This PR is a manual backport of #21292 to `release-3.7.x`. It wraps the `lint`
Makefile target so it can run inside the build image, and extracts the repeated
`log` and `metric` strings in `pkg/logql/bench` into constants.

## Why

`check / golangciLint` is currently failing for **every** PR raised against
`release-3.7.x`:

    pkg/logql/bench/k6_types.go:38:13: string `log` has 6 occurrences, make it a constant (goconst)
    pkg/logql/bench/testcase.go:56:10: string `metric` has 5 occurrences, make it a constant (goconst)

`.golangci.yml` on this branch sets goconst's `min-occurrences` to 5 and those
strings sit right on the threshold. Main fixed this back in April via #21292,
but it was never backported, so the branch has been one lint run away from red
ever since — #23737 (a single-file docs change) and #23748 are both blocked on
it today.

Doing this by hand rather than through the backport bot because the bot is
currently failing at its `Generate GitHub App Token` step with a 401
("A JSON web token could not be decoded") — see run 30869882470. Worth someone
looking at, since eleven workflows share that app, including the release ones.

## Testing

- `golangci-lint run ./pkg/logql/bench/...` → 0 issues
- `go build ./cmd/loki` passes
- `make -n lint` dispatches correctly with `BUILD_IN_CONTAINER` both true and false
- No CI job invokes `make lint` bare, so the container default is local-only
