### PR TITLE
fix(chunkenc): Use the same sample hash in every head block format

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -12,7 +12,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/cespare/xxhash/v2"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
@@ -1418,10 +1417,13 @@ func (hb *headBlock) SampleIterator(
 					series[lblStr] = s
 				}
 
+				// Several samples can come from one line. They share the timestamp and the
+				// stream hash, so the line alone does not tell them apart. Mix in the label
+				// string, as the other head block and the compressed blocks already do.
 				s.Samples = append(s.Samples, logproto.Sample{
 					Timestamp: e.t,
 					Value:     value,
-					Hash:      xxhash.Sum64(unsafeGetBytes(e.s)),
+					Hash:      util.UniqueSampleHash(lblStr, unsafeGetBytes(e.s)),
 				})
 			}
 

--- a/pkg/chunkenc/unordered_test.go
+++ b/pkg/chunkenc/unordered_test.go
@@ -358,6 +358,81 @@ func Test_UnorderedBoundedIter(t *testing.T) {
 	}
 }
 
+// TestHeadBlockSampleHashesMatchAcrossFormats pins the sample hash to the same value in every
+// head block format.
+//
+// Replicas cut blocks at independent points, so at any moment one replica can serve a line from
+// its head block while another serves the same line from a compressed block. The merge iterator
+// recognises the duplicate only if both sides hashed the sample the same way. A divergence makes
+// it count the sample twice.
+//
+// The query is a variants() one because that is the case the hash has to disambiguate: a single
+// extractor emits one sample per variant, and all of them share a timestamp and a stream hash.
+func TestHeadBlockSampleHashesMatchAcrossFormats(t *testing.T) {
+	streamLabels := labels.FromStrings("app", "foo")
+
+	type sampleKey struct {
+		labels    string
+		timestamp int64
+	}
+
+	collect := func(t *testing.T, hb HeadBlock) map[sampleKey]uint64 {
+		t.Helper()
+
+		extractors, err := getMultiVariantExtractors(multiVariantQuery, streamLabels)
+		require.NoError(t, err)
+		require.Len(t, extractors, 1, "a variants() query consolidates into a single extractor")
+
+		it := hb.SampleIterator(context.Background(), 0, math.MaxInt64, extractors...)
+		defer it.Close()
+
+		got := map[sampleKey]uint64{}
+		for it.Next() {
+			s := it.At()
+			got[sampleKey{labels: it.Labels(), timestamp: s.Timestamp}] = s.Hash
+		}
+		require.NoError(t, it.Err())
+		require.NotEmpty(t, got)
+
+		return got
+	}
+
+	blocks := map[HeadBlockFmt]HeadBlock{
+		OrderedHeadBlockFmt:                         &headBlock{},
+		UnorderedHeadBlockFmt:                       newUnorderedHeadBlock(UnorderedHeadBlockFmt, newSymbolizer()),
+		UnorderedWithStructuredMetadataHeadBlockFmt: newUnorderedHeadBlock(UnorderedWithStructuredMetadataHeadBlockFmt, newSymbolizer()),
+	}
+
+	for i := 0; i < 10; i++ {
+		for _, hb := range blocks {
+			dup, err := hb.Append(int64(i), fmt.Sprintf("line %d", i), labels.EmptyLabels())
+			require.False(t, dup)
+			require.NoError(t, err)
+		}
+	}
+
+	want := collect(t, blocks[UnorderedWithStructuredMetadataHeadBlockFmt])
+
+	// Every variant of a line must get its own hash, otherwise the merge iterator drops all but
+	// one of them as duplicates.
+	perTimestamp := map[int64]map[uint64]struct{}{}
+	for key, h := range want {
+		if perTimestamp[key.timestamp] == nil {
+			perTimestamp[key.timestamp] = map[uint64]struct{}{}
+		}
+		perTimestamp[key.timestamp][h] = struct{}{}
+	}
+	for ts, hashes := range perTimestamp {
+		require.Len(t, hashes, 2, "the two variants of the line at ts %d must hash differently", ts)
+	}
+
+	for format, hb := range blocks {
+		t.Run(format.String(), func(t *testing.T) {
+			require.Equal(t, want, collect(t, hb))
+		})
+	}
+}
+
 func TestHeadBlockInterop(t *testing.T) {
 	unordered, ordered := newUnorderedHeadBlock(UnorderedHeadBlockFmt, newSymbolizer()), &headBlock{}
 	unorderedWithStructuredMetadata := newUnorderedHeadBlock(UnorderedWithStructuredMetadataHeadBlockFmt, newSymbolizer())


### PR DESCRIPTION
**What this PR does / why we need it**:

`logproto.Sample.Hash` exists for one purpose: `mergeSampleIterator` uses it to recognise that two samples with the same stream hash and timestamp are the same log line, and drops the duplicate. For that to work, every producer has to hash a sample the same way.

Three of the four producers use `util.UniqueSampleHash(labels, line)`. The ordered head block (`headBlock.SampleIterator`) still hashes the line alone — it was missed when #17064 introduced the label component. Two consequences:

- Replicas cut blocks at independent points, so one replica can serve a line from its head block while another serves the same line from a compressed block. Different hashes means the merge iterator does not see the duplicate and counts the sample twice.
- Every sample a `variants()` extractor emits from one line gets the same hash. Those samples share a timestamp and a stream hash, so the hash is the only thing distinguishing them.

**Special notes for your reviewer**:

Neither is reachable today, so there is no user-visible bug to fix. The ordered head block is only instantiated for `ChunkFormatV2`, and `PeriodConfig.ChunkFormat()` returns `ChunkFormatV3` at the lowest for every schema version. Persisted chunks never carry a head block either — `MemChunk.writeTo` explicitly excludes it. Only tests can construct the combination.

This is consistency hygiene: it removes a trap for anyone who touches this path later, and the new test pins the invariant so the four producers cannot drift again. I confirmed the test fails on `ordered` alone without the one-line change.

Found while profiling `util.UniqueSampleHash`, which is ~10% of querier CPU on heavy metric queries. The optimisation work for that is separate and does not change any hash value.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.