### PR TITLE
fix(chunkenc): Stop counting filtered-out lines in post_filter_lines

### DIFF
--- a/pkg/chunkenc/memchunk.go
+++ b/pkg/chunkenc/memchunk.go
@@ -1347,12 +1347,12 @@ func (hb *headBlock) SampleIterator(
 	setQueryReferencedStructuredMetadata := false
 	for _, e := range hb.entries {
 		stats.AddHeadChunkBytes(int64(len(e.s)))
-		stats.AddPostFilterLines(1)
 
 		sample, ok := extractor.ProcessString(e.t, e.s, e.structuredMetadata)
 		if !ok {
 			continue
 		}
+		stats.AddPostFilterLines(1)
 
 		lblStr := sample.Labels.String()
 		s, found := series[lblStr]
@@ -1805,12 +1805,11 @@ type sampleBufferedIterator struct {
 
 func (e *sampleBufferedIterator) Next() bool {
 	for e.bufferedIterator.Next() {
-		e.stats.AddPostFilterLines(1)
-
 		sample, ok := e.extractor.Process(e.currTs, e.currLine, e.currStructuredMetadata)
 		if !ok {
 			continue
 		}
+		e.stats.AddPostFilterLines(1)
 
 		lblString := sample.Labels.String()
 		e.currLabels = sample.Labels

--- a/pkg/chunkenc/memchunk_test.go
+++ b/pkg/chunkenc/memchunk_test.go
@@ -801,6 +801,144 @@ func TestChunkStats(t *testing.T) {
 	require.Equal(t, int64(inserted), s.TotalDecompressedLines())
 }
 
+// TestPostFilterLinesCountsMatchingLinesOnly ensures that post_filter_lines counts
+// only the lines a query keeps: for log and metric queries, in the head block and in
+// cut blocks, across every head block format. Counting every line read reports lines
+// scanned, which makes every filter look like it matched everything.
+func TestPostFilterLinesCountsMatchingLinesOnly(t *testing.T) {
+	const (
+		matching = 3
+		total    = 10
+	)
+
+	var (
+		streamLabels = labels.FromStrings("app", "foo")
+		logQuery     = `{app="foo"} |= "keep"`
+		metricQuery  = `count_over_time({app="foo"} |= "keep" [5m])`
+	)
+
+	line := func(i int) string {
+		if i < matching {
+			return "keep me"
+		}
+		return "drop me"
+	}
+
+	// Returns post_filter_lines alongside total_lines, so a subtest can pin the ratio
+	// between lines read and lines kept. The bug made the two equal, which reads as a
+	// filter that matched everything.
+	countLines := func(t *testing.T, drain func(ctx context.Context)) (postFilter, total int64) {
+		t.Helper()
+		statsCtx, ctx := stats.NewContext(context.Background())
+		drain(ctx)
+		res := statsCtx.Result(0, 0, 0)
+		return res.Summary.TotalPostFilterLines, res.Summary.TotalLinesProcessed
+	}
+
+	for _, format := range allPossibleFormats {
+		for _, cutBlock := range []bool{false, true} {
+			name := fmt.Sprintf("%s/chunk=v%d/cut=%v", format.headBlockFmt, format.chunkFormat, cutBlock)
+			t.Run(name, func(t *testing.T) {
+				chk := newMemChunkWithFormat(format.chunkFormat, compression.None, format.headBlockFmt, testBlockSize, testTargetSize)
+				for i := 0; i < total; i++ {
+					dup, err := chk.Append(&logproto.Entry{Timestamp: time.Unix(0, int64(i)), Line: line(i)})
+					require.False(t, dup)
+					require.NoError(t, err)
+				}
+				// Cutting moves the entries out of the head block, so the block
+				// iterators are exercised instead.
+				if cutBlock {
+					require.NoError(t, chk.cut())
+				}
+
+				logExpr, err := syntax.ParseLogSelector(logQuery, true)
+				require.NoError(t, err)
+				pipeline, err := logExpr.Pipeline()
+				require.NoError(t, err)
+
+				logLines, logTotal := countLines(t, func(ctx context.Context) {
+					it, err := chk.Iterator(ctx, time.Unix(0, 0), time.Unix(0, total), logproto.FORWARD, pipeline.ForStream(streamLabels))
+					require.NoError(t, err)
+					for it.Next() { //nolint:revive
+					}
+					require.NoError(t, it.Err())
+					require.NoError(t, it.Close())
+				})
+
+				extractor, err := getStreamExtractor(metricQuery, streamLabels)
+				require.NoError(t, err)
+
+				sampleLines, sampleTotal := countLines(t, func(ctx context.Context) {
+					it := chk.SampleIterator(ctx, time.Unix(0, 0), time.Unix(0, total), extractor)
+					for it.Next() { //nolint:revive
+					}
+					require.NoError(t, it.Err())
+					require.NoError(t, it.Close())
+				})
+
+				assert.Equal(t, int64(matching), logLines, "log query post_filter_lines")
+				assert.Equal(t, int64(matching), sampleLines, "metric query post_filter_lines")
+				assert.Equal(t, int64(total), logTotal, "log query total_lines")
+				assert.Equal(t, int64(total), sampleTotal, "metric query total_lines")
+			})
+		}
+	}
+}
+
+// TestPostFilterLinesCountsLinesThatProducedSamples asserts on which rejections stop a line
+// from counting.
+func TestPostFilterLinesCountsLinesThatProducedSamples(t *testing.T) {
+	lines := []string{
+		`{"latency":"1"}`,
+		`{"latency":"2"}`,
+		`{"other":"3"}`, // parses, but carries no latency label
+		`not json`,      // fails to parse, so the pipeline sets __error__
+	}
+
+	for _, tc := range []struct {
+		query string
+		want  int64
+	}{
+		// Every line reaches the extractor, including the one that failed to parse.
+		// A parse error is not a rejection: the pipeline sets __error__ and keeps
+		// the line, so it counts.
+		{query: `count_over_time({app="foo"} | json [5m])`, want: 4},
+
+		// Only the two lines carrying latency yield a sample. A missing unwrap label
+		// is a rejection, so those lines do not count even though no filter excluded them.
+		{query: `sum_over_time({app="foo"} | json | unwrap latency [5m])`, want: 2},
+	} {
+		for _, cutBlock := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/cut=%v", tc.query, cutBlock), func(t *testing.T) {
+				chk := newMemChunkWithFormat(ChunkFormatV4, compression.None, UnorderedWithStructuredMetadataHeadBlockFmt, testBlockSize, testTargetSize)
+				for i, l := range lines {
+					dup, err := chk.Append(&logproto.Entry{Timestamp: time.Unix(0, int64(i)), Line: l})
+					require.False(t, dup)
+					require.NoError(t, err)
+				}
+				if cutBlock {
+					require.NoError(t, chk.cut())
+				}
+
+				extractor, err := getStreamExtractor(tc.query, labels.FromStrings("app", "foo"))
+				require.NoError(t, err)
+
+				statsCtx, ctx := stats.NewContext(context.Background())
+				it := chk.SampleIterator(ctx, time.Unix(0, 0), time.Unix(0, int64(len(lines))), extractor)
+				samples := 0
+				for it.Next() {
+					samples++
+				}
+				require.NoError(t, it.Err())
+				require.NoError(t, it.Close())
+
+				require.Equal(t, int(tc.want), samples, "samples")
+				require.Equal(t, tc.want, statsCtx.Result(0, 0, 0).Summary.TotalPostFilterLines, "post_filter_lines")
+			})
+		}
+	}
+}
+
 func TestIteratorClose(t *testing.T) {
 	for _, f := range allPossibleFormats {
 		for _, enc := range testEncodings {

--- a/pkg/chunkenc/unordered.go
+++ b/pkg/chunkenc/unordered.go
@@ -346,6 +346,7 @@ func (hb *unorderedHeadBlock) SampleIterator(
 			if !ok {
 				return nil
 			}
+			statsCtx.AddPostFilterLines(1)
 
 			lblStr := sample.Labels.String()
 			s, found := series[lblStr]
@@ -367,7 +368,6 @@ func (hb *unorderedHeadBlock) SampleIterator(
 				setQueryReferencedStructuredMetadata = true
 			}
 
-			statsCtx.AddPostFilterLines(1)
 			return nil
 		},
 	)

--- a/pkg/logqlmodel/stats/context.go
+++ b/pkg/logqlmodel/stats/context.go
@@ -456,6 +456,8 @@ func (c *Context) AddDecompressedLines(i int64) {
 	atomic.AddInt64(&c.store.Chunk.DecompressedLines, i)
 }
 
+// AddPostFilterLines adds lines that passed the query filters. Call it only after
+// the pipeline or the extractor accepts the line.
 func (c *Context) AddPostFilterLines(i int64) {
 	atomic.AddInt64(&c.store.Chunk.PostFilterLines, i)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`post_filter_lines` reports how many lines matched a query's filters — that is how it is documented at `docs/sources/operations/meta-monitoring/_index.md:96`. Two of the three sample paths incremented it *before* asking the extractor, so a filtered metric query reported every line it read and looked as though its filter matched everything. `sampleBufferedIterator` is the path that serves stored chunks, so that is what most queries reported.

This moves the call after the extractor check in `headBlock.SampleIterator` and `sampleBufferedIterator.Next`. All six call sites now count a line only once the pipeline or the extractor accepts it, matching the three log paths and `unorderedHeadBlock.SampleIterator`, which were already correct.

The docs needed no change: the code was violating them. Confirmed against `5b16c0be7d^` that all four sites counted after the check before the `variants()` work moved two of them ahead of it.

**Which issue(s) this PR fixes**:

Item 7 of grafana/loki-private#2750. It does not close it — see the note on the v2 engine below.

**Special notes for your reviewer**:

**What the statistic now means, precisely.** A single bool carries every reason the extractor declines a line, so `post_filter_lines` counts lines that *produced a sample*. Measured, not assumed:

| query over the same 4 lines | `post_filter_lines` |
|---|---|
| `count_over_time({app="foo"} \| json [5m])` | 4 — a line that failed to parse still counts, because the pipeline records `__error__` and carries on |
| `sum_over_time({app="foo"} \| json \| unwrap latency [5m])` | 2 — lines with no `latency` label do not count, even though no filter excluded them |

The second row is a narrowing for `unwrap` queries versus what the compressed path reported before. It is the semantic `unorderedHeadBlock.SampleIterator` has always had, and the chunk iterator cannot distinguish "filter rejected" from "no unwrap label" because `Process` returns one bool. `TestPostFilterLinesCountsLinesThatProducedSamples` pins both rows so the choice is explicit rather than accidental.

**Two things deliberately left out of scope:**

- **The v2/dataobj engine still over-reports.** `Summary.TotalPostFilterLines` also sums `Dataobj.PostFilterRows`, set at `pkg/engine/engine.go:368` under an existing `// TODO: this will report the wrong value if the plan has a filter stage`. So dataobj-backed queries are unchanged by this PR, and a split range hitting both engines sums two semantics.
- **`headBlock.SampleIterator` still has no per-entry time filter** (`memchunk.go:1348`) where its log counterpart does (`:1279`), so it counts matching lines outside the query range that the time-ranged wrapper later discards. That is a missing time filter rather than a misplaced counter, and fixing it would move `AddHeadChunkBytes`/`AddHeadChunkLines` too. Reachability is near-zero: ordered head blocks exist only for chunk format below v3, which no schema produces — so the production fix here is `memchunk.go:1812`, and `:1355` is effectively test-only.

**The counter in `unorderedHeadBlock.SampleIterator` also moved**, from the end of the callback to immediately after its own check. Provably a no-op — nothing between the two positions returns — but having all six sites read alike stops a later early return from silently skipping it.

**`AddPostFilterLines` now has a doc comment.** This is the durable part of the fix: the bug was not a logic error, it was two call sites reading an undocumented counter.

**On testing.** Nothing anywhere asserted a non-zero `post_filter_lines` before this PR, which is why the bug survived. The new `TestPostFilterLinesCountsMatchingLinesOnly` runs a log query and an equivalent metric query over the same data and requires they agree, across all four chunk/head-block pairings and both the head-block and cut-block paths. It fails on the unfixed code with `expected: 3, actual: 10`, and each path is independently guarded — breaking any one of the six call sites fails a specific, identifiable pair of subtests. It also asserts `total_lines`, so the read-versus-kept ratio is pinned; that ratio collapsing to 1.0 is what the bug looked like.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
