### PR TITLE
test(logql): Add vector/vector comparison operator coverage

### DIFF
--- a/pkg/logql/internal/logqltest/testdata/binary_operations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/binary_operations.logqltest
@@ -21,6 +21,13 @@ eval instant at 60s 10 / 5 / 2
   1
 eval instant at 60s 10 / (5 / 2)
   4
+eval instant at 60s 10 % 3
+  1
+# Division and modulo return NaN for a zero divisor.
+eval instant at 60s 10 / 0
+  NaN
+eval instant at 60s 10 % 0
+  NaN
 eval instant at 60s 1+1--1
   3
 
@@ -48,6 +55,20 @@ eval instant at 60s rate({app="bar"}[1m]) - 1 / 2
   {app="bar"} -0.45
 eval range from 60s to 180s step 30s rate({app="bar"}[1m]) - 1 / 2
   {app="bar"} -0.45 -0.45 -0.45 -0.45 -0.45
+# Modulo applies to each sample; the scalar can be on either side.
+eval instant at 60s count_over_time({app="foo"}[1m]) % 4
+  {app="foo"} 2
+eval range from 60s to 180s step 30s count_over_time({app="foo"}[1m]) % 4
+  {app="foo"} 2 2 2 2 2
+eval instant at 60s 16 % count_over_time({app="foo"}[1m])
+  {app="foo"} 4
+eval range from 60s to 180s step 30s 16 % count_over_time({app="foo"}[1m])
+  {app="foo"} 4 4 4 4 4
+# Division and modulo return NaN for a zero divisor.
+eval instant at 60s count_over_time({app="foo"}[1m]) / 0
+  {app="foo"} NaN
+eval instant at 60s count_over_time({app="foo"}[1m]) % 0
+  {app="foo"} NaN
 
 # Logical operators.
 eval instant at 60s rate({app="foo"}[1m]) or rate({app="bar"}[1m])
@@ -95,6 +116,15 @@ eval instant at 60s count_over_time({app=~"foo|bar"}[1m]) % count_over_time({app
   {app="bar"} 0
 eval range from 60s to 180s step 30s count_over_time({app=~"foo|bar"}[1m]) % count_over_time({app="bar"}[1m])
   {app="bar"} 0 0 0 0 0
+# A zero divisor yields NaN for both / and %.
+eval instant at 60s sum(count_over_time({app="foo"}[1m])) / vector(0)
+  {} NaN
+eval range from 60s to 180s step 30s sum(count_over_time({app="foo"}[1m])) / vector(0)
+  {} NaN NaN NaN NaN NaN
+eval instant at 60s sum(count_over_time({app="foo"}[1m])) % vector(0)
+  {} NaN
+eval range from 60s to 180s step 30s sum(count_over_time({app="foo"}[1m])) % vector(0)
+  {} NaN NaN NaN NaN NaN
 eval instant at 60s count_over_time({app="bar"}[1m]) ^ count_over_time({app="bar"}[1m])
   {app="bar"} 27
 eval range from 60s to 180s step 30s count_over_time({app="bar"}[1m]) ^ count_over_time({app="bar"}[1m])

--- a/pkg/logql/internal/logqltest/testdata/binary_operations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/binary_operations.logqltest
@@ -130,6 +130,109 @@ eval instant at 60s sum by (app) (count_over_time({app="foo"}[1m])) + sum by (ap
 eval range from 60s to 180s step 30s sum by (app) (count_over_time({app="foo"}[1m])) + sum by (app) (count_over_time({app="foo"}[1m]))
   {app="foo"} 12 12 12 12 12
 
+# Vector to vector comparison operators. Non-bool keeps the left value; `bool` gives 1
+# where the comparison holds, else 0.
+#
+# In this scenario, the sides match on `id` as less-than, equal, and greater-than pairs,
+# so each operator keeps a different subset.
+clear
+load
+  {app="left",  id="lt"} "x" @ 0s [repeat every 20s for 10]
+  {app="left",  id="eq"} "x" @ 0s [repeat every 20s for 10]
+  {app="left",  id="gt"} "x" @ 0s [repeat every 10s for 19]
+  {app="right", id="lt"} "x" @ 0s [repeat every 10s for 19]
+  {app="right", id="eq"} "x" @ 0s [repeat every 20s for 10]
+  {app="right", id="gt"} "x" @ 0s [repeat every 20s for 10]
+  {app="noise"} "noise" @ 0s [repeat every 10s for 19]
+
+# <
+eval instant at 60s sum by (id) (count_over_time({app="left"}[1m])) < sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 3
+eval range from 60s to 180s step 30s sum by (id) (count_over_time({app="left"}[1m])) < sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 3 3 3 3 3
+eval instant at 60s sum by (id) (count_over_time({app="left"}[1m])) < bool sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 1
+  {id="eq"} 0
+  {id="gt"} 0
+eval range from 60s to 180s step 30s sum by (id) (count_over_time({app="left"}[1m])) < bool sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 1 1 1 1 1
+  {id="eq"} 0 0 0 0 0
+  {id="gt"} 0 0 0 0 0
+# <=
+eval instant at 60s sum by (id) (count_over_time({app="left"}[1m])) <= sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 3
+  {id="eq"} 3
+eval range from 60s to 180s step 30s sum by (id) (count_over_time({app="left"}[1m])) <= sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 3 3 3 3 3
+  {id="eq"} 3 3 3 3 3
+eval instant at 60s sum by (id) (count_over_time({app="left"}[1m])) <= bool sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 1
+  {id="eq"} 1
+  {id="gt"} 0
+eval range from 60s to 180s step 30s sum by (id) (count_over_time({app="left"}[1m])) <= bool sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 1 1 1 1 1
+  {id="eq"} 1 1 1 1 1
+  {id="gt"} 0 0 0 0 0
+# >
+eval instant at 60s sum by (id) (count_over_time({app="left"}[1m])) > sum by (id) (count_over_time({app="right"}[1m]))
+  {id="gt"} 6
+eval range from 60s to 180s step 30s sum by (id) (count_over_time({app="left"}[1m])) > sum by (id) (count_over_time({app="right"}[1m]))
+  {id="gt"} 6 6 6 6 6
+eval instant at 60s sum by (id) (count_over_time({app="left"}[1m])) > bool sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 0
+  {id="eq"} 0
+  {id="gt"} 1
+eval range from 60s to 180s step 30s sum by (id) (count_over_time({app="left"}[1m])) > bool sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 0 0 0 0 0
+  {id="eq"} 0 0 0 0 0
+  {id="gt"} 1 1 1 1 1
+# >=
+eval instant at 60s sum by (id) (count_over_time({app="left"}[1m])) >= sum by (id) (count_over_time({app="right"}[1m]))
+  {id="eq"} 3
+  {id="gt"} 6
+eval range from 60s to 180s step 30s sum by (id) (count_over_time({app="left"}[1m])) >= sum by (id) (count_over_time({app="right"}[1m]))
+  {id="eq"} 3 3 3 3 3
+  {id="gt"} 6 6 6 6 6
+eval instant at 60s sum by (id) (count_over_time({app="left"}[1m])) >= bool sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 0
+  {id="eq"} 1
+  {id="gt"} 1
+eval range from 60s to 180s step 30s sum by (id) (count_over_time({app="left"}[1m])) >= bool sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 0 0 0 0 0
+  {id="eq"} 1 1 1 1 1
+  {id="gt"} 1 1 1 1 1
+# ==
+eval instant at 60s sum by (id) (count_over_time({app="left"}[1m])) == sum by (id) (count_over_time({app="right"}[1m]))
+  {id="eq"} 3
+eval range from 60s to 180s step 30s sum by (id) (count_over_time({app="left"}[1m])) == sum by (id) (count_over_time({app="right"}[1m]))
+  {id="eq"} 3 3 3 3 3
+eval instant at 60s sum by (id) (count_over_time({app="left"}[1m])) == bool sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 0
+  {id="eq"} 1
+  {id="gt"} 0
+eval range from 60s to 180s step 30s sum by (id) (count_over_time({app="left"}[1m])) == bool sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 0 0 0 0 0
+  {id="eq"} 1 1 1 1 1
+  {id="gt"} 0 0 0 0 0
+# !=
+eval instant at 60s sum by (id) (count_over_time({app="left"}[1m])) != sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 3
+  {id="gt"} 6
+eval range from 60s to 180s step 30s sum by (id) (count_over_time({app="left"}[1m])) != sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 3 3 3 3 3
+  {id="gt"} 6 6 6 6 6
+eval instant at 60s sum by (id) (count_over_time({app="left"}[1m])) != bool sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 1
+  {id="eq"} 0
+  {id="gt"} 1
+eval range from 60s to 180s step 30s sum by (id) (count_over_time({app="left"}[1m])) != bool sum by (id) (count_over_time({app="right"}[1m]))
+  {id="lt"} 1 1 1 1 1
+  {id="eq"} 0 0 0 0 0
+  {id="gt"} 1 1 1 1 1
+# `bool` is only valid immediately after the operator; before it the query fails to parse.
+eval instant at 60s sum by (id) (count_over_time({app="left"}[1m])) bool > sum by (id) (count_over_time({app="right"}[1m]))
+  expect fail msg: syntax error: unexpected bool
+
 clear
 load
   {app="foo"} "xbar"  @ 0s [repeat every 10s for 19]


### PR DESCRIPTION
**What this PR does / why we need it**:

Fills gaps in `binary_operations.logqltest`. The comparison operators had thin coverage: `<` and `==` were tested only against a scalar, and `<=` and `!=` were not tested at all.

Adds a scenario that runs all six comparison operators (`<`, `<=`, `>`, `>=`, `==`, `!=`) as vector/vector comparisons over `less-than` / `equal` / `greater-than` matched pairs, so each operator keeps a distinct subset (non-bool) and returns `1`/`0` per pair (`bool`), tested instant and range. It also asserts that `bool` before the operator is a parse error, since it is only valid immediately after the operator.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Pure test data; no engine changes.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.
