### PR TITLE
fix: deduplicate log lines split across stream shards

### DIFF
--- a/docs/sources/operations/automatic-stream-sharding.md
+++ b/docs/sources/operations/automatic-stream-sharding.md
@@ -70,6 +70,10 @@ Because automatic stream sharding is reactive and relies on successive calls to 
 always somewhat behind. As a result, the actual size of sharded streams will always be higher than the `desired_rate`.
 In practice, this is still sufficient to keep log producers from being rate limited by per-stream rate limits.
 
+At query time the shards of a stream are treated as a single stream again: the `__stream_shard__` and `__time_shard__`
+labels are not part of a stream's query-time identity and do not appear in query results, and identical log lines that a
+client retry sent to more than one shard are deduplicated.
+
 ## Automatic stream sharding metrics
 
 Use these metrics to help tune Loki so that it is sharding streams aggressively enough to avoid the per-stream rate

--- a/pkg/chunkenc/dedup_shards_test.go
+++ b/pkg/chunkenc/dedup_shards_test.go
@@ -1,0 +1,103 @@
+package chunkenc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/compression"
+	"github.com/grafana/loki/v3/pkg/iter"
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logql/log"
+)
+
+// TestMergeDedupsEntriesAcrossStreamShards reproduces a line that automatic
+// stream sharding split across two shards: the same line lands in two streams
+// that differ only in __stream_shard__. Merging the shard iterators must return
+// the line once for log queries and its sample once for metric queries.
+func TestMergeDedupsEntriesAcrossStreamShards(t *testing.T) {
+	shard0 := labels.FromStrings("__stream_shard__", "0", "app", "foo")
+	shard1 := labels.FromStrings("__stream_shard__", "1", "app", "foo")
+
+	newChunk := func(t *testing.T) *MemChunk {
+		c := NewMemChunk(ChunkFormatV4, compression.GZIP, DefaultTestHeadBlockFmt, testBlockSize, testTargetSize)
+		dup, err := c.Append(logprotoEntry(1e9, "duplicate line"))
+		require.NoError(t, err)
+		require.False(t, dup)
+		return c
+	}
+	c0, c1 := newChunk(t), newChunk(t)
+	from, through := time.Unix(0, 0), time.Unix(0, 2e9)
+
+	t.Run("logs", func(t *testing.T) {
+		pipeline := log.NewNoopPipeline()
+		it0, err := c0.Iterator(context.Background(), from, through, logproto.FORWARD, pipeline.ForStream(shard0))
+		require.NoError(t, err)
+		it1, err := c1.Iterator(context.Background(), from, through, logproto.FORWARD, pipeline.ForStream(shard1))
+		require.NoError(t, err)
+
+		merged := iter.NewMergeEntryIterator(context.Background(), []iter.EntryIterator{it0, it1}, logproto.FORWARD)
+		var lines []string
+		for merged.Next() {
+			lines = append(lines, merged.At().Line)
+		}
+		require.NoError(t, merged.Err())
+		require.Equal(t, []string{"duplicate line"}, lines)
+	})
+
+	t.Run("samples", func(t *testing.T) {
+		extractor, err := log.NewLineSampleExtractor(log.CountExtractor, nil, nil, false, false)
+		require.NoError(t, err)
+
+		merged := iter.NewMergeSampleIterator(context.Background(), []iter.SampleIterator{
+			c0.SampleIterator(context.Background(), from, through, extractor.ForStream(shard0)),
+			c1.SampleIterator(context.Background(), from, through, extractor.ForStream(shard1)),
+		})
+		var samples int
+		for merged.Next() {
+			samples++
+		}
+		require.NoError(t, merged.Err())
+		require.Equal(t, 1, samples, "the duplicate sample must be dropped across shards")
+	})
+
+	// When only the store (or only the ingesters) is queried, the shards arrive
+	// sort-merged within a single iterator, and the merge iterator has to
+	// deduplicate them there.
+	t.Run("logs from a single sorted iterator", func(t *testing.T) {
+		pipeline := log.NewNoopPipeline()
+		it0, err := c0.Iterator(context.Background(), from, through, logproto.FORWARD, pipeline.ForStream(shard0))
+		require.NoError(t, err)
+		it1, err := c1.Iterator(context.Background(), from, through, logproto.FORWARD, pipeline.ForStream(shard1))
+		require.NoError(t, err)
+		sorted := iter.NewSortEntryIterator([]iter.EntryIterator{it0, it1}, logproto.FORWARD)
+
+		merged := iter.NewMergeEntryIterator(context.Background(), []iter.EntryIterator{sorted}, logproto.FORWARD)
+		var entries int
+		for merged.Next() {
+			entries++
+		}
+		require.NoError(t, merged.Err())
+		require.Equal(t, 1, entries)
+	})
+
+	t.Run("samples from a single sorted iterator", func(t *testing.T) {
+		extractor, err := log.NewLineSampleExtractor(log.CountExtractor, nil, nil, false, false)
+		require.NoError(t, err)
+		sorted := iter.NewSortSampleIterator([]iter.SampleIterator{
+			c0.SampleIterator(context.Background(), from, through, extractor.ForStream(shard0)),
+			c1.SampleIterator(context.Background(), from, through, extractor.ForStream(shard1)),
+		})
+
+		merged := iter.NewMergeSampleIterator(context.Background(), []iter.SampleIterator{sorted})
+		var samples int
+		for merged.Next() {
+			samples++
+		}
+		require.NoError(t, merged.Err())
+		require.Equal(t, 1, samples)
+	})
+}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -67,7 +67,7 @@ const (
 
 	ringAutoForgetUnhealthyPeriods = 2
 
-	timeShardLabel = "__time_shard__"
+	timeShardLabel = constants.TimeShardLabel
 )
 
 var (

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -55,7 +55,7 @@ import (
 const (
 	// ShardLbName is the internal label to be used by Loki when dividing a stream into smaller pieces.
 	// Possible values are only increasing integers starting from 0.
-	ShardLbName        = "__stream_shard__"
+	ShardLbName        = constants.StreamShardLabel
 	ShardLbPlaceholder = "__placeholder__"
 
 	queryBatchSize       = 128

--- a/pkg/ingester/tailer_test.go
+++ b/pkg/ingester/tailer_test.go
@@ -312,7 +312,8 @@ func Test_StructuredMetadata(t *testing.T) {
 			expectedResponses: []logproto.TailResponse{
 				{
 					Stream: &logproto.Stream{
-						Labels: labels.NewBuilder(lbs).Set("foo", "1").Labels().String(),
+						// The pipeline drops the shard label from a stream's query-time identity.
+						Labels: labels.NewBuilder(lbs).Del(ShardLbName).Set("foo", "1").Labels().String(),
 						Entries: []logproto.Entry{
 							{
 								Timestamp:          time.Unix(0, 1),
@@ -326,7 +327,7 @@ func Test_StructuredMetadata(t *testing.T) {
 				},
 				{
 					Stream: &logproto.Stream{
-						Labels: labels.NewBuilder(lbs).Set("traceID", "123").Set("foo", "2").Labels().String(),
+						Labels: labels.NewBuilder(lbs).Del(ShardLbName).Set("traceID", "123").Set("foo", "2").Labels().String(),
 						Entries: []logproto.Entry{
 							{
 								Timestamp:          time.Unix(0, 2),

--- a/pkg/iter/entry_iterator.go
+++ b/pkg/iter/entry_iterator.go
@@ -75,9 +75,8 @@ type mergeEntryIterator struct {
 	errs      []error
 }
 
-// NewMergeEntryIterator returns a new iterator which uses a looser tree to merge together entries for multiple iterators and deduplicate entries if any.
-// The iterator only order and merge entries across given `is` iterators, it does not merge entries within individual iterator.
-// This means using this iterator with a single iterator will result in the same result as the input iterator.
+// NewMergeEntryIterator returns a new iterator which uses a loser tree to merge together entries for multiple iterators and deduplicate entries if any.
+// Equal entries that share a timestamp and stream hash are dropped, including within a single iterator, such as lines that automatic stream sharding sent to more than one shard.
 // If you don't need to deduplicate entries, use `NewSortEntryIterator` instead.
 func NewMergeEntryIterator(ctx context.Context, is []EntryIterator, direction logproto.Direction) MergeEntryIterator {
 	maxVal, less := treeLess(direction)

--- a/pkg/iter/merge_dedup_test.go
+++ b/pkg/iter/merge_dedup_test.go
@@ -1,0 +1,93 @@
+package iter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+// Lines that automatic stream sharding sent to more than one shard arrive
+// within a single iterator when only the store or only the ingesters are
+// queried, because those paths sort-merge the shard streams before the merge
+// iterator runs. The merge iterators must deduplicate them there too.
+
+func TestMergeEntryIteratorDedupesWithinSingleIterator(t *testing.T) {
+	stream := func(entries ...logproto.Entry) EntryIterator {
+		return NewStreamIterator(logproto.Stream{Labels: `{app="foo"}`, Hash: 42, Entries: entries})
+	}
+	dup := logproto.Entry{Timestamp: time.Unix(0, 1), Line: "dup"}
+	other := logproto.Entry{Timestamp: time.Unix(0, 1), Line: "other"}
+	later := logproto.Entry{Timestamp: time.Unix(0, 2), Line: "later"}
+
+	for _, tc := range []struct {
+		name    string
+		entries []logproto.Entry
+		want    []string
+	}{
+		{"adjacent duplicate", []logproto.Entry{dup, dup, later}, []string{"dup", "later"}},
+		{"duplicate split by another line at the same timestamp", []logproto.Entry{dup, other, dup}, []string{"dup", "other"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			it := NewMergeEntryIterator(context.Background(), []EntryIterator{stream(tc.entries...)}, logproto.FORWARD)
+			var got []string
+			for it.Next() {
+				got = append(got, it.At().Line)
+			}
+			require.NoError(t, it.Err())
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMergeSampleIteratorDedupesWithinSingleIterator(t *testing.T) {
+	series := func(samples ...logproto.Sample) SampleIterator {
+		return NewSeriesIterator(logproto.Series{Labels: `{app="foo"}`, StreamHash: 42, Samples: samples})
+	}
+	dup := logproto.Sample{Timestamp: 1, Value: 1, Hash: 99}
+	other := logproto.Sample{Timestamp: 1, Value: 1, Hash: 77}
+	later := logproto.Sample{Timestamp: 2, Value: 1, Hash: 55}
+
+	for _, tc := range []struct {
+		name string
+		its  []SampleIterator
+		want []uint64
+	}{
+		{"adjacent duplicate", []SampleIterator{series(dup, dup, later)}, []uint64{99, 55}},
+		{"duplicate split by another sample at the same timestamp", []SampleIterator{series(dup, other, dup)}, []uint64{99, 77}},
+		// A zero hash means the duplicate state is unknown, so nothing is dropped.
+		{"zero hash is not deduplicated", []SampleIterator{series(
+			logproto.Sample{Timestamp: 1, Value: 1, Hash: 0},
+			logproto.Sample{Timestamp: 1, Value: 1, Hash: 0},
+		)}, []uint64{0, 0}},
+		// Once all but one iterator are exhausted, the merge drains the last one
+		// through a fast path which must keep deduplicating.
+		{"duplicates while draining the last iterator", []SampleIterator{
+			series(dup),
+			series(dup, later, later),
+		}, []uint64{99, 55}},
+		// A duplicate inside one iterator must also be dropped while other
+		// sources are still active, not only against the other iterators.
+		{"within-iterator duplicate while another source is active", []SampleIterator{
+			series(dup, dup),
+			series(dup),
+		}, []uint64{99}},
+		{"within-iterator duplicate next to a distinct sample while another source is active", []SampleIterator{
+			series(dup, other, dup),
+			series(dup),
+		}, []uint64{99, 77}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			it := NewMergeSampleIterator(context.Background(), tc.its)
+			var got []uint64
+			for it.Next() {
+				got = append(got, it.At().Hash)
+			}
+			require.NoError(t, it.Err())
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/iter/sample_iterator.go
+++ b/pkg/iter/sample_iterator.go
@@ -165,8 +165,7 @@ type mergeSampleIterator struct {
 }
 
 // NewMergeSampleIterator returns a new iterator which uses a heap to merge together samples for multiple iterators and deduplicate if any.
-// The iterator only order and merge entries across given `is` iterators, it does not merge entries within individual iterator.
-// This means using this iterator with a single iterator will result in the same result as the input iterator.
+// Samples that share a timestamp, stream hash and sample hash are dropped, including within a single iterator, such as lines that automatic stream sharding sent to more than one shard.
 // If you don't need to deduplicate sample, use `NewSortSampleIterator` instead.
 func NewMergeSampleIterator(ctx context.Context, is []SampleIterator) SampleIterator {
 	h := SampleIteratorHeap{
@@ -229,14 +228,46 @@ func (i *mergeSampleIterator) Next() bool {
 		return false
 	}
 
-	// shortcut for the last iterator.
+	// Shortcut for the last iterator: no heap operations are needed, but
+	// duplicates that share a timestamp, stream hash and sample hash, such as
+	// lines that automatic stream sharding sent to more than one shard, must
+	// still be dropped.
 	if i.heap.Len() == 1 {
-		i.curr.Sample = i.heap.Peek().At()
-		i.curr.labels = i.heap.Peek().Labels()
-		i.curr.streamHash = i.heap.Peek().StreamHash()
-		if !i.heap.Peek().Next() {
-			i.heap.Pop()
+		it := i.heap.Peek()
+		i.buffer = append(i.buffer, sampleWithLabels{
+			Sample:     it.At(),
+			labels:     it.Labels(),
+			streamHash: it.StreamHash(),
+		})
+		for {
+			if !it.Next() {
+				i.heap.Pop()
+				break
+			}
+			sample := it.At()
+			if it.StreamHash() != i.buffer[0].streamHash ||
+				sample.Timestamp != i.buffer[0].Timestamp {
+				break
+			}
+			var dupe bool
+			if sample.Hash != 0 {
+				for _, t := range i.buffer {
+					if t.Hash == sample.Hash {
+						i.stats.AddDuplicates(1)
+						dupe = true
+						break
+					}
+				}
+			}
+			if !dupe {
+				i.buffer = append(i.buffer, sampleWithLabels{
+					Sample:     sample,
+					labels:     it.Labels(),
+					streamHash: it.StreamHash(),
+				})
+			}
 		}
+		i.nextFromBuffer()
 		return true
 	}
 
@@ -252,10 +283,9 @@ Outer:
 			break
 		}
 		heap.Pop(i.heap)
-		previous := i.buffer
 		var dupe bool
 		if sample.Hash != 0 {
-			for _, t := range previous {
+			for _, t := range i.buffer {
 				if t.Hash == sample.Hash {
 					i.stats.AddDuplicates(1)
 					dupe = true
@@ -280,8 +310,11 @@ Outer:
 				sample.Timestamp != i.buffer[0].Timestamp {
 				break
 			}
+			// Scan the whole buffer, not only the samples collected from the
+			// other iterators: shards of one stream arrive sort-merged within a
+			// single iterator, so a duplicate can follow its original here.
 			if sample.Hash != 0 {
-				for _, t := range previous {
+				for _, t := range i.buffer {
 					if t.Hash == sample.Hash {
 						i.stats.AddDuplicates(1)
 						continue inner

--- a/pkg/logql/log/metrics_extraction.go
+++ b/pkg/logql/log/metrics_extraction.go
@@ -10,6 +10,8 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/dustin/go-humanize"
+
+	"github.com/grafana/loki/v3/pkg/util"
 )
 
 const (
@@ -75,6 +77,8 @@ func NewLineSampleExtractor(ex LineExtractor, stages []Stage, groups []string, w
 }
 
 func (l *lineSampleExtractor) ForStream(labels labels.Labels) StreamSampleExtractor {
+	// See noopPipeline.ForStream: shards of one stream share one identity.
+	labels = util.LabelsWithoutStreamShards(labels)
 	hash := l.baseBuilder.Hash(labels)
 	if res, ok := l.streamExtractors[hash]; ok {
 		return res
@@ -186,6 +190,8 @@ func (l *labelSampleExtractor) ReferencedStructuredMetadata() bool {
 }
 
 func (l *labelSampleExtractor) ForStream(labels labels.Labels) StreamSampleExtractor {
+	// See noopPipeline.ForStream: shards of one stream share one identity.
+	labels = util.LabelsWithoutStreamShards(labels)
 	hash := l.baseBuilder.Hash(labels)
 	if res, ok := l.streamExtractors[hash]; ok {
 		return res

--- a/pkg/logql/log/pipeline.go
+++ b/pkg/logql/log/pipeline.go
@@ -2,10 +2,11 @@ package log
 
 import (
 	"context"
+	"unsafe"
 
 	"github.com/prometheus/prometheus/model/labels"
 
-	"unsafe"
+	"github.com/grafana/loki/v3/pkg/util"
 )
 
 // NoopStage is a stage that doesn't process a log line.
@@ -62,6 +63,10 @@ type noopPipeline struct {
 }
 
 func (n *noopPipeline) ForStream(labels labels.Labels) StreamPipeline {
+	// Drop the labels that automatic stream sharding added, so that shards of
+	// one stream share a single query-time identity (hash and base labels) and
+	// their duplicate lines can be deduplicated.
+	labels = util.LabelsWithoutStreamShards(labels)
 	h := n.baseBuilder.Hash(labels)
 	if cached, ok := n.cache[h]; ok {
 		return cached
@@ -179,6 +184,8 @@ func NewStreamPipeline(stages []Stage, labelsBuilder *LabelsBuilder) StreamPipel
 }
 
 func (p *pipeline) ForStream(labels labels.Labels) StreamPipeline {
+	// See noopPipeline.ForStream: shards of one stream share one identity.
+	labels = util.LabelsWithoutStreamShards(labels)
 	hash := p.baseBuilder.Hash(labels)
 	if res, ok := p.streamPipelines[hash]; ok {
 		return res

--- a/pkg/logql/log/pipeline_dedup_test.go
+++ b/pkg/logql/log/pipeline_dedup_test.go
@@ -1,0 +1,120 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+// TestForStreamIgnoresStreamShardLabels verifies that streams which automatic
+// stream sharding split across shards (via __stream_shard__ and __time_shard__)
+// share a single query-time identity: one stream hash and one set of base
+// labels, regardless of which shard is seen first. Streams that differ in a
+// real label, or in a reserved label that identifies a distinct stream (such as
+// __aggregated_metric__ or __pattern__), must keep distinct hashes.
+func TestForStreamIgnoresStreamShardLabels(t *testing.T) {
+	base := labels.FromStrings("app", "foo", "namespace", "prod")
+	streamShard0 := labels.FromStrings("__stream_shard__", "0", "app", "foo", "namespace", "prod")
+	streamShard1 := labels.FromStrings("__stream_shard__", "1", "app", "foo", "namespace", "prod")
+	timeShard := labels.FromStrings("__stream_shard__", "1", "__time_shard__", "5", "app", "foo", "namespace", "prod")
+	different := labels.FromStrings("app", "bar", "namespace", "prod")
+	aggregated := labels.FromStrings("__aggregated_metric__", "svc", "app", "foo", "namespace", "prod")
+	pattern := labels.FromStrings("__pattern__", "level=<_>", "app", "foo", "namespace", "prod")
+
+	t.Run("pipelines", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			p    Pipeline
+		}{
+			{"noop", NewNoopPipeline()},
+			{"stages", NewPipeline([]Stage{NoopStage})},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				hash := func(ls labels.Labels) uint64 { return tc.p.ForStream(ls).BaseLabels().Hash() }
+
+				require.Equal(t, hash(base), hash(streamShard0), "a sharded stream must hash like its unsharded form")
+				require.Equal(t, hash(streamShard0), hash(streamShard1), "shards of one stream must share a hash")
+				require.Equal(t, hash(streamShard0), hash(timeShard), "time-sharding must not change the hash either")
+
+				require.NotEqual(t, hash(base), hash(different), "genuinely different streams must still differ")
+				require.NotEqual(t, hash(base), hash(aggregated), "__aggregated_metric__ identifies a distinct stream; it must not be treated as a shard label")
+				require.NotEqual(t, hash(base), hash(pattern), "__pattern__ identifies a distinct stream; it must not be treated as a shard label")
+			})
+		}
+	})
+
+	t.Run("sample extractors", func(t *testing.T) {
+		lineEx, err := NewLineSampleExtractor(CountExtractor, nil, nil, false, false)
+		require.NoError(t, err)
+		labelEx, err := LabelExtractorWithStages("foo", ConvertFloat, nil, false, false, nil, NoopStage)
+		require.NoError(t, err)
+
+		for _, tc := range []struct {
+			name string
+			ex   SampleExtractor
+		}{
+			{"line", lineEx},
+			{"label", labelEx},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				hash := func(ls labels.Labels) uint64 { return tc.ex.ForStream(ls).BaseLabels().Hash() }
+
+				require.Equal(t, hash(base), hash(streamShard0), "a sharded stream must hash like its unsharded form")
+				require.Equal(t, hash(streamShard0), hash(streamShard1), "shards of one stream must share a hash")
+				require.Equal(t, hash(streamShard0), hash(timeShard), "time-sharding must not change the hash either")
+
+				require.NotEqual(t, hash(base), hash(different), "genuinely different streams must still differ")
+				require.NotEqual(t, hash(base), hash(aggregated), "__aggregated_metric__ identifies a distinct stream; it must not be treated as a shard label")
+			})
+		}
+	})
+
+	// A fresh pipeline whose first stream is a shard must produce the unsharded
+	// base labels, not the shard's own labels, so the identity does not depend
+	// on which shard is seen first.
+	t.Run("base labels are the unsharded form regardless of order", func(t *testing.T) {
+		sp1 := NewNoopPipeline().ForStream(streamShard1)
+		require.Equal(t, base.String(), sp1.BaseLabels().String())
+
+		sp0 := NewNoopPipeline().ForStream(streamShard0)
+		require.Equal(t, base.String(), sp0.BaseLabels().String())
+
+		// Result labels feed the streams returned to clients and the line hash
+		// that deduplicates metric samples, so separate queriers seeing
+		// different shards of a stream must produce identical result labels.
+		_, res0, ok := sp0.ProcessString(0, "line", labels.EmptyLabels())
+		require.True(t, ok)
+		_, res1, ok := sp1.ProcessString(0, "line", labels.EmptyLabels())
+		require.True(t, ok)
+		require.Equal(t, res0.String(), res1.String())
+	})
+}
+
+// BenchmarkForStreamShardStrip reports the per-ForStream cost of dropping the
+// shard labels. The unsharded case (the common one) only checks for the two
+// labels; the sharded case additionally rebuilds the label set without them.
+func BenchmarkForStreamShardStrip(b *testing.B) {
+	unsharded := labels.FromStrings(
+		"app", "foo", "namespace", "prod", "cluster", "dev",
+		"pod", "foo-0", "container", "app", "level", "info",
+	)
+	sharded := labels.FromStrings(
+		"__stream_shard__", "3", "app", "foo", "namespace", "prod", "cluster", "dev",
+		"pod", "foo-0", "container", "app", "level", "info",
+	)
+
+	p := NewNoopPipeline()
+	b.Run("unsharded", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = p.ForStream(unsharded)
+		}
+	})
+	b.Run("sharded", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = p.ForStream(sharded)
+		}
+	})
+}

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -210,9 +210,10 @@ func (q *SingleTenantQuerier) SelectLogs(ctx context.Context, params logql.Selec
 
 		iters = append(iters, storeIter)
 	}
-	if len(iters) == 1 {
-		return iters[0], nil
-	}
+	// Always merge, even for a single source: the merge iterator also
+	// deduplicates identical lines that automatic stream sharding sent to more
+	// than one shard, which arrive within one iterator when only the store or
+	// only the ingesters are queried.
 	return iter.NewMergeEntryIterator(ctx, iters, params.Direction), nil
 }
 

--- a/pkg/util/constants/sharding.go
+++ b/pkg/util/constants/sharding.go
@@ -1,0 +1,14 @@
+package constants
+
+// Labels that automatic server-side stream sharding adds to split a single
+// logical stream into shards. Unlike the internal-stream labels in this package
+// (AggregatedMetricLabel, PatternLabel, ...), these do not identify a distinct
+// stream: every shard belongs to the same stream. They must therefore be
+// ignored when computing a stream's identity for query-time deduplication.
+const (
+	// StreamShardLabel is added by rate-based stream sharding. Values are
+	// increasing integers starting from 0.
+	StreamShardLabel = "__stream_shard__"
+	// TimeShardLabel is added by time-based stream sharding.
+	TimeShardLabel = "__time_shard__"
+)

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/loki/v3/pkg/util/constants"
+)
+
+// HasStreamShardLabels reports whether ls carries a label added by automatic
+// stream sharding (constants.StreamShardLabel or constants.TimeShardLabel).
+func HasStreamShardLabels(ls labels.Labels) bool {
+	return ls.Has(constants.StreamShardLabel) || ls.Has(constants.TimeShardLabel)
+}
+
+// LabelsWithoutStreamShards returns ls without the labels that automatic stream
+// sharding adds (constants.StreamShardLabel, constants.TimeShardLabel). Labels
+// carrying none of them are returned unchanged.
+//
+// Automatic stream sharding splits one stream into shards by adding these
+// labels. A log line that a client resends can land in a different shard, so the
+// copies end up in different streams and are not deduplicated at query time.
+// Dropping the shard labels from a stream's query-time identity gives every
+// shard a single identity, so the merge iterators can drop the duplicates.
+//
+// Only the sharding labels are removed. Other reserved labels, such as
+// __aggregated_metric__ and __pattern__, identify genuinely different streams
+// and are left in place.
+func LabelsWithoutStreamShards(ls labels.Labels) labels.Labels {
+	if !HasStreamShardLabels(ls) {
+		return ls
+	}
+	return labels.NewBuilder(ls).Del(constants.StreamShardLabel, constants.TimeShardLabel).Labels()
+}

--- a/pkg/util/labels_test.go
+++ b/pkg/util/labels_test.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasStreamShardLabels(t *testing.T) {
+	require.False(t, HasStreamShardLabels(labels.FromStrings("app", "foo", "namespace", "prod")))
+	require.True(t, HasStreamShardLabels(labels.FromStrings("app", "foo", "__stream_shard__", "1")))
+	require.True(t, HasStreamShardLabels(labels.FromStrings("app", "foo", "__time_shard__", "42")))
+
+	// Reserved labels that identify a distinct stream are not shard labels.
+	require.False(t, HasStreamShardLabels(labels.FromStrings("app", "foo", "__aggregated_metric__", "svc")))
+	require.False(t, HasStreamShardLabels(labels.FromStrings("app", "foo", "__pattern__", "p")))
+}
+
+func TestLabelsWithoutStreamShards(t *testing.T) {
+	hash := func(ls labels.Labels) uint64 {
+		return labels.StableHash(LabelsWithoutStreamShards(ls))
+	}
+
+	base := labels.FromStrings("app", "foo", "namespace", "prod")
+	streamShard0 := labels.FromStrings("__stream_shard__", "0", "app", "foo", "namespace", "prod")
+	streamShard1 := labels.FromStrings("__stream_shard__", "1", "app", "foo", "namespace", "prod")
+	timeShard := labels.FromStrings("__stream_shard__", "1", "__time_shard__", "42", "app", "foo", "namespace", "prod")
+	different := labels.FromStrings("app", "bar", "namespace", "prod")
+
+	// The shard labels are dropped, so shards of one stream become identical.
+	require.Equal(t, base, LabelsWithoutStreamShards(streamShard0))
+	require.Equal(t, base, LabelsWithoutStreamShards(timeShard))
+
+	// And therefore hash equally, while a real label difference still does not.
+	require.Equal(t, hash(base), hash(streamShard0))
+	require.Equal(t, hash(streamShard0), hash(streamShard1))
+	require.Equal(t, hash(streamShard0), hash(timeShard))
+	require.NotEqual(t, hash(base), hash(different))
+
+	// A stream without shard labels is returned unchanged.
+	require.Equal(t, base, LabelsWithoutStreamShards(base))
+
+	// Reserved labels that merely start with "__" but identify a distinct stream
+	// must be preserved. Stripping them would collapse different streams into one
+	// identity and deduplicate lines that are not actually duplicates.
+	for _, name := range []string{"__aggregated_metric__", "__pattern__", "__backfill_shard__"} {
+		ls := labels.NewBuilder(base).Set(name, "x").Labels()
+		require.Equal(t, ls, LabelsWithoutStreamShards(ls), "%s must not be stripped", name)
+		require.NotEqual(t, hash(base), hash(ls), "%s identifies a distinct stream", name)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Automatic stream sharding splits one stream into shards by adding an internal label (`__stream_shard__`, and `__time_shard__` for time-based sharding). When a client resends a log line, the copy can be assigned to a different shard, so the two copies land in different streams and are not deduplicated at query time (#18760).

Drop the two sharding labels from a stream's query-time identity in `pipeline.ForStream` and in the sample extractors, which the ingester and store query paths both use. Shards of one stream then share one stream hash and one set of base labels, so the merge iterators drop the duplicate lines and samples. Streams without a sharding label are unaffected, and other reserved (`__`-prefixed) labels that identify a distinct stream, such as `__aggregated_metric__` and `__pattern__`, are left in place.

Sharing the hash alone is not enough for metric queries: the per-sample line hash is computed from the result labels string (`sample.Hash` in `sampleBufferedIterator`), so a shard label left in the labels still blocks sample dedup. Dropping the labels from the identity covers both. It also keeps the identity independent of which shard a querier happens to see first: `BaseLabelsBuilder.ForLabels` caches the labels result by hash, so hashing shards together while keeping their own labels would return the first shard's labels for the others.

Deduplication also has to handle duplicates that arrive within one iterator, because store and ingester paths sort-merge the shard streams before the querier sees them. The querier no longer skips the merge iterator for a single input (the entry merge iterator already deduplicates within one input), and the sample merge iterator now scans the whole buffered group in all three of its phases: the multi-iterator loop compared a sample only against the other iterators' samples, so a duplicate following its original inside the same iterator survived while several sources were active.

As a result the sharding labels no longer appear in query results. That matches how they are already treated elsewhere: the label browser, query builder, and autocomplete hide `__`-prefixed internal labels, and #13095 reports them showing up in results as confusing.

**Which issue(s) this PR fixes**:
Fixes #18760

**Special notes for your reviewer**:

#7005 fixed this the same way (dropping the shard label at query time) and was reverted in #7031 for a simpler version that was never opened. This keeps the change in `ForStream`, so it applies to the ingester, store, and tail paths without touching the iterators.

The two sharding labels are defined once in `pkg/util/constants` and referenced from the ingester and distributor.

The revert of #7005 was about cost, so the common path stays cheap. The cost is per `ForStream` call (once per stream/chunk iterator, not per line):

```
BenchmarkForStreamShardStrip/unsharded-14   18868245    62.71 ns/op     0 B/op   0 allocs/op
BenchmarkForStreamShardStrip/sharded-14      6412525   196.1  ns/op   336 B/op   3 allocs/op
```

Behavior notes:
- Lines are dropped only when they are identical (same timestamp, line, and structured metadata) and belong to shards of the same stream, so streams that genuinely differ are never merged. There is a chunk-level test that merges two shards and verifies one entry for log queries and one sample for metric queries, in the multi-iterator shape and in the single sorted iterator shape that store-only queries produce; the sample cases fail without the extractor and fast-path changes.
- Single-source log queries now go through the merge iterator instead of returning the raw iterator. The sample fast path keeps its shape (no heap operations) and only adds a timestamp comparison per sample when there are no duplicates. The doc comments on the two merge constructors said they do not deduplicate within a single iterator; the entry iterator already did, so they now describe the actual behavior.
- Every deduplication comparison in the codebase (one in the entry merge iterator, three in the sample merge iterator) now scans the full buffered group of a timestamp and stream hash, regardless of which iterator a sample came from.
- One known gap remains for index-sharded metric queries: partial aggregations are evaluated per index shard, and the shards of a stream have different fingerprints, so they can fall into different index shards where their duplicates never meet a merge iterator. That is a property of fingerprint-based index sharding and out of scope here.
- A label filter or grouping on `__stream_shard__` no longer matches, since the label is not part of the stream's identity anymore. Selector matchers are unaffected (they are applied before the pipeline runs), and so is the deletion path, which matches on the original labels.
- Tailing without a filter keeps its existing fast path that forwards streams untouched, so those responses still carry the shard label.
- `Test_StructuredMetadata` in the ingester asserted that tail responses echo the shard label back; it now expects the label to be dropped.

cc @trevorwhitney @monxas, who discussed the approach on the issue.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
