### PR TITLE
chore: Implement streaming reading of fingerprint offsets table

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
@@ -123,6 +123,7 @@ func (p *streamPostings) postingsFor(labelName string, labelValues ...string) (P
 		// Unchecked because we already checked CRC32 at startup
 		decbuf := p.factory.NewDecbufAtUnchecked(ctx, p.off)
 		if err := decbuf.Err(); err != nil {
+			_ = decbuf.Close()
 			return nil, err
 		}
 		decbuf.ResetAt(offsets[i].offset)
@@ -182,10 +183,10 @@ func (p *streamPostings) postingsFor(labelName string, labelValues ...string) (P
 // validates while opening).
 func (p *streamPostings) readPostingsList(postingsOffset uint64) (Postings, error) {
 	decbuf := p.factory.NewDecbufAtChecked(context.Background(), int(postingsOffset), castagnoliTable)
+	defer func() { _ = decbuf.Close() }()
 	if err := decbuf.Err(); err != nil {
 		return nil, err
 	}
-	defer func() { _ = decbuf.Close() }()
 
 	n := decbuf.Be32int()
 	if err := decbuf.Err(); err != nil {
@@ -214,10 +215,10 @@ func streamPostingsOffsetTable(
 	) error,
 ) error {
 	decbuf := factory.NewDecbufAtChecked(ctx, postingsOffsetTableOffset, castagnoliTable)
+	defer func() { _ = decbuf.Close() }()
 	if err := decbuf.Err(); err != nil {
 		return err
 	}
-	defer func() { _ = decbuf.Close() }()
 
 	size := decbuf.Be32()
 	for i := uint32(0); decbuf.Err() == nil && i < size; i++ {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings_test.go
@@ -25,16 +25,16 @@ func drainPostings(t *testing.T, p Postings) []storage.SeriesRef {
 }
 
 // mustPostings runs Reader.Postings and asserts that doing so doesn't return an error.
-func mustPostings(t *testing.T, r Reader, name string, values ...string) Postings {
+func mustPostings(t *testing.T, r Reader, fpFilter FingerprintFilter, name string, values ...string) Postings {
 	t.Helper()
-	p, err := r.Postings(name, nil, values...)
+	p, err := r.Postings(name, fpFilter, values...)
 	require.NoError(t, err)
 	return p
 }
 
-func mustPostingsAndDrain(t *testing.T, r Reader, name string, values ...string) []storage.SeriesRef {
+func mustPostingsAndDrain(t *testing.T, r Reader, fpFilter FingerprintFilter, name string, values ...string) []storage.SeriesRef {
 	t.Helper()
-	return drainPostings(t, mustPostings(t, r, name, values...))
+	return drainPostings(t, mustPostings(t, r, fpFilter, name, values...))
 }
 
 // TestStreamPostings_MatchesMmap cross-checks the streaming Postings
@@ -65,16 +65,16 @@ func TestStreamPostings_MatchesMmap(t *testing.T) {
 			// block and the forward walk within a block.
 			for _, v := range values {
 				require.Equal(t,
-					mustPostingsAndDrain(t, mmap, "id", v),
-					mustPostingsAndDrain(t, stream, "id", v),
+					mustPostingsAndDrain(t, mmap, nil, "id", v),
+					mustPostingsAndDrain(t, stream, nil, "id", v),
 				)
 			}
 
 			// A multi-value query with every value at once exercises walking
 			// across sparse blocks in a single call.
 			require.Equal(t,
-				mustPostingsAndDrain(t, mmap, "id", values...),
-				mustPostingsAndDrain(t, stream, "id", values...),
+				mustPostingsAndDrain(t, mmap, nil, "id", values...),
+				mustPostingsAndDrain(t, stream, nil, "id", values...),
 			)
 
 			// A scattered subset (every 5th value) exercises seeking between
@@ -84,30 +84,30 @@ func TestStreamPostings_MatchesMmap(t *testing.T) {
 				subset = append(subset, values[i])
 			}
 			require.Equal(t,
-				mustPostingsAndDrain(t, mmap, "id", subset...),
-				mustPostingsAndDrain(t, stream, "id", subset...),
+				mustPostingsAndDrain(t, mmap, nil, "id", subset...),
+				mustPostingsAndDrain(t, stream, nil, "id", subset...),
 			)
 
 			// Unknown label name yields empty postings in both readers.
-			require.Empty(t, drainPostings(t, mustPostings(t, stream, "does-not-exist", "x")))
+			require.Empty(t, mustPostingsAndDrain(t, stream, nil, "does-not-exist", "x"))
 			require.Equal(t,
-				mustPostingsAndDrain(t, mmap, "does-not-exist", "x"),
-				mustPostingsAndDrain(t, stream, "does-not-exist", "x"),
+				mustPostingsAndDrain(t, mmap, nil, "does-not-exist", "x"),
+				mustPostingsAndDrain(t, stream, nil, "does-not-exist", "x"),
 			)
 
 			// Values outside the range of stored values (before the first and
 			// after the last) match mmap — both should be empty.
 			for _, v := range []string{"\x00", "zzzzzzzz"} {
 				require.Equal(t,
-					mustPostingsAndDrain(t, mmap, "id", v),
-					mustPostingsAndDrain(t, stream, "id", v),
+					mustPostingsAndDrain(t, mmap, nil, "id", v),
+					mustPostingsAndDrain(t, stream, nil, "id", v),
 				)
 			}
 
 			// No values requested yields empty postings in both readers.
 			require.Equal(t,
-				mustPostingsAndDrain(t, mmap, "id"),
-				mustPostingsAndDrain(t, stream, "id"),
+				mustPostingsAndDrain(t, mmap, nil, "id"),
+				mustPostingsAndDrain(t, stream, nil, "id"),
 			)
 		})
 	}
@@ -188,7 +188,7 @@ func TestStreamingPostings_SeekMatchesMmap(t *testing.T) {
 			t.Cleanup(func() { require.NoError(t, stream.Close()) })
 
 			// Ground-truth ordered ref list for the shared postings.
-			allRefs := mustPostingsAndDrain(t, mmap, "shared", "all")
+			allRefs := mustPostingsAndDrain(t, mmap, nil, "shared", "all")
 			require.Greater(t, len(allRefs), 1000, "need a large postings list to exercise the binary search")
 
 			// A target that falls in a gap (absent, between two refs) so we
@@ -213,8 +213,8 @@ func TestStreamingPostings_SeekMatchesMmap(t *testing.T) {
 				allRefs[len(allRefs)-1] + 1,
 			}
 			for _, target := range targets {
-				mmapPostings := mustPostings(t, mmap, "shared", "all")
-				streamPostings := mustPostings(t, stream, "shared", "all")
+				mmapPostings := mustPostings(t, mmap, nil, "shared", "all")
+				streamPostings := mustPostings(t, stream, nil, "shared", "all")
 				mmapOk, streamOk := mmapPostings.Seek(target), streamPostings.Seek(target)
 				require.Equal(t, mmapOk, streamOk)
 				if mmapOk {
@@ -229,8 +229,8 @@ func TestStreamingPostings_SeekMatchesMmap(t *testing.T) {
 			// Part 2: one iterator pair driven in lockstep with interleaved Next
 			// and ascending Seek, exercising a binary search from a non-zero
 			// starting position.
-			mmapPostings := mustPostings(t, mmap, "shared", "all")
-			streamPostings := mustPostings(t, stream, "shared", "all")
+			mmapPostings := mustPostings(t, mmap, nil, "shared", "all")
+			streamPostings := mustPostings(t, stream, nil, "shared", "all")
 			n := len(allRefs)
 			type op struct {
 				seek   bool
@@ -260,6 +260,64 @@ func TestStreamingPostings_SeekMatchesMmap(t *testing.T) {
 			}
 			require.NoError(t, mmapPostings.Err())
 			require.NoError(t, streamPostings.Err())
+		})
+	}
+}
+
+// TestStreamPostings_ShardedMatchesMmap cross-checks shard-aware Postings
+// (fpFilter != nil) against the mmap reader over the large shared-label
+// postings list, across several shard configurations.
+func TestStreamPostings_ShardedMatchesMmap(t *testing.T) {
+	for _, format := range []int{FormatV3, FormatV4} {
+		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
+			path := writeSharedLabelFixture(t, format)
+
+			mmap, err := NewMmapFileReader(path)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, mmap.Close()) })
+
+			stream, err := NewStreamFileReader(path)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, stream.Close()) })
+
+			// Should both have the same fingerprintOffsets
+			require.NotEmpty(t, mmap.fingerprintOffsets)
+			require.Equal(t, mmap.fingerprintOffsets, stream.fingerprintOffsets)
+
+			// The unsharded ground truth.
+			allSeriesRefs := mustPostingsAndDrain(t, mmap, nil, "shared", "all")
+			require.Greater(t, len(allSeriesRefs), 1000, "need a large postings list to exercise sharding")
+
+			// Every shard, in every configuration, must return exactly what the
+			// mmap reader returns.
+			shards := []ShardAnnotation{
+				NewShard(0, 2), NewShard(1, 2), NewShard(2, 16), NewShard(13, 32),
+				NewShard(0, 4), NewShard(1, 4), NewShard(2, 4), NewShard(3, 4),
+			}
+			for _, shard := range shards {
+				require.Equal(t,
+					mustPostingsAndDrain(t, mmap, shard, "shared", "all"),
+					mustPostingsAndDrain(t, stream, shard, "shared", "all"),
+					"shard %d/%d", shard.Shard, shard.Of,
+				)
+			}
+
+			// A single shard covering the whole space is an identity filter:
+			// the fpFilter != nil path must still return the full list.
+			require.Equal(t, allSeriesRefs, mustPostingsAndDrain(t, stream, NewShard(0, 1), "shared", "all"))
+
+			// Series are written in fingerprint order, so a 2-way partition
+			// must cover every series (sharding may return a slight superset at
+			// the boundaries, never a subset of the union).
+			union := map[storage.SeriesRef]struct{}{}
+			for _, shard := range []ShardAnnotation{NewShard(0, 2), NewShard(1, 2)} {
+				for _, ref := range mustPostingsAndDrain(t, stream, shard, "shared", "all") {
+					union[ref] = struct{}{}
+				}
+			}
+			for _, ref := range allSeriesRefs {
+				require.Contains(t, union, ref, "series %d missing from the 2-way shard partition", ref)
+			}
 		})
 	}
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
@@ -26,10 +26,11 @@ type StreamReader struct {
 	path    string
 	size    int64
 	version int
-	toc     *TOC
 
-	symbols  *streamSymbols
-	postings *streamPostings
+	toc                *TOC
+	symbols            *streamSymbols
+	postings           *streamPostings
+	fingerprintOffsets FingerprintOffsets
 }
 
 // NewStreamFileReader constructs a StreamReader against the given index file.
@@ -69,6 +70,12 @@ func NewStreamFileReader(path string) (*StreamReader, error) {
 	}
 
 	reader.postings, err = newStreamPostings(context.Background(), factory, int(toc.PostingsTable))
+	if err != nil {
+		_ = factory.Close()
+		return nil, err
+	}
+
+	reader.fingerprintOffsets, err = reader.readFingerprintOffsetsTable(int(toc.FingerprintOffsets))
 	if err != nil {
 		_ = factory.Close()
 		return nil, err
@@ -161,6 +168,28 @@ func (s StreamReader) readTOC() (*TOC, error) {
 	return toc, nil
 }
 
+// readFingerprintOffsetsTable reads the fingerprint-offsets section at the
+// given absolute file offset into memory.
+// It is the StreamReader's counterpart to readFingerprintOffsetsTable in index.go.
+// On disk the section is a 4-byte big-endian count N, followed by N
+// (seriesRef, fingerprint) pairs of 8-byte big-endian values, then the section CRC,
+// which NewDecbufAtChecked validates while opening.
+func (s StreamReader) readFingerprintOffsetsTable(offset int) (FingerprintOffsets, error) {
+	decbuf := s.factory.NewDecbufAtChecked(context.Background(), offset, castagnoliTable)
+	if err := decbuf.Err(); err != nil {
+		return nil, err
+	}
+	defer func() { _ = decbuf.Close() }()
+
+	n := decbuf.Be32()
+	result := make(FingerprintOffsets, 0, int(n))
+	for decbuf.Err() == nil && n > 0 {
+		result = append(result, [2]uint64{decbuf.Be64(), decbuf.Be64()})
+		n--
+	}
+	return result, decbuf.Err()
+}
+
 func (s StreamReader) Version() int {
 	return s.version
 }
@@ -206,17 +235,17 @@ func (s StreamReader) ChunkStats(id storage.SeriesRef, from, through int64, lbls
 // Postings returns a postings iterator for the given label name and values.
 // Values must be provided in ascending order.
 //
-// A non-nil FingerprintFilter (shard-aware queries) still falls through to the
-// mmap reader: the streaming reader does not yet load the fingerprint-offsets
-// table needed to shard postings — that is a later step. The common
-// fpFilter==nil path is served natively by streamPostings.
+// A non-nil FingerprintFilter restricts the result to the requested shard by
+// bounding the merged postings with the fingerprint offsets table.
 func (s StreamReader) Postings(labelName string, fpFilter FingerprintFilter, labelValues ...string) (Postings, error) {
-	if fpFilter != nil {
-		// Serve shard-aware queries from mmap reader until we've implemented
-		// reading the fingerprint offsets table needed to serve these properly.
-		return s.mmapReader.Postings(labelName, fpFilter, labelValues...)
+	postings, err := s.postings.postingsFor(labelName, labelValues...)
+	if err != nil {
+		return nil, err
 	}
-	return s.postings.postingsFor(labelName, labelValues...)
+	if fpFilter != nil {
+		return NewShardedPostings(postings, fpFilter, s.fingerprintOffsets), nil
+	}
+	return postings, nil
 }
 
 func (s StreamReader) Size() int64 {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
@@ -100,10 +100,10 @@ func (s StreamReader) readHeader() (int, error) {
 	}
 	// Construct decbuf
 	decbuf := s.factory.NewRawDecbuf(context.Background())
+	defer func() { _ = decbuf.Close() }()
 	if err := decbuf.Err(); err != nil {
 		return 0, fmt.Errorf("open header decbuf: %w", err)
 	}
-	defer func() { _ = decbuf.Close() }()
 	// Extract and validate magic
 	magic := decbuf.Be32()
 	if err := decbuf.Err(); err != nil {
@@ -132,10 +132,10 @@ func (s StreamReader) readTOC() (*TOC, error) {
 	}
 	// Create decbuf
 	decbuf := s.factory.NewRawDecbuf(context.Background())
+	defer func() { _ = decbuf.Close() }()
 	if err := decbuf.Err(); err != nil {
 		return nil, fmt.Errorf("open toc decbuf: %w", err)
 	}
-	defer func() { _ = decbuf.Close() }()
 	// Validate CRC32
 	tocStart := int(s.size) - indexTOCLen
 	if decbuf.ResetAt(tocStart); decbuf.Err() != nil {
@@ -176,10 +176,10 @@ func (s StreamReader) readTOC() (*TOC, error) {
 // which NewDecbufAtChecked validates while opening.
 func (s StreamReader) readFingerprintOffsetsTable(offset int) (FingerprintOffsets, error) {
 	decbuf := s.factory.NewDecbufAtChecked(context.Background(), offset, castagnoliTable)
+	defer func() { _ = decbuf.Close() }()
 	if err := decbuf.Err(); err != nil {
 		return nil, err
 	}
-	defer func() { _ = decbuf.Close() }()
 
 	n := decbuf.Be32()
 	result := make(FingerprintOffsets, 0, int(n))

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols.go
@@ -28,11 +28,10 @@ type streamSymbols struct {
 // capturing the sparse offset table.
 func newStreamSymbols(ctx context.Context, factory *streamenc.FilePoolDecbufFactory, off int) (*streamSymbols, error) {
 	decbuf := factory.NewDecbufAtChecked(ctx, off, castagnoliTable)
+	defer func() { _ = decbuf.Close() }()
 	if err := decbuf.Err(); err != nil {
-		_ = decbuf.Close()
 		return nil, err
 	}
-	defer func() { _ = decbuf.Close() }()
 
 	size := decbuf.Be32int()
 	if err := decbuf.Err(); err != nil {
@@ -63,10 +62,10 @@ func (s *streamSymbols) Lookup(n uint32) (string, error) {
 	}
 
 	decbuf := s.factory.NewDecbufAtUnchecked(context.Background(), s.off)
+	defer func() { _ = decbuf.Close() }()
 	if err := decbuf.Err(); err != nil {
 		return "", err
 	}
-	defer func() { _ = decbuf.Close() }()
 
 	// Use sparse offset table to jump right to the start of the bucket the symbol is in.
 	decbuf.ResetAt(s.offsets[int(n/symbolFactor)])


### PR DESCRIPTION
- Read it into memory on open (like existing mmap implementation).
- Implement Postings(...) for non-nil fingerprint filters.
- Test against existing implementation.
- Second commit makes changes across a few of the files I've been working on to prevent leaking file descriptors when creating a decbuf fails. This problem was identified by cursor's review of this PR. 

**What this PR does / why we need it**: Part of our effort to move away from mmap in index gateways.

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**: Can be compared to existing implementation in index.go. 

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
