### PR TITLE
chore: Use the logobj.Builder during compaction

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -391,10 +391,7 @@ func (b *Builder) AppendRecord(tenant string, ls labels.Labels, record logs.Reco
 	})
 
 	singleRecordIter := func(yield func(entry logs.Record, size int64) bool) {
-		ok := yield(record, sz)
-		if !ok {
-			return
-		}
+		_ = yield(record, sz)
 	}
 
 	return b.appendAll(tenant, ls, time.Time{}, singleRecordIter)

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"iter"
 	"slices"
 	"strings"
 	"time"
@@ -262,8 +263,8 @@ func NewBuilder(cfg BuilderConfig, scratchStore scratch.Store, metrics *BuilderM
 	}, nil
 }
 
-// initBuilder initializes the builders for the tenant.
-func (b *Builder) initBuilder(tenant string) {
+// buildersFor initializes the builders for the tenant.
+func (b *Builder) buildersFor(tenant string) (*streams.Builder, *logs.Builder) {
 	if _, ok := b.streams[tenant]; !ok {
 		sb := streams.NewBuilder(b.metrics.streams, int(b.cfg.TargetPageSize), b.cfg.MaxPageRows)
 		sb.SetTenant(tenant)
@@ -309,6 +310,8 @@ func (b *Builder) initBuilder(tenant string) {
 		lb.SetTenant(tenant)
 		b.logs[tenant] = lb
 	}
+
+	return b.streams[tenant], b.logs[tenant]
 }
 
 func (b *Builder) GetEarliestRecordTime() time.Time {
@@ -323,23 +326,7 @@ func (b *Builder) IsFull() bool {
 	return b.currentSizeEstimate > int(b.cfg.TargetObjectSize)
 }
 
-// Append buffers a stream to be written to a data object.
-// Callers are expected to poll [Builder.IsFull] before appending and
-// to flush the builder once it reports full. Appending entries to a full
-// builder is permitted.
-func (b *Builder) Append(tenant string, stream logproto.Stream, recTime time.Time) error {
-	ls, err := b.parseLabels(stream.Labels)
-	if err != nil {
-		return err
-	}
-
-	b.initBuilder(tenant)
-	sb, lb := b.streams[tenant], b.logs[tenant]
-
-	b.metrics.appends.Inc()
-	timer := prometheus.NewTimer(b.metrics.appendTime)
-	defer timer.ObserveDuration()
-
+func (b *Builder) getSortKey(tenant string, ls labels.Labels) (string, error) {
 	var sortKey string
 	if b.cfg.DataobjUseSortSchema && b.overrides != nil {
 		schemaLabels := b.overrides.SortSchemaLabels(tenant)
@@ -347,26 +334,85 @@ func (b *Builder) Append(tenant string, stream logproto.Stream, recTime time.Tim
 			var err error
 			sortKey, err = ComputeSortKey(ls, schemaLabels)
 			if err != nil {
-				return fmt.Errorf("compute sort key for tenant %s: %w", tenant, err)
+				return "", fmt.Errorf("compute sort key for tenant %s: %w", tenant, err)
+			}
+		}
+	}
+	return sortKey, nil
+}
+
+// Append buffers a stream to be written to a data object.
+// Callers are expected to poll [Builder.IsFull] before appending and
+// to flush the builder once it reports full. Appending entries to a full
+// builder is permitted.
+func (b *Builder) Append(tenant string, stream logproto.Stream, recTime time.Time) error {
+	b.metrics.appends.Inc()
+	timer := prometheus.NewTimer(b.metrics.appendTime)
+	defer timer.ObserveDuration()
+
+	ls, err := b.parseLabels(stream.Labels)
+	if err != nil {
+		return err
+	}
+
+	recordIter := func(yield func(logs.Record, int64) bool) {
+		for _, entry := range stream.Entries {
+			sz := int64(len(entry.Line))
+			for _, md := range entry.StructuredMetadata {
+				sz += int64(len(md.Value))
+			}
+			ok := yield(logs.Record{
+				Timestamp: entry.Timestamp,
+				Metadata:  convertMetadata(entry.StructuredMetadata),
+				Line:      []byte(entry.Line),
+			}, sz)
+			if !ok {
+				return
 			}
 		}
 	}
 
-	for _, entry := range stream.Entries {
-		sz := int64(len(entry.Line))
-		for _, md := range entry.StructuredMetadata {
-			sz += int64(len(md.Value))
+	return b.appendAll(tenant, ls, recTime, recordIter)
+}
+
+// AppendRecord buffers a pre-existing log record to be written to a data object.
+// Callers are expected to poll [Builder.IsFull] before appending and
+// to flush the builder once it reports full. Appending entries to a full
+// builder is permitted.
+// The SortKey & StreamID fields of the given record are ignored and re-calculated.
+func (b *Builder) AppendRecord(tenant string, ls labels.Labels, record logs.Record) error {
+	b.metrics.appends.Inc()
+	timer := prometheus.NewTimer(b.metrics.appendTime)
+	defer timer.ObserveDuration()
+
+	sz := int64(len(record.Line))
+	record.Metadata.Range(func(lb labels.Label) {
+		sz += int64(len(lb.Value))
+	})
+
+	singleRecordIter := func(yield func(entry logs.Record, size int64) bool) {
+		ok := yield(record, sz)
+		if !ok {
+			return
 		}
+	}
 
-		streamID := sb.Record(ls, entry.Timestamp, sz)
+	return b.appendAll(tenant, ls, time.Time{}, singleRecordIter)
+}
 
-		lb.Append(logs.Record{
-			StreamID:  streamID,
-			Timestamp: entry.Timestamp,
-			Metadata:  convertMetadata(entry.StructuredMetadata),
-			Line:      []byte(entry.Line),
-			SortKey:   sortKey,
-		})
+func (b *Builder) appendAll(tenant string, ls labels.Labels, recordTime time.Time, entriesIter iter.Seq2[logs.Record, int64]) error {
+	streamSortKey, err := b.getSortKey(tenant, ls)
+	if err != nil {
+		return err
+	}
+
+	sb, lb := b.buildersFor(tenant)
+
+	for entry, size := range entriesIter {
+		entry.SortKey = streamSortKey
+		entry.StreamID = sb.Record(ls, entry.Timestamp, size)
+
+		lb.Append(entry)
 
 		// If our logs section has gotten big enough, we want to flush it to the
 		// encoder and start a new section.
@@ -379,8 +425,8 @@ func (b *Builder) Append(tenant string, stream logproto.Stream, recTime time.Tim
 		}
 	}
 
-	if b.earliestRecordTime.IsZero() || recTime.Before(b.earliestRecordTime) {
-		b.earliestRecordTime = recTime
+	if b.earliestRecordTime.IsZero() || recordTime.Before(b.earliestRecordTime) {
+		b.earliestRecordTime = recordTime
 	}
 	b.currentSizeEstimate = b.estimatedSize()
 	b.state = builderStateDirty

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -380,7 +380,7 @@ func (b *Builder) Append(tenant string, stream logproto.Stream, recTime time.Tim
 // to flush the builder once it reports full. Appending entries to a full
 // builder is permitted.
 // The SortKey & StreamID fields of the given record are ignored and re-calculated.
-func (b *Builder) AppendRecord(tenant string, ls labels.Labels, record logs.Record) error {
+func (b *Builder) AppendRecord(tenant string, ls labels.Labels, record logs.Record, ingestionTime time.Time) error {
 	b.metrics.appends.Inc()
 	timer := prometheus.NewTimer(b.metrics.appendTime)
 	defer timer.ObserveDuration()
@@ -394,7 +394,7 @@ func (b *Builder) AppendRecord(tenant string, ls labels.Labels, record logs.Reco
 		_ = yield(record, sz)
 	}
 
-	return b.appendAll(tenant, ls, time.Time{}, singleRecordIter)
+	return b.appendAll(tenant, ls, ingestionTime, singleRecordIter)
 }
 
 func (b *Builder) appendAll(tenant string, ls labels.Labels, recordTime time.Time, entriesIter iter.Seq2[logs.Record, int64]) error {

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -1,6 +1,7 @@
 package logsobj
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -20,6 +21,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/syntax"
 )
 
 var testBuilderConfig = BuilderConfig{
@@ -119,6 +121,50 @@ func TestBuilder_Append(t *testing.T) {
 				Line:      strings.Repeat("a", 1024),
 			}},
 		}, time.Now()))
+	}
+
+	obj, closer, err := builder.Flush()
+	require.NoError(t, err)
+	defer closer.Close()
+
+	// When a section builder is reset, which happens on flush, the
+	// tenant is reset too. We must check that the tenant is added back
+	// to the section builder otherwise tenant will be absent from successive
+	// sections.
+	secs := obj.Sections()
+	require.Equal(t, 1, secs.Count(streams.CheckSection))
+	require.Greater(t, secs.Count(logs.CheckSection), 1)
+	for _, section := range secs.Filter(logs.CheckSection) {
+		require.Equal(t, tenant, section.Tenant)
+	}
+}
+
+// TestBuilder_AppendRecord ensures that appending to the buffer eventually reports
+// that the buffer is full via the AppendRecord call.
+func TestBuilder_AppendRecord(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	builder, err := NewBuilder(testBuilderConfig, nil, NewBuilderMetrics(), log.NewNopLogger(), nil)
+	require.NoError(t, err)
+
+	tenant := "test"
+
+	lbs, err := syntax.ParseLabels(`{cluster="test",app="foo"}`)
+	require.NoError(t, err)
+
+	for {
+		require.NoError(t, ctx.Err())
+
+		// Append until the builder reports that it is full.
+		if builder.IsFull() {
+			break
+		}
+
+		require.NoError(t, builder.AppendRecord(tenant, lbs, logs.Record{
+			Timestamp: time.Now().UTC(),
+			Line:      bytes.Repeat([]byte("a"), 1024),
+		}))
 	}
 
 	obj, closer, err := builder.Flush()

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -164,7 +164,7 @@ func TestBuilder_AppendRecord(t *testing.T) {
 		require.NoError(t, builder.AppendRecord(tenant, lbs, logs.Record{
 			Timestamp: time.Now().UTC(),
 			Line:      bytes.Repeat([]byte("a"), 1024),
-		}))
+		}, time.Now()))
 	}
 
 	obj, closer, err := builder.Flush()

--- a/pkg/engine/compactor/metrics.go
+++ b/pkg/engine/compactor/metrics.go
@@ -265,12 +265,9 @@ type workerMetrics struct {
 	outputBytesCompressed   *prometheus.HistogramVec // tenant
 	outputBytesUncompressed *prometheus.HistogramVec // tenant
 
-	logMergeTasksTotal              *prometheus.CounterVec   // tenant, outcome
-	logMergeDurationSeconds         *prometheus.HistogramVec // tenant
-	logMergeOutputRecords           *prometheus.HistogramVec // tenant
-	logMergeOutputStreams           *prometheus.HistogramVec // tenant
-	logMergeOutputBytesCompressed   *prometheus.HistogramVec // tenant
-	logMergeOutputBytesUncompressed *prometheus.HistogramVec // tenant
+	logMergeTasksTotal            *prometheus.CounterVec   // tenant, outcome
+	logMergeDurationSeconds       *prometheus.HistogramVec // tenant
+	logMergeOutputBytesCompressed *prometheus.HistogramVec // tenant
 }
 
 func newWorkerMetrics(reg prometheus.Registerer) *workerMetrics {

--- a/pkg/engine/compactor/metrics.go
+++ b/pkg/engine/compactor/metrics.go
@@ -276,7 +276,6 @@ type workerMetrics struct {
 func newWorkerMetrics(reg prometheus.Registerer) *workerMetrics {
 	f := promauto.With(reg)
 	byteBuckets := prometheus.ExponentialBuckets(1024, 2, 21)
-	countBuckets := prometheus.ExponentialBuckets(1, 2, 16)
 	durationBuckets := prometheus.ExponentialBuckets(0.01, 2, 14)
 	return &workerMetrics{
 		outputBytesCompressed: f.NewHistogramVec(prometheus.HistogramOpts{
@@ -298,24 +297,9 @@ func newWorkerMetrics(reg prometheus.Registerer) *workerMetrics {
 			Help:    "Wall-clock duration of a LogMerge task on the worker.",
 			Buckets: durationBuckets,
 		}, []string{labelTenant}),
-		logMergeOutputRecords: f.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "loki_dataobj_compaction_log_merge_output_records",
-			Help:    "Number of log records written by a successful LogMerge task.",
-			Buckets: countBuckets,
-		}, []string{labelTenant}),
-		logMergeOutputStreams: f.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "loki_dataobj_compaction_log_merge_output_streams",
-			Help:    "Number of output streams written by a successful LogMerge task.",
-			Buckets: countBuckets,
-		}, []string{labelTenant}),
 		logMergeOutputBytesCompressed: f.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "loki_dataobj_compaction_log_merge_output_bytes_compressed",
 			Help:    "Total encoded bytes uploaded across all compacted log objects for a successful LogMerge task.",
-			Buckets: byteBuckets,
-		}, []string{labelTenant}),
-		logMergeOutputBytesUncompressed: f.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "loki_dataobj_compaction_log_merge_output_bytes_uncompressed",
-			Help:    "Estimated uncompressed bytes of log records written by a successful LogMerge task.",
 			Buckets: byteBuckets,
 		}, []string{labelTenant}),
 	}
@@ -350,16 +334,7 @@ func (m *workerMetrics) ObserveLogMerge(tenant string, stats executor.LogMergeOb
 	if stats.Outcome != "success" {
 		return
 	}
-	if stats.OutputRecords > 0 {
-		m.logMergeOutputRecords.WithLabelValues(tenant).Observe(float64(stats.OutputRecords))
-	}
-	if stats.OutputStreams > 0 {
-		m.logMergeOutputStreams.WithLabelValues(tenant).Observe(float64(stats.OutputStreams))
-	}
 	if stats.OutputBytesCompressed > 0 {
 		m.logMergeOutputBytesCompressed.WithLabelValues(tenant).Observe(float64(stats.OutputBytesCompressed))
-	}
-	if stats.OutputBytesUncompressed > 0 {
-		m.logMergeOutputBytesUncompressed.WithLabelValues(tenant).Observe(float64(stats.OutputBytesUncompressed))
 	}
 }

--- a/pkg/engine/internal/executor/log_merge.go
+++ b/pkg/engine/internal/executor/log_merge.go
@@ -141,10 +141,7 @@ func (c *Context) doLogObjectMerge(ctx context.Context, node *physical.LogMerge)
 		"source_objects", stats.SourceObjects,
 		"input_sections", stats.InputSections,
 		"output_objects", stats.OutputObjects,
-		"output_streams", stats.OutputStreams,
-		"output_records", stats.OutputRecords,
 		"output_bytes", stats.OutputBytesCompressed,
-		"output_bytes_uncompressed", stats.OutputBytesUncompressed,
 		"sort_schema", strings.Join(node.SortSchema, ","),
 		"duration", time.Since(start),
 	)
@@ -161,14 +158,11 @@ const (
 // LogMergeObservedStats is the per-task compaction summary reported to
 // LogMergeObserver and xcap statistics.
 type LogMergeObservedStats struct {
-	Outcome                 string
-	SourceObjects           int
-	InputSections           int
-	OutputObjects           int
-	OutputStreams           int
-	OutputRecords           int
-	OutputBytesCompressed   int64
-	OutputBytesUncompressed int64
+	Outcome               string
+	SourceObjects         int
+	InputSections         int
+	OutputObjects         int
+	OutputBytesCompressed int64
 }
 
 // logMergeObservedStats is the internal alias used while assembling stats.

--- a/pkg/engine/internal/executor/log_merge.go
+++ b/pkg/engine/internal/executor/log_merge.go
@@ -434,7 +434,9 @@ func (w *logObjectWriter) add(ctx context.Context, rec logs.Record) error {
 	w.lastSortKey = rec.SortKey
 	stream := w.table.streams[rec.StreamID]
 
-	err := w.logsBuilder.AppendRecord(w.node.Tenant, stream.Labels, rec)
+	// There's no equivalent for ingestion time during compaction, so use the current time.
+	ingestionTime := time.Now()
+	err := w.logsBuilder.AppendRecord(w.node.Tenant, stream.Labels, rec, ingestionTime)
 	if err != nil {
 		return err
 	}

--- a/pkg/engine/internal/executor/log_merge.go
+++ b/pkg/engine/internal/executor/log_merge.go
@@ -431,6 +431,7 @@ func (w *logObjectWriter) add(ctx context.Context, rec logs.Record) error {
 			return err
 		}
 	}
+	w.lastSortKey = rec.SortKey
 	stream := w.table.streams[rec.StreamID]
 
 	err := w.logsBuilder.AppendRecord(w.node.Tenant, stream.Labels, rec)

--- a/pkg/engine/internal/executor/log_merge.go
+++ b/pkg/engine/internal/executor/log_merge.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/go-kit/log/level"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/thanos-io/objstore"
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
@@ -80,7 +79,10 @@ func (c *Context) doLogObjectMerge(ctx context.Context, node *physical.LogMerge)
 	}
 
 	// Consume the globally-sorted stream and build compacted object
-	w := c.newLogObjectWriter(node, table, calc)
+	w, err := c.newLogObjectWriter(node, table, calc)
+	if err != nil {
+		return nil, err
+	}
 	for res := range merged {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -370,87 +372,85 @@ type logObjectWriter struct {
 	table *globalStreamTable
 	calc  *dataobjindex.Calculator
 
-	logsMetrics    *logs.Metrics
-	streamsMetrics *streams.Metrics
-	targetObject   int
-	targetSection  int
+	builderMetrics *logsobj.BuilderMetrics
 
-	builder       *dataobj.Builder
-	lb            *logs.Builder
-	sb            *streams.Builder
-	objSize       int
-	objStreams    int
-	objRecords    int
-	curGlobalID   int64
-	curObjLocalID int64
+	logsBuilder *logsobj.Builder
+	sortBuilder *logsobj.Builder
+	lastSortKey string
 
 	stats logMergeStats
 }
 
-func (c *Context) newLogObjectWriter(node *physical.LogMerge, table *globalStreamTable, calc *dataobjindex.Calculator) *logObjectWriter {
+type fixedSortSchema []string
+
+func (s fixedSortSchema) SortSchemaLabels(string) []string { return s }
+
+func (c *Context) newLogObjectWriter(node *physical.LogMerge, table *globalStreamTable, calc *dataobjindex.Calculator) (*logObjectWriter, error) {
 	w := &logObjectWriter{
 		c:              c,
 		node:           node,
 		table:          table,
 		calc:           calc,
-		logsMetrics:    logs.NewMetrics(),
-		streamsMetrics: streams.NewMetrics(),
-		targetObject:   int(c.indexobjCfg.TargetObjectSize),
-		targetSection:  int(c.indexobjCfg.TargetSectionSize),
+		builderMetrics: logsobj.NewBuilderMetrics(),
 	}
-	w.startObject()
-	return w
+	err := w.startNewObject()
+	if err != nil {
+		return nil, err
+	}
+	return w, nil
 }
 
-func (w *logObjectWriter) startObject() {
-	w.builder = dataobj.NewBuilder(w.c.scratchStore)
-	w.lb = logs.NewBuilder(w.logsMetrics, w.c.logsBuilderOptions(w.node.SortSchema))
-	w.lb.SetTenant(w.node.Tenant)
-	w.sb = streams.NewBuilder(w.streamsMetrics, int(w.c.indexobjCfg.TargetPageSize), w.c.indexobjCfg.MaxPageRows)
-	w.sb.SetTenant(w.node.Tenant)
-	w.objSize, w.objStreams, w.objRecords = 0, 0, 0
-	w.curGlobalID, w.curObjLocalID = 0, 0
+func (w *logObjectWriter) startNewObject() error {
+	cfg := logsobj.BuilderConfig{
+		BuilderBaseConfig:    w.c.indexobjCfg,
+		DataobjSortOrder:     "stream-asc",
+		AppendOrderedEnabled: true,
+		DataobjUseSortSchema: true,
+	}
+	overrides := fixedSortSchema(w.node.SortSchema)
+
+	var err error
+	w.logsBuilder, err = logsobj.NewBuilder(cfg, w.c.scratchStore, w.builderMetrics, w.c.logger, overrides)
+	if err != nil {
+		return err
+	}
+
+	// Sort builder uses the same sort schema for now
+	w.sortBuilder, err = logsobj.NewBuilder(cfg, w.c.scratchStore, w.builderMetrics, w.c.logger, overrides)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // add appends one merged record (carrying a global stream ID), rolling to a new
 // output object at stream boundaries once the current object reaches its target
 // size, and re-basing stream IDs to 1..M within each object.
 func (w *logObjectWriter) add(ctx context.Context, rec logs.Record) error {
-	if rec.StreamID != w.curGlobalID {
-
-		if w.objRecords > 0 && w.targetObject > 0 && w.objSize >= w.targetObject {
-			if err := w.finalizeAndUpload(ctx); err != nil {
-				return err
-			}
-			w.startObject()
+	if w.logsBuilder.IsFull() && rec.SortKey != w.lastSortKey {
+		if err := w.finalizeAndUpload(ctx); err != nil {
+			return err
 		}
-		w.curGlobalID = rec.StreamID
-		w.curObjLocalID++
-		s := w.table.streams[rec.StreamID]
-		s.ID = w.curObjLocalID
-		w.sb.AppendValue(s)
-		w.objStreams++
+		err := w.startNewObject()
+		if err != nil {
+			return err
+		}
+	}
+	stream := w.table.streams[rec.StreamID]
+
+	err := w.logsBuilder.AppendRecord(w.node.Tenant, stream.Labels, rec)
+	if err != nil {
+		return err
 	}
 
-	rec.StreamID = w.curObjLocalID
-	w.lb.Append(rec)
-	w.objRecords++
-	w.objSize += logRecordSize(rec)
-
-	if w.lb.UncompressedSize() > w.targetSection {
-		if err := w.builder.Append(w.lb); err != nil {
-			return fmt.Errorf("appending logs section: %w", err)
-		}
-		w.lb.Reset()
-		w.lb.SetTenant(w.node.Tenant)
-	}
 	return nil
 }
 
 // finish flushes and uploads the last in-progress object (if any) and returns the
 // accumulated stats.
 func (w *logObjectWriter) finish(ctx context.Context) (logMergeStats, error) {
-	if w.objRecords > 0 {
+	if w.logsBuilder.GetEstimatedSize() > 0 {
 		if err := w.finalizeAndUpload(ctx); err != nil {
 			return w.stats, err
 		}
@@ -461,18 +461,23 @@ func (w *logObjectWriter) finish(ctx context.Context) (logMergeStats, error) {
 // finalizeAndUpload appends the pending sections, flushes them into one compacted
 // log object, computes its content-hash path, and uploads it to the data bucket.
 func (w *logObjectWriter) finalizeAndUpload(ctx context.Context) error {
-	if w.lb.UncompressedSize() > 0 {
-		if err := w.builder.Append(w.lb); err != nil {
-			return fmt.Errorf("appending logs section: %w", err)
-		}
-	}
-	if err := w.builder.Append(w.sb); err != nil {
-		return fmt.Errorf("appending streams section: %w", err)
+	intermediate, intermediateCloser, err := w.logsBuilder.Flush()
+	if err != nil {
+		return fmt.Errorf("flushing logs builder: %w", err)
 	}
 
-	obj, closer, err := w.builder.Flush()
+	// Enforce object-wide arbitrary sorting on top of the schema via an intermediate sort.
+	// This enables resorting into any order after schema: e.g. [schema, stream ID, timestamp ASC]
+	// This is useful when the output ordering is different from the input ordering.
+	//
+	// Differing stream orders can happen if two input objects appended streams in a different order at build time,
+	// assigning them different stream IDs that the loser merge tree cannot dedup.
+	obj, closer, err := w.sortBuilder.CopyAndSort(ctx, intermediate)
 	if err != nil {
-		return fmt.Errorf("flushing object: %w", err)
+		return errors.Join(fmt.Errorf("sorting compacted object: %w", err), intermediateCloser.Close())
+	}
+	if err := intermediateCloser.Close(); err != nil {
+		return errors.Join(fmt.Errorf("closing unsorted compacted object: %w", err), closer.Close())
 	}
 
 	pathReader, err := obj.Reader(ctx)
@@ -505,41 +510,12 @@ func (w *logObjectWriter) finalizeAndUpload(ctx context.Context) error {
 		"msg", "LogMerge: uploaded compacted log object",
 		"tenant", w.node.Tenant,
 		"path", path,
-		"object_index", w.stats.OutputObjects,
-		"streams", w.objStreams,
-		"records", w.objRecords,
 		"bytes", size,
+		"object_index", w.stats.OutputObjects,
 	)
 	w.stats.OutputObjects++
-	w.stats.OutputStreams += w.objStreams
-	w.stats.OutputRecords += w.objRecords
 	w.stats.OutputBytesCompressed += size
-	w.stats.OutputBytesUncompressed += int64(w.objSize)
 	return nil
-}
-
-// logsBuilderOptions builds the logs section options for a schema-sorted output,
-// sized from the executor's shared builder config.
-func (c *Context) logsBuilderOptions(sortSchema []string) logs.BuilderOptions {
-	return logs.BuilderOptions{
-		PageSizeHint:     int(c.indexobjCfg.TargetPageSize),
-		PageMaxRowCount:  c.indexobjCfg.MaxPageRows,
-		BufferSize:       int(c.indexobjCfg.BufferSize),
-		StripeMergeLimit: c.indexobjCfg.SectionStripeMergeLimit,
-		AppendStrategy:   logs.AppendOrdered,
-		SortOrder:        logs.SortSchemaASC,
-		SchemaLabels:     sortSchema,
-	}
-}
-
-// logRecordSize approximates a record's uncompressed footprint the same way the
-// ingest builder does: line length plus structured-metadata value lengths.
-func logRecordSize(rec logs.Record) int {
-	size := len(rec.Line)
-	rec.Metadata.Range(func(l labels.Label) {
-		size += len(l.Value)
-	})
-	return size
 }
 
 // uploadObject streams a built object to the given bucket and returns its encoded

--- a/pkg/engine/internal/executor/log_merge_test.go
+++ b/pkg/engine/internal/executor/log_merge_test.go
@@ -363,9 +363,9 @@ func TestDoLogObjectMerge_MergesAndSplits(t *testing.T) {
 	tb := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
 	tc := time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC)
 
-	// Overlapping label sets across objects (a,b,c / b,c,d / c,d,e). With the
-	// k-way merge (no cross-object stream dedup) every source stream becomes its
-	// own output stream: 9 source streams -> 9 output streams.
+	// Overlapping label sets across objects (a,b,c / b,c,d / c,d,e). The
+	// logsobj output builder deduplicates the 9 source stream occurrences into
+	// 5 logical streams.
 	buildSourceLogObject(t, dataBucket, "objA", sortSchema, map[string][]testStream{
 		tenant: {
 			{labels: `{app="a"}`, entries: wideLinesAt(ta, 4)},
@@ -407,11 +407,9 @@ func TestDoLogObjectMerge_MergesAndSplits(t *testing.T) {
 	objs := readCompactedObjectsFromIndex(ctx, t, dataBucket, indexBucket, indexPath, tenant)
 	require.GreaterOrEqual(t, len(objs), 2, "output must be split into multiple objects")
 
-	totalStreams := 0
 	totalRecords := 0
 	distinctApps := make(map[string]bool)
 	for objIdx, o := range objs {
-		totalStreams += len(o.streamApp)
 		totalRecords += len(o.records)
 		for _, app := range o.streamApp {
 			distinctApps[app] = true
@@ -430,12 +428,73 @@ func TestDoLogObjectMerge_MergesAndSplits(t *testing.T) {
 		}
 	}
 
-	// No cross-object dedup: 9 source streams => 9 output streams.
-	require.Equal(t, 9, totalStreams)
+	// Cross-object dedup: 9 source stream occurrences => 5 logical streams.
+	require.Equal(t, 5, len(distinctApps))
 	// The 5 distinct label sets are all present.
 	require.Equal(t, map[string]bool{"a": true, "b": true, "c": true, "d": true, "e": true}, distinctApps)
 	// 9 stream-appends x 4 entries = 36 records.
 	require.Equal(t, 36, totalRecords)
+}
+
+func TestDoLogObjectMerge_DeduplicatesConflictingSourceStreamOrder(t *testing.T) {
+	ctx := context.Background()
+	dataBucket := objstore.NewInMemBucket()
+	indexBucket := objstore.NewInMemBucket()
+
+	const tenant = "T"
+	sortSchema := []string{"label:app"}
+	early := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	late := early.Add(time.Hour)
+
+	// Both streams have the same schema key, but their local stream ID ordering is
+	// different between objects. The loser tree preserves those source-local
+	// orders; the output CopyAndSort pass must restore ordering after logsobj
+	// deduplicates the repeated full-label streams.
+	buildSourceLogObject(t, dataBucket, "objA", sortSchema, map[string][]testStream{
+		tenant: {
+			{labels: `{app="a",instance="1"}`, entries: linesAt(early, 1)},
+			{labels: `{app="a",instance="2"}`, entries: linesAt(early.Add(time.Second), 1)},
+		},
+	})
+	buildSourceLogObject(t, dataBucket, "objB", sortSchema, map[string][]testStream{
+		tenant: {
+			{labels: `{app="a",instance="2"}`, entries: linesAt(late, 1)},
+			{labels: `{app="a",instance="1"}`, entries: linesAt(late.Add(time.Second), 1)},
+		},
+	})
+
+	c := newTestExecutorContext(t, indexBucket)
+	c.dataBucket = dataBucket
+	node := &physical.LogMerge{
+		Tenant:     tenant,
+		SortSchema: sortSchema,
+		Runs: []*compactionv2pb.RunRef{
+			{Sections: []*compactionv2pb.SectionRef{{ObjectPath: "objA"}, {ObjectPath: "objB"}}},
+		},
+	}
+
+	arts, err := c.doLogObjectMerge(ctx, node)
+	require.NoError(t, err)
+	require.Len(t, arts, 1)
+
+	objs := readCompactedObjectsFromIndex(ctx, t, dataBucket, indexBucket, arts[0].Path, tenant)
+	require.Len(t, objs, 1)
+	require.Len(t, objs[0].streamApp, 2, "two full-label streams must remain after cross-object deduplication")
+	require.Len(t, objs[0].records, 4)
+
+	counts := make(map[int64]int)
+	for i, record := range objs[0].records {
+		counts[record.streamID]++
+		if i == 0 {
+			continue
+		}
+		prev := objs[0].records[i-1]
+		require.LessOrEqual(t, prev.streamID, record.streamID)
+		if prev.streamID == record.streamID {
+			require.False(t, record.ts.After(prev.ts), "timestamps must be descending within the deduplicated stream")
+		}
+	}
+	require.Equal(t, map[int64]int{1: 2, 2: 2}, counts)
 }
 
 func TestDoLogObjectMerge_WritesIndexOverCompactedObjects(t *testing.T) {

--- a/pkg/engine/internal/executor/log_merge_test.go
+++ b/pkg/engine/internal/executor/log_merge_test.go
@@ -263,8 +263,9 @@ type outputRecord struct {
 // extracts the embedded compacted log object paths, and loads each object from
 // the data bucket. Returns the streamID->app map and records for each object.
 func readCompactedObjectsFromIndex(ctx context.Context, t *testing.T, dataBucket objstore.Bucket, indexBucket objstore.Bucket, indexPath, tenant string) []struct {
-	streamApp map[int64]string
-	records   []outputRecord
+	streamApp    map[int64]string
+	records      []outputRecord
+	streamLabels []string
 } {
 	t.Helper()
 
@@ -304,8 +305,9 @@ func readCompactedObjectsFromIndex(ctx context.Context, t *testing.T, dataBucket
 
 	// Now load each compacted log object from the data bucket
 	var out []struct {
-		streamApp map[int64]string
-		records   []outputRecord
+		streamApp    map[int64]string
+		records      []outputRecord
+		streamLabels []string
 	}
 
 	for _, logPath := range logObjectPaths {
@@ -313,6 +315,7 @@ func readCompactedObjectsFromIndex(ctx context.Context, t *testing.T, dataBucket
 		require.NoError(t, err, "compacted log object must exist at %s", logPath)
 
 		streamApp := make(map[int64]string)
+		var streamLabels []string
 		for _, sec := range logObj.Sections().Filter(streams.CheckSection) {
 			if sec.Tenant != tenant {
 				continue
@@ -322,6 +325,7 @@ func readCompactedObjectsFromIndex(ctx context.Context, t *testing.T, dataBucket
 			for res := range streams.IterSection(ctx, ss) {
 				s, err := res.Value()
 				require.NoError(t, err)
+				streamLabels = append(streamLabels, s.Labels.String())
 				streamApp[s.ID] = s.Labels.Get("app")
 			}
 		}
@@ -345,9 +349,10 @@ func readCompactedObjectsFromIndex(ctx context.Context, t *testing.T, dataBucket
 		}
 
 		out = append(out, struct {
-			streamApp map[int64]string
-			records   []outputRecord
-		}{streamApp: streamApp, records: records})
+			streamApp    map[int64]string
+			records      []outputRecord
+			streamLabels []string
+		}{streamApp: streamApp, records: records, streamLabels: streamLabels})
 	}
 	return out
 }
@@ -409,10 +414,14 @@ func TestDoLogObjectMerge_MergesAndSplits(t *testing.T) {
 
 	totalRecords := 0
 	distinctApps := make(map[string]bool)
+	uniqueStreams := map[string]struct{}{}
 	for objIdx, o := range objs {
 		totalRecords += len(o.records)
 		for _, app := range o.streamApp {
 			distinctApps[app] = true
+		}
+		for _, labels := range o.streamLabels {
+			uniqueStreams[labels] = struct{}{}
 		}
 
 		// Each object is schema-sorted by [app ASC, streamID ASC, timestamp DESC].
@@ -429,7 +438,7 @@ func TestDoLogObjectMerge_MergesAndSplits(t *testing.T) {
 	}
 
 	// Cross-object dedup: 9 source stream occurrences => 5 logical streams.
-	require.Equal(t, 5, len(distinctApps))
+	require.Equal(t, 5, len(uniqueStreams))
 	// The 5 distinct label sets are all present.
 	require.Equal(t, map[string]bool{"a": true, "b": true, "c": true, "d": true, "e": true}, distinctApps)
 	// 9 stream-appends x 4 entries = 36 records.

--- a/pkg/engine/internal/executor/log_merge_test.go
+++ b/pkg/engine/internal/executor/log_merge_test.go
@@ -263,9 +263,8 @@ type outputRecord struct {
 // extracts the embedded compacted log object paths, and loads each object from
 // the data bucket. Returns the streamID->app map and records for each object.
 func readCompactedObjectsFromIndex(ctx context.Context, t *testing.T, dataBucket objstore.Bucket, indexBucket objstore.Bucket, indexPath, tenant string) []struct {
-	streamApp    map[int64]string
-	records      []outputRecord
-	streamLabels []string
+	streamApp map[int64]string
+	records   []outputRecord
 } {
 	t.Helper()
 
@@ -305,9 +304,8 @@ func readCompactedObjectsFromIndex(ctx context.Context, t *testing.T, dataBucket
 
 	// Now load each compacted log object from the data bucket
 	var out []struct {
-		streamApp    map[int64]string
-		records      []outputRecord
-		streamLabels []string
+		streamApp map[int64]string
+		records   []outputRecord
 	}
 
 	for _, logPath := range logObjectPaths {
@@ -315,7 +313,6 @@ func readCompactedObjectsFromIndex(ctx context.Context, t *testing.T, dataBucket
 		require.NoError(t, err, "compacted log object must exist at %s", logPath)
 
 		streamApp := make(map[int64]string)
-		var streamLabels []string
 		for _, sec := range logObj.Sections().Filter(streams.CheckSection) {
 			if sec.Tenant != tenant {
 				continue
@@ -325,7 +322,6 @@ func readCompactedObjectsFromIndex(ctx context.Context, t *testing.T, dataBucket
 			for res := range streams.IterSection(ctx, ss) {
 				s, err := res.Value()
 				require.NoError(t, err)
-				streamLabels = append(streamLabels, s.Labels.String())
 				streamApp[s.ID] = s.Labels.Get("app")
 			}
 		}
@@ -349,10 +345,9 @@ func readCompactedObjectsFromIndex(ctx context.Context, t *testing.T, dataBucket
 		}
 
 		out = append(out, struct {
-			streamApp    map[int64]string
-			records      []outputRecord
-			streamLabels []string
-		}{streamApp: streamApp, records: records, streamLabels: streamLabels})
+			streamApp map[int64]string
+			records   []outputRecord
+		}{streamApp: streamApp, records: records})
 	}
 	return out
 }
@@ -412,16 +407,14 @@ func TestDoLogObjectMerge_MergesAndSplits(t *testing.T) {
 	objs := readCompactedObjectsFromIndex(ctx, t, dataBucket, indexBucket, indexPath, tenant)
 	require.GreaterOrEqual(t, len(objs), 2, "output must be split into multiple objects")
 
+	totalStreams := 0
 	totalRecords := 0
 	distinctApps := make(map[string]bool)
-	uniqueStreams := map[string]struct{}{}
 	for objIdx, o := range objs {
 		totalRecords += len(o.records)
+		totalStreams += len(o.streamApp)
 		for _, app := range o.streamApp {
 			distinctApps[app] = true
-		}
-		for _, labels := range o.streamLabels {
-			uniqueStreams[labels] = struct{}{}
 		}
 
 		// Each object is schema-sorted by [app ASC, streamID ASC, timestamp DESC].
@@ -438,7 +431,7 @@ func TestDoLogObjectMerge_MergesAndSplits(t *testing.T) {
 	}
 
 	// Cross-object dedup: 9 source stream occurrences => 5 logical streams.
-	require.Equal(t, 5, len(uniqueStreams))
+	require.Equal(t, 5, totalStreams)
 	// The 5 distinct label sets are all present.
 	require.Equal(t, map[string]bool{"a": true, "b": true, "c": true, "d": true, "e": true}, distinctApps)
 	// 9 stream-appends x 4 entries = 36 records.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bug in the compactor where it would concatenate streams from incoming objects instead of deduplicating them.
* I chose to fix this by replacing some of the custom builder logic in the compactor with the existing logic in the logsobj builder, which already accounts for sections filling up and deduping stream entries.
* There is a CopyAndSort step when flushing an object due to the lack of a global sorting order. As a side-effect, this could be re-purposed to sort objects into different orders for tertiary attributes (e.g. timestamp ASC) as long as they comply with the top-level sort-key schema so merges are correct.
