### PR TITLE
fix(operator): Release leader lease on shutdown so upgrades are faster

### DIFF
--- a/operator/internal/config/options.go
+++ b/operator/internal/config/options.go
@@ -21,7 +21,11 @@ import (
 // LoadConfig initializes the controller configuration, optionally overriding the defaults
 // from a provided configuration file.
 func LoadConfig(scheme *runtime.Scheme, configFile string) (*configv1.ProjectConfig, *TokenCCOAuthConfig, ctrl.Options, error) {
-	options := ctrl.Options{Scheme: scheme}
+	options := ctrl.Options{
+		Scheme:                        scheme,
+		LeaderElectionReleaseOnCancel: true,
+	}
+
 	leaderElection := leaderelection.LeaderElectionDefaulting(openshiftconfigv1.LeaderElection{}, "", "")
 	if configFile == "" {
 		return &configv1.ProjectConfig{}, nil, options, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Without releasing the lock on SIGTERM, the next operator pod always waits the non-graceful timeout (~163s) after OLM upgrades and redeploys.

**Which issue(s) this PR fixes**:
https://redhat.atlassian.net/browse/LOG-8579

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
