### PR TITLE
refactor(util): Rename SizeReader to CountingReader

### DIFF
--- a/pkg/loghttp/push/otlp.go
+++ b/pkg/loghttp/push/otlp.go
@@ -58,7 +58,7 @@ func ParseOTLPRequest(userID string, r *http.Request, limits Limits, tenantConfi
 func extractLogs(r *http.Request, maxRecvMsgSize int, maxDecompressedSize int64, pushStats *Stats) (plog.Logs, error) {
 	pushStats.ContentEncoding = r.Header.Get(contentEnc)
 	// bodySize should always reflect the compressed size of the request body
-	bodySize := loki_util.NewSizeReader(r.Body)
+	bodySize := loki_util.NewCountingReader(r.Body)
 	var body io.Reader = bodySize
 	if maxRecvMsgSize > 0 {
 		// Read from LimitReader with limit max+1. So if the underlying
@@ -104,7 +104,7 @@ func extractLogs(r *http.Request, maxRecvMsgSize int, maxDecompressedSize int64,
 	}
 
 	// Check the size of the compressed body
-	if size := bodySize.Size(); size > int64(maxRecvMsgSize) && maxRecvMsgSize > 0 {
+	if size := bodySize.N(); size > int64(maxRecvMsgSize) && maxRecvMsgSize > 0 {
 		return plog.NewLogs(), fmt.Errorf(messageSizeLargerErrFmt, loki_util.ErrMessageSizeTooLarge, size, maxRecvMsgSize)
 	}
 	// Check the size of the decompressed body
@@ -112,7 +112,7 @@ func extractLogs(r *http.Request, maxRecvMsgSize int, maxDecompressedSize int64,
 		return plog.NewLogs(), fmt.Errorf(messageSizeLargerErrFmt, loki_util.ErrMessageDecompressedSizeTooLarge, len(buf), maxDecompressedSize)
 	}
 
-	pushStats.BodySize = bodySize.Size()
+	pushStats.BodySize = bodySize.N()
 
 	req := plogotlp.NewExportRequest()
 

--- a/pkg/loghttp/push/push.go
+++ b/pkg/loghttp/push/push.go
@@ -339,12 +339,12 @@ func parsePushRequestBody(r *http.Request, maxRecvMsgSize int, maxDecompressedSi
 	// Body
 	var body io.Reader
 	// bodySize should always reflect the compressed size of the request body
-	bodySizeReader := util.NewSizeReader(r.Body)
+	bodySizeReader := util.NewCountingReader(r.Body)
 	// decompressedSize reflects the decompressed size of the request body. It stays
 	// nil when the body is not decompressed here, either because it is uncompressed
 	// or because ParseProtoReaderWithLimits does the snappy-decoding (and its own
 	// decompressed size check) below.
-	var decompressedSizeReader util.SizeReader
+	var decompressedSizeReader *util.CountingReader
 
 	// Apply compressed size limit
 	body = bodySizeReader
@@ -367,7 +367,7 @@ func parsePushRequestBody(r *http.Request, maxRecvMsgSize int, maxDecompressedSi
 		defer func(gzipReader *gzip.Reader) {
 			_ = gzipReader.Close()
 		}(gzipReader)
-		decompressedSizeReader = util.NewSizeReader(gzipReader)
+		decompressedSizeReader = util.NewCountingReader(gzipReader)
 		body = decompressedSizeReader
 		if maxDecompressedSize > 0 {
 			body = io.LimitReader(body, maxDecompressedSize+1)
@@ -377,7 +377,7 @@ func parsePushRequestBody(r *http.Request, maxRecvMsgSize int, maxDecompressedSi
 		defer func(flateReader io.ReadCloser) {
 			_ = flateReader.Close()
 		}(flateReader)
-		decompressedSizeReader = util.NewSizeReader(flateReader)
+		decompressedSizeReader = util.NewCountingReader(flateReader)
 		body = decompressedSizeReader
 		if maxDecompressedSize > 0 {
 			body = io.LimitReader(body, maxDecompressedSize+1)
@@ -427,7 +427,7 @@ func parsePushRequestBody(r *http.Request, maxRecvMsgSize int, maxDecompressedSi
 		}
 	}
 
-	pushStats.BodySize = bodySizeReader.Size()
+	pushStats.BodySize = bodySizeReader.N()
 	pushStats.ContentType = contentType
 	pushStats.ContentEncoding = contentEncoding
 
@@ -441,12 +441,12 @@ func parsePushRequestBody(r *http.Request, maxRecvMsgSize int, maxDecompressedSi
 // decompressed size limit. The readers wrapping the body are limited to max+1 bytes,
 // so a size greater than max means the body was truncated. decompressedSize may be
 // nil, in which case only the compressed size is checked.
-func checkSizeLimits(bodySizeReader, decompressedSizeReader util.SizeReader, maxRecvMsgSize int, maxDecompressedSize int64) error {
-	if size := bodySizeReader.Size(); maxRecvMsgSize > 0 && size > int64(maxRecvMsgSize) {
+func checkSizeLimits(bodySizeReader, decompressedSizeReader *util.CountingReader, maxRecvMsgSize int, maxDecompressedSize int64) error {
+	if size := bodySizeReader.N(); maxRecvMsgSize > 0 && size > int64(maxRecvMsgSize) {
 		return fmt.Errorf(messageSizeLargerErrFmt, util.ErrMessageSizeTooLarge, size, maxRecvMsgSize)
 	}
 	if decompressedSizeReader != nil {
-		if size := decompressedSizeReader.Size(); maxDecompressedSize > 0 && size > maxDecompressedSize {
+		if size := decompressedSizeReader.N(); maxDecompressedSize > 0 && size > maxDecompressedSize {
 			return fmt.Errorf(messageSizeLargerErrFmt, util.ErrMessageDecompressedSizeTooLarge, size, maxDecompressedSize)
 		}
 	}

--- a/pkg/util/reader.go
+++ b/pkg/util/reader.go
@@ -6,28 +6,31 @@ import (
 	"go.uber.org/atomic"
 )
 
-type sizeReader struct {
-	size atomic.Int64
-	r    io.Reader
+// A CountingReader counts the total number of bytes read from an [io.Reader].
+// The count can be reset, useful when used with an [io.ReadSeeker].
+type CountingReader struct {
+	n atomic.Int64
+	r io.Reader
 }
 
-type SizeReader interface {
-	io.Reader
-	Size() int64
+// NewCountingReader returns a new CountingReader.
+func NewCountingReader(r io.Reader) *CountingReader {
+	return &CountingReader{r: r}
 }
 
-// NewSizeReader returns an io.Reader that will have the number of bytes
-// read from r available.
-func NewSizeReader(r io.Reader) SizeReader {
-	return &sizeReader{r: r}
+// N returns the total number of bytes read from the reader.
+func (r *CountingReader) N() int64 {
+	return r.n.Load()
 }
 
-func (v *sizeReader) Read(p []byte) (int, error) {
-	n, err := v.r.Read(p)
-	v.size.Add(int64(n))
+// Read implements the [io.Reader] interface.
+func (r *CountingReader) Read(p []byte) (n int, err error) {
+	n, err = r.r.Read(p)
+	r.n.Add(int64(n))
 	return n, err
 }
 
-func (v *sizeReader) Size() int64 {
-	return v.size.Load()
+// Reset the count to zero.
+func (r *CountingReader) Reset() {
+	r.n.Store(0)
 }

--- a/pkg/util/reader_test.go
+++ b/pkg/util/reader_test.go
@@ -1,0 +1,99 @@
+package util_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/util"
+)
+
+// errReader is a special reader that replaces io.EOF with a different error.
+type errReader struct {
+	data  []byte
+	onEOF error
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, r.onEOF
+	}
+	n := copy(p, r.data)
+	r.data = r.data[n:]
+	return n, nil
+}
+
+func TestCountingReader(t *testing.T) {
+	t.Run("N starts from zero", func(t *testing.T) {
+		cr := util.NewCountingReader(bytes.NewReader([]byte("hello")))
+		assert.Equal(t, int64(0), cr.N())
+	})
+
+	t.Run("data is not modified, just counted", func(t *testing.T) {
+		data := []byte("the quick brown fox jumps over the lazy dog")
+		cr := util.NewCountingReader(bytes.NewReader(data))
+
+		actual, err := io.ReadAll(cr)
+		require.NoError(t, err)
+		assert.Equal(t, data, actual)
+		assert.Equal(t, int64(len(data)), cr.N())
+	})
+
+	t.Run("N is the sum of all reads", func(t *testing.T) {
+		data := []byte("0123456789")
+		cr := util.NewCountingReader(bytes.NewReader(data))
+
+		buf := make([]byte, 3)
+		total := 0
+		for {
+			n, err := cr.Read(buf)
+			total += n
+			if err != nil {
+				require.ErrorIs(t, err, io.EOF)
+				break
+			}
+			assert.Equal(t, int64(total), cr.N())
+		}
+		assert.Equal(t, len(data), total)
+		assert.Equal(t, int64(len(data)), cr.N())
+	})
+
+	t.Run("N is not incremented on error", func(t *testing.T) {
+		expectedErr := errors.New("this is an error")
+		cr := util.NewCountingReader(&errReader{data: []byte("abc"), onEOF: expectedErr})
+
+		buf := make([]byte, 16)
+		n, err := cr.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, 3, n)
+		assert.Equal(t, int64(3), cr.N())
+
+		n, err = cr.Read(buf)
+		require.ErrorIs(t, err, expectedErr)
+		assert.Equal(t, 0, n)
+		assert.Equal(t, int64(3), cr.N())
+	})
+
+	t.Run("reset N does not reset the reader", func(t *testing.T) {
+		data := []byte("0123456789")
+		cr := util.NewCountingReader(bytes.NewReader(data))
+
+		buf := make([]byte, 4)
+		n, err := cr.Read(buf)
+		require.NoError(t, err)
+		require.Equal(t, 4, n)
+		require.Equal(t, int64(4), cr.N())
+
+		cr.Reset()
+		assert.Equal(t, int64(0), cr.N())
+
+		rest, err := io.ReadAll(cr)
+		require.NoError(t, err)
+		assert.Equal(t, data[4:], rest)
+		assert.Equal(t, int64(len(data)-4), cr.N())
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Renames the sizeReader/SizeReader type and NewSizeReader constructor to CountingReader/NewCountingReader (Size() becomes N()), and updates the push and OTLP body-parsing call sites accordingly.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
