### PR TITLE
test(ruler): Fix flaky TestMemstoreBlocks

### DIFF
--- a/pkg/ruler/memstore_test.go
+++ b/pkg/ruler/memstore_test.go
@@ -176,11 +176,12 @@ func TestMemstoreBlocks(t *testing.T) {
 	})
 
 	store := testStore(fn)
+	t.Cleanup(store.Stop)
 
 	done := make(chan struct{})
 	go func() {
 		_, _ = store.Querier(0, 1)
-		done <- struct{}{}
+		close(done)
 	}()
 
 	select {

--- a/pkg/ruler/memstore_test.go
+++ b/pkg/ruler/memstore_test.go
@@ -186,13 +186,13 @@ func TestMemstoreBlocks(t *testing.T) {
 	select {
 	case <-time.After(time.Millisecond):
 	case <-done:
-		t.FailNow()
+		t.Fatal("Querier returned before Start was called")
 	}
 
 	store.Start(MockRuleIter(ars))
 	select {
 	case <-done:
-	case <-time.After(time.Millisecond):
-		t.FailNow()
+	case <-time.After(time.Second):
+		t.Fatal("Querier did not return after Start was called")
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR de-flakes `TestMemstoreBlocks` in `pkg/ruler`, which has been failing release CI —
it took out the 3.6.14 release PR
([#23685](https://github.com/grafana/loki/pull/23685),
[failed run](https://github.com/grafana/loki/actions/runs/30885017388/job/92167894808)) and
only went green on a re-run.

`MemStore.Querier` blocks on the `initiated` channel until `Start` closes it. The test
asserted that a waiting goroutine had returned within **1ms** of that close. Measured over
3000 runs under 2x CPU oversubscription, that wake-up takes 7.8us at p50 but **3.6ms at p99,
topping out at 6.4ms** — so the 1ms budget was sitting well inside the goroutine scheduling
noise, and the test fell over whenever CI got busy. Every observed failure was that second
assertion; the first cannot fire spuriously, since the channel is only closed in `Start`.

The post-`Start` timeout is increased to 1s. A closed channel is a broadcast with no lost-wakeup
mode, so a genuine failure to unblock still fails the test.
1s is selected as the happy medium: 1ms
is too short, and no timeout at all leaves a real hang to `go test`'s default 10m to catch,
losing a meaningful error message.

A second commit clears up a goroutine leak that turned up while poking at this. `Start`
kicks off `run()`, which the test never shut down, so every iteration stranded a goroutine
for the life of the test binary — a probe around 200 iterations measured 200 goroutines left
standing, and none once `Stop` is called. The unbuffered `done <- struct{}{}` was the same
story on the failure paths, where a `t.Fatal` returning before the receive left the waiter
parked with nobody coming.

Note this was never fixed on `main`: [#20178](https://github.com/grafana/loki/pull/20178)
bumped the sibling `TestMemStoreStopBeforeStart` from 1ms to 100ms and left this one alone.
`main`, `release-3.6.x` and `release-3.7.x` all carry byte-identical flaky code, hence the
backport labels.

**Which issue(s) this PR fixes**:

N/A — flaky test, no tracking issue.

**Special notes for your reviewer**:

Verified by reproducing the flake and then re-running the same experiment against the fix:

- Repro: 64 busy loops on a 32-core box, ~17% failure rate over thousands of runs. Both
  `select`s were instrumented separately to confirm 100% of failures were the post-`Start`
  one.
- After the fix: 0 failures in 5000 runs under identical load.
- Leak: measured 200 stranded goroutines over 200 iterations before, 0 after.
- `pkg/ruler` passes clean and under `-race`.

Test-only change, no production code touched.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
