### PR TITLE
chore: Add new code to decompress the request body

### DIFF
--- a/pkg/loghttp/push/http.go
+++ b/pkg/loghttp/push/http.go
@@ -1,0 +1,158 @@
+package push
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/golang/snappy"
+	"github.com/klauspost/compress/zstd"
+	"github.com/pierrec/lz4/v4"
+)
+
+var (
+	ErrContentTooLarge            = errors.New("content exceeds maximum size")
+	ErrUnsupportedContentEncoding = errors.New("unsupported content encoding")
+)
+
+// readBody reads the full request body from r. If it is encoded (i.e. with
+// gzip, snappy, etc) then the decompressed body is returned instead. It
+// supports an optional limit that caps the maximum size of the plain and
+// the decompressed body, and returns an error if this limit is exceeded.
+// A value of 0 means no limit.
+func readBody(r *http.Request, limit int64) ([]byte, error) {
+	contentEncValue := r.Header.Get(contentEnc)
+	switch contentEncValue {
+	case "deflate", "gzip", "lz4", "zstd":
+		return decompressReader(r.Body, contentEncValue, limit)
+	case "snappy":
+		// Unlike other content encs, block-compressed snappy cannot be decoded from
+		// an io.Reader. It has a special method to handle this.
+		return decompressReaderSnappy(r.Body, limit)
+	case "":
+		return readPlain(r.Body, limit)
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedContentEncoding, contentEncValue)
+	}
+}
+
+// readPlain reads the plain text from r.
+func readPlain(r io.Reader, limit int64) ([]byte, error) {
+	// If r is a bytes.Buffer then we don't need to copy it.
+	buf, ok := readFromNoCopy(r)
+	if !ok {
+		if limit > 0 {
+			r = io.LimitReader(r, limit+1)
+		}
+		buf = new(bytes.Buffer)
+		_, err := buf.ReadFrom(r)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if limit > 0 && int64(buf.Len()) > limit {
+		return nil, fmt.Errorf("%w: %d", ErrContentTooLarge, limit)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// decompressReader decompresses the data in r based on the content enc.
+// Supported encs include deflate, gzip, lz4, zstd, and "".
+func decompressReader(r io.Reader, contentEncValue string, limit int64) ([]byte, error) {
+	rc, err := wrapDecoder(r, contentEncValue)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	if limit > 0 {
+		rc = io.NopCloser(io.LimitReader(rc, limit+1))
+	}
+
+	buf := bytes.Buffer{}
+	_, err = buf.ReadFrom(rc)
+	if err != nil {
+		return nil, err
+	}
+
+	if limit > 0 && int64(buf.Len()) > limit {
+		return nil, fmt.Errorf("%w: %d", ErrContentTooLarge, limit)
+	}
+
+	return buf.Bytes(), err
+}
+
+func decompressReaderSnappy(r io.Reader, limit int64) ([]byte, error) {
+	// Unlike other readers, snappy can only decode block-compressed data from an
+	// []byte. That means we must read the entire body before we can start to
+	// decompress it.
+	buf, ok := readFromNoCopy(r)
+	if !ok {
+		if limit > 0 {
+			r = io.LimitReader(r, limit+1)
+		}
+		buf = new(bytes.Buffer)
+		_, err := buf.ReadFrom(r)
+		if err != nil {
+			return nil, err
+		}
+	}
+	src := buf.Bytes()
+
+	// Check the raw size.
+	if limit > 0 && int64(len(src)) > limit {
+		return nil, fmt.Errorf("%w: %d", ErrContentTooLarge, limit)
+	}
+
+	// Check the decompressed size.
+	if limit > 0 {
+		if n, err := snappy.DecodedLen(src); err != nil {
+			return nil, err
+		} else if int64(n) > limit {
+			return nil, fmt.Errorf("%w: %d", ErrContentTooLarge, limit)
+		}
+	}
+
+	return snappy.Decode(nil, src)
+}
+
+// wrapDecoder returns an io.ReadCloser that decompresses r.
+func wrapDecoder(r io.Reader, contentEncValue string) (io.ReadCloser, error) {
+	switch contentEncValue {
+	case "deflate":
+		return flate.NewReader(r), nil
+	case "gzip":
+		return gzip.NewReader(r)
+	case "lz4":
+		return io.NopCloser(lz4.NewReader(r)), nil
+	case "zstd":
+		zstdReader, err := zstd.NewReader(r)
+		if err != nil {
+			return nil, err
+		}
+		return zstdReader.IOReadCloser(), nil
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedContentEncoding, contentEncValue)
+	}
+}
+
+// readFromNoCopy checks if r is a bytes.Buffer and if it is returns a pointer
+// to it. If r is any other type it returns false.
+func readFromNoCopy(r io.Reader) (*bytes.Buffer, bool) {
+	// If the request came from httpgrpc instead of net/http, r.Body is already
+	// buffered. We know if this is the case because r.Body implements the
+	// bytesBuffer interface.
+	type bytesBuffer interface {
+		BytesBuffer() *bytes.Buffer
+	}
+	if bytesBuf, ok := r.(bytesBuffer); ok {
+		return bytesBuf.BytesBuffer(), true
+	}
+	return nil, false
+}

--- a/pkg/loghttp/push/http_test.go
+++ b/pkg/loghttp/push/http_test.go
@@ -1,0 +1,227 @@
+package push
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/golang/snappy"
+	"github.com/klauspost/compress/zstd"
+	"github.com/pierrec/lz4/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadBody(t *testing.T) {
+	t.Run("can read a plain body", func(t *testing.T) {
+		data := []byte("the quick brown fox")
+		r := newRequest(t, "", bytes.NewReader(data))
+		actual, err := readBody(r, 0)
+		require.NoError(t, err)
+		require.Equal(t, data, actual)
+		// Should be false since readBody copies the data.
+		require.NotSame(t, &data[0], &actual[0])
+	})
+
+	t.Run("can read a nocopy plain body", func(t *testing.T) {
+		data := []byte("the quick brown fox")
+		buf := bytes.NewBuffer(data)
+		r := newRequest(t, "", &wrappedBytesBuffer{Buffer: buf})
+		actual, err := readBody(r, 0)
+		require.NoError(t, err)
+		require.Equal(t, data, actual)
+		// Should be true if readyBody returns a pointer to the buf instead of a copy.
+		require.Same(t, &data[0], &actual[0])
+	})
+
+	t.Run("can read a body encoded with gzip, deflate, snappy, lz4 and zstd", func(t *testing.T) {
+		for _, contentEncValue := range []string{"gzip", "deflate", "snappy", "lz4", "zstd"} {
+			t.Run(contentEncValue, func(t *testing.T) {
+				data := []byte(strings.Repeat("the quick brown fox ", 10))
+				b := compressWithContentEnc(t, contentEncValue, data)
+
+				r := newRequest(t, contentEncValue, bytes.NewReader(b))
+				actual, err := readBody(r, 0)
+				require.NoError(t, err)
+				require.Equal(t, data, actual)
+			})
+		}
+	})
+
+	t.Run("unsupported content encoding returns error", func(t *testing.T) {
+		r := newRequest(t, "bzip2", bytes.NewReader([]byte("data")))
+		_, err := readBody(r, 0)
+		require.Error(t, err)
+		require.EqualError(t, err, "unsupported content encoding: bzip2")
+	})
+
+	t.Run("corrupted data returns error", func(t *testing.T) {
+		for _, contentEncValue := range []string{"gzip", "deflate", "snappy", "lz4", "zstd"} {
+			t.Run(contentEncValue, func(t *testing.T) {
+				r := newRequest(t, contentEncValue, bytes.NewReader([]byte("invalid data")))
+				_, err := readBody(r, 0)
+				require.Error(t, err)
+			})
+		}
+	})
+
+	t.Run("reads the entire plain body", func(t *testing.T) {
+		data := bytes.Repeat([]byte("x"), 1000)
+		r := newRequest(t, "", bytes.NewReader(data))
+		actual, err := readBody(r, 0)
+		require.NoError(t, err)
+		require.Equal(t, data, actual)
+	})
+
+	t.Run("reads the entire plain body if within the limit", func(t *testing.T) {
+		data := bytes.Repeat([]byte("x"), 10)
+		r := newRequest(t, "", bytes.NewReader(data))
+		actual, err := readBody(r, 10)
+		require.NoError(t, err)
+		require.Equal(t, data, actual)
+	})
+
+	t.Run("returns error when plain body above the limit", func(t *testing.T) {
+		data := bytes.Repeat([]byte("x"), 11)
+		r := newRequest(t, "", bytes.NewReader(data))
+		_, err := readBody(r, 10)
+		require.Error(t, err)
+		require.EqualError(t, err, "content exceeds maximum size: 10")
+	})
+
+	t.Run("reads the entire encoded body if within the limit", func(t *testing.T) {
+		for _, contentEncValue := range []string{"gzip", "deflate", "snappy", "lz4", "zstd"} {
+			t.Run(contentEncValue, func(t *testing.T) {
+				data := bytes.Repeat([]byte("x"), 1000)
+				b := compressWithContentEnc(t, contentEncValue, data)
+
+				r := newRequest(t, contentEncValue, bytes.NewReader(b))
+				limit := int64(len(data))
+				actual, err := readBody(r, limit)
+				require.NoError(t, err)
+				require.Equal(t, data, actual)
+			})
+		}
+	})
+
+	t.Run("returns error when encoded body is above the limit", func(t *testing.T) {
+		for _, contentEncValue := range []string{"gzip", "deflate", "snappy", "lz4", "zstd"} {
+			t.Run(contentEncValue, func(t *testing.T) {
+				data := bytes.Repeat([]byte("x"), 1000)
+				b := compressWithContentEnc(t, contentEncValue, data)
+
+				r := newRequest(t, contentEncValue, bytes.NewReader(b))
+				limit := int64(len(data) - 1)
+				_, err := readBody(r, limit)
+				require.Error(t, err)
+				require.EqualError(t, err, fmt.Sprintf("content exceeds maximum size: %d", limit))
+			})
+		}
+	})
+
+	t.Run("snappy: returns error if encoded body is above the limit", func(t *testing.T) {
+		data := bytes.Repeat([]byte("x"), 100)
+		b := snappy.Encode(nil, data)
+		r := newRequest(t, "snappy", bytes.NewReader(b))
+		limit := int64(len(data) - 1)
+		_, err := readBody(r, limit)
+		require.EqualError(t, err, fmt.Sprintf("content exceeds maximum size: %d", limit))
+	})
+
+	t.Run("snappy: returns error if decoded body is above the limit", func(t *testing.T) {
+		data := bytes.Repeat([]byte("x"), 1000)
+		b := snappy.Encode(nil, data)
+		r := newRequest(t, "snappy", bytes.NewReader(b))
+		limit := int64(len(data) - 1)
+		_, err := readBody(r, limit)
+		require.EqualError(t, err, fmt.Sprintf("content exceeds maximum size: %d", limit))
+	})
+}
+
+// A wrapepdBytesBuffer copies how httpgrpc wraps a bytes.Buffer in its own
+// io.nopCloser.
+type wrappedBytesBuffer struct {
+	*bytes.Buffer
+}
+
+// BytesBuffer returns a pointer to the bytes.Buffer.
+func (b *wrappedBytesBuffer) BytesBuffer() *bytes.Buffer {
+	return b.Buffer
+}
+
+// Close implements io.Closer.
+func (b *wrappedBytesBuffer) Close() error {
+	return nil
+}
+
+func TestReadFromNoCopy(t *testing.T) {
+	t.Run("should return pointer to buf", func(t *testing.T) {
+		buf := bytes.Buffer{}
+		_, err := buf.Write([]byte("the quick brown fox"))
+		require.NoError(t, err)
+
+		wrappedBuf := wrappedBytesBuffer{Buffer: &buf}
+		actual, ok := readFromNoCopy(&wrappedBuf)
+		require.True(t, ok)
+		require.Equal(t, &buf, actual)
+	})
+
+	t.Run("should return false", func(t *testing.T) {
+		s := "the quick brown fox"
+		actual, ok := readFromNoCopy(strings.NewReader(s))
+		require.False(t, ok)
+		require.Nil(t, actual)
+	})
+}
+
+// compressWithContentEnc is a test helper that compresses the data with
+// contentEncValue. Supported values are gzip, deflate, snappy, lz4, and
+// zstd.
+func compressWithContentEnc(t *testing.T, contentEncValue string, data []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	switch contentEncValue {
+	case "gzip":
+		w := gzip.NewWriter(&buf)
+		_, err := w.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+	case "deflate":
+		w, err := flate.NewWriter(&buf, flate.DefaultCompression)
+		require.NoError(t, err)
+		_, err = w.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+	case "snappy":
+		return snappy.Encode(nil, data)
+	case "lz4":
+		w := lz4.NewWriter(&buf)
+		_, err := w.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+	case "zstd":
+		w, err := zstd.NewWriter(&buf)
+		require.NoError(t, err)
+		_, err = w.Write(data)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+	default:
+		t.Fatalf("unsupported encoding in test helper: %s", contentEncValue)
+	}
+	return buf.Bytes()
+}
+
+func newRequest(t *testing.T, contentEncValue string, body io.Reader) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/loki/api/v1/push", body)
+	if contentEncValue != "" {
+		r.Header.Set(contentEnc, contentEncValue)
+	}
+	return r
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The Push path has a lot of duplicate code, one of these is duplication around decompression. You will find the same code copy/pasted between loghttp/push.go, loghttp/otlp.go and pkg/util/http.go.

This adds two new files decompress.go and decompress_test.go that merges all of that behavior into a single place.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
