### PR TITLE
chore: Treat objects as runs in compaction planning

### DIFF
--- a/pkg/dataobj/compaction/v2/calculator.go
+++ b/pkg/dataobj/compaction/v2/calculator.go
@@ -88,11 +88,11 @@ func calculateRuns[K any](objects []object[K], compare CompareFunc[K]) []*run[K]
 	//
 	// When two runs have the same upper bound, the oldest run wins.
 	//
-	// Consider three L0 sections sorted by timestamp rather than service_name.
-	// Services interleave inside each section, so every section spans much of the
+	// Consider three L0 objects sorted by timestamp rather than service_name. The objects may have multiple sections.
+	// Services interleave inside each object, so every object spans much of the
 	// service_name keyspace:
 	//
-	//	Section A0                         Section B0                         Section C0
+	//	Object A0                          Object B0                          Object C0
 	//	----------                         ----------                         ----------
 	//	auth    | T1 | "login"            billing | T4 | "pay"              auth    | T7 | "refresh"
 	//	billing | T2 | "invoice"          auth    | T5 | "logout"           auth    | T8 | "login"
@@ -108,9 +108,9 @@ func calculateRuns[K any](objects []object[K], compare CompareFunc[K]) []*run[K]
 	//   - C0 starts run 2 for the same reason.
 	//
 	// The result is three overlapping runs. A K-way merge can rewrite them into
-	// sections that are ordered by service_name:
+	// objects that are ordered by service_name:
 	//
-	//	Section X1                         Section Y1                         Section Z1
+	//	Object X1                          Object Y1                          Object Z1
 	//	----------                         ----------                         ----------
 	//	auth | T1 | "login"               auth    | T8 | "login"            billing | T9 | "renew"
 	//	auth | T5 | "logout"              billing | T2 | "invoice"          cart    | T3 | "add"
@@ -120,7 +120,7 @@ func calculateRuns[K any](objects []object[K], compare CompareFunc[K]) []*run[K]
 	//	Max = ["auth", T7]               Max = ["billing", T4]            Max = ["cart", T6]
 	//
 	// A later calculation places X1, Y1, and Z1 in one run. This is why run count
-	// measures locality even when the number of physical sections does not
+	// measures locality even when the number of physical objects does not
 	// change.
 	var runs []*run[K]
 	for _, obj := range objects {

--- a/pkg/dataobj/compaction/v2/calculator.go
+++ b/pkg/dataobj/compaction/v2/calculator.go
@@ -6,11 +6,17 @@ import (
 	compactionv2pb "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2/proto"
 )
 
-// run is one ordered sequence built by calculateRuns. topMax is the upper
+// run is one ordered sequence built by the calculateRuns. topMax is the upper
 // bound of its final section.
 type run[K any] struct {
 	sections []*compactionv2pb.SectionRef
 	topMax   K
+}
+
+type object[K any] struct {
+	path     string
+	sections []*compactionv2pb.SectionRef
+	min, max K
 }
 
 func (r *run[K]) Sections() []*compactionv2pb.SectionRef { return r.sections }
@@ -23,36 +29,63 @@ func (r *run[K]) Size() uint64 {
 	return total
 }
 
-func sortSections[K any](sections []Section[K], compare CompareFunc[K]) {
+func groupSectionsByObject[K any](sections []Section[K], compare CompareFunc[K]) []object[K] {
 	for _, section := range sections {
 		if section.Ref == nil {
 			panic("nil section reference")
 		}
 	}
 
-	sort.Slice(sections, func(i, j int) bool {
-		a, b := sections[i], sections[j]
-		if n := compare(a.Min, b.Min); n != 0 {
+	byPath := make(map[string][]Section[K])
+	for _, section := range sections {
+		path := section.Ref.ObjectPath
+		byPath[path] = append(byPath[path], section)
+	}
+
+	objects := make([]object[K], 0, len(byPath))
+	for path, objectSections := range byPath {
+		// Sort indexes
+		sort.Slice(objectSections, func(i, j int) bool {
+			a, b := objectSections[i], objectSections[j]
+			return a.Ref.SectionIndex < b.Ref.SectionIndex
+		})
+
+		group := object[K]{
+			path:     path,
+			sections: make([]*compactionv2pb.SectionRef, len(objectSections)),
+			min:      objectSections[0].Min,
+			max:      objectSections[0].Max,
+		}
+		for i, section := range objectSections {
+			group.sections[i] = section.Ref
+			if compare(section.Min, group.min) < 0 {
+				group.min = section.Min
+			}
+			if compare(section.Max, group.max) > 0 {
+				group.max = section.Max
+			}
+		}
+		objects = append(objects, group)
+	}
+
+	sort.Slice(objects, func(i, j int) bool {
+		a, b := objects[i], objects[j]
+		if n := compare(a.min, b.min); n != 0 {
 			return n < 0
 		}
-		if n := compare(a.Max, b.Max); n != 0 {
+		if n := compare(a.max, b.max); n != 0 {
 			return n < 0
 		}
-		if a.Ref.ObjectPath != b.Ref.ObjectPath {
-			return a.Ref.ObjectPath < b.Ref.ObjectPath
-		}
-		return a.Ref.SectionIndex < b.Ref.SectionIndex
+		return a.path < b.path
 	})
+	return objects
 }
 
-func calculateRuns[K any](sections []Section[K], compare CompareFunc[K]) []*run[K] {
-	if len(sections) == 0 {
-		return nil
-	}
-	sortSections(sections, compare)
-
-	// Place each section in the run with the greatest upper bound that still
-	// ends before this section starts. If no run is eligible, start a new one.
+func calculateRuns[K any](objects []object[K], compare CompareFunc[K]) []*run[K] {
+	// Place each object in the run with the greatest upper bound that still
+	// ends before this object starts. If no run is eligible, start a new one.
+	// An object is assumed to be internally sorted and is considered a single Run to simplify planning.
+	//
 	// When two runs have the same upper bound, the oldest run wins.
 	//
 	// Consider three L0 sections sorted by timestamp rather than service_name.
@@ -90,10 +123,10 @@ func calculateRuns[K any](sections []Section[K], compare CompareFunc[K]) []*run[
 	// measures locality even when the number of physical sections does not
 	// change.
 	var runs []*run[K]
-	for _, section := range sections {
+	for _, obj := range objects {
 		var best *run[K]
 		for _, candidate := range runs {
-			canFollow := compare(candidate.topMax, section.Min) < 0
+			canFollow := compare(candidate.topMax, obj.min) < 0
 			isCloser := best == nil || compare(candidate.topMax, best.topMax) > 0
 			if canFollow && isCloser {
 				best = candidate
@@ -102,14 +135,14 @@ func calculateRuns[K any](sections []Section[K], compare CompareFunc[K]) []*run[
 
 		if best == nil {
 			runs = append(runs, &run[K]{
-				sections: []*compactionv2pb.SectionRef{section.Ref},
-				topMax:   section.Max,
+				sections: append([]*compactionv2pb.SectionRef(nil), obj.sections...),
+				topMax:   obj.max,
 			})
 			continue
 		}
 
-		best.sections = append(best.sections, section.Ref)
-		best.topMax = section.Max
+		best.sections = append(best.sections, obj.sections...)
+		best.topMax = obj.max
 	}
 	return runs
 }

--- a/pkg/dataobj/compaction/v2/calculator_test.go
+++ b/pkg/dataobj/compaction/v2/calculator_test.go
@@ -36,6 +36,57 @@ func key(label string, timestamp int64) testKey {
 	return testKey{labels: []string{label}, timestamp: timestamp}
 }
 
+func TestGroupSectionsByObject(t *testing.T) {
+	sections := []Section[testKey]{
+		testSection("b", 1, key("h", 0), key("i", 0)),
+		testSection("a", 2, key("e", 0), key("f", 0)),
+		testSection("a", 0, key("c", 0), key("d", 0)),
+		testSection("b", 0, key("g", 0), key("h", 0)),
+		testSection("a", 1, key("a", 0), key("z", 0)),
+	}
+	original := append([]Section[testKey](nil), sections...)
+
+	got := groupSectionsByObject(sections, compareTestKey)
+
+	require.Equal(t, []object[testKey]{
+		{
+			path:     "a",
+			sections: []*compactionv2pb.SectionRef{sections[2].Ref, sections[4].Ref, sections[1].Ref},
+			min:      key("a", 0),
+			max:      key("z", 0),
+		},
+		{
+			path:     "b",
+			sections: []*compactionv2pb.SectionRef{sections[3].Ref, sections[0].Ref},
+			min:      key("g", 0),
+			max:      key("i", 0),
+		},
+	}, got)
+	require.Equal(t, original, sections, "grouping must not mutate the input")
+}
+
+func TestGroupSectionsByObject_OrdersTiesByMaxThenPath(t *testing.T) {
+	sections := []Section[testKey]{
+		testSection("z", 0, key("a", 0), key("c", 0)),
+		testSection("b", 0, key("a", 0), key("b", 0)),
+		testSection("a", 0, key("a", 0), key("b", 0)),
+	}
+
+	got := groupSectionsByObject(sections, compareTestKey)
+
+	require.Equal(t, []string{"a", "b", "z"}, []string{got[0].path, got[1].path, got[2].path})
+}
+
+func TestGroupSectionsByObject_Empty(t *testing.T) {
+	require.Empty(t, groupSectionsByObject([]Section[int](nil), cmp.Compare[int]))
+}
+
+func TestGroupSectionsByObject_NilRefPanics(t *testing.T) {
+	require.PanicsWithValue(t, "nil section reference", func() {
+		groupSectionsByObject([]Section[int]{{Min: 1, Max: 2}}, cmp.Compare[int])
+	})
+}
+
 func TestCalculateRuns(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/dataobj/compaction/v2/calculator_test.go
+++ b/pkg/dataobj/compaction/v2/calculator_test.go
@@ -48,43 +48,43 @@ func TestCalculateRuns(t *testing.T) {
 		{
 			name: "non-overlapping",
 			sections: []Section[testKey]{
-				testSection("o", 2, key("e", 0), key("f", 0)),
-				testSection("o", 0, key("a", 0), key("b", 0)),
-				testSection("o", 1, key("c", 0), key("d", 0)),
+				testSection("a", 2, key("e", 0), key("f", 0)),
+				testSection("b", 0, key("a", 0), key("b", 0)),
+				testSection("c", 1, key("c", 0), key("d", 0)),
 			},
 			want: [][]int64{{0, 1, 2}},
 		},
 		{
 			name: "touching",
 			sections: []Section[testKey]{
-				testSection("o", 0, key("a", 0), key("b", 0)),
-				testSection("o", 1, key("b", 0), key("c", 0)),
+				testSection("a", 0, key("a", 0), key("b", 0)),
+				testSection("b", 1, key("b", 0), key("c", 0)),
 			},
 			want: [][]int64{{0}, {1}},
 		},
 		{
 			name: "overlapping",
 			sections: []Section[testKey]{
-				testSection("o", 0, key("a", 0), key("d", 0)),
-				testSection("o", 1, key("b", 0), key("e", 0)),
-				testSection("o", 2, key("c", 0), key("f", 0)),
+				testSection("a", 0, key("a", 0), key("d", 0)),
+				testSection("b", 1, key("b", 0), key("e", 0)),
+				testSection("c", 2, key("c", 0), key("f", 0)),
 			},
 			want: [][]int64{{0}, {1}, {2}},
 		},
 		{
 			name: "timestamp breaks label tie",
 			sections: []Section[testKey]{
-				testSection("o", 1, key("api", 30), key("api", 40)),
-				testSection("o", 0, key("api", 10), key("api", 20)),
+				testSection("b", 1, key("api", 30), key("api", 40)),
+				testSection("a", 0, key("api", 10), key("api", 20)),
 			},
 			want: [][]int64{{0, 1}},
 		},
 		{
 			name: "best fit",
 			sections: []Section[testKey]{
-				testSection("o", 0, key("00", 0), key("05", 0)),
-				testSection("o", 1, key("01", 0), key("10", 0)),
-				testSection("o", 2, key("12", 0), key("20", 0)),
+				testSection("a", 0, key("00", 0), key("05", 0)),
+				testSection("b", 1, key("01", 0), key("10", 0)),
+				testSection("c", 2, key("12", 0), key("20", 0)),
 			},
 			want: [][]int64{{0}, {1, 2}},
 		},
@@ -140,7 +140,20 @@ func TestCalculateRuns_TiedBoundsUseReferenceOrder(t *testing.T) {
 	}
 
 	runs := CalculateRuns(sections, compareTestKey)
-	require.Equal(t, [][]string{{"a#0"}, {"a#1"}, {"b#0"}}, runRefs(runs))
+	require.Equal(t, [][]string{{"a#0", "a#1"}, {"b#0"}}, runRefs(runs))
+}
+
+func TestObjectEnvelopeControlsRunsAndConvergence(t *testing.T) {
+	sections := []Section[testKey]{
+		testSection("b", 0, key("c", 0), key("f", 0)),
+		testSection("a", 1, key("d", 0), key("e", 0)),
+		testSection("a", 0, key("a", 0), key("b", 0)),
+	}
+
+	runs := CalculateRuns(sections, compareTestKey)
+
+	require.Equal(t, [][]string{{"a#0", "a#1"}, {"b#0"}}, runRefs(runs))
+	require.False(t, IsConverged(sections, compareTestKey))
 }
 
 func TestIsConverged(t *testing.T) {
@@ -153,25 +166,35 @@ func TestIsConverged(t *testing.T) {
 		{
 			name: "strict run",
 			sections: []Section[testKey]{
-				testSection("o", 0, key("a", 0), key("b", 0)),
-				testSection("o", 1, key("c", 0), key("d", 0)),
+				testSection("a", 0, key("a", 0), key("b", 0)),
+				testSection("b", 0, key("c", 0), key("d", 0)),
 			},
 			converged: true,
 		},
 		{
 			name: "touching only",
 			sections: []Section[testKey]{
-				testSection("o", 0, key("a", 0), key("b", 0)),
-				testSection("o", 1, key("b", 0), key("c", 0)),
+				testSection("a", 0, key("a", 0), key("b", 0)),
+				testSection("b", 0, key("b", 0), key("c", 0)),
 			},
 			converged: true,
 		},
 		{
 			name: "true overlap",
 			sections: []Section[testKey]{
-				testSection("o", 0, key("a", 0), key("c", 0)),
-				testSection("o", 1, key("b", 0), key("d", 0)),
+				testSection("a", 0, key("a", 0), key("c", 0)),
+				testSection("b", 0, key("b", 0), key("d", 0)),
 			},
+		},
+		{
+			// This test breaks the assumption that sections within an object are sorted.
+			// It's included to show that the algorithm does not check for overlap within an object.
+			name: "overlap within one object is not checked",
+			sections: []Section[testKey]{
+				testSection("a", 0, key("a", 0), key("c", 0)),
+				testSection("a", 1, key("b", 0), key("d", 0)),
+			},
+			converged: true,
 		},
 	}
 

--- a/pkg/dataobj/compaction/v2/doc.go
+++ b/pkg/dataobj/compaction/v2/doc.go
@@ -1,5 +1,6 @@
 // Package compactionv2 plans K-way compaction from sections with inclusive
-// ordering-key bounds. CalculateRuns forms strict merge inputs, while
-// IsConverged treats touching-only boundaries as a terminal fixed point. Plan
-// batches P runs into ceil(P/K) tasks that each produce one output sequence.
+// ordering-key bounds. CalculateRuns keeps physical objects intact while
+// forming strict merge inputs. IsConverged treats touching-only object boundaries
+// as a terminal fixed point. Plan batches P runs into ceil(P/K) tasks that each
+// produce one output sequence.
 package compactionv2

--- a/pkg/dataobj/compaction/v2/plan.go
+++ b/pkg/dataobj/compaction/v2/plan.go
@@ -24,7 +24,8 @@ type Run interface {
 }
 
 // CalculateRuns groups sections into N disjoint, contiguous runs based on the Min and Max sort keys.
-// All sections within a single object are assumed to be a Run. It panics if a section has a nil Ref.
+// Sections of the same object are treated as one indivisible unit and always land in the same run.
+// It panics if a section has a nil Ref.
 func CalculateRuns[K any](sections []Section[K], compare CompareFunc[K]) []Run {
 	if len(sections) == 0 {
 		return nil

--- a/pkg/dataobj/compaction/v2/plan.go
+++ b/pkg/dataobj/compaction/v2/plan.go
@@ -23,9 +23,15 @@ type Run interface {
 	Size() uint64
 }
 
-// CalculateRuns sorts sections in place and groups them into strict runs. It panics if a section has a nil Ref.
+// CalculateRuns groups sections into N disjoint, contiguous runs based on the Min and Max sort keys.
+// All sections within a single object are assumed to be a Run. It panics if a section has a nil Ref.
 func CalculateRuns[K any](sections []Section[K], compare CompareFunc[K]) []Run {
-	calculated := calculateRuns(sections, compare)
+	if len(sections) == 0 {
+		return nil
+	}
+	groups := groupSectionsByObject(sections, compare)
+	calculated := calculateRuns(groups, compare)
+
 	runs := make([]Run, len(calculated))
 	for i, run := range calculated {
 		runs[i] = run
@@ -33,24 +39,22 @@ func CalculateRuns[K any](sections []Section[K], compare CompareFunc[K]) []Run {
 	return runs
 }
 
-// IsConverged reports whether sections have no positive overlap. Touching
-// sections remain separate runs because their stable order is unknown, but
-// rewriting them cannot remove that ambiguity, so run count alone does not
-// prevent convergence. It does not mutate sections.
+// IsConverged reports whether a set of sections have no positive
+// overlap. Touching bounds are considered converged because rewriting cannot remove their
+// ambiguity. It does not mutate sections.
 func IsConverged[K any](sections []Section[K], compare CompareFunc[K]) bool {
-	sections = append([]Section[K](nil), sections...)
-	sortSections(sections, compare)
-	if len(sections) <= 1 {
+	objects := groupSectionsByObject(sections, compare)
+	if len(objects) <= 1 {
 		return true
 	}
 
-	maxKey := sections[0].Max
-	for _, section := range sections[1:] {
-		if compare(maxKey, section.Min) > 0 {
+	maxKey := objects[0].max
+	for _, obj := range objects[1:] {
+		if compare(maxKey, obj.min) > 0 {
 			return false
 		}
-		if compare(section.Max, maxKey) > 0 {
-			maxKey = section.Max
+		if compare(obj.max, maxKey) > 0 {
+			maxKey = obj.max
 		}
 	}
 	return true

--- a/pkg/dataobj/compaction/v2/plan_test.go
+++ b/pkg/dataobj/compaction/v2/plan_test.go
@@ -108,19 +108,20 @@ func TestCalculateRuns_EmptyInput(t *testing.T) {
 	require.Empty(t, CalculateRuns([]Section[int](nil), func(a, b int) int { return a - b }))
 }
 
-func TestCalculateRuns_WrapsRunsAndSortsInPlace(t *testing.T) {
+func TestCalculateRuns_WrapsRunsWithoutMutatingInput(t *testing.T) {
 	a := &compactionv2pb.SectionRef{ObjectPath: "a", SectionIndex: 0, UncompressedSize: 5}
 	b := &compactionv2pb.SectionRef{ObjectPath: "b", SectionIndex: 0, UncompressedSize: 7}
 	input := []Section[int]{
 		{Ref: b, Min: 30, Max: 40},
 		{Ref: a, Min: 10, Max: 20},
 	}
+	original := append([]Section[int](nil), input...)
 
 	runs := CalculateRuns(input, func(a, b int) int { return a - b })
 
 	require.Len(t, runs, 1)
 	require.Equal(t, uint64(12), runs[0].Size())
-	require.Equal(t, []Section[int]{{Ref: a, Min: 10, Max: 20}, {Ref: b, Min: 30, Max: 40}}, input)
+	require.Equal(t, original, input)
 }
 
 func TestBelowMinCompactionSize(t *testing.T) {

--- a/pkg/engine/compactor/coordinator.go
+++ b/pkg/engine/compactor/coordinator.go
@@ -399,10 +399,6 @@ func (c *coordinator) compactTenant(ctx context.Context, tenant string, window t
 	level.Info(windowLogger).Log("msg", "planned index compaction tasks", "tenant", tenant, "tasks", len(tasks), "input_runs", len(runs))
 	logIndexTaskDetails(windowLogger, tasks)
 
-	// IndexMerge opens each referenced object whole. Until it reads individual
-	// sections, one object may be repeated across task outputs and deduplicated
-	// by a later pass.
-	// TODO(rfratto): Preserve multiple log sort schemas in one IndexMerge output.
 	g, gctx := errgroup.WithContext(ctx)
 	if c.cfg.MaxRunningCompactionTasks > 0 {
 		g.SetLimit(c.cfg.MaxRunningCompactionTasks)

--- a/pkg/engine/compactor/coordinator_test.go
+++ b/pkg/engine/compactor/coordinator_test.go
@@ -24,8 +24,9 @@ import (
 	compactionv2pb "github.com/grafana/loki/v3/pkg/dataobj/compaction/v2/proto"
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
-	stats "github.com/grafana/loki/v3/pkg/dataobj/sections/stats"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/stats"
 	"github.com/grafana/loki/v3/pkg/engine/internal/planner/physical"
+	"github.com/grafana/loki/v3/pkg/engine/internal/util/dag"
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
 )
 
@@ -67,6 +68,35 @@ func (f *fakeRunner) snapshot() []runCall {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]runCall(nil), f.calls...)
+}
+
+func (f *fakeRunner) assertUniqueObjects(t *testing.T) {
+	// Validate that no object section appears in more than one task
+	for _, call := range f.calls {
+		root, err := call.plan.Root()
+		require.NoError(t, err)
+
+		callObjects := map[string]struct{}{}
+		err = call.plan.Graph().Walk(root, func(n physical.Node) error {
+			switch n.(type) {
+			case *physical.LogMerge:
+				runs := n.(*physical.LogMerge).Runs
+				for _, run := range runs {
+					runObjects := map[string]struct{}{}
+					for _, sectionRef := range run.Sections {
+						runObjects[sectionRef.ObjectPath] = struct{}{}
+					}
+					for obj := range runObjects {
+						_, exists := callObjects[obj]
+						require.False(t, exists, "object %q appears in more than one task", obj)
+						callObjects[obj] = struct{}{}
+					}
+				}
+			}
+			return nil
+		}, dag.PreOrderWalk)
+		require.NoError(t, err)
+	}
 }
 
 // fakeReplacer records each ReplaceIndexPointers invocation and returns
@@ -180,6 +210,7 @@ func TestCompactTenant_RaceLossIsSuccess(t *testing.T) {
 	})
 
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{swapped: false, err: nil}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
 
@@ -211,6 +242,7 @@ func TestCompactTenant_HardSwapErrorPropagates(t *testing.T) {
 
 	swapErr := errors.New("bucket: temporary failure")
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{swapped: false, err: swapErr}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
 
@@ -240,6 +272,8 @@ func TestCompactTenantLogs_DispatchesLogMergePlans(t *testing.T) {
 	})
 
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
+
 	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
 
@@ -286,6 +320,7 @@ func TestCompactTenantLogs_NoStatsRowsForTenantIsConverged(t *testing.T) {
 	})
 
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
 
@@ -311,6 +346,7 @@ func TestCompactTenantLogs_InternalObjectOverlapIsConverged(t *testing.T) {
 	})
 
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
 
@@ -337,6 +373,7 @@ func TestCompactTenantLogs_TouchingRunsAreConverged(t *testing.T) {
 	})
 
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
 
@@ -362,6 +399,7 @@ func TestCompactTenantLogs_TerminalBelowFloorSkips(t *testing.T) {
 	})
 
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
 	c.cfg.LogMinCompactionSize = 1 << 30 // 1GiB floor; 30 bytes is below it
@@ -394,6 +432,7 @@ func TestCompactTenantLogs_SwapsToC(t *testing.T) {
 	bucket := twoRunConvergedBucket(ctx, t, "acme", convergedPath)
 
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
 
@@ -417,6 +456,7 @@ func TestCompactTenantLogs_SwapErrorFails(t *testing.T) {
 	bucket := twoRunConvergedBucket(ctx, t, "acme", convergedPath)
 
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{err: errors.New("boom")}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
 
@@ -433,6 +473,7 @@ func TestCompactTenantLogs_SwapRaceLossConverged(t *testing.T) {
 	bucket := twoRunConvergedBucket(ctx, t, "acme", convergedPath)
 
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{swapped: false}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
 
@@ -450,6 +491,7 @@ func TestCompactTenantLogs_DryRunSkipsSwap(t *testing.T) {
 	bucket := twoRunConvergedBucket(ctx, t, "acme", convergedPath)
 
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
 	c.cfg.DryRun = true
@@ -470,6 +512,7 @@ func TestCompactTenantLogs_PartialFailureNoSwap(t *testing.T) {
 	bucket := twoRunConvergedBucket(ctx, t, "acme", convergedPath)
 
 	runner := &fakeRunner{failOnCall: 1}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
 
@@ -489,6 +532,7 @@ func TestCompactTenantLogs_DeterministicOutputPaths(t *testing.T) {
 	run := func() []metastore.TableOfContentsEntry {
 		bucket := twoRunConvergedBucket(ctx, t, "acme", convergedPath)
 		runner := &fakeRunner{}
+		defer runner.assertUniqueObjects(t)
 		replacer := &fakeReplacer{swapped: true}
 		c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
 		_, err := c.compactTenantLogs(ctx, "acme", window, entry)
@@ -525,6 +569,7 @@ func TestRunIndexMergePhase_SingleIndexIsNoWork(t *testing.T) {
 		"acme": {{path: "indexes/a", start: window.Add(time.Hour), end: window.Add(2 * time.Hour)}},
 	})
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
 
@@ -571,6 +616,7 @@ func TestCompactTenant_TouchingSectionsAreConverged(t *testing.T) {
 	}
 
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
 	stats, err := c.compactTenant(ctx, "acme", window, []indexEntry{{Path: "indexes/a"}, {Path: "indexes/b"}})
@@ -601,6 +647,7 @@ func TestCompactTenant_PostingTimestampsDetectOverlap(t *testing.T) {
 	}
 
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
 	_, err := c.compactTenant(ctx, "acme", window, []indexEntry{
@@ -621,6 +668,7 @@ func TestCompactTenant_FailsOnIncompleteDiscovery(t *testing.T) {
 	buildOverlappingPostingsIndex(ctx, t, bucket, "acme", "indexes/a")
 
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
 	_, err := c.compactTenant(ctx, "acme", window, []indexEntry{{Path: "indexes/a"}, {Path: "indexes/missing"}})
@@ -652,6 +700,7 @@ func TestRunIndexMergePhase_MultiIndexSwaps(t *testing.T) {
 		},
 	})
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
 
@@ -700,6 +749,7 @@ func TestRunLogMergePhase_PerIndexSwaps(t *testing.T) {
 	window := imWindow()
 	bucket := logMergeBucket(ctx, t, window, "acme", []string{"indexes/a", "indexes/b"})
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
 
@@ -726,6 +776,7 @@ func TestRun_CancelDrainsGoroutines(t *testing.T) {
 	window := imWindow()
 	bucket := seededToC(ctx, t, window, "acme")
 	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
 	replacer := &fakeReplacer{swapped: true}
 
 	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))

--- a/pkg/engine/compactor/coordinator_test.go
+++ b/pkg/engine/compactor/coordinator_test.go
@@ -198,72 +198,27 @@ func sectionRefNames(refs []*compactionv2pb.SectionRef) []string {
 	return names
 }
 
+func mergeNodeRuns(t *testing.T, plan *physical.Plan) []*compactionv2pb.RunRef {
+	t.Helper()
+	root, err := plan.Root()
+	require.NoError(t, err)
+	switch n := root.(type) {
+	case *physical.LogMerge:
+		return n.Runs
+	case *physical.IndexMerge:
+		return n.Runs
+	default:
+		t.Fatalf("plan root is %T, want LogMerge or IndexMerge", root)
+		return nil
+	}
+}
+
 func buildOverlappingPostingsIndex(ctx context.Context, t *testing.T, bucket objstore.Bucket, tenant, path string) {
 	t.Helper()
 	buildIndexWithPostings(ctx, t, bucket, tenant, path, 1<<20, []postings.Row{
 		{Kind: postings.KindLabel, ObjectPath: path + ".log-0", ColumnName: "service_name", LabelValue: "a", MinTimestamp: 10, MaxTimestamp: 20},
 		{Kind: postings.KindLabel, ObjectPath: path + ".log-1", ColumnName: "service_name", LabelValue: "z", MinTimestamp: 30, MaxTimestamp: 40},
 	})
-}
-
-// TestRunTenantCycle_RaceLossIsSuccess verifies the (swapped=false, err=nil)
-// path is treated as success: the cycle returns nil and the next cycle
-// re-plans against the post-swap ToC.
-func TestCompactTenant_RaceLossIsSuccess(t *testing.T) {
-	ctx := context.Background()
-	bucket := objstore.NewInMemBucket()
-	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
-	buildOverlappingPostingsIndex(ctx, t, bucket, "acme", "indexes/aa/src-0")
-	buildOverlappingPostingsIndex(ctx, t, bucket, "acme", "indexes/bb/src-1")
-
-	writeToCWithIndexes(ctx, t, bucket, map[string][]testIndex{
-		"acme": {
-			{path: "indexes/aa/src-0", start: window.Add(1 * time.Hour), end: window.Add(2 * time.Hour)},
-			{path: "indexes/bb/src-1", start: window.Add(3 * time.Hour), end: window.Add(4 * time.Hour)},
-		},
-	})
-
-	runner := &fakeRunner{}
-	defer runner.assertUniqueObjects(t)
-	replacer := &fakeReplacer{swapped: false, err: nil}
-	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
-
-	// compactTenant surfaces the tenant error directly (the phase wrapper is
-	// what swallows/logs it); assert on it via the lower API here.
-	indexes, err := loadTenantIndexes(ctx, bucket, window)
-	require.NoError(t, err)
-	_, runErr := c.compactTenant(ctx, "acme", window, indexes["acme"])
-	require.NoError(t, runErr)
-}
-
-// TestCompactTenant_HardSwapErrorPropagates verifies that a non-nil error
-// from ReplaceIndexPointers is returned by compactTenant (wrapped), so
-// callers can pin it. The phase wrapper logs and re-arms on such errors;
-// compactTenant itself surfaces the wrapped error.
-func TestCompactTenant_HardSwapErrorPropagates(t *testing.T) {
-	ctx := context.Background()
-	bucket := objstore.NewInMemBucket()
-	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
-	buildOverlappingPostingsIndex(ctx, t, bucket, "acme", "indexes/aa/src-0")
-	buildOverlappingPostingsIndex(ctx, t, bucket, "acme", "indexes/bb/src-1")
-
-	writeToCWithIndexes(ctx, t, bucket, map[string][]testIndex{
-		"acme": {
-			{path: "indexes/aa/src-0", start: window.Add(1 * time.Hour), end: window.Add(2 * time.Hour)},
-			{path: "indexes/bb/src-1", start: window.Add(3 * time.Hour), end: window.Add(4 * time.Hour)},
-		},
-	})
-
-	swapErr := errors.New("bucket: temporary failure")
-	runner := &fakeRunner{}
-	defer runner.assertUniqueObjects(t)
-	replacer := &fakeReplacer{swapped: false, err: swapErr}
-	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
-
-	indexes, err := loadTenantIndexes(ctx, bucket, window)
-	require.NoError(t, err)
-	_, runErr := c.compactTenant(ctx, "acme", window, indexes["acme"])
-	require.ErrorIs(t, runErr, swapErr)
 }
 
 func TestCompactTenantLogs_DispatchesLogMergePlans(t *testing.T) {
@@ -318,6 +273,44 @@ func TestCompactTenantLogs_DispatchesLogMergePlans(t *testing.T) {
 	swaps := replacer.snapshot()
 	require.Len(t, swaps, 1, "log path now swaps the ToC after dispatch")
 	require.Equal(t, []string{convergedPath}, swaps[0].oldPaths)
+}
+
+func TestCompactTenant_DispatchesIndexMergePlans(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
+
+	// Two overlapping indexes, each with two physical sections. Sections of
+	// the same index must stay together and ordered in the dispatched task.
+	buildIndexWithPostingsSections(ctx, t, bucket, "acme", "indexes/a",
+		[]postings.Row{{Kind: postings.KindLabel, ObjectPath: "logs/a-0", ColumnName: "service", LabelValue: "a", MinTimestamp: 10, MaxTimestamp: 20}},
+		[]postings.Row{{Kind: postings.KindLabel, ObjectPath: "logs/a-1", ColumnName: "service", LabelValue: "z", MinTimestamp: 30, MaxTimestamp: 40}},
+	)
+	buildIndexWithPostingsSections(ctx, t, bucket, "acme", "indexes/b",
+		[]postings.Row{{Kind: postings.KindLabel, ObjectPath: "logs/b-0", ColumnName: "service", LabelValue: "a", MinTimestamp: 15, MaxTimestamp: 25}},
+		[]postings.Row{{Kind: postings.KindLabel, ObjectPath: "logs/b-1", ColumnName: "service", LabelValue: "z", MinTimestamp: 35, MaxTimestamp: 45}},
+	)
+
+	runner := &fakeRunner{}
+	defer runner.assertUniqueObjects(t)
+	replacer := &fakeReplacer{swapped: true}
+	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
+
+	stats, err := c.compactTenant(ctx, "acme", window, []indexEntry{
+		{Path: "indexes/a", Start: window.Add(time.Hour), End: window.Add(2 * time.Hour)},
+		{Path: "indexes/b", Start: window.Add(time.Hour), End: window.Add(2 * time.Hour)},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.dispatched, "two runs -> one task -> one IndexMerge plan")
+
+	dispatches := runner.snapshot()
+	require.Len(t, dispatches, 1)
+	require.Equal(t, []string{"compaction", "index-merge"}, dispatches[0].opts.Actor)
+
+	runs := mergeNodeRuns(t, dispatches[0].plan)
+	require.Len(t, runs, 2)
+	require.Equal(t, []string{"indexes/a#0", "indexes/a#1"}, sectionRefNames(runs[0].Sections))
+	require.Equal(t, []string{"indexes/b#0", "indexes/b#1"}, sectionRefNames(runs[1].Sections))
 }
 
 func TestCompactTenantLogs_NoStatsRowsForTenantIsConverged(t *testing.T) {
@@ -439,102 +432,178 @@ func twoRunConvergedBucket(ctx context.Context, t *testing.T, tenant, path strin
 	return bucket
 }
 
-func TestCompactTenantLogs_SwapsToC(t *testing.T) {
-	ctx := context.Background()
-	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
-	convergedPath := "indexes/aa/converged"
-	bucket := twoRunConvergedBucket(ctx, t, "acme", convergedPath)
-
-	runner := &fakeRunner{}
-	defer runner.assertUniqueObjects(t)
-	replacer := &fakeReplacer{swapped: true}
-	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
-
-	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
-	stats, err := c.compactTenantLogs(ctx, "acme", window, entry)
-
-	require.NoError(t, err)
-	require.NotZero(t, stats.added)
-	require.NotEmpty(t, runner.snapshot(), "non-terminal window dispatches plans")
-
-	calls := replacer.snapshot()
-	require.Len(t, calls, 1)
-	require.Equal(t, []string{convergedPath}, calls[0].oldPaths)
-	require.NotEmpty(t, calls[0].newEntries)
+func overlappingIndexesBucket(ctx context.Context, t *testing.T, window time.Time, tenant string, paths ...string) objstore.Bucket {
+	t.Helper()
+	if len(paths) == 0 {
+		paths = []string{"indexes/aa/src-0", "indexes/bb/src-1"}
+	}
+	bucket := objstore.NewInMemBucket()
+	entries := make([]testIndex, 0, len(paths))
+	for i, path := range paths {
+		buildOverlappingPostingsIndex(ctx, t, bucket, tenant, path)
+		entries = append(entries, testIndex{
+			path:  path,
+			start: window.Add(time.Duration(i+1) * time.Hour),
+			end:   window.Add(time.Duration(i+2) * time.Hour),
+		})
+	}
+	writeToCWithIndexes(ctx, t, bucket, map[string][]testIndex{tenant: entries})
+	return bucket
 }
 
-func TestCompactTenantLogs_SwapErrorFails(t *testing.T) {
-	ctx := context.Background()
+// TestCompactJobToCEdgeCases covers the shared post-plan contract of compactTenant
+// and compactTenantLogs: dispatch jobs, then swap / skip / fail the ToC.
+func TestCompactJobToCEdgeCases(t *testing.T) {
 	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
-	convergedPath := "indexes/aa/converged"
-	bucket := twoRunConvergedBucket(ctx, t, "acme", convergedPath)
 
-	runner := &fakeRunner{}
-	defer runner.assertUniqueObjects(t)
-	replacer := &fakeReplacer{err: errors.New("boom")}
-	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
+	type compactKind struct {
+		name string
+		seed func(ctx context.Context, t *testing.T, window time.Time) (objstore.Bucket, func(*coordinator) (compactionStats, error))
+	}
+	kinds := []compactKind{
+		{
+			name: "logs",
+			seed: func(ctx context.Context, t *testing.T, window time.Time) (objstore.Bucket, func(*coordinator) (compactionStats, error)) {
+				path := "indexes/aa/converged"
+				bucket := twoRunConvergedBucket(ctx, t, "acme", path)
+				entry := indexEntry{Path: path, Start: window.Add(time.Hour), End: window.Add(2 * time.Hour)}
+				return bucket, func(c *coordinator) (compactionStats, error) {
+					return c.compactTenantLogs(ctx, "acme", window, entry)
+				}
+			},
+		},
+		{
+			name: "index",
+			seed: func(ctx context.Context, t *testing.T, window time.Time) (objstore.Bucket, func(*coordinator) (compactionStats, error)) {
+				bucket := overlappingIndexesBucket(ctx, t, window, "acme")
+				return bucket, func(c *coordinator) (compactionStats, error) {
+					indexes, err := loadTenantIndexes(ctx, bucket, window)
+					require.NoError(t, err)
+					return c.compactTenant(ctx, "acme", window, indexes["acme"])
+				}
+			},
+		},
+	}
 
-	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
-	_, err := c.compactTenantLogs(ctx, "acme", window, entry)
+	edges := []struct {
+		name       string
+		failOnCall int
+		swapped    bool
+		swapErr    error
+		dryRun     bool
+		wantErr    bool
+		wantSwap   bool
+		wantAdded  int
+	}{
+		{name: "swap_ok", swapped: true, wantSwap: true, wantAdded: 1},
+		{name: "swap_error", swapErr: errors.New("boom"), wantErr: true, wantSwap: true},
+		{name: "race_loss", swapped: false, wantSwap: true, wantAdded: 0},
+		{name: "dry_run", swapped: true, dryRun: true, wantAdded: 0},
+		{name: "job_failure", failOnCall: 1, swapped: true, wantErr: true},
+	}
 
-	require.Error(t, err)
+	for _, kind := range kinds {
+		for _, edge := range edges {
+			t.Run(kind.name+"/"+edge.name, func(t *testing.T) {
+				ctx := context.Background()
+				bucket, run := kind.seed(ctx, t, window)
+				runner := &fakeRunner{failOnCall: edge.failOnCall}
+				defer runner.assertUniqueObjects(t)
+				replacer := &fakeReplacer{swapped: edge.swapped, err: edge.swapErr}
+				c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
+				c.cfg.DryRun = edge.dryRun
+
+				stats, err := run(c)
+				if edge.wantErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+				require.NotEmpty(t, runner.snapshot(), "jobs must be dispatched")
+
+				swaps := replacer.snapshot()
+				if edge.wantSwap {
+					require.Len(t, swaps, 1)
+					require.NotEmpty(t, swaps[0].newEntries)
+				} else {
+					require.Empty(t, swaps)
+				}
+				if !edge.wantErr {
+					require.Equal(t, edge.wantAdded, stats.added)
+				}
+			})
+		}
+	}
 }
 
-func TestCompactTenantLogs_SwapRaceLossConverged(t *testing.T) {
-	ctx := context.Background()
+// TestCompact_SplitsWhenRunsExceedK checks that multiple tasks are dispatched when the planning steps detect more Runs than allowed Runs per task (2)
+func TestCompact_SplitsWhenRunsExceedK(t *testing.T) {
 	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
-	convergedPath := "indexes/aa/converged"
-	bucket := twoRunConvergedBucket(ctx, t, "acme", convergedPath)
 
-	runner := &fakeRunner{}
-	defer runner.assertUniqueObjects(t)
-	replacer := &fakeReplacer{swapped: false}
-	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
+	t.Run("logs", func(t *testing.T) {
+		ctx := context.Background()
+		path := "indexes/aa/converged"
+		bucket := objstore.NewInMemBucket()
+		buildIndexWithStats(ctx, t, bucket, "acme", path, []stats.Stat{
+			{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "label:service_name",
+				Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 30, RowCount: 1, UncompressedSize: 100},
+			{ObjectPath: "logs/log-1", SectionIndex: 0, SortSchema: "label:service_name",
+				Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 20, MaxTimestamp: 40, RowCount: 1, UncompressedSize: 100},
+			{ObjectPath: "logs/log-2", SectionIndex: 0, SortSchema: "label:service_name",
+				Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 25, MaxTimestamp: 50, RowCount: 1, UncompressedSize: 100},
+		})
 
-	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
-	stats, err := c.compactTenantLogs(ctx, "acme", window, entry)
+		runner := &fakeRunner{}
+		defer runner.assertUniqueObjects(t)
+		replacer := &fakeReplacer{swapped: true}
+		c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
 
-	require.NoError(t, err)
-	require.Zero(t, stats.added)
+		stats, err := c.compactTenantLogs(ctx, "acme", window, indexEntry{
+			Path: path, Start: window.Add(time.Hour), End: window.Add(2 * time.Hour), UncompressedLogsSize: 300,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 2, stats.dispatched, "3 overlapping runs with K=2 must split into 2 tasks")
+		require.Equal(t, 2, stats.added)
+
+		dispatches := runner.snapshot()
+		require.Len(t, dispatches, 2)
+		require.Equal(t, 3, countMergeObjects(t, dispatches))
+	})
+
+	t.Run("index", func(t *testing.T) {
+		ctx := context.Background()
+		bucket := overlappingIndexesBucket(ctx, t, window, "acme",
+			"indexes/aa/src-0", "indexes/bb/src-1", "indexes/cc/src-2")
+
+		runner := &fakeRunner{}
+		defer runner.assertUniqueObjects(t)
+		replacer := &fakeReplacer{swapped: true}
+		c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
+
+		indexes, err := loadTenantIndexes(ctx, bucket, window)
+		require.NoError(t, err)
+		stats, err := c.compactTenant(ctx, "acme", window, indexes["acme"])
+		require.NoError(t, err)
+		require.Equal(t, 2, stats.dispatched, "3 overlapping runs with K=2 must split into 2 tasks")
+		require.Equal(t, 2, stats.added)
+
+		dispatches := runner.snapshot()
+		require.Len(t, dispatches, 2)
+		require.Equal(t, 3, countMergeObjects(t, dispatches))
+	})
 }
 
-func TestCompactTenantLogs_DryRunSkipsSwap(t *testing.T) {
-	ctx := context.Background()
-	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
-	convergedPath := "indexes/aa/converged"
-	bucket := twoRunConvergedBucket(ctx, t, "acme", convergedPath)
-
-	runner := &fakeRunner{}
-	defer runner.assertUniqueObjects(t)
-	replacer := &fakeReplacer{swapped: true}
-	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
-	c.cfg.DryRun = true
-
-	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
-	stats, err := c.compactTenantLogs(ctx, "acme", window, entry)
-
-	require.NoError(t, err)
-	require.Zero(t, stats.added)
-	require.NotEmpty(t, runner.snapshot(), "dry-run still dispatches")
-	require.Empty(t, replacer.snapshot(), "dry-run must not swap the ToC")
-}
-
-func TestCompactTenantLogs_PartialFailureNoSwap(t *testing.T) {
-	ctx := context.Background()
-	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
-	convergedPath := "indexes/aa/converged"
-	bucket := twoRunConvergedBucket(ctx, t, "acme", convergedPath)
-
-	runner := &fakeRunner{failOnCall: 1}
-	defer runner.assertUniqueObjects(t)
-	replacer := &fakeReplacer{swapped: true}
-	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(1*time.Hour)), newFakeLimits("acme"))
-
-	entry := indexEntry{Path: convergedPath, Start: window.Add(1 * time.Hour), End: window.Add(2 * time.Hour)}
-	_, err := c.compactTenantLogs(ctx, "acme", window, entry)
-
-	require.Error(t, err)
-	require.Empty(t, replacer.snapshot(), "partial failure must not swap the ToC")
+func countMergeObjects(t *testing.T, calls []runCall) int {
+	t.Helper()
+	objects := map[string]struct{}{}
+	for _, call := range calls {
+		for _, run := range mergeNodeRuns(t, call.plan) {
+			for _, section := range run.Sections {
+				objects[section.ObjectPath] = struct{}{}
+			}
+		}
+	}
+	return len(objects)
 }
 
 func TestCompactTenantLogs_DeterministicOutputPaths(t *testing.T) {
@@ -771,6 +840,25 @@ func TestRunLogMergePhase_PerIndexSwaps(t *testing.T) {
 	require.Len(t, replacer.snapshot(), 2, "one swap per index")
 	require.Positive(t, testutil.ToFloat64(c.metrics.indexesAddedTotal.WithLabelValues("acme")))
 	require.Positive(t, testutil.ToFloat64(c.metrics.tasksTotal.WithLabelValues("acme")))
+}
+
+// TestRunLogMergePhase_PartialIndexFailureRetries checks that a partial failure is recorded but retried so progress continues.
+func TestRunLogMergePhase_PartialIndexFailureRetries(t *testing.T) {
+	ctx := context.Background()
+	window := imWindow()
+	bucket := logMergeBucket(ctx, t, window, "acme", []string{"indexes/a", "indexes/b"})
+	runner := &fakeRunner{failOnCall: 1}
+	defer runner.assertUniqueObjects(t)
+	replacer := &fakeReplacer{swapped: true}
+	c := newTestCoordinator(t, bucket, runner, replacer, fixedClock(window.Add(time.Hour)), newFakeLimits("acme"))
+
+	require.Equal(t, phaseOutcomeError, c.runLogMergePhase(ctx, "acme", window),
+		"a mixed success+failure cycle must retry the phase rather than flip")
+	require.Len(t, runner.snapshot(), 2, "both indexes are attempted")
+	require.Len(t, replacer.snapshot(), 1, "the successful index still swaps")
+	require.Equal(t, 1.0, testutil.ToFloat64(c.metrics.tenantLogCyclesTotal.WithLabelValues("compacted", "acme")),
+		"partial progress is recorded as compacted, not failed")
+	require.Zero(t, testutil.ToFloat64(c.metrics.tenantLogCyclesTotal.WithLabelValues("failed", "acme")))
 }
 
 func TestRunLogMergePhase_CancelledMidIterationStops(t *testing.T) {

--- a/pkg/engine/compactor/coordinator_test.go
+++ b/pkg/engine/compactor/coordinator_test.go
@@ -146,6 +146,14 @@ func newTestCoordinator(t *testing.T, bucket objstore.Bucket, runner *fakeRunner
 // fixedClock returns a clock function pinned to t.
 func fixedClock(t time.Time) func() time.Time { return func() time.Time { return t } }
 
+func sectionRefNames(refs []*compactionv2pb.SectionRef) []string {
+	names := make([]string, len(refs))
+	for i, ref := range refs {
+		names[i] = fmt.Sprintf("%s#%d", ref.ObjectPath, ref.SectionIndex)
+	}
+	return names
+}
+
 func buildOverlappingPostingsIndex(ctx context.Context, t *testing.T, bucket objstore.Bucket, tenant, path string) {
 	t.Helper()
 	buildIndexWithPostings(ctx, t, bucket, tenant, path, 1<<20, []postings.Row{
@@ -218,13 +226,17 @@ func TestCompactTenantLogs_DispatchesLogMergePlans(t *testing.T) {
 	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
 	convergedPath := "indexes/aa/converged"
 
-	// Same tuple, overlapping times -> 2 runs -> still dispatches after the
-	// terminal gate (total size 200 clears the test floor of 1).
+	// Two overlapping objects -> 2 runs. Each object's physical sections must
+	// stay together and ordered in the dispatched task.
 	buildIndexWithStats(ctx, t, bucket, "acme", convergedPath, []stats.Stat{
 		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "label:service_name",
-			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 30, RowCount: 1, UncompressedSize: 100},
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 20, RowCount: 1, UncompressedSize: 50},
+		{ObjectPath: "logs/log-0", SectionIndex: 1, SortSchema: "label:service_name",
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 15, MaxTimestamp: 30, RowCount: 1, UncompressedSize: 50},
 		{ObjectPath: "logs/log-1", SectionIndex: 0, SortSchema: "label:service_name",
-			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 20, MaxTimestamp: 40, RowCount: 1, UncompressedSize: 100},
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 20, MaxTimestamp: 30, RowCount: 1, UncompressedSize: 50},
+		{ObjectPath: "logs/log-1", SectionIndex: 1, SortSchema: "label:service_name",
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 25, MaxTimestamp: 40, RowCount: 1, UncompressedSize: 50},
 	})
 
 	runner := &fakeRunner{}
@@ -251,6 +263,9 @@ func TestCompactTenantLogs_DispatchesLogMergePlans(t *testing.T) {
 	node, ok := root.(*physical.LogMerge)
 	require.True(t, ok)
 	require.Equal(t, []string{"label:service_name"}, node.SortSchema)
+	require.Len(t, node.Runs, 2)
+	require.Equal(t, []string{"logs/log-0#0", "logs/log-0#1"}, sectionRefNames(node.Runs[0].Sections))
+	require.Equal(t, []string{"logs/log-1#0", "logs/log-1#1"}, sectionRefNames(node.Runs[1].Sections))
 
 	swaps := replacer.snapshot()
 	require.Len(t, swaps, 1, "log path now swaps the ToC after dispatch")
@@ -280,16 +295,19 @@ func TestCompactTenantLogs_NoStatsRowsForTenantIsConverged(t *testing.T) {
 	require.Empty(t, runner.snapshot())
 }
 
-func TestCompactTenantLogs_TerminalSingleRunSkips(t *testing.T) {
+func TestCompactTenantLogs_InternalObjectOverlapIsConverged(t *testing.T) {
 	ctx := context.Background()
 	bucket := objstore.NewInMemBucket()
 	window := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC).Truncate(metastore.MetastoreWindowSize)
 	convergedPath := "indexes/aa/converged"
 
-	// Single stat row -> P=1 -> terminal regardless of size.
+	// Overlapping physical sections in one object are one planning unit and do
+	// not trigger a rewrite by themselves.
 	buildIndexWithStats(ctx, t, bucket, "acme", convergedPath, []stats.Stat{
 		{ObjectPath: "logs/log-0", SectionIndex: 0, SortSchema: "label:service_name",
-			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 20, RowCount: 1, UncompressedSize: 100},
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 10, MaxTimestamp: 30, RowCount: 1, UncompressedSize: 100},
+		{ObjectPath: "logs/log-0", SectionIndex: 1, SortSchema: "label:service_name",
+			Labels: map[string]string{"service_name": "auth"}, MinTimestamp: 20, MaxTimestamp: 40, RowCount: 1, UncompressedSize: 100},
 	})
 
 	runner := &fakeRunner{}
@@ -514,7 +532,7 @@ func TestRunIndexMergePhase_SingleIndexIsNoWork(t *testing.T) {
 	require.Empty(t, replacer.snapshot(), "no swap for a single-index window")
 }
 
-func TestRunIndexMergePhase_SingleIndexWithOverlappingSectionsSwaps(t *testing.T) {
+func TestRunIndexMergePhase_SingleIndexWithOverlappingSectionsIsNoWork(t *testing.T) {
 	ctx := context.Background()
 	window := imWindow()
 	bucket := objstore.NewInMemBucket()
@@ -536,10 +554,10 @@ func TestRunIndexMergePhase_SingleIndexWithOverlappingSectionsSwaps(t *testing.T
 	replacer := &fakeReplacer{swapped: true}
 	c := newTestCoordinator(t, bucket, &fakeRunner{}, replacer, fixedClock(window.Add(3*time.Hour)), newFakeLimits("acme"))
 
-	require.Equal(t, phaseOutcomeSwapped, c.runIndexMergePhase(ctx, "acme", window))
-	require.Len(t, replacer.snapshot(), 1)
-	require.Equal(t, 1.0, testutil.ToFloat64(c.metrics.unconsolidatedBacklog.WithLabelValues("acme")))
-	require.Equal(t, time.Hour.Seconds(), testutil.ToFloat64(c.metrics.oldestBacklogLogAgeSeconds.WithLabelValues("acme")))
+	require.Equal(t, phaseOutcomeNoWork, c.runIndexMergePhase(ctx, "acme", window))
+	require.Empty(t, replacer.snapshot(), "sections from one physical object are already converged")
+	require.Zero(t, testutil.ToFloat64(c.metrics.unconsolidatedBacklog.WithLabelValues("acme")))
+	require.Zero(t, testutil.ToFloat64(c.metrics.oldestBacklogLogAgeSeconds.WithLabelValues("acme")))
 }
 
 func TestCompactTenant_TouchingSectionsAreConverged(t *testing.T) {

--- a/pkg/engine/compactor/coordinator_test.go
+++ b/pkg/engine/compactor/coordinator_test.go
@@ -71,26 +71,40 @@ func (f *fakeRunner) snapshot() []runCall {
 }
 
 func (f *fakeRunner) assertUniqueObjects(t *testing.T) {
-	// Validate that no object section appears in more than one task
+	t.Helper()
+
+	// An object is one run: many sections of the same path may share a run,
+	// but that path must not appear in any other run or dispatched task.
+	seen := map[string]struct{}{}
 	for _, call := range f.calls {
 		root, err := call.plan.Root()
 		require.NoError(t, err)
 
-		callObjects := map[string]struct{}{}
 		err = call.plan.Graph().Walk(root, func(n physical.Node) error {
-			switch n.(type) {
+			var runs []*compactionv2pb.RunRef
+			switch n := n.(type) {
 			case *physical.LogMerge:
-				runs := n.(*physical.LogMerge).Runs
-				for _, run := range runs {
-					runObjects := map[string]struct{}{}
-					for _, sectionRef := range run.Sections {
-						runObjects[sectionRef.ObjectPath] = struct{}{}
+				runs = n.Runs
+			case *physical.IndexMerge:
+				runs = n.Runs
+			default:
+				return nil
+			}
+			for _, run := range runs {
+				if run == nil {
+					continue
+				}
+				runObjects := map[string]struct{}{}
+				for _, sectionRef := range run.Sections {
+					if sectionRef == nil {
+						continue
 					}
-					for obj := range runObjects {
-						_, exists := callObjects[obj]
-						require.False(t, exists, "object %q appears in more than one task", obj)
-						callObjects[obj] = struct{}{}
-					}
+					runObjects[sectionRef.ObjectPath] = struct{}{}
+				}
+				for obj := range runObjects {
+					_, exists := seen[obj]
+					require.False(t, exists, "object %q appears in more than one task", obj)
+					seen[obj] = struct{}{}
 				}
 			}
 			return nil

--- a/pkg/engine/compactor/sections.go
+++ b/pkg/engine/compactor/sections.go
@@ -24,6 +24,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/stats"
 )
 
+const prefetchBytes = 2 * 1024 * 1024
+
 // indexEntry is one index object listed in a ToC for a particular tenant.
 type indexEntry struct {
 	Path                 string
@@ -222,7 +224,7 @@ func indexSectionRefsFor(ctx context.Context, bucket objstore.Bucket, tenant str
 
 	var reads []sectionRead
 	for _, entry := range entries {
-		obj, err := dataobj.FromBucket(ctx, bucket, entry.Path, 0)
+		obj, err := dataobj.FromBucket(ctx, bucket, entry.Path, prefetchBytes)
 		if err != nil {
 			return nil, fmt.Errorf("open index tenant=%s index=%s: %w", tenant, entry.Path, err)
 		}

--- a/pkg/engine/compactor/sections.go
+++ b/pkg/engine/compactor/sections.go
@@ -340,7 +340,7 @@ func postingsBoundColumns(section *postings.Section) ([]*postings.Column, error)
 
 // logSectionRefsFor returns one bounded reference per log section indexed by idxPath.
 func logSectionRefsFor(ctx context.Context, bucket objstore.Bucket, tenant, idxPath string) ([]v2.Section[sortKey], []string, error) {
-	obj, err := dataobj.FromBucket(ctx, bucket, idxPath, 0)
+	obj, err := dataobj.FromBucket(ctx, bucket, idxPath, prefetchBytes)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open converged index tenant=%s index=%s: %w", tenant, idxPath, err)
 	}

--- a/pkg/engine/compactor/sections_test.go
+++ b/pkg/engine/compactor/sections_test.go
@@ -196,7 +196,7 @@ func TestLogSectionRefsFor_AggregatesStatsRows(t *testing.T) {
 			Labels: map[string]string{"service_name": "billing"}, MinTimestamp: 100, MaxTimestamp: 900, RowCount: 2, UncompressedSize: 200},
 	})
 
-	sections, schema, err := logSectionRefsFor(ctx, bucket, "acme", path)
+	refs, schema, err := logSectionRefsFor(ctx, bucket, "acme", path)
 	require.NoError(t, err)
 	require.Equal(t, []string{"label:service_name"}, schema)
 	require.Equal(t, []v2.Section[sortKey]{
@@ -213,7 +213,7 @@ func TestLogSectionRefsFor_AggregatesStatsRows(t *testing.T) {
 			Min: sortKey{labels: []string{"auth"}, timestamp: 500},
 			Max: sortKey{labels: []string{"billing"}, timestamp: 900},
 		},
-	}, sections)
+	}, refs)
 }
 
 func TestLogSectionRefsFor_OrdersPhysicalSections(t *testing.T) {
@@ -255,7 +255,7 @@ func TestLogSectionRefsFor_MultiKeySchemaOrdersValuesAndReturnsFQN(t *testing.T)
 			Labels: map[string]string{"service_name": "auth", "namespace": "eu"}, MinTimestamp: 10, MaxTimestamp: 20, RowCount: 1, UncompressedSize: 100},
 	})
 
-	sections, schema, err := logSectionRefsFor(ctx, bucket, "acme", path)
+	refs, schema, err := logSectionRefsFor(ctx, bucket, "acme", path)
 	require.NoError(t, err)
 	require.Equal(t, []string{"label:service_name", "label:namespace"}, schema)
 	require.Equal(t, []v2.Section[sortKey]{
@@ -271,7 +271,7 @@ func TestLogSectionRefsFor_MultiKeySchemaOrdersValuesAndReturnsFQN(t *testing.T)
 			Min: sortKey{labels: []string{"auth", "eu"}, timestamp: 10},
 			Max: sortKey{labels: []string{"auth", "eu"}, timestamp: 20},
 		},
-	}, sections)
+	}, refs)
 }
 
 func TestLogSectionRefsFor_EmptySortSchema(t *testing.T) {
@@ -284,14 +284,14 @@ func TestLogSectionRefsFor_EmptySortSchema(t *testing.T) {
 			Labels: map[string]string{}, MinTimestamp: 10, MaxTimestamp: 20, RowCount: 1, UncompressedSize: 100},
 	})
 
-	sections, schema, err := logSectionRefsFor(ctx, bucket, "acme", path)
+	refs, schema, err := logSectionRefsFor(ctx, bucket, "acme", path)
 	require.NoError(t, err)
 	require.Empty(t, schema, "empty sort_schema yields no schema keys (not a bogus label: entry)")
-	require.Len(t, sections, 1)
-	require.Equal(t, sortKey{timestamp: 10}, sections[0].Min)
-	require.Equal(t, sortKey{timestamp: 20}, sections[0].Max)
-	require.Equal(t, "logs/log-0", sections[0].Ref.ObjectPath)
-	require.Equal(t, int64(100), sections[0].Ref.UncompressedSize)
+	require.Len(t, refs, 1)
+	require.Equal(t, sortKey{timestamp: 10}, refs[0].Min)
+	require.Equal(t, sortKey{timestamp: 20}, refs[0].Max)
+	require.Equal(t, "logs/log-0", refs[0].Ref.ObjectPath)
+	require.Equal(t, int64(100), refs[0].Ref.UncompressedSize)
 }
 
 func TestLogSectionRefsFor_RejectsMixedSchemas(t *testing.T) {

--- a/pkg/engine/compactor/sections_test.go
+++ b/pkg/engine/compactor/sections_test.go
@@ -196,7 +196,7 @@ func TestLogSectionRefsFor_AggregatesStatsRows(t *testing.T) {
 			Labels: map[string]string{"service_name": "billing"}, MinTimestamp: 100, MaxTimestamp: 900, RowCount: 2, UncompressedSize: 200},
 	})
 
-	refs, schema, err := logSectionRefsFor(ctx, bucket, "acme", path)
+	sections, schema, err := logSectionRefsFor(ctx, bucket, "acme", path)
 	require.NoError(t, err)
 	require.Equal(t, []string{"label:service_name"}, schema)
 	require.Equal(t, []v2.Section[sortKey]{
@@ -213,7 +213,36 @@ func TestLogSectionRefsFor_AggregatesStatsRows(t *testing.T) {
 			Min: sortKey{labels: []string{"auth"}, timestamp: 500},
 			Max: sortKey{labels: []string{"billing"}, timestamp: 900},
 		},
-	}, refs)
+	}, sections)
+}
+
+func TestLogSectionRefsFor_OrdersPhysicalSections(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	path := "indexes/aa/objects"
+
+	buildIndexWithStats(ctx, t, bucket, "acme", path, []stats.Stat{
+		{ObjectPath: "logs/log-b", SectionIndex: 1, SortSchema: "label:service_name",
+			Labels: map[string]string{"service_name": "delta"}, MinTimestamp: 30, MaxTimestamp: 40, UncompressedSize: 100},
+		{ObjectPath: "logs/log-a", SectionIndex: 0, SortSchema: "label:service_name",
+			Labels: map[string]string{"service_name": "echo"}, MinTimestamp: 50, MaxTimestamp: 60, UncompressedSize: 100},
+		{ObjectPath: "logs/log-b", SectionIndex: 0, SortSchema: "label:service_name",
+			Labels: map[string]string{"service_name": "alpha"}, MinTimestamp: 10, MaxTimestamp: 20, UncompressedSize: 100},
+	})
+
+	sections, _, err := logSectionRefsFor(ctx, bucket, "acme", path)
+	require.NoError(t, err)
+	require.Len(t, sections, 3)
+	require.Equal(t, []string{"logs/log-a", "logs/log-b", "logs/log-b"}, []string{
+		sections[0].Ref.ObjectPath,
+		sections[1].Ref.ObjectPath,
+		sections[2].Ref.ObjectPath,
+	})
+	require.Equal(t, []int64{0, 0, 1}, []int64{
+		sections[0].Ref.SectionIndex,
+		sections[1].Ref.SectionIndex,
+		sections[2].Ref.SectionIndex,
+	})
 }
 
 func TestLogSectionRefsFor_MultiKeySchemaOrdersValuesAndReturnsFQN(t *testing.T) {
@@ -226,7 +255,7 @@ func TestLogSectionRefsFor_MultiKeySchemaOrdersValuesAndReturnsFQN(t *testing.T)
 			Labels: map[string]string{"service_name": "auth", "namespace": "eu"}, MinTimestamp: 10, MaxTimestamp: 20, RowCount: 1, UncompressedSize: 100},
 	})
 
-	refs, schema, err := logSectionRefsFor(ctx, bucket, "acme", path)
+	sections, schema, err := logSectionRefsFor(ctx, bucket, "acme", path)
 	require.NoError(t, err)
 	require.Equal(t, []string{"label:service_name", "label:namespace"}, schema)
 	require.Equal(t, []v2.Section[sortKey]{
@@ -242,7 +271,7 @@ func TestLogSectionRefsFor_MultiKeySchemaOrdersValuesAndReturnsFQN(t *testing.T)
 			Min: sortKey{labels: []string{"auth", "eu"}, timestamp: 10},
 			Max: sortKey{labels: []string{"auth", "eu"}, timestamp: 20},
 		},
-	}, refs)
+	}, sections)
 }
 
 func TestLogSectionRefsFor_EmptySortSchema(t *testing.T) {
@@ -255,14 +284,14 @@ func TestLogSectionRefsFor_EmptySortSchema(t *testing.T) {
 			Labels: map[string]string{}, MinTimestamp: 10, MaxTimestamp: 20, RowCount: 1, UncompressedSize: 100},
 	})
 
-	refs, schema, err := logSectionRefsFor(ctx, bucket, "acme", path)
+	sections, schema, err := logSectionRefsFor(ctx, bucket, "acme", path)
 	require.NoError(t, err)
 	require.Empty(t, schema, "empty sort_schema yields no schema keys (not a bogus label: entry)")
-	require.Len(t, refs, 1)
-	require.Equal(t, sortKey{timestamp: 10}, refs[0].Min)
-	require.Equal(t, sortKey{timestamp: 20}, refs[0].Max)
-	require.Equal(t, "logs/log-0", refs[0].Ref.ObjectPath)
-	require.Equal(t, int64(100), refs[0].Ref.UncompressedSize)
+	require.Len(t, sections, 1)
+	require.Equal(t, sortKey{timestamp: 10}, sections[0].Min)
+	require.Equal(t, sortKey{timestamp: 20}, sections[0].Max)
+	require.Equal(t, "logs/log-0", sections[0].Ref.ObjectPath)
+	require.Equal(t, int64(100), sections[0].Ref.UncompressedSize)
 }
 
 func TestLogSectionRefsFor_RejectsMixedSchemas(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This updates compaction planning to treat objects are pre-existing indivisible runs when planning.
* It isn't possible to consistently re-detect Runs from just looking at the sections, which meant that the planning phase tends to move data around rather than compact it. Said differently, without this change, compaction does not converge because it constantly shuffles data from overlapping objects around instead of consistently minimising it.