### PR TITLE
fix(logql): Count unwrapped samples in the sharded avg_over_time denominator

### DIFF
--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -6,8 +6,11 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
 
+	"github.com/grafana/loki/v3/pkg/logql/log"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
@@ -499,6 +502,14 @@ func (m ShardMapper) mapRangeAggregationExpr(expr *syntax.RangeAggregationExpr, 
 			return m.mapSampleExpr(expr, r)
 		}
 
+		// Below this point the avg_over_time() is decomposed into a sum_over_time()
+		// divided by a count_over_time(). The count leg cannot reproduce a
+		// post filter on __error__, because only the unwrap conversion sets that
+		// label and the count_over_time() doesn't support unwrap.
+		if hasUnwrapPostFiltersOnError(expr.Left) {
+			return noOp(expr, m.shards.Resolver())
+		}
+
 		grouping := expr.Grouping
 		if grouping == nil {
 			grouping = &syntax.Grouping{Without: true}
@@ -518,7 +529,7 @@ func (m ShardMapper) mapRangeAggregationExpr(expr *syntax.RangeAggregationExpr, 
 		}
 
 		// Strip unwrap from log range
-		countOverTimeSelector, err := expr.Left.WithoutUnwrap()
+		countOverTimeSelector, err := convertUnwrapToLabelFilters(expr.Left)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -693,4 +704,59 @@ func isLiteralOrVector(e syntax.Expr) bool {
 
 func badASTMapping(got syntax.Expr) error {
 	return fmt.Errorf("bad AST mapping: expected SampleExpr, but got (%T)", got)
+}
+
+// convertUnwrapToLabelFilters returns a copy of the log range with the unwrap
+// removed and replaced by the label filters that select the same log lines.
+//
+// A line yields an unwrapped sample only when the unwrap identifier resolves to
+// a non-empty label and the post filters keep the line, so `| unwrap x | f`
+// becomes `| x != "" | f`.
+func convertUnwrapToLabelFilters(r *syntax.LogRangeExpr) (*syntax.LogRangeExpr, error) {
+	if r.Unwrap == nil {
+		return syntax.Clone(r)
+	}
+
+	// WithoutUnwrap clones the selector, and the copy is required: the stages
+	// below are appended in place, while the caller keeps the original pipeline
+	// on the sum leg of the decomposition.
+	out, err := r.WithoutUnwrap()
+	if err != nil {
+		return nil, err
+	}
+
+	stages := syntax.MultiStageExpr{
+		&syntax.LabelFilterExpr{
+			LabelFilterer: log.NewStringLabelFilter(
+				labels.MustNewMatcher(labels.MatchNotEqual, r.Unwrap.Identifier, ""),
+			),
+		},
+	}
+	for _, f := range r.Unwrap.PostFilters {
+		stages = append(stages, &syntax.LabelFilterExpr{LabelFilterer: f})
+	}
+
+	switch left := out.Left.(type) {
+	case *syntax.PipelineExpr:
+		left.MultiStages = append(left.MultiStages, stages...)
+	case *syntax.MatchersExpr:
+		out.Left = &syntax.PipelineExpr{Left: left, MultiStages: stages}
+	default:
+		return nil, fmt.Errorf("unsupported log selector type %T", out.Left)
+	}
+	return out, nil
+}
+
+func hasUnwrapPostFiltersOnError(r *syntax.LogRangeExpr) bool {
+	if r.Unwrap == nil {
+		return false
+	}
+	for _, f := range r.Unwrap.PostFilters {
+		for _, name := range f.RequiredLabelNames() {
+			if name == logqlmodel.ErrorLabel || name == logqlmodel.ErrorDetailsLabel {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/logql/shardmapper_test.go
+++ b/pkg/logql/shardmapper_test.go
@@ -394,9 +394,9 @@ func TestMappingStrings(t *testing.T) {
 				)
 				/
 				sum by (cluster) (
-					downstream<sum by (cluster) (count_over_time({job=~"myapps.*"}|="stats" | json busy="utilization" [5m])),shard=0_of_2>
+					downstream<sum by (cluster) (count_over_time({job=~"myapps.*"}|="stats" | json busy="utilization" | busy != "" [5m])),shard=0_of_2>
 					++
-					downstream<sum by (cluster) (count_over_time({job=~"myapps.*"}|="stats" | json busy="utilization" [5m])),shard=1_of_2>
+					downstream<sum by (cluster) (count_over_time({job=~"myapps.*"}|="stats" | json busy="utilization" | busy != "" [5m])),shard=1_of_2>
 				)
 			)`,
 		},
@@ -410,9 +410,9 @@ func TestMappingStrings(t *testing.T) {
 				)
 				/
 				sum without(busy) (
-					downstream<sum without(busy) (count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m])),shard=0_of_2>
+					downstream<sum without(busy) (count_over_time({job=~"myapps.*"} |="stats" | json | keep busy | busy != "" [5m])),shard=0_of_2>
 					++
-					downstream<sum without(busy) (count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m])),shard=1_of_2>
+					downstream<sum without(busy) (count_over_time({job=~"myapps.*"} |="stats" | json | keep busy | busy != "" [5m])),shard=1_of_2>
 				)
 			)`,
 		},
@@ -426,9 +426,9 @@ func TestMappingStrings(t *testing.T) {
 				)
 				/
 				sum without(foo,busy) (
-					downstream<sum without(foo,busy) (count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m])),shard=0_of_2>
+					downstream<sum without(foo,busy) (count_over_time({job=~"myapps.*"} |="stats" | json | keep busy | busy != "" [5m])),shard=0_of_2>
 					++
-					downstream<sum without(foo,busy) (count_over_time({job=~"myapps.*"} |="stats" | json | keep busy [5m])),shard=1_of_2>
+					downstream<sum without(foo,busy) (count_over_time({job=~"myapps.*"} |="stats" | json | keep busy | busy != "" [5m])),shard=1_of_2>
 				)
 			)`,
 		},
@@ -507,9 +507,9 @@ func TestMappingStrings(t *testing.T) {
 					)
 					/
 					sum without (bar) (
-						downstream<sum without (bar) (count_over_time({foo="bar"} | logfmt | drop level [5m])), shard=0_of_2>
+						downstream<sum without (bar) (count_over_time({foo="bar"} | logfmt | drop level | bar != "" [5m])), shard=0_of_2>
 						++
-						downstream<sum without (bar) (count_over_time({foo="bar"} | logfmt | drop level [5m])), shard=1_of_2>
+						downstream<sum without (bar) (count_over_time({foo="bar"} | logfmt | drop level | bar != "" [5m])), shard=1_of_2>
 					)
 				)
 			)`,
@@ -1682,8 +1682,15 @@ func TestMapping(t *testing.T) {
 								Left: &syntax.RangeAggregationExpr{
 									Operation: syntax.OpRangeTypeCount,
 									Left: &syntax.LogRangeExpr{
-										Left: &syntax.MatchersExpr{
-											Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")},
+										Left: &syntax.PipelineExpr{
+											Left: &syntax.MatchersExpr{
+												Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")},
+											},
+											MultiStages: syntax.MultiStageExpr{
+												&syntax.LabelFilterExpr{
+													LabelFilterer: log.NewStringLabelFilter(mustNewMatcher(labels.MatchNotEqual, "bytes", "")),
+												},
+											},
 										},
 										Interval: 5 * time.Minute,
 									},
@@ -1704,8 +1711,15 @@ func TestMapping(t *testing.T) {
 									Left: &syntax.RangeAggregationExpr{
 										Operation: syntax.OpRangeTypeCount,
 										Left: &syntax.LogRangeExpr{
-											Left: &syntax.MatchersExpr{
-												Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")},
+											Left: &syntax.PipelineExpr{
+												Left: &syntax.MatchersExpr{
+													Mts: []*labels.Matcher{mustNewMatcher(labels.MatchEqual, "foo", "bar")},
+												},
+												MultiStages: syntax.MultiStageExpr{
+													&syntax.LabelFilterExpr{
+														LabelFilterer: log.NewStringLabelFilter(mustNewMatcher(labels.MatchNotEqual, "bytes", "")),
+													},
+												},
 											},
 											Interval: 5 * time.Minute,
 										},


### PR DESCRIPTION
**What this PR does / why we need it**:

With sharding enabled, a grouped `avg_over_time(... | unwrap x)` returns a value that is too low whenever a log line yields no unwrapped sample. The shard mapper decomposes the average into a sum leg over samples divided by a count leg over lines, and the count leg counts lines the numerator never saw.

A line yields an unwrapped sample exactly when the pipeline keeps it, the identifier resolves to a non-empty label, and the post filters keep it. All three are expressible as pipeline stages, so the count leg becomes `count_over_time(E | x != "" | f [r])`. The `| x != ""` filter resolves the value through the same `LabelsBuilder.Get()` call the sample extractor makes, so this matches the unsharded result rather than approximating it. The emitted plan stays ordinary LogQL, so no querier-side changes and no rollout gate are needed.

This also fixes two related divergences: `WithoutUnwrap()` dropped the unwrap's post filters entirely, and an unwrap on a stream label absent from some streams was counted as if present.

One shape is left unsharded instead: a post filter on `__error__`. Only the unwrap conversion sets that label, so a pipeline filter cannot reproduce it.

**Which issue(s) this PR fixes**:
Fixes #23890

**Special notes for your reviewer**:

More tests have been added in https://github.com/grafana/loki/pull/23909, where I've also cherry-picked the changes in this PR. I have a chicken-egg problem: logqltest on query-frontend fail without with PR, but logqltest on query-frontend is not yet supported in `main` (because they fail), so that's why the the PRs are related together.

The issue describes two other options and why this one was preferred over them.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
