### PR TITLE
fix(logql): Fail fast for unsupported approx_topk range queries

### DIFF
--- a/pkg/logql/count_min_sketch.go
+++ b/pkg/logql/count_min_sketch.go
@@ -397,6 +397,10 @@ type CountMinSketchEvalStepEvaluator struct {
 }
 
 func NewCountMinSketchEvalStepEvaluator(ctx context.Context, nextEvFactory SampleEvaluatorFactory, expr *CountMinSketchEvalExpr, params Params) (*CountMinSketchEvalStepEvaluator, error) {
+	// The count-min sketch is only supported for instant queries.
+	if GetRangeType(params) != InstantType {
+		return nil, fmt.Errorf("count min sketches are only supported on instant queries")
+	}
 	return &CountMinSketchEvalStepEvaluator{
 		ctx:           ctx,
 		nextEvFactory: nextEvFactory,

--- a/pkg/logql/engine.go
+++ b/pkg/logql/engine.go
@@ -162,6 +162,10 @@ type EngineOpts struct {
 	MaxCountMinSketchHeapSize int `yaml:"max_count_min_sketch_heap_size"`
 }
 
+func (opts *EngineOpts) RegisterFlags(f *flag.FlagSet) {
+	opts.RegisterFlagsWithPrefix("", f)
+}
+
 func (opts *EngineOpts) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.DurationVar(&opts.MaxLookBackPeriod, prefix+"max-lookback-period", 30*time.Second, "The maximum amount of time to look back for log lines. Used only for instant log queries.")
 	f.IntVar(&opts.MaxCountMinSketchHeapSize, prefix+"max-count-min-sketch-heap-size", 10_000, "The maximum number of labels the heap of a topk query using a count min sketch can track.")

--- a/pkg/logql/internal/logqltest/runner.go
+++ b/pkg/logql/internal/logqltest/runner.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
@@ -122,7 +123,10 @@ func runEval(t *testing.T, name string, querier logql.Querier, cmd evalCmd, exp 
 	}
 
 	t.Run(label, func(t *testing.T) {
-		engine := logql.NewEngine(logql.EngineOpts{}, querier, logql.NoLimits, log.NewNopLogger())
+		// Run query engine with the default config.
+		var opts logql.EngineOpts
+		flagext.DefaultValues(&opts)
+		engine := logql.NewEngine(opts, querier, logql.NoLimits, log.NewNopLogger())
 
 		var start, end, step time.Duration
 		if cmd.instant {

--- a/pkg/logql/internal/logqltest/testdata/functions.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/functions.logqltest
@@ -129,3 +129,43 @@ eval instant at 60s label_replace(count_over_time({app="a"} | logfmt [1m]), "out
 # Without the parser the metadata value is the only loser, so it keeps `k_extracted`.
 eval instant at 60s label_replace(count_over_time({app="a"} [1m]), "out", "$1", "k_extracted", "(.*)")
   {app="a", k="s", k_extracted="m", out="m"} 3
+
+# approx_topk() selects the top k series by value, like topk(), but estimates the
+# values with a count-min sketch. approx_topk() is supported only for instant queries.
+#
+# In this scenario, the log streams are few and distinct, so they never collide in the
+# sketch: the counts are exact and match topk().
+clear
+load
+  {app="foo", pod="a"} "xbar"  @ 10s [repeat every 10s for 18]
+  {app="foo", pod="a"} "noise" @ 15s [repeat every 10s for 18]
+  {app="foo", pod="b"} "xbar"  @ 5s  [repeat every 5s  for 36]
+  {app="foo", pod="b"} "noise" @ 7s  [repeat every 5s  for 36]
+  {app="bar", pod="a"} "xbar"  @ 4s  [repeat every 4s  for 45]
+  {app="bar", pod="a"} "noise" @ 2s  [repeat every 4s  for 45]
+  {app="bar", pod="b"} "xbar"  @ 2s  [repeat every 2s  for 90]
+  {app="bar", pod="b"} "noise" @ 1s  [repeat every 2s  for 90]
+  {app="noise"} "noise" @ 0s [repeat every 10s for 19]
+
+eval instant at 60s approx_topk(2, sum by (app, pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m])))
+  {app="bar", pod="b"} 30
+  {app="bar", pod="a"} 15
+eval instant at 60s approx_topk(1, sum by (app, pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m])))
+  {app="bar", pod="b"} 30
+# k above the series count returns them all.
+eval instant at 60s approx_topk(10, sum by (app, pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m])))
+  {app="bar", pod="b"} 30
+  {app="bar", pod="a"} 15
+  {app="foo", pod="b"} 12
+  {app="foo", pod="a"} 6
+# approx_topk() is supported only for instant queries.
+eval range from 20s to 60s step 20s approx_topk(2, sum by (app, pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m])))
+  expect fail msg: only supported on instant queries
+# approx_topk() forbids grouping (unlike topk).
+eval instant at 60s approx_topk(2, sum by (app, pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m]))) by (app)
+  expect fail msg: grouping not allowed
+# k must be an integer greater than 0.
+eval instant at 60s approx_topk(1.5, sum by (app, pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m])))
+  expect fail msg: invalid parameter
+eval instant at 60s approx_topk(sum by (app, pod) (count_over_time({app=~"foo|bar"} |~".+bar" [1m])))
+  expect fail msg: parameter required


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds declarative `logqltest` coverage for `approx_topk`.

While adding it, one gap surfaced: `approx_topk` is backed by a count-min sketch, which is only supported for instant queries. When the query wasn't sharded it reached the querier and failed during execution. This detects the unsupported case earlier — when building the step evaluator — so it fails fast with the same error the sharded path already returns.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

The engine change is the small guard in `count_min_sketch.go`. The rest is test data plus the `logqltest` runner now building the engine with the default config (needed so count-min-sketch queries behave as in production; that also required a `RegisterFlags` method on `EngineOpts`).

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.
