### PR TITLE
feat(distributor): add -distributor.extend-writes to keep write quorum during ingester scale-down

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3470,6 +3470,12 @@ otlp_config:
 # CLI flag: -distributor.ingester-writes-enabled
 [ingester_writes_enabled: <boolean> | default = true]
 
+# Replace a non-ACTIVE ingester in the write set (for example one that is
+# LEAVING during a scale-down or rollout) with the next healthy ingester so
+# writes keep quorum. Defaults to false.
+# CLI flag: -distributor.extend-writes
+[extend_writes: <boolean> | default = false]
+
 # Enable checking limits against the ingest-limits service. Defaults to false.
 # CLI flag: -distributor.ingest-limits-enabled
 [ingest_limits_enabled: <boolean> | default = false]

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -114,8 +114,12 @@ type Config struct {
 	// DefaultPolicyStreamMappings contains the default policy stream mappings that are merged with per-tenant mappings.
 	DefaultPolicyStreamMappings validation.PolicyStreamMapping `yaml:"default_policy_stream_mappings" doc:"description=Default policy stream mappings that are merged with per-tenant mappings."`
 
-	KafkaEnabled              bool `yaml:"kafka_writes_enabled"`
-	IngesterEnabled           bool `yaml:"ingester_writes_enabled"`
+	KafkaEnabled    bool `yaml:"kafka_writes_enabled"`
+	IngesterEnabled bool `yaml:"ingester_writes_enabled"`
+	// ExtendWrites replaces a non-ACTIVE ingester in the write set (for example one
+	// that is LEAVING during a scale-down or rollout) with the next healthy ingester,
+	// so writes keep quorum while the ring changes.
+	ExtendWrites              bool `yaml:"extend_writes"`
 	IngestLimitsEnabled       bool `yaml:"ingest_limits_enabled"`
 	IngestLimitsDryRunEnabled bool `yaml:"ingest_limits_dry_run_enabled"`
 
@@ -140,6 +144,7 @@ func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
 	fs.IntVar(&cfg.PushWorkerCount, "distributor.push-worker-count", 256, "Number of workers to push batches to ingesters.")
 	fs.BoolVar(&cfg.KafkaEnabled, "distributor.kafka-writes-enabled", false, "Enable writes to Kafka during Push requests.")
 	fs.BoolVar(&cfg.IngesterEnabled, "distributor.ingester-writes-enabled", true, "Enable writes to Ingesters during Push requests. Defaults to true.")
+	fs.BoolVar(&cfg.ExtendWrites, "distributor.extend-writes", false, "Replace a non-ACTIVE ingester in the write set (for example one that is LEAVING during a scale-down or rollout) with the next healthy ingester so writes keep quorum. Defaults to false.")
 	fs.BoolVar(&cfg.IngestLimitsEnabled, "distributor.ingest-limits-enabled", false, "Enable checking limits against the ingest-limits service. Defaults to false.")
 	fs.BoolVar(&cfg.IngestLimitsDryRunEnabled, "distributor.ingest-limits-dry-run-enabled", false, "Enable dry-run mode where limits are checked the ingest-limits service, but not enforced. Defaults to false.")
 }
@@ -662,6 +667,16 @@ func (d *Distributor) Push(ctx context.Context, req *logproto.PushRequest) (*log
 	return d.PushWithResolver(ctx, req, newRequestScopedStreamResolver(tenantID, d.validator.Limits, d.logger), constants.Loki)
 }
 
+// writeRingOp picks the ring operation for the ingester write path. WriteNoExtend
+// drops a non-ACTIVE ingester from the write set without replacing it; Write pulls
+// in the next healthy ingester instead, so quorum survives ring changes.
+func writeRingOp(extendWrites bool) ring.Operation {
+	if extendWrites {
+		return ring.Write
+	}
+	return ring.WriteNoExtend
+}
+
 // Push a set of streams.
 // Can modify the input req parameter.
 // The returned error is the last one seen.
@@ -1022,8 +1037,9 @@ func (d *Distributor) PushWithResolver(ctx context.Context, req *logproto.PushRe
 			sp.AddEvent("started to query ingesters ring")
 			defer sp.AddEvent("finished to query ingesters ring")
 
+			writeOp := writeRingOp(d.cfg.ExtendWrites)
 			for i, stream := range streams {
-				replicationSet, err := d.ingestersRing.Get(stream.HashKey, ring.WriteNoExtend, descs[:0], nil, nil)
+				replicationSet, err := d.ingestersRing.Get(stream.HashKey, writeOp, descs[:0], nil, nil)
 				if err != nil {
 					return err
 				}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2236,6 +2236,11 @@ func TestDistributor_PushIngestionBlockedByPolicy(t *testing.T) {
 	}
 }
 
+func TestWriteRingOp(t *testing.T) {
+	require.Equal(t, ring.WriteNoExtend, writeRingOp(false))
+	require.Equal(t, ring.Write, writeRingOp(true))
+}
+
 func prepare(t *testing.T, numDistributors, numIngesters int, limits *validation.Limits, factory func(addr string) (ring_client.PoolClient, error)) ([]*Distributor, []mockIngester) {
 	t.Helper()
 	distributors, ingesters := prepareButDontStart(t, numDistributors, numIngesters, limits, factory)


### PR DESCRIPTION
**What this PR does / why we need it**:

The distributor always builds the ingester write set with `ring.WriteNoExtend`. When an ingester is briefly non-`ACTIVE` (for example `LEAVING` during a graceful scale-down or a rollout) it is dropped from the replica set with no replacement. If there is no quorum slack (RF=2, or RF=3 when several ingesters change at once), `ring.Get` returns `at least N live replicas required` and the write fails with 5xx even though the shutdown was graceful. With ingester autoscaling this shows up as constant write retries from clients.

This adds `-distributor.extend-writes` (`extend_writes`), off by default so nothing changes for existing setups. When enabled the distributor uses `ring.Write`, which replaces the `LEAVING`/`JOINING` ingester with the next healthy one and keeps write quorum while the ring changes. Mimir already exposes the same flag, and dskit's lifecycler references it in the `-unregister-on-shutdown` flag help, but Loki never wired it up.

Reads are unaffected: `ring.Read` already includes `LEAVING` instances and extends, so anything written to the extension target is still queried, and `maxExpectedReplicationSet` already leaves room for the extra instance.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Opt-in only; the default keeps `WriteNoExtend`, so behavior is unchanged unless the flag is set. `writeRingOp` isolates the selection and has a unit test. The config reference was regenerated with `make doc`.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory.
