### PR TITLE
fix(logql): Allow PB/PiB byte-size literals in queries

### DIFF
--- a/docs/sources/query/log_queries/_index.md
+++ b/docs/sources/query/log_queries/_index.md
@@ -229,7 +229,7 @@ We support multiple **value** types which are automatically inferred from the qu
 - **String** is double quoted or backticked such as `"200"` or \``us-central1`\`.
 - **[Duration](https://golang.org/pkg/time/#ParseDuration)** is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "1.5h" or "2h45m". The query literal accepts the time units "ns", "us" (or "µs"), "ms", "s", "m", "h", "d", "w" and "y". The value of the label identifier used for comparison must be a string with a unit suffix to be parsed correctly, such as "0.10ms" or "1h30m", and only accepts "ns", "us" (or "µs"), "ms", "s", "m" and "h". Optionally, `label_format` can be used to modify the value and append the unit before making the comparison, for example to convert a "d", "w" or "y" value to one of those accepted units first.
 - **Number** are floating-point number (64bits), such as`250`, `89.923`.
-- **Bytes** is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as "42MB", "1.5KiB" or "20B". Valid bytes units are "B", "kB", "MB", "GB", "TB", "KB", "KiB", "MiB", "GiB", "TiB".
+- **Bytes** is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as "42MB", "1.5KiB" or "20B". Valid bytes units are "B", "kB", "MB", "GB", "TB", "PB", "KB", "KiB", "MiB", "GiB", "TiB", "PiB".
 
 String type work exactly like Prometheus label matchers use in [log stream selector](#log-stream-selector). This means you can use the same operations (`=`,`!=`,`=~`,`!~`).
 

--- a/pkg/logql/internal/logqltest/testdata/binary_operations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/binary_operations.logqltest
@@ -19,6 +19,22 @@ eval instant at 60s 10 % 3
   1
 eval instant at 60s 1+1--1
   3
+# Binary, octal, and integer hex numbers are not supported as scalar literals.
+eval instant at 60s 0b1010
+  expect fail msg: unable to parse literal as a float
+eval instant at 60s 0o17
+  expect fail msg: unable to parse literal as a float
+eval instant at 60s 0x1A
+  expect fail msg: unable to parse literal as a float
+# Hex floats are supported: they always have a 'p' exponent.
+eval instant at 60s 0x1p3
+  8
+eval instant at 60s 0X1p3
+  8
+eval instant at 60s 0x1P3
+  8
+eval instant at 60s 0x1.8p3
+  12
 # Division and modulo return NaN for a zero divisor, regardless of dividend sign.
 eval instant at 60s 10 / 0
   NaN

--- a/pkg/logql/internal/logqltest/testdata/conversions.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/conversions.logqltest
@@ -4,6 +4,13 @@ load
   {unit="kb"}    "b=1KB"      @ 10s [repeat every 10s for 18]
   {unit="kib"}   "b=1KiB"     @ 10s [repeat every 10s for 18]
   {unit="mb"}    "b=1MB"      @ 10s [repeat every 10s for 18]
+  {unit="mib"}   "b=1MiB"     @ 10s [repeat every 10s for 18]
+  {unit="gb"}    "b=1GB"      @ 10s [repeat every 10s for 18]
+  {unit="gib"}   "b=1GiB"     @ 10s [repeat every 10s for 18]
+  {unit="tb"}    "b=1TB"      @ 10s [repeat every 10s for 18]
+  {unit="tib"}   "b=1TiB"     @ 10s [repeat every 10s for 18]
+  {unit="pb"}    "b=1PB"      @ 10s [repeat every 10s for 18]
+  {unit="pib"}   "b=1PiB"     @ 10s [repeat every 10s for 18]
   {unit="dec"}   "b=1.5KB"    @ 10s [repeat every 10s for 18]
   {unit="bare"}  "b=1024"     @ 10s [repeat every 10s for 18]
   {unit="mixed"} "b=2Kb"      @ 10s [repeat every 10s for 18]
@@ -17,6 +24,13 @@ eval instant at 120s max_over_time({unit=~".+"} | logfmt | unwrap bytes(b) [1m])
   {unit="kb"}    1000
   {unit="kib"}   1024
   {unit="mb"}    1000000
+  {unit="mib"}   1048576
+  {unit="gb"}    1000000000
+  {unit="gib"}   1073741824
+  {unit="tb"}    1000000000000
+  {unit="tib"}   1099511627776
+  {unit="pb"}    1000000000000000
+  {unit="pib"}   1125899906842624
   {unit="dec"}   1500
   {unit="bare"}  1024
   {unit="mixed"} 2000
@@ -26,6 +40,13 @@ eval range from 60s to 180s step 60s max_over_time({unit=~".+"} | logfmt | unwra
   {unit="kb"}    1000 1000 1000
   {unit="kib"}   1024 1024 1024
   {unit="mb"}    1000000 1000000 1000000
+  {unit="mib"}   1048576 1048576 1048576
+  {unit="gb"}    1000000000 1000000000 1000000000
+  {unit="gib"}   1073741824 1073741824 1073741824
+  {unit="tb"}    1000000000000 1000000000000 1000000000000
+  {unit="tib"}   1099511627776 1099511627776 1099511627776
+  {unit="pb"}    1000000000000000 1000000000000000 1000000000000000
+  {unit="pib"}   1125899906842624 1125899906842624 1125899906842624
   {unit="dec"}   1500 1500 1500
   {unit="bare"}  1024 1024 1024
   {unit="mixed"} 2000 2000 2000

--- a/pkg/logql/internal/logqltest/testdata/label_filters.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/label_filters.logqltest
@@ -511,21 +511,70 @@ eval range from 60s to 180s step 120s count_over_time({app="a"} | logfmt | took 
 # bytes label filter.
 clear
 load
-  {app="p"}               "size=3MB"       @ 20s [repeat every 20s for 4]
-  {app="p"}               "size=500KB"     @ 30s [repeat every 20s for 2]
+  {app="p"}               "size=3MB"      @ 20s [repeat every 20s for 4]
+  {app="p"}               "size=500KB"    @ 30s [repeat every 20s for 2]
+  {app="p"}               "size=2048KiB"  @ 20s [repeat every 20s for 4]
+  {app="p"}               "size=2MiB"     @ 20s [repeat every 20s for 4]
+  {app="p"}               "size=2GB"      @ 20s [repeat every 20s for 4]
+  {app="p"}               "size=2GiB"     @ 20s [repeat every 20s for 4]
+  {app="p"}               "size=2TB"      @ 20s [repeat every 20s for 4]
+  {app="p"}               "size=2TiB"     @ 20s [repeat every 20s for 4]
+  {app="p"}               "size=2PB"      @ 20s [repeat every 20s for 4]
+  {app="p"}               "size=2PiB"     @ 20s [repeat every 20s for 4]
   {app="j"}               `{"size":"3MB"}` @ 20s [repeat every 20s for 4]
-  {app="s", size="3MB"}   "x"              @ 15s [repeat every 15s for 5]
-  {app="s", size="500KB"} "x"              @ 30s [repeat every 20s for 2]
-  {app="m"}               "x"              @ 12s [repeat every 12s for 6] [metadata size="3MB"]
-  {app="m"}               "x"              @ 30s [repeat every 20s for 2] [metadata size="500KB"]
+  {app="s", size="3MB"}       "x"         @ 15s [repeat every 15s for 5]
+  {app="s", size="500KB"}     "x"         @ 30s [repeat every 20s for 2]
+  {app="s", size="500KiB"}    "x"         @ 30s [repeat every 20s for 2]
+  {app="s", size="2MiB"}      "x"         @ 15s [repeat every 15s for 5]
+  {app="s", size="2GB"}       "x"         @ 15s [repeat every 15s for 5]
+  {app="s", size="2GiB"}      "x"         @ 15s [repeat every 15s for 5]
+  {app="s", size="2TB"}       "x"         @ 15s [repeat every 15s for 5]
+  {app="s", size="2TiB"}      "x"         @ 15s [repeat every 15s for 5]
+  {app="s", size="2PB"}       "x"         @ 15s [repeat every 15s for 5]
+  {app="s", size="2PiB"}      "x"         @ 15s [repeat every 15s for 5]
+  {app="m"}               "x"             @ 12s [repeat every 12s for 6] [metadata size="3MB"]
+  {app="m"}               "x"             @ 30s [repeat every 20s for 2] [metadata size="500KB"]
+  {app="m"}               "x"             @ 12s [repeat every 12s for 6] [metadata size="2048KiB"]
+  {app="m"}               "x"             @ 12s [repeat every 12s for 6] [metadata size="2MiB"]
+  {app="m"}               "x"             @ 12s [repeat every 12s for 6] [metadata size="2GB"]
+  {app="m"}               "x"             @ 12s [repeat every 12s for 6] [metadata size="2GiB"]
+  {app="m"}               "x"             @ 12s [repeat every 12s for 6] [metadata size="2TB"]
+  {app="m"}               "x"             @ 12s [repeat every 12s for 6] [metadata size="2TiB"]
+  {app="m"}               "x"             @ 12s [repeat every 12s for 6] [metadata size="2PB"]
+  {app="m"}               "x"             @ 12s [repeat every 12s for 6] [metadata size="2PiB"]
 
 # parsed field
+# every supported unit is a valid query literal, not just MB: KiB, MiB, GB, GiB, TB, TiB, PB, PiB.
 eval instant at 60s count_over_time({app="p"} | logfmt | size > 1MB [1m])
   {app="p", size="3MB"} 3
+  {app="p", size="2048KiB"} 3
+  {app="p", size="2MiB"} 3
+  {app="p", size="2GB"} 3
+  {app="p", size="2GiB"} 3
+  {app="p", size="2TB"} 3
+  {app="p", size="2TiB"} 3
+  {app="p", size="2PB"} 3
+  {app="p", size="2PiB"} 3
 eval range from 40s to 80s step 20s count_over_time({app="p"} | logfmt | size > 1MB [1m])   # overlapping
   {app="p", size="3MB"} 2 3 3
+  {app="p", size="2048KiB"} 2 3 3
+  {app="p", size="2MiB"} 2 3 3
+  {app="p", size="2GB"} 2 3 3
+  {app="p", size="2GiB"} 2 3 3
+  {app="p", size="2TB"} 2 3 3
+  {app="p", size="2TiB"} 2 3 3
+  {app="p", size="2PB"} 2 3 3
+  {app="p", size="2PiB"} 2 3 3
 eval range from 60s to 180s step 120s count_over_time({app="p"} | logfmt | size > 1MB [1m]) # non-overlapping
   {app="p", size="3MB"} 3 _
+  {app="p", size="2048KiB"} 3 _
+  {app="p", size="2MiB"} 3 _
+  {app="p", size="2GB"} 3 _
+  {app="p", size="2GiB"} 3 _
+  {app="p", size="2TB"} 3 _
+  {app="p", size="2TiB"} 3 _
+  {app="p", size="2PB"} 3 _
+  {app="p", size="2PiB"} 3 _
 eval instant at 60s count_over_time({app="p"} | logfmt | size < 1MB [1m])
   {app="p", size="500KB"} 2
 eval instant at 60s count_over_time({app="j"} | json | size > 1MB [1m])
@@ -533,26 +582,95 @@ eval instant at 60s count_over_time({app="j"} | json | size > 1MB [1m])
 # stream label
 eval instant at 60s count_over_time({app="s"} | size > 1MB [1m])
   {app="s", size="3MB"} 4
+  {app="s", size="2MiB"} 4
+  {app="s", size="2GB"} 4
+  {app="s", size="2GiB"} 4
+  {app="s", size="2TB"} 4
+  {app="s", size="2TiB"} 4
+  {app="s", size="2PB"} 4
+  {app="s", size="2PiB"} 4
 eval range from 40s to 80s step 20s count_over_time({app="s"} | size > 1MB [1m])   # overlapping
   {app="s", size="3MB"} 2 4 4
+  {app="s", size="2MiB"} 2 4 4
+  {app="s", size="2GB"} 2 4 4
+  {app="s", size="2GiB"} 2 4 4
+  {app="s", size="2TB"} 2 4 4
+  {app="s", size="2TiB"} 2 4 4
+  {app="s", size="2PB"} 2 4 4
+  {app="s", size="2PiB"} 2 4 4
 eval range from 60s to 180s step 120s count_over_time({app="s"} | size > 1MB [1m]) # non-overlapping
   {app="s", size="3MB"} 4 _
+  {app="s", size="2MiB"} 4 _
+  {app="s", size="2GB"} 4 _
+  {app="s", size="2GiB"} 4 _
+  {app="s", size="2TB"} 4 _
+  {app="s", size="2TiB"} 4 _
+  {app="s", size="2PB"} 4 _
+  {app="s", size="2PiB"} 4 _
 eval instant at 60s count_over_time({app="s"} | size < 1MB [1m])
   {app="s", size="500KB"} 2
+  {app="s", size="500KiB"} 2
 # structured metadata
 eval instant at 60s count_over_time({app="m"} | size > 1MB [1m])
   {app="m", size="3MB"} 5
+  {app="m", size="2048KiB"} 5
+  {app="m", size="2MiB"} 5
+  {app="m", size="2GB"} 5
+  {app="m", size="2GiB"} 5
+  {app="m", size="2TB"} 5
+  {app="m", size="2TiB"} 5
+  {app="m", size="2PB"} 5
+  {app="m", size="2PiB"} 5
 eval range from 40s to 80s step 20s count_over_time({app="m"} | size > 1MB [1m])   # overlapping
   {app="m", size="3MB"} 3 5 5
+  {app="m", size="2048KiB"} 3 5 5
+  {app="m", size="2MiB"} 3 5 5
+  {app="m", size="2GB"} 3 5 5
+  {app="m", size="2GiB"} 3 5 5
+  {app="m", size="2TB"} 3 5 5
+  {app="m", size="2TiB"} 3 5 5
+  {app="m", size="2PB"} 3 5 5
+  {app="m", size="2PiB"} 3 5 5
 eval range from 60s to 180s step 120s count_over_time({app="m"} | size > 1MB [1m]) # non-overlapping
   {app="m", size="3MB"} 5 _
+  {app="m", size="2048KiB"} 5 _
+  {app="m", size="2MiB"} 5 _
+  {app="m", size="2GB"} 5 _
+  {app="m", size="2GiB"} 5 _
+  {app="m", size="2TB"} 5 _
+  {app="m", size="2TiB"} 5 _
+  {app="m", size="2PB"} 5 _
+  {app="m", size="2PiB"} 5 _
 eval instant at 60s count_over_time({app="m"} | size < 1MB [1m])
   {app="m", size="500KB"} 2
 # {app=~".+"} selects the match from every source at once; the sources repeat at different cadences.
 eval instant at 60s count_over_time({app=~".+"} | logfmt | size > 1MB [1m])
   {app="p", size="3MB"} 3
+  {app="p", size="2048KiB"} 3
+  {app="p", size="2MiB"} 3
+  {app="p", size="2GB"} 3
+  {app="p", size="2GiB"} 3
+  {app="p", size="2TB"} 3
+  {app="p", size="2TiB"} 3
+  {app="p", size="2PB"} 3
+  {app="p", size="2PiB"} 3
   {app="s", size="3MB"} 4
+  {app="s", size="2MiB"} 4
+  {app="s", size="2GB"} 4
+  {app="s", size="2GiB"} 4
+  {app="s", size="2TB"} 4
+  {app="s", size="2TiB"} 4
+  {app="s", size="2PB"} 4
+  {app="s", size="2PiB"} 4
   {app="m", size="3MB"} 5
+  {app="m", size="2048KiB"} 5
+  {app="m", size="2MiB"} 5
+  {app="m", size="2GB"} 5
+  {app="m", size="2GiB"} 5
+  {app="m", size="2TB"} 5
+  {app="m", size="2TiB"} 5
+  {app="m", size="2PB"} 5
+  {app="m", size="2PiB"} 5
 
 # bytes label filter comparators: = == != > >= < <=.
 clear

--- a/pkg/logql/syntax/lex.go
+++ b/pkg/logql/syntax/lex.go
@@ -380,7 +380,7 @@ func tryScanBytes(number string, l *Scanner) (uint64, bool) {
 
 func isBytesSizeRune(r rune) bool {
 	// Accept: B, kB, MB, GB, TB, PB, KB, KiB, MiB, GiB, TiB, PiB
-	// Do not accept: EB, ZB, YB, PiB, ZiB and YiB. They are not supported since the value migh not be represented in an uint64
+	// Do not accept: EB, ZB, YB, EiB, ZiB and YiB. They are not supported since the value migh not be represented in an uint64
 	switch r {
 	case 'B', 'i', 'k', 'K', 'M', 'G', 'T', 'P':
 		return true

--- a/pkg/logql/syntax/lex_test.go
+++ b/pkg/logql/syntax/lex_test.go
@@ -102,8 +102,11 @@ func TestLex(t *testing.T) {
 		{`123.45`, []int{NUMBER}},
 		{`-123.45`, []int{SUB, NUMBER}},
 		{`123KB`, []int{BYTES}},
+		{`123PB`, []int{BYTES}},
+		{`123PiB`, []int{BYTES}},
 		// Skip -123KB: Negative bytes are explicitly not supported in the Lexer.
 		{`123ms`, []int{DURATION}},
+		{`1e6`, []int{NUMBER}},
 		{`-123ms`, []int{DURATION}},
 		{`34 + - 123`, []int{NUMBER, ADD, SUB, NUMBER}},
 		{`34 + -123`, []int{NUMBER, ADD, SUB, NUMBER}},
@@ -114,6 +117,9 @@ func TestLex(t *testing.T) {
 		{`{foo="bar"} | logfmt | bytes  < 1B`, []int{OPEN_BRACE, IDENTIFIER, EQ, STRING, CLOSE_BRACE, PIPE, LOGFMT, PIPE, IDENTIFIER, LT, BYTES}},
 		{`0b01`, []int{NUMBER}},
 		{`0b10`, []int{NUMBER}},
+		{`0x1A`, []int{NUMBER}},
+		{`0x1p3`, []int{NUMBER}},
+		{`0x1P3`, []int{NUMBER}},
 	} {
 		t.Run(tc.input, func(t *testing.T) {
 			actual := []int{}

--- a/pkg/logql/syntax/query_scanner.go
+++ b/pkg/logql/syntax/query_scanner.go
@@ -441,12 +441,13 @@ func (s *Scanner) scanNumber(ch rune, seenDot bool) (rune, rune) {
 	}
 
 	// exponent
-	if e := lower(ch); (e == 'e' || e == 'p') && s.Mode&ScanFloats != 0 {
-		switch {
-		case e == 'e' && prefix != 0 && prefix != '0':
+	//
+	// 'p'/'P' only introduces an exponent for a hex mantissa (prefix == 'x'), matching Go's hex-float
+	// syntax (e.g. 0x1p3). For any other prefix, 'p'/'P' is left unconsumed so callers can treat it as
+	// part of a following identifier, such as the "PB"/"PiB" byte-size suffix handled in lex.go.
+	if e := lower(ch); (e == 'e' || (e == 'p' && prefix == 'x')) && s.Mode&ScanFloats != 0 {
+		if e == 'e' && prefix != 0 && prefix != '0' {
 			s.errorf("%q exponent requires decimal mantissa", ch)
-		case e == 'p' && prefix != 'x':
-			s.errorf("%q exponent requires hexadecimal mantissa", ch)
 		}
 		ch = s.next()
 		tok = Float


### PR DESCRIPTION
**What this PR does / why we need it**:

LogQL's scanner mis-read a number immediately followed by `p`/`P` as a Go hex-float exponent marker (e.g. `0x1p3`), hard-failing the parse before the existing byte-size unit logic ever ran. This made `PB`/`PiB` literals unusable anywhere a byte-size literal is otherwise valid, even though the runtime value-parsing path (label filters, `bytes()` conversion) already supported them fine. No other supported unit collides with a reserved Go exponent letter, so this affected only `PB`/`PiB`.

The fix restricts the exponent check to genuine hex-prefixed literals (`prefix == 'x'`), mirroring the existing `0b`-prefix guard already in the same file. No grammar changes.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

Also extended `logqltest` coverage for every supported byte unit (KiB, MiB, GB, GiB, TB, TiB, PB, PiB) across query literals, label values, and stream-label/structured-metadata sources; added lexer coverage for `PB`/`PiB` tokenization plus a scientific-notation regression guard; and documented that bare hex, octal, and binary integers are not valid scalar literals, while hex floats (with a `p` exponent) are.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)