### PR TITLE
fix(logql): Fix ip() line filter matching inside "or" chains

### DIFF
--- a/pkg/logql/internal/logqltest/testdata/line_filters.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/line_filters.logqltest
@@ -88,6 +88,79 @@ eval instant at 60s count_over_time({app="a"} |= ip("10.0.0.0/8") [1m])
 eval instant at 60s count_over_time({app="a"} |= ip("notanip") [1m])
   expect fail msg: ip: invalid pattern
 
+# ip() line filter with "or" operator.
+clear
+load
+  {app="net"} "src 192.168.1.10 ok" @ 20s [repeat every 20s for 4]
+  {app="net"} "src 10.0.0.9 ok"     @ 25s [repeat every 20s for 2]
+  {app="net"} "src 172.16.5.5 ok"   @ 30s
+  {app="net"} "src 8.8.8.8 ok"      @ 35s
+  {app="txt"} "no ip here"          @ 50s
+  {app="txt"} "special no ip"       @ 55s
+
+eval instant at 60s count_over_time({app=~"net|txt"} |= ip("192.168.1.0/24") or ip("10.0.0.0/8") [1m])
+  {app="net"} 5
+eval range from 40s to 80s step 20s count_over_time({app=~"net|txt"} |= ip("192.168.1.0/24") or ip("10.0.0.0/8") [1m])   # overlapping
+  {app="net"} 3 5 5
+eval range from 60s to 180s step 120s count_over_time({app=~"net|txt"} |= ip("192.168.1.0/24") or ip("10.0.0.0/8") [1m]) # non-overlapping
+  {app="net"} 5 _
+# |= a substring or ip range.
+eval instant at 60s count_over_time({app=~"net|txt"} |= "special" or ip("10.0.0.0/8") [1m])
+  {app="net"} 2
+  {app="txt"} 1
+eval range from 40s to 80s step 20s count_over_time({app=~"net|txt"} |= "special" or ip("10.0.0.0/8") [1m])
+  {app="net"} 1 2 2
+  {app="txt"} _ 1 1
+eval instant at 60s count_over_time({app=~"net|txt"} |= ip("10.0.0.0/8") or "special" [1m])
+  {app="net"} 2
+  {app="txt"} 1
+eval range from 40s to 80s step 20s count_over_time({app=~"net|txt"} |= ip("10.0.0.0/8") or "special" [1m])
+  {app="net"} 1 2 2
+  {app="txt"} _ 1 1
+# |= three operands chain: substring at the end.
+eval instant at 60s count_over_time({app=~"net|txt"} |= ip("192.168.1.0/24") or ip("10.0.0.0/8") or "special" [1m])
+  {app="net"} 5
+  {app="txt"} 1
+eval range from 40s to 80s step 20s count_over_time({app=~"net|txt"} |= ip("192.168.1.0/24") or ip("10.0.0.0/8") or "special" [1m])
+  {app="net"} 3 5 5
+  {app="txt"} _ 1 1
+# |= three operands chain: substring both at the start and at the end.
+eval instant at 60s count_over_time({app=~"net|txt"} |= "special" or ip("10.0.0.0/8") or "no ip here" [1m])
+  {app="net"} 2
+  {app="txt"} 2
+eval range from 40s to 80s step 20s count_over_time({app=~"net|txt"} |= "special" or ip("10.0.0.0/8") or "no ip here" [1m])
+  {app="net"} 1 2 2
+  {app="txt"} _ 2 2
+# |= four operands chain.
+eval instant at 60s count_over_time({app=~"net|txt"} |= ip("192.168.1.0/24") or ip("10.0.0.0/8") or ip("172.16.0.0/12") or "special" [1m])
+  {app="net"} 6
+  {app="txt"} 1
+eval range from 40s to 80s step 20s count_over_time({app=~"net|txt"} |= ip("192.168.1.0/24") or ip("10.0.0.0/8") or ip("172.16.0.0/12") or "special" [1m])
+  {app="net"} 4 6 6
+  {app="txt"} _ 1 1
+# != two operands.
+eval instant at 60s count_over_time({app=~"net|txt"} != ip("192.168.1.0/24") or ip("10.0.0.0/8") [1m])
+  {app="net"} 2
+  {app="txt"} 2
+eval range from 40s to 80s step 20s count_over_time({app=~"net|txt"} != ip("192.168.1.0/24") or ip("10.0.0.0/8") [1m])
+  {app="net"} 2 2 2
+  {app="txt"} _ 2 2
+# != three operands chain.
+eval instant at 60s count_over_time({app=~"net|txt"} != ip("192.168.1.0/24") or ip("10.0.0.0/8") or "special" [1m])
+  {app="net"} 2
+  {app="txt"} 1
+eval range from 40s to 80s step 20s count_over_time({app=~"net|txt"} != ip("192.168.1.0/24") or ip("10.0.0.0/8") or "special" [1m])
+  {app="net"} 2 2 2
+  {app="txt"} _ 1 1
+# |~ does not support ip(), even when it's included in a or operands chain.
+eval instant at 60s count_over_time({app=~"net|txt"} |~ ip("192.168.1.0/24") or "special" [1m])
+  expect fail msg: ip: invalid operation
+eval instant at 60s count_over_time({app=~"net|txt"} |~ "special" or ip("192.168.1.0/24") [1m])
+  expect fail msg: ip: invalid operation
+# An invalid ip() pattern fails at parse time, with or without or.
+eval instant at 60s count_over_time({app=~"net|txt"} |= ip("") or "special" [1m])
+  expect fail msg: ip: invalid pattern
+
 # or-chained filters: a positive filter keeps a line that matches any operand; a negative filter
 # drops a line that matches any operand. Each operand inherits the match type of the primary filter.
 clear

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -482,7 +482,27 @@ func newOrLineFilterExpr(left, right *LineFilterExpr) *LineFilterExpr {
 	}
 
 	if left.Ty == log.LineMatchEqual || left.Ty == log.LineMatchRegexp || left.Ty == log.LineMatchPattern {
-		left.Or = right
+		// The left hand may already carry an Or chain. If we simply replace left.Or
+		// we would overwrite existing filters. Instead, we need to find the tail of
+		// the Or chain (if any) and add the right hand to it.
+		//
+		// To be clear, we don't enter this case just with or-ed strings. A string
+		// can continue an "or" chain in the grammar, so a chain of strings builds
+		// its whole tail in one pass, and left.Or is nil here.
+		//
+		// The case where this can happen is when there's ip() involved. ip() cannot
+		// continue a chain in the grammar. The parser attaches operands one at a time
+		// instead, so left already carries a chain by the second attach.
+		//
+		// For example, given the linter filter `ip("a") or ip("b") or ip("c")`, it
+		// reaches this branch twice:
+		// - First with left=`ip("a")`, right=`ip("b")`
+		// - Then with left=`ip("a") or ip("b")`, right=`ip("c")`
+		tail := left
+		for tail.Or != nil {
+			tail = tail.Or
+		}
+		tail.Or = right
 		right.IsOrChild = true
 		return left
 	}
@@ -608,28 +628,14 @@ func (e *LineFilterExpr) Filter() (log.Filterer, error) {
 		var next log.Filterer
 		var err error
 		if curr.Or != nil {
-			next, err = newOrFilter(curr)
-			if err != nil {
-				return nil, err
-			}
-			acc = append(acc, next)
+			next, err = newOrLineFilter(curr)
 		} else {
-			switch curr.Op {
-			case OpFilterIP:
-				next, err := log.NewIPLineFilter(curr.Match, curr.Ty)
-				if err != nil {
-					return nil, err
-				}
-				acc = append(acc, next)
-			default:
-				next, err = log.NewFilter(curr.Match, curr.Ty)
-				if err != nil {
-					return nil, err
-				}
-
-				acc = append(acc, next)
-			}
+			next, err = newLineFilterer(curr.LineFilter)
 		}
+		if err != nil {
+			return nil, err
+		}
+		acc = append(acc, next)
 	}
 
 	if len(acc) == 1 {
@@ -645,14 +651,26 @@ func (e *LineFilterExpr) Filter() (log.Filterer, error) {
 	return log.NewAndFilters(acc), nil
 }
 
-func newOrFilter(f *LineFilterExpr) (log.Filterer, error) {
-	orFilter, err := log.NewFilter(f.Match, f.Ty)
+// newLineFilterer returns the Filterer for a single line filter node.
+func newLineFilterer(f LineFilter) (log.Filterer, error) {
+	switch f.Op {
+	case "":
+		return log.NewFilter(f.Match, f.Ty)
+	case OpFilterIP:
+		return log.NewIPLineFilter(f.Match, f.Ty)
+	default:
+		return nil, fmt.Errorf("unknown line filter op %q", f.Op)
+	}
+}
+
+func newOrLineFilter(f *LineFilterExpr) (log.Filterer, error) {
+	orFilter, err := newLineFilterer(f.LineFilter)
 	if err != nil {
 		return nil, err
 	}
 
 	for or := f.Or; or != nil; or = or.Or {
-		filter, err := log.NewFilter(or.Match, or.Ty)
+		filter, err := newLineFilterer(or.LineFilter)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/logql/syntax/ast_test.go
+++ b/pkg/logql/syntax/ast_test.go
@@ -538,6 +538,27 @@ func Test_FilterMatcher(t *testing.T) {
 			[]linecheck{{"foo", true}, {"bar", false}, {"127.0.0.2", false}, {"127.0.0.1", true}},
 		},
 		{
+			`{app="foo"} |= ip("127.0.0.0/8") or "foo"`,
+			[]*labels.Matcher{
+				mustNewMatcher(labels.MatchEqual, "app", "foo"),
+			},
+			[]linecheck{{"foo", true}, {"bar", false}, {"req from 127.0.0.2 ok", true}, {"req from 8.8.8.8 ok", false}},
+		},
+		{
+			`{app="foo"} |= ip("10.0.0.0/8") or ip("192.168.0.0/16")`,
+			[]*labels.Matcher{
+				mustNewMatcher(labels.MatchEqual, "app", "foo"),
+			},
+			[]linecheck{{"from 10.5.3.2", true}, {"from 192.168.1.1", true}, {"from 8.8.8.8", false}},
+		},
+		{
+			`{app="foo"} |= "special" or ip("10.0.0.0/8") or "special2"`,
+			[]*labels.Matcher{
+				mustNewMatcher(labels.MatchEqual, "app", "foo"),
+			},
+			[]linecheck{{"has special", true}, {"from 10.5.3.2", true}, {"has special2", true}, {"nothing relevant", false}},
+		},
+		{
 			`{app="foo"} != ip("127.0.0.1") or "foo"`,
 			[]*labels.Matcher{
 				mustNewMatcher(labels.MatchEqual, "app", "foo"),
@@ -722,6 +743,26 @@ func TestStringer(t *testing.T) {
 		{
 			in:  `{app="foo"} |~ ip("127.0.0.1") or "foo"`,
 			out: `{app="foo"} |~ ip("127.0.0.1") or "foo"`,
+		},
+		{
+			in:  `{app="foo"} |= ip("10.0.0.0/8") or ip("192.168.0.0/16") or "baz"`,
+			out: `{app="foo"} |= ip("10.0.0.0/8") or ip("192.168.0.0/16") or "baz"`,
+		},
+		{
+			in:  `{app="foo"} |= "baz" or ip("10.0.0.0/8") or ip("192.168.0.0/16")`,
+			out: `{app="foo"} |= "baz" or ip("10.0.0.0/8") or ip("192.168.0.0/16")`,
+		},
+		{
+			in:  `{app="foo"} |= "baz" or ip("10.0.0.0/8") or "qux"`,
+			out: `{app="foo"} |= "baz" or ip("10.0.0.0/8") or "qux"`,
+		},
+		{
+			in:  `{app="foo"} |= ip("10.0.0.0/8") or ip("192.168.0.0/16") or ip("172.16.0.0/12") or "baz"`,
+			out: `{app="foo"} |= ip("10.0.0.0/8") or ip("192.168.0.0/16") or ip("172.16.0.0/12") or "baz"`,
+		},
+		{
+			in:  `{app="foo"} != ip("10.0.0.0/8") or ip("192.168.0.0/16") or "baz"`,
+			out: `{app="foo"} != ip("10.0.0.0/8") != ip("192.168.0.0/16") != "baz"`,
 		},
 		{
 			in:  `{app="foo"} |> "foo <_> baz" or "foo <_>"`,


### PR DESCRIPTION
**What this PR does / why we need it**:

`ip()` line filters combined with `or` (e.g. `|= ip(a) or ip(b)`) silently degraded to a literal substring/regex match on the raw pattern text instead of matching real addresses, because the `or` chain compiler ignored each filter node's `Op` field.

Example: `{app="foo"} |= ip("10.0.0.0/8") or ip("192.168.0.0/16")` never matched a line like `connection from 10.5.3.2 accepted`, even though `10.5.3.2` is inside `10.0.0.0/8`. It was actually compiled as "line contains the literal text `10.0.0.0/8`" OR "line contains the literal text `192.168.0.0/16`", which real log lines essentially never do.

A related, independent bug in the same code path could also silently drop an operand from a chain of three or more `or` operands whenever `ip()` needed to continue the chain past the second position, since the parser attaches operands one at a time in that case and the old code overwrote any existing `Or` chain instead of appending to it.

Example: `{app="foo"} |= ip("10.0.0.0/8") or ip("192.168.0.0/16") or "error"` silently parsed (confirmed via `.String()`) as `ip("10.0.0.0/8") or "error"` — the `ip("192.168.0.0/16")` check vanished entirely, with no error. A line containing only a `192.168.0.0/16` address (no `10.x` address, no `"error"` text) would incorrectly fail to match.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
The new v2 query engine (`pkg/engine/internal/planner/logical/planner.go`) has an independent instance of the same class of bug — `convertLineFilter` never inspects `filter.Op`, so any `ip()` line filter routed there (with or without `or`) is silently compiled to a literal substring/regex match. Left out of this PR since it's a different engine/code path.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
