### PR TITLE
fix: Mask all credentials (backport release-3.5.x)

### DIFF
--- a/pkg/loki/config_wrapper_test.go
+++ b/pkg/loki/config_wrapper_test.go
@@ -626,7 +626,7 @@ memberlist:
 				assert.Equal(t, "testbucket", actual.Bucket)
 				assert.Equal(t, "https://example.com", actual.Endpoint)
 				assert.Equal(t, "abc123", actual.AccessKeyID)
-				assert.Equal(t, "def789", actual.SecretAccessKey)
+				assert.Equal(t, flagext.SecretWithValue("def789"), actual.SecretAccessKey)
 			}
 
 			// should remain empty

--- a/pkg/ruler/base/notifier.go
+++ b/pkg/ruler/base/notifier.go
@@ -218,15 +218,15 @@ func amConfigFromURL(cfg *ruler_config.AlertManagerConfig, url *url.URL, apiVers
 	if cfg.Notifier.BasicAuth.IsEnabled() {
 		amConfig.HTTPClientConfig.BasicAuth = &config_util.BasicAuth{
 			Username: cfg.Notifier.BasicAuth.Username,
-			Password: config_util.Secret(cfg.Notifier.BasicAuth.Password),
+			Password: config_util.Secret(cfg.Notifier.BasicAuth.Password.String()),
 		}
 	}
 
 	if cfg.Notifier.HeaderAuth.IsEnabled() {
-		if cfg.Notifier.HeaderAuth.Credentials != "" {
+		if cfg.Notifier.HeaderAuth.Credentials.String() != "" {
 			amConfig.HTTPClientConfig.Authorization = &config_util.Authorization{
 				Type:        cfg.Notifier.HeaderAuth.Type,
-				Credentials: config_util.Secret(cfg.Notifier.HeaderAuth.Credentials),
+				Credentials: config_util.Secret(cfg.Notifier.HeaderAuth.Credentials.String()),
 			}
 		} else if cfg.Notifier.HeaderAuth.CredentialsFile != "" {
 			amConfig.HTTPClientConfig.Authorization = &config_util.Authorization{

--- a/pkg/ruler/base/notifier_test.go
+++ b/pkg/ruler/base/notifier_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/dskit/flagext"
+
 	ruler_config "github.com/grafana/loki/v3/pkg/ruler/config"
 	"github.com/grafana/loki/v3/pkg/util"
 )
@@ -210,7 +212,7 @@ func TestBuildNotifierConfig(t *testing.T) {
 					Notifier: ruler_config.NotifierConfig{
 						BasicAuth: util.BasicAuth{
 							Username: "jacob",
-							Password: "test",
+							Password: flagext.SecretWithValue("test"),
 						},
 					},
 				},
@@ -245,7 +247,7 @@ func TestBuildNotifierConfig(t *testing.T) {
 					Notifier: ruler_config.NotifierConfig{
 						HeaderAuth: util.HeaderAuth{
 							Type:        "Bearer",
-							Credentials: "jacob",
+							Credentials: flagext.SecretWithValue("jacob"),
 						},
 					},
 				},

--- a/pkg/storage/chunk/client/alibaba/oss_object_client.go
+++ b/pkg/storage/chunk/client/alibaba/oss_object_client.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/instrument"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -35,12 +36,12 @@ type OssObjectClient struct {
 
 // OssConfig is config for the OSS Chunk Client.
 type OssConfig struct {
-	Bucket               string `yaml:"bucket"`
-	Endpoint             string `yaml:"endpoint"`
-	AccessKeyID          string `yaml:"access_key_id"`
-	SecretAccessKey      string `yaml:"secret_access_key"`
-	ConnectionTimeoutSec int64  `yaml:"conn_timeout_sec"`
-	ReadWriteTimeoutSec  int64  `yaml:"read_write_timeout_sec"`
+	Bucket               string         `yaml:"bucket"`
+	Endpoint             string         `yaml:"endpoint"`
+	AccessKeyID          string         `yaml:"access_key_id"`
+	SecretAccessKey      flagext.Secret `yaml:"secret_access_key"`
+	ConnectionTimeoutSec int64          `yaml:"conn_timeout_sec"`
+	ReadWriteTimeoutSec  int64          `yaml:"read_write_timeout_sec"`
 }
 
 // RegisterFlags registers flags.
@@ -53,7 +54,7 @@ func (cfg *OssConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.Bucket, prefix+"oss.bucketname", "", "Name of OSS bucket.")
 	f.StringVar(&cfg.Endpoint, prefix+"oss.endpoint", "", "oss Endpoint to connect to.")
 	f.StringVar(&cfg.AccessKeyID, prefix+"oss.access-key-id", "", "alibabacloud Access Key ID")
-	f.StringVar(&cfg.SecretAccessKey, prefix+"oss.secret-access-key", "", "alibabacloud Secret Access Key")
+	f.Var(&cfg.SecretAccessKey, prefix+"oss.secret-access-key", "alibabacloud Secret Access Key")
 	f.Int64Var(&cfg.ConnectionTimeoutSec, prefix+"oss.conn-timeout-sec", 30, "Connection timeout in seconds")
 	f.Int64Var(&cfg.ReadWriteTimeoutSec, prefix+"oss.read-write-timeout-sec", 60, "Read/Write timeout in seconds")
 }
@@ -67,7 +68,7 @@ func (cfg *OssConfig) Validate() error {
 
 // NewOssObjectClient makes a new chunk.Client that writes chunks to OSS.
 func NewOssObjectClient(_ context.Context, cfg OssConfig) (client.ObjectClient, error) {
-	client, err := oss.New(cfg.Endpoint, cfg.AccessKeyID, cfg.SecretAccessKey, oss.Timeout(cfg.ConnectionTimeoutSec, cfg.ReadWriteTimeoutSec))
+	client, err := oss.New(cfg.Endpoint, cfg.AccessKeyID, cfg.SecretAccessKey.String(), oss.Timeout(cfg.ConnectionTimeoutSec, cfg.ReadWriteTimeoutSec))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/chunk/client/azure/blob_storage_client.go
+++ b/pkg/storage/chunk/client/azure/blob_storage_client.go
@@ -87,7 +87,7 @@ type BlobStorageConfig struct {
 	Environment         string         `yaml:"environment"`
 	StorageAccountName  string         `yaml:"account_name"`
 	StorageAccountKey   flagext.Secret `yaml:"account_key"`
-	ConnectionString    string         `yaml:"connection_string"`
+	ConnectionString    flagext.Secret `yaml:"connection_string"`
 	ContainerName       string         `yaml:"container_name"`
 	EndpointSuffix      string         `yaml:"endpoint_suffix"`
 	UseManagedIdentity  bool           `yaml:"use_managed_identity"`
@@ -122,7 +122,7 @@ func (c *BlobStorageConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagS
 	f.StringVar(&c.Environment, prefix+"azure.environment", azureGlobal, fmt.Sprintf("Azure Cloud environment. Supported values are: %s.", strings.Join(supportedEnvironments, ", ")))
 	f.StringVar(&c.StorageAccountName, prefix+"azure.account-name", "", "Azure storage account name.")
 	f.Var(&c.StorageAccountKey, prefix+"azure.account-key", "Azure storage account key.")
-	f.StringVar(&c.ConnectionString, prefix+"azure.connection-string", "", "If `connection-string` is set, the values of `account-name` and `endpoint-suffix` values will not be used. Use this method over `account-key` if you need to authenticate via a SAS token. Or if you use the Azurite emulator.")
+	f.Var(&c.ConnectionString, prefix+"azure.connection-string", "If `connection-string` is set, the values of `account-name` and `endpoint-suffix` values will not be used. Use this method over `account-key` if you need to authenticate via a SAS token. Or if you use the Azurite emulator.")
 	f.StringVar(&c.ContainerName, prefix+"azure.container-name", constants.Loki, "Name of the storage account blob container used to store chunks. This container must be created before running cortex.")
 	f.StringVar(&c.EndpointSuffix, prefix+"azure.endpoint-suffix", "", "Azure storage endpoint suffix without schema. The storage account name will be prefixed to this value to create the FQDN.")
 	f.BoolVar(&c.UseManagedIdentity, prefix+"azure.use-managed-identity", false, "Use Managed Identity to authenticate to the Azure storage account.")
@@ -405,8 +405,8 @@ func (b *BlobStorage) newPipeline(hedgingCfg hedging.Config, hedging bool) (pipe
 		})
 	}
 
-	if b.cfg.ConnectionString != "" {
-		parsed, err := parseConnectionString(b.cfg.ConnectionString)
+	if b.cfg.ConnectionString.String() != "" {
+		parsed, err := parseConnectionString(b.cfg.ConnectionString.String())
 		if err != nil {
 			return nil, err
 		}
@@ -618,7 +618,7 @@ func (c *BlobStorageConfig) Validate() error {
 }
 
 func (b *BlobStorage) fmtResourceURL() string {
-	if b.cfg.ConnectionString != "" {
+	if b.cfg.ConnectionString.String() != "" {
 		return b.endpointFromConnectionString()
 	}
 
@@ -633,7 +633,7 @@ func (b *BlobStorage) fmtResourceURL() string {
 }
 
 func (b *BlobStorage) endpointFromConnectionString() string {
-	parsed, err := parseConnectionString(b.cfg.ConnectionString)
+	parsed, err := parseConnectionString(b.cfg.ConnectionString.String())
 	if err != nil || parsed.ServiceURL == "" {
 		level.Warn(log.Logger).Log("msg", "could not get resource URL from connection string", "err", err)
 	}

--- a/pkg/storage/chunk/client/azure/blob_storage_client_test.go
+++ b/pkg/storage/chunk/client/azure/blob_storage_client_test.go
@@ -200,7 +200,7 @@ func Test_EndpointSuffixWithContainer(t *testing.T) {
 func Test_ConnectionStringWithContainer(t *testing.T) {
 	c, err := NewBlobStorage(&BlobStorageConfig{
 		ContainerName:    "foo",
-		ConnectionString: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=shorter=;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;",
+		ConnectionString: flagext.SecretWithValue("DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=shorter=;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"),
 	}, metrics, hedging.Config{})
 	require.NoError(t, err)
 	expect, _ := url.Parse("http://127.0.0.1:10000/devstoreaccount1/foo")
@@ -241,7 +241,7 @@ func Test_EndpointSuffixWithBlob(t *testing.T) {
 func Test_ConnectionStringWithBlob(t *testing.T) {
 	c, err := NewBlobStorage(&BlobStorageConfig{
 		ContainerName:    "foo",
-		ConnectionString: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=shorter=;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;",
+		ConnectionString: flagext.SecretWithValue("DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=shorter=;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"),
 	}, metrics, hedging.Config{})
 	require.NoError(t, err)
 	expect, _ := url.Parse("http://127.0.0.1:10000/devstoreaccount1/foo/blob")

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
+	"github.com/grafana/dskit/flagext"
 	"github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"gopkg.in/yaml.v2"
@@ -37,36 +38,36 @@ func IsRequestBodyTooLarge(err error) bool {
 
 // BasicAuth configures basic authentication for HTTP clients.
 type BasicAuth struct {
-	Username string `yaml:"basic_auth_username"`
-	Password string `yaml:"basic_auth_password"`
+	Username string         `yaml:"basic_auth_username"`
+	Password flagext.Secret `yaml:"basic_auth_password"`
 }
 
 func (b *BasicAuth) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&b.Username, prefix+"basic-auth-username", "", "HTTP Basic authentication username. It overrides the username set in the URL (if any).")
-	f.StringVar(&b.Password, prefix+"basic-auth-password", "", "HTTP Basic authentication password. It overrides the password set in the URL (if any).")
+	f.Var(&b.Password, prefix+"basic-auth-password", "HTTP Basic authentication password. It overrides the password set in the URL (if any).")
 }
 
 // IsEnabled returns false if basic authentication isn't enabled.
 func (b BasicAuth) IsEnabled() bool {
-	return b.Username != "" || b.Password != ""
+	return b.Username != "" || b.Password.String() != ""
 }
 
 // HeaderAuth condigures header based authorization for HTTP clients.
 type HeaderAuth struct {
-	Type            string `yaml:"type,omitempty"`
-	Credentials     string `yaml:"credentials,omitempty"`
-	CredentialsFile string `yaml:"credentials_file,omitempty"`
+	Type            string         `yaml:"type,omitempty"`
+	Credentials     flagext.Secret `yaml:"credentials,omitempty"`
+	CredentialsFile string         `yaml:"credentials_file,omitempty"`
 }
 
 func (h *HeaderAuth) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&h.Type, prefix+"type", "Bearer", "HTTP Header authorization type (default: Bearer).")
-	f.StringVar(&h.Credentials, prefix+"credentials", "", "HTTP Header authorization credentials.")
+	f.Var(&h.Credentials, prefix+"credentials", "HTTP Header authorization credentials.")
 	f.StringVar(&h.CredentialsFile, prefix+"credentials-file", "", "HTTP Header authorization credentials file.")
 }
 
 // IsEnabled returns false if header authorization isn't enabled.
 func (h HeaderAuth) IsEnabled() bool {
-	return h.Credentials != "" || h.CredentialsFile != ""
+	return h.Credentials.String() != "" || h.CredentialsFile != ""
 }
 
 // WriteJSONResponse writes some JSON as a HTTP response.


### PR DESCRIPTION
This PR backports `grafana/loki#20766` ("fix: Mask all credentials") to `release-3.5.x`. It types the last few remaining plaintext secret fields as `flagext.Secret` instead of `string`:

- `storage_config.azure.connection_string`
- `storage_config.alibabacloud.secret_access_key`
- `ruler.alertmanager_client.basic_auth_password`
- `ruler.alertmanager_client.credentials`

Loki only redacts config fields typed as `flagext.Secret` when serving `GET /config`; a plain `string` field is returned verbatim, so these four values were leaking in cleartext to anyone with access to that endpoint.

## Backport notes

Upstream merged this to `main` on 2026-02-11 but it was never backported. Cherry-picking onto `release-3.5.x` hit two conflicts, both resolved by hand:

- `pkg/storage/chunk/client/azure/blob_storage_client.go` — conflict was just field-alignment noise from `main`'s extra `active_directory_endpoint` field (a `main`-only addition, not present on this branch). Kept this branch's field set and applied the real change.
- `pkg/util/http.go` — conflict was `main`'s OpenTelemetry tracing imports vs. this branch's `opentracing-go`. Kept this branch's imports, added the one new `flagext` import.

## Notes to reviewer

- This loki branch has been retired. The fix is for backporting to GEL 3.5
- The CI is out of date so a number of steps will fail because of infrastructure changes and not code correctness
- We don't need to do a build or release of this branch
