### PR TITLE
feat(logql): Evaluate approx_count_distinct with HyperLogLog

### DIFF
--- a/pkg/logql/approx_count_distinct.go
+++ b/pkg/logql/approx_count_distinct.go
@@ -1,0 +1,111 @@
+package logql
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/axiomhq/hyperloglog"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	promql_parser "github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/grafana/loki/v3/pkg/iter"
+	"github.com/grafana/loki/v3/pkg/logqlmodel"
+)
+
+type countDistinctStepEvaluator struct {
+	it        iter.PeekingSampleIterator
+	params    Params
+	interval  time.Duration
+	offset    time.Duration
+	exhausted bool
+	err       error
+}
+
+func newCountDistinctStepEvaluator(
+	it iter.PeekingSampleIterator,
+	params Params,
+	interval, offset time.Duration,
+) (StepEvaluator, error) {
+	if GetRangeType(params) != InstantType {
+		return nil, fmt.Errorf("approx_count_distinct is only supported on instant queries")
+	}
+	return &countDistinctStepEvaluator{
+		it:       it,
+		params:   params,
+		interval: interval,
+		offset:   offset,
+	}, nil
+}
+
+func (e *countDistinctStepEvaluator) Next() (bool, int64, StepResult) {
+	if e.exhausted {
+		return false, 0, SampleVector{}
+	}
+	e.exhausted = true
+
+	// Match RangeAggregationExpr: (T-D-O, T-O]
+	start := e.params.Start().Add(-e.interval).Add(-e.offset).UnixNano()
+	end := e.params.End().Add(-e.offset).UnixNano()
+	ts := e.params.Start().UnixMilli()
+
+	type group struct {
+		hll    *hyperloglog.Sketch
+		metric labels.Labels
+	}
+	groups := make(map[string]*group)
+
+	for lbs, sample, ok := e.it.Peek(); ok; lbs, sample, ok = e.it.Peek() {
+		if sample.Timestamp > end {
+			break
+		}
+		if sample.Timestamp <= start {
+			_ = e.it.Next()
+			continue
+		}
+
+		g, exists := groups[lbs]
+		if !exists {
+			metric, err := promql_parser.NewParser(promql_parser.Options{}).ParseMetric(lbs)
+			if err != nil {
+				_ = e.it.Next()
+				continue
+			}
+			if metric.Has(logqlmodel.ErrorLabel) && metric.Get(logqlmodel.PreserveErrorLabel) != trueString {
+				e.err = logqlmodel.NewPipelineErr(metric)
+				return false, 0, SampleVector{}
+			}
+			g = &group{
+				hll:    hyperloglog.New14(),
+				metric: metric,
+			}
+			groups[lbs] = g
+		}
+		g.hll.InsertHash(math.Float64bits(sample.Value))
+		_ = e.it.Next()
+	}
+
+	out := make(promql.Vector, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, promql.Sample{
+			T:      ts,
+			F:      float64(g.hll.Estimate()),
+			Metric: g.metric,
+		})
+	}
+	return true, ts, SampleVector(out)
+}
+
+func (e *countDistinctStepEvaluator) Close() error { return e.it.Close() }
+
+func (e *countDistinctStepEvaluator) Error() error {
+	if e.err != nil {
+		return e.err
+	}
+	return e.it.Err()
+}
+
+func (e *countDistinctStepEvaluator) Explain(parent Node) {
+	parent.Child("CountDistinct")
+}

--- a/pkg/logql/approx_count_distinct.go
+++ b/pkg/logql/approx_count_distinct.go
@@ -1,111 +1,85 @@
 package logql
 
 import (
-	"fmt"
 	"math"
 	"time"
 
 	"github.com/axiomhq/hyperloglog"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
-	promql_parser "github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/loki/v3/pkg/iter"
-	"github.com/grafana/loki/v3/pkg/logqlmodel"
 )
-
-type countDistinctStepEvaluator struct {
-	it        iter.PeekingSampleIterator
-	params    Params
-	interval  time.Duration
-	offset    time.Duration
-	exhausted bool
-	err       error
-}
 
 func newCountDistinctStepEvaluator(
 	it iter.PeekingSampleIterator,
 	params Params,
 	interval, offset time.Duration,
 ) (StepEvaluator, error) {
-	if GetRangeType(params) != InstantType {
-		return nil, fmt.Errorf("approx_count_distinct is only supported on instant queries")
-	}
-	return &countDistinctStepEvaluator{
-		it:       it,
-		params:   params,
-		interval: interval,
-		offset:   offset,
+	return &RangeVectorEvaluator{
+		iter: newCountDistinctIterator(
+			it,
+			interval.Nanoseconds(),
+			params.Step().Nanoseconds(),
+			params.Start().UnixNano(),
+			params.End().UnixNano(),
+			offset.Nanoseconds(),
+		),
 	}, nil
 }
 
-func (e *countDistinctStepEvaluator) Next() (bool, int64, StepResult) {
-	if e.exhausted {
-		return false, 0, SampleVector{}
+func newCountDistinctIterator(
+	it iter.PeekingSampleIterator,
+	selRange, step, start, end, offset int64,
+) RangeVectorIterator {
+	// forces at least one step.
+	if step == 0 {
+		step = 1
 	}
-	e.exhausted = true
-
-	// Match RangeAggregationExpr: (T-D-O, T-O]
-	start := e.params.Start().Add(-e.interval).Add(-e.offset).UnixNano()
-	end := e.params.End().Add(-e.offset).UnixNano()
-	ts := e.params.Start().UnixMilli()
-
-	type group struct {
-		hll    *hyperloglog.Sketch
-		metric labels.Labels
-	}
-	groups := make(map[string]*group)
-
-	for lbs, sample, ok := e.it.Peek(); ok; lbs, sample, ok = e.it.Peek() {
-		if sample.Timestamp > end {
-			break
-		}
-		if sample.Timestamp <= start {
-			_ = e.it.Next()
-			continue
-		}
-
-		g, exists := groups[lbs]
-		if !exists {
-			metric, err := promql_parser.NewParser(promql_parser.Options{}).ParseMetric(lbs)
-			if err != nil {
-				_ = e.it.Next()
-				continue
-			}
-			if metric.Has(logqlmodel.ErrorLabel) && metric.Get(logqlmodel.PreserveErrorLabel) != trueString {
-				e.err = logqlmodel.NewPipelineErr(metric)
-				return false, 0, SampleVector{}
-			}
-			g = &group{
-				hll:    hyperloglog.New14(),
-				metric: metric,
-			}
-			groups[lbs] = g
-		}
-		g.hll.InsertHash(math.Float64bits(sample.Value))
-		_ = e.it.Next()
+	if offset != 0 {
+		start = start - offset
+		end = end - offset
 	}
 
-	out := make(promql.Vector, 0, len(groups))
-	for _, g := range groups {
-		out = append(out, promql.Sample{
+	return &countDistinctBatchRangeVectorIterator{
+		batchRangeVectorIterator: &batchRangeVectorIterator{
+			iter:     it,
+			step:     step,
+			end:      end,
+			selRange: selRange,
+			metrics:  map[string]labels.Labels{},
+			window:   map[string]*promql.Series{},
+			current:  start - step, // first loop iteration will set it to start
+			offset:   offset,
+		},
+	}
+}
+
+type countDistinctBatchRangeVectorIterator struct {
+	*batchRangeVectorIterator
+}
+
+func (r *countDistinctBatchRangeVectorIterator) At() (int64, StepResult) {
+	if r.at == nil {
+		r.at = make([]promql.Sample, 0, len(r.window))
+	}
+	r.at = r.at[:0]
+	// convert ts from nano to milli seconds as the iterator work with nanoseconds
+	ts := r.current/1e+6 + r.offset/1e+6
+	for _, series := range r.window {
+		r.at = append(r.at, promql.Sample{
+			F:      countDistinctEstimate(series.Floats),
 			T:      ts,
-			F:      float64(g.hll.Estimate()),
-			Metric: g.metric,
+			Metric: series.Metric,
 		})
 	}
-	return true, ts, SampleVector(out)
+	return ts, SampleVector(r.at)
 }
 
-func (e *countDistinctStepEvaluator) Close() error { return e.it.Close() }
-
-func (e *countDistinctStepEvaluator) Error() error {
-	if e.err != nil {
-		return e.err
+func countDistinctEstimate(samples []promql.FPoint) float64 {
+	hll := hyperloglog.New14()
+	for _, sample := range samples {
+		hll.InsertHash(math.Float64bits(sample.F))
 	}
-	return e.it.Err()
-}
-
-func (e *countDistinctStepEvaluator) Explain(parent Node) {
-	parent.Child("CountDistinct")
+	return float64(hll.Estimate())
 }

--- a/pkg/logql/approx_count_distinct.go
+++ b/pkg/logql/approx_count_distinct.go
@@ -15,7 +15,7 @@ func newCountDistinctStepEvaluator(
 	it iter.PeekingSampleIterator,
 	params Params,
 	interval, offset time.Duration,
-) (StepEvaluator, error) {
+) StepEvaluator {
 	return &RangeVectorEvaluator{
 		iter: newCountDistinctIterator(
 			it,
@@ -25,7 +25,7 @@ func newCountDistinctStepEvaluator(
 			params.End().UnixNano(),
 			offset.Nanoseconds(),
 		),
-	}, nil
+	}
 }
 
 func newCountDistinctIterator(

--- a/pkg/logql/approx_count_distinct_test.go
+++ b/pkg/logql/approx_count_distinct_test.go
@@ -51,6 +51,23 @@ func TestApproxCountDistinctEval(t *testing.T) {
 		series  []seriesExpect
 	}{
 		{
+			name:    "instant default grouped",
+			query:   `approx_count_distinct(mac, {job="devices"} | logfmt [1m])`,
+			instant: true,
+			series: []seriesExpect{
+				{metric: labels.FromStrings("job", "devices", "version", "1"), instant: 2},
+				{metric: labels.FromStrings("job", "devices", "version", "2"), instant: 1},
+			},
+		},
+		{
+			name:    "instant ungrouped",
+			query:   `approx_count_distinct(mac, {job="devices"} | logfmt [1m]) by ()`,
+			instant: true,
+			series: []seriesExpect{
+				{metric: labels.EmptyLabels(), instant: 3},
+			},
+		},
+		{
 			name:    "instant grouped",
 			query:   `approx_count_distinct(mac, {job="devices"} | logfmt [1m]) by (version)`,
 			instant: true,
@@ -60,11 +77,20 @@ func TestApproxCountDistinctEval(t *testing.T) {
 			},
 		},
 		{
-			name:    "instant ungrouped",
+			name:    "range default grouped",
 			query:   `approx_count_distinct(mac, {job="devices"} | logfmt [1m])`,
-			instant: true,
+			instant: false,
 			series: []seriesExpect{
-				{metric: labels.EmptyLabels(), instant: 3},
+				{metric: labels.FromStrings("job", "devices", "version", "1"), rangeTs: []float64{2, 1, 1}},
+				{metric: labels.FromStrings("job", "devices", "version", "2"), rangeTs: []float64{1, 1}},
+			},
+		},
+		{
+			name:    "range ungrouped",
+			query:   `approx_count_distinct(mac, {job="devices"} | logfmt [1m]) by ()`,
+			instant: false,
+			series: []seriesExpect{
+				{metric: labels.EmptyLabels(), rangeTs: []float64{3, 2, 1}},
 			},
 		},
 		{
@@ -74,14 +100,6 @@ func TestApproxCountDistinctEval(t *testing.T) {
 			series: []seriesExpect{
 				{metric: labels.FromStrings("version", "1"), rangeTs: []float64{2, 1, 1}},
 				{metric: labels.FromStrings("version", "2"), rangeTs: []float64{1, 1}},
-			},
-		},
-		{
-			name:    "range ungrouped",
-			query:   `approx_count_distinct(mac, {job="devices"} | logfmt [1m])`,
-			instant: false,
-			series: []seriesExpect{
-				{metric: labels.EmptyLabels(), rangeTs: []float64{3, 2, 1}},
 			},
 		},
 	}

--- a/pkg/logql/approx_count_distinct_test.go
+++ b/pkg/logql/approx_count_distinct_test.go
@@ -1,0 +1,97 @@
+package logql
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/logproto"
+)
+
+func TestApproxCountDistinctLocalEval(t *testing.T) {
+	now := time.Unix(100, 0)
+	streams := []logproto.Stream{
+		{
+			Labels: `{job="devices", version="1"}`,
+			Entries: []logproto.Entry{
+				{Timestamp: now.Add(-30 * time.Second), Line: `mac="aa:bb"`},
+				{Timestamp: now.Add(-20 * time.Second), Line: `mac="aa:bb"`},
+				{Timestamp: now.Add(-10 * time.Second), Line: `mac="cc:dd"`},
+			},
+		},
+		{
+			Labels: `{job="devices", version="2"}`,
+			Entries: []logproto.Entry{
+				{Timestamp: now.Add(-15 * time.Second), Line: `mac="ee:ff"`},
+			},
+		},
+	}
+
+	eng := NewEngine(EngineOpts{}, NewMockQuerier(1, streams), NoLimits, nil)
+	params, err := NewLiteralParams(
+		`approx_count_distinct(mac, {job="devices"} | logfmt [1m]) by (version)`,
+		now, now, 0, 0, logproto.FORWARD, 1000, nil, nil,
+	)
+	require.NoError(t, err)
+
+	res, err := eng.Query(params).Exec(user.InjectOrgID(context.Background(), "fake"))
+	require.NoError(t, err)
+
+	vec, ok := res.Data.(promql.Vector)
+	require.True(t, ok)
+	require.Len(t, vec, 2)
+
+	byVersion := map[string]float64{}
+	for _, sample := range vec {
+		byVersion[sample.Metric.Get("version")] = sample.F
+	}
+	require.InDelta(t, 2, byVersion["1"], 0.01)
+	require.InDelta(t, 1, byVersion["2"], 0.01)
+}
+
+func TestApproxCountDistinctInstantOnly(t *testing.T) {
+	eng := NewEngine(EngineOpts{}, NewMockQuerier(1, nil), NoLimits, nil)
+	params, err := NewLiteralParams(
+		`approx_count_distinct(mac, {job="devices"}[1m]) by (version)`,
+		time.Unix(0, 0), time.Unix(60, 0), time.Second, 0, logproto.FORWARD, 1000, nil, nil,
+	)
+	require.NoError(t, err)
+
+	_, err = eng.Query(params).Exec(user.InjectOrgID(context.Background(), "fake"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "only supported on instant queries")
+}
+
+func TestApproxCountDistinctBoundaries(t *testing.T) {
+	now := time.Unix(100, 0)
+	streams := []logproto.Stream{
+		{
+			Labels: `{job="devices", version="1"}`,
+			Entries: []logproto.Entry{
+				// Exactly at lower bound (T-D): excluded (open lower).
+				{Timestamp: now.Add(-time.Minute), Line: `mac="lower"`},
+				// Inside range.
+				{Timestamp: now.Add(-30 * time.Second), Line: `mac="inside"`},
+				// Exactly at T: included (closed upper via +1ns on End).
+				{Timestamp: now, Line: `mac="upper"`},
+			},
+		},
+	}
+
+	eng := NewEngine(EngineOpts{}, NewMockQuerier(1, streams), NoLimits, nil)
+	params, err := NewLiteralParams(
+		`approx_count_distinct(mac, {job="devices"} | logfmt [1m]) by (version)`,
+		now, now, 0, 0, logproto.FORWARD, 1000, nil, nil,
+	)
+	require.NoError(t, err)
+
+	res, err := eng.Query(params).Exec(user.InjectOrgID(context.Background(), "fake"))
+	require.NoError(t, err)
+	vec := res.Data.(promql.Vector)
+	require.Len(t, vec, 1)
+	require.InDelta(t, 2, vec[0].F, 0.01)
+}

--- a/pkg/logql/approx_count_distinct_test.go
+++ b/pkg/logql/approx_count_distinct_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/loki/v3/pkg/iter"
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
@@ -54,7 +55,8 @@ func TestApproxCountDistinctLocalEval(t *testing.T) {
 }
 
 func TestApproxCountDistinctInstantOnly(t *testing.T) {
-	eng := NewEngine(EngineOpts{}, NewMockQuerier(1, nil), NoLimits, nil)
+	q := &countingSampleQuerier{MockQuerier: NewMockQuerier(1, nil)}
+	eng := NewEngine(EngineOpts{}, q, NoLimits, nil)
 	params, err := NewLiteralParams(
 		`approx_count_distinct(mac, {job="devices"}[1m]) by (version)`,
 		time.Unix(0, 0), time.Unix(60, 0), time.Second, 0, logproto.FORWARD, 1000, nil, nil,
@@ -64,6 +66,17 @@ func TestApproxCountDistinctInstantOnly(t *testing.T) {
 	_, err = eng.Query(params).Exec(user.InjectOrgID(context.Background(), "fake"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "only supported on instant queries")
+	require.Zero(t, q.selectSamples)
+}
+
+type countingSampleQuerier struct {
+	MockQuerier
+	selectSamples int
+}
+
+func (q *countingSampleQuerier) SelectSamples(ctx context.Context, req SelectSampleParams) (iter.SampleIterator, error) {
+	q.selectSamples++
+	return q.MockQuerier.SelectSamples(ctx, req)
 }
 
 func TestApproxCountDistinctBoundaries(t *testing.T) {

--- a/pkg/logql/approx_count_distinct_test.go
+++ b/pkg/logql/approx_count_distinct_test.go
@@ -6,77 +6,161 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/user"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/loki/v3/pkg/iter"
 	"github.com/grafana/loki/v3/pkg/logproto"
 )
 
-func TestApproxCountDistinctLocalEval(t *testing.T) {
-	now := time.Unix(100, 0)
+func TestApproxCountDistinctEval(t *testing.T) {
+	start := time.Unix(100, 0)
+	end := start.Add(60 * time.Second)
+	step := 30 * time.Second
 	streams := []logproto.Stream{
 		{
 			Labels: `{job="devices", version="1"}`,
 			Entries: []logproto.Entry{
-				{Timestamp: now.Add(-30 * time.Second), Line: `mac="aa:bb"`},
-				{Timestamp: now.Add(-20 * time.Second), Line: `mac="aa:bb"`},
-				{Timestamp: now.Add(-10 * time.Second), Line: `mac="cc:dd"`},
+				// T=100 window (40s, 100s] only.
+				{Timestamp: start.Add(-50 * time.Second), Line: `mac="early"`},
+				// T=100 and T=130 windows.
+				{Timestamp: start.Add(-10 * time.Second), Line: `mac="mid"`},
+				// T=160 window (100s, 160s] only.
+				{Timestamp: start.Add(40 * time.Second), Line: `mac="late"`},
 			},
 		},
 		{
 			Labels: `{job="devices", version="2"}`,
 			Entries: []logproto.Entry{
-				{Timestamp: now.Add(-15 * time.Second), Line: `mac="ee:ff"`},
+				// T=100 and T=130 windows.
+				{Timestamp: start.Add(-15 * time.Second), Line: `mac="other"`},
+			},
+		},
+	}
+
+	type seriesExpect struct {
+		metric  labels.Labels
+		instant float64
+		rangeTs []float64
+	}
+
+	tests := []struct {
+		name    string
+		query   string
+		instant bool
+		series  []seriesExpect
+	}{
+		{
+			name:    "instant grouped",
+			query:   `approx_count_distinct(mac, {job="devices"} | logfmt [1m]) by (version)`,
+			instant: true,
+			series: []seriesExpect{
+				{metric: labels.FromStrings("version", "1"), instant: 2},
+				{metric: labels.FromStrings("version", "2"), instant: 1},
+			},
+		},
+		{
+			name:    "instant ungrouped",
+			query:   `approx_count_distinct(mac, {job="devices"} | logfmt [1m])`,
+			instant: true,
+			series: []seriesExpect{
+				{metric: labels.EmptyLabels(), instant: 3},
+			},
+		},
+		{
+			name:    "range grouped",
+			query:   `approx_count_distinct(mac, {job="devices"} | logfmt [1m]) by (version)`,
+			instant: false,
+			series: []seriesExpect{
+				{metric: labels.FromStrings("version", "1"), rangeTs: []float64{2, 1, 1}},
+				{metric: labels.FromStrings("version", "2"), rangeTs: []float64{1, 1}},
+			},
+		},
+		{
+			name:    "range ungrouped",
+			query:   `approx_count_distinct(mac, {job="devices"} | logfmt [1m])`,
+			instant: false,
+			series: []seriesExpect{
+				{metric: labels.EmptyLabels(), rangeTs: []float64{3, 2, 1}},
+			},
+		},
+	}
+
+	eng := NewEngine(EngineOpts{}, NewMockQuerier(1, streams), NoLimits, nil)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			qStart, qEnd, qStep := start, start, time.Duration(0)
+			if !tc.instant {
+				qEnd, qStep = end, step
+			}
+			params, err := NewLiteralParams(
+				tc.query, qStart, qEnd, qStep, 0, logproto.FORWARD, 1000, nil, nil,
+			)
+			require.NoError(t, err)
+
+			res, err := eng.Query(params).Exec(user.InjectOrgID(context.Background(), "fake"))
+			require.NoError(t, err)
+
+			if tc.instant {
+				vec, ok := res.Data.(promql.Vector)
+				require.True(t, ok)
+				require.Len(t, vec, len(tc.series))
+				got := map[uint64]float64{}
+				for _, sample := range vec {
+					got[labels.StableHash(sample.Metric)] = sample.F
+				}
+				for _, exp := range tc.series {
+					require.InDelta(t, exp.instant, got[labels.StableHash(exp.metric)], 0.01, exp.metric.String())
+				}
+				return
+			}
+
+			matrix, ok := res.Data.(promql.Matrix)
+			require.True(t, ok)
+			require.Len(t, matrix, len(tc.series))
+			got := map[uint64][]promql.FPoint{}
+			for _, series := range matrix {
+				got[labels.StableHash(series.Metric)] = series.Floats
+			}
+			for _, exp := range tc.series {
+				points := got[labels.StableHash(exp.metric)]
+				require.Len(t, points, len(exp.rangeTs), exp.metric.String())
+				for i, want := range exp.rangeTs {
+					require.Equal(t, start.Add(time.Duration(i)*step).UnixMilli(), points[i].T)
+					require.InDelta(t, want, points[i].F, 0.01, exp.metric.String())
+				}
+			}
+		})
+	}
+}
+
+func TestApproxCountDistinctRangeOffset(t *testing.T) {
+	now := time.Unix(100, 0)
+	streams := []logproto.Stream{
+		{
+			Labels: `{job="devices", version="1"}`,
+			Entries: []logproto.Entry{
+				// Inside the offset window (T-1m-30s, T-30s] = (10s, 70s].
+				{Timestamp: now.Add(-50 * time.Second), Line: `mac="shifted"`},
+				// After the offset window; excluded.
+				{Timestamp: now.Add(-10 * time.Second), Line: `mac="too-new"`},
 			},
 		},
 	}
 
 	eng := NewEngine(EngineOpts{}, NewMockQuerier(1, streams), NoLimits, nil)
 	params, err := NewLiteralParams(
-		`approx_count_distinct(mac, {job="devices"} | logfmt [1m]) by (version)`,
+		`approx_count_distinct(mac, {job="devices"} | logfmt [1m] offset 30s) by (version)`,
 		now, now, 0, 0, logproto.FORWARD, 1000, nil, nil,
 	)
 	require.NoError(t, err)
 
 	res, err := eng.Query(params).Exec(user.InjectOrgID(context.Background(), "fake"))
 	require.NoError(t, err)
-
-	vec, ok := res.Data.(promql.Vector)
-	require.True(t, ok)
-	require.Len(t, vec, 2)
-
-	byVersion := map[string]float64{}
-	for _, sample := range vec {
-		byVersion[sample.Metric.Get("version")] = sample.F
-	}
-	require.InDelta(t, 2, byVersion["1"], 0.01)
-	require.InDelta(t, 1, byVersion["2"], 0.01)
-}
-
-func TestApproxCountDistinctInstantOnly(t *testing.T) {
-	q := &countingSampleQuerier{MockQuerier: NewMockQuerier(1, nil)}
-	eng := NewEngine(EngineOpts{}, q, NoLimits, nil)
-	params, err := NewLiteralParams(
-		`approx_count_distinct(mac, {job="devices"}[1m]) by (version)`,
-		time.Unix(0, 0), time.Unix(60, 0), time.Second, 0, logproto.FORWARD, 1000, nil, nil,
-	)
-	require.NoError(t, err)
-
-	_, err = eng.Query(params).Exec(user.InjectOrgID(context.Background(), "fake"))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "only supported on instant queries")
-	require.Zero(t, q.selectSamples)
-}
-
-type countingSampleQuerier struct {
-	MockQuerier
-	selectSamples int
-}
-
-func (q *countingSampleQuerier) SelectSamples(ctx context.Context, req SelectSampleParams) (iter.SampleIterator, error) {
-	q.selectSamples++
-	return q.MockQuerier.SelectSamples(ctx, req)
+	vec := res.Data.(promql.Vector)
+	require.Len(t, vec, 1)
+	require.Equal(t, now.UnixMilli(), vec[0].T)
+	require.InDelta(t, 1, vec[0].F, 0.01)
 }
 
 func TestApproxCountDistinctBoundaries(t *testing.T) {

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -376,9 +376,6 @@ func (ev *DefaultEvaluator) NewStepEvaluator(
 		}
 		return newRangeAggEvaluator(iter.NewPeekingSampleIterator(it), e, q, e.Left.Offset)
 	case *syntax.LabelAggregationExpr:
-		if GetRangeType(q) != InstantType {
-			return nil, fmt.Errorf("approx_count_distinct is only supported on instant queries")
-		}
 		it, err := ev.querier.SelectSamples(ctx, SelectSampleParams{
 			&logproto.SampleQueryRequest{
 				Start:    q.Start().Add(-e.Left.Interval).Add(-e.Left.Offset),

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -375,6 +375,23 @@ func (ev *DefaultEvaluator) NewStepEvaluator(
 			return nil, err
 		}
 		return newRangeAggEvaluator(iter.NewPeekingSampleIterator(it), e, q, e.Left.Offset)
+	case *syntax.LabelAggregationExpr:
+		it, err := ev.querier.SelectSamples(ctx, SelectSampleParams{
+			&logproto.SampleQueryRequest{
+				Start:    q.Start().Add(-e.Left.Interval).Add(-e.Left.Offset),
+				End:      q.End().Add(-e.Left.Offset).Add(time.Nanosecond),
+				Selector: e.String(),
+				Shards:   q.Shards(),
+				Plan: &plan.QueryPlan{
+					AST: expr,
+				},
+				StoreChunks: q.GetStoreChunks(),
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return newCountDistinctStepEvaluator(iter.NewPeekingSampleIterator(it), q, e.Left.Interval, e.Left.Offset)
 	case *syntax.BinOpExpr:
 		return newBinOpStepEvaluator(ctx, nextEvFactory, e, q)
 	case *syntax.LabelReplaceExpr:

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -376,6 +376,9 @@ func (ev *DefaultEvaluator) NewStepEvaluator(
 		}
 		return newRangeAggEvaluator(iter.NewPeekingSampleIterator(it), e, q, e.Left.Offset)
 	case *syntax.LabelAggregationExpr:
+		if GetRangeType(q) != InstantType {
+			return nil, fmt.Errorf("approx_count_distinct is only supported on instant queries")
+		}
 		it, err := ev.querier.SelectSamples(ctx, SelectSampleParams{
 			&logproto.SampleQueryRequest{
 				Start:    q.Start().Add(-e.Left.Interval).Add(-e.Left.Offset),
@@ -391,7 +394,12 @@ func (ev *DefaultEvaluator) NewStepEvaluator(
 		if err != nil {
 			return nil, err
 		}
-		return newCountDistinctStepEvaluator(iter.NewPeekingSampleIterator(it), q, e.Left.Interval, e.Left.Offset)
+		eval, err := newCountDistinctStepEvaluator(iter.NewPeekingSampleIterator(it), q, e.Left.Interval, e.Left.Offset)
+		if err != nil {
+			_ = it.Close()
+			return nil, err
+		}
+		return eval, nil
 	case *syntax.BinOpExpr:
 		return newBinOpStepEvaluator(ctx, nextEvFactory, e, q)
 	case *syntax.LabelReplaceExpr:

--- a/pkg/logql/evaluator.go
+++ b/pkg/logql/evaluator.go
@@ -391,12 +391,7 @@ func (ev *DefaultEvaluator) NewStepEvaluator(
 		if err != nil {
 			return nil, err
 		}
-		eval, err := newCountDistinctStepEvaluator(iter.NewPeekingSampleIterator(it), q, e.Left.Interval, e.Left.Offset)
-		if err != nil {
-			_ = it.Close()
-			return nil, err
-		}
-		return eval, nil
+		return newCountDistinctStepEvaluator(iter.NewPeekingSampleIterator(it), q, e.Left.Interval, e.Left.Offset), nil
 	case *syntax.BinOpExpr:
 		return newBinOpStepEvaluator(ctx, nextEvFactory, e, q)
 	case *syntax.LabelReplaceExpr:


### PR DESCRIPTION
## Summary

Second slice of experimental `approx_count_distinct` ([grafana/loki-private#2769](https://github.com/grafana/loki-private/issues/2769)). Stacked on #24112.

This PR teaches the querier engine to evaluate `LabelAggregationExpr` locally and return HyperLogLog estimates: a PromQL vector for instant queries (`/query`) and a matrix for range queries (`/query_range`). Sketch emission, shard merge, protobuf transport, and the feature gate are later PRs.

```logql
approx_count_distinct(
  mac_address,
  {job="devices"} | json [1d]
) by (version)
```

At each evaluation time `T` with duration `D` and optional offset `O`, Loki scans `(T - D - O, T - O]`.

## How it wires to #24112

#24112 added the syntax and the extractor, but the engine still treated `LabelAggregationExpr` as an unknown sample expression.

1. The parser still produces `LabelAggregationExpr`.
2. `DefaultEvaluator.NewStepEvaluator` now handles that type. It calls `SelectSamples` with the AST in the query plan, using the same `(T-D-O, T-O]` window as range aggregations.
3. Store and ingester already call `expr.Extractor()` from #24112, so they emit xxhash64 bits in `Sample.Value` and labels reduced to the grouping set (or no labels when ungrouped).
4. The step evaluator reuses the sliding-window iterator used by `count_over_time` / `quantile_over_time`. Each step rebuilds one HLL per group from the current window and returns `Estimate()` as a `SampleVector`. Existing `JoinSampleVector` turns that into a vector (instant) or matrix (range).

`CountDistinctSketchExpr` remains parseable in query plans from #24112 but is still not evaluated here. Returning mergeable sketches is part of the sharding PR.

## Roadmap

1. Syntax, AST, extractor (#24112)
2. **This PR** — local HLL estimates on a querier (instant and range)
3. Shard + sketch eval + protobuf transport (merge-before-estimate)
4. Feature gate + result-cache bypass
5. Docs

## What to check

- Only `LabelAggregationExpr` is wired; `CountDistinctSketchExpr` still hits `EvaluatorUnsupportedType`.
- Grouping uses exact label strings, not a hash, so two groups cannot collapse.
- Ungrouped and `by ()` produce one unlabeled series.
- Range evaluation slides the lookback window; it does **not** temporally split the lookback and sum estimates (RangeMapper stays a noop, same as `quantile_over_time`).
- `TestApproxCountDistinctEval` covers instant/range × grouped/ungrouped. Bounds in `TestApproxCountDistinctBoundaries` match range aggregations: `(T-D, T]`.

## Risks

This PR makes evaluation work on a **querier** (direct `/query` or `/query_range`, or a frontend that forwards the original AST unchanged). The public result is a normal PromQL vector or matrix of estimates.

The default query-frontend path still fails. `querier.parallelise-shardable-queries` defaults to true, and `ShardMapper` has no `LabelAggregationExpr` case, so mapping returns `unexpected expr type` before any querier runs.

Peak memory is one window of hashed samples plus one HLL per live group while estimating that step (~16 KiB dense per group). That is comparable to `quantile_over_time`, which is why range queries are in contract.

## Test plan

- [x] `go test ./pkg/logql/`