### PR TITLE
refactor(compression): Export Codecs() and de-duplicate test codec lists

### DIFF
--- a/cmd/chunks-inspect/loki_test.go
+++ b/cmd/chunks-inspect/loki_test.go
@@ -16,17 +16,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
-var testCodecs = []compression.Codec{
-	compression.None,
-	compression.GZIP,
-	compression.LZ4_64k,
-	compression.LZ4_256k,
-	compression.LZ4_1M,
-	compression.LZ4_4M,
-	compression.Snappy,
-	compression.Flate,
-	compression.Zstd,
-}
+var testCodecs = compression.Codecs()
 
 var testFormats = []struct {
 	chunkFormat  byte

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -33,17 +33,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/filter"
 )
 
-var testEncodings = []compression.Codec{
-	compression.None,
-	compression.GZIP,
-	compression.LZ4_64k,
-	compression.LZ4_256k,
-	compression.LZ4_1M,
-	compression.LZ4_4M,
-	compression.Snappy,
-	compression.Flate,
-	compression.Zstd,
-}
+var testEncodings = compression.Codecs()
 
 var (
 	testBlockSize  = 256 * 1024

--- a/pkg/compression/codec.go
+++ b/pkg/compression/codec.go
@@ -68,6 +68,11 @@ func (e Codec) IsSupported() bool {
 	return slices.Contains(supportedCodecs, e)
 }
 
+// Codecs returns the list of supported codecs.
+func Codecs() []Codec {
+	return slices.Clone(supportedCodecs)
+}
+
 // ParseCodec parses a chunk encoding (compression codec) by its name.
 func ParseCodec(enc string) (Codec, error) {
 	for _, e := range supportedCodecs {

--- a/pkg/compression/codec_test.go
+++ b/pkg/compression/codec_test.go
@@ -1,6 +1,18 @@
 package compression
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodecs(t *testing.T) {
+	got := Codecs()
+	require.Equal(t, supportedCodecs, got)
+
+	got[0] = Zstd
+	require.Equal(t, None, supportedCodecs[0], "mutating the returned slice must not affect supportedCodecs")
+}
 
 func TestParseEncoding(t *testing.T) {
 	tests := []struct {

--- a/pkg/storage/stores/shipper/bloomshipper/client_test.go
+++ b/pkg/storage/stores/shipper/bloomshipper/client_test.go
@@ -21,17 +21,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/config"
 )
 
-var supportedCompressions = []compression.Codec{
-	compression.None,
-	compression.GZIP,
-	compression.Snappy,
-	compression.LZ4_64k,
-	compression.LZ4_256k,
-	compression.LZ4_1M,
-	compression.LZ4_4M,
-	compression.Flate,
-	compression.Zstd,
-}
+var supportedCompressions = compression.Codecs()
 
 func parseTime(s string) model.Time {
 	t, err := time.Parse("2006-01-02 15:04", s)


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up to #23721. During review, `@pracucci` pointed out that the new `testCodecs` list in `cmd/chunks-inspect/loki_test.go` duplicates `compression`'s internal, unexported `supportedCodecs` list.

This PR adds `compression.Codecs()` (a clone of `supportedCodecs`, so callers can't mutate the package's internal state) and swaps it in wherever a test file was hand-listing the full codec set:

* `cmd/chunks-inspect/loki_test.go`'s `testCodecs`
* `pkg/chunkenc/memchunk_test.go`'s `testEncodings`
* `pkg/storage/stores/shipper/bloomshipper/client_test.go`'s `supportedCompressions`

Each was a verbatim copy that would silently go stale if a codec were ever added or removed. `pkg/storage/bloom/v1/builder_test.go`'s `blockEncodings` is left as-is — it's a deliberate 5-of-9 subset, not a duplicate of the full list.

Also adds `TestCodecs` covering both membership and that the returned slice is a copy, not an alias.

**Which issue(s) this PR fixes**:

None. Follow-up to #23721.

**Special notes for your reviewer**:

Adversarially reviewed with Codex — no correctness findings; the one gap it flagged (no direct test for `Codecs()`) is fixed in this PR.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
