### PR TITLE
docs: Configuration best practices had "Simple Storage Storage" mistake

### DIFF
--- a/docs/sources/configure/storage.md
+++ b/docs/sources/configure/storage.md
@@ -56,7 +56,7 @@ The file system is the simplest backend for chunks, although it's also susceptib
 
 GCS is a hosted object store offered by Google. It is a good candidate for a managed object store, especially when you're already running on GCP, and is production safe.
 
-#### Amazon Simple Storage Storage (S3)
+#### Amazon Simple Storage Service (S3)
 
 S3 is AWS's hosted object store. It is a good candidate for a managed object store, especially when you're already running on AWS, and is production safe.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix a minor mistake in the configuration best practices doc (S3 was described as "Simple Storage Storage", should be "Simple Storage Service"
**Which issue(s) this PR fixes**:
Fixes no issues

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [ ] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
