### PR TITLE
fix(queryrange): Avoid panic when V2 router is unavailable

### DIFF
--- a/pkg/querier/queryrange/roundtrip.go
+++ b/pkg/querier/queryrange/roundtrip.go
@@ -140,6 +140,11 @@ func NewMiddleware(
 	registerer prometheus.Registerer,
 	metricsNamespace string,
 ) (base.Middleware, Stopper, error) {
+	if cfg.EnableV2EngineRouter {
+		level.Warn(log).Log("msg", "v2 engine router is not available; using the standard query path")
+		cfg.EnableV2EngineRouter = false
+	}
+
 	metrics := NewMetrics(registerer, metricsNamespace)
 
 	var (

--- a/pkg/querier/queryrange/roundtrip_test.go
+++ b/pkg/querier/queryrange/roundtrip_test.go
@@ -1,6 +1,7 @@
 package queryrange
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/common/model"
@@ -178,6 +180,55 @@ func getQueryAndStatsHandler(queryHandler, statsHandler base.Handler) base.Handl
 
 		return nil, fmt.Errorf("Request not supported: %T", r)
 	})
+}
+
+func TestNewMiddlewareWithUnavailableV2EngineRouter(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		engineEnabled bool
+	}{
+		{name: "engine enabled", engineEnabled: true},
+		{name: "engine disabled", engineEnabled: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var logs bytes.Buffer
+			logger := log.NewLogfmtLogger(&logs)
+
+			cfg := testConfig
+			cfg.CacheResults = false
+			cfg.CacheIndexStatsResults = false
+			cfg.CacheInstantMetricResults = false
+			cfg.CacheSeriesResults = false
+			cfg.CacheLabelResults = false
+			cfg.EnableV2EngineRouter = true
+
+			require.NotPanics(t, func() {
+				middleware, stopper, err := NewMiddleware(
+					cfg,
+					testEngineOpts,
+					engine.Config{Enable: tt.engineEnabled},
+					nil,
+					logger,
+					fakeLimits{maxQueryParallelism: 1},
+					config.SchemaConfig{Configs: testSchemasTSDB},
+					nil,
+					false,
+					nil,
+					constants.Loki,
+				)
+				require.NoError(t, err)
+				if stopper != nil {
+					t.Cleanup(stopper.Stop)
+				}
+
+				handler := middleware.Wrap(base.HandlerFunc(func(context.Context, base.Request) (base.Response, error) {
+					return nil, nil
+				}))
+				require.NotNil(t, handler)
+			})
+			require.Contains(t, logs.String(), "v2 engine router is not available; using the standard query path")
+		})
+	}
 }
 
 // those tests are mostly for testing the glue between all component and make sure they activate correctly.


### PR DESCRIPTION
**What this PR does / why we need it**:

Loki 3.6 accepts `query_range.enable_v2_engine_router`, but this release branch has no V2 frontend handler to give the router. Enabling the option therefore reaches `newEngineRouterMiddleware` with a nil handler and panics while the query frontend is initialized.

This release-specific fix treats the unavailable frontend router as a warned no-op before the tripperware is built. Queries continue through the standard frontend path, which preserves its limits, splitting, caching, sharding, and retry middleware. Querier-side embedded V2 selection remains unchanged.

The main branch has the distributed V2 handler introduced by #19744. That implementation depends on scheduler and worker changes that are not present on `release-3.6.x`, so this PR intentionally avoids turning a startup bug fix into a distributed-engine feature backport.

**Which issue(s) this PR fixes**:

Fixes #19919

**Special notes for your reviewer**:

Validated on the current `release-3.6.x` head:

- `go test -count=1 ./pkg/querier/queryrange ./pkg/querier`
- `go test -race -count=1 ./pkg/querier/queryrange ./pkg/querier`
- `go vet ./pkg/querier/queryrange ./pkg/querier`
- `golangci-lint run ./pkg/querier/queryrange/...`
- `go build ./cmd/loki`
- monolithic Loki smoke test with both `-querier.engine-v2.enable=true` and `-querier.enable-v2-engine-router=true`; startup reached `Loki started` and shut down cleanly on the test timeout

**Checklist**

- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added (not applicable; no supported configuration behavior is added)
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md` (not applicable; no upgrade action is required)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. (not applicable)
