### PR TITLE
fix(iter): Fix error handling and resource leaks in chained sample and entry iterators

### DIFF
--- a/pkg/iter/entry_iterator.go
+++ b/pkg/iter/entry_iterator.go
@@ -408,6 +408,7 @@ func (i *queryClientIterator) Close() error {
 type nonOverlappingIterator struct {
 	iterators []EntryIterator
 	curr      EntryIterator
+	err       error
 }
 
 // NewNonOverlappingIterator gives a chained iterator over a list of iterators.
@@ -419,15 +420,23 @@ func NewNonOverlappingIterator(iterators []EntryIterator) EntryIterator {
 
 func (i *nonOverlappingIterator) Next() bool {
 	for i.curr == nil || !i.curr.Next() {
-		if len(i.iterators) == 0 {
-			if i.curr != nil {
-				i.curr.Close()
-			}
-			return false
-		}
 		if i.curr != nil {
+			// The current iterator stopped. If it failed, surface the error and stop:
+			// any error fails the query, so advancing would hide the failure as normal
+			// exhaustion and read remaining streams whose data the query discards.
+			if err := i.curr.Err(); err != nil {
+				i.err = err
+				return false
+			}
+			// A close error here is a cleanup failure, not a read failure. Reporting it
+			// as a read failure would be inaccurate.
 			i.curr.Close()
 		}
+
+		if len(i.iterators) == 0 {
+			return false
+		}
+
 		i.curr, i.iterators = i.iterators[0], i.iterators[1:]
 	}
 
@@ -453,21 +462,22 @@ func (i *nonOverlappingIterator) StreamHash() uint64 {
 }
 
 func (i *nonOverlappingIterator) Err() error {
-	if i.curr == nil {
-		return nil
-	}
-	return i.curr.Err()
+	return i.err
 }
 
 func (i *nonOverlappingIterator) Close() error {
+	// Close every iterator and keep all errors: Add ignores nil, so a clean close
+	// still returns nil.
+	var errs util.MultiError
 	if i.curr != nil {
-		i.curr.Close()
+		errs.Add(i.curr.Close())
 	}
 	for _, iter := range i.iterators {
-		iter.Close()
+		errs.Add(iter.Close())
 	}
 	i.iterators = nil
-	return nil
+
+	return errs.Err()
 }
 
 type timeRangedIterator struct {

--- a/pkg/iter/entry_iterator.go
+++ b/pkg/iter/entry_iterator.go
@@ -470,7 +470,12 @@ func (i *nonOverlappingIterator) Close() error {
 	// still returns nil.
 	var errs util.MultiError
 	if i.curr != nil {
-		errs.Add(i.curr.Close())
+		// If curr already failed, some implementations return that same read error
+		// from Close too. It was already surfaced through Err, so closing here is
+		// cleanup only: do not report it a second time as a close error.
+		if err := i.curr.Close(); err != nil && i.err == nil {
+			errs.Add(err)
+		}
 	}
 	for _, iter := range i.iterators {
 		errs.Add(iter.Close())

--- a/pkg/iter/entry_iterator_test.go
+++ b/pkg/iter/entry_iterator_test.go
@@ -2,6 +2,7 @@ package iter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"math/rand"
@@ -959,4 +960,184 @@ func TestMergeIteratorNoDedupDifferentStructuredMetadata(t *testing.T) {
 	require.Equal(t, ts, got[1].Timestamp)
 	require.Equal(t, line, got[1].Line)
 	require.NotEqual(t, got[0].StructuredMetadata, got[1].StructuredMetadata)
+}
+
+// TestNonOverlappingIterator_ShouldSurfaceErrors verifies the entry concatenation
+// reports a sub-iterator failure through Err instead of treating it as normal
+// exhaustion.
+func TestNonOverlappingIterator_ShouldSurfaceErrors(t *testing.T) {
+	line := func(ts int) logproto.Entry {
+		return logproto.Entry{Timestamp: time.Unix(int64(ts), 0), Line: fmt.Sprintf("%d", ts)}
+	}
+	failing := func(ts int, labels string, err error) EntryIterator {
+		return &erroringEntryIterator{entries: []logproto.Entry{line(ts)}, labels: labels, err: err}
+	}
+	healthy := func(ts int, labels string) EntryIterator {
+		return NewStreamIterator(logproto.Stream{Labels: labels, Entries: []logproto.Entry{line(ts)}})
+	}
+
+	t.Run("error stops iteration and is surfaced", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		it := NewNonOverlappingIterator([]EntryIterator{
+			failing(1, `{app="a"}`, wantErr),
+			healthy(2, `{app="b"}`),
+		})
+
+		var got int
+		for it.Next() {
+			got++
+		}
+		require.Equal(t, 1, got, "iteration stops at the failing stream; later streams are not played")
+		require.ErrorIs(t, it.Err(), wantErr, "the error must be surfaced, not dropped as normal exhaustion")
+	})
+
+	t.Run("error in the last stream is surfaced", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		it := NewNonOverlappingIterator([]EntryIterator{
+			healthy(1, `{app="a"}`),
+			failing(2, `{app="b"}`, wantErr),
+		})
+
+		for it.Next() { //nolint:revive
+		}
+		require.ErrorIs(t, it.Err(), wantErr)
+	})
+
+	t.Run("no error returns nil", func(t *testing.T) {
+		it := NewNonOverlappingIterator([]EntryIterator{
+			healthy(1, `{app="a"}`),
+			healthy(2, `{app="b"}`),
+		})
+
+		var got int
+		for it.Next() {
+			got++
+		}
+		require.Equal(t, 2, got)
+		require.NoError(t, it.Err())
+	})
+
+	t.Run("close error surfaces through Close, not Err", func(t *testing.T) {
+		wantErr := errors.New("close boom")
+		it := NewNonOverlappingIterator([]EntryIterator{
+			&erroringEntryIterator{entries: []logproto.Entry{line(1)}, labels: `{app="a"}`, closeErr: wantErr},
+			healthy(2, `{app="b"}`),
+		})
+
+		require.NoError(t, it.Err(), "a close error is not a read error")
+		require.ErrorIs(t, it.Close(), wantErr, "Close must surface a sub-iterator close error")
+	})
+
+	t.Run("close error while iterating is not a read error", func(t *testing.T) {
+		// The first iterator reads cleanly, then its Close fails while iterating.
+		// That is a cleanup failure, not a read failure, so iteration continues
+		// and Err stays nil.
+		it := NewNonOverlappingIterator([]EntryIterator{
+			&erroringEntryIterator{entries: []logproto.Entry{line(1)}, labels: `{app="a"}`, closeErr: errors.New("close boom")},
+			healthy(2, `{app="b"}`),
+		})
+
+		var got int
+		for it.Next() {
+			got++
+		}
+		require.Equal(t, 2, got, "both streams play; a close failure does not stop iteration")
+		require.NoError(t, it.Err(), "a close error during iteration must not become a read error")
+	})
+
+	t.Run("stream that errors before any entry stops immediately", func(t *testing.T) {
+		wantErr := errors.New("open failed")
+		it := NewNonOverlappingIterator([]EntryIterator{
+			&erroringEntryIterator{labels: `{app="a"}`, err: wantErr}, // no entries
+			healthy(2, `{app="b"}`),
+		})
+
+		var got int
+		for it.Next() {
+			got++
+		}
+		require.Equal(t, 0, got, "no entries are produced")
+		require.ErrorIs(t, it.Err(), wantErr)
+	})
+
+	t.Run("error in a middle stream stops before later streams", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		it := NewNonOverlappingIterator([]EntryIterator{
+			healthy(1, `{app="a"}`),
+			failing(2, `{app="b"}`, wantErr),
+			healthy(3, `{app="c"}`),
+		})
+
+		var got int
+		for it.Next() {
+			got++
+		}
+		require.Equal(t, 2, got, "the stream after the failing one is not played")
+		require.ErrorIs(t, it.Err(), wantErr)
+	})
+
+	t.Run("fail-fast leaves cleanup to Close", func(t *testing.T) {
+		errored := &erroringEntryIterator{entries: []logproto.Entry{line(1)}, labels: `{app="a"}`, err: errors.New("boom")}
+		later1 := &erroringEntryIterator{entries: []logproto.Entry{line(2)}, labels: `{app="b"}`}
+		later2 := &erroringEntryIterator{entries: []logproto.Entry{line(3)}, labels: `{app="c"}`}
+
+		it := NewNonOverlappingIterator([]EntryIterator{errored, later1, later2})
+		for it.Next() { //nolint:revive
+		}
+		require.NoError(t, it.Close())
+
+		require.Equal(t, 1, errored.closed, "the errored current iterator is closed once")
+		require.Equal(t, 1, later1.closed, "an un-started iterator is closed once")
+		require.Equal(t, 1, later2.closed, "an un-started iterator is closed once")
+	})
+
+	t.Run("Close surfaces every close error", func(t *testing.T) {
+		it := NewNonOverlappingIterator([]EntryIterator{
+			&erroringEntryIterator{entries: []logproto.Entry{line(1)}, closeErr: errors.New("close a")},
+			&erroringEntryIterator{entries: []logproto.Entry{line(2)}, closeErr: errors.New("close b")},
+		})
+
+		err := it.Close() // no iteration, so both remain for Close to close
+		require.ErrorContains(t, err, "close a")
+		require.ErrorContains(t, err, "close b")
+	})
+
+	t.Run("Err is stable after a read error", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		it := NewNonOverlappingIterator([]EntryIterator{failing(1, `{app="a"}`, wantErr)})
+
+		for it.Next() { //nolint:revive
+		}
+		require.ErrorIs(t, it.Err(), wantErr)
+
+		require.False(t, it.Next(), "further Next calls keep returning false")
+		require.ErrorIs(t, it.Err(), wantErr, "Err stays set")
+	})
+}
+
+// erroringEntryIterator yields its entries, then fails: the Next after the last
+// entry returns false with err set, modeling a stream that read some data and
+// then failed mid-stream.
+type erroringEntryIterator struct {
+	entries  []logproto.Entry
+	labels   string
+	err      error // a read failure, returned by Err once the entries are exhausted
+	closeErr error // a cleanup failure, returned by Close; kept separate from err
+	closed   int   // number of times Close was called
+	i        int
+}
+
+func (it *erroringEntryIterator) Next() bool {
+	it.i++
+	return it.i <= len(it.entries)
+}
+func (it *erroringEntryIterator) At() logproto.Entry { return it.entries[it.i-1] }
+func (it *erroringEntryIterator) Labels() string     { return it.labels }
+func (it *erroringEntryIterator) StreamHash() uint64 { return 0 }
+func (it *erroringEntryIterator) Close() error       { it.closed++; return it.closeErr }
+func (it *erroringEntryIterator) Err() error {
+	if it.i > len(it.entries) {
+		return it.err
+	}
+	return nil
 }

--- a/pkg/iter/entry_iterator_test.go
+++ b/pkg/iter/entry_iterator_test.go
@@ -1091,6 +1091,22 @@ func TestNonOverlappingIterator_ShouldSurfaceErrors(t *testing.T) {
 		require.Equal(t, 1, later2.closed, "an un-started iterator is closed once")
 	})
 
+	t.Run("close error replaying an already-surfaced read error is not reported again", func(t *testing.T) {
+		// Some EntryIterator implementations (e.g. the chunk block iterator) return
+		// their stored read error from Close too, as a fallback for callers that
+		// only check the Close return value. That must not turn into a second,
+		// spurious close error once the read error already surfaced through Err.
+		wantErr := errors.New("boom")
+		errored := &erroringEntryIterator{entries: []logproto.Entry{line(1)}, labels: `{app="a"}`, err: wantErr, closeErr: wantErr}
+
+		it := NewNonOverlappingIterator([]EntryIterator{errored, healthy(2, `{app="b"}`)})
+		for it.Next() { //nolint:revive
+		}
+		require.ErrorIs(t, it.Err(), wantErr)
+		require.NoError(t, it.Close())
+		require.Equal(t, 1, errored.closed)
+	})
+
 	t.Run("Close surfaces every close error", func(t *testing.T) {
 		it := NewNonOverlappingIterator([]EntryIterator{
 			&erroringEntryIterator{entries: []logproto.Entry{line(1)}, closeErr: errors.New("close a")},

--- a/pkg/iter/sample_iterator.go
+++ b/pkg/iter/sample_iterator.go
@@ -211,6 +211,14 @@ func (i *mergeSampleIterator) requeue(ei SampleIterator, advanced bool) {
 		return
 	}
 
+	i.closeIterator(ei)
+}
+
+// closeIterator closes a drained input iterator and records its pending error.
+//
+// This function runs while Next drains an iterator. Close reaches only the iterators left
+// on the heap, so without this a fully drained merge would leak every source.
+func (i *mergeSampleIterator) closeIterator(ei SampleIterator) {
 	if err := ei.Err(); err != nil {
 		i.errs = append(i.errs, err)
 	}
@@ -235,7 +243,7 @@ func (i *mergeSampleIterator) Next() bool {
 		i.curr.labels = i.heap.Peek().Labels()
 		i.curr.streamHash = i.heap.Peek().StreamHash()
 		if !i.heap.Peek().Next() {
-			i.heap.Pop()
+			i.closeIterator(i.heap.Pop().(SampleIterator))
 		}
 		return true
 	}
@@ -273,6 +281,7 @@ Outer:
 	inner:
 		for {
 			if !next.Next() {
+				i.closeIterator(next)
 				continue Outer
 			}
 			sample := next.At()
@@ -341,14 +350,21 @@ func (i *mergeSampleIterator) Err() error {
 	}
 }
 
+// Close closes every input iterator and returns any error the merge collected.
 func (i *mergeSampleIterator) Close() error {
+	// Closes the sources not yet moved onto the heap (Close before the first Next).
+	for _, it := range i.is {
+		i.closeIterator(it)
+	}
+	i.is = nil
+
+	// Close the sources still on the heap, and closes all of them even when one fails,
+	// so no source leaks.
 	for i.heap.Len() > 0 {
-		if err := i.heap.Pop().(SampleIterator).Close(); err != nil {
-			return err
-		}
+		i.closeIterator(i.heap.Pop().(SampleIterator))
 	}
 	i.buffer = nil
-	return nil
+	return i.Err()
 }
 
 // sortSampleIterator iterates over a heap of iterators by sorting samples.
@@ -394,10 +410,7 @@ func (i *sortSampleIterator) init() {
 			continue
 		}
 
-		if err := it.Err(); err != nil {
-			i.errs = append(i.errs, err)
-		}
-		util.LogError("closing iterator", it.Close)
+		i.closeIterator(it)
 	}
 	heap.Init(i.heap)
 
@@ -420,10 +433,7 @@ func (i *sortSampleIterator) Next() bool {
 	// if the top iterator is empty, we remove it.
 	if !next.Next() {
 		heap.Pop(i.heap)
-		if err := next.Err(); err != nil {
-			i.errs = append(i.errs, err)
-		}
-		util.LogError("closing iterator", next.Close)
+		i.closeIterator(next)
 		return true
 	}
 	if i.heap.Len() > 1 {
@@ -455,13 +465,28 @@ func (i *sortSampleIterator) Err() error {
 	}
 }
 
-func (i *sortSampleIterator) Close() error {
-	for i.heap.Len() > 0 {
-		if err := i.heap.Pop().(SampleIterator).Close(); err != nil {
-			return err
-		}
+// closeIterator closes a drained input iterator and records its pending error.
+func (i *sortSampleIterator) closeIterator(it SampleIterator) {
+	if err := it.Err(); err != nil {
+		i.errs = append(i.errs, err)
 	}
-	return nil
+	util.LogError("closing iterator", it.Close)
+}
+
+// Close closes every input iterator and returns any error the sort collected.
+func (i *sortSampleIterator) Close() error {
+	// Closes the sources not yet moved onto the heap.
+	for _, it := range i.is {
+		i.closeIterator(it)
+	}
+	i.is = nil
+
+	// Close the sources still on the heap, and closes all of them even when one fails,
+	// so no source leaks.
+	for i.heap.Len() > 0 {
+		i.closeIterator(i.heap.Pop().(SampleIterator))
+	}
+	return i.Err()
 }
 
 type sampleQueryClientIterator struct {

--- a/pkg/iter/sample_iterator.go
+++ b/pkg/iter/sample_iterator.go
@@ -610,6 +610,7 @@ type nonOverlappingSampleIterator struct {
 	i         int
 	iterators []SampleIterator
 	curr      SampleIterator
+	err       error
 }
 
 // NewNonOverlappingSampleIterator gives a chained iterator over a list of iterators.
@@ -621,15 +622,23 @@ func NewNonOverlappingSampleIterator(iterators []SampleIterator) SampleIterator 
 
 func (i *nonOverlappingSampleIterator) Next() bool {
 	for i.curr == nil || !i.curr.Next() {
-		if len(i.iterators) == 0 {
-			if i.curr != nil {
-				i.curr.Close()
-			}
-			return false
-		}
 		if i.curr != nil {
+			// The current iterator stopped. If it failed, surface the error and stop:
+			// any error fails the query, so advancing would hide the failure as normal
+			// exhaustion and read remaining streams whose data the query discards.
+			if err := i.curr.Err(); err != nil {
+				i.err = err
+				return false
+			}
+			// A close error here is a cleanup failure, not a read failure. Reporting it
+			// as a read failure would be inaccurate.
 			i.curr.Close()
 		}
+
+		if len(i.iterators) == 0 {
+			return false
+		}
+
 		i.i++
 		i.curr, i.iterators = i.iterators[0], i.iterators[1:]
 	}
@@ -656,21 +665,22 @@ func (i *nonOverlappingSampleIterator) StreamHash() uint64 {
 }
 
 func (i *nonOverlappingSampleIterator) Err() error {
-	if i.curr == nil {
-		return nil
-	}
-	return i.curr.Err()
+	return i.err
 }
 
 func (i *nonOverlappingSampleIterator) Close() error {
+	// Close every iterator and keep all errors: Add ignores nil, so a clean close
+	// still returns nil.
+	var errs util.MultiError
 	if i.curr != nil {
-		i.curr.Close()
+		errs.Add(i.curr.Close())
 	}
 	for _, iter := range i.iterators {
-		iter.Close()
+		errs.Add(iter.Close())
 	}
 	i.iterators = nil
-	return nil
+
+	return errs.Err()
 }
 
 type timeRangedSampleIterator struct {

--- a/pkg/iter/sample_iterator.go
+++ b/pkg/iter/sample_iterator.go
@@ -673,7 +673,12 @@ func (i *nonOverlappingSampleIterator) Close() error {
 	// still returns nil.
 	var errs util.MultiError
 	if i.curr != nil {
-		errs.Add(i.curr.Close())
+		// If curr already failed, some implementations return that same read error
+		// from Close too. It was already surfaced through Err, so closing here is
+		// cleanup only: do not report it a second time as a close error.
+		if err := i.curr.Close(); err != nil && i.err == nil {
+			errs.Add(err)
+		}
 	}
 	for _, iter := range i.iterators {
 		errs.Add(iter.Close())

--- a/pkg/iter/sample_iterator_test.go
+++ b/pkg/iter/sample_iterator_test.go
@@ -541,3 +541,180 @@ func TestMergeSampleIteratorZeroHash(t *testing.T) {
 	require.NoError(t, it.Err())
 	require.NoError(t, it.Close())
 }
+
+// TestNonOverlappingSampleIterator_ShouldSurfaceErrors verifies the concatenation
+// reports a sub-iterator failure through Err instead of treating it as normal
+// exhaustion.
+func TestNonOverlappingSampleIterator_ShouldSurfaceErrors(t *testing.T) {
+	failing := func(ts int, labels string, err error) SampleIterator {
+		return &erroringSampleIterator{samples: []logproto.Sample{sample(ts)}, labels: labels, err: err}
+	}
+	healthy := func(ts int, labels string) SampleIterator {
+		return NewSeriesIterator(logproto.Series{Labels: labels, Samples: []logproto.Sample{sample(ts)}})
+	}
+
+	t.Run("error stops iteration and is surfaced", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		it := NewNonOverlappingSampleIterator([]SampleIterator{
+			failing(1, `{app="a"}`, wantErr),
+			healthy(2, `{app="b"}`),
+		})
+
+		var got int
+		for it.Next() {
+			got++
+		}
+		require.Equal(t, 1, got, "iteration stops at the failing stream; later streams are not played")
+		require.ErrorIs(t, it.Err(), wantErr, "the error must be surfaced, not dropped as normal exhaustion")
+	})
+
+	t.Run("error in the last stream is surfaced", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		it := NewNonOverlappingSampleIterator([]SampleIterator{
+			healthy(1, `{app="a"}`),
+			failing(2, `{app="b"}`, wantErr),
+		})
+
+		for it.Next() { //nolint:revive
+		}
+		require.ErrorIs(t, it.Err(), wantErr)
+	})
+
+	t.Run("no error returns nil", func(t *testing.T) {
+		it := NewNonOverlappingSampleIterator([]SampleIterator{
+			healthy(1, `{app="a"}`),
+			healthy(2, `{app="b"}`),
+		})
+
+		var got int
+		for it.Next() {
+			got++
+		}
+		require.Equal(t, 2, got)
+		require.NoError(t, it.Err())
+	})
+
+	t.Run("close error surfaces through Close, not Err", func(t *testing.T) {
+		wantErr := errors.New("close boom")
+		it := NewNonOverlappingSampleIterator([]SampleIterator{
+			&erroringSampleIterator{samples: []logproto.Sample{sample(1)}, labels: `{app="a"}`, closeErr: wantErr},
+			healthy(2, `{app="b"}`),
+		})
+
+		require.NoError(t, it.Err(), "a close error is not a read error")
+		require.ErrorIs(t, it.Close(), wantErr, "Close must surface a sub-iterator close error")
+	})
+
+	t.Run("close error while iterating is not a read error", func(t *testing.T) {
+		// The first iterator reads cleanly, then its Close fails while iterating.
+		// That is a cleanup failure, not a read failure, so iteration continues
+		// and Err stays nil.
+		it := NewNonOverlappingSampleIterator([]SampleIterator{
+			&erroringSampleIterator{samples: []logproto.Sample{sample(1)}, labels: `{app="a"}`, closeErr: errors.New("close boom")},
+			healthy(2, `{app="b"}`),
+		})
+
+		var got int
+		for it.Next() {
+			got++
+		}
+		require.Equal(t, 2, got, "both streams play; a close failure does not stop iteration")
+		require.NoError(t, it.Err(), "a close error during iteration must not become a read error")
+	})
+
+	t.Run("stream that errors before any sample stops immediately", func(t *testing.T) {
+		wantErr := errors.New("open failed")
+		it := NewNonOverlappingSampleIterator([]SampleIterator{
+			&erroringSampleIterator{labels: `{app="a"}`, err: wantErr}, // no samples
+			healthy(2, `{app="b"}`),
+		})
+
+		var got int
+		for it.Next() {
+			got++
+		}
+		require.Equal(t, 0, got, "no samples are produced")
+		require.ErrorIs(t, it.Err(), wantErr)
+	})
+
+	t.Run("error in a middle stream stops before later streams", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		it := NewNonOverlappingSampleIterator([]SampleIterator{
+			healthy(1, `{app="a"}`),
+			failing(2, `{app="b"}`, wantErr),
+			healthy(3, `{app="c"}`),
+		})
+
+		var got int
+		for it.Next() {
+			got++
+		}
+		require.Equal(t, 2, got, "the stream after the failing one is not played")
+		require.ErrorIs(t, it.Err(), wantErr)
+	})
+
+	t.Run("fail-fast leaves cleanup to Close", func(t *testing.T) {
+		// The fail-fast path does not close the errored current iterator, so Close
+		// must close it and the never-started streams, each exactly once.
+		errored := &erroringSampleIterator{samples: []logproto.Sample{sample(1)}, labels: `{app="a"}`, err: errors.New("boom")}
+		later1 := &erroringSampleIterator{samples: []logproto.Sample{sample(2)}, labels: `{app="b"}`}
+		later2 := &erroringSampleIterator{samples: []logproto.Sample{sample(3)}, labels: `{app="c"}`}
+
+		it := NewNonOverlappingSampleIterator([]SampleIterator{errored, later1, later2})
+		for it.Next() { //nolint:revive
+		}
+		require.NoError(t, it.Close())
+
+		require.Equal(t, 1, errored.closed, "the errored current iterator is closed once")
+		require.Equal(t, 1, later1.closed, "an un-started iterator is closed once")
+		require.Equal(t, 1, later2.closed, "an un-started iterator is closed once")
+	})
+
+	t.Run("Close surfaces every close error", func(t *testing.T) {
+		it := NewNonOverlappingSampleIterator([]SampleIterator{
+			&erroringSampleIterator{samples: []logproto.Sample{sample(1)}, closeErr: errors.New("close a")},
+			&erroringSampleIterator{samples: []logproto.Sample{sample(2)}, closeErr: errors.New("close b")},
+		})
+
+		err := it.Close() // no iteration, so both remain for Close to close
+		require.ErrorContains(t, err, "close a")
+		require.ErrorContains(t, err, "close b")
+	})
+
+	t.Run("Err is stable after a read error", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		it := NewNonOverlappingSampleIterator([]SampleIterator{failing(1, `{app="a"}`, wantErr)})
+
+		for it.Next() { //nolint:revive
+		}
+		require.False(t, it.Next(), "further Next calls keep returning false")
+		require.ErrorIs(t, it.Err(), wantErr, "Err stays set")
+	})
+}
+
+// erroringSampleIterator yields its samples, then fails: the Next after the last
+// sample returns false with err set, modeling a stream that read some data and
+// then failed mid-stream.
+type erroringSampleIterator struct {
+	samples  []logproto.Sample
+	labels   string
+	err      error // a read failure, returned by Err once the samples are exhausted
+	closeErr error // a cleanup failure, returned by Close; kept separate from err
+	closed   int   // number of times Close was called
+	i        int
+}
+
+func (it *erroringSampleIterator) Next() bool {
+	it.i++
+	return it.i <= len(it.samples)
+}
+func (it *erroringSampleIterator) At() logproto.Sample { return it.samples[it.i-1] }
+func (it *erroringSampleIterator) Labels() string      { return it.labels }
+func (it *erroringSampleIterator) StreamHash() uint64  { return 0 }
+func (it *erroringSampleIterator) Close() error        { it.closed++; return it.closeErr }
+func (it *erroringSampleIterator) Err() error {
+	if it.i > len(it.samples) {
+		return it.err
+	}
+	return nil
+}

--- a/pkg/iter/sample_iterator_test.go
+++ b/pkg/iter/sample_iterator_test.go
@@ -670,6 +670,22 @@ func TestNonOverlappingSampleIterator_ShouldSurfaceErrors(t *testing.T) {
 		require.Equal(t, 1, later2.closed, "an un-started iterator is closed once")
 	})
 
+	t.Run("close error replaying an already-surfaced read error is not reported again", func(t *testing.T) {
+		// Some SampleIterator implementations (e.g. the chunk block iterator) return
+		// their stored read error from Close too, as a fallback for callers that
+		// only check the Close return value. That must not turn into a second,
+		// spurious close error once the read error already surfaced through Err.
+		wantErr := errors.New("boom")
+		errored := &erroringSampleIterator{samples: []logproto.Sample{sample(1)}, labels: `{app="a"}`, err: wantErr, closeErr: wantErr}
+
+		it := NewNonOverlappingSampleIterator([]SampleIterator{errored, healthy(2, `{app="b"}`)})
+		for it.Next() { //nolint:revive
+		}
+		require.ErrorIs(t, it.Err(), wantErr)
+		require.NoError(t, it.Close())
+		require.Equal(t, 1, errored.closed)
+	})
+
 	t.Run("Close surfaces every close error", func(t *testing.T) {
 		it := NewNonOverlappingSampleIterator([]SampleIterator{
 			&erroringSampleIterator{samples: []logproto.Sample{sample(1)}, closeErr: errors.New("close a")},

--- a/pkg/iter/sample_iterator_test.go
+++ b/pkg/iter/sample_iterator_test.go
@@ -281,6 +281,239 @@ func TestNonOverlappingSampleClose(t *testing.T) {
 	require.Equal(t, true, b.closed.Load())
 }
 
+// TestMergeSampleIterator_ShouldCloseEverySource checks the merge closes every
+// input exactly once: drained during Next, empty in requeue, left on the heap
+// for Close, or never prefetched.
+func TestMergeSampleIterator_ShouldCloseEverySource(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("fully drained closes every source once", func(t *testing.T) {
+		// Staggered timestamps drain the early sources through the merge loop and
+		// the last remaining source through the single-iterator shortcut.
+		a := &erroringSampleIterator{samples: []logproto.Sample{sample(1), sample(4)}, labels: `{s="a"}`}
+		b := &erroringSampleIterator{samples: []logproto.Sample{sample(2), sample(5)}, labels: `{s="b"}`}
+		c := &erroringSampleIterator{samples: []logproto.Sample{sample(3)}, labels: `{s="c"}`}
+
+		it := NewMergeSampleIterator(ctx, []SampleIterator{a, b, c})
+		var got int
+		for it.Next() {
+			got++
+		}
+		require.NoError(t, it.Err())
+		require.Equal(t, 5, got)
+		require.NoError(t, it.Close())
+
+		require.Equal(t, 1, a.closed, "a drains through the merge loop and is closed once")
+		require.Equal(t, 1, b.closed, "b drains last through the shortcut and is closed once")
+		require.Equal(t, 1, c.closed, "c drains through the merge loop and is closed once")
+	})
+
+	t.Run("single source drained through the shortcut is closed once", func(t *testing.T) {
+		a := &erroringSampleIterator{samples: []logproto.Sample{sample(1), sample(2)}, labels: `{s="a"}`}
+
+		it := NewMergeSampleIterator(ctx, []SampleIterator{a})
+		for it.Next() { //nolint:revive
+		}
+		require.NoError(t, it.Close())
+
+		require.Equal(t, 1, a.closed)
+	})
+
+	t.Run("empty sources are closed once", func(t *testing.T) {
+		empty := &erroringSampleIterator{labels: `{s="empty"}`}
+		a := &erroringSampleIterator{samples: []logproto.Sample{sample(1)}, labels: `{s="a"}`}
+
+		it := NewMergeSampleIterator(ctx, []SampleIterator{empty, a})
+		for it.Next() { //nolint:revive
+		}
+		require.NoError(t, it.Close())
+
+		require.Equal(t, 1, empty.closed, "an empty source is closed once when requeued")
+		require.Equal(t, 1, a.closed)
+	})
+
+	t.Run("close before full drain closes each source once", func(t *testing.T) {
+		a := &erroringSampleIterator{samples: []logproto.Sample{sample(1)}, labels: `{s="a"}`}
+		b := &erroringSampleIterator{samples: []logproto.Sample{sample(2)}, labels: `{s="b"}`}
+
+		it := NewMergeSampleIterator(ctx, []SampleIterator{a, b})
+		require.True(t, it.Next()) // drains a; b stays on the heap
+		require.NoError(t, it.Close())
+
+		require.Equal(t, 1, a.closed, "a drained during Next is not closed again by Close")
+		require.Equal(t, 1, b.closed, "b left on the heap is closed by Close")
+	})
+
+	t.Run("Close closes every heap source even when one Close fails", func(t *testing.T) {
+		// Two data runs so a single Next leaves both sources on the heap. Both
+		// Close calls fail, so a first-error return would leak whichever is second.
+		a := &erroringSampleIterator{samples: []logproto.Sample{sample(1), sample(3)}, labels: `{s="a"}`, closeErr: errors.New("close a")}
+		b := &erroringSampleIterator{samples: []logproto.Sample{sample(2), sample(4)}, labels: `{s="b"}`, closeErr: errors.New("close b")}
+
+		it := NewMergeSampleIterator(ctx, []SampleIterator{a, b})
+		require.True(t, it.Next()) // prefetch both onto the heap
+		it.Close()
+
+		require.Equal(t, 1, a.closed, "a is closed once")
+		require.Equal(t, 1, b.closed, "a failing Close must not leak b")
+	})
+
+	t.Run("Close before any iteration closes every source", func(t *testing.T) {
+		// Never iterated, so the sources are still queued and not yet on the heap.
+		a := &erroringSampleIterator{samples: []logproto.Sample{sample(1)}, labels: `{s="a"}`}
+		b := &erroringSampleIterator{samples: []logproto.Sample{sample(2)}, labels: `{s="b"}`}
+
+		it := NewMergeSampleIterator(ctx, []SampleIterator{a, b})
+		require.NoError(t, it.Close())
+
+		require.Equal(t, 1, a.closed, "an un-prefetched source is closed by Close")
+		require.Equal(t, 1, b.closed, "an un-prefetched source is closed by Close")
+	})
+}
+
+// TestMergeSampleIterator_ShouldSurfaceDrainError checks a source's read error
+// reaches Err when it fails at EOF while draining through Next.
+func TestMergeSampleIterator_ShouldSurfaceDrainError(t *testing.T) {
+	ctx := context.Background()
+	wantErr := errors.New("boom")
+
+	t.Run("error draining through the merge loop is surfaced", func(t *testing.T) {
+		// errored yields ts1,ts2 then fails at EOF; healthy at ts3 keeps the merge
+		// going, so errored drains through the merge loop rather than the shortcut.
+		errored := &erroringSampleIterator{samples: []logproto.Sample{sample(1), sample(2)}, labels: `{s="a"}`, err: wantErr}
+		healthy := &erroringSampleIterator{samples: []logproto.Sample{sample(3)}, labels: `{s="b"}`}
+
+		it := NewMergeSampleIterator(ctx, []SampleIterator{errored, healthy})
+		for it.Next() { //nolint:revive
+		}
+		require.ErrorIs(t, it.Err(), wantErr)
+		require.Equal(t, 1, errored.closed)
+		require.Equal(t, 1, healthy.closed)
+		it.Close()
+	})
+
+	t.Run("error draining through the single-iterator shortcut is surfaced", func(t *testing.T) {
+		// A lone source that fails at EOF drains through the heap.Len()==1 shortcut.
+		errored := &erroringSampleIterator{samples: []logproto.Sample{sample(1), sample(2)}, labels: `{s="a"}`, err: wantErr}
+
+		it := NewMergeSampleIterator(ctx, []SampleIterator{errored})
+		for it.Next() { //nolint:revive
+		}
+		require.ErrorIs(t, it.Err(), wantErr)
+		require.Equal(t, 1, errored.closed)
+		it.Close()
+	})
+}
+
+// TestSortSampleIterator_ShouldCloseEverySource checks the sort closes every
+// input exactly once: drained during Next, empty at init, left on the heap for
+// Close, or never prefetched.
+func TestSortSampleIterator_ShouldCloseEverySource(t *testing.T) {
+	t.Run("fully drained closes every source once", func(t *testing.T) {
+		// Distinct timestamps interleave the sources so each drains through Next.
+		// The sort does not dedupe, so all five samples are returned.
+		a := &erroringSampleIterator{samples: []logproto.Sample{sample(1), sample(4)}, labels: `{s="a"}`}
+		b := &erroringSampleIterator{samples: []logproto.Sample{sample(2), sample(5)}, labels: `{s="b"}`}
+		c := &erroringSampleIterator{samples: []logproto.Sample{sample(3)}, labels: `{s="c"}`}
+
+		it := NewSortSampleIterator([]SampleIterator{a, b, c})
+		var got int
+		for it.Next() {
+			got++
+		}
+		require.NoError(t, it.Err())
+		require.Equal(t, 5, got)
+		require.NoError(t, it.Close())
+
+		require.Equal(t, 1, a.closed)
+		require.Equal(t, 1, b.closed)
+		require.Equal(t, 1, c.closed)
+	})
+
+	t.Run("empty sources are closed once", func(t *testing.T) {
+		empty := &erroringSampleIterator{labels: `{s="empty"}`}
+		a := &erroringSampleIterator{samples: []logproto.Sample{sample(1)}, labels: `{s="a"}`}
+
+		it := NewSortSampleIterator([]SampleIterator{empty, a})
+		for it.Next() { //nolint:revive
+		}
+		require.NoError(t, it.Close())
+
+		require.Equal(t, 1, empty.closed, "an empty source is closed once in init")
+		require.Equal(t, 1, a.closed)
+	})
+
+	t.Run("close before full drain closes each source once", func(t *testing.T) {
+		a := &erroringSampleIterator{samples: []logproto.Sample{sample(1)}, labels: `{s="a"}`}
+		b := &erroringSampleIterator{samples: []logproto.Sample{sample(2)}, labels: `{s="b"}`}
+
+		it := NewSortSampleIterator([]SampleIterator{a, b})
+		require.True(t, it.Next()) // drains a; b stays on the heap
+		require.NoError(t, it.Close())
+
+		require.Equal(t, 1, a.closed, "a drained during Next is not closed again by Close")
+		require.Equal(t, 1, b.closed, "b left on the heap is closed by Close")
+	})
+
+	t.Run("Close closes every heap source even when one Close fails", func(t *testing.T) {
+		// Two data runs so a single Next leaves both sources on the heap. Both
+		// Close calls fail, so a first-error return would leak whichever is second.
+		a := &erroringSampleIterator{samples: []logproto.Sample{sample(1), sample(3)}, labels: `{s="a"}`, closeErr: errors.New("close a")}
+		b := &erroringSampleIterator{samples: []logproto.Sample{sample(2), sample(4)}, labels: `{s="b"}`, closeErr: errors.New("close b")}
+
+		it := NewSortSampleIterator([]SampleIterator{a, b})
+		require.True(t, it.Next()) // both stay on the heap
+		it.Close()
+
+		require.Equal(t, 1, a.closed, "a is closed once")
+		require.Equal(t, 1, b.closed, "a failing Close must not leak b")
+	})
+
+	t.Run("Close before any iteration closes every source", func(t *testing.T) {
+		// Never iterated, so the sources are still queued and not yet on the heap.
+		a := &erroringSampleIterator{samples: []logproto.Sample{sample(1)}, labels: `{s="a"}`}
+		b := &erroringSampleIterator{samples: []logproto.Sample{sample(2)}, labels: `{s="b"}`}
+
+		it := NewSortSampleIterator([]SampleIterator{a, b})
+		require.NoError(t, it.Close())
+
+		require.Equal(t, 1, a.closed, "an un-prefetched source is closed by Close")
+		require.Equal(t, 1, b.closed, "an un-prefetched source is closed by Close")
+	})
+}
+
+// TestSortSampleIterator_ShouldSurfaceDrainError checks a source's read error
+// reaches Err whether it fails at EOF during Next or fails immediately in init.
+func TestSortSampleIterator_ShouldSurfaceDrainError(t *testing.T) {
+	wantErr := errors.New("boom")
+
+	t.Run("error draining through Next is surfaced", func(t *testing.T) {
+		errored := &erroringSampleIterator{samples: []logproto.Sample{sample(1), sample(2)}, labels: `{s="a"}`, err: wantErr}
+		healthy := &erroringSampleIterator{samples: []logproto.Sample{sample(3)}, labels: `{s="b"}`}
+
+		it := NewSortSampleIterator([]SampleIterator{errored, healthy})
+		for it.Next() { //nolint:revive
+		}
+		require.ErrorIs(t, it.Err(), wantErr)
+		require.Equal(t, 1, errored.closed)
+		require.Equal(t, 1, healthy.closed)
+		it.Close()
+	})
+
+	t.Run("error from an empty source in init is surfaced", func(t *testing.T) {
+		errored := &erroringSampleIterator{labels: `{s="a"}`, err: wantErr} // no samples: fails immediately
+		healthy := &erroringSampleIterator{samples: []logproto.Sample{sample(1)}, labels: `{s="b"}`}
+
+		it := NewSortSampleIterator([]SampleIterator{errored, healthy})
+		for it.Next() { //nolint:revive
+		}
+		require.ErrorIs(t, it.Err(), wantErr)
+		require.Equal(t, 1, errored.closed)
+		require.Equal(t, 1, healthy.closed)
+		it.Close()
+	})
+}
+
 func TestSampleIteratorWithClose_CloseIdempotent(t *testing.T) {
 	c := 0
 	closeFn := func() error {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes three related bugs in `pkg/iter`'s chaining iterators where a failing or drained sub-iterator was silently dropped instead of being surfaced or closed:

1. `nonOverlappingIterator`/`nonOverlappingSampleIterator.Next()` advanced past a sub-iterator that failed with a real read error instead of stopping, and `Err()` only ever reflected the last-visited sub-iterator. Once iteration finished normally, the earlier error was gone: the query completed successfully but silently dropped all data from the point of failure onward. These iterators sit under both the ingester read path (per in-memory chunk) and the querier read path (per stored chunk), both funneling through `MemChunk`'s block-level iterator, which returns real errors on decompression failures and corrupt/truncated block data — exactly what a corrupted or truncated chunk raises in production. `Next()` now stops and surfaces the error through `Err()`; `Close()` closes every remaining sub-iterator and aggregates their close errors instead of discarding them.

2. Some sub-iterators (e.g. the chunk block iterator) return their stored read error from `Close` too, as a fallback for callers that only check the `Close` return value. Without accounting for that, fix (1) reported the same failure a second time as a spurious close error. `Close` now skips it once the read error already surfaced through `Err`.

3. `mergeSampleIterator`/`sortSampleIterator` dropped fully-drained sources from the heap without closing them, and `Close` returned on the first sub-iterator close error, so any source drained during iteration, or left over after an early stop, was never closed. A source whose `Close` releases resources (e.g. the data-object reader releasing its object cache and folding read bytes into query stats) leaked, and its stats were lost.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
(1) and (2) apply the same fix to both `pkg/iter/entry_iterator.go` and `pkg/iter/sample_iterator.go` — the entry and sample iterator types are structurally identical. (3) only affects the sample-iterator side (`mergeSampleIterator`/`sortSampleIterator`); their entry-iterator equivalents were not part of this change.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
