### PR TITLE
fix(logql): Make avg() order-independent with infinite inputs

### DIFF
--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -524,10 +524,16 @@ func (e *VectorAggEvaluator) Next() (bool, int64, StepResult) {
 
 		case syntax.OpTypeAvg:
 			group.groupCount++
-			// The incremental mean below evaluates Inf + (s.F - Inf), which is
-			// NaN once the running mean is infinite. That makes the result
-			// depend on sample order. Guard the two cases where the mean must
-			// keep the infinity it already holds.
+			// Floating-point math has any operation between positive
+			// and a negative Infinity to evaluate to a NaN.
+			//
+			// If our running mean is already +Inf, it will cause the mean
+			// to unintentionally become NaN:
+			//
+			//   Inf + (s.F - Inf) == Inf + (-Inf /* negative from subtraction */) == NaN
+			//
+			// We add checks to prevent unintentional conversions. Explicitly
+			// averaging an +Inf and -Inf will evaluate to NaN as expected.
 			if math.IsInf(group.mean, 0) {
 				if math.IsInf(s.F, 0) && (group.mean > 0) == (s.F > 0) {
 					break // Same-sign infinity leaves the mean unchanged.

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -524,6 +524,18 @@ func (e *VectorAggEvaluator) Next() (bool, int64, StepResult) {
 
 		case syntax.OpTypeAvg:
 			group.groupCount++
+			// The incremental mean below evaluates Inf + (s.F - Inf), which is
+			// NaN once the running mean is infinite. That makes the result
+			// depend on sample order. Guard the two cases where the mean must
+			// keep the infinity it already holds.
+			if math.IsInf(group.mean, 0) {
+				if math.IsInf(s.F, 0) && (group.mean > 0) == (s.F > 0) {
+					break // Same-sign infinity leaves the mean unchanged.
+				}
+				if !math.IsInf(s.F, 0) && !math.IsNaN(s.F) {
+					break // A finite sample cannot change an infinite mean.
+				}
+			}
 			group.mean += (s.F - group.mean) / float64(group.groupCount)
 
 		case syntax.OpTypeMax:

--- a/pkg/logql/internal/logqltest/testdata/vector_aggregations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/vector_aggregations.logqltest
@@ -1,46 +1,484 @@
+# sum()
 clear
 load
-  {app="foo"} "xbar"  @ 0s [repeat every 10s for 19]
-  {app="foo"} "noise" @ 5s [repeat every 10s for 19]
-  {app="bar"} "xbar"  @ 0s [repeat every 20s for 10]
-  {app="bar"} "noise" @ 10s [repeat every 20s for 10]
+  {app="foo", namespace="a", cluster="c1"} "xbar"  @ 10s [repeat every 10s for 18]
+  {app="foo", namespace="a", cluster="c1"} "noise" @ 15s [repeat every 10s for 18]
+  {app="foo", namespace="a", cluster="c2"} "xbar"  @ 5s  [repeat every 5s  for 36]
+  {app="foo", namespace="a", cluster="c2"} "noise" @ 7s  [repeat every 5s  for 36]
+  {app="bar", namespace="b", cluster="c2"} "xbar"  @ 10s [repeat every 10s for 18]
+  {app="bar", namespace="b", cluster="c2"} "noise" @ 15s [repeat every 10s for 18]
+
+eval instant at 60s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {} 24
+eval range from 20s to 60s step 20s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {} 8 16 24
+# sum() by()
+eval instant at 60s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (app)
+  {app="foo"} 18
+  {app="bar"} 6
+eval range from 20s to 60s step 20s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (app)
+  {app="foo"} 6 12 18
+  {app="bar"} 2 4 6
+# sum() without() with a single grouping label
+eval instant at 60s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without (cluster)
+  {app="foo", namespace="a"} 18
+  {app="bar", namespace="b"} 6
+# sum() without() with multiple grouping labels
+eval instant at 60s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without (namespace, cluster)
+  {app="foo"} 18
+  {app="bar"} 6
+eval instant at 60s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without (cluster, namespace)
+  {app="foo"} 18
+  {app="bar"} 6
+# offset shifts the window back
+eval instant at 90s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m] offset 30s)) by (namespace, app)
+  {app="foo", namespace="a"} 18
+  {app="bar", namespace="b"} 6
+
+# sum() with special inputs.
+clear
+load
+  {app="a", k="fin"}  "v=2"    @ 30s
+  {app="a", k="nan"}  "v=NaN"  @ 30s
+  {app="a", k="pinf"} "v=Inf"  @ 30s
+  {app="a", k="ninf"} "v=-Inf" @ 30s
+  {app="noise"}       "z=1"    @ 30s
+
+eval instant at 60s sum(max_over_time({app="a", k=~"fin|nan"} | logfmt | unwrap v [1m]))
+  {} NaN
+eval instant at 60s sum(max_over_time({app="a", k=~"fin|pinf"} | logfmt | unwrap v [1m]))
+  {} +Inf
+eval instant at 60s sum(max_over_time({app="a", k=~"pinf|ninf"} | logfmt | unwrap v [1m]))
+  {} NaN
+eval instant at 60s sum(max_over_time({app="a", k=~"pinf|nan"} | logfmt | unwrap v [1m]))
+  {} NaN
+eval instant at 60s sum(max_over_time({app="a", k=~"ninf|nan"} | logfmt | unwrap v [1m]))
+  {} NaN
+
+# avg()
+clear
+load
+  {app="foo", pod="a", zone="eu"} "xbar"  @ 10s [repeat every 10s for 18]
+  {app="foo", pod="a", zone="eu"} "noise" @ 15s [repeat every 10s for 18]
+  {app="foo", pod="b", zone="eu"} "xbar"  @ 5s  [repeat every 5s  for 36]
+  {app="foo", pod="b", zone="eu"} "noise" @ 7s  [repeat every 5s  for 36]
+  {app="bar", pod="a", zone="us"} "xbar"  @ 5s  [repeat every 5s  for 36]
+  {app="bar", pod="a", zone="us"} "noise" @ 7s  [repeat every 5s  for 36]
+  {app="bar", pod="b", zone="us"} "xbar"  @ 2s  [repeat every 2s  for 90]
+  {app="bar", pod="b", zone="us"} "noise" @ 1s  [repeat every 2s  for 90]
 
 eval instant at 60s avg(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
-  {} 4.5
-eval range from 60s to 180s step 30s avg(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
-  {} 4.5 4.5 4.5 4.5 4.5
+  {} 15
+eval range from 20s to 60s step 20s avg(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {} 5 10 15
+# avg() by()
+eval instant at 60s avg by (app) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 9
+  {app="bar"} 21
+eval range from 20s to 60s step 20s avg by (app) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 3 6 9
+  {app="bar"} 7 14 21
+# avg() without() with a single grouping label
+eval instant at 60s avg without (pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", zone="eu"} 9
+  {app="bar", zone="us"} 21
+# avg() without() with multiple grouping labels
+eval instant at 60s avg without (pod, zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 9
+  {app="bar"} 21
 
-eval instant at 60s min(rate({app=~"foo|bar"} |~".+bar" [1m]))
-  {} 0.05
-eval range from 60s to 180s step 30s min(rate({app=~"foo|bar"} |~".+bar" [1m]))
-  {} 0.05 0.05 0.05 0.05 0.05
+# avg() with special inputs.
+clear
+load
+  {app="a", k="fin"}  "v=2"    @ 30s
+  {app="a", k="nan"}  "v=NaN"  @ 30s
+  {app="a", k="pinf"} "v=Inf"  @ 30s
+  {app="a", k="ninf"} "v=-Inf" @ 30s
+  {app="noise"}       "z=1"    @ 30s
 
-eval instant at 60s max by (app) (rate({app=~"foo|bar"} |~".+bar" [1m]))
-  {app="foo"} 0.1
-  {app="bar"} 0.05
-eval range from 60s to 180s step 30s max by (app) (rate({app=~"foo|bar"} |~".+bar" [1m]))
-  {app="foo"} 0.1 0.1 0.1 0.1 0.1
-  {app="bar"} 0.05 0.05 0.05 0.05 0.05
+eval instant at 60s avg(max_over_time({app="a", k=~"fin|nan"} | logfmt | unwrap v [1m]))
+  {} NaN
+eval instant at 60s avg(max_over_time({app="a", k=~"fin|pinf"} | logfmt | unwrap v [1m]))
+  {} +Inf
+eval instant at 60s avg(max_over_time({app="a", k=~"pinf|ninf"} | logfmt | unwrap v [1m]))
+  {} NaN
+eval instant at 60s avg(max_over_time({app="a", k=~"pinf|nan"} | logfmt | unwrap v [1m]))
+  {} NaN
+eval instant at 60s avg(max_over_time({app="a", k=~"ninf|nan"} | logfmt | unwrap v [1m]))
+  {} NaN
 
-eval instant at 60s max(rate({app=~"foo|bar"} |~".+bar" [1m]))
-  {} 0.1
-eval range from 60s to 180s step 30s max(rate({app=~"foo|bar"} |~".+bar" [1m]))
-  {} 0.1 0.1 0.1 0.1 0.1
+# min()
+clear
+load
+  {app="foo", pod="a", zone="eu"} "xbar"  @ 10s [repeat every 10s for 18]
+  {app="foo", pod="a", zone="eu"} "noise" @ 15s [repeat every 10s for 18]
+  {app="foo", pod="b", zone="eu"} "xbar"  @ 5s  [repeat every 5s  for 36]
+  {app="foo", pod="b", zone="eu"} "noise" @ 7s  [repeat every 5s  for 36]
+  {app="bar", pod="a", zone="us"} "xbar"  @ 5s  [repeat every 5s  for 36]
+  {app="bar", pod="a", zone="us"} "noise" @ 7s  [repeat every 5s  for 36]
+  {app="bar", pod="b", zone="us"} "xbar"  @ 2s  [repeat every 2s  for 90]
+  {app="bar", pod="b", zone="us"} "noise" @ 1s  [repeat every 2s  for 90]
 
-eval instant at 60s sum(rate({app=~"foo|bar"} |~".+bar" [1m]))
-  {} 0.15
-eval range from 60s to 180s step 30s sum(rate({app=~"foo|bar"} |~".+bar" [1m]))
-  {} 0.15 0.15 0.15 0.15 0.15
+eval instant at 60s min(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {} 6
+eval range from 20s to 60s step 20s min(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {} 2 4 6
+# min() by()
+eval instant at 60s min by (app) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 6
+  {app="bar"} 12
+eval range from 20s to 60s step 20s min by (app) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 2 4 6
+  {app="bar"} 4 8 12
+# min() without() with a single grouping label
+eval instant at 60s min without (pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", zone="eu"} 6
+  {app="bar", zone="us"} 12
+# min() without() with multiple grouping labels
+eval instant at 60s min without (pod, zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 6
+  {app="bar"} 12
 
-eval instant at 60s count(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without (app)
+# min() with special inputs.
+clear
+load
+  {app="a", k="fin"}  "v=2"    @ 30s
+  {app="a", k="nan"}  "v=NaN"  @ 30s
+  {app="a", k="pinf"} "v=Inf"  @ 30s
+  {app="a", k="ninf"} "v=-Inf" @ 30s
+  {app="noise"}       "z=1"    @ 30s
+
+eval instant at 60s min(max_over_time({app="a", k=~"fin|nan"} | logfmt | unwrap v [1m]))
   {} 2
-eval range from 60s to 180s step 30s count(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without (app)
-  {} 2 2 2 2 2
+eval instant at 60s min(max_over_time({app="a", k=~"fin|pinf"} | logfmt | unwrap v [1m]))
+  {} 2
+eval instant at 60s min(max_over_time({app="a", k=~"pinf|ninf"} | logfmt | unwrap v [1m]))
+  {} -Inf
+eval instant at 60s min(max_over_time({app="a", k=~"pinf|nan"} | logfmt | unwrap v [1m]))
+  {} +Inf
+eval instant at 60s min(max_over_time({app="a", k=~"ninf|nan"} | logfmt | unwrap v [1m]))
+  {} -Inf
 
-# topk(), bottomk(), sort() and sort_desc()
-#
-# In this scenario, "foo" and "bar" apps are each split by pod, so {app=~"foo|bar"} selector
-# matches four distinct rates: foo/a=0.1, foo/b=0.2, bar/a=0.05, bar/b=0.25.
+# max()
+clear
+load
+  {app="foo", pod="a", zone="eu"} "xbar"  @ 10s [repeat every 10s for 18]
+  {app="foo", pod="a", zone="eu"} "noise" @ 15s [repeat every 10s for 18]
+  {app="foo", pod="b", zone="eu"} "xbar"  @ 5s  [repeat every 5s  for 36]
+  {app="foo", pod="b", zone="eu"} "noise" @ 7s  [repeat every 5s  for 36]
+  {app="bar", pod="a", zone="us"} "xbar"  @ 5s  [repeat every 5s  for 36]
+  {app="bar", pod="a", zone="us"} "noise" @ 7s  [repeat every 5s  for 36]
+  {app="bar", pod="b", zone="us"} "xbar"  @ 2s  [repeat every 2s  for 90]
+  {app="bar", pod="b", zone="us"} "noise" @ 1s  [repeat every 2s  for 90]
+
+eval instant at 60s max(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {} 30
+eval range from 20s to 60s step 20s max(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {} 10 20 30
+# max() by()
+eval instant at 60s max by (app) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 12
+  {app="bar"} 30
+eval range from 20s to 60s step 20s max by (app) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 4 8 12
+  {app="bar"} 10 20 30
+# max() without() with a single grouping label
+eval instant at 60s max without (pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", zone="eu"} 12
+  {app="bar", zone="us"} 30
+# max() without() with multiple grouping labels
+eval instant at 60s max without (pod, zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 12
+  {app="bar"} 30
+
+# max() with special inputs.
+clear
+load
+  {app="a", k="fin"}  "v=2"    @ 30s
+  {app="a", k="nan"}  "v=NaN"  @ 30s
+  {app="a", k="pinf"} "v=Inf"  @ 30s
+  {app="a", k="ninf"} "v=-Inf" @ 30s
+  {app="noise"}       "z=1"    @ 30s
+
+eval instant at 60s max(max_over_time({app="a", k=~"fin|nan"} | logfmt | unwrap v [1m]))
+  {} 2
+eval instant at 60s max(max_over_time({app="a", k=~"fin|pinf"} | logfmt | unwrap v [1m]))
+  {} +Inf
+eval instant at 60s max(max_over_time({app="a", k=~"pinf|ninf"} | logfmt | unwrap v [1m]))
+  {} +Inf
+eval instant at 60s max(max_over_time({app="a", k=~"pinf|nan"} | logfmt | unwrap v [1m]))
+  {} +Inf
+eval instant at 60s max(max_over_time({app="a", k=~"ninf|nan"} | logfmt | unwrap v [1m]))
+  {} -Inf
+
+# count()
+# The pods start at different times, so as the window slides more streams enter it.
+clear
+load
+  {app="foo", pod="a", zone="eu"} "xbar"  @ 10s [repeat every 10s for 18]
+  {app="foo", pod="a", zone="eu"} "noise" @ 15s [repeat every 10s for 18]
+  {app="foo", pod="b", zone="eu"} "xbar"  @ 30s [repeat every 10s for 16]
+  {app="foo", pod="b", zone="eu"} "noise" @ 35s [repeat every 10s for 16]
+  {app="bar", pod="a", zone="us"} "xbar"  @ 50s [repeat every 10s for 14]
+  {app="bar", pod="a", zone="us"} "noise" @ 55s [repeat every 10s for 14]
+
+eval instant at 60s count(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {} 3
+eval range from 20s to 60s step 20s count(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {} 1 2 3
+# count() by()
+eval instant at 60s count by (app) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 2
+  {app="bar"} 1
+eval range from 20s to 60s step 20s count by (app) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 1 2 2
+  {app="bar"} _ _ 1
+# count() without() with a single grouping label
+eval instant at 60s count without (pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", zone="eu"} 2
+  {app="bar", zone="us"} 1
+# count() without() with multiple grouping labels
+eval instant at 60s count without (pod, zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 2
+  {app="bar"} 1
+
+# count() with special inputs.
+clear
+load
+  {app="a", k="fin"}  "v=2"    @ 30s
+  {app="a", k="nan"}  "v=NaN"  @ 30s
+  {app="a", k="pinf"} "v=Inf"  @ 30s
+  {app="a", k="ninf"} "v=-Inf" @ 30s
+  {app="noise"}       "z=1"    @ 30s
+
+# count is value-insensitive, so each added NaN or infinity raises the count.
+eval instant at 60s count(max_over_time({app="a", k="fin"} | logfmt | unwrap v [1m]))
+  {} 1
+eval instant at 60s count(max_over_time({app="a", k=~"fin|nan"} | logfmt | unwrap v [1m]))
+  {} 2
+eval instant at 60s count(max_over_time({app="a", k=~"fin|nan|pinf"} | logfmt | unwrap v [1m]))
+  {} 3
+eval instant at 60s count(max_over_time({app="a"} | logfmt | unwrap v [1m]))
+  {} 4
+
+# stddev()
+clear
+load
+  {app="foo", pod="a", zone="eu"} "xbar"  @ 10s [repeat every 10s for 18]
+  {app="foo", pod="a", zone="eu"} "noise" @ 15s [repeat every 10s for 18]
+  {app="foo", pod="b", zone="eu"} "xbar"  @ 5s  [repeat every 5s  for 36]
+  {app="foo", pod="b", zone="eu"} "noise" @ 7s  [repeat every 5s  for 36]
+  {app="bar", pod="a", zone="us"} "xbar"  @ 5s  [repeat every 5s  for 36]
+  {app="bar", pod="a", zone="us"} "noise" @ 7s  [repeat every 5s  for 36]
+  {app="bar", pod="b", zone="us"} "xbar"  @ 2s  [repeat every 2s  for 90]
+  {app="bar", pod="b", zone="us"} "noise" @ 1s  [repeat every 2s  for 90]
+
+eval instant at 60s stddev(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {} 9
+eval range from 20s to 60s step 20s stddev(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {} 3 6 9
+# stddev() by()
+eval instant at 60s stddev by (app) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 3
+  {app="bar"} 9
+eval range from 20s to 60s step 20s stddev by (app) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 1 2 3
+  {app="bar"} 3 6 9
+# stddev() without() with a single grouping label
+eval instant at 60s stddev without (pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", zone="eu"} 3
+  {app="bar", zone="us"} 9
+# stddev() without() with multiple grouping labels
+eval instant at 60s stddev without (pod, zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 3
+  {app="bar"} 9
+
+# stddev() with special inputs.
+clear
+load
+  {app="a", k="fin"}  "v=2"    @ 30s
+  {app="a", k="nan"}  "v=NaN"  @ 30s
+  {app="a", k="pinf"} "v=Inf"  @ 30s
+  {app="a", k="ninf"} "v=-Inf" @ 30s
+  {app="noise"}       "z=1"    @ 30s
+
+# A NaN input, or any infinity in the variance, makes the result NaN.
+eval instant at 60s stddev(max_over_time({app="a", k=~"fin|nan"} | logfmt | unwrap v [1m]))
+  {} NaN
+eval instant at 60s stddev(max_over_time({app="a", k=~"fin|pinf"} | logfmt | unwrap v [1m]))
+  {} NaN
+eval instant at 60s stddev(max_over_time({app="a", k=~"pinf|ninf"} | logfmt | unwrap v [1m]))
+  {} NaN
+eval instant at 60s stddev(max_over_time({app="a", k=~"pinf|nan"} | logfmt | unwrap v [1m]))
+  {} NaN
+eval instant at 60s stddev(max_over_time({app="a", k=~"ninf|nan"} | logfmt | unwrap v [1m]))
+  {} NaN
+
+# stdvar()
+clear
+load
+  {app="foo", pod="a", zone="eu"} "xbar"  @ 10s [repeat every 10s for 18]
+  {app="foo", pod="a", zone="eu"} "noise" @ 15s [repeat every 10s for 18]
+  {app="foo", pod="b", zone="eu"} "xbar"  @ 5s  [repeat every 5s  for 36]
+  {app="foo", pod="b", zone="eu"} "noise" @ 7s  [repeat every 5s  for 36]
+  {app="bar", pod="a", zone="us"} "xbar"  @ 5s  [repeat every 5s  for 36]
+  {app="bar", pod="a", zone="us"} "noise" @ 7s  [repeat every 5s  for 36]
+  {app="bar", pod="b", zone="us"} "xbar"  @ 2s  [repeat every 2s  for 90]
+  {app="bar", pod="b", zone="us"} "noise" @ 1s  [repeat every 2s  for 90]
+
+eval instant at 60s stdvar(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {} 81
+eval range from 20s to 60s step 20s stdvar(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {} 9 36 81
+# stdvar() by()
+eval instant at 60s stdvar by (app) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 9
+  {app="bar"} 81
+eval range from 20s to 60s step 20s stdvar by (app) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 1 4 9
+  {app="bar"} 9 36 81
+# stdvar() without() with a single grouping label
+eval instant at 60s stdvar without (pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", zone="eu"} 9
+  {app="bar", zone="us"} 81
+# stdvar() without() with multiple grouping labels
+eval instant at 60s stdvar without (pod, zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo"} 9
+  {app="bar"} 81
+
+# stdvar() with special inputs.
+clear
+load
+  {app="a", k="fin"}  "v=2"    @ 30s
+  {app="a", k="nan"}  "v=NaN"  @ 30s
+  {app="a", k="pinf"} "v=Inf"  @ 30s
+  {app="a", k="ninf"} "v=-Inf" @ 30s
+  {app="noise"}       "z=1"    @ 30s
+
+# A NaN input, or any infinity in the variance, makes the result NaN.
+eval instant at 60s stdvar(max_over_time({app="a", k=~"fin|nan"} | logfmt | unwrap v [1m]))
+  {} NaN
+eval instant at 60s stdvar(max_over_time({app="a", k=~"fin|pinf"} | logfmt | unwrap v [1m]))
+  {} NaN
+eval instant at 60s stdvar(max_over_time({app="a", k=~"pinf|ninf"} | logfmt | unwrap v [1m]))
+  {} NaN
+eval instant at 60s stdvar(max_over_time({app="a", k=~"pinf|nan"} | logfmt | unwrap v [1m]))
+  {} NaN
+eval instant at 60s stdvar(max_over_time({app="a", k=~"ninf|nan"} | logfmt | unwrap v [1m]))
+  {} NaN
+
+# topk() selects – it does not aggregate.
+clear
+load
+  {app="foo", pod="a"} "xbar"  @ 10s [repeat every 10s for 18]
+  {app="foo", pod="a"} "noise" @ 15s [repeat every 10s for 18]
+  {app="foo", pod="b"} "xbar"  @ 5s  [repeat every 5s  for 36]
+  {app="foo", pod="b"} "noise" @ 7s  [repeat every 5s  for 36]
+  {app="bar", pod="a"} "xbar"  @ 4s  [repeat every 4s  for 45]
+  {app="bar", pod="a"} "noise" @ 2s  [repeat every 4s  for 45]
+  {app="bar", pod="b"} "xbar"  @ 2s  [repeat every 2s  for 90]
+  {app="bar", pod="b"} "noise" @ 1s  [repeat every 2s  for 90]
+
+eval instant at 60s topk(2, count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="bar", pod="b"} 30
+  {app="bar", pod="a"} 15
+eval range from 20s to 60s step 20s topk(2, count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="bar", pod="b"} 10 20 30
+  {app="bar", pod="a"} 5 10 15
+eval instant at 60s topk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="bar", pod="b"} 30
+# topk() by()
+eval instant at 60s topk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (app)
+  {app="foo", pod="b"} 12
+  {app="bar", pod="b"} 30
+# topk() without() with a single grouping label
+eval instant at 60s topk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without (app)
+  {app="bar", pod="a"} 15
+  {app="bar", pod="b"} 30
+# topk() without() with multiple grouping labels leaves one group, so it selects globally.
+eval instant at 60s topk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without (app, pod)
+  {app="bar", pod="b"} 30
+# topk() with an invalid or missing parameter.
+eval instant at 60s topk(1.5, count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  expect fail msg: invalid parameter
+eval instant at 60s topk(count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  expect fail msg: parameter required
+
+# topk() with special inputs.
+clear
+load
+  {app="a", k="fin"}  "v=2"    @ 30s
+  {app="a", k="nan"}  "v=NaN"  @ 30s
+  {app="a", k="pinf"} "v=Inf"  @ 30s
+  {app="a", k="ninf"} "v=-Inf" @ 30s
+  {app="noise"}       "z=1"    @ 30s
+
+# topk(1) drops NaN and treats an infinity as the extreme.
+eval instant at 60s topk(1, max_over_time({app="a", k=~"fin|nan"} | logfmt | unwrap v [1m]))
+  {app="a", k="fin"} 2
+eval instant at 60s topk(1, max_over_time({app="a", k=~"fin|pinf"} | logfmt | unwrap v [1m]))
+  {app="a", k="pinf"} +Inf
+eval instant at 60s topk(1, max_over_time({app="a", k=~"pinf|ninf"} | logfmt | unwrap v [1m]))
+  {app="a", k="pinf"} +Inf
+eval instant at 60s topk(1, max_over_time({app="a", k=~"pinf|nan"} | logfmt | unwrap v [1m]))
+  {app="a", k="pinf"} +Inf
+eval instant at 60s topk(1, max_over_time({app="a", k=~"ninf|nan"} | logfmt | unwrap v [1m]))
+  {app="a", k="ninf"} -Inf
+
+# bottomk() selects – it does not aggregate.
+clear
+load
+  {app="foo", pod="a"} "xbar"  @ 10s [repeat every 10s for 18]
+  {app="foo", pod="a"} "noise" @ 15s [repeat every 10s for 18]
+  {app="foo", pod="b"} "xbar"  @ 5s  [repeat every 5s  for 36]
+  {app="foo", pod="b"} "noise" @ 7s  [repeat every 5s  for 36]
+  {app="bar", pod="a"} "xbar"  @ 4s  [repeat every 4s  for 45]
+  {app="bar", pod="a"} "noise" @ 2s  [repeat every 4s  for 45]
+  {app="bar", pod="b"} "xbar"  @ 2s  [repeat every 2s  for 90]
+  {app="bar", pod="b"} "noise" @ 1s  [repeat every 2s  for 90]
+
+eval instant at 60s bottomk(2, count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", pod="a"} 6
+  {app="foo", pod="b"} 12
+eval range from 20s to 60s step 20s bottomk(2, count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", pod="a"} 2 4 6
+  {app="foo", pod="b"} 4 8 12
+eval instant at 60s bottomk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", pod="a"} 6
+# bottomk() by()
+eval instant at 60s bottomk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (app)
+  {app="foo", pod="a"} 6
+  {app="bar", pod="a"} 15
+# bottomk() without() with a single grouping label
+eval instant at 60s bottomk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without (app)
+  {app="foo", pod="a"} 6
+  {app="foo", pod="b"} 12
+# bottomk() without() with multiple grouping labels leaves one group, so it selects globally.
+eval instant at 60s bottomk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without (app, pod)
+  {app="foo", pod="a"} 6
+
+# bottomk() with special inputs.
+clear
+load
+  {app="a", k="fin"}  "v=2"    @ 30s
+  {app="a", k="nan"}  "v=NaN"  @ 30s
+  {app="a", k="pinf"} "v=Inf"  @ 30s
+  {app="a", k="ninf"} "v=-Inf" @ 30s
+  {app="noise"}       "z=1"    @ 30s
+
+# bottomk(1) drops NaN and treats an infinity as the extreme.
+eval instant at 60s bottomk(1, max_over_time({app="a", k=~"fin|nan"} | logfmt | unwrap v [1m]))
+  {app="a", k="fin"} 2
+eval instant at 60s bottomk(1, max_over_time({app="a", k=~"fin|pinf"} | logfmt | unwrap v [1m]))
+  {app="a", k="fin"} 2
+eval instant at 60s bottomk(1, max_over_time({app="a", k=~"pinf|ninf"} | logfmt | unwrap v [1m]))
+  {app="a", k="ninf"} -Inf
+eval instant at 60s bottomk(1, max_over_time({app="a", k=~"pinf|nan"} | logfmt | unwrap v [1m]))
+  {app="a", k="pinf"} +Inf
+eval instant at 60s bottomk(1, max_over_time({app="a", k=~"ninf|nan"} | logfmt | unwrap v [1m]))
+  {app="a", k="ninf"} -Inf
+
+# sort() / sort_desc() order the vector by value. They are instant-only.
 clear
 load
   {app="foo", pod="a"} "xbar"  @ 0s  [repeat every 10s for 19]
@@ -52,46 +490,6 @@ load
   {app="bar", pod="b"} "xbar"  @ 0s  [repeat every 4s  for 46]
   {app="bar", pod="b"} "noise" @ 2s  [repeat every 4s  for 46]
 
-eval instant at 60s topk(2,rate(({app=~"foo|bar"} |~".+bar")[1m]))
-  {app="bar", pod="b"} 0.25
-  {app="foo", pod="b"} 0.2
-eval range from 60s to 180s step 30s topk(2,rate(({app=~"foo|bar"} |~".+bar")[1m]))
-  {app="bar", pod="b"} 0.25 0.25 0.25 0.25 0.25
-  {app="foo", pod="b"} 0.2 0.2 0.2 0.2 0.2
-
-eval instant at 60s topk(1,rate(({app=~"foo|bar"} |~".+bar")[1m]))
-  {app="bar", pod="b"} 0.25
-eval range from 60s to 180s step 30s topk(1,rate(({app=~"foo|bar"} |~".+bar")[1m]))
-  {app="bar", pod="b"} 0.25 0.25 0.25 0.25 0.25
-
-eval instant at 60s topk(1,rate(({app=~"foo|bar"} |~".+bar")[1m])) by (app)
-  {app="foo", pod="b"} 0.2
-  {app="bar", pod="b"} 0.25
-eval range from 60s to 180s step 30s topk(1,rate(({app=~"foo|bar"} |~".+bar")[1m])) by (app)
-  {app="foo", pod="b"} 0.2 0.2 0.2 0.2 0.2
-  {app="bar", pod="b"} 0.25 0.25 0.25 0.25 0.25
-
-eval instant at 60s bottomk(2,rate(({app=~"foo|bar"} |~".+bar")[1m]))
-  {app="bar", pod="a"} 0.05
-  {app="foo", pod="a"} 0.1
-eval range from 60s to 180s step 30s bottomk(2,rate(({app=~"foo|bar"} |~".+bar")[1m]))
-  {app="bar", pod="a"} 0.05 0.05 0.05 0.05 0.05
-  {app="foo", pod="a"} 0.1 0.1 0.1 0.1 0.1
-
-eval instant at 60s bottomk(1,rate(({app=~"foo|bar"} |~".+bar")[1m]))
-  {app="bar", pod="a"} 0.05
-eval range from 60s to 180s step 30s bottomk(1,rate(({app=~"foo|bar"} |~".+bar")[1m]))
-  {app="bar", pod="a"} 0.05 0.05 0.05 0.05 0.05
-
-eval instant at 60s bottomk(1,rate(({app=~"foo|bar"} |~".+bar")[1m])) by (app)
-  {app="foo", pod="a"} 0.1
-  {app="bar", pod="a"} 0.05
-eval range from 60s to 180s step 30s bottomk(1,rate(({app=~"foo|bar"} |~".+bar")[1m])) by (app)
-  {app="foo", pod="a"} 0.1 0.1 0.1 0.1 0.1
-  {app="bar", pod="a"} 0.05 0.05 0.05 0.05 0.05
-
-# The four values interleave against label order, so sort by value is distinguishable
-# from sort by label.
 eval instant at 60s sort(rate(({app=~"foo|bar"} |~".+bar")[1m]))  + 1
   expect ordered
   {app="bar", pod="a"} 1.05
@@ -105,107 +503,28 @@ eval instant at 60s sort_desc(rate(({app=~"foo|bar"} |~".+bar")[1m]))  + 1
   {app="foo", pod="a"} 1.1
   {app="bar", pod="a"} 1.05
 
-# bottomk(3) without (app) drops the highest-rate stream (buzz).
+# sort() / sort_desc() with special inputs.
+#
+# - ±Inf order like any value.
+# - A single NaN sorts to the end in both directions. Two or more NaN keep no stable
+#   order among themselves, so test just one.
 clear
 load
-  {app="foo"} "xbar"  @ 0s [repeat every 10s for 19]
-  {app="foo"} "noise" @ 5s [repeat every 10s for 19]
-  {app="bar"} "xbar"  @ 0s [repeat every 20s for 10]
-  {app="bar"} "noise" @ 10s [repeat every 20s for 10]
-  {app="fuzz"} "xbar"  @ 0s [repeat every 5s for 37]
-  {app="fuzz"} "noise" @ 2s [repeat every 5s for 37]
-  {app="buzz"} "xbar"  @ 0s [repeat every 4s for 46]
-  {app="buzz"} "noise" @ 2s [repeat every 4s for 46]
+  {app="a", k="fin"}  "v=2"    @ 30s
+  {app="a", k="nan"}  "v=NaN"  @ 30s
+  {app="a", k="pinf"} "v=Inf"  @ 30s
+  {app="a", k="ninf"} "v=-Inf" @ 30s
+  {app="noise"}       "z=1"    @ 30s
 
-eval instant at 60s bottomk(3,rate(({app=~"foo|bar|fuzz|buzz"} |~".+bar")[1m])) without (app)
-  {app="foo"} 0.1
-  {app="bar"} 0.05
-  {app="fuzz"} 0.2
-eval range from 60s to 180s step 30s bottomk(3,rate(({app=~"foo|bar|fuzz|buzz"} |~".+bar")[1m])) without (app)
-  {app="foo"} 0.1 0.1 0.1 0.1 0.1
-  {app="bar"} 0.05 0.05 0.05 0.05 0.05
-  {app="fuzz"} 0.2 0.2 0.2 0.2 0.2
-
-eval instant at 60s bottomk(3,rate(({app=~"foo|bar|fuzz|buzz"} |~".+bar")[1m])) without (app) + 1
-  {app="foo"} 1.1
-  {app="bar"} 1.05
-  {app="fuzz"} 1.2
-eval range from 60s to 180s step 30s bottomk(3,rate(({app=~"foo|bar|fuzz|buzz"} |~".+bar")[1m])) without (app) + 1
-  {app="foo"} 1.1 1.1 1.1 1.1 1.1
-  {app="bar"} 1.05 1.05 1.05 1.05 1.05
-  {app="fuzz"} 1.2 1.2 1.2 1.2 1.2
-
-# Grouping.
-clear
-load
-  {app="foo", namespace="a", cluster="c1"} "xbar"  @ 0s [repeat every 10s for 19]
-  {app="foo", namespace="a", cluster="c1"} "noise" @ 5s [repeat every 10s for 19]
-  {app="foo", namespace="a", cluster="c2"} "xbar"  @ 0s [repeat every 5s  for 37]
-  {app="foo", namespace="a", cluster="c2"} "noise" @ 2s [repeat every 5s  for 37]
-  {app="bar", namespace="b", cluster="c2"} "xbar"  @ 0s [repeat every 10s for 19]
-  {app="bar", namespace="b", cluster="c2"} "noise" @ 5s [repeat every 10s for 19]
-
-eval instant at 60s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (app)
-  {app="foo"} 18
-  {app="bar"} 6
-eval range from 60s to 180s step 30s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (app)
-  {app="foo"} 18 18 18 18 18
-  {app="bar"} 6 6 6 6 6
-
-eval instant at 60s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (namespace, app)
-  {app="foo", namespace="a"} 18
-  {app="bar", namespace="b"} 6
-eval range from 60s to 180s step 30s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (namespace, app)
-  {app="foo", namespace="a"} 18 18 18 18 18
-  {app="bar", namespace="b"} 6 6 6 6 6
-
-eval instant at 60s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (namespace,cluster, app)
-  {app="foo", namespace="a", cluster="c1"} 6
-  {app="foo", namespace="a", cluster="c2"} 12
-  {app="bar", namespace="b", cluster="c2"} 6
-eval range from 60s to 180s step 30s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (namespace,cluster, app)
-  {app="foo", namespace="a", cluster="c1"} 6 6 6 6 6
-  {app="foo", namespace="a", cluster="c2"} 12 12 12 12 12
-  {app="bar", namespace="b", cluster="c2"} 6 6 6 6 6
-
-eval instant at 60s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (cluster, namespace, app)
-  {app="foo", namespace="a", cluster="c1"} 6
-  {app="foo", namespace="a", cluster="c2"} 12
-  {app="bar", namespace="b", cluster="c2"} 6
-eval range from 60s to 180s step 30s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) by (cluster, namespace, app)
-  {app="foo", namespace="a", cluster="c1"} 6 6 6 6 6
-  {app="foo", namespace="a", cluster="c2"} 12 12 12 12 12
-  {app="bar", namespace="b", cluster="c2"} 6 6 6 6 6
-
-eval instant at 90s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m] offset 30s)) by (namespace,app)
-  {app="foo", namespace="a"} 18
-  {app="bar", namespace="b"} 6
-eval range from 60s to 180s step 30s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m] offset 30s)) by (namespace,app)
-  {app="foo", namespace="a"} 11 18 18 18 18
-  {app="bar", namespace="b"} 4 6 6 6 6
-
-# stdvar without (app): counts 6 and 12 → variance 9.
-clear
-load
-  {app="foo"} "xbar"  @ 0s [repeat every 10s for 19]
-  {app="foo"} "noise" @ 5s [repeat every 10s for 19]
-  {app="bar"} "xbar"  @ 0s [repeat every 5s for 37]
-  {app="bar"} "noise" @ 2s [repeat every 5s for 37]
-
-eval instant at 60s stdvar without (app) (count_over_time(({app=~"foo|bar"} |~".+bar")[1m]))
-  {} 9
-eval range from 60s to 180s step 30s stdvar without (app) (count_over_time(({app=~"foo|bar"} |~".+bar")[1m]))
-  {} 9 9 9 9 9
-
-# stddev: counts 6 and 30 → stddev 12.
-clear
-load
-  {app="foo"} "xbar"  @ 0s [repeat every 10s for 19]
-  {app="foo"} "noise" @ 5s [repeat every 10s for 19]
-  {app="bar"} "xbar"  @ 0s [repeat every 2s for 91]
-  {app="bar"} "noise" @ 1s [repeat every 2s for 91]
-
-eval instant at 60s stddev(count_over_time(({app=~"foo|bar"} |~".+bar")[1m]))
-  {} 12
-eval range from 60s to 180s step 30s stddev(count_over_time(({app=~"foo|bar"} |~".+bar")[1m]))
-  {} 12 12 12 12 12
+eval instant at 60s sort(max_over_time({app="a"} | logfmt | unwrap v [1m]))
+  expect ordered
+  {app="a", k="ninf"} -Inf
+  {app="a", k="fin"} 2
+  {app="a", k="pinf"} +Inf
+  {app="a", k="nan"} NaN
+eval instant at 60s sort_desc(max_over_time({app="a"} | logfmt | unwrap v [1m]))
+  expect ordered
+  {app="a", k="pinf"} +Inf
+  {app="a", k="fin"} 2
+  {app="a", k="ninf"} -Inf
+  {app="a", k="nan"} NaN

--- a/pkg/logql/internal/logqltest/testdata/vector_aggregations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/vector_aggregations.logqltest
@@ -30,6 +30,11 @@ eval instant at 60s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) withou
 eval instant at 60s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without (cluster, namespace)
   {app="foo"} 18
   {app="bar"} 6
+# sum() without() with no grouping labels keeps every label.
+eval instant at 60s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without ()
+  {app="foo", namespace="a", cluster="c1"} 6
+  {app="foo", namespace="a", cluster="c2"} 12
+  {app="bar", namespace="b", cluster="c2"} 6
 # offset shifts the window back
 eval instant at 90s sum(count_over_time({app=~"foo|bar"} |~".+bar" [1m] offset 30s)) by (namespace, app)
   {app="foo", namespace="a"} 18
@@ -86,6 +91,12 @@ eval instant at 60s avg without (pod) (count_over_time({app=~"foo|bar"} |~".+bar
 eval instant at 60s avg without (pod, zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
   {app="foo"} 9
   {app="bar"} 21
+# avg() without() with no grouping labels keeps every label.
+eval instant at 60s avg without () (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", pod="a", zone="eu"} 6
+  {app="foo", pod="b", zone="eu"} 12
+  {app="bar", pod="a", zone="us"} 12
+  {app="bar", pod="b", zone="us"} 30
 
 # avg() with special inputs.
 clear
@@ -138,6 +149,12 @@ eval instant at 60s min without (pod) (count_over_time({app=~"foo|bar"} |~".+bar
 eval instant at 60s min without (pod, zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
   {app="foo"} 6
   {app="bar"} 12
+# min() without() with no grouping labels keeps every label.
+eval instant at 60s min without () (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", pod="a", zone="eu"} 6
+  {app="foo", pod="b", zone="eu"} 12
+  {app="bar", pod="a", zone="us"} 12
+  {app="bar", pod="b", zone="us"} 30
 
 # min() with special inputs.
 clear
@@ -190,6 +207,12 @@ eval instant at 60s max without (pod) (count_over_time({app=~"foo|bar"} |~".+bar
 eval instant at 60s max without (pod, zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
   {app="foo"} 12
   {app="bar"} 30
+# max() without() with no grouping labels keeps every label.
+eval instant at 60s max without () (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", pod="a", zone="eu"} 6
+  {app="foo", pod="b", zone="eu"} 12
+  {app="bar", pod="a", zone="us"} 12
+  {app="bar", pod="b", zone="us"} 30
 
 # max() with special inputs.
 clear
@@ -241,6 +264,11 @@ eval instant at 60s count without (pod) (count_over_time({app=~"foo|bar"} |~".+b
 eval instant at 60s count without (pod, zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
   {app="foo"} 2
   {app="bar"} 1
+# count() without() with no grouping labels keeps every label.
+eval instant at 60s count without () (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", pod="a", zone="eu"} 1
+  {app="foo", pod="b", zone="eu"} 1
+  {app="bar", pod="a", zone="us"} 1
 
 # count() with special inputs.
 clear
@@ -292,6 +320,12 @@ eval instant at 60s stddev without (pod) (count_over_time({app=~"foo|bar"} |~".+
 eval instant at 60s stddev without (pod, zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
   {app="foo"} 3
   {app="bar"} 9
+# stddev() without() with no grouping labels keeps every label. Each series is its own group, so each deviates 0.
+eval instant at 60s stddev without () (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", pod="a", zone="eu"} 0
+  {app="foo", pod="b", zone="eu"} 0
+  {app="bar", pod="a", zone="us"} 0
+  {app="bar", pod="b", zone="us"} 0
 
 # stddev() with special inputs.
 clear
@@ -345,6 +379,12 @@ eval instant at 60s stdvar without (pod) (count_over_time({app=~"foo|bar"} |~".+
 eval instant at 60s stdvar without (pod, zone) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
   {app="foo"} 9
   {app="bar"} 81
+# stdvar() without() with no grouping labels keeps every label. Each series is its own group, so each varies 0.
+eval instant at 60s stdvar without () (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
+  {app="foo", pod="a", zone="eu"} 0
+  {app="foo", pod="b", zone="eu"} 0
+  {app="bar", pod="a", zone="us"} 0
+  {app="bar", pod="b", zone="us"} 0
 
 # stdvar() with special inputs.
 clear
@@ -397,6 +437,12 @@ eval instant at 60s topk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m])) wi
   {app="bar", pod="b"} 30
 # topk() without() with multiple grouping labels leaves one group, so it selects globally.
 eval instant at 60s topk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without (app, pod)
+  {app="bar", pod="b"} 30
+# topk() without() with no grouping labels keeps every label.
+eval instant at 60s topk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without ()
+  {app="foo", pod="a"} 6
+  {app="foo", pod="b"} 12
+  {app="bar", pod="a"} 15
   {app="bar", pod="b"} 30
 # topk() with an invalid or missing parameter.
 eval instant at 60s topk(1.5, count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
@@ -456,6 +502,12 @@ eval instant at 60s bottomk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m]))
 # bottomk() without() with multiple grouping labels leaves one group, so it selects globally.
 eval instant at 60s bottomk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without (app, pod)
   {app="foo", pod="a"} 6
+# bottomk() without() with no grouping labels keeps every label.
+eval instant at 60s bottomk(1, count_over_time({app=~"foo|bar"} |~".+bar" [1m])) without ()
+  {app="foo", pod="a"} 6
+  {app="foo", pod="b"} 12
+  {app="bar", pod="a"} 15
+  {app="bar", pod="b"} 30
 
 # bottomk() with special inputs.
 clear


### PR DESCRIPTION
**What this PR does / why we need it**:

Expands the declarative `vector_aggregations.logqltest` coverage: one scenario per aggregation (`sum`, `avg`, `min`, `max`, `count`, `stddev`, `stdvar`, `topk`, `bottomk`, `sort`, `sort_desc`), both `by`/`without` grouping with single and multiple labels, and special inputs (`NaN`, `+Inf`, `-Inf`) for each — including where `NaN` lands in `sort` / `sort_desc`.

Adding the special-input cases surfaced a correctness bug, which this PR also fixes: **`avg()` was order-sensitive with infinite inputs**. It accumulates an incremental mean, so once the running mean is infinite it computes `Inf + (s.F - Inf) = NaN`, making the output depend on the order samples arrive — `avg({+Inf, 2})` gave `+Inf` but `avg({2, +Inf})` gave `NaN`. The fix keeps an infinite mean stable in the two cases that need it; the finite path is unchanged. It mirrors the guard-based approach Prometheus used before its later Kahan-summation rework (a possible follow-up for accuracy).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

The engine fix is the 12-line change in `pkg/logql/evaluator.go`; everything else is test data.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.
