### PR TITLE
fix(logql): Avoid data race in sharded avg_over_time grouping

### DIFF
--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -61,6 +61,15 @@ func TestMappingEquivalence(t *testing.T) {
 		{`avg_over_time({a=~".+"} | logfmt | unwrap value [1s])`, false, nil},
 		{`avg_over_time({a=~".+"} | logfmt | unwrap value [1s]) by (a)`, true, nil},
 		{`avg_over_time({a=~".+"} | logfmt | unwrap value [1s]) without (stream)`, true, nil},
+		// avg_over_time() by(<unsorted labels>) needs to sort grouping labels
+		// on both side of the legs the avg_over_time() gets decomposed to
+		// (sum_over_time() / count_over_time).
+		{`avg_over_time({a=~".+"} | logfmt | unwrap value [1s]) by (c, a)`, true, nil},
+		// avg_over_time() with "unwrap" and without() grouping gets sharded
+		// by adding a filter to ensure the existence of the unwrap field on
+		// right side of the legs the avg_over_time() gets decomposed to
+		// (sum_over_time() / count_over_time).
+		{`avg_over_time({a=~".+"} | logfmt | unwrap value [1s]) without (stream, level)`, true, nil},
 		{`avg_over_time({a=~".+"} | logfmt | drop level | unwrap value [1s])`, true, nil},
 		{`avg_over_time({a=~".+"} | logfmt | drop level | unwrap value [1s]) without (stream)`, true, nil},
 		// outer sum around a non-additive range aggregation with label

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -404,25 +404,36 @@ func newVectorAggEvaluator(
 	if err != nil {
 		return nil, err
 	}
-	sort.Strings(expr.Grouping.Groups)
 
 	if expr.Operation == syntax.OpTypeCountMinSketch {
 		return newCountMinSketchVectorAggEvaluator(nextEvaluator, expr, maxCountMinSketchHeapSize)
 	}
 
+	// We can't mutate expr directly because it may be shared with another
+	// VectorAggregationExpr (e.g. the sum/count legs of a sharded
+	// avg_over_time). So we make a copy of the groups and sort the copy.
+	exprSortedGroups := make([]string, len(expr.Grouping.Groups))
+	copy(exprSortedGroups, expr.Grouping.Groups)
+	sort.Strings(exprSortedGroups)
+
 	return &VectorAggEvaluator{
-		nextEvaluator: nextEvaluator,
-		expr:          expr,
-		buf:           make([]byte, 0, 1024),
-		lb:            labels.NewBuilder(labels.EmptyLabels()),
+		nextEvaluator:    nextEvaluator,
+		expr:             expr,
+		exprSortedGroups: exprSortedGroups,
+		buf:              make([]byte, 0, 1024),
+		lb:               labels.NewBuilder(labels.EmptyLabels()),
 	}, nil
 }
 
 type VectorAggEvaluator struct {
 	nextEvaluator StepEvaluator
 	expr          *syntax.VectorAggregationExpr
-	buf           []byte
-	lb            *labels.Builder
+
+	// exprSortedGroups holds the expr.Grouping.Groups sorted lexicographically.
+	exprSortedGroups []string
+
+	buf []byte
+	lb  *labels.Builder
 }
 
 func (e *VectorAggEvaluator) Next() (bool, int64, StepResult) {
@@ -443,9 +454,9 @@ func (e *VectorAggEvaluator) Next() (bool, int64, StepResult) {
 
 		var groupingKey uint64
 		if e.expr.Grouping.Without {
-			groupingKey, e.buf = metric.HashWithoutLabels(e.buf, e.expr.Grouping.Groups...)
+			groupingKey, e.buf = metric.HashWithoutLabels(e.buf, e.exprSortedGroups...)
 		} else {
-			groupingKey, e.buf = metric.HashForLabels(e.buf, e.expr.Grouping.Groups...)
+			groupingKey, e.buf = metric.HashForLabels(e.buf, e.exprSortedGroups...)
 		}
 		group, ok := result[groupingKey]
 		// Add a new group if it doesn't exist.
@@ -454,13 +465,13 @@ func (e *VectorAggEvaluator) Next() (bool, int64, StepResult) {
 
 			if e.expr.Grouping.Without {
 				e.lb.Reset(metric)
-				e.lb.Del(e.expr.Grouping.Groups...)
+				e.lb.Del(e.exprSortedGroups...)
 				e.lb.Del(model.MetricNameLabel)
 				m = e.lb.Labels()
 			} else {
-				b := labels.NewScratchBuilder(len(e.expr.Grouping.Groups))
+				b := labels.NewScratchBuilder(len(e.exprSortedGroups))
 				metric.Range(func(l labels.Label) {
-					for _, n := range e.expr.Grouping.Groups {
+					for _, n := range e.exprSortedGroups {
 						if l.Name == n {
 							b.Add(l.Name, l.Value)
 							break

--- a/pkg/logql/evaluator_test.go
+++ b/pkg/logql/evaluator_test.go
@@ -1,6 +1,7 @@
 package logql
 
 import (
+	"context"
 	"math"
 	"testing"
 	"time"
@@ -329,6 +330,27 @@ func TestLiteralStepEvaluator(t *testing.T) {
 			assert.Equal(t, tc.expected, gotSamples)
 		})
 	}
+}
+
+// TestNewVectorAggEvaluator_DoesNotMutateGroupingInPlace ensure the expression
+// groups are not mutated in place. Another VectorAggregationExpr evaluated concurrently
+// (e.g. the sum/count legs of a sharded avg_over_time) may hold the same
+// Grouping.Groups backing slice, so newVectorAggEvaluator() must sort a
+// private copy rather than the AST node's own slice.
+func TestNewVectorAggEvaluator_DoesNotMutateGroupingInPlace(t *testing.T) {
+	expr := &syntax.VectorAggregationExpr{
+		Left:      &syntax.VectorExpr{Val: 1},
+		Operation: syntax.OpTypeSum,
+		Grouping:  &syntax.Grouping{Groups: []string{"b", "a"}},
+	}
+
+	nextEvFactory := SampleEvaluatorFunc(func(_ context.Context, _ SampleEvaluatorFactory, _ syntax.SampleExpr, _ Params) (StepEvaluator, error) {
+		return &emptyEvaluator{}, nil
+	})
+
+	_, err := newVectorAggEvaluator(context.Background(), nextEvFactory, expr, nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, []string{"b", "a"}, expr.Grouping.Groups)
 }
 
 type emptyEvaluator struct{}

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -1481,6 +1481,11 @@ func (e *RangeAggregationExpr) Accept(v RootVisitor) { v.VisitRangeAggregation(e
 //   - Grouping without empty label set: <operation> without () (<expr>) => Grouping{Without: true, Groups: []}
 //   - Grouping without label set: <operation> without (<labels...>) (<expr>) => Grouping{Without: true, Groups: [<labels...>]}
 type Grouping struct {
+	// Groups is in the order the query text wrote it, not sorted.
+	//
+	// A Grouping may be shared by more than one node and access concurrently,
+	// so it's not safe to change or sort Groups in place. A consumer that needs
+	// sorted order must sort its own copy.
 	Groups  []string
 	Without bool
 }

--- a/pkg/logql/syntax/extractor.go
+++ b/pkg/logql/syntax/extractor.go
@@ -21,9 +21,12 @@ func (r RangeAggregationExpr) extractor(override *Grouping) (log.SampleExtractor
 	if err := r.validate(); err != nil {
 		return nil, err
 	}
-	var groups []string
-	var without bool
-	var noLabels bool
+
+	var (
+		exprGroups []string
+		without    bool
+		noLabels   bool
+	)
 
 	// TODO(owen-d|cyriltovena): override grouping (i.e. from a parent `sum`)
 	// technically can break the query.
@@ -31,7 +34,7 @@ func (r RangeAggregationExpr) extractor(override *Grouping) (log.SampleExtractor
 	// the `by (bar)` grouping in the child is ignored in favor of the parent's `by (foo)`
 	for _, grp := range []*Grouping{r.Grouping, override} {
 		if grp != nil {
-			groups = grp.Groups
+			exprGroups = grp.Groups
 			without = grp.Without
 			noLabels = grp.Singleton()
 		}
@@ -43,7 +46,11 @@ func (r RangeAggregationExpr) extractor(override *Grouping) (log.SampleExtractor
 		noLabels = true
 	}
 
-	sort.Strings(groups)
+	// We can't mutate the expression's groups in place (see Grouping.Groups doc), so we make
+	// our own copy and sort it.
+	sortedGroups := make([]string, len(exprGroups))
+	copy(sortedGroups, exprGroups)
+	sort.Strings(sortedGroups)
 
 	var stages []log.Stage
 	if p, ok := r.Left.Left.(*PipelineExpr); ok {
@@ -68,16 +75,16 @@ func (r RangeAggregationExpr) extractor(override *Grouping) (log.SampleExtractor
 
 		return log.LabelExtractorWithStages(
 			r.Left.Unwrap.Identifier,
-			convOp, groups, without, noLabels, stages,
+			convOp, sortedGroups, without, noLabels, stages,
 			log.ReduceAndLabelFilter(r.Left.Unwrap.PostFilters),
 		)
 	}
 	// otherwise we extract metrics from the log line.
 	switch r.Operation {
 	case OpRangeTypeRate, OpRangeTypeCount, OpRangeTypeAbsent:
-		return log.NewLineSampleExtractor(log.CountExtractor, stages, groups, without, noLabels)
+		return log.NewLineSampleExtractor(log.CountExtractor, stages, sortedGroups, without, noLabels)
 	case OpRangeTypeBytes, OpRangeTypeBytesRate:
-		return log.NewLineSampleExtractor(log.BytesExtractor, stages, groups, without, noLabels)
+		return log.NewLineSampleExtractor(log.BytesExtractor, stages, sortedGroups, without, noLabels)
 	default:
 		return nil, fmt.Errorf(UnsupportedErr, r.Operation)
 	}

--- a/pkg/logql/syntax/extractor_test.go
+++ b/pkg/logql/syntax/extractor_test.go
@@ -126,3 +126,23 @@ func Test_Extractor_NilForExprsThatDoNotReadLogs(t *testing.T) {
 		})
 	}
 }
+
+// Test_Extractor_DoesNotMutateGroupingInPlace ensure the expression groups
+// are not mutated in place. A VectorAggregationExpr's Grouping can be shared
+// with another expression evaluated concurrently (e.g. the sum/count legs of
+// a sharded avg_over_time), so extractor() must sort a private copy.
+func Test_Extractor_DoesNotMutateGroupingInPlace(t *testing.T) {
+	t.Parallel()
+
+	expr, err := ParseSampleExpr(`sum by (c, a) (sum_over_time({job="mysql"} | unwrap bytes [5m]))`)
+	require.NoError(t, err)
+
+	vecAgg, ok := expr.(*VectorAggregationExpr)
+	require.True(t, ok, "expected a VectorAggregationExpr, got %T", expr)
+	require.Equal(t, []string{"c", "a"}, vecAgg.Grouping.Groups)
+
+	_, err = expr.Extractor()
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"c", "a"}, vecAgg.Grouping.Groups)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Sharded `avg_over_time(...) by (...)` decomposes into `sum_over_time() / count_over_time()`, and the two legs are evaluated concurrently. Both `newVectorAggEvaluator` and `RangeAggregationExpr.extractor` sorted `Grouping.Groups` in place, and the two legs can share the same backing array, so `go test -race` flags a data race on that slice.

This PR sorts a private copy in both places instead of mutating the AST node, and documents on `Grouping` that `Groups` must not be mutated in place, since it can be shared across concurrently evaluated expressions.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

This is a data race, that I've found while working on logqltest and locally running them with `-race` (CI still doesn't run tests with `-race`).

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
