### PR TITLE
chore: Remove dead code relating to blooms in Gateway.GetShards

### DIFF
--- a/pkg/indexgateway/gateway.go
+++ b/pkg/indexgateway/gateway.go
@@ -415,7 +415,7 @@ func (g *Gateway) boundedShards(
 
 	start := time.Now()
 
-	// 1) for all bounds, get chunk refs
+	// For all bounds, get chunk refs
 	refs, err := g.indexQuerier.GetChunkRefsWithSizingInfo(ctx, instanceID, req.From, req.Through, p)
 	if err != nil {
 		return err
@@ -427,39 +427,15 @@ func (g *Gateway) boundedShards(
 		attribute.Int("index_chunks_resolved", ct),
 	))
 
-	filtered := refs
-
-	// 2) filter via blooms if enabled
-	filters := v1.ExtractTestableLabelMatchers(p.Plan().AST)
-	// NOTE(chaudum): Temporarily disable bloom filtering of chunk refs,
-	// as this doubles the load on bloom gateways.
-	// if g.bloomQuerier != nil && len(filters) > 0 {
-	// 	xs, err := g.bloomQuerier.FilterChunkRefs(ctx, instanceID, req.From, req.Through, refs, p.Plan())
-	// 	if err != nil {
-	// 		level.Error(logger).Log("msg", "failed to filter chunk refs", "err", err)
-	// 	} else {
-	// 		filtered = xs
-	// 	}
-	// 	sp.LogKV(
-	// 		"stage", "queried bloom gateway",
-	// 		"err", err,
-	// 	)
-	// }
-
-	g.metrics.preFilterChunks.WithLabelValues(routeShards).Observe(float64(ct))
-	g.metrics.postFilterChunks.WithLabelValues(routeShards).Observe(float64(len(filtered)))
-
 	resp := &logproto.ShardsResponse{}
-
-	// Edge case: if there are no chunks after filtering, we still need to return a single shard
-	if len(filtered) == 0 {
+	if len(refs) == 0 {
+		// Edge case: if there are no chunks, we still need to return a single shard
 		resp.Shards = []logproto.Shard{
 			{
 				Bounds: logproto.FPBounds{Min: 0, Max: math.MaxUint64},
 				Stats:  &logproto.IndexStatsResponse{},
 			},
 		}
-
 	} else {
 		shards, chunkGrps, err := accumulateChunksToShards(req, refs)
 		if err != nil {
@@ -487,7 +463,6 @@ func (g *Gateway) boundedShards(
 	level.Debug(logger).Log(
 		"msg", "send shards response",
 		"total_chunks", ct,
-		"post_filter_chunks", len(filtered),
 		"shards", len(resp.Shards),
 		"query", req.Query,
 		"target_bytes_per_shard", datasize.ByteSize(req.TargetBytesPerShard).HumanReadable(),
@@ -497,23 +472,20 @@ func (g *Gateway) boundedShards(
 		"through", req.Through.Time().String(),
 		"length", req.Through.Time().Sub(req.From.Time()).String(),
 		"end_delta", time.Since(req.Through.Time()).String(),
-		"filters", len(filters),
 	)
 
 	// Populate index statistics for metrics logging
 	resp.Statistics.Index.TotalChunks = int64(ct)
-	resp.Statistics.Index.PostFilterChunks = int64(len(filtered))
 	// compute unique streams matched post-filtering
 	{
 		seen := make(map[model.Fingerprint]struct{}, 1024)
-		for _, ref := range filtered {
+		for _, ref := range refs {
 			seen[model.Fingerprint(ref.Fingerprint)] = struct{}{}
 		}
 		resp.Statistics.Index.TotalStreams = int64(len(seen))
 	}
 	resp.Statistics.Index.ShardsDuration = int64(time.Since(start))
 
-	// 3) build shards
 	return server.Send(resp)
 }
 

--- a/pkg/indexgateway/gateway.go
+++ b/pkg/indexgateway/gateway.go
@@ -427,6 +427,9 @@ func (g *Gateway) boundedShards(
 		attribute.Int("index_chunks_resolved", ct),
 	))
 
+	g.metrics.preFilterChunks.WithLabelValues(routeShards).Observe(float64(ct))
+	g.metrics.postFilterChunks.WithLabelValues(routeShards).Observe(float64(ct))
+
 	resp := &logproto.ShardsResponse{}
 	if len(refs) == 0 {
 		// Edge case: if there are no chunks, we still need to return a single shard
@@ -476,6 +479,7 @@ func (g *Gateway) boundedShards(
 
 	// Populate index statistics for metrics logging
 	resp.Statistics.Index.TotalChunks = int64(ct)
+	resp.Statistics.Index.PostFilterChunks = int64(ct)
 	// compute unique streams matched post-filtering
 	{
 		seen := make(map[model.Fingerprint]struct{}, 1024)

--- a/pkg/indexgateway/gateway_test.go
+++ b/pkg/indexgateway/gateway_test.go
@@ -6,14 +6,17 @@ import (
 	"testing"
 
 	"github.com/grafana/dskit/user"
+	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/mock"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/stretchr/testify/require"
 
 	v2 "github.com/grafana/loki/v3/pkg/iter/v2"
 	"github.com/grafana/loki/v3/pkg/logproto"
+	"github.com/grafana/loki/v3/pkg/logqlmodel/stats"
 	tsdb_index "github.com/grafana/loki/v3/pkg/storage/stores/shipper/indexshipper/tsdb/index"
 	util_test "github.com/grafana/loki/v3/pkg/util"
 	util_log "github.com/grafana/loki/v3/pkg/util/log"
@@ -66,6 +69,38 @@ func (i *indexQuerierMock) Volume(_ context.Context, userID string, from, throug
 	}
 
 	return args.Get(0).(*logproto.VolumeResponse), args.Error(1)
+}
+
+func (i *indexQuerierMock) HasChunkSizingInfo(from, through model.Time) bool {
+	args := i.Called(from, through)
+	return args.Bool(0)
+}
+
+func (i *indexQuerierMock) GetShards(
+	_ context.Context,
+	userID string,
+	from, through model.Time,
+	targetBytesPerShard uint64,
+	_ chunk.Predicate,
+) (*logproto.ShardsResponse, error) {
+	args := i.Called(userID, from, through, targetBytesPerShard)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*logproto.ShardsResponse), args.Error(1)
+}
+
+func (i *indexQuerierMock) GetChunkRefsWithSizingInfo(
+	_ context.Context,
+	userID string,
+	from, through model.Time,
+	_ chunk.Predicate,
+) ([]logproto.ChunkRefWithSizingInfo, error) {
+	args := i.Called(userID, from, through)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]logproto.ChunkRefWithSizingInfo), args.Error(1)
 }
 
 // Tests for various cases of the `refWithSizingInfo.Cmp` function
@@ -289,4 +324,286 @@ func TestAccumulateChunksToShards(t *testing.T) {
 	}
 	require.Equal(t, len(exp), len(shards))
 
+}
+
+type mockGetShardsServer struct {
+	ctx  context.Context
+	sent []*logproto.ShardsResponse
+}
+
+var _ logproto.IndexGateway_GetShardsServer = (*mockGetShardsServer)(nil)
+
+func (s *mockGetShardsServer) Send(response *logproto.ShardsResponse) error {
+	s.sent = append(s.sent, response)
+	return nil
+}
+
+func (s *mockGetShardsServer) Context() context.Context { return s.ctx }
+
+func (s *mockGetShardsServer) SetHeader(_ metadata.MD) error  { panic("unused") }
+func (s *mockGetShardsServer) SendHeader(_ metadata.MD) error { panic("unused") }
+func (s *mockGetShardsServer) SetTrailer(_ metadata.MD)       { panic("unused") }
+func (s *mockGetShardsServer) SendMsg(_ any) error            { panic("unused") }
+func (s *mockGetShardsServer) RecvMsg(_ any) error            { panic("unused") }
+
+// sendShards runs a shard request against a gateway backed by indexQuerier and returns the
+// single response it streamed back.
+func sendShards(t *testing.T, indexQuerier IndexQuerier, tenant string, precomputeChunks bool, req *logproto.ShardsRequest) *logproto.ShardsResponse {
+	t.Helper()
+
+	gateway, err := NewIndexGateway(Config{}, mockLimits{precomputeChunks: precomputeChunks}, util_log.Logger, nil, indexQuerier, nil, nil)
+	require.NoError(t, err)
+
+	server := &mockGetShardsServer{ctx: user.InjectOrgID(context.Background(), tenant)}
+	require.NoError(t, gateway.GetShards(req, server))
+	require.Len(t, server.sent, 1)
+
+	return server.sent[0]
+}
+
+func TestGetShards(t *testing.T) {
+	const (
+		tenant = "fake"
+		query  = `{service_name=~".+"}`
+
+		// Every chunk in the fixtures below carries the same number of entries; only
+		// the byte size varies, since that is what drives sharding.
+		chunkEntries = 10
+
+		// Shard sizes are accumulated from per-chunk KB, so express the target the same
+		// way and derive the chunk sizes from it.
+		targetKB            = 100
+		targetBytesPerShard = targetKB << 10
+
+		smallChunkKB = 4
+	)
+
+	var (
+		from    = model.Time(1000)
+		through = model.Time(2000)
+
+		// Fingerprints of the streams used by the multi-shard fixture
+		fpA = model.Fingerprint(1)
+		fpB = fpA + 1
+		fpC = fpB + 1
+	)
+
+	mkRef := func(fp model.Fingerprint, checksum, kb uint32) logproto.ChunkRefWithSizingInfo {
+		return logproto.ChunkRefWithSizingInfo{
+			ChunkRef: logproto.ChunkRef{
+				Fingerprint: uint64(fp),
+				UserID:      tenant,
+				From:        from,
+				Through:     through,
+				Checksum:    checksum,
+			},
+			KB:      kb,
+			Entries: chunkEntries,
+		}
+	}
+
+	// When the index matches nothing, the gateway still has to answer with a shard so the
+	// querier has something to execute against.
+	noStreamRefs := []logproto.ChunkRefWithSizingInfo{}
+
+	noStreamShards := []logproto.Shard{
+		{
+			Bounds: logproto.FPBounds{Min: 0, Max: math.MaxUint64},
+			Stats:  &logproto.IndexStatsResponse{},
+		},
+	}
+
+	// A single small stream, which fits in one shard covering the whole keyspace.
+	oneStreamChunk := mkRef(fpA, 1, smallChunkKB)
+	oneStreamRefs := []logproto.ChunkRefWithSizingInfo{oneStreamChunk}
+
+	oneStreamShards := []logproto.Shard{
+		{
+			Bounds: logproto.FPBounds{Min: 0, Max: math.MaxUint64},
+			Stats: &logproto.IndexStatsResponse{
+				Streams: 1,
+				Chunks:  1,
+				Bytes:   smallChunkKB << 10,
+				Entries: chunkEntries,
+			},
+		},
+	}
+
+	oneStreamGroups := []logproto.ChunkRefGroup{
+		{Refs: []*logproto.ChunkRef{&oneStreamChunk.ChunkRef}},
+	}
+
+	// Three streams, each exactly the size of a whole shard, so none of them can share
+	// one. The refs must be ordered by fingerprint, as the index returns them.
+	streamAChunk1 := mkRef(fpA, 1, targetKB/2)
+	streamAChunk2 := mkRef(fpA, 2, targetKB/2)
+	streamBChunk := mkRef(fpB, 1, targetKB)
+	streamCChunk := mkRef(fpC, 1, targetKB)
+	manyStreamRefs := []logproto.ChunkRefWithSizingInfo{streamAChunk1, streamAChunk2, streamBChunk, streamCChunk}
+
+	manyStreamShards := []logproto.Shard{
+		{
+			// Starts at the beginning of the keyspace and stops just short of the next stream.
+			Bounds: logproto.FPBounds{Min: 0, Max: fpB - 1},
+			Stats: &logproto.IndexStatsResponse{
+				Streams: 1,
+				Chunks:  2,
+				Bytes:   targetBytesPerShard,
+				Entries: 2 * chunkEntries,
+			},
+		},
+		{
+			Bounds: logproto.FPBounds{Min: fpB, Max: fpC - 1},
+			Stats: &logproto.IndexStatsResponse{
+				Streams: 1,
+				Chunks:  1,
+				Bytes:   targetBytesPerShard,
+				Entries: chunkEntries,
+			},
+		},
+		{
+			// The last shard always extends to the end of the keyspace.
+			Bounds: logproto.FPBounds{Min: fpC, Max: math.MaxUint64},
+			Stats: &logproto.IndexStatsResponse{
+				Streams: 1,
+				Chunks:  1,
+				Bytes:   targetBytesPerShard,
+				Entries: chunkEntries,
+			},
+		},
+	}
+
+	// One group per shard, holding that shard's chunks.
+	manyStreamGroups := []logproto.ChunkRefGroup{
+		{Refs: []*logproto.ChunkRef{&streamAChunk1.ChunkRef, &streamAChunk2.ChunkRef}},
+		{Refs: []*logproto.ChunkRef{&streamBChunk.ChunkRef}},
+		{Refs: []*logproto.ChunkRef{&streamCChunk.ChunkRef}},
+	}
+
+	for _, tc := range []struct {
+		desc             string
+		refs             []logproto.ChunkRefWithSizingInfo
+		precomputeChunks bool
+		expectedShards   []logproto.Shard
+		expectedGroups   []logproto.ChunkRefGroup
+	}{
+		{
+			desc:             "no chunks yields a single empty shard covering the whole keyspace",
+			refs:             noStreamRefs,
+			precomputeChunks: true,
+			expectedShards:   noStreamShards,
+			expectedGroups:   nil,
+		},
+		{
+			desc:             "single shard, chunk refs are discarded when precomputing is disabled",
+			refs:             oneStreamRefs,
+			precomputeChunks: false,
+			expectedShards:   oneStreamShards,
+			expectedGroups:   nil,
+		},
+		{
+			desc:             "single shard, chunk refs are returned alongside the shards when precomputing is enabled",
+			refs:             oneStreamRefs,
+			precomputeChunks: true,
+			expectedShards:   oneStreamShards,
+			expectedGroups:   oneStreamGroups,
+		},
+		{
+			desc:             "multiple shards, chunk refs are discarded when precomputing is disabled",
+			refs:             manyStreamRefs,
+			precomputeChunks: false,
+			expectedShards:   manyStreamShards,
+			expectedGroups:   nil,
+		},
+		{
+			desc:             "multiple shards, chunk refs are grouped per shard when precomputing is enabled",
+			refs:             manyStreamRefs,
+			precomputeChunks: true,
+			expectedShards:   manyStreamShards,
+			expectedGroups:   manyStreamGroups,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			indexQuerier := newIngesterQuerierMock()
+			indexQuerier.On("HasChunkSizingInfo", from, through).Return(true)
+			indexQuerier.On("GetChunkRefsWithSizingInfo", tenant, from, through).Return(tc.refs, nil)
+
+			resp := sendShards(t, indexQuerier, tenant, tc.precomputeChunks, &logproto.ShardsRequest{
+				From:                from,
+				Through:             through,
+				Query:               query,
+				TargetBytesPerShard: targetBytesPerShard,
+			})
+
+			require.Equal(t, tc.expectedShards, resp.Shards)
+			require.Equal(t, tc.expectedGroups, resp.ChunkGroups)
+
+			// Every stream lands in exactly one shard, so the index-level stream count
+			// must add up to the per-shard counts.
+			var expectedStreams int64
+			for _, shard := range tc.expectedShards {
+				expectedStreams += int64(shard.Stats.Streams)
+			}
+
+			require.Equal(t, int64(len(tc.refs)), resp.Statistics.Index.TotalChunks)
+			require.Equal(t, expectedStreams, resp.Statistics.Index.TotalStreams)
+			require.Positive(t, resp.Statistics.Index.ShardsDuration)
+
+			indexQuerier.AssertExpectations(t)
+		})
+	}
+}
+
+// When the index has no chunk sizing info the gateway can't compute shards itself, so it
+// delegates to the index querier and forwards that response untouched.
+func TestGetShardsWithoutChunkSizingInfo(t *testing.T) {
+	const (
+		tenant              = "fake"
+		query               = `{service_name=~".+"}`
+		targetBytesPerShard = 100 << 10
+	)
+
+	var (
+		from    = model.Time(1000)
+		through = model.Time(2000)
+	)
+
+	// The response the index querier computed on the gateway's behalf. Its contents are
+	// arbitrary, all the test cares about is
+	// that they come back unchanged.
+	// It is built by a constructor so the querier's copy and the expected copy are
+	// distinct objects.
+	fallbackResponse := func() *logproto.ShardsResponse {
+		return &logproto.ShardsResponse{
+			Shards: []logproto.Shard{
+				{
+					Bounds: logproto.FPBounds{Min: 0, Max: math.MaxUint64},
+					Stats:  &logproto.IndexStatsResponse{Streams: 1, Chunks: 2},
+				},
+			},
+			ChunkGroups: []logproto.ChunkRefGroup{
+				{Refs: []*logproto.ChunkRef{{Checksum: 1}}},
+			},
+			Statistics: stats.Result{
+				Index: stats.Index{TotalChunks: 2, TotalStreams: 1},
+			},
+		}
+	}
+
+	indexQuerier := newIngesterQuerierMock()
+	indexQuerier.On("HasChunkSizingInfo", from, through).Return(false)
+	indexQuerier.On("GetShards", tenant, from, through, uint64(targetBytesPerShard)).Return(fallbackResponse(), nil)
+
+	resp := sendShards(t, indexQuerier, tenant, false, &logproto.ShardsRequest{
+		From:                from,
+		Through:             through,
+		Query:               query,
+		TargetBytesPerShard: targetBytesPerShard,
+	})
+
+	require.Equal(t, fallbackResponse(), resp)
+
+	// The gateway must delegate instead of resolving chunk refs itself.
+	indexQuerier.AssertNotCalled(t, "GetChunkRefsWithSizingInfo", mock.Anything, mock.Anything, mock.Anything)
+	indexQuerier.AssertExpectations(t)
 }

--- a/pkg/indexgateway/gateway_test.go
+++ b/pkg/indexgateway/gateway_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	"github.com/grafana/dskit/user"
-	"github.com/grafana/loki/v3/pkg/storage/chunk"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/grafana/loki/v3/pkg/storage/chunk"
 
 	"github.com/stretchr/testify/require"
 


### PR DESCRIPTION
Added test coverage (which passes before and after the change) to assert that behaviour hasn't changed here. This gives line coverage of all the happy cases, but doesn't exhaustively go through all the error cases. 

**What this PR does / why we need it**: Clean-up.

**Which issue(s) this PR fixes**: N/A.

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
