### PR TITLE
chore: Cache resolved label value symbols

### DIFF
--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_reader_test.go
@@ -146,15 +146,21 @@ func BenchmarkNewStreamFileReader(b *testing.B) {
 	}
 }
 
-func writeBenchmarkFixture(t testing.TB, numSeries int, numChunksPerLabel int) string {
+func writeBenchmarkFixture(t testing.TB, numSeries int, numChunksPerSeries int) string {
 	t.Helper()
-	chunks := make([]ChunkMeta, numChunksPerLabel)
-	for i := range numChunksPerLabel {
+	chunks := make([]ChunkMeta, numChunksPerSeries)
+	for i := range numChunksPerSeries {
 		chunks[i] = ChunkMeta{Checksum: uint32(i), MinTime: int64(i * 10), MaxTime: int64(i*10 + 10)}
 	}
 	series := make([]seriesFixture, numSeries)
 	for i := range numSeries {
-		series[i].ls = labels.FromStrings("a", strconv.Itoa(i%5), "b", strconv.Itoa(i%11), "c", strconv.Itoa(i%17))
+		series[i].ls = labels.FromStrings(
+			"id", fmt.Sprintf("series-%d", i),
+			"pod", fmt.Sprintf("pod-%d", i),
+			"a", strconv.Itoa(i%5),
+			"b", strconv.Itoa(i%11),
+			"c", strconv.Itoa(i%17),
+		)
 		series[i].chunks = chunks
 	}
 	return writeIndexFixture(t, FormatV4, series)

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols.go
@@ -8,6 +8,8 @@ import (
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc"
 )
 
+// Constant taken from thanos https://github.com/thanos-io/thanos/pull/3557.
+// Research has not been done into whether this is the best number for Loki's indexes.
 const labelValueSymbolsCacheSize = 1024
 
 // streamSymbols is StreamReader's equivalent of Symbols.

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols.go
@@ -3,9 +3,12 @@ package index
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index/streamenc"
 )
+
+const labelValueSymbolsCacheSize = 1024
 
 // streamSymbols is StreamReader's equivalent of Symbols.
 //
@@ -27,6 +30,17 @@ type streamSymbols struct {
 	// There are not many label names compared to label values, and they
 	// make up half of all lookups, so holding them in memory is a good trade-off.
 	labelNameSymbols map[uint32]string
+
+	// labelValueSymbolsCache is a direct cache of label value symbols,
+	// keyed on the low bits of the ordinal.
+	// An entry answers for ordinal n only when it holds n and a non-empty
+	// symbol, so the zero value is a miss and a collision costs a re-read
+	// rather than the wrong symbol.
+	labelValueSymbolsMtx   sync.Mutex
+	labelValueSymbolsCache [labelValueSymbolsCacheSize]struct {
+		ordinal uint32
+		symbol  string
+	}
 }
 
 // newStreamSymbols scans the symbol section once, validating its CRC,
@@ -65,6 +79,7 @@ func newStreamSymbols(ctx context.Context, factory *streamenc.FilePoolDecbufFact
 	return s, nil
 }
 
+// Lookup resolves ordinal n either from a file or a local cache.
 func (s *streamSymbols) Lookup(n uint32) (string, error) {
 	if symbol, ok := s.labelNameSymbols[n]; ok {
 		return symbol, nil
@@ -74,6 +89,29 @@ func (s *streamSymbols) Lookup(n uint32) (string, error) {
 		return "", fmt.Errorf("unknown symbol offset %d", n)
 	}
 
+	cacheIndex := n % labelValueSymbolsCacheSize
+	s.labelValueSymbolsMtx.Lock()
+	if entry := s.labelValueSymbolsCache[cacheIndex]; entry.ordinal == n && entry.symbol != "" {
+		s.labelValueSymbolsMtx.Unlock()
+		return entry.symbol, nil
+	}
+	s.labelValueSymbolsMtx.Unlock()
+
+	symbol, err := s.lookup(n)
+	if err != nil {
+		return "", err
+	}
+
+	s.labelValueSymbolsMtx.Lock()
+	s.labelValueSymbolsCache[cacheIndex].ordinal = n
+	s.labelValueSymbolsCache[cacheIndex].symbol = symbol
+	s.labelValueSymbolsMtx.Unlock()
+
+	return symbol, nil
+}
+
+// lookup resolves ordinal n from the file.
+func (s *streamSymbols) lookup(n uint32) (string, error) {
 	decbuf := s.factory.NewDecbufAtUnchecked(context.Background(), s.off)
 	defer decbuf.Close()
 	if err := decbuf.Err(); err != nil {

--- a/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/tsdb/index/stream_symbols_test.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -55,6 +56,68 @@ func TestStreamSymbols_LookupMatchesMmap(t *testing.T) {
 				require.Error(t, mmapErr)
 				require.Error(t, streamErr)
 				require.Equal(t, mmapErr.Error(), streamErr.Error())
+			}
+		})
+	}
+}
+
+// writeWideSymbolsFixture builds an index with more symbols than a reader caches.
+func writeWideSymbolsFixture(t *testing.T, format int) (string, int64) {
+	t.Helper()
+
+	// Two unique values per series, so the symbol table exceeds
+	// labelValueSymbolsCacheSize without writing that many series.
+	const numSeries = labelValueSymbolsCacheSize*2 + 100
+
+	series := make([]seriesFixture, 0, numSeries)
+	for i := range numSeries {
+		series = append(series, seriesFixture{
+			ls: labels.FromStrings(
+				"id", fmt.Sprintf("series%05d", i),
+				"pod", fmt.Sprintf("pod%05d", i),
+				"app", fmt.Sprintf("app%02d", i%7),
+				"env", []string{"dev", "prod", "staging"}[i%3],
+				"tenant", "loki",
+			),
+			chunks: []ChunkMeta{{
+				Checksum: uint32(i),
+				MinTime:  0,
+				MaxTime:  chunkSpan - 1,
+				KB:       1,
+				Entries:  1,
+			}},
+		})
+	}
+
+	return writeIndexFixture(t, format, series), chunkSpan
+}
+
+// TestStreamSymbols_LookupMatchesMmapPastCacheEviction runs the cross-check
+// against the mmap reader over an index with more symbols than the cache holds,
+// so lookups evict each other while it runs.
+func TestStreamSymbols_LookupMatchesMmapPastCacheEviction(t *testing.T) {
+	for _, format := range []int{FormatV3, FormatV4} {
+		t.Run(fmt.Sprintf("format=%d", format), func(t *testing.T) {
+			path, _ := writeWideSymbolsFixture(t, format)
+			mmap, stream := openBothReaders(t, path)
+
+			require.Equal(t, mmap.symbols.seen, stream.symbols.size)
+			// Big enough we'll certainly be exercising plenty of eviction
+			require.Greater(t, stream.symbols.size, labelValueSymbolsCacheSize*4)
+
+			ordinals := make([]uint32, stream.symbols.size)
+			for i := range ordinals {
+				ordinals[i] = uint32(i)
+			}
+			rnd := rand.New(rand.NewSource(1))
+			rnd.Shuffle(len(ordinals), func(i, j int) { ordinals[i], ordinals[j] = ordinals[j], ordinals[i] })
+
+			for _, n := range ordinals {
+				mmapResolvedSymbol, err := mmap.symbols.Lookup(n)
+				require.NoError(t, err)
+				streamResolvedSymbol, err := stream.symbols.Lookup(n)
+				require.NoError(t, err)
+				require.Equal(t, mmapResolvedSymbol, streamResolvedSymbol)
 			}
 		})
 	}


### PR DESCRIPTION
This mirrors a similar optimisation that is present in mimir - this is where I've gotten the magic number 1024 from - https://github.com/grafana/mimir/blob/aad7765a7aca27b7430bc956cd3ccfc4e1ff1690/pkg/storage/indexheader/stream_binary_reader.go#L316-L333.

Benchmarking:
```
                   │ before.txt  │              after.txt              │
                   │   sec/op    │   sec/op     vs base                │
SeriesIteration-12   98.80m ± 1%   45.85m ± 3%  -53.59% (p=0.000 n=10)

                   │  before.txt  │              after.txt               │
                   │     B/op     │     B/op      vs base                │
SeriesIteration-12   5.035Mi ± 0%   2.889Mi ± 0%  -42.62% (p=0.000 n=10)

                   │  before.txt  │              after.txt              │
                   │  allocs/op   │  allocs/op   vs base                │
SeriesIteration-12   106.97k ± 0%   70.85k ± 0%  -33.77% (p=0.000 n=10)
```

Measured ~65% improvement in sec/op on a benchmark against a realistic index.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
