### PR TITLE
fix(engine): anchor non-message regex filters in the v2 planner

### DIFF
--- a/pkg/engine/internal/planner/logical/logical_optimize.go
+++ b/pkg/engine/internal/planner/logical/logical_optimize.go
@@ -241,6 +241,18 @@ func (pass simplifyRegexPass) simplifyBinop(b *BinOp) (simplified []Node, change
 
 	nodes, changed := pass.simplifyRegex(b.Left, isMessage, reg.Simplify())
 
+	if !changed && !isMessage {
+		// A regex on a non-message column must match the whole value, like a
+		// stream selector matcher. The executor's MATCH_RE is unanchored, so
+		// anchor the pattern before it reaches execution.
+		anchored := &BinOp{
+			Left:  b.Left,
+			Op:    b.Op,
+			Right: NewLiteral("^(?:" + expr + ")$"),
+		}
+		return []Node{anchored}, true, nil
+	}
+
 	if changed && b.Op == types.BinaryOpNotMatchRe {
 		// Add a final instruction to invert the match.
 		nodes = append(nodes, &UnaryOp{
@@ -282,6 +294,11 @@ func (pass simplifyRegexPass) simplifyRegex(from Value, isMessage bool, reg *syn
 		return result, true
 
 	case syntax.OpConcat:
+		// Non-message columns match whole values: only .*literal.* is safe as
+		// a substring match, other shapes fall back to an anchored regexp.
+		if !isMessage && !isContainsEquivalentConcat(reg) {
+			return nil, false
+		}
 		return pass.simplifyRegexConcat(from, reg, nil)
 
 	case syntax.OpCapture:
@@ -334,12 +351,38 @@ func (pass simplifyRegexPass) simplifyRegex(from Value, isMessage bool, reg *syn
 		}
 
 	case syntax.OpEmptyMatch:
+		if !isMessage {
+			// anchored empty regexp matches only empty values.
+			return []Node{
+				&BinOp{
+					Left:  from,
+					Right: &Literal{inner: types.StringLiteral("")},
+					Op:    types.BinaryOpEq,
+				},
+			}, true
+		}
 		// "()" simplifies to an always-pass expression, so we propagate the
 		// source back up.
 		return []Node{from}, true
 	}
 
 	return nil, false
+}
+
+// isContainsEquivalentConcat reports whether a concat regexp is .*literal.*,
+// the only concat shape whose substring simplification matches whole values.
+func isContainsEquivalentConcat(reg *syntax.Regexp) bool {
+	util.ClearCapture(reg.Sub...)
+	isDotStar := func(r *syntax.Regexp) bool {
+		return r.Op == syntax.OpStar && r.Sub[0].Op == syntax.OpAnyCharNotNL
+	}
+	subs := make([]*syntax.Regexp, 0, len(reg.Sub))
+	for _, sub := range reg.Sub {
+		if sub.Op != syntax.OpEmptyMatch {
+			subs = append(subs, sub)
+		}
+	}
+	return len(subs) == 3 && isDotStar(subs[0]) && subs[1].Op == syntax.OpLiteral && isDotStar(subs[2])
 }
 
 // simplifyRegexConcat attempts to simplify regex concatenations. Supported

--- a/pkg/engine/internal/planner/logical/logical_optimize_test.go
+++ b/pkg/engine/internal/planner/logical/logical_optimize_test.go
@@ -229,6 +229,34 @@ RETURN %11
 	require.Equal(t, expect, actual, "Actual plan:\n%s", actual)
 }
 
+func Test_simplifyRegexPass_LabelFallbackNegate(t *testing.T) {
+	// A non-message regex that cannot be simplified must be anchored, keeping
+	// the negated operation.
+	id, err := semconv.ParseFQN("utf8.label.foo")
+	require.NoError(t, err)
+
+	orig := &BinOp{
+		Left:  &ColumnRef{Ref: id.ColumnRef()},
+		Op:    types.BinaryOpNotMatchRe,
+		Right: NewLiteral("foo.*"),
+	}
+
+	var pass simplifyRegexPass
+	instrs, changed, err := pass.simplifyBinop(orig)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	p, err := convertToPlan(instrs[len(instrs)-1].(Value))
+	require.NoError(t, err)
+
+	expect := strings.TrimSpace(`
+%1 = NOT_MATCH_RE label.foo "^(?:foo.*)$"
+RETURN %1
+`)
+	actual := strings.TrimSpace(p.String())
+	require.Equal(t, expect, actual, "Actual plan:\n%s", actual)
+}
+
 //go:embed testdata/simplifyRegexPass/*.txtar
 var simplifyRegexTests embed.FS
 

--- a/pkg/engine/internal/planner/logical/testdata/simplifyRegexPass/concat_alternates_label.txtar
+++ b/pkg/engine/internal/planner/logical/testdata/simplifyRegexPass/concat_alternates_label.txtar
@@ -1,0 +1,13 @@
+Alternates with a common literal prefix are factored into a concatenation by
+the regexp parser (bar|buzz becomes b(?:ar|uzz)). On a non-message column
+that shape must stay anchored.
+
+-- column --
+utf8.label.foo
+
+-- regex --
+bar|buzz
+
+-- expect --
+%1 = MATCH_RE label.foo "^(?:bar|buzz)$"
+RETURN %1

--- a/pkg/engine/internal/planner/logical/testdata/simplifyRegexPass/concat_infix_label.txtar
+++ b/pkg/engine/internal/planner/logical/testdata/simplifyRegexPass/concat_infix_label.txtar
@@ -1,0 +1,12 @@
+A .*literal.* concatenation keeps whole-value semantics as a substring
+match, even on a non-message column.
+
+-- column --
+utf8.label.foo
+
+-- regex --
+.*foo.*
+
+-- expect --
+%1 = MATCH_STR label.foo "foo"
+RETURN %1

--- a/pkg/engine/internal/planner/logical/testdata/simplifyRegexPass/concat_prefix_label.txtar
+++ b/pkg/engine/internal/planner/logical/testdata/simplifyRegexPass/concat_prefix_label.txtar
@@ -1,0 +1,13 @@
+Concatenations with a literal prefix on a non-message column must match the
+whole value, so they are rewritten to an anchored regex instead of a
+substring match.
+
+-- column --
+utf8.label.foo
+
+-- regex --
+foo.*
+
+-- expect --
+%1 = MATCH_RE label.foo "^(?:foo.*)$"
+RETURN %1

--- a/pkg/engine/internal/planner/logical/testdata/simplifyRegexPass/concat_suffix_label.txtar
+++ b/pkg/engine/internal/planner/logical/testdata/simplifyRegexPass/concat_suffix_label.txtar
@@ -1,0 +1,13 @@
+Concatenations with a literal suffix on a non-message column must match the
+whole value, so they are rewritten to an anchored regex instead of a
+substring match.
+
+-- column --
+utf8.label.foo
+
+-- regex --
+.*foo
+
+-- expect --
+%1 = MATCH_RE label.foo "^(?:.*foo)$"
+RETURN %1

--- a/pkg/engine/internal/planner/logical/testdata/simplifyRegexPass/empty_label.txtar
+++ b/pkg/engine/internal/planner/logical/testdata/simplifyRegexPass/empty_label.txtar
@@ -1,0 +1,11 @@
+An empty regex on a non-message column only matches an empty value.
+
+-- column --
+utf8.label.foo
+
+-- regex --
+
+
+-- expect --
+%1 = EQ label.foo ""
+RETURN %1

--- a/pkg/engine/internal/planner/logical/testdata/simplifyRegexPass/insensitive_concat_prefix_label.txtar
+++ b/pkg/engine/internal/planner/logical/testdata/simplifyRegexPass/insensitive_concat_prefix_label.txtar
@@ -1,0 +1,12 @@
+A case-insensitive literal prefix concatenation on a non-message column must
+stay anchored.
+
+-- column --
+utf8.label.foo
+
+-- regex --
+(?i)ERROR.*
+
+-- expect --
+%1 = MATCH_RE label.foo "^(?:(?i)ERROR.*)$"
+RETURN %1


### PR DESCRIPTION
**What this PR does / why we need it**:

The v2 engine executor evaluates `MATCH_RE` with an unanchored
`regexp.Match`, and the `SimplifyRegex` pass dropped the column type when
simplifying concatenations, always emitting `MATCH_SUBSTR`. Together this
made label filter regexes match substrings instead of whole values, and
made the engine internally inconsistent: `name=~"foo"` simplified to exact
equality while `name=~"foo.*"` and the unsimplifiable `name=~"foo?"` both
matched substrings.

```logql
{app="a"} | detected_level=~"warn.*"
# before: matches "warning" but also "prewarning" (substring)
# after:  matches only values starting with "warn" (anchored)
```

This PR gives non-message columns whole-value semantics, matching stream
selector matchers and the documented label filter behavior:

- Only the `.*literal.*` concat shape still simplifies to a substring
  match on non-message columns (equivalent to the anchored regex).
- Any other pattern that cannot be simplified is rewritten to an anchored
  `^(?:...)$` `MATCH_RE`/`NOT_MATCH_RE`, since the executor is unanchored.
- An empty regex on a non-message column becomes `EQ ""` instead of
  always-pass.

Message columns (line filters `|~`) are unchanged, and stream selector
BinOps were already excluded from the pass by `shouldApply`.

**Which issue(s) this PR fixes**:
Relates to #23892, which reports the same simplification defect in the
classic engine (`RegexSimplifier` in `pkg/logql/log/filter.go`). This PR
fixes the v2 engine only; the classic engine still has the issue.

**Special notes for your reviewer**:

- The `shouldApply` comment already acknowledged the un-anchoring problem
  for stream selectors; this extends the correction to label filters.
- New txtar cases pin the non-message behavior (`concat_*_label`,
  `empty_label`, `insensitive_concat_prefix_label`), plus a unit test for
  the negated fallback. All existing message-column cases are unchanged.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
