### PR TITLE
fix(logql)!: Reject invalid binary operator modifiers

### DIFF
--- a/docs/sources/query/query_reference.md
+++ b/docs/sources/query/query_reference.md
@@ -200,7 +200,7 @@ The syntax:
 <vector expr> <bin-op> on(<labels>) group_left(<labels>) <vector expr>
 <vector expr> <bin-op> on(<labels>) group_right(<labels>) <vector expr>
 ```
-The label list provided with the group modifier contains additional labels from the "one"-side that are included in the result metrics. And a label should only appear in one of the lists specified by `on` and `group_x`. Every time series of the result vector must be uniquely identifiable.
+The label list provided with the group modifier contains additional labels from the "one"-side that are included in the result metrics. A label already listed in `on(...)` is redundant in `group_x(...)`, since matching on it already guarantees it holds the same value on both sides. Every time series of the result vector must be uniquely identifiable.
 Grouping modifiers can only be used for comparison and arithmetic. By default, the system matches `and`, `unless`, and `or` operations with all entries in the right vector.
 
 The following example returns the rates requests partitioned by `app` and `status` as a percentage of total requests.

--- a/docs/sources/setup/upgrade/_index.md
+++ b/docs/sources/setup/upgrade/_index.md
@@ -47,6 +47,20 @@ Schedulers and queriers already accept both encodings, so mixed frontends during
 
 The default value of `frontend.compress_responses` changed to `true`. A bug in Loki 3.4.0 unintentionally switched it to `false`. If you don't want the query-frontend to compress HTTP responses, set `frontend.compress_responses` to `false` explicitly.
 
+### Breaking change: LogQL rejects invalid binary operator modifiers
+
+LogQL now rejects, at parse time, a few combinations of binary operator modifiers that
+previously parsed but had no effect:
+
+- `bool` on an operator other than `==`, `!=`, `>`, `>=`, `<`, or `<=`.
+- `group_left`/`group_right` on `and`, `or`, or `unless`.
+- `on(...)`/`ignoring(...)` with at least one label next to a scalar operand. An empty
+  `on()`/`ignoring()` stays valid, including when combined with `group_left`/`group_right`.
+
+Because the modifier had no effect in every one of these cases, no query's computed result
+changes. Only a query that already contained one of these invalid combinations starts returning
+a parse error. If a query fails after upgrading, remove the invalid modifier from it.
+
 ### Breaking change: Removal of LogQL `variants()` queries
 
 The experimental `variants()` LogQL expression is no longer supported.

--- a/pkg/logql/internal/logqltest/testdata/binary_operations.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/binary_operations.logqltest
@@ -53,6 +53,9 @@ eval instant at 60s 2 == bool 1
 # A literal cannot be a leg of a logical/set operator.
 eval instant at 60s 1 and 2
   expect fail msg: unexpected literal for left leg of logical/set binary operation
+# `bool` is not supported for arithmetic and logical/set operators.
+eval instant at 60s 1 + bool 2
+  expect fail msg: bool modifier can only be used on comparison operators
 
 # Scalar operators precedence and associativity.
 clear
@@ -140,6 +143,22 @@ eval instant at 60s count_over_time({app="foo"}[1m]) / 0
   {app="foo"} NaN
 eval instant at 60s count_over_time({app="foo"}[1m]) % 0
   {app="foo"} NaN
+# on()/ignoring() with labels are rejected next to a scalar operand.
+eval instant at 60s 1 + on (app) count_over_time({app="foo"}[1m])
+  expect fail msg: vector matching only allowed between instant vectors
+eval instant at 60s count_over_time({app="foo"}[1m]) + on (app) 1
+  expect fail msg: vector matching only allowed between instant vectors
+eval instant at 60s 1 + on (app) 1
+  expect fail msg: vector matching only allowed between instant vectors
+eval instant at 60s 1 + ignoring (app) 1
+  expect fail msg: vector matching only allowed between instant vectors
+# on()/ignoring() without labels is allowed next to a scalar operand.
+eval instant at 60s 1 + on () 1
+  2
+eval instant at 60s 1 + ignoring () 1
+  2
+eval instant at 60s count_over_time({app="foo"}[1m]) + on () group_left (baz) 1
+  {app="foo"} 7
 
 # Vector / scalar comparisons.
 #
@@ -218,6 +237,9 @@ eval instant at 60s 6 == bool count_over_time({app=~"foo|bar"}[1m])
 eval range from 60s to 180s step 30s 6 == bool count_over_time({app=~"foo|bar"}[1m])
   {app="foo"} 1 1 1 1 1
   {app="bar"} 0 0 0 0 0
+# on()/ignoring() with labels are rejected next to a scalar operand.
+eval instant at 60s count_over_time({app="foo"}[1m]) == on (app) 1
+  expect fail msg: vector matching only allowed between instant vectors
 
 # Vector / scalar arithmetic: ^ (power) edge cases.
 clear
@@ -267,29 +289,37 @@ load
   {app="bar"} "x" @ 0s [repeat every 20s for 10]
   {app="noise"} "noise" @ 0s [repeat every 10s for 19]
 
+# vector or vector
 eval instant at 60s rate({app="foo"}[1m]) or rate({app="bar"}[1m])
   {app="foo"} 0.1
   {app="bar"} 0.05
 eval range from 60s to 180s step 30s rate({app="foo"}[1m]) or rate({app="bar"}[1m])
   {app="foo"} 0.1 0.1 0.1 0.1 0.1
   {app="bar"} 0.05 0.05 0.05 0.05 0.05
-
+# vector or vector()
 eval instant at 60s rate({app="foo"}[1m]) or vector(0)
   {app="foo"} 0.1
   {} 0
 eval range from 60s to 180s step 30s rate({app="foo"}[1m]) or vector(0)
   {app="foo"} 0.1 0.1 0.1 0.1 0.1
   {} 0 0 0 0 0
-
+# vector and vector
 eval instant at 60s rate({app=~"foo|bar"}[1m]) and rate({app="bar"}[1m])
   {app="bar"} 0.05
 eval range from 60s to 180s step 30s rate({app=~"foo|bar"}[1m]) and rate({app="bar"}[1m])
   {app="bar"} 0.05 0.05 0.05 0.05 0.05
-
+# vector unless vector
 eval instant at 60s rate({app=~"foo|bar"}[1m]) unless rate({app="bar"}[1m])
   {app="foo"} 0.1
 eval range from 60s to 180s step 30s rate({app=~"foo|bar"}[1m]) unless rate({app="bar"}[1m])
   {app="foo"} 0.1 0.1 0.1 0.1 0.1
+# `bool` is not valid on logical/set operators.
+eval instant at 60s count_over_time({app="foo"}[1m]) or bool count_over_time({app="bar"}[1m])
+  expect fail msg: bool modifier can only be used on comparison operators
+eval instant at 60s count_over_time({app="foo"}[1m]) and bool count_over_time({app="bar"}[1m])
+  expect fail msg: bool modifier can only be used on comparison operators
+eval instant at 60s count_over_time({app="foo"}[1m]) unless bool count_over_time({app="bar"}[1m])
+  expect fail msg: bool modifier can only be used on comparison operators
 
 # Vector / vector arithmetic (matched on identical labels; foo is dropped, bar survives).
 eval instant at 60s rate({app=~"foo|bar"}[1m]) + rate({app="bar"}[1m])
@@ -325,6 +355,9 @@ eval instant at 60s count_over_time({app="bar"}[1m]) ^ count_over_time({app="bar
   {app="bar"} 27
 eval range from 60s to 180s step 30s count_over_time({app="bar"}[1m]) ^ count_over_time({app="bar"}[1m])
   {app="bar"} 27 27 27 27 27
+# `bool` is not valid on arithmetic operators.
+eval instant at 60s count_over_time({app="foo"}[1m]) + bool count_over_time({app="bar"}[1m])
+  expect fail msg: bool modifier can only be used on comparison operators
 
 # Vector / vector comparison. Bare foo vs bar never share labels → empty result.
 clear
@@ -727,6 +760,13 @@ eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) < on
 eval range from 60s to 180s step 30s sum by (app,machine) (count_over_time({app="foo"}[1m])) < on () group_left sum by (app) (count_over_time({app="foo"}[1m]))
   {app="foo", machine="fuzz"} 6 6 6 6 6
   {app="foo", machine="buzz"} 4 4 4 4 4
+# and/or/unless group_left are rejected.
+eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) and ignoring (machine) group_left sum by (app) (count_over_time({app="foo"}[1m]))
+  expect fail msg: no grouping allowed for "and" operation
+eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) or ignoring (machine) group_left sum by (app) (count_over_time({app="foo"}[1m]))
+  expect fail msg: no grouping allowed for "or" operation
+eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) unless ignoring (machine) group_left sum by (app) (count_over_time({app="foo"}[1m]))
+  expect fail msg: no grouping allowed for "unless" operation
 
 # group_left() without labels: duplicate series case.
 clear
@@ -755,6 +795,12 @@ eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) > bo
 eval range from 60s to 180s step 30s sum by (app,machine) (count_over_time({app="foo"}[1m])) > bool on (app) group_left (pool) sum by (app,pool) (count_over_time({app="foo"}[1m]))
   {app="foo", machine="fuzz", pool="foo"} 0 0 0 0 0
   {app="foo", machine="buzz", pool="foo"} 0 0 0 0 0
+# A label already used to match via on(...) can also appear in group_left(...). It is
+# guaranteed equal on both sides already, so including it again is a harmless no-op: the
+# output keeps its own value for that label instead of picking up a different one.
+eval instant at 60s sum by (app,machine) (count_over_time({app="foo"}[1m])) > bool on (app) group_left (app) sum by (app,pool) (count_over_time({app="foo"}[1m]))
+  {app="foo", machine="fuzz"} 0
+  {app="foo", machine="buzz"} 0
 # Each machine's own share of the app total.
 eval instant at 60s count_over_time({app="foo"}[1m]) / on (app) group_left sum by (app) (count_over_time({app="foo"}[1m]))
   {app="foo", machine="fuzz", pool="foo"} 0.6
@@ -775,6 +821,22 @@ eval instant at 60s sum by (app,machine,pool) (count_over_time({app="foo"}[1m]))
 eval range from 60s to 180s step 30s sum by (app,machine,pool) (count_over_time({app="foo"}[1m])) > bool on (app) group_left (pool) sum by (app) (count_over_time({app="foo"}[1m]))
   {app="foo", machine="fuzz"} 0 0 0 0 0
   {app="foo", machine="buzz"} 0 0 0 0 0
+
+# group_left() with labels: ignoring() the same grouped label.
+clear
+load
+  {app="foo", machine="fuzz"} "x" @ 0s [repeat every 10s for 19]
+  {app="foo", machine="buzz"} "x" @ 0s [repeat every 20s for 10]
+  {app="foo", org="acme"}     "x" @ 0s [repeat every 10s for 19]
+  {app="noise"}                "noise" @ 0s [repeat every 10s for 19]
+
+# A label excluded from matching via ignoring(...) can still be pulled in via group_left(...).
+eval instant at 60s sum by (app,machine) (count_over_time({app="foo", machine=~".+"}[1m])) / ignoring (machine,org) group_left (org) sum by (app,org) (count_over_time({app="foo", org=~".+"}[1m]))
+  {app="foo", machine="fuzz", org="acme"} 1
+  {app="foo", machine="buzz", org="acme"} 0.5
+eval range from 60s to 180s step 30s sum by (app,machine) (count_over_time({app="foo", machine=~".+"}[1m])) / ignoring (machine,org) group_left (org) sum by (app,org) (count_over_time({app="foo", org=~".+"}[1m]))
+  {app="foo", machine="fuzz", org="acme"} 1 1 1 1 1
+  {app="foo", machine="buzz", org="acme"} 0.5 0.5 0.5 0.5 0.5
 
 # group_left() with labels: collision case.
 #
@@ -832,6 +894,13 @@ eval instant at 60s sum by (app) (count_over_time({app="foo"}[1m])) > on () grou
 eval range from 60s to 180s step 30s sum by (app) (count_over_time({app="foo"}[1m])) > on () group_right sum by (app,machine) (count_over_time({app="foo"}[1m]))
   {app="foo", machine="fuzz"} 10 10 10 10 10
   {app="foo", machine="buzz"} 10 10 10 10 10
+# and/or/unless group_right are rejected.
+eval instant at 60s sum by (app) (count_over_time({app="foo"}[1m])) and ignoring (machine) group_right sum by (app,machine) (count_over_time({app="foo"}[1m]))
+  expect fail msg: no grouping allowed for "and" operation
+eval instant at 60s sum by (app) (count_over_time({app="foo"}[1m])) or ignoring (machine) group_right sum by (app,machine) (count_over_time({app="foo"}[1m]))
+  expect fail msg: no grouping allowed for "or" operation
+eval instant at 60s sum by (app) (count_over_time({app="foo"}[1m])) unless ignoring (machine) group_right sum by (app,machine) (count_over_time({app="foo"}[1m]))
+  expect fail msg: no grouping allowed for "unless" operation
 
 # group_right() without labels: duplicate series case.
 clear
@@ -860,6 +929,12 @@ eval instant at 60s sum by (app,pool) (count_over_time({app="foo"}[1m])) > bool 
 eval range from 60s to 180s step 30s sum by (app,pool) (count_over_time({app="foo"}[1m])) > bool on (app) group_right (pool) sum by (app,machine) (count_over_time({app="foo"}[1m]))
   {app="foo", machine="fuzz", pool="foo"} 1 1 1 1 1
   {app="foo", machine="buzz", pool="foo"} 1 1 1 1 1
+# A label already used to match via on(...) can also appear in group_right(...). It is
+# guaranteed equal on both sides already, so including it again is a harmless no-op: the
+# output keeps its own value for that label instead of picking up a different one.
+eval instant at 60s sum by (app,pool) (count_over_time({app="foo"}[1m])) > bool on (app) group_right (app) sum by (app,machine) (count_over_time({app="foo"}[1m]))
+  {app="foo", machine="fuzz"} 1
+  {app="foo", machine="buzz"} 1
 # Include-label deletion: the LHS lacks `pool` (aggregated away), so group_right(pool)
 # deletes it from the result rather than keeping the many side's own value.
 eval instant at 60s sum by (app) (count_over_time({app="foo"}[1m])) > bool on (app) group_right (pool) sum by (app,machine,pool) (count_over_time({app="foo"}[1m]))
@@ -868,6 +943,22 @@ eval instant at 60s sum by (app) (count_over_time({app="foo"}[1m])) > bool on (a
 eval range from 60s to 180s step 30s sum by (app) (count_over_time({app="foo"}[1m])) > bool on (app) group_right (pool) sum by (app,machine,pool) (count_over_time({app="foo"}[1m]))
   {app="foo", machine="fuzz"} 1 1 1 1 1
   {app="foo", machine="buzz"} 1 1 1 1 1
+
+# group_right() with labels: ignoring() the same grouped label.
+clear
+load
+  {app="foo", machine="fuzz"} "x" @ 0s [repeat every 10s for 19]
+  {app="foo", machine="buzz"} "x" @ 0s [repeat every 20s for 10]
+  {app="foo", org="acme"}     "x" @ 0s [repeat every 10s for 19]
+  {app="noise"}                "noise" @ 0s [repeat every 10s for 19]
+
+# A label excluded from matching via ignoring(...) can still be pulled in via group_right(...).
+eval instant at 60s sum by (app,org) (count_over_time({app="foo", org=~".+"}[1m])) / ignoring (machine,org) group_right (org) sum by (app,machine) (count_over_time({app="foo", machine=~".+"}[1m]))
+  {app="foo", machine="fuzz", org="acme"} 1
+  {app="foo", machine="buzz", org="acme"} 2
+eval range from 60s to 180s step 30s sum by (app,org) (count_over_time({app="foo", org=~".+"}[1m])) / ignoring (machine,org) group_right (org) sum by (app,machine) (count_over_time({app="foo", machine=~".+"}[1m]))
+  {app="foo", machine="fuzz", org="acme"} 1 1 1 1 1
+  {app="foo", machine="buzz", org="acme"} 2 2 2 2 2
 
 # group_right() with labels: collision case.
 #

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -1886,6 +1886,27 @@ func mustNewBinOpExpr(op string, opts *BinOpOptions, lhs, rhs Expr) SampleExpr {
 		}
 	}
 
+	if opts != nil {
+		if opts.ReturnBool && !IsComparisonOperator(op) {
+			return &BinOpExpr{err: logqlmodel.NewParseError(
+				"bool modifier can only be used on comparison operators", 0, 0)}
+		}
+
+		if matching := opts.VectorMatching; matching != nil {
+			if IsLogicalBinOp(op) && matching.Card != CardOneToOne {
+				return &BinOpExpr{err: logqlmodel.NewParseError(fmt.Sprintf(
+					"no grouping allowed for %q operation", op), 0, 0)}
+			}
+
+			// An empty on()/ignoring() list names no matching labels, so it stays legal
+			// next to a scalar operand. Only an explicit label list requires a vector.
+			if (lOk || rOk) && len(matching.MatchingLabels) > 0 {
+				return &BinOpExpr{err: logqlmodel.NewParseError(
+					"vector matching only allowed between instant vectors", 0, 0)}
+			}
+		}
+	}
+
 	// map expr like (1+1) -> 2
 	if lOk && rOk {
 		return reduceBinOp(op, leftVal, rightVal)

--- a/pkg/logql/syntax/parser_test.go
+++ b/pkg/logql/syntax/parser_test.go
@@ -2821,6 +2821,109 @@ var ParseTestCases = []struct {
 		err: logqlmodel.NewParseError(`unexpected literal for right leg of logical/set binary operation (or): 1.000000`, 0, 0),
 	},
 	{
+		// bool is only valid on comparison operators.
+		in:  `count_over_time({foo="bar"}[5m]) + bool count_over_time({foo="bar"}[5m])`,
+		err: logqlmodel.NewParseError(`bool modifier can only be used on comparison operators`, 0, 0),
+	},
+	{
+		in:  `count_over_time({foo="bar"}[5m]) and bool count_over_time({foo="bar"}[5m])`,
+		err: logqlmodel.NewParseError(`bool modifier can only be used on comparison operators`, 0, 0),
+	},
+	{
+		// group_left/group_right are not allowed on and/or/unless.
+		in:  `count_over_time({foo="bar"}[5m]) and on (foo) group_left count_over_time({foo="bar"}[5m])`,
+		err: logqlmodel.NewParseError(`no grouping allowed for "and" operation`, 0, 0),
+	},
+	{
+		in:  `count_over_time({foo="bar"}[5m]) or on (foo) group_right count_over_time({foo="bar"}[5m])`,
+		err: logqlmodel.NewParseError(`no grouping allowed for "or" operation`, 0, 0),
+	},
+	{
+		in:  `count_over_time({foo="bar"}[5m]) unless on (foo) group_left (bar) count_over_time({foo="bar"}[5m])`,
+		err: logqlmodel.NewParseError(`no grouping allowed for "unless" operation`, 0, 0),
+	},
+	{
+		// A label may occur in both on(...)/ignoring(...) and group_left(...)/group_right(...).
+		// It's redundant when combined with on(...) (the label is already guaranteed equal on
+		// both sides), but it's not incorrect, so it's not rejected.
+		in: `count_over_time({foo="bar"}[5m]) == on (foo) group_left (foo) count_over_time({foo="bar"}[5m])`,
+		exp: mustNewBinOpExpr(OpTypeCmpEQ, &BinOpOptions{
+			VectorMatching: &VectorMatching{Card: CardManyToOne, Include: []string{"foo"}, On: true, MatchingLabels: []string{"foo"}},
+		},
+			newRangeAggregationExpr(
+				newLogRange(newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "foo", Value: "bar"}}), 5*time.Minute, nil, nil),
+				OpRangeTypeCount, nil, nil,
+			),
+			newRangeAggregationExpr(
+				newLogRange(newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "foo", Value: "bar"}}), 5*time.Minute, nil, nil),
+				OpRangeTypeCount, nil, nil,
+			),
+		),
+	},
+	{
+		// Unlike the on(...) case above, this isn't redundant: ignoring(foo) excludes foo
+		// from the matching guarantee, so group_left(foo) is a genuine value transfer here.
+		// It's simply never validated either way.
+		in: `count_over_time({foo="bar"}[5m]) == ignoring (foo) group_left (foo) count_over_time({foo="bar"}[5m])`,
+		exp: mustNewBinOpExpr(OpTypeCmpEQ, &BinOpOptions{
+			VectorMatching: &VectorMatching{Card: CardManyToOne, Include: []string{"foo"}, On: false, MatchingLabels: []string{"foo"}},
+		},
+			newRangeAggregationExpr(
+				newLogRange(newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "foo", Value: "bar"}}), 5*time.Minute, nil, nil),
+				OpRangeTypeCount, nil, nil,
+			),
+			newRangeAggregationExpr(
+				newLogRange(newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "foo", Value: "bar"}}), 5*time.Minute, nil, nil),
+				OpRangeTypeCount, nil, nil,
+			),
+		),
+	},
+	{
+		// vector matching modifiers are rejected next to a scalar operand, but only when
+		// explicit matching labels are given.
+		in:  `1 + on (foo) count_over_time({foo="bar"}[5m])`,
+		err: logqlmodel.NewParseError(`vector matching only allowed between instant vectors`, 0, 0),
+	},
+	{
+		in:  `count_over_time({foo="bar"}[5m]) + on (foo) 1`,
+		err: logqlmodel.NewParseError(`vector matching only allowed between instant vectors`, 0, 0),
+	},
+	{
+		in:  `1 + on (foo) 1`,
+		err: logqlmodel.NewParseError(`vector matching only allowed between instant vectors`, 0, 0),
+	},
+	{
+		in:  `1 + ignoring (foo) 1`,
+		err: logqlmodel.NewParseError(`vector matching only allowed between instant vectors`, 0, 0),
+	},
+	{
+		// the rule applies to comparison operators too, not just arithmetic.
+		in:  `count_over_time({foo="bar"}[5m]) == on (foo) 1`,
+		err: logqlmodel.NewParseError(`vector matching only allowed between instant vectors`, 0, 0),
+	},
+	{
+		// an empty on()/ignoring() label list is not "matching labels", so it stays legal next
+		// to a scalar operand, even combined with group_left/group_right.
+		in:  `1 + on () 1`,
+		exp: &LiteralExpr{Val: 2},
+	},
+	{
+		in:  `1 + ignoring () 1`,
+		exp: &LiteralExpr{Val: 2},
+	},
+	{
+		in: `count_over_time({foo="bar"}[5m]) + on () group_left (baz) 1`,
+		exp: mustNewBinOpExpr(OpTypeAdd, &BinOpOptions{
+			VectorMatching: &VectorMatching{Card: CardManyToOne, Include: []string{"baz"}, On: true},
+		},
+			newRangeAggregationExpr(
+				newLogRange(newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "foo", Value: "bar"}}), 5*time.Minute, nil, nil),
+				OpRangeTypeCount, nil, nil,
+			),
+			mustNewLiteralExpr("1", false),
+		),
+	},
+	{
 		in: `count_over_time({ foo ="bar" }[12m]) > count_over_time({ foo = "bar" }[12m])`,
 		exp: &BinOpExpr{
 			Op: OpTypeGT,


### PR DESCRIPTION
**What this PR does / why we need it**:

LogQL's parser accepted several binary operator modifier combinations that the query evaluator silently discarded, so the query ran as if the modifier weren't there:

- `bool` on an operator other than `==`, `!=`, `>`, `>=`, `<`, `<=`.
- `group_left`/`group_right` on `and`, `or`, or `unless`.
- `on(...)`/`ignoring(...)` with an explicit label list next to a scalar operand.

None of these ever changed a query's result — the modifier was inert in every case — but a query using one of them looked valid while silently doing less than it appeared to. This PR rejects them at parse time instead, matching PromQL's own parser behavior for the equivalent PromQL constructs.

This is a breaking change: a query containing one of these combinations now fails to parse instead of silently running with the modifier ignored. We think that's a strict improvement over the current behavior of quietly accepting and ignoring part of a query — anyone hitting this was already getting a result that didn't reflect what they wrote, they just had no signal that anything was wrong.

One related, superficially similar case was deliberately left alone: a label listed in both `on(...)` and `group_left(...)`/`group_right(...)` is guaranteed equal on both sides by construction of the match, so naming it again is a provable no-op — never an incorrect result, unlike the three cases above where the modifier was actually discarded. That's harmless, so it isn't rejected.

An empty `on()`/`ignoring()` list still parses next to a scalar operand, since it names no labels to match on — this matches PromQL's own exact boundary, verified directly against the vendored PromQL parser.

**Which issue(s) this PR fixes**:
N/A — found while extending binary operation test coverage in #24007.

**Special notes for your reviewer**:

Test coverage is at two layers: a unit-level `{in, err}` table in `pkg/logql/syntax/parser_test.go`, and end-to-end `expect fail` scenarios in `pkg/logql/internal/logqltest/testdata/binary_operations.logqltest` that also regression-guard the nuances above (empty label list, `ignoring(...)` label-overlap staying legal and producing a hand-verified correct result, `on`/`ignoring` alone still working on `and`/`or`/`unless`).

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)