### PR TITLE
refactor(storage): Simplify NewChunkClient

### DIFF
--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -249,6 +249,11 @@ func (ns *NamedStores) Validate() error {
 	return ns.populateStoreType()
 }
 
+func (ns *NamedStores) LookupStoreType(name string) (string, bool) {
+	st, ok := ns.storeType[name]
+	return st, ok
+}
+
 func (ns *NamedStores) Exists(name string) bool {
 	_, ok := ns.storeType[name]
 	return ok
@@ -347,35 +352,30 @@ func (cfg *Config) Validate() error {
 // NewChunkClient makes a new chunk.Client of the desired types.
 func NewChunkClient(name, component string, cfg Config, schemaCfg config.SchemaConfig, p config.PeriodConfig, registerer prometheus.Registerer, clientMetrics ClientMetrics, logger log.Logger) (client.Client, error) {
 	storeType := name
-	if st, ok := cfg.ObjectStore.NamedStores.LookupStoreType(name); ok {
+	if st, ok := cfg.ObjectStore.NamedStores.LookupStoreType(name); cfg.UseThanosObjstore && ok {
+		storeType = st
+	} else if st, ok := cfg.NamedStores.LookupStoreType(name); !cfg.UseThanosObjstore && ok {
 		storeType = st
 	}
 
-	switch storeType {
-	case types.StorageTypeFileSystem:
-		c, err := NewObjectClient(name, component, cfg, clientMetrics)
-		if err != nil {
-			return nil, err
-		}
-		return client.NewClientWithMaxParallel(c, client.FSEncoder, cfg.MaxParallelGetChunk, schemaCfg), nil
-
-	case types.StorageTypeAWS, types.StorageTypeS3, types.StorageTypeAzure, types.StorageTypeBOS, types.StorageTypeSwift, types.StorageTypeCOS, types.StorageTypeAlibabaCloud, types.StorageTypeGCS:
-		c, err := NewObjectClient(name, component, cfg, clientMetrics)
-		if err != nil {
-			return nil, err
-		}
-		if ccCfg := cfg.CongestionControl; ccCfg.Enabled {
-			cc := congestion.NewController(
-				ccCfg,
-				logger,
-				congestion.NewMetrics(fmt.Sprintf("%s-%s", name, p.From.String()), ccCfg),
-			)
-			c = cc.Wrap(c)
-		}
-		return client.NewClientWithMaxParallel(c, nil, cfg.MaxParallelGetChunk, schemaCfg), nil
+	c, err := NewObjectClient(name, component, cfg, clientMetrics)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, fmt.Errorf("unrecognized chunk client type %s, choose one of: %s", name, strings.Join(types.SupportedStorageTypes, ", "))
+	if storeType == types.StorageTypeFileSystem {
+		return client.NewClientWithMaxParallel(c, client.FSEncoder, cfg.MaxParallelGetChunk, schemaCfg), nil
+	}
+
+	if ccCfg := cfg.CongestionControl; ccCfg.Enabled {
+		cc := congestion.NewController(
+			ccCfg,
+			logger,
+			congestion.NewMetrics(fmt.Sprintf("%s-%s", name, p.From.String()), ccCfg),
+		)
+		c = cc.Wrap(c)
+	}
+	return client.NewClientWithMaxParallel(c, nil, cfg.MaxParallelGetChunk, schemaCfg), nil
 }
 
 type ClientMetrics struct {

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -33,7 +33,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads"
 	"github.com/grafana/loki/v3/pkg/storage/types"
-	"github.com/grafana/loki/v3/pkg/util"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
 )
 
@@ -347,84 +346,33 @@ func (cfg *Config) Validate() error {
 
 // NewChunkClient makes a new chunk.Client of the desired types.
 func NewChunkClient(name, component string, cfg Config, schemaCfg config.SchemaConfig, p config.PeriodConfig, registerer prometheus.Registerer, clientMetrics ClientMetrics, logger log.Logger) (client.Client, error) {
-	var cc congestion.Controller
-	ccCfg := cfg.CongestionControl
-
-	if ccCfg.Enabled {
-		cc = congestion.NewController(
-			ccCfg,
-			logger,
-			congestion.NewMetrics(fmt.Sprintf("%s-%s", name, p.From.String()), ccCfg),
-		)
+	storeType := name
+	if st, ok := cfg.ObjectStore.NamedStores.LookupStoreType(name); ok {
+		storeType = st
 	}
 
-	var storeType = name
-
-	if cfg.UseThanosObjstore {
-		// Check if this is a named store and get its type
-		if st, ok := cfg.ObjectStore.NamedStores.LookupStoreType(name); ok {
-			storeType = st
-		}
-
-		var (
-			c   client.ObjectClient
-			err error
-		)
-		c, err = NewObjectClient(name, component, cfg, clientMetrics)
+	switch storeType {
+	case types.StorageTypeFileSystem:
+		c, err := NewObjectClient(name, component, cfg, clientMetrics)
 		if err != nil {
 			return nil, err
 		}
+		return client.NewClientWithMaxParallel(c, client.FSEncoder, cfg.MaxParallelGetChunk, schemaCfg), nil
 
-		var encoder client.KeyEncoder
-		if storeType == bucket.Filesystem {
-			encoder = client.FSEncoder
-		} else if cfg.CongestionControl.Enabled {
-			// Apply congestion control wrapper for non-filesystem storage
+	case types.StorageTypeAWS, types.StorageTypeS3, types.StorageTypeAzure, types.StorageTypeBOS, types.StorageTypeSwift, types.StorageTypeCOS, types.StorageTypeAlibabaCloud, types.StorageTypeGCS:
+		c, err := NewObjectClient(name, component, cfg, clientMetrics)
+		if err != nil {
+			return nil, err
+		}
+		if ccCfg := cfg.CongestionControl; ccCfg.Enabled {
+			cc := congestion.NewController(
+				ccCfg,
+				logger,
+				congestion.NewMetrics(fmt.Sprintf("%s-%s", name, p.From.String()), ccCfg),
+			)
 			c = cc.Wrap(c)
 		}
-
-		return client.NewClientWithMaxParallel(c, encoder, cfg.MaxParallelGetChunk, schemaCfg), nil
-	}
-
-	// lookup storeType for named stores
-	if nsType, ok := cfg.NamedStores.storeType[name]; ok {
-		storeType = nsType
-	}
-
-	switch true {
-
-	case util.StringsContain(types.SupportedStorageTypes, storeType):
-		switch storeType {
-		case types.StorageTypeFileSystem:
-			c, err := NewObjectClient(name, component, cfg, clientMetrics)
-			if err != nil {
-				return nil, err
-			}
-			return client.NewClientWithMaxParallel(c, client.FSEncoder, cfg.MaxParallelGetChunk, schemaCfg), nil
-
-		case types.StorageTypeAWS, types.StorageTypeS3, types.StorageTypeAzure, types.StorageTypeBOS, types.StorageTypeSwift, types.StorageTypeCOS, types.StorageTypeAlibabaCloud:
-			c, err := NewObjectClient(name, component, cfg, clientMetrics)
-			if err != nil {
-				return nil, err
-			}
-			if cfg.CongestionControl.Enabled {
-				c = cc.Wrap(c)
-			}
-			return client.NewClientWithMaxParallel(c, nil, cfg.MaxParallelGetChunk, schemaCfg), nil
-
-		case types.StorageTypeGCS:
-			c, err := NewObjectClient(name, component, cfg, clientMetrics)
-			if err != nil {
-				return nil, err
-			}
-			// TODO(dannyk): expand congestion control to all other object clients
-			// this switch statement can be simplified; all the branches like this one are alike
-			if cfg.CongestionControl.Enabled {
-				c = cc.Wrap(c)
-			}
-			return client.NewClientWithMaxParallel(c, nil, cfg.MaxParallelGetChunk, schemaCfg), nil
-		}
-
+		return client.NewClientWithMaxParallel(c, nil, cfg.MaxParallelGetChunk, schemaCfg), nil
 	}
 
 	return nil, fmt.Errorf("unrecognized chunk client type %s, choose one of: %s", name, strings.Join(types.SupportedStorageTypes, ", "))

--- a/pkg/storage/factory_test.go
+++ b/pkg/storage/factory_test.go
@@ -91,7 +91,7 @@ func TestNamedStores(t *testing.T) {
 		schemaConfig.Configs[0].ObjectType = "not-found"
 		_, err := NewStore(cfg, config.ChunkStoreConfig{}, schemaConfig, limits, cm, nil, util_log.Logger, constants.Loki)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "unrecognized chunk client type not-found, choose one of:")
+		require.Contains(t, err.Error(), "Unrecognized storage client not-found, choose one of:")
 	})
 }
 


### PR DESCRIPTION
**What this PR does**:
`NewChunkClient` had two parallel code paths for building the underlying object client: a `UseThanosObjstore` branch that called `NewObjectClient` directly, and a legacy `NamedStores.storeType`/`util.StringsContain` switch with a separate, near-duplicate case for GCS (flagged with a `TODO(dannyk): ... this switch statement can be simplified` comment). Since `NewObjectClient` already handles the thanos-vs-legacy split internally, `NewChunkClient` doesn't need to branch on `UseThanosObjstore` itself — I dropped the redundant legacy path and merged the GCS case in with the other object store types.

No behavior change intended.