### PR TITLE
fix(logql): Stop double-counting nested IndexStats ranges

### DIFF
--- a/pkg/querier/queryrange/stats.go
+++ b/pkg/querier/queryrange/stats.go
@@ -102,13 +102,50 @@ type queryData struct {
 	recorded            bool
 	estimatedQueryBytes int64
 	indexStatsMu        sync.Mutex
-	indexStatsBytesSeen map[indexStatsRequestKey]struct{}
+	indexStatsRanges    []indexStatsRange
 }
 
-type indexStatsRequestKey struct {
+// indexStatsRange is one IndexStats lookup observed on a query. Nested ranges
+// with the same matchers are not separate haystacks: a full-query lookup and
+// later per-split lookups cover the same bytes.
+type indexStatsRange struct {
 	from     model.Time
 	through  model.Time
 	matchers string
+	bytes    int64
+}
+
+func (r indexStatsRange) covers(other indexStatsRange) bool {
+	return r.matchers == other.matchers && r.from <= other.from && r.through >= other.through
+}
+
+// mergeIndexStatsRange keeps the covering set of IndexStats ranges: a range is
+// dropped when a same-matcher range already spans it, and a newly covering
+// range replaces the nested ranges it contains. Remaining (non-overlapping)
+// ranges are summed.
+func mergeIndexStatsRange(ranges []indexStatsRange, next indexStatsRange) []indexStatsRange {
+	for _, existing := range ranges {
+		if existing.covers(next) {
+			return ranges
+		}
+	}
+
+	merged := make([]indexStatsRange, 0, len(ranges)+1)
+	for _, existing := range ranges {
+		if next.covers(existing) {
+			continue
+		}
+		merged = append(merged, existing)
+	}
+	return append(merged, next)
+}
+
+func sumIndexStatsBytes(ranges []indexStatsRange) int64 {
+	var total int64
+	for _, r := range ranges {
+		total += r.bytes
+	}
+	return total
 }
 
 func (d *queryData) recordEstimatedQueryBytes(req *logproto.IndexStatsRequest, responseBytes uint64) {
@@ -119,22 +156,13 @@ func (d *queryData) recordEstimatedQueryBytes(req *logproto.IndexStatsRequest, r
 	d.indexStatsMu.Lock()
 	defer d.indexStatsMu.Unlock()
 
-	if d.indexStatsBytesSeen == nil {
-		d.indexStatsBytesSeen = make(map[indexStatsRequestKey]struct{})
-	}
-
-	key := indexStatsRequestKey{
+	d.indexStatsRanges = mergeIndexStatsRange(d.indexStatsRanges, indexStatsRange{
 		from:     req.From,
 		through:  req.Through,
 		matchers: req.Matchers,
-	}
-
-	if _, seen := d.indexStatsBytesSeen[key]; seen {
-		return
-	}
-
-	d.indexStatsBytesSeen[key] = struct{}{}
-	d.estimatedQueryBytes += int64(responseBytes)
+		bytes:    int64(responseBytes),
+	})
+	d.estimatedQueryBytes = sumIndexStatsBytes(d.indexStatsRanges)
 }
 
 func IndexStatsContextCollectorMiddleware() queryrangebase.Middleware {

--- a/pkg/querier/queryrange/stats.go
+++ b/pkg/querier/queryrange/stats.go
@@ -122,7 +122,8 @@ func (r indexStatsRange) covers(other indexStatsRange) bool {
 // mergeIndexStatsRange keeps the covering set of IndexStats ranges: a range is
 // dropped when a same-matcher range already spans it, and a newly covering
 // range replaces the nested ranges it contains. Remaining (non-overlapping)
-// ranges are summed.
+// ranges are summed. Compaction is in place so append can grow the slice
+// instead of allocating a copy on every insert.
 func mergeIndexStatsRange(ranges []indexStatsRange, next indexStatsRange) []indexStatsRange {
 	for _, existing := range ranges {
 		if existing.covers(next) {
@@ -130,14 +131,15 @@ func mergeIndexStatsRange(ranges []indexStatsRange, next indexStatsRange) []inde
 		}
 	}
 
-	merged := make([]indexStatsRange, 0, len(ranges)+1)
+	n := 0
 	for _, existing := range ranges {
 		if next.covers(existing) {
 			continue
 		}
-		merged = append(merged, existing)
+		ranges[n] = existing
+		n++
 	}
-	return append(merged, next)
+	return append(ranges[:n], next)
 }
 
 func sumIndexStatsBytes(ranges []indexStatsRange) int64 {

--- a/pkg/querier/queryrange/stats_test.go
+++ b/pkg/querier/queryrange/stats_test.go
@@ -275,6 +275,84 @@ func TestStatsCollectorMiddleware_DoesNotOverwriteLargerEstimatedQueryBytes(t *t
 	require.Equal(t, int64(4096), lokiResp.Statistics.Summary.EstimatedQueryBytes)
 }
 
+func TestMergeIndexStatsRange_DoesNotDoubleCountNestedRanges(t *testing.T) {
+	const matchers = `{foo="bar"}`
+	hour := model.Time(time.Hour / time.Millisecond)
+	full := indexStatsRange{from: 0, through: 2 * hour, matchers: matchers, bytes: 1000}
+	firstSplit := indexStatsRange{from: 0, through: hour, matchers: matchers, bytes: 400}
+	secondSplit := indexStatsRange{from: hour, through: 2 * hour, matchers: matchers, bytes: 600}
+	otherMatchers := indexStatsRange{from: 0, through: 2 * hour, matchers: `{baz="qux"}`, bytes: 1000}
+
+	for _, tc := range []struct {
+		name  string
+		input []indexStatsRange
+		want  int64
+	}{
+		{
+			name:  "full range then nested splits matches the covering haystack",
+			input: []indexStatsRange{full, firstSplit, secondSplit},
+			want:  1000,
+		},
+		{
+			name:  "nested splits then covering range replaces the split sum",
+			input: []indexStatsRange{firstSplit, secondSplit, full},
+			want:  1000,
+		},
+		{
+			name:  "non-overlapping splits are summed",
+			input: []indexStatsRange{firstSplit, secondSplit},
+			want:  1000,
+		},
+		{
+			name:  "identical range is recorded once",
+			input: []indexStatsRange{full, full},
+			want:  1000,
+		},
+		{
+			name:  "different matchers are summed",
+			input: []indexStatsRange{full, otherMatchers},
+			want:  2000,
+		},
+		{
+			name:  "nested splits for one matcher do not drop another matcher",
+			input: []indexStatsRange{full, firstSplit, secondSplit, otherMatchers},
+			want:  2000,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var ranges []indexStatsRange
+			for _, next := range tc.input {
+				ranges = mergeIndexStatsRange(ranges, next)
+			}
+			require.Equal(t, tc.want, sumIndexStatsBytes(ranges))
+		})
+	}
+}
+
+func TestQueryData_RecordEstimatedQueryBytes_DoesNotDoubleCountNestedRanges(t *testing.T) {
+	hour := model.Time(time.Hour / time.Millisecond)
+	data := &queryData{}
+	matchers := `{app="loki"}`
+
+	data.recordEstimatedQueryBytes(&logproto.IndexStatsRequest{
+		From:     0,
+		Through:  2 * hour,
+		Matchers: matchers,
+	}, 60<<30)
+	data.recordEstimatedQueryBytes(&logproto.IndexStatsRequest{
+		From:     0,
+		Through:  hour,
+		Matchers: matchers,
+	}, 30<<30)
+	data.recordEstimatedQueryBytes(&logproto.IndexStatsRequest{
+		From:     hour,
+		Through:  2 * hour,
+		Matchers: matchers,
+	}, 30<<30)
+
+	require.Equal(t, int64(60<<30), data.estimatedQueryBytes)
+}
+
 func TestIndexStatsContextCollectorMiddleware_DedupesAcrossCollectorPaths(t *testing.T) {
 	data := &queryData{}
 	ctx := context.WithValue(context.Background(), ctxKey, data)
@@ -323,4 +401,67 @@ func TestIndexStatsContextCollectorMiddleware_DedupesAcrossCollectorPaths(t *tes
 	lokiResp, ok := resp.(*LokiResponse)
 	require.True(t, ok)
 	require.Equal(t, int64(2048), lokiResp.Statistics.Summary.EstimatedQueryBytes)
+}
+
+func TestStatsCollectorMiddleware_DoesNotDoubleCountNestedIndexStatsRanges(t *testing.T) {
+	hour := model.Time(time.Hour / time.Millisecond)
+	matchers := `{foo="bar"}`
+	full := &logproto.IndexStatsRequest{From: 0, Through: 2 * hour, Matchers: matchers}
+	firstSplit := &logproto.IndexStatsRequest{From: 0, Through: hour, Matchers: matchers}
+	secondSplit := &logproto.IndexStatsRequest{From: hour, Through: 2 * hour, Matchers: matchers}
+	bytesByReq := map[indexStatsRange]uint64{
+		{from: full.From, through: full.Through, matchers: matchers}:               1000,
+		{from: firstSplit.From, through: firstSplit.Through, matchers: matchers}:   400,
+		{from: secondSplit.From, through: secondSplit.Through, matchers: matchers}: 600,
+	}
+
+	for _, tc := range []struct {
+		name  string
+		order []*logproto.IndexStatsRequest
+	}{
+		{
+			name:  "full range then per-split stats",
+			order: []*logproto.IndexStatsRequest{full, firstSplit, secondSplit},
+		},
+		{
+			name:  "per-split stats then covering range",
+			order: []*logproto.IndexStatsRequest{firstSplit, secondSplit, full},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			data := &queryData{}
+			ctx := context.WithValue(context.Background(), ctxKey, data)
+			mw := queryrangebase.MergeMiddlewares(
+				StatsCollectorMiddleware(),
+				IndexStatsContextCollectorMiddleware(),
+			).Wrap(queryrangebase.HandlerFunc(func(_ context.Context, req queryrangebase.Request) (queryrangebase.Response, error) {
+				switch r := req.(type) {
+				case *logproto.IndexStatsRequest:
+					bytes, ok := bytesByReq[indexStatsRange{from: r.From, through: r.Through, matchers: r.Matchers}]
+					if !ok {
+						return nil, fmt.Errorf("unexpected index stats range %s %s %s", r.From, r.Through, r.Matchers)
+					}
+					return &IndexStatsResponse{
+						Response: &logproto.IndexStatsResponse{Bytes: bytes},
+					}, nil
+				case *LokiRequest:
+					return &LokiResponse{}, nil
+				default:
+					return nil, fmt.Errorf("unexpected request type %T", req)
+				}
+			}))
+
+			for _, req := range tc.order {
+				_, err := mw.Do(ctx, req)
+				require.NoError(t, err)
+			}
+			require.Equal(t, int64(1000), data.estimatedQueryBytes)
+
+			resp, err := mw.Do(ctx, &LokiRequest{Query: "foo", StartTs: time.Now()})
+			require.NoError(t, err)
+			lokiResp, ok := resp.(*LokiResponse)
+			require.True(t, ok)
+			require.Equal(t, int64(1000), lokiResp.Statistics.Summary.EstimatedQueryBytes)
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- `estimated_query_bytes` summed every distinct IndexStats lookup keyed by `(from, through, matchers)`. A full-query lookup and later per-split lookups for the same stream matchers are the same haystack, so query metrics reported ~2x the bytes the size gate actually used.
- The collector now keeps the covering range when one IndexStats response spans the others, and still sums non-overlapping ranges (and different matchers). The logged estimate then matches the original query-range IndexStats value.

## Test plan
- [x] `go test -count=1 ./pkg/querier/queryrange/`
- [x] New tests cover full-range-then-splits, splits-then-covering-range, non-overlapping split sums, and matcher isolation.

## Risks / rollout
- Reporting-only. Query execution, sharding, and any byte-size gate that calls IndexStats itself are unchanged.
- Queries that never get a covering-range lookup still sum non-overlapping per-split stats, which is the previous sharding-only estimate.


Made with [Cursor](https://cursor.com)