### PR TITLE
chore: Add new code to parse uncompressed proto from []byte

### DIFF
--- a/pkg/util/proto.go
+++ b/pkg/util/proto.go
@@ -1,0 +1,17 @@
+package util //nolint:revive
+
+import (
+	"github.com/gogo/protobuf/proto"
+)
+
+// ParseProto unmarshals a decompressed proto message body into req.
+//
+// We re-implement proto.Unmarshal here as it calls XXX_Unmarshal first,
+// which we can't override without upsetting golint.
+func ParseProto(body []byte, req proto.Message) error {
+	req.Reset()
+	if u, ok := req.(proto.Unmarshaler); ok {
+		return u.Unmarshal(body)
+	}
+	return proto.NewBuffer(body).Unmarshal(req)
+}

--- a/pkg/util/proto_test.go
+++ b/pkg/util/proto_test.go
@@ -1,0 +1,39 @@
+package util_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/util"
+)
+
+func TestParseProto(t *testing.T) {
+	req := &logproto.PushRequest{
+		Streams: []logproto.Stream{
+			{
+				Labels:  `{foo="bar"}`,
+				Entries: []logproto.Entry{{Timestamp: time.Unix(0, 1).UTC(), Line: "line1"}},
+			},
+		},
+	}
+
+	t.Run("valid proto", func(t *testing.T) {
+		body, err := req.Marshal()
+		require.NoError(t, err)
+
+		var fromWire logproto.PushRequest
+		err = util.ParseProto(body, &fromWire)
+		assert.NoError(t, err)
+		assert.Equal(t, req, &fromWire)
+	})
+
+	t.Run("invalid proto", func(t *testing.T) {
+		var fromWire logproto.PushRequest
+		err := util.ParseProto([]byte{0xff, 0xff, 0xff}, &fromWire)
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The Push path has a lot of duplicate code between pkg/loghttp and pkg/util when it comes to reading, decompression and decoding push requests in its various formats: snappy + protobuf, JSON + push, JSON + OTEL, and all the various compression types.

This is the first step in cleaning it up, where we have functions just to decode protobuf from []byte, and move the reading, decompression and decoding elsewhere.

This code has been extracted from `pkg/util/http.go`.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
