### PR TITLE
refactor(logql): One sample per log line

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -1349,29 +1349,27 @@ func (hb *headBlock) SampleIterator(
 		stats.AddHeadChunkBytes(int64(len(e.s)))
 		stats.AddPostFilterLines(1)
 
-		samples, ok := extractor.ProcessString(e.t, e.s, e.structuredMetadata)
-		if !ok || len(samples) == 0 {
+		sample, ok := extractor.ProcessString(e.t, e.s, e.structuredMetadata)
+		if !ok {
 			continue
 		}
 
-		for _, sample := range samples {
-			lblStr := sample.Labels.String()
-			s, found := series[lblStr]
-			if !found {
-				s = &logproto.Series{
-					Labels:     lblStr,
-					Samples:    SamplesPool.Get(len(hb.entries)).([]logproto.Sample)[:0],
-					StreamHash: extractor.BaseLabels().Hash(),
-				}
-				series[lblStr] = s
+		lblStr := sample.Labels.String()
+		s, found := series[lblStr]
+		if !found {
+			s = &logproto.Series{
+				Labels:     lblStr,
+				Samples:    SamplesPool.Get(len(hb.entries)).([]logproto.Sample)[:0],
+				StreamHash: extractor.BaseLabels().Hash(),
 			}
-
-			s.Samples = append(s.Samples, logproto.Sample{
-				Timestamp: e.t,
-				Value:     sample.Value,
-				Hash:      hasher.Hash(lblStr, unsafeGetBytes(e.s)),
-			})
+			series[lblStr] = s
 		}
+
+		s.Samples = append(s.Samples, logproto.Sample{
+			Timestamp: e.t,
+			Value:     sample.Value,
+			Hash:      hasher.Hash(lblStr, unsafeGetBytes(e.s)),
+		})
 
 		if extractor.ReferencedStructuredMetadata() {
 			setQueryReferencedStructuredMetadata = true
@@ -1791,8 +1789,6 @@ func newSampleIterator(
 		bufferedIterator: newBufferedIterator(ctx, pool, b, format, symbolizer),
 		extractor:        extractor,
 		stats:            stats.FromContext(ctx),
-		curr:             []logproto.Sample{},
-		currLabels:       []log.LabelsResult{},
 	}
 }
 
@@ -1803,48 +1799,28 @@ type sampleBufferedIterator struct {
 	stats     *stats.Context
 	hasher    util.SampleHasher
 
-	curr       []logproto.Sample
-	currLabels []log.LabelsResult
+	curr       logproto.Sample
+	currLabels log.LabelsResult
 }
 
 func (e *sampleBufferedIterator) Next() bool {
-	// sample at e.curr[0] is the current sample
-	// since there is more than one sample, shift the remaining samples down by one
-	// to make e.curr[1] the new current sample
-	if len(e.curr) > 1 {
-		e.curr = e.curr[1:]
-		e.currLabels = e.currLabels[1:]
-
-		return true
-	}
-
-	// sample at e.curr[0] is the current sample
-	// since there is only one sample (the current one), we need to shift it out
-	// and clear the slice
-	if len(e.curr) == 1 {
-		e.curr = e.curr[:0]
-		e.currLabels = e.currLabels[:0]
-	}
-
 	for e.bufferedIterator.Next() {
 		e.stats.AddPostFilterLines(1)
 
-		samples, ok := e.extractor.Process(e.currTs, e.currLine, e.currStructuredMetadata)
-		if !ok || len(samples) == 0 {
+		sample, ok := e.extractor.Process(e.currTs, e.currLine, e.currStructuredMetadata)
+		if !ok {
 			continue
 		}
 
-		for _, sample := range samples {
-			e.currLabels = append(e.currLabels, sample.Labels)
-
-			// multilple samples from the same line can't have the same line hash or they will be deduplicated
-			// so they must have unique labels, which we'll use to create a unique line hash
-			lblString := sample.Labels.String()
-			e.curr = append(e.curr, logproto.Sample{
-				Timestamp: e.currTs,
-				Value:     sample.Value,
-				Hash:      e.hasher.Hash(lblString, e.currLine),
-			})
+		lblString := sample.Labels.String()
+		e.currLabels = sample.Labels
+		e.curr = logproto.Sample{
+			Timestamp: e.currTs,
+			Value:     sample.Value,
+			// Two entries in one stream can share a timestamp and a line but extract
+			// different labels. Without the labels in the hash, the merge iterator drops
+			// one as a duplicate.
+			Hash: e.hasher.Hash(lblString, e.currLine),
 		}
 
 		return true
@@ -1860,12 +1836,12 @@ func (e *sampleBufferedIterator) Close() error {
 	return e.bufferedIterator.Close()
 }
 
-func (e *sampleBufferedIterator) Labels() string { return e.currLabels[0].String() }
+func (e *sampleBufferedIterator) Labels() string { return e.currLabels.String() }
 
 func (e *sampleBufferedIterator) StreamHash() uint64 { return e.extractor.BaseLabels().Hash() }
 
 func (e *sampleBufferedIterator) At() logproto.Sample {
-	return e.curr[0]
+	return e.curr
 }
 
 // validateBlock validates block by doing following checks:

--- a/pkg/chunkenc/unordered.go
+++ b/pkg/chunkenc/unordered.go
@@ -342,28 +342,26 @@ func (hb *unorderedHeadBlock) SampleIterator(
 				return fmt.Errorf("symbolizer lookup: %w", err)
 			}
 
-			samples, ok := extractor.ProcessString(ts, line, structuredMetadata)
-			if !ok || len(samples) == 0 {
+			sample, ok := extractor.ProcessString(ts, line, structuredMetadata)
+			if !ok {
 				return nil
 			}
 
-			for _, sample := range samples {
-				lblStr := sample.Labels.String()
-				s, found := series[lblStr]
-				if !found {
-					s = &logproto.Series{
-						Labels:     lblStr,
-						Samples:    SamplesPool.Get(hb.lines).([]logproto.Sample)[:0],
-						StreamHash: extractor.BaseLabels().Hash(),
-					}
-					series[lblStr] = s
+			lblStr := sample.Labels.String()
+			s, found := series[lblStr]
+			if !found {
+				s = &logproto.Series{
+					Labels:     lblStr,
+					Samples:    SamplesPool.Get(hb.lines).([]logproto.Sample)[:0],
+					StreamHash: extractor.BaseLabels().Hash(),
 				}
-				s.Samples = append(s.Samples, logproto.Sample{
-					Timestamp: ts,
-					Value:     sample.Value,
-					Hash:      hasher.Hash(lblStr, unsafeGetBytes(line)),
-				})
+				series[lblStr] = s
 			}
+			s.Samples = append(s.Samples, logproto.Sample{
+				Timestamp: ts,
+				Value:     sample.Value,
+				Hash:      hasher.Hash(lblStr, unsafeGetBytes(line)),
+			})
 
 			if extractor.ReferencedStructuredMetadata() {
 				setQueryReferencedStructuredMetadata = true

--- a/pkg/ingester/instance_test.go
+++ b/pkg/ingester/instance_test.go
@@ -962,12 +962,12 @@ func (p *mockStreamExtractor) BaseLabels() log.LabelsResult {
 	return p.wrappedSP.BaseLabels()
 }
 
-func (p *mockStreamExtractor) Process(ts int64, line []byte, lbs labels.Labels) ([]log.ExtractedSample, bool) {
+func (p *mockStreamExtractor) Process(ts int64, line []byte, lbs labels.Labels) (log.ExtractedSample, bool) {
 	p.called++
 	return p.wrappedSP.Process(ts, line, lbs)
 }
 
-func (p *mockStreamExtractor) ProcessString(ts int64, line string, lbs labels.Labels) ([]log.ExtractedSample, bool) {
+func (p *mockStreamExtractor) ProcessString(ts int64, line string, lbs labels.Labels) (log.ExtractedSample, bool) {
 	p.called++
 	return p.wrappedSP.ProcessString(ts, line, lbs)
 }

--- a/pkg/logql/log/metrics_extraction.go
+++ b/pkg/logql/log/metrics_extraction.go
@@ -31,17 +31,20 @@ type SampleExtractor interface {
 	ForStream(labels labels.Labels) StreamSampleExtractor
 }
 
-// StreamSampleExtractor extracts samples for a log line.
+// StreamSampleExtractor extracts at most one sample from a log line.
 // A StreamSampleExtractor never mutates the received line.
 type StreamSampleExtractor interface {
 	BaseLabels() LabelsResult
-	Process(ts int64, line []byte, structuredMetadata labels.Labels) ([]ExtractedSample, bool)
-	ProcessString(ts int64, line string, structuredMetadata labels.Labels) ([]ExtractedSample, bool)
+	// Process extracts the sample for a log line. It returns the zero sample and
+	// false when it extracts none. A true result always carries non-nil Labels.
+	Process(ts int64, line []byte, structuredMetadata labels.Labels) (ExtractedSample, bool)
+	// ProcessString extracts the sample for a log line. It returns the zero sample
+	// and false when it extracts none. A true result always carries non-nil Labels.
+	ProcessString(ts int64, line string, structuredMetadata labels.Labels) (ExtractedSample, bool)
 	ReferencedStructuredMetadata() bool
 }
 
-// ExtractedSample represents a single sample extracted from a log line,
-// including its value and associated labels.
+// ExtractedSample is the sample a StreamSampleExtractor derives from a log line.
 type ExtractedSample struct {
 	Value  float64
 	Labels LabelsResult
@@ -99,28 +102,24 @@ func (l *streamLineSampleExtractor) ReferencedStructuredMetadata() bool {
 	return l.builder.referencedStructuredMetadata
 }
 
-func (l *streamLineSampleExtractor) Process(ts int64, line []byte, structuredMetadata labels.Labels) ([]ExtractedSample, bool) {
+func (l *streamLineSampleExtractor) Process(ts int64, line []byte, structuredMetadata labels.Labels) (ExtractedSample, bool) {
 	l.builder.Reset()
 	l.builder.Add(StructuredMetadataLabel, structuredMetadata)
 
 	// short circuit.
 	if l.Stage == NoopStage {
-		value := l.LineExtractor(line)
-		labels := l.builder.GroupedLabels()
-		return []ExtractedSample{{Value: value, Labels: labels}}, true
+		return ExtractedSample{Value: l.LineExtractor(line), Labels: l.builder.GroupedLabels()}, true
 	}
 
 	line, ok := l.Stage.Process(ts, line, l.builder)
 	if !ok {
-		return nil, false
+		return ExtractedSample{}, false
 	}
 
-	value := l.LineExtractor(line)
-	labels := l.builder.GroupedLabels()
-	return []ExtractedSample{{Value: value, Labels: labels}}, true
+	return ExtractedSample{Value: l.LineExtractor(line), Labels: l.builder.GroupedLabels()}, true
 }
 
-func (l *streamLineSampleExtractor) ProcessString(ts int64, line string, structuredMetadata labels.Labels) ([]ExtractedSample, bool) {
+func (l *streamLineSampleExtractor) ProcessString(ts int64, line string, structuredMetadata labels.Labels) (ExtractedSample, bool) {
 	// unsafe get bytes since we have the guarantee that the line won't be mutated.
 	return l.Process(ts, unsafeGetBytes(line), structuredMetadata)
 }
@@ -199,13 +198,13 @@ func (l *labelSampleExtractor) ForStream(labels labels.Labels) StreamSampleExtra
 	return res
 }
 
-func (l *streamLabelSampleExtractor) Process(ts int64, line []byte, structuredMetadata labels.Labels) ([]ExtractedSample, bool) {
+func (l *streamLabelSampleExtractor) Process(ts int64, line []byte, structuredMetadata labels.Labels) (ExtractedSample, bool) {
 	// Apply the pipeline first.
 	l.builder.Reset()
 	l.builder.Add(StructuredMetadataLabel, structuredMetadata)
 	line, ok := l.preStage.Process(ts, line, l.builder)
 	if !ok {
-		return nil, false
+		return ExtractedSample{}, false
 	}
 	// convert the label value.
 	var v float64
@@ -213,7 +212,7 @@ func (l *streamLabelSampleExtractor) Process(ts int64, line []byte, structuredMe
 	if stringValue == "" {
 		// NOTE: It's totally fine for log line to not have this particular label.
 		// See Issue: https://github.com/grafana/loki/issues/6713
-		return nil, false
+		return ExtractedSample{}, false
 	}
 
 	var err error
@@ -225,12 +224,12 @@ func (l *streamLabelSampleExtractor) Process(ts int64, line []byte, structuredMe
 
 	// post filters
 	if _, ok = l.postFilter.Process(ts, line, l.builder); !ok {
-		return nil, false
+		return ExtractedSample{}, false
 	}
-	return []ExtractedSample{{Value: v, Labels: l.builder.GroupedLabels()}}, true
+	return ExtractedSample{Value: v, Labels: l.builder.GroupedLabels()}, true
 }
 
-func (l *streamLabelSampleExtractor) ProcessString(ts int64, line string, structuredMetadata labels.Labels) ([]ExtractedSample, bool) {
+func (l *streamLabelSampleExtractor) ProcessString(ts int64, line string, structuredMetadata labels.Labels) (ExtractedSample, bool) {
 	// unsafe get bytes since we have the guarantee that the line won't be mutated.
 	return l.Process(ts, unsafeGetBytes(line), structuredMetadata)
 }
@@ -283,7 +282,7 @@ func (sp *filteringStreamExtractor) BaseLabels() LabelsResult {
 	return sp.extractor.BaseLabels()
 }
 
-func (sp *filteringStreamExtractor) Process(ts int64, line []byte, structuredMetadata labels.Labels) ([]ExtractedSample, bool) {
+func (sp *filteringStreamExtractor) Process(ts int64, line []byte, structuredMetadata labels.Labels) (ExtractedSample, bool) {
 	for _, filter := range sp.filters {
 		if ts < filter.start || ts > filter.end {
 			continue
@@ -291,14 +290,14 @@ func (sp *filteringStreamExtractor) Process(ts int64, line []byte, structuredMet
 
 		_, _, matches := filter.pipeline.Process(ts, line, structuredMetadata)
 		if matches { // When the filter matches, don't run the next step
-			return nil, false
+			return ExtractedSample{}, false
 		}
 	}
 
 	return sp.extractor.Process(ts, line, structuredMetadata)
 }
 
-func (sp *filteringStreamExtractor) ProcessString(ts int64, line string, structuredMetadata labels.Labels) ([]ExtractedSample, bool) {
+func (sp *filteringStreamExtractor) ProcessString(ts int64, line string, structuredMetadata labels.Labels) (ExtractedSample, bool) {
 	for _, filter := range sp.filters {
 		if ts < filter.start || ts > filter.end {
 			continue
@@ -306,7 +305,7 @@ func (sp *filteringStreamExtractor) ProcessString(ts int64, line string, structu
 
 		_, _, matches := filter.pipeline.ProcessString(ts, line, structuredMetadata)
 		if matches { // When the filter matches, don't run the next step
-			return nil, false
+			return ExtractedSample{}, false
 		}
 	}
 

--- a/pkg/logql/log/metrics_extraction_test.go
+++ b/pkg/logql/log/metrics_extraction_test.go
@@ -251,20 +251,18 @@ func Test_labelSampleExtractor_Extract(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			samples, ok := tt.ex.ForStream(tt.in).Process(0, []byte(tt.line), tt.structuredMetadata)
+			sample, ok := tt.ex.ForStream(tt.in).Process(0, []byte(tt.line), tt.structuredMetadata)
 			require.Equal(t, tt.wantOk, ok)
 			if ok {
-				require.Len(t, samples, 1, "Expected exactly one sample")
-				require.Equal(t, tt.want, samples[0].Value)
-				require.Equal(t, tt.wantLbs, samples[0].Labels.Labels())
+				require.Equal(t, tt.want, sample.Value)
+				require.Equal(t, tt.wantLbs, sample.Labels.Labels())
 			}
 
-			samples, ok = tt.ex.ForStream(tt.in).ProcessString(0, tt.line, tt.structuredMetadata)
+			sample, ok = tt.ex.ForStream(tt.in).ProcessString(0, tt.line, tt.structuredMetadata)
 			require.Equal(t, tt.wantOk, ok)
 			if ok {
-				require.Len(t, samples, 1, "Expected exactly one sample")
-				require.Equal(t, tt.want, samples[0].Value)
-				require.Equal(t, tt.wantLbs, samples[0].Labels.Labels())
+				require.Equal(t, tt.want, sample.Value)
+				require.Equal(t, tt.wantLbs, sample.Labels.Labels())
 			}
 		})
 	}
@@ -273,11 +271,10 @@ func Test_labelSampleExtractor_Extract(t *testing.T) {
 func Test_Extract_ExpectedLabels(t *testing.T) {
 	ex := mustSampleExtractor(LabelExtractorWithStages("duration", ConvertDuration, []string{"foo"}, false, false, []Stage{NewJSONParser(false)}, NoopStage))
 
-	samples, ok := ex.ForStream(labels.FromStrings("bar", "foo")).ProcessString(0, `{"duration":"20ms","foo":"json"}`, labels.EmptyLabels())
+	sample, ok := ex.ForStream(labels.FromStrings("bar", "foo")).ProcessString(0, `{"duration":"20ms","foo":"json"}`, labels.EmptyLabels())
 	require.True(t, ok)
-	require.Len(t, samples, 1, "Expected exactly one sample")
-	require.Equal(t, (20 * time.Millisecond).Seconds(), samples[0].Value)
-	require.Equal(t, labels.FromStrings("foo", "json"), samples[0].Labels.Labels())
+	require.Equal(t, (20 * time.Millisecond).Seconds(), sample.Value)
+	require.Equal(t, labels.FromStrings("foo", "json"), sample.Labels.Labels())
 
 }
 func TestLabelExtractorWithStages(t *testing.T) {
@@ -325,20 +322,18 @@ func TestLabelExtractorWithStages(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, line := range tc.checkLines {
-				samples, ok := tc.extractor.ForStream(labels.FromStrings("bar", "foo")).ProcessString(0, line.logLine, labels.EmptyLabels())
+				sample, ok := tc.extractor.ForStream(labels.FromStrings("bar", "foo")).ProcessString(0, line.logLine, labels.EmptyLabels())
 				skipped := !ok
 				assert.Equal(t, line.skip, skipped, "line", line.logLine)
 				if !skipped {
-					require.Len(t, samples, 1, "Expected exactly one sample")
-					assert.Equal(t, line.sample, samples[0].Value)
+					assert.Equal(t, line.sample, sample.Value)
 
 					// lbs shouldn't have __error__ = SampleExtractionError
-					assert.Empty(t, samples[0].Labels.Labels())
-					return
+					assert.Empty(t, sample.Labels.Labels())
+					continue
 				}
 
-				// if line is skipped, samples will be nil
-				assert.Nil(t, samples, "line", line.logLine)
+				assert.Equal(t, ExtractedSample{}, sample, "line", line.logLine)
 			}
 		})
 	}
@@ -360,28 +355,25 @@ func TestNewLineSampleExtractor(t *testing.T) {
 	)
 
 	sse := se.ForStream(lbs)
-	samples, ok := sse.Process(0, []byte(`foo`), labels.EmptyLabels())
+	sample, ok := sse.Process(0, []byte(`foo`), labels.EmptyLabels())
 	require.True(t, ok)
-	require.Len(t, samples, 1, "Expected exactly one sample")
-	require.Equal(t, 1., samples[0].Value)
-	assertLabelResult(t, lbs, samples[0].Labels)
+	require.Equal(t, 1., sample.Value)
+	assertLabelResult(t, lbs, sample.Labels)
 
-	samples, ok = sse.ProcessString(0, `foo`, labels.EmptyLabels())
+	sample, ok = sse.ProcessString(0, `foo`, labels.EmptyLabels())
 	require.True(t, ok)
-	require.Len(t, samples, 1, "Expected exactly one sample")
-	require.Equal(t, 1., samples[0].Value)
-	assertLabelResult(t, lbs, samples[0].Labels)
+	require.Equal(t, 1., sample.Value)
+	assertLabelResult(t, lbs, sample.Labels)
 
 	stage := mustFilter(NewFilter("foo", LineMatchEqual)).ToStage()
 	se, err = NewLineSampleExtractor(BytesExtractor, []Stage{stage}, []string{"namespace"}, false, false)
 	require.NoError(t, err)
 
 	sse = se.ForStream(lbs)
-	samples, ok = sse.Process(0, []byte(`foo`), labels.EmptyLabels())
+	sample, ok = sse.Process(0, []byte(`foo`), labels.EmptyLabels())
 	require.True(t, ok)
-	require.Len(t, samples, 1, "Expected exactly one sample")
-	require.Equal(t, 3., samples[0].Value)
-	assertLabelResult(t, labels.FromStrings("namespace", "dev"), samples[0].Labels)
+	require.Equal(t, 3., sample.Value)
+	assertLabelResult(t, labels.FromStrings("namespace", "dev"), sample.Labels)
 
 	sse = se.ForStream(lbs)
 	_, ok = sse.Process(0, []byte(`nope`), labels.EmptyLabels())
@@ -399,32 +391,28 @@ func TestNewLineSampleExtractorWithStructuredMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	sse := se.ForStream(lbs)
-	samples, ok := sse.Process(0, []byte(`foo`), structuredMetadata)
+	sample, ok := sse.Process(0, []byte(`foo`), structuredMetadata)
 	require.True(t, ok)
-	require.Len(t, samples, 1, "Expected exactly one sample")
-	require.Equal(t, 1., samples[0].Value)
-	assertLabelResult(t, expectedLabelsResults, samples[0].Labels)
+	require.Equal(t, 1., sample.Value)
+	assertLabelResult(t, expectedLabelsResults, sample.Labels)
 
-	samples, ok = sse.ProcessString(0, `foo`, structuredMetadata)
+	sample, ok = sse.ProcessString(0, `foo`, structuredMetadata)
 	require.True(t, ok)
-	require.Len(t, samples, 1, "Expected exactly one sample")
-	require.Equal(t, 1., samples[0].Value)
-	assertLabelResult(t, expectedLabelsResults, samples[0].Labels)
+	require.Equal(t, 1., sample.Value)
+	assertLabelResult(t, expectedLabelsResults, sample.Labels)
 
 	// test duplicated structured metadata with stream labels
 	expectedLabelsResults = appendLabel(lbs, "foo_extracted", "baz")
 	expectedLabelsResults = appendLabels(expectedLabelsResults, structuredMetadata)
-	samples, ok = sse.Process(0, []byte(`foo`), appendLabel(structuredMetadata, "foo", "baz"))
+	sample, ok = sse.Process(0, []byte(`foo`), appendLabel(structuredMetadata, "foo", "baz"))
 	require.True(t, ok)
-	require.Len(t, samples, 1, "Expected exactly one sample")
-	require.Equal(t, 1., samples[0].Value)
-	assertLabelResult(t, expectedLabelsResults, samples[0].Labels)
+	require.Equal(t, 1., sample.Value)
+	assertLabelResult(t, expectedLabelsResults, sample.Labels)
 
-	samples, ok = sse.ProcessString(0, `foo`, appendLabel(structuredMetadata, "foo", "baz"))
+	sample, ok = sse.ProcessString(0, `foo`, appendLabel(structuredMetadata, "foo", "baz"))
 	require.True(t, ok)
-	require.Len(t, samples, 1, "Expected exactly one sample")
-	require.Equal(t, 1., samples[0].Value)
-	assertLabelResult(t, expectedLabelsResults, samples[0].Labels)
+	require.Equal(t, 1., sample.Value)
+	assertLabelResult(t, expectedLabelsResults, sample.Labels)
 
 	se, err = NewLineSampleExtractor(BytesExtractor, []Stage{
 		NewStringLabelFilter(labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")),
@@ -434,11 +422,10 @@ func TestNewLineSampleExtractorWithStructuredMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	sse = se.ForStream(lbs)
-	samples, ok = sse.Process(0, []byte(`foo`), structuredMetadata)
+	sample, ok = sse.Process(0, []byte(`foo`), structuredMetadata)
 	require.True(t, ok)
-	require.Len(t, samples, 1, "Expected exactly one sample")
-	require.Equal(t, 3., samples[0].Value)
-	assertLabelResult(t, labels.FromStrings("foo", "bar"), samples[0].Labels)
+	require.Equal(t, 3., sample.Value)
+	assertLabelResult(t, labels.FromStrings("foo", "bar"), sample.Labels)
 
 	sse = se.ForStream(lbs)
 	_, ok = sse.Process(0, []byte(`nope`), labels.EmptyLabels())
@@ -515,26 +502,20 @@ func (p *stubStreamExtractor) Process(
 	_ int64,
 	_ []byte,
 	structuredMetadata labels.Labels,
-) ([]ExtractedSample, bool) {
+) (ExtractedSample, bool) {
 	builder := NewBaseLabelsBuilder().ForLabels(labels.FromStrings("foo", "bar"), 0)
 	builder.Add(StructuredMetadataLabel, structuredMetadata)
-	result := []ExtractedSample{
-		{Value: 1.0, Labels: builder.LabelsResult()},
-	}
-	return result, true
+	return ExtractedSample{Value: 1.0, Labels: builder.LabelsResult()}, true
 }
 
 func (p *stubStreamExtractor) ProcessString(
 	_ int64,
 	_ string,
 	structuredMetadata labels.Labels,
-) ([]ExtractedSample, bool) {
+) (ExtractedSample, bool) {
 	builder := NewBaseLabelsBuilder().ForLabels(labels.FromStrings("foo", "bar"), 0)
 	builder.Add(StructuredMetadataLabel, structuredMetadata)
-	result := []ExtractedSample{
-		{Value: 1.0, Labels: builder.LabelsResult()},
-	}
-	return result, true
+	return ExtractedSample{Value: 1.0, Labels: builder.LabelsResult()}, true
 }
 
 func (p *stubStreamExtractor) ReferencedStructuredMetadata() bool {

--- a/pkg/logql/log/parser_hints_test.go
+++ b/pkg/logql/log/parser_hints_test.go
@@ -233,17 +233,15 @@ func Test_ParserHints(t *testing.T) {
 			ex, err := expr.Extractor()
 			require.NoError(t, err)
 
-			res, ok := ex.ForStream(lbs).Process(0, append([]byte{}, tt.line...), labels.EmptyLabels())
+			sample, ok := ex.ForStream(lbs).Process(0, append([]byte{}, tt.line...), labels.EmptyLabels())
 			require.Equal(t, tt.expectOk, ok)
 
-			for _, sample := range res {
-				var lbsResString string
-				if sample.Labels != nil {
-					lbsResString = sample.Labels.String()
-				}
-				require.Equal(t, tt.expectVal, sample.Value)
-				require.Equal(t, tt.expectLbs, lbsResString)
+			var lbsResString string
+			if sample.Labels != nil {
+				lbsResString = sample.Labels.String()
 			}
+			require.Equal(t, tt.expectVal, sample.Value)
+			require.Equal(t, tt.expectLbs, lbsResString)
 		})
 	}
 }

--- a/pkg/logql/log/pipeline_test.go
+++ b/pkg/logql/log/pipeline_test.go
@@ -621,10 +621,10 @@ func Benchmark_Pipeline(b *testing.B) {
 	b.Run("line extractor bytes", func(b *testing.B) {
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			samples, ok := ex.Process(0, line, labels.EmptyLabels())
-			if ok && len(samples) > 0 {
-				resSample = samples[0].Value
-				resLbs = samples[0].Labels
+			sample, ok := ex.Process(0, line, labels.EmptyLabels())
+			if ok {
+				resSample = sample.Value
+				resLbs = sample.Labels
 				resMatches = true
 			} else {
 				resMatches = false
@@ -634,10 +634,10 @@ func Benchmark_Pipeline(b *testing.B) {
 	b.Run("line extractor string", func(b *testing.B) {
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			samples, ok := ex.ProcessString(0, lineString, labels.EmptyLabels())
-			if ok && len(samples) > 0 {
-				resSample = samples[0].Value
-				resLbs = samples[0].Labels
+			sample, ok := ex.ProcessString(0, lineString, labels.EmptyLabels())
+			if ok {
+				resSample = sample.Value
+				resLbs = sample.Labels
 				resMatches = true
 			} else {
 				resMatches = false
@@ -652,10 +652,10 @@ func Benchmark_Pipeline(b *testing.B) {
 	b.Run("label extractor bytes", func(b *testing.B) {
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			samples, ok := ex.Process(0, line, labels.EmptyLabels())
-			if ok && len(samples) > 0 {
-				resSample = samples[0].Value
-				resLbs = samples[0].Labels
+			sample, ok := ex.Process(0, line, labels.EmptyLabels())
+			if ok {
+				resSample = sample.Value
+				resLbs = sample.Labels
 				resMatches = true
 			} else {
 				resMatches = false
@@ -665,10 +665,10 @@ func Benchmark_Pipeline(b *testing.B) {
 	b.Run("label extractor string", func(b *testing.B) {
 		b.ResetTimer()
 		for n := 0; n < b.N; n++ {
-			samples, ok := ex.ProcessString(0, lineString, labels.EmptyLabels())
-			if ok && len(samples) > 0 {
-				resSample = samples[0].Value
-				resLbs = samples[0].Labels
+			sample, ok := ex.ProcessString(0, lineString, labels.EmptyLabels())
+			if ok {
+				resSample = sample.Value
+				resLbs = sample.Labels
 				resMatches = true
 			} else {
 				resMatches = false

--- a/pkg/logql/syntax/parser_test.go
+++ b/pkg/logql/syntax/parser_test.go
@@ -3425,7 +3425,7 @@ func Benchmark_MetricPipelineCombined(b *testing.B) {
 
 	sp := extractor.ForStream(labels.EmptyLabels())
 	var (
-		samples []log.ExtractedSample
+		sample  log.ExtractedSample
 		v       float64
 		lbs     log.LabelsResult
 		matches bool
@@ -3436,11 +3436,11 @@ func Benchmark_MetricPipelineCombined(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		samples, matches = sp.Process(0, in, labels.EmptyLabels())
+		sample, matches = sp.Process(0, in, labels.EmptyLabels())
 	}
 
-	v = samples[0].Value
-	lbs = samples[0].Labels
+	v = sample.Value
+	lbs = sample.Labels
 
 	require.True(b, matches)
 	require.Equal(

--- a/pkg/logql/test_utils.go
+++ b/pkg/logql/test_utils.go
@@ -146,28 +146,26 @@ func processSeries(in []logproto.Stream, ex log.SampleExtractor) ([]logproto.Ser
 	for _, stream := range in {
 		exs := ex.ForStream(mustParseLabels(stream.Labels))
 		for _, e := range stream.Entries {
-			samples, ok := exs.Process(e.Timestamp.UnixNano(), []byte(e.Line), labels.EmptyLabels())
+			sample, ok := exs.Process(e.Timestamp.UnixNano(), []byte(e.Line), labels.EmptyLabels())
 			if !ok {
 				continue
 			}
 
-			for _, sample := range samples {
-				lbs := sample.Labels.String()
-				s, found := resBySeries[lbs]
-				if !found {
-					s = &logproto.Series{
-						Labels:     lbs,
-						StreamHash: exs.BaseLabels().Hash(),
-					}
-					resBySeries[lbs] = s
+			lbs := sample.Labels.String()
+			s, found := resBySeries[lbs]
+			if !found {
+				s = &logproto.Series{
+					Labels:     lbs,
+					StreamHash: exs.BaseLabels().Hash(),
 				}
-
-				s.Samples = append(s.Samples, logproto.Sample{
-					Timestamp: e.Timestamp.UnixNano(),
-					Value:     sample.Value,
-					Hash:      xxhash.Sum64([]byte(e.Line)),
-				})
+				resBySeries[lbs] = s
 			}
+
+			s.Samples = append(s.Samples, logproto.Sample{
+				Timestamp: e.Timestamp.UnixNano(),
+				Value:     sample.Value,
+				Hash:      xxhash.Sum64([]byte(e.Line)),
+			})
 		}
 	}
 

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -997,12 +997,12 @@ func (p *mockStreamExtractor) BaseLabels() lokilog.LabelsResult {
 	return p.wrappedSP.BaseLabels()
 }
 
-func (p *mockStreamExtractor) Process(ts int64, line []byte, lbs labels.Labels) ([]lokilog.ExtractedSample, bool) {
+func (p *mockStreamExtractor) Process(ts int64, line []byte, lbs labels.Labels) (lokilog.ExtractedSample, bool) {
 	p.called++
 	return p.wrappedSP.Process(ts, line, lbs)
 }
 
-func (p *mockStreamExtractor) ProcessString(ts int64, line string, lbs labels.Labels) ([]lokilog.ExtractedSample, bool) {
+func (p *mockStreamExtractor) ProcessString(ts int64, line string, lbs labels.Labels) (lokilog.ExtractedSample, bool) {
 	p.called++
 	return p.wrappedSP.ProcessString(ts, line, lbs)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Last step of the `variants()` removal (#23823, #23889, #23905, #23935). `variants()` was the only thing that ever derived more than one sample from a single log line, so the plumbing that carried several is now dead weight.

- `StreamSampleExtractor.Process`/`ProcessString` return `(ExtractedSample, bool)` instead of `([]ExtractedSample, bool)`
- `sampleBufferedIterator` holds one sample again instead of a slice it shifted down across `Next()` calls
- The per-sample loops in `headBlock.SampleIterator`, `unorderedHeadBlock.SampleIterator` and `processSeries` are gone
- Callers lose the redundant `len(samples) == 0` half of their guard, since arity is now a compile-time fact

Side benefit: the old code allocated a one-element slice per log line that produced a sample, on the hot path of every metric query, and returned it through an interface method so it always escaped.

**Which issue(s) this PR fixes**:

Step 5 of grafana/loki-private#2750.

**Special notes for your reviewer**:

**Review changes with "hide whitespaces" enabled.**

**`logproto.Sample.Hash` is deliberately untouched, and that is the invariant to check.** It is a wire field that `MergeSampleIterator` dedups on, so changing it during a rolling upgrade silently drops or duplicates samples.

**One comment was rewritten because it stated the wrong mechanism.** The old rationale for including labels in the sample hash claimed it keeps two *streams* carrying the same line text distinct. The real reason is within one stream — two entries can share a timestamp and line text but extract different labels, for instance when their structured metadata differs.

**`At()` after exhaustion now returns the last sample instead of panicking**, because the slice bounds that used to panic are gone. This is a deliberate decision.

**Two test defects fixed, both of which made assertions unreachable** (pre-existing issues, but in files this PR changes):

- `Test_ParserHints` returned early on a failed extraction, skipping the zero-sample assertion its own table already described. All three `expectOk: false` rows declare `expectVal: 0, expectLbs: ""` — exactly the zero sample.
- `Test_labelSampleExtractor_ExtractError` used `return` instead of `continue`, so it only ever checked the first line of each case and never reached its zero-sample assertion.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
