### PR TITLE
fix(logql): Reuse a sharded first/last_over_time() candidate across overlapping steps

### DIFF
--- a/pkg/logql/downstream.go
+++ b/pkg/logql/downstream.go
@@ -332,6 +332,9 @@ type MergeFirstOverTimeExpr struct {
 	syntax.SampleExpr
 	downstreams []DownstreamSampleExpr
 	offset      time.Duration
+
+	// rangeInterval is the range vector's own interval, e.g. the 1m in first_over_time(...[1m]).
+	rangeInterval time.Duration
 }
 
 func (e MergeFirstOverTimeExpr) String() string {
@@ -366,6 +369,9 @@ type MergeLastOverTimeExpr struct {
 	syntax.SampleExpr
 	downstreams []DownstreamSampleExpr
 	offset      time.Duration
+
+	// rangeInterval is the range vector's own interval, e.g. the 1m in last_over_time(...[1m]).
+	rangeInterval time.Duration
 }
 
 func (e MergeLastOverTimeExpr) String() string {
@@ -637,7 +643,7 @@ func (ev *DownstreamEvaluator) NewStepEvaluator(
 			}
 		}
 
-		return NewMergeFirstOverTimeStepEvaluator(params, xs, e.offset), nil
+		return NewMergeFirstOverTimeStepEvaluator(params, xs, e.offset, e.rangeInterval), nil
 	case *MergeLastOverTimeExpr:
 		queries := make([]DownstreamQuery, len(e.downstreams))
 
@@ -672,7 +678,7 @@ func (ev *DownstreamEvaluator) NewStepEvaluator(
 				return nil, fmt.Errorf("unexpected type (%s) uncoercible to StepEvaluator", data.Type())
 			}
 		}
-		return NewMergeLastOverTimeStepEvaluator(params, xs, e.offset), nil
+		return NewMergeLastOverTimeStepEvaluator(params, xs, e.offset, e.rangeInterval), nil
 	case *CountMinSketchEvalExpr:
 		queries := make([]DownstreamQuery, len(e.downstreams))
 

--- a/pkg/logql/downstream_test.go
+++ b/pkg/logql/downstream_test.go
@@ -96,10 +96,17 @@ func TestMappingEquivalence(t *testing.T) {
 		{`first_over_time({a=~".+"} | logfmt | unwrap value [1s]) by (a)`, false, []string{ShardFirstOverTime}},
 		{`first_over_time({a=~".+"} | logfmt | unwrap value [1s] offset 2s) by (a)`, false, []string{ShardFirstOverTime}},
 		{`first_over_time({a=~".+"} | logfmt | unwrap value [1s] offset -2s) by (a)`, false, []string{ShardFirstOverTime}},
+		// window wider than step: the range vector selector overlaps across steps, so a
+		// grouped, sharded first/last_over_time must reuse the same picked sample across
+		// several consecutive output steps instead of matching it to a single one.
+		{`first_over_time({a=~".+"} | logfmt | unwrap value [5s]) by (a)`, false, []string{ShardFirstOverTime}},
+		{`first_over_time({a=~".+"} | logfmt | unwrap value [5s] offset 2s) by (a)`, false, []string{ShardFirstOverTime}},
 		{`last_over_time({a=~".+"} | logfmt | unwrap value [1s])`, false, []string{ShardLastOverTime}},
 		{`last_over_time({a=~".+"} | logfmt | unwrap value [1s]) by (a)`, false, []string{ShardLastOverTime}},
 		{`last_over_time({a=~".+"} | logfmt | unwrap value [1s] offset 2s) by (a)`, false, []string{ShardLastOverTime}},
 		{`last_over_time({a=~".+"} | logfmt | unwrap value [1s] offset -2s) by (a)`, false, []string{ShardLastOverTime}},
+		{`last_over_time({a=~".+"} | logfmt | unwrap value [5s]) by (a)`, false, []string{ShardLastOverTime}},
+		{`last_over_time({a=~".+"} | logfmt | unwrap value [5s] offset 2s) by (a)`, false, []string{ShardLastOverTime}},
 		// topk prefers already-seen values in tiebreakers. Since the test data generates
 		// the same log lines for each series & the resulting promql.Vectors aren't deterministically
 		// sorted by labels, we don't expect this to pass.

--- a/pkg/logql/first_last_over_time.go
+++ b/pkg/logql/first_last_over_time.go
@@ -59,7 +59,7 @@ func (r *firstWithTimestampBatchRangeVectorIterator) At() (int64, StepResult) {
 		s := r.agg(series.Floats)
 		r.at = append(r.at, promql.Sample{
 			F:      s.F,
-			T:      s.T / int64(time.Millisecond),
+			T:      sampleTimestampToMillis(s.T),
 			Metric: series.Metric,
 		})
 	}
@@ -124,7 +124,7 @@ func (r *lastWithTimestampBatchRangeVectorIterator) At() (int64, StepResult) {
 		s := r.agg(series.Floats)
 		r.at = append(r.at, promql.Sample{
 			F:      s.F,
-			T:      s.T / int64(time.Millisecond),
+			T:      sampleTimestampToMillis(s.T),
 			Metric: series.Metric,
 		})
 	}
@@ -146,6 +146,7 @@ type mergeOverTimeStepEvaluator struct {
 	matrices       []promql.Matrix
 	merge          func(promql.Vector, int, int, promql.Series) promql.Vector
 	offset         time.Duration
+	rangeInterval  time.Duration
 }
 
 // Next returns the first or last element within one step of each matrix.
@@ -187,24 +188,33 @@ func (e *mergeOverTimeStepEvaluator) pop(r, s int) {
 	e.matrices[r][s].Floats = e.matrices[r][s].Floats[1:]
 }
 
-// inRange returns true if t is in step range of ts.
-func (e *mergeOverTimeStepEvaluator) inRange(t, ts int64) bool {
-	// The time stamp needs to be adjusted because the original datapoint at t is
+// inRange returns true if sampleTimestamp, the timestamp of the sample a shard picked as its
+// first/last candidate, falls inside the aggregation window ending at stepTimestamp.
+func (e *mergeOverTimeStepEvaluator) inRange(sampleTimestamp, stepTimestamp int64) bool {
+	// The time stamp needs to be adjusted because the original datapoint at sampleTimestamp is
 	// from a shifted query.
-	ts -= e.offset.Milliseconds()
+	stepTimestamp -= e.offset.Milliseconds()
 
-	// special case instant queries
+	// An instant query has a single output step, so a candidate a shard returns has no other
+	// step to be confused with. The shard already restricted it to the right window, so there
+	// is nothing left to check here.
 	if e.step.Milliseconds() == 0 {
 		return true
 	}
-	return (ts-e.step.Milliseconds()) <= t && t < ts
+
+	// Compare against the range vector's own interval, not the step. The step would silently
+	// drop series from grouped, sharded first/last_over_time range queries whenever the interval
+	// is wider.
+	//
+	// The interval is half-open: the lower bound is exclusive, the upper bound is inclusive.
+	return (stepTimestamp-e.rangeInterval.Milliseconds()) < sampleTimestamp && sampleTimestamp <= stepTimestamp
 }
 
 func (*mergeOverTimeStepEvaluator) Close() error { return nil }
 
 func (*mergeOverTimeStepEvaluator) Error() error { return nil }
 
-func NewMergeFirstOverTimeStepEvaluator(params Params, m []promql.Matrix, offset time.Duration) StepEvaluator {
+func NewMergeFirstOverTimeStepEvaluator(params Params, m []promql.Matrix, offset, rangeInterval time.Duration) StepEvaluator {
 	if len(m) == 0 {
 		return EmptyEvaluator[SampleVector]{}
 	}
@@ -216,13 +226,14 @@ func NewMergeFirstOverTimeStepEvaluator(params Params, m []promql.Matrix, offset
 	)
 
 	return &mergeOverTimeStepEvaluator{
-		start:    start,
-		end:      end,
-		ts:       start.Add(-step), // will be corrected on first Next() call
-		step:     step,
-		matrices: m,
-		merge:    mergeFirstOverTime,
-		offset:   offset,
+		start:         start,
+		end:           end,
+		ts:            start.Add(-step), // will be corrected on first Next() call
+		step:          step,
+		matrices:      m,
+		merge:         mergeFirstOverTime,
+		offset:        offset,
+		rangeInterval: rangeInterval,
 	}
 }
 
@@ -242,7 +253,7 @@ func mergeFirstOverTime(vec promql.Vector, pos int, nSeries int, series promql.S
 	return vec
 }
 
-func NewMergeLastOverTimeStepEvaluator(params Params, m []promql.Matrix, offset time.Duration) StepEvaluator {
+func NewMergeLastOverTimeStepEvaluator(params Params, m []promql.Matrix, offset, rangeInterval time.Duration) StepEvaluator {
 	if len(m) == 0 {
 		return EmptyEvaluator[SampleVector]{}
 	}
@@ -254,13 +265,14 @@ func NewMergeLastOverTimeStepEvaluator(params Params, m []promql.Matrix, offset 
 	)
 
 	return &mergeOverTimeStepEvaluator{
-		start:    start,
-		end:      end,
-		ts:       start.Add(-step), // will be corrected on first Next() call
-		step:     step,
-		matrices: m,
-		merge:    mergeLastOverTime,
-		offset:   offset,
+		start:         start,
+		end:           end,
+		ts:            start.Add(-step), // will be corrected on first Next() call
+		step:          step,
+		matrices:      m,
+		merge:         mergeLastOverTime,
+		offset:        offset,
+		rangeInterval: rangeInterval,
 	}
 }
 
@@ -278,4 +290,13 @@ func mergeLastOverTime(vec promql.Vector, pos int, nSeries int, series promql.Se
 	}
 
 	return vec
+}
+
+// sampleTimestampToMillis converts a sample's nanosecond timestamp to milliseconds, rounding up.
+//
+// Truncating down instead could shift the timestamp into the previous millisecond, making the
+// sharded merge (mergeOverTimeStepEvaluator) attribute the sample to the wrong output step.
+func sampleTimestampToMillis(sampleTimestamp int64) int64 {
+	const millis = int64(time.Millisecond)
+	return (sampleTimestamp + millis - 1) / millis
 }

--- a/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
@@ -171,38 +171,43 @@ load
   {app="a", pod="2"} "v=20" @ 50s
   {app="a", pod="1"} "noise" @ 25s
 
+# first_over_time() by()
 eval instant at 60s first_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
   {pod="1"} 2
   {pod="2"} 10
-eval instant at 60s last_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
-  {pod="1"} 4
-  {pod="2"} 20
-eval instant at 60s first_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
-  {app="a"} 2
-eval instant at 60s last_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
-  {app="a"} 20
 eval range from 20s to 50s step 10s first_over_time({app="a"} | logfmt | unwrap v [10s]) by (pod) # non-overlapping
-  {pod="1"} 2 4 _ _
-  {pod="2"} _ _ 10 20
-eval range from 20s to 50s step 10s last_over_time({app="a"} | logfmt | unwrap v [10s]) by (pod)  # non-overlapping
   {pod="1"} 2 4 _ _
   {pod="2"} _ _ 10 20
 eval range from 60s to 70s step 10s first_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod) # overlapping
   {pod="1"} 2 2
   {pod="2"} 10 10
+# last_over_time() by()
+eval instant at 60s last_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
+  {pod="1"} 4
+  {pod="2"} 20
+eval range from 20s to 50s step 10s last_over_time({app="a"} | logfmt | unwrap v [10s]) by (pod)  # non-overlapping
+  {pod="1"} 2 4 _ _
+  {pod="2"} _ _ 10 20
 eval range from 60s to 70s step 10s last_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)  # overlapping
   {pod="1"} 4 4
   {pod="2"} 20 20
+# first_over_time() without()
+eval instant at 60s first_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
+  {app="a"} 2
 eval range from 70s to 80s step 10s first_over_time({app="a"} | logfmt | unwrap v [1m] offset 10s) by (pod) # overlapping
   {pod="1"} 2 2
   {pod="2"} 10 10
+# last_over_time() without()
+eval instant at 60s last_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
+  {app="a"} 20
 eval range from 70s to 80s step 10s last_over_time({app="a"} | logfmt | unwrap v [1m] offset 10s) by (pod)  # overlapping
   {pod="1"} 4 4
   {pod="2"} 20 20
 
-# first_over_time() / last_over_time() with grouping, selection range narrower than the step: each
-# window only covers the trailing [R] slice, so a stream can carry several samples in one step and
-# have most of them fall in the dead zone before the window.
+# first_over_time() / last_over_time() with grouping, range vector interval narrower than the step.
+#
+# In this scenario, each range vector selector only covers the trailing 5s of a 20s step, so a stream
+# can carry several samples in one step and have most of them fall in the dead zone before the window.
 clear
 load
   {app="a", pod="1"} "v=1" @ 10s   # dead zone

--- a/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/range_aggregations.logqltest
@@ -181,6 +181,44 @@ eval instant at 60s first_over_time({app="a"} | logfmt | unwrap v [1m]) without 
   {app="a"} 2
 eval instant at 60s last_over_time({app="a"} | logfmt | unwrap v [1m]) without (pod)
   {app="a"} 20
+eval range from 20s to 50s step 10s first_over_time({app="a"} | logfmt | unwrap v [10s]) by (pod) # non-overlapping
+  {pod="1"} 2 4 _ _
+  {pod="2"} _ _ 10 20
+eval range from 20s to 50s step 10s last_over_time({app="a"} | logfmt | unwrap v [10s]) by (pod)  # non-overlapping
+  {pod="1"} 2 4 _ _
+  {pod="2"} _ _ 10 20
+eval range from 60s to 70s step 10s first_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod) # overlapping
+  {pod="1"} 2 2
+  {pod="2"} 10 10
+eval range from 60s to 70s step 10s last_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)  # overlapping
+  {pod="1"} 4 4
+  {pod="2"} 20 20
+eval range from 70s to 80s step 10s first_over_time({app="a"} | logfmt | unwrap v [1m] offset 10s) by (pod) # overlapping
+  {pod="1"} 2 2
+  {pod="2"} 10 10
+eval range from 70s to 80s step 10s last_over_time({app="a"} | logfmt | unwrap v [1m] offset 10s) by (pod)  # overlapping
+  {pod="1"} 4 4
+  {pod="2"} 20 20
+
+# first_over_time() / last_over_time() with grouping, selection range narrower than the step: each
+# window only covers the trailing [R] slice, so a stream can carry several samples in one step and
+# have most of them fall in the dead zone before the window.
+clear
+load
+  {app="a", pod="1"} "v=1" @ 10s   # dead zone
+  {app="a", pod="1"} "v=2" @ 15s   # on the window's exclusive lower bound: excluded
+  {app="a", pod="1"} "v=5" @ 16s
+  {app="a", pod="1"} "v=8" @ 19s
+  {app="a", pod="2"} "v=10" @ 30s  # dead zone
+  {app="a", pod="2"} "v=20" @ 36s
+  {app="a", pod="2"} "v=25" @ 39s
+
+eval range from 20s to 40s step 20s first_over_time({app="a"} | logfmt | unwrap v [5s]) by (pod) # non-overlapping
+  {pod="1"} 5 _
+  {pod="2"} _ 20
+eval range from 20s to 40s step 20s last_over_time({app="a"} | logfmt | unwrap v [5s]) by (pod)  # non-overlapping
+  {pod="1"} 8 _
+  {pod="2"} _ 25
 
 # quantile_over_time()
 clear

--- a/pkg/logql/shardmapper.go
+++ b/pkg/logql/shardmapper.go
@@ -637,8 +637,9 @@ func (m ShardMapper) mapRangeAggregationExpr(expr *syntax.RangeAggregationExpr, 
 		}
 
 		return &MergeFirstOverTimeExpr{
-			downstreams: downstreams,
-			offset:      expr.Left.Offset,
+			downstreams:   downstreams,
+			offset:        expr.Left.Offset,
+			rangeInterval: expr.Left.Interval,
 		}, bytesPerShard, nil
 	case syntax.OpRangeTypeLast:
 		if !m.lastOverTimeSharding {
@@ -668,8 +669,9 @@ func (m ShardMapper) mapRangeAggregationExpr(expr *syntax.RangeAggregationExpr, 
 		}
 
 		return &MergeLastOverTimeExpr{
-			downstreams: downstreams,
-			offset:      expr.Left.Offset,
+			downstreams:   downstreams,
+			offset:        expr.Left.Offset,
+			rangeInterval: expr.Left.Interval,
 		}, bytesPerShard, nil
 	default:
 		// don't shard if there's not an appropriate optimization


### PR DESCRIPTION
**What this PR does / why we need it**:

Stacked on #23903, which found this bug (via the new coverage it adds) but didn't fix it — the failing eval was dropped there to keep that PR green.

Grouped, sharded `first_over_time()`/`last_over_time()` **range** queries return no series whenever the range vector's window is wider than the query step, e.g.:

```
first_over_time({app="a"} | logfmt | unwrap v [1m]) by (pod)
```
evaluated from `60s` to `70s` at `step 10s`. Unsharded, or without `by (pod)`, the same query returns the correct 2 series.

|                | before | after |
|----------------|--------|-------|
| direct / unsharded | 2 series | 2 series |
| sharded | **0 series** | 2 series |

Root cause: the cross-shard merge (`mergeOverTimeStepEvaluator.inRange`) reconstructed each output step's window as `[ts-step, ts)`, sized by the query **step** (10s), instead of the range vector's own **interval** (the `1m`). Since the interval is wider than the step, the reconstructed window was too narrow and rejected every valid candidate at every step, so nothing ever got merged. A second, related bug (truncating instead of rounding up the candidate's packed nanosecond timestamp) could additionally misattribute a candidate to the wrong step right at a millisecond boundary.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
