### PR TITLE
feat: Collapse max request body size and decompressed size

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3402,8 +3402,8 @@ ring:
 [push_worker_count: <int> | default = 256]
 
 # The maximum size of a Push request.
-# CLI flag: -distributor.max-push-size
-[max_push_size: <int> | default = 2147483647]
+# CLI flag: -distributor.max-push-size-bytes
+[max_push_size_bytes: <int> | default = 2147483647]
 
 # The maximum number of inflight bytes at a time. 0 means disabled.
 # CLI flag: -distributor.max-inflight-bytes

--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -3401,13 +3401,9 @@ ring:
 # CLI flag: -distributor.push-worker-count
 [push_worker_count: <int> | default = 256]
 
-# The maximum size of a received message.
-# CLI flag: -distributor.max-recv-msg-size
-[max_recv_msg_size: <int> | default = 104857600]
-
-# The maximum size of a decompressed message. Defaults to 50x max-recv-msg-size.
-# CLI flag: -distributor.max-decompressed-size
-[max_decompressed_size: <int> | default = 5242880000]
+# The maximum size of a Push request.
+# CLI flag: -distributor.max-push-size
+[max_push_size: <int> | default = 2147483647]
 
 # The maximum number of inflight bytes at a time. 0 means disabled.
 # CLI flag: -distributor.max-inflight-bytes

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -92,7 +92,7 @@ type Config struct {
 	PushWorkerCount int        `yaml:"push_worker_count"`
 
 	// Request parser
-	MaxPushSize      int `yaml:"max_push_size"`
+	MaxPushSizeBytes int `yaml:"max_push_size_bytes"`
 	MaxInflightBytes int `yaml:"max_inflight_bytes"`
 
 	// For testing.
@@ -133,7 +133,7 @@ func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
 	cfg.RateStore.RegisterFlagsWithPrefix("distributor.rate-store", fs)
 	cfg.WriteFailuresLogging.RegisterFlagsWithPrefix("distributor.write-failures-logging", fs)
 	cfg.OTLPAttributeLogging.RegisterFlagsWithPrefix("distributor.otlp-attribute-logging", fs)
-	fs.IntVar(&cfg.MaxPushSize, "distributor.max-push-size", math.MaxInt32, "The maximum size of a Push request.")
+	fs.IntVar(&cfg.MaxPushSizeBytes, "distributor.max-push-size-bytes", math.MaxInt32, "The maximum size of a Push request.")
 	fs.IntVar(&cfg.MaxInflightBytes, "distributor.max-inflight-bytes", 0, "The maximum number of inflight bytes at a time. 0 means disabled.")
 	fs.IntVar(&cfg.PushWorkerCount, "distributor.push-worker-count", 256, "Number of workers to push batches to ingesters.")
 	fs.BoolVar(&cfg.KafkaEnabled, "distributor.kafka-writes-enabled", false, "Enable writes to Kafka during Push requests.")
@@ -152,7 +152,7 @@ func (cfg *Config) Validate() error {
 	if err := cfg.CircuitBreaker.Validate(); err != nil {
 		return err
 	}
-	if cfg.MaxPushSize < 0 {
+	if cfg.MaxPushSizeBytes < 0 {
 		return errors.New("max push size cannot be less than zero")
 	}
 	if cfg.MaxInflightBytes < 0 {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -92,9 +92,8 @@ type Config struct {
 	PushWorkerCount int        `yaml:"push_worker_count"`
 
 	// Request parser
-	MaxRecvMsgSize      int   `yaml:"max_recv_msg_size"`
-	MaxDecompressedSize int64 `yaml:"max_decompressed_size"`
-	MaxInflightBytes    int   `yaml:"max_inflight_bytes"`
+	MaxPushSize      int `yaml:"max_push_size"`
+	MaxInflightBytes int `yaml:"max_inflight_bytes"`
 
 	// For testing.
 	factory ring_client.PoolFactory `yaml:"-"`
@@ -134,8 +133,7 @@ func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
 	cfg.RateStore.RegisterFlagsWithPrefix("distributor.rate-store", fs)
 	cfg.WriteFailuresLogging.RegisterFlagsWithPrefix("distributor.write-failures-logging", fs)
 	cfg.OTLPAttributeLogging.RegisterFlagsWithPrefix("distributor.otlp-attribute-logging", fs)
-	fs.IntVar(&cfg.MaxRecvMsgSize, "distributor.max-recv-msg-size", 100<<20, "The maximum size of a received message.")
-	fs.Int64Var(&cfg.MaxDecompressedSize, "distributor.max-decompressed-size", 5000<<20, "The maximum size of a decompressed message. Defaults to 50x max-recv-msg-size.")
+	fs.IntVar(&cfg.MaxPushSize, "distributor.max-push-size", math.MaxInt32, "The maximum size of a Push request.")
 	fs.IntVar(&cfg.MaxInflightBytes, "distributor.max-inflight-bytes", 0, "The maximum number of inflight bytes at a time. 0 means disabled.")
 	fs.IntVar(&cfg.PushWorkerCount, "distributor.push-worker-count", 256, "Number of workers to push batches to ingesters.")
 	fs.BoolVar(&cfg.KafkaEnabled, "distributor.kafka-writes-enabled", false, "Enable writes to Kafka during Push requests.")
@@ -154,9 +152,8 @@ func (cfg *Config) Validate() error {
 	if err := cfg.CircuitBreaker.Validate(); err != nil {
 		return err
 	}
-	// Set default maxDecompressedSize if not configured (50x maxRecvMsgSize)
-	if cfg.MaxDecompressedSize == 0 && cfg.MaxRecvMsgSize > 0 {
-		cfg.MaxDecompressedSize = int64(cfg.MaxRecvMsgSize) * 50
+	if cfg.MaxPushSize < 0 {
+		return errors.New("max push size cannot be less than zero")
 	}
 	if cfg.MaxInflightBytes < 0 {
 		return errors.New("max inflight bytes cannot be less than zero")

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -3126,67 +3126,6 @@ func TestDistributor_PushIngestLimits(t *testing.T) {
 	}
 }
 
-func TestConfig_Validate(t *testing.T) {
-	tests := []struct {
-		name                        string
-		cfg                         Config
-		expectedMaxDecompressedSize int64
-		expectedError               string
-	}{
-		{
-			name: "sets default maxDecompressedSize when zero and maxRecvMsgSize is set",
-			cfg: Config{
-				MaxRecvMsgSize:      100 << 20, // 100 MB
-				MaxDecompressedSize: 0,
-				KafkaEnabled:        false,
-				IngesterEnabled:     true,
-			},
-			expectedMaxDecompressedSize: 5000 << 20, // 5000 MB (50x)
-		},
-		{
-			name: "does not override explicit maxDecompressedSize",
-			cfg: Config{
-				MaxRecvMsgSize:      100 << 20, // 100 MB
-				MaxDecompressedSize: 500 << 20, // 500 MB
-				KafkaEnabled:        false,
-				IngesterEnabled:     true,
-			},
-			expectedMaxDecompressedSize: 500 << 20, // 500 MB (unchanged)
-		},
-		{
-			name: "does not set default when maxRecvMsgSize is zero",
-			cfg: Config{
-				MaxRecvMsgSize:      0,
-				MaxDecompressedSize: 0,
-				KafkaEnabled:        false,
-				IngesterEnabled:     true,
-			},
-			expectedMaxDecompressedSize: 0, // Should remain 0
-		},
-		{
-			name: "validates kafka and ingester enabled",
-			cfg: Config{
-				KafkaEnabled:    false,
-				IngesterEnabled: false,
-			},
-			expectedError: "at least one of kafka and ingestor writes must be enabled",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.cfg.Validate()
-			if tt.expectedError != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.expectedError)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tt.expectedMaxDecompressedSize, tt.cfg.MaxDecompressedSize)
-			}
-		})
-	}
-}
-
 func TestDistributorMaxInflightBytesLimit(t *testing.T) {
 	validationLimits := &validation.Limits{}
 	flagext.DefaultValues(validationLimits)

--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -69,7 +69,7 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 	streamResolver := newRequestScopedStreamResolver(tenantID, d.validator.Limits, logger)
 
 	presumedAgentIP := extractPresumedAgentIP(r)
-	req, pushStats, err := push.ParseRequest(logger, tenantID, d.cfg.MaxRecvMsgSize, d.cfg.MaxDecompressedSize, r, d.validator.Limits, d.tenantConfigs,
+	req, pushStats, err := push.ParseRequest(logger, tenantID, d.cfg.MaxPushSize, int64(d.cfg.MaxPushSize), r, d.validator.Limits, d.tenantConfigs,
 		pushRequestParser, d.usageTracker, streamResolver, presumedAgentIP, format)
 	if err != nil {
 		switch {

--- a/pkg/distributor/http.go
+++ b/pkg/distributor/http.go
@@ -69,7 +69,7 @@ func (d *Distributor) pushHandler(w http.ResponseWriter, r *http.Request, pushRe
 	streamResolver := newRequestScopedStreamResolver(tenantID, d.validator.Limits, logger)
 
 	presumedAgentIP := extractPresumedAgentIP(r)
-	req, pushStats, err := push.ParseRequest(logger, tenantID, d.cfg.MaxPushSize, int64(d.cfg.MaxPushSize), r, d.validator.Limits, d.tenantConfigs,
+	req, pushStats, err := push.ParseRequest(logger, tenantID, d.cfg.MaxPushSizeBytes, int64(d.cfg.MaxPushSizeBytes), r, d.validator.Limits, d.tenantConfigs,
 		pushRequestParser, d.usageTracker, streamResolver, presumedAgentIP, format)
 	if err != nil {
 		switch {

--- a/pkg/distributor/http_test.go
+++ b/pkg/distributor/http_test.go
@@ -76,132 +76,25 @@ func TestDistributorRingHandler(t *testing.T) {
 	})
 }
 
-func TestPushHandlerMaxRecvMsgSize(t *testing.T) {
-	const line = "the quick brown fox jumps over the lazy dog"
+func TestPushHandlerMaxPushSize(t *testing.T) {
+	line := strings.Repeat("a ", 1000)
 
 	limits := &validation.Limits{}
 	flagext.DefaultValues(limits)
 	limits.RejectOldSamples = false
 	distributors, _ := prepare(t, 1, 3, limits, nil)
-	distributors[0].cfg.MaxRecvMsgSize = 10
+	distributors[0].cfg.MaxPushSize = 1000
 
-	t.Run("protobuf returns 413", func(t *testing.T) {
-		body, err := proto.Marshal(&logproto.PushRequest{
+	newPushRequest := func() *logproto.PushRequest {
+		return &logproto.PushRequest{
 			Streams: []logproto.Stream{
 				{
 					Labels:  `{foo="bar"}`,
 					Entries: []logproto.Entry{{Timestamp: time.Now(), Line: line}},
 				},
 			},
-		})
-		require.NoError(t, err)
-		require.Greater(t, len(body), distributors[0].cfg.MaxRecvMsgSize)
-
-		req := httptest.NewRequest(http.MethodPost, "/loki/api/v1/push", bytes.NewReader(body))
-		ctx := user.InjectOrgID(t.Context(), "test")
-		req = req.WithContext(ctx)
-		req.Header.Set("Content-Type", "application/x-protobuf")
-
-		// The metric is a global counter shared across tests, so measure the
-		// delta produced by this request rather than an absolute value.
-		discardedBytes := validation.DiscardedBytes.WithLabelValues(validation.RequestBodyTooLarge, "test", "", "", constants.Loki)
-		before := testutil.ToFloat64(discardedBytes)
-
-		rec := httptest.NewRecorder()
-		distributors[0].pushHandler(rec, req, push.ParseLokiRequest, push.HTTPError, constants.Loki)
-
-		require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
-		require.Equal(t, float64(req.ContentLength), testutil.ToFloat64(discardedBytes)-before)
-	})
-
-	t.Run("snappy compressed protobuf returns 413", func(t *testing.T) {
-		protoBytes, err := proto.Marshal(&logproto.PushRequest{
-			Streams: []logproto.Stream{
-				{
-					Labels:  `{foo="bar"}`,
-					Entries: []logproto.Entry{{Timestamp: time.Now(), Line: line}},
-				},
-			},
-		})
-		require.NoError(t, err)
-		body := snappy.Encode(nil, protoBytes)
-		require.Greater(t, len(body), distributors[0].cfg.MaxRecvMsgSize)
-
-		req := httptest.NewRequest(http.MethodPost, "/loki/api/v1/push", bytes.NewReader(body))
-		ctx := user.InjectOrgID(t.Context(), "test")
-		req = req.WithContext(ctx)
-		req.Header.Set("Content-Type", "application/x-protobuf")
-
-		// The metric is a global counter shared across tests, so measure the
-		// delta produced by this request rather than an absolute value.
-		discardedBytes := validation.DiscardedBytes.WithLabelValues(validation.RequestBodyTooLarge, "test", "", "", constants.Loki)
-		before := testutil.ToFloat64(discardedBytes)
-
-		rec := httptest.NewRecorder()
-		distributors[0].pushHandler(rec, req, push.ParseLokiRequest, push.HTTPError, constants.Loki)
-
-		require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
-		require.Equal(t, float64(req.ContentLength), testutil.ToFloat64(discardedBytes)-before)
-	})
-
-	t.Run("Loki JSON returns 413", func(t *testing.T) {
-		body := []byte(`{"streams":[{"stream":{"foo":"bar"},"values":[["1234567890000000000","` + line + `"]]}]}`)
-		require.Greater(t, len(body), distributors[0].cfg.MaxRecvMsgSize)
-
-		req := httptest.NewRequest(http.MethodPost, "/loki/api/v1/push", bytes.NewReader(body))
-		ctx := user.InjectOrgID(t.Context(), "test")
-		req = req.WithContext(ctx)
-		req.Header.Set("Content-Type", "application/json")
-
-		// The metric is a global counter shared across tests, so measure the
-		// delta produced by this request rather than an absolute value.
-		discardedBytes := validation.DiscardedBytes.WithLabelValues(validation.RequestBodyTooLarge, "test", "", "", constants.Loki)
-		before := testutil.ToFloat64(discardedBytes)
-
-		rec := httptest.NewRecorder()
-		distributors[0].pushHandler(rec, req, push.ParseLokiRequest, push.HTTPError, constants.Loki)
-
-		require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
-		require.Equal(t, float64(req.ContentLength), testutil.ToFloat64(discardedBytes)-before)
-	})
-
-	t.Run("OTLP JSON returns 413", func(t *testing.T) {
-		otlpLogs := plog.NewLogs()
-		rl := otlpLogs.ResourceLogs().AppendEmpty()
-		rl.Resource().Attributes().PutStr("service.name", "test-service")
-		lr := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
-		lr.Body().SetStr(line)
-		lr.SetTimestamp(pcommon.Timestamp(time.Now().UnixNano()))
-		body, err := plogotlp.NewExportRequestFromLogs(otlpLogs).MarshalJSON()
-		require.NoError(t, err)
-		require.Greater(t, len(body), distributors[0].cfg.MaxRecvMsgSize)
-
-		req := httptest.NewRequest(http.MethodPost, "/otlp/v1/logs", bytes.NewReader(body))
-		ctx := user.InjectOrgID(t.Context(), "test")
-		req = req.WithContext(ctx)
-		req.Header.Set("Content-Type", "application/json")
-
-		// The metric is a global counter shared across tests, so measure the
-		// delta produced by this request rather than an absolute value.
-		discardedBytes := validation.DiscardedBytes.WithLabelValues(validation.RequestBodyTooLarge, "test", "", "", constants.OTLP)
-		before := testutil.ToFloat64(discardedBytes)
-
-		rec := httptest.NewRecorder()
-		distributors[0].pushHandler(rec, req, push.ParseOTLPRequest, push.OTLPError, constants.OTLP)
-
-		require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
-		require.Equal(t, float64(req.ContentLength), testutil.ToFloat64(discardedBytes)-before)
-	})
-}
-
-func TestPushHandlerMaxDecompressedSize(t *testing.T) {
-	const line = "the quick brown fox jumps over the lazy dog"
-
-	limits := &validation.Limits{}
-	flagext.DefaultValues(limits)
-	limits.RejectOldSamples = false
-	distributors, _ := prepare(t, 1, 3, limits, nil)
-	distributors[0].cfg.MaxDecompressedSize = 10
+		}
+	}
 
 	withGzip := func(t *testing.T, b []byte) []byte {
 		t.Helper()
@@ -213,89 +106,129 @@ func TestPushHandlerMaxDecompressedSize(t *testing.T) {
 		return buf.Bytes()
 	}
 
-	t.Run("snappy compressed protobuf returns 413", func(t *testing.T) {
-		protoBytes, err := proto.Marshal(&logproto.PushRequest{
-			Streams: []logproto.Stream{
-				{
-					Labels:  `{foo="bar"}`,
-					Entries: []logproto.Entry{{Timestamp: time.Now(), Line: line}},
-				},
+	for _, tc := range []struct {
+		name            string
+		path            string
+		contentType     string
+		contentEncoding string
+		format          string
+		parser          push.RequestParser
+		errorWriter     push.ErrorWriter
+		buildBody       func(t *testing.T) []byte
+	}{
+		{
+			name:        "plain proto returns 413 because its over max size",
+			path:        "/loki/api/v1/push",
+			contentType: "application/x-protobuf",
+			format:      constants.Loki,
+			parser:      push.ParseLokiRequest,
+			errorWriter: push.HTTPError,
+			buildBody: func(_ *testing.T) []byte {
+				body, err := proto.Marshal(newPushRequest())
+				require.NoError(t, err)
+				return body
 			},
+		},
+		{
+			name:        "Plain JSON returns 413 because its over max size",
+			path:        "/loki/api/v1/push",
+			contentType: "application/json",
+			format:      constants.Loki,
+			parser:      push.ParseLokiRequest,
+			errorWriter: push.HTTPError,
+			buildBody: func(_ *testing.T) []byte {
+				return []byte(`{"streams":[{"stream":{"foo":"bar"},"values":[["1234567890000000000","` + line + `"]]}]}`)
+			},
+		},
+		{
+			name:        "Plain OTLP returns 413 because its over max size",
+			path:        "/otlp/v1/logs",
+			contentType: "application/json",
+			format:      constants.OTLP,
+			parser:      push.ParseOTLPRequest,
+			errorWriter: push.OTLPError,
+			buildBody: func(t *testing.T) []byte {
+				otlpLogs := plog.NewLogs()
+				rl := otlpLogs.ResourceLogs().AppendEmpty()
+				rl.Resource().Attributes().PutStr("service.name", "test-service")
+				lr := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+				lr.Body().SetStr(line)
+				lr.SetTimestamp(pcommon.Timestamp(time.Now().UnixNano()))
+				body, err := plogotlp.NewExportRequestFromLogs(otlpLogs).MarshalJSON()
+				require.NoError(t, err)
+				return body
+			},
+		},
+		{
+			name:        "snappy compressed protobuf returns 413 because the decompressed data is over max size",
+			path:        "/loki/api/v1/push",
+			contentType: "application/x-protobuf",
+			format:      constants.Loki,
+			parser:      push.ParseLokiRequest,
+			errorWriter: push.HTTPError,
+			buildBody: func(t *testing.T) []byte {
+				protoBytes, err := proto.Marshal(newPushRequest())
+				require.NoError(t, err)
+				return snappy.Encode(nil, protoBytes)
+			},
+		},
+		{
+			name:            "gzip compressed Loki JSON returns 413 because the decompressed size is over max size",
+			path:            "/loki/api/v1/push",
+			contentType:     "application/json",
+			contentEncoding: "gzip",
+			format:          constants.Loki,
+			parser:          push.ParseLokiRequest,
+			errorWriter:     push.HTTPError,
+			buildBody: func(t *testing.T) []byte {
+				lokiJSON := []byte(`{"streams":[{"stream":{"foo":"bar"},"values":[["1234567890000000000","` + line + `"]]}]}`)
+				return withGzip(t, lokiJSON)
+			},
+		},
+		{
+			name:            "gzip compressed OTLP JSON returns 413 because the decompressed size is over max size",
+			path:            "/otlp/v1/logs",
+			contentType:     "application/json",
+			contentEncoding: "gzip",
+			format:          constants.OTLP,
+			parser:          push.ParseOTLPRequest,
+			errorWriter:     push.OTLPError,
+			buildBody: func(t *testing.T) []byte {
+				otlpLogs := plog.NewLogs()
+				rl := otlpLogs.ResourceLogs().AppendEmpty()
+				rl.Resource().Attributes().PutStr("service.name", "test-service")
+				lr := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+				lr.Body().SetStr(line)
+				lr.SetTimestamp(pcommon.Timestamp(time.Now().UnixNano()))
+				otlpJSON, err := plogotlp.NewExportRequestFromLogs(otlpLogs).MarshalJSON()
+				require.NoError(t, err)
+				return withGzip(t, otlpJSON)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := tc.buildBody(t)
+
+			req := httptest.NewRequest(http.MethodPost, tc.path, bytes.NewReader(body))
+			ctx := user.InjectOrgID(t.Context(), "test")
+			req = req.WithContext(ctx)
+			req.Header.Set("Content-Type", tc.contentType)
+			if tc.contentEncoding != "" {
+				req.Header.Set("Content-Encoding", tc.contentEncoding)
+			}
+
+			// The metric is a global counter shared across tests, so measure the
+			// delta produced by this request rather than an absolute value.
+			discardedBytes := validation.DiscardedBytes.WithLabelValues(validation.RequestBodyTooLarge, "test", "", "", tc.format)
+			before := testutil.ToFloat64(discardedBytes)
+
+			rec := httptest.NewRecorder()
+			distributors[0].pushHandler(rec, req, tc.parser, tc.errorWriter, tc.format)
+
+			require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+			require.Equal(t, float64(req.ContentLength), testutil.ToFloat64(discardedBytes)-before)
 		})
-		require.NoError(t, err)
-		body := snappy.Encode(nil, protoBytes)
-		require.Greater(t, int64(len(protoBytes)), distributors[0].cfg.MaxDecompressedSize)
-
-		req := httptest.NewRequest(http.MethodPost, "/loki/api/v1/push", bytes.NewReader(body))
-		ctx := user.InjectOrgID(t.Context(), "test")
-		req = req.WithContext(ctx)
-		req.Header.Set("Content-Type", "application/x-protobuf")
-		req.Header.Set("Content-Encoding", "snappy")
-
-		// The metric is a global counter shared across tests, so measure the
-		// delta produced by this request rather than an absolute value.
-		discardedBytes := validation.DiscardedBytes.WithLabelValues(validation.RequestBodyTooLarge, "test", "", "", constants.Loki)
-		before := testutil.ToFloat64(discardedBytes)
-
-		rec := httptest.NewRecorder()
-		distributors[0].pushHandler(rec, req, push.ParseLokiRequest, push.HTTPError, constants.Loki)
-
-		require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
-		require.Equal(t, float64(req.ContentLength), testutil.ToFloat64(discardedBytes)-before)
-	})
-
-	t.Run("gzip compressed Loki JSON returns 413", func(t *testing.T) {
-		lokiJSON := []byte(`{"streams":[{"stream":{"foo":"bar"},"values":[["1234567890000000000","` + line + `"]]}]}`)
-		body := withGzip(t, lokiJSON)
-		require.Greater(t, int64(len(lokiJSON)), distributors[0].cfg.MaxDecompressedSize)
-
-		req := httptest.NewRequest(http.MethodPost, "/loki/api/v1/push", bytes.NewReader(body))
-		ctx := user.InjectOrgID(t.Context(), "test")
-		req = req.WithContext(ctx)
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Content-Encoding", "gzip")
-
-		// The metric is a global counter shared across tests, so measure the
-		// delta produced by this request rather than an absolute value.
-		discardedBytes := validation.DiscardedBytes.WithLabelValues(validation.RequestBodyTooLarge, "test", "", "", constants.Loki)
-		before := testutil.ToFloat64(discardedBytes)
-
-		rec := httptest.NewRecorder()
-		distributors[0].pushHandler(rec, req, push.ParseLokiRequest, push.HTTPError, constants.Loki)
-
-		require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
-		require.Equal(t, float64(req.ContentLength), testutil.ToFloat64(discardedBytes)-before)
-	})
-
-	t.Run("gzip compressed OTLP JSON returns 413", func(t *testing.T) {
-		otlpLogs := plog.NewLogs()
-		rl := otlpLogs.ResourceLogs().AppendEmpty()
-		rl.Resource().Attributes().PutStr("service.name", "test-service")
-		lr := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
-		lr.Body().SetStr(line)
-		lr.SetTimestamp(pcommon.Timestamp(time.Now().UnixNano()))
-		otlpJSON, err := plogotlp.NewExportRequestFromLogs(otlpLogs).MarshalJSON()
-		require.NoError(t, err)
-		body := withGzip(t, otlpJSON)
-		require.Greater(t, int64(len(otlpJSON)), distributors[0].cfg.MaxDecompressedSize)
-
-		req := httptest.NewRequest(http.MethodPost, "/otlp/v1/logs", bytes.NewReader(body))
-		ctx := user.InjectOrgID(t.Context(), "test")
-		req = req.WithContext(ctx)
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Content-Encoding", "gzip")
-
-		// The metric is a global counter shared across tests, so measure the
-		// delta produced by this request rather than an absolute value.
-		discardedBytes := validation.DiscardedBytes.WithLabelValues(validation.RequestBodyTooLarge, "test", "", "", constants.OTLP)
-		before := testutil.ToFloat64(discardedBytes)
-
-		rec := httptest.NewRecorder()
-		distributors[0].pushHandler(rec, req, push.ParseOTLPRequest, push.OTLPError, constants.OTLP)
-
-		require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
-		require.Equal(t, float64(req.ContentLength), testutil.ToFloat64(discardedBytes)-before)
-	})
+	}
 }
 
 func TestPushHandlerLogPushRequestStreams(t *testing.T) {

--- a/pkg/distributor/http_test.go
+++ b/pkg/distributor/http_test.go
@@ -83,7 +83,7 @@ func TestPushHandlerMaxPushSize(t *testing.T) {
 	flagext.DefaultValues(limits)
 	limits.RejectOldSamples = false
 	distributors, _ := prepare(t, 1, 3, limits, nil)
-	distributors[0].cfg.MaxPushSize = 1000
+	distributors[0].cfg.MaxPushSizeBytes = 1000
 
 	newPushRequest := func() *logproto.PushRequest {
 		return &logproto.PushRequest{

--- a/tools/deprecated-config-checker/deleted-config.yaml
+++ b/tools/deprecated-config-checker/deleted-config.yaml
@@ -4,6 +4,10 @@
 
 legacy-read-mode: "Legacy read SSD mode is deprecated and will be eventually removed. Use the new read and backend targets."
 
+distributor:
+  max_recv_msg_size: "Replaced by max_push_size which includes both max_recv_msg_size and max_decompressed_size."
+  max_decompressed_size: "Replaced by max_push_size which includes both max_recv_msg_size and max_decompressed_size."
+
 ingester:
   max_transfer_retries: "Enable the ingester WAL and rely on new ingesters to replay the WAL."
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit collapses the max-recv-msg-size, which measures the size of the HTTP request body, and the max decompressed size (i.e. if the request has been Gzip or Snappy compressed) into a single flag.

As far as Loki is concerned, we only care about the maximum size of the actual logproto that is parsed out of the request after any decompression. It doesn't make sense to have two different flags for this with the same value.

You will notice that in http.go we pass the same flag twice to push.ParseRequest. This is temporary, and the only reason for it is to make the diff smaller and easier to review.

We will remove the two options completely in a future commit.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
