### PR TITLE
perf(indexgateway): Only calculate chunk groups if we're going to return them

### DIFF
--- a/pkg/indexgateway/gateway.go
+++ b/pkg/indexgateway/gateway.go
@@ -483,16 +483,16 @@ func buildShardsResponse(
 			},
 		}
 	} else {
-		shards, chunkGrps, err := accumulateChunksToShards(req, refs)
+		shards, err := accumulateChunksToShards(req, refs)
 		if err != nil {
 			return nil, err
 		}
 		resp.Shards = shards
 
 		// If the index gateway is configured to precompute chunks, we can return the chunk groups
-		// alongside the shards, otherwise discarding them
+		// alongside the shards, otherwise avoid calculating them.
 		if precomputeChunks {
-			resp.ChunkGroups = chunkGrps
+			resp.ChunkGroups = chunkGroupsForShards(shards, refs)
 		}
 	}
 
@@ -544,7 +544,7 @@ func ExtractShardRequestMatchersAndAST(query string) (chunk.Predicate, error) {
 func accumulateChunksToShards(
 	req *logproto.ShardsRequest,
 	filtered []logproto.ChunkRefWithSizingInfo,
-) ([]logproto.Shard, []logproto.ChunkRefGroup, error) {
+) ([]logproto.Shard, error) {
 	// map for looking up post-filtered chunks in O(n) while iterating the index again for sizing info
 	filteredM := make(map[model.Fingerprint][]logproto.ChunkRefWithSizingInfo, 1024)
 	for _, ref := range filtered {
@@ -566,21 +566,29 @@ func accumulateChunksToShards(
 	}
 	sort.Sort(collectedSeries)
 
-	shards := collectedSeries.ShardsFor(req.TargetBytesPerShard)
+	return collectedSeries.ShardsFor(req.TargetBytesPerShard), nil
+}
+
+// chunkGroupsForShards buckets the given chunk refs into one group per shard.
+// It expects chunkRefs to be ordered by fingerprint.
+func chunkGroupsForShards(
+	shards []logproto.Shard,
+	chunkRefs []logproto.ChunkRefWithSizingInfo,
+) []logproto.ChunkRefGroup {
 	chkGrps := make([]logproto.ChunkRefGroup, 0, len(shards))
 	for _, s := range shards {
-		from := sort.Search(len(filtered), func(i int) bool {
-			return filtered[i].Fingerprint >= uint64(s.Bounds.Min)
+		from := sort.Search(len(chunkRefs), func(i int) bool {
+			return chunkRefs[i].Fingerprint >= uint64(s.Bounds.Min)
 		})
-		through := sort.Search(len(filtered), func(i int) bool {
-			return filtered[i].Fingerprint > uint64(s.Bounds.Max)
+		through := sort.Search(len(chunkRefs), func(i int) bool {
+			return chunkRefs[i].Fingerprint > uint64(s.Bounds.Max)
 		})
 		chkGrps = append(chkGrps, logproto.ChunkRefGroup{
-			Refs: refsWithSizingInfoToRefs(filtered[from:through]),
+			Refs: refsWithSizingInfoToRefs(chunkRefs[from:through]),
 		})
 	}
 
-	return shards, chkGrps, nil
+	return chkGrps
 }
 
 func refsWithSizingInfoToRefs(refsWithSizingInfo []logproto.ChunkRefWithSizingInfo) []*logproto.ChunkRef {

--- a/pkg/indexgateway/gateway.go
+++ b/pkg/indexgateway/gateway.go
@@ -430,27 +430,9 @@ func (g *Gateway) boundedShards(
 	g.metrics.preFilterChunks.WithLabelValues(routeShards).Observe(float64(ct))
 	g.metrics.postFilterChunks.WithLabelValues(routeShards).Observe(float64(ct))
 
-	resp := &logproto.ShardsResponse{}
-	if len(refs) == 0 {
-		// Edge case: if there are no chunks, we still need to return a single shard
-		resp.Shards = []logproto.Shard{
-			{
-				Bounds: logproto.FPBounds{Min: 0, Max: math.MaxUint64},
-				Stats:  &logproto.IndexStatsResponse{},
-			},
-		}
-	} else {
-		shards, chunkGrps, err := accumulateChunksToShards(req, refs)
-		if err != nil {
-			return err
-		}
-		resp.Shards = shards
-
-		// If the index gateway is configured to precompute chunks, we can return the chunk groups
-		// alongside the shards, otherwise discarding them
-		if g.limits.TSDBPrecomputeChunks(instanceID) {
-			resp.ChunkGroups = chunkGrps
-		}
+	resp, err := buildShardsResponse(req, refs, g.limits.TSDBPrecomputeChunks(instanceID))
+	if err != nil {
+		return err
 	}
 
 	sp.AddEvent("send shards response", trace.WithAttributes(
@@ -477,20 +459,55 @@ func (g *Gateway) boundedShards(
 		"end_delta", time.Since(req.Through.Time()).String(),
 	)
 
-	// Populate index statistics for metrics logging
-	resp.Statistics.Index.TotalChunks = int64(ct)
-	resp.Statistics.Index.PostFilterChunks = int64(ct)
-	// compute unique streams matched post-filtering
-	{
-		seen := make(map[model.Fingerprint]struct{}, 1024)
-		for _, ref := range refs {
-			seen[model.Fingerprint(ref.Fingerprint)] = struct{}{}
-		}
-		resp.Statistics.Index.TotalStreams = int64(len(seen))
-	}
 	resp.Statistics.Index.ShardsDuration = int64(time.Since(start))
 
 	return server.Send(resp)
+}
+
+// buildShardsResponse builds the response for a shards request from the chunk refs
+// resolved from the index. precomputeChunks controls whether the per-shard chunk
+// groups are returned alongside the shards.
+func buildShardsResponse(
+	req *logproto.ShardsRequest,
+	refs []logproto.ChunkRefWithSizingInfo,
+	precomputeChunks bool,
+) (*logproto.ShardsResponse, error) {
+	resp := &logproto.ShardsResponse{}
+
+	if len(refs) == 0 {
+		// Edge case: if there are no chunks, we still need to return a single shard
+		resp.Shards = []logproto.Shard{
+			{
+				Bounds: logproto.FPBounds{Min: 0, Max: math.MaxUint64},
+				Stats:  &logproto.IndexStatsResponse{},
+			},
+		}
+	} else {
+		shards, chunkGrps, err := accumulateChunksToShards(req, refs)
+		if err != nil {
+			return nil, err
+		}
+		resp.Shards = shards
+
+		// If the index gateway is configured to precompute chunks, we can return the chunk groups
+		// alongside the shards, otherwise discarding them
+		if precomputeChunks {
+			resp.ChunkGroups = chunkGrps
+		}
+	}
+
+	// Populate index statistics for metrics logging
+	ct := len(refs)
+	resp.Statistics.Index.TotalChunks = int64(ct)
+	resp.Statistics.Index.PostFilterChunks = int64(ct)
+	// compute unique streams matched post-filtering
+	seen := make(map[model.Fingerprint]struct{}, 1024)
+	for _, ref := range refs {
+		seen[model.Fingerprint(ref.Fingerprint)] = struct{}{}
+	}
+	resp.Statistics.Index.TotalStreams = int64(len(seen))
+
+	return resp, nil
 }
 
 // ExtractShardRequestMatchersAndAST extracts the matchers and AST from a query string.

--- a/pkg/indexgateway/gateway_test.go
+++ b/pkg/indexgateway/gateway_test.go
@@ -268,9 +268,12 @@ func TestAccumulateChunksToShards(t *testing.T) {
 		sized(mkRef(7, 10), 25, 1),
 	}
 
-	shards, grps, err := accumulateChunksToShards(&logproto.ShardsRequest{
+	shards, err := accumulateChunksToShards(&logproto.ShardsRequest{
 		TargetBytesPerShard: 100 << 10,
 	}, filtered)
+	require.NoError(t, err)
+
+	grps := chunkGroupsForShards(shards, filtered)
 
 	expectedChks := [][]logproto.ChunkRefWithSizingInfo{
 		filtered[0:3],

--- a/pkg/indexgateway/gateway_test.go
+++ b/pkg/indexgateway/gateway_test.go
@@ -2,8 +2,10 @@ package indexgateway
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/common/model"
@@ -607,4 +609,54 @@ func TestGetShardsWithoutChunkSizingInfo(t *testing.T) {
 	// The gateway must delegate instead of resolving chunk refs itself.
 	indexQuerier.AssertNotCalled(t, "GetChunkRefsWithSizingInfo", mock.Anything, mock.Anything, mock.Anything)
 	indexQuerier.AssertExpectations(t)
+}
+
+// BenchmarkBuildShardsResponse benchmarks building the shards response for a tenant
+// without TSDBPrecomputeChunks enabled, i.e. one where the per-shard chunk groups are
+// not returned.
+func BenchmarkBuildShardsResponse(b *testing.B) {
+	req := &logproto.ShardsRequest{
+		TargetBytesPerShard: 600 << 20,
+	}
+
+	for _, tc := range []struct {
+		series, chunksPerSeries int
+	}{
+		{series: 10_000, chunksPerSeries: 100},
+		{series: 100_000, chunksPerSeries: 10},
+		{series: 1_000_000, chunksPerSeries: 1},
+	} {
+		refs := buildChunkRefs(tc.series, tc.chunksPerSeries)
+
+		b.Run(fmt.Sprintf("series=%d/chunks_per_series=%d", tc.series, tc.chunksPerSeries), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := buildShardsResponse(req, refs, false); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func buildChunkRefs(series, chunksPerSeries int) []logproto.ChunkRefWithSizingInfo {
+	refs := make([]logproto.ChunkRefWithSizingInfo, 0, series*chunksPerSeries)
+	for i := range series {
+		// leave gaps in the fingerprint space so shard bounds don't line up exactly
+		fp := uint64(i) * 3
+		for j := range chunksPerSeries {
+			refs = append(refs, logproto.ChunkRefWithSizingInfo{
+				ChunkRef: logproto.ChunkRef{
+					Fingerprint: fp,
+					UserID:      "fake",
+					From:        model.Time(j * int(time.Hour/time.Millisecond)),
+					Through:     model.Time((j + 1) * int(time.Hour/time.Millisecond)),
+					Checksum:    uint32(i*chunksPerSeries + j),
+				},
+				KB:      uint32(1024 + (i+j)%1024),
+				Entries: uint32(10_000 + (i+j)%1_000),
+			})
+		}
+	}
+	return refs
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Two commits: 
1. Small refactor identified in https://github.com/grafana/loki/pull/24103#pullrequestreview-4983565819, and add a benchmark. 
2. Optimisation - don't do work that we're going to throw away.

Benchmark results:
```
                                                          │ before.txt  │              after.txt              │
                                                          │   sec/op    │   sec/op     vs base                │
BuildShardsResponse/series=10000/chunks_per_series=100-12   54.28m ± 3%   34.34m ± 1%  -36.73% (p=0.000 n=10)
BuildShardsResponse/series=100000/chunks_per_series=10-12   89.12m ± 1%   69.67m ± 1%  -21.82% (p=0.000 n=10)
BuildShardsResponse/series=1000000/chunks_per_series=1-12   317.1m ± 1%   292.6m ± 2%   -7.73% (p=0.000 n=10)
geomean                                                     115.3m        88.79m       -23.01%

                                                          │  before.txt  │              after.txt               │
                                                          │     B/op     │     B/op      vs base                │
BuildShardsResponse/series=10000/chunks_per_series=100-12   226.5Mi ± 0%   157.3Mi ± 0%  -30.58% (p=0.000 n=10)
BuildShardsResponse/series=100000/chunks_per_series=10-12   266.4Mi ± 0%   197.1Mi ± 0%  -26.00% (p=0.000 n=10)
BuildShardsResponse/series=1000000/chunks_per_series=1-12   400.6Mi ± 0%   331.3Mi ± 0%  -17.30% (p=0.000 n=10)
geomean                                                     289.2Mi        217.4Mi       -24.82%

                                                          │  before.txt   │              after.txt              │
                                                          │   allocs/op   │  allocs/op   vs base                │
BuildShardsResponse/series=10000/chunks_per_series=100-12   1087.75k ± 0%   85.22k ± 0%  -92.17% (p=0.000 n=10)
BuildShardsResponse/series=100000/chunks_per_series=10-12    1508.5k ± 0%   506.0k ± 0%  -66.45% (p=0.000 n=10)
BuildShardsResponse/series=1000000/chunks_per_series=1-12     2.024M ± 0%   1.021M ± 0%  -49.53% (p=0.000 n=10)
geomean                                                       1.492M        353.2k       -76.33%
```

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**: I recommend reviewing the commits separately.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] Documentation added
- [x] Tests updated
- [x] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [x] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
