### PR TITLE
fix(frontend): Bind -frontend.support-parquet-encoding to its own config field

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -37,6 +37,10 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 ## Main / Unreleased
 
+### `frontend.compress_responses` default changed to `true`
+
+The default value of `frontend.compress_responses` changed to `true`. A bug in Loki 3.4.0 unintentionally switched it to `false`. If you don't want the query-frontend to compress HTTP responses, set `frontend.compress_responses` to `false` explicitly.
+
 ### Breaking change: Removal of LogQL `variants()` queries
 
 The experimental `variants()` LogQL expression is no longer supported.

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3678,7 +3678,8 @@ The `frontend` block configures the Loki query-frontend.
 [tail_tls_config: <tls_config>]
 
 # Support 'application/vnd.apache.parquet' content type in HTTP responses.
-[support_parquet_encoding: <boolean>]
+# CLI flag: -frontend.support-parquet-encoding
+[support_parquet_encoding: <boolean> | default = false]
 ```
 
 ### frontend_worker

--- a/pkg/lokifrontend/config.go
+++ b/pkg/lokifrontend/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	TailProxyURL string           `yaml:"tail_proxy_url"`
 	TLS          tls.ClientConfig `yaml:"tail_tls_config"`
 
-	SupportParquetEncoding bool `yaml:"support_parquet_encoding" doc:"description=Support 'application/vnd.apache.parquet' content type in HTTP responses."`
+	SupportParquetEncoding bool `yaml:"support_parquet_encoding"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
@@ -35,5 +35,5 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.DownstreamURL, "frontend.downstream-url", "", "URL of downstream Loki.")
 	f.StringVar(&cfg.TailProxyURL, "frontend.tail-proxy-url", "", "URL of querier for tail proxy.")
 
-	f.BoolVar(&cfg.CompressResponses, "frontend.support-parquet-encoding", false, "Support 'application/vnd.apache.parquet' content type in HTTP responses.")
+	f.BoolVar(&cfg.SupportParquetEncoding, "frontend.support-parquet-encoding", false, "Support 'application/vnd.apache.parquet' content type in HTTP responses.")
 }

--- a/pkg/lokifrontend/config_test.go
+++ b/pkg/lokifrontend/config_test.go
@@ -1,0 +1,24 @@
+package lokifrontend
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_RegisterFlags(t *testing.T) {
+	t.Run("-frontend.support-parquet-encoding", func(t *testing.T) {
+		var cfg Config
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		cfg.RegisterFlags(fs)
+
+		require.True(t, cfg.CompressResponses)
+		require.False(t, cfg.SupportParquetEncoding)
+
+		require.NoError(t, fs.Parse([]string{"-frontend.support-parquet-encoding=true"}))
+
+		require.True(t, cfg.SupportParquetEncoding)
+		require.True(t, cfg.CompressResponses)
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

`-frontend.support-parquet-encoding` was registered against `&cfg.CompressResponses` instead of `&cfg.SupportParquetEncoding`, so two flags shared a single field:

```go
f.BoolVar(&cfg.CompressResponses, "querier.compress-http-responses", true, ...)
f.BoolVar(&cfg.CompressResponses, "frontend.support-parquet-encoding", false, ...)
```

`flag.BoolVar()` assigns the default at registration time, so the second call wins. This has two consequences:

- **`compress_responses` silently defaults to `false`.** It is documented as `true`, and was `true` before Loki 3.4.0. Any deployment that does not set it explicitly has been serving uncompressed query-frontend responses since then.
- **`-frontend.support-parquet-encoding` cannot enable Parquet responses.** It writes to the wrong field, so the only working way to turn the feature on is the `frontend.support_parquet_encoding` YAML setting. Passing the flag instead toggles response compression.

Binding each flag to its own field fixes both.

**Impact on upgrade**: query-frontend responses become gzip-compressed again for deployments that never set `compress_responses` explicitly. This restores the documented behaviour, but it is a visible change, so it is called out in the upgrade guide together with the opt-out. Every config shipped in this repo already sets `compress_responses: true`, and explicit YAML was never affected by the bug.

The `doc:"description=..."` tag on `SupportParquetEncoding` existed only because no flag was bound to the field. The flag usage string now supplies that text, so the tag is removed and the generated config reference gains the CLI flag and its default.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

The new test fails on `main` and passes with the fix.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
