### PR TITLE
chore: Run index merge phase multiple times per log merge phase

### DIFF
--- a/pkg/engine/compactor/coordinator.go
+++ b/pkg/engine/compactor/coordinator.go
@@ -22,6 +22,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/engine/internal/workflow"
 )
 
+const indexMergeIterations = 3
+
 // tocReplacer is the subset of *metastore.TableOfContentsWriter the
 // coordinator needs.
 type tocReplacer interface {
@@ -789,6 +791,7 @@ func (c *coordinator) runLogMergePhase(ctx context.Context, tenant string, windo
 // window errored so a single failing window retries the whole phase.
 func (c *coordinator) runTenantLoop(ctx context.Context, tenant string) {
 	p := phaseIndexMerge
+	phaseCounter := 0
 	for {
 		if ctx.Err() != nil {
 			return
@@ -808,7 +811,14 @@ func (c *coordinator) runTenantLoop(ctx context.Context, tenant string) {
 		}
 
 		if outcome != phaseOutcomeError {
+			phaseCounter++
+			if p == phaseIndexMerge && phaseCounter < indexMergeIterations {
+				// Run index merge multiple times before flipping to log merge
+				continue
+			}
+
 			p = p.flip()
+			phaseCounter = 0
 		}
 	}
 }

--- a/pkg/engine/compactor/coordinator.go
+++ b/pkg/engine/compactor/coordinator.go
@@ -655,14 +655,13 @@ func (p phase) flip() phase {
 	return phaseIndexMerge
 }
 
-// phaseOutcome is the result of running one phase; it drives the flip-vs-retry
-// decision.
+// phaseOutcome is the result of running one phase
 type phaseOutcome int
 
 const (
 	phaseOutcomeError   phaseOutcome = iota // re-arm same phase
-	phaseOutcomeNoWork                      // success, nothing to do; flip
-	phaseOutcomeSwapped                     // ToC swap applied/observed; flip
+	phaseOutcomeNoWork                      // success, nothing to do
+	phaseOutcomeSwapped                     // ToC swap applied/observed
 )
 
 // runIndexMergePhase runs IndexMerge for the tenant's current window and swaps
@@ -791,7 +790,6 @@ func (c *coordinator) runLogMergePhase(ctx context.Context, tenant string, windo
 // window errored so a single failing window retries the whole phase.
 func (c *coordinator) runTenantLoop(ctx context.Context, tenant string) {
 	p := phaseIndexMerge
-	phaseCounter := 0
 	for {
 		if ctx.Err() != nil {
 			return
@@ -805,46 +803,46 @@ func (c *coordinator) runTenantLoop(ctx context.Context, tenant string) {
 			continue
 		}
 
-		outcome := c.runPhaseAllWindows(ctx, tenant, p)
+		iterations := 1
+		if p == phaseIndexMerge {
+			iterations = indexMergeIterations
+		}
+
+		outcome := c.runMultiplePhasesForAllWindows(ctx, tenant, p, iterations)
 		if ctx.Err() != nil {
 			return
 		}
 
 		if outcome != phaseOutcomeError {
-			phaseCounter++
-			if p == phaseIndexMerge && phaseCounter < indexMergeIterations {
-				// Run index merge multiple times before flipping to log merge
-				continue
-			}
-
 			p = p.flip()
-			phaseCounter = 0
 		}
 	}
 }
 
-// runPhaseAllWindows runs phase p for the tenant against each compacted window,
+// runMultiplePhasesForAllWindows runs phase p for the tenant against each compacted window, iterations times,
 // recording the worker-loop cycle metric per window, and returns the worst
 // outcome across them. Error dominates (the caller re-arms the same phase);
 // otherwise swapped (progress) outranks no-work. Windows are independent: a
 // window with no ToC no-ops while a populated one does real work.
-func (c *coordinator) runPhaseAllWindows(ctx context.Context, tenant string, p phase) phaseOutcome {
+func (c *coordinator) runMultiplePhasesForAllWindows(ctx context.Context, tenant string, p phase, iterations int) phaseOutcome {
 	worst := phaseOutcomeNoWork
-	for _, window := range c.windows() {
-		if ctx.Err() != nil {
-			return worst
-		}
+	for range iterations {
+		for _, window := range c.windows() {
+			if ctx.Err() != nil {
+				return worst
+			}
 
-		start := c.clock()
-		var outcome phaseOutcome
-		switch p {
-		case phaseIndexMerge:
-			outcome = c.runIndexMergePhase(ctx, tenant, window)
-		case phaseLogMerge:
-			outcome = c.runLogMergePhase(ctx, tenant, window)
+			start := c.clock()
+			var outcome phaseOutcome
+			switch p {
+			case phaseIndexMerge:
+				outcome = c.runIndexMergePhase(ctx, tenant, window)
+			case phaseLogMerge:
+				outcome = c.runLogMergePhase(ctx, tenant, window)
+			}
+			c.metrics.observeCycle(cycleOutcome(outcome), c.clock().Sub(start))
+			worst = worstOutcome(worst, outcome)
 		}
-		c.metrics.observeCycle(cycleOutcome(outcome), c.clock().Sub(start))
-		worst = worstOutcome(worst, outcome)
 	}
 	return worst
 }

--- a/pkg/engine/compactor/coordinator_test.go
+++ b/pkg/engine/compactor/coordinator_test.go
@@ -1739,6 +1739,51 @@ func TestRunTenantLoop_LogEnabledRunsBothPhases(t *testing.T) {
 		"log-enabled tenant flips between index-merge and log-merge")
 }
 
+func TestRunTenantLoop_RunsMultipleIndexMergesPerLogMerge(t *testing.T) {
+	window := imWindow()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bucket := logMergeBucket(ctx, t, window, "acme", []string{"a", "b"})
+	replacer := &fakeReplacer{swapped: true}
+	limits := newFakeLimits("acme")
+	limits.setLog("acme", true)
+	c := newTestCoordinator(t, bucket, &fakeRunner{}, replacer, fixedClock(window.Add(time.Hour)), limits)
+
+	var mu sync.Mutex
+	var phases []string
+	c.runPlan = func(_ context.Context, opts workflow.Options, _ *physical.Plan) (arrow.RecordBatch, error) {
+		mu.Lock()
+		phases = append(phases, opts.Actor[1])
+		if opts.Actor[1] == "log-merge" {
+			cancel()
+		}
+		mu.Unlock()
+		return v2.BuildResultRecord(memory.DefaultAllocator, []v2.ResultArtifact{{Path: "indexes/aa/bb"}}), nil
+	}
+
+	done := make(chan struct{})
+	go func() { c.runTenantLoop(ctx, "acme"); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		cancel()
+		t.Fatal("tenant loop did not reach log merge")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	expectation := []string{}
+	for range indexMergeIterations {
+		expectation = append(expectation, "index-merge")
+	}
+	expectation = append(expectation, "log-merge")
+
+	// expect: index-merge, index-merge, index-merge, log-merge
+	require.Equal(t, expectation, phases)
+}
+
 // TestRunTenantLoop_DisablingLogMidRunStopsLogMerge verifies that turning off
 // log compaction while the loop runs stops further log-merge dispatches on the
 // next iteration while index-merge continues, because runTenantLoop re-reads


### PR DESCRIPTION
**What this PR does / why we need it**:

This runs 3x index compactions for every log merge done by the compactor.
Each merge reduces Runs by K, but each log merge increases it again by K
 * (The K can be different for index & log merge, but in reality they are in the same ballpark)

This means index-compaction doesn't make progress if it flip-flops 1-1. This PR improves that behaviour by running 3x index merges to reduce index Runs by K^3 per each log-merge. This is enough to converge the index files to a single Run in most environments.