### PR TITLE
chore: Implement streaming reading of series

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
@@ -84,6 +84,15 @@ func (p *streamPostings) build(ctx context.Context) error {
 	return nil
 }
 
+// isLabelName reports whether the given name is a label name held in the postings offset table.
+func (p *streamPostings) isLabelName(name string) bool {
+	if name == "" { // in postings, this is where the all-postings entry is stored, not a real label name
+		return false
+	}
+	_, ok := p.postings[name]
+	return ok
+}
+
 // postingsFor returns a merged postings iterator over the series matching the
 // given label name and values.
 // It mirrors ByteSliceReader.Postings.

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings_test.go
@@ -1,13 +1,9 @@
 package index
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
-	"sort"
 	"testing"
 
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/require"
@@ -45,15 +41,7 @@ func mustPostingsAndDrain(t *testing.T, r Reader, fpFilter FingerprintFilter, na
 func TestStreamPostings_MatchesMmap(t *testing.T) {
 	for _, format := range []int{FormatV3, FormatV4} {
 		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
-			fn := writeManySymbolsFixture(t, format)
-
-			mmap, err := NewMmapFileReader(fn)
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, mmap.Close()) })
-
-			stream, err := NewStreamFileReader(fn)
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, stream.Close()) })
+			mmap, stream := openBothReaders(t, writeManySymbolsFixture(t, format))
 
 			// LabelValues returns the values in ascending order, which is the
 			// order Postings requires. The fixture uses a single "id" label.
@@ -119,56 +107,25 @@ func TestStreamPostings_MatchesMmap(t *testing.T) {
 // several read buffers and exercise the streaming Seek's binary search.
 func writeSharedLabelFixture(t *testing.T, format int) string {
 	t.Helper()
-	dir := t.TempDir()
-	fileName := filepath.Join(dir, IndexFilename)
-
-	creator, err := NewWriter(context.Background(), format, fileName)
-	require.NoError(t, err)
 
 	const numSeries = 4000
 
-	type entry struct {
-		ls labels.Labels
-	}
-	symbolSet := map[string]struct{}{"id": {}, "shared": {}, "all": {}}
-	entries := make([]entry, 0, numSeries)
-	for j := range numSeries {
-		id := fmt.Sprintf("v%05d", j)
-		symbolSet[id] = struct{}{}
+	series := make([]seriesFixture, 0, numSeries)
+	for i := range numSeries {
+		id := fmt.Sprintf("v%05d", i)
+		ls := labels.FromStrings("id", id)
 		// Attach "shared"="all" to ~2/3 of the series so its postings list is
 		// large but leaves gaps in the ref sequence.
-		if j%3 == 0 {
-			entries = append(entries, entry{ls: labels.FromStrings("id", id)})
-		} else {
-			entries = append(entries, entry{ls: labels.FromStrings("id", id, "shared", "all")})
+		if i%3 != 0 {
+			ls = labels.FromStrings("id", id, "shared", "all")
 		}
+		series = append(series, seriesFixture{
+			ls:     ls,
+			chunks: []ChunkMeta{{Checksum: 1, MinTime: 0, MaxTime: 10, KB: 1, Entries: 1}},
+		})
 	}
 
-	symbols := make([]string, 0, len(symbolSet))
-	for s := range symbolSet {
-		symbols = append(symbols, s)
-	}
-	sort.Strings(symbols)
-	for _, s := range symbols {
-		require.NoError(t, creator.AddSymbol(s))
-	}
-
-	// AddSeries requires ascending fingerprint order.
-	sort.Slice(entries, func(i, j int) bool {
-		return labels.StableHash(entries[i].ls) < labels.StableHash(entries[j].ls)
-	})
-	for i, e := range entries {
-		require.NoError(t, creator.AddSeries(
-			storage.SeriesRef(i+1),
-			e.ls,
-			model.Fingerprint(labels.StableHash(e.ls)),
-			ChunkMeta{Checksum: 1, MinTime: 0, MaxTime: 10, KB: 1, Entries: 1},
-		))
-	}
-
-	_, err = creator.Close(false)
-	require.NoError(t, err)
-	return fileName
+	return writeIndexFixture(t, format, series)
 }
 
 // TestStreamingPostings_SeekMatchesMmap cross-checks the streaming postings
@@ -177,15 +134,7 @@ func writeSharedLabelFixture(t *testing.T, format int) string {
 func TestStreamingPostings_SeekMatchesMmap(t *testing.T) {
 	for _, format := range []int{FormatV3, FormatV4} {
 		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
-			fn := writeSharedLabelFixture(t, format)
-
-			mmap, err := NewMmapFileReader(fn)
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, mmap.Close()) })
-
-			stream, err := NewStreamFileReader(fn)
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, stream.Close()) })
+			mmap, stream := openBothReaders(t, writeSharedLabelFixture(t, format))
 
 			// Ground-truth ordered ref list for the shared postings.
 			allRefs := mustPostingsAndDrain(t, mmap, nil, "shared", "all")
@@ -270,15 +219,7 @@ func TestStreamingPostings_SeekMatchesMmap(t *testing.T) {
 func TestStreamPostings_ShardedMatchesMmap(t *testing.T) {
 	for _, format := range []int{FormatV3, FormatV4} {
 		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
-			path := writeSharedLabelFixture(t, format)
-
-			mmap, err := NewMmapFileReader(path)
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, mmap.Close()) })
-
-			stream, err := NewStreamFileReader(path)
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, stream.Close()) })
+			mmap, stream := openBothReaders(t, writeSharedLabelFixture(t, format))
 
 			// Should both have the same fingerprintOffsets
 			require.NotEmpty(t, mmap.fingerprintOffsets)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"os"
 
@@ -31,22 +32,20 @@ type StreamReader struct {
 	symbols            *streamSymbols
 	postings           *streamPostings
 	fingerprintOffsets FingerprintOffsets
+	decoder            *Decoder
 }
 
 // NewStreamFileReader constructs a StreamReader against the given index file.
 func NewStreamFileReader(path string) (*StreamReader, error) {
-	fileInfo, err := os.Stat(path)
+	factory, err := streamenc.NewFilePoolDecbufFactory(path, 0, filepool.NewFilePoolMetrics(nil))
 	if err != nil {
-		return nil, fmt.Errorf("stat index file: %w", err)
+		return nil, fmt.Errorf("index file decbuf factory: %w", err)
 	}
-	size := fileInfo.Size()
-
-	factory := streamenc.NewFilePoolDecbufFactory(path, 0, filepool.NewFilePoolMetrics(nil))
 
 	reader := &StreamReader{
 		factory: factory,
 		path:    path,
-		size:    size,
+		size:    factory.FileSize(),
 	}
 
 	version, err := reader.readHeader()
@@ -63,13 +62,13 @@ func NewStreamFileReader(path string) (*StreamReader, error) {
 	}
 	reader.toc = toc
 
-	reader.symbols, err = newStreamSymbols(context.Background(), factory, int(toc.Symbols))
+	reader.postings, err = newStreamPostings(context.Background(), factory, int(toc.PostingsTable))
 	if err != nil {
 		_ = factory.Close()
 		return nil, err
 	}
 
-	reader.postings, err = newStreamPostings(context.Background(), factory, int(toc.PostingsTable))
+	reader.symbols, err = newStreamSymbols(context.Background(), factory, int(toc.Symbols), reader.postings.isLabelName)
 	if err != nil {
 		_ = factory.Close()
 		return nil, err
@@ -80,6 +79,8 @@ func NewStreamFileReader(path string) (*StreamReader, error) {
 		_ = factory.Close()
 		return nil, err
 	}
+
+	reader.decoder = newDecoder(reader.symbols.Lookup, DefaultMaxChunksToBypassMarkerLookup)
 
 	// Fallback used by not-yet-ported methods
 	mmapReader, err := NewMmapFileReader(path)
@@ -190,6 +191,62 @@ func (s StreamReader) readFingerprintOffsetsTable(offset int) (FingerprintOffset
 	return result, decbuf.Err()
 }
 
+// seriesOffset returns the absolute file offset of the series record for the
+// given series ref.
+// Series records are padded to a 16-byte alignment and a ref is the record's
+// file offset divided by 16, which is what lets a 4-byte ref address a much
+// larger file.
+// See Creator.AddSeries.
+func seriesOffset(id storage.SeriesRef) int {
+	return int(id) * 16
+}
+
+// readSeriesRecord reads the series record at the given absolute file offset
+// and returns its content bytes, having validated the record's CRC32.
+//
+// On disk a series record is a uvarint content length, the content, then
+// a CRC32 over the content alone.
+// The uvarint length prefix is why this can't go through the streamenc
+// factory: NewDecbufAtChecked assumes a 4-byte big-endian length, so we open
+// a raw Decbuf over the whole file and decode the record ourselves.
+func (s StreamReader) readSeriesRecord(offset int) ([]byte, error) {
+	decbuf := s.factory.NewRawDecbuf(context.Background())
+	if err := decbuf.Err(); err != nil {
+		return nil, fmt.Errorf("open series decbuf: %w", err)
+	}
+	defer func() { _ = decbuf.Close() }()
+
+	if decbuf.ResetAt(offset); decbuf.Err() != nil {
+		return nil, fmt.Errorf("go to start of series record: %w", decbuf.Err())
+	}
+
+	contentLen := decbuf.Uvarint64()
+	if err := decbuf.Err(); err != nil {
+		return nil, fmt.Errorf("read series record length: %w", err)
+	}
+	// Bound the claimed length against what is left in the file before
+	// allocating, so a corrupt length prefix can't ask for an arbitrarily
+	// large buffer.
+	remaining := decbuf.Len()
+	if remaining < crc32.Size || contentLen > uint64(remaining-crc32.Size) {
+		return nil, fmt.Errorf(
+			"series record at %d claims %d content bytes but only %d remain: %w",
+			offset, contentLen, remaining, streamenc.ErrInvalidSize,
+		)
+	}
+
+	content := make([]byte, contentLen)
+	decbuf.ReadInto(content)
+	expectedCRC := decbuf.Be32()
+	if err := decbuf.Err(); err != nil {
+		return nil, fmt.Errorf("read series record: %w", err)
+	}
+	if crc32.Checksum(content, castagnoliTable) != expectedCRC {
+		return nil, fmt.Errorf("series record at %d: %w", offset, streamenc.ErrInvalidChecksum)
+	}
+	return content, nil
+}
+
 func (s StreamReader) Version() int {
 	return s.version
 }
@@ -225,11 +282,25 @@ func (s StreamReader) LabelNamesFor(ids ...storage.SeriesRef) ([]string, error) 
 }
 
 func (s StreamReader) Series(id storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]ChunkMeta) (uint64, error) {
-	return s.mmapReader.Series(id, from, through, lbls, chks)
+	content, err := s.readSeriesRecord(seriesOffset(id))
+	if err != nil {
+		return 0, err
+	}
+
+	fingerprint, err := s.decoder.Series(s.version, content, id, from, through, lbls, chks)
+	if err != nil {
+		return 0, fmt.Errorf("decode series: %w", err)
+	}
+	return fingerprint, nil
 }
 
 func (s StreamReader) ChunkStats(id storage.SeriesRef, from, through int64, lbls *labels.Labels, by map[string]struct{}) (uint64, ChunkStats, error) {
-	return s.mmapReader.ChunkStats(id, from, through, lbls, by)
+	content, err := s.readSeriesRecord(seriesOffset(id))
+	if err != nil {
+		return 0, ChunkStats{}, err
+	}
+
+	return s.decoder.ChunkStats(s.version, content, id, from, through, lbls, by)
 }
 
 // Postings returns a postings iterator for the given label name and values.

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
@@ -30,47 +30,85 @@ func allReaderConstructors() []readerConstructor {
 	}
 }
 
-// writeCrossCheckFixture builds a small but non-trivial index used by
-// the cross-check tests: multiple label names, multiple values per
-// name, a couple of chunks per series.
-func writeCrossCheckFixture(t *testing.T, format int) string {
+type seriesFixture struct {
+	ls     labels.Labels
+	chunks []ChunkMeta
+}
+
+// writeIndexFixture writes series into a new index file and returns its path.
+//
+// It derives the symbol table from the series' labels, so no fixture has to
+// keep a symbol list in sync by hand, and it reorders series by fingerprint,
+// which is the order AddSeries requires. Refs are assigned in that order,
+// starting at 1.
+func writeIndexFixture(t *testing.T, format int, series []seriesFixture) string {
 	t.Helper()
-	dir := t.TempDir()
-	fileName := filepath.Join(dir, IndexFilename)
+	fileName := filepath.Join(t.TempDir(), IndexFilename)
 
 	creator, err := NewWriter(context.Background(), format, fileName)
 	require.NoError(t, err)
 
-	symbols := []string{"1", "2", "3", "a", "b", "c", "svcA", "svcB"}
+	symbolSet := map[string]struct{}{}
+	for _, s := range series {
+		s.ls.Range(func(l labels.Label) {
+			symbolSet[l.Name] = struct{}{}
+			symbolSet[l.Value] = struct{}{}
+		})
+	}
+	symbols := make([]string, 0, len(symbolSet))
+	for s := range symbolSet {
+		symbols = append(symbols, s)
+	}
+	sort.Strings(symbols)
 	for _, s := range symbols {
 		require.NoError(t, creator.AddSymbol(s))
 	}
 
-	type entry struct {
-		ls     labels.Labels
-		chunks []ChunkMeta
-	}
-	entries := []entry{
-		{ls: labels.FromStrings("a", "1", "b", "1", "c", "svcA"), chunks: []ChunkMeta{{Checksum: 1, MinTime: 0, MaxTime: 10, KB: 1, Entries: 1}}},
-		{ls: labels.FromStrings("a", "1", "b", "2", "c", "svcA"), chunks: []ChunkMeta{{Checksum: 2, MinTime: 10, MaxTime: 20, KB: 1, Entries: 1}}},
-		{ls: labels.FromStrings("a", "2", "b", "3", "c", "svcB"), chunks: []ChunkMeta{{Checksum: 3, MinTime: 20, MaxTime: 30, KB: 1, Entries: 1}}},
-	}
 	// AddSeries requires ascending fingerprint order.
-	sort.Slice(entries, func(i, j int) bool {
-		return labels.StableHash(entries[i].ls) < labels.StableHash(entries[j].ls)
+	sort.Slice(series, func(i, j int) bool {
+		return labels.StableHash(series[i].ls) < labels.StableHash(series[j].ls)
 	})
-	for i, e := range entries {
+	for i, s := range series {
 		require.NoError(t, creator.AddSeries(
 			storage.SeriesRef(i+1),
-			e.ls,
-			model.Fingerprint(labels.StableHash(e.ls)),
-			e.chunks...,
+			s.ls,
+			model.Fingerprint(labels.StableHash(s.ls)),
+			s.chunks...,
 		))
 	}
 
 	_, err = creator.Close(false)
 	require.NoError(t, err)
 	return fileName
+}
+
+// openBothReaders opens path with both reader implementations, registering
+// cleanups that close them. It returns the concrete reader types because
+// several tests compare their internals.
+func openBothReaders(t *testing.T, path string) (*ByteSliceReader, *StreamReader) {
+	t.Helper()
+
+	mmap, err := NewMmapFileReader(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, mmap.Close()) })
+
+	stream, err := NewStreamFileReader(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, stream.Close()) })
+
+	return mmap, stream
+}
+
+// writeCrossCheckFixture builds a small but non-trivial index used by
+// the cross-check tests: multiple label names, multiple values per
+// name, a couple of chunks per series.
+func writeCrossCheckFixture(t *testing.T, format int) string {
+	t.Helper()
+	return writeIndexFixture(t, format, []seriesFixture{
+		{ls: labels.FromStrings("a", "1", "b", "1", "c", "svcA"), chunks: []ChunkMeta{{Checksum: 1, MinTime: 0, MaxTime: 10, KB: 1, Entries: 1}}},
+		{ls: labels.FromStrings("a", "1", "b", "2", "c", "svcA"), chunks: []ChunkMeta{{Checksum: 2, MinTime: 10, MaxTime: 20, KB: 1, Entries: 1}}},
+		{ls: labels.FromStrings("a", "2", "b", "3", "c", "svcB"), chunks: []ChunkMeta{{Checksum: 3, MinTime: 20, MaxTime: 30, KB: 1, Entries: 1}}},
+	})
 }
 
 // chunkSpan is the millisecond width of every chunk written by
@@ -88,26 +126,15 @@ const chunkSpan = 100
 // It returns the file name and the exclusive end of the time range covered.
 func writeManyChunksFixture(t *testing.T, format int) (string, int64) {
 	t.Helper()
-	dir := t.TempDir()
-	fileName := filepath.Join(dir, IndexFilename)
-
-	creator, err := NewWriter(context.Background(), format, fileName)
-	require.NoError(t, err)
 
 	// Straddle the linear-scan/marker-lookup boundary (64) and the page size
 	// (16) from both sides, and include a series long enough to span many
 	// pages.
 	chunkCounts := []int{1, 2, 15, 16, 17, 63, 64, 65, 200}
 
-	type entry struct {
-		ls     labels.Labels
-		chunks []ChunkMeta
-	}
-
 	var (
-		symbolSet = map[string]struct{}{}
-		entries   = make([]entry, 0, len(chunkCounts))
-		through   int64
+		series  = make([]seriesFixture, 0, len(chunkCounts))
+		through int64
 	)
 	for i, chunkCount := range chunkCounts {
 		ls := labels.FromStrings(
@@ -117,10 +144,6 @@ func writeManyChunksFixture(t *testing.T, format int) (string, int64) {
 			"pod", fmt.Sprintf("pod%03d", (i*7)%len(chunkCounts)),
 			"tenant", "loki",
 		)
-		ls.Range(func(l labels.Label) {
-			symbolSet[l.Name] = struct{}{}
-			symbolSet[l.Value] = struct{}{}
-		})
 
 		chunks := make([]ChunkMeta, 0, chunkCount)
 		for c := range chunkCount {
@@ -143,34 +166,10 @@ func writeManyChunksFixture(t *testing.T, format int) (string, int64) {
 				through = maxTime + 1
 			}
 		}
-		entries = append(entries, entry{ls: ls, chunks: chunks})
+		series = append(series, seriesFixture{ls: ls, chunks: chunks})
 	}
 
-	symbols := make([]string, 0, len(symbolSet))
-	for s := range symbolSet {
-		symbols = append(symbols, s)
-	}
-	sort.Strings(symbols)
-	for _, s := range symbols {
-		require.NoError(t, creator.AddSymbol(s))
-	}
-
-	// AddSeries requires ascending fingerprint order.
-	sort.Slice(entries, func(i, j int) bool {
-		return labels.StableHash(entries[i].ls) < labels.StableHash(entries[j].ls)
-	})
-	for i, e := range entries {
-		require.NoError(t, creator.AddSeries(
-			storage.SeriesRef(i+1),
-			e.ls,
-			model.Fingerprint(labels.StableHash(e.ls)),
-			e.chunks...,
-		))
-	}
-
-	_, err = creator.Close(false)
-	require.NoError(t, err)
-	return fileName, through
+	return writeIndexFixture(t, format, series), through
 }
 
 // TestReaders_CrossCheck opens the same fixture with every Reader
@@ -181,15 +180,7 @@ func writeManyChunksFixture(t *testing.T, format int) (string, int64) {
 func TestReaders_CrossCheck(t *testing.T) {
 	for _, format := range []int{FormatV3, FormatV4} {
 		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
-			fn := writeCrossCheckFixture(t, format)
-
-			mmap, err := NewMmapFileReader(fn)
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, mmap.Close()) })
-
-			stream, err := NewStreamFileReader(fn)
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, stream.Close()) })
+			mmap, stream := openBothReaders(t, writeCrossCheckFixture(t, format))
 
 			require.Equal(t, mmap.Version(), stream.Version())
 			require.Equal(t, mmap.Checksum(), stream.Checksum())
@@ -215,14 +206,7 @@ func TestStreamReader_SeriesMatchesMmap(t *testing.T) {
 	for _, format := range []int{FormatV3, FormatV4} {
 		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
 			path, through := writeManyChunksFixture(t, format)
-
-			mmap, err := NewMmapFileReader(path)
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, mmap.Close()) })
-
-			stream, err := NewStreamFileReader(path)
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, stream.Close()) })
+			mmap, stream := openBothReaders(t, path)
 
 			refs := allSeriesRefs(t, mmap)
 			require.NotEmpty(t, refs)
@@ -549,8 +533,8 @@ func requirePostingsSeriesEqual(t *testing.T, mmap, stream Reader) {
 		labelValues, err := mmap.LabelValues(labelName)
 		require.NoError(t, err)
 		for _, labelValue := range labelValues {
-			mmapSeriesRefs := getPostings(t, mmap, labelName, labelValue)
-			streamSeriesRefs := getPostings(t, stream, labelName, labelValue)
+			mmapSeriesRefs := mustPostingsAndDrain(t, mmap, nil, labelName, labelValue)
+			streamSeriesRefs := mustPostingsAndDrain(t, stream, nil, labelName, labelValue)
 			require.Equal(t, mmapSeriesRefs, streamSeriesRefs)
 
 			for _, seriesRef := range mmapSeriesRefs {
@@ -558,18 +542,6 @@ func requirePostingsSeriesEqual(t *testing.T, mmap, stream Reader) {
 			}
 		}
 	}
-}
-
-func getPostings(t *testing.T, reader Reader, labelName, labelValue string) []storage.SeriesRef {
-	t.Helper()
-	p, err := reader.Postings(labelName, nil, labelValue)
-	require.NoError(t, err)
-	var refs []storage.SeriesRef
-	for p.Next() {
-		refs = append(refs, p.At())
-	}
-	require.NoError(t, p.Err())
-	return refs
 }
 
 func requireSeriesEqual(t *testing.T, mmap, stream Reader, seriesRef storage.SeriesRef, labelName string) {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
@@ -73,6 +73,106 @@ func writeCrossCheckFixture(t *testing.T, format int) string {
 	return fileName
 }
 
+// chunkSpan is the millisecond width of every chunk written by
+// writeManyChunksFixture. Chunks are contiguous, so a series with n chunks
+// covers [0, n*chunkSpan).
+const chunkSpan = 100
+
+// writeManyChunksFixture builds an index whose series carry chunk counts
+// straddling both ChunkPageSize (16) and DefaultMaxChunksToBypassMarkerLookup
+// (64), so decoding takes the linear-scan path for the short series and the
+// chunk-page-marker path for the long ones. Series carry several labels drawn
+// from a pool of well over symbolFactor symbols, so resolving a series' labels
+// walks the sparse symbol table rather than hitting only its first block.
+//
+// It returns the file name and the exclusive end of the time range covered.
+func writeManyChunksFixture(t *testing.T, format int) (string, int64) {
+	t.Helper()
+	dir := t.TempDir()
+	fileName := filepath.Join(dir, IndexFilename)
+
+	creator, err := NewWriter(context.Background(), format, fileName)
+	require.NoError(t, err)
+
+	// Straddle the linear-scan/marker-lookup boundary (64) and the page size
+	// (16) from both sides, and include a series long enough to span many
+	// pages.
+	chunkCounts := []int{1, 2, 15, 16, 17, 63, 64, 65, 200}
+
+	type entry struct {
+		ls     labels.Labels
+		chunks []ChunkMeta
+	}
+
+	var (
+		symbolSet = map[string]struct{}{}
+		entries   = make([]entry, 0, len(chunkCounts))
+		through   int64
+	)
+	for i, chunkCount := range chunkCounts {
+		ls := labels.FromStrings(
+			"app", fmt.Sprintf("app%02d", i%4),
+			"env", []string{"dev", "prod", "staging"}[i%3],
+			"id", fmt.Sprintf("series%03d", i),
+			"pod", fmt.Sprintf("pod%03d", (i*7)%len(chunkCounts)),
+			"tenant", "loki",
+		)
+		ls.Range(func(l labels.Label) {
+			symbolSet[l.Name] = struct{}{}
+			symbolSet[l.Value] = struct{}{}
+		})
+
+		chunks := make([]ChunkMeta, 0, chunkCount)
+		for c := range chunkCount {
+			minTime := int64(c) * chunkSpan
+			maxTime := minTime + chunkSpan - 1
+			chunk := ChunkMeta{
+				Checksum: uint32(i*1000 + c),
+				MinTime:  minTime,
+				MaxTime:  maxTime,
+				KB:       uint32(c + 1),
+				Entries:  uint32(2*c + 1),
+			}
+			// Only FormatV4 encodes IngestedAt. Stamp it on every other series
+			// so both the set and unset encodings are covered.
+			if i%2 == 0 {
+				chunk.IngestedAt = maxTime + int64(c%3+1)*ingestedAtDayMilliseconds
+			}
+			chunks = append(chunks, chunk)
+			if maxTime+1 > through {
+				through = maxTime + 1
+			}
+		}
+		entries = append(entries, entry{ls: ls, chunks: chunks})
+	}
+
+	symbols := make([]string, 0, len(symbolSet))
+	for s := range symbolSet {
+		symbols = append(symbols, s)
+	}
+	sort.Strings(symbols)
+	for _, s := range symbols {
+		require.NoError(t, creator.AddSymbol(s))
+	}
+
+	// AddSeries requires ascending fingerprint order.
+	sort.Slice(entries, func(i, j int) bool {
+		return labels.StableHash(entries[i].ls) < labels.StableHash(entries[j].ls)
+	})
+	for i, e := range entries {
+		require.NoError(t, creator.AddSeries(
+			storage.SeriesRef(i+1),
+			e.ls,
+			model.Fingerprint(labels.StableHash(e.ls)),
+			e.chunks...,
+		))
+	}
+
+	_, err = creator.Close(false)
+	require.NoError(t, err)
+	return fileName, through
+}
+
 // TestReaders_CrossCheck opens the same fixture with every Reader
 // implementation and asserts each method returns identical results to
 // the ByteSliceReader baseline. Today StreamReader delegates to
@@ -104,6 +204,101 @@ func TestReaders_CrossCheck(t *testing.T) {
 			requirePostingsSeriesEqual(t, mmap, stream)
 		})
 	}
+}
+
+// TestStreamReader_SeriesMatchesMmap cross-checks the streaming Series and
+// ChunkStats implementations against the mmap reader over series with widely
+// varying chunk counts and a range of query windows, so both the linear chunk
+// scan and the chunk-page-marker lookup are exercised, along with windows that
+// select all, some, and none of a series' chunks.
+func TestStreamReader_SeriesMatchesMmap(t *testing.T) {
+	for _, format := range []int{FormatV3, FormatV4} {
+		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
+			path, through := writeManyChunksFixture(t, format)
+
+			mmap, err := NewMmapFileReader(path)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, mmap.Close()) })
+
+			stream, err := NewStreamFileReader(path)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, stream.Close()) })
+
+			refs := allSeriesRefs(t, mmap)
+			require.NotEmpty(t, refs)
+
+			windows := []struct {
+				name          string
+				from, through int64
+			}{
+				{"everything", 0, math.MaxInt64},
+				{"first chunk only", 0, chunkSpan},
+				{"single mid-range chunk", 20 * chunkSpan, 21 * chunkSpan},
+				{"across page boundaries", 20*chunkSpan + 50, 40*chunkSpan + 50},
+				{"tail", 150 * chunkSpan, math.MaxInt64},
+				{"past the end", through, through + chunkSpan},
+				{"before the start", -2 * chunkSpan, 0},
+			}
+
+			for _, w := range windows {
+				t.Run(w.name, func(t *testing.T) {
+					for _, ref := range refs {
+						requireStreamSeriesEqual(t, mmap, stream, ref, w.from, w.through)
+					}
+				})
+			}
+		})
+	}
+}
+
+// requireStreamSeriesEqual asserts that Series and ChunkStats agree between the
+// two readers for one series ref and one query window, including the
+// labels-free Series path.
+func requireStreamSeriesEqual(t *testing.T, mmap, stream Reader, ref storage.SeriesRef, from, through int64) {
+	t.Helper()
+
+	var mmapLabels, streamLabels labels.Labels
+	var mmapChunks, streamChunks []ChunkMeta
+
+	mmapFingerprint, err := mmap.Series(ref, from, through, &mmapLabels, &mmapChunks)
+	require.NoError(t, err)
+	streamFingerprint, err := stream.Series(ref, from, through, &streamLabels, &streamChunks)
+	require.NoError(t, err)
+	require.Equal(t, mmapFingerprint, streamFingerprint)
+	require.Equal(t, mmapLabels, streamLabels)
+	require.Equal(t, mmapChunks, streamChunks)
+
+	// Series with nil labels takes the skip-labels decode path.
+	var mmapChunksNoLabels, streamChunksNoLabels []ChunkMeta
+	mmapFingerprint, err = mmap.Series(ref, from, through, nil, &mmapChunksNoLabels)
+	require.NoError(t, err)
+	streamFingerprint, err = stream.Series(ref, from, through, nil, &streamChunksNoLabels)
+	require.NoError(t, err)
+	require.Equal(t, mmapFingerprint, streamFingerprint)
+	require.Equal(t, mmapChunks, streamChunksNoLabels)
+	require.Equal(t, mmapChunksNoLabels, streamChunksNoLabels)
+
+	// ChunkStats both without and with a `by` set.
+	for _, by := range []map[string]struct{}{nil, {"app": {}, "env": {}}} {
+		var mmapStatsLabels, streamStatsLabels labels.Labels
+		mmapFingerprint, mmapStats, err := mmap.ChunkStats(ref, from, through, &mmapStatsLabels, by)
+		require.NoError(t, err)
+		streamFingerprint, streamStats, err := stream.ChunkStats(ref, from, through, &streamStatsLabels, by)
+		require.NoError(t, err)
+		require.Equal(t, mmapFingerprint, streamFingerprint)
+		require.Equal(t, mmapStats, streamStats)
+		require.Equal(t, mmapStatsLabels, streamStatsLabels)
+	}
+}
+
+// allSeriesRefs returns every series ref in the index, in ascending order. The
+// fixtures give each series a unique "id" value, so the union of that label's
+// postings covers all of them.
+func allSeriesRefs(t *testing.T, r Reader) []storage.SeriesRef {
+	t.Helper()
+	values, err := r.LabelValues("id")
+	require.NoError(t, err)
+	return mustPostingsAndDrain(t, r, nil, "id", values...)
 }
 
 func TestReaders_RejectsBadMagic(t *testing.T) {
@@ -205,6 +400,74 @@ func TestReaders_RejectsCorruptSymbolsChecksum(t *testing.T) {
 			_, err = rc.open(path)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "invalid checksum")
+		})
+	}
+}
+
+// TestReaders_RejectsCorruptSeriesRecord asserts that a series record whose
+// content no longer matches its trailing CRC32 is rejected rather than
+// silently decoded into corrupt labels or chunks.
+func TestReaders_RejectsCorruptSeriesRecord(t *testing.T) {
+	for _, format := range []int{FormatV3, FormatV4} {
+		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
+			path, _ := writeManyChunksFixture(t, format)
+
+			mmap, err := NewMmapFileReader(path)
+			require.NoError(t, err)
+			ref := allSeriesRefs(t, mmap)[0]
+			require.NoError(t, mmap.Close())
+
+			// Flip a bit in the record's content, leaving its length prefix and CRC intact.
+			corruptFileBytes(t, path, func(b []byte) {
+				offset := seriesOffset(ref)
+				_, lenBytes := binary.Uvarint(b[offset:])
+				require.Positive(t, lenBytes)
+				b[offset+lenBytes] ^= 0x01
+			})
+
+			for _, rc := range allReaderConstructors() {
+				t.Run(rc.name, func(t *testing.T) {
+					r, err := rc.open(path)
+					require.NoError(t, err)
+					t.Cleanup(func() { require.NoError(t, r.Close()) })
+
+					var lbls labels.Labels
+					var chunks []ChunkMeta
+					_, err = r.Series(ref, 0, math.MaxInt64, &lbls, &chunks)
+					require.ErrorContains(t, err, "invalid checksum")
+
+					_, _, err = r.ChunkStats(ref, 0, math.MaxInt64, &lbls, nil)
+					require.ErrorContains(t, err, "invalid checksum")
+				})
+			}
+		})
+	}
+}
+
+// TestReaders_RejectsOutOfRangeSeriesRef asserts that a series ref pointing
+// past the end of the index is rejected rather than read as garbage.
+func TestReaders_RejectsOutOfRangeSeriesRef(t *testing.T) {
+	path, _ := writeManyChunksFixture(t, FormatV4)
+
+	fileInfo, err := os.Stat(path)
+	require.NoError(t, err)
+	// Series refs are file offsets divided by 16, so this one addresses well
+	// past the end of the file.
+	ref := storage.SeriesRef(fileInfo.Size()/16 + 100)
+
+	for _, rc := range allReaderConstructors() {
+		t.Run(rc.name, func(t *testing.T) {
+			r, err := rc.open(path)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, r.Close()) })
+
+			var lbls labels.Labels
+			var chunks []ChunkMeta
+			_, err = r.Series(ref, 0, math.MaxInt64, &lbls, &chunks)
+			require.ErrorContains(t, err, "invalid size")
+
+			_, _, err = r.ChunkStats(ref, 0, math.MaxInt64, &lbls, nil)
+			require.ErrorContains(t, err, "invalid size")
 		})
 	}
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols.go
@@ -22,11 +22,16 @@ type streamSymbols struct {
 	offsets []int
 	// size is the total number of symbols in the section.
 	size int
+	// labelNameSymbols caches label name symbols by ordinal, mirroring
+	// ByteSliceReader.nameSymbols.
+	// There are not many label names compared to label values, and they
+	// make up half of all lookups, so holding them in memory is a good trade-off.
+	labelNameSymbols map[uint32]string
 }
 
-// newStreamSymbols scans the symbol section once, validating its CRC and
-// capturing the sparse offset table.
-func newStreamSymbols(ctx context.Context, factory *streamenc.FilePoolDecbufFactory, off int) (*streamSymbols, error) {
+// newStreamSymbols scans the symbol section once, validating its CRC,
+// capturing the sparse offset table, and building labelNameSymbols.
+func newStreamSymbols(ctx context.Context, factory *streamenc.FilePoolDecbufFactory, off int, isLabelName func(symbol string) bool) (*streamSymbols, error) {
 	decbuf := factory.NewDecbufAtChecked(ctx, off, castagnoliTable)
 	defer func() { _ = decbuf.Close() }()
 	if err := decbuf.Err(); err != nil {
@@ -39,16 +44,20 @@ func newStreamSymbols(ctx context.Context, factory *streamenc.FilePoolDecbufFact
 	}
 	// Construct the sparse offset table
 	s := &streamSymbols{
-		factory: factory,
-		off:     off,
-		size:    size,
-		offsets: make([]int, 0, 1+size/symbolFactor),
+		factory:          factory,
+		off:              off,
+		size:             size,
+		offsets:          make([]int, 0, 1+size/symbolFactor),
+		labelNameSymbols: map[uint32]string{},
 	}
 	for i := 0; decbuf.Err() == nil && i < size; i++ {
 		if i%symbolFactor == 0 {
 			s.offsets = append(s.offsets, decbuf.Offset())
 		}
-		decbuf.SkipUvarintBytes()
+		symbol := decbuf.UvarintStr()
+		if isLabelName(symbol) {
+			s.labelNameSymbols[uint32(i)] = symbol
+		}
 	}
 	if err := decbuf.Err(); err != nil {
 		return nil, err
@@ -57,6 +66,10 @@ func newStreamSymbols(ctx context.Context, factory *streamenc.FilePoolDecbufFact
 }
 
 func (s *streamSymbols) Lookup(n uint32) (string, error) {
+	if symbol, ok := s.labelNameSymbols[n]; ok {
+		return symbol, nil
+	}
+
 	if int(n) >= s.size {
 		return "", fmt.Errorf("unknown symbol offset %d", n)
 	}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols_test.go
@@ -1,15 +1,10 @@
 package index
 
 import (
-	"context"
 	"fmt"
-	"path/filepath"
-	"sort"
 	"testing"
 
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,58 +14,18 @@ import (
 // "id" value; symbols are the sorted union of the label name and every value.
 func writeManySymbolsFixture(t *testing.T, format int) string {
 	t.Helper()
-	dir := t.TempDir()
-	fileName := filepath.Join(dir, IndexFilename)
-
-	creator, err := NewWriter(context.Background(), format, fileName)
-	require.NoError(t, err)
 
 	const numSeries = symbolFactor*4 + 5 // 133: several full sparse blocks plus a remainder.
 
-	// Collect the sorted, de-duplicated symbol set (label name + all values).
-	symbolSet := map[string]struct{}{"id": {}}
-	values := make([]string, 0, numSeries)
+	series := make([]seriesFixture, 0, numSeries)
 	for i := range numSeries {
-		v := fmt.Sprintf("v%04d", i)
-		values = append(values, v)
-		symbolSet[v] = struct{}{}
-	}
-	symbols := make([]string, 0, len(symbolSet))
-	for s := range symbolSet {
-		symbols = append(symbols, s)
-	}
-	sort.Strings(symbols)
-	for _, s := range symbols {
-		require.NoError(t, creator.AddSymbol(s))
-	}
-
-	type entry struct {
-		ls     labels.Labels
-		chunks []ChunkMeta
-	}
-	entries := make([]entry, 0, numSeries)
-	for _, v := range values {
-		entries = append(entries, entry{
-			ls:     labels.FromStrings("id", v),
+		series = append(series, seriesFixture{
+			ls:     labels.FromStrings("id", fmt.Sprintf("v%04d", i)),
 			chunks: []ChunkMeta{{Checksum: 1, MinTime: 0, MaxTime: 10, KB: 1, Entries: 1}},
 		})
 	}
-	// AddSeries requires ascending fingerprint order.
-	sort.Slice(entries, func(i, j int) bool {
-		return labels.StableHash(entries[i].ls) < labels.StableHash(entries[j].ls)
-	})
-	for i, e := range entries {
-		require.NoError(t, creator.AddSeries(
-			storage.SeriesRef(i+1),
-			e.ls,
-			model.Fingerprint(labels.StableHash(e.ls)),
-			e.chunks...,
-		))
-	}
 
-	_, err = creator.Close(false)
-	require.NoError(t, err)
-	return fileName
+	return writeIndexFixture(t, format, series)
 }
 
 // TestStreamSymbols_LookupMatchesMmap asserts that streamSymbols.Lookup and
@@ -78,15 +33,7 @@ func writeManySymbolsFixture(t *testing.T, format int) string {
 func TestStreamSymbols_LookupMatchesMmap(t *testing.T) {
 	for _, format := range []int{FormatV3, FormatV4} {
 		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
-			fn := writeManySymbolsFixture(t, format)
-
-			mmap, err := NewMmapFileReader(fn)
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, mmap.Close()) })
-
-			stream, err := NewStreamFileReader(fn)
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, stream.Close()) })
+			mmap, stream := openBothReaders(t, writeManySymbolsFixture(t, format))
 
 			// Both symbol tables must agree on how many symbols exist.
 			require.Equal(t, mmap.symbols.seen, stream.symbols.size)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding_test.go
@@ -731,7 +731,8 @@ func runAllBufReaderTypes(t *testing.T, caseName string, bytes []byte, testFn fu
 	require.NoError(t, os.WriteFile(filePath, bytes, 0700))
 
 	reg := prometheus.WrapRegistererWithPrefix("indexheader_", prometheus.NewPedanticRegistry())
-	diskFactory := NewFilePoolDecbufFactory(filePath, 0, filepool.NewFilePoolMetrics(reg))
+	diskFactory, err := NewFilePoolDecbufFactory(filePath, 0, filepool.NewFilePoolMetrics(reg))
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = diskFactory.Close()
 	})

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/factory_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/factory_test.go
@@ -246,7 +246,8 @@ func createDecbufFactoryWithBytes(t testing.TB, filePoolSize uint, length int, e
 	require.NoError(t, os.WriteFile(filePath, bytes, 0700))
 
 	reg := prometheus.NewPedanticRegistry()
-	diskFactory := NewFilePoolDecbufFactory(filePath, filePoolSize, filepool.NewFilePoolMetrics(reg))
+	diskFactory, err := NewFilePoolDecbufFactory(filePath, filePoolSize, filepool.NewFilePoolMetrics(reg))
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = diskFactory.Close()
 	})

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_factory.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_factory.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
+	"os"
 
 	"github.com/pkg/errors"
 
@@ -20,20 +21,34 @@ import (
 // for a specific index-header file on local disk.
 type FilePoolDecbufFactory struct {
 	files *filepool.FilePool
+	// fileSize is the size of the file at path in bytes, cached here
+	// to avoid repeated stat calls.
+	// Index files are immutable once written, so this cannot go stale.
+	fileSize int64
 }
 
 func NewFilePoolDecbufFactory(
 	path string,
 	maxIdleFileHandles uint,
 	metrics *filepool.FilePoolMetrics,
-) *FilePoolDecbufFactory {
+) (*FilePoolDecbufFactory, error) {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "stat file for decbuf factory")
+	}
+
 	return &FilePoolDecbufFactory{
 		files: filepool.NewFilePool(
 			path,
 			maxIdleFileHandles,
 			metrics,
 		),
-	}
+		fileSize: fileInfo.Size(),
+	}, nil
+}
+
+func (df *FilePoolDecbufFactory) FileSize() int64 {
+	return df.fileSize
 }
 
 func (df *FilePoolDecbufFactory) NewDecbufAtChecked(_ context.Context, offset int, table *crc32.Table) Decbuf {
@@ -112,13 +127,7 @@ func (df *FilePoolDecbufFactory) NewRawDecbuf(_ context.Context) Decbuf {
 		}
 	}()
 
-	stat, err := f.Stat()
-	if err != nil {
-		return Decbuf{E: errors.Wrap(err, "stat file for decbuf")}
-	}
-
-	fileSize := stat.Size()
-	reader, err := NewFileReader(f, 0, int(fileSize), df.files)
+	reader, err := NewFileReader(f, 0, int(df.fileSize), df.files)
 	if err != nil {
 		return Decbuf{E: errors.Wrap(err, "file reader for decbuf")}
 	}


### PR DESCRIPTION
- Add optimisation to FilePoolDecbufFactory to cache fileSize
- Cache all label names in memory in streamSymbols (same as mmap)
- Add isLabelName to streamPostings, used to populate that cache in streamSymbols
- These two optimisations make the new Series and ChunkStats implementations more efficient.

**What this PR does / why we need it**: Part of our effort to move away from mmap in index gateways.

**Which issue(s) this PR fixes**: N/A.

**Special notes for your reviewer**: Second commit can be reviewed separately - it's a small refactor over tests added during this project. 

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
