### PR TITLE
fix: Allow -list-targets to run without a config file 🤖🤖🤖

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -56,6 +56,23 @@ func main() {
 		fmt.Println(version.Print("loki"))
 		os.Exit(0)
 	}
+
+	// List targets command - runs before config file parsing so that a config
+	// file is not required. A config file is still honoured when it is present.
+	// The available targets only depend on the modules registered by Loki, not
+	// on the config file, so config validation is skipped here.
+	if loki.ListTargetsRequested(os.Args[1:]) {
+		if err := cfg.DynamicUnmarshalOptionalConfig(&config, os.Args[1:], flag.CommandLine); err != nil {
+			fmt.Fprintf(os.Stderr, "failed parsing config: %v\n", err)
+			os.Exit(1)
+		}
+
+		t, err := loki.New(config.Config)
+		util_log.CheckFatal("initializing loki", err, util_log.Logger)
+		t.ListTargets()
+		exit(0)
+	}
+
 	if err := cfg.DynamicUnmarshal(&config, os.Args[1:], flag.CommandLine); err != nil {
 		fmt.Fprintf(os.Stderr, "failed parsing config: %v\n", err)
 		os.Exit(1)
@@ -137,11 +154,6 @@ func main() {
 	// Start Loki
 	t, err := loki.New(config.Config)
 	util_log.CheckFatal("initializing loki", err, util_log.Logger)
-
-	if config.ListTargets {
-		t.ListTargets()
-		exit(0)
-	}
 
 	level.Info(util_log.Logger).Log("msg", "Starting Loki", "version", version.Info())
 	level.Info(util_log.Logger).Log("msg", "Loading configuration file", "filename", config.ConfigFile)

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -3,6 +3,7 @@ package loki
 import (
 	"flag"
 	"fmt"
+	"io"
 	"reflect"
 	"regexp"
 	"strings"
@@ -48,6 +49,27 @@ func PrintVersion(args []string) bool {
 		}
 	}
 	return false
+}
+
+// ListTargetsRequested reports whether the -list-targets flag is set after
+// parsing the supplied args with Go's standard flag rules. It is intended to be
+// checked before config file parsing so that listing available targets does
+// not require a config file to exist.
+//
+// Flags are parsed on a clone of ConfigWrapper so that every valid flag is
+// recognised and the boolean value of -list-targets follows Go flag semantics
+// (all forms accepted by strconv.ParseBool, last-wins on repetition).
+func ListTargetsRequested(args []string) bool {
+	fs := flag.NewFlagSet("list-targets-check", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
+
+	var c ConfigWrapper
+	c.RegisterFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		return false
+	}
+	return c.ListTargets
 }
 
 func (c *ConfigWrapper) RegisterFlags(f *flag.FlagSet) {

--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -2452,3 +2452,34 @@ func TestBucketNamedStores_applyDefaults(t *testing.T) {
 		assert.Equal(t, expected, (swift.Config)(nsCfg.Swift["store-5"]))
 	})
 }
+
+func TestListTargetsRequested(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "bare single dash", args: []string{"-list-targets"}, want: true},
+		{name: "bare double dash", args: []string{"--list-targets"}, want: true},
+		{name: "explicit true", args: []string{"--list-targets=true"}, want: true},
+		{name: "explicit t", args: []string{"-list-targets=t"}, want: true},
+		{name: "explicit T", args: []string{"-list-targets=T"}, want: true},
+		{name: "explicit TRUE", args: []string{"-list-targets=TRUE"}, want: true},
+		{name: "explicit True", args: []string{"-list-targets=True"}, want: true},
+		{name: "explicit one", args: []string{"-list-targets=1"}, want: true},
+		{name: "explicit False", args: []string{"-list-targets=false"}, want: false},
+		{name: "explicit f", args: []string{"-list-targets=f"}, want: false},
+		{name: "explicit zero", args: []string{"--list-targets=0"}, want: false},
+		{name: "among other flags", args: []string{"-target=all", "-list-targets", "-config.file=foo.yaml"}, want: true},
+		{name: "missing flag", args: []string{"-target=all", "-config.file=foo.yaml"}, want: false},
+		{name: "unrelated flag containing substring", args: []string{"-config.file=list-targets.yaml"}, want: false},
+		{name: "no args", args: nil, want: false},
+		{name: "last wins false", args: []string{"-list-targets=true", "-list-targets=false"}, want: false},
+		{name: "last wins true", args: []string{"-list-targets=false", "-list-targets"}, want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, ListTargetsRequested(tc.args))
+		})
+	}
+}

--- a/pkg/util/cfg/dynamic.go
+++ b/pkg/util/cfg/dynamic.go
@@ -16,13 +16,29 @@ type DynamicCloneable interface {
 // 3. Any config options specified directly in the config file
 // 4. Any config options specified on the command line.
 func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet) error {
+	return dynamicUnmarshal(dst, args, fs, func(strict bool) Source {
+		return ConfigFileLoader(args, "config.file", strict)
+	})
+}
+
+// DynamicUnmarshalOptionalConfig is like DynamicUnmarshal but does not fail
+// when the config file does not exist. The config file is still loaded when it
+// is present. This supports commands that don't require a config file (such as
+// -list-targets) while still honouring a config file when one is supplied.
+func DynamicUnmarshalOptionalConfig(dst DynamicCloneable, args []string, fs *flag.FlagSet) error {
+	return dynamicUnmarshal(dst, args, fs, func(strict bool) Source {
+		return OptionalConfigFileLoader(args, "config.file", strict)
+	})
+}
+
+func dynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet, configFile func(strict bool) Source) error {
 	return Unmarshal(dst,
 		// First populate the config with defaults including flags from the command line
 		Defaults(fs),
 		// Next populate the config from the config file, we do this to populate the `common`
 		// section of the config file by taking advantage of the code in ConfigFileLoader which will load
 		// and process the config file.
-		ConfigFileLoader(args, "config.file", true),
+		configFile(true),
 		// Now load the flags again, this will supersede anything set from config file with flags from the command line.
 		Flags(args, fs),
 		// Apply any dynamic logic to set other defaults in the config. This function is called after parsing the
@@ -35,7 +51,7 @@ func DynamicUnmarshal(dst DynamicCloneable, args []string, fs *flag.FlagSet) err
 		// using strict yaml unmarshal causes an `already set in map` error with the `Clients` config,
 		// because it's a map that already has the keys we are trying to unmarshal into it.
 		// That is why we don't use strict for the second marshaling.
-		ConfigFileLoader(args, "config.file", false),
+		configFile(false),
 		// Load the flags again, this will supersede anything set from config file with flags from the command line.
 		Flags(args, fs),
 	)

--- a/pkg/util/cfg/dynamic_test.go
+++ b/pkg/util/cfg/dynamic_test.go
@@ -104,6 +104,43 @@ server:
 		data := testContext(mockApplyDynamicConfig, defaultYamlConfig, args)
 		assert.Equal(t, 7070, data.Port)
 	})
+
+	t.Run("DynamicUnmarshal fails when config file does not exist", func(t *testing.T) {
+		data := NewDynamicConfig(nil)
+		fs := flag.NewFlagSet(t.Name(), flag.PanicOnError)
+		args := []string{"-config.file", "/path/that/does/not/exist.yaml"}
+
+		err := DynamicUnmarshal(&data, args, fs)
+		require.Error(t, err)
+	})
+
+	t.Run("DynamicUnmarshalOptionalConfig does not fail when config file does not exist", func(t *testing.T) {
+		data := NewDynamicConfig(nil)
+		fs := flag.NewFlagSet(t.Name(), flag.PanicOnError)
+		args := []string{"-config.file", "/path/that/does/not/exist.yaml"}
+
+		err := DynamicUnmarshalOptionalConfig(&data, args, fs)
+		require.NoError(t, err)
+		// Defaults are still applied.
+		assert.Equal(t, 80, data.Port)
+		assert.Equal(t, 60*time.Second, data.Timeout)
+	})
+
+	t.Run("DynamicUnmarshalOptionalConfig still loads config file when present", func(t *testing.T) {
+		data := NewDynamicConfig(nil)
+		fs := flag.NewFlagSet(t.Name(), flag.PanicOnError)
+
+		file, err := os.CreateTemp(t.TempDir(), "config.yaml")
+		require.NoError(t, err)
+		_, err = file.WriteString(defaultYamlConfig)
+		require.NoError(t, err)
+		require.NoError(t, file.Close())
+
+		args := []string{"-config.file", file.Name()}
+		err = DynamicUnmarshalOptionalConfig(&data, args, fs)
+		require.NoError(t, err)
+		assert.Equal(t, 8080, data.Port)
+	})
 }
 
 type DynamicConfig struct {

--- a/pkg/util/cfg/files.go
+++ b/pkg/util/cfg/files.go
@@ -75,6 +75,18 @@ func dYAML(y []byte, strict bool) Source {
 }
 
 func ConfigFileLoader(args []string, name string, strict bool) Source {
+	return configFileLoader(args, name, strict, false)
+}
+
+// OptionalConfigFileLoader behaves like ConfigFileLoader but does not return an
+// error when none of the configured paths exist; instead it is a no-op. This
+// allows commands that don't depend on a config file (such as -list-targets) to
+// load one when it is present without requiring one to exist.
+func OptionalConfigFileLoader(args []string, name string, strict bool) Source {
+	return configFileLoader(args, name, strict, true)
+}
+
+func configFileLoader(args []string, name string, strict, optional bool) Source {
 	return func(dst Cloneable) error {
 		freshFlags := flag.NewFlagSet("config-file-loader", flag.ContinueOnError)
 
@@ -115,6 +127,9 @@ func ConfigFileLoader(args []string, name string, strict bool) Source {
 				}
 				return err
 			}
+		}
+		if optional {
+			return nil
 		}
 		return fmt.Errorf("%s does not exist, set %s for custom config path", f.Value.String(), name)
 	}


### PR DESCRIPTION
## What this PR does

Running `loki -list-targets` previously failed with exit code `1` when no config file existed:

```
failed parsing config: config.yaml,config/config.yaml does not exist, set config.file for custom config path
```

This happened because `cmd/loki/main.go` parsed the config file (via `cfg.DynamicUnmarshal`) before the `-list-targets` flag was ever checked. Listing available targets only depends on the modules registered by Loki, not on a config file, so requiring one is unnecessary.

This PR makes the config file **optional** for `-list-targets`:

- Adds `OptionalConfigFileLoader` / `DynamicUnmarshalOptionalConfig` in `pkg/util/cfg`: these behave exactly like the existing loaders but do **not** fail when no config file is found. The config file is still loaded when present.
- Adds `loki.ListTargetsRequested(args)` (mirroring the existing `PrintVersion`/`CheckHealth` pre-scan pattern) so the flag is detected before config parsing.
- In `cmd/loki/main.go`, when `-list-targets` is requested, loads config with the optional loader (honouring a config file when supplied), builds the Loki module manager via `loki.New`, prints the targets, and exits. Config validation is skipped because it is irrelevant to listing targets and would otherwise fail on default config.

### Why this approach

- **No behaviour change when a config file is supplied.** `loki -config.file=loki.yaml -list-targets` still loads the config file, so config-driven module registration (e.g. LBAC/label-access modules) and target-based dependency wiring are preserved. A config file simply stops being *required*.
- **No behaviour change for normal starts.** `loki` (without `-list-targets`) still fails fast when no config file exists, so misconfigurations are still surfaced loudly.
- `-list-targets=false` correctly leaves the normal startup path in place.
- Follows the existing early-exit pattern already used for `-version` and `-health`.

## Verification

```bash
# Before: exit code 1, error
$ loki -list-targets
failed parsing config: config.yaml,config/config.yaml does not exist, set config.file for custom config path

# After: exit code 0, lists targets
$ loki -list-targets
all
  compactor
  ...
ui
```

- `loki` (no config) → still errors with exit code 1 (no regression)
- `loki -list-targets=false` (no config) → still errors (correctly does *not* trigger list mode)
- `loki -config.file=loki.yaml -list-targets` → works, exit code 0 (config file still honoured)

Tests added:
- `TestListTargetsRequested` — covers bare flag, `--list-targets`, `=true`/`=1`/`=TRUE`, `=false`/`=0`, flag among others, missing flag, substring false positives, no args.
- `DynamicUnmarshalOptionalConfig` cases in `pkg/util/cfg` — fails vs. optional behaviour for missing file, and that the config file is still loaded when present.

## Which issue(s) this PR fixes

Closes #23734

## Notes for the reviewer

- The now-unreachable `if config.ListTargets { ... }` block later in `main()` was removed, since the early-exit handles all `-list-targets` invocations (with or without a config file). The `ListTargets` flag is still registered on `ConfigWrapper`, so `flag.Parse` continues to accept it.
- The `cfg.DynamicUnmarshal` signature is unchanged; a small shared helper (`dynamicUnmarshal`) was extracted so `DynamicUnmarshalOptionalConfig` duplicates no logic. No other call sites are affected.

## PR checklist

- [x] **Title** follows conventional commits format, sentence case, imperative verb.
- [x] **Description** explains what and why.
- [x] **Branch** synced with `main` (based on latest `upstream/main`).
- [x] **Tests** added (`TestListTargetsRequested`, `DynamicUnmarshalOptionalConfig` cases).
- [x] **Upgrade guide** — not applicable: no breaking changes, no default config value changes, no metric/label/API changes.
- [x] **Deprecated/deleted config** — none.
- [x] **Documentation** — no user-visible behaviour change beyond fixing the reported bug; the `-list-targets` flag is already documented as listing available targets.