### PR TITLE
chore(frontend)!: Default frontend.encoding to protobuf

### DIFF
--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -37,6 +37,12 @@ The output is incredibly verbose as it shows the entire internal config struct u
 
 ## Main / Unreleased
 
+### `frontend.encoding` default changed to `protobuf`
+
+The default value of `-frontend.encoding` / `frontend.encoding` changed from `json` to `protobuf`. This only affects the internal request/response encoding between the query-frontend, query-scheduler, and querier. Client-facing APIs are unchanged, and no persisted state uses this setting, so no data migration is required.
+
+Schedulers and queriers already accept both encodings, so mixed frontends during a rolling upgrade are safe. To keep the previous behavior, set `frontend.encoding: json` explicitly.
+
 ### `frontend.compress_responses` default changed to `true`
 
 The default value of `frontend.compress_responses` changed to `true`. A bug in Loki 3.4.0 unintentionally switched it to `false`. If you don't want the query-frontend to compress HTTP responses, set `frontend.compress_responses` to `false` explicitly.

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3657,9 +3657,9 @@ The `frontend` block configures the Loki query-frontend.
 [instance_enable_ipv6: <boolean> | default = false]
 
 # Defines the encoding for requests to and responses from the scheduler and
-# querier. Can be 'json' or 'protobuf' (defaults to 'json').
+# querier. Can be 'json' or 'protobuf' (defaults to 'protobuf').
 # CLI flag: -frontend.encoding
-[encoding: <string> | default = "json"]
+[encoding: <string> | default = "protobuf"]
 
 # Compress HTTP responses.
 # CLI flag: -querier.compress-http-responses

--- a/pkg/lokifrontend/frontend/v2/frontend.go
+++ b/pkg/lokifrontend/frontend/v2/frontend.go
@@ -76,7 +76,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 	cfg.GRPCClientConfig.RegisterFlagsWithPrefix("frontend.grpc-client-config", f)
 
-	f.StringVar(&cfg.Encoding, "frontend.encoding", "json", "Defines the encoding for requests to and responses from the scheduler and querier. Can be 'json' or 'protobuf' (defaults to 'json').")
+	f.StringVar(&cfg.Encoding, "frontend.encoding", EncodingProtobuf, "Defines the encoding for requests to and responses from the scheduler and querier. Can be 'json' or 'protobuf' (defaults to 'protobuf').")
 }
 
 // Frontend implements GrpcRoundTripper. It queues HTTP requests,


### PR DESCRIPTION
## Summary

- Change the default of `-frontend.encoding` / `frontend.encoding` from `json` to `protobuf`.
- This only affects the internal query-frontend ↔ query-scheduler ↔ querier wire format. Client APIs are unchanged, and nothing is persisted with this encoding, so no data migration is required.
- Schedulers and queriers already accept both encodings, so rolling upgrades with mixed frontends are safe. Operators who need the old behavior can set `frontend.encoding: json` explicitly.
- Documented under Main / Unreleased in the upgrade guide and regenerated `configuration.md`.

## Test plan

- [x] `go test ./pkg/lokifrontend/frontend/v2/... ./pkg/loki/`
- [x] `make doc` regenerated `docs/sources/shared/configuration.md`
- [ ] CI green


Made with [Cursor](https://cursor.com)