### PR TITLE
fix(ingester): Distinguish WAL replay backpressure from WAL corruption

### DIFF
--- a/docs/sources/operations/storage/wal.md
+++ b/docs/sources/operations/storage/wal.md
@@ -33,11 +33,16 @@ The Write Ahead Log in Loki takes a few particular tradeoffs compared to other W
 
 The WAL also includes a backpressure mechanism to allow a large WAL to be replayed within a smaller memory bound. This is helpful after bad scenarios (i.e. an outage) when a WAL has grown past the point it may be recovered in memory. In this case, the ingester will track the amount of data being replayed and once it's passed the `ingester.wal-replay-memory-ceiling` threshold, will flush to storage. When this happens, it's likely that the Loki attempt to deduplicate chunks via content addressable storage will suffer. We deemed this efficiency loss an acceptable tradeoff considering how it simplifies operation and that it should not occur during regular operation (rollouts, rescheduling) where the WAL can be replayed without triggering this threshold.
 
+If a replay-triggered flush cannot bring memory back below the ceiling, the ingester gives up on the rest of the replay and starts with an incomplete WAL. Unlike a corrupt WAL, this needs administrator action: raise `ingester.wal-replay-memory-ceiling`, or find out why flushing is not draining, for example object storage being slow or unavailable, or `chunk_retain_period` holding on to freshly flushed chunks.
+
+You can use the Prometheus metric `loki_ingester_wal_replay_backpressure_failures_total` to track and alert when this happens.
+
 ### Metrics
 
 The following metrics are available for monitoring the WAL:
 
 * `loki_ingester_wal_corruptions_total`: Total number of WAL corruptions encountered
+* `loki_ingester_wal_replay_backpressure_failures_total`: Total number of WAL replays left incomplete because a replay-triggered flush could not bring memory back below the replay memory ceiling
 * `loki_ingester_wal_disk_full_failures_total`: Total number of disk full failures
 * `loki_ingester_wal_records_logged`: Counter for WAL records logged
 * `loki_ingester_wal_logged_bytes_total`: Total bytes written to WAL

--- a/docs/sources/operations/troubleshooting/troubleshoot-ingest.md
+++ b/docs/sources/operations/troubleshooting/troubleshoot-ingest.md
@@ -737,6 +737,43 @@ The WAL has become corrupted, possibly due to:
 Loki prioritizes availability over complete data recovery. The replication factor provides redundancy if one ingester loses WAL data. Recovered data may be incomplete if corruption is severe.
 {{< /admonition >}}
 
+### Error: WAL replay stopped by memory backpressure
+
+**Error message:**
+
+`WAL replay could not free enough memory to finish, so this ingester is starting with an incomplete WAL`
+
+**Metric:** `loki_ingester_wal_replay_backpressure_failures_total`
+
+**Cause:**
+
+The WAL is intact, but a replay-triggered flush could not bring memory back below `-ingester.wal-replay-memory-ceiling`, so the ingester gave up on the rest of the replay and became active with an incomplete view of its streams. Common reasons a flush stops draining:
+
+- Object storage is slow or unavailable
+- Immediate flush operations keep failing and being re-enqueued
+- `chunk_retain_period` is holding on to freshly flushed chunks
+
+**Resolution:**
+
+Unlike WAL corruption, this requires administrator action.
+
+* **Monitor for backpressure failures**:
+
+   ```promql
+   increase(loki_ingester_wal_replay_backpressure_failures_total[5m]) > 0
+   ```
+
+* **Give the replay more headroom**: raise `-ingester.wal-replay-memory-ceiling`.
+
+* **Unblock flushing**: check object storage availability and latency, and review `chunk_retain_period`.
+
+**Properties:**
+
+- Enforced by: Ingester (on startup)
+- Retryable: N/A (Loki continues starting with an incomplete WAL)
+- HTTP status: N/A (occurs during startup, not request handling)
+- Configurable per tenant: No
+
 ## Network and connectivity errors
 
 These errors occur due to network issues or service unavailability.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -579,11 +579,11 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 
 		checkpointRecoveryErr := RecoverCheckpoint(checkpointReader, recoverer)
 		if checkpointRecoveryErr != nil {
-			i.metrics.walCorruptionsTotal.WithLabelValues(walTypeCheckpoint).Inc()
-			level.Error(i.logger).Log(
-				"msg",
+			i.reportWALRecoveryErr(
+				walTypeCheckpoint,
+				checkpointRecoveryErr,
 				`Recovered from checkpoint with errors. Some streams were likely not recovered due to WAL checkpoint file corruptions (or WAL file deletions while Loki is running). No administrator action is needed and data loss is only a possibility if more than (replication factor / 2 + 1) ingesters suffer from this.`,
-				"elapsed", time.Since(start).String(),
+				start,
 			)
 		}
 		level.Info(i.logger).Log(
@@ -601,11 +601,11 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 
 		segmentRecoveryErr := RecoverWAL(ctx, segmentReader, recoverer)
 		if segmentRecoveryErr != nil {
-			i.metrics.walCorruptionsTotal.WithLabelValues(walTypeSegment).Inc()
-			level.Error(i.logger).Log(
-				"msg",
+			i.reportWALRecoveryErr(
+				walTypeSegment,
+				segmentRecoveryErr,
 				"Recovered from WAL segments with errors. Some streams and/or entries were likely not recovered due to WAL segment file corruptions (or WAL file deletions while Loki is running). No administrator action is needed and data loss is only a possibility if more than (replication factor / 2 + 1) ingesters suffer from this.",
-				"elapsed", time.Since(start).String(),
+				start,
 			)
 		}
 		level.Info(i.logger).Log(
@@ -673,6 +673,32 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 	}
 
 	return nil
+}
+
+// reportWALRecoveryErr records and logs a WAL recovery failure for the given WAL
+// type. Memory backpressure and file corruption both leave the WAL partially
+// recovered, but they are different problems with different remedies, so they
+// must not share a metric or a message: a torn segment needs no administrator
+// action, whereas a backpressure failure does.
+func (i *Ingester) reportWALRecoveryErr(walType string, err error, corruptionMsg string, start time.Time) {
+	var backpressureErr *ReplayBackpressureError
+	if errors.As(err, &backpressureErr) {
+		i.metrics.walReplayBackpressure.WithLabelValues(walType).Inc()
+		level.Error(i.logger).Log(
+			"msg",
+			"WAL replay could not free enough memory to finish, so this ingester is starting with an incomplete WAL. Administrator action is needed: raise the replay memory ceiling, or find out why flushing is not draining (for example object storage being slow or unavailable, or chunk_retain_period holding on to freshly flushed chunks).",
+			"type", walType,
+			"err", err,
+			"elapsed", time.Since(start).String(),
+		)
+		return
+	}
+
+	i.metrics.walCorruptionsTotal.WithLabelValues(walType).Inc()
+	level.Error(i.logger).Log(
+		"msg", corruptionMsg,
+		"elapsed", time.Since(start).String(),
+	)
 }
 
 func (i *Ingester) running(ctx context.Context) error {

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -24,6 +24,7 @@ type ingesterMetrics struct {
 	walReplaySamplesDropped *prometheus.CounterVec
 	walReplayBytesDropped   *prometheus.CounterVec
 	walCorruptionsTotal     *prometheus.CounterVec
+	walReplayBackpressure   *prometheus.CounterVec
 	walLoggedBytesTotal     prometheus.Counter
 	walRecordsLogged        prometheus.Counter
 
@@ -119,6 +120,10 @@ func newIngesterMetrics(r prometheus.Registerer, metricsNamespace string) *inges
 		walCorruptionsTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Name: "loki_ingester_wal_corruptions_total",
 			Help: "Total number of WAL corruptions encountered.",
+		}, []string{"type"}),
+		walReplayBackpressure: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Name: "loki_ingester_wal_replay_backpressure_failures_total",
+			Help: "Total number of WAL replays left incomplete because a replay-triggered flush could not bring memory back below the replay memory ceiling.",
 		}, []string{"type"}),
 		checkpointDeleteFail: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "loki_ingester_checkpoint_deletions_failed_total",

--- a/pkg/ingester/recovery_test.go
+++ b/pkg/ingester/recovery_test.go
@@ -10,7 +10,10 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/user"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/record"
@@ -342,5 +345,65 @@ func TestRecoveryWritesContinuesEntryCountAfterWALReplay(t *testing.T) {
 			return nil
 		})
 		require.NoError(t, err)
+	}
+}
+
+// A WAL replay left incomplete by memory backpressure must not be counted or
+// logged as WAL corruption: the two have different remedies, and the corruption
+// message tells the operator that no action is needed.
+func TestReportWALRecoveryErrSeparatesBackpressureFromCorruption(t *testing.T) {
+	const corruptionMsg = "Recovered from WAL segments with errors."
+
+	for _, tc := range []struct {
+		name               string
+		err                error
+		wantCorruptions    float64
+		wantBackpressure   float64
+		wantLogContains    string
+		wantLogNotContains string
+	}{
+		{
+			name:               "backpressure",
+			err:                &ReplayBackpressureError{InUse: 100, Ceiling: 90},
+			wantCorruptions:    0,
+			wantBackpressure:   1,
+			wantLogContains:    "Administrator action is needed",
+			wantLogNotContains: corruptionMsg,
+		},
+		{
+			name:               "wrapped backpressure",
+			err:                fmt.Errorf("recovering WAL: %w", &ReplayBackpressureError{InUse: 100, Ceiling: 90}),
+			wantCorruptions:    0,
+			wantBackpressure:   1,
+			wantLogContains:    "Administrator action is needed",
+			wantLogNotContains: corruptionMsg,
+		},
+		{
+			name:               "corruption",
+			err:                fmt.Errorf("unexpected checksum"),
+			wantCorruptions:    1,
+			wantBackpressure:   0,
+			wantLogContains:    corruptionMsg,
+			wantLogNotContains: "Administrator action is needed",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := prometheus.NewPedanticRegistry()
+			var logs concurrency.SyncBuffer
+			i := &Ingester{
+				metrics: newIngesterMetrics(reg, constants.Loki),
+				logger:  log.NewLogfmtLogger(&logs),
+			}
+
+			i.reportWALRecoveryErr(walTypeSegment, tc.err, corruptionMsg, time.Now())
+
+			require.Equal(t, tc.wantCorruptions,
+				testutil.ToFloat64(i.metrics.walCorruptionsTotal.WithLabelValues(walTypeSegment)))
+			require.Equal(t, tc.wantBackpressure,
+				testutil.ToFloat64(i.metrics.walReplayBackpressure.WithLabelValues(walTypeSegment)))
+
+			require.Contains(t, logs.String(), tc.wantLogContains)
+			require.NotContains(t, logs.String(), tc.wantLogNotContains)
+		})
 	}
 }

--- a/pkg/ingester/replay_controller.go
+++ b/pkg/ingester/replay_controller.go
@@ -118,6 +118,23 @@ func (c *replayController) flush() int64 {
 	return c.totalSubtracted.Load() - subtractedBefore
 }
 
+// ReplayBackpressureError is returned by WithBackPressure when a replay-triggered
+// flush can no longer bring the in-memory byte count below the replay memory
+// ceiling. The WAL itself is intact; the ingester simply cannot make room to
+// finish replaying it, so the remedy is to raise ReplayMemoryCeiling or to
+// unblock flushing rather than to investigate WAL corruption.
+type ReplayBackpressureError struct {
+	InUse   int64
+	Ceiling int64
+}
+
+func (e *ReplayBackpressureError) Error() string {
+	return fmt.Sprintf("WAL replay flush made no progress: %s in use, ceiling %s; cannot recover",
+		humanize.Bytes(uint64(e.InUse)),
+		humanize.Bytes(uint64(e.Ceiling)),
+	)
+}
+
 // WithBackPressure is expected to call replayController.Add in the passed function to increase the managed byte count.
 // It will call the function as long as there is expected room before the memory cap and will then flush data intermittently
 // when needed.
@@ -138,10 +155,10 @@ func (c *replayController) WithBackPressure(fn func() error) error {
 		// our own flush legitimately has nothing to do and we should simply exit
 		// the loop rather than report a spurious no-progress error.
 		if c.Flush() == 0 && c.Cur() > ceiling {
-			return fmt.Errorf("WAL replay flush made no progress: %s in use, ceiling %s; cannot recover",
-				humanize.Bytes(uint64(c.currentBytes.Load())),
-				humanize.Bytes(uint64(ceiling)),
-			)
+			return &ReplayBackpressureError{
+				InUse:   c.currentBytes.Load(),
+				Ceiling: int64(ceiling),
+			}
 		}
 	}
 

--- a/pkg/ingester/replay_controller_test.go
+++ b/pkg/ingester/replay_controller_test.go
@@ -315,3 +315,22 @@ func TestReplayControllerConcurrentFlushes(t *testing.T) {
 			"Singleflight should coalesce all flush requests into one")
 	})
 }
+
+// A no-progress flush must surface a *ReplayBackpressureError so that callers can
+// tell a memory backpressure failure apart from WAL corruption.
+func TestReplayControllerBackpressureErrorIsTyped(t *testing.T) {
+	flusher := newDumbFlusher(nil) // never calls rc.Sub, so bytes never decrease
+	rc := newReplayController(nilMetrics(), WALConfig{ReplayMemoryCeiling: 100}, flusher)
+
+	rc.Add(95) // above the 90-byte ceiling
+
+	err := rc.WithBackPressure(func() error { return nil })
+	require.Error(t, err)
+
+	var backpressureErr *ReplayBackpressureError
+	require.ErrorAs(t, err, &backpressureErr)
+	require.Equal(t, int64(95), backpressureErr.InUse)
+	require.Equal(t, int64(90), backpressureErr.Ceiling)
+	// The operator-facing wording is unchanged.
+	require.Contains(t, err.Error(), "WAL replay flush made no progress")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

A WAL replay stopped by memory backpressure and a WAL with torn segments both leave the WAL partially recovered, but they are different problems with different remedies. The ingester reported them identically.

When `replayController.WithBackPressure` gives up because a replay-triggered flush can no longer drain below the ceiling, that error propagates out through `ingesterRecoverer.Series`/`Push` and becomes the return value of `RecoverCheckpoint`/`RecoverWAL`. `Ingester.starting()` then counts it in `loki_ingester_wal_corruptions_total` and logs the corruption message — the one that says *"No administrator action is needed"*.

For this failure an administrator very much does need to act. The ingester goes ACTIVE serving an incomplete view of its streams and will keep doing so until `-ingester.wal-replay-memory-ceiling` is raised, or until whatever is stopping flushes from draining is fixed (object storage slow or unavailable, `chunk_retain_period` holding freshly flushed chunks, immediate flush ops failing and being re-enqueued). Meanwhile any alert on the corruption counter fires for a memory/storage condition, and the `type` label gives no way to separate the two.

This matters more than it used to: the old behaviour was a loud crash loop — the ingester never became ready and the startup probe killed it, so an operator could hardly miss it. The new behaviour is quiet, so the one signal that would surface it needs to point at the right cause.

**Changes**

- `WithBackPressure` now returns a typed `*ReplayBackpressureError` so the cause survives propagation through the recovery workers. The operator-facing message text is unchanged.
- `Ingester.starting()` classifies the recovery error in a new `reportWALRecoveryErr` helper. Backpressure increments a new `loki_ingester_wal_replay_backpressure_failures_total` counter (same `type` label: `checkpoint`/`segment`) and logs its own actionable message. Corruption reporting is byte-for-byte unchanged.

I went with a distinct metric rather than an extra `type` value on the corruption counter, so that existing alerts on `loki_ingester_wal_corruptions_total` stop firing for this condition instead of needing to be rewritten to exclude a label value.

**Which issue(s) this PR fixes**:
Fixes #23758

**Special notes for your reviewer**:

No config or API changes; the only new user-visible surface is the added metric. `reportWALRecoveryErr` takes the corruption message as a parameter purely to keep the two existing messages (checkpoint vs. segment) verbatim.

Tests added:
- `TestReplayControllerBackpressureErrorIsTyped` — the no-progress path returns a `*ReplayBackpressureError` carrying in-use/ceiling, and the existing wording is preserved.
- `TestReportWALRecoveryErrSeparatesBackpressureFromCorruption` — table test over bare backpressure, wrapped backpressure (`errors.As` through `%w`), and a generic error, asserting which counter moves and that each case gets the right log message and not the other one.

`go test ./pkg/ingester/` passes in full.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.
