### PR TITLE
fix(workflows): Remove trigger-cd

### DIFF
--- a/.github/release-workflows.jsonnet
+++ b/.github/release-workflows.jsonnet
@@ -204,26 +204,6 @@ local weeklyImageJobs = {
           ||| % { name: name }),
         ])
       for name in std.objectFields(weeklyImageJobs)
-    } + {
-      'trigger-cd': job.new()
-                    + job.withNeeds(['loki-image', 'loki-manifest', 'loki-canary-manifest'])
-                    + job.withIf("github.ref == 'refs/heads/main'")
-                    + job.withPermissions({
-                      contents: 'read',
-                      'id-token': 'write',
-                    })
-                    + job.withEnv({
-                      IMAGE_TAG: '${{ needs.loki-image.outputs.image_tag }}',
-                    })
-                    + job.withSteps([
-                      step.new('Trigger CD workflow', 'grafana/shared-workflows/actions/trigger-argo-workflow@8b88213bca76e86f9f59b43038cc5d7545452436')  // main
-                      + step.with({
-                        instance: 'ops',
-                        namespace: 'loki-cd',
-                        workflow_template: 'loki-continuous-deployment',
-                        parameters: 'imageTag=${{ env.IMAGE_TAG }}',
-                      }),
-                    ]),
     },
   }),
 }

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -707,26 +707,6 @@
           ${IMAGE_NAME}@${IMAGE_DIGEST_AMD64} \
           ${IMAGE_NAME}@${IMAGE_DIGEST_ARM}
         docker buildx imagetools inspect $IMAGE
-  "trigger-cd":
-    "env":
-      "IMAGE_TAG": "${{ needs.loki-image.outputs.image_tag }}"
-    "if": "github.ref == 'refs/heads/main'"
-    "needs":
-    - "loki-image"
-    - "loki-manifest"
-    - "loki-canary-manifest"
-    "permissions":
-      "contents": "read"
-      "id-token": "write"
-    "runs-on": "ubuntu-x64"
-    "steps":
-    - "name": "Trigger CD workflow"
-      "uses": "grafana/shared-workflows/actions/trigger-argo-workflow@8b88213bca76e86f9f59b43038cc5d7545452436"
-      "with":
-        "instance": "ops"
-        "namespace": "loki-cd"
-        "parameters": "imageTag=${{ env.IMAGE_TAG }}"
-        "workflow_template": "loki-continuous-deployment"
 "name": "Publish images"
 "on":
   "push":


### PR DESCRIPTION
**What this PR does / why we need it**:

Removing trigger-cd step because the corresponding argo workflow no longer exists.