### PR TITLE
fix(logql): Skip empty-pattern blocker warns on misses

### DIFF
--- a/pkg/logql/blocker.go
+++ b/pkg/logql/blocker.go
@@ -58,32 +58,41 @@ func (qb *queryBlocker) isBlocked(ctx context.Context, tenant string) bool {
 		// This makes `isBlocked` safe to be called concurrently.
 		pattern := b.Pattern
 		isRegex := b.Regex
+		isEmptyPattern := pattern == ""
+		logMessage := ""
+		logOnlyIfBlocked := false
 
-		// if no pattern is given, assume we want to match all queries
-		if pattern == "" {
-			pattern = ".*"
-			isRegex = true
-		}
-
-		if strings.TrimSpace(pattern) == strings.TrimSpace(query) {
-			typesMatched, tagsMatched, blocked := qb.block(ctx, b, typ, logger)
-			level.Warn(logger).Log("msg", "query blocker matched with exact match policy", "query", query, "typesMatched", typesMatched, "tagsMatched", tagsMatched, "blocked", blocked)
-			return blocked
-		}
-
-		if isRegex {
+		if isEmptyPattern {
+			// if no pattern is given, assume we want to match all queries
+			logMessage = "query blocker matched with empty pattern policy"
+			logOnlyIfBlocked = true
+		} else if isRegex {
 			r, err := regexp.Compile(pattern)
 			if err != nil {
 				level.Error(logger).Log("msg", "query blocker regex does not compile", "pattern", pattern, "err", err)
 				continue
 			}
 
-			if r.MatchString(query) {
-				typesMatched, tagsMatched, blocked := qb.block(ctx, b, typ, logger)
-				level.Warn(logger).Log("msg", "query blocker matched with regex policy", "pattern", pattern, "query", query, "typesMatched", typesMatched, "tagsMatched", tagsMatched, "blocked", blocked)
-				return blocked
+			if !r.MatchString(query) {
+				continue // query does not match regex pattern, skip this block
 			}
+			logMessage = "query blocker matched with regex policy"
+		} else {
+			if strings.TrimSpace(pattern) != strings.TrimSpace(query) {
+				continue // query does not match exact pattern, skip this block
+			}
+			logMessage = "query blocker matched with exact match policy"
 		}
+
+		// if we get here, the query matches the pattern
+		typesMatched, tagsMatched, blocked := qb.block(ctx, b, typ, logger)
+		if !logOnlyIfBlocked || blocked {
+			level.Warn(logger).Log("msg", logMessage, "query", query, "typesMatched", typesMatched, "tagsMatched", tagsMatched, "blocked", blocked)
+		}
+
+		// the documentation says "The order of patterns is preserved, so the first matching pattern will be used." So we return after the first 
+		// matching pattern even if the block is not triggered
+		return blocked
 	}
 
 	return false

--- a/pkg/logql/blocker.go
+++ b/pkg/logql/blocker.go
@@ -64,6 +64,7 @@ func (qb *queryBlocker) isBlocked(ctx context.Context, tenant string) bool {
 
 		if isEmptyPattern {
 			// if no pattern is given, assume we want to match all queries
+			pattern = ".*"
 			logMessage = "query blocker matched with empty pattern policy"
 			logOnlyIfBlocked = true
 		} else if isRegex {
@@ -87,10 +88,10 @@ func (qb *queryBlocker) isBlocked(ctx context.Context, tenant string) bool {
 		// if we get here, the query matches the pattern
 		typesMatched, tagsMatched, blocked := qb.block(ctx, b, typ, logger)
 		if !logOnlyIfBlocked || blocked {
-			level.Warn(logger).Log("msg", logMessage, "query", query, "typesMatched", typesMatched, "tagsMatched", tagsMatched, "blocked", blocked)
+			level.Warn(logger).Log("msg", logMessage, "pattern", pattern, "query", query, "typesMatched", typesMatched, "tagsMatched", tagsMatched, "blocked", blocked)
 		}
 
-		// the documentation says "The order of patterns is preserved, so the first matching pattern will be used." So we return after the first 
+		// the documentation says "The order of patterns is preserved, so the first matching pattern will be used." So we return after the first
 		// matching pattern even if the block is not triggered
 		return blocked
 	}

--- a/pkg/logql/blocker_test.go
+++ b/pkg/logql/blocker_test.go
@@ -1,6 +1,7 @@
 package logql
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sync"
@@ -216,6 +217,70 @@ func TestEngine_BlockedQueries_ConcurrentAccess(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestEngine_BlockedQueries_EmptyPatternLogging(t *testing.T) {
+	const query = `topk(1,rate(({app=~"foo|bar"})[1m]))`
+
+	for _, test := range []struct {
+		name           string
+		blocked        *validation.BlockedQuery
+		expectWarnMsg  string
+		expectNoWarnOf string
+	}{
+		{
+			name: "omit warning when empty pattern does not match type",
+			blocked: &validation.BlockedQuery{
+				Types: []string{QueryTypeLimited},
+			},
+			expectNoWarnOf: "query blocker matched with",
+		},
+		{
+			name: "warn when empty pattern blocks query",
+			blocked: &validation.BlockedQuery{
+				Types: []string{QueryTypeMetric},
+			},
+			expectWarnMsg: "query blocker matched with empty pattern policy",
+		},
+		{
+			name: "warn when explicit catch-all does not match type",
+			blocked: &validation.BlockedQuery{
+				Pattern: ".*",
+				Regex:   true,
+				Types:   []string{QueryTypeLimited},
+			},
+			expectWarnMsg: "query blocker matched with regex policy",
+		},
+		{
+			name: "warn with exact match policy for exact pattern",
+			blocked: &validation.BlockedQuery{
+				Pattern: query,
+			},
+			expectWarnMsg: "query blocker matched with exact match policy",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			limits := &fakeLimits{
+				maxSeries:      10,
+				blockedQueries: []*validation.BlockedQuery{test.blocked},
+			}
+			eng := NewEngine(EngineOpts{}, getLocalQuerier(100000), limits, log.NewLogfmtLogger(&buf))
+
+			params, err := NewLiteralParams(query, time.Unix(0, 0), time.Unix(100000, 0), 60*time.Second, 0, logproto.FORWARD, 1000, nil, nil)
+			require.NoError(t, err)
+
+			_, _ = eng.Query(params).Exec(user.InjectOrgID(context.Background(), "fake"))
+
+			logs := buf.String()
+			if test.expectWarnMsg != "" {
+				require.Contains(t, logs, test.expectWarnMsg)
+			}
+			if test.expectNoWarnOf != "" {
+				require.NotContains(t, logs, test.expectNoWarnOf)
+			}
+		})
+	}
 }
 
 func TestEngine_ExecWithBlockedQueries_Tags(t *testing.T) {


### PR DESCRIPTION
## Summary

Empty `blocked_queries` rules (no pattern) match every query via the default `.*` behavior. Previously Loki always emitted a warn when that catch-all pattern matched, even when types/tags later decided not to block. With query splitting that produced a lot of warn noise for tag/type-scoped policies.

- Suppress the match warn for empty-pattern rules unless the query is actually blocked
- Keep warn logs for explicit exact/regex/hash near-misses and for real blocks
- Use a distinct empty-pattern log message when those rules do block
- Preserve first-matching-pattern short-circuit behavior
- Refactor the code to make the logic easier to follow (pattern check first, then block check)

## Test plan

- [x] `go test -count=1 ./pkg/logql`
- [x] New `TestEngine_BlockedQueries_EmptyPatternLogging` covers omit-on-near-miss, warn-on-block, explicit catch-all near-miss, and exact-match messages