### PR TITLE
test(logql): Add logqltest coverage for bytes and duration conversions

### DIFF
--- a/pkg/logql/internal/logqltest/testdata/conversions.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/conversions.logqltest
@@ -11,6 +11,9 @@ load
   {unit="frac"}  "b=1.5B"  @ 10s [repeat every 10s for 18]
   {unit="noise"} "noise"   @ 10s [repeat every 10s for 18]
 
+# The noise line has no `b`, so `unwrap` drops it: no sample, no `__error__`, so it
+# never appears in the output. A value that is present but unconvertible is
+# different: it sets `__error__` and fails the query (see "bytes() parse failure").
 eval instant at 120s max_over_time({unit=~".+"} | logfmt | unwrap bytes(b) [1m]) by (unit)
   {unit="kb"}    1000
   {unit="kib"}   1024

--- a/pkg/logql/internal/logqltest/testdata/conversions.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/conversions.logqltest
@@ -1,0 +1,99 @@
+# bytes()
+clear
+load
+  {unit="kb"}    "b=1KB"   @ 10s [repeat every 10s for 18]
+  {unit="kib"}   "b=1KiB"  @ 10s [repeat every 10s for 18]
+  {unit="mb"}    "b=1MB"   @ 10s [repeat every 10s for 18]
+  {unit="dec"}   "b=1.5KB" @ 10s [repeat every 10s for 18]
+  {unit="bare"}  "b=1024"  @ 10s [repeat every 10s for 18]
+  {unit="mixed"} "b=2Kb"   @ 10s [repeat every 10s for 18]
+  {unit="comma"} "b=2,048" @ 10s [repeat every 10s for 18]
+  {unit="frac"}  "b=1.5B"  @ 10s [repeat every 10s for 18]
+  {unit="noise"} "noise"   @ 10s [repeat every 10s for 18]
+
+eval instant at 120s max_over_time({unit=~".+"} | logfmt | unwrap bytes(b) [1m]) by (unit)
+  {unit="kb"}    1000
+  {unit="kib"}   1024
+  {unit="mb"}    1000000
+  {unit="dec"}   1500
+  {unit="bare"}  1024
+  {unit="mixed"} 2000
+  {unit="comma"} 2048
+  {unit="frac"}  1
+eval range from 60s to 180s step 60s max_over_time({unit=~".+"} | logfmt | unwrap bytes(b) [30s]) by (unit)
+  {unit="kb"}    1000 1000 1000
+  {unit="kib"}   1024 1024 1024
+  {unit="mb"}    1000000 1000000 1000000
+  {unit="dec"}   1500 1500 1500
+  {unit="bare"}  1024 1024 1024
+  {unit="mixed"} 2000 2000 2000
+  {unit="comma"} 2048 2048 2048
+  {unit="frac"}  1 1 1
+
+# bytes() parse failure.
+clear
+load
+  {unit="bad"} "b=1XB" @ 10s [repeat every 10s for 6]
+
+eval instant at 60s max_over_time({unit=~".+"} | logfmt | unwrap bytes(b) [1m]) by (unit)
+  expect fail
+eval instant at 60s max_over_time({unit=~".+"} | logfmt | unwrap bytes(b) | __error__="" [1m]) by (unit)
+  expect empty
+
+# duration() / duration_seconds(): both route to the same conversion and return
+# seconds, so they yield identical values on identical input.
+clear
+load
+  {unit="s"}     "d=2s"    @ 10s [repeat every 10s for 18]
+  {unit="ms"}    "d=500ms" @ 10s [repeat every 10s for 18]
+  {unit="m"}     "d=1m"    @ 10s [repeat every 10s for 18]
+  {unit="hm"}    "d=1h30m" @ 10s [repeat every 10s for 18]
+  {unit="fh"}    "d=1.5h"  @ 10s [repeat every 10s for 18]
+  {unit="neg"}   "d=-5s"   @ 10s [repeat every 10s for 18]
+  {unit="noise"} "noise"   @ 10s [repeat every 10s for 18]
+
+eval instant at 120s max_over_time({unit=~".+"} | logfmt | unwrap duration(d) [1m]) by (unit)
+  {unit="s"}   2
+  {unit="ms"}  0.5
+  {unit="m"}   60
+  {unit="hm"}  5400
+  {unit="fh"}  5400
+  {unit="neg"} -5
+# duration_seconds() is identical to duration().
+eval instant at 120s max_over_time({unit=~".+"} | logfmt | unwrap duration_seconds(d) [1m]) by (unit)
+  {unit="s"}   2
+  {unit="ms"}  0.5
+  {unit="m"}   60
+  {unit="hm"}  5400
+  {unit="fh"}  5400
+  {unit="neg"} -5
+
+eval range from 60s to 120s step 30s max_over_time({unit=~".+"} | logfmt | unwrap duration(d) [1m]) by (unit)
+  {unit="s"}   2 2 2
+  {unit="ms"}  0.5 0.5 0.5
+  {unit="m"}   60 60 60
+  {unit="hm"}  5400 5400 5400
+  {unit="fh"}  5400 5400 5400
+  {unit="neg"} -5 -5 -5
+eval range from 60s to 120s step 30s max_over_time({unit=~".+"} | logfmt | unwrap duration_seconds(d) [1m]) by (unit)
+  {unit="s"}   2 2 2
+  {unit="ms"}  0.5 0.5 0.5
+  {unit="m"}   60 60 60
+  {unit="hm"}  5400 5400 5400
+  {unit="fh"}  5400 5400 5400
+  {unit="neg"} -5 -5 -5
+
+# duration() parse failure.
+clear
+load
+  {unit="bad"} "d=1d" @ 10s [repeat every 10s for 6]
+
+eval instant at 60s max_over_time({unit=~".+"} | logfmt | unwrap duration(d) [1m]) by (unit)
+  expect fail
+eval instant at 60s max_over_time({unit=~".+"} | logfmt | unwrap duration_seconds(d) [1m]) by (unit)
+  expect fail
+
+eval instant at 60s max_over_time({unit=~".+"} | logfmt | unwrap duration(d) | __error__="" [1m]) by (unit)
+  expect empty
+eval instant at 60s max_over_time({unit=~".+"} | logfmt | unwrap duration_seconds(d) | __error__="" [1m]) by (unit)
+  expect empty

--- a/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
@@ -346,22 +346,6 @@ eval instant at 120s stdvar_over_time({app="a"} | logfmt | unwrap v [1m])
 eval range from 60s to 120s step 60s stdvar_over_time({app="a"} | logfmt | unwrap v [1m])
   {app="a"} 9 9
 
-# unwrap conversions: duration() and bytes().
-clear
-load
-  {app="a"} "d=2s"  @ 70s [repeat every 10s for 6]
-  {app="a"} "b=1KB" @ 70s [repeat every 10s for 6]
-  {app="noise"} "noise" @ 70s [repeat every 10s for 6]
-
-eval instant at 120s sum_over_time({app="a"} | logfmt | unwrap duration(d) [1m])
-  {app="a"} 12
-eval range from 90s to 120s step 30s sum_over_time({app="a"} | logfmt | unwrap duration(d) [1m])
-  {app="a"} 6 12
-eval instant at 120s sum_over_time({app="a"} | logfmt | unwrap bytes(b) [1m])
-  {app="a"} 6000
-eval range from 90s to 120s step 30s sum_over_time({app="a"} | logfmt | unwrap bytes(b) [1m])
-  {app="a"} 3000 6000
-
 # rate_counter treats the unwrapped value as a counter: the per-second increase over the range with
 # counter resets added back, using Prometheus-style boundary extrapolation.
 #


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds declarative `logqltest` coverage for the LogQL unwrap conversions, continuing the effort to build a readable correctness corpus for the LogQL engine.

`conversions.logqltest` covers `bytes()`, `duration()`, and `duration_seconds()`: many unit forms (KB/KiB/MB, decimal, bare, comma-grouped, fractional; ms/s/m/h, `1h30m`, negative), all three window shapes, and the `__error__` parse-failure cases (with the `| __error__=""` drop).

It also removes the older "unwrap conversions" scenario from `range_aggregations.logqltest`, now redundant: the conversion result is independent of the range aggregation that consumes it, and both the conversions and `sum_over_time` are covered on their own.

**Special notes for your reviewer**:

The harness runs metric queries only, so each conversion is observed through `max_over_time` values.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.
