### PR TITLE
feat: Adds observability for recently added backfill endpoints

### DIFF
--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -1322,6 +1322,10 @@ client timeout when calling it.
 
 In microservices mode, the `/flush/tenant` endpoint is exposed by the ingester.
 
+Each request is counted in the `loki_ingester_flush_tenant_requests_total`
+metric, labeled by tenant (`user`) and outcome (`status`: `success` or
+`failure`).
+
 ## Sync indexes from object storage
 
 ```bash

--- a/docs/sources/reference/loki-http-api.md
+++ b/docs/sources/reference/loki-http-api.md
@@ -1323,8 +1323,7 @@ client timeout when calling it.
 In microservices mode, the `/flush/tenant` endpoint is exposed by the ingester.
 
 Each request is counted in the `loki_ingester_flush_tenant_requests_total`
-metric, labeled by tenant (`user`) and outcome (`status`: `success` or
-`failure`).
+metric, labeled by outcome (`status`: `success` or `failure`).
 
 ## Sync indexes from object storage
 

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -164,10 +164,16 @@ func (i *Ingester) FlushTenantHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	status := "success"
+	defer func() {
+		i.metrics.flushTenantRequestsTotal.WithLabelValues(tenantID, status).Inc()
+	}()
+
 	var matchers []*labels.Matcher
 	if streams := r.URL.Query().Get("streams"); streams != "" {
 		matchers, err = syntax.ParseMatchers(streams, true)
 		if err != nil {
+			status = "failure"
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
@@ -187,6 +193,7 @@ func (i *Ingester) FlushTenantHandler(w http.ResponseWriter, r *http.Request) {
 		fps = append(fps, s.fp)
 		return nil
 	}); err != nil {
+		status = "failure"
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -194,6 +201,7 @@ func (i *Ingester) FlushTenantHandler(w http.ResponseWriter, r *http.Request) {
 	level.Info(i.logger).Log("msg", "flushing tenant streams", "tenant", tenantID, "streams", len(fps))
 
 	if err := i.flushMatchedStreamsChunks(tenantID, fps); err != nil {
+		status = "failure"
 		level.Error(i.logger).Log("msg", "failed flushing tenant streams", "tenant", tenantID, "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -202,6 +210,7 @@ func (i *Ingester) FlushTenantHandler(w http.ResponseWriter, r *http.Request) {
 	// Force the in-memory index to be built and shipped so the just-flushed
 	// chunks are referenceable from object storage.
 	if err := i.store.FlushIndexes(ctx); err != nil {
+		status = "failure"
 		level.Error(i.logger).Log("msg", "failed flushing index", "tenant", tenantID, "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/pkg/ingester/flush.go
+++ b/pkg/ingester/flush.go
@@ -166,7 +166,7 @@ func (i *Ingester) FlushTenantHandler(w http.ResponseWriter, r *http.Request) {
 
 	status := "success"
 	defer func() {
-		i.metrics.flushTenantRequestsTotal.WithLabelValues(tenantID, status).Inc()
+		i.metrics.flushTenantRequestsTotal.WithLabelValues(status).Inc()
 	}()
 
 	var matchers []*labels.Matcher

--- a/pkg/ingester/flush_test.go
+++ b/pkg/ingester/flush_test.go
@@ -617,8 +617,8 @@ func TestFlushTenantHandler(t *testing.T) {
 		// expectedFlushes is the number of forced index ships (FlushIndexes calls).
 		expectedFlushes int32
 		// expectedMetricStatus is the status label expected on
-		// loki_ingester_flush_tenant_requests_total for orgID; empty means the
-		// request should not be counted (e.g. no tenant could be resolved).
+		// loki_ingester_flush_tenant_requests_total; empty means the request
+		// should not be counted (e.g. no tenant could be resolved).
 		expectedMetricStatus string
 	}{
 		{
@@ -691,7 +691,7 @@ func TestFlushTenantHandler(t *testing.T) {
 
 			if tc.expectedMetricStatus != "" {
 				require.Equal(t, 1, testutil.CollectAndCount(ing.metrics.flushTenantRequestsTotal))
-				require.Equal(t, float64(1), testutil.ToFloat64(ing.metrics.flushTenantRequestsTotal.WithLabelValues(tc.orgID, tc.expectedMetricStatus)))
+				require.Equal(t, float64(1), testutil.ToFloat64(ing.metrics.flushTenantRequestsTotal.WithLabelValues(tc.expectedMetricStatus)))
 			} else {
 				require.Equal(t, 0, testutil.CollectAndCount(ing.metrics.flushTenantRequestsTotal))
 			}

--- a/pkg/ingester/flush_test.go
+++ b/pkg/ingester/flush_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/user"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -615,6 +616,10 @@ func TestFlushTenantHandler(t *testing.T) {
 		expectedStreams []string
 		// expectedFlushes is the number of forced index ships (FlushIndexes calls).
 		expectedFlushes int32
+		// expectedMetricStatus is the status label expected on
+		// loki_ingester_flush_tenant_requests_total for orgID; empty means the
+		// request should not be counted (e.g. no tenant could be resolved).
+		expectedMetricStatus string
 	}{
 		{
 			name:                    "matcher scopes flush to matching streams",
@@ -624,6 +629,7 @@ func TestFlushTenantHandler(t *testing.T) {
 			expectedFlushStatusCode: http.StatusNoContent,
 			expectedStreams:         []string{`{app="a"}`},
 			expectedFlushes:         1,
+			expectedMetricStatus:    "success",
 		},
 		{
 			name:                    "empty selector flushes the whole tenant",
@@ -632,6 +638,7 @@ func TestFlushTenantHandler(t *testing.T) {
 			expectedFlushStatusCode: http.StatusNoContent,
 			expectedStreams:         []string{`{app="a"}`, `{app="b"}`},
 			expectedFlushes:         1,
+			expectedMetricStatus:    "success",
 		},
 		{
 			name:                    "missing tenant is a bad request",
@@ -642,11 +649,13 @@ func TestFlushTenantHandler(t *testing.T) {
 			orgID:                   userID,
 			flushStreamsSelector:    "not-a-matcher",
 			expectedFlushStatusCode: http.StatusBadRequest,
+			expectedMetricStatus:    "failure",
 		},
 		{
 			name:                    "unknown tenant is a no-op",
 			orgID:                   "no-such-tenant",
 			expectedFlushStatusCode: http.StatusNoContent,
+			expectedMetricStatus:    "success",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -679,6 +688,13 @@ func TestFlushTenantHandler(t *testing.T) {
 			require.ElementsMatch(t, tc.expectedStreams, flushedStreams)
 
 			require.Equal(t, tc.expectedFlushes, store.flushIndexCalls.Load())
+
+			if tc.expectedMetricStatus != "" {
+				require.Equal(t, 1, testutil.CollectAndCount(ing.metrics.flushTenantRequestsTotal))
+				require.Equal(t, float64(1), testutil.ToFloat64(ing.metrics.flushTenantRequestsTotal.WithLabelValues(tc.orgID, tc.expectedMetricStatus)))
+			} else {
+				require.Equal(t, 0, testutil.CollectAndCount(ing.metrics.flushTenantRequestsTotal))
+			}
 		})
 	}
 }

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -257,8 +257,8 @@ func newIngesterMetrics(r prometheus.Registerer, metricsNamespace string) *inges
 		flushTenantRequestsTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: constants.Loki,
 			Name:      "ingester_flush_tenant_requests_total",
-			Help:      "Total number of tenant flush (/flush/tenant) requests, partitioned by tenant and status.",
-		}, []string{"user", "status"}),
+			Help:      "Total number of tenant flush (/flush/tenant) requests, partitioned by status.",
+		}, []string{"status"}),
 		chunksFlushedPerReason: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: constants.Loki,
 			Name:      "ingester_chunks_flushed_total",

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -50,6 +50,7 @@ type ingesterMetrics struct {
 	chunkEncodeTime               prometheus.Histogram
 	chunksFlushFailures           prometheus.Counter
 	chunksFlushRequestsTotal      prometheus.Counter
+	flushTenantRequestsTotal      *prometheus.CounterVec
 	chunksFlushedPerReason        *prometheus.CounterVec
 	chunkLifespan                 prometheus.Histogram
 	chunksEncoded                 *prometheus.CounterVec
@@ -253,6 +254,11 @@ func newIngesterMetrics(r prometheus.Registerer, metricsNamespace string) *inges
 			Name:      "ingester_chunks_flush_requests_total",
 			Help:      "Total number of flush requests (successful or not).",
 		}),
+		flushTenantRequestsTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: constants.Loki,
+			Name:      "ingester_flush_tenant_requests_total",
+			Help:      "Total number of tenant flush (/flush/tenant) requests, partitioned by tenant and status.",
+		}, []string{"user", "status"}),
 		chunksFlushedPerReason: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: constants.Loki,
 			Name:      "ingester_chunks_flushed_total",


### PR DESCRIPTION
**What this PR does / why we need it**:
We recetly introduced two endpoints to accomodate support for the backfill work. They are:
- /flush/tenant
- /sync_indexes
However, we noticed a gap in our observability regarding tracking the triggering of those endpoints. This PR addesses that.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
