### PR TITLE
fix(querytee): override Request.Host when proxying to backends

### DIFF
--- a/pkg/querytee/proxy_backend.go
+++ b/pkg/querytee/proxy_backend.go
@@ -141,7 +141,9 @@ func (b *ProxyBackend) createBackendRequest(orig *http.Request, body io.ReadClos
 	// Prepend the endpoint path to the request path.
 	req.URL.Path = path.Join(b.endpoint.Path, req.URL.Path)
 
-	// Set the correct host header for the backend
+	// Override Host. Go's client prefers Request.Host over Header["Host"], and
+	// Clone() copies the inbound Host; without this the backend sees the client Host.
+	req.Host = b.endpoint.Host
 	req.Header.Set("Host", b.endpoint.Host)
 
 	// Replace the auth:

--- a/pkg/querytee/proxy_backend_test.go
+++ b/pkg/querytee/proxy_backend_test.go
@@ -226,3 +226,19 @@ func Test_ProxyBackend_Alias(t *testing.T) {
 		})
 	}
 }
+
+func Test_ProxyBackend_createBackendRequest_overridesRequestHost(t *testing.T) {
+	u, err := url.Parse("http://backend.example:3100")
+	require.NoError(t, err)
+
+	orig := httptest.NewRequest("GET", "http://querytee.local/loki/api/v1/query", nil)
+	orig.Host = "evil.example"
+
+	b, err := NewProxyBackend("test", u, time.Second, false)
+	require.NoError(t, err)
+	r, span := b.createBackendRequest(orig, nil)
+	defer span.Finish()
+
+	assert.Equal(t, "backend.example:3100", r.Host)
+	assert.Equal(t, "backend.example:3100", r.Header.Get("Host"))
+}


### PR DESCRIPTION
## Summary
- `createBackendRequest` only set `Header[\"Host\"]` to the backend endpoint.
- Go's HTTP client prefers `Request.Host` (copied from the client via `Clone`), so backends received the client-controlled Host.
- Set `req.Host = b.endpoint.Host` as well (same fix as grafana/mimir#7386).

## Test plan
- [x] `go test ./pkg/querytee/ -run Test_ProxyBackend_createBackendRequest`
- [x] Local differential: without `req.Host`, backend saw `evil.example`; with it, backend saw endpoint host

Made with [Cursor](https://cursor.com)