### PR TITLE
chore(bloomplanner): Improve error logging for task retry

### DIFF
--- a/pkg/bloombuild/planner/planner.go
+++ b/pkg/bloombuild/planner/planner.go
@@ -753,7 +753,7 @@ func (p *Planner) BuilderLoop(builder protos.PlannerForBuilder_BuilderLoopServer
 				p.tasksQueue.Release(task.ProtoTask)
 				level.Error(logger).Log(
 					"msg", "task failed after max retries",
-					"retries", task.timesEnqueued.Load(),
+					"attempt", task.timesEnqueued.Load(),
 					"maxRetries", maxRetries,
 					"err", err,
 				)
@@ -763,6 +763,12 @@ func (p *Planner) BuilderLoop(builder protos.PlannerForBuilder_BuilderLoopServer
 				}
 				continue
 			}
+
+			level.Error(logger).Log(
+				"msg", "task attempt failed",
+				"attempt", task.timesEnqueued.Load(),
+				"err", err,
+			)
 
 			// Re-queue the task if the builder is failing to process the tasks
 			if err := p.enqueueTask(task); err != nil {
@@ -777,10 +783,9 @@ func (p *Planner) BuilderLoop(builder protos.PlannerForBuilder_BuilderLoopServer
 			}
 
 			p.metrics.tasksRequeued.Inc()
-			level.Error(logger).Log(
-				"msg", "error forwarding task to builder, Task requeued",
-				"retries", task.timesEnqueued.Load(),
-				"err", err,
+			level.Debug(logger).Log(
+				"msg", "task requeued",
+				"next_attempt", task.timesEnqueued.Load(),
 			)
 			continue
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Current error message is misleading as it always logs `error forwarding task to builder` even when the task failed for other reasons. Error returned by `forwardTaskToBuilder()` details why a task failed. This PR updates the error messages for clarity.



**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
