### PR TITLE
feat(dataobj): Enable lazy downloading of pages in batches when reading dataobj

### DIFF
--- a/pkg/dataobj/internal/dataset/row_reader.go
+++ b/pkg/dataobj/internal/dataset/row_reader.go
@@ -577,10 +577,10 @@ func (r *RowReader) initDownloader(ctx context.Context) error {
 	} else {
 		r.dl.Reset(r.opts.Dataset)
 	}
+
+	r.dl.targetSize = defaultTargetCachedBytes
 	if r.opts.Prefetch {
 		r.dl.targetSize = 0
-	} else {
-		r.dl.targetSize = defaultDownloadTargetSize
 	}
 
 	mask := bitmask.New(len(r.opts.Columns))

--- a/pkg/dataobj/internal/dataset/row_reader.go
+++ b/pkg/dataobj/internal/dataset/row_reader.go
@@ -578,7 +578,7 @@ func (r *RowReader) initDownloader(ctx context.Context) error {
 		r.dl.Reset(r.opts.Dataset)
 	}
 
-	r.dl.targetSize = defaultTargetCachedBytes
+	r.dl.targetSize = defaultTargetDownloadedBytes
 	if r.opts.Prefetch {
 		r.dl.targetSize = 0
 	}

--- a/pkg/dataobj/internal/dataset/row_reader.go
+++ b/pkg/dataobj/internal/dataset/row_reader.go
@@ -578,9 +578,9 @@ func (r *RowReader) initDownloader(ctx context.Context) error {
 		r.dl.Reset(r.opts.Dataset)
 	}
 
-	r.dl.targetSize = defaultTargetDownloadedBytes
+	r.dl.targetCompressedBytes = defaultTargetDownloadedBytes
 	if r.opts.PrefetchAllOnOpen {
-		r.dl.targetSize = 0
+		r.dl.targetCompressedBytes = 0
 	}
 
 	mask := bitmask.New(len(r.opts.Columns))

--- a/pkg/dataobj/internal/dataset/row_reader.go
+++ b/pkg/dataobj/internal/dataset/row_reader.go
@@ -33,9 +33,13 @@ type RowReaderOptions struct {
 	// Holds a list of predicates that can be sequentially applied to the dataset.
 	Predicates []Predicate
 
-	// Prefetch enables bulk retrieving pages from the dataset when reading
-	// starts. To reduce read latency, this option should only be disabled when
-	// the entire Dataset is already held in memory.
+	// Prefetch controls when pages are downloaded.
+	//
+	// If true, all pages are downloaded when the reader is opened.
+	// If false, pages are downloaded lazily as they are read, targeting
+	// [defaultDownloadTargetSize] bytes of cached pages at a time. Pages
+	// required for the current read range are always downloaded even if they
+	// exceed the target.
 	Prefetch bool
 
 	// StatsTracker keeps track of the various reader internal stats.
@@ -499,34 +503,19 @@ func (r *RowReader) prefetchPages(ctx context.Context) error {
 	return r.dl.Prefetch(ctx)
 }
 
-// allColumns returns the full set of column to read. If r was configured with
-// prefetching, wrapped columns from [rowReaderDownloader] are returned. Otherwise,
-// the columns of the original dataset are returned.
+// allColumns returns the full set of columns to read.
 func (r *RowReader) allColumns() []Column {
-	if r.opts.Prefetch {
-		return r.dl.AllColumns()
-	}
-	return r.dl.OrigColumns()
+	return r.dl.AllColumns()
 }
 
-// primaryColumns returns the primary columns to read. If r was configured with
-// prefetching, wrapped columns from [rowReaderDownloader] are returned. Otherwise,
-// the primary columns of the original dataset are returned.
+// primaryColumns returns the primary columns to read.
 func (r *RowReader) primaryColumns() []Column {
-	if r.opts.Prefetch {
-		return r.dl.PrimaryColumns()
-	}
-	return r.dl.OrigPrimaryColumns()
+	return r.dl.PrimaryColumns()
 }
 
-// secondaryColumns returns the secondary columns to read. If r was configured with
-// prefetching, wrapped columns from [rowReaderDownloader] are returned. Otherwise,
-// the secondary columns of the original dataset are returned.
+// secondaryColumns returns the secondary columns to read.
 func (r *RowReader) secondaryColumns() []Column {
-	if r.opts.Prefetch {
-		return r.dl.SecondaryColumns()
-	}
-	return r.dl.OrigSecondaryColumns()
+	return r.dl.SecondaryColumns()
 }
 
 // validatePredicate ensures that all columns used in a predicate have been
@@ -587,6 +576,11 @@ func (r *RowReader) initDownloader(ctx context.Context) error {
 		r.dl = newRowReaderDownloader(r.opts.Dataset)
 	} else {
 		r.dl.Reset(r.opts.Dataset)
+	}
+	if r.opts.Prefetch {
+		r.dl.targetSize = 0
+	} else {
+		r.dl.targetSize = defaultDownloadTargetSize
 	}
 
 	mask := bitmask.New(len(r.opts.Columns))

--- a/pkg/dataobj/internal/dataset/row_reader.go
+++ b/pkg/dataobj/internal/dataset/row_reader.go
@@ -33,14 +33,14 @@ type RowReaderOptions struct {
 	// Holds a list of predicates that can be sequentially applied to the dataset.
 	Predicates []Predicate
 
-	// Prefetch controls when pages are downloaded.
+	// PrefetchAllOnOpen controls when pages are downloaded.
 	//
 	// If true, all pages are downloaded when the reader is opened.
 	// If false, pages are downloaded lazily as they are read, targeting
-	// [defaultDownloadTargetSize] bytes of cached pages at a time. Pages
+	// [defaultTargetDownloadedBytes] bytes of cached pages at a time. Pages
 	// required for the current read range are always downloaded even if they
 	// exceed the target.
-	Prefetch bool
+	PrefetchAllOnOpen bool
 
 	// StatsTracker keeps track of the various reader internal stats.
 	StatsTracker RowReaderStatsTracker
@@ -497,7 +497,7 @@ func (r *RowReader) init(ctx context.Context) error {
 }
 
 func (r *RowReader) prefetchPages(ctx context.Context) error {
-	if !r.opts.Prefetch {
+	if !r.opts.PrefetchAllOnOpen {
 		return nil
 	}
 	return r.dl.Prefetch(ctx)
@@ -579,7 +579,7 @@ func (r *RowReader) initDownloader(ctx context.Context) error {
 	}
 
 	r.dl.targetSize = defaultTargetDownloadedBytes
-	if r.opts.Prefetch {
+	if r.opts.PrefetchAllOnOpen {
 		r.dl.targetSize = 0
 	}
 

--- a/pkg/dataobj/internal/dataset/row_reader_downloader.go
+++ b/pkg/dataobj/internal/dataset/row_reader_downloader.go
@@ -97,11 +97,11 @@ type rowReaderDownloader struct {
 	readRange rangeset.Range // Current range being read.
 	rangeMask rangeset.Set   // Inverse of dsetRanges: ranges to _exclude_ from download.
 
-	// targetSize is the target number of compressed page bytes held in-memory. 0 means unlimited.
+	// targetCompressedBytes is the target number of compressed page bytes held in-memory. 0 means unlimited.
 	// P1 pages are always downloaded even if they exceed the target.
 	// It can be used to efficiently read pages from object storage in batches
 	// without downloading an entire section at once.
-	targetSize int
+	targetCompressedBytes int
 }
 
 // defaultTargetDownloadedBytes is the target size in bytes of compressed pages to hold in-memory when
@@ -366,11 +366,11 @@ func (dl *rowReaderDownloader) buildDownloadBatch(ctx context.Context, requestor
 }
 
 func (dl *rowReaderDownloader) targetReached(batchSize int) bool {
-	return dl.targetSize > 0 && batchSize >= dl.targetSize
+	return dl.targetCompressedBytes > 0 && batchSize >= dl.targetCompressedBytes
 }
 
 func (dl *rowReaderDownloader) wouldExceedTarget(batchSize, pageSize int) bool {
-	return dl.targetSize > 0 && batchSize+pageSize > dl.targetSize
+	return dl.targetCompressedBytes > 0 && batchSize+pageSize > dl.targetCompressedBytes
 }
 
 // iterP1Pages returns an iterator over P1 pages in round-robin column order,

--- a/pkg/dataobj/internal/dataset/row_reader_downloader.go
+++ b/pkg/dataobj/internal/dataset/row_reader_downloader.go
@@ -46,8 +46,8 @@ import (
 //     This excludes any page that is outside of the dataset ranges passed to
 //     [newReaderDownloader] and [rowReaderDownloader.Reset].
 //
-// The rowReaderDownloader targets [defaultDownloadTargetSize] bytes of cached
-// pages when [RowReaderOptions.Prefetch] is false. A target of 0 is unlimited.
+// The rowReaderDownloader targets [defaultTargetDownloadedBytes] bytes of cached
+// pages when [RowReaderOptions.PrefetchAllOnOpen] is false. A target of 0 is unlimited.
 //
 // Batches of pages to download are built in four steps:
 //
@@ -105,7 +105,7 @@ type rowReaderDownloader struct {
 }
 
 // defaultTargetDownloadedBytes is the target size in bytes of compressed pages to hold in-memory when
-// [RowReaderOptions.Prefetch] is false.
+// [RowReaderOptions.PrefetchAllOnOpen] is false.
 const defaultTargetDownloadedBytes = 16 << 20 // 16 MB
 
 // newReaderDataset creates a new readerDataset wrapping around an inner

--- a/pkg/dataobj/internal/dataset/row_reader_downloader.go
+++ b/pkg/dataobj/internal/dataset/row_reader_downloader.go
@@ -46,8 +46,8 @@ import (
 //     This excludes any page that is outside of the dataset ranges passed to
 //     [newReaderDownloader] and [rowReaderDownloader.Reset].
 //
-// The rowReaderDownloader targets a configurable batch size, which is the target
-// size of pages to cache in memory at once.
+// The rowReaderDownloader targets [defaultDownloadTargetSize] bytes of cached
+// pages when [RowReaderOptions.Prefetch] is false. A target of 0 is unlimited.
 //
 // Batches of pages to download are built in four steps:
 //
@@ -89,14 +89,22 @@ import (
 type rowReaderDownloader struct {
 	inner Dataset
 
-	origColumns, origPrimary, origSecondary []Column
-	allColumns, primary, secondary          []Column
+	origColumns                    []Column
+	allColumns, primary, secondary []Column
 
 	dsetRanges rangeset.Set // Ranges of rows to _include_ in the download.
 
 	readRange rangeset.Range // Current range being read.
 	rangeMask rangeset.Set   // Inverse of dsetRanges: ranges to _exclude_ from download.
+
+	// targetSize is the target number of cached page bytes. 0 means unlimited.
+	// P1 pages are always downloaded even if they exceed the target.
+	targetSize int
 }
+
+// defaultDownloadTargetSize is the target size of cached pages when
+// [RowReaderOptions.Prefetch] is false.
+const defaultDownloadTargetSize = 64 << 20
 
 // newReaderDataset creates a new readerDataset wrapping around an inner
 // Dataset. The resulting Dataset only wraps around the provided columns.
@@ -154,10 +162,8 @@ func (dl *rowReaderDownloader) AddColumn(col Column, primary bool) {
 	dl.allColumns = append(dl.allColumns, wrappedCol)
 
 	if primary {
-		dl.origPrimary = append(dl.origPrimary, col)
 		dl.primary = append(dl.primary, wrappedCol)
 	} else {
-		dl.origSecondary = append(dl.origSecondary, col)
 		dl.secondary = append(dl.secondary, wrappedCol)
 	}
 }
@@ -184,18 +190,6 @@ func (dl *rowReaderDownloader) SetReadRange(r rangeset.Range) {
 func (dl *rowReaderDownloader) Mask(r rangeset.Range) {
 	dl.rangeMask.Add(r)
 }
-
-// OrigColumns returns the original columns of the rowReaderDownloader in the order
-// they were added.
-func (dl *rowReaderDownloader) OrigColumns() []Column { return dl.origColumns }
-
-// OrigPrimaryColumns returns the original primary columns of the
-// rowReaderDownloader in the order they were added.
-func (dl *rowReaderDownloader) OrigPrimaryColumns() []Column { return dl.origPrimary }
-
-// OrigSecondaryColumns returns the original secondary columns of the
-// rowReaderDownloader in the order they were added.
-func (dl *rowReaderDownloader) OrigSecondaryColumns() []Column { return dl.origSecondary }
 
 // AllColumns returns the wrapped columns of the rowReaderDownloader in the order
 // they were added.
@@ -290,6 +284,7 @@ func (dl *rowReaderDownloader) buildDownloadBatch(ctx context.Context, requestor
 	// Always add the requestor page to the batch if it's uncached.
 	if requestor != nil && len(requestor.data) == 0 {
 		pageBatch = append(pageBatch, requestor)
+		batchSize += requestor.PageDesc().CompressedSize
 	}
 
 	// If we're not calling buildDownloadBatch due to a page read, we'll assume
@@ -312,6 +307,10 @@ func (dl *rowReaderDownloader) buildDownloadBatch(ctx context.Context, requestor
 		}
 
 		pageBatch = append(pageBatch, page)
+		batchSize += page.PageDesc().CompressedSize
+	}
+	if dl.targetReached(batchSize) {
+		return pageBatch, nil
 	}
 
 	// Now we add P2 and P3 pages. We ignore pages that would have us exceed the
@@ -323,8 +322,6 @@ func (dl *rowReaderDownloader) buildDownloadBatch(ctx context.Context, requestor
 	// stuff our batch size as full as possible and downloading pages that never
 	// get used.
 
-	var targetReached bool
-
 	for result := range dl.iterP2Pages(ctx, isPrimary) {
 		page, err := result.Value()
 		if err != nil {
@@ -335,10 +332,13 @@ func (dl *rowReaderDownloader) buildDownloadBatch(ctx context.Context, requestor
 			continue // Already added.
 		}
 
+		pageSize := page.PageDesc().CompressedSize
+		if dl.wouldExceedTarget(batchSize, pageSize) {
+			return pageBatch, nil
+		}
+
 		pageBatch = append(pageBatch, page)
-	}
-	if targetReached {
-		return pageBatch, nil
+		batchSize += pageSize
 	}
 
 	for result := range dl.iterP3Pages(ctx, isPrimary) {
@@ -351,10 +351,24 @@ func (dl *rowReaderDownloader) buildDownloadBatch(ctx context.Context, requestor
 			continue // Already added.
 		}
 
+		pageSize := page.PageDesc().CompressedSize
+		if dl.wouldExceedTarget(batchSize, pageSize) {
+			return pageBatch, nil
+		}
+
 		pageBatch = append(pageBatch, page)
+		batchSize += pageSize
 	}
 
 	return pageBatch, nil
+}
+
+func (dl *rowReaderDownloader) targetReached(batchSize int) bool {
+	return dl.targetSize > 0 && batchSize >= dl.targetSize
+}
+
+func (dl *rowReaderDownloader) wouldExceedTarget(batchSize, pageSize int) bool {
+	return dl.targetSize > 0 && batchSize+pageSize > dl.targetSize
 }
 
 // iterP1Pages returns an iterator over P1 pages in round-robin column order,
@@ -483,8 +497,6 @@ func (dl *rowReaderDownloader) Reset(dset Dataset) {
 	dl.readRange = rangeset.Range{}
 
 	dl.origColumns = sliceclear.Clear(dl.origColumns)
-	dl.origPrimary = sliceclear.Clear(dl.origPrimary)
-	dl.origSecondary = sliceclear.Clear(dl.origSecondary)
 
 	dl.allColumns = sliceclear.Clear(dl.allColumns)
 	dl.primary = sliceclear.Clear(dl.primary)

--- a/pkg/dataobj/internal/dataset/row_reader_downloader.go
+++ b/pkg/dataobj/internal/dataset/row_reader_downloader.go
@@ -97,14 +97,16 @@ type rowReaderDownloader struct {
 	readRange rangeset.Range // Current range being read.
 	rangeMask rangeset.Set   // Inverse of dsetRanges: ranges to _exclude_ from download.
 
-	// targetSize is the target number of cached page bytes. 0 means unlimited.
+	// targetSize is the target number of compressed page bytes held in-memory. 0 means unlimited.
 	// P1 pages are always downloaded even if they exceed the target.
+	// It can be used to efficiently read pages from object storage in batches
+	// without downloading an entire section at once.
 	targetSize int
 }
 
-// defaultTargetCachedBytes is the target size in bytes of compressed pages to be cached when
+// defaultTargetDownloadedBytes is the target size in bytes of compressed pages to hold in-memory when
 // [RowReaderOptions.Prefetch] is false.
-const defaultTargetCachedBytes = 16 << 20 // 16 MB
+const defaultTargetDownloadedBytes = 16 << 20 // 16 MB
 
 // newReaderDataset creates a new readerDataset wrapping around an inner
 // Dataset. The resulting Dataset only wraps around the provided columns.

--- a/pkg/dataobj/internal/dataset/row_reader_downloader.go
+++ b/pkg/dataobj/internal/dataset/row_reader_downloader.go
@@ -102,9 +102,9 @@ type rowReaderDownloader struct {
 	targetSize int
 }
 
-// defaultDownloadTargetSize is the target size of cached pages when
+// defaultTargetCachedBytes is the target size in bytes of compressed pages to be cached when
 // [RowReaderOptions.Prefetch] is false.
-const defaultDownloadTargetSize = 64 << 20
+const defaultTargetCachedBytes = 16 << 20 // 16 MB
 
 // newReaderDataset creates a new readerDataset wrapping around an inner
 // Dataset. The resulting Dataset only wraps around the provided columns.

--- a/pkg/dataobj/internal/dataset/row_reader_test.go
+++ b/pkg/dataobj/internal/dataset/row_reader_test.go
@@ -46,7 +46,7 @@ func Test_RowReader_LazyDownloadTarget(t *testing.T) {
 	defer r.Close()
 
 	require.NoError(t, r.Open(t.Context()))
-	require.Equal(t, defaultTargetCachedBytes, r.dl.targetSize)
+	require.Equal(t, defaultTargetDownloadedBytes, r.dl.targetSize)
 
 	// Force the target below a single page so only P1 pages for the current
 	// read range are downloaded.

--- a/pkg/dataobj/internal/dataset/row_reader_test.go
+++ b/pkg/dataobj/internal/dataset/row_reader_test.go
@@ -40,6 +40,38 @@ func Test_RowReader_Open_Prefetch(t *testing.T) {
 	}
 }
 
+func Test_RowReader_LazyDownloadTarget(t *testing.T) {
+	dset, columns := buildTestDataset(t)
+	r := NewRowReader(RowReaderOptions{Dataset: dset, Columns: columns, Prefetch: false})
+	defer r.Close()
+
+	require.NoError(t, r.Open(t.Context()))
+	require.Equal(t, defaultDownloadTargetSize, r.dl.targetSize)
+
+	// Force the target below a single page so only P1 pages for the current
+	// read range are downloaded.
+	r.dl.targetSize = 1
+
+	n, err := r.Read(t.Context(), make([]Row, 1))
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	var cached, total int
+	for _, col := range r.dl.allColumns {
+		rc := col.(*readerColumn)
+		require.NotEmpty(t, rc.pages)
+		for _, page := range rc.pages {
+			total++
+			if page.data != nil {
+				cached++
+			}
+		}
+	}
+
+	require.Greater(t, cached, 0, "expected the current read range to download pages")
+	require.Less(t, cached, total, "expected the download target to leave later pages uncached")
+}
+
 func Test_Reader_ReadAll(t *testing.T) {
 	dset, columns := buildTestDataset(t)
 	r := NewRowReader(RowReaderOptions{Dataset: dset, Columns: columns})

--- a/pkg/dataobj/internal/dataset/row_reader_test.go
+++ b/pkg/dataobj/internal/dataset/row_reader_test.go
@@ -24,7 +24,7 @@ import (
 
 func Test_RowReader_Open_Prefetch(t *testing.T) {
 	dset, columns := buildTestDataset(t)
-	r := NewRowReader(RowReaderOptions{Dataset: dset, Columns: columns, Prefetch: true})
+	r := NewRowReader(RowReaderOptions{Dataset: dset, Columns: columns, PrefetchAllOnOpen: true})
 	defer r.Close()
 
 	require.NoError(t, r.Open(t.Context()))
@@ -42,7 +42,7 @@ func Test_RowReader_Open_Prefetch(t *testing.T) {
 
 func Test_RowReader_LazyDownloadTarget(t *testing.T) {
 	dset, columns := buildTestDataset(t)
-	r := NewRowReader(RowReaderOptions{Dataset: dset, Columns: columns, Prefetch: false})
+	r := NewRowReader(RowReaderOptions{Dataset: dset, Columns: columns, PrefetchAllOnOpen: false})
 	defer r.Close()
 
 	require.NoError(t, r.Open(t.Context()))

--- a/pkg/dataobj/internal/dataset/row_reader_test.go
+++ b/pkg/dataobj/internal/dataset/row_reader_test.go
@@ -46,11 +46,11 @@ func Test_RowReader_LazyDownloadTarget(t *testing.T) {
 	defer r.Close()
 
 	require.NoError(t, r.Open(t.Context()))
-	require.Equal(t, defaultTargetDownloadedBytes, r.dl.targetSize)
+	require.Equal(t, defaultTargetDownloadedBytes, r.dl.targetCompressedBytes)
 
 	// Force the target below a single page so only P1 pages for the current
 	// read range are downloaded.
-	r.dl.targetSize = 1
+	r.dl.targetCompressedBytes = 1
 
 	n, err := r.Read(t.Context(), make([]Row, 1))
 	require.NoError(t, err)

--- a/pkg/dataobj/internal/dataset/row_reader_test.go
+++ b/pkg/dataobj/internal/dataset/row_reader_test.go
@@ -46,7 +46,7 @@ func Test_RowReader_LazyDownloadTarget(t *testing.T) {
 	defer r.Close()
 
 	require.NoError(t, r.Open(t.Context()))
-	require.Equal(t, defaultDownloadTargetSize, r.dl.targetSize)
+	require.Equal(t, defaultTargetCachedBytes, r.dl.targetSize)
 
 	// Force the target below a single page so only P1 pages for the current
 	// read range are downloaded.
@@ -56,20 +56,21 @@ func Test_RowReader_LazyDownloadTarget(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, n)
 
-	var cached, total int
+	var pagesCached, totalPages int
 	for _, col := range r.dl.allColumns {
 		rc := col.(*readerColumn)
 		require.NotEmpty(t, rc.pages)
 		for _, page := range rc.pages {
-			total++
+			totalPages++
 			if page.data != nil {
-				cached++
+				pagesCached++
 			}
 		}
 	}
 
-	require.Greater(t, cached, 0, "expected the current read range to download pages")
-	require.Less(t, cached, total, "expected the download target to leave later pages uncached")
+	require.Greater(t, totalPages, len(columns), "expected more than one page per column")
+	require.Greater(t, pagesCached, 0, "expected the current read range to download pages")
+	require.Less(t, pagesCached, totalPages, "expected the download target to leave later pages uncached")
 }
 
 func Test_Reader_ReadAll(t *testing.T) {

--- a/pkg/dataobj/sections/indexpointers/iter.go
+++ b/pkg/dataobj/sections/indexpointers/iter.go
@@ -50,9 +50,9 @@ func IterSection(ctx context.Context, section *Section) result.Seq[IndexPointer]
 		}
 
 		r := dataset.NewRowReader(dataset.RowReaderOptions{
-			Dataset:  dset,
-			Columns:  columns,
-			Prefetch: true,
+			Dataset:           dset,
+			Columns:           columns,
+			PrefetchAllOnOpen: true,
 		})
 		defer r.Close()
 

--- a/pkg/dataobj/sections/indexpointers/reader.go
+++ b/pkg/dataobj/sections/indexpointers/reader.go
@@ -253,10 +253,10 @@ func (r *Reader) init(ctx context.Context) error {
 	}
 
 	innerOptions := dataset.RowReaderOptions{
-		Dataset:    dset,
-		Columns:    dset.Columns(),
-		Predicates: preds,
-		Prefetch:   true,
+		Dataset:           dset,
+		Columns:           dset.Columns(),
+		Predicates:        preds,
+		PrefetchAllOnOpen: true,
 	}
 	if r.inner == nil {
 		r.inner = columnar.NewReaderAdapter(innerOptions)

--- a/pkg/dataobj/sections/indexpointers/row_reader.go
+++ b/pkg/dataobj/sections/indexpointers/row_reader.go
@@ -113,10 +113,10 @@ func (r *RowReader) initReader(ctx context.Context) error {
 	}
 
 	readerOpts := dataset.RowReaderOptions{
-		Dataset:    dset,
-		Columns:    columns,
-		Predicates: predicates,
-		Prefetch:   true,
+		Dataset:           dset,
+		Columns:           columns,
+		Predicates:        predicates,
+		PrefetchAllOnOpen: true,
 	}
 
 	if r.reader == nil {

--- a/pkg/dataobj/sections/logs/dataset_forward_compat_test.go
+++ b/pkg/dataobj/sections/logs/dataset_forward_compat_test.go
@@ -40,9 +40,9 @@ func TestMakeColumnarDataset_ForwardCompatUnknownColumn(t *testing.T) {
 	require.NoError(t, err)
 
 	r := dataset.NewRowReader(dataset.RowReaderOptions{
-		Dataset:  dset,
-		Columns:  columns,
-		Prefetch: true,
+		Dataset:           dset,
+		Columns:           columns,
+		PrefetchAllOnOpen: true,
 	})
 	defer r.Close()
 	require.NoError(t, r.Open(t.Context()))

--- a/pkg/dataobj/sections/logs/iter.go
+++ b/pkg/dataobj/sections/logs/iter.go
@@ -52,9 +52,9 @@ func IterSection(ctx context.Context, section *Section) result.Seq[Record] {
 		}
 
 		r := dataset.NewRowReader(dataset.RowReaderOptions{
-			Dataset:  dset,
-			Columns:  columns,
-			Prefetch: true,
+			Dataset:           dset,
+			Columns:           columns,
+			PrefetchAllOnOpen: true,
 		})
 		defer r.Close()
 

--- a/pkg/dataobj/sections/logs/reader.go
+++ b/pkg/dataobj/sections/logs/reader.go
@@ -265,10 +265,10 @@ func (r *Reader) init(ctx context.Context) error {
 	}
 
 	innerOptions := dataset.RowReaderOptions{
-		Dataset:    dset,
-		Columns:    dset.Columns(),
-		Predicates: preds,
-		Prefetch:   true,
+		Dataset:           dset,
+		Columns:           dset.Columns(),
+		Predicates:        preds,
+		PrefetchAllOnOpen: true,
 	}
 	if r.inner == nil {
 		r.inner = columnar.NewReaderAdapter(innerOptions)

--- a/pkg/dataobj/sections/logs/row_reader.go
+++ b/pkg/dataobj/sections/logs/row_reader.go
@@ -158,10 +158,10 @@ func (r *RowReader) initReader(ctx context.Context) error {
 	}
 
 	readerOpts := dataset.RowReaderOptions{
-		Dataset:    dset,
-		Columns:    columns,
-		Predicates: predicates,
-		Prefetch:   true,
+		Dataset:           dset,
+		Columns:           columns,
+		Predicates:        predicates,
+		PrefetchAllOnOpen: true,
 	}
 
 	if r.reader == nil {

--- a/pkg/dataobj/sections/logs/table_merge.go
+++ b/pkg/dataobj/sections/logs/table_merge.go
@@ -74,7 +74,7 @@ func mergeTables(buf *tableBuffer, pageSize, pageRowCount int, compressionOpts *
 			Columns: dsetColumns,
 
 			// Download pages lazily; the table is already in memory.
-			Prefetch: false,
+			PrefetchAllOnOpen: false,
 		})
 		if err := r.Open(context.Background()); err != nil {
 			return nil, fmt.Errorf("opening dataset row reader: %w", err)

--- a/pkg/dataobj/sections/logs/table_merge.go
+++ b/pkg/dataobj/sections/logs/table_merge.go
@@ -73,7 +73,7 @@ func mergeTables(buf *tableBuffer, pageSize, pageRowCount int, compressionOpts *
 			Dataset: t,
 			Columns: dsetColumns,
 
-			// The table is in memory, so don't prefetch.
+			// Download pages lazily; the table is already in memory.
 			Prefetch: false,
 		})
 		if err := r.Open(context.Background()); err != nil {

--- a/pkg/dataobj/sections/pointers/iter.go
+++ b/pkg/dataobj/sections/pointers/iter.go
@@ -51,9 +51,9 @@ func IterSection(ctx context.Context, section *Section) result.Seq[SectionPointe
 		}
 
 		r := dataset.NewRowReader(dataset.RowReaderOptions{
-			Dataset:  dset,
-			Columns:  columns,
-			Prefetch: true,
+			Dataset:           dset,
+			Columns:           columns,
+			PrefetchAllOnOpen: true,
 		})
 		defer r.Close()
 

--- a/pkg/dataobj/sections/pointers/reader.go
+++ b/pkg/dataobj/sections/pointers/reader.go
@@ -261,10 +261,10 @@ func (r *Reader) init(ctx context.Context) error {
 	}
 
 	innerOptions := dataset.RowReaderOptions{
-		Dataset:    dset,
-		Columns:    dset.Columns(),
-		Predicates: preds,
-		Prefetch:   true,
+		Dataset:           dset,
+		Columns:           dset.Columns(),
+		Predicates:        preds,
+		PrefetchAllOnOpen: true,
 	}
 	if r.inner == nil {
 		r.inner = newRecordBatchLabelDecorator(columnar.NewReaderAdapter(innerOptions), innerOptions, r.opts)

--- a/pkg/dataobj/sections/pointers/row_reader.go
+++ b/pkg/dataobj/sections/pointers/row_reader.go
@@ -146,10 +146,10 @@ func (r *RowReader) initReader(ctx context.Context) error {
 	}
 
 	readerOpts := dataset.RowReaderOptions{
-		Dataset:    dset,
-		Columns:    columns,
-		Predicates: predicates,
-		Prefetch:   true,
+		Dataset:           dset,
+		Columns:           columns,
+		Predicates:        predicates,
+		PrefetchAllOnOpen: true,
 	}
 
 	if r.reader == nil {

--- a/pkg/dataobj/sections/postings/reader.go
+++ b/pkg/dataobj/sections/postings/reader.go
@@ -202,11 +202,11 @@ func (r *Reader) init(ctx context.Context) error {
 	}
 
 	innerOptions := dataset.RowReaderOptions{
-		Dataset:      dset,
-		Columns:      dset.Columns(),
-		Predicates:   preds,
-		Prefetch:     true,
-		StatsTracker: r.opts.StatsTracker,
+		Dataset:           dset,
+		Columns:           dset.Columns(),
+		Predicates:        preds,
+		PrefetchAllOnOpen: true,
+		StatsTracker:      r.opts.StatsTracker,
 	}
 	if r.inner == nil {
 		r.inner = columnar.NewReaderAdapter(innerOptions)

--- a/pkg/dataobj/sections/stats/reader.go
+++ b/pkg/dataobj/sections/stats/reader.go
@@ -230,9 +230,9 @@ func (r *Reader) init(ctx context.Context) error {
 	}
 
 	innerOptions := dataset.RowReaderOptions{
-		Dataset:  dset,
-		Columns:  dset.Columns(),
-		Prefetch: true,
+		Dataset:           dset,
+		Columns:           dset.Columns(),
+		PrefetchAllOnOpen: true,
 	}
 	if r.inner == nil {
 		r.inner = columnar.NewReaderAdapter(innerOptions)

--- a/pkg/dataobj/sections/streams/iter.go
+++ b/pkg/dataobj/sections/streams/iter.go
@@ -92,9 +92,9 @@ func iterSection(ctx context.Context, section *Section, cfg iterConfig) result.S
 		}
 
 		r := dataset.NewRowReader(dataset.RowReaderOptions{
-			Dataset:  dset,
-			Columns:  columns,
-			Prefetch: true,
+			Dataset:           dset,
+			Columns:           columns,
+			PrefetchAllOnOpen: true,
 		})
 		defer r.Close()
 

--- a/pkg/dataobj/sections/streams/reader.go
+++ b/pkg/dataobj/sections/streams/reader.go
@@ -262,10 +262,10 @@ func (r *Reader) init(ctx context.Context) error {
 	}
 
 	innerOptions := dataset.RowReaderOptions{
-		Dataset:    dset,
-		Columns:    dset.Columns(),
-		Predicates: preds,
-		Prefetch:   true,
+		Dataset:           dset,
+		Columns:           dset.Columns(),
+		Predicates:        preds,
+		PrefetchAllOnOpen: true,
 	}
 	if r.inner == nil {
 		r.inner = columnar.NewReaderAdapter(innerOptions)

--- a/pkg/dataobj/sections/streams/row_reader.go
+++ b/pkg/dataobj/sections/streams/row_reader.go
@@ -116,10 +116,10 @@ func (r *RowReader) initReader(ctx context.Context) error {
 	}
 
 	readerOpts := dataset.RowReaderOptions{
-		Dataset:    dset,
-		Columns:    columns,
-		Predicates: predicates,
-		Prefetch:   true,
+		Dataset:           dset,
+		Columns:           columns,
+		Predicates:        predicates,
+		PrefetchAllOnOpen: true,
 	}
 
 	if r.reader == nil {

--- a/pkg/dataobj/sortmerge/sortmerge.go
+++ b/pkg/dataobj/sortmerge/sortmerge.go
@@ -99,9 +99,9 @@ func iterator(
 		}
 
 		r := dataset.NewRowReader(dataset.RowReaderOptions{
-			Dataset:  ds,
-			Columns:  columns,
-			Prefetch: false,
+			Dataset:           ds,
+			Columns:           columns,
+			PrefetchAllOnOpen: false,
 		})
 		if err := r.Open(ctx); err != nil {
 			return nil, fmt.Errorf("opening dataset row reader: %w", err)

--- a/pkg/dataobj/sortmerge/sortmerge.go
+++ b/pkg/dataobj/sortmerge/sortmerge.go
@@ -101,7 +101,7 @@ func iterator(
 		r := dataset.NewRowReader(dataset.RowReaderOptions{
 			Dataset:  ds,
 			Columns:  columns,
-			Prefetch: true,
+			Prefetch: false,
 		})
 		if err := r.Open(ctx); err != nil {
 			return nil, fmt.Errorf("opening dataset row reader: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces the behaviour implied by the Row Downloader comments. Previously there was no target size and each request under a non-prefetched reader would fetch very few pages.
This changes enables a batch of pages to be fetched at once, up to the requested size, in order to balance memory usage versus object storage requests.

I didn't expose this as a config param because I think a sensible default is best. I don't think this is easy to tune without knowing the internals of the system (how big are sections when compressed, which cloud provider etc.).
If different target sizes are required, it can be exposed as a parameter later.