### PR TITLE
feat(validation): Add inherit_limits flag to per-policy override limits

### DIFF
--- a/pkg/distributor/ingestion_rate_strategy_test.go
+++ b/pkg/distributor/ingestion_rate_strategy_test.go
@@ -126,6 +126,9 @@ func TestIngestionRateStrategy_PolicyOverride(t *testing.T) {
 			"finance": {IngestionRateMB: ptr(5.0), IngestionBurstSizeMB: ptr(10.0)},
 			"ops":     {IngestionRateMB: ptr(5.0)},                                 // rate set, burst unset -> falls back to tenant burst
 			"blocked": {IngestionRateMB: ptr(5.0), IngestionBurstSizeMB: ptr(0.0)}, // explicit 0 burst must be honored (blocks), not fall back
+			// inherit_limits: unset fields resolve to the tenant values (in their own bucket).
+			"inherit":         {InheritLimits: true},
+			"inherit-partial": {InheritLimits: true, IngestionRateMB: ptr(5.0)}, // explicit rate wins, burst inherits
 		},
 	}
 	overrides, err := validation.NewOverrides(limits, nil)
@@ -152,6 +155,14 @@ func TestIngestionRateStrategy_PolicyOverride(t *testing.T) {
 
 		// policy with an explicit 0 burst -> 0 is honored (blocks ingestion), not the tenant burst.
 		assert.Equal(t, 0, s.Burst(encodeRateLimitKey("123", "blocked")))
+
+		// inherit_limits policy -> tenant rate/burst, applied to the policy's own bucket key.
+		assert.Equal(t, 1.0*float64(bytesInMB), s.Limit(encodeRateLimitKey("123", "inherit")))
+		assert.Equal(t, int(2.0*float64(bytesInMB)), s.Burst(encodeRateLimitKey("123", "inherit")))
+
+		// inherit_limits + explicit rate -> explicit rate wins, burst inherits the tenant burst.
+		assert.Equal(t, 5.0*float64(bytesInMB), s.Limit(encodeRateLimitKey("123", "inherit-partial")))
+		assert.Equal(t, int(2.0*float64(bytesInMB)), s.Burst(encodeRateLimitKey("123", "inherit-partial")))
 	})
 
 	t.Run("global divides policy rate by distributor count", func(t *testing.T) {

--- a/pkg/validation/ingestion_policies.go
+++ b/pkg/validation/ingestion_policies.go
@@ -381,9 +381,11 @@ func (o *PerPolicyConfigOverride) ApplyTo(base shardstreams.Config) shardstreams
 	return base
 }
 
-// PolicyOverridableLimits holds the per-policy overrides for a single policy. Every field is a
-// pointer: a nil field means "not overridden" (the tenant value is inherited); a non-nil field
-// overrides the tenant value for streams resolved to the policy.
+// PolicyOverridableLimits holds the per-policy overrides for a single policy. Every limit field is
+// a pointer: a nil field means "not overridden" (the tenant value is inherited and usage counts
+// against the shared tenant bucket); a non-nil field overrides the tenant value for streams
+// resolved to the policy. InheritLimits changes what a nil field means: the tenant value is still
+// used, but it is reported as overridden, so usage is tracked in a policy-specific bucket.
 type PolicyOverridableLimits struct {
 	MaxLocalStreamsPerUser  *int                     `yaml:"max_streams_per_user" json:"max_streams_per_user" doc:"hidden"`
 	MaxGlobalStreamsPerUser *int                     `yaml:"max_global_streams_per_user" json:"max_global_streams_per_user" doc:"hidden"`
@@ -392,6 +394,13 @@ type PolicyOverridableLimits struct {
 	PerStreamRateLimit      *flagext.ByteSize        `yaml:"per_stream_rate_limit" json:"per_stream_rate_limit" doc:"hidden"`
 	PerStreamRateLimitBurst *flagext.ByteSize        `yaml:"per_stream_rate_limit_burst" json:"per_stream_rate_limit_burst" doc:"hidden"`
 	ShardStreams            *PerPolicyConfigOverride `yaml:"shard_streams" json:"shard_streams" doc:"hidden"`
+
+	// InheritLimits, when true, makes every unset limit field resolve to the tenant-level value
+	// while still reporting overridden=true, so the policy gets the same limits as the tenant but
+	// tracked in its own bucket. Explicitly set fields take precedence. It applies to
+	// max_streams_per_user, max_global_streams_per_user, ingestion_rate_mb,
+	// ingestion_burst_size_mb, per_stream_rate_limit and per_stream_rate_limit_burst.
+	InheritLimits bool `yaml:"inherit_limits" json:"inherit_limits" doc:"hidden"`
 }
 
 // Validate checks that the overridden values are non-negative. Returned errors are field-scoped;
@@ -411,7 +420,8 @@ func (p PolicyOverridableLimits) Validate() error {
 
 // IngestionPolicyOverrideLimits exposes the per-policy limit overrides. Each scalar accessor
 // returns (value, overridden) where overridden reports whether the policy explicitly set that
-// limit; when false the caller should fall back to the tenant-level limit.
+// limit (or inherits it via inherit_limits, in which case the tenant value is returned); when
+// false the caller should fall back to the tenant-level limit.
 type IngestionPolicyOverrideLimits interface {
 	PolicyMaxLocalStreamsPerUser(userID, policy string) (int, bool)
 	PolicyMaxGlobalStreamsPerUser(userID, policy string) (int, bool)
@@ -432,22 +442,43 @@ func (o *Overrides) policyOverride(userID, policy string) (PolicyOverridableLimi
 }
 
 func (o *Overrides) PolicyMaxLocalStreamsPerUser(userID, policy string) (int, bool) {
-	if pl, ok := o.policyOverride(userID, policy); ok && pl.MaxLocalStreamsPerUser != nil {
+	pl, ok := o.policyOverride(userID, policy)
+	if !ok {
+		return 0, false
+	}
+	if pl.MaxLocalStreamsPerUser != nil {
 		return *pl.MaxLocalStreamsPerUser, true
+	}
+	if pl.InheritLimits {
+		return o.MaxLocalStreamsPerUser(userID), true
 	}
 	return 0, false
 }
 
 func (o *Overrides) PolicyMaxGlobalStreamsPerUser(userID, policy string) (int, bool) {
-	if pl, ok := o.policyOverride(userID, policy); ok && pl.MaxGlobalStreamsPerUser != nil {
+	pl, ok := o.policyOverride(userID, policy)
+	if !ok {
+		return 0, false
+	}
+	if pl.MaxGlobalStreamsPerUser != nil {
 		return *pl.MaxGlobalStreamsPerUser, true
+	}
+	if pl.InheritLimits {
+		return o.MaxGlobalStreamsPerUser(userID), true
 	}
 	return 0, false
 }
 
 func (o *Overrides) PolicyIngestionRateBytes(userID, policy string) (float64, bool) {
-	if pl, ok := o.policyOverride(userID, policy); ok && pl.IngestionRateMB != nil {
+	pl, ok := o.policyOverride(userID, policy)
+	if !ok {
+		return 0, false
+	}
+	if pl.IngestionRateMB != nil {
 		return *pl.IngestionRateMB * bytesInMB, true
+	}
+	if pl.InheritLimits {
+		return o.IngestionRateBytes(userID), true
 	}
 	return 0, false
 }
@@ -456,17 +487,34 @@ func (o *Overrides) PolicyIngestionRateBytes(userID, policy string) (float64, bo
 // overridden. overridden is true whenever the policy explicitly sets the burst, including an
 // explicit 0 (which blocks ingestion); callers must gate on the bool, not on a non-zero value.
 func (o *Overrides) PolicyIngestionBurstSizeBytes(userID, policy string) (int, bool) {
-	if pl, ok := o.policyOverride(userID, policy); ok && pl.IngestionBurstSizeMB != nil {
+	pl, ok := o.policyOverride(userID, policy)
+	if !ok {
+		return 0, false
+	}
+	if pl.IngestionBurstSizeMB != nil {
 		return int(*pl.IngestionBurstSizeMB * bytesInMB), true
+	}
+	if pl.InheritLimits {
+		return o.IngestionBurstSizeBytes(userID), true
 	}
 	return 0, false
 }
 
-// PolicyPerStreamRateLimit is overridden iff either the rate or the burst is set; the unset half
-// inherits the tenant per-stream limit so the returned RateLimit is always complete.
+// PolicyPerStreamRateLimit returns the per-policy per-stream rate limit and whether the policy
+// overrides it. When the policy sets only one of the rate/burst pair, the unset half falls back
+// to the tenant's per-stream value — mirroring tenant overrides, where a tenant that sets only
+// the rate keeps the default burst (Limits.UnmarshalYAML overlays the tenant YAML on the
+// defaults). When neither is set, the limit is overridden only with inherit_limits: true, which
+// returns the tenant's per-stream rate limit unchanged.
 func (o *Overrides) PolicyPerStreamRateLimit(userID, policy string) (RateLimit, bool) {
 	pl, ok := o.policyOverride(userID, policy)
-	if !ok || (pl.PerStreamRateLimit == nil && pl.PerStreamRateLimitBurst == nil) {
+	if !ok {
+		return RateLimit{}, false
+	}
+	if pl.PerStreamRateLimit == nil && pl.PerStreamRateLimitBurst == nil {
+		if pl.InheritLimits {
+			return o.PerStreamRateLimit(userID), true
+		}
 		return RateLimit{}, false
 	}
 	rl := o.PerStreamRateLimit(userID)

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -739,6 +739,91 @@ func TestLimits_PolicyRateOverrides(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestLimits_PolicyInheritLimits(t *testing.T) {
+	limits := &Limits{
+		IngestionRateMB:         5,
+		IngestionBurstSizeMB:    10,
+		MaxLocalStreamsPerUser:  100,
+		MaxGlobalStreamsPerUser: 1000,
+		PerStreamRateLimit:      flagext.ByteSize(9 * 1024 * 1024),
+		PerStreamRateLimitBurst: flagext.ByteSize(11 * 1024 * 1024),
+		PolicyOverrideLimits: map[string]PolicyOverridableLimits{
+			// Inherit everything: same values as the tenant, but reported as overridden so usage
+			// is tracked in a policy-specific bucket.
+			"inherit-all": {InheritLimits: true},
+			// Explicit fields win; the rest inherit the tenant value (still overridden).
+			"inherit-partial": {InheritLimits: true, IngestionRateMB: ptr(2.0), MaxLocalStreamsPerUser: ptr(7)},
+		},
+	}
+
+	overrides := &Overrides{defaultLimits: limits, tenantLimits: nil}
+
+	// inherit-all: every accessor returns the tenant value with overridden=true.
+	rateBytes, ok := overrides.PolicyIngestionRateBytes("tenant1", "inherit-all")
+	require.True(t, ok)
+	require.Equal(t, float64(5*bytesInMB), rateBytes)
+	burstBytes, ok := overrides.PolicyIngestionBurstSizeBytes("tenant1", "inherit-all")
+	require.True(t, ok)
+	require.Equal(t, 10*bytesInMB, burstBytes)
+	v, ok := overrides.PolicyMaxLocalStreamsPerUser("tenant1", "inherit-all")
+	require.True(t, ok)
+	require.Equal(t, 100, v)
+	v, ok = overrides.PolicyMaxGlobalStreamsPerUser("tenant1", "inherit-all")
+	require.True(t, ok)
+	require.Equal(t, 1000, v)
+	psrl, ok := overrides.PolicyPerStreamRateLimit("tenant1", "inherit-all")
+	require.True(t, ok)
+	require.Equal(t, RateLimit{Limit: rate.Limit(9 * 1024 * 1024), Burst: 11 * 1024 * 1024}, psrl)
+
+	// inherit-partial: explicit fields win, the rest inherit with overridden=true.
+	rateBytes, ok = overrides.PolicyIngestionRateBytes("tenant1", "inherit-partial")
+	require.True(t, ok)
+	require.Equal(t, float64(2*bytesInMB), rateBytes)
+	v, ok = overrides.PolicyMaxLocalStreamsPerUser("tenant1", "inherit-partial")
+	require.True(t, ok)
+	require.Equal(t, 7, v)
+	burstBytes, ok = overrides.PolicyIngestionBurstSizeBytes("tenant1", "inherit-partial")
+	require.True(t, ok)
+	require.Equal(t, 10*bytesInMB, burstBytes)
+	v, ok = overrides.PolicyMaxGlobalStreamsPerUser("tenant1", "inherit-partial")
+	require.True(t, ok)
+	require.Equal(t, 1000, v)
+
+	// Other policies and tenants without an entry are unaffected.
+	_, ok = overrides.PolicyIngestionRateBytes("tenant1", "other")
+	require.False(t, ok)
+	_, ok = overrides.PolicyIngestionRateBytes("tenant1", "")
+	require.False(t, ok)
+}
+
+func TestLimits_PolicyInheritLimitsYAML(t *testing.T) {
+	var limits Limits
+	yamlConfig := `
+ingestion_rate_mb: 5
+max_global_streams_per_user: 1000
+policy_override_limits:
+  finance:
+    inherit_limits: true
+  ops:
+    inherit_limits: true
+    ingestion_rate_mb: 2
+`
+	require.NoError(t, yaml.Unmarshal([]byte(yamlConfig), &limits))
+
+	overrides := &Overrides{defaultLimits: &limits, tenantLimits: nil}
+
+	rateBytes, ok := overrides.PolicyIngestionRateBytes("tenant1", "finance")
+	require.True(t, ok)
+	require.Equal(t, float64(5*bytesInMB), rateBytes)
+	v, ok := overrides.PolicyMaxGlobalStreamsPerUser("tenant1", "finance")
+	require.True(t, ok)
+	require.Equal(t, 1000, v)
+
+	rateBytes, ok = overrides.PolicyIngestionRateBytes("tenant1", "ops")
+	require.True(t, ok)
+	require.Equal(t, float64(2*bytesInMB), rateBytes)
+}
+
 func TestPolicyShardStreams(t *testing.T) {
 	timeOn := true
 	desired := flagext.ByteSize(512 * 1024)


### PR DESCRIPTION
## What this PR does / why we need it

Adds an `inherit_limits` flag to `policy_override_limits`. When enabled, unset override fields resolve to the tenant-level values while still reporting `overridden=true`, so the policy gets the same limits as the tenant but tracked in its own bucket (separate distributor rate bucket and stream-count allowance). Explicitly set fields take precedence.

```yaml
policy_override_limits:
  finance:
    inherit_limits: true
```

E.g. a tenant with a 5MB/s rate limit and 100-stream limit: the `finance` policy gets its own independent 5MB/s bucket and its own 100-stream allowance.

Applies to `max_streams_per_user`, `max_global_streams_per_user`, `ingestion_rate_mb`, `ingestion_burst_size_mb`, `per_stream_rate_limit` and `per_stream_rate_limit_burst`. No enforcement-site changes needed — the `overridden` bool already drives per-policy bucketing in the distributor, ingester and ingest-limits service.

## Checklist
- [x] Tests updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)