### PR TITLE
chore: Fix flaky test TestTCPErrs

### DIFF
--- a/pkg/storage/chunk/client/gcp/gcs_object_client_test.go
+++ b/pkg/storage/chunk/client/gcp/gcs_object_client_test.go
@@ -3,9 +3,12 @@ package gcp
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"syscall"
 	"testing"
 	"time"
 
@@ -153,73 +156,50 @@ func TestUpstreamRetryableErrs(t *testing.T) {
 	}
 }
 
-func TestTCPErrs(t *testing.T) {
+type errTransport struct{ err error }
 
+func (t errTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, t.err }
+
+func TestTCPErrs(t *testing.T) {
 	tests := []struct {
-		name           string
-		responseSleep  time.Duration
-		connectSleep   time.Duration
-		clientTimeout  time.Duration
-		serverTimeout  time.Duration
-		connectTimeout time.Duration
-		closeOnNew     bool
-		closeOnActive  bool
-		retryable      bool
+		name         string
+		transportErr error
+		retryable    bool
 	}{
 		{
-			name:          "request took longer than client timeout, not retryable",
-			responseSleep: time.Millisecond * 20,
-			clientTimeout: time.Millisecond * 10,
-			retryable:     false,
+			name:         "client side timeout, not retryable",
+			transportErr: context.DeadlineExceeded,
+			retryable:    false,
 		},
 		{
-			name:          "client timeout exceeded on connect, not retryable",
-			connectSleep:  time.Millisecond * 20,
-			clientTimeout: time.Millisecond * 10,
-			retryable:     false,
+			// Retryable because it's a server-side timeout
+			name:         "transport connect timeout exceeded, retryable",
+			transportErr: fmt.Errorf("net/http: request canceled (Client.Timeout exceeded while awaiting headers): %w", context.DeadlineExceeded),
+			retryable:    true,
 		},
 		{
-			// there are retryable because it's a server-side timeout
-			name:           "transport connect timeout exceeded, retryable",
-			connectSleep:   time.Millisecond * 40,
-			connectTimeout: time.Millisecond * 20,
-			// even though the client timeout is set, the connect timeout will be hit first
-			clientTimeout: time.Millisecond * 100,
-			retryable:     true,
-		},
-		{
-			name:          "connection is closed server-side before being established",
-			connectSleep:  time.Millisecond * 10,
-			clientTimeout: time.Millisecond * 100,
-			closeOnNew:    true,
-			retryable:     true,
-		},
-		{
-			name:          "connection is closed server-side after being established",
-			connectSleep:  time.Millisecond * 10,
-			clientTimeout: time.Millisecond * 100,
-			closeOnActive: true,
-			retryable:     true,
+			name: "connection is closed server-side, retryable",
+			transportErr: &net.OpError{
+				Op:  "read",
+				Net: "tcp",
+				Err: &os.SyscallError{Syscall: "read", Err: syscall.ECONNRESET},
+			},
+			retryable: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			server := fakeSleepingServer(t, tc.responseSleep, tc.connectSleep, tc.closeOnNew, tc.closeOnActive)
-			ctx, cancelFunc := context.WithTimeout(context.Background(), tc.clientTimeout)
-			defer t.Cleanup(cancelFunc)
+			ctx := context.Background()
 
-			client := http.DefaultClient
-			transport := http.DefaultTransport.(*http.Transport).Clone()
-			client.Transport = transport
-			client.Timeout = tc.connectTimeout
+			client := &http.Client{Transport: errTransport{tc.transportErr}}
 
 			cli, err := newGCSObjectClient(ctx, GCSConfig{
 				BucketName:    "test-bucket",
 				Insecure:      true,
 				EnableRetries: false,
 			}, hedging.Config{}, func(ctx context.Context, opts ...option.ClientOption) (*storage.Client, error) {
-				opts = append(opts, option.WithEndpoint(server.URL))
+				opts = append(opts, option.WithEndpoint("http://fake-gcs.invalid"))
 				opts = append(opts, option.WithoutAuthentication())
 				opts = append(opts, option.WithHTTPClient(client))
 				return storage.NewClient(ctx, opts...)
@@ -241,28 +221,5 @@ func fakeHTTPRespondingServer(t *testing.T, code int) *httptest.Server {
 	server.StartTLS()
 	t.Cleanup(server.Close)
 
-	return server
-}
-
-func fakeSleepingServer(t *testing.T, responseSleep, connectSleep time.Duration, closeOnNew, closeOnActive bool) *httptest.Server {
-	server := httptest.NewUnstartedServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		// sleep on response to mimic server overload
-		time.Sleep(responseSleep)
-	}))
-	server.Config.ConnState = func(conn net.Conn, state http.ConnState) {
-		// sleep on initial connection attempt to mimic server non-responsiveness
-		if state == http.StateNew {
-			time.Sleep(connectSleep)
-			if closeOnNew {
-				require.NoError(t, conn.Close())
-			}
-		}
-
-		if closeOnActive && state != http.StateClosed {
-			require.NoError(t, conn.Close())
-		}
-	}
-	t.Cleanup(server.Close)
-	server.Start()
 	return server
 }


### PR DESCRIPTION
This test was failing occasionally in CI due to racing wall-clock timers. In this PR I propose that we stop mocking out an http server and instead mock out the http transport to return the error that would've been returned by the error case.

We could also have tweaked the numbers to make it less likely for timers to trigger in the wrong order - I'd be happy to change to that approach if that's what people prefer.

Another approach I tried was using testing/synctest, but wasn't able to get it working because then the timer would trigger at exactly the deadline and we'd end up in the wrong branch here https://github.com/golang/go/blob/go1.26.5/src/net/http/client.go#L372 because of the strict inequality. In reality we'd wave up slightly after the deadline rather than exactly at that moment.

Flaky test failure I've seen in CI:
```
  === FAIL: pkg/storage/chunk/client/gcp TestTCPErrs/transport_connect_timeout_exceeded,_retryable (0.04s)
      gcs_object_client_test.go:232:
              Error Trace:    /__w/loki/loki/release/pkg/storage/chunk/client/gcp/gcs_object_client_test.go:232
              Error:          Not equal:
                              expected: true
                              actual  : false
              Test:           TestTCPErrs/transport_connect_timeout_exceeded,_retryable
```

**What this PR does / why we need it**: Fixes a flaky test. 

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**: N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
