### PR TITLE
fix: Flush final loki_logql_querystats_bytes_processed_total value on querier shutdown

### DIFF
--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -649,12 +649,7 @@ func (t *Loki) Run(opts RunOpts) error {
 	sm.AddListener(services.NewManagerListener(healthy, stopped, serviceFailed))
 
 	// Setup signal handler. If signal arrives, we stop the manager, which stops all the services.
-	var signalReceivers []signals.SignalReceiver
-	if queryStatsShutdownPushReceiver := newQueryStatsShutdownPushReceiver(t.Cfg.Worker, prometheus.DefaultGatherer, util_log.Logger); queryStatsShutdownPushReceiver != nil {
-		signalReceivers = append(signalReceivers, queryStatsShutdownPushReceiver)
-	}
-
-	t.SignalHandler = signals.NewHandler(t.Server.Log, signalReceivers...)
+	t.SignalHandler = signals.NewHandler(t.Server.Log)
 	go func() {
 		t.SignalHandler.Loop()
 		shutdownRequested.Store(true)
@@ -689,6 +684,10 @@ func (t *Loki) Run(opts RunOpts) error {
 				}
 			}
 		}
+	}
+
+	if shutdownRequested.Load() {
+		flushShutdownQueryStats(t.Cfg.Worker, prometheus.DefaultGatherer, util_log.Logger)
 	}
 	return err
 }

--- a/pkg/loki/loki.go
+++ b/pkg/loki/loki.go
@@ -649,7 +649,12 @@ func (t *Loki) Run(opts RunOpts) error {
 	sm.AddListener(services.NewManagerListener(healthy, stopped, serviceFailed))
 
 	// Setup signal handler. If signal arrives, we stop the manager, which stops all the services.
-	t.SignalHandler = signals.NewHandler(t.Server.Log)
+	var signalReceivers []signals.SignalReceiver
+	if queryStatsShutdownPushReceiver := newQueryStatsShutdownPushReceiver(t.Cfg.Worker, prometheus.DefaultGatherer, util_log.Logger); queryStatsShutdownPushReceiver != nil {
+		signalReceivers = append(signalReceivers, queryStatsShutdownPushReceiver)
+	}
+
+	t.SignalHandler = signals.NewHandler(t.Server.Log, signalReceivers...)
 	go func() {
 		t.SignalHandler.Loop()
 		shutdownRequested.Store(true)

--- a/pkg/loki/query_stats_shutdown_push.go
+++ b/pkg/loki/query_stats_shutdown_push.go
@@ -18,42 +18,28 @@ const queryStatsBytesProcessedMetricName = "loki_logql_querystats_bytes_processe
 
 var errMetricFamilyNotFound = errors.New("metric family not found")
 
-type queryStatsShutdownPushReceiver struct {
-	cfg      worker.Config
-	gatherer prometheus.Gatherer
-	logger   log.Logger
-}
-
-func newQueryStatsShutdownPushReceiver(cfg worker.Config, gatherer prometheus.Gatherer, logger log.Logger) *queryStatsShutdownPushReceiver {
+func flushShutdownQueryStats(cfg worker.Config, gatherer prometheus.Gatherer, logger log.Logger) {
 	if cfg.ShutdownQueryStatsPushGatewayURL == "" {
-		return nil
+		return
 	}
 
-	return &queryStatsShutdownPushReceiver{
-		cfg:      cfg,
-		gatherer: gatherer,
-		logger:   logger,
-	}
-}
-
-func (r *queryStatsShutdownPushReceiver) Stop() error {
-	metricFamily, err := gatherMetricFamily(r.gatherer, queryStatsBytesProcessedMetricName)
+	metricFamily, err := gatherMetricFamily(gatherer, queryStatsBytesProcessedMetricName)
 	if err != nil {
 		if errors.Is(err, errMetricFamilyNotFound) {
-			level.Debug(r.logger).Log("msg", "skipping shutdown query-stats push because metric family is not present", "metric", queryStatsBytesProcessedMetricName)
-			return nil
+			level.Debug(logger).Log("msg", "skipping shutdown query-stats push because metric family is not present", "metric", queryStatsBytesProcessedMetricName)
+			return
 		}
 
-		level.Warn(r.logger).Log("msg", "failed to gather shutdown query-stats metric", "metric", queryStatsBytesProcessedMetricName, "err", err)
-		return nil
+		level.Warn(logger).Log("msg", "failed to gather shutdown query-stats metric", "metric", queryStatsBytesProcessedMetricName, "err", err)
+		return
 	}
 
-	jobName := r.cfg.ShutdownQueryStatsPushJobName
-	pusher := push.New(r.cfg.ShutdownQueryStatsPushGatewayURL, jobName).
+	jobName := cfg.ShutdownQueryStatsPushJobName
+	pusher := push.New(cfg.ShutdownQueryStatsPushGatewayURL, jobName).
 		Gatherer(metricFamilyGatherer{metricFamily: metricFamily}).
 		Grouping("component", "querier")
 
-	querierID := r.cfg.QuerierID
+	querierID := cfg.QuerierID
 	if querierID == "" {
 		hostname, hostnameErr := os.Hostname()
 		if hostnameErr == nil && hostname != "" {
@@ -64,16 +50,15 @@ func (r *queryStatsShutdownPushReceiver) Stop() error {
 		pusher = pusher.Grouping("instance", querierID)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), r.cfg.ShutdownQueryStatsPushTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownQueryStatsPushTimeout)
 	defer cancel()
 
 	if err := pusher.PushContext(ctx); err != nil {
-		level.Warn(r.logger).Log("msg", "failed to push shutdown query-stats metric", "metric", queryStatsBytesProcessedMetricName, "url", r.cfg.ShutdownQueryStatsPushGatewayURL, "err", err)
-		return nil
+		level.Warn(logger).Log("msg", "failed to push shutdown query-stats metric", "metric", queryStatsBytesProcessedMetricName, "url", cfg.ShutdownQueryStatsPushGatewayURL, "err", err)
+		return
 	}
 
-	level.Info(r.logger).Log("msg", "pushed shutdown query-stats metric", "metric", queryStatsBytesProcessedMetricName, "url", r.cfg.ShutdownQueryStatsPushGatewayURL)
-	return nil
+	level.Info(logger).Log("msg", "pushed shutdown query-stats metric", "metric", queryStatsBytesProcessedMetricName, "url", cfg.ShutdownQueryStatsPushGatewayURL)
 }
 
 type metricFamilyGatherer struct {

--- a/pkg/loki/query_stats_shutdown_push.go
+++ b/pkg/loki/query_stats_shutdown_push.go
@@ -1,0 +1,100 @@
+package loki
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/push"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/grafana/loki/v3/pkg/querier/worker"
+)
+
+const queryStatsBytesProcessedMetricName = "loki_logql_querystats_bytes_processed_total"
+
+var errMetricFamilyNotFound = errors.New("metric family not found")
+
+type queryStatsShutdownPushReceiver struct {
+	cfg      worker.Config
+	gatherer prometheus.Gatherer
+	logger   log.Logger
+}
+
+func newQueryStatsShutdownPushReceiver(cfg worker.Config, gatherer prometheus.Gatherer, logger log.Logger) *queryStatsShutdownPushReceiver {
+	if cfg.ShutdownQueryStatsPushGatewayURL == "" {
+		return nil
+	}
+
+	return &queryStatsShutdownPushReceiver{
+		cfg:      cfg,
+		gatherer: gatherer,
+		logger:   logger,
+	}
+}
+
+func (r *queryStatsShutdownPushReceiver) Stop() error {
+	metricFamily, err := gatherMetricFamily(r.gatherer, queryStatsBytesProcessedMetricName)
+	if err != nil {
+		if errors.Is(err, errMetricFamilyNotFound) {
+			level.Debug(r.logger).Log("msg", "skipping shutdown query-stats push because metric family is not present", "metric", queryStatsBytesProcessedMetricName)
+			return nil
+		}
+
+		level.Warn(r.logger).Log("msg", "failed to gather shutdown query-stats metric", "metric", queryStatsBytesProcessedMetricName, "err", err)
+		return nil
+	}
+
+	jobName := r.cfg.ShutdownQueryStatsPushJobName
+	pusher := push.New(r.cfg.ShutdownQueryStatsPushGatewayURL, jobName).
+		Gatherer(metricFamilyGatherer{metricFamily: metricFamily}).
+		Grouping("component", "querier")
+
+	querierID := r.cfg.QuerierID
+	if querierID == "" {
+		hostname, hostnameErr := os.Hostname()
+		if hostnameErr == nil && hostname != "" {
+			querierID = hostname
+		}
+	}
+	if querierID != "" {
+		pusher = pusher.Grouping("instance", querierID)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), r.cfg.ShutdownQueryStatsPushTimeout)
+	defer cancel()
+
+	if err := pusher.PushContext(ctx); err != nil {
+		level.Warn(r.logger).Log("msg", "failed to push shutdown query-stats metric", "metric", queryStatsBytesProcessedMetricName, "url", r.cfg.ShutdownQueryStatsPushGatewayURL, "err", err)
+		return nil
+	}
+
+	level.Info(r.logger).Log("msg", "pushed shutdown query-stats metric", "metric", queryStatsBytesProcessedMetricName, "url", r.cfg.ShutdownQueryStatsPushGatewayURL)
+	return nil
+}
+
+type metricFamilyGatherer struct {
+	metricFamily *dto.MetricFamily
+}
+
+func (g metricFamilyGatherer) Gather() ([]*dto.MetricFamily, error) {
+	return []*dto.MetricFamily{g.metricFamily}, nil
+}
+
+func gatherMetricFamily(gatherer prometheus.Gatherer, metricName string) (*dto.MetricFamily, error) {
+	families, err := gatherer.Gather()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, family := range families {
+		if family.GetName() == metricName {
+			return family, nil
+		}
+	}
+
+	return nil, errMetricFamilyNotFound
+}

--- a/pkg/loki/query_stats_shutdown_push_test.go
+++ b/pkg/loki/query_stats_shutdown_push_test.go
@@ -1,0 +1,87 @@
+package loki
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/querier/worker"
+)
+
+func TestNewQueryStatsShutdownPushReceiver(t *testing.T) {
+	t.Run("returns nil when URL is empty", func(t *testing.T) {
+		receiver := newQueryStatsShutdownPushReceiver(worker.Config{}, prometheus.DefaultGatherer, log.NewNopLogger())
+		require.Nil(t, receiver)
+	})
+}
+
+func TestQueryStatsShutdownPushReceiver_Stop(t *testing.T) {
+	t.Run("pushes query-stats metric", func(t *testing.T) {
+		var (
+			requestCount  atomic.Int64
+			requestPath   atomic.Value
+			requestMethod atomic.Value
+		)
+
+		requestPath.Store("")
+		requestMethod.Store("")
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
+			requestPath.Store(r.URL.Path)
+			requestMethod.Store(r.Method)
+			require.NoError(t, r.Body.Close())
+			w.WriteHeader(http.StatusAccepted)
+		}))
+		defer server.Close()
+
+		reg := prometheus.NewRegistry()
+		queryStats := prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: queryStatsBytesProcessedMetricName,
+			Help: "Total number of bytes processed by LogQL queries, partitioned by tenant.",
+		}, []string{"tenant"})
+		reg.MustRegister(queryStats)
+		queryStats.WithLabelValues("tenant-a").Add(123)
+
+		receiver := newQueryStatsShutdownPushReceiver(worker.Config{
+			QuerierID:                        "querier-1",
+			ShutdownQueryStatsPushGatewayURL: server.URL,
+			ShutdownQueryStatsPushJobName:    "loki-querier-shutdown",
+			ShutdownQueryStatsPushTimeout:    time.Second,
+		}, reg, log.NewNopLogger())
+
+		require.NotNil(t, receiver)
+		require.NoError(t, receiver.Stop())
+		require.EqualValues(t, 1, requestCount.Load())
+		require.Equal(t, http.MethodPut, requestMethod.Load().(string))
+		require.True(t, strings.Contains(requestPath.Load().(string), "/metrics/job/loki-querier-shutdown"))
+		require.True(t, strings.Contains(requestPath.Load().(string), "/component/querier"))
+		require.True(t, strings.Contains(requestPath.Load().(string), "/instance/querier-1"))
+	})
+
+	t.Run("skips push if metric family does not exist", func(t *testing.T) {
+		var requestCount atomic.Int64
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			requestCount.Add(1)
+			w.WriteHeader(http.StatusAccepted)
+		}))
+		defer server.Close()
+
+		receiver := newQueryStatsShutdownPushReceiver(worker.Config{
+			ShutdownQueryStatsPushGatewayURL: server.URL,
+			ShutdownQueryStatsPushJobName:    "loki-querier-shutdown",
+			ShutdownQueryStatsPushTimeout:    time.Second,
+		}, prometheus.NewRegistry(), log.NewNopLogger())
+
+		require.NotNil(t, receiver)
+		require.NoError(t, receiver.Stop())
+		require.EqualValues(t, 0, requestCount.Load())
+	})
+}

--- a/pkg/loki/query_stats_shutdown_push_test.go
+++ b/pkg/loki/query_stats_shutdown_push_test.go
@@ -4,9 +4,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
+
+	"go.uber.org/atomic"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -16,7 +17,7 @@ import (
 )
 
 func TestFlushShutdownQueryStats(t *testing.T) {
-	t.Run("returns immediately when URL is empty", func(t *testing.T) {
+	t.Run("returns immediately when URL is empty", func(_ *testing.T) {
 		flushShutdownQueryStats(worker.Config{}, prometheus.DefaultGatherer, log.NewNopLogger())
 	})
 

--- a/pkg/loki/query_stats_shutdown_push_test.go
+++ b/pkg/loki/query_stats_shutdown_push_test.go
@@ -15,14 +15,11 @@ import (
 	"github.com/grafana/loki/v3/pkg/querier/worker"
 )
 
-func TestNewQueryStatsShutdownPushReceiver(t *testing.T) {
-	t.Run("returns nil when URL is empty", func(t *testing.T) {
-		receiver := newQueryStatsShutdownPushReceiver(worker.Config{}, prometheus.DefaultGatherer, log.NewNopLogger())
-		require.Nil(t, receiver)
+func TestFlushShutdownQueryStats(t *testing.T) {
+	t.Run("returns immediately when URL is empty", func(t *testing.T) {
+		flushShutdownQueryStats(worker.Config{}, prometheus.DefaultGatherer, log.NewNopLogger())
 	})
-}
 
-func TestQueryStatsShutdownPushReceiver_Stop(t *testing.T) {
 	t.Run("pushes query-stats metric", func(t *testing.T) {
 		var (
 			requestCount  atomic.Int64
@@ -49,15 +46,14 @@ func TestQueryStatsShutdownPushReceiver_Stop(t *testing.T) {
 		reg.MustRegister(queryStats)
 		queryStats.WithLabelValues("tenant-a").Add(123)
 
-		receiver := newQueryStatsShutdownPushReceiver(worker.Config{
+		cfg := worker.Config{
 			QuerierID:                        "querier-1",
 			ShutdownQueryStatsPushGatewayURL: server.URL,
 			ShutdownQueryStatsPushJobName:    "loki-querier-shutdown",
 			ShutdownQueryStatsPushTimeout:    time.Second,
-		}, reg, log.NewNopLogger())
+		}
 
-		require.NotNil(t, receiver)
-		require.NoError(t, receiver.Stop())
+		flushShutdownQueryStats(cfg, reg, log.NewNopLogger())
 		require.EqualValues(t, 1, requestCount.Load())
 		require.Equal(t, http.MethodPut, requestMethod.Load().(string))
 		require.True(t, strings.Contains(requestPath.Load().(string), "/metrics/job/loki-querier-shutdown"))
@@ -74,14 +70,13 @@ func TestQueryStatsShutdownPushReceiver_Stop(t *testing.T) {
 		}))
 		defer server.Close()
 
-		receiver := newQueryStatsShutdownPushReceiver(worker.Config{
+		cfg := worker.Config{
 			ShutdownQueryStatsPushGatewayURL: server.URL,
 			ShutdownQueryStatsPushJobName:    "loki-querier-shutdown",
 			ShutdownQueryStatsPushTimeout:    time.Second,
-		}, prometheus.NewRegistry(), log.NewNopLogger())
+		}
 
-		require.NotNil(t, receiver)
-		require.NoError(t, receiver.Stop())
+		flushShutdownQueryStats(cfg, prometheus.NewRegistry(), log.NewNopLogger())
 		require.EqualValues(t, 0, requestCount.Load())
 	})
 }

--- a/pkg/querier/worker/config_test.go
+++ b/pkg/querier/worker/config_test.go
@@ -1,0 +1,46 @@
+package worker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigValidate_ShutdownQueryStatsPush(t *testing.T) {
+	t.Run("accepts empty pushgateway URL", func(t *testing.T) {
+		cfg := Config{}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("rejects invalid pushgateway URL", func(t *testing.T) {
+		cfg := Config{ShutdownQueryStatsPushGatewayURL: "://bad-url"}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid querier.shutdown-query-stats-pushgateway-url")
+	})
+
+	t.Run("requires job name when URL is configured", func(t *testing.T) {
+		cfg := Config{
+			ShutdownQueryStatsPushGatewayURL: "http://pushgateway:9091",
+			ShutdownQueryStatsPushJobName:    "",
+			ShutdownQueryStatsPushTimeout:    time.Second,
+		}
+
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "querier.shutdown-query-stats-push-job-name must be set")
+	})
+
+	t.Run("requires positive timeout when URL is configured", func(t *testing.T) {
+		cfg := Config{
+			ShutdownQueryStatsPushGatewayURL: "http://pushgateway:9091",
+			ShutdownQueryStatsPushJobName:    "loki-querier-shutdown",
+			ShutdownQueryStatsPushTimeout:    0,
+		}
+
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "querier.shutdown-query-stats-push-timeout must be greater than 0")
+	})
+}

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"flag"
+	"net/url"
 	"os"
 	"sync"
 	"time"
@@ -38,6 +39,10 @@ type Config struct {
 	OldQueryFrontendGRPCClientConfig grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the querier gRPC client used to communicate with the query-frontend and with the query-scheduler. This can't be used in conjunction with 'query_frontend_grpc_client' or 'query_scheduler_grpc_client'."`
 
 	QuerySchedulerGRPCClientConfig grpcclient.Config `yaml:"query_scheduler_grpc_client" doc:"description=Configures the querier gRPC client used to communicate with the query-scheduler. This can't be used in conjunction with 'grpc_client_config'."`
+
+	ShutdownQueryStatsPushGatewayURL string        `yaml:"shutdown_query_stats_pushgateway_url" doc:"description=Optional Pushgateway URL to push the final loki_logql_querystats_bytes_processed_total value when the process receives SIGINT/SIGTERM. Disabled when empty."`
+	ShutdownQueryStatsPushJobName    string        `yaml:"shutdown_query_stats_push_job_name" doc:"description=Pushgateway job name used for shutdown query stats push."`
+	ShutdownQueryStatsPushTimeout    time.Duration `yaml:"shutdown_query_stats_push_timeout" doc:"description=Timeout for pushing query stats to Pushgateway during shutdown."`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
@@ -51,6 +56,10 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 	cfg.NewQueryFrontendGRPCClientConfig.RegisterFlagsWithPrefix("querier.frontend-grpc-client", f)
 	cfg.QuerySchedulerGRPCClientConfig.RegisterFlagsWithPrefix("querier.scheduler-grpc-client", f)
+
+	f.StringVar(&cfg.ShutdownQueryStatsPushGatewayURL, "querier.shutdown-query-stats-pushgateway-url", "", "Optional Pushgateway URL to push final loki_logql_querystats_bytes_processed_total on SIGINT/SIGTERM. If empty, pushing is disabled.")
+	f.StringVar(&cfg.ShutdownQueryStatsPushJobName, "querier.shutdown-query-stats-push-job-name", "loki-querier-shutdown", "Pushgateway job name used for shutdown query stats push.")
+	f.DurationVar(&cfg.ShutdownQueryStatsPushTimeout, "querier.shutdown-query-stats-push-timeout", 5*time.Second, "Timeout for pushing shutdown query stats to Pushgateway.")
 }
 
 func (cfg *Config) Validate() error {
@@ -62,6 +71,17 @@ func (cfg *Config) Validate() error {
 	}
 	if err := cfg.OldQueryFrontendGRPCClientConfig.Validate(); err != nil {
 		return err
+	}
+	if cfg.ShutdownQueryStatsPushGatewayURL != "" {
+		if _, err := url.ParseRequestURI(cfg.ShutdownQueryStatsPushGatewayURL); err != nil {
+			return errors.Wrap(err, "invalid querier.shutdown-query-stats-pushgateway-url")
+		}
+		if cfg.ShutdownQueryStatsPushJobName == "" {
+			return errors.New("querier.shutdown-query-stats-push-job-name must be set when querier.shutdown-query-stats-pushgateway-url is configured")
+		}
+		if cfg.ShutdownQueryStatsPushTimeout <= 0 {
+			return errors.New("querier.shutdown-query-stats-push-timeout must be greater than 0")
+		}
 	}
 
 	return cfg.QuerySchedulerGRPCClientConfig.Validate()


### PR DESCRIPTION
On short-lived queriers (particularly burst queriers), the querier pod may not last long enough to send the loki_logql_querystats_bytes_processed_total metric twice. Because the metric is a counter, at least two values are needed for the metric to count as part of the rate. This change ensures that queriers will push at least one additional copy of the metric.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
