### PR TITLE
chore: Consolidate state handling in CopyAndSort

### DIFF
--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -533,7 +533,7 @@ func (b *Builder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataob
 			return nil, nil, err
 		}
 
-		iter, iterErr := sortedSchemaIter(ctx, sections, streamRemap)
+		logsIter, iterErr := sortedLogsIter(ctx, sections, streamRemap)
 		if iterErr != nil {
 			return nil, nil, fmt.Errorf("creating sort iterator: %w", iterErr)
 		}
@@ -551,7 +551,7 @@ func (b *Builder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataob
 		})
 		lb.SetTenant(tenant)
 
-		if err := b.drainLogsIter(ctx, iter, lb, tenant); err != nil {
+		if err := b.drainLogsIter(ctx, logsIter, lb, tenant); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/pkg/dataobj/consumer/logsobj/builder.go
+++ b/pkg/dataobj/consumer/logsobj/builder.go
@@ -2,7 +2,6 @@
 package logsobj
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"flag"
@@ -534,7 +533,7 @@ func (b *Builder) CopyAndSort(ctx context.Context, obj *dataobj.Object) (*dataob
 			return nil, nil, err
 		}
 
-		iter, iterErr := sortedSchemaIter(ctx, sections, streamRemap.shards, streamRemap.sortKeys, streamRemap.hashes, streamRemap.ids)
+		iter, iterErr := sortedSchemaIter(ctx, sections, streamRemap)
 		if iterErr != nil {
 			return nil, nil, fmt.Errorf("creating sort iterator: %w", iterErr)
 		}
@@ -660,16 +659,9 @@ func (b *Builder) buildStreamSection(ctx context.Context, tenant string, iter re
 	return b.builder.Append(sb)
 }
 
-type streamIDRemap struct {
-	shards   []uint32
-	sortKeys []string
-	hashes   []uint64
-	ids      []int64
-}
-
-type streamWithSortKey struct {
-	stream   streams.Stream
-	orderKey StreamOrderKey
+type streamWithRemap struct {
+	stream streams.Stream
+	remap  streamRemap
 }
 
 // sortAndRemapStreams orders the streams by the globally stable stream order
@@ -685,37 +677,30 @@ type streamWithSortKey struct {
 // compression and pruning at query time.
 //
 // Log records must also be remapped to keep their stream references valid.
-func sortAndRemapStreams(iter result.Seq[streams.Stream], tenant string, schemaLabels []string, numStreams int) (result.Seq[streams.Stream], streamIDRemap, error) {
-	var (
-		collected = make([]streamWithSortKey, 0, numStreams)
-		remap     = streamIDRemap{
-			shards:   make([]uint32, numStreams+1),
-			sortKeys: make([]string, numStreams+1),
-			hashes:   make([]uint64, numStreams+1),
-			ids:      make([]int64, numStreams+1),
-		}
-	)
+func sortAndRemapStreams(iter result.Seq[streams.Stream], tenant string, schemaLabels []string, numStreams int) (result.Seq[streams.Stream], []streamRemap, error) {
+	collected := make([]streamWithRemap, 0, numStreams)
+	remap := make([]streamRemap, numStreams+1)
 
 	for res := range iter {
 		stream, err := res.Value()
 		if err != nil {
-			return nil, streamIDRemap{}, err
+			return nil, nil, err
 		}
-		k, err := NewStreamOrderKey(stream.Labels, schemaLabels)
+		r, err := newStreamRemap(stream.Labels, schemaLabels)
 		if err != nil {
-			return nil, streamIDRemap{}, err
+			return nil, nil, err
 		}
-		collected = append(collected, streamWithSortKey{
-			stream:   stream,
-			orderKey: k,
+		collected = append(collected, streamWithRemap{
+			stream: stream,
+			remap:  r,
 		})
 	}
 
-	slices.SortFunc(collected, func(a, b streamWithSortKey) int {
-		if res := CompareStreamOrderKey(a.orderKey, b.orderKey); res != 0 {
+	slices.SortFunc(collected, func(a, b streamWithRemap) int {
+		if res := a.remap.StreamSort.Compare(b.remap.StreamSort); res != 0 {
 			return res
 		}
-		return cmp.Compare(a.stream.ID, b.stream.ID)
+		return labels.Compare(a.stream.Labels, b.stream.Labels)
 	})
 
 	for i := range collected {
@@ -723,16 +708,14 @@ func sortAndRemapStreams(iter result.Seq[streams.Stream], tenant string, schemaL
 		newID := int64(i + 1)
 
 		if oldID <= 0 || oldID > int64(numStreams) {
-			return nil, streamIDRemap{}, fmt.Errorf("stream id %d out of range for tenant %s with %d streams", oldID, tenant, numStreams)
+			return nil, nil, fmt.Errorf("stream id %d out of range for tenant %s with %d streams", oldID, tenant, numStreams)
 		}
-		if prevNewID := remap.ids[oldID]; prevNewID != 0 {
-			return nil, streamIDRemap{}, fmt.Errorf("duplicate stream id for tenant %s: old id %d maps to both %d and %d", tenant, oldID, prevNewID, newID)
+		if prev := remap[oldID]; prev.newID != 0 {
+			return nil, nil, fmt.Errorf("duplicate stream id for tenant %s: old id %d maps to both %d and %d", tenant, oldID, prev.newID, newID)
 		}
 
-		remap.shards[oldID] = collected[i].orderKey.Shard
-		remap.sortKeys[oldID] = collected[i].orderKey.SchemaKey
-		remap.hashes[oldID] = collected[i].orderKey.Hash
-		remap.ids[oldID] = newID
+		collected[i].remap.newID = newID
+		remap[oldID] = collected[i].remap
 
 		// Remap to the new stream ID.
 		collected[i].stream.ID = newID

--- a/pkg/dataobj/consumer/logsobj/sort.go
+++ b/pkg/dataobj/consumer/logsobj/sort.go
@@ -4,18 +4,62 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/prometheus/prometheus/model/labels"
+
 	"github.com/grafana/loki/v3/pkg/dataobj"
 	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
 	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
 	"github.com/grafana/loki/v3/pkg/dataobj/sortmerge"
 )
 
+// streamRemap is the CopyAndSort sidecar for one stream, indexed by that
+// object's old stream ID. newID is the rank in this object after sorting by
+// StreamOrderKey; independently written objects do not share newID.
+type streamRemap struct {
+	newID int64
+	logs.StreamSort
+}
+
+// newStreamRemap fills shard, schema key, and hash from one labels.StableHash.
+// newID is left 0; sortAndRemapStreams assigns it after the object-wide sort.
+func newStreamRemap(ls labels.Labels, schemaLabels []string) (streamRemap, error) {
+	schemaKey, err := ComputeSortKey(ls, schemaLabels)
+	if err != nil {
+		return streamRemap{}, err
+	}
+	hash := labels.StableHash(ls)
+	return streamRemap{
+		StreamSort: logs.StreamSort{
+			Shard: streams.ShardBucketFromHash(hash),
+			Key:   schemaKey,
+			Hash:  hash,
+		},
+	}, nil
+}
+
+func (r streamRemap) orderKey(ls labels.Labels) StreamOrderKey {
+	return StreamOrderKey{
+		Shard:     r.Shard,
+		SchemaKey: r.Key,
+		Hash:      r.Hash,
+		Labels:    ls,
+	}
+}
+
+// streamSorts extracts the sort-tuple column for the k-way merge comparator.
+func streamSorts(remap []streamRemap) []logs.StreamSort {
+	out := make([]logs.StreamSort, len(remap))
+	for i, e := range remap {
+		out[i] = e.StreamSort
+	}
+	return out
+}
+
 // sortedSchemaIter merges schema-sorted input sections, injects schema sort
 // keys, remaps stream IDs, and returns an iterator suitable for AppendOrdered.
-func sortedSchemaIter(
-	ctx context.Context, sections []*dataobj.Section, shards []uint32, sortKeys []string, hashes []uint64, streamIDs []int64,
-) (result.Seq[logs.Record], error) {
-	iter, err := sortmerge.IteratorForSchema(ctx, sections, shards, sortKeys, hashes)
+func sortedSchemaIter(ctx context.Context, sections []*dataobj.Section, remap []streamRemap) (result.Seq[logs.Record], error) {
+	iter, err := sortmerge.IteratorForSchema(ctx, sections, streamSorts(remap))
 	if err != nil {
 		return nil, err
 	}
@@ -28,22 +72,17 @@ func sortedSchemaIter(
 			}
 
 			oldStreamID := rec.StreamID
-			if oldStreamID <= 0 || oldStreamID >= int64(len(sortKeys)) {
-				return fmt.Errorf("missing schema sort key for stream ID %d", oldStreamID)
+			if oldStreamID <= 0 || oldStreamID >= int64(len(remap)) {
+				return fmt.Errorf("missing stream remap for stream ID %d", oldStreamID)
 			}
-			sortKey := sortKeys[oldStreamID]
-
-			if oldStreamID >= int64(len(streamIDs)) {
+			e := remap[oldStreamID]
+			if e.newID == 0 {
 				return fmt.Errorf("missing stream ID remap for stream ID %d", oldStreamID)
 			}
-			streamID := streamIDs[oldStreamID]
-			if streamID == 0 {
-				return fmt.Errorf("missing stream ID remap for stream ID %d", oldStreamID)
-			}
-			rec.SortKey = sortKey
-			rec.ShardBucket = shards[oldStreamID]
-			rec.StreamHash = hashes[oldStreamID]
-			rec.StreamID = streamID
+			rec.SortKey = e.Key
+			rec.ShardBucket = e.Shard
+			rec.StreamHash = e.Hash
+			rec.StreamID = e.newID
 			if !yield(rec) {
 				return nil
 			}

--- a/pkg/dataobj/consumer/logsobj/sort.go
+++ b/pkg/dataobj/consumer/logsobj/sort.go
@@ -56,9 +56,9 @@ func streamSorts(remap []streamRemap) []logs.StreamSort {
 	return out
 }
 
-// sortedSchemaIter merges schema-sorted input sections, injects schema sort
+// sortedLogsIter merges schema-sorted input sections, injects schema sort
 // keys, remaps stream IDs, and returns an iterator suitable for AppendOrdered.
-func sortedSchemaIter(ctx context.Context, sections []*dataobj.Section, remap []streamRemap) (result.Seq[logs.Record], error) {
+func sortedLogsIter(ctx context.Context, sections []*dataobj.Section, remap []streamRemap) (result.Seq[logs.Record], error) {
 	iter, err := sortmerge.IteratorForSchema(ctx, sections, streamSorts(remap))
 	if err != nil {
 		return nil, err

--- a/pkg/dataobj/consumer/logsobj/stream_order.go
+++ b/pkg/dataobj/consumer/logsobj/stream_order.go
@@ -30,12 +30,12 @@ func NewStreamOrderKey(streamLabels labels.Labels, schemaLabels []string) (Strea
 // CompareStreamOrderKey compares stream keys by shard bucket, schema key,
 // stable hash, and full labels.
 func CompareStreamOrderKey(a, b StreamOrderKey) int {
-	if n := a.streamSort().Compare(b.streamSort()); n != 0 {
+	if n := a.sortingOrder().Compare(b.sortingOrder()); n != 0 {
 		return n
 	}
 	return labels.Compare(a.Labels, b.Labels)
 }
 
-func (k StreamOrderKey) streamSort() logs.StreamSort {
+func (k StreamOrderKey) sortingOrder() logs.StreamSort {
 	return logs.StreamSort{Shard: k.Shard, Key: k.SchemaKey, Hash: k.Hash}
 }

--- a/pkg/dataobj/consumer/logsobj/stream_order.go
+++ b/pkg/dataobj/consumer/logsobj/stream_order.go
@@ -1,11 +1,9 @@
 package logsobj
 
 import (
-	"cmp"
-
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/grafana/loki/v3/pkg/dataobj/sections/streams"
+	"github.com/grafana/loki/v3/pkg/dataobj/sections/logs"
 )
 
 // StreamOrderKey is the globally stable ordering key for one stream.
@@ -22,30 +20,22 @@ type StreamOrderKey struct {
 
 // NewStreamOrderKey computes the globally stable ordering key for a stream.
 func NewStreamOrderKey(streamLabels labels.Labels, schemaLabels []string) (StreamOrderKey, error) {
-	schemaKey, err := ComputeSortKey(streamLabels, schemaLabels)
+	r, err := newStreamRemap(streamLabels, schemaLabels)
 	if err != nil {
 		return StreamOrderKey{}, err
 	}
-	hash := labels.StableHash(streamLabels)
-	return StreamOrderKey{
-		Shard:     streams.ShardBucketFromHash(hash),
-		SchemaKey: schemaKey,
-		Hash:      hash,
-		Labels:    streamLabels,
-	}, nil
+	return r.orderKey(streamLabels), nil
 }
 
 // CompareStreamOrderKey compares stream keys by shard bucket, schema key,
 // stable hash, and full labels.
 func CompareStreamOrderKey(a, b StreamOrderKey) int {
-	if n := cmp.Compare(a.Shard, b.Shard); n != 0 {
-		return n
-	}
-	if n := cmp.Compare(a.SchemaKey, b.SchemaKey); n != 0 {
-		return n
-	}
-	if n := cmp.Compare(a.Hash, b.Hash); n != 0 {
+	if n := a.streamSort().Compare(b.streamSort()); n != 0 {
 		return n
 	}
 	return labels.Compare(a.Labels, b.Labels)
+}
+
+func (k StreamOrderKey) streamSort() logs.StreamSort {
+	return logs.StreamSort{Shard: k.Shard, Key: k.SchemaKey, Hash: k.Hash}
 }

--- a/pkg/dataobj/consumer/logsobj/stream_order_test.go
+++ b/pkg/dataobj/consumer/logsobj/stream_order_test.go
@@ -30,6 +30,18 @@ func TestNewStreamOrderKey_UsesShardBucket(t *testing.T) {
 	key, err := NewStreamOrderKey(ls, []string{"label:app"})
 	require.NoError(t, err)
 	require.Equal(t, streams.ShardBucket(ls), key.Shard)
+	require.Equal(t, streams.ShardBucketFromHash(key.Hash), key.Shard)
 	require.Equal(t, "auth", key.SchemaKey)
 	require.Equal(t, labels.StableHash(ls), key.Hash)
+}
+
+func TestNewStreamRemap_FillsSortFromOneHash(t *testing.T) {
+	ls := labels.FromStrings("app", "auth")
+	r, err := newStreamRemap(ls, []string{"label:app"})
+	require.NoError(t, err)
+	require.Zero(t, r.newID)
+	require.Equal(t, streams.ShardBucket(ls), r.Shard)
+	require.Equal(t, "auth", r.Key)
+	require.Equal(t, labels.StableHash(ls), r.Hash)
+	require.Equal(t, streams.ShardBucketFromHash(r.Hash), r.Shard)
 }

--- a/pkg/dataobj/sections/logs/table_build.go
+++ b/pkg/dataobj/sections/logs/table_build.go
@@ -75,13 +75,9 @@ func sortRecords(records []Record, sortOrder SortOrder) {
 			return reverseOrderIfEqual(cmp.Compare(a.StreamID, b.StreamID))
 		case SortSchemaASC:
 			// Sort by [shard_bucket ASC, schema sort key ASC, stream hash ASC, streamID ASC, timestamp DESC].
-			if res := cmp.Compare(a.ShardBucket, b.ShardBucket); res != 0 {
-				return res
-			}
-			if res := cmp.Compare(a.SortKey, b.SortKey); res != 0 {
-				return res
-			}
-			if res := cmp.Compare(a.StreamHash, b.StreamHash); res != 0 {
+			aSort := StreamSort{Shard: a.ShardBucket, Key: a.SortKey, Hash: a.StreamHash}
+			bSort := StreamSort{Shard: b.ShardBucket, Key: b.SortKey, Hash: b.StreamHash}
+			if res := aSort.Compare(bSort); res != 0 {
 				return res
 			}
 			if res := cmp.Compare(a.StreamID, b.StreamID); res != 0 {

--- a/pkg/dataobj/sections/logs/table_build.go
+++ b/pkg/dataobj/sections/logs/table_build.go
@@ -98,10 +98,6 @@ func reverseOrderIfEqual(res int) int {
 	return -1
 }
 
-// SortRecords sorts records in place by sortOrder. For SortSchemaASC each
-// record's ShardBucket, SortKey, and StreamHash must be set before calling.
-func SortRecords(records []Record, sortOrder SortOrder) { sortRecords(records, sortOrder) }
-
 func equalRecords(a, b Record) bool {
 	if a.StreamID != b.StreamID {
 		return false

--- a/pkg/dataobj/sections/logs/table_merge.go
+++ b/pkg/dataobj/sections/logs/table_merge.go
@@ -204,12 +204,28 @@ func (seq *DatasetSequence) Close() {
 	_ = seq.r.Close()
 }
 
+// StreamSort is the physical sort tuple for one stream: shard, schema key, hash.
+// A []StreamSort is indexed by stream ID with [0] unused.
+type StreamSort struct {
+	Shard uint32
+	Key   string
+	Hash  uint64
+}
+
+// Compare reports the order of a and b by [shard, key, hash].
+func (a StreamSort) Compare(b StreamSort) int {
+	return cmp.Or(
+		cmp.Compare(a.Shard, b.Shard),
+		cmp.Compare(a.Key, b.Key),
+		cmp.Compare(a.Hash, b.Hash),
+	)
+}
+
 // CompareForSortSchema returns a comparison function for k-way merge using
 // schema-based sort order: [shard ASC, sortKey ASC, hash ASC, streamID ASC, timestamp DESC].
-// shards, sortKeys, and hashes map streamID to the corresponding sort component.
-// An empty hashes slice skips the hash comparison.
+// order maps stream ID to the corresponding sort tuple ([0] unused).
 // math.MaxInt64 is treated as a sentinel (loser-tree maxValue) and always compares greater.
-func CompareForSortSchema(shards []uint32, sortKeys []string, hashes []uint64) func(result.Result[dataset.Row], result.Result[dataset.Row]) bool {
+func CompareForSortSchema(order []StreamSort) func(result.Result[dataset.Row], result.Result[dataset.Row]) bool {
 	return func(a, b result.Result[dataset.Row]) bool {
 		aVal, aErr := a.Value()
 		bVal, bErr := b.Value()
@@ -233,21 +249,9 @@ func CompareForSortSchema(shards []uint32, sortKeys []string, hashes []uint64) f
 			return true
 		}
 
-		aShard := shards[aStreamID]
-		bShard := shards[bStreamID]
-		if res := cmp.Compare(aShard, bShard); res != 0 {
-			return res < 0
-		}
-
-		aKey := sortKeys[aStreamID]
-		bKey := sortKeys[bStreamID]
-		if res := cmp.Compare(aKey, bKey); res != 0 {
-			return res < 0
-		}
-
-		aHash := hashes[aStreamID]
-		bHash := hashes[bStreamID]
-		if res := cmp.Compare(aHash, bHash); res != 0 {
+		aSort := order[aStreamID]
+		bSort := order[bStreamID]
+		if res := aSort.Compare(bSort); res != 0 {
 			return res < 0
 		}
 

--- a/pkg/dataobj/sections/logs/table_merge_test.go
+++ b/pkg/dataobj/sections/logs/table_merge_test.go
@@ -1,0 +1,48 @@
+package logs
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/dataset"
+	"github.com/grafana/loki/v3/pkg/dataobj/internal/result"
+)
+
+func TestCompareForSortSchema(t *testing.T) {
+	order := []StreamSort{
+		{}, // [0] unused
+		{Shard: 1, Key: "a", Hash: 2},
+		{Shard: 0, Key: "z", Hash: 9},
+		{Shard: 1, Key: "a", Hash: 1},
+	}
+	less := CompareForSortSchema(order)
+	row := func(id, ts int64) result.Result[dataset.Row] {
+		return result.Value(dataset.Row{
+			Values: []dataset.Value{dataset.Int64Value(id), dataset.Int64Value(ts)},
+		})
+	}
+
+	// shard 0 (id 2) precedes shard 1
+	require.True(t, less(row(2, 1), row(3, 1)))
+	// same shard+key: lower hash (id 3) precedes higher hash (id 1)
+	require.True(t, less(row(3, 1), row(1, 1)))
+	require.False(t, less(row(1, 1), row(3, 1)))
+	// same stream: later timestamp first
+	require.True(t, less(row(1, 20), row(1, 10)))
+	// sentinel never wins
+	require.False(t, less(row(math.MaxInt64, 0), row(2, 1)))
+	require.True(t, less(row(2, 1), row(math.MaxInt64, 0)))
+}
+
+func TestStreamSortCompare(t *testing.T) {
+	a := StreamSort{Shard: 0, Key: "z", Hash: 9}
+	b := StreamSort{Shard: 1, Key: "a", Hash: 1}
+	c := StreamSort{Shard: 1, Key: "a", Hash: 2}
+
+	require.Negative(t, a.Compare(b))
+	require.Negative(t, b.Compare(c))
+	require.Zero(t, a.Compare(a))
+	require.Positive(t, c.Compare(b))
+}

--- a/pkg/dataobj/sections/streams/builder.go
+++ b/pkg/dataobj/sections/streams/builder.go
@@ -229,6 +229,8 @@ func (b *Builder) getOrAddStream(streamLabels labels.Labels) *Stream {
 	return b.addStream(hash, streamLabels)
 }
 
+// ShardBucketFromHash returns the physical shard bucket for a stream fingerprint.
+// Buckets are 0-based in [0, ShardFactor).
 func ShardBucketFromHash(hash uint64) uint32 {
 	return uint32(hash >> (64 - ShardBits))
 }
@@ -249,7 +251,7 @@ func (b *Builder) addStream(hash uint64, streamLabels labels.Labels) *Stream {
 	newStream.Reset()
 	newStream.ID = b.lastID.Add(1)
 	newStream.Labels = streamLabels
-	newStream.ShardBucket = int64(ShardBucket(streamLabels))
+	newStream.ShardBucket = int64(ShardBucketFromHash(hash))
 
 	b.lookup[hash] = append(b.lookup[hash], newStream)
 	b.ordered = append(b.ordered, newStream)

--- a/pkg/dataobj/sections/streams/builder_test.go
+++ b/pkg/dataobj/sections/streams/builder_test.go
@@ -91,6 +91,11 @@ func Test(t *testing.T) {
 	require.Equal(t, expect, actual)
 }
 
+func TestShardBucketFromHash(t *testing.T) {
+	ls := labels.FromStrings("app", "auth")
+	require.Equal(t, streams.ShardBucket(ls), streams.ShardBucketFromHash(labels.StableHash(ls)))
+}
+
 func copyLabels(in labels.Labels) labels.Labels {
 	builder := labels.NewScratchBuilder(in.Len())
 

--- a/pkg/dataobj/sortmerge/sortmerge.go
+++ b/pkg/dataobj/sortmerge/sortmerge.go
@@ -30,9 +30,9 @@ func Iterator(ctx context.Context, sections []*dataobj.Section, sort logs.SortOr
 // from multiple schema-sorted logs sections. The input sections must be sorted
 // by [shard ASC, schema sort key ASC, hash ASC, streamID ASC, timestamp DESC].
 //
-// shards, sortKeys, and hashes map StreamID to the corresponding sort component.
-func IteratorForSchema(ctx context.Context, sections []*dataobj.Section, shards []uint32, sortKeys []string, hashes []uint64) (result.Seq[logs.Record], error) {
-	return iterator(ctx, sections, iteratorOptions{less: logs.CompareForSortSchema(shards, sortKeys, hashes)})
+// order maps StreamID to the corresponding sort tuple ([0] unused).
+func IteratorForSchema(ctx context.Context, sections []*dataobj.Section, order []logs.StreamSort) (result.Seq[logs.Record], error) {
+	return iterator(ctx, sections, iteratorOptions{less: logs.CompareForSortSchema(order)})
 }
 
 // IteratorWithStreamRemap performs a k-way merge over logs sections drawn from


### PR DESCRIPTION
**What this PR does / why we need it**:

Consolidates the state handling in CopyAndSort to avoid passing so many maps around.

This sets up the next PR which refactors ordering information into a unified representation.