### PR TITLE
chore(logcli): Mention local queries as an option

### DIFF
--- a/cmd/logcli/main.go
+++ b/cmd/logcli/main.go
@@ -105,6 +105,10 @@ Example with --output-timestamp-format:
 	   --output-timestamp-format=rfc3339nano
 	   'my-query'
 
+By default the query command sends the request to be executed by a Loki server.
+Optionally, logcli can execute the query itself, reading from object storage
+via --store-config.
+
 The output is limited to 30 entries by default; use --limit to increase.
 
 While "query" does support metrics queries, its output contains multiple


### PR DESCRIPTION
**What this PR does / why we need it**:

If you run `logcli` by itself it dumps out a long set of possible commands, but no mention of the ability to run a query locally.

