### PR TITLE
chore: Implement streaming reading of postings offset table

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1434,31 +1434,6 @@ type nopCloserReadSeeker struct{ io.ReadSeeker }
 
 func (nopCloserReadSeeker) Close() error { return nil }
 
-// Range marks a byte range.
-type Range struct {
-	Start, End int64
-}
-
-// PostingsRanges returns a new map of byte range in the underlying index file
-// for all postings lists.
-func (r *ByteSliceReader) PostingsRanges() (map[labels.Label]Range, error) {
-	m := map[labels.Label]Range{}
-	if err := ReadOffsetTable(r.b, r.toc.PostingsTable, func(name, value []byte, off uint64, _ int) error {
-		d := encoding.DecWrap(tsdb_enc.NewDecbufAt(r.b, int(off), castagnoliTable))
-		if d.Err() != nil {
-			return d.Err()
-		}
-		m[labels.Label{Name: string(name), Value: string(value)}] = Range{
-			Start: int64(off) + 4,
-			End:   int64(off) + 4 + int64(d.Len()),
-		}
-		return nil
-	}); err != nil {
-		return nil, errors.Wrap(err, "read postings table")
-	}
-	return m, nil
-}
-
 type Symbols struct {
 	bs  ByteSlice
 	off int

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/reader.go
@@ -17,10 +17,6 @@ type Reader interface {
 	// The caller owns the returned reader and must Close it.
 	RawFileReader() (io.ReadSeekCloser, error)
 
-	// PostingsRanges returns the byte range in the underlying index file for
-	// every posting list.
-	PostingsRanges() (map[labels.Label]Range, error)
-
 	// Bounds returns the min/max time range covered by the index.
 	Bounds() (int64, int64)
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
@@ -1,0 +1,239 @@
+package index
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc"
+)
+
+// streamPostings is StreamReader's equivalent of ByteSliceReader's postings.
+//
+// It is used to read the postings-offset table of an index.
+// On creation it builds a sparse offset table keeping every label name but only
+// every symbolFactor-th value (plus the first and last per name).
+// A postings lookup then binary-searches the sparse table and walks forward
+// from there through the offset table to the target value(s).
+type streamPostings struct {
+	factory *streamenc.FilePoolDecbufFactory
+	// off is the absolute file offset of the postings offset table.
+	off int
+	// postings maps a label name to its retained sparse postings offset table entries.
+	postings map[string][]streamPostingOffset
+}
+
+type streamPostingOffset struct {
+	labelValue string
+	offset     int // relative offset of this entry within the postings offset table
+}
+
+// newStreamPostings scans the postings-offset table once, validating its CRC
+// and capturing the sparse offset table.
+func newStreamPostings(ctx context.Context, factory *streamenc.FilePoolDecbufFactory, off int) (*streamPostings, error) {
+	p := &streamPostings{
+		factory:  factory,
+		off:      off,
+		postings: map[string][]streamPostingOffset{},
+	}
+	if err := p.build(ctx); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func (p *streamPostings) build(ctx context.Context) error {
+	var (
+		lastName, lastValue string
+		haveLast            bool
+		lastOff             int
+		valueCount          int
+	)
+	err := streamPostingsOffsetTable(ctx, p.factory, p.off, func(labelName, labelValue string, _ uint64, entryOffset int) error {
+		if _, ok := p.postings[labelName]; !ok {
+			// New label name
+			p.postings[labelName] = []streamPostingOffset{}
+			if haveLast {
+				// Always include the last value for the previous label name
+				p.postings[lastName] = append(p.postings[lastName], streamPostingOffset{labelValue: lastValue, offset: lastOff})
+			}
+			valueCount = 0
+		}
+		if valueCount%symbolFactor == 0 {
+			p.postings[labelName] = append(p.postings[labelName], streamPostingOffset{labelValue: labelValue, offset: entryOffset})
+			haveLast = false
+		} else {
+			lastName, lastValue, lastOff = labelName, labelValue, entryOffset
+			haveLast = true
+		}
+		valueCount++
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if haveLast {
+		p.postings[lastName] = append(p.postings[lastName], streamPostingOffset{labelValue: lastValue, offset: lastOff})
+	}
+	// Trim any extra space in the slices
+	for k, v := range p.postings {
+		trimmedSlice := make([]streamPostingOffset, len(v))
+		copy(trimmedSlice, v)
+		p.postings[k] = trimmedSlice
+	}
+	return nil
+}
+
+// postingsFor returns a merged postings iterator over the series matching the
+// given label name and values.
+// It mirrors ByteSliceReader.Postings.
+// Values must be provided in ascending order.
+func (p *streamPostings) postingsFor(labelName string, labelValues ...string) (Postings, error) {
+	ctx := context.Background()
+
+	if len(labelValues) == 0 {
+		return EmptyPostings(), nil
+	}
+
+	offsets, ok := p.postings[labelName]
+	if !ok {
+		return EmptyPostings(), nil
+	}
+
+	results := make([]Postings, 0, len(labelValues))
+	skip := 0
+	valueIndex := 0
+	for valueIndex < len(labelValues) && labelValues[valueIndex] < offsets[0].labelValue {
+		// Discard values before the start
+		valueIndex++
+	}
+	for valueIndex < len(labelValues) {
+		targetLabelValue := labelValues[valueIndex]
+
+		i := sort.Search(len(offsets), func(i int) bool { return offsets[i].labelValue >= targetLabelValue })
+		if i == len(offsets) {
+			// We're past the end
+			break
+		}
+		if i > 0 && offsets[i].labelValue != targetLabelValue {
+			// Need to look from the previous entry
+			i--
+		}
+
+		// Unchecked because we already checked CRC32 at startup
+		decbuf := p.factory.NewDecbufAtUnchecked(ctx, p.off)
+		if err := decbuf.Err(); err != nil {
+			return nil, err
+		}
+		decbuf.ResetAt(offsets[i].offset)
+
+		// Iterate the offset table entries from the sparse position forward
+		for decbuf.Err() == nil {
+			if skip == 0 {
+				// These are always the same number of bytes,
+				// and it's faster to skip than parse.
+				skip = decbuf.Len()
+				decbuf.Uvarint()          // Key count
+				decbuf.SkipUvarintBytes() // Label name
+				skip -= decbuf.Len()
+			} else {
+				decbuf.Skip(skip)
+			}
+			currentLabelValue := decbuf.UvarintStr() // Label value
+			postingsOffset := decbuf.Uvarint64()     // Absolute file offset to postings entry
+			if err := decbuf.Err(); err != nil {
+				_ = decbuf.Close()
+				return nil, err
+			}
+			for currentLabelValue >= targetLabelValue {
+				if currentLabelValue == targetLabelValue {
+					postings, err := p.readPostingsList(postingsOffset)
+					if err != nil {
+						_ = decbuf.Close()
+						return nil, fmt.Errorf("decode postings: %w", err)
+					}
+					results = append(results, postings)
+				}
+				valueIndex++
+				if valueIndex == len(labelValues) {
+					break
+				}
+				targetLabelValue = labelValues[valueIndex]
+			}
+			if i+1 == len(offsets) || targetLabelValue >= offsets[i+1].labelValue || valueIndex == len(labelValues) {
+				// Need to go to a later sparse entry, if there is one
+				break
+			}
+		}
+		if err := decbuf.Err(); err != nil {
+			_ = decbuf.Close()
+			return nil, fmt.Errorf("get postings offset entry: %w", err)
+		}
+		_ = decbuf.Close()
+	}
+
+	return Merge(results...), nil
+}
+
+// readPostingsList reads the postings list stored at absolute file offset
+// postingsOffset into memory and wraps it in a BigEndianPostings.
+// On disk, the list is a 4-byte big-endian count N followed by N contiguous
+// 4-byte big-endian series refs (then the section CRC, which NewDecbufAtChecked
+// validates while opening).
+func (p *streamPostings) readPostingsList(postingsOffset uint64) (Postings, error) {
+	decbuf := p.factory.NewDecbufAtChecked(context.Background(), int(postingsOffset), castagnoliTable)
+	if err := decbuf.Err(); err != nil {
+		return nil, err
+	}
+	defer func() { _ = decbuf.Close() }()
+
+	n := decbuf.Be32int()
+	if err := decbuf.Err(); err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, 4*n)
+	decbuf.ReadInto(buf)
+	if err := decbuf.Err(); err != nil {
+		return nil, err
+	}
+	return NewBigEndianPostings(buf), nil
+}
+
+// streamPostingsOffsetTable iterates the postings-offset table, running
+// perEntryFn against each entry in the table.
+// It is the streaming equivalent of ReadOffsetTable.
+func streamPostingsOffsetTable(
+	ctx context.Context,
+	factory *streamenc.FilePoolDecbufFactory,
+	postingsOffsetTableOffset int,
+	perEntryFn func(
+		labelName, labelValue string,
+		postingsOffset uint64, // Absolute file offset
+		entryOffset int, // Relative offset of this entry within the postings offset table
+	) error,
+) error {
+	decbuf := factory.NewDecbufAtChecked(ctx, postingsOffsetTableOffset, castagnoliTable)
+	if err := decbuf.Err(); err != nil {
+		return err
+	}
+	defer func() { _ = decbuf.Close() }()
+
+	size := decbuf.Be32()
+	for i := uint32(0); decbuf.Err() == nil && i < size; i++ {
+		entryOffset := decbuf.Offset()
+		if keyCount := decbuf.Uvarint(); keyCount != 2 {
+			return fmt.Errorf("unexpected number of keys for postings offset table %d", keyCount)
+		}
+		labelName := decbuf.UvarintStr()
+		labelValue := decbuf.UvarintStr()
+		postingsOffset := decbuf.Uvarint64()
+		if err := decbuf.Err(); err != nil {
+			return err
+		}
+		if err := perEntryFn(labelName, labelValue, postingsOffset, entryOffset); err != nil {
+			return err
+		}
+	}
+	return decbuf.Err()
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings_test.go
@@ -1,0 +1,265 @@
+package index
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// drainPostings iterates a Postings to completion and returns the refs.
+func drainPostings(t *testing.T, p Postings) []storage.SeriesRef {
+	t.Helper()
+	var refs []storage.SeriesRef
+	for p.Next() {
+		refs = append(refs, p.At())
+	}
+	require.NoError(t, p.Err())
+	return refs
+}
+
+// mustPostings runs Reader.Postings and asserts that doing so doesn't return an error.
+func mustPostings(t *testing.T, r Reader, name string, values ...string) Postings {
+	t.Helper()
+	p, err := r.Postings(name, nil, values...)
+	require.NoError(t, err)
+	return p
+}
+
+func mustPostingsAndDrain(t *testing.T, r Reader, name string, values ...string) []storage.SeriesRef {
+	t.Helper()
+	return drainPostings(t, mustPostings(t, r, name, values...))
+}
+
+// TestStreamPostings_MatchesMmap cross-checks the streaming Postings
+// implementation against the mmap reader on a fixture with many values per
+// label name, so the sparse postings-offset table (every symbolFactor-th
+// value) has multiple entries and both the single-value and multi-value query
+// paths walk forward within and across sparse blocks.
+func TestStreamPostings_MatchesMmap(t *testing.T) {
+	for _, format := range []int{FormatV3, FormatV4} {
+		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
+			fn := writeManySymbolsFixture(t, format)
+
+			mmap, err := NewMmapFileReader(fn)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, mmap.Close()) })
+
+			stream, err := NewStreamFileReader(fn)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, stream.Close()) })
+
+			// LabelValues returns the values in ascending order, which is the
+			// order Postings requires. The fixture uses a single "id" label.
+			values, err := mmap.LabelValues("id")
+			require.NoError(t, err)
+			require.Greater(t, len(values), symbolFactor)
+
+			// Single-value queries across every value exercise every sparse
+			// block and the forward walk within a block.
+			for _, v := range values {
+				require.Equal(t,
+					mustPostingsAndDrain(t, mmap, "id", v),
+					mustPostingsAndDrain(t, stream, "id", v),
+				)
+			}
+
+			// A multi-value query with every value at once exercises walking
+			// across sparse blocks in a single call.
+			require.Equal(t,
+				mustPostingsAndDrain(t, mmap, "id", values...),
+				mustPostingsAndDrain(t, stream, "id", values...),
+			)
+
+			// A scattered subset (every 5th value) exercises seeking between
+			// non-adjacent sparse entries.
+			var subset []string
+			for i := 0; i < len(values); i += 5 {
+				subset = append(subset, values[i])
+			}
+			require.Equal(t,
+				mustPostingsAndDrain(t, mmap, "id", subset...),
+				mustPostingsAndDrain(t, stream, "id", subset...),
+			)
+
+			// Unknown label name yields empty postings in both readers.
+			require.Empty(t, drainPostings(t, mustPostings(t, stream, "does-not-exist", "x")))
+			require.Equal(t,
+				mustPostingsAndDrain(t, mmap, "does-not-exist", "x"),
+				mustPostingsAndDrain(t, stream, "does-not-exist", "x"),
+			)
+
+			// Values outside the range of stored values (before the first and
+			// after the last) match mmap — both should be empty.
+			for _, v := range []string{"\x00", "zzzzzzzz"} {
+				require.Equal(t,
+					mustPostingsAndDrain(t, mmap, "id", v),
+					mustPostingsAndDrain(t, stream, "id", v),
+				)
+			}
+
+			// No values requested yields empty postings in both readers.
+			require.Equal(t,
+				mustPostingsAndDrain(t, mmap, "id"),
+				mustPostingsAndDrain(t, stream, "id"),
+			)
+		})
+	}
+}
+
+// writeSharedLabelFixture builds an index where a single label pair
+// ("shared"="all") is attached to a large, gapped subset of the series, so its
+// postings list holds many refs with gaps between them — enough to span
+// several read buffers and exercise the streaming Seek's binary search.
+func writeSharedLabelFixture(t *testing.T, format int) string {
+	t.Helper()
+	dir := t.TempDir()
+	fileName := filepath.Join(dir, IndexFilename)
+
+	creator, err := NewWriter(context.Background(), format, fileName)
+	require.NoError(t, err)
+
+	const numSeries = 4000
+
+	type entry struct {
+		ls labels.Labels
+	}
+	symbolSet := map[string]struct{}{"id": {}, "shared": {}, "all": {}}
+	entries := make([]entry, 0, numSeries)
+	for j := range numSeries {
+		id := fmt.Sprintf("v%05d", j)
+		symbolSet[id] = struct{}{}
+		// Attach "shared"="all" to ~2/3 of the series so its postings list is
+		// large but leaves gaps in the ref sequence.
+		if j%3 == 0 {
+			entries = append(entries, entry{ls: labels.FromStrings("id", id)})
+		} else {
+			entries = append(entries, entry{ls: labels.FromStrings("id", id, "shared", "all")})
+		}
+	}
+
+	symbols := make([]string, 0, len(symbolSet))
+	for s := range symbolSet {
+		symbols = append(symbols, s)
+	}
+	sort.Strings(symbols)
+	for _, s := range symbols {
+		require.NoError(t, creator.AddSymbol(s))
+	}
+
+	// AddSeries requires ascending fingerprint order.
+	sort.Slice(entries, func(i, j int) bool {
+		return labels.StableHash(entries[i].ls) < labels.StableHash(entries[j].ls)
+	})
+	for i, e := range entries {
+		require.NoError(t, creator.AddSeries(
+			storage.SeriesRef(i+1),
+			e.ls,
+			model.Fingerprint(labels.StableHash(e.ls)),
+			ChunkMeta{Checksum: 1, MinTime: 0, MaxTime: 10, KB: 1, Entries: 1},
+		))
+	}
+
+	_, err = creator.Close(false)
+	require.NoError(t, err)
+	return fileName
+}
+
+// TestStreamingPostings_SeekMatchesMmap cross-checks the streaming postings
+// iterator's Seek (a binary search over the on-disk refs) against the mmap
+// BigEndianPostings over a large, gapped postings list.
+func TestStreamingPostings_SeekMatchesMmap(t *testing.T) {
+	for _, format := range []int{FormatV3, FormatV4} {
+		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
+			fn := writeSharedLabelFixture(t, format)
+
+			mmap, err := NewMmapFileReader(fn)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, mmap.Close()) })
+
+			stream, err := NewStreamFileReader(fn)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, stream.Close()) })
+
+			// Ground-truth ordered ref list for the shared postings.
+			allRefs := mustPostingsAndDrain(t, mmap, "shared", "all")
+			require.Greater(t, len(allRefs), 1000, "need a large postings list to exercise the binary search")
+
+			// A target that falls in a gap (absent, between two refs) so we
+			// exercise landing on the next-greater ref.
+			var gap storage.SeriesRef
+			for k := 0; k+1 < len(allRefs); k++ {
+				if allRefs[k+1] > allRefs[k]+1 {
+					gap = allRefs[k] + 1
+					break
+				}
+			}
+			require.NotZero(t, gap)
+
+			// Part 1: fresh iterators, full-range search for a spread of targets:
+			// before-first, exact, gap, midpoint, last, past-end.
+			targets := []storage.SeriesRef{
+				0,
+				allRefs[0],
+				gap,
+				allRefs[len(allRefs)/2],
+				allRefs[len(allRefs)-1],
+				allRefs[len(allRefs)-1] + 1,
+			}
+			for _, target := range targets {
+				mmapPostings := mustPostings(t, mmap, "shared", "all")
+				streamPostings := mustPostings(t, stream, "shared", "all")
+				mmapOk, streamOk := mmapPostings.Seek(target), streamPostings.Seek(target)
+				require.Equal(t, mmapOk, streamOk)
+				if mmapOk {
+					require.Equal(t, mmapPostings.At(), streamPostings.At())
+					// The remainder after the sought ref must match too.
+					require.Equal(t, drainPostings(t, mmapPostings), drainPostings(t, streamPostings))
+				}
+				require.NoError(t, mmapPostings.Err())
+				require.NoError(t, streamPostings.Err())
+			}
+
+			// Part 2: one iterator pair driven in lockstep with interleaved Next
+			// and ascending Seek, exercising a binary search from a non-zero
+			// starting position.
+			mmapPostings := mustPostings(t, mmap, "shared", "all")
+			streamPostings := mustPostings(t, stream, "shared", "all")
+			n := len(allRefs)
+			type op struct {
+				seek   bool
+				target storage.SeriesRef
+			}
+			for i, o := range []op{
+				{seek: false},
+				{seek: false},
+				{seek: true, target: allRefs[n/4]},
+				{seek: false},
+				{seek: true, target: allRefs[n/2] + 1},
+				{seek: true, target: allRefs[3*n/4]},
+				{seek: false},
+				{seek: true, target: allRefs[n-1]},
+			} {
+				var mmapOk, streamOk bool
+				if o.seek {
+					mmapOk, streamOk = mmapPostings.Seek(o.target), streamPostings.Seek(o.target)
+				} else {
+					mmapOk, streamOk = mmapPostings.Next(), streamPostings.Next()
+				}
+				require.Equal(t, mmapOk, streamOk, "op %d ok", i)
+				if !mmapOk {
+					break
+				}
+				require.Equal(t, mmapPostings.At(), streamPostings.At())
+			}
+			require.NoError(t, mmapPostings.Err())
+			require.NoError(t, streamPostings.Err())
+		})
+	}
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
@@ -28,7 +28,8 @@ type StreamReader struct {
 	version int
 	toc     *TOC
 
-	symbols *streamSymbols
+	symbols  *streamSymbols
+	postings *streamPostings
 }
 
 // NewStreamFileReader constructs a StreamReader against the given index file.
@@ -62,6 +63,12 @@ func NewStreamFileReader(path string) (*StreamReader, error) {
 	reader.toc = toc
 
 	reader.symbols, err = newStreamSymbols(context.Background(), factory, int(toc.Symbols))
+	if err != nil {
+		_ = factory.Close()
+		return nil, err
+	}
+
+	reader.postings, err = newStreamPostings(context.Background(), factory, int(toc.PostingsTable))
 	if err != nil {
 		_ = factory.Close()
 		return nil, err
@@ -164,10 +171,6 @@ func (s StreamReader) RawFileReader() (io.ReadSeekCloser, error) {
 	return os.Open(s.path)
 }
 
-func (s StreamReader) PostingsRanges() (map[labels.Label]Range, error) {
-	return s.mmapReader.PostingsRanges()
-}
-
 func (s StreamReader) Bounds() (int64, int64) {
 	return s.toc.Metadata.From, s.toc.Metadata.Through
 }
@@ -200,8 +203,20 @@ func (s StreamReader) ChunkStats(id storage.SeriesRef, from, through int64, lbls
 	return s.mmapReader.ChunkStats(id, from, through, lbls, by)
 }
 
-func (s StreamReader) Postings(name string, fpFilter FingerprintFilter, values ...string) (Postings, error) {
-	return s.mmapReader.Postings(name, fpFilter, values...)
+// Postings returns a postings iterator for the given label name and values.
+// Values must be provided in ascending order.
+//
+// A non-nil FingerprintFilter (shard-aware queries) still falls through to the
+// mmap reader: the streaming reader does not yet load the fingerprint-offsets
+// table needed to shard postings — that is a later step. The common
+// fpFilter==nil path is served natively by streamPostings.
+func (s StreamReader) Postings(labelName string, fpFilter FingerprintFilter, labelValues ...string) (Postings, error) {
+	if fpFilter != nil {
+		// Serve shard-aware queries from mmap reader until we've implemented
+		// reading the fingerprint offsets table needed to serve these properly.
+		return s.mmapReader.Postings(labelName, fpFilter, labelValues...)
+	}
+	return s.postings.postingsFor(labelName, labelValues...)
 }
 
 func (s StreamReader) Size() int64 {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
@@ -102,7 +102,6 @@ func TestReaders_CrossCheck(t *testing.T) {
 
 			requireLabelsEqual(t, mmap, stream)
 			requirePostingsSeriesEqual(t, mmap, stream)
-			requirePostingsRangesEqual(t, mmap, stream)
 		})
 	}
 }
@@ -349,13 +348,4 @@ func requireChunkStatsEqual(t *testing.T, mmap Reader, stream Reader, seriesRef 
 		require.Equal(t, mmapChunkStats, streamChunkStats)
 		require.Equal(t, mmapLabels, streamLabels)
 	}
-}
-
-func requirePostingsRangesEqual(t *testing.T, base, other Reader) {
-	t.Helper()
-	baseRanges, err := base.PostingsRanges()
-	require.NoError(t, err)
-	otherRanges, err := other.PostingsRanges()
-	require.NoError(t, err)
-	require.Equal(t, baseRanges, otherRanges)
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding.go
@@ -91,6 +91,16 @@ func (d *Decbuf) Skip(l int) {
 	d.E = d.r.Skip(l)
 }
 
+// ReadInto reads len(dst) bytes into dst, consuming them. If E is non-nil,
+// this method has no effect.
+func (d *Decbuf) ReadInto(dst []byte) {
+	if d.E != nil {
+		return
+	}
+
+	d.E = d.r.ReadInto(dst)
+}
+
 // SkipUvarintBytes advances the pointer of the underlying BufReader past the
 // next varint-prefixed bytes. If E is non-nil, this method has no effect.
 func (d *Decbuf) SkipUvarintBytes() {


### PR DESCRIPTION
- Remove PostingsRanges() from interface as it's unused
- Implement Postings for cases where a fingerprint filter isn't given
- All is derivative of existing implementation, so can be reviewed against that. And also is tested against the existing implementation so we know it behaves similarly.

**What this PR does / why we need it**: Part of our effort to move away from mmap in index gateways.

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**: Can be compared to the existing implementation in index.go. 

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
