### PR TITLE
chore: Wire in shard_bucket min/max to postings

### DIFF
--- a/pkg/dataobj/index/label_postings_calculation.go
+++ b/pkg/dataobj/index/label_postings_calculation.go
@@ -51,6 +51,7 @@ func (c *labelPostingsCalculation) ProcessBatch(_ context.Context, calcCtx *logs
 				StreamID:         log.StreamID,
 				Timestamp:        log.Timestamp,
 				UncompressedSize: uncompressedSize,
+				ShardBucket:      uint32(log.ShardBucket),
 			})
 		})
 	}

--- a/pkg/dataobj/index/label_postings_calculation.go
+++ b/pkg/dataobj/index/label_postings_calculation.go
@@ -51,7 +51,6 @@ func (c *labelPostingsCalculation) ProcessBatch(_ context.Context, calcCtx *logs
 				StreamID:         log.StreamID,
 				Timestamp:        log.Timestamp,
 				UncompressedSize: uncompressedSize,
-				ShardBucket:      uint32(log.ShardBucket),
 			})
 		})
 	}

--- a/pkg/dataobj/sections/postings/builder_test.go
+++ b/pkg/dataobj/sections/postings/builder_test.go
@@ -47,9 +47,9 @@ func TestBuilder_LabelPostingRoundTrip(t *testing.T) {
 	b := NewBuilder(nil, 0, 0, 1<<20)
 
 	ts := time.Unix(0, 1000).UTC()
-	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/tenant/abc/obj1", ShardBuckets: 16, SectionIndex: 0, ColumnName: "env", LabelValue: "value1", StreamID: 3, Timestamp: ts, UncompressedSize: 4096})
-	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/tenant/abc/obj1", ShardBuckets: 16, SectionIndex: 0, ColumnName: "env", LabelValue: "value1", StreamID: 7, Timestamp: ts, UncompressedSize: 0})
-	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/tenant/abc/obj1", ShardBuckets: 16, SectionIndex: 0, ColumnName: "env", LabelValue: "value1", StreamID: 15, Timestamp: ts, UncompressedSize: 0})
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/tenant/abc/obj1", ShardBuckets: 16, SectionIndex: 0, ColumnName: "env", LabelValue: "value1", StreamID: 3, Timestamp: ts, UncompressedSize: 4096, ShardBucket: 2})
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/tenant/abc/obj1", ShardBuckets: 16, SectionIndex: 0, ColumnName: "env", LabelValue: "value1", StreamID: 7, Timestamp: ts, UncompressedSize: 0, ShardBucket: 7})
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/tenant/abc/obj1", ShardBuckets: 16, SectionIndex: 0, ColumnName: "env", LabelValue: "value1", StreamID: 15, Timestamp: ts, UncompressedSize: 0, ShardBucket: 4})
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
@@ -70,6 +70,8 @@ func TestBuilder_LabelPostingRoundTrip(t *testing.T) {
 			"uncompressed_size.int64": int64(4096),
 			"min_timestamp.timestamp": ts,
 			"max_timestamp.timestamp": ts,
+			"min_shard_bucket.int64":  int64(2),
+			"max_shard_bucket.int64":  int64(7),
 		},
 	}
 
@@ -121,6 +123,8 @@ func TestBuilder_BloomPostingRoundTrip(t *testing.T) {
 			"uncompressed_size.int64": int64(8192),
 			"min_timestamp.timestamp": ts,
 			"max_timestamp.timestamp": ts,
+			"min_shard_bucket.int64":  nil,
+			"max_shard_bucket.int64":  nil,
 		},
 	}
 
@@ -641,9 +645,9 @@ func TestBuilder_ObserveLabelPosting(t *testing.T) {
 	midTs := time.Unix(0, 200).UTC()
 	maxTs := time.Unix(0, 300).UTC()
 
-	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/obj", SectionIndex: 0, ColumnName: "env", LabelValue: "prod", StreamID: 1, Timestamp: minTs, UncompressedSize: 100})
-	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/obj", SectionIndex: 0, ColumnName: "env", LabelValue: "prod", StreamID: 5, Timestamp: midTs, UncompressedSize: 200})
-	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/obj", SectionIndex: 0, ColumnName: "env", LabelValue: "prod", StreamID: 10, Timestamp: maxTs, UncompressedSize: 300})
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/obj", SectionIndex: 0, ColumnName: "env", LabelValue: "prod", StreamID: 1, Timestamp: minTs, UncompressedSize: 100, ShardBucket: 1})
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/obj", SectionIndex: 0, ColumnName: "env", LabelValue: "prod", StreamID: 5, Timestamp: midTs, UncompressedSize: 200, ShardBucket: 5})
+	b.ObserveLabelPosting(LabelObservation{ObjectPath: "/obj", SectionIndex: 0, ColumnName: "env", LabelValue: "prod", StreamID: 10, Timestamp: maxTs, UncompressedSize: 300, ShardBucket: 3})
 
 	sections := flushAndOpenSections(t, b)
 	require.Len(t, sections, 1)
@@ -666,6 +670,8 @@ func TestBuilder_ObserveLabelPosting(t *testing.T) {
 			"uncompressed_size.int64": int64(600),
 			"min_timestamp.timestamp": minTs,
 			"max_timestamp.timestamp": maxTs,
+			"min_shard_bucket.int64":  int64(1),
+			"max_shard_bucket.int64":  int64(5),
 		},
 	}
 

--- a/pkg/dataobj/sections/postings/encode_columnar.go
+++ b/pkg/dataobj/sections/postings/encode_columnar.go
@@ -121,7 +121,7 @@ func (p *postingsEncoder) writeSection(w dataobj.SectionWriter, tenant string, b
 // encodeColumns encodes bloom and label entries into the provided columnar
 // encoder. Bloom entries (Kind=0) first, label entries (Kind=1) second.
 func (p *postingsEncoder) encodeColumns(bloomEntries []BloomEntry, labelEntries []LabelEntry, enc *columnar.Encoder) error {
-	// Build column builders for all 11 columns.
+	// Build column builders for all 13 columns.
 
 	// kind is a 2-value flag (0=bloom, 1=label). With sorted rows (blooms first,
 	// then labels), deltas are almost all zeros — ZSTD compresses these runs very
@@ -202,6 +202,16 @@ func (p *postingsEncoder) encodeColumns(bloomEntries []BloomEntry, labelEntries 
 		return fmt.Errorf("creating max_timestamp column: %w", err)
 	}
 
+	minShardBucketBuilder, err := numberColumnBuilder(ColumnTypeMinShardBucket, p.pageSizeHint, p.pageMaxRowCount)
+	if err != nil {
+		return fmt.Errorf("creating min_shard_bucket column: %w", err)
+	}
+
+	maxShardBucketBuilder, err := numberColumnBuilder(ColumnTypeMaxShardBucket, p.pageSizeHint, p.pageMaxRowCount)
+	if err != nil {
+		return fmt.Errorf("creating max_shard_bucket column: %w", err)
+	}
+
 	// Populate column builders: bloom entries first (Kind=0), then label entries (Kind=1).
 	rowIdx := 0
 
@@ -217,6 +227,8 @@ func (p *postingsEncoder) encodeColumns(bloomEntries []BloomEntry, labelEntries 
 		_ = uncompressedSizeBuilder.Append(rowIdx, dataset.Int64Value(e.UncompressedSize))
 		_ = minTimestampBuilder.Append(rowIdx, dataset.Int64Value(e.MinTimestamp))
 		_ = maxTimestampBuilder.Append(rowIdx, dataset.Int64Value(e.MaxTimestamp))
+		_ = minShardBucketBuilder.Append(rowIdx, dataset.Value{}) // null for bloom
+		_ = maxShardBucketBuilder.Append(rowIdx, dataset.Value{}) // null for bloom
 		rowIdx++
 	}
 
@@ -232,6 +244,8 @@ func (p *postingsEncoder) encodeColumns(bloomEntries []BloomEntry, labelEntries 
 		_ = uncompressedSizeBuilder.Append(rowIdx, dataset.Int64Value(e.UncompressedSize))
 		_ = minTimestampBuilder.Append(rowIdx, dataset.Int64Value(e.MinTimestamp))
 		_ = maxTimestampBuilder.Append(rowIdx, dataset.Int64Value(e.MaxTimestamp))
+		_ = minShardBucketBuilder.Append(rowIdx, dataset.Int64Value(int64(e.MinShardBucket)))
+		_ = maxShardBucketBuilder.Append(rowIdx, dataset.Int64Value(int64(e.MaxShardBucket)))
 		rowIdx++
 	}
 
@@ -246,7 +260,7 @@ func (p *postingsEncoder) encodeColumns(bloomEntries []BloomEntry, labelEntries 
 	}})
 
 	// Encode all columns.
-	errs := make([]error, 0, 11)
+	errs := make([]error, 0, 13)
 	errs = append(errs, encodeColumn(enc, ColumnTypeKind, kindBuilder))
 	errs = append(errs, encodeColumn(enc, ColumnTypeObjectPath, objectPathBuilder))
 	errs = append(errs, encodeColumn(enc, ColumnTypeShardBuckets, shardBucketsBuilder))
@@ -258,6 +272,8 @@ func (p *postingsEncoder) encodeColumns(bloomEntries []BloomEntry, labelEntries 
 	errs = append(errs, encodeColumn(enc, ColumnTypeUncompressedSize, uncompressedSizeBuilder))
 	errs = append(errs, encodeColumn(enc, ColumnTypeMinTimestamp, minTimestampBuilder))
 	errs = append(errs, encodeColumn(enc, ColumnTypeMaxTimestamp, maxTimestampBuilder))
+	errs = append(errs, encodeColumn(enc, ColumnTypeMinShardBucket, minShardBucketBuilder))
+	errs = append(errs, encodeColumn(enc, ColumnTypeMaxShardBucket, maxShardBucketBuilder))
 
 	if err := errors.Join(errs...); err != nil {
 		return fmt.Errorf("encoding columns: %w", err)

--- a/pkg/dataobj/sections/postings/encode_columnar.go
+++ b/pkg/dataobj/sections/postings/encode_columnar.go
@@ -80,12 +80,12 @@ func encodeInSections[E any](entries []E, target int, sizeOf func(E) int, emit f
 
 // bloomEntrySize estimates the encoded size of one bloom entry.
 func bloomEntrySize(e BloomEntry) int {
-	return 6*8 + len(e.ObjectPath) + len(e.ColumnName) + len(e.BloomFilter) + len(e.StreamIDBitmap)
+	return 5*8 + len(e.ObjectPath) + len(e.ColumnName) + len(e.BloomFilter) + len(e.StreamIDBitmap)
 }
 
 // labelEntrySize estimates the encoded size of one label entry.
 func labelEntrySize(e LabelEntry) int {
-	return 6*8 + len(e.ObjectPath) + len(e.ColumnName) + len(e.LabelValue) + len(e.StreamIDBitmap)
+	return 7*8 + len(e.ObjectPath) + len(e.ColumnName) + len(e.LabelValue) + len(e.StreamIDBitmap)
 }
 
 // trimTrailingZeros returns b with trailing zero bytes removed. Stream-ID

--- a/pkg/dataobj/sections/postings/label_aggregator.go
+++ b/pkg/dataobj/sections/postings/label_aggregator.go
@@ -25,6 +25,8 @@ type labelPostingEntry struct {
 	MinTimestamp     int64
 	MaxTimestamp     int64
 	UncompressedSize int64
+	MinShardBucket   uint32
+	MaxShardBucket   uint32
 }
 
 // BitmapBytes returns the raw bytes of the bitmap trimmed to the logical size
@@ -76,14 +78,16 @@ func (a *labelAggregator) Observe(obs LabelObservation) {
 	entry, ok := a.entries[key]
 	if !ok {
 		entry = &labelPostingEntry{
-			ObjectPath:   obs.ObjectPath,
-			ShardBuckets: obs.ShardBuckets,
-			SectionIndex: obs.SectionIndex,
-			ColumnName:   obs.ColumnName,
-			LabelValue:   obs.LabelValue,
-			bitmap:       memory.NewBitmap(nil, 0),
-			MinTimestamp: tsNano,
-			MaxTimestamp: tsNano,
+			ObjectPath:     obs.ObjectPath,
+			ShardBuckets:   obs.ShardBuckets,
+			SectionIndex:   obs.SectionIndex,
+			ColumnName:     obs.ColumnName,
+			LabelValue:     obs.LabelValue,
+			bitmap:         memory.NewBitmap(nil, 0),
+			MinTimestamp:   tsNano,
+			MaxTimestamp:   tsNano,
+			MinShardBucket: obs.ShardBucket,
+			MaxShardBucket: obs.ShardBucket,
 		}
 		a.entries[key] = entry
 
@@ -108,6 +112,12 @@ func (a *labelAggregator) Observe(obs LabelObservation) {
 	if tsNano > entry.MaxTimestamp {
 		entry.MaxTimestamp = tsNano
 	}
+	if obs.ShardBucket < entry.MinShardBucket {
+		entry.MinShardBucket = obs.ShardBucket
+	}
+	if obs.ShardBucket > entry.MaxShardBucket {
+		entry.MaxShardBucket = obs.ShardBucket
+	}
 	entry.UncompressedSize += obs.UncompressedSize
 }
 
@@ -130,6 +140,8 @@ func (a *labelAggregator) Entries() []LabelEntry {
 			MinTimestamp:     entry.MinTimestamp,
 			MaxTimestamp:     entry.MaxTimestamp,
 			UncompressedSize: entry.UncompressedSize,
+			MinShardBucket:   entry.MinShardBucket,
+			MaxShardBucket:   entry.MaxShardBucket,
 		})
 	}
 	return result

--- a/pkg/dataobj/sections/postings/label_aggregator.go
+++ b/pkg/dataobj/sections/postings/label_aggregator.go
@@ -91,8 +91,8 @@ func (a *labelAggregator) Observe(obs LabelObservation) {
 		}
 		a.entries[key] = entry
 
-		// Track size for new entry: 6 int64 fields + string sizes
-		a.estimatedSize += 6*8 + len(obs.ObjectPath) + len(obs.ColumnName) + len(obs.LabelValue)
+		// Track size for new entry: 5 int64 fields + 2 uint32 fields encoded as int64 + string sizes
+		a.estimatedSize += 7*8 + len(obs.ObjectPath) + len(obs.ColumnName) + len(obs.LabelValue)
 	}
 
 	// Grow bitmap if needed and set the bit for this stream ID.

--- a/pkg/dataobj/sections/postings/label_aggregator_test.go
+++ b/pkg/dataobj/sections/postings/label_aggregator_test.go
@@ -45,3 +45,16 @@ func TestLabelAggregator_TimeRange_ObserveAtUnixEpoch(t *testing.T) {
 	require.Equal(t, epoch, gotMin)
 	require.Equal(t, epoch, gotMax)
 }
+
+func TestLabelAggregator_ShardBucketRange(t *testing.T) {
+	a := newLabelAggregator()
+	ts := time.Unix(1, 0).UTC()
+	a.Observe(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x", StreamID: 1, Timestamp: ts, ShardBucket: 4})
+	a.Observe(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x", StreamID: 2, Timestamp: ts, ShardBucket: 1})
+	a.Observe(LabelObservation{ObjectPath: "/a", SectionIndex: 0, ColumnName: "app", LabelValue: "x", StreamID: 3, Timestamp: ts, ShardBucket: 9})
+
+	entries := a.Entries()
+	require.Len(t, entries, 1)
+	require.Equal(t, uint32(1), entries[0].MinShardBucket)
+	require.Equal(t, uint32(9), entries[0].MaxShardBucket)
+}

--- a/pkg/dataobj/sections/postings/merge_builder_test.go
+++ b/pkg/dataobj/sections/postings/merge_builder_test.go
@@ -59,6 +59,8 @@ func TestMergeBuilder_AppendLabelEntry_RoundTrip(t *testing.T) {
 			"uncompressed_size.int64": int64(4096),
 			"min_timestamp.timestamp": timeVal,
 			"max_timestamp.timestamp": timeVal,
+			"min_shard_bucket.int64":  int64(0),
+			"max_shard_bucket.int64":  int64(0),
 		},
 	}
 
@@ -126,6 +128,8 @@ func TestMergeBuilder_AppendBloomEntry_RoundTrip(t *testing.T) {
 			"uncompressed_size.int64": int64(8192),
 			"min_timestamp.timestamp": timeVal,
 			"max_timestamp.timestamp": timeVal,
+			"min_shard_bucket.int64":  nil,
+			"max_shard_bucket.int64":  nil,
 		},
 	}
 

--- a/pkg/dataobj/sections/postings/observation.go
+++ b/pkg/dataobj/sections/postings/observation.go
@@ -11,7 +11,7 @@ import "time"
 type LabelObservation struct {
 	// ObjectPath is the path of the data object that originated this posting.
 	ObjectPath string
-	// ShardBuckets is the number of shard buckets used by ObjectPath.
+	// ShardBuckets is the total number of shard buckets used by ObjectPath.
 	ShardBuckets int64
 	// SectionIndex is the index of the logs section within ObjectPath.
 	SectionIndex int64
@@ -27,6 +27,8 @@ type LabelObservation struct {
 	// produced the observation. It is summed across all observations in the
 	// aggregated posting.
 	UncompressedSize int64
+	// The shard bucket associated with the log stream being observed.
+	ShardBucket uint32
 }
 
 // BloomObservation describes a single observation of a bloom posting (a

--- a/pkg/dataobj/sections/postings/postings.go
+++ b/pkg/dataobj/sections/postings/postings.go
@@ -34,6 +34,8 @@ const (
 	ColumnTypeUncompressedSize                   // "uncompressed_size"
 	ColumnTypeMinTimestamp                       // "min_timestamp"
 	ColumnTypeMaxTimestamp                       // "max_timestamp"
+	ColumnTypeMinShardBucket                     // "min_shard_bucket"
+	ColumnTypeMaxShardBucket                     // "max_shard_bucket"
 )
 
 var columnTypeNames = map[ColumnType]string{
@@ -49,6 +51,8 @@ var columnTypeNames = map[ColumnType]string{
 	ColumnTypeUncompressedSize: "uncompressed_size",
 	ColumnTypeMinTimestamp:     "min_timestamp",
 	ColumnTypeMaxTimestamp:     "max_timestamp",
+	ColumnTypeMinShardBucket:   "min_shard_bucket",
+	ColumnTypeMaxShardBucket:   "max_shard_bucket",
 }
 
 // ParseColumnType parses a [ColumnType] from a string. The expected string
@@ -79,6 +83,10 @@ func ParseColumnType(text string) (ColumnType, error) {
 		return ColumnTypeMinTimestamp, nil
 	case "max_timestamp":
 		return ColumnTypeMaxTimestamp, nil
+	case "min_shard_bucket":
+		return ColumnTypeMinShardBucket, nil
+	case "max_shard_bucket":
+		return ColumnTypeMaxShardBucket, nil
 	}
 	return ColumnTypeInvalid, fmt.Errorf("invalid column type %q", text)
 }
@@ -130,6 +138,9 @@ type LabelEntry struct {
 	MaxTimestamp int64
 	// UncompressedSize is the total uncompressed size in bytes.
 	UncompressedSize int64
+	// MinShardBucket and MaxShardBucket are the minimum and maximum shard buckets observed within this posting.
+	MinShardBucket uint32
+	MaxShardBucket uint32
 }
 
 // BloomEntry represents an aggregated bloom posting entry that can be

--- a/pkg/dataobj/sections/postings/postings.go
+++ b/pkg/dataobj/sections/postings/postings.go
@@ -138,8 +138,9 @@ type LabelEntry struct {
 	MaxTimestamp int64
 	// UncompressedSize is the total uncompressed size in bytes.
 	UncompressedSize int64
-	// MinShardBucket and MaxShardBucket are the minimum and maximum shard buckets observed within this posting.
+	// MinShardBucket is the minimum shard bucket observed within ObjectPath & SectionIndex.
 	MinShardBucket uint32
+	// MaxShardBucket is the maximum shard bucket observed within ObjectPath & SectionIndex.
 	MaxShardBucket uint32
 }
 

--- a/pkg/dataobj/sections/postings/reader.go
+++ b/pkg/dataobj/sections/postings/reader.go
@@ -269,6 +269,8 @@ var columnDatatypes = map[ColumnType]arrow.DataType{
 	ColumnTypeUncompressedSize: arrow.PrimitiveTypes.Int64,
 	ColumnTypeMinTimestamp:     arrow.FixedWidthTypes.Timestamp_ns,
 	ColumnTypeMaxTimestamp:     arrow.FixedWidthTypes.Timestamp_ns,
+	ColumnTypeMinShardBucket:   arrow.PrimitiveTypes.Int64,
+	ColumnTypeMaxShardBucket:   arrow.PrimitiveTypes.Int64,
 }
 
 func columnToField(col *Column) arrow.Field {

--- a/pkg/dataobj/sections/postings/reader_test.go
+++ b/pkg/dataobj/sections/postings/reader_test.go
@@ -72,6 +72,8 @@ func TestReader_RoundTrip(t *testing.T) {
 	require.Equal(t, int64(100), row["uncompressed_size.int64"])
 	require.Equal(t, ts.UTC(), row["min_timestamp.timestamp"])
 	require.Equal(t, ts.UTC(), row["max_timestamp.timestamp"])
+	require.Equal(t, int64(0), row["min_shard_bucket.int64"])
+	require.Equal(t, int64(0), row["max_shard_bucket.int64"])
 }
 
 // readTable drains a Reader into an arrow.Table, mirroring the helper in

--- a/pkg/dataobj/sections/postings/row.go
+++ b/pkg/dataobj/sections/postings/row.go
@@ -37,6 +37,8 @@ type Row struct {
 	UncompressedSize int64
 	MinTimestamp     int64 // unix nanos
 	MaxTimestamp     int64 // unix nanos
+	MinShardBucket   uint32
+	MaxShardBucket   uint32
 }
 
 // LabelEntry converts the Row to a [LabelEntry]. The caller should only call
@@ -52,6 +54,8 @@ func (r Row) LabelEntry() LabelEntry {
 		MinTimestamp:     r.MinTimestamp,
 		MaxTimestamp:     r.MaxTimestamp,
 		UncompressedSize: r.UncompressedSize,
+		MinShardBucket:   r.MinShardBucket,
+		MaxShardBucket:   r.MaxShardBucket,
 	}
 }
 
@@ -85,6 +89,8 @@ func (e LabelEntry) Row() Row {
 		MinTimestamp:     e.MinTimestamp,
 		MaxTimestamp:     e.MaxTimestamp,
 		UncompressedSize: e.UncompressedSize,
+		MinShardBucket:   e.MinShardBucket,
+		MaxShardBucket:   e.MaxShardBucket,
 	}
 }
 
@@ -178,6 +184,14 @@ func DecodeRow(batch arrow.RecordBatch, columns ColumnIndex, rowIndex int) Row {
 
 	if col := getColumn("max_timestamp.timestamp"); col != nil && !col.IsNull(rowIndex) {
 		result.MaxTimestamp = int64(col.(*array.Timestamp).Value(rowIndex))
+	}
+
+	if col := getColumn("min_shard_bucket.int64"); col != nil && !col.IsNull(rowIndex) {
+		result.MinShardBucket = uint32(col.(*array.Int64).Value(rowIndex))
+	}
+
+	if col := getColumn("max_shard_bucket.int64"); col != nil && !col.IsNull(rowIndex) {
+		result.MaxShardBucket = uint32(col.(*array.Int64).Value(rowIndex))
 	}
 
 	return result


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds min-max shard-bucket to the postings section (low-level encoding & read support)

This is required so planning can skip sections which definitely don't contain any information for the given shard, rather than needing to fetch the stream section to filter them out later.

The writing of this field from the index-builder will come in a separate PR.