### PR TITLE
chore: Move logging to its own method logPushRequestStreams

### DIFF
--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -1,6 +1,7 @@
 package distributor
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
+	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/httpgrpc"
 
@@ -19,6 +21,7 @@ import (
 
 	"github.com/grafana/dskit/tenant"
 
+	push2 "github.com/grafana/loki/pkg/push"
 	"github.com/grafana/loki/v3/pkg/loghttp/push"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 	"github.com/grafana/loki/v3/pkg/validation"
@@ -129,34 +132,7 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 	// Only reported for tenants that have enabled log_otlp_attribute_expansion in their runtime config.
 	d.otlpAttrReporter.Report(logger, tenantID, pushStats.OTLPAttributes)
 
-	if d.shouldLogPushRequestStreams(tenantID, presumedAgentIP) {
-		for _, s := range req.Streams {
-			lbs, err := syntax.ParseLabels(s.Labels)
-			if err != nil {
-				// We just log the error and continue, we need the parsed labels to log the policy.
-				// In this case, the lbs will be empty and the policy will be empty.
-				level.Error(logger).Log("msg", "error parsing labels before logging push request", "err", err)
-			}
-
-			logValues := []interface{}{
-				"msg", "push request streams",
-				"stream", s.Labels,
-				"streamLabelsHash", util.HashedQuery(s.Labels), // this is to make it easier to do searching and grouping
-				"streamSizeBytes", humanize.Bytes(uint64(pushStats.StreamSizeBytes[s.Labels])),
-				"policy", streamResolver.PolicyFor(r.Context(), lbs),
-			}
-			if timestamp, ok := pushStats.MostRecentEntryTimestampPerStream[s.Labels]; ok {
-				logValues = append(logValues, "mostRecentLagMs", time.Since(timestamp).Milliseconds())
-			}
-			if presumedAgentIP != "" {
-				logValues = append(logValues, "presumedAgentIp", presumedAgentIP)
-			}
-			if pushStats.HashOfAllStreams != 0 {
-				logValues = append(logValues, "hashOfAllStreams", pushStats.HashOfAllStreams)
-			}
-			level.Debug(logger).Log(logValues...)
-		}
-	}
+	d.logPushRequestStreams(r.Context(), logger, tenantID, req.Streams, streamResolver, pushStats, presumedAgentIP)
 
 	_, err = d.PushWithResolver(r.Context(), req, streamResolver, format)
 	if err == nil {
@@ -208,6 +184,48 @@ func (d *Distributor) shouldLogPushRequestStreams(tenantID, presumedAgentIP stri
 		}
 	}
 	return true
+}
+
+// logPushRequestStreams logs all streams in the push request. This must be enabled
+// on a per-tenant basis.
+func (d *Distributor) logPushRequestStreams(
+	ctx context.Context,
+	logger log.Logger,
+	tenantID string,
+	streams []push2.Stream,
+	streamResolver *requestScopedStreamResolver,
+	pushStats *push.Stats,
+	presumedAgentIP string,
+) {
+	if !d.shouldLogPushRequestStreams(tenantID, presumedAgentIP) {
+		return
+	}
+	for _, s := range streams {
+		lbs, err := syntax.ParseLabels(s.Labels)
+		if err != nil {
+			// We just log the error and continue, we need the parsed labels to log the policy.
+			// In this case, the lbs will be empty and the policy will be empty.
+			level.Error(logger).Log("msg", "error parsing labels before logging push request", "err", err)
+		}
+
+		logValues := []interface{}{
+			"msg", "push request streams",
+			"stream", s.Labels,
+			"streamLabelsHash", util.HashedQuery(s.Labels), // this is to make it easier to do searching and grouping
+			"streamSizeBytes", humanize.Bytes(uint64(pushStats.StreamSizeBytes[s.Labels])),
+			"policy", streamResolver.PolicyFor(ctx, lbs),
+		}
+		if timestamp, ok := pushStats.MostRecentEntryTimestampPerStream[s.Labels]; ok {
+			logValues = append(logValues, "mostRecentLagMs", time.Since(timestamp).Milliseconds())
+		}
+		if presumedAgentIP != "" {
+			logValues = append(logValues, "presumedAgentIp", presumedAgentIP)
+		}
+		if pushStats.HashOfAllStreams != 0 {
+			logValues = append(logValues, "hashOfAllStreams", pushStats.HashOfAllStreams)
+		}
+		level.Debug(logger).Log(logValues...)
+	}
 }
 
 // ServeHTTP implements the distributor ring status page.

--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -132,7 +132,9 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 	// Only reported for tenants that have enabled log_otlp_attribute_expansion in their runtime config.
 	d.otlpAttrReporter.Report(logger, tenantID, pushStats.OTLPAttributes)
 
-	d.logPushRequestStreams(r.Context(), logger, tenantID, req.Streams, streamResolver, pushStats, presumedAgentIP)
+	if d.shouldLogPushRequestStreams(tenantID, presumedAgentIP) {
+		d.logPushRequestStreams(r.Context(), logger, req.Streams, streamResolver, pushStats, presumedAgentIP)
+	}
 
 	_, err = d.PushWithResolver(r.Context(), req, streamResolver, format)
 	if err == nil {
@@ -191,15 +193,11 @@ func (d *Distributor) shouldLogPushRequestStreams(tenantID, presumedAgentIP stri
 func (d *Distributor) logPushRequestStreams(
 	ctx context.Context,
 	logger log.Logger,
-	tenantID string,
 	streams []push2.Stream,
 	streamResolver *requestScopedStreamResolver,
 	pushStats *push.Stats,
 	presumedAgentIP string,
 ) {
-	if !d.shouldLogPushRequestStreams(tenantID, presumedAgentIP) {
-		return
-	}
 	for _, s := range streams {
 		lbs, err := syntax.ParseLabels(s.Labels)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Working to clean up all the code in `distributor/http.go` one PR at a time.

Final clean up PR.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
