### PR TITLE
fix: Large requests returned 400 instead 413

### DIFF
--- a/pkg/distributor/http_test.go
+++ b/pkg/distributor/http_test.go
@@ -240,12 +240,6 @@ func TestPushHandlerMaxRecvMsgSize(t *testing.T) {
 	})
 
 	t.Run("Loki JSON returns 413", func(t *testing.T) {
-		t.Skip() // Returns HTTP 400
-
-		// NOTE: this currently returns 400, not 413: an oversized JSON body is
-		// truncated by the max-recv-msg-size LimitReader and fails to decode
-		// before any size check maps to ErrRequestBodyTooLarge. We assert 413
-		// here as the desired behavior.
 		body := []byte(`{"streams":[{"stream":{"foo":"bar"},"values":[["1234567890000000000","` + line + `"]]}]}`)
 		require.Greater(t, len(body), distributors[0].cfg.MaxRecvMsgSize)
 
@@ -315,7 +309,6 @@ func TestPushHandlerMaxDecompressedSize(t *testing.T) {
 	}
 
 	t.Run("snappy compressed protobuf returns 413", func(t *testing.T) {
-		t.Skip() // Returns HTTP 400
 		protoBytes, err := proto.Marshal(&logproto.PushRequest{
 			Streams: []logproto.Stream{
 				{
@@ -347,7 +340,6 @@ func TestPushHandlerMaxDecompressedSize(t *testing.T) {
 	})
 
 	t.Run("gzip compressed Loki JSON returns 413", func(t *testing.T) {
-		t.Skip() // Returns HTTP 400
 		lokiJSON := []byte(`{"streams":[{"stream":{"foo":"bar"},"values":[["1234567890000000000","` + line + `"]]}]}`)
 		body := withGzip(t, lokiJSON)
 		require.Greater(t, int64(len(lokiJSON)), distributors[0].cfg.MaxDecompressedSize)
@@ -371,7 +363,6 @@ func TestPushHandlerMaxDecompressedSize(t *testing.T) {
 	})
 
 	t.Run("gzip compressed OTLP JSON returns 413", func(t *testing.T) {
-		t.Skip() // Returns HTTP 400
 		otlpLogs := plog.NewLogs()
 		rl := otlpLogs.ResourceLogs().AppendEmpty()
 		rl.Resource().Attributes().PutStr("service.name", "test-service")

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -340,15 +340,15 @@ func parsePushRequestBody(r *http.Request, maxRecvMsgSize int, maxDecompressedSi
 	// Body
 	var body io.Reader
 	// bodySize should always reflect the compressed size of the request body
-	bodySize := util.NewSizeReader(r.Body)
+	bodySizeReader := util.NewSizeReader(r.Body)
 	// decompressedSize reflects the decompressed size of the request body. It stays
 	// nil when the body is not decompressed here, either because it is uncompressed
 	// or because ParseProtoReaderWithLimits does the snappy-decoding (and its own
 	// decompressed size check) below.
-	var decompressedSize util.SizeReader
+	var decompressedSizeReader util.SizeReader
 
 	// Apply compressed size limit
-	body = bodySize
+	body = bodySizeReader
 	if maxRecvMsgSize > 0 {
 		body = io.LimitReader(body, int64(maxRecvMsgSize)+1)
 	}
@@ -368,8 +368,8 @@ func parsePushRequestBody(r *http.Request, maxRecvMsgSize int, maxDecompressedSi
 		defer func(gzipReader *gzip.Reader) {
 			_ = gzipReader.Close()
 		}(gzipReader)
-		decompressedSize = util.NewSizeReader(gzipReader)
-		body = decompressedSize
+		decompressedSizeReader = util.NewSizeReader(gzipReader)
+		body = decompressedSizeReader
 		if maxDecompressedSize > 0 {
 			body = io.LimitReader(body, maxDecompressedSize+1)
 		}
@@ -378,8 +378,8 @@ func parsePushRequestBody(r *http.Request, maxRecvMsgSize int, maxDecompressedSi
 		defer func(flateReader io.ReadCloser) {
 			_ = flateReader.Close()
 		}(flateReader)
-		decompressedSize = util.NewSizeReader(flateReader)
-		body = decompressedSize
+		decompressedSizeReader = util.NewSizeReader(flateReader)
+		body = decompressedSizeReader
 		if maxDecompressedSize > 0 {
 			body = io.LimitReader(body, maxDecompressedSize+1)
 		}
@@ -414,7 +414,7 @@ func parsePushRequestBody(r *http.Request, maxRecvMsgSize int, maxDecompressedSi
 			// The readers above are limited to max+1 bytes, so an oversized body is
 			// truncated and fails to decode. Report that as a size error rather than
 			// as a malformed request.
-			if sizeErr := checkSizeLimits(bodySize, decompressedSize, maxRecvMsgSize, maxDecompressedSize); sizeErr != nil {
+			if sizeErr := checkSizeLimits(bodySizeReader, decompressedSizeReader, maxRecvMsgSize, maxDecompressedSize); sizeErr != nil {
 				return nil, sizeErr
 			}
 			return nil, err
@@ -428,11 +428,11 @@ func parsePushRequestBody(r *http.Request, maxRecvMsgSize int, maxDecompressedSi
 		}
 	}
 
-	pushStats.BodySize = bodySize.Size()
+	pushStats.BodySize = bodySizeReader.Size()
 	pushStats.ContentType = contentType
 	pushStats.ContentEncoding = contentEncoding
 
-	if err := checkSizeLimits(bodySize, decompressedSize, maxRecvMsgSize, maxDecompressedSize); err != nil {
+	if err := checkSizeLimits(bodySizeReader, decompressedSizeReader, maxRecvMsgSize, maxDecompressedSize); err != nil {
 		return nil, err
 	}
 	return &req, nil

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -200,7 +200,7 @@ func ParseRequest(logger log.Logger, userID string, maxRecvMsgSize int, maxDecom
 
 	req, pushStats, err := pushRequestParser(userID, r, limits, tenantConfigs, maxRecvMsgSize, maxDecompressedSize, tracker, streamResolver, logger)
 	if err != nil && !errors.Is(err, ErrAllLogsFiltered) {
-		if errors.Is(err, util.ErrMessageSizeTooLarge) {
+		if errors.Is(err, util.ErrMessageSizeTooLarge) || errors.Is(err, util.ErrMessageDecompressedSizeTooLarge) {
 			return nil, nil, fmt.Errorf("%w: %s", ErrRequestBodyTooLarge, err.Error())
 		}
 		return nil, nil, err
@@ -341,6 +341,11 @@ func parsePushRequestBody(r *http.Request, maxRecvMsgSize int, maxDecompressedSi
 	var body io.Reader
 	// bodySize should always reflect the compressed size of the request body
 	bodySize := util.NewSizeReader(r.Body)
+	// decompressedSize reflects the decompressed size of the request body. It stays
+	// nil when the body is not decompressed here, either because it is uncompressed
+	// or because ParseProtoReaderWithLimits does the snappy-decoding (and its own
+	// decompressed size check) below.
+	var decompressedSize util.SizeReader
 
 	// Apply compressed size limit
 	body = bodySize
@@ -363,7 +368,8 @@ func parsePushRequestBody(r *http.Request, maxRecvMsgSize int, maxDecompressedSi
 		defer func(gzipReader *gzip.Reader) {
 			_ = gzipReader.Close()
 		}(gzipReader)
-		body = gzipReader
+		decompressedSize = util.NewSizeReader(gzipReader)
+		body = decompressedSize
 		if maxDecompressedSize > 0 {
 			body = io.LimitReader(body, maxDecompressedSize+1)
 		}
@@ -372,7 +378,8 @@ func parsePushRequestBody(r *http.Request, maxRecvMsgSize int, maxDecompressedSi
 		defer func(flateReader io.ReadCloser) {
 			_ = flateReader.Close()
 		}(flateReader)
-		body = flateReader
+		decompressedSize = util.NewSizeReader(flateReader)
+		body = decompressedSize
 		if maxDecompressedSize > 0 {
 			body = io.LimitReader(body, maxDecompressedSize+1)
 		}
@@ -404,6 +411,12 @@ func parsePushRequestBody(r *http.Request, maxRecvMsgSize int, maxDecompressedSi
 		}
 
 		if err != nil {
+			// The readers above are limited to max+1 bytes, so an oversized body is
+			// truncated and fails to decode. Report that as a size error rather than
+			// as a malformed request.
+			if sizeErr := checkSizeLimits(bodySize, decompressedSize, maxRecvMsgSize, maxDecompressedSize); sizeErr != nil {
+				return nil, sizeErr
+			}
 			return nil, err
 		}
 
@@ -419,10 +432,26 @@ func parsePushRequestBody(r *http.Request, maxRecvMsgSize int, maxDecompressedSi
 	pushStats.ContentType = contentType
 	pushStats.ContentEncoding = contentEncoding
 
-	if size := bodySize.Size(); size > int64(maxRecvMsgSize) && maxRecvMsgSize > 0 {
-		return nil, fmt.Errorf("compressed message size %d exceeds limit %d", size, maxRecvMsgSize)
+	if err := checkSizeLimits(bodySize, decompressedSize, maxRecvMsgSize, maxDecompressedSize); err != nil {
+		return nil, err
 	}
 	return &req, nil
+}
+
+// checkSizeLimits reports whether the request body exceeded the compressed or the
+// decompressed size limit. The readers wrapping the body are limited to max+1 bytes,
+// so a size greater than max means the body was truncated. decompressedSize may be
+// nil, in which case only the compressed size is checked.
+func checkSizeLimits(bodySize, decompressedSize util.SizeReader, maxRecvMsgSize int, maxDecompressedSize int64) error {
+	if size := bodySize.Size(); maxRecvMsgSize > 0 && size > int64(maxRecvMsgSize) {
+		return fmt.Errorf(messageSizeLargerErrFmt, util.ErrMessageSizeTooLarge, size, maxRecvMsgSize)
+	}
+	if decompressedSize != nil {
+		if size := decompressedSize.Size(); maxDecompressedSize > 0 && size > maxDecompressedSize {
+			return fmt.Errorf(messageSizeLargerErrFmt, util.ErrMessageDecompressedSizeTooLarge, size, maxDecompressedSize)
+		}
+	}
+	return nil
 }
 
 func ParseLokiRequest(userID string, r *http.Request, limits Limits, tenantConfigs *runtime.TenantConfigs, maxRecvMsgSize int, maxDecompressedSize int64, tracker UsageTracker, streamResolver StreamResolver, logger log.Logger) (*logproto.PushRequest, *Stats, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request fixes a number of cases where large requests were failed with a 400 instead of a 413 status code. This seems inconsequential, but it meant a number of these cases were invisible on provisioned Grafana Cloud dashboards that customers use to track their ingest.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
