### PR TITLE
feat(operator): Allow custom certs to be used by the passthrough gateway tenancy

### DIFF
--- a/operator/internal/manifests/gateway.go
+++ b/operator/internal/manifests/gateway.go
@@ -880,14 +880,6 @@ func configurePassGatewayServerPKI(
 		},
 	)
 
-	if tlsOptions.CA != nil {
-		gwContainer.VolumeMounts = append(gwContainer.VolumeMounts, corev1.VolumeMount{
-			Name:      serverCAName,
-			ReadOnly:  true,
-			MountPath: gatewaySigningCADir(),
-		})
-	}
-
 	p := corev1.PodSpec{
 		Containers: []corev1.Container{
 			*gwContainer,

--- a/operator/internal/manifests/gateway.go
+++ b/operator/internal/manifests/gateway.go
@@ -829,7 +829,6 @@ func configurePassGatewayServerPKI(
 		},
 	)
 
-	// Client CA
 	var clientCAVolumeSource corev1.VolumeSource
 	if clientCAs.ConfigMapName != "" {
 		clientCAVolumeSource = corev1.VolumeSource{
@@ -852,7 +851,6 @@ func configurePassGatewayServerPKI(
 		VolumeSource: clientCAVolumeSource,
 	})
 
-	// Server TLS (cert/key from tenants.gateway.tls, or default OpenShift service cert)
 	serverTLSVolumes := buildCustomTLSVolumes(tlsOptions, serverCAName)
 	gwVolumes = append(gwVolumes, serverTLSVolumes...)
 

--- a/operator/internal/manifests/gateway.go
+++ b/operator/internal/manifests/gateway.go
@@ -636,7 +636,7 @@ func configureGatewayServerPKI(
 		if stack.Tenants.Passthrough == nil || stack.Tenants.Passthrough.CA == nil {
 			return kverrors.New("client CA not provided")
 		}
-		return configurePassGatewayServerPKI(podSpec, stack.Tenants.Passthrough.CA, serviceName, upstreamCAName, upstreamClientName, minTLSVersion, ciphers)
+		return configurePassGatewayServerPKI(podSpec, stack.Tenants.Passthrough.CA, serverCAName, upstreamCAName, upstreamClientName, minTLSVersion, ciphers, tlsOptions)
 	}
 	return configureObsGatewayServerPKI(podSpec, namespace, serviceName, serverCAName, upstreamCAName, upstreamClientName, minTLSVersion, ciphers, tlsOptions)
 }
@@ -765,9 +765,10 @@ func configureObsGatewayServerPKI(
 func configurePassGatewayServerPKI(
 	podSpec *corev1.PodSpec,
 	clientCAs *lokiv1.ValueReference,
-	serviceName string,
+	serverCAName string,
 	upstreamCAName, upstreamClientName string,
 	minTLSVersion, ciphers string,
+	tlsOptions *lokiv1.TLSSpec,
 ) error {
 	var gwIndex int
 	for i, c := range podSpec.Containers {
@@ -808,14 +809,6 @@ func configurePassGatewayServerPKI(
 
 	gwVolumes = append(gwVolumes,
 		corev1.Volume{
-			Name: tlsSecretVolume,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: serviceName,
-				},
-			},
-		},
-		corev1.Volume{
 			Name: upstreamCAName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -836,6 +829,7 @@ func configurePassGatewayServerPKI(
 		},
 	)
 
+	// Client CA
 	var clientCAVolumeSource corev1.VolumeSource
 	if clientCAs.ConfigMapName != "" {
 		clientCAVolumeSource = corev1.VolumeSource{
@@ -857,6 +851,10 @@ func configurePassGatewayServerPKI(
 		Name:         clientCAVolume,
 		VolumeSource: clientCAVolumeSource,
 	})
+
+	// Server TLS (cert/key from tenants.gateway.tls, or default OpenShift service cert)
+	serverTLSVolumes := buildCustomTLSVolumes(tlsOptions, serverCAName)
+	gwVolumes = append(gwVolumes, serverTLSVolumes...)
 
 	// Add volume mounts
 	gwContainer.VolumeMounts = append(gwContainer.VolumeMounts,
@@ -881,6 +879,14 @@ func configurePassGatewayServerPKI(
 			MountPath: clientCADir,
 		},
 	)
+
+	if tlsOptions.CA != nil {
+		gwContainer.VolumeMounts = append(gwContainer.VolumeMounts, corev1.VolumeMount{
+			Name:      serverCAName,
+			ReadOnly:  true,
+			MountPath: gatewaySigningCADir(),
+		})
+	}
 
 	p := corev1.PodSpec{
 		Containers: []corev1.Container{

--- a/operator/internal/manifests/gateway_test.go
+++ b/operator/internal/manifests/gateway_test.go
@@ -2020,11 +2020,6 @@ func TestBuildGateway_PassthroughMode_WithHTTPEncryption_WithCustomTLS(t *testin
 					ReadOnly:  true,
 					MountPath: "/var/run/ca/client",
 				},
-				{
-					Name:      "abcd-gateway-ca-bundle",
-					ReadOnly:  true,
-					MountPath: "/var/run/ca/server",
-				},
 			},
 			expectedVolumes: []corev1.Volume{
 				{

--- a/operator/internal/manifests/gateway_test.go
+++ b/operator/internal/manifests/gateway_test.go
@@ -1842,3 +1842,330 @@ func TestBuildGateway_PassthroughMode_TopologySpreadConstraint(t *testing.T) {
 		},
 	})
 }
+
+func TestBuildGateway_PassthroughMode_WithHTTPEncryption_WithCustomTLS(t *testing.T) {
+	tt := []struct {
+		name                 string
+		tlsSpec              *lokiv1.TLSSpec
+		expectedArgs         []string
+		expectedVolumeMounts []corev1.VolumeMount
+		expectedVolumes      []corev1.Volume
+	}{
+		{
+			name: "custom TLS without CA",
+			tlsSpec: &lokiv1.TLSSpec{
+				Certificate: &lokiv1.ValueReference{
+					Key:           "tls.crt",
+					ConfigMapName: "my-custom-cert",
+				},
+				PrivateKey: &lokiv1.SecretReference{
+					Key:        "tls.key",
+					SecretName: "my-custom-key",
+				},
+			},
+			expectedArgs: []string{
+				"-listen-addr=:8080",
+				"-admin-addr=:8081",
+				"-loki-distributor-endpoint=https://abcd-distributor-http.efgh.svc.cluster.local:3100",
+				"-loki-query-frontend-endpoint=https://abcd-query-frontend-http.efgh.svc.cluster.local:3100",
+				"-tls-cert-file=/var/run/tls/http/server/tls.crt",
+				"-tls-key-file=/var/run/tls/http/server/tls.key",
+				"-loki-ca-file=/var/run/ca/upstream/service-ca.crt",
+				"-loki-cert-file=/var/run/tls/http/upstream/tls.crt",
+				"-loki-key-file=/var/run/tls/http/upstream/tls.key",
+				"-tls-client-auth=RequireAndVerifyClientCert",
+				"-tls-client-ca-file=/var/run/ca/client/ca.crt",
+				"-tls-min-version=",
+				"-tls-cipher-suites=",
+			},
+			expectedVolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "tls-secret",
+					ReadOnly:  true,
+					MountPath: "/var/run/tls/http/server",
+				},
+				{
+					Name:      "abcd-ca-bundle",
+					ReadOnly:  true,
+					MountPath: "/var/run/ca/upstream",
+				},
+				{
+					Name:      "abcd-gateway-client-http",
+					ReadOnly:  true,
+					MountPath: "/var/run/tls/http/upstream",
+				},
+				{
+					Name:      "client-ca",
+					ReadOnly:  true,
+					MountPath: "/var/run/ca/client",
+				},
+			},
+			expectedVolumes: []corev1.Volume{
+				{
+					Name: "abcd-ca-bundle",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							DefaultMode: &defaultConfigMapMode,
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "abcd-ca-bundle",
+							},
+						},
+					},
+				},
+				{
+					Name: "abcd-gateway-client-http",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "abcd-gateway-client-http",
+						},
+					},
+				},
+				{
+					Name: "client-ca",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							DefaultMode: &defaultConfigMapMode,
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "client-ca-bundle",
+							},
+						},
+					},
+				},
+				{
+					Name: "tls-secret",
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{
+								{
+									ConfigMap: &corev1.ConfigMapProjection{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "my-custom-cert",
+										},
+										Items: []corev1.KeyToPath{
+											{
+												Key:  "tls.crt",
+												Path: "tls.crt",
+											},
+										},
+									},
+								},
+								{
+									Secret: &corev1.SecretProjection{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "my-custom-key",
+										},
+										Items: []corev1.KeyToPath{
+											{
+												Key:  "tls.key",
+												Path: "tls.key",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "custom TLS with CA",
+			tlsSpec: &lokiv1.TLSSpec{
+				CA: &lokiv1.ValueReference{
+					Key:        "ca.crt",
+					SecretName: "my-custom-ca",
+				},
+				Certificate: &lokiv1.ValueReference{
+					Key:           "tls.crt",
+					ConfigMapName: "my-custom-cert",
+				},
+				PrivateKey: &lokiv1.SecretReference{
+					Key:        "tls.key",
+					SecretName: "my-custom-key",
+				},
+			},
+			expectedArgs: []string{
+				"-listen-addr=:8080",
+				"-admin-addr=:8081",
+				"-loki-distributor-endpoint=https://abcd-distributor-http.efgh.svc.cluster.local:3100",
+				"-loki-query-frontend-endpoint=https://abcd-query-frontend-http.efgh.svc.cluster.local:3100",
+				"-tls-cert-file=/var/run/tls/http/server/tls.crt",
+				"-tls-key-file=/var/run/tls/http/server/tls.key",
+				"-loki-ca-file=/var/run/ca/upstream/service-ca.crt",
+				"-loki-cert-file=/var/run/tls/http/upstream/tls.crt",
+				"-loki-key-file=/var/run/tls/http/upstream/tls.key",
+				"-tls-client-auth=RequireAndVerifyClientCert",
+				"-tls-client-ca-file=/var/run/ca/client/ca.crt",
+				"-tls-min-version=",
+				"-tls-cipher-suites=",
+			},
+			expectedVolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "tls-secret",
+					ReadOnly:  true,
+					MountPath: "/var/run/tls/http/server",
+				},
+				{
+					Name:      "abcd-ca-bundle",
+					ReadOnly:  true,
+					MountPath: "/var/run/ca/upstream",
+				},
+				{
+					Name:      "abcd-gateway-client-http",
+					ReadOnly:  true,
+					MountPath: "/var/run/tls/http/upstream",
+				},
+				{
+					Name:      "client-ca",
+					ReadOnly:  true,
+					MountPath: "/var/run/ca/client",
+				},
+				{
+					Name:      "abcd-gateway-ca-bundle",
+					ReadOnly:  true,
+					MountPath: "/var/run/ca/server",
+				},
+			},
+			expectedVolumes: []corev1.Volume{
+				{
+					Name: "abcd-ca-bundle",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							DefaultMode: &defaultConfigMapMode,
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "abcd-ca-bundle",
+							},
+						},
+					},
+				},
+				{
+					Name: "abcd-gateway-client-http",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "abcd-gateway-client-http",
+						},
+					},
+				},
+				{
+					Name: "client-ca",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							DefaultMode: &defaultConfigMapMode,
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "client-ca-bundle",
+							},
+						},
+					},
+				},
+				{
+					Name: "abcd-gateway-ca-bundle",
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{
+								{
+									Secret: &corev1.SecretProjection{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "my-custom-ca",
+										},
+										Items: []corev1.KeyToPath{
+											{
+												Key:  "ca.crt",
+												Path: "service-ca.crt",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "tls-secret",
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{
+								{
+									ConfigMap: &corev1.ConfigMapProjection{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "my-custom-cert",
+										},
+										Items: []corev1.KeyToPath{
+											{
+												Key:  "tls.crt",
+												Path: "tls.crt",
+											},
+										},
+									},
+								},
+								{
+									Secret: &corev1.SecretProjection{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "my-custom-key",
+										},
+										Items: []corev1.KeyToPath{
+											{
+												Key:  "tls.key",
+												Path: "tls.key",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			objs, err := BuildGateway(Options{
+				Name:      "abcd",
+				Namespace: "efgh",
+				Gates: configv1.FeatureGates{
+					LokiStackGateway: true,
+					HTTPEncryption:   true,
+				},
+				Stack: lokiv1.LokiStackSpec{
+					Template: &lokiv1.LokiTemplateSpec{
+						Gateway: &lokiv1.LokiComponentSpec{
+							Replicas: rand.Int31(),
+						},
+					},
+					Tenants: &lokiv1.TenantsSpec{
+						Mode: lokiv1.Passthrough,
+						Passthrough: &lokiv1.PassthroughTenantSpec{
+							CA: &lokiv1.ValueReference{
+								Key:           "ca.crt",
+								ConfigMapName: "client-ca-bundle",
+							},
+						},
+						Gateway: &lokiv1.GatewaySpec{
+							TLS: tc.tlsSpec,
+						},
+					},
+				},
+				Timeouts: defaultTimeoutConfig,
+			})
+
+			require.NoError(t, err)
+
+			dpl := objs[0].(*appsv1.Deployment)
+			require.NotNil(t, dpl)
+			require.Len(t, dpl.Spec.Template.Spec.Containers, 1)
+
+			c := dpl.Spec.Template.Spec.Containers[0]
+
+			require.Equal(t, tc.expectedArgs, c.Args)
+			require.Equal(t, tc.expectedVolumeMounts, c.VolumeMounts)
+			require.Equal(t, tc.expectedVolumes, dpl.Spec.Template.Spec.Volumes)
+
+			// Verify service does not have serving-certs annotation when custom TLS is provided
+			svc := objs[3].(*corev1.Service)
+			require.NotNil(t, svc)
+			_, hasServingCertAnnotation := svc.Annotations["service.beta.openshift.io/serving-cert-secret-name"]
+			require.False(t, hasServingCertAnnotation, "service should not have serving-cert annotation with custom TLS")
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, you can specify custom tls for tenants, but passthrough-gateway will always disregard that setting and use default auto-generated secrets.  There may be a case where you want to "Bring-Your-Own" cert, such that you don't have to use the server identity generated by default, so added a fix such that passthrough gateway uses the certs defined for `tenants.gateway.tls`
```
tenants:
  mode: passthrough
  passthrough:
    ca: ...
  gateway:
    tls:   <-- fix: passthrough gateway now can use the tls config defined here                     
      ca:  ...
      certificate: ...
      privateKey:  ...
```

Adds test case based off of existing `TestBuildGateway_WithHTTPEncryption_WithCustomTLS` to validate custom cert is used by passthrough gateway

Note: A volume is created for `tenants.gateway.tls.ca` but it is never used for passthrough so it is not included in the list of volumemounts. I couldn't find a flag that could consume it, so I assume it is not used.

**Which issue(s) this PR fixes**:
Fixes No issue created

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
