### PR TITLE
fix(mixin): Drop stray 100 multiplier on canary ratio panels

### DIFF
--- a/production/loki-mixin/dashboards/loki-canary-dashboard.libsonnet
+++ b/production/loki-mixin/dashboards/loki-canary-dashboard.libsonnet
@@ -70,15 +70,15 @@ local grafana = import 'grafonnet/grafana.libsonnet';
           { gridPos: { h: 4, w: 3, x: 0, y: 4 } },
 
           dashboard.panel('Metric Test Error %') +
-          dashboard.newStatPanel('((sum(loki_canary_metric_test_expected{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}) - sum(loki_canary_metric_test_actual{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}))/(sum(loki_canary_metric_test_actual{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}))) * 100') +
+          dashboard.newStatPanel('((sum(loki_canary_metric_test_expected{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}) - sum(loki_canary_metric_test_actual{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}))/(sum(loki_canary_metric_test_actual{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"})))') +
           { gridPos: { h: 4, w: 3, x: 3, y: 4 } },
 
           dashboard.panel('Missing %') +
-          dashboard.newStatPanel('(sum(increase(loki_canary_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range]))/sum(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range])))*100') +
+          dashboard.newStatPanel('(sum(increase(loki_canary_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range]))/sum(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range])))') +
           { gridPos: { h: 4, w: 3, x: 6, y: 4 } },
 
           dashboard.panel('Spotcheck Missing %') +
-          dashboard.newStatPanel('(sum(increase(loki_canary_spot_check_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range]))/sum(increase(loki_canary_spot_check_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range]))) * 100') +
+          dashboard.newStatPanel('(sum(increase(loki_canary_spot_check_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range]))/sum(increase(loki_canary_spot_check_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range])))') +
           { gridPos: { h: 4, w: 3, x: 9, y: 4 } },
 
           // grid row 3
@@ -95,7 +95,7 @@ local grafana = import 'grafonnet/grafana.libsonnet';
           { gridPos: { h: 4, w: 3, x: 6, y: 8 } },
 
           dashboard.panel('Websocket Missing %') +
-          dashboard.newStatPanel('(sum(increase(loki_canary_websocket_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range]))/sum(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range])))*100') +
+          dashboard.newStatPanel('(sum(increase(loki_canary_websocket_missing_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range]))/sum(increase(loki_canary_entries_total{' + $._config.per_cluster_label + '=~"$cluster",' + $._config.per_namespace_label + '=~"$namespace"}[$__range])))') +
           { gridPos: { h: 4, w: 3, x: 9, y: 8 } },
           // end of grid
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The four ratio panels on the canary dashboard (Metric Test Error %, Missing %, Spotcheck Missing %, Websocket Missing %) display 100x the real value.

Each of them multiplies its query by 100, but none of them passes a `unit` to `newStatPanel`, so they inherit its default of `percentunit`. Grafana treats `percentunit` as a 0.0-1.0 ratio and multiplies by 100 again for display, so the scaling is applied twice.

For example, on Loki 3.7.6 the `Metric Test Error %` panel read 11.8% when the real error was 0.118%. The query returns 0.118:

```
(203.24027 - 203) / 203 * 100 = 0.118
```

Grafana then multiplies that by 100 again to render it as a percentage.

This drops the multiplier so the queries return a 0.0-1.0 ratio, which is how percentunit panels are built elsewhere in the mixin (for example `Utilization` in `loki-chunks.libsonnet`). Passing `unit='percent'` instead would render the same, but keeping the ratio convention seemed more consistent with the rest of the mixin.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

The two graph panels on the same dashboard (`Spot Check Missing %` and `Missing logs`) also multiply by 100, but they render on a `short` axis rather than a percent one, so their numbers are not double-scaled. They are only missing a `%` label. I left them alone to keep this change focused.

The canary dashboard is behind `_config.canary.enabled` (default false), so `production/loki-mixin-compiled` is unchanged and `make loki-mixin-check` passes.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
