### PR TITLE
feat(dataobj): Persist shard bucket in index objects

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -100,6 +100,8 @@ func TestBuilder(t *testing.T) {
 				stream, err := res.Value()
 				require.NoError(t, err)
 				require.Equal(t, int64(streams.ShardBucket(stream.Labels)), stream.ShardBucket)
+				require.GreaterOrEqual(t, stream.ShardBucket, int64(0))
+				require.Less(t, stream.ShardBucket, int64(streams.ShardFactor))
 			}
 		}
 	})

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -92,6 +92,16 @@ func TestBuilder(t *testing.T) {
 
 		require.Equal(t, 1, obj.Sections().Count(streams.CheckSection))
 		require.Equal(t, 1, obj.Sections().Count(logs.CheckSection))
+
+		for _, sec := range obj.Sections().Filter(streams.CheckSection) {
+			streamSec, err := streams.Open(t.Context(), sec)
+			require.NoError(t, err)
+			for res := range streams.IterSection(t.Context(), streamSec) {
+				stream, err := res.Value()
+				require.NoError(t, err)
+				require.Equal(t, int64(streams.ShardBucket(stream.Labels)), stream.ShardBucket)
+			}
+		}
 	})
 }
 

--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -53,8 +53,9 @@ type logsCalculationContext struct {
 	// TODO(twhitney): monitor the memory of this. [streamLabels] is passed in from Calculate,
 	// and is thus object scoped. As longs as streams sections stay small enough this shouldn't
 	// be a problem.
-	streamLabels map[int64]labels.Labels // source stream ID -> labels
-	builder      *indexobj.Builder
+	streamLabels       map[int64]labels.Labels // source stream ID -> labels
+	streamShardBuckets map[int64]uint32        // source stream ID -> shard bucket
+	builder            *indexobj.Builder
 }
 
 // These steps are applied to all logs and are unique to a section
@@ -136,12 +137,13 @@ func (c *Calculator) Calculate(ctx context.Context, logger log.Logger, reader *d
 	g.SetLimit(runtime.GOMAXPROCS(0))
 	streamIDLookupByTenant := sync.Map{}
 	streamLabelsByTenant := sync.Map{}
+	shardBucketsByTenant := sync.Map{}
 
 	// Streams Section: process these first to ensure all streams have been added to the builder and are given new IDs.
 	for i, section := range reader.Sections().Filter(streams.CheckSection) {
 		g.Go(func() error {
 			streamIDLookup := make(map[int64]int64)
-			streamLabels, err := c.processStreamsSection(streamsCtx, section, streamIDLookup)
+			streamLabels, shardBuckets, err := c.processStreamsSection(streamsCtx, section, streamIDLookup)
 			if err != nil {
 				return fmt.Errorf("failed to process stream section path=%s section=%d: %w", objectPath, i, err)
 			}
@@ -153,6 +155,10 @@ func (c *Calculator) Calculate(ctx context.Context, logger log.Logger, reader *d
 
 			_, labelsExist := streamLabelsByTenant.LoadOrStore(section.Tenant, streamLabels)
 			if labelsExist {
+				panic("multiple streams sections for the same tenant within one data object")
+			}
+			_, shardBucketsExist := shardBucketsByTenant.LoadOrStore(section.Tenant, shardBuckets)
+			if shardBucketsExist {
 				panic("multiple streams sections for the same tenant within one data object")
 			}
 			return nil
@@ -179,9 +185,13 @@ func (c *Calculator) Calculate(ctx context.Context, logger log.Logger, reader *d
 			if !ok {
 				return fmt.Errorf("stream labels not found for tenant %s", section.Tenant)
 			}
+			shardBuckets, ok := shardBucketsByTenant.Load(section.Tenant)
+			if !ok {
+				return fmt.Errorf("stream labels not found for tenant %s", section.Tenant)
+			}
 			// 1. A bloom filter for each column in the logs section.
 			// 2. A per-section stream time-range index using min/max of each stream in the logs section. StreamIDs will reference the aggregate stream section.
-			if err := c.processLogsSection(logsCtx, sectionLogger, objectPath, section, int64(i), streamIDLookup.(map[int64]int64), streamLabelsVal.(map[int64]labels.Labels)); err != nil {
+			if err := c.processLogsSection(logsCtx, sectionLogger, objectPath, section, int64(i), streamIDLookup.(map[int64]int64), streamLabelsVal.(map[int64]labels.Labels), shardBuckets.(map[int64]uint32)); err != nil {
 				return fmt.Errorf("failed to process logs section path=%s section=%d: %w", objectPath, i, err)
 			}
 			return nil
@@ -195,25 +205,26 @@ func (c *Calculator) Calculate(ctx context.Context, logger log.Logger, reader *d
 	return nil
 }
 
-func (c *Calculator) processStreamsSection(ctx context.Context, section *dataobj.Section, streamIDLookup map[int64]int64) (map[int64]labels.Labels, error) {
+func (c *Calculator) processStreamsSection(ctx context.Context, section *dataobj.Section, streamIDLookup map[int64]int64) (map[int64]labels.Labels, map[int64]uint32, error) {
 	streamSection, err := streams.Open(ctx, section)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open stream section: %w", err)
+		return nil, nil, fmt.Errorf("failed to open stream section: %w", err)
 	}
 
 	rowReader := streams.NewRowReader(streamSection)
 	defer rowReader.Close()
 
 	if err := rowReader.Open(ctx); err != nil {
-		return nil, fmt.Errorf("failed to open stream row reader: %w", err)
+		return nil, nil, fmt.Errorf("failed to open stream row reader: %w", err)
 	}
 
 	streamBuf := make([]streams.Stream, 8192)
-	streamLabels := map[int64]labels.Labels{}
+	streamLabels := make(map[int64]labels.Labels)
+	shardBuckets := make(map[int64]uint32)
 	for {
 		n, err := rowReader.Read(ctx, streamBuf)
 		if err != nil && !errors.Is(err, io.EOF) {
-			return nil, fmt.Errorf("failed to read stream section: %w", err)
+			return nil, nil, fmt.Errorf("failed to read stream section: %w", err)
 		}
 		if n == 0 && errors.Is(err, io.EOF) {
 			break
@@ -228,19 +239,20 @@ func (c *Calculator) processStreamsSection(ctx context.Context, section *dataobj
 				}
 				streamIDLookup[stream.ID] = newStreamID
 				streamLabels[stream.ID] = stream.Labels
+				shardBuckets[stream.ID] = uint32(stream.ShardBucket)
 				c.uncompressedByTenant[section.Tenant] += uint64(stream.UncompressedSize)
 			}
 			return nil
 		}()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
-	return streamLabels, nil
+	return streamLabels, shardBuckets, nil
 }
 
 // processLogsSection reads information from the logs section in order to build index information in the c.indexobjBuilder.
-func (c *Calculator) processLogsSection(ctx context.Context, sectionLogger log.Logger, objectPath string, section *dataobj.Section, sectionIdx int64, streamIDLookup map[int64]int64, streamLabels map[int64]labels.Labels) error {
+func (c *Calculator) processLogsSection(ctx context.Context, sectionLogger log.Logger, objectPath string, section *dataobj.Section, sectionIdx int64, streamIDLookup map[int64]int64, streamLabels map[int64]labels.Labels, shardBuckets map[int64]uint32) error {
 	logsBuf := make([]logs.Record, 8192)
 
 	logsSection, err := logs.Open(ctx, section)
@@ -262,12 +274,13 @@ func (c *Calculator) processLogsSection(ctx context.Context, sectionLogger log.L
 	}
 
 	calculationContext := &logsCalculationContext{
-		tenantID:       tenantID,
-		objectPath:     objectPath,
-		sectionIdx:     sectionIdx,
-		streamIDLookup: streamIDLookup,
-		streamLabels:   streamLabels,
-		builder:        c.indexobjBuilder,
+		tenantID:           tenantID,
+		objectPath:         objectPath,
+		sectionIdx:         sectionIdx,
+		streamIDLookup:     streamIDLookup,
+		streamLabels:       streamLabels,
+		streamShardBuckets: shardBuckets,
+		builder:            c.indexobjBuilder,
 	}
 
 	// Lock-free steps run without builderMtx held, so they must not touch the

--- a/pkg/dataobj/index/calculate.go
+++ b/pkg/dataobj/index/calculate.go
@@ -187,7 +187,7 @@ func (c *Calculator) Calculate(ctx context.Context, logger log.Logger, reader *d
 			}
 			shardBuckets, ok := shardBucketsByTenant.Load(section.Tenant)
 			if !ok {
-				return fmt.Errorf("stream labels not found for tenant %s", section.Tenant)
+				return fmt.Errorf("shard buckets not found for tenant %s", section.Tenant)
 			}
 			// 1. A bloom filter for each column in the logs section.
 			// 2. A per-section stream time-range index using min/max of each stream in the logs section. StreamIDs will reference the aggregate stream section.
@@ -239,7 +239,7 @@ func (c *Calculator) processStreamsSection(ctx context.Context, section *dataobj
 				}
 				streamIDLookup[stream.ID] = newStreamID
 				streamLabels[stream.ID] = stream.Labels
-				shardBuckets[stream.ID] = uint32(stream.ShardBucket)
+				shardBuckets[stream.ID] = streams.ShardBucket(stream.Labels)
 				c.uncompressedByTenant[section.Tenant] += uint64(stream.UncompressedSize)
 			}
 			return nil

--- a/pkg/dataobj/index/calculate_test.go
+++ b/pkg/dataobj/index/calculate_test.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
 	"github.com/thanos-io/objstore/providers/filesystem"
@@ -112,6 +114,71 @@ func createTestLogObject(t *testing.T, tenants int) *dataobj.Object {
 	require.Equal(t, tenants, logSections)
 
 	return obj
+}
+
+func TestCalculator_Calculate_StatsShardBuckets(t *testing.T) {
+	// Two streams share service_name (the default stats grouping key) but
+	// land in different shard buckets. Calculate must populate
+	// streamShardBuckets from labels; a missing or zeroed map would either
+	// error or collapse these into one row.
+	first := labels.FromStrings("service_name", "api", "instance", "0")
+	firstShard := streams.ShardBucket(first)
+	var second labels.Labels
+	for i := 1; i < 256; i++ {
+		candidate := labels.FromStrings("service_name", "api", "instance", strconv.Itoa(i))
+		if streams.ShardBucket(candidate) != firstShard {
+			second = candidate
+			break
+		}
+	}
+	require.NotEmpty(t, second)
+
+	logBuilder, err := logsobj.NewBuilder(logsobj.BuilderConfig{
+		BuilderBaseConfig: logsobj.BuilderBaseConfig{
+			TargetPageSize:          2048,
+			TargetObjectSize:        1 << 22,
+			TargetSectionSize:       1 << 21,
+			BufferSize:              2048 * 8,
+			SectionStripeMergeLimit: 2,
+		},
+	}, nil, logsobj.NewBuilderMetrics(), log.NewNopLogger(), nil)
+	require.NoError(t, err)
+
+	ts := time.Unix(10, 0).UTC()
+	for _, lbls := range []labels.Labels{first, second} {
+		require.NoError(t, logBuilder.Append("tenant-1", logproto.Stream{
+			Labels: lbls.String(),
+			Entries: []push.Entry{{
+				Timestamp: ts,
+				Line:      "hello",
+			}},
+		}, ts))
+	}
+
+	logObj, logCloser, err := logBuilder.Flush()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = logCloser.Close() })
+
+	indexBuilder, err := indexobj.NewBuilder(testCalculatorConfig, nil)
+	require.NoError(t, err)
+	calculator := NewCalculator(indexBuilder)
+	require.NoError(t, calculator.Calculate(context.Background(), log.NewNopLogger(), logObj, "test/path/obj1"))
+
+	indexObj, indexCloser, _, err := calculator.Flush()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = indexCloser.Close() })
+
+	rows := readAllStatsRows(t, indexObj)
+	require.Len(t, rows, 2)
+	gotShards := make(map[int64]struct{}, len(rows))
+	for _, row := range rows {
+		require.Equal(t, "api", row["service_name.label.utf8"])
+		gotShards[row["__shard_bucket__.int64"].(int64)] = struct{}{}
+	}
+	require.Equal(t, map[int64]struct{}{
+		int64(firstShard):                  {},
+		int64(streams.ShardBucket(second)): {},
+	}, gotShards)
 }
 
 func TestCalculator_Calculate(t *testing.T) {

--- a/pkg/dataobj/index/column_values.go
+++ b/pkg/dataobj/index/column_values.go
@@ -36,7 +36,7 @@ func (c *columnValuesCalculation) Prepare(_ context.Context, calcCtx *logsCalcul
 		c.columnIndexes[column.Name] = column.ColumnIndex
 		calcCtx.builder.PrepareBloomColumn(
 			calcCtx.tenantID, calcCtx.objectPath, calcCtx.sectionIdx,
-			column.Name, uint(column.Cardinality),
+			column.Name, uint(column.Cardinality), int64(streams.ShardFactor),
 		)
 	}
 	return nil

--- a/pkg/dataobj/index/column_values.go
+++ b/pkg/dataobj/index/column_values.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 )
 
 // created for and scoped to each logs section
@@ -56,6 +57,7 @@ func (c *columnValuesCalculation) ProcessBatch(_ context.Context, calcCtx *logsC
 			}
 			batchErr = calcCtx.builder.ObserveBloomPosting(calcCtx.tenantID, postings.BloomObservation{
 				ObjectPath:       calcCtx.objectPath,
+				ShardBuckets:     int64(streams.ShardFactor),
 				SectionIndex:     calcCtx.sectionIdx,
 				ColumnName:       md.Name,
 				Value:            md.Value,

--- a/pkg/dataobj/index/column_values_test.go
+++ b/pkg/dataobj/index/column_values_test.go
@@ -49,12 +49,14 @@ func makeColumnValuesStats(metadataColumns []string) logs.Stats {
 
 func TestColumnValuesCalculation_BloomPostingAppended(t *testing.T) {
 	builder := newTestIndexBuilder(t)
+	testLabels := makeTestStreamLabels()
 	calcCtx := &logsCalculationContext{
-		tenantID:     "tenant-1",
-		objectPath:   "test/path/obj1",
-		sectionIdx:   0,
-		streamLabels: makeTestStreamLabels(),
-		builder:      builder,
+		tenantID:           "tenant-1",
+		objectPath:         "test/path/obj1",
+		sectionIdx:         0,
+		streamLabels:       testLabels,
+		streamShardBuckets: makeTestShardBuckets(testLabels),
+		builder:            builder,
 	}
 
 	calc := &columnValuesCalculation{}
@@ -120,12 +122,14 @@ func TestColumnValuesCalculation_BloomPostingAppended(t *testing.T) {
 
 func TestColumnValuesCalculation_TimestampsAndSizes(t *testing.T) {
 	builder := newTestIndexBuilder(t)
+	testLabels := makeTestStreamLabels()
 	calcCtx := &logsCalculationContext{
-		tenantID:     "tenant-1",
-		objectPath:   "test/path/obj1",
-		sectionIdx:   0,
-		streamLabels: makeTestStreamLabels(),
-		builder:      builder,
+		tenantID:           "tenant-1",
+		objectPath:         "test/path/obj1",
+		sectionIdx:         0,
+		streamLabels:       testLabels,
+		streamShardBuckets: makeTestShardBuckets(testLabels),
+		builder:            builder,
 	}
 
 	calc := &columnValuesCalculation{}
@@ -170,12 +174,14 @@ func TestColumnValuesCalculation_TimestampsAndSizes(t *testing.T) {
 
 func TestColumnValuesCalculation_StreamIDBitmapBitsSet(t *testing.T) {
 	builder := newTestIndexBuilder(t)
+	testLabels := makeTestStreamLabels()
 	calcCtx := &logsCalculationContext{
-		tenantID:     "tenant-1",
-		objectPath:   "test/path/obj1",
-		sectionIdx:   0,
-		streamLabels: makeTestStreamLabels(),
-		builder:      builder,
+		tenantID:           "tenant-1",
+		objectPath:         "test/path/obj1",
+		sectionIdx:         0,
+		streamLabels:       testLabels,
+		streamShardBuckets: makeTestShardBuckets(testLabels),
+		builder:            builder,
 	}
 
 	calc := &columnValuesCalculation{}
@@ -205,12 +211,14 @@ func TestColumnValuesCalculation_StreamIDBitmapBitsSet(t *testing.T) {
 
 func TestColumnValuesCalculation_EmptyBatch(t *testing.T) {
 	builder := newTestIndexBuilder(t)
+	testLabels := makeTestStreamLabels()
 	calcCtx := &logsCalculationContext{
-		tenantID:     "tenant-1",
-		objectPath:   "test/path/obj1",
-		sectionIdx:   0,
-		streamLabels: makeTestStreamLabels(),
-		builder:      builder,
+		tenantID:           "tenant-1",
+		objectPath:         "test/path/obj1",
+		sectionIdx:         0,
+		streamLabels:       testLabels,
+		streamShardBuckets: makeTestShardBuckets(testLabels),
+		builder:            builder,
 	}
 
 	calc := &columnValuesCalculation{}
@@ -242,12 +250,14 @@ func TestColumnValuesCalculation_EmptyBatch(t *testing.T) {
 
 func TestColumnValuesCalculation_MultipleBatches(t *testing.T) {
 	builder := newTestIndexBuilder(t)
+	testLabels := makeTestStreamLabels()
 	calcCtx := &logsCalculationContext{
-		tenantID:     "tenant-1",
-		objectPath:   "test/path/obj1",
-		sectionIdx:   0,
-		streamLabels: makeTestStreamLabels(),
-		builder:      builder,
+		tenantID:           "tenant-1",
+		objectPath:         "test/path/obj1",
+		sectionIdx:         0,
+		streamLabels:       testLabels,
+		streamShardBuckets: makeTestShardBuckets(testLabels),
+		builder:            builder,
 	}
 
 	calc := &columnValuesCalculation{}

--- a/pkg/dataobj/index/column_values_test.go
+++ b/pkg/dataobj/index/column_values_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 )
 
 // makeColumnValuesStats creates a logs.Stats with a set of metadata columns
@@ -49,15 +50,7 @@ func makeColumnValuesStats(metadataColumns []string) logs.Stats {
 
 func TestColumnValuesCalculation_BloomPostingAppended(t *testing.T) {
 	builder := newTestIndexBuilder(t)
-	testLabels := makeTestStreamLabels()
-	calcCtx := &logsCalculationContext{
-		tenantID:           "tenant-1",
-		objectPath:         "test/path/obj1",
-		sectionIdx:         0,
-		streamLabels:       testLabels,
-		streamShardBuckets: makeTestShardBuckets(testLabels),
-		builder:            builder,
-	}
+	calcCtx := makeTestCalcContext(builder)
 
 	calc := &columnValuesCalculation{}
 	stat := makeColumnValuesStats([]string{"trace_id", "span_id"})
@@ -111,6 +104,9 @@ func TestColumnValuesCalculation_BloomPostingAppended(t *testing.T) {
 	})
 	require.NotEqual(t, -1, j, "expected bloom posting for span_id")
 
+	require.Equal(t, int64(streams.ShardFactor), tbl.rows[i]["shard_buckets.int64"])
+	require.Equal(t, int64(streams.ShardFactor), tbl.rows[j]["shard_buckets.int64"])
+
 	// Bloom filter bytes should be non-empty.
 	require.NotEmpty(t, tbl.opaque["bloom_filter.binary"][i], "expected non-empty bloom filter for trace_id")
 	require.NotEmpty(t, tbl.opaque["bloom_filter.binary"][j], "expected non-empty bloom filter for span_id")
@@ -122,15 +118,7 @@ func TestColumnValuesCalculation_BloomPostingAppended(t *testing.T) {
 
 func TestColumnValuesCalculation_TimestampsAndSizes(t *testing.T) {
 	builder := newTestIndexBuilder(t)
-	testLabels := makeTestStreamLabels()
-	calcCtx := &logsCalculationContext{
-		tenantID:           "tenant-1",
-		objectPath:         "test/path/obj1",
-		sectionIdx:         0,
-		streamLabels:       testLabels,
-		streamShardBuckets: makeTestShardBuckets(testLabels),
-		builder:            builder,
-	}
+	calcCtx := makeTestCalcContext(builder)
 
 	calc := &columnValuesCalculation{}
 	stat := makeColumnValuesStats([]string{"trace_id"})
@@ -162,6 +150,7 @@ func TestColumnValuesCalculation_TimestampsAndSizes(t *testing.T) {
 	require.NotEqual(t, -1, i, "expected bloom posting for trace_id")
 
 	row := tbl.rows[i]
+	require.Equal(t, int64(streams.ShardFactor), row["shard_buckets.int64"])
 	// Timestamps: min=ts1 (10s), max=ts3 (30s) — ts3 is the latest, proving the
 	// third record's timestamp was tracked.
 	require.Equal(t, ts1.UTC(), row["min_timestamp.timestamp"])
@@ -174,15 +163,7 @@ func TestColumnValuesCalculation_TimestampsAndSizes(t *testing.T) {
 
 func TestColumnValuesCalculation_StreamIDBitmapBitsSet(t *testing.T) {
 	builder := newTestIndexBuilder(t)
-	testLabels := makeTestStreamLabels()
-	calcCtx := &logsCalculationContext{
-		tenantID:           "tenant-1",
-		objectPath:         "test/path/obj1",
-		sectionIdx:         0,
-		streamLabels:       testLabels,
-		streamShardBuckets: makeTestShardBuckets(testLabels),
-		builder:            builder,
-	}
+	calcCtx := makeTestCalcContext(builder)
 
 	calc := &columnValuesCalculation{}
 	stat := makeColumnValuesStats([]string{"trace_id"})
@@ -204,6 +185,7 @@ func TestColumnValuesCalculation_StreamIDBitmapBitsSet(t *testing.T) {
 		"column_name.utf8": "trace_id",
 	})
 	require.NotEqual(t, -1, i, "expected bloom posting for trace_id")
+	require.Equal(t, int64(streams.ShardFactor), tbl.rows[i]["shard_buckets.int64"])
 
 	// Bitmap should have bit 1 set (stream ID 1 has trace_id).
 	require.NotEmpty(t, tbl.opaque["stream_id_bitmap.binary"][i])
@@ -211,15 +193,7 @@ func TestColumnValuesCalculation_StreamIDBitmapBitsSet(t *testing.T) {
 
 func TestColumnValuesCalculation_EmptyBatch(t *testing.T) {
 	builder := newTestIndexBuilder(t)
-	testLabels := makeTestStreamLabels()
-	calcCtx := &logsCalculationContext{
-		tenantID:           "tenant-1",
-		objectPath:         "test/path/obj1",
-		sectionIdx:         0,
-		streamLabels:       testLabels,
-		streamShardBuckets: makeTestShardBuckets(testLabels),
-		builder:            builder,
-	}
+	calcCtx := makeTestCalcContext(builder)
 
 	calc := &columnValuesCalculation{}
 	stat := makeColumnValuesStats([]string{"trace_id"})
@@ -238,6 +212,7 @@ func TestColumnValuesCalculation_EmptyBatch(t *testing.T) {
 	require.NotEqual(t, -1, i, "expected bloom posting for trace_id even with empty batch")
 
 	row := tbl.rows[i]
+	require.Equal(t, int64(streams.ShardFactor), row["shard_buckets.int64"])
 	// With the bloom aggregator, an unobserved but prepared column uses sentinel values:
 	// MinTimestamp = math.MaxInt64 and MaxTimestamp = math.MinInt64.
 	// These are stored and read back as time.Time values.
@@ -250,15 +225,7 @@ func TestColumnValuesCalculation_EmptyBatch(t *testing.T) {
 
 func TestColumnValuesCalculation_MultipleBatches(t *testing.T) {
 	builder := newTestIndexBuilder(t)
-	testLabels := makeTestStreamLabels()
-	calcCtx := &logsCalculationContext{
-		tenantID:           "tenant-1",
-		objectPath:         "test/path/obj1",
-		sectionIdx:         0,
-		streamLabels:       testLabels,
-		streamShardBuckets: makeTestShardBuckets(testLabels),
-		builder:            builder,
-	}
+	calcCtx := makeTestCalcContext(builder)
 
 	calc := &columnValuesCalculation{}
 	stat := makeColumnValuesStats([]string{"trace_id"})
@@ -287,6 +254,7 @@ func TestColumnValuesCalculation_MultipleBatches(t *testing.T) {
 	require.NotEqual(t, -1, i, "expected bloom posting for trace_id")
 
 	row := tbl.rows[i]
+	require.Equal(t, int64(streams.ShardFactor), row["shard_buckets.int64"])
 	// Timestamps should span both batches.
 	require.Equal(t, ts1.UTC(), row["min_timestamp.timestamp"])
 	require.Equal(t, ts2.UTC(), row["max_timestamp.timestamp"])

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -232,10 +232,12 @@ func (b *Builder) ObserveLabelPosting(tenantID string, obs postings.LabelObserva
 
 // PrepareBloomColumn initializes the bloom filter for a specific column.
 // Must be called before any ObserveBloomPosting calls for the given (objectPath, sectionIdx, columnName).
+// shardBuckets is stored on the entry immediately so a prepared-but-unobserved
+// column still records the object's shard factor.
 func (b *Builder) PrepareBloomColumn(tenantID, objectPath string, sectionIdx int64,
-	columnName string, estimatedCardinality uint) {
+	columnName string, estimatedCardinality uint, shardBuckets int64) {
 	tenantPostings := b.getPostingsBuilderForTenant(tenantID)
-	tenantPostings.PrepareBloomColumn(objectPath, sectionIdx, columnName, estimatedCardinality)
+	tenantPostings.PrepareBloomColumn(objectPath, sectionIdx, columnName, estimatedCardinality, shardBuckets)
 }
 
 // ObserveBloomPosting records a bloom-filter posting observation for a data

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -157,8 +157,7 @@ func (b *Builder) getPostingsBuilderForTenant(tenantID string) *postings.Builder
 
 // AppendStat records a per-sort-key aggregate for a data object section.
 func (b *Builder) AppendStat(tenantID, objectPath string, sectionIdx int64,
-	sortSchema string, labels map[string]string, minTs, maxTs time.Time, rows int, uncompressedSize int64,
-	shard uint32) error {
+	shardBucket uint32, sortSchema string, labels map[string]string, minTs, maxTs time.Time, rows int, uncompressedSize int64) error {
 	b.metrics.appendsTotal.Inc()
 
 	timer := prometheus.NewTimer(b.metrics.appendTime)
@@ -170,13 +169,13 @@ func (b *Builder) AppendStat(tenantID, objectPath string, sectionIdx int64,
 	tenantStats.Append(stats.Stat{
 		ObjectPath:       objectPath,
 		SectionIndex:     sectionIdx,
+		ShardBucket:      shardBucket,
 		SortSchema:       sortSchema,
 		Labels:           labels,
 		MinTimestamp:     minTs.UnixNano(),
 		MaxTimestamp:     maxTs.UnixNano(),
 		RowCount:         int64(rows),
 		UncompressedSize: uncompressedSize,
-		ShardBucket:      shard,
 	})
 
 	postAppendSizeEstimate := tenantStats.EstimatedSize()

--- a/pkg/dataobj/index/indexobj/builder.go
+++ b/pkg/dataobj/index/indexobj/builder.go
@@ -157,7 +157,8 @@ func (b *Builder) getPostingsBuilderForTenant(tenantID string) *postings.Builder
 
 // AppendStat records a per-sort-key aggregate for a data object section.
 func (b *Builder) AppendStat(tenantID, objectPath string, sectionIdx int64,
-	sortSchema string, labels map[string]string, minTs, maxTs time.Time, rows int, uncompressedSize int64) error {
+	sortSchema string, labels map[string]string, minTs, maxTs time.Time, rows int, uncompressedSize int64,
+	shard uint32) error {
 	b.metrics.appendsTotal.Inc()
 
 	timer := prometheus.NewTimer(b.metrics.appendTime)
@@ -175,6 +176,7 @@ func (b *Builder) AppendStat(tenantID, objectPath string, sectionIdx int64,
 		MaxTimestamp:     maxTs.UnixNano(),
 		RowCount:         int64(rows),
 		UncompressedSize: uncompressedSize,
+		ShardBucket:      shard,
 	})
 
 	postAppendSizeEstimate := tenantStats.EstimatedSize()

--- a/pkg/dataobj/index/indexobj/merge_builder_test.go
+++ b/pkg/dataobj/index/indexobj/merge_builder_test.go
@@ -171,7 +171,7 @@ func TestMergeBuilder_AppendPostingsBloomEntry(t *testing.T) {
 
 	// Create valid bloom bytes using an observation builder
 	tempBuilder := postings.NewBuilder(nil, 0, 0, 1<<20)
-	tempBuilder.PrepareBloomColumn("/obj2", 1, "service_name", 100)
+	tempBuilder.PrepareBloomColumn("/obj2", 1, "service_name", 100, 0)
 	err = tempBuilder.ObserveBloomPosting(postings.BloomObservation{
 		ObjectPath:       "/obj2",
 		SectionIndex:     1,

--- a/pkg/dataobj/index/label_postings_calculation.go
+++ b/pkg/dataobj/index/label_postings_calculation.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 )
 
 // created for and scoped to each logs section
@@ -45,6 +46,7 @@ func (c *labelPostingsCalculation) ProcessBatch(_ context.Context, calcCtx *logs
 			}
 			calcCtx.builder.ObserveLabelPosting(calcCtx.tenantID, postings.LabelObservation{
 				ObjectPath:       calcCtx.objectPath,
+				ShardBuckets:     int64(streams.ShardFactor),
 				SectionIndex:     calcCtx.sectionIdx,
 				ColumnName:       lbl.Name,
 				LabelValue:       lbl.Value,

--- a/pkg/dataobj/index/label_postings_calculation_test.go
+++ b/pkg/dataobj/index/label_postings_calculation_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/postings"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 	"github.com/grafana/loki/v3/pkg/util/arrowtest"
 )
 
@@ -187,6 +188,7 @@ func TestLabelPostingsCalculation_BasicPostings(t *testing.T) {
 	// All should be label-kind.
 	for _, row := range tbl.rows {
 		require.Equal(t, int64(postings.KindLabel), row["kind.int64"])
+		require.Equal(t, int64(streams.ShardFactor), row["shard_buckets.int64"])
 		require.NotNil(t, row["label_value.utf8"])
 	}
 

--- a/pkg/dataobj/index/stats_calculation.go
+++ b/pkg/dataobj/index/stats_calculation.go
@@ -14,16 +14,19 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 )
 
 // created for and scoped to each logs section
 type statsCalculation struct {
-	schema     []string                   // schema is the fully-qualified sort schema ("label:<name>")
-	labelKeys  []string                   // labelKeys are the bare Prometheus label names derived from schema
-	aggregates map[uint64]*statsAggregate // keyed by hash of composite label values
+	schema       []string                   // schema is the fully-qualified sort schema ("label:<name>")
+	labelKeys    []string                   // labelKeys are the bare Prometheus label names derived from schema
+	aggregates   map[uint64]*statsAggregate // keyed by hash of shard + composite label values
+	streamShards map[int64]uint32
 }
 
 type statsAggregate struct {
+	shard            uint32
 	labels           map[string]string // all sort schema key-value pairs
 	minTimestamp     time.Time
 	maxTimestamp     time.Time
@@ -45,6 +48,7 @@ func (c *statsCalculation) Prepare(_ context.Context, _ *logsCalculationContext,
 	}
 	c.labelKeys = labelKeys
 	c.aggregates = make(map[uint64]*statsAggregate)
+	c.streamShards = make(map[int64]uint32)
 	return nil
 }
 
@@ -57,15 +61,18 @@ func (c *statsCalculation) ProcessBatch(_ context.Context, calcCtx *logsCalculat
 	)
 	for _, log := range batch {
 		streamLbls := calcCtx.streamLabels[log.StreamID]
+		shard, ok := c.streamShards[log.StreamID]
+		if !ok {
+			shard = uint32(streams.ShardBucket(streamLbls))
+			c.streamShards[log.StreamID] = shard
+		}
 
-		// Build the composite key from all sort schema keys.
+		// Build the composite key from the shard and all sort schema keys.
 		// Uses key=value pairs separated by \x00 to avoid ambiguity.
 		buf.Reset()
-		for i, key := range c.labelKeys {
-			if i > 0 {
-				buf.WriteByte(0)
-			}
-
+		buf.WriteByte(byte(shard))
+		for _, key := range c.labelKeys {
+			buf.WriteByte(0)
 			buf.WriteString(key)
 			buf.WriteByte('=')
 			buf.WriteString(streamLbls.Get(key))
@@ -82,6 +89,7 @@ func (c *statsCalculation) ProcessBatch(_ context.Context, calcCtx *logsCalculat
 				labelMap[key] = streamLbls.Get(key)
 			}
 			agg = &statsAggregate{
+				shard:        shard,
 				labels:       labelMap,
 				minTimestamp: log.Timestamp,
 				maxTimestamp: log.Timestamp,
@@ -115,12 +123,15 @@ func (c *statsCalculation) Flush(_ context.Context, calcCtx *logsCalculationCont
 		return nil
 	}
 
-	// Sort aggregates by label values in schema key order
+	// Sort aggregates by shard, then label values in schema key order.
 	sorted := make([]*statsAggregate, 0, len(c.aggregates))
 	for _, agg := range c.aggregates {
 		sorted = append(sorted, agg)
 	}
 	slices.SortFunc(sorted, func(a, b *statsAggregate) int {
+		if n := cmp.Compare(a.shard, b.shard); n != 0 {
+			return n
+		}
 		for _, key := range c.labelKeys {
 			if n := cmp.Compare(a.labels[key], b.labels[key]); n != 0 {
 				return n
@@ -141,6 +152,7 @@ func (c *statsCalculation) Flush(_ context.Context, calcCtx *logsCalculationCont
 			agg.maxTimestamp,
 			agg.rowCount,
 			agg.uncompressedSize,
+			agg.shard,
 		)
 		if err != nil {
 			return err

--- a/pkg/dataobj/index/stats_calculation.go
+++ b/pkg/dataobj/index/stats_calculation.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"cmp"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"hash/fnv"
 	"slices"
@@ -56,14 +57,19 @@ func (c *statsCalculation) ProcessBatch(_ context.Context, calcCtx *logsCalculat
 		h   = fnv.New64a()
 		buf bytes.Buffer
 	)
+	var shardKey [4]byte
 	for _, log := range batch {
 		streamLbls := calcCtx.streamLabels[log.StreamID]
-		shardBucket := calcCtx.streamShardBuckets[log.StreamID]
+		shardBucket, ok := calcCtx.streamShardBuckets[log.StreamID]
+		if !ok {
+			return fmt.Errorf("shard bucket not found for stream ID %d", log.StreamID)
+		}
 
 		// Build the composite key from the shard and all sort schema keys.
 		// Uses key=value pairs separated by \x00 to avoid ambiguity.
 		buf.Reset()
-		buf.WriteByte(byte(shardBucket))
+		binary.BigEndian.PutUint32(shardKey[:], shardBucket)
+		buf.Write(shardKey[:])
 		for _, key := range c.labelKeys {
 			buf.WriteByte(0)
 			buf.WriteString(key)

--- a/pkg/dataobj/index/stats_calculation.go
+++ b/pkg/dataobj/index/stats_calculation.go
@@ -14,19 +14,17 @@ import (
 
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
-	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 )
 
 // created for and scoped to each logs section
 type statsCalculation struct {
-	schema       []string                   // schema is the fully-qualified sort schema ("label:<name>")
-	labelKeys    []string                   // labelKeys are the bare Prometheus label names derived from schema
-	aggregates   map[uint64]*statsAggregate // keyed by hash of shard + composite label values
-	streamShards map[int64]uint32
+	schema     []string                   // schema is the fully-qualified sort schema ("label:<name>")
+	labelKeys  []string                   // labelKeys are the bare Prometheus label names derived from schema
+	aggregates map[uint64]*statsAggregate // keyed by hash of shard + composite label values
 }
 
 type statsAggregate struct {
-	shard            uint32
+	shardBucket      uint32
 	labels           map[string]string // all sort schema key-value pairs
 	minTimestamp     time.Time
 	maxTimestamp     time.Time
@@ -48,7 +46,6 @@ func (c *statsCalculation) Prepare(_ context.Context, _ *logsCalculationContext,
 	}
 	c.labelKeys = labelKeys
 	c.aggregates = make(map[uint64]*statsAggregate)
-	c.streamShards = make(map[int64]uint32)
 	return nil
 }
 
@@ -61,16 +58,12 @@ func (c *statsCalculation) ProcessBatch(_ context.Context, calcCtx *logsCalculat
 	)
 	for _, log := range batch {
 		streamLbls := calcCtx.streamLabels[log.StreamID]
-		shard, ok := c.streamShards[log.StreamID]
-		if !ok {
-			shard = uint32(streams.ShardBucket(streamLbls))
-			c.streamShards[log.StreamID] = shard
-		}
+		shardBucket := calcCtx.streamShardBuckets[log.StreamID]
 
 		// Build the composite key from the shard and all sort schema keys.
 		// Uses key=value pairs separated by \x00 to avoid ambiguity.
 		buf.Reset()
-		buf.WriteByte(byte(shard))
+		buf.WriteByte(byte(shardBucket))
 		for _, key := range c.labelKeys {
 			buf.WriteByte(0)
 			buf.WriteString(key)
@@ -89,7 +82,7 @@ func (c *statsCalculation) ProcessBatch(_ context.Context, calcCtx *logsCalculat
 				labelMap[key] = streamLbls.Get(key)
 			}
 			agg = &statsAggregate{
-				shard:        shard,
+				shardBucket:  shardBucket,
 				labels:       labelMap,
 				minTimestamp: log.Timestamp,
 				maxTimestamp: log.Timestamp,
@@ -129,7 +122,7 @@ func (c *statsCalculation) Flush(_ context.Context, calcCtx *logsCalculationCont
 		sorted = append(sorted, agg)
 	}
 	slices.SortFunc(sorted, func(a, b *statsAggregate) int {
-		if n := cmp.Compare(a.shard, b.shard); n != 0 {
+		if n := cmp.Compare(a.shardBucket, b.shardBucket); n != 0 {
 			return n
 		}
 		for _, key := range c.labelKeys {
@@ -146,13 +139,13 @@ func (c *statsCalculation) Flush(_ context.Context, calcCtx *logsCalculationCont
 			calcCtx.tenantID,
 			calcCtx.objectPath,
 			calcCtx.sectionIdx,
+			agg.shardBucket,
 			sortSchema,
 			agg.labels,
 			agg.minTimestamp,
 			agg.maxTimestamp,
 			agg.rowCount,
 			agg.uncompressedSize,
-			agg.shard,
 		)
 		if err != nil {
 			return err

--- a/pkg/dataobj/index/stats_calculation_test.go
+++ b/pkg/dataobj/index/stats_calculation_test.go
@@ -40,13 +40,24 @@ func makeTestStreamLabels() map[int64]labels.Labels {
 	}
 }
 
+// makeTestShardBuckets creates the shard buckets for each of the provided labels
+func makeTestShardBuckets(testLabels map[int64]labels.Labels) map[int64]uint32 {
+	return map[int64]uint32{
+		1: uint32(streams.ShardBucket(testLabels[1])),
+		2: uint32(streams.ShardBucket(testLabels[2])),
+		3: uint32(streams.ShardBucket(testLabels[3])),
+	}
+}
+
 func makeTestCalcContext(builder *indexobj.Builder) *logsCalculationContext {
+	testLabels := makeTestStreamLabels()
 	return &logsCalculationContext{
-		tenantID:     "tenant-1",
-		objectPath:   "test/path/obj1",
-		sectionIdx:   0,
-		streamLabels: makeTestStreamLabels(),
-		builder:      builder,
+		tenantID:           "tenant-1",
+		objectPath:         "test/path/obj1",
+		sectionIdx:         0,
+		streamLabels:       testLabels,
+		streamShardBuckets: makeTestShardBuckets(testLabels),
+		builder:            builder,
 	}
 }
 
@@ -105,12 +116,16 @@ func readStatsTable(ctx context.Context, r *stats.Reader) (arrow.Table, error) {
 
 func TestStatsCalculation_StoresFullyQualifiedSchema(t *testing.T) {
 	builder := newTestIndexBuilder(t)
+	testLabels := labels.FromStrings("service_name", "svcA", "cluster", "c1")
 	ctx := &logsCalculationContext{
 		tenantID:   "tenant-1",
 		objectPath: "test/path/obj1",
 		sectionIdx: 0,
 		streamLabels: map[int64]labels.Labels{
-			1: labels.FromStrings("service_name", "svcA", "cluster", "c1"),
+			1: testLabels,
+		},
+		streamShardBuckets: map[int64]uint32{
+			1: uint32(streams.ShardBucket(testLabels)),
 		},
 		builder: builder,
 	}
@@ -154,6 +169,10 @@ func TestStatsCalculation_GroupsByShardAndSchema(t *testing.T) {
 		streamLabels: map[int64]labels.Labels{
 			1: first,
 			2: second,
+		},
+		streamShardBuckets: map[int64]uint32{
+			1: uint32(streams.ShardBucket(first)),
+			2: uint32(streams.ShardBucket(second)),
 		},
 		builder: builder,
 	}

--- a/pkg/dataobj/index/stats_calculation_test.go
+++ b/pkg/dataobj/index/stats_calculation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/stats"
@@ -42,11 +43,11 @@ func makeTestStreamLabels() map[int64]labels.Labels {
 
 // makeTestShardBuckets creates the shard buckets for each of the provided labels
 func makeTestShardBuckets(testLabels map[int64]labels.Labels) map[int64]uint32 {
-	return map[int64]uint32{
-		1: uint32(streams.ShardBucket(testLabels[1])),
-		2: uint32(streams.ShardBucket(testLabels[2])),
-		3: uint32(streams.ShardBucket(testLabels[3])),
+	buckets := make(map[int64]uint32, len(testLabels))
+	for id, lbls := range testLabels {
+		buckets[id] = streams.ShardBucket(lbls)
 	}
+	return buckets
 }
 
 func makeTestCalcContext(builder *indexobj.Builder) *logsCalculationContext {
@@ -66,7 +67,11 @@ func flushAndReadAllStatsTable(t *testing.T, builder *indexobj.Builder) arrowtes
 	obj, closer, err := builder.Flush()
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = closer.Close() })
+	return readAllStatsRows(t, obj)
+}
 
+func readAllStatsRows(t *testing.T, obj *dataobj.Object) arrowtest.Rows {
+	t.Helper()
 	var all arrowtest.Rows
 	for _, s := range obj.Sections() {
 		if !stats.CheckSection(s) {
@@ -125,7 +130,7 @@ func TestStatsCalculation_StoresFullyQualifiedSchema(t *testing.T) {
 			1: testLabels,
 		},
 		streamShardBuckets: map[int64]uint32{
-			1: uint32(streams.ShardBucket(testLabels)),
+			1: streams.ShardBucket(testLabels),
 		},
 		builder: builder,
 	}
@@ -152,11 +157,11 @@ func TestStatsCalculation_StoresFullyQualifiedSchema(t *testing.T) {
 func TestStatsCalculation_GroupsByShardAndSchema(t *testing.T) {
 	builder := newTestIndexBuilder(t)
 	first := labels.FromStrings("service_name", "api", "instance", "0")
-	firstShard := uint32(streams.ShardBucket(first))
+	firstShard := streams.ShardBucket(first)
 	var second labels.Labels
 	for i := 1; i < 256; i++ {
 		candidate := labels.FromStrings("service_name", "api", "instance", strconv.Itoa(i))
-		if uint32(streams.ShardBucket(candidate)) != firstShard {
+		if streams.ShardBucket(candidate) != firstShard {
 			second = candidate
 			break
 		}
@@ -171,8 +176,8 @@ func TestStatsCalculation_GroupsByShardAndSchema(t *testing.T) {
 			2: second,
 		},
 		streamShardBuckets: map[int64]uint32{
-			1: uint32(streams.ShardBucket(first)),
-			2: uint32(streams.ShardBucket(second)),
+			1: streams.ShardBucket(first),
+			2: streams.ShardBucket(second),
 		},
 		builder: builder,
 	}
@@ -195,6 +200,19 @@ func TestStatsCalculation_GroupsByShardAndSchema(t *testing.T) {
 	}
 	require.Contains(t, gotShards, int64(firstShard))
 	require.Contains(t, gotShards, int64(streams.ShardBucket(second)))
+}
+
+func TestStatsCalculation_MissingShardBucket(t *testing.T) {
+	builder := newTestIndexBuilder(t)
+	ctx := makeTestCalcContext(builder)
+	ctx.streamShardBuckets = map[int64]uint32{}
+	calc := &statsCalculation{schema: defaultSortSchema}
+
+	require.NoError(t, calc.Prepare(context.Background(), ctx, nil, logs.Stats{}))
+	err := calc.ProcessBatch(context.Background(), ctx, []logs.Record{
+		{StreamID: 1, Timestamp: time.Unix(1, 0).UTC(), Line: []byte("x")},
+	})
+	require.ErrorContains(t, err, "shard bucket not found")
 }
 
 func TestStatsCalculation_RejectsUnsupportedSortKey(t *testing.T) {

--- a/pkg/dataobj/index/stats_calculation_test.go
+++ b/pkg/dataobj/index/stats_calculation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strconv"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/index/indexobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/stats"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 	"github.com/grafana/loki/v3/pkg/util/arrowtest"
 )
 
@@ -129,7 +131,51 @@ func TestStatsCalculation_StoresFullyQualifiedSchema(t *testing.T) {
 		"label columns must stay keyed by the bare Prometheus name")
 	require.Equal(t, "c1", actual[0]["cluster.label.utf8"],
 		"label columns must stay keyed by the bare Prometheus name")
-	require.Equal(t, int64(0), actual[0]["__shard_bucket__.int64"])
+	require.Equal(t, int64(streams.ShardBucket(ctx.streamLabels[1])), actual[0]["__shard_bucket__.int64"])
+}
+
+func TestStatsCalculation_GroupsByShardAndSchema(t *testing.T) {
+	builder := newTestIndexBuilder(t)
+	first := labels.FromStrings("service_name", "api", "instance", "0")
+	firstShard := uint32(streams.ShardBucket(first))
+	var second labels.Labels
+	for i := 1; i < 256; i++ {
+		candidate := labels.FromStrings("service_name", "api", "instance", strconv.Itoa(i))
+		if uint32(streams.ShardBucket(candidate)) != firstShard {
+			second = candidate
+			break
+		}
+	}
+	require.NotEmpty(t, second)
+	ctx := &logsCalculationContext{
+		tenantID:   "tenant-1",
+		objectPath: "test/path/obj1",
+		sectionIdx: 0,
+		streamLabels: map[int64]labels.Labels{
+			1: first,
+			2: second,
+		},
+		builder: builder,
+	}
+	calc := &statsCalculation{schema: defaultSortSchema}
+	records := []logs.Record{
+		{StreamID: 1, Timestamp: time.Unix(100, 0).UTC(), Line: []byte("a")},
+		{StreamID: 2, Timestamp: time.Unix(150, 0).UTC(), Line: []byte("c")},
+	}
+
+	require.NoError(t, calc.Prepare(context.Background(), ctx, nil, logs.Stats{}))
+	require.NoError(t, calc.ProcessBatch(context.Background(), ctx, records))
+	require.NoError(t, calc.Flush(context.Background(), ctx))
+
+	actual := flushAndReadAllStatsTable(t, builder)
+	require.Len(t, actual, 2)
+	gotShards := make(map[int64]struct{}, len(actual))
+	for _, row := range actual {
+		require.Equal(t, "api", row["service_name.label.utf8"])
+		gotShards[row["__shard_bucket__.int64"].(int64)] = struct{}{}
+	}
+	require.Contains(t, gotShards, int64(firstShard))
+	require.Contains(t, gotShards, int64(streams.ShardBucket(second)))
 }
 
 func TestStatsCalculation_RejectsUnsupportedSortKey(t *testing.T) {
@@ -169,45 +215,48 @@ func TestStatsCalculation_BasicAggregation(t *testing.T) {
 	require.NoError(t, calc.Flush(context.Background(), ctx))
 
 	actual := flushAndReadAllStatsTable(t, builder)
-	// We expect 3 aggregates: "", "svcA", "svcB" (sorted)
+	// We expect 3 aggregates: "", "svcA", and "svcB".
 	require.Len(t, actual, 3)
+	byService := make(map[string]arrowtest.Row, len(actual))
+	for _, row := range actual {
+		byService[row["service_name.label.utf8"].(string)] = row
+	}
 
-	// Sorted order: "" < "svcA" < "svcB"
 	require.Equal(t, arrowtest.Row{
 		"object_path.utf8":        "test/path/obj1",
 		"section_index.int64":     int64(0),
 		"sort_schema.utf8":        "label:service_name",
-		"__shard_bucket__.int64":  int64(0),
+		"__shard_bucket__.int64":  int64(streams.ShardBucket(ctx.streamLabels[3])),
 		"service_name.label.utf8": "",
 		"min_timestamp.timestamp": time.Unix(50, 0).UTC(),
 		"max_timestamp.timestamp": time.Unix(50, 0).UTC(),
 		"row_count.int64":         int64(1),
 		"uncompressed_size.int64": int64(len(line4)),
-	}, actual[0])
+	}, byService[""])
 
 	require.Equal(t, arrowtest.Row{
 		"object_path.utf8":        "test/path/obj1",
 		"section_index.int64":     int64(0),
 		"sort_schema.utf8":        "label:service_name",
-		"__shard_bucket__.int64":  int64(0),
+		"__shard_bucket__.int64":  int64(streams.ShardBucket(ctx.streamLabels[1])),
 		"service_name.label.utf8": "svcA",
 		"min_timestamp.timestamp": ts1,
 		"max_timestamp.timestamp": ts2,
 		"row_count.int64":         int64(2),
 		"uncompressed_size.int64": int64(len(line1) + len(line2)),
-	}, actual[1])
+	}, byService["svcA"])
 
 	require.Equal(t, arrowtest.Row{
 		"object_path.utf8":        "test/path/obj1",
 		"section_index.int64":     int64(0),
 		"sort_schema.utf8":        "label:service_name",
-		"__shard_bucket__.int64":  int64(0),
+		"__shard_bucket__.int64":  int64(streams.ShardBucket(ctx.streamLabels[2])),
 		"service_name.label.utf8": "svcB",
 		"min_timestamp.timestamp": ts3,
 		"max_timestamp.timestamp": ts3,
 		"row_count.int64":         int64(1),
 		"uncompressed_size.int64": int64(len(line3)),
-	}, actual[2])
+	}, byService["svcB"])
 }
 
 func TestStatsCalculation_MetadataFields(t *testing.T) {
@@ -232,7 +281,7 @@ func TestStatsCalculation_MetadataFields(t *testing.T) {
 		"object_path.utf8":        "test/path/obj1",
 		"section_index.int64":     int64(0),
 		"sort_schema.utf8":        "label:service_name",
-		"__shard_bucket__.int64":  int64(0),
+		"__shard_bucket__.int64":  int64(streams.ShardBucket(ctx.streamLabels[1])),
 		"service_name.label.utf8": "svcA",
 		"min_timestamp.timestamp": ts,
 		"max_timestamp.timestamp": ts,
@@ -311,9 +360,14 @@ func TestStatsCalculation_MultipleBatches(t *testing.T) {
 	actual := flushAndReadAllStatsTable(t, builder)
 	// svcA and svcB
 	require.Len(t, actual, 2)
-
-	// Rows are sorted by label value asc, so "svcA" < "svcB" → svcA is actual[0]
-	svcA := actual[0]
+	var svcA arrowtest.Row
+	for _, row := range actual {
+		if row["service_name.label.utf8"] == "svcA" {
+			svcA = row
+			break
+		}
+	}
+	require.NotNil(t, svcA)
 	require.Equal(t, int64(2), svcA["row_count.int64"])
 	require.Equal(t, time.Unix(10, 0).UTC(), svcA["min_timestamp.timestamp"])
 	require.Equal(t, time.Unix(30, 0).UTC(), svcA["max_timestamp.timestamp"])

--- a/pkg/dataobj/metastore/stream_selector_test.go
+++ b/pkg/dataobj/metastore/stream_selector_test.go
@@ -655,7 +655,7 @@ func buildLabelBloomSection(t testing.TB, labelsIn []labelPosting, bloomsIn []bl
 		}
 	}
 	for _, bp := range bloomsIn {
-		b.PrepareBloomColumn(bp.obj, bp.section, bp.columnName, 1000)
+		b.PrepareBloomColumn(bp.obj, bp.section, bp.columnName, 1000, 0)
 		for _, v := range bp.values {
 			require.NoError(t, b.ObserveBloomPosting(postings.BloomObservation{
 				ObjectPath: bp.obj, SectionIndex: bp.section, ColumnName: bp.columnName,

--- a/pkg/dataobj/sections/postings/bloom_aggregator.go
+++ b/pkg/dataobj/sections/postings/bloom_aggregator.go
@@ -73,8 +73,9 @@ func newBloomAggregator() *bloomAggregator {
 
 // PrepareColumn initializes the bloom filter for a specific column. Must be
 // called before any Observe calls for the given (objectPath, sectionIndex,
-// columnName) combination.
-func (a *bloomAggregator) PrepareColumn(objectPath string, sectionIndex int64, columnName string, estimatedCardinality uint) {
+// columnName) combination. shardBuckets is stored on the entry immediately so
+// a prepared-but-unobserved column still records the object's shard factor.
+func (a *bloomAggregator) PrepareColumn(objectPath string, sectionIndex int64, columnName string, estimatedCardinality uint, shardBuckets int64) {
 	key := bloomPostingKey{
 		objectPath:   objectPath,
 		sectionIndex: sectionIndex,
@@ -87,6 +88,7 @@ func (a *bloomAggregator) PrepareColumn(objectPath string, sectionIndex int64, c
 
 	entry := &bloomPostingEntry{
 		ObjectPath:   objectPath,
+		ShardBuckets: shardBuckets,
 		SectionIndex: sectionIndex,
 		ColumnName:   columnName,
 		bloomFilter:  bloom.NewWithEstimates(estimatedCardinality, 1.0/128.0),

--- a/pkg/dataobj/sections/postings/bloom_aggregator_test.go
+++ b/pkg/dataobj/sections/postings/bloom_aggregator_test.go
@@ -15,7 +15,7 @@ func TestBloomAggregator_TimeRange(t *testing.T) {
 	require.True(t, gotMax.IsZero(), "empty aggregator max must be zero")
 
 	// Prepared but never observed: must NOT contribute a range.
-	a.PrepareColumn("/a", 0, "svc", 16)
+	a.PrepareColumn("/a", 0, "svc", 16, 0)
 	gotMin, gotMax = a.TimeRange()
 	require.True(t, gotMin.IsZero(), "prepared-but-unobserved min must be zero")
 	require.True(t, gotMax.IsZero(), "prepared-but-unobserved max must be zero")
@@ -38,7 +38,7 @@ func TestBloomAggregator_TimeRange_ObserveAtUnixEpoch(t *testing.T) {
 	a := newBloomAggregator()
 	epoch := time.Unix(0, 0).UTC()
 
-	a.PrepareColumn("/a", 0, "svc", 16)
+	a.PrepareColumn("/a", 0, "svc", 16, 0)
 	require.NoError(t, a.Observe(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "v", StreamID: 1, Timestamp: epoch}))
 
 	gotMin, gotMax := a.TimeRange()

--- a/pkg/dataobj/sections/postings/builder.go
+++ b/pkg/dataobj/sections/postings/builder.go
@@ -67,9 +67,11 @@ func (b *Builder) Type() dataobj.SectionType { return sectionType }
 
 // PrepareBloomColumn initializes the bloom filter for a specific column. Must
 // be called before any ObserveBloomPosting calls for the given
-// (objectPath, sectionIndex, columnName) combination.
-func (b *Builder) PrepareBloomColumn(objectPath string, sectionIndex int64, columnName string, estimatedCardinality uint) {
-	b.blooms.PrepareColumn(objectPath, sectionIndex, columnName, estimatedCardinality)
+// (objectPath, sectionIndex, columnName) combination. shardBuckets is stored
+// on the entry immediately so a prepared-but-unobserved column still records
+// the object's shard factor.
+func (b *Builder) PrepareBloomColumn(objectPath string, sectionIndex int64, columnName string, estimatedCardinality uint, shardBuckets int64) {
+	b.blooms.PrepareColumn(objectPath, sectionIndex, columnName, estimatedCardinality, shardBuckets)
 }
 
 // ObserveLabelPosting records a label posting observation. Multiple

--- a/pkg/dataobj/sections/postings/builder_test.go
+++ b/pkg/dataobj/sections/postings/builder_test.go
@@ -91,7 +91,7 @@ func TestBuilder_BloomPostingRoundTrip(t *testing.T) {
 	b := NewBuilder(nil, 0, 0, 1<<20)
 
 	ts := time.Unix(0, 500).UTC()
-	b.PrepareBloomColumn("/tenant/abc/obj2", 1, "service_name", 100)
+	b.PrepareBloomColumn("/tenant/abc/obj2", 1, "service_name", 100, 0)
 	err := b.ObserveBloomPosting(BloomObservation{ObjectPath: "/tenant/abc/obj2", ShardBuckets: 16, SectionIndex: 1, ColumnName: "service_name", Value: "my-service", StreamID: 0, Timestamp: ts, UncompressedSize: 8192})
 	require.NoError(t, err)
 	err = b.ObserveBloomPosting(BloomObservation{ObjectPath: "/tenant/abc/obj2", ShardBuckets: 16, SectionIndex: 1, ColumnName: "service_name", Value: "my-service", StreamID: 2, Timestamp: ts, UncompressedSize: 0})
@@ -144,7 +144,7 @@ func TestBuilder_MixedPostings(t *testing.T) {
 
 	ts := time.Unix(0, 100).UTC()
 	ts2 := time.Unix(0, 300).UTC()
-	b.PrepareBloomColumn("/obj1", 0, "col_a", 10)
+	b.PrepareBloomColumn("/obj1", 0, "col_a", 10, 0)
 	err := b.ObserveBloomPosting(BloomObservation{ObjectPath: "/obj1", SectionIndex: 0, ColumnName: "col_a", Value: "val", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 	require.NoError(t, err)
 
@@ -177,10 +177,10 @@ func TestBuilder_SortOrder(t *testing.T) {
 	b := NewBuilder(nil, 0, 0, 1<<20)
 
 	// Prepare and add bloom entries.
-	b.PrepareBloomColumn("", 0, "col_a", 10)
+	b.PrepareBloomColumn("", 0, "col_a", 10, 0)
 	_ = b.ObserveBloomPosting(BloomObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col_a", Value: "v", StreamID: 0, Timestamp: time.Unix(0, 50), UncompressedSize: 0})
 
-	b.PrepareBloomColumn("", 0, "col_b", 10)
+	b.PrepareBloomColumn("", 0, "col_b", 10, 0)
 	_ = b.ObserveBloomPosting(BloomObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col_b", Value: "v", StreamID: 0, Timestamp: time.Unix(0, 10), UncompressedSize: 0})
 
 	// Label entries.
@@ -249,7 +249,7 @@ func TestBuilder_NullableHandling(t *testing.T) {
 
 	ts := time.Unix(0, 0).UTC()
 
-	b.PrepareBloomColumn("", 0, "col", 10)
+	b.PrepareBloomColumn("", 0, "col", 10, 0)
 	_ = b.ObserveBloomPosting(BloomObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col", Value: "val", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 
 	b.ObserveLabelPosting(LabelObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col", LabelValue: "val", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
@@ -283,7 +283,7 @@ func TestBuilder_BitmapCorrectness(t *testing.T) {
 	b := NewBuilder(nil, 0, 0, 1<<20)
 
 	ts := time.Unix(0, 0).UTC()
-	b.PrepareBloomColumn("", 0, "col", 10)
+	b.PrepareBloomColumn("", 0, "col", 10, 0)
 	// Observe stream IDs 0, 3, 7.
 	_ = b.ObserveBloomPosting(BloomObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col", Value: "v", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 	_ = b.ObserveBloomPosting(BloomObservation{ObjectPath: "", SectionIndex: 0, ColumnName: "col", Value: "v", StreamID: 3, Timestamp: ts, UncompressedSize: 0})
@@ -364,7 +364,7 @@ func TestBuilder_AllBloom(t *testing.T) {
 	ts := time.Unix(0, 0).UTC()
 	for i := range 3 {
 		colName := fmt.Sprintf("col%d", i)
-		b.PrepareBloomColumn("", 0, colName, 10)
+		b.PrepareBloomColumn("", 0, colName, 10, 0)
 		_ = b.ObserveBloomPosting(BloomObservation{ObjectPath: "", SectionIndex: 0, ColumnName: colName, Value: "val", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 	}
 
@@ -428,7 +428,7 @@ func TestBuilder_KindColumnRangeStats(t *testing.T) {
 	b := NewBuilder(nil, 0, 0, 1<<20)
 
 	ts := time.Unix(0, 1000).UTC()
-	b.PrepareBloomColumn("/a", 0, "svc", 16)
+	b.PrepareBloomColumn("/a", 0, "svc", 16, 0)
 	require.NoError(t, b.ObserveBloomPosting(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "v", StreamID: 1, Timestamp: ts}))
 	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "env", LabelValue: "x", StreamID: 2, Timestamp: ts})
 
@@ -483,7 +483,7 @@ func TestBuilder_KindColumnPruning(t *testing.T) {
 	b := NewBuilder(nil, 0, 0, 1<<20)
 
 	ts := time.Unix(0, 1000).UTC()
-	b.PrepareBloomColumn("/a", 0, "svc", 16)
+	b.PrepareBloomColumn("/a", 0, "svc", 16, 0)
 	require.NoError(t, b.ObserveBloomPosting(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "v", StreamID: 1, Timestamp: ts}))
 	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "env", LabelValue: "x", StreamID: 2, Timestamp: ts})
 
@@ -686,7 +686,7 @@ func TestBuilder_ObserveBloomPosting(t *testing.T) {
 	b := NewBuilder(nil, 0, 0, 1<<20)
 
 	ts := time.Unix(0, 100)
-	b.PrepareBloomColumn("/obj", 0, "service_name", 100)
+	b.PrepareBloomColumn("/obj", 0, "service_name", 100, 0)
 
 	values := []string{"alpha", "beta", "gamma"}
 	for i, v := range values {
@@ -738,7 +738,7 @@ func TestBuilder_MixedObservations(t *testing.T) {
 	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/obj", SectionIndex: 0, ColumnName: "col_b", LabelValue: "v", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 
 	// Add bloom second.
-	b.PrepareBloomColumn("/obj", 0, "col_a", 10)
+	b.PrepareBloomColumn("/obj", 0, "col_a", 10, 0)
 	_ = b.ObserveBloomPosting(BloomObservation{ObjectPath: "/obj", SectionIndex: 0, ColumnName: "col_a", Value: "v", StreamID: 0, Timestamp: ts, UncompressedSize: 0})
 
 	sections := flushAndOpenSections(t, b)
@@ -833,7 +833,7 @@ func TestBuilder_BloomBytes(t *testing.T) {
 	b := NewBuilder(nil, 0, 0, 1<<20)
 
 	ts := time.Unix(0, 0)
-	b.PrepareBloomColumn("/obj", 0, "col", 50)
+	b.PrepareBloomColumn("/obj", 0, "col", 50, 0)
 
 	values := []string{"foo", "bar", "baz"}
 	for _, v := range values {
@@ -866,7 +866,7 @@ func TestBuilder_BloomBytes(t *testing.T) {
 func mustBuildBloomBytes(t *testing.T, objectPath string, sectionIndex int64, columnName, value string, ts time.Time) []byte {
 	t.Helper()
 	tempBuilder := NewBuilder(nil, 0, 0, 1<<20)
-	tempBuilder.PrepareBloomColumn(objectPath, sectionIndex, columnName, 100)
+	tempBuilder.PrepareBloomColumn(objectPath, sectionIndex, columnName, 100, 0)
 	err := tempBuilder.ObserveBloomPosting(BloomObservation{
 		ObjectPath:       objectPath,
 		SectionIndex:     sectionIndex,
@@ -1037,7 +1037,7 @@ func TestBuilder_SplitsBloomAndLabelIntoSeparateSections(t *testing.T) {
 
 	for i := range 4 {
 		col := fmt.Sprintf("bcol%d", i)
-		b.PrepareBloomColumn("/o", 0, col, 10)
+		b.PrepareBloomColumn("/o", 0, col, 10, 0)
 		require.NoError(t, b.ObserveBloomPosting(BloomObservation{ObjectPath: "/o", SectionIndex: 0, ColumnName: col, Value: "v", StreamID: 0, Timestamp: ts, UncompressedSize: 0}))
 	}
 	for _, lv := range []string{"a", "b", "c", "d"} {
@@ -1180,7 +1180,7 @@ func TestBuilder_TimeRange(t *testing.T) {
 	require.Equal(t, base, gotMax)
 
 	// Bloom observation extends the range on both ends.
-	b.PrepareBloomColumn("/a", 0, "svc", 16)
+	b.PrepareBloomColumn("/a", 0, "svc", 16, 0)
 	require.NoError(t, b.ObserveBloomPosting(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "v", StreamID: 2, Timestamp: base.Add(-time.Hour)}))
 	require.NoError(t, b.ObserveBloomPosting(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "w", StreamID: 3, Timestamp: base.Add(time.Hour)}))
 
@@ -1200,7 +1200,7 @@ func TestBuilder_TimeRange_BloomOnly(t *testing.T) {
 	b := NewBuilder(nil, 0, 0, 1024)
 	base := time.Unix(6000, 0).UTC()
 
-	b.PrepareBloomColumn("/a", 0, "svc", 16)
+	b.PrepareBloomColumn("/a", 0, "svc", 16, 0)
 	require.NoError(t, b.ObserveBloomPosting(BloomObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "svc", Value: "v", StreamID: 1, Timestamp: base}))
 
 	gotMin, gotMax := b.TimeRange()
@@ -1215,7 +1215,7 @@ func TestBuilder_TimeRange_PreparedBloomNoObservation(t *testing.T) {
 	// Label observation sets the range.
 	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x", StreamID: 1, Timestamp: base})
 	// Prepared-but-unobserved bloom column must not widen the range.
-	b.PrepareBloomColumn("/a", 0, "svc", 16)
+	b.PrepareBloomColumn("/a", 0, "svc", 16, 0)
 
 	gotMin, gotMax := b.TimeRange()
 	require.Equal(t, base, gotMin)

--- a/pkg/dataobj/sections/postings/fixtures_test.go
+++ b/pkg/dataobj/sections/postings/fixtures_test.go
@@ -26,7 +26,7 @@ func buildTestSection(t *testing.T) ([]*postings.Section, func()) {
 		ObjectPath: "/obj", SectionIndex: 0, ColumnName: "env", LabelValue: "prod",
 		StreamID: 1, Timestamp: ts, UncompressedSize: 100,
 	})
-	b.PrepareBloomColumn("/obj", 0, "trace_id", 1000)
+	b.PrepareBloomColumn("/obj", 0, "trace_id", 1000, 0)
 	require.NoError(t, b.ObserveBloomPosting(postings.BloomObservation{
 		ObjectPath: "/obj", SectionIndex: 0, ColumnName: "trace_id",
 		StreamID: 2, Timestamp: ts, UncompressedSize: 200,

--- a/pkg/dataobj/sections/postings/row_reader_test.go
+++ b/pkg/dataobj/sections/postings/row_reader_test.go
@@ -42,7 +42,7 @@ func TestRowReader_RoundTrip(t *testing.T) {
 		UncompressedSize: 100,
 	})
 
-	b.PrepareBloomColumn("/obj", 0, "trace_id", 1000)
+	b.PrepareBloomColumn("/obj", 0, "trace_id", 1000, 0)
 	require.NoError(t, b.ObserveBloomPosting(postings.BloomObservation{
 		ObjectPath:       "/obj",
 		SectionIndex:     0,
@@ -225,7 +225,7 @@ func TestRowReader_BloomMatchPredicate(t *testing.T) {
 	b := postings.NewBuilder(nil, 0, 0, 1<<20)
 	ts := time.Unix(0, 0).UTC()
 
-	b.PrepareBloomColumn("/obj", 0, "pod", 1000)
+	b.PrepareBloomColumn("/obj", 0, "pod", 1000, 0)
 	require.NoError(t, b.ObserveBloomPosting(postings.BloomObservation{
 		ObjectPath:       "/obj",
 		SectionIndex:     0,
@@ -277,7 +277,7 @@ func TestRowReader_NotBloomMatchPredicate(t *testing.T) {
 	b := postings.NewBuilder(nil, 0, 0, 1<<20)
 	ts := time.Unix(0, 0).UTC()
 
-	b.PrepareBloomColumn("/obj", 0, "pod", 1000)
+	b.PrepareBloomColumn("/obj", 0, "pod", 1000, 0)
 	require.NoError(t, b.ObserveBloomPosting(postings.BloomObservation{
 		ObjectPath:       "/obj",
 		SectionIndex:     0,

--- a/pkg/dataobj/sections/postings/scanner_test.go
+++ b/pkg/dataobj/sections/postings/scanner_test.go
@@ -438,7 +438,7 @@ func buildLabelBloomSection(t *testing.T, labelsIn []labelPosting, bloomsIn []bl
 		}
 	}
 	for _, bp := range bloomsIn {
-		b.PrepareBloomColumn(bp.obj, bp.section, bp.columnName, 1000)
+		b.PrepareBloomColumn(bp.obj, bp.section, bp.columnName, 1000, 0)
 		for _, v := range bp.values {
 			require.NoError(t, b.ObserveBloomPosting(postings.BloomObservation{
 				ObjectPath: bp.obj, SectionIndex: bp.section, ColumnName: bp.columnName,

--- a/pkg/dataobj/sections/stats/stats.go
+++ b/pkg/dataobj/sections/stats/stats.go
@@ -93,13 +93,13 @@ func CheckSection(section *dataobj.Section) bool {
 type Stat struct {
 	ObjectPath       string
 	SectionIndex     int64
+	ShardBucket      uint32
 	SortSchema       string
 	Labels           map[string]string // Label values keyed by sort schema key name
 	MinTimestamp     int64             // UnixNano
 	MaxTimestamp     int64             // UnixNano
 	RowCount         int64
 	UncompressedSize int64
-	ShardBucket      uint32
 }
 
 // SectionEncoder encodes a batch of sorted Stat rows into a columnar encoder.

--- a/pkg/dataobj/sections/streams/builder.go
+++ b/pkg/dataobj/sections/streams/builder.go
@@ -3,7 +3,6 @@ package streams
 import (
 	"errors"
 	"fmt"
-	"math"
 	"sync"
 	"time"
 
@@ -17,6 +16,16 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/streamio"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/util/sliceclear"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/internal/columnar"
+)
+
+const (
+	// ShardBits is the number of high labels.StableHash(labels) bits that select a stream's shard bucket.
+	// Changing it is a storage-format break, not a tunable: the query side reads it to map shards to
+	// buckets, and the exact fast path trusts stored bucket values without re-verifying them, so a change
+	// would mis-read every object written with the old value.
+	ShardBits = 5
+	// ShardFactor is the number of physical shard buckets, 2^ShardBits.
+	ShardFactor = 1 << ShardBits
 )
 
 // A Stream is an individual stream within a data object.
@@ -54,12 +63,6 @@ func (s *Stream) Reset() {
 	s.UncompressedSize = 0
 	s.Rows = 0
 }
-
-// ShardFactor is the number of physical shard buckets derived from
-// labels.StableHash. Valid [ShardBucket] values are in [0, ShardFactor).
-const ShardFactor uint32 = 32
-
-var shardBits = int(math.Log2(float64(ShardFactor)))
 
 var streamPool = sync.Pool{
 	New: func() interface{} {
@@ -230,7 +233,7 @@ func (b *Builder) getOrAddStream(streamLabels labels.Labels) *Stream {
 // Buckets are 0-based in [0, ShardFactor).
 func ShardBucket(streamLabels labels.Labels) uint32 {
 	fp := labels.StableHash(streamLabels)
-	return uint32(fp >> (64 - shardBits))
+	return uint32(fp >> (64 - ShardBits))
 }
 
 func (b *Builder) addStream(hash uint64, streamLabels labels.Labels) *Stream {

--- a/pkg/dataobj/sections/streams/builder.go
+++ b/pkg/dataobj/sections/streams/builder.go
@@ -228,7 +228,7 @@ func (b *Builder) getOrAddStream(streamLabels labels.Labels) *Stream {
 // ShardBucket returns the physical shard bucket for streamLabels.
 func ShardBucket(streamLabels labels.Labels) uint64 {
 	fp := labels.StableHash(streamLabels)
-	return fp >> (64 - shardBits)
+	return fp>>(64-shardBits) + 1
 }
 
 func (b *Builder) addStream(hash uint64, streamLabels labels.Labels) *Stream {
@@ -239,8 +239,8 @@ func (b *Builder) addStream(hash uint64, streamLabels labels.Labels) *Stream {
 	newStream := streamPool.Get().(*Stream)
 	newStream.Reset()
 	newStream.ID = b.lastID.Add(1)
-	newStream.ShardBucket = int64(ShardBucket(streamLabels))
 	newStream.Labels = streamLabels
+	newStream.ShardBucket = int64(ShardBucket(streamLabels))
 
 	b.lookup[hash] = append(b.lookup[hash], newStream)
 	b.ordered = append(b.ordered, newStream)

--- a/pkg/dataobj/sections/streams/builder.go
+++ b/pkg/dataobj/sections/streams/builder.go
@@ -54,9 +54,11 @@ func (s *Stream) Reset() {
 	s.Rows = 0
 }
 
-const shardFactor = 32
+// ShardFactor is the number of physical shard buckets derived from
+// labels.StableHash.
+const ShardFactor uint32 = 32
 
-var shardBits = int(math.Log2(shardFactor))
+var shardBits = int(math.Log2(float64(ShardFactor)))
 
 var streamPool = sync.Pool{
 	New: func() interface{} {

--- a/pkg/dataobj/sections/streams/builder.go
+++ b/pkg/dataobj/sections/streams/builder.go
@@ -40,6 +40,7 @@ type Stream struct {
 	Rows int
 
 	// ShardBucket is derived from the high bits of labels.StableHash(Labels).
+	// Valid buckets are in [0, ShardFactor).
 	ShardBucket int64
 }
 
@@ -55,7 +56,7 @@ func (s *Stream) Reset() {
 }
 
 // ShardFactor is the number of physical shard buckets derived from
-// labels.StableHash.
+// labels.StableHash. Valid [ShardBucket] values are in [0, ShardFactor).
 const ShardFactor uint32 = 32
 
 var shardBits = int(math.Log2(float64(ShardFactor)))
@@ -226,9 +227,10 @@ func (b *Builder) getOrAddStream(streamLabels labels.Labels) *Stream {
 }
 
 // ShardBucket returns the physical shard bucket for streamLabels.
-func ShardBucket(streamLabels labels.Labels) uint64 {
+// Buckets are 0-based in [0, ShardFactor).
+func ShardBucket(streamLabels labels.Labels) uint32 {
 	fp := labels.StableHash(streamLabels)
-	return fp>>(64-shardBits) + 1
+	return uint32(fp >> (64 - shardBits))
 }
 
 func (b *Builder) addStream(hash uint64, streamLabels labels.Labels) *Stream {

--- a/pkg/dataobj/sections/streams/builder_test.go
+++ b/pkg/dataobj/sections/streams/builder_test.go
@@ -26,6 +26,9 @@ func Test(t *testing.T) {
 		{labels.FromStrings("cluster", "test", "app", "bar", "special", "yes"), time.Unix(100, 0), 20},
 		{labels.FromStrings("cluster", "test", "app", "foo"), time.Unix(15, 0), 15},
 		{labels.FromStrings("cluster", "test", "app", "foo"), time.Unix(9, 0), 5},
+		// Zero uncompressed size must survive decode into a reused Stream;
+		// decodeRow skips zero cells, so it has to Reset first.
+		{labels.FromStrings("cluster", "test", "app", "empty"), time.Unix(1, 0), 0},
 	}
 
 	tracker := streams.NewBuilder(nil, 1024, 0)
@@ -55,6 +58,15 @@ func Test(t *testing.T) {
 			Rows:             1,
 			UncompressedSize: 20,
 			ShardBucket:      int64(streams.ShardBucket(labels.FromStrings("cluster", "test", "app", "bar", "special", "yes"))),
+		},
+		{
+			ID:               3,
+			Labels:           labels.FromStrings("cluster", "test", "app", "empty"),
+			MinTimestamp:     time.Unix(1, 0),
+			MaxTimestamp:     time.Unix(1, 0),
+			Rows:             1,
+			UncompressedSize: 0,
+			ShardBucket:      int64(streams.ShardBucket(labels.FromStrings("cluster", "test", "app", "empty"))),
 		},
 	}
 

--- a/pkg/dataobj/sections/streams/iter.go
+++ b/pkg/dataobj/sections/streams/iter.go
@@ -164,6 +164,8 @@ func decodeRow(columns []*Column, row dataset.Row, stream *Stream, sym *symboliz
 	// Callers reuse Stream values across rows. Reset so a zero cell in this
 	// row cannot leave a previous row's value in place (decode skips zeros).
 	stream.Reset()
+	// Callers reuse label builder across rows when passed in. Explicitly Reset it so it cannot leak values between rows.
+	labelBuilder.Reset()
 
 	for columnIndex, columnValue := range row.Values {
 		if columnValue.IsNil() || columnValue.IsZero() {

--- a/pkg/dataobj/sections/streams/iter.go
+++ b/pkg/dataobj/sections/streams/iter.go
@@ -115,7 +115,6 @@ func iterSection(ctx context.Context, section *Section, cfg iterConfig) result.S
 
 			var stream Stream
 			for _, row := range rows[:n] {
-				labelBuilder.Reset()
 				if err := decodeRow(section.Columns(), row, &stream, cfg.symbolizer, &labelBuilder, cfg.reuseLabelsBuffer); err != nil {
 					return err
 				}

--- a/pkg/dataobj/sections/streams/iter.go
+++ b/pkg/dataobj/sections/streams/iter.go
@@ -148,6 +148,7 @@ func (s *Section) makeDataset() (*columnar.Dataset, error) {
 //
 // The labelBuilder argument is used to reuse label builder between calls to decodeRow.
 // If labelBuilder is nil, a builder is picked up from the pool and returned to the pool after use.
+// If labelBuilder is not nil, it is Reset before use.
 //
 // The reuseLabelsBuffer argument controls whether the internal buffer used by the labelBuilder
 // to build the labels is to be reused. Setting it to true would overwrite the previous labels

--- a/pkg/dataobj/sections/streams/iter.go
+++ b/pkg/dataobj/sections/streams/iter.go
@@ -161,6 +161,10 @@ func decodeRow(columns []*Column, row dataset.Row, stream *Stream, sym *symboliz
 		defer labelpool.Put(labelBuilder)
 	}
 
+	// Callers reuse Stream values across rows. Reset so a zero cell in this
+	// row cannot leave a previous row's value in place (decode skips zeros).
+	stream.Reset()
+
 	for columnIndex, columnValue := range row.Values {
 		if columnValue.IsNil() || columnValue.IsZero() {
 			continue

--- a/pkg/engine/internal/executor/index_merge_test.go
+++ b/pkg/engine/internal/executor/index_merge_test.go
@@ -612,7 +612,7 @@ func buildSourceWithLegacySections(t *testing.T, bucket objstore.Bucket, tenant,
 	// Append a stat to get a stats section.
 	err = builder.AppendStat(tenant, "log-A", 0, "label:service",
 		map[string]string{"service": "api"},
-		ts, ts.Add(time.Second), 10, 1000)
+		ts, ts.Add(time.Second), 10, 1000, 0)
 	require.NoError(t, err, "failed to append stat")
 
 	// Observe a label posting to get a postings section.

--- a/pkg/engine/internal/executor/index_merge_test.go
+++ b/pkg/engine/internal/executor/index_merge_test.go
@@ -610,9 +610,9 @@ func buildSourceWithLegacySections(t *testing.T, bucket objstore.Bucket, tenant,
 	require.NoError(t, err, "failed to observe log line")
 
 	// Append a stat to get a stats section.
-	err = builder.AppendStat(tenant, "log-A", 0, "label:service",
+	err = builder.AppendStat(tenant, "log-A", 0, 16, "label:service",
 		map[string]string{"service": "api"},
-		ts, ts.Add(time.Second), 10, 1000, 0)
+		ts, ts.Add(time.Second), 10, 1000)
 	require.NoError(t, err, "failed to append stat")
 
 	// Observe a label posting to get a postings section.
@@ -624,6 +624,7 @@ func buildSourceWithLegacySections(t *testing.T, bucket objstore.Bucket, tenant,
 		StreamID:         1,
 		Timestamp:        ts,
 		UncompressedSize: 100,
+		ShardBuckets:     16,
 	})
 
 	// Flush the builder to create the object.


### PR DESCRIPTION
**What this PR does / why we need it**:

Wires up shard bucket through the indexing step

Before this PR, shard bucket column was populated in streams sections in log objects but was not aggregated through into stats sections or postings sections in the index-builder code.

This PR populates those fields so they can be used during planning stages and during compaction. Most of this is just plumbing.