### PR TITLE
chore: Pool postings-list read buffer

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
@@ -17,6 +17,7 @@ var postingsListBufferPool = pool.New(64, 16<<20, 2, func(sz int) interface{} {
 })
 
 // getPostingsListBuffer returns a buffer of exactly n bytes.
+// Buffers are returned dirty, so the caller is expected to overwrite any data in the buffer.
 func getPostingsListBuffer(n int) []byte {
 	return postingsListBufferPool.Get(n).([]byte)[:n]
 }
@@ -282,6 +283,8 @@ func (p *streamPostings) readPostingsList(postingsOffset uint64) (Postings, erro
 	}
 
 	buf := getPostingsListBuffer(4 * n)
+	// We may be reusing a dirty buffer.
+	// ReadInfo either fills the entire buffer (erasing all accessible stale data) or errors (in which case we abort).
 	decbuf.ReadInto(buf)
 	if err := decbuf.Err(); err != nil {
 		postingsListBufferPool.Put(buf)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_postings.go
@@ -5,8 +5,21 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/pool"
+
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc"
 )
+
+// postingsListBufferPool holds reusable []byte buffers for streaming postings lists.
+var postingsListBufferPool = pool.New(64, 16<<20, 2, func(sz int) interface{} {
+	return make([]byte, 0, sz)
+})
+
+// getPostingsListBuffer returns a buffer of exactly n bytes.
+func getPostingsListBuffer(n int) []byte {
+	return postingsListBufferPool.Get(n).([]byte)[:n]
+}
 
 // streamPostings is StreamReader's equivalent of ByteSliceReader's postings.
 //
@@ -268,12 +281,56 @@ func (p *streamPostings) readPostingsList(postingsOffset uint64) (Postings, erro
 		return nil, err
 	}
 
-	buf := make([]byte, 4*n)
+	buf := getPostingsListBuffer(4 * n)
 	decbuf.ReadInto(buf)
 	if err := decbuf.Err(); err != nil {
+		postingsListBufferPool.Put(buf)
 		return nil, err
 	}
-	return NewBigEndianPostings(buf), nil
+	return newPooledBigEndianPostings(buf), nil
+}
+
+// pooledBigEndianPostings wraps BigEndianPostings so the backing []byte
+// buffer is returned to postingsListBufferPool once iteration drains (Next
+// or Seek returns false).
+// Callers that abandon the iterator mid-scan lose the pool benefit for
+// that buffer but are otherwise unaffected — GC still reclaims it.
+type pooledBigEndianPostings struct {
+	BigEndianPostings
+	buf    []byte // the buffer that we will return to the pool
+	pooled bool   // tracks whether we've already returned the buffer to the pool
+}
+
+func newPooledBigEndianPostings(list []byte) *pooledBigEndianPostings {
+	return &pooledBigEndianPostings{
+		BigEndianPostings: BigEndianPostings{list: list},
+		buf:               list,
+		pooled:            true,
+	}
+}
+
+func (p *pooledBigEndianPostings) Next() bool {
+	ok := p.BigEndianPostings.Next()
+	if !ok {
+		p.release()
+	}
+	return ok
+}
+
+func (p *pooledBigEndianPostings) Seek(x storage.SeriesRef) bool {
+	ok := p.BigEndianPostings.Seek(x)
+	if !ok {
+		p.release()
+	}
+	return ok
+}
+
+func (p *pooledBigEndianPostings) release() {
+	if !p.pooled {
+		return
+	}
+	p.pooled = false
+	postingsListBufferPool.Put(p.buf)
 }
 
 // streamPostingsOffsetTable iterates the postings-offset table, running

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strconv"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -129,15 +130,29 @@ func BenchmarkNewStreamFileReader(b *testing.B) {
 	}
 }
 
+func writeBenchmarkFixture(t testing.TB, numSeries int, numChunksPerLabel int) string {
+	t.Helper()
+	chunks := make([]ChunkMeta, numChunksPerLabel)
+	for i := range numChunksPerLabel {
+		chunks[i] = ChunkMeta{Checksum: uint32(i), MinTime: int64(i * 10), MaxTime: int64(i*10 + 10)}
+	}
+	series := make([]seriesFixture, numSeries)
+	for i := range numSeries {
+		series[i].ls = labels.FromStrings("a", strconv.Itoa(i%5), "b", strconv.Itoa(i%11), "c", strconv.Itoa(i%17))
+		series[i].chunks = chunks
+	}
+	return writeIndexFixture(t, FormatV4, series)
+}
+
 func BenchmarkPostings(b *testing.B) {
-	path := writeCrossCheckFixture(b, FormatV4)
+	path := writeBenchmarkFixture(b, 1_000_000, 3)
 	r, err := NewStreamFileReader(path)
 	require.NoError(b, err)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		postings, err := r.Postings("c", nil, "svcA")
+		postings, err := r.Postings("c", nil, "3")
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
streamPostings.readPostingsList allocates a fresh []byte for every postings list read. This is invoked on the query path when Postings(...) is called. This change benchmarks the improvement.

Benchmark results: 
```
                   │  before   │             after              │
                   │   B/op    │    B/op       vs base          │
ReadPostingsList      16030.5      924.0      -94.24% (p=0.000)
Postings             323409.5      933.0      -99.71% (p=0.000)
```
Benchmarking against realistic indexes looks like this will save ~25% of CPU usage on these operations (on GC).

**What this PR does / why we need it**: Part of our effort to migrate away from mmap in index gateways - we're now in the optimisation phase.

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
