### PR TITLE
chore: Pool CRC32 scratch buffer

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
@@ -42,7 +42,7 @@ type seriesFixture struct {
 // keep a symbol list in sync by hand, and it reorders series by fingerprint,
 // which is the order AddSeries requires. Refs are assigned in that order,
 // starting at 1.
-func writeIndexFixture(t *testing.T, format int, series []seriesFixture) string {
+func writeIndexFixture(t testing.TB, format int, series []seriesFixture) string {
 	t.Helper()
 	fileName := filepath.Join(t.TempDir(), IndexFilename)
 
@@ -86,7 +86,7 @@ func writeIndexFixture(t *testing.T, format int, series []seriesFixture) string 
 // openBothReaders opens path with both reader implementations, registering
 // cleanups that close them. It returns the concrete reader types because
 // several tests compare their internals.
-func openBothReaders(t *testing.T, path string) (*ByteSliceReader, *StreamReader) {
+func openBothReaders(t testing.TB, path string) (*ByteSliceReader, *StreamReader) {
 	t.Helper()
 
 	mmap, err := NewMmapFileReader(path)
@@ -103,13 +103,51 @@ func openBothReaders(t *testing.T, path string) (*ByteSliceReader, *StreamReader
 // writeCrossCheckFixture builds a small but non-trivial index used by
 // the cross-check tests: multiple label names, multiple values per
 // name, a couple of chunks per series.
-func writeCrossCheckFixture(t *testing.T, format int) string {
+func writeCrossCheckFixture(t testing.TB, format int) string {
 	t.Helper()
 	return writeIndexFixture(t, format, []seriesFixture{
 		{ls: labels.FromStrings("a", "1", "b", "1", "c", "svcA"), chunks: []ChunkMeta{{Checksum: 1, MinTime: 0, MaxTime: 10, KB: 1, Entries: 1}}},
 		{ls: labels.FromStrings("a", "1", "b", "2", "c", "svcA"), chunks: []ChunkMeta{{Checksum: 2, MinTime: 10, MaxTime: 20, KB: 1, Entries: 1}}},
 		{ls: labels.FromStrings("a", "2", "b", "3", "c", "svcB"), chunks: []ChunkMeta{{Checksum: 3, MinTime: 20, MaxTime: 30, KB: 1, Entries: 1}}},
 	})
+}
+
+// BenchmarkNewStreamFileReader reproduces the index-open hot path.
+func BenchmarkNewStreamFileReader(b *testing.B) {
+	path := writeCrossCheckFixture(b, FormatV4)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r, err := NewStreamFileReader(path)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := r.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPostings(b *testing.B) {
+	path := writeCrossCheckFixture(b, FormatV4)
+	r, err := NewStreamFileReader(path)
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		postings, err := r.Postings("c", nil, "svcA")
+		if err != nil {
+			b.Fatal(err)
+		}
+		for postings.Next() {
+			_ = postings.At()
+		}
+		if err := postings.Err(); err != nil {
+			b.Fatal(err)
+		}
+	}
 }
 
 // chunkSpan is the millisecond width of every chunk written by

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding.go
@@ -12,6 +12,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
+	"sync"
 
 	"github.com/dennwc/varint"
 	"github.com/pkg/errors"
@@ -21,6 +22,17 @@ var (
 	ErrInvalidSize     = errors.New("invalid size")
 	ErrInvalidChecksum = errors.New("invalid checksum")
 )
+
+// crc32ChunkSize is the chunk size used when streaming a Decbuf's contents through a CRC32 hash.
+const crc32ChunkSize = 1024 * 1024
+
+// crc32BufferPool holds reusable scratch buffers for CheckCrc32, saving allocations.
+var crc32BufferPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, crc32ChunkSize)
+		return &b
+	},
+}
 
 // Decbuf provides safe methods to extract data from a big-endian binary data.
 // It the Prometheus encoding.Decbuf type, but for a generic BufReader rather than []byte.
@@ -47,11 +59,13 @@ func (d *Decbuf) CheckCrc32(castagnoliTable *crc32.Table) {
 
 	hash := crc32.New(castagnoliTable)
 	bytesToRead := d.r.Len() - 4
-	maxChunkSize := 1024 * 1024
-	rawBuf := make([]byte, maxChunkSize)
+
+	bufferPointer := crc32BufferPool.Get().(*[]byte)
+	defer crc32BufferPool.Put(bufferPointer)
+	rawBuf := *bufferPointer
 
 	for bytesToRead > 0 {
-		chunkSize := min(bytesToRead, maxChunkSize)
+		chunkSize := min(bytesToRead, crc32ChunkSize)
 		chunkBuf := rawBuf[0:chunkSize]
 
 		err := d.r.ReadInto(chunkBuf)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/factory_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/factory_test.go
@@ -39,14 +39,13 @@ func BenchmarkDecbufFactory_NewDecbufAtUnchecked(b *testing.B) {
 	for factoryName, factory := range factories {
 		b.Run(fmt.Sprintf("DecbufFactory=%s", factoryName), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				decbuf := factory.NewDecbufAtUnchecked(context.Background(), 0)
-				b.Cleanup(func() { _ = decbuf.Close() })
+				d := factory.NewDecbufAtUnchecked(context.Background(), 0)
 
-				if err := decbuf.Err(); err != nil {
+				if err := d.Err(); err != nil {
 					require.NoError(b, err)
 				}
 
-				if err := decbuf.Close(); err != nil {
+				if err := d.Close(); err != nil {
 					require.NoError(b, err)
 				}
 			}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/factory_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/factory_test.go
@@ -39,13 +39,14 @@ func BenchmarkDecbufFactory_NewDecbufAtUnchecked(b *testing.B) {
 	for factoryName, factory := range factories {
 		b.Run(fmt.Sprintf("DecbufFactory=%s", factoryName), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				d := factory.NewDecbufAtUnchecked(context.Background(), 0)
+				decbuf := factory.NewDecbufAtUnchecked(context.Background(), 0)
+				b.Cleanup(func() { _ = decbuf.Close() })
 
-				if err := d.Err(); err != nil {
+				if err := decbuf.Err(); err != nil {
 					require.NoError(b, err)
 				}
 
-				if err := d.Close(); err != nil {
+				if err := decbuf.Close(); err != nil {
 					require.NoError(b, err)
 				}
 			}


### PR DESCRIPTION
Decbuf.CheckCrc32 allocates a fresh 1 MiB scratch buffer on every checked Decbuf open. This is run against various parts of the index when a file reader is opened, and on the query path when Postings(...) is called. This PR includes benchmarks for both.

On these benchmarks:
```
                       │  before.txt   │              after.txt              │
                       │    sec/op     │   sec/op     vs base                │
NewStreamFileReader-12   297.50µ ± 70%   55.36µ ± 2%  -81.39% (p=0.000 n=10)
Postings-12               88.65µ ± 27%   20.54µ ± 1%  -76.83% (p=0.000 n=10)
geomean                   162.4µ         33.72µ       -79.24%

                       │   before.txt    │               after.txt               │
                       │      B/op       │     B/op       vs base                │
NewStreamFileReader-12   4103.256Ki ± 0%   6.951Ki ±  4%  -99.83% (p=0.000 n=10)
Postings-12               1049814.5 ± 0%     847.0 ± 13%  -99.92% (p=0.000 n=10)
geomean                     2.003Mi        2.398Ki        -99.88%

                       │ before.txt │             after.txt              │
                       │ allocs/op  │ allocs/op   vs base                │
NewStreamFileReader-12   83.00 ± 1%   77.00 ± 0%   -7.23% (p=0.000 n=10)
Postings-12              12.00 ± 0%   10.00 ± 0%  -16.67% (p=0.000 n=10)
geomean                  31.56        27.75       -12.07%
```

Benchmarking against realistic indexes I see as much as an 80% time saving on Postings(...) calls for selective queries, and a 40% time saving for less selective queries.

**What this PR does / why we need it**: Part of our effort to migrate away from mmap in index gateways - we're now in the optimisation phase. 

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
