### PR TITLE
fix(helm): prevent duplicate label collision in zone-aware ingester

### DIFF
--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-a.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-a.yaml
@@ -62,10 +62,7 @@ spec:
         {{- end }}
       labels:
         {{- include "loki.ingesterLabels" . | nindent 8 }}
-        app.kubernetes.io/part-of: memberlist
-        name: {{ include "loki.prefixIngesterName" . }}ingester-zone-a
-        rollout-group: {{ include "loki.prefixRolloutGroup" . }}ingester
-        {{- with merge (dict) .Values.loki.podLabels .Values.ingester.podLabels }}
+        {{- with merge (dict) (dict "app.kubernetes.io/part-of" "memberlist" "name" (printf "%singester-zone-a" (include "loki.prefixIngesterName" .)) "rollout-group" (printf "%singester" (include "loki.prefixRolloutGroup" .))) .Values.loki.podLabels .Values.ingester.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:

--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-b.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-b.yaml
@@ -62,10 +62,7 @@ spec:
         {{- end }}
       labels:
         {{- include "loki.ingesterLabels" . | nindent 8 }}
-        app.kubernetes.io/part-of: memberlist
-        name: {{ include "loki.prefixIngesterName" . }}ingester-zone-b
-        rollout-group: {{ include "loki.prefixRolloutGroup" . }}ingester
-        {{- with merge (dict) .Values.ingester.podLabels .Values.loki.podLabels }}
+        {{- with merge (dict) (dict "app.kubernetes.io/part-of" "memberlist" "name" (printf "%singester-zone-b" (include "loki.prefixIngesterName" .)) "rollout-group" (printf "%singester" (include "loki.prefixRolloutGroup" .))) .Values.loki.podLabels .Values.ingester.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:

--- a/production/helm/loki/templates/ingester/statefulset-ingester-zone-c.yaml
+++ b/production/helm/loki/templates/ingester/statefulset-ingester-zone-c.yaml
@@ -62,10 +62,7 @@ spec:
         {{- end }}
       labels:
         {{- include "loki.ingesterLabels" . | nindent 8 }}
-        app.kubernetes.io/part-of: memberlist
-        name: {{ include "loki.prefixIngesterName" . }}ingester-zone-c
-        rollout-group: {{ include "loki.prefixRolloutGroup" . }}ingester
-        {{- with merge (dict) .Values.ingester.podLabels .Values.loki.podLabels  }}
+        {{- with merge (dict) (dict "app.kubernetes.io/part-of" "memberlist" "name" (printf "%singester-zone-c" (include "loki.prefixIngesterName" .)) "rollout-group" (printf "%singester" (include "loki.prefixRolloutGroup" .))) .Values.loki.podLabels .Values.ingester.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:


### PR DESCRIPTION
## Problem

When `ingester.zoneAwareReplication.enabled=true`, the per-zone StatefulSet templates set structural labels (`name`, `rollout-group`, `app.kubernetes.io/part-of`) on both `spec.selector.matchLabels` and `spec.template.metadata.labels`. These labels act as the zone discriminator so the StatefulSet controller can match pods to their zone.

The pod template labels then merge user-supplied `.Values.loki.podLabels` and `.Values.ingester.podLabels` after those structural labels. If a user sets `ingester.podLabels.name` (or `rollout-group`, or `app.kubernetes.io/part-of`), the rendered YAML contains a duplicate key with the user value winning, while `spec.selector.matchLabels` still requires the chart's value. Kubernetes rejects the StatefulSet with:

```
spec.template.metadata.labels: Invalid value: map[..."name":"my-ingester"...]: `selector` does not match template `labels`
```

## Fix

Embed the chart's structural labels inside the merge call so they always win over user-supplied values. This keeps the selector and template labels in sync for any user configuration.



Same pattern applied to zone-b and zone-c templates.

## Verification

```yaml
# Before fix - with podLabels.name set:
spec:
  selector:
    matchLabels:
      name: ingester-zone-a      # chart value
  template:
    metadata:
      labels:
        name: ingester-zone-a    # chart value
        name: my-ingester        # duplicate, wins -> selector mismatch!
```

```yaml
# After fix - same config:
spec:
  selector:
    matchLabels:
      name: ingester-zone-a      # chart value
  template:
    metadata:
      labels:
        name: ingester-zone-a    # structural label wins, no duplicate
```

Resolves #23919
