### PR TITLE
fix(pattern-ingester): Cluster count inflated by stream.prune

### DIFF
--- a/pkg/pattern/stream.go
+++ b/pkg/pattern/stream.go
@@ -174,10 +174,10 @@ func (s *stream) prune(olderThan time.Duration) bool {
 			if cluster.Size == 0 {
 				pattern.Delete(cluster)
 			}
-			// Clear empty branches and track total clusters
-			pattern.Prune()
-			totalClusters += len(pattern.Clusters())
 		}
+		// Clear empty branches and track total clusters
+		pattern.Prune()
+		totalClusters += len(pattern.Clusters())
 	}
 
 	// Filter clusters by volume if volumeThreshold is set (< 1.0)

--- a/pkg/pattern/stream_test.go
+++ b/pkg/pattern/stream_test.go
@@ -178,6 +178,50 @@ func TestPruneStream(t *testing.T) {
 	require.Equal(t, int64(1), res.Series[0].Samples[0].Value)
 }
 
+// TestPruneStreamMultipleClustersInSameLevel guards against a regression where
+// totalClusters was tallied once per cluster processed (an intermediate,
+// partially-pruned snapshot) instead of once per level after all of that
+// level's clusters were pruned. With a single cluster the two approaches
+// happen to agree, which is why TestPruneStream didn't catch it: two or more
+// clusters in the same level aging out together is required to tell them
+// apart.
+func TestPruneStreamMultipleClustersInSameLevel(t *testing.T) {
+	lbs := labels.New(labels.Label{Name: "test", Value: "test"})
+	mockWriter := &mockEntryWriter{}
+	mockWriter.On("WriteEntry", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	stream, err := newStream(
+		model.Fingerprint(labels.StableHash(lbs)),
+		lbs,
+		newIngesterMetrics(nil, "test"),
+		log.NewNopLogger(),
+		drain.FormatUnknown,
+		"123",
+		drain.DefaultConfig(),
+		&fakeLimits{patternRateThreshold: 1.0, persistenceGranularity: time.Hour},
+		mockWriter,
+		aggregation.NewMetrics(nil),
+		0.99,
+	)
+	require.NoError(t, err)
+
+	// Two distinct patterns produce two distinct clusters in the same
+	// ("unknown") level, both old enough to be pruned away in one sweep.
+	err = stream.Push(context.Background(), []push.Entry{
+		{Timestamp: time.Unix(20, 0), Line: "aaaa bbbb cccc dddd"},
+		{Timestamp: time.Unix(20, 0), Line: "wwww xxxx yyyy zzzz"},
+	})
+	require.NoError(t, err)
+
+	clusters := 0
+	for _, p := range stream.patterns {
+		clusters += len(p.Clusters())
+	}
+	require.Equal(t, 2, clusters, "expected 2 distinct clusters before pruning")
+
+	require.True(t, stream.prune(time.Hour),
+		"stream has zero clusters left in every level; prune() should report it as empty")
+}
+
 func TestStreamPruneFiltersLowVolumePatterns(t *testing.T) {
 	lbs := labels.New(
 		labels.Label{Name: "test", Value: "test"},


### PR DESCRIPTION
**What this PR does / why we need it**:
## Summary

`stream.prune` calls `pattern.Prune()` (a full prefix-tree walk) and tallies                                                                                                                `totalClusters` once per **cluster processed**, instead of once per level after all its clusters are processed. This is both a performance bug and a correctness bug:

- **Performance:** for a level with N clusters, the tree gets walked N times per sweep instead of once.
- **Correctness:** `totalClusters` sums N *intermediate* snapshots of `pattern.Clusters()` (taken mid-loop, before later clusters in the same level have been deleted) instead of one *final* snapshot. When two or more clusters in the same level age out in the same sweep, this inflates the total above zero even though the level ends the sweep empty.

`stream.prune`'s return value (`totalClusters == 0`) is what tells `sweepInstance` whether to call `instance.removeStream`. With the bug, a stream whose patterns had 2+ clusters expire together would be incorrectly kept alive for at least one extra `FlushCheckPeriod` cycle instead of being removed immediately — it isn't a permanent leak (the next sweep sees the already-emptied cache and self-corrects), but its memory held longer than it needs to be.

  ## Fix
  
Move the `pattern.Prune()` call and the `totalClusters` tally out of the per-cluster loop and into the per-level loop, so each level's tree is walked once and its cluster count is read once, after that level's deletes are done.
  
 **Correctness** — added `TestPruneStreamMultipleClustersInSameLevel`, which pushes two distinct patterns into the same level and ages both out in one sweep. Verified by temporarily reverting to the old placement:

  - Old code: `stream.prune(time.Hour)` → `false` (wrong — the stream has 0
    clusters left in every level)
  - Fixed code: → `true` (correct)

**Performance** — `BenchmarkStreamMemory_PruneNoop` (34 clusters, nothing actually due for pruning — i.e. the steady-state cost paid every `FlushCheckPeriod` for every stream):

  | | before | after | Δ |
  |---|---|---|---|
  | time/op | 669.8 µs | 20.9 µs | **−96.9%** |
  | B/op | 10,368 | 864 | **−91.7%** |
  | allocs/op | 36 | 3 | **−91.7%** |
  | clusters (sanity) | 34 | 34 | unchanged |

  (benchstat, n=5, p=0.008 for time/op and B/op)


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
