### PR TITLE
fix: prevent duplicate labels in ingester zone StatefulSet when podLabels conflicts

### DIFF
--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-a.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-a.yaml
@@ -8,10 +8,8 @@ metadata:
   namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
-    app.kubernetes.io/part-of: memberlist
-    name: {{ include "loki.prefixIngesterName" . }}ingester-zone-a
-    rollout-group: {{ include "loki.prefixRolloutGroup" . }}ingester
-    {{- with .Values.ingester.labels }}
+    {{- $zoneMetaLabels := dict "app.kubernetes.io/part-of" "memberlist" "name" (include "loki.prefixIngesterName" .)ingester-zone-a "rollout-group" (include "loki.prefixRolloutGroup" .)ingester -}}
+    {{- with merge .Values.ingester.labels $zoneMetaLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
@@ -63,13 +61,11 @@ spec:
       labels:
         {{- include "loki.ingesterLabels" . | nindent 8 }}
         app.kubernetes.io/part-of: memberlist
-        name: {{ include "loki.prefixIngesterName" . }}ingester-zone-a
-        rollout-group: {{ include "loki.prefixRolloutGroup" . }}ingester
-        {{- with merge (dict) .Values.loki.podLabels .Values.ingester.podLabels }}
+        {{- include "loki.ingesterLabels" . | nindent 8 }}
+        {{- $zoneLabels := dict "app.kubernetes.io/part-of" "memberlist" "name" (include "loki.prefixIngesterName" .)ingester-zone-a "rollout-group" (include "loki.prefixRolloutGroup" .)ingester -}}
+        {{- with merge .Values.loki.podLabels .Values.ingester.podLabels $zoneLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-    spec:
-      {{- if semverCompare ">=1.19-0" (include "loki.kubeVersion" .) }}
       {{- with .Values.ingester.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- tpl ( . | toYaml) $ | nindent 8 }}

--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-b.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-b.yaml
@@ -8,10 +8,8 @@ metadata:
   namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
-    app.kubernetes.io/part-of: memberlist
-    name: {{ include "loki.prefixIngesterName" . }}ingester-zone-b
-    rollout-group: {{ include "loki.prefixRolloutGroup" . }}ingester
-    {{- with .Values.ingester.labels }}
+    {{- $zoneMetaLabels := dict "app.kubernetes.io/part-of" "memberlist" "name" (include "loki.prefixIngesterName" .)ingester-zone-b "rollout-group" (include "loki.prefixRolloutGroup" .)ingester -}}
+    {{- with merge .Values.ingester.labels $zoneMetaLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
@@ -63,13 +61,11 @@ spec:
       labels:
         {{- include "loki.ingesterLabels" . | nindent 8 }}
         app.kubernetes.io/part-of: memberlist
-        name: {{ include "loki.prefixIngesterName" . }}ingester-zone-b
-        rollout-group: {{ include "loki.prefixRolloutGroup" . }}ingester
-        {{- with merge (dict) .Values.ingester.podLabels .Values.loki.podLabels }}
+        {{- include "loki.ingesterLabels" . | nindent 8 }}
+        {{- $zoneLabels := dict "app.kubernetes.io/part-of" "memberlist" "name" (include "loki.prefixIngesterName" .)ingester-zone-b "rollout-group" (include "loki.prefixRolloutGroup" .)ingester -}}
+        {{- with merge .Values.loki.podLabels .Values.ingester.podLabels $zoneLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-    spec:
-      {{- if semverCompare ">=1.19-0" (include "loki.kubeVersion" .) }}
       {{- with .Values.ingester.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- tpl ( . | toYaml) $ | nindent 8 }}

--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-c.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-c.yaml
@@ -8,10 +8,8 @@ metadata:
   namespace: {{ include "loki.namespace" . }}
   labels:
     {{- include "loki.ingesterLabels" . | nindent 4 }}
-    app.kubernetes.io/part-of: memberlist
-    name: {{ include "loki.prefixIngesterName" . }}ingester-zone-c
-    rollout-group: {{ include "loki.prefixRolloutGroup" . }}ingester
-    {{- with .Values.ingester.labels }}
+    {{- $zoneMetaLabels := dict "app.kubernetes.io/part-of" "memberlist" "name" (include "loki.prefixIngesterName" .)ingester-zone-c "rollout-group" (include "loki.prefixRolloutGroup" .)ingester -}}
+    {{- with merge .Values.ingester.labels $zoneMetaLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
@@ -63,13 +61,11 @@ spec:
       labels:
         {{- include "loki.ingesterLabels" . | nindent 8 }}
         app.kubernetes.io/part-of: memberlist
-        name: {{ include "loki.prefixIngesterName" . }}ingester-zone-c
-        rollout-group: {{ include "loki.prefixRolloutGroup" . }}ingester
-        {{- with merge (dict) .Values.ingester.podLabels .Values.loki.podLabels  }}
+        {{- include "loki.ingesterLabels" . | nindent 8 }}
+        {{- $zoneLabels := dict "app.kubernetes.io/part-of" "memberlist" "name" (include "loki.prefixIngesterName" .)ingester-zone-c "rollout-group" (include "loki.prefixRolloutGroup" .)ingester -}}
+        {{- with merge .Values.loki.podLabels .Values.ingester.podLabels $zoneLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-    spec:
-      {{- if semverCompare ">=1.19-0" (include "loki.kubeVersion" .) }}
       {{- with .Values.ingester.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- tpl ( . | toYaml) $ | nindent 8 }}


### PR DESCRIPTION
### Problem

When `ingester.zoneAwareReplication.enabled=true`, the three zone StatefulSet templates use the pod label `name: <prefix>ingester-zone-{a,b,c}` as the zone discriminator, and reference it from `spec.selector.matchLabels`.

The same templates also append `.Values.loki.podLabels` and `.Values.ingester.podLabels` verbatim via `toYaml`, after their own labels. If a user sets `podLabels.name`, the rendered `spec.template.metadata.labels` contains the key `name` **twice** — once from the chart's own label, and once from the user's podLabels.

### Consequences

1. The chart emits a YAML mapping with a duplicate key, which is invalid per the YAML spec.
2. Duplicate keys resolve last-wins, so the effective pod label becomes the user's value while `spec.selector.matchLabels` still requires the chart's value. The API server rejects the StatefulSet with `selector does not match template labels`.

The same collision applies to `rollout-group` and `app.kubernetes.io/part-of`.

### Fix

Use Sprig's `merge` function with the chart's structurally significant labels as the rightmost (highest-precedence) argument, so they always win over user-supplied `podLabels`:

```yaml
{{- $zoneLabels := dict "app.kubernetes.io/part-of" "memberlist" "name" (include "loki.prefixIngesterName" .)ingester-zone-X "rollout-group" (include "loki.prefixRolloutGroup" .)ingester -}}
{{- with merge .Values.loki.podLabels .Values.ingester.podLabels $zoneLabels }}
{{- toYaml . | nindent 8 }}
{{- end }}
```

This ensures `merge` gives precedence to the rightmost dict (`$zoneLabels`), so the chart's critical labels can never be overridden by user podLabels.

Applied to all three zone files (`statefulset-ingester-zone-{a,b,c}.yaml`) for both `metadata.labels` and `spec.template.metadata.labels`.

Fixes #23919
