### PR TITLE
fix: allow -list-targets to run without a config file

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -56,9 +56,17 @@ func main() {
 		fmt.Println(version.Print("loki"))
 		os.Exit(0)
 	}
+	// list-targets should not require a config file: it only lists the
+	// available targets, which does not depend on the configuration.
+	// See https://github.com/grafana/loki/issues/23734
 	if err := cfg.DynamicUnmarshal(&config, os.Args[1:], flag.CommandLine); err != nil {
-		fmt.Fprintf(os.Stderr, "failed parsing config: %v\n", err)
-		os.Exit(1)
+		if !loki.ShouldListTargets(os.Args[1:]) {
+			fmt.Fprintf(os.Stderr, "failed parsing config: %v\n", err)
+			os.Exit(1)
+		}
+		// -list-targets does not need a configuration file, so we ignore the
+		// config parsing failure and use the defaults.
+		config.ListTargets = true
 	}
 
 	// Set the global OTLP config which is needed in per tenant otlp config

--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -64,9 +64,15 @@ func main() {
 			fmt.Fprintf(os.Stderr, "failed parsing config: %v\n", err)
 			os.Exit(1)
 		}
-		// -list-targets does not need a configuration file, so we ignore the
-		// config parsing failure and use the defaults.
-		config.ListTargets = true
+		// -list-targets does not need a configuration file: create a Loki instance
+		// with default config and list the available targets.
+		t, newErr := loki.New(config.Config)
+		if newErr != nil {
+			fmt.Fprintf(os.Stderr, "failed to create Loki: %v\n", newErr)
+			os.Exit(1)
+		}
+		t.ListTargets()
+		os.Exit(0)
 	}
 
 	// Set the global OTLP config which is needed in per tenant otlp config

--- a/pkg/loki/config_wrapper.go
+++ b/pkg/loki/config_wrapper.go
@@ -24,6 +24,7 @@ import (
 )
 
 const versionFlag = "version"
+const listTargetsFlag = "list-targets"
 
 // ConfigWrapper is a struct containing the Loki config along with other values that can be set on the command line
 // for interacting with the config file or the application directly.
@@ -42,6 +43,16 @@ type ConfigWrapper struct {
 
 func PrintVersion(args []string) bool {
 	pattern := regexp.MustCompile(`^-+` + versionFlag + `$`)
+	for _, a := range args {
+		if pattern.MatchString(a) {
+			return true
+		}
+	}
+	return false
+}
+
+func ShouldListTargets(args []string) bool {
+	pattern := regexp.MustCompile(`^-+` + listTargetsFlag + `$`)
 	for _, a := range args {
 		if pattern.MatchString(a) {
 			return true


### PR DESCRIPTION
## Description

`loki -list-targets` currently fails when no config file is present:
```
failed parsing config: config.yaml,config/config.yaml does not exist, set config.file for custom config path
```

This is because the `-list-targets` flag is handled after `cfg.DynamicUnmarshal`, which requires a valid config file. However, listing available targets does not depend on any configuration — it only needs a Loki instance with registered modules.

## Fix

1. Added `ShouldListTargets(args []string) bool` to `pkg/loki/config_wrapper.go` (following the same pattern as `PrintVersion`) to detect the `-list-targets` flag from raw args.
2. In `cmd/loki/main.go`, when `cfg.DynamicUnmarshal` fails and `-list-targets` is set, create a Loki instance with default config and list the targets directly, bypassing config validation.

Fixes #23734