### PR TITLE
chore(chunkenc): Remove the unused MemChunk.Rebound

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -38,11 +38,6 @@ const (
 	blocksPerChunk = 10
 	maxLineLength  = 1024 * 1024 * 1024
 
-	// defaultBlockSize is used for target block size when cutting partially deleted chunks from a delete request.
-	// This could wary from configured block size using `ingester.chunks-block-size` flag or equivalent yaml config resulting in
-	// different block size in the new chunk which should be fine.
-	defaultBlockSize = 256 * 1024
-
 	chunkMetasSectionIdx              = 1
 	chunkStructuredMetadataSectionIdx = 2
 )
@@ -1201,47 +1196,6 @@ func (c *MemChunk) Rewrite(filter filter.Func) (Chunk, error) {
 			if err := newChunk.cut(); err != nil {
 				return nil, err
 			}
-		}
-	}
-
-	if newChunk.Size() == 0 {
-		return nil, chunk.ErrRewriteNoDataLeft
-	}
-
-	if err := newChunk.Close(); err != nil {
-		return nil, err
-	}
-
-	return newChunk, nil
-}
-
-// Rebound builds a smaller chunk with logs having timestamp from start and end(both inclusive)
-func (c *MemChunk) Rebound(start, end time.Time, filter filter.Func) (Chunk, error) {
-	// add a millisecond to end time because the Chunk.Iterator considers end time to be non-inclusive.
-	itr, err := c.Iterator(context.Background(), start, end.Add(time.Millisecond), logproto.FORWARD, log.NewNoopPipeline().ForStream(labels.Labels{}))
-	if err != nil {
-		return nil, err
-	}
-
-	var newChunk *MemChunk
-	// as close as possible, respect the block/target sizes specified. However,
-	// if the blockSize is not set, use reasonable defaults.
-	if c.blockSize > 0 {
-		newChunk = NewMemChunk(c.format, c.Encoding(), c.headFmt, c.blockSize, c.targetSize)
-	} else {
-		// Using defaultBlockSize for target block size.
-		// The alternative here could be going over all the blocks and using the size of the largest block as target block size but I(Sandeep) feel that it is not worth the complexity.
-		// For target chunk size I am using compressed size of original chunk since the newChunk should anyways be lower in size than that.
-		newChunk = NewMemChunk(c.format, c.Encoding(), c.headFmt, defaultBlockSize, c.CompressedSize())
-	}
-
-	for itr.Next() {
-		entry := itr.At()
-		if filter != nil && filter(entry.Timestamp, entry.Line, logproto.FromLabelAdaptersToLabels(entry.StructuredMetadata)) {
-			continue
-		}
-		if _, err := newChunk.Append(&entry); err != nil {
-			return nil, err
 		}
 	}
 

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -1682,7 +1682,7 @@ func TestMemChunk_Rewrite(t *testing.T) {
 	}
 }
 
-func TestMemChunk_Rewrite_with_filter(t *testing.T) {
+func TestMemChunk_Rewrite_WithFilter(t *testing.T) {
 	chkFrom := time.Unix(1, 0) // headBlock.Append treats Unix time 0 as not set so we have to use a later time
 	chkFromPlus5 := chkFrom.Add(5 * time.Second)
 	chkThrough := chkFrom.Add(10 * time.Second)

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -1553,7 +1553,7 @@ func Test_HeadIteratorReverse(t *testing.T) {
 	}
 }
 
-func TestMemChunk_Rebound(t *testing.T) {
+func TestMemChunk_Rewrite(t *testing.T) {
 	for _, format := range allPossibleFormats {
 		chunkfmt, headfmt := format.chunkFormat, format.headBlockFmt
 		chkFrom := time.Unix(0, 0)
@@ -1682,7 +1682,7 @@ func TestMemChunk_Rebound(t *testing.T) {
 	}
 }
 
-func TestMemChunk_ReboundAndFilter_with_filter(t *testing.T) {
+func TestMemChunk_Rewrite_with_filter(t *testing.T) {
 	chkFrom := time.Unix(1, 0) // headBlock.Append treats Unix time 0 as not set so we have to use a later time
 	chkFromPlus5 := chkFrom.Add(5 * time.Second)
 	chkThrough := chkFrom.Add(10 * time.Second)
@@ -1762,7 +1762,7 @@ func TestMemChunk_ReboundAndFilter_with_filter(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			originalChunk := tc.testMemChunk
-			newChunk, err := originalChunk.Rebound(chkFrom, chkThrough, tc.filterFunc)
+			newChunk, err := originalChunk.Rewrite(tc.filterFunc)
 			if tc.err != nil {
 				require.Equal(t, tc.err, err)
 				return
@@ -1791,7 +1791,7 @@ func TestMemChunk_ReboundAndFilter_with_filter(t *testing.T) {
 }
 
 func buildFilterableTestMemChunk(t *testing.T, from, through time.Time, matchingFrom, matchingTo *time.Time, withStructuredMetadata bool) *MemChunk {
-	chk := NewMemChunk(ChunkFormatV4, compression.GZIP, DefaultTestHeadBlockFmt, defaultBlockSize, 0)
+	chk := NewMemChunk(ChunkFormatV4, compression.GZIP, DefaultTestHeadBlockFmt, testBlockSize, 0)
 	t.Logf("from   : %v", from.String())
 	t.Logf("through: %v", through.String())
 	var structuredMetadata push.LabelsAdapter
@@ -1824,6 +1824,11 @@ func buildFilterableTestMemChunk(t *testing.T, from, through time.Time, matching
 		}
 		from = from.Add(time.Second)
 	}
+
+	// Rewrite only reads cut blocks, so the head block has to be cut before the chunk is
+	// usable. This also matches what Rewrite sees in production, where chunks come from
+	// storage and never carry head block data.
+	require.NoError(t, chk.Close())
 
 	return chk
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`MemChunk.Rebound` has no callers. #19140 replaced it with `Rewrite`: it swapped the two in the retention and deletion compactors, and removed `Rebound` from the `chunkenc.Chunk` interface, the `chunk.Data` interface, `Facade`, `dumbChunk` and `dummyChunk`. `MemChunk.Rebound` and its tests were left behind.

This removes it, plus `defaultBlockSize`, whose only caller it was.

**Special notes for your reviewer**:

Two details in the test changes are worth a look, because the names in this area are misleading.

`TestMemChunk_Rebound` never tested `Rebound` — it calls `originalChunk.Rewrite(...)`. #19140 renamed the method but not the test. It is renamed to `TestMemChunk_Rewrite` and otherwise untouched.

`TestMemChunk_ReboundAndFilter_with_filter` is the one that really tested `Rebound`, and it is the only test whose `filter.Func` inspects structured metadata and line content rather than timestamps. Deleting it would have lost coverage that the live `Rewrite` path has nowhere else, so it is ported rather than dropped:

- Every case built its chunk over exactly the `[from, through]` range it then passed to `Rebound`, so the range never narrowed anything. The test was always about filter semantics, which `Rewrite` shares, and it ports across unchanged.
- `Rewrite` iterates `c.blocks` and never looks at `c.head`, while `Rebound` went through `c.Iterator`, which includes the head. The fixture never cut its chunk, so all its entries sat in the head block. It now calls `Close()`. That is also the state `Rewrite` sees in production, since chunks decoded from storage never carry head block data (`MemChunk.writeTo` excludes it).

I confirmed the ported test is not vacuous: removing that `Close()` makes all seven subtests fail with `ErrRewriteNoDataLeft`.

`ErrRewriteNoDataLeft` is untouched — `Rewrite` still returns it, and both compactors still check for it.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.