### PR TITLE
fix(logql): Validate numeric label filter literals

### DIFF
--- a/docs/sources/query/log_queries/_index.md
+++ b/docs/sources/query/log_queries/_index.md
@@ -227,7 +227,7 @@ For example with `cluster="namespace"` the cluster is the label identifier, the 
 We support multiple **value** types which are automatically inferred from the query input.
 
 - **String** is double quoted or backticked such as `"200"` or \``us-central1`\`.
-- **[Duration](https://golang.org/pkg/time/#ParseDuration)** is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". The value of the label identifier used for comparison must be a string with a unit suffix to be parsed correctly, such as "0.10ms" or "1h30m". Optionally, `label_format` can be used to modify the value and append the unit before making the comparison.
+- **[Duration](https://golang.org/pkg/time/#ParseDuration)** is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "1.5h" or "2h45m". The query literal accepts the time units "ns", "us" (or "µs"), "ms", "s", "m", "h", "d", "w" and "y". The value of the label identifier used for comparison must be a string with a unit suffix to be parsed correctly, such as "0.10ms" or "1h30m", and only accepts "ns", "us" (or "µs"), "ms", "s", "m" and "h". Optionally, `label_format` can be used to modify the value and append the unit before making the comparison, for example to convert a "d", "w" or "y" value to one of those accepted units first.
 - **Number** are floating-point number (64bits), such as`250`, `89.923`.
 - **Bytes** is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as "42MB", "1.5KiB" or "20B". Valid bytes units are "B", "kB", "MB", "GB", "TB", "KB", "KiB", "MiB", "GiB", "TiB".
 
@@ -244,7 +244,7 @@ Using Duration, Number and Bytes will convert the label value prior to compariso
 
 For instance, `logfmt | duration > 1m and bytes_consumed > 20MB`
 
-If the conversion of the label value fails, the log line is not filtered and an `__error__` label is added. To filters those errors see the [pipeline errors](../#pipeline-errors) section.
+If the conversion of the label value fails, the log line is not filtered and an `__error__` label is added. To filters those errors see the [pipeline errors](../query_reference/#pipeline-errors) section.
 
 You can chain multiple predicates using `and` and `or` which respectively express the `and` and `or` binary operations. `and` can be equivalently expressed by a comma or a space. Loki evaluates `and` before `or`. Label filters can be place anywhere in a log pipeline.
 

--- a/pkg/logql/internal/logqltest/testdata/conversions.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/conversions.logqltest
@@ -1,19 +1,18 @@
 # bytes()
 clear
 load
-  {unit="kb"}    "b=1KB"   @ 10s [repeat every 10s for 18]
-  {unit="kib"}   "b=1KiB"  @ 10s [repeat every 10s for 18]
-  {unit="mb"}    "b=1MB"   @ 10s [repeat every 10s for 18]
-  {unit="dec"}   "b=1.5KB" @ 10s [repeat every 10s for 18]
-  {unit="bare"}  "b=1024"  @ 10s [repeat every 10s for 18]
-  {unit="mixed"} "b=2Kb"   @ 10s [repeat every 10s for 18]
-  {unit="comma"} "b=2,048" @ 10s [repeat every 10s for 18]
-  {unit="frac"}  "b=1.5B"  @ 10s [repeat every 10s for 18]
-  {unit="noise"} "noise"   @ 10s [repeat every 10s for 18]
+  {unit="kb"}    "b=1KB"      @ 10s [repeat every 10s for 18]
+  {unit="kib"}   "b=1KiB"     @ 10s [repeat every 10s for 18]
+  {unit="mb"}    "b=1MB"      @ 10s [repeat every 10s for 18]
+  {unit="dec"}   "b=1.5KB"    @ 10s [repeat every 10s for 18]
+  {unit="bare"}  "b=1024"     @ 10s [repeat every 10s for 18]
+  {unit="mixed"} "b=2Kb"      @ 10s [repeat every 10s for 18]
+  {unit="comma"} "b=2,048"    @ 10s [repeat every 10s for 18]
+  {unit="frac"}  "b=1.5B"     @ 10s [repeat every 10s for 18]
+  {unit="noise"} "noise"      @ 10s [repeat every 10s for 18]
+  {unit="bytes"} "bytes=25MB" @ 10s [repeat every 10s for 18]
 
-# The noise line has no `b`, so `unwrap` drops it: no sample, no `__error__`, so it
-# never appears in the output. A value that is present but unconvertible is
-# different: it sets `__error__` and fails the query (see "bytes() parse failure").
+# A line without the unwrapped field (e.g. "noise" line has no "b") is dropped by unwrap.
 eval instant at 120s max_over_time({unit=~".+"} | logfmt | unwrap bytes(b) [1m]) by (unit)
   {unit="kb"}    1000
   {unit="kib"}   1024
@@ -32,6 +31,9 @@ eval range from 60s to 180s step 60s max_over_time({unit=~".+"} | logfmt | unwra
   {unit="mixed"} 2000 2000 2000
   {unit="comma"} 2048 2048 2048
   {unit="frac"}  1 1 1
+# The unwrapped label can itself be named "bytes".
+eval instant at 120s max_over_time({unit="bytes"} | logfmt | unwrap bytes(bytes) [1m])
+  {unit="bytes"} 25000000
 
 # bytes() parse failure.
 clear
@@ -47,14 +49,16 @@ eval instant at 60s max_over_time({unit=~".+"} | logfmt | unwrap bytes(b) | __er
 # seconds, so they yield identical values on identical input.
 clear
 load
-  {unit="s"}     "d=2s"    @ 10s [repeat every 10s for 18]
-  {unit="ms"}    "d=500ms" @ 10s [repeat every 10s for 18]
-  {unit="m"}     "d=1m"    @ 10s [repeat every 10s for 18]
-  {unit="hm"}    "d=1h30m" @ 10s [repeat every 10s for 18]
-  {unit="fh"}    "d=1.5h"  @ 10s [repeat every 10s for 18]
-  {unit="neg"}   "d=-5s"   @ 10s [repeat every 10s for 18]
-  {unit="noise"} "noise"   @ 10s [repeat every 10s for 18]
+  {unit="s"}     "d=2s"         @ 10s [repeat every 10s for 18]
+  {unit="ms"}    "d=500ms"      @ 10s [repeat every 10s for 18]
+  {unit="m"}     "d=1m"         @ 10s [repeat every 10s for 18]
+  {unit="hm"}    "d=1h30m"      @ 10s [repeat every 10s for 18]
+  {unit="fh"}    "d=1.5h"       @ 10s [repeat every 10s for 18]
+  {unit="neg"}   "d=-5s"        @ 10s [repeat every 10s for 18]
+  {unit="noise"} "noise"        @ 10s [repeat every 10s for 18]
+  {unit="dur"}   "duration=90s" @ 10s [repeat every 10s for 18]
 
+# A line without the unwrapped field (e.g. "noise" line has no "d") is dropped by unwrap.
 eval instant at 120s max_over_time({unit=~".+"} | logfmt | unwrap duration(d) [1m]) by (unit)
   {unit="s"}   2
   {unit="ms"}  0.5
@@ -85,6 +89,9 @@ eval range from 60s to 120s step 30s max_over_time({unit=~".+"} | logfmt | unwra
   {unit="hm"}  5400 5400 5400
   {unit="fh"}  5400 5400 5400
   {unit="neg"} -5 -5 -5
+# The unwrapped label can itself be named "duration".
+eval instant at 120s max_over_time({unit="dur"} | logfmt | unwrap duration(duration) [1m])
+  {unit="dur"} 90
 
 # duration() parse failure.
 clear

--- a/pkg/logql/internal/logqltest/testdata/label_filters.logqltest
+++ b/pkg/logql/internal/logqltest/testdata/label_filters.logqltest
@@ -163,12 +163,14 @@ eval instant at 60s count_over_time({app="a"} | logfmt | name!~"(?i)alpha" [1m])
 # numeric label filter: > >= < <= == !=.
 clear
 load
-  {app="p"}                "status=500"  @ 20s [repeat every 20s for 4]
-  {app="p"}                "status=200"  @ 30s [repeat every 20s for 2]
-  {app="s", status="500"}  "x"           @ 15s [repeat every 15s for 5]
-  {app="s", status="200"}  "x"           @ 30s [repeat every 20s for 2]
-  {app="m"}                "x"           @ 12s [repeat every 12s for 6] [metadata status="500"]
-  {app="m"}                "x"           @ 30s [repeat every 20s for 2] [metadata status="200"]
+  {app="p"}                "status=500"       @ 20s [repeat every 20s for 4]
+  {app="p"}                "status=200"       @ 30s [repeat every 20s for 2]
+  {app="j"}                `{"status":"500"}` @ 20s [repeat every 20s for 4]
+  {app="j"}                `{"status":500}`   @ 30s [repeat every 20s for 2]
+  {app="s", status="500"}  "x"                @ 15s [repeat every 15s for 5]
+  {app="s", status="200"}  "x"                @ 30s [repeat every 20s for 2]
+  {app="m"}                "x"                @ 12s [repeat every 12s for 6] [metadata status="500"]
+  {app="m"}                "x"                @ 30s [repeat every 20s for 2] [metadata status="200"]
 
 # parsed field
 eval instant at 60s count_over_time({app="p"} | logfmt | status >= 500 [1m])
@@ -183,6 +185,8 @@ eval instant at 60s count_over_time({app="p"} | logfmt | status == 200 [1m])
   {app="p", status="200"} 2
 eval instant at 60s count_over_time({app="p"} | logfmt | status != 200 [1m])
   {app="p", status="500"} 3
+eval instant at 60s count_over_time({app="j"} | json | status >= 500 [1m])
+  {app="j", status="500"} 5
 # stream label
 eval instant at 60s count_over_time({app="s"} | status >= 500 [1m])
   {app="s", status="500"} 4
@@ -225,11 +229,16 @@ eval instant at 60s count_over_time({app="b"} | logfmt | status > 400 [1m])
 eval instant at 60s count_over_time({app="b"} | logfmt | status > 400 | __error__="" [1m])
   expect empty
 
-# string vs numeric equality matcher: a quoted value compares as a string, a bare number as a number.
+# numeric label filter: literal parsing edge cases.
+# - a quoted value compares as a string, a bare number as a number.
+# - a negative or scientific-notation literal converts like any other float.
+# - a literal the float parser rejects is a parse error.
 clear
 load
   {app="a"} "code=200"   @ 20s [repeat every 20s for 4]
   {app="a"} "code=200.0" @ 30s [repeat every 20s for 2]
+  {app="a"} "code=-5"    @ 15s [repeat every 15s for 5]
+  {app="a"} "code=1500"  @ 55s
 
 eval instant at 60s count_over_time({app="a"} | logfmt | code = "200" [1m])
   {app="a", code="200"} 3
@@ -247,16 +256,34 @@ eval instant at 60s count_over_time({app="a"} | logfmt | code = 200 [1m])
 eval instant at 60s count_over_time({app="a"} | logfmt | code == 200 [1m])
   {app="a", code="200"} 3
   {app="a", code="200.0"} 2
+# A negative literal compares below zero.
+eval instant at 60s count_over_time({app="a"} | logfmt | code < 0 [1m])
+  {app="a", code="-5"} 4
+eval instant at 60s count_over_time({app="a"} | logfmt | code >= 0 [1m])
+  {app="a", code="200"} 3
+  {app="a", code="200.0"} 2
+  {app="a", code="1500"} 1
+# Scientific notation converts the same as a plain float.
+eval instant at 60s count_over_time({app="a"} | logfmt | code > 1e3 [1m])
+  {app="a", code="1500"} 1
+eval instant at 60s count_over_time({app="a"} | logfmt | code == 1.5e3 [1m])
+  {app="a", code="1500"} 1
+# A literal the float parser rejects (no float syntax for hex or octal integers) is a parse error.
+eval instant at 60s count_over_time({app="a"} | logfmt | code > 0x10 [1m])
+  expect fail msg: unable to parse literal as a float
+eval instant at 60s count_over_time({app="a"} | logfmt | code > 0o17 [1m])
+  expect fail msg: unable to parse literal as a float
 
 # duration label filter.
 clear
 load
-  {app="p"}               "took=2s"    @ 20s [repeat every 20s for 4]
-  {app="p"}               "took=500ms" @ 30s [repeat every 20s for 2]
-  {app="s", took="2s"}    "x"          @ 15s [repeat every 15s for 5]
-  {app="s", took="500ms"} "x"          @ 30s [repeat every 20s for 2]
-  {app="m"}               "x"          @ 12s [repeat every 12s for 6] [metadata took="2s"]
-  {app="m"}               "x"          @ 30s [repeat every 20s for 2] [metadata took="500ms"]
+  {app="p"}               "took=2s"       @ 20s [repeat every 20s for 4]
+  {app="p"}               "took=500ms"    @ 30s [repeat every 20s for 2]
+  {app="j"}               `{"took":"2s"}` @ 20s [repeat every 20s for 4]
+  {app="s", took="2s"}    "x"             @ 15s [repeat every 15s for 5]
+  {app="s", took="500ms"} "x"             @ 30s [repeat every 20s for 2]
+  {app="m"}               "x"             @ 12s [repeat every 12s for 6] [metadata took="2s"]
+  {app="m"}               "x"             @ 30s [repeat every 20s for 2] [metadata took="500ms"]
 
 # parsed field
 eval instant at 60s count_over_time({app="p"} | logfmt | took > 1s [1m])
@@ -267,6 +294,8 @@ eval range from 60s to 180s step 120s count_over_time({app="p"} | logfmt | took 
   {app="p", took="2s"} 3 _
 eval instant at 60s count_over_time({app="p"} | logfmt | took <= 1s [1m])
   {app="p", took="500ms"} 2
+eval instant at 60s count_over_time({app="j"} | json | took > 1s [1m])
+  {app="j", took="2s"} 3
 # stream label
 eval instant at 60s count_over_time({app="s"} | took > 1s [1m])
   {app="s", took="2s"} 4
@@ -294,11 +323,19 @@ eval instant at 60s count_over_time({app=~".+"} | logfmt | took > 1s [1m])
 # duration label filter comparators: = == != > >= < <=.
 clear
 load
-  {app="a"} "took=2s"    @ 20s [repeat every 20s for 4]
-  {app="a"} "took=500ms" @ 30s [repeat every 20s for 2]
-  {app="a"} "took=1h30m" @ 15s [repeat every 15s for 5]
-  {app="a"} "took=1.5s"  @ 55s
-  {app="a"} "other=1"    @ 45s
+  {app="a"}                "took=2s"    @ 20s [repeat every 20s for 4]
+  {app="a"}                "took=500ms" @ 30s [repeat every 20s for 2]
+  {app="a"}                "took=1h30m" @ 15s [repeat every 15s for 5]
+  {app="a"}                "took=1.5s"  @ 55s
+  {app="a"}                "other=1"    @ 45s
+  {app="s", took="2s"}     "x"          @ 20s [repeat every 20s for 4]
+  {app="s", took="500ms"}  "x"          @ 30s [repeat every 20s for 2]
+  {app="s", took="1h30m"}  "x"          @ 15s [repeat every 15s for 5]
+  {app="s", took="1.5s"}   "x"          @ 55s
+  {app="m"}                "x"          @ 20s [repeat every 20s for 4] [metadata took="2s"]
+  {app="m"}                "x"          @ 30s [repeat every 20s for 2] [metadata took="500ms"]
+  {app="m"}                "x"          @ 15s [repeat every 15s for 5] [metadata took="1h30m"]
+  {app="m"}                "x"          @ 55s                          [metadata took="1.5s"]
 
 # =
 eval instant at 60s count_over_time({app="a"} | logfmt | took = 2s [1m])
@@ -307,30 +344,70 @@ eval range from 40s to 80s step 20s count_over_time({app="a"} | logfmt | took = 
   {app="a", took="2s"} 2 3 3
 eval range from 60s to 180s step 120s count_over_time({app="a"} | logfmt | took = 2s [1m]) # non-overlapping
   {app="a", took="2s"} 3 _
+eval instant at 60s count_over_time({app="s"} | took = 2s [1m])
+  {app="s", took="2s"} 3
+eval instant at 60s count_over_time({app="m"} | took = 2s [1m])
+  {app="m", took="2s"} 3
 # ==
 eval instant at 60s count_over_time({app="a"} | logfmt | took == 90m [1m])
   {app="a", took="1h30m"} 4
+eval instant at 60s count_over_time({app="s"} | took == 90m [1m])
+  {app="s", took="1h30m"} 4
+eval instant at 60s count_over_time({app="m"} | took == 90m [1m])
+  {app="m", took="1h30m"} 4
 # !=
 eval instant at 60s count_over_time({app="a"} | logfmt | took != 2s [1m])
   {app="a", took="500ms"} 2
   {app="a", took="1h30m"} 4
   {app="a", took="1.5s"} 1
+eval instant at 60s count_over_time({app="s"} | took != 2s [1m])
+  {app="s", took="500ms"} 2
+  {app="s", took="1h30m"} 4
+  {app="s", took="1.5s"} 1
+eval instant at 60s count_over_time({app="m"} | took != 2s [1m])
+  {app="m", took="500ms"} 2
+  {app="m", took="1h30m"} 4
+  {app="m", took="1.5s"} 1
 # >
 eval instant at 60s count_over_time({app="a"} | logfmt | took > 1.5s [1m])
   {app="a", took="2s"} 3
   {app="a", took="1h30m"} 4
+eval instant at 60s count_over_time({app="s"} | took > 1.5s [1m])
+  {app="s", took="2s"} 3
+  {app="s", took="1h30m"} 4
+eval instant at 60s count_over_time({app="m"} | took > 1.5s [1m])
+  {app="m", took="2s"} 3
+  {app="m", took="1h30m"} 4
 # >=
 eval instant at 60s count_over_time({app="a"} | logfmt | took >= 1.5s [1m])
   {app="a", took="2s"} 3
   {app="a", took="1h30m"} 4
   {app="a", took="1.5s"} 1
+eval instant at 60s count_over_time({app="s"} | took >= 1.5s [1m])
+  {app="s", took="2s"} 3
+  {app="s", took="1h30m"} 4
+  {app="s", took="1.5s"} 1
+eval instant at 60s count_over_time({app="m"} | took >= 1.5s [1m])
+  {app="m", took="2s"} 3
+  {app="m", took="1h30m"} 4
+  {app="m", took="1.5s"} 1
 # <
 eval instant at 60s count_over_time({app="a"} | logfmt | took < 1s [1m])
   {app="a", took="500ms"} 2
+eval instant at 60s count_over_time({app="s"} | took < 1s [1m])
+  {app="s", took="500ms"} 2
+eval instant at 60s count_over_time({app="m"} | took < 1s [1m])
+  {app="m", took="500ms"} 2
 # <=
 eval instant at 60s count_over_time({app="a"} | logfmt | took <= 1.5s [1m])
   {app="a", took="500ms"} 2
   {app="a", took="1.5s"} 1
+eval instant at 60s count_over_time({app="s"} | took <= 1.5s [1m])
+  {app="s", took="500ms"} 2
+  {app="s", took="1.5s"} 1
+eval instant at 60s count_over_time({app="m"} | took <= 1.5s [1m])
+  {app="m", took="500ms"} 2
+  {app="m", took="1.5s"} 1
 # A line without the label is dropped, and sets no error.
 eval instant at 60s count_over_time({app="a"} | logfmt | took > 0s [1m])
   {app="a", took="2s"} 3
@@ -434,12 +511,13 @@ eval range from 60s to 180s step 120s count_over_time({app="a"} | logfmt | took 
 # bytes label filter.
 clear
 load
-  {app="p"}               "size=3MB"   @ 20s [repeat every 20s for 4]
-  {app="p"}               "size=500KB" @ 30s [repeat every 20s for 2]
-  {app="s", size="3MB"}   "x"          @ 15s [repeat every 15s for 5]
-  {app="s", size="500KB"} "x"          @ 30s [repeat every 20s for 2]
-  {app="m"}               "x"          @ 12s [repeat every 12s for 6] [metadata size="3MB"]
-  {app="m"}               "x"          @ 30s [repeat every 20s for 2] [metadata size="500KB"]
+  {app="p"}               "size=3MB"       @ 20s [repeat every 20s for 4]
+  {app="p"}               "size=500KB"     @ 30s [repeat every 20s for 2]
+  {app="j"}               `{"size":"3MB"}` @ 20s [repeat every 20s for 4]
+  {app="s", size="3MB"}   "x"              @ 15s [repeat every 15s for 5]
+  {app="s", size="500KB"} "x"              @ 30s [repeat every 20s for 2]
+  {app="m"}               "x"              @ 12s [repeat every 12s for 6] [metadata size="3MB"]
+  {app="m"}               "x"              @ 30s [repeat every 20s for 2] [metadata size="500KB"]
 
 # parsed field
 eval instant at 60s count_over_time({app="p"} | logfmt | size > 1MB [1m])
@@ -450,6 +528,8 @@ eval range from 60s to 180s step 120s count_over_time({app="p"} | logfmt | size 
   {app="p", size="3MB"} 3 _
 eval instant at 60s count_over_time({app="p"} | logfmt | size < 1MB [1m])
   {app="p", size="500KB"} 2
+eval instant at 60s count_over_time({app="j"} | json | size > 1MB [1m])
+  {app="j", size="3MB"} 3
 # stream label
 eval instant at 60s count_over_time({app="s"} | size > 1MB [1m])
   {app="s", size="3MB"} 4
@@ -739,6 +819,7 @@ load
   {app="a"} "x=1 y=0 z=0" @ 30s [repeat every 20s for 2]
   {app="a"} "x=0 y=1 z=1" @ 15s [repeat every 15s for 5]
   {app="a"} "x=0 y=1 z=0" @ 55s
+  {app="a"} "x=0 y=0 z=1" @ 58s # noise: matches none of x="1", y="1", z="0"
 
 # An unparenthesized chain groups as x="1" or (y="1" and z="1").
 eval instant at 60s count_over_time({app="a"} | logfmt | x="1" or y="1" and z="1" [1m])
@@ -773,55 +854,90 @@ eval instant at 60s count_over_time({app="a"} | logfmt | x="1" or y="1" | z="1" 
 eval instant at 60s count_over_time({app="a"} | logfmt | (x="1" or y="1") and z="1" [1m])
   {app="a", x="1", y="1", z="1"} 3
   {app="a", x="0", y="1", z="1"} 4
+# A three-operand or chain evaluates every clause. Dropping the middle one here would
+# incorrectly exclude the third row, which matches only through y="1".
+eval instant at 60s count_over_time({app="a"} | logfmt | x="1" or y="1" or z="0" [1m])
+  {app="a", x="1", y="1", z="1"} 3
+  {app="a", x="1", y="0", z="0"} 2
+  {app="a", x="0", y="1", z="1"} 4
+  {app="a", x="0", y="1", z="0"} 1
+# A trailing clause that matches nothing does not change the result.
+eval instant at 60s count_over_time({app="a"} | logfmt | x="1" or y="1" or z="0" or missing="1" [1m])
+  {app="a", x="1", y="1", z="1"} 3
+  {app="a", x="1", y="0", z="0"} 2
+  {app="a", x="0", y="1", z="1"} 4
+  {app="a", x="0", y="1", z="0"} 1
 
 # label filter or: a match on the left operand skips evaluating the right one.
 clear
 load
-  {app="a"} "lvl=error took=oops" @ 20s [repeat every 20s for 4]
-  {app="a"} "lvl=info took=2s"    @ 30s [repeat every 20s for 2]
+  {app="a"} "lvl=error took=oops size=oops" @ 20s [repeat every 20s for 4]
+  {app="a"} "lvl=info took=2s size=3MB"     @ 30s [repeat every 20s for 2]
+  {app="b"} "addr=1.2.3.9 took=oops"        @ 20s
 
 eval instant at 60s count_over_time({app="a"} | logfmt | lvl="error" or took > 1s [1m])
-  {app="a", lvl="error", took="oops"} 3
-  {app="a", lvl="info", took="2s"} 2
+  {app="a", lvl="error", took="oops", size="oops"} 3
+  {app="a", lvl="info", took="2s", size="3MB"} 2
 eval range from 40s to 80s step 20s count_over_time({app="a"} | logfmt | lvl="error" or took > 1s [1m])   # overlapping
-  {app="a", lvl="error", took="oops"} 2 3 3
-  {app="a", lvl="info", took="2s"} 1 2 2
+  {app="a", lvl="error", took="oops", size="oops"} 2 3 3
+  {app="a", lvl="info", took="2s", size="3MB"} 1 2 2
 eval range from 60s to 180s step 120s count_over_time({app="a"} | logfmt | lvl="error" or took > 1s [1m]) # non-overlapping
-  {app="a", lvl="error", took="oops"} 3 _
-  {app="a", lvl="info", took="2s"} 2 _
+  {app="a", lvl="error", took="oops", size="oops"} 3 _
+  {app="a", lvl="info", took="2s", size="3MB"} 2 _
 # The same predicates in the other order convert oops first, which fails.
 eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s or lvl="error" [1m])
   expect fail msg: LabelFilterErr
 # and always runs both operands.
 eval instant at 60s count_over_time({app="a"} | logfmt | lvl="error" and took > 1s [1m])
   expect fail msg: LabelFilterErr
+# ip() mixed with a duration filter in the same chain: whichever operand comes first decides the outcome.
+eval instant at 60s count_over_time({app="b"} | logfmt | addr = ip("1.2.3.0/24") or took > 1s [1m])
+  {app="b", addr="1.2.3.9", took="oops"} 1
+eval instant at 60s count_over_time({app="b"} | logfmt | took > 1s or addr = ip("1.2.3.0/24") [1m])
+  expect fail msg: invalid duration
+# The same shape holds for a bytes filter instead of a duration filter.
+eval instant at 60s count_over_time({app="a"} | logfmt | lvl="error" or size > 1MB [1m])
+  {app="a", lvl="error", took="oops", size="oops"} 3
+  {app="a", lvl="info", took="2s", size="3MB"} 2
+# size="oops" has no leading digit, so ParseBytes tries to parse an empty string.
+eval instant at 60s count_over_time({app="a"} | logfmt | size > 1MB or lvl="error" [1m])
+  expect fail msg: parsing \"\": invalid syntax
+eval instant at 60s count_over_time({app="a"} | logfmt | lvl="error" and size > 1MB [1m])
+  expect fail msg: parsing \"\": invalid syntax
 
 # label filter errors: the first filter that fails owns __error_details__.
 clear
 load
-  {app="a"} "x=nope y=90" @ 20s [repeat every 20s for 4]
+  {app="a"} "x=nope y=90 z=oops" @ 20s [repeat every 20s for 4]
 
 eval instant at 60s count_over_time({app="a"} | logfmt | x > 1s and y > 1s [1m])
   expect fail msg: invalid duration
 eval instant at 60s count_over_time({app="a"} | logfmt | y > 1s and x > 1s [1m])
   expect fail msg: missing unit in duration
+# The same rule holds when a bytes filter is the one that fails first.
+eval instant at 60s count_over_time({app="a"} | logfmt | x > 1s and z > 1MB [1m])
+  expect fail msg: invalid duration
+eval instant at 60s count_over_time({app="a"} | logfmt | z > 1MB and x > 1s [1m])
+  expect fail msg: parsing \"\": invalid syntax
 
 # __error__ label filter: it drops a line that a later stage failed to process.
 clear
 load
-  {app="a"} "took=oops" @ 20s [repeat every 20s for 4]
-  {app="a"} "took=2s"   @ 30s [repeat every 20s for 2]
+  {app="a"} "took=oops size=3MB"   @ 20s [repeat every 20s for 4]
+  {app="a"} "took=2s size=500KB"   @ 30s [repeat every 20s for 2]
 
 eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s [1m])
   expect fail msg: LabelFilterErr
+eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s and size > 1MB [1m])
+  expect fail msg: LabelFilterErr
 eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__="" [1m])
-  {app="a", took="2s"} 2
+  {app="a", took="2s", size="500KB"} 2
 eval range from 40s to 80s step 20s count_over_time({app="a"} | logfmt | took > 1s | __error__="" [1m])   # overlapping
-  {app="a", took="2s"} 1 2 2
+  {app="a", took="2s", size="500KB"} 1 2 2
 eval range from 60s to 180s step 120s count_over_time({app="a"} | logfmt | took > 1s | __error__="" [1m]) # non-overlapping
-  {app="a", took="2s"} 2 _
+  {app="a", took="2s", size="500KB"} 2 _
 eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__!="LabelFilterErr" [1m])
-  {app="a", took="2s"} 2
+  {app="a", took="2s", size="500KB"} 2
 # A filter that runs before the parser cannot drop the line: no stage has failed yet.
 eval instant at 60s count_over_time({app="a"} | __error__="" | logfmt | took > 1s [1m])
   expect fail msg: LabelFilterErr
@@ -834,6 +950,10 @@ eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__!=
 # A converting filter cannot read __error__, so the same intent drops every line instead.
 eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s | __error__ > 0 [1m])
   expect empty
+# A line skipped by a comparison (e.g. size < 1MB) doesn't fail the query even if
+# another comparison in the query has failed (e.g. took > 1s).
+eval instant at 60s count_over_time({app="a"} | logfmt | took > 1s and size < 1MB [1m])
+  {app="a", took="2s", size="500KB"} 2
 
 # structured metadata label filter: metadata joins the label set without a parser.
 clear
@@ -930,3 +1050,23 @@ eval instant at 60s sum_over_time({app=~".+"} | logfmt | unwrap v | lvl="error" 
   {app="p", lvl="error"} 6
   {app="s", lvl="error"} 8
   {app="m", lvl="error"} 10
+
+# duration and bytes as ordinary label names.
+clear
+load
+  {app="a"}                               "duration=90s bytes=25MB" @ 20s [repeat every 20s for 3]
+  {app="a"}                               "duration=30s bytes=25MB" @ 20s # noise: duration too short
+  {app="a"}                               "duration=90s bytes=10MB" @ 20s # noise: bytes too small
+  {app="s", duration="90s", bytes="25MB"} "x"                       @ 20s [repeat every 20s for 3]
+  {app="s", duration="30s", bytes="25MB"} "x"                       @ 20s # noise: duration too short
+  {app="s", duration="90s", bytes="10MB"} "x"                       @ 20s # noise: bytes too small
+  {app="m"}                               "x"                       @ 20s [repeat every 20s for 3] [metadata duration="90s" bytes="25MB"]
+  {app="m"}                               "x"                       @ 20s [metadata duration="30s" bytes="25MB"] # noise: duration too short
+  {app="m"}                               "x"                       @ 20s [metadata duration="90s" bytes="10MB"] # noise: bytes too small
+
+eval instant at 60s count_over_time({app="a"} | logfmt | duration > 1m and bytes > 20MB [1m])
+  {app="a", duration="90s", bytes="25MB"} 3
+eval instant at 60s count_over_time({app="s"} | duration > 1m and bytes > 20MB [1m])
+  {app="s", duration="90s", bytes="25MB"} 3
+eval instant at 60s count_over_time({app="m"} | duration > 1m and bytes > 20MB [1m])
+  {app="m", duration="90s", bytes="25MB"} 3

--- a/pkg/logql/syntax/ast.go
+++ b/pkg/logql/syntax/ast.go
@@ -1117,6 +1117,14 @@ func mustNewMatcher(t labels.MatchType, n, v string) *labels.Matcher {
 	return m
 }
 
+func mustNewNumericLabelFilter(t log.LabelFilterType, name string, lit *LiteralExpr) log.LabelFilterer {
+	v, err := lit.Value()
+	if err != nil {
+		panic(err)
+	}
+	return log.NewNumericLabelFilter(t, name, v)
+}
+
 type UnwrapExpr struct {
 	Identifier string
 	Operation  string

--- a/pkg/logql/syntax/parser_test.go
+++ b/pkg/logql/syntax/parser_test.go
@@ -1421,6 +1421,11 @@ var ParseTestCases = []struct {
 		},
 	},
 	{
+		// a numeric label filter literal the float parser rejects is a parse error, not a silent 0.
+		in:  `{app="foo"} | logfmt | status_code > 0x10`,
+		err: logqlmodel.NewParseError(`unable to parse literal as a float: strconv.ParseFloat: parsing "0x10": invalid syntax`, 0, 0),
+	},
+	{
 		in: `{app="foo"} |= "bar" | unpack | json | latency >= 250ms or ( status_code < 500 and status_code > 200)`,
 		exp: &PipelineExpr{
 			Left: newMatcherExpr([]*labels.Matcher{{Type: labels.MatchEqual, Name: "app", Value: "foo"}}),

--- a/pkg/logql/syntax/syntax.y
+++ b/pkg/logql/syntax/syntax.y
@@ -341,13 +341,13 @@ bytesFilter:
     ;
 
 numberFilter:
-      IDENTIFIER GT literalExpr      { $$ = log.NewNumericLabelFilter(log.LabelFilterGreaterThan, $1,  $3.Val)}
-    | IDENTIFIER GTE literalExpr     { $$ = log.NewNumericLabelFilter(log.LabelFilterGreaterThanOrEqual, $1,$3.Val)}
-    | IDENTIFIER LT literalExpr      { $$ = log.NewNumericLabelFilter(log.LabelFilterLesserThan, $1, $3.Val)}
-    | IDENTIFIER LTE literalExpr     { $$ = log.NewNumericLabelFilter(log.LabelFilterLesserThanOrEqual, $1, $3.Val)}
-    | IDENTIFIER NEQ literalExpr     { $$ = log.NewNumericLabelFilter(log.LabelFilterNotEqual, $1, $3.Val)}
-    | IDENTIFIER EQ literalExpr      { $$ = log.NewNumericLabelFilter(log.LabelFilterEqual, $1, $3.Val)}
-    | IDENTIFIER CMP_EQ literalExpr  { $$ = log.NewNumericLabelFilter(log.LabelFilterEqual, $1, $3.Val)}
+      IDENTIFIER GT literalExpr      { $$ = mustNewNumericLabelFilter(log.LabelFilterGreaterThan, $1, $3)}
+    | IDENTIFIER GTE literalExpr     { $$ = mustNewNumericLabelFilter(log.LabelFilterGreaterThanOrEqual, $1, $3)}
+    | IDENTIFIER LT literalExpr      { $$ = mustNewNumericLabelFilter(log.LabelFilterLesserThan, $1, $3)}
+    | IDENTIFIER LTE literalExpr     { $$ = mustNewNumericLabelFilter(log.LabelFilterLesserThanOrEqual, $1, $3)}
+    | IDENTIFIER NEQ literalExpr     { $$ = mustNewNumericLabelFilter(log.LabelFilterNotEqual, $1, $3)}
+    | IDENTIFIER EQ literalExpr      { $$ = mustNewNumericLabelFilter(log.LabelFilterEqual, $1, $3)}
+    | IDENTIFIER CMP_EQ literalExpr  { $$ = mustNewNumericLabelFilter(log.LabelFilterEqual, $1, $3)}
     ;
 
 namedMatcher:

--- a/pkg/logql/syntax/syntax.y.go
+++ b/pkg/logql/syntax/syntax.y.go
@@ -1570,37 +1570,37 @@ syntaxdefault:
 	case 144:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewNumericLabelFilter(log.LabelFilterGreaterThan, syntaxDollar[1].str, syntaxDollar[3].literalExpr.Val)
+			syntaxVAL.filterer = mustNewNumericLabelFilter(log.LabelFilterGreaterThan, syntaxDollar[1].str, syntaxDollar[3].literalExpr)
 		}
 	case 145:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewNumericLabelFilter(log.LabelFilterGreaterThanOrEqual, syntaxDollar[1].str, syntaxDollar[3].literalExpr.Val)
+			syntaxVAL.filterer = mustNewNumericLabelFilter(log.LabelFilterGreaterThanOrEqual, syntaxDollar[1].str, syntaxDollar[3].literalExpr)
 		}
 	case 146:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewNumericLabelFilter(log.LabelFilterLesserThan, syntaxDollar[1].str, syntaxDollar[3].literalExpr.Val)
+			syntaxVAL.filterer = mustNewNumericLabelFilter(log.LabelFilterLesserThan, syntaxDollar[1].str, syntaxDollar[3].literalExpr)
 		}
 	case 147:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewNumericLabelFilter(log.LabelFilterLesserThanOrEqual, syntaxDollar[1].str, syntaxDollar[3].literalExpr.Val)
+			syntaxVAL.filterer = mustNewNumericLabelFilter(log.LabelFilterLesserThanOrEqual, syntaxDollar[1].str, syntaxDollar[3].literalExpr)
 		}
 	case 148:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewNumericLabelFilter(log.LabelFilterNotEqual, syntaxDollar[1].str, syntaxDollar[3].literalExpr.Val)
+			syntaxVAL.filterer = mustNewNumericLabelFilter(log.LabelFilterNotEqual, syntaxDollar[1].str, syntaxDollar[3].literalExpr)
 		}
 	case 149:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewNumericLabelFilter(log.LabelFilterEqual, syntaxDollar[1].str, syntaxDollar[3].literalExpr.Val)
+			syntaxVAL.filterer = mustNewNumericLabelFilter(log.LabelFilterEqual, syntaxDollar[1].str, syntaxDollar[3].literalExpr)
 		}
 	case 150:
 		syntaxDollar = syntaxS[syntaxpt-3 : syntaxpt+1]
 		{
-			syntaxVAL.filterer = log.NewNumericLabelFilter(log.LabelFilterEqual, syntaxDollar[1].str, syntaxDollar[3].literalExpr.Val)
+			syntaxVAL.filterer = mustNewNumericLabelFilter(log.LabelFilterEqual, syntaxDollar[1].str, syntaxDollar[3].literalExpr)
 		}
 	case 151:
 		syntaxDollar = syntaxS[syntaxpt-1 : syntaxpt+1]


### PR DESCRIPTION
**What this PR does / why we need it**:

A numeric label filter literal such as `foo > 0x10` used to parse successfully and silently compare against `0` instead of failing, because the grammar read `LiteralExpr.Val` directly instead of checking whether the literal actually parsed as a float.

Found while auditing numeric/duration/bytes label filter test coverage after the recent ip() line-filter or-chain fix (#23940). This PR fixes that bug and closes several test gaps found in that coverage along the way: parser-agnostic conversion checks, multi-operand `or` chains, `ip()` mixed with a numeric/duration filter in the same chain, negative and scientific-notation literals, and a few others. It also fixes two stale details in the LogQL docs (the duration units list, a broken anchor link).

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
- The bytes label filter comparator scenario in `label_filters.logqltest` intentionally does not get the same per-source (stream label / structured metadata) treatment as the duration one — that's being addressed separately in #24030.

**Checklist**
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)