### PR TITLE
chore: Always close decbufs and do it the less verbose way

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
@@ -197,10 +197,10 @@ func (p *streamPostings) labelValuesFor(labelName string) ([]string, error) {
 
 	// Unchecked because we already checked CRC32 at startup
 	decbuf := p.factory.NewDecbufAtUnchecked(context.Background(), p.off)
+	defer decbuf.Close()
 	if err := decbuf.Err(); err != nil {
 		return nil, err
 	}
-	defer func() { _ = decbuf.Close() }()
 
 	// The sparse table always retains a name's first and last value, so walking
 	// forward from the first entry until the last value turns up covers every
@@ -258,7 +258,7 @@ func (p *streamPostings) labelNames() []string {
 // validates while opening).
 func (p *streamPostings) readPostingsList(postingsOffset uint64) (Postings, error) {
 	decbuf := p.factory.NewDecbufAtChecked(context.Background(), int(postingsOffset), castagnoliTable)
-	defer func() { _ = decbuf.Close() }()
+	defer decbuf.Close()
 	if err := decbuf.Err(); err != nil {
 		return nil, err
 	}
@@ -290,7 +290,7 @@ func streamPostingsOffsetTable(
 	) error,
 ) error {
 	decbuf := factory.NewDecbufAtChecked(ctx, postingsOffsetTableOffset, castagnoliTable)
-	defer func() { _ = decbuf.Close() }()
+	defer decbuf.Close()
 	if err := decbuf.Err(); err != nil {
 		return err
 	}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
@@ -99,7 +99,7 @@ func (s StreamReader) readHeader() (int, error) {
 	}
 	// Construct decbuf
 	decbuf := s.factory.NewRawDecbuf(context.Background())
-	defer func() { _ = decbuf.Close() }()
+	defer decbuf.Close()
 	if err := decbuf.Err(); err != nil {
 		return 0, fmt.Errorf("open header decbuf: %w", err)
 	}
@@ -131,7 +131,7 @@ func (s StreamReader) readTOC() (*TOC, error) {
 	}
 	// Create decbuf
 	decbuf := s.factory.NewRawDecbuf(context.Background())
-	defer func() { _ = decbuf.Close() }()
+	defer decbuf.Close()
 	if err := decbuf.Err(); err != nil {
 		return nil, fmt.Errorf("open toc decbuf: %w", err)
 	}
@@ -175,7 +175,7 @@ func (s StreamReader) readTOC() (*TOC, error) {
 // which NewDecbufAtChecked validates while opening.
 func (s StreamReader) readFingerprintOffsetsTable(offset int) (FingerprintOffsets, error) {
 	decbuf := s.factory.NewDecbufAtChecked(context.Background(), offset, castagnoliTable)
-	defer func() { _ = decbuf.Close() }()
+	defer decbuf.Close()
 	if err := decbuf.Err(); err != nil {
 		return nil, err
 	}
@@ -209,10 +209,10 @@ func seriesOffset(id storage.SeriesRef) int {
 // a raw Decbuf over the whole file and decode the record ourselves.
 func (s StreamReader) readSeriesRecord(offset int) ([]byte, error) {
 	decbuf := s.factory.NewRawDecbuf(context.Background())
+	defer decbuf.Close()
 	if err := decbuf.Err(); err != nil {
 		return nil, fmt.Errorf("open series decbuf: %w", err)
 	}
-	defer func() { _ = decbuf.Close() }()
 
 	if decbuf.ResetAt(offset); decbuf.Err() != nil {
 		return nil, fmt.Errorf("go to start of series record: %w", decbuf.Err())

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols.go
@@ -33,7 +33,7 @@ type streamSymbols struct {
 // capturing the sparse offset table, and building labelNameSymbols.
 func newStreamSymbols(ctx context.Context, factory *streamenc.FilePoolDecbufFactory, off int, isLabelName func(symbol string) bool) (*streamSymbols, error) {
 	decbuf := factory.NewDecbufAtChecked(ctx, off, castagnoliTable)
-	defer func() { _ = decbuf.Close() }()
+	defer decbuf.Close()
 	if err := decbuf.Err(); err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (s *streamSymbols) Lookup(n uint32) (string, error) {
 	}
 
 	decbuf := s.factory.NewDecbufAtUnchecked(context.Background(), s.off)
-	defer func() { _ = decbuf.Close() }()
+	defer decbuf.Close()
 	if err := decbuf.Err(); err != nil {
 		return "", err
 	}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/encoding_test.go
@@ -737,6 +737,7 @@ func runAllBufReaderTypes(t *testing.T, caseName string, bytes []byte, testFn fu
 		_ = diskFactory.Close()
 	})
 	diskDecBuf := diskFactory.NewRawDecbuf(context.Background())
+	t.Cleanup(func() { _ = diskDecBuf.Close() })
 	require.NoError(t, diskDecBuf.Err())
 
 	name := caseName


### PR DESCRIPTION
Addresses some PR feedback:
- https://github.com/grafana/loki/pull/23663#discussion_r3765416195
- https://github.com/grafana/loki/pull/23730#discussion_r3765503011
- https://github.com/grafana/loki/pull/23730#discussion_r3765472943

**What this PR does / why we need it**: Just a little clean-up and avoiding leaking resources in some error cases. 

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**: N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)