### PR TITLE
fix(operator): Remove BoltDB alerts, recording rules, and Grafana dashboards

### DIFF
--- a/operator/docs/lokistack/sop.md
+++ b/operator/docs/lokistack/sop.md
@@ -205,58 +205,6 @@ A service(s) is rate limiting at least 10% of all incoming requests.
 | `per_stream_rate_limit` | `perStreamRateLimit`, `perStreamRateLimitBurst` |
 
 
-## Loki Storage Slow Write
-
-### Impact
-
-The cluster is unable to push logs to backend storage in a timely manner.
-
-### Summary
-
-The cluster is unable to push logs to backend storage in a timely manner.
-
-### Severity
-
-`Warning`
-
-### Access Required
-
-- Console access to the cluster
-- Edit access to the deployed operator and Loki namespace:
-  - OpenShift
-    - `openshift-logging` (LokiStack)
-    - `openshift-operators-redhat` (Loki Operator)
-
-### Steps
-
-- Ensure that the cluster can communicate with the backend storage
-
-## Loki Storage Slow Read
-
-### Impact
-
-The cluster is unable to retrieve logs to backend storage in a timely manner.
-
-### Summary
-
-The cluster is unable to retrieve logs to backend storage in a timely manner.
-
-### Severity
-
-`Warning`
-
-### Access Required
-
-- Console access to the cluster
-- Edit access to the deployed operator and Loki namespace:
-  - OpenShift
-    - `openshift-logging` (LokiStack)
-    - `openshift-operators-redhat` (Loki Operator)
-
-### Steps
-
-- Ensure that the cluster can communicate with the backend storage
-
 ## Loki Write Path High Load
 
 ### Impact

--- a/operator/internal/manifests/internal/alerts/prometheus-alerts.yaml
+++ b/operator/internal/manifests/internal/alerts/prometheus-alerts.yaml
@@ -111,38 +111,6 @@ groups:
     for: 15m
     labels:
       severity: warning
-  - alert: LokiStorageSlowWrite
-    annotations:
-      description: |-
-        The storage path is experiencing slow write response rates.
-      summary: "The storage path is experiencing slow write response rates."
-      runbook_url: "[[ .RunbookURL ]]#Loki-Storage-Slow-Write"
-    expr: |
-      histogram_quantile(0.99,
-        sum(
-          job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{operation="WRITE"}
-        ) by (job, le, namespace)
-      )
-      > 1
-    for: 15m
-    labels:
-      severity: warning
-  - alert: LokiStorageSlowRead
-    annotations:
-      description: |-
-        The storage path is experiencing slow read response rates.
-      summary: "The storage path is experiencing slow read response rates."
-      runbook_url: "[[ .RunbookURL ]]#Loki-Storage-Slow-Read"
-    expr: |
-      histogram_quantile(0.99,
-        sum(
-          job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{operation="Shipper.Query"}
-        ) by (job, le, namespace)
-      )
-      > 5
-    for: 15m
-    labels:
-      severity: warning
   - alert: LokiWritePathHighLoad
     annotations:
       description: |-

--- a/operator/internal/manifests/internal/alerts/prometheus-rules.yaml
+++ b/operator/internal/manifests/internal/alerts/prometheus-rules.yaml
@@ -16,10 +16,3 @@ groups:
           loki_request_duration_seconds_count[1m]
         )
       ) by (job, namespace, route, status_code)
-  - record: job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m
-    expr: |
-      sum(
-        rate(
-          loki_boltdb_shipper_request_duration_seconds_bucket[5m]
-        )
-      ) by (job, le, namespace, operation)

--- a/operator/internal/manifests/internal/alerts/testdata/test.yaml
+++ b/operator/internal/manifests/internal/alerts/testdata/test.yaml
@@ -37,23 +37,6 @@ tests:
       - series: 'loki_request_duration_seconds_bucket{namespace="my-ns", job="ingester", route="my-route", le="+Inf"}'
         values: '0+100x60'
 
-      - series: 'job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{namespace="my-ns", job="ingester", operation="WRITE", le="1"}'
-        values: '0+10x20'
-      - series: 'job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{namespace="my-ns", job="ingester", operation="WRITE", le="5"}'
-        values: '0+50x20'
-      - series: 'job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{namespace="my-ns", job="ingester", operation="WRITE", le="10"}'
-        values: '0+100x20'
-      - series: 'job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{namespace="my-ns", job="ingester", operation="WRITE", le="+Inf"}'
-        values: '0+100x20'
-      - series: 'job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{namespace="my-ns", job="querier", operation="Shipper.Query", le="1"}'
-        values: '0+10x20'
-      - series: 'job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{namespace="my-ns", job="querier", operation="Shipper.Query", le="5"}'
-        values: '0+50x20'
-      - series: 'job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{namespace="my-ns", job="querier", operation="Shipper.Query", le="10"}'
-        values: '0+100x20'
-      - series: 'job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{namespace="my-ns", job="querier", operation="Shipper.Query", le="+Inf"}'
-        values: '0+100x20'
-
       - series: 'loki_logql_querystats_latency_seconds_bucket{namespace="my-ns", job="querier", route="my-route", le="1"}'
         values: '0x20'
       - series: 'loki_logql_querystats_latency_seconds_bucket{namespace="my-ns", job="querier", route="my-route", le="30"}'
@@ -144,28 +127,6 @@ tests:
               summary: "At least 10% of requests are responded with the rate limit error code."
               description: "ingester my-route is experiencing 429 errors."
               runbook_url: "[[ .RunbookURL ]]#Loki-Tenant-Rate-Limit"
-      - eval_time: 16m
-        alertname: LokiStorageSlowWrite
-        exp_alerts:
-          - exp_labels:
-              namespace: my-ns
-              job: ingester
-              severity: warning
-            exp_annotations:
-              summary: "The storage path is experiencing slow write response rates."
-              description: "The storage path is experiencing slow write response rates."
-              runbook_url: "[[ .RunbookURL ]]#Loki-Storage-Slow-Write"
-      - eval_time: 16m
-        alertname: LokiStorageSlowRead
-        exp_alerts:
-          - exp_labels:
-              namespace: my-ns
-              job: querier
-              severity: warning
-            exp_annotations:
-              summary: "The storage path is experiencing slow read response rates."
-              description: "The storage path is experiencing slow read response rates."
-              runbook_url: "[[ .RunbookURL ]]#Loki-Storage-Slow-Read"
       - eval_time: 16m
         alertname: LokiWritePathHighLoad
         exp_alerts:

--- a/operator/internal/manifests/openshift/internal/dashboards/static/grafana-dashboard-lokistack-retention.json
+++ b/operator/internal/manifests/openshift/internal/dashboards/static/grafana-dashboard-lokistack-retention.json
@@ -356,7 +356,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "loki_compactor_apply_retention_last_successful_run_timestamp_seconds{ namespace=~\"$namespace\"} * 1e3",
+                     "expr": "loki_boltdb_shipper_compact_tables_operation_last_successful_run_timestamp_seconds{ namespace=~\"$namespace\"} * 1e3",
                      "format": "time_series",
                      "instant": true,
                      "refId": "A"
@@ -365,7 +365,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Last Retention Operation Success",
+               "title": "Last Compact Tables Operation Success",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -436,13 +436,13 @@
                "span": 6,
                "targets": [
                   {
-                     "expr": "loki_compactor_apply_retention_operation_duration_seconds{ namespace=~\"$namespace\"}",
+                     "expr": "loki_boltdb_shipper_compact_tables_operation_duration_seconds{ namespace=~\"$namespace\"}",
                      "format": "time_series",
                      "legendFormat": "duration",
                      "legendLink": null
                   }
                ],
-               "title": "Retention Operation Duration",
+               "title": "Compact Tables Operations Duration",
                "type": "graph"
             }
          ],
@@ -495,20 +495,196 @@
                "span": 6,
                "targets": [
                   {
-                     "expr": "sum by (status)(rate(loki_compactor_apply_retention_operation_total{ namespace=~\"$namespace\"}[$__rate_interval]))",
+                     "expr": "sum by (status)(rate(loki_boltdb_shipper_compact_tables_operation_total{ namespace=~\"$namespace\"}[$__rate_interval]))",
                      "format": "time_series",
                      "legendFormat": "{{success}}",
                      "legendLink": null
                   }
                ],
-               "title": "Retention Operations Per Status",
+               "title": "Compact Tables Operations Per Status",
+               "type": "graph"
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "",
+         "titleSize": "h6"
+      },
+      {
+         "collapse": false,
+         "height": "250px",
+         "panels": [
+            {
+               "datasource": "$datasource",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "drawStyle": "line",
+                        "fillOpacity": 100,
+                        "lineWidth": 0,
+                        "pointSize": 5,
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                           "group": "A",
+                           "mode": "normal"
+                        }
+                     },
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "short"
+                  },
+                  "overrides": [ ]
+               },
+               "id": 11,
+               "links": [ ],
+               "options": {
+                  "legend": {
+                     "showLegend": true
+                  },
+                  "tooltip": {
+                     "mode": "single",
+                     "sort": "none"
+                  }
+               },
+               "span": 4,
+               "targets": [
+                  {
+                     "expr": "count by(action)(loki_boltdb_shipper_retention_marker_table_processed_total{ namespace=~\"$namespace\"})",
+                     "format": "time_series",
+                     "legendFormat": "{{action}}",
+                     "legendLink": null
+                  }
+               ],
+               "title": "Processed Tables Per Action",
                "type": "graph"
             },
             {
                "datasource": "$datasource",
                "fieldConfig": {
                   "defaults": {
-                     "custom": { },
+                     "custom": {
+                        "drawStyle": "line",
+                        "fillOpacity": 100,
+                        "lineWidth": 0,
+                        "pointSize": 5,
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                           "group": "A",
+                           "mode": "normal"
+                        }
+                     },
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "short"
+                  },
+                  "overrides": [ ]
+               },
+               "id": 12,
+               "links": [ ],
+               "options": {
+                  "legend": {
+                     "showLegend": true
+                  },
+                  "tooltip": {
+                     "mode": "single",
+                     "sort": "none"
+                  }
+               },
+               "span": 4,
+               "targets": [
+                  {
+                     "expr": "count by(table,action)(loki_boltdb_shipper_retention_marker_table_processed_total{ namespace=~\"$namespace\" , action=~\"modified|deleted\"})",
+                     "format": "time_series",
+                     "legendFormat": "{{table}}-{{action}}",
+                     "legendLink": null
+                  }
+               ],
+               "title": "Modified Tables",
+               "type": "graph"
+            },
+            {
+               "datasource": "$datasource",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "drawStyle": "line",
+                        "fillOpacity": 100,
+                        "lineWidth": 0,
+                        "pointSize": 5,
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                           "group": "A",
+                           "mode": "normal"
+                        }
+                     },
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "short"
+                  },
+                  "overrides": [ ]
+               },
+               "id": 13,
+               "links": [ ],
+               "options": {
+                  "legend": {
+                     "showLegend": true
+                  },
+                  "tooltip": {
+                     "mode": "single",
+                     "sort": "none"
+                  }
+               },
+               "span": 4,
+               "targets": [
+                  {
+                     "expr": "sum by (table)(rate(loki_boltdb_shipper_retention_marker_count_total{ namespace=~\"$namespace\"}[$__rate_interval])) >0",
+                     "format": "time_series",
+                     "legendFormat": "{{table}}",
+                     "legendLink": null
+                  }
+               ],
+               "title": "Marks Creation Rate Per Table",
+               "type": "graph"
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Per Table Marker",
+         "titleSize": "h6"
+      },
+      {
+         "collapse": false,
+         "height": "250px",
+         "panels": [
+            {
+               "datasource": "$datasource",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                           "group": "A",
+                           "mode": "none"
+                        }
+                     },
                      "thresholds": {
                         "mode": "absolute",
                         "steps": [ ]
@@ -518,34 +694,399 @@
                   "overrides": [ ]
                },
                "format": "short",
-               "id": 8,
+               "id": 14,
                "links": [ ],
                "options": {
-                  "colorMode": "value",
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto",
-                  "reduceOptions": {
-                     "calcs": [
-                        "lastNotNull"
-                     ],
-                     "fields": "",
-                     "values": false
+                  "legend": {
+                     "showLegend": true
                   },
-                  "text": { },
-                  "textMode": "auto"
+                  "tooltip": {
+                     "mode": "single",
+                     "sort": "none"
+                  }
                },
                "span": 6,
                "targets": [
                   {
-                     "expr": "sum(increase(loki_compactor_retention_chunks_expired_by_ingestion_time_total{ namespace=~\"$namespace\"}[24h]))",
+                     "expr": "sum (increase(loki_boltdb_shipper_retention_marker_count_total{ namespace=~\"$namespace\"}[24h]))",
                      "format": "time_series",
                      "instant": true,
                      "refId": "A"
                   }
                ],
-               "title": "Chunks Expired by Retention (24h)",
+               "thresholds": "70,80",
+               "title": "Marked Chunks (24h)",
                "type": "singlestat"
+            },
+            {
+               "datasource": "$datasource",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                           "group": "A",
+                           "mode": "none"
+                        }
+                     },
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "short"
+                  },
+                  "overrides": [ ]
+               },
+               "id": 15,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "options": {
+                  "legend": {
+                     "showLegend": true
+                  },
+                  "tooltip": {
+                     "mode": "single",
+                     "sort": "none"
+                  }
+               },
+               "span": 6,
+               "targets": [
+                  {
+                     "expr": "histogram_quantile(0.99, sum(rate(loki_boltdb_shipper_retention_marker_table_processed_duration_seconds_bucket{ namespace=~\"$namespace\"}[$__rate_interval])) by (le)) * 1e3",
+                     "format": "time_series",
+                     "legendFormat": "99th Percentile",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "histogram_quantile(0.50, sum(rate(loki_boltdb_shipper_retention_marker_table_processed_duration_seconds_bucket{ namespace=~\"$namespace\"}[$__rate_interval])) by (le)) * 1e3",
+                     "format": "time_series",
+                     "legendFormat": "50th Percentile",
+                     "refId": "B"
+                  },
+                  {
+                     "expr": "sum(rate(loki_boltdb_shipper_retention_marker_table_processed_duration_seconds_sum{ namespace=~\"$namespace\"}[$__rate_interval])) * 1e3 / sum(rate(loki_boltdb_shipper_retention_marker_table_processed_duration_seconds_count{ namespace=~\"$namespace\"}[$__rate_interval]))",
+                     "format": "time_series",
+                     "legendFormat": "Average",
+                     "refId": "C"
+                  }
+               ],
+               "title": "Mark Table Latency",
+               "type": "graph",
+               "yaxes": [
+                  {
+                     "format": "ms",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "",
+         "titleSize": "h6"
+      },
+      {
+         "collapse": false,
+         "height": "250px",
+         "panels": [
+            {
+               "datasource": "$datasource",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                           "group": "A",
+                           "mode": "none"
+                        }
+                     },
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "short"
+                  },
+                  "overrides": [ ]
+               },
+               "format": "short",
+               "id": 16,
+               "links": [ ],
+               "options": {
+                  "legend": {
+                     "showLegend": true
+                  },
+                  "tooltip": {
+                     "mode": "single",
+                     "sort": "none"
+                  }
+               },
+               "span": 6,
+               "targets": [
+                  {
+                     "expr": "sum (increase(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_count{ namespace=~\"$namespace\"}[24h]))",
+                     "format": "time_series",
+                     "instant": true,
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": "70,80",
+               "title": "Delete Chunks (24h)",
+               "type": "singlestat"
+            },
+            {
+               "datasource": "$datasource",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                           "group": "A",
+                           "mode": "none"
+                        }
+                     },
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "short"
+                  },
+                  "overrides": [ ]
+               },
+               "id": 17,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "options": {
+                  "legend": {
+                     "showLegend": true
+                  },
+                  "tooltip": {
+                     "mode": "single",
+                     "sort": "none"
+                  }
+               },
+               "span": 6,
+               "targets": [
+                  {
+                     "expr": "histogram_quantile(0.99, sum(rate(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_bucket{ namespace=~\"$namespace\"}[$__rate_interval])) by (le)) * 1e3",
+                     "format": "time_series",
+                     "legendFormat": "99th Percentile",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "histogram_quantile(0.50, sum(rate(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_bucket{ namespace=~\"$namespace\"}[$__rate_interval])) by (le)) * 1e3",
+                     "format": "time_series",
+                     "legendFormat": "50th Percentile",
+                     "refId": "B"
+                  },
+                  {
+                     "expr": "sum(rate(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_sum{ namespace=~\"$namespace\"}[$__rate_interval])) * 1e3 / sum(rate(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_count{ namespace=~\"$namespace\"}[$__rate_interval]))",
+                     "format": "time_series",
+                     "legendFormat": "Average",
+                     "refId": "C"
+                  }
+               ],
+               "title": "Delete Latency",
+               "type": "graph",
+               "yaxes": [
+                  {
+                     "format": "ms",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Sweeper",
+         "titleSize": "h6"
+      },
+      {
+         "collapse": false,
+         "height": "250px",
+         "panels": [
+            {
+               "datasource": "$datasource",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                           "group": "A",
+                           "mode": "none"
+                        }
+                     },
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "s"
+                  },
+                  "overrides": [ ]
+               },
+               "id": 18,
+               "links": [ ],
+               "options": {
+                  "legend": {
+                     "showLegend": true
+                  },
+                  "tooltip": {
+                     "mode": "single",
+                     "sort": "none"
+                  }
+               },
+               "span": 4,
+               "targets": [
+                  {
+                     "expr": "time() - (loki_boltdb_shipper_retention_sweeper_marker_file_processing_current_time{ namespace=~\"$namespace\"} > 0)",
+                     "format": "time_series",
+                     "legendFormat": "lag",
+                     "legendLink": null
+                  }
+               ],
+               "title": "Sweeper Lag",
+               "type": "graph"
+            },
+            {
+               "datasource": "$datasource",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                           "group": "A",
+                           "mode": "none"
+                        }
+                     },
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "short"
+                  },
+                  "overrides": [ ]
+               },
+               "id": 19,
+               "links": [ ],
+               "options": {
+                  "legend": {
+                     "showLegend": true
+                  },
+                  "tooltip": {
+                     "mode": "single",
+                     "sort": "none"
+                  }
+               },
+               "span": 4,
+               "targets": [
+                  {
+                     "expr": "sum(loki_boltdb_shipper_retention_sweeper_marker_files_current{ namespace=~\"$namespace\"})",
+                     "format": "time_series",
+                     "legendFormat": "count",
+                     "legendLink": null
+                  }
+               ],
+               "title": "Marks Files to Process",
+               "type": "graph"
+            },
+            {
+               "datasource": "$datasource",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                           "group": "A",
+                           "mode": "none"
+                        }
+                     },
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "short"
+                  },
+                  "overrides": [ ]
+               },
+               "id": 20,
+               "links": [ ],
+               "options": {
+                  "legend": {
+                     "showLegend": true
+                  },
+                  "tooltip": {
+                     "mode": "single",
+                     "sort": "none"
+                  }
+               },
+               "span": 4,
+               "targets": [
+                  {
+                     "expr": "sum by (status)(rate(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_count{ namespace=~\"$namespace\"}[$__rate_interval]))",
+                     "format": "time_series",
+                     "legendFormat": "{{status}}",
+                     "legendLink": null
+                  }
+               ],
+               "title": "Delete Rate Per Status",
+               "type": "graph"
             }
          ],
          "repeat": null,

--- a/operator/internal/manifests/openshift/internal/dashboards/static/grafana-dashboard-lokistack-retention.json
+++ b/operator/internal/manifests/openshift/internal/dashboards/static/grafana-dashboard-lokistack-retention.json
@@ -495,7 +495,7 @@
                "span": 6,
                "targets": [
                   {
-                     "expr": "sum(loki_compactor_locked_table_successive_compaction_skips{ namespace=~\"$namespace\"})",
+                     "expr": "sum by (table_name)(loki_compactor_locked_table_successive_compaction_skips{ namespace=~\"$namespace\"})",
                      "format": "time_series",
                      "legendFormat": "{{table_name}}",
                      "legendLink": null
@@ -544,7 +544,7 @@
                   {
                      "expr": "sum by (status)(rate(loki_boltdb_shipper_compact_tables_operation_total{ namespace=~\"$namespace\"}[$__rate_interval]))",
                      "format": "time_series",
-                     "legendFormat": "{{success}}",
+                     "legendFormat": "{{status}}",
                      "legendLink": null
                   }
                ],
@@ -758,7 +758,7 @@
                   {
                      "expr": "sum by (status)(rate(loki_compactor_apply_retention_operation_total{ namespace=~\"$namespace\"}[$__rate_interval]))",
                      "format": "time_series",
-                     "legendFormat": "{{success}}",
+                     "legendFormat": "{{status}}",
                      "legendLink": null
                   }
                ],

--- a/operator/internal/manifests/openshift/internal/dashboards/static/grafana-dashboard-lokistack-retention.json
+++ b/operator/internal/manifests/openshift/internal/dashboards/static/grafana-dashboard-lokistack-retention.json
@@ -481,6 +481,53 @@
                   },
                   "overrides": [ ]
                },
+               "id": 6,
+               "links": [ ],
+               "options": {
+                  "legend": {
+                     "showLegend": true
+                  },
+                  "tooltip": {
+                     "mode": "single",
+                     "sort": "none"
+                  }
+               },
+               "span": 6,
+               "targets": [
+                  {
+                     "expr": "sum(loki_compactor_locked_table_successive_compaction_skips{ namespace=~\"$namespace\"})",
+                     "format": "time_series",
+                     "legendFormat": "{{table_name}}",
+                     "legendLink": null
+                  }
+               ],
+               "title": "Number of times Tables were skipped during Compaction",
+               "type": "graph"
+            },
+            {
+               "datasource": "$datasource",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                           "group": "A",
+                           "mode": "none"
+                        }
+                     },
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ ]
+                     },
+                     "unit": "short"
+                  },
+                  "overrides": [ ]
+               },
                "id": 7,
                "links": [ ],
                "options": {
@@ -517,269 +564,97 @@
          "height": "250px",
          "panels": [
             {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
                "datasource": "$datasource",
                "fieldConfig": {
                   "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 100,
-                        "lineWidth": 0,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "normal"
-                        }
+                     "color": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
                      },
+                     "custom": { },
                      "thresholds": {
                         "mode": "absolute",
-                        "steps": [ ]
+                        "steps": [
+                           {
+                              "color": "green",
+                              "value": null
+                           }
+                        ]
                      },
-                     "unit": "short"
-                  },
-                  "overrides": [ ]
-               },
-               "id": 11,
-               "links": [ ],
-               "options": {
-                  "legend": {
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
+                     "unit": "dateTimeFromNow"
                   }
                },
+               "fill": 1,
+               "id": 8,
+               "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null as zero",
+               "options": {
+                  "colorMode": "value",
+                  "graphMode": "area",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
+                  },
+                  "text": { },
+                  "textMode": "auto"
+               },
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
                "span": 4,
+               "stack": false,
+               "steppedLine": false,
                "targets": [
                   {
-                     "expr": "count by(action)(loki_boltdb_shipper_retention_marker_table_processed_total{ namespace=~\"$namespace\"})",
-                     "format": "time_series",
-                     "legendFormat": "{{action}}",
-                     "legendLink": null
-                  }
-               ],
-               "title": "Processed Tables Per Action",
-               "type": "graph"
-            },
-            {
-               "datasource": "$datasource",
-               "fieldConfig": {
-                  "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 100,
-                        "lineWidth": 0,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "normal"
-                        }
-                     },
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     },
-                     "unit": "short"
-                  },
-                  "overrides": [ ]
-               },
-               "id": 12,
-               "links": [ ],
-               "options": {
-                  "legend": {
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "span": 4,
-               "targets": [
-                  {
-                     "expr": "count by(table,action)(loki_boltdb_shipper_retention_marker_table_processed_total{ namespace=~\"$namespace\" , action=~\"modified|deleted\"})",
-                     "format": "time_series",
-                     "legendFormat": "{{table}}-{{action}}",
-                     "legendLink": null
-                  }
-               ],
-               "title": "Modified Tables",
-               "type": "graph"
-            },
-            {
-               "datasource": "$datasource",
-               "fieldConfig": {
-                  "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 100,
-                        "lineWidth": 0,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "normal"
-                        }
-                     },
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     },
-                     "unit": "short"
-                  },
-                  "overrides": [ ]
-               },
-               "id": 13,
-               "links": [ ],
-               "options": {
-                  "legend": {
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "span": 4,
-               "targets": [
-                  {
-                     "expr": "sum by (table)(rate(loki_boltdb_shipper_retention_marker_count_total{ namespace=~\"$namespace\"}[$__rate_interval])) >0",
-                     "format": "time_series",
-                     "legendFormat": "{{table}}",
-                     "legendLink": null
-                  }
-               ],
-               "title": "Marks Creation Rate Per Table",
-               "type": "graph"
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Per Table Marker",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "datasource": "$datasource",
-               "fieldConfig": {
-                  "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        }
-                     },
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     },
-                     "unit": "short"
-                  },
-                  "overrides": [ ]
-               },
-               "format": "short",
-               "id": 14,
-               "links": [ ],
-               "options": {
-                  "legend": {
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "span": 6,
-               "targets": [
-                  {
-                     "expr": "sum (increase(loki_boltdb_shipper_retention_marker_count_total{ namespace=~\"$namespace\"}[24h]))",
+                     "expr": "loki_compactor_apply_retention_last_successful_run_timestamp_seconds{ namespace=~\"$namespace\"} * 1e3",
                      "format": "time_series",
                      "instant": true,
                      "refId": "A"
                   }
                ],
-               "thresholds": "70,80",
-               "title": "Marked Chunks (24h)",
-               "type": "singlestat"
-            },
-            {
-               "datasource": "$datasource",
-               "fieldConfig": {
-                  "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        }
-                     },
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     },
-                     "unit": "short"
-                  },
-                  "overrides": [ ]
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Last Mark Operation Success",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
                },
-               "id": 15,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "options": {
-                  "legend": {
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
-                  }
+               "type": "singlestat",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
                },
-               "span": 6,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(loki_boltdb_shipper_retention_marker_table_processed_duration_seconds_bucket{ namespace=~\"$namespace\"}[$__rate_interval])) by (le)) * 1e3",
-                     "format": "time_series",
-                     "legendFormat": "99th Percentile",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.50, sum(rate(loki_boltdb_shipper_retention_marker_table_processed_duration_seconds_bucket{ namespace=~\"$namespace\"}[$__rate_interval])) by (le)) * 1e3",
-                     "format": "time_series",
-                     "legendFormat": "50th Percentile",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(rate(loki_boltdb_shipper_retention_marker_table_processed_duration_seconds_sum{ namespace=~\"$namespace\"}[$__rate_interval])) * 1e3 / sum(rate(loki_boltdb_shipper_retention_marker_table_processed_duration_seconds_count{ namespace=~\"$namespace\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "legendFormat": "Average",
-                     "refId": "C"
-                  }
-               ],
-               "title": "Mark Table Latency",
-               "type": "graph",
                "yaxes": [
                   {
-                     "format": "ms",
+                     "format": "short",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -795,158 +670,7 @@
                      "show": false
                   }
                ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "datasource": "$datasource",
-               "fieldConfig": {
-                  "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        }
-                     },
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     },
-                     "unit": "short"
-                  },
-                  "overrides": [ ]
-               },
-               "format": "short",
-               "id": 16,
-               "links": [ ],
-               "options": {
-                  "legend": {
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "span": 6,
-               "targets": [
-                  {
-                     "expr": "sum (increase(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_count{ namespace=~\"$namespace\"}[24h]))",
-                     "format": "time_series",
-                     "instant": true,
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "70,80",
-               "title": "Delete Chunks (24h)",
-               "type": "singlestat"
             },
-            {
-               "datasource": "$datasource",
-               "fieldConfig": {
-                  "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        }
-                     },
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     },
-                     "unit": "short"
-                  },
-                  "overrides": [ ]
-               },
-               "id": 17,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "options": {
-                  "legend": {
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "span": 6,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_bucket{ namespace=~\"$namespace\"}[$__rate_interval])) by (le)) * 1e3",
-                     "format": "time_series",
-                     "legendFormat": "99th Percentile",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.50, sum(rate(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_bucket{ namespace=~\"$namespace\"}[$__rate_interval])) by (le)) * 1e3",
-                     "format": "time_series",
-                     "legendFormat": "50th Percentile",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(rate(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_sum{ namespace=~\"$namespace\"}[$__rate_interval])) * 1e3 / sum(rate(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_count{ namespace=~\"$namespace\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "legendFormat": "Average",
-                     "refId": "C"
-                  }
-               ],
-               "title": "Delete Latency",
-               "type": "graph",
-               "yaxes": [
-                  {
-                     "format": "ms",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Sweeper",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
             {
                "datasource": "$datasource",
                "fieldConfig": {
@@ -971,7 +695,7 @@
                   },
                   "overrides": [ ]
                },
-               "id": 18,
+               "id": 9,
                "links": [ ],
                "options": {
                   "legend": {
@@ -985,13 +709,13 @@
                "span": 4,
                "targets": [
                   {
-                     "expr": "time() - (loki_boltdb_shipper_retention_sweeper_marker_file_processing_current_time{ namespace=~\"$namespace\"} > 0)",
+                     "expr": "loki_compactor_apply_retention_operation_duration_seconds{ namespace=~\"$namespace\"}",
                      "format": "time_series",
-                     "legendFormat": "lag",
+                     "legendFormat": "duration",
                      "legendLink": null
                   }
                ],
-               "title": "Sweeper Lag",
+               "title": "Mark Operations Duration",
                "type": "graph"
             },
             {
@@ -1018,7 +742,7 @@
                   },
                   "overrides": [ ]
                },
-               "id": 19,
+               "id": 10,
                "links": [ ],
                "options": {
                   "legend": {
@@ -1032,60 +756,13 @@
                "span": 4,
                "targets": [
                   {
-                     "expr": "sum(loki_boltdb_shipper_retention_sweeper_marker_files_current{ namespace=~\"$namespace\"})",
+                     "expr": "sum by (status)(rate(loki_compactor_apply_retention_operation_total{ namespace=~\"$namespace\"}[$__rate_interval]))",
                      "format": "time_series",
-                     "legendFormat": "count",
+                     "legendFormat": "{{success}}",
                      "legendLink": null
                   }
                ],
-               "title": "Marks Files to Process",
-               "type": "graph"
-            },
-            {
-               "datasource": "$datasource",
-               "fieldConfig": {
-                  "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        }
-                     },
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     },
-                     "unit": "short"
-                  },
-                  "overrides": [ ]
-               },
-               "id": 20,
-               "links": [ ],
-               "options": {
-                  "legend": {
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "span": 4,
-               "targets": [
-                  {
-                     "expr": "sum by (status)(rate(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_count{ namespace=~\"$namespace\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "legendFormat": "{{status}}",
-                     "legendLink": null
-                  }
-               ],
-               "title": "Delete Rate Per Status",
+               "title": "Mark Operations Per Status",
                "type": "graph"
             }
          ],
@@ -1093,7 +770,7 @@
          "repeatIteration": null,
          "repeatRowId": null,
          "showTitle": true,
-         "title": "",
+         "title": "Retention",
          "titleSize": "h6"
       }
    ],

--- a/operator/internal/manifests/openshift/internal/dashboards/static/grafana-dashboard-lokistack-retention.json
+++ b/operator/internal/manifests/openshift/internal/dashboards/static/grafana-dashboard-lokistack-retention.json
@@ -356,7 +356,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "loki_boltdb_shipper_compact_tables_operation_last_successful_run_timestamp_seconds{ namespace=~\"$namespace\"} * 1e3",
+                     "expr": "loki_compactor_apply_retention_last_successful_run_timestamp_seconds{ namespace=~\"$namespace\"} * 1e3",
                      "format": "time_series",
                      "instant": true,
                      "refId": "A"
@@ -365,7 +365,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Last Compact Tables Operation Success",
+               "title": "Last Retention Operation Success",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -436,13 +436,13 @@
                "span": 6,
                "targets": [
                   {
-                     "expr": "loki_boltdb_shipper_compact_tables_operation_duration_seconds{ namespace=~\"$namespace\"}",
+                     "expr": "loki_compactor_apply_retention_operation_duration_seconds{ namespace=~\"$namespace\"}",
                      "format": "time_series",
                      "legendFormat": "duration",
                      "legendLink": null
                   }
                ],
-               "title": "Compact Tables Operations Duration",
+               "title": "Retention Operation Duration",
                "type": "graph"
             }
          ],
@@ -495,196 +495,20 @@
                "span": 6,
                "targets": [
                   {
-                     "expr": "sum by (status)(rate(loki_boltdb_shipper_compact_tables_operation_total{ namespace=~\"$namespace\"}[$__rate_interval]))",
+                     "expr": "sum by (status)(rate(loki_compactor_apply_retention_operation_total{ namespace=~\"$namespace\"}[$__rate_interval]))",
                      "format": "time_series",
                      "legendFormat": "{{success}}",
                      "legendLink": null
                   }
                ],
-               "title": "Compact Tables Operations Per Status",
-               "type": "graph"
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "datasource": "$datasource",
-               "fieldConfig": {
-                  "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 100,
-                        "lineWidth": 0,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "normal"
-                        }
-                     },
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     },
-                     "unit": "short"
-                  },
-                  "overrides": [ ]
-               },
-               "id": 11,
-               "links": [ ],
-               "options": {
-                  "legend": {
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "span": 4,
-               "targets": [
-                  {
-                     "expr": "count by(action)(loki_boltdb_shipper_retention_marker_table_processed_total{ namespace=~\"$namespace\"})",
-                     "format": "time_series",
-                     "legendFormat": "{{action}}",
-                     "legendLink": null
-                  }
-               ],
-               "title": "Processed Tables Per Action",
+               "title": "Retention Operations Per Status",
                "type": "graph"
             },
             {
                "datasource": "$datasource",
                "fieldConfig": {
                   "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 100,
-                        "lineWidth": 0,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "normal"
-                        }
-                     },
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     },
-                     "unit": "short"
-                  },
-                  "overrides": [ ]
-               },
-               "id": 12,
-               "links": [ ],
-               "options": {
-                  "legend": {
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "span": 4,
-               "targets": [
-                  {
-                     "expr": "count by(table,action)(loki_boltdb_shipper_retention_marker_table_processed_total{ namespace=~\"$namespace\" , action=~\"modified|deleted\"})",
-                     "format": "time_series",
-                     "legendFormat": "{{table}}-{{action}}",
-                     "legendLink": null
-                  }
-               ],
-               "title": "Modified Tables",
-               "type": "graph"
-            },
-            {
-               "datasource": "$datasource",
-               "fieldConfig": {
-                  "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 100,
-                        "lineWidth": 0,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "normal"
-                        }
-                     },
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     },
-                     "unit": "short"
-                  },
-                  "overrides": [ ]
-               },
-               "id": 13,
-               "links": [ ],
-               "options": {
-                  "legend": {
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "span": 4,
-               "targets": [
-                  {
-                     "expr": "sum by (table)(rate(loki_boltdb_shipper_retention_marker_count_total{ namespace=~\"$namespace\"}[$__rate_interval])) >0",
-                     "format": "time_series",
-                     "legendFormat": "{{table}}",
-                     "legendLink": null
-                  }
-               ],
-               "title": "Marks Creation Rate Per Table",
-               "type": "graph"
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Per Table Marker",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "datasource": "$datasource",
-               "fieldConfig": {
-                  "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        }
-                     },
+                     "custom": { },
                      "thresholds": {
                         "mode": "absolute",
                         "steps": [ ]
@@ -694,399 +518,34 @@
                   "overrides": [ ]
                },
                "format": "short",
-               "id": 14,
+               "id": 8,
                "links": [ ],
                "options": {
-                  "legend": {
-                     "showLegend": true
+                  "colorMode": "value",
+                  "graphMode": "area",
+                  "justifyMode": "auto",
+                  "orientation": "auto",
+                  "reduceOptions": {
+                     "calcs": [
+                        "lastNotNull"
+                     ],
+                     "fields": "",
+                     "values": false
                   },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
-                  }
+                  "text": { },
+                  "textMode": "auto"
                },
                "span": 6,
                "targets": [
                   {
-                     "expr": "sum (increase(loki_boltdb_shipper_retention_marker_count_total{ namespace=~\"$namespace\"}[24h]))",
+                     "expr": "sum(increase(loki_compactor_retention_chunks_expired_by_ingestion_time_total{ namespace=~\"$namespace\"}[24h]))",
                      "format": "time_series",
                      "instant": true,
                      "refId": "A"
                   }
                ],
-               "thresholds": "70,80",
-               "title": "Marked Chunks (24h)",
+               "title": "Chunks Expired by Retention (24h)",
                "type": "singlestat"
-            },
-            {
-               "datasource": "$datasource",
-               "fieldConfig": {
-                  "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        }
-                     },
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     },
-                     "unit": "short"
-                  },
-                  "overrides": [ ]
-               },
-               "id": 15,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "options": {
-                  "legend": {
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "span": 6,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(loki_boltdb_shipper_retention_marker_table_processed_duration_seconds_bucket{ namespace=~\"$namespace\"}[$__rate_interval])) by (le)) * 1e3",
-                     "format": "time_series",
-                     "legendFormat": "99th Percentile",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.50, sum(rate(loki_boltdb_shipper_retention_marker_table_processed_duration_seconds_bucket{ namespace=~\"$namespace\"}[$__rate_interval])) by (le)) * 1e3",
-                     "format": "time_series",
-                     "legendFormat": "50th Percentile",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(rate(loki_boltdb_shipper_retention_marker_table_processed_duration_seconds_sum{ namespace=~\"$namespace\"}[$__rate_interval])) * 1e3 / sum(rate(loki_boltdb_shipper_retention_marker_table_processed_duration_seconds_count{ namespace=~\"$namespace\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "legendFormat": "Average",
-                     "refId": "C"
-                  }
-               ],
-               "title": "Mark Table Latency",
-               "type": "graph",
-               "yaxes": [
-                  {
-                     "format": "ms",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "datasource": "$datasource",
-               "fieldConfig": {
-                  "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        }
-                     },
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     },
-                     "unit": "short"
-                  },
-                  "overrides": [ ]
-               },
-               "format": "short",
-               "id": 16,
-               "links": [ ],
-               "options": {
-                  "legend": {
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "span": 6,
-               "targets": [
-                  {
-                     "expr": "sum (increase(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_count{ namespace=~\"$namespace\"}[24h]))",
-                     "format": "time_series",
-                     "instant": true,
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "70,80",
-               "title": "Delete Chunks (24h)",
-               "type": "singlestat"
-            },
-            {
-               "datasource": "$datasource",
-               "fieldConfig": {
-                  "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        }
-                     },
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     },
-                     "unit": "short"
-                  },
-                  "overrides": [ ]
-               },
-               "id": 17,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "options": {
-                  "legend": {
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "span": 6,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_bucket{ namespace=~\"$namespace\"}[$__rate_interval])) by (le)) * 1e3",
-                     "format": "time_series",
-                     "legendFormat": "99th Percentile",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.50, sum(rate(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_bucket{ namespace=~\"$namespace\"}[$__rate_interval])) by (le)) * 1e3",
-                     "format": "time_series",
-                     "legendFormat": "50th Percentile",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(rate(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_sum{ namespace=~\"$namespace\"}[$__rate_interval])) * 1e3 / sum(rate(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_count{ namespace=~\"$namespace\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "legendFormat": "Average",
-                     "refId": "C"
-                  }
-               ],
-               "title": "Delete Latency",
-               "type": "graph",
-               "yaxes": [
-                  {
-                     "format": "ms",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Sweeper",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "datasource": "$datasource",
-               "fieldConfig": {
-                  "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        }
-                     },
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     },
-                     "unit": "s"
-                  },
-                  "overrides": [ ]
-               },
-               "id": 18,
-               "links": [ ],
-               "options": {
-                  "legend": {
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "span": 4,
-               "targets": [
-                  {
-                     "expr": "time() - (loki_boltdb_shipper_retention_sweeper_marker_file_processing_current_time{ namespace=~\"$namespace\"} > 0)",
-                     "format": "time_series",
-                     "legendFormat": "lag",
-                     "legendLink": null
-                  }
-               ],
-               "title": "Sweeper Lag",
-               "type": "graph"
-            },
-            {
-               "datasource": "$datasource",
-               "fieldConfig": {
-                  "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        }
-                     },
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     },
-                     "unit": "short"
-                  },
-                  "overrides": [ ]
-               },
-               "id": 19,
-               "links": [ ],
-               "options": {
-                  "legend": {
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "span": 4,
-               "targets": [
-                  {
-                     "expr": "sum(loki_boltdb_shipper_retention_sweeper_marker_files_current{ namespace=~\"$namespace\"})",
-                     "format": "time_series",
-                     "legendFormat": "count",
-                     "legendLink": null
-                  }
-               ],
-               "title": "Marks Files to Process",
-               "type": "graph"
-            },
-            {
-               "datasource": "$datasource",
-               "fieldConfig": {
-                  "defaults": {
-                     "custom": {
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        }
-                     },
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     },
-                     "unit": "short"
-                  },
-                  "overrides": [ ]
-               },
-               "id": 20,
-               "links": [ ],
-               "options": {
-                  "legend": {
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "span": 4,
-               "targets": [
-                  {
-                     "expr": "sum by (status)(rate(loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_count{ namespace=~\"$namespace\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "legendFormat": "{{status}}",
-                     "legendLink": null
-                  }
-               ],
-               "title": "Delete Rate Per Status",
-               "type": "graph"
             }
          ],
          "repeat": null,

--- a/operator/jsonnet/config.libsonnet
+++ b/operator/jsonnet/config.libsonnet
@@ -160,13 +160,20 @@ local utils = (import 'github.com/grafana/jsonnet-libs/mixin-utils/utils.libsonn
           { from: 'cluster=~"$cluster",', to: '' },
           { from: 'container="compactor"', to: 'container=~".+-compactor"' },
           { from: 'job=~"($namespace)/compactor"', to: 'namespace="$namespace", job=~".+-compactor-http"' },
+          { from: 'sum(loki_compactor_locked_table_successive_compaction_skips', to: 'sum by (table_name)(loki_compactor_locked_table_successive_compaction_skips' },
         ],
         uid: 'RetCujSHzC8gd9i5fck9a3v9n2EvTzA',
         title: 'OpenShift Logging / LokiStack / Retention',
         tags: defaultLokiTags(super.tags),
         local processedRows = [
           r {
-            panels: mapPanels([replaceMatchers(replacements), replaceType('stat', 'singlestat'), replaceType('timeseries', 'graph')], dropPanels(r.panels, dropList, function(p) true)),
+            panels: mapPanels([
+              replaceMatchers(replacements),
+              replaceLabelFormat('Compact Tables Operations Per Status', '{{success}}', '{{status}}'),
+              replaceLabelFormat('Mark Operations Per Status', '{{success}}', '{{status}}'),
+              replaceType('stat', 'singlestat'),
+              replaceType('timeseries', 'graph'),
+            ], dropPanels(r.panels, dropList, function(p) true)),
           }
           for r in dropPanels(super.rows, dropList, function(p) true)
         ],

--- a/operator/jsonnet/config.libsonnet
+++ b/operator/jsonnet/config.libsonnet
@@ -144,10 +144,18 @@ local utils = (import 'github.com/grafana/jsonnet-libs/mixin-utils/utils.libsonn
 
     grafanaDashboards+: {
       'loki-retention.json'+: {
-        // TODO (JoaoBraveCoding) Once we upgrade to 3.x we should be able to lift the drops on
-        // 'Number of times Tables were skipped during Compaction' and 'Retention' since Loki will then have the
-        // updated metrics
-        local dropList = ['Logs', 'Number of times Tables were skipped during Compaction', 'Retention'],
+        local dropList = [
+          'Logs',
+          // BoltDB-specific rows
+          'Per Table Marker',
+          'Sweeper',
+          // BoltDB-specific panels in unnamed rows
+          'Marked Chunks (24h)',
+          'Mark Table Latency',
+          'Sweeper Lag',
+          'Marks Files to Process',
+          'Delete Rate Per Status',
+        ],
         local replacements = [
           { from: 'cluster=~"$cluster",', to: '' },
           { from: 'container="compactor"', to: 'container=~".+-compactor"' },
@@ -156,11 +164,16 @@ local utils = (import 'github.com/grafana/jsonnet-libs/mixin-utils/utils.libsonn
         uid: 'RetCujSHzC8gd9i5fck9a3v9n2EvTzA',
         title: 'OpenShift Logging / LokiStack / Retention',
         tags: defaultLokiTags(super.tags),
-        rows: [
+        local processedRows = [
           r {
             panels: mapPanels([replaceMatchers(replacements), replaceType('stat', 'singlestat'), replaceType('timeseries', 'graph')], dropPanels(r.panels, dropList, function(p) true)),
           }
           for r in dropPanels(super.rows, dropList, function(p) true)
+        ],
+        rows: [
+          r
+          for r in processedRows
+          if std.length(r.panels) > 0
         ],
         templating+: {
           list: mapTemplateParameters(super.list),


### PR DESCRIPTION
**What this PR does / why we need it**:
- Removes `LokiStorageSlowWrite` and `LokiStorageSlowRead` alerts
- Removes the `job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket` recording rule
- Rewrites the retention dashboard compaction panels from `loki_boltdb_shipper_compact_tables_operation_*` to `loki_compactor_apply_retention_*` metrics
- Removes dashboard rows for BoltDB-specific marker/sweeper panels
- Updates alert test data to match the new rules

**Which issue(s) this PR fixes**:
Fixes [LOG-9666](https://redhat.atlassian.net/browse/LOG-9666)

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
