### PR TITLE
fix: Use distributor's component logger in http.go instead of global logger

### DIFF
--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -34,7 +34,7 @@ func (d *Distributor) OTLPPushHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRequestParser push.RequestParser, errorWriter push.ErrorWriter, format string) {
-	logger := util_log.WithContext(r.Context(), util_log.Logger)
+	logger := util_log.WithContext(r.Context(), d.logger)
 	tenantID, err := tenant.TenantID(r.Context())
 	if err != nil {
 		level.Error(logger).Log("msg", "error getting tenant id", "err", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `component=distributor` to request logs, and allows the logger to be replaced in tests without overriding the global `util_log.Logger` (bad for tests that run in parallel). This is useful for testing features such as `logPushRequestStreams`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
