### PR TITLE
perf: Lazy instantiation of drains for pattern ingesters

### DIFF
--- a/pkg/pattern/stream.go
+++ b/pkg/pattern/stream.go
@@ -34,8 +34,7 @@ type stream struct {
 	instanceID         string
 
 	// Fields retained so Drains can be created lazily on first observation
-	// of each detected_level. Most streams only see 1–3 levels; eagerly
-	// allocating all len(constants.LogLevels) trees was pure idle RSS.
+	// of each detected_level. Most streams only see 1–3 levels
 	drainCfg      *drain.Config
 	drainLimits   drain.Limits
 	guessedFormat string

--- a/pkg/pattern/stream.go
+++ b/pkg/pattern/stream.go
@@ -33,6 +33,14 @@ type stream struct {
 	aggregationMetrics *aggregation.Metrics
 	instanceID         string
 
+	// Fields retained so Drains can be created lazily on first observation
+	// of each detected_level. Most streams only see 1–3 levels; eagerly
+	// allocating all len(constants.LogLevels) trees was pure idle RSS.
+	drainCfg      *drain.Config
+	drainLimits   drain.Limits
+	guessedFormat string
+	drainMetrics  *drain.Metrics
+
 	lastTS                 int64
 	persistenceGranularity time.Duration
 	sampleInterval         time.Duration
@@ -58,18 +66,6 @@ func newStream(
 		return nil, err
 	}
 
-	patterns := make(map[string]*drain.Drain, len(constants.LogLevels))
-	for _, lvl := range constants.LogLevels {
-		patterns[lvl] = drain.New(instanceID, drainCfg, limits, guessedFormat, &drain.Metrics{
-			PatternsEvictedTotal:  metrics.patternsDiscardedTotal.WithLabelValues(instanceID, guessedFormat, "false"),
-			PatternsPrunedTotal:   metrics.patternsDiscardedTotal.WithLabelValues(instanceID, guessedFormat, "true"),
-			PatternsDetectedTotal: metrics.patternsDetectedTotal.WithLabelValues(instanceID, guessedFormat),
-			LinesSkipped:          linesSkipped,
-			TokensPerLine:         metrics.tokensPerLine.WithLabelValues(instanceID, guessedFormat),
-			StatePerLine:          metrics.statePerLine.WithLabelValues(instanceID, guessedFormat),
-		})
-	}
-
 	// Get per-tenant persistence granularity (requires casting drainLimits to Limits interface)
 	persistenceGranularity := limits.PersistenceGranularity(instanceID)
 	if persistenceGranularity == 0 {
@@ -77,12 +73,24 @@ func newStream(
 	}
 
 	return &stream{
-		fp:                     fp,
-		labels:                 ls,
-		labelsString:           ls.String(),
-		labelHash:              labels.StableHash(ls),
-		logger:                 logger,
-		patterns:               patterns,
+		fp:           fp,
+		labels:       ls,
+		labelsString: ls.String(),
+		labelHash:    labels.StableHash(ls),
+		logger:       logger,
+		// Drains are created on first Push for each observed level.
+		patterns:      make(map[string]*drain.Drain),
+		drainCfg:      drainCfg,
+		drainLimits:   limits,
+		guessedFormat: guessedFormat,
+		drainMetrics: &drain.Metrics{
+			PatternsEvictedTotal:  metrics.patternsDiscardedTotal.WithLabelValues(instanceID, guessedFormat, "false"),
+			PatternsPrunedTotal:   metrics.patternsDiscardedTotal.WithLabelValues(instanceID, guessedFormat, "true"),
+			PatternsDetectedTotal: metrics.patternsDetectedTotal.WithLabelValues(instanceID, guessedFormat),
+			LinesSkipped:          linesSkipped,
+			TokensPerLine:         metrics.tokensPerLine.WithLabelValues(instanceID, guessedFormat),
+			StatePerLine:          metrics.statePerLine.WithLabelValues(instanceID, guessedFormat),
+		},
 		patternWriter:          patternWriter,
 		aggregationMetrics:     aggregationMetrics,
 		instanceID:             instanceID,
@@ -91,6 +99,34 @@ func newStream(
 		patternRateThreshold:   limits.PatternRateThreshold(instanceID),
 		volumeThreshold:        volumeThreshold,
 	}, nil
+}
+
+// getOrCreateDrain returns the Drain for lvl, creating it on first use.
+// Levels outside constants.LogLevels fall back to the unknown Drain so
+// unexpected detected_level values still train somewhere.
+// Caller must hold s.mtx.
+func (s *stream) getOrCreateDrain(lvl string) *drain.Drain {
+	if pattern, ok := s.patterns[lvl]; ok {
+		return pattern
+	}
+	if !isKnownLogLevel(lvl) {
+		lvl = constants.LogLevelUnknown
+		if pattern, ok := s.patterns[lvl]; ok {
+			return pattern
+		}
+	}
+	pattern := drain.New(s.instanceID, s.drainCfg, s.drainLimits, s.guessedFormat, s.drainMetrics)
+	s.patterns[lvl] = pattern
+	return pattern
+}
+
+func isKnownLogLevel(lvl string) bool {
+	for _, known := range constants.LogLevels {
+		if lvl == known {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *stream) Push(
@@ -113,12 +149,7 @@ func (s *stream) Push(
 		s.lastTS = entry.Timestamp.UnixNano()
 
 		//TODO(twhitney): Can we reduce lock contention by locking by level rather than for the entire stream?
-		if pattern, ok := s.patterns[lvl]; ok {
-			pattern.Train(entry.Line, entry.Timestamp.UnixNano())
-		} else {
-			// since we're defaulting the level to unknown above, we should never get here.
-			s.patterns[constants.LogLevelUnknown].Train(entry.Line, entry.Timestamp.UnixNano())
-		}
+		s.getOrCreateDrain(lvl).Train(entry.Line, entry.Timestamp.UnixNano())
 	}
 	return nil
 }

--- a/pkg/pattern/stream_test.go
+++ b/pkg/pattern/stream_test.go
@@ -130,6 +130,144 @@ func TestAddStream(t *testing.T) {
 	require.Equal(t, int64(2), res.Series[0].Samples[0].Value)
 }
 
+func TestLazyDrainCreation(t *testing.T) {
+	newTestStream := func(t *testing.T) *stream {
+		t.Helper()
+		lbs := labels.New(labels.Label{Name: "test", Value: "test"})
+		s, err := newStream(
+			model.Fingerprint(labels.StableHash(lbs)),
+			lbs,
+			newIngesterMetrics(nil, "test"),
+			log.NewNopLogger(),
+			drain.FormatUnknown,
+			"123",
+			drain.DefaultConfig(),
+			&fakeLimits{patternRateThreshold: 1.0, persistenceGranularity: time.Hour},
+			nil,
+			aggregation.NewMetrics(nil),
+			0.99,
+		)
+		require.NoError(t, err)
+		return s
+	}
+
+	entryAt := func(ts int64, line, level string) push.Entry {
+		e := push.Entry{Timestamp: time.Unix(ts, 0), Line: line}
+		if level != "" {
+			e.StructuredMetadata = []logproto.LabelAdapter{
+				{Name: constants.LevelLabel, Value: level},
+			}
+		}
+		return e
+	}
+
+	t.Run("no drains allocated until first push", func(t *testing.T) {
+		s := newTestStream(t)
+		require.Empty(t, s.patterns)
+	})
+
+	t.Run("single level creates exactly one drain", func(t *testing.T) {
+		s := newTestStream(t)
+		require.NoError(t, s.Push(context.Background(), []push.Entry{
+			entryAt(1, "ts=1 msg=hello", constants.LogLevelInfo),
+			entryAt(2, "ts=2 msg=hello", constants.LogLevelInfo),
+		}))
+		require.Len(t, s.patterns, 1)
+		require.Contains(t, s.patterns, constants.LogLevelInfo)
+		require.NotNil(t, s.patterns[constants.LogLevelInfo])
+	})
+
+	t.Run("missing level metadata uses unknown drain", func(t *testing.T) {
+		s := newTestStream(t)
+		require.NoError(t, s.Push(context.Background(), []push.Entry{
+			entryAt(1, "ts=1 msg=hello", ""),
+		}))
+		require.Len(t, s.patterns, 1)
+		require.Contains(t, s.patterns, constants.LogLevelUnknown)
+	})
+
+	t.Run("unknown custom level falls back to unknown drain", func(t *testing.T) {
+		s := newTestStream(t)
+		require.NoError(t, s.Push(context.Background(), []push.Entry{
+			entryAt(1, "ts=1 msg=hello", "not-a-real-level"),
+		}))
+		require.Len(t, s.patterns, 1)
+		require.Contains(t, s.patterns, constants.LogLevelUnknown)
+		require.NotContains(t, s.patterns, "not-a-real-level")
+	})
+
+	t.Run("all eight log levels create eight drains", func(t *testing.T) {
+		require.Len(t, constants.LogLevels, 8, "test assumes eight known log levels")
+
+		s := newTestStream(t)
+		entries := make([]push.Entry, 0, len(constants.LogLevels)*2)
+		for i, lvl := range constants.LogLevels {
+			// Distinct lines per level so each Drain forms its own cluster.
+			line := fmt.Sprintf("level=%s event=unique_%s value=%d", lvl, lvl, i)
+			entries = append(entries,
+				entryAt(int64(i*2+1), line, lvl),
+				entryAt(int64(i*2+2), line, lvl),
+			)
+		}
+		require.NoError(t, s.Push(context.Background(), entries))
+
+		require.Len(t, s.patterns, len(constants.LogLevels))
+		for _, lvl := range constants.LogLevels {
+			require.Contains(t, s.patterns, lvl, "expected drain for level %q", lvl)
+			require.NotEmpty(t, s.patterns[lvl].Clusters(), "expected trained clusters for level %q", lvl)
+		}
+
+		it, err := s.Iterator(context.Background(), model.Earliest, model.Latest, model.Time(time.Second))
+		require.NoError(t, err)
+		res, err := iter.ReadAll(it)
+		require.NoError(t, err)
+		require.Len(t, res.Series, len(constants.LogLevels),
+			"iterator should return one series per level that was trained")
+
+		seenLevels := make(map[string]struct{}, len(res.Series))
+		for _, series := range res.Series {
+			seenLevels[series.Level] = struct{}{}
+			require.Equal(t, int64(2), series.Samples[0].Value,
+				"each level was pushed twice with the same line")
+		}
+		for _, lvl := range constants.LogLevels {
+			require.Contains(t, seenLevels, lvl)
+		}
+	})
+
+	t.Run("repeated pushes for existing levels do not allocate more drains", func(t *testing.T) {
+		s := newTestStream(t)
+		require.NoError(t, s.Push(context.Background(), []push.Entry{
+			entryAt(1, "ts=1 msg=hello", constants.LogLevelError),
+			entryAt(2, "ts=2 msg=world", constants.LogLevelWarn),
+		}))
+		require.Len(t, s.patterns, 2)
+		firstError, firstWarn := s.patterns[constants.LogLevelError], s.patterns[constants.LogLevelWarn]
+
+		require.NoError(t, s.Push(context.Background(), []push.Entry{
+			entryAt(3, "ts=3 msg=hello", constants.LogLevelError),
+			entryAt(4, "ts=4 msg=world", constants.LogLevelWarn),
+		}))
+		require.Len(t, s.patterns, 2)
+		require.Same(t, firstError, s.patterns[constants.LogLevelError])
+		require.Same(t, firstWarn, s.patterns[constants.LogLevelWarn])
+	})
+
+	t.Run("patterns stay isolated across levels", func(t *testing.T) {
+		s := newTestStream(t)
+		require.NoError(t, s.Push(context.Background(), []push.Entry{
+			entryAt(1, "aaaa bbbb cccc dddd", constants.LogLevelInfo),
+			entryAt(2, "wwww xxxx yyyy zzzz", constants.LogLevelError),
+		}))
+
+		infoClusters := s.patterns[constants.LogLevelInfo].Clusters()
+		errorClusters := s.patterns[constants.LogLevelError].Clusters()
+		require.Len(t, infoClusters, 1)
+		require.Len(t, errorClusters, 1)
+		require.NotEqual(t, infoClusters[0].String(), errorClusters[0].String())
+	})
+}
+
 func TestPruneStream(t *testing.T) {
 	lbs := labels.New(labels.Label{Name: "test", Value: "test"})
 	mockWriter := &mockEntryWriter{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Lazily create per-`detected_level` Drain trees in the pattern ingester instead of always allocating all 8 at stream creation.
Most streams only see 1–3 levels; unused trees previously paid idle RSS (root node, LRU, tokenizer) for every owned stream.
Unknown/custom levels still fall back to the unknown Drain; observing all 8 known levels still creates all 8.

**Which issue(s) this PR fixes**:
Pattern-ingester OOMs track retained Drain state per owned stream. Cutting the per-stream floor (especially for single-level streams) reduces steady-state working set.

**Special notes for your reviewer**:

```
BenchmarkStreamMemory_LazyDrain/single_level   1.000 drains/stream   ~1024 retained_B/stream
BenchmarkStreamMemory_LazyDrain/all_levels     8.000 drains/stream  ~34816 retained_B/stream
```

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [X] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
