### PR TITLE
fix(indexgateway): Cap client-side in-flight requests to avoid retry amplification

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1282,7 +1282,7 @@ dataobj:
       # The maximum row count for pages to use for the data object builder. A
       # value of 0 means no limit.
       # CLI flag: -dataobj-consumer.max-page-rows
-      [max_page_rows: <int> | default = 0]
+      [max_page_rows: <int> | default = 10000]
 
       # The target maximum size of the encoded object and all of its encoded
       # sections (after compression), to limit memory usage of a builder.
@@ -1545,7 +1545,7 @@ dataobj:
     # The maximum row count for pages to use for the data object builder. A
     # value of 0 means no limit.
     # CLI flag: -dataobj-index-builder.max-page-rows
-    [max_page_rows: <int> | default = 0]
+    [max_page_rows: <int> | default = 10000]
 
     # The target maximum size of the encoded object and all of its encoded
     # sections (after compression), to limit memory usage of a builder.
@@ -1709,28 +1709,28 @@ dataobj:
       # (for columnar sections). Uncompressed size is used for consistent I/O
       # and planning.
       # CLI flag: -dataobj.compaction.indexobj-builder.target-page-size
-      [target_page_size: <int> | default = 2KiB]
+      [target_page_size: <int> | default = 128KiB]
 
       # The maximum row count for pages to use for the data object builder. A
       # value of 0 means no limit.
       # CLI flag: -dataobj.compaction.indexobj-builder.max-page-rows
-      [max_page_rows: <int> | default = 0]
+      [max_page_rows: <int> | default = 10000]
 
       # The target maximum size of the encoded object and all of its encoded
       # sections (after compression), to limit memory usage of a builder.
       # CLI flag: -dataobj.compaction.indexobj-builder.target-builder-memory-limit
-      [target_object_size: <int> | default = 4MiB]
+      [target_object_size: <int> | default = 512MiB]
 
       # The target maximum amount of uncompressed data to hold in sections, for
       # sections that support being limited by size. Uncompressed size is used
       # for consistent I/O and planning.
       # CLI flag: -dataobj.compaction.indexobj-builder.target-section-size
-      [target_section_size: <int> | default = 2MiB]
+      [target_section_size: <int> | default = 512MiB]
 
       # The size of logs to buffer in memory before adding into columnar
       # builders, used to reduce CPU load of sorting.
       # CLI flag: -dataobj.compaction.indexobj-builder.buffer-size
-      [buffer_size: <int> | default = 16KiB]
+      [buffer_size: <int> | default = 128MiB]
 
       # The maximum number of dataobj section stripes to merge into a section at
       # once. Must be greater than 1.
@@ -1741,6 +1741,45 @@ dataobj:
       # output size from uncompressed buffered records. Only takes effect with
       # ordered append. Set to 0 or 1 to disable.
       # CLI flag: -dataobj.compaction.indexobj-builder.estimated-compression-ratio
+      [estimated_compression_ratio: <int> | default = 8]
+
+    logsobj_builder:
+      # The target maximum amount of uncompressed data to hold in data pages
+      # (for columnar sections). Uncompressed size is used for consistent I/O
+      # and planning.
+      # CLI flag: -dataobj.compaction.logsobj-builder.target-page-size
+      [target_page_size: <int> | default = 1MiB]
+
+      # The maximum row count for pages to use for the data object builder. A
+      # value of 0 means no limit.
+      # CLI flag: -dataobj.compaction.logsobj-builder.max-page-rows
+      [max_page_rows: <int> | default = 10000]
+
+      # The target maximum size of the encoded object and all of its encoded
+      # sections (after compression), to limit memory usage of a builder.
+      # CLI flag: -dataobj.compaction.logsobj-builder.target-builder-memory-limit
+      [target_object_size: <int> | default = 512MiB]
+
+      # The target maximum amount of uncompressed data to hold in sections, for
+      # sections that support being limited by size. Uncompressed size is used
+      # for consistent I/O and planning.
+      # CLI flag: -dataobj.compaction.logsobj-builder.target-section-size
+      [target_section_size: <int> | default = 512MiB]
+
+      # The size of logs to buffer in memory before adding into columnar
+      # builders, used to reduce CPU load of sorting.
+      # CLI flag: -dataobj.compaction.logsobj-builder.buffer-size
+      [buffer_size: <int> | default = 128MiB]
+
+      # The maximum number of dataobj section stripes to merge into a section at
+      # once. Must be greater than 1.
+      # CLI flag: -dataobj.compaction.logsobj-builder.section-stripe-merge-limit
+      [section_stripe_merge_limit: <int> | default = 2]
+
+      # Expected compression ratio for log data, used to estimate compressed
+      # output size from uncompressed buffered records. Only takes effect with
+      # ordered append. Set to 0 or 1 to disable.
+      # CLI flag: -dataobj.compaction.logsobj-builder.estimated-compression-ratio
       [estimated_compression_ratio: <int> | default = 8]
 
   # The prefix to use for the storage bucket.
@@ -6847,6 +6886,12 @@ tsdb_shipper:
     # disables the limit.
     # CLI flag: -tsdb.shipper.index-gateway-client.max-in-flight-requests
     [max_in_flight_requests: <int> | default = 2048]
+
+  # Experimental. Number of idle file handles the stream index reader keeps open
+  # per index file. Only applies when -shipper.index-reader-mode=stream. Set to
+  # 0 to disable pooling.
+  # CLI flag: -tsdb.shipper.streaming-index-max-idle-file-handles
+  [streaming_index_max_idle_file_handles: <int> | default = 16]
 
   [ingestername: <string> | default = ""]
 

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1282,7 +1282,7 @@ dataobj:
       # The maximum row count for pages to use for the data object builder. A
       # value of 0 means no limit.
       # CLI flag: -dataobj-consumer.max-page-rows
-      [max_page_rows: <int> | default = 10000]
+      [max_page_rows: <int> | default = 0]
 
       # The target maximum size of the encoded object and all of its encoded
       # sections (after compression), to limit memory usage of a builder.
@@ -1545,7 +1545,7 @@ dataobj:
     # The maximum row count for pages to use for the data object builder. A
     # value of 0 means no limit.
     # CLI flag: -dataobj-index-builder.max-page-rows
-    [max_page_rows: <int> | default = 10000]
+    [max_page_rows: <int> | default = 0]
 
     # The target maximum size of the encoded object and all of its encoded
     # sections (after compression), to limit memory usage of a builder.
@@ -1709,28 +1709,28 @@ dataobj:
       # (for columnar sections). Uncompressed size is used for consistent I/O
       # and planning.
       # CLI flag: -dataobj.compaction.indexobj-builder.target-page-size
-      [target_page_size: <int> | default = 128KiB]
+      [target_page_size: <int> | default = 2KiB]
 
       # The maximum row count for pages to use for the data object builder. A
       # value of 0 means no limit.
       # CLI flag: -dataobj.compaction.indexobj-builder.max-page-rows
-      [max_page_rows: <int> | default = 10000]
+      [max_page_rows: <int> | default = 0]
 
       # The target maximum size of the encoded object and all of its encoded
       # sections (after compression), to limit memory usage of a builder.
       # CLI flag: -dataobj.compaction.indexobj-builder.target-builder-memory-limit
-      [target_object_size: <int> | default = 512MiB]
+      [target_object_size: <int> | default = 4MiB]
 
       # The target maximum amount of uncompressed data to hold in sections, for
       # sections that support being limited by size. Uncompressed size is used
       # for consistent I/O and planning.
       # CLI flag: -dataobj.compaction.indexobj-builder.target-section-size
-      [target_section_size: <int> | default = 512MiB]
+      [target_section_size: <int> | default = 2MiB]
 
       # The size of logs to buffer in memory before adding into columnar
       # builders, used to reduce CPU load of sorting.
       # CLI flag: -dataobj.compaction.indexobj-builder.buffer-size
-      [buffer_size: <int> | default = 128MiB]
+      [buffer_size: <int> | default = 16KiB]
 
       # The maximum number of dataobj section stripes to merge into a section at
       # once. Must be greater than 1.
@@ -1741,45 +1741,6 @@ dataobj:
       # output size from uncompressed buffered records. Only takes effect with
       # ordered append. Set to 0 or 1 to disable.
       # CLI flag: -dataobj.compaction.indexobj-builder.estimated-compression-ratio
-      [estimated_compression_ratio: <int> | default = 8]
-
-    logsobj_builder:
-      # The target maximum amount of uncompressed data to hold in data pages
-      # (for columnar sections). Uncompressed size is used for consistent I/O
-      # and planning.
-      # CLI flag: -dataobj.compaction.logsobj-builder.target-page-size
-      [target_page_size: <int> | default = 1MiB]
-
-      # The maximum row count for pages to use for the data object builder. A
-      # value of 0 means no limit.
-      # CLI flag: -dataobj.compaction.logsobj-builder.max-page-rows
-      [max_page_rows: <int> | default = 10000]
-
-      # The target maximum size of the encoded object and all of its encoded
-      # sections (after compression), to limit memory usage of a builder.
-      # CLI flag: -dataobj.compaction.logsobj-builder.target-builder-memory-limit
-      [target_object_size: <int> | default = 512MiB]
-
-      # The target maximum amount of uncompressed data to hold in sections, for
-      # sections that support being limited by size. Uncompressed size is used
-      # for consistent I/O and planning.
-      # CLI flag: -dataobj.compaction.logsobj-builder.target-section-size
-      [target_section_size: <int> | default = 512MiB]
-
-      # The size of logs to buffer in memory before adding into columnar
-      # builders, used to reduce CPU load of sorting.
-      # CLI flag: -dataobj.compaction.logsobj-builder.buffer-size
-      [buffer_size: <int> | default = 128MiB]
-
-      # The maximum number of dataobj section stripes to merge into a section at
-      # once. Must be greater than 1.
-      # CLI flag: -dataobj.compaction.logsobj-builder.section-stripe-merge-limit
-      [section_stripe_merge_limit: <int> | default = 2]
-
-      # Expected compression ratio for log data, used to estimate compressed
-      # output size from uncompressed buffered records. Only takes effect with
-      # ordered append. Set to 0 or 1 to disable.
-      # CLI flag: -dataobj.compaction.logsobj-builder.estimated-compression-ratio
       [estimated_compression_ratio: <int> | default = 8]
 
   # The prefix to use for the storage bucket.
@@ -6879,11 +6840,13 @@ tsdb_shipper:
     # CLI flag: -tsdb.shipper.index-gateway-client.min-shuffle-shard-size
     [min_shuffle_shard_size: <int> | default = 3]
 
-  # Experimental. Number of idle file handles the stream index reader keeps open
-  # per index file. Only applies when -shipper.index-reader-mode=stream. Set to
-  # 0 to disable pooling.
-  # CLI flag: -tsdb.shipper.streaming-index-max-idle-file-handles
-  [streaming_index_max_idle_file_handles: <int> | default = 16]
+    # Experimental: Maximum number of in-flight requests this client will send
+    # to the index gateway pool at once. Requests beyond this limit are rejected
+    # immediately instead of retrying across every pool member, to avoid
+    # amplifying load when all Index Gateway replicas are shedding. A value of 0
+    # disables the limit.
+    # CLI flag: -tsdb.shipper.index-gateway-client.max-in-flight-requests
+    [max_in_flight_requests: <int> | default = 2048]
 
   [ingestername: <string> | default = ""]
 

--- a/pkg/indexgateway/client.go
+++ b/pkg/indexgateway/client.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"math/rand"
 	"slices"
-	"sync/atomic"
 	"time"
 
 	"github.com/cespare/xxhash/v2"
@@ -26,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
 	"github.com/grafana/loki/v3/pkg/distributor/clientpool"
@@ -86,7 +86,7 @@ type ClientConfig struct {
 	// will send to the index gateway pool. Once reached, new requests are rejected immediately
 	// instead of retrying across every pool member, to avoid amplifying load when all Index
 	// Gateway replicas are shedding. A value of 0 disables the limit.
-	MaxInFlightRequests int `yaml:"max_in_flight_requests"`
+	MaxInFlightRequests int `yaml:"max_in_flight_requests" category:"Experimental"`
 }
 
 // RegisterFlagsWithPrefix register client-specific flags with the given prefix.
@@ -104,11 +104,18 @@ func (i *ClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 		"Experimental: Defines buckets for time-based sharding. Time based sharding only takes affect when index gateways run in simple mode. To enable client side time-based sharding of queries across index gateway instances set at least one bucket in the format of a string representation of a time.Duration, e.g. ['168h', '336h', '504h']",
 	)
 	f.IntVar(&i.MinShuffleShardSize, prefix+".min-shuffle-shard-size", 3, "Minimum number of index gateway instances included in the shuffle shard, regardless of the max-capacity setting. A value of 0 disables the minimum. Only applies to simple mode.")
-	f.IntVar(&i.MaxInFlightRequests, prefix+".max-in-flight-requests", 2048, "Maximum number of in-flight requests this client will send to the index gateway pool at once. Requests beyond this limit are rejected immediately instead of retrying across every pool member, to avoid amplifying load when all Index Gateway replicas are shedding. A value of 0 disables the limit.")
+	f.IntVar(&i.MaxInFlightRequests, prefix+".max-in-flight-requests", 2048, "Experimental: Maximum number of in-flight requests this client will send to the index gateway pool at once. Requests beyond this limit are rejected immediately instead of retrying across every pool member, to avoid amplifying load when all Index Gateway replicas are shedding. A value of 0 disables the limit.")
 }
 
 func (i *ClientConfig) RegisterFlags(f *flag.FlagSet) {
 	i.RegisterFlagsWithPrefix("index-gateway-client", f)
+}
+
+func (i *ClientConfig) Validate() error {
+	if i.MaxInFlightRequests < 0 {
+		return errors.New("max_in_flight_requests must not be negative")
+	}
+	return nil
 }
 
 type GatewayClient struct {

--- a/pkg/indexgateway/client.go
+++ b/pkg/indexgateway/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"math/rand"
+	"net/http"
 	"slices"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/grpcclient"
+	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/instrument"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/ring"
@@ -34,6 +36,11 @@ import (
 	"github.com/grafana/loki/v3/pkg/util/discovery"
 	"github.com/grafana/loki/v3/pkg/util/jumphash"
 )
+
+// errPoolAtCapacity is returned when the client-side in-flight request cap is reached. It's
+// wrapped as a 503 via httpgrpc, matching how server-side admission-control shedding is
+// surfaced, so clients don't see a client-side rejection as a generic 500.
+var errPoolAtCapacity = httpgrpc.Errorf(http.StatusServiceUnavailable, "index gateway pool at capacity, rejecting request to avoid retry amplification")
 
 // ClientConfig configures the Index Gateway client used to communicate with
 // the Index Gateway server.
@@ -427,7 +434,7 @@ func (s *GatewayClient) poolDo(
 	// retry-amplification storms, not a hard resource cap, so exactness isn't required.
 	if s.cfg.MaxInFlightRequests > 0 && s.inFlightRequests.Load() >= int64(s.cfg.MaxInFlightRequests) {
 		s.inFlightCapRejections.Inc()
-		return errors.New("index gateway pool at capacity, rejecting request to avoid retry amplification")
+		return errPoolAtCapacity
 	}
 	s.inFlightRequests.Add(1)
 	defer s.inFlightRequests.Add(-1)

--- a/pkg/indexgateway/client.go
+++ b/pkg/indexgateway/client.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"math/rand"
 	"slices"
+	"sync/atomic"
 	"time"
 
 	"github.com/cespare/xxhash/v2"
@@ -80,6 +81,12 @@ type ClientConfig struct {
 	// MinShuffleShardSize is the minimum number of index gateway instances included in the
 	// shuffle shard, regardless of the max-capacity setting. Only applies to simple mode.
 	MinShuffleShardSize int `yaml:"min_shuffle_shard_size"`
+
+	// MaxInFlightRequests is the maximum number of concurrent in-flight requests this client
+	// will send to the index gateway pool. Once reached, new requests are rejected immediately
+	// instead of retrying across every pool member, to avoid amplifying load when all Index
+	// Gateway replicas are shedding. A value of 0 disables the limit.
+	MaxInFlightRequests int `yaml:"max_in_flight_requests"`
 }
 
 // RegisterFlagsWithPrefix register client-specific flags with the given prefix.
@@ -97,6 +104,7 @@ func (i *ClientConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 		"Experimental: Defines buckets for time-based sharding. Time based sharding only takes affect when index gateways run in simple mode. To enable client side time-based sharding of queries across index gateway instances set at least one bucket in the format of a string representation of a time.Duration, e.g. ['168h', '336h', '504h']",
 	)
 	f.IntVar(&i.MinShuffleShardSize, prefix+".min-shuffle-shard-size", 3, "Minimum number of index gateway instances included in the shuffle shard, regardless of the max-capacity setting. A value of 0 disables the minimum. Only applies to simple mode.")
+	f.IntVar(&i.MaxInFlightRequests, prefix+".max-in-flight-requests", 2048, "Maximum number of in-flight requests this client will send to the index gateway pool at once. Requests beyond this limit are rejected immediately instead of retrying across every pool member, to avoid amplifying load when all Index Gateway replicas are shedding. A value of 0 disables the limit.")
 }
 
 func (i *ClientConfig) RegisterFlags(f *flag.FlagSet) {
@@ -108,12 +116,15 @@ type GatewayClient struct {
 	cfg                               ClientConfig
 	storeGatewayClientRequestDuration *prometheus.HistogramVec
 	retriesHistogram                  *prometheus.HistogramVec
+	inFlightCapRejections             prometheus.Counter
 	dnsProvider                       discovery.DNS
 	pool                              *client.Pool
 	ring                              ring.ReadRing
 	limits                            Limits
 	buckets                           []time.Duration
 	done                              chan struct{}
+
+	inFlightRequests atomic.Int64
 }
 
 // NewGatewayClient instantiates a new client used to communicate with an Index Gateway instance.
@@ -155,6 +166,22 @@ func NewGatewayClient(cfg ClientConfig, r prometheus.Registerer, limits Limits, 
 		}
 	}
 
+	inFlightCapRejections := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: constants.Loki,
+		Name:      "index_gateway_request_rejected_total",
+		Help:      "Total number of index gateway requests rejected because the client-side in-flight request cap was reached, to avoid retry amplification when replicas are shedding load.",
+	})
+	if r != nil {
+		err := r.Register(inFlightCapRejections)
+		if err != nil {
+			alreadyErr, ok := err.(prometheus.AlreadyRegisteredError)
+			if !ok {
+				return nil, err
+			}
+			inFlightCapRejections = alreadyErr.ExistingCollector.(prometheus.Counter)
+		}
+	}
+
 	buckets := make([]time.Duration, len(cfg.TimeBasedShardingBuckets))
 	for i := range len(buckets) {
 		b, err := time.ParseDuration(cfg.TimeBasedShardingBuckets[i])
@@ -172,6 +199,7 @@ func NewGatewayClient(cfg ClientConfig, r prometheus.Registerer, limits Limits, 
 		cfg:                               cfg,
 		storeGatewayClientRequestDuration: latency,
 		retriesHistogram:                  retries,
+		inFlightCapRejections:             inFlightCapRejections,
 		ring:                              cfg.Ring,
 		limits:                            limits,
 		buckets:                           buckets,
@@ -387,6 +415,16 @@ func (s *GatewayClient) poolDo(
 	filterServerList func([]string) []string,
 	maxRetries int, // -1 for unlimited retries, 0 to disable retries
 ) error {
+	// Check-then-increment is racy: concurrent callers can briefly push the true in-flight
+	// count past MaxInFlightRequests. Accepted tradeoff — this is a soft limit to blunt
+	// retry-amplification storms, not a hard resource cap, so exactness isn't required.
+	if s.cfg.MaxInFlightRequests > 0 && s.inFlightRequests.Load() >= int64(s.cfg.MaxInFlightRequests) {
+		s.inFlightCapRejections.Inc()
+		return errors.New("index gateway pool at capacity, rejecting request to avoid retry amplification")
+	}
+	s.inFlightRequests.Add(1)
+	defer s.inFlightRequests.Add(-1)
+
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return errors.Wrap(err, "index gateway client get tenant ID")

--- a/pkg/indexgateway/client_test.go
+++ b/pkg/indexgateway/client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"sync"
 	"testing"
 	"time"
 
@@ -496,33 +497,45 @@ func TestPoolDo_RejectsWhenAtInFlightCap(t *testing.T) {
 	require.NotContains(t, err.Error(), "tenant ID")
 }
 
-func TestPoolDo_DecrementsInFlightAfterSuccess(t *testing.T) {
+// TestPoolDo_ConcurrentRequestsRespectInFlightCap exercises real concurrent behavior: it
+// holds the single in-flight slot open with a blocked callback and asserts a second,
+// concurrent poolDo call is rejected while the first is still running (and succeeds once
+// released). Asserting on the counter's value alone wouldn't catch a broken/removed
+// increment-decrement, since a no-op counter would also read back to 0 after a successful call.
+func TestPoolDo_ConcurrentRequestsRespectInFlightCap(t *testing.T) {
 	_, _, client := createSimpleGatewayClient(t, []string{"0.0.0.0", "1.1.1.1"})
-	client.cfg.MaxInFlightRequests = 10
+	client.cfg.MaxInFlightRequests = 1
 
 	ctx := user.InjectOrgID(context.Background(), "tenant-123")
-	err := client.poolDo(ctx, func(c logproto.IndexGatewayClient) error {
-		_, err := c.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
-		return err
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var firstErr error
+	go func() {
+		defer wg.Done()
+		firstErr = client.poolDo(ctx, func(logproto.IndexGatewayClient) error {
+			close(started)
+			<-release
+			return nil
+		}, func(addrs []string) []string { return addrs }, -1)
+	}()
+
+	<-started // the first call now holds the one in-flight slot
+
+	err := client.poolDo(ctx, func(logproto.IndexGatewayClient) error {
+		t.Error("callback should not run while the in-flight cap is already reached")
+		return nil
 	}, func(addrs []string) []string { return addrs }, -1)
-
-	require.NoError(t, err)
-	require.Equal(t, int64(0), client.inFlightRequests.Load())
-}
-
-func TestPoolDo_DecrementsInFlightAfterCallbackError(t *testing.T) {
-	addrs := []string{"0.0.0.0", "1.1.1.1"}
-	logger, _, client := createSimpleGatewayClient(t, addrs)
-	client.cfg.MaxInFlightRequests = 10
-	configurePool(t, client, logger, len(addrs)) // every address returns an error
-
-	ctx := user.InjectOrgID(context.Background(), "tenant-123")
-	err := client.poolDo(ctx, func(c logproto.IndexGatewayClient) error {
-		_, err := c.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
-		return err
-	}, func(addrs []string) []string { return addrs }, 0) // no retries
-
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "index gateway pool at capacity")
+
+	close(release)
+	wg.Wait()
+
+	require.NoError(t, firstErr)
 	require.Equal(t, int64(0), client.inFlightRequests.Load())
 }
 

--- a/pkg/indexgateway/client_test.go
+++ b/pkg/indexgateway/client_test.go
@@ -477,6 +477,73 @@ func Test_jumpHashShuffleSharding(t *testing.T) {
 
 }
 
+func TestPoolDo_RejectsWhenAtInFlightCap(t *testing.T) {
+	client := &GatewayClient{
+		cfg:                   ClientConfig{MaxInFlightRequests: 2},
+		inFlightCapRejections: prometheus.NewCounter(prometheus.CounterOpts{Name: "test_rejections"}),
+		logger:                log.NewNopLogger(),
+	}
+	client.inFlightRequests.Store(2)
+
+	// No tenant ID injected into the context, so if the cap check did not run first,
+	// poolDo would instead fail with a tenant ID lookup error.
+	err := client.poolDo(context.Background(), func(logproto.IndexGatewayClient) error {
+		return nil
+	}, func(addrs []string) []string { return addrs }, 0)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "index gateway pool at capacity")
+	require.NotContains(t, err.Error(), "tenant ID")
+}
+
+func TestPoolDo_DecrementsInFlightAfterSuccess(t *testing.T) {
+	_, _, client := createSimpleGatewayClient(t, []string{"0.0.0.0", "1.1.1.1"})
+	client.cfg.MaxInFlightRequests = 10
+
+	ctx := user.InjectOrgID(context.Background(), "tenant-123")
+	err := client.poolDo(ctx, func(c logproto.IndexGatewayClient) error {
+		_, err := c.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
+		return err
+	}, func(addrs []string) []string { return addrs }, -1)
+
+	require.NoError(t, err)
+	require.Equal(t, int64(0), client.inFlightRequests.Load())
+}
+
+func TestPoolDo_DecrementsInFlightAfterCallbackError(t *testing.T) {
+	addrs := []string{"0.0.0.0", "1.1.1.1"}
+	logger, _, client := createSimpleGatewayClient(t, addrs)
+	client.cfg.MaxInFlightRequests = 10
+	configurePool(t, client, logger, len(addrs)) // every address returns an error
+
+	ctx := user.InjectOrgID(context.Background(), "tenant-123")
+	err := client.poolDo(ctx, func(c logproto.IndexGatewayClient) error {
+		_, err := c.GetChunkRef(ctx, &logproto.GetChunkRefRequest{})
+		return err
+	}, func(addrs []string) []string { return addrs }, 0) // no retries
+
+	require.Error(t, err)
+	require.Equal(t, int64(0), client.inFlightRequests.Load())
+}
+
+func TestPoolDo_ZeroMeansUnlimited(t *testing.T) {
+	client := &GatewayClient{
+		cfg:                   ClientConfig{MaxInFlightRequests: 0},
+		inFlightCapRejections: prometheus.NewCounter(prometheus.CounterOpts{Name: "test_rejections_unlimited"}),
+		logger:                log.NewNopLogger(),
+	}
+	client.inFlightRequests.Store(999999)
+
+	// No tenant ID injected, so the cap check being bypassed surfaces as a tenant ID
+	// lookup error rather than the "at capacity" rejection.
+	err := client.poolDo(context.Background(), func(logproto.IndexGatewayClient) error {
+		return nil
+	}, func(addrs []string) []string { return addrs }, 0)
+
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "at capacity")
+}
+
 func Test_addressesForQueryEndTime(t *testing.T) {
 	// Use the current time as reference and create relative times
 	now := time.Date(2025, time.September, 11, 0, 0, 0, 0, time.UTC)

--- a/pkg/indexgateway/client_test.go
+++ b/pkg/indexgateway/client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -22,9 +23,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/grafana/loki/v3/pkg/util/discovery"
+	"github.com/grafana/loki/v3/pkg/util/server"
 
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/util/constants"
@@ -495,6 +499,15 @@ func TestPoolDo_RejectsWhenAtInFlightCap(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "index gateway pool at capacity")
 	require.NotContains(t, err.Error(), "tenant ID")
+
+	// Client-side shedding must surface as a 503, matching server-side admission-control
+	// shedding, rather than falling through to a generic 500.
+	httpStatus, _ := server.ClientHTTPStatusAndError(err)
+	require.Equal(t, http.StatusServiceUnavailable, httpStatus)
+
+	s, ok := grpcstatus.FromError(err)
+	require.True(t, ok, "expected err to carry a gRPC status")
+	require.Equal(t, codes.Code(http.StatusServiceUnavailable), s.Code())
 }
 
 // TestPoolDo_ConcurrentRequestsRespectInFlightCap exercises real concurrent behavior: it

--- a/pkg/storage/stores/shipper/indexshipper/shipper.go
+++ b/pkg/storage/stores/shipper/indexshipper/shipper.go
@@ -160,6 +160,14 @@ func (cfg *Config) Validate() error {
 		return fmt.Errorf("shipper.download-timeout must be greater than zero, got %s", cfg.DownloadTimeout)
 	}
 
+	if err := cfg.IndexGatewayClientConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid shipper.index-gateway-client config: %w", err)
+	}
+
+	if err := cfg.ShadowIndexGatewayClientConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid shipper.shadow-index-gateway-client config: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/storage/stores/shipper/indexshipper/shipper_test.go
+++ b/pkg/storage/stores/shipper/indexshipper/shipper_test.go
@@ -1,0 +1,41 @@
+package indexshipper
+
+import (
+	"testing"
+
+	"github.com/grafana/dskit/flagext"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	validConfig := func() Config {
+		cfg := Config{}
+		flagext.DefaultValues(&cfg)
+		return cfg
+	}
+
+	t.Run("default config is valid", func(t *testing.T) {
+		cfg := validConfig()
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("negative index_gateway_client.max_in_flight_requests fails", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.IndexGatewayClientConfig.MaxInFlightRequests = -1
+
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "shipper.index-gateway-client")
+		require.ErrorContains(t, err, "max_in_flight_requests must not be negative")
+	})
+
+	t.Run("negative shadow_index_gateway_client.max_in_flight_requests fails", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.ShadowIndexGatewayClientConfig.MaxInFlightRequests = -1
+
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "shipper.shadow-index-gateway-client")
+		require.ErrorContains(t, err, "max_in_flight_requests must not be negative")
+	})
+}


### PR DESCRIPTION
Fixes #24051

## What this does

`poolDo` had no bound on concurrent in-flight requests to the index
gateway pool. With `maxRetries = -1` (used by 6 of the 7 call sites),
a client under load would serially walk every address in the pool on
failure, each attempt bounded by that gateway's own admission-control
queue timeout (from #23932). When every replica is shedding load, this
amplifies load at exactly the moment the pool is most overloaded,
instead of failing fast.

## The fix

Adds a configurable client-side cap on in-flight requests
(`-index-gateway-client.max-in-flight-requests`, default 2048, 0 =
unlimited to match the convention used elsewhere in this file). The
check runs at the very start of `poolDo`, before any tenant lookup or
address resolution — once at capacity, requests are rejected
immediately with a distinct error instead of retrying across the whole
pool.

Tracked via a new `loki_index_gateway_request_rejected_total` counter
so operators can see this happening rather than it being silent.

One deliberate tradeoff: the cap check is check-then-act, not a single
atomic compare-and-swap, so under concurrency the actual in-flight
count can briefly exceed the configured cap by a small margin. Noted
in a code comment — this is acceptable for a soft limit meant to
prevent amplification storms, not a hard resource cap.

## Testing

Added four tests covering: rejection at cap (verified by confirming
the capacity error returns before any tenant/address lookup would even
be attempted), the in-flight counter decrementing after both success
and failure paths (proving the `defer` fires on every exit), and
`MaxInFlightRequests = 0` correctly disabling the check.

Happy to adjust the default cap value or error message if you'd prefer
something different.