### PR TITLE
fix(docker-driver): Bound log frame size and restore stream cleanup

### DIFF
--- a/clients/cmd/docker-driver/driver.go
+++ b/clients/cmd/docker-driver/driver.go
@@ -39,21 +39,25 @@ type logPair struct {
 	folder string
 	// keep created files after stopping the container.
 	keepFile bool
+
+	closeOnce sync.Once
 }
 
 func (l *logPair) Close() {
-	if err := l.stream.Close(); err != nil {
-		level.Error(l.logger).Log("msg", "error while closing fifo stream", "err", err)
-	}
-	if err := l.lokil.Close(); err != nil {
-		level.Error(l.logger).Log("msg", "error while closing loki logger", "err", err)
-	}
-	if l.jsonl == nil {
-		return
-	}
-	if err := l.jsonl.Close(); err != nil {
-		level.Error(l.logger).Log("msg", "error while closing json logger", "err", err)
-	}
+	l.closeOnce.Do(func() {
+		if err := l.stream.Close(); err != nil {
+			level.Error(l.logger).Log("msg", "error while closing fifo stream", "err", err)
+		}
+		if err := l.lokil.Close(); err != nil {
+			level.Error(l.logger).Log("msg", "error while closing loki logger", "err", err)
+		}
+		if l.jsonl == nil {
+			return
+		}
+		if err := l.jsonl.Close(); err != nil {
+			level.Error(l.logger).Log("msg", "error while closing json logger", "err", err)
+		}
+	})
 }
 
 func newDriver(logger log.Logger) *driver {
@@ -107,7 +111,15 @@ func (d *driver) StartLogging(file string, logCtx logger.Info) error {
 	}
 
 	d.mu.Lock()
-	lf := &logPair{jsonl, lokil, f, logCtx, d.logger, folder, keepFile}
+	lf := &logPair{
+		jsonl:    jsonl,
+		lokil:    lokil,
+		stream:   f,
+		info:     logCtx,
+		logger:   d.logger,
+		folder:   folder,
+		keepFile: keepFile,
+	}
 	d.logs[file] = lf
 	d.idx[logCtx.ContainerID] = lf
 	d.mu.Unlock()
@@ -136,6 +148,7 @@ func (d *driver) StopLogging(file string) {
 
 func consumeLog(lf *logPair) {
 	dec := logdriver.NewLogEntryDecoder(lf.stream)
+	defer lf.Close()
 	var buf logdriver.LogEntry
 	for {
 		if err := dec.Decode(&buf); err != nil {
@@ -143,8 +156,17 @@ func consumeLog(lf *logPair) {
 				level.Debug(lf.logger).Log("msg", "shutting down log logger", "id", lf.info.ContainerID, "err", err)
 				return
 			}
-			dec = logdriver.NewLogEntryDecoder(lf.stream)
-			continue
+			if errors.Is(err, logdriver.ErrPayloadUnmarshal) {
+				// The frame was consumed in full, so the stream is still
+				// aligned: drop this entry and carry on.
+				level.Warn(lf.logger).Log("msg", "skipping undecodable log entry", "id", lf.info.ContainerID, "err", err)
+				buf.Reset()
+				continue
+			}
+			// Any other failure leaves the stream at an unknown offset, and the
+			// framing gives us nothing to resynchronise against.
+			level.Error(lf.logger).Log("msg", "error decoding log entry, shutting down log logger", "id", lf.info.ContainerID, "err", err)
+			return
 		}
 		var msg logger.Message
 		msg.Line = buf.Line

--- a/clients/cmd/docker-driver/driver_test.go
+++ b/clients/cmd/docker-driver/driver_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/moby/moby/v2/daemon/logger"
+
+	"github.com/grafana/loki/v3/clients/cmd/docker-driver/logdriver"
+)
+
+type recordingLogger struct {
+	mu     sync.Mutex
+	lines  []string
+	closes int
+}
+
+func (r *recordingLogger) Log(m *logger.Message) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.lines = append(r.lines, string(m.Line))
+	return nil
+}
+
+func (r *recordingLogger) Name() string { return "recording" }
+
+func (r *recordingLogger) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.closes++
+	return nil
+}
+
+type countingStream struct {
+	io.Reader
+	closes int
+}
+
+func (c *countingStream) Close() error {
+	c.closes++
+	return nil
+}
+
+// StopLogging and consumeLog can both reach Close, so it must be safe to call
+// more than once.
+func TestLogPairCloseIsIdempotent(t *testing.T) {
+	lokil := &recordingLogger{}
+	jsonl := &recordingLogger{}
+	stream := &countingStream{Reader: bytes.NewReader(nil)}
+	lf := &logPair{lokil: lokil, jsonl: jsonl, stream: stream, logger: log.NewNopLogger()}
+
+	lf.Close()
+	lf.Close()
+	lf.Close()
+
+	if stream.closes != 1 {
+		t.Errorf("stream closed %d times, want 1", stream.closes)
+	}
+	if lokil.closes != 1 {
+		t.Errorf("loki logger closed %d times, want 1", lokil.closes)
+	}
+	if jsonl.closes != 1 {
+		t.Errorf("json logger closed %d times, want 1", jsonl.closes)
+	}
+}
+
+// A frame whose payload will not unmarshal was still read in full, so the
+// consumer must skip it and keep shipping the frames that follow.
+func TestConsumeLogSkipsUndecodablePayload(t *testing.T) {
+	var buf bytes.Buffer
+
+	// Field 1 declared as varint where LogEntry.Line expects bytes.
+	bad := []byte{0x08, 0x80}
+	header := make([]byte, 4)
+	binary.BigEndian.PutUint32(header, uint32(len(bad)))
+	buf.Write(header)
+	buf.Write(bad)
+
+	for _, line := range []string{"first survivor", "second survivor"} {
+		if err := logdriver.NewLogEntryEncoder(&buf).Encode(&logdriver.LogEntry{
+			Line:     []byte(line),
+			Source:   "stdout",
+			TimeNano: 1,
+		}); err != nil {
+			t.Fatalf("Encode: %v", err)
+		}
+	}
+
+	lokil := &recordingLogger{}
+	stream := &countingStream{Reader: bytes.NewReader(buf.Bytes())}
+	lf := &logPair{
+		lokil:  lokil,
+		stream: stream,
+		info:   logger.Info{ContainerID: "abc"},
+		logger: log.NewNopLogger(),
+	}
+
+	consumeLog(lf)
+
+	want := []string{"first survivor", "second survivor"}
+	if len(lokil.lines) != len(want) {
+		t.Fatalf("shipped %d lines (%q), want %d after skipping one bad frame", len(lokil.lines), lokil.lines, len(want))
+	}
+	for i, line := range want {
+		if lokil.lines[i] != line {
+			t.Errorf("line %d = %q, want %q", i, lokil.lines[i], line)
+		}
+	}
+
+	// consumeLog owns cleanup on the way out.
+	if stream.closes != 1 {
+		t.Errorf("stream closed %d times, want 1: consumeLog must close the logPair", stream.closes)
+	}
+}
+
+// An oversized frame leaves the stream at an unknown offset, so the consumer
+// must stop rather than carry on misaligned.
+func TestConsumeLogStopsOnFramingError(t *testing.T) {
+	var buf bytes.Buffer
+	header := make([]byte, 4)
+	binary.BigEndian.PutUint32(header, 1e6+1)
+	buf.Write(header)
+	buf.Write(bytes.Repeat([]byte("z"), 64))
+
+	// A valid frame after it must NOT be shipped: alignment is already lost.
+	if err := logdriver.NewLogEntryEncoder(&buf).Encode(&logdriver.LogEntry{Line: []byte("unreachable")}); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	lokil := &recordingLogger{}
+	stream := &countingStream{Reader: bytes.NewReader(buf.Bytes())}
+	lf := &logPair{
+		lokil:  lokil,
+		stream: stream,
+		info:   logger.Info{ContainerID: "abc"},
+		logger: log.NewNopLogger(),
+	}
+
+	consumeLog(lf)
+
+	if len(lokil.lines) != 0 {
+		t.Errorf("shipped %q after a framing error, want nothing", lokil.lines)
+	}
+	if stream.closes != 1 {
+		t.Errorf("stream closed %d times, want 1", stream.closes)
+	}
+}

--- a/clients/cmd/docker-driver/logdriver/io.go
+++ b/clients/cmd/docker-driver/logdriver/io.go
@@ -2,12 +2,26 @@ package logdriver
 
 import (
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
 
 	"github.com/gogo/protobuf/proto"
 )
 
+// ErrPayloadUnmarshal reports a frame whose payload could not be unmarshalled.
+// The frame was read in full first, so the stream is still aligned on a frame
+// boundary and decoding can continue with the next one. Every other Decode
+// error leaves the offset unknown.
+var ErrPayloadUnmarshal = errors.New("log entry payload could not be unmarshalled")
+
 const binaryEncodeLen = 4
+
+// maxFrameSize bounds the payload a single frame may declare. Decode sizes its
+// buffer from the length prefix before any protobuf validation, so without this
+// a corrupt frame forces an arbitrary allocation. Matches the limit the
+// gogo/protobuf reader this replaced was constructed with.
+const maxFrameSize uint32 = 1e6
 
 // LogEntryEncoder encodes a LogEntry to a protobuf stream.
 // The stream format is [uint32 big-endian size][protobuf message].
@@ -68,7 +82,13 @@ func (d *logEntryDecoder) Decode(l *LogEntry) error {
 		return err
 	}
 
-	size := int(binary.BigEndian.Uint32(d.lenBuf))
+	// Compared as uint32: on a 32-bit build int(size) would wrap negative and
+	// slip past the bound.
+	frameSize := binary.BigEndian.Uint32(d.lenBuf)
+	if frameSize > maxFrameSize {
+		return fmt.Errorf("log entry frame size %d exceeds maximum %d", frameSize, maxFrameSize)
+	}
+	size := int(frameSize)
 	if len(d.buf) < size {
 		d.buf = make([]byte, size)
 	}
@@ -76,5 +96,8 @@ func (d *logEntryDecoder) Decode(l *LogEntry) error {
 	if _, err := io.ReadFull(d.r, d.buf[:size]); err != nil {
 		return err
 	}
-	return proto.Unmarshal(d.buf[:size], l)
+	if err := proto.Unmarshal(d.buf[:size], l); err != nil {
+		return fmt.Errorf("%w: %w", ErrPayloadUnmarshal, err)
+	}
+	return nil
 }

--- a/clients/cmd/docker-driver/logdriver/io_test.go
+++ b/clients/cmd/docker-driver/logdriver/io_test.go
@@ -1,0 +1,139 @@
+package logdriver
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	enc := NewLogEntryEncoder(&buf)
+
+	want := []string{"first line", "second line", strings.Repeat("x", 8192)}
+	for _, line := range want {
+		if err := enc.Encode(&LogEntry{Line: []byte(line), Source: "stdout", TimeNano: 42}); err != nil {
+			t.Fatalf("Encode(%.10q): %v", line, err)
+		}
+	}
+
+	dec := NewLogEntryDecoder(&buf)
+	for _, line := range want {
+		var got LogEntry
+		if err := dec.Decode(&got); err != nil {
+			t.Fatalf("Decode(%.10q): %v", line, err)
+		}
+		if string(got.Line) != line {
+			t.Errorf("Line = %.20q, want %.20q", got.Line, line)
+		}
+		if got.Source != "stdout" || got.TimeNano != 42 {
+			t.Errorf("Source/TimeNano = %q/%d, want stdout/42", got.Source, got.TimeNano)
+		}
+	}
+
+	var extra LogEntry
+	if err := dec.Decode(&extra); err != io.EOF {
+		t.Errorf("Decode after last entry = %v, want io.EOF", err)
+	}
+}
+
+// A frame length prefix is attacker- or corruption-controlled, so the decoder
+// must reject an oversized one rather than allocate what it asks for.
+func TestDecodeRejectsOversizedFrame(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		size uint32
+	}{
+		{"just over the limit", maxFrameSize + 1},
+		{"four gigabytes", ^uint32(0)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			header := make([]byte, binaryEncodeLen)
+			binary.BigEndian.PutUint32(header, tc.size)
+			buf.Write(header)
+
+			var got LogEntry
+			err := NewLogEntryDecoder(&buf).Decode(&got)
+			if err == nil {
+				t.Fatalf("Decode(size=%d) = nil, want an error", tc.size)
+			}
+			if !strings.Contains(err.Error(), "exceeds maximum") {
+				t.Errorf("Decode(size=%d) = %v, want a frame-size error", tc.size, err)
+			}
+		})
+	}
+}
+
+func TestDecodeAcceptsFrameAtLimit(t *testing.T) {
+	var buf bytes.Buffer
+	if err := NewLogEntryEncoder(&buf).Encode(&LogEntry{Line: bytes.Repeat([]byte("y"), int(maxFrameSize)-64)}); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	var got LogEntry
+	if err := NewLogEntryDecoder(&buf).Decode(&got); err != nil {
+		t.Fatalf("Decode of a frame under the limit: %v", err)
+	}
+	if len(got.Line) != int(maxFrameSize)-64 {
+		t.Errorf("len(Line) = %d, want %d", len(got.Line), int(maxFrameSize)-64)
+	}
+}
+
+// A payload that fails to unmarshal has still been read in full, so the stream
+// stays aligned and the next frame must decode normally.
+func TestDecodeRecoversAfterBadPayload(t *testing.T) {
+	var buf bytes.Buffer
+
+	// A frame whose payload is not a valid LogEntry: field 1 is declared as
+	// varint where LogEntry.Line expects bytes.
+	bad := []byte{0x08, 0x80}
+	header := make([]byte, binaryEncodeLen)
+	binary.BigEndian.PutUint32(header, uint32(len(bad)))
+	buf.Write(header)
+	buf.Write(bad)
+
+	if err := NewLogEntryEncoder(&buf).Encode(&LogEntry{Line: []byte("after the bad frame")}); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	dec := NewLogEntryDecoder(&buf)
+
+	var first LogEntry
+	err := dec.Decode(&first)
+	if err == nil {
+		t.Fatal("Decode of the bad payload = nil, want an error")
+	}
+	if !errors.Is(err, ErrPayloadUnmarshal) {
+		t.Fatalf("Decode of the bad payload = %v, want ErrPayloadUnmarshal so the caller can recover", err)
+	}
+
+	var second LogEntry
+	if err := dec.Decode(&second); err != nil {
+		t.Fatalf("Decode of the frame after a bad payload: %v", err)
+	}
+	if string(second.Line) != "after the bad frame" {
+		t.Errorf("Line = %q, want %q", second.Line, "after the bad frame")
+	}
+}
+
+// An oversized frame is fatal: the declared length was never consumed, so the
+// caller must not treat it as recoverable.
+func TestOversizedFrameIsNotRecoverable(t *testing.T) {
+	var buf bytes.Buffer
+	header := make([]byte, binaryEncodeLen)
+	binary.BigEndian.PutUint32(header, maxFrameSize+1)
+	buf.Write(header)
+
+	var got LogEntry
+	err := NewLogEntryDecoder(&buf).Decode(&got)
+	if err == nil {
+		t.Fatal("Decode = nil, want an error")
+	}
+	if errors.Is(err, ErrPayloadUnmarshal) {
+		t.Errorf("Decode = %v, must not be ErrPayloadUnmarshal: stream alignment is unknown", err)
+	}
+}


### PR DESCRIPTION
This PR hardens the docker logging plugin's frame decoder and restores the stream cleanup it lost when the driver moved from `github.com/docker/docker` to `github.com/moby/moby/v2` in #22034.

## The problems

**Unbounded allocation.** That migration replaced gogo/protobuf's `Uint32DelimitedReader`, which was constructed with a `1e6` max message size, with a local length-prefixed codec carrying no bound at all. `Decode` sized its read buffer straight off the 4-byte prefix, so a corrupt frame could ask for a 4GiB allocation and exhaust the memory.

**Leaked resources.** The migration also lost `consumeLog`'s `defer lf.Close()`. If the fifo stream dies before `StopLogging` runs, the fifo, the Loki client and the json logger are all left open.

**Error handling.** Error recovery cannot resynchronise a length-prefixed stream, so with a frame cap in place we don't retry but return a hard error.

## The fix

- Reject frames declaring more than `1e6` bytes before sizing the buffer. The prefix is compared as a `uint32`, because `int(...)` wraps negative on a 32-bit build and would slip straight past the bound into a panicking slice expression.
- Return `ErrPayloadUnmarshal` for a payload that will not unmarshal, so `consumeLog` can skip that frame and carry on. Every other decode error leaves the offset unknown and still shuts the consumer down.
- Restore the deferred `logPair.Close()`, guarded with a `sync.Once` since both `consumeLog` and `StopLogging` can now reach it.

## Testing

`logdriver` new tests cover round-trip encoding, an oversized prefix (just-over-limit and 4GiB), a frame at the limit, recovery after a bad payload, and that an oversized frame is *not* reported as recoverable. On the driver side there are tests for `Close` idempotency, for skipping a bad payload while still shipping the frames either side of it, and for stopping dead on a framing error.

