### PR TITLE
chore: Implement streaming reading of label methods

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
@@ -185,6 +185,72 @@ func (p *streamPostings) postingsFor(labelName string, labelValues ...string) (P
 	return Merge(results...), nil
 }
 
+// labelValuesFor returns every value stored for the given label name, in the
+// ascending order they appear in the offset table.
+// It mirrors ByteSliceReader.LabelValues.
+func (p *streamPostings) labelValuesFor(labelName string) ([]string, error) {
+	offsets, ok := p.postings[labelName]
+	if !ok || len(offsets) == 0 {
+		return nil, nil
+	}
+	labelValues := make([]string, 0, len(offsets)*symbolFactor)
+
+	// Unchecked because we already checked CRC32 at startup
+	decbuf := p.factory.NewDecbufAtUnchecked(context.Background(), p.off)
+	if err := decbuf.Err(); err != nil {
+		return nil, err
+	}
+	defer func() { _ = decbuf.Close() }()
+
+	// The sparse table always retains a name's first and last value, so walking
+	// forward from the first entry until the last value turns up covers every
+	// value of this name and stops before the next name's entries.
+	decbuf.ResetAt(offsets[0].offset)
+	lastLabelValue := offsets[len(offsets)-1].labelValue
+
+	skip := 0
+	for decbuf.Err() == nil {
+		if skip == 0 {
+			// These are always the same number of bytes,
+			// and it's faster to skip than parse.
+			skip = decbuf.Len()
+			decbuf.Uvarint()          // Key count
+			decbuf.SkipUvarintBytes() // Label name
+			skip -= decbuf.Len()
+		} else {
+			decbuf.Skip(skip)
+		}
+		currentLabelValue := decbuf.UvarintStr() // Label value
+		if err := decbuf.Err(); err != nil {
+			return nil, fmt.Errorf("get postings offset entry: %w", err)
+		}
+		labelValues = append(labelValues, currentLabelValue)
+		if currentLabelValue == lastLabelValue {
+			break
+		}
+		decbuf.Uvarint64() // Absolute file offset to postings entry
+	}
+	if err := decbuf.Err(); err != nil {
+		return nil, fmt.Errorf("get postings offset entry: %w", err)
+	}
+	return labelValues, nil
+}
+
+// labelNames returns the sorted label names held in the offset table.
+// It mirrors ByteSliceReader.LabelNames.
+func (p *streamPostings) labelNames() []string {
+	labelNames := make([]string, 0, len(p.postings))
+	for name := range p.postings {
+		if name == allPostingsKey.Name {
+			// This isn't from any log.
+			continue
+		}
+		labelNames = append(labelNames, name)
+	}
+	sort.Strings(labelNames)
+	return labelNames
+}
+
 // readPostingsList reads the postings list stored at absolute file offset
 // postingsOffset into memory and wraps it in a BigEndianPostings.
 // On disk, the list is a 4-byte big-endian count N followed by N contiguous

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
@@ -2,11 +2,11 @@ package index
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
 	"os"
+	"sort"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -17,12 +17,18 @@ import (
 
 // StreamReader is the file-streaming counterpart to ByteSliceReader.
 //
-// Currently, StreamReader delegates some calls to a *ByteSliceReader.
-// Follow-up changes will progressively replace embedded calls with streaming implementations
-// backed by a file-handle pool.
+// It serves every read through a pool of file handles rather than a memory
+// mapping, so the Go scheduler can observe a blocking read and run other work
+// while it completes. A page fault on a memory mapping is invisible to the
+// runtime and blocks the whole OS thread instead.
+//
+// The sections that are small enough to hold in memory — the TOC and the
+// fingerprint offsets — are read once at construction.
+// The symbols section and the postings offset table are scanned once to
+// build a sparse offset table, so later lookups seek close to their target
+// and read only a bounded window.
+// Series records are read on demand, one per lookup.
 type StreamReader struct {
-	mmapReader *ByteSliceReader
-
 	factory *streamenc.FilePoolDecbufFactory
 	path    string
 	size    int64
@@ -81,14 +87,6 @@ func NewStreamFileReader(path string) (*StreamReader, error) {
 	}
 
 	reader.decoder = newDecoder(reader.symbols.Lookup, DefaultMaxChunksToBypassMarkerLookup)
-
-	// Fallback used by not-yet-ported methods
-	mmapReader, err := NewMmapFileReader(path)
-	if err != nil {
-		_ = factory.Close()
-		return nil, err
-	}
-	reader.mmapReader = mmapReader
 
 	return reader, nil
 }
@@ -266,19 +264,64 @@ func (s StreamReader) Checksum() uint32 {
 }
 
 func (s StreamReader) LabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
-	return s.mmapReader.LabelValues(name, matchers...)
+	if len(matchers) > 0 {
+		return nil, fmt.Errorf("matchers parameter is not implemented: %+v", matchers)
+	}
+	return s.postings.labelValuesFor(name)
 }
 
 func (s StreamReader) LabelNames(matchers ...*labels.Matcher) ([]string, error) {
-	return s.mmapReader.LabelNames(matchers...)
+	if len(matchers) > 0 {
+		return nil, fmt.Errorf("matchers parameter is not implemented: %+v", matchers)
+	}
+	return s.postings.labelNames(), nil
 }
 
 func (s StreamReader) LabelValueFor(id storage.SeriesRef, label string) (string, error) {
-	return s.mmapReader.LabelValueFor(id, label)
+	content, err := s.readSeriesRecord(seriesOffset(id))
+	if err != nil {
+		return "", fmt.Errorf("label values for: %w", err)
+	}
+
+	value, err := s.decoder.LabelValueFor(content, label)
+	if err != nil {
+		return "", storage.ErrNotFound
+	}
+	if value == "" {
+		return "", storage.ErrNotFound
+	}
+	return value, nil
 }
 
 func (s StreamReader) LabelNamesFor(ids ...storage.SeriesRef) ([]string, error) {
-	return s.mmapReader.LabelNamesFor(ids...)
+	// Gather the name offsets in the symbol table first, so each distinct name
+	// is only resolved once no matter how many series carry it.
+	offsetsMap := make(map[uint32]struct{})
+	for _, id := range ids {
+		content, err := s.readSeriesRecord(seriesOffset(id))
+		if err != nil {
+			return nil, fmt.Errorf("get buffer for series: %w", err)
+		}
+
+		offsets, err := s.decoder.LabelNamesOffsetsFor(content)
+		if err != nil {
+			return nil, fmt.Errorf("get label name offsets: %w", err)
+		}
+		for _, offset := range offsets {
+			offsetsMap[offset] = struct{}{}
+		}
+	}
+
+	names := make([]string, 0, len(offsetsMap))
+	for offset := range offsetsMap {
+		name, err := s.symbols.Lookup(offset)
+		if err != nil {
+			return nil, fmt.Errorf("lookup symbol in LabelNamesFor: %w", err)
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
 }
 
 func (s StreamReader) Series(id storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]ChunkMeta) (uint64, error) {
@@ -324,7 +367,5 @@ func (s StreamReader) Size() int64 {
 }
 
 func (s StreamReader) Close() error {
-	mmapErr := s.mmapReader.Close()
-	factoryErr := s.factory.Close()
-	return errors.Join(mmapErr, factoryErr)
+	return s.factory.Close()
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"testing"
 
@@ -173,10 +174,8 @@ func writeManyChunksFixture(t *testing.T, format int) (string, int64) {
 }
 
 // TestReaders_CrossCheck opens the same fixture with every Reader
-// implementation and asserts each method returns identical results to
-// the ByteSliceReader baseline. Today StreamReader delegates to
-// ByteSliceReader so this passes trivially; the check exists to catch
-// regressions as StreamReader gains real, standalone implementations.
+// implementation and asserts each method returns identical results to the
+// ByteSliceReader baseline.
 func TestReaders_CrossCheck(t *testing.T) {
 	for _, format := range []int{FormatV3, FormatV4} {
 		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
@@ -364,26 +363,39 @@ func TestReaders_RejectsCorruptTOCChecksum(t *testing.T) {
 	}
 }
 
-func TestReaders_RejectsCorruptSymbolsChecksum(t *testing.T) {
-	for _, rc := range allReaderConstructors() {
-		t.Run(rc.name, func(t *testing.T) {
-			path := writeCrossCheckFixture(t, FormatV3)
+// TestReaders_RejectsCorruptSectionChecksum asserts that every section a reader
+// validates while opening is checked, for each of the sections the readers scan
+// up front.
+func TestReaders_RejectsCorruptSectionChecksum(t *testing.T) {
+	sections := map[string]func(toc *TOC) int{
+		"symbols":             func(toc *TOC) int { return int(toc.Symbols) },
+		"postings table":      func(toc *TOC) int { return int(toc.PostingsTable) },
+		"fingerprint offsets": func(toc *TOC) int { return int(toc.FingerprintOffsets) },
+	}
 
-			// Locate the symbols section from the TOC
-			reader, err := NewStreamFileReader(path)
-			require.NoError(t, err)
-			symbolsOffset := int(reader.toc.Symbols)
-			require.NoError(t, reader.Close())
+	for name, sectionOffset := range sections {
+		t.Run(name, func(t *testing.T) {
+			for _, rc := range allReaderConstructors() {
+				t.Run(rc.name, func(t *testing.T) {
+					path := writeCrossCheckFixture(t, FormatV3)
 
-			corruptFileBytes(t, path, func(b []byte) {
-				// Flip the first byte of the section's content (skipping the first 4 bytes,
-				// which is the size of the section).
-				b[symbolsOffset+4] ^= 0x01
-			})
+					// Locate the section from the TOC
+					reader, err := NewStreamFileReader(path)
+					require.NoError(t, err)
+					offset := sectionOffset(reader.toc)
+					require.NoError(t, reader.Close())
 
-			_, err = rc.open(path)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "invalid checksum")
+					corruptFileBytes(t, path, func(b []byte) {
+						// Flip the first byte of the section's content (skipping the first 4 bytes,
+						// which is the size of the section).
+						b[offset+4] ^= 0x01
+					})
+
+					_, err = rc.open(path)
+					require.Error(t, err)
+					require.Contains(t, err.Error(), "invalid checksum")
+				})
+			}
 		})
 	}
 }
@@ -401,13 +413,7 @@ func TestReaders_RejectsCorruptSeriesRecord(t *testing.T) {
 			ref := allSeriesRefs(t, mmap)[0]
 			require.NoError(t, mmap.Close())
 
-			// Flip a bit in the record's content, leaving its length prefix and CRC intact.
-			corruptFileBytes(t, path, func(b []byte) {
-				offset := seriesOffset(ref)
-				_, lenBytes := binary.Uvarint(b[offset:])
-				require.Positive(t, lenBytes)
-				b[offset+lenBytes] ^= 0x01
-			})
+			corruptSeriesRecord(t, path, ref)
 
 			for _, rc := range allReaderConstructors() {
 				t.Run(rc.name, func(t *testing.T) {
@@ -426,6 +432,19 @@ func TestReaders_RejectsCorruptSeriesRecord(t *testing.T) {
 			}
 		})
 	}
+}
+
+// corruptSeriesRecord flips a bit in the content of the series record for ref,
+// leaving its uvarint length prefix and its trailing CRC32 intact so the record
+// still parses but no longer matches its checksum.
+func corruptSeriesRecord(t *testing.T, path string, ref storage.SeriesRef) {
+	t.Helper()
+	corruptFileBytes(t, path, func(b []byte) {
+		offset := seriesOffset(ref)
+		_, lenBytes := binary.Uvarint(b[offset:])
+		require.Positive(t, lenBytes)
+		b[offset+lenBytes] ^= 0x01
+	})
 }
 
 // TestReaders_RejectsOutOfRangeSeriesRef asserts that a series ref pointing
@@ -495,6 +514,121 @@ func TestReaders_RawFileReaderIndependence(t *testing.T) {
 			require.Equal(t, FormatV3, r.Version())
 		})
 	}
+}
+
+// TestStreamLabels_MatchesMmap cross-checks the streaming LabelNames,
+// LabelValues, LabelValueFor and LabelNamesFor against the mmap reader.
+func TestStreamLabels_MatchesMmap(t *testing.T) {
+	fixtures := map[string]func(t *testing.T, format int) string{
+		"many values for one name": writeManySymbolsFixture,
+		"several names": func(t *testing.T, format int) string {
+			path, _ := writeManyChunksFixture(t, format)
+			return path
+		},
+	}
+
+	for name, writeFixture := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			for _, format := range []int{FormatV3, FormatV4} {
+				t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
+					mmap, stream := openBothReaders(t, writeFixture(t, format))
+
+					mmapNames, err := mmap.LabelNames()
+					require.NoError(t, err)
+					streamNames, err := stream.LabelNames()
+					require.NoError(t, err)
+					require.Equal(t, mmapNames, streamNames)
+					require.NotEmpty(t, streamNames)
+
+					// Every name the index holds, plus the all-postings key
+					// (which LabelNames omits but LabelValues still answers for)
+					// and a name that doesn't exist.
+					for _, labelName := range slices.Concat(mmapNames, []string{"", "does-not-exist"}) {
+						mmapValues, err := mmap.LabelValues(labelName)
+						require.NoError(t, err)
+						streamValues, err := stream.LabelValues(labelName)
+						require.NoError(t, err)
+						require.Equal(t, mmapValues, streamValues)
+					}
+
+					refs := allSeriesRefs(t, mmap)
+					require.NotEmpty(t, refs)
+
+					// LabelNamesFor over every ref at once
+					mmapNamesFor, err := mmap.LabelNamesFor(refs...)
+					require.NoError(t, err)
+					streamNamesFor, err := stream.LabelNamesFor(refs...)
+					require.NoError(t, err)
+					require.Equal(t, mmapNamesFor, streamNamesFor)
+
+					for _, ref := range refs {
+						// LabelNamesFor over every ref at once
+						mmapNamesFor, err := mmap.LabelNamesFor(ref)
+						require.NoError(t, err)
+						streamNamesFor, err := stream.LabelNamesFor(ref)
+						require.NoError(t, err)
+						require.Equal(t, mmapNamesFor, streamNamesFor)
+
+						// Both a label the series carries and one it doesn't,
+						// the latter being reported as storage.ErrNotFound.
+						for _, labelName := range slices.Concat(mmapNames, []string{"does-not-exist"}) {
+							mmapValue, mmapErr := mmap.LabelValueFor(ref, labelName)
+							streamValue, streamErr := stream.LabelValueFor(ref, labelName)
+							require.Equal(t, mmapErr, streamErr)
+							require.Equal(t, mmapValue, streamValue)
+						}
+					}
+
+					// LabelNamesFor rejects a ref past the end of the file the
+					// same way in both readers.
+					_, err = stream.LabelNamesFor(refs[len(refs)-1] + 1<<20)
+					require.Error(t, err)
+					_, err = mmap.LabelNamesFor(refs[len(refs)-1] + 1<<20)
+					require.Error(t, err)
+				})
+			}
+		})
+	}
+}
+
+func TestStreamLabels_RejectsMatchers(t *testing.T) { // Neither implementation supports matchers
+	mmap, stream := openBothReaders(t, writeManySymbolsFixture(t, FormatV4))
+
+	matcher := labels.MustNewMatcher(labels.MatchEqual, "id", "v0000")
+
+	_, mmapErr := mmap.LabelValues("id", matcher)
+	_, streamErr := stream.LabelValues("id", matcher)
+	require.Error(t, streamErr)
+	require.Equal(t, mmapErr.Error(), streamErr.Error())
+
+	_, mmapErr = mmap.LabelNames(matcher)
+	_, streamErr = stream.LabelNames(matcher)
+	require.Error(t, streamErr)
+	require.Equal(t, mmapErr.Error(), streamErr.Error())
+}
+
+func TestStreamLabels_RejectsCorruptSeriesRecord(t *testing.T) {
+	path := writeManySymbolsFixture(t, FormatV4)
+
+	// Pick a ref from the intact file, then corrupt it before opening the
+	// readers under test.
+	reader, err := NewMmapFileReader(path)
+	require.NoError(t, err)
+	ref := allSeriesRefs(t, reader)[0]
+	require.NoError(t, reader.Close())
+	corruptSeriesRecord(t, path, ref)
+
+	mmap, stream := openBothReaders(t, path)
+
+	_, mmapErr := mmap.LabelNamesFor(ref)
+	_, streamErr := stream.LabelNamesFor(ref)
+	require.ErrorContains(t, mmapErr, "invalid checksum")
+	require.ErrorContains(t, streamErr, "invalid checksum")
+	_, mmapErr = mmap.LabelValueFor(ref, "id")
+	_, streamErr = stream.LabelValueFor(ref, "id")
+	require.ErrorContains(t, mmapErr, "invalid checksum")
+	require.ErrorContains(t, streamErr, "invalid checksum")
+
 }
 
 // corruptFileBytes reads the whole file, hands the bytes to mutate, and


### PR DESCRIPTION
- Implement LabelValues, LabelNames, LabelValueFor and LabelNamesFor
- Test these against the existing implementation
- Remove mmap fallback from stream_reader.go as it's no longer needed

**What this PR does / why we need it**: Part of our effort to move away from mmap in index gateways.

**Which issue(s) this PR fixes**: N/A.

**Special notes for your reviewer**: This is all very close to the existing implementation and can be reviewed against it. 

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
