### PR TITLE
chore: Wire up a separate logsobj builder config

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1282,7 +1282,7 @@ dataobj:
       # The maximum row count for pages to use for the data object builder. A
       # value of 0 means no limit.
       # CLI flag: -dataobj-consumer.max-page-rows
-      [max_page_rows: <int> | default = 0]
+      [max_page_rows: <int> | default = 10000]
 
       # The target maximum size of the encoded object and all of its encoded
       # sections (after compression), to limit memory usage of a builder.
@@ -1545,7 +1545,7 @@ dataobj:
     # The maximum row count for pages to use for the data object builder. A
     # value of 0 means no limit.
     # CLI flag: -dataobj-index-builder.max-page-rows
-    [max_page_rows: <int> | default = 0]
+    [max_page_rows: <int> | default = 10000]
 
     # The target maximum size of the encoded object and all of its encoded
     # sections (after compression), to limit memory usage of a builder.
@@ -1709,28 +1709,28 @@ dataobj:
       # (for columnar sections). Uncompressed size is used for consistent I/O
       # and planning.
       # CLI flag: -dataobj.compaction.indexobj-builder.target-page-size
-      [target_page_size: <int> | default = 2KiB]
+      [target_page_size: <int> | default = 128KiB]
 
       # The maximum row count for pages to use for the data object builder. A
       # value of 0 means no limit.
       # CLI flag: -dataobj.compaction.indexobj-builder.max-page-rows
-      [max_page_rows: <int> | default = 0]
+      [max_page_rows: <int> | default = 10000]
 
       # The target maximum size of the encoded object and all of its encoded
       # sections (after compression), to limit memory usage of a builder.
       # CLI flag: -dataobj.compaction.indexobj-builder.target-builder-memory-limit
-      [target_object_size: <int> | default = 4MiB]
+      [target_object_size: <int> | default = 512MiB]
 
       # The target maximum amount of uncompressed data to hold in sections, for
       # sections that support being limited by size. Uncompressed size is used
       # for consistent I/O and planning.
       # CLI flag: -dataobj.compaction.indexobj-builder.target-section-size
-      [target_section_size: <int> | default = 2MiB]
+      [target_section_size: <int> | default = 512MiB]
 
       # The size of logs to buffer in memory before adding into columnar
       # builders, used to reduce CPU load of sorting.
       # CLI flag: -dataobj.compaction.indexobj-builder.buffer-size
-      [buffer_size: <int> | default = 16KiB]
+      [buffer_size: <int> | default = 128MiB]
 
       # The maximum number of dataobj section stripes to merge into a section at
       # once. Must be greater than 1.
@@ -1741,6 +1741,45 @@ dataobj:
       # output size from uncompressed buffered records. Only takes effect with
       # ordered append. Set to 0 or 1 to disable.
       # CLI flag: -dataobj.compaction.indexobj-builder.estimated-compression-ratio
+      [estimated_compression_ratio: <int> | default = 8]
+
+    logsobj_builder:
+      # The target maximum amount of uncompressed data to hold in data pages
+      # (for columnar sections). Uncompressed size is used for consistent I/O
+      # and planning.
+      # CLI flag: -dataobj.compaction.logsobj-builder.target-page-size
+      [target_page_size: <int> | default = 1MiB]
+
+      # The maximum row count for pages to use for the data object builder. A
+      # value of 0 means no limit.
+      # CLI flag: -dataobj.compaction.logsobj-builder.max-page-rows
+      [max_page_rows: <int> | default = 10000]
+
+      # The target maximum size of the encoded object and all of its encoded
+      # sections (after compression), to limit memory usage of a builder.
+      # CLI flag: -dataobj.compaction.logsobj-builder.target-builder-memory-limit
+      [target_object_size: <int> | default = 512MiB]
+
+      # The target maximum amount of uncompressed data to hold in sections, for
+      # sections that support being limited by size. Uncompressed size is used
+      # for consistent I/O and planning.
+      # CLI flag: -dataobj.compaction.logsobj-builder.target-section-size
+      [target_section_size: <int> | default = 512MiB]
+
+      # The size of logs to buffer in memory before adding into columnar
+      # builders, used to reduce CPU load of sorting.
+      # CLI flag: -dataobj.compaction.logsobj-builder.buffer-size
+      [buffer_size: <int> | default = 128MiB]
+
+      # The maximum number of dataobj section stripes to merge into a section at
+      # once. Must be greater than 1.
+      # CLI flag: -dataobj.compaction.logsobj-builder.section-stripe-merge-limit
+      [section_stripe_merge_limit: <int> | default = 2]
+
+      # Expected compression ratio for log data, used to estimate compressed
+      # output size from uncompressed buffered records. Only takes effect with
+      # ordered append. Set to 0 or 1 to disable.
+      # CLI flag: -dataobj.compaction.logsobj-builder.estimated-compression-ratio
       [estimated_compression_ratio: <int> | default = 8]
 
   # The prefix to use for the storage bucket.

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -93,6 +93,7 @@ type BuilderBaseConfig struct {
 
 // RegisterFlagsWithPrefix registers flags with the given prefix.
 func (cfg *BuilderBaseConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+
 	f.Var(&cfg.TargetPageSize, prefix+"target-page-size", "The target maximum amount of uncompressed data to hold in data pages (for columnar sections). Uncompressed size is used for consistent I/O and planning.")
 	f.IntVar(&cfg.MaxPageRows, prefix+"max-page-rows", 10000, "The maximum row count for pages to use for the data object builder. A value of 0 means no limit.")
 	f.Var(&cfg.TargetObjectSize, prefix+"target-builder-memory-limit", "The target maximum size of the encoded object and all of its encoded sections (after compression), to limit memory usage of a builder.")

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -93,7 +93,6 @@ type BuilderBaseConfig struct {
 
 // RegisterFlagsWithPrefix registers flags with the given prefix.
 func (cfg *BuilderBaseConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-
 	f.Var(&cfg.TargetPageSize, prefix+"target-page-size", "The target maximum amount of uncompressed data to hold in data pages (for columnar sections). Uncompressed size is used for consistent I/O and planning.")
 	f.IntVar(&cfg.MaxPageRows, prefix+"max-page-rows", 10000, "The maximum row count for pages to use for the data object builder. A value of 0 means no limit.")
 	f.Var(&cfg.TargetObjectSize, prefix+"target-builder-memory-limit", "The target maximum size of the encoded object and all of its encoded sections (after compression), to limit memory usage of a builder.")

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -94,7 +94,7 @@ type BuilderBaseConfig struct {
 // RegisterFlagsWithPrefix registers flags with the given prefix.
 func (cfg *BuilderBaseConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.Var(&cfg.TargetPageSize, prefix+"target-page-size", "The target maximum amount of uncompressed data to hold in data pages (for columnar sections). Uncompressed size is used for consistent I/O and planning.")
-	f.IntVar(&cfg.MaxPageRows, prefix+"max-page-rows", 0, "The maximum row count for pages to use for the data object builder. A value of 0 means no limit.")
+	f.IntVar(&cfg.MaxPageRows, prefix+"max-page-rows", 10000, "The maximum row count for pages to use for the data object builder. A value of 0 means no limit.")
 	f.Var(&cfg.TargetObjectSize, prefix+"target-builder-memory-limit", "The target maximum size of the encoded object and all of its encoded sections (after compression), to limit memory usage of a builder.")
 	f.Var(&cfg.TargetSectionSize, prefix+"target-section-size", "The target maximum amount of uncompressed data to hold in sections, for sections that support being limited by size. Uncompressed size is used for consistent I/O and planning.")
 	f.Var(&cfg.BufferSize, prefix+"buffer-size", "The size of logs to buffer in memory before adding into columnar builders, used to reduce CPU load of sorting.")

--- a/pkg/engine/compactor/config.go
+++ b/pkg/engine/compactor/config.go
@@ -93,10 +93,10 @@ type Config struct {
 
 	// IndexobjBuilder controls index object construction parameters (page sizes,
 	// target object/section sizes, etc.) used by the compactor worker when
-	// merging postings + stats sections into a new index object.
+	// merging postings and stats sections into a new index object.
 	IndexobjBuilder logsobj.BuilderBaseConfig `yaml:"indexobj_builder" category:"experimental"`
 
-	// LogsobjBuilder controls index object construction parameters (page sizes,
+	// LogsobjBuilder controls log object construction parameters (page sizes,
 	// target object/section sizes, etc.) used by the compactor worker when
 	// merging streams and logs sections into a new logs object.
 	LogsobjBuilder logsobj.BuilderBaseConfig `yaml:"logsobj_builder" category:"experimental"`
@@ -212,17 +212,18 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 		"Experimental: HTTP path the embedded compaction scheduler listens on for worker frame traffic.")
 	cfg.Worker.RegisterFlagsWithPrefix(prefix+"worker.", f)
 
+	cfg.IndexobjBuilder.RegisterFlagsWithPrefix(prefix+"indexobj-builder.", f)
 	_ = cfg.IndexobjBuilder.TargetPageSize.Set("128KB")
 	_ = cfg.IndexobjBuilder.TargetObjectSize.Set("512MB")
 	_ = cfg.IndexobjBuilder.TargetSectionSize.Set("512MB")
 	_ = cfg.IndexobjBuilder.BufferSize.Set("128MB")
-	cfg.IndexobjBuilder.RegisterFlagsWithPrefix(prefix+"indexobj-builder.", f)
 
+	cfg.LogsobjBuilder.RegisterFlagsWithPrefix(prefix+"logsobj-builder.", f)
 	_ = cfg.LogsobjBuilder.TargetPageSize.Set("1MB")
 	_ = cfg.LogsobjBuilder.TargetObjectSize.Set("512MB")
 	_ = cfg.LogsobjBuilder.TargetSectionSize.Set("512MB")
 	_ = cfg.LogsobjBuilder.BufferSize.Set("128MB")
-	cfg.LogsobjBuilder.RegisterFlagsWithPrefix(prefix+"logsobj-builder.", f)
+
 }
 
 // RegisterFlagsWithPrefix registers the worker config flags using prefix

--- a/pkg/engine/compactor/config.go
+++ b/pkg/engine/compactor/config.go
@@ -212,18 +212,21 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 		"Experimental: HTTP path the embedded compaction scheduler listens on for worker frame traffic.")
 	cfg.Worker.RegisterFlagsWithPrefix(prefix+"worker.", f)
 
-	cfg.IndexobjBuilder.RegisterFlagsWithPrefix(prefix+"indexobj-builder.", f)
+	// These configs do not have defaults in the flagset so default values must be Set before registering
+	// the flags to be documented correctly.
 	_ = cfg.IndexobjBuilder.TargetPageSize.Set("128KB")
 	_ = cfg.IndexobjBuilder.TargetObjectSize.Set("512MB")
 	_ = cfg.IndexobjBuilder.TargetSectionSize.Set("512MB")
 	_ = cfg.IndexobjBuilder.BufferSize.Set("128MB")
+	cfg.IndexobjBuilder.RegisterFlagsWithPrefix(prefix+"indexobj-builder.", f)
 
-	cfg.LogsobjBuilder.RegisterFlagsWithPrefix(prefix+"logsobj-builder.", f)
+	// These flags do not have defaults in the flagset so default values must be Set before registering
+	// the flags to be documented correctly.
 	_ = cfg.LogsobjBuilder.TargetPageSize.Set("1MB")
 	_ = cfg.LogsobjBuilder.TargetObjectSize.Set("512MB")
 	_ = cfg.LogsobjBuilder.TargetSectionSize.Set("512MB")
 	_ = cfg.LogsobjBuilder.BufferSize.Set("128MB")
-
+	cfg.LogsobjBuilder.RegisterFlagsWithPrefix(prefix+"logsobj-builder.", f)
 }
 
 // RegisterFlagsWithPrefix registers the worker config flags using prefix

--- a/pkg/engine/compactor/config.go
+++ b/pkg/engine/compactor/config.go
@@ -218,7 +218,6 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	_ = cfg.IndexobjBuilder.BufferSize.Set("128MB")
 	cfg.IndexobjBuilder.RegisterFlagsWithPrefix(prefix+"indexobj-builder.", f)
 
-	cfg.LogsobjBuilder.MaxPageRows = 10000
 	_ = cfg.LogsobjBuilder.TargetPageSize.Set("1MB")
 	_ = cfg.LogsobjBuilder.TargetObjectSize.Set("512MB")
 	_ = cfg.LogsobjBuilder.TargetSectionSize.Set("512MB")
@@ -278,6 +277,9 @@ func (cfg *Config) Validate() error {
 
 	if err := cfg.IndexobjBuilder.Validate(); err != nil {
 		return fmt.Errorf("invalid indexobj builder config: %w", err)
+	}
+	if err := cfg.LogsobjBuilder.Validate(); err != nil {
+		return fmt.Errorf("invalid logsobj builder config: %w", err)
 	}
 	return nil
 }

--- a/pkg/engine/compactor/config.go
+++ b/pkg/engine/compactor/config.go
@@ -95,6 +95,11 @@ type Config struct {
 	// target object/section sizes, etc.) used by the compactor worker when
 	// merging postings + stats sections into a new index object.
 	IndexobjBuilder logsobj.BuilderBaseConfig `yaml:"indexobj_builder" category:"experimental"`
+
+	// LogsobjBuilder controls index object construction parameters (page sizes,
+	// target object/section sizes, etc.) used by the compactor worker when
+	// merging streams and logs sections into a new logs object.
+	LogsobjBuilder logsobj.BuilderBaseConfig `yaml:"logsobj_builder" category:"experimental"`
 }
 
 // SchedulerConfig holds the scheduler-side parameters that get passed
@@ -207,11 +212,18 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 		"Experimental: HTTP path the embedded compaction scheduler listens on for worker frame traffic.")
 	cfg.Worker.RegisterFlagsWithPrefix(prefix+"worker.", f)
 
-	_ = cfg.IndexobjBuilder.TargetPageSize.Set("2KB")
-	_ = cfg.IndexobjBuilder.TargetObjectSize.Set("4MB")
-	_ = cfg.IndexobjBuilder.TargetSectionSize.Set("2MB")
-	_ = cfg.IndexobjBuilder.BufferSize.Set("16KB")
+	_ = cfg.IndexobjBuilder.TargetPageSize.Set("128KB")
+	_ = cfg.IndexobjBuilder.TargetObjectSize.Set("512MB")
+	_ = cfg.IndexobjBuilder.TargetSectionSize.Set("512MB")
+	_ = cfg.IndexobjBuilder.BufferSize.Set("128MB")
 	cfg.IndexobjBuilder.RegisterFlagsWithPrefix(prefix+"indexobj-builder.", f)
+
+	cfg.LogsobjBuilder.MaxPageRows = 10000
+	_ = cfg.LogsobjBuilder.TargetPageSize.Set("1MB")
+	_ = cfg.LogsobjBuilder.TargetObjectSize.Set("512MB")
+	_ = cfg.LogsobjBuilder.TargetSectionSize.Set("512MB")
+	_ = cfg.LogsobjBuilder.BufferSize.Set("128MB")
+	cfg.LogsobjBuilder.RegisterFlagsWithPrefix(prefix+"logsobj-builder.", f)
 }
 
 // RegisterFlagsWithPrefix registers the worker config flags using prefix

--- a/pkg/engine/compactor/worker.go
+++ b/pkg/engine/compactor/worker.go
@@ -28,8 +28,10 @@ type WorkerParams struct {
 	Logger     log.Logger
 	Registerer prometheus.Registerer
 
-	// IndexobjCfg controls index object construction parameters.
+	// IndexobjCfg controls index object construction parameters for compaction.
 	IndexobjCfg logsobj.BuilderBaseConfig
+	// LogsobjCfg controls index object construction parameters for compaction.
+	LogsobjCfg logsobj.BuilderBaseConfig
 }
 
 // Worker is the dataobj-compaction-worker target service. It wraps an
@@ -102,6 +104,7 @@ func NewWorker(params WorkerParams) (*Worker, error) {
 		// LocalScheduler left nil: the compaction worker only ever
 		// connects to remote schedulers via DNS-SRV.
 		IndexobjCfg:        params.IndexobjCfg,
+		LogsobjCfg:         params.LogsobjCfg,
 		IndexMergeObserver: wm,
 		LogMergeObserver:   wm,
 	}, registerer)

--- a/pkg/engine/internal/executor/executor.go
+++ b/pkg/engine/internal/executor/executor.go
@@ -50,6 +50,8 @@ type Config struct {
 	ScratchStore scratch.Store
 	// IndexobjCfg is the builder config for index objects.
 	IndexobjCfg logsobj.BuilderBaseConfig
+	// LogsobjCfg is the builder config for index objects.
+	LogsobjCfg logsobj.BuilderBaseConfig
 
 	// IndexMergeObserver is used  by compaction to populate output-size
 	// histograms. Optional; nil disables observation.
@@ -108,6 +110,7 @@ func Run(ctx context.Context, cfg Config, plan *physical.Plan, logger log.Logger
 		taskCaches:         cfg.TaskCaches,
 		scratchStore:       cfg.ScratchStore,
 		indexobjCfg:        cfg.IndexobjCfg,
+		logsobjCfg:         cfg.LogsobjCfg,
 		indexMergeObserver: cfg.IndexMergeObserver,
 		logMergeObserver:   cfg.LogMergeObserver,
 	}
@@ -143,6 +146,7 @@ type Context struct {
 
 	scratchStore scratch.Store
 	indexobjCfg  logsobj.BuilderBaseConfig
+	logsobjCfg   logsobj.BuilderBaseConfig
 
 	indexMergeObserver IndexMergeObserver
 	logMergeObserver   LogMergeObserver

--- a/pkg/engine/internal/executor/index_merge_test.go
+++ b/pkg/engine/internal/executor/index_merge_test.go
@@ -717,17 +717,21 @@ func uploadObjectToBucket(ctx context.Context, bucket objstore.Bucket, path stri
 func newTestExecutorContext(t *testing.T, bucket objstore.Bucket) *Context {
 	t.Helper()
 
+	testBuilderCfg := logsobj.BuilderBaseConfig{
+		TargetPageSize:          2048,
+		MaxPageRows:             10000,
+		TargetObjectSize:        1 << 22, // 4 MiB
+		TargetSectionSize:       1 << 21, // 2 MiB
+		BufferSize:              2048 * 8,
+		SectionStripeMergeLimit: 2,
+	}
+
 	return &Context{
 		bucket:       bucket,
 		scratchStore: scratch.NewMemory(),
-		indexobjCfg: logsobj.BuilderBaseConfig{
-			TargetPageSize:          2048,
-			MaxPageRows:             10000,
-			TargetObjectSize:        1 << 22, // 4 MiB
-			TargetSectionSize:       1 << 21, // 2 MiB
-			BufferSize:              2048 * 8,
-			SectionStripeMergeLimit: 2,
-		},
+		indexobjCfg:  testBuilderCfg,
+		logsobjCfg:   testBuilderCfg,
+
 		logger: log.NewNopLogger(),
 	}
 }

--- a/pkg/engine/internal/executor/log_merge.go
+++ b/pkg/engine/internal/executor/log_merge.go
@@ -396,7 +396,7 @@ func (c *Context) newLogObjectWriter(node *physical.LogMerge, table *globalStrea
 
 func (w *logObjectWriter) startNewObject() error {
 	cfg := logsobj.BuilderConfig{
-		BuilderBaseConfig:    w.c.indexobjCfg,
+		BuilderBaseConfig:    w.c.logsobjCfg,
 		DataobjSortOrder:     "stream-asc",
 		AppendOrderedEnabled: true,
 		DataobjUseSortSchema: true,

--- a/pkg/engine/internal/executor/log_merge_test.go
+++ b/pkg/engine/internal/executor/log_merge_test.go
@@ -246,9 +246,9 @@ func TestCollectLogSources_ReadsFromUnprefixedDataBucket(t *testing.T) {
 func newSmallObjectExecutorContext(t *testing.T, bucket objstore.Bucket) *Context {
 	t.Helper()
 	c := newTestExecutorContext(t, bucket)
-	c.indexobjCfg.TargetPageSize = 512
-	c.indexobjCfg.TargetObjectSize = 1000 // bytes; forces splitting
-	c.indexobjCfg.TargetSectionSize = 800
+	c.logsobjCfg.TargetPageSize = 512
+	c.logsobjCfg.TargetObjectSize = 1000 // bytes; forces splitting
+	c.logsobjCfg.TargetSectionSize = 800
 	return c
 }
 

--- a/pkg/engine/internal/worker/thread.go
+++ b/pkg/engine/internal/worker/thread.go
@@ -97,6 +97,7 @@ type thread struct {
 	TaskCaches     executor.TaskCacheRegistry
 	ScratchStore   scratch.Store
 	IndexobjCfg    logsobj.BuilderBaseConfig
+	LogsobjCfg     logsobj.BuilderBaseConfig
 
 	// IndexMergeObserver is optional; nil for query-only workers.
 	IndexMergeObserver executor.IndexMergeObserver
@@ -225,6 +226,7 @@ func (t *thread) runJob(ctx context.Context, job *threadJob) {
 		TaskCaches:     t.TaskCaches,
 		ScratchStore:   t.ScratchStore,
 		IndexobjCfg:    t.IndexobjCfg,
+		LogsobjCfg:     t.LogsobjCfg,
 
 		IndexMergeObserver: t.IndexMergeObserver,
 		LogMergeObserver:   t.LogMergeObserver,

--- a/pkg/engine/internal/worker/worker.go
+++ b/pkg/engine/internal/worker/worker.go
@@ -102,9 +102,13 @@ type Config struct {
 	// Required for compaction tasks; may be nil for query-only workers.
 	ScratchStore scratch.Store
 
-	// IndexobjCfg is the builder config for index objects.
+	// IndexobjCfg is the builder config for compacted index objects.
 	// Required for compaction tasks; may be nil for query-only workers.
 	IndexobjCfg logsobj.BuilderBaseConfig
+
+	// LogsobjCfg is the builder config for compacted log objects
+	// Required for compaction tasks; may be nil for query-only workers.
+	LogsobjCfg logsobj.BuilderBaseConfig
 
 	// IndexMergeObserver is used  by compaction to populate output-size
 	// histograms. Optional; nil disables observation.
@@ -215,6 +219,7 @@ func (w *Worker) run(ctx context.Context) error {
 			TaskCaches:     w.taskCaches,
 			ScratchStore:   w.config.ScratchStore,
 			IndexobjCfg:    w.config.IndexobjCfg,
+			LogsobjCfg:     w.config.LogsobjCfg,
 
 			IndexMergeObserver: w.config.IndexMergeObserver,
 			LogMergeObserver:   w.config.LogMergeObserver,

--- a/pkg/engine/worker.go
+++ b/pkg/engine/worker.go
@@ -75,11 +75,11 @@ type WorkerParams struct {
 	ScratchStore scratch.Store
 
 	// IndexobjCfg is the builder config for compacted index objects.
-	// Required for compaction tasks; may be nil for query-only workers.
+	// Required for compaction tasks; may be the zero value for query-only workers.
 	IndexobjCfg logsobj.BuilderBaseConfig
 
 	// LogsobjCfg is the builder config for compacted log objects
-	// Required for compaction tasks; may be nil for query-only workers.
+	// Required for compaction tasks; may be the zero-value for query-only workers.
 	LogsobjCfg logsobj.BuilderBaseConfig
 
 	// IndexMergeObserver is used  by compaction to populate output-size

--- a/pkg/engine/worker.go
+++ b/pkg/engine/worker.go
@@ -74,9 +74,13 @@ type WorkerParams struct {
 	// Required for compaction tasks; may be nil for query-only workers.
 	ScratchStore scratch.Store
 
-	// IndexobjCfg is the builder config for index objects.
+	// IndexobjCfg is the builder config for compacted index objects.
 	// Required for compaction tasks; may be nil for query-only workers.
 	IndexobjCfg logsobj.BuilderBaseConfig
+
+	// LogsobjCfg is the builder config for compacted log objects
+	// Required for compaction tasks; may be nil for query-only workers.
+	LogsobjCfg logsobj.BuilderBaseConfig
 
 	// IndexMergeObserver is used  by compaction to populate output-size
 	// histograms. Optional; nil for query-only workers.
@@ -173,6 +177,7 @@ func NewWorker(params WorkerParams, reg prometheus.Registerer) (*Worker, error) 
 		TaskCaches:     taskCaches,
 		ScratchStore:   params.ScratchStore,
 		IndexobjCfg:    params.IndexobjCfg,
+		LogsobjCfg:     params.LogsobjCfg,
 
 		IndexMergeObserver: params.IndexMergeObserver,
 		LogMergeObserver:   params.LogMergeObserver,

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -2459,6 +2459,7 @@ func (t *Loki) initDataObjCompactionWorker() (services.Service, error) {
 		Metastore:    ms,
 		ScratchStore: t.scratchStore,
 		IndexobjCfg:  t.Cfg.DataObj.Compaction.IndexobjBuilder,
+		LogsobjCfg:   t.Cfg.DataObj.Compaction.LogsobjBuilder,
 		Logger:       logger,
 		Registerer:   prometheus.DefaultRegisterer,
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

Wires up a separate configuration for logsobj vs indexobj so we don't need to use the same for both.

From experience, these are similar but we use smaller page sizes on index objects
I updated the defaults against the latest recommendations.

This ends up wiring all the way through multiple layers so there a lot of small changes in many files.