### PR TITLE
fix(tsdb): Skip local PVC index cache directories outside query readiness window at startup

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go
@@ -361,17 +361,13 @@ func (tm *tableManager) ensureQueryReadiness(ctx context.Context) error {
 	activeTableNumber := getActiveTableNumber()
 
 	// find the largest query readiness number
-	largestQueryReadinessNum := tm.cfg.QueryReadyNumDays
-	if defaultLimits := tm.cfg.Limits.DefaultLimits(); defaultLimits.QueryReadyIndexNumDays > largestQueryReadinessNum {
-		largestQueryReadinessNum = defaultLimits.QueryReadyIndexNumDays
-	}
+	largestQueryReadinessNum := tm.getLargestQueryReadinessNum()
 
 	queryReadinessNumByUserID := make(map[string]int)
-	for userID, limits := range tm.cfg.Limits.AllByUserID() {
-		if limits.QueryReadyIndexNumDays != 0 {
-			queryReadinessNumByUserID[userID] = limits.QueryReadyIndexNumDays
-			if limits.QueryReadyIndexNumDays > largestQueryReadinessNum {
-				largestQueryReadinessNum = limits.QueryReadyIndexNumDays
+	if tm.cfg.Limits != nil {
+		for userID, limits := range tm.cfg.Limits.AllByUserID() {
+			if limits != nil && limits.QueryReadyIndexNumDays != 0 {
+				queryReadinessNumByUserID[userID] = limits.QueryReadyIndexNumDays
 			}
 		}
 	}
@@ -462,6 +458,25 @@ func (tm *tableManager) ensureQueryReadiness(ctx context.Context) error {
 	return nil
 }
 
+func (tm *tableManager) getLargestQueryReadinessNum() int {
+	largestQueryReadinessNum := tm.cfg.QueryReadyNumDays
+	if tm.cfg.Limits == nil {
+		return largestQueryReadinessNum
+	}
+
+	if defaultLimits := tm.cfg.Limits.DefaultLimits(); defaultLimits != nil && defaultLimits.QueryReadyIndexNumDays > largestQueryReadinessNum {
+		largestQueryReadinessNum = defaultLimits.QueryReadyIndexNumDays
+	}
+
+	for _, limits := range tm.cfg.Limits.AllByUserID() {
+		if limits != nil && limits.QueryReadyIndexNumDays > largestQueryReadinessNum {
+			largestQueryReadinessNum = limits.QueryReadyIndexNumDays
+		}
+	}
+
+	return largestQueryReadinessNum
+}
+
 // findUsersInTableForQueryReadiness returns the users that needs their index to be query ready based on the tableNumber and
 // query readiness number provided per user
 func (tm *tableManager) findUsersInTableForQueryReadiness(tableNumber int64, usersWithIndexInTable []string, queryReadinessNumByUserID map[string]int) ([]string, error) {
@@ -471,7 +486,7 @@ func (tm *tableManager) findUsersInTableForQueryReadiness(tableNumber int64, use
 	for _, userID := range usersWithIndexInTable {
 		// use the query readiness config for the user if it exists or use the default config
 		queryReadyNumDays, ok := queryReadinessNumByUserID[userID]
-		if !ok {
+		if !ok && tm.cfg.Limits != nil && tm.cfg.Limits.DefaultLimits() != nil {
 			queryReadyNumDays = tm.cfg.Limits.DefaultLimits().QueryReadyIndexNumDays
 		}
 
@@ -496,6 +511,9 @@ func (tm *tableManager) loadLocalTables() error {
 		return err
 	}
 
+	activeTableNumber := getActiveTableNumber()
+	largestQueryReadinessNum := tm.getLargestQueryReadinessNum()
+
 	for _, entry := range dirEntries {
 		if !entry.IsDir() {
 			continue
@@ -508,6 +526,16 @@ func (tm *tableManager) loadLocalTables() error {
 				level.Debug(tm.logger).Log("msg", "skip loading table as it is not in range", "table-name", entry.Name())
 			}
 
+			continue
+		}
+
+		tableNumber, err := config.ExtractTableNumberFromName(entry.Name())
+		if err != nil {
+			return fmt.Errorf("cannot extract table number from %s: %w", entry.Name(), err)
+		}
+
+		if largestQueryReadinessNum > 0 && activeTableNumber-tableNumber > int64(largestQueryReadinessNum) {
+			level.Info(tm.logger).Log("msg", "skip loading table as it exceeds query ready num days", "table-name", entry.Name())
 			continue
 		}
 

--- a/pkg/storage/stores/shipper/indexshipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -503,4 +504,147 @@ func TestTableManager_TriggerSyncRecordsManualMetric(t *testing.T) {
 	tm.syncManager.Wait()
 	require.Equal(t, float64(1), testutil.ToFloat64(
 		tm.metrics.tablesSyncOperationTotal.WithLabelValues(statusSuccess, syncTriggerManual)))
+}
+
+func TestTableManager_loadLocalTables_QueryReadyNumDays(t *testing.T) {
+	tableRangeToHandle := config.TableRange{
+		Start: 0,
+		End:   math.MaxInt64,
+		PeriodConfig: &config.PeriodConfig{
+			IndexTables: config.IndexPeriodicTableConfig{
+				PeriodicTableConfig: config.PeriodicTableConfig{
+					Prefix: indexTablePrefix,
+					Period: indexTablePeriod,
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                          string
+		queryReadyNumDays             int
+		queryReadyIndexNumDaysDefault int
+		queryReadyIndexNumDaysByUser  map[string]int
+		numTablesCreated              int
+		expectedLoadedTables          []string
+		expectedSkippedTables         []string
+	}{
+		{
+			name:              "loads tables within QueryReadyNumDays window and skips older tables",
+			queryReadyNumDays: 2,
+			numTablesCreated:  6,
+			expectedLoadedTables: []string{
+				buildTableName(0),
+				buildTableName(1),
+				buildTableName(2),
+			},
+			expectedSkippedTables: []string{
+				buildTableName(3),
+				buildTableName(4),
+				buildTableName(5),
+			},
+		},
+		{
+			name:                          "respects default limit override when default limits exceed global QueryReadyNumDays",
+			queryReadyNumDays:             1,
+			queryReadyIndexNumDaysDefault: 3,
+			numTablesCreated:              6,
+			expectedLoadedTables: []string{
+				buildTableName(0),
+				buildTableName(1),
+				buildTableName(2),
+				buildTableName(3),
+			},
+			expectedSkippedTables: []string{
+				buildTableName(4),
+				buildTableName(5),
+			},
+		},
+		{
+			name:              "respects per-user limit override when a tenant limit exceeds global QueryReadyNumDays",
+			queryReadyNumDays: 1,
+			queryReadyIndexNumDaysByUser: map[string]int{
+				"vip_user": 4,
+			},
+			numTablesCreated: 6,
+			expectedLoadedTables: []string{
+				buildTableName(0),
+				buildTableName(1),
+				buildTableName(2),
+				buildTableName(3),
+				buildTableName(4),
+			},
+			expectedSkippedTables: []string{
+				buildTableName(5),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			cachePath := filepath.Join(tempDir, cacheDirName)
+			require.NoError(t, os.MkdirAll(cachePath, 0750))
+
+			for i := 0; i < tc.numTablesCreated; i++ {
+				tableName := buildTableName(i)
+				setupIndexesAtPath(t, "", filepath.Join(cachePath, tableName), 1, 3)
+				setupIndexesAtPath(t, "user1", filepath.Join(cachePath, tableName, "user1"), 1, 3)
+				for userID := range tc.queryReadyIndexNumDaysByUser {
+					setupIndexesAtPath(t, userID, filepath.Join(cachePath, tableName, userID), 1, 3)
+				}
+			}
+
+			// Add non-table directory clutter (lost+found, .ds_store) to verify clean skip handling
+			require.NoError(t, os.MkdirAll(filepath.Join(cachePath, "lost+found"), 0750))
+			require.NoError(t, os.MkdirAll(filepath.Join(cachePath, ".ds_store"), 0750))
+
+			baseStorageClient := buildTestStorageClient(t, tempDir)
+
+			limits := &mockLimits{
+				queryReadyIndexNumDaysDefault: tc.queryReadyIndexNumDaysDefault,
+				queryReadyIndexNumDaysByUser:  tc.queryReadyIndexNumDaysByUser,
+			}
+
+			cfg := Config{
+				CacheDir:          cachePath,
+				SyncInterval:      time.Hour,
+				CacheTTL:          time.Hour,
+				QueryReadyNumDays: tc.queryReadyNumDays,
+				DownloadTimeout:   5 * time.Minute,
+				Limits:            limits,
+			}
+
+			tm := &tableManager{
+				cfg: cfg,
+				openIndexFileFunc: func(s string) (index.Index, error) {
+					return openMockIndexFile(t, s), nil
+				},
+				indexStorageClient: baseStorageClient,
+				tableRangeToHandle: tableRangeToHandle,
+				tables:             make(map[string]Table),
+				metrics:            newMetrics(nil),
+				logger:             log.NewNopLogger(),
+				ctx:                context.Background(),
+				cancel:             func() {},
+			}
+
+			require.NoError(t, tm.loadLocalTables())
+			defer func() {
+				for _, tbl := range tm.tables {
+					tbl.Close()
+				}
+			}()
+
+			require.Len(t, tm.tables, len(tc.expectedLoadedTables))
+
+			for _, tableName := range tc.expectedLoadedTables {
+				require.Contains(t, tm.tables, tableName)
+			}
+
+			for _, tableName := range tc.expectedSkippedTables {
+				require.NotContains(t, tm.tables, tableName)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Unify the calculation of the maximum query readiness horizon across global configuration and tenant limits via getLargestQueryReadinessNum. This ensures loadLocalTables skips loading stale local PVC directories beyond the readiness window during boot without ignoring tenant limit overrides, preventing startup probe timeouts and redundant S3 downloads under object storage latency.

**What this PR does / why we need it**:
Even when operators reduce `query_ready_num_days` (e.g. from 30 days down to 1 day), pre-existing historical table directories remaining on the local PVC disk were still unconditionally loaded during container boot by `loadLocalTables()`.

Specifically, `loadLocalTables()` scanned all directories in `tm.cfg.CacheDir` and called `LoadTable()` on every entry, triggering synchronous `checkStorageForUpdates` S3 storage calls for older pre-existing directories regardless of the newly configured `query_ready_num_days`.

Under object storage latency, booting a container with pre-existing historical PVC directories causes significant startup latency, resulting in Kubelet readiness/liveness probe failures and container `CrashLoopBackOff`.

This PR unifies the calculation of the maximum query readiness horizon across global configuration and tenant limits via `getLargestQueryReadinessNum()`. In `loadLocalTables()`, table age is evaluated against `largestQueryReadinessNum` before calling `LoadTable()`, cleanly skipping historical tables outside the window at boot.

**Which issue(s) this PR fixes**:
Fixes TSDB Shipper PVC cache trap startup timeout under object storage latency.

**Special notes for your reviewer**:
- `loadLocalTables()` remains read-only and non-destructive.
- Skips S3 network calls for historical tables outside the query readiness window.
- Respects per-tenant `QueryReadyIndexNumDays` limit overrides.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.