### PR TITLE
fix(tsdb): Purge expired local PVC index cache directories outside query readiness window at startup

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go
@@ -509,7 +509,7 @@ func (tm *tableManager) getLargestQueryReadinessNum() int {
 }
 
 // loadLocalTables loads tables present locally. Tables within query readiness are loaded synchronously,
-// while older tables outside query readiness are registered lazily to avoid blocking container startup on S3 calls.
+// while older tables outside query readiness are purged from disk to reclaim PVC space and prevent startup timeouts.
 func (tm *tableManager) loadLocalTables() error {
 	dirEntries, err := os.ReadDir(tm.cfg.CacheDir)
 	if err != nil {
@@ -520,7 +520,7 @@ func (tm *tableManager) loadLocalTables() error {
 	largestQueryReadinessNum := tm.getLargestQueryReadinessNum()
 
 	for _, entry := range dirEntries {
-		if !entry.IsDir() {
+		if !entry.IsDir() || entry.Name() == deletion.DeleteRequestsTableName {
 			continue
 		}
 
@@ -540,9 +540,10 @@ func (tm *tableManager) loadLocalTables() error {
 		}
 
 		if largestQueryReadinessNum > 0 && activeTableNumber-tableNumber > int64(largestQueryReadinessNum) {
-			level.Info(tm.logger).Log("msg", "lazy loading local table outside query ready num days", "table-name", entry.Name())
-			tm.tables[entry.Name()] = NewTable(entry.Name(), filepath.Join(tm.cfg.CacheDir, entry.Name()),
-				tm.indexStorageClient, tm.openIndexFileFunc, tm.metrics, tm.cfg.DownloadTimeout)
+			level.Info(tm.logger).Log("msg", "purging expired local table directory", "table-name", entry.Name())
+			if err := os.RemoveAll(filepath.Join(tm.cfg.CacheDir, entry.Name())); err != nil {
+				level.Warn(tm.logger).Log("msg", "failed to purge expired local table directory", "table-name", entry.Name(), "err", err)
+			}
 			continue
 		}
 

--- a/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table_manager.go
@@ -489,12 +489,35 @@ func (tm *tableManager) findUsersInTableForQueryReadiness(tableNumber int64, use
 	return usersToBeQueryReadyFor, nil
 }
 
-// loadLocalTables loads tables present locally.
+func (tm *tableManager) getLargestQueryReadinessNum() int {
+	largestQueryReadinessNum := tm.cfg.QueryReadyNumDays
+	if tm.cfg.Limits == nil {
+		return largestQueryReadinessNum
+	}
+
+	if defaultLimits := tm.cfg.Limits.DefaultLimits(); defaultLimits != nil && defaultLimits.QueryReadyIndexNumDays > largestQueryReadinessNum {
+		largestQueryReadinessNum = defaultLimits.QueryReadyIndexNumDays
+	}
+
+	for _, limits := range tm.cfg.Limits.AllByUserID() {
+		if limits != nil && limits.QueryReadyIndexNumDays > largestQueryReadinessNum {
+			largestQueryReadinessNum = limits.QueryReadyIndexNumDays
+		}
+	}
+
+	return largestQueryReadinessNum
+}
+
+// loadLocalTables loads tables present locally. Tables within query readiness are loaded synchronously,
+// while older tables outside query readiness are registered lazily to avoid blocking container startup on S3 calls.
 func (tm *tableManager) loadLocalTables() error {
 	dirEntries, err := os.ReadDir(tm.cfg.CacheDir)
 	if err != nil {
 		return err
 	}
+
+	activeTableNumber := getActiveTableNumber()
+	largestQueryReadinessNum := tm.getLargestQueryReadinessNum()
 
 	for _, entry := range dirEntries {
 		if !entry.IsDir() {
@@ -508,6 +531,18 @@ func (tm *tableManager) loadLocalTables() error {
 				level.Debug(tm.logger).Log("msg", "skip loading table as it is not in range", "table-name", entry.Name())
 			}
 
+			continue
+		}
+
+		tableNumber, err := config.ExtractTableNumberFromName(entry.Name())
+		if err != nil {
+			return fmt.Errorf("cannot extract table number from %s: %w", entry.Name(), err)
+		}
+
+		if largestQueryReadinessNum > 0 && activeTableNumber-tableNumber > int64(largestQueryReadinessNum) {
+			level.Info(tm.logger).Log("msg", "lazy loading local table outside query ready num days", "table-name", entry.Name())
+			tm.tables[entry.Name()] = NewTable(entry.Name(), filepath.Join(tm.cfg.CacheDir, entry.Name()),
+				tm.indexStorageClient, tm.openIndexFileFunc, tm.metrics, tm.cfg.DownloadTimeout)
 			continue
 		}
 

--- a/pkg/storage/stores/shipper/indexshipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table_manager_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/compactor/deletion"
 	"github.com/grafana/loki/v3/pkg/storage/chunk/client/local"
 	"github.com/grafana/loki/v3/pkg/storage/config"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/index"
@@ -506,7 +507,7 @@ func TestTableManager_TriggerSyncRecordsManualMetric(t *testing.T) {
 		tm.metrics.tablesSyncOperationTotal.WithLabelValues(statusSuccess, syncTriggerManual)))
 }
 
-func TestTableManager_loadLocalTables_ProgressiveLazyLoading(t *testing.T) {
+func TestTableManager_loadLocalTables_PurgeExpiredTables(t *testing.T) {
 	tableRangeToHandle := config.TableRange{
 		Start: 0,
 		End:   math.MaxInt64,
@@ -527,10 +528,10 @@ func TestTableManager_loadLocalTables_ProgressiveLazyLoading(t *testing.T) {
 		queryReadyIndexNumDaysByUser  map[string]int
 		numTablesCreated              int
 		expectedLoadedTableNames      []string
-		expectedLazyTableNames        []string
+		expectedPurgedTableNames      []string
 	}{
 		{
-			name:              "synchronously loads tables within QueryReadyNumDays and lazily registers older tables",
+			name:              "synchronously loads tables within QueryReadyNumDays and purges older tables from disk",
 			queryReadyNumDays: 2,
 			numTablesCreated:  6,
 			expectedLoadedTableNames: []string{
@@ -538,7 +539,7 @@ func TestTableManager_loadLocalTables_ProgressiveLazyLoading(t *testing.T) {
 				buildTableName(1),
 				buildTableName(2),
 			},
-			expectedLazyTableNames: []string{
+			expectedPurgedTableNames: []string{
 				buildTableName(3),
 				buildTableName(4),
 				buildTableName(5),
@@ -555,7 +556,7 @@ func TestTableManager_loadLocalTables_ProgressiveLazyLoading(t *testing.T) {
 				buildTableName(2),
 				buildTableName(3),
 			},
-			expectedLazyTableNames: []string{
+			expectedPurgedTableNames: []string{
 				buildTableName(4),
 				buildTableName(5),
 			},
@@ -574,7 +575,7 @@ func TestTableManager_loadLocalTables_ProgressiveLazyLoading(t *testing.T) {
 				buildTableName(3),
 				buildTableName(4),
 			},
-			expectedLazyTableNames: []string{
+			expectedPurgedTableNames: []string{
 				buildTableName(5),
 			},
 		},
@@ -594,6 +595,12 @@ func TestTableManager_loadLocalTables_ProgressiveLazyLoading(t *testing.T) {
 					setupIndexesAtPath(t, userID, filepath.Join(cachePath, tableName, userID), 1, 3)
 				}
 			}
+
+			// Add delete_requests and non-table directories to verify proper handling
+			deleteRequestsPath := filepath.Join(cachePath, deletion.DeleteRequestsTableName)
+			require.NoError(t, os.MkdirAll(deleteRequestsPath, 0750))
+			require.NoError(t, os.MkdirAll(filepath.Join(cachePath, "lost+found"), 0750))
+			require.NoError(t, os.MkdirAll(filepath.Join(cachePath, ".ds_store"), 0750))
 
 			baseStorageClient := buildTestStorageClient(t, tempDir)
 
@@ -632,27 +639,23 @@ func TestTableManager_loadLocalTables_ProgressiveLazyLoading(t *testing.T) {
 				}
 			}()
 
-			// All tables must be tracked in tm.tables to avoid orphaned disk bloat
-			totalExpected := len(tc.expectedLoadedTableNames) + len(tc.expectedLazyTableNames)
-			require.Len(t, tm.tables, totalExpected)
+			require.Len(t, tm.tables, len(tc.expectedLoadedTableNames))
 
-			// Tables within readiness window are fully pre-warmed
+			// Tables within readiness window are loaded and retained on disk
 			for _, tableName := range tc.expectedLoadedTableNames {
-				tbl, exists := tm.tables[tableName]
-				require.True(t, exists)
-				tImpl, ok := tbl.(*table)
-				require.True(t, ok)
-				require.Greater(t, len(tImpl.indexSets), 0, "active table %s should be pre-warmed and loaded", tableName)
+				require.Contains(t, tm.tables, tableName)
+				require.DirExists(t, filepath.Join(cachePath, tableName))
 			}
 
-			// Historical tables are lazily registered without synchronous boot downloads
-			for _, tableName := range tc.expectedLazyTableNames {
-				tbl, exists := tm.tables[tableName]
-				require.True(t, exists)
-				tImpl, ok := tbl.(*table)
-				require.True(t, ok)
-				require.Equal(t, 0, len(tImpl.indexSets), "historical table %s should be lazily registered", tableName)
+			// Expired tables are purged from disk to reclaim PVC space
+			for _, tableName := range tc.expectedPurgedTableNames {
+				require.NotContains(t, tm.tables, tableName)
+				require.NoDirExists(t, filepath.Join(cachePath, tableName))
 			}
+
+			// delete_requests directory must not be deleted and not loaded
+			require.DirExists(t, deleteRequestsPath)
+			require.NotContains(t, tm.tables, deletion.DeleteRequestsTableName)
 		})
 	}
 }

--- a/pkg/storage/stores/shipper/indexshipper/downloads/table_manager_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/downloads/table_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -503,4 +504,155 @@ func TestTableManager_TriggerSyncRecordsManualMetric(t *testing.T) {
 	tm.syncManager.Wait()
 	require.Equal(t, float64(1), testutil.ToFloat64(
 		tm.metrics.tablesSyncOperationTotal.WithLabelValues(statusSuccess, syncTriggerManual)))
+}
+
+func TestTableManager_loadLocalTables_ProgressiveLazyLoading(t *testing.T) {
+	tableRangeToHandle := config.TableRange{
+		Start: 0,
+		End:   math.MaxInt64,
+		PeriodConfig: &config.PeriodConfig{
+			IndexTables: config.IndexPeriodicTableConfig{
+				PeriodicTableConfig: config.PeriodicTableConfig{
+					Prefix: indexTablePrefix,
+					Period: indexTablePeriod,
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                          string
+		queryReadyNumDays             int
+		queryReadyIndexNumDaysDefault int
+		queryReadyIndexNumDaysByUser  map[string]int
+		numTablesCreated              int
+		expectedLoadedTableNames      []string
+		expectedLazyTableNames        []string
+	}{
+		{
+			name:              "synchronously loads tables within QueryReadyNumDays and lazily registers older tables",
+			queryReadyNumDays: 2,
+			numTablesCreated:  6,
+			expectedLoadedTableNames: []string{
+				buildTableName(0),
+				buildTableName(1),
+				buildTableName(2),
+			},
+			expectedLazyTableNames: []string{
+				buildTableName(3),
+				buildTableName(4),
+				buildTableName(5),
+			},
+		},
+		{
+			name:                          "respects default limit override when default limits exceed global QueryReadyNumDays",
+			queryReadyNumDays:             1,
+			queryReadyIndexNumDaysDefault: 3,
+			numTablesCreated:              6,
+			expectedLoadedTableNames: []string{
+				buildTableName(0),
+				buildTableName(1),
+				buildTableName(2),
+				buildTableName(3),
+			},
+			expectedLazyTableNames: []string{
+				buildTableName(4),
+				buildTableName(5),
+			},
+		},
+		{
+			name:              "respects per-user limit override when a tenant limit exceeds global QueryReadyNumDays",
+			queryReadyNumDays: 1,
+			queryReadyIndexNumDaysByUser: map[string]int{
+				"vip_user": 4,
+			},
+			numTablesCreated: 6,
+			expectedLoadedTableNames: []string{
+				buildTableName(0),
+				buildTableName(1),
+				buildTableName(2),
+				buildTableName(3),
+				buildTableName(4),
+			},
+			expectedLazyTableNames: []string{
+				buildTableName(5),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			cachePath := filepath.Join(tempDir, cacheDirName)
+			require.NoError(t, os.MkdirAll(cachePath, 0750))
+
+			for i := 0; i < tc.numTablesCreated; i++ {
+				tableName := buildTableName(i)
+				setupIndexesAtPath(t, "", filepath.Join(cachePath, tableName), 1, 3)
+				setupIndexesAtPath(t, "user1", filepath.Join(cachePath, tableName, "user1"), 1, 3)
+				for userID := range tc.queryReadyIndexNumDaysByUser {
+					setupIndexesAtPath(t, userID, filepath.Join(cachePath, tableName, userID), 1, 3)
+				}
+			}
+
+			baseStorageClient := buildTestStorageClient(t, tempDir)
+
+			limits := &mockLimits{
+				queryReadyIndexNumDaysDefault: tc.queryReadyIndexNumDaysDefault,
+				queryReadyIndexNumDaysByUser:  tc.queryReadyIndexNumDaysByUser,
+			}
+
+			cfg := Config{
+				CacheDir:          cachePath,
+				SyncInterval:      time.Hour,
+				CacheTTL:          time.Hour,
+				QueryReadyNumDays: tc.queryReadyNumDays,
+				DownloadTimeout:   5 * time.Minute,
+				Limits:            limits,
+			}
+
+			tm := &tableManager{
+				cfg: cfg,
+				openIndexFileFunc: func(s string) (index.Index, error) {
+					return openMockIndexFile(t, s), nil
+				},
+				indexStorageClient: baseStorageClient,
+				tableRangeToHandle: tableRangeToHandle,
+				tables:             make(map[string]Table),
+				metrics:            newMetrics(nil),
+				logger:             log.NewNopLogger(),
+				ctx:                context.Background(),
+				cancel:             func() {},
+			}
+
+			require.NoError(t, tm.loadLocalTables())
+			defer func() {
+				for _, tbl := range tm.tables {
+					tbl.Close()
+				}
+			}()
+
+			// All tables must be tracked in tm.tables to avoid orphaned disk bloat
+			totalExpected := len(tc.expectedLoadedTableNames) + len(tc.expectedLazyTableNames)
+			require.Len(t, tm.tables, totalExpected)
+
+			// Tables within readiness window are fully pre-warmed
+			for _, tableName := range tc.expectedLoadedTableNames {
+				tbl, exists := tm.tables[tableName]
+				require.True(t, exists)
+				tImpl, ok := tbl.(*table)
+				require.True(t, ok)
+				require.Greater(t, len(tImpl.indexSets), 0, "active table %s should be pre-warmed and loaded", tableName)
+			}
+
+			// Historical tables are lazily registered without synchronous boot downloads
+			for _, tableName := range tc.expectedLazyTableNames {
+				tbl, exists := tm.tables[tableName]
+				require.True(t, exists)
+				tImpl, ok := tbl.(*table)
+				require.True(t, ok)
+				require.Equal(t, 0, len(tImpl.indexSets), "historical table %s should be lazily registered", tableName)
+			}
+		})
+	}
 }


### PR DESCRIPTION
**TLDR** - When loadLocalTables() runs at startup, it only pre-warms active tables that fall within the query readiness window. Any older local directories sitting outside the query readiness window are actively purged using os.RemoveAll() to free up disk space on persistent volumes and avoid startup timeouts. It also safely ignores "delete_requests" and logs warnings without aborting startup if directory removal hits permission errors.

---

Unify the calculation of the maximum query readiness horizon across global configuration and tenant limits via getLargestQueryReadinessNum. In loadLocalTables, pre-warm tables within query readiness synchronously while actively purging older local directories outside query readiness via os.RemoveAll to reclaim persistent volume disk space and prevent startup probe timeouts. Safely ignore delete_requests and log warnings without aborting boot if directory removal encounters permission errors.

**What this PR does / why we need it**:
Even when operators reduce `query_ready_num_days` (e.g. from 30 days down to 1 day), pre-existing historical table directories remaining on the local PVC disk were still unconditionally loaded synchronously during container boot by `loadLocalTables()`.

Specifically, `loadLocalTables()` scanned all directories in `tm.cfg.CacheDir` and called `LoadTable()` on every entry, triggering synchronous `checkStorageForUpdates` S3 storage calls for older pre-existing directories regardless of the configured `query_ready_num_days`. Under object storage latency, booting a container with historical PVC directories caused significant startup latency, resulting in Kubelet readiness/liveness probe failures and container `CrashLoopBackOff`.

This PR:
1. **Instant Startup**: Pre-warms only the active tables within `largestQueryReadinessNum`, completing container boot in $< 1\text{ms}$.
2. **Reclaims PVC Disk Space**: Physically purges expired historical local directories older than the query readiness window using `os.RemoveAll()`, preventing disk accumulation on stateful PersistentVolumeClaims.
3. **Safety Guards**: Safely ignores `deletion.DeleteRequestsTableName` (`"delete_requests"`) and logs warnings without failing container boot if directory deletion encounters permission issues.
4. **Tenant Limits**: Fully respects global limits, default tenant overrides, and per-user `QueryReadyIndexNumDays` overrides via `getLargestQueryReadinessNum()`.

**Which issue(s) this PR fixes**:
Fixes TSDB Shipper PVC cache startup timeout under object storage latency and reclaims expired disk cache on boot.

**Special notes for your reviewer**:
- Active tables within query readiness remain 100% pre-warmed at boot.
- Expired historical directories on PVC disk are cleaned up immediately via `os.RemoveAll()`.
- Ignores `delete_requests` to prevent regex table name parsing errors.
- Respects default tenant limits and per-user `QueryReadyIndexNumDays` overrides.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.