### PR TITLE
docs: Add Thanos storage examples  🤖🤖🤖

### DIFF
--- a/docs/sources/configure/examples/configuration-examples.md
+++ b/docs/sources/configure/examples/configuration-examples.md
@@ -41,7 +41,6 @@ storage_config:
 
 ```
 
-
 ## 2-S3-Cluster-Example.yaml
 
 ```yaml
@@ -83,7 +82,6 @@ storage_config:
 
 ```
 
-
 ## 3-S3-Without-Credentials-Snippet.yaml
 
 ```yaml
@@ -97,7 +95,6 @@ storage_config:
       
 
 ```
-
 
 ## 4-GCS-Example.yaml
 
@@ -138,7 +135,6 @@ storage_config:
 
 ```
 
-
 ## 5-BOS-Example.yaml
 
 ```yaml
@@ -167,7 +163,6 @@ storage_config:
 
 ```
 
-
 ## 6-Compactor-Snippet.yaml
 
 ```yaml
@@ -180,7 +175,6 @@ compactor:
   compaction_interval: 5m
 
 ```
-
 
 ## 7-Schema-Migration-Snippet.yaml
 
@@ -213,7 +207,6 @@ schema_config:
         prefix: index_
 
 ```
-
 
 ## 8-alibaba-cloud-storage-Snippet.yaml
 
@@ -255,7 +248,6 @@ storage_config:
 
 ```
 
-
 ## 9-S3-With-SSE-KMS-Snippet.yaml
 
 ```yaml
@@ -270,7 +262,6 @@ storage_config:
       kms_key_id: 1234abcd-12ab-34cd-56ef-1234567890ab
 
 ```
-
 
 ## 10-Expanded-S3-Snippet.yaml
 
@@ -295,7 +286,6 @@ storage_config:
     
 
 ```
-
 
 ## 11-COS-HMAC-Example.yaml
 
@@ -326,7 +316,6 @@ storage_config:
 
 ```
 
-
 ## 12-COS-APIKey-Example.yaml
 
 ```yaml
@@ -356,7 +345,6 @@ storage_config:
     auth_endpoint: <iam_endpoint_for_authentication>
 
 ```
-
 
 ## 13-COS-Trusted-Profile-Example.yaml
 
@@ -394,7 +382,6 @@ storage_config:
 
 ```
 
-
 ## 15-Memberlist-Ring-Snippet.yaml
 
 ```yaml
@@ -414,7 +401,6 @@ memberlist:
     - loki-gossip-ring.loki.svc.cluster.local:7946 # :7946 is the default memberlist port.
 
 ```
-
 
 ## 16-Azure-Account-Name-Example.yaml
 
@@ -438,7 +424,6 @@ storage_config:
 
 ```
 
-
 ## 17-Azure-Service-Principal-Example.yaml
 
 ```yaml
@@ -459,3 +444,181 @@ storage_config:
 
 ```
 
+## 18-Thanos-GCS-Example.yaml
+
+```yaml
+
+# This is a complete configuration to deploy Loki backed by GCS, using the
+# Thanos-based object store client (storage_config.object_store).
+# Index files will be written locally at /loki/index and, eventually, will be shipped to the storage via tsdb-shipper.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: tsdb
+      object_store: gcs
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  use_thanos_objstore: true
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+  object_store:
+    gcs:
+      bucket_name: <BUCKET_NAME>
+
+```
+
+## 19-Thanos-S3-Example.yaml
+
+```yaml
+
+# This is a complete configuration to deploy Loki backed by a s3-compatible API
+# like MinIO for storage, using the Thanos-based object store client (storage_config.object_store).
+# Index files will be written locally at /loki/index and, eventually, will be shipped to the storage via tsdb-shipper.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: tsdb
+      object_store: s3
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  use_thanos_objstore: true
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+  object_store:
+    s3:
+      bucket_name: <BUCKET_NAME>
+      endpoint: <CUSTOM_ENDPOINT>
+      access_key_id: <ACCESS_KEY_ID>
+      secret_access_key: <SECRET_ACCESS_KEY>
+      bucket_lookup_type: path
+
+```
+
+## 20-Thanos-Azure-Example.yaml
+
+```yaml
+
+# This is a complete configuration to deploy Loki backed by Azure Blob Storage,
+# using the Thanos-based object store client (storage_config.object_store).
+# Index files will be written locally at /loki/index and, eventually, will be shipped to the storage via tsdb-shipper.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: tsdb
+      object_store: azure
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  use_thanos_objstore: true
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+  object_store:
+    azure:
+      account_name: <ACCOUNT_NAME>
+      account_key: <ACCOUNT_KEY>
+      container_name: <CONTAINER_NAME>
+
+```
+
+## 21-Thanos-MinIO-Example.yaml
+
+```yaml
+
+# This is a complete configuration to deploy Loki backed by a MinIO cluster,
+# using the Thanos-based object store client (storage_config.object_store).
+# Index files will be written locally at /loki/index and, eventually, will be shipped to the storage via tsdb-shipper.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: tsdb
+      object_store: s3
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  use_thanos_objstore: true
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+  object_store:
+    s3:
+      bucket_name: <BUCKET_NAME>
+      # Use a fully qualified domain name (fqdn), like localhost, without a scheme.
+      endpoint: <FQDN>:<PORT>
+      access_key_id: <ACCESS_KEY_ID>
+      secret_access_key: <SECRET_ACCESS_KEY>
+      insecure: true
+      bucket_lookup_type: path
+```

--- a/docs/sources/configure/examples/configuration-examples.md
+++ b/docs/sources/configure/examples/configuration-examples.md
@@ -41,6 +41,7 @@ storage_config:
 
 ```
 
+
 ## 2-S3-Cluster-Example.yaml
 
 ```yaml
@@ -82,6 +83,7 @@ storage_config:
 
 ```
 
+
 ## 3-S3-Without-Credentials-Snippet.yaml
 
 ```yaml
@@ -95,6 +97,7 @@ storage_config:
       
 
 ```
+
 
 ## 4-GCS-Example.yaml
 
@@ -135,6 +138,7 @@ storage_config:
 
 ```
 
+
 ## 5-BOS-Example.yaml
 
 ```yaml
@@ -163,6 +167,7 @@ storage_config:
 
 ```
 
+
 ## 6-Compactor-Snippet.yaml
 
 ```yaml
@@ -175,6 +180,7 @@ compactor:
   compaction_interval: 5m
 
 ```
+
 
 ## 7-Schema-Migration-Snippet.yaml
 
@@ -207,6 +213,7 @@ schema_config:
         prefix: index_
 
 ```
+
 
 ## 8-alibaba-cloud-storage-Snippet.yaml
 
@@ -248,6 +255,7 @@ storage_config:
 
 ```
 
+
 ## 9-S3-With-SSE-KMS-Snippet.yaml
 
 ```yaml
@@ -262,6 +270,7 @@ storage_config:
       kms_key_id: 1234abcd-12ab-34cd-56ef-1234567890ab
 
 ```
+
 
 ## 10-Expanded-S3-Snippet.yaml
 
@@ -286,6 +295,7 @@ storage_config:
     
 
 ```
+
 
 ## 11-COS-HMAC-Example.yaml
 
@@ -316,6 +326,7 @@ storage_config:
 
 ```
 
+
 ## 12-COS-APIKey-Example.yaml
 
 ```yaml
@@ -345,6 +356,7 @@ storage_config:
     auth_endpoint: <iam_endpoint_for_authentication>
 
 ```
+
 
 ## 13-COS-Trusted-Profile-Example.yaml
 
@@ -382,6 +394,7 @@ storage_config:
 
 ```
 
+
 ## 15-Memberlist-Ring-Snippet.yaml
 
 ```yaml
@@ -401,6 +414,7 @@ memberlist:
     - loki-gossip-ring.loki.svc.cluster.local:7946 # :7946 is the default memberlist port.
 
 ```
+
 
 ## 16-Azure-Account-Name-Example.yaml
 
@@ -424,6 +438,7 @@ storage_config:
 
 ```
 
+
 ## 17-Azure-Service-Principal-Example.yaml
 
 ```yaml
@@ -443,6 +458,7 @@ storage_config:
     request_timeout: 0
 
 ```
+
 
 ## 18-Thanos-GCS-Example.yaml
 
@@ -486,12 +502,13 @@ storage_config:
 
 ```
 
+
 ## 19-Thanos-S3-Example.yaml
 
 ```yaml
 
-# This is a complete configuration to deploy Loki backed by a s3-compatible API
-# like MinIO for storage, using the Thanos-based object store client (storage_config.object_store).
+# This is a complete configuration to deploy Loki backed by AWS S3,
+# using the Thanos-based object store client (storage_config.object_store).
 # Index files will be written locally at /loki/index and, eventually, will be shipped to the storage via tsdb-shipper.
 
 auth_enabled: false
@@ -525,12 +542,16 @@ storage_config:
   object_store:
     s3:
       bucket_name: <BUCKET_NAME>
-      endpoint: <CUSTOM_ENDPOINT>
+      # The endpoint is required. For AWS, use the regional S3 endpoint.
+      endpoint: s3.<REGION>.amazonaws.com
+      region: <REGION>
+      # Leave the access key and secret unset to use an EC2 instance role, or
+      # the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.
       access_key_id: <ACCESS_KEY_ID>
       secret_access_key: <SECRET_ACCESS_KEY>
-      bucket_lookup_type: path
 
 ```
+
 
 ## 20-Thanos-Azure-Example.yaml
 
@@ -575,6 +596,7 @@ storage_config:
       container_name: <CONTAINER_NAME>
 
 ```
+
 
 ## 21-Thanos-MinIO-Example.yaml
 
@@ -621,4 +643,6 @@ storage_config:
       secret_access_key: <SECRET_ACCESS_KEY>
       insecure: true
       bucket_lookup_type: path
+
 ```
+

--- a/docs/sources/configure/examples/thanos-storage-configs.md
+++ b/docs/sources/configure/examples/thanos-storage-configs.md
@@ -106,7 +106,8 @@ storage_config:
   object_store:
     s3:
       bucket_name: <BUCKET_NAME>
-      endpoint: <ENDPOINT>
+      # The endpoint is required. For AWS, use the regional S3 endpoint.
+      endpoint: s3.<REGION>.amazonaws.com
       region: <REGION>
       # You can either declare the access key and secret in the config or
       # use environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY which will be picked up by the AWS SDK.
@@ -153,9 +154,9 @@ storage_config:
       container_name: <CONTAINER_NAME>
 ```
 
-## MinIO / S3-compatible example
+## MinIO (S3-compatible) example
 
-MinIO and other S3-compatible object stores use the same `object_store.s3` client as AWS S3. Set `bucket_lookup_type: path` (MinIO's equivalent of the legacy `s3forcepathstyle` option), and `insecure: true` if MinIO is served over plain HTTP:
+MinIO and other S3-compatible object stores use the same `object_store.s3` client as AWS S3. Set `bucket_lookup_type: path`, which is the equivalent of the deprecated `s3forcepathstyle` option. Set `insecure: true` if MinIO is served over plain HTTP.
 
 ```yaml
 auth_enabled: false

--- a/docs/sources/configure/examples/thanos-storage-configs.md
+++ b/docs/sources/configure/examples/thanos-storage-configs.md
@@ -7,7 +7,7 @@ weight: 100
 
 # Configuration examples for using Thanos-based storage clients
 
-Use these examples as a starting point for configuring [Thanos based object storage clients](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#thanos_object_store_config) in Grafana Loki. Each example is a complete configuration you can adapt and run, not just a snippet.
+Use these examples as a starting point for configuring [Thanos-based object storage clients](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#thanos_object_store_config) in Grafana Loki. Each example is a complete configuration you can adapt and run, not just a snippet.
 
 ## GCS example
 

--- a/docs/sources/configure/examples/thanos-storage-configs.md
+++ b/docs/sources/configure/examples/thanos-storage-configs.md
@@ -1,21 +1,49 @@
 ---
 title: "Configuration examples for using Thanos-based storage clients"
 menuTitle: Thanos storage examples
-description: "Minimal examples for using Thanos-based S3, GCS, Azure, and filesystem clients in Grafana Loki."
+description: "Real-world examples for using Thanos-based S3, GCS, Azure, MinIO, and filesystem clients in Grafana Loki."
 weight: 100
 ---
 
 # Configuration examples for using Thanos-based storage clients
 
-Use these examples as a starting point for configuring [Thanos based object storage clients](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#thanos_object_store_config) in Grafana Loki.
+Use these examples as a starting point for configuring [Thanos based object storage clients](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#thanos_object_store_config) in Grafana Loki. Each example is a complete configuration you can adapt and run, not just a snippet.
 
 ## GCS example
+
 ```yaml
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+    - from: 2020-07-01
+      store: tsdb
+      object_store: gcs
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
 storage_config:
   use_thanos_objstore: true
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+    cache_ttl: 24h # Can be increased for faster performance over longer query periods, uses more disk space
   object_store:
     gcs:
-      bucket_name: my-gcs-bucket
+      bucket_name: <BUCKET_NAME>
 
       # JSON either from a Google Developers Console client_credentials.json file,
       # or a Google Developers service account key. Needs to be valid JSON, not a
@@ -44,36 +72,161 @@ storage_config:
 ```
 
 ## S3 example
+
 ```yaml
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+    - from: 2020-07-01
+      store: tsdb
+      object_store: s3
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
 storage_config:
   use_thanos_objstore: true
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+    cache_ttl: 24h
   object_store:
     s3:
-      bucket_name: my-s3-bucket
-      endpoint: s3.us-west-2.amazonaws.com
-      region: us-west-2
+      bucket_name: <BUCKET_NAME>
+      endpoint: <ENDPOINT>
+      region: <REGION>
       # You can either declare the access key and secret in the config or
       # use environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY which will be picked up by the AWS SDK.
-      access_key_id: access-key-id
-      secret_access_key: secret-access-key
+      access_key_id: <ACCESS_KEY_ID>
+      secret_access_key: <SECRET_ACCESS_KEY>
 ```
 
 ## Azure example
+
 ```yaml
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+    - from: 2020-07-01
+      store: tsdb
+      object_store: azure
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
 storage_config:
   use_thanos_objstore: true
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+    cache_ttl: 24h
   object_store:
     azure:
-      account_name: myaccount
+      account_name: <ACCOUNT_NAME>
       account_key: ${SECRET_ACCESS_KEY} # loki expands environment variables
-      container_name: example-container
+      container_name: <CONTAINER_NAME>
+```
+
+## MinIO / S3-compatible example
+
+MinIO and other S3-compatible object stores use the same `object_store.s3` client as AWS S3. Set `bucket_lookup_type: path` (MinIO's equivalent of the legacy `s3forcepathstyle` option), and `insecure: true` if MinIO is served over plain HTTP:
+
+```yaml
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+    - from: 2020-07-01
+      store: tsdb
+      object_store: s3
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  use_thanos_objstore: true
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+    cache_ttl: 24h
+  object_store:
+    s3:
+      bucket_name: <BUCKET_NAME>
+      # Use a fully qualified domain name (fqdn), like localhost, without a scheme.
+      endpoint: <FQDN>:<PORT>
+      access_key_id: <ACCESS_KEY_ID>
+      secret_access_key: <SECRET_ACCESS_KEY>
+      insecure: true
+      bucket_lookup_type: path
 ```
 
 ## Filesystem example
+
 ```yaml
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /tmp/loki
+
+schema_config:
+  configs:
+    - from: 2020-07-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
 storage_config:
   use_thanos_objstore: true
   object_store:
     filesystem:
-      dir: /var/loki/chunks
+      dir: /tmp/loki/chunks
 ```

--- a/docs/sources/configure/examples/yaml/18-Thanos-GCS-Example.yaml
+++ b/docs/sources/configure/examples/yaml/18-Thanos-GCS-Example.yaml
@@ -1,0 +1,35 @@
+# This is a complete configuration to deploy Loki backed by GCS, using the
+# Thanos-based object store client (storage_config.object_store).
+# Index files will be written locally at /loki/index and, eventually, will be shipped to the storage via tsdb-shipper.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: tsdb
+      object_store: gcs
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  use_thanos_objstore: true
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+  object_store:
+    gcs:
+      bucket_name: <BUCKET_NAME>

--- a/docs/sources/configure/examples/yaml/19-Thanos-S3-Example.yaml
+++ b/docs/sources/configure/examples/yaml/19-Thanos-S3-Example.yaml
@@ -1,5 +1,5 @@
-# This is a complete configuration to deploy Loki backed by a s3-compatible API
-# like MinIO for storage, using the Thanos-based object store client (storage_config.object_store).
+# This is a complete configuration to deploy Loki backed by AWS S3,
+# using the Thanos-based object store client (storage_config.object_store).
 # Index files will be written locally at /loki/index and, eventually, will be shipped to the storage via tsdb-shipper.
 
 auth_enabled: false
@@ -33,7 +33,10 @@ storage_config:
   object_store:
     s3:
       bucket_name: <BUCKET_NAME>
-      endpoint: <CUSTOM_ENDPOINT>
+      # The endpoint is required. For AWS, use the regional S3 endpoint.
+      endpoint: s3.<REGION>.amazonaws.com
+      region: <REGION>
+      # Leave the access key and secret unset to use an EC2 instance role, or
+      # the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.
       access_key_id: <ACCESS_KEY_ID>
       secret_access_key: <SECRET_ACCESS_KEY>
-      bucket_lookup_type: path

--- a/docs/sources/configure/examples/yaml/19-Thanos-S3-Example.yaml
+++ b/docs/sources/configure/examples/yaml/19-Thanos-S3-Example.yaml
@@ -1,0 +1,39 @@
+# This is a complete configuration to deploy Loki backed by a s3-compatible API
+# like MinIO for storage, using the Thanos-based object store client (storage_config.object_store).
+# Index files will be written locally at /loki/index and, eventually, will be shipped to the storage via tsdb-shipper.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: tsdb
+      object_store: s3
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  use_thanos_objstore: true
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+  object_store:
+    s3:
+      bucket_name: <BUCKET_NAME>
+      endpoint: <CUSTOM_ENDPOINT>
+      access_key_id: <ACCESS_KEY_ID>
+      secret_access_key: <SECRET_ACCESS_KEY>
+      bucket_lookup_type: path

--- a/docs/sources/configure/examples/yaml/20-Thanos-Azure-Example.yaml
+++ b/docs/sources/configure/examples/yaml/20-Thanos-Azure-Example.yaml
@@ -1,0 +1,37 @@
+# This is a complete configuration to deploy Loki backed by Azure Blob Storage,
+# using the Thanos-based object store client (storage_config.object_store).
+# Index files will be written locally at /loki/index and, eventually, will be shipped to the storage via tsdb-shipper.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: tsdb
+      object_store: azure
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  use_thanos_objstore: true
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+  object_store:
+    azure:
+      account_name: <ACCOUNT_NAME>
+      account_key: <ACCOUNT_KEY>
+      container_name: <CONTAINER_NAME>

--- a/docs/sources/configure/examples/yaml/21-Thanos-MinIO-Example.yaml
+++ b/docs/sources/configure/examples/yaml/21-Thanos-MinIO-Example.yaml
@@ -1,0 +1,41 @@
+# This is a complete configuration to deploy Loki backed by a MinIO cluster,
+# using the Thanos-based object store client (storage_config.object_store).
+# Index files will be written locally at /loki/index and, eventually, will be shipped to the storage via tsdb-shipper.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: tsdb
+      object_store: s3
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  use_thanos_objstore: true
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+  object_store:
+    s3:
+      bucket_name: <BUCKET_NAME>
+      # Use a fully qualified domain name (fqdn), like localhost, without a scheme.
+      endpoint: <FQDN>:<PORT>
+      access_key_id: <ACCESS_KEY_ID>
+      secret_access_key: <SECRET_ACCESS_KEY>
+      insecure: true
+      bucket_lookup_type: path

--- a/docs/sources/configure/storage.md
+++ b/docs/sources/configure/storage.md
@@ -133,7 +133,7 @@ For more information, see the [retention configuration](https://grafana.com/docs
 ## Examples
 
 {{< admonition type="note" >}}
-Loki uses the Thanos based object storage clients by default, because the `use_thanos_objstore` setting defaults to `true`. With this default, Loki reads the configuration under `storage_config.object_store` and ignores the legacy client sections such as `storage_config.aws` or `storage_config.gcs`.
+Loki uses the Thanos-based object storage clients by default, because the `use_thanos_objstore` setting defaults to `true`. With this default, Loki reads the configuration under `storage_config.object_store` and ignores the legacy client sections such as `storage_config.aws` or `storage_config.gcs`.
 
 Each example below shows the Thanos configuration first. The legacy configuration follows it for reference, because the legacy clients are deprecated. To keep using a legacy client, you must set `use_thanos_objstore: false`.
 
@@ -146,7 +146,7 @@ To convert an existing configuration to the new format, refer to [Migrate to Tha
 
 ### GCP deployment (GCS Single Store)
 
-Configuration using the [Thanos based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#gcs-example):
+Configuration using the [Thanos-based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#gcs-example):
 
 ```yaml
 storage_config:
@@ -213,7 +213,7 @@ GCP recommends [Workload Identity Federation](https://cloud.google.com/iam/docs/
 
 ### AWS deployment (S3 Single Store)
 
-Configuration using the [Thanos based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#s3-example):
+Configuration using the [Thanos-based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#s3-example):
 
 ```yaml
 storage_config:
@@ -245,7 +245,7 @@ schema_config:
         period: 24h
 ```
 
-The Thanos based client supports one bucket only. If you previously used `bucketnames` with several buckets, you must consolidate to a single bucket.
+The Thanos-based client supports one bucket only. If you previously used `bucketnames` with several buckets, you must consolidate to a single bucket.
 
 If you don't wish to hard-code S3 credentials, you can use an EC2 instance role instead. Leave `access_key_id` and `secret_access_key` unset. The client then looks for credentials in environment variables, in the AWS credentials file, and finally in the EC2 instance metadata:
 
@@ -354,7 +354,7 @@ This guide assumes a provisioned EKS cluster.
 
 #### Using account name and key
 
-Configuration using the [Thanos based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#azure-example):
+Configuration using the [Thanos-based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#azure-example):
 
 ```yaml
 schema_config:
@@ -431,7 +431,7 @@ storage_config:
 
 #### Using a service principal
 
-The [Thanos based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#azure-example) has no service principal settings in `storage_config`. Instead, pass the credentials in the standard environment variables read by the [Azure Identity Client Module for Go](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity), which are `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET`. Leave `account_key` unset so that Loki uses those credentials. You must still set `account_name`, because Loki uses it to build the storage URL.
+The [Thanos-based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#azure-example) has no service principal settings in `storage_config`. Instead, pass the credentials in the standard environment variables read by the [Azure Identity Client Module for Go](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity), which are `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET`. Leave `account_key` unset so that Loki uses those credentials. You must still set `account_name`, because Loki uses it to build the storage URL.
 
 ```yaml
 schema_config:
@@ -491,9 +491,9 @@ storage_config:
 ### IBM Deployment (COS Single Store)
 
 {{< admonition type="note" >}}
-The Thanos based object store client does not support IBM COS. Because `use_thanos_objstore` defaults to `true`, you must set it to `false` to use COS. If you leave the default in place, Loki fails to start with the error `unrecognized object_store type cos`.
+The Thanos-based object store client does not support IBM COS. Because `use_thanos_objstore` defaults to `true`, you must set it to `false` to use COS. If you leave the default in place, Loki fails to start with the error `unrecognized object_store type cos`.
 
-For the list of backends that the Thanos based client supports, refer to the [Thanos storage configuration reference](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#thanos_object_store_config).
+For the list of backends that the Thanos-based client supports, refer to the [Thanos storage configuration reference](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#thanos_object_store_config).
 {{< /admonition >}}
 
 ```yaml
@@ -508,7 +508,7 @@ schema_config:
       store: tsdb
 
 storage_config:
-  use_thanos_objstore: false # COS is not supported by the Thanos based client
+  use_thanos_objstore: false # COS is not supported by the Thanos-based client
   tsdb_shipper:
     active_index_directory: /loki/index
     cache_location: /loki/index_cache
@@ -525,7 +525,7 @@ storage_config:
 
 You configure MinIO by using the S3 settings, because MinIO implements the S3 API.
 
-Configuration using the [Thanos based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#minio-s3-compatible-example):
+Configuration using the [Thanos-based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#minio-s3-compatible-example):
 
 ```yaml
 storage_config:

--- a/docs/sources/configure/storage.md
+++ b/docs/sources/configure/storage.md
@@ -145,12 +145,41 @@ storage_config:
     cache_location: /loki/index_cache
     cache_ttl: 24h # Can be increased for faster performance over longer query periods, uses more disk space
   gcs:
-    bucket_name: <bucket>
+    bucket_name: <BUCKET_NAME>
     service_account: |
       {
         "type": "service_account",
         ...
       }
+
+schema_config:
+  configs:
+    - from: 2020-07-01
+      store: tsdb
+      object_store: gcs
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+```
+
+Equivalent configuration using the [Thanos-based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#gcs-example):
+
+```yaml
+storage_config:
+  use_thanos_objstore: true
+  object_store:
+    gcs:
+      bucket_name: <BUCKET_NAME>
+      service_account: |
+        {
+          "type": "service_account",
+          ...
+        }
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+    cache_ttl: 24h
 
 schema_config:
   configs:
@@ -180,8 +209,8 @@ storage_config:
     cache_location: /loki/index_cache
     cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
   aws:
-    s3: s3://<access_key>:<uri-encoded-secret-access-key>@<region>
-    bucketnames: <bucket1,bucket2>
+    s3: s3://<ACCESS_KEY>:<URI_ENCODED_SECRET_ACCESS_KEY>@<REGION>
+    bucketnames: <BUCKET_1>,<BUCKET_2>
 
 schema_config:
   configs:
@@ -194,14 +223,58 @@ schema_config:
         period: 24h
 ```
 
+Equivalent configuration using the [Thanos-based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#s3-example):
+
+```yaml
+storage_config:
+  use_thanos_objstore: true
+  object_store:
+    s3:
+      bucket_name: <BUCKET_NAME>
+      endpoint: <REGION>.amazonaws.com
+      region: <REGION>
+      # You can either declare the access key and secret in the config or
+      # use environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY,
+      # which will be picked up by the AWS SDK.
+      access_key_id: <ACCESS_KEY_ID>
+      secret_access_key: <SECRET_ACCESS_KEY>
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+    cache_ttl: 24h
+
+schema_config:
+  configs:
+    - from: 2020-07-01
+      store: tsdb
+      object_store: s3
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+```
+
+Note that the Thanos-based client only supports a single bucket. If you previously used `bucketnames` with multiple buckets, consolidate to one bucket.
+
 If you don't wish to hard-code S3 credentials, you can also configure an EC2
 instance role by changing the `storage_config` section:
 
 ```yaml
 storage_config:
   aws:
-    s3: s3://region
-    bucketnames: <bucket1,bucket2>
+    s3: s3://<REGION>
+    bucketnames: <BUCKET_1>,<BUCKET_2>
+```
+
+The Thanos-based client picks up the same EC2 instance role automatically when `access_key_id` and `secret_access_key` are left unset:
+
+```yaml
+storage_config:
+  use_thanos_objstore: true
+  object_store:
+    s3:
+      bucket_name: <BUCKET_NAME>
+      region: <REGION>
 ```
 
 The role should have a policy with the following permissions attached.
@@ -215,7 +288,7 @@ The role should have a policy with the following permissions attached.
             "Effect": "Allow",
             "Principal": {
                 "AWS": [
-                    "arn:aws:iam::<account_ID>"
+                    "arn:aws:iam::<ACCOUNT_ID>"
                 ]
             },
             "Action": [
@@ -225,8 +298,8 @@ The role should have a policy with the following permissions attached.
                 "s3:DeleteObject"
             ],
             "Resource": [
-                "arn:aws:s3:::<bucket_name>",
-                "arn:aws:s3:::<bucket_name>/*"
+                "arn:aws:s3:::<BUCKET_NAME>",
+                "arn:aws:s3:::<BUCKET_NAME>/*"
             ]
         }
     ]
@@ -244,19 +317,19 @@ This guide assumes a provisioned EKS cluster.
 3. Export the AWS profile and region if not done so:
 
    ```bash
-   export AWS_PROFILE=<profile in ~/.aws/config>
-   export AWS_REGION=<region of EKS cluster>
+   export AWS_PROFILE=<AWS_PROFILE_NAME>
+   export AWS_REGION=<EKS_CLUSTER_REGION>
    ```
 
 4. Save the OIDC provider in an environment variable:
 
    ```bash
-   oidc_provider=$(aws eks describe-cluster --name <EKS cluster> --query "cluster.identity.oidc.issuer" --output text | sed -e "s/^https:\/\///")
+   oidc_provider=$(aws eks describe-cluster --name <EKS_CLUSTER_NAME> --query "cluster.identity.oidc.issuer" --output text | sed -e "s/^https:\/\///")
    ```
 
    See the [IAM OIDC provider guide](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) for a guide for creating a provider.
 
-5. Apply the Terraform module `terraform -var region="$AWS_REGION" -var cluster_name=<EKS cluster> -var oidc_id="$oidc_provider"`
+5. Apply the Terraform module `terraform -var region="$AWS_REGION" -var cluster_name=<EKS_CLUSTER_NAME> -var oidc_id="$oidc_provider"`
 
    Note, the bucket name defaults to `loki-data` but can be changed via the
    `bucket_name` variable.
@@ -278,25 +351,53 @@ schema_config:
 storage_config:
   azure:
     # Your Azure storage account name
-    account_name: <account-name>
+    account_name: <ACCOUNT_NAME>
     # For the account-key, see docs: https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage?tabs=azure-portal
-    account_key: <account-key>
+    account_key: <ACCOUNT_KEY>
     # See https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction#containers
-    container_name: <container-name>
-    use_managed_identity: <true|false>
+    container_name: <CONTAINER_NAME>
+    use_managed_identity: <TRUE|FALSE>
     # Providing a user assigned ID will override use_managed_identity
-    user_assigned_id: <user-assigned-identity-id>
+    user_assigned_id: <USER_ASSIGNED_IDENTITY_ID>
     request_timeout: 0
     # Configure this if you are using private azure cloud like azure stack hub and will use this endpoint suffix to compose container and blob storage URL. Ex: https://account_name.endpoint_suffix/container_name/blob_name
-    endpoint_suffix: <endpoint-suffix>
+    endpoint_suffix: <ENDPOINT_SUFFIX>
     # If `connection_string` is set, the values of `account_name` and `endpoint_suffix` values will not be used. Use this method over `account_key` if you need to authenticate via a SAS token. Or if you use the Azurite emulator.
-    connection_string: <connection-string>
+    connection_string: <CONNECTION_STRING>
   tsdb_shipper:
     active_index_directory: /loki/index
     cache_location: /loki/index_cache
     cache_ttl: 24h
   filesystem:
     directory: /loki/chunks
+```
+
+Equivalent configuration using the [Thanos-based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#azure-example):
+
+```yaml
+schema_config:
+  configs:
+    - from: "2020-12-11"
+      index:
+        period: 24h
+        prefix: index_
+      object_store: azure
+      schema: v13
+      store: tsdb
+storage_config:
+  use_thanos_objstore: true
+  object_store:
+    azure:
+      account_name: <ACCOUNT_NAME>
+      account_key: <ACCOUNT_KEY>
+      container_name: <CONTAINER_NAME>
+      user_assigned_id: <USER_ASSIGNED_IDENTITY_ID>
+      endpoint_suffix: <ENDPOINT_SUFFIX>
+      connection_string: <CONNECTION_STRING>
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+    cache_ttl: 24h
 ```
 
 #### Using a service principal
@@ -315,13 +416,13 @@ storage_config:
   azure:
     use_service_principal: true
     # Azure tenant ID used to authenticate through Azure OAuth
-    tenant_id : <tenant-id>
+    tenant_id : <TENANT_ID>
     # Azure Service Principal ID
-    client_id: <client-id>
+    client_id: <CLIENT_ID>
     # Azure Service Principal secret key
-    client_secret: <client-secret>
+    client_secret: <CLIENT_SECRET>
     # See https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction#containers
-    container_name: <container-name>
+    container_name: <CONTAINER_NAME>
     request_timeout: 0
   tsdb_shipper:
     active_index_directory: /loki/index
@@ -329,6 +430,31 @@ storage_config:
     cache_ttl: 24h
   filesystem:
     directory: /loki/chunks
+```
+
+Equivalent configuration using the [Thanos-based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#azure-example):
+
+Loki's Azure Thanos client doesn't have a dedicated service principal option in `storage_config`. Instead, pass the necessary credentials using the standard [Azure Identity Client Module for Go](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity) environment variables (for example `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET`), then configure only the container name:
+
+```yaml
+schema_config:
+  configs:
+    - from: "2020-12-11"
+      index:
+        period: 24h
+        prefix: index_
+      object_store: azure
+      schema: v13
+      store: tsdb
+storage_config:
+  use_thanos_objstore: true
+  object_store:
+    azure:
+      container_name: <CONTAINER_NAME>
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+    cache_ttl: 24h
 ```
 
 ### IBM Deployment (COS Single Store)
@@ -349,13 +475,17 @@ storage_config:
     active_index_directory: /loki/index
     cache_location: /loki/index_cache
   cos:
-    bucketnames: <bucket1, bucket2>
-    endpoint: <endpoint>
-    api_key: <api_key_to_authenticate_with_cos>
-    region: <region>
-    service_instance_id: <cos_service_instance_id>
-    auth_endpoint: <iam_endpoint_for_authentication>
+    bucketnames: <BUCKET_1>, <BUCKET_2>
+    endpoint: <ENDPOINT>
+    api_key: <API_KEY_TO_AUTHENTICATE_WITH_COS>
+    region: <REGION>
+    service_instance_id: <COS_SERVICE_INSTANCE_ID>
+    auth_endpoint: <IAM_ENDPOINT_FOR_AUTHENTICATION>
 ```
+
+{{< admonition type="note" >}}
+IBM COS is not yet supported by the Thanos-based object store client, so `storage_config.cos` (shown above) remains the only way to configure COS. Set `use_thanos_objstore: false` explicitly if the default changes in a future release. See the [Thanos storage configuration examples](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/) for the backends that are currently supported.
+{{< /admonition >}}
 
 ### On premise deployment (MinIO Single Store)
 
@@ -366,12 +496,42 @@ storage_config:
   aws:
     # Note: use a fully qualified domain name (fqdn), like localhost.
     # full example: http://loki:supersecret@localhost.:9000
-    s3: http<s>://<username>:<secret>@<fqdn>:<port>
+    s3: http(s)://<USERNAME>:<SECRET>@<FQDN>:<PORT>
     s3forcepathstyle: true
   tsdb_shipper:
     active_index_directory: /loki/index
     cache_location: /loki/index_cache
     cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
+
+schema_config:
+  configs:
+    - from: 2020-07-01
+      store: tsdb
+      object_store: s3
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+```
+
+Equivalent configuration using the [Thanos-based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#minio-s3-compatible-example):
+
+```yaml
+storage_config:
+  use_thanos_objstore: true
+  object_store:
+    s3:
+      bucket_name: <BUCKET_NAME>
+      # Use a fully qualified domain name (fqdn), like localhost, without a scheme.
+      endpoint: <FQDN>:<PORT>
+      access_key_id: <USERNAME>
+      secret_access_key: <SECRET>
+      insecure: true            # set to false if MinIO is served over https
+      bucket_lookup_type: path  # MinIO's equivalent of s3forcepathstyle
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+    cache_ttl: 24h
 
 schema_config:
   configs:

--- a/docs/sources/configure/storage.md
+++ b/docs/sources/configure/storage.md
@@ -132,38 +132,21 @@ For more information, see the [retention configuration](https://grafana.com/docs
 
 ## Examples
 
+{{< admonition type="note" >}}
+Loki uses the Thanos based object storage clients by default, because the `use_thanos_objstore` setting defaults to `true`. With this default, Loki reads the configuration under `storage_config.object_store` and ignores the legacy client sections such as `storage_config.aws` or `storage_config.gcs`.
+
+Each example below shows the Thanos configuration first. The legacy configuration follows it for reference, because the legacy clients are deprecated. To keep using a legacy client, you must set `use_thanos_objstore: false`.
+
+To convert an existing configuration to the new format, refer to [Migrate to Thanos storage clients](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/migrate/migrate-storage-clients/).
+{{< /admonition >}}
+
 ### Single machine/local development (tsdb+filesystem)
 
 [The repo contains a working example](https://github.com/grafana/loki/blob/main/cmd/loki/loki-local-config.yaml), you may want to checkout a tag of the repo to make sure you get a compatible example.
 
 ### GCP deployment (GCS Single Store)
 
-```yaml
-storage_config:
-  tsdb_shipper:
-    active_index_directory: /loki/index
-    cache_location: /loki/index_cache
-    cache_ttl: 24h # Can be increased for faster performance over longer query periods, uses more disk space
-  gcs:
-    bucket_name: <BUCKET_NAME>
-    service_account: |
-      {
-        "type": "service_account",
-        ...
-      }
-
-schema_config:
-  configs:
-    - from: 2020-07-01
-      store: tsdb
-      object_store: gcs
-      schema: v13
-      index:
-        prefix: index_
-        period: 24h
-```
-
-Equivalent configuration using the [Thanos-based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#gcs-example):
+Configuration using the [Thanos based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#gcs-example):
 
 ```yaml
 storage_config:
@@ -179,7 +162,35 @@ storage_config:
   tsdb_shipper:
     active_index_directory: /loki/index
     cache_location: /loki/index_cache
+    cache_ttl: 24h # Can be increased for faster performance over longer query periods, uses more disk space
+
+schema_config:
+  configs:
+    - from: 2020-07-01
+      store: tsdb
+      object_store: gcs
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+```
+
+The same deployment using the deprecated GCS client:
+
+```yaml
+storage_config:
+  use_thanos_objstore: false # required to use the deprecated client
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
     cache_ttl: 24h
+  gcs:
+    bucket_name: <BUCKET_NAME>
+    service_account: |
+      {
+        "type": "service_account",
+        ...
+      }
 
 schema_config:
   configs:
@@ -202,12 +213,61 @@ GCP recommends [Workload Identity Federation](https://cloud.google.com/iam/docs/
 
 ### AWS deployment (S3 Single Store)
 
+Configuration using the [Thanos based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#s3-example):
+
 ```yaml
 storage_config:
+  use_thanos_objstore: true
+  object_store:
+    s3:
+      bucket_name: <BUCKET_NAME>
+      # The endpoint is required. For AWS, use the regional S3 endpoint.
+      endpoint: s3.<REGION>.amazonaws.com
+      region: <REGION>
+      # You can either declare the access key and secret in the config or
+      # use environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY,
+      # which will be picked up by the AWS SDK.
+      access_key_id: <ACCESS_KEY_ID>
+      secret_access_key: <SECRET_ACCESS_KEY>
   tsdb_shipper:
     active_index_directory: /loki/index
     cache_location: /loki/index_cache
     cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
+
+schema_config:
+  configs:
+    - from: 2020-07-01
+      store: tsdb
+      object_store: s3
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+```
+
+The Thanos based client supports one bucket only. If you previously used `bucketnames` with several buckets, you must consolidate to a single bucket.
+
+If you don't wish to hard-code S3 credentials, you can use an EC2 instance role instead. Leave `access_key_id` and `secret_access_key` unset. The client then looks for credentials in environment variables, in the AWS credentials file, and finally in the EC2 instance metadata:
+
+```yaml
+storage_config:
+  use_thanos_objstore: true
+  object_store:
+    s3:
+      bucket_name: <BUCKET_NAME>
+      endpoint: s3.<REGION>.amazonaws.com
+      region: <REGION>
+```
+
+The same deployment using the deprecated S3 client:
+
+```yaml
+storage_config:
+  use_thanos_objstore: false # required to use the deprecated client
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+    cache_ttl: 24h
   aws:
     s3: s3://<ACCESS_KEY>:<URI_ENCODED_SECRET_ACCESS_KEY>@<REGION>
     bucketnames: <BUCKET_1>,<BUCKET_2>
@@ -223,58 +283,14 @@ schema_config:
         period: 24h
 ```
 
-Equivalent configuration using the [Thanos-based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#s3-example):
+To use an EC2 instance role with the deprecated client, change the `storage_config` section:
 
 ```yaml
 storage_config:
-  use_thanos_objstore: true
-  object_store:
-    s3:
-      bucket_name: <BUCKET_NAME>
-      endpoint: <REGION>.amazonaws.com
-      region: <REGION>
-      # You can either declare the access key and secret in the config or
-      # use environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY,
-      # which will be picked up by the AWS SDK.
-      access_key_id: <ACCESS_KEY_ID>
-      secret_access_key: <SECRET_ACCESS_KEY>
-  tsdb_shipper:
-    active_index_directory: /loki/index
-    cache_location: /loki/index_cache
-    cache_ttl: 24h
-
-schema_config:
-  configs:
-    - from: 2020-07-01
-      store: tsdb
-      object_store: s3
-      schema: v13
-      index:
-        prefix: index_
-        period: 24h
-```
-
-Note that the Thanos-based client only supports a single bucket. If you previously used `bucketnames` with multiple buckets, consolidate to one bucket.
-
-If you don't wish to hard-code S3 credentials, you can also configure an EC2
-instance role by changing the `storage_config` section:
-
-```yaml
-storage_config:
+  use_thanos_objstore: false
   aws:
     s3: s3://<REGION>
     bucketnames: <BUCKET_1>,<BUCKET_2>
-```
-
-The Thanos-based client picks up the same EC2 instance role automatically when `access_key_id` and `secret_access_key` are left unset:
-
-```yaml
-storage_config:
-  use_thanos_objstore: true
-  object_store:
-    s3:
-      bucket_name: <BUCKET_NAME>
-      region: <REGION>
 ```
 
 The role should have a policy with the following permissions attached.
@@ -338,6 +354,8 @@ This guide assumes a provisioned EKS cluster.
 
 #### Using account name and key
 
+Configuration using the [Thanos based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#azure-example):
+
 ```yaml
 schema_config:
   configs:
@@ -349,6 +367,45 @@ schema_config:
       schema: v13
       store: tsdb
 storage_config:
+  use_thanos_objstore: true
+  object_store:
+    azure:
+      # Your Azure storage account name
+      account_name: <ACCOUNT_NAME>
+      # See https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction#containers
+      container_name: <CONTAINER_NAME>
+      # For the account key, see https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage?tabs=azure-portal
+      # If you leave the account key unset, Loki uses an Azure managed identity instead.
+      account_key: <ACCOUNT_KEY>
+      # Set this to use a user assigned managed identity. If you leave it empty,
+      # Loki uses the system assigned identity.
+      user_assigned_id: <USER_ASSIGNED_IDENTITY_ID>
+      # Configure this if you use a private Azure cloud, such as Azure Stack Hub.
+      # Loki composes the storage URL as https://account_name.endpoint_suffix/container_name/blob_name
+      endpoint_suffix: <ENDPOINT_SUFFIX>
+      # If `connection_string` is set, the `account_name` and `endpoint_suffix` values are not used.
+      # Use this instead of `account_key` to authenticate with a SAS token, or to use the Azurite emulator.
+      connection_string: <CONNECTION_STRING>
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+    cache_ttl: 24h
+```
+
+The same deployment using the deprecated Azure Blob Storage client:
+
+```yaml
+schema_config:
+  configs:
+    - from: "2020-12-11"
+      index:
+        period: 24h
+        prefix: index_
+      object_store: azure
+      schema: v13
+      store: tsdb
+storage_config:
+  use_thanos_objstore: false # required to use the deprecated client
   azure:
     # Your Azure storage account name
     account_name: <ACCOUNT_NAME>
@@ -372,7 +429,9 @@ storage_config:
     directory: /loki/chunks
 ```
 
-Equivalent configuration using the [Thanos-based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#azure-example):
+#### Using a service principal
+
+The [Thanos based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#azure-example) has no service principal settings in `storage_config`. Instead, pass the credentials in the standard environment variables read by the [Azure Identity Client Module for Go](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity), which are `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET`. Leave `account_key` unset so that Loki uses those credentials. You must still set `account_name`, because Loki uses it to build the storage URL.
 
 ```yaml
 schema_config:
@@ -389,18 +448,14 @@ storage_config:
   object_store:
     azure:
       account_name: <ACCOUNT_NAME>
-      account_key: <ACCOUNT_KEY>
       container_name: <CONTAINER_NAME>
-      user_assigned_id: <USER_ASSIGNED_IDENTITY_ID>
-      endpoint_suffix: <ENDPOINT_SUFFIX>
-      connection_string: <CONNECTION_STRING>
   tsdb_shipper:
     active_index_directory: /loki/index
     cache_location: /loki/index_cache
     cache_ttl: 24h
 ```
 
-#### Using a service principal
+The same deployment using the deprecated Azure Blob Storage client:
 
 ```yaml
 schema_config:
@@ -413,6 +468,7 @@ schema_config:
       schema: v13
       store: tsdb
 storage_config:
+  use_thanos_objstore: false # required to use the deprecated client
   azure:
     use_service_principal: true
     # Azure tenant ID used to authenticate through Azure OAuth
@@ -432,32 +488,13 @@ storage_config:
     directory: /loki/chunks
 ```
 
-Equivalent configuration using the [Thanos-based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#azure-example):
-
-Loki's Azure Thanos client doesn't have a dedicated service principal option in `storage_config`. Instead, pass the necessary credentials using the standard [Azure Identity Client Module for Go](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity) environment variables (for example `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET`), then configure only the container name:
-
-```yaml
-schema_config:
-  configs:
-    - from: "2020-12-11"
-      index:
-        period: 24h
-        prefix: index_
-      object_store: azure
-      schema: v13
-      store: tsdb
-storage_config:
-  use_thanos_objstore: true
-  object_store:
-    azure:
-      container_name: <CONTAINER_NAME>
-  tsdb_shipper:
-    active_index_directory: /loki/index
-    cache_location: /loki/index_cache
-    cache_ttl: 24h
-```
-
 ### IBM Deployment (COS Single Store)
+
+{{< admonition type="note" >}}
+The Thanos based object store client does not support IBM COS. Because `use_thanos_objstore` defaults to `true`, you must set it to `false` to use COS. If you leave the default in place, Loki fails to start with the error `unrecognized object_store type cos`.
+
+For the list of backends that the Thanos based client supports, refer to the [Thanos storage configuration reference](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#thanos_object_store_config).
+{{< /admonition >}}
 
 ```yaml
 schema_config:
@@ -471,6 +508,7 @@ schema_config:
       store: tsdb
 
 storage_config:
+  use_thanos_objstore: false # COS is not supported by the Thanos based client
   tsdb_shipper:
     active_index_directory: /loki/index
     cache_location: /loki/index_cache
@@ -483,21 +521,24 @@ storage_config:
     auth_endpoint: <IAM_ENDPOINT_FOR_AUTHENTICATION>
 ```
 
-{{< admonition type="note" >}}
-IBM COS is not yet supported by the Thanos-based object store client, so `storage_config.cos` (shown above) remains the only way to configure COS. Set `use_thanos_objstore: false` explicitly if the default changes in a future release. See the [Thanos storage configuration examples](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/) for the backends that are currently supported.
-{{< /admonition >}}
-
 ### On premise deployment (MinIO Single Store)
 
-You configure MinIO by using the AWS config because MinIO implements the S3 API:
+You configure MinIO by using the S3 settings, because MinIO implements the S3 API.
+
+Configuration using the [Thanos based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#minio-s3-compatible-example):
 
 ```yaml
 storage_config:
-  aws:
-    # Note: use a fully qualified domain name (fqdn), like localhost.
-    # full example: http://loki:supersecret@localhost.:9000
-    s3: http(s)://<USERNAME>:<SECRET>@<FQDN>:<PORT>
-    s3forcepathstyle: true
+  use_thanos_objstore: true
+  object_store:
+    s3:
+      bucket_name: <BUCKET_NAME>
+      # Use a fully qualified domain name (fqdn), like localhost, without a scheme.
+      endpoint: <FQDN>:<PORT>
+      access_key_id: <USERNAME>
+      secret_access_key: <SECRET>
+      insecure: true            # set to false if MinIO is served over https
+      bucket_lookup_type: path  # MinIO's equivalent of s3forcepathstyle
   tsdb_shipper:
     active_index_directory: /loki/index
     cache_location: /loki/index_cache
@@ -514,20 +555,16 @@ schema_config:
         period: 24h
 ```
 
-Equivalent configuration using the [Thanos-based object store client](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/examples/thanos-storage-configs/#minio-s3-compatible-example):
+The same deployment using the deprecated S3 client:
 
 ```yaml
 storage_config:
-  use_thanos_objstore: true
-  object_store:
-    s3:
-      bucket_name: <BUCKET_NAME>
-      # Use a fully qualified domain name (fqdn), like localhost, without a scheme.
-      endpoint: <FQDN>:<PORT>
-      access_key_id: <USERNAME>
-      secret_access_key: <SECRET>
-      insecure: true            # set to false if MinIO is served over https
-      bucket_lookup_type: path  # MinIO's equivalent of s3forcepathstyle
+  use_thanos_objstore: false # required to use the deprecated client
+  aws:
+    # Note: use a fully qualified domain name (fqdn), like localhost.
+    # full example: http://loki:supersecret@localhost.:9000
+    s3: http(s)://<USERNAME>:<SECRET>@<FQDN>:<PORT>
+    s3forcepathstyle: true
   tsdb_shipper:
     active_index_directory: /loki/index
     cache_location: /loki/index_cache

--- a/docs/sources/setup/install/helm/configure-storage/_index.md
+++ b/docs/sources/setup/install/helm/configure-storage/_index.md
@@ -26,6 +26,8 @@ This guide assumes Loki will be installed in one of the modes above and that a `
 
 1. Set `loki.storage.bucketNames.chunks` and `loki.storage.bucketNames.ruler` to your bucket or container names.
 
+These values configure the legacy storage clients, which are deprecated. To use the Thanos based clients instead, refer to the following section.
+
 **To install Minio alongside Loki:**
 
 {{< admonition type="warning" >}}
@@ -42,11 +44,13 @@ The built-in MinIO subchart is deprecated and will be removed on 2026-10-31. Set
       enabled: true
     ```
 
-**To use Thanos object store clients (experimental):**
+**To use Thanos object store clients:**
 
-Loki supports using Thanos-compatible storage clients as an alternative to the built-in storage clients. This is configured via `loki.storage.use_thanos_objstore` and will become the default in a future release.
+Loki 4.0 uses object storage clients based on the [Thanos Object Storage Client Go module](https://github.com/thanos-io/objstore) by default, and the legacy storage clients are deprecated. The Helm chart is an exception, because it sets `loki.storage.use_thanos_objstore` to `false`. To use the Thanos based clients with the chart, you must set this value to `true` yourself.
 
-1. Enable Thanos object store in `values.yaml`:
+To convert an existing storage configuration to the new format, refer to [Migrate to Thanos storage clients](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/migrate/migrate-storage-clients/).
+
+1. Enable the Thanos based clients in `values.yaml`:
 
    ```yaml
    loki:

--- a/docs/sources/setup/install/helm/configure-storage/_index.md
+++ b/docs/sources/setup/install/helm/configure-storage/_index.md
@@ -26,7 +26,7 @@ This guide assumes Loki will be installed in one of the modes above and that a `
 
 1. Set `loki.storage.bucketNames.chunks` and `loki.storage.bucketNames.ruler` to your bucket or container names.
 
-These values configure the legacy storage clients, which are deprecated. To use the Thanos based clients instead, refer to the following section.
+These values configure the legacy storage clients, which are deprecated. To use the Thanos-based clients instead, refer to the following section.
 
 **To install Minio alongside Loki:**
 
@@ -46,11 +46,11 @@ The built-in MinIO subchart is deprecated and will be removed on 2026-10-31. Set
 
 **To use Thanos object store clients:**
 
-Loki 4.0 uses object storage clients based on the [Thanos Object Storage Client Go module](https://github.com/thanos-io/objstore) by default, and the legacy storage clients are deprecated. The Helm chart is an exception, because it sets `loki.storage.use_thanos_objstore` to `false`. To use the Thanos based clients with the chart, you must set this value to `true` yourself.
+Loki 4.0 uses object storage clients based on the [Thanos Object Storage Client Go module](https://github.com/thanos-io/objstore) by default, and the legacy storage clients are deprecated. The Helm chart is an exception, because it sets `loki.storage.use_thanos_objstore` to `false`. To use the Thanos-based clients with the chart, you must set this value to `true` yourself.
 
 To convert an existing storage configuration to the new format, refer to [Migrate to Thanos storage clients](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/migrate/migrate-storage-clients/).
 
-1. Enable the Thanos based clients in `values.yaml`:
+1. Enable the Thanos-based clients in `values.yaml`:
 
    ```yaml
    loki:

--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -457,4 +457,4 @@ We recommend running Loki at scale within a cloud environment like AWS, Azure, o
 ## Next Steps
 
 * Configure an agent to [send log data to Loki](/docs/loki/<LOKI_VERSION>/send-data/).
-* Monitor the Loki deployment using the [Meta Monitoring Helm chart](/docs/loki/<LOKI_VERSION>/setup/install/helm/monitor-and-alert/)
+* [Monitor the Loki deployment](/docs/loki/<LOKI_VERSION>/setup/install/helm/monitor-and-alert/), using the recommended Kubernetes monitoring Helm chart.

--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -461,4 +461,4 @@ We recommend running Loki at scale within a cloud environment like AWS, Azure, o
 ## Next Steps
 
 * Configure an agent to [send log data to Loki](/docs/loki/<LOKI_VERSION>/send-data/).
-* Monitor the Loki deployment using the [Meta Monitoring Helm chart](/docs/loki/<LOKI_VERSION>/setup/install/helm/monitor-and-alert/)
+* [Monitor the Loki deployment](/docs/loki/<LOKI_VERSION>/setup/install/helm/monitor-and-alert/), using the recommended Kubernetes monitoring Helm chart.

--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -457,4 +457,4 @@ We recommend running Loki at scale within a cloud environment like AWS, Azure, o
 ## Next Steps
 
 * Configure an agent to [send log data to Loki](/docs/loki/<LOKI_VERSION>/send-data/).
-* [Monitor the Loki deployment](/docs/loki/<LOKI_VERSION>/setup/install/helm/monitor-and-alert/), using the recommended Kubernetes monitoring Helm chart.
+* Monitor the Loki deployment using the [Meta Monitoring Helm chart](/docs/loki/<LOKI_VERSION>/setup/install/helm/monitor-and-alert/)

--- a/docs/sources/setup/install/helm/install-monolithic/_index.md
+++ b/docs/sources/setup/install/helm/install-monolithic/_index.md
@@ -461,4 +461,4 @@ We recommend running Loki at scale within a cloud environment like AWS, Azure, o
 ## Next Steps
 
 * Configure an agent to [send log data to Loki](/docs/loki/<LOKI_VERSION>/send-data/).
-* [Monitor the Loki deployment](/docs/loki/<LOKI_VERSION>/setup/install/helm/monitor-and-alert/), using the recommended Kubernetes monitoring Helm chart.
+* Monitor the Loki deployment using the [Meta Monitoring Helm chart](/docs/loki/<LOKI_VERSION>/setup/install/helm/monitor-and-alert/)

--- a/docs/sources/setup/migrate/migrate-storage-clients/_index.md
+++ b/docs/sources/setup/migrate/migrate-storage-clients/_index.md
@@ -10,25 +10,27 @@ keywords:
 ---
 # Migrate to Thanos storage clients
 
-Loki release 3.4 introduces new object storage clients based on the [Thanos Object Storage Client Go module](https://github.com/thanos-io/objstore).
+Loki has object storage clients based on the [Thanos Object Storage Client Go module](https://github.com/thanos-io/objstore). These clients were added in Loki 3.4.
 
 One of the reasons for making this change is to have a consistent storage configuration across Grafana Loki, Mimir and other telemetry databases from Grafana Labs. If you are already using Grafana Mimir or Pyroscope, you can reuse the storage configuration for setting up Loki.
 
-This is an opt-in feature with the Loki 3.4 release. In a future release, Thanos will become the default way of configuring storage and the existing storage clients will be deprecated.
+Loki 4.0 uses the Thanos based clients by default, because the `use_thanos_objstore` setting defaults to `true`. The legacy storage clients are deprecated. Use this guide to convert your storage configuration to the new format. If you are not ready to migrate, set `use_thanos_objstore` to `false` to keep using the legacy clients.
+
+In Loki 3.4 and later 3.x releases, the Thanos based clients are optional. To use them in those releases, set `use_thanos_objstore` to `true`.
 
 {{< admonition type="note" >}}
 The new storage configuration deviates from the existing format. The following sections describe the changes in detail for each provider.
 Refer to the [Thanos storage configuration reference](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#thanos_object_store_config) to view the complete list of supported storage providers and their configuration options.
 {{< /admonition >}}
 
-### Enable the new storage clients
+### Configure the new storage clients
 
-1. Enable Thanos storage clients by setting `use_thanos_objstore` to `true` in the `storage_config` section or by setting the `-use-thanos-objstore` flag to true. When enabled, configuration under `storage_config.object_store` takes effect instead of existing storage configurations.
+1. Configure your object storage under `storage_config.object_store`. When the Thanos based clients are in use, Loki reads this section instead of the legacy storage configuration. In Loki 3.x, you must also set `use_thanos_objstore` to `true` in the `storage_config` section, or set the `-use-thanos-objstore` flag to `true`. The following examples set this option explicitly, which is also valid in Loki 4.0.
 
    ```yaml
    # Uses the new storage clients for connecting to gcs backend
    storage_config:
-     use_thanos_objstore: true # enable the new storage clients
+     use_thanos_objstore: true # use the Thanos based storage clients
      object_store:
        gcs:
          bucket_name: "example-bucket"
@@ -38,7 +40,7 @@ Refer to the [Thanos storage configuration reference](https://grafana.com/docs/l
 
    ```yaml
    storage_config:
-      use_thanos_objstore: true # enable the new storage clients
+      use_thanos_objstore: true # use the Thanos based storage clients
    common:
      storage:
        object_store:
@@ -50,7 +52,7 @@ Refer to the [Thanos storage configuration reference](https://grafana.com/docs/l
 
    ```yaml
    storage_config:
-      use_thanos_objstore: true # enable the new storage clients
+      use_thanos_objstore: true # use the Thanos based storage clients
    ruler_storage:
       backend: gcs
       gcs:
@@ -62,7 +64,7 @@ Refer to the [Thanos storage configuration reference](https://grafana.com/docs/l
    ```yaml
    # Example configuration to prefix all objects with "prefix"
    storage_config:
-      use_thanos_objstore: true # enable the new storage clients
+      use_thanos_objstore: true # use the Thanos based storage clients
       object_store:
          storage_prefix: "prefix"
    ```

--- a/docs/sources/setup/migrate/migrate-storage-clients/_index.md
+++ b/docs/sources/setup/migrate/migrate-storage-clients/_index.md
@@ -14,9 +14,9 @@ Loki has object storage clients based on the [Thanos Object Storage Client Go mo
 
 One of the reasons for making this change is to have a consistent storage configuration across Grafana Loki, Mimir and other telemetry databases from Grafana Labs. If you are already using Grafana Mimir or Pyroscope, you can reuse the storage configuration for setting up Loki.
 
-Loki 4.0 uses the Thanos based clients by default, because the `use_thanos_objstore` setting defaults to `true`. The legacy storage clients are deprecated. Use this guide to convert your storage configuration to the new format. If you are not ready to migrate, set `use_thanos_objstore` to `false` to keep using the legacy clients.
+Loki 4.0 uses the Thanos-based clients by default, because the `use_thanos_objstore` setting defaults to `true`. The legacy storage clients are deprecated. Use this guide to convert your storage configuration to the new format. If you are not ready to migrate, set `use_thanos_objstore` to `false` to keep using the legacy clients.
 
-In Loki 3.4 and later 3.x releases, the Thanos based clients are optional. To use them in those releases, set `use_thanos_objstore` to `true`.
+In Loki 3.4 and later 3.x releases, the Thanos-based clients are optional. To use them in those releases, set `use_thanos_objstore` to `true`.
 
 {{< admonition type="note" >}}
 The new storage configuration deviates from the existing format. The following sections describe the changes in detail for each provider.
@@ -25,12 +25,12 @@ Refer to the [Thanos storage configuration reference](https://grafana.com/docs/l
 
 ### Configure the new storage clients
 
-1. Configure your object storage under `storage_config.object_store`. When the Thanos based clients are in use, Loki reads this section instead of the legacy storage configuration. In Loki 3.x, you must also set `use_thanos_objstore` to `true` in the `storage_config` section, or set the `-use-thanos-objstore` flag to `true`. The following examples set this option explicitly, which is also valid in Loki 4.0.
+1. Configure your object storage under `storage_config.object_store`. When the Thanos-based clients are in use, Loki reads this section instead of the legacy storage configuration. In Loki 3.x, you must also set `use_thanos_objstore` to `true` in the `storage_config` section, or set the `-use-thanos-objstore` flag to `true`. The following examples set this option explicitly, which is also valid in Loki 4.0.
 
    ```yaml
    # Uses the new storage clients for connecting to gcs backend
    storage_config:
-     use_thanos_objstore: true # use the Thanos based storage clients
+     use_thanos_objstore: true # use the Thanos-based storage clients
      object_store:
        gcs:
          bucket_name: "example-bucket"
@@ -40,7 +40,7 @@ Refer to the [Thanos storage configuration reference](https://grafana.com/docs/l
 
    ```yaml
    storage_config:
-      use_thanos_objstore: true # use the Thanos based storage clients
+      use_thanos_objstore: true # use the Thanos-based storage clients
    common:
      storage:
        object_store:
@@ -52,7 +52,7 @@ Refer to the [Thanos storage configuration reference](https://grafana.com/docs/l
 
    ```yaml
    storage_config:
-      use_thanos_objstore: true # use the Thanos based storage clients
+      use_thanos_objstore: true # use the Thanos-based storage clients
    ruler_storage:
       backend: gcs
       gcs:
@@ -64,7 +64,7 @@ Refer to the [Thanos storage configuration reference](https://grafana.com/docs/l
    ```yaml
    # Example configuration to prefix all objects with "prefix"
    storage_config:
-      use_thanos_objstore: true # use the Thanos based storage clients
+      use_thanos_objstore: true # use the Thanos-based storage clients
       object_store:
          storage_prefix: "prefix"
    ```

--- a/docs/sources/setup/migrate/migrate-to-tsdb/_index.md
+++ b/docs/sources/setup/migrate/migrate-to-tsdb/_index.md
@@ -10,9 +10,9 @@ keywords:
 
 # Migrate to TSDB
 
-[TSDB](../../../operations/storage/tsdb/) is the recommended index type for Loki and is where the current development lies.
-If you are running Loki with [boltdb-shipper](../../../operations/storage/boltdb-shipper/) or any of the [legacy index types](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/storage/#index-storage) that have been deprecated,
-we strongly recommend migrating to TSDB.
+[TSDB](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/tsdb/) is the recommended index type for Loki, and it is where current development happens.
+
+Loki 4.0 removes the older index types, which are BoltDB (`boltdb-shipper`), Google BigTable, Apache Cassandra, Amazon DynamoDB, and the gRPC store. Loki fails to start if your schema or storage configuration still refers to one of them. If you use any of these index types, migrate to TSDB before you upgrade to Loki 4.0. For the full list of removed storage backends, refer to [Upgrading](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/#breaking-change-removal-of-deprecated-storage-backends).
 
 
 ### Configure TSDB index for an upcoming period
@@ -52,6 +52,10 @@ schema_config:
 1. This sample configuration uses filesystem as the storage in both the periods. If you want to use a different storage for the TSDB index and chunks, you can specify a different `object_store` in the new period.
 
 1.  Update the schema to v13 which is the recommended version at the time of writing. Please refer to the [configure page](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#period_config) for the current recommended version.
+
+{{< admonition type="note" >}}
+Do this migration on Loki 3.x, because Loki 4.0 does not read the older index types. The example above keeps the old `boltdb-shipper` period so that Loki can still query the data you ingested before the migration. Loki 4.0 fails to start while that period is still in your `schema_config`. Remove the old period entries after your retention period has passed, then upgrade to Loki 4.0.
+{{< /admonition >}}
 
 ### Configure TSDB shipper
 

--- a/docs/sources/setup/migrate/migrate-to-tsdb/_index.md
+++ b/docs/sources/setup/migrate/migrate-to-tsdb/_index.md
@@ -10,9 +10,9 @@ keywords:
 
 # Migrate to TSDB
 
-[TSDB](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/tsdb/) is the recommended index type for Loki and is where the current development lies.
-If you are running Loki with [boltdb-shipper](https://grafana.com/docs/loki/v3.0.x/operations/storage/boltdb-shipper/) or any of the [legacy index types](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/storage/#index-storage) that have been deprecated,
-we strongly recommend migrating to TSDB.
+[TSDB](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/tsdb/) is the recommended index type for Loki, and it is where current development happens.
+
+Loki 4.0 removes the older index types, which are BoltDB (`boltdb-shipper`), Google BigTable, Apache Cassandra, Amazon DynamoDB, and the gRPC store. Loki fails to start if your schema or storage configuration still refers to one of them. If you use any of these index types, migrate to TSDB before you upgrade to Loki 4.0. For the full list of removed storage backends, refer to [Upgrading](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/upgrade/#breaking-change-removal-of-deprecated-storage-backends).
 
 
 ### Configure TSDB index for an upcoming period
@@ -52,6 +52,10 @@ schema_config:
 1. This sample configuration uses filesystem as the storage in both the periods. If you want to use a different storage for the TSDB index and chunks, you can specify a different `object_store` in the new period.
 
 1.  Update the schema to v13 which is the recommended version at the time of writing. Please refer to the [configure page](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/#period_config) for the current recommended version.
+
+{{< admonition type="note" >}}
+Do this migration on Loki 3.x, because Loki 4.0 does not read the older index types. The example above keeps the old `boltdb-shipper` period so that Loki can still query the data you ingested before the migration. Loki 4.0 fails to start while that period is still in your `schema_config`. Remove the old period entries after your retention period has passed, then upgrade to Loki 4.0.
+{{< /admonition >}}
 
 ### Configure TSDB shipper
 

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -588,7 +588,7 @@ All of these are cached to the `results_cache` which is configured in the `query
 #### Write dedupe cache is deprecated
 
 Write dedupe cache is deprecated because it not required by the newer single store indexes ([TSDB](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/tsdb/) and boltdb-shipper).
-If you are using a legacy index type, consider migrating to TSDB (recommended).
+If you are using a legacy index type, you must migrate to TSDB to use Loki 4.0.
 
 #### Embedded cache metric changes
 

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -62,7 +62,7 @@ stopping new v14 writes first, because earlier binaries cannot read v14 indexes.
 
 ### Breaking change: Thanos storage clients are used by default
 
-The default value of `storage_config.use_thanos_objstore` changed from `false` to `true`, enabling the Thanos based object store clients by default if not otherwise explicitly specified.
+The default value of `storage_config.use_thanos_objstore` changed from `false` to `true`, enabling the Thanos-based object store clients by default if not otherwise explicitly specified.
 
 Please refer to [Migrate to Thanos storage clients](https://grafana.com/docs/loki/<LOKI_VERSION>/setup/migrate/migrate-storage-clients/) for how to migrate your configuration.
 

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -465,7 +465,7 @@ period_config:
 ```
 
 {{< admonition type="note" >}}
-`path_prefix` only applies to TSDB and BoltDB indexes. This setting has no effect on [legacy indexes](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/storage/#index-storage).
+`path_prefix` only applies to TSDB and BoltDB indexes. This setting has no effect on legacy indexes.
 {{< /admonition >}}
 
 `path_prefix` defaults to `index/` which is same as the default value of the removed configurations.
@@ -588,7 +588,7 @@ All of these are cached to the `results_cache` which is configured in the `query
 #### Write dedupe cache is deprecated
 
 Write dedupe cache is deprecated because it not required by the newer single store indexes ([TSDB](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/tsdb/) and boltdb-shipper).
-If you using a [legacy index type](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/storage/#index-storage), consider migrating to TSDB (recommended).
+If you are using a legacy index type, consider migrating to TSDB (recommended).
 
 #### Embedded cache metric changes
 

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -459,7 +459,7 @@ period_config:
 ```
 
 {{< admonition type="note" >}}
-`path_prefix` only applies to TSDB and BoltDB indexes. This setting has no effect on [legacy indexes](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/storage/#index-storage).
+`path_prefix` only applies to TSDB and BoltDB indexes. This setting has no effect on legacy indexes.
 {{< /admonition >}}
 
 `path_prefix` defaults to `index/` which is same as the default value of the removed configurations.
@@ -582,7 +582,7 @@ All of these are cached to the `results_cache` which is configured in the `query
 #### Write dedupe cache is deprecated
 
 Write dedupe cache is deprecated because it not required by the newer single store indexes ([TSDB](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/tsdb/) and boltdb-shipper).
-If you using a [legacy index type](https://grafana.com/docs/loki/<LOKI_VERSION>/configure/storage/#index-storage), consider migrating to TSDB (recommended).
+If you are using a legacy index type, consider migrating to TSDB (recommended).
 
 #### Embedded cache metric changes
 

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -582,7 +582,7 @@ All of these are cached to the `results_cache` which is configured in the `query
 #### Write dedupe cache is deprecated
 
 Write dedupe cache is deprecated because it not required by the newer single store indexes ([TSDB](https://grafana.com/docs/loki/<LOKI_VERSION>/operations/storage/tsdb/) and boltdb-shipper).
-If you are using a legacy index type, consider migrating to TSDB (recommended).
+If you are using a legacy index type, you must migrate to TSDB to use Loki 4.0.
 
 #### Embedded cache metric changes
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the sample storage examples to include Thanos configuration format using `object_store` as requested by @bboreham.

This PR
- Adds four new examples of Thanos storage configuration files
- Updates existing examples to better indicate <REPLACEMENT_VALUES>
- Removes some extra lines

**Special notes for your reviewer**:
Planned with AI (Sonnet 5)
Written with AI (Sonnet 5)
Validated with a different model (Opus 5)

Since storage.md has already been updated for the next release, we won't backport this update either, although it will be available in `next` until the next release.