### PR TITLE
chore: Read series records through one scan per postings pass

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
@@ -883,8 +883,6 @@ func (t *tenantHeads) forAll(fn func(user string, ls labels.Labels, fp uint64, c
 			}
 
 			scan := idx.NewSeriesScan()
-			defer scan.Close()
-
 			for ps.Next() {
 				var (
 					ls   labels.Labels
@@ -894,13 +892,16 @@ func (t *tenantHeads) forAll(fn func(user string, ls labels.Labels, fp uint64, c
 				fp, err := scan.Series(ps.At(), 0, math.MaxInt64, &ls, &chks)
 
 				if err != nil {
+					_ = scan.Close()
 					return errors.Wrapf(err, "iterating postings for tenant: %s", user)
 				}
 
 				if err := fn(user, ls, fp, chks); err != nil {
+					_ = scan.Close()
 					return err
 				}
 			}
+			_ = scan.Close()
 		}
 	}
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_manager.go
@@ -882,13 +882,16 @@ func (t *tenantHeads) forAll(fn func(user string, ls labels.Labels, fp uint64, c
 				return err
 			}
 
+			scan := idx.NewSeriesScan()
+			defer scan.Close()
+
 			for ps.Next() {
 				var (
 					ls   labels.Labels
 					chks []index.ChunkMeta
 				)
 
-				fp, err := idx.Series(ps.At(), 0, math.MaxInt64, &ls, &chks)
+				fp, err := scan.Series(ps.At(), 0, math.MaxInt64, &ls, &chks)
 
 				if err != nil {
 					return errors.Wrapf(err, "iterating postings for tenant: %s", user)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/head_read.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/head_read.go
@@ -106,6 +106,24 @@ func (h *headIndexReader) Postings(name string, fpFilter index.FingerprintFilter
 	return p, nil
 }
 
+// NewSeriesScan implements IndexReader.
+//
+// The head keeps its series in memory, so there is nothing for a scan to
+// amortise across a pass and nothing for it to hold: headSeriesScan forwards
+// straight to the reader.
+func (h *headIndexReader) NewSeriesScan() index.SeriesScan {
+	return headSeriesScan{h}
+}
+
+// headSeriesScan is the no-op scan a headIndexReader hands out. Embedding the
+// reader promotes the series reads it already implements; only Close needs
+// overriding, because a scan borrows the reader rather than owning it.
+type headSeriesScan struct{ *headIndexReader }
+
+// Close is a no-op. Closing a scan must not close the reader it borrows, which
+// the embedded headIndexReader.Close would otherwise do.
+func (headSeriesScan) Close() error { return nil }
+
 // Series returns the series for the given reference.
 // lbls can be nil, to indicate that just the chunks are needed.
 func (h *headIndexReader) Series(ref storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]index.ChunkMeta) (uint64, error) {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/index.go
@@ -1689,6 +1689,20 @@ func (r *ByteSliceReader) LabelValues(name string, matchers ...*labels.Matcher) 
 	return values, nil
 }
 
+// NewSeriesScan returns a byteSliceSeriesScan which forwards requests
+// back to the ByteSliceReader.
+// A ByteSliceReader already has the whole index addressable in memory,
+// so there is nothing to amortize across a scan.
+func (r *ByteSliceReader) NewSeriesScan() SeriesScan {
+	return byteSliceSeriesScan{r}
+}
+
+// byteSliceSeriesScan forwards straight to its ByteSliceReader.
+type byteSliceSeriesScan struct{ *ByteSliceReader }
+
+// Close is a no-op.
+func (byteSliceSeriesScan) Close() error { return nil }
+
 // LabelNamesFor returns all the label names for the series referred to by IDs.
 // The names returned are sorted.
 func (r *ByteSliceReader) LabelNamesFor(ids ...storage.SeriesRef) ([]string, error) {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/reader.go
@@ -38,6 +38,40 @@ type Reader interface {
 	// sorted order.
 	LabelNames(matchers ...*labels.Matcher) ([]string, error)
 
+	// Postings returns a postings iterator over the series matching the
+	// (name, value) pairs.
+	Postings(name string, fpFilter FingerprintFilter, values ...string) (Postings, error)
+
+	// NewSeriesScan returns a scan over the series records of one pass over a
+	// postings list.
+	// The caller owns the returned scan and must Close it.
+	NewSeriesScan() SeriesScan
+
+	// Size returns the size of the underlying index in bytes.
+	Size() int64
+
+	// Close releases the underlying resources of the reader.
+	Close() error
+}
+
+// SeriesScan reads series records for a single pass over a postings list.
+// We generally scan through the series section of an index in ascending order
+// of SeriesRef, which is the order in which they're stored in the index file.
+// This makes it much more efficient to keep a reader open scanning forwards
+// through the file rather than opening a new one for each series that needs
+// to be read.
+//
+// A scan is not safe for concurrent use.
+// Refs are expected, but not required to arrive in ascending order. If they
+// arrive out of order then a performance cost may be paid.
+type SeriesScan interface {
+	// Series populates lbls and chks for the series identified by id.
+	Series(id storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]ChunkMeta) (uint64, error)
+
+	// ChunkStats returns aggregated chunk statistics for the series
+	// identified by id.
+	ChunkStats(id storage.SeriesRef, from, through int64, lbls *labels.Labels, by map[string]struct{}) (uint64, ChunkStats, error)
+
 	// LabelValueFor returns the value of the given label name for the series
 	// referred to by id.
 	LabelValueFor(id storage.SeriesRef, label string) (string, error)
@@ -46,20 +80,6 @@ type Reader interface {
 	// by ids.
 	LabelNamesFor(ids ...storage.SeriesRef) ([]string, error)
 
-	// Series populates lbls and chks for the series identified by id.
-	Series(id storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]ChunkMeta) (uint64, error)
-
-	// ChunkStats returns aggregated chunk statistics for the series
-	// identified by id.
-	ChunkStats(id storage.SeriesRef, from, through int64, lbls *labels.Labels, by map[string]struct{}) (uint64, ChunkStats, error)
-
-	// Postings returns a postings iterator over the series matching the
-	// (name, value) pairs.
-	Postings(name string, fpFilter FingerprintFilter, values ...string) (Postings, error)
-
-	// Size returns the size of the underlying index in bytes.
-	Size() int64
-
-	// Close releases the underlying resources of the reader.
+	// Close releases the resources held for the duration of the scan.
 	Close() error
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
@@ -3,13 +3,10 @@ package index
 import (
 	"context"
 	"fmt"
-	"hash/crc32"
 	"io"
 	"os"
-	"sort"
 
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/storage"
 
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc"
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/filepool"
@@ -212,125 +209,6 @@ func (s *StreamReader) readFingerprintOffsetsTable(offset int) (FingerprintOffse
 	return result, decbuf.Err()
 }
 
-// seriesOffset returns the absolute file offset of the series record for the
-// given series ref.
-// Series records are padded to a 16-byte alignment and a ref is the record's
-// file offset divided by 16, which is what lets a 4-byte ref address a much
-// larger file.
-// See Creator.AddSeries.
-func seriesOffset(id storage.SeriesRef) int {
-	return int(id) * 16
-}
-
-// maxSeriesForwardSkip bounds how far a seriesScan will read-and-discard
-// forward rather than repositioning the file.
-// Discarding drains the read-ahead buffer and then refills it, one read syscall
-// per bufferful, so past a buffer's worth of bytes a seek is the cheaper way to
-// get there.
-const maxSeriesForwardSkip = streamenc.ReaderBufferSize
-
-// seriesScan reads series records for a single pass over a postings list.
-// A seriesScan is not safe for concurrent use.
-type seriesScan struct {
-	reader *StreamReader
-	decbuf streamenc.Decbuf
-	// scratch backs the content slice handed to the decoder.
-	// The decoder never retains it, so it is reused across records rather
-	// than allocated per readSeriesRecord.
-	// It grows to the largest record the scan has seen.
-	scratch []byte
-	// reopen records that decbuf hit an error.
-	// A Decbuf's error is sticky and would silently no-op every later read,
-	// so the scan replaces it before the next readSeriesRecord rather than
-	// failing the rest of the iteration.
-	reopen bool
-}
-
-// NewSeriesScan implements Reader.
-func (s *StreamReader) NewSeriesScan() SeriesScan {
-	return &seriesScan{
-		reader: s,
-		decbuf: s.factory.NewRawDecbuf(context.Background()),
-	}
-}
-
-func (sc *seriesScan) Close() error {
-	return sc.decbuf.Close()
-}
-
-// seek positions the scan's reader at the given absolute file offset.
-//
-// A short forward step is served by discarding bytes, which will often come
-// straight out of the read-ahead buffer and cost nothing; anything else falls
-// back to repositioning the file.
-// Backwards steps are always a reposition, so out-of-order refs stay correct
-// and merely incur the cost of ResetAt.
-func (sc *seriesScan) seek(offset int) {
-	if distance := offset - sc.decbuf.Offset(); distance >= 0 && distance <= maxSeriesForwardSkip {
-		sc.decbuf.Skip(distance)
-		return
-	}
-	sc.decbuf.ResetAt(offset)
-}
-
-// readSeriesRecord reads the series record at the given absolute file offset
-// and returns its content bytes, having validated the record's CRC32.
-//
-// On disk a series record is a uvarint content length, the content, then
-// a CRC32 over the content alone.
-// The uvarint length prefix is why this can't go through the streamenc
-// factory: NewDecbufAtChecked assumes a 4-byte big-endian length, so we open
-// a raw Decbuf over the whole file and decode the record ourselves.
-// The returned bytes are only valid until the next call on this scan.
-func (sc *seriesScan) readSeriesRecord(offset int) ([]byte, error) {
-	if sc.reopen {
-		_ = sc.decbuf.Close()
-		sc.decbuf = sc.reader.factory.NewRawDecbuf(context.Background())
-		sc.reopen = false
-	}
-	if err := sc.decbuf.Err(); err != nil {
-		sc.reopen = true
-		return nil, fmt.Errorf("open series decbuf: %w", err)
-	}
-
-	if sc.seek(offset); sc.decbuf.Err() != nil {
-		sc.reopen = true
-		return nil, fmt.Errorf("go to start of series record: %w", sc.decbuf.Err())
-	}
-
-	contentLen := sc.decbuf.Uvarint64()
-	if err := sc.decbuf.Err(); err != nil {
-		sc.reopen = true
-		return nil, fmt.Errorf("read series record length: %w", err)
-	}
-	// Bound the claimed length against what is left in the file before
-	// allocating, so a corrupt length prefix can't ask for an arbitrarily
-	// large buffer.
-	remaining := sc.decbuf.Len()
-	if remaining < crc32.Size || contentLen > uint64(remaining-crc32.Size) {
-		return nil, fmt.Errorf(
-			"series record at %d claims %d content bytes but only %d remain: %w",
-			offset, contentLen, remaining, streamenc.ErrInvalidSize,
-		)
-	}
-
-	if uint64(cap(sc.scratch)) < contentLen {
-		sc.scratch = make([]byte, contentLen)
-	}
-	content := sc.scratch[:contentLen]
-
-	sc.decbuf.ReadInto(content)
-	expectedCRC := sc.decbuf.Be32()
-	if err := sc.decbuf.Err(); err != nil {
-		sc.reopen = true
-		return nil, fmt.Errorf("read series record: %w", err)
-	}
-	if crc32.Checksum(content, castagnoliTable) != expectedCRC {
-		return nil, fmt.Errorf("series record at %d: %w", offset, streamenc.ErrInvalidChecksum)
-	}
-	return content, nil
-}
-
 func (s *StreamReader) Version() int {
 	return s.version
 }
@@ -361,75 +239,6 @@ func (s *StreamReader) LabelNames(matchers ...*labels.Matcher) ([]string, error)
 		return nil, fmt.Errorf("matchers parameter is not implemented: %+v", matchers)
 	}
 	return s.postings.labelNames(), nil
-}
-
-func (sc *seriesScan) LabelValueFor(id storage.SeriesRef, label string) (string, error) {
-	content, err := sc.readSeriesRecord(seriesOffset(id))
-	if err != nil {
-		return "", fmt.Errorf("label values for: %w", err)
-	}
-
-	value, err := sc.reader.decoder.LabelValueFor(content, label)
-	if err != nil {
-		return "", storage.ErrNotFound
-	}
-	if value == "" {
-		return "", storage.ErrNotFound
-	}
-	return value, nil
-}
-
-func (sc *seriesScan) LabelNamesFor(ids ...storage.SeriesRef) ([]string, error) {
-	// Gather the name offsets in the symbol table first, so each distinct name
-	// is only resolved once no matter how many series carry it.
-	offsetsMap := make(map[uint32]struct{})
-	for _, id := range ids {
-		content, err := sc.readSeriesRecord(seriesOffset(id))
-		if err != nil {
-			return nil, fmt.Errorf("get buffer for series: %w", err)
-		}
-
-		offsets, err := sc.reader.decoder.LabelNamesOffsetsFor(content)
-		if err != nil {
-			return nil, fmt.Errorf("get label name offsets: %w", err)
-		}
-		for _, offset := range offsets {
-			offsetsMap[offset] = struct{}{}
-		}
-	}
-
-	names := make([]string, 0, len(offsetsMap))
-	for offset := range offsetsMap {
-		name, err := sc.reader.symbols.Lookup(offset)
-		if err != nil {
-			return nil, fmt.Errorf("lookup symbol in LabelNamesFor: %w", err)
-		}
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names, nil
-}
-
-func (sc *seriesScan) Series(id storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]ChunkMeta) (uint64, error) {
-	content, err := sc.readSeriesRecord(seriesOffset(id))
-	if err != nil {
-		return 0, err
-	}
-
-	fingerprint, err := sc.reader.decoder.Series(sc.reader.version, content, id, from, through, lbls, chks)
-	if err != nil {
-		return 0, fmt.Errorf("decode series: %w", err)
-	}
-	return fingerprint, nil
-}
-
-func (sc *seriesScan) ChunkStats(id storage.SeriesRef, from, through int64, lbls *labels.Labels, by map[string]struct{}) (uint64, ChunkStats, error) {
-	content, err := sc.readSeriesRecord(seriesOffset(id))
-	if err != nil {
-		return 0, ChunkStats{}, err
-	}
-
-	return sc.reader.decoder.ChunkStats(sc.reader.version, content, id, from, through, lbls, by)
 }
 
 // Postings returns a postings iterator for the given label name and values.

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader.go
@@ -115,7 +115,7 @@ func NewStreamFileReader(path string, opts StreamOptions) (*StreamReader, error)
 }
 
 // readHeader validates the magic bytes and returns the on-disk format version.
-func (s StreamReader) readHeader() (int, error) {
+func (s *StreamReader) readHeader() (int, error) {
 	// Validate header size
 	if s.size < int64(HeaderLen) {
 		return 0, fmt.Errorf("index header: %w", streamenc.ErrInvalidSize)
@@ -147,7 +147,7 @@ func (s StreamReader) readHeader() (int, error) {
 
 // readTOC reads the fixed-size TOC record from the tail of
 // the file and validates its CRC32.
-func (s StreamReader) readTOC() (*TOC, error) {
+func (s *StreamReader) readTOC() (*TOC, error) {
 	// Validate size
 	if s.size < int64(indexTOCLen) {
 		return nil, fmt.Errorf("index toc: %w", streamenc.ErrInvalidSize)
@@ -196,7 +196,7 @@ func (s StreamReader) readTOC() (*TOC, error) {
 // On disk the section is a 4-byte big-endian count N, followed by N
 // (seriesRef, fingerprint) pairs of 8-byte big-endian values, then the section CRC,
 // which NewDecbufAtChecked validates while opening.
-func (s StreamReader) readFingerprintOffsetsTable(offset int) (FingerprintOffsets, error) {
+func (s *StreamReader) readFingerprintOffsetsTable(offset int) (FingerprintOffsets, error) {
 	decbuf := s.factory.NewDecbufAtChecked(context.Background(), offset, castagnoliTable)
 	defer decbuf.Close()
 	if err := decbuf.Err(); err != nil {
@@ -222,6 +222,57 @@ func seriesOffset(id storage.SeriesRef) int {
 	return int(id) * 16
 }
 
+// maxSeriesForwardSkip bounds how far a seriesScan will read-and-discard
+// forward rather than repositioning the file.
+// Discarding drains the read-ahead buffer and then refills it, one read syscall
+// per bufferful, so past a buffer's worth of bytes a seek is the cheaper way to
+// get there.
+const maxSeriesForwardSkip = streamenc.ReaderBufferSize
+
+// seriesScan reads series records for a single pass over a postings list.
+// A seriesScan is not safe for concurrent use.
+type seriesScan struct {
+	reader *StreamReader
+	decbuf streamenc.Decbuf
+	// scratch backs the content slice handed to the decoder.
+	// The decoder never retains it, so it is reused across records rather
+	// than allocated per readSeriesRecord.
+	// It grows to the largest record the scan has seen.
+	scratch []byte
+	// reopen records that decbuf hit an error.
+	// A Decbuf's error is sticky and would silently no-op every later read,
+	// so the scan replaces it before the next readSeriesRecord rather than
+	// failing the rest of the iteration.
+	reopen bool
+}
+
+// NewSeriesScan implements Reader.
+func (s *StreamReader) NewSeriesScan() SeriesScan {
+	return &seriesScan{
+		reader: s,
+		decbuf: s.factory.NewRawDecbuf(context.Background()),
+	}
+}
+
+func (sc *seriesScan) Close() error {
+	return sc.decbuf.Close()
+}
+
+// seek positions the scan's reader at the given absolute file offset.
+//
+// A short forward step is served by discarding bytes, which will often come
+// straight out of the read-ahead buffer and cost nothing; anything else falls
+// back to repositioning the file.
+// Backwards steps are always a reposition, so out-of-order refs stay correct
+// and merely incur the cost of ResetAt.
+func (sc *seriesScan) seek(offset int) {
+	if distance := offset - sc.decbuf.Offset(); distance >= 0 && distance <= maxSeriesForwardSkip {
+		sc.decbuf.Skip(distance)
+		return
+	}
+	sc.decbuf.ResetAt(offset)
+}
+
 // readSeriesRecord reads the series record at the given absolute file offset
 // and returns its content bytes, having validated the record's CRC32.
 //
@@ -230,25 +281,32 @@ func seriesOffset(id storage.SeriesRef) int {
 // The uvarint length prefix is why this can't go through the streamenc
 // factory: NewDecbufAtChecked assumes a 4-byte big-endian length, so we open
 // a raw Decbuf over the whole file and decode the record ourselves.
-func (s StreamReader) readSeriesRecord(offset int) ([]byte, error) {
-	decbuf := s.factory.NewRawDecbuf(context.Background())
-	defer decbuf.Close()
-	if err := decbuf.Err(); err != nil {
+// The returned bytes are only valid until the next call on this scan.
+func (sc *seriesScan) readSeriesRecord(offset int) ([]byte, error) {
+	if sc.reopen {
+		_ = sc.decbuf.Close()
+		sc.decbuf = sc.reader.factory.NewRawDecbuf(context.Background())
+		sc.reopen = false
+	}
+	if err := sc.decbuf.Err(); err != nil {
+		sc.reopen = true
 		return nil, fmt.Errorf("open series decbuf: %w", err)
 	}
 
-	if decbuf.ResetAt(offset); decbuf.Err() != nil {
-		return nil, fmt.Errorf("go to start of series record: %w", decbuf.Err())
+	if sc.seek(offset); sc.decbuf.Err() != nil {
+		sc.reopen = true
+		return nil, fmt.Errorf("go to start of series record: %w", sc.decbuf.Err())
 	}
 
-	contentLen := decbuf.Uvarint64()
-	if err := decbuf.Err(); err != nil {
+	contentLen := sc.decbuf.Uvarint64()
+	if err := sc.decbuf.Err(); err != nil {
+		sc.reopen = true
 		return nil, fmt.Errorf("read series record length: %w", err)
 	}
 	// Bound the claimed length against what is left in the file before
 	// allocating, so a corrupt length prefix can't ask for an arbitrarily
 	// large buffer.
-	remaining := decbuf.Len()
+	remaining := sc.decbuf.Len()
 	if remaining < crc32.Size || contentLen > uint64(remaining-crc32.Size) {
 		return nil, fmt.Errorf(
 			"series record at %d claims %d content bytes but only %d remain: %w",
@@ -256,10 +314,15 @@ func (s StreamReader) readSeriesRecord(offset int) ([]byte, error) {
 		)
 	}
 
-	content := make([]byte, contentLen)
-	decbuf.ReadInto(content)
-	expectedCRC := decbuf.Be32()
-	if err := decbuf.Err(); err != nil {
+	if uint64(cap(sc.scratch)) < contentLen {
+		sc.scratch = make([]byte, contentLen)
+	}
+	content := sc.scratch[:contentLen]
+
+	sc.decbuf.ReadInto(content)
+	expectedCRC := sc.decbuf.Be32()
+	if err := sc.decbuf.Err(); err != nil {
+		sc.reopen = true
 		return nil, fmt.Errorf("read series record: %w", err)
 	}
 	if crc32.Checksum(content, castagnoliTable) != expectedCRC {
@@ -268,45 +331,45 @@ func (s StreamReader) readSeriesRecord(offset int) ([]byte, error) {
 	return content, nil
 }
 
-func (s StreamReader) Version() int {
+func (s *StreamReader) Version() int {
 	return s.version
 }
 
 // RawFileReader opens a fresh file handle over the index file.
 // The caller owns closing it.
-func (s StreamReader) RawFileReader() (io.ReadSeekCloser, error) {
+func (s *StreamReader) RawFileReader() (io.ReadSeekCloser, error) {
 	return os.Open(s.path)
 }
 
-func (s StreamReader) Bounds() (int64, int64) {
+func (s *StreamReader) Bounds() (int64, int64) {
 	return s.toc.Metadata.From, s.toc.Metadata.Through
 }
 
-func (s StreamReader) Checksum() uint32 {
+func (s *StreamReader) Checksum() uint32 {
 	return s.toc.Metadata.Checksum
 }
 
-func (s StreamReader) LabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
+func (s *StreamReader) LabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
 	if len(matchers) > 0 {
 		return nil, fmt.Errorf("matchers parameter is not implemented: %+v", matchers)
 	}
 	return s.postings.labelValuesFor(name)
 }
 
-func (s StreamReader) LabelNames(matchers ...*labels.Matcher) ([]string, error) {
+func (s *StreamReader) LabelNames(matchers ...*labels.Matcher) ([]string, error) {
 	if len(matchers) > 0 {
 		return nil, fmt.Errorf("matchers parameter is not implemented: %+v", matchers)
 	}
 	return s.postings.labelNames(), nil
 }
 
-func (s StreamReader) LabelValueFor(id storage.SeriesRef, label string) (string, error) {
-	content, err := s.readSeriesRecord(seriesOffset(id))
+func (sc *seriesScan) LabelValueFor(id storage.SeriesRef, label string) (string, error) {
+	content, err := sc.readSeriesRecord(seriesOffset(id))
 	if err != nil {
 		return "", fmt.Errorf("label values for: %w", err)
 	}
 
-	value, err := s.decoder.LabelValueFor(content, label)
+	value, err := sc.reader.decoder.LabelValueFor(content, label)
 	if err != nil {
 		return "", storage.ErrNotFound
 	}
@@ -316,17 +379,17 @@ func (s StreamReader) LabelValueFor(id storage.SeriesRef, label string) (string,
 	return value, nil
 }
 
-func (s StreamReader) LabelNamesFor(ids ...storage.SeriesRef) ([]string, error) {
+func (sc *seriesScan) LabelNamesFor(ids ...storage.SeriesRef) ([]string, error) {
 	// Gather the name offsets in the symbol table first, so each distinct name
 	// is only resolved once no matter how many series carry it.
 	offsetsMap := make(map[uint32]struct{})
 	for _, id := range ids {
-		content, err := s.readSeriesRecord(seriesOffset(id))
+		content, err := sc.readSeriesRecord(seriesOffset(id))
 		if err != nil {
 			return nil, fmt.Errorf("get buffer for series: %w", err)
 		}
 
-		offsets, err := s.decoder.LabelNamesOffsetsFor(content)
+		offsets, err := sc.reader.decoder.LabelNamesOffsetsFor(content)
 		if err != nil {
 			return nil, fmt.Errorf("get label name offsets: %w", err)
 		}
@@ -337,7 +400,7 @@ func (s StreamReader) LabelNamesFor(ids ...storage.SeriesRef) ([]string, error) 
 
 	names := make([]string, 0, len(offsetsMap))
 	for offset := range offsetsMap {
-		name, err := s.symbols.Lookup(offset)
+		name, err := sc.reader.symbols.Lookup(offset)
 		if err != nil {
 			return nil, fmt.Errorf("lookup symbol in LabelNamesFor: %w", err)
 		}
@@ -347,26 +410,26 @@ func (s StreamReader) LabelNamesFor(ids ...storage.SeriesRef) ([]string, error) 
 	return names, nil
 }
 
-func (s StreamReader) Series(id storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]ChunkMeta) (uint64, error) {
-	content, err := s.readSeriesRecord(seriesOffset(id))
+func (sc *seriesScan) Series(id storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]ChunkMeta) (uint64, error) {
+	content, err := sc.readSeriesRecord(seriesOffset(id))
 	if err != nil {
 		return 0, err
 	}
 
-	fingerprint, err := s.decoder.Series(s.version, content, id, from, through, lbls, chks)
+	fingerprint, err := sc.reader.decoder.Series(sc.reader.version, content, id, from, through, lbls, chks)
 	if err != nil {
 		return 0, fmt.Errorf("decode series: %w", err)
 	}
 	return fingerprint, nil
 }
 
-func (s StreamReader) ChunkStats(id storage.SeriesRef, from, through int64, lbls *labels.Labels, by map[string]struct{}) (uint64, ChunkStats, error) {
-	content, err := s.readSeriesRecord(seriesOffset(id))
+func (sc *seriesScan) ChunkStats(id storage.SeriesRef, from, through int64, lbls *labels.Labels, by map[string]struct{}) (uint64, ChunkStats, error) {
+	content, err := sc.readSeriesRecord(seriesOffset(id))
 	if err != nil {
 		return 0, ChunkStats{}, err
 	}
 
-	return s.decoder.ChunkStats(s.version, content, id, from, through, lbls, by)
+	return sc.reader.decoder.ChunkStats(sc.reader.version, content, id, from, through, lbls, by)
 }
 
 // Postings returns a postings iterator for the given label name and values.
@@ -374,7 +437,7 @@ func (s StreamReader) ChunkStats(id storage.SeriesRef, from, through int64, lbls
 //
 // A non-nil FingerprintFilter restricts the result to the requested shard by
 // bounding the merged postings with the fingerprint offsets table.
-func (s StreamReader) Postings(labelName string, fpFilter FingerprintFilter, labelValues ...string) (Postings, error) {
+func (s *StreamReader) Postings(labelName string, fpFilter FingerprintFilter, labelValues ...string) (Postings, error) {
 	postings, err := s.postings.postingsFor(labelName, labelValues...)
 	if err != nil {
 		return nil, err
@@ -385,10 +448,10 @@ func (s StreamReader) Postings(labelName string, fpFilter FingerprintFilter, lab
 	return postings, nil
 }
 
-func (s StreamReader) Size() int64 {
+func (s *StreamReader) Size() int64 {
 	return s.size
 }
 
-func (s StreamReader) Close() error {
+func (s *StreamReader) Close() error {
 	return s.factory.Close()
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
@@ -7,6 +7,7 @@ import (
 	"hash/crc32"
 	"io"
 	"math"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"slices"
@@ -99,6 +100,21 @@ func openBothReaders(t testing.TB, path string) (*ByteSliceReader, *StreamReader
 	t.Cleanup(func() { require.NoError(t, stream.Close()) })
 
 	return mmap, stream
+}
+
+// scanFor opens a series scan over r, registering a cleanup that closes it.
+func scanFor(t testing.TB, r Reader) SeriesScan {
+	t.Helper()
+
+	scan := r.NewSeriesScan()
+	t.Cleanup(func() { require.NoError(t, scan.Close()) })
+	return scan
+}
+
+// scanBoth opens a series scan over each reader returned by openBothReaders.
+func scanBoth(t testing.TB, mmap, stream Reader) (SeriesScan, SeriesScan) {
+	t.Helper()
+	return scanFor(t, mmap), scanFor(t, stream)
 }
 
 // writeCrossCheckFixture builds a small but non-trivial index used by
@@ -259,6 +275,7 @@ func TestStreamReader_SeriesMatchesMmap(t *testing.T) {
 		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
 			path, through := writeManyChunksFixture(t, format)
 			mmap, stream := openBothReaders(t, path)
+			mmapScan, streamScan := scanBoth(t, mmap, stream)
 
 			refs := allSeriesRefs(t, mmap)
 			require.NotEmpty(t, refs)
@@ -279,7 +296,7 @@ func TestStreamReader_SeriesMatchesMmap(t *testing.T) {
 			for _, w := range windows {
 				t.Run(w.name, func(t *testing.T) {
 					for _, ref := range refs {
-						requireStreamSeriesEqual(t, mmap, stream, ref, w.from, w.through)
+						requireStreamSeriesEqual(t, mmapScan, streamScan, ref, w.from, w.through)
 					}
 				})
 			}
@@ -288,9 +305,9 @@ func TestStreamReader_SeriesMatchesMmap(t *testing.T) {
 }
 
 // requireStreamSeriesEqual asserts that Series and ChunkStats agree between the
-// two readers for one series ref and one query window, including the
+// two readers' scans for one series ref and one query window, including the
 // labels-free Series path.
-func requireStreamSeriesEqual(t *testing.T, mmap, stream Reader, ref storage.SeriesRef, from, through int64) {
+func requireStreamSeriesEqual(t *testing.T, mmap, stream SeriesScan, ref storage.SeriesRef, from, through int64) {
 	t.Helper()
 
 	var mmapLabels, streamLabels labels.Labels
@@ -474,12 +491,14 @@ func TestReaders_RejectsCorruptSeriesRecord(t *testing.T) {
 					require.NoError(t, err)
 					t.Cleanup(func() { require.NoError(t, r.Close()) })
 
+					scan := scanFor(t, r)
+
 					var lbls labels.Labels
 					var chunks []ChunkMeta
-					_, err = r.Series(ref, 0, math.MaxInt64, &lbls, &chunks)
+					_, err = scan.Series(ref, 0, math.MaxInt64, &lbls, &chunks)
 					require.ErrorContains(t, err, "invalid checksum")
 
-					_, _, err = r.ChunkStats(ref, 0, math.MaxInt64, &lbls, nil)
+					_, _, err = scan.ChunkStats(ref, 0, math.MaxInt64, &lbls, nil)
 					require.ErrorContains(t, err, "invalid checksum")
 				})
 			}
@@ -517,12 +536,14 @@ func TestReaders_RejectsOutOfRangeSeriesRef(t *testing.T) {
 			require.NoError(t, err)
 			t.Cleanup(func() { require.NoError(t, r.Close()) })
 
+			scan := scanFor(t, r)
+
 			var lbls labels.Labels
 			var chunks []ChunkMeta
-			_, err = r.Series(ref, 0, math.MaxInt64, &lbls, &chunks)
+			_, err = scan.Series(ref, 0, math.MaxInt64, &lbls, &chunks)
 			require.ErrorContains(t, err, "invalid size")
 
-			_, _, err = r.ChunkStats(ref, 0, math.MaxInt64, &lbls, nil)
+			_, _, err = scan.ChunkStats(ref, 0, math.MaxInt64, &lbls, nil)
 			require.ErrorContains(t, err, "invalid size")
 		})
 	}
@@ -585,6 +606,7 @@ func TestStreamLabels_MatchesMmap(t *testing.T) {
 			for _, format := range []int{FormatV3, FormatV4} {
 				t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
 					mmap, stream := openBothReaders(t, writeFixture(t, format))
+					mmapScan, streamScan := scanBoth(t, mmap, stream)
 
 					mmapNames, err := mmap.LabelNames()
 					require.NoError(t, err)
@@ -608,25 +630,25 @@ func TestStreamLabels_MatchesMmap(t *testing.T) {
 					require.NotEmpty(t, refs)
 
 					// LabelNamesFor over every ref at once
-					mmapNamesFor, err := mmap.LabelNamesFor(refs...)
+					mmapNamesFor, err := mmapScan.LabelNamesFor(refs...)
 					require.NoError(t, err)
-					streamNamesFor, err := stream.LabelNamesFor(refs...)
+					streamNamesFor, err := streamScan.LabelNamesFor(refs...)
 					require.NoError(t, err)
 					require.Equal(t, mmapNamesFor, streamNamesFor)
 
 					for _, ref := range refs {
 						// LabelNamesFor over every ref at once
-						mmapNamesFor, err := mmap.LabelNamesFor(ref)
+						mmapNamesFor, err := mmapScan.LabelNamesFor(ref)
 						require.NoError(t, err)
-						streamNamesFor, err := stream.LabelNamesFor(ref)
+						streamNamesFor, err := streamScan.LabelNamesFor(ref)
 						require.NoError(t, err)
 						require.Equal(t, mmapNamesFor, streamNamesFor)
 
 						// Both a label the series carries and one it doesn't,
 						// the latter being reported as storage.ErrNotFound.
 						for _, labelName := range slices.Concat(mmapNames, []string{"does-not-exist"}) {
-							mmapValue, mmapErr := mmap.LabelValueFor(ref, labelName)
-							streamValue, streamErr := stream.LabelValueFor(ref, labelName)
+							mmapValue, mmapErr := mmapScan.LabelValueFor(ref, labelName)
+							streamValue, streamErr := streamScan.LabelValueFor(ref, labelName)
 							require.Equal(t, mmapErr, streamErr)
 							require.Equal(t, mmapValue, streamValue)
 						}
@@ -634,9 +656,9 @@ func TestStreamLabels_MatchesMmap(t *testing.T) {
 
 					// LabelNamesFor rejects a ref past the end of the file the
 					// same way in both readers.
-					_, err = stream.LabelNamesFor(refs[len(refs)-1] + 1<<20)
+					_, err = streamScan.LabelNamesFor(refs[len(refs)-1] + 1<<20)
 					require.Error(t, err)
-					_, err = mmap.LabelNamesFor(refs[len(refs)-1] + 1<<20)
+					_, err = mmapScan.LabelNamesFor(refs[len(refs)-1] + 1<<20)
 					require.Error(t, err)
 				})
 			}
@@ -672,16 +694,221 @@ func TestStreamLabels_RejectsCorruptSeriesRecord(t *testing.T) {
 	corruptSeriesRecord(t, path, ref)
 
 	mmap, stream := openBothReaders(t, path)
+	mmapScan, streamScan := scanBoth(t, mmap, stream)
 
-	_, mmapErr := mmap.LabelNamesFor(ref)
-	_, streamErr := stream.LabelNamesFor(ref)
+	_, mmapErr := mmapScan.LabelNamesFor(ref)
+	_, streamErr := streamScan.LabelNamesFor(ref)
 	require.ErrorContains(t, mmapErr, "invalid checksum")
 	require.ErrorContains(t, streamErr, "invalid checksum")
-	_, mmapErr = mmap.LabelValueFor(ref, "id")
-	_, streamErr = stream.LabelValueFor(ref, "id")
+	_, mmapErr = mmapScan.LabelValueFor(ref, "id")
+	_, streamErr = streamScan.LabelValueFor(ref, "id")
 	require.ErrorContains(t, mmapErr, "invalid checksum")
 	require.ErrorContains(t, streamErr, "invalid checksum")
 
+}
+
+// TestStreamReader_SeriesScanRefOrders asserts a scan agrees with the mmap
+// reader whatever order the refs arrive in.
+func TestStreamReader_SeriesScanRefOrders(t *testing.T) {
+	for _, format := range []int{FormatV3, FormatV4} {
+		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
+			path, _ := writeManyChunksFixture(t, format)
+			mmap, stream := openBothReaders(t, path)
+			mmapScan := scanFor(t, mmap)
+
+			ascending := allSeriesRefs(t, mmap)
+			require.NotEmpty(t, ascending)
+
+			descending := slices.Clone(ascending)
+			slices.Reverse(descending)
+
+			// A fixed shuffle, plus repeats, so the scan sees both backwards
+			// steps and a ref it has already read.
+			shuffled := slices.Clone(ascending)
+			rnd := rand.New(rand.NewSource(1))
+			rnd.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+			shuffled = append(shuffled, ascending[0], ascending[len(ascending)-1], ascending[0])
+
+			for name, refs := range map[string][]storage.SeriesRef{
+				"ascending":  ascending,
+				"descending": descending,
+				"shuffled":   shuffled,
+			} {
+				t.Run(name, func(t *testing.T) {
+					scan := stream.NewSeriesScan()
+					defer func() { require.NoError(t, scan.Close()) }()
+
+					// Collect everything the scan produces before comparing, so a
+					// record whose bytes were invalidated by a later read shows up
+					// as a mismatch rather than being compared while still valid.
+					type result struct {
+						fingerprint uint64
+						lbls        labels.Labels
+						chunks      []ChunkMeta
+						stats       ChunkStats
+						labelValue  string
+					}
+					got := make([]result, 0, len(refs))
+					for _, ref := range refs {
+						var r result
+						var err error
+						r.fingerprint, err = scan.Series(ref, 0, math.MaxInt64, &r.lbls, &r.chunks)
+						require.NoError(t, err)
+						r.chunks = slices.Clone(r.chunks)
+
+						var statsLabels labels.Labels
+						_, r.stats, err = scan.ChunkStats(ref, 0, math.MaxInt64, &statsLabels, nil)
+						require.NoError(t, err)
+
+						r.labelValue, err = scan.LabelValueFor(ref, "id")
+						require.NoError(t, err)
+
+						got = append(got, r)
+					}
+
+					for i, ref := range refs {
+						var wantLabels labels.Labels
+						var wantChunks []ChunkMeta
+						wantFingerprint, err := mmapScan.Series(ref, 0, math.MaxInt64, &wantLabels, &wantChunks)
+						require.NoError(t, err)
+						require.Equal(t, wantFingerprint, got[i].fingerprint)
+						require.Equal(t, wantLabels, got[i].lbls)
+						require.Equal(t, wantChunks, got[i].chunks)
+
+						var statsLabels labels.Labels
+						_, wantStats, err := mmapScan.ChunkStats(ref, 0, math.MaxInt64, &statsLabels, nil)
+						require.NoError(t, err)
+						require.Equal(t, wantStats, got[i].stats)
+
+						wantValue, err := mmapScan.LabelValueFor(ref, "id")
+						require.NoError(t, err)
+						require.Equal(t, wantValue, got[i].labelValue)
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestStreamReader_SeriesScanRecoversFromError asserts a scan that hits a bad
+// record keeps working for the records after it.
+func TestStreamReader_SeriesScanRecoversFromError(t *testing.T) {
+	path, _ := writeManyChunksFixture(t, FormatV4)
+
+	mmap, err := NewMmapFileReader(path)
+	require.NoError(t, err)
+	refs := allSeriesRefs(t, mmap)
+	require.NoError(t, mmap.Close())
+	require.Greater(t, len(refs), 2)
+
+	corruptSeriesRecord(t, path, refs[0])
+
+	mmap, stream := openBothReaders(t, path)
+	mmapScan, scan := scanBoth(t, mmap, stream)
+
+	var lbls labels.Labels
+	var chunks []ChunkMeta
+
+	// A corrupt record, then a ref past the end of the file, then good records:
+	// each failure mode must leave the scan usable.
+	_, err = scan.Series(refs[0], 0, math.MaxInt64, &lbls, &chunks)
+	require.ErrorContains(t, err, "invalid checksum")
+
+	_, err = scan.Series(refs[len(refs)-1]+1<<20, 0, math.MaxInt64, &lbls, &chunks)
+	require.ErrorContains(t, err, "invalid size")
+
+	for _, ref := range refs[1:] {
+		var wantLabels labels.Labels
+		var wantChunks []ChunkMeta
+		wantFingerprint, err := mmapScan.Series(ref, 0, math.MaxInt64, &wantLabels, &wantChunks)
+		require.NoError(t, err)
+
+		gotFingerprint, err := scan.Series(ref, 0, math.MaxInt64, &lbls, &chunks)
+		require.NoError(t, err)
+		require.Equal(t, wantFingerprint, gotFingerprint)
+		require.Equal(t, wantLabels, lbls)
+		require.Equal(t, wantChunks, chunks)
+	}
+}
+
+// TestStreamReader_ConcurrentSeriesScans asserts that scans taken from one
+// reader are independent.
+func TestStreamReader_ConcurrentSeriesScans(t *testing.T) {
+	path, _ := writeManyChunksFixture(t, FormatV4)
+	mmap, stream := openBothReaders(t, path)
+
+	refs := allSeriesRefs(t, mmap)
+	require.NotEmpty(t, refs)
+
+	mmapScan := scanFor(t, mmap)
+	want := make([]labels.Labels, len(refs))
+	for i, ref := range refs {
+		var chunks []ChunkMeta
+		_, err := mmapScan.Series(ref, 0, math.MaxInt64, &want[i], &chunks)
+		require.NoError(t, err)
+	}
+
+	const goroutines = 8
+	errs := make(chan error, goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			errs <- func() error {
+				scan := stream.NewSeriesScan()
+				defer func() { _ = scan.Close() }()
+
+				for round := 0; round < 20; round++ {
+					for i, ref := range refs {
+						var lbls labels.Labels
+						var chunks []ChunkMeta
+						if _, err := scan.Series(ref, 0, math.MaxInt64, &lbls, &chunks); err != nil {
+							return err
+						}
+						if !labels.Equal(want[i], lbls) {
+							return fmt.Errorf("ref %d: got %s, want %s", ref, lbls, want[i])
+						}
+					}
+				}
+				return nil
+			}()
+		}()
+	}
+	for g := 0; g < goroutines; g++ {
+		require.NoError(t, <-errs)
+	}
+}
+
+// BenchmarkSeriesIteration reads every series matched by a broad postings list.
+func BenchmarkSeriesIteration(b *testing.B) {
+	path := writeBenchmarkFixture(b, 200_000, 3)
+	r, err := NewStreamFileReader(path, DefaultStreamOptions())
+	require.NoError(b, err)
+	b.Cleanup(func() { require.NoError(b, r.Close()) })
+
+	postings, err := r.Postings("c", nil, "3")
+	require.NoError(b, err)
+	var refs []storage.SeriesRef
+	for postings.Next() {
+		refs = append(refs, postings.At())
+	}
+	require.NoError(b, postings.Err())
+	require.NotEmpty(b, refs)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		scan := r.NewSeriesScan()
+		var lbls labels.Labels
+		chunks := make([]ChunkMeta, 0, 8)
+		for _, ref := range refs {
+			chunks = chunks[:0]
+			if _, err := scan.Series(ref, 0, math.MaxInt64, &lbls, &chunks); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err := scan.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
 }
 
 // corruptFileBytes reads the whole file, hands the bytes to mutate, and
@@ -714,6 +941,8 @@ func requireLabelsEqual(t *testing.T, mmap, stream Reader) {
 
 func requirePostingsSeriesEqual(t *testing.T, mmap, stream Reader) {
 	t.Helper()
+	mmapScan, streamScan := scanBoth(t, mmap, stream)
+
 	labelNames, err := mmap.LabelNames()
 	require.NoError(t, err)
 	for _, labelName := range labelNames {
@@ -725,13 +954,13 @@ func requirePostingsSeriesEqual(t *testing.T, mmap, stream Reader) {
 			require.Equal(t, mmapSeriesRefs, streamSeriesRefs)
 
 			for _, seriesRef := range mmapSeriesRefs {
-				requireSeriesEqual(t, mmap, stream, seriesRef, labelName)
+				requireSeriesEqual(t, mmapScan, streamScan, seriesRef, labelName)
 			}
 		}
 	}
 }
 
-func requireSeriesEqual(t *testing.T, mmap, stream Reader, seriesRef storage.SeriesRef, labelName string) {
+func requireSeriesEqual(t *testing.T, mmap, stream SeriesScan, seriesRef storage.SeriesRef, labelName string) {
 	t.Helper()
 
 	var mmapLabels, streamLabels labels.Labels
@@ -759,7 +988,7 @@ func requireSeriesEqual(t *testing.T, mmap, stream Reader, seriesRef storage.Ser
 	requireChunkStatsEqual(t, mmap, stream, seriesRef, labelName)
 }
 
-func requireChunkStatsEqual(t *testing.T, mmap Reader, stream Reader, seriesRef storage.SeriesRef, labelName string) {
+func requireChunkStatsEqual(t *testing.T, mmap, stream SeriesScan, seriesRef storage.SeriesRef, labelName string) {
 	for _, by := range []map[string]struct{}{nil, {labelName: {}}} {
 		var mmapLabels, streamLabels labels.Labels
 		mmapFingerprints, mmapChunkStats, err := mmap.ChunkStats(seriesRef, 0, math.MaxInt64, &mmapLabels, by)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_series.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_series.go
@@ -1,0 +1,202 @@
+package index
+
+import (
+	"context"
+	"fmt"
+	"hash/crc32"
+	"sort"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+
+	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc"
+)
+
+// seriesOffset returns the absolute file offset of the series record for the
+// given series ref.
+// Series records are padded to a 16-byte alignment and a ref is the record's
+// file offset divided by 16, which is what lets a 4-byte ref address a much
+// larger file.
+// See Creator.AddSeries.
+func seriesOffset(id storage.SeriesRef) int {
+	return int(id) * 16
+}
+
+// maxSeriesForwardSkip bounds how far a seriesScan will read-and-discard
+// forward rather than repositioning the file.
+// Discarding drains the read-ahead buffer and then refills it, one read syscall
+// per bufferful, so past a buffer's worth of bytes a seek is the cheaper way to
+// get there.
+const maxSeriesForwardSkip = streamenc.ReaderBufferSize
+
+// seriesScan reads series records for a single pass over a postings list.
+// It is how StreamReader reads the postings list.
+// A seriesScan is not safe for concurrent use.
+type seriesScan struct {
+	reader *StreamReader
+	decbuf streamenc.Decbuf
+	// scratch backs the content slice handed to the decoder.
+	// The decoder never retains it, so it is reused across records rather
+	// than allocated per readSeriesRecord.
+	// It grows to the largest record the scan has seen.
+	scratch []byte
+	// reopen records that decbuf hit an error.
+	// A Decbuf's error is sticky and would silently no-op every later read,
+	// so the scan replaces it before the next readSeriesRecord rather than
+	// failing the rest of the iteration.
+	reopen bool
+}
+
+// NewSeriesScan implements Reader.
+func (s *StreamReader) NewSeriesScan() SeriesScan {
+	return &seriesScan{
+		reader: s,
+		decbuf: s.factory.NewRawDecbuf(context.Background()),
+	}
+}
+
+func (sc *seriesScan) Close() error {
+	return sc.decbuf.Close()
+}
+
+// seek positions the scan's reader at the given absolute file offset.
+//
+// A short forward step is served by discarding bytes, which will often come
+// straight out of the read-ahead buffer and cost nothing; anything else falls
+// back to repositioning the file.
+// Backwards steps are always a reposition, so out-of-order refs stay correct
+// and merely incur the cost of ResetAt.
+func (sc *seriesScan) seek(offset int) {
+	if distance := offset - sc.decbuf.Offset(); distance >= 0 && distance <= maxSeriesForwardSkip {
+		sc.decbuf.Skip(distance)
+		return
+	}
+	sc.decbuf.ResetAt(offset)
+}
+
+// readSeriesRecord reads the series record at the given absolute file offset
+// and returns its content bytes, having validated the record's CRC32.
+//
+// On disk a series record is a uvarint content length, the content, then
+// a CRC32 over the content alone.
+// The uvarint length prefix is why this can't go through the streamenc
+// factory: NewDecbufAtChecked assumes a 4-byte big-endian length, so we open
+// a raw Decbuf over the whole file and decode the record ourselves.
+// The returned bytes are only valid until the next call on this scan.
+func (sc *seriesScan) readSeriesRecord(offset int) ([]byte, error) {
+	if sc.reopen {
+		_ = sc.decbuf.Close()
+		sc.decbuf = sc.reader.factory.NewRawDecbuf(context.Background())
+		sc.reopen = false
+	}
+	if err := sc.decbuf.Err(); err != nil {
+		sc.reopen = true
+		return nil, fmt.Errorf("open series decbuf: %w", err)
+	}
+
+	if sc.seek(offset); sc.decbuf.Err() != nil {
+		sc.reopen = true
+		return nil, fmt.Errorf("go to start of series record: %w", sc.decbuf.Err())
+	}
+
+	contentLen := sc.decbuf.Uvarint64()
+	if err := sc.decbuf.Err(); err != nil {
+		sc.reopen = true
+		return nil, fmt.Errorf("read series record length: %w", err)
+	}
+	// Bound the claimed length against what is left in the file before
+	// allocating, so a corrupt length prefix can't ask for an arbitrarily
+	// large buffer.
+	remaining := sc.decbuf.Len()
+	if remaining < crc32.Size || contentLen > uint64(remaining-crc32.Size) {
+		return nil, fmt.Errorf(
+			"series record at %d claims %d content bytes but only %d remain: %w",
+			offset, contentLen, remaining, streamenc.ErrInvalidSize,
+		)
+	}
+
+	if uint64(cap(sc.scratch)) < contentLen {
+		sc.scratch = make([]byte, contentLen)
+	}
+	content := sc.scratch[:contentLen]
+
+	sc.decbuf.ReadInto(content)
+	expectedCRC := sc.decbuf.Be32()
+	if err := sc.decbuf.Err(); err != nil {
+		sc.reopen = true
+		return nil, fmt.Errorf("read series record: %w", err)
+	}
+	if crc32.Checksum(content, castagnoliTable) != expectedCRC {
+		return nil, fmt.Errorf("series record at %d: %w", offset, streamenc.ErrInvalidChecksum)
+	}
+	return content, nil
+}
+
+func (sc *seriesScan) LabelValueFor(id storage.SeriesRef, label string) (string, error) {
+	content, err := sc.readSeriesRecord(seriesOffset(id))
+	if err != nil {
+		return "", fmt.Errorf("label values for: %w", err)
+	}
+
+	value, err := sc.reader.decoder.LabelValueFor(content, label)
+	if err != nil {
+		return "", storage.ErrNotFound
+	}
+	if value == "" {
+		return "", storage.ErrNotFound
+	}
+	return value, nil
+}
+
+func (sc *seriesScan) LabelNamesFor(ids ...storage.SeriesRef) ([]string, error) {
+	// Gather the name offsets in the symbol table first, so each distinct name
+	// is only resolved once no matter how many series carry it.
+	offsetsMap := make(map[uint32]struct{})
+	for _, id := range ids {
+		content, err := sc.readSeriesRecord(seriesOffset(id))
+		if err != nil {
+			return nil, fmt.Errorf("get buffer for series: %w", err)
+		}
+
+		offsets, err := sc.reader.decoder.LabelNamesOffsetsFor(content)
+		if err != nil {
+			return nil, fmt.Errorf("get label name offsets: %w", err)
+		}
+		for _, offset := range offsets {
+			offsetsMap[offset] = struct{}{}
+		}
+	}
+
+	names := make([]string, 0, len(offsetsMap))
+	for offset := range offsetsMap {
+		name, err := sc.reader.symbols.Lookup(offset)
+		if err != nil {
+			return nil, fmt.Errorf("lookup symbol in LabelNamesFor: %w", err)
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func (sc *seriesScan) Series(id storage.SeriesRef, from int64, through int64, lbls *labels.Labels, chks *[]ChunkMeta) (uint64, error) {
+	content, err := sc.readSeriesRecord(seriesOffset(id))
+	if err != nil {
+		return 0, err
+	}
+
+	fingerprint, err := sc.reader.decoder.Series(sc.reader.version, content, id, from, through, lbls, chks)
+	if err != nil {
+		return 0, fmt.Errorf("decode series: %w", err)
+	}
+	return fingerprint, nil
+}
+
+func (sc *seriesScan) ChunkStats(id storage.SeriesRef, from, through int64, lbls *labels.Labels, by map[string]struct{}) (uint64, ChunkStats, error) {
+	content, err := sc.readSeriesRecord(seriesOffset(id))
+	if err != nil {
+		return 0, ChunkStats{}, err
+	}
+
+	return sc.reader.decoder.ChunkStats(sc.reader.version, content, id, from, through, lbls, by)
+}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_series.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_series.go
@@ -22,13 +22,6 @@ func seriesOffset(id storage.SeriesRef) int {
 	return int(id) * 16
 }
 
-// maxSeriesForwardSkip bounds how far a seriesScan will read-and-discard
-// forward rather than repositioning the file.
-// Discarding drains the read-ahead buffer and then refills it, one read syscall
-// per bufferful, so past a buffer's worth of bytes a seek is the cheaper way to
-// get there.
-const maxSeriesForwardSkip = streamenc.ReaderBufferSize
-
 // seriesScan reads series records for a single pass over a postings list.
 // It is how StreamReader reads the postings list.
 // A seriesScan is not safe for concurrent use.
@@ -67,7 +60,7 @@ func (sc *seriesScan) Close() error {
 // Backwards steps are always a reposition, so out-of-order refs stay correct
 // and merely incur the cost of ResetAt.
 func (sc *seriesScan) seek(offset int) {
-	if distance := offset - sc.decbuf.Offset(); distance >= 0 && distance <= maxSeriesForwardSkip {
+	if distance := offset - sc.decbuf.Offset(); distance >= 0 && distance <= streamenc.ReaderBufferSize {
 		sc.decbuf.Skip(distance)
 		return
 	}

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_reader.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/file_reader.go
@@ -16,9 +16,9 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc/filepool"
 )
 
-// readerBufferSize is the size of the buffer used for reading index-header files. This
+// ReaderBufferSize is the size of the buffer used for reading index-header files. This
 // value is arbitrary and will likely change in the future based on profiling results.
-const readerBufferSize = 4096
+const ReaderBufferSize = 4096
 
 type FileReader struct {
 	file   *os.File
@@ -31,7 +31,7 @@ type FileReader struct {
 
 var bufferPool = sync.Pool{
 	New: func() any {
-		return bufio.NewReaderSize(nil, readerBufferSize)
+		return bufio.NewReaderSize(nil, ReaderBufferSize)
 	},
 }
 

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/querier.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/querier.go
@@ -55,25 +55,12 @@ type IndexReader interface {
 	// during background garbage collections. Input values must be sorted.
 	Postings(name string, fpFilter index.FingerprintFilter, values ...string) (index.Postings, error)
 
-	// Series populates the given labels and chunk metas for the series identified
-	// by the reference.
-	// Returns storage.ErrNotFound if the ref does not resolve to a known series.
-	Series(ref storage.SeriesRef, from int64, through int64, lset *labels.Labels, chks *[]index.ChunkMeta) (uint64, error)
-
-	// ChunkStats returns the stats for the chunks in the given series.
-	ChunkStats(ref storage.SeriesRef, from, through int64, lset *labels.Labels, by map[string]struct{}) (uint64, index.ChunkStats, error)
-
 	// LabelNames returns all the unique label names present in the index in sorted order.
 	LabelNames(matchers ...*labels.Matcher) ([]string, error)
 
-	// LabelValueFor returns label value for the given label name in the series referred to by ID.
-	// If the series couldn't be found or the series doesn't have the requested label a
-	// storage.ErrNotFound is returned as error.
-	LabelValueFor(id storage.SeriesRef, label string) (string, error)
-
-	// LabelNamesFor returns all the label names for the series referred to by IDs.
-	// The names returned are sorted.
-	LabelNamesFor(ids ...storage.SeriesRef) ([]string, error)
+	// NewSeriesScan returns a scan over the series of one pass over a postings
+	// list. The caller owns the returned scan and must Close it.
+	NewSeriesScan() index.SeriesScan
 
 	// Close releases the underlying resources of the reader.
 	Close() error
@@ -303,9 +290,12 @@ func labelValuesWithMatchers(r IndexReader, name string, matchers ...*labels.Mat
 		return nil, err
 	}
 
+	scan := r.NewSeriesScan()
+	defer scan.Close()
+
 	dedupe := map[string]interface{}{}
 	for p.Next() {
-		v, err := r.LabelValueFor(p.At(), name)
+		v, err := scan.LabelValueFor(p.At(), name)
 		if err != nil {
 			if err == storage.ErrNotFound {
 				continue
@@ -342,5 +332,8 @@ func labelNamesWithMatchers(r IndexReader, matchers ...*labels.Matcher) ([]strin
 		return nil, errors.Wrapf(p.Err(), "postings for label names with matchers")
 	}
 
-	return r.LabelNamesFor(postings...)
+	scan := r.NewSeriesScan()
+	defer scan.Close()
+
+	return scan.LabelNamesFor(postings...)
 }

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/single_file_index.go
@@ -178,8 +178,11 @@ func (i *TSDBIndex) forSeriesAndLabels(ctx context.Context, fpFilter index.Finge
 	defer func() { ChunkMetasPool.Put(chks) }()
 
 	return i.forPostings(ctx, fpFilter, from, through, matchers, func(p index.Postings) error {
+		scan := i.reader.NewSeriesScan()
+		defer scan.Close()
+
 		for p.Next() {
-			hash, err := i.reader.Series(p.At(), int64(from), int64(through), &ls, &chks)
+			hash, err := scan.Series(p.At(), int64(from), int64(through), &ls, &chks)
 			if err != nil {
 				return err
 			}
@@ -208,8 +211,11 @@ func (i *TSDBIndex) forSeriesNoLabels(ctx context.Context, fpFilter index.Finger
 	defer func() { ChunkMetasPool.Put(chks) }()
 
 	return i.forPostings(ctx, fpFilter, from, through, matchers, func(p index.Postings) error {
+		scan := i.reader.NewSeriesScan()
+		defer scan.Close()
+
 		for p.Next() {
-			hash, err := i.reader.Series(p.At(), int64(from), int64(through), nil, &chks)
+			hash, err := scan.Series(p.At(), int64(from), int64(through), nil, &chks)
 			if err != nil {
 				return err
 			}
@@ -353,8 +359,11 @@ func (i *TSDBIndex) Stats(ctx context.Context, _ string, from, through model.Tim
 			}
 		}
 
+		scan := i.reader.NewSeriesScan()
+		defer scan.Close()
+
 		for p.Next() {
-			fp, stats, err := i.reader.ChunkStats(p.At(), int64(from), int64(through), &ls, by)
+			fp, stats, err := scan.ChunkStats(p.At(), int64(from), int64(through), &ls, by)
 			if err != nil {
 				return err
 			}
@@ -439,8 +448,11 @@ func (i *TSDBIndex) Volume(
 
 	return i.forPostings(ctx, fpFilter, from, through, matchers, func(p index.Postings) error {
 		var ls labels.Labels
+		scan := i.reader.NewSeriesScan()
+		defer scan.Close()
+
 		for p.Next() {
-			fp, stats, err := i.reader.ChunkStats(p.At(), int64(from), int64(through), &ls, by)
+			fp, stats, err := scan.ChunkStats(p.At(), int64(from), int64(through), &ls, by)
 			if err != nil {
 				return fmt.Errorf("series volume: %w", err)
 			}


### PR DESCRIPTION
The stream reader built a fresh decbuf for every series record: a pooled
file handle, a 4 KiB bufio buffer, a seek to the record, and a read. A
series ref is the record's file offset divided by 16 and postings hand
out refs in ascending order, so consecutive series in a result set are
usually adjacent in the file and often inside the same 4 KiB window. The
read-ahead that would have covered a series' neighbours was discarded by
the next ResetAt before it could be used.

Hold one decbuf for the whole postings pass instead, moving forward by
discarding buffered bytes when the next record is within the buffer and
repositioning otherwise. Nothing depends on refs being ascending: an
out-of-order ref just repositions, which costs what it costs today.

This PR changes the Reader interface to support this streaming approach.

Added benchmark:
```
├────────────────────────┼──────────┼──────────┼───────────────────┤
│       Benchmark        │  before  │  after   │         Δ         │
│ SeriesIteration        │ 68.41 ms │ 56.36 ms │ −17.63% (p=0.002) │
├────────────────────────┼──────────┼──────────┼───────────────────┤
│ SeriesIteration B/op   │ 4.320 Mi │ 2.880 Mi │ −33.32%           │
├────────────────────────┼──────────┼──────────┼───────────────────┤
│ SeriesIteration allocs │ 83.44 k  │ 59.91 k  │ −28.20%           │
├────────────────────────┼──────────┼──────────┼───────────────────┤
```

Against realistic indexes with broad queries, I see improvements of 40-80%.

**What this PR does / why we need it**: Part of our effort to migrate away from mmap in index gateways - we're now in the optimisation phase.

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**: This is best reviewed commit by commit - the first commit makes small changes in place to make a minimal diff, then the second commit refactors out a separate file. 

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
