### PR TITLE
docs: Add Apache APISIX to third-party clients 🤖🤖🤖

### DIFF
--- a/docs/sources/send-data/_index.md
+++ b/docs/sources/send-data/_index.md
@@ -47,6 +47,7 @@ By adding our output plugin you can quickly try Loki without doing big configura
 
 These third-party clients also enable sending logs to Loki:
 
+- [Apache APISIX loki-logger](https://apisix.apache.org/docs/apisix/plugins/loki-logger/) (API gateway)
 - [Cribl Loki Destination](https://docs.cribl.io/stream/destinations-loki)
 - [GrafanaLokiLogger](https://github.com/antoniojmsjr/GrafanaLokiLogger) (Delphi/Lazarus)
 - [ilogtail](https://github.com/alibaba/ilogtail) (Go)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Apache APISIX `loki-logger` to the third-party clients list. The existing APISIX plugin sends batched request and response logs to Loki through the Loki HTTP push API, and the link points to the official APISIX plugin documentation.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

This is a one-line documentation-only change. The contribution was prepared with automated assistance and is submitted through Loki's agent review path.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated (not applicable; documentation-only change)
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md` (not applicable)
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15) (not applicable)