### PR TITLE
perf(chunkenc): Remove the per-sample allocation from the dedup hash

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -12,7 +12,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/cespare/xxhash/v2"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
@@ -1344,6 +1343,7 @@ func (hb *headBlock) SampleIterator(
 	stats.AddHeadChunkLines(int64(len(hb.entries)))
 	series := map[string]*logproto.Series{}
 
+	var hasher util.SampleHasher
 	setQueryReferencedStructuredMetadata := false
 	for _, e := range hb.entries {
 		for _, extractor := range extractors {
@@ -1375,7 +1375,7 @@ func (hb *headBlock) SampleIterator(
 				s.Samples = append(s.Samples, logproto.Sample{
 					Timestamp: e.t,
 					Value:     value,
-					Hash:      xxhash.Sum64(unsafeGetBytes(e.s)),
+					Hash:      hasher.Hash(lblStr, unsafeGetBytes(e.s)),
 				})
 			}
 
@@ -1813,6 +1813,7 @@ type sampleBufferedIterator struct {
 
 	extractor log.StreamSampleExtractor
 	stats     *stats.Context
+	hasher    util.SampleHasher
 
 	curr       []logproto.Sample
 	currLabels []log.LabelsResult
@@ -1854,7 +1855,7 @@ func (e *sampleBufferedIterator) Next() bool {
 			e.curr = append(e.curr, logproto.Sample{
 				Timestamp: e.currTs,
 				Value:     sample.Value,
-				Hash:      util.UniqueSampleHash(lblString, e.currLine),
+				Hash:      e.hasher.Hash(lblString, e.currLine),
 			})
 		}
 

--- a/pkg/chunkenc/unordered.go
+++ b/pkg/chunkenc/unordered.go
@@ -329,6 +329,8 @@ func (hb *unorderedHeadBlock) SampleIterator(
 	setQueryReferencedStructuredMetadata := false
 	labelsBuilder := labelpool.Get()
 
+	var hasher util.SampleHasher
+
 	_ = hb.forEntries(
 		ctx,
 		logproto.FORWARD,
@@ -368,7 +370,7 @@ func (hb *unorderedHeadBlock) SampleIterator(
 					s.Samples = append(s.Samples, logproto.Sample{
 						Timestamp: ts,
 						Value:     value,
-						Hash:      util.UniqueSampleHash(lblStr, unsafeGetBytes(line)),
+						Hash:      hasher.Hash(lblStr, unsafeGetBytes(line)),
 					})
 				}
 				if extractor.ReferencedStructuredMetadata() {

--- a/pkg/chunkenc/unordered_test.go
+++ b/pkg/chunkenc/unordered_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"sort"
 	"testing"
 	"time"
 
@@ -354,6 +355,77 @@ func Test_UnorderedBoundedIter(t *testing.T) {
 					iterEq(t, expected, itr)
 				})
 			}
+		})
+	}
+}
+
+// TestHeadBlockSampleHashesMatchAcrossFormats ensures we generate the sample hash for the same
+// exact samples in every head block format.
+func TestHeadBlockSampleHashesMatchAcrossFormats(t *testing.T) {
+	streamLabels := labels.FromStrings("app", "foo")
+
+	collect := func(t *testing.T, hb HeadBlock) []logproto.Sample {
+		t.Helper()
+
+		extractors, err := getMultiVariantExtractors(multiVariantQuery, streamLabels)
+		require.NoError(t, err)
+		require.Len(t, extractors, 1, "a variants() query consolidates into a single extractor")
+
+		it := hb.SampleIterator(context.Background(), 0, math.MaxInt64, extractors...)
+		defer it.Close()
+
+		var got []logproto.Sample
+		for it.Next() {
+			got = append(got, it.At())
+		}
+		require.NoError(t, it.Err())
+
+		// Samples sharing a timestamp also share a stream hash here, so the sort iterator
+		// treats them as tied and their order follows map iteration. Sort to compare.
+		sort.Slice(got, func(i, j int) bool {
+			if got[i].Timestamp != got[j].Timestamp {
+				return got[i].Timestamp < got[j].Timestamp
+			}
+			if got[i].Hash != got[j].Hash {
+				return got[i].Hash < got[j].Hash
+			}
+			return got[i].Value < got[j].Value
+		})
+
+		return got
+	}
+
+	// Build one block per format Loki can create, so a format added later is covered without
+	// touching this test.
+	require.NotEmpty(t, HeadBlockFmts)
+	blocks := make(map[HeadBlockFmt]HeadBlock, len(HeadBlockFmts))
+	for _, format := range HeadBlockFmts {
+		blocks[format] = format.NewBlock(newSymbolizer())
+	}
+
+	for i := 0; i < 10; i++ {
+		for _, hb := range blocks {
+			dup, err := hb.Append(int64(i), fmt.Sprintf("line %d", i), labels.EmptyLabels())
+			require.False(t, dup)
+			require.NoError(t, err)
+		}
+	}
+
+	// The newest format is the reference every other one has to match.
+	want := collect(t, blocks[HeadBlockFmts[len(HeadBlockFmts)-1]])
+
+	// Pre-condition check: every sample must hash differently.
+	require.Len(t, want, 20)
+	hashes := map[uint64]struct{}{}
+	for _, s := range want {
+		hashes[s.Hash] = struct{}{}
+	}
+	require.Len(t, hashes, len(want))
+
+	// Ensure all other formats return the same exact hashes.
+	for _, format := range HeadBlockFmts {
+		t.Run(format.String(), func(t *testing.T) {
+			require.Equal(t, want, collect(t, blocks[format]))
 		})
 	}
 }

--- a/pkg/chunkenc/variants.go
+++ b/pkg/chunkenc/variants.go
@@ -33,6 +33,7 @@ type multiExtractorSampleBufferedIterator struct {
 
 	extractors []log.StreamSampleExtractor
 	stats      *stats.Context
+	hasher     util.SampleHasher
 
 	cur            []logproto.Sample
 	currLabels     []log.LabelsResult
@@ -70,7 +71,7 @@ func (e *multiExtractorSampleBufferedIterator) Next() bool {
 				lblString := sample.Labels.String()
 				e.cur = append(e.cur, logproto.Sample{
 					Value:     sample.Value,
-					Hash:      util.UniqueSampleHash(lblString, e.currLine),
+					Hash:      e.hasher.Hash(lblString, e.currLine),
 					Timestamp: e.currTs,
 				})
 			}

--- a/pkg/util/sample.go
+++ b/pkg/util/sample.go
@@ -7,6 +7,12 @@ import (
 // sampleHashBufferSize is the largest labels+line pair that SampleHasher copies into its inline
 // buffer. Below it, hashing one contiguous slice beats feeding xxhash in three writes. Above it
 // the copy costs more than it saves and the streaming path is faster.
+//
+// BenchmarkSampleHashThreshold measures the two against each other, so the value can be checked
+// again on other hardware. The crossover moves with the CPU, so this is one machine's answer
+// rather than a universal one: it sat near 800 bytes on an Apple M3 Pro. Being off by a little
+// only picks the slower of two paths that are within a few percent of each other there, so the
+// value does not need to be exact.
 const sampleHashBufferSize = 768
 
 // SampleHasher computes sample deduplication hashes without allocating.

--- a/pkg/util/sample.go
+++ b/pkg/util/sample.go
@@ -4,10 +4,39 @@ import (
 	"github.com/cespare/xxhash/v2"
 )
 
+// sampleHashBufferSize is the largest labels+line pair that SampleHasher copies into its inline
+// buffer. Below it, hashing one contiguous slice beats feeding xxhash in three writes. Above it
+// the copy costs more than it saves and the streaming path is faster.
+const sampleHashBufferSize = 768
+
+// SampleHasher computes sample deduplication hashes without allocating.
+// The zero value is ready to use. A SampleHasher is not safe for concurrent use.
+type SampleHasher struct {
+	// Because the streaming path handles everything larger, the buffer never has to grow: a
+	// SampleHasher keeps a fixed size no matter how long the lines are.
+	buf    [sampleHashBufferSize]byte
+	digest xxhash.Digest
+}
+
+// Hash returns the deduplication hash of the sample that lblString and line identify.
+func (h *SampleHasher) Hash(lblString string, line []byte) uint64 {
+	if len(lblString)+1+len(line) <= len(h.buf) {
+		b := append(h.buf[:0], lblString...)
+		b = append(b, ':')
+		b = append(b, line...)
+		return xxhash.Sum64(b)
+	}
+
+	h.digest.Reset()
+	_, _ = h.digest.WriteString(lblString)
+	_, _ = h.digest.WriteString(":")
+	_, _ = h.digest.Write(line)
+	return h.digest.Sum64()
+}
+
+// UniqueSampleHash returns the deduplication hash of the sample that lblString and line
+// identify. Callers on a hot path should hold a SampleHasher and reuse it.
 func UniqueSampleHash(lblString string, line []byte) uint64 {
-	uniqueID := make([]byte, 0, len(lblString)+len(line)+1)
-	uniqueID = append(uniqueID, lblString...)
-	uniqueID = append(uniqueID, ':')
-	uniqueID = append(uniqueID, line...)
-	return xxhash.Sum64(uniqueID)
+	var h SampleHasher
+	return h.Hash(lblString, line)
 }

--- a/pkg/util/sample_test.go
+++ b/pkg/util/sample_test.go
@@ -62,3 +62,56 @@ func BenchmarkSampleHash(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkSampleHashThreshold measures the two hashing strategies against each other so
+// sampleHashBufferSize can be re-derived.
+//
+// The buffer strategy copies the labels and the line into one contiguous slice and hashes it in a
+// single call. The streaming strategy feeds xxhash three writes and copies nothing. Copying wins
+// while the copy is cheap, so the size at which they cross is where the constant belongs.
+//
+// Both are written out here rather than called through SampleHasher.Hash, which would consult the
+// constant and pick one for us, measuring nothing. Run:
+//
+//	go test ./pkg/util/ -run '^$' -bench BenchmarkSampleHashThreshold -count=6
+//
+// and compare buffer against streaming at each total size. The crossover moves with the CPU, so
+// treat the committed constant as one machine's answer.
+func BenchmarkSampleHashThreshold(b *testing.B) {
+	lbl := `{cluster="dev-002", namespace="loki-ops", pod="querier-7d9f8b6c4d-x2n4k", container="querier", job="loki-ops/querier", level="info"}`
+
+	// Sizes are the labels+separator+line total the threshold is compared against, spanning the
+	// crossover in both directions.
+	for _, total := range []int{256, 384, 512, 640, 768, 896, 1024, 1536, 2048} {
+		line := []byte(strings.Repeat("a", total-len(lbl)-1))
+
+		b.Run(fmt.Sprintf("total=%d/buffer", total), func(b *testing.B) {
+			b.ReportAllocs()
+			// Deliberately larger than sampleHashBufferSize, so the strategy can be measured
+			// past the point where it stops being the one Hash would choose.
+			var buf [4096]byte
+			var sink uint64
+			for i := 0; i < b.N; i++ {
+				s := append(buf[:0], lbl...)
+				s = append(s, ':')
+				s = append(s, line...)
+				sink = xxhash.Sum64(s)
+			}
+			require.NotZero(b, sink)
+		})
+
+		b.Run(fmt.Sprintf("total=%d/streaming", total), func(b *testing.B) {
+			b.ReportAllocs()
+			var digest xxhash.Digest
+			var sink uint64
+			for i := 0; i < b.N; i++ {
+				digest.Reset()
+				_, _ = digest.WriteString(lbl)
+				_, _ = digest.WriteString(":")
+				_, _ = digest.Write(line)
+				sink = digest.Sum64()
+			}
+			require.NotZero(b, sink)
+		})
+	}
+}

--- a/pkg/util/sample_test.go
+++ b/pkg/util/sample_test.go
@@ -1,0 +1,64 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSampleHasher(t *testing.T) {
+	t.Run("matches the concatenated hash", func(t *testing.T) {
+		lbl := `{cluster="dev-002", namespace="loki-ops", pod="querier-7d9f8b6c4d-x2n4k"}`
+
+		var hasher SampleHasher
+
+		// Run the test on len(line) > sampleHashBufferSize twice, to exercise the xxhash
+		// internal reset too.
+		for _, n := range []int{sampleHashBufferSize / 4, sampleHashBufferSize * 4, sampleHashBufferSize * 4} {
+			line := []byte(strings.Repeat("a", n))
+
+			// The value goes on the wire between ingesters and queriers, so it has to stay
+			// exactly the hash of the concatenation.
+			want := xxhash.Sum64String(lbl + ":" + string(line))
+
+			require.Equal(t, want, hasher.Hash(lbl, line), "line=%d", n)
+			require.Equal(t, want, UniqueSampleHash(lbl, line), "line=%d", n)
+		}
+	})
+
+	t.Run("does not allocate", func(t *testing.T) {
+		var hasher SampleHasher
+		lbl := `{cluster="dev-002", namespace="loki-ops", pod="querier-7d9f8b6c4d-x2n4k"}`
+
+		for _, n := range []int{sampleHashBufferSize / 4, sampleHashBufferSize * 4} {
+			line := []byte(strings.Repeat("a", n))
+			t.Run(fmt.Sprintf("line=%d", n), func(t *testing.T) {
+				var sink uint64
+				allocs := testing.AllocsPerRun(100, func() { sink = hasher.Hash(lbl, line) })
+				require.Zero(t, allocs)
+				require.NotZero(t, sink)
+			})
+		}
+	})
+}
+
+func BenchmarkSampleHash(b *testing.B) {
+	lbl := `{cluster="dev-002", namespace="loki-ops", pod="querier-7d9f8b6c4d-x2n4k", container="querier", job="loki-ops/querier", level="info"}`
+
+	for _, n := range []int{50, 100, 200, 300, 400, 500, 1000, 4000} {
+		line := []byte(strings.Repeat("a", n))
+
+		b.Run(fmt.Sprintf("line=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			var hasher SampleHasher
+			var sink uint64
+			for i := 0; i < b.N; i++ {
+				sink = hasher.Hash(lbl, line)
+			}
+			_ = sink
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

`UniqueSampleHash` allocated a buffer for the hashed bytes on every sample. Querier profiles of heavy metric queries show that allocation as a large share of the work and as the dominant source of `makeslice` calls, though how large varies by workload.

`SampleHasher` replaces it: callers hold one and reuse it. A fixed inline buffer covers the common case, and xxhash's streaming digest handles anything larger, so the buffer never grows and neither path allocates. The threshold is the measured crossover between the two.

**The hash value is unchanged.** xxhash is a streaming hash, so both paths return exactly what hashing the concatenation returned. This is load bearing: the value is computed in ingesters, sent on the wire, and compared in a querier against hashes other processes computed, so it has to stay identical across versions. A test pins it against the canonical concatenation.

While here, the ordered head block now hashes the label string with the line too, so all four sample hash producers agree.

This PR is part of https://github.com/grafana/loki-private/issues/2751.

**Special notes for your reviewer**:

Benchmarks were run before/after by swapping only `SampleHasher.Hash`'s internals, so everything else is byte identical. Full raw `benchstat` output for the microbenchmark is below; the metric query comparison is in the first comment, because both together exceed GitHub's description size limit.

The higher level benchmark is `BenchmarkLogQL` in `pkg/logql/bench` filtered to `kind=metric/store=chunk`. `store=chunk` is the **v1 engine**: `setupBenchmarkWithStore` builds `logql.NewEngine(...)` for it, while `store=dataobj-engine` returns the v2 engine. 59 queries, 6 runs each, over a generated 512 MB / 250 stream dataset.

Headline from that run:

```
sec/op      22.68m  -> 22.22m   -1.99%
B/op        11.42Mi -> 9.541Mi  -16.48%
allocs/op   85.32k  -> 79.79k   -6.48%

linesProcessed / postFilterLines / kilobytesProcessed   +0.00%
```

Identical `linesProcessed` and `postFilterLines` on both sides is a useful correctness signal: same work, less garbage. Wall clock is the noisiest of the three; the allocation figures reproduced across two independent runs.

<details>
<summary><code>benchstat</code> — BenchmarkSampleHash (10 runs each)</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/loki/v3/pkg/util
cpu: Apple M3 Pro
                        │ hash-before.txt │           hash-after.txt            │
                        │     sec/op      │   sec/op     vs base                │
SampleHash/line=50-11        63.18n ±  3%   20.14n ± 1%  -68.13% (p=0.000 n=10)
SampleHash/line=100-11       60.44n ± 18%   21.41n ± 1%  -64.58% (p=0.000 n=10)
SampleHash/line=200-11       77.72n ±  1%   28.48n ± 4%  -63.35% (p=0.000 n=10)
SampleHash/line=300-11       90.06n ±  2%   33.82n ± 0%  -62.44% (p=0.000 n=10)
SampleHash/line=400-11      109.25n ±  1%   40.52n ± 2%  -62.92% (p=0.000 n=10)
SampleHash/line=500-11      126.75n ±  2%   48.19n ± 0%  -61.98% (p=0.000 n=10)
SampleHash/line=1000-11     224.80n ±  4%   80.34n ± 1%  -64.26% (p=0.000 n=10)
SampleHash/line=4000-11      748.1n ±  3%   265.6n ± 2%  -64.50% (p=0.000 n=10)
geomean                      125.7n         45.16n       -64.07%

                        │ hash-before.txt │              hash-after.txt               │
                        │      B/op       │     B/op      vs base                     │
SampleHash/line=50-11          192.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
SampleHash/line=100-11         240.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
SampleHash/line=200-11         352.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
SampleHash/line=300-11         448.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
SampleHash/line=400-11         576.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
SampleHash/line=500-11         640.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
SampleHash/line=1000-11      1.125Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.000 n=10)
SampleHash/line=4000-11      4.750Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.000 n=10)
geomean                        591.6                      ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                        │ hash-before.txt │             hash-after.txt              │
                        │    allocs/op    │ allocs/op   vs base                     │
SampleHash/line=50-11          1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
SampleHash/line=100-11         1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
SampleHash/line=200-11         1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
SampleHash/line=300-11         1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
SampleHash/line=400-11         1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
SampleHash/line=500-11         1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
SampleHash/line=1000-11        1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
SampleHash/line=4000-11        1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
geomean                        1.000                    ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```

</details>

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.
