### PR TITLE
chore: Bump loki-release to 2a4930bb9e2087b22d41a7162ed87d27f4c499f4

### DIFF
--- a/.github/jsonnetfile.json
+++ b/.github/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "workflows"
         }
       },
-      "version": "79fc5eab3e11751a7c18b9255202d81aaf031c86"
+      "version": "2a4930bb9e2087b22d41a7162ed87d27f4c499f4"
     }
   ],
   "legacyImports": true

--- a/.github/jsonnetfile.lock.json
+++ b/.github/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "workflows"
         }
       },
-      "version": "79fc5eab3e11751a7c18b9255202d81aaf031c86",
-      "sum": "LIie2dXOzK6sD36cNAh1pIl/x54BT2KAufPw5I2Lroo="
+      "version": "2a4930bb9e2087b22d41a7162ed87d27f4c499f4",
+      "sum": "+fgkme205lBtZz05Wy1I298/sSNwXrYdFT9TLio02eU="
     }
   ],
   "legacyImports": false

--- a/.github/vendor/github.com/grafana/loki-release/workflows/common.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/common.libsonnet
@@ -137,7 +137,7 @@
                          git config --global --add safe.directory "$GITHUB_WORKSPACE"
                        |||),
 
-  githubAppToken: $.step.new('get github app token', 'grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0')  // create-github-app-token/v0.2.2
+  githubAppToken: $.step.new('get github app token', 'grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e')  // create-github-app-token/v0.3.1
                   + $.step.withId('get_github_app_token')
                   + $.step.with({
                     github_app: '${{ env.GITHUB_APP }}',

--- a/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/release.libsonnet
@@ -191,9 +191,9 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
                    exists: '${{ steps.check_release.outputs.exists }}',
                  }),
 
-  publishImages: function()
+  publishImages: function(needs=['createRelease'], sha='${{ needs.createRelease.outputs.sha }}', isLatest='${{ needs.createRelease.outputs.isLatest }}')
     job.new()
-    + job.withNeeds(['createRelease'])
+    + job.withNeeds(needs)
     + job.withPermissions({
       'id-token': 'write',
     })
@@ -206,7 +206,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         + step.with({ registry: 'us-docker.pkg.dev' }),
         step.new('download images')
         + step.withEnv({
-          SHA: '${{ needs.createRelease.outputs.sha }}',
+          SHA: sha,
         })
         + step.withRun(|||
           echo "downloading images to $(pwd)/images"
@@ -223,14 +223,14 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         + step.with({
           imageDir: 'images',
           imagePrefix: '${{ env.IMAGE_PREFIX }}',
-          isLatest: '${{ needs.createRelease.outputs.isLatest }}',
+          isLatest: isLatest,
         }),
       ]
     ),
 
-  publishDockerPlugins: function(path)
+  publishDockerPlugins: function(path, needs=['createRelease'], sha='${{ needs.createRelease.outputs.sha }}', isLatest='${{ needs.createRelease.outputs.isLatest }}')
     job.new()
-    + job.withNeeds(['createRelease'])
+    + job.withNeeds(needs)
     + job.withPermissions({
       'id-token': 'write',
     })
@@ -244,7 +244,7 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
         + step.with({ registry: 'us-docker.pkg.dev' }),
         step.new('download and prepare plugins')
         + step.withEnv({
-          SHA: '${{ needs.createRelease.outputs.sha }}',
+          SHA: sha,
         })
         + step.withRun(|||
           echo "downloading plugins to $(pwd)/plugins"
@@ -258,14 +258,39 @@ local pullRequestFooter = 'Merging this PR will release the [artifacts](https://
             --destination=plugins/
           mkdir -p "release/%s"
         ||| % path),
+        step.new('start local registry for plugins')
+        + step.withRun(|||
+          set -euo pipefail
+          crane_version="v0.21.6"
+          curl -sSL "https://github.com/google/go-containerregistry/releases/download/${crane_version}/go-containerregistry_Linux_x86_64.tar.gz" \
+            | tar -xz crane
+          nohup ./crane registry serve --address localhost:5000 >crane-registry.log 2>&1 &
+          for _ in $(seq 1 30); do
+            curl -sf http://localhost:5000/v2/ >/dev/null && break
+            sleep 1
+          done
+          curl -sf http://localhost:5000/v2/ >/dev/null || { echo "local registry failed to start" >&2; cat crane-registry.log >&2 || true; exit 1; }
+        |||),
         step.new('publish docker driver', './lib/actions/push-images')
         + step.with({
           imageDir: 'plugins',
-          imagePrefix: '${{ env.PLUGIN_IMAGE_PREFIX }}',
+          imagePrefix: 'localhost:5000',
           isPlugin: true,
           buildDir: 'release/%s' % path,
-          isLatest: '${{ needs.createRelease.outputs.isLatest }}',
+          isLatest: isLatest,
         }),
+        step.new('mirror plugins to GAR with crane')
+        + step.withRun(|||
+          set -euo pipefail
+          for repo in $(./crane catalog localhost:5000 --insecure); do
+            for tag in $(./crane ls "localhost:5000/${repo}" --insecure); do
+              layout="$(mktemp -d)"
+              echo "mirroring ${repo}:${tag} to ${PLUGIN_IMAGE_PREFIX}/${repo}:${tag}"
+              ./crane pull --insecure --format=oci "localhost:5000/${repo}:${tag}" "${layout}"
+              ./crane push "${layout}" "${PLUGIN_IMAGE_PREFIX}/${repo}:${tag}"
+            done
+          done
+        |||),
       ]
     ),
 

--- a/.github/vendor/github.com/grafana/loki-release/workflows/workflows.jsonnet
+++ b/.github/vendor/github.com/grafana/loki-release/workflows/workflows.jsonnet
@@ -46,6 +46,23 @@ local dockerPluginDir = 'clients/cmd/docker-driver';
       on+: {
         pull_request: {},
       },
+      env+: {
+        IMAGE_PREFIX: 'us-docker.pkg.dev/grafanalabs-dev/docker-loki-dev/ci/${{ github.run_id }}',
+        PLUGIN_IMAGE_PREFIX: 'us-docker.pkg.dev/grafanalabs-dev/docker-loki-dev/ci/${{ github.run_id }}',
+      },
+      jobs+: {
+        publishImages: lokiRelease.release.publishImages(
+          needs=['loki', 'loki-docker-driver'],
+          sha='${{ github.sha }}',
+          isLatest='false',
+        ),
+        publishDockerPlugins: lokiRelease.release.publishDockerPlugins(
+          dockerPluginDir,
+          needs=['loki', 'loki-docker-driver'],
+          sha='${{ github.sha }}',
+          isLatest='false',
+        ),
+      },
     }, false, false
   ),
   '.github/workflows/release.yml': std.manifestYamlDoc(

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@79fc5eab3e11751a7c18b9255202d81aaf031c86"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@2a4930bb9e2087b22d41a7162ed87d27f4c499f4"
     "with":
       "build_image": "golang:1.26.6"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "79fc5eab3e11751a7c18b9255202d81aaf031c86"
+      "release_lib_ref": "2a4930bb9e2087b22d41a7162ed87d27f4c499f4"
       "skip_validation": false
       "use_github_app_token": true
 "name": "check"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,10 +1,10 @@
 "jobs":
   "check":
-    "uses": "grafana/loki-release/.github/workflows/check.yml@79fc5eab3e11751a7c18b9255202d81aaf031c86"
+    "uses": "grafana/loki-release/.github/workflows/check.yml@2a4930bb9e2087b22d41a7162ed87d27f4c499f4"
     "with":
       "build_image": "golang:1.26.6"
       "golang_ci_lint_version": "v2.10.1"
-      "release_lib_ref": "79fc5eab3e11751a7c18b9255202d81aaf031c86"
+      "release_lib_ref": "2a4930bb9e2087b22d41a7162ed87d27f4c499f4"
       "skip_validation": false
       "use_github_app_token": true
   "logql-analyzer-image":
@@ -12,7 +12,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.6"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "79fc5eab3e11751a7c18b9255202d81aaf031c86"
+      "RELEASE_LIB_REF": "2a4930bb9e2087b22d41a7162ed87d27f4c499f4"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -135,12 +135,12 @@
         echo "linux/arm64 $IMAGE_DIGEST_ARM64"
         echo "linux/amd64 $IMAGE_DIGEST_AMD64"
         echo "linux/arm   $IMAGE_DIGEST_ARM"
-
+        
         # 'needs.logql-analyzer-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
         # See https://github.com/actions/runner/issues/2316
         # Using the IMAGE_NAME env variable instead
         IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
-
+        
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
           ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
@@ -152,7 +152,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.6"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "79fc5eab3e11751a7c18b9255202d81aaf031c86"
+      "RELEASE_LIB_REF": "2a4930bb9e2087b22d41a7162ed87d27f4c499f4"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -275,12 +275,12 @@
         echo "linux/arm64 $IMAGE_DIGEST_ARM64"
         echo "linux/amd64 $IMAGE_DIGEST_AMD64"
         echo "linux/arm   $IMAGE_DIGEST_ARM"
-
+        
         # 'needs.loki-canary-boringcrypto-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
         # See https://github.com/actions/runner/issues/2316
         # Using the IMAGE_NAME env variable instead
         IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
-
+        
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
           ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
@@ -292,7 +292,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.6"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "79fc5eab3e11751a7c18b9255202d81aaf031c86"
+      "RELEASE_LIB_REF": "2a4930bb9e2087b22d41a7162ed87d27f4c499f4"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -415,12 +415,12 @@
         echo "linux/arm64 $IMAGE_DIGEST_ARM64"
         echo "linux/amd64 $IMAGE_DIGEST_AMD64"
         echo "linux/arm   $IMAGE_DIGEST_ARM"
-
+        
         # 'needs.loki-canary-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
         # See https://github.com/actions/runner/issues/2316
         # Using the IMAGE_NAME env variable instead
         IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
-
+        
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
           ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
@@ -432,7 +432,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.6"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "79fc5eab3e11751a7c18b9255202d81aaf031c86"
+      "RELEASE_LIB_REF": "2a4930bb9e2087b22d41a7162ed87d27f4c499f4"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -555,12 +555,12 @@
         echo "linux/arm64 $IMAGE_DIGEST_ARM64"
         echo "linux/amd64 $IMAGE_DIGEST_AMD64"
         echo "linux/arm   $IMAGE_DIGEST_ARM"
-
+        
         # 'needs.loki-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
         # See https://github.com/actions/runner/issues/2316
         # Using the IMAGE_NAME env variable instead
         IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
-
+        
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
           ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \
@@ -572,7 +572,7 @@
       "BUILD_TIMEOUT": 60
       "GO_VERSION": "1.26.6"
       "IMAGE_PREFIX": "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-      "RELEASE_LIB_REF": "79fc5eab3e11751a7c18b9255202d81aaf031c86"
+      "RELEASE_LIB_REF": "2a4930bb9e2087b22d41a7162ed87d27f4c499f4"
       "RELEASE_REPO": "grafana/loki"
     "needs":
     - "check"
@@ -695,12 +695,12 @@
         echo "linux/arm64 $IMAGE_DIGEST_ARM64"
         echo "linux/amd64 $IMAGE_DIGEST_AMD64"
         echo "linux/arm   $IMAGE_DIGEST_ARM"
-
+        
         # 'needs.loki-query-tee-image.outputs.image_name' gets masked and therefore OUTPUTS_IMAGE_NAME is empty
         # See https://github.com/actions/runner/issues/2316
         # Using the IMAGE_NAME env variable instead
         IMAGE="${IMAGE_NAME}:${OUTPUTS_IMAGE_TAG}"
-
+        
         echo "Create multi-arch manifest for $IMAGE"
         docker buildx imagetools create -t $IMAGE \
           ${IMAGE_NAME}@${IMAGE_DIGEST_ARM64} \

--- a/.github/workflows/minor-release-pr.yml
+++ b/.github/workflows/minor-release-pr.yml
@@ -8,7 +8,7 @@ env:
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-  RELEASE_LIB_REF: "79fc5eab3e11751a7c18b9255202d81aaf031c86"
+  RELEASE_LIB_REF: "2a4930bb9e2087b22d41a7162ed87d27f4c499f4"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   VERSIONING_STRATEGY: "always-bump-minor"
@@ -18,11 +18,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@79fc5eab3e11751a7c18b9255202d81aaf031c86"
+    uses: "grafana/loki-release/.github/workflows/check.yml@2a4930bb9e2087b22d41a7162ed87d27f4c499f4"
     with:
       build_image: "golang:1.26.6"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "79fc5eab3e11751a7c18b9255202d81aaf031c86"
+      release_lib_ref: "2a4930bb9e2087b22d41a7162ed87d27f4c499f4"
       skip_validation: false
   create-release-pr:
     needs:
@@ -69,7 +69,7 @@ jobs:
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
     - id: "get_github_app_token"
       name: "get github app token"
-      uses: "grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0"
+      uses: "grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e"
       with:
         github_app: "${{ env.GITHUB_APP }}"
     - env:
@@ -96,7 +96,7 @@ jobs:
           --target-branch "$(echo $OUTPUTS_BRANCH | tr -d '"')" \
           --token "$(echo $OUTPUTS_TOKEN | tr -d '"')" \
           --dry-run ${{ fromJSON(env.DRY_RUN) }}
-
+        
       working-directory: "lib"
   dist:
     needs:
@@ -214,7 +214,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -291,7 +291,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -368,7 +368,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -451,7 +451,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -528,7 +528,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -611,7 +611,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -694,7 +694,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -778,7 +778,7 @@ jobs:
       run: |
         mkdir -p images
         mkdir -p plugins
-
+        
         platform="$(echo "${{ matrix.arch}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -874,7 +874,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -957,7 +957,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -1038,7 +1038,7 @@ jobs:
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
     - id: "get_github_app_token"
       name: "get github app token"
-      uses: "grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0"
+      uses: "grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e"
       with:
         github_app: "${{ env.GITHUB_APP }}"
     - env:
@@ -1048,7 +1048,7 @@ jobs:
       name: "get release version"
       run: |
         yarn install
-
+        
         if [[ -z "${{ env.RELEASE_AS }}" ]]; then
           yarn exec -- release-please release-pr \
             --consider-all-branches \
@@ -1078,16 +1078,16 @@ jobs:
             --token "$OUTPUTS_TOKEN" \
             --release-as "${{ env.RELEASE_AS }}"
         fi
-
+        
         cat release.json
-
-        if [[ `jq length release.json` -gt 1 ]]; then
+        
+        if [[ `jq length release.json` -gt 1 ]]; then 
           echo 'release-please would create more than 1 PR, so cannot determine correct version'
           echo "pr_created=false" >> $GITHUB_OUTPUT
           exit 1
         fi
-
-        if [[ `jq length release.json` -eq 0 ]]; then
+        
+        if [[ `jq length release.json` -eq 0 ]]; then 
           echo "pr_created=false" >> $GITHUB_OUTPUT
         else
           version="$(yarn run --silent get-version)"

--- a/.github/workflows/patch-release-pr.yml
+++ b/.github/workflows/patch-release-pr.yml
@@ -8,7 +8,7 @@ env:
   GAR_REPO_SLUG: "loki"
   GITHUB_APP: "loki-gh-app"
   IMAGE_PREFIX: "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
-  RELEASE_LIB_REF: "79fc5eab3e11751a7c18b9255202d81aaf031c86"
+  RELEASE_LIB_REF: "2a4930bb9e2087b22d41a7162ed87d27f4c499f4"
   RELEASE_REPO: "grafana/loki"
   SKIP_VALIDATION: false
   VERSIONING_STRATEGY: "always-bump-patch"
@@ -18,11 +18,11 @@ jobs:
       contents: "write"
       id-token: "write"
       pull-requests: "write"
-    uses: "grafana/loki-release/.github/workflows/check.yml@79fc5eab3e11751a7c18b9255202d81aaf031c86"
+    uses: "grafana/loki-release/.github/workflows/check.yml@2a4930bb9e2087b22d41a7162ed87d27f4c499f4"
     with:
       build_image: "golang:1.26.6"
       golang_ci_lint_version: "v2.10.1"
-      release_lib_ref: "79fc5eab3e11751a7c18b9255202d81aaf031c86"
+      release_lib_ref: "2a4930bb9e2087b22d41a7162ed87d27f4c499f4"
       skip_validation: false
   create-release-pr:
     needs:
@@ -69,7 +69,7 @@ jobs:
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
     - id: "get_github_app_token"
       name: "get github app token"
-      uses: "grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0"
+      uses: "grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e"
       with:
         github_app: "${{ env.GITHUB_APP }}"
     - env:
@@ -96,7 +96,7 @@ jobs:
           --target-branch "$(echo $OUTPUTS_BRANCH | tr -d '"')" \
           --token "$(echo $OUTPUTS_TOKEN | tr -d '"')" \
           --dry-run ${{ fromJSON(env.DRY_RUN) }}
-
+        
       working-directory: "lib"
   dist:
     needs:
@@ -214,7 +214,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -291,7 +291,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -368,7 +368,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -451,7 +451,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -528,7 +528,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -611,7 +611,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -694,7 +694,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -778,7 +778,7 @@ jobs:
       run: |
         mkdir -p images
         mkdir -p plugins
-
+        
         platform="$(echo "${{ matrix.arch}}" |  sed  "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -874,7 +874,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -957,7 +957,7 @@ jobs:
       name: "Parse image platform"
       run: |
         mkdir -p images
-
+        
         platform="$(echo "${{ matrix.arch }}" | sed "s/\(.*\)\/\(.*\)/\1-\2/")"
         echo "platform=${platform}" >> $GITHUB_OUTPUT
         echo "platform_short=$(echo ${{ matrix.arch }} | cut -d / -f 2)" >> $GITHUB_OUTPUT
@@ -1038,7 +1038,7 @@ jobs:
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
     - id: "get_github_app_token"
       name: "get github app token"
-      uses: "grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0"
+      uses: "grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e"
       with:
         github_app: "${{ env.GITHUB_APP }}"
     - env:
@@ -1048,7 +1048,7 @@ jobs:
       name: "get release version"
       run: |
         yarn install
-
+        
         if [[ -z "${{ env.RELEASE_AS }}" ]]; then
           yarn exec -- release-please release-pr \
             --consider-all-branches \
@@ -1078,16 +1078,16 @@ jobs:
             --token "$OUTPUTS_TOKEN" \
             --release-as "${{ env.RELEASE_AS }}"
         fi
-
+        
         cat release.json
-
-        if [[ `jq length release.json` -gt 1 ]]; then
+        
+        if [[ `jq length release.json` -gt 1 ]]; then 
           echo 'release-please would create more than 1 PR, so cannot determine correct version'
           echo "pr_created=false" >> $GITHUB_OUTPUT
           exit 1
         fi
-
-        if [[ `jq length release.json` -eq 0 ]]; then
+        
+        if [[ `jq length release.json` -eq 0 ]]; then 
           echo "pr_created=false" >> $GITHUB_OUTPUT
         else
           version="$(yarn run --silent get-version)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ env:
   IMAGE_PREFIX: "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
   PLUGIN_IMAGE_PREFIX: "us-docker.pkg.dev/grafanalabs-global/dockerhub-loki-prod-mirror"
   PUBLISH_TO_GCS: false
-  RELEASE_LIB_REF: "79fc5eab3e11751a7c18b9255202d81aaf031c86"
+  RELEASE_LIB_REF: "2a4930bb9e2087b22d41a7162ed87d27f4c499f4"
   RELEASE_REPO: "grafana/loki"
 jobs:
   createRelease:
@@ -50,7 +50,7 @@ jobs:
       run: "corepack enable"
     - id: "get_github_app_token"
       name: "get github app token"
-      uses: "grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0"
+      uses: "grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e"
       with:
         github_app: "${{ env.GITHUB_APP }}"
     - name: "Login to GAR"
@@ -155,7 +155,7 @@ jobs:
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
     - id: "get_github_app_token"
       name: "get github app token"
-      uses: "grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0"
+      uses: "grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e"
       with:
         github_app: "${{ env.GITHUB_APP }}"
     - env:
@@ -271,7 +271,7 @@ jobs:
         repository: "${{ env.RELEASE_REPO }}"
     - id: "get_github_app_token"
       name: "get github app token"
-      uses: "grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0"
+      uses: "grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e"
       with:
         github_app: "${{ env.GITHUB_APP }}"
     - env:


### PR DESCRIPTION
**What this PR does / why we need it**:
Vendors in: https://github.com/grafana/loki-release/pull/398

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [X] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
