### PR TITLE
chore: Use sort-schema as the primary sort-order for dataobj

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/facette/natsort"
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/prometheus/client_golang/prometheus"
@@ -28,7 +27,6 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/metastore/multitenancy"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
-	"github.com/grafana/loki/v3/pkg/dataobj/sortmerge"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
 	"github.com/grafana/loki/v3/pkg/scratch"
@@ -38,12 +36,6 @@ import (
 // data to flush.
 var (
 	ErrBuilderEmpty = errors.New("builder empty")
-)
-
-const (
-	// Constants for the sort order configuration
-	sortStreamASC     = "stream-asc"
-	sortTimestampDESC = "timestamp-desc"
 )
 
 // BuilderBaseConfig configures a data object builder.
@@ -135,19 +127,14 @@ func (cfg *BuilderBaseConfig) Validate() error {
 type BuilderConfig struct {
 	BuilderBaseConfig `yaml:",inline"`
 
-	// DataobjSortOrder defines the order in which the rows of the logs sections are sorted.
-	// They can either be sorted by [streamID ASC, timestamp DESC] or [timestamp DESC, streamID ASC].
-	DataobjSortOrder string `yaml:"dataobj_sort_order" doc:"hidden"`
-
 	// AppendOrderedEnabled controls whether the builder uses the AppendOrdered
 	// strategy, which skips intermediate stripe sorting and merging for data
 	// that is already in sort order. When false, the classic
 	// AppendUnordered strategy is used.
+	//
+	// SortSchemaASC does not yet support AppendUnordered (stripe merging cannot
+	// use schema ordering), so the builder currently forces AppendOrdered.
 	AppendOrderedEnabled bool `yaml:"append_ordered_enabled" doc:"hidden"`
-
-	// DataobjSortSchemaEnabled controls whether the per-tenant sort_schema tenant config is used
-	// to determine sort order instead of DataobjSortOrder.
-	DataobjUseSortSchema bool `yaml:"dataobj_use_sort_schema" doc:"hidden"`
 }
 
 // RegisterFlagsWithPrefix registers flags with the given prefix.
@@ -159,45 +146,12 @@ func (cfg *BuilderConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet
 	_ = cfg.TargetSectionSize.Set("128MB")
 	cfg.BuilderBaseConfig.RegisterFlagsWithPrefix(prefix, f)
 
-	f.StringVar(&cfg.DataobjSortOrder, prefix+"dataobj-sort-order", sortStreamASC, "The desired sort order of the logs section. Can either be `stream-asc` (order by streamID ascending and timestamp descending) or `timestamp-desc` (order by timestamp descending and streamID ascending).")
 	f.BoolVar(&cfg.AppendOrderedEnabled, prefix+"append-ordered-enabled", true, "Skips intermediate stripe sorting and merging. Expects data to be sorted before appending.")
-	f.BoolVar(&cfg.DataobjUseSortSchema, prefix+"dataobj-use-sort-schema", false, "Experimental: When enabled, use the per-tenant sort_schema tenant config to determine sort order of data objects. dataobj-sort-order is used as fallback sort order if schema labels are empty for a tenant.")
 }
 
 // Validate validates the BuilderConfig.
 func (cfg *BuilderConfig) Validate() error {
-	var errs []error
-
-	if err := cfg.BuilderBaseConfig.Validate(); err != nil {
-		errs = append(errs, err)
-	}
-
-	if cfg.DataobjSortOrder == "" {
-		cfg.DataobjSortOrder = sortStreamASC // default to [streamID ASC, timestamp DESC] sorting
-	}
-
-	if cfg.DataobjSortOrder != sortStreamASC && cfg.DataobjSortOrder != sortTimestampDESC {
-		errs = append(errs, fmt.Errorf("invalid dataobj sort order. must be one of `stream-asc` or `timestamp-desc`, got: %s", cfg.DataobjSortOrder))
-	}
-
-	return errors.Join(errs...)
-}
-
-var sortOrderMapping = map[string]logs.SortOrder{
-	sortStreamASC:     logs.SortStreamASC,
-	sortTimestampDESC: logs.SortTimestampDESC,
-}
-
-func parseSortOrder(s string) logs.SortOrder {
-	val := sortOrderMapping[s]
-	return val
-}
-
-func appendStrategy(ordered bool) logs.AppendStrategy {
-	if ordered {
-		return logs.AppendOrdered
-	}
-	return logs.AppendUnordered
+	return cfg.BuilderBaseConfig.Validate()
 }
 
 // TenantOverrides provides per-tenant configuration for the Builder.
@@ -271,41 +225,18 @@ func (b *Builder) buildersFor(tenant string) (*streams.Builder, *logs.Builder) {
 		b.streams[tenant] = sb
 	}
 	if _, ok := b.logs[tenant]; !ok {
-		var schemaLabels []string
-		sortOrder := parseSortOrder(b.cfg.DataobjSortOrder)
-		appendStrategy := appendStrategy(b.cfg.AppendOrderedEnabled)
-
-		if b.cfg.DataobjUseSortSchema {
-			if b.overrides != nil {
-				schemaLabels = b.overrides.SortSchemaLabels(tenant)
-			}
-
-			if len(schemaLabels) == 0 {
-				level.Warn(b.logger).Log("msg", "sort schema labels not configured, falling back to dataobj_sort_order", "tenant", tenant, "dataobj_sort_order", b.cfg.DataobjSortOrder)
-			} else {
-				schemaLabelsStr := strings.Join(schemaLabels, ",")
-				level.Info(b.logger).Log("msg", "sort schema configured, dataobj-sort-order value will be ignored.", "tenant", tenant, "schema_labels", schemaLabelsStr)
-
-				sortOrder = logs.SortSchemaASC
-
-				// TODO(ashwanth): SortSchemaASC does not support AppendUnordered
-				// It cannot merge stripes with schema ordering. This is
-				// good to have as sorting stripes can help lower peak
-				// memory usage compared to sorting entire section at once.
-				// Force to always use AppendOrdered temporarily.
-				appendStrategy = logs.AppendOrdered
-			}
-		}
-
+		// TODO(ashwanth): SortSchemaASC does not support AppendUnordered.
+		// It cannot merge stripes with schema ordering. Force AppendOrdered
+		// until stripe merging can use schema keys.
 		lb := logs.NewBuilder(b.metrics.logs, logs.BuilderOptions{
 			PageSizeHint:              int(b.cfg.TargetPageSize),
 			PageMaxRowCount:           b.cfg.MaxPageRows,
 			BufferSize:                int(b.cfg.BufferSize),
 			StripeMergeLimit:          b.cfg.SectionStripeMergeLimit,
-			AppendStrategy:            appendStrategy,
+			AppendStrategy:            logs.AppendOrdered,
 			EstimatedCompressionRatio: b.cfg.EstimatedCompressionRatio,
-			SortOrder:                 sortOrder,
-			SchemaLabels:              schemaLabels,
+			SortOrder:                 logs.SortSchemaASC,
+			SchemaLabels:              b.schemaLabelsFor(tenant),
 		})
 		lb.SetTenant(tenant)
 		b.logs[tenant] = lb
@@ -327,18 +258,21 @@ func (b *Builder) IsFull() bool {
 }
 
 func (b *Builder) getSortKey(tenant string, ls labels.Labels) (string, error) {
-	var sortKey string
-	if b.cfg.DataobjUseSortSchema && b.overrides != nil {
-		schemaLabels := b.overrides.SortSchemaLabels(tenant)
-		if len(schemaLabels) > 0 {
-			var err error
-			sortKey, err = ComputeSortKey(ls, schemaLabels)
-			if err != nil {
-				return "", fmt.Errorf("compute sort key for tenant %s: %w", tenant, err)
-			}
-		}
+	sortKey, err := ComputeSortKey(ls, b.schemaLabelsFor(tenant))
+	if err != nil {
+		return "", fmt.Errorf("compute sort key for tenant %s: %w", tenant, err)
 	}
 	return sortKey, nil
+}
+
+// schemaLabelsFor returns the tenant sort schema from overrides.
+// Defaults come from limits flags/YAML via Overrides.SortSchemaLabels;
+// a nil overrides yields an empty schema.
+func (b *Builder) schemaLabelsFor(tenant string) []string {
+	if b.overrides == nil {
+		return nil
+	}
+	return b.overrides.SortSchemaLabels(tenant)
 }
 
 // Append buffers a stream to be written to a data object.
@@ -565,22 +499,7 @@ func (b *Builder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataob
 
 		// TODO(chaudum): Handle special case len(sections) == 1
 
-		var (
-			sortOrder    logs.SortOrder
-			schemaLabels []string
-			iter         result.Seq[logs.Record]
-			iterErr      error
-		)
-
-		if b.cfg.DataobjUseSortSchema {
-			if b.overrides != nil {
-				schemaLabels = b.overrides.SortSchemaLabels(tenant)
-			}
-
-			if len(schemaLabels) == 0 {
-				level.Warn(b.logger).Log("msg", "sort schema labels not configured, falling back to dataobj_sort_order", "tenant", tenant, "dataobj_sort_order", b.cfg.DataobjSortOrder)
-			}
-		}
+		schemaLabels := b.schemaLabelsFor(tenant)
 
 		var streamSections []*dataobj.Section
 		for _, sec := range obj.Sections().Filter(func(s *dataobj.Section) bool {
@@ -599,26 +518,16 @@ func (b *Builder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataob
 			return nil, nil, fmt.Errorf("opening streams section for tenant %s: %w", tenant, err)
 		}
 
-		if len(schemaLabels) > 0 {
-			streamIter, streamRemap, err := sortAndRemapStreams(streamsSectionIter(ctx, streamsSection), tenant, schemaLabels, streamsSection.NumRows())
-			if err != nil {
-				return nil, nil, fmt.Errorf("building stream ID remap for tenant %s: %w", tenant, err)
-			}
-
-			if err := b.buildStreamSection(ctx, tenant, streamIter, sb); err != nil {
-				return nil, nil, err
-			}
-
-			sortOrder = logs.SortSchemaASC
-			iter, iterErr = sortedSchemaIter(ctx, sections, streamRemap.sortKeys, streamRemap.ids)
-		} else {
-			if err := b.buildStreamSection(ctx, tenant, streamsSectionIter(ctx, streamsSection), sb); err != nil {
-				return nil, nil, err
-			}
-
-			sortOrder = parseSortOrder(b.cfg.DataobjSortOrder)
-			iter, iterErr = sortmerge.Iterator(ctx, sections, sortOrder)
+		streamIter, streamRemap, err := sortAndRemapStreams(streamsSectionIter(ctx, streamsSection), tenant, schemaLabels, streamsSection.NumRows())
+		if err != nil {
+			return nil, nil, fmt.Errorf("building stream ID remap for tenant %s: %w", tenant, err)
 		}
+
+		if err := b.buildStreamSection(ctx, tenant, streamIter, sb); err != nil {
+			return nil, nil, err
+		}
+
+		iter, iterErr := sortedSchemaIter(ctx, sections, streamRemap.sortKeys, streamRemap.ids)
 		if iterErr != nil {
 			return nil, nil, fmt.Errorf("creating sort iterator: %w", iterErr)
 		}
@@ -629,7 +538,7 @@ func (b *Builder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataob
 			BufferSize:       int(b.cfg.BufferSize),
 			StripeMergeLimit: b.cfg.SectionStripeMergeLimit,
 			AppendStrategy:   logs.AppendOrdered,
-			SortOrder:        sortOrder,
+			SortOrder:        logs.SortSchemaASC,
 			SchemaLabels:     schemaLabels,
 		})
 		lb.SetTenant(tenant)

--- a/pkg/dataobj/consumer/logsobj/builder_e2e_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_e2e_test.go
@@ -95,67 +95,46 @@ func TestBuilder_EndToEnd(t *testing.T) {
 		}
 	}
 
-	for _, tc := range []struct {
-		name          string
-		sortOrder     string
-		useSortSchema bool
-	}{
-		{name: "SortOrderStreamASC", sortOrder: sortStreamASC},
-		{name: "SortOrderTimestampDESC", sortOrder: sortTimestampDESC},
-		{name: "UseSchemaSort", sortOrder: sortStreamASC, useSortSchema: true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := baseCfg
-			cfg.DataobjSortOrder = tc.sortOrder
-			cfg.DataobjUseSortSchema = tc.useSortSchema
+	overrides := makeOverrides()
 
-			overrides := makeOverrides()
-			var expectedSchemaLabels []string
-			if tc.useSortSchema {
-				expectedSchemaLabels = schemaLabels
-			}
+	b, err := NewBuilder(baseCfg, nil, NewBuilderMetrics(), log.NewNopLogger(), overrides)
+	require.NoError(t, err)
+	appendDataset(t, b)
 
-			b, err := NewBuilder(cfg, nil, NewBuilderMetrics(), log.NewNopLogger(), overrides)
-			require.NoError(t, err)
-			appendDataset(t, b)
+	obj1, closer, err := b.Flush()
+	require.NoError(t, err)
+	defer closer.Close()
 
-			obj1, closer, err := b.Flush()
-			require.NoError(t, err)
-			defer closer.Close()
+	intermediateByTenant := make(map[string][]builderE2EResolvedRecord, len(tenants))
+	for _, tenant := range tenants {
+		require.Equal(t, 1, countTenantSections(obj1, tenant, streams.CheckSection))
+		require.Greater(t, countTenantSections(obj1, tenant, logs.CheckSection), 1)
 
-			intermediateByTenant := make(map[string][]builderE2EResolvedRecord, len(tenants))
-			for _, tenant := range tenants {
-				require.Equal(t, 1, countTenantSections(obj1, tenant, streams.CheckSection))
-				require.Greater(t, countTenantSections(obj1, tenant, logs.CheckSection), 1)
+		assertBuilderE2ESchemaLabels(t, obj1, tenant, schemaLabels)
 
-				assertBuilderE2ESchemaLabels(t, obj1, tenant, expectedSchemaLabels)
+		for _, sec := range obj1.Sections().Filter(func(s *dataobj.Section) bool {
+			return logs.CheckSection(s) && s.Tenant == tenant
+		}) {
+			assertBuilderE2EOrdered(t, resolveTenantLogsSection(t, obj1, tenant, sec), schemaLabels)
+		}
+		intermediateByTenant[tenant] = resolveTenantLogs(t, obj1, tenant)
+	}
 
-				for _, sec := range obj1.Sections().Filter(func(s *dataobj.Section) bool {
-					return logs.CheckSection(s) && s.Tenant == tenant
-				}) {
-					// logs are ordered within each section.
-					assertBuilderE2EOrdered(t, resolveTenantLogsSection(t, obj1, tenant, sec), tc.sortOrder, expectedSchemaLabels)
-				}
-				intermediateByTenant[tenant] = resolveTenantLogs(t, obj1, tenant)
-			}
+	mergeBuilder, err := NewBuilder(baseCfg, nil, NewBuilderMetrics(), log.NewNopLogger(), overrides)
+	require.NoError(t, err)
+	obj2, closer2, err := mergeBuilder.CopyAndSort(t.Context(), obj1)
+	require.NoError(t, err)
+	defer closer2.Close()
 
-			mergeBuilder, err := NewBuilder(cfg, nil, NewBuilderMetrics(), log.NewNopLogger(), overrides)
-			require.NoError(t, err)
-			obj2, closer2, err := mergeBuilder.CopyAndSort(t.Context(), obj1)
-			require.NoError(t, err)
-			defer closer2.Close()
+	require.ElementsMatch(t, obj1.Tenants(), obj2.Tenants())
+	for _, tenant := range tenants {
+		require.Equal(t, 1, countTenantSections(obj2, tenant, streams.CheckSection))
+		require.Greater(t, countTenantSections(obj2, tenant, logs.CheckSection), 1)
+		assertBuilderE2ESchemaLabels(t, obj2, tenant, schemaLabels)
 
-			require.ElementsMatch(t, obj1.Tenants(), obj2.Tenants())
-			for _, tenant := range tenants {
-				require.Equal(t, 1, countTenantSections(obj2, tenant, streams.CheckSection))
-				require.Greater(t, countTenantSections(obj2, tenant, logs.CheckSection), 1)
-				assertBuilderE2ESchemaLabels(t, obj2, tenant, expectedSchemaLabels)
-
-				got := resolveTenantLogs(t, obj2, tenant)
-				assertBuilderE2ESameContent(t, intermediateByTenant[tenant], got)
-				assertBuilderE2EOrdered(t, got, tc.sortOrder, expectedSchemaLabels)
-			}
-		})
+		got := resolveTenantLogs(t, obj2, tenant)
+		assertBuilderE2ESameContent(t, intermediateByTenant[tenant], got)
+		assertBuilderE2EOrdered(t, got, schemaLabels)
 	}
 }
 
@@ -248,46 +227,30 @@ func contentCounts(records []builderE2EResolvedRecord) map[string]int {
 	return counts
 }
 
-func assertBuilderE2EOrdered(t *testing.T, records []builderE2EResolvedRecord, sortOrder string, schemaLabels []string) {
+func assertBuilderE2EOrdered(t *testing.T, records []builderE2EResolvedRecord, schemaLabels []string) {
 	t.Helper()
 	for i := 1; i < len(records); i++ {
-		require.LessOrEqualf(t, compareRecords(t, records[i-1], records[i], sortOrder, schemaLabels), 0,
+		require.LessOrEqualf(t, compareRecords(t, records[i-1], records[i], schemaLabels), 0,
 			"records out of order at index %d: %+v then %+v", i, records[i-1], records[i])
 	}
 }
 
-func compareRecords(t *testing.T, a, b builderE2EResolvedRecord, sortOrder string, schemaLabels []string) int {
+func compareRecords(t *testing.T, a, b builderE2EResolvedRecord, schemaLabels []string) int {
 	t.Helper()
 
-	if len(schemaLabels) > 0 {
-		aKey, err := ComputeSortKey(a.labels, schemaLabels)
-		require.NoError(t, err)
+	aKey, err := ComputeSortKey(a.labels, schemaLabels)
+	require.NoError(t, err)
 
-		bKey, err := ComputeSortKey(b.labels, schemaLabels)
-		require.NoError(t, err)
+	bKey, err := ComputeSortKey(b.labels, schemaLabels)
+	require.NoError(t, err)
 
-		if res := cmp.Compare(aKey, bKey); res != 0 {
-			return res
-		}
-		if res := cmp.Compare(a.streamID, b.streamID); res != 0 {
-			return res
-		}
-		return cmp.Compare(b.ts, a.ts)
-	} else if sortOrder == sortStreamASC {
-
-		if res := cmp.Compare(a.streamID, b.streamID); res != 0 {
-			return res
-		}
-		return cmp.Compare(b.ts, a.ts)
-	} else if sortOrder == sortTimestampDESC {
-		if res := cmp.Compare(b.ts, a.ts); res != 0 {
-			return res
-		}
-		return cmp.Compare(a.streamID, b.streamID)
+	if res := cmp.Compare(aKey, bKey); res != 0 {
+		return res
 	}
-
-	t.Fatalf("unknown sort order: %q", sortOrder)
-	return 0
+	if res := cmp.Compare(a.streamID, b.streamID); res != 0 {
+		return res
+	}
+	return cmp.Compare(b.ts, a.ts)
 }
 
 func countTenantSections(obj *dataobj.Object, tenant string, check func(*dataobj.Section) bool) int {

--- a/pkg/dataobj/consumer/logsobj/builder_test.go
+++ b/pkg/dataobj/consumer/logsobj/builder_test.go
@@ -3,6 +3,7 @@ package logsobj
 import (
 	"bytes"
 	"context"
+	"flag"
 	"fmt"
 	"math"
 	"math/rand"
@@ -22,6 +23,7 @@ import (
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 	"github.com/grafana/loki/v3/pkg/logproto"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/grafana/loki/v3/pkg/validation"
 )
 
 var testBuilderConfig = BuilderConfig{
@@ -32,7 +34,6 @@ var testBuilderConfig = BuilderConfig{
 		BufferSize:              2048 * 8,
 		SectionStripeMergeLimit: 2,
 	},
-	DataobjSortOrder: sortTimestampDESC,
 }
 
 func TestBuilder(t *testing.T) {
@@ -360,10 +361,10 @@ func BenchmarkBuilder_CopyAndSort(b *testing.B) {
 		labels    func(tenant string, i int) string
 	}{
 		{
-			name: "default",
+			name: "default_sort_schema",
 			cfg: BuilderConfig{
-				BuilderBaseConfig: benchBaseCfg,
-				DataobjSortOrder:  sortTimestampDESC,
+				BuilderBaseConfig:    benchBaseCfg,
+				AppendOrderedEnabled: true,
 			},
 			labels: func(_ string, i int) string {
 				app := apps[i%len(apps)]
@@ -372,11 +373,9 @@ func BenchmarkBuilder_CopyAndSort(b *testing.B) {
 			},
 		},
 		{
-			name: "sort_schema",
+			name: "custom_sort_schema",
 			cfg: BuilderConfig{
 				BuilderBaseConfig:    benchBaseCfg,
-				DataobjSortOrder:     sortStreamASC,
-				DataobjUseSortSchema: true,
 				AppendOrderedEnabled: true,
 			},
 			overrides: tenantOverrides{
@@ -435,10 +434,17 @@ type tenantOverrides map[string][]string
 
 func (m tenantOverrides) SortSchemaLabels(tenant string) []string { return m[tenant] }
 
+// limitsByTenant implements validation.TenantLimits for builder tests that
+// need the real Overrides defaulting path.
+type limitsByTenant map[string]*validation.Limits
+
+func (m limitsByTenant) TenantLimits(userID string) *validation.Limits { return m[userID] }
+func (m limitsByTenant) AllByUserID() map[string]*validation.Limits    { return m }
+
 func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 	now := time.Date(2025, time.September, 17, 0, 0, 0, 0, time.UTC)
 
-	makeCfg := func(useSortSchema bool) BuilderConfig {
+	makeCfg := func() BuilderConfig {
 		return BuilderConfig{
 			BuilderBaseConfig: BuilderBaseConfig{
 				TargetPageSize:          2048,
@@ -447,8 +453,6 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 				BufferSize:              2048 * 8,
 				SectionStripeMergeLimit: 2,
 			},
-			DataobjSortOrder:     sortTimestampDESC,
-			DataobjUseSortSchema: useSortSchema,
 		}
 	}
 
@@ -546,22 +550,28 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 		}
 	}
 
-	t.Run("schema tenant sorted by label, plain tenant by DataobjSortOrder", func(t *testing.T) {
-		cfg := makeCfg(true)
-		overrides := tenantOverrides{"schema-tenant": {"label:app"}}
+	t.Run("custom schema tenant sorted by app, default schema tenant by service_name", func(t *testing.T) {
+		cfg := makeCfg()
+		var defaults validation.Limits
+		defaults.RegisterFlags(flag.NewFlagSet("test", flag.PanicOnError))
+		overrides, err := validation.NewOverrides(defaults, limitsByTenant{
+			"schema-tenant": {SortSchema: validation.SortSchema{"label:app"}},
+		})
+		require.NoError(t, err)
 
 		b, err := NewBuilder(cfg, nil, NewBuilderMetrics(), log.NewNopLogger(), overrides)
 		require.NoError(t, err)
-		for _, app := range []string{"zoo", "alpha", "middle"} {
+		for _, name := range []string{"zoo", "alpha", "middle"} {
 			for i := range 4 {
+				ts := now.Add(time.Duration(i) * time.Second)
 				require.NoError(t, b.Append("schema-tenant", logproto.Stream{
-					Labels:  fmt.Sprintf(`{app=%q}`, app),
-					Entries: []push.Entry{{Timestamp: now.Add(time.Duration(i) * time.Second), Line: app}},
-				}, now.Add(time.Duration(i)*time.Second)))
-				require.NoError(t, b.Append("plain-tenant", logproto.Stream{
-					Labels:  fmt.Sprintf(`{app=%q}`, app),
-					Entries: []push.Entry{{Timestamp: now.Add(time.Duration(i) * time.Second), Line: app}},
-				}, now.Add(time.Duration(i)*time.Second)))
+					Labels:  fmt.Sprintf(`{app=%q}`, name),
+					Entries: []push.Entry{{Timestamp: ts, Line: name}},
+				}, ts))
+				require.NoError(t, b.Append("default-tenant", logproto.Stream{
+					Labels:  fmt.Sprintf(`{service_name=%q}`, name),
+					Entries: []push.Entry{{Timestamp: ts, Line: name}},
+				}, ts))
 			}
 		}
 		obj1, closer1, err := b.Flush()
@@ -573,24 +583,40 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 		require.Equal(t, []string{"alpha", "middle", "zoo"}, appOrder(t, obj2, "schema-tenant"))
 		timestampsDescWithinGroups(t, obj2, "schema-tenant")
 
-		var allTS []time.Time
+		// default-tenant has no per-tenant override, so Overrides.SortSchemaLabels
+		// returns the limits default (label:service_name).
+		streamToSvc := make(map[int64]string)
 		for _, sec := range obj2.Sections().Filter(func(s *dataobj.Section) bool {
-			return logs.CheckSection(s) && s.Tenant == "plain-tenant"
+			return streams.CheckSection(s) && s.Tenant == "default-tenant"
+		}) {
+			streamSec, err := streams.Open(t.Context(), sec)
+			require.NoError(t, err)
+			for res := range streams.IterSection(t.Context(), streamSec) {
+				val, err := res.Value()
+				require.NoError(t, err)
+				streamToSvc[val.ID] = val.Labels.Get("service_name")
+			}
+		}
+		seen := make(map[string]bool)
+		var svcOrder []string
+		for _, sec := range obj2.Sections().Filter(func(s *dataobj.Section) bool {
+			return logs.CheckSection(s) && s.Tenant == "default-tenant"
 		}) {
 			for res := range iterLogsSection(t, sec) {
 				val, err := res.Value()
 				require.NoError(t, err)
-				allTS = append(allTS, val.Timestamp)
+				svc := streamToSvc[val.StreamID]
+				if !seen[svc] {
+					seen[svc] = true
+					svcOrder = append(svcOrder, svc)
+				}
 			}
 		}
-		for i := 1; i < len(allTS); i++ {
-			require.LessOrEqual(t, allTS[i].UnixNano(), allTS[i-1].UnixNano(),
-				"plain-tenant must be timestamp DESC at index %d", i)
-		}
+		require.Equal(t, []string{"alpha", "middle", "zoo"}, svcOrder)
 	})
 
 	t.Run("schema labels persisted in section metadata", func(t *testing.T) {
-		cfg := makeCfg(true)
+		cfg := makeCfg()
 		overrides := tenantOverrides{"t1": {"label:app"}}
 		obj1 := buildObj(t, cfg, "t1", []string{"b", "a"}, overrides)
 		obj2 := copyAndSort(t, cfg, obj1, overrides)
@@ -610,7 +636,7 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 	})
 
 	t.Run("initial flush emits schema-ordered logs sections", func(t *testing.T) {
-		cfg := makeCfg(true)
+		cfg := makeCfg()
 		overrides := tenantOverrides{"t1": {"label:app"}}
 		obj := buildObj(t, cfg, "t1", []string{"zoo", "alpha", "middle"}, overrides)
 
@@ -664,20 +690,19 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 		}
 	})
 
-	t.Run("idempotent: second CopyAndSort reads schema from metadata, not overrides", func(t *testing.T) {
-		cfg := makeCfg(true)
+	t.Run("idempotent: second CopyAndSort with the same schema preserves order", func(t *testing.T) {
+		cfg := makeCfg()
 		overrides := tenantOverrides{"t1": {"label:app"}}
 		obj1 := buildObj(t, cfg, "t1", []string{"zoo", "alpha", "middle"}, overrides)
 		obj2 := copyAndSort(t, cfg, obj1, overrides)
-		obj3 := copyAndSort(t, cfg, obj2, nil)
+		obj3 := copyAndSort(t, cfg, obj2, overrides)
 
-		require.Equal(t, []string{"alpha", "middle", "zoo"}, appOrder(t, obj3, "t1"),
-			"second CopyAndSort must preserve schema sort using persisted metadata")
+		require.Equal(t, []string{"alpha", "middle", "zoo"}, appOrder(t, obj3, "t1"))
 		timestampsDescWithinGroups(t, obj3, "t1")
 	})
 
 	t.Run("multi-label compound key", func(t *testing.T) {
-		cfg := makeCfg(true)
+		cfg := makeCfg()
 		overrides := tenantOverrides{"t1": {"label:namespace", "label:app"}}
 		b, err := NewBuilder(cfg, nil, NewBuilderMetrics(), log.NewNopLogger(), overrides)
 		require.NoError(t, err)
@@ -728,7 +753,7 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 	})
 
 	t.Run("stream IDs remapped to sort key order", func(t *testing.T) {
-		cfg := makeCfg(true)
+		cfg := makeCfg()
 		overrides := tenantOverrides{"t1": {"label:app"}}
 		schemaLabels := []string{"label:app"}
 
@@ -899,37 +924,6 @@ func TestBuilder_CopyAndSort_SortSchema(t *testing.T) {
 		}
 	})
 
-	t.Run("flag off: schema config ignored, DataobjSortOrder used", func(t *testing.T) {
-		cfg := makeCfg(false)
-		overrides := tenantOverrides{"t1": {"label:app"}}
-		obj1 := buildObj(t, cfg, "t1", []string{"zoo", "alpha", "middle"}, overrides)
-		obj2 := copyAndSort(t, cfg, obj1, overrides)
-
-		var allTS []time.Time
-		for _, sec := range obj2.Sections().Filter(func(s *dataobj.Section) bool {
-			return logs.CheckSection(s) && s.Tenant == "t1"
-		}) {
-			for res := range iterLogsSection(t, sec) {
-				val, err := res.Value()
-				require.NoError(t, err)
-				allTS = append(allTS, val.Timestamp)
-			}
-		}
-		for i := 1; i < len(allTS); i++ {
-			require.LessOrEqual(t, allTS[i].UnixNano(), allTS[i-1].UnixNano(),
-				"with flag off, order must be timestamp DESC at index %d", i)
-		}
-
-		for _, sec := range obj2.Sections().Filter(func(s *dataobj.Section) bool {
-			return logs.CheckSection(s) && s.Tenant == "t1"
-		}) {
-			logsSection, err := logs.Open(t.Context(), sec)
-			require.NoError(t, err)
-			schemaLabels, err := logsSection.SchemaLabels()
-			require.NoError(t, err)
-			require.Empty(t, schemaLabels, "SchemaLabels must be absent when flag is off")
-		}
-	})
 }
 
 func TestComputeSortKey(t *testing.T) {

--- a/pkg/dataobj/consumer/logsobj/factory.go
+++ b/pkg/dataobj/consumer/logsobj/factory.go
@@ -33,7 +33,7 @@ func NewBuilderFactory(
 	if overrides != nil {
 		level.Info(logger).Log("msg", "sort schema overrides wired to builder factory at construction")
 	} else {
-		level.Warn(logger).Log("msg", "sort schema overrides not provided at construction; schema sort will not apply to the initial builder")
+		level.Info(logger).Log("msg", "no sort schema overrides at construction")
 	}
 
 	return &BuilderFactory{

--- a/pkg/dataobj/index/builder_test.go
+++ b/pkg/dataobj/index/builder_test.go
@@ -550,7 +550,6 @@ func buildLogObject(t *testing.T, app string, path string, bucket objstore.Bucke
 			BufferSize:              4 * 1024 * 1024,
 			SectionStripeMergeLimit: 2,
 		},
-		DataobjSortOrder: "stream-asc",
 	}, nil, logsobj.NewBuilderMetrics(), log.NewNopLogger(), nil)
 	require.NoError(t, err)
 

--- a/pkg/dataobj/sortmerge/sortmerge_test.go
+++ b/pkg/dataobj/sortmerge/sortmerge_test.go
@@ -152,9 +152,7 @@ func buildSchemaObject(t *testing.T, sortSchema []string, byLabel map[string][]p
 	t.Helper()
 
 	cfg := testBuilderConfig
-	cfg.DataobjSortOrder = "timestamp-desc"
 	cfg.AppendOrderedEnabled = true
-	cfg.DataobjUseSortSchema = true
 
 	b, err := logsobj.NewBuilder(cfg, nil, logsobj.NewBuilderMetrics(), log.NewNopLogger(), schemaOverrides(sortSchema))
 	require.NoError(t, err)

--- a/pkg/engine/internal/executor/dataobjscan_test.go
+++ b/pkg/engine/internal/executor/dataobjscan_test.go
@@ -340,7 +340,6 @@ func buildDataobj(t testing.TB, streams []logproto.Stream) *dataobj.Object {
 			BufferSize:              8_000,
 			SectionStripeMergeLimit: 2,
 		},
-		DataobjSortOrder: "timestamp-desc",
 	}, nil, logsobj.NewBuilderMetrics(), log.NewNopLogger(), nil)
 	require.NoError(t, err)
 

--- a/pkg/engine/internal/executor/dataobjscan_test.go
+++ b/pkg/engine/internal/executor/dataobjscan_test.go
@@ -266,9 +266,9 @@ func Test_dataobjScan_DuplicateColumns(t *testing.T) {
 			semconv.FieldFromFQN("utf8.builtin.message", true),
 		}
 
-		expectCSV := `prod,namespace-2,NULL,loki,NULL,NULL,1970-01-01 00:00:03,message 3
+		expectCSV := `prod,NULL,pod-1,loki,NULL,override,1970-01-01 00:00:01,message 1
 prod,NULL,NULL,loki,namespace-1,NULL,1970-01-01 00:00:02,message 2
-prod,NULL,pod-1,loki,NULL,override,1970-01-01 00:00:01,message 1`
+prod,namespace-2,NULL,loki,NULL,NULL,1970-01-01 00:00:03,message 3`
 
 		expectRecord, err := CSVToArrow(expectFields, expectCSV)
 		require.NoError(t, err)
@@ -292,9 +292,9 @@ prod,NULL,pod-1,loki,NULL,override,1970-01-01 00:00:01,message 1`
 			semconv.FieldFromFQN("utf8.metadata.pod", true),
 		}
 
-		expectCSV := `NULL,NULL
+		expectCSV := `pod-1,override
 NULL,NULL
-pod-1,override`
+NULL,NULL`
 
 		expectRecord, err := CSVToArrow(expectFields, expectCSV)
 		require.NoError(t, err)
@@ -318,9 +318,9 @@ pod-1,override`
 			semconv.FieldFromFQN("utf8.metadata.namespace", true),
 		}
 
-		expectCSV := `namespace-2,NULL
+		expectCSV := `NULL,NULL
 NULL,namespace-1
-NULL,NULL`
+namespace-2,NULL`
 
 		expectRecord, err := CSVToArrow(expectFields, expectCSV)
 		require.NoError(t, err)

--- a/pkg/engine/internal/executor/log_merge.go
+++ b/pkg/engine/internal/executor/log_merge.go
@@ -397,9 +397,7 @@ func (c *Context) newLogObjectWriter(node *physical.LogMerge, table *globalStrea
 func (w *logObjectWriter) startNewObject() error {
 	cfg := logsobj.BuilderConfig{
 		BuilderBaseConfig:    w.c.logsobjCfg,
-		DataobjSortOrder:     "stream-asc",
 		AppendOrderedEnabled: true,
-		DataobjUseSortSchema: true,
 	}
 	overrides := fixedSortSchema(w.node.SortSchema)
 

--- a/pkg/engine/internal/executor/log_merge_test.go
+++ b/pkg/engine/internal/executor/log_merge_test.go
@@ -81,9 +81,7 @@ func buildSourceLogObject(t *testing.T, bucket objstore.Bucket, path string, sor
 			SectionStripeMergeLimit:   2,
 			EstimatedCompressionRatio: 8,
 		},
-		DataobjSortOrder:     "timestamp-desc",
 		AppendOrderedEnabled: true,
-		DataobjUseSortSchema: len(sortSchema) > 0,
 	}
 
 	b, err := logsobj.NewBuilder(cfg, scratch.NewMemory(), logsobj.NewBuilderMetrics(), log.NewNopLogger(), sortSchemaOverrides(sortSchema))

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -315,6 +315,29 @@ func (s SortSchema) Validate() error {
 	return nil
 }
 
+// String implements flag.Value.
+func (s SortSchema) String() string {
+	parts := make([]string, len(s))
+	for i, fqn := range s {
+		parts[i] = string(fqn)
+	}
+	return strings.Join(parts, ",")
+}
+
+// Set implements flag.Value. Each call overwrites any previous value.
+// Input is a comma-separated list of SortKeyFqn values.
+func (s *SortSchema) Set(v string) error {
+	*s = nil
+	for _, part := range strings.Split(v, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		*s = append(*s, SortKeyFqn(part))
+	}
+	return nil
+}
+
 type StreamRetention struct {
 	Period   model.Duration    `yaml:"period" json:"period" doc:"description:Retention period applied to the log lines matching the selector."`
 	Priority int               `yaml:"priority" json:"priority" doc:"description:The larger the value, the higher the priority."`
@@ -532,6 +555,9 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.BoolVar(&l.DebugEngineTasks, "limits.debug-engine-tasks", false, "Experimental: Toggles verbose debug logging of tasks in the new query engine.")
 	f.BoolVar(&l.DebugEngineStreams, "limits.debug-engine-streams", false, "Experimental: Toggles verbose debug logging of data streams in the new query engine.")
+
+	l.SortSchema = DefaultSortSchema
+	f.Var(&l.SortSchema, "limits.sort-schema", "Experimental: Ordered, comma-separated sort keys for data objects, as `label:<name>,...`. Only the label type is currently supported. Defaults to "+DefaultSortSchema.String()+".")
 }
 
 // SetGlobalOTLPConfig set GlobalOTLPConfig which is used while unmarshaling per-tenant otlp config to use the default list of resource attributes picked as index labels.

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -1188,3 +1188,88 @@ func TestDataObjCompaction_ValidateAcceptsValidCombinations(t *testing.T) {
 		})
 	}
 }
+
+func TestOverrides_SortSchemaLabelsDefault(t *testing.T) {
+	t.Run("register-flags default", func(t *testing.T) {
+		var defaults Limits
+		defaults.RegisterFlags(flag.NewFlagSet("test", flag.PanicOnError))
+		ov, err := NewOverrides(defaults, nil)
+		require.NoError(t, err)
+		require.Equal(t, []string{"label:service_name"}, ov.SortSchemaLabels("any-tenant"))
+	})
+
+	t.Run("flag value is the default for tenants without override", func(t *testing.T) {
+		var defaults Limits
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		defaults.RegisterFlags(fs)
+		require.NoError(t, fs.Parse([]string{"-limits.sort-schema=label:cluster"}))
+		ov, err := NewOverrides(defaults, nil)
+		require.NoError(t, err)
+		require.Equal(t, []string{"label:cluster"}, ov.SortSchemaLabels("any-tenant"))
+	})
+
+	t.Run("per-tenant yaml wins", func(t *testing.T) {
+		var defaults Limits
+		defaults.RegisterFlags(flag.NewFlagSet("test", flag.PanicOnError))
+		ov, err := NewOverrides(defaults, newMockTenantLimits(map[string]*Limits{
+			"custom": {SortSchema: SortSchema{"label:app"}},
+		}))
+		require.NoError(t, err)
+		require.Equal(t, []string{"label:app"}, ov.SortSchemaLabels("custom"))
+		require.Equal(t, []string{"label:service_name"}, ov.SortSchemaLabels("other"))
+	})
+}
+
+func TestSortSchema_FlagValue(t *testing.T) {
+	t.Run("string joins fqns", func(t *testing.T) {
+		s := SortSchema{"label:service_name", "label:namespace"}
+		require.Equal(t, "label:service_name,label:namespace", s.String())
+	})
+
+	t.Run("set replaces previous value", func(t *testing.T) {
+		var s SortSchema
+		require.NoError(t, s.Set("label:app"))
+		require.NoError(t, s.Set("label:job, label:ns"))
+		require.Equal(t, SortSchema{"label:job", "label:ns"}, s)
+	})
+
+	t.Run("set skips empty parts", func(t *testing.T) {
+		var s SortSchema
+		require.NoError(t, s.Set("label:app,,label:job,"))
+		require.Equal(t, SortSchema{"label:app", "label:job"}, s)
+	})
+}
+
+func TestSortSchema_RegisterFlags(t *testing.T) {
+	t.Run("default is DefaultSortSchema", func(t *testing.T) {
+		var l Limits
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		l.RegisterFlags(fs)
+		require.Equal(t, DefaultSortSchema, l.SortSchema)
+	})
+
+	t.Run("parses comma-separated keys", func(t *testing.T) {
+		var l Limits
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		l.RegisterFlags(fs)
+		require.NoError(t, fs.Parse([]string{"-limits.sort-schema=label:app,label:ns"}))
+		require.Equal(t, SortSchema{"label:app", "label:ns"}, l.SortSchema)
+		require.NoError(t, l.Validate())
+	})
+
+	t.Run("validate rejects bad fqn after flag parse", func(t *testing.T) {
+		var l Limits
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		l.RegisterFlags(fs)
+		require.NoError(t, fs.Parse([]string{"-limits.sort-schema=not-a-fqn"}))
+		require.Error(t, l.Validate())
+	})
+
+	t.Run("validate rejects duplicates after flag parse", func(t *testing.T) {
+		var l Limits
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		l.RegisterFlags(fs)
+		require.NoError(t, fs.Parse([]string{"-limits.sort-schema=label:app,label:app"}))
+		require.Error(t, l.Validate())
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Sets sort-schema as the sort-schema for new objects. The PR takes the opportunity for code simplification.
* Adds sort-schema as a flag
* Always defaults to `label:service_name` for every tenant if nothing else is set.
* Removes configuration for "legacy" sort schemas (stream ASC and timestamp DESC) since sort-schemas are required for compaction anyway.