### PR TITLE
chore: Pool file handles

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -6840,6 +6840,12 @@ tsdb_shipper:
     # CLI flag: -tsdb.shipper.index-gateway-client.min-shuffle-shard-size
     [min_shuffle_shard_size: <int> | default = 3]
 
+  # Experimental. Number of idle file handles the stream index reader keeps open
+  # per index file. Only applies when -shipper.index-reader-mode=stream. Set to
+  # 0 to disable pooling.
+  # CLI flag: -tsdb.shipper.streaming-index-max-idle-file-handles
+  [streaming_index_max_idle_file_handles: <int> | default = 16]
+
   [ingestername: <string> | default = ""]
 
   [mode: <string> | default = ""]

--- a/pkg/labelaccess/store_wrapper_test.go
+++ b/pkg/labelaccess/store_wrapper_test.go
@@ -189,6 +189,7 @@ func getLocalStore(t *testing.T) storage.Store {
 			IngesterName:         "test-ingester",
 			ResyncInterval:       5 * time.Minute,
 			CacheTTL:             24 * time.Hour,
+			IndexReaderMode:      indexshipper.DefaultIndexReaderMode,
 		},
 	}
 

--- a/pkg/logql/bench/discover/pkg/tsdb/reader.go
+++ b/pkg/logql/bench/discover/pkg/tsdb/reader.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/prometheus/common/model"
 
-	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
-
 	lokitsdb "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
 	tsdbindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 )
@@ -55,7 +53,7 @@ func openAndInspectIndex(path string) (result IndexReaderResult, err error) {
 
 	// Full index handle for structural discovery (ForSeries traversal).
 	// This stays open — the caller must close it via result.Index.Close().
-	idx, _, err := lokitsdb.NewTSDBIndexFromFile(path, indexshipper.IndexReaderModeMmap)
+	idx, _, err := lokitsdb.NewTSDBIndexFromFile(path, tsdbindex.MmapOptions{})
 	if err != nil {
 		return IndexReaderResult{}, fmt.Errorf("open TSDB index for discovery %q: %w", path, err)
 	}

--- a/pkg/logql/bench/discover/pkg/tsdb/structural_test.go
+++ b/pkg/logql/bench/discover/pkg/tsdb/structural_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
-
 	"github.com/grafana/loki/v3/pkg/loghttp"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb"
 	tsdbindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
@@ -158,7 +156,7 @@ func openStructuralIndexes(t *testing.T, paths ...string) []tsdb.Index {
 
 	res := make([]tsdb.Index, 0, len(paths))
 	for _, path := range paths {
-		idx, _, err := tsdb.NewTSDBIndexFromFile(path, indexshipper.IndexReaderModeMmap)
+		idx, _, err := tsdb.NewTSDBIndexFromFile(path, tsdbindex.MmapOptions{})
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, idx.Close())

--- a/pkg/logql/bench/store_chunk.go
+++ b/pkg/logql/bench/store_chunk.go
@@ -69,6 +69,7 @@ func NewChunkStoreWithRegisterer(dir, tenantID string, reg prometheus.Registerer
 			CacheLocation:        cacheDir,
 			ResyncInterval:       5 * time.Minute,
 			CacheTTL:             24 * time.Hour,
+			IndexReaderMode:      indexshipper.DefaultIndexReaderMode,
 		},
 		FSConfig: local.FSConfig{Directory: storageDir},
 	}

--- a/pkg/logql/internal/logqltest/store.go
+++ b/pkg/logql/internal/logqltest/store.go
@@ -51,6 +51,7 @@ func newTestingChunkStore(t *testing.T) *testingChunkStore {
 			CacheLocation:        dir + "/cache",
 			ResyncInterval:       5 * time.Minute,
 			CacheTTL:             24 * time.Hour,
+			IndexReaderMode:      indexshipper.DefaultIndexReaderMode,
 		},
 		FSConfig: local.FSConfig{Directory: dir + "/storage"},
 	}

--- a/pkg/loki/modules_test.go
+++ b/pkg/loki/modules_test.go
@@ -258,6 +258,7 @@ func minimalWorkingConfig(t *testing.T, dir, target string, cfgTransformers ...f
 			CacheLocation:        filepath.Join(dir, "cache"),
 			Mode:                 indexshipper.ModeWriteOnly,
 			ResyncInterval:       24 * time.Hour,
+			IndexReaderMode:      indexshipper.DefaultIndexReaderMode,
 		},
 	}
 

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -68,6 +68,7 @@ func getLocalStore(path string, cm ClientMetrics) Store {
 			ResyncInterval:         1 * time.Minute,
 			IngesterDBRetainPeriod: 1 * time.Minute,
 			IngesterName:           "ingester-1",
+			IndexReaderMode:        indexshipper.DefaultIndexReaderMode,
 			Mode:                   indexshipper.ModeReadWrite,
 		},
 		MaxChunkBatchSize: 10,

--- a/pkg/storage/stores/shipper/indexshipper/shipper.go
+++ b/pkg/storage/stores/shipper/indexshipper/shipper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/downloads"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/index"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/storage"
+	tsdbindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/uploads"
 )
 
@@ -57,15 +58,15 @@ const (
 	IndexReaderModeMmap IndexReaderMode = "mmap"
 	// IndexReaderModeStream serves reads via schedulable file I/O so the
 	// runtime can observe blocking.
-	// It is not yet fully implemented and currently delegates calls to a
-	// mmap reader under the hood.
-	// Over time its implementation will be fleshed out until it no longer
-	// depends on the mmap implementation.
 	IndexReaderModeStream IndexReaderMode = "stream"
 )
 
 // DefaultIndexReaderMode is the mode used when none is configured.
 const DefaultIndexReaderMode = IndexReaderModeMmap
+
+// DefaultStreamingIndexMaxIdleFileHandles is the number of idle file handles
+// the stream reader keeps per index file when none is configured.
+const DefaultStreamingIndexMaxIdleFileHandles = tsdbindex.DefaultMaxIdleFileHandles
 
 type Index interface {
 	Close() error
@@ -99,6 +100,8 @@ type Config struct {
 	IndexReaderMode          IndexReaderMode           `yaml:"index_reader_mode" category:"experimental"`
 	IndexGatewayClientConfig indexgateway.ClientConfig `yaml:"index_gateway_client"`
 
+	StreamingIndexMaxIdleFileHandles uint `yaml:"streaming_index_max_idle_file_handles" category:"experimental"`
+
 	// Temporary experimental feature
 	ShadowIndexGatewayClientConfig indexgateway.ClientConfig `yaml:"shadow_index_gateway_client,omitempty" category:"experimental" doc:"hidden"`
 
@@ -125,6 +128,22 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 		"Raise this for tenants with large indexes when slow object-storage responses cause downloads to hit the deadline; lower it to fail queries faster when storage is degraded.")
 	f.StringVar((*string)(&cfg.IndexReaderMode), prefix+"shipper.index-reader-mode", string(DefaultIndexReaderMode),
 		"Experimental. Implementation used to read TSDB index files off disk. Supported values: mmap (memory-map the file, the historical default) or stream (experimental, not yet fully implemented).")
+	f.UintVar(&cfg.StreamingIndexMaxIdleFileHandles, prefix+"shipper.streaming-index-max-idle-file-handles", DefaultStreamingIndexMaxIdleFileHandles,
+		"Experimental. Number of idle file handles the stream index reader keeps open per index file. "+
+			"Only applies when -shipper.index-reader-mode=stream. "+
+			"Set to 0 to disable pooling.")
+}
+
+// IndexReaderOptions translates the flat, user-facing config into the reader options it describes.
+func (cfg *Config) IndexReaderOptions() (tsdbindex.ReaderOptions, error) {
+	switch cfg.IndexReaderMode {
+	case IndexReaderModeStream:
+		return tsdbindex.StreamOptions{MaxIdleFileHandles: cfg.StreamingIndexMaxIdleFileHandles}, nil
+	case IndexReaderModeMmap:
+		return tsdbindex.MmapOptions{}, nil
+	default:
+		return nil, fmt.Errorf("invalid shipper.index-reader-mode %q, must be one of mmap|stream", cfg.IndexReaderMode)
+	}
 }
 
 func (cfg *Config) Validate() error {
@@ -133,10 +152,8 @@ func (cfg *Config) Validate() error {
 		cfg.Mode = ModeReadWrite
 	}
 
-	switch cfg.IndexReaderMode {
-	case IndexReaderModeMmap, IndexReaderModeStream:
-	default:
-		return fmt.Errorf("invalid shipper.index-reader-mode %q, must be one of mmap|stream", cfg.IndexReaderMode)
+	if _, err := cfg.IndexReaderOptions(); err != nil {
+		return err
 	}
 
 	if cfg.DownloadTimeout <= 0 {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/compactor.go
@@ -14,8 +14,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
-
 	"github.com/grafana/loki/v3/pkg/compactor"
 	"github.com/grafana/loki/v3/pkg/compactor/retention"
 	"github.com/grafana/loki/v3/pkg/logproto"
@@ -39,7 +37,7 @@ func (i indexProcessor) NewTableCompactor(ctx context.Context, commonIndexSet co
 }
 
 func (i indexProcessor) OpenCompactedIndexFile(ctx context.Context, path, tableName, userID, workingDir string, periodConfig config.PeriodConfig, logger log.Logger) (compactor.CompactedIndex, error) {
-	indexFile, err := OpenShippableTSDB(path, indexshipper.IndexReaderModeMmap)
+	indexFile, err := OpenShippableTSDB(path, tsdbindex.MmapOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +107,7 @@ func (t *tableCompactor) CompactTable() error {
 		}
 
 		downloadPaths[job] = downloadedAt
-		idx, err := OpenShippableTSDB(downloadedAt, indexshipper.IndexReaderModeMmap)
+		idx, err := OpenShippableTSDB(downloadedAt, tsdbindex.MmapOptions{})
 		if err != nil {
 			return err
 		}
@@ -233,7 +231,7 @@ func processSourceIndex(ctx context.Context, sourceIndex storage.IndexFile, sour
 		}
 	}()
 
-	indexFile, err := OpenShippableTSDB(path, indexshipper.IndexReaderModeMmap)
+	indexFile, err := OpenShippableTSDB(path, tsdbindex.MmapOptions{})
 	if err != nil {
 		return err
 	}
@@ -482,7 +480,7 @@ func (c *compactedIndex) ToIndexFile() (shipperindex.Index, error) {
 		return nil, err
 	}
 
-	return NewShippableTSDBFile(id, indexshipper.IndexReaderModeMmap)
+	return NewShippableTSDBFile(id, tsdbindex.MmapOptions{})
 }
 
 func getUnsafeBytes(s string) []byte {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1310,6 +1310,18 @@ func NewByteSliceReader(b ByteSlice) (*ByteSliceReader, error) {
 	return newByteSliceReader(b, io.NopCloser(nil))
 }
 
+// MmapOptions selects the mmap-backed reader, which has nothing to tune.
+type MmapOptions struct{}
+
+// OpenReader implements ReaderOptions.
+func (MmapOptions) OpenReader(path string) (Reader, error) {
+	r, err := NewMmapFileReader(path)
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
 // NewMmapFileReader returns a new index reader against the given index file.
 // It uses mmap to read the file.
 func NewMmapFileReader(path string) (*ByteSliceReader, error) {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/reader.go
@@ -7,6 +7,14 @@ import (
 	"github.com/prometheus/prometheus/storage"
 )
 
+// ReaderOptions selects and configures one of the Reader implementations in this package.
+type ReaderOptions interface {
+	// OpenReader constructs the reader described by these options against the
+	// selected index file.
+	// The caller owns the returned Reader and must Close it.
+	OpenReader(path string) (Reader, error)
+}
+
 // Reader is the read-side interface implemented by every on-disk TSDB index reader.
 type Reader interface {
 	// Version returns the on-disk index format version.

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
@@ -41,9 +41,32 @@ type StreamReader struct {
 	decoder            *Decoder
 }
 
+const DefaultMaxIdleFileHandles = 16
+
+// StreamOptions selects the streaming reader and tunes it.
+type StreamOptions struct {
+	// MaxIdleFileHandles is the number of idle file handles the reader keeps
+	// open for its index file.
+	// Zero disables pooling entirely: every read opens and closes the file.
+	MaxIdleFileHandles uint
+}
+
+func DefaultStreamOptions() StreamOptions {
+	return StreamOptions{MaxIdleFileHandles: DefaultMaxIdleFileHandles}
+}
+
+// OpenReader implements ReaderOptions.
+func (o StreamOptions) OpenReader(path string) (Reader, error) {
+	r, err := NewStreamFileReader(path, o)
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
 // NewStreamFileReader constructs a StreamReader against the given index file.
-func NewStreamFileReader(path string) (*StreamReader, error) {
-	factory, err := streamenc.NewFilePoolDecbufFactory(path, 0, filepool.NewFilePoolMetrics(nil))
+func NewStreamFileReader(path string, opts StreamOptions) (*StreamReader, error) {
+	factory, err := streamenc.NewFilePoolDecbufFactory(path, opts.MaxIdleFileHandles, filepool.NewFilePoolMetrics(nil))
 	if err != nil {
 		return nil, fmt.Errorf("index file decbuf factory: %w", err)
 	}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
@@ -28,7 +28,7 @@ type readerConstructor struct {
 func allReaderConstructors() []readerConstructor {
 	return []readerConstructor{
 		{name: "MmapReader", open: func(p string) (Reader, error) { return NewMmapFileReader(p) }},
-		{name: "StreamReader", open: func(p string) (Reader, error) { return NewStreamFileReader(p) }},
+		{name: "StreamReader", open: func(p string) (Reader, error) { return NewStreamFileReader(p, DefaultStreamOptions()) }},
 	}
 }
 
@@ -94,7 +94,7 @@ func openBothReaders(t testing.TB, path string) (*ByteSliceReader, *StreamReader
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, mmap.Close()) })
 
-	stream, err := NewStreamFileReader(path)
+	stream, err := NewStreamFileReader(path, DefaultStreamOptions())
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, stream.Close()) })
 
@@ -120,7 +120,7 @@ func BenchmarkNewStreamFileReader(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		r, err := NewStreamFileReader(path)
+		r, err := NewStreamFileReader(path, DefaultStreamOptions())
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -146,7 +146,7 @@ func writeBenchmarkFixture(t testing.TB, numSeries int, numChunksPerLabel int) s
 
 func BenchmarkPostings(b *testing.B) {
 	path := writeBenchmarkFixture(b, 1_000_000, 3)
-	r, err := NewStreamFileReader(path)
+	r, err := NewStreamFileReader(path, DefaultStreamOptions())
 	require.NoError(b, err)
 
 	b.ReportAllocs()
@@ -433,7 +433,7 @@ func TestReaders_RejectsCorruptSectionChecksum(t *testing.T) {
 					path := writeCrossCheckFixture(t, FormatV3)
 
 					// Locate the section from the TOC
-					reader, err := NewStreamFileReader(path)
+					reader, err := NewStreamFileReader(path, DefaultStreamOptions())
 					require.NoError(t, err)
 					offset := sectionOffset(reader.toc)
 					require.NoError(t, reader.Close())

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/manager.go
@@ -134,7 +134,7 @@ func (m *tsdbManager) Start() error {
 			indices++
 
 			prefixed := NewPrefixedIdentifier(id, filepath.Join(mulitenantDir, bucket), "")
-			loaded, err := NewShippableTSDBFile(prefixed, indexshipper.IndexReaderModeMmap)
+			loaded, err := NewShippableTSDBFile(prefixed, index.MmapOptions{})
 
 			if err != nil {
 				level.Warn(m.log).Log(
@@ -237,7 +237,7 @@ func (m *tsdbManager) buildFromHead(heads *tenantHeads, indexShipper indexshippe
 
 		level.Debug(m.log).Log("msg", "finished building tsdb for period", "pd", p, "dst", dst.Path(), "duration", time.Since(start))
 
-		loaded, err := NewShippableTSDBFile(dst, indexshipper.IndexReaderModeMmap)
+		loaded, err := NewShippableTSDBFile(dst, index.MmapOptions{})
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/grafana/loki/v3/pkg/storage/stores/index/seriesvolume"
-	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	shipperindex "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/index"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 	"github.com/grafana/loki/v3/pkg/util"
@@ -30,17 +29,17 @@ var ErrAlreadyOnDesiredVersion = errors.New("tsdb file already on desired versio
 // The caller owns the returned reader and must Close it.
 type GetRawFileReaderFunc func() (io.ReadSeekCloser, error)
 
-func OpenShippableTSDB(p string, mode indexshipper.IndexReaderMode) (shipperindex.Index, error) {
+func OpenShippableTSDB(p string, opts index.ReaderOptions) (shipperindex.Index, error) {
 	id, err := identifierFromPath(p)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewShippableTSDBFile(id, mode)
+	return NewShippableTSDBFile(id, opts)
 }
 
 func RebuildWithVersion(ctx context.Context, path string, desiredVer int) (shipperindex.Index, error) {
-	indexFile, err := OpenShippableTSDB(path, indexshipper.IndexReaderModeMmap)
+	indexFile, err := OpenShippableTSDB(path, index.MmapOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +79,7 @@ func RebuildWithVersion(ctx context.Context, path string, desiredVer int) (shipp
 	if err != nil {
 		return nil, err
 	}
-	return NewShippableTSDBFile(id, indexshipper.IndexReaderModeMmap)
+	return NewShippableTSDBFile(id, index.MmapOptions{})
 }
 
 // nolint
@@ -96,8 +95,8 @@ type TSDBFile struct {
 	getRawFileReader GetRawFileReaderFunc
 }
 
-func NewShippableTSDBFile(id Identifier, mode indexshipper.IndexReaderMode) (*TSDBFile, error) {
-	idx, getRawFileReader, err := NewTSDBIndexFromFile(id.Path(), mode)
+func NewShippableTSDBFile(id Identifier, opts index.ReaderOptions) (*TSDBFile, error) {
+	idx, getRawFileReader, err := NewTSDBIndexFromFile(id.Path(), opts)
 	if err != nil {
 		return nil, err
 	}
@@ -128,8 +127,8 @@ type TSDBIndex struct {
 
 // Return the index as well as the underlying raw file reader which isn't exposed as an index
 // method but is helpful for building an io.reader for the index shipper
-func NewTSDBIndexFromFile(location string, mode indexshipper.IndexReaderMode) (*TSDBIndex, GetRawFileReaderFunc, error) {
-	reader, err := openIndexFileReader(location, mode)
+func NewTSDBIndexFromFile(location string, opts index.ReaderOptions) (*TSDBIndex, GetRawFileReaderFunc, error) {
+	reader, err := opts.OpenReader(location)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -137,17 +136,6 @@ func NewTSDBIndexFromFile(location string, mode indexshipper.IndexReaderMode) (*
 	return NewTSDBIndex(reader), func() (io.ReadSeekCloser, error) {
 		return reader.RawFileReader()
 	}, nil
-}
-
-// openIndexFileReader constructs the configured index.Reader implementation
-// for the given file. An empty mode falls back to the default (mmap).
-func openIndexFileReader(location string, mode indexshipper.IndexReaderMode) (index.Reader, error) {
-	switch mode {
-	case indexshipper.IndexReaderModeStream:
-		return index.NewStreamFileReader(location)
-	default:
-		return index.NewMmapFileReader(location)
-	}
 }
 
 func NewTSDBIndex(reader IndexReader) *TSDBIndex {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/store.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/store.go
@@ -67,7 +67,11 @@ func NewStore(
 func (s *store) init(name, prefix string, indexShipperCfg indexshipper.Config, schemaCfg config.SchemaConfig, objectClient client.ObjectClient,
 	limits downloads.Limits, tableRange config.TableRange, reg prometheus.Registerer) error {
 
-	var err error
+	readerOpts, err := indexShipperCfg.IndexReaderOptions()
+	if err != nil {
+		return err
+	}
+
 	s.indexShipper, err = indexshipper.NewIndexShipper(
 		prefix,
 		indexShipperCfg,
@@ -75,7 +79,7 @@ func (s *store) init(name, prefix string, indexShipperCfg indexshipper.Config, s
 		limits,
 		nil,
 		func(p string) (shipperindex.Index, error) {
-			return OpenShippableTSDB(p, indexShipperCfg.IndexReaderMode)
+			return OpenShippableTSDB(p, readerOpts)
 		},
 		tableRange,
 		prometheus.WrapRegistererWithPrefix("loki_tsdb_shipper_", reg),

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/util_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/util_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
-
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 )
 
@@ -37,7 +35,7 @@ func BuildIndex(t testing.TB, dir string, cases []LoadableSeries) *TSDBFile {
 	})
 	require.Nil(t, err)
 
-	idx, err := NewShippableTSDBFile(dst, indexshipper.IndexReaderModeMmap)
+	idx, err := NewShippableTSDBFile(dst, index.MmapOptions{})
 	require.Nil(t, err)
 	return idx
 }

--- a/tools/querycomparator/execute.go
+++ b/tools/querycomparator/execute.go
@@ -189,6 +189,7 @@ func doLocalQueryWithV1Engine(params logql.LiteralParams, bucketName string) (lo
 			CacheTTL:          time.Hour,
 			ResyncInterval:    time.Hour,
 			QueryReadyNumDays: 7,
+			IndexReaderMode:   indexshipper.DefaultIndexReaderMode,
 		},
 	}, config.ChunkStoreConfig{}, config.SchemaConfig{
 		Configs: []config.PeriodConfig{

--- a/tools/tsdb/index-analyzer/main.go
+++ b/tools/tsdb/index-analyzer/main.go
@@ -28,6 +28,9 @@ func main() {
 	objectClient, err := storage.NewObjectClient(periodCfg.ObjectType, "index-analyzer", conf.StorageConfig, clientMetrics)
 	helpers.ExitErr("creating object client", err)
 
+	readerOpts, err := conf.StorageConfig.TSDBShipperConfig.IndexReaderOptions()
+	helpers.ExitErr("resolving index reader options", err)
+
 	shipper, err := indexshipper.NewIndexShipper(
 		periodCfg.IndexTables.PathPrefix,
 		conf.StorageConfig.TSDBShipperConfig,
@@ -35,7 +38,7 @@ func main() {
 		overrides,
 		nil,
 		func(p string) (shipperindex.Index, error) {
-			return tsdb.OpenShippableTSDB(p, conf.StorageConfig.TSDBShipperConfig.IndexReaderMode)
+			return tsdb.OpenShippableTSDB(p, readerOpts)
 		},
 		tableRange,
 		prometheus.WrapRegistererWithPrefix("loki_tsdb_shipper_", prometheus.DefaultRegisterer),

--- a/tools/tsdb/migrate-versions/main_test.go
+++ b/tools/tsdb/migrate-versions/main_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -91,7 +90,7 @@ func TestMigrateTables(t *testing.T) {
 		require.NoError(t, err)
 
 		tableName := fmt.Sprintf("%s%d", indexPrefix, i)
-		idx, err := tsdb.NewShippableTSDBFile(id, indexshipper.IndexReaderModeMmap)
+		idx, err := tsdb.NewShippableTSDBFile(id, index.MmapOptions{})
 		require.NoError(t, err)
 
 		require.NoError(t, uploadFile(idx, indexStorageClient, tableName, userID))


### PR DESCRIPTION
One of the biggest costs when reading postings is opening and closing files. This change pools file handles, reducing that cost significantly.

We introduce ``-tsdb.shipper.streaming-index-max-idle-file-handles` to allow configuring this, with a default of 16. This number is chosen with minimal testing, but it's definitely better than 0!

Existing benchmarks:
```
                       │ before_pkg.txt │            after_pkg.txt            │
                       │     sec/op     │    sec/op     vs base               │
NewStreamFileReader-12      57.03µ ± 1%   20.75µ ±  4%  -63.61% (p=0.002 n=6)
Postings-12                 224.8µ ± 0%   208.3µ ± 10%        ~ (p=0.065 n=6)

                       │      B/op      │     B/op       vs base               │
NewStreamFileReader-12    6.867Ki ±  5%   5.440Ki ±  2%  -20.78% (p=0.002 n=6)
Postings-12                 939.5 ± 20%     673.0 ± 58%  -28.37% (p=0.002 n=6)

                       │   allocs/op    │ allocs/op   vs base               │
NewStreamFileReader-12       77.00 ± 0%   66.00 ± 0%  -14.29% (p=0.002 n=6)
Postings-12                 11.000 ± 0%   5.000 ± 0%  -54.55% (p=0.002 n=6)
```

Benchmarks against realistic indexes show an improvement of ~80% for selective queries.

**What this PR does / why we need it**: Part of our effort to migrate away from mmap in index gateways - we're now in the optimisation phase.

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**: N/A

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)