### PR TITLE
perf: Replace drain prefix tree map with a slice

### DIFF
--- a/pkg/pattern/drain/drain.go
+++ b/pkg/pattern/drain/drain.go
@@ -85,14 +85,68 @@ func (c *LogClusterCache) Get(key int) *LogCluster {
 
 func createNode() *Node {
 	return &Node{
-		keyToChildNode: make(map[string]*Node),
-		clusterIDs:     make([]int, 0),
+		clusterIDs: make([]int, 0),
 	}
 }
 
+// nodeChild is a single edge of the prefix tree.
+type nodeChild struct {
+	key   string
+	child *Node
+}
+
 type Node struct {
-	keyToChildNode map[string]*Node
-	clusterIDs     []int
+	// children is scanned linearly instead of using a map because Config.MaxChildren
+	// caps the fan-out (15 by default) and the tree is overwhelmingly made of nodes
+	// with a single edge, where a map's header plus bucket array is pure overhead.
+	// The scan beats a map lookup up to about four children and stays within a few
+	// nanoseconds at the cap; only the root grows wider, holding one child per
+	// distinct token count. See BenchmarkNodeChildLookup_MapVsSlice.
+	children   []nodeChild
+	clusterIDs []int
+}
+
+// childIndex returns the position of key in n.children, or -1 when absent.
+func (n *Node) childIndex(key string) int {
+	for i := range n.children {
+		if n.children[i].key == key {
+			return i
+		}
+	}
+	return -1
+}
+
+// getChild reports the child stored under key, mirroring a map lookup.
+func (n *Node) getChild(key string) (*Node, bool) {
+	if i := n.childIndex(key); i >= 0 {
+		return n.children[i].child, true
+	}
+	return nil, false
+}
+
+// setChild inserts child under key, replacing any existing entry.
+func (n *Node) setChild(key string, child *Node) {
+	if i := n.childIndex(key); i >= 0 {
+		n.children[i].child = child
+		return
+	}
+	n.children = append(n.children, nodeChild{key: key, child: child})
+}
+
+// deleteChildAt removes the child at position i, keeping the remaining children
+// in insertion order.
+func (n *Node) deleteChildAt(i int) {
+	last := len(n.children) - 1
+	copy(n.children[i:], n.children[i+1:])
+	// Clear the vacated slot: the GC scans the whole backing array, so a stale
+	// entry would keep the removed subtree alive.
+	n.children[last] = nodeChild{}
+	n.children = n.children[:last]
+}
+
+// childCount reports how many edges leave n.
+func (n *Node) childCount() int {
+	return len(n.children)
 }
 
 func DefaultConfig() *Config {
@@ -306,10 +360,12 @@ func (d *Drain) Prune() {
 }
 
 func (d *Drain) pruneTree(node *Node) int {
-	for key, child := range node.keyToChildNode {
-		if d.pruneTree(child) == 0 {
-			delete(node.keyToChildNode, key)
+	for i := 0; i < node.childCount(); {
+		if d.pruneTree(node.children[i].child) == 0 {
+			node.deleteChildAt(i)
+			continue
 		}
+		i++
 	}
 
 	validClusterIDs := 0
@@ -319,7 +375,7 @@ func (d *Drain) pruneTree(node *Node) int {
 			validClusterIDs++
 		}
 	}
-	return len(node.keyToChildNode) + validClusterIDs
+	return node.childCount() + validClusterIDs
 }
 
 func (d *Drain) Delete(cluster *LogCluster) {
@@ -332,7 +388,7 @@ func (d *Drain) treeSearch(rootNode *Node, tokens []string, simTh float64, inclu
 	tokenCount := len(tokens)
 
 	// at first level, children are grouped by token (word) count
-	curNode, ok := rootNode.keyToChildNode[strconv.Itoa(tokenCount)]
+	curNode, ok := rootNode.getChild(strconv.Itoa(tokenCount))
 
 	// no template with same token count yet
 	if !ok {
@@ -357,10 +413,10 @@ func (d *Drain) treeSearch(rootNode *Node, tokens []string, simTh float64, inclu
 			break
 		}
 
-		keyToChildNode := curNode.keyToChildNode
-		curNode, ok = keyToChildNode[token]
+		parentNode := curNode
+		curNode, ok = parentNode.getChild(token)
 		if !ok { // no exact next token exist, try wildcard node
-			curNode, ok = keyToChildNode[d.config.ParamString]
+			curNode, ok = parentNode.getChild(d.config.ParamString)
 		}
 		if !ok { // no wildcard node exist
 			return nil
@@ -434,10 +490,10 @@ func (d *Drain) addSeqToPrefixTree(rootNode *Node, cluster *LogCluster) {
 	tokenCount := len(cluster.Tokens)
 	tokenCountStr := strconv.Itoa(tokenCount)
 
-	firstLayerNode, ok := rootNode.keyToChildNode[tokenCountStr]
+	firstLayerNode, ok := rootNode.getChild(tokenCountStr)
 	if !ok {
 		firstLayerNode = createNode()
-		rootNode.keyToChildNode[tokenCountStr] = firstLayerNode
+		rootNode.setChild(tokenCountStr, firstLayerNode)
 	}
 	curNode := firstLayerNode
 
@@ -464,43 +520,47 @@ func (d *Drain) addSeqToPrefixTree(rootNode *Node, cluster *LogCluster) {
 		}
 
 		// if token not matched in this layer of existing tree.
-		if _, ok = curNode.keyToChildNode[token]; !ok {
+		tokenIdx := curNode.childIndex(token)
+		if tokenIdx < 0 {
+			// paramNode is nil when the wildcard child is absent, which mirrors the
+			// zero value a missing map lookup used to yield.
+			paramNode, hasParam := curNode.getChild(d.config.ParamString)
 			if !d.hasNumbers(token) {
 				// Numbers in token: Prioritize the param string path
-				if _, ok = curNode.keyToChildNode[d.config.ParamString]; ok {
-					if len(curNode.keyToChildNode) < d.config.MaxChildren {
+				if hasParam {
+					if curNode.childCount() < d.config.MaxChildren {
 						newNode := createNode()
-						curNode.keyToChildNode[token] = newNode
+						curNode.setChild(token, newNode)
 						curNode = newNode
 					} else {
-						curNode = curNode.keyToChildNode[d.config.ParamString]
+						curNode = paramNode
 					}
 				} else {
-					if len(curNode.keyToChildNode)+1 < d.config.MaxChildren {
+					if curNode.childCount()+1 < d.config.MaxChildren {
 						newNode := createNode()
-						curNode.keyToChildNode[token] = newNode
+						curNode.setChild(token, newNode)
 						curNode = newNode
-					} else if len(curNode.keyToChildNode)+1 == d.config.MaxChildren {
+					} else if curNode.childCount()+1 == d.config.MaxChildren {
 						newNode := createNode()
-						curNode.keyToChildNode[d.config.ParamString] = newNode
+						curNode.setChild(d.config.ParamString, newNode)
 						curNode = newNode
 					} else {
-						curNode = curNode.keyToChildNode[d.config.ParamString]
+						curNode = paramNode
 					}
 				}
 			} else {
 				// No numbers, use the key as-is to traverse
-				if _, ok = curNode.keyToChildNode[d.config.ParamString]; !ok {
+				if !hasParam {
 					newNode := createNode()
-					curNode.keyToChildNode[d.config.ParamString] = newNode
+					curNode.setChild(d.config.ParamString, newNode)
 					curNode = newNode
 				} else {
-					curNode = curNode.keyToChildNode[d.config.ParamString]
+					curNode = paramNode
 				}
 			}
 		} else {
 			// if the token is matched
-			curNode = curNode.keyToChildNode[token]
+			curNode = curNode.children[tokenIdx].child
 		}
 
 		currentDepth++

--- a/pkg/pattern/drain/drain_golden_test.go
+++ b/pkg/pattern/drain/drain_golden_test.go
@@ -1,0 +1,170 @@
+package drain
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// childKeys and childByKey isolate the test suite from how a Node stores its
+// children, so the golden hashes below stay comparable across that change.
+func childKeys(node *Node) []string {
+	keys := make([]string, 0, node.childCount())
+	for _, c := range node.children {
+		keys = append(keys, c.key)
+	}
+	return keys
+}
+
+func childByKey(node *Node, key string) (*Node, bool) {
+	return node.getChild(key)
+}
+
+// goldenFiles pins both the clustering result and the exact prefix tree shape
+// produced by Train (and by Train followed by Prune) over every testdata corpus.
+// The values were captured from the map-backed prefix tree and must survive any
+// change to how a Node stores its children.
+//
+// Set DRAIN_GOLDEN_PRINT=1 to print the current values when the corpora change.
+var goldenFiles = []struct {
+	file          string
+	clusters      int
+	sha256        string
+	nodes         int
+	tree          string
+	prunedNodes   int
+	prunedTree    string
+	prunedCluster int
+}{
+	{file: "testdata/agent-logfmt.txt", clusters: 15, sha256: "63fbe63eaff23c1f0cf57da434e9357c83a7854e8399ebb73e91de1e2d315ec9", nodes: 111, tree: "fe2e6ce9cee743f68b826c47444f3af73ba857c457f1ff2f91f2bd608fbe52ff", prunedNodes: 63, prunedTree: "f2b23ea479227344ee50fca8971791cc54f9d7011e995feecccf64f5b2735b55", prunedCluster: 8},
+	{file: "testdata/calico.txt", clusters: 81, sha256: "a982388216a9f1e4749307a9947f745fb1318a17a2639f64cda159ae24f7f28d", nodes: 1294, tree: "40de9b39d214d8e73e3d4f29ba9de066a8034cc8c05899ff8b42fd5039cf533d", prunedNodes: 786, prunedTree: "36eb7957d168129d8a652ed7a343c93e3c9099df29c5c777ce9d9a6250e4a851", prunedCluster: 41},
+	{file: "testdata/distributor-logfmt.txt", clusters: 1, sha256: "ae7b7411306022a8a6b828dc6d8a6e43cb1592428d336d8fe783f958908d834a", nodes: 13, tree: "a06a998a1bec84e25dfd2ba5f1c63245e9db262d6f0b3ae297354b35fda188ff", prunedNodes: 13, prunedTree: "a06a998a1bec84e25dfd2ba5f1c63245e9db262d6f0b3ae297354b35fda188ff", prunedCluster: 1},
+	{file: "testdata/drone-json.txt", clusters: 1, sha256: "ed03e6e22b442584ae577baae0c586581b56cf8dddce9b689f9239afbd1e427d", nodes: 5, tree: "70c881338c76742d04d9dbd67bf37336842aefaf4cb19a5db0c4505ab9248119", prunedNodes: 5, prunedTree: "70c881338c76742d04d9dbd67bf37336842aefaf4cb19a5db0c4505ab9248119", prunedCluster: 1},
+	{file: "testdata/grafana-ruler.txt", clusters: 300, sha256: "011fcfbc2d7964366e2788b7a79df1fc29d1092a5d938c6a203f5b03b778f621", nodes: 3347, tree: "7e1f01533b25aa133125bfb6fcb373a8bc0647d52390c8924cfb3dc3804eaa0a", prunedNodes: 1597, prunedTree: "7658efb70a880faf285d29e51c7fa21911a0df3651d0e781de844824933682d2", prunedCluster: 154},
+	{file: "testdata/ingester-logfmt.txt", clusters: 3, sha256: "ffa527aba5f4928a4668b31ddc688f7dacbb9be024b8aa35844bbdfda2a00f25", nodes: 28, tree: "3c36d50973ec3ddb352de55228aa96df6ed82c1d8f6f9442daef021fa5c0e96a", prunedNodes: 23, prunedTree: "71b5c55bc51325c42cf2cdf206efed2db5832415df3abb93c43ea9cc00299cdd", prunedCluster: 2},
+	{file: "testdata/journald.txt", clusters: 111, sha256: "65f6a1b399af39831fb37b2e6be04847a5e783242f345b60fcd7285777488429", nodes: 1686, tree: "5ca408fc45b7e34036cc1ed725ad850efffa925a4dc05a123943ce8b007d7c7f", prunedNodes: 943, prunedTree: "113d301a161ff28252f9a65ef5c2e369f17521c05fcdb90ffe02c7865ad88d45", prunedCluster: 56},
+	{file: "testdata/kafka.txt", clusters: 13, sha256: "a2bd50ab76fadd2ec1b08f3a535da8aa10fa267b56a29f3c004cd262a84df634", nodes: 291, tree: "440d5aaff0d2e25d30eb028d6602a9c94d473910c75e01272f91c6993ebe093e", prunedNodes: 168, prunedTree: "5b7bf1f15097996726b8cf84e3106a9b89ac9ce5be470973b0541e29d222f598", prunedCluster: 7},
+	{file: "testdata/kubernetes.txt", clusters: 34, sha256: "981203ad898a7537ef350bb949b6c820873f405c0ee13b774c3bb66ad6ef2eea", nodes: 740, tree: "b1a475d6da03b37bfa13efcc10a757e0a934bea9b68868be77580fb12b56acb5", prunedNodes: 405, prunedTree: "ed26ba7f7ada0e32b06b8623d6197fc95fb4705bda36901ae7be71cd027bb520", prunedCluster: 17},
+	{file: "testdata/vault.txt", clusters: 1, sha256: "1de109a53af58d6aaa75f71ffeb91e7fd32d6468f4bd6c6914420fd985bdabef", nodes: 11, tree: "590beef42d2e170ef73f262adb3ad107680eddf3b13c930d09c94b2f126cced1", prunedNodes: 11, prunedTree: "590beef42d2e170ef73f262adb3ad107680eddf3b13c930d09c94b2f126cced1", prunedCluster: 1},
+}
+
+func readTestdataLines(tb testing.TB, path string) []string {
+	tb.Helper()
+
+	file, err := os.Open(path)
+	require.NoError(tb, err)
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	require.NoError(tb, scanner.Err())
+	require.NotEmpty(tb, lines)
+	return lines
+}
+
+// clusterFingerprint hashes the sorted cluster templates held by d.
+func clusterFingerprint(d *Drain) (int, string) {
+	clusters := d.Clusters()
+	templates := make([]string, 0, len(clusters))
+	for _, c := range clusters {
+		templates = append(templates, c.String())
+	}
+	slices.Sort(templates)
+
+	sum := sha256.Sum256([]byte(strings.Join(templates, "\n")))
+	return len(clusters), hex.EncodeToString(sum[:])
+}
+
+// treeFingerprint hashes the full prefix tree: every node's children (sorted by
+// key, so the hash is independent of child storage order) and cluster IDs.
+func treeFingerprint(root *Node) (int, string) {
+	h := sha256.New()
+	nodes := writeNode(h, root)
+	return nodes, hex.EncodeToString(h.Sum(nil))
+}
+
+func writeNode(h io.Writer, node *Node) int {
+	fmt.Fprintf(h, "ids=%v(", node.clusterIDs)
+
+	children := childKeys(node)
+	slices.Sort(children)
+
+	total := 1
+	for _, key := range children {
+		child, ok := childByKey(node, key)
+		if !ok {
+			panic("child disappeared: " + key)
+		}
+		fmt.Fprintf(h, "%q:", key)
+		total += writeNode(h, child)
+	}
+	fmt.Fprint(h, ")")
+	return total
+}
+
+// trainAndFingerprint trains a fresh Drain over lines, then reports cluster and
+// tree fingerprints before and after dropping every even cluster ID and pruning.
+func trainAndFingerprint(tb testing.TB, lines []string) (clusters int, clusterSum string, nodes int, treeSum string, prunedNodes int, prunedTreeSum string, prunedClusters int) {
+	tb.Helper()
+
+	d := New(testTenant, DefaultConfig(), &fakeLimits{}, DetectLogFormat(lines[0]), nil)
+	for _, line := range lines {
+		d.Train(line, 0)
+	}
+
+	clusters, clusterSum = clusterFingerprint(d)
+	nodes, treeSum = treeFingerprint(d.rootNode)
+
+	// Drop half the clusters so Prune has empty branches to collect.
+	for _, c := range d.Clusters() {
+		if c.id%2 == 0 {
+			d.Delete(c)
+		}
+	}
+	d.Prune()
+
+	prunedClusters = len(d.Clusters())
+	prunedNodes, prunedTreeSum = treeFingerprint(d.rootNode)
+	return
+}
+
+func TestTrainGoldenClusters(t *testing.T) {
+	t.Parallel()
+
+	printGolden := os.Getenv("DRAIN_GOLDEN_PRINT") == "1"
+
+	for _, tt := range goldenFiles {
+		t.Run(tt.file, func(t *testing.T) {
+			t.Parallel()
+
+			lines := readTestdataLines(t, tt.file)
+			clusters, clusterSum, nodes, treeSum, prunedNodes, prunedTreeSum, prunedClusters := trainAndFingerprint(t, lines)
+
+			if printGolden {
+				t.Logf("{file: %q, clusters: %d, sha256: %q, nodes: %d, tree: %q, prunedNodes: %d, prunedTree: %q, prunedCluster: %d},",
+					tt.file, clusters, clusterSum, nodes, treeSum, prunedNodes, prunedTreeSum, prunedClusters)
+				return
+			}
+
+			require.Equal(t, tt.clusters, clusters, "cluster count changed for %s", tt.file)
+			require.Equal(t, tt.sha256, clusterSum, "cluster templates changed for %s", tt.file)
+			require.Equal(t, tt.nodes, nodes, "prefix tree node count changed for %s", tt.file)
+			require.Equal(t, tt.tree, treeSum, "prefix tree shape changed for %s", tt.file)
+			require.Equal(t, tt.prunedCluster, prunedClusters, "surviving cluster count changed for %s", tt.file)
+			require.Equal(t, tt.prunedNodes, prunedNodes, "pruned node count changed for %s", tt.file)
+			require.Equal(t, tt.prunedTree, prunedTreeSum, "pruned tree shape changed for %s", tt.file)
+		})
+	}
+}

--- a/pkg/pattern/drain/drain_memory_benchmark_test.go
+++ b/pkg/pattern/drain/drain_memory_benchmark_test.go
@@ -1,0 +1,99 @@
+package drain
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+// liveBytes approximates the live heap. Two GC cycles let the second one see a
+// fully swept heap, after which HeapAlloc counts reachable objects only; it is
+// finer grained than HeapInuse, which rounds up to whole spans and hides the
+// per-node deltas this package cares about.
+func liveBytes() uint64 {
+	runtime.GC()
+	runtime.GC()
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	return ms.HeapAlloc
+}
+
+var memoryBenchmarkFiles = []string{
+	"testdata/agent-logfmt.txt",
+	"testdata/journald.txt",
+	"testdata/calico.txt",
+	"testdata/kubernetes.txt",
+	"testdata/grafana-ruler.txt",
+}
+
+// BenchmarkDrainMemory_Retained reports the heap a trained Drain holds onto,
+// normalized per drain, per cluster and per prefix tree node. The input corpus
+// is loaded once and shared, so the reported bytes cover Drain-owned state:
+// the prefix tree, the cluster cache and the cluster templates.
+func BenchmarkDrainMemory_Retained(b *testing.B) {
+	for _, file := range memoryBenchmarkFiles {
+		b.Run(file, func(b *testing.B) {
+			lines := readTestdataLines(b, file)
+			format := DetectLogFormat(lines[0])
+
+			var totalRetained, totalNodes, totalClusters uint64
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				base := liveBytes()
+
+				d := New(testTenant, DefaultConfig(), &fakeLimits{}, format, nil)
+				for _, line := range lines {
+					d.Train(line, 0)
+				}
+
+				totalRetained += liveBytes() - base
+				totalNodes += uint64(countNodes(d.rootNode))
+				totalClusters += uint64(len(d.Clusters()))
+				runtime.KeepAlive(d)
+			}
+
+			n := float64(b.N)
+			b.ReportMetric(float64(totalRetained)/n, "retained_B/drain")
+			b.ReportMetric(float64(totalRetained)/float64(max(totalClusters, 1)), "retained_B/cluster")
+			b.ReportMetric(float64(totalRetained)/float64(max(totalNodes, 1)), "retained_B/node")
+			b.ReportMetric(float64(totalNodes)/n, "nodes/drain")
+		})
+	}
+}
+
+// BenchmarkDrainMemory_RetainedByDepth varies LogClusterDepth: deeper trees mean
+// more internal nodes per cluster, which is exactly where per-node child storage
+// overhead compounds.
+func BenchmarkDrainMemory_RetainedByDepth(b *testing.B) {
+	const file = "testdata/journald.txt"
+
+	for _, depth := range []int{8, 15, 30} {
+		b.Run(fmt.Sprintf("depth=%d", depth), func(b *testing.B) {
+			lines := readTestdataLines(b, file)
+			format := DetectLogFormat(lines[0])
+
+			var totalRetained, totalNodes uint64
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				cfg := DefaultConfig()
+				cfg.LogClusterDepth = depth
+
+				base := liveBytes()
+
+				d := New(testTenant, cfg, &fakeLimits{}, format, nil)
+				for _, line := range lines {
+					d.Train(line, 0)
+				}
+
+				totalRetained += liveBytes() - base
+				totalNodes += uint64(countNodes(d.rootNode))
+				runtime.KeepAlive(d)
+			}
+
+			n := float64(b.N)
+			b.ReportMetric(float64(totalRetained)/n, "retained_B/drain")
+			b.ReportMetric(float64(totalRetained)/float64(max(totalNodes, 1)), "retained_B/node")
+			b.ReportMetric(float64(totalNodes)/n, "nodes/drain")
+		})
+	}
+}

--- a/pkg/pattern/drain/drain_test.go
+++ b/pkg/pattern/drain/drain_test.go
@@ -711,8 +711,8 @@ func TestDrain_PruneTreeClearsOldBranches(t *testing.T) {
 
 func countNodes(node *Node) int {
 	total := 1
-	for _, child := range node.keyToChildNode {
-		total += countNodes(child)
+	for _, c := range node.children {
+		total += countNodes(c.child)
 	}
 	return total
 }

--- a/pkg/pattern/drain/prefix_tree_memory_test.go
+++ b/pkg/pattern/drain/prefix_tree_memory_test.go
@@ -1,0 +1,185 @@
+package drain
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+// mapNode mirrors Node as it looked while children lived in a map. It exists only
+// so both layouts can be priced in the same process against the same tree; the
+// production tree no longer allocates a map per node.
+type mapNode struct {
+	keyToChildNode map[string]*mapNode
+	clusterIDs     []int
+}
+
+// cloneAsMapTree rebuilds node with map-backed children. Keys are shared with the
+// source tree, exactly as they are shared with the cluster templates in either
+// layout, so the measured difference is child storage and nothing else.
+func cloneAsMapTree(node *Node) *mapNode {
+	clone := &mapNode{keyToChildNode: make(map[string]*mapNode)}
+	if len(node.clusterIDs) > 0 {
+		clone.clusterIDs = append(clone.clusterIDs, node.clusterIDs...)
+	}
+	for _, c := range node.children {
+		clone.keyToChildNode[c.key] = cloneAsMapTree(c.child)
+	}
+	return clone
+}
+
+// cloneAsSliceTree rebuilds node with the production slice-backed children,
+// including the append growth pattern a real Drain produces.
+func cloneAsSliceTree(node *Node) *Node {
+	clone := createNode()
+	if len(node.clusterIDs) > 0 {
+		clone.clusterIDs = append(clone.clusterIDs, node.clusterIDs...)
+	}
+	for _, c := range node.children {
+		clone.setChild(c.key, cloneAsSliceTree(c.child))
+	}
+	return clone
+}
+
+type treeSizes struct {
+	nodes     int
+	sliceB    int64
+	mapB      int64
+	fanout    map[int]int
+	maxFanout int
+}
+
+// measureTreeLayouts trains a Drain over lines and then prices two structurally
+// identical copies of its prefix tree: one slice-backed, one map-backed.
+func measureTreeLayouts(tb testing.TB, lines []string) treeSizes {
+	tb.Helper()
+
+	d := New(testTenant, DefaultConfig(), &fakeLimits{}, DetectLogFormat(lines[0]), nil)
+	for _, line := range lines {
+		d.Train(line, 0)
+	}
+
+	sizes := treeSizes{
+		nodes:  countNodes(d.rootNode),
+		fanout: map[int]int{},
+	}
+	collectFanout(d.rootNode, sizes.fanout, &sizes.maxFanout)
+
+	base := liveBytes()
+	sliceClone := cloneAsSliceTree(d.rootNode)
+	afterSlice := liveBytes()
+	mapClone := cloneAsMapTree(d.rootNode)
+	afterMap := liveBytes()
+
+	sizes.sliceB = int64(afterSlice) - int64(base)
+	sizes.mapB = int64(afterMap) - int64(afterSlice)
+
+	// Keep everything reachable until both measurements are taken.
+	runtime.KeepAlive(d)
+	runtime.KeepAlive(sliceClone)
+	runtime.KeepAlive(mapClone)
+	return sizes
+}
+
+func collectFanout(node *Node, hist map[int]int, maxFanout *int) {
+	n := node.childCount()
+	hist[n]++
+	if n > *maxFanout {
+		*maxFanout = n
+	}
+	for _, c := range node.children {
+		collectFanout(c.child, hist, maxFanout)
+	}
+}
+
+// TestPrefixTreeRetainedHeap_MapVsSlice is the memory proof for storing children
+// in a slice: it builds real Drain trees from the testdata corpora and reports the
+// heap each layout needs for the very same tree.
+func TestPrefixTreeRetainedHeap_MapVsSlice(t *testing.T) {
+	for _, file := range memoryBenchmarkFiles {
+		lines := readTestdataLines(t, file)
+		sizes := measureTreeLayouts(t, lines)
+
+		saved := sizes.mapB - sizes.sliceB
+		t.Logf("%-30s nodes=%-5d slice=%8d B (%6.1f B/node)  map=%8d B (%6.1f B/node)  saved=%8d B (%4.1f%%)  max_fanout=%d",
+			file, sizes.nodes,
+			sizes.sliceB, float64(sizes.sliceB)/float64(sizes.nodes),
+			sizes.mapB, float64(sizes.mapB)/float64(sizes.nodes),
+			saved, 100*float64(saved)/float64(sizes.mapB),
+			sizes.maxFanout)
+		t.Logf("%-30s children per node: %v", file, sizes.fanout)
+
+		if sizes.sliceB >= sizes.mapB {
+			t.Errorf("%s: slice-backed children (%d B) should stay below map-backed children (%d B)", file, sizes.sliceB, sizes.mapB)
+		}
+	}
+}
+
+// BenchmarkNodeChildLookup_MapVsSlice prices the lookup that replaced the map
+// read. Fan-out 1-15 covers every internal node (Config.MaxChildren caps it),
+// while 77 covers the root, whose children are token counts (4..80) and are
+// therefore the widest scan Drain can perform: one per Train call.
+//
+// Each case looks up the last key, the worst case for a linear scan.
+func BenchmarkNodeChildLookup_MapVsSlice(b *testing.B) {
+	for _, fanout := range []int{1, 2, 5, 15, 77} {
+		keys := make([]string, fanout)
+		for i := range keys {
+			// Root keys are token counts; inner keys are log tokens. Numeric keys are
+			// the shorter, cheaper comparison, so they keep the scan honest at 77.
+			keys[i] = fmt.Sprintf("%d", i+4)
+		}
+		want := keys[len(keys)-1]
+
+		sliceNode := createNode()
+		mapped := &mapNode{keyToChildNode: make(map[string]*mapNode)}
+		for _, key := range keys {
+			sliceNode.setChild(key, createNode())
+			mapped.keyToChildNode[key] = &mapNode{}
+		}
+
+		b.Run(fmt.Sprintf("fanout=%d/slice", fanout), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if _, ok := sliceNode.getChild(want); !ok {
+					b.Fatal("miss")
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("fanout=%d/map", fanout), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if _, ok := mapped.keyToChildNode[want]; !ok {
+					b.Fatal("miss")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkPrefixTreeChildren_MapVsSlice reports the same comparison as
+// b.ReportMetric values so the delta shows up in benchstat-friendly output.
+func BenchmarkPrefixTreeChildren_MapVsSlice(b *testing.B) {
+	for _, file := range memoryBenchmarkFiles {
+		lines := readTestdataLines(b, file)
+
+		for _, layout := range []string{"slice", "map"} {
+			b.Run(fmt.Sprintf("%s/%s", file, layout), func(b *testing.B) {
+				var totalBytes, totalNodes int64
+				for i := 0; i < b.N; i++ {
+					sizes := measureTreeLayouts(b, lines)
+					if layout == "slice" {
+						totalBytes += sizes.sliceB
+					} else {
+						totalBytes += sizes.mapB
+					}
+					totalNodes += int64(sizes.nodes)
+				}
+
+				n := float64(b.N)
+				b.ReportMetric(float64(totalBytes)/n, "tree_B/drain")
+				b.ReportMetric(float64(totalBytes)/float64(totalNodes), "tree_B/node")
+				b.ReportMetric(float64(totalNodes)/n, "nodes/drain")
+			})
+		}
+	}
+}

--- a/pkg/pattern/drain/prefix_tree_test.go
+++ b/pkg/pattern/drain/prefix_tree_test.go
@@ -1,0 +1,188 @@
+package drain
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeChildAccessors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("get on empty node misses", func(t *testing.T) {
+		t.Parallel()
+
+		n := createNode()
+		child, ok := n.getChild("missing")
+		require.False(t, ok)
+		require.Nil(t, child)
+		require.Equal(t, -1, n.childIndex("missing"))
+		require.Equal(t, 0, n.childCount())
+	})
+
+	t.Run("set then get hits", func(t *testing.T) {
+		t.Parallel()
+
+		n := createNode()
+		a, b := createNode(), createNode()
+		n.setChild("a", a)
+		n.setChild("b", b)
+
+		require.Equal(t, 2, n.childCount())
+		require.Equal(t, 0, n.childIndex("a"))
+		require.Equal(t, 1, n.childIndex("b"))
+
+		got, ok := n.getChild("a")
+		require.True(t, ok)
+		require.Same(t, a, got)
+
+		got, ok = n.getChild("b")
+		require.True(t, ok)
+		require.Same(t, b, got)
+
+		_, ok = n.getChild("c")
+		require.False(t, ok)
+	})
+
+	t.Run("set replaces without duplicating the key", func(t *testing.T) {
+		t.Parallel()
+
+		n := createNode()
+		first, second := createNode(), createNode()
+		n.setChild("a", first)
+		n.setChild("a", second)
+
+		require.Equal(t, 1, n.childCount())
+		got, ok := n.getChild("a")
+		require.True(t, ok)
+		require.Same(t, second, got)
+	})
+
+	t.Run("delete keeps insertion order and clears the vacated slot", func(t *testing.T) {
+		t.Parallel()
+
+		n := createNode()
+		keys := []string{"a", "b", "c", "d"}
+		for _, key := range keys {
+			n.setChild(key, createNode())
+		}
+
+		n.deleteChildAt(n.childIndex("b"))
+
+		require.Equal(t, 3, n.childCount())
+		require.Equal(t, []string{"a", "c", "d"}, childKeys(n))
+		_, ok := n.getChild("b")
+		require.False(t, ok)
+
+		// The removed subtree must not stay reachable through the backing array,
+		// otherwise pruning would never release memory.
+		tail := n.children[:len(n.children)+1]
+		require.Equal(t, nodeChild{}, tail[len(tail)-1])
+	})
+
+	t.Run("delete of the only child empties the node", func(t *testing.T) {
+		t.Parallel()
+
+		n := createNode()
+		n.setChild("a", createNode())
+		n.deleteChildAt(0)
+
+		require.Equal(t, 0, n.childCount())
+		require.Empty(t, childKeys(n))
+	})
+}
+
+// TestPrefixTreeMaxChildren pins the fan-out contract: a node accepts distinct
+// tokens until one slot is left, spends that slot on the wildcard child, and
+// funnels every later token through it.
+func TestPrefixTreeMaxChildren(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	d := New(testTenant, cfg, &fakeLimits{}, FormatUnknown, nil)
+
+	tokensFor := func(i int) []string {
+		// Only the first token varies, so every cluster lands under the same
+		// token-count node and competes for its children.
+		return []string{fmt.Sprintf("tok%c", rune('a'+i)), "beta", "gamma", "delta", "epsilon"}
+	}
+
+	const inserted = 20
+	for i := 0; i < inserted; i++ {
+		cluster := &LogCluster{id: i + 1, Tokens: tokensFor(i), Size: 1}
+		d.idToCluster.Set(cluster.id, cluster)
+		d.addSeqToPrefixTree(d.rootNode, cluster)
+	}
+
+	require.Equal(t, 1, d.rootNode.childCount(), "root groups clusters by token count")
+	firstLayer, ok := d.rootNode.getChild("5")
+	require.True(t, ok, "first layer key is the token count")
+
+	require.Equal(t, cfg.MaxChildren, firstLayer.childCount(), "fan-out must stop at MaxChildren")
+
+	wantKeys := make([]string, 0, cfg.MaxChildren)
+	for i := 0; i < cfg.MaxChildren-1; i++ {
+		wantKeys = append(wantKeys, tokensFor(i)[0])
+	}
+	wantKeys = append(wantKeys, cfg.ParamString)
+	require.Equal(t, wantKeys, childKeys(firstLayer), "last slot is spent on the wildcard child")
+
+	// Tokens beyond the limit follow the wildcard branch rather than adding children.
+	wildcard, ok := firstLayer.getChild(cfg.ParamString)
+	require.True(t, ok)
+	require.NotEmpty(t, wildcard.children)
+
+	// treeSearch falls back to the wildcard node for a token never seen before.
+	unseen := []string{"never-seen-token", "beta", "gamma", "delta", "epsilon"}
+	require.NotNil(t, d.treeSearch(d.rootNode, unseen, cfg.SimTh, false),
+		"unseen leading token should match through the wildcard branch")
+
+	// An exact token still beats the wildcard.
+	exact := tokensFor(0)
+	match := d.treeSearch(d.rootNode, exact, cfg.SimTh, false)
+	require.NotNil(t, match)
+	require.Equal(t, 1, match.id, "exact match must win over the wildcard branch")
+}
+
+// TestPrefixTreePruneRemovesEmptyChildren checks that pruning drops branches whose
+// clusters are gone and keeps the ones still referenced.
+func TestPrefixTreePruneRemovesEmptyChildren(t *testing.T) {
+	t.Parallel()
+
+	d := New(testTenant, DefaultConfig(), &fakeLimits{}, FormatUnknown, nil)
+
+	now := time.Now()
+	lines := []string{
+		"alpha alpha alpha keep",
+		"beta beta beta drop",
+	}
+	for i, line := range lines {
+		d.Train(line, now.Add(time.Duration(i)*time.Millisecond).UnixNano())
+	}
+
+	require.Len(t, d.Clusters(), 2)
+	before := countNodes(d.rootNode)
+	require.Equal(t, 1, d.rootNode.childCount(), "both lines have the same token count")
+
+	var dropped *LogCluster
+	for _, c := range d.Clusters() {
+		if c.String() == "beta beta beta drop" {
+			dropped = c
+		}
+	}
+	require.NotNil(t, dropped)
+	d.Delete(dropped)
+
+	require.Equal(t, before, countNodes(d.rootNode), "deleting a cluster alone must not touch the tree")
+
+	d.Prune()
+
+	require.Len(t, d.Clusters(), 1)
+	require.Less(t, countNodes(d.rootNode), before, "prune must release the dead branch")
+
+	// The surviving cluster is still reachable through the pruned tree.
+	survivor := d.Clusters()[0]
+	require.Equal(t, survivor, d.treeSearch(d.rootNode, survivor.Tokens, DefaultConfig().SimTh, false))
+}


### PR DESCRIPTION
## Summary
Replace each Drain prefix-tree node's `map[string]*Node` children with a small linearly scanned slice (`MaxChildren` is 15; most nodes have fan-out 0–1).

Empty maps dominate per-node overhead. Same clustering behavior; lower retained heap per Drain.

## Change
- `pkg/pattern/drain/drain.go`: `Node` children → `[]nodeChild` with get/set/delete helpers; `treeSearch` / `addSeqToPrefixTree` / `pruneTree` updated to use them.

## Tests
| File | Purpose |
|------|---------|
| `prefix_tree_test.go` | Child accessors, MaxChildren / `<_>` fan-out, prune removes empty branches |
| `drain_golden_test.go` | Locks cluster templates + tree shape over `testdata/*` (captured from the old map tree). Refresh with `DRAIN_GOLDEN_PRINT=1` if Drain outputs change on purpose |
| `prefix_tree_memory_test.go` | Map-vs-slice retained-heap comparison (map clone exists only in tests) |
| `drain_memory_benchmark_test.go` | Retained heap benches for future memory work |

## Memory (map vs slice, same trees)

Prefix-tree child storage only:

| Corpus | Nodes | Slice | Map | Tree savings |
|--------|------:|------:|----:|-------------:|
| agent-logfmt | 111 | 8 KB | 29 KB | ~71% |
| journald | 1686 | 123 KB | 476 KB | ~74% |
| grafana-ruler | 3347 | 246 KB | 904 KB | ~73% |

Including clusters/chunks, expect roughly **~45–55% less retained heap per Drain**.

Train cost is unchanged in practice, average lookup is as good or better when using a slice as opposed to the map.

```bash
go test ./pkg/pattern/drain/ -run 'TestPrefixTreeRetainedHeap_MapVsSlice' -v
go test ./pkg/pattern/drain/ -run '^$' -bench 'BenchmarkPrefixTreeChildren_MapVsSlice|BenchmarkNodeChildLookup' -benchtime 20x
```

## Test plan
- [x] `go test ./pkg/pattern/drain/...`
- [x] `go test ./pkg/pattern/...`
- [x] Goldens match map-era fingerprints
- [x] Map-vs-slice heap test shows slice ≪ map