### PR TITLE
fix: Give each tenant its own request in multi-tenant queries

### DIFF
--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -81,7 +81,11 @@ func (q *MultiTenantQuerier) SelectLogs(ctx context.Context, params logql.Select
 	for id := range matchedTenants {
 		singleContext := user.InjectOrgID(ctx, id)
 
-		tenantParams := params
+		// Give each tenant its own request. The downstream querier resolves deletes and
+		// clamps the time range in place, so a shared request would leak one tenant's
+		// values into the others and mutate it while their sends are still in flight.
+		tenantRequest := *params.QueryRequest
+		tenantParams := logql.SelectLogParams{QueryRequest: &tenantRequest}
 
 		if tenantChunkOverrides, ok := storeOverridesByTenant[id]; ok {
 			tenantParams = tenantParams.WithStoreChunks(&logproto.ChunkRefGroup{Refs: tenantChunkOverrides})
@@ -124,7 +128,10 @@ func (q *MultiTenantQuerier) SelectSamples(ctx context.Context, params logql.Sel
 	i := 0
 	for id := range matchedTenants {
 		singleContext := user.InjectOrgID(ctx, id)
-		tenantParams := params
+
+		// See SelectLogs: each tenant needs its own request.
+		tenantRequest := *params.SampleQueryRequest
+		tenantParams := logql.SelectSampleParams{SampleQueryRequest: &tenantRequest}
 
 		if tenantChunkOverrides, ok := storeOverridesByTenant[id]; ok {
 			tenantParams = tenantParams.WithStoreChunks(&logproto.ChunkRefGroup{Refs: tenantChunkOverrides})

--- a/pkg/querier/multi_tenant_querier.go
+++ b/pkg/querier/multi_tenant_querier.go
@@ -86,7 +86,11 @@ func (q *MultiTenantQuerier) SelectLogs(ctx context.Context, params logql.Select
 	for id := range matchedTenants {
 		singleContext := user.InjectOrgID(ctx, id)
 
-		tenantParams := params
+		// Give each tenant its own request. The downstream querier resolves deletes and
+		// clamps the time range in place, so a shared request would leak one tenant's
+		// values into the others and mutate it while their sends are still in flight.
+		tenantRequest := *params.QueryRequest
+		tenantParams := logql.SelectLogParams{QueryRequest: &tenantRequest}
 
 		if tenantChunkOverrides, ok := storeOverridesByTenant[id]; ok {
 			tenantParams = tenantParams.WithStoreChunks(&logproto.ChunkRefGroup{Refs: tenantChunkOverrides})
@@ -138,7 +142,10 @@ func (q *MultiTenantQuerier) SelectSamples(ctx context.Context, params logql.Sel
 	i := 0
 	for id := range matchedTenants {
 		singleContext := user.InjectOrgID(ctx, id)
-		tenantParams := params
+
+		// See SelectLogs: each tenant needs its own request.
+		tenantRequest := *params.SampleQueryRequest
+		tenantParams := logql.SelectSampleParams{SampleQueryRequest: &tenantRequest}
 
 		if tenantChunkOverrides, ok := storeOverridesByTenant[id]; ok {
 			tenantParams = tenantParams.WithStoreChunks(&logproto.ChunkRefGroup{Refs: tenantChunkOverrides})

--- a/pkg/querier/multi_tenant_querier_test.go
+++ b/pkg/querier/multi_tenant_querier_test.go
@@ -177,6 +177,46 @@ func TestMultiTenantQuerier_SelectSamples(t *testing.T) {
 	}
 }
 
+// The downstream querier resolves deletes and clamps the time range on the request it
+// is handed, so every tenant needs its own copy.
+func TestMultiTenantQuerier_EachTenantGetsItsOwnRequest(t *testing.T) {
+	selector := `count_over_time({foo="bar"}[1m])`
+	original := &logproto.SampleQueryRequest{
+		Selector: selector,
+		Start:    time.Unix(0, 0),
+		End:      time.Unix(3600, 0),
+		Plan:     &plan.QueryPlan{AST: syntax.MustParseExpr(selector)},
+	}
+
+	var seen []*logproto.SampleQueryRequest
+	querier := newQuerierMock()
+	querier.On("SelectSamples", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			params := args.Get(1).(logql.SelectSampleParams)
+			seen = append(seen, params.SampleQueryRequest)
+			// Mirror SingleTenantQuerier.SelectSamples, which writes both in place.
+			params.Deletes = append(params.Deletes, &logproto.Delete{Selector: `{app="deleted"}`})
+			params.Start = params.Start.Add(time.Minute)
+		}).
+		Return(func() iter.SampleIterator { return newSampleIterator() }, nil)
+
+	multiTenantQuerier := NewMultiTenantQuerier(querier, log.NewNopLogger())
+	ctx := user.InjectOrgID(context.Background(), "1|2")
+
+	it, err := multiTenantQuerier.SelectSamples(ctx, logql.SelectSampleParams{SampleQueryRequest: original})
+	require.NoError(t, err)
+	for it.Next() { //nolint:revive
+	}
+	require.NoError(t, it.Close())
+
+	require.Len(t, seen, 2)
+	require.NotSame(t, seen[0], seen[1], "both tenants were handed the same request")
+	require.Len(t, seen[0].Deletes, 1, "one tenant observed another tenant's deletes")
+	require.Len(t, seen[1].Deletes, 1, "one tenant observed another tenant's deletes")
+	require.Empty(t, original.Deletes, "downstream deletes leaked into the caller's request")
+	require.Equal(t, time.Unix(0, 0).UTC(), original.Start.UTC(), "downstream clamped the caller's request")
+}
+
 func TestMultiTenantQuerier_TenantFilter(t *testing.T) {
 	for _, tc := range []struct {
 		selector string

--- a/pkg/querier/multi_tenant_querier_test.go
+++ b/pkg/querier/multi_tenant_querier_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/querier/plan"
 	"github.com/grafana/loki/v3/pkg/querier/testutil"
 )
 
@@ -171,6 +172,46 @@ func TestMultiTenantQuerier_SelectSamples(t *testing.T) {
 			require.ElementsMatch(t, tc.expLabels, received)
 		})
 	}
+}
+
+// The downstream querier resolves deletes and clamps the time range on the request it
+// is handed, so every tenant needs its own copy.
+func TestMultiTenantQuerier_EachTenantGetsItsOwnRequest(t *testing.T) {
+	selector := `count_over_time({foo="bar"}[1m])`
+	original := &logproto.SampleQueryRequest{
+		Selector: selector,
+		Start:    time.Unix(0, 0),
+		End:      time.Unix(3600, 0),
+		Plan:     &plan.QueryPlan{AST: syntax.MustParseExpr(selector)},
+	}
+
+	var seen []*logproto.SampleQueryRequest
+	querier := newQuerierMock()
+	querier.On("SelectSamples", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			params := args.Get(1).(logql.SelectSampleParams)
+			seen = append(seen, params.SampleQueryRequest)
+			// Mirror SingleTenantQuerier.SelectSamples, which writes both in place.
+			params.Deletes = append(params.Deletes, &logproto.Delete{Selector: `{app="deleted"}`})
+			params.Start = params.Start.Add(time.Minute)
+		}).
+		Return(func() iter.SampleIterator { return newSampleIterator() }, nil)
+
+	multiTenantQuerier := NewMultiTenantQuerier(querier, log.NewNopLogger())
+	ctx := user.InjectOrgID(context.Background(), "1|2")
+
+	it, err := multiTenantQuerier.SelectSamples(ctx, logql.SelectSampleParams{SampleQueryRequest: original})
+	require.NoError(t, err)
+	for it.Next() { //nolint:revive
+	}
+	require.NoError(t, it.Close())
+
+	require.Len(t, seen, 2)
+	require.NotSame(t, seen[0], seen[1], "both tenants were handed the same request")
+	require.Len(t, seen[0].Deletes, 1, "one tenant observed another tenant's deletes")
+	require.Len(t, seen[1].Deletes, 1, "one tenant observed another tenant's deletes")
+	require.Empty(t, original.Deletes, "downstream deletes leaked into the caller's request")
+	require.Equal(t, time.Unix(0, 0).UTC(), original.Start.UTC(), "downstream clamped the caller's request")
 }
 
 func TestMultiTenantQuerier_TenantFilter(t *testing.T) {


### PR DESCRIPTION
Fixes #23376.

`MultiTenantQuerier` hands every tenant the same request. `SelectLogParams` and
`SelectSampleParams` embed a pointer (`logql/engine.go:76-78`, `107-109`), and the only copy in the
loop is conditional on a store-chunk override:

```go
tenantParams := params
if tenantChunkOverrides, ok := storeOverridesByTenant[id]; ok {
    tenantParams = tenantParams.WithStoreChunks(...)   // copies
}
iter, err := q.Querier.SelectSamples(singleContext, tenantParams)
```

With no overrides, which is the common case, all tenants share one `*SampleQueryRequest`.
`SingleTenantQuerier` then writes to it in place, three times per call:

| line | write |
|---|---|
| `querier.go:224` | `params.Start, params.End = ValidateQueryRequest(...)`, clamped by per-tenant limits |
| `querier.go:237` | `params.Deletes = DeletesForUserQuery(ctx, ...)`, resolved from the per-tenant context |
| `querier.go:264` | `params.Start = storeQueryInterval.start` |

`SelectLogs` has the same three at `158`, `171`, `201`.

## Two consequences

**Cross-tenant leakage.** Deletes and the validated time range are per-tenant, so tenant B's values
overwrite tenant A's on the shared object. The returned iterators are lazy, so a still-executing
tenant A query can observe tenant B's delete set and clamped window.

**The panic in #23376.** `forAllIngesters` marshals that one request from several goroutines at once
(`ingester_querier.go:259-263`). gogo's `MarshalToSizedBuffer` writes backwards into a buffer sized by
an earlier `Size()`, so a write landing between the two makes the write run off the front of the
buffer. That is the reported `index out of range [-1]` in `encodeVarintLogproto`.

I reproduced that mechanism against `logproto` on `main`: eight goroutines calling `proto.Marshal` on
one `SampleQueryRequest` while another grows `Selector` panics with `slice bounds out of range [-40:]`
within seconds.

## Change

Copy per tenant, which is what `WithStoreChunks` already does one line below. Six lines of production
code, in both `SelectLogs` and `SelectSamples`.

I put the copy here rather than at the entry to `SingleTenantQuerier` deliberately: this is where the
sharing is introduced, and the single-tenant path returns before the loop, so nothing outside
multi-tenant queries changes behaviour.

## Testing

`TestMultiTenantQuerier_EachTenantGetsItsOwnRequest` drives two tenants through a mock querier that
mutates the request the way `SingleTenantQuerier` does, then asserts the tenants got distinct requests,
neither saw the other's deletes, and the caller's request was left alone. It is deterministic and does
not depend on winning a race.

Reverting the `SelectSamples` copy fails it on the assertion, with the two pointers shown identical:

```
Error: Expected and actual point to the same object: 0x767de7ed9900 &logproto.SampleQueryRequest{...}
Messages: both tenants were handed the same request
```

`go test ./pkg/querier/` passes, `go test -race ./pkg/querier/` passes with no races, `go vet` and
gofmt clean.

## Not covered here

`params.Selector` and `params.Plan` are still written to the caller's request before the loop
(`multi_tenant_querier.go:63`, `69`, `119`). That is pre-existing and safe for the callers I could
find, since it happens before any fan-out starts, so I left it alone rather than widen the change. Say
if you would rather the whole function stopped mutating its argument and I will extend it.
