### PR TITLE
docs: Backport add link to upgrade topic

### DIFF
--- a/docs/sources/setup/install/helm/install-microservices/_index.md
+++ b/docs/sources/setup/install/helm/install-microservices/_index.md
@@ -42,15 +42,17 @@ Zone-aware replication is enabled by default for ingesters. This creates three i
 We do not recommend running in microservices mode with `filesystem` storage. For the purpose of this guide, we will use the deprecated built-in MinIO subchart to provide a complete self-contained example. Configure a dedicated external object storage backend for production.
 {{< /admonition >}}
 
-
 ## Prerequisites
 
 - Helm 3 or above. See [Installing Helm](https://helm.sh/docs/intro/install/).
 - Kubernetes 1.25 or later.
 - A running Kubernetes cluster (must have at least 3 nodes for zone-aware replication, which is enabled by default).
 
-
 ## Deploying the Helm chart for development and testing
+
+{{< admonition type="note" >}}
+If this is the first time you have deployed the Loki Helm chart since the move to the Community managed Helm chart, note that the URL for the chart has changed. For more information see the [Upgrade documentation](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/upgrade-to-6x/).
+{{< /admonition >}}
 
 1. Add the [Grafana Community chart repository](https://github.com/grafana-community/helm-charts) to Helm:
 
@@ -149,19 +151,23 @@ We do not recommend running in microservices mode with `filesystem` storage. For
 
 1. Install or upgrade the Loki deployment.
      - To install:
+
         ```bash
        helm install --values values.yaml loki grafana-community/loki
        ```
+
     - To upgrade:
+
        ```bash
        helm upgrade --values values.yaml loki grafana-community/loki
        ```
-       
 
 1. Verify that Loki is running:
+
     ```bash
     kubectl get pods -n loki
     ```
+
     The output should an output similar to the following:
 
     ```bash
@@ -197,7 +203,6 @@ After testing Loki with [MinIO](https://min.io/docs/minio/kubernetes/upstream/in
 {{< admonition type="caution" >}}
 When deploying Loki using S3 Storage **DO NOT** use the default bucket names;  `chunk`, `ruler` and `admin`. Choose a unique name for each bucket. For more information see the following [security update](https://grafana.com/blog/2024/06/27/grafana-security-update-grafana-loki-and-unintended-data-write-attempts-to-amazon-s3-buckets/). This caution does not apply when you are using MinIO. When using MinIO we recommend using the default bucket names.
 {{< /admonition >}}
-
 
 {{< collapse title="S3" >}}
 
@@ -304,6 +309,7 @@ singleBinary:
   replicas: 0
 
 ```
+
 {{< /collapse >}}
 
 {{< collapse title="Azure" >}}
@@ -392,6 +398,7 @@ singleBinary:
   replicas: 0
 
 ```
+
 {{< /collapse >}}
 
 To configure other storage providers, refer to the [Helm Chart Reference](../reference/).
@@ -453,13 +460,15 @@ distributor:
 ## Deploying the Loki Helm chart to a Production Environment
 
 {{< admonition type="note" >}}
-We are actively working on providing more guides for deploying Loki in production. 
+We are actively working on providing more guides for deploying Loki in production.
 {{< /admonition >}}
 
 We recommend running Loki at scale within a cloud environment like AWS, Azure, or GCP. The below guides will show you how to deploy a minimally viable production environment.
+
 - [Deploy Loki on AWS](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/deployment-guides/aws/)
 - [Deploy Loki on Azure](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/deployment-guides/azure/)
 
-## Next Steps 
+## Next Steps
+
 * Configure an agent to [send log data to Loki](/docs/loki/<LOKI_VERSION>/send-data/).
 * [Monitor the Loki deployment](/docs/loki/<LOKI_VERSION>/setup/install/helm/monitor-and-alert/), using the recommended Kubernetes monitoring Helm chart.

--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -207,6 +207,10 @@ In this configuration, update `commonConfig.replication_factor` and `singleBinar
 
 ## Deploying the Helm chart for development and testing
 
+{{< admonition type="note" >}}
+If this is the first time you have deployed the Loki Helm chart since the move to the Community managed Helm chart, note that the URL for the chart has changed. For more information see the [Upgrade documentation](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/upgrade-to-6x/).
+{{< /admonition >}}
+
 1. Add the [Grafana Community chart repository](https://github.com/grafana-community/helm-charts) to Helm:
 
    ```bash
@@ -443,13 +447,14 @@ To configure other storage providers, refer to the [Helm Chart Reference](https:
 ## Deploying the Loki Helm chart to a Production Environment
 
 {{< admonition type="note" >}}
-We are actively working on providing more guides for deploying Loki in production. 
+We are actively working on providing more guides for deploying Loki in production.
 {{< /admonition >}}
 
 We recommend running Loki at scale within a cloud environment like AWS, Azure, or GCP. The below guides will show you how to deploy a minimally viable production environment.
+
 - [Deploy Loki on AWS](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/deployment-guides/aws)
 
+## Next Steps
 
-## Next Steps 
 * Configure an agent to [send log data to Loki](/docs/loki/<LOKI_VERSION>/send-data/).
-* [Monitor the Loki deployment](/docs/loki/<LOKI_VERSION>/setup/install/helm/monitor-and-alert/), using the recommended Kubernetes monitoring Helm chart.
+* Monitor the Loki deployment using the [Meta Monitoring Helm chart](/docs/loki/<LOKI_VERSION>/setup/install/helm/monitor-and-alert/)

--- a/docs/sources/setup/install/helm/install-scalable/_index.md
+++ b/docs/sources/setup/install/helm/install-scalable/_index.md
@@ -46,6 +46,10 @@ Simple scalable mode requires object storage (`loki.storage.type` must be `s3`, 
 
 ## Deploying the Helm chart for development and testing
 
+{{< admonition type="note" >}}
+If this is the first time you have deployed the Loki Helm chart since the move to the Community managed Helm chart, note that the URL for the chart has changed. For more information see the [Upgrade documentation](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/upgrade-to-6x/).
+{{< /admonition >}}
+
 The following steps show how to deploy the Loki Helm chart in simple scalable mode using the included MinIO as the storage backend. Our recommendation is to start here for development and testing purposes. Then configure Loki with an object storage provider when moving to production.
 
 1. Add the [Grafana Community chart repository](https://github.com/grafana-community/helm-charts) to Helm:

--- a/docs/sources/setup/upgrade/upgrade-to-6x/index.md
+++ b/docs/sources/setup/upgrade/upgrade-to-6x/index.md
@@ -7,7 +7,7 @@ keywords:
   - upgrade
 ---
 
-## Upgrading to v6.x
+# Upgrading to v6.x
 
 v6.x of this chart introduces distributed mode but also introduces breaking changes from v5x.
 
@@ -20,13 +20,12 @@ Simple Scalable Deployment (SSD) mode is being deprecated and will be removed wi
 {{< /admonition >}}
 
 {{< admonition type="tip" >}}
-With the move to the [Grafana-community/helm-charts repository](https://github.com/grafana-community/helm-charts), the chart numbering has changed. Major version updates signal breaking changes in the chart. For more information, refer to the [README](https://github.com/grafana-community/helm-charts/blob/main/charts/loki/README.md#upgrading).
+With the move to the [Grafana-community/helm-charts repository](https://github.com/grafana-community/helm-charts), the chart URL and numbering has changed. Major version updates signal breaking changes in the chart. For more information, refer to the [README](https://github.com/grafana-community/helm-charts/blob/main/charts/loki/README.md#upgrading).
 {{< /admonition >}}
 
+## Changes
 
-### Changes
-
-#### BREAKING: `deploymentMode` setting
+### BREAKING: `deploymentMode` setting
 
 This only breaks you if you are running the chart in Single Binary mode, you will need to set
 
@@ -34,17 +33,17 @@ This only breaks you if you are running the chart in Single Binary mode, you wil
 deploymentMode: SingleBinary
 ```
 
-#### BREAKING: `lokiCanary` section was moved
+### BREAKING: `lokiCanary` section was moved
 
 This section was moved from within the `monitoring` section to the root level of the values file.
 
-#### BREAKING: `topologySpreadConstraints` and `podAffinity` converted to objects
+### BREAKING: `topologySpreadConstraints` and `podAffinity` converted to objects
 
 Previously they were strings which were passed through `tpl` now they are normal objects which will be added to deployments.
 
 Also we removed the soft constraint on zone.
 
-#### BREAKING: `externalConfigSecretName` was removed and replaced
+### BREAKING: `externalConfigSecretName` was removed and replaced
 
 Instead you can now provide `configObjectName` which is used by Loki components for loading the config.
 
@@ -52,7 +51,7 @@ Instead you can now provide `configObjectName` which is used by Loki components 
 
 This gives greater flexibility in using the chart to still generate a config object but allowing for another process to load and mutate this config into a new object which can be loaded by Loki and `configObjectName`
 
-#### Monitoring
+### Monitoring
 
 After some consideration of how this chart works with other charts provided by Grafana, we decided to deprecate the monitoring sections of this chart and take a new approach entirely to monitoring Loki, Mimir and Tempo with the [Meta Monitoring Chart](https://github.com/grafana/meta-monitoring-chart).
 
@@ -77,13 +76,13 @@ monitoring:
       installOperator: true
 ```
 
-#### Memcached is included and enabled by default
+### Memcached is included and enabled by default
 
 Caching is crucial to the proper operation of Loki and Memcached is now included in this chart and enabled by default for the `chunksCache` and `resultsCache`.
 
 If you are already running Memcached separately you can remove your existing installation and use the Memcached deployments built into this chart.
 
-##### Single Binary
+#### Single Binary
 
 Memcached also deploys for the Single Binary, but this may not be desired in resource constrained environments.
 
@@ -98,7 +97,7 @@ resultsCache:
 
 With these caches disabled, Loki will return to defaults which enables an in-memory results and chunks cache, so you will still get some caching.
 
-#### BREAKING: Zone-aware ingester StatefulSet serviceName fix (6.34.0+)
+### BREAKING: Zone-aware ingester StatefulSet serviceName fix (6.34.0+)
 
 **Affected users**: Only deployments using zone-aware ingester replication (`ingester.zoneAwareReplication.enabled: true`)
 
@@ -139,7 +138,7 @@ In Helm chart version 6.34.0, [PR #18558](https://github.com/grafana/loki/pull/1
 **Why this change was necessary**:
 The previous configuration caused ingester scaling operations to fail because the rollout-operator couldn't find the correct headless services for the `/ingester/prepare-downscale` endpoint.
 
-#### BREAKING: Make access modes for persistence on all PVCs and StatefulSets editable (6.38.0+)
+### BREAKING: Make access modes for persistence on all PVCs and StatefulSets editable (6.38.0+)
 
 Version 6.38.0 of the Helm charts introduced the ability to edit the access modes for persistence on all PVCs and StatefulSets. This is a breaking change because it requires users to manually orphan StatefulSets before upgrading.
 
@@ -177,6 +176,6 @@ Version 6.38.0 of the Helm charts introduced the ability to edit the access mode
    helm upgrade <RELEASE_NAME> grafana/loki --version 6.38.0
    ```
 
-#### Distributed mode
+### Distributed mode
 
 This chart introduces the ability to run Loki in distributed, or [microservices mode](https://grafana.com/docs/loki/<LOKI_VERSION>/get-started/deployment-modes/#microservices-mode). For installation instructions, refer to [Install the microservices Helm chart](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/install/helm/install-microservices/).


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport https://github.com/grafana/loki/commit/ebe38fffa07a4509fb8d4b8afb6d07b7a72a86ec from https://github.com/grafana/loki/pull/22000

**Which issue(s) this PR fixes**:
Replaces https://github.com/grafana/loki/pull/22001 which had unsigned commits

**What this PR does / why we need it:**

Adds a link to the Helm Upgrade topic to the installation topics.
Cleans up some formatting issues (missing or extra lines).
Updated the Upgrade charts topic.